### PR TITLE
chore: update runners from 22.04 to 24.04

### DIFF
--- a/.github/workflows/e2e-rn-test.yml
+++ b/.github/workflows/e2e-rn-test.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   e2e-tests:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-4vcpu-ubuntu-2204
 
     steps:
       - name: Checkout

--- a/.github/workflows/e2e-rn-test.yml
+++ b/.github/workflows/e2e-rn-test.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   e2e-tests:
-    runs-on: blacksmith-4vcpu-ubuntu-2204
+    runs-on: blacksmith-4vcpu-ubuntu-2404
 
     steps:
       - name: Checkout

--- a/.github/workflows/jazz-run.yml
+++ b/.github/workflows/jazz-run.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: blacksmith-4vcpu-ubuntu-2204
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 5
 
     steps:

--- a/.github/workflows/playwright-homepage.yml
+++ b/.github/workflows/playwright-homepage.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   test:
     timeout-minutes: 60
-    runs-on: blacksmith-4vcpu-ubuntu-2204
+    runs-on: blacksmith-4vcpu-ubuntu-2404
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   test:
     timeout-minutes: 60
-    runs-on: blacksmith-4vcpu-ubuntu-2204
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     continue-on-error: true
     strategy:
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   release:
     name: Release
-    runs-on: blacksmith-4vcpu-ubuntu-2204
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   unit-tests:
-    runs-on: blacksmith-4vcpu-ubuntu-2204
+    runs-on: blacksmith-4vcpu-ubuntu-2404
 
     steps:
       - name: Checkout


### PR DESCRIPTION
update actions to use ubuntu 24.04 instead of 22.04 (except rn tests, which seems to hang, see https://github.com/garden-co/jazz/actions/runs/15819032275/job/44583735905?pr=2566).

this is a follow up to the code-quality action from https://github.com/garden-co/jazz/pull/2561