### PR TITLE
Fix issue when code sample is formatted

### DIFF
--- a/homepage/homepage/content/docs/code-snippets/permissions-and-sharing/sharing/create-invite-link.svelte.ts
+++ b/homepage/homepage/content/docs/code-snippets/permissions-and-sharing/sharing/create-invite-link.svelte.ts
@@ -1,10 +1,11 @@
-//[!code hide]
 import { Organization } from "./schema";
-//[!code hide]
 const organization = Organization.create({
   name: "Garden Computing",
   projects: [],
 });
+
+// #region Basic
 import { createInviteLink } from "jazz-tools/svelte";
 
 const inviteLink = createInviteLink(organization, "writer");
+// #endregion

--- a/homepage/homepage/content/docs/code-snippets/permissions-and-sharing/sharing/create-invite-link.svelte.ts
+++ b/homepage/homepage/content/docs/code-snippets/permissions-and-sharing/sharing/create-invite-link.svelte.ts
@@ -6,6 +6,5 @@ const organization = Organization.create({
 
 // #region Basic
 import { createInviteLink } from "jazz-tools/svelte";
-
 const inviteLink = createInviteLink(organization, "writer");
 // #endregion

--- a/homepage/homepage/content/docs/permissions-and-sharing/sharing.mdx
+++ b/homepage/homepage/content/docs/permissions-and-sharing/sharing.mdx
@@ -46,7 +46,7 @@ This is used in the [todo example](https://github.com/garden-co/jazz/tree/main/e
   ```
   </TabbedCodeGroupItem>
   <TabbedCodeGroupItem icon={<SvelteLogo />} label="Svelte" value="svelte" preferWrap>
-  ```ts create-invite-link.svelte.ts
+  ```ts create-invite-link.svelte.ts#Basic
   ```
   </TabbedCodeGroupItem>
   <TabbedCodeGroupItem icon={<RNLogo />} label="React Native" value="react-native" preferWrap>


### PR DESCRIPTION
# Description
Minor fix to svelte permissions docs: // [!code hide] only hides the first line of a multi-line expression

## Manual testing instructions

Check the first code sample under Permissions & Sharing / Sharing # Invites (Svelte)

## Tests

- [ ] Tests have been added and/or updated
- [x] Tests have not been updated, because: N/A
- [ ] I need help with writing tests


## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [ ] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing