### PR TITLE
feat(vue): allow reactive inputs to useCoState and useInboxSender

### DIFF
--- a/packages/community-jazz-vue/src/composables.ts
+++ b/packages/community-jazz-vue/src/composables.ts
@@ -23,17 +23,18 @@ import {
 import { consumeInviteLinkFromWindowLocation } from "jazz-tools/browser";
 import {
   type ComputedRef,
+  type MaybeRefOrGetter,
   type Ref,
   type ShallowRef,
   computed,
   inject,
   markRaw,
-  nextTick,
   onMounted,
   onUnmounted,
   ref,
   shallowRef,
   toRaw,
+  toValue,
   watch,
 } from "vue";
 
@@ -157,11 +158,11 @@ export function useCoState<
   const R extends ResolveQuery<S> = true,
 >(
   Schema: S,
-  id: string | undefined,
+  id: MaybeRefOrGetter<string | undefined>,
   options?: { resolve?: ResolveQueryStrict<S, R> },
 ): Ref<MaybeLoaded<Loaded<S, R>>> {
   const state: ShallowRef<MaybeLoaded<Loaded<S, R>>> = shallowRef(
-    createUnloadedCoValue(id ?? "", CoValueLoadingState.LOADING),
+    createUnloadedCoValue(toValue(id) ?? "", CoValueLoadingState.LOADING),
   );
   const context = useJazzContext();
 
@@ -179,7 +180,7 @@ export function useCoState<
   };
 
   watch(
-    [() => id, context],
+    [() => toValue(id), context],
     ([currentId, currentContext]) => {
       if (unsubscribe) {
         unsubscribe();
@@ -313,7 +314,7 @@ export function useAcceptInvite<S extends CoValueClassOrSchema>({
 export function experimental_useInboxSender<
   I extends CoValue,
   O extends CoValue | undefined,
->(inboxOwnerID: string | undefined) {
+>(inboxOwnerID: MaybeRefOrGetter<string | undefined>) {
   const context = useJazzContext();
 
   if (!context.value) {
@@ -332,17 +333,21 @@ export function experimental_useInboxSender<
   const inboxRef = ref<Promise<InboxSender<I, O>> | undefined>(undefined);
 
   const sendMessage = async (message: I) => {
-    if (!inboxOwnerID) throw new Error("Inbox owner ID is required");
+    const resolvedInboxOwnerID = toValue(inboxOwnerID);
+    if (!resolvedInboxOwnerID) throw new Error("Inbox owner ID is required");
 
     if (!inboxRef.value) {
-      const inbox = InboxSender.load<I, O>(inboxOwnerID, toRaw(me.value));
+      const inbox = InboxSender.load<I, O>(
+        resolvedInboxOwnerID,
+        toRaw(me.value),
+      );
       inboxRef.value = inbox;
     }
 
     let inbox = await inboxRef.value;
 
-    if (inbox.owner.id !== inboxOwnerID) {
-      const req = InboxSender.load<I, O>(inboxOwnerID, toRaw(me.value));
+    if (inbox.owner.id !== resolvedInboxOwnerID) {
+      const req = InboxSender.load<I, O>(resolvedInboxOwnerID, toRaw(me.value));
       inboxRef.value = req;
       inbox = await req;
     }
@@ -351,7 +356,7 @@ export function experimental_useInboxSender<
   };
 
   watch(
-    () => inboxOwnerID,
+    () => toValue(inboxOwnerID),
     () => {
       inboxRef.value = undefined;
     },

--- a/packages/community-jazz-vue/src/tests/useInboxSender.test.ts
+++ b/packages/community-jazz-vue/src/tests/useInboxSender.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from "vitest";
 import { experimental_useInboxSender } from "../composables.js";
 import { createJazzTestAccount, linkAccounts } from "../testing.js";
 import { withJazzTestSetup } from "./testUtils.js";
+import { ref } from "vue";
 
 describe("useInboxSender", () => {
   it("should send the message to the inbox", async () => {
@@ -59,5 +60,64 @@ describe("useInboxSender", () => {
 
     assertLoaded(responseMap);
     expect(responseMap.value).toEqual("got it");
+  });
+
+  it("should accept reactive input", async () => {
+    const TestMap = co.map({
+      value: z.string(),
+    });
+
+    const account = await createJazzTestAccount();
+    const inboxReceiver1 = await createJazzTestAccount();
+    const inboxReceiver2 = await createJazzTestAccount();
+
+    await linkAccounts(account, inboxReceiver1);
+    await linkAccounts(account, inboxReceiver2);
+
+    const id = ref(inboxReceiver1.$jazz.id);
+    const [result] = withJazzTestSetup(
+      () =>
+        experimental_useInboxSender<
+          Loaded<typeof TestMap>,
+          Loaded<typeof TestMap>
+        >(id),
+      {
+        account,
+      },
+    );
+
+    const sendMessage = result;
+
+    sendMessage(
+      TestMap.create(
+        { value: "hello" },
+        { owner: Group.create({ owner: account }) },
+      ),
+    );
+
+    const inbox1 = await Inbox.load(inboxReceiver1);
+
+    const incoming1 = await new Promise<Loaded<typeof TestMap>>((resolve) => {
+      inbox1.subscribe(TestMap, async (message) => resolve(message));
+    });
+
+    expect(incoming1.value).toEqual("hello");
+
+    // now the second inbox
+    id.value = inboxReceiver2.$jazz.id;
+
+    sendMessage(
+      TestMap.create(
+        { value: "hello to you too" },
+        { owner: Group.create({ owner: account }) },
+      ),
+    );
+    const inbox2 = await Inbox.load(inboxReceiver2);
+
+    const incoming2 = await new Promise<Loaded<typeof TestMap>>((resolve) => {
+      inbox2.subscribe(TestMap, async (message) => resolve(message));
+    });
+
+    expect(incoming2.value).toEqual("hello to you too");
   });
 });


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed -->
<!-- Please also include relevant motivation and context -->
<!-- Include any links to documentation like RFC’s if necessary -->
<!-- Add a link to to relevant preview environments or anything that would simplify visual review process -->
<!-- Supplemental screenshots and video are encouraged, but the primary description should be in text -->
this changes the useCoState and useInboxSender composables to accept reactive input using the [MaybeRefOrGetter](https://vuejs.org/api/utility-types#maybereforgetter) pattern.
this allows to for example useCoState with an id that was passed via a prop.

## Manual testing instructions

<!-- Add any actions required to manually test the changes -->
none required, automated tests should be enough, was tested in my app project tho.

## Tests

- [x] Tests have been added and/or updated
- [ ] Tests have not been updated, because: <!-- Insert reason for not updating tests here -->
- [ ] I need help with writing tests


## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [ ] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Allow reactive (MaybeRefOrGetter) IDs for `useCoState` and `experimental_useInboxSender`, resolving via `toValue` and adding tests for ref/getter inputs.
> 
> - **Vue Composables**
>   - `useCoState`:
>     - Change `id` to `MaybeRefOrGetter<string | undefined>` and resolve with `toValue` for initial state and `watch` deps.
>   - `experimental_useInboxSender`:
>     - Change `inboxOwnerID` to `MaybeRefOrGetter<string | undefined>`; resolve with `toValue`, validate, and reset cached sender on ID change.
> - **Tests**
>   - Add tests verifying `useCoState` accepts `ref` and getter IDs and updates on change.
>   - Add test verifying `experimental_useInboxSender` accepts reactive input and switches recipients correctly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9caa7a37a906576affd2382877fb154a573cc44d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->