### PR TITLE
perf: optimize CoValue creation by caching schema->coField transforms

### DIFF
--- a/.changeset/beige-ghosts-turn.md
+++ b/.changeset/beige-ghosts-turn.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Optimize CoValue creation by caching schema->coField transformations


### PR DESCRIPTION
# Description

We were previously converting CoValue schemas into coField definitions on each CoValue container creation (i.e. for CoMaps, CoLists and CoFeeds). This PR caches the result of computing the coField definition to avoid unnecessary recomputations.

## Tests

- [x] Tests have not been updated, because: this is a performance improvement. It causes no regressions on existing tests.

## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [x] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing