### PR TITLE
Use getServerPeers() in peersInPriorityOrder()

### DIFF
--- a/.changeset/good-dots-love.md
+++ b/.changeset/good-dots-love.md
@@ -2,4 +2,4 @@
 "cojson": patch
 ---
 
-Use getServerPeers() in peersInPriorityOrder()
+Apply `serverPeerSelector` in all the peers getters

--- a/.changeset/good-dots-love.md
+++ b/.changeset/good-dots-love.md
@@ -1,0 +1,5 @@
+---
+"cojson": patch
+---
+
+Use getServerPeers() in peersInPriorityOrder()

--- a/packages/cojson-transport-ws/src/tests/webSocket.integration.test.ts
+++ b/packages/cojson-transport-ws/src/tests/webSocket.integration.test.ts
@@ -60,7 +60,8 @@ describe("WebSocket Peer Integration", () => {
     });
 
     expect(connectionEstablished).toBe(true);
-    expect(clientNode.syncManager.getPeers()).toHaveLength(1);
+    expect(clientNode.syncManager.getServerPeers("co_z12345")).toHaveLength(1);
+    expect(clientNode.syncManager.getClientPeers()).toHaveLength(0);
   });
 
   test("should sync data between nodes through WebSocket connection", async () => {
@@ -183,7 +184,7 @@ describe("WebSocket Peer Integration", () => {
       expect(server.wss.clients.size).toBe(1);
     });
 
-    const peerOnServer = server.localNode.syncManager.getPeers()[0];
+    const peerOnServer = server.localNode.syncManager.getClientPeers()[0];
 
     for (const client of server.wss.clients) {
       client.terminate();

--- a/packages/cojson/src/sync.ts
+++ b/packages/cojson/src/sync.ts
@@ -170,8 +170,13 @@ export class SyncManager {
     this.skipVerify = true;
   }
 
-  peersInPriorityOrder(): PeerState[] {
-    return Object.values(this.peers).sort((a, b) => {
+  peersInPriorityOrder(id: RawCoID): PeerState[] {
+    const clientPeers = Object.values(this.peers).filter(
+      (peer) => peer.role === "client",
+    );
+    const serverPeers = this.getServerPeers(id);
+
+    return [...serverPeers, ...clientPeers].sort((a, b) => {
       const aPriority = a.priority || 0;
       const bPriority = b.priority || 0;
 
@@ -760,7 +765,7 @@ export class SyncManager {
       this.storeContent(contentToStore);
     }
 
-    for (const peer of this.peersInPriorityOrder()) {
+    for (const peer of this.peersInPriorityOrder(coValue.id)) {
       /**
        * We sync the content against the source peer if it is a client or server peers
        * to upload any content that is available on the current node and not on the source peer.
@@ -818,7 +823,7 @@ export class SyncManager {
 
     const contentKnownState = knownStateFromContent(content);
 
-    for (const peer of this.peersInPriorityOrder()) {
+    for (const peer of this.peersInPriorityOrder(coValue.id)) {
       if (peer.closed) continue;
       if (coValue.isErroredInPeer(peer.id)) continue;
 

--- a/packages/cojson/src/tests/sync.sharding.test.ts
+++ b/packages/cojson/src/tests/sync.sharding.test.ts
@@ -4,6 +4,7 @@ import {
   SyncMessagesLog,
   TEST_NODE_CONFIG,
   blockMessageTypeOnOutgoingPeer,
+  connectedPeersWithMessagesTracking,
   getSyncServerConnectedPeer,
   loadCoValueOrFail,
   setupTestAccount,
@@ -47,7 +48,6 @@ describe("sharding", () => {
     const firstAlphabetical: ServerPeerSelector = (id, serverPeers) => {
       return serverPeers.sort((a, b) => a.id.localeCompare(b.id)).slice(0, 1);
     };
-
     const { node: client } = setupTestNode({
       connected: false,
     });
@@ -71,6 +71,49 @@ describe("sharding", () => {
     expect(serverPeers.length).toBe(1);
     expect(serverPeers[0]!.id).toEqual(
       allPeers.sort((a, b) => a.id.localeCompare(b.id))[0]!.id,
+    );
+  });
+
+  test("peersInPriorityOrder respects the serverPeerSelector", async () => {
+    const firstPeer: ServerPeerSelector = (id, serverPeers) => {
+      return serverPeers.slice(0, 1);
+    };
+    const { node: edge } = setupTestNode({
+      connected: false,
+    });
+    edge.syncManager.serverPeerSelector = firstPeer;
+
+    // Connect 2 clients to edge
+    for (let i = 0; i < 2; i++) {
+      const client = await setupTestAccount({});
+      const { peer1, peer2 } = connectedPeersWithMessagesTracking({
+        peer1: {
+          id: client.node.getCurrentAgent().id,
+          role: "client",
+        },
+        peer2: {
+          id: edge.getCurrentAgent().id,
+          role: "server",
+        },
+      });
+
+      edge.syncManager.addPeer(peer1);
+    }
+
+    // Connect edge to 3 core nodes
+    for (let i = 0; i < 3; i++) {
+      const syncServer = await setupTestAccount({ isSyncServer: true });
+
+      const { peer } = getSyncServerConnectedPeer({
+        peerId: edge.getCurrentAgent().id,
+        syncServer: syncServer.node,
+      });
+
+      edge.syncManager.addPeer(peer);
+    }
+
+    expect(edge.syncManager.peersInPriorityOrder("co_z12345").length).toBe(
+      2 + 1, // 2 clients + 1 selected core
     );
   });
 });

--- a/packages/cojson/src/tests/sync.sharding.test.ts
+++ b/packages/cojson/src/tests/sync.sharding.test.ts
@@ -74,7 +74,7 @@ describe("sharding", () => {
     );
   });
 
-  test("peersInPriorityOrder respects the serverPeerSelector", async () => {
+  test("getPeers respects the serverPeerSelector", async () => {
     const firstPeer: ServerPeerSelector = (id, serverPeers) => {
       return serverPeers.slice(0, 1);
     };
@@ -112,7 +112,7 @@ describe("sharding", () => {
       edge.syncManager.addPeer(peer);
     }
 
-    expect(edge.syncManager.peersInPriorityOrder("co_z12345").length).toBe(
+    expect(edge.syncManager.getPeers("co_z12345").length).toBe(
       2 + 1, // 2 clients + 1 selected core
     );
   });

--- a/packages/cojson/src/tests/sync.storage.test.ts
+++ b/packages/cojson/src/tests/sync.storage.test.ts
@@ -164,7 +164,7 @@ describe("client with storage syncs with server", () => {
     const mapOnClient = await loadCoValueOrFail(client.node, map.id);
     expect(mapOnClient.get("hello")).toEqual("world");
 
-    client.node.syncManager.getPeers()[0]?.gracefulShutdown();
+    client.node.syncManager.getPeers(map.id)[0]?.gracefulShutdown();
 
     SyncMessagesLog.clear();
     map.set("hello", "updated", "trusting");

--- a/packages/cojson/src/tests/sync.storageAsync.test.ts
+++ b/packages/cojson/src/tests/sync.storageAsync.test.ts
@@ -156,7 +156,7 @@ describe("client with storage syncs with server", () => {
     const mapOnClient = await loadCoValueOrFail(client.node, map.id);
     expect(mapOnClient.get("hello")).toEqual("world");
 
-    client.node.syncManager.getPeers()[0]?.gracefulShutdown();
+    client.node.syncManager.getPeers(map.id)[0]?.gracefulShutdown();
 
     SyncMessagesLog.clear();
     map.set("hello", "updated", "trusting");

--- a/packages/cojson/src/tests/sync.test.ts
+++ b/packages/cojson/src/tests/sync.test.ts
@@ -599,8 +599,12 @@ describe("SyncManager - knownStates vs optimisticKnownStates", () => {
     // Wait for the full sync to complete
     await mapOnClient.core.waitForSync();
 
-    const peerStateClient = client.syncManager.getPeers()[0]!;
-    const peerStateJazzCloud = jazzCloud.node.syncManager.getPeers()[0]!;
+    const peerStateClient = client.syncManager.getPeers(
+      mapOnClient.core.id,
+    )[0]!;
+    const peerStateJazzCloud = jazzCloud.node.syncManager.getPeers(
+      mapOnClient.core.id,
+    )[0]!;
 
     // The optimisticKnownStates should be the same as the knownStates after the full sync is complete
     expect(

--- a/packages/cojson/src/tests/testUtils.ts
+++ b/packages/cojson/src/tests/testUtils.ts
@@ -669,9 +669,11 @@ export async function setupTestAccount(
     addStorage,
     addAsyncStorage,
     disconnect: () => {
-      ctx.node.syncManager.getPeers().forEach((peer) => {
+      const allPeers = ctx.node.syncManager.getPeers(ctx.accountID);
+      allPeers.forEach((peer) => {
         peer.gracefulShutdown();
       });
+      ctx.node.syncManager.peers = {};
     },
   };
 }

--- a/packages/jazz-tools/src/react-core/tests/useCoState.test.ts
+++ b/packages/jazz-tools/src/react-core/tests/useCoState.test.ts
@@ -172,7 +172,7 @@ describe("useCoState", () => {
       isCurrentActiveAccount: true,
     });
 
-    for (const peer of account._raw.core.node.syncManager.getPeers()) {
+    for (const peer of account._raw.core.node.syncManager.getClientPeers()) {
       peer.gracefulShutdown();
     }
 

--- a/packages/jazz-tools/src/tools/tests/coMap.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coMap.test.ts
@@ -726,9 +726,11 @@ describe("CoMap resolution", async () => {
     const currentAccount = Account.getMe();
 
     // Disconnect the current account
-    currentAccount._raw.core.node.syncManager.getPeers().forEach((peer) => {
-      peer.gracefulShutdown();
-    });
+    currentAccount._raw.core.node.syncManager
+      .getServerPeers(currentAccount._raw.id)
+      .forEach((peer) => {
+        peer.gracefulShutdown();
+      });
 
     const group = Group.create();
     group.addMember("everyone", "writer");
@@ -771,9 +773,11 @@ describe("CoMap resolution", async () => {
     const currentAccount = Account.getMe();
 
     // Disconnect the current account
-    currentAccount._raw.core.node.syncManager.getPeers().forEach((peer) => {
-      peer.gracefulShutdown();
-    });
+    currentAccount._raw.core.node.syncManager
+      .getServerPeers(currentAccount._raw.id)
+      .forEach((peer) => {
+        peer.gracefulShutdown();
+      });
 
     const group = Group.create();
     group.addMember("everyone", "writer");

--- a/packages/jazz-tools/src/tools/tests/exportImport.test.ts
+++ b/packages/jazz-tools/src/tools/tests/exportImport.test.ts
@@ -257,7 +257,7 @@ describe("importContentPieces", () => {
     const alice = await createJazzTestAccount();
     const bob = await createJazzTestAccount();
 
-    bob._raw.core.node.syncManager.getPeers().forEach((peer) => {
+    bob._raw.core.node.syncManager.getClientPeers().forEach((peer) => {
       peer.gracefulShutdown();
     });
 
@@ -300,7 +300,7 @@ describe("importContentPieces", () => {
     const alice = await createJazzTestAccount();
     const bob = await createJazzTestAccount();
 
-    bob._raw.core.node.syncManager.getPeers().forEach((peer) => {
+    bob._raw.core.node.syncManager.getClientPeers().forEach((peer) => {
       peer.gracefulShutdown();
     });
 
@@ -340,7 +340,7 @@ describe("importContentPieces", () => {
     const alice = await createJazzTestAccount();
     const { guest } = await createJazzTestGuest();
 
-    guest.node.syncManager.getPeers().forEach((peer) => {
+    guest.node.syncManager.getClientPeers().forEach((peer) => {
       peer.gracefulShutdown();
     });
 
@@ -374,7 +374,7 @@ describe("importContentPieces", () => {
       isCurrentActiveAccount: true,
     });
 
-    bob._raw.core.node.syncManager.getPeers().forEach((peer) => {
+    bob._raw.core.node.syncManager.getClientPeers().forEach((peer) => {
       peer.gracefulShutdown();
     });
 
@@ -415,7 +415,7 @@ describe("importContentPieces", () => {
     const alice = await createJazzTestAccount();
     const bob = await createJazzTestAccount();
 
-    bob._raw.core.node.syncManager.getPeers().forEach((peer) => {
+    bob._raw.core.node.syncManager.getClientPeers().forEach((peer) => {
       peer.gracefulShutdown();
     });
 
@@ -479,7 +479,7 @@ describe("importContentPieces", () => {
     const alice = await createJazzTestAccount();
     const bob = await createJazzTestAccount();
 
-    bob._raw.core.node.syncManager.getPeers().forEach((peer) => {
+    bob._raw.core.node.syncManager.getClientPeers().forEach((peer) => {
       peer.gracefulShutdown();
     });
 

--- a/packages/jazz-tools/src/tools/tests/load.test.ts
+++ b/packages/jazz-tools/src/tools/tests/load.test.ts
@@ -137,7 +137,7 @@ test("retry an unavailable value", async () => {
   const currentAccount = Account.getMe();
 
   // Disconnect the current account
-  currentAccount._raw.core.node.syncManager.getPeers().forEach((peer) => {
+  currentAccount._raw.core.node.syncManager.getClientPeers().forEach((peer) => {
     peer.gracefulShutdown();
   });
 
@@ -169,9 +169,11 @@ test("returns null if the value is unavailable after retries", async () => {
   const currentAccount = Account.getMe();
 
   // Disconnect the current account
-  currentAccount._raw.core.node.syncManager.getPeers().forEach((peer) => {
-    peer.gracefulShutdown();
-  });
+  currentAccount._raw.core.node.syncManager
+    .getServerPeers(currentAccount._raw.id)
+    .forEach((peer) => {
+      peer.gracefulShutdown();
+    });
 
   const group = Group.create();
   const map = Person.create({ name: "John" }, group);

--- a/packages/jazz-tools/src/tools/tests/subscribe.test.ts
+++ b/packages/jazz-tools/src/tools/tests/subscribe.test.ts
@@ -503,9 +503,11 @@ describe("subscribeToCoValue", () => {
     });
 
     // Disconnect the creator from the sync server
-    creator._raw.core.node.syncManager.getPeers().forEach((peer) => {
-      peer.gracefulShutdown();
-    });
+    creator._raw.core.node.syncManager
+      .getServerPeers(creator._raw.id)
+      .forEach((peer) => {
+        peer.gracefulShutdown();
+      });
 
     const everyone = Group.create(creator);
     everyone.addMember("everyone", "reader");
@@ -867,9 +869,11 @@ describe("subscribeToCoValue", () => {
     await person.waitForSync();
 
     // Disconnect from the sync server, so we can change permissions but not sync them
-    creator._raw.core.node.syncManager.getPeers().forEach((peer) => {
-      peer.gracefulShutdown();
-    });
+    creator._raw.core.node.syncManager
+      .getServerPeers(creator._raw.id)
+      .forEach((peer) => {
+        peer.gracefulShutdown();
+      });
 
     group.removeMember(writer1);
     group.addMember(writer2, "writer");


### PR DESCRIPTION
# Description
`peersInPriorityOrder()` is used in a couple spots during `handleNewContent`, particularly for pushing updates to connected peers (including servers). It was always returning every peer, which is incorrect now that `getServerPeers()` can return a filtered set.

This change just uses `getServerPeers()` within `peersInPriorityOrder()`

## Manual testing instructions

N/A

## Tests

- [x] Tests have been added and/or updated
- [ ] Tests have not been updated, because: <!-- Insert reason for not updating tests here -->
- [ ] I need help with writing tests


## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [x] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing