### PR TITLE
Better Auth: ensure email-otp uniqueness pt. 2

### DIFF
--- a/.changeset/shaggy-ads-camp.md
+++ b/.changeset/shaggy-ads-camp.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+fix: in 32d1444 was used the wrong Better Auth internal function to delete old verification codes

--- a/packages/jazz-tools/src/better-auth/auth/server.ts
+++ b/packages/jazz-tools/src/better-auth/auth/server.ts
@@ -96,7 +96,7 @@ export const jazzPlugin: () => JazzPlugin = () => {
                     verification.identifier.startsWith("sign-in-otp-")
                   ) {
                     const identifier = `jazz-auth-${verification.identifier}`;
-                    await context.context.internalAdapter.deleteVerificationValue(
+                    await context.context.internalAdapter.deleteVerificationByIdentifier(
                       identifier,
                     );
                     await context.context.internalAdapter.createVerificationValue(


### PR DESCRIPTION
In 32d1444, I used the wrong method to delete old email-otp verifications to ensure the uniqueness. 

For a weird setup I had locally, the manual testing was successful.

As reported in #2890, due to limitations on the Better Auth test environment, I haven't found a way to verify the in-memory queries applied.

## Manual testing instructions

Call OTP requests twice with a database that supports unique fields (in memory doesn't).
