### PR TITLE
Refactor useFramework hook and update framework usage in components

### DIFF
--- a/homepage/homepage/components/SearchBoxWithResults.tsx
+++ b/homepage/homepage/components/SearchBoxWithResults.tsx
@@ -132,7 +132,7 @@ export function SearchBoxWithResults({ searchTerms }: { searchTerms: string }) {
   const [page, setPage] = useState(0);
   const [loading, setLoading] = useState(true);
   const [results, setResults] = useState<PagefindResult[]>([]);
-  const currentFramework = useFramework();
+  const { framework: currentFramework } = useFramework();
 
   useEffect(() => {
     async function loadPagefind() {

--- a/homepage/homepage/components/SideNavSection.tsx
+++ b/homepage/homepage/components/SideNavSection.tsx
@@ -14,7 +14,7 @@ export function SideNavSection({
   item: { name, href, collapse, items, prefix, startClosed },
 }: { item: SideNavItem }) {
   const path = usePathname();
-  const framework = useFramework();
+  const { framework } = useFramework();
 
   const isOpen = useMemo(() => {
     // Check if current path matches this section's href, and open if so

--- a/homepage/homepage/components/docs/ContentByFramework.tsx
+++ b/homepage/homepage/components/docs/ContentByFramework.tsx
@@ -21,7 +21,7 @@ export function ContentByFramework(props: {
   framework: string | string[];
   children: React.ReactNode;
 }) {
-  const framework = useFramework();
+  const { framework } = useFramework();
 
   if (framework == props.framework) {
     return props.children;

--- a/homepage/homepage/components/docs/DocsLayout.tsx
+++ b/homepage/homepage/components/docs/DocsLayout.tsx
@@ -49,7 +49,7 @@ export default function DocsLayout({
     });
   }
 
-  const framework = useFramework();
+  const { framework } = useFramework();
 
   let pagefindProps: {
     [key: `data-pagefind-${string}`]: string | boolean | number;

--- a/homepage/homepage/components/docs/Framework.tsx
+++ b/homepage/homepage/components/docs/Framework.tsx
@@ -4,7 +4,7 @@ import { frameworkNames } from "@/content/framework";
 import { useFramework } from "@/lib/use-framework";
 
 export function Framework() {
-  const framework = useFramework();
+  const { framework } = useFramework();
 
   return <>{frameworkNames[framework].label}</>;
 }

--- a/homepage/homepage/components/pagefind.tsx
+++ b/homepage/homepage/components/pagefind.tsx
@@ -171,7 +171,7 @@ export function PagefindSearch() {
   const [query, setQuery] = useState("");
   const [results, setResults] = useState<PagefindResult[]>([]);
   const listRef = useRef<HTMLDivElement>(null);
-  const currentFramework = useFramework();
+  const { framework: currentFramework } = useFramework();
   const pathname = usePathname();
 
   const close = () => {

--- a/homepage/homepage/content/docs/permissions-and-sharing/quickstart.mdx
+++ b/homepage/homepage/content/docs/permissions-and-sharing/quickstart.mdx
@@ -96,7 +96,7 @@ We're going to continue updating our existing `Festival` component so that it ca
   <FileName>src/lib/components/Festival.svelte</FileName>
 </ContentByFramework>
 
-<TabbedCodeGroup default="react" savedPreferenceKey="framework">
+<TabbedCodeGroup default="react" savedPreferenceKey="framework" id="festival-component">
 <TabbedCodeGroupItem icon={<ReactLogo />} label="React" value="react" preferWrap>
 ```tsx Festival.tsx
 ```
@@ -119,7 +119,7 @@ We'll also update our `NewBand` component so that it can take a prop for the fes
 </ContentByFramework>
 
 <TabbedCodeGroup default="react" savedPreferenceKey="framework"
->
+id="new-band-component">
 <TabbedCodeGroupItem label="React" value="react" icon={<ReactLogo />} preferWrap>
 ```tsx NewBand.tsx
 ```

--- a/homepage/homepage/lib/use-framework.ts
+++ b/homepage/homepage/lib/use-framework.ts
@@ -5,74 +5,146 @@ import {
   isValidFramework,
 } from "@/content/framework";
 import { useParams, usePathname, useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback } from "react";
 import {
   TAB_CHANGE_EVENT,
   isFrameworkChange,
 } from "@garden-co/design-system/src/types/tabbed-code-group";
 
-// Global tracking to prevent multiple simultaneous redirects
-// (since useFramework is called by multiple components on the same page)
+// Keep these module level to avoid all components on the page which depend on useFramework from triggering new redirects
 let isRedirecting = false;
-let lastRedirectedTo = "";
+let userInitiatedChange = false;
+let lastRedirectedFramework: Framework | null = null;
+
+/* 
+ * This hook does the following:
+ * 1. Lazily initialises the user's preferred framework from localStorage
+ * 2. Defines a `setFramework` function which updates the framework in storage 
+ *    and dispatches a `TAB_CHANGE_EVENT` 
+ * 3. Looks up whether the URL specifies a framework
+ * 4. Registers an event listener for the `TAB_CHANGE_EVENT` emitted from a 
+ *    TabbedCodeGroup
+ * 5. Builds an appropriate URL to redirect to, and completes the redirect.
+ */
 
 export const useFramework = () => {
   const pathname = usePathname();
   const { framework } = useParams<{ framework?: string }>();
-  const [savedFramework, setSavedFramework] = useState<Framework | null>(null);
-  const [mounted, setMounted] = useState(false);
+  const [savedFramework, setSavedFramework] = useState<Framework | null>(() => {
+    if (typeof window === "undefined") return null;
+    const stored = localStorage.getItem("_tcgpref_framework");
+    if (stored && isValidFramework(stored)) {
+      return stored;
+    }
+    return null;
+  });
   const router = useRouter();
 
-  useEffect(() => {
-    setMounted(true);
-    // Check localStorage after mounting
-    if (typeof window !== "undefined") {
-      const stored = window.localStorage.getItem("_tcgpref_framework");
-      if (stored && isValidFramework(stored)) {
-        setSavedFramework(stored as Framework);
-      }
-    }
+  const setFramework = useCallback((newFramework: Framework) => {
+    if (!isValidFramework(newFramework)) return;
+    userInitiatedChange = true;
+    localStorage.setItem("_tcgpref_framework", newFramework);
+    setSavedFramework(newFramework);
+    window.dispatchEvent(
+      new CustomEvent(TAB_CHANGE_EVENT, {
+        detail: {
+          key: "framework",
+          value: newFramework,
+        },
+      }),
+    );
   }, []);
+
+  const urlFramework = framework && isValidFramework(framework) ? framework : null;
 
   useEffect(() => {
     const handleTabChange = (event: CustomEvent) => {
       if (isFrameworkChange(event.detail)) {
         const newFramework = event.detail.value;
         if (isValidFramework(newFramework)) {
-          setSavedFramework(newFramework as Framework);
+          userInitiatedChange = true;
+          setSavedFramework(newFramework);
         }
       }
     };
-    window.addEventListener(TAB_CHANGE_EVENT as any, handleTabChange);
+    window.addEventListener(TAB_CHANGE_EVENT, handleTabChange);
     return () =>
-      window.removeEventListener(TAB_CHANGE_EVENT as any, handleTabChange);
+      window.removeEventListener(TAB_CHANGE_EVENT, handleTabChange);
   }, []);
 
+
   useEffect(() => {
-    if (!mounted || !savedFramework || !pathname.startsWith("/docs")) return;
+    if (!pathname.startsWith("/docs") || isRedirecting) return;
 
-    const parts = pathname.split("/");
-    const newPath = parts.toSpliced(2, 1, savedFramework).join("/");
+    // Trigger this block only once after the user changes framework to update
+    // to match user's choice
+    if (userInitiatedChange) {
+      userInitiatedChange = false;
+      if (!savedFramework) return;
 
-    // Don't redirect if already redirecting or if we just redirected to this path
-    if (isRedirecting || lastRedirectedTo === newPath) return;
+      const parts = pathname.split("/");
+      if (parts.length >= 3 && parts[2] === savedFramework) return;
 
-    if (parts[2] !== savedFramework) {
+      parts[2] = savedFramework;
+      const newPath = parts.join("/");
+      lastRedirectedFramework = savedFramework;
+
       isRedirecting = true;
-      lastRedirectedTo = newPath;
       router.replace(newPath, { scroll: false });
-      // Reset the flag after navigation completes
+
       const timeout = setTimeout(() => {
         isRedirecting = false;
+        lastRedirectedFramework = null;
       }, 200);
+
       return () => {
         clearTimeout(timeout);
         isRedirecting = false;
+        lastRedirectedFramework = null;
       };
     }
-  }, [mounted, savedFramework, pathname, router]);
 
-  if (mounted && savedFramework) return savedFramework;
-  if (framework && isValidFramework(framework)) return framework;
-  return DEFAULT_FRAMEWORK;
+    if (urlFramework) {
+      // Exit early if the redirect has *just* happened
+      if (lastRedirectedFramework === urlFramework) {
+        lastRedirectedFramework = null;
+        return;
+      }
+      // Otherwise update localStorage and the saved framework (manually, not 
+      // using the helper otherwise we'll trigger a new loop)
+      localStorage.setItem("_tcgpref_framework", urlFramework);
+      setSavedFramework(urlFramework);
+      return;
+    }
+
+    const parts = pathname.split("/");
+
+    // Race condition guard in case effect runs before `useParams` updates
+    if (parts.length >= 3 && parts[2] === savedFramework) return;
+
+    // And if not, update the framework and rebuild the URL—if users have no preference and no indication in URL, just use React
+    parts[2] = savedFramework || DEFAULT_FRAMEWORK;
+    const newPath = parts.join("/");
+
+    // Tell everyone not to trigger cascading updates
+    isRedirecting = true;
+    // and update the URL
+    router.replace(newPath, { scroll: false });
+
+    // Let the change settle, then tell everyone we're free to update the URL
+    // again
+    const timeout = setTimeout(() => {
+      isRedirecting = false;
+    }, 200);
+
+    // Clean up
+    return () => {
+      clearTimeout(timeout);
+      isRedirecting = false;
+    };
+  }, [pathname, urlFramework, savedFramework, router]);
+
+  const currentFramework = urlFramework || savedFramework || DEFAULT_FRAMEWORK;
+
+  return { framework: currentFramework, setFramework };
 };


### PR DESCRIPTION
# Description
- Refactored and simplified the useFramework hook to make it easier to reason about
- Consolidated framework updating logic in the hook
- Added a bunch of comments to help track logic
- Updated dependents with new API

## Manual testing instructions

Check that:
1. Changing the framework changes the URL
2. Codegroups update to show the correct framework
3. Select Framework A in the dropdown, the navigate directly to URL for framework B. Access the URL again with no framework (you should see Framework B's docs as preference should be updated)
## Tests

- [ ] Tests have been added and/or updated
- [ ] Tests have not been updated, because: <!-- Insert reason for not updating tests here -->
- [ ] I need help with writing tests


## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [ ] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing