### PR TITLE
fix: improve header validation in CoValueCore and SyncManager

### DIFF
--- a/.changeset/dirty-weeks-itch.md
+++ b/.changeset/dirty-weeks-itch.md
@@ -1,0 +1,5 @@
+---
+"cojson": patch
+---
+
+Validate incoming id/header to ensure that the id matches the header hash

--- a/packages/cojson/src/coValueCore/coValueCore.ts
+++ b/packages/cojson/src/coValueCore/coValueCore.ts
@@ -337,6 +337,12 @@ export class CoValueCore {
   ) {
     const previousState = this.loadingState;
 
+    const expectedId = idforHeader(header, this.node.crypto);
+
+    if (this.id !== expectedId) {
+      return false;
+    }
+
     if (this._verified?.sessions.size) {
       throw new Error(
         "CoValueCore: provideHeader called on coValue with verified sessions present!",
@@ -354,6 +360,8 @@ export class CoValueCore {
 
     this.updateCounter(previousState);
     this.notifyUpdate("immediate");
+
+    return true;
   }
 
   internalMarkMagicallyAvailable(

--- a/packages/cojson/src/sync.ts
+++ b/packages/cojson/src/sync.ts
@@ -594,12 +594,21 @@ export class SyncManager {
         }
       }
 
-      peer?.updateHeader(msg.id, true);
-      coValue.provideHeader(
+      const success = coValue.provideHeader(
         msg.header,
         peer?.id ?? "storage",
         msg.expectContentUntil,
       );
+
+      if (!success) {
+        logger.error("Failed to provide header", {
+          id: msg.id,
+          header: msg.header,
+        });
+        return;
+      }
+
+      peer?.updateHeader(msg.id, true);
 
       if (msg.expectContentUntil) {
         peer?.combineWith(msg.id, {

--- a/packages/cojson/src/tests/coValueCoreLoadingState.test.ts
+++ b/packages/cojson/src/tests/coValueCoreLoadingState.test.ts
@@ -1,11 +1,12 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { PeerState } from "../PeerState";
-import { CoValueCore } from "../coValueCore/coValueCore";
+import { CoValueCore, idforHeader } from "../coValueCore/coValueCore";
 import { CoValueHeader, VerifiedState } from "../coValueCore/verifiedState";
 import { RawCoID } from "../ids";
 import { LocalNode } from "../localNode";
 import { Peer } from "../sync";
 import { createTestMetricReader, tearDownTestMetricReader } from "./testUtils";
+import { WasmCrypto } from "../crypto/WasmCrypto";
 
 let metricReader: ReturnType<typeof createTestMetricReader>;
 
@@ -17,10 +18,21 @@ afterEach(() => {
   tearDownTestMetricReader();
 });
 
-const mockNode = {} as LocalNode;
+const mockNode = {
+  crypto: await WasmCrypto.create(),
+} as unknown as LocalNode;
+
+const testCoValueHeader = {
+  type: "comap",
+  ruleset: { type: "ownedByGroup", group: "co_ztest123" },
+  meta: null,
+  uniqueness: null,
+} as CoValueHeader;
+
+const testCoValueId = idforHeader(testCoValueHeader, mockNode.crypto);
 
 describe("CoValueCore loading state", () => {
-  const mockCoValueId = "co_test123" as RawCoID;
+  const mockCoValueId = testCoValueId;
 
   test("should create unknown state", async () => {
     const state = CoValueCore.fromID(mockCoValueId, mockNode);
@@ -195,7 +207,7 @@ describe("CoValueCore loading state", () => {
         role: "server",
       },
       async () => {
-        state.provideHeader({} as CoValueHeader, "peer1");
+        state.provideHeader(testCoValueHeader, "peer1");
       },
     );
     const peer2 = createMockPeerState(
@@ -248,7 +260,7 @@ describe("CoValueCore loading state", () => {
         role: "server",
       },
       async () => {
-        state.provideHeader({} as CoValueHeader, "peer2");
+        state.provideHeader(testCoValueHeader, "peer2");
       },
     );
 


### PR DESCRIPTION
# Description

Added a validation to provideHeader and syncManager to accept only headers which hash matches the given id.

## Tests

- [x] Tests have been added and/or updated
- [ ] Tests have not been updated, because: <!-- Insert reason for not updating tests here -->
- [ ] I need help with writing tests
