### PR TITLE
fix: align JazzVueProvider and JazzVueProviderWithClerk types

### DIFF
--- a/packages/community-jazz-vue/src/auth/JazzVueProviderWithClerk.ts
+++ b/packages/community-jazz-vue/src/auth/JazzVueProviderWithClerk.ts
@@ -46,7 +46,7 @@ export const JazzVueProviderWithClerk = defineComponent({
       required: true,
     },
     AccountSchema: {
-      type: Function as unknown as PropType<
+      type: [Function, Object] as unknown as PropType<
         (AccountClass<Account> & CoValueFromRaw<Account>) | AnyAccountSchema
       >,
       required: false,
@@ -72,7 +72,7 @@ export const JazzVueProviderWithClerk = defineComponent({
       required: false,
     },
     onAnonymousAccountDiscarded: {
-      type: Function as PropType<(anonymousAccount: any) => Promise<void>>,
+      type: Function as PropType<(anonymousAccount: Account) => Promise<void>>,
       required: false,
     },
     enableSSR: {


### PR DESCRIPTION
this fixes a prop check error: `[Vue warn]: Invalid prop: type check failed for prop "AccountSchema". Expected Function, got Object`

I diffed the props and found no other difference, other than the new clerk prop and the missing logOutReplacement prop, which is handled via clerk.