### PR TITLE
feat: add delete button to Todo list example

### DIFF
--- a/examples/todo/src/3_NewProjectForm.tsx
+++ b/examples/todo/src/3_NewProjectForm.tsx
@@ -1,10 +1,10 @@
 import { useCallback } from "react";
 
-import { Task, TodoAccount, TodoProject } from "./1_schema";
+import { TodoAccount, TodoProject } from "./1_schema";
 
 import { SubmittableInput } from "./basicComponents";
 
-import { Group, co } from "jazz-tools";
+import { Group } from "jazz-tools";
 import { useAccount } from "jazz-tools/react";
 import { useNavigate } from "react-router";
 
@@ -16,9 +16,11 @@ export function NewProjectForm() {
   });
   const navigate = useNavigate();
 
+  const projects = me?.root?.projects;
+
   const createProject = useCallback(
     (title: string) => {
-      if (!me || !title) return;
+      if (!projects || !title) return;
 
       // To create a new todo project, we first create a `Group`,
       // which is a scope for defining access rights (reader/writer/admin)
@@ -29,16 +31,16 @@ export function NewProjectForm() {
       const project = TodoProject.create(
         {
           title,
-          tasks: co.list(Task).create([], { owner: projectGroup }),
+          tasks: [],
         },
         { owner: projectGroup },
       );
 
-      me.root?.projects?.$jazz.push(project);
+      projects?.$jazz.push(project);
 
       navigate("/project/" + project.$jazz.id);
     },
-    [me, navigate],
+    [projects, navigate],
   );
 
   return (

--- a/examples/todo/src/4_ProjectTodoTable.tsx
+++ b/examples/todo/src/4_ProjectTodoTable.tsx
@@ -3,6 +3,7 @@ import { useCallback } from "react";
 import { Task, TodoProject } from "./1_schema";
 
 import {
+  Button,
   Checkbox,
   Skeleton,
   SubmittableInput,
@@ -18,6 +19,7 @@ import { Loaded } from "jazz-tools";
 import { useCoState } from "jazz-tools/react";
 import { useParams } from "react-router";
 import uniqolor from "uniqolor";
+import { Trash2 } from "lucide-react";
 import { InviteButton } from "./components/InviteButton";
 
 /** Walkthrough: Reactively rendering a todo project as a table,
@@ -66,6 +68,15 @@ export function ProjectTodoTable() {
     [project?.tasks, project?.$jazz.owner],
   );
 
+  const deleteTask = useCallback(
+    (taskId: string) => {
+      if (!project?.tasks) return;
+      // similarly, removing a task will update everyone that is subscribed to this project's tasks
+      project.tasks.$jazz.remove((t) => t?.$jazz.id === taskId);
+    },
+    [project?.tasks],
+  );
+
   return (
     <div className="max-w-full w-xl">
       <div className="flex justify-between items-center gap-4 mb-4">
@@ -94,7 +105,14 @@ export function ProjectTodoTable() {
         </TableHeader>
         <TableBody>
           {project?.tasks.map(
-            (task) => task && <TaskRow key={task.$jazz.id} task={task} />,
+            (task) =>
+              task && (
+                <TaskRow
+                  key={task.$jazz.id}
+                  task={task}
+                  deleteTask={deleteTask}
+                />
+              ),
           )}
           <NewTaskInputRow createTask={createTask} disabled={!project} />
         </TableBody>
@@ -103,7 +121,13 @@ export function ProjectTodoTable() {
   );
 }
 
-export function TaskRow({ task }: { task: Loaded<typeof Task> | undefined }) {
+export function TaskRow({
+  task,
+  deleteTask,
+}: {
+  task: Loaded<typeof Task> | undefined;
+  deleteTask: (taskId: string) => void;
+}) {
   return (
     <TableRow>
       <TableCell>
@@ -145,6 +169,17 @@ export function TaskRow({ task }: { task: Loaded<typeof Task> | undefined }) {
           }
         </div>
       </TableCell>
+      <TableCell>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => deleteTask(task?.$jazz.id ?? "")}
+          disabled={!task}
+          className="border-red-300 text-red-600 hover:bg-red-50 hover:text-red-700 hover:border-red-400"
+        >
+          <Trash2 className="h-4 w-4" />
+        </Button>
+      </TableCell>
     </TableRow>
   );
 }
@@ -171,6 +206,7 @@ function NewTaskInputRow({
           disabled={disabled}
         />
       </TableCell>
+      <TableCell>{/* Empty cell for delete button column */}</TableCell>
     </TableRow>
   );
 }

--- a/examples/todo/src/4_ProjectTodoTable.tsx
+++ b/examples/todo/src/4_ProjectTodoTable.tsx
@@ -14,7 +14,7 @@ import {
   TableRow,
 } from "./basicComponents";
 
-import { CoPlainText, Loaded } from "jazz-tools";
+import { Loaded } from "jazz-tools";
 import { useCoState } from "jazz-tools/react";
 import { useParams } from "react-router";
 import uniqolor from "uniqolor";
@@ -23,7 +23,7 @@ import { InviteButton } from "./components/InviteButton";
 /** Walkthrough: Reactively rendering a todo project as a table,
  *               adding and editing tasks
  *
- *  Here in `<TodoTable/>`, we use `useAutoSub()` for the first time,
+ *  Here in `<TodoTable/>`, we use `useCoState()` for the first time,
  *  in this case to load the CoValue for our `TodoProject` as well as
  *  the `ListOfTasks` referenced in it.
  */
@@ -31,7 +31,7 @@ import { InviteButton } from "./components/InviteButton";
 export function ProjectTodoTable() {
   const projectId = useParams<{ projectId: string }>().projectId;
 
-  // `useAutoSub()` reactively subscribes to updates to a CoValue's
+  // `useCoState()` reactively subscribes to updates to a CoValue's
   // content - whether we create edits locally, load persisted data, or receive
   // sync updates from other devices or participants!
   // It also recursively resolves and subsribes to all referenced CoValues.
@@ -54,7 +54,7 @@ export function ProjectTodoTable() {
       const task = Task.create(
         {
           done: false,
-          text: CoPlainText.create(text, project.$jazz.owner),
+          text,
           version: 1,
         },
         project.$jazz.owner,


### PR DESCRIPTION
# Description

I plan to showcase this example tomorrow and let people play with it. I thought it'd be more fun to support a delete operation to show everything working even under concurrent 

## Manual testing instructions

You can play with the updated example [here](https://jazz-todo-git-feat-todo-example-gcmp.vercel.app/).

## Tests

- [ ] Tests have not been updated, because: this example has no automated tests.