### PR TITLE
feat: export `z.record` and `z.intersection` as part of jazz-tools

### DIFF
--- a/.changeset/metal-carpets-jump.md
+++ b/.changeset/metal-carpets-jump.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Export `z.record` and `z.intersection` as part of jazz-tools

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/runtimeConverters/schemaFieldToCoFieldDef.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/runtimeConverters/schemaFieldToCoFieldDef.ts
@@ -26,6 +26,7 @@ export type SchemaField =
   | z.core.$ZodNullable<z.core.$ZodType>
   | z.core.$ZodUnion<z.core.$ZodType[]>
   | z.core.$ZodDiscriminatedUnion<z.core.$ZodType[]>
+  | z.core.$ZodIntersection<z.core.$ZodType, z.core.$ZodType>
   | z.core.$ZodObject<z.core.$ZodLooseShape>
   | z.core.$ZodRecord<z.core.$ZodRecordKey, z.core.$ZodType>
   | z.core.$ZodArray<z.core.$ZodType>
@@ -149,7 +150,8 @@ export function schemaFieldToCoFieldDef(schema: SchemaField) {
         zodSchemaDef.type === "object" ||
         zodSchemaDef.type === "record" ||
         zodSchemaDef.type === "array" ||
-        zodSchemaDef.type === "tuple"
+        zodSchemaDef.type === "tuple" ||
+        zodSchemaDef.type === "intersection"
       ) {
         return coField.json();
       } else if (zodSchemaDef.type === "union") {

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/runtimeConverters/schemaFieldToCoFieldDef.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/runtimeConverters/schemaFieldToCoFieldDef.ts
@@ -27,6 +27,7 @@ export type SchemaField =
   | z.core.$ZodUnion<z.core.$ZodType[]>
   | z.core.$ZodDiscriminatedUnion<z.core.$ZodType[]>
   | z.core.$ZodObject<z.core.$ZodLooseShape>
+  | z.core.$ZodRecord<z.core.$ZodRecordKey, z.core.$ZodType>
   | z.core.$ZodArray<z.core.$ZodType>
   | z.core.$ZodTuple<z.core.$ZodType[]>
   | z.core.$ZodReadonly<z.core.$ZodType>
@@ -146,6 +147,7 @@ export function schemaFieldToCoFieldDef(schema: SchemaField) {
         );
       } else if (
         zodSchemaDef.type === "object" ||
+        zodSchemaDef.type === "record" ||
         zodSchemaDef.type === "array" ||
         zodSchemaDef.type === "tuple"
       ) {

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/TypeOfZodSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/TypeOfZodSchema.ts
@@ -39,45 +39,52 @@ export type TypeOfZodSchema<S extends z.core.$ZodType> =
                   ? key
                   : never]?: TypeOfZodSchema<Shape[key]>;
               }
-            : S extends z.core.$ZodArray<infer Item extends z.core.$ZodType>
-              ? TypeOfZodSchema<Item>[]
-              : S extends z.core.$ZodTuple<
-                    infer Items extends readonly z.core.$ZodType[]
-                  >
-                ? {
-                    [key in keyof Items]: TypeOfZodSchema<Items[key]>;
-                  }
-                : S extends z.core.$ZodString
-                  ? string
-                  : S extends z.core.$ZodNumber
-                    ? number
-                    : S extends z.core.$ZodBoolean
-                      ? boolean
-                      : S extends z.core.$ZodLiteral<infer Literal>
-                        ? Literal
-                        : S extends z.core.$ZodDate
-                          ? Date
-                          : S extends z.core.$ZodEnum<infer Enum>
-                            ? Enum[keyof Enum]
-                            : S extends z.core.$ZodTemplateLiteral<
-                                  infer pattern
-                                >
-                              ? pattern
-                              : S extends z.core.$ZodReadonly<
-                                    infer Inner extends z.core.$ZodType
+            : S extends z.core.$ZodRecord<
+                  infer Key,
+                  infer Value extends z.core.$ZodType
+                >
+              ? {
+                  [key in z.output<Key>]: TypeOfZodSchema<Value>;
+                }
+              : S extends z.core.$ZodArray<infer Item extends z.core.$ZodType>
+                ? TypeOfZodSchema<Item>[]
+                : S extends z.core.$ZodTuple<
+                      infer Items extends readonly z.core.$ZodType[]
+                    >
+                  ? {
+                      [key in keyof Items]: TypeOfZodSchema<Items[key]>;
+                    }
+                  : S extends z.core.$ZodString
+                    ? string
+                    : S extends z.core.$ZodNumber
+                      ? number
+                      : S extends z.core.$ZodBoolean
+                        ? boolean
+                        : S extends z.core.$ZodLiteral<infer Literal>
+                          ? Literal
+                          : S extends z.core.$ZodDate
+                            ? Date
+                            : S extends z.core.$ZodEnum<infer Enum>
+                              ? Enum[keyof Enum]
+                              : S extends z.core.$ZodTemplateLiteral<
+                                    infer pattern
                                   >
-                                ? TypeOfZodSchema<Inner>
-                                : S extends z.core.$ZodDefault<
-                                      infer Default extends z.core.$ZodType
+                                ? pattern
+                                : S extends z.core.$ZodReadonly<
+                                      infer Inner extends z.core.$ZodType
                                     >
-                                  ? TypeOfZodSchema<Default>
-                                  : S extends z.core.$ZodCodec<
-                                        any,
-                                        infer Out extends z.core.$ZodType
+                                  ? TypeOfZodSchema<Inner>
+                                  : S extends z.core.$ZodDefault<
+                                        infer Default extends z.core.$ZodType
                                       >
-                                    ? Out["_zod"]["output"]
-                                    : S extends z.core.$ZodCatch<
-                                          infer Catch extends z.core.$ZodType
+                                    ? TypeOfZodSchema<Default>
+                                    : S extends z.core.$ZodCodec<
+                                          any,
+                                          infer Out extends z.core.$ZodType
                                         >
-                                      ? TypeOfZodSchema<Catch>
-                                      : never;
+                                      ? Out["_zod"]["output"]
+                                      : S extends z.core.$ZodCatch<
+                                            infer Catch extends z.core.$ZodType
+                                          >
+                                        ? TypeOfZodSchema<Catch>
+                                        : never;

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/TypeOfZodSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/TypeOfZodSchema.ts
@@ -25,66 +25,72 @@ export type TypeOfZodSchema<S extends z.core.$ZodType> =
               infer Members extends readonly z.core.$ZodType[]
             >
           ? TypeOfZodSchema<Members[number]>
-          : S extends z.core.$ZodObject<infer Shape>
-            ? /**
-               * Cannot use {@link PartialOnUndefined} because evaluating TypeOfZodSchema<Shape[key]>
-               * to know if the value can be undefined does not work with recursive types.
-               */
-              {
-                -readonly [key in keyof Shape as Shape[key] extends OptionalInSchema
-                  ? never
-                  : key]: TypeOfZodSchema<Shape[key]>;
-              } & {
-                -readonly [key in keyof Shape as Shape[key] extends OptionalInSchema
-                  ? key
-                  : never]?: TypeOfZodSchema<Shape[key]>;
-              }
-            : S extends z.core.$ZodRecord<
-                  infer Key,
-                  infer Value extends z.core.$ZodType
-                >
-              ? {
-                  [key in z.output<Key>]: TypeOfZodSchema<Value>;
+          : S extends z.core.$ZodIntersection<
+                infer Left extends z.core.$ZodType,
+                infer Right extends z.core.$ZodType
+              >
+            ? TypeOfZodSchema<Left> & TypeOfZodSchema<Right>
+            : S extends z.core.$ZodObject<infer Shape>
+              ? /**
+                 * Cannot use {@link PartialOnUndefined} because evaluating TypeOfZodSchema<Shape[key]>
+                 * to know if the value can be undefined does not work with recursive types.
+                 */
+                {
+                  -readonly [key in keyof Shape as Shape[key] extends OptionalInSchema
+                    ? never
+                    : key]: TypeOfZodSchema<Shape[key]>;
+                } & {
+                  -readonly [key in keyof Shape as Shape[key] extends OptionalInSchema
+                    ? key
+                    : never]?: TypeOfZodSchema<Shape[key]>;
                 }
-              : S extends z.core.$ZodArray<infer Item extends z.core.$ZodType>
-                ? TypeOfZodSchema<Item>[]
-                : S extends z.core.$ZodTuple<
-                      infer Items extends readonly z.core.$ZodType[]
-                    >
-                  ? {
-                      [key in keyof Items]: TypeOfZodSchema<Items[key]>;
-                    }
-                  : S extends z.core.$ZodString
-                    ? string
-                    : S extends z.core.$ZodNumber
-                      ? number
-                      : S extends z.core.$ZodBoolean
-                        ? boolean
-                        : S extends z.core.$ZodLiteral<infer Literal>
-                          ? Literal
-                          : S extends z.core.$ZodDate
-                            ? Date
-                            : S extends z.core.$ZodEnum<infer Enum>
-                              ? Enum[keyof Enum]
-                              : S extends z.core.$ZodTemplateLiteral<
-                                    infer pattern
-                                  >
-                                ? pattern
-                                : S extends z.core.$ZodReadonly<
-                                      infer Inner extends z.core.$ZodType
+              : S extends z.core.$ZodRecord<
+                    infer Key,
+                    infer Value extends z.core.$ZodType
+                  >
+                ? {
+                    [key in z.output<Key>]: TypeOfZodSchema<Value>;
+                  }
+                : S extends z.core.$ZodArray<infer Item extends z.core.$ZodType>
+                  ? TypeOfZodSchema<Item>[]
+                  : S extends z.core.$ZodTuple<
+                        infer Items extends readonly z.core.$ZodType[]
+                      >
+                    ? {
+                        [key in keyof Items]: TypeOfZodSchema<Items[key]>;
+                      }
+                    : S extends z.core.$ZodString
+                      ? string
+                      : S extends z.core.$ZodNumber
+                        ? number
+                        : S extends z.core.$ZodBoolean
+                          ? boolean
+                          : S extends z.core.$ZodLiteral<infer Literal>
+                            ? Literal
+                            : S extends z.core.$ZodDate
+                              ? Date
+                              : S extends z.core.$ZodEnum<infer Enum>
+                                ? Enum[keyof Enum]
+                                : S extends z.core.$ZodTemplateLiteral<
+                                      infer pattern
                                     >
-                                  ? TypeOfZodSchema<Inner>
-                                  : S extends z.core.$ZodDefault<
-                                        infer Default extends z.core.$ZodType
+                                  ? pattern
+                                  : S extends z.core.$ZodReadonly<
+                                        infer Inner extends z.core.$ZodType
                                       >
-                                    ? TypeOfZodSchema<Default>
-                                    : S extends z.core.$ZodCodec<
-                                          any,
-                                          infer Out extends z.core.$ZodType
+                                    ? TypeOfZodSchema<Inner>
+                                    : S extends z.core.$ZodDefault<
+                                          infer Default extends z.core.$ZodType
                                         >
-                                      ? Out["_zod"]["output"]
-                                      : S extends z.core.$ZodCatch<
-                                            infer Catch extends z.core.$ZodType
+                                      ? TypeOfZodSchema<Default>
+                                      : S extends z.core.$ZodCodec<
+                                            any,
+                                            infer Out extends z.core.$ZodType
                                           >
-                                        ? TypeOfZodSchema<Catch>
-                                        : never;
+                                        ? Out["_zod"]["output"]
+                                        : S extends z.core.$ZodCatch<
+                                              infer Catch extends
+                                                z.core.$ZodType
+                                            >
+                                          ? TypeOfZodSchema<Catch>
+                                          : never;

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/zodReExport.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/zodReExport.ts
@@ -32,7 +32,7 @@ export {
   int32,
   union,
   discriminatedUnion,
-  // record,
+  record,
   // intersection,
   int,
   codec,

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/zodReExport.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/zodReExport.ts
@@ -33,7 +33,7 @@ export {
   union,
   discriminatedUnion,
   record,
-  // intersection,
+  intersection,
   int,
   codec,
   optional,

--- a/packages/jazz-tools/src/tools/tests/zod.test-d.ts
+++ b/packages/jazz-tools/src/tools/tests/zod.test-d.ts
@@ -10,7 +10,6 @@ describe("CoValue and Zod schema compatibility", () => {
 
     const Person = co.map({
       // @ts-expect-error: cannot use z.record with a CoValue schema
-      // (z.record is not exported by jazz-tools)
       pets: z.record(z.string(), Dog),
     });
   });

--- a/packages/jazz-tools/src/tools/tests/zod.test-d.ts
+++ b/packages/jazz-tools/src/tools/tests/zod.test-d.ts
@@ -67,7 +67,6 @@ describe("CoValue and Zod schema compatibility", () => {
 
     const Person = co.map({
       // @ts-expect-error: cannot use z.intersection with a CoValue schema
-      // (z.intersection is not exported by jazz-tools)
       pets: z.intersection(Dog, Cat),
     });
   });

--- a/packages/jazz-tools/src/tools/tests/zod.test.ts
+++ b/packages/jazz-tools/src/tools/tests/zod.test.ts
@@ -369,6 +369,18 @@ describe("co.map and Zod schema compatibility", () => {
       expect(map.person).toEqual({ name: "John" });
     });
 
+    it("should handle record fields", async () => {
+      const schema = co.map({
+        record: z.record(z.string(), z.string()),
+      });
+      const account = await createJazzTestAccount();
+      const map = schema.create(
+        { record: { key1: "value1", key2: "value2" } },
+        account,
+      );
+      expect(map.record).toEqual({ key1: "value1", key2: "value2" });
+    });
+
     it("should handle tuple fields", async () => {
       const schema = co.map({
         tuple: z.tuple([z.string(), z.number(), z.boolean()]),

--- a/packages/jazz-tools/src/tools/tests/zod.test.ts
+++ b/packages/jazz-tools/src/tools/tests/zod.test.ts
@@ -414,46 +414,37 @@ describe("co.map and Zod schema compatibility", () => {
       expect(map2.value).toBe(42);
     });
 
-    // it("should handle discriminated unions of primitives", async () => {
-    //   const schema = co.map({
-    //     result: z.discriminatedUnion("status", [
-    //       z.object({ status: z.literal("success"), data: z.string() }),
-    //       z.object({ status: z.literal("failed"), error: z.string() }),
-    //     ]),
-    //   });
-    //   const account = await createJazzTestAccount();
-    //   const successMap = schema.create(
-    //     { result: { status: "success", data: "data" } },
-    //     account,
-    //   );
-    //   const failedMap = schema.create(
-    //     { result: { status: "failed", error: "error" } },
-    //     account,
-    //   );
-    //   expect(successMap.result).toEqual({ status: "success", data: "data" });
-    //   expect(failedMap.result).toEqual({ status: "failed", error: "error" });
-    // });
+    it("should handle discriminated unions of primitives", async () => {
+      const schema = co.map({
+        result: z.discriminatedUnion("status", [
+          z.object({ status: z.literal("success"), data: z.string() }),
+          z.object({ status: z.literal("failed"), error: z.string() }),
+        ]),
+      });
+      const account = await createJazzTestAccount();
+      const successMap = schema.create(
+        { result: { status: "success", data: "data" } },
+        account,
+      );
+      const failedMap = schema.create(
+        { result: { status: "failed", error: "error" } },
+        account,
+      );
+      expect(successMap.result).toEqual({ status: "success", data: "data" });
+      expect(failedMap.result).toEqual({ status: "failed", error: "error" });
+    });
 
-    // it("should handle intersections", async () => {
-    //   const schema = co.map({
-    //     value: z.intersection(
-    //       z.union([z.number(), z.string()]),
-    //       z.union([z.number(), z.boolean()])
-    //     ),
-    //   });
-    //   const account = await createJazzTestAccount();
-    //   const map = schema.create({ value: 42 }, account);
-    //   expect(map.value).toBe(42);
-    // });
-
-    // it("should handle record types", async () => {
-    //   const schema = co.map({
-    //     cache: z.record(z.string(), z.string()),
-    //   });
-    //   const account = await createJazzTestAccount();
-    //   const map = schema.create({ cache: { key1: "value1", key2: "value2" } }, account);
-    //   expect(map.cache).toEqual({ key1: "value1", key2: "value2" });
-    // });
+    it("should handle intersections", async () => {
+      const schema = co.map({
+        value: z.intersection(
+          z.union([z.number(), z.string()]),
+          z.union([z.number(), z.boolean()]),
+        ),
+      });
+      const account = await createJazzTestAccount();
+      const map = schema.create({ value: 42 }, account);
+      expect(map.value).toBe(42);
+    });
 
     it("should handle refined types", async () => {
       const schema = co.map({


### PR DESCRIPTION
# Description

Adds support for `z.record` and `z.intersection` as CoValue fields.

## Tests

- [x] Tests have been added and/or updated

## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [x] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing