### PR TITLE
feat: add transactions size histogram & covalue updown counters

### DIFF
--- a/.changeset/strange-pigs-grab.md
+++ b/.changeset/strange-pigs-grab.md
@@ -1,0 +1,5 @@
+---
+"cojson": patch
+---
+
+feat: add transactions size histogram & loaded covalues gauges

--- a/packages/cojson/src/coValueState.ts
+++ b/packages/cojson/src/coValueState.ts
@@ -1,3 +1,5 @@
+import { ValueType } from "@opentelemetry/api";
+import { UpDownCounter, metrics } from "@opentelemetry/api";
 import { PeerState } from "./PeerState.js";
 import { CoValueCore } from "./coValueCore.js";
 import { RawCoID } from "./ids.js";
@@ -106,11 +108,24 @@ type CoValueStateType =
 export class CoValueState {
   promise?: Promise<CoValueCore | "unavailable">;
   private resolve?: (value: CoValueCore | "unavailable") => void;
+  private counter: UpDownCounter;
 
   constructor(
     public id: RawCoID,
     public state: CoValueStateType,
-  ) {}
+  ) {
+    this.counter = metrics
+      .getMeter("cojson")
+      .createUpDownCounter("jazz.covalues.loaded", {
+        description: "The number of covalues in the system",
+        unit: "covalue",
+        valueType: ValueType.INT,
+      });
+
+    this.counter.add(1, {
+      state: this.state.type,
+    });
+  }
 
   static Unknown(id: RawCoID) {
     return new CoValueState(id, new CoValueUnknownState());
@@ -151,8 +166,16 @@ export class CoValueState {
   }
 
   private moveToState(value: CoValueStateType) {
+    this.counter.add(-1, {
+      state: this.state.type,
+    });
     this.state = value;
 
+    this.counter.add(1, {
+      state: this.state.type,
+    });
+
+    // TODO Handle state changes
     if (!this.resolve) {
       return;
     }

--- a/packages/cojson/src/coValueState.ts
+++ b/packages/cojson/src/coValueState.ts
@@ -175,7 +175,6 @@ export class CoValueState {
       state: this.state.type,
     });
 
-    // TODO Handle state changes
     if (!this.resolve) {
       return;
     }

--- a/packages/cojson/src/sync.ts
+++ b/packages/cojson/src/sync.ts
@@ -550,14 +550,14 @@ export class SyncManager {
 
   recordTransactionsSize(newTransactions: Transaction[], source: string) {
     for (const tx of newTransactions) {
-      this.transactionsSizeHistogram.record(
+      const txLength =
         tx.privacy === "private"
           ? tx.encryptedChanges.length
-          : tx.changes.length,
-        {
-          source,
-        },
-      );
+          : tx.changes.length;
+
+      this.transactionsSizeHistogram.record(txLength, {
+        source,
+      });
     }
   }
 

--- a/packages/cojson/src/sync.ts
+++ b/packages/cojson/src/sync.ts
@@ -1,4 +1,4 @@
-import { ValueType, metrics } from "@opentelemetry/api";
+import { Histogram, ValueType, metrics } from "@opentelemetry/api";
 import { PeerState } from "./PeerState.js";
 import { SyncStateManager } from "./SyncStateManager.js";
 import { CoValueHeader, Transaction } from "./coValueCore.js";
@@ -122,10 +122,19 @@ export class SyncManager {
     valueType: ValueType.INT,
     unit: "peer",
   });
+  private transactionsSizeHistogram: Histogram;
 
   constructor(local: LocalNode) {
     this.local = local;
     this.syncState = new SyncStateManager(this);
+
+    this.transactionsSizeHistogram = metrics
+      .getMeter("cojson")
+      .createHistogram("jazz.transactions.size", {
+        description: "The size of transactions in a covalue",
+        unit: "bytes",
+        valueType: ValueType.INT,
+      });
   }
 
   syncState: SyncStateManager;
@@ -539,6 +548,19 @@ export class SyncManager {
     }
   }
 
+  recordTransactionsSize(newTransactions: Transaction[], source: string) {
+    for (const tx of newTransactions) {
+      this.transactionsSizeHistogram.record(
+        tx.privacy === "private"
+          ? tx.encryptedChanges.length
+          : tx.changes.length,
+        {
+          source,
+        },
+      );
+    }
+  }
+
   async handleNewContent(msg: NewContentMessage, peer: PeerState) {
     const entry = this.local.coValuesStore.get(msg.id);
 
@@ -637,6 +659,8 @@ export class SyncManager {
         peer.erroredCoValues.set(msg.id, result.error);
         continue;
       }
+
+      this.recordTransactionsSize(newTransactions, peer.role);
 
       peer.dispatchToKnownStates({
         type: "UPDATE_SESSION_COUNTER",

--- a/packages/cojson/src/tests/coValueCore.test.ts
+++ b/packages/cojson/src/tests/coValueCore.test.ts
@@ -1,4 +1,4 @@
-import { expect, test, vi } from "vitest";
+import { assert, afterEach, beforeEach, expect, test, vi } from "vitest";
 import { CoValueCore, Transaction } from "../coValueCore.js";
 import { MapOpPayload } from "../coValues/coMap.js";
 import { WasmCrypto } from "../crypto/WasmCrypto.js";
@@ -6,13 +6,25 @@ import { stableStringify } from "../jsonStringify.js";
 import { LocalNode } from "../localNode.js";
 import { Role } from "../permissions.js";
 import {
+  createTestMetricReader,
   createTestNode,
   createTwoConnectedNodes,
   loadCoValueOrFail,
   randomAnonymousAccountAndSessionID,
+  tearDownTestMetricReader,
 } from "./testUtils.js";
 
 const Crypto = await WasmCrypto.create();
+
+let metricReader: ReturnType<typeof createTestMetricReader>;
+
+beforeEach(() => {
+  metricReader = createTestMetricReader();
+});
+
+afterEach(() => {
+  tearDownTestMetricReader();
+});
 
 test("Can create coValue with new agent credentials and add transaction to it", () => {
   const [account, sessionID] = randomAnonymousAccountAndSessionID();
@@ -195,6 +207,63 @@ test("New transactions in a group correctly update owned values, including subsc
   expect(listener.mock.calls[1]?.[0].get("hello")).toBe(undefined);
 
   expect(map.core.getValidSortedTransactions().length).toBe(0);
+});
+
+test("correctly records transactions", async () => {
+  const [account, sessionID] = randomAnonymousAccountAndSessionID();
+  const node = new LocalNode(account, sessionID, Crypto);
+
+  const changes1 = stableStringify([{ hello: "world" }]);
+  node.syncManager.recordTransactionsSize(
+    [
+      {
+        privacy: "trusting",
+        changes: changes1,
+        madeAt: Date.now(),
+      },
+    ],
+    "server",
+  );
+
+  let value = await metricReader.getMetricValue("jazz.transactions.size", {
+    source: "server",
+  });
+  assert(typeof value !== "number" && !!value?.count);
+  expect(value.count).toBe(1);
+  expect(value.sum).toBe(changes1.length);
+
+  const changes2 = stableStringify([{ foo: "bar" }]);
+  node.syncManager.recordTransactionsSize(
+    [
+      {
+        privacy: "trusting",
+        changes: changes2,
+        madeAt: Date.now(),
+      },
+    ],
+    "server",
+  );
+
+  value = await metricReader.getMetricValue("jazz.transactions.size", {
+    source: "server",
+  });
+  assert(typeof value !== "number" && !!value?.count);
+  expect(value.count).toBe(2);
+  expect(value.sum).toBe(changes1.length + changes2.length);
+});
+
+test("(smoke test) records transactions from local node", async () => {
+  const [account, sessionID] = randomAnonymousAccountAndSessionID();
+  const node = new LocalNode(account, sessionID, Crypto);
+
+  node.createGroup();
+
+  let value = await metricReader.getMetricValue("jazz.transactions.size", {
+    source: "local",
+  });
+
+  assert(typeof value !== "number" && !!value?.count);
+  expect(value.count).toBe(3);
 });
 
 test("creating a coValue with a group should't trigger automatically a content creation (performance)", () => {


### PR DESCRIPTION
adds a `jazz.transactions.size` histogram, with a a `source` label to meter transactions sizes, and a `jazz.covalues.loaded` updown counter - with a `state` label - to count loaded covalues by state.


example:

```
# HELP jazz_transactions_size The size of transactions in a covalue
# UNIT jazz_transactions_size bytes
# TYPE jazz_transactions_size histogram
jazz_transactions_size_count{source="client"} 10375
jazz_transactions_size_sum{source="client"} 25721899
jazz_transactions_size_bucket{source="client",le="0"} 0
jazz_transactions_size_bucket{source="client",le="5"} 0
jazz_transactions_size_bucket{source="client",le="10"} 0
jazz_transactions_size_bucket{source="client",le="25"} 0
jazz_transactions_size_bucket{source="client",le="50"} 10
jazz_transactions_size_bucket{source="client",le="75"} 66
jazz_transactions_size_bucket{source="client",le="100"} 75
jazz_transactions_size_bucket{source="client",le="250"} 5271
jazz_transactions_size_bucket{source="client",le="500"} 5289
jazz_transactions_size_bucket{source="client",le="750"} 5289
jazz_transactions_size_bucket{source="client",le="1000"} 5289
jazz_transactions_size_bucket{source="client",le="2500"} 5289
jazz_transactions_size_bucket{source="client",le="5000"} 10375
jazz_transactions_size_bucket{source="client",le="7500"} 10375
jazz_transactions_size_bucket{source="client",le="10000"} 10375
jazz_transactions_size_bucket{source="client",le="+Inf"} 10375
# HELP jazz_covalues_loaded The number of covalues in the system
# UNIT jazz_covalues_loaded covalue
# TYPE jazz_covalues_loaded gauge
jazz_covalues_loaded{state="unknown"} 0
jazz_covalues_loaded{state="loading"} 0
jazz_covalues_loaded{state="available"} 5160
jazz_covalues_loaded{state="unavailable"} 0
```

NB: buckets size can be modified on the instumentation side