### PR TITLE
Make all React Native deps in `jazz-tools` optional peer dependencies

### DIFF
--- a/.changeset/curvy-humans-drive.md
+++ b/.changeset/curvy-humans-drive.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Make all React Native dependencies in `jazz-tools` optional peer dependencies

--- a/homepage/homepage/content/docs/project-setup/providers/react-native-expo.mdx
+++ b/homepage/homepage/content/docs/project-setup/providers/react-native-expo.mdx
@@ -118,7 +118,7 @@ To use it, install the following Packages:
 
 <CodeGroup>
 ```bash
-pnpm add react-native-quick-crypto@1.0.0-beta.18 react-native-nitro-modules
+pnpm add react-native-quick-crypto@1.0.0-beta.18 react-native-nitro-modules react-native-fast-encoder
 ```
 </CodeGroup>
 

--- a/homepage/homepage/content/docs/project-setup/providers/react-native.mdx
+++ b/homepage/homepage/content/docs/project-setup/providers/react-native.mdx
@@ -116,7 +116,7 @@ To use it, install the following Packages:
 
 <CodeGroup>
 ```bash
-pnpm add react-native-quick-crypto@1.0.0-beta.18 react-native-nitro-modules
+pnpm add react-native-quick-crypto@1.0.0-beta.18 react-native-nitro-modules react-native-fast-encoder
 ```
 </CodeGroup>
 

--- a/homepage/homepage/content/docs/project-setup/react-native-expo.mdx
+++ b/homepage/homepage/content/docs/project-setup/react-native-expo.mdx
@@ -40,7 +40,7 @@ npx expo prebuild
 <CodeGroup>
 ```bash
 # Expo dependencies
-npx expo install expo-linking expo-secure-store expo-file-system @react-native-community/netinfo @bam.tech/react-native-image-resizer
+npx expo install expo-linking expo-secure-store expo-sqlite expo-file-system @react-native-community/netinfo @bam.tech/react-native-image-resizer
 
 # React Native polyfills
 npm i -S @azure/core-asynciterator-polyfill react-native-url-polyfill readable-stream react-native-get-random-values

--- a/packages/jazz-tools/package.json
+++ b/packages/jazz-tools/package.json
@@ -161,6 +161,7 @@
     "prosemirror-schema-basic": "^1.2.2",
     "prosemirror-state": "^1.4.3",
     "prosemirror-transform": "^1.9.0",
+    "react-native-fast-encoder": "^0.2.0",
     "zod": "3.25.28"
   },
   "scripts": {
@@ -198,7 +199,6 @@
     "react": "*",
     "react-dom": "*",
     "react-native": "*",
-    "react-native-fast-encoder": "^0.2.0",
     "react-native-mmkv": "^3.2.0",
     "react-native-nitro-modules": "0.25.2",
     "react-native-quick-crypto": "1.0.0-beta.16",
@@ -230,9 +230,6 @@
       "optional": true
     },
     "react-native": {
-      "optional": true
-    },
-    "react-native-fast-encoder": {
       "optional": true
     },
     "react-native-mmkv": {

--- a/packages/jazz-tools/package.json
+++ b/packages/jazz-tools/package.json
@@ -161,7 +161,6 @@
     "prosemirror-schema-basic": "^1.2.2",
     "prosemirror-state": "^1.4.3",
     "prosemirror-transform": "^1.9.0",
-    "react-native-fast-encoder": "^0.2.0",
     "zod": "3.25.28"
   },
   "scripts": {
@@ -199,6 +198,7 @@
     "react": "*",
     "react-dom": "*",
     "react-native": "*",
+    "react-native-fast-encoder": "^0.2.0",
     "react-native-mmkv": "^3.2.0",
     "react-native-nitro-modules": "0.25.2",
     "react-native-quick-crypto": "1.0.0-beta.16",
@@ -230,6 +230,9 @@
       "optional": true
     },
     "react-native": {
+      "optional": true
+    },
+    "react-native-fast-encoder": {
       "optional": true
     },
     "react-native-mmkv": {

--- a/packages/jazz-tools/package.json
+++ b/packages/jazz-tools/package.json
@@ -142,7 +142,6 @@
   "version": "0.15.4",
   "dependencies": {
     "@manuscripts/prosemirror-recreate-steps": "^0.1.4",
-    "@op-engineering/op-sqlite": "^11.4.8",
     "@scure/base": "1.2.1",
     "@scure/bip39": "^1.3.0",
     "@tiptap/core": "^2.12.0",
@@ -152,7 +151,6 @@
     "cojson-storage": "workspace:*",
     "cojson-storage-indexeddb": "workspace:*",
     "cojson-transport-ws": "workspace:*",
-    "expo-sqlite": "15.2.9",
     "fast-myers-diff": "^3.2.0",
     "goober": "^2.1.16",
     "image-blob-reduce": "^4.1.0",
@@ -163,8 +161,6 @@
     "prosemirror-schema-basic": "^1.2.2",
     "prosemirror-state": "^1.4.3",
     "prosemirror-transform": "^1.9.0",
-    "react-native-fast-encoder": "^0.2.0",
-    "react-native-mmkv": "^3.2.0",
     "zod": "3.25.28"
   },
   "scripts": {
@@ -194,12 +190,16 @@
   },
   "peerDependencies": {
     "@bam.tech/react-native-image-resizer": "*",
+    "@op-engineering/op-sqlite": "^11.4.8",
     "@react-native-community/netinfo": "*",
     "expo-file-system": "*",
     "expo-secure-store": "*",
+    "expo-sqlite": "15.2.9",
     "react": "*",
     "react-dom": "*",
     "react-native": "*",
+    "react-native-fast-encoder": "^0.2.0",
+    "react-native-mmkv": "^3.2.0",
     "react-native-nitro-modules": "0.25.2",
     "react-native-quick-crypto": "1.0.0-beta.16",
     "svelte": "^5.0.0"
@@ -208,13 +208,19 @@
     "@bam.tech/react-native-image-resizer": {
       "optional": true
     },
-    "expo-file-system": {
+    "@op-engineering/op-sqlite": {
       "optional": true
     },
     "@react-native-community/netinfo": {
       "optional": true
     },
+    "expo-file-system": {
+      "optional": true
+    },
     "expo-secure-store": {
+      "optional": true
+    },
+    "expo-sqlite": {
       "optional": true
     },
     "react": {
@@ -224,6 +230,12 @@
       "optional": true
     },
     "react-native": {
+      "optional": true
+    },
+    "react-native-fast-encoder": {
+      "optional": true
+    },
+    "react-native-mmkv": {
       "optional": true
     },
     "react-native-nitro-modules": {


### PR DESCRIPTION
### What this Does

Follow-up to https://github.com/garden-co/jazz/pull/2595. Closes https://github.com/garden-co/jazz/issues/2576

Converts all React Native dependencies in `jazz-tools` into optional peer dependencies, since these dependencies are already required to be installed in the host project.

This PR also updates the project setup docs for Expo to include all required dependencies.

### Why Are We Doing This?

Some users have reported issues with React Native dependencies in non-RN projects. This also reduces the download size when installing `jazz-tools` noticeably, given that some of this RN dependencies are quite heavy (e.g. `op-sqlite` weights 100Mb).

### Testing Instructions

- [x] Confirmed the React Native and Expo Project setup docs include all required peer dependencies
- [x] Confirmed `chat-rn` and `chat-rn-expo` include the required peer dependencies
- [x] Manually tested that both the `chat-rn` and `chat-rn-expo` examples continue to work.

### Related Links
- GitHub issue: https://github.com/garden-co/jazz/issues/2576
