### PR TITLE
fix(jazz-tools/media): get resized file's id without triggering shallow load

### DIFF
--- a/.changeset/spotty-scissors-boil.md
+++ b/.changeset/spotty-scissors-boil.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+get resized image's id without triggering shallow load in `loadImageBySize`

--- a/packages/jazz-tools/src/media/utils.test.ts
+++ b/packages/jazz-tools/src/media/utils.test.ts
@@ -347,7 +347,6 @@ describe("loadImageBySize", async () => {
 
   it("returns the image already loaded", async () => {
     const account = await setupJazzTestSync({ asyncPeers: true });
-    const account2 = await createJazzTestAccount();
 
     setActiveAccount(account);
 
@@ -363,9 +362,11 @@ describe("loadImageBySize", async () => {
       group,
     );
 
+    const account2 = await createJazzTestAccount();
     setActiveAccount(account2);
 
-    const result = await loadImageBySize(imageDef, 1024, 1024);
+    const result = await loadImageBySize(imageDef.id, 1024, 1024);
+    expect(result).not.toBeNull();
     expect(result?.image.id).toBe(imageDef["1024x1024"]!.id);
     expect(result?.image.isBinaryStreamEnded()).toBe(true);
     expect(result?.image.asBase64()).toStrictEqual(expect.any(String));

--- a/packages/jazz-tools/src/media/utils.ts
+++ b/packages/jazz-tools/src/media/utils.ts
@@ -185,7 +185,11 @@ export async function loadImageBySize(
   const bestTarget =
     sortedSizes.find((el) => el.match > 0.95) || sortedSizes.at(-1)!;
 
-  const file = image[bestTarget.size[2]];
+  // The image's `wxh` keys reference FileStream.
+  // image[bestTarget.size[2]] returns undefined if FileStream hasn't loaded yet.
+  // Since we only need the file's ID to fetch it later, we check the raw _refs
+  // which contain only the linked covalue's ID.
+  const file = image._refs[bestTarget.size[2]];
 
   if (!file) {
     return null;


### PR DESCRIPTION
# Description
Follow up of #2726
