### PR TITLE
Fix Image's lazy-loading placeholder transparency

### DIFF
--- a/.changeset/crisp-heads-cut.md
+++ b/.changeset/crisp-heads-cut.md
@@ -1,0 +1,6 @@
+---
+"community-jazz-vue": patch
+"jazz-tools": patch
+---
+
+fix: Image's lazy loading placeholder trasparency

--- a/packages/community-jazz-vue/src/Image.vue
+++ b/packages/community-jazz-vue/src/Image.vue
@@ -129,7 +129,7 @@ const emptyPixelBlob = new Blob(
   [
     Uint8Array.from(
       atob(
-        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==",
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=",
       ),
       (c) => c.charCodeAt(0),
     ),

--- a/packages/jazz-tools/src/media/create-image-factory.test.ts
+++ b/packages/jazz-tools/src/media/create-image-factory.test.ts
@@ -74,7 +74,7 @@ describe("createImage", async () => {
 
     getImageSize.mockResolvedValue({ width: 1, height: 1 });
     getPlaceholderBase64.mockResolvedValue(
-      "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==",
+      "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=",
     );
 
     const image = await createImage(imageBlob, {
@@ -204,7 +204,7 @@ describe("createImage", async () => {
 
 // 1x1 png
 const OnePixel = atob(
-  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==",
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=",
 );
 
 // Image 1920x400

--- a/packages/jazz-tools/src/svelte/media/image.svelte
+++ b/packages/jazz-tools/src/svelte/media/image.svelte
@@ -113,7 +113,7 @@
     [
       Uint8Array.from(
         atob(
-          "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==",
+          "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=",
         ),
         (c) => c.charCodeAt(0),
       ),

--- a/packages/jazz-tools/src/svelte/tests/media/image.svelte.test.ts
+++ b/packages/jazz-tools/src/svelte/tests/media/image.svelte.test.ts
@@ -626,7 +626,7 @@ describe("Image", async () => {
 
       const img = container.querySelector("img");
       expect(img).toBeDefined();
-      expect(img!.src).toBe("blob:test-70");
+      expect(img!.src).toBe("blob:test-68");
     });
 
     it("should load the image when threshold is reached", async () => {


### PR DESCRIPTION
# Description

The transparent pixel used for lazy-loading placeholders... wasn't transparent, but yellow.