### PR TITLE
fix: fix merge operation for co.list and co.richText

### DIFF
--- a/.changeset/chilled-moose-thank.md
+++ b/.changeset/chilled-moose-thank.md
@@ -1,0 +1,5 @@
+---
+"cojson": patch
+---
+
+Fixed the merge operation for RawCoList and RawCoPlainText and done a small performance optimization on RawCoList

--- a/bench/colist.load.bench.ts
+++ b/bench/colist.load.bench.ts
@@ -1,0 +1,91 @@
+import { describe, bench } from "vitest";
+import * as tools from "jazz-tools";
+import * as toolsLatest from "jazz-tools-latest";
+import { WasmCrypto } from "cojson/crypto/WasmCrypto";
+import { WasmCrypto as WasmCryptoLatest } from "cojson-latest/crypto/WasmCrypto";
+import { PureJSCrypto } from "cojson/crypto/PureJSCrypto";
+import { PureJSCrypto as PureJSCryptoLatest } from "cojson-latest/crypto/PureJSCrypto";
+
+// Define the schemas based on the provided Message schema
+async function createSchema(
+  { co, Group, z, createJazzContextForNewAccount }: typeof tools,
+  WasmCrypto: typeof WasmCryptoLatest,
+) {
+  const List = co.list(z.string());
+
+  const ctx = await createJazzContextForNewAccount({
+    creationProps: {
+      name: "Test Account",
+    },
+    // @ts-expect-error
+    crypto: await WasmCrypto.create(),
+  });
+
+  return {
+    List,
+    Group,
+    account: ctx.account,
+  };
+}
+
+const PUREJS = false;
+
+// @ts-expect-error
+const schema = await createSchema(tools, PUREJS ? PureJSCrypto : WasmCrypto);
+const schemaLatest = await createSchema(
+  toolsLatest as any,
+  // @ts-expect-error
+  PUREJS ? PureJSCryptoLatest : WasmCryptoLatest,
+);
+
+const list = schema.List.create(
+  [],
+  schema.Group.create(schema.account).makePublic(),
+);
+
+for (let i = 0; i < 1000; i++) {
+  list.$jazz.push("A");
+}
+
+for (let i = 0; i < 100; i++) {
+  const index = Math.floor(Math.random() * list.length);
+  list.$jazz.set(index, "B");
+}
+
+list.$jazz.remove(() => Math.random() < 0.3);
+
+const content = await tools.exportCoValue(schema.List, list.$jazz.id, {
+  loadAs: schema.account,
+});
+tools.importContentPieces(content ?? [], schema.account as any);
+toolsLatest.importContentPieces(content ?? [], schemaLatest.account as any);
+
+describe("list loading", () => {
+  bench(
+    "current version",
+    () => {
+      const node = schema.account.$jazz.raw.core.node;
+
+      const coValue = node.expectCoValueLoaded(list.$jazz.id as any);
+
+      coValue.getCurrentContent();
+      // @ts-expect-error
+      coValue._cachedContent = undefined;
+    },
+    { iterations: 5000 },
+  );
+
+  bench(
+    "Jazz 0.17.9",
+    () => {
+      // @ts-expect-error
+      const node = schemaLatest.account._raw.core.node;
+
+      const coValue = node.expectCoValueLoaded(list.$jazz.id as any);
+
+      coValue.getCurrentContent();
+      coValue._cachedContent = undefined;
+    },
+    { iterations: 5000 },
+  );
+});

--- a/packages/cojson/src/coValues/coList.ts
+++ b/packages/cojson/src/coValues/coList.ts
@@ -1,11 +1,7 @@
 import { CoID, RawCoValue } from "../coValue.js";
-import {
-  AvailableCoValueCore,
-  CoValueCore,
-} from "../coValueCore/coValueCore.js";
+import { AvailableCoValueCore } from "../coValueCore/coValueCore.js";
 import { AgentID, SessionID, TransactionID } from "../ids.js";
 import { JsonObject, JsonValue } from "../jsonValue.js";
-import { CoValueKnownState } from "../sync.js";
 import { accountOrAgentIDfromSessionID } from "../typeUtils/accountOrAgentIDfromSessionID.js";
 import { isCoValue } from "../typeUtils/isCoValue.js";
 import { RawAccountID } from "./account.js";
@@ -39,12 +35,14 @@ type InsertionEntry<T extends JsonValue> = {
   madeAt: number;
   predecessors: OpID[];
   successors: OpID[];
-} & InsertionOpPayload<T>;
+  change: InsertionOpPayload<T>;
+};
 
 type DeletionEntry = {
   madeAt: number;
   deletionID: OpID;
-} & DeletionOpPayload;
+  change: DeletionOpPayload;
+};
 
 export class RawCoList<
   Item extends JsonValue = JsonValue,
@@ -109,6 +107,83 @@ export class RawCoList<
     this.processNewTransactions();
   }
 
+  private getInsertionsEntry(opID: OpID) {
+    const index = getSessionIndex(opID);
+
+    const sessionEntry = this.insertions[index];
+    if (!sessionEntry) {
+      return undefined;
+    }
+
+    const txEntry = sessionEntry[opID.txIndex];
+    if (!txEntry) {
+      return undefined;
+    }
+
+    return txEntry[opID.changeIdx];
+  }
+
+  private createInsertionsEntry(opID: OpID, value: InsertionEntry<Item>) {
+    const index = getSessionIndex(opID);
+
+    let sessionEntry = this.insertions[index];
+    if (!sessionEntry) {
+      sessionEntry = {};
+      this.insertions[index] = sessionEntry;
+    }
+
+    let txEntry = sessionEntry[opID.txIndex];
+    if (!txEntry) {
+      txEntry = {};
+      sessionEntry[opID.txIndex] = txEntry;
+    }
+
+    txEntry[opID.changeIdx] = value;
+  }
+
+  private isDeleted(opID: OpID) {
+    const index = getSessionIndex(opID);
+
+    const sessionEntry = this.deletionsByInsertion[index];
+
+    if (!sessionEntry) {
+      return false;
+    }
+
+    const txEntry = sessionEntry[opID.txIndex];
+
+    if (!txEntry) {
+      return false;
+    }
+
+    return Boolean(txEntry[opID.changeIdx]?.length);
+  }
+
+  private pushDeletionsByInsertionEntry(opID: OpID, value: DeletionEntry) {
+    const index = getSessionIndex(opID);
+
+    let sessionEntry = this.deletionsByInsertion[index];
+    if (!sessionEntry) {
+      sessionEntry = {};
+      this.deletionsByInsertion[index] = sessionEntry;
+    }
+
+    let txEntry = sessionEntry[opID.txIndex];
+    if (!txEntry) {
+      txEntry = {};
+      sessionEntry[opID.txIndex] = txEntry;
+    }
+
+    let list = txEntry[opID.changeIdx];
+
+    if (!list) {
+      list = [];
+      txEntry[opID.changeIdx] = list;
+    }
+
+    list.push(value);
+  }
+
   processNewTransactions() {
     const transactions = this.core.getValidSortedTransactions({
       ignorePrivateTransactions: false,
@@ -133,87 +208,51 @@ export class RawCoList<
       for (const [changeIdx, changeUntyped] of changes.entries()) {
         const change = changeUntyped as ListOpPayload<Item>;
 
+        const opID = {
+          sessionID: txID.sessionID,
+          txIndex: txID.txIndex,
+          branch: txID.branch,
+          changeIdx,
+        };
+
         if (change.op === "pre" || change.op === "app") {
-          let sessionEntry = this.insertions[txID.sessionID];
-          if (!sessionEntry) {
-            sessionEntry = {};
-            this.insertions[txID.sessionID] = sessionEntry;
-          }
-          let txEntry = sessionEntry[txID.txIndex];
-          if (!txEntry) {
-            txEntry = {};
-            sessionEntry[txID.txIndex] = txEntry;
-          }
-          txEntry[changeIdx] = {
+          this.createInsertionsEntry(opID, {
             madeAt,
             predecessors: [],
             successors: [],
-            ...change,
-          };
+            change,
+          });
+
           if (change.op === "pre") {
             if (change.before === "end") {
-              this.beforeEnd.push({
-                ...txID,
-                changeIdx,
-              });
+              this.beforeEnd.push(opID);
             } else {
-              const beforeEntry =
-                this.insertions[change.before.sessionID]?.[
-                  change.before.txIndex
-                ]?.[change.before.changeIdx];
+              const beforeEntry = this.getInsertionsEntry(change.before);
+
               if (!beforeEntry) {
                 continue;
               }
-              beforeEntry.predecessors.splice(0, 0, {
-                ...txID,
-                changeIdx,
-              });
+
+              beforeEntry.predecessors.push(opID);
             }
           } else {
             if (change.after === "start") {
-              this.afterStart.push({
-                ...txID,
-                changeIdx,
-              });
+              this.afterStart.push(opID);
             } else {
-              const afterEntry =
-                this.insertions[change.after.sessionID]?.[
-                  change.after.txIndex
-                ]?.[change.after.changeIdx];
+              const afterEntry = this.getInsertionsEntry(change.after);
+
               if (!afterEntry) {
                 continue;
               }
-              afterEntry.successors.push({
-                ...txID,
-                changeIdx,
-              });
+
+              afterEntry.successors.push(opID);
             }
           }
         } else if (change.op === "del") {
-          let sessionEntry =
-            this.deletionsByInsertion[change.insertion.sessionID];
-          if (!sessionEntry) {
-            sessionEntry = {};
-            this.deletionsByInsertion[change.insertion.sessionID] =
-              sessionEntry;
-          }
-          let txEntry = sessionEntry[change.insertion.txIndex];
-          if (!txEntry) {
-            txEntry = {};
-            sessionEntry[change.insertion.txIndex] = txEntry;
-          }
-          let changeEntry = txEntry[change.insertion.changeIdx];
-          if (!changeEntry) {
-            changeEntry = [];
-            txEntry[change.insertion.changeIdx] = changeEntry;
-          }
-          changeEntry.push({
+          this.pushDeletionsByInsertionEntry(change.insertion, {
             madeAt,
-            deletionID: {
-              ...txID,
-              changeIdx,
-            },
-            ...change,
+            deletionID: opID,
+            change,
           });
         } else {
           throw new Error(
@@ -324,10 +363,7 @@ export class RawCoList<
     while (todo.length > 0) {
       const currentOpID = todo[todo.length - 1]!;
 
-      const entry =
-        this.insertions[currentOpID.sessionID]?.[currentOpID.txIndex]?.[
-          currentOpID.changeIdx
-        ];
+      const entry = this.getInsertionsEntry(currentOpID);
 
       if (!entry) {
         throw new Error("Missing op " + currentOpID);
@@ -338,22 +374,19 @@ export class RawCoList<
 
       // We navigate the predecessors before processing the current opID in the list
       if (shouldTraversePredecessors) {
-        for (let i = entry.predecessors.length - 1; i >= 0; i--) {
-          todo.push(entry.predecessors[i]!);
+        for (const predecessor of entry.predecessors) {
+          todo.push(predecessor);
         }
         predecessorsVisited.add(currentOpID);
       } else {
         // Remove the current opID from the todo stack to consider it processed.
         todo.pop();
 
-        const deleted =
-          (this.deletionsByInsertion[currentOpID.sessionID]?.[
-            currentOpID.txIndex
-          ]?.[currentOpID.changeIdx]?.length || 0) > 0;
+        const deleted = this.isDeleted(currentOpID);
 
         if (!deleted) {
           arr.push({
-            value: entry.value,
+            value: entry.change.value,
             madeAt: entry.madeAt,
             opID: currentOpID,
           });
@@ -628,4 +661,11 @@ export class RawCoList<
     this.deletionsByInsertion = listAfter.deletionsByInsertion;
     this._cachedEntries = undefined;
   }
+}
+
+function getSessionIndex(txID: TransactionID): SessionID {
+  if (txID.branch) {
+    return `${txID.sessionID}_branch_${txID.branch}`;
+  }
+  return txID.sessionID;
 }

--- a/packages/cojson/src/ids.ts
+++ b/packages/cojson/src/ids.ts
@@ -23,6 +23,7 @@ export function rawCoIDfromBytes(bytes: Uint8Array): RawCoID {
 export type TransactionID = {
   sessionID: SessionID;
   txIndex: number;
+  branch?: RawCoID;
 };
 
 export type AgentID = `sealer_z${string}/signer_z${string}`;

--- a/packages/cojson/src/tests/coList.test.ts
+++ b/packages/cojson/src/tests/coList.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, expect, test } from "vitest";
+import { beforeEach, describe, expect, test } from "vitest";
 import { expectList } from "../coValue.js";
 import { WasmCrypto } from "../crypto/WasmCrypto.js";
 import { LocalNode } from "../localNode.js";
@@ -427,4 +427,532 @@ test("Should ignore unknown meta transactions", () => {
   content.append("first", 0, "trusting");
 
   expect(content.toJSON()).toEqual(["first"]);
+});
+
+describe("CoList Branching", () => {
+  test("should handle concurrent appends from multiple branches", async () => {
+    const client1 = setupTestNode({
+      connected: true,
+    });
+
+    const group = client1.node.createGroup();
+    group.addMember("everyone", "writer");
+
+    const groceryList = group.createList(["milk"]);
+
+    // Create branches for each client
+    const aliceBranch = expectList(
+      groceryList.core
+        .createBranch("alice-branch", group.id)
+        .getCurrentContent(),
+    );
+    const bobBranch = expectList(
+      groceryList.core.createBranch("bob-branch", group.id).getCurrentContent(),
+    );
+
+    // Both branches append grocery items
+    aliceBranch.append("bread", undefined, "trusting");
+    aliceBranch.append("butter", undefined, "trusting");
+    bobBranch.append("eggs", undefined, "trusting");
+
+    // Merge both branches back to source
+    aliceBranch.core.mergeBranch();
+    bobBranch.core.mergeBranch();
+
+    // Wait for sync
+    await groceryList.core.waitForSync();
+
+    // Source list should contain all items from both branches
+    expect(groceryList.toJSON()).toMatchInlineSnapshot(`
+      [
+        "milk",
+        "eggs",
+        "bread",
+        "butter",
+      ]
+    `);
+  });
+
+  test("should handle concurrent prepends from multiple branches", async () => {
+    const client1 = setupTestNode({
+      connected: true,
+    });
+
+    const group = client1.node.createGroup();
+    group.addMember("everyone", "writer");
+
+    const groceryList = group.createList(["milk"]);
+
+    // Create branches for each client
+    const aliceBranch = expectList(
+      groceryList.core
+        .createBranch("alice-branch", group.id)
+        .getCurrentContent(),
+    );
+    const bobBranch = expectList(
+      groceryList.core.createBranch("bob-branch", group.id).getCurrentContent(),
+    );
+
+    // Both branches prepend grocery items
+    aliceBranch.prepend("bread", undefined, "trusting");
+    aliceBranch.prepend("butter", undefined, "trusting");
+    bobBranch.prepend("eggs", undefined, "trusting");
+
+    // Merge both branches back to source
+    aliceBranch.core.mergeBranch();
+    bobBranch.core.mergeBranch();
+
+    // Wait for sync
+    await groceryList.core.waitForSync();
+
+    // Source list should contain all items from both branches
+    expect(groceryList.toJSON()).toMatchInlineSnapshot(`
+      [
+        "eggs",
+        "butter",
+        "bread",
+        "milk",
+      ]
+    `);
+  });
+
+  test("should handle concurrent deletes from multiple branches", async () => {
+    const client1 = setupTestNode({
+      connected: true,
+    });
+
+    const group = client1.node.createGroup();
+    group.addMember("everyone", "writer");
+
+    const groceryList = group.createList(["milk", "bread", "eggs", "cheese"]);
+
+    // Create branches for each client
+    const aliceBranch = expectList(
+      groceryList.core
+        .createBranch("alice-branch", group.id)
+        .getCurrentContent(),
+    );
+    const bobBranch = expectList(
+      groceryList.core.createBranch("bob-branch", group.id).getCurrentContent(),
+    );
+
+    // Both branches delete different grocery items
+    aliceBranch.delete(aliceBranch.asArray().indexOf("bread"), "trusting");
+    bobBranch.delete(bobBranch.asArray().indexOf("eggs"), "trusting");
+
+    // Merge both branches back to source
+    aliceBranch.core.mergeBranch();
+    bobBranch.core.mergeBranch();
+
+    // Wait for sync
+    await groceryList.core.waitForSync();
+
+    // Source list should reflect both deletions
+    expect(groceryList.toJSON()).toEqual(["milk", "cheese"]);
+  });
+
+  test("should handle concurrent insertions at different positions from branches", async () => {
+    const client1 = setupTestNode({
+      connected: true,
+    });
+
+    const group = client1.node.createGroup();
+    group.addMember("everyone", "writer");
+
+    const groceryList = group.createList(["milk", "cheese", "butter"]);
+
+    // Create branches for each client
+    const aliceBranch = expectList(
+      groceryList.core
+        .createBranch("alice-branch", group.id)
+        .getCurrentContent(),
+    );
+    const bobBranch = expectList(
+      groceryList.core.createBranch("bob-branch", group.id).getCurrentContent(),
+    );
+
+    // Both branches insert grocery items at position 1
+    aliceBranch.append("bread", 0, "trusting");
+    bobBranch.append("eggs", 0, "trusting");
+
+    // Merge both branches back to source
+    aliceBranch.core.mergeBranch();
+    bobBranch.core.mergeBranch();
+
+    // Wait for sync
+    await groceryList.core.waitForSync();
+
+    // Source list should contain both insertions
+    expect(groceryList.toJSON()).toMatchInlineSnapshot(`
+      [
+        "milk",
+        "eggs",
+        "bread",
+        "cheese",
+        "butter",
+      ]
+    `);
+  });
+
+  test("should handle multiple branches modifying different list items", async () => {
+    const client1 = setupTestNode({
+      connected: true,
+    });
+
+    const group = client1.node.createGroup();
+    group.addMember("everyone", "writer");
+
+    const groceryList = group.createList(["milk", "bread", "eggs"]);
+
+    // Create branches for each client
+    const aliceBranch = expectList(
+      groceryList.core
+        .createBranch("alice-branch", group.id)
+        .getCurrentContent(),
+    );
+    const bobBranch = expectList(
+      groceryList.core.createBranch("bob-branch", group.id).getCurrentContent(),
+    );
+    const charlieBranch = expectList(
+      groceryList.core
+        .createBranch("charlie-branch", group.id)
+        .getCurrentContent(),
+    );
+
+    // Each branch modifies different grocery items
+    aliceBranch.replace(0, "organic milk", "trusting");
+    bobBranch.replace(1, "whole wheat bread", "trusting");
+    charlieBranch.replace(2, "free-range eggs", "trusting");
+
+    // Merge all branches back to source
+    aliceBranch.core.mergeBranch();
+    bobBranch.core.mergeBranch();
+    charlieBranch.core.mergeBranch();
+
+    // Wait for sync
+    await groceryList.core.waitForSync();
+
+    // Source list should contain all modifications
+    const expected = ["organic milk", "whole wheat bread", "free-range eggs"];
+    expect(groceryList.toJSON()).toEqual(expected);
+  });
+
+  test("should handle appendItems from multiple branches", async () => {
+    const client1 = setupTestNode({
+      connected: true,
+    });
+
+    const group = client1.node.createGroup();
+    group.addMember("everyone", "writer");
+
+    const groceryList = group.createList(["milk"]);
+
+    // Create branches for each client
+    const aliceBranch = expectList(
+      groceryList.core
+        .createBranch("alice-branch", group.id)
+        .getCurrentContent(),
+    );
+    const bobBranch = expectList(
+      groceryList.core.createBranch("bob-branch", group.id).getCurrentContent(),
+    );
+
+    // Both branches append multiple grocery items
+    aliceBranch.appendItems(["bread", "butter"], undefined, "trusting");
+    bobBranch.appendItems(["eggs", "cheese"], undefined, "trusting");
+
+    // Merge both branches back to source
+    aliceBranch.core.mergeBranch();
+    bobBranch.core.mergeBranch();
+
+    // Wait for sync
+    await groceryList.core.waitForSync();
+
+    // Source list should contain all items
+    expect(groceryList.toJSON()).toMatchInlineSnapshot(`
+      [
+        "milk",
+        "eggs",
+        "cheese",
+        "bread",
+        "butter",
+      ]
+    `);
+  });
+
+  test("should handle complex operations from multiple branches", async () => {
+    const client1 = setupTestNode({
+      connected: true,
+    });
+    const client2 = setupTestNode({
+      connected: true,
+    });
+
+    const group = client1.node.createGroup();
+    group.addMember("everyone", "writer");
+
+    const groceryList = group.createList(["milk", "bread", "eggs"]);
+
+    // Create branches for each client
+    const aliceBranch = expectList(
+      groceryList.core
+        .createBranch("alice-branch", group.id)
+        .getCurrentContent(),
+    );
+    const bobBranch = expectList(
+      groceryList.core.createBranch("bob-branch", group.id).getCurrentContent(),
+    );
+
+    // Alice performs multiple operations
+    aliceBranch.delete(1, "trusting"); // Remove "bread"
+    aliceBranch.append("cheese", undefined, "trusting");
+    aliceBranch.prepend("yogurt", undefined, "trusting");
+
+    // Bob performs different operations
+    bobBranch.replace(0, "organic milk", "trusting");
+    bobBranch.append("butter", undefined, "trusting");
+    bobBranch.delete(2, "trusting"); // Remove "eggs"
+
+    // Merge both branches back to source
+    aliceBranch.core.mergeBranch();
+    bobBranch.core.mergeBranch();
+
+    // Wait for sync
+    await groceryList.core.waitForSync();
+
+    // Source list should contain the combined result
+    expect(groceryList.toJSON()).toMatchInlineSnapshot(`
+      [
+        "yogurt",
+        "organic milk",
+        "butter",
+        "cheese",
+      ]
+    `);
+  });
+
+  test("should handle multiple branch merges with incremental changes", async () => {
+    const client1 = setupTestNode({
+      connected: true,
+    });
+
+    const group = client1.node.createGroup();
+    group.addMember("everyone", "writer");
+
+    const groceryList = group.createList(["milk"]);
+
+    // Create branches for each client
+    const aliceBranch = expectList(
+      groceryList.core
+        .createBranch("alice-branch", group.id)
+        .getCurrentContent(),
+    );
+    const bobBranch = expectList(
+      groceryList.core.createBranch("bob-branch", group.id).getCurrentContent(),
+    );
+    const charlieBranch = expectList(
+      groceryList.core
+        .createBranch("charlie-branch", group.id)
+        .getCurrentContent(),
+    );
+
+    // Each branch adds grocery items
+    aliceBranch.append("bread", undefined, "trusting");
+    bobBranch.append("eggs", undefined, "trusting");
+    charlieBranch.append("cheese", undefined, "trusting");
+
+    // Merge branches one by one
+    aliceBranch.core.mergeBranch();
+    await groceryList.core.waitForSync();
+    expect(groceryList.toJSON()).toEqual(["milk", "bread"]);
+
+    bobBranch.core.mergeBranch();
+    await groceryList.core.waitForSync();
+    expect(groceryList.toJSON()).toEqual(["milk", "eggs", "bread"]);
+
+    charlieBranch.core.mergeBranch();
+    await groceryList.core.waitForSync();
+    expect(groceryList.toJSON()).toEqual(["milk", "cheese", "eggs", "bread"]);
+  });
+
+  test("should resolve conflicts when multiple branches modify the same position", async () => {
+    const client1 = setupTestNode({
+      connected: true,
+    });
+
+    const group = client1.node.createGroup();
+    group.addMember("everyone", "writer");
+
+    const groceryList = group.createList(["milk", "bread", "eggs"]);
+
+    // Create branches for each client
+    const aliceBranch = expectList(
+      groceryList.core
+        .createBranch("alice-branch", group.id)
+        .getCurrentContent(),
+    );
+    const bobBranch = expectList(
+      groceryList.core.createBranch("bob-branch", group.id).getCurrentContent(),
+    );
+
+    // Both branches try to replace the same item at position 1
+    aliceBranch.replace(1, "whole wheat bread", "trusting");
+    bobBranch.replace(1, "sourdough bread", "trusting");
+
+    // Merge both branches back to source
+    aliceBranch.core.mergeBranch();
+    bobBranch.core.mergeBranch();
+
+    // Wait for sync
+    await groceryList.core.waitForSync();
+
+    // Source list should have a consistent state after conflict resolution
+    expect(groceryList.toJSON()).toContain("whole wheat bread");
+    expect(groceryList.toJSON()).toContain("sourdough bread");
+    expect(groceryList.toJSON()).toMatchInlineSnapshot(`
+      [
+        "milk",
+        "sourdough bread",
+        "whole wheat bread",
+        "eggs",
+      ]
+    `);
+  });
+
+  test("should handle concurrent deletions at overlapping positions across branches", async () => {
+    const client1 = setupTestNode({
+      connected: true,
+    });
+
+    const group = client1.node.createGroup();
+    group.addMember("everyone", "writer");
+
+    const list = group.createList(["milk", "bread", "eggs"]);
+
+    // Create branches for each client
+    const mondayShoppingBranch = expectList(
+      list.core.createBranch("monday-shopping", group.id).getCurrentContent(),
+    );
+    const tuesdayShoppingBranch = expectList(
+      list.core.createBranch("tuesday-shopping", group.id).getCurrentContent(),
+    );
+
+    mondayShoppingBranch.delete(list.asArray().indexOf("milk"), "trusting");
+    tuesdayShoppingBranch.delete(list.asArray().indexOf("eggs"), "trusting");
+
+    // Merge both branches back to source
+    mondayShoppingBranch.core.mergeBranch();
+    tuesdayShoppingBranch.core.mergeBranch();
+
+    // Source list should reflect all deletions
+    expect(list.toJSON()).toEqual(["bread"]);
+  });
+
+  test("should handle branching from different sessions and merging back", async () => {
+    const client1 = setupTestNode({
+      connected: true,
+    });
+    const client2 = setupTestNode({
+      connected: true,
+    });
+
+    const group = client1.node.createGroup();
+    group.addMember("everyone", "writer");
+
+    const groceryList = group.createList(["milk", "bread"]);
+
+    // Client1 creates a branch
+    const aliceBranch = expectList(
+      groceryList.core
+        .createBranch("alice-shopping-branch", group.id)
+        .getCurrentContent(),
+    );
+
+    // Client1 adds items to the branch
+    aliceBranch.append("eggs", undefined, "trusting");
+
+    // Client2 loads the branch from a different session
+    const branchOnClient2 = await loadCoValueOrFail(
+      client2.node,
+      aliceBranch.id,
+    );
+
+    // Client2 adds more items and removes some existing ones
+    branchOnClient2.append("cheese", undefined, "trusting");
+    branchOnClient2.delete(
+      branchOnClient2.asArray().indexOf("bread"),
+      "trusting",
+    );
+
+    // Merge the branch back to source
+    branchOnClient2.core.mergeBranch();
+
+    // Wait for sync
+    await groceryList.core.waitForSync();
+
+    // Source list should contain the final state
+    expect(groceryList.toJSON()).toEqual(["milk", "eggs", "cheese"]);
+  });
+
+  test("should handle multiple branches from different sessions with complex operations", async () => {
+    const client1 = setupTestNode({
+      connected: true,
+    });
+    const client2 = setupTestNode({
+      connected: true,
+    });
+
+    const group = client1.node.createGroup();
+    group.addMember("everyone", "writer");
+
+    const groceryList = group.createList(["milk"]);
+
+    // Client1 creates first branch
+    const aliceBranch = expectList(
+      groceryList.core
+        .createBranch("alice-shopping-branch", group.id)
+        .getCurrentContent(),
+    );
+
+    // Client1 adds items to first branch
+    aliceBranch.append("bread", undefined, "trusting");
+
+    // Client2 creates second branch
+    const bobBranch = expectList(
+      groceryList.core
+        .createBranch("bob-shopping-branch", group.id)
+        .getCurrentContent(),
+    );
+
+    // Client2 adds different items to second branch
+    bobBranch.append("eggs", undefined, "trusting");
+
+    // Client2 loads first branch and modifies it
+    const aliceBranchOnClient2 = await loadCoValueOrFail(
+      client2.node,
+      aliceBranch.id,
+    );
+    aliceBranchOnClient2.append("butter", undefined, "trusting");
+
+    // Merge all branches back to source
+    aliceBranchOnClient2.core.mergeBranch();
+
+    // Make the second merge happen later than the previous one, so the ordering is not based on the random sessionIDs
+    await new Promise((resolve) => setTimeout(resolve, 1));
+
+    bobBranch.core.mergeBranch();
+
+    // Wait for sync
+    await groceryList.core.waitForSync();
+
+    // Source list should contain all changes
+    expect(groceryList.toJSON()).toMatchInlineSnapshot(`
+      [
+        "milk",
+        "eggs",
+        "bread",
+        "butter",
+      ]
+    `);
+  });
 });


### PR DESCRIPTION
# Description

Found that the merge operation is breaking co.list and co.richText, because the transactions store pointers to the session log.

When merging we append all the transactions of the branch to the current session log of the source CoValue, making the pointers invalid.

Fixed by mapping the colist pointers to the new session.

Since I had to learn deeply the inner workings of colist, I've used the opportunity to simplify the code there and managed to get some performance improvmenents in the process

<img width="986" height="184" alt="Screenshot 2025-09-02 at 15 40 55" src="https://github.com/user-attachments/assets/57d70c94-dc64-40a3-9912-21a8fd57716e" />


## Tests

- [x] Tests have been added and/or updated
- [ ] Tests have not been updated, because: <!-- Insert reason for not updating tests here -->
- [ ] I need help with writing tests
