### PR TITLE
Add host option to the jazz-run sync command

### DIFF
--- a/.changeset/tiny-panthers-check.md
+++ b/.changeset/tiny-panthers-check.md
@@ -1,0 +1,5 @@
+---
+"jazz-run": patch
+---
+
+Add host option to the jazz-run sync command

--- a/homepage/homepage/content/docs/sync-and-storage.mdx
+++ b/homepage/homepage/content/docs/sync-and-storage.mdx
@@ -46,6 +46,7 @@ In this case, provide the WebSocket endpoint your proxy exposes as the sync serv
 
 ### Command line options:
 
+- `--host` / `-h` - the host to run the sync server on. Defaults to 127.0.0.1.
 - `--port` / `-p` - the port to run the sync server on. Defaults to 4200.
 - `--in-memory` - keep CoValues in-memory only and do sync only, no persistence. Persistence is enabled by default.
 - `--db` - the path to the file where to store the data (SQLite). Defaults to `sync-db/storage.db`.

--- a/packages/jazz-run/src/config.ts
+++ b/packages/jazz-run/src/config.ts
@@ -1,0 +1,6 @@
+export const serverDefaults = {
+  host: "127.0.0.1",
+  port: 4200,
+  inMemory: false,
+  db: "sync-db/storage.db",
+};

--- a/packages/jazz-run/src/index.ts
+++ b/packages/jazz-run/src/index.ts
@@ -39,6 +39,11 @@ const accountCommand = Command.make("account").pipe(
   Command.withSubcommands([createAccountCommand]),
 );
 
+const hostOption = Options.text("host")
+  .pipe(Options.withAlias("h"))
+  .pipe(Options.withDescription("The host to listen on. Default is 127.0.0.1"))
+  .pipe(Options.withDefault("127.0.0.1"));
+
 const portOption = Options.text("port")
   .pipe(Options.withAlias("p"))
   .pipe(
@@ -62,13 +67,20 @@ const dbOption = Options.file("db")
 
 const startSyncServerCommand = Command.make(
   "sync",
-  { port: portOption, inMemory: inMemoryOption, db: dbOption },
-  ({ port, inMemory, db }) => {
+  {
+    host: hostOption,
+    port: portOption,
+    inMemory: inMemoryOption,
+    db: dbOption,
+  },
+  ({ host, port, inMemory, db }) => {
     return Effect.gen(function* () {
-      yield* Effect.promise(() => startSyncServer({ port, inMemory, db }));
+      yield* Effect.promise(() =>
+        startSyncServer({ host, port, inMemory, db }),
+      );
 
       yield* Console.log(
-        `COJSON sync server listening on ws://127.0.0.1:${port}`,
+        `COJSON sync server listening on ws://${host}:${port}`,
       );
 
       // Keep the server up

--- a/packages/jazz-run/src/index.ts
+++ b/packages/jazz-run/src/index.ts
@@ -5,6 +5,7 @@ import { NodeContext, NodeRuntime } from "@effect/platform-node";
 import { Console, Effect } from "effect";
 import { createWorkerAccount } from "./createWorkerAccount.js";
 import { startSyncServer } from "./startSyncServer.js";
+import { serverDefaults } from "./config.js";
 
 const jazzTools = Command.make("jazz-tools");
 
@@ -41,29 +42,33 @@ const accountCommand = Command.make("account").pipe(
 
 const hostOption = Options.text("host")
   .pipe(Options.withAlias("h"))
-  .pipe(Options.withDescription("The host to listen on. Default is 127.0.0.1"))
-  .pipe(Options.withDefault("127.0.0.1"));
+  .pipe(
+    Options.withDescription(
+      `The host to listen on. Default is ${serverDefaults.host}`,
+    ),
+  )
+  .pipe(Options.withDefault(serverDefaults.host));
 
 const portOption = Options.text("port")
   .pipe(Options.withAlias("p"))
   .pipe(
     Options.withDescription(
-      "Select a different port for the WebSocket server. Default is 4200",
+      `Select a different port for the WebSocket server. Default is ${serverDefaults.port}`,
     ),
   )
-  .pipe(Options.withDefault("4200"));
+  .pipe(Options.withDefault(serverDefaults.port.toString()));
 
 const inMemoryOption = Options.boolean("in-memory").pipe(
-  Options.withDescription("Use an in-memory storage instead of file-based"),
+  Options.withDescription("Use an in-memory storage instead of file-based."),
 );
 
 const dbOption = Options.file("db")
   .pipe(
     Options.withDescription(
-      "The path to the file where to store the data. Default is 'sync-db/storage.db'",
+      `The path to the file where to store the data. Default is '${serverDefaults.db}'`,
     ),
   )
-  .pipe(Options.withDefault("sync-db/storage.db"));
+  .pipe(Options.withDefault(serverDefaults.db));
 
 const startSyncServerCommand = Command.make(
   "sync",
@@ -75,12 +80,23 @@ const startSyncServerCommand = Command.make(
   },
   ({ host, port, inMemory, db }) => {
     return Effect.gen(function* () {
-      yield* Effect.promise(() =>
+      const server = yield* Effect.promise(() =>
         startSyncServer({ host, port, inMemory, db }),
       );
 
+      const serverAddress = server.address();
+
+      if (!serverAddress) {
+        return yield* Effect.fail(new Error("Failed to start sync server."));
+      }
+
+      const socketAddress =
+        typeof serverAddress === "object"
+          ? `${serverAddress.address}:${serverAddress.port}`
+          : serverAddress;
+
       yield* Console.log(
-        `COJSON sync server listening on ws://${host}:${port}`,
+        `COJSON sync server listening on ws://${socketAddress}`,
       );
 
       // Keep the server up

--- a/packages/jazz-run/src/startSyncServer.ts
+++ b/packages/jazz-run/src/startSyncServer.ts
@@ -8,10 +8,12 @@ import { WasmCrypto } from "cojson/crypto/WasmCrypto";
 import { WebSocketServer } from "ws";
 
 export const startSyncServer = async ({
+  host,
   port,
   inMemory,
   db,
 }: {
+  host: string | undefined;
   port: string | undefined;
   inMemory: boolean;
   db: string;
@@ -94,7 +96,7 @@ export const startSyncServer = async ({
     localNode.gracefulShutdown();
   });
 
-  server.listen(port ? parseInt(port) : undefined);
+  server.listen(port ? parseInt(port) : undefined, host);
 
   const _close = server.close;
 

--- a/packages/jazz-run/src/startSyncServer.ts
+++ b/packages/jazz-run/src/startSyncServer.ts
@@ -1,4 +1,4 @@
-import { createServer, type Server } from "node:http";
+import { createServer } from "node:http";
 import { mkdir } from "node:fs/promises";
 import { dirname } from "node:path";
 import { LocalNode } from "cojson";
@@ -6,6 +6,7 @@ import { getBetterSqliteStorage } from "cojson-storage-sqlite";
 import { createWebSocketPeer } from "cojson-transport-ws";
 import { WasmCrypto } from "cojson/crypto/WasmCrypto";
 import { WebSocketServer } from "ws";
+import { type SyncServer } from "./types.js";
 
 export const startSyncServer = async ({
   host,
@@ -17,7 +18,7 @@ export const startSyncServer = async ({
   port: string | undefined;
   inMemory: boolean;
   db: string;
-}) => {
+}): Promise<SyncServer> => {
   const crypto = await WasmCrypto.create();
 
   const server = createServer((req, res) => {
@@ -96,8 +97,6 @@ export const startSyncServer = async ({
     localNode.gracefulShutdown();
   });
 
-  server.listen(port ? parseInt(port) : undefined, host);
-
   const _close = server.close;
 
   server.close = () => {
@@ -108,5 +107,11 @@ export const startSyncServer = async ({
 
   Object.defineProperty(server, "localNode", { value: localNode });
 
-  return server as Server & { localNode: LocalNode };
+  server.listen(port ? parseInt(port) : undefined, host);
+
+  return new Promise((resolve) => {
+    server.once("listening", () => {
+      resolve(server as SyncServer);
+    });
+  });
 };

--- a/packages/jazz-run/src/tests/createWorkerAccount.test.ts
+++ b/packages/jazz-run/src/tests/createWorkerAccount.test.ts
@@ -5,11 +5,13 @@ import { describe, expect, it, onTestFinished } from "vitest";
 import { WebSocket } from "ws";
 import { createWorkerAccount } from "../createWorkerAccount.js";
 import { startSyncServer } from "../startSyncServer.js";
+import { serverDefaults } from "../config.js";
 
 describe("createWorkerAccount - integration tests", () => {
   it("should create a worker account using the local sync server", async () => {
     // Pass port: undefined to let the server choose a random port
     const server = await startSyncServer({
+      host: serverDefaults.host,
       port: undefined,
       inMemory: true,
       db: "",

--- a/packages/jazz-run/src/tests/startSyncServer.test.ts
+++ b/packages/jazz-run/src/tests/startSyncServer.test.ts
@@ -1,24 +1,29 @@
 import { randomUUID } from "crypto";
 import { tmpdir } from "os";
 import { join } from "path";
-import { LocalNode } from "cojson";
 import { co, z } from "jazz-tools";
 import { startWorker } from "jazz-tools/worker";
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, afterAll } from "vitest";
 import { createWorkerAccount } from "../createWorkerAccount.js";
 import { startSyncServer } from "../startSyncServer.js";
+import { serverDefaults } from "../config.js";
+import { unlinkSync } from "node:fs";
 
 const TestMap = co.map({
   value: z.string(),
 });
 
+const dbPath = join(tmpdir(), `test-${randomUUID()}.db`);
+
+afterAll(() => {
+  unlinkSync(dbPath);
+});
+
 describe("startSyncServer", () => {
   test("persists values in storage and loads them after restart", async () => {
-    // Create a temporary database file
-    const dbPath = join(tmpdir(), `test-${randomUUID()}.db`);
-
     // Start first server instance
     const server1 = await startSyncServer({
+      host: serverDefaults.host,
       port: "0", // Random available port
       inMemory: false,
       db: dbPath,
@@ -48,6 +53,7 @@ describe("startSyncServer", () => {
 
     // Start second server instance with same DB
     const server2 = await startSyncServer({
+      host: serverDefaults.host,
       port: "0",
       inMemory: false,
       db: dbPath,
@@ -73,5 +79,22 @@ describe("startSyncServer", () => {
     // Cleanup
     await worker2.done();
     server2.close();
+  });
+
+  test("starts a sync server with a specific host and port", async () => {
+    const server = await startSyncServer({
+      host: "0.0.0.0",
+      port: "4900",
+      inMemory: false,
+      db: dbPath,
+    });
+
+    expect(server.address()).toEqual({
+      address: "0.0.0.0",
+      port: 4900,
+      family: "IPv4",
+    });
+
+    server.close();
   });
 });

--- a/packages/jazz-run/src/tests/startWorker.test.ts
+++ b/packages/jazz-run/src/tests/startWorker.test.ts
@@ -18,6 +18,7 @@ import { afterAll, describe, expect, onTestFinished, test } from "vitest";
 import { createWorkerAccount } from "../createWorkerAccount.js";
 import { startSyncServer } from "../startSyncServer.js";
 import { waitFor } from "./utils.js";
+import { serverDefaults } from "../config.js";
 
 const dbPath = join(tmpdir(), `test-${randomUUID()}.db`);
 
@@ -30,9 +31,9 @@ async function setup<
     | (AccountClass<Account> & CoValueFromRaw<Account>)
     | AnyAccountSchema,
 >(AccountSchema?: S) {
-  const { server, port } = await setupSyncServer();
+  const { server, port, host } = await setupSyncServer();
 
-  const syncServer = `ws://localhost:${port}`;
+  const syncServer = `ws://${host}:${port}`;
 
   const { worker, done, waitForConnection, subscribeToConnectionChange } =
     await setupWorker(syncServer, AccountSchema);
@@ -43,13 +44,18 @@ async function setup<
     syncServer,
     server,
     port,
+    host,
     waitForConnection,
     subscribeToConnectionChange,
   };
 }
 
-async function setupSyncServer(defaultPort = "0") {
+async function setupSyncServer(
+  defaultHost = serverDefaults.host,
+  defaultPort = "0",
+) {
   const server = await startSyncServer({
+    host: defaultHost,
     port: defaultPort,
     inMemory: false,
     db: dbPath,
@@ -61,7 +67,7 @@ async function setupSyncServer(defaultPort = "0") {
     server.close();
   });
 
-  return { server, port };
+  return { server, port, host: defaultHost };
 }
 
 async function setupWorker<
@@ -258,6 +264,7 @@ describe("startWorker integration", () => {
 
     // Start a new sync server on the same port
     const newServer = await startSyncServer({
+      host: worker1.host,
       port: worker1.port,
       inMemory: true,
       db: "",
@@ -290,6 +297,7 @@ describe("startWorker integration", () => {
 
     // Start a new sync server on the same port
     const newServer = await startSyncServer({
+      host: worker1.host,
       port: worker1.port,
       inMemory: true,
       db: "",
@@ -326,6 +334,7 @@ describe("startWorker integration", () => {
 
     // Start a new sync server on the same port
     const newServer = await startSyncServer({
+      host: worker1.host,
       port: worker1.port,
       inMemory: true,
       db: "",

--- a/packages/jazz-run/src/types.ts
+++ b/packages/jazz-run/src/types.ts
@@ -1,0 +1,4 @@
+import { type Server } from "node:http";
+import { type LocalNode } from "cojson";
+
+export type SyncServer = Server & { localNode: LocalNode };


### PR DESCRIPTION
# Description

Added a `--host` option to the jazz-run sync command. This makes it possible to bind to 0.0.0.0, which can be important when running inside Docker containers. Binding to 0.0.0.0 exposes the server on the container’s external interface, making it reachable from other containers on the same network.

Made a slight modification to `startSyncServer` so that the returned promise now resolves once the server is listening. This allows the command to display the true host/ip of the newly created server (instead of just the arguments passed to the command). This should offer a more bullet proof status message, and could also be helpful if  `--port=0` was passed and a random port was selected.

## Manual testing instructions

```
npx jazz-run sync --host=0.0.0.0

 ./packages/jazz-run/dist/index.js sync --host=0.0.0.0 --in-memory
```

## Tests

- [x] Tests have been added and/or updated
- [ ] Tests have not been updated, because: <!-- Insert reason for not updating tests here -->
- [ ] I need help with writing tests


## Checklist

- [x] I've updated the part of the docs that are affected the PR changes
- [ ] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing