### PR TITLE
feat: add `skipErrorsInLists` option to subscriptions

### DIFF
--- a/packages/jazz-tools/src/tools/coValues/coList.ts
+++ b/packages/jazz-tools/src/tools/coValues/coList.ts
@@ -612,6 +612,10 @@ export class CoListJazzApi<L extends CoList> extends CoValueJazzApi<L> {
    * @category Content
    */
   pop(): CoListItem<L> | undefined {
+    if (this.coList.length === 0) {
+      return undefined;
+    }
+
     const last = this.coList[this.coList.length - 1];
 
     this.raw.delete(this.toRawIndex(this.coList.length - 1));
@@ -626,6 +630,10 @@ export class CoListJazzApi<L extends CoList> extends CoValueJazzApi<L> {
    * @category Content
    */
   shift(): CoListItem<L> | undefined {
+    if (this.coList.length === 0) {
+      return undefined;
+    }
+
     const first = this.coList[0];
 
     this.raw.delete(this.toRawIndex(0));

--- a/packages/jazz-tools/src/tools/exports.ts
+++ b/packages/jazz-tools/src/tools/exports.ts
@@ -53,6 +53,7 @@ export {
   subscribeToCoValue,
   ImageDefinition,
   SubscriptionScope,
+  skipErrorsInLists,
   exportCoValue,
   importContentPieces,
   Ref,

--- a/packages/jazz-tools/src/tools/internal.ts
+++ b/packages/jazz-tools/src/tools/internal.ts
@@ -25,6 +25,7 @@ export * from "./implementation/activeAccountContext.js";
 export * from "./implementation/errors.js";
 export * from "./implementation/refs.js";
 export * from "./implementation/schema.js";
+export * from "./subscribe/queryView.js";
 export * from "./subscribe/SubscriptionScope.js";
 export * from "./subscribe/types.js";
 export * from "./subscribe/index.js";

--- a/packages/jazz-tools/src/tools/subscribe/SubscriptionScope.ts
+++ b/packages/jazz-tools/src/tools/subscribe/SubscriptionScope.ts
@@ -132,6 +132,9 @@ export class SubscriptionScope<D extends CoValue> {
 
     // Flags that the value has changed and we need to trigger an update
     this.dirty = true;
+
+    // Reset the cached query view so it's computed again on the next access
+    this.cachedQueryView = null;
   }
 
   handleUpdate(update: RawCoValue | "unavailable") {
@@ -361,8 +364,6 @@ export class SubscriptionScope<D extends CoValue> {
     }
 
     this.dirty = false;
-
-    this.cachedQueryView = null;
   }
 
   subscribers = new Set<(value: SubscriptionValue<D, any>) => void>();

--- a/packages/jazz-tools/src/tools/subscribe/SubscriptionScope.ts
+++ b/packages/jazz-tools/src/tools/subscribe/SubscriptionScope.ts
@@ -16,6 +16,18 @@ import { CoValueCoreSubscription } from "./CoValueCoreSubscription.js";
 import { JazzError, type JazzErrorIssue } from "./JazzError.js";
 import type { BranchDefinition, SubscriptionValue, Unloaded } from "./types.js";
 import { createCoValue, myRoleForRawValue } from "./utils.js";
+import { computeQueryView, type QueryView } from "./queryView.js";
+
+let SKIP_ERRORS_IN_COLISTS = false;
+
+/**
+ * If set to true, inaccessible items in a CoList will be skipped when loading the CoList.
+ * This setting is disabled by default, so CoLists with inaccessible items will not be
+ * loaded unless `$onError: null` is provided in the resolve query.
+ */
+export function skipErrorsInLists(skip: boolean) {
+  SKIP_ERRORS_IN_COLISTS = skip;
+}
 
 export class SubscriptionScope<D extends CoValue> {
   childNodes = new Map<string, SubscriptionScope<CoValue>>();
@@ -37,7 +49,7 @@ export class SubscriptionScope<D extends CoValue> {
   errorFromChildren: JazzError | undefined;
   subscription: CoValueCoreSubscription;
   dirty = false;
-  resolve: RefsToResolve<any>;
+  resolve: Exclude<RefsToResolve<any>, true | false>;
   idsSubscribed = new Set<string>();
   autoloaded = new Set<string>();
   autoloadedKeys = new Set<string>();
@@ -49,6 +61,8 @@ export class SubscriptionScope<D extends CoValue> {
 
   silenceUpdates = false;
 
+  private cachedQueryView: QueryView | null = null;
+
   constructor(
     public node: LocalNode,
     resolve: RefsToResolve<D>,
@@ -58,7 +72,16 @@ export class SubscriptionScope<D extends CoValue> {
     public bestEffortResolution = false,
     public unstable_branch?: BranchDefinition,
   ) {
-    this.resolve = resolve;
+    this.resolve = resolve === true || !resolve ? {} : resolve;
+    if (SKIP_ERRORS_IN_COLISTS) {
+      if (this.resolve.$each === true) {
+        this.resolve.$each = {};
+      }
+      if (this.resolve.$each && this.resolve.$each.$onError !== null) {
+        // @ts-expect-error 'skip' is only used internally, it's not part of the resolve query API
+        this.resolve.$each.$onError = "skip";
+      }
+    }
     this.value = { type: "unloaded", id };
 
     let lastUpdate: RawCoValue | "unavailable" | undefined;
@@ -338,6 +361,8 @@ export class SubscriptionScope<D extends CoValue> {
     }
 
     this.dirty = false;
+
+    this.cachedQueryView = null;
   }
 
   subscribers = new Set<(value: SubscriptionValue<D, any>) => void>();
@@ -355,10 +380,6 @@ export class SubscriptionScope<D extends CoValue> {
   }
 
   subscribeToKey(key: string) {
-    if (this.resolve === true || !this.resolve) {
-      this.resolve = {};
-    }
-
     if (!this.resolve.$each && !(key in this.resolve)) {
       const resolve = this.resolve as Record<string, any>;
 
@@ -700,7 +721,9 @@ export class SubscriptionScope<D extends CoValue> {
       this.autoloaded.add(id);
     }
 
-    const skipInvalid = typeof query === "object" && query.$onError === null;
+    const skipInvalid =
+      typeof query === "object" &&
+      (query.$onError === null || query.$onError === "skip");
 
     if (skipInvalid) {
       if (key) {
@@ -739,6 +762,30 @@ export class SubscriptionScope<D extends CoValue> {
     if (this.closed) {
       child.destroy();
     }
+  }
+
+  /**
+   * When loading a CoValue, the view over it can be different from the actual CoValue's content.
+   * The query view is a mapping that links the keys in the CoValue query view to the keys in the raw CoValue.
+   * @internal
+   */
+  get queryView(): QueryView | null {
+    if (
+      this.value.type !== "loaded" ||
+      this.value.value[TypeSym] !== "CoList"
+    ) {
+      return null;
+    }
+
+    if (
+      typeof this.resolve.$each !== "object" ||
+      // @ts-expect-error 'skip' is only used internally, it's not part of the resolve query API
+      this.resolve.$each.$onError !== "skip"
+    ) {
+      return null;
+    }
+    this.cachedQueryView ||= computeQueryView(this.value.value as CoList);
+    return this.cachedQueryView;
   }
 
   destroy() {

--- a/packages/jazz-tools/src/tools/subscribe/index.ts
+++ b/packages/jazz-tools/src/tools/subscribe/index.ts
@@ -32,12 +32,13 @@ export function getSubscriptionScope<D extends CoValue>(value: D) {
 /** Autoload internals */
 
 /**
- * Given a coValue, access a child coValue by key
+ * Given a coValue, access a child coValue by key.
+ * Returns the current loading state of the child CoValue.
  *
  * By subscribing to a given key, the subscription will automatically react to the id changes
  * on that key (e.g. deleting the key value will result on unsubscribing from the id)
  */
-export function accessChildByKey<D extends CoValue>(
+export function accessChildLoadingStateByKey<D extends CoValue>(
   parent: D,
   childId: string,
   key: string,
@@ -53,8 +54,22 @@ export function accessChildByKey<D extends CoValue>(
       subscriptionScope.handleChildUpdate(childId, value),
     );
   }
+  return subscriptionScope.childValues.get(childId);
+}
 
-  const value = subscriptionScope.childValues.get(childId);
+/**
+ * Given a coValue, access a child coValue by key.
+ * Returns the current value of the child CoValue, or null if the CoValue is not loaded.
+ *
+ * By subscribing to a given key, the subscription will automatically react to the id changes
+ * on that key (e.g. deleting the key value will result on unsubscribing from the id)
+ */
+export function accessChildByKey<D extends CoValue>(
+  parent: D,
+  childId: string,
+  key: string,
+) {
+  const value = accessChildLoadingStateByKey(parent, childId, key);
 
   if (value?.type === "loaded") {
     return value.value;

--- a/packages/jazz-tools/src/tools/subscribe/queryView.ts
+++ b/packages/jazz-tools/src/tools/subscribe/queryView.ts
@@ -1,0 +1,42 @@
+import type { CoList } from "../internal.js";
+import {
+  ItemsSym,
+  isRefEncoded,
+  accessChildLoadingStateByKey,
+} from "../internal.js";
+
+/**
+ * When loading a CoValue, the view over it can be different from the actual CoValue's content.
+ * The query view is a mapping that links the keys in the CoValue query view to the keys in the raw CoValue.
+ */
+export type QueryView = Record<number, number>;
+
+export function computeQueryView(value: CoList): QueryView {
+  const items = accessibleItems(value);
+  return Object.fromEntries(items.map((rawIndex, idx) => [idx, rawIndex]));
+}
+
+/**
+ * Get the keys of the CoValue that are loaded and accessible.
+ */
+function accessibleItems(coValue: CoList): number[] {
+  const allItems = coValue.$jazz.raw.entries().map((_entry, i) => i);
+  if (!isRefEncoded(coValue.$jazz.schema[ItemsSym])) {
+    return allItems;
+  }
+  return allItems.filter((rawIndex) => isItemAccessible(coValue, rawIndex));
+}
+
+function isItemAccessible(coValue: CoList, key: number): boolean {
+  const rawValue = coValue.$jazz.raw.get(key) as string | null;
+  // Omit null references
+  if (rawValue === null) {
+    return false;
+  }
+  // CoList elements have already been loaded by the subscription scope.
+  // Omit inaccessible elements from the query view.
+  const isLoaded =
+    accessChildLoadingStateByKey(coValue, rawValue, String(key))?.type ===
+    "loaded";
+  return isLoaded;
+}

--- a/packages/jazz-tools/src/tools/tests/coList.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coList.test.ts
@@ -425,6 +425,13 @@ describe("Simple CoList operations", async () => {
         list.$jazz.splice(1, 0, "lettuce");
         expect(list[1]?.toString()).toBe("lettuce");
       });
+
+      test("ignore out-of-bound indices", () => {
+        const Schema = co.list(co.plainText());
+        const list = Schema.create(["bread", "butter", "onion"]);
+        list.$jazz.splice(2, 3, "lettuce");
+        expect(list[2]?.toString()).toBe("lettuce");
+      });
     });
 
     describe("remove", () => {
@@ -1552,7 +1559,7 @@ describe("CoList query view", () => {
     expect(list[0]?.toString()).toBe("onion");
     expect(list[1]?.toString()).toBe("pasta");
     expect(list[2]?.toString()).toBe("butter");
-    // TODO expect(list[3]).toBeUndefined();
+    expect(list[3]).toBeUndefined();
   });
 
   test("updates items included in the query view", () => {
@@ -1572,7 +1579,7 @@ describe("CoList query view", () => {
     expect(refs[0]?.id).toBe(list[0]!.$jazz.id);
     expect(refs[1]?.id).toBe(list[1]!.$jazz.id);
     expect(refs[2]?.id).toBe(list[2]!.$jazz.id);
-    // TODO expect(refs[3]).toBeUndefined();
+    expect(refs[3]).toBeUndefined();
   });
 
   test("toJSON only returns items included in the query view", () => {

--- a/packages/jazz-tools/src/tools/tests/coList.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coList.test.ts
@@ -316,22 +316,40 @@ describe("Simple CoList operations", async () => {
       });
     });
 
-    test("pop", () => {
-      const list = TestList.create(["bread", "butter", "onion"], {
-        owner: me,
+    describe("pop", () => {
+      test("removes the last element from the list and returns it", () => {
+        const list = TestList.create(["bread", "butter", "onion"], {
+          owner: me,
+        });
+        expect(list.$jazz.pop()).toBe("onion");
+        expect(list.length).toBe(2);
+        expect(list.$jazz.raw.asArray()).toEqual(["bread", "butter"]);
       });
-      expect(list.$jazz.pop()).toBe("onion");
-      expect(list.length).toBe(2);
-      expect(list.$jazz.raw.asArray()).toEqual(["bread", "butter"]);
+
+      test("returns undefined if the list is empty", () => {
+        const list = TestList.create([], { owner: me });
+        expect(list.$jazz.pop()).toBeUndefined();
+        expect(list.length).toBe(0);
+        expect(list.$jazz.raw.asArray()).toEqual([]);
+      });
     });
 
-    test("shift", () => {
-      const list = TestList.create(["bread", "butter", "onion"], {
-        owner: me,
+    describe("shift", () => {
+      test("removes the first element from the list and returns it", () => {
+        const list = TestList.create(["bread", "butter", "onion"], {
+          owner: me,
+        });
+        expect(list.$jazz.shift()).toBe("bread");
+        expect(list.length).toBe(2);
+        expect(list.$jazz.raw.asArray()).toEqual(["butter", "onion"]);
       });
-      expect(list.$jazz.shift()).toBe("bread");
-      expect(list.length).toBe(2);
-      expect(list.$jazz.raw.asArray()).toEqual(["butter", "onion"]);
+
+      test("returns undefined if the list is empty", () => {
+        const list = TestList.create([], { owner: me });
+        expect(list.$jazz.shift()).toBeUndefined();
+        expect(list.length).toBe(0);
+        expect(list.$jazz.raw.asArray()).toEqual([]);
+      });
     });
 
     describe("splice", () => {


### PR DESCRIPTION
# Description

Adds a new global `skipErrorsInLists` configuration that allows skipping inaccessible elements from CoLists when loading them. In order to enable this feature, use:

```typescript
skipErrorsInLists(true)
```
anywhere in your app, before you start loading CoValues.

Before this feature, the only alternative for loading CoLists with inaccessible items was using `$each: { $onError: null }` on each resolve query, and manually filtering out the null references.

While working on this I found some edge cases that were not being properly handled by pop, shift and splice, so those are fixed as well.

## Key changes

Now that inaccessible items are not shown as part of the CoList, we've introduced a difference between the elements in the RawCoValue and the elements in the jazz-tools CoList.

This PR introduces the concept of **query views** to support this new feature. The query view gives us a way to decouple the elements from a jazz-tools CoList from the elements in the underlying RawCoList, by mapping the keys in the CoList to the keys in the RawCoList. This means users will see only the elements returned by their resolve query, but will still be able to perform operations on the CoList that will be mapped to the underlying RawCoList.

The logic for creating and invalidating the query view is pretty naive at the moment (we recompute the whole view on each change). We'll be implementing a more efficient strategy for incrementally updating the view as a follow-up.

In the future, query views will also enable filtering, sorting and pagination.

## Benchmark

Tested query view generation with CoLists containing 10k - 50k elements and got times between 4ms and 20ms. Considering the generation time will grow linearly, I think performance is good enough for this initial release. I'll start looking into Incremental View Maintenance as a follow-up. 

## Tests

- [x] Tests have been added and/or updated

## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [ ] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce global skipErrorsInLists and query view mapping so CoLists hide inaccessible items and all mutations/read ops respect the filtered view; add related subscribe utilities and tests.
> 
> - **CoList / Query Views**:
>   - Introduce query views to map visible indices to raw indices (`queryView`, `computeQueryView`).
>   - Update `CoListJazzApi` to respect query views: `get`, `set`, `push`, `unshift`, `pop`, `shift`, `splice`, `remove`, `applyDiff`, `length`, `asArray`, and `refs` now translate via `toRawIndex` and keep the view in sync.
>   - Adjust `CoList` proxy (`get`, `length`, `has`, `ownKeys`, `getOwnPropertyDescriptor`) to use query views.
> - **Subscriptions**:
>   - Add global `skipErrorsInLists(skip: boolean)`; when enabled, inaccessible list items are skipped by default.
>   - Support `$onError: "skip"` internally and cache per-scope query views in `SubscriptionScope`.
>   - Refine resolve handling, autoloading, and child access with `accessChildLoadingStateByKey` (new) and reuse in `accessChildByKey`.
> - **Exports**:
>   - Re-export `skipErrorsInLists` and new query view utilities.
> - **Bug fixes / Behavior**:
>   - Handle empty `pop`/`shift`, ignore out-of-bounds in `splice`, and ensure mutations operate on filtered views.
> - **Tests**:
>   - Add/expand tests for skipErrorsInLists, `$onError: null` behaviors, query views (reads/mutations/array methods), and edge cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1b7a70426bcb9d964434af257757643dabeee5e6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->