### PR TITLE
Add more options to CLI

### DIFF
--- a/.changeset/witty-rivers-agree.md
+++ b/.changeset/witty-rivers-agree.md
@@ -1,0 +1,6 @@
+---
+"create-jazz-app": minor
+"jazz-tools": patch
+---
+
+Added more options to the create-jazz-app tool

--- a/examples/betterauth/src/app/(app)/page.tsx
+++ b/examples/betterauth/src/app/(app)/page.tsx
@@ -67,12 +67,12 @@ export default function Home() {
       <footer className="flex gap-4 py-8">
         <Button asChild variant="ghost">
           <a
-            href="https://jazz.tools/api-reference"
+            href="https://jazz.tools/docs"
             target="_blank"
             rel="noopener noreferrer"
           >
             <FileTextIcon className="size-4" />
-            API reference
+            Docs
           </a>
         </Button>
         <Button asChild variant="ghost">

--- a/packages/create-jazz-app/.gitignore
+++ b/packages/create-jazz-app/.gitignore
@@ -169,3 +169,6 @@ dist
 .pnp.\*
 
 .DS_Store
+
+# Dev artefacts
+src/*.js

--- a/packages/create-jazz-app/src/config.ts
+++ b/packages/create-jazz-app/src/config.ts
@@ -1,12 +1,13 @@
 export type Environment = "browser" | "mobile";
 export type Engine = "browser" | "mobile" | "nodejs" | "deno" | "bun";
-export type Framework = "react" | "svelte" | "rn";
+export type Framework = "react" | "svelte" | "rn" | "expo" | "nextjs";
 export type AuthMethod =
   | "minimal"
   | "passkey"
   | "passphrase"
   | "clerk"
-  | "keypair";
+  | "betterauth"
+  | "multi";
 
 export type EngineConfig = {
   [K in Engine]?: {
@@ -21,12 +22,20 @@ export const frameworks: {
   value: Framework;
 }[] = [
   {
-    name: "React",
+    name: "React (Vite)",
     value: "react",
+  },
+  {
+    name: "React (Next.js)",
+    value: "nextjs",
   },
   {
     name: "React Native",
     value: "rn",
+  },
+  {
+    name: "React Native (Expo)",
+    value: "expo",
   },
   {
     name: "Svelte",
@@ -56,11 +65,13 @@ export const configMap: ConfigStructure = {
     browser: {
       react: { auth: ["minimal", "passkey", "passphrase", "clerk"] },
       svelte: { auth: ["passkey"] },
+      nextjs: { auth: ["minimal"] },
     },
   },
   mobile: {
     mobile: {
       rn: { auth: ["minimal"] },
+      expo: { auth: ["minimal"] },
     },
   },
 };
@@ -88,9 +99,29 @@ export const frameworkToAuthExamples: Partial<
     repo: "garden-co/jazz/starters/react-passkey-auth",
     platform: PLATFORM.WEB,
   },
+  "react-passphrase-auth": {
+    name: "Passphrase auth",
+    repo: "garden-co/jazz/examples/passphrase",
+    platform: PLATFORM.WEB,
+  },
   "react-clerk-auth": {
     name: "Clerk auth",
     repo: "garden-co/jazz/examples/clerk",
+    platform: PLATFORM.WEB,
+  },
+  "react-multi-auth": {
+    name: "Multi auth",
+    repo: "garden-co/jazz/examples/multiauth",
+    platform: PLATFORM.WEB,
+  },
+  "nextjs-betterauth-auth": {
+    name: "BetterAuth",
+    repo: "garden-co/jazz/examples/betterauth",
+    platform: PLATFORM.WEB,
+  },
+  "nextjs-minimal-auth": {
+    name: "Anonymous Auth",
+    repo: "garden-co/jazz/examples/jazz-nextjs",
     platform: PLATFORM.WEB,
   },
   "svelte-passkey-auth": {
@@ -98,7 +129,17 @@ export const frameworkToAuthExamples: Partial<
     repo: "garden-co/jazz/starters/svelte-passkey-auth",
     platform: PLATFORM.WEB,
   },
+  "svelte-minimal-auth": {
+    name: "Anonymous Auth with SvelteKit",
+    repo: "garden-co/jazz/examples/jazz-sveltekit",
+    platform: PLATFORM.WEB,
+  },
   "rn-minimal-auth": {
+    name: "Anonymous auth",
+    repo: "garden-co/jazz/examples/chat-rn",
+    platform: PLATFORM.REACT_NATIVE,
+  },
+  "expo-minimal-auth": {
     name: "Anonymous auth",
     repo: "garden-co/jazz/examples/chat-rn-expo",
     platform: PLATFORM.REACT_NATIVE,

--- a/packages/jazz-tools/src/inspector/viewer/use-open-inspector.ts
+++ b/packages/jazz-tools/src/inspector/viewer/use-open-inspector.ts
@@ -5,6 +5,7 @@ const STORAGE_KEY = "jazz-inspector-open";
 export function useOpenInspector() {
   const [open, setOpen] = useState(() => {
     // Initialize from localStorage if available
+    if (typeof window === "undefined") return false;
     const stored = localStorage.getItem(STORAGE_KEY);
     return stored ? JSON.parse(stored) : false;
   });

--- a/packages/jazz-tools/src/inspector/viewer/use-page-path.ts
+++ b/packages/jazz-tools/src/inspector/viewer/use-page-path.ts
@@ -6,6 +6,7 @@ const STORAGE_KEY = "jazz-inspector-paths";
 
 export function usePagePath(defaultPath?: PageInfo[]) {
   const [path, setPath] = useState<PageInfo[]>(() => {
+    if (typeof window === "undefined") return [];
     const stored = localStorage.getItem(STORAGE_KEY);
     if (stored) {
       try {


### PR DESCRIPTION
# Description
Added some more options to the CLI.

In particular:
- React is now broken down into React (Vite) and React (Next.js)
- More auth options added
- Fixed RN/Expo

## Manual testing instructions
Checkout, build the CLI tool. Test the new options.

## Tests

- [ ] Tests have been added and/or updated
- [X] Tests have not been updated, because: N/A
- [ ] I need help with writing tests


## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [X] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing