### PR TITLE
Export hwrServerPeerSelector

### DIFF
--- a/.changeset/warm-drinks-invite.md
+++ b/.changeset/warm-drinks-invite.md
@@ -1,0 +1,5 @@
+---
+"cojson": patch
+---
+
+Export the highest weighted random server peer selector

--- a/packages/cojson/src/exports.ts
+++ b/packages/cojson/src/exports.ts
@@ -63,7 +63,12 @@ import type { JsonObject, JsonValue } from "./jsonValue.js";
 import type * as Media from "./media.js";
 import { disablePermissionErrors } from "./permissions.js";
 import type { Peer, SyncMessage } from "./sync.js";
-import { DisconnectedError, SyncManager, emptyKnownState } from "./sync.js";
+import {
+  DisconnectedError,
+  SyncManager,
+  emptyKnownState,
+  hwrServerPeerSelector,
+} from "./sync.js";
 
 import {
   getContentMessageSize,
@@ -108,6 +113,7 @@ export const cojsonInternals = {
   getGroupDependentKey,
   disablePermissionErrors,
   SyncManager,
+  hwrServerPeerSelector,
   CO_VALUE_LOADING_CONFIG,
   CO_VALUE_PRIORITY,
   setIncomingMessagesTimeBudget,

--- a/packages/cojson/src/exports.ts
+++ b/packages/cojson/src/exports.ts
@@ -113,7 +113,6 @@ export const cojsonInternals = {
   getGroupDependentKey,
   disablePermissionErrors,
   SyncManager,
-  hwrServerPeerSelector,
   CO_VALUE_LOADING_CONFIG,
   CO_VALUE_PRIORITY,
   setIncomingMessagesTimeBudget,
@@ -169,6 +168,7 @@ export {
   LogLevel,
   base64URLtoBytes,
   bytesToBase64url,
+  hwrServerPeerSelector,
 };
 
 export type {


### PR DESCRIPTION
# Description
This exports `hwrServerPeerSelector` because we'll need access to it in `jazz-sync`. Alternatively we could move it there if we don't want `jazz` to be prescriptive in any way if that's preferred.

## Manual testing instructions

N/A

## Tests

- [ ] Tests have been added and/or updated
- [x] Tests have not been updated, because: it's just an export
- [ ] I need help with writing tests


## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [x] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing