### PR TITLE
Hotfix for homepage

### DIFF
--- a/homepage/design-system/src/components/atoms/Button.tsx
+++ b/homepage/design-system/src/components/atoms/Button.tsx
@@ -81,7 +81,6 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
 
     const classNames = clsx(
       "inline-flex items-center justify-center gap-2 rounded-lg text-center transition-colors w-fit text-nowrap",
-      "after:absolute after:inset-[-6px] after:content-[''] after:pointer-events-none",
       getClasses({ variant }),
       "disabled:pointer-events-none disabled:opacity-70",
       disabled && "opacity-50 cursor-not-allowed pointer-events-none",


### PR DESCRIPTION
# Description
The added styling was causing overflow on basically every parent which contained a button.

## Manual testing instructions
Check and see there's no overflow any more

Before:
<img width="1667" height="2332" alt="image" src="https://github.com/user-attachments/assets/2dba2aa2-58b2-4cb8-9652-a0afa8e3f97c" />

After:
<img width="1661" height="5281" alt="image" src="https://github.com/user-attachments/assets/e462e681-fe55-4afc-8e71-9c640863bba3" />

## Tests

- [ ] Tests have been added and/or updated
- [x] Tests have not been updated, because: N/A
- [ ] I need help with writing tests


## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [ ] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing