### PR TITLE
fix: react bundling in jazz-tools/inspector/register-custom-element

### DIFF
--- a/.changeset/long-schools-report.md
+++ b/.changeset/long-schools-report.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Fix react bundling in jazz-tools/inspector/register-custom-element

--- a/packages/jazz-tools/src/inspector/custom-element.tsx
+++ b/packages/jazz-tools/src/inspector/custom-element.tsx
@@ -1,6 +1,6 @@
 import { Account } from "jazz-tools";
-import { JazzInspectorInternal } from "jazz-tools/inspector";
 import { createRoot } from "react-dom/client";
+import { JazzInspectorInternal } from "./index.js";
 
 export class JazzInspectorElement extends HTMLElement {
   private root: ReturnType<typeof createRoot> | null = null;

--- a/packages/jazz-tools/tsup.config.ts
+++ b/packages/jazz-tools/tsup.config.ts
@@ -60,7 +60,7 @@ export default defineConfig([
       "register-custom-element": "src/inspector/register-custom-element.ts",
     },
     // This is a custom element meant to be used on non-react apps
-    noExternal: ["react", "react-dom"],
+    noExternal: ["react", "react-dom", "react-dom/client", "react/jsx-runtime"],
     outDir: "dist/inspector",
   },
   {


### PR DESCRIPTION
# Description

In Svelte the inspector was unable to run due to some bundling issues on React.

Changed the imports to ensure that react is correctly bundled inside the custom-element entry.

## Manual testing instructions

- Start the svelte-passkey-auth starter locally
- The inspector button should be visible

## Tests

- [ ] Tests have been added and/or updated
- [x] Tests have not been updated, because: e2e tests run on the prod build where the inspector isn't displayed
- [ ] I need help with writing tests


## Checklist

- [x] I've updated the part of the docs that are affected the PR changes
- [x] I've generated a changeset, if a version bump is required
- [x] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing