### PR TITLE
[website] Use `/next` import for analytics

### DIFF
--- a/homepage/homepage/app/layout.tsx
+++ b/homepage/homepage/app/layout.tsx
@@ -3,7 +3,7 @@ import { ThemeProvider } from "@/components/ThemeProvider";
 import { JazzFooter } from "@/components/footer";
 import { marketingCopy } from "@/content/marketingCopy";
 import { fontClasses } from "@garden-co/design-system/src/fonts";
-import { Analytics } from "@vercel/analytics/react";
+import { Analytics } from "@vercel/analytics/next";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import type { Metadata } from "next";
 


### PR DESCRIPTION
 Use Next.js import for Vercel Analytics to get pageviews per route as well