### PR TITLE
fix: enforce transaction size limit

### DIFF
--- a/.changeset/shaggy-cheetahs-tap.md
+++ b/.changeset/shaggy-cheetahs-tap.md
@@ -1,0 +1,5 @@
+---
+"cojson": patch
+---
+
+Enforce a 1MB size limit for transactions

--- a/packages/cojson/src/coValueContentMessage.ts
+++ b/packages/cojson/src/coValueContentMessage.ts
@@ -2,6 +2,7 @@ import { CoValueHeader, Transaction } from "./coValueCore/verifiedState.js";
 import { TRANSACTION_CONFIG } from "./config.js";
 import { Signature } from "./crypto/crypto.js";
 import { RawCoID, SessionID } from "./ids.js";
+import { JsonValue } from "./jsonValue.js";
 import { getPriorityFromHeader } from "./priority.js";
 import { NewContentMessage, emptyKnownState } from "./sync.js";
 
@@ -57,6 +58,18 @@ export function exceedsRecommendedSize(
   return (
     baseSize + transactionSize > TRANSACTION_CONFIG.MAX_RECOMMENDED_TX_SIZE
   );
+}
+
+export function validateTxSizeLimitInBytes(changes: JsonValue[]): void {
+  const serializedSize = new TextEncoder().encode(
+    JSON.stringify(changes),
+  ).length;
+  if (serializedSize > TRANSACTION_CONFIG.MAX_TX_SIZE_BYTES) {
+    throw new Error(
+      `Transaction is too large to be synced: ${serializedSize} > ${TRANSACTION_CONFIG.MAX_TX_SIZE_BYTES} bytes. ` +
+        `Consider breaking your transaction into smaller chunks.`,
+    );
+  }
 }
 
 export function knownStateFromContent(content: NewContentMessage) {

--- a/packages/cojson/src/coValueCore/coValueCore.ts
+++ b/packages/cojson/src/coValueCore/coValueCore.ts
@@ -5,10 +5,10 @@ import type { RawCoValue } from "../coValue.js";
 import type { ControlledAccountOrAgent } from "../coValues/account.js";
 import type { RawGroup } from "../coValues/group.js";
 import { CO_VALUE_LOADING_CONFIG } from "../config.js";
+import { validateTxSizeLimitInBytes } from "../coValueContentMessage.js";
 import { coreToCoValue } from "../coreToCoValue.js";
 import {
   CryptoProvider,
-  Encrypted,
   Hash,
   KeyID,
   KeySecret,
@@ -17,7 +17,6 @@ import {
 } from "../crypto/crypto.js";
 import { AgentID, RawCoID, SessionID, TransactionID } from "../ids.js";
 import { JsonObject, JsonValue } from "../jsonValue.js";
-import { parseJSON, safeParseJSON } from "../jsonStringify.js";
 import { LocalNode, ResolveAccountAgentError } from "../localNode.js";
 import { logger } from "../logger.js";
 import { determineValidTransactions } from "../permissions.js";
@@ -606,6 +605,8 @@ export class CoValueCore {
         "CoValueCore: makeTransaction called on coValue without verified state",
       );
     }
+
+    validateTxSizeLimitInBytes(changes);
 
     // This is an ugly hack to get a unique but stable session ID for editing the current account
     const sessionID =

--- a/packages/cojson/src/config.ts
+++ b/packages/cojson/src/config.ts
@@ -7,10 +7,19 @@
 **/
 export const TRANSACTION_CONFIG = {
   MAX_RECOMMENDED_TX_SIZE: 100 * 1024,
+  /**
+   * Messages larger than this will be rejected when creating a transaction.
+   * The current limit is set at 1MB because that's the limit imposed by Cloudflare to Websocket messages.
+   */
+  MAX_TX_SIZE_BYTES: 1 * 1024 * 1024,
 };
 
 export function setMaxRecommendedTxSize(size: number) {
   TRANSACTION_CONFIG.MAX_RECOMMENDED_TX_SIZE = size;
+}
+
+export function setMaxTxSizeBytes(size: number) {
+  TRANSACTION_CONFIG.MAX_TX_SIZE_BYTES = size;
 }
 
 export const CO_VALUE_LOADING_CONFIG = {

--- a/packages/cojson/src/storage/storageAsync.ts
+++ b/packages/cojson/src/storage/storageAsync.ts
@@ -1,7 +1,6 @@
 import {
   createContentMessage,
   exceedsRecommendedSize,
-  getTransactionSize,
 } from "../coValueContentMessage.js";
 import {
   type CoValueCore,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1629,6 +1629,9 @@ importers:
       '@types/react-dom':
         specifier: 19.1.0
         version: 19.1.0(@types/react@19.1.0)
+      is-ci:
+        specifier: ^4.1.0
+        version: 4.1.0
       jazz-run:
         specifier: workspace:*
         version: link:../../packages/jazz-run
@@ -8843,6 +8846,10 @@ packages:
     resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
     engines: {node: '>=8'}
 
+  ci-info@4.3.0:
+    resolution: {integrity: sha512-l+2bNRMiQgcfILUi33labAZYIWlH1kWDp+ecNo5iisRKrbm0xcRyCww71/YU0Fkw0mAFpz9bJayXPjey6vkmaQ==}
+    engines: {node: '>=8'}
+
   cjs-module-lexer@1.4.3:
     resolution: {integrity: sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==}
 
@@ -10673,6 +10680,10 @@ packages:
 
   is-ci@3.0.1:
     resolution: {integrity: sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==}
+    hasBin: true
+
+  is-ci@4.1.0:
+    resolution: {integrity: sha512-Ab9bQDQ11lWootZUI5qxgN2ZXwxNI5hTwnsvOc1wyxQ7zQ8OkEDw79mI0+9jI3x432NfwbVRru+3noJfXF6lSQ==}
     hasBin: true
 
   is-core-module@2.16.0:
@@ -24612,6 +24623,8 @@ snapshots:
 
   ci-info@3.9.0: {}
 
+  ci-info@4.3.0: {}
+
   cjs-module-lexer@1.4.3:
     optional: true
 
@@ -26857,6 +26870,10 @@ snapshots:
   is-ci@3.0.1:
     dependencies:
       ci-info: 3.9.0
+
+  is-ci@4.1.0:
+    dependencies:
+      ci-info: 4.3.0
 
   is-core-module@2.16.0:
     dependencies:


### PR DESCRIPTION
# Description

Fixes https://github.com/garden-co/jazz/issues/2740.

Cloudflare Workers have a 1MB size limit for each message. This causes issues with large transactions, that users can create by dumping a large object into a `z.json()` field, for example. In order to avoid getting into that situation, we're enforcing a transaction size limit on transaction creation.

## Discussion

Not sure the approach I went with is what we want. Is it worth it to first serialize the changes as a string and then encode them as UTF-8 to get a precise result? Or should we use a simpler estimate (like multiplying the stringified length by a constant)?  

Also not sure if we should validate the size limit when creating the transaction, or when adding it to the session. I did it on creation to fail fast, but maybe we prefer to keep it in `tryAddTransactions` since that operation is already expected to fail sometimes.

## Tests

- [x] Tests have been added and/or updated

## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [x] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing