### PR TITLE
fix: disable streaming state propagation between clients

### DIFF
--- a/.changeset/silver-news-shave.md
+++ b/.changeset/silver-news-shave.md
@@ -1,0 +1,5 @@
+---
+"cojson": patch
+---
+
+Disable client-to-client streaming state propagation

--- a/packages/cojson/src/coValueCore/verifiedState.ts
+++ b/packages/cojson/src/coValueCore/verifiedState.ts
@@ -160,9 +160,6 @@ export class VerifiedState {
 
   newContentSince(
     knownState: CoValueKnownState | undefined,
-    opts?: {
-      skipExpectContentUntil?: boolean;
-    },
   ): NewContentMessage[] | undefined {
     let currentPiece: NewContentMessage = createContentMessage(
       this.id,
@@ -290,18 +287,15 @@ export class VerifiedState {
     );
 
     if (piecesWithContent.length > 1 || this.isStreaming()) {
-      if (!opts?.skipExpectContentUntil) {
-        // Flag that more content is coming
-        if (knownState) {
-          firstPiece.expectContentUntil = getKnownStateToSend(
-            this.knownStateWithStreaming().sessions,
-            knownState.sessions,
-          );
-        } else {
-          firstPiece.expectContentUntil = {
-            ...this.knownStateWithStreaming().sessions,
-          };
-        }
+      if (knownState) {
+        firstPiece.expectContentUntil = getKnownStateToSend(
+          this.knownStateWithStreaming().sessions,
+          knownState.sessions,
+        );
+      } else {
+        firstPiece.expectContentUntil = {
+          ...this.knownStateWithStreaming().sessions,
+        };
       }
     }
 

--- a/packages/cojson/src/coValueCore/verifiedState.ts
+++ b/packages/cojson/src/coValueCore/verifiedState.ts
@@ -315,14 +315,11 @@ export class VerifiedState {
   }
 
   immutableKnownState() {
-    return this.sessions.immutableKnownState;
+    return this.sessions.getImmutableKnownState();
   }
 
   immutableKnownStateWithStreaming() {
-    return (
-      this.sessions.immutableKnownStateWithStreaming ??
-      this.immutableKnownState()
-    );
+    return this.sessions.getImmutableKnownStateWithStreaming();
   }
 
   isStreaming(): boolean {

--- a/packages/cojson/src/queue/LocalTransactionsSyncQueue.ts
+++ b/packages/cojson/src/queue/LocalTransactionsSyncQueue.ts
@@ -50,33 +50,14 @@ export class LocalTransactionsSyncQueue {
     coValue: VerifiedState,
     knownStateBefore: CoValueKnownState,
   ) {
-    const content = coValue.newContentSince(knownStateBefore, {
-      skipExpectContentUntil: true, // we need to calculate the streaming header considering the current batch
-    });
+    const content = coValue.newContentSince(knownStateBefore);
 
     if (!content) {
       return;
     }
 
-    let firstChunk = this.firstChunks.get(coValue.id);
-
     for (const piece of content) {
       this.batch.push(piece);
-
-      // Check if the local content updates are in streaming, if so we need to add the info to the first chunk
-      if (firstChunk) {
-        if (!firstChunk.expectContentUntil) {
-          firstChunk.expectContentUntil =
-            knownStateFromContent(firstChunk).sessions;
-        }
-        combineKnownStateSessions(
-          firstChunk.expectContentUntil,
-          knownStateFromContent(piece).sessions,
-        );
-      } else {
-        firstChunk = piece;
-        this.firstChunks.set(coValue.id, firstChunk);
-      }
     }
   }
 

--- a/packages/cojson/src/sync.ts
+++ b/packages/cojson/src/sync.ts
@@ -484,6 +484,15 @@ export class SyncManager {
           ? "import"
           : peer?.role;
 
+    // TODO: We can't handle client-to-client streaming until we
+    // handle the streaming state reset on disconnection
+    if (peer?.role === "client" && msg.expectContentUntil) {
+      msg = {
+        ...msg,
+        expectContentUntil: undefined,
+      };
+    }
+
     coValue.addDependenciesFromContentMessage(msg);
 
     // If some of the dependencies are missing, we wait for them to be available

--- a/packages/cojson/src/tests/StorageApiAsync.test.ts
+++ b/packages/cojson/src/tests/StorageApiAsync.test.ts
@@ -539,16 +539,16 @@ describe("StorageApiAsync", () => {
         }),
       ).toMatchInlineSnapshot(`
         [
-          "test -> test-storage | CONTENT Core header: false new: After: 1 New: 1 expectContentUntil: header/3",
-          "test -> test-storage | CONTENT Core2 header: false new: After: 1 New: 1 expectContentUntil: header/3",
+          "test -> test-storage | CONTENT Core header: false new: After: 1 New: 1",
+          "test -> test-storage | CONTENT Core2 header: false new: After: 1 New: 1",
           "test -> test-storage | CONTENT Core header: false new: After: 2 New: 1",
           "test -> test-storage | CONTENT Core2 header: false new: After: 2 New: 1",
           "test-storage -> test | KNOWN CORRECTION Core sessions: empty",
           "test -> test-storage | CONTENT Core header: true new: After: 0 New: 3",
           "test-storage -> test | KNOWN CORRECTION Core2 sessions: empty",
           "test -> test-storage | CONTENT Core2 header: true new: After: 0 New: 3",
-          "test -> test-storage | CONTENT Core header: false new: After: 3 New: 1 expectContentUntil: header/5",
-          "test -> test-storage | CONTENT Core2 header: false new: After: 3 New: 1 expectContentUntil: header/5",
+          "test -> test-storage | CONTENT Core header: false new: After: 3 New: 1",
+          "test -> test-storage | CONTENT Core2 header: false new: After: 3 New: 1",
           "test -> test-storage | CONTENT Core header: false new: After: 4 New: 1",
           "test -> test-storage | CONTENT Core2 header: false new: After: 4 New: 1",
         ]
@@ -606,14 +606,14 @@ describe("StorageApiAsync", () => {
         }),
       ).toMatchInlineSnapshot(`
         [
-          "test -> test-storage | CONTENT Core header: false new: After: 1 New: 1 expectContentUntil: header/3",
-          "test -> test-storage | CONTENT Core2 header: false new: After: 1 New: 1 expectContentUntil: header/3",
+          "test -> test-storage | CONTENT Core header: false new: After: 1 New: 1",
+          "test -> test-storage | CONTENT Core2 header: false new: After: 1 New: 1",
           "test -> test-storage | CONTENT Core header: false new: After: 2 New: 1",
           "test -> test-storage | CONTENT Core2 header: false new: After: 2 New: 1",
           "test-storage -> test | KNOWN CORRECTION Core sessions: empty",
           "test -> test-storage | CONTENT Core header: true new: After: 0 New: 3",
-          "test -> test-storage | CONTENT Core header: false new: After: 3 New: 1 expectContentUntil: header/5",
-          "test -> test-storage | CONTENT Core2 header: false new: After: 3 New: 1 expectContentUntil: header/5",
+          "test -> test-storage | CONTENT Core header: false new: After: 3 New: 1",
+          "test -> test-storage | CONTENT Core2 header: false new: After: 3 New: 1",
           "test -> test-storage | CONTENT Core header: false new: After: 4 New: 1",
           "test -> test-storage | CONTENT Core2 header: false new: After: 4 New: 1",
         ]

--- a/packages/cojson/src/tests/sync.auth.test.ts
+++ b/packages/cojson/src/tests/sync.auth.test.ts
@@ -53,7 +53,7 @@ describe("LocalNode auth sync", () => {
       }),
     ).toMatchInlineSnapshot(`
       [
-        "client -> server | CONTENT Account header: true new: After: 0 New: 3 expectContentUntil: header/4",
+        "client -> server | CONTENT Account header: true new: After: 0 New: 3",
         "client -> server | CONTENT ProfileGroup header: true new: After: 0 New: 5",
         "client -> server | CONTENT Profile header: true new: After: 0 New: 1",
         "client -> server | CONTENT Account header: false new: After: 3 New: 1",
@@ -116,9 +116,9 @@ describe("LocalNode auth sync", () => {
       }),
     ).toMatchInlineSnapshot(`
       [
-        "client -> server | CONTENT Account header: true new: After: 0 New: 3 expectContentUntil: header/5",
-        "client -> server | CONTENT Root header: true new:  expectContentUntil: header/1",
-        "client -> server | CONTENT Profile header: true new:  expectContentUntil: header/1",
+        "client -> server | CONTENT Account header: true new: After: 0 New: 3",
+        "client -> server | CONTENT Root header: true new: ",
+        "client -> server | CONTENT Profile header: true new: ",
         "client -> server | CONTENT Root header: false new: After: 0 New: 1",
         "client -> server | CONTENT Profile header: false new: After: 0 New: 1",
         "client -> server | CONTENT Account header: false new: After: 3 New: 2",
@@ -176,7 +176,7 @@ describe("LocalNode auth sync", () => {
       }),
     ).toMatchInlineSnapshot(`
       [
-        "creation-node -> server | CONTENT Account header: true new: After: 0 New: 3 expectContentUntil: header/4",
+        "creation-node -> server | CONTENT Account header: true new: After: 0 New: 3",
         "creation-node -> server | CONTENT ProfileGroup header: true new: After: 0 New: 5",
         "creation-node -> server | CONTENT Profile header: true new: After: 0 New: 1",
         "creation-node -> server | CONTENT Account header: false new: After: 3 New: 1",
@@ -246,7 +246,7 @@ describe("LocalNode auth sync", () => {
       }),
     ).toMatchInlineSnapshot(`
       [
-        "creation-node -> server | CONTENT Account header: true new: After: 0 New: 3 expectContentUntil: header/4",
+        "creation-node -> server | CONTENT Account header: true new: After: 0 New: 3",
         "creation-node -> server | CONTENT ProfileGroup header: true new: After: 0 New: 5",
         "creation-node -> server | CONTENT Profile header: true new: After: 0 New: 1",
         "creation-node -> server | CONTENT Account header: false new: After: 3 New: 1",

--- a/packages/cojson/src/tests/sync.load.test.ts
+++ b/packages/cojson/src/tests/sync.load.test.ts
@@ -1318,8 +1318,8 @@ describe("loading coValues from server", () => {
       }),
     ).toMatchInlineSnapshot(`
       [
-        "client -> server | CONTENT Group header: true new: After: 0 New: 3 expectContentUntil: header/5",
-        "client -> server | CONTENT ParentGroup header: true new: After: 0 New: 5 expectContentUntil: header/7",
+        "client -> server | CONTENT Group header: true new: After: 0 New: 3",
+        "client -> server | CONTENT ParentGroup header: true new: After: 0 New: 5",
         "client -> server | CONTENT Group header: false new: After: 3 New: 2",
         "client -> server | CONTENT ParentGroup header: false new: After: 5 New: 2",
         "client -> server | CONTENT Map header: true new: After: 0 New: 1",

--- a/packages/cojson/src/tests/sync.mesh.test.ts
+++ b/packages/cojson/src/tests/sync.mesh.test.ts
@@ -152,8 +152,8 @@ describe("multiple clients syncing with the a cloud-like server mesh", () => {
       }),
     ).toMatchInlineSnapshot(`
       [
-        "edge-france -> storage | CONTENT Group header: true new: After: 0 New: 3 expectContentUntil: header/5",
-        "edge-france -> core | CONTENT Group header: true new: After: 0 New: 3 expectContentUntil: header/5",
+        "edge-france -> storage | CONTENT Group header: true new: After: 0 New: 3",
+        "edge-france -> core | CONTENT Group header: true new: After: 0 New: 3",
         "edge-france -> storage | CONTENT ParentGroup header: true new: After: 0 New: 5",
         "edge-france -> core | CONTENT ParentGroup header: true new: After: 0 New: 5",
         "edge-france -> storage | CONTENT Group header: false new: After: 3 New: 2",

--- a/packages/cojson/src/tests/sync.storage.test.ts
+++ b/packages/cojson/src/tests/sync.storage.test.ts
@@ -709,8 +709,8 @@ describe("client syncs with a server with storage", () => {
       }),
     ).toMatchInlineSnapshot(`
       [
-        "client -> server | CONTENT Group header: true new: After: 0 New: 3 expectContentUntil: header/5",
-        "client -> server | CONTENT Map header: true new:  expectContentUntil: header/1",
+        "client -> server | CONTENT Group header: true new: After: 0 New: 3",
+        "client -> server | CONTENT Map header: true new: ",
         "client -> server | CONTENT Group header: false new: After: 3 New: 2",
         "client -> server | CONTENT Map header: false new: After: 0 New: 1",
         "server -> client | KNOWN Group sessions: header/3",

--- a/packages/cojson/src/tests/sync.storageAsync.test.ts
+++ b/packages/cojson/src/tests/sync.storageAsync.test.ts
@@ -211,7 +211,7 @@ describe("client with storage syncs with server", () => {
     ).toMatchInlineSnapshot(`
       [
         "client -> storage | CONTENT Group header: true new: After: 0 New: 3",
-        "client -> storage | CONTENT InitialMap header: true new:  expectContentUntil: header/1",
+        "client -> storage | CONTENT InitialMap header: true new: ",
         "client -> storage | CONTENT ChildMap header: true new: After: 0 New: 1",
         "client -> storage | CONTENT InitialMap header: false new: After: 0 New: 1",
       ]

--- a/packages/cojson/src/tests/sync.upload.test.ts
+++ b/packages/cojson/src/tests/sync.upload.test.ts
@@ -164,7 +164,7 @@ describe("client to server upload", () => {
       }),
     ).toMatchInlineSnapshot(`
       [
-        "client -> server | CONTENT Group header: true new: After: 0 New: 3 expectContentUntil: header/5",
+        "client -> server | CONTENT Group header: true new: After: 0 New: 3",
         "client -> server | CONTENT ParentGroup header: true new: After: 0 New: 5",
         "client -> server | CONTENT Group header: false new: After: 3 New: 2",
         "client -> server | CONTENT Map header: true new: After: 0 New: 1",
@@ -364,7 +364,7 @@ describe("client to server upload", () => {
     ).toMatchInlineSnapshot(`
       [
         "client -> server | CONTENT Group header: true new: After: 0 New: 3",
-        "client -> server | CONTENT InitialMap header: true new:  expectContentUntil: header/1",
+        "client -> server | CONTENT InitialMap header: true new: ",
         "client -> server | CONTENT ChildMap header: true new: After: 0 New: 1",
         "client -> server | CONTENT InitialMap header: false new: After: 0 New: 1",
         "server -> client | KNOWN Group sessions: header/3",


### PR DESCRIPTION
We've found that when a client disconnects and stops sending content, it could leave the coValue in a streaming state that would be never fullfilled on the sync server.

This highlights that we need a more detailed spec on the sync protocol on how to handle different situations of client-to-client streaming.

As a quick fix I'm going to disable the streaming state from clients, as we currently need only the streaming state for when a client is downloading data from storage or the server.

