### PR TITLE
feat(jazz-tools): allow usage of z.codec with custom encoders

### DIFF
--- a/.changeset/blue-planets-retire.md
+++ b/.changeset/blue-planets-retire.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Allow usage of z.codec with custom encoders in CoValues

--- a/examples/chat-svelte/package.json
+++ b/examples/chat-svelte/package.json
@@ -31,7 +31,8 @@
     "svelte-check": "catalog:svelte",
     "typescript": "5.6.2",
     "typescript-eslint": "^8.32.1",
-    "vite": "6.0.11"
+    "vite": "6.0.11",
+    "zod": "^4.1.11"
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.1.7",

--- a/examples/file-share-svelte/package.json
+++ b/examples/file-share-svelte/package.json
@@ -34,7 +34,8 @@
     "tailwindcss": "^4.1.10",
     "typescript": "5.6.2",
     "typescript-eslint": "^8.0.0",
-    "vite": "^6.3.5"
+    "vite": "^6.3.5",
+    "zod": "^4.1.11"
   },
   "dependencies": {
     "@tailwindcss/typography": "^0.5.15",

--- a/homepage/homepage/content/docs/docNavigationItems.js
+++ b/homepage/homepage/content/docs/docNavigationItems.js
@@ -205,6 +205,11 @@ export const docNavigationItems = [
         done: 100,
       },
       {
+        name: "Codecs",
+        href: "/docs/using-covalues/codecs",
+        done: 100,
+      },
+      {
         name: "Subscriptions & Deep Loading",
         href: "/docs/using-covalues/subscription-and-loading",
         done: 80,

--- a/homepage/homepage/content/docs/using-covalues/codecs.mdx
+++ b/homepage/homepage/content/docs/using-covalues/codecs.mdx
@@ -1,0 +1,43 @@
+import { CodeGroup } from "@/components/forMdx";
+
+export const metadata = {
+  description:
+    "Use z.codec to store arbitrary data types or classes in your schemas.",
+};
+
+# Codecs
+
+You can use `z.codec()` Zos schemas to store arbitrary data types such as class instances within CoValues by defining custom encoders.
+This allows you to directly use these data types within CoValues without having to do an extra manual conversion step.
+
+## Using Zod codecs
+
+To define use a Zod `z.codec()` with Jazz, your encoder must encode your data into a JSON-compatible format.
+This is means that the `Input` type shall map to the JSON-compatible type, and `Output` will map to your custom type.
+
+<CodeGroup>
+```ts twoslash
+import { co, z } from "jazz-tools";
+// ---cut---
+class Greeter {
+  constructor(public name: string) {}
+
+  greet() {
+    console.log(`Hello, ${this.name}!`);
+  }
+}
+
+const schema = co.map({
+  greeter: z.codec(z.string(), z.z.instanceof(Greeter), {
+    encode: (value) => value.name,
+    decode: (value) => new Greeter(value),
+  }),
+});
+
+const porter = schema.create({
+  greeter: new Greeter("Alice"),
+});
+
+porter.greeter.greet();
+```
+</CodeGroup>

--- a/homepage/homepage/content/docs/using-covalues/codecs.mdx
+++ b/homepage/homepage/content/docs/using-covalues/codecs.mdx
@@ -1,4 +1,5 @@
 import { CodeGroup } from "@/components/forMdx";
+import { Alert } from "@garden-co/design-system/src/components/atoms/Alert";
 
 export const metadata = {
   description:
@@ -7,12 +8,12 @@ export const metadata = {
 
 # Codecs
 
-You can use `z.codec()` Zos schemas to store arbitrary data types such as class instances within CoValues by defining custom encoders.
+You can use Zod `z.codec()` schemas to store arbitrary data types such as class instances within CoValues by defining custom encoders.
 This allows you to directly use these data types within CoValues without having to do an extra manual conversion step.
 
 ## Using Zod codecs
 
-To define use a Zod `z.codec()` with Jazz, your encoder must encode your data into a JSON-compatible format.
+To use a Zod `z.codec()` with Jazz, your encoder must encode the data into a JSON-compatible format.
 This is means that the `Input` type shall map to the JSON-compatible type, and `Output` will map to your custom type.
 
 <CodeGroup>
@@ -41,3 +42,8 @@ const porter = schema.create({
 porter.greeter.greet();
 ```
 </CodeGroup>
+
+<Alert className="mt-4 flex gap-2 items-center" variant="info">
+Schemas that are not directly supported by Jazz such as `z.instanceof` are not re-exported by Jazz under the `z` object.
+The full Zod API is exported under `z.z` if you need to use any of these schemas as part of a codec.
+</Alert>

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/runtimeConverters/schemaFieldToCoFieldDef.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/runtimeConverters/schemaFieldToCoFieldDef.ts
@@ -173,7 +173,7 @@ export function schemaFieldToCoFieldDef(schema: SchemaField) {
           schemaFieldToCoFieldDef(zodSchemaDef.in as SchemaField);
         } catch (error) {
           if (error instanceof Error) {
-            error.message = `z.codec() is only supported if the input schema is already supported: ${error.message}`;
+            error.message = `z.codec() is only supported if the input schema is already supported. ${error.message}`;
           }
 
           throw error;

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/runtimeConverters/schemaFieldToCoFieldDef.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/runtimeConverters/schemaFieldToCoFieldDef.ts
@@ -1,3 +1,4 @@
+import type { JsonValue } from "cojson";
 import { CoValueClass, isCoValueClass } from "../../../internal.js";
 import { coField } from "../../schema.js";
 import { CoreCoValueSchema } from "../schemaTypes/CoValueSchema.js";
@@ -32,10 +33,30 @@ export type SchemaField =
   | z.core.$ZodLazy<z.core.$ZodType>
   | z.core.$ZodTemplateLiteral<any>
   | z.core.$ZodLiteral<any>
-  | z.core.$ZodCatch<z.core.$ZodType>
   | z.core.$ZodEnum<any>
+  | z.core.$ZodCodec<z.core.$ZodType, z.core.$ZodType>
   | z.core.$ZodDefault<z.core.$ZodType>
   | z.core.$ZodCatch<z.core.$ZodType>;
+
+function makeCodecCoField(
+  codec: z.core.$ZodCodec<z.core.$ZodType, z.core.$ZodType>,
+) {
+  return coField.optional.encoded({
+    encode: (value: any) => {
+      if (value === undefined) return undefined as unknown as JsonValue;
+      if (value === null) return null;
+      return codec._zod.def.reverseTransform(value, {
+        value,
+        issues: [],
+      }) as JsonValue;
+    },
+    decode: (value) => {
+      if (value === null) return null;
+      if (value === undefined) return undefined;
+      return codec._zod.def.transform(value, { value, issues: [] });
+    },
+  });
+}
 
 export function schemaFieldToCoFieldDef(schema: SchemaField) {
   if (isCoValueClass(schema)) {
@@ -54,7 +75,7 @@ export function schemaFieldToCoFieldDef(schema: SchemaField) {
         zodSchemaDef.type === "optional" ||
         zodSchemaDef.type === "nullable"
       ) {
-        const inner = zodSchemaDef.innerType as ZodPrimitiveSchema;
+        const inner = zodSchemaDef.innerType as SchemaField;
         const coFieldDef: any = schemaFieldToCoFieldDef(inner);
         if (
           zodSchemaDef.type === "nullable" &&
@@ -137,6 +158,30 @@ export function schemaFieldToCoFieldDef(schema: SchemaField) {
             "z.union()/z.discriminatedUnion() of collaborative types is not supported. Use co.discriminatedUnion() instead.",
           );
         }
+      } else if (zodSchemaDef.type === "pipe") {
+        const isCodec =
+          zodSchemaDef.transform !== undefined &&
+          zodSchemaDef.reverseTransform !== undefined;
+
+        if (!isCodec) {
+          throw new Error(
+            "z.pipe() is not supported. Only z.codec() is supported.",
+          );
+        }
+
+        try {
+          schemaFieldToCoFieldDef(zodSchemaDef.in as SchemaField);
+        } catch (error) {
+          if (error instanceof Error) {
+            error.message = `z.codec() is only supported if the input schema is already supported: ${error.message}`;
+          }
+
+          throw error;
+        }
+
+        return makeCodecCoField(
+          schema as z.core.$ZodCodec<z.core.$ZodType, z.core.$ZodType>,
+        );
       } else {
         throw new Error(
           `Unsupported zod type: ${(schema._zod?.def as any)?.type || JSON.stringify(schema)}`,

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/TypeOfZodSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/TypeOfZodSchema.ts
@@ -71,8 +71,13 @@ export type TypeOfZodSchema<S extends z.core.$ZodType> =
                                       infer Default extends z.core.$ZodType
                                     >
                                   ? TypeOfZodSchema<Default>
-                                  : S extends z.core.$ZodCatch<
-                                        infer Catch extends z.core.$ZodType
+                                  : S extends z.core.$ZodCodec<
+                                        any,
+                                        infer Out extends z.core.$ZodType
                                       >
-                                    ? TypeOfZodSchema<Catch>
-                                    : never;
+                                    ? Out["_zod"]["output"]
+                                    : S extends z.core.$ZodCatch<
+                                          infer Catch extends z.core.$ZodType
+                                        >
+                                      ? TypeOfZodSchema<Catch>
+                                      : never;

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/zodReExport.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/zodReExport.ts
@@ -35,6 +35,7 @@ export {
   // record,
   // intersection,
   int,
+  codec,
   optional,
   array,
   tuple,

--- a/packages/jazz-tools/src/tools/tests/zod.test.ts
+++ b/packages/jazz-tools/src/tools/tests/zod.test.ts
@@ -638,7 +638,7 @@ describe("co.map and Zod schema compatibility", () => {
           },
         }),
       ).toThrow(
-        "z.codec() is only supported if the input schema is already supported: Unsupported zod type: map",
+        "z.codec() is only supported if the input schema is already supported. Unsupported zod type: map",
       );
     });
   });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -495,6 +495,9 @@ importers:
       vite:
         specifier: 6.3.5
         version: 6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
+      zod:
+        specifier: ^4.1.11
+        version: 4.1.11
 
   examples/clerk:
     dependencies:
@@ -831,6 +834,9 @@ importers:
       vite:
         specifier: 6.3.5
         version: 6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
+      zod:
+        specifier: ^4.1.11
+        version: 4.1.11
 
   examples/filestream:
     dependencies:
@@ -2565,6 +2571,9 @@ importers:
       vite:
         specifier: 6.3.5
         version: 6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
+      zod:
+        specifier: ^4.1.11
+        version: 4.1.11
 
   tests/stress-test:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2390,6 +2390,9 @@ importers:
       vite:
         specifier: 6.3.5
         version: 6.3.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.6.1)
+      zod:
+        specifier: ^4.1.11
+        version: 4.1.11
 
   tests/browser-integration:
     dependencies:

--- a/starters/svelte-passkey-auth/package.json
+++ b/starters/svelte-passkey-auth/package.json
@@ -36,7 +36,8 @@
     "@tailwindcss/postcss": "^4.1.11",
     "typescript": "5.6.2",
     "typescript-eslint": "^8.0.0",
-    "vite": "^6.3.5"
+    "vite": "^6.3.5",
+    "zod": "^4.1.11"
   },
   "dependencies": {
     "jazz-tools": "workspace:*"

--- a/tests/jazz-svelte/package.json
+++ b/tests/jazz-svelte/package.json
@@ -50,7 +50,8 @@
     "svelte-check": "catalog:svelte",
     "typescript": "catalog:default",
     "virtua": "^0.41.5",
-    "vite": "^6.3.5"
+    "vite": "^6.3.5",
+    "zod": "^4.1.11"
   },
   "dependencies": {
     "cojson": "workspace:*",


### PR DESCRIPTION
# Description
I've been wanting to switch to `Temporal` objects for a while now, but didn't want to keep converting between `Date` and `Temporal.PlainDate`, etc. every time we create or load CoValues. I think it's still too early to add first-class support for `Temporal` in Jazz, but that spurred the idea to allow any class instances really to be stored in Jazz and it ended up being a simple change.

I'm not in love with the idea that encoder registration becomes a library side-effect, but the only alternative I can think of is wrapping `z.instanceof()` to include the encoder in the params, but then it becomes unergonomic and we'd lose the ability of re-using existing zod schemas that already include `z.instanceof`

## Manual testing instructions

<!-- Add any actions required to manually test the changes -->

## Tests

- [x] Tests have been added and/or updated
- [ ] Tests have not been updated, because: <!-- Insert reason for not updating tests here -->
- [ ] I need help with writing tests


## Checklist

- [x] I've updated the part of the docs that are affected the PR changes
- [x] I've generated a changeset, if a version bump is required
- [x] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds support for Zod z.codec with custom encoders in CoValues, updating runtime/type handling, docs, and tests.
> 
> - **jazz-tools**:
>   - **Runtime**: Extend `schemaFieldToCoFieldDef` to support `z.codec()` (via `pipe`) with JSON-compatible encode/decode, handling optional/nullable/nullish and rejecting unsupported input schemas; import `JsonValue`.
>   - **Types**: Update `TypeOfZodSchema` to infer codec output types; include `$ZodCodec` in `SchemaField`.
>   - **Zod re-exports**: Expose `z.codec`.
> - **Docs**:
>   - Add `docs/using-covalues/codecs` with usage guidance; add "Codecs" to docs navigation.
> - **Tests**:
>   - Add codec tests (e.g., `DateRange`, `RegExp`, optional/nullable/nullish, unsupported inner schema).
> - **Examples/Starters**:
>   - Add `zod` devDependency to Svelte example and starter packages.
> - **Changeset**:
>   - Patch release for `jazz-tools`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d47e02b60e5faa271cd4c5491107cb7ba394435d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->