### PR TITLE
Fix missing link to the BetterAuth Database Adapter doc

### DIFF
--- a/homepage/homepage/content/docs/docNavigationItems.js
+++ b/homepage/homepage/content/docs/docNavigationItems.js
@@ -254,11 +254,11 @@ export const docNavigationItems = [
           href: "/docs/authentication/better-auth",
           done: 100,
         },
-        //{
-        //  name: "Writing your own",
-        //  href: "/docs/authentication/writing-your-own",
-        //  done: 0,
-        //},
+        {
+          name: "Better Auth Database Adapter",
+          href: "/docs/authentication/better-auth-database-adapter",
+          done: 100,
+        },
       ]
     }, {
       name: "Permissions & sharing",


### PR DESCRIPTION
# Description
At some point the BA DB Adapter link got dropped from the nav. This quick PR adds it back.

## Manual testing instructions

## Tests

- [ ] Tests have been added and/or updated
- [X] Tests have not been updated, because: N/A
- [ ] I need help with writing tests


## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [ ] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing