### PR TITLE
Ability to filter getServerPeers() result based on covalue id

### DIFF
--- a/.changeset/silver-tools-travel.md
+++ b/.changeset/silver-tools-travel.md
@@ -1,0 +1,5 @@
+---
+"cojson": patch
+---
+
+Ability to filter getServerPeers() result based on covalue id

--- a/packages/cojson/src/localNode.ts
+++ b/packages/cojson/src/localNode.ts
@@ -408,7 +408,7 @@ export class LocalNode {
         coValue.loadingState === "unknown" ||
         coValue.loadingState === "unavailable"
       ) {
-        const peers = this.syncManager.getServerPeers(skipLoadingFromPeer);
+        const peers = this.syncManager.getServerPeers(id, skipLoadingFromPeer);
 
         if (!this.storage && peers.length === 0) {
           return coValue;

--- a/packages/cojson/src/sync.ts
+++ b/packages/cojson/src/sync.ts
@@ -128,6 +128,11 @@ export function combinedKnownStates(
   };
 }
 
+export type ServerPeerSelector = (
+  id: RawCoID,
+  serverPeers: PeerState[],
+) => PeerState[];
+
 export class SyncManager {
   peers: { [key: PeerID]: PeerState } = {};
   local: LocalNode;
@@ -143,6 +148,8 @@ export class SyncManager {
     unit: "peer",
   });
   private transactionsSizeHistogram: Histogram;
+
+  serverPeerSelector?: ServerPeerSelector;
 
   constructor(local: LocalNode) {
     this.local = local;
@@ -176,10 +183,13 @@ export class SyncManager {
     return Object.values(this.peers);
   }
 
-  getServerPeers(excludePeerId?: PeerID): PeerState[] {
-    return this.getPeers().filter(
+  getServerPeers(id: RawCoID, excludePeerId?: PeerID): PeerState[] {
+    const serverPeers = this.getPeers().filter(
       (peer) => peer.role === "server" && peer.id !== excludePeerId,
     );
+    return this.serverPeerSelector
+      ? this.serverPeerSelector(id, serverPeers)
+      : serverPeers;
   }
 
   handleSyncMessage(msg: SyncMessage, peer: PeerState) {
@@ -421,7 +431,7 @@ export class SyncManager {
       return;
     }
 
-    const peers = this.getServerPeers(peer.id);
+    const peers = this.getServerPeers(msg.id, peer.id);
 
     coValue.load(peers);
 
@@ -547,7 +557,7 @@ export class SyncManager {
           if (!dependencyCoValue.hasVerifiedContent()) {
             coValue.markMissingDependency(dependency);
 
-            const peers = this.getServerPeers();
+            const peers = this.getServerPeers(dependencyCoValue.id);
 
             // if the peer that sent the content is a client, we add it to the list of peers
             // to also ask them for the dependency
@@ -630,7 +640,7 @@ export class SyncManager {
             // This covers the case where we are getting a new session on an already loaded coValue
             // where we need to load the account to get their public key
             if (!coValue.missingDependencies.has(accountId)) {
-              const peers = this.getServerPeers();
+              const peers = this.getServerPeers(account.id);
 
               if (peer?.role === "client") {
                 // if the peer that sent the content is a client, we add it to the list of peers

--- a/packages/cojson/src/tests/sync.sharding.test.ts
+++ b/packages/cojson/src/tests/sync.sharding.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, test } from "vitest";
+import { setCoValueLoadingRetryDelay } from "../config";
+import {
+  SyncMessagesLog,
+  TEST_NODE_CONFIG,
+  blockMessageTypeOnOutgoingPeer,
+  getSyncServerConnectedPeer,
+  loadCoValueOrFail,
+  setupTestAccount,
+  setupTestNode,
+} from "./testUtils";
+import { Peer } from "../exports";
+import { ServerPeerSelector } from "../sync";
+
+beforeEach(async () => {
+  // We want to simulate a real world communication that happens asynchronously
+  TEST_NODE_CONFIG.withAsyncPeers = true;
+
+  SyncMessagesLog.clear();
+});
+
+describe("sharding", () => {
+  test("server peers are not filtered by default", async () => {
+    const { node: client } = setupTestNode({
+      connected: false,
+    });
+    const group = client.createGroup();
+
+    const allPeers: Peer[] = [];
+    for (let i = 0; i < 5; i++) {
+      const syncServer = await setupTestAccount({ isSyncServer: true });
+
+      const { peer } = getSyncServerConnectedPeer({
+        peerId: client.getCurrentAgent().id,
+        syncServer: syncServer.node,
+      });
+
+      client.syncManager.addPeer(peer);
+      allPeers.push(peer);
+    }
+
+    const serverPeers = client.syncManager.getServerPeers(group.id);
+    expect(serverPeers.map((p) => p.id)).toEqual(allPeers.map((p) => p.id));
+  });
+
+  test("server peers are filtered when a serverPeerSelector is set", async () => {
+    const firstAlphabetical: ServerPeerSelector = (id, serverPeers) => {
+      return serverPeers.sort((a, b) => a.id.localeCompare(b.id)).slice(0, 1);
+    };
+
+    const { node: client } = setupTestNode({
+      connected: false,
+    });
+    client.syncManager.serverPeerSelector = firstAlphabetical;
+    const group = client.createGroup();
+
+    const allPeers: Peer[] = [];
+    for (let i = 0; i < 5; i++) {
+      const syncServer = await setupTestAccount({ isSyncServer: true });
+
+      const { peer } = getSyncServerConnectedPeer({
+        peerId: client.getCurrentAgent().id,
+        syncServer: syncServer.node,
+      });
+
+      client.syncManager.addPeer(peer);
+      allPeers.push(peer);
+    }
+
+    const serverPeers = client.syncManager.getServerPeers(group.id);
+    expect(serverPeers.length).toBe(1);
+    expect(serverPeers[0]!.id).toEqual(
+      allPeers.sort((a, b) => a.id.localeCompare(b.id))[0]!.id,
+    );
+  });
+});


### PR DESCRIPTION
# Description
This adds an optional `ServerPeerSelector` to `SyncManager` that, if set, gets invoked whenever `getServerPeers()` is called. Even though it's unused at the moment, I've also added the current covalue ID as a parameter to `getServerPeers` since it'll get used imminently to implement a `RendezvousHashServerPeerSelector`.

Fixes GCO-772, GCO-773

## Manual testing instructions

N/A

## Tests

- [x] Tests have been added and/or updated
- [ ] Tests have not been updated, because: <!-- Insert reason for not updating tests here -->
- [ ] I need help with writing tests


## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [x] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing