### PR TITLE
feat: narrow down `.load` return type to not include `loading` CoValues

### DIFF
--- a/.changeset/heavy-points-trade.md
+++ b/.changeset/heavy-points-trade.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Narrow down `.load` return type to not include `loading` CoValues

--- a/packages/jazz-tools/src/tools/coValues/account.ts
+++ b/packages/jazz-tools/src/tools/coValues/account.ts
@@ -28,6 +28,7 @@ import {
   ID,
   InstanceOrPrimitiveOfSchema,
   MaybeLoaded,
+  Settled,
   Profile,
   Ref,
   type RefEncoded,
@@ -131,9 +132,7 @@ export class Account extends CoValueBase implements CoValue {
     valueID: string,
     inviteSecret: InviteSecret,
     coValueClass?: S,
-  ): Promise<
-    MaybeLoaded<Resolved<InstanceOfSchemaCoValuesMaybeLoaded<S>, true>>
-  > {
+  ): Promise<Settled<Resolved<InstanceOfSchemaCoValuesMaybeLoaded<S>, true>>> {
     if (!this.$jazz.isLocalNodeOwner) {
       throw new Error("Only a controlled account can accept invites");
     }
@@ -356,7 +355,7 @@ export class Account extends CoValueBase implements CoValue {
       resolve?: RefsToResolveStrict<A, R>;
       loadAs?: Account | AnonymousJazzAgent;
     },
-  ): Promise<MaybeLoaded<Resolved<A, R>>> {
+  ): Promise<Settled<Resolved<A, R>>> {
     return loadCoValueWithoutMe(this, id, options);
   }
 

--- a/packages/jazz-tools/src/tools/coValues/coFeed.ts
+++ b/packages/jazz-tools/src/tools/coValues/coFeed.ts
@@ -20,6 +20,7 @@ import {
   Group,
   ID,
   MaybeLoaded,
+  Settled,
   LoadedAndRequired,
   unstable_mergeBranch,
   RefsToResolve,
@@ -297,7 +298,7 @@ export class CoFeed<out Item = any> extends CoValueBase implements CoValue {
       resolve?: RefsToResolveStrict<F, R>;
       loadAs?: Account | AnonymousJazzAgent;
     },
-  ): Promise<MaybeLoaded<Resolved<F, R>>> {
+  ): Promise<Settled<Resolved<F, R>>> {
     return loadCoValueWithoutMe(this, id, options ?? {});
   }
 
@@ -983,7 +984,7 @@ export class FileStream extends CoValueBase implements CoValue {
       loadAs?: Account | AnonymousJazzAgent;
       allowUnfinished?: boolean;
     },
-  ): Promise<MaybeLoaded<FileStream>> {
+  ): Promise<Settled<FileStream>> {
     const stream = await loadCoValueWithoutMe(this, id, options);
 
     /**

--- a/packages/jazz-tools/src/tools/coValues/coList.ts
+++ b/packages/jazz-tools/src/tools/coValues/coList.ts
@@ -11,7 +11,7 @@ import {
   Group,
   ID,
   AsLoaded,
-  MaybeLoaded,
+  Settled,
   unstable_mergeBranch,
   RefEncoded,
   RefsToResolve,
@@ -268,7 +268,7 @@ export class CoList<out Item = any>
       resolve?: RefsToResolveStrict<L, R>;
       loadAs?: Account | AnonymousJazzAgent;
     },
-  ): Promise<MaybeLoaded<Resolved<L, R>>> {
+  ): Promise<Settled<Resolved<L, R>>> {
     return loadCoValueWithoutMe(this, id, options);
   }
 
@@ -380,7 +380,7 @@ export class CoList<out Item = any>
       owner: Account | Group;
       resolve?: RefsToResolveStrict<L, R>;
     },
-  ): Promise<MaybeLoaded<Resolved<L, R>>> {
+  ): Promise<Settled<Resolved<L, R>>> {
     const header = CoList._getUniqueHeader(
       options.unique,
       options.owner.$jazz.id,
@@ -420,7 +420,7 @@ export class CoList<out Item = any>
       resolve?: RefsToResolveStrict<L, R>;
       loadAs?: Account | AnonymousJazzAgent;
     },
-  ): Promise<MaybeLoaded<Resolved<L, R>>> {
+  ): Promise<Settled<Resolved<L, R>>> {
     const header = CoList._getUniqueHeader(unique, ownerID);
 
     const owner = await Group.load(ownerID, {

--- a/packages/jazz-tools/src/tools/coValues/coMap.ts
+++ b/packages/jazz-tools/src/tools/coValues/coMap.ts
@@ -18,7 +18,7 @@ import {
   getCoValueOwner,
   Group,
   ID,
-  MaybeLoaded,
+  Settled,
   PartialOnUndefined,
   RefEncoded,
   RefIfCoValue,
@@ -377,7 +377,7 @@ export class CoMap extends CoValueBase implements CoValue {
       loadAs?: Account | AnonymousJazzAgent;
       skipRetry?: boolean;
     },
-  ): Promise<MaybeLoaded<Resolved<M, R>>> {
+  ): Promise<Settled<Resolved<M, R>>> {
     return loadCoValueWithoutMe(this, id, options);
   }
 
@@ -494,7 +494,7 @@ export class CoMap extends CoValueBase implements CoValue {
       owner: Account | Group;
       resolve?: RefsToResolveStrict<M, R>;
     },
-  ): Promise<MaybeLoaded<Resolved<M, R>>> {
+  ): Promise<Settled<Resolved<M, R>>> {
     const header = CoMap._getUniqueHeader(
       options.unique,
       options.owner.$jazz.id,
@@ -536,7 +536,7 @@ export class CoMap extends CoValueBase implements CoValue {
       resolve?: RefsToResolveStrict<M, R>;
       loadAs?: Account | AnonymousJazzAgent;
     },
-  ): Promise<MaybeLoaded<Resolved<M, R>>> {
+  ): Promise<Settled<Resolved<M, R>>> {
     const header = CoMap._getUniqueHeader(unique, ownerID);
 
     const owner = await Group.load(ownerID, {

--- a/packages/jazz-tools/src/tools/coValues/coPlainText.ts
+++ b/packages/jazz-tools/src/tools/coValues/coPlainText.ts
@@ -7,7 +7,7 @@ import {
   CoValueJazzApi,
   CoValueLoadingState,
   ID,
-  MaybeLoaded,
+  Settled,
   Resolved,
   SubscribeListenerOptions,
   SubscribeRestArgs,
@@ -164,7 +164,7 @@ export class CoPlainText extends String implements CoValue {
     this: CoValueClass<T>,
     id: ID<T>,
     options?: { loadAs?: Account | AnonymousJazzAgent },
-  ): Promise<MaybeLoaded<T>> {
+  ): Promise<Settled<T>> {
     return loadCoValueWithoutMe(this, id, options);
   }
 

--- a/packages/jazz-tools/src/tools/coValues/coVector.ts
+++ b/packages/jazz-tools/src/tools/coValues/coVector.ts
@@ -11,7 +11,7 @@ import {
   SubscribeListenerOptions,
   SubscribeRestArgs,
   TypeSym,
-  MaybeLoaded,
+  Settled,
   Account,
   CoValueJazzApi,
   inspect,
@@ -232,7 +232,7 @@ export class CoVector
     options?: {
       loadAs?: Account | AnonymousJazzAgent;
     },
-  ): Promise<MaybeLoaded<C>> {
+  ): Promise<Settled<C>> {
     const coVector = await loadCoValueWithoutMe(this, id, options);
 
     /**

--- a/packages/jazz-tools/src/tools/coValues/deepLoading.ts
+++ b/packages/jazz-tools/src/tools/coValues/deepLoading.ts
@@ -32,13 +32,44 @@ type IsUnion<T, U = T> = (
 export type MaybeLoaded<T> = T | NotLoaded<T>;
 
 /**
+ * A CoValue that is either successfully loaded or that could not be loaded.
+ */
+export type Settled<T> = T | Inaccessible<T>;
+
+/**
  * A CoValue that is not loaded.
  */
+// Manually inlining the type to reduce type-checking complexity
+// type NotLoaded<T> = Loading<T> | Inaccessible<T>;
 export type NotLoaded<T> = {
   $jazz: {
     id: ID<T>;
     loadingState:
       | typeof CoValueLoadingState.LOADING
+      | typeof CoValueLoadingState.UNAVAILABLE
+      | typeof CoValueLoadingState.UNAUTHORIZED;
+  };
+  $isLoaded: false;
+};
+
+/**
+ * A CoValue that is being loaded
+ */
+export type Loading<T> = {
+  $jazz: {
+    id: ID<T>;
+    loadingState: typeof CoValueLoadingState.LOADING;
+  };
+  $isLoaded: false;
+};
+
+/**
+ * A CoValue that could not be loaded
+ */
+export type Inaccessible<T> = {
+  $jazz: {
+    id: ID<T>;
+    loadingState:
       | typeof CoValueLoadingState.UNAVAILABLE
       | typeof CoValueLoadingState.UNAUTHORIZED;
   };

--- a/packages/jazz-tools/src/tools/coValues/group.ts
+++ b/packages/jazz-tools/src/tools/coValues/group.ts
@@ -14,7 +14,7 @@ import {
   CoValue,
   CoValueClass,
   ID,
-  MaybeLoaded,
+  Settled,
   RefEncoded,
   RefsToResolve,
   RefsToResolveStrict,
@@ -283,7 +283,7 @@ export class Group extends CoValueBase implements CoValue {
       resolve?: RefsToResolveStrict<G, R>;
       loadAs?: Account | AnonymousJazzAgent;
     },
-  ): Promise<MaybeLoaded<Resolved<G, R>>> {
+  ): Promise<Settled<Resolved<G, R>>> {
     return loadCoValueWithoutMe(this, id, options);
   }
 

--- a/packages/jazz-tools/src/tools/coValues/schemaUnion.ts
+++ b/packages/jazz-tools/src/tools/coValues/schemaUnion.ts
@@ -10,7 +10,7 @@ import {
   CoValueJazzApi,
   Group,
   ID,
-  MaybeLoaded,
+  Settled,
   RefsToResolve,
   RefsToResolveStrict,
   Resolved,
@@ -162,7 +162,7 @@ export abstract class SchemaUnion extends CoValueBase implements CoValue {
       loadAs?: Account | AnonymousJazzAgent;
       skipRetry?: boolean;
     },
-  ): Promise<MaybeLoaded<Resolved<M, R>>> {
+  ): Promise<Settled<Resolved<M, R>>> {
     return loadCoValueWithoutMe(this, id, options);
   }
 

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/AccountSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/AccountSchema.ts
@@ -5,7 +5,7 @@ import {
   CoMapSchemaDefinition,
   coOptionalDefiner,
   Group,
-  MaybeLoaded,
+  Settled,
   RefsToResolveStrict,
   RefsToResolve,
   Resolved,
@@ -84,7 +84,7 @@ export class AccountSchema<
       loadAs?: Account | AnonymousJazzAgent;
       resolve?: RefsToResolveStrict<AccountSchema<Shape>, R>;
     },
-  ): Promise<MaybeLoaded<Loaded<AccountSchema<Shape>, R>>> {
+  ): Promise<Settled<Loaded<AccountSchema<Shape>, R>>> {
     // @ts-expect-error
     return this.coValueClass.load(
       id,

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoDiscriminatedUnionSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoDiscriminatedUnionSchema.ts
@@ -5,7 +5,7 @@ import {
   BranchDefinition,
   InstanceOfSchema,
   InstanceOrPrimitiveOfSchemaCoValuesMaybeLoaded,
-  MaybeLoaded,
+  Settled,
   RefsToResolve,
   RefsToResolveStrict,
   Resolved,
@@ -87,7 +87,7 @@ export class CoDiscriminatedUnionSchema<
       unstable_branch?: BranchDefinition;
     },
   ): Promise<
-    MaybeLoaded<
+    Settled<
       Resolved<
         CoDiscriminatedUnionInstanceCoValuesMaybeLoaded<Options> & SchemaUnion,
         R

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoFeedSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoFeedSchema.ts
@@ -4,7 +4,7 @@ import {
   BranchDefinition,
   CoFeed,
   Group,
-  MaybeLoaded,
+  Settled,
   RefsToResolve,
   RefsToResolveStrict,
   Resolved,
@@ -69,7 +69,7 @@ export class CoFeedSchema<
       loadAs?: Account | AnonymousJazzAgent;
       unstable_branch?: BranchDefinition;
     },
-  ): Promise<MaybeLoaded<Resolved<CoFeedInstanceCoValuesMaybeLoaded<T>, R>>> {
+  ): Promise<Settled<Resolved<CoFeedInstanceCoValuesMaybeLoaded<T>, R>>> {
     // @ts-expect-error
     return this.coValueClass.load(
       id,

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoListSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoListSchema.ts
@@ -4,7 +4,7 @@ import {
   CoList,
   Group,
   ID,
-  MaybeLoaded,
+  Settled,
   RefsToResolve,
   RefsToResolveStrict,
   Resolved,
@@ -77,7 +77,7 @@ export class CoListSchema<
       loadAs?: Account | AnonymousJazzAgent;
       unstable_branch?: BranchDefinition;
     },
-  ): Promise<MaybeLoaded<Resolved<CoListInstanceCoValuesMaybeLoaded<T>, R>>> {
+  ): Promise<Settled<Resolved<CoListInstanceCoValuesMaybeLoaded<T>, R>>> {
     // @ts-expect-error
     return this.coValueClass.load(
       id,
@@ -147,7 +147,7 @@ export class CoListSchema<
     unique: CoValueUniqueness["uniqueness"];
     owner: Account | Group;
     resolve?: RefsToResolveStrict<CoListInstanceCoValuesMaybeLoaded<T>, R>;
-  }): Promise<MaybeLoaded<Resolved<CoListInstanceCoValuesMaybeLoaded<T>, R>>> {
+  }): Promise<Settled<Resolved<CoListInstanceCoValuesMaybeLoaded<T>, R>>> {
     // @ts-expect-error
     return this.coValueClass.upsertUnique(
       // @ts-expect-error
@@ -166,7 +166,7 @@ export class CoListSchema<
       resolve?: RefsToResolveStrict<CoListInstanceCoValuesMaybeLoaded<T>, R>;
       loadAs?: Account | AnonymousJazzAgent;
     },
-  ): Promise<MaybeLoaded<Resolved<CoListInstanceCoValuesMaybeLoaded<T>, R>>> {
+  ): Promise<Settled<Resolved<CoListInstanceCoValuesMaybeLoaded<T>, R>>> {
     // @ts-expect-error
     return this.coValueClass.loadUnique(
       unique,

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoMapSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoMapSchema.ts
@@ -6,7 +6,7 @@ import {
   DiscriminableCoValueSchemaDefinition,
   DiscriminableCoreCoValueSchema,
   Group,
-  MaybeLoaded,
+  Settled,
   RefsToResolve,
   RefsToResolveStrict,
   Resolved,
@@ -97,7 +97,7 @@ export class CoMapSchema<
       unstable_branch?: BranchDefinition;
     },
   ): Promise<
-    MaybeLoaded<
+    Settled<
       Resolved<Simplify<CoMapInstanceCoValuesMaybeLoaded<Shape>> & CoMap, R>
     >
   > {
@@ -183,7 +183,7 @@ export class CoMapSchema<
       R
     >;
   }): Promise<
-    MaybeLoaded<
+    Settled<
       Resolved<Simplify<CoMapInstanceCoValuesMaybeLoaded<Shape>> & CoMap, R>
     >
   > {
@@ -210,7 +210,7 @@ export class CoMapSchema<
       loadAs?: Account | AnonymousJazzAgent;
     },
   ): Promise<
-    MaybeLoaded<
+    Settled<
       Resolved<Simplify<CoMapInstanceCoValuesMaybeLoaded<Shape>> & CoMap, R>
     >
   > {

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoRecordSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoRecordSchema.ts
@@ -6,7 +6,7 @@ import {
   CoMapSchemaDefinition,
   Group,
   ID,
-  MaybeLoaded,
+  Settled,
   RefsToResolve,
   RefsToResolveStrict,
   Resolved,
@@ -64,9 +64,7 @@ export interface CoRecordSchema<
       loadAs?: Account | AnonymousJazzAgent;
       unstable_branch?: BranchDefinition;
     },
-  ): Promise<
-    MaybeLoaded<Resolved<CoRecordInstanceCoValuesMaybeLoaded<K, V>, R>>
-  >;
+  ): Promise<Settled<Resolved<CoRecordInstanceCoValuesMaybeLoaded<K, V>, R>>>;
 
   unstable_merge<
     const R extends RefsToResolve<
@@ -119,9 +117,7 @@ export interface CoRecordSchema<
     unique: CoValueUniqueness["uniqueness"];
     owner: Account | Group;
     resolve?: RefsToResolveStrict<CoRecordInstanceCoValuesMaybeLoaded<K, V>, R>;
-  }): Promise<
-    MaybeLoaded<Resolved<CoRecordInstanceCoValuesMaybeLoaded<K, V>, R>>
-  >;
+  }): Promise<Settled<Resolved<CoRecordInstanceCoValuesMaybeLoaded<K, V>, R>>>;
 
   loadUnique<
     const R extends RefsToResolve<
@@ -138,9 +134,7 @@ export interface CoRecordSchema<
       >;
       loadAs?: Account | AnonymousJazzAgent;
     },
-  ): Promise<
-    MaybeLoaded<Resolved<CoRecordInstanceCoValuesMaybeLoaded<K, V>, R>>
-  >;
+  ): Promise<Settled<Resolved<CoRecordInstanceCoValuesMaybeLoaded<K, V>, R>>>;
 
   getCoValueClass: () => typeof CoMap;
 

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/FileStreamSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/FileStreamSchema.ts
@@ -3,7 +3,7 @@ import {
   AnonymousJazzAgent,
   FileStream,
   Group,
-  MaybeLoaded,
+  Settled,
   coOptionalDefiner,
   unstable_mergeBranchWithResolve,
 } from "../../../internal.js";
@@ -82,7 +82,7 @@ export class FileStreamSchema implements CoreFileStreamSchema {
   load(
     id: string,
     options?: { loadAs?: Account | AnonymousJazzAgent },
-  ): Promise<MaybeLoaded<FileStream>> {
+  ): Promise<Settled<FileStream>> {
     return this.coValueClass.load(id, options);
   }
 

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/GroupSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/GroupSchema.ts
@@ -6,7 +6,7 @@ import {
 } from "../../../coValues/interfaces.js";
 import {
   Account,
-  MaybeLoaded,
+  Settled,
   RefsToResolve,
   RefsToResolveStrict,
   Resolved,
@@ -52,7 +52,7 @@ export class GroupSchema implements CoreGroupSchema {
       loadAs?: Account;
       resolve?: RefsToResolveStrict<Group, R>;
     },
-  ): Promise<MaybeLoaded<Group>> {
+  ): Promise<Settled<Group>> {
     return Group.load(id, options);
   }
   createInvite<G extends Group>(

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/PlainTextSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/PlainTextSchema.ts
@@ -4,7 +4,7 @@ import {
   BranchDefinition,
   CoPlainText,
   Group,
-  MaybeLoaded,
+  Settled,
   coOptionalDefiner,
   unstable_mergeBranchWithResolve,
 } from "../../../internal.js";
@@ -50,7 +50,7 @@ export class PlainTextSchema implements CorePlainTextSchema {
       loadAs: Account | AnonymousJazzAgent;
       unstable_branch?: BranchDefinition;
     },
-  ): Promise<MaybeLoaded<CoPlainText>> {
+  ): Promise<Settled<CoPlainText>> {
     return this.coValueClass.load(id, options);
   }
 

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/RichTextSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/RichTextSchema.ts
@@ -3,7 +3,7 @@ import {
   BranchDefinition,
   CoRichText,
   Group,
-  MaybeLoaded,
+  Settled,
   coOptionalDefiner,
   unstable_mergeBranchWithResolve,
 } from "../../../internal.js";
@@ -49,7 +49,7 @@ export class RichTextSchema implements CoreRichTextSchema {
       loadAs: Account | AnonymousJazzAgent;
       unstable_branch?: BranchDefinition;
     },
-  ): Promise<MaybeLoaded<CoRichText>> {
+  ): Promise<Settled<CoRichText>> {
     return this.coValueClass.load(id, options);
   }
 

--- a/packages/jazz-tools/src/tools/tests/request.test.ts
+++ b/packages/jazz-tools/src/tools/tests/request.test.ts
@@ -14,6 +14,7 @@ import {
   CoValueLoadingState,
   exportCoValue,
   importContentPieces,
+  Inaccessible,
 } from "../internal.js";
 import { createJazzTestAccount, linkAccounts } from "../testing.js";
 
@@ -663,7 +664,7 @@ describe("JazzRequestError handling", () => {
             createUnloadedCoValue(
               "some-covalue-id",
               CoValueLoadingState.UNAVAILABLE,
-            ),
+            ) as Inaccessible<Account>,
           );
 
           return userRequest.handle(request, worker, async () => {


### PR DESCRIPTION
# Description

All CoValue `.load` methods used to return a `MaybeLoaded` CoValue, which meant the CoValue loading state could be either loaded, loading, unavailable or unauthorized.

`.load` methods never actually return a CoValue in `loading` state, because the returned Promise resolves once the CoValue is no longer in loading state. This PR modifies the return types to reflect the runtime behavior. 

## Tests

- [x] Tests have been added and/or updated

## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [x] I've generated a changeset, if a version bump is required
- [x] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing