### PR TITLE
fix: skip inbox failed messages, wait for streaming to be completed and apply a concurrency cap on the subscribe

### DIFF
--- a/.changeset/rich-games-punch.md
+++ b/.changeset/rich-games-punch.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Add concurrency limit on the Inbox subscribe, and simplify the failed messages management

--- a/packages/cojson/src/coValueCore/coValueCore.ts
+++ b/packages/cojson/src/coValueCore/coValueCore.ts
@@ -215,6 +215,20 @@ export class CoValueCore {
     });
   }
 
+  waitForFullStreaming(): Promise<CoValueCore> {
+    return new Promise<CoValueCore>((resolve) => {
+      const listener = (core: CoValueCore) => {
+        if (core.isAvailable() && !core.verified.isStreaming()) {
+          resolve(core);
+          this.listeners.delete(listener);
+        }
+      };
+
+      this.listeners.add(listener);
+      listener(this);
+    });
+  }
+
   getStateForPeer(peerId: PeerID) {
     return this.peers.get(peerId);
   }

--- a/packages/cojson/src/exports.ts
+++ b/packages/cojson/src/exports.ts
@@ -1,6 +1,10 @@
 import { base64URLtoBytes, bytesToBase64url } from "./base64url.js";
 import { type RawCoValue } from "./coValue.js";
-import { CoValueCore, idforHeader } from "./coValueCore/coValueCore.js";
+import {
+  CoValueCore,
+  idforHeader,
+  type AvailableCoValueCore,
+} from "./coValueCore/coValueCore.js";
 import { CoValueUniqueness } from "./coValueCore/verifiedState.js";
 import {
   ControlledAccount,
@@ -171,6 +175,7 @@ export type {
   BinaryStreamStart,
   OpID,
   AccountRole,
+  AvailableCoValueCore,
 };
 
 export * from "./storage/index.js";

--- a/packages/cojson/src/storage/storageAsync.ts
+++ b/packages/cojson/src/storage/storageAsync.ts
@@ -110,10 +110,14 @@ export class StorageApiAsync implements StorageAPI {
 
       let idx = 0;
 
-      signatures.push({
-        idx: sessionRow.lastIdx,
-        signature: sessionRow.lastSignature,
-      });
+      const lastSignature = signatures[signatures.length - 1];
+
+      if (lastSignature?.signature !== sessionRow.lastSignature) {
+        signatures.push({
+          idx: sessionRow.lastIdx,
+          signature: sessionRow.lastSignature,
+        });
+      }
 
       for (const signature of signatures) {
         const newTxsInSession = await this.dbClient.getNewTransactionInSession(

--- a/packages/cojson/src/storage/storageSync.ts
+++ b/packages/cojson/src/storage/storageSync.ts
@@ -113,10 +113,14 @@ export class StorageApiSync implements StorageAPI {
 
       let idx = 0;
 
-      signatures.push({
-        idx: sessionRow.lastIdx,
-        signature: sessionRow.lastSignature,
-      });
+      const lastSignature = signatures[signatures.length - 1];
+
+      if (lastSignature?.signature !== sessionRow.lastSignature) {
+        signatures.push({
+          idx: sessionRow.lastIdx,
+          signature: sessionRow.lastSignature,
+        });
+      }
 
       for (const signature of signatures) {
         const newTxsInSession = this.dbClient.getNewTransactionInSession(

--- a/packages/cojson/src/tests/sync.load.test.ts
+++ b/packages/cojson/src/tests/sync.load.test.ts
@@ -507,9 +507,9 @@ describe("loading coValues from server", () => {
       connected: true,
     });
 
-    await loadCoValueOrFail(client.node, largeMap.id);
+    const mapOnClient = await loadCoValueOrFail(client.node, largeMap.id);
 
-    await largeMap.core.waitForSync();
+    await mapOnClient.core.waitForFullStreaming();
 
     expect(
       SyncMessagesLog.getMessages({

--- a/packages/jazz-tools/src/tools/coValues/inbox.ts
+++ b/packages/jazz-tools/src/tools/coValues/inbox.ts
@@ -216,10 +216,8 @@ export class Inbox {
 
     // Invoked immediately
     this.processed.subscribe(() => {
-      for (const {
-        changes: [txKey],
-      } of processedFeed.getNewItems()) {
-        processed.add(txKey as TxKey);
+      for (const { changes } of processedFeed.getNewItems()) {
+        processed.add(changes[0] as TxKey);
       }
     });
 

--- a/packages/jazz-tools/src/tools/tests/inbox.test.ts
+++ b/packages/jazz-tools/src/tools/tests/inbox.test.ts
@@ -433,7 +433,6 @@ describe("Inbox", () => {
 
     const subscribeEmitted = await new Promise((resolve) => {
       const unsubscribe = reloadedInbox.subscribe(Message, async (message) => {
-        console.log("Got a message", message.text);
         // Got a message
         resolve(true);
       });
@@ -505,7 +504,6 @@ describe("Inbox", () => {
 
     const subscribeEmitted = await new Promise((resolve) => {
       const unsubscribe = reloadedInbox.subscribe(Message, async (message) => {
-        console.log("Got a message", message.text);
         // Got a message
         resolve(true);
       });

--- a/packages/jazz-tools/src/tools/tests/inbox.test.ts
+++ b/packages/jazz-tools/src/tools/tests/inbox.test.ts
@@ -1,10 +1,27 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Group, Inbox, InboxSender, z } from "../exports";
-import { Loaded, co, coValueClassFromCoValueClassOrSchema } from "../internal";
+import {
+  Account,
+  Loaded,
+  co,
+  coValueClassFromCoValueClassOrSchema,
+} from "../internal";
 import { setupTwoNodes, waitFor } from "./utils";
+import {
+  createJazzTestAccount,
+  getPeerConnectedToTestSyncServer,
+  setupJazzTestSync,
+} from "../testing";
+import { cojsonInternals, LocalNode } from "cojson";
+import { WasmCrypto } from "cojson/crypto/WasmCrypto";
 
 const Message = co.map({
   text: z.string(),
+});
+
+beforeEach(async () => {
+  await setupJazzTestSync();
+  vi.useRealTimers();
 });
 
 describe("Inbox", () => {
@@ -211,10 +228,7 @@ describe("Inbox", () => {
 
     unsubscribe();
 
-    expect(errorLogSpy).toHaveBeenCalledWith(
-      "Error processing inbox message",
-      expect.any(Error),
-    );
+    expect(errorLogSpy).toHaveBeenCalledWith(new Error("Failed"));
 
     errorLogSpy.mockRestore();
   });
@@ -298,7 +312,7 @@ describe("Inbox", () => {
     expect(receivedMessages[0]?.text).toBe("Hello");
   });
 
-  it("should retry failed messages", async () => {
+  it("should not retry failed messages", async () => {
     const { clientAccount: sender, serverAccount: receiver } =
       await setupTwoNodes();
 
@@ -320,25 +334,18 @@ describe("Inbox", () => {
     let failures = 0;
 
     // Subscribe to inbox messages
-    const unsubscribe = receiverInbox.subscribe(
-      Message,
-      async () => {
-        failures++;
-        throw new Error("Failed");
-      },
-      { retries: 2 },
-    );
+    const unsubscribe = receiverInbox.subscribe(Message, async () => {
+      failures++;
+      throw new Error("Failed");
+    });
 
     await expect(promise).rejects.toThrow();
-    expect(failures).toBe(3);
+    expect(failures).toBe(1);
     const [failed] = Object.values(receiverInbox.failed.items).flat();
-    expect(failed?.value.errors.length).toBe(3);
+    expect(failed?.value.errors.length).toBe(1);
     unsubscribe();
 
-    expect(errorLogSpy).toHaveBeenCalledWith(
-      "Error processing inbox message",
-      expect.any(Error),
-    );
+    expect(errorLogSpy).toHaveBeenCalledWith(new Error("Failed"));
 
     errorLogSpy.mockRestore();
   });
@@ -357,28 +364,157 @@ describe("Inbox", () => {
     const errorLogSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
     // Subscribe to inbox messages
-    const unsubscribe = receiverInbox.subscribe(
-      Message,
-      async () => {
-        spy();
-      },
-      { retries: 2 },
-    );
+    const unsubscribe = receiverInbox.subscribe(Message, async () => {
+      spy();
+    });
 
     await waitFor(() => {
       const [failed] = Object.values(receiverInbox.failed.items).flat();
 
-      expect(failed?.value.errors.length).toBe(3);
+      expect(failed?.value.errors.length).toBe(1);
     });
 
     expect(spy).not.toHaveBeenCalled();
     unsubscribe();
 
     expect(errorLogSpy).toHaveBeenCalledWith(
-      "Error processing inbox message",
-      expect.any(Error),
+      new Error("Inbox: message co_z123234 is unavailable"),
     );
 
     errorLogSpy.mockRestore();
+  });
+
+  it("should skip processed messages when a large inbox is restarted", async () => {
+    cojsonInternals.setMaxRecommendedTxSize(100);
+
+    const sender = await createJazzTestAccount();
+    const receiver = await createJazzTestAccount();
+
+    await receiver.$jazz.waitForAllCoValuesSync();
+
+    const receiverInbox = await Inbox.load(receiver);
+    const inboxSender = await InboxSender.load(receiver.$jazz.id, sender);
+
+    const group = Group.create({ owner: receiver });
+
+    // This generates 4 chunks on the processed stream
+    for (let i = 0; i < 5; i++) {
+      inboxSender.sendMessage(Message.create({ text: `Hello ${i}` }, group));
+    }
+
+    inboxSender.sendMessage(Message.create({ text: `done` }, group));
+
+    await new Promise((resolve) => {
+      const unsubscribe = receiverInbox.subscribe(Message, async (message) => {
+        if (message.text === "done") {
+          resolve(true);
+          unsubscribe();
+        }
+      });
+    });
+
+    const accountId = receiver.$jazz.id;
+    const accountSecret =
+      receiver.$jazz.localNode.getCurrentAgent().agentSecret;
+    const sessionID = receiver.$jazz.localNode.currentSessionID;
+
+    await receiver.$jazz.waitForAllCoValuesSync();
+    await receiver.$jazz.localNode.gracefulShutdown();
+
+    const node = await LocalNode.withLoadedAccount({
+      accountID: accountId as any,
+      accountSecret: accountSecret,
+      peersToLoadFrom: [getPeerConnectedToTestSyncServer()],
+      crypto: receiver.$jazz.localNode.crypto,
+      sessionID: sessionID,
+    });
+
+    const reloadedInbox = await Inbox.load(Account.fromNode(node));
+
+    const subscribeEmitted = await new Promise((resolve) => {
+      const unsubscribe = reloadedInbox.subscribe(Message, async (message) => {
+        console.log("Got a message", message.text);
+        // Got a message
+        resolve(true);
+      });
+      setTimeout(() => {
+        resolve(false);
+        unsubscribe();
+      }, 100);
+    });
+
+    expect(subscribeEmitted).toBe(false);
+  });
+
+  it("should skip failed messages when a large inbox is restarted", async () => {
+    cojsonInternals.setMaxRecommendedTxSize(100);
+
+    const sender = await createJazzTestAccount();
+    const receiver = await createJazzTestAccount();
+
+    await receiver.$jazz.waitForAllCoValuesSync();
+
+    const receiverInbox = await Inbox.load(receiver);
+    const inboxSender = await InboxSender.load(receiver.$jazz.id, sender);
+
+    const group = Group.create({ owner: receiver });
+
+    // This generates 4 chunks on the processed stream
+    for (let i = 0; i < 5; i++) {
+      inboxSender
+        .sendMessage(Message.create({ text: `Hello ${i}` }, group))
+        .catch(() => {});
+    }
+
+    inboxSender
+      .sendMessage(Message.create({ text: `done` }, group))
+      .catch(() => {});
+
+    await new Promise((resolve) => {
+      const unsubscribe = receiverInbox.subscribe(Message, async (message) => {
+        if (message.text === "done") {
+          resolve(true);
+          unsubscribe();
+        }
+
+        throw new Error("Failed");
+      });
+    });
+
+    await waitFor(() => {
+      expect(Object.values(receiverInbox.processed.items).length).toBe(1);
+    });
+
+    const accountId = receiver.$jazz.id;
+    const accountSecret =
+      receiver.$jazz.localNode.getCurrentAgent().agentSecret;
+    const sessionID = receiver.$jazz.localNode.currentSessionID;
+
+    await receiver.$jazz.waitForAllCoValuesSync();
+    await receiver.$jazz.localNode.gracefulShutdown();
+
+    const node = await LocalNode.withLoadedAccount({
+      accountID: accountId as any,
+      accountSecret: accountSecret,
+      peersToLoadFrom: [getPeerConnectedToTestSyncServer()],
+      crypto: receiver.$jazz.localNode.crypto,
+      sessionID: sessionID,
+    });
+
+    const reloadedInbox = await Inbox.load(Account.fromNode(node));
+
+    const subscribeEmitted = await new Promise((resolve) => {
+      const unsubscribe = reloadedInbox.subscribe(Message, async (message) => {
+        console.log("Got a message", message.text);
+        // Got a message
+        resolve(true);
+      });
+      setTimeout(() => {
+        resolve(false);
+        unsubscribe();
+      }, 100);
+    });
+
+    expect(subscribeEmitted).toBe(false);
   });
 });


### PR DESCRIPTION
# Description

While debugging an error from one of our adopters I've found the following flaws of the inbox implementation:
- if the processed stream is too big, it might come in chunks, making the Inbox re-process some messages
- the failure retry process causes too much complexity, and we don't need it in first place
- if many messages come at the same time, we might congestion the sync server connection, making the Inbox starting to have timeouts

I fixed all these problems in this PR.

## Tests

- [x] Tests have been added and/or updated
- [ ] Tests have not been updated, because: <!-- Insert reason for not updating tests here -->
- [ ] I need help with writing tests
