### PR TITLE
Show proper downtime on status page, make it more responsive & compact

### DIFF
--- a/homepage/homepage/components/LatencyChart.tsx
+++ b/homepage/homepage/components/LatencyChart.tsx
@@ -72,9 +72,10 @@ export default function LatencyChart({ latencyOverTime, upOverTime, upCountOverT
         </HoverCard.Content>
       </HoverCard.Root>
       {series.map(({ value, ts, up, upCount }) => {
-        const valueClass = getClassForLatencyAndUp(value, up / upCount);
+        const upPercentage = up / upCount;
+        const valueClass = getClassForLatencyAndUp(value, upPercentage);
 
-        const downtimeMin = (1 - up / upCount) * intervalMin;
+        const downtimeMin = (1 - upPercentage) * intervalMin;
         return (
           <HoverCard.Root key={ts} openDelay={0} closeDelay={0}>
             <HoverCard.Trigger asChild >
@@ -87,33 +88,54 @@ export default function LatencyChart({ latencyOverTime, upOverTime, upCountOverT
                 />
               </div>
             </HoverCard.Trigger>
-            <HoverCard.Content className="border border-stone-500 bg-white dark:bg-black shadow-lg absolute w-[150px] -ml-[75px] l-[50%] rounded-md p-2">
+            <HoverCard.Content className="border border-stone-500 bg-white dark:bg-black shadow-lg absolute w-[150px] -ml-[75px] l-[50%] rounded-md py-1 px-2">
               <HoverCard.Arrow className="fill-stone-500" />
-
-              <time
-                className="text-xs"
-                dateTime={new Date(ts).toISOString()}
-              >
-                {new Date(ts).toLocaleString()}
-              </time>
-              <p className="text-sm text-right">
-                <span
-                  className={cn(
-                    "rounded-md size-3 inline-block mr-1",
-                    getClassForLatencyAndUp(value, 1),
-                  )}
-                />
-                <span className="font-semibold">{value}</span> ms
-              </p>
-              <p className="text-sm text-right">
-                <span
-                  className={cn(
-                    "rounded-md size-3 inline-block mr-1",
-                    getClassForLatencyAndUp(0, up / upCount),
-                  )}
-                />
-                <span className="font-semibold">{Math.round(downtimeMin)}/{intervalMin}min</span> down
-              </p>                </HoverCard.Content>
+                <div className="text-right">
+                  <time
+                    className="text-xs"
+                    dateTime={new Date(ts).toISOString()}
+                    >
+                    {new Date(ts).toLocaleString()}
+                  </time>
+                </div>
+                <div className="text-sm text-right flex items-center justify-between">
+                  <span className="flex items-center">
+                    <span
+                      className={cn(
+                        "rounded-md size-2.5 inline-block mr-1",
+                        getClassForLatencyAndUp(value, 1),
+                      )}
+                    />
+                    Latency
+                  </span>
+                  <span>
+                    <span className="font-semibold">{value}</span> ms
+                    
+                  </span>
+                </div>
+                {upPercentage < 0.99 && (
+                  <div className="text-sm text-right flex items-center justify-between">
+                    <span className="flex items-center">
+                      <span
+                        className={cn(
+                          "rounded-md size-2.5 inline-block mr-1",
+                          getClassForLatencyAndUp(0, upPercentage),
+                        )}
+                      />
+                      Downtime
+                      </span>
+                    <span>
+                    <span className="font-semibold">
+                      {Math.round(downtimeMin)}</span> min
+                    </span>
+                </div>
+                  
+                )}
+                
+                <p className="text-sm text-right">
+                  
+                </p>                
+              </HoverCard.Content>
           </HoverCard.Root>
         );
       })}

--- a/homepage/homepage/components/LatencyChart.tsx
+++ b/homepage/homepage/components/LatencyChart.tsx
@@ -76,6 +76,23 @@ export default function LatencyChart({ latencyOverTime, upOverTime, upCountOverT
         const valueClass = getClassForLatencyAndUp(value, upPercentage);
 
         const downtimeMin = (1 - upPercentage) * intervalMin;
+
+        const from = new Date(ts);
+        const to = new Date(ts + intervalMin * 60 * 1000);
+
+        let fromH = Intl.DateTimeFormat("en-US", {
+          hour: "numeric",
+        }).formatToParts(from);
+        const toH = Intl.DateTimeFormat("en-US", {
+          hour: "numeric",
+        }).formatToParts(to);
+
+
+        // remove the (PM) or (AM) if the "from" if its the same as the "to"
+        if(fromH[2].value === toH[2].value) {
+          fromH = fromH.filter(({type}) => type !== "literal").slice(0, 1);
+        }
+        
         return (
           <HoverCard.Root key={ts} openDelay={0} closeDelay={0}>
             <HoverCard.Trigger asChild >
@@ -88,14 +105,28 @@ export default function LatencyChart({ latencyOverTime, upOverTime, upCountOverT
                 />
               </div>
             </HoverCard.Trigger>
-            <HoverCard.Content className="border border-stone-500 bg-white dark:bg-black shadow-lg absolute w-[150px] -ml-[75px] l-[50%] rounded-md py-1 px-2">
+            <HoverCard.Content className="border border-stone-500 bg-white dark:bg-black shadow-lg absolute w-[180px] -ml-[90px] l-[50%] rounded-md py-1 px-2">
               <HoverCard.Arrow className="fill-stone-500" />
                 <div className="text-right">
                   <time
-                    className="text-xs"
-                    dateTime={new Date(ts).toISOString()}
+                    className="text-xs flex justify-between"
+                    dateTime={from.toISOString()}
                     >
-                    {new Date(ts).toLocaleString()}
+                      <span>
+                        {Intl.DateTimeFormat("en-US", {
+                          dateStyle: "medium",
+                        }).format(from)}
+                      </span>
+
+                      <span className="whitespace-nowrap">
+                        {fromH.map((part, index) => (
+                          <span key={index}>{part.value}</span>
+                        ))}
+                        {' – '}
+                        {toH.map((part, index) => (
+                          <span key={index}>{part.value}</span>
+                        ))}
+                      </span>
                   </time>
                 </div>
                 <div className="text-sm text-right flex items-center justify-between">


### PR DESCRIPTION
# Description

Tiny tweaks to the hover card content for redability:
- hides the downtime if none was recorded
- reduces the indicator size
- improves alignment
<img width="685" height="214" alt="SCR-20250823-lasj" src="https://github.com/user-attachments/assets/7be12890-1c08-46b7-9cad-5bd5aeda64b7" />
<img width="787" height="249" alt="SCR-20250823-lanv" src="https://github.com/user-attachments/assets/5ff19f4b-5643-401d-84df-1937641fddfe" />

