### PR TITLE
feat: support multiple instances of storage

### DIFF
--- a/.changeset/rotten-meals-compare.md
+++ b/.changeset/rotten-meals-compare.md
@@ -1,0 +1,6 @@
+---
+"cojson-storage-indexeddb": patch
+"cojson": patch
+---
+
+Add a multi-storage scheduler to avoid conflicting store operations when having multiple storage instances open on the same database

--- a/packages/cojson-storage-indexeddb/src/CoJsonIDBTransaction.ts
+++ b/packages/cojson-storage-indexeddb/src/CoJsonIDBTransaction.ts
@@ -138,3 +138,23 @@ export function queryIndexedDbStore<T>(
     };
   });
 }
+
+export function putIndexedDbStore<T, O extends IDBValidKey>(
+  db: IDBDatabase,
+  storeName: StoreName,
+  value: T,
+) {
+  return new Promise<O>((resolve, reject) => {
+    const tx = db.transaction(storeName, "readwrite");
+    const request = tx.objectStore(storeName).put(value);
+
+    request.onerror = () => {
+      reject(request.error);
+    };
+
+    request.onsuccess = () => {
+      resolve(request.result as O);
+      tx.commit();
+    };
+  });
+}

--- a/packages/cojson/src/storage/sqliteAsync/client.ts
+++ b/packages/cojson/src/storage/sqliteAsync/client.ts
@@ -112,14 +112,31 @@ export class SQLiteClientAsync implements DBClientInterfaceAsync {
     );
   }
 
-  async addCoValue(msg: NewContentMessage): Promise<number> {
+  async getCoValueRowID(id: RawCoID): Promise<number | undefined> {
+    const row = await this.db.get<{ rowID: number }>(
+      "SELECT rowID FROM coValues WHERE id = ?",
+      [id],
+    );
+    return row?.rowID;
+  }
+
+  async upsertCoValue(
+    id: RawCoID,
+    header?: CoValueHeader,
+  ): Promise<number | undefined> {
+    if (!header) {
+      return this.getCoValueRowID(id);
+    }
+
     const result = await this.db.get<{ rowID: number }>(
-      "INSERT INTO coValues (id, header) VALUES (?, ?) RETURNING rowID",
-      [msg.id, JSON.stringify(msg.header)],
+      `INSERT INTO coValues (id, header) VALUES (?, ?) 
+       ON CONFLICT(id) DO NOTHING 
+       RETURNING rowID`,
+      [id, JSON.stringify(header)],
     );
 
     if (!result) {
-      throw new Error("Failed to add coValue");
+      return this.getCoValueRowID(id);
     }
 
     return result.rowID;

--- a/packages/cojson/src/storage/storageAsync.ts
+++ b/packages/cojson/src/storage/storageAsync.ts
@@ -254,21 +254,17 @@ export class StorageApiAsync implements StorageAPI {
     }
 
     const id = msg.id;
-    const coValueRow = await this.dbClient.getCoValue(id);
+    const storedCoValueRowID = await this.dbClient.upsertCoValue(
+      id,
+      msg.header,
+    );
 
-    // We have no info about coValue header
-    const invalidAssumptionOnHeaderPresence = !msg.header && !coValueRow;
-
-    if (invalidAssumptionOnHeaderPresence) {
+    if (!storedCoValueRowID) {
       const knownState = emptyKnownState(id as RawCoID);
       this.knwonStates.setKnownState(id, knownState);
 
       return this.handleCorrection(knownState, correctionCallback);
     }
-
-    const storedCoValueRowID: number = coValueRow
-      ? coValueRow.rowID
-      : await this.dbClient.addCoValue(msg);
 
     const knownState = this.knwonStates.getKnownState(id);
     knownState.header = true;

--- a/packages/cojson/src/storage/storageSync.ts
+++ b/packages/cojson/src/storage/storageSync.ts
@@ -235,21 +235,14 @@ export class StorageApiSync implements StorageAPI {
     correctionCallback: CorrectionCallback,
   ): boolean {
     const id = msg.id;
-    const coValueRow = this.dbClient.getCoValue(id);
+    const storedCoValueRowID = this.dbClient.upsertCoValue(id, msg.header);
 
-    // We have no info about coValue header
-    const invalidAssumptionOnHeaderPresence = !msg.header && !coValueRow;
-
-    if (invalidAssumptionOnHeaderPresence) {
+    if (!storedCoValueRowID) {
       const knownState = emptyKnownState(id as RawCoID);
       this.knwonStates.setKnownState(id, knownState);
 
       return this.handleCorrection(knownState, correctionCallback);
     }
-
-    const storedCoValueRowID: number = coValueRow
-      ? coValueRow.rowID
-      : this.dbClient.addCoValue(msg);
 
     const knownState = this.knwonStates.getKnownState(id);
     knownState.header = true;

--- a/packages/cojson/src/storage/types.ts
+++ b/packages/cojson/src/storage/types.ts
@@ -65,6 +65,11 @@ export interface DBClientInterfaceAsync {
     coValueId: string,
   ): Promise<StoredCoValueRow | undefined> | undefined;
 
+  upsertCoValue(
+    id: string,
+    header?: CoValueHeader,
+  ): Promise<number | undefined>;
+
   getCoValueSessions(coValueRowId: number): Promise<StoredSessionRow[]>;
 
   getSingleCoValueSession(
@@ -82,8 +87,6 @@ export interface DBClientInterfaceAsync {
     sessionRowId: number,
     firstNewTxIdx: number,
   ): Promise<SignatureAfterRow[]>;
-
-  addCoValue(msg: NewContentMessage): Promise<number>;
 
   addSessionUpdate({
     sessionUpdate,
@@ -115,6 +118,8 @@ export interface DBClientInterfaceAsync {
 export interface DBClientInterfaceSync {
   getCoValue(coValueId: string): StoredCoValueRow | undefined;
 
+  upsertCoValue(id: string, header?: CoValueHeader): number | undefined;
+
   getCoValueSessions(coValueRowId: number): StoredSessionRow[];
 
   getSingleCoValueSession(
@@ -132,8 +137,6 @@ export interface DBClientInterfaceSync {
     sessionRowId: number,
     firstNewTxIdx: number,
   ): Pick<SignatureAfterRow, "idx" | "signature">[];
-
-  addCoValue(msg: NewContentMessage): number;
 
   addSessionUpdate({
     sessionUpdate,

--- a/packages/cojson/src/tests/sync.storageAsync.test.ts
+++ b/packages/cojson/src/tests/sync.storageAsync.test.ts
@@ -8,6 +8,7 @@ import {
   setupTestNode,
   waitFor,
 } from "./testUtils";
+import { getDbPath } from "./testStorage";
 
 // We want to simulate a real world communication that happens asynchronously
 TEST_NODE_CONFIG.withAsyncPeers = true;
@@ -507,5 +508,38 @@ describe("client syncs with a server with storage", () => {
         "server -> client | KNOWN Map sessions: header/200",
       ]
     `);
+  });
+
+  test("two storage instances open on the same file should not conflict with each other", async () => {
+    const client = setupTestNode();
+
+    client.connectToSyncServer({
+      syncServer: jazzCloud.node,
+    });
+    const dbPath = getDbPath();
+    await client.addAsyncStorage({
+      ourName: "client",
+      filename: dbPath,
+    });
+
+    const client2 = setupTestNode();
+    client2.connectToSyncServer({
+      syncServer: jazzCloud.node,
+    });
+    await client2.addAsyncStorage({
+      ourName: "client2",
+      filename: dbPath,
+    });
+
+    for (let i = 0; i < 10; i++) {
+      for (const node of [client.node, client2.node]) {
+        const group = node.createGroup();
+        const map = group.createMap();
+        map.set("hello", "world", "trusting");
+      }
+    }
+
+    await client.node.syncManager.waitForAllCoValuesSync();
+    await client2.node.syncManager.waitForAllCoValuesSync();
   });
 });

--- a/packages/cojson/src/tests/testStorage.ts
+++ b/packages/cojson/src/tests/testStorage.ts
@@ -123,7 +123,7 @@ export function createSyncStorage({
   return storage;
 }
 
-function getDbPath(defaultDbPath?: string) {
+export function getDbPath(defaultDbPath?: string) {
   const dbPath = defaultDbPath ?? join(tmpdir(), `test-${randomUUID()}.db`);
 
   if (!defaultDbPath) {

--- a/packages/cojson/src/tests/testUtils.ts
+++ b/packages/cojson/src/tests/testUtils.ts
@@ -530,10 +530,11 @@ export function setupTestNode(
     return { storage };
   }
 
-  async function addAsyncStorage(opts: { ourName?: string } = {}) {
+  async function addAsyncStorage(opts: { ourName?: string; filename?: string } = {}) {
     const storage = await createAsyncStorage({
       nodeName: opts.ourName ?? "client",
-      storageName: "storage",
+      storageName: "storage", 
+      filename: opts.filename,
     });
     node.setStorage(storage);
 


### PR DESCRIPTION
# Description

Changes the StoreQueue to ensure that only one store queue is processed at any given time, fixing the "Database is locked" issue when having two Sqlite instances open.

Also changes the `addCoValue` queries to try to INSERT the CoValue before falling back to reading.
This way we cover the cases when two storage instances try to insert the same CoValue concurrently after getting a miss on read.

On IndexedDB, we don't need locks because the readwrite transactions are ensured to be executed one at time.
The only feature it lacks is the transaction isolation, but if one tab tries to load from a session in the middle of an update things do not break.

## Tests

- [x] Tests have been added and/or updated
- [ ] Tests have not been updated, because: <!-- Insert reason for not updating tests here -->
- [ ] I need help with writing tests


## Checklist

- [x] I've updated the part of the docs that are affected the PR changes
- [x] I've generated a changeset, if a version bump is required
- [x] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing