### PR TITLE
docs: explicit loading states

### DIFF
--- a/homepage/homepage/content/docs/authentication/authentication-states.mdx
+++ b/homepage/homepage/content/docs/authentication/authentication-states.mdx
@@ -124,6 +124,7 @@ export async function onAnonymousAccountDiscarded(
     },
   });
 
+  // @ts-expect-error TODO: fix issue that prevents iterating CoLists inside loaded CoMaps 
   for (const track of anonymousAccountRoot.rootPlaylist.tracks) {
     if (track.isExampleTrack) continue;
 

--- a/homepage/homepage/content/docs/design-patterns/form.mdx
+++ b/homepage/homepage/content/docs/design-patterns/form.mdx
@@ -135,7 +135,7 @@ export function OrderForm({
 export function EditOrder(props: { id: string }) {
   const order = useCoState(BubbleTeaOrder, props.id);
 
-  if (!order) return;
+  if (!order.$isLoaded) return;
 
   return <OrderForm order={order} />;
 }
@@ -203,12 +203,12 @@ export function OrderForm({
 export function CreateOrder(props: { id: string }) {
   const orders = useAccountWithSelector(JazzAccount, {
     resolve: { root: { orders: true } },
-    select: (account) => account?.root.orders,
+    select: (account) => account.$isLoaded ? account.root.orders : undefined,
   });
 
-const newOrder = useCoState(PartialBubbleTeaOrder, props.id);
+  const newOrder = useCoState(PartialBubbleTeaOrder, props.id);
 
-  if (!newOrder || !orders) return;
+  if (!newOrder.$isLoaded || !orders) return;
 
   const handleSave = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -254,7 +254,7 @@ export function EditOrderWithSave(props: { id: string }) {
 
   function handleSave(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
-    if (!order) return;
+    if (!order.$isLoaded) return;
 
     // Merge the branch back to the original
     order.$jazz.unstable_merge();
@@ -265,7 +265,7 @@ export function EditOrderWithSave(props: { id: string }) {
     // Navigate away without saving - the branch will be discarded
   }
 
-  if (!order) return;
+  if (!order.$isLoaded) return;
 
   return <OrderForm order={order} onSave={handleSave} onCancel={handleCancel} />;
 }

--- a/homepage/homepage/content/docs/design-patterns/history-patterns.mdx
+++ b/homepage/homepage/content/docs/design-patterns/history-patterns.mdx
@@ -50,8 +50,9 @@ function getAuditLog(task: Task) {
 // Use it to show change history
 const auditLog = getAuditLog(task);
 auditLog.forEach((entry) => {
+  if (!entry.by?.profile?.$isLoaded) return;
   const when = entry.at.toLocaleString();
-  const who = entry.by?.profile?.name;
+  const who = entry.by.profile.name;
   const what = entry.field;
   const value = entry.value;
 
@@ -132,7 +133,7 @@ Show when something was last updated:
 
 <CodeGroup>
 ```ts twoslash
-import { co, z } from 'jazz-tools'
+import { co, z, CoMapEdit } from 'jazz-tools'
 import { createJazzTestAccount } from 'jazz-tools/testing'
 
 const me = await createJazzTestAccount();
@@ -147,7 +148,7 @@ const task = Task.create({ title: "New task", status: "todo" }, { owner: me });
 // ---cut---
 function getLastUpdated(task: Task) {
   // Find the most recent edit across all fields
-  let lastEdit: any = null;
+  let lastEdit: CoMapEdit<unknown> | null = null;
 
   const edits = task.$jazz.getEdits();
   for (const field of Object.keys(task)) {
@@ -161,12 +162,12 @@ function getLastUpdated(task: Task) {
     }
   }
 
-  if (!lastEdit) return null;
+  if (!lastEdit || !lastEdit.by?.profile?.$isLoaded) return null;
 
   return {
-    updatedBy: lastEdit.by?.profile?.name,
+    updatedBy: lastEdit.by.profile.name,
     updatedAt: lastEdit.madeAt,
-    message: `Last updated by ${lastEdit.by?.profile?.name} at ${lastEdit.madeAt.toLocaleString()}`
+    message: `Last updated by ${lastEdit.by.profile.name} at ${lastEdit.madeAt.toLocaleString()}`
   };
 }
 
@@ -241,7 +242,9 @@ function findWhoChanged(task: Task, field: string, value: any) {
   return matchingEdit?.by || null;
 }
 const account = findWhoChanged(task, "status", "completed");
-console.log(account?.profile?.name);
+if (account?.profile?.$isLoaded) {
+  console.log(account.profile.name);
+}
 // Alice
 ```
 </CodeGroup>

--- a/homepage/homepage/content/docs/design-patterns/organization.mdx
+++ b/homepage/homepage/content/docs/design-patterns/organization.mdx
@@ -140,7 +140,7 @@ export function AcceptInvitePage() {
   });
 
   const onAccept = (organizationId: string) => {
-    if (me) {
+    if (me.$isLoaded) {
       Organization.load(organizationId).then((organization) => {
         if (organization) {
           // avoid duplicates

--- a/homepage/homepage/content/docs/getting-started/quickstart.mdx
+++ b/homepage/homepage/content/docs/getting-started/quickstart.mdx
@@ -236,7 +236,7 @@ export function NewBand() {
   const [name, setName] = useState("");
 
   const handleSave = () => {
-    if (!me.$isLoaded) return; // not loaded yet
+    if (!me.$isLoaded) return;
     me.root.myFestival.$jazz.push({ name });
     setName("");
   };
@@ -267,7 +267,7 @@ export function NewBand() {
   let name = $state("");
 
   function handleSave() {
-    if (!me.current.$isLoaded) return; // not loaded yet
+    if (!me.current.$isLoaded) return;
     me.current.root.myFestival.$jazz.push({ name });
     name = "";
   }
@@ -302,7 +302,7 @@ export function Festival() {
   const { me } = useAccount(JazzFestAccount, { 
     resolve: { root: { myFestival: { $each: true } } } 
   });
-  if (!me.$isLoaded) return null; // not loaded yet
+  if (!me.$isLoaded) return null;
   return (
     <ul>
       {me.root.myFestival.map((band) => <li key={band.$jazz.id}>{band.name}</li>)}

--- a/homepage/homepage/content/docs/getting-started/quickstart.mdx
+++ b/homepage/homepage/content/docs/getting-started/quickstart.mdx
@@ -236,7 +236,7 @@ export function NewBand() {
   const [name, setName] = useState("");
 
   const handleSave = () => {
-    if (!me) return; // not loaded yet
+    if (!me.$isLoaded) return; // not loaded yet
     me.root.myFestival.$jazz.push({ name });
     setName("");
   };
@@ -267,7 +267,7 @@ export function NewBand() {
   let name = $state("");
 
   function handleSave() {
-    if (!me.current) return; // not loaded yet
+    if (!me.current.$isLoaded) return; // not loaded yet
     me.current.root.myFestival.$jazz.push({ name });
     name = "";
   }
@@ -300,12 +300,12 @@ import { JazzFestAccount } from "@/app/schema";
 
 export function Festival() {
   const { me } = useAccount(JazzFestAccount, { 
-    resolve: { root: { myFestival: true } } 
+    resolve: { root: { myFestival: { $each: true } } } 
   });
-  if (!me) return null; // not loaded yet
+  if (!me.$isLoaded) return null; // not loaded yet
   return (
     <ul>
-      {me?.root.myFestival.map((band) => band && <li key={band.$jazz.id}>{band.name}</li>)}
+      {me.root.myFestival.map((band) => <li key={band.$jazz.id}>{band.name}</li>)}
     </ul>
   );
 }
@@ -317,14 +317,16 @@ export function Festival() {
   import { AccountCoState } from "jazz-tools/svelte";
   import { JazzFestAccount } from "$lib/schema";
   const me = new AccountCoState(JazzFestAccount, { 
-    resolve: { root: { myFestival: true } } 
+    resolve: { root: { myFestival: { $each: true } } } 
   });
 </script>
 
 <ul>
-  {#each me.current?.root.myFestival || [] as band}
-    <li>{band?.name}</li>
-  {/each}
+  {#if me.current.$isLoaded}
+    {#each me.current.root.myFestival as band}
+      <li>{band.name}</li>
+    {/each}
+  {/if}
 </ul>
 ```
 </TabbedCodeGroupItem>

--- a/homepage/homepage/content/docs/groups/intro.mdx
+++ b/homepage/homepage/content/docs/groups/intro.mdx
@@ -54,7 +54,7 @@ const group = Group.create();
 
 const bob = await co.account().load(bobsID);
 
-if (bob) {
+if (bob.$isLoaded) {
   group.addMember(bob, "writer");
 }
 ```
@@ -75,7 +75,7 @@ import { ID, Account, co } from "jazz-tools";
 const bob = await Account.load(bobsID);
 // Or: const bob = await co.account().load(bobsID);
 
-if (bob) {
+if (bob.$isLoaded) {
   group.addMember(bob, "writer");
 }
 ```
@@ -187,7 +187,7 @@ const accountID = account.$jazz.id;
 const value = await MyCoMap.create({ color: "red"})
 const bob = await co.account().load(accountID);
 
-if (bob) {
+if (bob.$isLoaded) {
   if (bob.canAdmin(value)) {
     console.log("Bob can share value with others");
   } else if (bob.canWrite(value)) {

--- a/homepage/homepage/content/docs/groups/quickstart.mdx
+++ b/homepage/homepage/content/docs/groups/quickstart.mdx
@@ -49,7 +49,7 @@ export function Festival() {
   const { me } = useAccount(JazzFestAccount, { 
     resolve: { root: { myFestival: { $each: true } } } 
   });
-  if (!me.$isLoaded) return null; // not loaded yet
+  if (!me.$isLoaded) return null;
   // [!code ++:4]
   const inviteLinkClickHandler = () => {
     const link = createInviteLink(me.root.myFestival, "writer")
@@ -87,7 +87,7 @@ export function Festival() {
   let inviteLink = $state<string | null>(null);
 
   function inviteLinkClickHandler() {
-    if (!me.current.$isLoaded) return; // not loaded yet
+    if (!me.current.$isLoaded) return;
     const link = createInviteLink(me.current?.root.myFestival, "writer")
     inviteLink = link;
   }
@@ -148,7 +148,7 @@ export function Festival() {
       router.push(`/festival/${festivalID}`);
     },
   });
-  if (!me.$isLoaded) return null; // not loaded yet
+  if (!me.$isLoaded) return null;
 
   const inviteLinkClickHandler = () => {
     const link = createInviteLink(me.root.myFestival, "writer")
@@ -193,7 +193,7 @@ export function Festival() {
 	});
 
   function inviteLinkClickHandler() {
-    if (!me.current.$isLoaded) return; // not loaded yet
+    if (!me.current.$isLoaded) return;
     const link = createInviteLink(me.current?.root.myFestival, "writer")
     inviteLink = link;
   }
@@ -256,7 +256,7 @@ export function Festival({id}: {id?: string}) {
   
   const festivalId = id ?? me?.root.myFestival.$jazz.id;
   const festival = useCoState(FestivalSchema, festivalId);
-  if (!festival.$isLoaded) return null; // not loaded yet
+  if (!festival.$isLoaded) return null;
   const inviteLinkClickHandler = () => {
     const link = createInviteLink(festival, "writer");
     setInviteLink(link);
@@ -331,9 +331,9 @@ export function Festival({id}: {id?: string}) {
   const festivalId = id ?? (me.$isLoaded ? me.root.myFestival.$jazz.id : undefined);
   const festival = useCoState(FestivalSchema, festivalId);
   // [!code --:1]
-  if (!me.$isLoaded) return null; // not loaded yet
+  if (!me.$isLoaded) return null;
   // [!code ++:1]
-  if (!festival.$isLoaded) return null; // not loaded yet
+  if (!festival.$isLoaded) return null;
   const inviteLinkClickHandler = () => {
     // [!code --:1]
     const link = createInviteLink(me.root.myFestival, "writer");
@@ -390,7 +390,7 @@ export function Festival({id}: {id?: string}) {
 	});
 
   function inviteLinkClickHandler() {
-    if (!me.current.$isLoaded) return; // not loaded yet
+    if (!me.current.$isLoaded) return;
     const link = createInviteLink(me.current?.root.myFestival, "writer")
     inviteLink = link;
   }
@@ -454,10 +454,10 @@ export function NewBand({ id }: { id?: string }) {
   
   const handleSave = () => {
     // [!code --:2]
-    if (!me.$isLoaded) return; // not loaded yet
+    if (!me.$isLoaded) return;
     me.root.myFestival.$jazz.push({ name });
     // [!code ++:2]
-    if (!festival.$isLoaded) return; // not loaded yet
+    if (!festival.$isLoaded) return;
     festival.$jazz.push({ name });
     setName("");
   };
@@ -498,10 +498,10 @@ export function NewBand({ id }: { id?: string }) {
 
   function handleSave() {
     // [!code --:2]
-    if (!me.current.$isLoaded) return; // not loaded yet
+    if (!me.current.$isLoaded) return;
     me.current.root.myFestival.$jazz.push({ name });
     // [!code ++:2]
-    if (!festival.current.$isLoaded) return; // not loaded yet
+    if (!festival.current.$isLoaded) return;
     festival.current.$jazz.push({ name });
     name = "";
   }

--- a/homepage/homepage/content/docs/groups/quickstart.mdx
+++ b/homepage/homepage/content/docs/groups/quickstart.mdx
@@ -47,9 +47,9 @@ export function Festival() {
   // [!code ++:1]
   const [inviteLink, setInviteLink] = useState<string>("");
   const { me } = useAccount(JazzFestAccount, { 
-    resolve: { root: { myFestival: true } } 
+    resolve: { root: { myFestival: { $each: true } } } 
   });
-  if (!me) return null; // not loaded yet
+  if (!me.$isLoaded) return null; // not loaded yet
   // [!code ++:4]
   const inviteLinkClickHandler = () => {
     const link = createInviteLink(me.root.myFestival, "writer")
@@ -59,7 +59,7 @@ export function Festival() {
     // [!code ++:1]
     <>
       <ul>
-        {me.root.myFestival.map((band) => band && <li key={band.$jazz.id}>{band.name}</li>)}
+        {me.root.myFestival.map((band) => <li key={band.$jazz.id}>{band.name}</li>)}
       </ul>
       {/* [!code ++:5] */}
       <input type="text" value={inviteLink} readOnly />
@@ -81,21 +81,21 @@ export function Festival() {
   import { JazzFestAccount } from "$lib/schema";
 
   const me = new AccountCoState(JazzFestAccount, { 
-    resolve: { root: { myFestival: true } } 
+    resolve: { root: { myFestival: { $each: true } } } 
   });
   // [!code ++:7]
   let inviteLink = $state<string | null>(null);
 
   function inviteLinkClickHandler() {
-    if (!me.current) return; // not loaded yet
+    if (!me.current.$isLoaded) return; // not loaded yet
     const link = createInviteLink(me.current?.root.myFestival, "writer")
     inviteLink = link;
   }
 </script>
 
 <ul>
-  {#each me.current?.root?.myFestival || [] as band}
-    <li>{band?.name}</li>
+  {#each me.current.$isLoaded ? me.current.root.myFestival : [] as band}
+    <li>{band.name}</li>
   {/each}
 </ul>
 
@@ -138,7 +138,7 @@ import { Festival as FestivalSchema, JazzFestAccount } from "@/app/schema";
 export function Festival() {
   const [inviteLink, setInviteLink] = useState<string>("");
   const { me } = useAccount(JazzFestAccount, { 
-    resolve: { root: { myFestival: true } } 
+    resolve: { root: { myFestival: { $each: true } } } 
   });
   // [!code ++:7]
   const router = useRouter();
@@ -148,7 +148,7 @@ export function Festival() {
       router.push(`/festival/${festivalID}`);
     },
   });
-  if (!me) return null; // not loaded yet
+  if (!me.$isLoaded) return null; // not loaded yet
 
   const inviteLinkClickHandler = () => {
     const link = createInviteLink(me.root.myFestival, "writer")
@@ -157,7 +157,7 @@ export function Festival() {
   return (
     <>
       <ul>
-        {me.root.myFestival.map((band) => band && <li key={band.$jazz.id}>{band.name}</li>)}
+        {me.root.myFestival.map((band) => <li key={band.$jazz.id}>{band.name}</li>)}
       </ul>
       <input type="text" value={inviteLink} readOnly />
       <button onClick={inviteLinkClickHandler}>
@@ -180,7 +180,7 @@ export function Festival() {
   import { Festival, JazzFestAccount } from "$lib/schema";
 
   const me = new AccountCoState(JazzFestAccount, { 
-    resolve: { root: { myFestival: true } } 
+    resolve: { root: { myFestival: { $each: true } } } 
   });
   let inviteLink = $state<string | null>(null);
 
@@ -193,15 +193,15 @@ export function Festival() {
 	});
 
   function inviteLinkClickHandler() {
-    if (!me.current) return; // not loaded yet
+    if (!me.current.$isLoaded) return; // not loaded yet
     const link = createInviteLink(me.current?.root.myFestival, "writer")
     inviteLink = link;
   }
 </script>
 
 <ul>
-  {#each me.current?.root?.myFestival || [] as band}
-    <li>{band?.name}</li>
+  {#each me.current.$isLoaded ? me.current.root.myFestival : [] as band}
+    <li>{band.name}</li>
   {/each}
 </ul>
 
@@ -256,7 +256,7 @@ export function Festival({id}: {id?: string}) {
   
   const festivalId = id ?? me?.root.myFestival.$jazz.id;
   const festival = useCoState(FestivalSchema, festivalId);
-  if (!festival) return null; // not loaded yet
+  if (!festival.$isLoaded) return null; // not loaded yet
   const inviteLinkClickHandler = () => {
     const link = createInviteLink(festival, "writer");
     setInviteLink(link);
@@ -328,12 +328,12 @@ export function Festival({id}: {id?: string}) {
     },
   });
   // [!code ++:2]
-  const festivalId = id ?? me?.root.myFestival.$jazz.id;
+  const festivalId = id ?? (me.$isLoaded ? me.root.myFestival.$jazz.id : undefined);
   const festival = useCoState(FestivalSchema, festivalId);
   // [!code --:1]
-  if (!me) return null; // not loaded yet
+  if (!me.$isLoaded) return null; // not loaded yet
   // [!code ++:1]
-  if (!festival) return null; // not loaded yet
+  if (!festival.$isLoaded) return null; // not loaded yet
   const inviteLinkClickHandler = () => {
     // [!code --:1]
     const link = createInviteLink(me.root.myFestival, "writer");
@@ -348,10 +348,10 @@ export function Festival({id}: {id?: string}) {
         {me.root.myFestival.map(
         {/* [!code ++:1] */}  
         {festival.map(
-          (band) => band && <li key={band.$jazz.id}>{band.name}</li>,
+          (band) => band.$isLoaded && <li key={band.$jazz.id}>{band.name}</li>,
         )}
       </ul>
-      {me?.canAdmin(festival) && (
+      {me.canAdmin(festival) && (
         <input type="text" value={inviteLink} readOnly />
         <button type="button" onClick={inviteLinkClickHandler}>
           Create Invite Link
@@ -378,7 +378,7 @@ export function Festival({id}: {id?: string}) {
     resolve: { root: { myFestival: true } } 
   });
   // [!code ++:2]
-  const festivalId = $derived(id ?? me.current?.root.myFestival.$jazz.id);
+  const festivalId = $derived(id ?? (me.current.$isLoaded ? me.current.root.myFestival.$jazz.id : undefined));
 	const festival = $derived(new CoState(Festival, festivalId));
   let inviteLink = $state<string | null>(null);
 
@@ -390,7 +390,7 @@ export function Festival({id}: {id?: string}) {
 	});
 
   function inviteLinkClickHandler() {
-    if (!me.current) return; // not loaded yet
+    if (!me.current.$isLoaded) return; // not loaded yet
     const link = createInviteLink(me.current?.root.myFestival, "writer")
     inviteLink = link;
   }
@@ -398,10 +398,10 @@ export function Festival({id}: {id?: string}) {
 
 <ul>
   <!-- [!code --:1] -->
-  {#each me.current?.root?.myFestival || [] as band}
+  {#each me.current.$isLoaded ? me.current.root.myFestival : [] as band}
   <!-- [!code ++:1] -->
-  {#each festival?.current || [] as band}
-    <li>{band?.name}</li>
+  {#each festival.current.$isLoaded ? festival.current : [] as band}
+    <li>{band.$isLoaded ? band.name : null}</li>
   {/each}
 </ul>
 
@@ -449,15 +449,15 @@ export function NewBand({ id }: { id?: string }) {
   const [name, setName] = useState("");
 
   // [!code ++:2]
-  const festivalId = id ?? me?.root.myFestival.$jazz.id;
+  const festivalId = id ?? me.$isLoaded ? me.root.myFestival.$jazz.id : undefined;
   const festival = useCoState(Festival, festivalId);
   
   const handleSave = () => {
     // [!code --:2]
-    if (!me) return; // not loaded yet
+    if (!me.$isLoaded) return; // not loaded yet
     me.root.myFestival.$jazz.push({ name });
     // [!code ++:2]
-    if (!festival) return; // not loaded yet
+    if (!festival.$isLoaded) return; // not loaded yet
     festival.$jazz.push({ name });
     setName("");
   };
@@ -493,15 +493,15 @@ export function NewBand({ id }: { id?: string }) {
   let name = $state("");
 
     // [!code ++:2]
-  const festivalId = $derived(id ?? me.current?.root.myFestival.$jazz.id);
+  const festivalId = $derived(id ?? me.current.$isLoaded ? me.current.root.myFestival.$jazz.id : undefined);
 	const festival = $derived(new CoState(Festival, festivalId));
 
   function handleSave() {
     // [!code --:2]
-    if (!me.current) return; // not loaded yet
+    if (!me.current.$isLoaded) return; // not loaded yet
     me.current.root.myFestival.$jazz.push({ name });
     // [!code ++:2]
-    if (!festival.current) return; // not loaded yet
+    if (!festival.current.$isLoaded) return; // not loaded yet
     festival.current.$jazz.push({ name });
     name = "";
   }

--- a/homepage/homepage/content/docs/groups/quickstart.mdx
+++ b/homepage/homepage/content/docs/groups/quickstart.mdx
@@ -94,9 +94,11 @@ export function Festival() {
 </script>
 
 <ul>
-  {#each me.current.$isLoaded ? me.current.root.myFestival : [] as band}
-    <li>{band.name}</li>
-  {/each}
+  {#if me.current.$isLoaded}
+    {#each me.current.root.myFestival as band}
+      <li>{band.name}</li>
+    {/each}
+  {/if}
 </ul>
 
 <input type="text" bind:value={inviteLink} readonly />
@@ -200,9 +202,11 @@ export function Festival() {
 </script>
 
 <ul>
-  {#each me.current.$isLoaded ? me.current.root.myFestival : [] as band}
-    <li>{band.name}</li>
-  {/each}
+  {#if me.current.$isLoaded}
+    {#each me.current.root.myFestival as band}
+      <li>{band.name}</li>
+    {/each}
+  {/if}
 </ul>
 
 <input type="text" bind:value={inviteLink} readonly />
@@ -397,12 +401,14 @@ export function Festival({id}: {id?: string}) {
 </script>
 
 <ul>
-  <!-- [!code --:1] -->
-  {#each me.current.$isLoaded ? me.current.root.myFestival : [] as band}
-  <!-- [!code ++:1] -->
-  {#each festival.current.$isLoaded ? festival.current : [] as band}
-    <li>{band.$isLoaded ? band.name : null}</li>
-  {/each}
+  {#if me.current.$isLoaded}
+    <!-- [!code --:1] -->
+    {#each me.current.root.myFestival as band}
+    <!-- [!code ++:1] -->
+    {#each festival.current as band}
+      <li>{band.$isLoaded ? band.name : null}</li>
+    {/each}
+  {/if}
 </ul>
 
 {#if me.current?.canAdmin(festival.current)}

--- a/homepage/homepage/content/docs/groups/sharing.mdx
+++ b/homepage/homepage/content/docs/groups/sharing.mdx
@@ -299,7 +299,7 @@ async function approveJoinRequest(
 ) {
   const account = await Account.load(joinRequest.$jazz.refs.account.id);
 
-  if (account) {
+  if (account.$isLoaded) {
     targetGroup.addMember(account, "reader");
     joinRequest.$jazz.set("status", "approved");
 

--- a/homepage/homepage/content/docs/project-setup.mdx
+++ b/homepage/homepage/content/docs/project-setup.mdx
@@ -210,7 +210,7 @@ export default async function ServerSidePage(props: {
         This is a server component!
       </div>
       <label>
-        <div className="text-sm">Item title "{item?.title}"</div>
+        {item.$isLoaded && <div className="text-sm">Item title "{item.title}"</div>}
       </label>
     </div>
   );
@@ -240,7 +240,7 @@ export default async function ServerSidePage(props: {
     This component can render on the server!
   </div>
   <label>
-    <div class="text-sm">Item title {#await item then item}"{item?.title}"{/await}</div>
+    <div class="text-sm">Item title {#await item then item}"{item.$isLoaded ? item.title : ""}"{/await}</div>
   </label>
 </div>
 ```

--- a/homepage/homepage/content/docs/project-setup/ssr.mdx
+++ b/homepage/homepage/content/docs/project-setup/ssr.mdx
@@ -244,7 +244,7 @@ export function Festival() {
   const { me } = useAccount(JazzFestAccount, {
     resolve: { root: { myFestival: { $each: true } } },
   });
-  if (!me.$isLoaded) return null; // not loaded yet
+  if (!me.$isLoaded) return null; 
   return (
     <>
       <ul>

--- a/homepage/homepage/content/docs/project-setup/ssr.mdx
+++ b/homepage/homepage/content/docs/project-setup/ssr.mdx
@@ -242,14 +242,15 @@ import { JazzFestAccount } from "@/app/schema";
 
 export function Festival() {
   const { me } = useAccount(JazzFestAccount, {
-    resolve: { root: { myFestival: { $each: true } } },
+    resolve: { root: { myFestival: { $each: { $onError: 'catch' } } } },
   });
   if (!me.$isLoaded) return null; 
   return (
     <>
       <ul>
-        {me.root.myFestival.map(
-          (band) => <li key={band.$jazz.id}>{band.name}</li>,
+        {me.root.myFestival.map((band) => {
+          if (!band.$isLoaded) return null;
+          return <li key={band.$jazz.id}>{band.name}</li>;
         )}
       </ul>
       {/* [!code ++:3] */}

--- a/homepage/homepage/content/docs/project-setup/ssr.mdx
+++ b/homepage/homepage/content/docs/project-setup/ssr.mdx
@@ -167,8 +167,8 @@ export default async function ServerSidePage(props: {
       <h1>🎪 Server-rendered Festival {festivalId}</h1>
 
       <ul>
-        {festival?.filter(Boolean).map((band) => {
-          if (!band) return null;
+        {festival.$isLoaded && festival.map((band) => {
+          if (!band.$isLoaded) return null;
           return <li key={band.$jazz.id}>🎶 {band.name}</li>;
         })}
       </ul>
@@ -200,8 +200,10 @@ export default async function ServerSidePage(props: {
   <h1>🎪 Server-rendered Festival {festivalId}</h1>
   <ul>
     {#await festival then festival}
-      {#each festival?.filter(Boolean) || [] as band (band.$jazz.id)} 
-        <li>🎶 {band.name}</li>;
+      {#each festival.$isLoaded ? festival : [] as band (band.$jazz.id)} 
+        {#if band.$isLoaded}
+          <li>🎶 {band.name}</li>
+        {/if}
       {/each}
     {/await}
   </ul>
@@ -240,14 +242,14 @@ import { JazzFestAccount } from "@/app/schema";
 
 export function Festival() {
   const { me } = useAccount(JazzFestAccount, {
-    resolve: { root: { myFestival: true } },
+    resolve: { root: { myFestival: { $each: true } } },
   });
-  if (!me) return null; // not loaded yet
+  if (!me.$isLoaded) return null; // not loaded yet
   return (
     <>
       <ul>
-        {me?.root.myFestival.map(
-          (band) => band && <li key={band.$jazz.id}>{band.name}</li>,
+        {me.root.myFestival.map(
+          (band) => <li key={band.$jazz.id}>{band.name}</li>,
         )}
       </ul>
       {/* [!code ++:3] */}
@@ -270,8 +272,10 @@ export function Festival() {
 </script>
 
 <ul>
-  {#each me.current?.root.myFestival || [] as band}
-    <li>{band?.name}</li>
+  {#each me.current.$isLoaded ? me.current.root.myFestival : [] as band}
+    {#if band.$isLoaded}
+      <li>{band.name}</li>
+    {/if}
   {/each}
 </ul>
 <!-- [!code ++:3] -->

--- a/homepage/homepage/content/docs/schemas/accounts-and-migrations.mdx
+++ b/homepage/homepage/content/docs/schemas/accounts-and-migrations.mdx
@@ -143,7 +143,7 @@ function DashboardPageComponent() {
   return (
     <div>
       <h1>Dashboard</h1>
-      {me ? (
+      {me.$isLoaded ? (
         <div>
           <p>Logged in as {me.profile.name}</p>
           <h2>My chats</h2>
@@ -259,14 +259,13 @@ export const MyAppAccount = co.account({
     });
   }
 
-  // We need to load the root field to check for the myContacts field
+  // We need to load the root field to check for the myBookmarks field
   const { root } = await account.$jazz.ensureLoaded({
     resolve: { root: true }
   });
 
-  // we specifically need to check for undefined,
-  // because myBookmarks might simply be not loaded (`null`) yet
-  if (root.myBookmarks === undefined) { // [!code ++:3]
+  // Check if the field has been set using $jazz.has()
+  if (!root.$jazz.has("myBookmarks")) { // [!code ++:3]
     root.$jazz.set("myBookmarks", co.list(Bookmark).create([], Group.create()));
   }
 });

--- a/homepage/homepage/content/docs/using-covalues/cofeeds.mdx
+++ b/homepage/homepage/content/docs/using-covalues/cofeeds.mdx
@@ -96,7 +96,9 @@ const sessionId = `${me.$jazz.id}_session_z1` as SessionID;
 const sessionFeed = activityFeed.perSession[sessionId];
 
 // Latest entry from a session
-console.log(sessionFeed?.value?.action); // "watering"
+if (sessionFeed?.value.$isLoaded) {
+  console.log(sessionFeed.value.action); // "watering"
+}
 ```
 </CodeGroup>
 
@@ -123,7 +125,9 @@ const sessionId = `${me.$jazz.id}_session_z1` as SessionID;
 const currentSessionFeed = activityFeed.inCurrentSession;
 
 // Latest entry from the current session
-console.log(currentSessionFeed?.value?.action); // "harvesting"
+if (currentSessionFeed?.value.$isLoaded) {
+  console.log(currentSessionFeed.value.action); // "harvesting"
+}
 ```
 </CodeGroup>
 
@@ -152,7 +156,9 @@ const accountId = me.$jazz.id;
 const accountFeed = activityFeed.perAccount[accountId];
 
 // Latest entry from the account
-console.log(accountFeed.value?.action); // "watering"
+if (accountFeed?.value.$isLoaded) {
+  console.log(accountFeed.value.action); // "watering"
+}
 ```
 </CodeGroup>
 
@@ -179,7 +185,9 @@ const accountId = me.$jazz.id;
 const myLatestEntry = activityFeed.byMe;
 
 // Latest entry from the current account
-console.log(myLatestEntry?.value?.action); // "harvesting"
+if (myLatestEntry?.value.$isLoaded) {
+  console.log(myLatestEntry.value.action); // "harvesting"
+}
 ```
 </CodeGroup>
 
@@ -213,12 +221,16 @@ const sessionFeed = activityFeed.perSession[sessionId];
 
 // Iterate over all entries from the account
 for (const entry of accountFeed.all) {
-  console.log(entry.value);
+  if (entry.value.$isLoaded) {
+    console.log(entry.value);
+  }
 }
 
 // Iterate over all entries from the session
 for (const entry of sessionFeed.all) {
-  console.log(entry.value);
+  if (entry.value.$isLoaded) {
+    console.log(entry.value);
+  }
 }
 ```
 </CodeGroup>
@@ -246,12 +258,14 @@ const activityFeed = ActivityFeed.create([]);
 // Get the latest entry from the current account
 const latestEntry = activityFeed.byMe;
 
-console.log(`My last action was ${latestEntry?.value?.action}`);
+if (latestEntry?.value.$isLoaded) {
+  console.log(`My last action was ${latestEntry.value.action}`);
   // "My last action was harvesting"
+}
 
 // Get the latest entry from each account
 const latestEntriesByAccount = Object.values(activityFeed.perAccount).map(entry => ({
-  accountName: entry.by?.profile?.name,
+  accountName: entry.by?.profile.$isLoaded ? entry.by.profile.name : "Unknown",
   value: entry.value,
 }));
 ```

--- a/homepage/homepage/content/docs/using-covalues/colists.mdx
+++ b/homepage/homepage/content/docs/using-covalues/colists.mdx
@@ -175,10 +175,8 @@ type Task = typeof Task;
 const ListOfTasks = co.list(Task);
 type ListOfTasks = typeof ListOfTasks;
 
-export function getCurrentTasks(list: co.loaded<ListOfTasks>) {
-  return list.filter(
-    (task): task is co.loaded<Task> => !task?.deleted
-  );
+export function getCurrentTasks(list: co.loaded<ListOfTasks, { $each: true }>) {
+  return list.filter(task => !task.deleted);
 }
 
 async function main() {
@@ -350,7 +348,7 @@ function TaskList({ tasks }: { tasks: co.loaded<typeof ListOfTasks> }) {
   return  (
    <ul>
      {tasks.map(task => (
-       task ? (
+       task.$isLoaded ? (
         <li key={task.$jazz.id}>
           {task.title} - {task.status}
         </li>

--- a/homepage/homepage/content/docs/using-covalues/cotexts.mdx
+++ b/homepage/homepage/content/docs/using-covalues/cotexts.mdx
@@ -209,7 +209,7 @@ function TextEditor({ textId }: { textId: string }) {
   const note = useCoState(co.plainText(), textId);
 
   return (
-    note && <textarea
+    note.$isLoaded && <textarea
       value={note.toString()}
       onChange={(e) => {
         // Efficiently update only what the user changed
@@ -358,16 +358,17 @@ import { EditorState } from "prosemirror-state";
 import { EditorView } from "prosemirror-view";
 
 function RichTextEditor() {
-  const { me } = useAccount(JazzAccount, { resolve: { profile: true } });
+  const { me } = useAccount(JazzAccount, { resolve: { profile: { bio: true} } });
   const editorRef = useRef<HTMLDivElement>(null);
   const viewRef = useRef<EditorView | null>(null);
 
+  const bio = me.$isLoaded ? me.profile.bio : undefined;
   useEffect(() => {
-    if (!me?.profile.bio || !editorRef.current) return;
+    if (!bio || !editorRef.current) return;
 
     // Create the Jazz plugin for ProseMirror
     // Providing a co.richText() instance to the plugin to automatically sync changes
-    const jazzPlugin = createJazzPlugin(me.profile.bio); // [!code ++]
+    const jazzPlugin = createJazzPlugin(bio); // [!code ++]
 
     // Set up ProseMirror with the Jazz plugin
     if (!viewRef.current) {
@@ -388,9 +389,9 @@ function RichTextEditor() {
         viewRef.current = null;
       }
     };
-  }, [me?.profile.bio?.$jazz.id]);
+  }, [bio?.$jazz.id]);
 
-  if (!me) return null;
+  if (!me.$isLoaded) return null;
 
   return (
     <div className="border rounded">

--- a/homepage/homepage/content/docs/using-covalues/covectors.mdx
+++ b/homepage/homepage/content/docs/using-covalues/covectors.mdx
@@ -135,7 +135,7 @@ const foundDocuments = useCoStateWithSelector(
       $each: { embedding: true }
     },
     select(documents) {
-      if (!documents) return;
+      if (!documents.$isLoaded) return;
 
       // If no query embedding, return all entries
       if (!queryEmbedding) return documents.map((value) => ({ value }));
@@ -175,13 +175,15 @@ const documents = await DocumentsList.load(documentsListId, {
 const queryEmbedding = await createEmbedding("search query");
 
 // 3) Sort documents by vector similarity
-const similarDocuments = documents
-  ?.map((value) => ({
-    value,
-    similarity: value.embedding.$jazz.cosineSimilarity(queryEmbedding), // [!code ++]
-  }))
-  .sort((a, b) => b.similarity - a.similarity)
-  .filter((result) => result.similarity > 0.5);
+const similarDocuments = documents.$isLoaded
+  ? documents
+      .map((value) => ({
+        value,
+        similarity: value.embedding.$jazz.cosineSimilarity(queryEmbedding), // [!code ++]
+      }))
+      .sort((a, b) => b.similarity - a.similarity)
+      .filter((result) => result.similarity > 0.5)
+  : undefined;
 ```
 </TabbedCodeGroupItem>
 <TabbedCodeGroupItem label="Svelte" value="svelte" className="[&_span]:[tab-size:2]" icon={<SvelteLogo />} preferWrap>
@@ -202,7 +204,7 @@ const similarDocuments = documents
   // 2) Sort documents by vector similarity
   const foundDocuments = $derived((() => {
     const docs = documents.current;
-    if (!docs) return;
+    if (!docs.$isLoaded) return;
 
     if (!queryEmbedding) {
       return docs.map((value) => ({ value }));

--- a/homepage/homepage/content/docs/using-covalues/filestreams.mdx
+++ b/homepage/homepage/content/docs/using-covalues/filestreams.mdx
@@ -314,7 +314,7 @@ const fileStreamId = "co_z123";
 // Load a FileStream by ID
 const fileStream = await FileStream.load(fileStreamId);
 
-if (fileStream) {
+if (fileStream.$isLoaded) {
   console.log('FileStream loaded successfully');
 
   // Check if it's complete

--- a/homepage/homepage/content/docs/using-covalues/history.mdx
+++ b/homepage/homepage/content/docs/using-covalues/history.mdx
@@ -50,8 +50,8 @@ task.$jazz.getEdits().status?.all
 
 // Check if edits exist
 const statusEdits = task.$jazz.getEdits().status;
-if (statusEdits) {
-  const name = statusEdits.by?.profile?.name;
+if (statusEdits && statusEdits.by?.profile.$isLoaded) {
+  const name = statusEdits.by.profile.name;
   console.log(`Last changed by ${name}`);
 }
 ```

--- a/homepage/homepage/content/docs/using-covalues/imagedef.mdx
+++ b/homepage/homepage/content/docs/using-covalues/imagedef.mdx
@@ -124,7 +124,7 @@ const thumbnail = await createImage(myBlob, {
 });
 
 // or, in case of migration, you can use the original stored image.
-const newThumb = await createImage(mainImage!.original!.toBlob()!, {
+const newThumb = await createImage(mainImage.original.toBlob()!, {
   maxSize: 100,
 });
 
@@ -174,7 +174,7 @@ const image = await ImageDefinition.load("123", {
   },
 });
 
-if(image) {
+if(image.$isLoaded) {
   console.log({
     originalSize: image.originalSize,
     placeholderDataUrl: image.placeholderDataURL,
@@ -238,7 +238,7 @@ import { highestResAvailable } from "jazz-tools/media";
 
 const image = await ImageDefinition.load(imageId);
 
-if(image === null) {
+if(!image.$isLoaded) {
   throw new Error("Image not found");
 }
 

--- a/homepage/homepage/content/docs/using-covalues/imagedef/react-native-expo.mdx
+++ b/homepage/homepage/content/docs/using-covalues/imagedef/react-native-expo.mdx
@@ -140,7 +140,7 @@ const thumbnail = await createImage(myFile, {
 });
 
 // or, in case of migration, you can use the original stored image.
-const newThumb = await createImage(mainImage!.original!.toBlob()!, {
+const newThumb = await createImage(mainImage.original.toBlob()!, {
   maxSize: 100,
 });
 
@@ -275,7 +275,7 @@ const image = await ImageDefinition.load("123", {
   },
 });
 
-if(image) {
+if(image.$isLoaded) {
   console.log({
     originalSize: image.originalSize,
     placeholderDataUrl: image.placeholderDataURL,

--- a/homepage/homepage/content/docs/using-covalues/imagedef/react-native.mdx
+++ b/homepage/homepage/content/docs/using-covalues/imagedef/react-native.mdx
@@ -140,7 +140,7 @@ const thumbnail = await createImage(myFile, {
 });
 
 // or, in case of migration, you can use the original stored image.
-const newThumb = await createImage(mainImage!.original!.toBlob()!, {
+const newThumb = await createImage(mainImage.original.toBlob()!, {
   maxSize: 100,
 });
 
@@ -275,7 +275,7 @@ const image = await ImageDefinition.load("123", {
   },
 });
 
-if(image) {
+if(image.$isLoaded) {
   console.log({
     originalSize: image.originalSize,
     placeholderDataUrl: image.placeholderDataURL,

--- a/homepage/homepage/content/docs/using-covalues/imagedef/react.mdx
+++ b/homepage/homepage/content/docs/using-covalues/imagedef/react.mdx
@@ -124,7 +124,7 @@ const thumbnail = await createImage(myBlob, {
 });
 
 // or, in case of migration, you can use the original stored image.
-const newThumb = await createImage(mainImage!.original!.toBlob()!, {
+const newThumb = await createImage(mainImage.original.toBlob()!, {
   maxSize: 100,
 });
 
@@ -263,7 +263,7 @@ const image = await ImageDefinition.load("123", {
   },
 });
 
-if(image) {
+if(image.$isLoaded) {
   console.log({
     originalSize: image.originalSize,
     placeholderDataUrl: image.placeholderDataURL,

--- a/homepage/homepage/content/docs/using-covalues/imagedef/svelte.mdx
+++ b/homepage/homepage/content/docs/using-covalues/imagedef/svelte.mdx
@@ -124,7 +124,7 @@ const thumbnail = await createImage(myBlob, {
 });
 
 // or, in case of migration, you can use the original stored image.
-const newThumb = await createImage(mainImage!.original!.toBlob()!, {
+const newThumb = await createImage(mainImage.original.toBlob()!, {
   maxSize: 100,
 });
 
@@ -248,7 +248,7 @@ const image = await ImageDefinition.load("123", {
   },
 });
 
-if(image) {
+if(image.$isLoaded) {
   console.log({
     originalSize: image.originalSize,
     placeholderDataUrl: image.placeholderDataURL,

--- a/homepage/homepage/content/docs/using-covalues/subscription-and-loading.mdx
+++ b/homepage/homepage/content/docs/using-covalues/subscription-and-loading.mdx
@@ -328,7 +328,7 @@ project.$jazz.loadingState // "unauthorized"
 ```
 </CodeGroup>
 
-Loading will be successful if all requested references are loaded, even if other references were not explicitly requested.
+Loading will be successful if all requested references are loaded. Non-requested references may or may not be available.
 
 <CodeGroup preferWrap>
 ```ts

--- a/homepage/homepage/content/docs/using-covalues/subscription-and-loading.mdx
+++ b/homepage/homepage/content/docs/using-covalues/subscription-and-loading.mdx
@@ -38,11 +38,16 @@ function ProjectView({ projectId }: { projectId: string }) {
     resolve: { tasks: { $each: true } } // Tell Jazz to load each task in the list
   });
   
-  if (project === null) {
-    return "Project not found or not accessible"
-  } else if (project === undefined) {
-	  return "Loading..."
-	}
+  if (!project.$isLoaded) {
+    switch (project.$jazz.loadingState) {
+      case "unauthorized":
+        return "Project not accessible";
+      case "unavailable":
+        return "Project not found";
+      case "unloaded":
+        return "Loading project...";
+    }
+  }
 
   return (
     <div>
@@ -70,10 +75,15 @@ function ProjectView({ projectId }: { projectId: string }) {
   });
 </script>
 
-{#if project.current === null}
-  Project not found or not accessible
-{:else if project.current === undefined}
-  Loading...
+{#if !project.current.$isLoaded}
+  switch (project.current.$jazz.loadingState) {
+    case "unauthorized":
+      return "Project not accessible";
+    case "unavailable":
+      return "Project not found";
+    case "unloaded":
+      return "Loading project...";
+  }
 {:else}
   <div>
     <h1>{project.current.name}</h1>
@@ -108,7 +118,7 @@ function ProjectList() {
     resolve: { profile: true }
   })
 
-  if (!me) {
+  if (!me.$isLoaded) {
     return "Loading...";
   }
 
@@ -130,7 +140,7 @@ function ProjectList() {
   });
 </script>
 
-{#if !account.current}
+{#if !account.current.$isLoaded}
   Loading...
 {:else}
   <div>
@@ -143,13 +153,18 @@ function ProjectList() {
 
 ### Loading States
 
-When you load or subscribe to a CoValue through a hook (or directly), it can return one of three states:
+When you load or subscribe to a CoValue through a hook (or directly), it can be either:
 
-- `undefined` → an interim state while Jazz is fetching the CoValue
-- `null` → a failure state. Either the CoValue couldn't be found, or it isn't accessible (e.g. due to permissions)
-- `Value` → The successfully loaded CoValue instance
+- **Loaded** → The CoValue has been successfully loaded and all its data is available
+- **Not Loaded** → The CoValue is not yet available
 
-Check the examples above for practical demonstrations of how to handle these three states in your application.
+You can use the `$isLoaded` field to check whether a CoValue is loaded. For more detailed information about why a CoValue is not loaded, you can check `$jazz.loadingState`:
+
+- `"unloaded"` → The CoValue is still being fetched
+- `"unauthorized"` → The current user doesn't have permission to access this CoValue
+- `"unavailable"` → The CoValue couldn't be found or an error (e.g. a network timeout) occurred while loading
+
+See the examples above for practical demonstrations of how to handle these three states in your application.
 
 ## Deep Loading
 
@@ -175,28 +190,27 @@ const Project = co.map({
 });
 
 const project = await Project.load(projectId);
-if (!project) throw new Error("Project not found or not accessible");
+if (!project.$isLoaded) throw new Error("Project not found or not accessible");
 
 // This will be loaded
 project.name; // string
 
 // This *may not be loaded*, and *may not be accessible*
-project.tasks; // undefined | null | ListOfTasks
+project.tasks; // ListOfTasks | Unloaded<ListOfTasks>
 
 const projectWithTasksShallow = await Project.load(projectId, {
   resolve: {
     tasks: true
   }
 });
-if (!projectWithTasksShallow) throw new Error("Project not found or not accessible");
-
+if (!projectWithTasksShallow.$isLoaded) throw new Error("Project not found or not accessible");
 
 // This list of tasks will be shallowly loaded
 projectWithTasksShallow.tasks; // ListOfTasks
 // We can access the properties of the shallowly loaded list
 projectWithTasksShallow.tasks.length; // number
 // This *may not be loaded*, and *may not be accessible*
-projectWithTasksShallow.tasks[0]; // undefined | null | Task
+projectWithTasksShallow.tasks[0]; // Task | Unloaded<Task>
 ```
 </CodeGroup>
 
@@ -211,16 +225,16 @@ const projectWithTasks = await Project.load(projectId, {
     }
   }
 });
-if (!projectWithTasks) throw new Error("Project not found or not accessible");
+if (!projectWithTasks.$isLoaded) throw new Error("Project not found or not accessible");
 
-// The task will either be loaded or null if it is not accessible
-projectWithTasks.tasks[0]; // Task | null
+// The task will be loaded
+projectWithTasks.tasks[0]; // Task
 // Primitive fields are always loaded
 projectWithTasks.tasks[0].title; // string
-// References on the Task may not be loaded, and may not be accessible
-projectWithTasks.tasks[0].subtasks // undefined | null | ListOfTasks
+// References on the Task may not be loaded
+projectWithTasks.tasks[0].subtasks; // ListOfTasks | Unloaded<ListOfTasks>
 // CoTexts are CoValues too
-projectWithTasks.tasks[0].description; // undefined | null | CoPlainText
+projectWithTasks.tasks[0].description; // CoPlainText | Unloaded<CoPlainText>
 ```
 </CodeGroup>
 We can also build a query that *deeply resolves* to multiple levels:
@@ -239,12 +253,12 @@ const projectDeep = await Project.load(projectId, {
     }
   }
 });
-if (!projectDeep) throw new Error("Project not found or not accessible");
+if (!projectDeep.$isLoaded) throw new Error("Project not found or not accessible");
 
 // Primitive fields are always loaded
 projectDeep.tasks[0].subtasks[0].title; // string
-// The description will either be loaded or null if it is not accessible
-projectDeep.tasks[0].description; // CoPlainText | null
+// The description will be loaded as well
+projectDeep.tasks[0].description; // CoPlainText
 ```
 </CodeGroup>
 
@@ -287,7 +301,7 @@ const projectWithTasksShallow = useCoState(Project, projectId, {
 
 ## Loading Errors
 
-A load operation will be successful **only** in case all references requested (both optional and required) could be successfully loaded, otherwise the load operation will return null in order to avoid potential inconsistencies.
+A load operation will be successful **only** if all references requested (both optional and required) could be successfully loaded. If any reference cannot be loaded, the entire load operation will return an unloaded CoValue to avoid potential inconsistencies.
 
 <CodeGroup preferWrap>
 ```ts
@@ -295,7 +309,8 @@ A load operation will be successful **only** in case all references requested (b
 const task = await Task.load(taskId, { 
   resolve: { description: true } 
 });
-task // null
+task.$isLoaded // false
+task.$jazz.loadingState // "unauthorized"
 ```
 </CodeGroup>
 
@@ -308,11 +323,12 @@ const project = await Project.load(projectId, {
   resolve: { tasks: { $each: true } }
 });
 
-project // null
+project.$isLoaded // false
+project.$jazz.loadingState // "unauthorized"
 ```
 </CodeGroup>
 
-Loading will be successful if all requested references are loaded, even if other references may not be accessible.
+Loading will be successful if all requested references are loaded, even if other references were not explicitly requested.
 
 <CodeGroup preferWrap>
 ```ts
@@ -320,11 +336,12 @@ Loading will be successful if all requested references are loaded, even if other
 const project = await Project.load(projectId, {
   resolve: true
 });
-if (!project) throw new Error("Project not found or not accessible");
+if (!project.$isLoaded) throw new Error("Project not found or not accessible");
 
 // Assuming the user has permissions on the project, this load will succeed, even if the user cannot load one of the tasks in the list
-project // Project | null
-project.tasks[0] // Task | null
+project.$isLoaded // true
+// Tasks may not be loaded since we didn't request them
+project.tasks.$isLoaded // may be false
 ```
 </CodeGroup>
 
@@ -363,20 +380,18 @@ For example, in case of a `project` (which the user can access) with three `task
 
 #### Scenario 1: Skip Inaccessible List Items
 
-If some of your list items may not be accessible, you can skip loading them by specifying `$onError: 'catch'`, and inaccessible items will be `null`, while accessible items load properly.
+If some of your list items may not be accessible, you can skip loading them by specifying `$onError: 'catch'`. Inaccessible items will be unloaded CoValues, while accessible items load properly.
 <CodeGroup preferWrap>
 ```ts
-// Inaccessible tasks will be null, but the project will be loaded
+// Inaccessible tasks will be unloaded, but the project will be loaded
 const project = await Project.load(projectId, {
-	resolve: { tasks: { $each: true, $onError: 'catch' } }
+	resolve: { tasks: { $each: { $onError: 'catch' } } }
 });
-if (!project) throw new Error("Project not found or not accessible");
-if (!project.tasks) throw new Error("Project's task list not found or not accessible");
+if (!project.$isLoaded) throw new Error("Project not found or not accessible");
 
-project // Project
-project.tasks[0]; // Task
-project.tasks[1]; // Task
-project.tasks[2]; // null
+project.tasks[0].$isLoaded; // true
+project.tasks[1].$isLoaded; // true
+project.tasks[2].$isLoaded; // false (caught by $onError)
 ```
 </CodeGroup>
 #### Scenario 2: Handling Inaccessible Nested References
@@ -390,13 +405,13 @@ This load will fail, because the `$onError` is defined only for the `task.descri
 const project = await Project.load(projectId, {
 	resolve: {
 		tasks: {
-			$each: { description: true, $onError: 'catch' },
+			$each: { description: { $onError: 'catch' } },
 		}
 	}
 });
 
 // The load fails because task[2] is inaccessible and no $onError caught it.
-project // null
+project.$isLoaded // false
 ```
 </CodeGroup>
 We can fix this by adding handlers at both levels
@@ -407,20 +422,19 @@ const project = await Project.load(projectId, {
 	resolve: {
 		tasks: {
 			$each: { 
-				description: true, 
-				$onError: 'catch' // catch errors loading task descriptions
+				description: { $onError: 'catch' }, // catch errors loading task descriptions
+				$onError: 'catch' // catch errors loading tasks too
 			},
-			$onError: 'catch' // catch errors loading tasks too
 		}
 	}
 });
 
-project // Project
-project.tasks[0];                // Task
-project.tasks[0]?.description;    // CoPlainText
-project.tasks[1];                // Task
-project.tasks[1]?.description;    // null (caught by the inner handler)
-project.tasks[2];                // null (caught by the outer handler)
+project.$isLoaded // true
+project.tasks[0].$isLoaded;                // true
+project.tasks[0].description.$isLoaded;    // true
+project.tasks[1].$isLoaded;                // true
+project.tasks[1].description.$isLoaded;    // false (caught by the inner handler)
+project.tasks[2].$isLoaded;                // false (caught by the outer handler)
 ```
 </CodeGroup>
 
@@ -520,6 +534,7 @@ unsubscribe();
 </CodeGroup>
 
 <ContentByFramework framework={["react", "react-native", "react-native-expo"]}>
+
 ## Selectors [!framework=react,react-native,react-native-expo]
 Sometimes, you only need to react to changes in specific parts of a CoValue. In those cases, you can use the `useCoStateWithSelector` hook to specify what data you are interested in.
 
@@ -539,7 +554,7 @@ function ProjectView({ projectId }: { projectId: string }) {
       tasks: true
     },
     select: (project) => {
-      if (!project) return project;
+      if (!project.$isLoaded) return project.$jazz.loadingState;
       return {
         name: project.name,
         taskCount: project.tasks.length,
@@ -550,10 +565,15 @@ function ProjectView({ projectId }: { projectId: string }) {
       a?.name === b?.name && a?.taskCount === b?.taskCount
   });
   
-  if (!project) {
-    return project === null
-      ? "Project not found or not accessible"
-      : "Loading...";
+  if (typeof project === 'string') {
+    switch (project) {
+      case "unauthorized":
+        return "Project not accessible";
+      case "unavailable":
+        return "Project not found";
+      case "unloaded":
+        return "Loading...";
+    }
   }
 
   return (
@@ -580,7 +600,7 @@ function ProfileName() {
     resolve: {
       profile: true,
     },
-    select: (account) => account ? account.profile.name : "Loading...",
+    select: (account) => account.$isLoaded ? account.profile.name : "Loading...",
   });
 
   return (
@@ -602,7 +622,7 @@ In most cases, you'll have specified the depth of data you need in a `resolve` q
 async function completeAllTasks(projectId: string) {
   // Load the project
   const project = await Project.load(projectId, { resolve: true });
-  if (!project) return;
+  if (!project.$isLoaded) return;
 
   // Ensure tasks are deeply loaded
   const loadedProject = await project.$jazz.ensureLoaded({
@@ -626,8 +646,8 @@ This can be useful if you have a shallowly loaded CoValue instance, and would li
 ## Best practices
 
 - Load exactly what you need. Start shallow and add your nested references with care.
-- Handle all three states up front. Treat `undefined` as loading, `null` as not found or not accessible, and only render data for real values.
-- Use `$onError` at each level of your query that can fail.
+- Always check `$isLoaded` before accessing CoValue data. Use `$jazz.loadingState` for more detailed information.
+- Use `$onError: 'catch'` at each level of your query that can fail to handle inaccessible data gracefully.
 <ContentByFramework framework="react">
 - Use selectors and an `equalityFn` to prevent unnecessary re-renders.
 </ContentByFramework>

--- a/packages/jazz-tools/src/tools/coValues/coList.ts
+++ b/packages/jazz-tools/src/tools/coValues/coList.ts
@@ -355,7 +355,7 @@ export class CoList<out Item = any>
   /**
    * Given some data, updates an existing CoList or initialises a new one if none exists.
    *
-   * Note: This method respects resolve options, and thus can return `null` if the references cannot be resolved.
+   * Note: This method respects resolve options, and thus can return an unloaded value if the references cannot be resolved.
    *
    * @example
    * ```ts
@@ -419,7 +419,7 @@ export class CoList<out Item = any>
    * @param unique The unique identifier of the CoList to load.
    * @param ownerID The ID of the owner of the CoList.
    * @param options Additional options for loading the CoList.
-   * @returns The loaded CoList, or null if unavailable.
+   * @returns The loaded CoList, or an unloaded value if unavailable.
    */
   static loadUnique<L extends CoList, const R extends RefsToResolve<L> = true>(
     this: CoValueClass<L>,

--- a/packages/jazz-tools/src/tools/coValues/coMap.ts
+++ b/packages/jazz-tools/src/tools/coValues/coMap.ts
@@ -464,7 +464,7 @@ export class CoMap extends CoValueBase implements CoValue {
   /**
    * Given some data, updates an existing CoMap or initialises a new one if none exists.
    *
-   * Note: This method respects resolve options, and thus can return `null` if the references cannot be resolved.
+   * Note: This method respects resolve options, and thus can return an unloaded value if the references cannot be resolved.
    *
    * @example
    * ```ts
@@ -534,7 +534,7 @@ export class CoMap extends CoValueBase implements CoValue {
    * @param unique The unique identifier of the CoMap to load.
    * @param ownerID The ID of the owner of the CoMap.
    * @param options Additional options for loading the CoMap.
-   * @returns The loaded CoMap, or null if unavailable.
+   * @returns The loaded CoMap, or an unloaded value if unavailable.
    *
    * @deprecated Use `co.map(...).loadUnique` instead.
    */


### PR DESCRIPTION
# Description

Follow-up to https://github.com/garden-co/jazz/pull/3001.

Updates TS docs and the homepage's docs to account for explicit loading states.

Key changes:
- updated the "Subscriptions & Deep Loading" page
- fixed the usages of `$onError` in that page's examples
- updated all code examples to use explicit loading states

⚠️ I'll hold off from writing an upgrade guide until we decide if we want to add explicit loading states and drop autoload in the same release or not.

## Manual testing instructions

See [updated docs](https://jazz-homepage-git-docs-explicit-loading-states-gcmp.vercel.app/).