### PR TITLE
fix: fix dashboard link & quick search alignment

### DIFF
--- a/homepage/homepage/components/nav.tsx
+++ b/homepage/homepage/components/nav.tsx
@@ -22,17 +22,16 @@ export function JazzNav({
       items={navigationItems}
       socials={socials}
       hideMobileNav={hideMobileNav}
-      cta={<>
+      cta={<div className="flex items-center gap-3 md:mr-2">
         <QuickSearch />
         <Button
           intent="primary"
           href="https://dashboard.jazz.tools"
-          className="mr-3"
           newTab
         >
           Dashboard
         </Button>
-      </>
+      </div>
     }
     ></Nav>
   );
@@ -47,12 +46,11 @@ export function JazzMobileNav({ sections }: { sections?: NavSection[] }) {
       themeToggle={ThemeToggle}
       items={navigationItems}
       socials={socials}
-      cta={<div className="flex items-center justify-between">
+      cta={<div className="flex items-center gap-2">
         <QuickSearch />
         <Button
           intent="primary"
           href="https://dashboard.jazz.tools"
-          className="mr-3"
           newTab
         >
           Dashboard

--- a/homepage/homepage/components/quick-search.tsx
+++ b/homepage/homepage/components/quick-search.tsx
@@ -15,7 +15,7 @@ export function QuickSearch() {
 
   return (
     <Button
-      className="group xl:min-w-48 md:mr-5 w-full md:w-auto"
+      className="group xl:min-w-48 w-full md:w-auto"
       intent="muted"
       variant="outline"
       onClick={() => setOpen((open) => !open)}


### PR DESCRIPTION
Probably messed up a merge before merging the previous PR and alignment/spacing was off:

## before 
<img width="1051" height="196" alt="image" src="https://github.com/user-attachments/assets/0c6b1de1-881b-4220-8b32-823628c1e23c" />

<img width="571" height="432" alt="image" src="https://github.com/user-attachments/assets/543331fc-96e9-4c01-be4f-5b9cf09fd6eb" />

<img width="573" height="479" alt="image" src="https://github.com/user-attachments/assets/845a0ac1-4e4a-451e-8d52-45f1e45b13d9" />


## after

<img width="554" height="439" alt="image" src="https://github.com/user-attachments/assets/1cad8697-8211-4d1b-8a3c-654b4cd3d138" />

<img width="577" height="444" alt="image" src="https://github.com/user-attachments/assets/11204669-460b-43df-a8a4-31e4e97fce60" />

<img width="972" height="87" alt="image" src="https://github.com/user-attachments/assets/252b46aa-9a50-456b-be7b-d788cf134a3f" />

