### PR TITLE
fix: keep the same instance of content when revalidating

### DIFF
--- a/.changeset/sparkly-yaks-cry.md
+++ b/.changeset/sparkly-yaks-cry.md
@@ -1,0 +1,5 @@
+---
+"cojson": patch
+---
+
+Reuse the same instance of the raw coValue view on invalidation from permissions

--- a/packages/codemod-upgrade-0-19/tests/codemod.test.ts
+++ b/packages/codemod-upgrade-0-19/tests/codemod.test.ts
@@ -5,21 +5,25 @@ import { fileURLToPath } from "node:url";
 
 const currentDir = fileURLToPath(new URL(".", import.meta.url));
 
-test("runTransform", () => {
-  const fixturesBefore = readFileSync(
-    `${currentDir}/fixtures/test-example.tsx`,
-    "utf-8",
-  );
-  runTransform(`${currentDir}/fixtures`);
+test(
+  "runTransform",
+  () => {
+    const fixturesBefore = readFileSync(
+      `${currentDir}/fixtures/test-example.tsx`,
+      "utf-8",
+    );
+    runTransform(`${currentDir}/fixtures`);
 
-  const result = readFileSync(
-    `${currentDir}/fixtures/test-example.tsx`,
-    "utf-8",
-  );
+    const result = readFileSync(
+      `${currentDir}/fixtures/test-example.tsx`,
+      "utf-8",
+    );
 
-  onTestFinished(() => {
-    writeFileSync(`${currentDir}/fixtures/test-example.tsx`, fixturesBefore);
-  });
+    onTestFinished(() => {
+      writeFileSync(`${currentDir}/fixtures/test-example.tsx`, fixturesBefore);
+    });
 
-  expect(result).toMatchSnapshot();
-});
+    expect(result).toMatchSnapshot();
+  },
+  { timeout: 20000 },
+);

--- a/packages/cojson/src/coValue.ts
+++ b/packages/cojson/src/coValue.ts
@@ -34,13 +34,24 @@ export interface RawCoValue {
    * Used internally by `useTelepathicData()` for reactive updates on changes to a `CoValue`. */
   subscribe(listener: (coValue: this) => void): () => void;
 
+  /** The number of valid transactions that have been processed for this CoValue View */
   totalValidTransactions: number;
+  /**
+   * The version of this CoValue View, incremented when the content of the CoValue is rebuilt
+   *
+   * This is used to detect changes to the CoValue View coming from permission changes.
+   */
+  version: number;
+
+  processNewTransactions(): void;
+  rebuildFromCore(): void;
 }
 
 export class RawUnknownCoValue implements RawCoValue {
   id: CoID<this>;
   core: AvailableCoValueCore;
   totalValidTransactions = 0;
+  version = 0;
 
   constructor(core: AvailableCoValueCore) {
     this.id = core.id as CoID<this>;
@@ -73,6 +84,9 @@ export class RawUnknownCoValue implements RawCoValue {
       listener(core.getCurrentContent() as this);
     });
   }
+
+  processNewTransactions(): void {}
+  rebuildFromCore(): void {}
 }
 
 export type AnyRawCoValue =

--- a/packages/cojson/src/coValueCore/coValueCore.ts
+++ b/packages/cojson/src/coValueCore/coValueCore.ts
@@ -659,15 +659,7 @@ export class CoValueCore {
 
   private processNewTransactions() {
     if (this._cachedContent) {
-      // Does the cached content support incremental processing?
-      if (
-        "processNewTransactions" in this._cachedContent &&
-        typeof this._cachedContent.processNewTransactions === "function"
-      ) {
-        this._cachedContent.processNewTransactions();
-      } else {
-        this._cachedContent = undefined;
-      }
+      this._cachedContent.processNewTransactions();
     }
   }
 
@@ -857,8 +849,6 @@ export class CoValueCore {
 
   // Reset the parsed transactions and branches, to validate them again from scratch when the group is updated
   resetParsedTransactions() {
-    this._cachedContent = undefined;
-
     this.branchStart = undefined;
     this.mergeCommits = [];
 
@@ -870,6 +860,8 @@ export class CoValueCore {
     this.toProcessTransactions = [];
     this.toDecryptTransactions = [];
     this.toParseMetaTransactions = [];
+
+    this._cachedContent?.rebuildFromCore();
   }
 
   verifiedTransactions: VerifiedTransaction[] = [];

--- a/packages/cojson/src/coValues/coList.ts
+++ b/packages/cojson/src/coValues/coList.ts
@@ -87,6 +87,7 @@ export class RawCoList<
   /** @internal */
   knownTransactions: Record<RawCoID, number>;
   totalValidTransactions: number = 0;
+  version: number = 0;
 
   lastValidTransaction: number | undefined;
 
@@ -661,16 +662,18 @@ export class RawCoList<
 
   /** @internal */
   rebuildFromCore() {
-    const listAfter = new RawCoList(this.core) as this;
+    this.version++;
 
-    this.afterStart = listAfter.afterStart;
-    this.beforeEnd = listAfter.beforeEnd;
-    this.insertions = listAfter.insertions;
-    this.lastValidTransaction = listAfter.lastValidTransaction;
-    this.knownTransactions = listAfter.knownTransactions;
-    this.totalValidTransactions = listAfter.totalValidTransactions;
-    this.deletionsByInsertion = listAfter.deletionsByInsertion;
+    this.afterStart = [];
+    this.beforeEnd = [];
+    this.insertions = {};
+    this.lastValidTransaction = undefined;
+    this.knownTransactions = { [this.core.id]: 0 };
+    this.totalValidTransactions = 0;
+    this.deletionsByInsertion = {};
     this._cachedEntries = undefined;
+
+    this.processNewTransactions();
   }
 }
 

--- a/packages/cojson/src/coValues/coList.ts
+++ b/packages/cojson/src/coValues/coList.ts
@@ -55,53 +55,52 @@ export class RawCoList<
   type: "colist" | "coplaintext" = "colist" as const;
   /** @category 6. Meta */
   core: AvailableCoValueCore;
-  /** @internal */
-  afterStart: OpID[];
-  /** @internal */
-  beforeEnd: OpID[];
-  /** @internal */
+
+  /** The internal state of the RawCoList */
+  afterStart: OpID[] = [];
+  beforeEnd: OpID[] = [];
   insertions: {
     [sessionID: SessionID]: {
       [txIdx: number]: {
         [changeIdx: number]: InsertionEntry<Item>;
       };
     };
-  };
-  /** @internal */
+  } = {};
   deletionsByInsertion: {
     [deletedSessionID: SessionID]: {
       [deletedTxIdx: number]: {
         [deletedChangeIdx: number]: DeletionEntry[];
       };
     };
-  };
-  /** @category 6. Meta */
-  readonly _item!: Item;
-
-  /** @internal */
+  } = {};
   _cachedEntries?: {
     value: Item;
     madeAt: number;
     opID: OpID;
   }[];
-  /** @internal */
-  knownTransactions: Record<RawCoID, number>;
-  totalValidTransactions: number = 0;
+  knownTransactions: Record<RawCoID, number> = {};
   version: number = 0;
-
   lastValidTransaction: number | undefined;
+  totalValidTransactions: number = 0;
+
+  private resetInternalState() {
+    this.afterStart = [];
+    this.beforeEnd = [];
+    this.insertions = {};
+    this.deletionsByInsertion = {};
+    this._cachedEntries = undefined;
+    this.knownTransactions = { [this.core.id]: 0 };
+    this.lastValidTransaction = undefined;
+    this.totalValidTransactions = 0;
+  }
+
+  /** @category 6. Meta */
+  readonly _item!: Item;
 
   /** @internal */
   constructor(core: AvailableCoValueCore) {
     this.id = core.id as CoID<this>;
     this.core = core;
-
-    this.insertions = {};
-    this.deletionsByInsertion = {};
-    this.afterStart = [];
-    this.beforeEnd = [];
-    this.knownTransactions = { [core.id]: 0 };
-
     this.processNewTransactions();
   }
 
@@ -282,6 +281,13 @@ export class RawCoList<
     }
 
     this.totalValidTransactions += transactions.length;
+  }
+
+  rebuildFromCore() {
+    this.version += 1;
+
+    this.resetInternalState();
+    this.processNewTransactions();
   }
 
   /** @category 6. Meta */
@@ -657,22 +663,6 @@ export class RawCoList<
       ],
       privacy,
     );
-    this.processNewTransactions();
-  }
-
-  /** @internal */
-  rebuildFromCore() {
-    this.version++;
-
-    this.afterStart = [];
-    this.beforeEnd = [];
-    this.insertions = {};
-    this.lastValidTransaction = undefined;
-    this.knownTransactions = { [this.core.id]: 0 };
-    this.totalValidTransactions = 0;
-    this.deletionsByInsertion = {};
-    this._cachedEntries = undefined;
-
     this.processNewTransactions();
   }
 }

--- a/packages/cojson/src/coValues/coStream.ts
+++ b/packages/cojson/src/coValues/coStream.ts
@@ -9,7 +9,6 @@ import { isAccountID } from "../typeUtils/isAccountID.js";
 import { isCoValue } from "../typeUtils/isCoValue.js";
 import { RawAccountID } from "./account.js";
 import { RawGroup } from "./group.js";
-import { Transaction } from "../coValueCore/verifiedState.js";
 import { RawCoID } from "../ids.js";
 
 export type BinaryStreamInfo = {
@@ -60,12 +59,21 @@ export class RawCoStreamView<
   readonly _item!: Item;
 
   totalValidTransactions: number = 0;
+  version: number = 0;
 
   constructor(core: AvailableCoValueCore) {
     this.id = core.id as CoID<this>;
     this.core = core;
     this.items = {};
     this.knownTransactions = { [core.id]: 0 };
+    this.processNewTransactions();
+  }
+
+  rebuildFromCore() {
+    this.version++;
+    this.items = {};
+    this.knownTransactions = { [this.core.id]: 0 };
+    this.totalValidTransactions = 0;
     this.processNewTransactions();
   }
 

--- a/packages/cojson/src/coValues/coStream.ts
+++ b/packages/cojson/src/coValues/coStream.ts
@@ -51,15 +51,20 @@ export class RawCoStreamView<
   id: CoID<this>;
   type = "costream" as const;
   core: AvailableCoValueCore;
+
+  /** The internal state of RawCoStream */
   items: {
     [key: SessionID]: CoStreamItem<Item>[];
   };
-  /** @internal */
   knownTransactions: Record<RawCoID, number>;
-  readonly _item!: Item;
-
   totalValidTransactions: number = 0;
   version: number = 0;
+
+  private resetInternalState() {
+    this.items = {};
+    this.knownTransactions = { [this.core.id]: 0 };
+    this.totalValidTransactions = 0;
+  }
 
   constructor(core: AvailableCoValueCore) {
     this.id = core.id as CoID<this>;
@@ -71,9 +76,8 @@ export class RawCoStreamView<
 
   rebuildFromCore() {
     this.version++;
-    this.items = {};
-    this.knownTransactions = { [this.core.id]: 0 };
-    this.totalValidTransactions = 0;
+
+    this.resetInternalState();
     this.processNewTransactions();
   }
 

--- a/packages/cojson/src/tests/coList.test.ts
+++ b/packages/cojson/src/tests/coList.test.ts
@@ -956,3 +956,31 @@ describe("CoList Branching", () => {
     `);
   });
 });
+
+test("the list should rebuild when the group permissions change", async () => {
+  const alice = setupTestNode({
+    connected: true,
+  });
+  const group = alice.node.createGroup();
+  const list = group.createList();
+
+  list.append("fromAdmin");
+
+  const bob = setupTestNode({
+    connected: true,
+  });
+
+  const listOnBob = await loadCoValueOrFail(bob.node, list.id);
+
+  expect(listOnBob.get(0)).toEqual(undefined);
+  expect(listOnBob.totalValidTransactions).toEqual(0);
+
+  group.addMember("everyone", "reader");
+
+  await waitFor(() => {
+    expect(listOnBob.get(0)).toEqual("fromAdmin");
+  });
+
+  expect(listOnBob.version).toEqual(1);
+  expect(listOnBob.totalValidTransactions).toEqual(1);
+});

--- a/packages/cojson/src/tests/group.invite.test.ts
+++ b/packages/cojson/src/tests/group.invite.test.ts
@@ -99,9 +99,7 @@ describe("Group invites", () => {
     await newMember.node.acceptInvite(group.id, inviteSecret);
 
     await waitFor(() => {
-      expect(
-        expectMap(personOnNewMemberNode.core.getCurrentContent()).get("name"),
-      ).toEqual("John Doe");
+      expect(personOnNewMemberNode.get("name")).toEqual("John Doe");
     });
 
     const groupOnNewMemberNode = await loadCoValueOrFail(
@@ -137,9 +135,7 @@ describe("Group invites", () => {
     await newMember.node.acceptInvite(group.id, inviteSecret);
 
     await waitFor(() => {
-      expect(
-        expectMap(personOnNewMemberNode.core.getCurrentContent()).get("name"),
-      ).toEqual("John Doe");
+      expect(personOnNewMemberNode.get("name")).toEqual("John Doe");
     });
 
     const groupOnNewMemberNode = await loadCoValueOrFail(
@@ -220,9 +216,7 @@ describe("Group invites", () => {
     await newMember.node.acceptInvite(group.id, inviteSecret);
 
     await waitFor(() => {
-      expect(
-        expectMap(personOnNewMemberNode.core.getCurrentContent()).get("name"),
-      ).toEqual("John Doe");
+      expect(personOnNewMemberNode.get("name")).toEqual("John Doe");
     });
 
     const groupOnNewMemberNode = await loadCoValueOrFail(
@@ -246,9 +240,7 @@ describe("Group invites", () => {
     const personOnReaderNode = await loadCoValueOrFail(reader.node, person.id);
 
     await waitFor(() => {
-      expect(
-        expectMap(personOnReaderNode.core.getCurrentContent()).get("name"),
-      ).toEqual("John Doe");
+      expect(personOnReaderNode.get("name")).toEqual("John Doe");
     });
   });
 
@@ -278,9 +270,7 @@ describe("Group invites", () => {
     await newMember.node.acceptInvite(group.id, inviteSecret);
 
     await waitFor(() => {
-      expect(
-        expectMap(personOnNewMemberNode.core.getCurrentContent()).get("name"),
-      ).toEqual("John Doe");
+      expect(personOnNewMemberNode.get("name")).toEqual("John Doe");
     });
 
     const groupOnNewMemberNode = await loadCoValueOrFail(
@@ -304,9 +294,7 @@ describe("Group invites", () => {
     const personOnReaderNode = await loadCoValueOrFail(reader.node, person.id);
 
     await waitFor(() => {
-      expect(
-        expectMap(personOnReaderNode.core.getCurrentContent()).get("name"),
-      ).toEqual("John Doe");
+      expect(personOnReaderNode.get("name")).toEqual("John Doe");
     });
   });
 
@@ -411,7 +399,7 @@ describe("Group invites", () => {
     // First add member as reader
     const memberAccount = await loadCoValueOrFail(admin.node, member.accountID);
     group.addMember(memberAccount, "reader");
-    await group.removeMember(memberAccount);
+    group.removeMember(memberAccount);
 
     // Create a new reader invite
     const inviteSecret = group.createInvite("reader");

--- a/packages/cojson/src/tests/group.roleOf.test.ts
+++ b/packages/cojson/src/tests/group.roleOf.test.ts
@@ -329,8 +329,7 @@ describe("roleOf", () => {
       expect(mapOnNode2.get("test")).toEqual("Written from everyone");
 
       await waitFor(async () => {
-        const updatedMap = expectMap(mapOnNode2.core.getCurrentContent());
-        expect(updatedMap.get("fromAdmin")).toEqual("Written from admin");
+        expect(mapOnNode2.get("fromAdmin")).toEqual("Written from admin");
       });
     });
 
@@ -374,9 +373,8 @@ describe("roleOf", () => {
       expect(mapOnNode2.get("test")).toEqual("Updated after the upgrade");
 
       await waitFor(async () => {
-        const updatedMap = expectMap(mapOnNode2.core.getCurrentContent());
         // Get the new content after the invalidation caused by group update
-        expect(updatedMap.get("fromAdmin")).toEqual("Written from admin");
+        expect(mapOnNode2.get("fromAdmin")).toEqual("Written from admin");
       });
     });
 

--- a/packages/cojson/src/tests/sync.load.test.ts
+++ b/packages/cojson/src/tests/sync.load.test.ts
@@ -481,10 +481,7 @@ describe("loading coValues from server", () => {
     map.set("fromServer", "updated", "trusting");
 
     await waitFor(() => {
-      const coValue = expectMap(
-        client.node.expectCoValueLoaded(map.id).getCurrentContent(),
-      );
-      expect(coValue.get("fromServer")).toEqual("updated");
+      expect(map.get("fromServer")).toEqual("updated");
     });
 
     expect(
@@ -1257,10 +1254,7 @@ describe("loading coValues from server", () => {
 
     // Wait for the update to arrive on the initial client
     await waitFor(() => {
-      const mapOnClient = expectMap(
-        client.node.getCoValue(map.core.id).getCurrentContent(),
-      );
-      expect(mapOnClient.get("newAccountClient")).toBe(true);
+      expect(map.get("newAccountClient")).toBe(true);
     });
 
     // The edge server should wait for the new Account to be available before sending the Map update

--- a/packages/cojson/src/tests/sync.storage.test.ts
+++ b/packages/cojson/src/tests/sync.storage.test.ts
@@ -733,4 +733,113 @@ describe("client syncs with a server with storage", () => {
       ]
     `);
   });
+
+  test("large parent group streaming from storage", async () => {
+    const syncServer = setupTestNode({
+      isSyncServer: true,
+    });
+    const { storage } = syncServer.addStorage({
+      ourName: "syncServer",
+    });
+
+    const alice = setupTestNode();
+    alice.connectToSyncServer({
+      syncServer: syncServer.node,
+    });
+
+    const parentGroup = alice.node.createGroup();
+    const group = alice.node.createGroup();
+    group.extend(parentGroup);
+
+    const map = group.createMap();
+
+    fillCoMapWithLargeData(parentGroup);
+
+    parentGroup.addMember("everyone", "reader");
+
+    map.set("hello", "world");
+
+    await map.core.waitForSync();
+    await parentGroup.core.waitForSync();
+
+    expect(
+      SyncMessagesLog.getMessages({
+        Group: group.core,
+        ParentGroup: parentGroup.core,
+        Map: map.core,
+      }),
+    ).toMatchInlineSnapshot(`
+      [
+        "client -> server | CONTENT ParentGroup header: true new: After: 0 New: 3",
+        "client -> server | CONTENT Group header: true new: After: 0 New: 5",
+        "client -> server | CONTENT Map header: true new: ",
+        "client -> server | CONTENT ParentGroup header: false new: After: 3 New: 73 expectContentUntil: header/205",
+        "client -> server | CONTENT ParentGroup header: false new: After: 76 New: 73",
+        "client -> server | CONTENT ParentGroup header: false new: After: 149 New: 56",
+        "client -> server | CONTENT Map header: false new: After: 0 New: 1",
+        "server -> client | KNOWN ParentGroup sessions: header/3",
+        "syncServer -> storage | CONTENT ParentGroup header: true new: After: 0 New: 3",
+        "server -> client | KNOWN Group sessions: header/5",
+        "syncServer -> storage | CONTENT Group header: true new: After: 0 New: 5",
+        "server -> client | KNOWN Map sessions: header/0",
+        "syncServer -> storage | CONTENT Map header: true new: ",
+        "server -> client | KNOWN ParentGroup sessions: header/76",
+        "syncServer -> storage | CONTENT ParentGroup header: false new: After: 3 New: 73",
+        "server -> client | KNOWN ParentGroup sessions: header/149",
+        "syncServer -> storage | CONTENT ParentGroup header: false new: After: 76 New: 73",
+        "server -> client | KNOWN ParentGroup sessions: header/205",
+        "syncServer -> storage | CONTENT ParentGroup header: false new: After: 149 New: 56",
+        "server -> client | KNOWN Map sessions: header/1",
+        "syncServer -> storage | CONTENT Map header: false new: After: 0 New: 1",
+      ]
+    `);
+
+    SyncMessagesLog.clear();
+
+    syncServer.restart();
+    syncServer.addStorage({
+      ourName: "syncServer",
+      storage,
+    });
+
+    const bob = setupTestNode();
+    bob.connectToSyncServer({
+      syncServer: syncServer.node,
+      ourName: "bob",
+    });
+
+    let mapOnBob = await loadCoValueOrFail(bob.node, map.id);
+
+    await mapOnBob.core.waitForAsync((value) => value.isCompletelyDownloaded());
+
+    expect(
+      SyncMessagesLog.getMessages({
+        ParentGroup: parentGroup.core,
+        Group: group.core,
+        Map: map.core,
+      }),
+    ).toMatchInlineSnapshot(`
+      [
+        "bob -> server | LOAD Map sessions: empty",
+        "syncServer -> storage | LOAD Map sessions: empty",
+        "storage -> syncServer | CONTENT ParentGroup header: true new: After: 0 New: 76 expectContentUntil: header/205",
+        "storage -> syncServer | CONTENT Group header: true new: After: 0 New: 5",
+        "storage -> syncServer | CONTENT Map header: true new: After: 0 New: 1",
+        "server -> bob | CONTENT ParentGroup header: true new: After: 0 New: 76 expectContentUntil: header/205",
+        "server -> bob | CONTENT Group header: true new: After: 0 New: 5",
+        "server -> bob | CONTENT Map header: true new: After: 0 New: 1",
+        "storage -> syncServer | CONTENT ParentGroup header: true new: After: 76 New: 73",
+        "server -> bob | CONTENT ParentGroup header: false new: After: 76 New: 73 expectContentUntil: header/205",
+        "bob -> server | KNOWN ParentGroup sessions: header/76",
+        "bob -> server | KNOWN Group sessions: header/5",
+        "bob -> server | KNOWN Map sessions: header/1",
+        "bob -> server | KNOWN ParentGroup sessions: header/149",
+        "storage -> syncServer | CONTENT ParentGroup header: true new: After: 149 New: 56",
+        "server -> bob | CONTENT ParentGroup header: false new: After: 149 New: 56",
+        "bob -> server | KNOWN ParentGroup sessions: header/205",
+      ]
+    `);
+
+    expect(mapOnBob.get("hello")).toEqual("world");
+  });
 });

