### PR TITLE
Homepage/button link fix

### DIFF
--- a/homepage/homepage/components/home/GetStartedSnippetSelect.tsx
+++ b/homepage/homepage/components/home/GetStartedSnippetSelect.tsx
@@ -1,4 +1,4 @@
-'use client'
+"use client";
 
 import { Framework } from "@/content/framework";
 import { useFramework } from "@/lib/use-framework";
@@ -30,12 +30,19 @@ export function GetStartedSnippetSelect() {
       </div>
       <div className="col-span-2 lg:col-span-3 flex flex-row gap-2">
         <div className="h-full items-center w-[175px]">
-          <FrameworkSelect onSelect={setSelectedFramework} size="md" routerPush={false} className="h-full md:px-4" />
+          <FrameworkSelect
+            onSelect={setSelectedFramework}
+            size="md"
+            routerPush={false}
+            className="h-full md:px-4"
+          />
         </div>
         <div className="flex h-full items-center">
-          <Button intent="primary" size="lg" className="w-full">
-            <Link className="my-[0.11rem]" href={`/docs/${selectedFramework}`}>Get started</Link>
-          </Button>
+          <Link href={`/docs/${selectedFramework}`}>
+            <Button intent="primary" size="lg" className="w-full py-[0.11rem]">
+              Get started
+            </Button>
+          </Link>
         </div>
       </div>
     </GappedGrid>

--- a/homepage/homepage/tests/routes.spec.ts
+++ b/homepage/homepage/tests/routes.spec.ts
@@ -33,21 +33,34 @@ test.describe("Docs pages load", () => {
     expect(response?.ok()).toBeTruthy();
   });
 
-  [
-    "react",
-    "react-native",
-    "react-native-expo",
-    "svelte",
-    "vanilla",
-  ].forEach((framework) => {
-    test(`docs for ${framework} loads`, async ({ page }) => {
-      const response = await page.goto(`/docs/${framework}`);
-      expect(response?.ok()).toBeTruthy();
-    });
-  });
+  ["react", "react-native", "react-native-expo", "svelte", "vanilla"].forEach(
+    (framework) => {
+      test(`docs for ${framework} loads`, async ({ page }) => {
+        const response = await page.goto(`/docs/${framework}`);
+        expect(response?.ok()).toBeTruthy();
+      });
+    },
+  );
 
   test("/docs redirects to /docs/react", async ({ page }) => {
     await page.goto("/docs");
     await expect(page).toHaveURL(/\/docs\/react$/);
+  });
+});
+
+test.describe("Homepage", () => {
+  test(`'Get started' button is fully clickable`, async ({ page }) => {
+    await page.goto("/");
+
+    // Locate button text and click it
+    const text = page.locator('a >> button:has-text("Get started")');
+    await text.click();
+    await expect(page).toHaveURL(/\/docs\/\w+/);
+
+    // Go back and click the whole button area
+    await page.goBack();
+    const button = page.locator("a >> button");
+    await button.click();
+    await expect(page).toHaveURL(/\/docs\/\w+/);
   });
 });


### PR DESCRIPTION
# Description
Currently, the Button component wraps a Next Link. That means the Button's padding is applied around the link, so only the *text* in the button is clickable. This changes the order of the components so that the Button is fully wrapped by the Link, meaning the whole of the button is now clickable.

## Manual testing instructions

1. Build and load the homepage
2. Attempt to click the 'Get started' button on the text
    1. You should be navigated to the appropriate docs landing page
3. Attempt to click the 'Get started' button *outside* the text (between the text and the outer edge of the element).
    1. You should be navigated to the appropriate docs landing page

## Tests

- [x] Tests have been added and/or updated
- [ ] Tests have not been updated, because: 
- [ ] I need help with writing tests


## Checklist

- [ ] ~~I've updated the part of the docs that are affected the PR changes~~
- [ ] ~~I've generated a changeset, if a version bump is required~~
- [ ] ~~I've updated the jsDoc comments to the public APIs I've modified, or added them when missing~~