### PR TITLE
fix(inspector): show unknown mime type instead of application/octet-stream

### DIFF
--- a/.changeset/thick-coats-film.md
+++ b/.changeset/thick-coats-film.md
@@ -1,0 +1,5 @@
+---
+"jazz-inspector": patch
+---
+
+show unknown mime type instead of application/octet-stream

--- a/examples/filestream/package.json
+++ b/examples/filestream/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "jazz-react": "workspace:*",
     "jazz-tools": "workspace:*",
+    "jazz-inspector": "workspace:*",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/examples/filestream/src/FileWidget.tsx
+++ b/examples/filestream/src/FileWidget.tsx
@@ -208,6 +208,10 @@ export function FileWidget() {
             <span className="font-bold">Size</span>
             <span>{formatFileSize(fileData?.totalSizeBytes)}</span>
           </div>
+          <div className="flex justify-between">
+            <span className="font-bold">CoValue ID</span>
+            <span>{me.profile.file.id}</span>
+          </div>
         </div>
       </div>
 

--- a/examples/filestream/src/main.tsx
+++ b/examples/filestream/src/main.tsx
@@ -1,3 +1,4 @@
+import { JazzInspector } from "jazz-inspector";
 import { JazzProvider } from "jazz-react";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
@@ -23,6 +24,7 @@ createRoot(document.getElementById("root")!).render(
       }}
       AccountSchema={JazzAccount}
     >
+      <JazzInspector />
       <App />
     </JazzProvider>
   </StrictMode>,

--- a/packages/jazz-inspector/src/viewer/co-stream-view.tsx
+++ b/packages/jazz-inspector/src/viewer/co-stream-view.tsx
@@ -120,7 +120,7 @@ const detectPDFMimeType = async (blob: Blob): Promise<string> => {
   if (header === "%PDF") {
     return "application/pdf";
   }
-  return "application/octet-stream";
+  return "unknown";
 };
 
 const BinaryDownloadButton = ({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -556,6 +556,9 @@ importers:
 
   examples/filestream:
     dependencies:
+      jazz-inspector:
+        specifier: workspace:*
+        version: link:../../packages/jazz-inspector
       jazz-react:
         specifier: workspace:*
         version: link:../../packages/jazz-react


### PR DESCRIPTION
closes #1738

I also added the embedded inspector to the filestream example and displayed the covalue ID. This example was useful for this task.