### PR TITLE
Show CoValue's history in inspector

### DIFF
--- a/.changeset/vast-results-relax.md
+++ b/.changeset/vast-results-relax.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+feat: CoValue's history is now visible in hispector

--- a/.changeset/vast-results-relax.md
+++ b/.changeset/vast-results-relax.md
@@ -2,4 +2,4 @@
 "jazz-tools": patch
 ---
 
-feat: CoValue's history is now visible in hispector
+feat: CoValue's history is now visible in inspector

--- a/examples/inspector/tests/inspector.spec.ts
+++ b/examples/inspector/tests/inspector.spec.ts
@@ -47,7 +47,7 @@ test("should inspect CoValue", async ({ page }) => {
 
   await inspectCoValue(page, organization.$jazz.id);
 
-  await expect(page.getByText(/Garden Computing/)).toHaveCount(2);
+  await expect(page.getByText(/Garden Computing/)).toHaveCount(3);
   await expect(
     page.getByRole("heading", { name: organization.$jazz.id }),
   ).toBeVisible();
@@ -68,10 +68,10 @@ test("should inspect CoValue", async ({ page }) => {
   await page.getByRole("button", { name: /labels/ }).click();
   // currently broken:
   // await expect(page.getByText("Showing 10 of 10")).toBeVisible();
-  await expect(page.getByRole("table").getByRole("row")).toHaveCount(11);
+  await expect(page.getByRole("table").nth(0).getByRole("row")).toHaveCount(11);
 
   await page.getByRole("button", { name: "issues" }).click();
-  await expect(page.getByRole("table").getByRole("row")).toHaveCount(4);
+  await expect(page.getByRole("table").nth(0).getByRole("row")).toHaveCount(4);
 
   const table = page.getByRole("table");
   const row = table.getByRole("row").nth(1);
@@ -114,7 +114,7 @@ test("should inspect CoValue", async ({ page }) => {
 
   // Test if CoMap/grid view is displaying Issue data correctly
   await row.getByRole("button", { name: "View" }).click();
-  await expect(page.getByRole("table")).not.toBeVisible();
+  await expect(page.getByRole("table")).toHaveCount(1);
   await expect(page.getByText(issue.title)).toBeVisible();
   await expect(page.getByText(issue.status)).toBeVisible();
   await expect(page.getByRole("button", { name: /labels/ })).toBeVisible();

--- a/packages/jazz-tools/src/inspector/tests/ui/data-table.test.tsx
+++ b/packages/jazz-tools/src/inspector/tests/ui/data-table.test.tsx
@@ -1,0 +1,296 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, assert, beforeAll, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { DataTable, ColumnDef } from "../../ui/data-table";
+import { setup } from "goober";
+import React from "react";
+
+type TestItem = {
+  id: number;
+  name: string;
+  value: number;
+};
+
+const mockData: TestItem[] = [
+  { id: 1, name: "Apple", value: 100 },
+  { id: 2, name: "Banana", value: 50 },
+  { id: 3, name: "Cherry", value: 200 },
+  { id: 4, name: "Date", value: 75 },
+  { id: 5, name: "Elderberry", value: 150 },
+];
+
+const mockColumns: ColumnDef<TestItem>[] = [
+  {
+    id: "name",
+    header: "Name",
+    accessor: (item) => item.name,
+    sortable: true,
+    filterable: true,
+  },
+  {
+    id: "value",
+    header: "Value",
+    accessor: (item) => item.value.toString(),
+    sortable: true,
+    sortFn: (a, b) => a.value - b.value,
+  },
+];
+
+describe("DataTable", () => {
+  beforeAll(() => {
+    // setup goober
+    setup(React.createElement);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders table with data", () => {
+    render(
+      <DataTable
+        columns={mockColumns}
+        data={mockData}
+        pageSize={10}
+        getRowKey={(item) => item.id.toString()}
+      />,
+    );
+
+    expect(screen.getByText("Apple")).toBeDefined();
+    expect(screen.getByText("Banana")).toBeDefined();
+    expect(screen.getByText("Cherry")).toBeDefined();
+  });
+
+  it("shows empty message when no data", () => {
+    render(
+      <DataTable
+        columns={mockColumns}
+        data={[]}
+        pageSize={10}
+        getRowKey={(item) => item.id.toString()}
+        emptyMessage="No items found"
+      />,
+    );
+
+    expect(screen.getByText("No items found")).toBeDefined();
+  });
+
+  it("hides pagination when data fits on one page", () => {
+    render(
+      <DataTable
+        columns={mockColumns}
+        data={mockData.slice(0, 3)}
+        pageSize={10}
+        getRowKey={(item) => item.id.toString()}
+      />,
+    );
+
+    expect(screen.queryByText(/Page \d+ of \d+/)).toBeNull();
+  });
+
+  it("shows pagination when data exceeds page size", () => {
+    const largeData = Array.from({ length: 25 }, (_, i) => ({
+      id: i,
+      name: `Item ${i}`,
+      value: i * 10,
+    }));
+
+    render(
+      <DataTable
+        columns={mockColumns}
+        data={largeData}
+        pageSize={10}
+        getRowKey={(item) => item.id.toString()}
+      />,
+    );
+
+    expect(screen.getByText(/Page 1 of 3/)).toBeDefined();
+  });
+
+  it("supports sorting when clicking header", () => {
+    render(
+      <DataTable
+        columns={mockColumns}
+        data={mockData}
+        pageSize={10}
+        getRowKey={(item) => item.id.toString()}
+      />,
+    );
+
+    const nameHeader = screen.getByText("Name").parentElement;
+
+    // Click to sort ascending
+    fireEvent.click(nameHeader!);
+    const rows = screen.getAllByRole("row");
+    expect(rows[2]?.textContent).toContain("Apple"); // First data row
+
+    // Click to sort descending
+    fireEvent.click(nameHeader!);
+    const rowsDesc = screen.getAllByRole("row");
+    expect(rowsDesc[2]?.textContent).toContain("Elderberry");
+  });
+
+  it("applies initial sort configuration", () => {
+    render(
+      <DataTable
+        columns={mockColumns}
+        data={mockData}
+        pageSize={10}
+        initialSort={{ columnId: "value", direction: "desc" }}
+        getRowKey={(item) => item.id.toString()}
+      />,
+    );
+
+    const rows = screen.getAllByRole("row");
+    expect(rows[2]?.textContent).toContain("Cherry"); // Highest value (200)
+  });
+
+  it("filters data based on input", () => {
+    render(
+      <DataTable
+        columns={mockColumns}
+        data={mockData}
+        pageSize={10}
+        getRowKey={(item) => item.id.toString()}
+      />,
+    );
+
+    const filterInput = screen.getAllByPlaceholderText("Filter name")[0];
+    assert(filterInput);
+    fireEvent.change(filterInput, { target: { value: "berry" } });
+
+    expect(screen.getByText("Elderberry")).toBeDefined();
+    expect(screen.queryByText("Apple")).toBeNull();
+  });
+
+  it("shows filtered count in pagination info", () => {
+    const largeData = Array.from({ length: 25 }, (_, i) => ({
+      id: i,
+      name: i % 2 === 0 ? `Apple ${i}` : `Banana ${i}`,
+      value: i * 10,
+    }));
+
+    render(
+      <DataTable
+        columns={mockColumns}
+        data={largeData}
+        pageSize={10}
+        getRowKey={(item) => item.id.toString()}
+      />,
+    );
+
+    const filterInput = screen.getAllByPlaceholderText("Filter name")[0];
+    assert(filterInput);
+    fireEvent.change(filterInput, { target: { value: "Apple" } });
+
+    expect(screen.getByText(/filtered from 25/)).toBeDefined();
+  });
+
+  it("navigates between pages", () => {
+    const largeData = Array.from({ length: 25 }, (_, i) => ({
+      id: i,
+      name: `Item ${i}`,
+      value: i * 10,
+    }));
+
+    render(
+      <DataTable
+        columns={mockColumns}
+        data={largeData}
+        pageSize={10}
+        getRowKey={(item) => item.id.toString()}
+      />,
+    );
+
+    expect(screen.getByText("Item 0")).toBeDefined();
+    expect(screen.queryByText("Item 10")).toBeNull();
+
+    // Click next page button
+    const nextButton = screen.getByText("»");
+    fireEvent.click(nextButton);
+
+    expect(screen.queryByText("Item 0")).toBeNull();
+    expect(screen.getByText("Item 10")).toBeDefined();
+  });
+
+  it("disables pagination buttons appropriately", () => {
+    const largeData = Array.from({ length: 25 }, (_, i) => ({
+      id: i,
+      name: `Item ${i}`,
+      value: i * 10,
+    }));
+
+    render(
+      <DataTable
+        columns={mockColumns}
+        data={largeData}
+        pageSize={10}
+        getRowKey={(item) => item.id.toString()}
+      />,
+    );
+
+    const firstPageButton = screen.getByText("««");
+    const prevButton = screen.getByText("«");
+
+    // On first page, first and prev should be disabled
+    expect((firstPageButton as HTMLButtonElement).disabled).toBe(true);
+    expect((prevButton as HTMLButtonElement).disabled).toBe(true);
+
+    // Navigate to last page
+    const lastPageButton = screen.getByText("»»");
+    fireEvent.click(lastPageButton);
+
+    const nextButton = screen.getByText("»");
+
+    // On last page, last and next should be disabled
+    expect((nextButton as HTMLButtonElement).disabled).toBe(true);
+    expect((lastPageButton as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("uses custom sort function when provided", () => {
+    render(
+      <DataTable
+        columns={mockColumns}
+        data={mockData}
+        pageSize={10}
+        getRowKey={(item) => item.id.toString()}
+      />,
+    );
+
+    const valueHeader = screen.getByText("Value").parentElement;
+    fireEvent.click(valueHeader!);
+
+    const rows = screen.getAllByRole("row");
+    expect(rows[2]?.textContent).toContain("50"); // Banana - lowest value
+  });
+
+  it("resets to page 1 when filter changes", () => {
+    const largeData = Array.from({ length: 25 }, (_, i) => ({
+      id: i,
+      name: `Item ${i}`,
+      value: i * 10,
+    }));
+
+    render(
+      <DataTable
+        columns={mockColumns}
+        data={largeData}
+        pageSize={10}
+        getRowKey={(item) => item.id.toString()}
+      />,
+    );
+
+    // Go to page 2
+    const nextButton = screen.getByText("»");
+    fireEvent.click(nextButton);
+    expect(screen.getByText(/Page 2 of 3/)).toBeDefined();
+
+    // Apply filter
+    const filterInput = screen.getAllByPlaceholderText("Filter name")[0];
+    assert(filterInput);
+    fireEvent.change(filterInput, { target: { value: "1" } });
+
+    // Should be back on page 1
+    expect(screen.getByText(/Page 1 of/)).toBeDefined();
+  });
+});

--- a/packages/jazz-tools/src/inspector/tests/viewer/history-view.test.tsx
+++ b/packages/jazz-tools/src/inspector/tests/viewer/history-view.test.tsx
@@ -1,0 +1,246 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import { createJazzTestAccount, setupJazzTestSync } from "jazz-tools/testing";
+import { co, z } from "jazz-tools";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { HistoryView } from "../../viewer/history-view";
+import { setup } from "goober";
+import React from "react";
+
+function extractAction(row: HTMLElement | null | undefined) {
+  if (!row) return "";
+  // index 0: author, index 1: action, index 2: timestamp
+  return row.querySelectorAll("td")?.[1]?.textContent ?? "";
+}
+
+function extractActions(): string[] {
+  // slice 2 to skip header and filters
+  return screen.getAllByRole("row").slice(2).map(extractAction);
+}
+
+describe("HistoryView", async () => {
+  const account = await setupJazzTestSync();
+  const account2 = await createJazzTestAccount();
+
+  beforeAll(() => {
+    // setup goober
+    setup(React.createElement);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("should render a history card", async () => {
+    const value = co
+      .map({
+        foo: z.string(),
+      })
+      .create({ foo: "bar" }, account);
+
+    render(
+      <HistoryView coValue={value.$jazz.raw} node={value.$jazz.localNode} />,
+    );
+
+    expect(
+      screen.getAllByText('Property "foo" has been set to "bar"'),
+    ).toHaveLength(1);
+  });
+
+  describe("co.map", () => {
+    it("should render co.map changes", async () => {
+      const value = co
+        .map({
+          pet: z.string(),
+          age: z.number(),
+          certified: z.boolean().optional(),
+        })
+        .create({ pet: "dog", age: 10, certified: false }, account);
+
+      value.$jazz.set("pet", "cat");
+      value.$jazz.set("age", 20);
+      value.$jazz.set("certified", true);
+      value.$jazz.delete("certified");
+
+      render(
+        <HistoryView coValue={value.$jazz.raw} node={value.$jazz.localNode} />,
+      );
+
+      const history = [
+        'Property "pet" has been set to "dog"',
+        'Property "age" has been set to "10"',
+        'Property "certified" has been set to "false"',
+        'Property "pet" has been set to "cat"',
+        'Property "age" has been set to "20"',
+        'Property "certified" has been set to "true"',
+        'Property "certified" has been deleted',
+      ].toReversed(); // Default sort is descending
+
+      expect(screen.getAllByRole("row")).toHaveLength(history.length + 2);
+
+      await waitFor(() => {
+        expect(screen.getAllByRole("row")[2]?.textContent).toContain(
+          account.$jazz.id,
+        );
+      });
+
+      expect(extractActions()).toEqual(history);
+    });
+  });
+
+  describe("co.list", () => {
+    it("should render simple co.list changes", async () => {
+      const value = co.list(z.string()).create(["dog", "cat"], account);
+
+      value.$jazz.push("bird");
+
+      value.$jazz.splice(1, 0, "fish");
+
+      value.$jazz.shift();
+
+      render(
+        <HistoryView coValue={value.$jazz.raw} node={value.$jazz.localNode} />,
+      );
+
+      const history = [
+        '"dog" has been appended',
+        '"cat" has been appended',
+        '"bird" has been inserted after "cat"',
+        '"fish" has been inserted after "dog"',
+        '"dog" has been deleted',
+      ].toReversed(); // Default sort is descending
+
+      expect(extractActions()).toEqual(history);
+    });
+
+    it("should render changes of a co.list of co.maps", async () => {
+      const Animal = co.map({
+        pet: z.string(),
+        age: z.number(),
+        certified: z.boolean(),
+      });
+
+      const dog = Animal.create(
+        { pet: "dog", age: 10, certified: false },
+        account,
+      );
+      const cat = Animal.create(
+        { pet: "cat", age: 20, certified: true },
+        account,
+      );
+      const fish = Animal.create(
+        { pet: "fish", age: 30, certified: false },
+        account,
+      );
+      const bird = Animal.create(
+        { pet: "bird", age: 40, certified: true },
+        account,
+      );
+
+      const value = co.list(Animal).create([dog, cat], account);
+
+      value.$jazz.push(bird);
+
+      value.$jazz.splice(1, 0, fish);
+
+      value.$jazz.shift();
+
+      render(
+        <HistoryView coValue={value.$jazz.raw} node={value.$jazz.localNode} />,
+      );
+
+      const history = [
+        `"${dog.$jazz.id}" has been appended`,
+        `"${cat.$jazz.id}" has been appended`,
+        `"${bird.$jazz.id}" has been inserted after "${cat.$jazz.id}"`,
+        `"${fish.$jazz.id}" has been inserted after "${dog.$jazz.id}"`,
+        `"${dog.$jazz.id}" has been deleted`,
+      ].toReversed(); // Default sort is descending
+
+      expect(extractActions()).toEqual(history);
+    });
+  });
+
+  describe("co.group", () => {
+    it("should render co.group changes", async () => {
+      const group = co.group().create(account);
+
+      const group2 = co.group().create(account);
+
+      group.addMember(group2, "writer");
+
+      group.addMember(account2, "reader");
+      group.removeMember(account2);
+
+      const group3 = co.group().create(account);
+      group3.addMember(group, "inherit");
+
+      const { container } = render(
+        <HistoryView coValue={group.$jazz.raw} node={group.$jazz.localNode} />,
+      );
+
+      const history = [
+        `${account.$jazz.id} has been promoted to admin`,
+        expect.stringContaining(` has been revealed to `), // key revelation
+        expect.stringContaining('Property "readKey" has been set to'),
+        `Group ${group2.$jazz.id} has been promoted to writer`,
+        expect.stringContaining(" has been revealed to"),
+        `${account2.$jazz.id} has been promoted to reader`,
+        expect.stringContaining(" has been revealed to"),
+        // Member revocation: key rotation
+        expect.stringContaining(" has been revealed to"),
+        expect.stringContaining(" has been revealed to"),
+        expect.stringContaining('Property "readKey" has been set to'),
+        expect.stringContaining(" has been revealed to"),
+        `${account2.$jazz.id} has been revoked`,
+
+        // Group extension
+        // `Group become a member of ${group3.$jazz.id}`,
+      ].toReversed(); // Default sort is descending
+
+      const historyPage1 = history.slice(0, 10);
+      const historyPage2 = history.slice(10, 20);
+
+      // Page 1: 10 rows
+      expect(extractActions()).toEqual(historyPage1);
+
+      // Go to page 2
+      fireEvent.click(screen.getByText("»"));
+
+      // Page 2: 3 rows
+      expect(extractActions()).toEqual(historyPage2);
+    });
+  });
+
+  describe("co.account", () => {
+    it("should render co.account changes", async () => {
+      const account = await createJazzTestAccount({
+        creationProps: {
+          name: "John Doe",
+        },
+      });
+
+      const history = [
+        expect.stringContaining(' has been set to "admin"'),
+        expect.stringContaining(" has been revealed to "),
+        expect.stringContaining('Property "readKey" has been set to '),
+        `Property "profile" has been set to "${account.profile!.$jazz.id}"`,
+      ].toReversed(); // Default sort is descending
+
+      render(
+        <HistoryView
+          coValue={account.$jazz.raw}
+          node={account.$jazz.localNode}
+        />,
+      );
+
+      expect(extractActions()).toEqual(history);
+    });
+  });
+});

--- a/packages/jazz-tools/src/inspector/ui/data-table.tsx
+++ b/packages/jazz-tools/src/inspector/ui/data-table.tsx
@@ -1,0 +1,265 @@
+import { useMemo, useState } from "react";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "./table";
+import { Button } from "./button";
+import { Input } from "./input";
+
+export type ColumnDef<T> = {
+  id: string;
+  header: string;
+  accessor: (row: T) => React.ReactNode;
+  sortable?: boolean;
+  filterable?: boolean;
+  sortFn?: (a: T, b: T) => number;
+  filterFn?: (row: T, filterValue: string) => boolean;
+};
+
+export type SortConfig = {
+  columnId: string;
+  direction: "asc" | "desc";
+} | null;
+
+export type DataTableProps<T> = {
+  columns: ColumnDef<T>[];
+  data: T[];
+  pageSize?: number;
+  initialSort?: SortConfig;
+  getRowKey: (row: T, index: number) => string;
+  emptyMessage?: string;
+};
+
+export function DataTable<T>({
+  columns,
+  data,
+  pageSize = 10,
+  initialSort = null,
+  getRowKey,
+  emptyMessage = "No data available",
+}: DataTableProps<T>) {
+  const [currentPage, setCurrentPage] = useState(1);
+  const [sortConfig, setSortConfig] = useState<SortConfig>(initialSort);
+  const [filters, setFilters] = useState<Record<string, string>>({});
+
+  // Apply filtering
+  const filteredData = useMemo(() => {
+    return data.filter((row) => {
+      return Object.entries(filters).every(([columnId, filterValue]) => {
+        if (!filterValue) return true;
+
+        const column = columns.find((col) => col.id === columnId);
+        if (!column?.filterable) return true;
+
+        if (column.filterFn) {
+          return column.filterFn(row, filterValue);
+        }
+
+        // Default filter: convert to string and check inclusion
+        const cellValue = String(column.accessor(row));
+        return cellValue.toLowerCase().includes(filterValue.toLowerCase());
+      });
+    });
+  }, [data, filters, columns]);
+
+  // Apply sorting
+  const sortedData = useMemo(() => {
+    if (!sortConfig) return filteredData;
+
+    const column = columns.find((col) => col.id === sortConfig.columnId);
+    if (!column?.sortable) return filteredData;
+
+    const sorted = [...filteredData].sort((a, b) => {
+      if (column.sortFn) {
+        return column.sortFn(a, b);
+      }
+
+      // Default sort: compare string values
+      const aValue = String(column.accessor(a));
+      const bValue = String(column.accessor(b));
+      return aValue.localeCompare(bValue);
+    });
+
+    return sortConfig.direction === "desc" ? sorted.reverse() : sorted;
+  }, [filteredData, sortConfig, columns]);
+
+  // Calculate pagination
+  const totalPages = Math.ceil(sortedData.length / pageSize);
+  const showPagination = sortedData.length > pageSize;
+  const startIndex = (currentPage - 1) * pageSize;
+  const endIndex = startIndex + pageSize;
+  const paginatedData = sortedData.slice(startIndex, endIndex);
+
+  // Reset to page 1 when filters change
+  useMemo(() => {
+    setCurrentPage(1);
+  }, [filters]);
+
+  const handleSort = (columnId: string) => {
+    const column = columns.find((col) => col.id === columnId);
+    if (!column?.sortable) return;
+
+    setSortConfig((current) => {
+      if (current?.columnId === columnId) {
+        if (current.direction === "asc") {
+          return { columnId, direction: "desc" };
+        }
+        return null; // Remove sorting
+      }
+      return { columnId, direction: "asc" };
+    });
+  };
+
+  const handleFilterChange = (columnId: string, value: string) => {
+    setFilters((current) => ({
+      ...current,
+      [columnId]: value,
+    }));
+  };
+
+  const handlePageChange = (page: number) => {
+    setCurrentPage(Math.max(1, Math.min(page, totalPages)));
+  };
+
+  return (
+    <>
+      <Table>
+        <TableHead>
+          <TableRow>
+            {columns.map((column) => (
+              <TableHeader key={column.id}>
+                <div
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: "8px",
+                    cursor: column.sortable ? "pointer" : "default",
+                  }}
+                  onClick={() => handleSort(column.id)}
+                >
+                  <span>{column.header}</span>
+                  {column.sortable && (
+                    <span
+                      style={{
+                        fontSize: "12px",
+                        opacity: 0.7,
+                      }}
+                    >
+                      {sortConfig?.columnId === column.id
+                        ? sortConfig.direction === "asc"
+                          ? "↑"
+                          : "↓"
+                        : "↕"}
+                    </span>
+                  )}
+                </div>
+              </TableHeader>
+            ))}
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {columns.some((column) => column.filterable) && (
+            <TableRow>
+              {columns.map((column) => (
+                <TableCell key={column.id}>
+                  {column.filterable && (
+                    <Input
+                      label="Filter"
+                      hideLabel
+                      type="search"
+                      placeholder={`Filter ${column.header.toLowerCase()}`}
+                      value={filters[column.id] || ""}
+                      onChange={(e) =>
+                        handleFilterChange(column.id, e.target.value)
+                      }
+                      onClick={(e) => e.stopPropagation()}
+                    />
+                  )}
+                </TableCell>
+              ))}
+            </TableRow>
+          )}
+          {paginatedData.length === 0 ? (
+            <TableRow>
+              <TableCell colSpan={columns.length}>
+                <div
+                  style={{
+                    textAlign: "center",
+                    padding: "20px",
+                    opacity: 0.6,
+                  }}
+                >
+                  {emptyMessage}
+                </div>
+              </TableCell>
+            </TableRow>
+          ) : (
+            paginatedData.map((row, index) => (
+              <TableRow key={getRowKey(row, startIndex + index)}>
+                {columns.map((column) => (
+                  <TableCell key={column.id}>{column.accessor(row)}</TableCell>
+                ))}
+              </TableRow>
+            ))
+          )}
+        </TableBody>
+      </Table>
+
+      {showPagination && (
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+            marginTop: "16px",
+            padding: "8px 0",
+          }}
+        >
+          <div style={{ fontSize: "14px", opacity: 0.7 }}>
+            Showing {startIndex + 1} to {Math.min(endIndex, sortedData.length)}{" "}
+            of {sortedData.length} entries
+            {Object.keys(filters).some((key) => filters[key]) &&
+              ` (filtered from ${data.length})`}
+          </div>
+          <div style={{ display: "flex", gap: "8px", alignItems: "center" }}>
+            <Button
+              variant="secondary"
+              onClick={() => handlePageChange(1)}
+              disabled={currentPage === 1}
+            >
+              ««
+            </Button>
+            <Button
+              variant="secondary"
+              onClick={() => handlePageChange(currentPage - 1)}
+              disabled={currentPage === 1}
+            >
+              «
+            </Button>
+            <span style={{ fontSize: "14px" }}>
+              Page {currentPage} of {totalPages}
+            </span>
+            <Button
+              variant="secondary"
+              onClick={() => handlePageChange(currentPage + 1)}
+              disabled={currentPage === totalPages}
+            >
+              »
+            </Button>
+            <Button
+              variant="secondary"
+              onClick={() => handlePageChange(totalPages)}
+              disabled={currentPage === totalPages}
+            >
+              »»
+            </Button>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/packages/jazz-tools/src/inspector/ui/data-table.tsx
+++ b/packages/jazz-tools/src/inspector/ui/data-table.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   Table,
   TableBody,
@@ -95,7 +95,7 @@ export function DataTable<T>({
   const paginatedData = sortedData.slice(startIndex, endIndex);
 
   // Reset to page 1 when filters change
-  useMemo(() => {
+  useEffect(() => {
     setCurrentPage(1);
   }, [filters]);
 

--- a/packages/jazz-tools/src/inspector/ui/index.ts
+++ b/packages/jazz-tools/src/inspector/ui/index.ts
@@ -3,3 +3,4 @@ export { Icon } from "./icon.js";
 export { Modal } from "./modal.js";
 export { Input } from "./input.js";
 export { Select } from "./select.js";
+export { DataTable } from "./data-table.js";

--- a/packages/jazz-tools/src/inspector/viewer/history-view.tsx
+++ b/packages/jazz-tools/src/inspector/viewer/history-view.tsx
@@ -171,12 +171,12 @@ function mapTransactionToAction(
 
   if (isGroupExtension(change)) {
     const child = change.key.slice(6);
-    return `Group become a member of ${child}`;
+    return `Group became a member of ${child}`;
   }
 
   if (isGroupExtendRevocation(change)) {
     const child = change.key.slice(6);
-    return `Group has been revoked from ${child}`;
+    return `Group's membership of ${child} has been revoked.`;
   }
 
   if (isGroupPromotion(change)) {

--- a/packages/jazz-tools/src/inspector/viewer/history-view.tsx
+++ b/packages/jazz-tools/src/inspector/viewer/history-view.tsx
@@ -1,0 +1,308 @@
+import {
+  AccountRole,
+  BinaryStreamStart,
+  CoID,
+  JsonValue,
+  LocalNode,
+  OpID,
+  RawCoValue,
+  Role,
+} from "cojson";
+import { useMemo } from "react";
+import { isCoId } from "./types";
+import { AccountOrGroupText } from "./account-or-group-text";
+import { DataTable, ColumnDef } from "../ui/data-table";
+import { Heading } from "../ui/heading";
+import { MapOpPayload } from "cojson/dist/coValues/coMap.js";
+import {
+  DeletionOpPayload,
+  InsertionOpPayload,
+} from "cojson/dist/coValues/coList.js";
+import {
+  BinaryStreamChunk,
+  BinaryStreamEnd,
+} from "cojson/dist/coValues/coStream.js";
+
+type HistoryEntry = {
+  id: string;
+  author: string;
+  action: string;
+  timestamp: Date;
+};
+
+export function HistoryView({
+  coValue,
+  node,
+}: {
+  coValue: RawCoValue;
+  node: LocalNode;
+}) {
+  const transactions = useMemo(
+    () => getHistory(coValue),
+    [coValue.core.verifiedTransactions.length],
+  );
+
+  const columns: ColumnDef<HistoryEntry>[] = [
+    {
+      id: "author",
+      header: "Author",
+      accessor: (row) =>
+        row.author.startsWith("co_") ? (
+          <AccountOrGroupText
+            coId={row.author as CoID<RawCoValue>}
+            node={node}
+            showId
+          />
+        ) : (
+          row.author
+        ),
+      sortable: false,
+      filterable: true,
+      sortFn: (a, b) => a.author.localeCompare(b.author),
+      filterFn: (row, filterValue) =>
+        row.author.toLowerCase().includes(filterValue.toLowerCase()),
+    },
+    {
+      id: "action",
+      header: "Action",
+      accessor: (row) => row.action,
+      sortable: false,
+      filterable: true,
+      sortFn: (a, b) => a.action.localeCompare(b.action),
+    },
+    {
+      id: "timestamp",
+      header: "Timestamp",
+      accessor: (row) => row.timestamp.toISOString(),
+      sortable: true,
+      filterable: true,
+      sortFn: (a, b) => a.timestamp.getTime() - b.timestamp.getTime(),
+    },
+  ];
+
+  return (
+    <section style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
+      <Heading>CoValue history</Heading>
+      <DataTable
+        columns={columns}
+        data={transactions}
+        pageSize={10}
+        initialSort={{ columnId: "timestamp", direction: "desc" }}
+        getRowKey={(row) => row.id}
+        emptyMessage="No history available"
+      />
+    </section>
+  );
+}
+
+function getHistory(coValue: RawCoValue): HistoryEntry[] {
+  return coValue.core.verifiedTransactions.flatMap((tx, index) => {
+    if (tx.changes === undefined || tx.changes.length === 0) {
+      return [
+        {
+          id: `${tx.txID.sessionID.toString()}-${tx.txID.txIndex}-${index}`,
+          author: tx.author,
+          action: (tx.tx as any).changes,
+          timestamp: new Date(tx.currentMadeAt),
+        },
+      ];
+    }
+
+    return tx.changes.map((change, changeIndex) => ({
+      id: `${tx.txID.sessionID.toString()}-${tx.txID.txIndex}-${index}-${changeIndex}`,
+      author: tx.author,
+      action: mapTransactionToAction(change, coValue),
+      timestamp: new Date(tx.currentMadeAt),
+    }));
+  });
+}
+
+function mapTransactionToAction(
+  change: JsonValue,
+  coValue: RawCoValue,
+): string {
+  // Group changes
+  if (isUserPromotion(change)) {
+    if (change.value === "revoked") {
+      return `${change.key} has been revoked`;
+    }
+
+    return `${change.key} has been promoted to ${change.value}`;
+  }
+
+  if (isGroupExtension(change)) {
+    const child = change.key.slice(6);
+    return `Group become a member of ${child}`;
+  }
+
+  if (isGroupExtendRevocation(change)) {
+    const child = change.key.slice(6);
+    return `Group has been revoked from ${child}`;
+  }
+
+  if (isGroupPromotion(change)) {
+    const parent = change.key.slice(7);
+    return `Group ${parent} has been promoted to ${change.value}`;
+  }
+
+  if (isKeyRevelation(change)) {
+    const [key, target] = change.key.split("_for_");
+    return `Key "${key}" has been revealed to "${target}"`;
+  }
+
+  // coList changes
+  if (isItemAppend(change)) {
+    if (change.after === "start") {
+      return `"${change.value}" has been appended`;
+    }
+
+    const after = findListChange(change.after, coValue);
+
+    if (after === undefined) {
+      return `"${change.value}" has been inserted after undefined item`;
+    }
+
+    return `"${change.value}" has been inserted after "${(after as any).value}"`;
+  }
+
+  if (isItemPrepend(change)) {
+    if (change.before === "end") {
+      return `"${change.value}" has been prepended`;
+    }
+
+    const before = findListChange(change.before, coValue);
+
+    if (before === undefined) {
+      return `"${change.value}" has been inserted before undefined item`;
+    }
+
+    return `"${change.value}" has been inserted before "${(before as any).value}"`;
+  }
+
+  if (isItemDeletion(change)) {
+    const insertion = findListChange(change.insertion, coValue);
+    if (insertion === undefined) {
+      return `An undefined item has been deleted`;
+    }
+
+    return `"${(insertion as any).value}" has been deleted`;
+  }
+
+  // coStream changes
+  if (isStreamStart(change)) {
+    return `Stream started with mime type "${change.mimeType}" and file name "${change.fileName}"`;
+  }
+
+  if (isStreamChunk(change)) {
+    return `Stream chunk added`;
+  }
+
+  if (isStreamEnd(change)) {
+    return `Stream ended`;
+  }
+
+  // coMap changes
+  if (isPropertySet(change)) {
+    return `Property "${change.key}" has been set to "${change.value}"`;
+  }
+
+  if (isPropertyDeletion(change)) {
+    return `Property "${change.key}" has been deleted`;
+  }
+
+  return "Unknown action: " + JSON.stringify(change);
+}
+
+const findListChange = (
+  opId: OpID,
+  coValue: RawCoValue,
+): JsonValue | undefined => {
+  return coValue.core.verifiedTransactions.find(
+    (tx) =>
+      tx.txID.sessionID === opId.sessionID && tx.txID.txIndex === opId.txIndex,
+  )?.changes?.[opId.changeIdx];
+};
+
+const isGroupExtension = (
+  change: any,
+): change is Extract<
+  MapOpPayload<`child_${string}`, "extend">,
+  { op: "set" }
+> => {
+  return change?.op === "set" && change?.value === "extend";
+};
+
+const isGroupExtendRevocation = (
+  change: any,
+): change is Extract<
+  MapOpPayload<`child_${string}`, "revoked">,
+  { op: "set" }
+> => {
+  return change?.op === "set" && change?.value === "revoked";
+};
+
+const isGroupPromotion = (
+  change: any,
+): change is Extract<
+  MapOpPayload<`parent_co_${string}`, AccountRole>,
+  { op: "set" }
+> => {
+  return change?.op === "set" && change?.key.startsWith("parent_co_");
+};
+
+const isUserPromotion = (
+  change: any,
+): change is Extract<MapOpPayload<CoID<RawCoValue>, Role>, { op: "set" }> => {
+  return (
+    change?.op === "set" && (isCoId(change?.key) || change?.key === "everyone")
+  );
+};
+
+const isKeyRevelation = (
+  change: any,
+): change is Extract<
+  MapOpPayload<`${string}_for_${string}`, string>,
+  { op: "set" }
+> => {
+  return change?.op === "set" && change?.key.includes("_for_");
+};
+
+const isPropertySet = (
+  change: any,
+): change is Extract<MapOpPayload<string, any>, { op: "set" }> => {
+  return change?.op === "set" && "key" in change && "value" in change;
+};
+const isPropertyDeletion = (
+  change: any,
+): change is Extract<MapOpPayload<string, any>, { op: "del" }> => {
+  return change?.op === "del" && "key" in change;
+};
+
+const isItemAppend = (
+  change: any,
+): change is Extract<InsertionOpPayload<any>, { op: "app" }> => {
+  return change?.op === "app" && "after" in change && "value" in change;
+};
+const isItemPrepend = (
+  change: any,
+): change is Extract<InsertionOpPayload<any>, { op: "pre" }> => {
+  return change?.op === "pre" && "before" in change && "value" in change;
+};
+
+const isItemDeletion = (
+  change: any,
+): change is Extract<DeletionOpPayload, { op: "del" }> => {
+  return change?.op === "del" && "insertion" in change;
+};
+
+const isStreamStart = (change: any): change is BinaryStreamStart => {
+  return change?.type === "start" && "mimeType" in change;
+};
+
+const isStreamChunk = (change: any): change is BinaryStreamChunk => {
+  return change?.type === "chunk" && "chunk" in change;
+};
+
+const isStreamEnd = (change: any): change is BinaryStreamEnd => {
+  return change?.type === "end";
+};

--- a/packages/jazz-tools/src/inspector/viewer/page.tsx
+++ b/packages/jazz-tools/src/inspector/viewer/page.tsx
@@ -22,6 +22,7 @@ import { TableView } from "./table-viewer.js";
 import { TypeIcon } from "./type-icon.js";
 import { PageInfo } from "./types.js";
 import { resolveCoValue, useResolvedCoValue } from "./use-resolve-covalue.js";
+import { HistoryView } from "./history-view.js";
 
 interface PageContainerProps extends React.HTMLAttributes<HTMLDivElement> {
   isTopLevel?: boolean;
@@ -240,6 +241,7 @@ export function Page(props: PageProps) {
             </Text>
           </>
         )}
+        {value && <HistoryView coValue={value} node={node} />}
       </ContentContainer>
     </PageContainer>
   );


### PR DESCRIPTION
# Description

First iteration of adding a table with the history of all changes attached to the covalue. 

<img width="1680" height="807" alt="immagine" src="https://github.com/user-attachments/assets/4913e899-93ce-4a57-9828-755baea93c8b" />

Some open topics:
- Should the transaction's ID be visible somehow for debugging? Now, only the timestamp can help
- Double-check the action messages

Ref [GCO-928](https://linear.app/garden-co/issue/GCO-928/inspect-the-covalues-history)


## Manual testing instructions

[Inspector example](https://jazz-inspector-git-feat-insector-covalue-history-gcmp.vercel.app) in the preview


## What's missing
- [x] Mark invalid transactions