### PR TITLE
feat: expose createAs as a public API for creating controlled accounts from workers

### DIFF
--- a/.changeset/good-nails-drum.md
+++ b/.changeset/good-nails-drum.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Make createAs a public API that can be used to create controlled accounts from workers

--- a/packages/jazz-tools/src/tools/coValues/account.ts
+++ b/packages/jazz-tools/src/tools/coValues/account.ts
@@ -269,29 +269,53 @@ export class Account extends CoValueBase implements CoValue {
    */
   static async createAs<A extends Account>(
     this: CoValueClass<A> & typeof Account,
-    as: Account,
+    worker: Account,
     options: {
       creationProps: { name: string };
+      onCreate?: (account: A, worker: Account) => Promise<void>;
     },
   ) {
-    // TODO: is there a cleaner way to do this?
+    const crypto = worker.$jazz.localNode.crypto;
+
     const connectedPeers = cojsonInternals.connectedPeers(
       "creatingAccount",
-      "createdAccount",
+      crypto.uniquenessForHeader(), // Use a unique id for the client peer, so we don't have clashes in the worker node
       { peer1role: "server", peer2role: "client" },
     );
 
-    as.$jazz.localNode.syncManager.addPeer(connectedPeers[1]);
+    worker.$jazz.localNode.syncManager.addPeer(connectedPeers[1]);
 
     const account = await this.create<A>({
       creationProps: options.creationProps,
-      crypto: as.$jazz.localNode.crypto,
+      crypto,
       peers: [connectedPeers[0]],
     });
 
+    // Load the worker inside the account node
+    const loadedWorker = await Account.load(worker.$jazz.id, {
+      loadAs: account,
+    });
+
+    // This should never happen, because the two accounts are linked
+    if (!loadedWorker.$isLoaded)
+      throw new Error("Unable to load the worker account");
+
+    // The onCreate hook can be helpful to define inline logic, such as querying the DB
+    if (options.onCreate) await options.onCreate(account, loadedWorker);
+
     await account.$jazz.waitForAllCoValuesSync();
 
-    return account;
+    const createdAccount = await this.load(account.$jazz.id, {
+      loadAs: worker,
+    });
+
+    if (!createdAccount.$isLoaded)
+      throw new Error("Unable to load the created account");
+
+    // Close the account node, to avoid leaking memory
+    account.$jazz.localNode.gracefulShutdown();
+
+    return createdAccount;
   }
 
   static fromNode<A extends Account>(

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/AccountSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/AccountSchema.ts
@@ -93,15 +93,19 @@ export class AccountSchema<
     );
   }
 
-  /** @internal */
+  // Create an account via worker, useful to generate controlled accounts from the server
   createAs(
-    as: Account,
+    worker: Account,
     options: {
       creationProps: { name: string };
+      onCreate?: (
+        account: AccountInstance<Shape>,
+        worker: Account,
+      ) => Promise<void>;
     },
   ): Promise<AccountInstance<Shape>> {
     // @ts-expect-error
-    return this.coValueClass.createAs(as, options);
+    return this.coValueClass.createAs(worker, options);
   }
 
   unstable_merge<

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/AccountSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/AccountSchema.ts
@@ -103,7 +103,8 @@ export class AccountSchema<
         worker: Account,
       ) => Promise<void>;
     },
-  ): Promise<AccountInstance<Shape>> {
+    // @ts-expect-error we can't statically enforce the schema's resolve query is a valid resolve query, but in practice it is
+  ): Promise<Loaded<AccountSchema<Shape>, DefaultResolveQuery>> {
     // @ts-expect-error
     return this.coValueClass.createAs(worker, options);
   }

--- a/packages/jazz-tools/src/tools/tests/account.test.ts
+++ b/packages/jazz-tools/src/tools/tests/account.test.ts
@@ -479,6 +479,12 @@ describe("createAs", () => {
         assertLoaded(account.root);
         expect(account.root.value).toBe("migration-set");
 
+        // It should be possible to add the worker as a member of the root
+        account.root.$jazz.owner.addMember(loadedWorker, "writer");
+        expect(account.root.$jazz.owner.getRoleOf(loadedWorker.$jazz.id)).toBe(
+          "writer",
+        );
+
         // Set root from worker in onCreate
         account.$jazz.set("root", workerRoot);
       },

--- a/packages/jazz-tools/src/tools/tests/account.test.ts
+++ b/packages/jazz-tools/src/tools/tests/account.test.ts
@@ -435,3 +435,62 @@ describe("accepting invites", () => {
     expect(group.getRoleOf(newAccount.$jazz.id)).toBe("reader");
   });
 });
+
+describe("createAs", () => {
+  test("migration is executed before onCreate and onCreate can set root from worker", async () => {
+    const executionOrder: string[] = [];
+
+    const CustomRoot = co.map({
+      value: z.string(),
+    });
+
+    const CustomAccount = co
+      .account({
+        profile: co.profile({
+          name: z.string(),
+        }),
+        root: CustomRoot,
+      })
+      .withMigration((me) => {
+        executionOrder.push("migration");
+        if (me.root === undefined) {
+          me.$jazz.set("root", { value: "migration-set" });
+        }
+      });
+
+    const worker = await createJazzTestAccount({
+      isCurrentActiveAccount: true,
+    });
+
+    const workerRoot = CustomRoot.create(
+      { value: "worker-root" },
+      { owner: worker },
+    );
+
+    const createdAccount = await CustomAccount.createAs(worker, {
+      creationProps: { name: "Test Account" },
+      onCreate: async (account, loadedWorker) => {
+        executionOrder.push("onCreate");
+
+        // Verify migration ran before onCreate
+        expect(executionOrder).toEqual(["migration", "onCreate"]);
+
+        // Verify migration set the root
+        assertLoaded(account.root);
+        expect(account.root.value).toBe("migration-set");
+
+        // Set root from worker in onCreate
+        account.$jazz.set("root", workerRoot);
+      },
+    });
+
+    assertLoaded(createdAccount);
+    assertLoaded(createdAccount.root);
+
+    // Verify onCreate was called and root was set from worker
+    expect(createdAccount.root.value).toBe("worker-root");
+
+    // Verify execution order
+    expect(executionOrder).toEqual(["migration", "onCreate"]);
+  });
+});

--- a/packages/jazz-tools/src/tools/tests/groupsAndAccounts.test.ts
+++ b/packages/jazz-tools/src/tools/tests/groupsAndAccounts.test.ts
@@ -12,6 +12,7 @@ import {
 import { createJazzTestAccount, setupJazzTestSync } from "../testing.js";
 import {
   assertLoaded,
+  createAccountAs,
   loadCoValueOrFail,
   setupTwoNodes,
   waitFor,
@@ -100,7 +101,7 @@ describe("Group inheritance", () => {
 
     group.addMember(parentGroup);
 
-    const reader = await co.account().createAs(me, {
+    const reader = await createAccountAs(co.account(), me, {
       creationProps: { name: "Reader" },
     });
 
@@ -141,7 +142,7 @@ describe("Group inheritance", () => {
     group.addMember(parentGroup);
     parentGroup.addMember(grandParentGroup);
 
-    const reader = await co.account().createAs(me, {
+    const reader = await createAccountAs(co.account(), me, {
       creationProps: { name: "Reader" },
     });
 
@@ -359,7 +360,7 @@ describe("Group inheritance", () => {
 
     test("nested CoValues inherit permissions from the referencing CoValue", async () => {
       const me = co.account().getMe();
-      const reader = await co.account().createAs(me, {
+      const reader = await createAccountAs(co.account(), me, {
         creationProps: { name: "Reader" },
       });
 
@@ -504,16 +505,16 @@ describe("Account permissions", () => {
     const group = Group.create({ owner: admin });
     const testObject = CoMap.create({}, { owner: group });
 
-    const manager = await co.account().createAs(admin, {
+    const manager = await createAccountAs(co.account(), admin, {
       creationProps: { name: "Manager" },
     });
-    const writer = await co.account().createAs(admin, {
+    const writer = await createAccountAs(co.account(), admin, {
       creationProps: { name: "Writer" },
     });
-    const reader = await co.account().createAs(admin, {
+    const reader = await createAccountAs(co.account(), admin, {
       creationProps: { name: "Reader" },
     });
-    const writeOnly = await co.account().createAs(admin, {
+    const writeOnly = await createAccountAs(co.account(), admin, {
       creationProps: { name: "WriteOnly" },
     });
 
@@ -541,16 +542,16 @@ describe("Account permissions", () => {
     const group = Group.create({ owner: admin });
     const testObject = CoMap.create({}, { owner: group });
 
-    const manager = await co.account().createAs(admin, {
+    const manager = await createAccountAs(co.account(), admin, {
       creationProps: { name: "Manager" },
     });
-    const writer = await co.account().createAs(admin, {
+    const writer = await createAccountAs(co.account(), admin, {
       creationProps: { name: "Writer" },
     });
-    const reader = await co.account().createAs(admin, {
+    const reader = await createAccountAs(co.account(), admin, {
       creationProps: { name: "Reader" },
     });
-    const writeOnly = await co.account().createAs(admin, {
+    const writeOnly = await createAccountAs(co.account(), admin, {
       creationProps: { name: "WriteOnly" },
     });
 
@@ -578,17 +579,17 @@ describe("Account permissions", () => {
     const group = Group.create({ owner: admin });
     const testObject = CoMap.create({}, { owner: group });
 
-    const manager = await co.account().createAs(admin, {
+    const manager = await createAccountAs(co.account(), admin, {
       creationProps: { name: "Admin" },
     });
 
-    const writer = await co.account().createAs(admin, {
+    const writer = await createAccountAs(co.account(), admin, {
       creationProps: { name: "Writer" },
     });
-    const reader = await co.account().createAs(admin, {
+    const reader = await createAccountAs(co.account(), admin, {
       creationProps: { name: "Reader" },
     });
-    const writeOnly = await co.account().createAs(admin, {
+    const writeOnly = await createAccountAs(co.account(), admin, {
       creationProps: { name: "WriteOnly" },
     });
 
@@ -616,17 +617,17 @@ describe("Account permissions", () => {
     const group = Group.create({ owner: admin });
     const testObject = CoMap.create({}, { owner: group });
 
-    const manager = await co.account().createAs(admin, {
+    const manager = await createAccountAs(co.account(), admin, {
       creationProps: { name: "Admin" },
     });
 
-    const writer = await co.account().createAs(admin, {
+    const writer = await createAccountAs(co.account(), admin, {
       creationProps: { name: "Writer" },
     });
-    const reader = await co.account().createAs(admin, {
+    const reader = await createAccountAs(co.account(), admin, {
       creationProps: { name: "Reader" },
     });
-    const writeOnly = await co.account().createAs(admin, {
+    const writeOnly = await createAccountAs(co.account(), admin, {
       creationProps: { name: "WriteOnly" },
     });
 
@@ -653,7 +654,7 @@ describe("Account permissions", () => {
     const group = Group.create({ owner: admin });
     const testObject = CoMap.create({}, { owner: group });
 
-    const nonMember = await co.account().createAs(admin, {
+    const nonMember = await createAccountAs(co.account(), admin, {
       creationProps: { name: "NonMember" },
     });
 

--- a/packages/jazz-tools/src/tools/tests/schema.resolved.test.ts
+++ b/packages/jazz-tools/src/tools/tests/schema.resolved.test.ts
@@ -248,11 +248,13 @@ describe("Schema.resolved()", () => {
 
         const account = await AccountWithProfile.createAs(serverAccount, {
           creationProps: { name: "Hermes Puggington" },
+          onCreate: async (account) => {
+            account.$jazz.set(
+              "profile",
+              co.profile().create({ name: "Hermes Puggington" }, publicGroup),
+            );
+          },
         });
-        account.$jazz.set(
-          "profile",
-          co.profile().create({ name: "Hermes Puggington" }, publicGroup),
-        );
 
         const loadedAccount = await AccountWithProfile.load(account.$jazz.id, {
           loadAs: clientAccount,
@@ -405,11 +407,13 @@ describe("Schema.resolved()", () => {
 
         const account = await AccountWithProfile.createAs(serverAccount, {
           creationProps: { name: "Hermes Puggington" },
+          onCreate: async (account) => {
+            account.$jazz.set(
+              "profile",
+              co.profile().create({ name: "Hermes Puggington" }, publicGroup),
+            );
+          },
         });
-        account.$jazz.set(
-          "profile",
-          co.profile().create({ name: "Hermes Puggington" }, publicGroup),
-        );
 
         const updates: co.loaded<typeof AccountWithProfile>[] = [];
         AccountWithProfile.subscribe(
@@ -559,18 +563,21 @@ describe("Schema.resolved()", () => {
 
         const account = await TestAccount.createAs(serverAccount, {
           creationProps: { name: "Hermes Puggington" },
+          onCreate: async (account) => {
+            account.$jazz.set(
+              "profile",
+              TestAccount.shape.profile.create(
+                { name: "Hermes Puggington" },
+                publicGroup,
+              ),
+            );
+            account.$jazz.set(
+              "root",
+              TestAccount.shape.root.create({ text: "Test" }, publicGroup),
+            );
+          },
         });
-        account.$jazz.set(
-          "profile",
-          TestAccount.shape.profile.create(
-            { name: "Hermes Puggington" },
-            publicGroup,
-          ),
-        );
-        account.$jazz.set(
-          "root",
-          TestAccount.shape.root.create({ text: "Test" }, publicGroup),
-        );
+
         const accountList = AccountList.create([account], publicGroup);
 
         const branchAccountList = await AccountList.load(accountList.$jazz.id, {


### PR DESCRIPTION
Refactored createAs to fix some usability issues:
- used an unique id for the client peer, so a worker can create more than one account without clashes
- added onCreate hook to handle inline inizalizations
- returned a loaded account instead the controlled one
- closed the new localNode to avoid memory leaks