### PR TITLE
fix(cojson-storage-indexeddb): resolve error when adding key to uniqueSessions in multi-tab Jazz apps

### DIFF
--- a/.changeset/good-bats-work.md
+++ b/.changeset/good-bats-work.md
@@ -1,0 +1,5 @@
+---
+"cojson-storage-indexeddb": patch
+---
+
+Fixed "unable to add key to index 'uniqueSessions'" when using a Jazz app in multiple tabs

--- a/packages/cojson-storage-indexeddb/src/CoJsonIDBTransaction.ts
+++ b/packages/cojson-storage-indexeddb/src/CoJsonIDBTransaction.ts
@@ -40,6 +40,10 @@ export class CoJsonIDBTransaction {
     };
   }
 
+  rollback() {
+    this.tx.abort();
+  }
+
   startedAt = performance.now();
   isReusable() {
     const delta = performance.now() - this.startedAt;

--- a/packages/cojson-storage-indexeddb/src/idbClient.ts
+++ b/packages/cojson-storage-indexeddb/src/idbClient.ts
@@ -1,4 +1,9 @@
-import type { CojsonInternalTypes, RawCoID, SessionID } from "cojson";
+import type {
+  CojsonInternalTypes,
+  RawCoID,
+  SessionID,
+  DBTransactionInterfaceAsync,
+} from "cojson";
 import type {
   CoValueRow,
   DBClientInterfaceAsync,
@@ -14,6 +19,80 @@ import {
   queryIndexedDbStore,
 } from "./CoJsonIDBTransaction.js";
 
+export class IDBTransaction implements DBTransactionInterfaceAsync {
+  constructor(private tx: CoJsonIDBTransaction) {}
+
+  run<T>(
+    handler: (txEntry: CoJsonIDBTransaction) => IDBRequest<T>,
+  ): Promise<T> {
+    return this.tx.handleRequest<T>(handler);
+  }
+
+  async getSingleCoValueSession(
+    coValueRowId: number,
+    sessionID: SessionID,
+  ): Promise<StoredSessionRow | undefined> {
+    return this.run((tx) =>
+      tx
+        .getObjectStore("sessions")
+        .index("uniqueSessions")
+        .get([coValueRowId, sessionID]),
+    );
+  }
+
+  async addSessionUpdate({
+    sessionUpdate,
+    sessionRow,
+  }: {
+    sessionUpdate: SessionRow;
+    sessionRow?: StoredSessionRow;
+  }): Promise<number> {
+    return this.run<number>(
+      (tx) =>
+        tx.getObjectStore("sessions").put(
+          sessionRow?.rowID
+            ? {
+                rowID: sessionRow.rowID,
+                ...sessionUpdate,
+              }
+            : sessionUpdate,
+        ) as IDBRequest<number>,
+    );
+  }
+
+  async addTransaction(
+    sessionRowID: number,
+    idx: number,
+    newTransaction: CojsonInternalTypes.Transaction,
+  ) {
+    await this.run((tx) =>
+      tx.getObjectStore("transactions").add({
+        ses: sessionRowID,
+        idx,
+        tx: newTransaction,
+      } satisfies TransactionRow),
+    );
+  }
+
+  async addSignatureAfter({
+    sessionRowID,
+    idx,
+    signature,
+  }: {
+    sessionRowID: number;
+    idx: number;
+    signature: CojsonInternalTypes.Signature;
+  }) {
+    return this.run((tx) =>
+      tx.getObjectStore("signatureAfter").put({
+        ses: sessionRowID,
+        idx,
+        signature,
+      }),
+    );
+  }
+}
+
 export class IDBClient implements DBClientInterfaceAsync {
   private db;
 
@@ -22,16 +101,6 @@ export class IDBClient implements DBClientInterfaceAsync {
 
   constructor(db: IDBDatabase) {
     this.db = db;
-  }
-
-  getActiveReadWriteTransaction<T>(
-    handler: (txEntry: CoJsonIDBTransaction) => IDBRequest<T>,
-  ): Promise<T> {
-    if (this.activeTransaction) {
-      return this.activeTransaction.handleRequest<T>(handler);
-    }
-
-    throw new Error("No active transaction");
   }
 
   async getCoValue(coValueId: RawCoID): Promise<StoredCoValueRow | undefined> {
@@ -47,18 +116,6 @@ export class IDBClient implements DBClientInterfaceAsync {
   async getCoValueSessions(coValueRowId: number): Promise<StoredSessionRow[]> {
     return queryIndexedDbStore(this.db, "sessions", (store) =>
       store.index("sessionsByCoValue").getAll(coValueRowId),
-    );
-  }
-
-  async getSingleCoValueSession(
-    coValueRowId: number,
-    sessionID: SessionID,
-  ): Promise<StoredSessionRow | undefined> {
-    return this.getActiveReadWriteTransaction((tx) =>
-      tx
-        .getObjectStore("sessions")
-        .index("uniqueSessions")
-        .get([coValueRowId, sessionID]),
     );
   }
 
@@ -102,76 +159,16 @@ export class IDBClient implements DBClientInterfaceAsync {
     }).catch(() => this.getCoValueRowID(id));
   }
 
-  async addSessionUpdate({
-    sessionUpdate,
-    sessionRow,
-  }: {
-    sessionUpdate: SessionRow;
-    sessionRow?: StoredSessionRow;
-  }): Promise<number> {
-    return this.getActiveReadWriteTransaction<number>(
-      (tx) =>
-        tx.getObjectStore("sessions").put(
-          sessionRow?.rowID
-            ? {
-                rowID: sessionRow.rowID,
-                ...sessionUpdate,
-              }
-            : sessionUpdate,
-        ) as IDBRequest<number>,
-    );
-  }
-
-  async addTransaction(
-    sessionRowID: number,
-    idx: number,
-    newTransaction: CojsonInternalTypes.Transaction,
+  async transaction(
+    operationsCallback: (tx: DBTransactionInterfaceAsync) => Promise<unknown>,
   ) {
-    await this.getActiveReadWriteTransaction((tx) =>
-      tx.getObjectStore("transactions").add({
-        ses: sessionRowID,
-        idx,
-        tx: newTransaction,
-      } satisfies TransactionRow),
-    );
-  }
-
-  async addSignatureAfter({
-    sessionRowID,
-    idx,
-    signature,
-  }: {
-    sessionRowID: number;
-    idx: number;
-    signature: CojsonInternalTypes.Signature;
-  }) {
-    return this.getActiveReadWriteTransaction((tx) =>
-      tx.getObjectStore("signatureAfter").put({
-        ses: sessionRowID,
-        idx,
-        signature,
-      }),
-    );
-  }
-
-  closeTransaction(tx: CoJsonIDBTransaction) {
-    tx.commit();
-
-    if (tx === this.activeTransaction) {
-      this.activeTransaction = undefined;
-    }
-  }
-
-  async transaction(operationsCallback: () => unknown) {
     const tx = new CoJsonIDBTransaction(this.db);
 
-    this.activeTransaction = tx;
-
     try {
-      await operationsCallback();
+      await operationsCallback(new IDBTransaction(tx));
       tx.commit(); // Tells the browser to not wait for another possible request and commit the transaction immediately
-    } finally {
-      this.activeTransaction = undefined;
+    } catch (error) {
+      tx.rollback();
     }
   }
 }

--- a/packages/cojson-storage-indexeddb/src/idbClient.ts
+++ b/packages/cojson-storage-indexeddb/src/idbClient.ts
@@ -63,8 +63,11 @@ export class IDBClient implements DBClientInterfaceAsync {
     coValueRowId: number,
     sessionID: SessionID,
   ): Promise<StoredSessionRow | undefined> {
-    return queryIndexedDbStore(this.db, "sessions", (store) =>
-      store.index("uniqueSessions").get([coValueRowId, sessionID]),
+    return this.makeRequest((tx) =>
+      tx
+        .getObjectStore("sessions")
+        .index("uniqueSessions")
+        .get([coValueRowId, sessionID]),
     );
   }
 

--- a/packages/cojson/src/storage/sqlite/client.ts
+++ b/packages/cojson/src/storage/sqlite/client.ts
@@ -8,6 +8,7 @@ import { logger } from "../../logger.js";
 import type { NewContentMessage } from "../../sync.js";
 import type {
   DBClientInterfaceSync,
+  DBTransactionInterfaceSync,
   SessionRow,
   SignatureAfterRow,
   StoredCoValueRow,
@@ -31,7 +32,9 @@ export function getErrorMessage(error: unknown) {
   return error instanceof Error ? error.message : "Unknown error";
 }
 
-export class SQLiteClient implements DBClientInterfaceSync {
+export class SQLiteClient
+  implements DBClientInterfaceSync, DBTransactionInterfaceSync
+{
   private readonly db: SQLiteDatabaseDriver;
 
   constructor(db: SQLiteDatabaseDriver) {
@@ -187,8 +190,8 @@ export class SQLiteClient implements DBClientInterfaceSync {
     );
   }
 
-  transaction(operationsCallback: () => unknown) {
-    this.db.transaction(operationsCallback);
+  transaction(operationsCallback: (tx: DBTransactionInterfaceSync) => unknown) {
+    this.db.transaction(() => operationsCallback(this));
     return undefined;
   }
 }

--- a/packages/cojson/src/storage/sqliteAsync/client.ts
+++ b/packages/cojson/src/storage/sqliteAsync/client.ts
@@ -8,6 +8,7 @@ import { logger } from "../../logger.js";
 import type { NewContentMessage } from "../../sync.js";
 import type {
   DBClientInterfaceAsync,
+  DBTransactionInterfaceAsync,
   SessionRow,
   SignatureAfterRow,
   StoredCoValueRow,
@@ -31,7 +32,9 @@ export function getErrorMessage(error: unknown) {
   return error instanceof Error ? error.message : "Unknown error";
 }
 
-export class SQLiteClientAsync implements DBClientInterfaceAsync {
+export class SQLiteClientAsync
+  implements DBClientInterfaceAsync, DBTransactionInterfaceAsync
+{
   private readonly db: SQLiteDatabaseDriverAsync;
 
   constructor(db: SQLiteDatabaseDriverAsync) {
@@ -194,7 +197,9 @@ export class SQLiteClientAsync implements DBClientInterfaceAsync {
     );
   }
 
-  async transaction(operationsCallback: () => unknown) {
-    return this.db.transaction(operationsCallback);
+  async transaction(
+    operationsCallback: (tx: DBTransactionInterfaceAsync) => Promise<unknown>,
+  ) {
+    return this.db.transaction(() => operationsCallback(this));
   }
 }

--- a/packages/cojson/src/storage/types.ts
+++ b/packages/cojson/src/storage/types.ts
@@ -61,33 +61,11 @@ export type SignatureAfterRow = {
   signature: Signature;
 };
 
-export interface DBClientInterfaceAsync {
-  getCoValue(
-    coValueId: string,
-  ): Promise<StoredCoValueRow | undefined> | undefined;
-
-  upsertCoValue(
-    id: string,
-    header?: CoValueHeader,
-  ): Promise<number | undefined>;
-
-  getCoValueSessions(coValueRowId: number): Promise<StoredSessionRow[]>;
-
+export interface DBTransactionInterfaceAsync {
   getSingleCoValueSession(
     coValueRowId: number,
     sessionID: SessionID,
   ): Promise<StoredSessionRow | undefined>;
-
-  getNewTransactionInSession(
-    sessionRowId: number,
-    fromIdx: number,
-    toIdx: number,
-  ): Promise<TransactionRow[]>;
-
-  getSignatures(
-    sessionRowId: number,
-    firstNewTxIdx: number,
-  ): Promise<SignatureAfterRow[]>;
 
   addSessionUpdate({
     sessionUpdate,
@@ -112,32 +90,41 @@ export interface DBClientInterfaceAsync {
     idx: number;
     signature: Signature;
   }): Promise<unknown>;
-
-  transaction(callback: () => unknown): Promise<unknown>;
 }
 
-export interface DBClientInterfaceSync {
-  getCoValue(coValueId: string): StoredCoValueRow | undefined;
+export interface DBClientInterfaceAsync {
+  getCoValue(
+    coValueId: string,
+  ): Promise<StoredCoValueRow | undefined> | undefined;
 
-  upsertCoValue(id: string, header?: CoValueHeader): number | undefined;
+  upsertCoValue(
+    id: string,
+    header?: CoValueHeader,
+  ): Promise<number | undefined>;
 
-  getCoValueSessions(coValueRowId: number): StoredSessionRow[];
-
-  getSingleCoValueSession(
-    coValueRowId: number,
-    sessionID: SessionID,
-  ): StoredSessionRow | undefined;
+  getCoValueSessions(coValueRowId: number): Promise<StoredSessionRow[]>;
 
   getNewTransactionInSession(
     sessionRowId: number,
     fromIdx: number,
     toIdx: number,
-  ): TransactionRow[];
+  ): Promise<TransactionRow[]>;
 
   getSignatures(
     sessionRowId: number,
     firstNewTxIdx: number,
-  ): Pick<SignatureAfterRow, "idx" | "signature">[];
+  ): Promise<SignatureAfterRow[]>;
+
+  transaction(
+    callback: (tx: DBTransactionInterfaceAsync) => Promise<unknown>,
+  ): Promise<unknown>;
+}
+
+export interface DBTransactionInterfaceSync {
+  getSingleCoValueSession(
+    coValueRowId: number,
+    sessionID: SessionID,
+  ): StoredSessionRow | undefined;
 
   addSessionUpdate({
     sessionUpdate,
@@ -162,6 +149,25 @@ export interface DBClientInterfaceSync {
     idx: number;
     signature: Signature;
   }): number | undefined | unknown;
+}
 
-  transaction(callback: () => unknown): unknown;
+export interface DBClientInterfaceSync {
+  getCoValue(coValueId: string): StoredCoValueRow | undefined;
+
+  upsertCoValue(id: string, header?: CoValueHeader): number | undefined;
+
+  getCoValueSessions(coValueRowId: number): StoredSessionRow[];
+
+  getNewTransactionInSession(
+    sessionRowId: number,
+    fromIdx: number,
+    toIdx: number,
+  ): TransactionRow[];
+
+  getSignatures(
+    sessionRowId: number,
+    firstNewTxIdx: number,
+  ): Pick<SignatureAfterRow, "idx" | "signature">[];
+
+  transaction(callback: (tx: DBTransactionInterfaceSync) => unknown): unknown;
 }


### PR DESCRIPTION
Switching `getSingleCoValueSession` in the indexeddb client to use the `readwrite` transaction we use for the updates.

This way it should be executed on the same transaction we use for updates, ensuring consistency [during the update transaction.](https://github.com/garden-co/jazz/blob/main/packages/cojson/src/storage/storageAsync.ts#L283)