### PR TITLE
[Inspector] print serialized json fields in history

### DIFF
--- a/.changeset/eighty-actors-film.md
+++ b/.changeset/eighty-actors-film.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+chore: Inspector now prints correctly json fields in covalue history

--- a/packages/jazz-tools/src/inspector/tests/viewer/history-view.test.tsx
+++ b/packages/jazz-tools/src/inspector/tests/viewer/history-view.test.tsx
@@ -93,16 +93,21 @@ describe("HistoryView", async () => {
       expect(extractActions()).toEqual(history);
     });
     it("should render co.map changes with json", async () => {
+      const d = new Date();
       const value = co
         .map({
           pet: z.object({
             name: z.string(),
             age: z.number(),
           }),
+          d: z.date(),
           n: z.number().optional(),
           s: z.string().nullable(),
         })
-        .create({ pet: { name: "dog", age: 10 }, n: 10, s: "hello" }, account);
+        .create(
+          { pet: { name: "dog", age: 10 }, d, n: 10, s: "hello" },
+          account,
+        );
 
       value.$jazz.set("pet", { name: "cat", age: 20 });
       value.$jazz.set("n", undefined);
@@ -113,6 +118,7 @@ describe("HistoryView", async () => {
 
       const history = [
         'Property "pet" has been set to {"name":"dog","age":10}',
+        `Property "d" has been set to "${d.toISOString()}"`,
         'Property "n" has been set to 10',
         'Property "s" has been set to "hello"',
         'Property "pet" has been set to {"name":"cat","age":20}',

--- a/packages/jazz-tools/src/inspector/tests/viewer/history-view.test.tsx
+++ b/packages/jazz-tools/src/inspector/tests/viewer/history-view.test.tsx
@@ -74,15 +74,51 @@ describe("HistoryView", async () => {
 
       const history = [
         'Property "pet" has been set to "dog"',
-        'Property "age" has been set to "10"',
-        'Property "certified" has been set to "false"',
+        'Property "age" has been set to 10',
+        'Property "certified" has been set to false',
         'Property "pet" has been set to "cat"',
-        'Property "age" has been set to "20"',
-        'Property "certified" has been set to "true"',
+        'Property "age" has been set to 20',
+        'Property "certified" has been set to true',
         'Property "certified" has been deleted',
       ].toReversed(); // Default sort is descending
 
       expect(screen.getAllByRole("row")).toHaveLength(history.length + 2);
+
+      await waitFor(() => {
+        expect(screen.getAllByRole("row")[2]?.textContent).toContain(
+          account.$jazz.id,
+        );
+      });
+
+      expect(extractActions()).toEqual(history);
+    });
+    it("should render co.map changes with json", async () => {
+      const value = co
+        .map({
+          pet: z.object({
+            name: z.string(),
+            age: z.number(),
+          }),
+          n: z.number().optional(),
+          s: z.string().nullable(),
+        })
+        .create({ pet: { name: "dog", age: 10 }, n: 10, s: "hello" }, account);
+
+      value.$jazz.set("pet", { name: "cat", age: 20 });
+      value.$jazz.set("n", undefined);
+      value.$jazz.set("s", null);
+      render(
+        <HistoryView coValue={value.$jazz.raw} node={value.$jazz.localNode} />,
+      );
+
+      const history = [
+        'Property "pet" has been set to {"name":"dog","age":10}',
+        'Property "n" has been set to 10',
+        'Property "s" has been set to "hello"',
+        'Property "pet" has been set to {"name":"cat","age":20}',
+        'Property "n" has been set to undefined',
+        'Property "s" has been set to null',
+      ].toReversed(); // Default sort is descending
 
       await waitFor(() => {
         expect(screen.getAllByRole("row")[2]?.textContent).toContain(

--- a/packages/jazz-tools/src/inspector/viewer/history-view.tsx
+++ b/packages/jazz-tools/src/inspector/viewer/history-view.tsx
@@ -242,7 +242,7 @@ function mapTransactionToAction(
 
   // coMap changes
   if (isPropertySet(change)) {
-    return `Property "${change.key}" has been set to "${change.value}"`;
+    return `Property "${change.key}" has been set to ${JSON.stringify(change.value)}`;
   }
 
   if (isPropertyDeletion(change)) {


### PR DESCRIPTION
# Description
From `[object Object]`  to `{pet: "dog", age: 3}` when using `z.object()` fields.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> HistoryView now renders map property values as proper JSON (objects, numbers, booleans, dates, null/undefined), with tests updated and added to cover these cases.
> 
> - **Inspector / HistoryView**:
>   - Render `co.map` property set actions using `JSON.stringify(change.value)` instead of quoting raw values.
> - **Tests**:
>   - Update expectations to remove quotes around numbers/booleans in `co.map` history.
>   - Add test covering JSON rendering for objects, dates, `undefined`, and `null` fields.
> - **Release**:
>   - Patch changeset for `jazz-tools`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4bb971823211fb9f6ba02dcf0d145d7943d2cfb9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->