### PR TITLE
Fixes GCO-829: Add removePeer() method to SyncManager

### DIFF
--- a/.changeset/thin-queens-crash.md
+++ b/.changeset/thin-queens-crash.md
@@ -1,0 +1,5 @@
+---
+"cojson": patch
+---
+
+Add removePeer() method to SyncManager

--- a/packages/cojson/src/sync.ts
+++ b/packages/cojson/src/sync.ts
@@ -414,9 +414,20 @@ export class SyncManager {
       this.peersCounter.add(-1, { role: peer.role });
 
       if (!peer.persistent && this.peers[peer.id] === peerState) {
-        delete this.peers[peer.id];
+        this.removePeer(peer.id);
       }
     });
+  }
+
+  removePeer(peerId: PeerID) {
+    const peer = this.peers[peerId];
+    if (!peer) {
+      return;
+    }
+    if (!peer.closed) {
+      peer.gracefulShutdown();
+    }
+    delete this.peers[peer.id];
   }
 
   trySendToPeer(peer: PeerState, msg: SyncMessage) {

--- a/packages/cojson/src/tests/sync.test.ts
+++ b/packages/cojson/src/tests/sync.test.ts
@@ -862,6 +862,27 @@ describe("loadCoValueCore with retry", () => {
   });
 });
 
+describe("SyncManager.removePeer", () => {
+  test("when removing a peer, the peer is closed", async () => {
+    const client = await setupTestAccount();
+
+    const { peerState } = client.connectToSyncServer();
+
+    // Store reference to peer and spy on gracefulShutdown
+    const closeSpy = vi.spyOn(peerState, "gracefulShutdown");
+
+    // Remove the peer
+    client.node.syncManager.removePeer(peerState.id);
+
+    // Verify that the peer was closed correctly
+    expect(closeSpy).toHaveBeenCalled();
+    expect(peerState.closed).toBe(true);
+
+    // Verify that the peer is no longer in the peers map
+    expect(client.node.syncManager.peers[peerState.id]).toBeUndefined();
+  });
+});
+
 describe("waitForSyncWithPeer", () => {
   test("should resolve when the coValue is fully uploaded into the peer", async () => {
     const client = await setupTestAccount();


### PR DESCRIPTION
# Description
This adds `removePeer()` to `SyncManager`.

Non-persistent peers automatically remove themselves when the connection closes, but persistent peers do not. We want to have the ability to remove persistent peers in certain cases. For example, when the core node shard membership changes (e.g. during a ring resizing).

## Manual testing instructions

n/a

## Tests

- [x] Tests have been added and/or updated
- [ ] Tests have not been updated, because: <!-- Insert reason for not updating tests here -->
- [ ] I need help with writing tests


## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [x] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing