### PR TITLE
fix: fix status page queries aggregation

### DIFF
--- a/homepage/homepage/app/(others)/status/page.tsx
+++ b/homepage/homepage/app/(others)/status/page.tsx
@@ -29,6 +29,7 @@ const PROBES = [
   "Spain",
   "UAE",
   "Zurich",
+  "Frankfurt",
 ] as const;
 
 interface DataRow {
@@ -72,7 +73,9 @@ const query = async () => {
             type: "prometheus",
             uid: "grafanacloud-prom",
           },
-          expr: `avg_over_time(probe_success{instance="https://mesh.jazz.tools/self-sync-check", job="self-sync-check", probe=~"${PROBES.join("|")}"}[$__range])`,
+          expr: `sum  by (probe) (sum_over_time(probe_success{instance="https://mesh.jazz.tools/self-sync-check", job="self-sync-check", probe=~"${PROBES.join("|")}"}[$__range]))
+          /
+          sum  by (probe) (count_over_time(probe_success{instance="https://mesh.jazz.tools/self-sync-check", job="self-sync-check", probe=~"${PROBES.join("|")}"}[$__range]))`,
           instant: true,
           range: false,
           refId: "up_ratio",
@@ -82,7 +85,7 @@ const query = async () => {
             type: "prometheus",
             uid: "grafanacloud-prom",
           },
-          expr: `sum_over_time(probe_success{instance="https://mesh.jazz.tools/self-sync-check", job="self-sync-check", probe=~"${PROBES.join("|")}"}[$__interval])`,
+          expr: `sum by (probe) (sum_over_time(probe_success{instance="https://mesh.jazz.tools/self-sync-check", job="self-sync-check", probe=~"${PROBES.join("|")}"}[$__interval]))`,
           instant: false,
           range: true,
           interval: intervalMin + "m",
@@ -93,7 +96,7 @@ const query = async () => {
             type: "prometheus",
             uid: "grafanacloud-prom",
           },
-          expr: `count_over_time(probe_success{instance="https://mesh.jazz.tools/self-sync-check", job="self-sync-check", probe=~"${PROBES.join("|")}"}[$__interval])`,
+          expr: `sum by (probe) (count_over_time(probe_success{instance="https://mesh.jazz.tools/self-sync-check", job="self-sync-check", probe=~"${PROBES.join("|")}"}[$__interval]))`,
           instant: false,
           range: true,
           interval: intervalMin + "m",
@@ -104,7 +107,7 @@ const query = async () => {
             type: "prometheus",
             uid: "grafanacloud-prom",
           },
-          expr: `1000 * sum(avg_over_time(probe_duration_seconds{instance="https://mesh.jazz.tools/self-sync-check", job="self-sync-check", probe=~"${PROBES.join("|")}"}[$__interval])) by (probe) / 2`,
+          expr: `1000 * sum by (probe) (avg_over_time(probe_duration_seconds{instance="https://mesh.jazz.tools/self-sync-check", job="self-sync-check", probe=~"${PROBES.join("|")}"}[$__interval])) / 2`,
           instant: false,
           range: true,
           interval: intervalMin + "m",
@@ -190,6 +193,7 @@ const query = async () => {
       case "Spain":
       case "Zurich":
       case "UAE":
+      case "Frankfurt":
         return { ...acc, EMEA: { ...acc["EMEA"], [label]: row } };
       case "North Virginia":
       case "North California":

--- a/homepage/homepage/components/LatencyChart.tsx
+++ b/homepage/homepage/components/LatencyChart.tsx
@@ -67,8 +67,8 @@ export default function LatencyChart({ latencyOverTime, upOverTime, upCountOverT
         </HoverCard.Trigger>
         <HoverCard.Content className="border border-stone-500 bg-white dark:bg-black shadow-lg absolute w-[150px] -ml-[75px] l-[50%] rounded-md p-2">
           <HoverCard.Arrow className="fill-stone-500" />
-          <p>
-            <span className="font-semibold">No data</span>
+          <p className="text-sm text-center">
+            No data
           </p>
         </HoverCard.Content>
       </HoverCard.Root>


### PR DESCRIPTION
Fixes status page queries aggregation, as a recent change has changed a label value (`config_version`) which caused the up ratio to be miscalculated.

now live:

<img width="853" height="664" alt="image" src="https://github.com/user-attachments/assets/3f9f7860-6e48-468d-8b8a-f044700d6107" />


after:

<img width="1362" height="711" alt="image" src="https://github.com/user-attachments/assets/afa8eb70-adea-4b33-94f5-4f704728d2e9" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fix Prometheus queries to aggregate uptime/latency per probe correctly, add `Frankfurt` to probes/EMEA, and tweak latency chart hover and last-bar coloring.
> 
> - **Status page data (`app/(others)/status/page.tsx`)**:
>   - **Prometheus aggregation fixes**:
>     - Compute uptime ratio as `sum_over_time(...) / count_over_time(...)` grouped `by (probe)`.
>     - Aggregate `sum_over_time` and `count_over_time` with `sum by (probe) (...)`.
>     - Aggregate latency over time with `sum by (probe) (avg_over_time(...))`.
>   - **Probes/regions**:
>     - Add `"Frankfurt"` to `PROBES` and map it under `EMEA`.
> - **UI (`components/LatencyChart.tsx`)**:
>   - Override last bar color to red when current status is down.
>   - Simplify “No data” hover text styling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0c21446dbd28a7922ec399eb19cd089cdaf07a14. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->