### PR TITLE
feat(jazz-expo): API for clearing local DB

### DIFF
--- a/.changeset/plenty-ways-smash.md
+++ b/.changeset/plenty-ways-smash.md
@@ -2,4 +2,4 @@
 "jazz-expo": patch
 ---
 
-feat: API for clearing local storage
+feat: API for clearing local data storage

--- a/.changeset/plenty-ways-smash.md
+++ b/.changeset/plenty-ways-smash.md
@@ -1,0 +1,5 @@
+---
+"jazz-expo": patch
+---
+
+feat: API for clearing local storage

--- a/packages/jazz-react-native-core/src/auth/auth.ts
+++ b/packages/jazz-react-native-core/src/auth/auth.ts
@@ -12,8 +12,3 @@ export function clearUserCredentials() {
     kvStore.delete("jazz-logged-in-secret"),
   ]);
 }
-
-export function clearLocalData() {
-  const kvStore = KvStoreContext.getInstance().getStorage();
-  return kvStore.clearAll();
-}

--- a/packages/jazz-react-native-core/src/auth/auth.ts
+++ b/packages/jazz-react-native-core/src/auth/auth.ts
@@ -12,3 +12,8 @@ export function clearUserCredentials() {
     kvStore.delete("jazz-logged-in-secret"),
   ]);
 }
+
+export function clearLocalData() {
+  const kvStore = KvStoreContext.getInstance().getStorage();
+  return kvStore.clearAll();
+}


### PR DESCRIPTION
Closes #2400.

Steps to test locally:
1. In `examples/chat-rn-expo`, run `pnpm start` and start a simulator using Expo Go
2. In the simulator, create a new chat, and write a message
3. Save the chat ID
4. Turn off your machine's network connection
5. Logout, then access the chat by its ID again
  - The chat should load from your local storage successfully
6. Open the JavaScript debugger
7. Save the SQLite database as a global variable (accessible from the `JazzProviderCore` component properties)
8. Call `clearLocalData()` on the database variable
9. Logout, then attempt to access the chat by its ID again
  - The chat should fail to load since the local storage has been cleared