### PR TITLE
Ref GCO-742: Don't load dependencies when skipVerify=true

### DIFF
--- a/.changeset/poor-keys-sparkle.md
+++ b/.changeset/poor-keys-sparkle.md
@@ -1,0 +1,5 @@
+---
+"cojson": patch
+---
+
+Only request covalue dependencies when transaction verification is enabled

--- a/packages/cojson/src/sync.ts
+++ b/packages/cojson/src/sync.ts
@@ -511,28 +511,31 @@ export class SyncManager {
         (content) => content.newTransactions,
       );
 
-      for (const dependency of getDependedOnCoValuesFromRawData(
-        msg.id,
-        msg.header,
-        sessionIDs,
-        transactions,
-      )) {
-        const dependencyCoValue = this.local.getCoValue(dependency);
+      // If we'll be performing transaction verification, ensure all the dependencies available.
+      if (!this.skipVerify) {
+        for (const dependency of getDependedOnCoValuesFromRawData(
+          msg.id,
+          msg.header,
+          sessionIDs,
+          transactions,
+        )) {
+          const dependencyCoValue = this.local.getCoValue(dependency);
 
-        if (!dependencyCoValue.hasVerifiedContent()) {
-          coValue.markMissingDependency(dependency);
+          if (!dependencyCoValue.hasVerifiedContent()) {
+            coValue.markMissingDependency(dependency);
 
-          const peers = this.getServerPeers();
+            const peers = this.getServerPeers();
 
-          // if the peer that sent the content is a client, we add it to the list of peers
-          // to also ask them for the dependency
-          if (peer?.role === "client") {
-            peers.push(peer);
+            // if the peer that sent the content is a client, we add it to the list of peers
+            // to also ask them for the dependency
+            if (peer?.role === "client") {
+              peers.push(peer);
+            }
+
+            dependencyCoValue.load(peers);
+          } else if (!dependencyCoValue.isAvailable()) {
+            coValue.markMissingDependency(dependency);
           }
-
-          dependencyCoValue.load(peers);
-        } else if (!dependencyCoValue.isAvailable()) {
-          coValue.markMissingDependency(dependency);
         }
       }
 
@@ -592,51 +595,54 @@ export class SyncManager {
         continue;
       }
 
-      const accountId = accountOrAgentIDfromSessionID(sessionID);
+      // If we'll be performing transaction verification, ensure the account is available.
+      if (!this.skipVerify) {
+        const accountId = accountOrAgentIDfromSessionID(sessionID);
 
-      if (isAccountID(accountId)) {
-        const account = this.local.getCoValue(accountId);
+        if (isAccountID(accountId)) {
+          const account = this.local.getCoValue(accountId);
 
-        // We can't verify the transaction without the account, so we delay the session content handling until the account is available
-        if (!account.isAvailable()) {
-          // This covers the case where we are getting a new session on an already loaded coValue
-          // where we need to load the account to get their public key
-          if (!coValue.missingDependencies.has(accountId)) {
-            const peers = this.getServerPeers();
+          // We can't verify the transaction without the account, so we delay the session content handling until the account is available
+          if (!account.isAvailable()) {
+            // This covers the case where we are getting a new session on an already loaded coValue
+            // where we need to load the account to get their public key
+            if (!coValue.missingDependencies.has(accountId)) {
+              const peers = this.getServerPeers();
 
-            if (peer?.role === "client") {
-              // if the peer that sent the content is a client, we add it to the list of peers
-              // to also ask them for the dependency
-              peers.push(peer);
+              if (peer?.role === "client") {
+                // if the peer that sent the content is a client, we add it to the list of peers
+                // to also ask them for the dependency
+                peers.push(peer);
+              }
+
+              account.load(peers);
             }
 
-            account.load(peers);
-          }
-
-          // We need to wait for the account to be available before we can verify the transaction
-          // Currently doing this by delaying the handleNewContent for the session to when we have the account
-          //
-          // This is not the best solution, because the knownState is not updated and the ACK response will be given
-          // by excluding the session.
-          // This is good enough implementation for now because the only case for the account to be missing are out-of-order
-          // dependencies push, so the gap should be short lived.
-          //
-          // When we are going to have sharded-peers we should revisit this, and store unverified sessions that are considered as part of the
-          // knwonState, but not actively used until they can be verified.
-          void account.waitForAvailable().then(() => {
-            this.handleNewContent(
-              {
-                action: "content",
-                id: coValue.id,
-                new: {
-                  [sessionID]: newContentForSession,
+            // We need to wait for the account to be available before we can verify the transaction
+            // Currently doing this by delaying the handleNewContent for the session to when we have the account
+            //
+            // This is not the best solution, because the knownState is not updated and the ACK response will be given
+            // by excluding the session.
+            // This is good enough implementation for now because the only case for the account to be missing are out-of-order
+            // dependencies push, so the gap should be short lived.
+            //
+            // When we are going to have sharded-peers we should revisit this, and store unverified sessions that are considered as part of the
+            // knwonState, but not actively used until they can be verified.
+            void account.waitForAvailable().then(() => {
+              this.handleNewContent(
+                {
+                  action: "content",
+                  id: coValue.id,
+                  new: {
+                    [sessionID]: newContentForSession,
+                  },
+                  priority: msg.priority,
                 },
-                priority: msg.priority,
-              },
-              from,
-            );
-          });
-          continue;
+                from,
+              );
+            });
+            continue;
+          }
         }
       }
 

--- a/packages/cojson/src/tests/sync.load.test.ts
+++ b/packages/cojson/src/tests/sync.load.test.ts
@@ -9,6 +9,7 @@ import {
   SyncMessagesLog,
   TEST_NODE_CONFIG,
   blockMessageTypeOnOutgoingPeer,
+  getSyncServerConnectedPeer,
   loadCoValueOrFail,
   setupTestAccount,
   setupTestNode,
@@ -1033,5 +1034,56 @@ describe("loading coValues from server", () => {
     `);
 
     vi.useRealTimers();
+  });
+
+  test("should not request dependencies if transaction verification is disabled", async () => {
+    // Create a disconnected client
+    const { node: client, accountID } = await setupTestAccount({
+      connected: false,
+    });
+    const account = client.expectCurrentAccount(accountID);
+
+    // Prepare a group and a map
+    const group = client.createGroup();
+    group.addMember("everyone", "writer");
+
+    // Create a sync server and disable transaction verification
+    const syncServer = await setupTestAccount({ isSyncServer: true });
+    syncServer.node.syncManager.disableTransactionVerification();
+
+    // Connect the client, but don't setup syncing just yet...
+    const { peer } = getSyncServerConnectedPeer({
+      peerId: client.getCurrentAgent().id,
+      syncServer: syncServer.node,
+    });
+
+    // Disable reconciliation while we setup syncing because we don't want the
+    // server to know about our map's dependencies (group + account).
+    const blocker = blockMessageTypeOnOutgoingPeer(peer, "load", {});
+    client.syncManager.addPeer(peer);
+    blocker.unblock();
+
+    // Create a map and set a value on it.
+    // If transaction verification were enabled, this would trigger LOAD messages
+    // from the server to the client asking for the group and account. However, we
+    // don't expect to see those messages since we disabled transaction verification.
+    const map = group.createMap();
+    map.set("hello", "world");
+    await map.core.waitForSync();
+
+    const syncMessages = SyncMessagesLog.getMessages({
+      Account: account.core,
+      Group: group.core,
+      Map: map.core,
+    });
+    expect(
+      syncMessages.some(
+        (msg) => msg.includes("LOAD Account") || msg.includes("LOAD Group"),
+      ),
+    ).toBe(false);
+
+    // Verify the map is available on the server (transaction was accepted)
+    const mapOnServerCore = await syncServer.node.loadCoValueCore(map.core.id);
+    expect(mapOnServerCore.isAvailable()).toBe(true);
   });
 });

--- a/packages/cojson/src/tests/sync.load.test.ts
+++ b/packages/cojson/src/tests/sync.load.test.ts
@@ -1043,7 +1043,7 @@ describe("loading coValues from server", () => {
     });
     const account = client.expectCurrentAccount(accountID);
 
-    // Prepare a group and a map
+    // Prepare a group -- this will be a non-account dependency of a forthcoming map.
     const group = client.createGroup();
     group.addMember("everyone", "writer");
 
@@ -1058,7 +1058,7 @@ describe("loading coValues from server", () => {
     });
 
     // Disable reconciliation while we setup syncing because we don't want the
-    // server to know about our map's dependencies (group + account).
+    // server to know about our forthcoming map's dependencies (group + account).
     const blocker = blockMessageTypeOnOutgoingPeer(peer, "load", {});
     client.syncManager.addPeer(peer);
     blocker.unblock();


### PR DESCRIPTION
# Description
This changes `SyncManager` to skip loading dependent covalues/accounts whenever `skipVerify=true`. We need this behavior because sharded core nodes typically won't have access to all of the dependencies (since some will live on other shards).

## Blockers

1. ~~This appears to work as intended, however, if I try to load the covalue that's been persisted without dependencies -- that will fail with:~~

    `Error: Determining valid transaction in owned object but its group wasn't loaded: CoValue co_zFQ8TKVUZaHPLeLUpR5PEQmsegb not yet loaded.`

    I suspect that's going to be a problem... cc @gdorsi @aeplay 


## Manual testing instructions

N/A

## Tests

- [x] Tests have been added and/or updated
- [ ] Tests have not been updated, because: <!-- Insert reason for not updating tests here -->
- [ ] I need help with writing tests


## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [x] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing