### PR TITLE
Upgrade `react-native-quick-crypto` to version 1.0.0-beta.21 and switch to using the native blake3 in RNQuickCrypto

### DIFF
--- a/.changeset/five-comics-peel.md
+++ b/.changeset/five-comics-peel.md
@@ -1,0 +1,7 @@
+---
+"jazz-tools": patch
+---
+
+Upgraded `react-native-quick-crypto` to version 1.0.0-beta.21 and switch to using the native blake3 in RNQuickCrypto
+
+Breaking: any app that uses RNQuickCrypto will have to upgrade to `react-native-quick-crypto@1.0.0-beta.21`

--- a/examples/chat-rn-expo/app.json
+++ b/examples/chat-rn-expo/app.json
@@ -27,6 +27,15 @@
     "web": {
       "favicon": "./assets/favicon.png"
     },
-    "plugins": ["expo-secure-store", "expo-sqlite"]
+    "plugins": [
+      "expo-secure-store",
+      "expo-sqlite",
+      [
+        "react-native-quick-crypto",
+        {
+          "sodiumEnabled": true
+        }
+      ]
+    ]
   }
 }

--- a/examples/chat-rn-expo/package.json
+++ b/examples/chat-rn-expo/package.json
@@ -25,6 +25,7 @@
     "react-native-get-random-values": "^1.11.0",
     "react-native-image-picker": "^8.2.1",
     "react-native-nitro-modules": "0.26.4",
+    "react-native-quick-crypto": "1.0.0-beta.21",
     "readable-stream": "^4.7.0"
   },
   "devDependencies": {

--- a/examples/chat-rn-expo/src/App.tsx
+++ b/examples/chat-rn-expo/src/App.tsx
@@ -2,11 +2,13 @@ import { JazzExpoProvider } from "jazz-tools/expo";
 import React, { StrictMode } from "react";
 import { apiKey } from "./apiKey";
 import ChatScreen from "./chat";
+import { RNQuickCrypto } from "jazz-tools/expo/crypto";
 
 export default function App() {
   return (
     <StrictMode>
       <JazzExpoProvider
+        CryptoProvider={RNQuickCrypto}
         sync={{
           peer: `wss://cloud.jazz.tools/?key=${apiKey}`,
         }}

--- a/examples/chat-rn-expo/src/schema.ts
+++ b/examples/chat-rn-expo/src/schema.ts
@@ -1,7 +1,7 @@
 import { co, z } from "jazz-tools";
 
 export const Message = co.map({
-  text: z.string(),
+  text: co.plainText(),
   image: co.image().optional(),
 });
 export type Message = co.loaded<typeof Message>;

--- a/packages/jazz-tools/package.json
+++ b/packages/jazz-tools/package.json
@@ -256,7 +256,7 @@
     "react-native-fast-encoder": "^0.2.0",
     "react-native-mmkv": "^3.3.0",
     "react-native-nitro-modules": "^0.26.4",
-    "react-native-quick-crypto": "^1.0.0-beta.18",
+    "react-native-quick-crypto": "1.0.0-beta.21",
     "sharp": "^0.33.5",
     "svelte": "^5.0.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -147,7 +147,7 @@ importers:
         version: link:../packages/cojson
       cojson-latest:
         specifier: npm:cojson@latest
-        version: cojson@0.19.3
+        version: cojson@0.19.4
       cronometro:
         specifier: ^5.3.0
         version: 5.3.0
@@ -156,7 +156,7 @@ importers:
         version: link:../packages/jazz-tools
       jazz-tools-latest:
         specifier: npm:jazz-tools@latest
-        version: jazz-tools@0.19.3(68f7a3ac23d8845d11a369ae92f7f0fa)
+        version: jazz-tools@0.19.4(24043b7f0320f7f00ff0c02eeb858bba)
       vitest:
         specifier: catalog:default
         version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.0)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(happy-dom@20.0.7)(jiti@2.5.1)(jsdom@25.0.1)(lightningcss@1.30.2)(msw@2.10.4(@types/node@24.10.0)(typescript@5.9.2))(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.1)
@@ -271,7 +271,7 @@ importers:
         version: 1.2.3(@types/react@19.1.0)(react@19.1.0)
       better-auth:
         specifier: ^1.3.4
-        version: 1.3.28(better-sqlite3@11.10.0)(next@15.3.2(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.50.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.3.28(better-sqlite3@11.10.0)(next@15.3.2(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(@playwright/test@1.50.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -286,7 +286,7 @@ importers:
         version: 0.510.0(react@19.1.0)
       next:
         specifier: 15.3.2
-        version: 15.3.2(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.50.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 15.3.2(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(@playwright/test@1.50.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: 19.1.0
         version: 19.1.0
@@ -329,7 +329,7 @@ importers:
         version: link:../../packages/jazz-run
       react-email:
         specifier: ^4.0.11
-        version: 4.0.13(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.50.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 4.0.13(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(@playwright/test@1.50.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       tailwindcss:
         specifier: ^4
         version: 4.1.10
@@ -551,6 +551,9 @@ importers:
       react-native-nitro-modules:
         specifier: 0.26.4
         version: 0.26.4(react-native@0.81.0(@babel/core@7.27.1)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.27.1))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
+      react-native-quick-crypto:
+        specifier: 1.0.0-beta.21
+        version: 1.0.0-beta.21(expo@54.0.0-preview.4(@babel/core@7.27.1)(graphql@16.11.0)(react-native@0.81.0(@babel/core@7.27.1)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.27.1))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native-nitro-modules@0.26.4(react-native@0.81.0(@babel/core@7.27.1)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.27.1))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native@0.81.0(@babel/core@7.27.1)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.27.1))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
       readable-stream:
         specifier: ^4.7.0
         version: 4.7.0
@@ -1193,7 +1196,7 @@ importers:
         version: link:../../packages/jazz-tools
       next:
         specifier: 15.3.2
-        version: 15.3.2(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.50.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 15.3.2(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(@playwright/test@1.50.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: 19.1.0
         version: 19.1.0
@@ -1768,7 +1771,7 @@ importers:
         version: 0.525.0(react@19.1.0)
       next:
         specifier: 15.3.2
-        version: 15.3.2(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.50.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 15.3.2(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(@playwright/test@1.50.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -2435,8 +2438,8 @@ importers:
         specifier: ^0.26.4
         version: 0.26.4(react-native@0.80.0(@babel/core@7.28.5)(@react-native-community/cli@19.0.0(typescript@5.6.2))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
       react-native-quick-crypto:
-        specifier: ^1.0.0-beta.18
-        version: 1.0.0-beta.20(expo@54.0.22(@babel/core@7.28.5)(graphql@16.11.0)(react-native@0.80.0(@babel/core@7.28.5)(@react-native-community/cli@19.0.0(typescript@5.6.2))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native-nitro-modules@0.26.4(react-native@0.80.0(@babel/core@7.28.5)(@react-native-community/cli@19.0.0(typescript@5.6.2))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native@0.80.0(@babel/core@7.28.5)(@react-native-community/cli@19.0.0(typescript@5.6.2))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
+        specifier: 1.0.0-beta.21
+        version: 1.0.0-beta.21(expo@54.0.22(@babel/core@7.28.5)(graphql@16.11.0)(react-native@0.80.0(@babel/core@7.28.5)(@react-native-community/cli@19.0.0(typescript@5.6.2))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native-nitro-modules@0.26.4(react-native@0.80.0(@babel/core@7.28.5)(@react-native-community/cli@19.0.0(typescript@5.6.2))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native@0.80.0(@babel/core@7.28.5)(@react-native-community/cli@19.0.0(typescript@5.6.2))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
       sharp:
         specifier: ^0.33.5
         version: 0.33.5
@@ -2565,7 +2568,7 @@ importers:
         version: 0.525.0(react@19.1.0)
       next:
         specifier: 15.4.2
-        version: 15.4.2(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.50.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 15.4.2(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(@playwright/test@1.50.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: 19.1.0
         version: 19.1.0
@@ -2932,7 +2935,7 @@ importers:
         version: link:../../packages/jazz-tools
       next:
         specifier: 15.5.3
-        version: 15.5.3(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.50.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 15.5.3(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(@playwright/test@1.50.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: 19.1.0
         version: 19.1.0
@@ -10641,67 +10644,67 @@ packages:
   code-block-writer@13.0.3:
     resolution: {integrity: sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==}
 
-  cojson-core-napi-darwin-arm64@0.19.3:
-    resolution: {integrity: sha512-hVXlMsMGclagY6uAfNAoIj7Z+BaW8EDf9OrAuoc+51+rwvrkrB9BLoDJ3mRH1bKU3vJH4AErLPYf42UqmiRGtw==}
+  cojson-core-napi-darwin-arm64@0.19.4:
+    resolution: {integrity: sha512-ctsqKhNUfIa0dVy2YNrPZ9eVRDpzGim3IdYPX7xHlIync9LKx9+AkEurSWSZmj5XHecj2nJrKyQeZI+sTWdjjw==}
     engines: {node: '>= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0'}
     cpu: [arm64]
     os: [darwin]
 
-  cojson-core-napi-darwin-x64@0.19.3:
-    resolution: {integrity: sha512-ZeB158KX4qytvi2gzs15XTdRcs0vZRsnZoybXdnhzZUDGxSy3Zu/MhSU+q3ygnzlB2LltYcILuDwwJiTHBKC7A==}
+  cojson-core-napi-darwin-x64@0.19.4:
+    resolution: {integrity: sha512-FdnRe/CWlwi6EZ2SXpIyq+hOAYhgyFkmkGEol/Oa6ijtBWOEfo/DrbJ+YX39sgpuVY75SQXnKAJ/JqTt0TQklw==}
     engines: {node: '>= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0'}
     cpu: [x64]
     os: [darwin]
 
-  cojson-core-napi-linux-arm-gnueabihf@0.19.3:
-    resolution: {integrity: sha512-Zl79dNnyEcrt1hVTJr9c1eX933/Sk1uCC1JqiOBjtoCdaW2T4TOdKer/Qlntqr6grF/eEzblLSMpc75WMf9fTQ==}
+  cojson-core-napi-linux-arm-gnueabihf@0.19.4:
+    resolution: {integrity: sha512-hhAYfm0Lxf+WmCjb3382aJo7B+yQn1YEnzF+dIW6KIQK5edJsI3gV1hxZHBtShfQ5HEywoGXhg39ktsMcxk9pA==}
     engines: {node: '>= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0'}
     cpu: [arm]
     os: [linux]
 
-  cojson-core-napi-linux-arm64-gnu@0.19.3:
-    resolution: {integrity: sha512-RQ1/p1FDR7XrtS+LlQSh6GUJGTqZ6IaNGzA2QPhKoo+y7KvhtWeeEen8MeHVa6i1vxurszlobOlgbkXC/aMDOg==}
+  cojson-core-napi-linux-arm64-gnu@0.19.4:
+    resolution: {integrity: sha512-6BqlmzwHmyYk27nK73Y87M1cHq1WFKCFMlW4Yr8AoOPniLJWQoxNjI3kq+37ZKqiVH8uLjPT+Bt90yZTIZBuHw==}
     engines: {node: '>= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  cojson-core-napi-linux-arm64-musl@0.19.3:
-    resolution: {integrity: sha512-l43lqMHtyhUziAdM8lLlzWO3gVcZK/RKmx7Z//fLE76UMyrY+jA4B9b46v8sWIaIrydoXHKYof+MrSlEBzCBdw==}
+  cojson-core-napi-linux-arm64-musl@0.19.4:
+    resolution: {integrity: sha512-Hv5RHJAfP4lWOVkfTeG9pnaFW0gFTYAk/wrfWQdU/n/Q8oUZ9hthYrzMuVk6df4zLZB4JsTS4WKDW/zEyIowkA==}
     engines: {node: '>= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  cojson-core-napi-linux-x64-gnu@0.19.3:
-    resolution: {integrity: sha512-AfepbdsvSo1UEs8BtBeKBs3jlAYDLKPMfF5/IwZ5oA49MkNrC39EmIK1sPbUrIC5xWaFbYUFUCUx4bkL33nDTw==}
+  cojson-core-napi-linux-x64-gnu@0.19.4:
+    resolution: {integrity: sha512-nJHaS4sFF68TiSl4oouvBkfeS3/P0u2xBCbp2kpwbv5hyz4XJeFf4jnWCRcniPhIY2eCdC501+LdegA/x0Fyzg==}
     engines: {node: '>= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  cojson-core-napi-linux-x64-musl@0.19.3:
-    resolution: {integrity: sha512-jwl1efXxnJTDO29VDfbuuQIfMN3tRskbZF/AKrA06HaCJqyZIi0GeKQmxs/M+5bNe8bruCKWgvUBZ72ybnASsA==}
+  cojson-core-napi-linux-x64-musl@0.19.4:
+    resolution: {integrity: sha512-9+bGeGTw7AZHOmaWpVqulJq2JgOcRonD4LTHmjtegP+ubEw3V3rralKWQwKDctjZf/+Et+OGArpUqycRgHXONA==}
     engines: {node: '>= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  cojson-core-napi@0.19.3:
-    resolution: {integrity: sha512-D/E+oGcL+J4+eOAXaB8FvM2Hq1gVwbt4mHTLjgFP1Ezdxw89Ib+cV4gh8tZtVR6Ui2OOdyjhUDNlYDD5M3Rhyg==}
+  cojson-core-napi@0.19.4:
+    resolution: {integrity: sha512-7+7zC35Y3oiC79uC/kt9utPHqyrL3mBlFUTz/A7ezIZwL5gwUyL1YMkV6eMnSY0RLIBtiEBWC8aLzRmFQQ9Tlw==}
     engines: {node: '>= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0'}
 
-  cojson-core-wasm@0.19.3:
-    resolution: {integrity: sha512-cfYtOnaOYOH4z1vT/EJPPtQI2XyvhS/6AKyiMJvFdD+hxHL6T6yYLuJL0wLoeXnJt/mMtGFqEhDLdrLkEV5Vew==}
+  cojson-core-wasm@0.19.4:
+    resolution: {integrity: sha512-sKe4inN+39JXW/ryOwwAyGMqG2IUs86tyijtES2aQtbcZP0sGh2z8CgKkvTTn6zodXviqvHAYJQy3nmDUwlr5Q==}
 
-  cojson-storage-indexeddb@0.19.3:
-    resolution: {integrity: sha512-gD4oOoUX8YuOpg+3UqWo9akxUZ5QvueAMaD2N3/PcSn6ztyHp7oAzpgi1s90olKlWa/bzLhk5JR3pCg7EGW0HQ==}
+  cojson-storage-indexeddb@0.19.4:
+    resolution: {integrity: sha512-zLzNVXwcHXrwkEybcIrbn+jtPt0Fs+ZOd/WJMRCoX8Sl2TsNQD05CJH65VWF8sBkzYegt0MDNlnMK5wKW+zv2A==}
 
-  cojson-transport-ws@0.19.3:
-    resolution: {integrity: sha512-rhOcSUCoIUXpKxM3VWcfyAr6lSquBfn/o+s/X4TBF8GY4EYVq2sy3zJs/n4PjC/w+yQnWmV88BzcE3YkWFw6Qg==}
+  cojson-transport-ws@0.19.4:
+    resolution: {integrity: sha512-JphuVBob/VNRcH3gBkP3UjQ5gZqa3M8+8iUP24g9jHks1rVeDazvczCnbHsYBhTLOXh9+wRaEy+KOZ9k9d8m4Q==}
 
-  cojson@0.19.3:
-    resolution: {integrity: sha512-ZXSRY/+14nbcHRlp7pVqkCmi8dzSsnRP6XrCDzd7g6R/ncm6sq0ucQOqbS7evJVAPfEEFIDQKnioojD2M14fAA==}
+  cojson@0.19.4:
+    resolution: {integrity: sha512-jbG0MCNHyf/MNXCB0A+m1DM/sOTUU1BHaGjtKmcif7OPB5QUsH8vCCzg7+NnGB/8J4jOt4RkDX8n9OzNS7/hKw==}
 
   collect-v8-coverage@1.0.3:
     resolution: {integrity: sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==}
@@ -11700,6 +11703,11 @@ packages:
       react: 19.1.0
       react-native: '*'
 
+  expo-build-properties@0.14.6:
+    resolution: {integrity: sha512-46+gcnFxb2Dz2TFEhFlEJ11qT85THlPtFgkRKQ3a11S3+stgDzDBC2WwbXS5/GMINLIDdBFbbZlajgVND0tMnQ==}
+    peerDependencies:
+      expo: '*'
+
   expo-clipboard@8.0.2:
     resolution: {integrity: sha512-588+Rrye4z4G80CKM9Kw7Dq8VJeMI9XVMV9cyRPtdzkUH4EIarfCCSBthW8wTSYtImr3r5skQCALnVU5pkFbrA==}
     peerDependencies:
@@ -12069,9 +12077,6 @@ packages:
 
   fontfaceobserver@2.3.0:
     resolution: {integrity: sha512-6FPvD/IVyT4ZlNe7Wcn5Fb/4ChigpucKYSvD6a+0iMoLn2inpo711eyIcKjmDtE5XNcgAkSH9uN/nfAeZzHEfg==}
-
-  for-each@0.3.3:
-    resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
 
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
@@ -12882,8 +12887,8 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  jazz-tools@0.19.3:
-    resolution: {integrity: sha512-+wx8mrgxYRQgx7fokS5CDsi7YMzmzo9QT6qTkOhaL950OqTjTtdZP5EEbs2jApHZYAm5fnByyYHkxDahfatQlA==}
+  jazz-tools@0.19.4:
+    resolution: {integrity: sha512-CvTy3hcxMDLIE0OEpv33i5XB9EY3CLxWcf/uEKGkfM3Ez3Z1wZJhgAc45D53ACC4FWAkYRnJZc0iDNxf5oBMUQ==}
     peerDependencies:
       '@bam.tech/react-native-image-resizer': '*'
       '@op-engineering/op-sqlite': '*'
@@ -15444,19 +15449,19 @@ packages:
       react: 19.1.0
       react-native: '*'
 
-  react-native-quick-base64@2.2.0:
-    resolution: {integrity: sha512-r7/BRsRl8QKEhS0JsHW6QX9+8LrC6NNWlwNnBnZ69h2kbcfABYsUILT71obrs9fqElEIMzuYSI5aHID955akyQ==}
+  react-native-quick-base64@2.2.2:
+    resolution: {integrity: sha512-WLHSifHLoamr2kF00Gov0W9ud6CfPshe1rmqWTquVIi9c62qxOaJCFVDrXFZhEBU8B8PvGLVuOlVKH78yhY0Fg==}
     peerDependencies:
       react: 19.1.0
       react-native: '*'
 
-  react-native-quick-crypto@1.0.0-beta.20:
-    resolution: {integrity: sha512-/9lYyD18y3zkQO9kNKIbPDaLRBRQUquijWgMnnBkPjjffMqkVr0qYHQqOOj3WUn2j5b4RIaD2nPW6YkEiDFZtg==}
+  react-native-quick-crypto@1.0.0-beta.21:
+    resolution: {integrity: sha512-/frTnTu7M6WlVnc8t3ybXQ1fI3EshD3wB+ARD1jb8Lk1519TA4st8LEjpvj9MbThUQZ4jZ0PFwl2s3ybQ+fH7g==}
     peerDependencies:
-      expo: '>=47.0.0'
+      expo: '>=48.0.0'
       react: 19.1.0
       react-native: '*'
-      react-native-nitro-modules: '*'
+      react-native-nitro-modules: '>=0.29.1'
     peerDependenciesMeta:
       expo:
         optional: true
@@ -17532,10 +17537,6 @@ packages:
 
   which-module@2.0.1:
     resolution: {integrity: sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==}
-
-  which-typed-array@1.1.18:
-    resolution: {integrity: sha512-qEcY+KJYlWyLH9vNbsr6/5j59AXk5ni5aakf8ldzBvGde6Iz4sxZGkJyWSAueTG7QhOvNRYb1lDdFmL5Td0QKA==}
-    engines: {node: '>= 0.4'}
 
   which-typed-array@1.1.19:
     resolution: {integrity: sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==}
@@ -20919,7 +20920,15 @@ snapshots:
   '@craftzdog/react-native-buffer@6.1.0(react-native@0.80.0(@babel/core@7.28.5)(@react-native-community/cli@19.0.0(typescript@5.6.2))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)':
     dependencies:
       ieee754: 1.2.1
-      react-native-quick-base64: 2.2.0(react-native@0.80.0(@babel/core@7.28.5)(@react-native-community/cli@19.0.0(typescript@5.6.2))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
+      react-native-quick-base64: 2.2.2(react-native@0.80.0(@babel/core@7.28.5)(@react-native-community/cli@19.0.0(typescript@5.6.2))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
+    transitivePeerDependencies:
+      - react
+      - react-native
+
+  '@craftzdog/react-native-buffer@6.1.0(react-native@0.81.0(@babel/core@7.27.1)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.27.1))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      ieee754: 1.2.1
+      react-native-quick-base64: 2.2.2(react-native@0.81.0(@babel/core@7.27.1)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.27.1))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
     transitivePeerDependencies:
       - react
       - react-native
@@ -20927,7 +20936,7 @@ snapshots:
   '@craftzdog/react-native-buffer@6.1.0(react-native@0.81.0(@babel/core@7.28.5)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.5))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)':
     dependencies:
       ieee754: 1.2.1
-      react-native-quick-base64: 2.2.0(react-native@0.81.0(@babel/core@7.28.5)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.5))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
+      react-native-quick-base64: 2.2.2(react-native@0.81.0(@babel/core@7.28.5)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.5))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
     transitivePeerDependencies:
       - react
       - react-native
@@ -25233,9 +25242,7 @@ snapshots:
       metro-runtime: 0.83.2
     transitivePeerDependencies:
       - '@babel/core'
-      - bufferutil
       - supports-color
-      - utf-8-validate
     optional: true
 
   '@react-native/normalize-colors@0.80.0': {}
@@ -28121,7 +28128,7 @@ snapshots:
 
   before-after-hook@4.0.0: {}
 
-  better-auth@1.3.28(better-sqlite3@11.10.0)(next@15.3.2(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.50.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+  better-auth@1.3.28(better-sqlite3@11.10.0)(next@15.3.2(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(@playwright/test@1.50.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
       '@better-auth/core': 1.3.28(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.18)(better-call@1.0.19)(better-sqlite3@11.10.0)(jose@6.1.0)(kysely@0.28.5)(nanostores@1.0.1)
       '@better-auth/telemetry': 1.3.28(better-call@1.0.19)(better-sqlite3@11.10.0)(jose@6.1.0)(kysely@0.28.5)(nanostores@1.0.1)
@@ -28138,7 +28145,7 @@ snapshots:
       nanostores: 1.0.1
       zod: 4.1.11
     optionalDependencies:
-      next: 15.3.2(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.50.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      next: 15.3.2(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(@playwright/test@1.50.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
     transitivePeerDependencies:
@@ -28567,57 +28574,57 @@ snapshots:
 
   code-block-writer@13.0.3: {}
 
-  cojson-core-napi-darwin-arm64@0.19.3:
+  cojson-core-napi-darwin-arm64@0.19.4:
     optional: true
 
-  cojson-core-napi-darwin-x64@0.19.3:
+  cojson-core-napi-darwin-x64@0.19.4:
     optional: true
 
-  cojson-core-napi-linux-arm-gnueabihf@0.19.3:
+  cojson-core-napi-linux-arm-gnueabihf@0.19.4:
     optional: true
 
-  cojson-core-napi-linux-arm64-gnu@0.19.3:
+  cojson-core-napi-linux-arm64-gnu@0.19.4:
     optional: true
 
-  cojson-core-napi-linux-arm64-musl@0.19.3:
+  cojson-core-napi-linux-arm64-musl@0.19.4:
     optional: true
 
-  cojson-core-napi-linux-x64-gnu@0.19.3:
+  cojson-core-napi-linux-x64-gnu@0.19.4:
     optional: true
 
-  cojson-core-napi-linux-x64-musl@0.19.3:
+  cojson-core-napi-linux-x64-musl@0.19.4:
     optional: true
 
-  cojson-core-napi@0.19.3:
+  cojson-core-napi@0.19.4:
     optionalDependencies:
-      cojson-core-napi-darwin-arm64: 0.19.3
-      cojson-core-napi-darwin-x64: 0.19.3
-      cojson-core-napi-linux-arm-gnueabihf: 0.19.3
-      cojson-core-napi-linux-arm64-gnu: 0.19.3
-      cojson-core-napi-linux-arm64-musl: 0.19.3
-      cojson-core-napi-linux-x64-gnu: 0.19.3
-      cojson-core-napi-linux-x64-musl: 0.19.3
+      cojson-core-napi-darwin-arm64: 0.19.4
+      cojson-core-napi-darwin-x64: 0.19.4
+      cojson-core-napi-linux-arm-gnueabihf: 0.19.4
+      cojson-core-napi-linux-arm64-gnu: 0.19.4
+      cojson-core-napi-linux-arm64-musl: 0.19.4
+      cojson-core-napi-linux-x64-gnu: 0.19.4
+      cojson-core-napi-linux-x64-musl: 0.19.4
 
-  cojson-core-wasm@0.19.3: {}
+  cojson-core-wasm@0.19.4: {}
 
-  cojson-storage-indexeddb@0.19.3:
+  cojson-storage-indexeddb@0.19.4:
     dependencies:
-      cojson: 0.19.3
+      cojson: 0.19.4
 
-  cojson-transport-ws@0.19.3:
+  cojson-transport-ws@0.19.4:
     dependencies:
       '@opentelemetry/api': 1.9.0
-      cojson: 0.19.3
+      cojson: 0.19.4
 
-  cojson@0.19.3:
+  cojson@0.19.4:
     dependencies:
       '@noble/ciphers': 1.3.0
       '@noble/curves': 1.9.1
       '@noble/hashes': 1.8.0
       '@opentelemetry/api': 1.9.0
       '@scure/base': 1.2.1
-      cojson-core-napi: 0.19.3
-      cojson-core-wasm: 0.19.3
+      cojson-core-napi: 0.19.4
+      cojson-core-wasm: 0.19.4
       unicode-segmenter: 0.12.0
 
   collect-v8-coverage@1.0.3:
@@ -29257,7 +29264,7 @@ snapshots:
       typed-array-byte-offset: 1.0.4
       typed-array-length: 1.0.7
       unbox-primitive: 1.1.0
-      which-typed-array: 1.1.18
+      which-typed-array: 1.1.19
 
   es-abstract@1.24.0:
     dependencies:
@@ -29775,6 +29782,25 @@ snapshots:
     transitivePeerDependencies:
       - expo
       - supports-color
+
+  expo-build-properties@0.14.6(expo@54.0.0-preview.4(@babel/core@7.27.1)(graphql@16.11.0)(react-native@0.81.0(@babel/core@7.27.1)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.27.1))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)):
+    dependencies:
+      ajv: 8.17.1
+      expo: 54.0.0-preview.4(@babel/core@7.27.1)(graphql@16.11.0)(react-native@0.81.0(@babel/core@7.27.1)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.27.1))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
+      semver: 7.7.3
+
+  expo-build-properties@0.14.6(expo@54.0.22(@babel/core@7.28.5)(graphql@16.11.0)(react-native@0.80.0(@babel/core@7.28.5)(@react-native-community/cli@19.0.0(typescript@5.6.2))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)):
+    dependencies:
+      ajv: 8.17.1
+      expo: 54.0.22(@babel/core@7.28.5)(graphql@16.11.0)(react-native@0.80.0(@babel/core@7.28.5)(@react-native-community/cli@19.0.0(typescript@5.6.2))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
+      semver: 7.7.3
+
+  expo-build-properties@0.14.6(expo@54.0.22(@babel/core@7.28.5)(graphql@16.11.0)(react-native@0.81.0(@babel/core@7.28.5)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.5))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)):
+    dependencies:
+      ajv: 8.17.1
+      expo: 54.0.22(@babel/core@7.28.5)(graphql@16.11.0)(react-native@0.81.0(@babel/core@7.28.5)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.5))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
+      semver: 7.7.3
+    optional: true
 
   expo-clipboard@8.0.2(expo@54.0.0-preview.4(@babel/core@7.27.1)(graphql@16.11.0)(react-native@0.81.0(@babel/core@7.27.1)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.27.1))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native@0.81.0(@babel/core@7.27.1)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.27.1))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0):
     dependencies:
@@ -30435,10 +30461,6 @@ snapshots:
   follow-redirects@1.15.11: {}
 
   fontfaceobserver@2.3.0: {}
-
-  for-each@0.3.3:
-    dependencies:
-      is-callable: 1.2.7
 
   for-each@0.3.5:
     dependencies:
@@ -31258,16 +31280,16 @@ snapshots:
       filelist: 1.0.4
       picocolors: 1.1.1
 
-  jazz-tools@0.19.3(68f7a3ac23d8845d11a369ae92f7f0fa):
+  jazz-tools@0.19.4(24043b7f0320f7f00ff0c02eeb858bba):
     dependencies:
       '@manuscripts/prosemirror-recreate-steps': 0.1.4
       '@scure/base': 1.2.1
       '@scure/bip39': 1.5.0
       '@tiptap/core': 2.12.0(@tiptap/pm@2.12.0)
       clsx: 2.1.1
-      cojson: 0.19.3
-      cojson-storage-indexeddb: 0.19.3
-      cojson-transport-ws: 0.19.3
+      cojson: 0.19.4
+      cojson-storage-indexeddb: 0.19.4
+      cojson-transport-ws: 0.19.4
       fast-myers-diff: 3.2.0
       goober: 2.1.18(csstype@3.1.3)
       prosemirror-example-setup: 1.2.3
@@ -31293,7 +31315,7 @@ snapshots:
       react-native-fast-encoder: 0.2.0(react-native@0.81.0(@babel/core@7.28.5)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.5))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
       react-native-mmkv: 3.3.1(react-native@0.81.0(@babel/core@7.28.5)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.5))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
       react-native-nitro-modules: 0.26.4(react-native@0.81.0(@babel/core@7.28.5)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.5))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
-      react-native-quick-crypto: 1.0.0-beta.20(expo@54.0.22(@babel/core@7.28.5)(graphql@16.11.0)(react-native@0.81.0(@babel/core@7.28.5)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.5))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native-nitro-modules@0.26.4(react-native@0.81.0(@babel/core@7.28.5)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.5))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native@0.81.0(@babel/core@7.28.5)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.5))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
+      react-native-quick-crypto: 1.0.0-beta.21(expo@54.0.22(@babel/core@7.28.5)(graphql@16.11.0)(react-native@0.81.0(@babel/core@7.28.5)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.5))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native-nitro-modules@0.26.4(react-native@0.81.0(@babel/core@7.28.5)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.5))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native@0.81.0(@babel/core@7.28.5)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.5))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
       sharp: 0.33.5
       svelte: 5.38.2
     transitivePeerDependencies:
@@ -33098,7 +33120,7 @@ snapshots:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  next@15.3.2(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.50.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+  next@15.3.2(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(@playwright/test@1.50.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
       '@next/env': 15.3.2
       '@swc/counter': 0.1.3
@@ -33108,7 +33130,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
-      styled-jsx: 5.1.6(@babel/core@7.28.5)(react@19.1.0)
+      styled-jsx: 5.1.6(@babel/core@7.28.3)(react@19.1.0)
     optionalDependencies:
       '@next/swc-darwin-arm64': 15.3.2
       '@next/swc-darwin-x64': 15.3.2
@@ -33126,7 +33148,7 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  next@15.4.2(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.50.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+  next@15.4.2(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(@playwright/test@1.50.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
       '@next/env': 15.4.2
       '@swc/helpers': 0.5.15
@@ -33134,7 +33156,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
-      styled-jsx: 5.1.6(@babel/core@7.28.5)(react@19.1.0)
+      styled-jsx: 5.1.6(@babel/core@7.28.3)(react@19.1.0)
     optionalDependencies:
       '@next/swc-darwin-arm64': 15.4.2
       '@next/swc-darwin-x64': 15.4.2
@@ -33152,7 +33174,7 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  next@15.4.4(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.50.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+  next@15.4.4(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(@playwright/test@1.50.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
       '@next/env': 15.4.4
       '@swc/helpers': 0.5.15
@@ -33160,7 +33182,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
-      styled-jsx: 5.1.6(@babel/core@7.28.5)(react@19.1.0)
+      styled-jsx: 5.1.6(@babel/core@7.28.3)(react@19.1.0)
     optionalDependencies:
       '@next/swc-darwin-arm64': 15.4.4
       '@next/swc-darwin-x64': 15.4.4
@@ -33178,7 +33200,7 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  next@15.5.3(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.50.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+  next@15.5.3(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(@playwright/test@1.50.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
       '@next/env': 15.5.3
       '@swc/helpers': 0.5.15
@@ -33186,7 +33208,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
-      styled-jsx: 5.1.6(@babel/core@7.28.5)(react@19.1.0)
+      styled-jsx: 5.1.6(@babel/core@7.28.3)(react@19.1.0)
     optionalDependencies:
       '@next/swc-darwin-arm64': 15.5.3
       '@next/swc-darwin-x64': 15.5.3
@@ -34282,7 +34304,7 @@ snapshots:
       react: 19.1.0
       scheduler: 0.26.0
 
-  react-email@4.0.13(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.50.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+  react-email@4.0.13(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(@playwright/test@1.50.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
       '@babel/parser': 7.27.2
       '@babel/traverse': 7.27.1
@@ -34294,7 +34316,7 @@ snapshots:
       glob: 11.0.2
       log-symbols: 7.0.0
       mime-types: 3.0.1
-      next: 15.4.4(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.50.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      next: 15.4.4(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(@playwright/test@1.50.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       normalize-path: 3.0.0
       ora: 8.2.0
       socket.io: 4.8.1
@@ -34396,39 +34418,63 @@ snapshots:
       react-native: 0.81.0(@babel/core@7.28.5)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.5))(@types/react@19.1.0)(react@19.1.0)
     optional: true
 
-  react-native-quick-base64@2.2.0(react-native@0.80.0(@babel/core@7.28.5)(@react-native-community/cli@19.0.0(typescript@5.6.2))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0):
+  react-native-quick-base64@2.2.2(react-native@0.80.0(@babel/core@7.28.5)(@react-native-community/cli@19.0.0(typescript@5.6.2))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0):
     dependencies:
       react: 19.1.0
       react-native: 0.80.0(@babel/core@7.28.5)(@react-native-community/cli@19.0.0(typescript@5.6.2))(@types/react@19.1.0)(react@19.1.0)
 
-  react-native-quick-base64@2.2.0(react-native@0.81.0(@babel/core@7.28.5)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.5))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0):
+  react-native-quick-base64@2.2.2(react-native@0.81.0(@babel/core@7.27.1)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.27.1))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+      react-native: 0.81.0(@babel/core@7.27.1)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.27.1))(@types/react@19.1.0)(react@19.1.0)
+
+  react-native-quick-base64@2.2.2(react-native@0.81.0(@babel/core@7.28.5)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.5))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0):
     dependencies:
       react: 19.1.0
       react-native: 0.81.0(@babel/core@7.28.5)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.5))(@types/react@19.1.0)(react@19.1.0)
     optional: true
 
-  react-native-quick-crypto@1.0.0-beta.20(expo@54.0.22(@babel/core@7.28.5)(graphql@16.11.0)(react-native@0.80.0(@babel/core@7.28.5)(@react-native-community/cli@19.0.0(typescript@5.6.2))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native-nitro-modules@0.26.4(react-native@0.80.0(@babel/core@7.28.5)(@react-native-community/cli@19.0.0(typescript@5.6.2))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native@0.80.0(@babel/core@7.28.5)(@react-native-community/cli@19.0.0(typescript@5.6.2))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0):
+  react-native-quick-crypto@1.0.0-beta.21(expo@54.0.0-preview.4(@babel/core@7.27.1)(graphql@16.11.0)(react-native@0.81.0(@babel/core@7.27.1)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.27.1))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native-nitro-modules@0.26.4(react-native@0.81.0(@babel/core@7.27.1)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.27.1))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native@0.81.0(@babel/core@7.27.1)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.27.1))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0):
+    dependencies:
+      '@craftzdog/react-native-buffer': 6.1.0(react-native@0.81.0(@babel/core@7.27.1)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.27.1))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
+      events: 3.3.0
+      expo-build-properties: 0.14.6(expo@54.0.0-preview.4(@babel/core@7.27.1)(graphql@16.11.0)(react-native@0.81.0(@babel/core@7.27.1)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.27.1))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))
+      react: 19.1.0
+      react-native: 0.81.0(@babel/core@7.27.1)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.27.1))(@types/react@19.1.0)(react@19.1.0)
+      react-native-nitro-modules: 0.26.4(react-native@0.81.0(@babel/core@7.27.1)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.27.1))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
+      react-native-quick-base64: 2.2.2(react-native@0.81.0(@babel/core@7.27.1)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.27.1))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
+      readable-stream: 4.5.2
+      safe-buffer: 5.2.1
+      util: 0.12.5
+    optionalDependencies:
+      expo: 54.0.0-preview.4(@babel/core@7.27.1)(graphql@16.11.0)(react-native@0.81.0(@babel/core@7.27.1)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.27.1))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
+
+  react-native-quick-crypto@1.0.0-beta.21(expo@54.0.22(@babel/core@7.28.5)(graphql@16.11.0)(react-native@0.80.0(@babel/core@7.28.5)(@react-native-community/cli@19.0.0(typescript@5.6.2))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native-nitro-modules@0.26.4(react-native@0.80.0(@babel/core@7.28.5)(@react-native-community/cli@19.0.0(typescript@5.6.2))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native@0.80.0(@babel/core@7.28.5)(@react-native-community/cli@19.0.0(typescript@5.6.2))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0):
     dependencies:
       '@craftzdog/react-native-buffer': 6.1.0(react-native@0.80.0(@babel/core@7.28.5)(@react-native-community/cli@19.0.0(typescript@5.6.2))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
       events: 3.3.0
+      expo-build-properties: 0.14.6(expo@54.0.22(@babel/core@7.28.5)(graphql@16.11.0)(react-native@0.80.0(@babel/core@7.28.5)(@react-native-community/cli@19.0.0(typescript@5.6.2))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))
       react: 19.1.0
       react-native: 0.80.0(@babel/core@7.28.5)(@react-native-community/cli@19.0.0(typescript@5.6.2))(@types/react@19.1.0)(react@19.1.0)
       react-native-nitro-modules: 0.26.4(react-native@0.80.0(@babel/core@7.28.5)(@react-native-community/cli@19.0.0(typescript@5.6.2))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
-      react-native-quick-base64: 2.2.0(react-native@0.80.0(@babel/core@7.28.5)(@react-native-community/cli@19.0.0(typescript@5.6.2))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
+      react-native-quick-base64: 2.2.2(react-native@0.80.0(@babel/core@7.28.5)(@react-native-community/cli@19.0.0(typescript@5.6.2))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
       readable-stream: 4.5.2
+      safe-buffer: 5.2.1
       util: 0.12.5
     optionalDependencies:
       expo: 54.0.22(@babel/core@7.28.5)(graphql@16.11.0)(react-native@0.80.0(@babel/core@7.28.5)(@react-native-community/cli@19.0.0(typescript@5.6.2))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
 
-  react-native-quick-crypto@1.0.0-beta.20(expo@54.0.22(@babel/core@7.28.5)(graphql@16.11.0)(react-native@0.81.0(@babel/core@7.28.5)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.5))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native-nitro-modules@0.26.4(react-native@0.81.0(@babel/core@7.28.5)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.5))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native@0.81.0(@babel/core@7.28.5)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.5))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0):
+  react-native-quick-crypto@1.0.0-beta.21(expo@54.0.22(@babel/core@7.28.5)(graphql@16.11.0)(react-native@0.81.0(@babel/core@7.28.5)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.5))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native-nitro-modules@0.26.4(react-native@0.81.0(@babel/core@7.28.5)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.5))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))(react-native@0.81.0(@babel/core@7.28.5)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.5))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0):
     dependencies:
       '@craftzdog/react-native-buffer': 6.1.0(react-native@0.81.0(@babel/core@7.28.5)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.5))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
       events: 3.3.0
+      expo-build-properties: 0.14.6(expo@54.0.22(@babel/core@7.28.5)(graphql@16.11.0)(react-native@0.81.0(@babel/core@7.28.5)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.5))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0))
       react: 19.1.0
       react-native: 0.81.0(@babel/core@7.28.5)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.5))(@types/react@19.1.0)(react@19.1.0)
       react-native-nitro-modules: 0.26.4(react-native@0.81.0(@babel/core@7.28.5)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.5))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
-      react-native-quick-base64: 2.2.0(react-native@0.81.0(@babel/core@7.28.5)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.5))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
+      react-native-quick-base64: 2.2.2(react-native@0.81.0(@babel/core@7.28.5)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.5))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
       readable-stream: 4.5.2
+      safe-buffer: 5.2.1
       util: 0.12.5
     optionalDependencies:
       expo: 54.0.22(@babel/core@7.28.5)(graphql@16.11.0)(react-native@0.81.0(@babel/core@7.28.5)(@react-native-community/cli@19.0.0(typescript@5.9.2))(@react-native/metro-config@0.81.0(@babel/core@7.28.5))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
@@ -35818,12 +35864,12 @@ snapshots:
 
   structured-headers@0.4.1: {}
 
-  styled-jsx@5.1.6(@babel/core@7.28.5)(react@19.1.0):
+  styled-jsx@5.1.6(@babel/core@7.28.3)(react@19.1.0):
     dependencies:
       client-only: 0.0.1
       react: 19.1.0
     optionalDependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.3
 
   stylis@4.2.0: {}
 
@@ -36421,7 +36467,7 @@ snapshots:
   typed-array-byte-length@1.0.3:
     dependencies:
       call-bind: 1.0.8
-      for-each: 0.3.3
+      for-each: 0.3.5
       gopd: 1.2.0
       has-proto: 1.2.0
       is-typed-array: 1.1.15
@@ -36430,7 +36476,7 @@ snapshots:
     dependencies:
       available-typed-arrays: 1.0.7
       call-bind: 1.0.8
-      for-each: 0.3.3
+      for-each: 0.3.5
       gopd: 1.2.0
       has-proto: 1.2.0
       is-typed-array: 1.1.15
@@ -36439,7 +36485,7 @@ snapshots:
   typed-array-length@1.0.7:
     dependencies:
       call-bind: 1.0.8
-      for-each: 0.3.3
+      for-each: 0.3.5
       gopd: 1.2.0
       is-typed-array: 1.1.15
       possible-typed-array-names: 1.0.0
@@ -37295,15 +37341,6 @@ snapshots:
       is-weakset: 2.0.4
 
   which-module@2.0.1: {}
-
-  which-typed-array@1.1.18:
-    dependencies:
-      available-typed-arrays: 1.0.7
-      call-bind: 1.0.8
-      call-bound: 1.0.4
-      for-each: 0.3.3
-      gopd: 1.2.0
-      has-tostringtag: 1.0.2
 
   which-typed-array@1.1.19:
     dependencies:


### PR DESCRIPTION
Switched to native blake3 in RNQuickCrypto, which should make perf better.

Tested by making a chat between web and mobile while using RNQuickCrypto:
<img width="466" height="984" alt="Screenshot 2025-11-26 at 12 08 06" src="https://github.com/user-attachments/assets/4afe751a-e4b2-49e0-9a76-11cc0c7356a5" />
