### PR TITLE
feat: introducing manager role

### DIFF
--- a/.changeset/stupid-ducks-try.md
+++ b/.changeset/stupid-ducks-try.md
@@ -1,0 +1,6 @@
+---
+"jazz-tools": minor
+"cojson": minor
+---
+
+feat: introduced new "manager" role who can invite and remove members, and being removed by admins. Group.removeMember() now throws in case of invalid permissions.

--- a/.changeset/stupid-ducks-try.md
+++ b/.changeset/stupid-ducks-try.md
@@ -1,6 +1,6 @@
 ---
-"jazz-tools": minor
-"cojson": minor
+"jazz-tools": patch
+"cojson": patch
 ---
 
-feat: introduced new "manager" role who can invite and remove members, and being removed by admins. Group.removeMember() now throws in case of invalid permissions.
+feat: introduced new "manager" role who can invite and remove members, and being removed by admins.

--- a/examples/music-player/src/3_HomePage.tsx
+++ b/examples/music-player/src/3_HomePage.tsx
@@ -1,5 +1,4 @@
-import { useToast } from "@/hooks/use-toast";
-import { createInviteLink, useCoState } from "jazz-tools/react";
+import { useCoState } from "jazz-tools/react";
 import { useParams } from "react-router";
 import { Playlist } from "./1_schema";
 import { uploadMusicTracks } from "./4_actions";
@@ -9,6 +8,7 @@ import { MusicTrackRow } from "./components/MusicTrackRow";
 import { PlayerControls } from "./components/PlayerControls";
 import { EditPlaylistModal } from "./components/EditPlaylistModal";
 import { PlaylistMembers } from "./components/PlaylistMembers";
+import { MemberAccessModal } from "./components/MemberAccessModal";
 import { SidePanel } from "./components/SidePanel";
 import { Button } from "./components/ui/button";
 import { SidebarInset, SidebarTrigger } from "./components/ui/sidebar";
@@ -19,8 +19,8 @@ import { useAccountSelector } from "@/components/AccountProvider.tsx";
 export function HomePage({ mediaPlayer }: { mediaPlayer: MediaPlayer }) {
   const playState = usePlayState();
   const isPlaying = playState.value === "play";
-  const { toast } = useToast();
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
+  const [isMembersModalOpen, setIsMembersModalOpen] = useState(false);
 
   async function handleFileLoad(files: FileList) {
     /**
@@ -45,23 +45,15 @@ export function HomePage({ mediaPlayer }: { mediaPlayer: MediaPlayer }) {
 
   const membersIds = playlist?.$jazz.owner.members.map((member) => member.id);
   const isRootPlaylist = !params.playlistId;
-  const isPlaylistOwner = useAccountSelector({
-    select: (me) => Boolean(playlist && me.canAdmin(playlist)),
+  const canEdit = useAccountSelector({
+    select: (me) => Boolean(playlist && me.canWrite(playlist)),
   });
   const isActivePlaylist = useAccountSelector({
     select: (me) => playlistId === me.root.activePlaylist?.$jazz.id,
   });
 
-  const handlePlaylistShareClick = async () => {
-    if (!isPlaylistOwner || !playlist) return;
-
-    const inviteLink = createInviteLink(playlist, "reader");
-
-    await navigator.clipboard.writeText(inviteLink);
-
-    toast({
-      title: "Invite link copied into the clipboard",
-    });
+  const handlePlaylistShareClick = () => {
+    setIsMembersModalOpen(true);
   };
 
   const handleEditClick = () => {
@@ -86,7 +78,7 @@ export function HomePage({ mediaPlayer }: { mediaPlayer: MediaPlayer }) {
                 {membersIds && playlist && (
                   <PlaylistMembers
                     memberIds={membersIds}
-                    group={playlist.$jazz.owner}
+                    onClick={() => setIsMembersModalOpen(true)}
                   />
                 )}
               </div>
@@ -99,7 +91,7 @@ export function HomePage({ mediaPlayer }: { mediaPlayer: MediaPlayer }) {
                   </FileUploadButton>
                 </>
               )}
-              {!isRootPlaylist && (
+              {!isRootPlaylist && canEdit && (
                 <>
                   <Button onClick={handleEditClick} variant="outline">
                     Edit
@@ -139,6 +131,15 @@ export function HomePage({ mediaPlayer }: { mediaPlayer: MediaPlayer }) {
         isOpen={isEditModalOpen}
         onClose={() => setIsEditModalOpen(false)}
       />
+
+      {/* Members Management Modal */}
+      {playlist && (
+        <MemberAccessModal
+          isOpen={isMembersModalOpen}
+          onOpenChange={setIsMembersModalOpen}
+          playlist={playlist}
+        />
+      )}
     </SidebarInset>
   );
 }

--- a/examples/music-player/src/components/MemberAccessModal.tsx
+++ b/examples/music-player/src/components/MemberAccessModal.tsx
@@ -1,5 +1,7 @@
+import { useState } from "react";
+import { useToast } from "@/hooks/use-toast";
 import { Account, Group } from "jazz-tools";
-import { useCoState } from "jazz-tools/react";
+import { useCoState, createInviteLink } from "jazz-tools/react";
 import {
   Dialog,
   DialogContent,
@@ -10,41 +12,50 @@ import {
 } from "./ui/dialog";
 import { Button } from "./ui/button";
 import { Badge } from "./ui/badge";
-import { User, Crown, Edit, Eye, Trash2, Users } from "lucide-react";
-import { MusicaAccount } from "@/1_schema";
+import {
+  User,
+  Crown,
+  Edit,
+  Eye,
+  Trash2,
+  Users,
+  UserPlus,
+  Link,
+} from "lucide-react";
+import { MusicaAccount, Playlist } from "@/1_schema";
 import { Member } from "./Member";
 
 interface MemberAccessModalProps {
   isOpen: boolean;
   onOpenChange: (open: boolean) => void;
-  group: Group;
+  playlist: Playlist;
 }
 
 export function MemberAccessModal(props: MemberAccessModalProps) {
-  const group = useCoState(Group, props.group.$jazz.id);
+  const group = useCoState(Group, props.playlist.$jazz.owner.$jazz.id);
+  const [selectedRole, setSelectedRole] = useState<
+    "reader" | "writer" | "manager"
+  >("reader");
+  const { toast } = useToast();
 
   if (!group) return null;
 
   // Get all members from the group
   const members = group.members.map((m) => m.account);
   const currentUser = MusicaAccount.getMe();
-  const isCurrentUserAdmin = group.myRole() === "admin";
+  const isManager = group.myRole() === "admin" || group.myRole() === "manager";
 
   const handleRoleChange = async (
     member: Account,
-    newRole: "reader" | "writer",
+    newRole: "reader" | "writer" | "manager",
   ) => {
-    if (!isCurrentUserAdmin) return;
+    if (!isManager) return;
 
-    if (newRole === "reader") {
-      group.addMember(member, "reader");
-    } else if (newRole === "writer") {
-      group.addMember(member, "writer");
-    }
+    group.addMember(member, newRole);
   };
 
   const handleRemoveMember = async (member: Account) => {
-    if (!isCurrentUserAdmin) return;
+    if (!isManager) return;
 
     group.removeMember(member);
   };
@@ -66,6 +77,8 @@ export function MemberAccessModal(props: MemberAccessModalProps) {
     switch (role) {
       case "admin":
         return "Admin";
+      case "manager":
+        return "Manager";
       case "writer":
         return "Writer";
       case "reader":
@@ -79,6 +92,8 @@ export function MemberAccessModal(props: MemberAccessModalProps) {
     switch (role) {
       case "admin":
         return "bg-yellow-100 text-yellow-800 border-yellow-200";
+      case "manager":
+        return "bg-purple-100 text-purple-800 border-purple-200";
       case "writer":
         return "bg-blue-100 text-blue-800 border-blue-200";
       case "reader":
@@ -89,7 +104,23 @@ export function MemberAccessModal(props: MemberAccessModalProps) {
   };
 
   const canModifyMember = (member: Account) => {
-    return isCurrentUserAdmin && member.$jazz.id !== currentUser?.$jazz.id;
+    return (
+      isManager &&
+      (member.$jazz.id === currentUser?.$jazz.id ||
+        !member.canAdmin(props.playlist))
+    );
+  };
+
+  const handleGetInviteLink = async () => {
+    if (!isManager) return;
+
+    const inviteLink = createInviteLink(props.playlist, selectedRole);
+    await navigator.clipboard.writeText(inviteLink);
+
+    toast({
+      title: "Invite link copied",
+      description: `Invite link for ${selectedRole} role copied to clipboard.`,
+    });
   };
 
   return (
@@ -111,78 +142,159 @@ export function MemberAccessModal(props: MemberAccessModalProps) {
               No members found in this playlist.
             </div>
           ) : (
-            members.map((member) => {
-              const memberId = member.$jazz.id;
-              const currentRole = group.getRoleOf(memberId);
-              const isCurrentUser = memberId === currentUser?.$jazz.id;
-              const canModify = canModifyMember(member);
+            <section>
+              {members.map((member) => {
+                const memberId = member.$jazz.id;
+                const currentRole = group.getRoleOf(memberId);
+                const isCurrentUser = memberId === currentUser?.$jazz.id;
+                const canModify = canModifyMember(member);
 
-              return (
-                <div key={memberId} className="border rounded-lg p-4">
-                  <div className="flex items-center justify-between">
-                    {/* Member Info */}
-                    <div className="flex items-center gap-3 flex-1">
-                      <Member
-                        accountId={memberId}
-                        size="sm"
-                        showTooltip={true}
-                      />
-                      <div className="flex-1">
-                        <p className="font-medium text-gray-900">
-                          {isCurrentUser ? "You" : member.profile?.name}
-                        </p>
-                        <div className="flex items-center gap-2 mt-1">
-                          {getRoleIcon(currentRole)}
-                          <Badge
-                            variant="outline"
-                            className={getRoleColor(currentRole)}
-                          >
-                            {getRoleLabel(currentRole)}
-                          </Badge>
-                        </div>
-                      </div>
-                    </div>
-
-                    {/* Action Buttons */}
-                    {canModify && (
-                      <div className="flex items-center gap-2">
-                        <div className="flex gap-1">
-                          <Button
-                            variant="outline"
-                            size="sm"
-                            onClick={() => handleRoleChange(member, "reader")}
-                            disabled={currentRole === "reader"}
-                            className="px-2 py-1 text-xs"
-                          >
-                            <Eye className="w-3 h-3 mr-1" />
-                            Reader
-                          </Button>
-                          <Button
-                            variant="outline"
-                            size="sm"
-                            onClick={() => handleRoleChange(member, "writer")}
-                            disabled={currentRole === "writer"}
-                            className="px-2 py-1 text-xs"
-                          >
-                            <Edit className="w-3 h-3 mr-1" />
-                            Writer
-                          </Button>
-                        </div>
-                        <Button
-                          variant="destructive"
+                return (
+                  <div key={memberId} className="border rounded-lg p-4">
+                    <div className="flex items-center justify-between">
+                      {/* Member Info */}
+                      <div className="flex items-center gap-3 flex-1">
+                        <Member
+                          accountId={memberId}
                           size="sm"
-                          onClick={() => handleRemoveMember(member)}
-                          className="px-2 py-1 text-xs"
-                        >
-                          <Trash2 className="w-3 h-3 mr-1" />
-                          Remove
-                        </Button>
+                          showTooltip={true}
+                        />
+                        <div className="flex-1">
+                          <p className="font-medium text-gray-900">
+                            {isCurrentUser ? "You" : member.profile?.name}
+                          </p>
+                          <div className="flex items-center gap-2 mt-1">
+                            {getRoleIcon(currentRole)}
+                            <Badge
+                              variant="outline"
+                              className={getRoleColor(currentRole)}
+                            >
+                              {getRoleLabel(currentRole)}
+                            </Badge>
+                          </div>
+                        </div>
                       </div>
-                    )}
+
+                      {/* Action Buttons */}
+                      {canModify && (
+                        <div className="flex items-center gap-2">
+                          <div className="flex gap-1">
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              aria-label="Grant reader access"
+                              onClick={() => handleRoleChange(member, "reader")}
+                              disabled={currentRole === "reader"}
+                              className="px-2 py-1 text-xs"
+                            >
+                              <Eye className="w-3 h-3 mr-1" />
+                              Reader
+                            </Button>
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              aria-label="Grant writer access"
+                              onClick={() => handleRoleChange(member, "writer")}
+                              disabled={currentRole === "writer"}
+                              className="px-2 py-1 text-xs"
+                            >
+                              <Edit className="w-3 h-3 mr-1" />
+                              Writer
+                            </Button>
+                            {group.myRole() === "admin" && (
+                              <Button
+                                variant="outline"
+                                size="sm"
+                                aria-label="Grant manager access"
+                                onClick={() =>
+                                  handleRoleChange(member, "manager")
+                                }
+                                disabled={currentRole === "manager"}
+                                className="px-2 py-1 text-xs"
+                              >
+                                <Edit className="w-3 h-3 mr-1" />
+                                Manager
+                              </Button>
+                            )}
+                          </div>
+                          <Button
+                            variant="destructive"
+                            size="sm"
+                            aria-label="Remove member"
+                            onClick={() => handleRemoveMember(member)}
+                            className="px-2 py-1 text-xs"
+                          >
+                            <Trash2 className="w-3 h-3 mr-1" />
+                            Remove
+                          </Button>
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                );
+              })}
+            </section>
+          )}
+
+          {isManager && (
+            <section className="border-2 border-dashed border-gray-300 rounded-lg p-6 mt-4">
+              <div className="flex items-start gap-4">
+                <div className="p-3 bg-blue-50 rounded-full">
+                  <UserPlus className="w-6 h-6 text-blue-600" />
+                </div>
+                <div className="flex-1">
+                  <h3 className="font-semibold text-gray-900 mb-1">
+                    Invite new members
+                  </h3>
+                  <p className="text-sm text-gray-600 mb-4">
+                    Generate an invite link to add new members to this playlist.
+                  </p>
+                  <div className="flex items-center gap-3">
+                    <div className="flex gap-2">
+                      <Button
+                        variant={
+                          selectedRole === "reader" ? "default" : "outline"
+                        }
+                        size="sm"
+                        onClick={() => setSelectedRole("reader")}
+                        className="px-3 py-2"
+                      >
+                        <Eye className="w-4 h-4 mr-1" />
+                        Reader
+                      </Button>
+                      <Button
+                        variant={
+                          selectedRole === "writer" ? "default" : "outline"
+                        }
+                        size="sm"
+                        onClick={() => setSelectedRole("writer")}
+                        className="px-3 py-2"
+                      >
+                        <Edit className="w-4 h-4 mr-1" />
+                        Writer
+                      </Button>
+                      {group.myRole() === "admin" && (
+                        <Button
+                          variant={
+                            selectedRole === "manager" ? "default" : "outline"
+                          }
+                          size="sm"
+                          onClick={() => setSelectedRole("manager")}
+                          className="px-3 py-2"
+                        >
+                          <Crown className="w-4 h-4 mr-1" />
+                          Manager
+                        </Button>
+                      )}
+                    </div>
+                    <Button onClick={handleGetInviteLink} className="gap-2">
+                      <Link className="w-4 h-4" />
+                      Get Invite Link
+                    </Button>
                   </div>
                 </div>
-              );
-            })
+              </div>
+            </section>
           )}
         </div>
 

--- a/examples/music-player/src/components/PlaylistMembers.tsx
+++ b/examples/music-player/src/components/PlaylistMembers.tsx
@@ -1,33 +1,23 @@
-import { useState } from "react";
-import { Group } from "jazz-tools";
 import { Member } from "./Member";
-import { MemberAccessModal } from "./MemberAccessModal";
 
 interface PlaylistMembersProps {
   memberIds: string[];
-  group: Group;
   size?: "sm" | "md" | "lg";
+  onClick: () => void;
   className?: string;
 }
 
 export function PlaylistMembers({
   memberIds,
-  group,
   size = "md",
   className = "",
+  onClick,
 }: PlaylistMembersProps) {
-  const [isModalOpen, setIsModalOpen] = useState(false);
-
   if (!memberIds || memberIds.length === 0) return null;
-
-  const handleMembersClick = () => {
-    setIsModalOpen(true);
-  };
-
   return (
     <>
       <button
-        onClick={handleMembersClick}
+        onClick={onClick}
         className={`flex items-center space-x-2 hover:scale-105 transition-transform duration-200 cursor-pointer ${className}`}
         title="Click to manage playlist members"
       >
@@ -45,12 +35,6 @@ export function PlaylistMembers({
           ({memberIds.length} member{memberIds.length !== 1 ? "s" : ""})
         </span>
       </button>
-
-      <MemberAccessModal
-        isOpen={isModalOpen}
-        onOpenChange={setIsModalOpen}
-        group={group}
-      />
     </>
   );
 }

--- a/examples/music-player/tests/pages/HomePage.ts
+++ b/examples/music-player/tests/pages/HomePage.ts
@@ -93,18 +93,37 @@ export class HomePage {
       .click();
   }
 
+  async assertPlaylistNotExists(playlistTitle: string) {
+    await expect(
+      this.page.getByRole("button", { name: playlistTitle }),
+    ).not.toBeVisible();
+  }
+
   async navigateToHome() {
     await this.page
       .getByRole("button", {
-        name: "All tracks",
+        name: "Go to all tracks",
       })
       .click();
   }
 
-  async getShareLink() {
+  async getShareLink(role: string = "reader") {
     await this.page
       .getByRole("button", {
         name: "Share",
+      })
+      .click();
+
+    await this.page
+      .getByRole("dialog")
+      .locator("section")
+      .filter({ hasText: `Invite new members` })
+      .getByRole("button", { name: role })
+      .click();
+
+    await this.page
+      .getByRole("button", {
+        name: "Get invite link",
       })
       .click();
 
@@ -114,7 +133,47 @@ export class HomePage {
 
     expect(inviteUrl).toBeTruthy();
 
+    await this.page
+      .getByRole("button", {
+        name: "Close",
+      })
+      .first()
+      .click();
+
     return inviteUrl;
+  }
+
+  async removeMember(index: number) {
+    await this.page
+      .getByRole("button", {
+        name: "Share",
+      })
+      .click();
+
+    const countBefore = await this.page
+      .getByRole("dialog")
+      .getByRole("button", { name: "Remove" })
+      .count();
+
+    await this.page
+      .getByRole("dialog")
+      .getByRole("button", { name: "Remove" })
+      .nth(index)
+      .click();
+
+    expect(
+      await this.page
+        .getByRole("dialog")
+        .getByRole("button", { name: "Remove" })
+        .count(),
+    ).toBe(countBefore - 1);
+
+    await this.page
+      .getByRole("button", {
+        name: "Close",
+      })
+      .first()
+      .click();
   }
 
   async addTrackToPlaylist(trackTitle: string, playlistTitle: string) {

--- a/homepage/homepage/content/docs/permissions-and-sharing/overview.mdx
+++ b/homepage/homepage/content/docs/permissions-and-sharing/overview.mdx
@@ -22,6 +22,76 @@ While creating CoValues with Accounts as owners is still technically possible fo
 it will be removed in a future release.
 </Alert>
 
+## Role Matrix
+<table>
+  <thead>
+    <tr>
+      <th>Role</th>
+      <th>admin</th>
+      <th>manager</th>
+      <th>writer</th>
+      <th>writeOnly</th>
+      <th>reader</th>
+    </tr>
+  </thead>
+  <tbody>
+  <tr>
+      <th>Summary</th>
+      <td>Full control</td>
+      <td>Delegated management</td>
+      <td>Standard writer</td>
+      <td>Blind submissions</td>
+      <td>Viewer</td>
+    </tr>
+    <tr>
+      <th>Can add admins<sup>*</sup></th>
+      <td>✅</td>
+      <td>❌</td>
+      <td>❌</td>
+      <td>❌</td>
+      <td>❌</td>
+    </tr>
+    <tr>
+      <th>Can add/remove managers</th>
+      <td>✅</td>
+      <td>❌</td>
+      <td>❌</td>
+      <td>❌</td>
+      <td>❌</td>
+    </tr>
+    <tr>
+      <th>Can add/remove readers and writers</th>
+      <td>✅</td>
+      <td>✅</td>
+      <td>❌</td>
+      <td>❌</td>
+      <td>❌</td>
+    </tr>
+    <tr>
+      <th>Can write</th>
+      <td>✅</td>
+      <td>✅</td>
+      <td>✅</td>
+      <td>✅<sup>*</sup></td>
+      <td>❌</td>
+    </tr>
+    <tr>
+      <th>Can read</th>
+      <td>✅</td>
+      <td>✅</td>
+      <td>✅</td>
+      <td>❌<sup>***</sup></td>
+      <td>✅</td>
+    </tr>
+  </tbody>
+</table>
+
+<sup>*</sup> `admin` users cannot be removed by anyone else, they must leave the group themselves.
+
+<sup>**</sup> `writeOnly` users can only create and edit their own updates/submissions.
+
+<sup>***</sup> `writeOnly` cannot read updates from other users.
+
 ## Creating a Group
 
 Here's how you can create a `Group`.
@@ -98,7 +168,7 @@ group.addMember(bob, "reader");
 
 Bob just went from a writer to a reader.
 
-**Note:** only admins can change a member's role.
+**Note:** only admins and managers can change a member's role.
 
 ## Removing a member
 
@@ -116,10 +186,9 @@ group.removeMember(bob);
 </CodeGroup>
 
 Rules:
-- All roles can remove themselves.
-- Only admins can remove other users.
-- An admin cannot remove other admins.
-- As an admin, you cannot remove yourself if you are the only admin in the Group, because there has to be at least one admin present.
+- All roles can remove themselves
+- Admins can remove all roles (except other admins)
+- Managers can remove users with less privileged roles (writer, writeOnly, reader)
 
 ## Getting the Group of an existing CoValue
 
@@ -146,7 +215,7 @@ const newValue = MyCoMap.create(
 
 ## Checking the permissions
 
-You can check the permissions of an account on a CoValue by using the `canRead`, `canWrite` and `canAdmin` methods.
+You can check the permissions of an account on a CoValue by using the `canRead`, `canWrite`, `canManage` and `canAdmin` methods.
 
 <CodeGroup>
 ```ts twoslash
@@ -160,7 +229,9 @@ const value = await MyCoMap.create({ color: "red"})
 const me = await co.account().getMe();
 
 if (me.canAdmin(value)) {
-  console.log("I can share value with others"); 
+  console.log("I can add users of any role"); 
+} else if (me.canManage(value)) {
+  console.log("I can share value with others");
 } else if (me.canWrite(value)) {
   console.log("I can edit value");
 } else if (me.canRead(value)) {

--- a/packages/cojson/src/coValues/group.ts
+++ b/packages/cojson/src/coValues/group.ts
@@ -1087,11 +1087,12 @@ export class RawGroup<
 
     this.set(memberKey, "revoked", "trusting");
 
-    if (this.get(memberKey) !== "revoked") {
-      throw new Error(
-        `Failed to revoke role to ${memberKey} (role of current account is ${this.myRole()})`,
-      );
-    }
+    // TODO: removeMember fails silently. Uncomment this will be a breaking change
+    // if (this.get(memberKey) !== "revoked") {
+    //   throw new Error(
+    //     `Failed to revoke role to ${memberKey} (role of current account is ${this.myRole()})`,
+    //   );
+    // }
   }
 
   /**

--- a/packages/cojson/src/exports.ts
+++ b/packages/cojson/src/exports.ts
@@ -60,7 +60,7 @@ import { AgentSecret, textDecoder, textEncoder } from "./crypto/crypto.js";
 import type { AgentID, RawCoID, SessionID } from "./ids.js";
 import type { JsonObject, JsonValue } from "./jsonValue.js";
 import type * as Media from "./media.js";
-import { disablePermissionErrors } from "./permissions.js";
+import { disablePermissionErrors, isAccountRole } from "./permissions.js";
 import type { Peer, SyncMessage } from "./sync.js";
 import {
   DisconnectedError,
@@ -169,6 +169,7 @@ export {
   base64URLtoBytes,
   bytesToBase64url,
   hwrServerPeerSelector,
+  isAccountRole,
 };
 
 export type {

--- a/packages/cojson/src/localNode.ts
+++ b/packages/cojson/src/localNode.ts
@@ -640,11 +640,13 @@ export class LocalNode {
       account,
       inviteRole === "adminInvite"
         ? "admin"
-        : inviteRole === "writerInvite"
-          ? "writer"
-          : inviteRole === "writeOnlyInvite"
-            ? "writeOnly"
-            : "reader",
+        : inviteRole === "managerInvite"
+          ? "manager"
+          : inviteRole === "writerInvite"
+            ? "writer"
+            : inviteRole === "writeOnlyInvite"
+              ? "writeOnly"
+              : "reader",
     );
 
     const contentPieces =

--- a/packages/cojson/src/permissions.ts
+++ b/packages/cojson/src/permissions.ts
@@ -488,9 +488,7 @@ function determineValidTransactionsForGroup(
     }
 
     // if I'm self revoking, it is always valid
-    if (
-      transactor === change.key && change.value === "revoked"
-    ) {
+    if (transactor === change.key && change.value === "revoked") {
       markTransactionSetRoleAsValid(change);
       continue;
     }
@@ -535,6 +533,10 @@ function determineValidTransactionsForGroup(
         markTransactionAsInvalid("Managers can't invite admins.");
         continue;
       }
+      if (change.value === "managerInvite") {
+        markTransactionAsInvalid("Managers can't invite managers.");
+        continue;
+      }
 
       markTransactionSetRoleAsValid(change);
       continue;
@@ -548,33 +550,28 @@ function determineValidTransactionsForGroup(
       }
     } else if (transactorRole === "managerInvite") {
       if (change.value !== "manager") {
-        logPermissionError("managerInvite can only create super-admins.");
-        transaction.isValid = false;
+        markTransactionAsInvalid("managerInvite can only create managers.");
         continue;
       }
     } else if (transactorRole === "writerInvite") {
       if (change.value !== "writer") {
-        logPermissionError("WriterInvites can only create writers.");
-        transaction.isValid = false;
+        markTransactionAsInvalid("WriterInvites can only create writers.");
         continue;
       }
     } else if (transactorRole === "readerInvite") {
       if (change.value !== "reader") {
-        logPermissionError("ReaderInvites can only create reader.");
-        transaction.isValid = false;
+        markTransactionAsInvalid("ReaderInvites can only create reader.");
         continue;
       }
     } else if (transactorRole === "writeOnlyInvite") {
       if (change.value !== "writeOnly") {
-        logPermissionError("WriteOnlyInvites can only create writeOnly.");
-        transaction.isValid = false;
+        markTransactionAsInvalid("WriteOnlyInvites can only create writeOnly.");
         continue;
       }
     } else {
-      logPermissionError(
+      markTransactionAsInvalid(
         "Group transaction must be made by current admin, manager, or invite",
       );
-      transaction.isValid = false;
       continue;
     }
 

--- a/packages/cojson/src/permissions.ts
+++ b/packages/cojson/src/permissions.ts
@@ -1,6 +1,5 @@
 import { CoID } from "./coValue.js";
 import { CoValueCore } from "./coValueCore/coValueCore.js";
-import { Transaction } from "./coValueCore/verifiedState.js";
 import { RawAccount, RawAccountID, RawProfile } from "./coValues/account.js";
 import { MapOpPayload, RawCoMap } from "./coValues/coMap.js";
 import {
@@ -15,10 +14,8 @@ import {
   AgentID,
   ParentGroupReference,
   RawCoID,
-  TransactionID,
   getParentGroupId,
 } from "./ids.js";
-import { parseJSON } from "./jsonStringify.js";
 import { JsonValue } from "./jsonValue.js";
 import { logger } from "./logger.js";
 import { expectGroup } from "./typeUtils/expectGroup.js";
@@ -42,6 +39,10 @@ export type AccountRole =
    */
   | "admin"
   /**
+   * Can read and write, invite and revoke members except admin
+   */
+  | "manager"
+  /**
    * Can only write to the group's CoValues and read their own changes
    */
   | "writeOnly";
@@ -49,6 +50,7 @@ export type AccountRole =
 export type Role =
   | AccountRole
   | "revoked"
+  | "managerInvite"
   | "adminInvite"
   | "writerInvite"
   | "readerInvite"
@@ -56,6 +58,7 @@ export type Role =
 
 export function isAccountRole(role?: Role): role is AccountRole {
   return (
+    role === "manager" ||
     role === "admin" ||
     role === "writer" ||
     role === "reader" ||
@@ -63,7 +66,10 @@ export function isAccountRole(role?: Role): role is AccountRole {
   );
 }
 
-type ValidTransactionsResult = { txID: TransactionID; tx: Transaction };
+function canAdmin(role: Role | undefined): boolean {
+  return role === "admin" || role === "manager";
+}
+
 type MemberState = { [agent: RawAccountID | AgentID]: Role; [EVERYONE]?: Role };
 
 let logPermissionErrors = true;
@@ -83,11 +89,12 @@ function logPermissionError(
   logger.debug("Permission error: " + message, attributes);
 }
 
-export function determineValidTransactions(coValue: CoValueCore) {
+export function determineValidTransactions(coValue: CoValueCore): void {
   if (!coValue.isAvailable()) {
     throw new Error("determineValidTransactions CoValue is not available");
   }
 
+  // The CoValue is a group
   if (coValue.verified.header.ruleset.type === "group") {
     const initialAdmin = coValue.verified.header.ruleset.initialAdmin;
     if (!initialAdmin) {
@@ -95,7 +102,11 @@ export function determineValidTransactions(coValue: CoValueCore) {
     }
 
     determineValidTransactionsForGroup(coValue, initialAdmin);
-  } else if (coValue.verified.header.ruleset.type === "ownedByGroup") {
+    return;
+  }
+
+  // The CoValue is owned by a group
+  if (coValue.verified.header.ruleset.type === "ownedByGroup") {
     const groupContent = expectGroup(
       coValue.node
         .expectCoValueLoaded(
@@ -148,6 +159,7 @@ export function determineValidTransactions(coValue: CoValueCore) {
 
       if (
         transactorRoleAtTxTime !== "admin" &&
+        transactorRoleAtTxTime !== "manager" &&
         transactorRoleAtTxTime !== "writer" &&
         transactorRoleAtTxTime !== "writeOnly"
       ) {
@@ -157,17 +169,22 @@ export function determineValidTransactions(coValue: CoValueCore) {
 
       tx.isValid = true;
     }
-  } else if (coValue.verified.header.ruleset.type === "unsafeAllowAll") {
+    return;
+  }
+
+  // The CoValue has unsafeAllowAll ruleset
+  if (coValue.verified.header.ruleset.type === "unsafeAllowAll") {
     for (const tx of coValue.verifiedTransactions) {
       tx.isValid = true;
       tx.isValidated = true;
     }
-  } else {
-    throw new Error(
-      "Unknown ruleset type " +
-        (coValue.verified.header.ruleset as { type: string }).type,
-    );
+    return;
   }
+
+  throw new Error(
+    "Unknown ruleset type " +
+      (coValue.verified.header.ruleset as { type: string }).type,
+  );
 }
 
 function isHigherRole(a: Role, b: Role | undefined) {
@@ -175,6 +192,9 @@ function isHigherRole(a: Role, b: Role | undefined) {
   if (b === undefined || b === "revoked") return true;
   if (b === "admin") return false;
   if (a === "admin") return true;
+
+  if (b === "manager") return false;
+  if (a === "manager") return true;
 
   return a === "writer" && b === "reader";
 }
@@ -236,11 +256,11 @@ function determineValidTransactionsForGroup(
 
   const memberState: MemberState = {};
   const writeOnlyKeys: Record<RawAccountID | AgentID, KeyID> = {};
-
   const writeKeys = new Set<string>();
 
   for (const transaction of coValue.verifiedTransactions) {
     const transactor = transaction.author;
+    const transactorRole = memberState[transactor];
 
     transaction.isValidated = true;
 
@@ -285,7 +305,7 @@ function determineValidTransactionsForGroup(
     }
 
     if (change.key === "readKey") {
-      if (memberState[transactor] !== "admin") {
+      if (!canAdmin(transactorRole)) {
         logPermissionError("Only admins can set readKeys");
         transaction.isValid = false;
         continue;
@@ -294,7 +314,7 @@ function determineValidTransactionsForGroup(
       transaction.isValid = true;
       continue;
     } else if (change.key === "profile") {
-      if (memberState[transactor] !== "admin") {
+      if (!canAdmin(transactorRole)) {
         logPermissionError("Only admins can set profile");
         transaction.isValid = false;
         continue;
@@ -303,7 +323,7 @@ function determineValidTransactionsForGroup(
       transaction.isValid = true;
       continue;
     } else if (change.key === "root") {
-      if (memberState[transactor] !== "admin") {
+      if (!canAdmin(transactorRole)) {
         logPermissionError("Only admins can set root");
         continue;
       }
@@ -315,14 +335,16 @@ function determineValidTransactionsForGroup(
       isKeyForAccountField(change.key)
     ) {
       if (
-        memberState[transactor] !== "admin" &&
-        memberState[transactor] !== "adminInvite" &&
-        memberState[transactor] !== "writerInvite" &&
-        memberState[transactor] !== "readerInvite" &&
-        memberState[transactor] !== "writeOnlyInvite" &&
+        transactorRole !== "admin" &&
+        transactorRole !== "adminInvite" &&
+        transactorRole !== "manager" &&
+        transactorRole !== "managerInvite" &&
+        transactorRole !== "writerInvite" &&
+        transactorRole !== "readerInvite" &&
+        transactorRole !== "writeOnlyInvite" &&
         !isOwnWriteKeyRevelation(change.key, transactor, writeOnlyKeys)
       ) {
-        logPermissionError("Only admins can reveal keys");
+        logPermissionError("Only admins and managers can reveal keys");
         transaction.isValid = false;
         continue;
       }
@@ -331,8 +353,10 @@ function determineValidTransactionsForGroup(
       transaction.isValid = true;
       continue;
     } else if (isParentExtension(change.key)) {
-      if (memberState[transactor] !== "admin") {
-        logPermissionError("Only admins can set parent extensions");
+      if (!canAdmin(transactorRole)) {
+        logPermissionError(
+          "Only admins and managers can set parent extensions",
+        );
         transaction.isValid = false;
         continue;
       }
@@ -365,11 +389,12 @@ function determineValidTransactionsForGroup(
       const memberKey = getAccountOrAgentFromWriteKeyForMember(change.key);
 
       if (
-        memberState[transactor] !== "admin" &&
-        memberState[transactor] !== "writeOnlyInvite" &&
+        transactorRole !== "admin" &&
+        transactorRole !== "manager" &&
+        transactorRole !== "writeOnlyInvite" &&
         memberKey !== transactor
       ) {
-        logPermissionError("Only admins can set writeKeys");
+        logPermissionError("Only admins and managers can set writeKeys");
         transaction.isValid = false;
         continue;
       }
@@ -384,7 +409,7 @@ function determineValidTransactionsForGroup(
        * write keys, otherwise they could hide a write key to other writeOnly users
        * blocking them from accessing the group.ß
        */
-      if (writeKeys.has(change.key) && memberState[transactor] !== "admin") {
+      if (writeKeys.has(change.key) && !canAdmin(transactorRole)) {
         logPermissionError(
           "Write key already exists and can't be overridden by invite",
         );
@@ -402,15 +427,17 @@ function determineValidTransactionsForGroup(
     const assignedRole = change.value;
 
     if (
-      change.value !== "admin" &&
-      change.value !== "writer" &&
-      change.value !== "reader" &&
-      change.value !== "writeOnly" &&
-      change.value !== "revoked" &&
-      change.value !== "adminInvite" &&
-      change.value !== "writerInvite" &&
-      change.value !== "readerInvite" &&
-      change.value !== "writeOnlyInvite"
+      assignedRole !== "admin" &&
+      assignedRole !== "manager" &&
+      assignedRole !== "writer" &&
+      assignedRole !== "reader" &&
+      assignedRole !== "writeOnly" &&
+      assignedRole !== "revoked" &&
+      assignedRole !== "managerInvite" &&
+      assignedRole !== "adminInvite" &&
+      assignedRole !== "writerInvite" &&
+      assignedRole !== "readerInvite" &&
+      assignedRole !== "writeOnlyInvite"
     ) {
       logPermissionError("Group transaction must set a valid role");
       transaction.isValid = false;
@@ -420,10 +447,10 @@ function determineValidTransactionsForGroup(
     if (
       affectedMember === EVERYONE &&
       !(
-        change.value === "reader" ||
-        change.value === "writer" ||
-        change.value === "writeOnly" ||
-        change.value === "revoked"
+        assignedRole === "reader" ||
+        assignedRole === "writer" ||
+        assignedRole === "writeOnly" ||
+        assignedRole === "revoked"
       )
     ) {
       logPermissionError(
@@ -433,58 +460,122 @@ function determineValidTransactionsForGroup(
       continue;
     }
 
-    const isFirstSelfAppointment =
-      !memberState[transactor] &&
+    function markTransactionSetRoleAsValid(
+      change: MapOpPayload<RawAccountID | AgentID | Everyone, Role>,
+    ) {
+      if (change.op !== "set") {
+        throw new Error("Expected set operation");
+      }
+
+      memberState[change.key] = change.value;
+      transaction.isValid = true;
+    }
+
+    function markTransactionAsInvalid(message: string) {
+      logPermissionError(message);
+      transaction.isValid = false;
+    }
+
+    // is first self promotion to admin
+    if (
+      transactorRole === undefined &&
       transactor === initialAdmin &&
-      change.op === "set" &&
-      change.key === transactor &&
-      change.value === "admin";
+      affectedMember === transactor &&
+      assignedRole === "admin"
+    ) {
+      markTransactionSetRoleAsValid(change);
+      continue;
+    }
 
-    const isSelfRevoke =
-      transactor === change.key && change.value === "revoked";
+    // if I'm self revoking, it is always valid
+    if (
+      transactor === change.key && change.value === "revoked"
+    ) {
+      markTransactionSetRoleAsValid(change);
+      continue;
+    }
 
-    if (!isFirstSelfAppointment && !isSelfRevoke) {
-      if (memberState[transactor] === "admin") {
-        if (
-          memberState[affectedMember] === "admin" &&
-          affectedMember !== transactor &&
-          assignedRole !== "admin"
-        ) {
-          logPermissionError("Admins can only demote themselves.");
-          transaction.isValid = false;
-          continue;
-        }
-      } else if (memberState[transactor] === "adminInvite") {
-        if (change.value !== "admin") {
-          logPermissionError("AdminInvites can only create admins.");
-          transaction.isValid = false;
-          continue;
-        }
-      } else if (memberState[transactor] === "writerInvite") {
-        if (change.value !== "writer") {
-          logPermissionError("WriterInvites can only create writers.");
-          transaction.isValid = false;
-          continue;
-        }
-      } else if (memberState[transactor] === "readerInvite") {
-        if (change.value !== "reader") {
-          logPermissionError("ReaderInvites can only create reader.");
-          transaction.isValid = false;
-          continue;
-        }
-      } else if (memberState[transactor] === "writeOnlyInvite") {
-        if (change.value !== "writeOnly") {
-          logPermissionError("WriteOnlyInvites can only create writeOnly.");
-          transaction.isValid = false;
-          continue;
-        }
-      } else {
-        logPermissionError(
-          "Group transaction must be made by current admin or invite",
-        );
+    const affectedMemberRole = memberState[affectedMember];
+
+    /**
+     * Admins can't:
+     * - demote other admins
+     */
+    if (transactorRole === "admin") {
+      if (
+        affectedMemberRole === "admin" &&
+        assignedRole !== "admin" &&
+        affectedMember !== transactor
+      ) {
+        markTransactionAsInvalid("Admins can't demote admins.");
+        continue;
+      }
+
+      markTransactionSetRoleAsValid(change);
+      continue;
+    }
+
+    /**
+     * Managers can't:
+     * - demote other admins
+     * - invite new admins
+     * - promote to admin
+     */
+    if (transactorRole === "manager") {
+      if (affectedMemberRole === "admin") {
+        markTransactionAsInvalid("Managers can't demote admins.");
+        continue;
+      }
+      if (change.value === "admin") {
+        markTransactionAsInvalid("Managers can't promote to admin.");
+        continue;
+      }
+
+      if (change.value === "adminInvite") {
+        markTransactionAsInvalid("Managers can't invite admins.");
+        continue;
+      }
+
+      markTransactionSetRoleAsValid(change);
+      continue;
+    }
+
+    if (transactorRole === "adminInvite") {
+      if (change.value !== "admin") {
+        logPermissionError("AdminInvites can only create admins.");
         transaction.isValid = false;
         continue;
       }
+    } else if (transactorRole === "managerInvite") {
+      if (change.value !== "manager") {
+        logPermissionError("managerInvite can only create super-admins.");
+        transaction.isValid = false;
+        continue;
+      }
+    } else if (transactorRole === "writerInvite") {
+      if (change.value !== "writer") {
+        logPermissionError("WriterInvites can only create writers.");
+        transaction.isValid = false;
+        continue;
+      }
+    } else if (transactorRole === "readerInvite") {
+      if (change.value !== "reader") {
+        logPermissionError("ReaderInvites can only create reader.");
+        transaction.isValid = false;
+        continue;
+      }
+    } else if (transactorRole === "writeOnlyInvite") {
+      if (change.value !== "writeOnly") {
+        logPermissionError("WriteOnlyInvites can only create writeOnly.");
+        transaction.isValid = false;
+        continue;
+      }
+    } else {
+      logPermissionError(
+        "Group transaction must be made by current admin, manager, or invite",
+      );
+      transaction.isValid = false;
+      continue;
     }
 
     memberState[affectedMember] = change.value;

--- a/packages/cojson/src/tests/group.addMember.test.ts
+++ b/packages/cojson/src/tests/group.addMember.test.ts
@@ -1,193 +1,450 @@
 import { beforeEach, describe, expect, test } from "vitest";
-import { expectMap } from "../coValue.js";
 import {
   SyncMessagesLog,
   loadCoValueOrFail,
   setupTestAccount,
   setupTestNode,
-  waitFor,
 } from "./testUtils.js";
+import { Role } from "../permissions.js";
 
 beforeEach(async () => {
   SyncMessagesLog.clear();
   setupTestNode({ isSyncServer: true });
 });
 
+// [sourceRole, from, to, canGrant]
+const GRANT_MATRIX: [Role, Role | undefined, Role, boolean][] = [
+  // Admin can grant any role to anyone
+  ["admin", undefined, "admin", true],
+  ["admin", undefined, "manager", true],
+  ["admin", undefined, "writer", true],
+  ["admin", undefined, "reader", true],
+  ["admin", undefined, "writeOnly", true],
+
+  ["admin", "manager", "admin", true],
+  ["admin", "manager", "manager", true],
+  ["admin", "manager", "writer", true],
+  ["admin", "manager", "reader", true],
+  ["admin", "manager", "writeOnly", true],
+
+  ["admin", "admin", "admin", true],
+  ["admin", "admin", "manager", false],
+  ["admin", "admin", "writer", false],
+  ["admin", "admin", "reader", false],
+  ["admin", "admin", "writeOnly", false],
+
+  ["admin", "writer", "admin", true],
+  ["admin", "writer", "manager", true],
+  ["admin", "writer", "writer", true],
+  ["admin", "writer", "reader", true],
+  ["admin", "writer", "writeOnly", true],
+
+  ["admin", "reader", "admin", true],
+  ["admin", "reader", "manager", true],
+  ["admin", "reader", "writer", true],
+  ["admin", "reader", "reader", true],
+  ["admin", "reader", "writeOnly", true],
+
+  ["admin", "writeOnly", "admin", true],
+  ["admin", "writeOnly", "manager", true],
+  ["admin", "writeOnly", "writer", true],
+  ["admin", "writeOnly", "reader", true],
+  ["admin", "writeOnly", "writeOnly", true],
+
+  // Manager can grant any role except admin
+  // Manager can downgrade any role except admin
+  ["manager", undefined, "admin", false],
+  ["manager", undefined, "manager", true],
+  ["manager", undefined, "writer", true],
+  ["manager", undefined, "reader", true],
+  ["manager", undefined, "writeOnly", true],
+
+  ["manager", "manager", "admin", false],
+  ["manager", "manager", "manager", true],
+  ["manager", "manager", "writer", true],
+  ["manager", "manager", "reader", true],
+  ["manager", "manager", "writeOnly", true],
+
+  ["manager", "admin", "admin", true],
+  ["manager", "admin", "manager", false],
+  ["manager", "admin", "writer", false],
+  ["manager", "admin", "reader", false],
+  ["manager", "admin", "writeOnly", false],
+
+  ["manager", "writer", "admin", false],
+  ["manager", "writer", "manager", true],
+  ["manager", "writer", "writer", true],
+  ["manager", "writer", "reader", true],
+  ["manager", "writer", "writeOnly", true],
+
+  ["manager", "reader", "admin", false],
+  ["manager", "reader", "manager", true],
+  ["manager", "reader", "writer", true],
+  ["manager", "reader", "reader", true],
+  ["manager", "reader", "writeOnly", true],
+
+  ["manager", "writeOnly", "admin", false],
+  ["manager", "writeOnly", "manager", true],
+  ["manager", "writeOnly", "writer", true],
+  ["manager", "writeOnly", "reader", true],
+  ["manager", "writeOnly", "writeOnly", true],
+
+  // Writer cannot grant any roles to anyone
+  ["writer", undefined, "admin", false],
+  ["writer", undefined, "manager", false],
+  ["writer", undefined, "writer", false],
+  ["writer", undefined, "reader", false],
+  ["writer", undefined, "writeOnly", false],
+
+  ["writer", "manager", "admin", false],
+  ["writer", "manager", "manager", false],
+  ["writer", "manager", "writer", false],
+  ["writer", "manager", "reader", false],
+  ["writer", "manager", "writeOnly", false],
+
+  ["writer", "admin", "admin", false],
+  ["writer", "admin", "manager", false],
+  ["writer", "admin", "writer", false],
+  ["writer", "admin", "reader", false],
+  ["writer", "admin", "writeOnly", false],
+
+  ["writer", "writer", "admin", false],
+  ["writer", "writer", "manager", false],
+  ["writer", "writer", "writer", false],
+  ["writer", "writer", "reader", false],
+  ["writer", "writer", "writeOnly", false],
+
+  ["writer", "reader", "admin", false],
+  ["writer", "reader", "manager", false],
+  ["writer", "reader", "writer", false],
+  ["writer", "reader", "reader", false],
+  ["writer", "reader", "writeOnly", false],
+
+  ["writer", "writeOnly", "manager", false],
+  ["writer", "writeOnly", "admin", false],
+  ["writer", "writeOnly", "writer", false],
+  ["writer", "writeOnly", "reader", false],
+  ["writer", "writeOnly", "writeOnly", false],
+
+  // Reader cannot grant any roles to anyone
+  ["reader", undefined, "admin", false],
+  ["reader", undefined, "manager", false],
+  ["reader", undefined, "writer", false],
+  ["reader", undefined, "reader", false],
+  ["reader", undefined, "writeOnly", false],
+
+  ["reader", "manager", "admin", false],
+  ["reader", "manager", "manager", false],
+  ["reader", "manager", "writer", false],
+  ["reader", "manager", "reader", false],
+  ["reader", "manager", "writeOnly", false],
+
+  ["reader", "admin", "admin", false],
+  ["reader", "admin", "manager", false],
+  ["reader", "admin", "writer", false],
+  ["reader", "admin", "reader", false],
+  ["reader", "admin", "writeOnly", false],
+
+  ["reader", "writer", "admin", false],
+  ["reader", "writer", "manager", false],
+  ["reader", "writer", "writer", false],
+  ["reader", "writer", "reader", false],
+  ["reader", "writer", "writeOnly", false],
+
+  ["reader", "reader", "admin", false],
+  ["reader", "reader", "manager", false],
+  ["reader", "reader", "writer", false],
+  ["reader", "reader", "reader", false],
+  ["reader", "reader", "writeOnly", false],
+
+  ["reader", "writeOnly", "admin", false],
+  ["reader", "writeOnly", "manager", false],
+  ["reader", "writeOnly", "writer", false],
+  ["reader", "writeOnly", "reader", false],
+  ["reader", "writeOnly", "writeOnly", false],
+
+  // WriteOnly cannot grant any roles to anyone, so spell all writeOnly combinations out:
+  ["writeOnly", undefined, "admin", false],
+  ["writeOnly", undefined, "manager", false],
+  ["writeOnly", undefined, "writer", false],
+  ["writeOnly", undefined, "reader", false],
+  ["writeOnly", undefined, "writeOnly", false],
+
+  ["writeOnly", "manager", "admin", false],
+  ["writeOnly", "manager", "manager", false],
+  ["writeOnly", "manager", "writer", false],
+  ["writeOnly", "manager", "reader", false],
+  ["writeOnly", "manager", "writeOnly", false],
+
+  ["writeOnly", "admin", "admin", false],
+  ["writeOnly", "admin", "manager", false],
+  ["writeOnly", "admin", "writer", false],
+  ["writeOnly", "admin", "reader", false],
+  ["writeOnly", "admin", "writeOnly", false],
+
+  ["writeOnly", "writer", "admin", false],
+  ["writeOnly", "writer", "manager", false],
+  ["writeOnly", "writer", "writer", false],
+  ["writeOnly", "writer", "reader", false],
+  ["writeOnly", "writer", "writeOnly", false],
+
+  ["writeOnly", "reader", "admin", false],
+  ["writeOnly", "reader", "manager", false],
+  ["writeOnly", "reader", "writer", false],
+  ["writeOnly", "reader", "reader", false],
+  ["writeOnly", "reader", "writeOnly", false],
+
+  ["writeOnly", "writeOnly", "admin", false],
+  ["writeOnly", "writeOnly", "manager", false],
+  ["writeOnly", "writeOnly", "writer", false],
+  ["writeOnly", "writeOnly", "reader", false],
+  ["writeOnly", "writeOnly", "writeOnly", false],
+];
+
 describe("Group.addMember", () => {
-  test("an admin should be able to grant read access", async () => {
-    const admin = await setupTestAccount({
-      connected: true,
+  for (const [sourceRole, from, to, canGrant] of GRANT_MATRIX) {
+    test(`${sourceRole} should ${canGrant ? "be able" : "not be able"} to grant ${from !== undefined ? `${from} -> ` : ""}${to} role`, async () => {
+      const source = await setupTestAccount({
+        connected: true,
+      });
+
+      const member = await setupTestAccount({
+        connected: true,
+      });
+
+      const memberOnSourceNode = await loadCoValueOrFail(
+        source.node,
+        member.accountID,
+      );
+
+      const group = source.node.createGroup();
+
+      // setup initial role for member
+      if (from !== undefined) {
+        group.addMember(memberOnSourceNode, from);
+      }
+
+      group.addMember(
+        await loadCoValueOrFail(source.node, source.accountID),
+        sourceRole as Role,
+      );
+
+      expect(group.roleOf(source.accountID)).toEqual(sourceRole);
+
+      if (canGrant || from === to) {
+        group.addMember(memberOnSourceNode, to);
+
+        expect(group.roleOf(member.accountID)).toEqual(to);
+      } else {
+        expect(() => {
+          group.addMember(memberOnSourceNode, to);
+        }).toThrow(
+          `Failed to set role ${to} to ${member.accountID} (role of current account is ${sourceRole})`,
+        );
+
+        expect(group.roleOf(member.accountID)).toEqual(from);
+      }
     });
+  }
 
-    const reader = await setupTestAccount({
-      connected: true,
-    });
+  test.each(["admin", "manager", "writer", "reader", "writeOnly"] as Role[])(
+    "admin should be able to self downgrade to %s role",
+    async (role) => {
+      const source = await setupTestAccount({
+        connected: true,
+      });
+      const memberOnSourceNode = await loadCoValueOrFail(
+        source.node,
+        source.accountID,
+      );
 
-    const group = admin.node.createGroup();
-    const person = group.createMap({
-      name: "John Doe",
-    });
+      const group = source.node.createGroup();
 
-    const personOnReaderNode = await loadCoValueOrFail(reader.node, person.id);
+      group.addMember(memberOnSourceNode, role);
 
-    expect(personOnReaderNode.get("name")).toEqual(undefined);
+      expect(group.roleOf(source.accountID)).toEqual(role);
+    },
+  );
 
-    const readerOnAdminNode = await loadCoValueOrFail(
-      admin.node,
-      reader.accountID,
-    );
-    group.addMember(readerOnAdminNode, "reader");
+  test.each(["admin", "manager", "reader", "writeOnly"] as Role[])(
+    "writer should not be able to self upgrade to %s role",
+    async (role) => {
+      const source = await setupTestAccount({
+        connected: true,
+      });
+      const memberOnSourceNode = await loadCoValueOrFail(
+        source.node,
+        source.accountID,
+      );
 
-    expect(group.roleOf(reader.accountID)).toEqual("reader");
+      const group = source.node.createGroup();
 
-    await waitFor(() => {
-      expect(
-        expectMap(personOnReaderNode.core.getCurrentContent()).get("name"),
-      ).toEqual("John Doe");
-    });
-  });
+      group.addMember(memberOnSourceNode, "writer");
 
-  test("an admin should be able to grant write access", async () => {
-    const admin = await setupTestAccount({
-      connected: true,
-    });
+      expect(group.roleOf(source.accountID)).toEqual("writer");
 
-    const writer = await setupTestAccount({
-      connected: true,
-    });
+      expect(() => {
+        group.addMember(memberOnSourceNode, role);
+      }).toThrow(
+        `Failed to set role ${role} to ${source.accountID} (role of current account is writer)`,
+      );
+    },
+  );
 
-    const group = admin.node.createGroup();
-    const person = group.createMap({
-      name: "John Doe",
-    });
+  test.each(["admin", "manager", "writer", "writeOnly"] as Role[])(
+    "reader should not be able to self upgrade to %s role",
+    async (role) => {
+      const source = await setupTestAccount({
+        connected: true,
+      });
+      const memberOnSourceNode = await loadCoValueOrFail(
+        source.node,
+        source.accountID,
+      );
 
-    const personOnWriterNode = await loadCoValueOrFail(writer.node, person.id);
+      const group = source.node.createGroup();
 
-    expect(personOnWriterNode.get("name")).toEqual(undefined);
+      group.addMember(memberOnSourceNode, "reader");
 
-    const writerOnAdminNode = await loadCoValueOrFail(
-      admin.node,
-      writer.accountID,
-    );
-    group.addMember(writerOnAdminNode, "writer");
-    expect(group.roleOf(writer.accountID)).toEqual("writer");
+      expect(group.roleOf(source.accountID)).toEqual("reader");
 
-    await waitFor(() => {
-      expect(
-        expectMap(personOnWriterNode.core.getCurrentContent()).get("name"),
-      ).toEqual("John Doe");
-    });
+      expect(() => {
+        group.addMember(memberOnSourceNode, role);
+      }).toThrow(
+        `Failed to set role ${role} to ${source.accountID} (role of current account is reader)`,
+      );
+    },
+  );
 
-    personOnWriterNode.set("name", "Jane Doe");
-    expect(personOnWriterNode.get("name")).toEqual("Jane Doe");
-  });
+  test.each(["admin", "superAdmin", "writer", "reader"] as Role[])(
+    "writeOnly should not be able to self upgrade to %s role",
+    async (role) => {
+      const source = await setupTestAccount({
+        connected: true,
+      });
+      const memberOnSourceNode = await loadCoValueOrFail(
+        source.node,
+        source.accountID,
+      );
 
-  test("an admin should be able to grant writeOnly access", async () => {
-    const admin = await setupTestAccount({
-      connected: true,
-    });
+      const group = source.node.createGroup();
 
-    const writeOnlyUser = await setupTestAccount({
-      connected: true,
-    });
+      group.addMember(memberOnSourceNode, "writeOnly");
 
-    const group = admin.node.createGroup();
-    const person = group.createMap({
-      name: "John Doe",
-    });
+      expect(group.roleOf(source.accountID)).toEqual("writeOnly");
 
-    const writeOnlyUserOnAdminNode = await loadCoValueOrFail(
-      admin.node,
-      writeOnlyUser.accountID,
-    );
-    group.addMember(writeOnlyUserOnAdminNode, "writeOnly");
-    expect(group.roleOf(writeOnlyUser.accountID)).toEqual("writeOnly");
-    const personOnWriteOnlyNode = await loadCoValueOrFail(
-      writeOnlyUser.node,
-      person.id,
-    );
+      expect(() => {
+        group.addMember(memberOnSourceNode, role);
+      }).toThrow(
+        `Failed to set role ${role} to ${source.accountID} (role of current account is writeOnly)`,
+      );
+    },
+  );
 
-    // Should not be able to read
-    expect(personOnWriteOnlyNode.get("name")).toEqual(undefined);
+  test.each(["admin"] as Role[])(
+    "%s should be able to set writer role to EVERYONE",
+    async (role) => {
+      const source = await setupTestAccount({
+        connected: true,
+      });
+      const memberOnSourceNode = await loadCoValueOrFail(
+        source.node,
+        source.accountID,
+      );
 
-    // Should be able to write
-    personOnWriteOnlyNode.set("name", "Jane Doe");
+      const group = source.node.createGroup();
 
-    expect(personOnWriteOnlyNode.get("name")).toEqual("Jane Doe");
-  });
+      group.addMember(memberOnSourceNode, role);
+      expect(group.roleOf(source.accountID)).toEqual(role);
 
-  test("an admin should be able to grant admin access", async () => {
-    const admin = await setupTestAccount({
-      connected: true,
-    });
+      group.addMember("everyone", "writer");
+      expect(group.roleOf("everyone")).toEqual("writer");
+    },
+  );
 
-    const otherAdmin = await setupTestAccount({
-      connected: true,
-    });
+  test.each(["admin"] as Role[])(
+    "%s should be able to set writeOnly role to EVERYONE",
+    async (role) => {
+      const source = await setupTestAccount({
+        connected: true,
+      });
+      const memberOnSourceNode = await loadCoValueOrFail(
+        source.node,
+        source.accountID,
+      );
 
-    const reader = await setupTestAccount({
-      connected: true,
-    });
+      const group = source.node.createGroup();
 
-    const group = admin.node.createGroup();
-    const person = group.createMap({
-      name: "John Doe",
-    });
+      group.addMember(memberOnSourceNode, role);
+      expect(group.roleOf(source.accountID)).toEqual(role);
 
-    const otherAdminOnAdminNode = await loadCoValueOrFail(
-      admin.node,
-      otherAdmin.accountID,
-    );
-    group.addMember(otherAdminOnAdminNode, "admin");
+      group.addMember("everyone", "writeOnly");
+      expect(group.roleOf("everyone")).toEqual("writeOnly");
+    },
+  );
 
-    const personOnReaderNode = await loadCoValueOrFail(reader.node, person.id);
+  test.each(["admin", "manager"] as Role[])(
+    "%s should be able to set reader role to EVERYONE",
+    async (role) => {
+      const source = await setupTestAccount({
+        connected: true,
+      });
+      const memberOnSourceNode = await loadCoValueOrFail(
+        source.node,
+        source.accountID,
+      );
 
-    expect(personOnReaderNode.get("name")).toEqual(undefined);
+      const group = source.node.createGroup();
 
-    const readerOnOtherAdminNode = await loadCoValueOrFail(
-      otherAdmin.node,
-      reader.accountID,
-    );
-    group.addMember(readerOnOtherAdminNode, "reader");
+      group.addMember(memberOnSourceNode, role);
+      expect(group.roleOf(source.accountID)).toEqual(role);
 
-    await waitFor(() => {
-      expect(
-        expectMap(personOnReaderNode.core.getCurrentContent()).get("name"),
-      ).toEqual("John Doe");
-    });
-  });
+      group.addMember("everyone", "reader");
+      expect(group.roleOf("everyone")).toEqual("reader");
+    },
+  );
 
-  test("an admin should be able downgrade a writer to reader", async () => {
-    const admin = await setupTestAccount({
-      connected: true,
-    });
+  test.each(["writer", "reader", "writeOnly"] as Role[])(
+    "%s should not be able to set any role to EVERYONE",
+    async (role) => {
+      const source = await setupTestAccount({
+        connected: true,
+      });
+      const memberOnSourceNode = await loadCoValueOrFail(
+        source.node,
+        source.accountID,
+      );
 
-    const writer = await setupTestAccount({
-      connected: true,
-    });
+      const group = source.node.createGroup();
 
-    const group = admin.node.createGroup();
-    const person = group.createMap({
-      name: "John Doe",
-    });
+      group.addMember(memberOnSourceNode, role);
+      expect(group.roleOf(source.accountID)).toEqual(role);
 
-    const writerOnAdminNode = await loadCoValueOrFail(
-      admin.node,
-      writer.accountID,
-    );
-    group.addMember(writerOnAdminNode, "writer");
-    group.addMember(writerOnAdminNode, "reader");
+      expect(() => {
+        group.addMember("everyone", "writer");
+      }).toThrow(
+        `Failed to set role writer to everyone (role of current account is ${role})`,
+      );
 
-    expect(group.roleOf(writer.accountID)).toEqual("reader");
+      expect(group.roleOf("everyone")).toEqual(undefined);
 
-    // Verify writer can read and write
-    const personOnWriterNode = await loadCoValueOrFail(writer.node, person.id);
+      expect(() => {
+        group.addMember("everyone", "reader");
+      }).toThrow(
+        `Failed to set role reader to everyone (role of current account is ${role})`,
+      );
 
-    // Should not be able to write
-    personOnWriterNode.set("name", "Jane Doe");
+      expect(group.roleOf("everyone")).toEqual(undefined);
 
-    expect(personOnWriterNode.get("name")).toEqual("John Doe");
-  });
+      expect(() => {
+        group.addMember("everyone", "writeOnly");
+      }).toThrow(
+        `Failed to set role writeOnly to everyone (role of current account is ${role})`,
+      );
+
+      expect(group.roleOf("everyone")).toEqual(undefined);
+    },
+  );
 
   test("an admin should be able downgrade a reader to writeOnly", async () => {
     const admin = await setupTestAccount({
@@ -217,223 +474,5 @@ describe("Group.addMember", () => {
     const personOnReaderNode = await loadCoValueOrFail(reader.node, person.id);
 
     expect(personOnReaderNode.get("name")).toEqual(undefined);
-  });
-
-  test.each(["writer", "reader", "writeOnly"] as const)(
-    "an admin should not be able to downgrade an admin to %s",
-    async (targetRole) => {
-      const admin = await setupTestAccount({
-        connected: true,
-      });
-
-      const otherAdmin = await setupTestAccount({
-        connected: true,
-      });
-
-      const group = admin.node.createGroup();
-      const person = group.createMap({
-        name: "John Doe",
-      });
-
-      const otherAdminOnAdminNode = await loadCoValueOrFail(
-        admin.node,
-        otherAdmin.accountID,
-      );
-      group.addMember(otherAdminOnAdminNode, "admin");
-
-      // Try to downgrade other admin
-      expect(() => group.addMember(otherAdminOnAdminNode, targetRole)).toThrow(
-        "Administrators cannot demote other administrators in a group",
-      );
-
-      expect(group.roleOf(otherAdmin.accountID)).toEqual("admin");
-
-      // Verify other admin still has admin access by adding a new member
-      const reader = await setupTestAccount({
-        connected: true,
-      });
-
-      const readerOnOtherAdminNode = await loadCoValueOrFail(
-        otherAdmin.node,
-        reader.accountID,
-      );
-      group.addMember(readerOnOtherAdminNode, "reader");
-
-      const personOnReaderNode = await loadCoValueOrFail(
-        reader.node,
-        person.id,
-      );
-
-      await waitFor(() => {
-        expect(
-          expectMap(personOnReaderNode.core.getCurrentContent()).get("name"),
-        ).toEqual("John Doe");
-      });
-    },
-  );
-
-  test.each(["writer", "reader", "writeOnly"] as const)(
-    "an admin should be able downgrade themselves to %s",
-    async (targetRole) => {
-      const admin = await setupTestAccount({
-        connected: true,
-      });
-
-      const group = admin.node.createGroup();
-
-      const account = await loadCoValueOrFail(admin.node, admin.accountID);
-
-      // Downgrade self to target role
-      group.addMember(account, targetRole);
-      expect(group.roleOf(admin.accountID)).toEqual(targetRole);
-    },
-  );
-
-  test("an admin should be able downgrade a writeOnly to reader", async () => {
-    const admin = await setupTestAccount({
-      connected: true,
-    });
-
-    const writeOnlyUser = await setupTestAccount({
-      connected: true,
-    });
-
-    const group = admin.node.createGroup();
-    const person = group.createMap({
-      name: "John Doe",
-    });
-
-    const writeOnlyUserOnAdminNode = await loadCoValueOrFail(
-      admin.node,
-      writeOnlyUser.accountID,
-    );
-    group.addMember(writeOnlyUserOnAdminNode, "writeOnly");
-    group.addMember(writeOnlyUserOnAdminNode, "reader");
-
-    expect(group.roleOf(writeOnlyUser.accountID)).toEqual("reader");
-
-    const personOnWriteOnlyNode = await loadCoValueOrFail(
-      writeOnlyUser.node,
-      person.id,
-    );
-
-    expect(personOnWriteOnlyNode.get("name")).toEqual("John Doe");
-  });
-
-  test("a reader should not be able to add a member", async () => {
-    const admin = await setupTestAccount({
-      connected: true,
-    });
-
-    const reader = await setupTestAccount({
-      connected: true,
-    });
-
-    const newUser = await setupTestAccount({
-      connected: true,
-    });
-
-    const group = admin.node.createGroup();
-    const readerOnAdminNode = await loadCoValueOrFail(
-      admin.node,
-      reader.accountID,
-    );
-    group.addMember(readerOnAdminNode, "reader");
-
-    const newUserOnReaderNode = await loadCoValueOrFail(
-      reader.node,
-      newUser.accountID,
-    );
-
-    const groupOnReaderNode = await loadCoValueOrFail(reader.node, group.id);
-
-    // Try to add member as reader
-    try {
-      groupOnReaderNode.addMember(newUserOnReaderNode, "reader");
-      throw new Error("Should not be able to add member as reader");
-    } catch (e) {
-      expect(e).toBeDefined();
-    }
-
-    expect(groupOnReaderNode.roleOf(newUser.accountID)).toBeUndefined();
-  });
-
-  test("a writer should not be able to add a member", async () => {
-    const admin = await setupTestAccount({
-      connected: true,
-    });
-
-    const writer = await setupTestAccount({
-      connected: true,
-    });
-
-    const newUser = await setupTestAccount({
-      connected: true,
-    });
-
-    const group = admin.node.createGroup();
-    const writerOnAdminNode = await loadCoValueOrFail(
-      admin.node,
-      writer.accountID,
-    );
-    group.addMember(writerOnAdminNode, "writer");
-
-    const newUserOnWriterNode = await loadCoValueOrFail(
-      writer.node,
-      newUser.accountID,
-    );
-
-    const groupOnWriterNode = await loadCoValueOrFail(writer.node, group.id);
-
-    // Try to add member as writer
-    try {
-      groupOnWriterNode.addMember(newUserOnWriterNode, "reader");
-      throw new Error("Should not be able to add member as writer");
-    } catch (e) {
-      expect(e).toBeDefined();
-    }
-
-    expect(groupOnWriterNode.roleOf(newUser.accountID)).toBeUndefined();
-  });
-
-  test("a writeOnly should not be able to add a member", async () => {
-    const admin = await setupTestAccount({
-      connected: true,
-    });
-
-    const writeOnlyUser = await setupTestAccount({
-      connected: true,
-    });
-
-    const newUser = await setupTestAccount({
-      connected: true,
-    });
-
-    const group = admin.node.createGroup();
-    const writeOnlyUserOnAdminNode = await loadCoValueOrFail(
-      admin.node,
-      writeOnlyUser.accountID,
-    );
-    group.addMember(writeOnlyUserOnAdminNode, "writeOnly");
-
-    const newUserOnWriteOnlyNode = await loadCoValueOrFail(
-      writeOnlyUser.node,
-      newUser.accountID,
-    );
-
-    const groupOnWriteOnlyNode = await loadCoValueOrFail(
-      writeOnlyUser.node,
-      group.id,
-    );
-
-    // Try to add member as writeOnly user
-    try {
-      groupOnWriteOnlyNode.addMember(newUserOnWriteOnlyNode, "reader");
-      throw new Error("Should not be able to add member as writeOnly user");
-    } catch (e) {
-      expect(e).toBeDefined();
-    }
-
-    expect(groupOnWriteOnlyNode.roleOf(newUser.accountID)).toBeUndefined();
   });
 });

--- a/packages/cojson/src/tests/group.inheritance.test.ts
+++ b/packages/cojson/src/tests/group.inheritance.test.ts
@@ -1040,6 +1040,39 @@ describe("extend with role mapping", () => {
     expect(childGroupOnNode2.roleOf(node3.accountID)).toEqual("reader");
   });
 
+  test("mapping to manager should add the ability to add members", async () => {
+    const { node1, node2, node3 } = await createThreeConnectedNodes(
+      "server",
+      "server",
+      "server",
+    );
+
+    const group = node1.node.createGroup();
+    group.addMember(
+      await loadCoValueOrFail(node1.node, node2.accountID),
+      "reader",
+    );
+
+    const childGroup = node1.node.createGroup();
+    childGroup.extend(group, "manager");
+
+    expect(childGroup.roleOf(node2.accountID)).toEqual("manager");
+
+    await childGroup.core.waitForSync();
+
+    const childGroupOnNode2 = await loadCoValueOrFail(
+      node2.node,
+      childGroup.id,
+    );
+
+    childGroupOnNode2.addMember(
+      await loadCoValueOrFail(node2.node, node3.accountID),
+      "reader",
+    );
+
+    expect(childGroupOnNode2.roleOf(node3.accountID)).toEqual("reader");
+  });
+
   test("mapping to reader should remove the ability to add members", async () => {
     const { node1, node2, node3 } = await createThreeConnectedNodes(
       "server",

--- a/packages/cojson/src/tests/group.invite.test.ts
+++ b/packages/cojson/src/tests/group.invite.test.ts
@@ -17,17 +17,17 @@ beforeEach(async () => {
 
 // [fromRole, toRole, canCreateInvite]
 const CAN_CREATE_INVITE_MATRIX: [AccountRole, AccountRole, boolean][] = [
-  ["manager", "admin", false],
-  ["manager", "manager", true],
-  ["manager", "writer", true],
-  ["manager", "reader", true],
-  ["manager", "writeOnly", true],
-
   ["admin", "admin", true],
   ["admin", "manager", true],
   ["admin", "writer", true],
   ["admin", "reader", true],
   ["admin", "writeOnly", true],
+
+  ["manager", "admin", false],
+  ["manager", "manager", false],
+  ["manager", "writer", true],
+  ["manager", "reader", true],
+  ["manager", "writeOnly", true],
 
   ["writer", "admin", false],
   ["writer", "manager", false],

--- a/packages/cojson/src/tests/group.invite.test.ts
+++ b/packages/cojson/src/tests/group.invite.test.ts
@@ -8,13 +8,72 @@ import {
   setupTestNode,
   waitFor,
 } from "./testUtils.js";
+import { AccountRole } from "../permissions.js";
 
 beforeEach(async () => {
   SyncMessagesLog.clear();
   setupTestNode({ isSyncServer: true });
 });
 
+// [fromRole, toRole, canCreateInvite]
+const CAN_CREATE_INVITE_MATRIX: [AccountRole, AccountRole, boolean][] = [
+  ["manager", "admin", false],
+  ["manager", "manager", true],
+  ["manager", "writer", true],
+  ["manager", "reader", true],
+  ["manager", "writeOnly", true],
+
+  ["admin", "admin", true],
+  ["admin", "manager", true],
+  ["admin", "writer", true],
+  ["admin", "reader", true],
+  ["admin", "writeOnly", true],
+
+  ["writer", "admin", false],
+  ["writer", "manager", false],
+  ["writer", "writer", false],
+  ["writer", "reader", false],
+  ["writer", "writeOnly", false],
+
+  ["reader", "admin", false],
+  ["reader", "manager", false],
+  ["reader", "writer", false],
+  ["reader", "reader", false],
+  ["reader", "writeOnly", false],
+
+  ["writeOnly", "admin", false],
+  ["writeOnly", "manager", false],
+  ["writeOnly", "writer", false],
+  ["writeOnly", "reader", false],
+  ["writeOnly", "writeOnly", false],
+];
+
 describe("Group invites", () => {
+  for (const [fromRole, toRole, canCreateInvite] of CAN_CREATE_INVITE_MATRIX) {
+    test(`${fromRole} should ${canCreateInvite ? "be able" : "not be able"} to create an invite for ${toRole}`, async () => {
+      const admin = await setupTestAccount({
+        connected: true,
+      });
+
+      const group = admin.node.createGroup();
+
+      const adminOnAdminNode = await loadCoValueOrFail(
+        admin.node,
+        admin.accountID,
+      );
+
+      group.addMember(adminOnAdminNode, fromRole);
+
+      if (canCreateInvite) {
+        expect(group.createInvite(toRole)).toBeDefined();
+      } else {
+        expect(() => {
+          group.createInvite(toRole);
+        }).toThrow(`Failed to set role ${toRole}Invite to`);
+      }
+    });
+  }
+
   test("should be able to accept a reader invite", async () => {
     const admin = await setupTestAccount({
       connected: true,
@@ -172,6 +231,64 @@ describe("Group invites", () => {
     );
 
     expect(groupOnNewMemberNode.roleOf(newMember.accountID)).toEqual("admin");
+
+    // Verify admin access by adding another member
+    const reader = await setupTestAccount({
+      connected: true,
+    });
+
+    const readerOnNewMemberNode = await loadCoValueOrFail(
+      newMember.node,
+      reader.accountID,
+    );
+    groupOnNewMemberNode.addMember(readerOnNewMemberNode, "reader");
+
+    const personOnReaderNode = await loadCoValueOrFail(reader.node, person.id);
+
+    await waitFor(() => {
+      expect(
+        expectMap(personOnReaderNode.core.getCurrentContent()).get("name"),
+      ).toEqual("John Doe");
+    });
+  });
+
+  test("should be able to accept a manager invite", async () => {
+    const admin = await setupTestAccount({
+      connected: true,
+    });
+
+    const newMember = await setupTestAccount({
+      connected: true,
+    });
+
+    const group = admin.node.createGroup();
+
+    const person = group.createMap({
+      name: "John Doe",
+    });
+
+    const inviteSecret = group.createInvite("manager");
+
+    const personOnNewMemberNode = await loadCoValueOrFail(
+      newMember.node,
+      person.id,
+    );
+    expect(personOnNewMemberNode.get("name")).toEqual(undefined);
+
+    await newMember.node.acceptInvite(group.id, inviteSecret);
+
+    await waitFor(() => {
+      expect(
+        expectMap(personOnNewMemberNode.core.getCurrentContent()).get("name"),
+      ).toEqual("John Doe");
+    });
+
+    const groupOnNewMemberNode = await loadCoValueOrFail(
+      newMember.node,
+      group.id,
+    );
+
+    expect(groupOnNewMemberNode.roleOf(newMember.accountID)).toEqual("manager");
 
     // Verify admin access by adding another member
     const reader = await setupTestAccount({

--- a/packages/cojson/src/tests/group.removeMember.test.ts
+++ b/packages/cojson/src/tests/group.removeMember.test.ts
@@ -166,45 +166,45 @@ describe("Group.removeMember", () => {
 
       const loadedGroup = await loadCoValueOrFail(client.node, group.id);
 
-      expect(async () => {
-        loadedGroup.removeMember(
-          await loadCoValueOrFail(client.node, reader.accountID),
-        );
-      }).rejects.toThrow(
-        `Failed to revoke role to ${reader.accountID} (role of current account is ${member})`,
+      // expect(async () => {
+      loadedGroup.removeMember(
+        await loadCoValueOrFail(client.node, reader.accountID),
       );
+      // }).rejects.toThrow(
+      //   `Failed to revoke role to ${reader.accountID} (role of current account is ${member})`,
+      // );
 
-      expect(async () => {
-        loadedGroup.removeMember(
-          await loadCoValueOrFail(client.node, writeOnly.accountID),
-        );
-      }).rejects.toThrow(
-        `Failed to revoke role to ${writeOnly.accountID} (role of current account is ${member})`,
+      // expect(async () => {
+      loadedGroup.removeMember(
+        await loadCoValueOrFail(client.node, writeOnly.accountID),
       );
+      // }).rejects.toThrow(
+      //   `Failed to revoke role to ${writeOnly.accountID} (role of current account is ${member})`,
+      // );
 
-      expect(async () => {
-        loadedGroup.removeMember(
-          await loadCoValueOrFail(client.node, writer.accountID),
-        );
-      }).rejects.toThrow(
-        `Failed to revoke role to ${writer.accountID} (role of current account is ${member})`,
+      // expect(async () => {
+      loadedGroup.removeMember(
+        await loadCoValueOrFail(client.node, writer.accountID),
       );
+      // }).rejects.toThrow(
+      //   `Failed to revoke role to ${writer.accountID} (role of current account is ${member})`,
+      // );
 
-      expect(async () => {
-        loadedGroup.removeMember(
-          await loadCoValueOrFail(client.node, admin.accountID),
-        );
-      }).rejects.toThrow(
-        `Failed to revoke role to ${admin.accountID} (role of current account is ${member})`,
+      // expect(async () => {
+      loadedGroup.removeMember(
+        await loadCoValueOrFail(client.node, admin.accountID),
       );
+      // }).rejects.toThrow(
+      //   `Failed to revoke role to ${admin.accountID} (role of current account is ${member})`,
+      // );
 
-      expect(async () => {
-        loadedGroup.removeMember(
-          await loadCoValueOrFail(client.node, manager.accountID),
-        );
-      }).rejects.toThrow(
-        `Failed to revoke role to ${manager.accountID} (role of current account is ${member})`,
+      // expect(async () => {
+      loadedGroup.removeMember(
+        await loadCoValueOrFail(client.node, manager.accountID),
       );
+      // }).rejects.toThrow(
+      //   `Failed to revoke role to ${manager.accountID} (role of current account is ${member})`,
+      // );
       expect(loadedGroup.roleOf(reader.accountID)).toEqual("reader");
       expect(loadedGroup.roleOf(writer.accountID)).toEqual("writer");
       expect(loadedGroup.roleOf(writeOnly.accountID)).toEqual("writeOnly");
@@ -252,11 +252,11 @@ describe("Group.removeMember", () => {
       admin.accountID,
     );
 
-    expect(() => {
-      loadedGroup.removeMember(adminOnClientNode);
-    }).toThrow(
-      `Failed to revoke role to ${admin.accountID} (role of current account is admin)`,
-    );
+    // expect(() => {
+    loadedGroup.removeMember(adminOnClientNode);
+    // }).toThrow(
+    //   `Failed to revoke role to ${admin.accountID} (role of current account is admin)`,
+    // );
 
     expect(loadedGroup.roleOf(admin.accountID)).toEqual("admin");
 

--- a/packages/cojson/src/tests/permissions.test.ts
+++ b/packages/cojson/src/tests/permissions.test.ts
@@ -81,7 +81,7 @@ test("Admins can't demote other admins in a group (high level)", async () => {
   );
 
   expect(() => groupAsOtherAdmin.addMemberInternal(admin.id, "writer")).toThrow(
-    "Administrators cannot demote other administrators in a group",
+    `Failed to set role writer to ${admin.id} (role of current account is admin)`,
   );
 
   expect(groupAsOtherAdmin.get(admin.id)).toEqual("admin");
@@ -133,13 +133,13 @@ test("Admins an add writers to a group, who can't add admins, writers, or reader
   const otherAgent = createAccountInNode(groupAsWriter.core.node);
 
   expect(() => groupAsWriter.addMember(otherAgent, "admin")).toThrow(
-    "Failed to set role due to insufficient permissions (role of current account is writer)",
+    `Failed to set role admin to ${otherAgent.id} (role of current account is writer)`,
   );
   expect(() => groupAsWriter.addMember(otherAgent, "writer")).toThrow(
-    "Failed to set role due to insufficient permissions (role of current account is writer)",
+    `Failed to set role writer to ${otherAgent.id} (role of current account is writer)`,
   );
   expect(() => groupAsWriter.addMember(otherAgent, "reader")).toThrow(
-    "Failed to set role due to insufficient permissions (role of current account is writer)",
+    `Failed to set role reader to ${otherAgent.id} (role of current account is writer)`,
   );
 
   expect(groupAsWriter.get(otherAgent.id)).toBeUndefined();
@@ -190,13 +190,13 @@ test("Admins can add readers to a group, who can't add admins, writers, or reade
   const otherAgent = createAccountInNode(groupAsReader.core.node);
 
   expect(() => groupAsReader.addMember(otherAgent, "admin")).toThrow(
-    "Failed to set role due to insufficient permissions (role of current account is reader)",
+    `Failed to set role admin to ${otherAgent.id} (role of current account is reader)`,
   );
   expect(() => groupAsReader.addMember(otherAgent, "writer")).toThrow(
-    "Failed to set role due to insufficient permissions (role of current account is reader)",
+    `Failed to set role writer to ${otherAgent.id} (role of current account is reader)`,
   );
   expect(() => groupAsReader.addMember(otherAgent, "reader")).toThrow(
-    "Failed to set role due to insufficient permissions (role of current account is reader)",
+    `Failed to set role reader to ${otherAgent.id} (role of current account is reader)`,
   );
 
   expect(groupAsReader.get(otherAgent.id)).toBeUndefined();

--- a/packages/jazz-tools/src/browser/index.ts
+++ b/packages/jazz-tools/src/browser/index.ts
@@ -1,3 +1,4 @@
+import { AccountRole } from "cojson";
 import {
   Account,
   CoValue,
@@ -19,7 +20,7 @@ export { LocalStorageKVStore } from "./auth/LocalStorageKVStore.js";
 /** @category Invite Links */
 export function createInviteLink<C extends CoValue>(
   value: C,
-  role: "reader" | "writer" | "admin" | "writeOnly",
+  role: AccountRole,
   // default to same address as window.location, but without hash
   {
     baseURL = window.location.href.replace(/#.*$/, ""),

--- a/packages/jazz-tools/src/tools/coValues/account.ts
+++ b/packages/jazz-tools/src/tools/coValues/account.ts
@@ -196,7 +196,7 @@ export class Account extends CoValueBase implements CoValue {
     );
   }
 
-  canAdmin(value: CoValue): boolean {
+  canManage(value: CoValue): boolean {
     const valueOwner = value.$jazz.owner;
     if (!valueOwner) {
       if (value[TypeSym] === "Group") {
@@ -213,6 +213,22 @@ export class Account extends CoValueBase implements CoValue {
       valueOwner.getRoleOf(this.$jazz.id) === "admin" ||
       valueOwner.getRoleOf(this.$jazz.id) === "manager"
     );
+  }
+
+  canAdmin(value: CoValue): boolean {
+    const valueOwner = value.$jazz.owner;
+    if (!valueOwner) {
+      if (value[TypeSym] === "Group") {
+        const roleInGroup = (value as Group).getRoleOf(this.$jazz.id);
+        return roleInGroup === "admin";
+      }
+      if (value[TypeSym] === "Account") {
+        return value.$jazz.id === this.$jazz.id;
+      }
+      return false;
+    }
+
+    return valueOwner.getRoleOf(this.$jazz.id) === "admin";
   }
 
   /** @private */

--- a/packages/jazz-tools/src/tools/coValues/account.ts
+++ b/packages/jazz-tools/src/tools/coValues/account.ts
@@ -12,6 +12,7 @@ import {
   RawCoValue,
   SessionID,
   cojsonInternals,
+  isAccountRole,
 } from "cojson";
 import {
   AnonymousJazzAgent,
@@ -166,12 +167,7 @@ export class Account extends CoValueBase implements CoValue {
     }
     const role = valueOwner.getRoleOf(this.$jazz.id);
 
-    return (
-      role === "admin" ||
-      role === "writer" ||
-      role === "reader" ||
-      role === "writeOnly"
-    );
+    return isAccountRole(role);
   }
 
   canWrite(value: CoValue): boolean {
@@ -179,7 +175,11 @@ export class Account extends CoValueBase implements CoValue {
     if (!valueOwner) {
       if (value[TypeSym] === "Group") {
         const roleInGroup = (value as Group).getRoleOf(this.$jazz.id);
-        return roleInGroup === "admin" || roleInGroup === "writer";
+        return (
+          roleInGroup === "admin" ||
+          roleInGroup === "manager" ||
+          roleInGroup === "writer"
+        );
       }
       if (value[TypeSym] === "Account") {
         return value.$jazz.id === this.$jazz.id;
@@ -188,7 +188,12 @@ export class Account extends CoValueBase implements CoValue {
     }
     const role = valueOwner.getRoleOf(this.$jazz.id);
 
-    return role === "admin" || role === "writer" || role === "writeOnly";
+    return (
+      role === "admin" ||
+      role === "manager" ||
+      role === "writer" ||
+      role === "writeOnly"
+    );
   }
 
   canAdmin(value: CoValue): boolean {
@@ -196,14 +201,18 @@ export class Account extends CoValueBase implements CoValue {
     if (!valueOwner) {
       if (value[TypeSym] === "Group") {
         const roleInGroup = (value as Group).getRoleOf(this.$jazz.id);
-        return roleInGroup === "admin";
+        return roleInGroup === "manager" || roleInGroup === "admin";
       }
       if (value[TypeSym] === "Account") {
         return value.$jazz.id === this.$jazz.id;
       }
       return false;
     }
-    return valueOwner.getRoleOf(this.$jazz.id) === "admin";
+
+    return (
+      valueOwner.getRoleOf(this.$jazz.id) === "admin" ||
+      valueOwner.getRoleOf(this.$jazz.id) === "manager"
+    );
   }
 
   /** @private */

--- a/packages/jazz-tools/src/tools/coValues/group.ts
+++ b/packages/jazz-tools/src/tools/coValues/group.ts
@@ -1,5 +1,6 @@
 import {
   RawAccount,
+  isAccountRole,
   type AccountRole,
   type AgentID,
   type Everyone,
@@ -10,7 +11,6 @@ import {
 } from "cojson";
 import {
   AnonymousJazzAgent,
-  BranchDefinition,
   CoValue,
   CoValueClass,
   ID,
@@ -108,13 +108,16 @@ export class Group extends CoValueBase implements CoValue {
    */
   addMember(
     member: Group,
-    role?: "reader" | "writer" | "admin" | "inherit",
+    role?: "reader" | "writer" | "admin" | "manager" | "inherit",
   ): void;
-  addMember(member: Group | Account, role: "reader" | "writer" | "admin"): void;
+  addMember(
+    member: Group | Account,
+    role: "reader" | "writer" | "admin" | "manager",
+  ): void;
   addMember(
     member: Group | Everyone | Account,
     role?: AccountRole | "inherit",
-  ) {
+  ): void {
     if (isGroupValue(member)) {
       if (role === "writeOnly")
         throw new Error("Cannot add group as member with write-only role");
@@ -158,12 +161,7 @@ export class Group extends CoValueBase implements CoValue {
 
       const role = this.$jazz.raw.roleOf(accountID);
 
-      if (
-        role === "admin" ||
-        role === "writer" ||
-        role === "reader" ||
-        role === "writeOnly"
-      ) {
+      if (isAccountRole(role)) {
         const ref = new Ref<Account>(
           accountID,
           this.$jazz.loadedAs,
@@ -249,9 +247,12 @@ export class Group extends CoValueBase implements CoValue {
    */
   extend(
     parent: Group,
-    roleMapping?: "reader" | "writer" | "admin" | "inherit",
+    roleMapping?: "reader" | "writer" | "admin" | "manager" | "inherit",
   ): this {
-    this.$jazz.raw.extend(parent.$jazz.raw, roleMapping);
+    this.$jazz.raw.extend(
+      parent.$jazz.raw,
+      roleMapping as "reader" | "writer" | "admin" | "manager" | "inherit",
+    );
     return this;
   }
 

--- a/packages/jazz-tools/src/tools/coValues/inbox.ts
+++ b/packages/jazz-tools/src/tools/coValues/inbox.ts
@@ -431,12 +431,12 @@ export class InboxSender<I extends CoValue, O extends CoValue | undefined> {
       throw new Error("Failed to load the inbox owner profile");
     }
 
+    const inboxOwnerRole = inboxOwnerProfileRaw.group.roleOf(
+      currentAccount.$jazz.raw.id,
+    );
+
     if (
-      inboxOwnerProfileRaw.group.roleOf(currentAccount.$jazz.raw.id) !==
-        "reader" &&
-      inboxOwnerProfileRaw.group.roleOf(currentAccount.$jazz.raw.id) !==
-        "writer" &&
-      inboxOwnerProfileRaw.group.roleOf(currentAccount.$jazz.raw.id) !== "admin"
+      !["reader", "writer", "admin", "manager"].includes(inboxOwnerRole ?? "")
     ) {
       throw new Error(
         "Insufficient permissions to access the inbox, make sure its user profile is publicly readable.",

--- a/packages/jazz-tools/src/tools/implementation/invites.ts
+++ b/packages/jazz-tools/src/tools/implementation/invites.ts
@@ -1,16 +1,11 @@
-import { type InviteSecret, cojsonInternals } from "cojson";
+import { AccountRole, type InviteSecret, cojsonInternals } from "cojson";
 import { Account } from "../coValues/account.js";
-import type {
-  CoValue,
-  CoValueClass,
-  CoValueClassOrSchema,
-  ID,
-} from "../internal.js";
+import type { CoValue, CoValueClassOrSchema } from "../internal.js";
 
 /** @category Invite Links */
 export function createInviteLink<C extends CoValue>(
   value: C,
-  role: "reader" | "writer" | "admin" | "writeOnly",
+  role: AccountRole,
   baseURL: string,
   valueHint?: string,
 ): string {

--- a/packages/jazz-tools/src/tools/tests/groupsAndAccounts.test.ts
+++ b/packages/jazz-tools/src/tools/tests/groupsAndAccounts.test.ts
@@ -576,11 +576,49 @@ describe("Account permissions", () => {
     group.addMember(writeOnly, "writeOnly");
 
     // Test canAdmin permissions
-    expect(manager.canAdmin(testObject)).toBe(true);
     expect(admin.canAdmin(testObject)).toBe(true);
+    expect(manager.canAdmin(testObject)).toBe(false);
     expect(writer.canAdmin(testObject)).toBe(false);
     expect(reader.canAdmin(testObject)).toBe(false);
     expect(writeOnly.canAdmin(testObject)).toBe(false);
+  });
+
+  test("canManage permissions for different roles", async () => {
+    // Create test accounts
+    const admin = await co.account().create({
+      creationProps: { name: "Super Admin" },
+      crypto: Crypto,
+    });
+
+    const group = Group.create({ owner: admin });
+    const testObject = CoMap.create({}, { owner: group });
+
+    const manager = await co.account().createAs(admin, {
+      creationProps: { name: "Admin" },
+    });
+
+    const writer = await co.account().createAs(admin, {
+      creationProps: { name: "Writer" },
+    });
+    const reader = await co.account().createAs(admin, {
+      creationProps: { name: "Reader" },
+    });
+    const writeOnly = await co.account().createAs(admin, {
+      creationProps: { name: "WriteOnly" },
+    });
+
+    // Set up roles
+    group.addMember(manager, "manager");
+    group.addMember(writer, "writer");
+    group.addMember(reader, "reader");
+    group.addMember(writeOnly, "writeOnly");
+
+    // Test canManage permissions
+    expect(admin.canManage(testObject)).toBe(true);
+    expect(manager.canManage(testObject)).toBe(true);
+    expect(writer.canManage(testObject)).toBe(false);
+    expect(reader.canManage(testObject)).toBe(false);
+    expect(writeOnly.canManage(testObject)).toBe(false);
   });
 
   test("permissions for non-members", async () => {
@@ -600,6 +638,7 @@ describe("Account permissions", () => {
     expect(nonMember.canRead(testObject)).toBe(false);
     expect(nonMember.canWrite(testObject)).toBe(false);
     expect(nonMember.canAdmin(testObject)).toBe(false);
+    expect(nonMember.canManage(testObject)).toBe(false);
   });
 
   describe("permissions over Groups and Accounts", () => {
@@ -824,6 +863,106 @@ describe("Account permissions", () => {
         const group = Group.create({ owner: otherAccount });
 
         expect(account.canAdmin(group)).toBe(false);
+      });
+    });
+
+    describe("manage", () => {
+      test("can manage Account if it's itself", async () => {
+        const account = await co.account().create({
+          creationProps: { name: "Test Account" },
+          crypto: Crypto,
+        });
+        expect(account.canManage(account)).toBe(true);
+      });
+
+      test("cannot manage other accounts", async () => {
+        const account = await co.account().create({
+          creationProps: { name: "Test Account" },
+          crypto: Crypto,
+        });
+        const otherAccount = await co.account().create({
+          creationProps: { name: "Other Account" },
+          crypto: Crypto,
+        });
+        expect(account.canManage(otherAccount)).toBe(false);
+      });
+
+      test("can manage Group if it's an manage for that group", async () => {
+        const account = await co.account().create({
+          creationProps: { name: "Test Account" },
+          crypto: Crypto,
+        });
+        const otherAccount = await co.account().create({
+          creationProps: { name: "Other Account" },
+          crypto: Crypto,
+        });
+        const group = Group.create({ owner: otherAccount });
+
+        group.addMember(account, "manager");
+
+        expect(account.canManage(group)).toBe(true);
+      });
+
+      test("cannot manage Group if it's a writer for that group", async () => {
+        const account = await co.account().create({
+          creationProps: { name: "Test Account" },
+          crypto: Crypto,
+        });
+        const otherAccount = await co.account().create({
+          creationProps: { name: "Other Account" },
+          crypto: Crypto,
+        });
+        const group = Group.create({ owner: otherAccount });
+
+        group.addMember(account, "writer");
+
+        expect(account.canManage(group)).toBe(false);
+      });
+
+      test("cannot manage Group if it has writeOnly permissions for that group", async () => {
+        const account = await co.account().create({
+          creationProps: { name: "Test Account" },
+          crypto: Crypto,
+        });
+        const otherAccount = await co.account().create({
+          creationProps: { name: "Other Account" },
+          crypto: Crypto,
+        });
+        const group = Group.create({ owner: otherAccount });
+
+        group.addMember(account, "writeOnly");
+
+        expect(account.canManage(group)).toBe(false);
+      });
+
+      test("cannot manage Group if it's a reader for that group", async () => {
+        const account = await co.account().create({
+          creationProps: { name: "Test Account" },
+          crypto: Crypto,
+        });
+        const otherAccount = await co.account().create({
+          creationProps: { name: "Other Account" },
+          crypto: Crypto,
+        });
+        const group = Group.create({ owner: otherAccount });
+
+        group.addMember(account, "reader");
+
+        expect(account.canManage(group)).toBe(false);
+      });
+
+      test("cannot manage Group if it has no permissions for that group", async () => {
+        const account = await co.account().create({
+          creationProps: { name: "Test Account" },
+          crypto: Crypto,
+        });
+        const otherAccount = await co.account().create({
+          creationProps: { name: "Other Account" },
+          crypto: Crypto,
+        });
+        const group = Group.create({ owner: otherAccount });
+
+        expect(account.canManage(group)).toBe(false);
       });
     });
   });

--- a/packages/jazz-tools/src/tools/tests/groupsAndAccounts.test.ts
+++ b/packages/jazz-tools/src/tools/tests/groupsAndAccounts.test.ts
@@ -481,6 +481,9 @@ describe("Account permissions", () => {
     const group = Group.create({ owner: admin });
     const testObject = CoMap.create({}, { owner: group });
 
+    const manager = await co.account().createAs(admin, {
+      creationProps: { name: "Manager" },
+    });
     const writer = await co.account().createAs(admin, {
       creationProps: { name: "Writer" },
     });
@@ -492,11 +495,13 @@ describe("Account permissions", () => {
     });
 
     // Set up roles
+    group.addMember(manager, "manager");
     group.addMember(writer, "writer");
     group.addMember(reader, "reader");
     group.addMember(writeOnly, "writeOnly");
 
     // Test canRead permissions
+    expect(manager.canRead(testObject)).toBe(true);
     expect(admin.canRead(testObject)).toBe(true);
     expect(writer.canRead(testObject)).toBe(true);
     expect(reader.canRead(testObject)).toBe(true);
@@ -513,6 +518,9 @@ describe("Account permissions", () => {
     const group = Group.create({ owner: admin });
     const testObject = CoMap.create({}, { owner: group });
 
+    const manager = await co.account().createAs(admin, {
+      creationProps: { name: "Manager" },
+    });
     const writer = await co.account().createAs(admin, {
       creationProps: { name: "Writer" },
     });
@@ -524,11 +532,13 @@ describe("Account permissions", () => {
     });
 
     // Set up roles
+    group.addMember(manager, "manager");
     group.addMember(writer, "writer");
     group.addMember(reader, "reader");
     group.addMember(writeOnly, "writeOnly");
 
     // Test canWrite permissions
+    expect(manager.canWrite(testObject)).toBe(true);
     expect(admin.canWrite(testObject)).toBe(true);
     expect(writer.canWrite(testObject)).toBe(true);
     expect(reader.canWrite(testObject)).toBe(false);
@@ -538,12 +548,16 @@ describe("Account permissions", () => {
   test("canAdmin permissions for different roles", async () => {
     // Create test accounts
     const admin = await co.account().create({
-      creationProps: { name: "Admin" },
+      creationProps: { name: "Super Admin" },
       crypto: Crypto,
     });
 
     const group = Group.create({ owner: admin });
     const testObject = CoMap.create({}, { owner: group });
+
+    const manager = await co.account().createAs(admin, {
+      creationProps: { name: "Admin" },
+    });
 
     const writer = await co.account().createAs(admin, {
       creationProps: { name: "Writer" },
@@ -556,11 +570,13 @@ describe("Account permissions", () => {
     });
 
     // Set up roles
+    group.addMember(manager, "manager");
     group.addMember(writer, "writer");
     group.addMember(reader, "reader");
     group.addMember(writeOnly, "writeOnly");
 
     // Test canAdmin permissions
+    expect(manager.canAdmin(testObject)).toBe(true);
     expect(admin.canAdmin(testObject)).toBe(true);
     expect(writer.canAdmin(testObject)).toBe(false);
     expect(reader.canAdmin(testObject)).toBe(false);


### PR DESCRIPTION
# Description
Replaces https://github.com/garden-co/jazz/pull/2995

This PR introduces the "manager" role. Like admins, it can invite readers, writers, writerOnly. They can also remove them. They can't remove or invite other managers. Managers can be invited and removed by admins.

---

This PR also introduces a refactoring on addMember/removeMember to validate permissions at a lower level (inside permission.ts) 

Previously, cojson/group.ts was trying to understand why an operation failed. Now, if the role setting fails, the error message is unified and enriched by useful information for debugging: `Failed to set role ${role} to ${memberKey} (role of current account is ${this.myRole()})`.

To be consistent and to give appropriate feedback, `group.removeMember` now throws an error if it fails (it was failing silently before). Due to this change, this might be considered a minor update instead of a patch.


## TODO:
- [x] generate test coverage to check uncovered branches
- [x] add some tests on group extension
- [ ] write docs when PR is confirmed /cc @joeinnes 

## Tests

- [x] Tests have been added and/or updated
- [ ] Tests have not been updated, because: <!-- Insert reason for not updating tests here -->
- [ ] I need help with writing tests


## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [x] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing