### PR TITLE
Update Image component to display a transparent pixel while the CoValue is loading

### DIFF
--- a/.changeset/neat-baboons-rhyme.md
+++ b/.changeset/neat-baboons-rhyme.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Fix an issue where a flash of alt text displays while an image definition is loading from storage

--- a/packages/jazz-tools/src/react-native-core/media/image.tsx
+++ b/packages/jazz-tools/src/react-native-core/media/image.tsx
@@ -69,7 +69,10 @@ export const Image = forwardRef<RNImage, ImageProps>(function Image(
   ref,
 ) {
   const image = useCoState(ImageDefinition, imageId);
-  const [src, setSrc] = useState<string | undefined>(image?.placeholderDataURL);
+  const [src, setSrc] = useState<string | undefined>(
+    image?.placeholderDataURL ??
+      "data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==",
+  );
 
   const dimensions: { width: number | undefined; height: number | undefined } =
     useMemo(() => {

--- a/packages/jazz-tools/src/react/media/image.tsx
+++ b/packages/jazz-tools/src/react/media/image.tsx
@@ -140,6 +140,8 @@ export const Image = forwardRef<HTMLImageElement, ImageProps>(function Image(
       return lazyPlaceholder;
     }
 
+    if (image === undefined)
+      return "data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==";
     if (!image) return undefined;
 
     const bestImage = highestResAvailable(

--- a/packages/jazz-tools/src/react/tests/media/image.test.tsx
+++ b/packages/jazz-tools/src/react/tests/media/image.test.tsx
@@ -13,6 +13,22 @@ describe("Image", async () => {
   vi.spyOn(Account, "getMe").mockReturnValue(account);
 
   describe("initial rendering", () => {
+    it("should render a blank placeholder while waiting for the coValue to load", async () => {
+      const { container } = render(
+        <Image imageId="co_zMTubMby3QiKDYnW9e2BEXW7Xaq" alt="test" />,
+        { account },
+      );
+
+      const img = container.querySelector("img");
+      expect(img).toBeDefined();
+      expect(img!.getAttribute("width")).toBe(null);
+      expect(img!.getAttribute("height")).toBe(null);
+      expect(img!.alt).toBe("test");
+      expect(img!.src).toBe(
+        "data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==",
+      );
+    });
+
     it("should render nothing if coValue is not found", async () => {
       const { container } = render(
         <Image imageId="co_zMTubMby3QiKDYnW9e2BEXW7Xaq" alt="test" />,

--- a/packages/jazz-tools/src/react/tests/media/image.test.tsx
+++ b/packages/jazz-tools/src/react/tests/media/image.test.tsx
@@ -18,12 +18,14 @@ describe("Image", async () => {
         <Image imageId="co_zMTubMby3QiKDYnW9e2BEXW7Xaq" alt="test" />,
         { account },
       );
-      const img = container.querySelector("img");
-      expect(img).toBeDefined();
-      expect(img!.getAttribute("width")).toBe(null);
-      expect(img!.getAttribute("height")).toBe(null);
-      expect(img!.alt).toBe("test");
-      expect(img!.src).toBe("");
+      await waitFor(() => {
+        const img = container.querySelector("img");
+        expect(img).toBeDefined();
+        expect(img!.getAttribute("width")).toBe(null);
+        expect(img!.getAttribute("height")).toBe(null);
+        expect(img!.alt).toBe("test");
+        expect(img!.src).toBe("");
+      });
     });
 
     it("should render an empty image if the image is not loaded yet", async () => {

--- a/packages/jazz-tools/src/svelte/media/image.svelte
+++ b/packages/jazz-tools/src/svelte/media/image.svelte
@@ -1,118 +1,122 @@
 <script lang="ts">
-import { ImageDefinition } from "jazz-tools";
-import { highestResAvailable } from "jazz-tools/media";
-import { onDestroy } from "svelte";
-import { CoState } from "../jazz.class.svelte";
-import type { ImageProps } from "./image.types.js";
+  import { ImageDefinition } from "jazz-tools";
+  import { highestResAvailable } from "jazz-tools/media";
+  import { onDestroy } from "svelte";
+  import { CoState } from "../jazz.class.svelte";
+  import type { ImageProps } from "./image.types.js";
 
-const { imageId, width, height, ...rest }: ImageProps = $props();
+  const { imageId, width, height, ...rest }: ImageProps = $props();
 
-const imageState = new CoState(ImageDefinition, () => imageId);
-let lastBestImage: [string, string] | null = null;
+  const imageState = new CoState(ImageDefinition, () => imageId);
+  let lastBestImage: [string, string] | null = null;
 
-/**
- * For lazy loading, we use the browser's strategy for images with loading="lazy".
- * We use an empty image, and when the browser triggers the load event, we load the best available image.
- * On page loading, if the image url is already in browser's cache, the load event is triggered immediately.
- * This is why we need to use a different blob url for every image.
- */
-let waitingLazyLoading = $state(rest.loading === "lazy");
-const lazyPlaceholder = $derived.by(() =>
-  waitingLazyLoading ? URL.createObjectURL(emptyPixelBlob) : undefined,
-);
-
-const dimensions = $derived.by<{
-  width: number | undefined;
-  height: number | undefined;
-}>(() => {
-  const originalWidth = imageState.current?.originalSize?.[0];
-  const originalHeight = imageState.current?.originalSize?.[1];
-
-  // Both width and height are "original"
-  if (width === "original" && height === "original") {
-    return { width: originalWidth, height: originalHeight };
-  }
-
-  // Width is "original", height is a number
-  if (width === "original" && typeof height === "number") {
-    if (originalWidth && originalHeight) {
-      return {
-        width: Math.round((height * originalWidth) / originalHeight),
-        height,
-      };
-    }
-    return { width: undefined, height };
-  }
-
-  // Height is "original", width is a number
-  if (height === "original" && typeof width === "number") {
-    if (originalWidth && originalHeight) {
-      return {
-        width,
-        height: Math.round((width * originalHeight) / originalWidth),
-      };
-    }
-    return { width, height: undefined };
-  }
-
-  // In all other cases, use the property value:
-  return {
-    width: width === "original" ? originalWidth : width,
-    height: height === "original" ? originalHeight : height,
-  };
-});
-
-const src = $derived.by(() => {
-  if (waitingLazyLoading) {
-    return lazyPlaceholder;
-  }
-
-  const image = imageState.current;
-  if (!image) return undefined;
-
-  const bestImage = highestResAvailable(
-    image,
-    dimensions.width || dimensions.height || 9999,
-    dimensions.height || dimensions.width || 9999,
+  /**
+   * For lazy loading, we use the browser's strategy for images with loading="lazy".
+   * We use an empty image, and when the browser triggers the load event, we load the best available image.
+   * On page loading, if the image url is already in browser's cache, the load event is triggered immediately.
+   * This is why we need to use a different blob url for every image.
+   */
+  let waitingLazyLoading = $state(rest.loading === "lazy");
+  const lazyPlaceholder = $derived.by(() =>
+    waitingLazyLoading ? URL.createObjectURL(emptyPixelBlob) : undefined,
   );
 
-  if (!bestImage) return image.placeholderDataURL;
-  if (lastBestImage?.[0] === bestImage.image.$jazz.id) return lastBestImage?.[1];
+  const dimensions = $derived.by<{
+    width: number | undefined;
+    height: number | undefined;
+  }>(() => {
+    const originalWidth = imageState.current?.originalSize?.[0];
+    const originalHeight = imageState.current?.originalSize?.[1];
 
-  const blob = bestImage.image.toBlob();
+    // Both width and height are "original"
+    if (width === "original" && height === "original") {
+      return { width: originalWidth, height: originalHeight };
+    }
 
-  if (blob) {
-    const url = URL.createObjectURL(blob);
+    // Width is "original", height is a number
+    if (width === "original" && typeof height === "number") {
+      if (originalWidth && originalHeight) {
+        return {
+          width: Math.round((height * originalWidth) / originalHeight),
+          height,
+        };
+      }
+      return { width: undefined, height };
+    }
+
+    // Height is "original", width is a number
+    if (height === "original" && typeof width === "number") {
+      if (originalWidth && originalHeight) {
+        return {
+          width,
+          height: Math.round((width * originalHeight) / originalWidth),
+        };
+      }
+      return { width, height: undefined };
+    }
+
+    // In all other cases, use the property value:
+    return {
+      width: width === "original" ? originalWidth : width,
+      height: height === "original" ? originalHeight : height,
+    };
+  });
+
+  const src = $derived.by(() => {
+    if (waitingLazyLoading) {
+      return lazyPlaceholder;
+    }
+
+    const image = imageState.current;
+    if (image === undefined)
+      return "data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==";
+
+    if (!image) return undefined;
+
+    const bestImage = highestResAvailable(
+      image,
+      dimensions.width || dimensions.height || 9999,
+      dimensions.height || dimensions.width || 9999,
+    );
+
+    if (!bestImage) return image.placeholderDataURL;
+    if (lastBestImage?.[0] === bestImage.image.$jazz.id)
+      return lastBestImage?.[1];
+
+    const blob = bestImage.image.toBlob();
+
+    if (blob) {
+      const url = URL.createObjectURL(blob);
+      revokeObjectURL(lastBestImage?.[1]);
+      lastBestImage = [bestImage.image.$jazz.id, url];
+      return url;
+    }
+
+    return image.placeholderDataURL;
+  });
+
+  // Cleanup object URL on component destroy
+  onDestroy(() => {
     revokeObjectURL(lastBestImage?.[1]);
-    lastBestImage = [bestImage.image.$jazz.id, url];
-    return url;
+  });
+
+  function revokeObjectURL(url: string | undefined) {
+    if (url && url.startsWith("blob:")) {
+      URL.revokeObjectURL(url);
+    }
   }
 
-  return image.placeholderDataURL;
-});
-
-// Cleanup object URL on component destroy
-onDestroy(() => {
-  revokeObjectURL(lastBestImage?.[1]);
-});
-
-function revokeObjectURL(url: string | undefined) {
-  if (url && url.startsWith("blob:")) {
-    URL.revokeObjectURL(url);
-  }
-}
-
-const emptyPixelBlob = new Blob(
-  [
-    Uint8Array.from(
-      atob(
-        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==",
+  const emptyPixelBlob = new Blob(
+    [
+      Uint8Array.from(
+        atob(
+          "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==",
+        ),
+        (c) => c.charCodeAt(0),
       ),
-      (c) => c.charCodeAt(0),
-    ),
-  ],
-  { type: "image/png" },
-);
+    ],
+    { type: "image/png" },
+  );
 </script>
 
 <img
@@ -120,6 +124,8 @@ const emptyPixelBlob = new Blob(
   width={dimensions.width}
   height={dimensions.height}
   alt={rest.alt}
-  onload={() => {waitingLazyLoading = false}}
+  onload={() => {
+    waitingLazyLoading = false;
+  }}
   {...rest}
 />

--- a/packages/jazz-tools/src/svelte/tests/media/image.svelte.test.ts
+++ b/packages/jazz-tools/src/svelte/tests/media/image.svelte.test.ts
@@ -15,6 +15,20 @@ describe("Image", async () => {
     render(Image, props, { account });
 
   describe("initial rendering", () => {
+    it("should render a blank placeholder while waiting for the coValue to load", async () => {
+      const { container } = renderWithAccount({
+        imageId: "co_zMTubMby3QiKDYnW9e2BEXW7Xaq",
+        alt: "test",
+      });
+
+      const img = container.querySelector("img");
+      expect(img).toBeDefined();
+      expect(img!.getAttribute("width")).toBe(null);
+      expect(img!.getAttribute("height")).toBe(null);
+      expect(img!.alt).toBe("test");
+      expect(img!.src).toBe("data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==");
+    });
+
     it("should render nothing if coValue is not found", async () => {
       const { container } = renderWithAccount({
         imageId: "co_zMTubMby3QiKDYnW9e2BEXW7Xaq",

--- a/packages/jazz-tools/src/svelte/tests/media/image.svelte.test.ts
+++ b/packages/jazz-tools/src/svelte/tests/media/image.svelte.test.ts
@@ -21,12 +21,14 @@ describe("Image", async () => {
         alt: "test",
       });
 
-      const img = container.querySelector("img");
-      expect(img).toBeDefined();
-      expect(img!.getAttribute("width")).toBe(null);
-      expect(img!.getAttribute("height")).toBe(null);
-      expect(img!.alt).toBe("test");
-      expect(img!.src).toBe("");
+      await waitFor(() => {
+        const img = container.querySelector("img");
+        expect(img).toBeDefined();
+        expect(img!.getAttribute("width")).toBe(null);
+        expect(img!.getAttribute("height")).toBe(null);
+        expect(img!.alt).toBe("test");
+        expect(img!.src).toBe("");
+      });
     });
 
     it("should render an empty image if the image is not loaded yet", async () => {


### PR DESCRIPTION
# Description
Instead of a full custom placeholder implementation (#2937), this focuses on the flash of alt text which can be experienced when an image CoValue is slow to load.

## Manual testing instructions
N/A

## Tests
- [x] Tests have been added and/or updated
- [ ] Tests have not been updated, because: <!-- Insert reason for not updating tests here -->
- [ ] I need help with writing tests


## Checklist
- [ ] I've updated the part of the docs that are affected the PR changes: N/A
- [ ] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing