### PR TITLE
fix: replace setTimeout with setImmediate/queueMicrotask in IncomingMessagesQueue

### DIFF
--- a/.changeset/chatty-numbers-yell.md
+++ b/.changeset/chatty-numbers-yell.md
@@ -1,0 +1,5 @@
+---
+"cojson": patch
+---
+
+Switch from setTimeout to setImmediate/queueMicrotask for scheduling inside IncomingMessagesQueue

--- a/packages/cojson/src/queue/IncomingMessagesQueue.ts
+++ b/packages/cojson/src/queue/IncomingMessagesQueue.ts
@@ -133,10 +133,18 @@ export class IncomingMessagesQueue {
         currentTimer - lastTimer >
         SYNC_SCHEDULER_CONFIG.INCOMING_MESSAGES_TIME_BUDGET
       ) {
-        await new Promise((resolve) => setTimeout(resolve, 0));
+        await waitForNextTick();
       }
     }
 
     this.processing = false;
   }
+}
+
+// Use setImmediate if available, otherwise use queueMicrotask
+let waitForNextTick = () =>
+  new Promise<void>((resolve) => queueMicrotask(resolve));
+
+if (typeof setImmediate === "function") {
+  waitForNextTick = () => new Promise<void>((resolve) => setImmediate(resolve));
 }


### PR DESCRIPTION
We've noticed when the sync server is busy processing incoming messages, the CPU usage is quite low.

I think that the reason is that setTimeout is too aggressive as a way to do collaborative scheduling, and moving to using setImmediate when available or queueMicrotask when not.

Doing some tests to see the effect.