### PR TITLE
feat: add `CoMap.$jazz.has`

### DIFF
--- a/.changeset/nervous-rules-heal.md
+++ b/.changeset/nervous-rules-heal.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Add `CoMap.$jazz.has` method to check for property existance without loading referenced CoValues or checking permissions

--- a/packages/jazz-tools/src/tools/coValues/coMap.ts
+++ b/packages/jazz-tools/src/tools/coValues/coMap.ts
@@ -581,7 +581,8 @@ class CoMapJazzApi<M extends CoMap> extends CoValueJazzApi<M> {
    * @category Content
    */
   has(key: CoKeys<M>): boolean {
-    return this.raw.get(key) !== undefined;
+    const entry = this.raw.getRaw(key);
+    return entry?.change !== undefined && entry.change.op !== "del";
   }
 
   /**
@@ -1017,7 +1018,7 @@ const CoMapProxyHandler: ProxyHandler<CoMap> = {
     const descriptor = target.$jazz?.getDescriptor(key as string);
 
     if (target.$jazz?.raw && typeof key === "string" && descriptor) {
-      return target.$jazz.has(key as CoKeys<typeof target>);
+      return target.$jazz.raw.get(key) !== undefined;
     } else {
       return Reflect.has(target, key);
     }

--- a/packages/jazz-tools/src/tools/coValues/coMap.ts
+++ b/packages/jazz-tools/src/tools/coValues/coMap.ts
@@ -572,6 +572,19 @@ class CoMapJazzApi<M extends CoMap> extends CoValueJazzApi<M> {
   }
 
   /**
+   * Check if a key is defined in the CoMap.
+   *
+   * This check does not load the referenced value or validate permissions.
+   *
+   * @param key The key to check
+   * @returns True if the key is defined, false otherwise
+   * @category Content
+   */
+  has(key: CoKeys<M>): boolean {
+    return this.raw.get(key) !== undefined;
+  }
+
+  /**
    * Set a value on the CoMap
    *
    * @param key The key to set
@@ -1004,7 +1017,7 @@ const CoMapProxyHandler: ProxyHandler<CoMap> = {
     const descriptor = target.$jazz?.getDescriptor(key as string);
 
     if (target.$jazz?.raw && typeof key === "string" && descriptor) {
-      return target.$jazz.raw.get(key) !== undefined;
+      return target.$jazz.has(key as CoKeys<typeof target>);
     } else {
       return Reflect.has(target, key);
     }

--- a/packages/jazz-tools/src/tools/tests/coMap.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coMap.test.ts
@@ -744,6 +744,81 @@ describe("CoMap", async () => {
     });
   });
 
+  describe("has", () => {
+    test("should return true if the key is defined", () => {
+      const Person = co.map({
+        name: z.string(),
+        age: z.number().optional(),
+      });
+
+      const person = Person.create({ name: "John", age: 20 });
+
+      expect(person.$jazz.has("name")).toBe(true);
+      expect(person.$jazz.has("age")).toBe(true);
+    });
+
+    test("should return false if the key is not defined", () => {
+      const Person = co.map({
+        name: z.string(),
+        age: z.number().optional(),
+      });
+
+      const person = Person.create({ name: "John" });
+
+      expect(person.$jazz.has("age")).toBe(false);
+    });
+
+    test("should not load the referenced CoValue", async () => {
+      const Person = co.map({
+        name: co.plainText(),
+      });
+
+      const { clientAccount, serverAccount } = await setupTwoNodes();
+
+      const person = Person.create(
+        {
+          name: "John",
+        },
+        { owner: Group.create().makePublic() },
+      );
+
+      await person.$jazz.waitForSync({ timeout: 1000 });
+
+      const loadedPerson = await Person.load(person.$jazz.id, {
+        resolve: true,
+        loadAs: serverAccount,
+      });
+
+      assert(loadedPerson);
+      expect(loadedPerson.$jazz.has("name")).toBe(true);
+      expect(loadedPerson.name).toBeNull();
+    });
+
+    test("should return true even if the viewer doesn't have access to the referenced CoValue", async () => {
+      const Person = co.map({
+        name: co.plainText(),
+      });
+
+      const person = Person.create(
+        // UserB has no access to name
+        { name: co.plainText().create("John", Group.create()) },
+        // UserB has access to person
+        { owner: Group.create().makePublic() },
+      );
+
+      const userB = await createJazzTestAccount();
+
+      const loadedPerson = await Person.load(person.$jazz.id, {
+        resolve: true,
+        loadAs: userB,
+      });
+
+      assert(loadedPerson);
+      expect(loadedPerson.$jazz.has("name")).toBe(true);
+      expect(loadedPerson.name).toBeNull();
+    });
+  });
+
   test("Enum of maps", () => {
     const ChildA = co.map({
       type: z.literal("a"),

--- a/packages/jazz-tools/src/tools/tests/coMap.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coMap.test.ts
@@ -757,6 +757,19 @@ describe("CoMap", async () => {
       expect(person.$jazz.has("age")).toBe(true);
     });
 
+    test("should return true if the key was set to undefined", () => {
+      const Person = co.map({
+        name: z.string(),
+        age: z.number().optional(),
+      });
+
+      const person = Person.create({ name: "John" });
+
+      person.$jazz.set("age", undefined);
+
+      expect(person.$jazz.has("age")).toBe(true);
+    });
+
     test("should return false if the key is not defined", () => {
       const Person = co.map({
         name: z.string(),
@@ -764,6 +777,19 @@ describe("CoMap", async () => {
       });
 
       const person = Person.create({ name: "John" });
+
+      expect(person.$jazz.has("age")).toBe(false);
+    });
+
+    test("should return false if the key was deleted", () => {
+      const Person = co.map({
+        name: z.string(),
+        age: z.number().optional(),
+      });
+
+      const person = Person.create({ name: "John", age: 20 });
+
+      person.$jazz.delete("age");
 
       expect(person.$jazz.has("age")).toBe(false);
     });
@@ -779,14 +805,12 @@ describe("CoMap", async () => {
         {
           name: "John",
         },
-        { owner: Group.create(clientAccount).makePublic() },
+        { owner: Group.create(serverAccount).makePublic() },
       );
-
-      await person.$jazz.waitForSync({ timeout: 1000 });
 
       const loadedPerson = await Person.load(person.$jazz.id, {
         resolve: true,
-        loadAs: serverAccount,
+        loadAs: clientAccount,
       });
 
       assert(loadedPerson);

--- a/packages/jazz-tools/src/tools/tests/coMap.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coMap.test.ts
@@ -779,7 +779,7 @@ describe("CoMap", async () => {
         {
           name: "John",
         },
-        { owner: Group.create().makePublic() },
+        { owner: Group.create(clientAccount).makePublic() },
       );
 
       await person.$jazz.waitForSync({ timeout: 1000 });


### PR DESCRIPTION
# Description

Related to https://github.com/garden-co/jazz/pull/2829.

`CoMap.$jazz.has` allows to check for property existence without loading referenced CoValues or checking permissions.

## Tests

- [x] Tests have been added and/or updated

## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [x] I've generated a changeset, if a version bump is required
- [x] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing