### PR TITLE
feat(jazz-tools): subscription scope re-use in react and coValue provider/consumer helpers

### DIFF
--- a/.changeset/popular-ears-remain.md
+++ b/.changeset/popular-ears-remain.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Expose subscription scope react hooks and new `createCoValueSubscriptionContext` and `createAccountSubscriptionContext` helper functions

--- a/examples/music-player/src/2_main.tsx
+++ b/examples/music-player/src/2_main.tsx
@@ -13,10 +13,14 @@ import "./index.css";
 import { MusicaAccount } from "@/1_schema";
 import { apiKey } from "@/apiKey.ts";
 import { SidebarProvider } from "@/components/ui/sidebar";
-import { JazzReactProvider, useAccountWithSelector } from "jazz-tools/react";
+import { JazzReactProvider } from "jazz-tools/react";
 import { onAnonymousAccountDiscarded } from "./4_actions";
 import { KeyboardListener } from "./components/PlayerControls";
 import { usePrepareAppState } from "./lib/usePrepareAppState";
+import {
+  AccountProvider,
+  useAccountSelector,
+} from "@/components/AccountProvider.tsx";
 
 /**
  * Walkthrough: The top-level provider `<JazzReactProvider/>`
@@ -33,9 +37,8 @@ function AppContent({
 }: {
   mediaPlayer: ReturnType<typeof useMediaPlayer>;
 }) {
-  const showWelcomeScreen = useAccountWithSelector(MusicaAccount, {
-    resolve: { root: true },
-    select: (me) => Boolean(me && !me.root.accountSetupCompleted),
+  const showWelcomeScreen = useAccountSelector({
+    select: (me) => !me.root.accountSetupCompleted,
   });
 
   const isReady = usePrepareAppState(mediaPlayer);
@@ -99,7 +102,9 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
       onAnonymousAccountDiscarded={onAnonymousAccountDiscarded}
     >
       <SidebarProvider>
-        <Main />
+        <AccountProvider>
+          <Main />
+        </AccountProvider>
         <JazzInspector />
       </SidebarProvider>
     </JazzReactProvider>

--- a/examples/music-player/src/3_HomePage.tsx
+++ b/examples/music-player/src/3_HomePage.tsx
@@ -1,7 +1,7 @@
 import { useToast } from "@/hooks/use-toast";
-import { createInviteLink, useAccount, useCoState } from "jazz-tools/react";
+import { createInviteLink, useCoState } from "jazz-tools/react";
 import { useParams } from "react-router";
-import { MusicaAccount, Playlist } from "./1_schema";
+import { Playlist } from "./1_schema";
 import { uploadMusicTracks } from "./4_actions";
 import { MediaPlayer } from "./5_useMediaPlayer";
 import { FileUploadButton } from "./components/FileUploadButton";
@@ -14,16 +14,9 @@ import { Button } from "./components/ui/button";
 import { SidebarInset, SidebarTrigger } from "./components/ui/sidebar";
 import { usePlayState } from "./lib/audio/usePlayState";
 import { useState } from "react";
+import { useAccountSelector } from "@/components/AccountProvider.tsx";
 
 export function HomePage({ mediaPlayer }: { mediaPlayer: MediaPlayer }) {
-  /**
-   * `me` represents the current user account, which will determine
-   *  access rights to CoValues. We get it from the top-level provider `<WithJazz/>`.
-   */
-  const { me } = useAccount(MusicaAccount, {
-    resolve: { root: { rootPlaylist: true, playlists: true } },
-  });
-
   const playState = usePlayState();
   const isPlaying = playState.value === "play";
   const { toast } = useToast();
@@ -38,7 +31,9 @@ export function HomePage({ mediaPlayer }: { mediaPlayer: MediaPlayer }) {
   }
 
   const params = useParams<{ playlistId: string }>();
-  const playlistId = params.playlistId ?? me?.root.$jazz.refs.rootPlaylist.id;
+  const playlistId = useAccountSelector({
+    select: (me) => params.playlistId ?? me.root.$jazz.refs.rootPlaylist.id,
+  });
 
   const playlist = useCoState(Playlist, playlistId, {
     resolve: {
@@ -50,11 +45,15 @@ export function HomePage({ mediaPlayer }: { mediaPlayer: MediaPlayer }) {
 
   const membersIds = playlist?.$jazz.owner.members.map((member) => member.id);
   const isRootPlaylist = !params.playlistId;
-  const isPlaylistOwner = playlist && me?.canAdmin(playlist);
-  const isActivePlaylist = playlistId === me?.root.activePlaylist?.$jazz.id;
+  const isPlaylistOwner = useAccountSelector({
+    select: (me) => Boolean(playlist && me.canAdmin(playlist)),
+  });
+  const isActivePlaylist = useAccountSelector({
+    select: (me) => playlistId === me.root.activePlaylist?.$jazz.id,
+  });
 
   const handlePlaylistShareClick = async () => {
-    if (!isPlaylistOwner) return;
+    if (!isPlaylistOwner || !playlist) return;
 
     const inviteLink = createInviteLink(playlist, "reader");
 

--- a/examples/music-player/src/5_useMediaPlayer.ts
+++ b/examples/music-player/src/5_useMediaPlayer.ts
@@ -1,11 +1,11 @@
-import { MusicTrack, MusicaAccount, Playlist } from "@/1_schema";
+import { MusicTrack, Playlist } from "@/1_schema";
 import { usePlayMedia } from "@/lib/audio/usePlayMedia";
 import { usePlayState } from "@/lib/audio/usePlayState";
-import { useAccountWithSelector } from "jazz-tools/react";
 import { useRef, useState } from "react";
 import { updateActivePlaylist, updateActiveTrack } from "./4_actions";
 import { useAudioManager } from "./lib/audio/AudioManager";
 import { getNextTrack, getPrevTrack } from "./lib/getters";
+import { useAccountSelector } from "@/components/AccountProvider.tsx";
 
 export function useMediaPlayer() {
   const audioManager = useAudioManager();
@@ -14,9 +14,8 @@ export function useMediaPlayer() {
 
   const [loading, setLoading] = useState<string | null>(null);
 
-  const activeTrackId = useAccountWithSelector(MusicaAccount, {
-    resolve: { root: { activeTrack: true } },
-    select: (me) => me?.root.$jazz.refs.activeTrack?.id,
+  const activeTrackId = useAccountSelector({
+    select: (me) => me.root.$jazz.refs.activeTrack?.id,
   });
   // Reference used to avoid out-of-order track loads
   const lastLoadedTrackId = useRef<string | null>(null);

--- a/examples/music-player/src/components/AccountProvider.tsx
+++ b/examples/music-player/src/components/AccountProvider.tsx
@@ -1,0 +1,17 @@
+import { MusicaAccount } from "@/1_schema.ts";
+import { createAccountSubscriptionContext } from "jazz-tools/react-core";
+
+export const { Provider: AccountProvider, useSelector: useAccountSelector } =
+  createAccountSubscriptionContext(MusicaAccount, {
+    root: {
+      rootPlaylist: {
+        tracks: {
+          $each: true,
+        },
+      },
+      playlists: true,
+      activeTrack: true,
+      activePlaylist: true,
+    },
+    profile: true,
+  });

--- a/examples/music-player/src/components/AuthModal.tsx
+++ b/examples/music-player/src/components/AuthModal.tsx
@@ -1,4 +1,3 @@
-import { MusicaAccount } from "@/1_schema";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -7,8 +6,9 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { useAccount, usePasskeyAuth } from "jazz-tools/react";
+import { usePasskeyAuth } from "jazz-tools/react";
 import { useState } from "react";
+import { useAccountSelector } from "@/components/AccountProvider.tsx";
 
 interface AuthModalProps {
   open: boolean;
@@ -18,18 +18,8 @@ interface AuthModalProps {
 export function AuthModal({ open, onOpenChange }: AuthModalProps) {
   const [isSignUp, setIsSignUp] = useState(true);
   const [error, setError] = useState<string | null>(null);
-
-  const { me } = useAccount(MusicaAccount, {
-    resolve: {
-      root: {
-        rootPlaylist: {
-          tracks: {
-            $each: true,
-          },
-        },
-      },
-      profile: true,
-    },
+  const profileName = useAccountSelector({
+    select: (me) => me.profile.name,
   });
 
   const auth = usePasskeyAuth({
@@ -46,7 +36,7 @@ export function AuthModal({ open, onOpenChange }: AuthModalProps) {
 
     try {
       if (isSignUp) {
-        await auth.signUp(me?.profile.name || "");
+        await auth.signUp(profileName);
       } else {
         await auth.logIn();
       }
@@ -64,9 +54,11 @@ export function AuthModal({ open, onOpenChange }: AuthModalProps) {
     }
   };
 
-  const shouldShowTransferRootPlaylist =
-    !isSignUp &&
-    me?.root.rootPlaylist.tracks.some((track) => !track.isExampleTrack);
+  const shouldShowTransferRootPlaylist = useAccountSelector({
+    select: (me) =>
+      !isSignUp &&
+      me.root.rootPlaylist.tracks.some((track) => !track.isExampleTrack),
+  });
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>

--- a/examples/music-player/src/components/MusicTrackRow.tsx
+++ b/examples/music-player/src/components/MusicTrackRow.tsx
@@ -18,6 +18,7 @@ import { Fragment, useCallback, useState } from "react";
 import { EditTrackDialog } from "./RenameTrackDialog";
 import { Waveform } from "./Waveform";
 import { Button } from "./ui/button";
+import { useAccountSelector } from "@/components/AccountProvider.tsx";
 
 function isPartOfThePlaylist(
   trackId: string,
@@ -49,13 +50,12 @@ export function MusicTrackRow({
     select: (account) => account?.root.playlists,
   });
 
-  const isActiveTrack = useAccountWithSelector(MusicaAccount, {
-    resolve: { root: { activeTrack: true } },
-    select: (account) => account?.root.activeTrack?.$jazz.id === trackId,
+  const isActiveTrack = useAccountSelector({
+    select: (me) => me.root.activeTrack?.$jazz.id === trackId,
   });
 
-  const canEditTrack = useAccountWithSelector(MusicaAccount, {
-    select: (account) => Boolean(track && account?.canWrite(track)),
+  const canEditTrack = useAccountSelector({
+    select: (me) => Boolean(track && me.canWrite(track)),
   });
 
   function handleTrackClick() {

--- a/examples/music-player/src/components/PlayerControls.tsx
+++ b/examples/music-player/src/components/PlayerControls.tsx
@@ -1,20 +1,20 @@
-import { MusicTrack, MusicaAccount } from "@/1_schema";
+import { MusicTrack } from "@/1_schema";
 import { MediaPlayer } from "@/5_useMediaPlayer";
 import { useMediaEndListener } from "@/lib/audio/useMediaEndListener";
 import { usePlayState } from "@/lib/audio/usePlayState";
 import { useKeyboardListener } from "@/lib/useKeyboardListener";
-import { useAccountWithSelector, useCoState } from "jazz-tools/react";
+import { useCoState } from "jazz-tools/react";
 import { Pause, Play, SkipBack, SkipForward } from "lucide-react";
 import WaveformCanvas from "./WaveformCanvas";
 import { Button } from "./ui/button";
+import { useAccountSelector } from "@/components/AccountProvider.tsx";
 
 export function PlayerControls({ mediaPlayer }: { mediaPlayer: MediaPlayer }) {
   const playState = usePlayState();
   const isPlaying = playState.value === "play";
 
-  const activePlaylist = useAccountWithSelector(MusicaAccount, {
-    resolve: { root: { activePlaylist: true } },
-    select: (me) => me?.root.activePlaylist,
+  const activePlaylistTitle = useAccountSelector({
+    select: (me) => me.root.activePlaylist?.title ?? "All tracks",
   });
 
   const activeTrack = useCoState(MusicTrack, mediaPlayer.activeTrackId);
@@ -72,7 +72,7 @@ export function PlayerControls({ mediaPlayer }: { mediaPlayer: MediaPlayer }) {
           {activeTrackTitle}
         </h4>
         <p className="hidden sm:block text-xs sm:text-sm text-gray-600 truncate sm:max-w-80">
-          {activePlaylist?.title || "All tracks"}
+          {activePlaylistTitle || "All tracks"}
         </p>
       </div>
     </footer>

--- a/examples/music-player/src/components/ProfileForm.tsx
+++ b/examples/music-player/src/components/ProfileForm.tsx
@@ -1,12 +1,12 @@
 import React, { useState, useRef } from "react";
-import { Image, useAccountWithSelector } from "jazz-tools/react";
+import { Image } from "jazz-tools/react";
 import { createImage } from "jazz-tools/media";
-import { MusicaAccount } from "../1_schema";
 import { Button } from "./ui/button";
 import { Input } from "./ui/input";
 import { Label } from "./ui/label";
 import { Separator } from "./ui/separator";
 import { Group } from "jazz-tools";
+import { useAccountSelector } from "@/components/AccountProvider.tsx";
 
 interface ProfileFormProps {
   onSubmit?: (data: { username: string; avatar?: any }) => void;
@@ -33,9 +33,8 @@ export function ProfileForm({
   cancelButtonText = "Cancel",
   className = "",
 }: ProfileFormProps) {
-  const profile = useAccountWithSelector(MusicaAccount, {
-    resolve: { profile: true },
-    select: (me) => me?.profile,
+  const profile = useAccountSelector({
+    select: (me) => me.profile,
   });
 
   const [username, setUsername] = useState(

--- a/examples/music-player/src/components/WelcomeScreen.tsx
+++ b/examples/music-player/src/components/WelcomeScreen.tsx
@@ -1,23 +1,28 @@
-import { useAccount, usePasskeyAuth } from "jazz-tools/react";
-import { MusicaAccount } from "../1_schema";
+import { usePasskeyAuth } from "jazz-tools/react";
 import { ProfileForm } from "./ProfileForm";
 import { Button } from "./ui/button";
+import { useAccountSelector } from "@/components/AccountProvider.tsx";
 
 export function WelcomeScreen() {
-  const { me } = useAccount(MusicaAccount, {
-    resolve: { profile: true, root: true },
-  });
-
   const auth = usePasskeyAuth({
     appName: "Jazz Music Player",
   });
 
-  if (!me) return null;
+  const { handleCompleteSetup } = useAccountSelector({
+    select: (me) => ({
+      id: me.root.$jazz.id,
+      handleCompleteSetup: () => {
+        me.root.$jazz.set("accountSetupCompleted", true);
+      },
+    }),
+    equalityFn: (a, b) => a.id === b.id,
+  });
 
-  const handleCompleteSetup = () => {
-    // Mark account setup as completed
-    me.root.$jazz.set("accountSetupCompleted", true);
-  };
+  const initialUsername = useAccountSelector({
+    select: (me) => me.profile.name,
+  });
+
+  if (!handleCompleteSetup) return null;
 
   const handleLogin = () => {
     auth.logIn();
@@ -34,7 +39,7 @@ export function WelcomeScreen() {
             showHeader={true}
             headerTitle="Welcome to Music Player! 🎵"
             headerDescription="Let's set up your profile to get started"
-            initialUsername={me?.profile?.name || ""}
+            initialUsername={initialUsername}
           />
         </div>
         <div className="lg:hidden pt-4 flex justify-end items-center w-full gap-2">

--- a/examples/organization/src/OrganizationPage.tsx
+++ b/examples/organization/src/OrganizationPage.tsx
@@ -1,53 +1,65 @@
-import { useCoState } from "jazz-tools/react";
 import { useParams } from "react-router";
 import { Layout } from "./Layout.tsx";
 import { CreateProject } from "./components/CreateProject.tsx";
 import { Heading } from "./components/Heading.tsx";
 import { InviteLink } from "./components/InviteLink.tsx";
 import { OrganizationMembers } from "./components/OrganizationMembers.tsx";
-import { Organization } from "./schema.ts";
+import {
+  OrganizationProvider,
+  useOrganizationSelector,
+} from "./components/OrganizationProvider.ts";
+import { ProjectList } from "./components/ProjectList.tsx";
 
 export function OrganizationPage() {
   const paramOrganizationId = useParams<{ organizationId: string }>()
     .organizationId;
 
-  const organization = useCoState(Organization, paramOrganizationId, {
-    resolve: { projects: true },
+  return (
+    <OrganizationProvider
+      id={paramOrganizationId}
+      loadingFallback={<p>Loading organization...</p>}
+      unavailableFallback={
+        <div className="h-full flex items-center justify-center">
+          <div className="text-center">
+            <h1 className="text-2xl font-bold">
+              You don't have access to this organization
+            </h1>
+            <a href="/#" className="text-blue-500">
+              Go back to home
+            </a>
+          </div>
+        </div>
+      }
+    >
+      <OrganizationPageContent />
+    </OrganizationProvider>
+  );
+}
+
+function OrganizationPageContent() {
+  const organizationName = useOrganizationSelector({
+    select: (organization) => organization.name,
   });
 
-  if (organization === undefined) return <p>Loading organization...</p>;
-  if (organization === null) {
-    return (
-      <div className="h-full flex items-center justify-center">
-        <div className="text-center">
-          <h1 className="text-2xl font-bold">
-            You don't have access to this organization
-          </h1>
-          <a href="/#" className="text-blue-500">
-            Go back to home
-          </a>
-        </div>
-      </div>
-    );
-  }
+  const isOrganizationAdmin = useOrganizationSelector({
+    select: (organization) => organization.$jazz.owner?.myRole() === "admin",
+  });
 
   return (
     <Layout>
       <div className="grid gap-8">
-        <Heading text={`Welcome to ${organization.name} organization!`} />
+        <Heading text={`Welcome to ${organizationName} organization!`} />
 
         <div className="rounded-lg border shadow-sm bg-white dark:bg-stone-925">
           <div className="border-b px-4 py-5 sm:px-6">
             <div className="flex justify-between items-center">
               <h2>Members</h2>
 
-              {organization.$jazz.owner?.myRole() === "admin" && (
-                <InviteLink organization={organization} />
-              )}
+              {isOrganizationAdmin && <InviteLink />}
             </div>
           </div>
           <div className="divide-y">
-            <OrganizationMembers organization={organization} />
+            <OrganizationMembers />
           </div>
         </div>
 
@@ -56,24 +68,9 @@ export function OrganizationPage() {
             <h2>Projects</h2>
           </div>
           <div className="divide-y">
-            {organization.projects.length > 0 ? (
-              organization.projects.map((project) =>
-                project ? (
-                  <strong
-                    key={project.$jazz.id}
-                    className="px-4 py-5 sm:px-6 font-medium block"
-                  >
-                    {project.name}
-                  </strong>
-                ) : null,
-              )
-            ) : (
-              <p className="col-span-full text-center px-4 py-8 sm:px-6">
-                You have no projects yet.
-              </p>
-            )}
+            <ProjectList />
             <div className="p-4 sm:p-6">
-              <CreateProject organization={organization} />
+              <CreateProject />
             </div>
           </div>
         </div>

--- a/examples/organization/src/components/CreateProject.tsx
+++ b/examples/organization/src/components/CreateProject.tsx
@@ -1,25 +1,25 @@
-import { Loaded } from "jazz-tools";
 import { useState } from "react";
-import { Organization, Project } from "../schema.ts";
+import { Project } from "../schema.ts";
+import { useOrganizationSelector } from "./OrganizationProvider.ts";
 
-export function CreateProject({
-  organization,
-}: {
-  organization: Loaded<typeof Organization>;
-}) {
+export function CreateProject() {
+  const organizationOwner = useOrganizationSelector({
+    select: (organization) => organization.$jazz.owner,
+  });
+
+  const projects = useOrganizationSelector({
+    select: (organization) => organization.projects,
+  });
+
   const [name, setName] = useState<string>("");
 
   const onSave = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
-    if (!organization?.projects) return;
-
     if (name.length > 0) {
-      const project = Project.create(
-        { name },
-        { owner: organization.$jazz.owner },
-      );
-      organization.projects.$jazz.push(project);
+      const project = Project.create({ name }, { owner: organizationOwner });
+
+      projects.$jazz.push(project);
       setName("");
     }
   };

--- a/examples/organization/src/components/InviteLink.tsx
+++ b/examples/organization/src/components/InviteLink.tsx
@@ -1,14 +1,11 @@
-import { Loaded } from "jazz-tools";
 import { createInviteLink } from "jazz-tools/react";
 import { CheckIcon, CopyIcon } from "lucide-react";
 import { useEffect, useState } from "react";
-import { Organization } from "../schema.ts";
+import { useOrganizationSelector } from "./OrganizationProvider";
 
-export function InviteLink({
-  organization,
-}: {
-  organization: Loaded<typeof Organization>;
-}) {
+export function InviteLink() {
+  const organization = useOrganizationSelector();
+
   let [copyCount, setCopyCount] = useState(0);
   let copied = copyCount > 0;
 

--- a/examples/organization/src/components/OrganizationMembers.tsx
+++ b/examples/organization/src/components/OrganizationMembers.tsx
@@ -1,13 +1,11 @@
-import { Account, Group, Loaded } from "jazz-tools";
+import { Account, Group } from "jazz-tools";
 import { useAccount } from "jazz-tools/react";
-import { Organization } from "../schema.ts";
+import { useOrganizationSelector } from "./OrganizationProvider.ts";
 
-export function OrganizationMembers({
-  organization,
-}: {
-  organization: Loaded<typeof Organization>;
-}) {
-  const group = organization.$jazz.owner;
+export function OrganizationMembers() {
+  const group = useOrganizationSelector({
+    select: (organization) => organization.$jazz.owner,
+  });
 
   return (
     <>

--- a/examples/organization/src/components/OrganizationProvider.ts
+++ b/examples/organization/src/components/OrganizationProvider.ts
@@ -1,0 +1,7 @@
+import { createCoValueSubscriptionContext } from "jazz-tools/react-core";
+import { Organization } from "@/schema.ts";
+
+export const {
+  Provider: OrganizationProvider,
+  useSelector: useOrganizationSelector,
+} = createCoValueSubscriptionContext(Organization, { projects: true });

--- a/examples/organization/src/components/ProjectList.tsx
+++ b/examples/organization/src/components/ProjectList.tsx
@@ -1,0 +1,32 @@
+import { useOrganizationSelector } from "./OrganizationProvider.ts";
+
+export function ProjectList() {
+  const projects = useOrganizationSelector({
+    select: (organization) => {
+      return organization.projects;
+    },
+  });
+
+  if (projects.length === 0) {
+    return (
+      <p className="col-span-full text-center px-4 py-8 sm:px-6">
+        You have no projects yet.
+      </p>
+    );
+  }
+
+  return (
+    <>
+      {projects.map((project) =>
+        project ? (
+          <strong
+            key={project.$jazz.id}
+            className="px-4 py-5 sm:px-6 font-medium block"
+          >
+            {project.name}
+          </strong>
+        ) : null,
+      )}
+    </>
+  );
+}

--- a/packages/jazz-tools/package.json
+++ b/packages/jazz-tools/package.json
@@ -203,6 +203,7 @@
     "format-and-lint": "biome check .",
     "format-and-lint:fix": "biome check . --write",
     "dev": "tsup --watch --dts",
+    "bench": "vitest bench --run --root ../../ --project jazz-tools",
     "test": "vitest --run --root ../../ --project jazz-tools",
     "test:watch": "vitest --watch --root ../../ --project jazz-tools",
     "types": "tsc --outDir dist",

--- a/packages/jazz-tools/src/react-core/hooks.ts
+++ b/packages/jazz-tools/src/react-core/hooks.ts
@@ -13,7 +13,6 @@ import {
   AnyAccountSchema,
   CoValue,
   CoValueClassOrSchema,
-  Group,
   InboxSender,
   InstanceOfSchema,
   JazzContextManager,
@@ -27,6 +26,7 @@ import {
 } from "jazz-tools";
 import { JazzContext, JazzContextManagerContext } from "./provider.js";
 import { getCurrentAccountFromContextManager } from "./utils.js";
+import { CoValueSubscription } from "./types.js";
 
 export function useJazzContext<Acc extends Account>() {
   const value = useContext(JazzContext) as JazzContextType<Acc>;
@@ -82,7 +82,7 @@ export function useIsAuthenticated() {
   );
 }
 
-function useCoValueSubscription<
+export function useCoValueSubscription<
   S extends CoValueClassOrSchema,
   const R extends ResolveQuery<S>,
 >(
@@ -161,7 +161,7 @@ function useCoValueSubscription<
     });
   }, [Schema, id, contextManager, branchName, branchOwnerId]);
 
-  return subscription.subscription;
+  return subscription.subscription as CoValueSubscription<S, R>;
 }
 
 /**
@@ -476,7 +476,39 @@ export function useCoStateWithSelector<
   );
 }
 
-function useAccountSubscription<
+export function useSubscriptionSelector<
+  S extends CoValueClassOrSchema,
+  R extends ResolveQuery<S>,
+  TSelectorReturn = Loaded<S, R> | undefined | null,
+>(
+  subscription: CoValueSubscription<S, R>,
+  options?: {
+    select?: (value: Loaded<S, R> | undefined | null) => TSelectorReturn;
+    equalityFn?: (a: TSelectorReturn, b: TSelectorReturn) => boolean;
+  },
+) {
+  return useSyncExternalStoreWithSelector<
+    Loaded<S, R> | undefined | null,
+    TSelectorReturn
+  >(
+    React.useCallback(
+      (callback) => {
+        if (!subscription) {
+          return () => {};
+        }
+
+        return subscription.subscribe(callback);
+      },
+      [subscription],
+    ),
+    () => (subscription ? subscription.getCurrentValue() : null),
+    () => (subscription ? subscription.getCurrentValue() : null),
+    options?.select ?? ((value) => value as TSelectorReturn),
+    options?.equalityFn ?? Object.is,
+  );
+}
+
+export function useAccountSubscription<
   S extends AccountClass<Account> | AnyAccountSchema,
   const R extends ResolveQuery<S>,
 >(
@@ -547,7 +579,7 @@ function useAccountSubscription<
     });
   }, [Schema, contextManager, branchName, branchOwnerId]);
 
-  return subscription.subscription;
+  return subscription.subscription as CoValueSubscription<S, R>;
 }
 
 /**

--- a/packages/jazz-tools/src/react-core/index.ts
+++ b/packages/jazz-tools/src/react-core/index.ts
@@ -1,3 +1,4 @@
 export * from "./hooks.js";
 export * from "./provider.js";
 export * from "./auth/index.js";
+export type * from "./types.js";

--- a/packages/jazz-tools/src/react-core/index.ts
+++ b/packages/jazz-tools/src/react-core/index.ts
@@ -1,4 +1,5 @@
 export * from "./hooks.js";
+export * from "./subscription-provider.js";
 export * from "./provider.js";
 export * from "./auth/index.js";
 export type * from "./types.js";

--- a/packages/jazz-tools/src/react-core/subscription-provider.tsx
+++ b/packages/jazz-tools/src/react-core/subscription-provider.tsx
@@ -1,0 +1,144 @@
+import React from "react";
+import {
+  Account,
+  AccountClass,
+  AnyAccountSchema,
+  CoValueClassOrSchema,
+  Loaded,
+  ResolveQuery,
+  ResolveQueryStrict,
+} from "jazz-tools";
+import {
+  useAccountSubscription,
+  useCoValueSubscription,
+  useSubscriptionSelector,
+} from "./hooks";
+import type { CoValueSubscription } from "./types";
+
+export function createCoValueSubscriptionContext<
+  S extends CoValueClassOrSchema,
+  const R extends ResolveQuery<S> = true,
+>(schema: S, resolve?: ResolveQueryStrict<S, R>) {
+  const Context = React.createContext<CoValueSubscription<S, R>>(null);
+
+  return {
+    Provider: ({
+      id,
+      options,
+      loadingFallback,
+      unavailableFallback,
+      children,
+    }: React.PropsWithChildren<{
+      id: string | undefined | null;
+      options?: Omit<
+        Parameters<typeof useCoValueSubscription<S, R>>[2],
+        "resolve"
+      >;
+      loadingFallback?: React.ReactNode;
+      unavailableFallback?: React.ReactNode;
+    }>) => {
+      const subscription = useCoValueSubscription(schema, id, {
+        ...options,
+        resolve: resolve,
+      });
+
+      const loadState = useSubscriptionSelector(subscription, {
+        select: (value) => (!value ? value : true),
+      });
+
+      if (loadState === undefined) {
+        return loadingFallback ?? null;
+      }
+
+      if (loadState === null) {
+        return unavailableFallback ?? null;
+      }
+
+      return (
+        <Context.Provider value={subscription}>{children}</Context.Provider>
+      );
+    },
+    useSelector: <TSelectorReturn,>(options?: {
+      select?: (value: Loaded<S, R>) => TSelectorReturn;
+      equalityFn?: (a: TSelectorReturn, b: TSelectorReturn) => boolean;
+    }) => {
+      const subscription = React.useContext(Context);
+
+      if (!subscription) {
+        throw new Error(
+          "useSelector must be used within a coValue subscription provider",
+        );
+      }
+
+      return useSubscriptionSelector<S, R, TSelectorReturn>(
+        subscription,
+        options as Parameters<
+          typeof useSubscriptionSelector<S, R, TSelectorReturn>
+        >[1],
+      );
+    },
+  };
+}
+
+export function createAccountSubscriptionContext<
+  A extends AccountClass<Account> | AnyAccountSchema,
+  const R extends ResolveQuery<A> = true,
+>(schema: A, resolve?: ResolveQueryStrict<A, R>) {
+  const Context = React.createContext<CoValueSubscription<A, R>>(null);
+
+  return {
+    Provider: ({
+      options,
+      loadingFallback,
+      unavailableFallback,
+      children,
+    }: React.PropsWithChildren<{
+      options?: Omit<
+        Parameters<typeof useAccountSubscription<A, R>>[1],
+        "resolve"
+      >;
+      loadingFallback?: React.ReactNode;
+      unavailableFallback?: React.ReactNode;
+    }>) => {
+      const subscription = useAccountSubscription(schema, {
+        ...options,
+        resolve: resolve,
+      });
+
+      const loadState = useSubscriptionSelector(subscription, {
+        select: (value) => (!value ? value : true),
+      });
+
+      if (loadState === undefined) {
+        return loadingFallback ?? null;
+      }
+
+      if (loadState === null) {
+        return unavailableFallback ?? null;
+      }
+
+      return (
+        <Context.Provider value={subscription}>{children}</Context.Provider>
+      );
+    },
+    useSelector: <TSelectorReturn,>(options?: {
+      select?: (value: Loaded<A, R>) => TSelectorReturn;
+      equalityFn?: (a: TSelectorReturn, b: TSelectorReturn) => boolean;
+    }) => {
+      const subscription = React.useContext(Context);
+
+      if (!subscription) {
+        throw new Error(
+          "useSelector must be used within an account subscription provider",
+        );
+      }
+
+      return useSubscriptionSelector<A, R, TSelectorReturn>(
+        subscription,
+        options as Parameters<
+          typeof useSubscriptionSelector<A, R, TSelectorReturn>
+        >[1],
+      );
+    },
+  };
+}

--- a/packages/jazz-tools/src/react-core/subscription-provider.tsx
+++ b/packages/jazz-tools/src/react-core/subscription-provider.tsx
@@ -12,8 +12,8 @@ import {
   useAccountSubscription,
   useCoValueSubscription,
   useSubscriptionSelector,
-} from "./hooks";
-import type { CoValueSubscription } from "./types";
+} from "./hooks.js";
+import type { CoValueSubscription } from "./types.js";
 
 export function createCoValueSubscriptionContext<
   S extends CoValueClassOrSchema,
@@ -58,7 +58,7 @@ export function createCoValueSubscriptionContext<
         <Context.Provider value={subscription}>{children}</Context.Provider>
       );
     },
-    useSelector: <TSelectorReturn,>(options?: {
+    useSelector: <TSelectorReturn = Loaded<S, R>>(options?: {
       select?: (value: Loaded<S, R>) => TSelectorReturn;
       equalityFn?: (a: TSelectorReturn, b: TSelectorReturn) => boolean;
     }) => {
@@ -121,7 +121,7 @@ export function createAccountSubscriptionContext<
         <Context.Provider value={subscription}>{children}</Context.Provider>
       );
     },
-    useSelector: <TSelectorReturn,>(options?: {
+    useSelector: <TSelectorReturn = Loaded<A, R>>(options?: {
       select?: (value: Loaded<A, R>) => TSelectorReturn;
       equalityFn?: (a: TSelectorReturn, b: TSelectorReturn) => boolean;
     }) => {

--- a/packages/jazz-tools/src/react-core/tests/subscription.bench.tsx
+++ b/packages/jazz-tools/src/react-core/tests/subscription.bench.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 
 import { cojsonInternals } from "cojson";
-import { co } from "jazz-tools";
+import { co, z } from "jazz-tools";
 import { describe, bench } from "vitest";
 import {
   useAccountSubscription,
@@ -90,5 +90,230 @@ describe("1000 value loads", () => {
       render(<UseAccountWithSelector />);
     },
     { iterations: 50 },
+  );
+});
+
+describe("deeply resolved coMaps", async () => {
+  const Task = co.map({
+    title: z.string(),
+    get project() {
+      return Project;
+    },
+  });
+
+  const TaskList = co.list(Task);
+
+  const Project = co.map({
+    name: z.string(),
+    tasks: TaskList,
+    draftTasks: TaskList,
+    deletedTasks: TaskList,
+  });
+
+  const Organization = co.map({
+    name: z.string(),
+    projects: co.list(Project),
+  });
+
+  const AccountRoot = co.map({
+    organizations: co.list(Organization),
+  });
+
+  const AccountSchema = co
+    .account({
+      root: AccountRoot,
+      profile: co.profile(),
+    })
+    .withMigration(async (account) => {
+      if (!account.$jazz.has("root")) {
+        account.$jazz.set("root", {
+          organizations: [
+            {
+              name: "My organization",
+              projects: [
+                {
+                  name: "My project",
+                  tasks: [],
+                  draftTasks: [],
+                  deletedTasks: [],
+                },
+              ],
+            },
+          ],
+        });
+      }
+    });
+
+  const account = await createJazzTestAccount({
+    AccountSchema,
+    isCurrentActiveAccount: true,
+    creationProps: { name: "Hermes Puggington" },
+  });
+
+  const root = await account.root.$jazz.ensureLoaded({
+    resolve: {
+      organizations: {
+        $each: {
+          projects: {
+            $each: true,
+          },
+        },
+      },
+    },
+  });
+
+  const project = root.organizations[0]?.projects[0]!;
+
+  for (let i = 0; i < 250; i++) {
+    const taskList = (["tasks", "draftTasks", "deletedTasks"] as const)[i % 3]!;
+
+    project[taskList].$jazz.push({
+      title: `Task ${i}`,
+      project,
+    });
+  }
+
+  const SingleSubscriptionTasks = ({
+    subscription,
+    taskListType,
+  }: {
+    subscription: CoValueSubscription<
+      typeof AccountSchema,
+      {
+        root: {
+          organizations: {
+            $each: {
+              projects: {
+                $each: {
+                  tasks: { $each: { project: true } };
+                  draftTasks: { $each: { project: true } };
+                  deletedTasks: { $each: { project: true } };
+                };
+              };
+            };
+          };
+        };
+      }
+    >;
+    taskListType: "tasks" | "draftTasks" | "deletedTasks";
+  }) => {
+    const allProjectsTasks = useSubscriptionSelector(subscription, {
+      select: (account) => {
+        return account?.root.organizations.flatMap((org) =>
+          org?.projects.flatMap((project) =>
+            project?.[taskListType]?.flatMap((task) => task),
+          ),
+        );
+      },
+    });
+
+    return (
+      <div>
+        {allProjectsTasks?.map((task) => (
+          <div key={task?.$jazz.id}>{task?.title}</div>
+        ))}
+      </div>
+    );
+  };
+
+  const SingleSubscription = () => {
+    const subscription = useAccountSubscription(AccountSchema, {
+      resolve: {
+        root: {
+          organizations: {
+            $each: {
+              projects: {
+                $each: {
+                  tasks: { $each: { project: true } },
+                  draftTasks: { $each: { project: true } },
+                  deletedTasks: { $each: { project: true } },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    return (
+      <div>
+        <SingleSubscriptionTasks
+          subscription={subscription}
+          taskListType="tasks"
+        />
+        <SingleSubscriptionTasks
+          subscription={subscription}
+          taskListType="draftTasks"
+        />
+        <SingleSubscriptionTasks
+          subscription={subscription}
+          taskListType="deletedTasks"
+        />
+      </div>
+    );
+  };
+
+  bench(
+    "useAccountSubscription + useSubscriptionSelector",
+    () => {
+      render(<SingleSubscription />);
+    },
+    { iterations: 200 },
+  );
+
+  const MultipleSubscriptionTasks = ({
+    taskListType,
+  }: {
+    taskListType: "tasks" | "draftTasks" | "deletedTasks";
+  }) => {
+    const subscription = useAccountWithSelector(AccountSchema, {
+      resolve: {
+        root: {
+          organizations: {
+            $each: {
+              projects: {
+                $each: {
+                  tasks: { $each: { project: true } },
+                  draftTasks: { $each: { project: true } },
+                  deletedTasks: { $each: { project: true } },
+                },
+              },
+            },
+          },
+        },
+      },
+      select: (account) =>
+        account?.root.organizations.flatMap((org) =>
+          org?.projects.flatMap((project) =>
+            project?.[taskListType]?.flatMap((task) => task),
+          ),
+        ),
+    });
+
+    return (
+      <div>
+        {subscription?.map((task) => (
+          <div key={task?.$jazz.id}>{task?.title}</div>
+        ))}
+      </div>
+    );
+  };
+
+  const MultipleSubscription = () => {
+    return (
+      <div>
+        <MultipleSubscriptionTasks taskListType="tasks" />
+        <MultipleSubscriptionTasks taskListType="draftTasks" />
+        <MultipleSubscriptionTasks taskListType="deletedTasks" />
+      </div>
+    );
+  };
+
+  bench(
+    "useAccountWithSelector",
+    () => {
+      render(<MultipleSubscription />);
+    },
+    { iterations: 200 },
   );
 });

--- a/packages/jazz-tools/src/react-core/tests/subscription.bench.tsx
+++ b/packages/jazz-tools/src/react-core/tests/subscription.bench.tsx
@@ -1,0 +1,94 @@
+// @vitest-environment happy-dom
+
+import { cojsonInternals } from "cojson";
+import { co } from "jazz-tools";
+import { describe, bench } from "vitest";
+import {
+  useAccountSubscription,
+  useSubscriptionSelector,
+  useAccountWithSelector,
+  CoValueSubscription,
+} from "../index.js";
+import { createJazzTestAccount, setupJazzTestSync } from "../testing.js";
+import { render } from "./testUtils.js";
+
+cojsonInternals.setCoValueLoadingRetryDelay(300);
+
+await setupJazzTestSync();
+await createJazzTestAccount({
+  isCurrentActiveAccount: true,
+  creationProps: { name: "Hermes Puggington" },
+});
+
+const AccountSchema = co.account();
+
+const AccountName = () => {
+  const name = useAccountWithSelector(AccountSchema, {
+    resolve: {
+      profile: true,
+    },
+    select: (account) => account?.profile?.name,
+  });
+
+  if (!name) return null;
+
+  return <span>{name}</span>;
+};
+
+const AccountNameFromSubscription = ({
+  subscription,
+}: {
+  subscription: CoValueSubscription<typeof AccountSchema, { profile: true }>;
+}) => {
+  const name = useSubscriptionSelector(subscription, {
+    select: (account) => account?.profile?.name,
+  });
+
+  if (!name) return null;
+
+  return <span>{name}</span>;
+};
+
+const UseAccountWithSelector = () => {
+  return (
+    <div>
+      {Array.from({ length: 1000 }).map((_, i) => (
+        <AccountName key={i} />
+      ))}
+    </div>
+  );
+};
+
+const UseAccountSubscription = () => {
+  const subscription = useAccountSubscription(AccountSchema, {
+    resolve: {
+      profile: true,
+    },
+  });
+
+  return (
+    <div>
+      {Array.from({ length: 1000 }).map((_, i) => (
+        <AccountNameFromSubscription key={i} subscription={subscription} />
+      ))}
+    </div>
+  );
+};
+
+describe("1000 value loads", () => {
+  bench(
+    "useAccountSubscription + useSubscriptionSelector",
+    () => {
+      render(<UseAccountSubscription />);
+    },
+    { iterations: 50 },
+  );
+
+  bench(
+    "useAccountWithSelector",
+    () => {
+      render(<UseAccountWithSelector />);
+    },
+    { iterations: 50 },
+  );
+});

--- a/packages/jazz-tools/src/react-core/tests/useSubscriptionSelector.test.ts
+++ b/packages/jazz-tools/src/react-core/tests/useSubscriptionSelector.test.ts
@@ -1,0 +1,250 @@
+// @vitest-environment happy-dom
+
+import { cojsonInternals } from "cojson";
+import { co, z } from "jazz-tools";
+import { beforeEach, describe, expect, expectTypeOf, it } from "vitest";
+import {
+  useCoValueSubscription,
+  useAccountSubscription,
+  useSubscriptionSelector,
+} from "../index.js";
+import { createJazzTestAccount, setupJazzTestSync } from "../testing.js";
+import { act, renderHook, waitFor } from "./testUtils.js";
+import { useRef } from "react";
+
+beforeEach(async () => {
+  await setupJazzTestSync();
+
+  await createJazzTestAccount({
+    isCurrentActiveAccount: true,
+  });
+});
+
+cojsonInternals.setCoValueLoadingRetryDelay(300);
+
+const useRenderCount = <T>(hook: () => T) => {
+  const renderCountRef = useRef(0);
+  const result = hook();
+  renderCountRef.current = renderCountRef.current + 1;
+  return {
+    renderCount: renderCountRef.current,
+    result,
+  };
+};
+
+describe("useSubscriptionSelector", () => {
+  it("should return coValue", () => {
+    const TestMap = co.map({
+      value: z.string(),
+    });
+
+    const map = TestMap.create({
+      value: "123",
+    });
+
+    const { result } = renderHook(() => {
+      const subscription = useCoValueSubscription(TestMap, map.$jazz.id);
+      return useSubscriptionSelector(subscription);
+    });
+
+    expect(result.current?.value).toBe("123");
+  });
+
+  it("should resolve nested coValues", () => {
+    const TestNestedMap = co.map({
+      content: z.string(),
+    });
+
+    const TestMap = co.map({
+      content: z.string(),
+      nested: TestNestedMap,
+    });
+
+    const map = TestMap.create({
+      content: "123",
+      nested: {
+        content: "456",
+      },
+    });
+
+    const { result } = renderHook(() => {
+      const subscription = useCoValueSubscription(TestMap, map.$jazz.id);
+      return useSubscriptionSelector(subscription);
+    });
+
+    expect(result.current?.nested?.content).toBe("456");
+  });
+
+  it("should return null on invalid coValue id", async () => {
+    const TestMap = co.map({
+      value: z.string(),
+    });
+
+    const { result } = renderHook(() => {
+      const subscription = useCoValueSubscription(TestMap, "123");
+      return useSubscriptionSelector(subscription);
+    });
+
+    expect(result.current).toBeUndefined();
+
+    await waitFor(() => {
+      expect(result.current).toBeNull();
+    });
+  });
+
+  it("should return coAccount", async () => {
+    const account = await createJazzTestAccount();
+
+    const { result } = renderHook(
+      () => {
+        const subscription = useAccountSubscription(co.account());
+        return useSubscriptionSelector(subscription);
+      },
+      {
+        account,
+      },
+    );
+
+    expect(result.current?.$jazz.id).toBe(account.$jazz.id);
+  });
+
+  it("should return value from coValue with selector", () => {
+    const TestMap = co.map({
+      value: z.string(),
+    });
+
+    const map = TestMap.create({
+      value: "123",
+    });
+
+    const { result } = renderHook(() => {
+      const subscription = useCoValueSubscription(TestMap, map.$jazz.id);
+      return useSubscriptionSelector(subscription, {
+        select: (v) => v?.value,
+      });
+    });
+
+    expect(result.current).toBe("123");
+  });
+
+  it("should return value from coAccount with selector", async () => {
+    const account = await createJazzTestAccount({
+      creationProps: { name: "test" },
+    });
+
+    const { result } = renderHook(
+      () => {
+        const subscription = useAccountSubscription(co.account());
+        return useSubscriptionSelector(subscription, {
+          select: (v) => v?.profile?.name,
+        });
+      },
+      {
+        account,
+      },
+    );
+
+    expect(result.current).toBe("test");
+  });
+
+  it("should update value from coValue with selected value changes", () => {
+    const TestMap = co.map({
+      value: z.string(),
+    });
+
+    const map = TestMap.create({
+      value: "123",
+    });
+
+    const { result } = renderHook(() => {
+      const subscription = useCoValueSubscription(TestMap, map.$jazz.id);
+      return useSubscriptionSelector(subscription, {
+        select: (v) => v?.value,
+      });
+    });
+
+    expect(result.current).toBe("123");
+
+    act(() => {
+      map.$jazz.set("value", "456");
+    });
+
+    expect(result.current).toBe("456");
+  });
+
+  it("should not re-render when a non-selected field is updated and not selected", () => {
+    const TestMap = co.map({
+      value: z.string(),
+      other: z.string(),
+    });
+
+    const map = TestMap.create({
+      value: "1",
+      other: "1",
+    });
+
+    const { result } = renderHook(() =>
+      useRenderCount(() => {
+        const subscription = useCoValueSubscription(TestMap, map.$jazz.id);
+        return useSubscriptionSelector(subscription, {
+          select: (v) => v?.value,
+        });
+      }),
+    );
+
+    expect(result.current.result).toBe("1");
+    expect(result.current.renderCount).toBe(1);
+
+    act(() => {
+      map.$jazz.set("other", "2");
+    });
+
+    expect(result.current.result).toBe("1");
+    expect(result.current.renderCount).toBe(1);
+  });
+
+  it("should only re-render or load new value when equalityFn returns true", () => {
+    const TestMap = co.map({
+      value: z.number(),
+      other: z.number(),
+    });
+
+    const map = TestMap.create({
+      value: 1,
+      other: 2,
+    });
+
+    const { result } = renderHook(() =>
+      useRenderCount(() => {
+        const subscription = useCoValueSubscription(TestMap, map.$jazz.id);
+        return useSubscriptionSelector(subscription, {
+          select: (v) =>
+            v
+              ? [Math.floor(v.value / 5), Math.floor(v.other / 5)].toSorted()
+              : [],
+          equalityFn: (a, b) => a.every((v, i) => v === b[i]),
+        });
+      }),
+    );
+
+    expect(result.current.result).toEqual([0, 0]);
+    expect(result.current.renderCount).toBe(1);
+
+    act(() => {
+      map.$jazz.applyDiff({
+        value: 3,
+        other: 4,
+      });
+    });
+
+    expect(result.current.result).toEqual([0, 0]);
+    expect(result.current.renderCount).toBe(1);
+
+    act(() => {
+      map.$jazz.set("value", 5);
+    });
+
+    expect(result.current.result).toEqual([0, 1]);
+    expect(result.current.renderCount).toBe(2);
+  });
+});

--- a/packages/jazz-tools/src/react-core/types.ts
+++ b/packages/jazz-tools/src/react-core/types.ts
@@ -1,0 +1,19 @@
+import {
+  CoValueClassOrSchema,
+  ResolveQuery,
+  SubscriptionScope,
+} from "jazz-tools";
+
+declare const subscriptionTag: unique symbol;
+
+export type CoValueSubscription<
+  S extends CoValueClassOrSchema,
+  R extends ResolveQuery<S>,
+> =
+  | (SubscriptionScope<any> & {
+      [subscriptionTag]: {
+        schema: S;
+        resolve: R;
+      };
+    })
+  | null;

--- a/packages/jazz-tools/src/react-native-core/hooks.tsx
+++ b/packages/jazz-tools/src/react-native-core/hooks.tsx
@@ -16,6 +16,9 @@ export {
   useCoStateWithSelector,
   useAccountWithSelector,
   useSyncConnectionStatus,
+  useCoValueSubscription,
+  useAccountSubscription,
+  useSubscriptionSelector,
 } from "jazz-tools/react-core";
 
 export function useAcceptInviteNative<S extends CoValueClassOrSchema>({

--- a/packages/jazz-tools/src/react-native-core/index.ts
+++ b/packages/jazz-tools/src/react-native-core/index.ts
@@ -4,6 +4,12 @@ export * from "./provider.js";
 export * from "./storage/kv-store-context.js";
 export * from "./media/image.js";
 
+export {
+  createCoValueSubscriptionContext,
+  createAccountSubscriptionContext,
+  type CoValueSubscription,
+} from "jazz-tools/react-core";
+
 export { SQLiteDatabaseDriverAsync } from "cojson";
 export { parseInviteLink } from "jazz-tools";
 export { createInviteLink, setupKvStore } from "./platform.js";

--- a/packages/jazz-tools/src/react/hooks.tsx
+++ b/packages/jazz-tools/src/react/hooks.tsx
@@ -53,4 +53,7 @@ export {
   useCoStateWithSelector,
   useAccountWithSelector,
   useSyncConnectionStatus,
+  useCoValueSubscription,
+  useAccountSubscription,
+  useSubscriptionSelector,
 } from "jazz-tools/react-core";

--- a/packages/jazz-tools/src/react/index.ts
+++ b/packages/jazz-tools/src/react/index.ts
@@ -10,6 +10,9 @@ export {
   useCoStateWithSelector,
   useAccountWithSelector,
   useSyncConnectionStatus,
+  useCoValueSubscription,
+  useAccountSubscription,
+  useSubscriptionSelector,
 } from "./hooks.js";
 
 export { createInviteLink, parseInviteLink } from "jazz-tools/browser";

--- a/packages/jazz-tools/src/react/index.ts
+++ b/packages/jazz-tools/src/react/index.ts
@@ -15,6 +15,12 @@ export {
   useSubscriptionSelector,
 } from "./hooks.js";
 
+export {
+  createCoValueSubscriptionContext,
+  createAccountSubscriptionContext,
+  type CoValueSubscription,
+} from "jazz-tools/react-core";
+
 export { createInviteLink, parseInviteLink } from "jazz-tools/browser";
 
 export * from "./auth/auth.js";


### PR DESCRIPTION
# Description
More granular reactivity changes, but this isn't the main goal actually. We've realized that every single `useCoState` call can incur a very heavy cost without actually needing to have a ton of them if you're doing some deep resolves. For example, we've have a use case where needed to do some medium complexity logic on a co-state with a couple of nested resolves, so we wrapped up the `useCoState` hook inside a custom hook that was used in about 5 to 10 components, and we realized that we'd often get 100ms+ render times for every single hook call, meaning a single re-render could take 500ms to 1000ms+ at times.

We were able to internally fix this issue by making sure these expensive hooks are called only once in the entire tree with the result served through a context. This by itself obviously wouldn't be ideal because then that would mean EVERYTHING would re-render on every single change. So we had to store the results in a non-reactive store that can then be read using reactive hooks wherever they're needed further down the tree. This wasn't a clean or issue-free solution, but it worked beautifully in terms of performance. Here are the results I'm getting from the benchmark I added.

```
 ✓  jazz-tools  src/react-core/tests/subscription.bench.tsx > 1000 value loads 2481ms
     name                                                   hz      min      max     mean      p75      p99     p995     p999     rme  samples
   · useAccountSubscription + useSubscriptionSelector  90.3840   8.1881  16.7962  11.0639  10.7508  16.7962  16.7962  16.7962  ±3.78%       50
   · useAccountWithSelector                            34.1230  25.1204  40.1154  29.3057  29.7515  40.1154  40.1154  40.1154  ±4.12%       50

 ✓  jazz-tools  src/react-core/tests/subscription.bench.tsx > deeply resolved coMaps 8756ms
     name                                                   hz      min      max     mean      p75      p99     p995     p999      rme  samples
   · useAccountSubscription + useSubscriptionSelector  97.7141   6.2516  15.5710  10.2339  11.7479  13.3393  13.5106  15.5710   ±3.00%      200
   · useAccountWithSelector                            31.1867  20.0294   413.61  32.0650  29.1083   131.56   195.34   413.61  ±14.21%      200

 BENCH  Summary

   jazz-tools  useAccountSubscription + useSubscriptionSelector - src/react-core/tests/subscription.bench.tsx > 1000 value loads
    2.65x faster than useAccountWithSelector

   jazz-tools  useAccountSubscription + useSubscriptionSelector - src/react-core/tests/subscription.bench.tsx > deeply resolved coMaps
    3.13x faster than useAccountWithSelector
```

2x - 3x faster is nice, but wouldn't really matter much if we're talking about single digit millisecond times, but you can see how especially in the deeply resolved benchmark the p99+ times are more than 10x slower.

It looks like the creation of SubscriptionScopes is what's really very computationally intensive, but adding listeners to the same subscription scope is basically negligible in terms of performance impact. When you think of it, there are a lot of examples ,`useAccount` being the main one, where it's just a waste to keep subscribing to the same data multiple times.

The solution in this PR is really nice, because now we can share the same subscription scope with all child components, while still maintaining granular reactivity. The DX enabled by the `createCoValueSubscriptionContext` and `createAccountSubscriptionContext` helper functions is pretty nice because it really simplifies the common pattern of sharing a "global" coValue with other components without having to explicitly add types to the props of all components (or pass an ID an keep creating new subscriptions for the same data).

## Manual testing instructions

<!-- Add any actions required to manually test the changes -->

## Tests

- [x] Tests have been added and/or updated
- [ ] Tests have not been updated, because: <!-- Insert reason for not updating tests here -->
- [ ] I need help with writing tests


## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [ ] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing