### PR TITLE
refactor: replace delete local data modal with a reusable component

### DIFF
--- a/packages/jazz-tools/src/inspector/viewer/delete-local-data.tsx
+++ b/packages/jazz-tools/src/inspector/viewer/delete-local-data.tsx
@@ -1,0 +1,101 @@
+import { Button } from "../ui/button.js";
+import { Modal } from "../ui/modal.js";
+import { Input } from "../ui/input.js";
+import { useState } from "react";
+
+const DELETE_LOCAL_DATA_STRING = "delete my local data";
+
+export function DeleteLocalData() {
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
+  const [confirmDeleteString, setConfirmDeleteString] = useState("");
+
+  return (
+    <>
+      <Button variant="destructive" onClick={() => setShowDeleteModal(true)}>
+        Delete my local data
+      </Button>
+      <Modal
+        isOpen={showDeleteModal}
+        onClose={() => setShowDeleteModal(false)}
+        heading="Delete Local Data"
+        showButtons={false}
+      >
+        <div
+          style={{
+            margin: "0 0 1rem 0",
+            color: "var(--j-text-color)",
+            display: "flex",
+            flexDirection: "column",
+            gap: "0.5rem",
+          }}
+        >
+          <p>
+            This action <strong>cannot</strong> be undone.
+          </p>
+          <p>
+            Be aware that the following data will be{" "}
+            <strong>permanently</strong> deleted:
+          </p>
+          <ul style={{ listStyleType: "disc", paddingLeft: "1rem" }}>
+            <li>
+              Unsynced data for <strong>all apps</strong> on{" "}
+              <code>{window.location.origin}</code>
+            </li>
+            <li>Accounts</li>
+            <li>Logged in sessions</li>
+          </ul>
+          <p></p>
+        </div>
+        <Input
+          label={`Type "${DELETE_LOCAL_DATA_STRING}" to confirm`}
+          placeholder={DELETE_LOCAL_DATA_STRING}
+          value={confirmDeleteString}
+          onChange={(e) => {
+            setConfirmDeleteString(e.target.value);
+          }}
+        />
+        <p
+          style={{
+            margin: "0 0 1rem 0",
+            color: "var(--j-text-color)",
+            display: "flex",
+            flexDirection: "column",
+            gap: "0.5rem",
+          }}
+        >
+          <small>
+            Data synced to a sync server will <strong>not</strong> be deleted,
+            and will be synced when you log in again.
+          </small>
+        </p>
+        <div
+          style={{
+            display: "flex",
+            marginTop: "0.5rem",
+            justifyContent: "flex-end",
+            gap: "0.5rem",
+          }}
+        >
+          <Button variant="secondary" onClick={() => setShowDeleteModal(false)}>
+            Cancel
+          </Button>
+          <Button
+            variant="destructive"
+            disabled={confirmDeleteString !== DELETE_LOCAL_DATA_STRING}
+            onClick={() => {
+              const jazzKeys = Object.keys(localStorage).filter(
+                (key) => key.startsWith("jazz-") || key.startsWith("co_z"),
+              );
+              jazzKeys.forEach((key) => localStorage.removeItem(key));
+              indexedDB.deleteDatabase("jazz-storage");
+              window.location.reload();
+              setShowDeleteModal(false);
+            }}
+          >
+            I'm sure, delete my local data
+          </Button>
+        </div>
+      </Modal>
+    </>
+  );
+}

--- a/packages/jazz-tools/src/inspector/viewer/new-app.tsx
+++ b/packages/jazz-tools/src/inspector/viewer/new-app.tsx
@@ -11,7 +11,7 @@ import { GlobalStyles } from "../ui/global-styles.js";
 import { Heading } from "../ui/heading.js";
 import { InspectorButton, type Position } from "./inspector-button.js";
 import { useOpenInspector } from "./use-open-inspector.js";
-import { Modal } from "../ui/modal.js";
+import { DeleteLocalData } from "./delete-local-data.js";
 
 const InspectorContainer = styled("div")`
   position: fixed;
@@ -69,10 +69,7 @@ export function JazzInspectorInternal({
   localNode?: LocalNode;
   accountId?: CoID<RawAccount>;
 }) {
-  const DELETE_LOCAL_DATA_STRING = "delete local data";
   const [open, setOpen] = useOpenInspector();
-  const [showDeleteModal, setShowDeleteModal] = useState(false);
-  const [confirmDeleteString, setConfirmDeleteString] = useState("");
   const [coValueId, setCoValueId] = useState<CoID<RawCoValue> | "">("");
   const { path, addPages, goToIndex, goBack, setPage } = usePagePath();
 
@@ -106,94 +103,7 @@ export function JazzInspectorInternal({
             />
           )}
         </Form>
-        <Button variant="destructive" onClick={() => setShowDeleteModal(true)}>
-          Delete my local data
-        </Button>
-        <Modal
-          isOpen={showDeleteModal}
-          onClose={() => setShowDeleteModal(false)}
-          heading="Delete Local Data"
-          showButtons={false}
-        >
-          <div
-            style={{
-              margin: "0 0 1rem 0",
-              color: "var(--j-text-color)",
-              display: "flex",
-              flexDirection: "column",
-              gap: "0.5rem",
-            }}
-          >
-            <p>
-              This action <strong>cannot</strong> be undone.
-            </p>
-            <p>
-              Be aware that the following data will be{" "}
-              <strong>permanently</strong> deleted:
-            </p>
-            <ul style={{ listStyleType: "disc", paddingLeft: "1rem" }}>
-              <li>
-                Unsynced data for <strong>all apps</strong> on{" "}
-                <code>{window.location.origin}</code>
-              </li>
-              <li>Accounts</li>
-              <li>Logged in sessions</li>
-            </ul>
-            <p></p>
-          </div>
-          <Input
-            label={`Type "${DELETE_LOCAL_DATA_STRING}" to confirm`}
-            placeholder={DELETE_LOCAL_DATA_STRING}
-            value={confirmDeleteString}
-            onChange={(e) => {
-              setConfirmDeleteString(e.target.value);
-            }}
-          />
-          <p
-            style={{
-              margin: "0 0 1rem 0",
-              color: "var(--j-text-color)",
-              display: "flex",
-              flexDirection: "column",
-              gap: "0.5rem",
-            }}
-          >
-            <small>
-              Data synced to a sync server will <strong>not</strong> be deleted,
-              and will be synced when you log in again.
-            </small>
-          </p>
-          <div
-            style={{
-              display: "flex",
-              marginTop: "0.5rem",
-              justifyContent: "flex-end",
-              gap: "0.5rem",
-            }}
-          >
-            <Button
-              variant="secondary"
-              onClick={() => setShowDeleteModal(false)}
-            >
-              Cancel
-            </Button>
-            <Button
-              variant="destructive"
-              disabled={confirmDeleteString !== DELETE_LOCAL_DATA_STRING}
-              onClick={() => {
-                const jazzKeys = Object.keys(localStorage).filter(
-                  (key) => key.startsWith("jazz-") || key.startsWith("co_z"),
-                );
-                jazzKeys.forEach((key) => localStorage.removeItem(key));
-                indexedDB.deleteDatabase("jazz-storage");
-                window.location.reload();
-                setShowDeleteModal(false);
-              }}
-            >
-              I'm sure, delete my local data
-            </Button>
-          </div>
-        </Modal>
+        <DeleteLocalData />
         <Button variant="plain" type="button" onClick={() => setOpen(false)}>
           Close
         </Button>


### PR DESCRIPTION
# Description
Extracted into separate module per https://github.com/garden-co/jazz/pull/2884#discussion_r2333481247

## Manual testing instructions

No specific testing, just a refactor.

## Tests

- [ ] Tests have been added and/or updated
- [x] Tests have not been updated, because: N/A
- [ ] I need help with writing tests


## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [ ] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing