### PR TITLE
feat: wait for the full streaming before return values in load and subscribe

### DIFF
--- a/.changeset/new-geckos-decide.md
+++ b/.changeset/new-geckos-decide.md
@@ -1,0 +1,6 @@
+---
+"jazz-tools": patch
+"cojson": patch
+---
+
+Wait for the full streaming before return values in load and subscribe

--- a/packages/cojson/src/coValueCore/verifiedState.ts
+++ b/packages/cojson/src/coValueCore/verifiedState.ts
@@ -386,6 +386,13 @@ export class VerifiedState {
     return knownState;
   }
 
+  isStreaming(): boolean {
+    // Call knownStateWithStreaming to delete the streamingKnownState when it matches the current knownState
+    this.knownStateWithStreaming();
+
+    return this.streamingKnownState !== undefined;
+  }
+
   knownState(): CoValueKnownState {
     if (this._cachedKnownState) {
       return this._cachedKnownState;

--- a/packages/jazz-tools/src/tools/subscribe/SubscriptionScope.ts
+++ b/packages/jazz-tools/src/tools/subscribe/SubscriptionScope.ts
@@ -249,6 +249,10 @@ export class SubscriptionScope<D extends CoValue> {
     // If the value is in error, we send the update regardless of the children statuses
     if (this.value.type !== "loaded") return true;
 
+    if (this.isStreaming()) {
+      return false;
+    }
+
     for (const value of this.childValues.values()) {
       // We don't wait for autoloaded values to be loaded, in order to stream updates
       // on autoloaded lists or records
@@ -283,6 +287,14 @@ export class SubscriptionScope<D extends CoValue> {
     }
 
     return undefined;
+  }
+
+  isStreaming() {
+    if (this.value.type !== "loaded") {
+      return false;
+    }
+
+    return this.value.value._raw.core.verified.isStreaming();
   }
 
   triggerUpdate() {

--- a/packages/jazz-tools/src/tools/tests/subscribe.test.ts
+++ b/packages/jazz-tools/src/tools/tests/subscribe.test.ts
@@ -1198,6 +1198,98 @@ describe("subscribeToCoValue", () => {
     expect(onUnavailable).not.toHaveBeenCalled();
     expect(onUnauthorized).not.toHaveBeenCalled();
   });
+
+  it("should subscribe to a large coValue", async () => {
+    const syncServer = await setupJazzTestSync({ asyncPeers: true });
+
+    const LargeDataset = co.map({
+      metadata: z.object({
+        name: z.string(),
+        description: z.string(),
+        createdAt: z.number(),
+      }),
+      data: co.list(z.string()),
+    });
+
+    const group = Group.create(syncServer);
+    const largeMap = LargeDataset.create(
+      {
+        metadata: {
+          name: "Large Dataset",
+          description:
+            "A dataset with many entries for testing large coValue subscription",
+          createdAt: Date.now(),
+        },
+        data: LargeDataset.def.shape.data.create([], group),
+      },
+      group,
+    );
+    group.addMember("everyone", "reader");
+
+    const dataSize = 100 * 1024;
+    const chunkSize = 1024;
+    const chunks = dataSize / chunkSize;
+
+    const value = "x".repeat(chunkSize);
+
+    for (let i = 0; i < chunks; i++) {
+      largeMap.data.push(value);
+    }
+
+    // Wait for the large coValue to be fully synced
+    await largeMap.data._raw.core.waitForSync();
+
+    const alice = await createJazzTestAccount();
+
+    let result = null as Loaded<typeof LargeDataset, { data: true }> | null;
+    const updateFn = vi.fn().mockImplementation((value) => {
+      result = value;
+    });
+
+    // Test subscribing to the large coValue
+    const unsubscribe = subscribeToCoValue(
+      zodSchemaToCoSchema(LargeDataset),
+      largeMap.id,
+      {
+        loadAs: alice,
+        resolve: {
+          data: true,
+        },
+      },
+      updateFn,
+    );
+
+    onTestFinished(unsubscribe);
+
+    await waitFor(() => {
+      expect(updateFn).toHaveBeenCalled();
+    });
+
+    assert(result);
+
+    expect(updateFn).toHaveBeenCalledTimes(1);
+    expect(result.metadata.name).toBe("Large Dataset");
+    expect(result.metadata.description).toBe(
+      "A dataset with many entries for testing large coValue subscription",
+    );
+
+    expect(result.data.length).toBe(chunks);
+    expect(result.data._raw.core.knownState()).toEqual(
+      largeMap.data._raw.core.knownState(),
+    );
+
+    // Test that updates to the large coValue are properly subscribed
+    updateFn.mockClear();
+    largeMap.data.push("new entry");
+
+    await waitFor(() => {
+      expect(updateFn).toHaveBeenCalled();
+    });
+
+    expect(updateFn).toHaveBeenCalledTimes(1);
+    expect(result.data.length).toBe(chunks + 1);
+    expect(result.data[chunks]).toBe("new entry");
+  });
 });
 
 describe("createCoValueObservable", () => {

--- a/tests/stress-test/src/ProjectScreen.tsx
+++ b/tests/stress-test/src/ProjectScreen.tsx
@@ -7,12 +7,7 @@ export function ProjectScreen() {
   const { projectId } = useParams();
   const project = useCoState(TodoProject, projectId, {
     resolve: {
-      tasks: {
-        $each: {
-          $onError: null,
-          text: true,
-        },
-      },
+      tasks: true,
     },
   });
   const { me } = useAccount(TodoAccount, {
@@ -108,9 +103,9 @@ export function ProjectScreen() {
           marginBottom: "30px",
         }}
       >
-        {project.tasks.slice(0, visibleTasks).map((task) => (
+        {project.tasks.slice(0, visibleTasks).map((task, index) => (
           <label
-            key={task?.id}
+            key={task?.id ?? index}
             style={{
               display: "flex",
               alignItems: "center",


### PR DESCRIPTION
# Description

Wait for the coValue streaming to be fully completed before considering a value as loaded

Before:

https://github.com/user-attachments/assets/30b5a8c0-b32f-48c3-8a96-6ed1d1cc7c02

After:

https://github.com/user-attachments/assets/29271b2c-05d8-436e-ace5-3853f94e82dd

## Manual testing instructions

- cd `tests/stress-test`
- `pnpm dev`
- Generate 2k tasks
- Navigate to the project
- Reload the page

Before: The counter shows some steps before reaching 2k
After: The counter directly render 2k

## Tests

- [x] Tests have been added and/or updated
- [ ] Tests have not been updated, because: <!-- Insert reason for not updating tests here -->
- [ ] I need help with writing tests


## Checklist

- [x] I've updated the part of the docs that are affected the PR changes
- [x] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing