### PR TITLE
feat: detect incompatible Zod schemas

### DIFF
--- a/.changeset/olive-steaks-juggle.md
+++ b/.changeset/olive-steaks-juggle.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Detect incompatible Zod schemas when creating `co.map`s and `co.profile`s

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/zodCo.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/zodCo.ts
@@ -20,7 +20,9 @@ import {
   createCoreFileStreamSchema,
   hydrateCoreCoValueSchema,
   isAnyCoValueSchema,
+  isCoValueClass,
 } from "../../internal.js";
+import { removeGetters } from "../schemaUtils.js";
 import {
   CoDiscriminatedUnionSchema,
   DiscriminableCoValueSchemas,
@@ -34,14 +36,41 @@ import {
 } from "./schemaTypes/RichTextSchema.js";
 import { z } from "./zodReExport.js";
 
-export const coMapDefiner = <Shape extends z.core.$ZodLooseShape>(
-  shape: Shape,
-): CoMapSchema<Shape> => {
+/**
+ * Checking for the presence of the `_zod` property is the recommended way
+ * to determine if a schema is a Zod v4 schema.
+ *
+ * @see https://zod.dev/library-authors?id=how-to-support-zod-3-and-zod-4-simultaneously
+ */
+const isZodV4Schema = (schema: unknown): schema is z.core.$ZodType => {
+  return typeof schema === "object" && schema !== null && "_zod" in schema;
+};
+
+const isValidShape = (shape: z.core.$ZodLooseShape) => {
+  return Object.values(removeGetters(shape)).every(
+    (schema) =>
+      isZodV4Schema(schema) ||
+      isAnyCoValueSchema(schema) ||
+      isCoValueClass(schema),
+  );
+};
+
+const validateCoMapShape = (shape: z.core.$ZodLooseShape) => {
   if (isAnyCoValueSchema(shape as any)) {
     throw new Error(
       "co.map() expects an object as its argument, not a CoValue schema",
     );
+  } else if (!isValidShape(shape)) {
+    throw new Error(
+      "co.map() supports only Zod v4 schemas and CoValue schemas",
+    );
   }
+};
+
+export const coMapDefiner = <Shape extends z.core.$ZodLooseShape>(
+  shape: Shape,
+): CoMapSchema<Shape> => {
+  validateCoMapShape(shape);
   const coreSchema = createCoreCoMapSchema(shape);
   return hydrateCoreCoValueSchema(coreSchema);
 };
@@ -117,16 +146,24 @@ export const coListDefiner = <T extends AnyZodOrCoValueSchema>(
   return hydrateCoreCoValueSchema(coreSchema);
 };
 
+const validateProfileShape = (shape: z.core.$ZodLooseShape) => {
+  if (isAnyCoValueSchema(shape as any)) {
+    throw new Error(
+      "co.profile() expects an object as its argument, not a CoValue schema",
+    );
+  } else if (!isValidShape(shape)) {
+    throw new Error(
+      "co.profile() supports only Zod v4 schemas and CoValue schemas",
+    );
+  }
+};
+
 export const coProfileDefiner = <
   Shape extends z.core.$ZodLooseShape = Simplify<DefaultProfileShape>,
 >(
   shape: Shape & Partial<DefaultProfileShape> = {} as any,
 ): CoProfileSchema<Shape> => {
-  if (isAnyCoValueSchema(shape as any)) {
-    throw new Error(
-      "co.profile() expects an object as its argument, not a CoValue schema",
-    );
-  }
+  validateProfileShape(shape);
   const ehnancedShape = Object.assign(shape, {
     name: z.string(),
     inbox: z.optional(z.string()),

--- a/packages/jazz-tools/src/tools/tests/account.test.ts
+++ b/packages/jazz-tools/src/tools/tests/account.test.ts
@@ -1,4 +1,4 @@
-import { assert, beforeEach, expect, test } from "vitest";
+import { assert, beforeEach, describe, expect, test } from "vitest";
 import { Account, Group, co, z } from "../exports.js";
 import {
   createJazzTestAccount,
@@ -137,10 +137,20 @@ test("loading raw accounts should work", async () => {
   expect(loadedAccount.profile!.name).toBe("test 1");
 });
 
-test("co.profile() should throw an error if passed a CoValue schema", async () => {
-  expect(() => co.profile(co.map({}))).toThrow(
-    "co.profile() expects an object as its argument, not a CoValue schema",
-  );
+describe("co.profile() schema", () => {
+  test("co.profile() should throw an error if passed a CoValue schema", async () => {
+    expect(() => co.profile(co.map({}))).toThrow(
+      "co.profile() expects an object as its argument, not a CoValue schema",
+    );
+  });
+
+  test("co.profile() should throw an error if its shape does not contain valid schemas", () => {
+    expect(() =>
+      co.profile({
+        field: "a string is not a valid schema",
+      }),
+    ).toThrow("co.profile() supports only Zod v4 schemas and CoValue schemas");
+  });
 });
 
 test("should support recursive props on co.profile", async () => {

--- a/packages/jazz-tools/src/tools/tests/coMap.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coMap.test.ts
@@ -2375,6 +2375,14 @@ describe("co.map schema", () => {
       "co.map() expects an object as its argument, not a CoValue schema",
     );
   });
+
+  test("co.map() should throw an error if its shape does not contain valid schemas", () => {
+    expect(() =>
+      co.map({
+        field: "a string is not a valid schema",
+      }),
+    ).toThrow("co.map() supports only Zod v4 schemas and CoValue schemas");
+  });
 });
 
 describe("Updating a nested reference", () => {


### PR DESCRIPTION
# Description

Fixes https://github.com/garden-co/jazz/issues/2808.

Old Zod schemas are detected by the type checker in most cases, except when using `co.map` and `co.profile` (since they accept any record type in order to support recursive references). For those cases, we're adding runtime checks when creating CoMap and Profile schemas. The validation also fails if the shape contains any other type of invalid schema.

## Tests

- [x] Tests have been added and/or updated

## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [x] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing