### PR TITLE
Fix empty form taking up space

### DIFF
--- a/.changeset/tough-oranges-teach.md
+++ b/.changeset/tough-oranges-teach.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+fix: visual bug on "delete my local data" button in inspector on mobile viewports

--- a/packages/jazz-tools/src/inspector/viewer/new-app.tsx
+++ b/packages/jazz-tools/src/inspector/viewer/new-app.tsx
@@ -91,18 +91,18 @@ export function JazzInspectorInternal({
     <InspectorContainer as={GlobalStyles} style={{ zIndex: 999 }}>
       <HeaderContainer>
         <Breadcrumbs path={path} onBreadcrumbClick={goToIndex} />
-        <Form onSubmit={handleCoValueIdSubmit}>
           {path.length !== 0 && (
-            <Input
-              label="CoValue ID"
-              style={{ fontFamily: "monospace" }}
-              hideLabel
-              placeholder="co_z1234567890abcdef123456789"
-              value={coValueId}
-              onChange={(e) => setCoValueId(e.target.value as CoID<RawCoValue>)}
-            />
+            <Form onSubmit={handleCoValueIdSubmit}>
+                <Input
+                  label="CoValue ID"
+                  style={{ fontFamily: "monospace" }}
+                  hideLabel
+                  placeholder="co_z1234567890abcdef123456789"
+                  value={coValueId}
+                  onChange={(e) => setCoValueId(e.target.value as CoID<RawCoValue>)}
+                />
+            </Form>
           )}
-        </Form>
         <DeleteLocalData />
         <Button variant="plain" type="button" onClick={() => setOpen(false)}>
           Close

--- a/packages/jazz-tools/src/inspector/viewer/new-app.tsx
+++ b/packages/jazz-tools/src/inspector/viewer/new-app.tsx
@@ -91,18 +91,18 @@ export function JazzInspectorInternal({
     <InspectorContainer as={GlobalStyles} style={{ zIndex: 999 }}>
       <HeaderContainer>
         <Breadcrumbs path={path} onBreadcrumbClick={goToIndex} />
-          {path.length !== 0 && (
-            <Form onSubmit={handleCoValueIdSubmit}>
-                <Input
-                  label="CoValue ID"
-                  style={{ fontFamily: "monospace" }}
-                  hideLabel
-                  placeholder="co_z1234567890abcdef123456789"
-                  value={coValueId}
-                  onChange={(e) => setCoValueId(e.target.value as CoID<RawCoValue>)}
-                />
-            </Form>
-          )}
+        {path.length !== 0 && (
+          <Form onSubmit={handleCoValueIdSubmit}>
+            <Input
+              label="CoValue ID"
+              style={{ fontFamily: "monospace" }}
+              hideLabel
+              placeholder="co_z1234567890abcdef123456789"
+              value={coValueId}
+              onChange={(e) => setCoValueId(e.target.value as CoID<RawCoValue>)}
+            />
+          </Form>
+        )}
         <DeleteLocalData />
         <Button variant="plain" type="button" onClick={() => setOpen(false)}>
           Close


### PR DESCRIPTION
# Description

Currently when there is no input, the empty Form still takes up `24rem`, causing the "Delete my local data" button to be squished. This can be seen at https://chat.jazz.tools with narrow/mobile viewport sizes.

| Current | Change |
| - | - |
| <img width="594" height="365" alt="Screenshot 2025-10-25 at 12 36 49 am" src="https://github.com/user-attachments/assets/fd235493-f2db-435a-91c4-67bee11e7583" /> | <img width="594" height="365" alt="Screenshot 2025-10-25 at 12 37 11 am" src="https://github.com/user-attachments/assets/0d0dbc86-8899-4793-8c02-74d50bde7d85" /> |

## Tests

- [ ] Tests have been added and/or updated
- [x] Tests have not been updated, because: Minor visual change
- [ ] I need help with writing tests

## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [ ] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing