### PR TITLE
fix(jazz-tools/inspector): remove children groups if revoked

### DIFF
--- a/packages/jazz-tools/src/inspector/viewer/group-view.tsx
+++ b/packages/jazz-tools/src/inspector/viewer/group-view.tsx
@@ -44,7 +44,9 @@ function partitionMembers(data: Record<string, string>) {
     }));
 
   const childGroups = Object.entries(data)
-    .filter(([key]) => key.startsWith("child_co_"))
+    .filter(
+      ([key, value]) => key.startsWith("child_co_") && value !== "revoked",
+    )
     .map(([key, value]) => ({
       id: key.slice(6) as CoID<RawCoValue>,
       role: value,


### PR DESCRIPTION
In the inspector group's view, the list of extended groups also contained groups with revoked access.

Fix of #3086 