### PR TITLE
Add warning regarding credential persistence on iOS

### DIFF
--- a/homepage/homepage/content/docs/code-snippets/key-features/authentication/authentication-states/expo.tsx
+++ b/homepage/homepage/content/docs/code-snippets/key-features/authentication/authentication-states/expo.tsx
@@ -39,7 +39,7 @@ function example1() {
     peer: `wss://cloud.jazz.tools/?key=${apiKey}`,
     // Controls when sync is enabled for
     // both Anonymous Authentication and Authenticated Account
-    when: "always", // or "signedUp" or "never"
+    when: "always", // or "signedUp" or "never"—use with caution. See warning below
   }}
 >
   <App />
@@ -58,7 +58,7 @@ function example2() {
   sync={{
     peer: `wss://cloud.jazz.tools/?key=${apiKey}`,
     // This makes the app work in local mode when using Anonymous Authentication
-    when: "signedUp",
+    when: "signedUp", // use with caution
   }}
 >
   <App />
@@ -78,8 +78,6 @@ function example3() {
   guestMode={true}
   sync={{
     peer: `wss://cloud.jazz.tools/?key=${apiKey}`,
-    // Only sync for authenticated users
-    when: "signedUp",
   }}
 >
   <App />

--- a/homepage/homepage/content/docs/key-features/authentication/authentication-states.mdx
+++ b/homepage/homepage/content/docs/key-features/authentication/authentication-states.mdx
@@ -2,7 +2,7 @@ export const metadata = {
   description: "Learn about Jazz's authentication states: anonymous, guest, and fully authenticated."
 };
 
-import { CodeGroup, ContentByFramework, RNLogo, ExpoLogo, VanillaLogo, SvelteLogo, ReactLogo, TabbedCodeGroup, TabbedCodeGroupItem } from "@/components/forMdx";
+import { Alert, CodeGroup, ContentByFramework, RNLogo, ExpoLogo, VanillaLogo, SvelteLogo, ReactLogo, TabbedCodeGroup, TabbedCodeGroupItem } from "@/components/forMdx";
 
 # Authentication States
 
@@ -147,6 +147,16 @@ For example, you may want to give users with Anonymous Authentication the opport
 ```
 </TabbedCodeGroupItem>
 </TabbedCodeGroup>
+
+<ContentByFramework framework="react-native-expo">
+  <Alert variant="warning" title="iOS Credential Persistence" className="mt-4">
+    When using `sync: 'never'` or `sync: 'signedUp'`, like all other data, the user's account exists only on their device, and is deleted if the user uninstalls your app. On iOS though, login credentials are saved to the Keychain, and are not deleted when the app is uninstalled. 
+    
+    If a user reinstalls your app, Jazz will try to re-use these credentials to sign in to an account that no longer exists, which will cause errors. 
+    
+    To avoid this, consider using `sync: 'always'` for your iOS users, or let them know they'll need to remove their credentials from Keychain before reinstalling.
+  </Alert>
+</ContentByFramework>
 
 <ContentByFramework framework={['react', 'react-native', 'react-native-expo', 'svelte']}>
 

--- a/homepage/homepage/content/docs/project-setup/providers.mdx
+++ b/homepage/homepage/content/docs/project-setup/providers.mdx
@@ -74,6 +74,16 @@ The `sync` property configures how your application connects to the Jazz network
 ```
 </CodeGroup>
 
+<ContentByFramework framework="react-native-expo">
+<Alert variant="warning" title="iOS Credential Persistence" className="mt-4">
+  When using `sync: 'never'` or `sync: 'signedUp'`, like all other data, the user's account exists only on their device, and is deleted if the user uninstalls your app. On iOS though, login credentials are saved to the Keychain, and are not deleted when the app is uninstalled. 
+  
+  If a user reinstalls your app, Jazz will try to re-use these credentials to sign in to an account that no longer exists, which will cause errors. 
+  
+  To avoid this, consider using `sync: 'always'` for your iOS users, or let them know they'll need to remove their credentials from Keychain before reinstalling.
+</Alert>
+</ContentByFramework>
+
 See [Authentication States](/docs/key-features/authentication/authentication-states#controlling-sync-for-different-authentication-states) for more details on how the `when` property affects synchronization based on authentication state.
 
 ### Account Schema


### PR DESCRIPTION
# Description
Updates the appropriate sections to add an alert for Expo that items stored in iOS keychain are NOT cleared between app reinstalls

## Manual testing instructions

N/A

## Tests

- [ ] Tests have been added and/or updated
- [x] Tests have not been updated, because: Docs only
- [ ] I need help with writing tests


## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [ ] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing