### PR TITLE
feat: useAccountWithSelector hook

### DIFF
--- a/.changeset/useAccountWithSelector-feature.md
+++ b/.changeset/useAccountWithSelector-feature.md
@@ -1,0 +1,6 @@
+---
+"jazz-tools": patch
+---
+
+Added useAccountWithSelector hook for granular account data selection with custom equality checking
+

--- a/.changeset/useAccountWithSelector-feature.md
+++ b/.changeset/useAccountWithSelector-feature.md
@@ -3,4 +3,3 @@
 ---
 
 Added useAccountWithSelector hook for granular account data selection with custom equality checking
-

--- a/examples/music-player/src/2_main.tsx
+++ b/examples/music-player/src/2_main.tsx
@@ -13,7 +13,7 @@ import "./index.css";
 import { MusicaAccount } from "@/1_schema";
 import { apiKey } from "@/apiKey.ts";
 import { SidebarProvider } from "@/components/ui/sidebar";
-import { JazzReactProvider, useAccount } from "jazz-tools/react";
+import { JazzReactProvider, useAccountWithSelector } from "jazz-tools/react";
 import { onAnonymousAccountDiscarded } from "./4_actions";
 import { KeyboardListener } from "./components/PlayerControls";
 import { usePrepareAppState } from "./lib/usePrepareAppState";
@@ -28,20 +28,20 @@ import { usePrepareAppState } from "./lib/usePrepareAppState";
  *
  * `<JazzReactProvider/>` also runs our account migration
  */
-
 function AppContent({
   mediaPlayer,
 }: {
   mediaPlayer: ReturnType<typeof useMediaPlayer>;
 }) {
-  const { me } = useAccount(MusicaAccount, {
+  const showWelcomeScreen = useAccountWithSelector(MusicaAccount, {
     resolve: { root: true },
+    select: (me) => Boolean(me && !me.root.accountSetupCompleted),
   });
 
   const isReady = usePrepareAppState(mediaPlayer);
 
   // Show welcome screen if account setup is not completed
-  if (me && !me.root.accountSetupCompleted) {
+  if (showWelcomeScreen) {
     return <WelcomeScreen />;
   }
 

--- a/examples/music-player/src/3_HomePage.tsx
+++ b/examples/music-player/src/3_HomePage.tsx
@@ -50,7 +50,7 @@ export function HomePage({ mediaPlayer }: { mediaPlayer: MediaPlayer }) {
 
   const membersIds = playlist?.$jazz.owner.members.map((member) => member.id);
   const isRootPlaylist = !params.playlistId;
-  const isPlaylistOwner = playlist?.$jazz.owner.myRole() === "admin";
+  const isPlaylistOwner = playlist && me?.canAdmin(playlist);
   const isActivePlaylist = playlistId === me?.root.activePlaylist?.$jazz.id;
 
   const handlePlaylistShareClick = async () => {

--- a/examples/music-player/src/5_useMediaPlayer.ts
+++ b/examples/music-player/src/5_useMediaPlayer.ts
@@ -1,25 +1,23 @@
 import { MusicTrack, MusicaAccount, Playlist } from "@/1_schema";
 import { usePlayMedia } from "@/lib/audio/usePlayMedia";
 import { usePlayState } from "@/lib/audio/usePlayState";
-import { useAccount } from "jazz-tools/react";
+import { useAccountWithSelector } from "jazz-tools/react";
 import { useRef, useState } from "react";
 import { updateActivePlaylist, updateActiveTrack } from "./4_actions";
 import { useAudioManager } from "./lib/audio/AudioManager";
 import { getNextTrack, getPrevTrack } from "./lib/getters";
 
 export function useMediaPlayer() {
-  const { me } = useAccount(MusicaAccount, {
-    resolve: { root: true },
-  });
-
   const audioManager = useAudioManager();
   const playState = usePlayState();
   const playMedia = usePlayMedia();
 
   const [loading, setLoading] = useState<string | null>(null);
 
-  const activeTrackId = me?.root.$jazz.refs.activeTrack?.id;
-
+  const activeTrackId = useAccountWithSelector(MusicaAccount, {
+    resolve: { root: { activeTrack: true } },
+    select: (me) => me?.root.$jazz.refs.activeTrack?.id,
+  });
   // Reference used to avoid out-of-order track loads
   const lastLoadedTrackId = useRef<string | null>(null);
 

--- a/examples/music-player/src/components/MusicTrackRow.tsx
+++ b/examples/music-player/src/components/MusicTrackRow.tsx
@@ -46,7 +46,7 @@ export function MusicTrackRow({
     resolve: {
       root: { playlists: { $onError: null, $each: { tracks: true } } },
     },
-    select: (account) => account?.root.playlists ?? [],
+    select: (account) => account?.root.playlists,
   });
 
   const isActiveTrack = useAccountWithSelector(MusicaAccount, {
@@ -162,7 +162,7 @@ export function MusicTrackRow({
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
               <DropdownMenuItem onSelect={handleEdit}>Edit</DropdownMenuItem>
-              {playlists.filter(Boolean).map((playlist, playlistIndex) => (
+              {playlists?.filter(Boolean).map((playlist, playlistIndex) => (
                 <Fragment key={playlistIndex}>
                   {isPartOfThePlaylist(trackId, playlist) ? (
                     <DropdownMenuItem

--- a/examples/music-player/src/components/MusicTrackRow.tsx
+++ b/examples/music-player/src/components/MusicTrackRow.tsx
@@ -12,7 +12,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { cn } from "@/lib/utils";
 import { Loaded } from "jazz-tools";
-import { useAccount, useCoState } from "jazz-tools/react";
+import { useAccountWithSelector, useCoState } from "jazz-tools/react";
 import { MoreHorizontal, Pause, Play } from "lucide-react";
 import { Fragment, useCallback, useState } from "react";
 import { EditTrackDialog } from "./RenameTrackDialog";
@@ -42,14 +42,21 @@ export function MusicTrackRow({
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const [isHovered, setIsHovered] = useState(false);
 
-  const { me } = useAccount(MusicaAccount, {
+  const playlists = useAccountWithSelector(MusicaAccount, {
     resolve: {
       root: { playlists: { $onError: null, $each: { tracks: true } } },
     },
+    select: (account) => account?.root.playlists ?? [],
   });
 
-  const playlists = me?.root.playlists ?? [];
-  const isActiveTrack = trackId === me?.root.$jazz.refs.activeTrack?.id;
+  const isActiveTrack = useAccountWithSelector(MusicaAccount, {
+    resolve: { root: { activeTrack: true } },
+    select: (account) => account?.root.activeTrack?.$jazz.id === trackId,
+  });
+
+  const canEditTrack = useAccountWithSelector(MusicaAccount, {
+    select: (account) => Boolean(track && account?.canWrite(track)),
+  });
 
   function handleTrackClick() {
     if (!track) return;
@@ -82,7 +89,6 @@ export function MusicTrackRow({
   }, []);
 
   const showWaveform = isHovered || isActiveTrack;
-  const canEdit = track && me?.canWrite(track);
 
   return (
     <li
@@ -141,7 +147,7 @@ export function MusicTrackRow({
         </div>
       )}
 
-      {canEdit && (
+      {canEditTrack && (
         <div onClick={(evt) => evt.stopPropagation()}>
           <DropdownMenu open={isDropdownOpen} onOpenChange={setIsDropdownOpen}>
             <DropdownMenuTrigger asChild>

--- a/examples/music-player/src/components/PlayerControls.tsx
+++ b/examples/music-player/src/components/PlayerControls.tsx
@@ -3,7 +3,7 @@ import { MediaPlayer } from "@/5_useMediaPlayer";
 import { useMediaEndListener } from "@/lib/audio/useMediaEndListener";
 import { usePlayState } from "@/lib/audio/usePlayState";
 import { useKeyboardListener } from "@/lib/useKeyboardListener";
-import { useAccount, useCoState } from "jazz-tools/react";
+import { useAccountWithSelector, useCoState } from "jazz-tools/react";
 import { Pause, Play, SkipBack, SkipForward } from "lucide-react";
 import WaveformCanvas from "./WaveformCanvas";
 import { Button } from "./ui/button";
@@ -12,9 +12,10 @@ export function PlayerControls({ mediaPlayer }: { mediaPlayer: MediaPlayer }) {
   const playState = usePlayState();
   const isPlaying = playState.value === "play";
 
-  const activePlaylist = useAccount(MusicaAccount, {
+  const activePlaylist = useAccountWithSelector(MusicaAccount, {
     resolve: { root: { activePlaylist: true } },
-  }).me?.root.activePlaylist;
+    select: (me) => me?.root.activePlaylist,
+  });
 
   const activeTrack = useCoState(MusicTrack, mediaPlayer.activeTrackId);
 

--- a/examples/music-player/src/components/ProfileForm.tsx
+++ b/examples/music-player/src/components/ProfileForm.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef } from "react";
-import { Image, useAccount } from "jazz-tools/react";
+import { Image, useAccountWithSelector } from "jazz-tools/react";
 import { createImage } from "jazz-tools/media";
 import { MusicaAccount } from "../1_schema";
 import { Button } from "./ui/button";
@@ -33,17 +33,18 @@ export function ProfileForm({
   cancelButtonText = "Cancel",
   className = "",
 }: ProfileFormProps) {
-  const { me } = useAccount(MusicaAccount, {
-    resolve: { profile: true, root: true },
+  const profile = useAccountWithSelector(MusicaAccount, {
+    resolve: { profile: true },
+    select: (me) => me?.profile,
   });
 
   const [username, setUsername] = useState(
-    initialUsername || me?.profile?.name || "",
+    initialUsername || profile?.name || "",
   );
   const [isUploading, setIsUploading] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  if (!me) return null;
+  if (!profile) return null;
 
   const handleAvatarUpload = async (
     event: React.ChangeEvent<HTMLInputElement>,
@@ -62,7 +63,7 @@ export function ProfileForm({
       });
 
       // Update the profile with the new avatar
-      me.profile.$jazz.set("avatar", image);
+      profile.$jazz.set("avatar", image);
     } catch (error) {
       console.error("Failed to upload avatar:", error);
     } finally {
@@ -76,15 +77,15 @@ export function ProfileForm({
     if (!username.trim()) return;
 
     // Update username
-    me.profile.$jazz.set("name", username.trim());
+    profile.$jazz.set("name", username.trim());
 
     // Call custom onSubmit if provided
     if (onSubmit) {
-      onSubmit({ username: username.trim(), avatar: me.profile.avatar });
+      onSubmit({ username: username.trim(), avatar: profile.avatar });
     }
   };
 
-  const currentAvatar = me.profile.avatar;
+  const currentAvatar = profile.avatar;
   const canSubmit = username.trim();
 
   return (

--- a/examples/music-player/src/components/SidePanel.tsx
+++ b/examples/music-player/src/components/SidePanel.tsx
@@ -12,7 +12,7 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
 } from "@/components/ui/sidebar";
-import { useAccount } from "jazz-tools/react";
+import { useAccountWithSelector } from "jazz-tools/react";
 import { Home, Music, Plus, Trash2 } from "lucide-react";
 import { useNavigate, useParams } from "react-router";
 import { useState } from "react";
@@ -22,8 +22,9 @@ import { CreatePlaylistModal } from "./CreatePlaylistModal";
 export function SidePanel() {
   const { playlistId } = useParams();
   const navigate = useNavigate();
-  const { me } = useAccount(MusicaAccount, {
+  const playlists = useAccountWithSelector(MusicaAccount, {
     resolve: { root: { playlists: { $each: { $onError: null } } } },
+    select: (me) => me?.root.playlists ?? [],
   });
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
 
@@ -106,7 +107,7 @@ export function SidePanel() {
                     <span>Add a new playlist</span>
                   </SidebarMenuButton>
                 </SidebarMenuItem>
-                {me?.root.playlists.map(
+                {playlists.map(
                   (playlist) =>
                     playlist && (
                       <SidebarMenuItem key={playlist.$jazz.id}>

--- a/examples/music-player/src/components/SidePanel.tsx
+++ b/examples/music-player/src/components/SidePanel.tsx
@@ -24,7 +24,7 @@ export function SidePanel() {
   const navigate = useNavigate();
   const playlists = useAccountWithSelector(MusicaAccount, {
     resolve: { root: { playlists: { $each: { $onError: null } } } },
-    select: (me) => me?.root.playlists ?? [],
+    select: (me) => me?.root.playlists,
   });
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
 
@@ -107,7 +107,7 @@ export function SidePanel() {
                     <span>Add a new playlist</span>
                   </SidebarMenuButton>
                 </SidebarMenuItem>
-                {playlists.map(
+                {playlists?.map(
                   (playlist) =>
                     playlist && (
                       <SidebarMenuItem key={playlist.$jazz.id}>

--- a/homepage/homepage/content/docs/using-covalues/subscription-and-loading.mdx
+++ b/homepage/homepage/content/docs/using-covalues/subscription-and-loading.mdx
@@ -208,7 +208,7 @@ function ProjectList() {
 
 </ContentByFramework>
 
-### `useCoStateWithSelector` & `useAccountWithSelector`
+### Selectors
 
 The `useCoStateWithSelector` hook is similar to `useCoState`, but allows you to select only specific parts of the CoValue data through a selector function.
 This helps reduce unnecessary re-renders by narrowing down the returned data. You can also pass a custom equality function other than the default `Object.is`.

--- a/homepage/homepage/content/docs/using-covalues/subscription-and-loading.mdx
+++ b/homepage/homepage/content/docs/using-covalues/subscription-and-loading.mdx
@@ -139,67 +139,6 @@ function TaskList({ tasks }: { tasks: ReadonlyArray<co.loaded<typeof Task>> }) {
 
 The `useCoState` hook handles subscribing when the component mounts and unsubscribing when it unmounts, making it easy to keep your UI in sync with the underlying data.
 
-### `useCoStateWithSelector`
-
-The `useCoStateWithSelector` hook is similar to `useCoState`, but allows you to select only specific parts of the CoValue data through a selector function.
-This helps reduce unnecessary re-renders by narrowing down the returned data. You can also pass a custom equality function other than the default `Object.is`.
-
-<CodeGroup>
-```tsx twoslash
-import React from "react";
-import { co, z } from "jazz-tools";
-
-const Task = co.map({
-  title: z.string(),
-  status: z.literal(["todo", "in-progress", "completed"]),
-});
-const Project = co.map({
-  name: z.string(),
-  tasks: co.list(Task),
-});
-// ---cut-before---
-import { useCoStateWithSelector } from "jazz-tools/react";
-
-function GardenPlanner({ projectId }: { projectId: string }) {
-  // Subscribe to a project and its tasks
-  const project = useCoStateWithSelector(Project, projectId, {
-    resolve: {
-      tasks: { $each: true },
-    },
-    select: (project) => {
-      if (!project) return project;
-      return {
-        name: project.name,
-        taskCount: project.tasks.length,
-        lastTaskTitle: project.tasks.at(-1)?.title,
-      };
-    },
-    equalityFn: (a, b) =>
-      a?.name === b?.name &&
-      a?.taskCount === b?.taskCount &&
-      a?.lastTaskTitle === b?.lastTaskTitle,
-  });
-
-  if (!project) {
-    return project === null
-      ? "Project not found or not accessible"
-      : "Loading project ...";
-  }
-
-  return (
-    <div>
-      <h1>{project.name}</h1>
-      <p>Number of tasks: {project.taskCount}</p>
-      <p>Last task: {project.lastTaskTitle}</p>
-    </div>
-  );
-}
-```
-</CodeGroup>
-
-The `useCoStateWithSelector` hook will subscribe to all data updates just like `useCoState`, but will only re-render when equalityFn returns `false`.
-In the above example, the `select` function will be called for all changes to all tasks, but the component will only re-render when a new task is added or when the last task's title changes.
-
 ### `useAccount`
 
 `useAccount` is used to access the current user's account.
@@ -268,6 +207,111 @@ function ProjectList() {
 </CodeGroup>
 
 </ContentByFramework>
+
+### `useCoStateWithSelector` & `useAccountWithSelector`
+
+The `useCoStateWithSelector` hook is similar to `useCoState`, but allows you to select only specific parts of the CoValue data through a selector function.
+This helps reduce unnecessary re-renders by narrowing down the returned data. You can also pass a custom equality function other than the default `Object.is`.
+
+<CodeGroup>
+```tsx twoslash
+import React from "react";
+import { co, z } from "jazz-tools";
+
+const Task = co.map({
+  title: z.string(),
+  status: z.literal(["todo", "in-progress", "completed"]),
+});
+const Project = co.map({
+  name: z.string(),
+  tasks: co.list(Task),
+});
+// ---cut-before---
+import { useCoStateWithSelector } from "jazz-tools/react";
+
+function GardenPlanner({ projectId }: { projectId: string }) {
+  // Subscribe to a project and its tasks
+  const project = useCoStateWithSelector(Project, projectId, {
+    resolve: {
+      tasks: { $each: true },
+    },
+    select: (project) => {
+      if (!project) return project;
+      return {
+        name: project.name,
+        taskCount: project.tasks.length,
+        lastTaskTitle: project.tasks.at(-1)?.title,
+      };
+    },
+    equalityFn: (a, b) =>
+      a?.name === b?.name &&
+      a?.taskCount === b?.taskCount &&
+      a?.lastTaskTitle === b?.lastTaskTitle,
+  });
+
+  if (!project) {
+    return project === null
+      ? "Project not found or not accessible"
+      : "Loading project ...";
+  }
+
+  return (
+    <div>
+      <h1>{project.name}</h1>
+      <p>Number of tasks: {project.taskCount}</p>
+      <p>Last task: {project.lastTaskTitle}</p>
+    </div>
+  );
+}
+```
+</CodeGroup>
+
+The `useCoStateWithSelector` hook will subscribe to all data updates just like `useCoState`, but will only re-render when equalityFn returns `false`.
+In the above example, the `select` function will be called for all changes to all tasks, but the component will only re-render when a new task is added or when the last task's title changes.
+
+The `useAccountWithSelector` hook is similar to `useAccount`, but allows you to select only specific parts of the account data through a selector function.
+This helps reduce unnecessary re-renders by narrowing down the returned data.
+
+
+<CodeGroup>
+```tsx twoslash
+import React from "react";
+import { co, z } from "jazz-tools";
+
+const Task = co.map({
+  title: z.string(),
+  status: z.literal(["todo", "in-progress", "completed"]),
+});
+const Project = co.map({
+  name: z.string(),
+  tasks: co.list(Task),
+});
+
+const MyAppAccount = co.account({
+  profile: co.profile(),
+  root: co.map({}),
+});
+
+// ---cut-before---
+import { useAccountWithSelector } from "jazz-tools/react";
+
+function ProfileName() {
+  // Subscribe to a project and its tasks
+  const project = useAccountWithSelector(MyAppAccount, {
+    resolve: {
+      profile: true,
+    },
+    select: (account) => account ? account.profile.name : "Loading...",
+  });
+
+  return (
+    <div>
+      {name}
+    </div>
+  );
+}
+```
+</CodeGroup>
 
 ## Loading States and Permission Checking
 

--- a/homepage/homepage/content/docs/using-covalues/subscription-and-loading.mdx
+++ b/homepage/homepage/content/docs/using-covalues/subscription-and-loading.mdx
@@ -297,7 +297,7 @@ import { useAccountWithSelector } from "jazz-tools/react";
 
 function ProfileName() {
   // Subscribe to a project and its tasks
-  const project = useAccountWithSelector(MyAppAccount, {
+  const profileName = useAccountWithSelector(MyAppAccount, {
     resolve: {
       profile: true,
     },
@@ -306,7 +306,7 @@ function ProfileName() {
 
   return (
     <div>
-      {name}
+      {profileName}
     </div>
   );
 }

--- a/homepage/homepage/content/docs/using-covalues/subscription-and-loading.mdx
+++ b/homepage/homepage/content/docs/using-covalues/subscription-and-loading.mdx
@@ -208,7 +208,7 @@ function ProjectList() {
 
 </ContentByFramework>
 
-### Selectors
+### Hooks with selectors
 
 The `useCoStateWithSelector` hook is similar to `useCoState`, but allows you to select only specific parts of the CoValue data through a selector function.
 This helps reduce unnecessary re-renders by narrowing down the returned data. You can also pass a custom equality function other than the default `Object.is`.

--- a/packages/jazz-tools/src/react-core/hooks.ts
+++ b/packages/jazz-tools/src/react-core/hooks.ts
@@ -591,10 +591,7 @@ export function useAccount<
  * The hook automatically handles the subscription lifecycle and supports deep loading of nested
  * CoValues through resolve queries, just like `useAccount`.
  *
- * @returns An object containing:
- * - `selected`: The result of the selector function applied to the loaded account data
- * - `agent`: The current agent (anonymous or authenticated user). Can be used as `loadAs` parameter for load and subscribe methods.
- * - `logOut`: Function to log out the current user
+ * @returns The result of the selector function applied to the loaded account data
  *
  * @example
  * ```tsx
@@ -610,7 +607,7 @@ export function useAccount<
  *
  * function UserProfile({ accountId }: { accountId: string }) {
  *   // Only re-render when the profile name changes, not other fields
- *   const { selected: profileName } = useAccountWithSelector(
+ *   const profileName = useAccountWithSelector(
  *     MyAppAccount,
  *     {
  *       resolve: {
@@ -643,17 +640,10 @@ export function useAccountWithSelector<
     /** Equality function to determine if the selected value has changed, defaults to `Object.is` */
     equalityFn?: (a: TSelectorReturn, b: TSelectorReturn) => boolean;
   },
-): {
-  selected: TSelectorReturn;
-  agent: AnonymousJazzAgent | Loaded<A, true>;
-  logOut: () => void;
-} {
-  const contextManager = useJazzContextManager<InstanceOfSchema<A>>();
+): TSelectorReturn {
   const subscription = useAccountSubscription(AccountSchema, options);
 
-  const agent = getCurrentAccountFromContextManager(contextManager);
-
-  const selected = useSyncExternalStoreWithSelector<
+  return useSyncExternalStoreWithSelector<
     Loaded<A, R> | undefined | null,
     TSelectorReturn
   >(
@@ -672,12 +662,6 @@ export function useAccountWithSelector<
     options.select,
     options.equalityFn ?? Object.is,
   );
-
-  return {
-    selected,
-    agent,
-    logOut: contextManager.logOut,
-  };
 }
 
 export function experimental_useInboxSender<

--- a/packages/jazz-tools/src/react-core/hooks.ts
+++ b/packages/jazz-tools/src/react-core/hooks.ts
@@ -580,6 +580,106 @@ export function useAccount<
   };
 }
 
+/**
+ * React hook for accessing the current user's account with selective data extraction and custom equality checking.
+ *
+ * This hook extends `useAccount` by allowing you to select only specific parts of the account data
+ * through a selector function, which helps reduce unnecessary re-renders by narrowing down the
+ * returned data. Additionally, you can provide a custom equality function to further optimize
+ * performance by controlling when the component should re-render based on the selected data.
+ *
+ * The hook automatically handles the subscription lifecycle and supports deep loading of nested
+ * CoValues through resolve queries, just like `useAccount`.
+ *
+ * @returns An object containing:
+ * - `selected`: The result of the selector function applied to the loaded account data
+ * - `agent`: The current agent (anonymous or authenticated user). Can be used as `loadAs` parameter for load and subscribe methods.
+ * - `logOut`: Function to log out the current user
+ *
+ * @example
+ * ```tsx
+ * // Select only specific fields to reduce re-renders
+ * const MyAppAccount = co.account({
+ *   profile: co.profile(),
+ *   root: co.map({
+ *     name: z.string(),
+ *     email: z.string(),
+ *     lastLogin: z.date(),
+ *   }),
+ * });
+ *
+ * function UserProfile({ accountId }: { accountId: string }) {
+ *   // Only re-render when the profile name changes, not other fields
+ *   const { selected: profileName } = useAccountWithSelector(
+ *     MyAppAccount,
+ *     {
+ *       resolve: {
+ *         profile: true,
+ *         root: true,
+ *       },
+ *       select: (account) => account?.profile?.name ?? "Loading...",
+ *     }
+ *   );
+ *
+ *   return <h1>{profileName}</h1>;
+ * }
+ * ```
+ *
+ * For more examples, see the [subscription and deep loading](https://jazz.tools/docs/react/using-covalues/subscription-and-loading) documentation.
+ */
+export function useAccountWithSelector<
+  A extends AccountClass<Account> | AnyAccountSchema,
+  TSelectorReturn,
+  R extends ResolveQuery<A> = true,
+>(
+  /** The account schema to use. Defaults to the base Account schema */
+  AccountSchema: A = Account as unknown as A,
+  /** Configuration for the subscription and selection */
+  options: {
+    /** Resolve query to specify which nested CoValues to load from the account */
+    resolve?: ResolveQueryStrict<A, R>;
+    /** Select which value to return from the account data */
+    select: (account: Loaded<A, R> | undefined | null) => TSelectorReturn;
+    /** Equality function to determine if the selected value has changed, defaults to `Object.is` */
+    equalityFn?: (a: TSelectorReturn, b: TSelectorReturn) => boolean;
+  },
+): {
+  selected: TSelectorReturn;
+  agent: AnonymousJazzAgent | Loaded<A, true>;
+  logOut: () => void;
+} {
+  const contextManager = useJazzContextManager<InstanceOfSchema<A>>();
+  const subscription = useAccountSubscription(AccountSchema, options);
+
+  const agent = getCurrentAccountFromContextManager(contextManager);
+
+  const selected = useSyncExternalStoreWithSelector<
+    Loaded<A, R> | undefined | null,
+    TSelectorReturn
+  >(
+    React.useCallback(
+      (callback) => {
+        if (!subscription) {
+          return () => {};
+        }
+
+        return subscription.subscribe(callback);
+      },
+      [subscription],
+    ),
+    () => (subscription ? subscription.getCurrentValue() : null),
+    () => (subscription ? subscription.getCurrentValue() : null),
+    options.select,
+    options.equalityFn ?? Object.is,
+  );
+
+  return {
+    selected,
+    agent,
+    logOut: contextManager.logOut,
+  };
+}
+
 export function experimental_useInboxSender<
   I extends CoValue,
   O extends CoValue | undefined,

--- a/packages/jazz-tools/src/react-core/tests/useAccountWithSelector.test.ts
+++ b/packages/jazz-tools/src/react-core/tests/useAccountWithSelector.test.ts
@@ -1,0 +1,365 @@
+// @vitest-environment happy-dom
+
+import { Account, RefsToResolve, co, z } from "jazz-tools";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useAccountWithSelector, useJazzContextManager } from "../hooks.js";
+import { useIsAuthenticated } from "../index.js";
+import {
+  createJazzTestAccount,
+  createJazzTestGuest,
+  setupJazzTestSync,
+} from "../testing.js";
+import { act, renderHook } from "./testUtils.js";
+import { useRef } from "react";
+
+beforeEach(async () => {
+  await setupJazzTestSync();
+});
+
+const useRenderCount = <T>(hook: () => T) => {
+  const renderCountRef = useRef(0);
+  const result = hook();
+  renderCountRef.current = renderCountRef.current + 1;
+  return {
+    renderCount: renderCountRef.current,
+    result,
+  };
+};
+
+describe("useAccountWithSelector", () => {
+  it("should return the correct selected value", async () => {
+    const AccountRoot = co.map({
+      value: z.string(),
+    });
+
+    const AccountSchema = co
+      .account({
+        root: AccountRoot,
+        profile: co.profile(),
+      })
+      .withMigration((account, creationProps) => {
+        if (!account.$jazz.refs.root) {
+          account.$jazz.set("root", { value: "123" });
+        }
+      });
+
+    const account = await createJazzTestAccount({
+      AccountSchema,
+    });
+
+    const { result } = renderHook(
+      () =>
+        useAccountWithSelector(AccountSchema, {
+          resolve: {
+            root: true,
+          },
+          select: (account) => account?.root.value ?? "Loading...",
+        }),
+      {
+        account,
+      },
+    );
+
+    expect(result.current.selected).toBe("123");
+    expect(result.current.agent).toBe(account);
+    expect(typeof result.current.logOut).toBe("function");
+  });
+
+  it("should load nested values if requested", async () => {
+    const AccountRoot = co.map({
+      value: z.string(),
+      nested: co.map({
+        nestedValue: z.string(),
+      }),
+    });
+
+    const AccountSchema = co
+      .account({
+        root: AccountRoot,
+        profile: co.profile(),
+      })
+      .withMigration((account, creationProps) => {
+        if (!account.$jazz.refs.root) {
+          const root = AccountRoot.create({
+            value: "123",
+            nested: co
+              .map({
+                nestedValue: z.string(),
+              })
+              .create({
+                nestedValue: "456",
+              }),
+          });
+          account.$jazz.set("root", root);
+        }
+      });
+
+    const account = await createJazzTestAccount({
+      AccountSchema,
+    });
+
+    const { result } = renderHook(
+      () =>
+        useAccountWithSelector(AccountSchema, {
+          resolve: {
+            root: {
+              nested: true,
+            },
+          },
+          select: (account) => account?.root.nested.nestedValue ?? "Loading...",
+        }),
+      {
+        account,
+      },
+    );
+
+    expect(result.current.selected).toBe("456");
+  });
+
+  it("should not re-render when a nested coValue is updated and not selected", async () => {
+    const AccountRoot = co.map({
+      value: z.string(),
+      get nested() {
+        return co
+          .map({
+            nestedValue: z.string(),
+          })
+          .optional();
+      },
+    });
+
+    const AccountSchema = co
+      .account({
+        root: AccountRoot,
+        profile: co.profile(),
+      })
+      .withMigration((account, creationProps) => {
+        if (!account.$jazz.refs.root) {
+          const root = AccountRoot.create({
+            value: "1",
+            nested: co
+              .map({
+                nestedValue: z.string(),
+              })
+              .create({
+                nestedValue: "1",
+              }),
+          });
+          account.$jazz.set("root", root);
+        }
+      });
+
+    const account = await createJazzTestAccount({
+      AccountSchema,
+    });
+
+    const { result } = renderHook(
+      () =>
+        useRenderCount(() =>
+          useAccountWithSelector(AccountSchema, {
+            resolve: {
+              root: {
+                nested: true,
+              },
+            },
+            select: (account) => account?.root.value ?? "Loading...",
+          }),
+        ),
+      {
+        account,
+      },
+    );
+
+    await act(async () => {
+      // Update nested value that is not selected
+      account.root.nested?.$jazz.set("nestedValue", "100");
+      await account.$jazz.waitForAllCoValuesSync();
+    });
+
+    expect(result.current.result.selected).toEqual("1");
+    expect(result.current.renderCount).toEqual(1);
+  });
+
+  it("should re-render when a nested coValue is updated and selected", async () => {
+    const AccountRoot = co.map({
+      value: z.string(),
+      get nested() {
+        return co
+          .map({
+            nestedValue: z.string(),
+          })
+          .optional();
+      },
+    });
+
+    const AccountSchema = co
+      .account({
+        root: AccountRoot,
+        profile: co.profile(),
+      })
+      .withMigration((account, creationProps) => {
+        if (!account.$jazz.refs.root) {
+          const root = AccountRoot.create({
+            value: "1",
+            nested: co
+              .map({
+                nestedValue: z.string(),
+              })
+              .create({
+                nestedValue: "1",
+              }),
+          });
+          account.$jazz.set("root", root);
+        }
+      });
+
+    const account = await createJazzTestAccount({
+      AccountSchema,
+    });
+
+    const { result } = renderHook(
+      () =>
+        useRenderCount(() =>
+          useAccountWithSelector(AccountSchema, {
+            resolve: {
+              root: {
+                nested: true,
+              },
+            },
+            select: (account) =>
+              account?.root?.nested?.nestedValue ?? "Loading...",
+          }),
+        ),
+      {
+        account,
+      },
+    );
+
+    await act(async () => {
+      // Update nested value that is selected
+      account.root?.nested?.$jazz.set("nestedValue", "100");
+      await account.$jazz.waitForAllCoValuesSync();
+    });
+
+    expect(result.current.result.selected).toEqual("100");
+    expect(result.current.renderCount).toEqual(2); // Initial render + update
+  });
+
+  it("should not re-render when equalityFn always returns true", async () => {
+    const AccountRoot = co.map({
+      value: z.string(),
+      get nested() {
+        return co
+          .map({
+            nestedValue: z.string(),
+          })
+          .optional();
+      },
+    });
+
+    const AccountSchema = co
+      .account({
+        root: AccountRoot,
+        profile: co.profile(),
+      })
+      .withMigration((account, creationProps) => {
+        if (!account.$jazz.refs.root) {
+          const root = AccountRoot.create({
+            value: "1",
+            nested: co
+              .map({
+                nestedValue: z.string(),
+              })
+              .create({
+                nestedValue: "1",
+              }),
+          });
+          account.$jazz.set("root", root);
+        }
+      });
+
+    const account = await createJazzTestAccount({
+      AccountSchema,
+    });
+
+    const { result } = renderHook(
+      () =>
+        useRenderCount(() =>
+          useAccountWithSelector(AccountSchema, {
+            resolve: {
+              root: {
+                nested: true,
+              },
+            },
+            select: (account) =>
+              account?.root?.nested?.nestedValue ?? "Loading...",
+            equalityFn: () => true, // Always return true to prevent re-renders
+          }),
+        ),
+      {
+        account,
+      },
+    );
+
+    await act(async () => {
+      // Update nested value that is selected
+      account.root?.nested?.$jazz.set("nestedValue", "100");
+      await account.$jazz.waitForAllCoValuesSync();
+    });
+
+    expect(result.current.result.selected).toEqual("1"); // Should still be "1" due to equalityFn
+    expect(result.current.renderCount).toEqual(1); // Should not re-render
+  });
+
+  it("should not load nested values if the account is a guest", async () => {
+    const AccountRoot = co.map({
+      value: z.string(),
+    });
+
+    const AccountSchema = co
+      .account({
+        root: AccountRoot,
+        profile: co.profile(),
+      })
+      .withMigration((account, creationProps) => {
+        if (!account.$jazz.refs.root) {
+          account.$jazz.set("root", { value: "123" });
+        }
+      });
+
+    const account = await createJazzTestGuest();
+
+    const { result } = renderHook(
+      () =>
+        useAccountWithSelector(AccountSchema, {
+          resolve: {
+            root: true,
+          },
+          select: (account) => account?.root?.value ?? "Guest",
+        }),
+      {
+        account,
+      },
+    );
+
+    expect(result.current.selected).toBe("Guest");
+    expect(result.current.agent).toBe(account.guest);
+  });
+
+  it("should handle undefined account gracefully", async () => {
+    const account = await createJazzTestGuest();
+
+    const { result } = renderHook(
+      () =>
+        useAccountWithSelector(Account, {
+          select: (account) => account?.$jazz.id ?? "No account",
+        }),
+      {
+        account,
+      },
+    );
+
+    expect(result.current.selected).toBe("No account");
+    expect(typeof result.current.logOut).toBe("function");
+  });
+});

--- a/packages/jazz-tools/src/react-native-core/hooks.tsx
+++ b/packages/jazz-tools/src/react-native-core/hooks.tsx
@@ -14,6 +14,7 @@ export {
   useIsAuthenticated,
   useAccount,
   useCoStateWithSelector,
+  useAccountWithSelector,
 } from "jazz-tools/react-core";
 
 export function useAcceptInviteNative<S extends CoValueClassOrSchema>({

--- a/packages/jazz-tools/src/react/hooks.tsx
+++ b/packages/jazz-tools/src/react/hooks.tsx
@@ -51,4 +51,5 @@ export {
   useJazzContext,
   useAccount,
   useCoStateWithSelector,
+  useAccountWithSelector,
 } from "jazz-tools/react-core";

--- a/packages/jazz-tools/src/react/index.ts
+++ b/packages/jazz-tools/src/react/index.ts
@@ -8,6 +8,7 @@ export {
   useJazzContext,
   useAuthSecretStorage,
   useCoStateWithSelector,
+  useAccountWithSelector,
 } from "./hooks.js";
 
 export { createInviteLink, parseInviteLink } from "jazz-tools/browser";


### PR DESCRIPTION
# Description

Adds a new `useAccountWithSelector` hook, which simplifies reaching nested values the user account.

Tested in the music player, and it's more useful than I would have expected.

## Tests

- [x] Tests have been added and/or updated
- [ ] Tests have not been updated, because: <!-- Insert reason for not updating tests here -->
- [ ] I need help with writing tests


## Checklist

- [x] I've updated the part of the docs that are affected the PR changes
- [x] I've generated a changeset, if a version bump is required
- [x] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing