### PR TITLE
chore: rename peersToLoadFrom into peers

### DIFF
--- a/.changeset/fruity-zoos-teach.md
+++ b/.changeset/fruity-zoos-teach.md
@@ -1,0 +1,6 @@
+---
+"jazz-tools": patch
+"cojson": patch
+---
+
+"peersToLoadFrom" renamed to only "peers"

--- a/examples/inspector/src/viewer/new-app.tsx
+++ b/examples/inspector/src/viewer/new-app.tsx
@@ -87,7 +87,7 @@ export default function CoJsonViewerApp() {
           accountID: currentAccount.id,
           accountSecret: currentAccount.secret,
           sessionID: crypto.newRandomSessionID(currentAccount.id),
-          peersToLoadFrom: [wsPeer],
+          peers: [wsPeer],
           crypto,
           migration: async () => {
             console.log("Not running any migration in inspector");

--- a/examples/inspector/tests/lib/utils.ts
+++ b/examples/inspector/tests/lib/utils.ts
@@ -20,7 +20,7 @@ export async function createAccount() {
     crypto: await WasmCrypto.create(),
     sessionProvider: randomSessionProvider,
     authSecretStorage: new AuthSecretStorage(),
-    peersToLoadFrom: [
+    peers: [
       createWebSocketPeer({
         id: "upstream",
         role: "server",

--- a/packages/cojson-storage-indexeddb/src/tests/storage.indexeddb.test.ts
+++ b/packages/cojson-storage-indexeddb/src/tests/storage.indexeddb.test.ts
@@ -576,7 +576,7 @@ test("should sync and load accounts from storage", async () => {
     crypto: Crypto,
     accountSecret: agentSecret,
     accountID,
-    peersToLoadFrom: [],
+    peers: [],
     storage: await getIndexedDBStorage(),
     sessionID: Crypto.newRandomSessionID(Crypto.getAgentID(agentSecret)),
   });

--- a/packages/cojson/src/localNode.ts
+++ b/packages/cojson/src/localNode.ts
@@ -178,13 +178,13 @@ export class LocalNode {
   static internalCreateAccount(opts: {
     crypto: CryptoProvider;
     initialAgentSecret?: AgentSecret;
-    peersToLoadFrom?: Peer[];
+    peers?: Peer[];
     storage?: StorageAPI;
   }): RawAccount {
     const {
       crypto,
       initialAgentSecret = crypto.newRandomAgentSecret(),
-      peersToLoadFrom = [],
+      peers = [],
     } = opts;
     const accountHeader = accountHeaderForInitialAgentSecret(
       initialAgentSecret,
@@ -202,7 +202,7 @@ export class LocalNode {
       node.setStorage(opts.storage);
     }
 
-    for (const peer of peersToLoadFrom) {
+    for (const peer of peers) {
       node.syncManager.addPeer(peer);
     }
 
@@ -236,14 +236,14 @@ export class LocalNode {
   /** @category 2. Node Creation */
   static async withNewlyCreatedAccount({
     creationProps,
-    peersToLoadFrom,
+    peers,
     migration,
     crypto,
     initialAgentSecret = crypto.newRandomAgentSecret(),
     storage,
   }: {
     creationProps: { name: string };
-    peersToLoadFrom?: Peer[];
+    peers?: Peer[];
     migration?: RawAccountMigration<AccountMeta>;
     crypto: CryptoProvider;
     initialAgentSecret?: AgentSecret;
@@ -257,7 +257,7 @@ export class LocalNode {
     const account = LocalNode.internalCreateAccount({
       crypto,
       initialAgentSecret,
-      peersToLoadFrom,
+      peers,
       storage,
     });
     const node = account.core.node;
@@ -299,7 +299,7 @@ export class LocalNode {
     accountID,
     accountSecret,
     sessionID,
-    peersToLoadFrom,
+    peers,
     crypto,
     migration,
     storage,
@@ -307,7 +307,7 @@ export class LocalNode {
     accountID: RawAccountID;
     accountSecret: AgentSecret;
     sessionID: SessionID | undefined;
-    peersToLoadFrom: Peer[];
+    peers: Peer[];
     crypto: CryptoProvider;
     migration?: RawAccountMigration<AccountMeta>;
     storage?: StorageAPI;
@@ -323,7 +323,7 @@ export class LocalNode {
         node.setStorage(storage);
       }
 
-      for (const peer of peersToLoadFrom) {
+      for (const peer of peers) {
         node.syncManager.addPeer(peer);
       }
 

--- a/packages/cojson/src/tests/account.test.ts
+++ b/packages/cojson/src/tests/account.test.ts
@@ -64,7 +64,7 @@ test("Can create account with one node, and then load it on another", async () =
     accountID,
     accountSecret,
     sessionID: Crypto.newRandomSessionID(accountID),
-    peersToLoadFrom: [node1asPeer],
+    peers: [node1asPeer],
     crypto: Crypto,
   });
 
@@ -104,7 +104,7 @@ test("Should migrate the root from private to trusting", async () => {
     accountID,
     accountSecret,
     sessionID: Crypto.newRandomSessionID(accountID),
-    peersToLoadFrom: [peers1[0]],
+    peers: [peers1[0]],
     crypto: Crypto,
   });
 
@@ -126,7 +126,7 @@ test("Should migrate the root from private to trusting", async () => {
     accountID,
     accountSecret,
     sessionID: Crypto.newRandomSessionID(accountID),
-    peersToLoadFrom: [peers2[0]],
+    peers: [peers2[0]],
     crypto: Crypto,
   });
 

--- a/packages/cojson/src/tests/sync.auth.test.ts
+++ b/packages/cojson/src/tests/sync.auth.test.ts
@@ -30,7 +30,7 @@ describe("LocalNode auth sync", () => {
       creationProps: {
         name: "new-account",
       },
-      peersToLoadFrom: [peer],
+      peers: [peer],
       crypto: Crypto,
     });
 
@@ -74,7 +74,7 @@ describe("LocalNode auth sync", () => {
       creationProps: {
         name: "new-account",
       },
-      peersToLoadFrom: [peer],
+      peers: [peer],
       crypto: Crypto,
       async migration(account) {
         const root = account.createMap();
@@ -143,7 +143,7 @@ describe("LocalNode auth sync", () => {
         creationProps: {
           name: "new-account",
         },
-        peersToLoadFrom: [newAccountPeer],
+        peers: [newAccountPeer],
         crypto: Crypto,
       });
 
@@ -155,7 +155,7 @@ describe("LocalNode auth sync", () => {
     const node = await LocalNode.withLoadedAccount({
       accountID,
       accountSecret,
-      peersToLoadFrom: [existingAccountPeer],
+      peers: [existingAccountPeer],
       sessionID: undefined,
       crypto: Crypto,
     });
@@ -210,7 +210,7 @@ describe("LocalNode auth sync", () => {
       creationProps: {
         name: "new-account",
       },
-      peersToLoadFrom: [newAccountPeer],
+      peers: [newAccountPeer],
       crypto: Crypto,
     });
 
@@ -225,7 +225,7 @@ describe("LocalNode auth sync", () => {
     const node = await LocalNode.withLoadedAccount({
       accountID,
       accountSecret,
-      peersToLoadFrom: [existingAccountPeer],
+      peers: [existingAccountPeer],
       sessionID: undefined,
       crypto: Crypto,
     });

--- a/packages/cojson/src/tests/testUtils.ts
+++ b/packages/cojson/src/tests/testUtils.ts
@@ -100,7 +100,7 @@ export async function createNConnectedNodes(...nodeRoles: Peer["role"][]) {
   const nodes = await Promise.all(
     Array.from({ length: nodeRoles.length }, async (_, i) => {
       return LocalNode.withNewlyCreatedAccount({
-        peersToLoadFrom: [],
+        peers: [],
         crypto: Crypto,
         creationProps: { name: `Node ${i + 1}` },
       });
@@ -551,7 +551,7 @@ export async function setupTestAccount(
   } = {},
 ) {
   const ctx = await LocalNode.withNewlyCreatedAccount({
-    peersToLoadFrom: [],
+    peers: [],
     crypto: Crypto,
     creationProps: { name: "Client" },
     storage: opts.storage,

--- a/packages/jazz-run/src/createWorkerAccount.ts
+++ b/packages/jazz-run/src/createWorkerAccount.ts
@@ -20,7 +20,7 @@ export const createWorkerAccount = async ({
 
   const account = await Account.create({
     creationProps: { name },
-    peersToLoadFrom: [peer],
+    peers: [peer],
     crypto,
   });
 

--- a/packages/jazz-run/src/tests/createWorkerAccount.test.ts
+++ b/packages/jazz-run/src/tests/createWorkerAccount.test.ts
@@ -44,7 +44,7 @@ describe("createWorkerAccount - integration tests", () => {
     const crypto = await WasmCrypto.create();
     const { node } = await LocalNode.withNewlyCreatedAccount({
       creationProps: { name: "test" },
-      peersToLoadFrom: [peer],
+      peers: [peer],
       crypto,
     });
 
@@ -69,7 +69,7 @@ describe("createWorkerAccount - integration tests", () => {
     const crypto = await WasmCrypto.create();
     const { node } = await LocalNode.withNewlyCreatedAccount({
       creationProps: { name: "test" },
-      peersToLoadFrom: [peer],
+      peers: [peer],
       crypto,
     });
 

--- a/packages/jazz-tools/src/better-auth/database-adapter/tests/sync-utils.ts
+++ b/packages/jazz-tools/src/better-auth/database-adapter/tests/sync-utils.ts
@@ -110,7 +110,7 @@ export const createWorkerAccount = async ({
 
   const account = await Account.create({
     creationProps: { name },
-    peersToLoadFrom: [peer],
+    peers: [peer],
     crypto,
   });
 

--- a/packages/jazz-tools/src/browser/createBrowserContext.ts
+++ b/packages/jazz-tools/src/browser/createBrowserContext.ts
@@ -53,7 +53,7 @@ async function setupPeers(options: BaseBrowserContextOptions) {
 
   const { useIndexedDB } = getStorageOptions(options.storage);
 
-  const peersToLoadFrom: Peer[] = [];
+  const peers: Peer[] = [];
 
   const storage = useIndexedDB ? await getIndexedDBStorage() : undefined;
 
@@ -62,7 +62,7 @@ async function setupPeers(options: BaseBrowserContextOptions) {
       addConnectionListener: () => () => {},
       connected: () => false,
       toggleNetwork: () => {},
-      peersToLoadFrom,
+      peers,
       storage,
       setNode: () => {},
       crypto,
@@ -76,11 +76,11 @@ async function setupPeers(options: BaseBrowserContextOptions) {
       if (node) {
         node.syncManager.addPeer(peer);
       } else {
-        peersToLoadFrom.push(peer);
+        peers.push(peer);
       }
     },
     removePeer: (peer) => {
-      peersToLoadFrom.splice(peersToLoadFrom.indexOf(peer), 1);
+      peers.splice(peers.indexOf(peer), 1);
     },
   });
 
@@ -112,7 +112,7 @@ async function setupPeers(options: BaseBrowserContextOptions) {
     connected() {
       return wsPeer.connected;
     },
-    peersToLoadFrom,
+    peers,
     storage,
     setNode,
     crypto,
@@ -124,7 +124,7 @@ export async function createJazzBrowserGuestContext(
 ) {
   const {
     toggleNetwork,
-    peersToLoadFrom,
+    peers,
     setNode,
     crypto,
     storage,
@@ -134,7 +134,7 @@ export async function createJazzBrowserGuestContext(
 
   const context = await createAnonymousJazzContext({
     crypto,
-    peersToLoadFrom,
+    peers,
     storage,
   });
 
@@ -176,7 +176,7 @@ export async function createJazzBrowserContext<
 >(options: BrowserContextOptions<S>) {
   const {
     toggleNetwork,
-    peersToLoadFrom,
+    peers,
     setNode,
     crypto,
     storage,
@@ -205,7 +205,7 @@ export async function createJazzBrowserContext<
   const context = await createJazzContext({
     credentials: options.credentials,
     newAccountProps: options.newAccountProps,
-    peersToLoadFrom,
+    peers,
     storage,
     crypto,
     defaultProfileName: options.defaultProfileName,

--- a/packages/jazz-tools/src/browser/tests/utils.ts
+++ b/packages/jazz-tools/src/browser/tests/utils.ts
@@ -16,7 +16,7 @@ export async function setupTwoNodes() {
   );
 
   const client = await LocalNode.withNewlyCreatedAccount({
-    peersToLoadFrom: [serverAsPeer],
+    peers: [serverAsPeer],
     crypto,
     creationProps: { name: "Client" },
     migration: async (rawAccount, _node, creationProps) => {
@@ -29,7 +29,7 @@ export async function setupTwoNodes() {
   });
 
   const server = await LocalNode.withNewlyCreatedAccount({
-    peersToLoadFrom: [clientAsPeer],
+    peers: [clientAsPeer],
     crypto,
     creationProps: { name: "Server" },
     migration: async (rawAccount, _node, creationProps) => {

--- a/packages/jazz-tools/src/react-native-core/platform.ts
+++ b/packages/jazz-tools/src/react-native-core/platform.ts
@@ -46,7 +46,7 @@ async function setupPeers(options: BaseReactNativeContextOptions) {
   const crypto = await CryptoProvider.create();
   let node: LocalNode | undefined = undefined;
 
-  const peersToLoadFrom: Peer[] = [];
+  const peers: Peer[] = [];
 
   const storage =
     options.storage && options.storage !== "disabled"
@@ -58,7 +58,7 @@ async function setupPeers(options: BaseReactNativeContextOptions) {
       toggleNetwork: () => {},
       addConnectionListener: () => () => {},
       connected: () => false,
-      peersToLoadFrom,
+      peers,
       setNode: () => {},
       crypto,
       storage,
@@ -72,11 +72,11 @@ async function setupPeers(options: BaseReactNativeContextOptions) {
       if (node) {
         node.syncManager.addPeer(peer);
       } else {
-        peersToLoadFrom.push(peer);
+        peers.push(peer);
       }
     },
     removePeer: (peer) => {
-      peersToLoadFrom.splice(peersToLoadFrom.indexOf(peer), 1);
+      peers.splice(peers.indexOf(peer), 1);
     },
   });
 
@@ -106,7 +106,7 @@ async function setupPeers(options: BaseReactNativeContextOptions) {
       };
     },
     connected: () => wsPeer.connected,
-    peersToLoadFrom,
+    peers,
     setNode,
     crypto,
     storage,
@@ -118,7 +118,7 @@ export async function createJazzReactNativeGuestContext(
 ) {
   const {
     toggleNetwork,
-    peersToLoadFrom,
+    peers,
     setNode,
     crypto,
     storage,
@@ -128,7 +128,7 @@ export async function createJazzReactNativeGuestContext(
 
   const context = createAnonymousJazzContext({
     crypto,
-    peersToLoadFrom,
+    peers,
     storage,
   });
 
@@ -170,7 +170,7 @@ export async function createJazzReactNativeContext<
 >(options: ReactNativeContextOptions<S>) {
   const {
     toggleNetwork,
-    peersToLoadFrom,
+    peers,
     setNode,
     crypto,
     storage,
@@ -202,7 +202,7 @@ export async function createJazzReactNativeContext<
   const context = await createJazzContext({
     credentials: options.credentials,
     newAccountProps: options.newAccountProps,
-    peersToLoadFrom,
+    peers,
     crypto,
     defaultProfileName: options.defaultProfileName,
     AccountSchema: options.AccountSchema,

--- a/packages/jazz-tools/src/tools/coValues/account.ts
+++ b/packages/jazz-tools/src/tools/coValues/account.ts
@@ -212,7 +212,7 @@ export class Account extends CoValueBase implements CoValue {
     options: {
       creationProps: { name: string };
       initialAgentSecret?: AgentSecret;
-      peersToLoadFrom?: Peer[];
+      peers?: Peer[];
       crypto: CryptoProvider;
     },
   ): Promise<A> {
@@ -256,7 +256,7 @@ export class Account extends CoValueBase implements CoValue {
     const account = await this.create<A>({
       creationProps: options.creationProps,
       crypto: as.$jazz.localNode.crypto,
-      peersToLoadFrom: [connectedPeers[0]],
+      peers: [connectedPeers[0]],
     });
 
     await account.$jazz.waitForAllCoValuesSync();

--- a/packages/jazz-tools/src/tools/implementation/ContextManager.ts
+++ b/packages/jazz-tools/src/tools/implementation/ContextManager.ts
@@ -45,7 +45,7 @@ type PlatformSpecificContext<Acc extends Account> =
 
 function getAnonymousFallback() {
   const context = createAnonymousJazzContext({
-    peersToLoadFrom: [],
+    peers: [],
     crypto: new PureJSCrypto(),
   });
 

--- a/packages/jazz-tools/src/tools/implementation/createContext.ts
+++ b/packages/jazz-tools/src/tools/implementation/createContext.ts
@@ -90,7 +90,7 @@ export async function createJazzContextFromExistingCredentials<
     | CoreAccountSchema,
 >({
   credentials,
-  peersToLoadFrom,
+  peers,
   crypto,
   storage,
   AccountSchema: PropsAccountSchema,
@@ -99,7 +99,7 @@ export async function createJazzContextFromExistingCredentials<
   asActiveAccount,
 }: {
   credentials: Credentials;
-  peersToLoadFrom: Peer[];
+  peers: Peer[];
   crypto: CryptoProvider;
   AccountSchema?: S;
   sessionProvider: SessionProvider;
@@ -122,7 +122,7 @@ export async function createJazzContextFromExistingCredentials<
     accountID: credentials.accountID as unknown as CoID<RawAccount>,
     accountSecret: credentials.secret,
     sessionID: sessionID,
-    peersToLoadFrom: peersToLoadFrom,
+    peers: peers,
     crypto: crypto,
     storage,
     migration: async (rawAccount, _node, creationProps) => {
@@ -162,7 +162,7 @@ export async function createJazzContextForNewAccount<
 >({
   creationProps,
   initialAgentSecret,
-  peersToLoadFrom,
+  peers,
   crypto,
   AccountSchema: PropsAccountSchema,
   onLogOut,
@@ -170,7 +170,7 @@ export async function createJazzContextForNewAccount<
 }: {
   creationProps: { name: string };
   initialAgentSecret?: AgentSecret;
-  peersToLoadFrom: Peer[];
+  peers: Peer[];
   crypto: CryptoProvider;
   AccountSchema?: S;
   onLogOut?: () => Promise<void>;
@@ -184,7 +184,7 @@ export async function createJazzContextForNewAccount<
 
   const { node } = await LocalNode.withNewlyCreatedAccount({
     creationProps,
-    peersToLoadFrom,
+    peers,
     crypto,
     initialAgentSecret,
     storage,
@@ -219,7 +219,7 @@ export async function createJazzContext<
 >(options: {
   credentials?: AuthCredentials;
   newAccountProps?: NewAccountProps;
-  peersToLoadFrom: Peer[];
+  peers: Peer[];
   crypto: CryptoProvider;
   defaultProfileName?: string;
   AccountSchema?: S;
@@ -243,7 +243,7 @@ export async function createJazzContext<
         accountID: credentials.accountID,
         secret: credentials.accountSecret,
       },
-      peersToLoadFrom: options.peersToLoadFrom,
+      peers: options.peers,
       crypto,
       AccountSchema: options.AccountSchema,
       sessionProvider: options.sessionProvider,
@@ -267,7 +267,7 @@ export async function createJazzContext<
     context = await createJazzContextForNewAccount({
       creationProps,
       initialAgentSecret,
-      peersToLoadFrom: options.peersToLoadFrom,
+      peers: options.peers,
       crypto,
       AccountSchema: options.AccountSchema,
       onLogOut: async () => {
@@ -293,11 +293,11 @@ export async function createJazzContext<
 }
 
 export function createAnonymousJazzContext({
-  peersToLoadFrom,
+  peers,
   crypto,
   storage,
 }: {
-  peersToLoadFrom: Peer[];
+  peers: Peer[];
   crypto: CryptoProvider;
   storage?: StorageAPI;
 }): JazzContextWithAgent {
@@ -309,7 +309,7 @@ export function createAnonymousJazzContext({
     crypto,
   );
 
-  for (const peer of peersToLoadFrom) {
+  for (const peer of peers) {
     node.syncManager.addPeer(peer);
   }
 

--- a/packages/jazz-tools/src/tools/ssr/ssr.ts
+++ b/packages/jazz-tools/src/tools/ssr/ssr.ts
@@ -5,7 +5,7 @@ import { createAnonymousJazzContext } from "jazz-tools";
 export function createSSRJazzAgent(opts: { peer: string }) {
   const ssrNode = createAnonymousJazzContext({
     crypto: new PureJSCrypto(),
-    peersToLoadFrom: [],
+    peers: [],
   });
 
   const wsPeer = new WebSocketPeerWithReconnection({

--- a/packages/jazz-tools/src/tools/testing.ts
+++ b/packages/jazz-tools/src/tools/testing.ts
@@ -112,7 +112,7 @@ export async function createJazzTestAccount<
     },
     initialAgentSecret: crypto.agentSecretFromSecretSeed(secretSeed),
     crypto,
-    peersToLoadFrom: peers,
+    peers: peers,
     migration: async (rawAccount, _node, creationProps) => {
       if (isMigrationActive) {
         throw new Error(
@@ -185,7 +185,7 @@ export function runWithoutActiveAccount<Result>(
 export async function createJazzTestGuest() {
   const ctx = await createAnonymousJazzContext({
     crypto: await PureJSCrypto.create(),
-    peersToLoadFrom: [],
+    peers: [],
   });
 
   return {
@@ -318,7 +318,7 @@ export class TestJazzContextManager<
       credentials: authProps?.credentials,
       defaultProfileName: props.defaultProfileName,
       newAccountProps: authProps?.newAccountProps,
-      peersToLoadFrom: [getPeerConnectedToTestSyncServer()],
+      peers: [getPeerConnectedToTestSyncServer()],
       crypto: await TestJSCrypto.create(),
       sessionProvider: randomSessionProvider,
       authSecretStorage: this.getAuthSecretStorage(),

--- a/packages/jazz-tools/src/tools/tests/ContextManager.test.ts
+++ b/packages/jazz-tools/src/tools/tests/ContextManager.test.ts
@@ -56,7 +56,7 @@ class TestJazzContextManager<Acc extends Account> extends JazzContextManager<
       credentials: authProps?.credentials,
       defaultProfileName: props.defaultProfileName,
       newAccountProps: authProps?.newAccountProps,
-      peersToLoadFrom: [getPeerConnectedToTestSyncServer()],
+      peers: [getPeerConnectedToTestSyncServer()],
       crypto: Crypto,
       sessionProvider: randomSessionProvider,
       authSecretStorage: this.getAuthSecretStorage(),

--- a/packages/jazz-tools/src/tools/tests/coPlainText.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coPlainText.test.ts
@@ -205,7 +205,7 @@ describe("CoPlainText", () => {
             secret: me.$jazz.localNode.getCurrentAgent().agentSecret,
           },
           sessionProvider: randomSessionProvider,
-          peersToLoadFrom: [initialAsPeer],
+          peers: [initialAsPeer],
           crypto: Crypto,
           asActiveAccount: true,
         });
@@ -237,7 +237,7 @@ describe("CoPlainText", () => {
           secret: me.$jazz.localNode.getCurrentAgent().agentSecret,
         },
         sessionProvider: randomSessionProvider,
-        peersToLoadFrom: [initialAsPeer],
+        peers: [initialAsPeer],
         crypto: Crypto,
         asActiveAccount: true,
       });

--- a/packages/jazz-tools/src/tools/tests/createContext.test.ts
+++ b/packages/jazz-tools/src/tools/tests/createContext.test.ts
@@ -51,7 +51,7 @@ describe("createContext methods", () => {
 
       const context = await createJazzContextFromExistingCredentials({
         credentials,
-        peersToLoadFrom: [getPeerConnectedToTestSyncServer()],
+        peers: [getPeerConnectedToTestSyncServer()],
         crypto: Crypto,
         sessionProvider: randomSessionProvider,
         asActiveAccount: true,
@@ -83,7 +83,7 @@ describe("createContext methods", () => {
 
       const context = await createJazzContextFromExistingCredentials({
         credentials,
-        peersToLoadFrom: [getPeerConnectedToTestSyncServer()],
+        peers: [getPeerConnectedToTestSyncServer()],
         crypto: Crypto,
         AccountSchema: CustomAccount,
         sessionProvider: randomSessionProvider,
@@ -107,7 +107,7 @@ describe("createContext methods", () => {
           accountID: account.$jazz.id,
           secret: account.$jazz.localNode.getCurrentAgent().agentSecret,
         },
-        peersToLoadFrom: [getPeerConnectedToTestSyncServer()],
+        peers: [getPeerConnectedToTestSyncServer()],
         crypto: Crypto,
         sessionProvider: randomSessionProvider,
         onLogOut,
@@ -131,7 +131,7 @@ describe("createContext methods", () => {
           accountID: account.$jazz.id,
           secret: account.$jazz.localNode.getCurrentAgent().agentSecret,
         },
-        peersToLoadFrom: [getPeerConnectedToTestSyncServer()],
+        peers: [getPeerConnectedToTestSyncServer()],
         crypto: Crypto,
         sessionProvider: randomSessionProvider,
         asActiveAccount: true,
@@ -152,7 +152,7 @@ describe("createContext methods", () => {
           accountID: account.$jazz.id,
           secret: account.$jazz.localNode.getCurrentAgent().agentSecret,
         },
-        peersToLoadFrom: [getPeerConnectedToTestSyncServer()],
+        peers: [getPeerConnectedToTestSyncServer()],
         crypto: Crypto,
         sessionProvider: randomSessionProvider,
         asActiveAccount: true,
@@ -171,7 +171,7 @@ describe("createContext methods", () => {
           accountID: account.$jazz.id,
           secret: account.$jazz.localNode.getCurrentAgent().agentSecret,
         },
-        peersToLoadFrom: [getPeerConnectedToTestSyncServer()],
+        peers: [getPeerConnectedToTestSyncServer()],
         crypto: Crypto,
         sessionProvider: randomSessionProvider,
         asActiveAccount: false,
@@ -185,7 +185,7 @@ describe("createContext methods", () => {
     test("creates new account with provided props", async () => {
       const context = await createJazzContextForNewAccount({
         creationProps: { name: "New User" },
-        peersToLoadFrom: [],
+        peers: [],
         crypto: Crypto,
       });
 
@@ -199,7 +199,7 @@ describe("createContext methods", () => {
       const context = await createJazzContextForNewAccount({
         creationProps: { name: "New User" },
         initialAgentSecret: initialSecret,
-        peersToLoadFrom: [],
+        peers: [],
         crypto: Crypto,
       });
 
@@ -216,7 +216,7 @@ describe("createContext methods", () => {
 
       const context = await createJazzContextForNewAccount({
         creationProps: { name: "New User" },
-        peersToLoadFrom: [],
+        peers: [],
         crypto: Crypto,
         AccountSchema: CustomAccount,
       });
@@ -229,7 +229,7 @@ describe("createContext methods", () => {
     test("sets the active account to the new account", async () => {
       const context = await createJazzContextForNewAccount({
         creationProps: { name: "New User" },
-        peersToLoadFrom: [],
+        peers: [],
         crypto: Crypto,
       });
       expect(activeAccountContext.get()).toBe(context.account);
@@ -239,7 +239,7 @@ describe("createContext methods", () => {
   describe("createAnonymousJazzContext", () => {
     test("creates anonymous context", async () => {
       const context = await createAnonymousJazzContext({
-        peersToLoadFrom: [],
+        peers: [],
         crypto: Crypto,
       });
 
@@ -257,7 +257,7 @@ describe("createContext methods", () => {
       coMap.set("test", "test", "trusting");
 
       const context = await createAnonymousJazzContext({
-        peersToLoadFrom: [getPeerConnectedToTestSyncServer()],
+        peers: [getPeerConnectedToTestSyncServer()],
         crypto: Crypto,
       });
 
@@ -268,7 +268,7 @@ describe("createContext methods", () => {
 
     test("sets the guest mode", async () => {
       await createAnonymousJazzContext({
-        peersToLoadFrom: [],
+        peers: [],
         crypto: Crypto,
       });
 
@@ -281,7 +281,7 @@ describe("createContext methods", () => {
   describe("createJazzContext", () => {
     test("creates new account when no credentials exist", async () => {
       const context = await createJazzContext({
-        peersToLoadFrom: [],
+        peers: [],
         crypto: Crypto,
         authSecretStorage,
         sessionProvider: randomSessionProvider,
@@ -294,7 +294,7 @@ describe("createContext methods", () => {
     test("uses existing credentials when available", async () => {
       // First create an account and store credentials
       const initialContext = await createJazzContext({
-        peersToLoadFrom: [getPeerConnectedToTestSyncServer()],
+        peers: [getPeerConnectedToTestSyncServer()],
         crypto: Crypto,
         authSecretStorage,
         sessionProvider: randomSessionProvider,
@@ -302,7 +302,7 @@ describe("createContext methods", () => {
 
       // Create new context with same storage
       const newContext = await createJazzContext({
-        peersToLoadFrom: [getPeerConnectedToTestSyncServer()],
+        peers: [getPeerConnectedToTestSyncServer()],
         crypto: Crypto,
         authSecretStorage,
         sessionProvider: randomSessionProvider,
@@ -316,7 +316,7 @@ describe("createContext methods", () => {
         newAccountProps: {
           creationProps: { name: "Custom User" },
         },
-        peersToLoadFrom: [],
+        peers: [],
         crypto: Crypto,
         authSecretStorage,
         sessionProvider: randomSessionProvider,
@@ -341,7 +341,7 @@ describe("createContext methods", () => {
         newAccountProps: {
           secret: initialSecret,
         },
-        peersToLoadFrom: [],
+        peers: [],
         crypto: Crypto,
         authSecretStorage,
         sessionProvider: randomSessionProvider,
@@ -365,7 +365,7 @@ describe("createContext methods", () => {
         .withMigration(async () => {});
 
       const context = await createJazzContext({
-        peersToLoadFrom: [],
+        peers: [],
         crypto: Crypto,
         authSecretStorage,
         sessionProvider: randomSessionProvider,

--- a/packages/jazz-tools/src/tools/tests/deepLoading.test.ts
+++ b/packages/jazz-tools/src/tools/tests/deepLoading.test.ts
@@ -55,7 +55,7 @@ describe("Deep loading with depth arg", async () => {
         secret: me.$jazz.localNode.getCurrentAgent().agentSecret,
       },
       sessionProvider: randomSessionProvider,
-      peersToLoadFrom: [initialAsPeer],
+      peers: [initialAsPeer],
       crypto: Crypto,
       asActiveAccount: true,
     });
@@ -286,7 +286,7 @@ test("Deep loading a record-like coMap", async () => {
         secret: me.$jazz.localNode.getCurrentAgent().agentSecret,
       },
       sessionProvider: randomSessionProvider,
-      peersToLoadFrom: [initialAsPeer],
+      peers: [initialAsPeer],
       crypto: Crypto,
       asActiveAccount: true,
     });

--- a/packages/jazz-tools/src/tools/tests/inbox.test.ts
+++ b/packages/jazz-tools/src/tools/tests/inbox.test.ts
@@ -424,7 +424,7 @@ describe("Inbox", () => {
     const node = await LocalNode.withLoadedAccount({
       accountID: accountId as any,
       accountSecret: accountSecret,
-      peersToLoadFrom: [getPeerConnectedToTestSyncServer()],
+      peers: [getPeerConnectedToTestSyncServer()],
       crypto: receiver.$jazz.localNode.crypto,
       sessionID: sessionID,
     });
@@ -495,7 +495,7 @@ describe("Inbox", () => {
     const node = await LocalNode.withLoadedAccount({
       accountID: accountId as any,
       accountSecret: accountSecret,
-      peersToLoadFrom: [getPeerConnectedToTestSyncServer()],
+      peers: [getPeerConnectedToTestSyncServer()],
       crypto: receiver.$jazz.localNode.crypto,
       sessionID: sessionID,
     });

--- a/packages/jazz-tools/src/tools/tests/utils.ts
+++ b/packages/jazz-tools/src/tools/tests/utils.ts
@@ -38,7 +38,7 @@ export async function setupAccount() {
         secret: me.$jazz.localNode.getCurrentAgent().agentSecret,
       },
       sessionProvider: randomSessionProvider,
-      peersToLoadFrom: [initialAsPeer],
+      peers: [initialAsPeer],
       crypto: Crypto,
       asActiveAccount: true,
     });
@@ -61,7 +61,7 @@ export async function setupTwoNodes(options?: {
   );
 
   const client = await LocalNode.withNewlyCreatedAccount({
-    peersToLoadFrom: [serverAsPeer],
+    peers: [serverAsPeer],
     crypto: Crypto,
     creationProps: { name: "Client" },
     migration: async (rawAccount, _node, creationProps) => {
@@ -74,7 +74,7 @@ export async function setupTwoNodes(options?: {
   });
 
   const server = await LocalNode.withNewlyCreatedAccount({
-    peersToLoadFrom: [clientAsPeer],
+    peers: [clientAsPeer],
     crypto: Crypto,
     creationProps: { name: "Server" },
     migration: async (rawAccount, _node, creationProps) => {

--- a/packages/jazz-tools/src/worker/index.ts
+++ b/packages/jazz-tools/src/worker/index.ts
@@ -54,7 +54,7 @@ export async function startWorker<
 
   let node: LocalNode | undefined = undefined;
 
-  const peersToLoadFrom: Peer[] = [];
+  const peers: Peer[] = [];
 
   const wsPeer = new WebSocketPeerWithReconnection({
     peer: syncServer,
@@ -63,7 +63,7 @@ export async function startWorker<
       if (node) {
         node.syncManager.addPeer(peer);
       } else {
-        peersToLoadFrom.push(peer);
+        peers.push(peer);
       }
     },
     removePeer: () => {},
@@ -92,7 +92,7 @@ export async function startWorker<
     },
     AccountSchema,
     sessionProvider: randomSessionProvider,
-    peersToLoadFrom,
+    peers,
     crypto: options.crypto ?? (await WasmCrypto.create()),
     asActiveAccount,
   });

--- a/tests/cloudflare-workers/src/index.ts
+++ b/tests/cloudflare-workers/src/index.ts
@@ -37,7 +37,7 @@ app.get("/", async (c) => {
 
   const account = await Account.create({
     creationProps: { name: "Cloudflare test account" },
-    peersToLoadFrom: [peer],
+    peers: [peer],
     crypto,
   });
 

--- a/tests/vercel-functions/src/app/api/hello/route.ts
+++ b/tests/vercel-functions/src/app/api/hello/route.ts
@@ -37,7 +37,7 @@ export async function GET(request: Request) {
 
   const account = await Account.create({
     creationProps: { name: "Cloudflare test account" },
-    peersToLoadFrom: [peer],
+    peers: [peer],
     crypto,
   });
 


### PR DESCRIPTION
# Description
As discussed, a simple renaming to enhance the property's clarity. 

Marked as PATCH upgrade, TBC