### PR TITLE
docs: adjust prominence of Node 20 alert

### DIFF
--- a/homepage/homepage/content/docs/getting-started/quickstart.mdx
+++ b/homepage/homepage/content/docs/getting-started/quickstart.mdx
@@ -11,9 +11,6 @@ import { ReactLogo } from "@/components/icons/ReactLogo";
 This quickstart guide will take you from an empty project to a working app with authentication and a simple data model.
 
 <ContentByFramework framework="react">
-  <Alert variant="info" className="mt-4 flex gap-2 items-center">
-    Requires Node.js 20+
-  </Alert>
   ## Create your React App
   We'll be using Next.js and TypeScript with `pnpm` for this guide, but Jazz works great with vanilla React too.
 
@@ -36,9 +33,6 @@ This quickstart guide will take you from an empty project to a working app with 
 
 </ContentByFramework>
 <ContentByFramework framework="svelte">
-  <Alert variant="info" className="mt-4 flex gap-2 items-center">
-    Requires Node.js 20+
-  </Alert>
   ## Create your Svelte App
 
   <TabbedCodeGroup id="create-svelte-app" default="pnpm" savedPreferenceKey="package-manager">
@@ -56,7 +50,7 @@ This quickstart guide will take you from an empty project to a working app with 
   </TabbedCodeGroupItem>
   </TabbedCodeGroup>
 </ContentByFramework>
-
+**Note: Requires Node.js 20+**
 
 ## Install Jazz
 


### PR DESCRIPTION
# Description
Moves Node 20 alert to a less prominent and aggressive bold note under the content, rather than a full alert block.

## Manual testing instructions
N/A

## Tests

- [ ] Tests have been added and/or updated
- [x] Tests have not been updated, because: N/A
- [ ] I need help with writing tests


## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [ ] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing