### PR TITLE
feat: create CoVectors using plain JS objects

### DIFF
--- a/.changeset/big-cats-pull.md
+++ b/.changeset/big-cats-pull.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Support creating CoVectors using plain `number[]` or `Float32Array` objects inside CoValue containers

--- a/packages/jazz-tools/src/tools/coValues/CoFieldInit.ts
+++ b/packages/jazz-tools/src/tools/coValues/CoFieldInit.ts
@@ -3,6 +3,7 @@ import { CoList } from "./coList.js";
 import { CoMap, CoMapInit } from "./coMap.js";
 import { CoPlainText } from "./coPlainText.js";
 import { CoRichText } from "./coRichText.js";
+import { CoVector } from "./coVector.js";
 
 /**
  * Returns the type of values that can be used to initialize a field of the provided type.
@@ -15,6 +16,8 @@ export type CoFieldInit<V> = V extends CoMap
   ? V | CoMapInit<V>
   : V extends CoList<infer T> | CoFeed<infer T>
     ? V | ReadonlyArray<CoFieldInit<T>>
-    : V extends CoPlainText | CoRichText
-      ? V | string
-      : V;
+    : V extends CoVector | Readonly<CoVector>
+      ? V | ReadonlyArray<number> | Float32Array
+      : V extends CoPlainText | CoRichText
+        ? V | string
+        : V;

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/CoFieldSchemaInit.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/CoFieldSchemaInit.ts
@@ -5,6 +5,7 @@ import {
   CoreCoListSchema,
   CoreCoMapSchema,
   CoreCoRecordSchema,
+  CoreCoVectorSchema,
   CorePlainTextSchema,
   Simplify,
 } from "../../../internal.js";
@@ -33,13 +34,15 @@ export type CoFieldSchemaInit<S extends CoValueClass | AnyZodOrCoValueSchema> =
                 ? CoListSchemaInit<T>
                 : S extends CoreCoFeedSchema<infer T>
                   ? CoFeedSchemaInit<T>
-                  : S extends CorePlainTextSchema | CoreRichTextSchema
-                    ? string
-                    : S extends CoreCoOptionalSchema<infer T>
-                      ? CoFieldSchemaInit<T> | undefined
-                      : S extends CoDiscriminatedUnionSchema<infer Members>
-                        ? CoFieldSchemaInit<Members[number]>
-                        : never)
+                  : S extends CoreCoVectorSchema
+                    ? CoVectorSchemaInit
+                    : S extends CorePlainTextSchema | CoreRichTextSchema
+                      ? string
+                      : S extends CoreCoOptionalSchema<infer T>
+                        ? CoFieldSchemaInit<T> | undefined
+                        : S extends CoDiscriminatedUnionSchema<infer Members>
+                          ? CoFieldSchemaInit<Members[number]>
+                          : never)
     : S extends z.core.$ZodType
       ? TypeOfZodSchema<S>
       : S extends CoValueClass
@@ -75,6 +78,8 @@ export type CoListSchemaInit<T extends AnyZodOrCoValueSchema> = Simplify<
 export type CoFeedSchemaInit<T extends AnyZodOrCoValueSchema> = Simplify<
   ReadonlyArray<CoFieldSchemaInit<T>>
 >;
+
+export type CoVectorSchemaInit = ReadonlyArray<number> | Float32Array;
 
 /**
  * The convenience type for extracting the init type of a CoValue schema.

--- a/packages/jazz-tools/src/tools/tests/coVector.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coVector.test.ts
@@ -112,6 +112,49 @@ describe("Creating a CoVector", async () => {
 
     expect(embedding.$jazz.owner).toEqual(group);
   });
+
+  describe("nested inside a container CoValue", async () => {
+    test("from an array of numbers", () => {
+      const VectorMap = co.map({
+        embedding: EmbeddingSchema,
+      });
+
+      const container = VectorMap.create({
+        embedding: [1, 2, 3],
+      });
+
+      expect(container.embedding).toBeInstanceOf(CoVector);
+      expect(Array.from(container.embedding)).toEqual([1, 2, 3]);
+      const vectorOwner = container.embedding.$jazz.owner;
+      expect(
+        vectorOwner.getParentGroups().map((group) => group.$jazz.id),
+      ).toContain(container.$jazz.owner.$jazz.id);
+
+      container.$jazz.set("embedding", [4, 5, 6]);
+      expect(Array.from(container.embedding)).toEqual([4, 5, 6]);
+    });
+
+    test("from a Float32Array", () => {
+      const VectorList = co.list(EmbeddingSchema);
+
+      const list = VectorList.create([new Float32Array([1, 2, 3])]);
+
+      const vector = list[0];
+      assert(vector);
+      expect(vector).toBeInstanceOf(CoVector);
+      expect(Array.from(vector)).toEqual([1, 2, 3]);
+      const vectorOwner = vector.$jazz.owner;
+      expect(
+        vectorOwner.getParentGroups().map((group) => group.$jazz.id),
+      ).toContain(list.$jazz.owner.$jazz.id);
+
+      list.$jazz.push(new Float32Array([4, 5, 6]));
+
+      const vector2 = list[1];
+      assert(vector2);
+      expect(Array.from(vector2)).toEqual([4, 5, 6]);
+    });
+  });
 });
 
 describe("CoVector structure", async () => {


### PR DESCRIPTION
# Description

Extends https://github.com/garden-co/jazz/pull/2683 to support creating CoVectors using plain `number[]` or `Float32Array` objects inside CoValue containers:

```ts
const VectorMap = co.map({
  embedding: EmbeddingSchema,
});

// Before
const container = VectorMap.create({
  embedding: CoVector.create([1, 2, 3]),
});

// After
const container = VectorMap.create({
  embedding: [1, 2, 3],
});
```

## Tests

- [x] Tests have been added and/or updated

## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [x] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing