### PR TITLE
chore: auto-install lefthook using `postinstall` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "changeset-version": "changeset version && pnpm i --no-frozen-lockfile",
     "release": "turbo run build --filter='./packages/*' && pnpm changeset publish && git push --follow-tags",
     "clean": "rm -rf ./packages/*/dist && rm -rf ./packages/*/node_modules && rm -rf ./examples/*/node_modules && rm -rf ./examples/*/dist",
+    "postinstall": "lefthook install",
     "check-catalog-deps": "node scripts/check-catalog-deps.js"
   },
   "version": "0.0.0",


### PR DESCRIPTION
Install the `lefthook`'s git hooks after dependency installations