### PR TITLE
Feat/adding delete packing co plaintext

### DIFF
--- a/bench/colist.pack.bench.ts
+++ b/bench/colist.pack.bench.ts
@@ -902,3 +902,381 @@ describe("Summary - Pack ON vs Pack OFF space savings\n", () => {
     bench("baseline - show summary", () => {});
   });
 });
+
+// ============================================================================
+// SECTION 7: COPLAINTEXT DELETE OPERATIONS - Pack ON vs OFF comparison
+// ============================================================================
+
+describe("CoPlainText - Delete Operations Pack ON vs Pack OFF\n", () => {
+  const account = cojson.LocalNode.internalCreateAccount({ crypto });
+  const group = account.core.node.createGroup();
+
+  describe("Delete 10 characters from text\n", () => {
+    const initialText = "The quick brown fox jumps over the lazy dog";
+
+    // Delete with pack enabled
+    const textPack = group.createPlainText("", null, "private");
+    textPack.insertAfter(-1, initialText, "private", {
+      disablePacking: false,
+    });
+    textPack.deleteRange({ from: 0, to: 10 }, "private");
+    const contentPack =
+      textPack.core.verified?.newContentSince(undefined) ?? [];
+    const packedSize = measureContentSize(contentPack);
+
+    // Delete with pack disabled
+    const textNoPack = group.createPlainText("", null, "private");
+    textNoPack.insertAfter(-1, initialText, "private", {
+      disablePacking: true,
+    });
+    textNoPack.deleteRange({ from: 0, to: 10 }, "private", {
+      disablePacking: true,
+    });
+
+    const contentNoPack =
+      textNoPack.core.verified?.newContentSince(undefined) ?? [];
+    const noPackSize = measureContentSize(contentNoPack);
+
+    const savings = calculateSavings(noPackSize, packedSize);
+
+    describe(`Delete Pack ON: ${packedSize}b | Pack OFF: ${noPackSize}b | Savings: ${savings}%\n`, () => {
+      bench(
+        "delete 10 chars with pack=true",
+        () => {
+          const tempText = group.createPlainText("", null, "private");
+          tempText.insertAfter(-1, initialText, "private", {
+            disablePacking: false,
+          });
+          tempText.deleteRange({ from: 0, to: 10 }, "private");
+        },
+        { iterations: 1000 },
+      );
+
+      bench(
+        "delete 10 chars with pack=false",
+        () => {
+          const tempText = group.createPlainText("", null, "private");
+          tempText.insertAfter(-1, initialText, "private", {
+            disablePacking: true,
+          });
+          tempText.deleteRange({ from: 0, to: 10 }, "private", {
+            disablePacking: true,
+          });
+        },
+        { iterations: 1000 },
+      );
+    });
+  });
+
+  describe("Delete 50 characters from text\n", () => {
+    const article = generateRealisticArticle(5);
+    const initialText = article.slice(0, 200);
+
+    // Delete with pack enabled
+    const textPack = group.createPlainText("", null, "private");
+    textPack.insertAfter(-1, initialText, "private", {
+      disablePacking: false,
+    });
+    textPack.deleteRange({ from: 20, to: 70 }, "private");
+    const contentPack =
+      textPack.core.verified?.newContentSince(undefined) ?? [];
+    const packedSize = measureContentSize(contentPack);
+
+    // Delete with pack disabled
+    const textNoPack = group.createPlainText("", null, "private");
+    textNoPack.insertAfter(-1, initialText, "private", {
+      disablePacking: true,
+    });
+    textNoPack.deleteRange({ from: 20, to: 70 }, "private", {
+      disablePacking: true,
+    });
+
+    const contentNoPack =
+      textNoPack.core.verified?.newContentSince(undefined) ?? [];
+    const noPackSize = measureContentSize(contentNoPack);
+
+    const savings = calculateSavings(noPackSize, packedSize);
+
+    describe(`Delete Pack ON: ${packedSize}b | Pack OFF: ${noPackSize}b | Savings: ${savings}%\n`, () => {
+      bench(
+        "delete 50 chars with pack=true",
+        () => {
+          const tempText = group.createPlainText("", null, "private");
+          tempText.insertAfter(-1, initialText, "private", {
+            disablePacking: false,
+          });
+          tempText.deleteRange({ from: 20, to: 70 }, "private");
+        },
+        { iterations: 500 },
+      );
+
+      bench(
+        "delete 50 chars with pack=false",
+        () => {
+          const tempText = group.createPlainText("", null, "private");
+          tempText.insertAfter(-1, initialText, "private", {
+            disablePacking: true,
+          });
+          tempText.deleteRange({ from: 20, to: 70 }, "private", {
+            disablePacking: true,
+          });
+        },
+        { iterations: 500 },
+      );
+    });
+  });
+
+  describe("Delete 100 characters from text\n", () => {
+    const article = generateRealisticArticle(10);
+    const initialText = article.slice(0, 500);
+
+    // Delete with pack enabled
+    const textPack = group.createPlainText("", null, "private");
+    textPack.insertAfter(-1, initialText, "private", {
+      disablePacking: false,
+    });
+    textPack.deleteRange({ from: 50, to: 150 }, "private");
+    const contentPack =
+      textPack.core.verified?.newContentSince(undefined) ?? [];
+    const packedSize = measureContentSize(contentPack);
+
+    // Delete with pack disabled
+    const textNoPack = group.createPlainText("", null, "private");
+    textNoPack.insertAfter(-1, initialText, "private", {
+      disablePacking: true,
+    });
+    textNoPack.deleteRange({ from: 50, to: 150 }, "private", {
+      disablePacking: true,
+    });
+
+    const contentNoPack =
+      textNoPack.core.verified?.newContentSince(undefined) ?? [];
+    const noPackSize = measureContentSize(contentNoPack);
+
+    const savings = calculateSavings(noPackSize, packedSize);
+
+    describe(`Delete Pack ON: ${packedSize}b | Pack OFF: ${noPackSize}b | Savings: ${savings}%\n`, () => {
+      bench(
+        "delete 100 chars with pack=true",
+        () => {
+          const tempText = group.createPlainText("", null, "private");
+          tempText.insertAfter(-1, initialText, "private", {
+            disablePacking: false,
+          });
+          tempText.deleteRange({ from: 50, to: 150 }, "private");
+        },
+        { iterations: 500 },
+      );
+
+      bench(
+        "delete 100 chars with pack=false",
+        () => {
+          const tempText = group.createPlainText("", null, "private");
+          tempText.insertAfter(-1, initialText, "private", {
+            disablePacking: true,
+          });
+          tempText.deleteRange({ from: 50, to: 150 }, "private", {
+            disablePacking: true,
+          });
+        },
+        { iterations: 500 },
+      );
+    });
+  });
+
+  describe("Delete 250 characters from large text\n", () => {
+    const article = generateRealisticArticle(20);
+    const initialText = article.slice(0, 1000);
+
+    // Delete with pack enabled
+    const textPack = group.createPlainText("", null, "private");
+    textPack.insertAfter(-1, initialText, "private", {
+      disablePacking: false,
+    });
+    textPack.deleteRange({ from: 100, to: 350 }, "private");
+    const contentPack =
+      textPack.core.verified?.newContentSince(undefined) ?? [];
+    const packedSize = measureContentSize(contentPack);
+
+    // Delete with pack disabled
+    const textNoPack = group.createPlainText("", null, "private");
+    textNoPack.insertAfter(-1, initialText, "private", {
+      disablePacking: true,
+    });
+    textNoPack.deleteRange({ from: 100, to: 350 }, "private", {
+      disablePacking: true,
+    });
+
+    const contentNoPack =
+      textNoPack.core.verified?.newContentSince(undefined) ?? [];
+    const noPackSize = measureContentSize(contentNoPack);
+
+    const savings = calculateSavings(noPackSize, packedSize);
+
+    describe(`Delete Pack ON: ${packedSize}b | Pack OFF: ${noPackSize}b | Savings: ${savings}%\n`, () => {
+      bench(
+        "delete 250 chars with pack=true",
+        () => {
+          const tempText = group.createPlainText("", null, "private");
+          tempText.insertAfter(-1, initialText, "private", {
+            disablePacking: false,
+          });
+          tempText.deleteRange({ from: 100, to: 350 }, "private");
+        },
+        { iterations: 200 },
+      );
+
+      bench(
+        "delete 250 chars with pack=false",
+        () => {
+          const tempText = group.createPlainText("", null, "private");
+          tempText.insertAfter(-1, initialText, "private", {
+            disablePacking: true,
+          });
+          tempText.deleteRange({ from: 100, to: 350 }, "private", {
+            disablePacking: true,
+          });
+        },
+        { iterations: 200 },
+      );
+    });
+  });
+
+  describe("Multiple small deletes (5 deletes of 10 chars each)\n", () => {
+    const initialText = generateRealisticArticle(5).slice(0, 300);
+
+    // Multiple deletes with pack enabled
+    const textPack = group.createPlainText("", null, "private");
+    textPack.insertAfter(-1, initialText, "private", {
+      disablePacking: false,
+    });
+
+    // Perform 5 delete operations
+    for (let i = 0; i < 5; i++) {
+      textPack.deleteRange({ from: 20, to: 30 }, "private");
+    }
+
+    const contentPack =
+      textPack.core.verified?.newContentSince(undefined) ?? [];
+    const packedSize = measureContentSize(contentPack);
+
+    // Multiple deletes with pack disabled
+    const textNoPack = group.createPlainText("", null, "private");
+    textNoPack.insertAfter(-1, initialText, "private", {
+      disablePacking: true,
+    });
+
+    // Perform 5 delete operations
+    for (let i = 0; i < 5; i++) {
+      textNoPack.deleteRange({ from: 20, to: 30 }, "private", {
+        disablePacking: true,
+      });
+    }
+
+    const contentNoPack =
+      textNoPack.core.verified?.newContentSince(undefined) ?? [];
+    const noPackSize = measureContentSize(contentNoPack);
+
+    const savings = calculateSavings(noPackSize, packedSize);
+
+    describe(`Multiple Delete Pack ON: ${packedSize}b | Pack OFF: ${noPackSize}b | Savings: ${savings}%\n`, () => {
+      bench(
+        "5 deletes with pack=true",
+        () => {
+          const tempText = group.createPlainText("", null, "private");
+          tempText.insertAfter(-1, initialText, "private", {
+            disablePacking: false,
+          });
+          for (let i = 0; i < 5; i++) {
+            tempText.deleteRange({ from: 20, to: 30 }, "private");
+          }
+        },
+        { iterations: 200 },
+      );
+
+      bench(
+        "5 deletes with pack=false",
+        () => {
+          const tempText = group.createPlainText("", null, "private");
+          tempText.insertAfter(-1, initialText, "private", {
+            disablePacking: true,
+          });
+          for (let i = 0; i < 5; i++) {
+            tempText.deleteRange({ from: 20, to: 30 }, "private", {
+              disablePacking: true,
+            });
+          }
+        },
+        { iterations: 200 },
+      );
+    });
+  });
+});
+
+// ============================================================================
+// SECTION 8: COPLAINTEXT DELETE SUMMARY
+// ============================================================================
+
+describe("Summary - CoPlainText Delete Operations space savings\n", () => {
+  const account = cojson.LocalNode.internalCreateAccount({ crypto });
+  const group = account.core.node.createGroup();
+
+  const deleteScenarios = [
+    { name: "10 chars", from: 0, to: 10, textSize: 100 },
+    { name: "50 chars", from: 20, to: 70, textSize: 200 },
+    { name: "100 chars", from: 50, to: 150, textSize: 500 },
+    { name: "250 chars", from: 100, to: 350, textSize: 1000 },
+  ];
+
+  const deleteResults = deleteScenarios.map(({ name, from, to, textSize }) => {
+    const article = generateRealisticArticle(20);
+    const initialText = article.slice(0, textSize);
+
+    // Delete with pack ON
+    const textPack = group.createPlainText("", null, "private");
+    textPack.insertAfter(-1, initialText, "private", {
+      disablePacking: false,
+    });
+    textPack.deleteRange({ from, to }, "private");
+    const contentPack =
+      textPack.core.verified?.newContentSince(undefined) ?? [];
+    const packedSize = measureContentSize(contentPack);
+
+    // Delete with pack OFF
+    const textNoPack = group.createPlainText("", null, "private");
+    textNoPack.insertAfter(-1, initialText, "private", {
+      disablePacking: true,
+    });
+    textNoPack.deleteRange({ from, to }, "private", {
+      disablePacking: true,
+    });
+
+    const contentNoPack =
+      textNoPack.core.verified?.newContentSince(undefined) ?? [];
+    const noPackSize = measureContentSize(contentNoPack);
+
+    const savings = calculateSavings(noPackSize, packedSize);
+
+    return { name, packedSize, noPackSize, savings };
+  });
+
+  const summaryLines = [
+    "=== CoPlainText Delete Operations - Space Savings Summary ===",
+    "",
+    "Delete operations (deleteRange):",
+    ...deleteResults.map(
+      ({ name, noPackSize, packedSize, savings }) =>
+        `  ${name.padEnd(12)}: Pack OFF ${noPackSize.toString().padStart(6)}b → Pack ON ${packedSize.toString().padStart(6)}b (${savings}% savings)`,
+    ),
+    "",
+    "Key Findings:",
+    "- Delete packing significantly reduces transaction size",
+    "- Larger delete ranges show more substantial savings",
+    "- Pack format: [first_delete_op, ...insertion_ids] vs individual delete ops",
+    "- Critical for collaborative editing with frequent deletions",
+  ].join("\n");
+
+  describe(`${summaryLines}\n`, () => {
+    bench("baseline - show delete summary", () => {});
+  });
+});

--- a/packages/cojson/src/coValues/coList.ts
+++ b/packages/cojson/src/coValues/coList.ts
@@ -219,11 +219,11 @@ export class RawCoList<
         madeAt,
       );
 
-      const changesDecompacted = this.pack.unpackChanges(
+      const changesUnpacked = this.pack.unpackChanges(
         changes as Packed | ListOpPayload<Item>[],
       );
 
-      for (const [changeIdx, change] of changesDecompacted.entries()) {
+      for (const [changeIdx, change] of changesUnpacked.entries()) {
         const opID = {
           sessionID: txID.sessionID,
           txIndex: txID.txIndex,

--- a/packages/cojson/src/coValues/coList.ts
+++ b/packages/cojson/src/coValues/coList.ts
@@ -52,6 +52,7 @@ type DeletionEntry = {
 export class RawCoList<
   Item extends JsonValue = JsonValue,
   Meta extends JsonObject | null = null,
+  Packed extends JsonValue[] = PackedChanges<Item>,
 > implements RawCoValue
 {
   /** @category 6. Meta */
@@ -98,13 +99,10 @@ export class RawCoList<
 
   lastValidTransaction: number | undefined;
 
-  pack: CoListPack<Item, PackedChanges<Item>>;
+  pack: CoListPack<Item, Packed>;
 
   /** @internal */
-  constructor(
-    core: AvailableCoValueCore,
-    pack: CoListPack<Item, PackedChanges<Item>>,
-  ) {
+  constructor(core: AvailableCoValueCore, pack: CoListPack<Item, Packed>) {
     this.id = core.id as CoID<this>;
     this.core = core;
 
@@ -222,7 +220,7 @@ export class RawCoList<
       );
 
       const changesDecompacted = this.pack.unpackChanges(
-        changes as PackedChanges<Item> | ListOpPayload<Item>[],
+        changes as Packed | ListOpPayload<Item>[],
       );
 
       for (const [changeIdx, change] of changesDecompacted.entries()) {

--- a/packages/cojson/src/coValues/coPlainText.ts
+++ b/packages/cojson/src/coValues/coPlainText.ts
@@ -180,6 +180,9 @@ export class RawCoPlainText<
   deleteRange(
     { from, to }: { from: number; to: number },
     privacy: "private" | "trusting" = "private",
+    options?: {
+      disablePacking?: boolean;
+    },
   ) {
     const ops: DeletionOpPayload[] = [];
     for (let idx = from; idx < to; ) {
@@ -197,7 +200,10 @@ export class RawCoPlainText<
       }
       idx = nextIdx;
     }
-    this.core.makeTransaction(ops, privacy);
+    this.core.makeTransaction(
+      options?.disablePacking ? ops : this.pack.packChanges(ops),
+      privacy,
+    );
     this.processNewTransactions();
   }
 

--- a/packages/cojson/src/coValues/coPlainText.ts
+++ b/packages/cojson/src/coValues/coPlainText.ts
@@ -3,7 +3,10 @@ import { AvailableCoValueCore } from "../coValueCore/coValueCore.js";
 import { TRANSACTION_CONFIG } from "../config.js";
 import { JsonObject } from "../jsonValue.js";
 import { DeletionOpPayload, OpID, RawCoList } from "./coList.js";
-import { CoPlainTextPackImplementation } from "../pack/coPlainText.js";
+import {
+  CoPlainTextPackImplementation,
+  PackedChangesCoPlainText,
+} from "../pack/coPlainText.js";
 
 export type StringifiedOpID = string & { __stringifiedOpID: true };
 
@@ -47,7 +50,7 @@ type PlaintextIdxMapping = {
  */
 export class RawCoPlainText<
   Meta extends JsonObject | null = JsonObject | null,
-> extends RawCoList<string, Meta> {
+> extends RawCoList<string, Meta, PackedChangesCoPlainText> {
   /** @category 6. Meta */
   type = "coplaintext" as const;
 

--- a/packages/cojson/src/pack/coList.ts
+++ b/packages/cojson/src/pack/coList.ts
@@ -8,7 +8,7 @@ export type PackedChanges<T extends JsonValue> = [
 
 export interface CoListPack<
   Item extends JsonValue,
-  PackedItems extends JsonValue[],
+  PackedItems extends JsonValue[] = PackedChanges<Item>,
 > {
   packChanges(
     changes: ListOpPayload<Item>[],

--- a/packages/cojson/src/pack/coPlainText.ts
+++ b/packages/cojson/src/pack/coPlainText.ts
@@ -1,10 +1,22 @@
 import { splitGraphemes } from "unicode-segmenter/grapheme";
-import { AppOpPayload, ListOpPayload, OpID } from "../coValues/coList.js";
+import {
+  AppOpPayload,
+  DeletionOpPayload,
+  ListOpPayload,
+  OpID,
+} from "../coValues/coList.js";
 import { CoListPack } from "./coList.js";
 
-export type PackedChangesCoPlainText = [
+export type PackedChangesCoPlainText = PackedChangesApp | PackedChangesDel;
+
+export type PackedChangesApp = [
   AppOpPayload<string> & { compacted: true },
   string,
+];
+
+export type PackedChangesDel = [
+  DeletionOpPayload & { compacted: true },
+  ...OpID[],
 ];
 
 /**
@@ -23,31 +35,54 @@ export class CoPlainTextPackImplementation
 
     const firstElement = changes[0];
 
-    if (firstElement?.op !== "app") {
+    if (firstElement?.op !== "app" && firstElement?.op !== "del") {
       return changes;
     }
 
-    // Check if all changes are app operations with the same after reference
-    for (const change of changes) {
-      if (change.op !== "app" || change.after !== firstElement.after) {
-        return changes;
+    if (firstElement?.op === "app") {
+      for (const change of changes) {
+        if (change.op !== "app" || change.after !== firstElement.after) {
+          return changes;
+        }
       }
+
+      const firstElementCompacted = firstElement as AppOpPayload<string> & {
+        compacted: true;
+      };
+      // Set the compacted flag to true
+      firstElementCompacted.compacted = true;
+
+      // Return the compacted changes and the joined string
+      return [
+        firstElementCompacted,
+        (changes as AppOpPayload<string>[])
+          .slice(1)
+          .map((change) => change.value)
+          .join(""),
+      ];
+    } else if (firstElement?.op === "del") {
+      // Check if all changes are deletion operations
+      for (const change of changes) {
+        if (change.op !== "del") {
+          return changes;
+        }
+      }
+
+      const firstElementCompacted = firstElement as DeletionOpPayload & {
+        compacted: true;
+      };
+      // Set the compacted flag to true
+      firstElementCompacted.compacted = true;
+
+      return [
+        firstElementCompacted,
+        ...(changes as DeletionOpPayload[])
+          .slice(1)
+          .map((change) => change.insertion),
+      ];
     }
 
-    const firstElementCompacted = firstElement as AppOpPayload<string> & {
-      compacted: true;
-    };
-    // Set the compacted flag to true
-    firstElementCompacted.compacted = true;
-
-    // Return the compacted changes and the joined string
-    return [
-      firstElementCompacted,
-      (changes as AppOpPayload<string>[])
-        .slice(1)
-        .map((change) => change.value)
-        .join(""),
-    ];
+    return changes;
   }
 
   unpackChanges(
@@ -58,13 +93,29 @@ export class CoPlainTextPackImplementation
     }
 
     // Check if the first element is compacted
-    const firstElement = changes[0] as AppOpPayload<string> & {
+    const firstElement = changes[0] as (
+      | AppOpPayload<string>
+      | DeletionOpPayload
+    ) & {
       compacted: true;
     };
 
     // Check if the first element is compacted
     if (!firstElement?.compacted) {
       return changes as ListOpPayload<string>[];
+    }
+
+    // If the first element is a deletion, return the unpacked changes and the deletions
+    if (firstElement?.op === "del") {
+      return [
+        firstElement,
+        ...changes.slice(1).map((insertion) => {
+          return {
+            op: "del",
+            insertion,
+          };
+        }),
+      ] as ListOpPayload<string>[];
     }
 
     // Get the joined string


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed -->
<!-- Please also include relevant motivation and context -->
<!-- Include any links to documentation like RFC’s if necessary -->
<!-- Add a link to to relevant preview environments or anything that would simplify visual review process -->
<!-- Supplemental screenshots and video are encouraged, but the primary description should be in text -->
This is the same approach used here #3089 , but it is made on delete. 
```bash
   bench  delete 10 chars with pack=true - colist.pack.bench.ts > CoPlainText - Delete Operations Pack ON vs Pack OFF
 > Delete 10 characters from text
 > Delete Pack ON: 2154b | Pack OFF: 4642b | Savings: 53.6%

    2.32x faster than delete 10 chars with pack=false

   bench  delete 50 chars with pack=true - colist.pack.bench.ts > CoPlainText - Delete Operations Pack ON vs Pack OFF
 > Delete 50 characters from text
 > Delete Pack ON: 7445b | Pack OFF: 19643b | Savings: 62.1%

    3.97x faster than delete 50 chars with pack=false

   bench  delete 100 chars with pack=true - colist.pack.bench.ts > CoPlainText - Delete Operations Pack ON vs Pack OFF
 > Delete 100 characters from text
 > Delete Pack ON: 14246b | Pack OFF: 44110b | Savings: 67.7%

    2.78x faster than delete 100 chars with pack=false

   bench  delete 250 chars with pack=true - colist.pack.bench.ts > CoPlainText - Delete Operations Pack ON vs Pack OFF
 > Delete 250 characters from large text
 > Delete Pack ON: 34499b | Pack OFF: 153535b | Savings: 77.5%

    1.45x faster than delete 250 chars with pack=false

   bench  5 deletes with pack=true - colist.pack.bench.ts > CoPlainText - Delete Operations Pack ON vs Pack OFF
 > Multiple small deletes (5 deletes of 10 chars each)
 > Multiple Delete Pack ON: 8259b | Pack OFF: 25578b | Savings: 67.7%

    18.44x faster than 5 deletes with pack=false

   bench  baseline - show delete summary - colist.pack.bench.ts > Summary - CoPlainText Delete Operations space savings
 > === CoPlainText Delete Operations - Space Savings Summary ===

Delete operations (deleteRange):
  10 chars    : Pack OFF   7763b → Pack ON   2231b (71.3% savings)
  50 chars    : Pack OFF  19643b → Pack ON   7446b (62.1% savings)
  100 chars   : Pack OFF  44110b → Pack ON  14247b (67.7% savings)
  250 chars   : Pack OFF 153536b → Pack ON  34500b (77.5% savings)

Key Findings:
- Delete packing significantly reduces transaction size
- Larger delete ranges show more substantial savings
- Pack format: [first_delete_op, ...insertion_ids] vs individual delete ops
- Critical for collaborative editing with frequent deletions
```


## Manual testing instructions

<!-- Add any actions required to manually test the changes -->

## Tests

- [ ] Tests have been added and/or updated
- [ ] Tests have not been updated, because: <!-- Insert reason for not updating tests here -->
- [ ] I need help with writing tests


## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [ ] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing