### PR TITLE
fix(ci): listen to e2e-rn-test's exit code

### DIFF
--- a/.github/workflows/e2e-rn-test.yml
+++ b/.github/workflows/e2e-rn-test.yml
@@ -61,7 +61,7 @@ jobs:
           disable-animations: true
           working-directory: ./examples/chat-rn-expo/
           # killall due to this issue: https://github.com/ReactiveCircus/android-emulator-runner/issues/385
-          script: ./test/e2e/run.sh && killall -INT crashpad_handler || true
+          script: ./test/e2e/run.sh && ( killall -INT crashpad_handler || true )
 
       - name: Copy Maestro Output
         if: steps.e2e_test.outcome != 'success'


### PR DESCRIPTION
As reported in https://github.com/garden-co/jazz/pull/2558#issuecomment-3014992239 , the e2e react native test's exit code was ignored.


Retested with failing test in https://github.com/garden-co/jazz/actions/runs/15977055254/job/45062181979?pr=2591#step:11:197