### PR TITLE
fix: create CoValues from JSON without an active account

### DIFF
--- a/.changeset/eight-jars-bow.md
+++ b/.changeset/eight-jars-bow.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+allow creating CoValues from JSON without an active account

--- a/packages/jazz-tools/src/tools/implementation/schema.ts
+++ b/packages/jazz-tools/src/tools/implementation/schema.ts
@@ -171,7 +171,9 @@ export function instantiateRefEncodedWithInit<V extends CoValue>(
       `Cannot automatically create CoValue from value: ${JSON.stringify(init)}. Use the CoValue schema's create() method instead.`,
     );
   }
-  const owner = Group.create();
+  const node = parentOwner._raw.core.node;
+  const rawGroup = node.createGroup();
+  const owner = new Group({ fromRaw: rawGroup });
   owner.addMember(parentOwner.castAs(Group));
   // @ts-expect-error - create is a static method in all CoValue classes
   return schema.ref.create(init, owner);

--- a/packages/jazz-tools/src/tools/testing.ts
+++ b/packages/jazz-tools/src/tools/testing.ts
@@ -154,6 +154,24 @@ export function setActiveAccount(account: Account) {
   activeAccountContext.set(account);
 }
 
+/**
+ * Run a callback without an active account.
+ *
+ * Takes care of restoring the active account after the callback is run.
+ *
+ * @param callback - The callback to run.
+ * @returns The result of the callback.
+ */
+export function runWithoutActiveAccount<Result>(
+  callback: () => Result,
+): Result {
+  const me = Account.getMe();
+  activeAccountContext.set(null);
+  const result = callback();
+  activeAccountContext.set(me);
+  return result;
+}
+
 export async function createJazzTestGuest() {
   const ctx = await createAnonymousJazzContext({
     crypto: await PureJSCrypto.create(),

--- a/packages/jazz-tools/src/tools/tests/coMap.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coMap.test.ts
@@ -12,10 +12,15 @@ import {
 } from "vitest";
 import { Group, co, subscribeToCoValue, z } from "../exports.js";
 import { Account } from "../index.js";
-import { Loaded, coValueClassFromCoValueClassOrSchema } from "../internal.js";
+import {
+  Loaded,
+  activeAccountContext,
+  coValueClassFromCoValueClassOrSchema,
+} from "../internal.js";
 import {
   createJazzTestAccount,
   getPeerConnectedToTestSyncServer,
+  runWithoutActiveAccount,
   setupJazzTestSync,
 } from "../testing.js";
 import { setupTwoNodes, waitFor } from "./utils.js";
@@ -213,6 +218,19 @@ describe("CoMap", async () => {
         const Schema = co.map({ text: co.plainText() });
         const map = Schema.create({ text: "" });
         expect(map.text.toString()).toBe("");
+      });
+
+      it("creates a group for the new CoValue when there is no active account", () => {
+        const Schema = co.map({ text: co.plainText() });
+
+        const parentGroup = Group.create();
+        runWithoutActiveAccount(() => {
+          const map = Schema.create({ text: "Hello" }, parentGroup);
+
+          expect(
+            map.text._owner.getParentGroups().map((group: Group) => group.id),
+          ).toContain(parentGroup.id);
+        });
       });
     });
 


### PR DESCRIPTION
# Description

Fixes https://github.com/garden-co/jazz/issues/2763

When creating CoValues that contain other CoValues using plain JSON objects, we create groups for the new CoValues automatically (see [Group hierarchy on CoValue creation](https://jazz.tools/docs/react/groups/inheritance#group-hierarchy-on-covalue-creation)). Until now, the owner for those groups was the active account.

This PR modifies the groups' creation to get the Account owner from the parent group, instead of relying on the active account. This allows using JSON inputs for CoValue creation even in contexts where there is no active account. 

## Tests

- [x] Tests have been added and/or updated

## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [x] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing