### PR TITLE
fix: prevent emitting unavailable state during fallback from storage to network

### DIFF
--- a/.changeset/covalue-load.md
+++ b/.changeset/covalue-load.md
@@ -1,0 +1,5 @@
+---
+"cojson": patch
+---
+
+Fix unavailable state emitted when a load operation falls back from storage to network

--- a/packages/cojson/src/coValueCore/coValueCore.ts
+++ b/packages/cojson/src/coValueCore/coValueCore.ts
@@ -1198,11 +1198,11 @@ export class CoValueCore {
         node.syncManager.handleNewContent(data, "storage");
       },
       (found) => {
+        done?.(found);
+
         if (!found) {
           this.markNotFoundInPeer("storage");
         }
-
-        done?.(found);
       },
     );
   }


### PR DESCRIPTION
While testing the connection status hook on multi-cursor I've noticed that in development mode, loading the covalue from a cold storage was failing.

That was happening because the cursor load is triggered inside an `useEffect` which in dev mode is emitted twice.

Since the cursor in the multi-cursor example is loaded using `loadUnique` which turns `skipRetry` to true, the load was failing because during a race condition the second load was getting the `unavailable` event caused by the storage miss.