### PR TITLE
fix: prevent passing CoValue schemas to `co.map` and `co.profile`

### DIFF
--- a/.changeset/long-rocks-itch.md
+++ b/.changeset/long-rocks-itch.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Fixed an issue where CoValue schemas could be incorrectly passed to `co.map` and `co.profile` schema definers.

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/runtimeConverters/coValueSchemaTransformation.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/runtimeConverters/coValueSchemaTransformation.ts
@@ -38,9 +38,14 @@ import {
 // Note: if you're editing this function, edit the `isAnyCoValueSchema`
 // function in `zodReExport.ts` as well
 export function isAnyCoValueSchema(
-  schema: AnyZodOrCoValueSchema | CoValueClass,
+  schema: unknown,
 ): schema is AnyCoreCoValueSchema {
-  return "collaborative" in schema && schema.collaborative === true;
+  return (
+    typeof schema === "object" &&
+    schema !== null &&
+    "collaborative" in schema &&
+    schema.collaborative === true
+  );
 }
 
 export function isCoValueSchema(

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/zodCo.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/zodCo.ts
@@ -19,6 +19,7 @@ import {
   createCoreCoPlainTextSchema,
   createCoreFileStreamSchema,
   hydrateCoreCoValueSchema,
+  isAnyCoValueSchema,
 } from "../../internal.js";
 import {
   CoDiscriminatedUnionSchema,
@@ -36,6 +37,11 @@ import { z } from "./zodReExport.js";
 export const coMapDefiner = <Shape extends z.core.$ZodLooseShape>(
   shape: Shape,
 ): CoMapSchema<Shape> => {
+  if (isAnyCoValueSchema(shape as any)) {
+    throw new Error(
+      "co.map() expects an object as its argument, not a CoValue schema",
+    );
+  }
   const coreSchema = createCoreCoMapSchema(shape);
   return hydrateCoreCoValueSchema(coreSchema);
 };
@@ -116,6 +122,11 @@ export const coProfileDefiner = <
 >(
   shape: Shape & Partial<DefaultProfileShape> = {} as any,
 ): CoProfileSchema<Shape> => {
+  if (isAnyCoValueSchema(shape as any)) {
+    throw new Error(
+      "co.profile() expects an object as its argument, not a CoValue schema",
+    );
+  }
   const ehnancedShape = Object.assign(shape, {
     name: z.string(),
     inbox: z.optional(z.string()),

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/zodReExport.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/zodReExport.ts
@@ -88,6 +88,11 @@ function containsCoValueSchema(shape?: core.$ZodLooseShape): boolean {
 
 // Note: if you're editing this function, edit the `isAnyCoValueSchema`
 // function in `zodSchemaToCoSchema.ts` as well
-function isAnyCoValueSchema(schema: any): boolean {
-  return "collaborative" in schema && schema.collaborative === true;
+function isAnyCoValueSchema(schema: unknown): boolean {
+  return (
+    typeof schema === "object" &&
+    schema !== null &&
+    "collaborative" in schema &&
+    schema.collaborative === true
+  );
 }

--- a/packages/jazz-tools/src/tools/tests/account.test.ts
+++ b/packages/jazz-tools/src/tools/tests/account.test.ts
@@ -137,6 +137,12 @@ test("loading raw accounts should work", async () => {
   expect(loadedAccount.profile!.name).toBe("test 1");
 });
 
+test("co.profile() should throw an error if passed a CoValue schema", async () => {
+  expect(() => co.profile(co.map({}))).toThrow(
+    "co.profile() expects an object as its argument, not a CoValue schema",
+  );
+});
+
 test("should support recursive props on co.profile", async () => {
   const User = co.profile({
     name: z.string(),

--- a/packages/jazz-tools/src/tools/tests/coMap.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coMap.test.ts
@@ -2325,6 +2325,12 @@ describe("co.map schema", () => {
       expect(draftPerson.extraField).toEqual("extra");
     });
   });
+
+  test("co.map() should throw an error if passed a CoValue schema", () => {
+    expect(() => co.map(co.map({}))).toThrow(
+      "co.map() expects an object as its argument, not a CoValue schema",
+    );
+  });
 });
 
 describe("Updating a nested reference", () => {


### PR DESCRIPTION
# Description

Fixes https://github.com/garden-co/jazz/issues/2770.

Prevent passing CoValue schemas as input to `co.map` and `co.profile` schema definers. Since types cannot be tightened (because that'd break recursive references), I'm adding a runtime check.

## Tests

- [x] Tests have been added and/or updated

## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [x] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing