### PR TITLE
[Inspector] avoid crashes when covalue has not group

### DIFF
--- a/.changeset/eighty-forks-shake.md
+++ b/.changeset/eighty-forks-shake.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+In the inspector, accounts are now identified by header's meta type

--- a/packages/jazz-tools/src/inspector/viewer/use-resolve-covalue.ts
+++ b/packages/jazz-tools/src/inspector/viewer/use-resolve-covalue.ts
@@ -48,10 +48,6 @@ export type ResolvedAccount = {
   [key: string]: JSON;
 };
 
-export const isAccount = (coValue: JSONObject): coValue is ResolvedAccount => {
-  return isGroup(coValue) && "profile" in coValue;
-};
-
 export async function resolveCoValue(
   coValueId: CoID<RawCoValue>,
   node: LocalNode,
@@ -89,7 +85,7 @@ export async function resolveCoValue(
   if (type === "comap") {
     if (isBrowserImage(snapshot)) {
       extendedType = "image";
-    } else if (isAccount(snapshot)) {
+    } else if (value.headerMeta?.type === "account") {
       extendedType = "account";
     } else if (value.core.isGroup()) {
       extendedType = "group";
@@ -125,7 +121,7 @@ function subscribeToCoValue(
       if (type === "comap") {
         if (isBrowserImage(snapshot)) {
           extendedType = "image";
-        } else if (isAccount(snapshot)) {
+        } else if (value.headerMeta?.type === "account") {
           extendedType = "account";
         } else if (value.core.isGroup()) {
           extendedType = "group";


### PR DESCRIPTION
# Description
When the inspector doesn't recognize a CoValue as an account, it is shown as CoMap. Accounts have no `.group`, and the inspector crashed.
This PR addresses this case, improving stability during debugging unstable covalues. 
