### PR TITLE
docs: Update jazz syntax in better-auth example

### DIFF
--- a/homepage/homepage/content/docs/authentication/better-auth.mdx
+++ b/homepage/homepage/content/docs/authentication/better-auth.mdx
@@ -203,7 +203,7 @@ await betterAuthClient.signUp.email(
     onSuccess: async () => {
       // Don't forget to update the profile's name. It's not done automatically.
       if (account?.me?.profile) {
-        account.me.profile.name = "John Doe";
+        account.me.profile.$jazz.set("name", "John Doe");
       }
     },
   }


### PR DESCRIPTION
# Description
The better-auth docs were using the pre 0.18 value assignment syntax

## Tests

- [ ] Tests have been added and/or updated
- [x] Tests have not been updated, because: Only docs were changed
- [ ] I need help with writing tests


## Checklist

- [X] I've updated the part of the docs that are affected the PR changes
- [ ] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing