### PR TITLE
fix: createImage return type

### DIFF
--- a/.changeset/silly-cooks-join.md
+++ b/.changeset/silly-cooks-join.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+fix: createImage return type now has the original image already loaded

--- a/packages/jazz-tools/src/media/create-image-factory.test.ts
+++ b/packages/jazz-tools/src/media/create-image-factory.test.ts
@@ -24,6 +24,24 @@ describe("createImage", async () => {
     vi.clearAllMocks();
   });
 
+  it("should return a loaded image definition", async () => {
+    const imageBlob = new Blob(
+      [Uint8Array.from(OnePixel, (c) => c.charCodeAt(0))],
+      { type: "image/png" },
+    );
+
+    getImageSize.mockResolvedValue({ width: 1, height: 1 });
+
+    const image = await createImage(imageBlob, { owner: account });
+
+    // ensure `original` is loaded
+    function typeMatch(value: { original: FileStream }) {
+      return value;
+    }
+
+    typeMatch(image);
+  });
+
   it("should create a single original image if all settings are off", async () => {
     const imageBlob = new Blob(
       [Uint8Array.from(OnePixel, (c) => c.charCodeAt(0))],

--- a/packages/jazz-tools/src/media/create-image-factory.ts
+++ b/packages/jazz-tools/src/media/create-image-factory.ts
@@ -37,6 +37,11 @@ export type CreateImageOptions = {
   progressive?: boolean;
 };
 
+export type CreateImageReturnType = Loaded<
+  typeof ImageDefinition,
+  { original: true }
+>;
+
 export type CreateImageImpl<
   TSourceType = SourceType,
   TResizeOutput = ResizeOutput,
@@ -70,7 +75,7 @@ async function createImage<TSourceType, TResizeOutput>(
   imageBlobOrFile: TSourceType,
   options: CreateImageOptions,
   impl: CreateImageImpl<TSourceType, TResizeOutput>,
-): Promise<Loaded<typeof ImageDefinition, { $each: true }>> {
+): Promise<CreateImageReturnType> {
   // Get the original size of the image
   const { width: originalWidth, height: originalHeight } =
     await impl.getImageSize(imageBlobOrFile);

--- a/packages/jazz-tools/src/media/index.ts
+++ b/packages/jazz-tools/src/media/index.ts
@@ -1,5 +1,8 @@
-import type { ImageDefinition } from "jazz-tools";
-import { CreateImageOptions } from "./create-image-factory";
+import type { ImageDefinition, Loaded } from "jazz-tools";
+import type {
+  CreateImageOptions,
+  CreateImageReturnType,
+} from "./create-image-factory";
 
 export * from "./exports";
 
@@ -38,7 +41,7 @@ export * from "./exports";
 export declare function createImage(
   imageBlobOrFile: Blob | File,
   options?: CreateImageOptions,
-): Promise<ImageDefinition>;
+): Promise<CreateImageReturnType>;
 
 /**
  * Creates an ImageDefinition from an image file path with built-in UX features.
@@ -66,4 +69,4 @@ export declare function createImage(
 export declare function createImage(
   filePath: string,
   options?: CreateImageOptions,
-): Promise<ImageDefinition>;
+): Promise<CreateImageReturnType>;


### PR DESCRIPTION
# Description
The `createImage` return type was not coherent with the implementation. Additionally, the `$each: true` blocks `original` property to be considered already loaded.

Now the return types are synced, and `original` (the only public filestream reference) is marked as loaded. 

## Tests

- [x] Tests have been added and/or updated
- [ ] Tests have not been updated, because: <!-- Insert reason for not updating tests here -->
- [ ] I need help with writing tests


## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [x] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing