### PR TITLE
fix: avoid migrating unauthorized CoValues

### DIFF
--- a/.changeset/true-lies-throw.md
+++ b/.changeset/true-lies-throw.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Avoid migrating unauthorized CoValues


### PR DESCRIPTION
# Description

I found we were attempting to migrate CoValues even if we don't have permission to access them. Usually this just led to doing unnecessary work, but for `co.discriminatedUnion` in particular it was causing the following error:
```
co.discriminatedUnion() of collaborative types with no matching discriminator value found
```

I added a check to prevent migrating CoValues the user has no access to.

## Tests

- [x] Tests have been added and/or updated

## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [x] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents migrating/processing unauthorized CoValues in `SubscriptionScope` and adds tests for discriminated unions and partial access handling.
> 
> - **Core subscription logic (`packages/jazz-tools/src/tools/subscribe/SubscriptionScope.ts`)**:
>   - Skip migrations unless the value is accessible via new `hasAccessToCoValue()` check.
>   - Early-return unauthorized updates by replacing inline ruleset checks with `hasAccessToCoValue()`.
>   - Add `hasAccessToCoValue(rawCoValue)` helper centralizing access logic.
> - **Tests (`packages/jazz-tools/src/tools/tests/coDiscriminatedUnion.test.ts`)**:
>   - Add test asserting error when creating union member without matching discriminator field.
>   - Add test confirming `co.list` of discriminated unions loads with mixed accessibility, marking inaccessible items as `UNAUTHORIZED`.
> - **Release**:
>   - Changeset: `jazz-tools` patch bump.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e113a79d401ecd8058970e7d9b8ae93668cd1ece. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->