### PR TITLE
[Inspector] ErrorBoundary around inspector's view

### DIFF
--- a/.changeset/sweet-games-float.md
+++ b/.changeset/sweet-games-float.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+chore: ErrorBoundary around inspector to handle render errors

--- a/packages/jazz-tools/src/inspector/ui/error-boundary.tsx
+++ b/packages/jazz-tools/src/inspector/ui/error-boundary.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+import { Text } from "./text";
+import { styled } from "goober";
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  error?: Error;
+}
+
+export class ErrorBoundary extends React.Component<
+  { children: React.ReactNode; title: string },
+  ErrorBoundaryState
+> {
+  constructor(props: { children: React.ReactNode; title: string }) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo): void {
+    console.error(error);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div style={{ padding: "1rem" }}>
+          <StyledHeading>{this.props.title}</StyledHeading>
+          <Text mono style={{ marginTop: "0.5rem", color: "#ef4444" }}>
+            {this.state.error?.message || "An unexpected error occurred"}
+          </Text>
+
+          <pre style={{ paddingLeft: "1rem", color: "#ef4444" }}>
+            {this.state.error?.stack}
+          </pre>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+const StyledHeading = styled("h1")<{ className?: string }>`
+  font-size: 1.125rem;
+  font-weight: 500;
+  color: var(--j-text-color-strong);
+`;

--- a/packages/jazz-tools/src/inspector/ui/text.tsx
+++ b/packages/jazz-tools/src/inspector/ui/text.tsx
@@ -56,6 +56,7 @@ export function Text(
     inline?: boolean;
     small?: boolean;
     mono?: boolean;
+    style?: React.CSSProperties;
   }>,
 ) {
   return <StyledText {...props} />;

--- a/packages/jazz-tools/src/inspector/viewer/page-stack.tsx
+++ b/packages/jazz-tools/src/inspector/viewer/page-stack.tsx
@@ -1,6 +1,7 @@
 import { CoID, LocalNode, RawCoValue } from "cojson";
 import { styled } from "goober";
 import { Page } from "./page.js";
+import { ErrorBoundary } from "../ui/error-boundary.js";
 
 // Define the structure of a page in the path
 interface PageInfo {
@@ -41,14 +42,16 @@ export function PageStack({
       <PageStackContainer>
         {children}
         {node && page && (
-          <Page
-            coId={page.coId}
-            node={node}
-            name={page.name || page.coId}
-            onHeaderClick={goBack}
-            onNavigate={addPages}
-            isTopLevel={index === path.length - 1}
-          />
+          <ErrorBoundary title="An error occurred while rendering this CoValue">
+            <Page
+              coId={page.coId}
+              node={node}
+              name={page.name || page.coId}
+              onHeaderClick={goBack}
+              onNavigate={addPages}
+              isTopLevel={index === path.length - 1}
+            />
+          </ErrorBoundary>
         )}
       </PageStackContainer>
     </>


### PR DESCRIPTION
# Description

If something happens that throws an error, the React render breaks the entire app.

Ref [GCO-968](https://linear.app/garden-co/issue/GCO-968/handle-covalues-errors)


## Before
<img width="864" height="625" alt="Screenshot 2025-11-03 alle 16 58 54" src="https://github.com/user-attachments/assets/dd284da7-6be8-4f9d-a043-8491aada8e96" />

## After
<img width="1139" height="578" alt="immagine" src="https://github.com/user-attachments/assets/6c7b15cf-a6e5-4f63-a3d6-f3e0473687cd" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add an ErrorBoundary around the inspector's Page to catch and show render errors.
> 
> - **Inspector UI**:
>   - **Error handling**: Add `ErrorBoundary` (`inspector/ui/error-boundary.tsx`) to catch and display render errors with message and stack.
>   - **Integration**: Wrap `Page` in `viewer/page-stack.tsx` with `ErrorBoundary` (title: "An error occurred while rendering this CoValue").
> - **UI Utility**:
>   - `Text` component: allow inline `style` prop for error styling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b3e36b6bfb1745fae60b55e4e35799aae1c16922. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->