### PR TITLE
Fixes GCO-828: Ability for SyncManager to ignore unknown covalues arriving from server peers

### DIFF
--- a/.changeset/soft-bugs-appear.md
+++ b/.changeset/soft-bugs-appear.md
@@ -1,0 +1,5 @@
+---
+"cojson": patch
+---
+
+Ability for SyncManager to ignore unknown covalues arriving from server peers

--- a/packages/cojson/src/localNode.ts
+++ b/packages/cojson/src/localNode.ts
@@ -97,6 +97,10 @@ export class LocalNode {
     this.storage = undefined;
   }
 
+  hasCoValue(id: RawCoID) {
+    return this.coValues.has(id);
+  }
+
   getCoValue(id: RawCoID) {
     let entry = this.coValues.get(id);
 

--- a/packages/cojson/src/sync.ts
+++ b/packages/cojson/src/sync.ts
@@ -139,6 +139,13 @@ export class SyncManager {
   // the transactions have already been verified by the [trusted] peer that sent them.
   private skipVerify: boolean = false;
 
+  // When true, coValues that arrive from server peers will be ignored if they had not
+  // explicitly been requested via a load message.
+  private _ignoreUnknownCoValuesFromServers: boolean = false;
+  ignoreUnknownCoValuesFromServers() {
+    this._ignoreUnknownCoValuesFromServers = true;
+  }
+
   peersCounter = metrics.getMeter("cojson").createUpDownCounter("jazz.peers", {
     description: "Amount of connected peers",
     valueType: ValueType.INT,
@@ -191,7 +198,28 @@ export class SyncManager {
         msg,
       });
       return;
-    } else if (this.local.getCoValue(msg.id).isErroredInPeer(peer.id)) {
+    }
+
+    // Prevent core shards from storing content that belongs to other shards.
+    //
+    // This can happen because a covalue "miss" on a core shard will cause a load message to
+    // be sent to the original unsharded core. The original core, treating the peer as a client,
+    // will respond with the covalue and its dependencies. Those dependencies might not belong
+    // to this shard, so they should be ignored.
+    //
+    // TODO: remove once core has been sharded.
+    if (
+      peer.role === "server" &&
+      this._ignoreUnknownCoValuesFromServers &&
+      !this.local.hasCoValue(msg.id)
+    ) {
+      logger.warn(
+        `Ignoring message ${msg.action} on unknown coValue ${msg.id} from peer ${peer.id}`,
+      );
+      return;
+    }
+
+    if (this.local.getCoValue(msg.id).isErroredInPeer(peer.id)) {
       logger.warn(
         `Skipping message ${msg.action} on errored coValue ${msg.id} from peer ${peer.id}`,
       );

--- a/packages/cojson/src/tests/sync.load.test.ts
+++ b/packages/cojson/src/tests/sync.load.test.ts
@@ -1134,4 +1134,21 @@ describe("loading coValues from server", () => {
     const mapOnServerCore = await syncServer.node.loadCoValueCore(map.core.id);
     expect(mapOnServerCore.isAvailable()).toBe(true);
   });
+
+  test("unknown coValues are ignored if ignoreUnrequestedCoValues is true", async () => {
+    const group = jazzCloud.node.createGroup();
+    const map = group.createMap();
+    map.set("hello", "world", "trusting");
+
+    const { node: shardedCoreNode } = setupTestNode({
+      connected: true,
+    });
+    shardedCoreNode.syncManager.disableTransactionVerification();
+    shardedCoreNode.syncManager.ignoreUnknownCoValuesFromServers();
+
+    await shardedCoreNode.loadCoValueCore(map.id);
+
+    expect(shardedCoreNode.hasCoValue(map.id)).toBe(true);
+    expect(shardedCoreNode.hasCoValue(group.id)).toBe(false);
+  });
 });


### PR DESCRIPTION
# Description
While migrating from solo-core to sharded-cores, dependencies can end up on multiple shards because the solo-core treats the sharded-cores as clients. When a sharded-core is missing a covalue (that DOES belong on that core) it requests it from the solo-core. The solo-core responds with the covalue AND its dependencies, which all get stored by the shard.

Instead of trying to prevent that behavior, which would require the solo-core to know that it's talking to a sharded-core (and then special case that), we decided it would be simpler to instruct the sharded-cores to simply ignore the covalues that it receives but didn't ask for.

## Manual testing instructions

N/A

## Tests

- [x] Tests have been added and/or updated
- [ ] Tests have not been updated, because: <!-- Insert reason for not updating tests here -->
- [ ] I need help with writing tests


## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [x] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing