### PR TITLE
Update the 404 page

### DIFF
--- a/homepage/homepage/app/not-found.tsx
+++ b/homepage/homepage/app/not-found.tsx
@@ -22,9 +22,6 @@ export default function NotFound() {
             <p className="text-lg text-pretty leading-relaxed max-w-3xl dark:text-stone-200 md:text-xl">
               Either the link you followed is broken or the content has moved.</p>
           </hgroup>
-          <p className="mb-4">
-
-          </p>
           <label htmlFor="search-in-searchbox" className="font-medium">Were you looking for...</label>
           <SearchBoxWithResults searchTerms={path.replace('/docs', '').split('/').join(' ').trim()} />
 

--- a/homepage/homepage/app/not-found.tsx
+++ b/homepage/homepage/app/not-found.tsx
@@ -1,15 +1,13 @@
 "use client";
-import { SideNavLayout } from "@/components/SideNavLayout";
 import { HelpLinks } from "@/components/docs/HelpLinks";
 import { JazzMobileNav } from "@/components/nav";
-import { DocProse } from "@/lib/docMdxContent";
-import { Icon404 } from "@garden-co/design-system/src/components/atoms/icons/404";
+import { Heading } from "@/components/docs/DocHeading";
 import { usePathname } from "next/navigation";
 import { JazzNav } from "@/components/nav";
-
+import { SearchBoxWithResults } from '@/components/SearchBoxWithResults';
+import { DocProse } from "@/lib/docMdxContent";
 
 export default function NotFound() {
-  const text = "Don't Worry 'Bout Me";
   const path = usePathname();
 
   return (
@@ -17,8 +15,14 @@ export default function NotFound() {
       <div className="w-full">
         <JazzNav />
         <DocProse>
-          <h1>Couldn't find that page</h1>
-          <Icon404 className="w-[30%]" />
+          <div className="p-2">
+            <Heading tag="h1">Page Not Found</Heading>
+            <p>
+              Either the link you followed is broken or the content has moved.
+            </p>
+            <p>Were you looking for...</p>
+            <SearchBoxWithResults searchTerms={path.replace('/docs', '').split('/').join(' ').trim()} />
+          </div>
         </DocProse>
       </div>
 

--- a/homepage/homepage/app/not-found.tsx
+++ b/homepage/homepage/app/not-found.tsx
@@ -1,13 +1,32 @@
+"use client";
+import { SideNavLayout } from "@/components/SideNavLayout";
+import { HelpLinks } from "@/components/docs/HelpLinks";
+import { JazzMobileNav } from "@/components/nav";
+import { DocProse } from "@/lib/docMdxContent";
 import { Icon404 } from "@garden-co/design-system/src/components/atoms/icons/404";
+import { usePathname } from "next/navigation";
+import { JazzNav } from "@/components/nav";
+
 
 export default function NotFound() {
   const text = "Don't Worry 'Bout Me";
+  const path = usePathname();
 
   return (
-    <div className="flex flex-col items-flex-start justify-center min-h-[95vh] w-auto pb-32">
-      <Icon404 className="w-75" />
-      <h1 className="text-3xl font-semibold my-7">{text}</h1>
-      <p>Page not found.</p>
-    </div>
+    <>
+      <div className="w-full">
+        <JazzNav />
+        <DocProse>
+          <h1>Couldn't find that page</h1>
+          <Icon404 className="w-[30%]" />
+        </DocProse>
+      </div>
+
+      <div className="pl-3 py-8 shrink-0 text-sm sticky align-start top-[61px] w-[16rem] h-[calc(100vh-61px)] overflow-y-auto hidden lg:block">
+        <HelpLinks />
+
+      </div>
+      <JazzMobileNav />
+    </>
   );
 }

--- a/homepage/homepage/app/not-found.tsx
+++ b/homepage/homepage/app/not-found.tsx
@@ -1,11 +1,11 @@
 "use client";
-import { HelpLinks } from "@/components/docs/HelpLinks";
+import { Button } from "@garden-co/design-system/src/components/atoms/Button";
+import { SiDiscord } from "@icons-pack/react-simple-icons";
 import { JazzMobileNav } from "@/components/nav";
-import { Heading } from "@/components/docs/DocHeading";
 import { usePathname } from "next/navigation";
 import { JazzNav } from "@/components/nav";
 import { SearchBoxWithResults } from '@/components/SearchBoxWithResults';
-import { DocProse } from "@/lib/docMdxContent";
+import Link from "next/link";
 
 export default function NotFound() {
   const path = usePathname();
@@ -14,23 +14,34 @@ export default function NotFound() {
     <>
       <div className="w-full">
         <JazzNav />
-        <DocProse>
-          <div className="p-2">
-            <Heading tag="h1">Page Not Found</Heading>
-            <p>
-              Either the link you followed is broken or the content has moved.
-            </p>
-            <p>Were you looking for...</p>
-            <SearchBoxWithResults searchTerms={path.replace('/docs', '').split('/').join(' ').trim()} />
-          </div>
-        </DocProse>
-      </div>
+        <div className="pb-8 pt-[calc(61px+2rem)] md:pt-8 md:max-w-3xl mx-auto">
+          <hgroup className="pt-12 md:pt-20 mb-10">
+            <h1 className="text-stone-950 dark:text-white font-display text-5xl lg:text-6xl mb-3 font-medium tracking-tighter">
+              Page Not Found
+            </h1>
+            <p className="text-lg text-pretty leading-relaxed max-w-3xl dark:text-stone-200 md:text-xl">
+              Either the link you followed is broken or the content has moved.</p>
+          </hgroup>
+          <p className="mb-4">
 
-      <div className="pl-3 py-8 shrink-0 text-sm sticky align-start top-[61px] w-[16rem] h-[calc(100vh-61px)] overflow-y-auto hidden lg:block">
-        <HelpLinks />
+          </p>
+          <label htmlFor="search-in-searchbox" className="font-medium">Were you looking for...</label>
+          <SearchBoxWithResults searchTerms={path.replace('/docs', '').split('/').join(' ').trim()} />
 
+          <p className="my-4">Still couldn't find what you were looking for? <a href="https://discord.gg/utDMjHYg42" className="underline inline-flex items-center gap-2">Let us know on Discord! <SiDiscord /></a></p>
+
+
+          <p>
+            <a
+              href="https://discord.gg/utDMjHYg42"
+              className="underline"
+            >
+              Go home &rarr;
+            </a>
+          </p>
+          <JazzMobileNav />
+        </div>
       </div>
-      <JazzMobileNav />
     </>
   );
 }

--- a/homepage/homepage/components/Pagination.tsx
+++ b/homepage/homepage/components/Pagination.tsx
@@ -1,0 +1,91 @@
+const Pagination = ({
+  pages,
+  page,
+  setPage,
+  windowSize = 2, // how many pages to show on either side
+}: {
+  pages: number;
+  page: number;
+  setPage: (p: number) => void;
+  pageLength?: number;
+  windowSize?: number;
+}) => {
+  if (pages <= 1) return null;
+
+  const goToPage = (p: number) => {
+    if (p >= 0 && p < pages) setPage(p);
+  };
+
+  const visiblePages = (): (number | string)[] => {
+    const visible: (number | string)[] = [];
+
+    const start = Math.max(0, page - windowSize);
+    const end = Math.min(pages - 1, page + windowSize);
+
+    // show first page and leading ellipsis
+    if (start > 0) {
+      visible.push(0);
+      if (start > 1) visible.push("…");
+    }
+
+    // show window around current page
+    for (let i = start; i <= end; i++) {
+      visible.push(i);
+    }
+
+    // show trailing ellipsis and last page
+    if (end < pages - 1) {
+      if (end < pages - 2) visible.push("…");
+      visible.push(pages - 1);
+    }
+
+    return visible;
+  };
+
+  return (
+    <nav className="flex justify-center gap-2 mt-4">
+      <button
+        onClick={() => goToPage(page - 1)}
+        disabled={page === 0}
+        className={`px-3 py-1 rounded ${page === 0
+          ? "bg-stone-100 text-stone-400 cursor-not-allowed"
+          : "bg-stone-200 hover:bg-stone-300"
+          }`}
+      >
+        Previous
+      </button>
+
+      {visiblePages().map((p, i) =>
+        typeof p === "number" ? (
+          <button
+            key={i}
+            onClick={() => goToPage(p)}
+            className={`px-3 py-1 rounded ${p === page
+              ? "bg-primary text-white"
+              : "bg-stone-200 hover:bg-stone-300"
+              }`}
+          >
+            {p + 1}
+          </button>
+        ) : (
+          <span key={i} className="px-2 text-stone-500">
+            {p}
+          </span>
+        )
+      )}
+
+      <button
+        onClick={() => goToPage(page + 1)}
+        disabled={page === pages - 1}
+        className={`px-3 py-1 rounded ${page === pages - 1
+          ? "bg-stone-100 text-stone-400 cursor-not-allowed"
+          : "bg-stone-200 hover:bg-stone-300"
+          }`}
+      >
+        Next
+      </button>
+    </nav>
+  );
+};
+
+export default Pagination;

--- a/homepage/homepage/components/SearchBoxWithResults.tsx
+++ b/homepage/homepage/components/SearchBoxWithResults.tsx
@@ -5,7 +5,6 @@ import { useFramework } from "@/lib/use-framework";
 import { Input } from "quint-ui";
 import React, { useState, useEffect } from "react";
 import Pagination from "./Pagination";
-import Link from "next/link";
 
 // Types
 interface PagefindResult {
@@ -198,9 +197,9 @@ export function SearchBoxWithResults({ searchTerms }: { searchTerms: string }) {
   if (loading) return null;
   return (
     <>
-      <Input value={query} onChange={(e) => handleSearch(e.target.value)} placeholder="Search" />
+      <Input value={query} onChange={(e) => handleSearch(e.target.value)} placeholder="Search" id="search-in-searchbox" />
 
-      <div className="not-prose">
+      <div className="mt-4">
         {results.length > 0 ? (
           <>
             <small>Page {page + 1} of {Math.ceil(results.length / PAGE_LENGTH)}</small>
@@ -256,10 +255,10 @@ export function SearchBoxWithResults({ searchTerms }: { searchTerms: string }) {
             </ul>
             <Pagination pages={Math.ceil(results.length / PAGE_LENGTH)} page={page} setPage={setPage} />
           </>
-        ) : <div><p className="mt-2">
+        ) : query && <div><p className="mt-2">
           Sorry, no results for "{query}".
         </p>
-          <Link href="/" className="underline">Go home &rarr;</Link></div>}
+        </div>}
       </div>
     </>
   );

--- a/homepage/homepage/components/SearchBoxWithResults.tsx
+++ b/homepage/homepage/components/SearchBoxWithResults.tsx
@@ -1,0 +1,266 @@
+"use client";
+
+import { Framework, frameworkNames, frameworks } from "@/content/framework";
+import { useFramework } from "@/lib/use-framework";
+import { Input } from "quint-ui";
+import React, { useState, useEffect } from "react";
+import Pagination from "./Pagination";
+import Link from "next/link";
+
+// Types
+interface PagefindResult {
+  id: string;
+  url: string;
+  meta: {
+    title: string;
+    framework?: string;
+  };
+  excerpt: string;
+  sub_results?: Array<PagefindSubResult>;
+}
+
+interface PagefindSubResult {
+  id: string;
+  title: string;
+  url: string;
+  excerpt: string;
+  anchor?: {
+    element: string;
+  };
+}
+
+// Utility functions
+const processUrl = (url: string): string => {
+  const urlPath = url
+    ?.split("/_next/static/chunks/pages/")?.[1]
+    ?.split(".html")?.[0];
+  return urlPath?.startsWith("/") ? urlPath : `/${urlPath}`;
+};
+
+const alternativeKeywordsByFramework: Partial<Record<Framework, string[]>> = {
+  [Framework.React]: ["reactjs", "react.js", "next.js", "nextjs"],
+  [Framework.ReactNative]: ["react native"],
+  [Framework.ReactNativeExpo]: ["react native expo", "expo"],
+  [Framework.Vanilla]: ["javascript", "js", "plain js", "vanilla js"],
+};
+
+const relatedFrameworks: Partial<Record<Framework, Framework[]>> = {
+  [Framework.ReactNative]: [Framework.ReactNativeExpo],
+  [Framework.ReactNativeExpo]: [Framework.ReactNative],
+};
+
+const filterAndPrioritizeResultsByFramework = (
+  results: PagefindResult[],
+  currentFramework: Framework = Framework.React,
+  query: string,
+): PagefindResult[] => {
+  const frameworksToSearch: Framework[] = [];
+
+  frameworks.forEach((framework) => {
+    const alternativeKeywords = alternativeKeywordsByFramework[framework] || [];
+
+    if (
+      framework.startsWith(query) ||
+      alternativeKeywords.some((keyword: string) => keyword.startsWith(query))
+    ) {
+      frameworksToSearch.push(framework);
+      frameworksToSearch.push(...(relatedFrameworks[framework] || []));
+    }
+  });
+
+  frameworksToSearch.push(currentFramework);
+
+  const filteredResults = results.filter((result) => {
+    const url = processUrl(result.url);
+    const fragments = url.split("/").filter(Boolean);
+    const frameworkInUrl = fragments[1];
+
+    return fragments.length > 1
+      ? frameworksToSearch.includes(frameworkInUrl as Framework)
+      : false;
+  });
+
+  return prioritizeResultsByFramework(filteredResults, frameworksToSearch[0]);
+};
+
+const prioritizeResultsByFramework = (
+  results: PagefindResult[],
+  framework: Framework,
+): PagefindResult[] => {
+  return results.sort((a, b) => {
+    const aUrl = processUrl(a.url);
+    const bUrl = processUrl(b.url);
+
+    const aHasFramework = aUrl.includes(`/${framework}`);
+    const bHasFramework = bUrl.includes(`/${framework}`);
+
+    // Prioritize results that match the current framework
+    if (aHasFramework && !bHasFramework) return -1;
+    if (!aHasFramework && bHasFramework) return 1;
+
+    // Keep original order for results with same framework priority
+    return 0;
+  });
+};
+
+function HighlightedText({ text }: { text: string }) {
+  const decodedText = text.replace(/&lt;/g, "<").replace(/&gt;/g, ">");
+  const parts = decodedText.split(/(<mark>.*?<\/mark>)/g);
+
+  return (
+    <p className="mt-1 text-sm line-clamp-2">
+      {parts.map((part, i) => {
+        if (part.startsWith("<mark>")) {
+          const content = part.replace(/<\/?mark>/g, "");
+          return (
+            <mark
+              key={i}
+              className="bg-transparent text-primary dark:text-white dark:text-underline dark:bg-highlight"
+            >
+              {content}
+            </mark>
+          );
+        }
+        return part;
+      })}
+    </p>
+  );
+}
+
+export function SearchBoxWithResults({ searchTerms }: { searchTerms: string }) {
+  const PAGE_LENGTH = 5;
+  const [query, setQuery] = useState<string>(searchTerms ?? "");
+  const [page, setPage] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [results, setResults] = useState<PagefindResult[]>([]);
+  const currentFramework = useFramework();
+
+  useEffect(() => {
+    async function loadPagefind() {
+      if (typeof window !== "undefined" && !window.pagefind) {
+        try {
+          // First try loading from the standard location
+          const pagefindModule = await import(
+            // @ts-expect-error - pagefind.js is generated after build and not available at compile time
+            /* webpackIgnore: true */ "/_pagefind/pagefind.js"
+          ).catch(() => {
+            // If that fails, try the alternative location
+            return import(
+              // @ts-expect-error - pagefind.js is generated after build and not available at compile time
+              /* webpackIgnore: true */ "/_next/static/chunks/pages/pagefind/pagefind.js"
+            );
+          });
+
+          window.pagefind = pagefindModule.default || pagefindModule;
+
+          if (window.pagefind && window.pagefind.options) {
+            await window.pagefind.options({
+              ranking: {
+                termFrequency: 0.8,
+                pageLength: 0.6,
+                termSaturation: 1.2,
+              },
+            });
+          }
+        } catch (e) {
+          console.warn("Failed to load Pagefind:", e);
+          window.pagefind = {
+            search: async () => ({ results: [] }),
+            options: async () => { },
+          };
+        }
+      }
+    }
+    loadPagefind().then(async () => {
+      await handleSearch(searchTerms);
+      setLoading(false);
+    });
+  }, [searchTerms]);
+
+  const handleSearch = async (value: string) => {
+    setQuery(value);
+    if (window.pagefind) {
+      const search = await window.pagefind.search(value);
+      const results = await Promise.all(
+        search.results.map((result: any) => result.data()),
+      );
+
+      const filteredResults = filterAndPrioritizeResultsByFramework(
+        results,
+        currentFramework,
+        value,
+      );
+
+      setResults(filteredResults);
+    }
+  };
+
+  if (loading) return null;
+  return (
+    <>
+      <Input value={query} onChange={(e) => handleSearch(e.target.value)} placeholder="Search" />
+
+      <div className="not-prose">
+        {results.length > 0 ? (
+          <>
+            <small>Page {page + 1} of {Math.ceil(results.length / PAGE_LENGTH)}</small>
+            <ul>
+              {results.slice((page) * PAGE_LENGTH, (page + 1) * PAGE_LENGTH).map((result) => (
+                <li className="cursor-default flex flex-col group data-[focus]:bg-stone-100 dark:data-[focus]:bg-stone-900" key={result.id}>
+                  <div>
+                    <p className="font-bold text-highlight line-clamp-1 border-b">
+                      <a href={processUrl(result.url)}>
+                        {result.meta?.title || "No title"}{" "}
+                        {result.meta?.framework ? (
+                          <span className="text-stone-600 dark:text-stone-400 font-normal">
+                            (
+                            {
+                              frameworkNames[
+                                result.meta?.framework as Framework
+                              ].label
+                            }
+                            )
+
+                          </span>
+                        ) : null}
+                      </a>
+                    </p>
+
+
+                    {result.sub_results?.length ? null : (
+                      <HighlightedText text={result.excerpt || ""} />
+                    )}
+                  </div>
+                  <ul>
+                    {result.sub_results?.map((subResult) =>
+                      subResult.anchor?.element === "h1" ? null : (
+                        <a href={processUrl(subResult.url)}>
+                          <li
+                            key={subResult.id}
+                            className="group cursor-pointer group data-[focus]:bg-stone-100 rounded-lg p-2 dark:data-[focus]:bg-stone-900"
+                          >
+                            <div>
+                              <p className="text-sm text-highlight font-bold">
+                                {subResult.title?.replace("#", "") ||
+                                  "No title"}
+                              </p>
+                              <HighlightedText text={subResult.excerpt || ""} />
+                            </div>
+                          </li>
+                        </a>
+                      ),
+                    )}
+                  </ul>
+                </li>
+              ))}
+            </ul>
+            <Pagination pages={Math.ceil(results.length / PAGE_LENGTH)} page={page} setPage={setPage} />
+          </>
+        ) : <div><p className="mt-2">
+          Sorry, no results for "{query}".
+        </p>
+          <Link href="/" className="underline">Go home &rarr;</Link></div>}
+      </div>
+    </>
+  );
+}

--- a/homepage/homepage/components/SearchBoxWithResults.tsx
+++ b/homepage/homepage/components/SearchBoxWithResults.tsx
@@ -233,20 +233,19 @@ export function SearchBoxWithResults({ searchTerms }: { searchTerms: string }) {
                   <ul>
                     {result.sub_results?.map((subResult) =>
                       subResult.anchor?.element === "h1" ? null : (
-                        <a href={processUrl(subResult.url)}>
-                          <li
-                            key={subResult.id}
-                            className="group cursor-pointer group data-[focus]:bg-stone-100 rounded-lg p-2 dark:data-[focus]:bg-stone-900"
-                          >
-                            <div>
-                              <p className="text-sm text-highlight font-bold">
-                                {subResult.title?.replace("#", "") ||
-                                  "No title"}
-                              </p>
-                              <HighlightedText text={subResult.excerpt || ""} />
-                            </div>
-                          </li>
-                        </a>
+                        <li
+                          key={subResult.id}
+                          className="group cursor-pointer group data-[focus]:bg-stone-100 rounded-lg p-2 dark:data-[focus]:bg-stone-900"
+                        >
+                          <a href={processUrl(subResult.url)}>
+                            <p className="text-sm text-highlight font-bold">
+                              {subResult.title?.replace("#", "") ||
+                                "No title"}
+                            </p>
+                            <HighlightedText text={subResult.excerpt || ""} />
+                          </a>
+                        </li>
+
                       ),
                     )}
                   </ul>
@@ -255,10 +254,10 @@ export function SearchBoxWithResults({ searchTerms }: { searchTerms: string }) {
             </ul>
             <Pagination pages={Math.ceil(results.length / PAGE_LENGTH)} page={page} setPage={setPage} />
           </>
-        ) : query && <div><p className="mt-2">
+        ) : query && <p className="mt-2">
           Sorry, no results for "{query}".
         </p>
-        </div>}
+        }
       </div>
     </>
   );

--- a/homepage/homepage/lib/docMdxContent.tsx
+++ b/homepage/homepage/lib/docMdxContent.tsx
@@ -6,7 +6,7 @@ import { Prose } from "@garden-co/design-system/src/components/molecules/Prose";
 import { Toc } from "@stefanprobst/rehype-extract-toc";
 import { error } from "console";
 
-function DocProse({ children }: { children: React.ReactNode }) {
+export function DocProse({ children }: { children: React.ReactNode }) {
   return (
     <Prose className="overflow-hidden pb-8 pt-[calc(61px+2rem)] md:pt-8 md:max-w-3xl mx-auto">
       {children}
@@ -25,22 +25,22 @@ export async function getDocModule(framework: string, slug?: string[]) {
   if (slugPath) {
     try {
       return await import(`../content/docs/${slugPath}/${framework}.mdx`);
-    } catch {}
+    } catch { }
   }
 
   // Fallback to generic MDX
   if (slugPath) {
     try {
       return await import(`../content/docs/${slugPath}.mdx`);
-    } catch {}
+    } catch { }
   }
 
   // Top-level index fallback
   try {
     return await import(`../content/docs/index.mdx`);
-  } catch {}
+  } catch { }
 
-  return null; 
+  return null;
 }
 
 
@@ -183,8 +183,8 @@ export function generateOGMetadata(
   const baseUrl = "https://jazz.tools";
   const imageUrl = image
     ? `${baseUrl}/api/opengraph-image?title=${encodeURIComponent(title)}&framework=${encodeURIComponent(
-        framework
-      )}${topic ? `&topic=${encodeURIComponent(topic)}` : ""}${subtopic ? `&subtopic=${encodeURIComponent(subtopic)}` : ""}`
+      framework
+    )}${topic ? `&topic=${encodeURIComponent(topic)}` : ""}${subtopic ? `&subtopic=${encodeURIComponent(subtopic)}` : ""}`
     : "/jazz-logo.png";
 
   return {


### PR DESCRIPTION
# Description
Current 404 page is a playful logo with a title that maybe comes from a Frank Sinatra song.

Ahead of restructuring docs content to match the nav hierarchy, I wanted to make sure we have something that will help users landing on old routes they may have saved somewhere.

The new 404 page has a search function which is pre-populated with the URL content

## Manual testing instructions

Bit convoluted because Pagefind doesn't work in dev mode. You have to build the homepage `pnpm run build` and then start `pnpm run start`.

OR use the Vercel preview deployment.

Access a nonsense URL, you should see the new 404 page.

## Tests

- [ ] Tests have been added and/or updated
- [x] Tests have not been updated, because: N/A
- [ ] I need help with writing tests


## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [ ] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing