### PR TITLE
Add automatic deduplication tip to loading docs

### DIFF
--- a/homepage/homepage/content/docs/core-concepts/subscription-and-loading.mdx
+++ b/homepage/homepage/content/docs/core-concepts/subscription-and-loading.mdx
@@ -1,4 +1,4 @@
-import { Alert, CodeGroup, ContentByFramework, ReactLogo, SvelteLogo, TabbedCodeGroup, TabbedCodeGroupItem } from "@/components/forMdx";
+import { Alert, CodeGroup, ContentByFramework, FileName, ReactLogo, SvelteLogo, TabbedCodeGroup, TabbedCodeGroupItem } from "@/components/forMdx";
 
 export const metadata = {
   description: "Learn how to subscribe to CoValues, specify loading depths, and handle loading states and inaccessible data."
@@ -14,6 +14,10 @@ You can load and subscribe to CoValues in one of two ways:
 
 - **shallowly**&hairsp;—&hairsp;all of the primitive fields are available (such as strings, numbers, dates), but the references to other CoValues are not loaded
 - **deeply**&hairsp;—&hairsp;some or all of the referenced CoValues have been loaded
+
+<Alert variant="info" title="Tip">
+  Jazz automatically deduplicates loading. If you subscribe to the same CoValue multiple times in your app, Jazz will only fetch it once. That means you don’t need to deeply load a CoValue *just in case* a child component might need its data, and you don’t have to worry about tracking every possible field your app needs in a top-level query. Instead, pass the CoValue ID to the child component and subscribe there&hairsp;—&hairsp;Jazz will only load what that component actually needs.
+</Alert>
 
 ## Subscription Hooks
 
@@ -37,7 +41,7 @@ function ProjectView({ projectId }: { projectId: string }) {
   const project = useCoState(Project, projectId, {
     resolve: { tasks: { $each: true } } // Tell Jazz to load each task in the list
   });
-  
+
   if (project === null) {
     return "Project not found or not accessible"
   } else if (project === undefined) {
@@ -153,7 +157,7 @@ Check the examples above for practical demonstrations of how to handle these thr
 
 ## Deep Loading
 
-When you're working with related CoValues (like tasks in a project), you often need to load nested references as well as the top-level CoValue. 
+When you're working with related CoValues (like tasks in a project), you often need to load nested references as well as the top-level CoValue.
 
 This is particularly the case when working with [CoMaps](/docs/core-concepts/covalues/comaps) that refer to other CoValues or [CoLists](/docs/core-concepts/covalues/colists) of CoValues. You can use `resolve` queries to tell Jazz what data you need to use.
 
@@ -292,8 +296,8 @@ A load operation will be successful **only** in case all references requested (b
 <CodeGroup preferWrap>
 ```ts
 // If permissions on description are restricted:
-const task = await Task.load(taskId, { 
-  resolve: { description: true } 
+const task = await Task.load(taskId, {
+  resolve: { description: true }
 });
 task // null
 ```
@@ -406,8 +410,8 @@ We can fix this by adding handlers at both levels
 const project = await Project.load(projectId, {
 	resolve: {
 		tasks: {
-			$each: { 
-				description: true, 
+			$each: {
+				description: true,
 				$onError: null // catch errors loading task descriptions
 			},
 			$onError: null // catch errors loading tasks too
@@ -433,9 +437,9 @@ The `co.loaded` type is especially useful when passing data between components, 
 <TabbedCodeGroup id="coloaded" default="react" savedPreferenceKey="framework">
 <TabbedCodeGroupItem label="React" value="react" icon={<ReactLogo />} preferWrap>
 ```tsx
-type ProjectWithTasks = co.loaded<typeof Project, 
+type ProjectWithTasks = co.loaded<typeof Project,
   {
-    tasks: { 
+    tasks: {
       $each: true
     };
   }
@@ -459,9 +463,9 @@ function TaskList({ project }: { project: ProjectWithTasks }) {
 <script lang="ts">
   import { co } from "jazz-tools";
 
-  type ProjectWithTasks = co.loaded<typeof Project, 
+  type ProjectWithTasks = co.loaded<typeof Project,
     {
-      tasks: { 
+      tasks: {
         $each: true
       };
     }
@@ -523,7 +527,7 @@ unsubscribe();
 ## Selectors [!framework=react,react-native,react-native-expo]
 Sometimes, you only need to react to changes in specific parts of a CoValue. In those cases, you can use the `useCoStateWithSelector` hook to specify what data you are interested in.
 
-When you use `useCoStateWithSelector` , in addition to `resolve` you can also add a `select` and optionally an `equalityFn` option. 
+When you use `useCoStateWithSelector` , in addition to `resolve` you can also add a `select` and optionally an `equalityFn` option.
 
 - `select`: extract the fields you care about
 - `equalityFn`: (optional) control when data should be considered equal
@@ -549,7 +553,7 @@ function ProjectView({ projectId }: { projectId: string }) {
     equalityFn: (a, b) =>
       a?.name === b?.name && a?.taskCount === b?.taskCount
   });
-  
+
   if (!project) {
     return project === null
       ? "Project not found or not accessible"


### PR DESCRIPTION
# Description
Highlight that subscribing to CoValues in multiple places is not an anti-pattern.

## Manual testing instructions
N/A

## Tests

- [ ] Tests have been added and/or updated
- [X] Tests have not been updated, because: N/A
- [ ] I need help with writing tests

## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [ ] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing