### PR TITLE
fix inspector render in Svelte - GCO-930

### DIFF
--- a/.changeset/nice-files-like.md
+++ b/.changeset/nice-files-like.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+fix inspector component in non-React apps

--- a/packages/jazz-tools/package.json
+++ b/packages/jazz-tools/package.json
@@ -198,7 +198,7 @@
     "cojson-storage-indexeddb": "workspace:*",
     "cojson-transport-ws": "workspace:*",
     "fast-myers-diff": "^3.2.0",
-    "goober": "^2.1.16",
+    "goober": "^2.1.18",
     "prosemirror-example-setup": "^1.2.2",
     "prosemirror-menu": "^1.2.4",
     "prosemirror-model": "^1.21.1",

--- a/packages/jazz-tools/src/inspector/custom-element.tsx
+++ b/packages/jazz-tools/src/inspector/custom-element.tsx
@@ -1,6 +1,10 @@
+import React from "react";
+import { setup } from "goober";
 import { Account } from "jazz-tools";
 import { createRoot } from "react-dom/client";
 import { JazzInspectorInternal } from "./viewer/new-app.js";
+
+setup(React.createElement);
 
 export class JazzInspectorElement extends HTMLElement {
   private root: ReturnType<typeof createRoot> | null = null;

--- a/packages/jazz-tools/src/inspector/index.tsx
+++ b/packages/jazz-tools/src/inspector/index.tsx
@@ -1,3 +1,5 @@
+import React from "react";
+
 export { JazzInspectorInternal } from "./viewer/new-app.js";
 export { PageStack } from "./viewer/page-stack.js";
 export { Breadcrumbs } from "./viewer/breadcrumbs.js";
@@ -16,6 +18,7 @@ export {
 
 export type { PageInfo } from "./viewer/types.js";
 
+import { setup } from "goober";
 import { useJazzContext } from "jazz-tools/react-core";
 import { Account } from "jazz-tools";
 
@@ -35,3 +38,5 @@ export function JazzInspector({ position = "right" }: { position?: Position }) {
     />
   );
 }
+
+setup(React.createElement);

--- a/packages/jazz-tools/src/inspector/index.tsx
+++ b/packages/jazz-tools/src/inspector/index.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 export { JazzInspectorInternal } from "./viewer/new-app.js";
 export { PageStack } from "./viewer/page-stack.js";
 export { Breadcrumbs } from "./viewer/breadcrumbs.js";
@@ -18,7 +16,6 @@ export {
 
 export type { PageInfo } from "./viewer/types.js";
 
-import { setup } from "goober";
 import { useJazzContext } from "jazz-tools/react-core";
 import { Account } from "jazz-tools";
 
@@ -30,8 +27,6 @@ export function JazzInspector({ position = "right" }: { position?: Position }) {
   const localNode = context.node;
   const me = "me" in context ? context.me : undefined;
 
-  if (process.env.NODE_ENV !== "development") return null;
-
   return (
     <JazzInspectorInternal
       position={position}
@@ -40,5 +35,3 @@ export function JazzInspector({ position = "right" }: { position?: Position }) {
     />
   );
 }
-
-setup(React.createElement);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2305,8 +2305,8 @@ importers:
         specifier: ^3.2.0
         version: 3.2.0
       goober:
-        specifier: ^2.1.16
-        version: 2.1.16(csstype@3.1.3)
+        specifier: ^2.1.18
+        version: 2.1.18(csstype@3.1.3)
       prosemirror-example-setup:
         specifier: ^1.2.2
         version: 1.2.3
@@ -11828,8 +11828,8 @@ packages:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
     engines: {node: '>=10'}
 
-  goober@2.1.16:
-    resolution: {integrity: sha512-erjk19y1U33+XAMe1VTvIONHYoSqE4iS7BYUZfHaqeohLmnC0FdxEh7rQU+6MZ4OajItzjZFSRtVANrQwNq6/g==}
+  goober@2.1.18:
+    resolution: {integrity: sha512-2vFqsaDVIT9Gz7N6kAL++pLpp41l3PfDuusHcjnGLfR6+huZkl6ziX+zgVC3ZxpqWhzH6pyDdGrCeDhMIvwaxw==}
     peerDependencies:
       csstype: ^3.0.10
 
@@ -24532,7 +24532,7 @@ snapshots:
     dependencies:
       '@tanstack/router-core': 1.129.4
       clsx: 2.1.1
-      goober: 2.1.16(csstype@3.1.3)
+      goober: 2.1.18(csstype@3.1.3)
       solid-js: 1.9.5
       tiny-invariant: 1.3.3
     optionalDependencies:
@@ -28708,7 +28708,7 @@ snapshots:
       merge2: 1.4.1
       slash: 3.0.0
 
-  goober@2.1.16(csstype@3.1.3):
+  goober@2.1.18(csstype@3.1.3):
     dependencies:
       csstype: 3.1.3
 


### PR DESCRIPTION
# Description
`gobber` lib failed in non-react environments, like our Svelte examples.

The previous call of `setup` was invoked too late.

## Manual testing instructions

Run the Svelte example.