### PR TITLE
feat: add `useCoValueRef` and similar hooks

### DIFF
--- a/.changeset/huge-cloths-smoke.md
+++ b/.changeset/huge-cloths-smoke.md
@@ -1,0 +1,6 @@
+---
+"jazz-tools": patch
+---
+
+Add `useCoValueRef`, `useAccountRef`, `useCoStateAndRef`, and `useAccountAndRef` hooks to allow access to the full CoValue in cases where the data is not needed for rendering.
+- Add `useRef` hook to `createCoValueSubscriptionContext` and `createAccountSubscriptionContext`

--- a/examples/music-player/src/3_HomePage.tsx
+++ b/examples/music-player/src/3_HomePage.tsx
@@ -1,4 +1,4 @@
-import { useCoState } from "jazz-tools/react";
+import { useCoStateAndRef } from "jazz-tools/react";
 import { useParams } from "react-router";
 import { PlaylistWithTracks } from "./1_schema";
 import { uploadMusicTracks } from "./4_actions";
@@ -37,9 +37,11 @@ export function HomePage({ mediaPlayer }: { mediaPlayer: MediaPlayer }) {
       (me.$isLoaded ? me.root.$jazz.refs.rootPlaylist.id : undefined),
   });
 
-  const playlist = useCoState(PlaylistWithTracks, playlistId, {
-    select: (playlist) => (playlist.$isLoaded ? playlist : undefined),
-  });
+  const [playlist, playlistRef] = useCoStateAndRef(
+    PlaylistWithTracks,
+    playlistId,
+    { select: (playlist) => (playlist.$isLoaded ? playlist : undefined) },
+  );
 
   const membersIds = playlist?.$jazz.owner.members.map((member) => member.id);
   const isRootPlaylist = !params.playlistId;
@@ -132,11 +134,12 @@ export function HomePage({ mediaPlayer }: { mediaPlayer: MediaPlayer }) {
       />
 
       {/* Members Management Modal */}
-      {playlist && (
+      {playlistRef.$isLoaded && playlist && (
         <MemberAccessModal
           isOpen={isMembersModalOpen}
           onOpenChange={setIsMembersModalOpen}
-          playlist={playlist}
+          playlistOwnerId={playlist.$jazz.owner.$jazz.id}
+          playlistRef={playlistRef}
         />
       )}
     </SidebarInset>

--- a/examples/music-player/src/5_useMediaPlayer.ts
+++ b/examples/music-player/src/5_useMediaPlayer.ts
@@ -15,8 +15,7 @@ export function useMediaPlayer() {
   const [loading, setLoading] = useState<string | null>(null);
 
   const activeTrackId = useAccountSelector({
-    select: (me) =>
-      me.$isLoaded ? me.root.$jazz.refs.activeTrack?.id : undefined,
+    select: (me) => me.root.$jazz.refs.activeTrack?.id,
   });
   // Reference used to avoid out-of-order track loads
   const lastLoadedTrackId = useRef<string | null>(null);

--- a/examples/music-player/src/components/AccountProvider.tsx
+++ b/examples/music-player/src/components/AccountProvider.tsx
@@ -1,17 +1,20 @@
 import { MusicaAccount, PlaylistWithTracks } from "@/1_schema.ts";
 import { createAccountSubscriptionContext } from "jazz-tools/react-core";
 
-export const { Provider: AccountProvider, useSelector: useAccountSelector } =
-  createAccountSubscriptionContext(MusicaAccount, {
-    root: {
-      rootPlaylist: PlaylistWithTracks.resolveQuery,
-      playlists: {
-        $each: {
-          $onError: "catch",
-        },
+export const {
+  Provider: AccountProvider,
+  useSelector: useAccountSelector,
+  useRef: useAccountRef,
+} = createAccountSubscriptionContext(MusicaAccount, {
+  root: {
+    rootPlaylist: PlaylistWithTracks.resolveQuery,
+    playlists: {
+      $each: {
+        $onError: "catch",
       },
-      activeTrack: { $onError: "catch" },
-      activePlaylist: { $onError: "catch" },
     },
-    profile: true,
-  });
+    activeTrack: { $onError: "catch" },
+    activePlaylist: { $onError: "catch" },
+  },
+  profile: true,
+});

--- a/examples/music-player/src/components/AuthModal.tsx
+++ b/examples/music-player/src/components/AuthModal.tsx
@@ -19,7 +19,7 @@ export function AuthModal({ open, onOpenChange }: AuthModalProps) {
   const [isSignUp, setIsSignUp] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const profileName = useAccountSelector({
-    select: (me) => (me.$isLoaded ? me.profile.name : undefined),
+    select: (me) => me.profile.name,
   });
 
   const auth = usePasskeyAuth({
@@ -59,7 +59,6 @@ export function AuthModal({ open, onOpenChange }: AuthModalProps) {
   const shouldShowTransferRootPlaylist = useAccountSelector({
     select: (me) =>
       !isSignUp &&
-      me.$isLoaded &&
       me.root.rootPlaylist.tracks.some((track) => !track.isExampleTrack),
   });
 

--- a/examples/music-player/src/components/EditPlaylistModal.tsx
+++ b/examples/music-player/src/components/EditPlaylistModal.tsx
@@ -1,6 +1,6 @@
 import { Playlist } from "@/1_schema";
 import { updatePlaylistTitle } from "@/4_actions";
-import { useCoState } from "jazz-tools/react";
+import { useCoStateAndRef } from "jazz-tools/react";
 import { ChangeEvent, useState, useEffect } from "react";
 import { Button } from "./ui/button";
 import { Input } from "./ui/input";
@@ -17,29 +17,31 @@ export function EditPlaylistModal({
   isOpen,
   onClose,
 }: EditPlaylistModalProps) {
-  const playlist = useCoState(Playlist, playlistId);
+  const [playlistTitle, playlistRef] = useCoStateAndRef(Playlist, playlistId, {
+    select: (playlist) => (playlist.$isLoaded ? playlist.title : undefined),
+  });
   const [localPlaylistTitle, setLocalPlaylistTitle] = useState("");
 
   // Reset local title when modal opens or playlist changes
   useEffect(() => {
-    if (isOpen && playlist.$isLoaded) {
-      setLocalPlaylistTitle(playlist.title);
+    if (isOpen && playlistTitle !== undefined) {
+      setLocalPlaylistTitle(playlistTitle);
     }
-  }, [isOpen, playlist]);
+  }, [isOpen, playlistTitle]);
 
   function handleTitleChange(evt: ChangeEvent<HTMLInputElement>) {
     setLocalPlaylistTitle(evt.target.value);
   }
 
   function handleSave() {
-    if (playlist.$isLoaded && localPlaylistTitle.trim()) {
-      updatePlaylistTitle(playlist, localPlaylistTitle.trim());
+    if (playlistRef.current.$isLoaded && localPlaylistTitle.trim()) {
+      updatePlaylistTitle(playlistRef.current, localPlaylistTitle.trim());
       onClose();
     }
   }
 
   function handleCancel() {
-    setLocalPlaylistTitle(playlist.$isLoaded ? playlist.title : "");
+    setLocalPlaylistTitle(playlistTitle ?? "");
     onClose();
   }
 

--- a/examples/music-player/src/components/MemberAccessModal.tsx
+++ b/examples/music-player/src/components/MemberAccessModal.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { useToast } from "@/hooks/use-toast";
 import { Account, Group } from "jazz-tools";
-import { useCoState, createInviteLink } from "jazz-tools/react";
+import { useCoState, createInviteLink, CoValueRef } from "jazz-tools/react";
 import {
   Dialog,
   DialogContent,
@@ -28,11 +28,12 @@ import { Member } from "./Member";
 interface MemberAccessModalProps {
   isOpen: boolean;
   onOpenChange: (open: boolean) => void;
-  playlist: Playlist;
+  playlistOwnerId: string;
+  playlistRef: CoValueRef<Playlist>;
 }
 
 export function MemberAccessModal(props: MemberAccessModalProps) {
-  const group = useCoState(Group, props.playlist.$jazz.owner.$jazz.id);
+  const group = useCoState(Group, props.playlistOwnerId);
   const [selectedRole, setSelectedRole] = useState<
     "reader" | "writer" | "manager"
   >("reader");
@@ -107,14 +108,17 @@ export function MemberAccessModal(props: MemberAccessModalProps) {
     return (
       isManager &&
       (member.$jazz.id === currentUser?.$jazz.id ||
-        !member.canAdmin(props.playlist))
+        !member.canAdmin(props.playlistRef.current))
     );
   };
 
   const handleGetInviteLink = async () => {
     if (!isManager) return;
 
-    const inviteLink = createInviteLink(props.playlist, selectedRole);
+    const inviteLink = createInviteLink(
+      props.playlistRef.current,
+      selectedRole,
+    );
     await navigator.clipboard.writeText(inviteLink);
 
     toast({

--- a/examples/music-player/src/components/MusicTrackTitleInput.tsx
+++ b/examples/music-player/src/components/MusicTrackTitleInput.tsx
@@ -1,6 +1,6 @@
 import { MusicTrack } from "@/1_schema";
 import { updateMusicTrackTitle } from "@/4_actions";
-import { useCoState } from "jazz-tools/react";
+import { useCoStateAndRef } from "jazz-tools/react";
 import { ChangeEvent, useState } from "react";
 
 export function MusicTrackTitleInput({
@@ -8,11 +8,11 @@ export function MusicTrackTitleInput({
 }: {
   trackId: string | undefined;
 }) {
-  const track = useCoState(MusicTrack, trackId);
+  const [trackTitle, trackRef] = useCoStateAndRef(MusicTrack, trackId, {
+    select: (track) => (track.$isLoaded ? track.title : ""),
+  });
   const [isEditing, setIsEditing] = useState(false);
   const [localTrackTitle, setLocalTrackTitle] = useState("");
-
-  const trackTitle = track.$isLoaded ? track.title : "";
 
   function handleTitleChange(evt: ChangeEvent<HTMLInputElement>) {
     setLocalTrackTitle(evt.target.value);
@@ -26,7 +26,9 @@ export function MusicTrackTitleInput({
   function handleFocusOut() {
     setIsEditing(false);
     setLocalTrackTitle("");
-    track.$isLoaded && updateMusicTrackTitle(track, localTrackTitle);
+    if (trackRef.current.$isLoaded) {
+      updateMusicTrackTitle(trackRef.current, localTrackTitle);
+    }
   }
 
   const inputValue = isEditing ? localTrackTitle : trackTitle;

--- a/examples/music-player/src/components/PlayerControls.tsx
+++ b/examples/music-player/src/components/PlayerControls.tsx
@@ -15,8 +15,8 @@ export function PlayerControls({ mediaPlayer }: { mediaPlayer: MediaPlayer }) {
 
   const activePlaylistTitle = useAccountSelector({
     select: (me) =>
-      me.$isLoaded && me.root.activePlaylist?.$isLoaded
-        ? (me.root.activePlaylist.title ?? "All tracks")
+      me.root.activePlaylist.$isLoaded
+        ? me.root.activePlaylist.title
         : "All tracks",
   });
 

--- a/examples/music-player/src/components/PlaylistTitleInput.tsx
+++ b/examples/music-player/src/components/PlaylistTitleInput.tsx
@@ -1,7 +1,7 @@
 import { Playlist } from "@/1_schema";
 import { updatePlaylistTitle } from "@/4_actions";
 import { cn } from "@/lib/utils";
-import { useCoState } from "jazz-tools/react";
+import { useCoStateAndRef } from "jazz-tools/react";
 import { ChangeEvent, useState } from "react";
 
 export function PlaylistTitleInput({
@@ -11,15 +11,15 @@ export function PlaylistTitleInput({
   playlistId: string | undefined;
   className?: string;
 }) {
-  const playlist = useCoState(Playlist, playlistId);
+  const [playlistTitle, playlistRef] = useCoStateAndRef(Playlist, playlistId, {
+    select: (playlist) => (playlist.$isLoaded ? playlist.title : ""),
+  });
   const [isEditing, setIsEditing] = useState(false);
   const [localPlaylistTitle, setLocalPlaylistTitle] = useState("");
 
   function handleTitleChange(evt: ChangeEvent<HTMLInputElement>) {
     setLocalPlaylistTitle(evt.target.value);
   }
-
-  const playlistTitle = playlist.$isLoaded ? playlist.title : "";
 
   function handleFoucsIn() {
     setIsEditing(true);
@@ -29,7 +29,9 @@ export function PlaylistTitleInput({
   function handleFocusOut() {
     setIsEditing(false);
     setLocalPlaylistTitle("");
-    playlist.$isLoaded && updatePlaylistTitle(playlist, localPlaylistTitle);
+    if (playlistRef.current.$isLoaded) {
+      updatePlaylistTitle(playlistRef.current, localPlaylistTitle);
+    }
   }
 
   const inputValue = isEditing ? localPlaylistTitle : playlistTitle;

--- a/examples/music-player/src/components/RenameTrackDialog.tsx
+++ b/examples/music-player/src/components/RenameTrackDialog.tsx
@@ -12,32 +12,35 @@ import {
 import { Input } from "@/components/ui/input";
 import { useState } from "react";
 import { ConfirmDialog } from "./ConfirmDialog";
+import { CoValueRef } from "jazz-tools/react";
 
 interface EditTrackDialogProps {
-  track: MusicTrack;
+  trackTitle: string;
+  trackRef: CoValueRef<MusicTrack>;
   isOpen: boolean;
   onOpenChange: (open: boolean) => void;
   onDelete: () => void;
 }
 
 export function EditTrackDialog({
-  track,
+  trackTitle,
+  trackRef,
   isOpen,
   onOpenChange,
   onDelete,
 }: EditTrackDialogProps) {
-  const [newTitle, setNewTitle] = useState(track.title);
+  const [newTitle, setNewTitle] = useState(trackTitle);
   const [isDeleteConfirmOpen, setIsDeleteConfirmOpen] = useState(false);
 
   function handleSave() {
-    if (track && newTitle.trim()) {
-      updateMusicTrackTitle(track, newTitle.trim());
+    if (newTitle.trim()) {
+      updateMusicTrackTitle(trackRef.current, newTitle.trim());
       onOpenChange(false);
     }
   }
 
   function handleCancel() {
-    setNewTitle(track?.title || "");
+    setNewTitle(trackTitle);
     onOpenChange(false);
   }
 
@@ -63,7 +66,7 @@ export function EditTrackDialog({
       <DialogContent>
         <DialogHeader>
           <DialogTitle>Edit Track</DialogTitle>
-          <DialogDescription>Edit "{track?.title}".</DialogDescription>
+          <DialogDescription>Edit "{trackTitle}".</DialogDescription>
         </DialogHeader>
         <form className="py-4" onSubmit={handleSave}>
           <Input
@@ -96,7 +99,7 @@ export function EditTrackDialog({
         isOpen={isDeleteConfirmOpen}
         onOpenChange={setIsDeleteConfirmOpen}
         title="Delete Track"
-        description={`Are you sure you want to delete "${track.title}"? This action cannot be undone.`}
+        description={`Are you sure you want to delete "${trackTitle}"? This action cannot be undone.`}
         confirmText="Delete"
         cancelText="Cancel"
         onConfirm={handleDeleteConfirm}

--- a/examples/music-player/src/components/SidePanel.tsx
+++ b/examples/music-player/src/components/SidePanel.tsx
@@ -1,4 +1,3 @@
-import { MusicaAccount } from "@/1_schema";
 import { deletePlaylist } from "@/4_actions";
 import {
   Sidebar,
@@ -12,19 +11,18 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
 } from "@/components/ui/sidebar";
-import { useAccount } from "jazz-tools/react";
 import { Home, Music, Plus, Trash2 } from "lucide-react";
 import { useNavigate, useParams } from "react-router";
 import { useState } from "react";
 import { AuthButton } from "./AuthButton";
 import { CreatePlaylistModal } from "./CreatePlaylistModal";
+import { useAccountSelector } from "@/components/AccountProvider.tsx";
 
 export function SidePanel() {
   const { playlistId } = useParams();
   const navigate = useNavigate();
-  const playlists = useAccount(MusicaAccount, {
-    resolve: { root: { playlists: { $each: { $onError: "catch" } } } },
-    select: (me) => (me.$isLoaded ? me.root.playlists : undefined),
+  const playlists = useAccountSelector({
+    select: (me) => me.root.playlists,
   });
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
 

--- a/examples/music-player/src/components/WelcomeScreen.tsx
+++ b/examples/music-player/src/components/WelcomeScreen.tsx
@@ -1,31 +1,20 @@
 import { usePasskeyAuth } from "jazz-tools/react";
 import { ProfileForm } from "./ProfileForm";
 import { Button } from "./ui/button";
-import { useAccountSelector } from "@/components/AccountProvider.tsx";
+import {
+  useAccountSelector,
+  useAccountRef,
+} from "@/components/AccountProvider.tsx";
 
 export function WelcomeScreen() {
   const auth = usePasskeyAuth({
     appName: "Jazz Music Player",
   });
 
-  const { handleCompleteSetup } = useAccountSelector({
-    select: (me) =>
-      me.$isLoaded
-        ? {
-            id: me.root.$jazz.id,
-            handleCompleteSetup: () => {
-              me.root.$jazz.set("accountSetupCompleted", true);
-            },
-          }
-        : { id: null, handleCompleteSetup: null },
-    equalityFn: (a, b) => a.id === b.id,
-  });
-
+  const meRef = useAccountRef();
   const initialUsername = useAccountSelector({
-    select: (me) => (me.$isLoaded ? me.profile.name : undefined),
+    select: (me) => me.profile.name,
   });
-
-  if (!handleCompleteSetup) return null;
 
   const handleLogin = () => {
     auth.logIn();
@@ -37,7 +26,9 @@ export function WelcomeScreen() {
         {/* Form Panel */}
         <div className="w-full max-w-md bg-white rounded-lg shadow-xl p-8">
           <ProfileForm
-            onSubmit={handleCompleteSetup}
+            onSubmit={() => {
+              meRef.current.root.$jazz.set("accountSetupCompleted", true);
+            }}
             submitButtonText="Continue"
             showHeader={true}
             headerTitle="Welcome to Music Player! 🎵"

--- a/examples/music-player/src/lib/utils.ts
+++ b/examples/music-player/src/lib/utils.ts
@@ -4,3 +4,47 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+export function shallowEqual<T>(a: T, b: T) {
+  if (Object.is(a, b)) {
+    return true;
+  }
+
+  if (
+    typeof a !== "object" ||
+    typeof b !== "object" ||
+    a === null ||
+    b === null
+  ) {
+    return false;
+  }
+
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) {
+      return false;
+    }
+
+    for (let i = 0; i < a.length; i++) {
+      if (!Object.is(a[i], b[i])) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  const keysA = Object.keys(a);
+  const keysB = Object.keys(b);
+
+  if (keysA.length !== keysB.length) {
+    return false;
+  }
+
+  for (const key of keysA) {
+    if (!(key in b) || !Object.is((a as any)[key], (b as any)[key])) {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/packages/jazz-tools/src/react-core/hooks.ts
+++ b/packages/jazz-tools/src/react-core/hooks.ts
@@ -208,6 +208,10 @@ function useGetCurrentValue<C extends CoValue>(
   }, [subscription]);
 }
 
+function identitySelector(value: any) {
+  return value;
+}
+
 /**
  * React hook for subscribing to CoValues and handling loading states.
  *
@@ -420,7 +424,7 @@ export function useCoState<
     ),
     getCurrentValue,
     getCurrentValue,
-    options?.select ?? ((value) => value as TSelectorReturn),
+    options?.select ?? identitySelector,
     options?.equalityFn ?? Object.is,
   );
 
@@ -457,7 +461,7 @@ export function useSubscriptionSelector<
     ),
     getCurrentValue,
     getCurrentValue,
-    options?.select ?? ((value) => value as TSelectorReturn),
+    options?.select ?? identitySelector,
     options?.equalityFn ?? Object.is,
   );
 }
@@ -678,7 +682,7 @@ export function useAccount<
     ),
     getCurrentValue,
     getCurrentValue,
-    options?.select ?? ((value) => value as TSelectorReturn),
+    options?.select ?? identitySelector,
     options?.equalityFn ?? Object.is,
   );
 }

--- a/packages/jazz-tools/src/react-core/subscription-provider.tsx
+++ b/packages/jazz-tools/src/react-core/subscription-provider.tsx
@@ -13,73 +13,210 @@ import {
 import {
   useAccountSubscription,
   useCoValueSubscription,
+  useSubscriptionRef,
   useSubscriptionSelector,
 } from "./hooks.js";
-import type { CoValueSubscription } from "./types.js";
+import type {
+  CoValueSubscription,
+  CoValueRef,
+  UseSubscriptionOptions,
+} from "./types.js";
+import { NotLoadedCoValueState } from "../tools/subscribe/types.js";
+
+interface FallbackProps {
+  loadingFallback?: React.ReactNode | (() => React.ReactNode);
+  unavailableFallback?:
+    | React.ReactNode
+    | ((props: {
+        loadingState: Exclude<
+          NotLoadedCoValueState,
+          CoValueLoadingState.LOADING
+        >;
+      }) => React.ReactNode);
+}
+
+const UninitializedContextSymbol = Symbol("UninitializedContext");
+
+/**
+ * We provide `ref` through a context instead of calling `useSubscriptionRef` repeatedly time for
+ * every single consumer since the returned `ref` will always be the same, thus reducing the number
+ * of subscribers.
+ */
+function RefProvider({
+  RefContext,
+  subscription,
+  children,
+}: {
+  RefContext: React.Context<CoValueRef<any>>;
+  subscription: CoValueSubscription<any, any>;
+  children?: React.ReactNode | undefined;
+}) {
+  const ref = useSubscriptionRef(subscription);
+
+  return <RefContext.Provider value={ref}>{children}</RefContext.Provider>;
+}
+
+function InternalProvider<
+  S extends CoValueClassOrSchema,
+  const R extends ResolveQuery<S> = true,
+>({
+  Context,
+  RefContext,
+  subscription,
+  passthroughNotLoaded,
+  loadingFallback,
+  unavailableFallback,
+  children,
+}: {
+  Context: React.Context<
+    CoValueSubscription<S, R> | typeof UninitializedContextSymbol
+  >;
+  RefContext: React.Context<any>;
+  subscription: CoValueSubscription<S, R>;
+  children?: React.ReactNode | undefined;
+  passthroughNotLoaded?: boolean;
+} & FallbackProps) {
+  const loadingState = useSubscriptionSelector(subscription, {
+    select: (value) => (passthroughNotLoaded ? null : value.$jazz.loadingState),
+  });
+
+  if (loadingState === CoValueLoadingState.LOADING) {
+    const LoadingFallback = loadingFallback;
+
+    if (typeof LoadingFallback === "function") {
+      return <LoadingFallback />;
+    }
+
+    return LoadingFallback ?? null;
+  }
+
+  if (
+    loadingState === CoValueLoadingState.UNAUTHORIZED ||
+    loadingState === CoValueLoadingState.UNAVAILABLE
+  ) {
+    const UnavailableFallback = unavailableFallback;
+
+    if (typeof UnavailableFallback === "function") {
+      return <UnavailableFallback loadingState={loadingState} />;
+    }
+
+    return UnavailableFallback ?? null;
+  }
+
+  return (
+    <Context.Provider value={subscription}>
+      <RefProvider RefContext={RefContext} subscription={subscription}>
+        {children}
+      </RefProvider>
+    </Context.Provider>
+  );
+}
+
+interface AccountSubscriptionContext<
+  S extends CoValueClassOrSchema,
+  R extends ResolveQuery<S> = true,
+  P extends boolean = false,
+  T = P extends true ? MaybeLoaded<Loaded<S, R>> : Loaded<S, R>,
+> {
+  Provider: React.FC<
+    {
+      options?: Omit<UseSubscriptionOptions<S, R>, "resolve">;
+      children?: React.ReactNode | undefined;
+    } & (P extends false ? FallbackProps : unknown)
+  >;
+  useSelector: <TSelectorReturn = T>(options?: {
+    select?: (value: T) => TSelectorReturn;
+    equalityFn?: (a: TSelectorReturn, b: TSelectorReturn) => boolean;
+  }) => TSelectorReturn;
+  useRef: () => CoValueRef<T>;
+}
+
+interface CoValueSubscriptionContext<
+  S extends CoValueClassOrSchema,
+  R extends ResolveQuery<S> = true,
+  P extends boolean = false,
+  T = P extends true ? MaybeLoaded<Loaded<S, R>> : Loaded<S, R>,
+> extends Omit<AccountSubscriptionContext<S, R, P, T>, "Provider"> {
+  Provider: React.FC<
+    {
+      id: string | undefined | null;
+      options?: Omit<UseSubscriptionOptions<S, R>, "resolve">;
+      children?: React.ReactNode | undefined;
+    } & (P extends false ? FallbackProps : unknown)
+  >;
+}
+
+interface ContextOptions<P extends boolean = false> {
+  /**
+   * If `false` (default behavior), the provider will render fallback components or `null` instead of its children
+   * until the CoValue is loaded. In this case, the `useSelector` and `useRef` hooks will be guaranteed to return a
+   * loaded value, and there would be no need to assert the value of `$isLoaded`.
+   *
+   * If `true`, the provider will always render its children even if the CoValue is not loaded, and you must handle
+   * loading states in `useSelector` and `useRef` hooks return values.
+   * This is useful for creating providers for optional CoValues.
+   */
+  passthroughNotLoaded?: P;
+}
 
 export function createCoValueSubscriptionContext<
   S extends CoValueClassOrSchema,
   const R extends ResolveQuery<S> = true,
->(schema: S, resolve?: ResolveQueryStrict<S, R>) {
-  const Context = React.createContext<CoValueSubscription<S, R>>(null);
+  const P extends boolean = false,
+  T = P extends true ? MaybeLoaded<Loaded<S, R>> : Loaded<S, R>,
+>(
+  /** The CoValue schema or class constructor */
+  schema: S,
+  /** Resolve query to specify which nested CoValues to load from the CoValue */
+  resolve?: ResolveQueryStrict<S, R>,
+  /** Optional behavior customization */
+  contextOptions?: {
+    passthroughNotLoaded?: P;
+  },
+): CoValueSubscriptionContext<S, R, P, T> {
+  const Context = React.createContext<
+    CoValueSubscription<S, R> | typeof UninitializedContextSymbol
+  >(UninitializedContextSymbol);
+  const RefContext = React.createContext<CoValueRef<T> | undefined>(undefined);
 
   return {
-    Provider: ({
-      id,
-      options,
-      loadingFallback,
-      unavailableFallback,
-      children,
-    }: React.PropsWithChildren<{
-      id: string | undefined | null;
-      options?: Omit<
-        Parameters<typeof useCoValueSubscription<S, R>>[2],
-        "resolve"
-      >;
-      loadingFallback?: React.ReactNode;
-      unavailableFallback?: React.ReactNode;
-    }>) => {
+    Provider: ({ id, options, ...props }) => {
       const subscription = useCoValueSubscription(schema, id, {
         ...options,
-        resolve: resolve,
+        resolve,
       });
-
-      const loadState = useSubscriptionSelector(subscription, {
-        select: (value) => value.$jazz.loadingState,
-      });
-
-      if (loadState === CoValueLoadingState.LOADING) {
-        return loadingFallback ?? null;
-      }
-      if (
-        loadState === CoValueLoadingState.UNAUTHORIZED ||
-        loadState === CoValueLoadingState.UNAVAILABLE
-      ) {
-        return unavailableFallback ?? null;
-      }
 
       return (
-        <Context.Provider value={subscription}>{children}</Context.Provider>
+        <InternalProvider
+          Context={Context}
+          RefContext={RefContext}
+          passthroughNotLoaded={contextOptions?.passthroughNotLoaded}
+          subscription={subscription}
+          {...props}
+        />
       );
     },
-    useSelector: <TSelectorReturn = Loaded<S, R>>(options?: {
-      select?: (value: Loaded<S, R>) => TSelectorReturn;
-      equalityFn?: (a: TSelectorReturn, b: TSelectorReturn) => boolean;
-    }) => {
+    useSelector: (options) => {
       const subscription = React.useContext(Context);
 
-      if (!subscription) {
+      if (subscription === UninitializedContextSymbol) {
         throw new Error(
-          "useSelector must be used within a coValue subscription provider",
+          "useSelector must be used within a CoValue subscription Provider",
         );
       }
 
-      return useSubscriptionSelector<S, R, TSelectorReturn>(
-        subscription,
-        options as Parameters<
-          typeof useSubscriptionSelector<S, R, TSelectorReturn>
-        >[1],
-      );
+      return useSubscriptionSelector(subscription, options as any);
+    },
+    useRef: () => {
+      const subscription = React.useContext(Context);
+
+      if (subscription === UninitializedContextSymbol) {
+        throw new Error(
+          "useRef must be used within a CoValue subscription Provider",
+        );
+      }
+
+      return React.useContext(RefContext) as CoValueRef<T>;
     },
   };
 }
@@ -87,65 +224,59 @@ export function createCoValueSubscriptionContext<
 export function createAccountSubscriptionContext<
   A extends AccountClass<Account> | AnyAccountSchema,
   const R extends ResolveQuery<A> = true,
->(schema: A, resolve?: ResolveQueryStrict<A, R>) {
-  const Context = React.createContext<CoValueSubscription<A, R>>(null);
+  const P extends boolean = false,
+  T = P extends true ? MaybeLoaded<Loaded<A, R>> : Loaded<A, R>,
+>(
+  /** The account schema to use. Defaults to the base Account schema */
+  schema: A = Account as unknown as A,
+  /** Resolve query to specify which nested CoValues to load from the account */
+  resolve?: ResolveQueryStrict<A, R>,
+  /** Optional behavior customization */
+  contextOptions?: ContextOptions<P>,
+): AccountSubscriptionContext<A, R, P, T> {
+  const Context = React.createContext<
+    CoValueSubscription<A, R> | typeof UninitializedContextSymbol
+  >(UninitializedContextSymbol);
+  const RefContext = React.createContext<CoValueRef<T> | undefined>(undefined);
 
   return {
-    Provider: ({
-      options,
-      loadingFallback,
-      unavailableFallback,
-      children,
-    }: React.PropsWithChildren<{
-      options?: Omit<
-        Parameters<typeof useAccountSubscription<A, R>>[1],
-        "resolve"
-      >;
-      loadingFallback?: React.ReactNode;
-      unavailableFallback?: React.ReactNode;
-    }>) => {
+    Provider: ({ options, ...props }) => {
       const subscription = useAccountSubscription(schema, {
         ...options,
-        resolve: resolve,
+        resolve,
       });
-
-      const loadState = useSubscriptionSelector(subscription, {
-        select: (value) => value.$jazz.loadingState,
-      });
-
-      if (loadState === CoValueLoadingState.LOADING) {
-        return loadingFallback ?? null;
-      }
-
-      if (
-        loadState === CoValueLoadingState.UNAUTHORIZED ||
-        loadState === CoValueLoadingState.UNAVAILABLE
-      ) {
-        return unavailableFallback ?? null;
-      }
 
       return (
-        <Context.Provider value={subscription}>{children}</Context.Provider>
+        <InternalProvider
+          Context={Context}
+          RefContext={RefContext}
+          passthroughNotLoaded={contextOptions?.passthroughNotLoaded}
+          subscription={subscription}
+          {...props}
+        />
       );
     },
-    useSelector: <TSelectorReturn = Loaded<A, R>>(options?: {
-      select?: (value: Loaded<A, R>) => TSelectorReturn;
-      equalityFn?: (a: TSelectorReturn, b: TSelectorReturn) => boolean;
-    }) => {
+    useSelector: (options) => {
       const subscription = React.useContext(Context);
 
-      if (!subscription) {
+      if (subscription === UninitializedContextSymbol) {
         throw new Error(
-          "useSelector must be used within an account subscription provider",
+          "useSelector must be used within an account subscription Provider",
         );
       }
 
-      return useSubscriptionSelector<A, R, TSelectorReturn>(
-        subscription,
-        options as Parameters<
-          typeof useSubscriptionSelector<A, R, TSelectorReturn>
-        >[1],
-      );
+      return useSubscriptionSelector(subscription, options as any);
+    },
+    useRef: () => {
+      const subscription = React.useContext(Context);
+
+      if (subscription === UninitializedContextSymbol) {
+        throw new Error(
+          "useRef must be used within an account subscription Provider",
+        );
+      }
+
+      return React.useContext(RefContext) as CoValueRef<T>;
     },
   };
 }

--- a/packages/jazz-tools/src/react-core/tests/createAccountSubscriptionContext.test.tsx
+++ b/packages/jazz-tools/src/react-core/tests/createAccountSubscriptionContext.test.tsx
@@ -1,0 +1,471 @@
+// @vitest-environment happy-dom
+
+import { cojsonInternals } from "cojson";
+import { co, z, CoValueLoadingState, Account } from "jazz-tools";
+import { beforeEach, describe, expect, it } from "vitest";
+import { createAccountSubscriptionContext } from "../index.js";
+import {
+  createJazzTestAccount,
+  JazzTestProvider,
+  setupJazzTestSync,
+  createJazzTestGuest,
+} from "../testing.js";
+import { act, render, renderHook, useRenderCount } from "./testUtils.js";
+
+beforeEach(async () => {
+  await setupJazzTestSync();
+
+  await createJazzTestAccount({
+    isCurrentActiveAccount: true,
+  });
+});
+
+cojsonInternals.setCoValueLoadingRetryDelay(300);
+
+describe("createAccountSubscriptionContext", () => {
+  describe("useSelector", () => {
+    it("creates a custom provider and selector hook for a coValue schema", async () => {
+      const account = await createJazzTestAccount();
+
+      const { Provider, useSelector } = createAccountSubscriptionContext();
+
+      const { result } = renderHook(
+        () => {
+          return useSelector({
+            select: (account) => account.$jazz.id,
+          });
+        },
+        {
+          wrapper: ({ children }) => (
+            <JazzTestProvider account={account} isAuthenticated>
+              <Provider>{children}</Provider>
+            </JazzTestProvider>
+          ),
+        },
+      );
+
+      expect(result.current).toBe(account.$jazz.id);
+    });
+
+    it("the selector hook updates when account deeply loaded values change", async () => {
+      const AccountRoot = co.map({
+        value: z.string(),
+      });
+
+      const AccountSchema = co
+        .account({
+          root: AccountRoot,
+          profile: co.profile(),
+        })
+        .withMigration((account) => {
+          if (!account.$jazz.refs.root) {
+            account.$jazz.set("root", { value: "123" });
+          }
+        });
+
+      const account = await createJazzTestAccount({
+        AccountSchema,
+      });
+
+      const { Provider, useSelector } = createAccountSubscriptionContext(
+        AccountSchema,
+        {
+          root: true,
+        },
+      );
+
+      const { result } = renderHook(
+        () => {
+          return useSelector({
+            select: (account) => account.root.value,
+          });
+        },
+        {
+          wrapper: ({ children }) => (
+            <JazzTestProvider account={account} isAuthenticated>
+              <Provider>{children}</Provider>
+            </JazzTestProvider>
+          ),
+        },
+      );
+
+      expect(result.current).toBe("123");
+
+      act(() => {
+        account.root.$jazz.set("value", "456");
+      });
+
+      expect(result.current).toBe("456");
+    });
+
+    it("should not render children when not authenticated", async () => {
+      const guest = await createJazzTestGuest();
+
+      const { Provider } = createAccountSubscriptionContext();
+
+      const { result } = renderHook(
+        () => {
+          return "hello";
+        },
+        {
+          wrapper: ({ children }) => (
+            <JazzTestProvider account={guest}>
+              <Provider unavailableFallback={<div>Unavailable</div>}>
+                {children}
+              </Provider>
+            </JazzTestProvider>
+          ),
+        },
+      );
+
+      expect(result.current).toBe(null);
+    });
+
+    it("should render unavailable fallback when not authenticated", async () => {
+      const guest = await createJazzTestGuest();
+
+      const { Provider } = createAccountSubscriptionContext();
+
+      const { container } = render(
+        <Provider unavailableFallback={<div>Unavailable</div>}>
+          <div>Children should not render</div>
+        </Provider>,
+        {
+          account: guest,
+        },
+      );
+
+      expect(container.textContent).toContain("Unavailable");
+      expect(container.textContent).not.toContain("Children should not render");
+    });
+
+    it("should throw error when useSelector is used outside provider", () => {
+      const { useSelector } = createAccountSubscriptionContext();
+
+      expect(() => {
+        renderHook(() => {
+          return useSelector();
+        });
+      }).toThrow(
+        "useSelector must be used within an account subscription Provider",
+      );
+    });
+
+    describe("with passthroughNotLoaded = true", () => {
+      it("should return the loaded CoValue when available", async () => {
+        const AccountRoot = co.map({
+          value: z.string(),
+        });
+
+        const AccountSchema = co
+          .account({
+            root: AccountRoot,
+            profile: co.profile(),
+          })
+          .withMigration((account) => {
+            if (!account.$jazz.refs.root) {
+              account.$jazz.set("root", { value: "123" });
+            }
+          });
+
+        const account = await createJazzTestAccount({
+          AccountSchema,
+        });
+
+        const { Provider, useSelector } = createAccountSubscriptionContext(
+          AccountSchema,
+          { root: true },
+          { passthroughNotLoaded: true },
+        );
+
+        const { result } = renderHook(
+          () => {
+            return useSelector({
+              select: (account) =>
+                account.$isLoaded ? account.root.value : undefined,
+            });
+          },
+          {
+            wrapper: ({ children }) => (
+              <JazzTestProvider account={account} isAuthenticated>
+                <Provider>{children}</Provider>
+              </JazzTestProvider>
+            ),
+          },
+        );
+
+        expect(result.current).toBe("123");
+      });
+
+      it("should return unavailable state when not authenticated", async () => {
+        const guest = await createJazzTestGuest();
+
+        const { Provider, useSelector } = createAccountSubscriptionContext(
+          Account,
+          true,
+          { passthroughNotLoaded: true },
+        );
+
+        const { result } = renderHook(
+          () => {
+            return useSelector({
+              select: (account) => account.$jazz.loadingState,
+            });
+          },
+          {
+            wrapper: ({ children }) => (
+              <JazzTestProvider account={guest}>
+                <Provider>{children}</Provider>
+              </JazzTestProvider>
+            ),
+          },
+        );
+
+        expect(result.current).toBe(CoValueLoadingState.UNAVAILABLE);
+      });
+    });
+  });
+
+  describe("useRef", () => {
+    it("should return a ref with the correct account", async () => {
+      const account = await createJazzTestAccount();
+
+      const { Provider, useRef } = createAccountSubscriptionContext();
+
+      const { result } = renderHook(
+        () => {
+          return useRef();
+        },
+        {
+          wrapper: ({ children }) => (
+            <JazzTestProvider account={account} isAuthenticated>
+              <Provider>{children}</Provider>
+            </JazzTestProvider>
+          ),
+        },
+      );
+
+      expect(result.current.current.$jazz.id).toBe(account.$jazz.id);
+    });
+
+    it("should update ref when account data changes", async () => {
+      const AccountRoot = co.map({
+        value: z.string(),
+      });
+
+      const AccountSchema = co
+        .account({
+          root: AccountRoot,
+          profile: co.profile(),
+        })
+        .withMigration((account) => {
+          if (!account.$jazz.refs.root) {
+            account.$jazz.set("root", { value: "123" });
+          }
+        });
+
+      const account = await createJazzTestAccount({
+        AccountSchema,
+      });
+
+      const { Provider, useRef } = createAccountSubscriptionContext(
+        AccountSchema,
+        {
+          root: true,
+        },
+      );
+
+      const { result } = renderHook(
+        () => {
+          return useRef();
+        },
+        {
+          wrapper: ({ children }) => (
+            <JazzTestProvider account={account} isAuthenticated>
+              <Provider>{children}</Provider>
+            </JazzTestProvider>
+          ),
+        },
+      );
+
+      expect(result.current.current.root.value).toBe("123");
+
+      // not running through act since updating a ref is not tied to the rendering pipeline
+      account.root.$jazz.set("value", "456");
+
+      expect(result.current.current.root.value).toBe("456");
+    });
+
+    it("should contain latest value when non-selected value changes", async () => {
+      const AccountRoot = co.map({
+        name: z.string(),
+        count: z.number(),
+      });
+
+      const AccountSchema = co
+        .account({
+          root: AccountRoot,
+          profile: co.profile(),
+        })
+        .withMigration((account) => {
+          if (!account.$jazz.refs.root) {
+            account.$jazz.set("root", { name: "stable", count: 0 });
+          }
+        });
+
+      const account = await createJazzTestAccount({
+        AccountSchema,
+      });
+
+      const { Provider, useSelector, useRef } =
+        createAccountSubscriptionContext(AccountSchema, {
+          root: true,
+        });
+
+      const { result } = renderHook(
+        () =>
+          useRenderCount(() => {
+            useSelector({
+              select: (acc) => acc.root.name,
+            });
+
+            return useRef();
+          }),
+        {
+          wrapper: ({ children }) => (
+            <JazzTestProvider account={account} isAuthenticated>
+              <Provider>{children}</Provider>
+            </JazzTestProvider>
+          ),
+        },
+      );
+
+      expect(result.current.result.current.root.count).toBe(0);
+
+      act(() => {
+        account.root.$jazz.set("count", 42);
+      });
+
+      expect(result.current.result.current.root.count).toBe(42);
+
+      // Should still only have rendered once
+      expect(result.current.renderCount).toBe(1);
+    });
+
+    it("should not re-render when editing non-selected value through ref", async () => {
+      const AccountRoot = co.map({
+        name: z.string(),
+        count: z.number(),
+      });
+
+      const AccountSchema = co
+        .account({
+          root: AccountRoot,
+          profile: co.profile(),
+        })
+        .withMigration((account) => {
+          if (!account.$jazz.refs.root) {
+            account.$jazz.set("root", { name: "User", count: 0 });
+          }
+        });
+
+      const account = await createJazzTestAccount({
+        AccountSchema,
+      });
+
+      const { Provider, useRef, useSelector } =
+        createAccountSubscriptionContext(AccountSchema, {
+          root: true,
+        });
+
+      const { result } = renderHook(
+        () =>
+          useRenderCount(() => {
+            return {
+              state: useSelector({
+                select: (acc) => acc.root.name,
+              }),
+              ref: useRef(),
+            };
+          }),
+        {
+          wrapper: ({ children }) => (
+            <JazzTestProvider account={account} isAuthenticated>
+              <Provider>{children}</Provider>
+            </JazzTestProvider>
+          ),
+        },
+      );
+
+      expect(result.current.result.ref.current.root.name).toBe("User");
+      expect(result.current.result.ref.current.root.count).toBe(0);
+      expect(result.current.renderCount).toBe(1);
+
+      // Edit through the ref
+      act(() => {
+        result.current.result.ref.current.root.$jazz.set("count", 42);
+      });
+
+      expect(result.current.result.ref.current.root.count).toBe(42);
+
+      // Should still only have rendered once
+      expect(result.current.renderCount).toBe(1);
+    });
+
+    it("should re-render when editing selected value through ref", async () => {
+      const account = await createJazzTestAccount({
+        creationProps: {
+          name: "Earl",
+        },
+      });
+
+      const { Provider, useRef, useSelector } =
+        createAccountSubscriptionContext(Account, {
+          profile: true,
+        });
+
+      const { result } = renderHook(
+        () =>
+          useRenderCount(() => {
+            return {
+              state: useSelector({
+                select: (acc) => acc.profile.name,
+              }),
+              ref: useRef(),
+            };
+          }),
+        {
+          wrapper: ({ children }) => (
+            <JazzTestProvider account={account} isAuthenticated>
+              <Provider>{children}</Provider>
+            </JazzTestProvider>
+          ),
+        },
+      );
+
+      expect(result.current.result.ref.current.profile.name).toBe("Earl");
+      expect(result.current.renderCount).toBe(1);
+
+      // Edit through the ref
+      act(() => {
+        result.current.result.ref.current.profile.$jazz.set("name", "Bob");
+      });
+
+      expect(result.current.result.ref.current.profile.name).toBe("Bob");
+      expect(result.current.result.state).toBe("Bob");
+
+      // should render one more time for the changed name
+      expect(result.current.renderCount).toBe(2);
+    });
+
+    it("should throw error when useRef is used outside provider", () => {
+      const { useRef } = createAccountSubscriptionContext();
+
+      expect(() => {
+        renderHook(() => {
+          return useRef();
+        });
+      }).toThrow("useRef must be used within an account subscription Provider");
+    });
+  });
+});

--- a/packages/jazz-tools/src/react-core/tests/createCoValueSubscriptionContext.test.tsx
+++ b/packages/jazz-tools/src/react-core/tests/createCoValueSubscriptionContext.test.tsx
@@ -3,7 +3,6 @@
 import { cojsonInternals } from "cojson";
 import { co, z, CoValueLoadingState } from "jazz-tools";
 import { assertLoaded } from "jazz-tools/testing";
-import { useRef } from "react";
 import { beforeEach, describe, expect, it } from "vitest";
 import { createCoValueSubscriptionContext } from "../index.js";
 import {
@@ -11,7 +10,13 @@ import {
   JazzTestProvider,
   setupJazzTestSync,
 } from "../testing.js";
-import { act, render, renderHook, waitFor } from "./testUtils.js";
+import {
+  act,
+  render,
+  renderHook,
+  useRenderCount,
+  waitFor,
+} from "./testUtils.js";
 
 beforeEach(async () => {
   await setupJazzTestSync();
@@ -23,211 +28,655 @@ beforeEach(async () => {
 
 cojsonInternals.setCoValueLoadingRetryDelay(300);
 
-const useRenderCount = <T,>(hook: () => T) => {
-  const renderCountRef = useRef(0);
-  const result = hook();
-  renderCountRef.current = renderCountRef.current + 1;
-  return {
-    renderCount: renderCountRef.current,
-    result,
-  };
-};
-
 describe("createCoValueSubscriptionContext", () => {
-  it("creates a custom provider and selector hook for a coValue schema", () => {
-    const TestMap = co.map({
-      value: z.string(),
+  describe("useSelector", () => {
+    it("creates a custom provider and selector hook for a coValue schema", () => {
+      const TestMap = co.map({
+        value: z.string(),
+      });
+
+      const map = TestMap.create({
+        value: "123",
+      });
+
+      const { Provider, useSelector } =
+        createCoValueSubscriptionContext(TestMap);
+
+      const { result } = renderHook(
+        () => {
+          return useSelector();
+        },
+        {
+          wrapper: ({ children }) => (
+            <JazzTestProvider>
+              <Provider id={map.$jazz.id}>{children}</Provider>
+            </JazzTestProvider>
+          ),
+        },
+      );
+
+      expect(result.current.value).toBe("123");
     });
 
-    const map = TestMap.create({
-      value: "123",
+    it("the selector hook updates when the coValue changes", () => {
+      const TestMap = co.map({
+        value: z.string(),
+      });
+
+      const map = TestMap.create({
+        value: "123",
+      });
+
+      const { Provider, useSelector } =
+        createCoValueSubscriptionContext(TestMap);
+
+      const { result } = renderHook(
+        () => {
+          return useSelector();
+        },
+        {
+          wrapper: ({ children }) => (
+            <JazzTestProvider>
+              <Provider id={map.$jazz.id}>{children}</Provider>
+            </JazzTestProvider>
+          ),
+        },
+      );
+
+      expect(result.current.value).toBe("123");
+
+      act(() => {
+        map.$jazz.set("value", "456");
+      });
+
+      expect(result.current.value).toBe("456");
     });
 
-    const { Provider, useSelector } = createCoValueSubscriptionContext(TestMap);
+    it("the selector hook can be narrowed down further with a select function", () => {
+      const TestMap = co.map({
+        value: z.string(),
+      });
 
-    const { result } = renderHook(
-      () => {
-        return useSelector();
-      },
-      {
-        wrapper: ({ children }) => (
-          <JazzTestProvider>
-            <Provider id={map.$jazz.id}>{children}</Provider>
-          </JazzTestProvider>
-        ),
-      },
-    );
+      const map = TestMap.create({
+        value: "123",
+      });
 
-    expect(result.current.value).toBe("123");
-  });
+      const { Provider, useSelector } =
+        createCoValueSubscriptionContext(TestMap);
 
-  it("the selector hook updates when the coValue changes", () => {
-    const TestMap = co.map({
-      value: z.string(),
-    });
-
-    const map = TestMap.create({
-      value: "123",
-    });
-
-    const { Provider, useSelector } = createCoValueSubscriptionContext(TestMap);
-
-    const { result } = renderHook(
-      () => {
-        return useSelector();
-      },
-      {
-        wrapper: ({ children }) => (
-          <JazzTestProvider>
-            <Provider id={map.$jazz.id}>{children}</Provider>
-          </JazzTestProvider>
-        ),
-      },
-    );
-
-    expect(result.current.value).toBe("123");
-
-    act(() => {
-      map.$jazz.set("value", "456");
-    });
-
-    expect(result.current.value).toBe("456");
-  });
-
-  it("the selector hook can be narrowed down further with a select function", () => {
-    const TestMap = co.map({
-      value: z.string(),
-    });
-
-    const map = TestMap.create({
-      value: "123",
-    });
-
-    const { Provider, useSelector } = createCoValueSubscriptionContext(TestMap);
-
-    const { result } = renderHook(
-      () => {
-        return useSelector({
-          select: (v) => v.value,
-        });
-      },
-      {
-        wrapper: ({ children }) => (
-          <JazzTestProvider>
-            <Provider id={map.$jazz.id}>{children}</Provider>
-          </JazzTestProvider>
-        ),
-      },
-    );
-
-    expect(result.current).toBe("123");
-  });
-
-  it("should not re-render when a non-selected field changes", () => {
-    const TestMap = co.map({
-      value: z.string(),
-      other: z.string(),
-    });
-
-    const map = TestMap.create({
-      value: "1",
-      other: "1",
-    });
-
-    const { Provider, useSelector } = createCoValueSubscriptionContext(TestMap);
-
-    const { result } = renderHook(
-      () =>
-        useRenderCount(() => {
+      const { result } = renderHook(
+        () => {
           return useSelector({
             select: (v) => v.value,
           });
-        }),
-      {
-        wrapper: ({ children }) => (
-          <JazzTestProvider>
-            <Provider id={map.$jazz.id}>{children}</Provider>
-          </JazzTestProvider>
-        ),
-      },
-    );
+        },
+        {
+          wrapper: ({ children }) => (
+            <JazzTestProvider>
+              <Provider id={map.$jazz.id}>{children}</Provider>
+            </JazzTestProvider>
+          ),
+        },
+      );
 
-    expect(result.current.result).toBe("1");
-    expect(result.current.renderCount).toBe(1);
-
-    act(() => {
-      map.$jazz.set("other", "2");
+      expect(result.current).toBe("123");
     });
 
-    expect(result.current.result).toBe("1");
-    expect(result.current.renderCount).toBe(1);
-  });
-
-  it("the provider shows a loading fallback when loading the coValue", async () => {
-    const TestMap = co.map({
-      value: z.string(),
-    });
-
-    const { Provider } = createCoValueSubscriptionContext(TestMap);
-
-    const { container } = render(
-      <JazzTestProvider>
-        <Provider id="co_test123" loadingFallback={<div>Loading...</div>}>
-          <div>Children should not render</div>
-        </Provider>
-      </JazzTestProvider>,
-    );
-
-    // The loading fallback should be rendered
-    expect(container.textContent).toContain("Loading...");
-    // Children should not be rendered
-    expect(container.textContent).not.toContain("Children should not render");
-  });
-
-  it("the provider shows an unavailable fallback when the coValue is unavailable", async () => {
-    const TestMap = co.map({
-      value: z.string(),
-    });
-
-    const { Provider } = createCoValueSubscriptionContext(TestMap);
-
-    const { container } = render(
-      <JazzTestProvider>
-        <Provider
-          id="invalid_id"
-          loadingFallback={<div>Loading...</div>}
-          unavailableFallback={<div>Unavailable</div>}
-        >
-          <div>Children should not render</div>
-        </Provider>
-      </JazzTestProvider>,
-    );
-
-    // Initially shows loading fallback
-    expect(container.textContent).toContain("Loading...");
-
-    // Should show unavailable fallback after CoValue load timeout
-    await waitFor(() => {
-      expect(container.textContent).toContain("Unavailable");
-    });
-
-    // Children should never be rendered
-    expect(container.textContent).not.toContain("Children should not render");
-  });
-
-  it("should throw error when useSelector is used outside provider", () => {
-    const TestMap = co.map({
-      value: z.string(),
-    });
-
-    const { useSelector } = createCoValueSubscriptionContext(TestMap);
-
-    expect(() => {
-      renderHook(() => {
-        return useSelector();
+    it("should not re-render when a non-selected field changes", () => {
+      const TestMap = co.map({
+        value: z.string(),
+        other: z.string(),
       });
-    }).toThrow(
-      "useSelector must be used within a coValue subscription provider",
-    );
+
+      const map = TestMap.create({
+        value: "1",
+        other: "1",
+      });
+
+      const { Provider, useSelector } =
+        createCoValueSubscriptionContext(TestMap);
+
+      const { result } = renderHook(
+        () =>
+          useRenderCount(() => {
+            return useSelector({
+              select: (v) => v.value,
+            });
+          }),
+        {
+          wrapper: ({ children }) => (
+            <JazzTestProvider>
+              <Provider id={map.$jazz.id}>{children}</Provider>
+            </JazzTestProvider>
+          ),
+        },
+      );
+
+      expect(result.current.result).toBe("1");
+      expect(result.current.renderCount).toBe(1);
+
+      act(() => {
+        map.$jazz.set("other", "2");
+      });
+
+      expect(result.current.result).toBe("1");
+      expect(result.current.renderCount).toBe(1);
+    });
+
+    it("the provider renders a loading fallback when loading the CoValue", async () => {
+      const TestMap = co.map({
+        value: z.string(),
+      });
+
+      const { Provider } = createCoValueSubscriptionContext(TestMap);
+
+      const { container } = render(
+        <JazzTestProvider>
+          <Provider id="co_test123" loadingFallback={<div>Loading...</div>}>
+            <div>Children should not render</div>
+          </Provider>
+        </JazzTestProvider>,
+      );
+
+      // The loading fallback should be rendered
+      expect(container.textContent).toContain("Loading...");
+      // Children should not be rendered
+      expect(container.textContent).not.toContain("Children should not render");
+    });
+
+    it("the provider accepts React components as fallbacks and renders them correctly", async () => {
+      const TestMap = co.map({
+        value: z.string(),
+      });
+
+      const { Provider } = createCoValueSubscriptionContext(TestMap);
+
+      const Loading = () => <div>Loading...</div>;
+      const Unavailable = () => <div>Unavailable</div>;
+
+      const { container } = render(
+        <JazzTestProvider>
+          <Provider
+            id="co_test123"
+            loadingFallback={Loading}
+            unavailableFallback={Unavailable}
+          >
+            <div>Children should not render</div>
+          </Provider>
+        </JazzTestProvider>,
+      );
+
+      // The loading fallback should be rendered
+      expect(container.textContent).toContain("Loading...");
+      // Children should not be rendered
+      expect(container.textContent).not.toContain("Children should not render");
+    });
+
+    it("the provider shows an unavailable fallback when the coValue is unavailable", async () => {
+      const TestMap = co.map({
+        value: z.string(),
+      });
+
+      const { Provider } = createCoValueSubscriptionContext(TestMap);
+
+      const { container } = render(
+        <JazzTestProvider>
+          <Provider
+            id="invalid_id"
+            loadingFallback={<div>Loading...</div>}
+            unavailableFallback={<div>Unavailable</div>}
+          >
+            <div>Children should not render</div>
+          </Provider>
+        </JazzTestProvider>,
+      );
+
+      // Initially shows loading fallback
+      expect(container.textContent).toContain("Loading...");
+
+      // Should show unavailable fallback after CoValue load timeout
+      await waitFor(() => {
+        expect(container.textContent).toContain("Unavailable");
+      });
+
+      // Children should never be rendered
+      expect(container.textContent).not.toContain("Children should not render");
+    });
+
+    it("should throw error when useSelector is used outside provider", () => {
+      const TestMap = co.map({
+        value: z.string(),
+      });
+
+      const { useSelector } = createCoValueSubscriptionContext(TestMap);
+
+      expect(() => {
+        renderHook(() => {
+          return useSelector();
+        });
+      }).toThrow(
+        "useSelector must be used within a CoValue subscription Provider",
+      );
+    });
+
+    describe("with passthroughNotLoaded = true", () => {
+      it("should return the loaded CoValue when available", () => {
+        const TestMap = co.map({
+          value: z.string(),
+        });
+
+        const map = TestMap.create({
+          value: "123",
+        });
+
+        const { Provider, useSelector } = createCoValueSubscriptionContext(
+          TestMap,
+          true,
+          {
+            passthroughNotLoaded: true,
+          },
+        );
+
+        const { result } = renderHook(
+          () => {
+            return useSelector({
+              select: (v) => (v.$isLoaded ? v.value : undefined),
+            });
+          },
+          {
+            wrapper: ({ children }) => (
+              <JazzTestProvider>
+                <Provider id={map.$jazz.id}>{children}</Provider>
+              </JazzTestProvider>
+            ),
+          },
+        );
+
+        expect(result.current).toBe("123");
+      });
+
+      it("should return loading state when CoValue is loading", () => {
+        const TestMap = co.map({
+          value: z.string(),
+        });
+
+        const { Provider, useSelector } = createCoValueSubscriptionContext(
+          TestMap,
+          true,
+          {
+            passthroughNotLoaded: true,
+          },
+        );
+
+        const { result } = renderHook(
+          () => {
+            return useSelector({
+              select: (v) => v.$jazz.loadingState,
+            });
+          },
+          {
+            wrapper: ({ children }) => (
+              <JazzTestProvider>
+                <Provider id="co_test123">{children}</Provider>
+              </JazzTestProvider>
+            ),
+          },
+        );
+
+        expect(result.current).toBe(CoValueLoadingState.LOADING);
+      });
+
+      it("should return unavailable state when CoValue is not found", async () => {
+        const TestMap = co.map({
+          value: z.string(),
+        });
+
+        const { Provider, useSelector } = createCoValueSubscriptionContext(
+          TestMap,
+          true,
+          {
+            passthroughNotLoaded: true,
+          },
+        );
+
+        const { result } = renderHook(
+          () => {
+            return useSelector({
+              select: (v) => {
+                // @ts-expect-error - must narrow to loaded type to access `v.value`
+                return v?.value ?? v.$jazz.loadingState;
+              },
+            });
+          },
+          {
+            wrapper: ({ children }) => (
+              <JazzTestProvider>
+                <Provider id="invalid_id">{children}</Provider>
+              </JazzTestProvider>
+            ),
+          },
+        );
+
+        await waitFor(() => {
+          expect(result.current).toBe(CoValueLoadingState.UNAVAILABLE);
+        });
+      });
+    });
+  });
+
+  describe("useRef", () => {
+    it("should return a ref with the correct CoValue", () => {
+      const TestMap = co.map({
+        value: z.string(),
+      });
+
+      const map = TestMap.create({
+        value: "123",
+      });
+
+      const { Provider, useRef: useCoValueContextRef } =
+        createCoValueSubscriptionContext(TestMap);
+
+      const { result } = renderHook(
+        () => {
+          return useCoValueContextRef();
+        },
+        {
+          wrapper: ({ children }) => (
+            <JazzTestProvider>
+              <Provider id={map.$jazz.id}>{children}</Provider>
+            </JazzTestProvider>
+          ),
+        },
+      );
+
+      expect(result.current.current.value).toBe("123");
+    });
+
+    it("should update ref when CoValue changes", async () => {
+      const TestMap = co.map({
+        value: z.string(),
+      });
+
+      const map = TestMap.create({
+        value: "123",
+      });
+
+      const { Provider, useRef: useCoValueContextRef } =
+        createCoValueSubscriptionContext(TestMap);
+
+      const { result } = renderHook(
+        () => {
+          return useCoValueContextRef();
+        },
+        {
+          wrapper: ({ children }) => (
+            <JazzTestProvider>
+              <Provider id={map.$jazz.id}>{children}</Provider>
+            </JazzTestProvider>
+          ),
+        },
+      );
+
+      expect(result.current.current.value).toBe("123");
+
+      map.$jazz.set("value", "456");
+
+      expect(result.current.current.value).toBe("456");
+    });
+
+    it("should contain latest value when non-selected value changes remotely", async () => {
+      const TestMap = co.map({
+        name: z.string(),
+        value: z.string(),
+      });
+
+      const map = TestMap.create({
+        name: "stable",
+        value: "123",
+      });
+
+      const { Provider, useSelector, useRef } =
+        createCoValueSubscriptionContext(TestMap);
+
+      const { result } = renderHook(
+        () =>
+          useRenderCount(() => {
+            useSelector({
+              select: (v) => v.name,
+            });
+
+            return useRef();
+          }),
+        {
+          wrapper: ({ children }) => (
+            <JazzTestProvider>
+              <Provider id={map.$jazz.id}>{children}</Provider>
+            </JazzTestProvider>
+          ),
+        },
+      );
+
+      expect(result.current.result.current.value).toBe("123");
+
+      map.$jazz.set("value", "456");
+
+      expect(result.current.result.current.value).toBe("456");
+
+      // Should still only have rendered once
+      expect(result.current.renderCount).toBe(1);
+    });
+
+    it("should not re-render when editing non-selected value through ref", async () => {
+      const TestMap = co.map({
+        value: z.string(),
+        count: z.number(),
+      });
+
+      const map = TestMap.create({
+        value: "123",
+        count: 0,
+      });
+
+      const { Provider, useRef, useSelector } =
+        createCoValueSubscriptionContext(TestMap);
+
+      const { result } = renderHook(
+        () =>
+          useRenderCount(() => {
+            return {
+              state: useSelector({
+                select: (v) => (v.$isLoaded ? v.value : undefined),
+              }),
+              ref: useRef(),
+            };
+          }),
+        {
+          wrapper: ({ children }) => (
+            <JazzTestProvider>
+              <Provider id={map.$jazz.id}>{children}</Provider>
+            </JazzTestProvider>
+          ),
+        },
+      );
+
+      expect(result.current.result.ref.current.value).toBe("123");
+      expect(result.current.result.ref.current.count).toBe(0);
+      expect(result.current.renderCount).toBe(1);
+
+      // Edit through the ref
+      result.current.result.ref.current.$jazz.applyDiff({
+        value: "updated",
+        count: 42,
+      });
+
+      expect(result.current.result.ref.current.value).toBe("updated");
+      expect(result.current.result.ref.current.count).toBe(42);
+
+      // Should still only have rendered once
+      expect(result.current.renderCount).toBe(1);
+    });
+
+    it("should contain latest value despite not re-rendering selected value in useSelector", async () => {
+      const TestMap = co.map({
+        value: z.string(),
+      });
+
+      const map = TestMap.create({
+        value: "123",
+      });
+
+      const { Provider, useRef, useSelector } =
+        createCoValueSubscriptionContext(TestMap);
+
+      const { result } = renderHook(
+        () =>
+          useRenderCount(() => {
+            return {
+              state: useSelector({
+                select: (v) => v.value,
+                equalityFn: () => true,
+              }),
+              ref: useRef(),
+            };
+          }),
+        {
+          wrapper: ({ children }) => (
+            <JazzTestProvider>
+              <Provider id={map.$jazz.id}>{children}</Provider>
+            </JazzTestProvider>
+          ),
+        },
+      );
+
+      expect(result.current.result.ref.current.value).toBe("123");
+
+      act(() => {
+        map.$jazz.set("value", "456");
+      });
+
+      // contains latest value despite not re-rendering
+      expect(result.current.result.ref.current.value).toBe("456");
+
+      // state still stuck at old value due to equalityFn = () => true
+      expect(result.current.result.state).toBe("123");
+
+      // Should still only have rendered once
+      expect(result.current.renderCount).toBe(1);
+    });
+
+    it("should throw error when useRef is used outside provider", () => {
+      const TestMap = co.map({
+        value: z.string(),
+      });
+
+      const { useRef } = createCoValueSubscriptionContext(TestMap);
+
+      expect(() => {
+        renderHook(() => {
+          return useRef();
+        });
+      }).toThrow("useRef must be used within a CoValue subscription Provider");
+    });
+
+    describe("with passthroughNotLoaded = true", () => {
+      it("should return the loaded CoValue when available", () => {
+        const TestMap = co.map({
+          value: z.string(),
+        });
+
+        const map = TestMap.create({
+          value: "123",
+        });
+
+        const { Provider, useRef } = createCoValueSubscriptionContext(
+          TestMap,
+          true,
+          {
+            passthroughNotLoaded: true,
+          },
+        );
+
+        const { result } = renderHook(
+          () => {
+            return useRef();
+          },
+          {
+            wrapper: ({ children }) => (
+              <JazzTestProvider>
+                <Provider id={map.$jazz.id}>{children}</Provider>
+              </JazzTestProvider>
+            ),
+          },
+        );
+
+        assertLoaded(result.current.current);
+        expect(result.current.current.value).toBe("123");
+      });
+
+      it("should return loading state when CoValue is loading", () => {
+        const TestMap = co.map({
+          value: z.string(),
+        });
+
+        const { Provider, useRef } = createCoValueSubscriptionContext(
+          TestMap,
+          true,
+          {
+            passthroughNotLoaded: true,
+          },
+        );
+
+        const { result } = renderHook(
+          () => {
+            return useRef();
+          },
+          {
+            wrapper: ({ children }) => (
+              <JazzTestProvider>
+                <Provider id="co_test123">{children}</Provider>
+              </JazzTestProvider>
+            ),
+          },
+        );
+
+        expect(result.current.current.$jazz.loadingState).toBe(
+          CoValueLoadingState.LOADING,
+        );
+      });
+
+      it("should return unavailable state when CoValue is not found", async () => {
+        const TestMap = co.map({
+          value: z.string(),
+        });
+
+        const { Provider, useRef } = createCoValueSubscriptionContext(
+          TestMap,
+          true,
+          {
+            passthroughNotLoaded: true,
+          },
+        );
+
+        const { result } = renderHook(
+          () => {
+            return useRef();
+          },
+          {
+            wrapper: ({ children }) => (
+              <JazzTestProvider>
+                <Provider id="invalid_id">{children}</Provider>
+              </JazzTestProvider>
+            ),
+          },
+        );
+
+        await waitFor(() => {
+          expect(result.current.current.$jazz.loadingState).toBe(
+            CoValueLoadingState.UNAVAILABLE,
+          );
+        });
+      });
+    });
   });
 });

--- a/packages/jazz-tools/src/react-core/tests/testUtils.tsx
+++ b/packages/jazz-tools/src/react-core/tests/testUtils.tsx
@@ -4,8 +4,8 @@ import {
   render,
   renderHook,
 } from "@testing-library/react";
-import { Account, AnonymousJazzAgent, AuthSecretStorage } from "jazz-tools";
-import React from "react";
+import { Account, AnonymousJazzAgent } from "jazz-tools";
+import React, { useRef } from "react";
 import { JazzTestProvider } from "../testing.js";
 
 type JazzExtendedOptions = {
@@ -47,6 +47,16 @@ const customRenderHook = <TProps, TResult>(
   };
 
   return renderHook(callback, { wrapper: AllTheProviders, ...options });
+};
+
+export const useRenderCount = <T,>(hook: () => T) => {
+  const renderCountRef = useRef(0);
+  const result = hook();
+  renderCountRef.current = renderCountRef.current + 1;
+  return {
+    renderCount: renderCountRef.current,
+    result,
+  };
 };
 
 // re-export everything

--- a/packages/jazz-tools/src/react-core/tests/useAccount.selector.test.ts
+++ b/packages/jazz-tools/src/react-core/tests/useAccount.selector.test.ts
@@ -9,22 +9,11 @@ import {
   createJazzTestGuest,
   setupJazzTestSync,
 } from "../testing.js";
-import { act, renderHook } from "./testUtils.js";
-import { useRef } from "react";
+import { act, renderHook, useRenderCount } from "./testUtils.js";
 
 beforeEach(async () => {
   await setupJazzTestSync();
 });
-
-const useRenderCount = <T>(hook: () => T) => {
-  const renderCountRef = useRef(0);
-  const result = hook();
-  renderCountRef.current = renderCountRef.current + 1;
-  return {
-    renderCount: renderCountRef.current,
-    result,
-  };
-};
 
 describe("useAccount", () => {
   it("should return the correct selected value", async () => {

--- a/packages/jazz-tools/src/react-core/tests/useAccountAndRef.test.ts
+++ b/packages/jazz-tools/src/react-core/tests/useAccountAndRef.test.ts
@@ -1,0 +1,375 @@
+// @vitest-environment happy-dom
+
+import { co, z } from "jazz-tools";
+import { assertLoaded } from "jazz-tools/testing";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useAccountAndRef } from "../index.js";
+import { createJazzTestAccount, setupJazzTestSync } from "../testing.js";
+import { act, renderHook, useRenderCount, waitFor } from "./testUtils.js";
+
+beforeEach(async () => {
+  await setupJazzTestSync();
+});
+
+describe("useAccountAndRef", () => {
+  it("should return state and ref with the correct account values", async () => {
+    const AccountRoot = co.map({
+      name: z.string(),
+      count: z.number(),
+    });
+
+    const AccountSchema = co
+      .account({
+        root: AccountRoot,
+        profile: co.profile(),
+      })
+      .withMigration((account) => {
+        if (!account.$jazz.refs.root) {
+          account.$jazz.set("root", { name: "test", count: 42 });
+        }
+      });
+
+    const account = await createJazzTestAccount({
+      AccountSchema,
+    });
+
+    const { result } = renderHook(
+      () =>
+        useAccountAndRef(AccountSchema, {
+          resolve: {
+            root: true,
+          },
+        }),
+      {
+        account,
+      },
+    );
+
+    assertLoaded(result.current[0]);
+    expect(result.current[0].root.name).toBe("test");
+    expect(result.current[0].root.count).toBe(42);
+
+    assertLoaded(result.current[1].current);
+    expect(result.current[1].current.root.name).toBe("test");
+    expect(result.current[1].current.root.count).toBe(42);
+  });
+
+  it("should only re-render when selected field changes", async () => {
+    const AccountRoot = co.map({
+      name: z.string(),
+      loginCount: z.number(),
+    });
+
+    const AccountSchema = co
+      .account({
+        root: AccountRoot,
+        profile: co.profile(),
+      })
+      .withMigration((account) => {
+        if (!account.$jazz.refs.root) {
+          account.$jazz.set("root", { name: "User", loginCount: 0 });
+        }
+      });
+
+    const account = await createJazzTestAccount({
+      AccountSchema,
+    });
+
+    const { result } = renderHook(
+      () =>
+        useRenderCount(() =>
+          useAccountAndRef(AccountSchema, {
+            resolve: {
+              root: true,
+            },
+            select: (acc) => (acc.$isLoaded ? acc.root.name : undefined),
+          }),
+        ),
+      {
+        account,
+      },
+    );
+
+    expect(result.current.renderCount).toBe(1);
+    expect(result.current.result[0]).toBe("User");
+
+    // Update field NOT in selector - should not re-render
+    act(() => {
+      account.root.$jazz.set("loginCount", 5);
+    });
+
+    await waitFor(() => {
+      assertLoaded(result.current.result[1].current);
+      expect(result.current.result[1].current.root.loginCount).toBe(5);
+    });
+
+    expect(result.current.renderCount).toBe(1);
+
+    // Update field in selector - should re-render
+    act(() => {
+      account.root.$jazz.set("name", "Updated User");
+    });
+
+    await waitFor(() => {
+      expect(result.current.result[0]).toBe("Updated User");
+    });
+
+    expect(result.current.renderCount).toBe(2);
+  });
+
+  it("should allow editing non-selected fields through ref without re-rendering", async () => {
+    const AccountRoot = co.map({
+      displayName: z.string(),
+      lastLoginAt: z.string().optional(),
+      loginCount: z.number(),
+    });
+
+    const AccountSchema = co
+      .account({
+        root: AccountRoot,
+        profile: co.profile(),
+      })
+      .withMigration((account, creationProps) => {
+        if (!account.$jazz.refs.root) {
+          account.$jazz.set("root", {
+            displayName: "John",
+            loginCount: 0,
+          });
+        }
+      });
+
+    const account = await createJazzTestAccount({
+      AccountSchema,
+    });
+
+    const { result } = renderHook(
+      () =>
+        useRenderCount(() =>
+          useAccountAndRef(AccountSchema, {
+            resolve: {
+              root: true,
+            },
+            select: (acc) => (acc.$isLoaded ? acc.root.displayName : undefined),
+          }),
+        ),
+      {
+        account,
+      },
+    );
+
+    expect(result.current.renderCount).toBe(1);
+    expect(result.current.result[0]).toBe("John");
+
+    // Edit fields NOT in selector using ref.$jazz - no re-render
+    act(() => {
+      assertLoaded(result.current.result[1].current);
+      result.current.result[1].current.root.$jazz.set("loginCount", 10);
+      result.current.result[1].current.root.$jazz.set(
+        "lastLoginAt",
+        "2024-01-01",
+      );
+    });
+
+    await waitFor(() => {
+      assertLoaded(result.current.result[1].current);
+      expect(result.current.result[1].current.root.loginCount).toBe(10);
+      expect(result.current.result[1].current.root.lastLoginAt).toBe(
+        "2024-01-01",
+      );
+    });
+
+    expect(result.current.renderCount).toBe(1);
+    expect(account.root.loginCount).toBe(10);
+    expect(account.root.lastLoginAt).toBe("2024-01-01");
+  });
+
+  it("should support selecting account ID (which never changes)", async () => {
+    const AccountRoot = co.map({
+      settings: co.map({
+        theme: z.string(),
+      }),
+    });
+
+    const AccountSchema = co
+      .account({
+        root: AccountRoot,
+        profile: co.profile(),
+      })
+      .withMigration((account, creationProps) => {
+        if (!account.$jazz.refs.root) {
+          account.$jazz.set("root", {
+            settings: { theme: "light" },
+          });
+        }
+      });
+
+    const account = await createJazzTestAccount({
+      AccountSchema,
+    });
+
+    const { result } = renderHook(
+      () =>
+        useRenderCount(() =>
+          useAccountAndRef(AccountSchema, {
+            resolve: {
+              root: {
+                settings: true,
+              },
+            },
+            select: (acc) => acc.$jazz.id,
+          }),
+        ),
+      {
+        account,
+      },
+    );
+
+    expect(result.current.renderCount).toBe(1);
+    expect(result.current.result[0]).toBe(account.$jazz.id);
+
+    // Update settings - should not re-render since ID never changes
+    act(() => {
+      account.root.settings.$jazz.set("theme", "dark");
+    });
+
+    await waitFor(() => {
+      assertLoaded(result.current.result[1].current);
+      expect(result.current.result[1].current.root.settings.theme).toBe("dark");
+    });
+
+    expect(result.current.renderCount).toBe(1);
+  });
+
+  it("should allow using ref.$jazz for permissions without re-rendering", async () => {
+    const AccountRoot = co.map({
+      name: z.string(),
+    });
+
+    const AccountSchema = co
+      .account({
+        root: AccountRoot,
+        profile: co.profile(),
+      })
+      .withMigration((account, creationProps) => {
+        if (!account.$jazz.refs.root) {
+          account.$jazz.set("root", { name: "User" });
+        }
+      });
+
+    const account = await createJazzTestAccount({
+      AccountSchema,
+    });
+
+    const { result } = renderHook(
+      () =>
+        useRenderCount(() =>
+          useAccountAndRef(AccountSchema, {
+            resolve: {
+              root: true,
+            },
+            select: (acc) => (acc.$isLoaded ? acc.root.name : undefined),
+          }),
+        ),
+      {
+        account,
+      },
+    );
+
+    expect(result.current.renderCount).toBe(1);
+    expect(result.current.result[0]).toBe("User");
+
+    // Access $jazz API through ref - no re-render
+    act(() => {
+      assertLoaded(result.current.result[1].current);
+      expect(result.current.result[1].current.$jazz.id).toBeDefined();
+    });
+
+    expect(result.current.renderCount).toBe(1);
+  });
+
+  it("should support complex selector with nested data", async () => {
+    const AccountRoot = co.map({
+      profile: co.map({
+        firstName: z.string(),
+        lastName: z.string(),
+      }),
+      metadata: co.map({
+        createdAt: z.string(),
+        lastActive: z.string(),
+      }),
+    });
+
+    const AccountSchema = co
+      .account({
+        root: AccountRoot,
+        profile: co.profile(),
+      })
+      .withMigration((account, creationProps) => {
+        if (!account.$jazz.refs.root) {
+          account.$jazz.set("root", {
+            profile: {
+              firstName: "John",
+              lastName: "Doe",
+            },
+            metadata: {
+              createdAt: "2024-01-01",
+              lastActive: "2024-01-01",
+            },
+          });
+        }
+      });
+
+    const account = await createJazzTestAccount({
+      AccountSchema,
+    });
+
+    const { result } = renderHook(
+      () =>
+        useRenderCount(() =>
+          useAccountAndRef(AccountSchema, {
+            resolve: {
+              root: {
+                profile: true,
+                metadata: true,
+              },
+            },
+            select: (acc) =>
+              acc.$isLoaded
+                ? `${acc.root.profile.firstName} ${acc.root.profile.lastName}`
+                : undefined,
+          }),
+        ),
+      {
+        account,
+      },
+    );
+
+    expect(result.current.renderCount).toBe(1);
+    expect(result.current.result[0]).toBe("John Doe");
+
+    // Update metadata (not in selector) - no re-render
+    act(() => {
+      account.root.metadata.$jazz.set("lastActive", "2024-01-02");
+    });
+
+    await waitFor(() => {
+      assertLoaded(result.current.result[1].current);
+      expect(result.current.result[1].current.root.metadata.lastActive).toBe(
+        "2024-01-02",
+      );
+    });
+
+    expect(result.current.renderCount).toBe(1);
+
+    // Update firstName (in selector) - should re-render
+    act(() => {
+      account.root.profile.$jazz.set("firstName", "Jane");
+    });
+
+    await waitFor(() => {
+      expect(result.current.result[0]).toBe("Jane Doe");
+    });
+
+    expect(result.current.renderCount).toBe(2);
+  });
+});

--- a/packages/jazz-tools/src/react-core/tests/useAccountRef.test.ts
+++ b/packages/jazz-tools/src/react-core/tests/useAccountRef.test.ts
@@ -1,0 +1,304 @@
+// @vitest-environment happy-dom
+
+import { co, z } from "jazz-tools";
+import { assertLoaded } from "jazz-tools/testing";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useAccountRef } from "../index.js";
+import { createJazzTestAccount, setupJazzTestSync } from "../testing.js";
+import { act, renderHook, useRenderCount, waitFor } from "./testUtils.js";
+
+beforeEach(async () => {
+  await setupJazzTestSync();
+});
+
+describe("useAccountRef", () => {
+  it("should return a ref with the correct account value", async () => {
+    const account = await createJazzTestAccount({
+      isCurrentActiveAccount: true,
+    });
+
+    const {
+      result: { current: accountRef },
+    } = renderHook(() => useAccountRef(), {
+      account,
+    });
+
+    assertLoaded(accountRef.current);
+    expect(accountRef.current.$jazz.id).toBe(account.$jazz.id);
+  });
+
+  it("should load nested values if requested", async () => {
+    const AccountRoot = co.map({
+      value: z.string(),
+    });
+
+    const AccountSchema = co
+      .account({
+        root: AccountRoot,
+        profile: co.profile(),
+      })
+      .withMigration((account, creationProps) => {
+        if (!account.$jazz.refs.root) {
+          account.$jazz.set("root", { value: "123" });
+        }
+      });
+
+    const account = await createJazzTestAccount({
+      AccountSchema,
+    });
+
+    const {
+      result: { current: accountRef },
+    } = renderHook(
+      () =>
+        useAccountRef(AccountSchema, {
+          resolve: {
+            root: true,
+          },
+        }),
+      {
+        account,
+      },
+    );
+
+    assertLoaded(accountRef.current);
+    expect(accountRef.current.root.value).toBe("123");
+  });
+
+  it("should update the ref when the account changes", async () => {
+    const AccountRoot = co.map({
+      value: z.string(),
+    });
+
+    const AccountSchema = co
+      .account({
+        root: AccountRoot,
+        profile: co.profile(),
+      })
+      .withMigration((account, creationProps) => {
+        if (!account.$jazz.refs.root) {
+          account.$jazz.set("root", { value: "initial" });
+        }
+      });
+
+    const account = await createJazzTestAccount({
+      AccountSchema,
+    });
+
+    const {
+      result: { current: accountRef },
+    } = renderHook(
+      () =>
+        useAccountRef(AccountSchema, {
+          resolve: {
+            root: true,
+          },
+        }),
+      {
+        account,
+      },
+    );
+
+    assertLoaded(accountRef.current);
+    expect(accountRef.current.root.value).toBe("initial");
+
+    act(() => {
+      account.root.$jazz.set("value", "updated");
+    });
+
+    await waitFor(() => {
+      assertLoaded(accountRef.current);
+      expect(accountRef.current.root.value).toBe("updated");
+    });
+  });
+
+  it("should not cause re-renders when the account changes", async () => {
+    const AccountRoot = co.map({
+      value: z.string(),
+    });
+
+    const AccountSchema = co
+      .account({
+        root: AccountRoot,
+        profile: co.profile(),
+      })
+      .withMigration((account, creationProps) => {
+        if (!account.$jazz.refs.root) {
+          account.$jazz.set("root", { value: "initial" });
+        }
+      });
+
+    const account = await createJazzTestAccount({
+      AccountSchema,
+    });
+
+    const {
+      result: {
+        current: { renderCount, result: accountRef },
+      },
+    } = renderHook(
+      () =>
+        useRenderCount(() =>
+          useAccountRef(AccountSchema, {
+            resolve: {
+              root: true,
+            },
+          }),
+        ),
+      {
+        account,
+      },
+    );
+
+    assertLoaded(accountRef.current);
+    expect(accountRef.current.root.value).toBe("initial");
+    expect(renderCount).toBe(1);
+
+    act(() => {
+      account.root.$jazz.set("value", "updated");
+    });
+
+    await waitFor(() => {
+      assertLoaded(accountRef.current);
+      expect(accountRef.current.root.value).toBe("updated");
+    });
+
+    expect(renderCount).toBe(1);
+  });
+
+  it("should allow editing the account through the ref without causing re-renders", async () => {
+    const AccountRoot = co.map({
+      value: z.string(),
+      count: z.number(),
+    });
+
+    const AccountSchema = co
+      .account({
+        root: AccountRoot,
+        profile: co.profile(),
+      })
+      .withMigration((account, creationProps) => {
+        if (!account.$jazz.refs.root) {
+          account.$jazz.set("root", { value: "initial", count: 0 });
+        }
+      });
+
+    const account = await createJazzTestAccount({
+      AccountSchema,
+    });
+
+    const {
+      result: {
+        current: { renderCount, result: accountRef },
+      },
+    } = renderHook(
+      () =>
+        useRenderCount(() =>
+          useAccountRef(AccountSchema, {
+            resolve: {
+              root: true,
+            },
+          }),
+        ),
+      {
+        account,
+      },
+    );
+
+    assertLoaded(accountRef.current);
+    expect(accountRef.current.root.value).toBe("initial");
+    expect(accountRef.current.root.count).toBe(0);
+    expect(renderCount).toBe(1);
+
+    act(() => {
+      const current = accountRef.current;
+      if (current.$isLoaded) {
+        current.root.$jazz.set("value", "updated");
+        current.root.$jazz.set("count", 42);
+      }
+    });
+
+    await waitFor(() => {
+      assertLoaded(accountRef.current);
+      expect(accountRef.current.root.value).toBe("updated");
+      expect(accountRef.current.root.count).toBe(42);
+    });
+
+    expect(renderCount).toBe(1);
+
+    expect(account.root.value).toBe("updated");
+    expect(account.root.count).toBe(42);
+  });
+
+  it("should provide access to $jazz object for editing without re-renders", async () => {
+    const AccountRoot = co.map({
+      settings: co.map({
+        theme: z.string(),
+        notifications: z.boolean(),
+      }),
+    });
+
+    const AccountSchema = co
+      .account({
+        root: AccountRoot,
+        profile: co.profile(),
+      })
+      .withMigration((account, creationProps) => {
+        if (!account.$jazz.refs.root) {
+          account.$jazz.set("root", {
+            settings: {
+              theme: "light",
+              notifications: true,
+            },
+          });
+        }
+      });
+
+    const account = await createJazzTestAccount({
+      AccountSchema,
+    });
+
+    const {
+      result: {
+        current: { renderCount, result: accountRef },
+      },
+    } = renderHook(
+      () =>
+        useRenderCount(() =>
+          useAccountRef(AccountSchema, {
+            resolve: {
+              root: {
+                settings: true,
+              },
+            },
+          }),
+        ),
+      {
+        account,
+      },
+    );
+
+    assertLoaded(accountRef.current);
+    expect(accountRef.current.root.settings.theme).toBe("light");
+    expect(renderCount).toBe(1);
+
+    act(() => {
+      const current = accountRef.current;
+      if (current.$isLoaded) {
+        current.root.settings.$jazz.set("theme", "dark");
+        current.root.settings.$jazz.set("notifications", false);
+      }
+    });
+
+    await waitFor(() => {
+      assertLoaded(accountRef.current);
+      expect(accountRef.current.root.settings.theme).toBe("dark");
+      expect(accountRef.current.root.settings.notifications).toBe(false);
+    });
+
+    expect(renderCount).toBe(1);
+
+    expect(account.root.settings.theme).toBe("dark");
+    expect(account.root.settings.notifications).toBe(false);
+  });
+});

--- a/packages/jazz-tools/src/react-core/tests/useCoState.selector.test.ts
+++ b/packages/jazz-tools/src/react-core/tests/useCoState.selector.test.ts
@@ -5,8 +5,7 @@ import { Account, co, Loaded, z } from "jazz-tools";
 import { beforeEach, describe, expect, expectTypeOf, it } from "vitest";
 import { useCoState } from "../index.js";
 import { createJazzTestAccount, setupJazzTestSync } from "../testing.js";
-import { renderHook, waitFor } from "./testUtils.js";
-import { useRef } from "react";
+import { renderHook, waitFor, useRenderCount } from "./testUtils.js";
 
 beforeEach(async () => {
   await setupJazzTestSync();
@@ -17,16 +16,6 @@ beforeEach(async () => {
 });
 
 cojsonInternals.setCoValueLoadingRetryDelay(300);
-
-const useRenderCount = <T>(hook: () => T) => {
-  const renderCountRef = useRef(0);
-  const result = hook();
-  renderCountRef.current = renderCountRef.current + 1;
-  return {
-    renderCount: renderCountRef.current,
-    result,
-  };
-};
 
 describe("useCoState", () => {
   it("should not re-render when a nested coValue is updated and not selected", async () => {

--- a/packages/jazz-tools/src/react-core/tests/useCoStateAndRef.test.ts
+++ b/packages/jazz-tools/src/react-core/tests/useCoStateAndRef.test.ts
@@ -1,0 +1,328 @@
+// @vitest-environment happy-dom
+
+import { cojsonInternals } from "cojson";
+import { CoValueLoadingState, Group, co, z } from "jazz-tools";
+import { assertLoaded } from "jazz-tools/testing";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useCoStateAndRef } from "../index.js";
+import { createJazzTestAccount, setupJazzTestSync } from "../testing.js";
+import { act, renderHook, useRenderCount, waitFor } from "./testUtils.js";
+
+beforeEach(async () => {
+  await setupJazzTestSync();
+
+  await createJazzTestAccount({
+    isCurrentActiveAccount: true,
+  });
+});
+
+cojsonInternals.setCoValueLoadingRetryDelay(300);
+
+describe("useCoStateAndRef", () => {
+  it("should return state and ref with the correct values", async () => {
+    const TestMap = co.map({
+      name: z.string(),
+      count: z.number(),
+    });
+
+    const account = await createJazzTestAccount({
+      isCurrentActiveAccount: true,
+    });
+
+    const map = TestMap.create({
+      name: "test",
+      count: 42,
+    });
+
+    const { result } = renderHook(
+      () => useCoStateAndRef(TestMap, map.$jazz.id),
+      {
+        account,
+      },
+    );
+
+    assertLoaded(result.current[0]);
+    expect(result.current[0].name).toBe("test");
+    expect(result.current[0].count).toBe(42);
+
+    assertLoaded(result.current[1].current);
+    expect(result.current[1].$isLoaded).toBe(true);
+    expect(result.current[1].current.name).toBe("test");
+    expect(result.current[1].current.count).toBe(42);
+  });
+
+  it("should only re-render when selected field changes", async () => {
+    const TestMap = co.map({
+      name: z.string(),
+      count: z.number(),
+    });
+
+    const account = await createJazzTestAccount({
+      isCurrentActiveAccount: true,
+    });
+
+    const map = TestMap.create({
+      name: "test",
+      count: 0,
+    });
+
+    const { result } = renderHook(
+      () =>
+        useRenderCount(() =>
+          useCoStateAndRef(TestMap, map.$jazz.id, {
+            select: (m) => (m.$isLoaded ? m.name : undefined),
+          }),
+        ),
+      {
+        account,
+      },
+    );
+
+    expect(result.current.renderCount).toBe(1);
+    expect(result.current.result[0]).toBe("test");
+
+    // Update field NOT in selector - should not re-render
+    act(() => {
+      map.$jazz.set("count", 42);
+    });
+
+    await waitFor(() => {
+      assertLoaded(result.current.result[1].current);
+      expect(result.current.result[1].current.count).toBe(42);
+    });
+
+    expect(result.current.renderCount).toBe(1);
+
+    // Update field in selector - should re-render
+    act(() => {
+      map.$jazz.set("name", "updated");
+    });
+
+    await waitFor(() => {
+      expect(result.current.result[0]).toBe("updated");
+    });
+
+    expect(result.current.renderCount).toBe(2);
+  });
+
+  it("should allow editing non-selected fields through ref without re-rendering", async () => {
+    const TestMap = co.map({
+      title: z.string(),
+      viewCount: z.number(),
+      lastViewed: z.string().optional(),
+    });
+
+    const account = await createJazzTestAccount({
+      isCurrentActiveAccount: true,
+    });
+
+    const map = TestMap.create({
+      title: "Document",
+      viewCount: 0,
+    });
+
+    const { result } = renderHook(
+      () =>
+        useRenderCount(() =>
+          useCoStateAndRef(TestMap, map.$jazz.id, {
+            select: (doc) => (doc.$isLoaded ? doc.title : undefined),
+          }),
+        ),
+      {
+        account,
+      },
+    );
+
+    expect(result.current.renderCount).toBe(1);
+    expect(result.current.result[0]).toBe("Document");
+
+    // Edit fields NOT in selector using ref.$jazz - no re-render
+    act(() => {
+      if (result.current.result[1].current.$isLoaded) {
+        result.current.result[1].current.$jazz.set("viewCount", 5);
+        result.current.result[1].current.$jazz.set("lastViewed", "2024-01-01");
+      }
+    });
+
+    await waitFor(() => {
+      assertLoaded(result.current.result[1].current);
+      expect(result.current.result[1].current.viewCount).toBe(5);
+      expect(result.current.result[1].current.lastViewed).toBe("2024-01-01");
+    });
+
+    expect(result.current.renderCount).toBe(1);
+    expect(map.viewCount).toBe(5);
+    expect(map.lastViewed).toBe("2024-01-01");
+  });
+
+  it("should handle unavailable state", async () => {
+    const TestMap = co.map({
+      value: z.string(),
+    });
+
+    const map = TestMap.create({
+      value: "test",
+    });
+
+    const viewerAccount = await createJazzTestAccount();
+
+    for (const peer of viewerAccount.$jazz.localNode.syncManager.getServerPeers(
+      viewerAccount.$jazz.raw.id,
+    )) {
+      peer.gracefulShutdown();
+    }
+
+    const { result } = renderHook(
+      () => useCoStateAndRef(TestMap, map.$jazz.id),
+      {
+        account: viewerAccount,
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current[1].current.$jazz.loadingState).toBe(
+        CoValueLoadingState.UNAVAILABLE,
+      );
+      expect(result.current[1].$isLoaded).toBe(false);
+    });
+  });
+
+  it("should handle unauthorized state", async () => {
+    const TestMap = co.map({
+      value: z.string(),
+    });
+
+    const someoneElse = await createJazzTestAccount({
+      isCurrentActiveAccount: true,
+    });
+
+    const map = TestMap.create(
+      {
+        value: "secret",
+      },
+      someoneElse,
+    );
+
+    const account = await createJazzTestAccount({
+      isCurrentActiveAccount: true,
+    });
+
+    const { result } = renderHook(
+      () => useCoStateAndRef(TestMap, map.$jazz.id),
+      {
+        account,
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current[1].current.$jazz.loadingState).toBe(
+        CoValueLoadingState.UNAUTHORIZED,
+      );
+      expect(result.current[1].$isLoaded).toBe(false);
+    });
+  });
+
+  it("should update when CoValue becomes accessible", async () => {
+    const TestMap = co.map({
+      value: z.string(),
+    });
+
+    const someoneElse = await createJazzTestAccount({
+      isCurrentActiveAccount: true,
+    });
+
+    const group = Group.create(someoneElse);
+
+    const map = TestMap.create(
+      {
+        value: "123",
+      },
+      group,
+    );
+
+    const account = await createJazzTestAccount({
+      isCurrentActiveAccount: true,
+    });
+
+    const { result } = renderHook(
+      () => useCoStateAndRef(TestMap, map.$jazz.id),
+      {
+        account,
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current[1].current.$jazz.loadingState).toBe(
+        CoValueLoadingState.UNAUTHORIZED,
+      );
+      expect(result.current[1].$isLoaded).toBe(false);
+    });
+
+    group.addMember("everyone", "reader");
+
+    await waitFor(() => {
+      expect(result.current[1].current.$isLoaded).toBe(true);
+      assertLoaded(result.current[0]);
+      expect(result.current[0].value).toBe("123");
+      assertLoaded(result.current[1].current);
+      expect(result.current[1].current.value).toBe("123");
+    });
+  });
+
+  it("should support custom selector with complex return type", async () => {
+    const TestMap = co.map({
+      firstName: z.string(),
+      lastName: z.string(),
+      age: z.number(),
+    });
+
+    const account = await createJazzTestAccount({
+      isCurrentActiveAccount: true,
+    });
+
+    const map = TestMap.create({
+      firstName: "John",
+      lastName: "Doe",
+      age: 30,
+    });
+
+    const { result } = renderHook(
+      () =>
+        useRenderCount(() =>
+          useCoStateAndRef(TestMap, map.$jazz.id, {
+            select: (user) =>
+              user.$isLoaded ? `${user.firstName} ${user.lastName}` : undefined,
+          }),
+        ),
+      {
+        account,
+      },
+    );
+
+    expect(result.current.renderCount).toBe(1);
+    expect(result.current.result[0]).toBe("John Doe");
+
+    // Update age (not in selector) - no re-render
+    act(() => {
+      map.$jazz.set("age", 31);
+    });
+
+    await waitFor(() => {
+      assertLoaded(result.current.result[1].current);
+      expect(result.current.result[1].current.age).toBe(31);
+    });
+
+    expect(result.current.renderCount).toBe(1);
+
+    // Update firstName (in selector) - should re-render
+    act(() => {
+      map.$jazz.set("firstName", "Jane");
+    });
+
+    await waitFor(() => {
+      expect(result.current.result[0]).toBe("Jane Doe");
+    });
+
+    expect(result.current.renderCount).toBe(2);
+  });
+});

--- a/packages/jazz-tools/src/react-core/tests/useCoValueRef.test.ts
+++ b/packages/jazz-tools/src/react-core/tests/useCoValueRef.test.ts
@@ -1,0 +1,423 @@
+// @vitest-environment happy-dom
+
+import { cojsonInternals } from "cojson";
+import { CoValueLoadingState, Group, co, z } from "jazz-tools";
+import { assertLoaded } from "jazz-tools/testing";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useCoValueRef } from "../index.js";
+import { createJazzTestAccount, setupJazzTestSync } from "../testing.js";
+import { act, renderHook, useRenderCount, waitFor } from "./testUtils.js";
+
+beforeEach(async () => {
+  await setupJazzTestSync();
+
+  await createJazzTestAccount({
+    isCurrentActiveAccount: true,
+  });
+});
+
+cojsonInternals.setCoValueLoadingRetryDelay(300);
+
+describe("useCoValueRef", () => {
+  it("should return a ref with the correct value", async () => {
+    const TestMap = co.map({
+      value: z.string(),
+    });
+
+    const account = await createJazzTestAccount({
+      isCurrentActiveAccount: true,
+    });
+
+    const map = TestMap.create({
+      value: "123",
+    });
+
+    const {
+      result: { current: coValueRef },
+    } = renderHook(() => useCoValueRef(TestMap, map.$jazz.id), {
+      account,
+    });
+
+    assertLoaded(coValueRef.current);
+    expect(coValueRef.current.value).toBe("123");
+  });
+
+  it("should return a ref with 'unavailable' value on invalid id", async () => {
+    const TestMap = co.map({
+      value: z.string(),
+    });
+
+    const account = await createJazzTestAccount({
+      isCurrentActiveAccount: true,
+    });
+
+    const {
+      result: { current: coValueRef },
+    } = renderHook(() => useCoValueRef(TestMap, "test"), {
+      account,
+    });
+
+    expect(coValueRef.current.$jazz.loadingState).toBe(
+      CoValueLoadingState.LOADING,
+    );
+
+    await waitFor(() => {
+      expect(coValueRef.current.$jazz.loadingState).toBe(
+        CoValueLoadingState.UNAVAILABLE,
+      );
+    });
+  });
+
+  it("should update the ref when the coValue changes", async () => {
+    const TestMap = co.map({
+      value: z.string(),
+    });
+
+    const account = await createJazzTestAccount({
+      isCurrentActiveAccount: true,
+    });
+
+    const map = TestMap.create({
+      value: "123",
+    });
+
+    const {
+      result: { current: coValueRef },
+    } = renderHook(() => useCoValueRef(TestMap, map.$jazz.id), {
+      account,
+    });
+
+    assertLoaded(coValueRef.current);
+    expect(coValueRef.current.value).toBe("123");
+
+    act(() => {
+      map.$jazz.set("value", "456");
+    });
+
+    await waitFor(() => {
+      assertLoaded(coValueRef.current);
+      expect(coValueRef.current.value).toBe("456");
+    });
+  });
+
+  it("should load nested values if requested", async () => {
+    const TestNestedMap = co.map({
+      value: z.string(),
+    });
+
+    const TestMap = co.map({
+      value: z.string(),
+      nested: TestNestedMap,
+    });
+
+    const account = await createJazzTestAccount({
+      isCurrentActiveAccount: true,
+    });
+
+    const map = TestMap.create({
+      value: "123",
+      nested: TestNestedMap.create({
+        value: "456",
+      }),
+    });
+
+    const {
+      result: { current: coValueRef },
+    } = renderHook(
+      () =>
+        useCoValueRef(TestMap, map.$jazz.id, {
+          resolve: {
+            nested: true,
+          },
+        }),
+      {
+        account,
+      },
+    );
+
+    assertLoaded(coValueRef.current);
+    expect(coValueRef.current.value).toBe("123");
+    expect(coValueRef.current.nested.value).toBe("456");
+  });
+
+  it("should return a ref with 'unavailable' value if the coValue is not found", async () => {
+    const TestMap = co.map({
+      value: z.string(),
+    });
+
+    const map = TestMap.create({
+      value: "123",
+    });
+
+    const viewerAccount = await createJazzTestAccount();
+
+    for (const peer of viewerAccount.$jazz.localNode.syncManager.getServerPeers(
+      viewerAccount.$jazz.raw.id,
+    )) {
+      peer.gracefulShutdown();
+    }
+
+    const {
+      result: { current: coValueRef },
+    } = renderHook(() => useCoValueRef(TestMap, map.$jazz.id), {
+      account: viewerAccount,
+    });
+
+    await waitFor(() => {
+      expect(coValueRef.current.$jazz.loadingState).toBe(
+        CoValueLoadingState.UNAVAILABLE,
+      );
+    });
+  });
+
+  it("should return a ref with 'unauthorized' value if the coValue is not accessible", async () => {
+    const TestMap = co.map({
+      value: z.string(),
+    });
+
+    const someoneElse = await createJazzTestAccount({
+      isCurrentActiveAccount: true,
+    });
+
+    const map = TestMap.create(
+      {
+        value: "123",
+      },
+      someoneElse,
+    );
+
+    const account = await createJazzTestAccount({
+      isCurrentActiveAccount: true,
+    });
+
+    const {
+      result: { current: coValueRef },
+    } = renderHook(() => useCoValueRef(TestMap, map.$jazz.id), {
+      account,
+    });
+
+    await waitFor(() => {
+      expect(coValueRef.current.$jazz.loadingState).toBe(
+        CoValueLoadingState.UNAUTHORIZED,
+      );
+    });
+  });
+
+  it("should return a ref with 'loaded' value if the coValue is shared with everyone", async () => {
+    const TestMap = co.map({
+      value: z.string(),
+    });
+
+    const someoneElse = await createJazzTestAccount({
+      isCurrentActiveAccount: true,
+    });
+
+    const group = Group.create(someoneElse);
+    group.addMember("everyone", "reader");
+
+    const map = TestMap.create(
+      {
+        value: "123",
+      },
+      group,
+    );
+
+    const account = await createJazzTestAccount({
+      isCurrentActiveAccount: true,
+    });
+
+    const {
+      result: { current: coValueRef },
+    } = renderHook(() => useCoValueRef(TestMap, map.$jazz.id), {
+      account,
+    });
+
+    await waitFor(() => {
+      assertLoaded(coValueRef.current);
+      expect(coValueRef.current.value).toBe("123");
+    });
+  });
+
+  it("should update ref when the coValue becomes accessible", async () => {
+    const TestMap = co.map({
+      value: z.string(),
+    });
+
+    const someoneElse = await createJazzTestAccount({
+      isCurrentActiveAccount: true,
+    });
+
+    const group = Group.create(someoneElse);
+
+    const map = TestMap.create(
+      {
+        value: "123",
+      },
+      group,
+    );
+
+    const account = await createJazzTestAccount({
+      isCurrentActiveAccount: true,
+    });
+
+    const {
+      result: { current: coValueRef },
+    } = renderHook(() => useCoValueRef(TestMap, map.$jazz.id), {
+      account,
+    });
+
+    await waitFor(() => {
+      expect(coValueRef.current.$jazz.loadingState).toBe(
+        CoValueLoadingState.UNAUTHORIZED,
+      );
+    });
+
+    group.addMember("everyone", "reader");
+
+    await waitFor(() => {
+      expect(coValueRef.current.$jazz.loadingState).not.toBe(
+        CoValueLoadingState.UNAUTHORIZED,
+      );
+    });
+
+    assertLoaded(coValueRef.current);
+    expect(coValueRef.current.value).toBe("123");
+  });
+
+  it("should return a ref with 'unauthorized' value when the coValue becomes inaccessible", async () => {
+    const TestMap = co.map({
+      value: z.string(),
+    });
+
+    const someoneElse = await createJazzTestAccount({
+      isCurrentActiveAccount: true,
+    });
+
+    const group = Group.create(someoneElse);
+
+    const map = TestMap.create(
+      {
+        value: "123",
+      },
+      group,
+    );
+
+    const account = await createJazzTestAccount({
+      isCurrentActiveAccount: true,
+    });
+
+    await account.$jazz.waitForAllCoValuesSync();
+
+    group.addMember(account, "reader");
+
+    const {
+      result: { current: coValueRef },
+    } = renderHook(() => useCoValueRef(TestMap, map.$jazz.id), {
+      account,
+    });
+
+    await waitFor(() => {
+      expect(coValueRef.current).not.toBeUndefined();
+    });
+
+    group.removeMember(account);
+
+    await waitFor(() => {
+      expect(coValueRef.current.$jazz.loadingState).toBe(
+        CoValueLoadingState.UNAUTHORIZED,
+      );
+    });
+  });
+
+  it("should not cause re-renders when the coValue changes", async () => {
+    const TestMap = co.map({
+      value: z.string(),
+    });
+
+    const account = await createJazzTestAccount({
+      isCurrentActiveAccount: true,
+    });
+
+    const map = TestMap.create({
+      value: "123",
+    });
+
+    const {
+      result: {
+        current: { renderCount, result: coValueRef },
+      },
+    } = renderHook(
+      () => useRenderCount(() => useCoValueRef(TestMap, map.$jazz.id)),
+      {
+        account,
+      },
+    );
+
+    expect(renderCount).toBe(1);
+
+    assertLoaded(coValueRef.current);
+    expect(coValueRef.current.value).toBe("123");
+
+    act(() => {
+      map.$jazz.set("value", "456");
+    });
+
+    await waitFor(() => {
+      assertLoaded(coValueRef.current);
+      expect(coValueRef.current.value).toBe("456");
+    });
+
+    expect(renderCount).toBe(1);
+  });
+
+  it("should allow editing the coValue through the ref without causing re-renders", async () => {
+    const TestMap = co.map({
+      value: z.string(),
+      count: z.number(),
+    });
+
+    const account = await createJazzTestAccount({
+      isCurrentActiveAccount: true,
+    });
+
+    const map = TestMap.create({
+      value: "123",
+      count: 0,
+    });
+
+    const {
+      result: {
+        current: { renderCount, result: coValueRef },
+      },
+    } = renderHook(
+      () => useRenderCount(() => useCoValueRef(TestMap, map.$jazz.id)),
+      {
+        account,
+      },
+    );
+
+    assertLoaded(coValueRef.current);
+    expect(coValueRef.current.value).toBe("123");
+    expect(coValueRef.current.count).toBe(0);
+    expect(renderCount).toBe(1);
+
+    act(() => {
+      const current = coValueRef.current;
+      if (current.$isLoaded) {
+        current.$jazz.set("value", "updated");
+        current.$jazz.set("count", 42);
+      }
+    });
+
+    await waitFor(() => {
+      assertLoaded(coValueRef.current);
+      expect(coValueRef.current.value).toBe("updated");
+      expect(coValueRef.current.count).toBe(42);
+    });
+
+    expect(renderCount).toBe(1);
+
+    expect(map.value).toBe("updated");
+    expect(map.count).toBe(42);
+  });
+});

--- a/packages/jazz-tools/src/react-core/tests/useSubscriptionSelector.test.ts
+++ b/packages/jazz-tools/src/react-core/tests/useSubscriptionSelector.test.ts
@@ -10,8 +10,7 @@ import {
   useSubscriptionSelector,
 } from "../index.js";
 import { createJazzTestAccount, setupJazzTestSync } from "../testing.js";
-import { act, renderHook, waitFor } from "./testUtils.js";
-import { useRef } from "react";
+import { act, renderHook, useRenderCount, waitFor } from "./testUtils.js";
 
 beforeEach(async () => {
   await setupJazzTestSync();
@@ -22,16 +21,6 @@ beforeEach(async () => {
 });
 
 cojsonInternals.setCoValueLoadingRetryDelay(300);
-
-const useRenderCount = <T>(hook: () => T) => {
-  const renderCountRef = useRef(0);
-  const result = hook();
-  renderCountRef.current = renderCountRef.current + 1;
-  return {
-    renderCount: renderCountRef.current,
-    result,
-  };
-};
 
 describe("useSubscriptionSelector", () => {
   it("should return coValue", () => {

--- a/packages/jazz-tools/src/react-core/types.ts
+++ b/packages/jazz-tools/src/react-core/types.ts
@@ -1,6 +1,11 @@
 import {
+  type BranchDefinition,
   CoValueClassOrSchema,
+  Loaded,
+  MaybeLoaded,
   ResolveQuery,
+  ResolveQueryStrict,
+  SchemaResolveQuery,
   SubscriptionScope,
 } from "jazz-tools";
 
@@ -17,3 +22,48 @@ export type CoValueSubscription<
       };
     })
   | null;
+
+export interface UseSubscriptionOptions<
+  S extends CoValueClassOrSchema,
+  // @ts-expect-error we can't statically enforce the schema's resolve query is a valid resolve query, but in practice it is
+  R extends ResolveQuery<S> = SchemaResolveQuery<S>,
+> {
+  /** Resolve query to specify which nested CoValues to load from the CoValue */
+  resolve?: ResolveQueryStrict<S, R>;
+  /**
+   * Create or load a branch for isolated editing.
+   *
+   * Branching lets you take a snapshot of the current state and start modifying it without affecting the canonical/shared version.
+   * It's a fork of your data graph: the same schema, but with diverging values.
+   *
+   * The checkout of the branch is applied on all the resolved values.
+   *
+   * @param name - A unique name for the branch. This identifies the branch
+   *   and can be used to switch between different branches of the same CoValue.
+   * @param owner - The owner of the branch. Determines who can access and modify
+   *   the branch. If not provided, the branch is owned by the current user.
+   *
+   * For more info see the [branching](https://jazz.tools/docs/react/using-covalues/version-control) documentation.
+   */
+  unstable_branch?: BranchDefinition;
+}
+
+export interface UseSubscriptionSelectorOptions<
+  S extends CoValueClassOrSchema,
+  // @ts-expect-error we can't statically enforce the schema's resolve query is a valid resolve query, but in practice it is
+  R extends ResolveQuery<S> = SchemaResolveQuery<S>,
+  TSelectorReturn = MaybeLoaded<Loaded<S, R>>,
+> {
+  /** Select what data to return from the loaded or unloaded CoValue */
+  select?: (value: MaybeLoaded<Loaded<S, R>>) => TSelectorReturn;
+  /** Equality function to determine if the selected value has changed, defaults to `Object.is` */
+  equalityFn?: (a: TSelectorReturn, b: TSelectorReturn) => boolean;
+}
+
+export interface UseCoValueOptions<
+  S extends CoValueClassOrSchema,
+  // @ts-expect-error we can't statically enforce the schema's resolve query is a valid resolve query, but in practice it is
+  R extends ResolveQuery<S> = SchemaResolveQuery<S>,
+  TSelectorReturn = MaybeLoaded<Loaded<S, R>>,
+> extends UseSubscriptionOptions<S, R>,
+    UseSubscriptionSelectorOptions<S, R, TSelectorReturn> {}

--- a/packages/jazz-tools/src/react-core/types.ts
+++ b/packages/jazz-tools/src/react-core/types.ts
@@ -1,3 +1,4 @@
+import React from "react";
 import {
   type BranchDefinition,
   CoValueClassOrSchema,
@@ -67,3 +68,17 @@ export interface UseCoValueOptions<
   TSelectorReturn = MaybeLoaded<Loaded<S, R>>,
 > extends UseSubscriptionOptions<S, R>,
     UseSubscriptionSelectorOptions<S, R, TSelectorReturn> {}
+
+export interface CoValueRef<T> {
+  readonly current: T;
+}
+
+export type MaybeLoadedCoValueRef<T> =
+  | {
+      readonly $isLoaded: true;
+      readonly current: T;
+    }
+  | {
+      readonly $isLoaded: false;
+      readonly current: MaybeLoaded<T>;
+    };

--- a/packages/jazz-tools/src/react-core/utils.ts
+++ b/packages/jazz-tools/src/react-core/utils.ts
@@ -11,18 +11,3 @@ export function getCurrentAccountFromContextManager<Acc extends Account>(
 
   return "me" in context ? context.me : context.guest;
 }
-
-export function subscribeToContextManager<Acc extends Account>(
-  contextManager: JazzContextManager<Acc, any>,
-  callback: () => () => void,
-) {
-  let unsub = () => {};
-
-  const handler = () => {
-    unsub();
-    unsub = callback();
-  };
-
-  handler();
-  return contextManager.subscribe(handler);
-}

--- a/packages/jazz-tools/src/react-native-core/hooks.tsx
+++ b/packages/jazz-tools/src/react-native-core/hooks.tsx
@@ -19,6 +19,11 @@ export {
   useCoValueSubscription,
   useAccountSubscription,
   useSubscriptionSelector,
+  useCoValueRef,
+  useAccountRef,
+  useCoStateAndRef,
+  useAccountAndRef,
+  useSubscriptionRef,
 } from "jazz-tools/react-core";
 
 export function useAcceptInviteNative<S extends CoValueClassOrSchema>({

--- a/packages/jazz-tools/src/react-native-core/index.ts
+++ b/packages/jazz-tools/src/react-native-core/index.ts
@@ -8,6 +8,8 @@ export {
   createCoValueSubscriptionContext,
   createAccountSubscriptionContext,
   type CoValueSubscription,
+  type CoValueRef,
+  type MaybeLoadedCoValueRef,
 } from "jazz-tools/react-core";
 
 export { SQLiteDatabaseDriverAsync } from "cojson";

--- a/packages/jazz-tools/src/react/hooks.tsx
+++ b/packages/jazz-tools/src/react/hooks.tsx
@@ -4,8 +4,6 @@ import { useEffect } from "react";
 import { CoValueClassOrSchema } from "jazz-tools";
 import { useJazzContext } from "jazz-tools/react-core";
 
-export { useCoState, useAuthSecretStorage } from "jazz-tools/react-core";
-
 export function useAcceptInvite<S extends CoValueClassOrSchema>({
   invitedObjectSchema,
   onAccept,
@@ -49,11 +47,18 @@ export function useAcceptInvite<S extends CoValueClassOrSchema>({
 export {
   experimental_useInboxSender,
   useJazzContext,
+  useAuthSecretStorage,
   useAccount,
+  useCoState,
   useAgent,
   useLogOut,
   useSyncConnectionStatus,
   useCoValueSubscription,
   useAccountSubscription,
   useSubscriptionSelector,
+  useCoValueRef,
+  useAccountRef,
+  useCoStateAndRef,
+  useAccountAndRef,
+  useSubscriptionRef,
 } from "jazz-tools/react-core";

--- a/packages/jazz-tools/src/react/index.ts
+++ b/packages/jazz-tools/src/react/index.ts
@@ -1,24 +1,13 @@
 export { JazzReactProvider } from "./provider.js";
 export type { JazzProviderProps } from "./provider.js";
-export {
-  useAccount,
-  useCoState,
-  useAcceptInvite,
-  experimental_useInboxSender,
-  useJazzContext,
-  useAuthSecretStorage,
-  useAgent,
-  useLogOut,
-  useSyncConnectionStatus,
-  useCoValueSubscription,
-  useAccountSubscription,
-  useSubscriptionSelector,
-} from "./hooks.js";
+export * from "./hooks.js";
 
 export {
   createCoValueSubscriptionContext,
   createAccountSubscriptionContext,
   type CoValueSubscription,
+  type CoValueRef,
+  type MaybeLoadedCoValueRef,
 } from "jazz-tools/react-core";
 
 export { createInviteLink, parseInviteLink } from "jazz-tools/browser";

--- a/packages/jazz-tools/src/tools/subscribe/types.ts
+++ b/packages/jazz-tools/src/tools/subscribe/types.ts
@@ -26,6 +26,13 @@ export const CoValueLoadingState = {
   UNAVAILABLE: "unavailable",
 } as const;
 
+export namespace CoValueLoadingState {
+  export type LOADED = typeof CoValueLoadingState.LOADED;
+  export type LOADING = typeof CoValueLoadingState.LOADING;
+  export type UNAUTHORIZED = typeof CoValueLoadingState.UNAUTHORIZED;
+  export type UNAVAILABLE = typeof CoValueLoadingState.UNAVAILABLE;
+}
+
 export type CoValueLoadingState =
   (typeof CoValueLoadingState)[keyof typeof CoValueLoadingState];
 


### PR DESCRIPTION
I've been using my own version of this `useRef` pattern for a while now, and it has made a huge difference in the performance of our app.

In the updated music player example, you can see how much less data is being selected now.

Quick summary:
- Added the new hooks
- Refactored all the hooks to share as much code and types as possible
- Add `useRef` to `createCoValueSubscriptionContext` and `createAccountSubscriptionContext`
- Added the `passthroughNotLoaded` option for the providers to skip the fallback rendering logic. I found this is useful for cases where we want to load at the top level of our app something like the first or last value of a list, but still be able to handle empty lists.
- I've made `useCoStateAndRef` and `useAccountAndRef` return the ref with an extra $isLoaded assigned that can narrow the type of the ref. This is useful when wanting to pass the refs between components and not forcing the child components keep checking `if (xRef.current.$isLoaded) ...`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce ref-based hooks for non-reactive access to CoValues/accounts, add `useRef` to subscription contexts, update exports, and refactor the music-player example and tests to use the new APIs.
> 
> - **API (react-core/react/react-native)**
>   - Add hooks: `useCoValueRef`, `useAccountRef`, `useCoStateAndRef`, `useAccountAndRef`, and internal `useSubscriptionRef`.
>   - Expose `useRef` from `createCoValueSubscriptionContext` and `createAccountSubscriptionContext`.
>   - Refine selector utilities: `useSubscriptionSelector` updates; `identitySelector` helper.
>   - Export new types `CoValueRef`, `MaybeLoadedCoValueRef` and wire through `react` and `react-native` packages.
>   - Minor: add `CoValueLoadingState` namespace types; remove unused context util.
> - **Examples (music-player)**
>   - Replace `useCoState` usages with `useCoStateAndRef` and context `useAccountRef` to edit via refs without re-renders.
>   - Update components (`HomePage`, `EditPlaylistModal`, `MemberAccessModal`, `MusicTrackRow`, `MusicTrackTitleInput`, `PlaylistTitleInput`, `WelcomeScreen`, `SidePanel`, `AuthModal`, `PlayerControls`, `Waveform`) to use selectors and ids; pass refs instead of full objects.
>   - Add `shallowEqual` helper in `lib/utils` for selector equality.
>   - `AccountProvider` now exports `useAccountRef`.
> - **Tests**
>   - Add comprehensive tests for new hooks and contexts (`useCoValueRef`, `useAccountRef`, `useCoStateAndRef`, `useAccountAndRef`, subscription contexts, selector behavior); add `useRenderCount` test util.
> - **Changeset**
>   - Patch release for `jazz-tools` describing new hooks and provider `useRef`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ecf74832807b733b99e47025c0ed88d9176899fa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->