--- a/packages/jazz-tools/src/tools/subscribe/SubscriptionScope.ts
+++ b/packages/jazz-tools/src/tools/subscribe/SubscriptionScope.ts
@@ -173,10 +173,7 @@ export class SubscriptionScope<D extends CoValue> {
     } else {
       const hasChanged =
         update.totalValidTransactions !== this.totalValidTransactions ||
-        update.version !== this.version ||
-        // Checking the identity of the raw value makes us cover the cases where the group
-        // has been updated and the coValues that don't update the totalValidTransactions value (e.g. FileStream)
-        this.value.value.$jazz.raw !== update;
+        update.version !== this.version;
 
       if (this.loadChildren()) {
         this.updateValue(createCoValue(this.schema, update, this));

--- a/packages/jazz-tools/src/tools/subscribe/SubscriptionScope.ts
+++ b/packages/jazz-tools/src/tools/subscribe/SubscriptionScope.ts
@@ -49,6 +49,7 @@ export class SubscriptionScope<D extends CoValue> {
   autoloadedKeys = new Set<string>();
   skipInvalidKeys = new Set<string>();
   totalValidTransactions = 0;
+  version = 0;
   migrated = false;
   migrating = false;
   closed = false;
@@ -172,6 +173,7 @@ export class SubscriptionScope<D extends CoValue> {
     } else {
       const hasChanged =
         update.totalValidTransactions !== this.totalValidTransactions ||
+        update.version !== this.version ||
         // Checking the identity of the raw value makes us cover the cases where the group
         // has been updated and the coValues that don't update the totalValidTransactions value (e.g. FileStream)
         this.value.value.$jazz.raw !== update;
@@ -184,6 +186,7 @@ export class SubscriptionScope<D extends CoValue> {
     }
 
     this.totalValidTransactions = update.totalValidTransactions;
+    this.version = update.version;
 
     this.silenceUpdates = false;
     this.triggerUpdate();


### PR DESCRIPTION
Since now we had this weird thing that, when the group updates a new "currentContent" is created.

This has always been a pain while testing, because something like this would fail in an hard-to-understand way:
```ts
test("the map should rebuild when the group permissions change", async () => {
  const alice = setupTestNode({
    connected: true,
  });
  const bob = setupTestNode({
    connected: true,
  });
  const group = alice.node.createGroup();
  const map = group.createMap();
  
  group.addMember("everyone", "writer");  // new content here!

  const mapOnBob = await loadCoValueOrFail(bob.node, map.id);
  map.set("fromBob", true);

  await waitFor(() => {
    expect(map.get("fromBob")).toBeTrue() // This is no more the current content, so it won't be never updated
  });
});
```

The same thing happens on `jazz-tools`.

In this PR I'm changing the approach to reset the state of the current view, keeping the same reference.
Had to introduce a `version` field to let SubscriptionScope know when we've got a "revalidation" because only checking the `totalValidTransactions` is not enough for some edge cases (when after the revalidation we have the same amount of valid transactions but different content, yes we already have a test covering this case).

We've got no one complaining about this, besides me, but since it can make things fail in an unpredictable way I think it's time to improve the flow.