### PR TITLE
[Inspector] show invalid transactions if invalid read key

### DIFF
--- a/.changeset/fine-webs-divide.md
+++ b/.changeset/fine-webs-divide.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Show invalid transaction in inspector even if they are not decryptable

--- a/packages/jazz-tools/src/inspector/viewer/history-view.tsx
+++ b/packages/jazz-tools/src/inspector/viewer/history-view.tsx
@@ -115,7 +115,9 @@ function getTransactionChanges(
   if (tx.isValid === false && tx.tx.privacy === "private") {
     const readKey = coValue.core.getReadKey(tx.tx.keyUsed);
     if (!readKey) {
-      throw new Error("Read key not found");
+      return [
+        `Unable to decrypt transaction: read key ${tx.tx.keyUsed} not found.`,
+      ];
     }
 
     return (


### PR DESCRIPTION
## Before
<img width="2035" height="788" alt="immagine" src="https://github.com/user-attachments/assets/a2091712-1081-451f-8376-cd95072d5ff6" />

## After
<img width="1205" height="399" alt="image" src="https://github.com/user-attachments/assets/35eb2e68-60f3-4dfe-acc1-28c5caa6f3ad" />

## Manual testing instructions

Remove somehow the readkey for a transaction.

## Tests

- [x] I need help with writing tests: I had no success breaking the readkey of a covalue 


## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [x] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing