### PR TITLE
feat: jazz-tools 0.19 codemod 

### DIFF
--- a/.changeset/fruity-monkeys-wear.md
+++ b/.changeset/fruity-monkeys-wear.md
@@ -20,3 +20,4 @@ Add explicit CoValue loading states:
   - `useLogOut`: returns a function for logging out of the current account
   - `useAgent`: returns the current agent
 - Add a `select` option (and an optional `equalityFn`) to `useAccount` and `useCoState`, and remove `useAccountWithSelector` and `useCoStateWithSelector`.
+- Allow specifying resolve queries at the schema level. Those queries will be used when loading CoValues, if no other resolve query is provided.

--- a/homepage/homepage/content/docs/core-concepts/subscription-and-loading.mdx
+++ b/homepage/homepage/content/docs/core-concepts/subscription-and-loading.mdx
@@ -303,6 +303,27 @@ const projectWithTasksShallow = useCoState(Project, projectId, {
 </TabbedCodeGroupItem>
 </TabbedCodeGroup>
 
+You can also specify resolve queries at the schema level, using the `.resolved()` method. These queries will be used when loading CoValues from that schema (if no resolve query is provided by the user) and in types defined with [co.loaded](/docs/core-concepts/subscription-and-loading#type-safety-with-coloaded).
+<CodeGroup>
+```ts
+const TaskWithDescription = Task.resolved({
+  description: true,
+});
+const ProjectWithTasks = Project.resolved({
+  tasks: {
+    // Use `.resolve` to get the resolve query from a schema and compose it in other queries
+    $each: TaskWithDescription.resolve,
+  }
+});
+
+// .load() will use the resolve query from the schema
+const project = await ProjectWithTasks.load(projectId);
+if (!project.$isLoaded) throw new Error("Project not found or not accessible");
+// Both the tasks and the descriptions are loaded
+project.tasks[0].description; // CoPlainText
+```
+</CodeGroup>
+
 ## Loading Errors
 
 A load operation will be successful **only** if all references requested (both optional and required) could be successfully loaded. If any reference cannot be loaded, the entire load operation will return a not-loaded CoValue to avoid potential inconsistencies.

--- a/homepage/homepage/content/docs/docNavigationItems.js
+++ b/homepage/homepage/content/docs/docNavigationItems.js
@@ -44,6 +44,11 @@ export const docNavigationItems = [
     prefix: "/docs/upgrade",
     items: [
       {
+        name: "0.19.0 - Explicit loading states",
+        href: "/docs/upgrade/0-19-0",
+        done: 100,
+      },
+      {
         name: "0.18.0 - New `$jazz` field in CoValues",
         href: "/docs/upgrade/0-18-0",
         done: 100,

--- a/homepage/homepage/content/docs/reference/testing.mdx
+++ b/homepage/homepage/content/docs/reference/testing.mdx
@@ -102,7 +102,7 @@ You can use this to test your app with multiple accounts.
 <CodeGroup preferWrap>
 ```ts twoslash
 import { co, z } from 'jazz-tools';
-import { createJazzTestAccount, setActiveAccount } from 'jazz-tools/testing';
+import { assertLoaded, createJazzTestAccount, setActiveAccount } from 'jazz-tools/testing';
 const MyMap = co.map({
   text: z.string()
 })
@@ -134,9 +134,10 @@ setActiveAccount(account2);
 // myMap is still loaded as account1, so we need to load again as account2
 const myMapFromAccount2 = await MyMap.load(myMapId);
 
-expect(myMapFromAccount2?.text)
+assertLoaded(myMapFromAccount2);
+expect(myMapFromAccount2.text)
   .toBe('Created by account1');
-expect(() => myMapFromAccount2?.$jazz.set('text', 'Updated by account2'))
+expect(() => myMapFromAccount2.$jazz.set('text', 'Updated by account2'))
   .toThrow();
 ```
 </CodeGroup>

--- a/homepage/homepage/content/docs/upgrade/0-19-0.mdx
+++ b/homepage/homepage/content/docs/upgrade/0-19-0.mdx
@@ -182,6 +182,8 @@ The goal of this codemod is to get you through 80% of the work quickly. After ru
 
 Note that some edge cases may be migrated incorrectly, and some code patterns (e.g. optional chaining) may not be detected by the codemod.
 
+We've found AI coding assistants like Cursor to be effective at fixing remaining issues.
+
 ## Known Issue: TypeScript Iterator Bug
 
 While introducing explicit loading states, we discovered [a TypeScript bug](https://github.com/microsoft/TypeScript/issues/62462) that prevents iterating over CoLists using methods that require an iterator, when these CoLists are loaded inside other CoValues (CoMaps, other CoLists, or CoFeeds).

--- a/homepage/homepage/content/docs/upgrade/0-19-0.mdx
+++ b/homepage/homepage/content/docs/upgrade/0-19-0.mdx
@@ -186,6 +186,7 @@ While introducing explicit loading states, we discovered [a TypeScript bug](http
 
 We've submitted [a fix](https://github.com/microsoft/TypeScript/pull/62661) for this bug. Until it's released, use one of the following workarounds if you encounter this issue:
 
+<CodeGroup>
 ```ts
 const Pet = co.map({
   name: z.string(),
@@ -209,5 +210,6 @@ person.pets.forEach(pet => { // [!code ++]
 } // [!code --]
 }); // [!code ++]
 ```
+</CodeGroup>
 
 Alternatively, you can suppress the TypeScript error by adding a `@ts-expect-error` comment, since this is purely a type-level issue.

--- a/homepage/homepage/content/docs/upgrade/0-19-0.mdx
+++ b/homepage/homepage/content/docs/upgrade/0-19-0.mdx
@@ -1,0 +1,213 @@
+import { Alert, CodeGroup } from '@/components/forMdx'
+
+# Jazz 0.19.0 - Explicit CoValue loading states
+
+This release introduces explicit loading states when loading CoValues.
+
+## Motivation
+
+Previously, APIs that loaded CoValues returned `undefined` to represent values that were still loading, and `null` for values that couldn't be loaded due to authorization or network errors.
+
+This approach had several problems:
+- **Lack of diagnostic information**: It's difficult to distinguish between different failure modes (authorization error vs. network error).
+- **Ambiguous nullable values**: It's easy to confuse unset CoValue properties with not-loaded CoValues, since both are represented as nullable values.
+- **Implicit error handling**: Unloaded values are typically handled with null-checks or optional chaining, which conflate multiple distinct states into a single code path. This often causes unexpected behavior when apps are deployed and used collaboratively.
+
+In this release, we're introducing a new way to represent loading states:
+<CodeGroup>
+```ts
+// APIs that load a CoValue now return a "maybe loaded" CoValue:
+type MaybeLoaded<C extends CoValue> = CoValue | NotLoaded<CoValue>;
+
+type NotLoaded<C extends CoValue> = { 
+  $isLoaded: false;
+  $jazz: {    
+    id: ID<C>;  
+    loadingState: "loading" | "unauthorized" | "unavailable";  
+  };
+};
+
+type CoValue = {
+  $isLoaded: true;
+  $jazz: {
+    id: ID<CoValue>;
+    loadingState: "loaded";
+  } & CoValueAPI<CoValue>; // the whole `$jazz` API
+  ... // all other properties from that CoValue
+};
+```
+</CodeGroup>
+
+The goal of explicit loading states is to encourage developers to think more carefully about CoValue resolution depth and loading states when building their apps, ensuring all cases are properly handled.
+
+## Changes
+
+### The new `$isLoaded` field
+
+Before consuming a CoValue, you must check whether it's loaded and handle the case where it's not. Use the `$isLoaded` field to perform this check.
+
+<CodeGroup>
+```ts
+const Person = co.map({
+  name: z.string(),
+  address: co.map({
+    street: z.string(),
+  }),
+});
+
+const person = await Person.load(id, {
+  resolve: { address: true },
+});
+
+if (!person.$isLoaded) {
+  // Handle the case where the CoValue is not loaded
+  throw new Error("Person not found or not accessible");
+}
+
+// Thanks to the resolve query, we know that if person is loaded, so is address
+console.log(person.address.street); // "123 Fake Street" 
+```
+</CodeGroup>
+
+### `$jazz.loadingState` provides additional information
+
+To handle different loading states more granularly, use the `$jazz.loadingState` field.
+
+<CodeGroup>
+```tsx
+const person = useCoState(Person, id, {
+  resolve: { address: true },
+});
+
+if (!person.$isLoaded) {
+  switch (person.$jazz.loadingState) {
+    case "loading":
+      return "Loading...";
+    case "unauthorized":
+      return "Person not accessible";
+    case "unavailable":
+      return "Person not found";
+  }
+}
+```
+</CodeGroup>
+
+### All hooks now accept selector functions
+
+The `useAccountWithSelector` and `useCoStateWithSelector` hooks have seen widespread adoption, allowing you to select a subset of a CoValue's properties to return.
+
+This prevents unnecessary re-renders, as components only re-render when the data you're interested in changes.
+
+In this release, we've added the `select` functionality directly to the `useAccount` and `useCoState` hooks.
+
+<CodeGroup>
+```tsx
+const profileName = useAccount(Account, {
+  resolve: { profile: true },
+  select: (account) => 
+    account.$isLoaded
+      ? account.profile.name 
+      : "Unavailable",
+});
+```
+</CodeGroup>
+
+## Breaking Changes
+
+### Return types when loading CoValues
+
+All methods and functions that load CoValues now return a `MaybeLoaded<CoValue>` instead of `CoValue | null | undefined`.
+
+You'll need to update your code to check the `$isLoaded` field instead of checking for `null` or `undefined`.
+
+<CodeGroup>
+```ts
+const person = await Person.load(id, {
+  resolve: { address: true },
+});
+
+if (!person) { // [!code --]
+if (!person.$isLoaded) { // [!code ++]
+  return;
+}
+```
+</CodeGroup>
+
+### Renamed `$onError: null` to `$onError: "catch"`
+
+Since `null` is no longer used to represent a not-loaded CoValue, we've renamed the `$onError: null` option in resolve queries to `$onError: "catch"`.
+
+For more information about `$onError`, see the [Catching loading errors](/docs/core-concepts/subscription-and-loading#catching-loading-errors) documentation.
+
+### Split the `useAccount` hook into three separate hooks
+
+Previously, `useAccount` returned an object containing the current account, the current agent, and a logout function.
+
+This caused confusion for users who only needed the current agent or the logout function.
+
+To address this, we've split `useAccount` into three separate hooks:
+- `useAccount`: now returns only the current account
+- `useAgent`: returns the current agent
+- `useLogOut`: returns a function for logging out of the current account
+
+### Removed the `useAccountWithSelector` and `useCoStateWithSelector` hooks
+
+Now that `useAccount` and `useCoState` accept selector functions, the `useAccountWithSelector` and `useCoStateWithSelector` hooks are no longer needed.
+
+The APIs are equivalent, so you can use `useAccount` and `useCoState` in place of the `-WithSelector` variants.
+
+## Codemod
+
+We provide a codemod to make the upgrade to explicit loading states quicker.
+
+The codemod is type-aware, so you must upgrade `jazz-tools` to 0.19 before running it.
+
+<CodeGroup>
+```bash
+npx jazz-tools-codemod-0-19@latest
+```
+</CodeGroup>
+
+Or if you want to run it on a specific path or file:
+
+<CodeGroup>
+```bash
+npx jazz-tools-codemod-0-19@latest ./path/to/your/src
+```
+</CodeGroup>
+
+The goal of this codemod is to get you through 80% of the work quickly. After running it, perform a TypeScript type check to identify the remaining issues.
+
+Note that some edge cases may be migrated incorrectly, and some code patterns (e.g. optional chaining) may not be detected by the codemod.
+
+## Known Issue: TypeScript Iterator Bug
+
+While introducing explicit loading states, we discovered [a TypeScript bug](https://github.com/microsoft/TypeScript/issues/62462) that prevents iterating over CoLists using methods that require an iterator, when these CoLists are loaded inside other CoValues (CoMaps, other CoLists, or CoFeeds).
+
+We've submitted [a fix](https://github.com/microsoft/TypeScript/pull/62661) for this bug. Until it's released, use one of the following workarounds if you encounter this issue:
+
+```ts
+const Pet = co.map({
+  name: z.string(),
+});
+const Person = co.map({
+  pets: co.list(Pet),
+});
+
+if (!person.$isLoaded) {
+  return;
+}
+
+// Use `.values()` to explicitly get the iterator
+const [firstPet] = person.pets; // [!code --]
+const [firstPet] = person.pets.values(); // [!code ++]
+
+// Array iteration methods (like `forEach` and `map`) work as expected
+for (const pet of person.pets) { // [!code --]
+person.pets.forEach(pet => { // [!code ++]
+  console.log(pet.name);
+} // [!code --]
+}); // [!code ++]
+```
+
+Alternatively, you can suppress the TypeScript error by adding a `@ts-expect-error` comment, since this is purely a type-level issue.

--- a/homepage/homepage/content/docs/upgrade/0-19-0.mdx
+++ b/homepage/homepage/content/docs/upgrade/0-19-0.mdx
@@ -38,7 +38,7 @@ type CoValue = {
 ```
 </CodeGroup>
 
-The goal of explicit loading states is to encourage developers to think more carefully about CoValue resolution depth and loading states when building their apps, ensuring all cases are properly handled.
+The goal of explicit loading states is to make it easier for developers to build apps which handle all kinds of loading states properly.
 
 ## Changes
 
@@ -92,9 +92,9 @@ if (!person.$isLoaded) {
 ```
 </CodeGroup>
 
-### All hooks now accept selector functions
+### All React hooks now accept selector functions
 
-The `useAccountWithSelector` and `useCoStateWithSelector` hooks have seen widespread adoption, allowing you to select a subset of a CoValue's properties to return.
+The `useAccountWithSelector` and `useCoStateWithSelector` React hooks have seen widespread adoption, allowing you to select a subset of a CoValue's properties to return.
 
 This prevents unnecessary re-renders, as components only re-render when the data you're interested in changes.
 

--- a/homepage/homepage/content/docs/upgrade/0-19-0.mdx
+++ b/homepage/homepage/content/docs/upgrade/0-19-0.mdx
@@ -133,6 +133,8 @@ if (!person.$isLoaded) { // [!code ++]
 ```
 </CodeGroup>
 
+We've added a `getLoadedOrUndefined` utility function so you can keep using your existing error handling logic and migrate to the new loading states gradually.
+
 ### Renamed `$onError: null` to `$onError: "catch"`
 
 Since `null` is no longer used to represent a not-loaded CoValue, we've renamed the `$onError: null` option in resolve queries to `$onError: "catch"`.

--- a/homepage/homepage/content/docs/upgrade/0-19-0.mdx
+++ b/homepage/homepage/content/docs/upgrade/0-19-0.mdx
@@ -2,7 +2,7 @@ import { Alert, CodeGroup } from '@/components/forMdx'
 
 # Jazz 0.19.0 - Explicit CoValue loading states
 
-This release introduces explicit loading states when loading CoValues.
+This release introduces explicit loading states when loading CoValues and a new way to define how CoValues are loaded.
 
 ## Motivation
 
@@ -89,6 +89,55 @@ if (!person.$isLoaded) {
       return "Person not found";
   }
 }
+```
+</CodeGroup>
+
+### Schema-level resolve queries
+
+When working with deeply-nested CoValue schemas, you need to handle complex resolve queries, and also make sure that they are in sync with the types of loaded CoValues to avoid type errors or unnecessary loading state checks:
+
+<CodeGroup>
+```tsx
+const account = useAccount(MusicAccount, {
+  resolve: { root: { playlists: { $each: { tracks: { $each: true } } } } },
+});
+
+type AccountWithPlaylists = co.loaded<
+  typeof MusicAccount,
+  { root: { playlists: { $each: { tracks: { $each: true } } } } }
+>;
+function allTracks(account: AccountWithPlaylists): MusicTrack[] {
+  return account.root.playlists.flatMap(playlist => playlist.tracks);
+}
+
+allTracks(account);
+```
+</CodeGroup>
+
+This has been a common source of confusion for users, so we've added a simpler way to define resolve queries.
+
+Schema-level resolve queries allow you specify the resolve query once at the schema level, and that query will be used both when loading CoValues from that schema (when no resolve query is provided by the user) and in `co.loaded` types:
+
+<CodeGroup>
+```tsx
+// `.resolved()` adds a resolve query to a schema
+const PlaylistWithTracks = Playlist.resolved({ tracks: { $each: true } });
+
+const AccountWithPlaylists = MusicAccount.resolved(
+  // Use `.resolve` to get the resolve query from a schema and compose it in other queries
+  { root: { playlists: { $each: PlaylistWithTracks.resolve } } },
+});
+
+// The schema's resolve query will be used if no other resolve query is provided
+const account = useAccount(AccountWithPlaylists);
+
+// `co.loaded` will infer the type of the loaded CoValue using the schema's resolve query.
+type AccountWithPlaylists = co.loaded<typeof AccountWithPlaylists>;
+function allTracks(account: AccountWithPlaylists): MusicTrack[] {
+  return account.root.playlists.flatMap(playlist => playlist.tracks);
+}
+
+allTracks(account);
 ```
 </CodeGroup>
 

--- a/packages/codemod-upgrade-0-19/.gitignore
+++ b/packages/codemod-upgrade-0-19/.gitignore
@@ -1,0 +1,5 @@
+dist
+node_modules
+*.log
+.turbo
+

--- a/packages/codemod-upgrade-0-19/CHANGELOG.md
+++ b/packages/codemod-upgrade-0-19/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 0.1.0
+
+- Initial release
+- Migrates `useCoStateWithSelector` to `useCoState`
+- Migrates `useAccountWithSelector` to `useAccount`
+

--- a/packages/codemod-upgrade-0-19/LICENSE
+++ b/packages/codemod-upgrade-0-19/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/packages/codemod-upgrade-0-19/README.md
+++ b/packages/codemod-upgrade-0-19/README.md
@@ -40,6 +40,28 @@ The hooks are now polymorphic and support the selector pattern natively.
 
 Updates `useAccount` and `useCoState` hooks to convert the new explicit loading states into `null | undefined`, maintaining backward compatibility in existing React components that use Jazz.
 
+### 5. **Migrates MaybeLoaded If Statements**
+
+The codemod automatically transforms `if` statements that directly check MaybeLoaded values:
+
+```typescript
+const account = await Account.load("account-id", {
+  resolve: { profile: true },
+});
+
+// Before
+if (!account) {
+  return "Loading...";
+}
+
+// After
+if (!account.$isLoaded) {
+  return "Loading...";
+}
+```
+
+This uses TypeScript's type system to detect variables with the `MaybeLoaded<T>` type and adds the `.$isLoaded` property access. Note: This only works on files with valid TypeScript types (files with `@ts-nocheck` or type errors won't be transformed).
+
 ## Usage
 
 ### Running the Jazz 0.19 Codemod

--- a/packages/codemod-upgrade-0-19/README.md
+++ b/packages/codemod-upgrade-0-19/README.md
@@ -1,0 +1,117 @@
+# Jazz Codemods - 0.19 Upgrade
+
+This repository contains codemods for upgrading Jazz projects to version 0.19.
+
+## What are Codemods?
+
+Codemods are automated refactoring tools that help you upgrade your codebase. 
+
+They rewrite your code using AST modification.
+
+We use `ts-morph` under the hood, to target specific Jazz types in our migrations.
+
+Codemods modify your code, not always in the correct way.
+Be sure that everything important is committed in your repo and there aren't unstaged changes that might get lost in the process.
+
+## What This Codemod Does
+
+The Jazz 0.19 upgrade codemod performs the following transformations:
+
+1. **Renames `useCoStateWithSelector` to `useCoState`** - The hooks are now polymorphic and support the selector pattern natively
+2. **Renames `useAccountWithSelector` to `useAccount`** - The hooks are now polymorphic and support the selector pattern natively
+
+These hooks maintain the same API and functionality, they just have simplified names since all hooks now support the selector pattern.
+
+## Usage
+
+### Running the Jazz 0.19 Codemod
+
+To run the Jazz 0.19 codemod, first upgrade the jazz-tools version to 0.19 and then execute:
+
+```bash
+npx jazz-tools-codemod-0-19
+```
+
+### How it Works
+
+By default, the codemod will:
+
+1. **Try to use the tsconfig.json in the current working directory** to resolve project files
+2. **Fall back to glob search** if no tsconfig.json is found or if it can't resolve the project structure
+
+## Prerequisites
+
+- Node.js (version 14 or higher)
+- npm, yarn, or pnpm
+
+## Installation
+
+The codemod is available as an npm package and can be run directly with npx, so no local installation is required.
+
+## Running on Specific Files
+
+If you want to run the codemod on specific files or directories, you can pass them as arguments:
+
+```bash
+npx jazz-tools-codemod-0-19 src/
+```
+
+## Examples
+
+### Before (0.18)
+
+```typescript
+import { useCoStateWithSelector, useAccountWithSelector } from "jazz-tools/react";
+
+function MyComponent() {
+  const todo = useCoStateWithSelector(TodoItem, todoId, {
+    resolve: { text: true },
+    select: (todo) => todo,
+  });
+
+  const todos = useAccountWithSelector(MyAccount, {
+    resolve: { root: { todos: { $each: true } } },
+    select: (me) => me?.root.todos,
+  });
+
+  // ...
+}
+```
+
+### After (0.19)
+
+```typescript
+import { useCoState, useAccount } from "jazz-tools/react";
+
+function MyComponent() {
+  const todo = useCoState(TodoItem, todoId, {
+    resolve: { text: true },
+    select: (todo) => todo,
+  });
+
+  const todos = useAccount(MyAccount, {
+    resolve: { root: { todos: { $each: true } } },
+    select: (me) => me?.root.todos,
+  });
+
+  // ...
+}
+```
+
+## Contributing
+
+If you find issues with the codemod or want to contribute improvements, please:
+
+1. Open an issue describing the problem
+2. Fork the repository
+3. Make your changes
+4. Submit a pull request
+
+## License
+
+MIT
+
+## Support
+
+For issues related to the codemod itself, please open an issue in this repository. For general Jazz support, please refer to the official Jazz documentation.
+

--- a/packages/codemod-upgrade-0-19/README.md
+++ b/packages/codemod-upgrade-0-19/README.md
@@ -50,6 +50,12 @@ To run the Jazz 0.19 codemod, first upgrade the jazz-tools version to 0.19 and t
 npx jazz-tools-codemod-0-19
 ```
 
+For large projects, you may need to increase Node.js heap size:
+
+```bash
+NODE_OPTIONS="--max-old-space-size=8192" npx jazz-tools-codemod-0-19
+```
+
 ### How it Works
 
 By default, the codemod will:

--- a/packages/codemod-upgrade-0-19/package.json
+++ b/packages/codemod-upgrade-0-19/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "jazz-tools-codemod-0-19",
+  "version": "0.1.0",
+  "description": "Codemod to migrate from Jazz Tools 0.18 to 0.19",
+  "type": "module",
+  "license": "MIT",
+  "files": [
+    "dist"
+  ],
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": "./dist/index.js",
+    "./package.json": "./package.json"
+  },
+  "bin": {
+    "jazz-tools-codemod-0-19": "./dist/index.js"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "ts-morph": "^26.0.0"
+  },
+  "scripts": {
+    "build": "tsdown && chmod +x dist/index.js",
+    "dev": "tsdown --watch",
+    "test": "vitest",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "tsdown": "^0.11.9",
+    "typescript": "catalog:default"
+  }
+}
+

--- a/packages/codemod-upgrade-0-19/src/index.ts
+++ b/packages/codemod-upgrade-0-19/src/index.ts
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+
+import { runTransform } from "./transform.js";
+
+const args = process.argv.slice(2);
+const projectPath = args[0] || process.cwd();
+
+console.log(`Running Jazz 0.19 upgrade transform on: ${projectPath}`);
+runTransform(projectPath);
+console.log("Transform completed!");

--- a/packages/codemod-upgrade-0-19/src/transform.ts
+++ b/packages/codemod-upgrade-0-19/src/transform.ts
@@ -15,7 +15,7 @@ export function transformFile(sourceFile: SourceFile): string {
 
   migrateUseAccount(sourceFile);
 
-  renameHooks(sourceFile);
+  renameWithSelectorHooks(sourceFile);
 
   migrateLoadingStateHandling(sourceFile);
 
@@ -290,7 +290,7 @@ function addJazzToolsImports(
 /**
  * Renames useAccountWithSelector to useAccount and useCoStateWithSelector to useCoState
  */
-function renameHooks(sourceFile: SourceFile) {
+function renameWithSelectorHooks(sourceFile: SourceFile) {
   transformHookImports(sourceFile);
   transformHookCalls(sourceFile);
 }
@@ -477,7 +477,7 @@ export function runTransform(projectPath: string) {
   } else {
     project = new Project();
 
-    const supportedExtensions = [".tsx"];
+    const supportedExtensions = [".ts", ".tsx"];
     const hasSupportedExtension = supportedExtensions.some((ext) =>
       projectPath.endsWith(ext),
     );
@@ -485,7 +485,7 @@ export function runTransform(projectPath: string) {
     if (hasSupportedExtension) {
       project.addSourceFilesAtPaths(projectPath);
     } else {
-      project.addSourceFilesAtPaths(`${projectPath}/**/*.tsx`);
+      project.addSourceFilesAtPaths(`${projectPath}/**/*.{ts,tsx}`);
     }
   }
 

--- a/packages/codemod-upgrade-0-19/src/transform.ts
+++ b/packages/codemod-upgrade-0-19/src/transform.ts
@@ -11,11 +11,24 @@ import {
 import fs from "node:fs";
 
 export function transformFile(sourceFile: SourceFile): string {
+  migrateOnError(sourceFile);
+
   migrateUseAccount(sourceFile);
 
   renameHooks(sourceFile);
 
   return sourceFile.getFullText();
+}
+
+function migrateOnError(sourceFile: SourceFile) {
+  const fullText = sourceFile.getFullText();
+
+  // Simple text replacement: $onError: null -> $onError: 'catch'
+  const newText = fullText.replace(/\$onError:\s*null/g, "$onError: 'catch'");
+
+  if (newText !== fullText) {
+    sourceFile.replaceWithText(newText);
+  }
 }
 
 function migrateUseAccount(sourceFile: SourceFile) {

--- a/packages/codemod-upgrade-0-19/src/transform.ts
+++ b/packages/codemod-upgrade-0-19/src/transform.ts
@@ -446,9 +446,16 @@ function migrateLoadingStateHandling(sourceFile: SourceFile) {
           // Arrow function without braces - safe to transform
           const selectorBody = body.getText();
 
-          // Remove optional chaining from the selector body since we're checking $isLoaded
-          // Convert account?.profile?.name to account.profile.name
-          const cleanedSelectorBody = selectorBody.replace(/\?\.(?=\w)/g, ".");
+          // Only remove optional chaining on the root parameter, preserve it for nested properties
+          const escapedParamName = paramName.replace(
+            // Escape special characters in the parameter name
+            /[.*+?^${}()|[\]\\]/g,
+            "\\$&",
+          );
+          const cleanedSelectorBody = selectorBody.replace(
+            new RegExp(`${escapedParamName}\\?\\.`, "g"),
+            `${paramName}.`,
+          );
 
           // Create the new selector with loading state handling (single line for better formatting)
           const newSelector = `(${paramName}) => ${paramName}.$isLoaded ? ${cleanedSelectorBody} : ${paramName}.$jazz.loadingState === "loading" ? undefined : null`;

--- a/packages/codemod-upgrade-0-19/src/transform.ts
+++ b/packages/codemod-upgrade-0-19/src/transform.ts
@@ -1,0 +1,132 @@
+import {
+  Project,
+  SyntaxKind,
+  SourceFile,
+  CallExpression,
+  PropertyAccessExpression,
+  ImportDeclaration,
+} from "ts-morph";
+import fs from "node:fs";
+
+export function transformFile(sourceFile: SourceFile): string {
+  renameHooks(sourceFile);
+
+  return sourceFile.getFullText();
+}
+
+/**
+ * Renames useAccountWithSelector to useAccount and useCoStateWithSelector to useCoState
+ */
+function renameHooks(sourceFile: SourceFile) {
+  transformHookImports(sourceFile);
+  transformHookCalls(sourceFile);
+}
+
+function transformHookImports(sourceFile: SourceFile) {
+  sourceFile.forEachDescendant((node) => {
+    if (node.getKind() === SyntaxKind.ImportDeclaration) {
+      const importDecl = node as ImportDeclaration;
+      const moduleSpecifier = importDecl.getModuleSpecifierValue();
+
+      // Only process imports from jazz-tools packages
+      if (moduleSpecifier.includes("jazz-tools")) {
+        const namedImports = importDecl.getNamedImports();
+
+        namedImports.forEach((namedImport) => {
+          const importName = namedImport.getName();
+          if (importName === "useCoStateWithSelector") {
+            namedImport.setName("useCoState");
+          }
+          if (importName === "useAccountWithSelector") {
+            namedImport.setName("useAccount");
+          }
+        });
+      }
+    }
+  });
+}
+
+function transformHookCalls(sourceFile: SourceFile) {
+  sourceFile.forEachDescendant((node) => {
+    if (node.getKind() === SyntaxKind.CallExpression) {
+      const callExpression = node as CallExpression;
+      const expression = callExpression.getExpression();
+
+      // Handle direct function calls
+      if (expression.getKind() === SyntaxKind.Identifier) {
+        const functionName = expression.getText();
+
+        if (functionName === "useCoStateWithSelector") {
+          expression.replaceWithText("useCoState");
+        } else if (functionName === "useAccountWithSelector") {
+          expression.replaceWithText("useAccount");
+        }
+      }
+    }
+  });
+}
+
+// Main function to run the transform
+function singleRun(projectPath: string) {
+  let project: Project;
+
+  if (fs.existsSync(`${projectPath}/tsconfig.json`)) {
+    project = new Project({
+      tsConfigFilePath: `${projectPath}/tsconfig.json`,
+    });
+  } else {
+    project = new Project();
+
+    const supportedExtensions = [".ts", ".tsx"];
+    const hasSupportedExtension = supportedExtensions.some((ext) =>
+      projectPath.endsWith(ext),
+    );
+
+    if (hasSupportedExtension) {
+      project.addSourceFilesAtPaths(projectPath);
+    } else {
+      project.addSourceFilesAtPaths(`${projectPath}/**/*.{ts,tsx}`);
+    }
+  }
+
+  const sourceFiles = project.getSourceFiles();
+
+  let changed = false;
+
+  sourceFiles.forEach((sourceFile) => {
+    if (sourceFile.getFilePath().includes("node_modules")) {
+      return;
+    }
+
+    try {
+      const originalText = sourceFile.getFullText();
+      const transformedText = transformFile(sourceFile);
+
+      if (originalText !== transformedText) {
+        sourceFile.saveSync();
+        console.log(`Transformed: ${sourceFile.getFilePath()}`);
+        changed = true;
+      }
+    } catch (error) {
+      console.error(`Error transforming ${sourceFile.getFilePath()}:`, error);
+    }
+  });
+
+  return changed;
+}
+
+// Run multiple times, because the resolved types gets fixed after each run
+export function runTransform(projectPath: string): void {
+  let runCount = 1;
+
+  while (singleRun(projectPath)) {
+    runCount++;
+
+    if (runCount > 5) {
+      console.log("Ran 5 times, stopping");
+      break;
+    }
+  }
+
+  console.log(`Ran ${runCount} times`);
+}

--- a/packages/codemod-upgrade-0-19/src/transform.ts
+++ b/packages/codemod-upgrade-0-19/src/transform.ts
@@ -554,7 +554,10 @@ export function runTransform(projectPath: string) {
     if (hasSupportedExtension) {
       project.addSourceFilesAtPaths(projectPath);
     } else {
-      project.addSourceFilesAtPaths(`${projectPath}/**/*.{ts,tsx}`);
+      project.addSourceFilesAtPaths([
+        `${projectPath}/**/*.{ts,tsx}`,
+        `!${projectPath}/**/node_modules/**`,
+      ]);
     }
   }
 
@@ -566,6 +569,7 @@ export function runTransform(projectPath: string) {
 
   sourceFiles.forEach((sourceFile) => {
     try {
+      console.log(`Transforming: ${sourceFile.getFilePath()}`);
       const originalText = sourceFile.getFullText();
       const transformedText = transformFile(sourceFile);
 

--- a/packages/codemod-upgrade-0-19/src/transform.ts
+++ b/packages/codemod-upgrade-0-19/src/transform.ts
@@ -492,7 +492,10 @@ function migrateMaybeLoadedIfStatements(sourceFile: SourceFile) {
       const expression = node.getExpression();
 
       // Check for direct variable reference: if (account)
-      if (Node.isIdentifier(expression)) {
+      if (
+        Node.isIdentifier(expression) ||
+        Node.isPropertyAccessExpression(expression)
+      ) {
         const varName = expression.getText();
         const type = expression.getType();
 
@@ -506,12 +509,16 @@ function migrateMaybeLoadedIfStatements(sourceFile: SourceFile) {
         }
       }
 
-      // Check for negation: if (!account)
+      // Check for negation: if (!account) or if (!account.profile)
       if (Node.isPrefixUnaryExpression(expression)) {
         const operator = expression.getOperatorToken();
         if (operator === SyntaxKind.ExclamationToken) {
           const operand = expression.getOperand();
-          if (Node.isIdentifier(operand)) {
+
+          if (
+            Node.isIdentifier(operand) ||
+            Node.isPropertyAccessExpression(operand)
+          ) {
             const varName = operand.getText();
             const type = operand.getType();
 

--- a/packages/codemod-upgrade-0-19/src/transform.ts
+++ b/packages/codemod-upgrade-0-19/src/transform.ts
@@ -437,15 +437,14 @@ function migrateLoadingStateHandling(sourceFile: SourceFile) {
 
           // Get the body of the selector
           const body = initializer.getBody();
-          let selectorBody: string;
 
           if (Node.isBlock(body)) {
-            // Function body with braces
-            selectorBody = body.getFullText();
-          } else {
-            // Arrow function without braces
-            selectorBody = body.getText();
+            // Skip transformation for block body selectors - they're too complex
+            return;
           }
+
+          // Arrow function without braces - safe to transform
+          const selectorBody = body.getText();
 
           // Remove optional chaining from the selector body since we're checking $isLoaded
           // Convert account?.profile?.name to account.profile.name

--- a/packages/codemod-upgrade-0-19/tests/__snapshots__/codemod.test.ts.snap
+++ b/packages/codemod-upgrade-0-19/tests/__snapshots__/codemod.test.ts.snap
@@ -229,11 +229,28 @@ async function MaybeLoadedCoValueIfCheck() {
     resolve: { profile: true },
   });
 
+  // if (!account.$isLoaded)
   if (!account.$isLoaded) {
     return "Loading...";
   }
 
   return account.profile.name;
+}
+
+// Nullability check on optional MaybeLoaded value
+async function OptionalMaybeLoadedCoValueIfCheck({ accountId }: { accountId?: string }) {
+  const optionalAccount = accountId
+    ? await Account.load("account-id", {
+        resolve: { profile: true },
+      })
+    : undefined;
+
+  // if (!optionalAccount?.$isLoaded)
+  if (!optionalAccount?.$isLoaded) {
+    return "Loading...";
+  }
+
+  return optionalAccount.profile.name;
 }
 
 export {
@@ -252,6 +269,7 @@ export {
   HookWithNoOptions,
   HookWithSchemaNoOptions,
   MaybeLoadedCoValueIfCheck,
+  OptionalMaybeLoadedCoValueIfCheck,
 };
 "
 `;

--- a/packages/codemod-upgrade-0-19/tests/__snapshots__/codemod.test.ts.snap
+++ b/packages/codemod-upgrade-0-19/tests/__snapshots__/codemod.test.ts.snap
@@ -7,9 +7,8 @@ exports[`runTransform 1`] = `
 // This file shows examples of what the codemod will transform
 
 import {
-  useCoState,
   useAccount,
-} from "jazz-tools/react";
+  useCoState, useAgent, useLogOut } from "jazz-tools/react";
 import { co, Account, z } from "jazz-tools";
 
 const TodoItem = co.map({
@@ -30,8 +29,9 @@ const MyAccount = co
     }
   });
 
-// Example 1: useCoStateWithSelector should become useCoState
+// useCoStateWithSelector should become useCoState
 function ExampleCoState({ todoId }: { todoId: string }) {
+  // Should be transformed to useCoState
   const todo = useCoState(TodoItem, todoId, {
     resolve: { text: true, done: true },
     select: (todo) => (todo.$isLoaded ? todo : undefined),
@@ -45,29 +45,28 @@ function ExampleCoState({ todoId }: { todoId: string }) {
   );
 }
 
-// Example 2: useAccountWithSelector should become useAccount
+// useAccountWithSelector should become useAccount
 function ExampleAccount() {
+  // Should be transformed to useAccount
   const todos = useAccount(MyAccount, {
     resolve: { root: { todos: { $each: { $onError: null } } } },
     select: (me) => me?.root.todos,
   });
 
   return (
-    <ul>
-      {todos?.map((todo) => (
-        <li key={todo.$jazz.id}>{todo.text}</li>
-      ))}
-    </ul>
+    <ul>{todos?.map((todo) => <li key={todo.$jazz.id}>{todo.text}</li>)}</ul>
   );
 }
 
-// Example 3: Multiple usages in same component
+// Multiple usages in same component
 function ComplexComponent({ itemId }: { itemId: string }) {
+  // Should be transformed to useCoState
   const item = useCoState(TodoItem, itemId, {
     resolve: { text: true },
     select: (item) => item,
   });
 
+  // Should be transformed to useAccount
   const account = useAccount(MyAccount, {
     resolve: { root: true },
     select: (me) => me,
@@ -81,6 +80,93 @@ function ComplexComponent({ itemId }: { itemId: string }) {
   );
 }
 
-export { ExampleCoState, ExampleAccount, ComplexComponent };
+// Old useAccount pattern with destructuring { me, agent, logOut }
+function OldUseAccountPattern() {
+  // const me = useAccount();
+  // const agent = useAgent();
+  // const logOut = useLogOut();
+  const me = useAccount();
+  const agent = useAgent();
+  const logOut = useLogOut();
+
+  return (
+    <div>
+      <p>User: {me?.profile?.name}</p>
+      <button onClick={logOut}>Log out</button>
+      <pre>{JSON.stringify(agent, null, 2)}</pre>
+    </div>
+  );
+}
+
+// Old useAccount pattern with only some properties
+function PartialUseAccountPattern() {
+  // const me = useAccount();
+  // const logOut = useLogOut();
+  const me = useAccount();
+  const logOut = useLogOut();
+
+  return (
+    <div>
+      <p>User: {me?.profile?.name}</p>
+      <button onClick={logOut}>Log out</button>
+    </div>
+  );
+}
+
+// Old useAccount pattern with only me
+function OnlyMePattern() {
+  // const me = useAccount();
+  const me = useAccount();
+
+  return <div>{me?.profile?.name}</div>;
+}
+
+// Old useAccount pattern with aliasing
+function AliasedPattern() {
+  // const currentUser = useAccount();
+  // const myAgent = useAgent();
+  const currentUser = useAccount();
+  const myAgent = useAgent();
+
+  return (
+    <div>
+      <p>{currentUser?.profile?.name}</p>
+      <pre>{JSON.stringify(myAgent, null, 2)}</pre>
+    </div>
+  );
+}
+
+// Old useAccount non-destructured pattern with account, agent and logOut
+function NoDestructuringWithAccountAgentLogOut() {
+  // const account = useAccount();
+  // const agent = useAgent();
+  // const logOut = useLogOut();
+  const account = useAccount();
+  const agent = useAgent();
+  const logOut = useLogOut();
+
+  return (
+    <div>
+      {/* account?.profile?.name */}
+      <p>{account?.profile?.name}</p>
+      {/* logOut */}
+      <button onClick={logOut}>Log out</button>
+      {/* agent */}
+      <pre>{JSON.stringify(agent, null, 2)}</pre>
+    </div>
+  );
+}
+
+export {
+  ExampleCoState,
+  ExampleAccount,
+  ComplexComponent,
+  OldUseAccountPattern,
+  PartialUseAccountPattern,
+  OnlyMePattern,
+  AliasedPattern,
+  NoDestructuringPattern,
+  NoDestructuringWithAccountAgentLogOut,
+};
 "
 `;

--- a/packages/codemod-upgrade-0-19/tests/__snapshots__/codemod.test.ts.snap
+++ b/packages/codemod-upgrade-0-19/tests/__snapshots__/codemod.test.ts.snap
@@ -29,6 +29,15 @@ const MyAccount = co
     }
   });
 
+// $onError: 'catch' should become $onError: 'catch'
+function ExampleOnErrorNull() {
+  const todo = useAccount(MyAccount, todoId, {
+    resolve: { root: { todos: { $each: { $onError: 'catch' } } } },
+  });
+
+  return <div>{todo?.text}</div>;
+}
+
 // useCoStateWithSelector should become useCoState
 function ExampleCoState({ todoId }: { todoId: string }) {
   // Should be transformed to useCoState
@@ -49,12 +58,16 @@ function ExampleCoState({ todoId }: { todoId: string }) {
 function ExampleAccount() {
   // Should be transformed to useAccount
   const todos = useAccount(MyAccount, {
-    resolve: { root: { todos: { $each: { $onError: null } } } },
+    resolve: { root: { todos: { $each: { $onError: 'catch' } } } },
     select: (me) => me?.root.todos,
   });
 
   return (
-    <ul>{todos?.map((todo) => <li key={todo.$jazz.id}>{todo.text}</li>)}</ul>
+    <ul>
+      {todos?.map((todo) => (
+        <li key={todo.$jazz.id}>{todo.text}</li>
+      ))}
+    </ul>
   );
 }
 
@@ -158,6 +171,7 @@ function NoDestructuringWithAccountAgentLogOut() {
 }
 
 export {
+  ExampleOnErrorNull,
   ExampleCoState,
   ExampleAccount,
   ComplexComponent,

--- a/packages/codemod-upgrade-0-19/tests/__snapshots__/codemod.test.ts.snap
+++ b/packages/codemod-upgrade-0-19/tests/__snapshots__/codemod.test.ts.snap
@@ -201,7 +201,7 @@ function HookWithExistingExpressionSelector() {
   // });
   const profileName = useAccount(MyAccount, {
     resolve: { profile: true },
-    select: (account) => account.$isLoaded ? account.profile.name : account.$jazz.loadingState === "loading" ? undefined : null,
+    select: (account) => account.$isLoaded ? account.profile?.name : account.$jazz.loadingState === "loading" ? undefined : null,
   });
 
   return <div>{profileName}</div>;

--- a/packages/codemod-upgrade-0-19/tests/__snapshots__/codemod.test.ts.snap
+++ b/packages/codemod-upgrade-0-19/tests/__snapshots__/codemod.test.ts.snap
@@ -223,6 +223,19 @@ function HookWithSchemaNoOptions() {
   return <div>{account?.profile?.name}</div>;
 }
 
+// Nullability check on MaybeLoaded value
+async function MaybeLoadedCoValueIfCheck() {
+  const account = await Account.load("account-id", {
+    resolve: { profile: true },
+  });
+
+  if (!account.$isLoaded) {
+    return "Loading...";
+  }
+
+  return account.profile.name;
+}
+
 export {
   ExampleOnErrorNull,
   ExampleCoState,
@@ -238,6 +251,7 @@ export {
   HookWithExistingSelector,
   HookWithNoOptions,
   HookWithSchemaNoOptions,
+  MaybeLoadedCoValueIfCheck,
 };
 "
 `;

--- a/packages/codemod-upgrade-0-19/tests/__snapshots__/codemod.test.ts.snap
+++ b/packages/codemod-upgrade-0-19/tests/__snapshots__/codemod.test.ts.snap
@@ -288,6 +288,79 @@ async function MaybeLoadedNestedCoValueIfCheck() {
   return account.profile.name;
 }
 
+// If with || operator
+async function MaybeLoadedOrCheck() {
+  const account = await Account.load("account-id", {
+    resolve: { profile: true },
+  });
+  const account2 = await Account.load("account-id-2", {
+    resolve: { profile: true },
+  });
+
+  // Should transform: if (!account.$isLoaded || !account2.$isLoaded)
+  if (!account.$isLoaded || !account2.$isLoaded) {
+    return "Loading...";
+  }
+
+  return account.profile.name;
+}
+
+// If with && operator
+async function MaybeLoadedAndCheck() {
+  const account = await Account.load("account-id", {
+    resolve: { profile: true },
+  });
+  const account2 = await Account.load("account-id-2");
+
+  // Should transform: if (account.$isLoaded && account2.$isLoaded)
+  if (account.$isLoaded && account2.$isLoaded) {
+    return account.profile.name;
+  }
+
+  return "Loading...";
+}
+
+// Complex if with mixed operators
+async function MaybeLoadedMixedCheck() {
+  const account = await Account.load("account-id");
+  const account2 = await Account.load("account-id-2");
+  const isAdmin = true;
+
+  // Should transform: if (account.$isLoaded && (account2.$isLoaded || isAdmin))
+  if (account.$isLoaded && (account2.$isLoaded || isAdmin)) {
+    return "Loaded";
+  }
+
+  return "Loading...";
+}
+
+// Complex if with negation and &&
+async function MaybeLoadedNegationAndCheck() {
+  const account = await Account.load("account-id");
+  const account2 = await Account.load("account-id-2");
+
+  // Should transform: if (!account.$isLoaded && account2.$isLoaded)
+  if (!account.$isLoaded && account2.$isLoaded) {
+    return "Account not loaded but account2 is";
+  }
+
+  return "Other state";
+}
+
+// Complex if with parentheses
+async function MaybeLoadedParenthesesCheck() {
+  const account = await Account.load("account-id");
+  const account2 = await Account.load("account-id-2");
+  const ready = true;
+
+  // Should transform: if ((account.$isLoaded && account2.$isLoaded) || ready)
+  if ((account.$isLoaded && account2.$isLoaded) || ready) {
+    return "Ready or loaded";
+  }
+
+  return "Not ready";
+}
+
 export {
   ExampleOnErrorNull,
   ExampleCoState,
@@ -307,6 +380,11 @@ export {
   MaybeLoadedCoValueIfCheck,
   OptionalMaybeLoadedCoValueIfCheck,
   MaybeLoadedNestedCoValueIfCheck,
+  MaybeLoadedOrCheck,
+  MaybeLoadedAndCheck,
+  MaybeLoadedMixedCheck,
+  MaybeLoadedNegationAndCheck,
+  MaybeLoadedParenthesesCheck,
 };
 "
 `;

--- a/packages/codemod-upgrade-0-19/tests/__snapshots__/codemod.test.ts.snap
+++ b/packages/codemod-upgrade-0-19/tests/__snapshots__/codemod.test.ts.snap
@@ -31,11 +31,12 @@ const MyAccount = co
 
 // $onError: 'catch' should become $onError: 'catch'
 function ExampleOnErrorNull() {
-  const todo = useAccount(MyAccount, todoId, {
+  const me = useAccount(MyAccount, {
     resolve: { root: { todos: { $each: { $onError: 'catch' } } } },
-  });
+      select: (me) => me.$isLoaded ? me : me.$jazz.loadingState === "loading" ? undefined : null
+});
 
-  return <div>{todo?.text}</div>;
+  return <div>{me?.root.todos[0]?.text}</div>;
 }
 
 // useCoStateWithSelector should become useCoState
@@ -43,7 +44,7 @@ function ExampleCoState({ todoId }: { todoId: string }) {
   // Should be transformed to useCoState
   const todo = useCoState(TodoItem, todoId, {
     resolve: { text: true, done: true },
-    select: (todo) => (todo.$isLoaded ? todo : undefined),
+    select: (todo) => todo.$isLoaded ? todo : todo.$jazz.loadingState === "loading" ? undefined : null,
   });
 
   return (
@@ -59,7 +60,7 @@ function ExampleAccount() {
   // Should be transformed to useAccount
   const todos = useAccount(MyAccount, {
     resolve: { root: { todos: { $each: { $onError: 'catch' } } } },
-    select: (me) => me?.root.todos,
+    select: (me) => me.$isLoaded ? me.root.todos : me.$jazz.loadingState === "loading" ? undefined : null,
   });
 
   return (
@@ -76,13 +77,13 @@ function ComplexComponent({ itemId }: { itemId: string }) {
   // Should be transformed to useCoState
   const item = useCoState(TodoItem, itemId, {
     resolve: { text: true },
-    select: (item) => item,
+    select: (item) => item.$isLoaded ? item : item.$jazz.loadingState === "loading" ? undefined : null,
   });
 
   // Should be transformed to useAccount
   const account = useAccount(MyAccount, {
     resolve: { root: true },
-    select: (me) => me,
+    select: (me) => me.$isLoaded ? me : me.$jazz.loadingState === "loading" ? undefined : null,
   });
 
   return (
@@ -98,7 +99,7 @@ function OldUseAccountPattern() {
   // const me = useAccount();
   // const agent = useAgent();
   // const logOut = useLogOut();
-  const me = useAccount();
+  const me = useAccount(undefined, { select: (me) => me.$isLoaded ? me : me.$jazz.loadingState === "loading" ? undefined : null });
   const agent = useAgent();
   const logOut = useLogOut();
 
@@ -115,7 +116,7 @@ function OldUseAccountPattern() {
 function PartialUseAccountPattern() {
   // const me = useAccount();
   // const logOut = useLogOut();
-  const me = useAccount();
+  const me = useAccount(undefined, { select: (me) => me.$isLoaded ? me : me.$jazz.loadingState === "loading" ? undefined : null });
   const logOut = useLogOut();
 
   return (
@@ -129,7 +130,7 @@ function PartialUseAccountPattern() {
 // Old useAccount pattern with only me
 function OnlyMePattern() {
   // const me = useAccount();
-  const me = useAccount();
+  const me = useAccount(undefined, { select: (me) => me.$isLoaded ? me : me.$jazz.loadingState === "loading" ? undefined : null });
 
   return <div>{me?.profile?.name}</div>;
 }
@@ -138,7 +139,7 @@ function OnlyMePattern() {
 function AliasedPattern() {
   // const currentUser = useAccount();
   // const myAgent = useAgent();
-  const currentUser = useAccount();
+  const currentUser = useAccount(undefined, { select: (currentUser) => currentUser.$isLoaded ? currentUser : currentUser.$jazz.loadingState === "loading" ? undefined : null });
   const myAgent = useAgent();
 
   return (
@@ -154,7 +155,7 @@ function NoDestructuringWithAccountAgentLogOut() {
   // const account = useAccount();
   // const agent = useAgent();
   // const logOut = useLogOut();
-  const account = useAccount();
+  const account = useAccount(undefined, { select: (account) => account.$isLoaded ? account : account.$jazz.loadingState === "loading" ? undefined : null });
   const agent = useAgent();
   const logOut = useLogOut();
 
@@ -170,6 +171,58 @@ function NoDestructuringWithAccountAgentLogOut() {
   );
 }
 
+// Hook without existing selector
+function HookWithoutExistingSelector() {
+  // const account = useAccount(MyAccount, {
+  //   resolve: { profile: true },
+  //   select: (account) => account.$isLoaded
+  //    ? account
+  //    : account.$jazz.loadingState === "loading"
+  //      ? undefined
+  //      : null
+  // });
+  const account = useAccount(MyAccount, {
+    resolve: { profile: true },
+      select: (account) => account.$isLoaded ? account : account.$jazz.loadingState === "loading" ? undefined : null
+});
+
+  return <div>{account?.profile?.name}</div>;
+}
+
+// Hook with existing selector
+function HookWithExistingSelector() {
+  // const profileName = useAccount(MyAccount, {
+  //   resolve: { profile: true },
+  //   select: (account) => account.$isLoaded
+  //    ? account.profile.name
+  //    : account.$jazz.loadingState === "loading"
+  //      ? undefined
+  //      : null
+  // });
+  const profileName = useAccount(MyAccount, {
+    resolve: { profile: true },
+    select: (account) => account.$isLoaded ? account.profile.name : account.$jazz.loadingState === "loading" ? undefined : null,
+  });
+
+  return <div>{profileName}</div>;
+}
+
+// Hook with no options argument at all
+function HookWithNoOptions() {
+  // Should add: useAccount() -> useAccount(undefined, { select: (me) => ... })
+  const me = useAccount(undefined, { select: (me) => me.$isLoaded ? me : me.$jazz.loadingState === "loading" ? undefined : null });
+
+  return <div>{me?.profile?.name}</div>;
+}
+
+// Hook with schema but no options
+function HookWithSchemaNoOptions() {
+  // Should add: useAccount(MyAccount) -> useAccount(undefined, { select: (account) => ... })
+  const account = useAccount(MyAccount, { select: (account) => account.$isLoaded ? account : account.$jazz.loadingState === "loading" ? undefined : null });
+
+  return <div>{account?.profile?.name}</div>;
+}
+
 export {
   ExampleOnErrorNull,
   ExampleCoState,
@@ -181,6 +234,10 @@ export {
   AliasedPattern,
   NoDestructuringPattern,
   NoDestructuringWithAccountAgentLogOut,
+  HookWithoutExistingSelector,
+  HookWithExistingSelector,
+  HookWithNoOptions,
+  HookWithSchemaNoOptions,
 };
 "
 `;

--- a/packages/codemod-upgrade-0-19/tests/__snapshots__/codemod.test.ts.snap
+++ b/packages/codemod-upgrade-0-19/tests/__snapshots__/codemod.test.ts.snap
@@ -189,8 +189,8 @@ function HookWithoutExistingSelector() {
   return <div>{account?.profile?.name}</div>;
 }
 
-// Hook with existing selector
-function HookWithExistingSelector() {
+// Hook with existing expression selector
+function HookWithExistingExpressionSelector() {
   // const profileName = useAccount(MyAccount, {
   //   resolve: { profile: true },
   //   select: (account) => account.$isLoaded
@@ -202,6 +202,19 @@ function HookWithExistingSelector() {
   const profileName = useAccount(MyAccount, {
     resolve: { profile: true },
     select: (account) => account.$isLoaded ? account.profile.name : account.$jazz.loadingState === "loading" ? undefined : null,
+  });
+
+  return <div>{profileName}</div>;
+}
+
+// Hook with existing block selector
+function HookWithExistingBlockSelector() {
+  // Skip migration for block body selectors
+  const profileName = useAccount(MyAccount, {
+    resolve: { profile: true },
+    select: (account) => {
+      return account?.profile.name;
+    },
   });
 
   return <div>{profileName}</div>;
@@ -238,7 +251,11 @@ async function MaybeLoadedCoValueIfCheck() {
 }
 
 // Nullability check on optional MaybeLoaded value
-async function OptionalMaybeLoadedCoValueIfCheck({ accountId }: { accountId?: string }) {
+async function OptionalMaybeLoadedCoValueIfCheck({
+  accountId,
+}: {
+  accountId?: string;
+}) {
   const optionalAccount = accountId
     ? await Account.load("account-id", {
         resolve: { profile: true },
@@ -265,7 +282,8 @@ export {
   NoDestructuringPattern,
   NoDestructuringWithAccountAgentLogOut,
   HookWithoutExistingSelector,
-  HookWithExistingSelector,
+  HookWithExistingExpressionSelector,
+  HookWithExistingBlockSelector,
   HookWithNoOptions,
   HookWithSchemaNoOptions,
   MaybeLoadedCoValueIfCheck,

--- a/packages/codemod-upgrade-0-19/tests/__snapshots__/codemod.test.ts.snap
+++ b/packages/codemod-upgrade-0-19/tests/__snapshots__/codemod.test.ts.snap
@@ -270,6 +270,24 @@ async function OptionalMaybeLoadedCoValueIfCheck({
   return optionalAccount.profile.name;
 }
 
+// Nullability check on nested MaybeLoaded value
+async function MaybeLoadedNestedCoValueIfCheck() {
+  const account = await Account.load("account-id", {
+    resolve: true,
+  });
+
+  if (!account.$isLoaded) {
+    return "Loading...";
+  }
+
+  // if (!account.profile.$isLoaded)
+  if (!account.profile.$isLoaded) {
+    return "Loading...";
+  }
+
+  return account.profile.name;
+}
+
 export {
   ExampleOnErrorNull,
   ExampleCoState,
@@ -288,6 +306,7 @@ export {
   HookWithSchemaNoOptions,
   MaybeLoadedCoValueIfCheck,
   OptionalMaybeLoadedCoValueIfCheck,
+  MaybeLoadedNestedCoValueIfCheck,
 };
 "
 `;

--- a/packages/codemod-upgrade-0-19/tests/__snapshots__/codemod.test.ts.snap
+++ b/packages/codemod-upgrade-0-19/tests/__snapshots__/codemod.test.ts.snap
@@ -1,0 +1,86 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`runTransform 1`] = `
+"// @ts-nocheck
+
+// Test file demonstrating Jazz hook patterns that will be migrated
+// This file shows examples of what the codemod will transform
+
+import {
+  useCoState,
+  useAccount,
+} from "jazz-tools/react";
+import { co, Account, z } from "jazz-tools";
+
+const TodoItem = co.map({
+  text: z.string(),
+  done: z.boolean(),
+});
+
+const TodoList = co.list(TodoItem);
+
+const MyAccount = co
+  .account({
+    root: co.map({ todos: TodoList }),
+    profile: co.profile(),
+  })
+  .withMigration(async (account) => {
+    if (!account.$jazz.has("root")) {
+      account.$jazz.set("root", { todos: [] });
+    }
+  });
+
+// Example 1: useCoStateWithSelector should become useCoState
+function ExampleCoState({ todoId }: { todoId: string }) {
+  const todo = useCoState(TodoItem, todoId, {
+    resolve: { text: true, done: true },
+    select: (todo) => (todo.$isLoaded ? todo : undefined),
+  });
+
+  return (
+    <div>
+      <span>{todo?.text}</span>
+      <input type="checkbox" checked={todo?.done} />
+    </div>
+  );
+}
+
+// Example 2: useAccountWithSelector should become useAccount
+function ExampleAccount() {
+  const todos = useAccount(MyAccount, {
+    resolve: { root: { todos: { $each: { $onError: null } } } },
+    select: (me) => me?.root.todos,
+  });
+
+  return (
+    <ul>
+      {todos?.map((todo) => (
+        <li key={todo.$jazz.id}>{todo.text}</li>
+      ))}
+    </ul>
+  );
+}
+
+// Example 3: Multiple usages in same component
+function ComplexComponent({ itemId }: { itemId: string }) {
+  const item = useCoState(TodoItem, itemId, {
+    resolve: { text: true },
+    select: (item) => item,
+  });
+
+  const account = useAccount(MyAccount, {
+    resolve: { root: true },
+    select: (me) => me,
+  });
+
+  return (
+    <div>
+      <h1>{item?.text}</h1>
+      <p>Owner: {account?.root?.owner}</p>
+    </div>
+  );
+}
+
+export { ExampleCoState, ExampleAccount, ComplexComponent };
+"
+`;

--- a/packages/codemod-upgrade-0-19/tests/codemod.test.ts
+++ b/packages/codemod-upgrade-0-19/tests/codemod.test.ts
@@ -1,0 +1,25 @@
+import { expect, onTestFinished, test } from "vitest";
+import { runTransform } from "../src/transform";
+import { readFileSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const currentDir = fileURLToPath(new URL(".", import.meta.url));
+
+test("runTransform", () => {
+  const fixturesBefore = readFileSync(
+    `${currentDir}/fixtures/test-example.tsx`,
+    "utf-8",
+  );
+  runTransform(`${currentDir}/fixtures`);
+
+  const result = readFileSync(
+    `${currentDir}/fixtures/test-example.tsx`,
+    "utf-8",
+  );
+
+  onTestFinished(() => {
+    writeFileSync(`${currentDir}/fixtures/test-example.tsx`, fixturesBefore);
+  });
+
+  expect(result).toMatchSnapshot();
+});

--- a/packages/codemod-upgrade-0-19/tests/fixtures/test-example.tsx
+++ b/packages/codemod-upgrade-0-19/tests/fixtures/test-example.tsx
@@ -214,6 +214,19 @@ function HookWithSchemaNoOptions() {
   return <div>{account?.profile?.name}</div>;
 }
 
+// Nullability check on MaybeLoaded value
+async function MaybeLoadedCoValueIfCheck() {
+  const account = await Account.load("account-id", {
+    resolve: { profile: true },
+  });
+
+  if (!account) {
+    return "Loading...";
+  }
+
+  return account.profile.name;
+}
+
 export {
   ExampleOnErrorNull,
   ExampleCoState,
@@ -229,4 +242,5 @@ export {
   HookWithExistingSelector,
   HookWithNoOptions,
   HookWithSchemaNoOptions,
+  MaybeLoadedCoValueIfCheck,
 };

--- a/packages/codemod-upgrade-0-19/tests/fixtures/test-example.tsx
+++ b/packages/codemod-upgrade-0-19/tests/fixtures/test-example.tsx
@@ -279,6 +279,79 @@ async function MaybeLoadedNestedCoValueIfCheck() {
   return account.profile.name;
 }
 
+// If with || operator
+async function MaybeLoadedOrCheck() {
+  const account = await Account.load("account-id", {
+    resolve: { profile: true },
+  });
+  const account2 = await Account.load("account-id-2", {
+    resolve: { profile: true },
+  });
+
+  // Should transform: if (!account.$isLoaded || !account2.$isLoaded)
+  if (!account || !account2) {
+    return "Loading...";
+  }
+
+  return account.profile.name;
+}
+
+// If with && operator
+async function MaybeLoadedAndCheck() {
+  const account = await Account.load("account-id", {
+    resolve: { profile: true },
+  });
+  const account2 = await Account.load("account-id-2");
+
+  // Should transform: if (account.$isLoaded && account2.$isLoaded)
+  if (account && account2) {
+    return account.profile.name;
+  }
+
+  return "Loading...";
+}
+
+// Complex if with mixed operators
+async function MaybeLoadedMixedCheck() {
+  const account = await Account.load("account-id");
+  const account2 = await Account.load("account-id-2");
+  const isAdmin = true;
+
+  // Should transform: if (account.$isLoaded && (account2.$isLoaded || isAdmin))
+  if (account && (account2 || isAdmin)) {
+    return "Loaded";
+  }
+
+  return "Loading...";
+}
+
+// Complex if with negation and &&
+async function MaybeLoadedNegationAndCheck() {
+  const account = await Account.load("account-id");
+  const account2 = await Account.load("account-id-2");
+
+  // Should transform: if (!account.$isLoaded && account2.$isLoaded)
+  if (!account && account2) {
+    return "Account not loaded but account2 is";
+  }
+
+  return "Other state";
+}
+
+// Complex if with parentheses
+async function MaybeLoadedParenthesesCheck() {
+  const account = await Account.load("account-id");
+  const account2 = await Account.load("account-id-2");
+  const ready = true;
+
+  // Should transform: if ((account.$isLoaded && account2.$isLoaded) || ready)
+  if ((account && account2) || ready) {
+    return "Ready or loaded";
+  }
+
+  return "Not ready";
+}
+
 export {
   ExampleOnErrorNull,
   ExampleCoState,
@@ -298,4 +371,9 @@ export {
   MaybeLoadedCoValueIfCheck,
   OptionalMaybeLoadedCoValueIfCheck,
   MaybeLoadedNestedCoValueIfCheck,
+  MaybeLoadedOrCheck,
+  MaybeLoadedAndCheck,
+  MaybeLoadedMixedCheck,
+  MaybeLoadedNegationAndCheck,
+  MaybeLoadedParenthesesCheck,
 };

--- a/packages/codemod-upgrade-0-19/tests/fixtures/test-example.tsx
+++ b/packages/codemod-upgrade-0-19/tests/fixtures/test-example.tsx
@@ -190,7 +190,7 @@ function HookWithExistingExpressionSelector() {
   //      ? undefined
   //      : null
   // });
-  const profileName = useAccount(MyAccount, {
+  const profileName = useAccountWithSelector(MyAccount, {
     resolve: { profile: true },
     select: (account) => account?.profile?.name,
   });
@@ -201,7 +201,7 @@ function HookWithExistingExpressionSelector() {
 // Hook with existing block selector
 function HookWithExistingBlockSelector() {
   // Skip migration for block body selectors
-  const profileName = useAccount(MyAccount, {
+  const profileName = useAccountWithSelector(MyAccount, {
     resolve: { profile: true },
     select: (account) => {
       return account?.profile.name;
@@ -267,7 +267,7 @@ async function MaybeLoadedNestedCoValueIfCheck() {
     resolve: true,
   });
 
-  if (!account.$isLoaded) {
+  if (!account) {
     return "Loading...";
   }
 

--- a/packages/codemod-upgrade-0-19/tests/fixtures/test-example.tsx
+++ b/packages/codemod-upgrade-0-19/tests/fixtures/test-example.tsx
@@ -28,6 +28,15 @@ const MyAccount = co
     }
   });
 
+// $onError: null should become $onError: 'catch'
+function ExampleOnErrorNull() {
+  const todo = useAccount(MyAccount, todoId, {
+    resolve: { root: { todos: { $each: { $onError: null } } } },
+  });
+
+  return <div>{todo?.text}</div>;
+}
+
 // useCoStateWithSelector should become useCoState
 function ExampleCoState({ todoId }: { todoId: string }) {
   // Should be transformed to useCoState
@@ -155,6 +164,7 @@ function NoDestructuringWithAccountAgentLogOut() {
 }
 
 export {
+  ExampleOnErrorNull,
   ExampleCoState,
   ExampleAccount,
   ComplexComponent,

--- a/packages/codemod-upgrade-0-19/tests/fixtures/test-example.tsx
+++ b/packages/codemod-upgrade-0-19/tests/fixtures/test-example.tsx
@@ -4,6 +4,7 @@
 // This file shows examples of what the codemod will transform
 
 import {
+  useAccount,
   useCoStateWithSelector,
   useAccountWithSelector,
 } from "jazz-tools/react";
@@ -27,8 +28,9 @@ const MyAccount = co
     }
   });
 
-// Example 1: useCoStateWithSelector should become useCoState
+// useCoStateWithSelector should become useCoState
 function ExampleCoState({ todoId }: { todoId: string }) {
+  // Should be transformed to useCoState
   const todo = useCoStateWithSelector(TodoItem, todoId, {
     resolve: { text: true, done: true },
     select: (todo) => (todo.$isLoaded ? todo : undefined),
@@ -42,8 +44,9 @@ function ExampleCoState({ todoId }: { todoId: string }) {
   );
 }
 
-// Example 2: useAccountWithSelector should become useAccount
+// useAccountWithSelector should become useAccount
 function ExampleAccount() {
+  // Should be transformed to useAccount
   const todos = useAccountWithSelector(MyAccount, {
     resolve: { root: { todos: { $each: { $onError: null } } } },
     select: (me) => me?.root.todos,
@@ -58,13 +61,15 @@ function ExampleAccount() {
   );
 }
 
-// Example 3: Multiple usages in same component
+// Multiple usages in same component
 function ComplexComponent({ itemId }: { itemId: string }) {
+  // Should be transformed to useCoState
   const item = useCoStateWithSelector(TodoItem, itemId, {
     resolve: { text: true },
     select: (item) => item,
   });
 
+  // Should be transformed to useAccount
   const account = useAccountWithSelector(MyAccount, {
     resolve: { root: true },
     select: (me) => me,
@@ -78,4 +83,85 @@ function ComplexComponent({ itemId }: { itemId: string }) {
   );
 }
 
-export { ExampleCoState, ExampleAccount, ComplexComponent };
+// Old useAccount pattern with destructuring { me, agent, logOut }
+function OldUseAccountPattern() {
+  // const me = useAccount();
+  // const agent = useAgent();
+  // const logOut = useLogOut();
+  const { me, agent, logOut } = useAccount();
+
+  return (
+    <div>
+      <p>User: {me?.profile?.name}</p>
+      <button onClick={logOut}>Log out</button>
+      <pre>{JSON.stringify(agent, null, 2)}</pre>
+    </div>
+  );
+}
+
+// Old useAccount pattern with only some properties
+function PartialUseAccountPattern() {
+  // const me = useAccount();
+  // const logOut = useLogOut();
+  const { me, logOut } = useAccount();
+
+  return (
+    <div>
+      <p>User: {me?.profile?.name}</p>
+      <button onClick={logOut}>Log out</button>
+    </div>
+  );
+}
+
+// Old useAccount pattern with only me
+function OnlyMePattern() {
+  // const me = useAccount();
+  const { me } = useAccount();
+
+  return <div>{me?.profile?.name}</div>;
+}
+
+// Old useAccount pattern with aliasing
+function AliasedPattern() {
+  // const currentUser = useAccount();
+  // const myAgent = useAgent();
+  const { me: currentUser, agent: myAgent } = useAccount();
+
+  return (
+    <div>
+      <p>{currentUser?.profile?.name}</p>
+      <pre>{JSON.stringify(myAgent, null, 2)}</pre>
+    </div>
+  );
+}
+
+// Old useAccount non-destructured pattern with account, agent and logOut
+function NoDestructuringWithAccountAgentLogOut() {
+  // const account = useAccount();
+  // const agent = useAgent();
+  // const logOut = useLogOut();
+  const account = useAccount();
+
+  return (
+    <div>
+      {/* account?.profile?.name */}
+      <p>{account.me?.profile?.name}</p>
+      {/* logOut */}
+      <button onClick={account.logOut}>Log out</button>
+      {/* agent */}
+      <pre>{JSON.stringify(account.agent, null, 2)}</pre>
+    </div>
+  );
+}
+
+export {
+  ExampleCoState,
+  ExampleAccount,
+  ComplexComponent,
+  OldUseAccountPattern,
+  PartialUseAccountPattern,
+  OnlyMePattern,
+  AliasedPattern,
+  NoDestructuringPattern,
+  NoDestructuringWithAccountAgentLogOut,
+};

--- a/packages/codemod-upgrade-0-19/tests/fixtures/test-example.tsx
+++ b/packages/codemod-upgrade-0-19/tests/fixtures/test-example.tsx
@@ -180,8 +180,8 @@ function HookWithoutExistingSelector() {
   return <div>{account?.profile?.name}</div>;
 }
 
-// Hook with existing selector
-function HookWithExistingSelector() {
+// Hook with existing expression selector
+function HookWithExistingExpressionSelector() {
   // const profileName = useAccount(MyAccount, {
   //   resolve: { profile: true },
   //   select: (account) => account.$isLoaded
@@ -193,6 +193,19 @@ function HookWithExistingSelector() {
   const profileName = useAccount(MyAccount, {
     resolve: { profile: true },
     select: (account) => account?.profile?.name,
+  });
+
+  return <div>{profileName}</div>;
+}
+
+// Hook with existing block selector
+function HookWithExistingBlockSelector() {
+  // Skip migration for block body selectors
+  const profileName = useAccount(MyAccount, {
+    resolve: { profile: true },
+    select: (account) => {
+      return account?.profile.name;
+    },
   });
 
   return <div>{profileName}</div>;
@@ -260,7 +273,8 @@ export {
   NoDestructuringPattern,
   NoDestructuringWithAccountAgentLogOut,
   HookWithoutExistingSelector,
-  HookWithExistingSelector,
+  HookWithExistingExpressionSelector,
+  HookWithExistingBlockSelector,
   HookWithNoOptions,
   HookWithSchemaNoOptions,
   MaybeLoadedCoValueIfCheck,

--- a/packages/codemod-upgrade-0-19/tests/fixtures/test-example.tsx
+++ b/packages/codemod-upgrade-0-19/tests/fixtures/test-example.tsx
@@ -30,11 +30,11 @@ const MyAccount = co
 
 // $onError: null should become $onError: 'catch'
 function ExampleOnErrorNull() {
-  const todo = useAccount(MyAccount, todoId, {
+  const { me } = useAccount(MyAccount, {
     resolve: { root: { todos: { $each: { $onError: null } } } },
   });
 
-  return <div>{todo?.text}</div>;
+  return <div>{me?.root.todos[0]?.text}</div>;
 }
 
 // useCoStateWithSelector should become useCoState
@@ -42,7 +42,7 @@ function ExampleCoState({ todoId }: { todoId: string }) {
   // Should be transformed to useCoState
   const todo = useCoStateWithSelector(TodoItem, todoId, {
     resolve: { text: true, done: true },
-    select: (todo) => (todo.$isLoaded ? todo : undefined),
+    select: (todo) => todo,
   });
 
   return (
@@ -163,6 +163,57 @@ function NoDestructuringWithAccountAgentLogOut() {
   );
 }
 
+// Hook without existing selector
+function HookWithoutExistingSelector() {
+  // const account = useAccount(MyAccount, {
+  //   resolve: { profile: true },
+  //   select: (account) => account.$isLoaded
+  //    ? account
+  //    : account.$jazz.loadingState === "loading"
+  //      ? undefined
+  //      : null
+  // });
+  const account = useAccount(MyAccount, {
+    resolve: { profile: true },
+  });
+
+  return <div>{account?.profile?.name}</div>;
+}
+
+// Hook with existing selector
+function HookWithExistingSelector() {
+  // const profileName = useAccount(MyAccount, {
+  //   resolve: { profile: true },
+  //   select: (account) => account.$isLoaded
+  //    ? account.profile.name
+  //    : account.$jazz.loadingState === "loading"
+  //      ? undefined
+  //      : null
+  // });
+  const profileName = useAccount(MyAccount, {
+    resolve: { profile: true },
+    select: (account) => account?.profile?.name,
+  });
+
+  return <div>{profileName}</div>;
+}
+
+// Hook with no options argument at all
+function HookWithNoOptions() {
+  // Should add: useAccount() -> useAccount(undefined, { select: (me) => ... })
+  const me = useAccount();
+
+  return <div>{me?.profile?.name}</div>;
+}
+
+// Hook with schema but no options
+function HookWithSchemaNoOptions() {
+  // Should add: useAccount(MyAccount) -> useAccount(undefined, { select: (account) => ... })
+  const account = useAccount(MyAccount);
+
+  return <div>{account?.profile?.name}</div>;
+}
+
 export {
   ExampleOnErrorNull,
   ExampleCoState,
@@ -174,4 +225,8 @@ export {
   AliasedPattern,
   NoDestructuringPattern,
   NoDestructuringWithAccountAgentLogOut,
+  HookWithoutExistingSelector,
+  HookWithExistingSelector,
+  HookWithNoOptions,
+  HookWithSchemaNoOptions,
 };

--- a/packages/codemod-upgrade-0-19/tests/fixtures/test-example.tsx
+++ b/packages/codemod-upgrade-0-19/tests/fixtures/test-example.tsx
@@ -261,6 +261,24 @@ async function OptionalMaybeLoadedCoValueIfCheck({
   return optionalAccount.profile.name;
 }
 
+// Nullability check on nested MaybeLoaded value
+async function MaybeLoadedNestedCoValueIfCheck() {
+  const account = await Account.load("account-id", {
+    resolve: true,
+  });
+
+  if (!account.$isLoaded) {
+    return "Loading...";
+  }
+
+  // if (!account.profile.$isLoaded)
+  if (!account.profile) {
+    return "Loading...";
+  }
+
+  return account.profile.name;
+}
+
 export {
   ExampleOnErrorNull,
   ExampleCoState,
@@ -279,4 +297,5 @@ export {
   HookWithSchemaNoOptions,
   MaybeLoadedCoValueIfCheck,
   OptionalMaybeLoadedCoValueIfCheck,
+  MaybeLoadedNestedCoValueIfCheck,
 };

--- a/packages/codemod-upgrade-0-19/tests/fixtures/test-example.tsx
+++ b/packages/codemod-upgrade-0-19/tests/fixtures/test-example.tsx
@@ -1,0 +1,81 @@
+// @ts-nocheck
+
+// Test file demonstrating Jazz hook patterns that will be migrated
+// This file shows examples of what the codemod will transform
+
+import {
+  useCoStateWithSelector,
+  useAccountWithSelector,
+} from "jazz-tools/react";
+import { co, Account, z } from "jazz-tools";
+
+const TodoItem = co.map({
+  text: z.string(),
+  done: z.boolean(),
+});
+
+const TodoList = co.list(TodoItem);
+
+const MyAccount = co
+  .account({
+    root: co.map({ todos: TodoList }),
+    profile: co.profile(),
+  })
+  .withMigration(async (account) => {
+    if (!account.$jazz.has("root")) {
+      account.$jazz.set("root", { todos: [] });
+    }
+  });
+
+// Example 1: useCoStateWithSelector should become useCoState
+function ExampleCoState({ todoId }: { todoId: string }) {
+  const todo = useCoStateWithSelector(TodoItem, todoId, {
+    resolve: { text: true, done: true },
+    select: (todo) => (todo.$isLoaded ? todo : undefined),
+  });
+
+  return (
+    <div>
+      <span>{todo?.text}</span>
+      <input type="checkbox" checked={todo?.done} />
+    </div>
+  );
+}
+
+// Example 2: useAccountWithSelector should become useAccount
+function ExampleAccount() {
+  const todos = useAccountWithSelector(MyAccount, {
+    resolve: { root: { todos: { $each: { $onError: null } } } },
+    select: (me) => me?.root.todos,
+  });
+
+  return (
+    <ul>
+      {todos?.map((todo) => (
+        <li key={todo.$jazz.id}>{todo.text}</li>
+      ))}
+    </ul>
+  );
+}
+
+// Example 3: Multiple usages in same component
+function ComplexComponent({ itemId }: { itemId: string }) {
+  const item = useCoStateWithSelector(TodoItem, itemId, {
+    resolve: { text: true },
+    select: (item) => item,
+  });
+
+  const account = useAccountWithSelector(MyAccount, {
+    resolve: { root: true },
+    select: (me) => me,
+  });
+
+  return (
+    <div>
+      <h1>{item?.text}</h1>
+      <p>Owner: {account?.root?.owner}</p>
+    </div>
+  );
+}
+
+export { ExampleCoState, ExampleAccount, ComplexComponent };

--- a/packages/codemod-upgrade-0-19/tests/fixtures/test-example.tsx
+++ b/packages/codemod-upgrade-0-19/tests/fixtures/test-example.tsx
@@ -220,11 +220,32 @@ async function MaybeLoadedCoValueIfCheck() {
     resolve: { profile: true },
   });
 
+  // if (!account.$isLoaded)
   if (!account) {
     return "Loading...";
   }
 
   return account.profile.name;
+}
+
+// Nullability check on optional MaybeLoaded value
+async function OptionalMaybeLoadedCoValueIfCheck({
+  accountId,
+}: {
+  accountId?: string;
+}) {
+  const optionalAccount = accountId
+    ? await Account.load("account-id", {
+        resolve: { profile: true },
+      })
+    : undefined;
+
+  // if (!optionalAccount?.$isLoaded)
+  if (!optionalAccount) {
+    return "Loading...";
+  }
+
+  return optionalAccount.profile.name;
 }
 
 export {
@@ -243,4 +264,5 @@ export {
   HookWithNoOptions,
   HookWithSchemaNoOptions,
   MaybeLoadedCoValueIfCheck,
+  OptionalMaybeLoadedCoValueIfCheck,
 };

--- a/packages/codemod-upgrade-0-19/tsconfig.json
+++ b/packages/codemod-upgrade-0-19/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "noEmit": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "module": "ESNext",
+    "target": "ES2020"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/codemod-upgrade-0-19/tsdown.config.ts
+++ b/packages/codemod-upgrade-0-19/tsdown.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  clean: true,
+  dts: true,
+  splitting: false,
+});

--- a/packages/codemod-upgrade-0-19/vitest.config.ts
+++ b/packages/codemod-upgrade-0-19/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    include: ["tests/**/*.test.ts"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2048,6 +2048,19 @@ importers:
         specifier: catalog:default
         version: 5.6.2
 
+  packages/codemod-upgrade-0-19:
+    dependencies:
+      ts-morph:
+        specifier: ^26.0.0
+        version: 26.0.0
+    devDependencies:
+      tsdown:
+        specifier: ^0.11.9
+        version: 0.11.13(typescript@5.6.2)(vue-tsc@2.2.12(typescript@5.6.2))
+      typescript:
+        specifier: catalog:default
+        version: 5.6.2
+
   packages/cojson:
     dependencies:
       '@noble/ciphers':


### PR DESCRIPTION
# Description

This codemod applies the following changes introduced in https://github.com/garden-co/jazz/pull/3001 to codebases that have just upgraded from jazz-tools `0.18.X` to `0.19.0`:
- renames `useAccountWithSelector` and `useCoStateWithSelector` to `useAccount` and `useCoState`, respectively
- splits `useAccount` into `useAccount` + `useLogOut` + `useAgent`
- replaces `$onError: null` with `$onError: 'catch'`
- adds a `select` function to all useAccount/useCoState hooks that converts values with explicit loading states into `CoValue | null | undefined` 
- migrates null-checks against MaybeLoaded CoValues (i.e. `if (coValue)` and `if (!coValue)`) to use `coValue.$isLoaded`

It **does not** handle loading state checks for nested CoValues (both when these CoValues are not loaded and require autoload, and when using `$onError: 'catch'`) nor `CoValueSchema.load()` calls, unless the maybe-loaded coValue is used in a `if (coValue)` or `if (!coValue)` check.

Selectors with block function bodies from existing `useAccountWithSelector` and `useCoStateWithSelector` hooks are not migrated either.

## Manual testing instructions

You can try out this codemod using the pre-release package (use the link for the latest pre-release in this PR):
```bash
npx https://pkg.pr.new/garden-co/jazz/jazz-tools-codemod-0-19@a487b86df4887c6158798f963c07082cee2078e4
```

## Tests

- [x] Tests have been added and/or updated

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a codemod to migrate projects to jazz-tools 0.19 (hooks rename/split, `$onError` change, explicit loading states) and updates docs with an upgrade guide and examples.
> 
> - **Tooling: 0.19 Codemod (`packages/codemod-upgrade-0-19`)**
>   - CLI to transform codebases using `ts-morph`.
>   - Migrates `useAccountWithSelector` → `useAccount`, `useCoStateWithSelector` → `useCoState`.
>   - Splits `useAccount` destructuring into `useAccount`, `useAgent`, `useLogOut` and updates usages.
>   - Rewrites `$onError: null` → `$onError: 'catch'`.
>   - Adds `select` mappers to hooks to normalize explicit loading states to `CoValue | null | undefined`.
>   - Converts `if (coValue)`/`if (!coValue)` to `.$isLoaded` checks; handles logical expressions.
>   - Includes tests, README, changelog, and build/test configs.
> - **Docs**
>   - Add upgrade guide `docs/upgrade/0-19-0.mdx` and nav entry.
>   - Expand subscription/loading docs with `$isLoaded`, `$jazz.loadingState`, schema-level `.resolved()` queries, and selector/equality examples.
>   - Testing docs: use `assertLoaded` in examples and minor fixes.
> - **Changeset**
>   - Notes explicit loading states, hook changes, selector support, and schema-level resolve queries.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f573a3038552d97e47b59e5b70be0566f3818afb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->