### PR TITLE
fix: refactor transaction decryption to use native method in RNQuickCrypto

### DIFF
--- a/.changeset/hot-wombats-go.md
+++ b/.changeset/hot-wombats-go.md
@@ -1,0 +1,5 @@
+---
+"cojson": patch
+---
+
+Switch to the native decrypt when decrypting transactions with RNQuickCrypto

--- a/packages/cojson/src/crypto/PureJSCrypto.ts
+++ b/packages/cojson/src/crypto/PureJSCrypto.ts
@@ -379,17 +379,11 @@ export class PureJSSessionLog implements SessionLogImpl {
         tx: { sessionID: this.sessionID, txIndex: txIndex },
       };
 
-      const nOnce = this.crypto.generateJsonNonce(nOnceMaterial);
-
-      const ciphertext = base64URLtoBytes(
-        tx.encryptedChanges.substring("encrypted_U".length),
+      return this.crypto.decryptRaw(
+        tx.encryptedChanges,
+        keySecret,
+        nOnceMaterial,
       );
-      const keySecretBytes = base58.decode(
-        keySecret.substring("keySecret_z".length),
-      );
-      const plaintext = xsalsa20(keySecretBytes, nOnce, ciphertext);
-
-      return textDecoder.decode(plaintext);
     } else {
       return tx.changes;
     }
@@ -415,17 +409,7 @@ export class PureJSSessionLog implements SessionLogImpl {
         tx: { sessionID: this.sessionID, txIndex: txIndex },
       };
 
-      const nOnce = this.crypto.generateJsonNonce(nOnceMaterial);
-
-      const ciphertext = base64URLtoBytes(
-        tx.meta.substring("encrypted_U".length),
-      );
-      const keySecretBytes = base58.decode(
-        keySecret.substring("keySecret_z".length),
-      );
-      const plaintext = xsalsa20(keySecretBytes, nOnce, ciphertext);
-
-      return textDecoder.decode(plaintext);
+      return this.crypto.decryptRaw(tx.meta, keySecret, nOnceMaterial);
     } else {
       return tx.meta;
     }


### PR DESCRIPTION
While reviewing the crypto code I noticed that SessionLog wasn't using the crypto.decrypt method but the implementation was inline, leading us to use a JS-based decrypt in ReactNative slowing down the decrypt by alot. 