### PR TITLE
feat: split useAccount and merge selectors into useAccount & useState

### DIFF
--- a/examples/betterauth/src/app/(app)/page.tsx
+++ b/examples/betterauth/src/app/(app)/page.tsx
@@ -12,7 +12,7 @@ import {
 import Image from "next/image";
 
 export default function Home() {
-  const { me } = useAccount(Account, { resolve: { profile: {} } });
+  const me = useAccount(Account, { resolve: { profile: {} } });
 
   if (!me.$isLoaded) {
     return null;

--- a/examples/betterauth/src/components/signup-form.tsx
+++ b/examples/betterauth/src/components/signup-form.tsx
@@ -31,7 +31,7 @@ export function SignupForm({ providers }: Props) {
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
 
-  const account = useAccount(Account, { resolve: { profile: true } });
+  const { me } = useAccount(Account, { resolve: { profile: true } });
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -51,8 +51,8 @@ export function SignupForm({ providers }: Props) {
       },
       {
         onSuccess: async () => {
-          if (account.me.$isLoaded) {
-            account.me.profile.$jazz.set("name", name);
+          if (me.$isLoaded) {
+            me.profile.$jazz.set("name", name);
           }
           router.push("/");
         },

--- a/examples/betterauth/src/components/signup-form.tsx
+++ b/examples/betterauth/src/components/signup-form.tsx
@@ -31,7 +31,7 @@ export function SignupForm({ providers }: Props) {
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
 
-  const { me } = useAccount(Account, { resolve: { profile: true } });
+  const me = useAccount(Account, { resolve: { profile: true } });
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();

--- a/examples/chat-rn-expo/src/chat.tsx
+++ b/examples/chat-rn-expo/src/chat.tsx
@@ -18,7 +18,7 @@ import { useAccount, useCoState, useLogOut } from "jazz-tools/expo";
 import { Chat, Message } from "./schema";
 
 export default function ChatScreen() {
-  const { me } = useAccount(Account, { resolve: { profile: true } });
+  const me = useAccount(Account, { resolve: { profile: true } });
   const logOut = useLogOut();
   const [chatId, setChatId] = useState<string>();
   const [chatIdInput, setChatIdInput] = useState<string>();

--- a/examples/chat-rn-expo/src/chat.tsx
+++ b/examples/chat-rn-expo/src/chat.tsx
@@ -14,11 +14,12 @@ import React, {
   StyleSheet,
 } from "react-native";
 
-import { useAccount, useCoState } from "jazz-tools/expo";
+import { useAccount, useCoState, useLogOut } from "jazz-tools/expo";
 import { Chat, Message } from "./schema";
 
 export default function ChatScreen() {
-  const { me, logOut } = useAccount(Account, { resolve: { profile: true } });
+  const { me } = useAccount(Account, { resolve: { profile: true } });
+  const logOut = useLogOut();
   const [chatId, setChatId] = useState<string>();
   const [chatIdInput, setChatIdInput] = useState<string>();
   const loadedChat = useCoState(Chat, chatId, { resolve: { $each: true } });

--- a/examples/chat-rn/src/chat.tsx
+++ b/examples/chat-rn/src/chat.tsx
@@ -6,7 +6,7 @@ import {
   LastAndAllCoMapEdits,
   Loaded,
 } from "jazz-tools";
-import { useAccount, useCoState } from "jazz-tools/react-native";
+import { useAccount, useCoState, useLogOut } from "jazz-tools/react-native";
 import { useEffect, useState } from "react";
 import {
   Button,
@@ -22,7 +22,8 @@ import {
 import { Chat, Message } from "./schema";
 
 export function ChatScreen({ navigation }: { navigation: any }) {
-  const { me, logOut } = useAccount();
+  const { me } = useAccount();
+  const logOut = useLogOut();
   const [chatId, setChatId] = useState<string>();
   const [chatIdInput, setChatIdInput] = useState<string>();
   const loadedChat = useCoState(Chat, chatId, {

--- a/examples/chat-rn/src/chat.tsx
+++ b/examples/chat-rn/src/chat.tsx
@@ -22,7 +22,7 @@ import {
 import { Chat, Message } from "./schema";
 
 export function ChatScreen({ navigation }: { navigation: any }) {
-  const { me } = useAccount();
+  const me = useAccount();
   const logOut = useLogOut();
   const [chatId, setChatId] = useState<string>();
   const [chatIdInput, setChatIdInput] = useState<string>();

--- a/examples/chat/src/app.tsx
+++ b/examples/chat/src/app.tsx
@@ -12,7 +12,7 @@ import { ThemeProvider } from "./themeProvider.tsx";
 import { AppContainer, TopBar } from "./ui.tsx";
 
 export function App() {
-  const { me } = useAccount(undefined, {
+  const me = useAccount(undefined, {
     resolve: {
       profile: true,
     },

--- a/examples/chat/src/app.tsx
+++ b/examples/chat/src/app.tsx
@@ -3,7 +3,7 @@ import { getRandomUsername, inIframe, onChatLoad } from "@/util.ts";
 import { useIframeHashRouter } from "hash-slash";
 import { Group } from "jazz-tools";
 import { JazzInspector } from "jazz-tools/inspector";
-import { JazzReactProvider, useAccount } from "jazz-tools/react";
+import { JazzReactProvider, useAccount, useLogOut } from "jazz-tools/react";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { ChatScreen } from "./chatScreen.tsx";
@@ -12,11 +12,12 @@ import { ThemeProvider } from "./themeProvider.tsx";
 import { AppContainer, TopBar } from "./ui.tsx";
 
 export function App() {
-  const { me, logOut } = useAccount(undefined, {
+  const { me } = useAccount(undefined, {
     resolve: {
       profile: true,
     },
   });
+  const logOut = useLogOut();
   const router = useIframeHashRouter();
 
   const profile = me.$isLoaded ? me.profile : undefined;

--- a/examples/chat/src/chatScreen.tsx
+++ b/examples/chat/src/chatScreen.tsx
@@ -24,7 +24,7 @@ export function ChatScreen(props: { chatID: string }) {
       $each: true,
     },
   });
-  const { me } = useAccount();
+  const me = useAccount();
   const [showNLastMessages, setShowNLastMessages] = useState(
     INITIAL_MESSAGES_TO_SHOW,
   );

--- a/examples/clerk-expo/src/MainScreen.tsx
+++ b/examples/clerk-expo/src/MainScreen.tsx
@@ -4,7 +4,7 @@ import { useAccount } from "jazz-tools/expo";
 import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
 
 export function MainScreen() {
-  const { me } = useAccount(Account, { resolve: { profile: true } });
+  const me = useAccount(Account, { resolve: { profile: true } });
   const { signOut } = useClerk();
 
   const handleSignOut = async () => {

--- a/examples/clerk/src/App.tsx
+++ b/examples/clerk/src/App.tsx
@@ -3,7 +3,7 @@ import { Account } from "jazz-tools";
 import { useAccount, useIsAuthenticated } from "jazz-tools/react";
 
 function App() {
-  const { me } = useAccount(Account, { resolve: { profile: true } });
+  const me = useAccount(Account, { resolve: { profile: true } });
 
   const isAuthenticated = useIsAuthenticated();
 

--- a/examples/community-chat-vue/src/App.vue
+++ b/examples/community-chat-vue/src/App.vue
@@ -9,12 +9,13 @@
 </template>
 
 <script setup lang="ts">
-import { useAccount } from "community-jazz-vue";
+import { useAccount, useLogOut } from "community-jazz-vue";
 import { useRouter } from "vue-router";
 import AppContainer from "./components/AppContainer.vue";
 import TopBar from "./components/TopBar.vue";
 
-const { me, logOut } = useAccount();
+const { me } = useAccount();
+const logOut = useLogOut();
 const router = useRouter();
 
 async function logoutHandler() {

--- a/examples/community-chat-vue/src/App.vue
+++ b/examples/community-chat-vue/src/App.vue
@@ -14,7 +14,7 @@ import { useRouter } from "vue-router";
 import AppContainer from "./components/AppContainer.vue";
 import TopBar from "./components/TopBar.vue";
 
-const { me } = useAccount();
+const me = useAccount();
 const logOut = useLogOut();
 const router = useRouter();
 

--- a/examples/community-chat-vue/src/views/HomeView.vue
+++ b/examples/community-chat-vue/src/views/HomeView.vue
@@ -11,7 +11,7 @@ import { useRouter } from "vue-router";
 import { Chat } from "../schema";
 
 const router = useRouter();
-const { me } = useAccount();
+const me = useAccount();
 const isAuthenticated = useIsAuthenticated();
 
 watch(

--- a/examples/community-todo-vue/src/App.vue
+++ b/examples/community-todo-vue/src/App.vue
@@ -68,11 +68,12 @@ main {
 </style>
 
 <script setup lang="ts">
-import { useAcceptInvite, useAccount } from "community-jazz-vue";
+import { useAcceptInvite, useAccount, useLogOut } from "community-jazz-vue";
 import { useRouter } from "vue-router";
 import { TodoProject } from "./schema";
 
-const { me, logOut } = useAccount();
+const { me } = useAccount();
+const logOut = useLogOut();
 const router = useRouter();
 
 async function logoutHandler() {

--- a/examples/community-todo-vue/src/App.vue
+++ b/examples/community-todo-vue/src/App.vue
@@ -72,7 +72,7 @@ import { useAcceptInvite, useAccount, useLogOut } from "community-jazz-vue";
 import { useRouter } from "vue-router";
 import { TodoProject } from "./schema";
 
-const { me } = useAccount();
+const me = useAccount();
 const logOut = useLogOut();
 const router = useRouter();
 

--- a/examples/community-todo-vue/src/components/NewProjectForm.vue
+++ b/examples/community-todo-vue/src/components/NewProjectForm.vue
@@ -26,7 +26,7 @@ import { ref } from "vue";
 import { useRouter } from "vue-router";
 import { Task, TodoAccount, TodoProject } from "../schema";
 
-const { me } = useAccount(TodoAccount, {
+const me = useAccount(TodoAccount, {
   resolve: { root: { projects: { $each: { $onError: "catch" } } } },
 });
 

--- a/examples/community-todo-vue/src/views/Home.vue
+++ b/examples/community-todo-vue/src/views/Home.vue
@@ -25,7 +25,7 @@ import { useRouter } from "vue-router";
 import NewProjectForm from "../components/NewProjectForm.vue";
 import { TodoAccount } from "../schema";
 
-const { me } = useAccount(TodoAccount, {
+const me = useAccount(TodoAccount, {
   resolve: { root: { projects: { $each: { $onError: "catch" } } } },
 });
 

--- a/examples/filestream/src/FileWidget.tsx
+++ b/examples/filestream/src/FileWidget.tsx
@@ -10,7 +10,7 @@ export function FileWidget() {
   const [isUploading, setIsUploading] = useState(false);
   const [progress, setProgress] = useState(0);
   const [error, setError] = useState<string | null>(null);
-  const { me } = useAccount(JazzAccount, { resolve: { profile: true } });
+  const me = useAccount(JazzAccount, { resolve: { profile: true } });
 
   if (!me.$isLoaded) {
     return (

--- a/examples/form/src/CreateOrder.tsx
+++ b/examples/form/src/CreateOrder.tsx
@@ -1,5 +1,5 @@
 import { useIframeHashRouter } from "hash-slash";
-import { useAccountWithSelector, useCoState } from "jazz-tools/react";
+import { useAccount, useCoState } from "jazz-tools/react";
 import { useState } from "react";
 import { Errors } from "./Errors.tsx";
 import { LinkToHome } from "./LinkToHome.tsx";
@@ -12,7 +12,7 @@ import {
 } from "./schema.ts";
 
 export function CreateOrder(props: { id: string }) {
-  const orders = useAccountWithSelector(JazzAccount, {
+  const orders = useAccount(JazzAccount, {
     resolve: { root: { orders: true } },
     select: (account) => {
       if (!account.$isLoaded) {

--- a/examples/form/src/Orders.tsx
+++ b/examples/form/src/Orders.tsx
@@ -1,4 +1,4 @@
-import { useAccountWithSelector } from "jazz-tools/react";
+import { useAccount } from "jazz-tools/react";
 import { OrderThumbnail } from "./OrderThumbnail.tsx";
 import { JazzAccount, PartialBubbleTeaOrder } from "./schema.ts";
 import { useHashRouter } from "hash-slash";
@@ -6,7 +6,7 @@ import { useHashRouter } from "hash-slash";
 export function Orders() {
   const router = useHashRouter();
 
-  const orders = useAccountWithSelector(JazzAccount, {
+  const orders = useAccount(JazzAccount, {
     resolve: {
       root: {
         orders: {

--- a/examples/image-upload/src/ImageUpload.tsx
+++ b/examples/image-upload/src/ImageUpload.tsx
@@ -4,7 +4,7 @@ import { ChangeEvent, useEffect, useRef, useState } from "react";
 import { JazzAccount } from "./schema";
 
 export default function ImageUpload() {
-  const { me } = useAccount(JazzAccount, { resolve: { profile: true } });
+  const me = useAccount(JazzAccount, { resolve: { profile: true } });
   const [imagePreviewUrl, setImagePreviewUrl] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 

--- a/examples/image-upload/src/ProfileImageComponent.tsx
+++ b/examples/image-upload/src/ProfileImageComponent.tsx
@@ -2,7 +2,7 @@ import { Image, useAccount } from "jazz-tools/react";
 import { JazzAccount } from "./schema";
 
 export default function ProfileImage() {
-  const { me } = useAccount(JazzAccount, {
+  const me = useAccount(JazzAccount, {
     resolve: { profile: { image: true } },
   });
 

--- a/examples/image-upload/src/ProfileImageImperative.tsx
+++ b/examples/image-upload/src/ProfileImageImperative.tsx
@@ -9,7 +9,7 @@ import { JazzAccount } from "./schema";
 
 export default function ProfileImageImperative() {
   const [image, setImage] = useState<string | undefined>(undefined);
-  const { me } = useAccount(JazzAccount, {
+  const me = useAccount(JazzAccount, {
     resolve: { profile: { image: true } },
   });
 

--- a/examples/jazz-nextjs/src/app/page.tsx
+++ b/examples/jazz-nextjs/src/app/page.tsx
@@ -5,7 +5,7 @@ import { useAccount } from "jazz-tools/react";
 import Link from "next/link";
 
 export default function Home() {
-  const { me } = useAccount(Account, {
+  const me = useAccount(Account, {
     resolve: {
       profile: true,
     },

--- a/examples/multi-cursors/src/App.tsx
+++ b/examples/multi-cursors/src/App.tsx
@@ -10,7 +10,7 @@ const cursorFeedIDToLoad = import.meta.env.VITE_CURSOR_FEED_ID;
 const groupIDToLoad = import.meta.env.VITE_GROUP_ID;
 
 function App() {
-  const { me } = useAccount(CursorAccount, { resolve: { profile: true } });
+  const me = useAccount(CursorAccount, { resolve: { profile: true } });
   const [loaded, setLoaded] = useState(false);
   const [cursorFeedID, setCursorFeedID] = useState<string | null>(null);
 

--- a/examples/multi-cursors/src/components/Container.tsx
+++ b/examples/multi-cursors/src/components/Container.tsx
@@ -34,7 +34,7 @@ function Avatar({
 
 /** A higher order component that wraps the canvas. */
 function Container({ cursorFeedID }: { cursorFeedID: string }) {
-  const { me } = useAccount(CursorAccount, { resolve: { profile: true } });
+  const me = useAccount(CursorAccount, { resolve: { profile: true } });
   const cursors = useCoState(CursorFeed, cursorFeedID, { resolve: true });
 
   const connected = useSyncConnectionStatus();

--- a/examples/multiauth/src/components/Home.tsx
+++ b/examples/multiauth/src/components/Home.tsx
@@ -1,8 +1,9 @@
 import { Account } from "jazz-tools";
-import { useAccount, useIsAuthenticated } from "jazz-tools/react";
+import { useAccount, useIsAuthenticated, useLogOut } from "jazz-tools/react";
 
 export function Home() {
-  const { me, logOut } = useAccount(Account, { resolve: { profile: true } });
+  const { me } = useAccount(Account, { resolve: { profile: true } });
+  const logOut = useLogOut();
   const isAuthenticated = useIsAuthenticated();
 
   if (!me.$isLoaded) return;

--- a/examples/multiauth/src/components/Home.tsx
+++ b/examples/multiauth/src/components/Home.tsx
@@ -2,7 +2,7 @@ import { Account } from "jazz-tools";
 import { useAccount, useIsAuthenticated, useLogOut } from "jazz-tools/react";
 
 export function Home() {
-  const { me } = useAccount(Account, { resolve: { profile: true } });
+  const me = useAccount(Account, { resolve: { profile: true } });
   const logOut = useLogOut();
   const isAuthenticated = useIsAuthenticated();
 

--- a/examples/music-player/src/3_HomePage.tsx
+++ b/examples/music-player/src/3_HomePage.tsx
@@ -1,5 +1,5 @@
 import { useToast } from "@/hooks/use-toast";
-import { createInviteLink, useCoStateWithSelector } from "jazz-tools/react";
+import { createInviteLink, useCoState } from "jazz-tools/react";
 import { useParams } from "react-router";
 import { Playlist } from "./1_schema";
 import { uploadMusicTracks } from "./4_actions";
@@ -37,7 +37,7 @@ export function HomePage({ mediaPlayer }: { mediaPlayer: MediaPlayer }) {
       (me.$isLoaded ? me.root.$jazz.refs.rootPlaylist.id : undefined),
   });
 
-  const playlist = useCoStateWithSelector(Playlist, playlistId, {
+  const playlist = useCoState(Playlist, playlistId, {
     resolve: {
       tracks: {
         $each: true,

--- a/examples/music-player/src/components/AuthButton.tsx
+++ b/examples/music-player/src/components/AuthButton.tsx
@@ -1,14 +1,14 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
-import { useAccount, useIsAuthenticated } from "jazz-tools/react";
+import { useLogOut, useIsAuthenticated } from "jazz-tools/react";
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { AuthModal } from "./AuthModal";
 
 export function AuthButton() {
   const [open, setOpen] = useState(false);
-  const { logOut } = useAccount();
+  const logOut = useLogOut();
   const navigate = useNavigate();
 
   const isAuthenticated = useIsAuthenticated();

--- a/examples/music-player/src/components/LogoutButton.tsx
+++ b/examples/music-player/src/components/LogoutButton.tsx
@@ -1,8 +1,8 @@
-import { useAccount } from "jazz-tools/react";
+import { useLogOut } from "jazz-tools/react";
 import { Button } from "./ui/button";
 
 export function LogoutButton() {
-  const { logOut } = useAccount();
+  const logOut = useLogOut();
 
   return <Button onClick={logOut}>Logout</Button>;
 }

--- a/examples/music-player/src/components/MusicTrackRow.tsx
+++ b/examples/music-player/src/components/MusicTrackRow.tsx
@@ -12,7 +12,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { cn } from "@/lib/utils";
 import { Loaded } from "jazz-tools";
-import { useAccountWithSelector, useCoState } from "jazz-tools/react";
+import { useAccount, useCoState } from "jazz-tools/react";
 import { MoreHorizontal, Pause, Play } from "lucide-react";
 import { Fragment, useCallback, useState } from "react";
 import { EditTrackDialog } from "./RenameTrackDialog";
@@ -43,7 +43,7 @@ export function MusicTrackRow({
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const [isHovered, setIsHovered] = useState(false);
 
-  const playlists = useAccountWithSelector(MusicaAccount, {
+  const playlists = useAccount(MusicaAccount, {
     resolve: {
       root: { playlists: { $onError: "catch", $each: { tracks: true } } },
     },

--- a/examples/music-player/src/components/SidePanel.tsx
+++ b/examples/music-player/src/components/SidePanel.tsx
@@ -12,7 +12,7 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
 } from "@/components/ui/sidebar";
-import { useAccountWithSelector } from "jazz-tools/react";
+import { useAccount } from "jazz-tools/react";
 import { Home, Music, Plus, Trash2 } from "lucide-react";
 import { useNavigate, useParams } from "react-router";
 import { useState } from "react";
@@ -22,7 +22,7 @@ import { CreatePlaylistModal } from "./CreatePlaylistModal";
 export function SidePanel() {
   const { playlistId } = useParams();
   const navigate = useNavigate();
-  const playlists = useAccountWithSelector(MusicaAccount, {
+  const playlists = useAccount(MusicaAccount, {
     resolve: { root: { playlists: { $each: { $onError: "catch" } } } },
     select: (me) => (me.$isLoaded ? me.root.playlists : undefined),
   });

--- a/examples/music-player/src/lib/usePrepareAppState.ts
+++ b/examples/music-player/src/lib/usePrepareAppState.ts
@@ -1,14 +1,14 @@
 import { MusicaAccount, MusicaAccountRoot } from "@/1_schema";
 import { MediaPlayer } from "@/5_useMediaPlayer";
 import { co } from "jazz-tools";
-import { useAccount } from "jazz-tools/react";
+import { useAgent } from "jazz-tools/react";
 import { useEffect, useState } from "react";
 import { uploadMusicTracks } from "../4_actions";
 
 export function usePrepareAppState(mediaPlayer: MediaPlayer) {
   const [isReady, setIsReady] = useState(false);
 
-  const { agent } = useAccount();
+  const agent = useAgent();
 
   useEffect(() => {
     loadInitialData(mediaPlayer).then(() => {

--- a/examples/organization/src/AcceptInvitePage.tsx
+++ b/examples/organization/src/AcceptInvitePage.tsx
@@ -4,7 +4,7 @@ import { JazzAccount, Organization } from "./schema.ts";
 
 export function AcceptInvitePage() {
   const navigate = useNavigate();
-  const { me } = useAccount(JazzAccount, {
+  const me = useAccount(JazzAccount, {
     resolve: { root: { organizations: true } },
   });
 

--- a/examples/organization/src/HomePage.tsx
+++ b/examples/organization/src/HomePage.tsx
@@ -5,7 +5,7 @@ import { Heading } from "./components/Heading.tsx";
 import { JazzAccount } from "./schema";
 
 export function HomePage() {
-  const { me } = useAccount(JazzAccount, {
+  const me = useAccount(JazzAccount, {
     resolve: {
       root: {
         organizations: {

--- a/examples/organization/src/Layout.tsx
+++ b/examples/organization/src/Layout.tsx
@@ -3,7 +3,7 @@ import { UserIcon } from "lucide-react";
 import { JazzAccount } from "./schema";
 
 export function Layout({ children }: { children: React.ReactNode }) {
-  const { me } = useAccount(JazzAccount, {
+  const me = useAccount(JazzAccount, {
     resolve: { profile: true },
   });
   const logOut = useLogOut();

--- a/examples/organization/src/Layout.tsx
+++ b/examples/organization/src/Layout.tsx
@@ -1,11 +1,12 @@
-import { useAccount } from "jazz-tools/react";
+import { useAccount, useLogOut } from "jazz-tools/react";
 import { UserIcon } from "lucide-react";
 import { JazzAccount } from "./schema";
 
 export function Layout({ children }: { children: React.ReactNode }) {
-  const { me, logOut } = useAccount(JazzAccount, {
+  const { me } = useAccount(JazzAccount, {
     resolve: { profile: true },
   });
+  const logOut = useLogOut();
 
   return (
     <>

--- a/examples/organization/src/components/CreateOrganization.tsx
+++ b/examples/organization/src/components/CreateOrganization.tsx
@@ -12,7 +12,7 @@ import { Errors } from "./Errors.tsx";
 import { OrganizationForm } from "./OrganizationForm.tsx";
 
 export function CreateOrganization() {
-  const { me } = useAccount(JazzAccount, {
+  const me = useAccount(JazzAccount, {
     resolve: { root: { draftOrganization: true, organizations: true } },
   });
   const [errors, setErrors] = useState<string[]>([]);

--- a/examples/organization/src/components/OrganizationMembers.tsx
+++ b/examples/organization/src/components/OrganizationMembers.tsx
@@ -30,7 +30,7 @@ function MemberItem({
   role: string;
   group: Group;
 }) {
-  const { me } = useAccount();
+  const me = useAccount();
 
   const canRemoveMember =
     group.myRole() === "admin" && account.$jazz.id !== me?.$jazz.id;

--- a/examples/organization/src/components/OrganizationSelector.tsx
+++ b/examples/organization/src/components/OrganizationSelector.tsx
@@ -5,7 +5,7 @@ import { useNavigate, useParams } from "react-router";
 import { JazzAccount } from "../schema.ts";
 
 export function OrganizationSelector({ className }: { className?: string }) {
-  const { me } = useAccount(JazzAccount, {
+  const me = useAccount(JazzAccount, {
     resolve: { root: { organizations: { $each: { $onError: "catch" } } } },
   });
 

--- a/examples/passphrase/src/App.tsx
+++ b/examples/passphrase/src/App.tsx
@@ -1,7 +1,7 @@
-import { useAccount } from "jazz-tools/react";
+import { useLogOut } from "jazz-tools/react";
 
 function App() {
-  const { logOut } = useAccount();
+  const logOut = useLogOut();
 
   return (
     <main>

--- a/examples/reactions/src/App.tsx
+++ b/examples/reactions/src/App.tsx
@@ -5,7 +5,7 @@ import { ReactionsScreen } from "./ReactionsScreen.tsx";
 import { Reactions } from "./schema.ts";
 
 function App() {
-  const { me } = useAccount(Account, {
+  const me = useAccount(Account, {
     resolve: {
       profile: true,
     },

--- a/examples/reactions/src/App.tsx
+++ b/examples/reactions/src/App.tsx
@@ -1,15 +1,16 @@
 import { useIframeHashRouter } from "hash-slash";
 import { Account, Group } from "jazz-tools";
-import { useAccount } from "jazz-tools/react";
+import { useAccount, useLogOut } from "jazz-tools/react";
 import { ReactionsScreen } from "./ReactionsScreen.tsx";
 import { Reactions } from "./schema.ts";
 
 function App() {
-  const { me, logOut } = useAccount(Account, {
+  const { me } = useAccount(Account, {
     resolve: {
       profile: true,
     },
   });
+  const logOut = useLogOut();
   const router = useIframeHashRouter();
 
   const createReactions = () => {

--- a/examples/richtext-prosekit/src/app.tsx
+++ b/examples/richtext-prosekit/src/app.tsx
@@ -8,7 +8,7 @@ import { JazzAccount } from "./schema.ts";
 import Textarea from "./textarea.tsx";
 
 function App() {
-  const { me } = useAccount(JazzAccount, {
+  const me = useAccount(JazzAccount, {
     resolve: { profile: { bio: true }, root: true },
   });
 

--- a/examples/richtext-prosekit/src/auth-button.tsx
+++ b/examples/richtext-prosekit/src/auth-button.tsx
@@ -1,8 +1,8 @@
-import { useAccount, usePasskeyAuth } from "jazz-tools/react";
+import { usePasskeyAuth, useLogOut } from "jazz-tools/react";
 import { APPLICATION_NAME } from "./app-name";
 
 export function AuthButton() {
-  const { logOut } = useAccount();
+  const logOut = useLogOut();
 
   const auth = usePasskeyAuth({
     appName: APPLICATION_NAME,

--- a/examples/richtext-prosemirror/src/App.tsx
+++ b/examples/richtext-prosemirror/src/App.tsx
@@ -5,7 +5,7 @@ import { Logo } from "./Logo.tsx";
 import { JazzAccount } from "./schema.ts";
 
 function App() {
-  const { me } = useAccount(JazzAccount, {
+  const me = useAccount(JazzAccount, {
     resolve: { profile: true, root: true },
   });
 

--- a/examples/richtext-prosemirror/src/AuthButton.tsx
+++ b/examples/richtext-prosemirror/src/AuthButton.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { useAccount, usePasskeyAuth } from "jazz-tools/react";
+import { usePasskeyAuth, useLogOut } from "jazz-tools/react";
 import { APPLICATION_NAME } from "./main";
 
 export function AuthButton() {
-  const { logOut } = useAccount();
+  const logOut = useLogOut();
 
   const auth = usePasskeyAuth({
     appName: APPLICATION_NAME,

--- a/examples/richtext-prosemirror/src/BranchManagement.tsx
+++ b/examples/richtext-prosemirror/src/BranchManagement.tsx
@@ -12,7 +12,7 @@ export function BranchManagement({
   onBranchChange,
   onBranchMerge,
 }: BranchManagementProps) {
-  const { me } = useAccount(JazzAccount, {
+  const me = useAccount(JazzAccount, {
     resolve: { profile: { branches: true } },
   });
 

--- a/examples/richtext-prosemirror/src/Editor.tsx
+++ b/examples/richtext-prosemirror/src/Editor.tsx
@@ -1,5 +1,5 @@
 import { createJazzPlugin } from "jazz-tools/prosemirror";
-import { useAccountWithSelector, useCoState } from "jazz-tools/react";
+import { useAccount, useCoState } from "jazz-tools/react";
 import { exampleSetup } from "prosemirror-example-setup";
 import { Schema } from "prosemirror-model";
 import { schema as basicSchema } from "prosemirror-schema-basic";
@@ -11,14 +11,14 @@ import { JazzAccount, JazzProfile } from "./schema";
 import { BranchManagement } from "./BranchManagement";
 
 export function Editor() {
-  const bioId = useAccountWithSelector(JazzAccount, {
+  const bioId = useAccount(JazzAccount, {
     resolve: { profile: true },
     select: (me) => (me.$isLoaded ? me.profile.$jazz.refs.bio.id : undefined),
   });
   const editorRef = useRef<HTMLDivElement>(null);
 
   const [branch, setBranch] = useState<string | undefined>(undefined);
-  const selectedBranch = useAccountWithSelector(JazzAccount, {
+  const selectedBranch = useAccount(JazzAccount, {
     select: (me) =>
       branch && me.$isLoaded ? { name: branch, owner: me } : undefined,
   });

--- a/examples/richtext-tiptap/src/App.tsx
+++ b/examples/richtext-tiptap/src/App.tsx
@@ -5,7 +5,7 @@ import { Logo } from "./Logo.tsx";
 import { JazzAccount } from "./schema.ts";
 
 function App() {
-  const { me } = useAccount(JazzAccount, {
+  const me = useAccount(JazzAccount, {
     resolve: { profile: { bio: true }, root: true },
   });
 

--- a/examples/richtext-tiptap/src/AuthButton.tsx
+++ b/examples/richtext-tiptap/src/AuthButton.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { useAccount, usePasskeyAuth } from "jazz-tools/react";
+import { usePasskeyAuth, useLogOut } from "jazz-tools/react";
 import { APPLICATION_NAME } from "./main";
 
 export function AuthButton() {
-  const { logOut } = useAccount();
+  const logOut = useLogOut();
 
   const auth = usePasskeyAuth({
     appName: APPLICATION_NAME,

--- a/examples/server-worker-inbox/src/app.tsx
+++ b/examples/server-worker-inbox/src/app.tsx
@@ -23,7 +23,7 @@ declare module "@tanstack/react-router" {
 }
 
 export function App() {
-  const { me } = useAccount();
+  const me = useAccount();
 
   if (!me.$isLoaded) {
     return <div>Loading...</div>;

--- a/examples/todo/src/2_main.tsx
+++ b/examples/todo/src/2_main.tsx
@@ -118,7 +118,7 @@ export default function App() {
 }
 
 function HomeScreen() {
-  const { me } = useAccount(TodoAccount, {
+  const me = useAccount(TodoAccount, {
     resolve: { root: { projects: { $each: { $onError: "catch" } } } },
   });
   const navigate = useNavigate();

--- a/examples/todo/src/2_main.tsx
+++ b/examples/todo/src/2_main.tsx
@@ -12,6 +12,7 @@ import {
   PassphraseAuthBasicUI,
   useAcceptInvite,
   useAccount,
+  useLogOut,
 } from "jazz-tools/react";
 import React from "react";
 import { TodoAccount, TodoProject } from "./1_schema.ts";
@@ -77,7 +78,7 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
  */
 export default function App() {
   // logOut logs out the AuthProvider passed to `<JazzReactProvider/>` above.
-  const { logOut } = useAccount();
+  const logOut = useLogOut();
 
   const router = createHashRouter([
     {

--- a/examples/todo/src/3_NewProjectForm.tsx
+++ b/examples/todo/src/3_NewProjectForm.tsx
@@ -11,7 +11,7 @@ import { useNavigate } from "react-router";
 export function NewProjectForm() {
   // `me` represents the current user account, which will determine
   // access rights to CoValues. We get it from the top-level provider `<WithJazz/>`.
-  const { me } = useAccount(TodoAccount, {
+  const me = useAccount(TodoAccount, {
     resolve: { root: { projects: { $each: { $onError: "catch" } } } },
   });
   const navigate = useNavigate();

--- a/examples/todo/src/components/InviteButton.tsx
+++ b/examples/todo/src/components/InviteButton.tsx
@@ -15,7 +15,7 @@ export function InviteButton<T extends CoValue>({
 }) {
   const [existingInviteLink, setExistingInviteLink] = useState<string>();
   const { toast } = useToast();
-  const { me } = useAccount();
+  const me = useAccount();
 
   return (
     value.$isLoaded &&

--- a/examples/vector-search/src/App.tsx
+++ b/examples/vector-search/src/App.tsx
@@ -16,7 +16,7 @@ import { useCreateEntry } from "./helpers/use-create-entry";
 import { useDeleteEntries } from "./helpers/use-delete-entries";
 
 function App() {
-  const { me } = useAccount(JazzAccount, {
+  const me = useAccount(JazzAccount, {
     resolve: { root: { journalEntries: true } },
   });
 

--- a/examples/vector-search/src/App.tsx
+++ b/examples/vector-search/src/App.tsx
@@ -1,5 +1,5 @@
 import { useRef, useState } from "react";
-import { useAccount, useCoStateWithSelector } from "jazz-tools/react";
+import { useAccount, useCoState } from "jazz-tools/react";
 
 import { Header } from "./components/Header";
 import { EmptyState } from "./components/EmptyState";
@@ -28,7 +28,7 @@ function App() {
     useCreateEmbedding({ createEmbedding });
 
   // 2) Load a CoList and sort the results by similarity to the query embedding
-  const journalEntries = useCoStateWithSelector(
+  const journalEntries = useCoState(
     JournalEntryList,
     me.$isLoaded ? me.root.journalEntries?.$jazz.id : undefined,
     {

--- a/examples/vector-search/src/components/AuthButton.tsx
+++ b/examples/vector-search/src/components/AuthButton.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { useAccount, usePasskeyAuth } from "jazz-tools/react";
+import { usePasskeyAuth, useLogOut } from "jazz-tools/react";
 import { config } from "../config";
 
 export function AuthButton() {
-  const { logOut } = useAccount();
+  const logOut = useLogOut();
 
   const auth = usePasskeyAuth({
     appName: config.appName,

--- a/examples/version-history/src/App.tsx
+++ b/examples/version-history/src/App.tsx
@@ -6,7 +6,7 @@ import { IssueVersionHistory } from "./IssueVersionHistory.tsx";
 import { Issue } from "./schema";
 
 function App() {
-  const { me } = useAccount(Account, {
+  const me = useAccount(Account, {
     resolve: {
       profile: true,
     },

--- a/examples/version-history/src/App.tsx
+++ b/examples/version-history/src/App.tsx
@@ -1,16 +1,17 @@
 import { Account, CoPlainText, Group } from "jazz-tools";
-import { useAccount, useCoState } from "jazz-tools/react";
+import { useAccount, useCoState, useLogOut } from "jazz-tools/react";
 import { useState } from "react";
 import { IssueComponent } from "./Issue.tsx";
 import { IssueVersionHistory } from "./IssueVersionHistory.tsx";
 import { Issue } from "./schema";
 
 function App() {
-  const { me, logOut } = useAccount(Account, {
+  const { me } = useAccount(Account, {
     resolve: {
       profile: true,
     },
   });
+  const logOut = useLogOut();
   const [issueID, setIssueID] = useState<string | undefined>(
     window.location.search?.replace("?issue=", "") || undefined,
   );

--- a/examples/version-history/src/Project.tsx
+++ b/examples/version-history/src/Project.tsx
@@ -4,7 +4,7 @@ import { IssueComponent } from "./Issue.tsx";
 import { Issue, Project } from "./schema.ts";
 
 export function ProjectComponent({ projectID }: { projectID: string }) {
-  const { me } = useAccount();
+  const me = useAccount();
   const project = useCoState(Project, projectID, {
     resolve: { issues: { $each: true } },
   });

--- a/homepage/homepage/content/docs/authentication/authentication-states.mdx
+++ b/homepage/homepage/content/docs/authentication/authentication-states.mdx
@@ -37,17 +37,17 @@ When a user loads a Jazz application for the first time, we create a new Account
 
 ## Detecting Authentication State
 
-You can detect the current authentication state using `useAccount` and `useIsAuthenticated`.
+You can detect the current authentication state using `useAgent` and `useIsAuthenticated`.
 
 <ContentByFramework framework="react">
 <CodeGroup>
 ```tsx twoslash
 import * as React from "react";
 // ---cut---
-import { useAccount, useIsAuthenticated } from "jazz-tools/react";
+import { useAgent, useIsAuthenticated } from "jazz-tools/react";
 
 function AuthStateIndicator() {
-  const { agent } = useAccount();
+  const agent = useAgent();
   const isAuthenticated = useIsAuthenticated();
 
   // Check if guest mode is enabled in JazzReactProvider

--- a/homepage/homepage/content/docs/authentication/clerk.mdx
+++ b/homepage/homepage/content/docs/authentication/clerk.mdx
@@ -156,10 +156,10 @@ export default function RootLayout() {
 import * as React from "react";
 // ---cut---
 import { SignInButton } from "@clerk/clerk-react";
-import { useAccount, useIsAuthenticated } from "jazz-tools/react";
+import { useIsAuthenticated, useLogOut } from "jazz-tools/react";
 
 export function AuthButton() {
-  const { logOut } = useAccount();
+  const logOut = useLogOut();
 
   const isAuthenticated = useIsAuthenticated();
 
@@ -179,11 +179,11 @@ export function AuthButton() {
 import * as React from "react";
 // ---cut---
 import { useSignIn } from "@clerk/clerk-expo";
-import { useAccount, useIsAuthenticated } from "jazz-tools/expo";
+import { useIsAuthenticated, useLogOut } from "jazz-tools/expo";
 import { Button, Text } from 'react-native';
 
 export function AuthButton() {
-  const { logOut } = useAccount();
+  const logOut = useLogOut();
   const { signIn, setActive, isLoaded } = useSignIn();
   const isAuthenticated = useIsAuthenticated();
 

--- a/homepage/homepage/content/docs/authentication/quickstart.mdx
+++ b/homepage/homepage/content/docs/authentication/quickstart.mdx
@@ -94,7 +94,7 @@ You'll need to make a couple of small changes to your structure in order for thi
 // [!code --:1]
 import { JazzReactProvider, PasskeyAuthBasicUI } from "jazz-tools/react"; 
 // [!code ++:1]
-import { JazzReactProvider, PasskeyAuthBasicUI, useAccount } from "jazz-tools/react"; 
+import { JazzReactProvider, PasskeyAuthBasicUI, useAgent } from "jazz-tools/react"; 
 import { JazzFestAccount } from "@/app/schema";
 
 const apiKey = process.env.NEXT_PUBLIC_JAZZ_API_KEY;
@@ -123,7 +123,7 @@ export function JazzWrapper({ children }: {
 
 // [!code ++:10]
 export function Auth({ children }: { children: React.ReactNode }) {
-  const { agent } = useAccount();
+  const agent = useAgent();
   const isGuest = agent.$type$ !== "Account"
   if (isGuest) return children;
   return (

--- a/homepage/homepage/content/docs/design-patterns/form.mdx
+++ b/homepage/homepage/content/docs/design-patterns/form.mdx
@@ -154,7 +154,7 @@ Here's how that looks like:
 <CodeGroup>
 ```tsx twoslash
 import { co, z } from "jazz-tools";
-import { useCoState, useAccountWithSelector } from "jazz-tools/react";
+import { useCoState, useAccount } from "jazz-tools/react";
 import * as React from "react";
 import { useState } from "react";
 
@@ -201,7 +201,7 @@ export function OrderForm({
 // ---cut---
 // CreateOrder.tsx
 export function CreateOrder(props: { id: string }) {
-  const orders = useAccountWithSelector(JazzAccount, {
+  const orders = useAccount(JazzAccount, {
     resolve: { root: { orders: true } },
     select: (account) => account.$isLoaded ? account.root.orders : undefined,
   });

--- a/homepage/homepage/content/docs/design-patterns/organization.mdx
+++ b/homepage/homepage/content/docs/design-patterns/organization.mdx
@@ -135,7 +135,7 @@ const JazzAccount = co.account({
 
 // ---cut---
 export function AcceptInvitePage() {
-  const { me } = useAccount(JazzAccount, {
+  const me = useAccount(JazzAccount, {
     resolve: { root: { organizations: { $each: { $onError: 'catch' } } } },
   });
 

--- a/homepage/homepage/content/docs/getting-started/quickstart.mdx
+++ b/homepage/homepage/content/docs/getting-started/quickstart.mdx
@@ -232,7 +232,7 @@ import { JazzFestAccount } from "@/app/schema";
 import { useState } from "react";
 
 export function NewBand() {
-  const { me } = useAccount(JazzFestAccount, { resolve: { root: { myFestival: true } } });
+  const me = useAccount(JazzFestAccount, { resolve: { root: { myFestival: true } } });
   const [name, setName] = useState("");
 
   const handleSave = () => {
@@ -299,7 +299,7 @@ import { useAccount } from "jazz-tools/react";
 import { JazzFestAccount } from "@/app/schema";
 
 export function Festival() {
-  const { me } = useAccount(JazzFestAccount, { 
+  const me = useAccount(JazzFestAccount, { 
     resolve: { root: { myFestival: { $each: true } } } 
   });
   if (!me.$isLoaded) return null;

--- a/homepage/homepage/content/docs/groups/quickstart.mdx
+++ b/homepage/homepage/content/docs/groups/quickstart.mdx
@@ -46,7 +46,7 @@ import { JazzFestAccount } from "@/app/schema";
 export function Festival() {
   // [!code ++:1]
   const [inviteLink, setInviteLink] = useState<string>("");
-  const { me } = useAccount(JazzFestAccount, { 
+  const me = useAccount(JazzFestAccount, { 
     resolve: { root: { myFestival: { $each: true } } } 
   });
   if (!me.$isLoaded) return null;
@@ -139,7 +139,7 @@ import { Festival as FestivalSchema, JazzFestAccount } from "@/app/schema";
 
 export function Festival() {
   const [inviteLink, setInviteLink] = useState<string>("");
-  const { me } = useAccount(JazzFestAccount, { 
+  const me = useAccount(JazzFestAccount, { 
     resolve: { root: { myFestival: { $each: true } } } 
   });
   // [!code ++:7]
@@ -242,7 +242,7 @@ export function Festival({id}: {id?: string}) {
   const [inviteLink, setInviteLink] = useState<string>("");
   // [!code ++:1]
   const agent = useAgent();
-  const { me } = useAccount(JazzFestAccount, {
+  const me = useAccount(JazzFestAccount, {
     resolve: { root: { myFestival: true } },
   });
   const router = useRouter();
@@ -321,7 +321,7 @@ export function Festival() {
 // [!code ++:1]
 export function Festival({id}: {id?: string}) {
   const [inviteLink, setInviteLink] = useState<string>("");
-  const { me } = useAccount(JazzFestAccount, {
+  const me = useAccount(JazzFestAccount, {
     resolve: { root: { myFestival: true } },
   });
   const router = useRouter();
@@ -449,7 +449,7 @@ import { JazzFestAccount, Festival } from "@/app/schema";
 export function NewBand() {
 // [!code ++:1]
 export function NewBand({ id }: { id?: string }) {
-  const { me } = useAccount(JazzFestAccount, {
+  const me = useAccount(JazzFestAccount, {
       resolve: { root: { myFestival: true } }
     });
   const [name, setName] = useState("");

--- a/homepage/homepage/content/docs/groups/quickstart.mdx
+++ b/homepage/homepage/content/docs/groups/quickstart.mdx
@@ -231,7 +231,8 @@ import {
   createInviteLink,
   useAcceptInvite,
   useAccount,
-  useCoState
+  useAgent,
+  useCoState,
 } from "jazz-tools/react";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
@@ -239,10 +240,9 @@ import { Festival as FestivalSchema, JazzFestAccount } from "@/app/schema";
 
 export function Festival({id}: {id?: string}) {
   const [inviteLink, setInviteLink] = useState<string>("");
-  // [!code --:1]
-  const { me } = useAccount(JazzFestAccount, {
   // [!code ++:1]
-  const { me, agent } = useAccount(JazzFestAccount, {
+  const agent = useAgent();
+  const { me } = useAccount(JazzFestAccount, {
     resolve: { root: { myFestival: true } },
   });
   const router = useRouter();

--- a/homepage/homepage/content/docs/project-setup/ssr.mdx
+++ b/homepage/homepage/content/docs/project-setup/ssr.mdx
@@ -241,7 +241,7 @@ import Link from "next/link";
 import { JazzFestAccount } from "@/app/schema";
 
 export function Festival() {
-  const { me } = useAccount(JazzFestAccount, {
+  const me = useAccount(JazzFestAccount, {
     resolve: { root: { myFestival: { $each: { $onError: 'catch' } } } },
   });
   if (!me.$isLoaded) return null; 

--- a/homepage/homepage/content/docs/schemas/accounts-and-migrations.mdx
+++ b/homepage/homepage/content/docs/schemas/accounts-and-migrations.mdx
@@ -133,7 +133,7 @@ class ContactPreview extends React.Component<{ contact: co.loaded<typeof MyAppAc
 import { useAccount } from "jazz-tools/react";
 
 function DashboardPageComponent() {
-  const { me } = useAccount(MyAppAccount, { resolve: {
+  const me = useAccount(MyAppAccount, { resolve: {
     profile: true,
     root: {
       myChats: { $each: true },

--- a/homepage/homepage/content/docs/upgrade/0-12-0.mdx
+++ b/homepage/homepage/content/docs/upgrade/0-12-0.mdx
@@ -24,10 +24,10 @@ We're introducing a new resolve API for deep loading, more friendly to TypeScrip
 
 <CodeGroup>
 ```tsx
-const { me } = useAccount({ root: { friends: [] } }); // [!code --]
+const me = useAccount({ root: { friends: [] } }); // [!code --]
 
 // After
-const { me } = useAccount({ // [!code ++]
+const me = useAccount({ // [!code ++]
   resolve: { root: { friends: true } } // [!code ++]
 }); // [!code ++]
 ```

--- a/homepage/homepage/content/docs/upgrade/0-12-0.mdx
+++ b/homepage/homepage/content/docs/upgrade/0-12-0.mdx
@@ -24,10 +24,10 @@ We're introducing a new resolve API for deep loading, more friendly to TypeScrip
 
 <CodeGroup>
 ```tsx
-const me = useAccount({ root: { friends: [] } }); // [!code --]
+const { me } = useAccount({ root: { friends: [] } }); // [!code --]
 
 // After
-const me = useAccount({ // [!code ++]
+const { me } = useAccount({ // [!code ++]
   resolve: { root: { friends: true } } // [!code ++]
 }); // [!code ++]
 ```

--- a/homepage/homepage/content/docs/upgrade/0-14-0.mdx
+++ b/homepage/homepage/content/docs/upgrade/0-14-0.mdx
@@ -260,7 +260,7 @@ import { useAccount } from "jazz-react";
 import { MyAccount } from "./schema";
 
 function MyComponent() {
-  const me = useAccount(MyAccount, {
+  const { me } = useAccount(MyAccount, {
     resolve: {
       profile: true,
     },

--- a/homepage/homepage/content/docs/upgrade/0-14-0.mdx
+++ b/homepage/homepage/content/docs/upgrade/0-14-0.mdx
@@ -260,7 +260,7 @@ import { useAccount } from "jazz-react";
 import { MyAccount } from "./schema";
 
 function MyComponent() {
-  const { me } = useAccount(MyAccount, {
+  const me = useAccount(MyAccount, {
     resolve: {
       profile: true,
     },

--- a/homepage/homepage/content/docs/upgrade/0-9-0/react-native.mdx
+++ b/homepage/homepage/content/docs/upgrade/0-9-0/react-native.mdx
@@ -68,7 +68,7 @@ This change improves IDE intellisense support and simplifies imports:
     import { useAccount } from "jazz-react-native"; // [!code ++]
 
     export function Hello() {
-        const { me } = useAccount();
+        const me = useAccount();
 
         return (
             <>

--- a/homepage/homepage/content/docs/upgrade/0-9-0/react-native.mdx
+++ b/homepage/homepage/content/docs/upgrade/0-9-0/react-native.mdx
@@ -68,7 +68,7 @@ This change improves IDE intellisense support and simplifies imports:
     import { useAccount } from "jazz-react-native"; // [!code ++]
 
     export function Hello() {
-        const me = useAccount();
+        const { me } = useAccount();
 
         return (
             <>

--- a/homepage/homepage/content/docs/upgrade/0-9-0/react.mdx
+++ b/homepage/homepage/content/docs/upgrade/0-9-0/react.mdx
@@ -67,7 +67,7 @@ This change improves IDE intellisense support and simplifies imports:
     import { useAccount } from "jazz-react"; // [!code ++]
 
     export function Hello() {
-        const me = useAccount();
+        const { me } = useAccount();
 
         return (
             <>

--- a/homepage/homepage/content/docs/upgrade/0-9-0/react.mdx
+++ b/homepage/homepage/content/docs/upgrade/0-9-0/react.mdx
@@ -67,7 +67,7 @@ This change improves IDE intellisense support and simplifies imports:
     import { useAccount } from "jazz-react"; // [!code ++]
 
     export function Hello() {
-        const { me } = useAccount();
+        const me = useAccount();
 
         return (
             <>

--- a/homepage/homepage/content/docs/upgrade/0-9-0/svelte.mdx
+++ b/homepage/homepage/content/docs/upgrade/0-9-0/svelte.mdx
@@ -63,7 +63,7 @@ So we decided to remove `createJazzApp` step and to provide the types through na
   import { useAccount } from '$lib/jazz'; // [!code --]
   import { useAccount } from 'jazz-svelte'; // [!code ++]
 
-  const { me } = useAccount();
+  const me = useAccount();
 </script>
 
 <div>

--- a/homepage/homepage/content/docs/upgrade/0-9-0/svelte.mdx
+++ b/homepage/homepage/content/docs/upgrade/0-9-0/svelte.mdx
@@ -63,7 +63,7 @@ So we decided to remove `createJazzApp` step and to provide the types through na
   import { useAccount } from '$lib/jazz'; // [!code --]
   import { useAccount } from 'jazz-svelte'; // [!code ++]
 
-  const me = useAccount();
+  const { me } = useAccount();
 </script>
 
 <div>

--- a/homepage/homepage/content/docs/using-covalues/cotexts.mdx
+++ b/homepage/homepage/content/docs/using-covalues/cotexts.mdx
@@ -358,7 +358,7 @@ import { EditorState } from "prosemirror-state";
 import { EditorView } from "prosemirror-view";
 
 function RichTextEditor() {
-  const { me } = useAccount(JazzAccount, { resolve: { profile: { bio: true} } });
+  const me = useAccount(JazzAccount, { resolve: { profile: { bio: true} } });
   const editorRef = useRef<HTMLDivElement>(null);
   const viewRef = useRef<EditorView | null>(null);
 

--- a/homepage/homepage/content/docs/using-covalues/covectors.mdx
+++ b/homepage/homepage/content/docs/using-covalues/covectors.mdx
@@ -97,7 +97,7 @@ CoVectors cannot be changed after creation. Instead, create a new CoVector with 
 Semantic search lets you find data based on meaning, not just keywords. In Jazz, you can easily sort results by how similar they are to your search query.
 
 <ContentByFramework framework="react">
-Use the `useCoStateWithSelector` hook to load your data and sort it by similarity to your query embedding:
+Use the `useCoState` hook to load your data and sort it by similarity to your query embedding:
 </ContentByFramework>
 <ContentByFramework framework="vanilla">
 You can load your data using the `.load` method, then compute and sort the results by similarity to your query embedding:
@@ -123,11 +123,11 @@ const useCreateEmbedding: () => YourCustomHook =
   });
 
 // ---cut---
-import { useCoStateWithSelector } from "jazz-tools/react";
+import { useCoState } from "jazz-tools/react";
 
 const { queryEmbedding, createQueryEmbedding } = useCreateEmbedding();
 
-const foundDocuments = useCoStateWithSelector(
+const foundDocuments = useCoState(
   DocumentsList,
   documentsListId,
   {

--- a/homepage/homepage/content/docs/using-covalues/subscription-and-loading.mdx
+++ b/homepage/homepage/content/docs/using-covalues/subscription-and-loading.mdx
@@ -536,20 +536,19 @@ unsubscribe();
 <ContentByFramework framework={["react", "react-native", "react-native-expo"]}>
 
 ## Selectors [!framework=react,react-native,react-native-expo]
-Sometimes, you only need to react to changes in specific parts of a CoValue. In those cases, you can use the `useCoStateWithSelector` hook to specify what data you are interested in.
-
-When you use `useCoStateWithSelector` , in addition to `resolve` you can also add a `select` and optionally an `equalityFn` option. 
+Sometimes, you only need to react to changes in specific parts of a CoValue. In those cases, you can provide a `select` function to specify what data you are interested in,
+and an optional `equalityFn` option to control re-renders. 
 
 - `select`: extract the fields you care about
 - `equalityFn`: (optional) control when data should be considered equal
 
 <CodeGroup>
 ```tsx
-import { useCoStateWithSelector } from "jazz-tools/react";
+import { useCoState } from "jazz-tools/react";
 
 function ProjectView({ projectId }: { projectId: string }) {
   // Subscribe to a project
-  const project = useCoStateWithSelector(Project, projectId, {
+  const project = useCoState(Project, projectId, {
     resolve: {
       tasks: true
     },

--- a/homepage/homepage/content/docs/using-covalues/subscription-and-loading.mdx
+++ b/homepage/homepage/content/docs/using-covalues/subscription-and-loading.mdx
@@ -114,7 +114,7 @@ function ProjectView({ projectId }: { projectId: string }) {
 import { useAccount } from "jazz-tools/react";
 
 function ProjectList() {
-  const { me } = useAccount(MyAppAccount, {
+  const me = useAccount(MyAppAccount, {
     resolve: { profile: true }
   })
 

--- a/homepage/homepage/content/docs/using-covalues/subscription-and-loading.mdx
+++ b/homepage/homepage/content/docs/using-covalues/subscription-and-loading.mdx
@@ -587,15 +587,15 @@ function ProjectView({ projectId }: { projectId: string }) {
 
 By default, the return values of the select function will be compared using `Object.is`, but you can use the `equalityFn` to add your own logic.
 
-You can also use `useAccountWithSelector` in the same way, to subscribe to only the changes in a user's account you are interested in.
+You can also use `useAccount` in the same way, to subscribe to only the changes in a user's account you are interested in.
 
 <CodeGroup>
 ```tsx
-import { useAccountWithSelector } from "jazz-tools/react";
+import { useAccount } from "jazz-tools/react";
 
 function ProfileName() {
   // Only re-renders when the profile name changes
-    const profileName = useAccountWithSelector(MyAppAccount, {
+    const profileName = useAccount(MyAppAccount, {
     resolve: {
       profile: true,
     },

--- a/homepage/homepage/content/docs/using-covalues/version-control.mdx
+++ b/homepage/homepage/content/docs/using-covalues/version-control.mdx
@@ -174,7 +174,7 @@ On account only root and profile replacements are not affected by the branching.
 
 <CodeGroup>
 ```tsx 
-const me = useAccount(MyAccount, {
+const { me } = useAccount(MyAccount, {
   resolve: { root: true },
   unstable_branch: { name: "feature-branch" }
 });

--- a/homepage/homepage/content/docs/using-covalues/version-control.mdx
+++ b/homepage/homepage/content/docs/using-covalues/version-control.mdx
@@ -174,7 +174,7 @@ On account only root and profile replacements are not affected by the branching.
 
 <CodeGroup>
 ```tsx 
-const { me } = useAccount(MyAccount, {
+const me = useAccount(MyAccount, {
   resolve: { root: true },
   unstable_branch: { name: "feature-branch" }
 });

--- a/packages/community-jazz-vue/src/composables.ts
+++ b/packages/community-jazz-vue/src/composables.ts
@@ -103,7 +103,6 @@ export function useAccount<
 ): {
   me: ComputedRef<MaybeLoaded<Loaded<A, R>>>;
   agent: AnonymousJazzAgent | Loaded<A, true>;
-  logOut: () => void;
 } {
   const context = useJazzContext();
   const contextManager = useJazzContextManager<InstanceOfSchema<A>>();
@@ -119,7 +118,6 @@ export function useAccount<
     return {
       me: computed(() => null) as any,
       agent: agent,
-      logOut: context.value.logOut,
     };
   }
 
@@ -138,8 +136,18 @@ export function useAccount<
       return value ? markRaw(value) : value;
     }) as any,
     agent: agent,
-    logOut: context.value.logOut,
   };
+}
+
+/**
+ * Returns a function for logging out the current account.
+ */
+export function useLogOut(): () => void {
+  const context = useJazzContext();
+  if (!context.value) {
+    throw new Error("useLogOut must be used within a JazzProvider");
+  }
+  return context.value.logOut;
 }
 
 export function useCoState<

--- a/packages/community-jazz-vue/src/composables.ts
+++ b/packages/community-jazz-vue/src/composables.ts
@@ -100,20 +100,16 @@ export function useAccount<
   options?: {
     resolve?: ResolveQueryStrict<A, R>;
   },
-): {
-  me: ComputedRef<MaybeLoaded<Loaded<A, R>>>;
-} {
+): ComputedRef<MaybeLoaded<Loaded<A, R>>> {
   const context = useJazzContext();
 
   if (!context.value) {
     throw new Error("useAccount must be used within a JazzProvider");
   }
 
-  // Handle guest mode - return null for me and the guest agent
+  // Handle guest mode - return null for the account data
   if (!("me" in context.value)) {
-    return {
-      me: computed(() => null) as any,
-    };
+    return computed(() => null) as any;
   }
 
   const contextMe = context.value.me as InstanceOfSchema<A>;
@@ -124,13 +120,11 @@ export function useAccount<
     options as any,
   );
 
-  return {
-    me: computed(() => {
-      const value =
-        options?.resolve === undefined ? me.value || contextMe : me.value;
-      return value ? markRaw(value) : value;
-    }) as any,
-  };
+  return computed(() => {
+    const value =
+      options?.resolve === undefined ? me.value || contextMe : me.value;
+    return value ? markRaw(value) : value;
+  }) as any;
 }
 
 /**

--- a/packages/community-jazz-vue/src/composables.ts
+++ b/packages/community-jazz-vue/src/composables.ts
@@ -146,10 +146,9 @@ export function useLogOut(): () => void {
  *
  * The agent can be used as the `loadAs` parameter for load and subscribe methods.
  */
-export function useAgent<A extends AccountClass<Account> | AnyAccountSchema>(
-  /** The account schema to use. Defaults to the base Account schema */
-  AccountSchema: A = Account as unknown as A,
-): AnonymousJazzAgent | Loaded<A, true> {
+export function useAgent<
+  A extends AccountClass<Account> | AnyAccountSchema = typeof Account,
+>(): AnonymousJazzAgent | Loaded<A, true> {
   const contextManager = useJazzContextManager<InstanceOfSchema<A>>();
   const agent = getCurrentAccountFromContextManager(contextManager.value);
   return agent;

--- a/packages/community-jazz-vue/src/composables.ts
+++ b/packages/community-jazz-vue/src/composables.ts
@@ -151,7 +151,7 @@ export function useAgent<
 >(): AnonymousJazzAgent | Loaded<A, true> {
   const contextManager = useJazzContextManager<InstanceOfSchema<A>>();
   const agent = getCurrentAccountFromContextManager(contextManager.value);
-  return agent;
+  return agent as AnonymousJazzAgent | Loaded<A, true>;
 }
 
 export function useCoState<

--- a/packages/community-jazz-vue/src/tests/proxyBehavior.test.ts
+++ b/packages/community-jazz-vue/src/tests/proxyBehavior.test.ts
@@ -4,7 +4,7 @@ import { Group, co, z } from "jazz-tools";
 import { assertLoaded } from "jazz-tools/testing";
 import { beforeAll, describe, expect, it } from "vitest";
 import { isProxy, nextTick, toRaw } from "vue";
-import { useAccount, useCoState } from "../composables.js";
+import { useAccount, useAgent, useCoState, useLogOut } from "../composables.js";
 import { createJazzTestAccount } from "../testing.js";
 import { withJazzTestSetup } from "./testUtils.js";
 
@@ -102,7 +102,7 @@ describe("Proxy Behavior Verification", () => {
     await nextTick();
 
     // Should be able to access deeply nested properties without proxy issues
-    const me = accountResult.me.value;
+    const me = accountResult.value;
     assertLoaded(me);
     expect(me?.root).toBeDefined();
     expect(me?.root?.testMap).toBeDefined();
@@ -181,28 +181,33 @@ describe("Proxy Behavior Verification", () => {
   it("should handle context manager objects without proxy issues", async () => {
     const account = await createJazzTestAccount();
 
-    const [result] = withJazzTestSetup(() => useAccount(), {
+    const [loadedAccount] = withJazzTestSetup(() => useAccount(), {
+      account,
+    });
+    const [agent] = withJazzTestSetup(() => useAgent(), {
+      account,
+    });
+    const [logOut] = withJazzTestSetup(() => useLogOut(), {
       account,
     });
 
     // The account object should not be a proxy
-    expect(isProxy(result.me.value)).toBe(false);
+    expect(isProxy(loadedAccount.value)).toBe(false);
 
     // The agent should be accessible and usable without toRaw() calls
-    expect(result.agent).toBeDefined();
-    expect(typeof result.agent).toBe("object");
+    expect(typeof agent).toBe("object");
 
     // Should be able to access agent properties without proxy issues
     expect(() => {
-      const agentType = result.agent.$type$; // Access agent property
+      const agentType = agent.$type$; // Access agent property
       expect(agentType).toBeDefined();
     }).not.toThrow();
 
     // LogOut function should work without proxy issues
-    expect(typeof result.logOut).toBe("function");
+    expect(typeof logOut).toBe("function");
     expect(() => {
       // Should be able to call without toRaw()
-      result.logOut.toString(); // Safe way to test function access
+      logOut.toString(); // Safe way to test function access
     }).not.toThrow();
   });
 
@@ -265,11 +270,11 @@ describe("Proxy Behavior Verification", () => {
     await nextTick();
 
     // Both account and project should work without proxy issues
-    expect(isProxy(accountResult.me.value)).toBe(false);
+    expect(isProxy(accountResult.value)).toBe(false);
     expect(isProxy(projectResult.value)).toBe(false);
 
     // Should be able to access properties without toRaw()
-    expect(accountResult.me.value?.$jazz.id).toBeDefined();
+    expect(accountResult.value?.$jazz.id).toBeDefined();
     assertLoaded(projectResult.value);
     expect(projectResult.value.content).toBe("new project");
   });

--- a/packages/community-jazz-vue/src/tests/useAccount.test.ts
+++ b/packages/community-jazz-vue/src/tests/useAccount.test.ts
@@ -2,7 +2,7 @@
 
 import { Group, co, z } from "jazz-tools";
 import { describe, expect, it } from "vitest";
-import { useAccount } from "../composables.js";
+import { useAccount, useAgent, useLogOut } from "../composables.js";
 import { createJazzTestAccount, createJazzTestGuest } from "../testing.js";
 import { withJazzTestSetup } from "./testUtils.js";
 
@@ -38,19 +38,25 @@ describe("useAccount", () => {
       account,
     });
 
-    expect(result.me.value).toEqual(account);
+    expect(result.value).toEqual(account);
   });
 
   it("should handle guest mode correctly", async () => {
     const guestAccount = await createJazzTestGuest();
 
-    const [result] = withJazzTestSetup(() => useAccount(), {
+    const [account] = withJazzTestSetup(() => useAccount(), {
+      account: guestAccount,
+    });
+    const [agent] = withJazzTestSetup(() => useAgent(), {
+      account: guestAccount,
+    });
+    const [logOut] = withJazzTestSetup(() => useLogOut(), {
       account: guestAccount,
     });
 
     // In guest mode, me should be null and agent should be the guest
-    expect(result.me.value).toBe(null);
-    expect(result.agent.$type$).toBe("Anonymous");
-    expect(typeof result.logOut).toBe("function");
+    expect(account.value).toBe(null);
+    expect(agent.$type$).toBe("Anonymous");
+    expect(typeof logOut).toBe("function");
   });
 });

--- a/packages/jazz-tools/src/react-core/hooks.ts
+++ b/packages/jazz-tools/src/react-core/hooks.ts
@@ -533,16 +533,15 @@ export function useAccountSubscription<
 
 /**
  * React hook for accessing the current user's account and authentication state.
- * 
+ *
  * This hook provides access to the current user's account profile and root data,
  * along with authentication utilities. It automatically handles subscription to
  * the user's account data and provides a logout function.
- * 
+ *
  * @returns An object containing:
  * - `me`: The account data, or an {@link Unloaded} value. Use `$isLoaded` to check whether the
  * CoValue is loaded, or use {@link MaybeLoaded.$jazz.loadingState} to get the detailed loading state.
- * - `logOut`: Function to log out the current user
-
+ *
  * @example
  * ```tsx
  * // Deep loading with resolve queries
@@ -559,7 +558,7 @@ export function useAccountSubscription<
  *       },
  *     },
  *   });
- * 
+ *
  *   if (!me.$isLoaded) {
  *     switch (me.$jazz.loadingState) {
  *       case "unauthorized":
@@ -570,7 +569,7 @@ export function useAccountSubscription<
  *         return "Loading account...";
  *     }
  *   }
- * 
+ *
  *   return (
  *     <div>
  *       <h1>{me.profile.name}'s projects</h1>
@@ -585,7 +584,7 @@ export function useAccountSubscription<
  *   );
  * }
  * ```
- * 
+ *
  */
 export function useAccount<
   A extends AccountClass<Account> | AnyAccountSchema,
@@ -641,6 +640,14 @@ export function useAccount<
     me: value,
     logOut: contextManager.logOut,
   };
+}
+
+/**
+ * Returns a function for logging out the current account.
+ */
+export function useLogOut(): () => void {
+  const contextManager = useJazzContextManager();
+  return contextManager.logOut;
 }
 
 /**

--- a/packages/jazz-tools/src/react-core/hooks.ts
+++ b/packages/jazz-tools/src/react-core/hooks.ts
@@ -538,15 +538,14 @@ export function useAccountSubscription<
  * along with authentication utilities. It automatically handles subscription to
  * the user's account data and provides a logout function.
  *
- * @returns An object containing:
- * - `me`: The account data, or an {@link Unloaded} value. Use `$isLoaded` to check whether the
+ * @returns The account data, or an {@link Unloaded} value. Use `$isLoaded` to check whether the
  * CoValue is loaded, or use {@link MaybeLoaded.$jazz.loadingState} to get the detailed loading state.
  *
  * @example
  * ```tsx
  * // Deep loading with resolve queries
  * function ProjectListWithDetails() {
- *   const { me } = useAccount(MyAppAccount, {
+ *   const me = useAccount(MyAppAccount, {
  *     resolve: {
  *       profile: true,
  *       root: {
@@ -613,9 +612,7 @@ export function useAccount<
      */
     unstable_branch?: BranchDefinition;
   },
-): {
-  me: MaybeLoaded<Loaded<A, R>>;
-} {
+): MaybeLoaded<Loaded<A, R>> {
   const subscription = useAccountSubscription(AccountSchema, options);
   const getCurrentValue = useGetCurrentValue(subscription);
 
@@ -634,9 +631,7 @@ export function useAccount<
     getCurrentValue,
   );
 
-  return {
-    me: value,
-  };
+  return value;
 }
 
 /**

--- a/packages/jazz-tools/src/react-core/hooks.ts
+++ b/packages/jazz-tools/src/react-core/hooks.ts
@@ -693,10 +693,9 @@ export function useLogOut(): () => void {
  *
  * The agent can be used as the `loadAs` parameter for load and subscribe methods.
  */
-export function useAgent<A extends AccountClass<Account> | AnyAccountSchema>(
-  /** The account schema to use. Defaults to the base Account schema */
-  AccountSchema: A = Account as unknown as A,
-): AnonymousJazzAgent | Loaded<A, true> {
+export function useAgent<
+  A extends AccountClass<Account> | AnyAccountSchema = typeof Account,
+>(): AnonymousJazzAgent | Loaded<A, true> {
   const contextManager = useJazzContextManager<InstanceOfSchema<A>>();
   const agent = getCurrentAccountFromContextManager(contextManager);
   return agent;

--- a/packages/jazz-tools/src/react-core/hooks.ts
+++ b/packages/jazz-tools/src/react-core/hooks.ts
@@ -698,7 +698,7 @@ export function useAgent<
 >(): AnonymousJazzAgent | Loaded<A, true> {
   const contextManager = useJazzContextManager<InstanceOfSchema<A>>();
   const agent = getCurrentAccountFromContextManager(contextManager);
-  return agent;
+  return agent as AnonymousJazzAgent | Loaded<A, true>;
 }
 
 export function experimental_useInboxSender<

--- a/packages/jazz-tools/src/react-core/hooks.ts
+++ b/packages/jazz-tools/src/react-core/hooks.ts
@@ -212,8 +212,38 @@ function useGetCurrentValue<C extends CoValue>(
  * handles the subscription lifecycle (subscribe on mount, unsubscribe on unmount).
  * It also supports deep loading of nested CoValues through resolve queries.
  *
+ * The {@param options.select} function allows returning only specific parts of the CoValue data,
+ * which helps reduce unnecessary re-renders by narrowing down the returned data.
+ * Additionally, you can provide a custom {@param options.equalityFn} to further optimize
+ * performance by controlling when the component should re-render based on the selected data.
+ *
  * @returns The loaded CoValue, or an {@link Unloaded} value. Use `$isLoaded` to check whether the
  * CoValue is loaded, or use {@link MaybeLoaded.$jazz.loadingState} to get the detailed loading state.
+ * If a selector function is provided, returns the result of the selector function.
+ *
+ * @example
+ * ```tsx
+ * // Select only specific fields to reduce re-renders
+ * const Project = co.map({
+ *   name: z.string(),
+ *   description: z.string(),
+ *   tasks: co.list(Task),
+ *   lastModified: z.date(),
+ * });
+ *
+ * function ProjectTitle({ projectId }: { projectId: string }) {
+ *   // Only re-render when the project name changes, not other fields
+ *   const projectName = useCoStateWithSelector(
+ *     Project,
+ *     projectId,
+ *     {
+ *       select: (project) => !project.$isLoading ? project.name : "Loading...",
+ *     }
+ *   );
+ *
+ *   return <h1>{projectName}</h1>;
+ * }
+ * ```
  *
  * @example
  * ```tsx
@@ -234,13 +264,13 @@ function useGetCurrentValue<C extends CoValue>(
  *
  *   if (!project.$isLoaded) {
  *     switch (project.$jazz.loadingState) {
-         case "unauthorized":
-           return "Project not accessible";
-         case "unavailable":
-           return "Project not found";
-         case "unloaded":
-           return "Loading project...";
-       }
+ *       case "unauthorized":
+ *         return "Project not accessible";
+ *       case "unavailable":
+ *         return "Project not found";
+ *       case "unloaded":
+ *         return "Loading project...";
+ *     }
  *   }
  *
  *   return (
@@ -299,96 +329,6 @@ function useGetCurrentValue<C extends CoValue>(
  * }
  * ```
  *
- * For more examples, see the [subscription and deep loading](https://jazz.tools/docs/react/using-covalues/subscription-and-loading) documentation.
- */
-export function useCoState<
-  S extends CoValueClassOrSchema,
-  const R extends ResolveQuery<S> = true,
->(
-  /** The CoValue schema or class constructor */
-  Schema: S,
-  /** The ID of the CoValue to subscribe to. If `undefined`, returns an `unavailable` value */
-  id: string | undefined,
-  /** Optional configuration for the subscription */
-  options?: {
-    /** Resolve query to specify which nested CoValues to load */
-    resolve?: ResolveQueryStrict<S, R>;
-    /**
-     * Create or load a branch for isolated editing.
-     *
-     * Branching lets you take a snapshot of the current state and start modifying it without affecting the canonical/shared version.
-     * It's a fork of your data graph: the same schema, but with diverging values.
-     *
-     * The checkout of the branch is applied on all the resolved values.
-     *
-     * @param name - A unique name for the branch. This identifies the branch
-     *   and can be used to switch between different branches of the same CoValue.
-     * @param owner - The owner of the branch. Determines who can access and modify
-     *   the branch. If not provided, the branch is owned by the current user.
-     *
-     * For more info see the [branching](https://jazz.tools/docs/react/using-covalues/version-control) documentation.
-     */
-    unstable_branch?: BranchDefinition;
-  },
-): MaybeLoaded<Loaded<S, R>> {
-  const subscription = useCoValueSubscription(Schema, id, options);
-  const getCurrentValue = useGetCurrentValue(subscription);
-
-  const value = React.useSyncExternalStore<MaybeLoaded<Loaded<S, R>>>(
-    React.useCallback(
-      (callback) => {
-        if (!subscription) {
-          return () => {};
-        }
-
-        return subscription.subscribe(callback);
-      },
-      [subscription],
-    ),
-    getCurrentValue,
-    getCurrentValue,
-  );
-
-  return value;
-}
-
-/**
- * React hook for subscribing to CoValues with selective data extraction and custom equality checking.
- *
- * This hook extends `useCoState` by allowing you to select only specific parts of the CoValue data
- * through a selector function, which helps reduce unnecessary re-renders by narrowing down the
- * returned data. Additionally, you can provide a custom equality function to further optimize
- * performance by controlling when the component should re-render based on the selected data.
- *
- * The hook automatically handles the subscription lifecycle and supports deep loading of nested
- * CoValues through resolve queries, just like `useCoState`.
- *
- * @returns The result of the selector function applied to the loaded CoValue data
- *
- * @example
- * ```tsx
- * // Select only specific fields to reduce re-renders
- * const Project = co.map({
- *   name: z.string(),
- *   description: z.string(),
- *   tasks: co.list(Task),
- *   lastModified: z.date(),
- * });
- *
- * function ProjectTitle({ projectId }: { projectId: string }) {
- *   // Only re-render when the project name changes, not other fields
- *   const projectName = useCoStateWithSelector(
- *     Project,
- *     projectId,
- *     {
- *       select: (project) => project?.name ?? "Loading...",
- *     }
- *   );
- *
- *   return <h1>{projectName}</h1>;
- * }
- * ```
- *
  * @example
  * ```tsx
  * // Use custom equality function for complex data structures
@@ -420,72 +360,23 @@ export function useCoState<
  * }
  * ```
  *
- * @example
- * ```tsx
- * // Combine with deep loading and complex selectors
- * const Team = co.map({
- *   name: z.string(),
- *   members: co.list(TeamMember),
- *   projects: co.list(Project),
- * });
- *
- * function TeamSummary({ teamId }: { teamId: string }) {
- *   const summary = useCoStateWithSelector(
- *     Team,
- *     teamId,
- *     {
- *       resolve: {
- *         members: { $each: true },
- *         projects: { $each: { tasks: { $each: true } } },
- *       },
- *       select: (team) => {
- *         if (!team.$isLoaded) return null;
- *
- *         const totalTasks = team.projects.reduce(
- *           (sum, project) => sum + project.tasks.length,
- *           0
- *         );
- *
- *         return {
- *           teamName: team.name,
- *           memberCount: team.members.length,
- *           projectCount: team.projects.length,
- *           totalTasks,
- *         };
- *       },
- *     }
- *   );
- *
- *   if (!summary) return <div>Loading team summary...</div>;
- *
- *   return (
- *     <div>
- *       <h2>{summary.teamName}</h2>
- *       <p>{summary.memberCount} members</p>
- *       <p>{summary.projectCount} projects</p>
- *       <p>{summary.totalTasks} total tasks</p>
- *     </div>
- *   );
- * }
- * ```
- *
  * For more examples, see the [subscription and deep loading](https://jazz.tools/docs/react/using-covalues/subscription-and-loading) documentation.
  */
-export function useCoStateWithSelector<
+export function useCoState<
   S extends CoValueClassOrSchema,
-  TSelectorReturn,
   const R extends ResolveQuery<S> = true,
+  TSelectorReturn = MaybeLoaded<Loaded<S, R>>,
 >(
   /** The CoValue schema or class constructor */
   Schema: S,
-  /** The ID of the CoValue to subscribe to. If `undefined`, returns the result of selector called with an `unavailable` value */
+  /** The ID of the CoValue to subscribe to. If `undefined`, returns an `unavailable` value */
   id: string | undefined,
   /** Optional configuration for the subscription */
-  options: {
+  options?: {
     /** Resolve query to specify which nested CoValues to load */
     resolve?: ResolveQueryStrict<S, R>;
     /** Select which value to return */
-    select: (value: MaybeLoaded<Loaded<S, R>>) => TSelectorReturn;
+    select?: (value: MaybeLoaded<Loaded<S, R>>) => TSelectorReturn;
     /** Equality function to determine if the selected value has changed, defaults to `Object.is` */
     equalityFn?: (a: TSelectorReturn, b: TSelectorReturn) => boolean;
     /**
@@ -509,7 +400,7 @@ export function useCoStateWithSelector<
   const subscription = useCoValueSubscription(Schema, id, options);
   const getCurrentValue = useGetCurrentValue(subscription);
 
-  return useSyncExternalStoreWithSelector<
+  const value = useSyncExternalStoreWithSelector<
     MaybeLoaded<Loaded<S, R>>,
     TSelectorReturn
   >(
@@ -525,10 +416,14 @@ export function useCoStateWithSelector<
     ),
     getCurrentValue,
     getCurrentValue,
-    options.select,
-    options.equalityFn ?? Object.is,
+    options?.select ?? ((value) => value as TSelectorReturn),
+    options?.equalityFn ?? Object.is,
   );
+
+  return value;
 }
+
+export const useCoStateWithSelector = useCoState;
 
 export function useSubscriptionSelector<
   S extends CoValueClassOrSchema,

--- a/packages/jazz-tools/src/react-core/hooks.ts
+++ b/packages/jazz-tools/src/react-core/hooks.ts
@@ -615,9 +615,7 @@ export function useAccount<
   },
 ): {
   me: MaybeLoaded<Loaded<A, R>>;
-  logOut: () => void;
 } {
-  const contextManager = useJazzContextManager<InstanceOfSchema<A>>();
   const subscription = useAccountSubscription(AccountSchema, options);
   const getCurrentValue = useGetCurrentValue(subscription);
 
@@ -638,7 +636,6 @@ export function useAccount<
 
   return {
     me: value,
-    logOut: contextManager.logOut,
   };
 }
 

--- a/packages/jazz-tools/src/react-core/hooks.ts
+++ b/packages/jazz-tools/src/react-core/hooks.ts
@@ -233,7 +233,7 @@ function useGetCurrentValue<C extends CoValue>(
  *
  * function ProjectTitle({ projectId }: { projectId: string }) {
  *   // Only re-render when the project name changes, not other fields
- *   const projectName = useCoStateWithSelector(
+ *   const projectName = useCoState(
  *     Project,
  *     projectId,
  *     {
@@ -335,7 +335,7 @@ function useGetCurrentValue<C extends CoValue>(
  * const TaskList = co.list(Task);
  *
  * function TaskCount({ listId }: { listId: string }) {
- *   const taskStats = useCoStateWithSelector(
+ *   const taskStats = useCoState(
  *     TaskList,
  *     listId,
  *     {
@@ -422,8 +422,6 @@ export function useCoState<
 
   return value;
 }
-
-export const useCoStateWithSelector = useCoState;
 
 export function useSubscriptionSelector<
   S extends CoValueClassOrSchema,

--- a/packages/jazz-tools/src/react-core/hooks.ts
+++ b/packages/jazz-tools/src/react-core/hooks.ts
@@ -678,7 +678,7 @@ export function useAccount<
 }
 
 /**
- * Returns a function for logging out the current account.
+ * Returns a function for logging out of the current account.
  */
 export function useLogOut(): () => void {
   const contextManager = useJazzContextManager();

--- a/packages/jazz-tools/src/react-core/hooks.ts
+++ b/packages/jazz-tools/src/react-core/hooks.ts
@@ -541,7 +541,6 @@ export function useAccountSubscription<
  * @returns An object containing:
  * - `me`: The account data, or an {@link Unloaded} value. Use `$isLoaded` to check whether the
  * CoValue is loaded, or use {@link MaybeLoaded.$jazz.loadingState} to get the detailed loading state.
- * - `agent`: The current agent (anonymous or authenticated user). Can be used as `loadAs` parameter for load and subscribe methods.
  * - `logOut`: Function to log out the current user
 
  * @example
@@ -617,14 +616,11 @@ export function useAccount<
   },
 ): {
   me: MaybeLoaded<Loaded<A, R>>;
-  agent: AnonymousJazzAgent | Loaded<A, true>;
   logOut: () => void;
 } {
   const contextManager = useJazzContextManager<InstanceOfSchema<A>>();
   const subscription = useAccountSubscription(AccountSchema, options);
   const getCurrentValue = useGetCurrentValue(subscription);
-
-  const agent = getCurrentAccountFromContextManager(contextManager);
 
   const value = React.useSyncExternalStore<MaybeLoaded<Loaded<A, R>>>(
     React.useCallback(
@@ -643,7 +639,6 @@ export function useAccount<
 
   return {
     me: value,
-    agent,
     logOut: contextManager.logOut,
   };
 }
@@ -653,6 +648,8 @@ export function useAccount<
  * - an Authenticated Account, if the user is logged in
  * - an Anonymous Account, if the user didn't log in
  * - or an anonymous agent, if in guest mode
+ *
+ * The agent can be used as the `loadAs` parameter for load and subscribe methods.
  */
 export function useAgent<A extends AccountClass<Account> | AnyAccountSchema>(
   /** The account schema to use. Defaults to the base Account schema */

--- a/packages/jazz-tools/src/react-core/hooks.ts
+++ b/packages/jazz-tools/src/react-core/hooks.ts
@@ -649,6 +649,21 @@ export function useAccount<
 }
 
 /**
+ * React hook for accessing the current agent. An agent can either be:
+ * - an Authenticated Account, if the user is logged in
+ * - an Anonymous Account, if the user didn't log in
+ * - or an anonymous agent, if in guest mode
+ */
+export function useAgent<A extends AccountClass<Account> | AnyAccountSchema>(
+  /** The account schema to use. Defaults to the base Account schema */
+  AccountSchema: A = Account as unknown as A,
+): AnonymousJazzAgent | Loaded<A, true> {
+  const contextManager = useJazzContextManager<InstanceOfSchema<A>>();
+  const agent = getCurrentAccountFromContextManager(contextManager);
+  return agent;
+}
+
+/**
  * React hook for accessing the current user's account with selective data extraction and custom equality checking.
  *
  * This hook extends `useAccount` by allowing you to select only specific parts of the account data

--- a/packages/jazz-tools/src/react-core/hooks.ts
+++ b/packages/jazz-tools/src/react-core/hooks.ts
@@ -561,7 +561,7 @@ export function useAccountSubscription<
  *
  * function UserProfile({ accountId }: { accountId: string }) {
  *   // Only re-render when the profile name changes, not other fields
- *   const profileName = useAccountWithSelector(
+ *   const profileName = useAccount(
  *     MyAppAccount,
  *     {
  *       resolve: {
@@ -701,8 +701,6 @@ export function useAgent<A extends AccountClass<Account> | AnyAccountSchema>(
   const agent = getCurrentAccountFromContextManager(contextManager);
   return agent;
 }
-
-export const useAccountWithSelector = useAccount;
 
 export function experimental_useInboxSender<
   I extends CoValue,

--- a/packages/jazz-tools/src/react-core/tests/subscription.bench.tsx
+++ b/packages/jazz-tools/src/react-core/tests/subscription.bench.tsx
@@ -6,7 +6,7 @@ import { describe, bench } from "vitest";
 import {
   useAccountSubscription,
   useSubscriptionSelector,
-  useAccountWithSelector,
+  useAccount,
   CoValueSubscription,
 } from "../index.js";
 import { createJazzTestAccount, setupJazzTestSync } from "../testing.js";
@@ -23,7 +23,7 @@ await createJazzTestAccount({
 const AccountSchema = co.account();
 
 const AccountName = () => {
-  const name = useAccountWithSelector(AccountSchema, {
+  const name = useAccount(AccountSchema, {
     resolve: {
       profile: true,
     },
@@ -279,7 +279,7 @@ describe("deeply resolved coMaps", async () => {
   }: {
     taskListType: "tasks" | "draftTasks" | "deletedTasks";
   }) => {
-    const subscription = useAccountWithSelector(AccountSchema, {
+    const subscription = useAccount(AccountSchema, {
       resolve: {
         root: {
           organizations: {

--- a/packages/jazz-tools/src/react-core/tests/useAccount.test.ts
+++ b/packages/jazz-tools/src/react-core/tests/useAccount.test.ts
@@ -3,7 +3,7 @@
 import { CoValueLoadingState, Group, RefsToResolve, co, z } from "jazz-tools";
 import { assertLoaded } from "jazz-tools/testing";
 import { assert, beforeEach, describe, expect, it } from "vitest";
-import { useAccount, useJazzContextManager } from "../hooks.js";
+import { useAccount, useAgent, useJazzContextManager } from "../hooks.js";
 import { useIsAuthenticated } from "../index.js";
 import {
   createJazzTestAccount,
@@ -204,18 +204,21 @@ describe("useAccount", () => {
     const account = await createJazzTestGuest();
 
     const { result } = renderHook(
-      () =>
-        useAccount(AccountSchema, {
+      () => {
+        const { me } = useAccount(AccountSchema, {
           resolve: {
             root: true,
           },
-        }),
+        });
+        const agent = useAgent();
+        return { account: me, agent };
+      },
       {
         account,
       },
     );
 
-    expect(result.current.me.$jazz.loadingState).toBe(
+    expect(result.current.account.$jazz.loadingState).toBe(
       CoValueLoadingState.UNAVAILABLE,
     );
     expect(result.current.agent).toBe(account.guest);

--- a/packages/jazz-tools/src/react-core/tests/useAccountWithSelector.test.ts
+++ b/packages/jazz-tools/src/react-core/tests/useAccountWithSelector.test.ts
@@ -2,7 +2,7 @@
 
 import { Account, RefsToResolve, co, z, Group } from "jazz-tools";
 import { assert, beforeEach, describe, expect, it } from "vitest";
-import { useAccountWithSelector, useJazzContextManager } from "../hooks.js";
+import { useAccount, useJazzContextManager } from "../hooks.js";
 import { useIsAuthenticated } from "../index.js";
 import {
   createJazzTestAccount,
@@ -26,7 +26,7 @@ const useRenderCount = <T>(hook: () => T) => {
   };
 };
 
-describe("useAccountWithSelector", () => {
+describe("useAccount", () => {
   it("should return the correct selected value", async () => {
     const AccountRoot = co.map({
       value: z.string(),
@@ -49,7 +49,7 @@ describe("useAccountWithSelector", () => {
 
     const { result } = renderHook(
       () =>
-        useAccountWithSelector(AccountSchema, {
+        useAccount(AccountSchema, {
           resolve: {
             root: true,
           },
@@ -103,7 +103,7 @@ describe("useAccountWithSelector", () => {
 
     const { result } = renderHook(
       () =>
-        useAccountWithSelector(AccountSchema, {
+        useAccount(AccountSchema, {
           resolve: {
             root: {
               nested: true,
@@ -164,7 +164,7 @@ describe("useAccountWithSelector", () => {
     const { result } = renderHook(
       () =>
         useRenderCount(() =>
-          useAccountWithSelector(AccountSchema, {
+          useAccount(AccountSchema, {
             resolve: {
               root: {
                 nested: true,
@@ -233,7 +233,7 @@ describe("useAccountWithSelector", () => {
     const { result } = renderHook(
       () =>
         useRenderCount(() =>
-          useAccountWithSelector(AccountSchema, {
+          useAccount(AccountSchema, {
             resolve: {
               root: {
                 nested: true,
@@ -302,7 +302,7 @@ describe("useAccountWithSelector", () => {
     const { result } = renderHook(
       () =>
         useRenderCount(() =>
-          useAccountWithSelector(AccountSchema, {
+          useAccount(AccountSchema, {
             resolve: {
               root: {
                 nested: true,
@@ -352,7 +352,7 @@ describe("useAccountWithSelector", () => {
 
     const { result } = renderHook(
       () =>
-        useAccountWithSelector(AccountSchema, {
+        useAccount(AccountSchema, {
           resolve: {
             root: true,
           },
@@ -376,7 +376,7 @@ describe("useAccountWithSelector", () => {
 
     const { result } = renderHook(
       () =>
-        useAccountWithSelector(Account, {
+        useAccount(Account, {
           select: (account) => {
             if (!account.$isLoaded) {
               return "No account";
@@ -417,7 +417,7 @@ describe("useAccountWithSelector", () => {
     const { result, rerender } = renderHook(
       () =>
         useRenderCount(() =>
-          useAccountWithSelector(AccountSchema, {
+          useAccount(AccountSchema, {
             resolve: {
               root: true,
             },
@@ -478,7 +478,7 @@ describe("useAccountWithSelector", () => {
     group.addMember("everyone", "writer");
     const { result } = renderHook(
       () => {
-        const branchAccountRoot = useAccountWithSelector(AccountSchema, {
+        const branchAccountRoot = useAccount(AccountSchema, {
           resolve: {
             root: true,
           },
@@ -491,7 +491,7 @@ describe("useAccountWithSelector", () => {
           unstable_branch: { name: "feature-branch" },
         });
 
-        const mainAccountRoot = useAccountWithSelector(AccountSchema, {
+        const mainAccountRoot = useAccount(AccountSchema, {
           resolve: {
             root: true,
           },

--- a/packages/jazz-tools/src/react-core/tests/useCoState.selector.test.ts
+++ b/packages/jazz-tools/src/react-core/tests/useCoState.selector.test.ts
@@ -3,7 +3,7 @@
 import { cojsonInternals } from "cojson";
 import { Account, co, Loaded, z } from "jazz-tools";
 import { beforeEach, describe, expect, expectTypeOf, it } from "vitest";
-import { useCoStateWithSelector } from "../index.js";
+import { useCoState } from "../index.js";
 import { createJazzTestAccount, setupJazzTestSync } from "../testing.js";
 import { renderHook, waitFor } from "./testUtils.js";
 import { useRef } from "react";
@@ -28,7 +28,7 @@ const useRenderCount = <T>(hook: () => T) => {
   };
 };
 
-describe("useCoStateWithSelector", () => {
+describe("useCoState", () => {
   it("should not re-render when a nested coValue is updated and not selected", async () => {
     const TestMap = co.map({
       value: z.string(),
@@ -46,7 +46,7 @@ describe("useCoStateWithSelector", () => {
 
     const { result } = renderHook(() =>
       useRenderCount(() =>
-        useCoStateWithSelector(TestMap, map.$jazz.id, {
+        useCoState(TestMap, map.$jazz.id, {
           resolve: {
             nested: true,
           },
@@ -90,7 +90,7 @@ describe("useCoStateWithSelector", () => {
 
     const { result } = renderHook(() =>
       useRenderCount(() =>
-        useCoStateWithSelector(TestMap, map.$jazz.id, {
+        useCoState(TestMap, map.$jazz.id, {
           resolve: {
             nested: true,
           },
@@ -138,7 +138,7 @@ describe("useCoStateWithSelector", () => {
 
     const { result } = renderHook(() =>
       useRenderCount(() =>
-        useCoStateWithSelector(TestMap, map.$jazz.id, {
+        useCoState(TestMap, map.$jazz.id, {
           resolve: {
             nested: true,
           },

--- a/packages/jazz-tools/src/react-core/tests/usePassPhraseAuth.test.ts
+++ b/packages/jazz-tools/src/react-core/tests/usePassPhraseAuth.test.ts
@@ -4,7 +4,7 @@ import { mnemonicToEntropy } from "@scure/bip39";
 import { AuthSecretStorage, KvStoreContext } from "jazz-tools";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { usePassphraseAuth } from "../auth/PassphraseAuth";
-import { useAccount } from "../hooks";
+import { useAccount, useLogOut } from "../hooks";
 import {
   createJazzTestAccount,
   createJazzTestGuest,
@@ -116,20 +116,21 @@ describe("usePassphraseAuth", () => {
     const { result } = renderHook(
       () => {
         const passphraseAuth = usePassphraseAuth({ wordlist: testWordlist });
-        const account = useAccount();
+        const me = useAccount();
+        const logOut = useLogOut();
 
-        if (account.me) {
-          if (!accounts.includes(account.me.$jazz.id)) {
-            accounts.push(account.me.$jazz.id);
+        if (me) {
+          if (!accounts.includes(me.$jazz.id)) {
+            accounts.push(me.$jazz.id);
           }
 
           updates.push({
             state: passphraseAuth.state,
-            accountIndex: accounts.indexOf(account.me.$jazz.id),
+            accountIndex: accounts.indexOf(me.$jazz.id),
           });
         }
 
-        return { passphraseAuth, account };
+        return { passphraseAuth, me, logOut };
       },
       {
         account,
@@ -138,23 +139,23 @@ describe("usePassphraseAuth", () => {
     );
 
     expect(result.current?.passphraseAuth.state).toBe("anonymous");
-    expect(result.current?.account?.me).toBeDefined();
+    expect(result.current?.me).toBeDefined();
 
-    const id = result.current?.account?.me?.$jazz.id;
+    const id = result.current?.me?.$jazz.id;
 
     await act(async () => {
       await result.current?.passphraseAuth.signUp();
     });
 
     expect(result.current?.passphraseAuth.state).toBe("signedIn");
-    expect(result.current?.account?.me?.$jazz.id).toBe(id);
+    expect(result.current?.me?.$jazz.id).toBe(id);
 
     await act(async () => {
-      await result.current?.account?.logOut();
+      await result.current?.logOut();
     });
 
     expect(result.current?.passphraseAuth.state).toBe("anonymous");
-    expect(result.current?.account?.me?.$jazz.id).not.toBe(id);
+    expect(result.current?.me?.$jazz.id).not.toBe(id);
 
     expect(updates).toMatchInlineSnapshot(`
       [

--- a/packages/jazz-tools/src/react-native-core/hooks.tsx
+++ b/packages/jazz-tools/src/react-native-core/hooks.tsx
@@ -15,6 +15,7 @@ export {
   useAccount,
   useAccountWithSelector,
   useAgent,
+  useLogOut,
   useSyncConnectionStatus,
   useCoValueSubscription,
   useAccountSubscription,

--- a/packages/jazz-tools/src/react-native-core/hooks.tsx
+++ b/packages/jazz-tools/src/react-native-core/hooks.tsx
@@ -14,6 +14,7 @@ export {
   useIsAuthenticated,
   useAccount,
   useAccountWithSelector,
+  useAgent,
   useSyncConnectionStatus,
   useCoValueSubscription,
   useAccountSubscription,

--- a/packages/jazz-tools/src/react-native-core/hooks.tsx
+++ b/packages/jazz-tools/src/react-native-core/hooks.tsx
@@ -13,7 +13,6 @@ export {
   useAuthSecretStorage,
   useIsAuthenticated,
   useAccount,
-  useCoStateWithSelector,
   useAccountWithSelector,
   useSyncConnectionStatus,
   useCoValueSubscription,

--- a/packages/jazz-tools/src/react-native-core/hooks.tsx
+++ b/packages/jazz-tools/src/react-native-core/hooks.tsx
@@ -13,7 +13,6 @@ export {
   useAuthSecretStorage,
   useIsAuthenticated,
   useAccount,
-  useAccountWithSelector,
   useAgent,
   useLogOut,
   useSyncConnectionStatus,

--- a/packages/jazz-tools/src/react-native-core/media/image.tsx
+++ b/packages/jazz-tools/src/react-native-core/media/image.tsx
@@ -2,7 +2,7 @@ import { FileStream, ImageDefinition } from "jazz-tools";
 import { highestResAvailable } from "jazz-tools/media";
 import { forwardRef, useEffect, useMemo, useState } from "react";
 import { Image as RNImage, ImageProps as RNImageProps } from "react-native";
-import { useCoStateWithSelector } from "../hooks.js";
+import { useCoState } from "../hooks.js";
 
 export type ImageProps = Omit<RNImageProps, "width" | "height" | "source"> & {
   /** The ID of the ImageDefinition to display */
@@ -68,7 +68,7 @@ export const Image = forwardRef<RNImage, ImageProps>(function Image(
   { imageId, width, height, ...props },
   ref,
 ) {
-  const image = useCoStateWithSelector(ImageDefinition, imageId, {
+  const image = useCoState(ImageDefinition, imageId, {
     select: (image) => (image.$isLoaded ? image : null),
   });
   const [src, setSrc] = useState<string | undefined>(

--- a/packages/jazz-tools/src/react/hooks.tsx
+++ b/packages/jazz-tools/src/react/hooks.tsx
@@ -50,7 +50,6 @@ export {
   experimental_useInboxSender,
   useJazzContext,
   useAccount,
-  useAccountWithSelector,
   useAgent,
   useLogOut,
   useSyncConnectionStatus,

--- a/packages/jazz-tools/src/react/hooks.tsx
+++ b/packages/jazz-tools/src/react/hooks.tsx
@@ -50,7 +50,6 @@ export {
   experimental_useInboxSender,
   useJazzContext,
   useAccount,
-  useCoStateWithSelector,
   useAccountWithSelector,
   useSyncConnectionStatus,
   useCoValueSubscription,

--- a/packages/jazz-tools/src/react/hooks.tsx
+++ b/packages/jazz-tools/src/react/hooks.tsx
@@ -51,6 +51,7 @@ export {
   useJazzContext,
   useAccount,
   useAccountWithSelector,
+  useAgent,
   useSyncConnectionStatus,
   useCoValueSubscription,
   useAccountSubscription,

--- a/packages/jazz-tools/src/react/hooks.tsx
+++ b/packages/jazz-tools/src/react/hooks.tsx
@@ -52,6 +52,7 @@ export {
   useAccount,
   useAccountWithSelector,
   useAgent,
+  useLogOut,
   useSyncConnectionStatus,
   useCoValueSubscription,
   useAccountSubscription,

--- a/packages/jazz-tools/src/react/index.ts
+++ b/packages/jazz-tools/src/react/index.ts
@@ -7,7 +7,6 @@ export {
   experimental_useInboxSender,
   useJazzContext,
   useAuthSecretStorage,
-  useAccountWithSelector,
   useAgent,
   useLogOut,
   useSyncConnectionStatus,

--- a/packages/jazz-tools/src/react/index.ts
+++ b/packages/jazz-tools/src/react/index.ts
@@ -7,7 +7,6 @@ export {
   experimental_useInboxSender,
   useJazzContext,
   useAuthSecretStorage,
-  useCoStateWithSelector,
   useAccountWithSelector,
   useSyncConnectionStatus,
   useCoValueSubscription,

--- a/packages/jazz-tools/src/react/index.ts
+++ b/packages/jazz-tools/src/react/index.ts
@@ -9,6 +9,7 @@ export {
   useAuthSecretStorage,
   useAccountWithSelector,
   useAgent,
+  useLogOut,
   useSyncConnectionStatus,
   useCoValueSubscription,
   useAccountSubscription,

--- a/packages/jazz-tools/src/react/index.ts
+++ b/packages/jazz-tools/src/react/index.ts
@@ -8,6 +8,7 @@ export {
   useJazzContext,
   useAuthSecretStorage,
   useAccountWithSelector,
+  useAgent,
   useSyncConnectionStatus,
   useCoValueSubscription,
   useAccountSubscription,

--- a/packages/jazz-tools/src/react/media/image.tsx
+++ b/packages/jazz-tools/src/react/media/image.tsx
@@ -9,7 +9,7 @@ import {
   useState,
 } from "react";
 import { highestResAvailable } from "../../media/index.js";
-import { useCoStateWithSelector } from "../hooks.js";
+import { useCoState } from "../hooks.js";
 import e from "cors";
 
 export type ImageProps = Omit<
@@ -79,7 +79,7 @@ export const Image = forwardRef<HTMLImageElement, ImageProps>(function Image(
   { imageId, width, height, ...props },
   ref,
 ) {
-  const image = useCoStateWithSelector(ImageDefinition, imageId, {
+  const image = useCoState(ImageDefinition, imageId, {
     select: (image) => {
       if (image.$isLoaded) {
         return image;

--- a/packages/jazz-tools/src/tools/coValues/deepLoading.ts
+++ b/packages/jazz-tools/src/tools/coValues/deepLoading.ts
@@ -41,9 +41,9 @@ export type Unloaded<T> = {
 /**
  * Narrows a maybe-loaded, optional CoValue to a loaded and required CoValue.
  */
-export type LoadedAndRequired<T> = Exclude<T, undefined> & {
-  $isLoaded: true;
-};
+export type LoadedAndRequired<T> = T extends { $isLoaded: true }
+  ? Exclude<T, undefined>
+  : Exclude<T, undefined> & { $isLoaded: true };
 
 /**
  * Narrows a maybe-loaded, optional CoValue to a loaded and optional CoValue

--- a/packages/jazz-tools/src/tools/tests/deepLoading.test.ts
+++ b/packages/jazz-tools/src/tools/tests/deepLoading.test.ts
@@ -1129,7 +1129,9 @@ test("should not throw when calling ensureLoaded a record with a deleted ref", a
   unsub();
 });
 
-test("deep loaded CoList nested inside a CoMap can be iterated over", async () => {
+// This was a regression that ocurred when we migrated `DeeplyLoaded` to use explicit loading states.
+// Keeping this test to prevent it from happening again.
+test("deep loaded CoList nested inside another CoValue can be iterated over", async () => {
   const TestMap = co.map({ list: co.list(z.number()) });
 
   const me = await Account.create({
@@ -1153,7 +1155,7 @@ test("deep loaded CoList nested inside a CoMap can be iterated over", async () =
   // @ts-expect-error TODO: fix type inference
   // Adding an explicit type annotation with the SAME type that's being inferred
   // works, for some reason:
-  // const list: CoList<number> & { $isLoaded: true } = loadedMap.list;
+  // const list: CoList<number> = loadedMap.list;
   for (const item of list) {
     expect(item).toEqual(expectedValue);
     expectedValue++;

--- a/starters/react-passkey-auth/src/App.tsx
+++ b/starters/react-passkey-auth/src/App.tsx
@@ -5,7 +5,7 @@ import { Logo } from "./Logo.tsx";
 import { JazzAccount, getUserAge } from "./schema.ts";
 
 function App() {
-  const { me } = useAccount(JazzAccount, {
+  const me = useAccount(JazzAccount, {
     resolve: { profile: true, root: true },
   });
 

--- a/starters/react-passkey-auth/src/AuthButton.tsx
+++ b/starters/react-passkey-auth/src/AuthButton.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { useAccount, usePasskeyAuth } from "jazz-tools/react";
+import { usePasskeyAuth, useLogOut } from "jazz-tools/react";
 import { APPLICATION_NAME } from "./Main";
 
 export function AuthButton() {
-  const { logOut } = useAccount();
+  const logOut = useLogOut();
 
   const auth = usePasskeyAuth({
     appName: APPLICATION_NAME,

--- a/starters/react-passkey-auth/src/Form.tsx
+++ b/starters/react-passkey-auth/src/Form.tsx
@@ -2,7 +2,7 @@ import { useAccount } from "jazz-tools/react";
 import { JazzAccount } from "./schema";
 
 export function Form() {
-  const { me } = useAccount(JazzAccount, {
+  const me = useAccount(JazzAccount, {
     resolve: { profile: true, root: true },
   });
 

--- a/tests/browser-integration/src/logout.react.test.tsx
+++ b/tests/browser-integration/src/logout.react.test.tsx
@@ -26,7 +26,7 @@ const TestAccount = co
 
 // React component that uses Jazz hooks for testing logout behavior
 function TestLogoutComponent({ onLogout }: { onLogout?: () => void }) {
-  const { me } = useAccount(TestAccount, {
+  const me = useAccount(TestAccount, {
     resolve: {
       profile: true,
     },

--- a/tests/browser-integration/src/logout.react.test.tsx
+++ b/tests/browser-integration/src/logout.react.test.tsx
@@ -1,7 +1,12 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { commands } from "@vitest/browser/context";
 import { AuthSecretStorage, co, z } from "jazz-tools";
-import { JazzReactProvider, useAccount, useCoState } from "jazz-tools/react";
+import {
+  JazzReactProvider,
+  useAccount,
+  useCoState,
+  useLogOut,
+} from "jazz-tools/react";
 import { afterAll, afterEach, describe, expect, test } from "vitest";
 import { createAccountContext, startSyncServer } from "./testUtils";
 
@@ -21,11 +26,12 @@ const TestAccount = co
 
 // React component that uses Jazz hooks for testing logout behavior
 function TestLogoutComponent({ onLogout }: { onLogout?: () => void }) {
-  const { logOut, me } = useAccount(TestAccount, {
+  const { me } = useAccount(TestAccount, {
     resolve: {
       profile: true,
     },
   });
+  const logOut = useLogOut();
 
   const root = useCoState(
     TestAccount.shape.root,

--- a/tests/e2e/src/pages/ConcurrentChanges.tsx
+++ b/tests/e2e/src/pages/ConcurrentChanges.tsx
@@ -13,7 +13,7 @@ function getIdParam() {
 export function ConcurrentChanges() {
   const [id, setId] = useState(getIdParam);
   const counter = useCoState(Counter, id);
-  const { me } = useAccount();
+  const me = useAccount();
 
   useEffect(() => {
     if (id) {

--- a/tests/e2e/src/pages/FileStream/DownloaderPeer.tsx
+++ b/tests/e2e/src/pages/FileStream/DownloaderPeer.tsx
@@ -3,7 +3,7 @@ import { useAccount, useCoState } from "jazz-tools/react";
 import { useEffect, useState } from "react";
 import { UploadedFile } from "./schema";
 export function DownloaderPeer(props: { testCoMapId: string }) {
-  const { me } = useAccount();
+  const me = useAccount();
   const testCoMap = useCoState(UploadedFile, props.testCoMapId, {});
   const [synced, setSynced] = useState(false);
 

--- a/tests/e2e/src/pages/FileStream/DownloaderPeer.tsx
+++ b/tests/e2e/src/pages/FileStream/DownloaderPeer.tsx
@@ -3,12 +3,12 @@ import { useAccount, useCoState } from "jazz-tools/react";
 import { useEffect, useState } from "react";
 import { UploadedFile } from "./schema";
 export function DownloaderPeer(props: { testCoMapId: string }) {
-  const account = useAccount();
+  const { me } = useAccount();
   const testCoMap = useCoState(UploadedFile, props.testCoMapId, {});
   const [synced, setSynced] = useState(false);
 
   useEffect(() => {
-    if (!account.me.$isLoaded) {
+    if (!me.$isLoaded) {
       return;
     }
 
@@ -34,7 +34,7 @@ export function DownloaderPeer(props: { testCoMapId: string }) {
       uploadedFile.$jazz.set("syncCompleted", true);
     }
 
-    run(account.me, props.testCoMapId);
+    run(me, props.testCoMapId);
   }, []);
 
   return (

--- a/tests/e2e/src/pages/FileStream/UploaderPeer.tsx
+++ b/tests/e2e/src/pages/FileStream/UploaderPeer.tsx
@@ -9,7 +9,7 @@ import { getDownloaderPeerUrl } from "./lib/getDownloaderPeerUrl";
 import { getDefaultFileSize, getIsAutoUpload } from "./lib/searchParams";
 import { UploadedFile } from "./schema";
 export function UploaderPeer() {
-  const { me } = useAccount();
+  const me = useAccount();
   const [uploadedFileId, setUploadedFileId] = useState<string | undefined>(
     undefined,
   );

--- a/tests/e2e/src/pages/FileStream/UploaderPeer.tsx
+++ b/tests/e2e/src/pages/FileStream/UploaderPeer.tsx
@@ -9,7 +9,7 @@ import { getDownloaderPeerUrl } from "./lib/getDownloaderPeerUrl";
 import { getDefaultFileSize, getIsAutoUpload } from "./lib/searchParams";
 import { UploadedFile } from "./schema";
 export function UploaderPeer() {
-  const account = useAccount();
+  const { me } = useAccount();
   const [uploadedFileId, setUploadedFileId] = useState<string | undefined>(
     undefined,
   );
@@ -20,7 +20,7 @@ export function UploaderPeer() {
   const testFile = useCoState(UploadedFile, uploadedFileId, {});
 
   async function uploadTestFile() {
-    if (!account.me.$isLoaded) return;
+    if (!me.$isLoaded) return;
 
     setUploadedFileId(undefined);
     setSynced(false);
@@ -28,7 +28,7 @@ export function UploaderPeer() {
     // Mark the sync start
     performance.mark("sync-start");
 
-    const file = await generateTestFile(account.me, bytes);
+    const file = await generateTestFile(me, bytes);
 
     // Create a credential-less iframe to spawn the downloader peer
     const iframe = createCredentiallessIframe(getDownloaderPeerUrl(file));
@@ -37,7 +37,7 @@ export function UploaderPeer() {
     setSyncDuration(null);
     setUploadedFileId(file.$jazz.id);
 
-    account.me.$jazz.waitForAllCoValuesSync().then(() => {
+    me.$jazz.waitForAllCoValuesSync().then(() => {
       setSynced(true);
     });
 
@@ -47,7 +47,7 @@ export function UploaderPeer() {
       coValueClassFromCoValueClassOrSchema(UploadedFile),
       file.$jazz.id,
       (value) => value.syncCompleted,
-      { loadAs: account.me },
+      { loadAs: me },
     );
 
     iframe.remove();

--- a/tests/e2e/src/pages/Inbox.tsx
+++ b/tests/e2e/src/pages/Inbox.tsx
@@ -19,7 +19,7 @@ function getIdParam() {
 
 export function InboxPage() {
   const [id] = useState(getIdParam);
-  const { me } = useAccount();
+  const me = useAccount();
   const [pingPong, setPingPong] = useState<PingPong | null>(null);
   const iframeRef = useRef<HTMLIFrameElement>(null);
 

--- a/tests/e2e/src/pages/ResumeSyncState.tsx
+++ b/tests/e2e/src/pages/ResumeSyncState.tsx
@@ -14,7 +14,7 @@ function getIdParam() {
 export function ResumeSyncState() {
   const [id, setId] = useState(getIdParam);
   const coMap = useCoState(ResumeSyncCoMap, id);
-  const { me } = useAccount();
+  const me = useAccount();
 
   useEffect(() => {
     if (id) {

--- a/tests/e2e/src/pages/RetryUnavailable.tsx
+++ b/tests/e2e/src/pages/RetryUnavailable.tsx
@@ -14,7 +14,7 @@ function getIdParam() {
 export function RetryUnavailable() {
   const [id, setId] = useState(getIdParam);
   const coMap = useCoState(RetryUnavailableCoMap, id);
-  const { me } = useAccount();
+  const me = useAccount();
 
   useEffect(() => {
     if (id) {

--- a/tests/e2e/src/pages/Sharing.tsx
+++ b/tests/e2e/src/pages/Sharing.tsx
@@ -9,7 +9,7 @@ class SharedCoMap extends CoMap {
 }
 
 export function Sharing() {
-  const { me } = useAccount();
+  const me = useAccount();
   const [id, setId] = useState<ID<SharedCoMap> | undefined>(undefined);
   const [revealLevels, setRevealLevels] = useState(1);
   const [inviteLinks, setInviteLinks] = useState<Record<string, string>>({});

--- a/tests/e2e/src/pages/TestInput.tsx
+++ b/tests/e2e/src/pages/TestInput.tsx
@@ -9,7 +9,7 @@ export class InputTestCoMap extends CoMap {
 export function TestInput() {
   const [id, setId] = useState<ID<InputTestCoMap> | undefined>(undefined);
   const coMap = useCoState(InputTestCoMap, id);
-  const { me } = useAccount();
+  const me = useAccount();
 
   useEffect(() => {
     if (!me.$isLoaded || id) return;

--- a/tests/stress-test/src/2_main.tsx
+++ b/tests/stress-test/src/2_main.tsx
@@ -46,7 +46,7 @@ function App() {
     },
   ]);
 
-  const { me } = useAccount(TodoAccount, {
+  const me = useAccount(TodoAccount, {
     resolve: { root: true },
   });
 
@@ -56,7 +56,7 @@ function App() {
 }
 
 function HomeScreen() {
-  const { me } = useAccount(TodoAccount, {
+  const me = useAccount(TodoAccount, {
     resolve: { root: { projects: { $each: { $onError: "catch" } } } },
   });
 

--- a/tests/stress-test/src/ProjectScreen.tsx
+++ b/tests/stress-test/src/ProjectScreen.tsx
@@ -14,7 +14,7 @@ export function ProjectScreen() {
       },
     },
   });
-  const { me } = useAccount(TodoAccount, {
+  const me = useAccount(TodoAccount, {
     resolve: {
       root: true,
     },


### PR DESCRIPTION
# Description

Splits the `useAccount` hook into three separate hooks _*_:
- `useAccount`: now only returns an Account CoValue
- `useLogOut`: returns a function for logging out of the current account
- `useAgent`: returns the current agent

It also adds a `select` option (and an optional `equalityFn`) to `useAccount` and `useCoState`, and removes `useAccountWithSelector` and `useCoStateWithSelector`_**_.

_*_ This change is applied both in the React and Vue bindings.
_**_ This change is applied only in React, as Vue bindings do not support selector functions.

## Discussion

I thought of splitting Svelte's [AccountCoState](https://github.com/garden-co/jazz/blob/feat/merge-useCoState-useCoStateWithSelector/packages/jazz-tools/src/svelte/jazz.class.svelte.ts#L142) class, but saw almost no benefit in doing so (apart from aligning the React & Svelte APIs more closely), so I ended up keeping it as is. If you think we should also make the split for Svelte, let me know.

## Tests

- [x] Tests have been added and/or updated