### PR TITLE
feat: add `useLogout` hook

### DIFF
--- a/.changeset/goofy-news-grow.md
+++ b/.changeset/goofy-news-grow.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Add `useLogOut` hook

--- a/packages/jazz-tools/src/react-core/hooks.ts
+++ b/packages/jazz-tools/src/react-core/hooks.ts
@@ -792,6 +792,14 @@ export function useAccountWithSelector<
   );
 }
 
+/**
+ * Returns a function for logging out of the current account.
+ */
+export function useLogOut(): () => void {
+  const contextManager = useJazzContextManager();
+  return contextManager.logOut;
+}
+
 export function experimental_useInboxSender<
   I extends CoValue,
   O extends CoValue | undefined,


### PR DESCRIPTION
# Description

Backports the `useLogout` hook introduced in https://github.com/garden-co/jazz/pull/3068 into jazz-tools 0.18. 

For now it's just an alternative to `useAccount.logOut`. The latter will be removed in jazz-tools 0.19.

## Tests

- [x] Tests have been added and/or updated

## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [x] I've generated a changeset, if a version bump is required
- [x] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing