### PR TITLE
feat: enhance invite listener to handle hash changes

### DIFF
--- a/.changeset/calm-cups-compare.md
+++ b/.changeset/calm-cups-compare.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Update the Svelte InviteListener to listen to hash change events


### PR DESCRIPTION
# Description
By default, the `createInviteLink` generates a hash link. This does not trigger a navigation or the listener to be reinstantiated. As a result, if you're currently viewing `localhost:5173` and you paste the link `http://localhost:5173/#/invite/co_z<val>/inviteSecret_z<secret>`, the invite is not accepted, and the `onAccept` callback doesn't run.

Implements the TODO, by adding an event listener to hash-change events.

## Manual testing instructions
Check that you can create and accept invites, without route changes (i.e.: hash change only)

## Tests

- [ ] Tests have been added and/or updated
- [x] Tests have not been updated, because: N/A
- [ ] I need help with writing tests


## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [ ] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing