### PR TITLE
chore: replace queue size updown counter with 2 monotonic counters (push & pull)

### DIFF
--- a/.changeset/silver-chicken-dance.md
+++ b/.changeset/silver-chicken-dance.md
@@ -1,0 +1,5 @@
+---
+"cojson": patch
+---
+
+Add jazz.messagequeue.pushed/pulled counters, remove jazz.messagequeue.size gauge

--- a/packages/cojson-transport-ws/src/tests/createWebSocketPeer.test.ts
+++ b/packages/cojson-transport-ws/src/tests/createWebSocketPeer.test.ts
@@ -126,7 +126,7 @@ describe("createWebSocketPeer", () => {
       action: "content",
       id: "co_zlow",
       new: {},
-      priority: 1,
+      priority: 6,
     };
 
     void peer.outgoing.push(message1);
@@ -214,7 +214,7 @@ describe("createWebSocketPeer", () => {
         action: "content",
         id: "co_zlow",
         new: {},
-        priority: 1,
+        priority: 6,
       };
 
       void peer.outgoing.push(message1);
@@ -243,7 +243,7 @@ describe("createWebSocketPeer", () => {
         action: "content",
         id: "co_zlow",
         new: {},
-        priority: 1,
+        priority: 6,
       };
 
       void peer.outgoing.push(message1);
@@ -269,7 +269,7 @@ describe("createWebSocketPeer", () => {
         action: "content",
         id: "co_zlow",
         new: {},
-        priority: 1,
+        priority: 6,
       };
 
       const stream: SyncMessage[] = [];
@@ -316,7 +316,7 @@ describe("createWebSocketPeer", () => {
         action: "content",
         id: "co_zlow",
         new: {},
-        priority: 1,
+        priority: 6,
       };
 
       const stream: SyncMessage[] = [];
@@ -365,7 +365,7 @@ describe("createWebSocketPeer", () => {
         action: "content",
         id: "co_zlow",
         new: {},
-        priority: 1,
+        priority: 6,
       };
 
       void peer.outgoing.push(message1);
@@ -411,7 +411,7 @@ describe("createWebSocketPeer", () => {
         action: "content",
         id: "co_zlow",
         new: {},
-        priority: 1,
+        priority: 6,
       };
 
       void peer.outgoing.push(message1);
@@ -450,7 +450,7 @@ describe("createWebSocketPeer", () => {
         action: "content",
         id: "co_zlow",
         new: {},
-        priority: 1,
+        priority: 6,
       };
 
       void peer.outgoing.push(message1);

--- a/packages/cojson/src/PeerState.ts
+++ b/packages/cojson/src/PeerState.ts
@@ -2,6 +2,7 @@ import { PeerKnownStateActions, PeerKnownStates } from "./PeerKnownStates.js";
 import {
   PriorityBasedMessageQueue,
   QueueEntry,
+  meteredQueue,
 } from "./PriorityBasedMessageQueue.js";
 import { TryAddTransactionsError } from "./coValueCore.js";
 import { RawCoID } from "./ids.js";
@@ -82,9 +83,11 @@ export class PeerState {
    *
    * This way we consider all the non-content messsages as HIGH priority.
    */
-  private queue = new PriorityBasedMessageQueue(
-    CO_VALUE_PRIORITY.HIGH,
-    this.peer.role,
+  private queue = meteredQueue(
+    new PriorityBasedMessageQueue(CO_VALUE_PRIORITY.HIGH),
+    {
+      peerRole: this.peer.role,
+    },
   );
   private processing = false;
   public closed = false;

--- a/packages/cojson/src/PeerState.ts
+++ b/packages/cojson/src/PeerState.ts
@@ -82,7 +82,10 @@ export class PeerState {
    *
    * This way we consider all the non-content messsages as HIGH priority.
    */
-  private queue = new PriorityBasedMessageQueue(CO_VALUE_PRIORITY.HIGH);
+  private queue = new PriorityBasedMessageQueue(
+    CO_VALUE_PRIORITY.HIGH,
+    this.peer.role,
+  );
   private processing = false;
   public closed = false;
 

--- a/packages/cojson/src/PeerState.ts
+++ b/packages/cojson/src/PeerState.ts
@@ -10,10 +10,21 @@ import { CO_VALUE_PRIORITY } from "./priority.js";
 import { Peer, SyncMessage } from "./sync.js";
 
 export class PeerState {
+  private queue: PriorityBasedMessageQueue;
+
   constructor(
     private peer: Peer,
     knownStates: PeerKnownStates | undefined,
   ) {
+    /**
+     * We set as default priority HIGH to handle all the messages without a
+     * priority property as HIGH priority.
+     *
+     * This way we consider all the non-content messsages as HIGH priority.
+     */
+    this.queue = new PriorityBasedMessageQueue(CO_VALUE_PRIORITY.HIGH, {
+      peerRole: peer.role,
+    });
     this.optimisticKnownStates = knownStates?.clone() ?? new PeerKnownStates();
 
     // We assume that exchanges with storage peers are always successful
@@ -76,15 +87,6 @@ export class PeerState {
     return this.peer.role === "server" || this.peer.role === "storage";
   }
 
-  /**
-   * We set as default priority HIGH to handle all the messages without a
-   * priority property as HIGH priority.
-   *
-   * This way we consider all the non-content messsages as HIGH priority.
-   */
-  private queue = new PriorityBasedMessageQueue(CO_VALUE_PRIORITY.HIGH, {
-    peerRole: this.peer.role,
-  });
   private processing = false;
   public closed = false;
 

--- a/packages/cojson/src/PeerState.ts
+++ b/packages/cojson/src/PeerState.ts
@@ -2,7 +2,6 @@ import { PeerKnownStateActions, PeerKnownStates } from "./PeerKnownStates.js";
 import {
   PriorityBasedMessageQueue,
   QueueEntry,
-  meteredQueue,
 } from "./PriorityBasedMessageQueue.js";
 import { TryAddTransactionsError } from "./coValueCore.js";
 import { RawCoID } from "./ids.js";
@@ -83,12 +82,9 @@ export class PeerState {
    *
    * This way we consider all the non-content messsages as HIGH priority.
    */
-  private queue = meteredQueue(
-    new PriorityBasedMessageQueue(CO_VALUE_PRIORITY.HIGH),
-    {
-      peerRole: this.peer.role,
-    },
-  );
+  private queue = new PriorityBasedMessageQueue(CO_VALUE_PRIORITY.HIGH, {
+    peerRole: this.peer.role,
+  });
   private processing = false;
   public closed = false;
 

--- a/packages/cojson/src/PriorityBasedMessageQueue.ts
+++ b/packages/cojson/src/PriorityBasedMessageQueue.ts
@@ -1,6 +1,7 @@
 import { ValueType, metrics } from "@opentelemetry/api";
+import { PeerState } from "./PeerState.js";
 import type { CoValuePriority } from "./priority.js";
-import type { SyncMessage } from "./sync.js";
+import type { Peer, SyncMessage } from "./sync.js";
 
 function promiseWithResolvers<R>() {
   let resolve = (_: R) => {};
@@ -118,7 +119,10 @@ export class PriorityBasedMessageQueue {
     return this.queues[priority];
   }
 
-  constructor(private defaultPriority: CoValuePriority) {}
+  constructor(
+    private defaultPriority: CoValuePriority,
+    private peerRole: Peer["role"],
+  ) {}
 
   public push(msg: SyncMessage) {
     const { promise, resolve, reject } = promiseWithResolvers<void>();
@@ -130,6 +134,7 @@ export class PriorityBasedMessageQueue {
 
     this.enqueuedCounter.add(1, {
       priority,
+      role: this.peerRole,
     });
 
     return promise;
@@ -144,6 +149,7 @@ export class PriorityBasedMessageQueue {
 
     this.dequeuedCounter.add(1, {
       priority,
+      role: this.peerRole,
     });
 
     return this.queues[priority]?.shift();

--- a/packages/cojson/src/PriorityBasedMessageQueue.ts
+++ b/packages/cojson/src/PriorityBasedMessageQueue.ts
@@ -112,6 +112,9 @@ class QueueMeter {
         valueType: ValueType.INT,
         unit: "1",
       });
+
+    this.pullCounter.add(0, this.attrs);
+    this.pushCounter.add(0, this.attrs);
   }
 
   public pull() {

--- a/packages/cojson/src/PriorityBasedMessageQueue.ts
+++ b/packages/cojson/src/PriorityBasedMessageQueue.ts
@@ -97,10 +97,19 @@ export class PriorityBasedMessageQueue {
     new LinkedList<QueueEntry>(),
     new LinkedList<QueueEntry>(),
   ];
-  queueSizeCounter = metrics
+
+  private enqueuedCounter = metrics
     .getMeter("cojson")
-    .createUpDownCounter("jazz.messagequeue.size", {
-      description: "Size of the message queue",
+    .createCounter("jazz.messagequeue.enqueued", {
+      description: "Number of messages enqueued",
+      valueType: ValueType.INT,
+      unit: "entry",
+    });
+
+  private dequeuedCounter = metrics
+    .getMeter("cojson")
+    .createCounter("jazz.messagequeue.removed", {
+      description: "Number of messages removed from the queue",
       valueType: ValueType.INT,
       unit: "entry",
     });
@@ -119,7 +128,7 @@ export class PriorityBasedMessageQueue {
 
     this.getQueue(priority).push(entry);
 
-    this.queueSizeCounter.add(1, {
+    this.enqueuedCounter.add(1, {
       priority,
     });
 
@@ -133,7 +142,7 @@ export class PriorityBasedMessageQueue {
       return;
     }
 
-    this.queueSizeCounter.add(-1, {
+    this.dequeuedCounter.add(1, {
       priority,
     });
 

--- a/packages/cojson/src/PriorityBasedMessageQueue.ts
+++ b/packages/cojson/src/PriorityBasedMessageQueue.ts
@@ -113,6 +113,11 @@ class QueueMeter {
         unit: "1",
       });
 
+    /**
+     * This makes sure that those metrics are generated (and emitted) as soon as the queue is created.
+     * This is to avoid edge cases where one series reset is delayed, which would cause spikes or dips
+     * when queried - and it also more correctly represents the actual state of the queue after a restart.
+     */
     this.pullCounter.add(0, this.attrs);
     this.pushCounter.add(0, this.attrs);
   }

--- a/packages/cojson/src/priority.ts
+++ b/packages/cojson/src/priority.ts
@@ -7,7 +7,7 @@ import { type CoValueHeader } from "./coValueCore.js";
  * The priority value is handled as weight in the weighed round robin algorithm
  * used to determine the order in which messages are sent.
  *
- * Follows the HTTP urgency range and order:
+ * Loosely follows the HTTP urgency range and order, but limited to 3 values:
  *  - https://www.rfc-editor.org/rfc/rfc9218.html#name-urgency
  */
 export const CO_VALUE_PRIORITY = {
@@ -16,7 +16,7 @@ export const CO_VALUE_PRIORITY = {
   LOW: 6,
 } as const;
 
-export type CoValuePriority = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7;
+export type CoValuePriority = 0 | 3 | 6;
 
 export function getPriorityFromHeader(
   header: CoValueHeader | undefined | boolean,

--- a/packages/cojson/src/tests/PriorityBasedMessageQueue.test.ts
+++ b/packages/cojson/src/tests/PriorityBasedMessageQueue.test.ts
@@ -144,7 +144,7 @@ describe("PriorityBasedMessageQueue", () => {
   test("should initialize with correct properties", () => {
     const { queue } = setup();
     expect(queue["defaultPriority"]).toBe(CO_VALUE_PRIORITY.MEDIUM);
-    expect(queue["queues"].length).toBe(8);
+    expect(queue["queues"].length).toBe(3);
     expect(queue["queues"].every((q) => !q.length)).toBe(true);
   });
 

--- a/packages/cojson/src/tests/PriorityBasedMessageQueue.test.ts
+++ b/packages/cojson/src/tests/PriorityBasedMessageQueue.test.ts
@@ -32,7 +32,7 @@ describe("PriorityBasedMessageQueue", () => {
         await metricReader.getMetricValue("jazz.messagequeue.pushed", {
           priority: CO_VALUE_PRIORITY.MEDIUM,
         }),
-      ).toBeUndefined();
+      ).toBe(0);
 
       void queue.push(message);
       expect(
@@ -62,14 +62,14 @@ describe("PriorityBasedMessageQueue", () => {
         await metricReader.getMetricValue("jazz.messagequeue.pulled", {
           priority: CO_VALUE_PRIORITY.MEDIUM,
         }),
-      ).toBeUndefined();
+      ).toBe(0);
 
       void queue.push(message);
       expect(
         await metricReader.getMetricValue("jazz.messagequeue.pulled", {
           priority: CO_VALUE_PRIORITY.MEDIUM,
         }),
-      ).toBeUndefined();
+      ).toBe(0);
 
       void queue.pull();
 
@@ -102,7 +102,7 @@ describe("PriorityBasedMessageQueue", () => {
           priority: CO_VALUE_PRIORITY.MEDIUM,
           role: "server",
         }),
-      ).toBeUndefined();
+      ).toBe(0);
       expect(
         await metricReader.getMetricValue("jazz.messagequeue.pushed", {
           priority: CO_VALUE_PRIORITY.MEDIUM,
@@ -122,7 +122,7 @@ describe("PriorityBasedMessageQueue", () => {
           priority: CO_VALUE_PRIORITY.MEDIUM,
           role: "server",
         }),
-      ).toBeUndefined();
+      ).toBe(0);
 
       void queue.pull();
 

--- a/packages/cojson/src/tests/PriorityBasedMessageQueue.test.ts
+++ b/packages/cojson/src/tests/PriorityBasedMessageQueue.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, describe, expect, test } from "vitest";
-import { PriorityBasedMessageQueue } from "../PriorityBasedMessageQueue.js";
+import {
+  PriorityBasedMessageQueue,
+  meteredQueue,
+} from "../PriorityBasedMessageQueue.js";
 import { CO_VALUE_PRIORITY } from "../priority.js";
 import type { SyncMessage } from "../sync.js";
 import {
@@ -8,8 +11,15 @@ import {
 } from "./testUtils.js";
 
 function setup() {
-  const metricReader = createTestMetricReader();
   const queue = new PriorityBasedMessageQueue(CO_VALUE_PRIORITY.MEDIUM);
+  return { queue };
+}
+
+function setupMeteredQueue(attrs?: Record<string, string>) {
+  const metricReader = createTestMetricReader();
+
+  const { queue: unmeteredQueue } = setup();
+  const queue = meteredQueue(unmeteredQueue, attrs);
   return { queue, metricReader };
 }
 
@@ -18,11 +28,127 @@ describe("PriorityBasedMessageQueue", () => {
     tearDownTestMetricReader();
   });
 
-  test("should initialize with correct properties", () => {
-    const { queue } = setup();
-    expect(queue["defaultPriority"]).toBe(CO_VALUE_PRIORITY.MEDIUM);
-    expect(queue["queues"].length).toBe(8);
-    expect(queue["queues"].every((q) => !q.length)).toBe(true);
+  describe("meteredQueue", () => {
+    test("should corretly count pushes", async () => {
+      const { queue, metricReader } = setupMeteredQueue();
+      const message: SyncMessage = {
+        action: "load",
+        id: "co_ztest-id",
+        header: false,
+        sessions: {},
+      };
+
+      expect(
+        await metricReader.getMetricValue("jazz.messagequeue.pushed", {
+          priority: CO_VALUE_PRIORITY.MEDIUM,
+        }),
+      ).toBeUndefined();
+
+      void queue.push(message);
+      expect(
+        await metricReader.getMetricValue("jazz.messagequeue.pushed", {
+          priority: CO_VALUE_PRIORITY.MEDIUM,
+        }),
+      ).toBe(1);
+
+      void queue.push(message);
+      expect(
+        await metricReader.getMetricValue("jazz.messagequeue.pushed", {
+          priority: CO_VALUE_PRIORITY.MEDIUM,
+        }),
+      ).toBe(2);
+    });
+
+    test("should corretly count pulls", async () => {
+      const { queue, metricReader } = setupMeteredQueue();
+      const message: SyncMessage = {
+        action: "load",
+        id: "co_ztest-id",
+        header: false,
+        sessions: {},
+      };
+
+      expect(
+        await metricReader.getMetricValue("jazz.messagequeue.pulled", {
+          priority: CO_VALUE_PRIORITY.MEDIUM,
+        }),
+      ).toBeUndefined();
+
+      void queue.push(message);
+      expect(
+        await metricReader.getMetricValue("jazz.messagequeue.pulled", {
+          priority: CO_VALUE_PRIORITY.MEDIUM,
+        }),
+      ).toBeUndefined();
+
+      void queue.pull();
+
+      expect(
+        await metricReader.getMetricValue("jazz.messagequeue.pulled", {
+          priority: CO_VALUE_PRIORITY.MEDIUM,
+        }),
+      ).toBe(1);
+
+      // We only have one item in the queue, so this should not change the metric value
+      void queue.pull();
+      expect(
+        await metricReader.getMetricValue("jazz.messagequeue.pulled", {
+          priority: CO_VALUE_PRIORITY.MEDIUM,
+        }),
+      ).toBe(1);
+    });
+
+    test("should corretly set custom attributes to the metrics", async () => {
+      const { queue, metricReader } = setupMeteredQueue({ role: "server" });
+      const message: SyncMessage = {
+        action: "load",
+        id: "co_ztest-id",
+        header: false,
+        sessions: {},
+      };
+
+      expect(
+        await metricReader.getMetricValue("jazz.messagequeue.pushed", {
+          priority: CO_VALUE_PRIORITY.MEDIUM,
+          role: "server",
+        }),
+      ).toBeUndefined();
+      expect(
+        await metricReader.getMetricValue("jazz.messagequeue.pushed", {
+          priority: CO_VALUE_PRIORITY.MEDIUM,
+          role: "client",
+        }),
+      ).toBeUndefined();
+
+      void queue.push(message);
+      expect(
+        await metricReader.getMetricValue("jazz.messagequeue.pushed", {
+          priority: CO_VALUE_PRIORITY.MEDIUM,
+          role: "server",
+        }),
+      ).toBe(1);
+      expect(
+        await metricReader.getMetricValue("jazz.messagequeue.pulled", {
+          priority: CO_VALUE_PRIORITY.MEDIUM,
+          role: "server",
+        }),
+      ).toBeUndefined();
+
+      void queue.pull();
+
+      expect(
+        await metricReader.getMetricValue("jazz.messagequeue.pushed", {
+          priority: CO_VALUE_PRIORITY.MEDIUM,
+          role: "server",
+        }),
+      ).toBe(1);
+      expect(
+        await metricReader.getMetricValue("jazz.messagequeue.pulled", {
+          priority: CO_VALUE_PRIORITY.MEDIUM,
+          role: "server",
+        }),
+      ).toBe(1);
+    });
   });
 
   test("should push message with default priority", async () => {
@@ -35,7 +161,7 @@ describe("PriorityBasedMessageQueue", () => {
     };
     void queue.push(message);
     const pulledEntry = queue.pull();
-    expect(pulledEntry?.msg).toEqual(message);
+    expect(pulledEntry?.entry.msg).toEqual(message);
   });
 
   test("should push message with specified priority", async () => {
@@ -48,11 +174,11 @@ describe("PriorityBasedMessageQueue", () => {
     };
     void queue.push(message);
     const pulledEntry = queue.pull();
-    expect(pulledEntry?.msg).toEqual(message);
+    expect(pulledEntry?.entry.msg).toEqual(message);
   });
 
   test("should pull messages in priority order", async () => {
-    const { queue, metricReader } = setup();
+    const { queue } = setup();
     const lowPriorityMsg: SyncMessage = {
       action: "content",
       id: "co_zlow",
@@ -73,42 +199,12 @@ describe("PriorityBasedMessageQueue", () => {
     };
 
     void queue.push(lowPriorityMsg);
-    expect(
-      await metricReader.getMetricValue("jazz.messagequeue.size", {
-        priority: lowPriorityMsg.priority,
-      }),
-    ).toBe(1);
     void queue.push(mediumPriorityMsg);
-    expect(
-      await metricReader.getMetricValue("jazz.messagequeue.size", {
-        priority: mediumPriorityMsg.priority,
-      }),
-    ).toBe(1);
     void queue.push(highPriorityMsg);
-    expect(
-      await metricReader.getMetricValue("jazz.messagequeue.size", {
-        priority: highPriorityMsg.priority,
-      }),
-    ).toBe(1);
 
-    expect(queue.pull()?.msg).toEqual(highPriorityMsg);
-    expect(
-      await metricReader.getMetricValue("jazz.messagequeue.size", {
-        priority: highPriorityMsg.priority,
-      }),
-    ).toBe(0);
-    expect(queue.pull()?.msg).toEqual(mediumPriorityMsg);
-    expect(
-      await metricReader.getMetricValue("jazz.messagequeue.size", {
-        priority: mediumPriorityMsg.priority,
-      }),
-    ).toBe(0);
-    expect(queue.pull()?.msg).toEqual(lowPriorityMsg);
-    expect(
-      await metricReader.getMetricValue("jazz.messagequeue.size", {
-        priority: lowPriorityMsg.priority,
-      }),
-    ).toBe(0);
+    expect(queue.pull()?.entry.msg).toEqual(highPriorityMsg);
+    expect(queue.pull()?.entry.msg).toEqual(mediumPriorityMsg);
+    expect(queue.pull()?.entry.msg).toEqual(lowPriorityMsg);
   });
 
   test("should return undefined when pulling from empty queue", () => {
@@ -127,7 +223,7 @@ describe("PriorityBasedMessageQueue", () => {
     const pushPromise = queue.push(message);
 
     const pulledEntry = queue.pull();
-    pulledEntry?.resolve();
+    pulledEntry?.entry.resolve();
 
     await expect(pushPromise).resolves.toBeUndefined();
   });
@@ -143,7 +239,7 @@ describe("PriorityBasedMessageQueue", () => {
     const pushPromise = queue.push(message);
 
     const pulledEntry = queue.pull();
-    pulledEntry?.reject(new Error("Test error"));
+    pulledEntry?.entry.reject(new Error("Test error"));
 
     await expect(pushPromise).rejects.toThrow("Test error");
   });


### PR DESCRIPTION
remove the previous queue size gauge and replaces it with two counters per each priority & peer role values. This will allow us to get better visibility into the amount of messages that are pushed to and pulled from the queue as opposed to only its size. We still can get the current size by subtracting them.

Also reduces the available priorities to 3, which are the ones actually being used, but i avoided changing the priority values to avoid mismatches between old versions of the clients & new version of the sync servers - or if we actually need to start using more priorities in the future