### PR TITLE
feat: add createdAt & lastUpdatedAt property to $jazz

### DIFF
--- a/.changeset/long-balloons-battle.md
+++ b/.changeset/long-balloons-battle.md
@@ -1,0 +1,6 @@
+---
+"jazz-tools": patch
+"cojson": patch
+---
+
+Add lastUpdatedAt & createdAt properties to $jazz in all the coValue types

--- a/packages/cojson/src/coValueCore/coValueCore.ts
+++ b/packages/cojson/src/coValueCore/coValueCore.ts
@@ -705,6 +705,8 @@ export class CoValueCore {
   // The list of merge commits that have been made
   mergeCommits: MergeCommit[] = [];
   branches: BranchPointerCommit[] = [];
+  earliestTxMadeAt: number = Number.MAX_SAFE_INTEGER;
+  latestTxMadeAt: number = 0;
 
   // Reset the parsed transactions and branches, to validate them again from scratch when the group is updated
   resetParsedTransactions() {
@@ -781,6 +783,14 @@ export class CoValueCore {
           tx,
           previous: this.lastVerifiedTransactionBySessionID[sessionID],
         };
+
+        if (verifiedTransaction.madeAt > this.latestTxMadeAt) {
+          this.latestTxMadeAt = verifiedTransaction.madeAt;
+        }
+
+        if (verifiedTransaction.madeAt < this.earliestTxMadeAt) {
+          this.earliestTxMadeAt = verifiedTransaction.madeAt;
+        }
 
         this.verifiedTransactions.push(verifiedTransaction);
         this.lastVerifiedTransactionBySessionID[sessionID] =

--- a/packages/cojson/src/coValues/coMap.ts
+++ b/packages/cojson/src/coValues/coMap.ts
@@ -49,10 +49,17 @@ export class RawCoMapView<
   latest: {
     [Key in keyof Shape & string]?: MapOp<Key, Shape[Key]>;
   };
+
   /** @internal */
-  latestTxMadeAt: number;
+  get latestTxMadeAt(): number {
+    return this.core.latestTxMadeAt;
+  }
+
   /** @internal */
-  earliestTxMadeAt: number | null;
+  get earliestTxMadeAt(): number {
+    return this.core.earliestTxMadeAt;
+  }
+
   /** @internal */
   ops: {
     [Key in keyof Shape & string]?: MapOp<Key, Shape[Key]>[];
@@ -80,8 +87,7 @@ export class RawCoMapView<
   ) {
     this.id = core.id as CoID<this>;
     this.core = core;
-    this.latestTxMadeAt = 0;
-    this.earliestTxMadeAt = null;
+
     this.ignorePrivateTransactions =
       options?.ignorePrivateTransactions ?? false;
     this.ops = {};
@@ -105,10 +111,6 @@ export class RawCoMapView<
       return;
     }
 
-    if (this.earliestTxMadeAt === null && newValidTransactions[0]) {
-      this.earliestTxMadeAt = newValidTransactions[0].madeAt;
-    }
-
     const { ops } = this;
 
     const changedEntries = new Map<
@@ -117,10 +119,6 @@ export class RawCoMapView<
     >();
 
     for (const { txID, changes, madeAt, tx } of newValidTransactions) {
-      if (madeAt > this.latestTxMadeAt) {
-        this.latestTxMadeAt = madeAt;
-      }
-
       for (let changeIdx = 0; changeIdx < changes.length; changeIdx++) {
         const change = changes[changeIdx] as MapOpPayload<
           keyof Shape & string,

--- a/packages/cojson/src/coValues/group.ts
+++ b/packages/cojson/src/coValues/group.ts
@@ -1070,6 +1070,9 @@ export class RawGroup<
 
     if (init) {
       map.assign(init, initPrivacy);
+    } else if (!uniqueness.createdAt) {
+      // If the createdAt is not set, we need to make a trusting transaction to set the createdAt
+      map.core.makeTransaction([], "trusting");
     }
 
     return map;
@@ -1101,6 +1104,9 @@ export class RawGroup<
 
     if (init?.length) {
       list.appendItems(init, undefined, initPrivacy);
+    } else if (!uniqueness.createdAt) {
+      // If the createdAt is not set, we need to make a trusting transaction to set the createdAt
+      list.core.makeTransaction([], "trusting");
     }
 
     return list;
@@ -1141,7 +1147,7 @@ export class RawGroup<
     meta?: C["headerMeta"],
     uniqueness: CoValueUniqueness = this.crypto.createdNowUnique(),
   ): C {
-    return this.core.node
+    const stream = this.core.node
       .createCoValue({
         type: "costream",
         ruleset: {
@@ -1152,6 +1158,13 @@ export class RawGroup<
         ...uniqueness,
       })
       .getCurrentContent() as C;
+
+    if (!uniqueness.createdAt) {
+      // If the createdAt is not set, we need to make a trusting transaction to set the createdAt
+      stream.core.makeTransaction([], "trusting");
+    }
+
+    return stream;
   }
 
   /** @category 3. Value creation */
@@ -1159,7 +1172,7 @@ export class RawGroup<
     meta: C["headerMeta"] = { type: "binary" },
     uniqueness: CoValueUniqueness = this.crypto.createdNowUnique(),
   ): C {
-    return this.core.node
+    const stream = this.core.node
       .createCoValue({
         type: "costream",
         ruleset: {
@@ -1170,6 +1183,13 @@ export class RawGroup<
         ...uniqueness,
       })
       .getCurrentContent() as C;
+
+    if (!uniqueness.createdAt) {
+      // If the createdAt is not set, we need to make a trusting transaction to set the createdAt
+      stream.core.makeTransaction([], "trusting");
+    }
+
+    return stream;
   }
 }
 

--- a/packages/jazz-tools/src/tools/coValues/CoValueBase.ts
+++ b/packages/jazz-tools/src/tools/coValues/CoValueBase.ts
@@ -77,4 +77,36 @@ export abstract class CoValueJazzApi<V extends CoValue> {
 
     return new AnonymousJazzAgent(this.localNode);
   }
+
+  /**
+   * The timestamp of the creation time of the CoValue
+   *
+   * @category Content
+   */
+  get createdAt(): number {
+    const createdAt = this.raw.core.verified.header.meta?.createdAt;
+
+    if (typeof createdAt === "string") {
+      return new Date(createdAt).getTime();
+    }
+
+    return this.raw.core.earliestTxMadeAt;
+  }
+
+  /**
+   * The timestamp of the last updated time of the CoValue
+   *
+   * Returns the creation time if there are no updates.
+   *
+   * @category Content
+   */
+  get lastUpdatedAt(): number {
+    const value = this.raw.core.latestTxMadeAt;
+
+    if (value === 0) {
+      return this.createdAt;
+    }
+
+    return value;
+  }
 }

--- a/packages/jazz-tools/src/tools/coValues/coMap.ts
+++ b/packages/jazz-tools/src/tools/coValues/coMap.ts
@@ -836,24 +836,6 @@ class CoMapJazzApi<M extends CoMap> extends CoValueJazzApi<M> {
     return this.getRaw();
   }
 
-  /**
-   * The timestamp of the creation time of the CoMap
-   *
-   * @category Content
-   */
-  get createdAt(): number {
-    return this.raw.earliestTxMadeAt ?? Number.MAX_SAFE_INTEGER;
-  }
-
-  /**
-   * The timestamp of the last updated time of the CoMap
-   *
-   * @category Content
-   */
-  get lastUpdatedAt(): number {
-    return this.raw.latestTxMadeAt;
-  }
-
   /** @internal */
   get schema(): CoMapFieldSchema {
     return (this.coMap.constructor as typeof CoMap)._schema;

--- a/packages/jazz-tools/src/tools/tests/coList.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coList.test.ts
@@ -1333,3 +1333,25 @@ describe("co.list schema", () => {
     expect(keywords[1]?.toString()).toEqual("world");
   });
 });
+
+describe("lastUpdatedAt", () => {
+  test("empty list last updated time", () => {
+    const emptyList = co.list(z.number()).create([]);
+
+    expect(emptyList.$jazz.lastUpdatedAt).not.toEqual(0);
+    expect(emptyList.$jazz.lastUpdatedAt).toEqual(emptyList.$jazz.createdAt);
+  });
+
+  test("last update should change on push", async () => {
+    const list = co.list(z.string()).create(["John"]);
+
+    expect(list.$jazz.lastUpdatedAt).not.toEqual(0);
+
+    const updatedAt = list.$jazz.lastUpdatedAt;
+
+    await new Promise((r) => setTimeout(r, 10));
+    list.$jazz.push("Jane");
+
+    expect(list.$jazz.lastUpdatedAt).not.toEqual(updatedAt);
+  });
+});

--- a/packages/jazz-tools/src/tools/tests/coPlainText.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coPlainText.test.ts
@@ -244,3 +244,25 @@ describe("CoPlainText", () => {
     expect(update3.toString()).toBe("hello world");
   });
 });
+
+describe("lastUpdatedAt", () => {
+  test("empty text last updated time", () => {
+    const text = co.plainText().create("");
+
+    expect(text.$jazz.lastUpdatedAt).toEqual(text.$jazz.createdAt);
+    expect(text.$jazz.lastUpdatedAt).not.toEqual(0);
+  });
+
+  test("last update should change on push", async () => {
+    const text = co.plainText().create("John");
+
+    expect(text.$jazz.lastUpdatedAt).not.toEqual(0);
+
+    const updatedAt = text.$jazz.lastUpdatedAt;
+
+    await new Promise((r) => setTimeout(r, 10));
+    text.$jazz.applyDiff("Jane");
+
+    expect(text.$jazz.lastUpdatedAt).not.toEqual(updatedAt);
+  });
+});


### PR DESCRIPTION
# Description

Adds lastUpdatedAt property to $jazz

Haven't added `createdAt` because we don't have a stable way to get it from every coValue.

CoMap are an exception because empty CoMap always start with an empty transaction.
Tried to do the same with every other type, but made the whole test suite blow up so I've settled for adding only lastUpdatedAt for now

## Tests

- [x] Tests have been added and/or updated
- [ ] Tests have not been updated, because: <!-- Insert reason for not updating tests here -->
- [ ] I need help with writing tests


## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [ ] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing