### PR TITLE
feat: Schema-level CoValue resolution rules

### DIFF
--- a/packages/jazz-tools/src/tools/coValues/coList.ts
+++ b/packages/jazz-tools/src/tools/coValues/coList.ts
@@ -267,6 +267,7 @@ export class CoList<out Item = any>
     options?: {
       resolve?: RefsToResolveStrict<L, R>;
       loadAs?: Account | AnonymousJazzAgent;
+      unstable_branch?: BranchDefinition;
     },
   ): Promise<MaybeLoaded<Resolved<L, R>>> {
     return loadCoValueWithoutMe(this, id, options);

--- a/packages/jazz-tools/src/tools/coValues/interfaces.ts
+++ b/packages/jazz-tools/src/tools/coValues/interfaces.ts
@@ -784,7 +784,7 @@ export async function unstable_mergeBranchWithResolve<
   id: ID<CoValue>,
   options: {
     resolve?: ResolveQueryStrict<S, R>;
-    loadAs: Account | AnonymousJazzAgent;
+    loadAs?: Account | AnonymousJazzAgent;
     branch: BranchDefinition;
   },
 ) {

--- a/packages/jazz-tools/src/tools/exports.ts
+++ b/packages/jazz-tools/src/tools/exports.ts
@@ -110,6 +110,7 @@ export {
   coValueClassFromCoValueClassOrSchema,
   type InstanceOfSchema,
   type InstanceOfSchemaCoValuesMaybeLoaded,
+  type DefaultResolveQuery,
   type CoValueClassOrSchema,
   CoValueLoadingState,
   type MaybeLoaded,

--- a/packages/jazz-tools/src/tools/implementation/schemaUtils.ts
+++ b/packages/jazz-tools/src/tools/implementation/schemaUtils.ts
@@ -32,5 +32,5 @@ export function withDefaultResolveQuery<
     // TODO merge the default resolve query with the user-provided resolve query
     newOptions.resolve ||= defaultResolveQuery;
   }
-  return loadOptions as T;
+  return newOptions as T;
 }

--- a/packages/jazz-tools/src/tools/implementation/schemaUtils.ts
+++ b/packages/jazz-tools/src/tools/implementation/schemaUtils.ts
@@ -26,7 +26,7 @@ export function removeGetters<T extends object>(obj: T): Partial<T> {
 export function withDefaultResolveQuery<
   const T extends { resolve?: CoreResolveQuery },
 >(loadOptions: T | undefined, defaultResolveQuery: CoreResolveQuery): T {
-  const newOptions: CoreResolveQuery = loadOptions ? loadOptions : {};
+  const newOptions: CoreResolveQuery = loadOptions ? { ...loadOptions } : {};
   // If the default resolve query is `false`, don't add it
   if (defaultResolveQuery) {
     // TODO merge the default resolve query with the user-provided resolve query

--- a/packages/jazz-tools/src/tools/implementation/schemaUtils.ts
+++ b/packages/jazz-tools/src/tools/implementation/schemaUtils.ts
@@ -1,3 +1,5 @@
+import { CoreResolveQuery } from "./zodSchema/schemaTypes/CoValueSchema.js";
+
 /**
  * Remove getters from an object
  *
@@ -15,4 +17,20 @@ export function removeGetters<T extends object>(obj: T): Partial<T> {
   }
 
   return result;
+}
+
+/**
+ * Adds a CoValue schema's default resolve query to a load options object
+ * if no resolve query is provided.
+ */
+export function withDefaultResolveQuery<
+  const T extends { resolve?: CoreResolveQuery },
+>(loadOptions: T | undefined, defaultResolveQuery: CoreResolveQuery): T {
+  const newOptions: CoreResolveQuery = loadOptions ? loadOptions : {};
+  // If the default resolve query is `false`, don't add it
+  if (defaultResolveQuery) {
+    // TODO merge the default resolve query with the user-provided resolve query
+    newOptions.resolve ||= defaultResolveQuery;
+  }
+  return loadOptions as T;
 }

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/runtimeConverters/coValueSchemaTransformation.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/runtimeConverters/coValueSchemaTransformation.ts
@@ -1,6 +1,7 @@
 import { RawCoList, RawCoMap } from "cojson";
 import {
   Account,
+  AccountSchema,
   CoDiscriminatedUnionSchema,
   CoFeed,
   CoFeedSchema,
@@ -16,7 +17,6 @@ import {
   CoVectorSchema,
   PlainTextSchema,
   SchemaUnion,
-  enrichAccountSchema,
   isCoValueClass,
   Group,
   CoVector,
@@ -98,7 +98,7 @@ export function hydrateCoreCoValueSchema<S extends AnyCoreCoValueSchema>(
 
     const coValueSchema =
       ClassToExtend === Account
-        ? enrichAccountSchema(schema as any, coValueClass as any)
+        ? new AccountSchema(schema as any, coValueClass as any)
         : new CoMapSchema(schema as any, coValueClass as any);
 
     return coValueSchema as unknown as CoValueSchemaFromCoreSchema<S>;

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/runtimeConverters/coValueSchemaTransformation.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/runtimeConverters/coValueSchemaTransformation.ts
@@ -7,6 +7,7 @@ import {
   CoList,
   CoListSchema,
   CoMap,
+  CoMapSchema,
   CoPlainText,
   CoRichText,
   CoValueClass,
@@ -16,7 +17,6 @@ import {
   PlainTextSchema,
   SchemaUnion,
   enrichAccountSchema,
-  enrichCoMapSchema,
   isCoValueClass,
   Group,
   CoVector,
@@ -99,7 +99,7 @@ export function hydrateCoreCoValueSchema<S extends AnyCoreCoValueSchema>(
     const coValueSchema =
       ClassToExtend === Account
         ? enrichAccountSchema(schema as any, coValueClass as any)
-        : enrichCoMapSchema(schema as any, coValueClass as any);
+        : new CoMapSchema(schema as any, coValueClass as any);
 
     return coValueSchema as unknown as CoValueSchemaFromCoreSchema<S>;
   } else if (schema.builtin === "CoList") {

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/AccountSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/AccountSchema.ts
@@ -142,7 +142,10 @@ export class AccountSchema<
   }
 
   subscribe<
-    const R extends RefsToResolve<Simplify<AccountInstance<Shape>>> = true,
+    const R extends RefsToResolve<
+      Simplify<AccountInstance<Shape>>
+      // @ts-expect-error
+    > = EagerlyLoaded extends false ? true : this["defaultResolveQuery"],
   >(
     id: string,
     options: SubscribeListenerOptions<Simplify<AccountInstance<Shape>>, R>,
@@ -151,8 +154,12 @@ export class AccountSchema<
       unsubscribe: () => void,
     ) => void,
   ): () => void {
-    // @ts-expect-error
-    return this.coValueClass.subscribe(id, options, listener);
+    return this.coValueClass.subscribe(
+      id,
+      // @ts-expect-error
+      withDefaultResolveQuery(options, this.defaultResolveQuery),
+      listener,
+    );
   }
 
   getMe(): Loaded<this, true> {

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoDiscriminatedUnionSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoDiscriminatedUnionSchema.ts
@@ -69,7 +69,6 @@ export class CoDiscriminatedUnionSchema<
     >,
   ) {
     this.getDefinition = coreSchema.getDefinition;
-    // TODO infer default resolve query from the union's members
   }
 
   load(

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoFeedSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoFeedSchema.ts
@@ -64,7 +64,7 @@ export class CoFeedSchema<T extends AnyZodOrCoValueSchema>
     const R extends RefsToResolve<CoFeedInstanceCoValuesMaybeLoaded<T>> = true,
   >(
     id: string,
-    options?: {
+    options: {
       resolve?: RefsToResolveStrict<CoFeedInstanceCoValuesMaybeLoaded<T>, R>;
       loadAs?: Account | AnonymousJazzAgent;
       branch: BranchDefinition;

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoFeedSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoFeedSchema.ts
@@ -10,8 +10,10 @@ import {
   RefsToResolveStrict,
   Resolved,
   SubscribeListenerOptions,
+  SubscribeRestArgs,
   coOptionalDefiner,
   unstable_mergeBranchWithResolve,
+  parseSubscribeRestArgs,
   ResolveQuery,
 } from "../../../internal.js";
 import { AnonymousJazzAgent } from "../../anonymousJazzAgent.js";
@@ -113,7 +115,10 @@ export class CoFeedSchema<
     ) => void,
   ): () => void;
   subscribe<
-    const R extends RefsToResolve<CoFeedInstanceCoValuesMaybeLoaded<T>> = true,
+    const R extends RefsToResolve<
+      CoFeedInstanceCoValuesMaybeLoaded<T>
+      // @ts-expect-error
+    > = EagerlyLoaded extends false ? true : this["defaultResolveQuery"],
   >(
     id: string,
     options: SubscribeListenerOptions<CoFeedInstanceCoValuesMaybeLoaded<T>, R>,
@@ -122,9 +127,14 @@ export class CoFeedSchema<
       unsubscribe: () => void,
     ) => void,
   ): () => void;
-  subscribe(...args: [any, ...any[]]) {
-    // @ts-expect-error
-    return this.coValueClass.subscribe(...args);
+  subscribe(id: string, ...args: any) {
+    const { options, listener } = parseSubscribeRestArgs(args);
+    return this.coValueClass.subscribe(
+      id,
+      // @ts-expect-error
+      withDefaultResolveQuery(options, this.defaultResolveQuery),
+      listener,
+    );
   }
 
   getCoValueClass(): typeof CoFeed {

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoFeedSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoFeedSchema.ts
@@ -94,7 +94,10 @@ export class CoFeedSchema<
   }
 
   unstable_merge<
-    const R extends RefsToResolve<CoFeedInstanceCoValuesMaybeLoaded<T>> = true,
+    const R extends RefsToResolve<
+      CoFeedInstanceCoValuesMaybeLoaded<T>
+      // @ts-expect-error
+    > = EagerlyLoaded extends false ? true : this["defaultResolveQuery"],
   >(
     id: string,
     options: {
@@ -103,8 +106,12 @@ export class CoFeedSchema<
       branch: BranchDefinition;
     },
   ): Promise<void> {
-    // @ts-expect-error
-    return unstable_mergeBranchWithResolve(this.coValueClass, id, options);
+    return unstable_mergeBranchWithResolve(
+      this.coValueClass,
+      id,
+      // @ts-expect-error
+      withDefaultResolveQuery(options, this.defaultResolveQuery),
+    );
   }
 
   subscribe(

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoFeedSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoFeedSchema.ts
@@ -11,19 +11,28 @@ import {
   SubscribeListenerOptions,
   coOptionalDefiner,
   unstable_mergeBranchWithResolve,
+  ResolveQuery,
 } from "../../../internal.js";
 import { AnonymousJazzAgent } from "../../anonymousJazzAgent.js";
 import { CoFeedSchemaInit } from "../typeConverters/CoFieldSchemaInit.js";
 import { InstanceOrPrimitiveOfSchema } from "../typeConverters/InstanceOrPrimitiveOfSchema.js";
 import { InstanceOrPrimitiveOfSchemaCoValuesMaybeLoaded } from "../typeConverters/InstanceOrPrimitiveOfSchemaCoValuesMaybeLoaded.js";
 import { CoOptionalSchema } from "./CoOptionalSchema.js";
-import { CoreCoValueSchema } from "./CoValueSchema.js";
+import { CoreCoValueSchema, CoreResolveQuery } from "./CoValueSchema.js";
 
+// TODO add type parameter for default resolve query
 export class CoFeedSchema<T extends AnyZodOrCoValueSchema>
   implements CoreCoFeedSchema<T>
 {
   collaborative = true as const;
   builtin = "CoFeed" as const;
+
+  /**
+   * The default resolve query to be used when loading instances of this schema.
+   * Defaults to `false`, meaning that no resolve query will used by default.
+   * @internal
+   */
+  public defaultResolveQuery: CoreResolveQuery = false;
 
   constructor(
     public element: T,
@@ -103,6 +112,12 @@ export class CoFeedSchema<T extends AnyZodOrCoValueSchema>
   optional(): CoOptionalSchema<this> {
     return coOptionalDefiner(this);
   }
+
+  resolved(): CoFeedSchema<T> {
+    const copy = new CoFeedSchema(this.element, this.coValueClass);
+    copy.defaultResolveQuery = true;
+    return copy;
+  }
 }
 
 export function createCoreCoFeedSchema<T extends AnyZodOrCoValueSchema>(
@@ -112,6 +127,7 @@ export function createCoreCoFeedSchema<T extends AnyZodOrCoValueSchema>(
     collaborative: true as const,
     builtin: "CoFeed" as const,
     element,
+    defaultResolveQuery: false,
   };
 }
 

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoListSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoListSchema.ts
@@ -74,7 +74,7 @@ export class CoListSchema<T extends AnyZodOrCoValueSchema>
     const R extends RefsToResolve<CoListInstanceCoValuesMaybeLoaded<T>> = true,
   >(
     id: string,
-    options?: {
+    options: {
       resolve?: RefsToResolveStrict<CoListInstanceCoValuesMaybeLoaded<T>, R>;
       loadAs?: Account | AnonymousJazzAgent;
       branch: BranchDefinition;

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoListSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoListSchema.ts
@@ -166,7 +166,10 @@ export class CoListSchema<
   }
 
   loadUnique<
-    const R extends RefsToResolve<CoListInstanceCoValuesMaybeLoaded<T>> = true,
+    const R extends RefsToResolve<
+      CoListInstanceCoValuesMaybeLoaded<T>
+      // @ts-expect-error
+    > = EagerlyLoaded extends false ? true : this["defaultResolveQuery"],
   >(
     unique: CoValueUniqueness["uniqueness"],
     ownerID: ID<Account> | ID<Group>,
@@ -176,7 +179,12 @@ export class CoListSchema<
     },
   ): Promise<MaybeLoaded<Resolved<CoListInstanceCoValuesMaybeLoaded<T>, R>>> {
     // @ts-expect-error
-    return this.coValueClass.loadUnique(unique, ownerID, options);
+    return this.coValueClass.loadUnique(
+      unique,
+      ownerID,
+      // @ts-expect-error
+      withDefaultResolveQuery(options, this.defaultResolveQuery),
+    );
   }
 
   optional(): CoOptionalSchema<this> {

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoListSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoListSchema.ts
@@ -148,7 +148,10 @@ export class CoListSchema<
   }
 
   upsertUnique<
-    const R extends RefsToResolve<CoListInstanceCoValuesMaybeLoaded<T>> = true,
+    const R extends RefsToResolve<
+      CoListInstanceCoValuesMaybeLoaded<T>
+      // @ts-expect-error
+    > = EagerlyLoaded extends false ? true : this["defaultResolveQuery"],
   >(options: {
     value: CoListSchemaInit<T>;
     unique: CoValueUniqueness["uniqueness"];
@@ -156,7 +159,10 @@ export class CoListSchema<
     resolve?: RefsToResolveStrict<CoListInstanceCoValuesMaybeLoaded<T>, R>;
   }): Promise<MaybeLoaded<Resolved<CoListInstanceCoValuesMaybeLoaded<T>, R>>> {
     // @ts-expect-error
-    return this.coValueClass.upsertUnique(options);
+    return this.coValueClass.upsertUnique(
+      // @ts-expect-error
+      withDefaultResolveQuery(options, this.defaultResolveQuery),
+    );
   }
 
   loadUnique<

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoListSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoListSchema.ts
@@ -115,7 +115,10 @@ export class CoListSchema<
   }
 
   subscribe<
-    const R extends RefsToResolve<CoListInstanceCoValuesMaybeLoaded<T>> = true,
+    const R extends RefsToResolve<
+      CoListInstanceCoValuesMaybeLoaded<T>
+      // @ts-expect-error
+    > = EagerlyLoaded extends false ? true : this["defaultResolveQuery"],
   >(
     id: string,
     options: SubscribeListenerOptions<CoListInstanceCoValuesMaybeLoaded<T>, R>,
@@ -124,7 +127,11 @@ export class CoListSchema<
       unsubscribe: () => void,
     ) => void,
   ): () => void {
-    return this.coValueClass.subscribe(id, options, listener);
+    return this.coValueClass.subscribe(
+      id,
+      withDefaultResolveQuery(options, this.defaultResolveQuery),
+      listener,
+    );
   }
 
   getCoValueClass(): typeof CoList {

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoListSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoListSchema.ts
@@ -4,7 +4,7 @@ import {
   CoList,
   Group,
   ID,
-  isCoValueSchema,
+  isAnyCoValueSchema,
   MaybeLoaded,
   RefsToResolve,
   RefsToResolveStrict,
@@ -42,10 +42,10 @@ export class CoListSchema<
     if (!this.isEagerlyLoaded) {
       return false as DefaultResolveQuery<this>;
     }
-    if (isCoValueSchema(this.element) && this.element.defaultResolveQuery) {
+    if (isAnyCoValueSchema(this.element) && this.element.defaultResolveQuery) {
       return {
         $each: this.element.defaultResolveQuery,
-      } as unknown as DefaultResolveQuery<this>;
+      } as DefaultResolveQuery<this>;
     }
     return true as DefaultResolveQuery<this>;
   }

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoListSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoListSchema.ts
@@ -101,7 +101,10 @@ export class CoListSchema<
   }
 
   unstable_merge<
-    const R extends RefsToResolve<CoListInstanceCoValuesMaybeLoaded<T>> = true,
+    const R extends RefsToResolve<
+      CoListInstanceCoValuesMaybeLoaded<T>
+      // @ts-expect-error
+    > = EagerlyLoaded extends false ? true : this["defaultResolveQuery"],
   >(
     id: string,
     options: {
@@ -110,8 +113,12 @@ export class CoListSchema<
       branch: BranchDefinition;
     },
   ): Promise<void> {
-    // @ts-expect-error
-    return unstable_mergeBranchWithResolve(this.coValueClass, id, options);
+    return unstable_mergeBranchWithResolve(
+      this.coValueClass,
+      id,
+      // @ts-expect-error
+      withDefaultResolveQuery(options, this.defaultResolveQuery),
+    );
   }
 
   subscribe<

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoMapSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoMapSchema.ts
@@ -102,7 +102,7 @@ export class CoMapSchema<
     > = true,
   >(
     id: string,
-    options?: {
+    options: {
       resolve?: RefsToResolveStrict<
         Simplify<CoMapInstanceCoValuesMaybeLoaded<Shape>> & CoMap,
         R

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoMapSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoMapSchema.ts
@@ -156,7 +156,8 @@ export class CoMapSchema<
   subscribe<
     const R extends RefsToResolve<
       Simplify<CoMapInstanceCoValuesMaybeLoaded<Shape>> & CoMap
-    > = true,
+      // @ts-expect-error
+    > = EagerlyLoaded extends false ? true : this["defaultResolveQuery"],
   >(
     id: string,
     options: SubscribeListenerOptions<
@@ -172,7 +173,11 @@ export class CoMapSchema<
     ) => void,
   ): () => void {
     // @ts-expect-error
-    return this.coValueClass.subscribe(id, options, listener);
+    return this.coValueClass.subscribe(
+      id,
+      withDefaultResolveQuery(options, this.defaultResolveQuery),
+      listener,
+    );
   }
 
   /** @deprecated Use `CoMap.upsertUnique` and `CoMap.loadUnique` instead. */

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoMapSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoMapSchema.ts
@@ -441,7 +441,7 @@ export type PartialShape<
 
 type FalseIfEmpty<T> = keyof T extends never ? false : T;
 
-type DefaultResolveQueryOfShape<Shape extends z.core.$ZodLooseShape> =
+export type DefaultResolveQueryOfShape<Shape extends z.core.$ZodLooseShape> =
   FalseIfEmpty<{
     [K in keyof Shape as DefaultResolveQueryOfSchema<Shape[K]> extends false
       ? never

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoMapSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoMapSchema.ts
@@ -137,7 +137,8 @@ export class CoMapSchema<
   unstable_merge<
     const R extends RefsToResolve<
       Simplify<CoMapInstanceCoValuesMaybeLoaded<Shape>> & CoMap
-    > = true,
+      // @ts-expect-error
+    > = EagerlyLoaded extends false ? true : this["defaultResolveQuery"],
   >(
     id: string,
     options: {
@@ -149,8 +150,12 @@ export class CoMapSchema<
       branch: BranchDefinition;
     },
   ): Promise<void> {
-    // @ts-expect-error
-    return unstable_mergeBranchWithResolve(this.coValueClass, id, options);
+    return unstable_mergeBranchWithResolve(
+      this.coValueClass,
+      id,
+      // @ts-expect-error
+      withDefaultResolveQuery(options, this.defaultResolveQuery),
+    );
   }
 
   subscribe<

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoMapSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoMapSchema.ts
@@ -192,7 +192,8 @@ export class CoMapSchema<
   upsertUnique<
     const R extends RefsToResolve<
       Simplify<CoMapInstanceCoValuesMaybeLoaded<Shape>> & CoMap
-    > = true,
+      // @ts-expect-error
+    > = EagerlyLoaded extends false ? true : this["defaultResolveQuery"],
   >(options: {
     value: Simplify<CoMapSchemaInit<Shape>>;
     unique: CoValueUniqueness["uniqueness"];
@@ -207,7 +208,10 @@ export class CoMapSchema<
     >
   > {
     // @ts-expect-error
-    return this.coValueClass.upsertUnique(options);
+    return this.coValueClass.upsertUnique(
+      // @ts-expect-error
+      withDefaultResolveQuery(options, this.defaultResolveQuery),
+    );
   }
 
   loadUnique<

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoMapSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoMapSchema.ts
@@ -217,7 +217,8 @@ export class CoMapSchema<
   loadUnique<
     const R extends RefsToResolve<
       Simplify<CoMapInstanceCoValuesMaybeLoaded<Shape>> & CoMap
-    > = true,
+      // @ts-expect-error
+    > = EagerlyLoaded extends false ? true : this["defaultResolveQuery"],
   >(
     unique: CoValueUniqueness["uniqueness"],
     ownerID: string,
@@ -234,7 +235,12 @@ export class CoMapSchema<
     >
   > {
     // @ts-expect-error
-    return this.coValueClass.loadUnique(unique, ownerID, options);
+    return this.coValueClass.loadUnique(
+      unique,
+      ownerID,
+      // @ts-expect-error
+      withDefaultResolveQuery(options, this.defaultResolveQuery),
+    );
   }
 
   /**

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoOptionalSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoOptionalSchema.ts
@@ -1,4 +1,4 @@
-import { isCoValueSchema } from "../../../internal.js";
+import { isAnyCoValueSchema } from "../../../internal.js";
 import { CoValueSchemaFromCoreSchema, ResolveQuery } from "../zodSchema.js";
 import { CoreCoValueSchema, CoreResolveQuery } from "./CoValueSchema.js";
 import { DefaultResolveQueryOfSchema } from "../typeConverters/DefaultResolveQueryOfSchema.js";
@@ -38,10 +38,11 @@ export class CoOptionalSchema<
     if (!this.isEagerlyLoaded) {
       return false as DefaultResolveQuery<this>;
     }
-    // Cast to CoreCoValueSchema to avoid excessively deep type resolution for innerType.defaultResolveQuery
-    const innerType: CoreCoValueSchema = this.innerType;
-    if (isCoValueSchema(innerType) && innerType.defaultResolveQuery) {
-      return innerType.defaultResolveQuery as DefaultResolveQuery<this>;
+    if (
+      isAnyCoValueSchema(this.innerType) &&
+      this.innerType.defaultResolveQuery
+    ) {
+      return this.innerType.defaultResolveQuery as DefaultResolveQuery<this>;
     }
     return true as DefaultResolveQuery<this>;
   }

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoRecordSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoRecordSchema.ts
@@ -72,7 +72,7 @@ export interface CoRecordSchema<
     > = true,
   >(
     id: string,
-    options?: {
+    options: {
       resolve?: RefsToResolveStrict<
         CoRecordInstanceCoValuesMaybeLoaded<K, V>,
         R

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoRecordSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoRecordSchema.ts
@@ -133,7 +133,8 @@ export interface CoRecordSchema<
   loadUnique<
     const R extends RefsToResolve<
       CoRecordInstanceCoValuesMaybeLoaded<K, V>
-    > = true,
+      // @ts-expect-error
+    > = EagerlyLoaded extends false ? true : this["defaultResolveQuery"],
   >(
     unique: CoValueUniqueness["uniqueness"],
     ownerID: ID<Account> | ID<Group>,

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoRecordSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoRecordSchema.ts
@@ -33,6 +33,7 @@ type CoRecordInit<
 export interface CoRecordSchema<
   K extends z.core.$ZodString<string>,
   V extends AnyZodOrCoValueSchema,
+  // TODO add type parameter for default resolve query
   DefaultResolveQuery extends CoreResolveQuery = false,
 > extends CoreCoRecordSchema<K, V> {
   defaultResolveQuery: CoreResolveQuery;

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoRecordSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoRecordSchema.ts
@@ -95,7 +95,8 @@ export interface CoRecordSchema<
   subscribe<
     const R extends RefsToResolve<
       CoRecordInstanceCoValuesMaybeLoaded<K, V>
-    > = true,
+      // @ts-expect-error
+    > = EagerlyLoaded extends false ? true : this["defaultResolveQuery"],
   >(
     id: ID<CoRecordInstanceCoValuesMaybeLoaded<K, V>>,
     options: SubscribeListenerOptions<

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoRecordSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoRecordSchema.ts
@@ -119,7 +119,8 @@ export interface CoRecordSchema<
   upsertUnique<
     const R extends RefsToResolve<
       CoRecordInstanceCoValuesMaybeLoaded<K, V>
-    > = true,
+      // @ts-expect-error
+    > = EagerlyLoaded extends false ? true : this["defaultResolveQuery"],
   >(options: {
     value: Simplify<CoRecordInit<K, V>>;
     unique: CoValueUniqueness["uniqueness"];

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoRecordSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoRecordSchema.ts
@@ -10,6 +10,7 @@ import {
   RefsToResolve,
   RefsToResolveStrict,
   Resolved,
+  ResolveQuery,
   Simplify,
   SubscribeListenerOptions,
 } from "../../../internal.js";
@@ -20,7 +21,7 @@ import { InstanceOrPrimitiveOfSchemaCoValuesMaybeLoaded } from "../typeConverter
 import { z } from "../zodReExport.js";
 import { AnyZodOrCoValueSchema } from "../zodSchema.js";
 import { CoOptionalSchema } from "./CoOptionalSchema.js";
-import { CoreCoValueSchema } from "./CoValueSchema.js";
+import { CoreCoValueSchema, CoreResolveQuery } from "./CoValueSchema.js";
 
 type CoRecordInit<
   K extends z.core.$ZodString<string>,
@@ -32,7 +33,10 @@ type CoRecordInit<
 export interface CoRecordSchema<
   K extends z.core.$ZodString<string>,
   V extends AnyZodOrCoValueSchema,
+  DefaultResolveQuery extends CoreResolveQuery = false,
 > extends CoreCoRecordSchema<K, V> {
+  defaultResolveQuery: CoreResolveQuery;
+
   create(
     init: Simplify<CoRecordInit<K, V>>,
     options?:
@@ -139,6 +143,9 @@ export interface CoRecordSchema<
   getCoValueClass: () => typeof CoMap;
 
   optional(): CoOptionalSchema<this>;
+
+  // TODO: wrap value's default resolve query with { $each: { ... } } if it's set
+  resolved(): CoRecordSchema<K, V, true>;
 }
 
 type CoRecordSchemaDefinition<

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoValueSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoValueSchema.ts
@@ -1,3 +1,10 @@
+import { ResolveQuery } from "../zodSchema.js";
+
+/**
+ * Simplified type for {@link ResolveQuery}, used to avoid circularity issues.
+ */
+export type CoreResolveQuery = boolean | Record<string, any>;
+
 /**
  * "Core" CoValue schemas contain all data necessary to represent a CoValue schema.
  * Behavior is provided by CoValue schemas that extend "core" CoValue schema data structures.
@@ -15,4 +22,6 @@ export interface CoreCoValueSchema {
    * Used for discriminating between different CoValue schemas.
    */
   builtin: string;
+
+  defaultResolveQuery: CoreResolveQuery;
 }

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoVectorSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoVectorSchema.ts
@@ -27,20 +27,21 @@ export function createCoreCoVectorSchema(
   };
 }
 
-export class CoVectorSchema<
-  DefaultResolveQuery extends CoreResolveQuery = false,
-> implements CoreCoVectorSchema
+export class CoVectorSchema<EagerlyLoaded extends boolean = false>
+  implements CoreCoVectorSchema
 {
   readonly collaborative = true as const;
   readonly builtin = "CoVector" as const;
 
+  private isEagerlyLoaded: EagerlyLoaded = false as EagerlyLoaded;
   /**
    * The default resolve query to be used when loading instances of this schema.
    * Defaults to `false`, meaning that no resolve query will be used by default.
    * @internal
    */
-  public defaultResolveQuery: DefaultResolveQuery =
-    false as DefaultResolveQuery;
+  get defaultResolveQuery(): boolean {
+    return this.isEagerlyLoaded;
+  }
 
   constructor(
     public dimensions: number,
@@ -112,8 +113,11 @@ export class CoVectorSchema<
   }
 
   resolved(): CoVectorSchema<true> {
+    if (this.isEagerlyLoaded) {
+      return this as CoVectorSchema<true>;
+    }
     const copy = new CoVectorSchema<true>(this.dimensions, this.coValueClass);
-    copy.defaultResolveQuery = true;
+    copy.isEagerlyLoaded = true;
     return copy;
   }
 }

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoVectorSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoVectorSchema.ts
@@ -6,9 +6,10 @@ import {
   InstanceOrPrimitiveOfSchema,
   InstanceOrPrimitiveOfSchemaCoValuesMaybeLoaded,
   coOptionalDefiner,
+  ResolveQuery,
 } from "../../../internal.js";
 import { CoOptionalSchema } from "./CoOptionalSchema.js";
-import { CoreCoValueSchema } from "./CoValueSchema.js";
+import { CoreCoValueSchema, CoreResolveQuery } from "./CoValueSchema.js";
 
 export interface CoreCoVectorSchema extends CoreCoValueSchema {
   builtin: "CoVector";
@@ -22,12 +23,24 @@ export function createCoreCoVectorSchema(
     collaborative: true as const,
     builtin: "CoVector" as const,
     dimensions,
+    defaultResolveQuery: false,
   };
 }
 
-export class CoVectorSchema implements CoreCoVectorSchema {
+export class CoVectorSchema<
+  DefaultResolveQuery extends CoreResolveQuery = false,
+> implements CoreCoVectorSchema
+{
   readonly collaborative = true as const;
   readonly builtin = "CoVector" as const;
+
+  /**
+   * The default resolve query to be used when loading instances of this schema.
+   * Defaults to `false`, meaning that no resolve query will be used by default.
+   * @internal
+   */
+  public defaultResolveQuery: DefaultResolveQuery =
+    false as DefaultResolveQuery;
 
   constructor(
     public dimensions: number,
@@ -96,6 +109,12 @@ export class CoVectorSchema implements CoreCoVectorSchema {
 
   optional(): CoOptionalSchema<this> {
     return coOptionalDefiner(this);
+  }
+
+  resolved(): CoVectorSchema<true> {
+    const copy = new CoVectorSchema<true>(this.dimensions, this.coValueClass);
+    copy.defaultResolveQuery = true;
+    return copy;
   }
 }
 

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/FileStreamSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/FileStreamSchema.ts
@@ -23,20 +23,21 @@ export function createCoreFileStreamSchema(): CoreFileStreamSchema {
   };
 }
 
-export class FileStreamSchema<
-  DefaultResolveQuery extends CoreResolveQuery = false,
-> implements CoreFileStreamSchema
+export class FileStreamSchema<EagerlyLoaded extends boolean = false>
+  implements CoreFileStreamSchema
 {
   readonly collaborative = true as const;
   readonly builtin = "FileStream" as const;
 
+  private isEagerlyLoaded: EagerlyLoaded = false as EagerlyLoaded;
   /**
    * The default resolve query to be used when loading instances of this schema.
    * Defaults to `false`, meaning that no resolve query will be used by default.
    * @internal
    */
-  public defaultResolveQuery: DefaultResolveQuery =
-    false as DefaultResolveQuery;
+  get defaultResolveQuery(): EagerlyLoaded {
+    return this.isEagerlyLoaded;
+  }
 
   constructor(private coValueClass: typeof FileStream) {}
 
@@ -128,8 +129,11 @@ export class FileStreamSchema<
   }
 
   resolved(): FileStreamSchema<true> {
+    if (this.isEagerlyLoaded) {
+      return this as FileStreamSchema<true>;
+    }
     const copy = new FileStreamSchema<true>(this.coValueClass);
-    copy.defaultResolveQuery = true;
+    copy.isEagerlyLoaded = true;
     return copy;
   }
 }

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/FileStreamSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/FileStreamSchema.ts
@@ -5,10 +5,11 @@ import {
   Group,
   MaybeLoaded,
   coOptionalDefiner,
+  ResolveQuery,
   unstable_mergeBranchWithResolve,
 } from "../../../internal.js";
 import { CoOptionalSchema } from "./CoOptionalSchema.js";
-import { CoreCoValueSchema } from "./CoValueSchema.js";
+import { CoreCoValueSchema, CoreResolveQuery } from "./CoValueSchema.js";
 
 export interface CoreFileStreamSchema extends CoreCoValueSchema {
   builtin: "FileStream";
@@ -18,12 +19,24 @@ export function createCoreFileStreamSchema(): CoreFileStreamSchema {
   return {
     collaborative: true as const,
     builtin: "FileStream" as const,
+    defaultResolveQuery: false,
   };
 }
 
-export class FileStreamSchema implements CoreFileStreamSchema {
+export class FileStreamSchema<
+  DefaultResolveQuery extends CoreResolveQuery = false,
+> implements CoreFileStreamSchema
+{
   readonly collaborative = true as const;
   readonly builtin = "FileStream" as const;
+
+  /**
+   * The default resolve query to be used when loading instances of this schema.
+   * Defaults to `false`, meaning that no resolve query will be used by default.
+   * @internal
+   */
+  public defaultResolveQuery: DefaultResolveQuery =
+    false as DefaultResolveQuery;
 
   constructor(private coValueClass: typeof FileStream) {}
 
@@ -112,5 +125,11 @@ export class FileStreamSchema implements CoreFileStreamSchema {
 
   optional(): CoOptionalSchema<this> {
     return coOptionalDefiner(this);
+  }
+
+  resolved(): FileStreamSchema<true> {
+    const copy = new FileStreamSchema<true>(this.coValueClass);
+    copy.defaultResolveQuery = true;
+    return copy;
   }
 }

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/GroupSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/GroupSchema.ts
@@ -12,7 +12,7 @@ import {
   Resolved,
   ResolveQuery,
 } from "../../../internal.js";
-import { CoreCoValueSchema } from "./CoValueSchema.js";
+import { CoreCoValueSchema, CoreResolveQuery } from "./CoValueSchema.js";
 import { coOptionalDefiner } from "../zodCo.js";
 import { CoOptionalSchema } from "./CoOptionalSchema.js";
 import type { AccountRole, InviteSecret } from "cojson";
@@ -25,12 +25,25 @@ export function createCoreGroupSchema(): CoreGroupSchema {
   return {
     collaborative: true as const,
     builtin: "Group" as const,
+    defaultResolveQuery: false,
   };
 }
 
-export class GroupSchema implements CoreGroupSchema {
+export class GroupSchema<DefaultResolveQuery extends CoreResolveQuery = false>
+  implements CoreGroupSchema
+{
   readonly collaborative = true as const;
   readonly builtin = "Group" as const;
+
+  /**
+   * The default resolve query to be used when loading instances of this schema.
+   * Defaults to `false`, meaning that no resolve query will be used by default.
+   * @internal
+   */
+  public defaultResolveQuery: DefaultResolveQuery =
+    false as DefaultResolveQuery;
+
+  constructor() {}
 
   getCoValueClass(): typeof Group {
     return Group;
@@ -38,6 +51,12 @@ export class GroupSchema implements CoreGroupSchema {
 
   optional(): CoOptionalSchema<this> {
     return coOptionalDefiner(this);
+  }
+
+  resolved(): GroupSchema<true> {
+    const copy = new GroupSchema<true>();
+    copy.defaultResolveQuery = true;
+    return copy;
   }
 
   create(options?: { owner: Account } | Account) {

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/GroupSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/GroupSchema.ts
@@ -29,19 +29,21 @@ export function createCoreGroupSchema(): CoreGroupSchema {
   };
 }
 
-export class GroupSchema<DefaultResolveQuery extends CoreResolveQuery = false>
+export class GroupSchema<EagerlyLoaded extends boolean = false>
   implements CoreGroupSchema
 {
   readonly collaborative = true as const;
   readonly builtin = "Group" as const;
 
+  private isEagerlyLoaded: EagerlyLoaded = false as EagerlyLoaded;
   /**
    * The default resolve query to be used when loading instances of this schema.
    * Defaults to `false`, meaning that no resolve query will be used by default.
    * @internal
    */
-  public defaultResolveQuery: DefaultResolveQuery =
-    false as DefaultResolveQuery;
+  get defaultResolveQuery(): EagerlyLoaded {
+    return this.isEagerlyLoaded;
+  }
 
   constructor() {}
 
@@ -54,8 +56,11 @@ export class GroupSchema<DefaultResolveQuery extends CoreResolveQuery = false>
   }
 
   resolved(): GroupSchema<true> {
+    if (this.isEagerlyLoaded) {
+      return this as GroupSchema<true>;
+    }
     const copy = new GroupSchema<true>();
-    copy.defaultResolveQuery = true;
+    copy.isEagerlyLoaded = true;
     return copy;
   }
 

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/PlainTextSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/PlainTextSchema.ts
@@ -25,20 +25,21 @@ export function createCoreCoPlainTextSchema(): CorePlainTextSchema {
   };
 }
 
-export class PlainTextSchema<
-  DefaultResolveQuery extends CoreResolveQuery = false,
-> implements CorePlainTextSchema
+export class PlainTextSchema<EagerlyLoaded extends boolean = false>
+  implements CorePlainTextSchema
 {
   readonly collaborative = true as const;
   readonly builtin = "CoPlainText" as const;
 
+  private isEagerlyLoaded: EagerlyLoaded = false as EagerlyLoaded;
   /**
    * The default resolve query to be used when loading instances of this schema.
    * Defaults to `false`, meaning that no resolve query will be used by default.
    * @internal
    */
-  public defaultResolveQuery: DefaultResolveQuery =
-    false as DefaultResolveQuery;
+  get defaultResolveQuery(): EagerlyLoaded {
+    return this.isEagerlyLoaded;
+  }
 
   constructor(private coValueClass: typeof CoPlainText) {}
 
@@ -103,8 +104,11 @@ export class PlainTextSchema<
   }
 
   resolved(): PlainTextSchema<true> {
+    if (this.isEagerlyLoaded) {
+      return this as PlainTextSchema<true>;
+    }
     const copy = new PlainTextSchema<true>(this.coValueClass);
-    copy.defaultResolveQuery = true;
+    copy.isEagerlyLoaded = true;
     return copy;
   }
 }

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/PlainTextSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/PlainTextSchema.ts
@@ -7,10 +7,11 @@ import {
   MaybeLoaded,
   coOptionalDefiner,
   unstable_mergeBranchWithResolve,
+  ResolveQuery,
 } from "../../../internal.js";
 import { AnonymousJazzAgent } from "../../anonymousJazzAgent.js";
 import { CoOptionalSchema } from "./CoOptionalSchema.js";
-import { CoreCoValueSchema } from "./CoValueSchema.js";
+import { CoreCoValueSchema, CoreResolveQuery } from "./CoValueSchema.js";
 
 export interface CorePlainTextSchema extends CoreCoValueSchema {
   builtin: "CoPlainText";
@@ -20,12 +21,24 @@ export function createCoreCoPlainTextSchema(): CorePlainTextSchema {
   return {
     collaborative: true as const,
     builtin: "CoPlainText" as const,
+    defaultResolveQuery: false,
   };
 }
 
-export class PlainTextSchema implements CorePlainTextSchema {
+export class PlainTextSchema<
+  DefaultResolveQuery extends CoreResolveQuery = false,
+> implements CorePlainTextSchema
+{
   readonly collaborative = true as const;
   readonly builtin = "CoPlainText" as const;
+
+  /**
+   * The default resolve query to be used when loading instances of this schema.
+   * Defaults to `false`, meaning that no resolve query will be used by default.
+   * @internal
+   */
+  public defaultResolveQuery: DefaultResolveQuery =
+    false as DefaultResolveQuery;
 
   constructor(private coValueClass: typeof CoPlainText) {}
 
@@ -87,5 +100,11 @@ export class PlainTextSchema implements CorePlainTextSchema {
 
   optional(): CoOptionalSchema<this> {
     return coOptionalDefiner(this);
+  }
+
+  resolved(): PlainTextSchema<true> {
+    const copy = new PlainTextSchema<true>(this.coValueClass);
+    copy.defaultResolveQuery = true;
+    return copy;
   }
 }

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/RichTextSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/RichTextSchema.ts
@@ -24,20 +24,21 @@ export function createCoreCoRichTextSchema(): CoreRichTextSchema {
   };
 }
 
-export class RichTextSchema<
-  DefaultResolveQuery extends CoreResolveQuery = false,
-> implements CoreRichTextSchema
+export class RichTextSchema<EagerlyLoaded extends boolean = false>
+  implements CoreRichTextSchema
 {
   readonly collaborative = true as const;
   readonly builtin = "CoRichText" as const;
 
+  private isEagerlyLoaded: EagerlyLoaded = false as EagerlyLoaded;
   /**
    * The default resolve query to be used when loading instances of this schema.
    * Defaults to `false`, meaning that no resolve query will be used by default.
    * @internal
    */
-  public defaultResolveQuery: DefaultResolveQuery =
-    false as DefaultResolveQuery;
+  get defaultResolveQuery(): EagerlyLoaded {
+    return this.isEagerlyLoaded;
+  }
 
   constructor(private coValueClass: typeof CoRichText) {}
 
@@ -98,8 +99,11 @@ export class RichTextSchema<
   }
 
   resolved(): RichTextSchema<true> {
+    if (this.isEagerlyLoaded) {
+      return this as RichTextSchema<true>;
+    }
     const copy = new RichTextSchema<true>(this.coValueClass);
-    copy.defaultResolveQuery = true;
+    copy.isEagerlyLoaded = true;
     return copy;
   }
 }

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/RichTextSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/RichTextSchema.ts
@@ -6,10 +6,11 @@ import {
   MaybeLoaded,
   coOptionalDefiner,
   unstable_mergeBranchWithResolve,
+  ResolveQuery,
 } from "../../../internal.js";
 import { AnonymousJazzAgent } from "../../anonymousJazzAgent.js";
 import { CoOptionalSchema } from "./CoOptionalSchema.js";
-import { CoreCoValueSchema } from "./CoValueSchema.js";
+import { CoreCoValueSchema, CoreResolveQuery } from "./CoValueSchema.js";
 
 export interface CoreRichTextSchema extends CoreCoValueSchema {
   builtin: "CoRichText";
@@ -19,12 +20,24 @@ export function createCoreCoRichTextSchema(): CoreRichTextSchema {
   return {
     collaborative: true as const,
     builtin: "CoRichText" as const,
+    defaultResolveQuery: false,
   };
 }
 
-export class RichTextSchema implements CoreRichTextSchema {
+export class RichTextSchema<
+  DefaultResolveQuery extends CoreResolveQuery = false,
+> implements CoreRichTextSchema
+{
   readonly collaborative = true as const;
   readonly builtin = "CoRichText" as const;
+
+  /**
+   * The default resolve query to be used when loading instances of this schema.
+   * Defaults to `false`, meaning that no resolve query will be used by default.
+   * @internal
+   */
+  public defaultResolveQuery: DefaultResolveQuery =
+    false as DefaultResolveQuery;
 
   constructor(private coValueClass: typeof CoRichText) {}
 
@@ -82,5 +95,11 @@ export class RichTextSchema implements CoreRichTextSchema {
 
   optional(): CoOptionalSchema<this> {
     return coOptionalDefiner(this);
+  }
+
+  resolved(): RichTextSchema<true> {
+    const copy = new RichTextSchema<true>(this.coValueClass);
+    copy.defaultResolveQuery = true;
+    return copy;
   }
 }

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/DefaultResolveQueryOfSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/DefaultResolveQueryOfSchema.ts
@@ -1,0 +1,12 @@
+import { AnyZodOrCoValueSchema } from "../zodSchema.js";
+import { CoreCoValueSchema } from "../schemaTypes/CoValueSchema.js";
+
+/**
+ * Get the default resolve query of a CoValue schema.
+ */
+export type DefaultResolveQueryOfSchema<S extends AnyZodOrCoValueSchema> =
+  S extends CoreCoValueSchema
+    ? S["defaultResolveQuery"] extends false
+      ? false
+      : S["defaultResolveQuery"]
+    : false;

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/DefaultResolveQueryOfSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/DefaultResolveQueryOfSchema.ts
@@ -5,8 +5,4 @@ import { CoreCoValueSchema } from "../schemaTypes/CoValueSchema.js";
  * Get the default resolve query of a CoValue schema.
  */
 export type DefaultResolveQueryOfSchema<S extends AnyZodOrCoValueSchema> =
-  S extends CoreCoValueSchema
-    ? S["defaultResolveQuery"] extends false
-      ? false
-      : S["defaultResolveQuery"]
-    : false;
+  S extends CoreCoValueSchema ? S["defaultResolveQuery"] : false;

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/zodCo.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/zodCo.ts
@@ -2,6 +2,7 @@ import {
   type AccountSchema,
   AnyZodOrCoValueSchema,
   BaseAccountShape,
+  DefaultAccountShape,
   type CoFeedSchema,
   type CoListSchema,
   type CoMapSchema,
@@ -118,7 +119,9 @@ export const coMapDefiner = <Shape extends z.core.$ZodLooseShape>(
  * });
  * ```
  */
-export const coAccountDefiner = <Shape extends BaseAccountShape>(
+export const coAccountDefiner = <
+  Shape extends BaseAccountShape = DefaultAccountShape,
+>(
   shape: Shape = {
     profile: coMapDefiner({
       name: z.string(),

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/zodSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/zodSchema.ts
@@ -47,6 +47,7 @@ import {
   RichTextSchema,
 } from "./schemaTypes/RichTextSchema.js";
 import { InstanceOfSchemaCoValuesMaybeLoaded } from "./typeConverters/InstanceOfSchemaCoValuesMaybeLoaded.js";
+import { DefaultResolveQueryOfSchema } from "./typeConverters/DefaultResolveQueryOfSchema.js";
 import { z } from "./zodReExport.js";
 import { CoreGroupSchema } from "./schemaTypes/GroupSchema.js";
 import { GroupSchema } from "./schemaTypes/GroupSchema.js";
@@ -136,3 +137,10 @@ export type ResolveQueryStrict<
   LoadedAndRequired<InstanceOfSchemaCoValuesMaybeLoaded<T>>,
   R
 >;
+
+export type DefaultResolveQuery<S extends CoValueClassOrSchema> =
+  S extends CoreCoValueSchema
+    ? DefaultResolveQueryOfSchema<S> extends false
+      ? true
+      : DefaultResolveQueryOfSchema<S>
+    : true;

--- a/packages/jazz-tools/src/tools/tests/account.test.ts
+++ b/packages/jazz-tools/src/tools/tests/account.test.ts
@@ -149,6 +149,7 @@ test("loading raw accounts should work", async () => {
 
 describe("co.profile() schema", () => {
   test("co.profile() should throw an error if passed a CoValue schema", async () => {
+    // @ts-expect-error investigate "Type instantiation is excessively deep and possibly infinite" error
     expect(() => co.profile(co.map({}))).toThrow(
       "co.profile() expects an object as its argument, not a CoValue schema",
     );

--- a/packages/jazz-tools/src/tools/tests/schemaResolve.test.ts
+++ b/packages/jazz-tools/src/tools/tests/schemaResolve.test.ts
@@ -542,23 +542,47 @@ describe("Schema-level CoValue resolution", () => {
 
       describe("on upsertUnique()", () => {
         test("for CoList", async () => {
-          // TODO
+          const TestList = co.list(co.plainText().resolved()).resolved();
+
+          const list = await TestList.upsertUnique({
+            value: ["Hello"],
+            unique: "test",
+            owner: publicGroup,
+          });
+
+          assertLoaded(list);
+          expect(list[0]?.toUpperCase()).toEqual("HELLO");
         });
 
         test("for CoMap", async () => {
-          // TODO
+          const TestMap = co
+            .map({ text: co.plainText().resolved() })
+            .resolved();
+
+          const map = await TestMap.upsertUnique({
+            value: { text: "Hello" },
+            unique: "test",
+            owner: publicGroup,
+          });
+
+          assertLoaded(map);
+          expect(map.text.toUpperCase()).toEqual("HELLO");
         });
 
         test("for CoRecord", async () => {
-          // TODO
-        });
+          const TestRecord = co
+            .record(z.string(), co.plainText().resolved())
+            .resolved();
 
-        test("for Account", async () => {
-          // TODO
-        });
+          const record = await TestRecord.upsertUnique({
+            value: { key1: "Hello", key2: "World" },
+            unique: "test",
+            owner: publicGroup,
+          });
 
-        test("for CoFeed", async () => {
-          // TODO
+          assertLoaded(record);
+          expect(record.key1?.toUpperCase()).toEqual("HELLO");
+          expect(record.key2?.toUpperCase()).toEqual("WORLD");
         });
       });
 

--- a/packages/jazz-tools/src/tools/tests/schemaResolve.test.ts
+++ b/packages/jazz-tools/src/tools/tests/schemaResolve.test.ts
@@ -518,35 +518,13 @@ describe("Schema-level CoValue resolution", () => {
         });
       });
 
-      describe("on merge()", () => {
-        test("for CoList", async () => {
-          // TODO
-        });
-
-        test("for CoMap", async () => {
-          // TODO
-        });
-
-        test("for CoRecord", async () => {
-          // TODO
-        });
-
-        test("for Account", async () => {
-          // TODO
-        });
-
-        test("for CoFeed", async () => {
-          // TODO
-        });
-      });
-
       describe("on upsertUnique()", () => {
         test("for CoList", async () => {
           const TestList = co.list(co.plainText().resolved()).resolved();
 
           const list = await TestList.upsertUnique({
             value: ["Hello"],
-            unique: "test",
+            unique: "test-upsertUnique-coList",
             owner: publicGroup,
           });
 
@@ -561,7 +539,7 @@ describe("Schema-level CoValue resolution", () => {
 
           const map = await TestMap.upsertUnique({
             value: { text: "Hello" },
-            unique: "test",
+            unique: "test-upsertUnique-coMap",
             owner: publicGroup,
           });
 
@@ -576,7 +554,7 @@ describe("Schema-level CoValue resolution", () => {
 
           const record = await TestRecord.upsertUnique({
             value: { key1: "Hello", key2: "World" },
-            unique: "test",
+            unique: "test-upsertUnique-coRecord",
             owner: publicGroup,
           });
 
@@ -587,24 +565,71 @@ describe("Schema-level CoValue resolution", () => {
       });
 
       describe("on loadUnique()", () => {
+        let group: Group;
+        beforeAll(async () => {
+          group = Group.create();
+        });
+
         test("for CoList", async () => {
-          // TODO
+          const TestList = co.list(co.plainText().resolved()).resolved();
+
+          const list = TestList.create(["Hello"], {
+            unique: "test-loadUnique-coList",
+            owner: group,
+          });
+
+          const loadedList = await TestList.loadUnique(
+            "test-loadUnique-coList",
+            group.$jazz.id,
+          );
+
+          assertLoaded(loadedList);
+          expect(loadedList[0]?.toUpperCase()).toEqual("HELLO");
         });
 
         test("for CoMap", async () => {
-          // TODO
+          const TestMap = co
+            .map({ text: co.plainText().resolved() })
+            .resolved();
+
+          const map = TestMap.create(
+            { text: "Hello" },
+            {
+              unique: "test-loadUnique-coMap",
+              owner: group,
+            },
+          );
+
+          const loadedMap = await TestMap.loadUnique(
+            "test-loadUnique-coMap",
+            group.$jazz.id,
+          );
+
+          assertLoaded(loadedMap);
+          expect(loadedMap.text.toUpperCase()).toEqual("HELLO");
         });
 
         test("for CoRecord", async () => {
-          // TODO
-        });
+          const TestRecord = co
+            .record(z.string(), co.plainText().resolved())
+            .resolved();
 
-        test("for Account", async () => {
-          // TODO
-        });
+          const record = TestRecord.create(
+            { key1: "Hello", key2: "World" },
+            {
+              unique: "test-loadUnique-coRecord",
+              owner: group,
+            },
+          );
 
-        test("for CoFeed", async () => {
-          // TODO
+          const loadedRecord = await TestRecord.loadUnique(
+            "test-loadUnique-coRecord",
+            group.$jazz.id,
+          );
+
+          assertLoaded(loadedRecord);
+          expect(loadedRecord.key1?.toUpperCase()).toEqual("HELLO");
+          expect(loadedRecord.key2?.toUpperCase()).toEqual("WORLD");
         });
       });
     });

--- a/packages/jazz-tools/src/tools/tests/schemaResolve.test.ts
+++ b/packages/jazz-tools/src/tools/tests/schemaResolve.test.ts
@@ -1,0 +1,160 @@
+import { assert, beforeAll, describe, expect, test } from "vitest";
+import { Account, co, CoValueLoadingState, Group, z } from "../exports";
+import { createJazzTestAccount, setupJazzTestSync } from "../testing";
+import { assertLoaded, setupTwoNodes } from "./utils";
+
+describe("Schema-level CoValue resolution", () => {
+  beforeAll(async () => {
+    await setupJazzTestSync();
+    await createJazzTestAccount({
+      isCurrentActiveAccount: true,
+    });
+  });
+
+  describe("defining resolve queries in schemas", () => {
+    test("by default, schemas have no default resolve queries", () => {
+      const AllSchemas = [
+        co.plainText(),
+        co.richText(),
+        co.fileStream(),
+        co.vector(1),
+        co.group(),
+        co.list(co.plainText()),
+        co.feed(co.plainText()),
+        co.map({ text: co.plainText() }),
+        co.record(z.string(), co.plainText()),
+        co.optional(co.plainText()),
+        co.discriminatedUnion("type", [
+          co.map({ type: z.literal("a") }),
+          co.map({ type: z.literal("b") }),
+        ]),
+      ];
+
+      for (const Schema of AllSchemas) {
+        expect(Schema.defaultResolveQuery).toBe(false);
+      }
+    });
+
+    test("can make a schema greedily-loaded by using resolved()", () => {
+      const Text = co.plainText().resolved();
+
+      expect(Text.defaultResolveQuery).toBe(true);
+    });
+
+    test("CoOption schemas inherit the default resolve query of their inner type", () => {
+      const Text = co.plainText().resolved();
+      const OptionalText = co.optional(Text);
+
+      expect(OptionalText.defaultResolveQuery).toBe(true);
+    });
+
+    test("CoList schemas inherit the default resolve query of their element type", () => {
+      const Text = co.plainText().resolved();
+      const TestList = co.list(Text);
+
+      expect(TestList.defaultResolveQuery).toEqual({ $each: true });
+    });
+
+    test("CoMap schemas inherit the default resolve query of their shape", () => {
+      const Text = co.plainText().resolved();
+      const TestMap = co.map({ text: Text });
+
+      expect(TestMap.defaultResolveQuery).toEqual({ text: true });
+    });
+
+    test("Account schemas inherit the default resolve query of their shape", () => {
+      const Account = co.account({
+        root: co
+          .map({
+            text: co.plainText(),
+          })
+          .resolved(),
+        profile: co.profile({
+          name: z.string(),
+        }),
+      });
+
+      expect(Account.defaultResolveQuery).toEqual({ root: true });
+    });
+  });
+
+  describe("using Schema-level resolution when loading CoValues", () => {
+    let clientAccount: Account;
+    let serverAccount: Account;
+    let publicGroup: Group;
+
+    beforeAll(async () => {
+      ({ clientAccount, serverAccount } = await setupTwoNodes());
+      publicGroup = Group.create(serverAccount).makePublic();
+    });
+
+    describe("the default resolve query is used if no resolve query is provided", () => {
+      describe("on load()", () => {
+        test("for CoList", async () => {
+          const TestList = co.list(co.plainText().resolved());
+
+          const list = TestList.create(["Hello"], publicGroup);
+
+          const loadedList = await TestList.load(list.$jazz.id, {
+            loadAs: clientAccount,
+          });
+
+          assertLoaded(loadedList);
+          assert(loadedList[0]);
+          expect(loadedList[0].$jazz.loadingState).toBe(
+            CoValueLoadingState.LOADED,
+          );
+          expect(loadedList[0].toUpperCase()).toEqual("HELLO");
+        });
+
+        test("for CoMap", async () => {
+          const TestMap = co.map({ text: co.plainText().resolved() });
+
+          const map = TestMap.create({ text: "Hello" }, publicGroup);
+
+          const loadedMap = await TestMap.load(map.$jazz.id, {
+            loadAs: clientAccount,
+          });
+
+          assertLoaded(loadedMap);
+          expect(loadedMap.text.$jazz.loadingState).toBe(
+            CoValueLoadingState.LOADED,
+          );
+          expect(loadedMap.text.toUpperCase()).toEqual("HELLO");
+        });
+
+        test("for CoRecord", async () => {
+          // TODO
+        });
+
+        test("for Account", async () => {
+          // TODO
+        });
+
+        test("for CoFeed", async () => {
+          // TODO
+        });
+      });
+
+      describe("on subscribe()", () => {
+        // TODO
+      });
+
+      describe("on merge()", () => {
+        // TODO
+      });
+
+      describe("on upsertUnique()", () => {
+        // TODO
+      });
+
+      describe("on loadUnique()", () => {
+        // TODO
+      });
+    });
+
+    test("the default resolve query is merged with provided resolve queries", async () => {
+      // TODO
+    });
+  });
+});

--- a/packages/jazz-tools/src/tools/tests/schemaResolve.test.ts
+++ b/packages/jazz-tools/src/tools/tests/schemaResolve.test.ts
@@ -95,6 +95,32 @@ describe("Schema-level CoValue resolution", () => {
         });
       });
 
+      describe("CoDiscriminatedUnion", () => {
+        test("schema can only be made shallowly-loaded", () => {
+          const DiscriminatedUnion = co
+            .discriminatedUnion("type", [
+              co
+                .map({
+                  type: z.literal("a"),
+                  fieldA: co.plainText().resolved(),
+                })
+                .resolved(),
+              co
+                .map({
+                  type: z.literal("b"),
+                  fieldB: co.plainText().resolved(),
+                })
+                .resolved(),
+            ])
+            .resolved();
+
+          expectTypeOf<
+            typeof DiscriminatedUnion.defaultResolveQuery
+          >().toEqualTypeOf(true);
+          expect(DiscriminatedUnion.defaultResolveQuery).toBe(true);
+        });
+      });
+
       describe("CoList", () => {
         test("schemas inherit the default resolve query of their element type", () => {
           const Text = co.plainText().resolved();


### PR DESCRIPTION
# Description

When working with deeply-nested CoValue schemas, users need to handle complex resolve queries, both in CoValue-loading APIs and at the type level. This is notoriously cumbersome, which leads many users to just ignore resolve queries and resort to autoloading.

Schema-level CoValue resolution rules aim to provide an alternative solution: you specify the CoValue load strategy at the schema level, and then the resolve query will be inferred automatically:
```typescript
const Pet = co.map({
  name: z.string(),
}).resolved();
const Pets = co.list(Pet).resolved();
const Person = co.map({
  name: z.string(),
  pets: Pets(),
}).resolved();

// The following resolve query will be automatically inferred:
// { pets: { $each: true }
const person = await Person.load(personId);
assertLoaded(person);
console.log(person.pets[0]?.name); // "Rex"
```

TODO:
- update bindings for React & Svelte
- user-provided resolve queries currently override default resolve queries. We probably want to merge both queries

## Tests

- [x] Tests have been added and/or updated

## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [ ] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing