### PR TITLE
fix: make jazz-tools a peerDependency

### DIFF
--- a/.changeset/many-doors-move.md
+++ b/.changeset/many-doors-move.md
@@ -1,0 +1,21 @@
+---
+"jazz-react-native-media-images": minor
+"jazz-browser-media-images": minor
+"jazz-richtext-prosemirror": minor
+"jazz-inspector-element": minor
+"jazz-react-native-core": minor
+"jazz-react-auth-clerk": minor
+"jazz-react-native": minor
+"jazz-auth-clerk": minor
+"jazz-react-core": minor
+"jazz-inspector": minor
+"jazz-browser": minor
+"jazz-nodejs": minor
+"jazz-svelte": minor
+"jazz-react": minor
+"jazz-expo": minor
+"jazz-run": minor
+"jazz-vue": minor
+---
+
+Make jazz-tools a peerDependency, to reduce risks of having multiple versions of it

--- a/packages/jazz-auth-clerk/package.json
+++ b/packages/jazz-auth-clerk/package.json
@@ -5,10 +5,12 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "license": "MIT",
+  "peerDependencies": {
+    "jazz-tools": "workspace:*"
+  },
   "dependencies": {
-    "cojson": "workspace:0.13.28",
-    "jazz-browser": "workspace:0.13.28",
-    "jazz-tools": "workspace:0.13.28"
+    "cojson": "workspace:*",
+    "jazz-browser": "workspace:*"
   },
   "scripts": {
     "format-and-lint": "biome check .",
@@ -19,6 +21,7 @@
     "dev": " tsc --sourceMap --outDir dist --watch"
   },
   "devDependencies": {
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "jazz-tools": "workspace:*"
   }
 }

--- a/packages/jazz-browser-media-images/package.json
+++ b/packages/jazz-browser-media-images/package.json
@@ -5,11 +5,13 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "license": "MIT",
+  "peerDependencies": {
+    "jazz-tools": "workspace:*"
+  },
   "dependencies": {
     "@types/image-blob-reduce": "^4.1.1",
     "image-blob-reduce": "^4.1.0",
-    "jazz-browser": "workspace:0.13.28",
-    "jazz-tools": "workspace:0.13.28",
+    "jazz-browser": "workspace:*",
     "pica": "^9.0.1"
   },
   "scripts": {
@@ -19,6 +21,7 @@
   },
   "devDependencies": {
     "@types/pica": "^9.0.4",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "jazz-tools": "workspace:*"
   }
 }

--- a/packages/jazz-browser/package.json
+++ b/packages/jazz-browser/package.json
@@ -5,15 +5,18 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "license": "MIT",
+  "peerDependencies": {
+    "jazz-tools": "workspace:*"
+  },
   "dependencies": {
     "cojson": "workspace:*",
     "cojson-storage-indexeddb": "workspace:*",
-    "cojson-transport-ws": "workspace:*",
-    "jazz-tools": "workspace:*"
+    "cojson-transport-ws": "workspace:*"
   },
   "devDependencies": {
     "fake-indexeddb": "^6.0.0",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "jazz-tools": "workspace:*"
   },
   "scripts": {
     "format-and-lint": "biome check .",

--- a/packages/jazz-expo/package.json
+++ b/packages/jazz-expo/package.json
@@ -41,20 +41,21 @@
     "expo-sqlite": "15.1.3",
     "jazz-auth-clerk": "workspace:*",
     "jazz-react-core": "workspace:*",
-    "jazz-react-native-core": "workspace:*",
-    "jazz-tools": "workspace:*"
+    "jazz-react-native-core": "workspace:*"
   },
   "peerDependencies": {
     "@react-native-community/netinfo": "*",
     "expo-secure-store": "*",
-    "react-native": "*"
+    "react-native": "*",
+    "jazz-tools": "workspace:*"
   },
   "devDependencies": {
     "@react-native-community/netinfo": "11.4.1",
     "expo-secure-store": "~14.0.1",
     "react": "18.3.1",
     "react-native": "0.76.7",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "jazz-tools": "workspace:*"
   },
   "scripts": {
     "dev": "tsc --watch --sourceMap --outDir dist",

--- a/packages/jazz-inspector-element/package.json
+++ b/packages/jazz-inspector-element/package.json
@@ -17,9 +17,11 @@
   },
   "dependencies": {
     "jazz-inspector": "workspace:*",
-    "jazz-tools": "workspace:*",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
+  },
+  "peerDependencies": {
+    "jazz-tools": "workspace:*"
   },
   "devDependencies": {
     "@types/react": "^18.3.12",
@@ -27,6 +29,7 @@
     "@vitejs/plugin-react-swc": "^3.3.2",
     "rollup-plugin-node-externals": "^8.0.0",
     "typescript": "catalog:",
-    "vite": "catalog:"
+    "vite": "catalog:",
+    "jazz-tools": "workspace:*"
   }
 }

--- a/packages/jazz-inspector/package.json
+++ b/packages/jazz-inspector/package.json
@@ -19,11 +19,11 @@
     "clsx": "^2.0.0",
     "cojson": "workspace:*",
     "goober": "^2.1.16",
-    "jazz-react-core": "workspace:*",
-    "jazz-tools": "workspace:*"
+    "jazz-react-core": "workspace:*"
   },
   "peerDependencies": {
-    "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+    "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+    "jazz-tools": "workspace:*"
   },
   "devDependencies": {
     "@types/react": "^18.3.12",
@@ -31,6 +31,7 @@
     "@vitejs/plugin-react-swc": "^3.3.2",
     "rollup-plugin-node-externals": "^8.0.0",
     "typescript": "catalog:",
-    "vite": "catalog:"
+    "vite": "catalog:",
+    "jazz-tools": "workspace:*"
   }
 }

--- a/packages/jazz-nodejs/package.json
+++ b/packages/jazz-nodejs/package.json
@@ -8,12 +8,15 @@
   "version": "0.13.28",
   "dependencies": {
     "cojson": "workspace:*",
-    "cojson-transport-ws": "workspace:*",
+    "cojson-transport-ws": "workspace:*"
+  },
+  "peerDependencies": {
     "jazz-tools": "workspace:*"
   },
   "devDependencies": {
     "jazz-run": "workspace:*",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "jazz-tools": "workspace:*"
   },
   "scripts": {
     "dev": "tsc --watch --sourceMap --outDir dist",

--- a/packages/jazz-react-auth-clerk/package.json
+++ b/packages/jazz-react-auth-clerk/package.json
@@ -9,11 +9,11 @@
     "cojson": "workspace:*",
     "jazz-auth-clerk": "workspace:*",
     "jazz-browser": "workspace:*",
-    "jazz-react": "workspace:*",
-    "jazz-tools": "workspace:*"
+    "jazz-react": "workspace:*"
   },
   "peerDependencies": {
-    "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+    "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+    "jazz-tools": "workspace:*"
   },
   "scripts": {
     "format-and-lint": "biome check .",
@@ -25,6 +25,7 @@
     "@testing-library/react": "16.2.0",
     "@types/react": "18.3.12",
     "@types/react-dom": "18.3.1",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "jazz-tools": "workspace:*"
   }
 }

