### PR TITLE
[Inspector] coplaintext history improved

### DIFF
--- a/.changeset/nice-badgers-wave.md
+++ b/.changeset/nice-badgers-wave.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Improved readability for CoPlainText's history in inspector

--- a/.changeset/twenty-wolves-serve.md
+++ b/.changeset/twenty-wolves-serve.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Inline edit for CoPlainTexts in inspector

--- a/packages/cojson/src/coValues/coPlainText.ts
+++ b/packages/cojson/src/coValues/coPlainText.ts
@@ -55,8 +55,8 @@ export class RawCoPlainText<
     PlaintextIdxMapping
   >;
 
-  constructor(core: AvailableCoValueCore) {
-    super(core);
+  constructor(core: AvailableCoValueCore, atTimeFilter?: number) {
+    super(core, atTimeFilter);
     this._cachedMapping = new WeakMap();
   }
 
@@ -95,6 +95,10 @@ export class RawCoPlainText<
     return this.entries()
       .map((entry) => entry.value)
       .join("");
+  }
+
+  atTime(time: number): this {
+    return new RawCoPlainText(this.core, time) as this;
   }
 
   /**

--- a/packages/jazz-tools/src/inspector/tests/utils/history.test.ts
+++ b/packages/jazz-tools/src/inspector/tests/utils/history.test.ts
@@ -403,7 +403,7 @@ describe("restoreCoMapToTimestamp", async () => {
 });
 
 describe("getTransactionChanges", async () => {
-  const account = await setupJazzTestSync();
+  const account = await createJazzTestAccount();
 
   describe("CoMap transactions", () => {
     it("should return changes for CoMap transactions", async () => {

--- a/packages/jazz-tools/src/inspector/tests/utils/history.test.ts
+++ b/packages/jazz-tools/src/inspector/tests/utils/history.test.ts
@@ -1,9 +1,11 @@
 import { assert, describe, expect, it } from "vitest";
 import { createJazzTestAccount, setupJazzTestSync } from "jazz-tools/testing";
 import { co, z } from "jazz-tools";
-import { restoreCoMapToTimestamp } from "../../utils/history";
+import {
+  getTransactionChanges,
+  restoreCoMapToTimestamp,
+} from "../../utils/history";
 import { JsonObject } from "cojson";
-import { loadCoValueOrFail, waitFor } from "../../../tools/tests/utils";
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -397,5 +399,234 @@ describe("restoreCoMapToTimestamp", async () => {
     restoreCoMapToTimestamp(valueOnReader.$jazz.raw, initialTimestamp, false);
 
     expect(valueOnReader.pet).toBe("cat");
+  });
+});
+
+describe("getTransactionChanges", async () => {
+  const account = await setupJazzTestSync();
+
+  describe("CoMap transactions", () => {
+    it("should return changes for CoMap transactions", async () => {
+      const value = co
+        .map({
+          pet: z.string(),
+        })
+        .create({ pet: "dog" }, account);
+
+      await sleep(2);
+      value.$jazz.set("pet", "cat");
+
+      const transactions = value.$jazz.raw.core.verifiedTransactions;
+      const firstTx = transactions[0]!;
+      const secondTx = transactions[1]!;
+
+      const firstChanges = getTransactionChanges(firstTx, value.$jazz.raw);
+      const secondChanges = getTransactionChanges(secondTx, value.$jazz.raw);
+
+      expect(firstChanges.length).toBeGreaterThan(0);
+      expect(secondChanges.length).toBeGreaterThan(0);
+      expect(firstChanges[0]).toHaveProperty("op", "set");
+      expect(secondChanges[0]).toHaveProperty("op", "set");
+    });
+
+    it("should return empty array for transactions with no changes", async () => {
+      const value = co.map({}).create({}, account);
+
+      const transactions = value.$jazz.raw.core.verifiedTransactions;
+      const firstTx = transactions[0]!;
+
+      const changes = getTransactionChanges(firstTx, value.$jazz.raw);
+
+      expect(Array.isArray(changes)).toBe(true);
+    });
+  });
+
+  describe("CoPlainText transactions", () => {
+    it("should collapse multiple append operations into one", async () => {
+      const value = co.plainText().create("hello", account);
+
+      const transactions = value.$jazz.raw.core.verifiedTransactions;
+      const firstTx = transactions[0]!;
+
+      const changes = getTransactionChanges(firstTx, value.$jazz.raw);
+
+      expect(changes.length).toBe(1);
+      expect(changes).toEqual([
+        {
+          op: "app",
+          value: "hello",
+          after: "start",
+        },
+      ]);
+    });
+
+    it("should collapse multiple append operations after a specific position", async () => {
+      const value = co.plainText().create("hello", account);
+      await sleep(2);
+      value.$jazz.applyDiff("hello world");
+
+      const transactions = value.$jazz.raw.core.verifiedTransactions;
+      const secondTx = transactions[1]!;
+
+      const changes = getTransactionChanges(secondTx, value.$jazz.raw);
+
+      expect(changes.length).toBe(1);
+      expect(changes[0]).toHaveProperty("op", "app");
+      expect(changes[0]).toHaveProperty("value");
+      expect(changes[0]).toHaveProperty("after");
+    });
+
+    it("should collapse multiple prepend operations into one", async () => {
+      const value = co.plainText().create("world", account);
+      await sleep(2);
+      value.insertBefore(0, "Hello, ");
+
+      const transactions = value.$jazz.raw.core.verifiedTransactions;
+      expect(transactions).toHaveLength(3);
+
+      const changes1 = getTransactionChanges(transactions[1]!, value.$jazz.raw);
+
+      expect(changes1).toEqual([
+        {
+          op: "pre",
+          value: "H",
+          before: expect.objectContaining({}),
+        },
+      ]);
+      const changes2 = getTransactionChanges(transactions[2]!, value.$jazz.raw);
+
+      expect(changes2).toEqual([
+        {
+          op: "app",
+          value: "ello, ",
+          after: expect.objectContaining({}),
+        },
+      ]);
+    });
+
+    it("should collapse consecutive deletions into grouped deletions", async () => {
+      const value = co.plainText().create("hello", account);
+      await sleep(2);
+      value.$jazz.applyDiff("hello world");
+      await sleep(2);
+      value.$jazz.applyDiff("hed");
+
+      const transactions = value.$jazz.raw.core.verifiedTransactions;
+      const deletionTx = transactions.find((tx) =>
+        tx.changes?.some((c: any) => c.op === "del"),
+      );
+
+      assert(deletionTx);
+
+      const changes = getTransactionChanges(deletionTx, value.$jazz.raw);
+
+      expect(changes).toEqual([
+        {
+          action: '"lo " has been deleted',
+          op: "custom",
+        },
+        {
+          action: '"dlrow" has been deleted',
+          op: "custom",
+        },
+      ]);
+    });
+
+    it("should handle single deletion", async () => {
+      const value = co.plainText().create("hello", account);
+      await sleep(2);
+      value.$jazz.applyDiff("hell");
+
+      const transactions = value.$jazz.raw.core.verifiedTransactions;
+      const deletionTx = transactions.find((tx) =>
+        tx.changes?.some((c: any) => c.op === "del"),
+      );
+
+      assert(deletionTx);
+
+      const changes = getTransactionChanges(deletionTx, value.$jazz.raw);
+      expect(changes).toEqual([
+        {
+          op: "del",
+          insertion: expect.objectContaining({}),
+        },
+      ]);
+    });
+  });
+
+  it("should return error message when read key is not found", async () => {
+    const group = co.group().create({ owner: account });
+    const account2 = await createJazzTestAccount();
+    group.addMember(account2, "reader");
+
+    const value = co
+      .map({
+        secret: z.string(),
+      })
+      .create({ secret: "hidden" }, group);
+
+    const valueOnReader = await co
+      .map({
+        secret: z.string(),
+      })
+      .load(value.$jazz.id, { loadAs: account2 });
+
+    assert(valueOnReader.$isLoaded);
+
+    const transactions = valueOnReader.$jazz.raw.core.verifiedTransactions;
+    const privateTx = transactions.find(
+      (tx) => tx.tx.privacy === "private" && tx.isValid === false,
+    );
+
+    if (privateTx) {
+      const changes = getTransactionChanges(privateTx, valueOnReader.$jazz.raw);
+
+      if (typeof changes[0] === "string") {
+        expect(changes[0]).toContain("Unable to decrypt transaction");
+      }
+    }
+  });
+
+  it("should decrypt transaction when read key is available", async () => {
+    const group = co.group().create({ owner: account });
+    const account2 = await createJazzTestAccount();
+    group.addMember(account2, "writer");
+
+    const value = co
+      .map({
+        secret: z.string(),
+      })
+      .create({ secret: "hidden" }, group);
+
+    const valueOnWriter = await co
+      .map({
+        secret: z.string(),
+      })
+      .load(value.$jazz.id, { loadAs: account2 });
+
+    assert(valueOnWriter.$isLoaded);
+
+    const transactions = valueOnWriter.$jazz.raw.core.verifiedTransactions;
+    const privateTx = transactions.find((tx) => tx.tx.privacy === "private");
+
+    if (privateTx) {
+      const changes = getTransactionChanges(privateTx, valueOnWriter.$jazz.raw);
+
+      expect(Array.isArray(changes)).toBe(true);
+      if (changes.length > 0 && typeof changes[0] !== "string") {
+        expect(changes[0]).toHaveProperty("op");
+      }
+    }
+  });
+
+  it("should handle transactions with undefined changes", async () => {
+    const value = co.map({}).create({}, account);
+
+    const transactions = value.$jazz.raw.core.verifiedTransactions;
+    const firstTx = transactions[0]!;
+
+    const changes = getTransactionChanges(firstTx, value.$jazz.raw);
+
+    expect(changes).toEqual([]);
   });
 });

--- a/packages/jazz-tools/src/inspector/tests/viewer/co-plain-text-view.test.tsx
+++ b/packages/jazz-tools/src/inspector/tests/viewer/co-plain-text-view.test.tsx
@@ -1,0 +1,125 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { setActiveAccount, setupJazzTestSync } from "jazz-tools/testing";
+import { co } from "jazz-tools";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { CoPlainTextView } from "../../viewer/co-plain-text-view";
+import { setup } from "goober";
+import React from "react";
+import { CoID, JsonObject, RawCoPlainText, RawCoValue } from "cojson";
+import { createJazzTestAccount } from "jazz-tools/testing";
+import { loadCoValueOrFail } from "../../../tools/tests/utils";
+
+describe("CoPlainTextView", async () => {
+  const account = await setupJazzTestSync();
+  setActiveAccount(account);
+
+  beforeAll(() => {
+    setup(React.createElement);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe("Edit", () => {
+    it("should show edit button when user has write permissions", async () => {
+      const value = co.plainText().create("Hello", account);
+      const data = value.$jazz.raw.toJSON() as unknown as JsonObject;
+
+      render(
+        <CoPlainTextView
+          data={data}
+          coValue={value.$jazz.raw}
+          node={account.$jazz.localNode}
+        />,
+      );
+
+      // The edit button contains an Icon (SVG), so we look for buttons containing SVG
+      expect(screen.getByTitle("Edit")).toBeDefined();
+    });
+
+    it("should not show edit button when user does not have write permissions", async () => {
+      // Create a new account without write permissions
+      const readOnlyAccount = await createJazzTestAccount();
+      const group = co.group().create({ owner: account });
+      group.addMember(readOnlyAccount, "reader");
+
+      const value = co.plainText().create("Hello", group);
+
+      const valueOnReader = await loadCoValueOrFail(
+        readOnlyAccount.$jazz.localNode,
+        value.$jazz.id as CoID<RawCoValue>,
+      );
+      const data = valueOnReader.toJSON() as unknown as JsonObject;
+
+      render(
+        <CoPlainTextView
+          data={data}
+          coValue={valueOnReader as RawCoPlainText}
+          node={readOnlyAccount.$jazz.localNode}
+        />,
+      );
+
+      // Should not have edit button (no buttons with SVG icons)
+      expect(screen.queryByTitle("Edit")).toBeNull();
+    });
+
+    it("should open edit mode when edit button is clicked", async () => {
+      const value = co.plainText().create("Hello, world!", account);
+      const data = value.$jazz.raw.toJSON() as unknown as JsonObject;
+
+      render(
+        <CoPlainTextView
+          data={data}
+          coValue={value.$jazz.raw}
+          node={account.$jazz.localNode}
+        />,
+      );
+
+      const editButton = screen.getByTitle("Edit");
+      expect(editButton).toBeDefined();
+
+      fireEvent.click(editButton);
+
+      await waitFor(() => {
+        const textarea = screen.getByRole("textbox");
+        expect(textarea).toBeDefined();
+        expect((textarea as HTMLTextAreaElement).value).toBe("Hello, world!");
+      });
+
+      expect(screen.getByText("Cancel")).toBeDefined();
+      expect(screen.getByText("Save")).toBeDefined();
+    });
+
+    it("should save changes when save button is clicked", async () => {
+      const value = co.plainText().create("Original", account);
+      const data = value.$jazz.raw.toJSON() as unknown as JsonObject;
+
+      render(
+        <CoPlainTextView
+          data={data}
+          coValue={value.$jazz.raw}
+          node={account.$jazz.localNode}
+        />,
+      );
+
+      const editButton = screen.getByTitle("Edit");
+      fireEvent.click(editButton);
+
+      await waitFor(() => {
+        const textarea = screen.getByRole("textbox");
+        fireEvent.change(textarea, { target: { value: "Updated text" } });
+      });
+
+      const saveButton = screen.getByText("Save");
+      fireEvent.click(saveButton);
+    });
+  });
+});

--- a/packages/jazz-tools/src/inspector/utils/history.ts
+++ b/packages/jazz-tools/src/inspector/utils/history.ts
@@ -1,5 +1,172 @@
-import type { JsonObject, JsonValue, RawCoMap, Role } from "cojson";
+import type {
+  JsonObject,
+  JsonValue,
+  OpID,
+  RawCoMap,
+  RawCoPlainText,
+  RawCoValue,
+  Role,
+} from "cojson";
+import { stringifyOpID } from "cojson";
+import type { VerifiedTransaction } from "cojson/dist/coValueCore/coValueCore.js";
 import type { MapOpPayload } from "cojson/dist/coValues/coMap.js";
+import * as TransactionChanges from "./transactions-changes";
+import type {
+  DeletionOpPayload,
+  InsertionOpPayload,
+} from "cojson/dist/coValues/coList.js";
+
+export function areSameOpIds(
+  opId1: OpID | string,
+  opId2: OpID | string,
+): boolean {
+  if (typeof opId1 === "string" || typeof opId2 === "string") {
+    return opId1 === opId2;
+  }
+
+  return (
+    opId1.sessionID === opId2.sessionID &&
+    opId1.txIndex === opId2.txIndex &&
+    opId1.changeIdx === opId2.changeIdx
+  );
+}
+
+export function isCoPlainText(coValue: RawCoValue): coValue is RawCoPlainText {
+  return coValue.type === "coplaintext";
+}
+
+export function getTransactionChanges(
+  tx: VerifiedTransaction,
+  coValue: RawCoValue,
+): JsonValue[] {
+  if (tx.isValid === false && tx.tx.privacy === "private") {
+    const readKey = coValue.core.getReadKey(tx.tx.keyUsed);
+    if (!readKey) {
+      return [
+        `Unable to decrypt transaction: read key ${tx.tx.keyUsed} not found.`,
+      ];
+    }
+
+    return (
+      coValue.core.verified.decryptTransaction(
+        tx.txID.sessionID,
+        tx.txID.txIndex,
+        readKey,
+      ) ?? []
+    );
+  }
+
+  // Trying to collapse multiple changes into a single action in the history
+  if (isCoPlainText(coValue)) {
+    if (tx.changes === undefined || tx.changes.length === 0) return [];
+    const firstChange = tx.changes[0]!;
+
+    if (
+      TransactionChanges.isItemAppend(firstChange) &&
+      tx.changes.every(
+        (c) =>
+          TransactionChanges.isItemAppend(c) &&
+          areSameOpIds(c.after, firstChange.after),
+      )
+    ) {
+      const changes = tx.changes as InsertionOpPayload<string>[];
+      if (firstChange.after !== "start") {
+        changes.reverse();
+      }
+
+      return [
+        {
+          op: "app",
+          value: changes.map((c) => c.value).join(""),
+          after: firstChange.after,
+        },
+      ];
+    }
+
+    if (
+      TransactionChanges.isItemPrepend(firstChange) &&
+      tx.changes.every(
+        (c) =>
+          TransactionChanges.isItemPrepend(c) &&
+          areSameOpIds(c.before, firstChange.before),
+      )
+    ) {
+      const changes = tx.changes as InsertionOpPayload<string>[];
+      if (firstChange.before !== "end") {
+        changes.reverse();
+      }
+
+      return [
+        {
+          op: "pre",
+          value: changes.map((c) => c.value).join(""),
+          before: firstChange.before,
+        },
+      ];
+    }
+
+    if (
+      TransactionChanges.isItemDeletion(firstChange) &&
+      tx.changes.every((c) => TransactionChanges.isItemDeletion(c))
+    ) {
+      const coValueBeforeDeletions = coValue.atTime(tx.madeAt - 1);
+
+      // Verify if the deleted chars are consecutive
+      function changesAreConsecutive(changes: DeletionOpPayload[]): boolean {
+        if (changes.length < 2) return false;
+        const mapping = coValueBeforeDeletions.mapping.idxAfterOpID;
+
+        for (let i = 1; i < changes.length; ++i) {
+          const prevIdx = mapping[stringifyOpID(changes[i - 1]!.insertion)];
+          const currIdx = mapping[stringifyOpID(changes[i]!.insertion)];
+          if (currIdx !== prevIdx && currIdx !== (prevIdx ?? -2) + 1) {
+            return false;
+          }
+        }
+        return true;
+      }
+
+      if (changesAreConsecutive(tx.changes)) {
+        // Group the deletions by insertion.sessionID-txIndex
+        // This is to help the readability of deletions that act on different previous transactions
+        const groupedBySession: Map<string, DeletionOpPayload[]> = new Map();
+        for (const change of tx.changes) {
+          const group = `${change.insertion.sessionID}-${change.insertion.txIndex}`;
+          if (!groupedBySession.has(group)) groupedBySession.set(group, []);
+          groupedBySession.get(group)!.push(change);
+        }
+
+        return Array.from(groupedBySession.values()).map((changes) => {
+          const stringDeleted = changes
+            // order by txIndex and changeIdx
+            .toSorted((a, b) => {
+              if (a.insertion.txIndex === b.insertion.txIndex) {
+                return a.insertion.changeIdx - b.insertion.changeIdx;
+              }
+
+              return a.insertion.txIndex - b.insertion.txIndex;
+            })
+            // extract the single char from the insertions
+            .map((c) =>
+              coValueBeforeDeletions.get(
+                coValueBeforeDeletions.mapping.idxAfterOpID[
+                  stringifyOpID(c.insertion)
+                ]!,
+              ),
+            )
+            .join("");
+
+          return {
+            op: "custom",
+            action: `"${stringDeleted}" has been deleted`,
+          };
+        });
+      }
+    }
+  }
+
+  return tx.changes ?? (tx.tx as any).changes ?? [];
+}
 
 export function restoreCoMapToTimestamp(
   coValue: RawCoMap,

--- a/packages/jazz-tools/src/inspector/viewer/co-plain-text-view.tsx
+++ b/packages/jazz-tools/src/inspector/viewer/co-plain-text-view.tsx
@@ -1,13 +1,112 @@
-import { JsonObject } from "cojson";
+import { JsonObject, LocalNode, RawCoPlainText } from "cojson";
+import { useState } from "react";
+import { styled } from "goober";
+import { CoPlainText } from "jazz-tools";
+import { isWriter } from "../utils/permissions.js";
+import { Button } from "../ui/button.js";
 import { RawDataCard } from "./raw-data-card.js";
+import { Icon } from "../ui/icon.js";
 
-export function CoPlainTextView({ data }: { data: JsonObject }) {
+export function CoPlainTextView({
+  data,
+  coValue,
+}: {
+  data: JsonObject;
+  coValue: RawCoPlainText;
+  node: LocalNode;
+}) {
+  const currentText = Object.values(data).join("");
+  const [isEditing, setIsEditing] = useState(false);
+  const [editValue, setEditValue] = useState("");
+  const canEdit = isWriter(coValue.group.myRole());
+
+  const handleEditClick = () => {
+    setIsEditing(true);
+    setEditValue(currentText);
+  };
+
+  const handleCancel = () => {
+    setIsEditing(false);
+    setEditValue(currentText);
+  };
+
+  const handleSave = (e: React.FormEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    const coPlainText = CoPlainText.fromRaw(coValue);
+    coPlainText.$jazz.applyDiff(editValue);
+
+    setIsEditing(false);
+  };
+
   if (!data) return;
+
+  if (isEditing) {
+    return (
+      <>
+        <EditForm onSubmit={handleSave}>
+          <StyledTextarea
+            value={editValue}
+            onChange={(e) => setEditValue(e.target.value)}
+            onClick={(e) => e.stopPropagation()}
+          />
+          <FormActions>
+            <Button type="button" variant="secondary" onClick={handleCancel}>
+              Cancel
+            </Button>
+            <Button type="submit" variant="primary">
+              Save
+            </Button>
+          </FormActions>
+        </EditForm>
+        <RawDataCard data={data} />
+      </>
+    );
+  }
 
   return (
     <>
-      <p>{Object.values(data).join("")}</p>
+      <p>{currentText}</p>
+      <div>
+        {canEdit && (
+          <Button variant="secondary" onClick={handleEditClick} title="Edit">
+            <Icon name="edit" />
+          </Button>
+        )}
+      </div>
       <RawDataCard data={data} />
     </>
   );
 }
+
+const EditForm = styled("form")`
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+`;
+
+const StyledTextarea = styled("textarea")`
+  width: 100%;
+  min-height: 120px;
+  border-radius: var(--j-radius-md);
+  border: 1px solid var(--j-border-color);
+  padding: 0.5rem 0.875rem;
+  box-shadow: var(--j-shadow-sm);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.875rem;
+  background-color: white;
+  color: var(--j-text-color-strong);
+  resize: vertical;
+
+  @media (prefers-color-scheme: dark) {
+    background-color: var(--j-foreground);
+  }
+`;
+
+const FormActions = styled("div")`
+  display: flex;
+  gap: 0.5rem;
+  justify-content: flex-end;
+`;

--- a/packages/jazz-tools/src/inspector/viewer/page.tsx
+++ b/packages/jazz-tools/src/inspector/viewer/page.tsx
@@ -3,6 +3,7 @@ import {
   LocalNode,
   RawCoList,
   RawCoMap,
+  RawCoPlainText,
   RawCoStream,
   RawCoValue,
   RawGroup,
@@ -142,7 +143,13 @@ function View(
   }
 
   if (type === "coplaintext") {
-    return <CoPlainTextView data={snapshot} />;
+    return (
+      <CoPlainTextView
+        data={snapshot}
+        coValue={value as RawCoPlainText}
+        node={node}
+      />
+    );
   }
 
   if (type === "colist") {


### PR DESCRIPTION
# Description
Improved CoPlainText in the inspector with:
- inline editing
- consecutive character changes are now grouped in a single history row.


**Caution:** This implementation adds time traveling to `CoList`

## Before
<img width="1617" height="797" alt="immagine" src="https://github.com/user-attachments/assets/1b00a226-1dfa-4ebb-85ab-bd8302e89334" />

## Later
<img width="1625" height="571" alt="immagine" src="https://github.com/user-attachments/assets/dc60ca15-5436-4745-adc5-a46487badb6f" />


## Manual testing instructions

Preview deployment

## Tests

- [x] Tests have been added and/or updated
- [ ] Tests have not been updated, because: <!-- Insert reason for not updating tests here -->
- [ ] I need help with writing tests


## Checklist

- [] I've updated the part of the docs that are affected the PR changes
- [x] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing