### PR TITLE
refactor(cojson): remove neverthrow dependency and improve error handling

### DIFF
--- a/.changeset/shiny-birds-shine.md
+++ b/.changeset/shiny-birds-shine.md
@@ -1,0 +1,5 @@
+---
+"cojson": patch
+---
+
+Remove neverthrow to easily propagate the original stacktrace of the transaction errors

--- a/packages/cojson/package.json
+++ b/packages/cojson/package.json
@@ -47,7 +47,6 @@
     "@scure/base": "1.2.1",
     "cojson-core-wasm": "workspace:*",
     "cojson-core-napi": "workspace:*",
-    "neverthrow": "^7.0.1",
     "unicode-segmenter": "^0.12.0"
   },
   "scripts": {

--- a/packages/cojson/src/coValueCore/SessionMap.ts
+++ b/packages/cojson/src/coValueCore/SessionMap.ts
@@ -1,4 +1,3 @@
-import { Result, err, ok } from "neverthrow";
 import { ControlledAccountOrAgent } from "../coValues/account.js";
 import type {
   CryptoProvider,
@@ -40,6 +39,9 @@ export class SessionMap {
   // Known state related properies, mutated when adding transactions to the session map
   knownState: CoValueKnownState;
   knownStateWithStreaming: CoValueKnownState | undefined;
+  // The immutable version of the known statuses, to get a different reference when the known state is updated
+  immutableKnownState: CoValueKnownState;
+  immutableKnownStateWithStreaming: CoValueKnownState | undefined;
   streamingKnownState?: KnownStateSessions;
 
   constructor(
@@ -48,6 +50,7 @@ export class SessionMap {
     streamingKnownState?: KnownStateSessions,
   ) {
     this.knownState = { id: this.id, header: true, sessions: {} };
+    this.immutableKnownState = { id: this.id, header: true, sessions: {} };
     if (streamingKnownState) {
       this.streamingKnownState = { ...streamingKnownState };
       this.knownStateWithStreaming = {
@@ -55,6 +58,9 @@ export class SessionMap {
         header: true,
         sessions: { ...streamingKnownState },
       };
+      this.immutableKnownStateWithStreaming = cloneKnownState(
+        this.knownStateWithStreaming,
+      );
     }
   }
 
@@ -86,6 +92,17 @@ export class SessionMap {
       this.knownStateWithStreaming.sessions,
       actualStreamingKnownState,
     );
+
+    this.immutableKnownStateWithStreaming = cloneKnownState(
+      this.knownStateWithStreaming,
+    );
+  }
+
+  updateImmutableKnownState() {
+    this.immutableKnownState = cloneKnownState(this.knownState);
+    this.immutableKnownStateWithStreaming = this.knownStateWithStreaming
+      ? cloneKnownState(this.knownStateWithStreaming)
+      : undefined;
   }
 
   get(sessionID: SessionID): SessionLog | undefined {
@@ -120,24 +137,12 @@ export class SessionMap {
     newTransactions: Transaction[],
     newSignature: Signature,
     skipVerify: boolean = false,
-  ): Result<true, TryAddTransactionsError> {
+  ) {
     const sessionLog = this.getOrCreateSessionLog(sessionID, signerID);
 
-    try {
-      sessionLog.impl.tryAdd(newTransactions, newSignature, skipVerify);
+    sessionLog.impl.tryAdd(newTransactions, newSignature, skipVerify);
 
-      this.addTransactionsToJsLog(sessionLog, newTransactions, newSignature);
-
-      return ok(true as const);
-    } catch (e) {
-      return err({
-        type: "InvalidSignature",
-        id: this.id,
-        sessionID,
-        newSignature,
-        signerID,
-      } satisfies TryAddTransactionsError);
-    }
+    this.addTransactionsToJsLog(sessionLog, newTransactions, newSignature);
   }
 
   makeNewPrivateTransaction(
@@ -250,6 +255,8 @@ export class SessionMap {
         transactionsCount,
       );
     }
+
+    this.updateImmutableKnownState();
   }
 
   decryptTransaction(

--- a/packages/cojson/src/coValues/group.ts
+++ b/packages/cojson/src/coValues/group.ts
@@ -508,12 +508,14 @@ export class RawGroup<
         memberRole === "writerInvite" ||
         memberRole === "adminInvite"
       ) {
-        const otherMemberAgent = this.core.node
-          .resolveAccountAgent(
-            otherMemberKey,
-            "Expected member agent to be loaded",
-          )
-          ._unsafeUnwrap({ withStackTrace: true });
+        const otherMemberAgent = this.core.node.resolveAccountAgent(
+          otherMemberKey,
+          "Expected member agent to be loaded",
+        ).value;
+
+        if (!otherMemberAgent) {
+          throw new Error("Expected member agent to be loaded");
+        }
 
         this.storeKeyRevelationForMember(
           otherMemberKey,
@@ -689,9 +691,14 @@ export class RawGroup<
 
     if (lastReadyKeyEdit?.value) {
       const revealer = lastReadyKeyEdit.by;
-      const revealerAgent = core.node
-        .resolveAccountAgent(revealer, "Expected to know revealer")
-        ._unsafeUnwrap({ withStackTrace: true });
+      const revealerAgent = core.node.resolveAccountAgent(
+        revealer,
+        "Expected to know revealer",
+      ).value;
+
+      if (!revealerAgent) {
+        throw new Error("Expected to know revealer");
+      }
 
       const secret = this.crypto.unseal(
         lastReadyKeyEdit.value,
@@ -841,12 +848,14 @@ export class RawGroup<
     const newReadKey = this.crypto.newRandomKeySecret();
 
     for (const readerID of currentlyPermittedReaders) {
-      const agent = this.core.node
-        .resolveAccountAgent(
-          readerID,
-          "Expected to know currently permitted reader",
-        )
-        ._unsafeUnwrap({ withStackTrace: true });
+      const agent = this.core.node.resolveAccountAgent(
+        readerID,
+        "Expected to know currently permitted reader",
+      ).value;
+
+      if (!agent) {
+        throw new Error("Expected to know currently permitted reader");
+      }
 
       this.storeKeyRevelationForMember(
         readerID,
@@ -861,12 +870,14 @@ export class RawGroup<
      * and reveal them to the other non-writeOnly members
      */
     for (const writeOnlyMemberID of writeOnlyMembers) {
-      const agent = this.core.node
-        .resolveAccountAgent(
-          writeOnlyMemberID,
-          "Expected to know writeOnly member",
-        )
-        ._unsafeUnwrap({ withStackTrace: true });
+      const agent = this.core.node.resolveAccountAgent(
+        writeOnlyMemberID,
+        "Expected to know writeOnly member",
+      ).value;
+
+      if (!agent) {
+        throw new Error("Expected to know writeOnly member");
+      }
 
       const writeOnlyKey = this.crypto.newRandomKeySecret();
 
@@ -879,12 +890,14 @@ export class RawGroup<
       this.set(`writeKeyFor_${writeOnlyMemberID}`, writeOnlyKey.id, "trusting");
 
       for (const readerID of currentlyPermittedReaders) {
-        const agent = this.core.node
-          .resolveAccountAgent(
-            readerID,
-            "Expected to know currently permitted reader",
-          )
-          ._unsafeUnwrap({ withStackTrace: true });
+        const agent = this.core.node.resolveAccountAgent(
+          readerID,
+          "Expected to know currently permitted reader",
+        ).value;
+
+        if (!agent) {
+          throw new Error("Expected to know currently permitted reader");
+        }
 
         this.storeKeyRevelationForMember(
           readerID,

--- a/packages/cojson/src/knownState.ts
+++ b/packages/cojson/src/knownState.ts
@@ -113,10 +113,7 @@ export function areCurrentSessionsInSyncWith(
   current: Record<string, number>,
   target: Record<string, number>,
 ) {
-  for (const [sessionId, currentCount] of Object.entries(current) as [
-    SessionID,
-    number,
-  ][]) {
+  for (const [sessionId, currentCount] of Object.entries(current)) {
     const targetCount = target[sessionId] ?? 0;
     if (currentCount !== targetCount) {
       return false;
@@ -133,10 +130,7 @@ export function isKnownStateSubsetOf(
   current: Record<string, number>,
   target: Record<string, number>,
 ) {
-  for (const [sessionId, currentCount] of Object.entries(current) as [
-    SessionID,
-    number,
-  ][]) {
+  for (const [sessionId, currentCount] of Object.entries(current)) {
     const targetCount = target[sessionId] ?? 0;
     if (currentCount > targetCount) {
       return false;
@@ -154,10 +148,7 @@ export function getKnownStateToSend(
   target: Record<string, number>,
 ) {
   const toSend: Record<string, number> = {};
-  for (const [sessionId, currentCount] of Object.entries(current) as [
-    SessionID,
-    number,
-  ][]) {
+  for (const [sessionId, currentCount] of Object.entries(current)) {
     const targetCount = target[sessionId] ?? 0;
     if (currentCount > targetCount) {
       toSend[sessionId] = currentCount;

--- a/packages/cojson/src/sync.ts
+++ b/packages/cojson/src/sync.ts
@@ -4,6 +4,8 @@ import { PeerState } from "./PeerState.js";
 import { SyncStateManager } from "./SyncStateManager.js";
 import {
   getContenDebugInfo,
+  getNewTransactionsFromContentMessage,
+  getSessionEntriesFromContentMessage,
   getTransactionSize,
   knownStateFromContent,
 } from "./coValueContentMessage.js";
@@ -609,25 +611,20 @@ export class SyncManager {
     /**
      * The coValue is in memory, load the transactions from the content message
      */
-    for (const [sessionID, newContentForSession] of Object.entries(msg.new) as [
-      SessionID,
-      SessionNewContent,
-    ][]) {
-      const ourKnownTxIdx =
-        coValue.verified.sessions.get(sessionID)?.transactions.length;
-      const theirFirstNewTxIdx = newContentForSession.after;
+    for (const [
+      sessionID,
+      newContentForSession,
+    ] of getSessionEntriesFromContentMessage(msg)) {
+      const newTransactions = getNewTransactionsFromContentMessage(
+        newContentForSession,
+        coValue.knownState(),
+        sessionID,
+      );
 
-      if ((ourKnownTxIdx || 0) < theirFirstNewTxIdx) {
+      if (newTransactions === undefined) {
         invalidStateAssumed = true;
         continue;
       }
-
-      const alreadyKnownOffset = ourKnownTxIdx
-        ? ourKnownTxIdx - theirFirstNewTxIdx
-        : 0;
-
-      const newTransactions =
-        newContentForSession.newTransactions.slice(alreadyKnownOffset);
 
       if (newTransactions.length === 0) {
         continue;
@@ -635,30 +632,34 @@ export class SyncManager {
 
       // TODO: Handle invalid signatures in the middle of streaming
       // This could cause a situation where we are unable to load a chunk, and ask for a correction for all the subsequent chunks
-      const result = coValue.tryAddTransactions(
+      const error = coValue.tryAddTransactions(
         sessionID,
         newTransactions,
         newContentForSession.lastSignature,
         this.skipVerify,
       );
 
-      if (result.isErr()) {
+      if (error) {
         if (peer) {
           logger.error("Failed to add transactions", {
             peerId: peer.id,
             peerRole: peer.role,
             id: msg.id,
-            err: result.error,
+            errorType: error.type,
+            err: error.error,
+            sessionID,
             msgKnownState: knownStateFromContent(msg).sessions,
+            msgSummary: getContenDebugInfo(msg),
             knownState: coValue.knownState().sessions,
-            newContent: validNewContent.new,
           });
           // TODO Mark only the session as errored, not the whole coValue
-          coValue.markErrored(peer.id, result.error);
+          coValue.markErrored(peer.id, error);
         } else {
           logger.error("Failed to add transactions from storage", {
             id: msg.id,
-            err: result.error,
+            err: error.error,
+            sessionID,
+            errorType: error.type,
           });
         }
         continue;
@@ -669,9 +670,7 @@ export class SyncManager {
       }
 
       // The new content for this session has been verified, so we can store it
-      if (result.value) {
-        validNewContent.new[sessionID] = newContentForSession;
-      }
+      validNewContent.new[sessionID] = newContentForSession;
     }
 
     if (peer) {

--- a/packages/cojson/src/tests/coValueContentMessage.test.ts
+++ b/packages/cojson/src/tests/coValueContentMessage.test.ts
@@ -1,10 +1,15 @@
 import { describe, expect, test } from "vitest";
-import { knownStateFromContent } from "../coValueContentMessage.js";
+import {
+  getNewTransactionsFromContentMessage,
+  knownStateFromContent,
+} from "../coValueContentMessage.js";
 import { emptyKnownState } from "../knownState.js";
-import { NewContentMessage } from "../sync.js";
+import { NewContentMessage, SessionNewContent } from "../sync.js";
 import type { RawCoID, SessionID } from "../ids.js";
 import { stableStringify } from "../jsonStringify.js";
 import { CO_VALUE_PRIORITY } from "../priority.js";
+import { CoValueKnownState } from "../knownState.js";
+import { Transaction } from "../coValueCore/verifiedState.js";
 
 describe("knownStateFromContent", () => {
   const mockCoID: RawCoID = "co_z1234567890abcdef";
@@ -211,5 +216,195 @@ describe("knownStateFromContent", () => {
     const result = knownStateFromContent(content);
 
     expect(result.sessions[mockSessionID1]).toBe(1); // 0 + 1
+  });
+});
+
+describe("getNewTransactionsFromContentMessage", () => {
+  const mockCoID: RawCoID = "co_z1234567890abcdef";
+  const mockSessionID: SessionID = "sealer_z123/signer_z456_session_z789";
+
+  function createTransaction(): Transaction {
+    return {
+      privacy: "trusting",
+      madeAt: Date.now(),
+      changes: stableStringify([{ op: "set", key: "test", value: "value" }]),
+    };
+  }
+
+  function createKnownState(
+    sessionTxIdx: number | undefined,
+  ): CoValueKnownState {
+    const knownState = emptyKnownState(mockCoID);
+    knownState.header = true;
+    if (sessionTxIdx !== undefined) {
+      knownState.sessions[mockSessionID] = sessionTxIdx;
+    }
+    return knownState;
+  }
+
+  test("returns all transactions when we know none (ourKnownTxIdx = 0, theirFirstNewTxIdx = 0)", () => {
+    const transactions = [createTransaction(), createTransaction()];
+    const content: SessionNewContent = {
+      after: 0,
+      newTransactions: transactions,
+      lastSignature: "signature_z1234",
+    };
+    const knownState = createKnownState(undefined); // defaults to 0
+
+    const result = getNewTransactionsFromContentMessage(
+      content,
+      knownState,
+      mockSessionID,
+    );
+
+    expect(result).toEqual(transactions);
+    expect(result).toHaveLength(2);
+  });
+
+  test("returns subset of transactions when we know some (ourKnownTxIdx = 3, theirFirstNewTxIdx = 0)", () => {
+    const transactions = [
+      createTransaction(),
+      createTransaction(),
+      createTransaction(),
+      createTransaction(),
+      createTransaction(),
+    ];
+    const content: SessionNewContent = {
+      after: 0,
+      newTransactions: transactions,
+      lastSignature: "signature_z1234",
+    };
+    const knownState = createKnownState(3); // we already know txs 0, 1, 2
+
+    const result = getNewTransactionsFromContentMessage(
+      content,
+      knownState,
+      mockSessionID,
+    );
+
+    expect(result).toEqual(transactions.slice(3));
+    expect(result).toHaveLength(2);
+  });
+
+  test("returns undefined when we're missing transactions (ourKnownTxIdx = 2, theirFirstNewTxIdx = 5)", () => {
+    const transactions = [createTransaction(), createTransaction()];
+    const content: SessionNewContent = {
+      after: 5, // they're sending txs starting from idx 5
+      newTransactions: transactions,
+      lastSignature: "signature_z1234",
+    };
+    const knownState = createKnownState(2); // but we only know up to idx 2
+
+    const result = getNewTransactionsFromContentMessage(
+      content,
+      knownState,
+      mockSessionID,
+    );
+
+    expect(result).toBeUndefined();
+  });
+
+  test("returns empty array when we know all transactions (ourKnownTxIdx = 5, theirFirstNewTxIdx = 2)", () => {
+    const transactions = [
+      createTransaction(),
+      createTransaction(),
+      createTransaction(),
+    ];
+    const content: SessionNewContent = {
+      after: 2, // they're sending txs 2, 3, 4
+      newTransactions: transactions,
+      lastSignature: "signature_z1234",
+    };
+    const knownState = createKnownState(5); // we already know txs up to idx 5
+
+    const result = getNewTransactionsFromContentMessage(
+      content,
+      knownState,
+      mockSessionID,
+    );
+
+    expect(result).toEqual([]);
+    expect(result).toHaveLength(0);
+  });
+
+  test("returns all transactions when ourKnownTxIdx equals theirFirstNewTxIdx", () => {
+    const transactions = [createTransaction(), createTransaction()];
+    const content: SessionNewContent = {
+      after: 3,
+      newTransactions: transactions,
+      lastSignature: "signature_z1234",
+    };
+    const knownState = createKnownState(3); // we know up to idx 3
+
+    const result = getNewTransactionsFromContentMessage(
+      content,
+      knownState,
+      mockSessionID,
+    );
+
+    expect(result).toEqual(transactions);
+    expect(result).toHaveLength(2);
+  });
+
+  test("handles session not in knownState (defaults to 0)", () => {
+    const transactions = [createTransaction()];
+    const content: SessionNewContent = {
+      after: 1,
+      newTransactions: transactions,
+      lastSignature: "signature_z1234",
+    };
+    const knownState = emptyKnownState(mockCoID);
+    knownState.header = true;
+    // no sessions defined, so mockSessionID defaults to 0
+
+    const result = getNewTransactionsFromContentMessage(
+      content,
+      knownState,
+      mockSessionID,
+    );
+
+    // ourKnownTxIdx = 0, theirFirstNewTxIdx = 1, so 0 < 1 -> undefined
+    expect(result).toBeUndefined();
+  });
+
+  test("returns single transaction when offset is length - 1", () => {
+    const transactions = [
+      createTransaction(),
+      createTransaction(),
+      createTransaction(),
+    ];
+    const content: SessionNewContent = {
+      after: 5,
+      newTransactions: transactions,
+      lastSignature: "signature_z1234",
+    };
+    const knownState = createKnownState(7); // we know up to idx 7 (5 + 2 transactions)
+
+    const result = getNewTransactionsFromContentMessage(
+      content,
+      knownState,
+      mockSessionID,
+    );
+
+    expect(result).toEqual([transactions[2]]);
+    expect(result).toHaveLength(1);
+  });
+
+  test("handles empty newTransactions array", () => {
+    const content: SessionNewContent = {
+      after: 5,
+      newTransactions: [],
+      lastSignature: "signature_z1234",
+    };
+    const knownState = createKnownState(5);
+
+    const result = getNewTransactionsFromContentMessage(
+      content,
+      knownState,
+      mockSessionID,
+    );
+
+    expect(result).toEqual([]);
+    expect(result).toHaveLength(0);
   });
 });

--- a/packages/cojson/src/tests/coValueCore.test.ts
+++ b/packages/cojson/src/tests/coValueCore.test.ts
@@ -78,14 +78,13 @@ test("transactions with wrong signature are rejected", () => {
 
   const newEntry = node.getCoValue(coValue.id);
 
-  // eslint-disable-next-line neverthrow/must-use-result
-  const result = newEntry.tryAddTransactions(
+  const error = newEntry.tryAddTransactions(
     node.currentSessionID,
     [transaction],
     signature,
   );
 
-  expect(result.isErr()).toBe(true);
+  expect(Boolean(error)).toBe(true);
   expect(newEntry.getValidSortedTransactions().length).toBe(0);
 });
 
@@ -448,13 +447,11 @@ test("getValidTransactions should skip private transactions with invalid JSON", 
   map.set("hello", "world");
 
   // This should fail silently, because the encryptedChanges will be outputted as gibberish
-  map.core
-    .tryAddTransactions(
-      fixtures.session,
-      [fixtures.transaction],
-      fixtures.signature,
-    )
-    ._unsafeUnwrap();
+  map.core.tryAddTransactions(
+    fixtures.session,
+    [fixtures.transaction],
+    fixtures.signature,
+  );
 
   // Get valid transactions - should only include the valid one
   const validTransactions = map.core.getValidTransactions();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2071,9 +2071,6 @@ importers:
       cojson-core-wasm:
         specifier: workspace:*
         version: link:../../crates/cojson-core-wasm
-      neverthrow:
-        specifier: ^7.0.1
-        version: 7.2.0
       unicode-segmenter:
         specifier: ^0.12.0
         version: 0.12.0
@@ -13736,10 +13733,6 @@ packages:
   netmask@2.0.2:
     resolution: {integrity: sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==}
     engines: {node: '>= 0.4.0'}
-
-  neverthrow@7.2.0:
-    resolution: {integrity: sha512-iGBUfFB7yPczHHtA8dksKTJ9E8TESNTAx1UQWW6TzMF280vo9jdPYpLUXrMN1BCkPdHFdNG3fxOt2CUad8KhAw==}
-    engines: {node: '>=18'}
 
   next-themes@0.4.6:
     resolution: {integrity: sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==}
@@ -31153,8 +31146,6 @@ snapshots:
   nested-error-stacks@2.0.1: {}
 
   netmask@2.0.2: {}
-
-  neverthrow@7.2.0: {}
 
   next-themes@0.4.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:


### PR DESCRIPTION
- Removed the neverthrow dependency from the cojson package to simplify error handling and propagate original stack traces for transaction errors.
- Updated various functions to return error objects directly instead of using Result types.
- Extracted utility functions for handling transactions and session entries, to cover those with tests.
- moved the knownState cloning up to SessonMap to ensure that the cache is correctly managed