### PR TITLE
Fix: Repair urls for og-images

### DIFF
--- a/homepage/homepage/app/(others)/cloud/page.tsx
+++ b/homepage/homepage/app/(others)/cloud/page.tsx
@@ -27,7 +27,7 @@ export const metadata: Metadata = {
     description: metaTags.description,
     images: [
       {
-        url: `${metaTags.url}/opengraph-image`,
+        url: `${metaTags.url}/api/opengraph-image?title=${encodeURIComponent(metaTags.title)}`,
         height: 630,
         alt: metaTags.title,
       },

--- a/homepage/homepage/app/(others)/examples/page.tsx
+++ b/homepage/homepage/app/(others)/examples/page.tsx
@@ -25,7 +25,7 @@ export const metadata: Metadata = {
     description: metaTags.description,
     images: [
       {
-        url: `${metaTags.url}/opengraph-image`,
+        url: `${metaTags.url}/api/opengraph-image?title=${encodeURIComponent(metaTags.title)}`,
         height: 630,
         alt: metaTags.title,
       },

--- a/homepage/homepage/app/(others)/showcase/page.tsx
+++ b/homepage/homepage/app/(others)/showcase/page.tsx
@@ -19,7 +19,7 @@ export const metadata: Metadata = {
     description: metaTags.description,
     images: [
       {
-        url: `${metaTags.url}/opengraph-image`,
+        url: `${metaTags.url}/api/opengraph-image?title=${encodeURIComponent(metaTags.title)}`,
         height: 630,
         alt: metaTags.title,
       },

--- a/homepage/homepage/app/(others)/status/page.tsx
+++ b/homepage/homepage/app/(others)/status/page.tsx
@@ -20,7 +20,7 @@ export const metadata: Metadata = {
     description: metaTags.description,
     images: [
       {
-        url: `${metaTags.url}/opengraph-image`,
+        url: `${metaTags.url}/api/opengraph-image?title=${encodeURIComponent(metaTags.title)}`,
         height: 630,
         alt: metaTags.title,
       },

--- a/homepage/homepage/app/layout.tsx
+++ b/homepage/homepage/app/layout.tsx
@@ -33,7 +33,7 @@ export const metadata: Metadata = {
     siteName: "Jazz",
     images: [
       {
-        url: `${metaTags.url}/opengraph-image`,
+        url: `${metaTags.url}/api/opengraph-image?title=${encodeURIComponent(metaTags.title)}`,
         height: 630,
         alt: metaTags.title,
       },

--- a/homepage/homepage/lib/docMdxContent.tsx
+++ b/homepage/homepage/lib/docMdxContent.tsx
@@ -182,7 +182,7 @@ export function generateOGMetadata(
   const { title, description, image, topic, subtopic } = docMeta;
   const baseUrl = "https://jazz.tools";
   const imageUrl = image
-    ? `${baseUrl}/opengraph-image?title=${encodeURIComponent(title)}&framework=${encodeURIComponent(
+    ? `${baseUrl}/api/opengraph-image?title=${encodeURIComponent(title)}&framework=${encodeURIComponent(
         framework
       )}${topic ? `&topic=${encodeURIComponent(topic)}` : ""}${subtopic ? `&subtopic=${encodeURIComponent(subtopic)}` : ""}`
     : "/jazz-logo.png";


### PR DESCRIPTION
# Description
OG image URLs were returning 404s because the images are served via the `/api/opengraph-image` route. Updating the URLs to include /api/ ensures they correctly hit the route both locally and in production.

## Manual testing instructions
Check meta tags in deployed homepage. Make sure generated image urls are working (not 404)

## Tests

- [ ] Tests have been added and/or updated
- [x] Tests have not been updated, because: N/A
- [ ] I need help with writing tests


## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [ ] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing