### PR TITLE
chore(cojson): removeMember throws on failure

### DIFF
--- a/.changeset/tender-pigs-wonder.md
+++ b/.changeset/tender-pigs-wonder.md
@@ -1,0 +1,5 @@
+---
+"cojson": minor
+---
+
+breaking change: now removeMember throws if unauthorized

--- a/packages/cojson/src/coValues/group.ts
+++ b/packages/cojson/src/coValues/group.ts
@@ -1087,12 +1087,11 @@ export class RawGroup<
 
     this.set(memberKey, "revoked", "trusting");
 
-    // TODO: removeMember fails silently. Uncomment this will be a breaking change
-    // if (this.get(memberKey) !== "revoked") {
-    //   throw new Error(
-    //     `Failed to revoke role to ${memberKey} (role of current account is ${this.myRole()})`,
-    //   );
-    // }
+    if (this.get(memberKey) !== "revoked") {
+      throw new Error(
+        `Failed to revoke role to ${memberKey} (role of current account is ${this.myRole()})`,
+      );
+    }
   }
 
   /**

--- a/packages/cojson/src/tests/group.removeMember.test.ts
+++ b/packages/cojson/src/tests/group.removeMember.test.ts
@@ -166,45 +166,45 @@ describe("Group.removeMember", () => {
 
       const loadedGroup = await loadCoValueOrFail(client.node, group.id);
 
-      // expect(async () => {
-      loadedGroup.removeMember(
-        await loadCoValueOrFail(client.node, reader.accountID),
+      expect(async () => {
+        loadedGroup.removeMember(
+          await loadCoValueOrFail(client.node, reader.accountID),
+        );
+      }).rejects.toThrow(
+        `Failed to revoke role to ${reader.accountID} (role of current account is ${member})`,
       );
-      // }).rejects.toThrow(
-      //   `Failed to revoke role to ${reader.accountID} (role of current account is ${member})`,
-      // );
 
-      // expect(async () => {
-      loadedGroup.removeMember(
-        await loadCoValueOrFail(client.node, writeOnly.accountID),
+      expect(async () => {
+        loadedGroup.removeMember(
+          await loadCoValueOrFail(client.node, writeOnly.accountID),
+        );
+      }).rejects.toThrow(
+        `Failed to revoke role to ${writeOnly.accountID} (role of current account is ${member})`,
       );
-      // }).rejects.toThrow(
-      //   `Failed to revoke role to ${writeOnly.accountID} (role of current account is ${member})`,
-      // );
 
-      // expect(async () => {
-      loadedGroup.removeMember(
-        await loadCoValueOrFail(client.node, writer.accountID),
+      expect(async () => {
+        loadedGroup.removeMember(
+          await loadCoValueOrFail(client.node, writer.accountID),
+        );
+      }).rejects.toThrow(
+        `Failed to revoke role to ${writer.accountID} (role of current account is ${member})`,
       );
-      // }).rejects.toThrow(
-      //   `Failed to revoke role to ${writer.accountID} (role of current account is ${member})`,
-      // );
 
-      // expect(async () => {
-      loadedGroup.removeMember(
-        await loadCoValueOrFail(client.node, admin.accountID),
+      expect(async () => {
+        loadedGroup.removeMember(
+          await loadCoValueOrFail(client.node, admin.accountID),
+        );
+      }).rejects.toThrow(
+        `Failed to revoke role to ${admin.accountID} (role of current account is ${member})`,
       );
-      // }).rejects.toThrow(
-      //   `Failed to revoke role to ${admin.accountID} (role of current account is ${member})`,
-      // );
 
-      // expect(async () => {
-      loadedGroup.removeMember(
-        await loadCoValueOrFail(client.node, manager.accountID),
+      expect(async () => {
+        loadedGroup.removeMember(
+          await loadCoValueOrFail(client.node, manager.accountID),
+        );
+      }).rejects.toThrow(
+        `Failed to revoke role to ${manager.accountID} (role of current account is ${member})`,
       );
-      // }).rejects.toThrow(
-      //   `Failed to revoke role to ${manager.accountID} (role of current account is ${member})`,
-      // );
       expect(loadedGroup.roleOf(reader.accountID)).toEqual("reader");
       expect(loadedGroup.roleOf(writer.accountID)).toEqual("writer");
       expect(loadedGroup.roleOf(writeOnly.accountID)).toEqual("writeOnly");
@@ -252,11 +252,11 @@ describe("Group.removeMember", () => {
       admin.accountID,
     );
 
-    // expect(() => {
-    loadedGroup.removeMember(adminOnClientNode);
-    // }).toThrow(
-    //   `Failed to revoke role to ${admin.accountID} (role of current account is admin)`,
-    // );
+    expect(() => {
+      loadedGroup.removeMember(adminOnClientNode);
+    }).toThrow(
+      `Failed to revoke role to ${admin.accountID} (role of current account is admin)`,
+    );
 
     expect(loadedGroup.roleOf(admin.accountID)).toEqual("admin");
 


### PR DESCRIPTION
# Description
Started the discussion in #3050 

To be consistent and to give appropriate feedback, `group.removeMember` now throws an error if it fails (it was failing silently before). This is a breaking change and needs a minor upgrade.

Looking for feedback