### PR TITLE
feat: centralize knownState mutators and types

### DIFF
--- a/packages/cojson/src/PeerState.ts
+++ b/packages/cojson/src/PeerState.ts
@@ -1,7 +1,8 @@
 import { PeerKnownStates, ReadonlyPeerKnownStates } from "./PeerKnownStates.js";
 import { RawCoID, SessionID } from "./ids.js";
+import { CoValueKnownState } from "./knownState.js";
 import { logger } from "./logger.js";
-import { CoValueKnownState, Peer, SyncMessage } from "./sync.js";
+import { Peer, SyncMessage } from "./sync.js";
 
 export class PeerState {
   constructor(

--- a/packages/cojson/src/SyncStateManager.ts
+++ b/packages/cojson/src/SyncStateManager.ts
@@ -1,10 +1,10 @@
 import { RawCoID } from "./ids.js";
 import {
   CoValueKnownState,
-  PeerID,
-  SyncManager,
   emptyKnownState,
-} from "./sync.js";
+  areLocalSessionsUploaded,
+} from "./knownState.js";
+import { PeerID, SyncManager } from "./sync.js";
 
 export type SyncState = {
   uploaded: boolean;
@@ -135,19 +135,6 @@ export class SyncStateManager {
       return false;
     }
 
-    return getIsUploaded(sessions.coValue, sessions.peer);
+    return areLocalSessionsUploaded(sessions.coValue, sessions.peer);
   }
-}
-
-export function getIsUploaded(
-  from: Record<string, number>,
-  to: Record<string, number>,
-) {
-  for (const sessionId of Object.keys(from)) {
-    if (from[sessionId] !== to[sessionId]) {
-      return false;
-    }
-  }
-
-  return true;
 }

--- a/packages/cojson/src/coValueContentMessage.ts
+++ b/packages/cojson/src/coValueContentMessage.ts
@@ -3,8 +3,9 @@ import { TRANSACTION_CONFIG } from "./config.js";
 import { Signature } from "./crypto/crypto.js";
 import { RawCoID, SessionID } from "./ids.js";
 import { JsonValue } from "./jsonValue.js";
+import { emptyKnownState } from "./knownState.js";
 import { getPriorityFromHeader } from "./priority.js";
-import { NewContentMessage, emptyKnownState } from "./sync.js";
+import { NewContentMessage } from "./sync.js";
 
 export function createContentMessage(
   id: RawCoID,

--- a/packages/cojson/src/coValueCore/coValueCore.ts
+++ b/packages/cojson/src/coValueCore/coValueCore.ts
@@ -20,12 +20,7 @@ import { JsonObject, JsonValue } from "../jsonValue.js";
 import { LocalNode, ResolveAccountAgentError } from "../localNode.js";
 import { logger } from "../logger.js";
 import { determineValidTransactions } from "../permissions.js";
-import {
-  CoValueKnownState,
-  NewContentMessage,
-  PeerID,
-  emptyKnownState,
-} from "../sync.js";
+import { NewContentMessage, PeerID } from "../sync.js";
 import { accountOrAgentIDfromSessionID } from "../typeUtils/accountOrAgentIDfromSessionID.js";
 import { expectGroup } from "../typeUtils/expectGroup.js";
 import {
@@ -48,7 +43,12 @@ import {
 } from "./branching.js";
 import { type RawAccountID } from "../coValues/account.js";
 import { decodeTransactionChangesAndMeta } from "./decodeTransactionChangesAndMeta.js";
-import { combineKnownStateSessions } from "../knownState.js";
+import {
+  combineKnownStateSessions,
+  CoValueKnownState,
+  emptyKnownState,
+  KnownStateSessions,
+} from "../knownState.js";
 
 export function idforHeader(
   header: CoValueHeader,
@@ -378,7 +378,7 @@ export class CoValueCore {
 
   provideHeader(
     header: CoValueHeader,
-    streamingKnownState?: CoValueKnownState["sessions"],
+    streamingKnownState?: KnownStateSessions,
     skipVerify?: boolean,
   ) {
     if (!skipVerify) {
@@ -400,8 +400,7 @@ export class CoValueCore {
       this.id,
       this.node.crypto,
       header,
-      new SessionMap(this.id, this.node.crypto),
-      streamingKnownState,
+      new SessionMap(this.id, this.node.crypto, streamingKnownState),
     );
 
     return true;

--- a/packages/cojson/src/coValues/coMap.ts
+++ b/packages/cojson/src/coValues/coMap.ts
@@ -1,11 +1,7 @@
 import { CoID, RawCoValue } from "../coValue.js";
-import {
-  AvailableCoValueCore,
-  CoValueCore,
-} from "../coValueCore/coValueCore.js";
+import { AvailableCoValueCore } from "../coValueCore/coValueCore.js";
 import { AgentID, TransactionID } from "../ids.js";
 import { JsonObject, JsonValue } from "../jsonValue.js";
-import { CoValueKnownState } from "../sync.js";
 import { accountOrAgentIDfromSessionID } from "../typeUtils/accountOrAgentIDfromSessionID.js";
 import { isCoValue } from "../typeUtils/isCoValue.js";
 import { RawAccountID } from "./account.js";

--- a/packages/cojson/src/coValues/coStream.ts
+++ b/packages/cojson/src/coValues/coStream.ts
@@ -1,13 +1,9 @@
 import { base64URLtoBytes, bytesToBase64url } from "../base64url.js";
 import { CoID, RawCoValue } from "../coValue.js";
-import {
-  AvailableCoValueCore,
-  CoValueCore,
-} from "../coValueCore/coValueCore.js";
+import { AvailableCoValueCore } from "../coValueCore/coValueCore.js";
 import { AgentID, SessionID, TransactionID } from "../ids.js";
 import { JsonObject, JsonValue } from "../jsonValue.js";
 import { logger } from "../logger.js";
-import { CoValueKnownState } from "../sync.js";
 import { accountOrAgentIDfromSessionID } from "../typeUtils/accountOrAgentIDfromSessionID.js";
 import { isAccountID } from "../typeUtils/isAccountID.js";
 import { isCoValue } from "../typeUtils/isCoValue.js";

--- a/packages/cojson/src/exports.ts
+++ b/packages/cojson/src/exports.ts
@@ -65,9 +65,9 @@ import type { Peer, SyncMessage } from "./sync.js";
 import {
   DisconnectedError,
   SyncManager,
-  emptyKnownState,
   hwrServerPeerSelector,
 } from "./sync.js";
+import { emptyKnownState } from "./knownState.js";
 
 import {
   getContentMessageSize,
@@ -189,7 +189,7 @@ export * from "./storage/index.js";
 // biome-ignore format: off
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace CojsonInternalTypes {
-  export type CoValueKnownState = import("./sync.js").CoValueKnownState;
+  export type CoValueKnownState = import("./knownState.js").CoValueKnownState;
   export type CoJsonValue<T> = import("./jsonValue.js").CoJsonValue<T>;
   export type DoneMessage = import("./sync.js").DoneMessage;
   export type Encrypted<T extends JsonValue, N extends JsonValue> = import("./crypto/crypto.js").Encrypted<T, N>;

--- a/packages/cojson/src/knownState.ts
+++ b/packages/cojson/src/knownState.ts
@@ -1,17 +1,123 @@
-import type { SessionID } from "./exports.js";
-import type { CoValueKnownState } from "./sync.js";
+import type { RawCoID, SessionID } from "./exports.js";
 
-export function combineKnownStateSessions(
-  a: CoValueKnownState["sessions"],
-  b: CoValueKnownState["sessions"],
-): CoValueKnownState["sessions"] {
-  const sessionStates: CoValueKnownState["sessions"] = {};
+export type KnownStateSessions = { [sessionID: SessionID]: number };
 
-  for (const sessionID of Object.keys(a).concat(
-    Object.keys(b),
-  ) as SessionID[]) {
-    sessionStates[sessionID] = Math.max(a[sessionID] || 0, b[sessionID] || 0);
+export type CoValueKnownState = {
+  id: RawCoID;
+  header: boolean;
+  sessions: KnownStateSessions;
+};
+
+/**
+ * Returns an empty known state for a CoValue, with no header and empty sessions.
+ */
+export function emptyKnownState(id: RawCoID): CoValueKnownState {
+  return {
+    id,
+    header: false,
+    sessions: {},
+  };
+}
+
+/**
+ * Picks the knownState properties from the input object
+ */
+export function knownStateFrom(input: CoValueKnownState) {
+  return {
+    id: input.id,
+    header: input.header,
+    sessions: input.sessions,
+  };
+}
+
+/**
+ * Mutate the target known state by combining the sessions from the source.
+ *
+ * The function assigns the sessions to the target only when the value in the source is greater.
+ */
+export function combineKnownStates(
+  target: CoValueKnownState,
+  source: CoValueKnownState,
+): CoValueKnownState {
+  combineKnownStateSessions(target.sessions, source.sessions);
+
+  if (source.header && !target.header) {
+    target.header = true;
   }
 
-  return sessionStates;
+  return target;
+}
+
+/**
+ * Mutate the target sessions counter by combining the entries from the source.
+ *
+ * The function assigns the sessions to the target only when the value in the source is greater.
+ */
+export function combineKnownStateSessions(
+  target: KnownStateSessions,
+  source: KnownStateSessions,
+) {
+  for (const [sessionID, count] of Object.entries(source) as [
+    SessionID,
+    number,
+  ][]) {
+    const currentCount = target[sessionID] || 0;
+
+    if (count > currentCount) {
+      target[sessionID] = count;
+    }
+  }
+
+  return target;
+}
+
+/**
+ * Set the session counter for a sessionId in the known state.
+ */
+export function setSessionCounter(
+  knownState: KnownStateSessions,
+  sessionId: SessionID,
+  value: number,
+) {
+  knownState[sessionId] = value;
+}
+
+/**
+ * Update the session counter for a sessionId in the known state.
+ *
+ * The function assigns the value to the target only when the value in the knownState is less than the provided value.
+ */
+export function updateSessionCounter(
+  knownState: KnownStateSessions,
+  sessionId: SessionID,
+  value: number,
+) {
+  knownState[sessionId] = Math.max(knownState[sessionId] || 0, value);
+}
+
+/**
+ * Efficient cloning of a known state.
+ */
+export function cloneKnownState(knownState: CoValueKnownState) {
+  return {
+    id: knownState.id,
+    header: knownState.header,
+    sessions: { ...knownState.sessions },
+  };
+}
+
+/**
+ * Checks if all the local sessions have the same counters as in remote.
+ */
+export function areLocalSessionsUploaded(
+  local: Record<string, number>,
+  remote: Record<string, number>,
+) {
+  for (const sessionId of Object.keys(local)) {
+    if (local[sessionId] !== remote[sessionId]) {
+      return false;
+    }
+  }
+
+  return true;
 }

--- a/packages/cojson/src/permissions.ts
+++ b/packages/cojson/src/permissions.ts
@@ -15,15 +15,12 @@ import {
   AgentID,
   ParentGroupReference,
   RawCoID,
-  SessionID,
   TransactionID,
   getParentGroupId,
 } from "./ids.js";
 import { parseJSON } from "./jsonStringify.js";
 import { JsonValue } from "./jsonValue.js";
 import { logger } from "./logger.js";
-import { CoValueKnownState } from "./sync.js";
-import { accountOrAgentIDfromSessionID } from "./typeUtils/accountOrAgentIDfromSessionID.js";
 import { expectGroup } from "./typeUtils/expectGroup.js";
 
 export type PermissionsDef =

--- a/packages/cojson/src/storage/knownState.ts
+++ b/packages/cojson/src/storage/knownState.ts
@@ -1,7 +1,10 @@
-import { getIsUploaded } from "../SyncStateManager.js";
 import { type CoValueCore } from "../exports.js";
 import { RawCoID } from "../ids.js";
-import { CoValueKnownState, emptyKnownState } from "../sync.js";
+import {
+  CoValueKnownState,
+  emptyKnownState,
+  areLocalSessionsUploaded,
+} from "../knownState.js";
 
 /**
  * Track how much data we have stored inside our storage
@@ -84,5 +87,8 @@ function isInSync(
     return false;
   }
 
-  return getIsUploaded(knownState.sessions, knownStateFromStorage.sessions);
+  return areLocalSessionsUploaded(
+    knownState.sessions,
+    knownStateFromStorage.sessions,
+  );
 }

--- a/packages/cojson/src/storage/types.ts
+++ b/packages/cojson/src/storage/types.ts
@@ -4,7 +4,8 @@ import type {
 } from "../coValueCore/verifiedState.js";
 import { Signature } from "../crypto/crypto.js";
 import type { CoValueCore, RawCoID, SessionID } from "../exports.js";
-import { CoValueKnownState, NewContentMessage } from "../sync.js";
+import { NewContentMessage } from "../sync.js";
+import { CoValueKnownState } from "../knownState.js";
 
 export type CorrectionCallback = (
   correction: CoValueKnownState,

--- a/packages/cojson/src/tests/PeerKnownStates.test.ts
+++ b/packages/cojson/src/tests/PeerKnownStates.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test, vi } from "vitest";
 import { PeerKnownStates } from "../PeerKnownStates.js";
 import { RawCoID, SessionID } from "../ids.js";
-import { CoValueKnownState, emptyKnownState } from "../sync.js";
+import { CoValueKnownState, emptyKnownState } from "../knownState.js";
 
 describe("PeerKnownStates", () => {
   test("should set and get a known state", () => {

--- a/packages/cojson/src/tests/PureJSCrypto.test.ts
+++ b/packages/cojson/src/tests/PureJSCrypto.test.ts
@@ -4,7 +4,6 @@ import {
   setCurrentTestCryptoProvider,
   setupTestNode,
   setupTestAccount,
-  randomAgentAndSessionID,
 } from "./testUtils";
 import { PureJSCrypto } from "../crypto/PureJSCrypto";
 import { stableStringify } from "../jsonStringify";

--- a/packages/cojson/src/tests/StorageApiAsync.test.ts
+++ b/packages/cojson/src/tests/StorageApiAsync.test.ts
@@ -4,13 +4,9 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, onTestFinished, test, vi } from "vitest";
 import { WasmCrypto } from "../crypto/WasmCrypto.js";
-import { CoID, LocalNode, RawCoID, RawCoMap, logger } from "../exports.js";
+import { CoID, LocalNode, RawCoMap, logger } from "../exports.js";
 import { CoValueCore } from "../exports.js";
-import {
-  CoValueKnownState,
-  NewContentMessage,
-  emptyKnownState,
-} from "../sync.js";
+import { NewContentMessage } from "../sync.js";
 import { createAsyncStorage } from "./testStorage.js";
 import {
   SyncMessagesLog,
@@ -18,6 +14,7 @@ import {
   randomAgentAndSessionID,
   waitFor,
 } from "./testUtils.js";
+import { CoValueKnownState, emptyKnownState } from "../knownState.js";
 
 const crypto = await WasmCrypto.create();
 

--- a/packages/cojson/src/tests/StorageApiSync.test.ts
+++ b/packages/cojson/src/tests/StorageApiSync.test.ts
@@ -6,11 +6,8 @@ import { describe, expect, onTestFinished, test, vi } from "vitest";
 import { WasmCrypto } from "../crypto/WasmCrypto.js";
 import { CoID, LocalNode, RawCoID, RawCoMap, logger } from "../exports.js";
 import { CoValueCore } from "../exports.js";
-import {
-  CoValueKnownState,
-  NewContentMessage,
-  emptyKnownState,
-} from "../sync.js";
+import { NewContentMessage } from "../sync.js";
+import { CoValueKnownState, emptyKnownState } from "../knownState.js";
 import { createSyncStorage } from "./testStorage.js";
 import { loadCoValueOrFail, randomAgentAndSessionID } from "./testUtils.js";
 
@@ -240,7 +237,6 @@ describe("StorageApiSync", () => {
 
       // Create a real group and add a member to create transactions
       const group = fixturesNode.createGroup();
-      const knownState = group.core.verified.knownState();
 
       group.addMember("everyone", "reader");
 

--- a/packages/cojson/src/tests/StoreQueue.test.ts
+++ b/packages/cojson/src/tests/StoreQueue.test.ts
@@ -1,6 +1,7 @@
-import { beforeEach, describe, expect, test, vi } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import { StoreQueue } from "../queue/StoreQueue.js";
-import type { CoValueKnownState, NewContentMessage } from "../sync.js";
+import { NewContentMessage } from "../sync.js";
+import { CoValueKnownState } from "../knownState.js";
 
 function createMockNewContentMessage(id: string): NewContentMessage {
   return {

--- a/packages/cojson/src/tests/SyncStateManager.test.ts
+++ b/packages/cojson/src/tests/SyncStateManager.test.ts
@@ -4,7 +4,7 @@ import {
   PeerSyncStateListenerCallback,
 } from "../SyncStateManager.js";
 import { connectedPeers } from "../streamUtils.js";
-import { emptyKnownState } from "../sync.js";
+import { emptyKnownState } from "../exports.js";
 import {
   SyncMessagesLog,
   loadCoValueOrFail,

--- a/packages/cojson/src/tests/coValueContentMessage.test.ts
+++ b/packages/cojson/src/tests/coValueContentMessage.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "vitest";
 import { knownStateFromContent } from "../coValueContentMessage.js";
-import { emptyKnownState } from "../sync.js";
-import type { NewContentMessage } from "../sync.js";
+import { emptyKnownState } from "../knownState.js";
+import { NewContentMessage } from "../sync.js";
 import type { RawCoID, SessionID } from "../ids.js";
 import { stableStringify } from "../jsonStringify.js";
 import { CO_VALUE_PRIORITY } from "../priority.js";

--- a/packages/cojson/src/tests/coValueCore.test.ts
+++ b/packages/cojson/src/tests/coValueCore.test.ts
@@ -716,3 +716,41 @@ describe("markErrored and isErroredInPeer", () => {
     expect(notificationCount).toBeGreaterThan(0);
   });
 });
+
+test("knownState should return the same object until the CoValue is modified", () => {
+  const [agent, sessionID] = randomAgentAndSessionID();
+  const node = new LocalNode(agent.agentSecret, sessionID, Crypto);
+
+  const group = node.createGroup();
+  const map = group.createMap();
+
+  // Get the knownState for the first time
+  const knownState1 = map.core.knownState();
+
+  // Get the knownState again - should be the same object
+  const knownState2 = map.core.knownState();
+  expect(knownState2).toBe(knownState1);
+
+  // Call it multiple times to ensure it's always the same object
+  const knownState3 = map.core.knownState();
+  expect(knownState3).toBe(knownState1);
+
+  // Now modify the CoValue by making a transaction
+  map.set("hello", "world");
+
+  // Get the knownState after modification - should be a different object
+  const knownState4 = map.core.knownState();
+  expect(knownState4).not.toBe(knownState1);
+
+  // Verify that subsequent calls still return the same (new) object
+  const knownState5 = map.core.knownState();
+  expect(knownState5).toBe(knownState4);
+
+  // Make another modification
+  map.set("foo", "bar");
+
+  // Get the knownState after second modification - should be yet another different object
+  const knownState6 = map.core.knownState();
+  expect(knownState6).not.toBe(knownState4);
+  expect(knownState6).not.toBe(knownState1);
+});

--- a/packages/cojson/src/tests/knownState.test.ts
+++ b/packages/cojson/src/tests/knownState.test.ts
@@ -1,0 +1,665 @@
+import { describe, expect, test } from "vitest";
+import {
+  emptyKnownState,
+  knownStateFrom,
+  combineKnownStates,
+  combineKnownStateSessions,
+  setSessionCounter,
+  updateSessionCounter,
+  cloneKnownState,
+  areLocalSessionsUploaded,
+  type CoValueKnownState,
+  type KnownStateSessions,
+} from "../knownState.js";
+import { RawCoID, SessionID } from "../ids.js";
+
+describe("knownState", () => {
+  describe("emptyKnownState", () => {
+    test("should create an empty known state with the given id", () => {
+      const id = "test-id" as RawCoID;
+      const result = emptyKnownState(id);
+
+      expect(result).toEqual({
+        id: "test-id",
+        header: false,
+        sessions: {},
+      });
+    });
+
+    test("should have no sessions", () => {
+      const id = "test-id" as RawCoID;
+      const result = emptyKnownState(id);
+
+      expect(Object.keys(result.sessions)).toHaveLength(0);
+    });
+
+    test("should have header set to false", () => {
+      const id = "test-id" as RawCoID;
+      const result = emptyKnownState(id);
+
+      expect(result.header).toBe(false);
+    });
+  });
+
+  describe("knownStateFrom", () => {
+    test("should extract known state properties from input", () => {
+      const id = "test-id" as RawCoID;
+      const session1 = "session-1" as SessionID;
+      const input: CoValueKnownState = {
+        id,
+        header: true,
+        sessions: { [session1]: 5 },
+      };
+
+      const result = knownStateFrom(input);
+
+      expect(result).toEqual({
+        id: "test-id",
+        header: true,
+        sessions: { [session1]: 5 },
+      });
+    });
+
+    test("should create a shallow copy of sessions", () => {
+      const id = "test-id" as RawCoID;
+      const session1 = "session-1" as SessionID;
+      const sessions = { [session1]: 5 };
+      const input: CoValueKnownState = {
+        id,
+        header: true,
+        sessions,
+      };
+
+      const result = knownStateFrom(input);
+
+      expect(result.sessions).toBe(sessions);
+    });
+
+    test("should work with empty sessions", () => {
+      const id = "test-id" as RawCoID;
+      const input = emptyKnownState(id);
+
+      const result = knownStateFrom(input);
+
+      expect(result).toEqual({
+        id: "test-id",
+        header: false,
+        sessions: {},
+      });
+    });
+  });
+
+  describe("combineKnownStates", () => {
+    test("should combine sessions from source to target", () => {
+      const id = "test-id" as RawCoID;
+      const session1 = "session-1" as SessionID;
+      const session2 = "session-2" as SessionID;
+      const target: CoValueKnownState = {
+        id,
+        header: false,
+        sessions: { [session1]: 3 },
+      };
+      const source: CoValueKnownState = {
+        id,
+        header: false,
+        sessions: { [session2]: 7 },
+      };
+
+      const result = combineKnownStates(target, source);
+
+      expect(result.sessions).toEqual({
+        [session1]: 3,
+        [session2]: 7,
+      });
+    });
+
+    test("should update target when source has higher counter", () => {
+      const id = "test-id" as RawCoID;
+      const session1 = "session-1" as SessionID;
+      const target: CoValueKnownState = {
+        id,
+        header: false,
+        sessions: { [session1]: 3 },
+      };
+      const source: CoValueKnownState = {
+        id,
+        header: false,
+        sessions: { [session1]: 7 },
+      };
+
+      combineKnownStates(target, source);
+
+      expect(target.sessions[session1]).toBe(7);
+    });
+
+    test("should not update target when source has lower counter", () => {
+      const id = "test-id" as RawCoID;
+      const session1 = "session-1" as SessionID;
+      const target: CoValueKnownState = {
+        id,
+        header: false,
+        sessions: { [session1]: 10 },
+      };
+      const source: CoValueKnownState = {
+        id,
+        header: false,
+        sessions: { [session1]: 5 },
+      };
+
+      combineKnownStates(target, source);
+
+      expect(target.sessions[session1]).toBe(10);
+    });
+
+    test("should set header to true when source has header true", () => {
+      const id = "test-id" as RawCoID;
+      const target: CoValueKnownState = {
+        id,
+        header: false,
+        sessions: {},
+      };
+      const source: CoValueKnownState = {
+        id,
+        header: true,
+        sessions: {},
+      };
+
+      combineKnownStates(target, source);
+
+      expect(target.header).toBe(true);
+    });
+
+    test("should not change header when both have header true", () => {
+      const id = "test-id" as RawCoID;
+      const target: CoValueKnownState = {
+        id,
+        header: true,
+        sessions: {},
+      };
+      const source: CoValueKnownState = {
+        id,
+        header: true,
+        sessions: {},
+      };
+
+      combineKnownStates(target, source);
+
+      expect(target.header).toBe(true);
+    });
+
+    test("should not change header when source has header false", () => {
+      const id = "test-id" as RawCoID;
+      const target: CoValueKnownState = {
+        id,
+        header: true,
+        sessions: {},
+      };
+      const source: CoValueKnownState = {
+        id,
+        header: false,
+        sessions: {},
+      };
+
+      combineKnownStates(target, source);
+
+      expect(target.header).toBe(true);
+    });
+
+    test("should return the target object", () => {
+      const id = "test-id" as RawCoID;
+      const target: CoValueKnownState = {
+        id,
+        header: false,
+        sessions: {},
+      };
+      const source: CoValueKnownState = {
+        id,
+        header: false,
+        sessions: {},
+      };
+
+      const result = combineKnownStates(target, source);
+
+      expect(result).toBe(target);
+    });
+
+    test("should mutate the target object", () => {
+      const id = "test-id" as RawCoID;
+      const session1 = "session-1" as SessionID;
+      const target: CoValueKnownState = {
+        id,
+        header: false,
+        sessions: {},
+      };
+      const source: CoValueKnownState = {
+        id,
+        header: true,
+        sessions: { [session1]: 5 },
+      };
+
+      combineKnownStates(target, source);
+
+      expect(target.header).toBe(true);
+      expect(target.sessions[session1]).toBe(5);
+    });
+  });
+
+  describe("combineKnownStateSessions", () => {
+    test("should add new sessions from source to target", () => {
+      const session1 = "session-1" as SessionID;
+      const session2 = "session-2" as SessionID;
+      const target: KnownStateSessions = { [session1]: 3 };
+      const source: KnownStateSessions = { [session2]: 7 };
+
+      combineKnownStateSessions(target, source);
+
+      expect(target).toEqual({
+        [session1]: 3,
+        [session2]: 7,
+      });
+    });
+
+    test("should update session when source has higher counter", () => {
+      const session1 = "session-1" as SessionID;
+      const target: KnownStateSessions = { [session1]: 3 };
+      const source: KnownStateSessions = { [session1]: 7 };
+
+      combineKnownStateSessions(target, source);
+
+      expect(target[session1]).toBe(7);
+    });
+
+    test("should not update session when source has lower counter", () => {
+      const session1 = "session-1" as SessionID;
+      const target: KnownStateSessions = { [session1]: 10 };
+      const source: KnownStateSessions = { [session1]: 5 };
+
+      combineKnownStateSessions(target, source);
+
+      expect(target[session1]).toBe(10);
+    });
+
+    test("should add session when target has no counter for that session", () => {
+      const session1 = "session-1" as SessionID;
+      const target: KnownStateSessions = {};
+      const source: KnownStateSessions = { [session1]: 5 };
+
+      combineKnownStateSessions(target, source);
+
+      expect(target[session1]).toBe(5);
+    });
+
+    test("should handle empty source", () => {
+      const session1 = "session-1" as SessionID;
+      const target: KnownStateSessions = { [session1]: 3 };
+      const source: KnownStateSessions = {};
+
+      combineKnownStateSessions(target, source);
+
+      expect(target).toEqual({ [session1]: 3 });
+    });
+
+    test("should handle empty target", () => {
+      const session1 = "session-1" as SessionID;
+      const target: KnownStateSessions = {};
+      const source: KnownStateSessions = { [session1]: 5 };
+
+      combineKnownStateSessions(target, source);
+
+      expect(target).toEqual({ [session1]: 5 });
+    });
+
+    test("should handle multiple sessions", () => {
+      const session1 = "session-1" as SessionID;
+      const session2 = "session-2" as SessionID;
+      const session3 = "session-3" as SessionID;
+      const target: KnownStateSessions = {
+        [session1]: 5,
+        [session2]: 10,
+      };
+      const source: KnownStateSessions = {
+        [session1]: 3,
+        [session2]: 15,
+        [session3]: 8,
+      };
+
+      combineKnownStateSessions(target, source);
+
+      expect(target).toEqual({
+        [session1]: 5,
+        [session2]: 15,
+        [session3]: 8,
+      });
+    });
+
+    test("should return the target object", () => {
+      const session1 = "session-1" as SessionID;
+      const target: KnownStateSessions = { [session1]: 3 };
+      const source: KnownStateSessions = { [session1]: 7 };
+
+      const result = combineKnownStateSessions(target, source);
+
+      expect(result).toBe(target);
+    });
+  });
+
+  describe("setSessionCounter", () => {
+    test("should set counter for a new session", () => {
+      const session1 = "session-1" as SessionID;
+      const knownState: KnownStateSessions = {};
+
+      setSessionCounter(knownState, session1, 5);
+
+      expect(knownState[session1]).toBe(5);
+    });
+
+    test("should update counter for an existing session", () => {
+      const session1 = "session-1" as SessionID;
+      const knownState: KnownStateSessions = { [session1]: 3 };
+
+      setSessionCounter(knownState, session1, 10);
+
+      expect(knownState[session1]).toBe(10);
+    });
+
+    test("should allow setting counter to 0", () => {
+      const session1 = "session-1" as SessionID;
+      const knownState: KnownStateSessions = { [session1]: 5 };
+
+      setSessionCounter(knownState, session1, 0);
+
+      expect(knownState[session1]).toBe(0);
+    });
+
+    test("should allow setting counter to a lower value", () => {
+      const session1 = "session-1" as SessionID;
+      const knownState: KnownStateSessions = { [session1]: 10 };
+
+      setSessionCounter(knownState, session1, 3);
+
+      expect(knownState[session1]).toBe(3);
+    });
+
+    test("should mutate the input object", () => {
+      const session1 = "session-1" as SessionID;
+      const knownState: KnownStateSessions = {};
+
+      setSessionCounter(knownState, session1, 5);
+
+      expect(knownState).toEqual({ [session1]: 5 });
+    });
+  });
+
+  describe("updateSessionCounter", () => {
+    test("should set counter for a new session", () => {
+      const session1 = "session-1" as SessionID;
+      const knownState: KnownStateSessions = {};
+
+      updateSessionCounter(knownState, session1, 5);
+
+      expect(knownState[session1]).toBe(5);
+    });
+
+    test("should update counter when new value is higher", () => {
+      const session1 = "session-1" as SessionID;
+      const knownState: KnownStateSessions = { [session1]: 3 };
+
+      updateSessionCounter(knownState, session1, 10);
+
+      expect(knownState[session1]).toBe(10);
+    });
+
+    test("should not update counter when new value is lower", () => {
+      const session1 = "session-1" as SessionID;
+      const knownState: KnownStateSessions = { [session1]: 10 };
+
+      updateSessionCounter(knownState, session1, 3);
+
+      expect(knownState[session1]).toBe(10);
+    });
+
+    test("should not update counter when new value is equal", () => {
+      const session1 = "session-1" as SessionID;
+      const knownState: KnownStateSessions = { [session1]: 5 };
+
+      updateSessionCounter(knownState, session1, 5);
+
+      expect(knownState[session1]).toBe(5);
+    });
+
+    test("should handle zero value for existing session", () => {
+      const session1 = "session-1" as SessionID;
+      const knownState: KnownStateSessions = { [session1]: 5 };
+
+      updateSessionCounter(knownState, session1, 0);
+
+      expect(knownState[session1]).toBe(5);
+    });
+
+    test("should set to 0 when counter does not exist and value is 0", () => {
+      const session1 = "session-1" as SessionID;
+      const knownState: KnownStateSessions = {};
+
+      updateSessionCounter(knownState, session1, 0);
+
+      expect(knownState[session1]).toBe(0);
+    });
+
+    test("should mutate the input object", () => {
+      const session1 = "session-1" as SessionID;
+      const knownState: KnownStateSessions = {};
+
+      updateSessionCounter(knownState, session1, 5);
+
+      expect(knownState).toEqual({ [session1]: 5 });
+    });
+  });
+
+  describe("cloneKnownState", () => {
+    test("should create a copy with the same values", () => {
+      const id = "test-id" as RawCoID;
+      const session1 = "session-1" as SessionID;
+      const original: CoValueKnownState = {
+        id,
+        header: true,
+        sessions: { [session1]: 5 },
+      };
+
+      const cloned = cloneKnownState(original);
+
+      expect(cloned).toEqual(original);
+    });
+
+    test("should create a new object", () => {
+      const id = "test-id" as RawCoID;
+      const original: CoValueKnownState = {
+        id,
+        header: true,
+        sessions: {},
+      };
+
+      const cloned = cloneKnownState(original);
+
+      expect(cloned).not.toBe(original);
+    });
+
+    test("should create a new sessions object", () => {
+      const id = "test-id" as RawCoID;
+      const session1 = "session-1" as SessionID;
+      const original: CoValueKnownState = {
+        id,
+        header: true,
+        sessions: { [session1]: 5 },
+      };
+
+      const cloned = cloneKnownState(original);
+
+      expect(cloned.sessions).not.toBe(original.sessions);
+    });
+
+    test("should not affect original when modifying clone", () => {
+      const id = "test-id" as RawCoID;
+      const session1 = "session-1" as SessionID;
+      const session2 = "session-2" as SessionID;
+      const original: CoValueKnownState = {
+        id,
+        header: false,
+        sessions: { [session1]: 5 },
+      };
+
+      const cloned = cloneKnownState(original);
+      cloned.header = true;
+      cloned.sessions[session2] = 10;
+
+      expect(original.header).toBe(false);
+      expect(original.sessions[session2]).toBeUndefined();
+    });
+
+    test("should work with empty sessions", () => {
+      const id = "test-id" as RawCoID;
+      const original = emptyKnownState(id);
+
+      const cloned = cloneKnownState(original);
+
+      expect(cloned).toEqual(original);
+      expect(cloned).not.toBe(original);
+    });
+
+    test("should work with multiple sessions", () => {
+      const id = "test-id" as RawCoID;
+      const session1 = "session-1" as SessionID;
+      const session2 = "session-2" as SessionID;
+      const session3 = "session-3" as SessionID;
+      const original: CoValueKnownState = {
+        id,
+        header: true,
+        sessions: {
+          [session1]: 5,
+          [session2]: 10,
+          [session3]: 15,
+        },
+      };
+
+      const cloned = cloneKnownState(original);
+
+      expect(cloned).toEqual(original);
+      expect(cloned.sessions).not.toBe(original.sessions);
+    });
+  });
+
+  describe("areLocalSessionsUploaded", () => {
+    test("should return true when all counters match", () => {
+      const session1 = "session-1" as SessionID;
+      const session2 = "session-2" as SessionID;
+      const from = { [session1]: 5, [session2]: 10 };
+      const to = { [session1]: 5, [session2]: 10 };
+
+      const result = areLocalSessionsUploaded(from, to);
+
+      expect(result).toBe(true);
+    });
+
+    test("should return false when counter differs", () => {
+      const session1 = "session-1" as SessionID;
+      const from = { [session1]: 5 };
+      const to = { [session1]: 3 };
+
+      const result = areLocalSessionsUploaded(from, to);
+
+      expect(result).toBe(false);
+    });
+
+    test("should return false when session is missing in to", () => {
+      const session1 = "session-1" as SessionID;
+      const from = { [session1]: 5 };
+      const to = {};
+
+      const result = areLocalSessionsUploaded(from, to);
+
+      expect(result).toBe(false);
+    });
+
+    test("should return true when from is empty", () => {
+      const session1 = "session-1" as SessionID;
+      const from = {};
+      const to = { [session1]: 5 };
+
+      const result = areLocalSessionsUploaded(from, to);
+
+      expect(result).toBe(true);
+    });
+
+    test("should return true when both are empty", () => {
+      const from = {};
+      const to = {};
+
+      const result = areLocalSessionsUploaded(from, to);
+
+      expect(result).toBe(true);
+    });
+
+    test("should handle multiple sessions", () => {
+      const session1 = "session-1" as SessionID;
+      const session2 = "session-2" as SessionID;
+      const session3 = "session-3" as SessionID;
+      const from = {
+        [session1]: 5,
+        [session2]: 10,
+        [session3]: 15,
+      };
+      const to = {
+        [session1]: 5,
+        [session2]: 10,
+        [session3]: 15,
+      };
+
+      const result = areLocalSessionsUploaded(from, to);
+
+      expect(result).toBe(true);
+    });
+
+    test("should return false if any session counter differs", () => {
+      const session1 = "session-1" as SessionID;
+      const session2 = "session-2" as SessionID;
+      const session3 = "session-3" as SessionID;
+      const from = {
+        [session1]: 5,
+        [session2]: 10,
+        [session3]: 15,
+      };
+      const to = {
+        [session1]: 5,
+        [session2]: 8,
+        [session3]: 15,
+      };
+
+      const result = areLocalSessionsUploaded(from, to);
+
+      expect(result).toBe(false);
+    });
+
+    test("should not check sessions in to that are not in from", () => {
+      const session1 = "session-1" as SessionID;
+      const session2 = "session-2" as SessionID;
+      const from = { [session1]: 5 };
+      const to = {
+        [session1]: 5,
+        [session2]: 10,
+      };
+
+      const result = areLocalSessionsUploaded(from, to);
+
+      expect(result).toBe(true);
+    });
+
+    test("should return false when counter in to is higher", () => {
+      const session1 = "session-1" as SessionID;
+      const from = { [session1]: 5 };
+      const to = { [session1]: 10 };
+
+      const result = areLocalSessionsUploaded(from, to);
+
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/packages/cojson/src/tests/messagesTestUtils.ts
+++ b/packages/cojson/src/tests/messagesTestUtils.ts
@@ -1,5 +1,6 @@
 import { CoValueCore, LocalNode } from "../exports";
-import { CoValueKnownState, NewContentMessage, SyncMessage } from "../sync";
+import { NewContentMessage, SyncMessage } from "../sync";
+import { CoValueKnownState } from "../knownState.js";
 
 function simplifySessions(msg: Pick<CoValueKnownState, "sessions" | "header">) {
   const count = Object.values(msg.sessions).reduce(

--- a/packages/cojson/src/tests/priority.test.ts
+++ b/packages/cojson/src/tests/priority.test.ts
@@ -1,11 +1,9 @@
 import { describe, expect, test } from "vitest";
 import { WasmCrypto } from "../crypto/WasmCrypto.js";
-import { LocalNode } from "../localNode.js";
 import { CO_VALUE_PRIORITY, getPriorityFromHeader } from "../priority.js";
 import {
   createAccountInNode,
   nodeWithRandomAgentAndSessionID,
-  randomAgentAndSessionID,
 } from "./testUtils.js";
 
 const Crypto = await WasmCrypto.create();

--- a/packages/cojson/src/tests/sync.storage.test.ts
+++ b/packages/cojson/src/tests/sync.storage.test.ts
@@ -20,7 +20,6 @@ import {
   waitFor,
 } from "./testUtils";
 import { stableStringify } from "../jsonStringify";
-import { determineValidTransactions } from "../permissions";
 
 // We want to simulate a real world communication that happens asynchronously
 TEST_NODE_CONFIG.withAsyncPeers = true;

--- a/packages/cojson/src/tests/sync.upload.test.ts
+++ b/packages/cojson/src/tests/sync.upload.test.ts
@@ -9,7 +9,6 @@ import {
   setupTestNode,
   waitFor,
 } from "./testUtils";
-import { determineValidTransactions } from "../permissions";
 import { RawCoMap } from "../coValues/coMap";
 
 // We want to simulate a real world communication that happens asynchronously

--- a/packages/cojson/src/tests/testUtils.ts
+++ b/packages/cojson/src/tests/testUtils.ts
@@ -12,12 +12,11 @@ import {
   type AgentSecret,
   type CoID,
   type CoValueCore,
-  CryptoProvider,
   type RawAccount,
   type RawCoValue,
   StorageAPI,
 } from "../exports.js";
-import type { RawCoID, SessionID } from "../ids.js";
+import type { SessionID } from "../ids.js";
 import { LocalNode } from "../localNode.js";
 import { connectedPeers } from "../streamUtils.js";
 import type { Peer, SyncMessage } from "../sync.js";


### PR DESCRIPTION
# Description

Done a bit of cleanup, to put most of the knownState manipulation logic inside a `knownState` module and making more intentional and consistent where we do mutate the knownState and where we do create a new object on change.

Also simplified and optimized a little the straming state tracking.

Used this refactoring to cover the knownState modifiers with tests.

## Tests

- [x] Tests have been added and/or updated
- [ ] Tests have not been updated, because: <!-- Insert reason for not updating tests here -->
- [ ] I need help with writing tests


## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes (not applicable)
- [ ] I've generated a changeset, if a version bump is required (not applicable)
- [x] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing