### PR TITLE
Make options parameter optional in load method

### DIFF
--- a/packages/jazz-tools/src/tools/coValues/coFeed.ts
+++ b/packages/jazz-tools/src/tools/coValues/coFeed.ts
@@ -286,12 +286,12 @@ export class CoFeed<out Item = any> extends CoValueBase implements CoValue {
   static load<F extends CoFeed, const R extends RefsToResolve<F> = true>(
     this: CoValueClass<F>,
     id: ID<F>,
-    options: {
+    options?: {
       resolve?: RefsToResolveStrict<F, R>;
       loadAs?: Account | AnonymousJazzAgent;
     },
   ): Promise<Resolved<F, R> | null> {
-    return loadCoValueWithoutMe(this, id, options);
+    return loadCoValueWithoutMe(this, id, options ?? {});
   }
 
   /**

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/FileStreamSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/FileStreamSchema.ts
@@ -78,7 +78,7 @@ export class FileStreamSchema implements CoreFileStreamSchema {
 
   load(
     id: string,
-    options: { loadAs: Account | AnonymousJazzAgent },
+    options?: { loadAs: Account | AnonymousJazzAgent },
   ): Promise<FileStream | null> {
     return this.coValueClass.load(id, options);
   }

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/FileStreamSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/FileStreamSchema.ts
@@ -78,7 +78,7 @@ export class FileStreamSchema implements CoreFileStreamSchema {
 
   load(
     id: string,
-    options?: { loadAs: Account | AnonymousJazzAgent },
+    options?: { loadAs?: Account | AnonymousJazzAgent },
   ): Promise<FileStream | null> {
     return this.coValueClass.load(id, options);
   }


### PR DESCRIPTION
# Description
Quick fix for options being mandatory on `co.filestream().load()`

## Manual testing instructions
N/A
## Tests

- [ ] Tests have been added and/or updated
- [x] Tests have not been updated, because: Typefix only with no runtime implication
- [ ] I need help with writing tests


## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [ ] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing