### PR TITLE
Fix issue with $onError not working in `ensureLoaded`

### DIFF
--- a/.changeset/better-grapes-stay.md
+++ b/.changeset/better-grapes-stay.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Ensured ensureLoaded properly handles $onError in resolve queries

--- a/examples/jazz-sveltekit/src/routes/+layout.svelte
+++ b/examples/jazz-sveltekit/src/routes/+layout.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
   import { JazzSvelteProvider } from "jazz-tools/svelte";
   import { apiKey } from "$lib/apiKey";
+  import type { SyncConfig } from "jazz-tools";
 
   let { children } = $props();
-  const sync = { peer: `wss://cloud.jazz.tools/?key=${apiKey}` };
+  const sync: SyncConfig = { peer: `wss://cloud.jazz.tools/?key=${apiKey}` };
 </script>
 
 <!-- Add the enableSSR flag to allow Jazz to render data server side -->

--- a/packages/jazz-tools/src/tools/subscribe/SubscriptionScope.ts
+++ b/packages/jazz-tools/src/tools/subscribe/SubscriptionScope.ts
@@ -627,6 +627,12 @@ export class SubscriptionScope<D extends CoValue> {
       return undefined;
     }
 
+    // Check if $onError: "catch" is specified for this key
+    const skipInvalid = typeof depth === "object" && depth.$onError === "catch";
+    if (skipInvalid) {
+      this.skipInvalidKeys.add(key);
+    }
+
     const id = map.$jazz.raw.get(key) as string | undefined;
     const descriptor = map.$jazz.getDescriptor(key);
 

--- a/packages/jazz-tools/src/tools/tests/deepLoading.test.ts
+++ b/packages/jazz-tools/src/tools/tests/deepLoading.test.ts
@@ -1169,6 +1169,28 @@ test("should not throw when calling ensureLoaded a record with a deleted ref", a
   unsub();
 });
 
+test("should not throw when calling ensureLoaded a record with a non-existent key if there's a catch block", async () => {
+  const Person = co.record(
+    z.string(),
+    co.map({
+      name: z.string(),
+      breed: z.string(),
+    }),
+  );
+
+  const person = Person.create({});
+
+  const loadedPerson = await person.$jazz.ensureLoaded({
+    resolve: {
+      ["pet1"]: {
+        $onError: "catch",
+      },
+    },
+  });
+
+  expect(loadedPerson.pet1).toBeUndefined();
+});
+
 // This was a regression that ocurred when we migrated `DeeplyLoaded` to use explicit loading states.
 // Keeping this test to prevent it from happening again.
 test("deep loaded CoList nested inside another CoValue can be iterated over", async () => {


### PR DESCRIPTION
# Description
Initially reported here: https://discord.com/channels/1139617727565271160/1139621689882321009/1442275363177762837

While resolve queries for `load` with `$onError: 'catch'` were behaving correctly, using `ensureLoaded` was throwing because the logic for adding invalid keys to the `skipInvalidKeys` set is only running in case `get(key)` returns a truthy value (https://github.com/garden-co/jazz/blob/5b51eed90be7b385cbd6e67973d21b8d957a6e98/packages/jazz-tools/src/tools/subscribe/SubscriptionScope.ts#L644)

Also adds a test, and fixes a build error with the `jazz-sveltekit` example.

## Manual testing instructions

N/A: covered by automated tests.

## Tests

- [x] Tests have been added and/or updated
- [ ] Tests have not been updated, because: <!-- Insert reason for not updating tests here -->
- [ ] I need help with writing tests


## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [x] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing