### PR TITLE
feat: support the selection of a subset of keys to make optional in `co.map().partial()`

### DIFF
--- a/.changeset/silver-buses-ring.md
+++ b/.changeset/silver-buses-ring.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Support the selection of a subset of keys to make optional in `co.map().partial()`

--- a/packages/jazz-tools/src/tools/coValues/CoFieldInit.ts
+++ b/packages/jazz-tools/src/tools/coValues/CoFieldInit.ts
@@ -1,8 +1,8 @@
-import { CoFeed } from "./coFeed";
-import { CoList } from "./coList";
-import { CoMap, CoMapInit } from "./coMap";
-import { CoPlainText } from "./coPlainText";
-import { CoRichText } from "./coRichText";
+import { CoFeed } from "./coFeed.js";
+import { CoList } from "./coList.js";
+import { CoMap, CoMapInit } from "./coMap.js";
+import { CoPlainText } from "./coPlainText.js";
+import { CoRichText } from "./coRichText.js";
 
 /**
  * Returns the type of values that can be used to initialize a field of the provided type.

--- a/packages/jazz-tools/src/tools/tests/coMap.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coMap.test.ts
@@ -2646,6 +2646,43 @@ describe("co.map schema", () => {
       expect(draftPerson.pet).toEqual(rex);
     });
 
+    test("creates a new CoMap schema by making some properties optional", () => {
+      const Dog = co.map({
+        name: z.string(),
+        breed: z.string(),
+      });
+      const Person = co.map({
+        name: z.string(),
+        age: z.number(),
+        pet: Dog,
+      });
+
+      const DraftPerson = Person.partial({
+        pet: true,
+      });
+
+      const draftPerson = DraftPerson.create({
+        name: "John",
+        age: 20,
+      });
+
+      expect(draftPerson.$jazz.has("pet")).toBe(false);
+
+      const rex = Dog.create({ name: "Rex", breed: "Labrador" });
+      draftPerson.$jazz.set("pet", rex);
+
+      expect(draftPerson.pet).toEqual(rex);
+
+      expect(draftPerson.$jazz.has("pet")).toBe(true);
+
+      draftPerson.$jazz.delete("pet");
+
+      expect(draftPerson.$jazz.has("pet")).toBe(false);
+
+      // @ts-expect-error - should not allow deleting required properties
+      draftPerson.$jazz.delete("age");
+    });
+
     test("the new schema includes catchall properties", () => {
       const Person = co
         .map({


### PR DESCRIPTION
Aligns ourselves to Zod's partial: https://zod.dev/api#partial

Needed when updating the form example to keep the inner coList required in the draft