### PR TITLE
feat: add `resolve` support for `co.discriminatedUnion`

### DIFF
--- a/.changeset/busy-brooms-lay.md
+++ b/.changeset/busy-brooms-lay.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Add `resolve` support for `co.discriminatedUnion`

--- a/homepage/homepage/content/docs/core-concepts/schemas/schemaunions.mdx
+++ b/homepage/homepage/content/docs/core-concepts/schemas/schemaunions.mdx
@@ -184,11 +184,6 @@ const unsubscribe = Widget.subscribe(widgetId, {}, (widget) => {
 ```
 </CodeGroup>
 
-<Alert variant="info" className="mt-4 flex gap-2 items-center">
- Resolve queries are not supported in schema unions yet. If you need to [deeply load](/docs/core-concepts/subscription-and-loading#deep-loading) a schema union,
- you'll need to first shallowly load the union, and then load the nested properties after narrowing the union type (using `$jazz.ensureLoaded` or `useCoState`).
-</Alert>
-
 ## Nested schema unions
 
 You can create complex hierarchies by nesting discriminated unions within other unions:
@@ -258,10 +253,9 @@ Schema unions have some limitations that you should be aware of. They are due to
 
 Note that these methods may still work at runtime, but their use is not recommended as you will lose type safety.
 
-### `$jazz.ensureLoaded` and `$jazz.subscribe` not supported
+### `$jazz.ensureLoaded` and `$jazz.subscribe` require type narrowing
 
-The `$jazz.ensureLoaded` and `$jazz.subscribe` methods are not available in schema unions.
-Instead, use the union schema's `load` and `subscribe` methods.
+The `$jazz.ensureLoaded` and `$jazz.subscribe` methods are not supported directly on a schema union unless you first narrow the type using the discriminator.
 
 ### Updating union fields
 

--- a/packages/jazz-tools/src/tools/coValues/coList.ts
+++ b/packages/jazz-tools/src/tools/coValues/coList.ts
@@ -397,7 +397,7 @@ export class CoList<out Item = any>
         });
       },
       onUpdateWhenFound(value) {
-        value.$jazz.applyDiff(options.value);
+        (value as Resolved<L>).$jazz.applyDiff(options.value);
       },
     });
   }

--- a/packages/jazz-tools/src/tools/coValues/deepLoading.ts
+++ b/packages/jazz-tools/src/tools/coValues/deepLoading.ts
@@ -6,16 +6,23 @@ import { type CoKeys } from "./coMap.js";
 import { type CoValue, type ID } from "./interfaces.js";
 
 /**
- * Used to check if T is a union type.
+ * Returns a boolean for whether the given type is a union.
  *
- * If T is a union type, the left hand side of the extends becomes a union of function types.
- * The right hand side is always a single function type.
+ * Taken from https://github.com/sindresorhus/type-fest/blob/main/source/is-union.d.ts
  */
-type IsUnion<T, U = T> = (T extends any ? (x: T) => void : never) extends (
-  x: U,
-) => void
-  ? false
-  : true;
+type IsUnion<T, U = T> = (
+  [T] extends [never]
+    ? false
+    : T extends any
+      ? [U] extends [T]
+        ? false
+        : true
+      : never
+) extends infer Result
+  ? boolean extends Result
+    ? true
+    : Result
+  : never;
 
 /**
  * A CoValue that may or may not be loaded.
@@ -67,61 +74,57 @@ export type RefsToResolve<
   | (DepthLimit extends CurrentDepth["length"]
       ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
         any
-      : IsUnion<LoadedAndRequired<V>> extends true
-        ? true
-        : // Basically V extends CoList - but if we used that we'd introduce circularity into the definition of CoList itself
-          V extends ReadonlyArray<infer Item>
-          ? LoadedAndRequired<Item> extends CoValue
+      : // Basically V extends CoList - but if we used that we'd introduce circularity into the definition of CoList itself
+        V extends ReadonlyArray<infer Item>
+        ? LoadedAndRequired<Item> extends CoValue
+          ?
+              | ({
+                  $each?: RefsToResolve<
+                    AsLoaded<Item>,
+                    DepthLimit,
+                    [0, ...CurrentDepth]
+                  >;
+                } & OnError)
+              | boolean
+          : OnError | boolean
+        : // Basically V extends CoMap | Group | Account - but if we used that we'd introduce circularity into the definition of CoMap itself
+          V extends { [TypeSym]: "CoMap" | "Group" | "Account" }
+          ?
+              | ({
+                  [Key in CoKeys<V> as LoadedAndRequired<V[Key]> extends CoValue
+                    ? Key
+                    : never]?: RefsToResolve<
+                    LoadedAndRequired<V[Key]>,
+                    DepthLimit,
+                    [0, ...CurrentDepth]
+                  >;
+                } & OnError)
+              | (ItemsSym extends keyof V
+                  ? {
+                      $each: RefsToResolve<
+                        LoadedAndRequired<V[ItemsSym]>,
+                        DepthLimit,
+                        [0, ...CurrentDepth]
+                      >;
+                    } & OnError
+                  : never)
+              | boolean
+          : V extends {
+                [TypeSym]: "CoStream";
+                byMe: CoFeedEntry<infer Item> | undefined;
+              }
             ?
                 | ({
-                    $each?: RefsToResolve<
+                    $each: RefsToResolve<
                       AsLoaded<Item>,
                       DepthLimit,
                       [0, ...CurrentDepth]
                     >;
                   } & OnError)
                 | boolean
-            : OnError | boolean
-          : // Basically V extends CoMap | Group | Account - but if we used that we'd introduce circularity into the definition of CoMap itself
-            V extends { [TypeSym]: "CoMap" | "Group" | "Account" }
-            ?
-                | ({
-                    [Key in CoKeys<V> as LoadedAndRequired<
-                      V[Key]
-                    > extends CoValue
-                      ? Key
-                      : never]?: RefsToResolve<
-                      LoadedAndRequired<V[Key]>,
-                      DepthLimit,
-                      [0, ...CurrentDepth]
-                    >;
-                  } & OnError)
-                | (ItemsSym extends keyof V
-                    ? {
-                        $each: RefsToResolve<
-                          LoadedAndRequired<V[ItemsSym]>,
-                          DepthLimit,
-                          [0, ...CurrentDepth]
-                        >;
-                      } & OnError
-                    : never)
-                | boolean
-            : V extends {
-                  [TypeSym]: "CoStream";
-                  byMe: CoFeedEntry<infer Item> | undefined;
-                }
-              ?
-                  | ({
-                      $each: RefsToResolve<
-                        AsLoaded<Item>,
-                        DepthLimit,
-                        [0, ...CurrentDepth]
-                      >;
-                    } & OnError)
-                  | boolean
-              : V extends { [TypeSym]: "CoPlainText" | "BinaryCoStream" }
-                ? boolean | OnError
-                : boolean);
+            : V extends { [TypeSym]: "CoPlainText" | "BinaryCoStream" }
+              ? boolean | OnError
+              : boolean);
 
 export type RefsToResolveStrict<T, V> = [V] extends [RefsToResolve<T>]
   ? RefsToResolve<T>
@@ -130,7 +133,7 @@ export type RefsToResolveStrict<T, V> = [V] extends [RefsToResolve<T>]
 export type Resolved<
   T,
   R extends RefsToResolve<T> | undefined = true,
-> = DeeplyLoaded<T, R, 10, []>;
+> = DeeplyLoaded<T, R>;
 
 /**
  * If the resolve query contains `$onError: "catch"`, we return a not loaded value for this nested CoValue.
@@ -145,21 +148,32 @@ type CoMapLikeLoaded<
   Depth,
   DepthLimit extends number,
   CurrentDepth extends number[],
-> = {
-  readonly [Key in keyof Omit<Depth, "$onError">]-?: Key extends CoKeys<V>
-    ? LoadedAndRequired<V[Key]> extends CoValue
-      ?
-          | DeeplyLoaded<
-              LoadedAndRequired<V[Key]>,
-              Depth[Key],
-              DepthLimit,
-              [0, ...CurrentDepth]
-            >
-          | (undefined extends V[Key] ? undefined : never)
-          | OnErrorResolvedValue<V[Key], Depth[Key]>
-      : never
-    : never;
-} & V;
+> = IsUnion<LoadedAndRequired<V>> extends true
+  ? // Trigger conditional type distributivity to deeply resolve each member of the union separately
+    // Otherwise, deeply loaded values will resolve to `never`
+    V extends V
+    ? CoMapLikeLoaded<
+        V,
+        Pick<Depth, keyof V & keyof Depth>,
+        DepthLimit,
+        CurrentDepth
+      >
+    : never
+  : {
+      readonly [Key in keyof Omit<Depth, "$onError">]-?: Key extends CoKeys<V>
+        ? LoadedAndRequired<V[Key]> extends CoValue
+          ?
+              | DeeplyLoaded<
+                  LoadedAndRequired<V[Key]>,
+                  Depth[Key],
+                  DepthLimit,
+                  [0, ...CurrentDepth]
+                >
+              | (undefined extends V[Key] ? undefined : never)
+              | OnErrorResolvedValue<V[Key], Depth[Key]>
+          : never
+        : never;
+    } & V;
 
 export type DeeplyLoaded<
   V,

--- a/packages/jazz-tools/src/tools/coValues/interfaces.ts
+++ b/packages/jazz-tools/src/tools/coValues/interfaces.ts
@@ -119,7 +119,7 @@ export function createUnloadedCoValue<T extends CoValue>(
 
 export function loadCoValueWithoutMe<
   V extends CoValue,
-  const R extends RefsToResolve<V>,
+  const R extends RefsToResolve<V> = true,
 >(
   cls: CoValueClass<V>,
   id: ID<CoValue>,
@@ -263,7 +263,7 @@ export function parseSubscribeRestArgs<
 
 export function subscribeToCoValueWithoutMe<
   V extends CoValue,
-  const R extends RefsToResolve<V>,
+  const R extends RefsToResolve<V> = true,
 >(
   cls: CoValueClass<V>,
   id: ID<CoValue>,
@@ -283,7 +283,7 @@ export function subscribeToCoValueWithoutMe<
 
 export function subscribeToCoValue<
   V extends CoValue,
-  const R extends RefsToResolve<V>,
+  const R extends RefsToResolve<V> = true,
 >(
   cls: CoValueClass<V>,
   id: ID<CoValue>,

--- a/packages/jazz-tools/src/tools/coValues/schemaUnion.ts
+++ b/packages/jazz-tools/src/tools/coValues/schemaUnion.ts
@@ -11,6 +11,8 @@ import {
   Group,
   ID,
   MaybeLoaded,
+  RefsToResolve,
+  RefsToResolveStrict,
   Resolved,
   Simplify,
   SubscribeListenerOptions,
@@ -150,18 +152,17 @@ export abstract class SchemaUnion extends CoValueBase implements CoValue {
   /**
    * Load a `SchemaUnion` with a given ID, as a given account.
    *
-   * Note: The `resolve` option is not supported for `SchemaUnion`s due to https://github.com/garden-co/jazz/issues/2639
-   *
    * @category Subscription & Loading
    */
-  static load<M extends SchemaUnion>(
+  static load<M extends SchemaUnion, const R extends RefsToResolve<M> = true>(
     this: CoValueClass<M>,
     id: ID<M>,
     options?: {
+      resolve?: RefsToResolveStrict<M, R>;
       loadAs?: Account | AnonymousJazzAgent;
       skipRetry?: boolean;
     },
-  ): Promise<MaybeLoaded<Resolved<M, true>>> {
+  ): Promise<MaybeLoaded<Resolved<M, R>>> {
     return loadCoValueWithoutMe(this, id, options);
   }
 
@@ -174,27 +175,31 @@ export abstract class SchemaUnion extends CoValueBase implements CoValue {
    *
    * Also see the `useCoState` hook to reactively subscribe to a CoValue in a React component.
    *
-   * Note: The `resolve` option is not supported for `SchemaUnion`s due to https://github.com/garden-co/jazz/issues/2639
-   *
    * @category Subscription & Loading
    */
-  static subscribe<M extends SchemaUnion>(
+  static subscribe<
+    M extends SchemaUnion,
+    const R extends RefsToResolve<M> = true,
+  >(
     this: CoValueClass<M>,
     id: ID<M>,
-    listener: (value: Resolved<M, true>, unsubscribe: () => void) => void,
+    listener: (value: Resolved<M, R>, unsubscribe: () => void) => void,
   ): () => void;
-  static subscribe<M extends SchemaUnion>(
+  static subscribe<
+    M extends SchemaUnion,
+    const R extends RefsToResolve<M> = true,
+  >(
     this: CoValueClass<M>,
     id: ID<M>,
-    options: SubscribeListenerOptions<M, true>,
-    listener: (value: Resolved<M, true>, unsubscribe: () => void) => void,
+    options: SubscribeListenerOptions<M, R>,
+    listener: (value: Resolved<M, R>, unsubscribe: () => void) => void,
   ): () => void;
-  static subscribe<M extends SchemaUnion>(
+  static subscribe<M extends SchemaUnion, const R extends RefsToResolve<M>>(
     this: CoValueClass<M>,
     id: ID<M>,
-    ...args: SubscribeRestArgs<M, true>
+    ...args: SubscribeRestArgs<M, R>
   ): () => void {
     const { options, listener } = parseSubscribeRestArgs(args);
-    return subscribeToCoValueWithoutMe<M, true>(this, id, options, listener);
+    return subscribeToCoValueWithoutMe<M, R>(this, id, options, listener);
   }
 }

--- a/packages/jazz-tools/src/tools/subscribe/SubscriptionScope.ts
+++ b/packages/jazz-tools/src/tools/subscribe/SubscriptionScope.ts
@@ -594,17 +594,6 @@ export class SubscriptionScope<D extends CoValue> {
     const descriptor = map.$jazz.getDescriptor(key);
 
     if (!descriptor) {
-      this.childErrors.set(
-        key,
-        new JazzError(undefined, CoValueLoadingState.UNAVAILABLE, [
-          {
-            code: "validationError",
-            message: `The ref ${key} requested on ${map.constructor.name} is not defined in the schema`,
-            params: {},
-            path: [key],
-          },
-        ]),
-      );
       return undefined;
     }
 

--- a/packages/jazz-tools/src/tools/tests/coDiscriminatedUnion.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coDiscriminatedUnion.test.ts
@@ -544,7 +544,7 @@ describe("co.discriminatedUnion", () => {
     const pets = Pets.create([dog, cat, bird]);
 
     const loadedPets = await Pets.load(pets.$jazz.id, {
-      resolve: { $each: { friend: { $each: { friend: true } } } },
+      resolve: { $each: { friend: { $each: { friend: true }, bird: true } } },
     });
 
     assertLoaded(loadedPets);
@@ -552,6 +552,7 @@ describe("co.discriminatedUnion", () => {
     for (const pet of loadedPets) {
       if (pet.type === "dog") {
         expect(pet.friend.name).toEqual("John Doe");
+        expect(pet.friend.bird.species).toEqual("Parrot");
         // @ts-expect-error - no species on Person
         expect(pet.friend.species).toBeUndefined();
       } else if (pet.type === "cat") {


### PR DESCRIPTION
Fixes #2639

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds resolve/deep-loading support and default schema resolve queries for `co.discriminatedUnion`, with type/runtime updates to correctly load nested union members and docs/tests to match.
> 
> - **Core/Schemas**:
>   - Add `resolve` support to `co.discriminatedUnion` schemas (`load`/`subscribe` accept `resolve`).
>   - Introduce `.resolved(...)` on `CoDiscriminatedUnionSchema` to set default resolve queries; defaults to `true`.
> - **Types/Deep Loading**:
>   - Replace `IsUnion` and update `DeeplyLoaded`/`CoMapLikeLoaded` to distribute over unions for correct resolution and typing.
>   - Make resolve generic defaults `R = true` across `load`/`subscribe` helpers; adjust `Resolved<T,R>` alias.
>   - Allow resolve queries to include discriminated-union member keys; extra keys are ignored at runtime but excluded from types.
> - **Runtime/Loading**:
>   - `unionUtils`: discriminator now injects dummy fields for non-common nested refs to enable resolving member-specific refs.
>   - `SchemaUnion` now fully supports `resolve` in `load`/`subscribe`.
>   - `SubscriptionScope`: ignore non-schema keys when resolving (no error for missing descriptor); improves `$onError` handling paths.
>   - `CoList.upsertUnique`: apply diffs with resolved typing.
> - **Docs**:
>   - Update schema unions guide: remove note about missing resolve; clarify `$jazz.ensureLoaded`/`$jazz.subscribe` require prior narrowing.
> - **Tests**:
>   - Add extensive tests for resolving `co.discriminatedUnion` (load/subscribe, nested unions, lists, mixed member shapes, default schema `resolved`, cross-account, `$onError`).
>   - Adjust deep-loading tests to reflect new behaviors (extra resolve keys tolerated; non-existent refs don’t throw on ensure/load).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c0d203340a5aefbad23d0cfb1d742335c3c72b95. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->