### PR TITLE
fix: validate write permissions against merge time

### DIFF
--- a/.changeset/three-trees-fail.md
+++ b/.changeset/three-trees-fail.md
@@ -1,0 +1,5 @@
+---
+"cojson": patch
+---
+
+Fix write permissions checks on merged transactions by checking membership on merge time instead of original transaction time

--- a/packages/cojson/src/coValueCore/branching.ts
+++ b/packages/cojson/src/coValueCore/branching.ts
@@ -27,7 +27,7 @@ export type BranchPointerCommit = {
  */
 export type MergedTransactionMetadata = {
   mi: number; // Transaction index and marker of a merge commit
-  t?: number;
+  t?: number; // The difference between the current time and the madeAt value of the original transaction. Used to calculate the original madeAt of the transaction, stored this way to reduce the size of the meta information.
   s?: SessionID;
   b?: RawCoID;
 };

--- a/packages/cojson/src/coValueCore/branching.ts
+++ b/packages/cojson/src/coValueCore/branching.ts
@@ -27,6 +27,7 @@ export type BranchPointerCommit = {
  */
 export type MergedTransactionMetadata = {
   mi: number; // Transaction index and marker of a merge commit
+  t?: number;
   s?: SessionID;
   b?: RawCoID;
 };
@@ -242,11 +243,20 @@ export function mergeBranch(branch: CoValueCore): CoValueCore {
   // To reduce the cost of the meta we skip the repeated information
   let lastSessionId: string | undefined = undefined;
   let lastBranchId: string | undefined = undefined;
+  let lastOriginalMadeAt: number = 0;
+
+  const now = Date.now();
 
   for (const tx of branchValidTransactions) {
     const mergeMeta: MergedTransactionMetadata = {
       mi: tx.txID.txIndex,
     };
+
+    // We compress the original made at, to reduce the size of the meta information
+    if (tx.madeAt !== lastOriginalMadeAt) {
+      // Storing the diff with madeAt to consume less bytes in the meta information
+      mergeMeta.t = now - tx.madeAt;
+    }
 
     if (lastSessionId !== tx.txID.sessionID) {
       mergeMeta.s = tx.txID.sessionID;
@@ -256,9 +266,10 @@ export function mergeBranch(branch: CoValueCore): CoValueCore {
       mergeMeta.b = tx.txID.branch;
     }
 
-    target.makeTransaction(tx.changes, tx.tx.privacy, mergeMeta, tx.madeAt);
+    target.makeTransaction(tx.changes, tx.tx.privacy, mergeMeta, now);
     lastSessionId = tx.txID.sessionID;
     lastBranchId = tx.txID.branch;
+    lastOriginalMadeAt = tx.madeAt;
   }
 
   // Track the merged transactions for the branch, so future merges will know which transactions have already been merged

--- a/packages/cojson/src/coValueCore/coValueCore.ts
+++ b/packages/cojson/src/coValueCore/coValueCore.ts
@@ -140,11 +140,7 @@ export class VerifiedTransaction {
   // The madeAt that refers to the time when the transaction was made
   // If this is a merged transaction, the madeAt is the time when the transaction has been made in the branch
   get madeAt() {
-    if (this.mergedTransactionMadeAt) {
-      return this.mergedTransactionMadeAt;
-    }
-
-    return this.originalMadeAt;
+    return this.mergedTransactionMadeAt ?? this.originalMadeAt;
   }
 
   isValidTransactionWithChanges(): this is {

--- a/packages/cojson/src/coValueCore/coValueCore.ts
+++ b/packages/cojson/src/coValueCore/coValueCore.ts
@@ -1177,14 +1177,11 @@ export class CoValueCore {
   }
 
   compareTransactions(
-    a: Pick<VerifiedTransaction, "madeAt" | "txID" | "mergedTransactionMadeAt">,
-    b: Pick<VerifiedTransaction, "madeAt" | "txID" | "mergedTransactionMadeAt">,
+    a: Pick<VerifiedTransaction, "madeAt" | "txID">,
+    b: Pick<VerifiedTransaction, "madeAt" | "txID">,
   ) {
-    const aMadeAt = a.mergedTransactionMadeAt ?? a.madeAt;
-    const bMadeAt = b.mergedTransactionMadeAt ?? b.madeAt;
-
-    if (aMadeAt !== bMadeAt) {
-      return aMadeAt - bMadeAt;
+    if (a.madeAt !== b.madeAt) {
+      return a.madeAt - b.madeAt;
     }
 
     if (a.txID.sessionID === b.txID.sessionID) {

--- a/packages/cojson/src/coValueCore/coValueCore.ts
+++ b/packages/cojson/src/coValueCore/coValueCore.ts
@@ -64,10 +64,15 @@ export type VerifiedTransaction = {
   // An object containing the session ID and the transaction index
   txID: TransactionID;
   // The unmodified TxID that refers to the current position in the session map
-  orginalTxID: TransactionID;
+  // When merging branches, the txID will differ from the originalTxID because the txID is modified by the merge meta to show the original transaction id before the merge
+  // We do this override to keep the txID consistent after the merge because it is used by CoList operations.
+  originalTxID: TransactionID;
   tx: Transaction;
   // The Unix time when the transaction was made
   madeAt: number;
+  // The unmodified madeAt that refers to the time when the transaction was made
+  // When merging branches, the madeAt will differ from the originalMadeAt because the madeAt is modified by the merge meta to show the madeAt of the transaction before the merge
+  // We do this override because the originalMadeAt is necessary for the permissions checks, and the madeAt is required to keep the conflict resolution the same we had before the merge.
   originalMadeAt: number;
   // Whether the transaction has been validated, used to track if determinedValidTransactions needs to be check this
   isValidated: boolean;
@@ -838,7 +843,7 @@ export class CoValueCore {
         const verifiedTransaction = {
           author: accountOrAgentIDfromSessionID(sessionID),
           txID,
-          orginalTxID: txID,
+          originalTxID: txID,
           originalMadeAt: tx.madeAt,
           madeAt: tx.madeAt,
           isValidated: false,
@@ -1010,8 +1015,8 @@ export class CoValueCore {
 
       options?.knownTransactions?.add(transaction.tx);
 
-      // Using the orginalTxID to filter the transactions, because the TxID is modified by the merge meta
-      const txID = transaction.orginalTxID;
+      // Using the originalTxID to filter the transactions, because the TxID is modified by the merge meta
+      const txID = transaction.originalTxID;
 
       const from = options?.from?.[txID.sessionID] ?? -1;
 

--- a/packages/cojson/src/coValueCore/coValueCore.ts
+++ b/packages/cojson/src/coValueCore/coValueCore.ts
@@ -141,6 +141,7 @@ export class VerifiedTransaction {
   // If this is a merged transaction, the madeAt is the time when the transaction has been merged
   get madeAt() {
     if (this.sourceTransactionMadeAt) {
+      // Using Math.min to avoid the case where the user might exploit the sourceTransactionMadeAt to make changes after the access revocation
       return Math.min(this.sourceTransactionMadeAt, this.originalMadeAt);
     }
 

--- a/packages/cojson/src/coValueCore/coValueCore.ts
+++ b/packages/cojson/src/coValueCore/coValueCore.ts
@@ -72,9 +72,9 @@ export type VerifiedTransaction = {
   madeAt: number;
   // The unmodified madeAt that refers to the time when the transaction was made
   // When merging branches, the madeAt will differ from the originalMadeAt because the madeAt is modified by the merge meta to show the madeAt of the transaction before the merge
-  // We do this override because the originalMadeAt is necessary for the permissions checks, and the madeAt is required to keep the conflict resolution the same we had before the merge.
+  // We do this override because the originalMadeAt is necessary for the permissions checks, and the madeAt is required to keep the conflict resolution the same as we had before the merge.
   originalMadeAt: number;
-  // Whether the transaction has been validated, used to track if determinedValidTransactions needs to be check this
+  // Whether the transaction has been validated, used to track if determinedValidTransactions needs to check this
   isValidated: boolean;
   // The decoded changes of the transaction
   changes: JsonValue[] | undefined;

--- a/packages/cojson/src/coValueCore/coValueCore.ts
+++ b/packages/cojson/src/coValueCore/coValueCore.ts
@@ -138,7 +138,7 @@ export class VerifiedTransaction {
   }
 
   // The madeAt that refers to the time when the transaction was made
-  // If this is a merged transaction, the madeAt is the time when the transaction has been merged
+  // If this is a merged transaction, the madeAt is the time when the transaction has been made in the branch
   get madeAt() {
     if (this.mergedTransactionMadeAt) {
       return this.mergedTransactionMadeAt;

--- a/packages/cojson/src/permissions.ts
+++ b/packages/cojson/src/permissions.ts
@@ -118,9 +118,9 @@ export function determineValidTransactions(coValue: CoValueCore) {
       }
 
       tx.isValidated = true;
-      const wasValid = tx.isValid;
-
-      const groupAtTime = groupContent.atTime(tx.madeAt);
+      // We use the original made at to get the group at the original time when the transaction was made
+      // madeAt might be changed by the meta field (e.g. merged transactions), and so can't be used for permissions checks
+      const groupAtTime = groupContent.atTime(tx.originalMadeAt);
       const effectiveTransactor = agentInAccountOrMemberInGroup(
         tx.author,
         groupAtTime,
@@ -220,13 +220,10 @@ function determineValidTransactionsForGroup(
   initialAdmin: RawAccountID | AgentID,
   extendChain?: Set<CoValueCore["id"]>,
 ): { memberState: MemberState } {
-  coValue.verifiedTransactions.sort((a, b) => {
-    return a.madeAt - b.madeAt;
-  });
+  coValue.verifiedTransactions.sort(coValue.compareTransactions);
 
   const memberState: MemberState = {};
   const writeOnlyKeys: Record<RawAccountID | AgentID, KeyID> = {};
-  const validTransactions: ValidTransactionsResult[] = [];
 
   const writeKeys = new Set<string>();
 

--- a/packages/cojson/src/permissions.ts
+++ b/packages/cojson/src/permissions.ts
@@ -120,7 +120,7 @@ export function determineValidTransactions(coValue: CoValueCore) {
       tx.isValidated = true;
       // We use the original made at to get the group at the original time when the transaction was made
       // madeAt might be changed by the meta field (e.g. merged transactions), and so can't be used for permissions checks
-      const groupAtTime = groupContent.atTime(tx.originalMadeAt);
+      const groupAtTime = groupContent.atTime(tx.currentMadeAt);
       const effectiveTransactor = agentInAccountOrMemberInGroup(
         tx.author,
         groupAtTime,

--- a/packages/cojson/src/tests/branching.test.ts
+++ b/packages/cojson/src/tests/branching.test.ts
@@ -526,6 +526,17 @@ describe("Branching Logic", () => {
         );
       });
 
+      // The set to 3 should be valid, but the timestamp is capped to the time of merge
+      const lastBranchChange = branch.core
+        .getValidSortedTransactions()
+        .findLast((tx) => tx.changes.length > 0);
+      const lastMapChange = map.core
+        .getValidTransactions()
+        .findLast((tx) => tx.changes.length > 0);
+
+      expect(lastBranchChange?.txID).toEqual(lastMapChange?.txID);
+      expect(lastMapChange?.isValid).toBe(true);
+
       expect(expectMap(map.core.getCurrentContent()).get("value")).toBe(2);
     });
   });

--- a/packages/cojson/src/tests/branching.test.ts
+++ b/packages/cojson/src/tests/branching.test.ts
@@ -526,17 +526,6 @@ describe("Branching Logic", () => {
         );
       });
 
-      // The set to 3 should be valid, but the timestamp is capped to the time of merge
-      const lastBranchChange = branch.core
-        .getValidSortedTransactions()
-        .findLast((tx) => tx.changes.length > 0);
-      const lastMapChange = map.core
-        .getValidTransactions()
-        .findLast((tx) => tx.changes.length > 0);
-
-      expect(lastBranchChange?.txID).toEqual(lastMapChange?.txID);
-      expect(lastMapChange?.isValid).toBe(true);
-
       expect(expectMap(map.core.getCurrentContent()).get("value")).toBe(2);
     });
   });

--- a/packages/cojson/src/tests/branching.test.ts
+++ b/packages/cojson/src/tests/branching.test.ts
@@ -386,7 +386,7 @@ describe("Branching Logic", () => {
         .getValidSortedTransactions()
         .findLast((tx) => tx.txID.branch === branch.id);
 
-      expect(lastMapTransaction?.originalMadeAt).not.toBe(
+      expect(lastMapTransaction?.currentMadeAt).not.toBe(
         lastMapTransaction?.madeAt,
       );
 
@@ -422,14 +422,14 @@ describe("Branching Logic", () => {
         .getValidSortedTransactions()
         .at(-1);
       expect(lastBranchTransaction?.madeAt).toBe(
-        lastBranchTransaction?.originalMadeAt,
+        lastBranchTransaction?.currentMadeAt,
       );
 
       const lastMapTransaction = result
         .getValidSortedTransactions()
         .findLast((tx) => tx.txID.branch === branch.id);
       expect(lastMapTransaction?.madeAt).not.toBe(
-        lastMapTransaction?.originalMadeAt,
+        lastMapTransaction?.currentMadeAt,
       );
     });
 
@@ -813,7 +813,7 @@ describe("Branching Logic", () => {
       .getCurrentContent() as RawCoMap;
     branch.set("branchKey", "branchValue");
 
-    const originalTxID = branch.core
+    const currentTxID = branch.core
       .getValidTransactions({
         skipBranchSource: true,
         ignorePrivateTransactions: false,
@@ -835,7 +835,7 @@ describe("Branching Logic", () => {
       undefined,
     );
     expect(validSortedTransactions[mergedTransactionIdx]?.txID).toEqual(
-      originalTxID,
+      currentTxID,
     );
     expect(validSortedTransactions[mergedTransactionIdx + 1]?.txID.branch).toBe(
       undefined,

--- a/packages/cojson/src/tests/branching.test.ts
+++ b/packages/cojson/src/tests/branching.test.ts
@@ -1,11 +1,20 @@
-import { assert, beforeEach, describe, expect, test } from "vitest";
+import {
+  assert,
+  beforeEach,
+  describe,
+  expect,
+  onTestFinished,
+  test,
+  vi,
+} from "vitest";
 import {
   createTestNode,
   setupTestNode,
   loadCoValueOrFail,
+  setupTestAccount,
 } from "./testUtils.js";
 import { expectList, expectMap, expectPlainText } from "../coValue.js";
-import { RawCoMap } from "../exports.js";
+import { RawAccount, RawCoMap } from "../exports.js";
 
 let jazzCloud: ReturnType<typeof setupTestNode>;
 
@@ -237,6 +246,7 @@ describe("Branching Logic", () => {
       loadedBranch2.core.mergeBranch();
 
       await loadedBranch2.core.waitForSync();
+      await new Promise((resolve) => setTimeout(resolve, 5));
 
       branch1.core.mergeBranch();
 
@@ -288,6 +298,174 @@ describe("Branching Logic", () => {
       await loadedBranchMergeResult.waitForSync();
 
       expect(plainText.toString()).toEqual("hello world people");
+    });
+
+    test("should preserve the conflict resolution that was applied to the branch", async () => {
+      const dateNowMock = vi.spyOn(Date, "now");
+
+      dateNowMock.mockReturnValue(1);
+
+      const client = setupTestNode({
+        connected: true,
+      });
+      const group = client.node.createGroup();
+      const map = group.createMap();
+      const branchName = "feature-branch";
+
+      onTestFinished(() => {
+        dateNowMock.mockRestore();
+      });
+
+      // Add initial transactions to original map
+      map.set("value", 1, "trusting");
+
+      // Create branch from original map
+      const branch = expectMap(
+        map.core.createBranch(branchName, group.id).getCurrentContent(),
+      );
+
+      dateNowMock.mockReturnValue(2);
+
+      // Add new transaction to branch
+      branch.set("value", 2, "trusting");
+
+      const newSession = client.spawnNewSession();
+
+      const loadedBranch = await loadCoValueOrFail(newSession.node, branch.id);
+
+      dateNowMock.mockReturnValue(3);
+
+      loadedBranch.set("value", 3, "trusting");
+
+      expect(loadedBranch.get("value")).toBe(3);
+
+      await loadedBranch.core.waitForSync();
+
+      // Push back the change, so it doesn't win the conflict
+      dateNowMock.mockReturnValue(1);
+
+      branch.set("value", 4, "trusting");
+
+      expect(branch.get("value")).toBe(3);
+
+      dateNowMock.mockReturnValue(4);
+      branch.core.mergeBranch();
+
+      // The conflict resolution should be preserved, so we should have 3 and not 4
+      expect(map.get("value")).toBe(3);
+    });
+
+    test("should preserve the original madeAt of the branch", async () => {
+      const client = setupTestNode();
+      const group = client.node.createGroup();
+      const map = group.createMap();
+
+      // Add initial transactions to original map
+      map.set("value", 1, "trusting");
+
+      // Create branch from original map
+      const branch = expectMap(
+        map.core.createBranch("feature-branch", group.id).getCurrentContent(),
+      );
+
+      // Add new transaction to branch
+      branch.set("value", 2, "trusting");
+
+      await new Promise((resolve) => setTimeout(resolve, 5));
+
+      const result = branch.core.mergeBranch();
+
+      // The merge should be successful
+      expect(map.get("value")).toBe(2);
+
+      const lastBranchTransaction = branch.core
+        .getValidSortedTransactions()
+        .at(-1);
+      const lastMapTransaction = result
+        .getValidSortedTransactions()
+        .findLast((tx) => tx.txID.branch === branch.id);
+
+      expect(lastMapTransaction?.originalMadeAt).not.toBe(
+        lastMapTransaction?.madeAt,
+      );
+
+      expect(lastBranchTransaction?.madeAt).toBe(lastMapTransaction?.madeAt);
+    });
+
+    test("should not load the merged transactions into the branch (regression test)", async () => {
+      const client = setupTestNode();
+      const group = client.node.createGroup();
+      const map = group.createMap();
+
+      // Add initial transactions to original map
+      map.set("value", 1, "trusting");
+
+      // Create branch from original map
+      const branch = expectMap(
+        map.core.createBranch("feature-branch", group.id).getCurrentContent(),
+      );
+
+      await new Promise((resolve) => setTimeout(resolve, 5));
+
+      // Add new transaction to branch
+      branch.set("value", 2, "trusting");
+
+      await new Promise((resolve) => setTimeout(resolve, 5));
+
+      const result = branch.core.mergeBranch();
+
+      // The merge should be successful
+      expect(map.get("value")).toBe(2);
+
+      const lastBranchTransaction = branch.core
+        .getValidSortedTransactions()
+        .at(-1);
+      expect(lastBranchTransaction?.madeAt).toBe(
+        lastBranchTransaction?.originalMadeAt,
+      );
+
+      const lastMapTransaction = result
+        .getValidSortedTransactions()
+        .findLast((tx) => tx.txID.branch === branch.id);
+      expect(lastMapTransaction?.madeAt).not.toBe(
+        lastMapTransaction?.originalMadeAt,
+      );
+    });
+
+    test("write permissions should be validated against the time of the merge and not the original madeAt", async () => {
+      const alice = setupTestNode({
+        connected: true,
+      });
+      const bob = await setupTestAccount({
+        connected: true,
+      });
+      const group = alice.node.createGroup();
+      const map = group.createMap();
+      const branchName = "feature-branch";
+
+      map.set("value", 1, "trusting");
+
+      const branch = expectMap(
+        map.core.createBranch(branchName, group.id).getCurrentContent(),
+      );
+
+      branch.set("value", 2, "trusting");
+
+      await new Promise((resolve) => setTimeout(resolve, 5));
+
+      // Grant writer rights to bob after the changes inside the branche
+      group.addMember(
+        await loadCoValueOrFail(alice.node, bob.accountID),
+        "writer",
+      );
+
+      const loadedBranch = await loadCoValueOrFail(bob.node, branch.id);
+
+      // Bob merges the branch
+      const mergeResult = loadedBranch.core.mergeBranch();
+
+      // The merge should be successful
+      expect(expectMap(mergeResult.getCurrentContent()).get("value")).toBe(2);
     });
   });
 


### PR DESCRIPTION
Refactored the merge operation in order to make it possible to validate write permissions against merge time instead off referring to the original transaction time.

This fixes the case where account that does the merge has got write access after some of the changes happened in the branch.

This PR preserves the conflict management in order to keep the idempotency property of the merge action, which we rely on in CoList.

We could apply a different conflict management (and even make it customizable) on CoMap, as the strategy is applied in the `compareTransactions` to make more intuitive.