### PR TITLE
Improve typechecking on vanilla snippets

### DIFF
--- a/homepage/homepage/content/docs/code-snippets/key-features/authentication/quickstart/+layout-with-auth.svelte
+++ b/homepage/homepage/content/docs/code-snippets/key-features/authentication/quickstart/+layout-with-auth.svelte
@@ -5,10 +5,11 @@
   import { JazzFestAccount } from "$lib/schema";
   // @ts-expect-error Will be there in a real app
   import { PUBLIC_JAZZ_API_KEY } from "$env/static/public";
+  import { SyncConfig } from "jazz-tools";
 
   const apiKey = PUBLIC_JAZZ_API_KEY;
   let { children } = $props();
-  const sync = { peer: `wss://cloud.jazz.tools/?key=${apiKey}` };
+  const sync: SyncConfig = { peer: `wss://cloud.jazz.tools/?key=${apiKey}` };
 </script>
 
 <JazzSvelteProvider {sync} AccountSchema={JazzFestAccount}>

--- a/homepage/homepage/content/docs/code-snippets/key-features/authentication/quickstart/+layout.svelte
+++ b/homepage/homepage/content/docs/code-snippets/key-features/authentication/quickstart/+layout.svelte
@@ -4,10 +4,11 @@
   import { JazzFestAccount } from "$lib/schema";
   // @ts-expect-error This is available in a real app.
   import { PUBLIC_JAZZ_API_KEY } from "$env/static/public";
+  import { SyncConfig } from "jazz-tools";
 
   const apiKey = PUBLIC_JAZZ_API_KEY;
   let { children } = $props();
-  const sync = { peer: `wss://cloud.jazz.tools/?key=${apiKey}` };
+  const sync: SyncConfig = { peer: `wss://cloud.jazz.tools/?key=${apiKey}` };
 </script>
 
 <JazzSvelteProvider {sync} AccountSchema={JazzFestAccount}>

--- a/homepage/homepage/content/docs/code-snippets/project-setup/+layout-with-ssr.svelte
+++ b/homepage/homepage/content/docs/code-snippets/project-setup/+layout-with-ssr.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
+  import { SyncConfig } from "jazz-tools";
   import { JazzSvelteProvider } from "jazz-tools/svelte";
   // [!code hide]
   const apiKey = "";
   let { children } = $props();
-  const sync = { peer: `wss://cloud.jazz.tools/?key=${apiKey}` };
+  const sync: SyncConfig = { peer: `wss://cloud.jazz.tools/?key=${apiKey}` };
 </script>
 
 <JazzSvelteProvider {sync} enableSSR>

--- a/homepage/homepage/content/docs/code-snippets/project-setup/+layout.svelte
+++ b/homepage/homepage/content/docs/code-snippets/project-setup/+layout.svelte
@@ -1,12 +1,13 @@
 <script lang="ts">
   import { JazzSvelteProvider } from "jazz-tools/svelte";
-  let { children } = $props();
+  const { children } = $props();
   import { MyAppAccount } from "./schema";
+  import { SyncConfig } from "jazz-tools";
   // [!code hide]
   const apiKey = "";
 
   // Example configuration for authentication and peer connection
-  let sync = { peer: `wss://cloud.jazz.tools/?key=${apiKey}` };
+  const sync: SyncConfig = { peer: `wss://cloud.jazz.tools/?key=${apiKey}` };
 </script>
 
 <JazzSvelteProvider {sync} AccountSchema={MyAppAccount}>

--- a/homepage/homepage/content/docs/code-snippets/project-setup/apiKey.ts
+++ b/homepage/homepage/content/docs/code-snippets/project-setup/apiKey.ts
@@ -1,0 +1,1 @@
+export const apiKey = "";

--- a/homepage/homepage/content/docs/code-snippets/project-setup/jazz.ts
+++ b/homepage/homepage/content/docs/code-snippets/project-setup/jazz.ts
@@ -1,0 +1,39 @@
+import type {
+  AccountClass,
+  Account,
+  CoValueFromRaw,
+  AnyAccountSchema,
+} from "jazz-tools";
+import {
+  type JazzContextManagerProps,
+  JazzBrowserContextManager,
+} from "jazz-tools/browser";
+
+export async function createVanillaJazzApp<
+  S extends
+    | (AccountClass<Account> & CoValueFromRaw<Account>)
+    | AnyAccountSchema,
+>(opts: Pick<JazzContextManagerProps<S>, "sync" | "AccountSchema">) {
+  const contextManager = new JazzBrowserContextManager<S>();
+
+  await contextManager.createContext({
+    guestMode: false,
+    ...opts,
+  });
+
+  function getCurrentAccount() {
+    const context = contextManager.getCurrentValue();
+    if (!context || !("me" in context)) {
+      throw new Error("");
+    }
+
+    return context.me;
+  }
+
+  return {
+    me: getCurrentAccount(),
+    getCurrentAccount,
+    logOut: contextManager.logOut,
+    authSecretStorage: contextManager.getAuthSecretStorage(),
+  };
+}

--- a/homepage/homepage/content/docs/code-snippets/project-setup/vanilla.ts
+++ b/homepage/homepage/content/docs/code-snippets/project-setup/vanilla.ts
@@ -1,0 +1,10 @@
+import { MyAppAccount } from "./schema";
+import { createVanillaJazzApp } from "./jazz";
+import { apiKey } from "./apiKey";
+const { me, logOut, authSecretStorage } = await createVanillaJazzApp({
+  sync: {
+    peer: `wss://cloud.jazz.tools/?key=${apiKey}`,
+    when: "always",
+  },
+  AccountSchema: MyAppAccount,
+});

--- a/homepage/homepage/content/docs/code-snippets/quickstart/+layout.svelte
+++ b/homepage/homepage/content/docs/code-snippets/quickstart/+layout.svelte
@@ -3,10 +3,11 @@
   import { JazzFestAccount } from "$lib/schema";
   // @ts-expect-error No real env vars
 	import { PUBLIC_JAZZ_API_KEY } from "$env/static/public";
+  import { SyncConfig } from "jazz-tools";
 
   const apiKey = PUBLIC_JAZZ_API_KEY;
   let { children } = $props();
-  const sync = { peer: `wss://cloud.jazz.tools/?key=${apiKey}` };
+  const sync: SyncConfig = { peer: `wss://cloud.jazz.tools/?key=${apiKey}` };
 </script>
 
 <JazzSvelteProvider {sync} AccountSchema={JazzFestAccount}>

--- a/homepage/homepage/content/docs/code-snippets/server-side/quickstart/+layout.svelte
+++ b/homepage/homepage/content/docs/code-snippets/server-side/quickstart/+layout.svelte
@@ -2,8 +2,9 @@
   import { JazzSvelteProvider } from "jazz-tools/svelte";
   // @ts-expect-error Only available in a real SK app
 	import { PUBLIC_JAZZ_API_KEY } from "$env/static/public";
+  import { SyncConfig } from "jazz-tools";
   let { children } = $props();
-  const sync = { peer: `wss://cloud.jazz.tools/?key=${PUBLIC_JAZZ_API_KEY}` };
+  const sync: SyncConfig = { peer: `wss://cloud.jazz.tools/?key=${PUBLIC_JAZZ_API_KEY}` };
 </script>
 
 <JazzSvelteProvider {sync}>

--- a/homepage/homepage/content/docs/code-snippets/server-side/ssr/+layout.svelte
+++ b/homepage/homepage/content/docs/code-snippets/server-side/ssr/+layout.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
   import { JazzSvelteProvider } from "jazz-tools/svelte";
   import { apiKey } from "$lib/apiKey";
+  import { SyncConfig } from "jazz-tools";
 
   let { children } = $props();
-  const sync = { peer: `wss://cloud.jazz.tools/?key=${apiKey}` };
+  const sync: SyncConfig = { peer: `wss://cloud.jazz.tools/?key=${apiKey}` };
 </script>
 
 <!--[!code ++:1]-->

--- a/homepage/homepage/content/docs/project-setup.mdx
+++ b/homepage/homepage/content/docs/project-setup.mdx
@@ -60,41 +60,7 @@ You can make sure Jazz always has the right context by wrapping your application
 
 <TabbedCodeGroup savedPreferenceKey="framework" id="add-provider">
 <TabbedCodeGroupItem label="Vanilla JS" value="vanilla" icon={<VanillaLogo />} preferWrap>
-```ts
-import type {
-  AccountClass,
-  Account,
-  CoValueFromRaw,
-  AnyAccountSchema,
-} from "jazz-tools";
-import {
-  type JazzContextManagerProps,
-  JazzBrowserContextManager,
-} from "jazz-tools/browser";
-
-export async function createVanillaJazzApp<
-  S extends
-    | (AccountClass<Account> & CoValueFromRaw<Account>)
-    | AnyAccountSchema,
->(opts: Pick<JazzContextManagerProps<S>, "sync" | "AccountSchema">) {
-  const contextManager = new JazzBrowserContextManager<S>()
-
-    await contextManager.createContext({
-        guestMode: false,
-        ...opts,
-    })
-
-    function getCurrentAccount() {
-       const context = contextManager.getCurrentValue()
-        if (!context || !('me' in context)) {
-        throw new Error("")
-    }
-
-       return context.me;
-    }
-
-    return { me: getCurrentAccount(), getCurrentAccount, logOut: contextManager.logOut, authSecretStorage: contextManager.getAuthSecretStorage() }
-}
+```ts jazz.ts
 ```
 </TabbedCodeGroupItem>
 <TabbedCodeGroupItem label="React" value="react" icon={<ReactLogo />} preferWrap>
@@ -115,17 +81,7 @@ export async function createVanillaJazzApp<
 ## Using your App [!framework=vanilla]
 You can start using your app by passing a `sync` parameter and a custom account schema to the `createVanillaJazzApp` factory.
 <CodeGroup>
-```ts
-import { MyAccount } from './schema';
-import { createVanillaJazzApp } from './jazz';
-import { apiKey } from './apiKey'
-const { me, logOut, authSecretStorage } = await createVanillaJazzApp({
-    sync: {
-        peer: `wss://cloud.jazz.tools/?key=${apiKey}`,
-        when: 'always'
-    },
-    AccountSchema: MyAccount,
-})
+```ts vanilla.ts
 ```
 </CodeGroup>
 


### PR DESCRIPTION
Svelte examples also updated with SyncConfig type.

# Description
Improves consistency and accuracy of the Vanilla JS snippets in the project setup guide.

## Manual testing instructions
Check docs/vanilla/project-setup

## Tests

- [ ] Tests have been added and/or updated
- [x] Tests have not been updated, because: N/A
- [ ] I need help with writing tests


## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [ ] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing