### PR TITLE
Fixes GCO-803: sharding-aware reconciliation

### DIFF
--- a/.changeset/lucky-fans-repair.md
+++ b/.changeset/lucky-fans-repair.md
@@ -1,0 +1,5 @@
+---
+"cojson": patch
+---
+
+Allow adding server peers without reconciliation

--- a/packages/cojson/src/tests/testUtils.ts
+++ b/packages/cojson/src/tests/testUtils.ts
@@ -506,6 +506,7 @@ export function setupTestNode(
     ourName?: string;
     syncServer?: LocalNode;
     persistent?: boolean;
+    skipReconciliation?: boolean;
   }) {
     const { peer, peerStateOnServer, peerOnServer } =
       getSyncServerConnectedPeer({
@@ -516,7 +517,7 @@ export function setupTestNode(
         persistent: opts?.persistent,
       });
 
-    node.syncManager.addPeer(peer);
+    node.syncManager.addPeer(peer, opts?.skipReconciliation);
 
     return {
       peerState: node.syncManager.peers[peer.id]!,


### PR DESCRIPTION
# Description
This does two things:
1. Allows reconciliation to be skipped when adding peers.
2. Makes the reconciliation sharding-aware by only reconciling covalues that are relevant to the peer being reconciled.

(1) is necessary because relevance is determined based on the current peer set, so if we always reconciled when adding peers, the first peer would always be deemed relevant for every single covalue. Similar but different problem for subsequent peers: there would be a ton of covalue rebalancing as peers were added.

So, the following is the expected pattern when setting up a node with sharded server peers:
1. Determine the full set of peers upfront
2. Add them all without reconciliation
3. Reconcile them all

## Manual testing instructions

N/A

## Tests

- [x] Tests have been added and/or updated
- [ ] Tests have not been updated, because: <!-- Insert reason for not updating tests here -->
- [ ] I need help with writing tests


## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [x] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing