### PR TITLE
Selectors also work on React Native (with or without Expo)

### DIFF
--- a/homepage/homepage/content/docs/using-covalues/subscription-and-loading.mdx
+++ b/homepage/homepage/content/docs/using-covalues/subscription-and-loading.mdx
@@ -522,9 +522,8 @@ unsubscribe();
 ```
 </CodeGroup>
 
-<ContentByFramework framework="react">
-## Selectors
-
+<ContentByFramework framework={["react", "react-native", "react-native-expo"]}>
+## Selectors [!framework=react,react-native,react-native-expo]
 Sometimes, you only need to react to changes in specific parts of a CoValue. In those cases, you can use the `useCoStateWithSelector` hook to specify what data you are interested in.
 
 When you use `useCoStateWithSelector` , in addition to `resolve` you can also add a `select` and optionally an `equalityFn` option. 


### PR DESCRIPTION
# Description
Quick update to Subscriptions & Deep Loading docs page to show that selectors are available in RN too.

## Manual testing instructions
N/A

## Tests

- [ ] Tests have been added and/or updated
- [x] Tests have not been updated, because: N/A
- [ ] I need help with writing tests


## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [ ] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing