### PR TITLE
Add .md route to all docs pages

### DIFF
--- a/homepage/homepage/.gitignore
+++ b/homepage/homepage/.gitignore
@@ -42,3 +42,4 @@ codeSamples
 
 # LLM docs
 public/llms*.txt
+public/docs

--- a/homepage/homepage/.gitignore
+++ b/homepage/homepage/.gitignore
@@ -41,5 +41,5 @@ codeSamples
 .env
 
 # LLM docs
-public/llms*.txt
+public/**/llms*.txt
 public/docs

--- a/homepage/homepage/generate-docs/llms-full.mjs
+++ b/homepage/homepage/generate-docs/llms-full.mjs
@@ -1,12 +1,24 @@
-// llms-full.mjs
 import { promises as fs } from "fs";
 import path from "path";
 import { DOC_SECTIONS, FRAMEWORKS } from "./utils/config.mjs";
 import { writeDocsFile } from "./utils/index.mjs";
 import { mdxToMd } from "./utils/mdx-processor.mjs";
 
-const exclude = [/\/upgrade\//];
 const CWD = process.cwd();
+const EXCLUDE_PATTERNS = [/\/upgrade\//];
+
+// Map each framework to its representative example
+const FRAMEWORK_EXAMPLES = {
+  react: "music-player",
+  "react-native": "chat-rn",
+  "react-native-expo": "chat-rn-expo",
+  svelte: "chat-svelte",
+  vanilla: "chat",
+};
+
+// ============================================================================
+// File Walking & Discovery
+// ============================================================================
 
 async function walkDocsDirectory(dir, basePath = "") {
   const results = [];
@@ -16,148 +28,16 @@ async function walkDocsDirectory(dir, basePath = "") {
     const fullPath = path.join(dir, entry.name);
     const relativePath = path.join(basePath, entry.name);
 
-    // Skip upgrade guides and other excluded paths
-    if (exclude.some((pattern) => pattern.test(fullPath))) continue;
+    if (EXCLUDE_PATTERNS.some((pattern) => pattern.test(fullPath))) continue;
 
     if (entry.isDirectory()) {
       results.push(...(await walkDocsDirectory(fullPath, relativePath)));
-    } else if (entry.isFile() && entry.name.endsWith(".mdx")) {
+    } else if (entry.name.endsWith(".mdx")) {
       results.push({ fullPath, relativePath });
     }
   }
 
   return results;
-}
-
-async function generateMarkdownFiles() {
-  const docsDir = path.join(CWD, "content/docs");
-  const mdxFiles = await walkDocsDirectory(docsDir);
-
-  console.log(`${mdxFiles.length} source files`);
-
-  for (const { fullPath, relativePath } of mdxFiles) {
-    try {
-      const filename = path.basename(relativePath, ".mdx");
-      const dirPath = path.dirname(relativePath);
-      const isFrameworkSpecific = FRAMEWORKS.includes(filename);
-
-      if (isFrameworkSpecific) {
-        // Framework-specific file: project-setup/providers/react.mdx
-        // Output: react/project-setup/providers.md
-        const framework = filename;
-        const content = await mdxToMd(fullPath, framework);
-        
-        const outputPath = path.join(
-          CWD,
-          "public/docs",
-          framework,
-          dirPath + ".md"
-        );
-
-        await fs.mkdir(path.dirname(outputPath), { recursive: true });
-        await fs.writeFile(outputPath, content);
-        console.log(`Generated: ${path.relative(CWD, outputPath)}`);
-      } else {
-        // Generic file: troubleshooting.mdx
-        // Output: troubleshooting.md (generic)
-        // AND: {framework}/troubleshooting.md (for each framework for fallback)
-        // This is necessary in order to serve static files
-        // If I don't do this redundant file generation, I need to do routing
-        // Which results in extremely long compilation times because we're
-        // adding hundreds of extra routes
-        
-        // Generate generic version (no framework filtering)
-        const genericContent = await mdxToMd(fullPath);
-
-        const genericPath = path.join(
-          CWD,
-          "public/docs",
-          relativePath.replace(/\.mdx$/, ".md")
-        );
-        await fs.mkdir(path.dirname(genericPath), { recursive: true });
-        await fs.writeFile(genericPath, genericContent);
-
-        // Generate framework-specific versions with filtering
-        for (const framework of FRAMEWORKS) {
-          const frameworkContent = await mdxToMd(fullPath, framework);
-          
-          const frameworkPath = path.join(
-            CWD,
-            "public/docs",
-            framework,
-            relativePath.replace(/\.mdx$/, ".md")
-          );
-
-          await fs.mkdir(path.dirname(frameworkPath), { recursive: true });
-          await fs.writeFile(frameworkPath, frameworkContent);
-        }
-      }
-    } catch (error) {
-      console.warn(`Error processing ${relativePath}:`, error.message);
-    }
-  }
-
-  // Handle the intro page - need to regenerate with framework context
-  const indexPath = path.join(CWD, "content/docs/index.mdx");
-  try {
-    for (const framework of FRAMEWORKS) {
-      const frameworkIndexContent = await mdxToMd(indexPath, framework);
-      const frameworkIndexPath = path.join(
-        CWD,
-        "public/docs",
-        `${framework}.md`
-      );
-
-      await fs.writeFile(frameworkIndexPath, frameworkIndexContent);
-      console.log(`Generated: ${path.relative(CWD, frameworkIndexPath)}`);
-    }
-  } catch (error) {
-    console.warn(`Error generating framework index files:`, error.message);
-  }
-}
-
-async function readMdxContent(url) {
-  try {
-    // Special case for the intro page
-    if (url === "/docs") {
-      const introPath = path.join(CWD, "content/docs/index.mdx");
-      return mdxToMd(introPath);
-    }
-
-    const relativePath = url.replace(/^\/docs\/?/, "");
-    const fullPath = path.join(CWD, "content/docs", relativePath);
-
-    if (exclude.some((pattern) => pattern.test(fullPath))) return null;
-
-    try {
-      const stats = await fs.stat(fullPath);
-      if (stats.isDirectory()) {
-        const files = await fs.readdir(fullPath);
-        const mdxFiles = files.filter(
-          (f) => f.endsWith(".mdx") && !exclude.some((p) => p.test(f))
-        );
-        if (mdxFiles.length === 0) return null;
-
-        const contents = await Promise.all(
-          mdxFiles.map((file) => mdxToMd(path.join(fullPath, file)))
-        );
-        // Write out this content to a file.
-        return contents.join("\n\n---\n\n");
-      }
-    } catch (err) {
-      if (err.code !== "ENOENT") throw err; // Re-throw unexpected errors
-    }
-
-    // Fallback to reading as a single .mdx file
-    return await mdxToMd(fullPath + ".mdx").catch((err) => {
-      if (err.code !== "ENOENT") console.warn(`Error processing ${url}:`, err);
-      return null;
-    });
-
-  } catch (error) {
-    console.warn(`Failed to read MDX content for ${url}:`, error);
-    return null;
-  }
 }
 
 async function loadDirectoryContent(dirPath) {
@@ -173,64 +53,248 @@ async function loadDirectoryContent(dirPath) {
       results.push({ filepath: fullPath, content });
     }
   }
+
   return results;
 }
 
-// Read the music player example source code (generally the most cutting-edge and append it to the output for llms-full.txt
-// TODO: consider adding a server-side example too.
-async function appendMusicExample(output) {
+// ============================================================================
+// Markdown File Generation
+// ============================================================================
+
+async function writeMarkdownFile(outputPath, content) {
+  await fs.mkdir(path.dirname(outputPath), { recursive: true });
+  await fs.writeFile(outputPath, content);
+  console.log(`Generated: ${path.relative(CWD, outputPath)}`);
+}
+
+async function generateFrameworkSpecificFile(fullPath, relativePath) {
+  const framework = path.basename(relativePath, ".mdx");
+  const dirPath = path.dirname(relativePath);
+  const content = await mdxToMd(fullPath, framework);
+  const outputPath = path.join(CWD, "public/docs", framework, dirPath + ".md");
+  await writeMarkdownFile(outputPath, content);
+}
+
+async function generateGenericFile(fullPath, relativePath) {
+  // Generate generic version (no framework filtering)
+  const genericContent = await mdxToMd(fullPath);
+  const genericPath = path.join(
+    CWD,
+    "public/docs",
+    relativePath.replace(/\.mdx$/, ".md")
+  );
+  await writeMarkdownFile(genericPath, genericContent);
+
+  // Generate framework-specific versions with filtering
+  // This redundancy avoids adding hundreds of dynamic routes which slows compilation
+  for (const framework of FRAMEWORKS) {
+    const frameworkContent = await mdxToMd(fullPath, framework);
+    const frameworkPath = path.join(
+      CWD,
+      "public/docs",
+      framework,
+      relativePath.replace(/\.mdx$/, ".md")
+    );
+    await writeMarkdownFile(frameworkPath, frameworkContent);
+  }
+}
+
+async function generateFrameworkIndexFiles() {
+  const indexPath = path.join(CWD, "content/docs/index.mdx");
+  
+  for (const framework of FRAMEWORKS) {
+    try {
+      const content = await mdxToMd(indexPath, framework);
+      const outputPath = path.join(CWD, "public/docs", `${framework}.md`);
+      await writeMarkdownFile(outputPath, content);
+    } catch (error) {
+      console.warn(`Error generating ${framework} index:`, error.message);
+    }
+  }
+}
+
+async function generateMarkdownFiles() {
+  const docsDir = path.join(CWD, "content/docs");
+  const mdxFiles = await walkDocsDirectory(docsDir);
+
+  console.log(`Processing ${mdxFiles.length} source files...`);
+
+  for (const { fullPath, relativePath } of mdxFiles) {
+    try {
+      const filename = path.basename(relativePath, ".mdx");
+      const isFrameworkSpecific = FRAMEWORKS.includes(filename);
+
+      if (isFrameworkSpecific) {
+        await generateFrameworkSpecificFile(fullPath, relativePath);
+      } else {
+        await generateGenericFile(fullPath, relativePath);
+      }
+    } catch (error) {
+      console.warn(`Error processing ${relativePath}:`, error.message);
+    }
+  }
+
+  await generateFrameworkIndexFiles();
+}
+
+// ============================================================================
+// LLM Documentation Generation
+// ============================================================================
+
+async function readMdxContent(url, framework = null) {
   try {
-    const examplePath = path.resolve(CWD, "../../examples/music-player/src");
+    const relativePath = url === "/docs" ? "index.mdx" : url.replace(/^\/docs\/?/, "");
+    const fullPath = path.join(CWD, "content/docs", relativePath);
+
+    if (EXCLUDE_PATTERNS.some((pattern) => pattern.test(fullPath))) {
+      return null;
+    }
+
+    // Check if it's a directory
+    try {
+      const stats = await fs.stat(fullPath);
+      if (stats.isDirectory()) {
+        const files = await fs.readdir(fullPath);
+        const mdxFiles = files.filter(
+          (f) => f.endsWith(".mdx") && !EXCLUDE_PATTERNS.some((p) => p.test(f))
+        );
+        
+        if (mdxFiles.length === 0) return null;
+
+        const contents = await Promise.all(
+          mdxFiles.map((file) => mdxToMd(path.join(fullPath, file), framework))
+        );
+        return contents.join("\n\n---\n\n");
+      }
+    } catch (err) {
+      if (err.code !== "ENOENT") throw err;
+    }
+
+    // Try reading as a single .mdx file
+    const mdxPath = fullPath.endsWith(".mdx") ? fullPath : fullPath + ".mdx";
+    return await mdxToMd(mdxPath, framework);
+  } catch (error) {
+    if (error.code !== "ENOENT") {
+      console.warn(`Failed to read ${url}:`, error.message);
+    }
+    return null;
+  }
+}
+
+async function appendExampleCode(output, exampleName) {
+  try {
+    const examplePath = path.resolve(CWD, `../../examples/${exampleName}/src`);
     const files = await loadDirectoryContent(examplePath);
 
-    output.push("## Music Example\n");
-    for (const file of files) {
-      const relativePath = path.relative(examplePath, file.filepath);
-      const lang = path.extname(relativePath).substring(1);
+    output.push(`## ${exampleName} Example\n`);
+    for (const { filepath, content } of files) {
+      const relativePath = path.relative(examplePath, filepath);
+      const extension = path.extname(relativePath).substring(1);
       output.push(`### ${relativePath}\n`);
-      output.push(`\`\`\`${lang}\n${file.content}\n\`\`\`\n`);
+      output.push(`\`\`\`${extension}\n${content}\n\`\`\`\n`);
     }
   } catch (error) {
-    console.warn("Could not read music example:", error.message);
+    console.warn(`Could not read ${exampleName} example:`, error.message);
   }
+}
+
+function initializeOutputs() {
+  return {
+    generic: ["# Jazz\n"],
+    ...Object.fromEntries(
+      FRAMEWORKS.map((fw) => [fw, [`# Jazz (${fw})\n`]])
+    ),
+  };
+}
+
+function addToAllOutputs(outputs, ...lines) {
+  for (const output of Object.values(outputs)) {
+    output.push(...lines);
+  }
+}
+
+async function buildDocumentationContent(outputs) {
+  for (const section of DOC_SECTIONS) {
+    addToAllOutputs(outputs, `## ${section.title}\n`);
+
+    for (const page of section.pages) {
+      if (!page.url) continue;
+
+      addToAllOutputs(outputs, `### ${page.title}`);
+
+      // Read content for all variants in parallel
+      const [genericContent, ...frameworkContents] = await Promise.all([
+        readMdxContent(page.url),
+        ...FRAMEWORKS.map((fw) => readMdxContent(page.url, fw)),
+      ]);
+
+      // Append content to respective outputs
+      if (genericContent) outputs.generic.push(genericContent);
+      outputs.generic.push("\n");
+      
+      FRAMEWORKS.forEach((framework, i) => {
+        if (frameworkContents[i]) outputs[framework].push(frameworkContents[i]);
+        outputs[framework].push("\n");
+      });
+    }
+  }
+
+  // Add resources section
+  addToAllOutputs(
+    outputs,
+    "## Resources\n",
+    "- [Documentation](https://jazz.tools/docs): Detailed documentation about Jazz",
+    "- [Examples](https://jazz.tools/examples): Code examples and tutorials\n"
+  );
+}
+
+async function writeOutputFiles(outputs) {
+  // Ensure framework directories exist upfront
+  await Promise.all(
+    FRAMEWORKS.map((fw) =>
+      fs.mkdir(path.join(CWD, "public", fw), { recursive: true })
+    )
+  );
+
+  // Write generic files
+  await writeDocsFile("llms.txt", outputs.generic.join("\n"));
+
+  const genericWithExample = [...outputs.generic];
+  await appendExampleCode(genericWithExample, "music-player");
+  await writeDocsFile("llms-full.txt", genericWithExample.join("\n"));
+
+  // Write framework-specific files in parallel
+  await Promise.all(
+    FRAMEWORKS.map(async (framework) => {
+      const frameworkOutput = [...outputs[framework]];
+      await writeDocsFile(`${framework}/llms.txt`, frameworkOutput.join("\n"));
+      const frameworkOutputWithExample = [...frameworkOutput];
+      await appendExampleCode(frameworkOutputWithExample, FRAMEWORK_EXAMPLES[framework]);
+      await writeDocsFile(`${framework}/llms-full.txt`, frameworkOutputWithExample.join("\n"));
+    })
+  );
 }
 
 async function generateDocs() {
-  // Generate the directory structure of markdown files
+  console.log("Generating markdown files...");
   await generateMarkdownFiles();
 
-  // Generate the combined LLM documentation files
-  const output = ["# Jazz\n"];
-
-  for (const section of DOC_SECTIONS) {
-    output.push(`## ${section.title}\n`);
-    for (const page of section.pages) {
-      if (!page.url) continue;
-      output.push(`### ${page.title}`);
-      const content = await readMdxContent(page.url); 
-      // TODO: we're 3 heading levels down already. Most pages start with an H1, so our docs are going H1, H2, H3, H1 in almost every case.
-      if (content) {
-        output.push(content);
-      }
-      output.push("\n");
-    }
-  }
-
-  output.push("## Resources\n");
-  output.push("- [Documentation](https://jazz.tools/docs): Detailed documentation about Jazz");
-  output.push("- [Examples](https://jazz.tools/examples): Code examples and tutorials\n");
-
-  const outputWithExample = [...output];
-  await appendMusicExample(outputWithExample);
-
-  await writeDocsFile("llms.txt", output.join("\n"));
-  await writeDocsFile("llms-full.txt", outputWithExample.join("\n"));
+  console.log("Building LLM documentation content...");
+  const outputs = initializeOutputs();
+  await buildDocumentationContent(outputs);
+  
+  console.log("Writing output files...");
+  await writeOutputFiles(outputs);
 }
 
+// ============================================================================
+// Main
+// ============================================================================
+
 async function main() {
-  console.log("Generating detailed LLM docs...");
+  console.log("Generating LLM documentation...");
   await generateDocs();
-  console.log("Docs generated successfully.");
+  console.log("Documentation generated successfully.");
 }
 
 main().catch(console.error);

--- a/homepage/homepage/generate-docs/llms-full.mjs
+++ b/homepage/homepage/generate-docs/llms-full.mjs
@@ -155,9 +155,23 @@ async function readMdxContent(url, framework = null) {
       const stats = await fs.stat(fullPath);
       if (stats.isDirectory()) {
         const files = await fs.readdir(fullPath);
-        const mdxFiles = files.filter(
+        let mdxFiles = files.filter(
           (f) => f.endsWith(".mdx") && !EXCLUDE_PATTERNS.some((p) => p.test(f))
         );
+        
+        // Filter framework-specific files
+        mdxFiles = mdxFiles.filter((file) => {
+          const fileBasename = path.basename(file, ".mdx");
+          const isFrameworkFile = FRAMEWORKS.includes(fileBasename);
+          
+          if (framework) {
+            // Include if: matches current framework OR not a framework-specific file
+            return fileBasename === framework || !isFrameworkFile;
+          } else {
+            // Generic case: exclude all framework-specific files
+            return !isFrameworkFile;
+          }
+        });
         
         if (mdxFiles.length === 0) return null;
 

--- a/homepage/homepage/generate-docs/llms-full.mjs
+++ b/homepage/homepage/generate-docs/llms-full.mjs
@@ -207,7 +207,8 @@ async function generateDocs() {
     for (const page of section.pages) {
       if (!page.url) continue;
       output.push(`### ${page.title}`);
-      const content = await readMdxContent(page.url);
+      const content = await readMdxContent(page.url); 
+      // TODO: we're 3 heading levels down already. Most pages start with an H1, so our docs are going H1, H2, H3, H1 in almost every case.
       if (content) {
         output.push(content);
       }

--- a/homepage/homepage/generate-docs/utils/config.mjs
+++ b/homepage/homepage/generate-docs/utils/config.mjs
@@ -1,4 +1,6 @@
 import { docNavigationItems } from "../../content/docs/docNavigationItems.js";
+// Can't import from framework.ts because node doesn't support enum types
+export const FRAMEWORKS = ["react", "react-native", "react-native-expo", "svelte", "vanilla"];
 
 // Recursively collect all pages from an item and its nested items
 function collectPages(item) {

--- a/homepage/homepage/generate-docs/utils/mdx-processor.mjs
+++ b/homepage/homepage/generate-docs/utils/mdx-processor.mjs
@@ -17,7 +17,7 @@ const htmlToMarkdown = new NodeHtmlMarkdown();
 
 const mockMdxComponentsPath = path.resolve(__dirname, "mock-mdx-components.mjs");
 
-export async function mdxToMd(filePath) {
+export async function mdxToMd(filePath, framework) {
   const source = await fs.readFile(filePath, "utf-8");
   const mockComponentsContent = await fs.readFile(mockMdxComponentsPath, "utf-8");
 

--- a/homepage/homepage/generate-docs/utils/mdx-processor.mjs
+++ b/homepage/homepage/generate-docs/utils/mdx-processor.mjs
@@ -52,6 +52,11 @@ export async function mdxToMd(filePath, framework) {
         ...(options.alias || {}),
         "@/components/forMdx": mockMdxComponentsPath,
       };
+      // Define CURRENT_FRAMEWORK as a build-time constant
+      options.define = {
+        ...(options.define || {}),
+        'CURRENT_FRAMEWORK': framework ? `"${framework}"` : 'null',
+      };
       return options;
     },
     globals: {

--- a/homepage/homepage/generate-docs/utils/mock-mdx-components.mjs
+++ b/homepage/homepage/generate-docs/utils/mock-mdx-components.mjs
@@ -1,18 +1,74 @@
-import { createElement } from "react";
+import { createElement, Children } from "react";
+
+// CURRENT_FRAMEWORK will be defined at build-time via esbuild's define option
+// It will be replaced with the actual framework string or null
 
 export const TabbedCodeGroup = ({ children }) => {
-  return createElement('div', null, children);
+  const currentFramework = CURRENT_FRAMEWORK;
+  
+  if (!currentFramework) {
+    // No framework set, render all tabs with labels
+    return createElement('div', null, children);
+  }
+
+  // Filter children to find matching framework tab
+  const childArray = Children.toArray(children);
+  const matchingChild = childArray.find(child => {
+    return child.props?.value === currentFramework;
+  });
+
+  // Render matching tab without the label wrapper, or first tab as fallback
+  const tabToRender = matchingChild || childArray[0];
+  if (tabToRender) {
+    // Just render the content directly, not the wrapper
+    return createElement('div', null, tabToRender.props.children);
+  }
+
+  return null;
 };
 
-export const TabbedCodeGroupItem = ({ children, label }) => {
-  return createElement('div', null, 
-    createElement('h5', null, `${label}:`), // H5 seems OK? We need to mark this out as some sort of section, so I think this is the best way.
-    children
-  );
+export const TabbedCodeGroupItem = ({ children, label, value }) => {
+  const currentFramework = CURRENT_FRAMEWORK;
+  
+  if (!currentFramework) {
+    // No framework set, render with label
+    return createElement('div', null, 
+      createElement('h5', null, `${label}:`),
+      children
+    );
+  }
+
+  // When framework is set, only render if this tab matches
+  if (value === currentFramework) {
+    return children;
+  }
+
+  return null;
 };
 
 export const ContentByFramework = ({ children, framework }) => {
-  return createElement('div', null, createElement('p', {}, `--- Section applies only to ${framework} ---`), children, createElement('p', null, `--- End of ${framework} specific section ---`));
+  const currentFramework = CURRENT_FRAMEWORK;
+  
+  if (!currentFramework) {
+    // No framework set, render with markers
+    return createElement('div', null, 
+      createElement('p', {}, `--- Section applies only to ${framework} ---`), 
+      children, 
+      createElement('p', null, `--- End of ${framework} specific section ---`)
+    );
+  }
+
+  // Check if framework prop matches current framework
+  if (framework === currentFramework) {
+    return children;
+  }
+
+  // Handle array of frameworks
+  if (Array.isArray(framework) && framework.includes(currentFramework)) {
+    return children;
+  }
+
+  return null;
 };
 
 export const CodeGroup = ({ children }) => {


### PR DESCRIPTION
# Description
When autogenerating the llms.txt file, we also now output MD files (compiled from MDX), which can be accessed by appending '.md' to the URL of any existing docs page.

These are output to the /public folder to avoid needing to compile them, which does result in some duplication at the moment to ensure we've got the right files for each framework

## Manual testing instructions
1. Navigate to a docs page
2. Add '.md' at the end of the URL
3. Check that the markdown accurately represents the content that was hosted at that URL
4. Check the framework specific llms-full.txt available at eg jazz.tools/svelte/llms-full.txt

## Tests

- [ ] Tests have been added and/or updated
- [X] Tests have not been updated, because: Docs only
- [ ] I need help with writing tests


## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [ ] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing