### PR TITLE
feat: allow injecting a custom meter for usage metering

### DIFF
--- a/.changeset/tidy-beans-reply.md
+++ b/.changeset/tidy-beans-reply.md
@@ -1,0 +1,5 @@
+---
+"cojson-transport-ws": patch
+---
+
+Allow providing a custom meter for usage tracking

--- a/packages/cojson-transport-ws/src/createWebSocketPeer.ts
+++ b/packages/cojson-transport-ws/src/createWebSocketPeer.ts
@@ -73,8 +73,8 @@ export function createWebSocketPeer({
   meter,
   meta,
 }: CreateWebSocketPeerOpts): Peer {
-  const totalIngressBytesCounter = (
-    meter ?? metrics.getMeter("default")
+  const ingressBytesCounter = (
+    meter ?? metrics.getMeter("cojson-transport-ws")
   ).createCounter("jazz.usage.ingress", {
     description: "Total ingress bytes from peer",
     unit: "bytes",
@@ -82,7 +82,7 @@ export function createWebSocketPeer({
   });
 
   // Initialize the counter by adding 0
-  totalIngressBytesCounter.add(0, meta);
+  ingressBytesCounter.add(0, meta);
 
   const incoming = new ConnectedPeerChannel();
   const emitClosedEvent = createClosedEventEmitter(onClose);
@@ -158,7 +158,7 @@ export function createWebSocketPeer({
         incoming.push(msg);
 
         if (msg.action === "content") {
-          totalIngressBytesCounter.add(getContentMessageSize(msg), meta);
+          ingressBytesCounter.add(getContentMessageSize(msg), meta);
         }
       }
     }

--- a/packages/cojson/src/coValueCore/SessionMap.ts
+++ b/packages/cojson/src/coValueCore/SessionMap.ts
@@ -35,7 +35,7 @@ export class SessionMap {
   sessions: Map<SessionID, SessionLog> = new Map();
 
   // Known state related properies, mutated when adding transactions to the session map
-  knownState: CoValueKnownState = { id: this.id, header: true, sessions: {} };
+  knownState: CoValueKnownState;
   knownStateWithStreaming: CoValueKnownState | undefined;
   streamingKnownState?: KnownStateSessions;
 
@@ -44,6 +44,7 @@ export class SessionMap {
     private readonly crypto: CryptoProvider,
     streamingKnownState?: KnownStateSessions,
   ) {
+    this.knownState = { id: this.id, header: true, sessions: {} };
     if (streamingKnownState) {
       this.streamingKnownState = { ...streamingKnownState };
       this.knownStateWithStreaming = {


### PR DESCRIPTION
Allows injection of a custom meter to `createWebsocketPeer` and `BatchedOutgoingMessages`. If no custom meter is provided a default one is retrieved.

[Fixes GCO-952
](https://linear.app/garden-co/issue/GCO-952/cojson-transport-ws-accept-a-custom-meter-when-dealing-with-usage)