### PR TITLE
Fixes GCO-821: Never include dependencies in sendNewContent for server peers

### DIFF
--- a/.changeset/afraid-kiwis-camp.md
+++ b/.changeset/afraid-kiwis-camp.md
@@ -1,0 +1,5 @@
+---
+"cojson": patch
+---
+
+Avoid greedily sending covalue dependencies to server peers

--- a/packages/cojson/src/sync.ts
+++ b/packages/cojson/src/sync.ts
@@ -777,7 +777,11 @@ export class SyncManager {
 
       // We directly forward the new content to peers that have an active subscription
       if (peer.optimisticKnownStates.has(coValue.id)) {
-        this.sendNewContentIncludingDependencies(coValue.id, peer);
+        if (peer.role === "server") {
+          this.sendNewContentWithoutDependencies(coValue.id, peer);
+        } else {
+          this.sendNewContentIncludingDependencies(coValue.id, peer);
+        }
         syncedPeers.push(peer);
       } else if (
         peer.role === "server" &&

--- a/packages/cojson/src/sync.ts
+++ b/packages/cojson/src/sync.ts
@@ -219,28 +219,7 @@ export class SyncManager {
     }
   }
 
-  sendNewContentIncludingDependencies(
-    id: RawCoID,
-    peer: PeerState,
-    seen: Set<RawCoID> = new Set(),
-  ) {
-    this.sendNewContent(id, peer, seen, true);
-  }
-
-  sendNewContentWithoutDependencies(
-    id: RawCoID,
-    peer: PeerState,
-    seen: Set<RawCoID> = new Set(),
-  ) {
-    this.sendNewContent(id, peer, seen, false);
-  }
-
-  private sendNewContent(
-    id: RawCoID,
-    peer: PeerState,
-    seen: Set<RawCoID> = new Set(),
-    includeDependencies: boolean,
-  ) {
+  sendNewContent(id: RawCoID, peer: PeerState, seen: Set<RawCoID> = new Set()) {
     if (seen.has(id)) {
       return;
     }
@@ -253,9 +232,10 @@ export class SyncManager {
       return;
     }
 
+    const includeDependencies = peer.role !== "server";
     if (includeDependencies) {
       for (const dependency of coValue.getDependedOnCoValues()) {
-        this.sendNewContentIncludingDependencies(dependency, peer, seen);
+        this.sendNewContent(dependency, peer, seen);
       }
     }
 
@@ -434,7 +414,7 @@ export class SyncManager {
     const coValue = this.local.getCoValue(msg.id);
 
     if (coValue.isAvailable()) {
-      this.sendNewContentIncludingDependencies(msg.id, peer);
+      this.sendNewContent(msg.id, peer);
       return;
     }
 
@@ -444,7 +424,7 @@ export class SyncManager {
 
     const handleLoadResult = () => {
       if (coValue.isAvailable()) {
-        this.sendNewContentIncludingDependencies(msg.id, peer);
+        this.sendNewContent(msg.id, peer);
         return;
       }
 
@@ -478,11 +458,7 @@ export class SyncManager {
     }
 
     if (coValue.isAvailable()) {
-      if (peer.role === "server") {
-        this.sendNewContentWithoutDependencies(msg.id, peer);
-      } else {
-        this.sendNewContentIncludingDependencies(msg.id, peer);
-      }
+      this.sendNewContent(msg.id, peer);
     }
   }
 
@@ -777,11 +753,7 @@ export class SyncManager {
 
       // We directly forward the new content to peers that have an active subscription
       if (peer.optimisticKnownStates.has(coValue.id)) {
-        if (peer.role === "server") {
-          this.sendNewContentWithoutDependencies(coValue.id, peer);
-        } else {
-          this.sendNewContentIncludingDependencies(coValue.id, peer);
-        }
+        this.sendNewContent(coValue.id, peer);
         syncedPeers.push(peer);
       } else if (
         peer.role === "server" &&
@@ -812,7 +784,7 @@ export class SyncManager {
   handleCorrection(msg: KnownStateMessage, peer: PeerState) {
     peer.setKnownState(msg.id, knownStateIn(msg));
 
-    return this.sendNewContentIncludingDependencies(msg.id, peer);
+    return this.sendNewContent(msg.id, peer);
   }
 
   private syncQueue = new LocalTransactionsSyncQueue((content) =>

--- a/packages/cojson/src/tests/sync.content.test.ts
+++ b/packages/cojson/src/tests/sync.content.test.ts
@@ -1,0 +1,196 @@
+import { assert, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { expectMap } from "../coValue";
+import { setMaxRecommendedTxSize } from "../config";
+import {
+  SyncMessagesLog,
+  TEST_NODE_CONFIG,
+  blockMessageTypeOnOutgoingPeer,
+  connectedPeersWithMessagesTracking,
+  loadCoValueOrFail,
+  setupTestNode,
+  waitFor,
+} from "./testUtils";
+import { stableStringify } from "../jsonStringify";
+
+// We want to simulate a real world communication that happens asynchronously
+TEST_NODE_CONFIG.withAsyncPeers = true;
+
+function setupMesh() {
+  const coreServer = setupTestNode();
+
+  coreServer.addStorage({
+    ourName: "core",
+  });
+
+  const edgeItaly = setupTestNode();
+  edgeItaly.connectToSyncServer({
+    ourName: "edge-italy",
+    syncServerName: "core",
+    syncServer: coreServer.node,
+    persistent: true,
+  });
+  edgeItaly.addStorage({
+    ourName: "edge-italy",
+  });
+
+  const edgeFrance = setupTestNode();
+  edgeFrance.connectToSyncServer({
+    ourName: "edge-france",
+    syncServerName: "core",
+    syncServer: coreServer.node,
+    persistent: true,
+  });
+  edgeFrance.addStorage({
+    ourName: "edge-france",
+  });
+
+  return { coreServer, edgeItaly, edgeFrance };
+}
+
+describe("handling content messages", () => {
+  beforeEach(async () => {
+    SyncMessagesLog.clear();
+  });
+
+  test("dependencies are included when syncing new content to clients", async () => {
+    /*
+     * Initial Setup:
+     * core <-- edge <-- client1
+     */
+    const core = setupTestNode();
+
+    const edge = setupTestNode();
+    edge.connectToSyncServer({
+      ourName: "edge",
+      syncServerName: "core",
+      syncServer: core.node,
+    });
+
+    const client1 = setupTestNode();
+    client1.connectToSyncServer({
+      ourName: "client1",
+      syncServerName: "edge",
+      syncServer: edge.node,
+    });
+
+    // Create a map with a dependency on the client.
+    // Everythig will sync all the way back to core.
+    const group = client1.node.createGroup();
+    const map = group.createMap();
+    map.set("hello", "world", "trusting");
+    await map.core.waitForSync();
+
+    /*
+     * Add another client:
+     *
+     *                  |-- client1
+     * core <-- edge <--|
+     *                  |-- client2
+     *
+     */
+    const client2 = setupTestNode();
+    const { peerStateOnServer: client2PeerStateOnEdge } =
+      client2.connectToSyncServer({
+        ourName: "client2",
+        syncServerName: "edge",
+        syncServer: edge.node,
+      });
+
+    client2PeerStateOnEdge.setOptimisticKnownState(map.core.id, {
+      id: map.core.id,
+      header: false,
+      sessions: {},
+    });
+
+    // Update the map on client1.
+    // This should sync the map AND its dependencies to the new client.
+    map.set("hello2", "world2", "trusting");
+    await map.core.waitForSync();
+
+    const syncMessages = SyncMessagesLog.getMessages({
+      Group: group.core,
+      Map: map.core,
+    });
+    expect(
+      syncMessages.some((msg) =>
+        msg.startsWith("edge -> client2 | CONTENT Map"),
+      ),
+    ).toBe(true);
+    expect(
+      syncMessages.some((msg) =>
+        msg.startsWith("edge -> client2 | CONTENT Group"),
+      ),
+    ).toBe(true);
+  });
+
+  test("dependencies are excluded when syncing new content to servers", async () => {
+    /*
+     * Initial Setup:
+     * core1 <-- edge <-- client
+     */
+    const core1 = setupTestNode();
+
+    const edge = setupTestNode();
+    edge.connectToSyncServer({
+      ourName: "edge",
+      syncServerName: "core1",
+      syncServer: core1.node,
+    });
+
+    const client = setupTestNode();
+    client.connectToSyncServer({
+      ourName: "client",
+      syncServerName: "edge",
+      syncServer: edge.node,
+    });
+
+    // Create a map with a dependency on the client.
+    // Everythig will sync all the way back to core1.
+    const group = client.node.createGroup();
+    const map = group.createMap();
+    map.set("hello", "world", "trusting");
+    await map.core.waitForSync();
+
+    /*
+     * Add another core:
+     *
+     * core1 <--
+     *         |
+     *         |-- edge <-- client
+     *         |
+     * core2 <--
+     */
+    const core2 = setupTestNode();
+    const { peerState: core2PeerStateOnEdge } = edge.connectToSyncServer({
+      ourName: "edge",
+      syncServerName: "core2",
+      syncServer: core2.node,
+      skipReconciliation: true,
+    });
+
+    core2PeerStateOnEdge.setOptimisticKnownState(map.core.id, {
+      id: map.core.id,
+      header: false,
+      sessions: {},
+    });
+
+    // Update the map on the client.
+    // This should sync ONLY the map back to both cores.
+    map.set("hello2", "world2", "trusting");
+    await map.core.waitForSync();
+
+    const syncMessages = SyncMessagesLog.getMessages({
+      Group: group.core,
+      Map: map.core,
+    });
+    expect(
+      syncMessages.some((msg) => msg.startsWith("edge -> core2 | CONTENT Map")),
+    ).toBe(true);
+    expect(
+      syncMessages.some((msg) =>
+        msg.startsWith("edge -> core2 | CONTENT Group"),
+      ),
+    ).toBe(false);
+  });
+});

--- a/packages/cojson/src/tests/sync.content.test.ts
+++ b/packages/cojson/src/tests/sync.content.test.ts
@@ -1,52 +1,9 @@
-import { assert, beforeEach, describe, expect, test, vi } from "vitest";
+import { beforeEach, describe, expect, test } from "vitest";
 
-import { expectMap } from "../coValue";
-import { setMaxRecommendedTxSize } from "../config";
-import {
-  SyncMessagesLog,
-  TEST_NODE_CONFIG,
-  blockMessageTypeOnOutgoingPeer,
-  connectedPeersWithMessagesTracking,
-  loadCoValueOrFail,
-  setupTestNode,
-  waitFor,
-} from "./testUtils";
-import { stableStringify } from "../jsonStringify";
+import { SyncMessagesLog, TEST_NODE_CONFIG, setupTestNode } from "./testUtils";
 
 // We want to simulate a real world communication that happens asynchronously
 TEST_NODE_CONFIG.withAsyncPeers = true;
-
-function setupMesh() {
-  const coreServer = setupTestNode();
-
-  coreServer.addStorage({
-    ourName: "core",
-  });
-
-  const edgeItaly = setupTestNode();
-  edgeItaly.connectToSyncServer({
-    ourName: "edge-italy",
-    syncServerName: "core",
-    syncServer: coreServer.node,
-    persistent: true,
-  });
-  edgeItaly.addStorage({
-    ourName: "edge-italy",
-  });
-
-  const edgeFrance = setupTestNode();
-  edgeFrance.connectToSyncServer({
-    ourName: "edge-france",
-    syncServerName: "core",
-    syncServer: coreServer.node,
-    persistent: true,
-  });
-  edgeFrance.addStorage({
-    ourName: "edge-france",
-  });
-
-  return { coreServer, edgeItaly, edgeFrance };
-}
 
 describe("handling content messages", () => {
   beforeEach(async () => {

--- a/packages/jazz-tools/src/tools/coValues/group.ts
+++ b/packages/jazz-tools/src/tools/coValues/group.ts
@@ -1,11 +1,10 @@
-import {
-  RawAccount,
+import type {
+  AccountRole,
+  AgentID,
+  Everyone,
+  RawAccountID,
   RawGroup,
-  type AccountRole,
-  type AgentID,
-  type Everyone,
-  type RawAccountID,
-  type Role,
+  Role,
 } from "cojson";
 import {
   CoValue,
@@ -36,7 +35,6 @@ import {
   subscribeToCoValueWithoutMe,
   subscribeToExistingCoValue,
 } from "../internal.js";
-import { isCoValueId } from "../lib/id.js";
 
 type GroupMember = {
   id: string;
@@ -122,24 +120,6 @@ export class Group extends CoValueBase implements CoValue {
         member === "everyone" ? member : member.$jazz.raw,
         role,
       );
-    }
-  }
-
-  async addMemberAccountById(memberId: string, role: AccountRole) {
-    if (!isCoValueId(memberId)) throw new Error("Invalid member ID");
-
-    const coValueCore = await this.$jazz.localNode.loadCoValueCore(memberId);
-
-    if (!coValueCore.isAvailable()) {
-      throw new Error("Member not found");
-    }
-
-    const content = coValueCore.getCurrentContent();
-
-    if (content instanceof RawAccount) {
-      this.$jazz.raw.addMember(content, role);
-    } else {
-      throw new Error("The member is not an account");
     }
   }
 

--- a/packages/jazz-tools/src/tools/coValues/group.ts
+++ b/packages/jazz-tools/src/tools/coValues/group.ts
@@ -1,10 +1,11 @@
-import type {
-  AccountRole,
-  AgentID,
-  Everyone,
-  RawAccountID,
+import {
+  RawAccount,
   RawGroup,
-  Role,
+  type AccountRole,
+  type AgentID,
+  type Everyone,
+  type RawAccountID,
+  type Role,
 } from "cojson";
 import {
   CoValue,
@@ -35,6 +36,7 @@ import {
   subscribeToCoValueWithoutMe,
   subscribeToExistingCoValue,
 } from "../internal.js";
+import { isCoValueId } from "../lib/id.js";
 
 type GroupMember = {
   id: string;
@@ -120,6 +122,24 @@ export class Group extends CoValueBase implements CoValue {
         member === "everyone" ? member : member.$jazz.raw,
         role,
       );
+    }
+  }
+
+  async addMemberAccountById(memberId: string, role: AccountRole) {
+    if (!isCoValueId(memberId)) throw new Error("Invalid member ID");
+
+    const coValueCore = await this.$jazz.localNode.loadCoValueCore(memberId);
+
+    if (!coValueCore.isAvailable()) {
+      throw new Error("Member not found");
+    }
+
+    const content = coValueCore.getCurrentContent();
+
+    if (content instanceof RawAccount) {
+      this.$jazz.raw.addMember(content, role);
+    } else {
+      throw new Error("The member is not an account");
     }
   }
 

--- a/packages/jazz-tools/src/tools/tests/patterns/requestToJoin.test.ts
+++ b/packages/jazz-tools/src/tools/tests/patterns/requestToJoin.test.ts
@@ -1,6 +1,10 @@
 import { assert, describe, expect, test } from "vitest";
 import { Account, Group, co, z } from "../../exports";
-import { createJazzTestAccount, linkAccounts } from "../../testing";
+import {
+  createJazzTestAccount,
+  linkAccounts,
+  setupJazzTestSync,
+} from "../../testing";
 
 const RequestToJoin = co.map({
   account: Account,
@@ -24,16 +28,20 @@ const Organization = co.map({
 });
 
 async function setup() {
+  await setupJazzTestSync();
+
   const admin1 = await createJazzTestAccount();
   const admin2 = await createJazzTestAccount();
   const user1 = await createJazzTestAccount();
   const user2 = await createJazzTestAccount();
 
-  await linkAccounts(admin1, admin2);
-  await linkAccounts(admin1, user1);
-  await linkAccounts(admin1, user2);
-  await linkAccounts(admin2, user1);
-  await linkAccounts(admin2, user2);
+  // TODO: with this setting the waitForAllCoValuesSync gets stuck
+  // https://github.com/garden-co/jazz/issues/2874
+  // await linkAccounts(admin1, admin2);
+  // await linkAccounts(admin1, user1);
+  // await linkAccounts(admin1, user2);
+  // await linkAccounts(admin2, user1);
+  // await linkAccounts(admin2, user2);
 
   // The organization info are public
   const adminsGroup = Group.create(admin1);


### PR DESCRIPTION
# Description

This is an alternative for #2871.

Instead of choosing whether to use `sendNewContentIncludingDependencies` or `sendNewContentWithoutDependencies` based on `peer.role` in multiple spots (see #2795), we instead just never include dependencies when it's a `server` peer.

## Manual testing instructions

N/A

## Tests

- [x] Tests have been added and/or updated
- [ ] Tests have not been updated, because: <!-- Insert reason for not updating tests here -->
- [ ] I need help with writing tests


## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [x] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing