### PR TITLE
fix(permissions): fix validation for self-revocation in groups

### DIFF
--- a/.changeset/quick-coins-try.md
+++ b/.changeset/quick-coins-try.md
@@ -1,0 +1,6 @@
+---
+"cojson": patch
+---
+
+Fix validation for self-revocation in groups. Now self-revocation will be considered as valid also by other accounts.
+

--- a/packages/cojson/src/permissions.ts
+++ b/packages/cojson/src/permissions.ts
@@ -441,12 +441,8 @@ function determineValidTransactionsForGroup(
       change.key === transactor &&
       change.value === "admin";
 
-    const currentAccountId = coValue.node.getCurrentAccountOrAgentID();
-
     const isSelfRevoke =
-      currentAccountId === change.key &&
-      transactor === currentAccountId &&
-      change.value === "revoked";
+      transactor === change.key && change.value === "revoked";
 
     if (!isFirstSelfAppointment && !isSelfRevoke) {
       if (memberState[transactor] === "admin") {

--- a/packages/cojson/src/tests/group.removeMember.test.ts
+++ b/packages/cojson/src/tests/group.removeMember.test.ts
@@ -6,6 +6,7 @@ import {
   loadCoValueOrFail,
   setupTestAccount,
   setupTestNode,
+  waitFor,
 } from "./testUtils.js";
 
 setCoValueLoadingRetryDelay(10);
@@ -98,9 +99,14 @@ describe("Group.removeMember", () => {
       const loadedGroup = await loadCoValueOrFail(client.node, group.id);
       expect(loadedGroup.myRole()).toEqual(member);
 
-      await loadedGroup.removeMember(client.node.expectCurrentAccount(member));
+      loadedGroup.removeMember(client.node.expectCurrentAccount(member));
 
       expect(loadedGroup.myRole()).toEqual(undefined);
+
+      await loadedGroup.core.waitForSync();
+      await waitFor(() => {
+        expect(group.roleOf(client.accountID)).toEqual(undefined);
+      });
     });
   }
 


### PR DESCRIPTION
Fixed the `isSelfRevocation` check in permissions.

Before the validation was done against the current account id, and so passing when validated by the account that removed themselves and and failing when validated by other accounts.