--- a/packages/jazz-react-core/package.json
+++ b/packages/jazz-react-core/package.json
@@ -16,8 +16,7 @@
     }
   },
   "dependencies": {
-    "cojson": "workspace:*",
-    "jazz-tools": "workspace:*"
+    "cojson": "workspace:*"
   },
   "devDependencies": {
     "@scure/bip39": "^1.3.0",
@@ -28,11 +27,13 @@
     "@types/react-dom": "18.3.1",
     "react": "18.3.1",
     "react-dom": "18.3.1",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "jazz-tools": "workspace:*"
   },
   "peerDependencies": {
     "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-    "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+    "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0",
+    "jazz-tools": "workspace:*"
   },
   "scripts": {
     "dev": "tsc --watch --sourceMap --outDir dist",

--- a/packages/jazz-react-native-core/package.json
+++ b/packages/jazz-react-native-core/package.json
@@ -39,12 +39,15 @@
     "cojson-storage": "workspace:*",
     "cojson-transport-ws": "workspace:*",
     "jazz-react-core": "workspace:*",
-    "jazz-tools": "workspace:*",
     "react-native-nitro-modules": "0.25.2",
     "react-native-quick-crypto": "1.0.0-beta.15"
   },
   "devDependencies": {
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "jazz-tools": "workspace:*"
+  },
+  "peerDependencies": {
+    "jazz-tools": "workspace:*"
   },
   "scripts": {
     "dev": "tsc --watch --sourceMap --outDir dist",

--- a/packages/jazz-react-native-media-images/package.json
+++ b/packages/jazz-react-native-media-images/package.json
@@ -5,20 +5,19 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "license": "MIT",
-  "dependencies": {
-    "jazz-tools": "workspace:*"
-  },
   "devDependencies": {
     "@bam.tech/react-native-image-resizer": "^3.0.11",
     "expo-file-system": "^18.0.4",
     "react": "18.2.0",
     "react-native": "0.76.7",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "jazz-tools": "workspace:*"
   },
   "peerDependencies": {
     "@bam.tech/react-native-image-resizer": "*",
     "expo-file-system": "*",
-    "react-native": "*"
+    "react-native": "*",
+    "jazz-tools": "workspace:*"
   },
   "scripts": {
     "format-and-lint": "biome check .",

--- a/packages/jazz-react-native/package.json
+++ b/packages/jazz-react-native/package.json
@@ -30,18 +30,19 @@
     "cojson": "workspace:*",
     "cojson-storage": "workspace:*",
     "jazz-react-native-core": "workspace:*",
-    "jazz-tools": "workspace:*",
     "react-native-mmkv": "^3.2.0"
   },
   "peerDependencies": {
     "@react-native-community/netinfo": "*",
-    "react-native": "*"
+    "react-native": "*",
+    "jazz-tools": "workspace:*"
   },
   "devDependencies": {
     "@react-native-community/netinfo": "11.4.1",
     "react": "18.3.1",
     "react-native": "0.76.7",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "jazz-tools": "workspace:*"
   },
   "scripts": {
     "dev": "tsc --watch --sourceMap --outDir dist",

--- a/packages/jazz-react/package.json
+++ b/packages/jazz-react/package.json
@@ -17,11 +17,10 @@
   },
   "dependencies": {
     "@scure/bip39": "^1.3.0",
-    "cojson": "workspace:0.13.28",
-    "jazz-browser-media-images": "workspace:0.13.28",
-    "jazz-browser": "workspace:0.13.28",
-    "jazz-react-core": "workspace:0.13.28",
-    "jazz-tools": "workspace:0.13.28"
+    "cojson": "workspace:*",
+    "jazz-browser-media-images": "workspace:*",
+    "jazz-browser": "workspace:*",
+    "jazz-react-core": "workspace:*"
   },
   "devDependencies": {
     "@testing-library/dom": "^10.4.0",
@@ -31,11 +30,13 @@
     "@types/react-dom": "18.3.1",
     "react": "18.3.1",
     "react-dom": "18.3.1",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "jazz-tools": "workspace:*"
   },
   "peerDependencies": {
     "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-    "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+    "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0",
+    "jazz-tools": "workspace:*"
   },
   "scripts": {
     "dev": "tsc --watch --sourceMap --outDir dist",

--- a/packages/jazz-richtext-prosemirror/package.json
+++ b/packages/jazz-richtext-prosemirror/package.json
@@ -15,10 +15,12 @@
   "keywords": [],
   "author": "Garden Computing, Inc.",
   "license": "MIT",
+  "peerDependencies": {
+    "jazz-tools": "workspace:*"
+  },
   "dependencies": {
     "@manuscripts/prosemirror-recreate-steps": "^0.1.4",
     "jazz-browser": "workspace:*",
-    "jazz-tools": "workspace:*",
     "prosemirror-example-setup": "^1.2.2",
     "prosemirror-menu": "^1.2.4",
     "prosemirror-model": "^1.21.1",
@@ -32,6 +34,7 @@
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/user-event": "^14.5.2",
     "typescript": "catalog:",
-    "vitest": "catalog:"
+    "vitest": "catalog:",
+    "jazz-tools": "workspace:*"
   }
 }

--- a/packages/jazz-run/package.json
+++ b/packages/jazz-run/package.json
@@ -28,15 +28,18 @@
     "@effect/printer-ansi": "^0.34.5",
     "@effect/schema": "^0.71.1",
     "@effect/typeclass": "^0.25.5",
-    "cojson": "workspace:0.13.28",
-    "cojson-storage-sqlite": "workspace:0.13.28",
-    "cojson-transport-ws": "workspace:0.13.28",
+    "cojson": "workspace:*",
+    "cojson-storage-sqlite": "workspace:*",
+    "cojson-transport-ws": "workspace:*",
     "effect": "^3.6.5",
-    "jazz-tools": "workspace:0.13.28",
     "ws": "^8.14.2"
+  },
+  "peerDependencies": {
+    "jazz-tools": "workspace:*"
   },
   "devDependencies": {
     "@types/ws": "8.5.10",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "jazz-tools": "workspace:*"
   }
 }

--- a/packages/jazz-svelte/package.json
+++ b/packages/jazz-svelte/package.json
@@ -38,7 +38,8 @@
     }
   },
   "peerDependencies": {
-    "svelte": "^5.0.0"
+    "svelte": "^5.0.0",
+    "jazz-tools": "workspace:*"
   },
   "devDependencies": {
     "@sveltejs/adapter-vercel": "^5.5.0",
@@ -61,11 +62,11 @@
     "svelte-check": "^4.0.0",
     "typescript": "catalog:",
     "typescript-eslint": "^8.0.0",
-    "vite": "catalog:"
+    "vite": "catalog:",
+    "jazz-tools": "workspace:*"
   },
   "dependencies": {
     "cojson": "workspace:*",
-    "jazz-browser": "workspace:*",
-    "jazz-tools": "workspace:*"
+    "jazz-browser": "workspace:*"
   }
 }

--- a/packages/jazz-vue/package.json
+++ b/packages/jazz-vue/package.json
@@ -17,8 +17,7 @@
   },
   "dependencies": {
     "cojson": "workspace:*",
-    "jazz-browser": "workspace:*",
-    "jazz-tools": "workspace:*"
+    "jazz-browser": "workspace:*"
   },
   "devDependencies": {
     "@scure/bip39": "^1.3.0",
@@ -28,10 +27,12 @@
     "vite": "catalog:",
     "vite-plugin-dts": "^4.2.4",
     "vue": "^3.5.11",
-    "vue-tsc": "^2.1.6"
+    "vue-tsc": "^2.1.6",
+    "jazz-tools": "workspace:*"
   },
   "peerDependencies": {
-    "vue": "^3.5.11"
+    "vue": "^3.5.11",
+    "jazz-tools": "workspace:*"
   },
   "scripts": {
     "dev": "vite build --watch",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2141,15 +2141,15 @@ importers:
   packages/jazz-auth-clerk:
     dependencies:
       cojson:
-        specifier: workspace:0.13.28
+        specifier: workspace:*
         version: link:../cojson
       jazz-browser:
-        specifier: workspace:0.13.28
+        specifier: workspace:*
         version: link:../jazz-browser
-      jazz-tools:
-        specifier: workspace:0.13.28
-        version: link:../jazz-tools
     devDependencies:
+      jazz-tools:
+        specifier: workspace:*
+        version: link:../jazz-tools
       typescript:
         specifier: 'catalog:'
         version: 5.6.2
@@ -2203,13 +2203,13 @@ importers:
       cojson-transport-ws:
         specifier: workspace:*
         version: link:../cojson-transport-ws
-      jazz-tools:
-        specifier: workspace:*
-        version: link:../jazz-tools
     devDependencies:
       fake-indexeddb:
         specifier: ^6.0.0
         version: 6.0.0
+      jazz-tools:
+        specifier: workspace:*
+        version: link:../jazz-tools
       typescript:
         specifier: 'catalog:'
         version: 5.6.2
@@ -2223,11 +2223,8 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0
       jazz-browser:
-        specifier: workspace:0.13.28
+        specifier: workspace:*
         version: link:../jazz-browser
-      jazz-tools:
-        specifier: workspace:0.13.28
-        version: link:../jazz-tools
       pica:
         specifier: ^9.0.1
         version: 9.0.1
@@ -2235,6 +2232,9 @@ importers:
       '@types/pica':
         specifier: ^9.0.4
         version: 9.0.4
+      jazz-tools:
+        specifier: workspace:*
+        version: link:../jazz-tools
       typescript:
         specifier: 'catalog:'
         version: 5.6.2
@@ -2262,9 +2262,6 @@ importers:
       jazz-react-native-core:
         specifier: workspace:*
         version: link:../jazz-react-native-core
-      jazz-tools:
-        specifier: workspace:*
-        version: link:../jazz-tools
     devDependencies:
       '@react-native-community/netinfo':
         specifier: 11.4.1
@@ -2272,6 +2269,9 @@ importers:
       expo-secure-store:
         specifier: ~14.0.1
         version: 14.0.1(expo@52.0.42(@babel/core@7.26.10)(@babel/preset-env@7.26.0(@babel/core@7.26.10))(@expo/metro-runtime@4.0.1(react-native@0.76.7(@babel/core@7.26.10)(@babel/preset-env@7.26.0(@babel/core@7.26.10))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1)))(graphql@16.10.0)(react-native@0.76.7(@babel/core@7.26.10)(@babel/preset-env@7.26.0(@babel/core@7.26.10))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1))(react@18.3.1))
+      jazz-tools:
+        specifier: workspace:*
+        version: link:../jazz-tools
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -2296,9 +2296,6 @@ importers:
       jazz-react-core:
         specifier: workspace:*
         version: link:../jazz-react-core
-      jazz-tools:
-        specifier: workspace:*
-        version: link:../jazz-tools
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -2312,6 +2309,9 @@ importers:
       '@vitejs/plugin-react-swc':
         specifier: ^3.3.2
         version: 3.7.2(@swc/helpers@0.5.15)(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1))
+      jazz-tools:
+        specifier: workspace:*
+        version: link:../jazz-tools
       rollup-plugin-node-externals:
         specifier: ^8.0.0
         version: 8.0.0(rollup@4.28.1)
@@ -2327,9 +2327,6 @@ importers:
       jazz-inspector:
         specifier: workspace:*
         version: link:../jazz-inspector
-      jazz-tools:
-        specifier: workspace:*
-        version: link:../jazz-tools
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -2346,6 +2343,9 @@ importers:
       '@vitejs/plugin-react-swc':
         specifier: ^3.3.2
         version: 3.7.2(@swc/helpers@0.5.15)(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1))
+      jazz-tools:
+        specifier: workspace:*
+        version: link:../jazz-tools
       rollup-plugin-node-externals:
         specifier: ^8.0.0
         version: 8.0.0(rollup@4.28.1)
@@ -2364,13 +2364,13 @@ importers:
       cojson-transport-ws:
         specifier: workspace:*
         version: link:../cojson-transport-ws
-      jazz-tools:
-        specifier: workspace:*
-        version: link:../jazz-tools
     devDependencies:
       jazz-run:
         specifier: workspace:*
         version: link:../jazz-run
+      jazz-tools:
+        specifier: workspace:*
+        version: link:../jazz-tools
       typescript:
         specifier: 'catalog:'
         version: 5.6.2
@@ -2381,20 +2381,17 @@ importers:
         specifier: ^1.3.0
         version: 1.5.0
       cojson:
-        specifier: workspace:0.13.28
+        specifier: workspace:*
         version: link:../cojson
       jazz-browser:
-        specifier: workspace:0.13.28
+        specifier: workspace:*
         version: link:../jazz-browser
       jazz-browser-media-images:
-        specifier: workspace:0.13.28
+        specifier: workspace:*
         version: link:../jazz-browser-media-images
       jazz-react-core:
-        specifier: workspace:0.13.28
+        specifier: workspace:*
         version: link:../jazz-react-core
-      jazz-tools:
-        specifier: workspace:0.13.28
-        version: link:../jazz-tools
     devDependencies:
       '@testing-library/dom':
         specifier: ^10.4.0
@@ -2411,6 +2408,9 @@ importers:
       '@types/react-dom':
         specifier: 18.3.1
         version: 18.3.1
+      jazz-tools:
+        specifier: workspace:*
+        version: link:../jazz-tools
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -2469,9 +2469,6 @@ importers:
       jazz-react:
         specifier: workspace:*
         version: link:../jazz-react
-      jazz-tools:
-        specifier: workspace:*
-        version: link:../jazz-tools
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -2485,6 +2482,9 @@ importers:
       '@types/react-dom':
         specifier: 18.3.1
         version: 18.3.1
+      jazz-tools:
+        specifier: workspace:*
+        version: link:../jazz-tools
       typescript:
         specifier: 'catalog:'
         version: 5.6.2
@@ -2494,9 +2494,6 @@ importers:
       cojson:
         specifier: workspace:*
         version: link:../cojson
-      jazz-tools:
-        specifier: workspace:*
-        version: link:../jazz-tools
     devDependencies:
       '@scure/bip39':
         specifier: ^1.3.0
@@ -2516,6 +2513,9 @@ importers:
       '@types/react-dom':
         specifier: 18.3.1
         version: 18.3.1
+      jazz-tools:
+        specifier: workspace:*
+        version: link:../jazz-tools
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -2543,9 +2543,6 @@ importers:
       jazz-react-native-core:
         specifier: workspace:*
         version: link:../jazz-react-native-core
-      jazz-tools:
-        specifier: workspace:*
-        version: link:../jazz-tools
       react-native-mmkv:
         specifier: ^3.2.0
         version: 3.2.0(react-native@0.76.7(@babel/core@7.26.10)(@babel/preset-env@7.26.0(@babel/core@7.26.10))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1))(react@18.3.1)
@@ -2553,6 +2550,9 @@ importers:
       '@react-native-community/netinfo':
         specifier: 11.4.1
         version: 11.4.1(react-native@0.76.7(@babel/core@7.26.10)(@babel/preset-env@7.26.0(@babel/core@7.26.10))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1))
+      jazz-tools:
+        specifier: workspace:*
+        version: link:../jazz-tools
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -2577,9 +2577,6 @@ importers:
       jazz-react-core:
         specifier: workspace:*
         version: link:../jazz-react-core
-      jazz-tools:
-        specifier: workspace:*
-        version: link:../jazz-tools
       react-native-nitro-modules:
         specifier: 0.25.2
         version: 0.25.2(react-native@0.76.8(@babel/core@7.26.10)(@babel/preset-env@7.26.0(@babel/core@7.26.10))(@react-native-community/cli@15.0.1(typescript@5.6.2))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1)
@@ -2587,15 +2584,14 @@ importers:
         specifier: 1.0.0-beta.15
         version: 1.0.0-beta.15(react-native-nitro-modules@0.25.2(react-native@0.76.8(@babel/core@7.26.10)(@babel/preset-env@7.26.0(@babel/core@7.26.10))(@react-native-community/cli@15.0.1(typescript@5.6.2))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1))(react-native@0.76.8(@babel/core@7.26.10)(@babel/preset-env@7.26.0(@babel/core@7.26.10))(@react-native-community/cli@15.0.1(typescript@5.6.2))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1)
     devDependencies:
+      jazz-tools:
+        specifier: workspace:*
+        version: link:../jazz-tools
       typescript:
         specifier: 'catalog:'
         version: 5.6.2
 
   packages/jazz-react-native-media-images:
-    dependencies:
-      jazz-tools:
-        specifier: workspace:*
-        version: link:../jazz-tools
     devDependencies:
       '@bam.tech/react-native-image-resizer':
         specifier: ^3.0.11
@@ -2603,6 +2599,9 @@ importers:
       expo-file-system:
         specifier: ^18.0.4
         version: 18.0.12(expo@52.0.42(@babel/core@7.26.10)(@babel/preset-env@7.26.0(@babel/core@7.26.10))(@expo/metro-runtime@4.0.1(react-native@0.76.7(@babel/core@7.26.10)(@babel/preset-env@7.26.0(@babel/core@7.26.10))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1)))(graphql@16.10.0)(react-native@0.76.7(@babel/core@7.26.10)(@babel/preset-env@7.26.0(@babel/core@7.26.10))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1))(react@18.3.1))(react-native@0.76.7(@babel/core@7.26.10)(@babel/preset-env@7.26.0(@babel/core@7.26.10))(@react-native-community/cli-server-api@15.0.1)(@types/react@18.3.18)(react@18.3.1))
+      jazz-tools:
+        specifier: workspace:*
+        version: link:../jazz-tools
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -2621,9 +2620,6 @@ importers:
       jazz-browser:
         specifier: workspace:*
         version: link:../jazz-browser
-      jazz-tools:
-        specifier: workspace:*
-        version: link:../jazz-tools
       prosemirror-example-setup:
         specifier: ^1.2.2
         version: 1.2.3
@@ -2655,6 +2651,9 @@ importers:
       '@testing-library/user-event':
         specifier: ^14.5.2
         version: 14.6.1(@testing-library/dom@10.4.0)
+      jazz-tools:
+        specifier: workspace:*
+        version: link:../jazz-tools
       typescript:
         specifier: 'catalog:'
         version: 5.6.2
@@ -2717,20 +2716,17 @@ importers:
         specifier: ^0.25.5
         version: 0.25.8(effect@3.11.9)
       cojson:
-        specifier: workspace:0.13.28
+        specifier: workspace:*
         version: link:../cojson
       cojson-storage-sqlite:
-        specifier: workspace:0.13.28
+        specifier: workspace:*
         version: link:../cojson-storage-sqlite
       cojson-transport-ws:
-        specifier: workspace:0.13.28
+        specifier: workspace:*
         version: link:../cojson-transport-ws
       effect:
         specifier: ^3.6.5
         version: 3.11.9
-      jazz-tools:
-        specifier: workspace:0.13.28
-        version: link:../jazz-tools
       ws:
         specifier: ^8.14.2
         version: 8.18.0
@@ -2738,6 +2734,9 @@ importers:
       '@types/ws':
         specifier: 8.5.10
         version: 8.5.10
+      jazz-tools:
+        specifier: workspace:*
+        version: link:../jazz-tools
       typescript:
         specifier: 'catalog:'
         version: 5.6.2
@@ -2750,9 +2749,6 @@ importers:
       jazz-browser:
         specifier: workspace:*
         version: link:../jazz-browser
-      jazz-tools:
-        specifier: workspace:*
-        version: link:../jazz-tools
     devDependencies:
       '@sveltejs/adapter-vercel':
         specifier: ^5.5.0
@@ -2790,6 +2786,9 @@ importers:
       globals:
         specifier: ^15.11.0
         version: 15.14.0
+      jazz-tools:
+        specifier: workspace:*
+        version: link:../jazz-tools
       jsdom:
         specifier: ^25.0.1
         version: 25.0.1
@@ -2851,9 +2850,6 @@ importers:
       jazz-browser:
         specifier: workspace:*
         version: link:../jazz-browser
-      jazz-tools:
-        specifier: workspace:*
-        version: link:../jazz-tools
     devDependencies:
       '@scure/bip39':
         specifier: ^1.3.0
@@ -2861,6 +2857,9 @@ importers:
       '@vitejs/plugin-vue':
         specifier: ^5.1.4
         version: 5.2.1(vite@6.0.11(@types/node@22.10.2)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.37.0)(tsx@4.19.3)(yaml@2.6.1))(vue@3.5.13(typescript@5.6.2))
+      jazz-tools:
+        specifier: workspace:*
+        version: link:../jazz-tools
       rollup-plugin-node-externals:
         specifier: ^8.0.0
         version: 8.0.0(rollup@4.28.1)


### PR DESCRIPTION
Make jazz-tools a peerDependency, to reduce risks of having multiple versions of it

fixes #1868 