### PR TITLE
feat: Prevent resolving discriminated union fields

### DIFF
--- a/.changeset/spotty-otters-press.md
+++ b/.changeset/spotty-otters-press.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Prevent resolving discriminated union fields


### PR DESCRIPTION
# Description

https://discord.com/channels/1139617727565271160/1139621689882321009/1395835683268071616

Loading fields from discriminated unions is not currently supported, but our `resolve` APIs allowed doing so. This PR is a quick fix to prevent users from getting into an invalid state.

## Tests

- [x] Tests have been added and/or updated

## Checklist

- [x] I've updated the part of the docs that are affected the PR changes (no need)
- [x] I've generated a changeset, if a version bump is required
