### PR TITLE
track event: template command copied from examples page

### DIFF
--- a/homepage/design-system/src/components/molecules/CodeGroup.tsx
+++ b/homepage/design-system/src/components/molecules/CodeGroup.tsx
@@ -81,11 +81,13 @@ export function CodeGroup({
   children,
   size = "md",
   className,
+  onCopy,
 }: {
   children?: React.ReactNode;
   text?: string;
   size?: "md" | "lg";
   className?: string;
+  onCopy?: () => void;
 }) {
   const textRef = useRef<HTMLPreElement | null>(null);
   const [code, setCode] = useState<string>();
@@ -127,7 +129,7 @@ export function CodeGroup({
         {children}
       </pre>
 
-      {code ? <CopyButton size={size} code={code} /> : <></>}
+      {code ? <CopyButton onCopy={onCopy} size={size} code={code} /> : <></>}
     </div>
   );
 }

--- a/homepage/homepage/app/(others)/examples/page.tsx
+++ b/homepage/homepage/app/(others)/examples/page.tsx
@@ -650,7 +650,8 @@ const svelteExamples: Example[] = [
     tech: [tech.svelte],
     features: [features.fileUpload, features.passkey, features.inviteLink],
     illustration: <FileShareIllustration />,
-  }, {
+  },
+  {
     name: "Chat",
     slug: "chat-svelte",
     description:

--- a/homepage/homepage/components/examples/ExampleLinks.tsx
+++ b/homepage/homepage/components/examples/ExampleLinks.tsx
@@ -11,6 +11,7 @@ import {
   DialogTitle,
 } from "@garden-co/design-system/src/components/organisms/Dialog";
 import { DialogDescription } from "@headlessui/react";
+import { track } from "@vercel/analytics";
 import { useState } from "react";
 import CreateJazzApp from "./CreateJazzApp.mdx";
 
@@ -47,7 +48,13 @@ export function ExampleLinks({ example }: { example: Example }) {
           <p className="mb-3">
             Generate a new Jazz app by running the command below.
           </p>
-          <CodeGroup>
+          <CodeGroup
+            onCopy={() => {
+              track("Template command copied from examples page", {
+                example: example.slug,
+              });
+            }}
+          >
             <CreateJazzApp
               components={InterpolateInCode({
                 $EXAMPLE: example.slug,


### PR DESCRIPTION
This adds event tracking for when the copy button is clicked from the examples page

```
track("Template command copied from examples page", {
  example: example.slug,
});
 ```

<img width="767" alt="image" src="https://github.com/user-attachments/assets/e41628c7-1bf0-4d2e-b86b-a27ffdfd2c8a" />