### PR TITLE
Grey out quickstarts for RN

### DIFF
--- a/homepage/homepage/content/docs/docNavigationItems.js
+++ b/homepage/homepage/content/docs/docNavigationItems.js
@@ -225,9 +225,9 @@ export const docNavigationItems = [
           name: "Quickstart",
           href: "/docs/key-features/authentication/quickstart",
           done: {
-          react: 100,
-          svelte: 100
-        },
+            react: 100,
+            svelte: 100
+          },
         },
 
         {
@@ -280,9 +280,9 @@ export const docNavigationItems = [
           name: "Sharing",
           href: "/docs/permissions-and-sharing/sharing",
           done: {
-          react: 100,
-          svelte: 100
-        }
+            react: 100,
+            svelte: 100
+          }
         },
         {
           name: "Cascading Permissions",
@@ -310,9 +310,9 @@ export const docNavigationItems = [
       name: "Quickstart",
       href: "/docs/server-side/quickstart",
       done: {
-          react: 100,
-          svelte: 100
-        }
+        react: 100,
+        svelte: 100
+      }
     },
     {
       name: "Setup",
@@ -329,7 +329,7 @@ export const docNavigationItems = [
         name: "Overview",
         href: "/docs/server-side/communicating-with-workers/overview",
         done: 100,
-      },{
+      }, {
         name: "JazzRPC",
         href: "/docs/server-side/jazz-rpc",
         done: 100,

--- a/homepage/homepage/content/docs/docNavigationItems.js
+++ b/homepage/homepage/content/docs/docNavigationItems.js
@@ -13,7 +13,10 @@ export const docNavigationItems = [
       }, {
         name: "Quickstart",
         href: "/docs/quickstart",
-        done: 100,
+        done: {
+          react: 100,
+          svelte: 100
+        }
       },
       {
         name: "Installation",
@@ -221,7 +224,10 @@ export const docNavigationItems = [
         {
           name: "Quickstart",
           href: "/docs/key-features/authentication/quickstart",
-          done: 100,
+          done: {
+          react: 100,
+          svelte: 100
+        },
         },
 
         {
@@ -273,7 +279,10 @@ export const docNavigationItems = [
         {
           name: "Sharing",
           href: "/docs/permissions-and-sharing/sharing",
-          done: 100,
+          done: {
+          react: 100,
+          svelte: 100
+        }
         },
         {
           name: "Cascading Permissions",
@@ -300,7 +309,10 @@ export const docNavigationItems = [
     items: [{
       name: "Quickstart",
       href: "/docs/server-side/quickstart",
-      done: 100,
+      done: {
+          react: 100,
+          svelte: 100
+        }
     },
     {
       name: "Setup",


### PR DESCRIPTION
# Description
Quickstarts are only available for React and Svelte. This PR greys them out in the nav until they're available for all frameworks

## Manual testing instructions
Switch to RN or Expo and check quickstarts are hidden.

## Tests

- [ ] Tests have been added and/or updated
- [x] Tests have not been updated, because: N/A
- [ ] I need help with writing tests


## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [ ] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing