### PR TITLE
feat: add `CoList.$jazz.remove` and `CoList.$jazz.retain`

### DIFF
--- a/packages/jazz-tools/src/tools/coValues/coList.ts
+++ b/packages/jazz-tools/src/tools/coValues/coList.ts
@@ -614,15 +614,9 @@ export class CoListJazzApi<L extends CoList>
         if (predicate(this.coList[i], i, this.coList)) indices.push(i);
       }
     } else {
-      indices = args as number[];
-      const outOfBoundIndices = indices.filter(
-        (index) => index < 0 || index >= this.coList.length,
-      );
-      if (outOfBoundIndices.length > 0) {
-        throw new Error(
-          `Indices [${outOfBoundIndices}] out of bounds for length ${this.coList.length}`,
-        );
-      }
+      indices = (args as number[])
+        .filter((index) => index >= 0 && index < this.coList.length)
+        .sort();
     }
     const deletedItems = indices.map((index) => this.coList[index]);
     for (const index of indices.reverse()) {

--- a/packages/jazz-tools/src/tools/coValues/coList.ts
+++ b/packages/jazz-tools/src/tools/coValues/coList.ts
@@ -584,6 +584,54 @@ export class CoListJazzApi<L extends CoList>
   }
 
   /**
+   * Removes the elements at the specified indices from the array.
+   * @param indices The indices of the elements to remove.
+   * @returns The removed elements.
+   *
+   * @category Content
+   */
+  remove(...indices: number[]): CoListItem<L>[];
+  /**
+   * Removes the elements matching the predicate from the array.
+   * @param predicate The predicate to match the elements to remove.
+   * @returns The removed elements.
+   *
+   * @category Content
+   */
+  remove(
+    predicate: (item: CoListItem<L>, index: number, coList: L) => boolean,
+  ): CoListItem<L>[];
+  remove(
+    ...args: (
+      | number
+      | ((item: CoListItem<L>, index: number, coList: L) => boolean)
+    )[]
+  ): CoListItem<L>[] {
+    const predicate = args[0] instanceof Function ? args[0] : undefined;
+    let indices: number[] = [];
+    if (predicate) {
+      for (let i = 0; i < this.coList.length; i++) {
+        if (predicate(this.coList[i], i, this.coList)) indices.push(i);
+      }
+    } else {
+      indices = args as number[];
+      const outOfBoundIndices = indices.filter(
+        (index) => index < 0 || index >= this.coList.length,
+      );
+      if (outOfBoundIndices.length > 0) {
+        throw new Error(
+          `Indices [${outOfBoundIndices}] out of bounds for length ${this.coList.length}`,
+        );
+      }
+    }
+    const deletedItems = indices.map((index) => this.coList[index]);
+    for (const index of indices.reverse()) {
+      this.raw.delete(index);
+    }
+    return deletedItems;
+  }
+
+  /**
    * Modify the `CoList` to match another list, where the changes are managed internally.
    *
    * Changes are detected using `Object.is` for non-collaborative values and `$jazz.id` for collaborative values.

--- a/packages/jazz-tools/src/tools/coValues/coList.ts
+++ b/packages/jazz-tools/src/tools/coValues/coList.ts
@@ -632,6 +632,19 @@ export class CoListJazzApi<L extends CoList>
   }
 
   /**
+   * Retains only the elements matching the predicate from the array.
+   * @param predicate The predicate to match the elements to retain.
+   * @returns The removed elements.
+   *
+   * @category Content
+   */
+  retain(
+    predicate: (item: CoListItem<L>, index: number, coList: L) => boolean,
+  ): CoListItem<L>[] {
+    return this.remove((...args) => !predicate(...args));
+  }
+
+  /**
    * Modify the `CoList` to match another list, where the changes are managed internally.
    *
    * Changes are detected using `Object.is` for non-collaborative values and `$jazz.id` for collaborative values.

--- a/packages/jazz-tools/src/tools/coValues/coList.ts
+++ b/packages/jazz-tools/src/tools/coValues/coList.ts
@@ -616,7 +616,7 @@ export class CoListJazzApi<L extends CoList>
     } else {
       indices = (args as number[])
         .filter((index) => index >= 0 && index < this.coList.length)
-        .sort();
+        .sort((a, b) => a - b);
     }
     const deletedItems = indices.map((index) => this.coList[index]);
     for (const index of indices.reverse()) {

--- a/packages/jazz-tools/src/tools/tests/coList.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coList.test.ts
@@ -363,6 +363,67 @@ describe("Simple CoList operations", async () => {
       });
     });
 
+    describe("remove", () => {
+      describe("remove by index", () => {
+        test("remove one item", () => {
+          const list = TestList.create(["bread", "butter", "onion"]);
+
+          expect(list.$jazz.remove(1)).toEqual(["butter"]);
+          expect(list.$jazz.raw.asArray()).toEqual(["bread", "onion"]);
+        });
+
+        test("remove multiple items", () => {
+          const list = TestList.create(["bread", "butter", "onion"]);
+
+          expect(list.$jazz.remove(0, 2)).toEqual(["bread", "onion"]);
+          expect(list.$jazz.raw.asArray()).toEqual(["butter"]);
+        });
+
+        test("throws an error if any of the indices are out of bounds", () => {
+          const list = TestList.create(["bread", "butter", "onion"]);
+
+          expect(() => list.$jazz.remove(3)).toThrow(
+            "Indices [3] out of bounds for length 3",
+          );
+        });
+
+        test("does not mutate the CoList if any of the indices are out of bounds", () => {
+          const list = TestList.create(["bread", "butter", "onion"]);
+
+          expect(() => list.$jazz.remove(4, 3, 2, 1, 0)).toThrow(
+            "Indices [4,3] out of bounds for length 3",
+          );
+          expect(list.$jazz.raw.asArray()).toEqual([
+            "bread",
+            "butter",
+            "onion",
+          ]);
+        });
+      });
+
+      describe("remove by predicate", () => {
+        test("removes elements matching the predicate", () => {
+          const list = TestList.create(["bread", "butter", "onion"]);
+
+          expect(list.$jazz.remove((item) => item === "butter")).toEqual([
+            "butter",
+          ]);
+          expect(list.$jazz.raw.asArray()).toEqual(["bread", "onion"]);
+        });
+
+        test("the predicate is called with the item, index and the coList", () => {
+          const list = TestList.create(["bread", "butter", "onion"]);
+
+          expect(
+            list.$jazz.remove(
+              (item, index, coList) => index > 0 && index < coList.length - 1,
+            ),
+          ).toEqual(["butter"]);
+          expect(list.$jazz.raw.asArray()).toEqual(["bread", "onion"]);
+        });
+      });
+    });
+
     test("filter + assign to coMap", () => {
       const TestMap = co.map({
         list: TestList,

--- a/packages/jazz-tools/src/tools/tests/coList.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coList.test.ts
@@ -424,6 +424,29 @@ describe("Simple CoList operations", async () => {
       });
     });
 
+    describe("retain", () => {
+      test("retains elements matching the predicate", () => {
+        const list = TestList.create(["bread", "butter", "onion"]);
+
+        expect(list.$jazz.retain((item) => item === "butter")).toEqual([
+          "bread",
+          "onion",
+        ]);
+        expect(list.$jazz.raw.asArray()).toEqual(["butter"]);
+      });
+
+      test("the predicate is called with the item, index and the coList", () => {
+        const list = TestList.create(["bread", "butter", "onion"]);
+
+        expect(
+          list.$jazz.retain(
+            (item, index, coList) => index > 0 && index < coList.length - 1,
+          ),
+        ).toEqual(["bread", "onion"]);
+        expect(list.$jazz.raw.asArray()).toEqual(["butter"]);
+      });
+    });
+
     test("filter + assign to coMap", () => {
       const TestMap = co.map({
         list: TestList,

--- a/packages/jazz-tools/src/tools/tests/coList.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coList.test.ts
@@ -379,25 +379,11 @@ describe("Simple CoList operations", async () => {
           expect(list.$jazz.raw.asArray()).toEqual(["butter"]);
         });
 
-        test("throws an error if any of the indices are out of bounds", () => {
+        test("ignores out-of-bound indices", () => {
           const list = TestList.create(["bread", "butter", "onion"]);
 
-          expect(() => list.$jazz.remove(3)).toThrow(
-            "Indices [3] out of bounds for length 3",
-          );
-        });
-
-        test("does not mutate the CoList if any of the indices are out of bounds", () => {
-          const list = TestList.create(["bread", "butter", "onion"]);
-
-          expect(() => list.$jazz.remove(4, 3, 2, 1, 0)).toThrow(
-            "Indices [4,3] out of bounds for length 3",
-          );
-          expect(list.$jazz.raw.asArray()).toEqual([
-            "bread",
-            "butter",
-            "onion",
-          ]);
+          expect(list.$jazz.remove(4, -1, 1)).toEqual(["butter"]);
+          expect(list.$jazz.raw.asArray()).toEqual(["bread", "onion"]);
         });
       });
 


### PR DESCRIPTION
# Description

A lot of people aren’t very familiar/good with `splice`, so we're adding this two alternative methods that are easier to use.

## Tests

- [x] Tests have been added and/or updated

## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [ ] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing