### PR TITLE
perf: optimize seal and unseal in PureJSCrypto by caching the shared key generation

### DIFF
--- a/.changeset/cyan-ravens-smoke.md
+++ b/.changeset/cyan-ravens-smoke.md
@@ -1,0 +1,5 @@
+---
+"cojson": patch
+---
+
+Optimize seal and unseal in PureJSCrypto by caching the shared key generation


### PR DESCRIPTION
This change gives us around a 1.5x boost when creating nested values with PureJSCrypto
<img width="988" height="188" alt="Screenshot 2025-09-10 at 16 32 42" src="https://github.com/user-attachments/assets/9fb58d99-9954-4d7b-9a6f-409124cbb37e" />

