### PR TITLE
Update Svelte starter

### DIFF
--- a/starters/svelte-passkey-auth/src/apiKey.ts
+++ b/starters/svelte-passkey-auth/src/apiKey.ts
@@ -1,3 +1,2 @@
-import { PUBLIC_JAZZ_API_KEY } from "$env/static/public";
-
-export const apiKey = PUBLIC_JAZZ_API_KEY ?? "jazz-svelte-starter@garden.co";
+import { env } from "$env/dynamic/public";
+export const apiKey = env.PUBLIC_JAZZ_API_KEY ?? "jazz-svelte-starter@garden.co";


### PR DESCRIPTION
# Description
Fix for #2892—Svelte starter won't run unless a `.env` file is present with the variable due to the way SvelteKit imports the variable.

## Manual testing instructions
N/A

## Tests

- [ ] Tests have been added and/or updated
- [ ] Tests have not been updated, because: N/A
- [ ] I need help with writing tests

## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [ ] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing