### PR TITLE
Add feedback buttons to every article

### DIFF
--- a/homepage/homepage/components/docs/FeedbackAffordances.tsx
+++ b/homepage/homepage/components/docs/FeedbackAffordances.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useState } from 'react';
+import { track } from "@vercel/analytics";
+import { Button } from "@garden-co/design-system/src/components/atoms/Button";
+
+export function FeedbackAffordances() {
+  const [option, setOption] = useState<'helpful' | 'not_helpful' | null>(null);
+  const handleClick = (type: 'helpful' | 'not_helpful') => {
+    // If the user is changing their feedback, let them, otherwise block them from voting again
+    if (option === type) return;
+    setOption(type);
+    track('Docs feedback', { feedback: type });
+  };
+
+  return (
+    <div className="flex flex-row justify-start flex-wrap items-center gap-2 py-2">
+      <strong>Was this page helpful?</strong>
+      <div>
+        <Button
+          size="sm"
+          icon="check"
+          variant={option === 'helpful' ? 'inverted' : 'default'}
+          onClick={() => handleClick('helpful')}
+          className="rounded-r-none"
+        >
+          Yes
+        </Button>
+        <Button
+          size="sm"
+          icon="close"
+          variant={option === 'not_helpful' ? 'inverted' : 'default'}
+          onClick={() => handleClick('not_helpful')}
+          className="rounded-l-none"
+        >
+          No
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/homepage/homepage/components/docs/FeedbackAffordances.tsx
+++ b/homepage/homepage/components/docs/FeedbackAffordances.tsx
@@ -3,14 +3,17 @@
 import { useState } from 'react';
 import { track } from "@vercel/analytics";
 import { Button } from "@garden-co/design-system/src/components/atoms/Button";
+import { usePathname } from "next/navigation";
 
 export function FeedbackAffordances() {
   const [option, setOption] = useState<'helpful' | 'not_helpful' | null>(null);
+  const pathname = usePathname();
+
   const handleClick = (type: 'helpful' | 'not_helpful') => {
     // If the user is changing their feedback, let them, otherwise block them from voting again
     if (option === type) return;
     setOption(type);
-    track('Docs feedback', { feedback: type });
+    track('Docs feedback', { feedback: type, page: pathname });
   };
 
   return (

--- a/homepage/homepage/lib/docMdxContent.tsx
+++ b/homepage/homepage/lib/docMdxContent.tsx
@@ -1,10 +1,10 @@
 import DocsLayout from "@/components/docs/DocsLayout";
 import { DocNav } from "@/components/docs/DocsNav";
+import { FeedbackAffordances } from "@/components/docs/FeedbackAffordances";
 import { HelpLinks } from "@/components/docs/HelpLinks";
 import { PreviousNextLinks } from "@/components/docs/PreviousNextLinks";
 import { Prose } from "@garden-co/design-system/src/components/molecules/Prose";
 import { Toc } from "@stefanprobst/rehype-extract-toc";
-import { error } from "console";
 
 export function DocProse({ children }: { children: React.ReactNode }) {
   return (
@@ -151,7 +151,9 @@ export async function DocPage({ framework, slug }: { framework: string; slug?: s
       <DocsLayout nav={<DocNav />} tocItems={tocItems} pagefindLowPriority={slug?.length ? slug[0] === "upgrade" : false}>
         <DocProse>
           <Content />
-          <div className="divide-y mt-12">
+          <FeedbackAffordances />
+
+          <div className="divide-y">
             <HelpLinks className="lg:hidden pb-4" />
             <PreviousNextLinks slug={slug} framework={framework} />
           </div>


### PR DESCRIPTION
# Description
Adds a 'Was this helpful?' prompt at the bottom of each article with buttons 'yes' and 'no' which trigger analytics events

## Manual testing instructions
Look at a docs page and check for the links at the bottom of the content.

## Tests

- [ ] Tests have been added and/or updated
- [x] Tests have not been updated, because: N/A
- [ ] I need help with writing tests


## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [ ] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing