### PR TITLE
fix: change log level from error to warn for ping timeout in WebSocket peer

### DIFF
--- a/.changeset/happy-queens-arrive.md
+++ b/.changeset/happy-queens-arrive.md
@@ -1,0 +1,5 @@
+---
+"cojson-transport-ws": patch
+---
+
+Downgrade the ping timeout logs to warning

--- a/packages/cojson-transport-ws/src/createWebSocketPeer.ts
+++ b/packages/cojson-transport-ws/src/createWebSocketPeer.ts
@@ -106,7 +106,7 @@ export function createWebSocketPeer({
     pingTimeout,
     () => {
       incoming.push("Disconnected");
-      logger.error("Ping timeout from peer", {
+      logger.warn("Ping timeout from peer", {
         peerId: id,
         peerRole: role,
       });


### PR DESCRIPTION
These error messages can be annoying, and most of the time a non-issue because caused by suspension.

Downgrading them to warning.