### PR TITLE
Fixes in image management for React Native 

### DIFF
--- a/.changeset/cold-cooks-look.md
+++ b/.changeset/cold-cooks-look.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+fix unused blob creation on react Image component

--- a/.changeset/unlucky-nails-wait.md
+++ b/.changeset/unlucky-nails-wait.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+React Native resizer is now imported dynamically, as it is an optional dependency

--- a/packages/jazz-tools/src/media/index.native.ts
+++ b/packages/jazz-tools/src/media/index.native.ts
@@ -1,5 +1,5 @@
-import ImageResizer from "@bam.tech/react-native-image-resizer";
-import type { Account, Group, ImageDefinition } from "jazz-tools";
+import type ImageResizerType from "@bam.tech/react-native-image-resizer";
+import type { Account, Group } from "jazz-tools";
 import { FileStream } from "jazz-tools";
 import { Image } from "react-native";
 import {
@@ -11,10 +11,23 @@ import {
 export { highestResAvailable, loadImage, loadImageBySize } from "./utils.js";
 export { createImageFactory };
 
+let ImageResizer: typeof ImageResizerType | undefined;
+
 export async function createImage(
   imageBlobOrFile: Blob | File | string,
   options?: CreateImageOptions,
 ) {
+  if (!ImageResizer) {
+    try {
+      ImageResizer = (await import("@bam.tech/react-native-image-resizer"))
+        .default;
+    } catch (e) {
+      throw new Error(
+        "ImageResizer is not installed, please run `npm install @bam.tech/react-native-image-resizer`",
+      );
+    }
+  }
+
   return createImageFactory({
     getImageSize,
     getPlaceholderBase64,
@@ -44,7 +57,7 @@ async function getPlaceholderBase64(filePath: SourceType): Promise<string> {
     );
   }
 
-  if (typeof ImageResizer === "undefined" || ImageResizer === null) {
+  if (!ImageResizer) {
     throw new Error(
       "ImageResizer is not installed, please run `npm install @bam.tech/react-native-image-resizer`",
     );
@@ -72,7 +85,7 @@ async function resize(
     );
   }
 
-  if (typeof ImageResizer === "undefined" || ImageResizer === null) {
+  if (!ImageResizer) {
     throw new Error(
       "ImageResizer is not installed, please run `npm install @bam.tech/react-native-image-resizer`",
     );

--- a/packages/jazz-tools/src/react/media/image.tsx
+++ b/packages/jazz-tools/src/react/media/image.tsx
@@ -92,7 +92,7 @@ export const Image = forwardRef<HTMLImageElement, ImageProps>(function Image(
   );
   const lazyPlaceholder = useMemo(
     () =>
-      waitingLazyLoading ? URL.createObjectURL(emptyPixelBlob) : undefined,
+      waitingLazyLoading ? URL.createObjectURL(getEmptyPixelBlob()) : undefined,
     [waitingLazyLoading],
   );
 
@@ -197,14 +197,20 @@ function revokeObjectURL(url: string | undefined) {
   }
 }
 
-const emptyPixelBlob = new Blob(
-  [
-    Uint8Array.from(
-      atob(
-        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==",
-      ),
-      (c) => c.charCodeAt(0),
-    ),
-  ],
-  { type: "image/png" },
-);
+let emptyPixelBlob: Blob | undefined;
+function getEmptyPixelBlob() {
+  if (!emptyPixelBlob) {
+    emptyPixelBlob = new Blob(
+      [
+        Uint8Array.from(
+          atob(
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==",
+          ),
+          (c) => c.charCodeAt(0),
+        ),
+      ],
+      { type: "image/png" },
+    );
+  }
+  return emptyPixelBlob;
+}


### PR DESCRIPTION
# Description
1. The `emptyPixelBlob` was initialized by importing `jazz-tools/react`, even if the Image component was not used. Now it is generated once when needed
2. The `@bam.tech/react-native-image-resizer` was always imported by importing `jazz-tools/react-native`. Moved into a dynamic import, as it is an optional dependency.

## Manual testing instructions
Install this branch version into a React Native project, import `jazz-tools/react`, and nothing should throw an error.

## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [x] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing