### PR TITLE
Closes GCO-621 - Add documentation for discriminated union workaround

### DIFF
--- a/.changeset/four-seas-mix.md
+++ b/.changeset/four-seas-mix.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Export the z.ZodDiscriminatedUnion type

--- a/homepage/homepage/content/docs/using-covalues/connecting-covalues.mdx
+++ b/homepage/homepage/content/docs/using-covalues/connecting-covalues.mdx
@@ -6,7 +6,7 @@ export const metadata = {
 
 # Connecting CoValues with direct linking
 CoValues can form relationships with each other by **linking directly to other CoValues**. This creates a powerful connection where one CoValue can point to the unique identity of another. 
-Instead of embedding all of the details of one coValue directly within another, you use its Jazz-Tools schema as the field type. This allows multiple CoValues to point to the same piece of data effortlessly.
+Instead of embedding all the details of one CoValue directly within another, you use its Jazz-Tools schema as the field type. This allows multiple CoValues to point to the same piece of data effortlessly.
 
 <CodeGroup>
 ```ts twoslash
@@ -51,18 +51,19 @@ This direct linking approach offers a single source of truth. When you update a 
 
 By connecting CoValues through these direct references, you can build robust and collaborative applications where data is consistent, efficient to manage, and relationships are clearly defined. The ability to link different CoValue types to the same underlying data is fundamental to building complex applications with Jazz.
 
-# Recursive Connections with Unions
-In advanced schemas, you may want a CoValue that can recursively reference itself. For example, a `NoteItem` that contains other notes or attachments inside it, forming a tree-like structure.
 
-Let’s say you’re building a `ProjectContextItem` where items can be of type `note`, `attachment`, or `reference`, and references can point to other `ProjectContextItems`.
+## Recursive Connections with Unions
+In advanced schemas, you may want a CoValue that recursively references itself. For example, a `ReferenceItem` that contains a list of other items like `NoteItem` or `AttachmentItem`. This is common in tree-like structures such as threaded comments or nested project outlines.
 
-When using Zod’s `z.discriminatedUnion`, this recursive pattern requires a small workaround due to how TypeScript handles inference.
+You can model this with a Zod `z.discriminatedUnion`, but TypeScript’s type inference doesn't handle recursive unions well without a workaround.
 
-### Use this pattern for recursive schemas
-<CodeGroup>
-```ts twoslash
-import { co, z } from "jazz-tools";
-  // First, define your item types
+Here’s how to structure your schema to avoid circular reference errors.
+
+### Use this pattern for recursive discriminated unions
+<CodeGroup> 
+```ts 
+// Recursive item modeling pattern using discriminated unions
+// First, define the non-recursive types
 export const NoteItem = co.map({
   type: z.literal("note"),
   internal: z.boolean(),
@@ -75,36 +76,43 @@ export const AttachmentItem = co.map({
   content: co.fileStream(),
 });
 
-// Declare the array of types before creating the discriminated union
-const projectContextItemTypes = [NoteItem, AttachmentItem]; // ReferenceItem will be added next
+// List the types in advance — ReferenceItem will be added after union creation
+const projectContextItemTypes = [NoteItem, AttachmentItem];
 
-// Create the union type
+// Create the union early (needed for circular refs to work)
 export const ProjectContextItem = z.discriminatedUnion("type", projectContextItemTypes);
 
-// Then define the recursive item and add it to the array
+// Now define the recursive type
 export const ReferenceItem = co.map({
   type: z.literal("reference"),
   internal: z.boolean(),
-  content: z.string(), // e.g., URL or external doc
-  get children(): CoListSchema<ZodDiscriminatedUnion<typeof projectContextItemTypes>> {
+  content: z.string(),
+
+  // Workaround: use ZodDiscriminatedUnion so TS can safely recurse
+  get children(): CoListSchema<ZodDiscriminatedUnion<"type", [typeof NoteItem, typeof AttachmentItem]>> {
     return ProjectContextItemList;
   },
 });
 
+// Add it to the list after the union is created
 projectContextItemTypes.push(ReferenceItem);
 
+// Final list of recursive types
 export const ProjectContextItemList = co.list(ProjectContextItem);
+```
 </CodeGroup>
+**Why it works:** By creating the union before adding recursion, TypeScript can resolve types without circular reference errors during inference.
+This workaround is purely for TypeScript’s benefit. The order has no effect at runtime.
 
-### Why not this?
+
+### Avoid defining recursive unions inline
 <CodeGroup>
-```ts twoslash
-import { co } from "jazz-tools";
-
-// This looks simpler, but will cause a circular reference error
+```ts 
+// This causes a circular reference error
 export const ReferenceItem = co.map({
-  children: co.list(ProjectContextItem), // ProjectContextItem not yet defined
+  children: co.list(ProjectContextItem), // X ProjectContextItem not yet defined
 });
+```
 </CodeGroup>
 
-Zod can’t resolve the circular reference this way. Always build recursive types using an intermediate list or ref.
+Even though this seems like a shortcut, TypeScript and Zod can't resolve the circular reference this way. Always define the discriminated union before introducing recursive links.

--- a/homepage/homepage/content/docs/using-covalues/connecting-covalues.mdx
+++ b/homepage/homepage/content/docs/using-covalues/connecting-covalues.mdx
@@ -52,7 +52,7 @@ This direct linking approach offers a single source of truth. When you update a 
 By connecting CoValues through these direct references, you can build robust and collaborative applications where data is consistent, efficient to manage, and relationships are clearly defined. The ability to link different CoValue types to the same underlying data is fundamental to building complex applications with Jazz.
 
 
-## Recursive Connections with Unions
+## Recursive references with DiscriminatedUnion
 In advanced schemas, you may want a CoValue that recursively references itself. For example, a `ReferenceItem` that contains a list of other items like `NoteItem` or `AttachmentItem`. This is common in tree-like structures such as threaded comments or nested project outlines.
 
 You can model this with a Zod `z.discriminatedUnion`, but TypeScript’s type inference doesn't handle recursive unions well without a workaround.
@@ -61,7 +61,9 @@ Here’s how to structure your schema to avoid circular reference errors.
 
 ### Use this pattern for recursive discriminated unions
 <CodeGroup> 
-```ts 
+```ts twoslash
+import { CoListSchema, co, z } from "jazz-tools";
+
 // Recursive item modeling pattern using discriminated unions
 // First, define the non-recursive types
 export const NoteItem = co.map({
@@ -76,42 +78,22 @@ export const AttachmentItem = co.map({
   content: co.fileStream(),
 });
 
-// List the types in advance — ReferenceItem will be added after union creation
-const projectContextItemTypes = [NoteItem, AttachmentItem];
-
-// Create the union early (needed for circular refs to work)
-export const ProjectContextItem = z.discriminatedUnion("type", projectContextItemTypes);
-
-// Now define the recursive type
 export const ReferenceItem = co.map({
   type: z.literal("reference"),
   internal: z.boolean(),
   content: z.string(),
 
-  // Workaround: use ZodDiscriminatedUnion so TS can safely recurse
-  get children(): CoListSchema<ZodDiscriminatedUnion<"type", [typeof NoteItem, typeof AttachmentItem]>> {
+  // Workaround: declare the field type using CoListSchema and ZodDiscriminatedUnion so TS can safely recurse
+  get children(): CoListSchema<z.ZodDiscriminatedUnion<[typeof NoteItem, typeof AttachmentItem, typeof ReferenceItem]>> {
     return ProjectContextItemList;
   },
 });
 
-// Add it to the list after the union is created
-projectContextItemTypes.push(ReferenceItem);
+// Create the recursive union
+export const ProjectContextItem = z.discriminatedUnion("type",  [NoteItem, AttachmentItem, ReferenceItem]);
 
 // Final list of recursive types
 export const ProjectContextItemList = co.list(ProjectContextItem);
-```
-</CodeGroup>
-**Why it works:** By creating the union before adding recursion, TypeScript can resolve types without circular reference errors during inference.
-This workaround is purely for TypeScript’s benefit. The order has no effect at runtime.
-
-
-### Avoid defining recursive unions inline
-<CodeGroup>
-```ts 
-// This causes a circular reference error
-export const ReferenceItem = co.map({
-  children: co.list(ProjectContextItem), // X ProjectContextItem not yet defined
-});
 ```
 </CodeGroup>
 

--- a/homepage/homepage/content/docs/using-covalues/connecting-covalues.mdx
+++ b/homepage/homepage/content/docs/using-covalues/connecting-covalues.mdx
@@ -50,3 +50,62 @@ export type User = co.loaded<typeof User>;
 This direct linking approach offers a single source of truth. When you update a referenced CoValue, all other CoValues that point to it are automatically updated, ensuring data consistency across your application.
 
 By connecting CoValues through these direct references, you can build robust and collaborative applications where data is consistent, efficient to manage, and relationships are clearly defined. The ability to link different CoValue types to the same underlying data is fundamental to building complex applications with Jazz.
+
+# Recursive Connections with Unions
+In advanced schemas, you may want a CoValue that can recursively reference itself. For example, a `NoteItem` that contains other notes or attachments inside it, forming a tree-like structure.
+
+Let’s say you’re building a `ProjectContextItem` where items can be of type `note`, `attachment`, or `reference`, and references can point to other `ProjectContextItems`.
+
+When using Zod’s `z.discriminatedUnion`, this recursive pattern requires a small workaround due to how TypeScript handles inference.
+
+### Use this pattern for recursive schemas
+<CodeGroup>
+```ts twoslash
+import { co, z } from "jazz-tools";
+  // First, define your item types
+export const NoteItem = co.map({
+  type: z.literal("note"),
+  internal: z.boolean(),
+  content: co.plainText(),
+});
+
+export const AttachmentItem = co.map({
+  type: z.literal("attachment"),
+  internal: z.boolean(),
+  content: co.fileStream(),
+});
+
+// Declare the array of types before creating the discriminated union
+const projectContextItemTypes = [NoteItem, AttachmentItem]; // ReferenceItem will be added next
+
+// Create the union type
+export const ProjectContextItem = z.discriminatedUnion("type", projectContextItemTypes);
+
+// Then define the recursive item and add it to the array
+export const ReferenceItem = co.map({
+  type: z.literal("reference"),
+  internal: z.boolean(),
+  content: z.string(), // e.g., URL or external doc
+  get children(): CoListSchema<ZodDiscriminatedUnion<typeof projectContextItemTypes>> {
+    return ProjectContextItemList;
+  },
+});
+
+projectContextItemTypes.push(ReferenceItem);
+
+export const ProjectContextItemList = co.list(ProjectContextItem);
+</CodeGroup>
+
+### Why not this?
+<CodeGroup>
+```ts twoslash
+import { co } from "jazz-tools";
+
+// This looks simpler, but will cause a circular reference error
+export const ReferenceItem = co.map({
+  children: co.list(ProjectContextItem), // ProjectContextItem not yet defined
+});
+</CodeGroup>
+
+Zod can’t resolve the circular reference this way. Always build recursive types using an intermediate list or ref.
+

--- a/homepage/homepage/content/docs/using-covalues/connecting-covalues.mdx
+++ b/homepage/homepage/content/docs/using-covalues/connecting-covalues.mdx
@@ -108,4 +108,3 @@ export const ReferenceItem = co.map({
 </CodeGroup>
 
 Zod can’t resolve the circular reference this way. Always build recursive types using an intermediate list or ref.
-

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/zodReExport.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/zodReExport.ts
@@ -39,5 +39,6 @@ export {
   type ZodDefault,
   type ZodCatch,
   type output as infer,
+  type ZodDiscriminatedUnion,
   z,
 } from "zod/v4";


### PR DESCRIPTION
# Description
Added documentation for workaround for discriminated union fix. 

**Please note: I did not use Twoslash in the examples due to limitations in how Twoslash parses advanced TypeScript types.
Specifically, Twoslash fails to handle `ZodDiscriminatedUnion` and throws internal errors (e.g., 2322, 2344) that break the MDX build. I attempted to specify expected errors, but Twoslash choked on the nested type structure, resulting in a 500 error during compilation.**

Rather than maintain a partially broken snippet, I’ve opted to show working TypeScript without Twoslash highlighting. This avoids misleading errors and keeps the documentation clear and buildable.

## Manual testing instructions

- Either run homepage locally (see Readme in Jazz/homepage/homepage for instructions) or use deployed vercel branch and navigate to `docs/react/using-covalues/connecting-covalues`,
- View new documentation and code snippets

## Tests

- [ ] Tests have been added and/or updated
- [x] Tests have not been updated, because: this is a new section of documentation (no unit tests necessary)
- [ ] I need help with writing tests


## Checklist

- [x] I've updated the part of the docs that are affected the PR changes
- [ ] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing