### PR TITLE
fix: detect accounts by their raw value in add & remove member

### DIFF
--- a/.changeset/add-member-account.md
+++ b/.changeset/add-member-account.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Fix addMember with account owners, by detecting the accounts from their raw value

--- a/packages/jazz-tools/src/tools/coValues/group.ts
+++ b/packages/jazz-tools/src/tools/coValues/group.ts
@@ -1,10 +1,11 @@
-import type {
-  AccountRole,
-  AgentID,
-  Everyone,
-  RawAccountID,
-  RawGroup,
-  Role,
+import {
+  RawAccount,
+  type AccountRole,
+  type AgentID,
+  type Everyone,
+  type RawAccountID,
+  type RawGroup,
+  type Role,
 } from "cojson";
 import {
   CoValue,
@@ -111,7 +112,7 @@ export class Group extends CoValueBase implements CoValue {
     member: Group | Everyone | Account,
     role?: AccountRole | "inherit",
   ) {
-    if (member !== "everyone" && member[TypeSym] === "Group") {
+    if (member !== "everyone" && isGroupValue(member)) {
       if (role === "writeOnly")
         throw new Error("Cannot add group as member with write-only role");
       this.$jazz.raw.extend(member.$jazz.raw, role);
@@ -130,7 +131,7 @@ export class Group extends CoValueBase implements CoValue {
    */
   removeMember(member: Group): void;
   removeMember(member: Group | Everyone | Account) {
-    if (member !== "everyone" && member[TypeSym] === "Group") {
+    if (member !== "everyone" && isGroupValue(member)) {
       this.$jazz.raw.revokeExtend(member.$jazz.raw);
     } else {
       return this.$jazz.raw.removeMember(
@@ -367,4 +368,8 @@ export function getCoValueOwner(coValue: CoValue): Group {
     throw new Error("CoValue has no owner");
   }
   return group;
+}
+
+function isGroupValue(value: Group | Everyone | Account): value is Group {
+  return value !== "everyone" && !(value.$jazz.raw instanceof RawAccount);
 }

--- a/packages/jazz-tools/src/tools/coValues/group.ts
+++ b/packages/jazz-tools/src/tools/coValues/group.ts
@@ -112,7 +112,7 @@ export class Group extends CoValueBase implements CoValue {
     member: Group | Everyone | Account,
     role?: AccountRole | "inherit",
   ) {
-    if (member !== "everyone" && isGroupValue(member)) {
+    if (isGroupValue(member)) {
       if (role === "writeOnly")
         throw new Error("Cannot add group as member with write-only role");
       this.$jazz.raw.extend(member.$jazz.raw, role);
@@ -131,7 +131,7 @@ export class Group extends CoValueBase implements CoValue {
    */
   removeMember(member: Group): void;
   removeMember(member: Group | Everyone | Account) {
-    if (member !== "everyone" && isGroupValue(member)) {
+    if (isGroupValue(member)) {
       this.$jazz.raw.revokeExtend(member.$jazz.raw);
     } else {
       return this.$jazz.raw.removeMember(

--- a/packages/jazz-tools/src/tools/tests/account.test.ts
+++ b/packages/jazz-tools/src/tools/tests/account.test.ts
@@ -340,6 +340,10 @@ describe("root and profile", () => {
     expect(account.profile.name).toBe("test 1");
     expect(account.profile.avatar.url).toBe("https://example.com/avatar.png");
     expect(account.root.name).toBe("test 1");
+
+    // The account when setting the owner, the owner should not extend the account
+    expect(account.root.$jazz.owner.getParentGroups()).toEqual([]);
+    expect(account.profile.$jazz.owner.getParentGroups()).toEqual([]);
   });
 });
 


### PR DESCRIPTION
When I was debugging one of my test accounts I found this:
<img width="2543" height="814" alt="Screenshot 2025-09-15 at 14 32 40" src="https://github.com/user-attachments/assets/ce257799-f245-48bf-ad3f-f90bb064b8b0" />

The cause is, when setting the root as JSON, the account is owner is detected as Group and then it follows the group.extend path instead of the group.addMember.

Fixed by detecting accounts by their raw value instead of the schema