### PR TITLE
[Inspector] Raw data and covalue history are now collapsible

### DIFF
--- a/.changeset/funky-signs-hunt.md
+++ b/.changeset/funky-signs-hunt.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+chore: Inspector's raw data and covalue history are now collapsible

--- a/examples/inspector/tests/inspector.spec.ts
+++ b/examples/inspector/tests/inspector.spec.ts
@@ -114,7 +114,6 @@ test("should inspect CoValue", async ({ page }) => {
 
   // Test if CoMap/grid view is displaying Issue data correctly
   await row.getByRole("button", { name: "View" }).click();
-  await expect(page.getByRole("table")).toHaveCount(1);
   await expect(page.getByText(issue.title)).toBeVisible();
   await expect(page.getByText(issue.status)).toBeVisible();
   await expect(page.getByRole("button", { name: /labels/ })).toBeVisible();

--- a/packages/jazz-tools/src/inspector/ui/accordion.tsx
+++ b/packages/jazz-tools/src/inspector/ui/accordion.tsx
@@ -1,0 +1,52 @@
+import { styled } from "goober";
+import { PropsWithChildren, useEffect, useState } from "react";
+
+type AccordionProps = PropsWithChildren<{
+  title: string;
+  storageKey: string;
+}>;
+
+export function Accordion({ title, children, storageKey }: AccordionProps) {
+  const [open, setOpen] = useStoragedState(storageKey, false);
+
+  return (
+    <details
+      open={open}
+      style={{ display: "flex", flexDirection: "column", gap: "1rem" }}
+    >
+      <StyledSummary
+        onClick={(e) => {
+          e.preventDefault();
+          setOpen((v) => !v);
+        }}
+      >
+        {title}
+      </StyledSummary>
+      {children}
+    </details>
+  );
+}
+
+function useStoragedState<T>(
+  key: string,
+  defaultValue: T,
+): [T, React.Dispatch<React.SetStateAction<T>>] {
+  const [state, setState] = useState<T>(() => {
+    if (typeof window === "undefined") return defaultValue;
+    const stored = localStorage.getItem(key);
+    return stored ? JSON.parse(stored) : defaultValue;
+  });
+
+  useEffect(() => {
+    localStorage.setItem(key, JSON.stringify(state));
+  }, [state]);
+
+  return [state, setState];
+}
+
+const StyledSummary = styled("summary")`
+  font-size: 1.125rem;
+  cursor: pointer;
+  font-weight: 500;
+  color: var(--j-text-color-strong);
+`;

--- a/packages/jazz-tools/src/inspector/ui/index.ts
+++ b/packages/jazz-tools/src/inspector/ui/index.ts
@@ -4,3 +4,4 @@ export { Modal } from "./modal.js";
 export { Input } from "./input.js";
 export { Select } from "./select.js";
 export { DataTable } from "./data-table.js";
+export { Accordion } from "./accordion.js";

--- a/packages/jazz-tools/src/inspector/viewer/history-view.tsx
+++ b/packages/jazz-tools/src/inspector/viewer/history-view.tsx
@@ -13,7 +13,6 @@ import { styled } from "goober";
 import { isCoId } from "./types";
 import { AccountOrGroupText } from "./account-or-group-text";
 import { DataTable, ColumnDef } from "../ui/data-table";
-import { Heading } from "../ui/heading";
 import { MapOpPayload } from "cojson/dist/coValues/coMap.js";
 import {
   DeletionOpPayload,
@@ -24,7 +23,7 @@ import {
   BinaryStreamEnd,
 } from "cojson/dist/coValues/coStream.js";
 import { VerifiedTransaction } from "cojson/dist/coValueCore/coValueCore.js";
-import { Icon } from "../ui";
+import { Icon, Accordion } from "../ui";
 
 type HistoryEntry = {
   id: string;
@@ -102,8 +101,7 @@ export function HistoryView({
   ];
 
   return (
-    <section style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
-      <Heading>CoValue history</Heading>
+    <Accordion title="CoValue history" storageKey="jazz-inspector-show-history">
       <DataTable
         columns={columns}
         data={transactions}
@@ -112,7 +110,7 @@ export function HistoryView({
         getRowKey={(row) => row.id}
         emptyMessage="No history available"
       />
-    </section>
+    </Accordion>
   );
 }
 

--- a/packages/jazz-tools/src/inspector/viewer/raw-data-card.tsx
+++ b/packages/jazz-tools/src/inspector/viewer/raw-data-card.tsx
@@ -1,8 +1,7 @@
 import { JsonObject } from "cojson";
 import { useEffect, useState } from "react";
-import { Button } from "../ui/button.js";
+import { Button, Accordion } from "../ui";
 import { Card, CardBody, CardHeader } from "../ui/card.js";
-import { Text } from "../ui/text.js";
 import { ValueRenderer } from "./value-renderer.js";
 
 function CopyButton({ data }: { data: JsonObject }) {
@@ -40,14 +39,15 @@ function CopyButton({ data }: { data: JsonObject }) {
 
 export function RawDataCard({ data }: { data: JsonObject }) {
   return (
-    <Card style={{ position: "relative" }}>
-      <CardHeader>
-        <Text strong>Raw data</Text>
-        <CopyButton data={data} />
-      </CardHeader>
-      <CardBody>
-        <ValueRenderer json={data} />
-      </CardBody>
-    </Card>
+    <Accordion title="Raw data" storageKey="jazz-inspector-show-raw-data">
+      <Card style={{ position: "relative" }}>
+        <CardHeader>
+          <CopyButton data={data} />
+        </CardHeader>
+        <CardBody>
+          <ValueRenderer json={data} />
+        </CardBody>
+      </Card>
+    </Accordion>
   );
 }


### PR DESCRIPTION
# Description

<img width="663" height="389" alt="immagine" src="https://github.com/user-attachments/assets/8b357361-88aa-41d3-86a2-fe8c8662b848" />

User's choices are stored in localStorage to maintain consistency during debugging navigation. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make Inspector’s Raw data and CoValue history sections collapsible using a new Accordion component with state persisted to localStorage, and update tests accordingly.
> 
> - **Inspector UI**:
>   - **Accordion**: Add `ui/accordion.tsx` with persisted open/closed state via `localStorage`.
>   - **Raw data**: Wrap `RawDataCard` content in `Accordion` titled "Raw data"; move copy button into header.
>   - **History**: Wrap `HistoryView` table in `Accordion` titled "CoValue history"; remove previous heading.
> - **UI Exports**: Export `Accordion` from `inspector/ui/index.ts`.
> - **Tests**: Adjust `examples/inspector/tests/inspector.spec.ts` to align with new UI (remove table count assertion in CoMap view).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3c6a971f11b22bcbfdfe17ca222930af785a369e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->