### PR TITLE
feat: Schema-level Permissions v2

### DIFF
--- a/examples/chat/src/schema.ts
+++ b/examples/chat/src/schema.ts
@@ -1,4 +1,4 @@
-import { co } from "jazz-tools";
+import { co, Group } from "jazz-tools";
 
 export const Message = co
   .map({
@@ -11,8 +11,6 @@ export const Message = co
 export type Message = co.loaded<typeof Message>;
 
 export const Chat = co.list(Message).withPermissions({
-  onCreate(newGroup) {
-    newGroup.makePublic("writer");
-  },
+  default: () => Group.create().makePublic("writer"),
 });
 export type Chat = co.loaded<typeof Chat>;

--- a/examples/multi-cursors/src/schema.ts
+++ b/examples/multi-cursors/src/schema.ts
@@ -1,4 +1,4 @@
-import { co, z } from "jazz-tools";
+import { co, Group, z } from "jazz-tools";
 import { Camera, Cursor } from "./types";
 
 export const CursorFeed = co.feed(Cursor).withPermissions({
@@ -11,9 +11,7 @@ export const CursorProfile = co
   })
   .withPermissions({
     // The profile info is visible to everyone
-    onCreate(newGroup) {
-      newGroup.makePublic();
-    },
+    default: () => Group.create().makePublic(),
     onInlineCreate(newGroup) {
       newGroup.makePublic();
     },

--- a/examples/multi-cursors/src/schema.ts
+++ b/examples/multi-cursors/src/schema.ts
@@ -1,4 +1,4 @@
-import { co, Group, z } from "jazz-tools";
+import { co, z } from "jazz-tools";
 import { Camera, Cursor } from "./types";
 
 export const CursorFeed = co.feed(Cursor).withPermissions({
@@ -11,10 +11,7 @@ export const CursorProfile = co
   })
   .withPermissions({
     // The profile info is visible to everyone
-    default: () => Group.create().makePublic(),
-    onInlineCreate(newGroup) {
-      newGroup.makePublic();
-    },
+    onCreate: (newGroup) => newGroup.makePublic(),
   });
 
 export const CursorRoot = co.map({

--- a/examples/organization/src/schema.ts
+++ b/examples/organization/src/schema.ts
@@ -53,10 +53,7 @@ export const JazzAccountRoot = co.map({
 export const JazzAccount = co
   .account({
     profile: co.profile().withPermissions({
-      default: (newGroup) => {
-        newGroup.addMember("everyone", "reader");
-      },
-      onInlineCreate: (newGroup) => {
+      onCreate: (newGroup) => {
         newGroup.addMember("everyone", "reader");
       },
     }),

--- a/examples/organization/src/schema.ts
+++ b/examples/organization/src/schema.ts
@@ -53,7 +53,7 @@ export const JazzAccountRoot = co.map({
 export const JazzAccount = co
   .account({
     profile: co.profile().withPermissions({
-      onCreate: (newGroup) => {
+      default: (newGroup) => {
         newGroup.addMember("everyone", "reader");
       },
       onInlineCreate: (newGroup) => {

--- a/examples/version-history/src/schema.ts
+++ b/examples/version-history/src/schema.ts
@@ -16,8 +16,6 @@ export const Issue = co
   })
   .resolved({ description: true })
   .withPermissions({
-    onCreate(newGroup) {
-      newGroup.addMember("everyone", "writer");
-    },
+    default: () => Group.create().addMember("everyone", "writer"),
   });
 export type Issue = co.loaded<typeof Issue>;

--- a/examples/version-history/src/schema.ts
+++ b/examples/version-history/src/schema.ts
@@ -3,7 +3,7 @@
  * https://jazz.tools/docs/react/schemas/covalues
  */
 
-import { co, z } from "jazz-tools";
+import { co, Group, z } from "jazz-tools";
 
 export const Issue = co
   .map({
@@ -16,6 +16,10 @@ export const Issue = co
   })
   .resolved({ description: true })
   .withPermissions({
-    default: () => Group.create().addMember("everyone", "writer"),
+    default: () => {
+      const owner = Group.create();
+      owner.addMember("everyone", "writer");
+      return owner;
+    },
   });
 export type Issue = co.loaded<typeof Issue>;

--- a/homepage/homepage/content/docs/code-snippets/permissions-and-sharing/overview/index.ts
+++ b/homepage/homepage/content/docs/code-snippets/permissions-and-sharing/overview/index.ts
@@ -84,9 +84,7 @@ const Dog = co.map({
 const Person = co.map({
   pet: Dog,
 }).withPermissions({
-  onCreate(newGroup) {
-    newGroup.makePublic();
-  }
+  default: () => Group.create().makePublic(),
 });
 
 // All Person CoValues will be public, and each Dog CoValue will share the same owner

--- a/homepage/homepage/content/docs/permissions-and-sharing/overview.mdx
+++ b/homepage/homepage/content/docs/permissions-and-sharing/overview.mdx
@@ -178,22 +178,22 @@ You can define permissions at the schema level by using the `withPermissions` me
 
 `withPermissions` supports two options, that let you customize how permissions are applied when creating or composing CoValues.
 
-#### `onCreate`
+#### `default`
 
-`onCreate` receives a callback that allows configuring a CoValue’s group when using `.create()` without providing an explicit owner. 
+`default` defines a group to be used when calling `.create()` without an explicit owner. 
 
 #### `onInlineCreate`
 
 `onInlineCreate` defines how a nested CoValue’s owner is obtained when creating inline CoValues.
 
-This configuration **is not applied** when using an explicit `.create()` for nested CoValues. In that case, `onCreate` is used.
+This configuration **is not applied** when using `.create()` for nested CoValues. In that case, `default` is used.
 
 `onInlineCreate` supports the following options:
 - `"extendsContainer"` - create a new group that includes the container CoValue's owner as a member, effectively inheriting all permissions from the container. This is the default if no `onInlineCreate` option is provided.
 - `"sameAsContainer"` - reuse the same owner as the container CoValue
 - `"newGroup"` - create a new group for inline CoValues, with the active account as admin
 - `{ extendsContainer: "reader" }` - similar to `“extendsContainer”`, but allows overriding the role of the container’s owner in the new group
-- `groupConfigurationCallback` - create a new group and configure it as needed (similarly to `onCreate`)
+- `groupConfigurationCallback` - create a new group and configure it as needed
 
 ### Configuring permissions globally
 

--- a/homepage/homepage/content/docs/permissions-and-sharing/overview.mdx
+++ b/homepage/homepage/content/docs/permissions-and-sharing/overview.mdx
@@ -176,7 +176,7 @@ You can define permissions at the schema level by using the `withPermissions` me
 ```
 </CodeGroup>
 
-`withPermissions` supports two options, that let you customize how permissions are applied when creating or composing CoValues.
+`withPermissions` supports several options that let you customize how permissions are applied when creating or composing CoValues.
 
 #### `default`
 
@@ -194,6 +194,11 @@ This configuration **is not applied** when using `.create()` for nested CoValues
 - `"newGroup"` - create a new group for inline CoValues, with the active account as admin
 - `{ extendsContainer: "reader" }` - similar to `“extendsContainer”`, but allows overriding the role of the container’s owner in the new group
 - `groupConfigurationCallback` - create a new group and configure it as needed
+
+#### `onCreate`
+
+`onCreate` is a callback that runs every time a CoValue is created. It can be used to configure the CoValue's owner.
+It runs both when creating CoValues with `.create()` and when creating inline CoValues.
 
 ### Configuring permissions globally
 

--- a/packages/jazz-tools/src/tools/coValues/account.ts
+++ b/packages/jazz-tools/src/tools/coValues/account.ts
@@ -433,11 +433,13 @@ class AccountJazzApi<A extends Account> extends CoValueJazzApi<A> {
       if (!refId) {
         const descriptor = this.schema[key];
         const newOwnerStrategy = descriptor.permissions?.newInlineOwnerStrategy;
+        const onCreate = descriptor.permissions?.onCreate;
         const coValue = instantiateRefEncodedWithInit(
           descriptor,
           value,
           accountOrGroupToGroup(this.account),
           newOwnerStrategy,
+          onCreate,
         );
         refId = coValue.$jazz.id as CoID<RawCoMap>;
       }

--- a/packages/jazz-tools/src/tools/coValues/coFeed.ts
+++ b/packages/jazz-tools/src/tools/coValues/coFeed.ts
@@ -378,11 +378,13 @@ export class CoFeedJazzApi<F extends CoFeed> extends CoValueJazzApi<F> {
       if (!refId) {
         const newOwnerStrategy =
           itemDescriptor.permissions?.newInlineOwnerStrategy;
+        const onCreate = itemDescriptor.permissions?.onCreate;
         const coValue = instantiateRefEncodedWithInit(
           itemDescriptor,
           item,
           this.owner,
           newOwnerStrategy,
+          onCreate,
         );
         refId = coValue.$jazz.id;
       }

--- a/packages/jazz-tools/src/tools/coValues/coFeed.ts
+++ b/packages/jazz-tools/src/tools/coValues/coFeed.ts
@@ -218,13 +218,7 @@ export class CoFeed<out Item = any> extends CoValueBase implements CoValue {
   static create<S extends CoFeed>(
     this: CoValueClass<S>,
     init: S extends CoFeed<infer Item> ? Item[] : never,
-    options?:
-      | {
-          owner: Account | Group;
-          configureImplicitGroupOwner?: (newGroup: Group) => void;
-        }
-      | Account
-      | Group,
+    options?: { owner: Account | Group } | Account | Group,
   ) {
     const { owner } = parseCoValueCreateOptions(options);
     const raw = owner.$jazz.raw.createStream();
@@ -748,13 +742,7 @@ export class FileStream extends CoValueBase implements CoValue {
    */
   static create<S extends FileStream>(
     this: CoValueClass<S>,
-    options?:
-      | {
-          owner?: Account | Group;
-          configureImplicitGroupOwner?: (newGroup: Group) => void;
-        }
-      | Account
-      | Group,
+    options?: { owner?: Account | Group } | Account | Group,
   ) {
     const { owner } = parseCoValueCreateOptions(options);
     return new this({ owner });
@@ -884,7 +872,6 @@ export class FileStream extends CoValueBase implements CoValue {
     options?:
       | {
           owner?: Account | Group;
-          configureImplicitGroupOwner?: (newGroup: Group) => void;
           onProgress?: (progress: number) => void;
         }
       | Account
@@ -918,7 +905,6 @@ export class FileStream extends CoValueBase implements CoValue {
     options?:
       | {
           owner?: Account | Group;
-          configureImplicitGroupOwner?: (newGroup: Group) => void;
           onProgress?: (progress: number) => void;
         }
       | Account

--- a/packages/jazz-tools/src/tools/coValues/coList.ts
+++ b/packages/jazz-tools/src/tools/coValues/coList.ts
@@ -918,11 +918,13 @@ function toRawItems<Item>(
       if (!refId) {
         const newOwnerStrategy =
           itemDescriptor.permissions?.newInlineOwnerStrategy;
+        const onCreate = itemDescriptor.permissions?.onCreate;
         const coValue = instantiateRefEncodedWithInit(
           itemDescriptor,
           value,
           owner,
           newOwnerStrategy,
+          onCreate,
         );
         refId = coValue.$jazz.id;
       }

--- a/packages/jazz-tools/src/tools/coValues/coList.ts
+++ b/packages/jazz-tools/src/tools/coValues/coList.ts
@@ -165,7 +165,6 @@ export class CoList<out Item = any>
     options?:
       | {
           owner: Account | Group;
-          configureImplicitGroupOwner?: (newGroup: Group) => void;
           unique?: CoValueUniqueness["uniqueness"];
         }
       | Account

--- a/packages/jazz-tools/src/tools/coValues/coMap.ts
+++ b/packages/jazz-tools/src/tools/coValues/coMap.ts
@@ -300,11 +300,13 @@ export class CoMap extends CoValueBase implements CoValue {
             if (!refId) {
               const newOwnerStrategy =
                 descriptor.permissions?.newInlineOwnerStrategy;
+              const onCreate = descriptor.permissions?.onCreate;
               const coValue = instantiateRefEncodedWithInit(
                 descriptor,
                 initValue,
                 owner,
                 newOwnerStrategy,
+                onCreate,
               );
               refId = coValue.$jazz.id;
             }
@@ -615,11 +617,13 @@ class CoMapJazzApi<M extends CoMap> extends CoValueJazzApi<M> {
         if (!refId) {
           const newOwnerStrategy =
             descriptor.permissions?.newInlineOwnerStrategy;
+          const onCreate = descriptor.permissions?.onCreate;
           const coValue = instantiateRefEncodedWithInit(
             descriptor,
             value,
             this.owner,
             newOwnerStrategy,
+            onCreate,
           );
           refId = coValue.$jazz.id;
         }

--- a/packages/jazz-tools/src/tools/coValues/coMap.ts
+++ b/packages/jazz-tools/src/tools/coValues/coMap.ts
@@ -174,7 +174,6 @@ export class CoMap extends CoValueBase implements CoValue {
     options?:
       | {
           owner?: Account | Group;
-          configureImplicitGroupOwner?: (newGroup: Group) => void;
           unique?: CoValueUniqueness["uniqueness"];
         }
       | Account
@@ -248,7 +247,6 @@ export class CoMap extends CoValueBase implements CoValue {
     options?:
       | {
           owner?: Account | Group;
-          configureImplicitGroupOwner?: (newGroup: Group) => void;
           unique?: CoValueUniqueness["uniqueness"];
         }
       | Account

--- a/packages/jazz-tools/src/tools/coValues/coPlainText.ts
+++ b/packages/jazz-tools/src/tools/coValues/coPlainText.ts
@@ -92,13 +92,7 @@ export class CoPlainText extends String implements CoValue {
   static create<T extends CoPlainText>(
     this: CoValueClass<T>,
     text: string,
-    options?:
-      | {
-          owner: Account | Group;
-          configureImplicitGroupOwner?: (newGroup: Group) => void;
-        }
-      | Account
-      | Group,
+    options?: { owner: Account | Group } | Account | Group,
   ) {
     const { owner } = parseCoValueCreateOptions(options);
     return new this({ text, owner });

--- a/packages/jazz-tools/src/tools/coValues/coVector.ts
+++ b/packages/jazz-tools/src/tools/coValues/coVector.ts
@@ -110,13 +110,7 @@ export class CoVector
   static create<S extends CoVector>(
     this: CoValueClass<S> & typeof CoVector,
     vector: number[] | Float32Array,
-    options?:
-      | {
-          owner?: Account | Group;
-          configureImplicitGroupOwner?: (newGroup: Group) => void;
-        }
-      | Account
-      | Group,
+    options?: { owner?: Account | Group } | Account | Group,
   ) {
     const vectorAsFloat32Array =
       vector instanceof Float32Array ? vector : new Float32Array(vector);

--- a/packages/jazz-tools/src/tools/coValues/interfaces.ts
+++ b/packages/jazz-tools/src/tools/coValues/interfaces.ts
@@ -429,7 +429,6 @@ export function parseCoValueCreateOptions(
   options:
     | {
         owner?: Account | Group;
-        configureImplicitGroupOwner?: (newGroup: Group) => void;
         unique?: CoValueUniqueness["uniqueness"];
       }
     | Account
@@ -439,19 +438,9 @@ export function parseCoValueCreateOptions(
   owner: Group;
   uniqueness?: CoValueUniqueness;
 } {
-  const configureImplicitGroupOwner =
-    options && "configureImplicitGroupOwner" in options
-      ? options.configureImplicitGroupOwner
-      : undefined;
-  const createNewGroup = () => {
-    const newGroup = Group.create();
-    configureImplicitGroupOwner?.(newGroup);
-    return newGroup;
-  };
-
   const Group = RegisteredSchemas["Group"];
   if (!options) {
-    return { owner: createNewGroup(), uniqueness: undefined };
+    return { owner: Group.create(), uniqueness: undefined };
   }
 
   if (TypeSym in options) {
@@ -469,7 +458,7 @@ export function parseCoValueCreateOptions(
   const opts = {
     owner: options.owner
       ? accountOrGroupToGroup(options.owner)
-      : createNewGroup(),
+      : Group.create(),
     uniqueness,
   };
   return opts;

--- a/packages/jazz-tools/src/tools/implementation/schema.ts
+++ b/packages/jazz-tools/src/tools/implementation/schema.ts
@@ -11,7 +11,7 @@ import {
   ItemsSym,
   LoadedAndRequired,
   type NewInlineOwnerStrategy,
-  type OnCreateCallback,
+  type RefOnCreateCallback,
   type RefPermissions,
   SchemaInit,
   isCoValueClass,
@@ -177,7 +177,7 @@ export function instantiateRefEncodedWithInit<V extends CoValue>(
   init: any,
   containerOwner: Group,
   newOwnerStrategy: NewInlineOwnerStrategy = extendContainerOwner,
-  onCreate?: OnCreateCallback,
+  onCreate?: RefOnCreateCallback,
 ): V {
   if (!isCoValueClass<V>(schema.ref)) {
     throw Error(
@@ -185,7 +185,7 @@ export function instantiateRefEncodedWithInit<V extends CoValue>(
     );
   }
   const owner = newOwnerStrategy(() => Group.create(), containerOwner, init);
-  onCreate?.(owner);
+  onCreate?.(owner, init);
   // @ts-expect-error - create is a static method in all CoValue classes
   return schema.ref.create(init, owner);
 }

--- a/packages/jazz-tools/src/tools/implementation/schema.ts
+++ b/packages/jazz-tools/src/tools/implementation/schema.ts
@@ -11,6 +11,7 @@ import {
   ItemsSym,
   LoadedAndRequired,
   type NewInlineOwnerStrategy,
+  type OnCreateCallback,
   type RefPermissions,
   SchemaInit,
   isCoValueClass,
@@ -166,7 +167,9 @@ export function instantiateRefEncodedFromRaw<V extends CoValue>(
  * @param schema - The schema of the CoValue to create.
  * @param init - The init values to use to create the CoValue.
  * @param containerOwner - The owner of the referencing CoValue. Will be used
- * as the parent group of the created CoValue's group
+ * to determine the owner of the new CoValue
+ * @param newOwnerStrategy - The strategy to use to determine the owner of the new CoValue
+ * @param onCreate - The callback to call when the new CoValue is created
  * @returns The created CoValue.
  */
 export function instantiateRefEncodedWithInit<V extends CoValue>(
@@ -174,6 +177,7 @@ export function instantiateRefEncodedWithInit<V extends CoValue>(
   init: any,
   containerOwner: Group,
   newOwnerStrategy: NewInlineOwnerStrategy = extendContainerOwner,
+  onCreate?: OnCreateCallback,
 ): V {
   if (!isCoValueClass<V>(schema.ref)) {
     throw Error(
@@ -181,6 +185,7 @@ export function instantiateRefEncodedWithInit<V extends CoValue>(
     );
   }
   const owner = newOwnerStrategy(() => Group.create(), containerOwner, init);
+  onCreate?.(owner);
   // @ts-expect-error - create is a static method in all CoValue classes
   return schema.ref.create(init, owner);
 }

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaPermissions.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaPermissions.ts
@@ -37,6 +37,12 @@ export type InlineGroupConfigurationCallback = (
 export type OnCreateCallback = (newGroup: Group) => void;
 
 /**
+ * Internal callback type used by RefPermissions that includes init for discriminated union support.
+ * @internal
+ */
+export type RefOnCreateCallback = (newGroup: Group, init?: unknown) => void;
+
+/**
  * Permissions to be used when creating or composing CoValues
  * @param default - default owner to be used when creating a CoValue without providing an explicit owner.
  * @param onInlineCreate - defines how a nested CoValue's owner is obtained when creating CoValues from JSON.
@@ -69,7 +75,7 @@ export function setDefaultSchemaPermissions(permissions: SchemaPermissions) {
  */
 export type RefPermissions = {
   newInlineOwnerStrategy: NewInlineOwnerStrategy;
-  onCreate?: OnCreateCallback;
+  onCreate?: RefOnCreateCallback;
 };
 
 /**
@@ -108,9 +114,12 @@ export function schemaToRefPermissions(
   const newInlineOwnerStrategy = parseOnInlineCreate(
     permissions.onInlineCreate,
   );
+  const onCreate: RefOnCreateCallback | undefined = permissions.onCreate
+    ? (newGroup, _init) => permissions.onCreate?.(newGroup)
+    : undefined;
   return {
     newInlineOwnerStrategy,
-    onCreate: permissions.onCreate,
+    onCreate,
   };
 }
 

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaPermissions.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaPermissions.ts
@@ -66,8 +66,10 @@ export let DEFAULT_SCHEMA_PERMISSIONS: SchemaPermissions = {
  * Schemas created before calling this function will not be affected.
  */
 export function setDefaultSchemaPermissions(permissions: SchemaPermissions) {
-  // TODO should this only update the provided options?
-  DEFAULT_SCHEMA_PERMISSIONS = permissions;
+  DEFAULT_SCHEMA_PERMISSIONS = {
+    ...DEFAULT_SCHEMA_PERMISSIONS,
+    ...permissions,
+  };
 }
 
 /**

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoFeedSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoFeedSchema.ts
@@ -13,7 +13,7 @@ import {
   coOptionalDefiner,
   parseSubscribeRestArgs,
   unstable_mergeBranchWithResolve,
-  mergeCreateOptionsWithSchemaPermissions,
+  withDefaultOwner,
 } from "../../../internal.js";
 import { AnonymousJazzAgent } from "../../anonymousJazzAgent.js";
 import { CoFeedSchemaInit } from "../typeConverters/CoFieldSchemaInit.js";
@@ -66,10 +66,7 @@ export class CoFeedSchema<
     init: CoFeedSchemaInit<T>,
     options?: { owner: Account | Group } | Account | Group,
   ): CoFeedInstance<T> {
-    const optionsWithPermissions = mergeCreateOptionsWithSchemaPermissions(
-      options,
-      this.permissions,
-    );
+    const optionsWithPermissions = withDefaultOwner(options, this.permissions);
     return this.coValueClass.create(
       init as any,
       optionsWithPermissions,

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoFeedSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoFeedSchema.ts
@@ -13,7 +13,7 @@ import {
   coOptionalDefiner,
   parseSubscribeRestArgs,
   unstable_mergeBranchWithResolve,
-  withDefaultOwner,
+  withSchemaPermissions,
 } from "../../../internal.js";
 import { AnonymousJazzAgent } from "../../anonymousJazzAgent.js";
 import { CoFeedSchemaInit } from "../typeConverters/CoFieldSchemaInit.js";
@@ -66,7 +66,10 @@ export class CoFeedSchema<
     init: CoFeedSchemaInit<T>,
     options?: { owner: Account | Group } | Account | Group,
   ): CoFeedInstance<T> {
-    const optionsWithPermissions = withDefaultOwner(options, this.permissions);
+    const optionsWithPermissions = withSchemaPermissions(
+      options,
+      this.permissions,
+    );
     return this.coValueClass.create(
       init as any,
       optionsWithPermissions,

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoListSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoListSchema.ts
@@ -12,7 +12,7 @@ import {
   SubscribeListenerOptions,
   coOptionalDefiner,
   unstable_mergeBranchWithResolve,
-  withDefaultOwner,
+  withSchemaPermissions,
 } from "../../../internal.js";
 import { CoValueUniqueness } from "cojson";
 import { AnonymousJazzAgent } from "../../anonymousJazzAgent.js";
@@ -75,7 +75,10 @@ export class CoListSchema<
       | Account
       | Group,
   ): CoListInstance<T> {
-    const optionsWithPermissions = withDefaultOwner(options, this.permissions);
+    const optionsWithPermissions = withSchemaPermissions(
+      options,
+      this.permissions,
+    );
     return this.coValueClass.create(
       items as any,
       optionsWithPermissions,

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoListSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoListSchema.ts
@@ -12,7 +12,7 @@ import {
   SubscribeListenerOptions,
   coOptionalDefiner,
   unstable_mergeBranchWithResolve,
-  mergeCreateOptionsWithSchemaPermissions,
+  withDefaultOwner,
 } from "../../../internal.js";
 import { CoValueUniqueness } from "cojson";
 import { AnonymousJazzAgent } from "../../anonymousJazzAgent.js";
@@ -75,10 +75,7 @@ export class CoListSchema<
       | Account
       | Group,
   ): CoListInstance<T> {
-    const optionsWithPermissions = mergeCreateOptionsWithSchemaPermissions(
-      options,
-      this.permissions,
-    );
+    const optionsWithPermissions = withDefaultOwner(options, this.permissions);
     return this.coValueClass.create(
       items as any,
       optionsWithPermissions,

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoMapSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoMapSchema.ts
@@ -17,7 +17,7 @@ import {
   hydrateCoreCoValueSchema,
   isAnyCoValueSchema,
   unstable_mergeBranchWithResolve,
-  withDefaultOwner,
+  withSchemaPermissions,
 } from "../../../internal.js";
 import { AnonymousJazzAgent } from "../../anonymousJazzAgent.js";
 import { removeGetters, withSchemaResolveQuery } from "../../schemaUtils.js";
@@ -88,7 +88,10 @@ export class CoMapSchema<
       | Owner,
   ): CoMapInstanceShape<Shape, CatchAll> & CoMap;
   create(init: any, options?: any) {
-    const optionsWithPermissions = withDefaultOwner(options, this.permissions);
+    const optionsWithPermissions = withSchemaPermissions(
+      options,
+      this.permissions,
+    );
     return this.coValueClass.create(init, optionsWithPermissions);
   }
 

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoMapSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoMapSchema.ts
@@ -17,7 +17,7 @@ import {
   hydrateCoreCoValueSchema,
   isAnyCoValueSchema,
   unstable_mergeBranchWithResolve,
-  mergeCreateOptionsWithSchemaPermissions,
+  withDefaultOwner,
 } from "../../../internal.js";
 import { AnonymousJazzAgent } from "../../anonymousJazzAgent.js";
 import { removeGetters, withSchemaResolveQuery } from "../../schemaUtils.js";
@@ -88,10 +88,7 @@ export class CoMapSchema<
       | Owner,
   ): CoMapInstanceShape<Shape, CatchAll> & CoMap;
   create(init: any, options?: any) {
-    const optionsWithPermissions = mergeCreateOptionsWithSchemaPermissions(
-      options,
-      this.permissions,
-    );
+    const optionsWithPermissions = withDefaultOwner(options, this.permissions);
     return this.coValueClass.create(init, optionsWithPermissions);
   }
 

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoVectorSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoVectorSchema.ts
@@ -6,7 +6,7 @@ import {
   InstanceOrPrimitiveOfSchema,
   InstanceOrPrimitiveOfSchemaCoValuesMaybeLoaded,
   coOptionalDefiner,
-  mergeCreateOptionsWithSchemaPermissions,
+  withDefaultOwner,
 } from "../../../internal.js";
 import { CoOptionalSchema } from "./CoOptionalSchema.js";
 import { CoreCoValueSchema } from "./CoValueSchema.js";
@@ -66,10 +66,7 @@ export class CoVectorSchema implements CoreCoVectorSchema {
     vector: number[] | Float32Array,
     options?: { owner: Account | Group } | Account | Group,
   ): CoVectorInstance {
-    const optionsWithPermissions = mergeCreateOptionsWithSchemaPermissions(
-      options,
-      this.permissions,
-    );
+    const optionsWithPermissions = withDefaultOwner(options, this.permissions);
     return this.coValueClass.create(vector, optionsWithPermissions);
   }
 

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoVectorSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoVectorSchema.ts
@@ -6,7 +6,7 @@ import {
   InstanceOrPrimitiveOfSchema,
   InstanceOrPrimitiveOfSchemaCoValuesMaybeLoaded,
   coOptionalDefiner,
-  withDefaultOwner,
+  withSchemaPermissions,
 } from "../../../internal.js";
 import { CoOptionalSchema } from "./CoOptionalSchema.js";
 import { CoreCoValueSchema } from "./CoValueSchema.js";
@@ -66,7 +66,10 @@ export class CoVectorSchema implements CoreCoVectorSchema {
     vector: number[] | Float32Array,
     options?: { owner: Account | Group } | Account | Group,
   ): CoVectorInstance {
-    const optionsWithPermissions = withDefaultOwner(options, this.permissions);
+    const optionsWithPermissions = withSchemaPermissions(
+      options,
+      this.permissions,
+    );
     return this.coValueClass.create(vector, optionsWithPermissions);
   }
 

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/FileStreamSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/FileStreamSchema.ts
@@ -6,7 +6,7 @@ import {
   MaybeLoaded,
   coOptionalDefiner,
   unstable_mergeBranchWithResolve,
-  withDefaultOwner,
+  withSchemaPermissions,
 } from "../../../internal.js";
 import { CoOptionalSchema } from "./CoOptionalSchema.js";
 import { CoreCoValueSchema } from "./CoValueSchema.js";
@@ -43,7 +43,10 @@ export class FileStreamSchema implements CoreFileStreamSchema {
   /** @deprecated Creating CoValues with an Account as owner is deprecated. Use a Group instead. */
   create(options?: { owner: Account | Group } | Account | Group): FileStream;
   create(options?: { owner: Account | Group } | Account | Group): FileStream {
-    const optionsWithPermissions = withDefaultOwner(options, this.permissions);
+    const optionsWithPermissions = withSchemaPermissions(
+      options,
+      this.permissions,
+    );
     return this.coValueClass.create(optionsWithPermissions);
   }
 
@@ -71,7 +74,10 @@ export class FileStreamSchema implements CoreFileStreamSchema {
       | Account
       | Group,
   ): Promise<FileStream> {
-    const optionsWithPermissions = withDefaultOwner(options, this.permissions);
+    const optionsWithPermissions = withSchemaPermissions(
+      options,
+      this.permissions,
+    );
     return this.coValueClass.createFromBlob(blob, optionsWithPermissions);
   }
 
@@ -87,7 +93,10 @@ export class FileStreamSchema implements CoreFileStreamSchema {
       | Account
       | Group,
   ) {
-    const optionsWithPermissions = withDefaultOwner(options, this.permissions);
+    const optionsWithPermissions = withSchemaPermissions(
+      options,
+      this.permissions,
+    );
     return this.coValueClass.createFromArrayBuffer(
       arrayBuffer,
       mimeType,

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/FileStreamSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/FileStreamSchema.ts
@@ -6,7 +6,7 @@ import {
   MaybeLoaded,
   coOptionalDefiner,
   unstable_mergeBranchWithResolve,
-  mergeCreateOptionsWithSchemaPermissions,
+  withDefaultOwner,
 } from "../../../internal.js";
 import { CoOptionalSchema } from "./CoOptionalSchema.js";
 import { CoreCoValueSchema } from "./CoValueSchema.js";
@@ -43,10 +43,7 @@ export class FileStreamSchema implements CoreFileStreamSchema {
   /** @deprecated Creating CoValues with an Account as owner is deprecated. Use a Group instead. */
   create(options?: { owner: Account | Group } | Account | Group): FileStream;
   create(options?: { owner: Account | Group } | Account | Group): FileStream {
-    const optionsWithPermissions = mergeCreateOptionsWithSchemaPermissions(
-      options,
-      this.permissions,
-    );
+    const optionsWithPermissions = withDefaultOwner(options, this.permissions);
     return this.coValueClass.create(optionsWithPermissions);
   }
 
@@ -74,10 +71,7 @@ export class FileStreamSchema implements CoreFileStreamSchema {
       | Account
       | Group,
   ): Promise<FileStream> {
-    const optionsWithPermissions = mergeCreateOptionsWithSchemaPermissions(
-      options,
-      this.permissions,
-    );
+    const optionsWithPermissions = withDefaultOwner(options, this.permissions);
     return this.coValueClass.createFromBlob(blob, optionsWithPermissions);
   }
 
@@ -93,10 +87,7 @@ export class FileStreamSchema implements CoreFileStreamSchema {
       | Account
       | Group,
   ) {
-    const optionsWithPermissions = mergeCreateOptionsWithSchemaPermissions(
-      options,
-      this.permissions,
-    );
+    const optionsWithPermissions = withDefaultOwner(options, this.permissions);
     return this.coValueClass.createFromArrayBuffer(
       arrayBuffer,
       mimeType,

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/PlainTextSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/PlainTextSchema.ts
@@ -7,7 +7,7 @@ import {
   MaybeLoaded,
   coOptionalDefiner,
   unstable_mergeBranchWithResolve,
-  withDefaultOwner,
+  withSchemaPermissions,
 } from "../../../internal.js";
 import { AnonymousJazzAgent } from "../../anonymousJazzAgent.js";
 import { CoOptionalSchema } from "./CoOptionalSchema.js";
@@ -52,7 +52,10 @@ export class PlainTextSchema implements CorePlainTextSchema {
     text: string,
     options?: { owner: Account | Group } | Account | Group,
   ): CoPlainText {
-    const optionsWithPermissions = withDefaultOwner(options, this.permissions);
+    const optionsWithPermissions = withSchemaPermissions(
+      options,
+      this.permissions,
+    );
     return this.coValueClass.create(text, optionsWithPermissions);
   }
 

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/PlainTextSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/PlainTextSchema.ts
@@ -7,7 +7,7 @@ import {
   MaybeLoaded,
   coOptionalDefiner,
   unstable_mergeBranchWithResolve,
-  mergeCreateOptionsWithSchemaPermissions,
+  withDefaultOwner,
 } from "../../../internal.js";
 import { AnonymousJazzAgent } from "../../anonymousJazzAgent.js";
 import { CoOptionalSchema } from "./CoOptionalSchema.js";
@@ -52,10 +52,7 @@ export class PlainTextSchema implements CorePlainTextSchema {
     text: string,
     options?: { owner: Account | Group } | Account | Group,
   ): CoPlainText {
-    const optionsWithPermissions = mergeCreateOptionsWithSchemaPermissions(
-      options,
-      this.permissions,
-    );
+    const optionsWithPermissions = withDefaultOwner(options, this.permissions);
     return this.coValueClass.create(text, optionsWithPermissions);
   }
 

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/RichTextSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/RichTextSchema.ts
@@ -6,7 +6,7 @@ import {
   MaybeLoaded,
   coOptionalDefiner,
   unstable_mergeBranchWithResolve,
-  withDefaultOwner,
+  withSchemaPermissions,
 } from "../../../internal.js";
 import { AnonymousJazzAgent } from "../../anonymousJazzAgent.js";
 import { CoOptionalSchema } from "./CoOptionalSchema.js";
@@ -47,7 +47,10 @@ export class RichTextSchema implements CoreRichTextSchema {
     text: string,
     options?: { owner: Account | Group } | Account | Group,
   ): CoRichText {
-    const optionsWithPermissions = withDefaultOwner(options, this.permissions);
+    const optionsWithPermissions = withSchemaPermissions(
+      options,
+      this.permissions,
+    );
     return this.coValueClass.create(text, optionsWithPermissions);
   }
 

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/RichTextSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/RichTextSchema.ts
@@ -6,7 +6,7 @@ import {
   MaybeLoaded,
   coOptionalDefiner,
   unstable_mergeBranchWithResolve,
-  mergeCreateOptionsWithSchemaPermissions,
+  withDefaultOwner,
 } from "../../../internal.js";
 import { AnonymousJazzAgent } from "../../anonymousJazzAgent.js";
 import { CoOptionalSchema } from "./CoOptionalSchema.js";
@@ -47,10 +47,7 @@ export class RichTextSchema implements CoreRichTextSchema {
     text: string,
     options?: { owner: Account | Group } | Account | Group,
   ): CoRichText {
-    const optionsWithPermissions = mergeCreateOptionsWithSchemaPermissions(
-      options,
-      this.permissions,
-    );
+    const optionsWithPermissions = withDefaultOwner(options, this.permissions);
     return this.coValueClass.create(text, optionsWithPermissions);
   }
 

--- a/packages/jazz-tools/src/tools/tests/schema.withPermissions.test.ts
+++ b/packages/jazz-tools/src/tools/tests/schema.withPermissions.test.ts
@@ -93,13 +93,11 @@ describe("Schema.withPermissions()", () => {
     ).toThrow();
   });
 
-  describe("onCreate", () => {
-    describe("allows configuring a CoValue's group when using .create() without providing an explicit owner", () => {
+  describe("default", () => {
+    describe("defines a default owner to be used when no explicit owner is passed to .create()", () => {
       test("for CoMap", async () => {
         const TestMap = co.map({ name: co.plainText() }).withPermissions({
-          onCreate(newGroup) {
-            newGroup.makePublic();
-          },
+          default: () => Group.create().makePublic(),
         });
 
         const map = TestMap.create({ name: "Hi!" });
@@ -114,9 +112,7 @@ describe("Schema.withPermissions()", () => {
 
       test("for CoList", async () => {
         const TestList = co.list(z.string()).withPermissions({
-          onCreate(newGroup) {
-            newGroup.makePublic();
-          },
+          default: () => Group.create().makePublic(),
         });
 
         const list = TestList.create(["a", "b", "c"]);
@@ -130,9 +126,7 @@ describe("Schema.withPermissions()", () => {
 
       test("for CoFeed", async () => {
         const TestFeed = co.feed(z.string()).withPermissions({
-          onCreate(newGroup) {
-            newGroup.makePublic();
-          },
+          default: () => Group.create().makePublic(),
         });
 
         const feed = TestFeed.create(["a", "b", "c"]);
@@ -146,9 +140,7 @@ describe("Schema.withPermissions()", () => {
 
       test("for CoPlainText", async () => {
         const TestPlainText = co.plainText().withPermissions({
-          onCreate(newGroup) {
-            newGroup.makePublic();
-          },
+          default: () => Group.create().makePublic(),
         });
 
         const plainText = TestPlainText.create("Hello");
@@ -162,9 +154,7 @@ describe("Schema.withPermissions()", () => {
 
       test("for CoRichText", async () => {
         const TestRichText = co.richText().withPermissions({
-          onCreate(newGroup) {
-            newGroup.makePublic();
-          },
+          default: () => Group.create().makePublic(),
         });
 
         const richText = TestRichText.create("Hello");
@@ -179,9 +169,7 @@ describe("Schema.withPermissions()", () => {
       describe("for FileStream", async () => {
         test(".create()", async () => {
           const TestFileStream = co.fileStream().withPermissions({
-            onCreate(newGroup) {
-              newGroup.makePublic();
-            },
+            default: () => Group.create().makePublic(),
           });
 
           const fileStream = TestFileStream.create();
@@ -202,9 +190,7 @@ describe("Schema.withPermissions()", () => {
 
         test(".createFromBlob()", async () => {
           const TestFileStream = co.fileStream().withPermissions({
-            onCreate(newGroup) {
-              newGroup.makePublic();
-            },
+            default: () => Group.create().makePublic(),
           });
 
           const blob = new Blob(["test"], { type: "text/plain" });
@@ -225,9 +211,7 @@ describe("Schema.withPermissions()", () => {
 
         test(".createFromArrayBuffer()", async () => {
           const TestFileStream = co.fileStream().withPermissions({
-            onCreate(newGroup) {
-              newGroup.makePublic();
-            },
+            default: () => Group.create().makePublic(),
           });
 
           const arrayBuffer = new TextEncoder().encode("test").buffer;
@@ -254,9 +238,7 @@ describe("Schema.withPermissions()", () => {
 
       test("for CoVector", async () => {
         const TestVector = co.vector(1).withPermissions({
-          onCreate(newGroup) {
-            newGroup.makePublic();
-          },
+          default: () => Group.create().makePublic(),
         });
 
         const vector = TestVector.create([1]);
@@ -269,11 +251,9 @@ describe("Schema.withPermissions()", () => {
       });
     });
 
-    test("configuration callback is not run when providing an explicit owner", async () => {
+    test("the default owner is not used when providing an explicit owner", async () => {
       const TestMap = co.map({ name: co.plainText() }).withPermissions({
-        onCreate(newGroup) {
-          newGroup.makePublic();
-        },
+        default: () => Group.create().makePublic(),
       });
       const map = TestMap.create({ name: "Hi!" }, { owner: Group.create() });
 


### PR DESCRIPTION
# Description

I made some API changes on top of https://github.com/garden-co/jazz/pull/3175 based on feedback from @aeplay and @gdorsi:
- `onCreate` now runs **always** (both when using `.create` & on inline CoValue creation, and when passing an explicit owner or not)
- added a new `default` option that lets you provide the default owner to be used when calling `.create` with no owner

## Manual testing instructions

I updated a few example apps to use the new options, but it'd be great if folks could try out the new API in other apps to form an opinion about it.

## Tests

- [x] Tests have been added and/or updated

## Checklist

- [x] I've updated the part of the docs that are affected the PR changes
- [ ] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce `withPermissions` v2: new `default` owner factory and an `onCreate` hook that runs on all creations (explicit/implicit, inline), wired across schemas and creation paths, with docs, examples, and tests updated.
> 
> - **Permissions API (core)**:
>   - Add `SchemaPermissions.default` to supply a default owner for `.create()` when none is passed.
>   - Change `onCreate` to run on every creation (explicit owner, implicit owner, and inline), including discriminated unions.
>   - Thread `onCreate` through creation utilities: `parseCoValueCreateOptions`, `instantiateRefEncodedWithInit`, and all CoValue create paths (`CoMap`, `CoList`, `CoFeed`, `CoPlainText`, `CoVector`, `FileStream`, `Account`).
>   - Replace `mergeCreateOptionsWithSchemaPermissions` with `withSchemaPermissions` and remove `configureImplicitGroupOwner` from deprecated `create` signatures.
> - **Zod/schema integration**:
>   - Extend `RefPermissions` with `onCreate`; update union handling to invoke option-specific `onCreate`.
>   - Update default permissions (`DEFAULT_SCHEMA_PERMISSIONS`) to include `default` and merge behavior in `setDefaultSchemaPermissions`.
> - **Examples & Docs**:
>   - Update example schemas to use `default: () => Group.create().makePublic(...)` and simplified `onCreate` callbacks.
>   - Revise docs to explain `default`, expanded `onInlineCreate`, and new `onCreate` behavior; update code snippets.
> - **Tests**:
>   - Add/modify tests covering `default` owner behavior, always-run `onCreate` (with/without explicit owner, inline, optional fields, discriminated unions), updated defaults merge, and existing behavior preservation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 217fc3bc13607153eae5427d5020beb8baafed1d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->