### PR TITLE
chore: upgrade Zod to 4.1

### DIFF
--- a/.changeset/tidy-horses-count.md
+++ b/.changeset/tidy-horses-count.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Upgrade Zod to 4.1

--- a/examples/chat/package.json
+++ b/examples/chat/package.json
@@ -17,8 +17,7 @@
     "jazz-tools": "workspace:*",
     "lucide-react": "^0.536.0",
     "react": "catalog:react",
-    "react-dom": "catalog:react",
-    "zod": "3.25.76"
+    "react-dom": "catalog:react"
   },
   "devDependencies": {
     "@playwright/test": "^1.50.1",

--- a/examples/multi-cursors/package.json
+++ b/examples/multi-cursors/package.json
@@ -14,8 +14,7 @@
     "@react-spring/web": "^9.7.5",
     "jazz-tools": "workspace:*",
     "react": "catalog:react",
-    "react-dom": "catalog:react",
-    "zod": "3.25.76"
+    "react-dom": "catalog:react"
   },
   "devDependencies": {
     "@biomejs/biome": "catalog:default",

--- a/packages/jazz-tools/package.json
+++ b/packages/jazz-tools/package.json
@@ -196,7 +196,7 @@
     "prosemirror-state": "^1.4.3",
     "prosemirror-transform": "^1.9.0",
     "use-sync-external-store": "^1.5.0",
-    "zod": "3.25.76"
+    "zod": "4.1.11"
   },
   "scripts": {
     "check": "tsc --noEmit",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -251,9 +251,6 @@ importers:
       react-dom:
         specifier: 19.1.0
         version: 19.1.0(react@19.1.0)
-      zod:
-        specifier: 3.25.76
-        version: 3.25.76
     devDependencies:
       '@playwright/test':
         specifier: ^1.50.1
@@ -1082,9 +1079,6 @@ importers:
       react-dom:
         specifier: 19.1.0
         version: 19.1.0(react@19.1.0)
-      zod:
-        specifier: 3.25.76
-        version: 3.25.76
     devDependencies:
       '@biomejs/biome':
         specifier: catalog:default

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,7 +165,7 @@ importers:
         version: 1.2.3(@types/react@19.1.0)(react@19.1.0)
       better-auth:
         specifier: ^1.3.4
-        version: 1.3.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(zod@4.0.15)
+        version: 1.3.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(zod@4.1.11)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -2091,7 +2091,7 @@ importers:
         version: 2.12.0(@tiptap/pm@2.12.0)
       better-auth:
         specifier: ^1.3.2
-        version: 1.3.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(zod@3.25.76)
+        version: 1.3.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(zod@4.1.11)
       clsx:
         specifier: ^2.0.0
         version: 2.1.1
@@ -2168,8 +2168,8 @@ importers:
         specifier: ^1.5.0
         version: 1.5.0(react@19.1.0)
       zod:
-        specifier: 3.25.76
-        version: 3.25.76
+        specifier: 4.1.11
+        version: 4.1.11
     devDependencies:
       '@sveltejs/package':
         specifier: ^2.0.0
@@ -15815,8 +15815,8 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
-  zod@4.0.15:
-    resolution: {integrity: sha512-2IVHb9h4Mt6+UXkyMs0XbfICUh1eUrlJJAOupBHUhLRnKkruawyDddYRCs0Eizt900ntIMk9/4RksYl+FgSpcQ==}
+  zod@4.1.11:
+    resolution: {integrity: sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -24397,7 +24397,7 @@ snapshots:
 
   before-after-hook@2.2.3: {}
 
-  better-auth@1.3.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(zod@3.25.76):
+  better-auth@1.3.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(zod@4.1.11):
     dependencies:
       '@better-auth/utils': 0.2.6
       '@better-fetch/fetch': 1.1.18
@@ -24410,25 +24410,7 @@ snapshots:
       jose: 5.10.0
       kysely: 0.28.5
       nanostores: 0.11.4
-      zod: 3.25.76
-    optionalDependencies:
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-
-  better-auth@1.3.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(zod@4.0.15):
-    dependencies:
-      '@better-auth/utils': 0.2.6
-      '@better-fetch/fetch': 1.1.18
-      '@noble/ciphers': 0.6.0
-      '@noble/hashes': 1.8.0
-      '@simplewebauthn/browser': 13.1.2
-      '@simplewebauthn/server': 13.1.2
-      better-call: 1.0.13
-      defu: 6.1.4
-      jose: 5.10.0
-      kysely: 0.28.5
-      nanostores: 0.11.4
-      zod: 4.0.15
+      zod: 4.1.11
     optionalDependencies:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
@@ -32808,6 +32790,6 @@ snapshots:
 
   zod@3.25.76: {}
 
-  zod@4.0.15: {}
+  zod@4.1.11: {}
 
   zwitch@2.0.4: {}


### PR DESCRIPTION
# Description

We want to upgrade to Zod 4.1 to get support for [codecs](https://zod.dev/codecs), so that we can have arbitrary classes with custom encoders inside Jazz schemas: https://github.com/garden-co/jazz/pull/2954.

## Caveats

Starting from 3.25/4.0, Zod does not allow mixing up schemas from different versions. If a user tries to use a Zod schema from a version prior to 4.1 inside a Jazz schema, they'll get the following type error:
```
The types of '_zod.version.minor' are incompatible between these types.
      Type '0' is not assignable to type '1'.
```

## Manual testing instructions

Tested in a project using Zod 3.25 to confirm the aren't any issues with multiple Zod versions (as long as schemas from the user's Zod library aren't used in Jazz schemas).

## Tests

- [x] Tests have not been updated, because: we're updating a library version

## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [x] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Upgrade Zod to v4.1.11 in jazz-tools, align lockfile/peer deps, and remove Zod from example apps.
> 
> - **Dependencies**:
>   - Upgrade `zod` to `4.1.11` in `packages/jazz-tools` and update lockfile references.
>   - Align `better-auth` resolution to use `zod@4.1.11`.
>   - Remove `zod` dependency from `examples/chat` and `examples/multi-cursors`.
> - **Release**:
>   - Add changeset: `jazz-tools` patch (Upgrade Zod to 4.1).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7b0facc575a47c1a3c07d853b59867a8f0f4017e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->