### PR TITLE
Add custom placeholders for Image components

### DIFF
--- a/.changeset/clever-dryers-battle.md
+++ b/.changeset/clever-dryers-battle.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Allow users to specify custom placeholders to be used while images are loading

--- a/homepage/homepage/content/docs/core-concepts/covalues/imagedef.mdx
+++ b/homepage/homepage/content/docs/core-concepts/covalues/imagedef.mdx
@@ -450,7 +450,7 @@ const styles = StyleSheet.create({
 </TabbedCodeGroup>
 
 The `Image` component handles:
-- Showing a placeholder while loading, if generated
+- Showing a placeholder while loading, if generated or specified
 - Automatically selecting the appropriate resolution, if generated with progressive loading
 - Progressive enhancement as higher resolutions become available, if generated with progressive loading
 - Determining the correct width/height attributes to avoid layout shifting
@@ -469,6 +469,7 @@ export type ImageProps = Omit<
   imageId: string;
   width?: number | "original";
   height?: number | "original";
+  placeholder?: string;
 };
 ```
 </CodeGroup>
@@ -484,6 +485,7 @@ export type ImageProps = Omit<
   imageId: string;
   width?: number | "original";
   height?: number | "original";
+  placeholder?: string;
 };
 ```
 </CodeGroup>
@@ -534,6 +536,11 @@ The `Image` component supports lazy loading with the [same options as the native
 </ContentByFramework>
 
 <ContentByFramework framework={['react', 'svelte','react-native','react-native-expo']}>
+
+#### Placeholder
+
+You can choose to specify a custom placeholder to display as a fallback while an image is loading in case your image does not have a placeholder generated. A data URL or a URL for a static asset works well here.
+
 ### Imperative Usage [!framework=react,svelte,react-native,react-native-expo]
 </ContentByFramework>
 

--- a/homepage/homepage/content/docs/core-concepts/covalues/imagedef.mdx
+++ b/homepage/homepage/content/docs/core-concepts/covalues/imagedef.mdx
@@ -228,7 +228,7 @@ async function handleImagePicker() {
 
 The `createImage()` function:
 - Creates an `ImageDefinition` with the right properties
-- Generates a small placeholder for immediate display
+- Optionally generates a small placeholder for immediate display
 - Creates multiple resolution variants of your image
 - Returns the created `ImageDefinition`
 
@@ -242,7 +242,7 @@ declare function createImage(
   image: Blob | File | string,
   options: {
     owner?: Group | Account;
-    placeholder?: "blur" | false;
+    placeholder?: false | "blur";
     maxSize?: number;
     progressive?: boolean;
   }): Loaded<
@@ -268,7 +268,7 @@ The owner of the `ImageDefinition`. This is used to control access to the image.
 
 #### `placeholder`
 
-The placeholder is a base64 encoded image that is displayed while the image is loading. Currently, only `"blur"` is a supported.
+Disabled by default. This option allows you to automatically generate a low resolution preview for use while the image is loading. Currently, only `"blur"` is a supported.
 
 #### `maxSize`
 

--- a/packages/jazz-tools/src/react-native-core/media/image.tsx
+++ b/packages/jazz-tools/src/react-native-core/media/image.tsx
@@ -38,9 +38,10 @@ export type ImageProps = Omit<RNImageProps, "width" | "height" | "source"> & {
   /**
    * A custom placeholder to display while an image is loading. This will
    * be passed as the src of the img tag, so a data URL works well here.
-   * This will override any placeholders generated when the image was created.
+   * This will be used as a fallback if no images are ready and no placeholder
+   * is available otherwise.
    */
-  customPlaceholder?: string;
+  placeholder?: string;
 };
 
 /**
@@ -59,7 +60,7 @@ export type ImageProps = Omit<RNImageProps, "width" | "height" | "source"> & {
  *       width={100}
  *       height={100}
  *       resizeMode="cover"
- *       customPlaceholder="/placeholder.png"
+ *       placeholder="/placeholder.png"
  *     />
  *   );
  * }
@@ -72,7 +73,7 @@ export type ImageProps = Omit<RNImageProps, "width" | "height" | "source"> & {
  * ```
  */
 export const Image = forwardRef<RNImage, ImageProps>(function Image(
-  { imageId, width, height, customPlaceholder, ...props },
+  { imageId, width, height, placeholder, ...props },
   ref,
 ) {
   const image = useCoState(ImageDefinition, imageId);
@@ -124,7 +125,7 @@ export const Image = forwardRef<RNImage, ImageProps>(function Image(
     if (!image) return;
 
     let lastBestImage: FileStream | string | undefined =
-      customPlaceholder ?? image?.placeholderDataURL;
+      image?.placeholderDataURL ?? placeholder;
 
     const unsub = image.$jazz.subscribe({}, (update) => {
       if (lastBestImage === undefined && update.placeholderDataURL) {

--- a/packages/jazz-tools/src/react-native-core/media/image.tsx
+++ b/packages/jazz-tools/src/react-native-core/media/image.tsx
@@ -35,6 +35,12 @@ export type ImageProps = Omit<RNImageProps, "width" | "height" | "source"> & {
    * ```
    */
   height?: number | "original";
+  /**
+   * A custom placeholder to display while an image is loading. This will
+   * be passed as the src of the img tag, so a data URL works well here.
+   * This will override any placeholders generated when the image was created.
+   */
+  customPlaceholder?: string;
 };
 
 /**
@@ -53,6 +59,7 @@ export type ImageProps = Omit<RNImageProps, "width" | "height" | "source"> & {
  *       width={100}
  *       height={100}
  *       resizeMode="cover"
+ *       customPlaceholder="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9ImN1cnJlbnRDb2xvciIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIGNsYXNzPSJsdWNpZGUgbHVjaWRlLXVzZXItaWNvbiBsdWNpZGUtdXNlciI+PHBhdGggZD0iTTE5IDIxdi0yYTQgNCAwIDAgMC00LTRIOWE0IDQgMCAwIDAtNCA0djIiLz48Y2lyY2xlIGN4PSIxMiIgY3k9IjciIHI9IjQiLz48L3N2Zz4="
  *     />
  *   );
  * }
@@ -65,7 +72,7 @@ export type ImageProps = Omit<RNImageProps, "width" | "height" | "source"> & {
  * ```
  */
 export const Image = forwardRef<RNImage, ImageProps>(function Image(
-  { imageId, width, height, ...props },
+  { imageId, width, height, customPlaceholder, ...props },
   ref,
 ) {
   const image = useCoState(ImageDefinition, imageId);
@@ -117,7 +124,7 @@ export const Image = forwardRef<RNImage, ImageProps>(function Image(
     if (!image) return;
 
     let lastBestImage: FileStream | string | undefined =
-      image.placeholderDataURL;
+      customPlaceholder ?? image?.placeholderDataURL;
 
     const unsub = image.$jazz.subscribe({}, (update) => {
       if (lastBestImage === undefined && update.placeholderDataURL) {
@@ -146,7 +153,7 @@ export const Image = forwardRef<RNImage, ImageProps>(function Image(
     return unsub;
   }, [image]);
 
-  if (!image) {
+  if (!src) {
     return null;
   }
 

--- a/packages/jazz-tools/src/react-native-core/media/image.tsx
+++ b/packages/jazz-tools/src/react-native-core/media/image.tsx
@@ -59,7 +59,7 @@ export type ImageProps = Omit<RNImageProps, "width" | "height" | "source"> & {
  *       width={100}
  *       height={100}
  *       resizeMode="cover"
- *       customPlaceholder="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9ImN1cnJlbnRDb2xvciIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIGNsYXNzPSJsdWNpZGUgbHVjaWRlLXVzZXItaWNvbiBsdWNpZGUtdXNlciI+PHBhdGggZD0iTTE5IDIxdi0yYTQgNCAwIDAgMC00LTRIOWE0IDQgMCAwIDAtNCA0djIiLz48Y2lyY2xlIGN4PSIxMiIgY3k9IjciIHI9IjQiLz48L3N2Zz4="
+ *       customPlaceholder="/placeholder.png"
  *     />
  *   );
  * }

--- a/packages/jazz-tools/src/react/media/image.tsx
+++ b/packages/jazz-tools/src/react/media/image.tsx
@@ -54,9 +54,10 @@ export type ImageProps = Omit<
   /**
    * A custom placeholder to display while an image is loading. This will
    * be passed as the src of the img tag, so a data URL works well here.
-   * This will override any placeholders generated when the image was created.
+   * This will be used as a fallback if no images are ready and no placeholder
+   * is available otherwise.
    */
-  customPlaceholder?: string;
+  placeholder?: string;
 };
 
 /**
@@ -75,7 +76,7 @@ export type ImageProps = Omit<
  *       height={100}
  *       alt="Avatar"
  *       style={{ borderRadius: "50%", objectFit: "cover" }}
- *       customPlaceholder="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9ImN1cnJlbnRDb2xvciIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIGNsYXNzPSJsdWNpZGUgbHVjaWRlLXVzZXItaWNvbiBsdWNpZGUtdXNlciI+PHBhdGggZD0iTTE5IDIxdi0yYTQgNCAwIDAgMC00LTRIOWE0IDQgMCAwIDAtNCA0djIiLz48Y2lyY2xlIGN4PSIxMiIgY3k9IjciIHI9IjQiLz48L3N2Zz4="
+         placeholder={myPlaceholder}
  *     />
  *   );
  * }
@@ -158,7 +159,7 @@ export const Image = forwardRef<HTMLImageElement, ImageProps>(function Image(
       dimensions.height || dimensions.width || 9999,
     );
 
-    if (!bestImage) return props?.customPlaceholder ?? image.placeholderDataURL;
+    if (!bestImage) return image.placeholderDataURL ?? props?.placeholder;
     if (lastBestImage.current?.[0] === bestImage.image.$jazz.id)
       return lastBestImage.current?.[1];
 
@@ -171,7 +172,7 @@ export const Image = forwardRef<HTMLImageElement, ImageProps>(function Image(
       return url;
     }
 
-    return props?.customPlaceholder ?? image.placeholderDataURL;
+    return image.placeholderDataURL ?? props?.placeholder;
   }, [image, dimensions.width, dimensions.height, waitingLazyLoading]);
 
   const onThresholdReached = useCallback(() => {

--- a/packages/jazz-tools/src/react/media/image.tsx
+++ b/packages/jazz-tools/src/react/media/image.tsx
@@ -51,6 +51,12 @@ export type ImageProps = Omit<
    * ```
    */
   height?: number | "original";
+  /**
+   * A custom placeholder to display while an image is loading. This will
+   * be passed as the src of the img tag, so a data URL works well here.
+   * This will override any placeholders generated when the image was created.
+   */
+  customPlaceholder?: string;
 };
 
 /**
@@ -69,11 +75,13 @@ export type ImageProps = Omit<
  *       height={100}
  *       alt="Avatar"
  *       style={{ borderRadius: "50%", objectFit: "cover" }}
+ *       customPlaceholder="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9ImN1cnJlbnRDb2xvciIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIGNsYXNzPSJsdWNpZGUgbHVjaWRlLXVzZXItaWNvbiBsdWNpZGUtdXNlciI+PHBhdGggZD0iTTE5IDIxdi0yYTQgNCAwIDAgMC00LTRIOWE0IDQgMCAwIDAtNCA0djIiLz48Y2lyY2xlIGN4PSIxMiIgY3k9IjciIHI9IjQiLz48L3N2Zz4="
  *     />
  *   );
  * }
  * ```
  */
+
 export const Image = forwardRef<HTMLImageElement, ImageProps>(function Image(
   { imageId, width, height, ...props },
   ref,
@@ -150,7 +158,7 @@ export const Image = forwardRef<HTMLImageElement, ImageProps>(function Image(
       dimensions.height || dimensions.width || 9999,
     );
 
-    if (!bestImage) return image.placeholderDataURL;
+    if (!bestImage) return props?.customPlaceholder ?? image.placeholderDataURL;
     if (lastBestImage.current?.[0] === bestImage.image.$jazz.id)
       return lastBestImage.current?.[1];
 
@@ -163,7 +171,7 @@ export const Image = forwardRef<HTMLImageElement, ImageProps>(function Image(
       return url;
     }
 
-    return image.placeholderDataURL;
+    return props?.customPlaceholder ?? image.placeholderDataURL;
   }, [image, dimensions.width, dimensions.height, waitingLazyLoading]);
 
   const onThresholdReached = useCallback(() => {

--- a/packages/jazz-tools/src/react/tests/media/image.test.tsx
+++ b/packages/jazz-tools/src/react/tests/media/image.test.tsx
@@ -101,6 +101,100 @@ describe("Image", async () => {
       expect(img!.src).toBe(placeholderDataUrl);
     });
 
+    it("should render a custom placeholder if one is provided", async () => {
+      const placeholderDataUrl =
+        "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=";
+      const customPlaceholder =
+        "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9ImN1cnJlbnRDb2xvciIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIGNsYXNzPSJsdWNpZGUgbHVjaWRlLXVzZXItaWNvbiBsdWNpZGUtdXNlciI+PHBhdGggZD0iTTE5IDIxdi0yYTQgNCAwIDAgMC00LTRIOWE0IDQgMCAwIDAtNCA0djIiLz48Y2lyY2xlIGN4PSIxMiIgY3k9IjciIHI9IjQiLz48L3N2Zz4=";
+
+      const original = FileStream.create({ owner: account });
+      original.start({ mimeType: "image/jpeg" });
+      // Don't end original, so it has no chunks
+
+      const im = ImageDefinition.create(
+        {
+          original,
+          originalSize: [100, 100],
+          progressive: false,
+          placeholderDataURL: placeholderDataUrl,
+        },
+        {
+          owner: account,
+        },
+      );
+
+      const { container } = render(
+        <Image
+          imageId={im.$jazz.id}
+          alt="test"
+          customPlaceholder={customPlaceholder}
+        />,
+        {
+          account,
+        },
+      );
+
+      const img = container.querySelector("img");
+      expect(img).toBeDefined();
+      expect(img!.src).toBe(customPlaceholder);
+    });
+
+    it("should show custom placeholder while loading and replace with loaded image", async () => {
+      const createObjectURLSpy = vi
+        .spyOn(URL, "createObjectURL")
+        .mockImplementation((blob) => {
+          if (!(blob instanceof Blob)) {
+            throw new Error("Blob expected");
+          }
+          return `blob:test-${blob.size}`;
+        });
+
+      const customPlaceholder =
+        "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9ImN1cnJlbnRDb2xvciIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIGNsYXNzPSJsdWNpZGUgbHVjaWRlLXVzZXItaWNvbiBsdWNpZGUtdXNlciI+PHBhdGggZD0iTTE5IDIxdi0yYTQgNCAwIDAgMC00LTRIOWE0IDQgMCAwIDAtNCA0djIiLz48Y2lyY2xlIGN4PSIxMiIgY3k9IjciIHI9IjQiLz48L3N2Zz4=";
+
+      // Create an image with no chunks initially (loading state)
+      const original = FileStream.create({ owner: account });
+      original.start({ mimeType: "image/jpeg" });
+      // Don't end original, so it has no chunks
+
+      const im = ImageDefinition.create(
+        {
+          original,
+          originalSize: [100, 100],
+          progressive: false,
+        },
+        {
+          owner: account,
+        },
+      );
+
+      const { container } = render(
+        <Image
+          imageId={im.$jazz.id}
+          alt="test-loading-custom-placeholder"
+          customPlaceholder={customPlaceholder}
+        />,
+        { account },
+      );
+
+      // Initially should show custom placeholder
+      let img = container.querySelector("img");
+      expect(img).toBeDefined();
+      expect(img!.src).toBe(customPlaceholder);
+
+      // Now add the actual image data
+      const imageData = await createDummyFileStream(100, account);
+      im.$jazz.set("100x100", imageData);
+
+      // Wait for the image to load and replace the placeholder
+      await waitFor(() => {
+        img = container.querySelector("img");
+        expect(img!.src).toBe("blob:test-100");
+      });
+
+      expect(createObjectURLSpy).toHaveBeenCalledTimes(1);
+    });
+
     it("should render the original image once loaded", async () => {
       const createObjectURLSpy = vi
         .spyOn(URL, "createObjectURL")

--- a/packages/jazz-tools/src/react/tests/media/image.test.tsx
+++ b/packages/jazz-tools/src/react/tests/media/image.test.tsx
@@ -101,7 +101,7 @@ describe("Image", async () => {
       expect(img!.src).toBe(placeholderDataUrl);
     });
 
-    it("should render a custom placeholder if one is provided", async () => {
+    it("should not override actual placeholders", async () => {
       const placeholderDataUrl =
         "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=";
       const customPlaceholder =
@@ -127,7 +127,7 @@ describe("Image", async () => {
         <Image
           imageId={im.$jazz.id}
           alt="test"
-          customPlaceholder={customPlaceholder}
+          placeholder={customPlaceholder}
         />,
         {
           account,
@@ -136,7 +136,7 @@ describe("Image", async () => {
 
       const img = container.querySelector("img");
       expect(img).toBeDefined();
-      expect(img!.src).toBe(customPlaceholder);
+      expect(img!.src).toBe(placeholderDataUrl);
     });
 
     it("should show custom placeholder while loading and replace with loaded image", async () => {
@@ -172,7 +172,7 @@ describe("Image", async () => {
         <Image
           imageId={im.$jazz.id}
           alt="test-loading-custom-placeholder"
-          customPlaceholder={customPlaceholder}
+          placeholder={customPlaceholder}
         />,
         { account },
       );

--- a/packages/jazz-tools/src/svelte/media/image.svelte
+++ b/packages/jazz-tools/src/svelte/media/image.svelte
@@ -5,7 +5,7 @@
   import { CoState } from "../jazz.class.svelte";
   import type { ImageProps } from "./image.types.js";
 
-  const { imageId, width, height, ...rest }: ImageProps = $props();
+  const { imageId, width, height, placeholder, ...rest }: ImageProps = $props();
 
   const imageState = new CoState(ImageDefinition, () => imageId);
   let lastBestImage: [string, string] | null = null;
@@ -69,7 +69,10 @@
 
     const image = imageState.current;
     if (image === undefined)
-      return "data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==";
+      return (
+        placeholder ??
+        "data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
+      );
 
     if (!image) return undefined;
 
@@ -79,7 +82,7 @@
       dimensions.height || dimensions.width || 9999,
     );
 
-    if (!bestImage) return image.placeholderDataURL;
+    if (!bestImage) return image.placeholderDataURL ?? placeholder;
     if (lastBestImage?.[0] === bestImage.image.$jazz.id)
       return lastBestImage?.[1];
 
@@ -92,7 +95,7 @@
       return url;
     }
 
-    return image.placeholderDataURL;
+    return image.placeholderDataURL ?? placeholder;
   });
 
   // Cleanup object URL on component destroy

--- a/packages/jazz-tools/src/svelte/media/image.types.ts
+++ b/packages/jazz-tools/src/svelte/media/image.types.ts
@@ -4,5 +4,5 @@ export interface ImageProps extends Omit<HTMLImgAttributes, "width" | "height"> 
   imageId: string;
   width?: number | "original";
   height?: number | "original";
-  customPlaceholder?: string;
+  placeholder?: string;
 }

--- a/packages/jazz-tools/src/svelte/media/image.types.ts
+++ b/packages/jazz-tools/src/svelte/media/image.types.ts
@@ -4,4 +4,5 @@ export interface ImageProps extends Omit<HTMLImgAttributes, "width" | "height"> 
   imageId: string;
   width?: number | "original";
   height?: number | "original";
+  customPlaceholder?: string;
 }

--- a/packages/jazz-tools/src/svelte/tests/media/image.svelte.test.ts
+++ b/packages/jazz-tools/src/svelte/tests/media/image.svelte.test.ts
@@ -12,7 +12,6 @@ describe("Image", async () => {
   });
 
   const renderWithAccount = (props: ImageProps) =>
-    // @ts-expect-error Svelte new Component type is not compatible with @testing-library/svelte
     render(Image, props, { account });
 
   describe("initial rendering", () => {

--- a/packages/jazz-tools/src/svelte/tests/media/image.svelte.test.ts
+++ b/packages/jazz-tools/src/svelte/tests/media/image.svelte.test.ts
@@ -104,7 +104,7 @@ describe("Image", async () => {
       expect(img!.src).toBe(placeholderDataUrl);
     });
 
-    it("should render a custom placeholder if one is provided", async () => {
+    it("should not override actual placeholders", async () => {
       const placeholderDataUrl =
         "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=";
       const customPlaceholder =
@@ -129,12 +129,12 @@ describe("Image", async () => {
       const { container } = renderWithAccount({
         imageId: im.$jazz.id,
         alt: "test",
-        customPlaceholder: customPlaceholder
+        placeholder: customPlaceholder
       });
 
       const img = container.querySelector("img");
       expect(img).toBeDefined();
-      expect(img!.src).toBe(customPlaceholder);
+      expect(img!.src).toBe(placeholderDataUrl);
     });
 
     it("should show custom placeholder while loading and replace with loaded image", async () => {
@@ -169,7 +169,7 @@ describe("Image", async () => {
       const { container } = renderWithAccount({
         imageId: im.$jazz.id,
         alt: "test-loading-custom-placeholder",
-        customPlaceholder: customPlaceholder
+        placeholder: customPlaceholder
       });
       // Initially should show custom placeholder
       let img = container.querySelector("img");

--- a/packages/jazz-tools/src/svelte/tests/media/image.svelte.test.ts
+++ b/packages/jazz-tools/src/svelte/tests/media/image.svelte.test.ts
@@ -12,6 +12,7 @@ describe("Image", async () => {
   });
 
   const renderWithAccount = (props: ImageProps) =>
+    // @ts-expect-error Svelte new Component type is not compatible with @testing-library/svelte
     render(Image, props, { account });
 
   describe("initial rendering", () => {
@@ -102,6 +103,91 @@ describe("Image", async () => {
       const img = container.querySelector("img");
       expect(img).toBeDefined();
       expect(img!.src).toBe(placeholderDataUrl);
+    });
+
+    it("should render a custom placeholder if one is provided", async () => {
+      const placeholderDataUrl =
+        "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=";
+      const customPlaceholder =
+        "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9ImN1cnJlbnRDb2xvciIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIGNsYXNzPSJsdWNpZGUgbHVjaWRlLXVzZXItaWNvbiBsdWNpZGUtdXNlciI+PHBhdGggZD0iTTE5IDIxdi0yYTQgNCAwIDAgMC00LTRIOWE0IDQgMCAwIDAtNCA0djIiLz48Y2lyY2xlIGN4PSIxMiIgY3k9IjciIHI9IjQiLz48L3N2Zz4=";
+
+      const original = FileStream.create({ owner: account });
+      original.start({ mimeType: "image/jpeg" });
+      // Don't end original, so it has no chunks
+
+      const im = ImageDefinition.create(
+        {
+          original,
+          originalSize: [100, 100],
+          progressive: false,
+          placeholderDataURL: placeholderDataUrl,
+        },
+        {
+          owner: account,
+        },
+      );
+
+      const { container } = renderWithAccount({
+        imageId: im.$jazz.id,
+        alt: "test",
+        customPlaceholder: customPlaceholder
+      });
+
+      const img = container.querySelector("img");
+      expect(img).toBeDefined();
+      expect(img!.src).toBe(customPlaceholder);
+    });
+
+    it("should show custom placeholder while loading and replace with loaded image", async () => {
+      const createObjectURLSpy = vi
+        .spyOn(URL, "createObjectURL")
+        .mockImplementation((blob) => {
+          if (!(blob instanceof Blob)) {
+            throw new Error("Blob expected");
+          }
+          return `blob:test-${blob.size}`;
+        });
+
+      const customPlaceholder =
+        "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9ImN1cnJlbnRDb2xvciIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIGNsYXNzPSJsdWNpZGUgbHVjaWRlLXVzZXItaWNvbiBsdWNpZGUtdXNlciI+PHBhdGggZD0iTTE5IDIxdi0yYTQgNCAwIDAgMC00LTRIOWE0IDQgMCAwIDAtNCA0djIiLz48Y2lyY2xlIGN4PSIxMiIgY3k9IjciIHI9IjQiLz48L3N2Zz4=";
+
+      // Create an image with no chunks initially (loading state)
+      const original = FileStream.create({ owner: account });
+      original.start({ mimeType: "image/jpeg" });
+      // Don't end original, so it has no chunks
+
+      const im = ImageDefinition.create(
+        {
+          original,
+          originalSize: [100, 100],
+          progressive: false,
+        },
+        {
+          owner: account,
+        },
+      );
+
+      const { container } = renderWithAccount({
+        imageId: im.$jazz.id,
+        alt: "test-loading-custom-placeholder",
+        customPlaceholder: customPlaceholder
+      });
+      // Initially should show custom placeholder
+      let img = container.querySelector("img");
+      expect(img).toBeDefined();
+      expect(img!.src).toBe(customPlaceholder);
+
+      // Now add the actual image data
+      const imageData = await createDummyFileStream(100, account);
+      im.$jazz.set("100x100", imageData);
+
+      // Wait for the image to load and replace the placeholder
+      await waitFor(() => {
+        img = container.querySelector("img");
+        expect(img!.src).toBe("blob:test-100");
+      });
+
+      expect(createObjectURLSpy).toHaveBeenCalledTimes(1);
     });
 
     it("should render the original image once loaded", async () => {


### PR DESCRIPTION
# Description
Since Jazz v0.17.0, we've defaulted to *not* generating placeholder images by default. This meant that some users were surprised on upgrading to see flashes of alt text instead of a loading image.

Although this is the browser's default behaviour, the experience can be somewhat jarring.

This PR allows users to specify custom placeholder images (e.g. their brand). If no custom placeholder is specified, the image will be transparent until the CoValue is resolved (i.e. when it's loading, there will be no flash of alt text), 

## Manual testing instructions

N/A

## Tests

- [x] Tests have been added and/or updated
- [ ] Tests have not been updated, because: <!-- Insert reason for not updating tests here -->
- [ ] I need help with writing tests


## Checklist

- [x] I've updated the part of the docs that are affected the PR changes
- [x] I've generated a changeset, if a version bump is required
- [x] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing