### PR TITLE
refactor: move unloaded management inside the SubscriptionScope

### DIFF
--- a/packages/community-jazz-vue/src/composables.ts
+++ b/packages/community-jazz-vue/src/composables.ts
@@ -214,21 +214,11 @@ export function useCoState<
           {
             resolve: options?.resolve as any,
             loadAs: safeLoadAsAgent,
-            onUnavailable: () => {
-              updateState(
-                createUnloadedCoValue(
-                  currentId,
-                  CoValueLoadingState.UNAVAILABLE,
-                ),
-              );
+            onUnavailable: (value) => {
+              updateState(value);
             },
-            onUnauthorized: () => {
-              updateState(
-                createUnloadedCoValue(
-                  currentId,
-                  CoValueLoadingState.UNAUTHORIZED,
-                ),
-              );
+            onUnauthorized: (value) => {
+              updateState(value);
             },
             syncResolution: true,
           },

--- a/packages/jazz-tools/src/react-core/hooks.ts
+++ b/packages/jazz-tools/src/react-core/hooks.ts
@@ -26,7 +26,7 @@ import {
   SchemaResolveQuery,
   SubscriptionScope,
   coValueClassFromCoValueClassOrSchema,
-  createUnloadedCoValue,
+  getUnloadedCoValueWithoutId,
   type BranchDefinition,
 } from "jazz-tools";
 import { JazzContext, JazzContextManagerContext } from "./provider.js";
@@ -172,39 +172,15 @@ export function useCoValueSubscription<
   return subscription.subscription as CoValueSubscription<S, R>;
 }
 
-function getSubscriptionValue<C extends CoValue>(
-  subscription: SubscriptionScope<C> | null,
-): MaybeLoaded<C> {
-  if (!subscription) {
-    return createUnloadedCoValue("", CoValueLoadingState.UNAVAILABLE);
-  }
-  const value = subscription.getCurrentValue();
-  if (typeof value === "string") {
-    return createUnloadedCoValue(subscription.id, value);
-  }
-  return value;
-}
-
 function useGetCurrentValue<C extends CoValue>(
   subscription: SubscriptionScope<C> | null,
 ) {
-  const previousValue = useRef<MaybeLoaded<CoValue> | undefined>(undefined);
-
   return useCallback(() => {
-    const currentValue = getSubscriptionValue(subscription);
-    // Avoid re-renders if the value is not loaded and didn't change
-    if (
-      previousValue.current !== undefined &&
-      previousValue.current.$jazz.id === currentValue.$jazz.id &&
-      !previousValue.current.$isLoaded &&
-      !currentValue.$isLoaded &&
-      previousValue.current.$jazz.loadingState ===
-        currentValue.$jazz.loadingState
-    ) {
-      return previousValue.current as MaybeLoaded<C>;
+    if (!subscription) {
+      return getUnloadedCoValueWithoutId(CoValueLoadingState.UNAVAILABLE);
     }
-    previousValue.current = currentValue;
-    return currentValue;
+
+    return subscription.getCurrentValue();
   }, [subscription]);
 }
 

--- a/packages/jazz-tools/src/tools/coValues/coFeed.ts
+++ b/packages/jazz-tools/src/tools/coValues/coFeed.ts
@@ -512,13 +512,16 @@ function entryFromRawEntry<Item>(
       }
     },
     get by() {
-      return (
-        accountID &&
-        accessChildById(accessFrom, accountID, {
-          ref: Account,
-          optional: false,
-        })
-      );
+      if (!accountID) return null;
+
+      const account = accessChildById(accessFrom, accountID, {
+        ref: Account,
+        optional: false,
+      }) as Account;
+
+      if (!account.$isLoaded) return null;
+
+      return account;
     },
     madeAt: rawEntry.at,
     tx: rawEntry.tx,

--- a/packages/jazz-tools/src/tools/coValues/coMap.ts
+++ b/packages/jazz-tools/src/tools/coValues/coMap.ts
@@ -1051,13 +1051,16 @@ function getEditFromRaw(
           )
         : undefined,
     get by() {
-      return (
-        rawEdit.by &&
-        accessChildById(target, rawEdit.by, {
-          ref: Account,
-          optional: false,
-        })
-      );
+      if (!rawEdit.by) return null;
+
+      const account = accessChildById(target, rawEdit.by, {
+        ref: Account,
+        optional: false,
+      }) as Account;
+
+      if (!account.$isLoaded) return null;
+
+      return account;
     },
     madeAt: rawEdit.at,
     key,

--- a/packages/jazz-tools/src/tools/coValues/group.ts
+++ b/packages/jazz-tools/src/tools/coValues/group.ts
@@ -178,7 +178,11 @@ export class Group extends CoValueBase implements CoValue {
           ref,
           get account() {
             // Accounts values are non-nullable because are loaded as dependencies
-            return accessChildById(group, accountID, refEncodedAccountSchema);
+            return accessChildById(
+              group,
+              accountID,
+              refEncodedAccountSchema,
+            ) as Account;
           },
         });
       }
@@ -410,7 +414,7 @@ export function getCoValueOwner(coValue: CoValue): Group {
     ref: RegisteredSchemas["Group"],
     optional: false,
   });
-  if (!group) {
+  if (!group.$isLoaded) {
     throw new Error("CoValue has no owner");
   }
   return group;

--- a/packages/jazz-tools/src/tools/coValues/interfaces.ts
+++ b/packages/jazz-tools/src/tools/coValues/interfaces.ts
@@ -107,6 +107,23 @@ export function isCoValueClass<V extends CoValue>(
  */
 export type ID<T> = string;
 
+const unloadedCoValueStates = new Map<
+  NotLoadedCoValueState,
+  NotLoaded<CoValue>
+>();
+
+export function getUnloadedCoValueWithoutId<T extends CoValue>(
+  loadingState: NotLoadedCoValueState,
+): NotLoaded<T> {
+  const value = unloadedCoValueStates.get(loadingState);
+  if (value) {
+    return value;
+  }
+  const newValue = createUnloadedCoValue("", loadingState);
+  unloadedCoValueStates.set(loadingState, newValue);
+  return newValue;
+}
+
 export function createUnloadedCoValue<T extends CoValue>(
   id: ID<T>,
   loadingState: NotLoadedCoValueState,
@@ -159,12 +176,8 @@ export function loadCoValue<
         loadAs: options.loadAs,
         syncResolution: true,
         skipRetry: options.skipRetry,
-        onUnavailable: () => {
-          resolve(createUnloadedCoValue(id, CoValueLoadingState.UNAVAILABLE));
-        },
-        onUnauthorized: () => {
-          resolve(createUnloadedCoValue(id, CoValueLoadingState.UNAUTHORIZED));
-        },
+        onUnavailable: resolve,
+        onUnauthorized: resolve,
         unstable_branch: options.unstable_branch,
       },
       (value, unsubscribe) => {
@@ -215,8 +228,8 @@ export type SubscribeListenerOptions<
 > = {
   resolve?: RefsToResolveStrict<V, R>;
   loadAs?: Account | AnonymousJazzAgent;
-  onUnauthorized?: () => void;
-  onUnavailable?: () => void;
+  onUnauthorized?: (value: NotLoaded<V>) => void;
+  onUnavailable?: (value: NotLoaded<V>) => void;
   unstable_branch?: BranchDefinition;
 };
 
@@ -290,8 +303,8 @@ export function subscribeToCoValue<
   options: {
     resolve?: RefsToResolveStrict<V, R>;
     loadAs: Account | AnonymousJazzAgent;
-    onUnavailable?: () => void;
-    onUnauthorized?: () => void;
+    onUnavailable?: (value: NotLoaded<V>) => void;
+    onUnauthorized?: (value: NotLoaded<V>) => void;
     syncResolution?: boolean;
     skipRetry?: boolean;
     unstable_branch?: BranchDefinition;
@@ -318,35 +331,42 @@ export function subscribeToCoValue<
     options.unstable_branch,
   );
 
-  const handleUpdate = (value: SubscriptionValue<V, any>) => {
+  const handleUpdate = () => {
     if (unsubscribed) return;
 
-    if (value.type === CoValueLoadingState.UNAVAILABLE) {
-      options.onUnavailable?.();
+    const value = rootNode.getCurrentValue();
 
-      // Don't log unavailable errors when `loadUnique` or `upsertUnique` are used
-      if (!options.skipRetry) {
+    if (value.$isLoaded) {
+      listener(value as Resolved<V, R>, unsubscribe);
+      return;
+    }
+
+    switch (value.$jazz.loadingState) {
+      case CoValueLoadingState.UNAVAILABLE:
+        options.onUnavailable?.(value);
+
+        // Don't log unavailable errors when `loadUnique` or `upsertUnique` are used
+        if (!options.skipRetry) {
+          console.error(value.toString());
+        }
+        break;
+      case CoValueLoadingState.UNAUTHORIZED:
+        options.onUnauthorized?.(value);
         console.error(value.toString());
-      }
-    } else if (value.type === CoValueLoadingState.UNAUTHORIZED) {
-      options.onUnauthorized?.();
-
-      console.error(value.toString());
-    } else if (value.type === CoValueLoadingState.LOADED) {
-      listener(value.value as Resolved<V, R>, unsubscribe);
+        break;
     }
   };
 
   let shouldDefer = !options.syncResolution;
 
-  rootNode.setListener((value) => {
+  rootNode.setListener(() => {
     if (shouldDefer) {
       shouldDefer = false;
       Promise.resolve().then(() => {
-        handleUpdate(value);
+        handleUpdate();
       });
     } else {
-      handleUpdate(value);
+      handleUpdate();
     }
   });
 
@@ -366,8 +386,8 @@ export function subscribeToExistingCoValue<
   options:
     | {
         resolve?: RefsToResolveStrict<V, R>;
-        onUnavailable?: () => void;
-        onUnauthorized?: () => void;
+        onUnavailable?: (value: NotLoaded<V>) => void;
+        onUnauthorized?: (value: NotLoaded<V>) => void;
         unstable_branch?: BranchDefinition;
       }
     | undefined,
@@ -703,7 +723,7 @@ function loadContentPiecesFromSubscription(
 
   const currentValue = subscription.getCurrentValue();
 
-  if (typeof currentValue !== "string") {
+  if (currentValue.$isLoaded) {
     const core = currentValue.$jazz.raw.core as AvailableCoValueCore;
     loadContentPiecesFromCoValue(core, valuesExported, contentPieces);
   }

--- a/packages/jazz-tools/src/tools/coValues/promise.ts
+++ b/packages/jazz-tools/src/tools/coValues/promise.ts
@@ -1,0 +1,34 @@
+export class CoValuePromise<T> extends Promise<T> {
+  status: "pending" | "fulfilled" | "rejected" = "pending";
+  value: T | undefined;
+  reason: unknown | undefined;
+
+  static getRejected<T = never>(reason?: unknown): CoValuePromise<T> {
+    return new CoValuePromise<T>((resolve, reject) => {
+      reject(reason);
+    });
+  }
+
+  static getFulfilled<T>(value: T): CoValuePromise<T> {
+    return new CoValuePromise<T>((resolve) => {
+      resolve(value);
+    });
+  }
+
+  constructor(
+    executor: (
+      resolve: (value: T) => void,
+      reject: (reason?: unknown) => void,
+    ) => void,
+  ) {
+    super((resolve, reject) => {
+      const _resolve = (value: T) => {
+        resolve(value);
+      };
+      const _reject = (reason?: unknown) => {
+        reject(reason);
+      };
+      executor(_resolve, _reject);
+    });
+  }
+}

--- a/packages/jazz-tools/src/tools/exports.ts
+++ b/packages/jazz-tools/src/tools/exports.ts
@@ -64,6 +64,7 @@ export {
   Ref,
   createUnloadedCoValue,
   unstable_loadUnique,
+  getUnloadedCoValueWithoutId,
 } from "./internal.js";
 
 export {

--- a/packages/jazz-tools/src/tools/subscribe/SubscriptionScope.ts
+++ b/packages/jazz-tools/src/tools/subscribe/SubscriptionScope.ts
@@ -295,6 +295,8 @@ export class SubscriptionScope<D extends CoValue> {
       $jazz: {
         id: this.id,
         loadingState: reason,
+        // @ts-expect-error - This is a private property
+        _subscriptionScope: this,
       },
       $isLoaded: false,
     };

--- a/packages/jazz-tools/src/tools/subscribe/SubscriptionScope.ts
+++ b/packages/jazz-tools/src/tools/subscribe/SubscriptionScope.ts
@@ -6,6 +6,7 @@ import {
   type CoValue,
   type ID,
   MaybeLoaded,
+  NotLoaded,
   type RefEncoded,
   type RefsToResolve,
   TypeSym,
@@ -283,7 +284,41 @@ export class SubscriptionScope<D extends CoValue> {
     return this.pendingLoadedChildren.size === 0;
   }
 
-  getCurrentValue(): D | NotLoadedCoValueState {
+  unloadedValue: NotLoaded<D> | undefined;
+
+  private getUnloadedValue(reason: NotLoadedCoValueState): NotLoaded<D> {
+    if (this.unloadedValue?.$jazz.loadingState === reason) {
+      return this.unloadedValue;
+    }
+
+    const unloadedValue: NotLoaded<D> = {
+      $jazz: {
+        id: this.id,
+        loadingState: reason,
+      },
+      $isLoaded: false,
+    };
+
+    this.unloadedValue = unloadedValue;
+
+    return unloadedValue;
+  }
+
+  getCurrentValue(): MaybeLoaded<D> {
+    const rawValue = this.getCurrentRawValue();
+
+    if (
+      rawValue === CoValueLoadingState.UNAUTHORIZED ||
+      rawValue === CoValueLoadingState.UNAVAILABLE ||
+      rawValue === CoValueLoadingState.LOADING
+    ) {
+      return this.getUnloadedValue(rawValue);
+    }
+
+    return rawValue;
+  }
+
+  getCurrentRawValue(): D | NotLoadedCoValueState {
     if (
       this.value.type === CoValueLoadingState.UNAUTHORIZED ||
       this.value.type === CoValueLoadingState.UNAVAILABLE
@@ -406,7 +441,7 @@ export class SubscriptionScope<D extends CoValue> {
     this.subscription.pullValue();
 
     // Check if the value is now available
-    const value = this.getCurrentValue();
+    const value = this.getCurrentRawValue();
 
     // If the value is available, trigger the listener
     if (typeof value !== "string") {

--- a/packages/jazz-tools/src/tools/subscribe/index.ts
+++ b/packages/jazz-tools/src/tools/subscribe/index.ts
@@ -61,6 +61,15 @@ export function accessChildByKey<D extends CoValue>(
     );
   }
 
+  // TODO: this doesn't check the subscription tree loading state
+  // so if one of the children is loading, it will return the loading state
+  // instead of the latest loaded state
+  const value = subscriptionScope.childValues.get(childId);
+
+  if (value?.type === CoValueLoadingState.LOADED) {
+    return value.value;
+  }
+
   const childNode = subscriptionScope.childNodes.get(childId);
 
   if (!childNode) {
@@ -86,6 +95,13 @@ export function accessChildById<D extends CoValue>(
   const subscriptionScope = getSubscriptionScope(parent);
 
   subscriptionScope.subscribeToId(childId, schema);
+
+  const value = subscriptionScope.childValues.get(childId);
+
+  // TODO: this doesn't check the subscription tree loading state
+  if (value?.type === CoValueLoadingState.LOADED) {
+    return value.value;
+  }
 
   const childNode = subscriptionScope.childNodes.get(childId);
 

--- a/packages/jazz-tools/src/tools/subscribe/types.ts
+++ b/packages/jazz-tools/src/tools/subscribe/types.ts
@@ -29,10 +29,13 @@ export const CoValueLoadingState = {
 export type CoValueLoadingState =
   (typeof CoValueLoadingState)[keyof typeof CoValueLoadingState];
 
+export type CoValueErrorState =
+  | typeof CoValueLoadingState.UNAVAILABLE
+  | typeof CoValueLoadingState.UNAUTHORIZED;
+
 export type NotLoadedCoValueState =
   | typeof CoValueLoadingState.LOADING
-  | typeof CoValueLoadingState.UNAUTHORIZED
-  | typeof CoValueLoadingState.UNAVAILABLE;
+  | CoValueErrorState;
 
 export type SubscriptionValue<D extends CoValue, R extends RefsToResolve<D>> =
   | {

--- a/packages/jazz-tools/src/tools/tests/SubscriptionScope.test.ts
+++ b/packages/jazz-tools/src/tools/tests/SubscriptionScope.test.ts
@@ -1,0 +1,397 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { Account, Group, co, z } from "../exports.js";
+import {
+  CoValueLoadingState,
+  coValueClassFromCoValueClassOrSchema,
+} from "../internal.js";
+import { createJazzTestAccount, setupJazzTestSync } from "../testing.js";
+import { JazzError } from "../subscribe/JazzError.js";
+import { SubscriptionScope } from "../subscribe/SubscriptionScope.js";
+
+describe("SubscriptionScope", () => {
+  const Person = co.map({
+    name: z.string(),
+  });
+
+  beforeEach(async () => {
+    await setupJazzTestSync();
+
+    await createJazzTestAccount({
+      isCurrentActiveAccount: true,
+      creationProps: { name: "Hermes Puggington" },
+    });
+  });
+
+  describe("getCurrentValue reference stability", () => {
+    it("returns the same reference when called multiple times with the same loading state", () => {
+      const person = Person.create({ name: "John" });
+      const node = person.$jazz.raw.core.node;
+      const id = person.$jazz.id;
+      const schema = {
+        ref: coValueClassFromCoValueClassOrSchema(Person),
+        optional: false,
+      };
+
+      const scope = new SubscriptionScope(node, true, id, schema);
+
+      // Simulate LOADING state
+      scope.value = { type: CoValueLoadingState.LOADING, id };
+
+      const firstCall = scope.getCurrentValue();
+      const secondCall = scope.getCurrentValue();
+      const thirdCall = scope.getCurrentValue();
+
+      // All calls should return the same reference
+      expect(firstCall).toBe(secondCall);
+      expect(secondCall).toBe(thirdCall);
+      expect(firstCall).toBe(thirdCall);
+
+      // Verify it's a NotLoaded value with LOADING state
+      expect(firstCall.$jazz.loadingState).toBe(CoValueLoadingState.LOADING);
+      expect(firstCall.$isLoaded).toBe(false);
+      expect(firstCall.$jazz.id).toBe(id);
+
+      // Verify the cached value matches
+      expect(scope.unloadedValue).toBe(firstCall);
+
+      scope.destroy();
+    });
+
+    it("returns different references when the loading state changes", () => {
+      const person = Person.create({ name: "John" });
+      const node = person.$jazz.raw.core.node;
+      const id = person.$jazz.id;
+      const schema = {
+        ref: coValueClassFromCoValueClassOrSchema(Person),
+        optional: false,
+      };
+
+      const scope = new SubscriptionScope(node, true, id, schema);
+
+      // Start with LOADING state
+      scope.value = { type: CoValueLoadingState.LOADING, id };
+      const loadingValue = scope.getCurrentValue();
+
+      // Switch to UNAVAILABLE state
+      scope.updateValue(
+        new JazzError(id, CoValueLoadingState.UNAVAILABLE, [
+          {
+            code: CoValueLoadingState.UNAVAILABLE,
+            message: "The value is unavailable",
+            params: { id },
+            path: [],
+          },
+        ]),
+      );
+      const unavailableValue = scope.getCurrentValue();
+
+      // Switch to UNAUTHORIZED state
+      scope.updateValue(
+        new JazzError(id, CoValueLoadingState.UNAUTHORIZED, [
+          {
+            code: CoValueLoadingState.UNAUTHORIZED,
+            message: "The current user is not authorized to access this value",
+            params: { id },
+            path: [],
+          },
+        ]),
+      );
+      const unauthorizedValue = scope.getCurrentValue();
+
+      // All should be different references
+      expect(loadingValue).not.toBe(unavailableValue);
+      expect(loadingValue).not.toBe(unauthorizedValue);
+      expect(unavailableValue).not.toBe(unauthorizedValue);
+
+      // Verify each has the correct loading state
+      expect(loadingValue.$jazz.loadingState).toBe(CoValueLoadingState.LOADING);
+      expect(unavailableValue.$jazz.loadingState).toBe(
+        CoValueLoadingState.UNAVAILABLE,
+      );
+      expect(unauthorizedValue.$jazz.loadingState).toBe(
+        CoValueLoadingState.UNAUTHORIZED,
+      );
+
+      // Verify the cached value is the last one
+      expect(scope.unloadedValue).toBe(unauthorizedValue);
+
+      scope.destroy();
+    });
+
+    it("maintains reference stability across multiple state transitions", () => {
+      const person = Person.create({ name: "John" });
+      const node = person.$jazz.raw.core.node;
+      const id = person.$jazz.id;
+      const schema = {
+        ref: coValueClassFromCoValueClassOrSchema(Person),
+        optional: false,
+      };
+
+      const scope = new SubscriptionScope(node, true, id, schema);
+
+      // Get LOADING value multiple times
+      scope.value = { type: CoValueLoadingState.LOADING, id };
+      const loading1 = scope.getCurrentValue();
+      const loading2 = scope.getCurrentValue();
+      expect(loading1).toBe(loading2);
+
+      // Switch to UNAVAILABLE
+      scope.updateValue(
+        new JazzError(id, CoValueLoadingState.UNAVAILABLE, [
+          {
+            code: CoValueLoadingState.UNAVAILABLE,
+            message: "The value is unavailable",
+            params: { id },
+            path: [],
+          },
+        ]),
+      );
+      const unavailable1 = scope.getCurrentValue();
+      expect(unavailable1).not.toBe(loading1);
+
+      // Get UNAVAILABLE again - should return same reference
+      const unavailable2 = scope.getCurrentValue();
+      expect(unavailable1).toBe(unavailable2);
+
+      // Switch to UNAUTHORIZED
+      scope.updateValue(
+        new JazzError(id, CoValueLoadingState.UNAUTHORIZED, [
+          {
+            code: CoValueLoadingState.UNAUTHORIZED,
+            message: "The current user is not authorized to access this value",
+            params: { id },
+            path: [],
+          },
+        ]),
+      );
+      const unauthorized1 = scope.getCurrentValue();
+      expect(unauthorized1).not.toBe(unavailable1);
+
+      // Get UNAUTHORIZED again - should return same reference
+      const unauthorized2 = scope.getCurrentValue();
+      expect(unauthorized1).toBe(unauthorized2);
+
+      // Switch back to UNAVAILABLE - should create new reference
+      scope.updateValue(
+        new JazzError(id, CoValueLoadingState.UNAVAILABLE, [
+          {
+            code: CoValueLoadingState.UNAVAILABLE,
+            message: "The value is unavailable",
+            params: { id },
+            path: [],
+          },
+        ]),
+      );
+      const unavailable3 = scope.getCurrentValue();
+      expect(unavailable3).not.toBe(unavailable1);
+      expect(unavailable3).not.toBe(unavailable2);
+
+      // Get UNAVAILABLE again - should return same reference as unavailable3
+      const unavailable4 = scope.getCurrentValue();
+      expect(unavailable3).toBe(unavailable4);
+
+      scope.destroy();
+    });
+
+    it("returns stable reference when switching back to a previously used state after cache was overwritten", () => {
+      const person = Person.create({ name: "John" });
+      const node = person.$jazz.raw.core.node;
+      const id = person.$jazz.id;
+      const schema = {
+        ref: coValueClassFromCoValueClassOrSchema(Person),
+        optional: false,
+      };
+
+      const scope = new SubscriptionScope(node, true, id, schema);
+
+      // First, get a LOADING value
+      scope.value = { type: CoValueLoadingState.LOADING, id };
+      const firstLoadingValue = scope.getCurrentValue();
+
+      // Switch to UNAVAILABLE (this overwrites the cache)
+      scope.updateValue(
+        new JazzError(id, CoValueLoadingState.UNAVAILABLE, [
+          {
+            code: CoValueLoadingState.UNAVAILABLE,
+            message: "The value is unavailable",
+            params: { id },
+            path: [],
+          },
+        ]),
+      );
+      const unavailableValue = scope.getCurrentValue();
+
+      // Switch back to LOADING (should create a new reference since cache was overwritten)
+      scope.value = { type: CoValueLoadingState.LOADING, id };
+      const secondLoadingValue = scope.getCurrentValue();
+
+      // The second LOADING value should be different from the first
+      // because the cache was overwritten with UNAVAILABLE
+      expect(firstLoadingValue).not.toBe(secondLoadingValue);
+
+      // But both should have the same loading state
+      expect(firstLoadingValue.$jazz.loadingState).toBe(
+        CoValueLoadingState.LOADING,
+      );
+      expect(secondLoadingValue.$jazz.loadingState).toBe(
+        CoValueLoadingState.LOADING,
+      );
+
+      // The cache should now point to the second LOADING value
+      expect(scope.unloadedValue).toBe(secondLoadingValue);
+
+      scope.destroy();
+    });
+
+    it("preserves correct loading state in returned value", () => {
+      const person = Person.create({ name: "John" });
+      const node = person.$jazz.raw.core.node;
+      const id = person.$jazz.id;
+      const schema = {
+        ref: coValueClassFromCoValueClassOrSchema(Person),
+        optional: false,
+      };
+
+      const scope = new SubscriptionScope(node, true, id, schema);
+
+      // Test LOADING state
+      scope.value = { type: CoValueLoadingState.LOADING, id };
+      const loadingValue = scope.getCurrentValue();
+      expect(loadingValue.$jazz.loadingState).toBe(CoValueLoadingState.LOADING);
+      expect(loadingValue.$isLoaded).toBe(false);
+      expect(loadingValue.$jazz.id).toBe(id);
+
+      // Test UNAVAILABLE state
+      scope.updateValue(
+        new JazzError(id, CoValueLoadingState.UNAVAILABLE, [
+          {
+            code: CoValueLoadingState.UNAVAILABLE,
+            message: "The value is unavailable",
+            params: { id },
+            path: [],
+          },
+        ]),
+      );
+      const unavailableValue = scope.getCurrentValue();
+      expect(unavailableValue.$jazz.loadingState).toBe(
+        CoValueLoadingState.UNAVAILABLE,
+      );
+      expect(unavailableValue.$isLoaded).toBe(false);
+      expect(unavailableValue.$jazz.id).toBe(id);
+
+      // Test UNAUTHORIZED state
+      scope.updateValue(
+        new JazzError(id, CoValueLoadingState.UNAUTHORIZED, [
+          {
+            code: CoValueLoadingState.UNAUTHORIZED,
+            message: "The current user is not authorized to access this value",
+            params: { id },
+            path: [],
+          },
+        ]),
+      );
+      const unauthorizedValue = scope.getCurrentValue();
+      expect(unauthorizedValue.$jazz.loadingState).toBe(
+        CoValueLoadingState.UNAUTHORIZED,
+      );
+      expect(unauthorizedValue.$isLoaded).toBe(false);
+      expect(unauthorizedValue.$jazz.id).toBe(id);
+
+      scope.destroy();
+    });
+
+    it("returns LOADING state when shouldSendUpdates returns false", () => {
+      const person = Person.create({ name: "John" });
+      const node = person.$jazz.raw.core.node;
+      const id = person.$jazz.id;
+      const schema = {
+        ref: coValueClassFromCoValueClassOrSchema(Person),
+        optional: false,
+      };
+
+      const scope = new SubscriptionScope(node, true, id, schema);
+
+      // Set up a loaded value with pending children
+      const loadedPerson = Person.create({ name: "Jane" });
+      scope.updateValue({
+        type: CoValueLoadingState.LOADED,
+        value: loadedPerson,
+        id: loadedPerson.$jazz.id,
+      });
+
+      // Add a pending child to make shouldSendUpdates return false
+      scope.pendingLoadedChildren.add("some-child-id");
+
+      const value1 = scope.getCurrentValue();
+      const value2 = scope.getCurrentValue();
+
+      // Should return the same LOADING reference
+      expect(value1).toBe(value2);
+      expect(value1.$jazz.loadingState).toBe(CoValueLoadingState.LOADING);
+      expect(value1.$isLoaded).toBe(false);
+
+      // Clear pending children
+      scope.pendingLoadedChildren.clear();
+
+      // Now should return the loaded value
+      const loadedValue = scope.getCurrentValue();
+      expect(loadedValue).toBe(loadedPerson);
+      expect(loadedValue.$isLoaded).toBe(true);
+
+      scope.destroy();
+    });
+
+    it("returns error state from errorFromChildren when present", () => {
+      const person = Person.create({ name: "John" });
+      const node = person.$jazz.raw.core.node;
+      const id = person.$jazz.id;
+      const schema = {
+        ref: coValueClassFromCoValueClassOrSchema(Person),
+        optional: false,
+      };
+
+      const scope = new SubscriptionScope(node, true, id, schema);
+
+      // Set up a loaded value
+      const loadedPerson = Person.create({ name: "Jane" });
+      scope.updateValue({
+        type: CoValueLoadingState.LOADED,
+        value: loadedPerson,
+        id: loadedPerson.$jazz.id,
+      });
+
+      // Set up an error from children
+      const childError = new JazzError(
+        "child-id" as any,
+        CoValueLoadingState.UNAVAILABLE,
+        [
+          {
+            code: CoValueLoadingState.UNAVAILABLE,
+            message: "Child value is unavailable",
+            params: { id: "child-id" },
+            path: [],
+          },
+        ],
+      );
+      scope.errorFromChildren = childError;
+
+      const value1 = scope.getCurrentValue();
+      const value2 = scope.getCurrentValue();
+
+      // Should return the same UNAVAILABLE reference
+      expect(value1).toBe(value2);
+      expect(value1.$jazz.loadingState).toBe(CoValueLoadingState.UNAVAILABLE);
+      expect(value1.$isLoaded).toBe(false);
+
+      // Clear the error
+      scope.errorFromChildren = undefined;
+
+      // Now should return the loaded value
+      const loadedValue = scope.getCurrentValue();
+      expect(loadedValue).toBe(loadedPerson);
+      expect(loadedValue.$isLoaded).toBe(true);
+
+      scope.destroy();
+    });
+  });
+});


### PR DESCRIPTION
In order to make it easier to implement `value.$jazz.promise` I'm moving the unloaded management inside of SubscriptionScope.

Unloaded values coming from there will always have a stable reference, which makes it easier to build a promise getter that also returns a stable promise.