### PR TITLE
Fix homepage build issues

### DIFF
--- a/homepage/homepage/content/docs/code-snippets/core-concepts/covalues/imagedef/rn.tsx
+++ b/homepage/homepage/content/docs/code-snippets/core-concepts/covalues/imagedef/rn.tsx
@@ -29,10 +29,15 @@ async function handleImagePicker() {
     quality: 1,
   });
 
-  if (!result.didCancel && result.assets && result.assets.length > 0 && me.profile.$isLoaded) {
+  if (
+    !result.didCancel &&
+    result.assets &&
+    result.assets.length > 0 &&
+    me.profile.$isLoaded
+  ) {
     // Creates ImageDefinition with a blurry placeholder, limited to 1024px on the longest side, and multiple resolutions automatically.
     // See the options below for more details.
-    const image = await createImage(result.assets[0].uri, {
+    const image = await createImage(result.assets[0].uri ?? "", {
       owner: me.$jazz.owner,
       maxSize: 1024,
       placeholder: "blur",

--- a/homepage/homepage/content/docs/code-snippets/core-concepts/covalues/imagedef/rn.tsx
+++ b/homepage/homepage/content/docs/code-snippets/core-concepts/covalues/imagedef/rn.tsx
@@ -19,7 +19,6 @@ await me.$jazz.ensureLoaded({
 
 // #region Basic
 import { createImage } from "jazz-tools/media";
-// @ts-expect-error Don't want to install, I'm OK with any typing.
 import { launchImageLibrary } from "react-native-image-picker";
 
 async function handleImagePicker() {


### PR DESCRIPTION
# Description
Homepage builds are failing since merging 3178 but 3178 built successfully in preview: https://vercel.com/gcmp/jazz-homepage/4GFURBFsp8apUe3zuKqcnKDyCyKW

I still don't know why the `// @ts-expect-error` is causing issues on Vercel but not locally (in fact, the opposite), but this will unblock homepage builds while I work it out.

## Manual testing instructions

Check the homepage builds in production.

## Tests

- [ ] Tests have been added and/or updated
- [ ] Tests have not been updated, because: <!-- Insert reason for not updating tests here -->
- [ ] I need help with writing tests


## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [ ] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing