### PR TITLE
docs: add TypeScript configuration requirements to troubleshooting guide

### DIFF
--- a/homepage/homepage/content/docs/troubleshooting.mdx
+++ b/homepage/homepage/content/docs/troubleshooting.mdx
@@ -31,6 +31,16 @@ nvm use 20
 ```
 </CodeGroup>
 ---
+
+### Required TypeScript Configuration
+
+In order to build successfully with TypeScript, you must ensure that you have the following options configured (either in your `tsconfig.json` or using the command line):
+
+* `skipLibCheck` must be `true`
+* `exactOptionalPropertyTypes` must be `false`
+
+---
+
 ## npx jazz-run: command not found
 If, when running:
 <CodeGroup>
@@ -64,6 +74,7 @@ npx clear-npx-cache
 npx jazz-run sync
 ```
 </CodeGroup>
+
 ---
 ### Node 18 workaround (rebuilding the native module)
 


### PR DESCRIPTION
# Description
Document a couple of TS settings we know we don't play nicely with

## Manual testing instructions
N/A

## Tests

- [ ] Tests have been added and/or updated
- [ ] Tests have not been updated, because: Docs update
- [ ] I need help with writing tests


## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [ ] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing