### PR TITLE
feat: remove CoMapSchema.catchall

### DIFF
--- a/examples/chat-svelte/src/lib/components/BubbleImage.svelte
+++ b/examples/chat-svelte/src/lib/components/BubbleImage.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
-  import { ImageDefinition, type Loaded } from 'jazz-tools';
+  import { type ImageDefinition } from 'jazz-tools';
   import { Image } from 'jazz-tools/svelte';
-  let { image }: { image: Loaded<typeof ImageDefinition> } = $props();
+  let { image }: { image: ImageDefinition } = $props();
 </script>
 
 <Image
-  imageId={image.id}
+  imageId={image.$jazz.id}
   alt=""
   class="h-auto max-h-[20rem] max-w-full rounded-t-xl mb-1"
 />

--- a/examples/chat/src/ui.tsx
+++ b/examples/chat/src/ui.tsx
@@ -1,5 +1,5 @@
 import clsx from "clsx";
-import { CoPlainText, ImageDefinition } from "jazz-tools";
+import { CoPlainText, ImageDefinition, Loaded } from "jazz-tools";
 import { Image } from "jazz-tools/react";
 import { ImageIcon } from "lucide-react";
 import { useId, useRef } from "react";
@@ -81,7 +81,7 @@ export function BubbleText(props: {
   );
 }
 
-export function BubbleImage(props: { image: ImageDefinition }) {
+export function BubbleImage(props: { image: Loaded<typeof ImageDefinition> }) {
   return (
     <Image
       imageId={props.image.$jazz.id}

--- a/examples/image-upload/src/ProfileImageImperative.tsx
+++ b/examples/image-upload/src/ProfileImageImperative.tsx
@@ -33,16 +33,19 @@ export default function ProfileImageImperative() {
     // });
 
     // keep it synced and return the best _loaded_ image for the given size
-    const unsub = me.profile.image.$jazz.subscribe({}, (image) => {
-      const bestImage = highestResAvailable(image, 1024, 1024);
-      console.info(bestImage ? "Blob is ready" : "Blob is not ready");
-      if (bestImage) {
-        const blob = bestImage.image.toBlob();
-        if (blob) {
-          setImage(URL.createObjectURL(blob));
+    const unsub = me.profile.image.$jazz.subscribe(
+      { resolve: { resolutions: true } },
+      (image) => {
+        const bestImage = highestResAvailable(image, 1024, 1024);
+        console.info(bestImage ? "Blob is ready" : "Blob is not ready");
+        if (bestImage) {
+          const blob = bestImage.image.toBlob();
+          if (blob) {
+            setImage(URL.createObjectURL(blob));
+          }
         }
-      }
-    });
+      },
+    );
 
     return () => {
       unsub();

--- a/homepage/design-system/src/app/covalues/page.tsx
+++ b/homepage/design-system/src/app/covalues/page.tsx
@@ -37,10 +37,10 @@ export default function Playground() {
 
   const examplePersonFeed = useMemo(() => {
     const feed = PersonFeed.create([]);
-    feed.push(Person.create({ name: "John", age: 5 }));
-    feed.push(Person.create({ name: "John", age: 10 }));
-    feed.push(Person.create({ name: "John", age: 15 }));
-    feed.push(Person.create({ name: "John", age: 20 }));
+    feed.$jazz.push(Person.create({ name: "John", age: 5 }));
+    feed.$jazz.push(Person.create({ name: "John", age: 10 }));
+    feed.$jazz.push(Person.create({ name: "John", age: 15 }));
+    feed.$jazz.push(Person.create({ name: "John", age: 20 }));
     return feed;
   }, []);
 

--- a/homepage/design-system/src/components/atoms/covalues/CoFeeds.tsx
+++ b/homepage/design-system/src/components/atoms/covalues/CoFeeds.tsx
@@ -22,7 +22,9 @@ export function CoFeedVisualizer<T extends CoFeed>({
     <div className="flex justify-center p-4">
       <div className="bg-white rounded-lg p-6 min-w-[200px] shadow-md">
         {showMetadata && (
-          <div className="text-stone-500 text-xs mb-4">coId: {instance.id}</div>
+          <div className="text-stone-500 text-xs mb-4">
+            coId: {instance.$jazz.id}
+          </div>
         )}
 
         {showAllEntries ? (

--- a/homepage/design-system/src/components/atoms/covalues/CoList.tsx
+++ b/homepage/design-system/src/components/atoms/covalues/CoList.tsx
@@ -18,7 +18,9 @@ export function CoListVisualizer<T extends CoList>({
     <div className="flex justify-center p-4">
       <div className="bg-white rounded-lg p-6 min-w-[200px] shadow-md">
         {showMetadata && (
-          <div className="text-stone-500 text-xs mb-4">coId: {instance.id}</div>
+          <div className="text-stone-500 text-xs mb-4">
+            coId: {instance.$jazz.id}
+          </div>
         )}
         <div className="flex flex-row gap-4 overflow-x-auto">
           {instance.map((coMap, index) => (

--- a/homepage/design-system/src/components/atoms/covalues/CoMap.tsx
+++ b/homepage/design-system/src/components/atoms/covalues/CoMap.tsx
@@ -15,7 +15,9 @@ export function CoMapVisualizer<T extends CoMap>({
     <div className="flex justify-center">
       <div className="bg-black rounded p-2 min-w-[16px] min-h-[32px] shadow-md">
         {showMetadata && (
-          <div className="text-white/50 text-xs mb-1">coId: {instance.id}</div>
+          <div className="text-white/50 text-xs mb-1">
+            coId: {instance.$jazz.id}
+          </div>
         )}
         {showData && (
           <ul className="list-none p-0 m-0">

--- a/homepage/homepage/content/docs/using-covalues/imagedef.mdx
+++ b/homepage/homepage/content/docs/using-covalues/imagedef.mdx
@@ -44,7 +44,6 @@ async function handleFileUpload(event: React.ChangeEvent<HTMLInputElement>) {
       maxSize: 1024,
       placeholder: "blur",
       progressive: true,
-      resolutions: {},
     });
 
     // Store the image in your application data

--- a/homepage/homepage/content/docs/using-covalues/imagedef.mdx
+++ b/homepage/homepage/content/docs/using-covalues/imagedef.mdx
@@ -44,6 +44,7 @@ async function handleFileUpload(event: React.ChangeEvent<HTMLInputElement>) {
       maxSize: 1024,
       placeholder: "blur",
       progressive: true,
+      resolutions: {},
     });
 
     // Store the image in your application data
@@ -145,6 +146,7 @@ import { ImageDefinition } from "jazz-tools";
 
 const image = await ImageDefinition.load("123", {
   resolve: {
+    resolutions: true,
     original: true,
   },
 });
@@ -211,7 +213,9 @@ import { ImageDefinition } from "jazz-tools";
 // function highestResAvailable(image: ImageDefinition, wantedWidth: number, wantedHeight: number): FileStream | null
 import { highestResAvailable } from "jazz-tools/media";
 
-const image = await ImageDefinition.load(imageId);
+const image = await ImageDefinition.load(imageId, {
+  resolve: { resolutions: true },
+});
 
 if(image === null) {
   throw new Error("Image not found");

--- a/homepage/homepage/content/docs/using-covalues/imagedef/react-native-expo.mdx
+++ b/homepage/homepage/content/docs/using-covalues/imagedef/react-native-expo.mdx
@@ -246,6 +246,7 @@ import { ImageDefinition } from "jazz-tools";
 
 const image = await ImageDefinition.load("123", {
   resolve: {
+    resolutions: true,
     original: true,
   },
 });
@@ -312,7 +313,9 @@ import { ImageDefinition } from "jazz-tools";
 // function highestResAvailable(image: ImageDefinition, wantedWidth: number, wantedHeight: number): FileStream | null
 import { highestResAvailable } from "jazz-tools/media";
 
-const image = await ImageDefinition.load("123");
+const image = await ImageDefinition.load("123", {
+  resolve: { resolutions: true },
+});
 
 image?.$jazz.subscribe({}, (image) => {
   const bestImage = highestResAvailable(image, 600, 600);

--- a/homepage/homepage/content/docs/using-covalues/imagedef/react-native.mdx
+++ b/homepage/homepage/content/docs/using-covalues/imagedef/react-native.mdx
@@ -246,6 +246,7 @@ import { ImageDefinition } from "jazz-tools";
 
 const image = await ImageDefinition.load("123", {
   resolve: {
+    resolutions: true,
     original: true,
   },
 });
@@ -312,7 +313,10 @@ import { ImageDefinition } from "jazz-tools";
 // function highestResAvailable(image: ImageDefinition, wantedWidth: number, wantedHeight: number): FileStream | null
 import { highestResAvailable } from "jazz-tools/media";
 
-const image = await ImageDefinition.load("123");
+const image = await ImageDefinition.load(
+  "123",
+  { resolve: { resolutions: true } },
+);
 
 image?.$jazz.subscribe({}, (image) => {
   const bestImage = highestResAvailable(image, 600, 600);

--- a/homepage/homepage/content/docs/using-covalues/imagedef/svelte.mdx
+++ b/homepage/homepage/content/docs/using-covalues/imagedef/svelte.mdx
@@ -44,6 +44,7 @@ async function handleFileUpload(event: React.ChangeEvent<HTMLInputElement>) {
       maxSize: 1024,
       placeholder: "blur",
       progressive: true,
+      resolutions: {},
     });
 
     // Store the image in your application data
@@ -219,6 +220,7 @@ import { ImageDefinition } from "jazz-tools";
 
 const image = await ImageDefinition.load("123", {
   resolve: {
+    resolutions: true,
     original: true,
   },
 });
@@ -285,7 +287,7 @@ import { ImageDefinition } from "jazz-tools";
 // function highestResAvailable(image: ImageDefinition, wantedWidth: number, wantedHeight: number): FileStream | null
 import { highestResAvailable } from "jazz-tools/media";
 
-const image = await ImageDefinition.load("123");
+const image = await ImageDefinition.load("123", { resolve: { resolutions: true } });
 
 image?.$jazz.subscribe({}, (image) => {
   const bestImage = highestResAvailable(image, 600, 600);

--- a/homepage/homepage/content/docs/using-covalues/imagedef/svelte.mdx
+++ b/homepage/homepage/content/docs/using-covalues/imagedef/svelte.mdx
@@ -44,7 +44,6 @@ async function handleFileUpload(event: React.ChangeEvent<HTMLInputElement>) {
       maxSize: 1024,
       placeholder: "blur",
       progressive: true,
-      resolutions: {},
     });
 
     // Store the image in your application data

--- a/packages/community-jazz-vue/src/Image.vue
+++ b/packages/community-jazz-vue/src/Image.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ImageDefinition } from "jazz-tools";
+import { ImageDefinition, Loaded } from "jazz-tools";
 import { highestResAvailable } from "jazz-tools/media";
 import { onUnmounted, ref, watch, computed } from "vue";
 import { useCoState } from "./composables.js";
@@ -31,7 +31,9 @@ const props = withDefaults(defineProps<ImageProps>(), {
   loading: "eager",
 });
 
-const image = useCoState(ImageDefinition, props.imageId, {});
+const image = useCoState(ImageDefinition, props.imageId, {
+  resolve: { resolutions: true },
+});
 let lastBestImage: [string, string] | null = null;
 
 /**
@@ -89,7 +91,7 @@ const src = computed(() => {
   if (!image.value) return undefined;
 
   const bestImage = highestResAvailable(
-    image.value,
+    image.value as Loaded<typeof ImageDefinition, { resolutions: true }>,
     dimensions.value.width || dimensions.value.height || 9999,
     dimensions.value.height || dimensions.value.width || 9999,
   );

--- a/packages/jazz-tools/src/media/create-image.test.ts
+++ b/packages/jazz-tools/src/media/create-image.test.ts
@@ -44,8 +44,8 @@ describe("createImage", async () => {
     expect(image.placeholderDataURL).not.toBeDefined();
     expect(image.progressive).toBe(false);
     expect(image.original).toBeDefined();
-    expect(image[`1x1`]).toBeDefined();
-    expect(image[`1x1`]).toStrictEqual(image.original);
+    expect(image.resolutions[`1x1`]).toBeDefined();
+    expect(image.resolutions[`1x1`]).toStrictEqual(image.original);
   });
 
   it("should create the image with original and placeholder", async () => {
@@ -95,7 +95,7 @@ describe("createImage", async () => {
     expect(image.placeholderDataURL).not.toBeDefined();
     expect(image.progressive).toBe(false);
     expect(image.original).toBeDefined();
-    expect(image[`256x53`]).toStrictEqual(image.original);
+    expect(image.resolutions[`256x53`]).toStrictEqual(image.original);
 
     expect(resize).toHaveBeenCalledWith(imageBlob, 256, 53);
   });
@@ -121,7 +121,7 @@ describe("createImage", async () => {
     expect(image.placeholderDataURL).not.toBeDefined();
     expect(image.progressive).toBe(false);
     expect(image.original).toBeDefined();
-    expect(image[`1x1`]).toStrictEqual(image.original);
+    expect(image.resolutions[`1x1`]).toStrictEqual(image.original);
 
     expect(resize).not.toHaveBeenCalled();
   });
@@ -145,9 +145,9 @@ describe("createImage", async () => {
     expect(image.originalSize).toEqual([1920, 400]);
     expect(image.placeholderDataURL).not.toBeDefined();
 
-    expect(image[`256x53`]).toBeDefined();
-    expect(image[`1024x213`]).toBeDefined();
-    expect(image[`2048x427`]).not.toBeDefined();
+    expect(image.resolutions[`256x53`]).toBeDefined();
+    expect(image.resolutions[`1024x213`]).toBeDefined();
+    expect(image.resolutions[`2048x427`]).not.toBeDefined();
 
     expect(resize).toHaveBeenCalledWith(imageBlob, 256, 53);
     expect(resize).toHaveBeenCalledWith(imageBlob, 1024, 213);
@@ -174,9 +174,9 @@ describe("createImage", async () => {
 
     expect(image.originalSize).toEqual([256, 53]);
     expect(image.placeholderDataURL).not.toBeDefined();
-    expect(image[`256x53`]).toBeDefined();
-    expect(image[`1024x213`]).not.toBeDefined();
-    expect(image[`2048x427`]).not.toBeDefined();
+    expect(image.resolutions[`256x53`]).toBeDefined();
+    expect(image.resolutions[`1024x213`]).not.toBeDefined();
+    expect(image.resolutions[`2048x427`]).not.toBeDefined();
 
     expect(resize).toHaveBeenCalledWith(imageBlob, 256, 53);
     expect(resize).not.toHaveBeenCalledWith(imageBlob, 1024, 213);

--- a/packages/jazz-tools/src/media/create-image.ts
+++ b/packages/jazz-tools/src/media/create-image.ts
@@ -60,7 +60,7 @@ async function createImage(
   imageBlobOrFile: SourceType,
   options: CreateImageOptions,
   impl: CreateImageImpl,
-): Promise<Loaded<typeof ImageDefinition, { $each: true }>> {
+): Promise<Loaded<typeof ImageDefinition, { resolutions: { $each: true } }>> {
   // Get the original size of the image
   const { width: originalWidth, height: originalHeight } =
     await impl.getImageSize(imageBlobOrFile);
@@ -124,7 +124,7 @@ async function createImage(
       progressive: def.progressive,
       placeholderDataURL: def.placeholderDataURL,
       original: def.original,
-      ...def.files,
+      resolutions: { ...def.files },
     },
     options?.owner,
   );
@@ -153,7 +153,7 @@ async function createImage(
       );
 
       const blob = await impl.resize(imageBlobOrFile, width, height);
-      imageCoValue.$jazz.set(
+      imageCoValue.resolutions.$jazz.set(
         `${width}x${height}`,
         await impl.createFileStreamFromSource(blob, options?.owner),
       );

--- a/packages/jazz-tools/src/media/utils.test.ts
+++ b/packages/jazz-tools/src/media/utils.test.ts
@@ -34,11 +34,12 @@ describe("highestResAvailable", async () => {
         originalSize: [1920, 1080],
         progressive: false,
         original,
+        resolutions: {},
       },
       { owner: account.$jazz.owner },
     );
 
-    imageDef.$jazz.set("1920x1080", original);
+    imageDef.resolutions.$jazz.set("1920x1080", original);
 
     const result = highestResAvailable(imageDef, 256, 256);
     expect(result?.image.$jazz.id).toBe(original.$jazz.id);
@@ -51,11 +52,12 @@ describe("highestResAvailable", async () => {
         originalSize: [1920, 1080],
         progressive: true,
         original,
+        resolutions: {},
       },
       { owner: account.$jazz.owner },
     );
 
-    imageDef.$jazz.set("1920x1080", original);
+    imageDef.resolutions.$jazz.set("1920x1080", original);
 
     const result = highestResAvailable(imageDef, 256, 256);
     expect(result?.image.$jazz.id).toBe(original.$jazz.id);
@@ -69,12 +71,13 @@ describe("highestResAvailable", async () => {
         originalSize: [1920, 1080],
         progressive: true,
         original,
+        resolutions: {},
       },
       { owner: account.$jazz.owner },
     );
 
-    imageDef.$jazz.set("1920x1080", original);
-    imageDef.$jazz.set("256x256", resize256);
+    imageDef.resolutions.$jazz.set("1920x1080", original);
+    imageDef.resolutions.$jazz.set("256x256", resize256);
 
     const result = highestResAvailable(imageDef, 256, 256);
     expect(result?.image.$jazz.id).toBe(resize256.$jazz.id);
@@ -87,11 +90,12 @@ describe("highestResAvailable", async () => {
         originalSize: [1024, 1024],
         progressive: true,
         original,
+        resolutions: {},
       },
       { owner: account.$jazz.owner },
     );
 
-    imageDef.$jazz.set("1024x1024", original);
+    imageDef.resolutions.$jazz.set("1024x1024", original);
 
     const result = highestResAvailable(imageDef, 1024, 1024);
     expect(result?.image.$jazz.id).toBe(original.$jazz.id);
@@ -107,13 +111,14 @@ describe("highestResAvailable", async () => {
         originalSize: [2048, 2048],
         progressive: true,
         original,
+        resolutions: {},
       },
       { owner: account.$jazz.owner },
     );
 
-    imageDef.$jazz.set("256x256", resize256);
-    imageDef.$jazz.set("1024x1024", resize1024);
-    imageDef.$jazz.set("2048x2048", resize2048);
+    imageDef.resolutions.$jazz.set("256x256", resize256);
+    imageDef.resolutions.$jazz.set("1024x1024", resize1024);
+    imageDef.resolutions.$jazz.set("2048x2048", resize2048);
 
     // Closest to 900x900 is 1024
     const result = highestResAvailable(imageDef, 900, 900);
@@ -134,12 +139,13 @@ describe("highestResAvailable", async () => {
         originalSize: [2048, 2048],
         progressive: true,
         original,
+        resolutions: {},
       },
       { owner: account.$jazz.owner },
     );
-    imageDef.$jazz.set("256x256", resize256);
-    imageDef.$jazz.set("1024x1024", resize1024);
-    imageDef.$jazz.set("2048x2048", resize2048);
+    imageDef.resolutions.$jazz.set("256x256", resize256);
+    imageDef.resolutions.$jazz.set("1024x1024", resize1024);
+    imageDef.resolutions.$jazz.set("2048x2048", resize2048);
 
     // Closest to 900x900 is 1024
     const result = highestResAvailable(imageDef, 900, 900);
@@ -153,16 +159,17 @@ describe("highestResAvailable", async () => {
         originalSize: [256, 256],
         progressive: true,
         original,
+        resolutions: {},
       },
       { owner: account.$jazz.owner },
     );
 
-    imageDef.$jazz.set("256x256", original);
+    imageDef.resolutions.$jazz.set("256x256", original);
     // 1024 is not loaded yet
     const resize1024 = FileStream.create({ owner: account.$jazz.owner });
     resize1024.start({ mimeType: "image/jpeg" });
     // Don't end resize1024, so it has no chunks
-    imageDef.$jazz.set("1024x1024", resize1024);
+    imageDef.resolutions.$jazz.set("1024x1024", resize1024);
 
     const result = highestResAvailable(imageDef, 1024, 1024);
     // Only original is valid
@@ -179,18 +186,21 @@ describe("highestResAvailable", async () => {
         originalSize: [300, 300],
         progressive: true,
         original,
+        resolutions: {},
       },
       { owner: account.$jazz.owner },
     );
 
-    imageDef.$jazz.set(
+    imageDef.resolutions.$jazz.set(
       "256x256",
       await createFileStream(account.$jazz.owner, 1),
     );
 
     const result = highestResAvailable(imageDef, 1024, 1024);
     // Only original is valid
-    expect(result?.image.$jazz.id).toBe(imageDef["256x256"]!.$jazz.id);
+    expect(result?.image.$jazz.id).toBe(
+      imageDef.resolutions["256x256"]!.$jazz.id,
+    );
   });
 
   it("returns the highest resolution if no good match is found", async () => {
@@ -201,15 +211,16 @@ describe("highestResAvailable", async () => {
         originalSize: [300, 300],
         progressive: true,
         original,
+        resolutions: {},
       },
       { owner: account.$jazz.owner },
     );
 
-    imageDef.$jazz.set(
+    imageDef.resolutions.$jazz.set(
       "256x256",
       await createFileStream(account.$jazz.owner, 1),
     );
-    imageDef.$jazz.set("300x300", original);
+    imageDef.resolutions.$jazz.set("300x300", original);
 
     const result = highestResAvailable(imageDef, 1024, 1024);
     expect(result?.image.$jazz.id).toBe(original.$jazz.id);
@@ -240,15 +251,22 @@ describe("loadImageBySize", async () => {
         originalSize,
         progressive,
         original,
+        resolutions: {},
       },
       { owner },
     );
-    imageDef.$jazz.set(`${originalSize[0]}x${originalSize[1]}`, original);
+    imageDef.resolutions.$jazz.set(
+      `${originalSize[0]}x${originalSize[1]}`,
+      original,
+    );
 
     for (const size of sizes) {
       if (!size) continue;
       const [w, h] = size;
-      imageDef.$jazz.set(`${w}x${h}`, await createFileStream(owner, 1));
+      imageDef.resolutions.$jazz.set(
+        `${w}x${h}`,
+        await createFileStream(owner, 1),
+      );
     }
     return imageDef;
   };
@@ -256,7 +274,9 @@ describe("loadImageBySize", async () => {
   it("returns original if progressive is false", async () => {
     const imageDef = await createImageDef([[1920, 1080]], false);
     const result = await loadImageBySize(imageDef, 256, 256);
-    expect(result?.image.$jazz.id).toBe(imageDef["1920x1080"]!.$jazz.id);
+    expect(result?.image.$jazz.id).toBe(
+      imageDef.resolutions["1920x1080"]!.$jazz.id,
+    );
   });
 
   it("returns the original image already loaded", async () => {
@@ -272,7 +292,9 @@ describe("loadImageBySize", async () => {
     setActiveAccount(account2);
 
     const result = await loadImageBySize(imageDef, 256, 256);
-    expect(result?.image.$jazz.id).toBe(imageDef["1920x1080"]!.$jazz.id);
+    expect(result?.image.$jazz.id).toBe(
+      imageDef.resolutions["1920x1080"]!.$jazz.id,
+    );
     expect(result?.image.isBinaryStreamEnded()).toBe(true);
     expect(result?.image.asBase64()).toStrictEqual(expect.any(String));
   });
@@ -284,6 +306,7 @@ describe("loadImageBySize", async () => {
         originalSize: [1920, 1080],
         progressive: true,
         original,
+        resolutions: {},
       },
       { owner: account.$jazz.owner },
     );
@@ -297,7 +320,9 @@ describe("loadImageBySize", async () => {
       [1920, 1080],
     ]);
     const result = await loadImageBySize(imageDef.$jazz.id, 256, 256);
-    expect(result?.image.$jazz.id).toBe(imageDef["256x256"]!.$jazz.id);
+    expect(result?.image.$jazz.id).toBe(
+      imageDef.resolutions["256x256"]!.$jazz.id,
+    );
     expect(result?.width).toBe(256);
     expect(result?.height).toBe(256);
   });
@@ -309,7 +334,9 @@ describe("loadImageBySize", async () => {
       [2048, 2048],
     ]);
     const result = await loadImageBySize(imageDef, 900, 900);
-    expect(result?.image.$jazz.id).toBe(imageDef["1024x1024"]!.$jazz.id);
+    expect(result?.image.$jazz.id).toBe(
+      imageDef.resolutions["1024x1024"]!.$jazz.id,
+    );
     expect(result?.width).toBe(1024);
     expect(result?.height).toBe(1024);
   });
@@ -320,7 +347,9 @@ describe("loadImageBySize", async () => {
       [300, 300],
     ]);
     const result = await loadImageBySize(imageDef, 1024, 1024);
-    expect(result?.image.$jazz.id).toBe(imageDef["300x300"]!.$jazz.id);
+    expect(result?.image.$jazz.id).toBe(
+      imageDef.resolutions["300x300"]!.$jazz.id,
+    );
     expect(result?.width).toBe(300);
     expect(result?.height).toBe(300);
   });
@@ -332,6 +361,7 @@ describe("loadImageBySize", async () => {
         originalSize: [256, 256],
         progressive: true,
         original,
+        resolutions: {},
       },
       { owner: account.$jazz.owner },
     );
@@ -346,7 +376,9 @@ describe("loadImageBySize", async () => {
       [1024, 1024],
     ]);
     const result = await loadImageBySize(imageDef, 1024, 1024);
-    expect(result?.image.$jazz.id).toBe(imageDef["1024x1024"]!.$jazz.id);
+    expect(result?.image.$jazz.id).toBe(
+      imageDef.resolutions["1024x1024"]!.$jazz.id,
+    );
     expect(result?.width).toBe(1024);
     expect(result?.height).toBe(1024);
   });
@@ -373,7 +405,9 @@ describe("loadImageBySize", async () => {
 
     const result = await loadImageBySize(imageDef.$jazz.id, 1024, 1024);
     expect(result).not.toBeNull();
-    expect(result?.image.$jazz.id).toBe(imageDef["1024x1024"]!.$jazz.id);
+    expect(result?.image.$jazz.id).toBe(
+      imageDef.resolutions["1024x1024"]!.$jazz.id,
+    );
     expect(result?.image.isBinaryStreamEnded()).toBe(true);
     expect(result?.image.asBase64()).toStrictEqual(expect.any(String));
   });

--- a/packages/jazz-tools/src/react-native-core/media/image.tsx
+++ b/packages/jazz-tools/src/react-native-core/media/image.tsx
@@ -68,7 +68,9 @@ export const Image = forwardRef<RNImage, ImageProps>(function Image(
   { imageId, width, height, ...props },
   ref,
 ) {
-  const image = useCoState(ImageDefinition, imageId);
+  const image = useCoState(ImageDefinition, imageId, {
+    resolve: { resolutions: true },
+  });
   const [src, setSrc] = useState<string | undefined>(image?.placeholderDataURL);
 
   const dimensions: { width: number | undefined; height: number | undefined } =
@@ -116,29 +118,32 @@ export const Image = forwardRef<RNImage, ImageProps>(function Image(
     let lastBestImage: FileStream | string | undefined =
       image.placeholderDataURL;
 
-    const unsub = image.$jazz.subscribe({}, (update) => {
-      if (lastBestImage === undefined && update.placeholderDataURL) {
-        setSrc(update.placeholderDataURL);
-        lastBestImage = update.placeholderDataURL;
-      }
+    const unsub = image.$jazz.subscribe(
+      { resolve: { resolutions: true } },
+      (update) => {
+        if (lastBestImage === undefined && update.placeholderDataURL) {
+          setSrc(update.placeholderDataURL);
+          lastBestImage = update.placeholderDataURL;
+        }
 
-      const bestImage = highestResAvailable(
-        update,
-        dimensions.width || dimensions.height || 9999,
-        dimensions.height || dimensions.width || 9999,
-      );
+        const bestImage = highestResAvailable(
+          update,
+          dimensions.width || dimensions.height || 9999,
+          dimensions.height || dimensions.width || 9999,
+        );
 
-      if (!bestImage) return;
+        if (!bestImage) return;
 
-      if (lastBestImage === bestImage.image) return;
+        if (lastBestImage === bestImage.image) return;
 
-      const url = bestImage.image.asBase64({ dataURL: true });
+        const url = bestImage.image.asBase64({ dataURL: true });
 
-      if (url) {
-        setSrc(url);
-        lastBestImage = bestImage.image;
-      }
-    });
+        if (url) {
+          setSrc(url);
+          lastBestImage = bestImage.image;
+        }
+      },
+    );
 
     return unsub;
   }, [image]);

--- a/packages/jazz-tools/src/react/media/image.tsx
+++ b/packages/jazz-tools/src/react/media/image.tsx
@@ -78,7 +78,9 @@ export const Image = forwardRef<HTMLImageElement, ImageProps>(function Image(
   { imageId, width, height, ...props },
   ref,
 ) {
-  const image = useCoState(ImageDefinition, imageId);
+  const image = useCoState(ImageDefinition, imageId, {
+    resolve: { resolutions: true },
+  });
   const lastBestImage = useRef<[string, string] | null>(null);
 
   /**

--- a/packages/jazz-tools/src/react/tests/media/image.test.tsx
+++ b/packages/jazz-tools/src/react/tests/media/image.test.tsx
@@ -36,6 +36,7 @@ describe("Image", async () => {
           original,
           originalSize: [100, 100],
           progressive: false,
+          resolutions: {},
         },
         {
           owner: account,
@@ -68,6 +69,7 @@ describe("Image", async () => {
           originalSize: [100, 100],
           progressive: false,
           placeholderDataURL: placeholderDataUrl,
+          resolutions: {},
         },
         {
           owner: account,
@@ -98,6 +100,7 @@ describe("Image", async () => {
           original: await createDummyFileStream(100, account),
           originalSize: [100, 100],
           progressive: false,
+          resolutions: {},
         },
         {
           owner: account,
@@ -123,6 +126,7 @@ describe("Image", async () => {
           original: await createDummyFileStream(100, account),
           originalSize: [100, 100],
           progressive: false,
+          resolutions: {},
         },
         {
           owner: account,
@@ -145,6 +149,7 @@ describe("Image", async () => {
           original: await createDummyFileStream(100, account),
           originalSize: [100, 100],
           progressive: false,
+          resolutions: {},
         },
         {
           owner: account,
@@ -175,6 +180,7 @@ describe("Image", async () => {
           original: await createDummyFileStream(100, account),
           originalSize: [100, 100],
           progressive: false,
+          resolutions: {},
         },
         {
           owner: account,
@@ -205,6 +211,7 @@ describe("Image", async () => {
           original: await createDummyFileStream(100, account),
           originalSize: [100, 100],
           progressive: false,
+          resolutions: {},
         },
         {
           owner: account,
@@ -228,6 +235,7 @@ describe("Image", async () => {
           original: await createDummyFileStream(100, account),
           originalSize: [100, 100],
           progressive: false,
+          resolutions: {},
         },
         {
           owner: account,
@@ -251,6 +259,7 @@ describe("Image", async () => {
           original: await createDummyFileStream(100, account),
           originalSize: [100, 100],
           progressive: false,
+          resolutions: {},
         },
         {
           owner: account,
@@ -286,14 +295,18 @@ describe("Image", async () => {
           original,
           originalSize: [500, 500],
           progressive: true,
+          resolutions: {},
         },
         {
           owner: account,
         },
       );
 
-      im.$jazz.set("500x500", original);
-      im.$jazz.set("256x256", await createDummyFileStream(256, account));
+      im.resolutions.$jazz.set("500x500", original);
+      im.resolutions.$jazz.set(
+        "256x256",
+        await createDummyFileStream(256, account),
+      );
 
       const { container } = render(
         <Image imageId={im.$jazz.id} alt="test-progressive" width={300} />,
@@ -326,14 +339,18 @@ describe("Image", async () => {
           original,
           originalSize: [1920, 1080],
           progressive: true,
+          resolutions: {},
         },
         {
           owner: account,
         },
       );
 
-      im.$jazz.set("1920x1080", original);
-      im.$jazz.set("256x256", await createDummyFileStream(256, account));
+      im.resolutions.$jazz.set("1920x1080", original);
+      im.resolutions.$jazz.set(
+        "256x256",
+        await createDummyFileStream(256, account),
+      );
 
       const { container } = render(
         <Image imageId={im.$jazz.id} alt="test-progressive" width={1024} />,
@@ -349,7 +366,10 @@ describe("Image", async () => {
       expect(createObjectURLSpy).toHaveBeenCalledTimes(1);
 
       // Load higher resolution image
-      im.$jazz.set("1024x1024", await createDummyFileStream(1024, account));
+      im.resolutions.$jazz.set(
+        "1024x1024",
+        await createDummyFileStream(1024, account),
+      );
 
       await waitFor(() => {
         expect((container.querySelector("img") as HTMLImageElement).src).toBe(
@@ -379,15 +399,22 @@ describe("Image", async () => {
           original,
           originalSize: [100, 100],
           progressive: true,
+          resolutions: {},
         },
         {
           owner: account,
         },
       );
 
-      im.$jazz.set("100x100", original);
-      im.$jazz.set("256x256", await createDummyFileStream(256, account));
-      im.$jazz.set("1024x1024", await createDummyFileStream(1024, account));
+      im.resolutions.$jazz.set("100x100", original);
+      im.resolutions.$jazz.set(
+        "256x256",
+        await createDummyFileStream(256, account),
+      );
+      im.resolutions.$jazz.set(
+        "1024x1024",
+        await createDummyFileStream(1024, account),
+      );
 
       const { container } = render(
         <Image imageId={im.$jazz.id} alt="test-progressive" width={256} />,
@@ -419,14 +446,18 @@ describe("Image", async () => {
           original,
           originalSize: [100, 100],
           progressive: true,
+          resolutions: {},
         },
         {
           owner: account,
         },
       );
 
-      im.$jazz.set("100x100", original);
-      im.$jazz.set("256x256", await createDummyFileStream(256, account));
+      im.resolutions.$jazz.set("100x100", original);
+      im.resolutions.$jazz.set(
+        "256x256",
+        await createDummyFileStream(256, account),
+      );
 
       const { container } = render(
         <Image imageId={im.$jazz.id} alt="test-progressive" width={100} />,
@@ -458,13 +489,17 @@ describe("Image", async () => {
           original,
           originalSize: [256, 256],
           progressive: true,
+          resolutions: {},
         },
         {
           owner: account,
         },
       );
-      im.$jazz.set("256x256", original);
-      im.$jazz.set("1024x1024", await createDummyFileStream(1024, account));
+      im.resolutions.$jazz.set("256x256", original);
+      im.resolutions.$jazz.set(
+        "1024x1024",
+        await createDummyFileStream(1024, account),
+      );
 
       const { container, rerender } = render(
         <Image
@@ -510,6 +545,7 @@ describe("Image", async () => {
           original: await createDummyFileStream(100, account),
           originalSize: [100, 100],
           progressive: false,
+          resolutions: {},
         },
         {
           owner: account,
@@ -536,6 +572,7 @@ describe("Image", async () => {
           original: await createDummyFileStream(100, account),
           originalSize: [100, 100],
           progressive: false,
+          resolutions: {},
         },
         {
           owner: account,
@@ -567,6 +604,7 @@ describe("Image", async () => {
           original: await createDummyFileStream(100, account),
           originalSize: [100, 100],
           progressive: false,
+          resolutions: {},
         },
         {
           owner: account,

--- a/packages/jazz-tools/src/svelte/media/image.svelte
+++ b/packages/jazz-tools/src/svelte/media/image.svelte
@@ -7,7 +7,7 @@ import type { ImageProps } from "./image.types.js";
 
 const { imageId, width, height, ...rest }: ImageProps = $props();
 
-const imageState = new CoState(ImageDefinition, () => imageId);
+const imageState = new CoState(ImageDefinition, () => imageId, { resolve: { resolutions: true } });
 let lastBestImage: [string, string] | null = null;
 
 /**

--- a/packages/jazz-tools/src/svelte/tests/media/image.svelte.test.ts
+++ b/packages/jazz-tools/src/svelte/tests/media/image.svelte.test.ts
@@ -39,6 +39,7 @@ describe("Image", async () => {
           original,
           originalSize: [100, 100],
           progressive: false,
+          resolutions: {},
         },
         {
           owner: account,
@@ -72,6 +73,7 @@ describe("Image", async () => {
           originalSize: [100, 100],
           progressive: false,
           placeholderDataURL: placeholderDataUrl,
+          resolutions: {},
         },
         {
           owner: account,
@@ -103,6 +105,7 @@ describe("Image", async () => {
           original: await createDummyFileStream(100, account),
           originalSize: [100, 100],
           progressive: false,
+          resolutions: {},
         },
         {
           owner: account,
@@ -131,6 +134,7 @@ describe("Image", async () => {
           original: await createDummyFileStream(100, account),
           originalSize: [100, 100],
           progressive: false,
+          resolutions: {},
         },
         {
           owner: account,
@@ -154,6 +158,7 @@ describe("Image", async () => {
           original: await createDummyFileStream(100, account),
           originalSize: [100, 100],
           progressive: false,
+          resolutions: {},
         },
         {
           owner: account,
@@ -179,6 +184,7 @@ describe("Image", async () => {
           original: await createDummyFileStream(100, account),
           originalSize: [100, 100],
           progressive: false,
+          resolutions: {},
         },
         {
           owner: account,
@@ -204,6 +210,7 @@ describe("Image", async () => {
           original: await createDummyFileStream(100, account),
           originalSize: [100, 100],
           progressive: false,
+          resolutions: {},
         },
         {
           owner: account,
@@ -228,6 +235,7 @@ describe("Image", async () => {
           original: await createDummyFileStream(100, account),
           originalSize: [100, 100],
           progressive: false,
+          resolutions: {},
         },
         {
           owner: account,
@@ -252,6 +260,7 @@ describe("Image", async () => {
           original: await createDummyFileStream(100, account),
           originalSize: [100, 100],
           progressive: false,
+          resolutions: {},
         },
         {
           owner: account,
@@ -288,14 +297,18 @@ describe("Image", async () => {
           original,
           originalSize: [500, 500],
           progressive: true,
+          resolutions: {},
         },
         {
           owner: account,
         },
       );
 
-      im.$jazz.set("500x500", original);
-      im.$jazz.set("256x256", await createDummyFileStream(256, account));
+      im.resolutions.$jazz.set("500x500", original);
+      im.resolutions.$jazz.set(
+        "256x256",
+        await createDummyFileStream(256, account),
+      );
 
       const { container } = renderWithAccount({
         imageId: im.$jazz.id,
@@ -329,14 +342,18 @@ describe("Image", async () => {
           original,
           originalSize: [1920, 1080],
           progressive: true,
+          resolutions: {},
         },
         {
           owner: account,
         },
       );
 
-      im.$jazz.set("1920x1080", original);
-      im.$jazz.set("256x256", await createDummyFileStream(256, account));
+      im.resolutions.$jazz.set("1920x1080", original);
+      im.resolutions.$jazz.set(
+        "256x256",
+        await createDummyFileStream(256, account),
+      );
 
       const { container } = renderWithAccount({
         imageId: im.$jazz.id,
@@ -353,7 +370,10 @@ describe("Image", async () => {
       expect(createObjectURLSpy).toHaveBeenCalledTimes(1);
 
       // Load higher resolution image
-      im.$jazz.set("1024x1024", await createDummyFileStream(1024, account));
+      im.resolutions.$jazz.set(
+        "1024x1024",
+        await createDummyFileStream(1024, account),
+      );
 
       await waitFor(() => {
         expect((container.querySelector("img") as HTMLImageElement).src).toBe(
@@ -383,15 +403,22 @@ describe("Image", async () => {
           original,
           originalSize: [100, 100],
           progressive: true,
+          resolutions: {},
         },
         {
           owner: account,
         },
       );
 
-      im.$jazz.set("100x100", original);
-      im.$jazz.set("256x256", await createDummyFileStream(256, account));
-      im.$jazz.set("1024x1024", await createDummyFileStream(1024, account));
+      im.resolutions.$jazz.set("100x100", original);
+      im.resolutions.$jazz.set(
+        "256x256",
+        await createDummyFileStream(256, account),
+      );
+      im.resolutions.$jazz.set(
+        "1024x1024",
+        await createDummyFileStream(1024, account),
+      );
 
       const { container } = renderWithAccount({
         imageId: im.$jazz.id,
@@ -424,14 +451,18 @@ describe("Image", async () => {
           original,
           originalSize: [100, 100],
           progressive: true,
+          resolutions: {},
         },
         {
           owner: account,
         },
       );
 
-      im.$jazz.set("100x100", original);
-      im.$jazz.set("256x256", await createDummyFileStream(256, account));
+      im.resolutions.$jazz.set("100x100", original);
+      im.resolutions.$jazz.set(
+        "256x256",
+        await createDummyFileStream(256, account),
+      );
 
       const { container } = renderWithAccount({
         imageId: im.$jazz.id,
@@ -464,13 +495,17 @@ describe("Image", async () => {
           original,
           originalSize: [256, 256],
           progressive: true,
+          resolutions: {},
         },
         {
           owner: account,
         },
       );
-      im.$jazz.set("256x256", original);
-      im.$jazz.set("1024x1024", await createDummyFileStream(1024, account));
+      im.resolutions.$jazz.set("256x256", original);
+      im.resolutions.$jazz.set(
+        "1024x1024",
+        await createDummyFileStream(1024, account),
+      );
 
       const { container, rerender } = renderWithAccount({
         imageId: im.$jazz.id,
@@ -511,6 +546,7 @@ describe("Image", async () => {
           original: await createDummyFileStream(100, account),
           originalSize: [100, 100],
           progressive: false,
+          resolutions: {},
         },
         {
           owner: account,
@@ -543,7 +579,8 @@ describe("Image", async () => {
           original: await createDummyFileStream(100, account),
           originalSize: [100, 100],
           progressive: false,
-        },
+          resolutions: {},
+      },
         {
           owner: account,
         },

--- a/packages/jazz-tools/src/tools/coValues/extensions/imageDef.ts
+++ b/packages/jazz-tools/src/tools/coValues/extensions/imageDef.ts
@@ -1,5 +1,10 @@
 import { z } from "../../implementation/zodSchema/zodReExport.js";
-import { Loaded, coFileStreamDefiner, coMapDefiner } from "../../internal.js";
+import {
+  Loaded,
+  coFileStreamDefiner,
+  coMapDefiner,
+  coRecordDefiner,
+} from "../../internal.js";
 
 // avoiding circularity by using the standalone definers instead of `co`
 const ImageDefinitionBase = coMapDefiner({
@@ -7,8 +12,12 @@ const ImageDefinitionBase = coMapDefiner({
   originalSize: z.tuple([z.number(), z.number()]),
   placeholderDataURL: z.string().optional(),
   progressive: z.boolean(),
-}).catchall(coFileStreamDefiner());
+  resolutions: coRecordDefiner(z.string(), coFileStreamDefiner()),
+});
 
 /** @category Media */
 export const ImageDefinition = ImageDefinitionBase;
-export type ImageDefinition = Loaded<typeof ImageDefinition>;
+export type ImageDefinition = Loaded<
+  typeof ImageDefinition,
+  { resolutions: true }
+>;

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/AccountSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/AccountSchema.ts
@@ -147,8 +147,7 @@ export type DefaultProfileShape = {
 
 export type CoProfileSchema<
   Shape extends z.core.$ZodLooseShape = DefaultProfileShape,
-  CatchAll extends AnyZodOrCoValueSchema | unknown = unknown,
-> = CoMapSchema<Shape & DefaultProfileShape, CatchAll, Group>;
+> = CoMapSchema<Shape & DefaultProfileShape, Group>;
 
 // less precise version to avoid circularity issues and allow matching against
 export interface CoreAccountSchema<

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/CoFieldSchemaInit.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/CoFieldSchemaInit.ts
@@ -47,8 +47,6 @@ export type CoFieldSchemaInit<S extends CoValueClass | AnyZodOrCoValueSchema> =
         ? InstanceType<S>
         : never;
 
-// Due to a TS limitation with types that contain known properties and
-// an index signature, we cannot accept catchall properties on creation
 export type CoMapSchemaInit<Shape extends z.core.$ZodLooseShape> = Simplify<
   {
     /**

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/InstanceOfSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/InstanceOfSchema.ts
@@ -36,17 +36,12 @@ export type InstanceOfSchema<S extends CoValueClass | AnyZodOrCoValueSchema> =
             readonly [key in z.output<K> &
               string]: InstanceOrPrimitiveOfSchema<V>;
           } & CoMap
-        : S extends CoreCoMapSchema<infer Shape, infer CatchAll>
+        : S extends CoreCoMapSchema<infer Shape>
           ? {
               readonly [key in keyof Shape]: InstanceOrPrimitiveOfSchema<
                 Shape[key]
               >;
-            } & (CatchAll extends AnyZodOrCoValueSchema
-              ? {
-                  readonly [key: string]: InstanceOrPrimitiveOfSchema<CatchAll>;
-                }
-              : {}) &
-              CoMap
+            } & CoMap
           : S extends CoreCoListSchema<infer T>
             ? CoList<InstanceOrPrimitiveOfSchema<T>>
             : S extends CoreCoFeedSchema<infer T>

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/InstanceOfSchemaCoValuesNullable.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/InstanceOfSchemaCoValuesNullable.ts
@@ -41,20 +41,13 @@ export type InstanceOfSchemaCoValuesNullable<
                 string]: InstanceOrPrimitiveOfSchemaCoValuesNullable<V>;
             } & CoMap)
           | null
-      : S extends CoreCoMapSchema<infer Shape, infer CatchAll>
+      : S extends CoreCoMapSchema<infer Shape>
         ?
             | ({
                 readonly [key in keyof Shape]: InstanceOrPrimitiveOfSchemaCoValuesNullable<
                   Shape[key]
                 >;
-              } & (CatchAll extends AnyZodOrCoValueSchema
-                ? {
-                    readonly [
-                      key: string
-                    ]: InstanceOrPrimitiveOfSchemaCoValuesNullable<CatchAll>;
-                  }
-                : {}) &
-                CoMap)
+              } & CoMap)
             | null
         : S extends CoreCoListSchema<infer T>
           ? CoList<InstanceOrPrimitiveOfSchemaCoValuesNullable<T>> | null

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/zodCo.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/zodCo.ts
@@ -17,6 +17,7 @@ import {
   createCoreCoListSchema,
   createCoreCoMapSchema,
   createCoreCoPlainTextSchema,
+  createCoreCoRecordSchema,
   createCoreFileStreamSchema,
   hydrateCoreCoValueSchema,
   isAnyCoValueSchema,
@@ -130,13 +131,11 @@ export const coRecordDefiner = <
   K extends z.core.$ZodString<string>,
   V extends AnyZodOrCoValueSchema,
 >(
-  _keyType: K,
+  keyType: K,
   valueType: V,
 ): CoRecordSchema<K, V> => {
-  return coMapDefiner({}).catchall(valueType) as unknown as CoRecordSchema<
-    K,
-    V
-  >;
+  const coreSchema = createCoreCoRecordSchema(keyType, valueType);
+  return hydrateCoreCoValueSchema(coreSchema);
 };
 
 export const coListDefiner = <T extends AnyZodOrCoValueSchema>(

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/zodSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/zodSchema.ts
@@ -59,8 +59,8 @@ export type CoValueSchemaFromCoreSchema<S extends CoreCoValueSchema> =
     ? AccountSchema<Shape>
     : S extends CoreCoRecordSchema<infer K, infer V>
       ? CoRecordSchema<K, V>
-      : S extends CoreCoMapSchema<infer Shape, infer Config>
-        ? CoMapSchema<Shape, Config>
+      : S extends CoreCoMapSchema<infer Shape>
+        ? CoMapSchema<Shape>
         : S extends CoreCoListSchema<infer T>
           ? CoListSchema<T>
           : S extends CoreCoFeedSchema<infer T>

--- a/packages/jazz-tools/src/tools/tests/coMap.record.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coMap.record.test.ts
@@ -383,6 +383,7 @@ describe("CoMap.Record", async () => {
         original: FileStream.create(),
         progressive: false,
         originalSize: [1920, 1080],
+        resolutions: {},
       }),
     });
 

--- a/packages/jazz-tools/src/tools/tests/coMap.record.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coMap.record.test.ts
@@ -398,42 +398,6 @@ describe("CoMap.Record", async () => {
   });
 
   // Covers https://github.com/garden-co/jazz/issues/2385
-  test("create a Record with a discriminated union containing a co.map that uses catchall", () => {
-    const Base = co.map({
-      type: z.literal("base"),
-      name: z.string(),
-    });
-
-    const Catchall = co.map({}).catchall(z.string());
-    const IssueRepro = co.map({
-      type: z.literal("repro"),
-      catchall: Catchall,
-      name: z.string(),
-    });
-
-    const PersonRecord = co.record(
-      z.string(),
-      co.discriminatedUnion("type", [Base, IssueRepro]),
-    );
-
-    const person = IssueRepro.create({
-      type: "repro",
-      catchall: Catchall.create({}),
-      name: "John",
-    });
-
-    const record = PersonRecord.create({
-      john: person,
-    });
-
-    if (record.john?.type === "repro") {
-      expect(record.john.catchall).toEqual({});
-      expect(record.john.name).toEqual("John");
-      expect(record.john.type).toEqual("repro");
-    }
-  });
-
-  // Covers https://github.com/garden-co/jazz/issues/2385
   test("create a Record with a discriminated union containing a co.image", () => {
     const Base = co.map({
       type: z.literal("base"),

--- a/packages/jazz-tools/src/tools/tests/coMap.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coMap.test.ts
@@ -412,28 +412,6 @@ describe("CoMap", async () => {
       });
     });
 
-    it("should allow extra properties when catchall is provided", () => {
-      const Person = co
-        .map({
-          name: z.string(),
-          age: z.number(),
-        })
-        .catchall(z.string());
-
-      const person = Person.create({ name: "John", age: 20 });
-      expect(person.name).toEqual("John");
-      expect(person.age).toEqual(20);
-      expect(person.extra).toBeUndefined();
-
-      person.$jazz.set("name", "Jane");
-      person.$jazz.set("age", 28);
-      person.$jazz.set("extra", "extra");
-
-      expect(person.name).toEqual("Jane");
-      expect(person.age).toEqual(28);
-      expect(person.extra).toEqual("extra");
-    });
-
     test("CoMap with reference can be created with a shallowly resolved reference", async () => {
       const Dog = co.map({
         name: z.string(),
@@ -2575,27 +2553,6 @@ describe("co.map schema", () => {
 
       expect(person.name).toEqual("John");
     });
-
-    test("the new schema does not include catchall properties", () => {
-      const Person = co
-        .map({
-          name: z.string(),
-          age: z.number(),
-        })
-        .catchall(z.string());
-
-      const PersonWithName = Person.pick({
-        name: true,
-      });
-
-      expect(PersonWithName.catchAll).toBeUndefined();
-
-      const person = PersonWithName.create({
-        name: "John",
-      });
-      // @ts-expect-error - property `extraField` does not exist in person
-      expect(person.extraField).toBeUndefined();
-    });
   });
 
   describe("partial()", () => {
@@ -2626,22 +2583,6 @@ describe("co.map schema", () => {
       expect(draftPerson.name).toEqual("John");
       expect(draftPerson.age).toEqual(20);
       expect(draftPerson.pet).toEqual(rex);
-    });
-
-    test("the new schema includes catchall properties", () => {
-      const Person = co
-        .map({
-          name: z.string(),
-          age: z.number(),
-        })
-        .catchall(z.string());
-
-      const DraftPerson = Person.partial();
-
-      const draftPerson = DraftPerson.create({});
-      draftPerson.$jazz.set("extraField", "extra");
-
-      expect(draftPerson.extraField).toEqual("extra");
     });
   });
 

--- a/packages/jazz-tools/src/tools/tests/coOptional.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coOptional.test.ts
@@ -79,6 +79,7 @@ describe("co.optional", () => {
         originalSize: [1920, 1080],
         original: FileStream.create(),
         progressive: false,
+        resolutions: {},
       }),
     );
     schema.$jazz.set(

--- a/tests/browser-integration/src/createImage.test.ts
+++ b/tests/browser-integration/src/createImage.test.ts
@@ -20,8 +20,8 @@ describe("createImage - Browser Edition", async () => {
     });
 
     expect(image.originalSize).toEqual([600, 125]);
-    expect(image["600x125"]).toBeDefined();
-    expect(image["256x53"]).toBeDefined();
+    expect(image.resolutions["600x125"]).toBeDefined();
+    expect(image.resolutions["256x53"]).toBeDefined();
 
     const imgOriginal = document.createElement("img");
     imgOriginal.src = URL.createObjectURL(image.original!.toBlob()!);
@@ -34,7 +34,9 @@ describe("createImage - Browser Edition", async () => {
     URL.revokeObjectURL(imgOriginal.src);
 
     const imgResized = document.createElement("img");
-    imgResized.src = URL.createObjectURL(image["256x53"]!.toBlob()!);
+    imgResized.src = URL.createObjectURL(
+      image.resolutions["256x53"]!.toBlob()!,
+    );
 
     await new Promise((resolve) => (imgResized.onload = resolve));
 
@@ -58,7 +60,7 @@ describe("createImage - Browser Edition", async () => {
     });
 
     expect(pngImage.original!.toBlob()!.type).toBe("image/png");
-    expect(pngImage["256x53"]!.toBlob()!.type).toBe("image/png");
+    expect(pngImage.resolutions["256x53"]!.toBlob()!.type).toBe("image/png");
 
     const jpegBlob = new Blob(
       [Uint8Array.from(White1920, (c) => c.charCodeAt(0))],
@@ -73,7 +75,7 @@ describe("createImage - Browser Edition", async () => {
     });
 
     expect(jpegImage.original!.toBlob()!.type).toBe("image/jpeg");
-    expect(jpegImage["256x53"]!.toBlob()!.type).toBe("image/jpeg");
+    expect(jpegImage.resolutions["256x53"]!.toBlob()!.type).toBe("image/jpeg");
   });
 });
 


### PR DESCRIPTION
# Description

_Keeping this PR as a draft until we've defined how to migrate existing CoMaps with index signatures._

This PR removes the `catchall` method from `co.map` schemas. It prevents building CoMaps that have both known properties and a catchall schema for unknown properties. `co.map` can now only be used to define struct-like CoMaps with known fields. Record-like CoMaps can still be defined using `co.record`.

The biggest impact this change has is on `ImageDefinition`: images relied on catchall to provide different-sized versions of the same image. These images have now been moved to `image.resolutions`.

## Motivation

Our support for CoMaps with both known & unknown properties was very limited:
- `co.map(...).create` does not allow initializing catchall properties
- `co.map(...).load` (and all other load methods) do not allow accessing catchall properties on the loaded CoMap
- Typescript has limitations for working with objects that contain both known properties + an index signature. The index signature's type often conflicts with the one defined for known fields.

Since struct-like CoMaps can contain record-like CoMaps, there's no motivation for providing a single data structure that allows both known and unknown properties. Removing `catchall` makes our CoValue data model simpler.

## Tests

- [x] Tests have been added and/or updated

## Checklist

- [x] I've updated the part of the docs that are affected the PR changes
- [ ] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing