### PR TITLE
Update `create-jazz-app` to only fetch framework specific llms.txt

### DIFF
--- a/.changeset/flat-boxes-fetch.md
+++ b/.changeset/flat-boxes-fetch.md
@@ -1,0 +1,5 @@
+---
+"create-jazz-app": patch
+---
+
+Fetch only the appropriate llms-full.txt for the framework

--- a/packages/create-jazz-app/src/config.ts
+++ b/packages/create-jazz-app/src/config.ts
@@ -1,5 +1,10 @@
 export type Environment = "browser" | "mobile";
 export type Engine = "browser" | "mobile" | "nodejs" | "deno" | "bun";
+export type DocsFrameworks =
+  | "react"
+  | "svelte"
+  | "react-native"
+  | "react-native-expo";
 export type Framework = "react" | "svelte" | "rn" | "expo" | "nextjs";
 export type AuthMethod =
   | "minimal"
@@ -20,26 +25,32 @@ export type EngineConfig = {
 export const frameworks: {
   name: string;
   value: Framework;
+  docs: DocsFrameworks;
 }[] = [
   {
     name: "React (Vite)",
     value: "react",
+    docs: "react",
   },
   {
     name: "React (Next.js)",
     value: "nextjs",
+    docs: "react",
   },
   {
     name: "React Native",
     value: "rn",
+    docs: "react-native",
   },
   {
     name: "React Native (Expo)",
     value: "expo",
+    docs: "react-native-expo",
   },
   {
     name: "Svelte",
     value: "svelte",
+    docs: "svelte",
   },
 ];
 

--- a/packages/create-jazz-app/src/index.ts
+++ b/packages/create-jazz-app/src/index.ts
@@ -16,7 +16,11 @@ import {
   frameworkToAuthExamples,
   frameworks,
 } from "./config.js";
-import { type PackageManager, getPkgManager } from "./utils.js";
+import {
+  type PackageManager,
+  getFrameworkSpecificDocsUrl,
+  getPkgManager,
+} from "./utils.js";
 import { parseCatalogDefinitions, resolveCatalogVersion } from "./catalog.js";
 
 // Handle SIGINT (Ctrl+C) gracefully
@@ -369,10 +373,8 @@ module.exports = mergeConfig(getDefaultConfig(__dirname), config);`;
 
     // Clean up temp directory
     fs.rmSync(tempDocsDir, { recursive: true, force: true });
-    // Fetch the latest llms-full.txt from the web
-    const response = await fetch(
-      `https://jazz.tools/${framework === "nextjs" ? "react" : framework}/llms-full.txt`,
-    );
+    const urlToFetch = getFrameworkSpecificDocsUrl(framework);
+    const response = await fetch(urlToFetch);
     if (!response.ok) throw new Error(`HTTP ${response.status}`);
     const text = await response.text();
     fs.writeFileSync(`${projectName}/.cursor/docs/llms-full.md`, text, "utf-8");

--- a/packages/create-jazz-app/src/index.ts
+++ b/packages/create-jazz-app/src/index.ts
@@ -30,6 +30,7 @@ type ScaffoldOptions = {
   template: FrameworkAuthPair | string;
   projectName: string;
   packageManager: PackageManager;
+  framework: Framework;
   apiKey?: string;
   git?: boolean;
 };
@@ -117,6 +118,7 @@ async function scaffoldProject({
   packageManager,
   apiKey,
   git,
+  framework,
 }: ScaffoldOptions): Promise<void> {
   const starterConfig = frameworkToAuthExamples[
     template as FrameworkAuthPair
@@ -127,7 +129,6 @@ async function scaffoldProject({
   };
 
   let devCommand = "dev";
-
   if (!starterConfig.repo) {
     throw new Error(
       `Starter template ${starterConfig.name} is not yet implemented`,
@@ -369,7 +370,9 @@ module.exports = mergeConfig(getDefaultConfig(__dirname), config);`;
     // Clean up temp directory
     fs.rmSync(tempDocsDir, { recursive: true, force: true });
     // Fetch the latest llms-full.txt from the web
-    const response = await fetch("https://jazz.tools/llms-full.txt");
+    const response = await fetch(
+      `https://jazz.tools/${framework === "nextjs" ? "react" : framework}/llms-full.txt`,
+    );
     if (!response.ok) throw new Error(`HTTP ${response.status}`);
     const text = await response.text();
     fs.writeFileSync(`${projectName}/.cursor/docs/llms-full.md`, text, "utf-8");
@@ -454,6 +457,7 @@ async function promptUser(
   console.log(chalk.blue.bold("Let's create your Jazz app! 🎷\n"));
 
   const questions = [];
+  let framework: Framework = partialOptions.framework ?? "react";
 
   if (
     partialOptions.framework &&
@@ -469,8 +473,6 @@ async function promptUser(
   }
 
   if (!partialOptions.example && !partialOptions.starter) {
-    let framework = partialOptions.framework;
-
     if (!partialOptions.framework) {
       const answers = await inquirer.prompt([
         {
@@ -550,6 +552,7 @@ async function promptUser(
   return {
     ...answers,
     ...partialOptions,
+    framework,
     template:
       answers.starter || partialOptions.starter || partialOptions.example,
   } as ScaffoldOptions;

--- a/packages/create-jazz-app/src/utils.ts
+++ b/packages/create-jazz-app/src/utils.ts
@@ -1,3 +1,5 @@
+import { frameworks, type Framework } from "./config.js";
+
 export type PackageManager = "npm" | "yarn" | "pnpm" | "bun" | "deno";
 
 export function getPkgManager(): PackageManager {
@@ -20,4 +22,10 @@ export function getPkgManager(): PackageManager {
   }
 
   return "npm";
+}
+
+export function getFrameworkSpecificDocsUrl(framework: Framework) {
+  const frameworkForDocs = frameworks.find((f) => f.value === framework)?.docs;
+  if (!frameworkForDocs) throw new Error("An invalid framework was specified.");
+  return `https://jazz.tools/${frameworkForDocs}/llms-full.txt`;
 }

--- a/packages/create-jazz-app/tests/docsFetch.test.ts
+++ b/packages/create-jazz-app/tests/docsFetch.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, suite } from "vitest";
+import { getFrameworkSpecificDocsUrl } from "../src/utils.js";
+import { frameworks } from "../src/config.js";
+
+describe("Framework specific docs fetch", () => {
+  suite("should only generate urls for frameworks which exist", () => {
+    const llmsTxtFrameworks = [
+      "react",
+      "svelte",
+      "react-native",
+      "react-native-expo",
+      "vanilla",
+    ];
+    const acceptableUrls = llmsTxtFrameworks.map(
+      (f) => `https://jazz.tools/${f}/llms-full.txt`,
+    );
+
+    for (const framework of frameworks) {
+      it("should generate a valid URL for " + framework.value, () => {
+        const frameworkDocsUrl = getFrameworkSpecificDocsUrl(framework.value);
+        expect(frameworkDocsUrl).toBeDefined();
+        expect(acceptableUrls.includes(frameworkDocsUrl)).toBeTruthy();
+      });
+    }
+  });
+});


### PR DESCRIPTION
# Description
Following https://github.com/garden-co/jazz/pull/3047, we now have framework variants of llms-full.txt hosted at https://jazz.tools/{FRAMEWORK}/llms-full.txt.

This PR ensures that when a user runs `create-jazz-app`, the appropriate llms-full.txt gets pulled into the .cursor folder.

## Manual testing instructions
Build the `create-jazz-app` package. 
Run it.
Check that the output in `.cursor/docs/llms-full.md` is specific to the framework you selected.

## Tests

- [ ] Tests have been added and/or updated
- [X] Tests have not been updated, because: N/A
- [ ] I need help with writing tests


## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [x] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing