### PR TITLE
fix: reveal child groups' writeOnly keys to parent groups

### DIFF
--- a/.changeset/spicy-chefs-retire.md
+++ b/.changeset/spicy-chefs-retire.md
@@ -1,0 +1,5 @@
+---
+"cojson": patch
+---
+
+fix: reveal child groups' writeOnly keys to parent groups

--- a/homepage/homepage/content/docs/groups/inheritance.mdx
+++ b/homepage/homepage/content/docs/groups/inheritance.mdx
@@ -90,26 +90,6 @@ containingGroup.addMember(addedGroup);
 ```
 </CodeGroup>
 
-To add a group to another group:
-
-1. The current account must be an admin in the containing group
-2. The current account must be a member of the added group
-
-<CodeGroup>
-```ts twoslash
-import { co, Group } from "jazz-tools";
-const group = Group.create();
-const Company = co.map({});
-const company = Company.create({ owner: group });
-// ---cut---
-const companyGroup = company.$jazz.owner;
-const teamGroup = Group.create();
-
-// Works only if I'm a member of `companyGroup`
-teamGroup.addMember(companyGroup);
-```
-</CodeGroup>
-
 ### Overriding the added group's roles
 
 In some cases you might want to inherit all members from an added group but override their roles to the same specific role in the containing group. You can do so by passing an "override role" as a second argument to `addMember`:

--- a/packages/cojson/src/coValues/group.ts
+++ b/packages/cojson/src/coValues/group.ts
@@ -880,16 +880,11 @@ export class RawGroup<
         continue;
       }
 
-      this.set(
-        `${newReadKey.id}_for_${parentReadKeyID}`,
-        this.crypto.encryptKeySecret({
-          encrypting: {
-            id: parentReadKeyID,
-            secret: parentReadKeySecret,
-          },
-          toEncrypt: newReadKey,
-        }).encrypted,
-        "trusting",
+      this.storeKeyRevelationForParentGroup(
+        parentReadKeyID,
+        parentReadKeySecret,
+        newReadKey.id,
+        newReadKey.secret,
       );
     }
 

--- a/packages/cojson/src/coValues/group.ts
+++ b/packages/cojson/src/coValues/group.ts
@@ -24,7 +24,12 @@ import {
 } from "../ids.js";
 import { JsonObject } from "../jsonValue.js";
 import { logger } from "../logger.js";
-import { AccountRole, Role, isKeyForKeyField } from "../permissions.js";
+import {
+  AccountRole,
+  Role,
+  isAccountRole,
+  isKeyForKeyField,
+} from "../permissions.js";
 import { accountOrAgentIDfromSessionID } from "../typeUtils/accountOrAgentIDfromSessionID.js";
 import { expectGroup } from "../typeUtils/expectGroup.js";
 import { isAccountID } from "../typeUtils/isAccountID.js";
@@ -932,12 +937,7 @@ export class RawGroup<
     parent.set(`child_${this.id}`, "extend", "trusting");
     this.set(`parent_${parent.id}`, value, "trusting");
 
-    if (
-      parent.myRole() !== "admin" &&
-      parent.myRole() !== "writer" &&
-      parent.myRole() !== "reader" &&
-      parent.myRole() !== "writeOnly"
-    ) {
+    if (!isAccountRole(parent.myRole())) {
       // Create a writeOnly key in the parent group to be able to reveal the current child key to the parent group
       parent.internalCreateWriteOnlyKeyForMember(
         this.core.node.getCurrentAgent().id,
@@ -981,12 +981,7 @@ export class RawGroup<
       );
     }
 
-    if (
-      parent.myRole() !== "admin" &&
-      parent.myRole() !== "writer" &&
-      parent.myRole() !== "reader" &&
-      parent.myRole() !== "writeOnly"
-    ) {
+    if (!isAccountRole(parent.myRole())) {
       throw new Error(
         "To unextend a group, the current account must be a member of the parent group",
       );

--- a/packages/cojson/src/coValues/group.ts
+++ b/packages/cojson/src/coValues/group.ts
@@ -450,7 +450,7 @@ export class RawGroup<
       writeKeyForNewMember.secret,
     );
 
-    // Reveal the write key to Account members
+    // Reveal the new writeOnly key to Account members
     for (const otherMemberKey of this.getMemberKeys()) {
       const memberRole = this.get(otherMemberKey);
 

--- a/packages/cojson/src/coValues/group.ts
+++ b/packages/cojson/src/coValues/group.ts
@@ -484,9 +484,7 @@ export class RawGroup<
         parentGroup,
         writeKeyForNewMember.id,
         writeKeyForNewMember.secret,
-        {
-          revealAllWriteOnlyKeys: false,
-        },
+        { revealAllWriteOnlyKeys: false },
       );
     }
 
@@ -849,6 +847,15 @@ export class RawGroup<
           writeOnlyKey.secret,
         );
       }
+
+      for (const parentGroup of this.getParentGroups()) {
+        this.revealReadKeyToParentGroup(
+          parentGroup,
+          writeOnlyKey.id,
+          writeOnlyKey.secret,
+          { revealAllWriteOnlyKeys: false },
+        );
+      }
     }
 
     this.set(
@@ -980,9 +987,7 @@ export class RawGroup<
       parent,
       childReadKeyID,
       childReadKeySecret,
-      {
-        revealAllWriteOnlyKeys: true,
-      },
+      { revealAllWriteOnlyKeys: true },
     );
   }
 

--- a/packages/cojson/src/permissions.ts
+++ b/packages/cojson/src/permissions.ts
@@ -57,6 +57,15 @@ export type Role =
   | "readerInvite"
   | "writeOnlyInvite";
 
+export function isAccountRole(role?: Role): role is AccountRole {
+  return (
+    role === "admin" ||
+    role === "writer" ||
+    role === "reader" ||
+    role === "writeOnly"
+  );
+}
+
 type ValidTransactionsResult = { txID: TransactionID; tx: Transaction };
 type MemberState = { [agent: RawAccountID | AgentID]: Role; [EVERYONE]?: Role };
 

--- a/packages/cojson/src/tests/testUtils.ts
+++ b/packages/cojson/src/tests/testUtils.ts
@@ -108,9 +108,6 @@ export async function createNConnectedNodes(...nodeRoles: Peer["role"][]) {
   );
   for (let i = 0; i < nodes.length; i++) {
     for (let j = i + 1; j < nodes.length; j++) {
-      if (i === j) {
-        continue;
-      }
       connectTwoPeers(
         nodes[i]!.node,
         nodes[j]!.node,

--- a/packages/cojson/src/tests/testUtils.ts
+++ b/packages/cojson/src/tests/testUtils.ts
@@ -70,33 +70,11 @@ export async function createTwoConnectedNodes(
   node1Role: Peer["role"],
   node2Role: Peer["role"],
 ) {
-  // Connect nodes initially
-  const [node1ToNode2Peer, node2ToNode1Peer] = connectedPeers(
-    "node1ToNode2",
-    "node2ToNode1",
-    {
-      peer1role: node2Role,
-      peer2role: node1Role,
-    },
-  );
-
-  const node1 = await LocalNode.withNewlyCreatedAccount({
-    peersToLoadFrom: [node1ToNode2Peer],
-    crypto: Crypto,
-    creationProps: { name: "Client" },
-  });
-
-  const node2 = await LocalNode.withNewlyCreatedAccount({
-    peersToLoadFrom: [node2ToNode1Peer],
-    crypto: Crypto,
-    creationProps: { name: "Server" },
-  });
+  const [node1, node2] = await createNConnectedNodes(node1Role, node2Role);
 
   return {
-    node1,
-    node2,
-    node1ToNode2Peer,
-    node2ToNode1Peer,
+    node1: node1!,
+    node2: node2!,
   };
 }
 
@@ -105,62 +83,43 @@ export async function createThreeConnectedNodes(
   node2Role: Peer["role"],
   node3Role: Peer["role"],
 ) {
-  const [node1ToNode2Peer, node2ToNode1Peer] = connectedPeers(
-    "node1ToNode2",
-    "node2ToNode1",
-    {
-      peer1role: node2Role,
-      peer2role: node1Role,
-    },
+  const [node1, node2, node3] = await createNConnectedNodes(
+    node1Role,
+    node2Role,
+    node3Role,
   );
-
-  const [node1ToNode3Peer, node3ToNode1Peer] = connectedPeers(
-    "node1ToNode3",
-    "node3ToNode1",
-    {
-      peer1role: node3Role,
-      peer2role: node1Role,
-    },
-  );
-
-  const [node2ToNode3Peer, node3ToNode2Peer] = connectedPeers(
-    "node2ToNode3",
-    "node3ToNode2",
-    {
-      peer1role: node3Role,
-      peer2role: node2Role,
-    },
-  );
-
-  const node1 = await LocalNode.withNewlyCreatedAccount({
-    peersToLoadFrom: [node1ToNode2Peer, node1ToNode3Peer],
-    crypto: Crypto,
-    creationProps: { name: "Node 1" },
-  });
-
-  const node2 = await LocalNode.withNewlyCreatedAccount({
-    peersToLoadFrom: [node2ToNode1Peer, node2ToNode3Peer],
-    crypto: Crypto,
-    creationProps: { name: "Node 2" },
-  });
-
-  const node3 = await LocalNode.withNewlyCreatedAccount({
-    peersToLoadFrom: [node3ToNode1Peer, node3ToNode2Peer],
-    crypto: Crypto,
-    creationProps: { name: "Node 3" },
-  });
 
   return {
-    node1,
-    node2,
-    node3,
-    node1ToNode2Peer,
-    node2ToNode1Peer,
-    node1ToNode3Peer,
-    node3ToNode1Peer,
-    node2ToNode3Peer,
-    node3ToNode2Peer,
+    node1: node1!,
+    node2: node2!,
+    node3: node3!,
   };
+}
+
+export async function createNConnectedNodes(...nodeRoles: Peer["role"][]) {
+  const nodes = await Promise.all(
+    Array.from({ length: nodeRoles.length }, async (_, i) => {
+      return LocalNode.withNewlyCreatedAccount({
+        peersToLoadFrom: [],
+        crypto: Crypto,
+        creationProps: { name: `Node ${i + 1}` },
+      });
+    }),
+  );
+  for (let i = 0; i < nodes.length; i++) {
+    for (let j = i + 1; j < nodes.length; j++) {
+      if (i === j) {
+        continue;
+      }
+      connectTwoPeers(
+        nodes[i]!.node,
+        nodes[j]!.node,
+        nodeRoles[i]!,
+        nodeRoles[j]!,
+      );
+    }
+  }
+  return nodes;
 }
 
 export function connectTwoPeers(


### PR DESCRIPTION
# Description

When adding a `writeOnly` key to a group that had another group as a member, the `writeOnly` key was not being revealed to the parent group, which meant members of the parent group were not able to read writes performed by members with `writeOnly` permission.

Since https://github.com/garden-co/jazz/pull/2290 made it possible to extend a group without having permissions over it by reusing `writeOnly` keys, this bug also affected active accounts extending a group they don't have permissions over. In this case, members of _grandparent_ groups could not see the changes made in the child groups.

This PR:
- reveals new `writeOnly` keys to parent groups when adding a new member with `writeOnly` permission
- reveals ALL existing `writeOnly` keys in a child group when adding a new parent group as a member
- reveals ALL new `writeOnly` keys in a child group to parent groups when rotating keys

## Manual testing instructions

I tested the repro script provided by @tobiaslins and confirmed that now all accounts have access to the CoValues owned by the client group.

## Tests

- [x] Tests have been added and/or updated

## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [x] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing