### PR TITLE
feat: add AdventOfJazzBanner component to RootLayout

### DIFF
--- a/homepage/homepage/app/layout.tsx
+++ b/homepage/homepage/app/layout.tsx
@@ -67,8 +67,7 @@ export default function RootLayout({
           {children}
           <JazzFooter />
           <PagefindSearch />
-          {/* TO DO: This will save us from having to remove on Jan 01 @ 00:00, but once the time has passed, should still be properly removed */}
-          {new Date() < new Date("2026-01-01") && <AdventOfJazzBanner />}
+          <AdventOfJazzBanner />
         </ThemeProvider>
       </body>
     </html>

--- a/homepage/homepage/app/layout.tsx
+++ b/homepage/homepage/app/layout.tsx
@@ -1,3 +1,4 @@
+import { AdventOfJazzBanner } from "@/components/AdventOfJazzBanner";
 import "./globals.css";
 import { ThemeProvider } from "@/components/ThemeProvider";
 import { JazzFooter } from "@/components/footer";
@@ -48,7 +49,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en" className="h-full" suppressHydrationWarning>
-       <body
+      <body
         className={[
           ...fontClasses,
           "min-h-full flex flex-col items-center **:scroll-mt-20",
@@ -62,12 +63,14 @@ export default function RootLayout({
           defaultTheme="system"
           enableSystem
           disableTransitionOnChange
-        > 
+        >
           {children}
           <JazzFooter />
           <PagefindSearch />
+          {/* TO DO: This will save us from having to remove on Jan 01 @ 00:00, but once the time has passed, should still be properly removed */}
+          {new Date() < new Date("2026-01-01") && <AdventOfJazzBanner />}
         </ThemeProvider>
-      </body> 
+      </body>
     </html>
   );
 }

--- a/homepage/homepage/components/AdventOfJazzBanner.tsx
+++ b/homepage/homepage/components/AdventOfJazzBanner.tsx
@@ -1,25 +1,39 @@
 "use client";
 import { useEffect, useState } from "react"
 import './snowflake.css';
-import { Button } from "@garden-co/design-system/src/components/atoms/Button";
 
 export const AdventOfJazzBanner = () => {
   let [shouldShow, setShouldShow] = useState<boolean | null>(null);
   useEffect(() => {
+    // Check if we're past the event date (client-side only to avoid hydration mismatch)
+    if (new Date() >= new Date("2026-01-01")) {
+      setShouldShow(false);
+      return;
+    }
+
     const showAdventOfJazzBanner = window.localStorage.getItem('show_advent_of_jazz_banner');
-    if (showAdventOfJazzBanner === 'false' || shouldShow === false) {
-      window.localStorage.setItem('show_advent_of_jazz_banner', 'false');
-      document.body.style.paddingBlockEnd = '0px';
+    if (showAdventOfJazzBanner === 'false') {
       setShouldShow(false);
       return;
     }
     document.body.style.paddingBlockEnd = '52px';
-    setShouldShow(true)
-  }, [shouldShow])
+    setShouldShow(true);
+
+    return () => {
+      document.body.style.paddingBlockEnd = '0px';
+    };
+  }, [])
+
+  const handleDismiss = () => {
+    window.localStorage.setItem('show_advent_of_jazz_banner', 'false');
+    document.body.style.paddingBlockEnd = '0px';
+    setShouldShow(false);
+  };
+
   if (!shouldShow) return;
   return (
     <>
-      <div className="fixed bottom-0 p-2 w-full grid grid-cols-3 justify-center bg-black overflow-hidden snow gap-2 items-center"><div></div><div>🎄 ❄️ 🕯️ <a href="https://discord.gg/utDMjHYg42" className="text-white underline">Join the Advent of Jazz event on our Discord!</a> 🕯️ ❄️ 🎄</div><button className="ms-auto px-2 py-1 cursor-pointer border-2 border-white rounded-lg hover:bg-white hover:text-black text-white transition-colors self-end" onClick={() => setShouldShow(false)}>No thanks</button>
+      <div className="fixed bottom-0 p-2 w-full grid grid-cols-3 justify-center bg-black overflow-hidden snow gap-2 items-center"><div></div><div>🎄 ❄️ 🕯️ <a href="https://discord.gg/utDMjHYg42" className="text-white underline">Join the Advent of Jazz event on our Discord!</a> 🕯️ ❄️ 🎄</div><button className="ms-auto px-2 py-1 cursor-pointer border-2 border-white rounded-lg hover:bg-white hover:text-black text-white transition-colors self-end" onClick={handleDismiss}>No thanks</button>
       </div >
     </>
   )

--- a/homepage/homepage/components/AdventOfJazzBanner.tsx
+++ b/homepage/homepage/components/AdventOfJazzBanner.tsx
@@ -1,0 +1,26 @@
+"use client";
+import { useEffect, useState } from "react"
+import './snowflake.css';
+import { Button } from "@garden-co/design-system/src/components/atoms/Button";
+
+export const AdventOfJazzBanner = () => {
+  let [shouldShow, setShouldShow] = useState<boolean | null>(null);
+  useEffect(() => {
+    const showAdventOfJazzBanner = window.localStorage.getItem('show_advent_of_jazz_banner');
+    if (showAdventOfJazzBanner === 'false' || shouldShow === false) {
+      window.localStorage.setItem('show_advent_of_jazz_banner', 'false');
+      document.body.style.paddingBlockEnd = '0px';
+      setShouldShow(false);
+      return;
+    }
+    document.body.style.paddingBlockEnd = '52px';
+    setShouldShow(true)
+  }, [shouldShow])
+  if (!shouldShow) return;
+  return (
+    <>
+      <div className="fixed bottom-0 p-2 w-full grid grid-cols-3 justify-center bg-black overflow-hidden snow gap-2 items-center"><div></div><div>🎄 ❄️ 🕯️ <a href="https://discord.gg/utDMjHYg42" className="text-white underline">Join the Advent of Jazz event on our Discord!</a> 🕯️ ❄️ 🎄</div><button className="ms-auto px-2 py-1 cursor-pointer border-2 border-white rounded-lg hover:bg-white hover:text-black text-white transition-colors self-end" onClick={() => setShouldShow(false)}>No thanks</button>
+      </div >
+    </>
+  )
+}

--- a/homepage/homepage/components/snowflake.css
+++ b/homepage/homepage/components/snowflake.css
@@ -1,0 +1,20 @@
+/* Thanks @Calleb:  https://codepen.io/Calleb/pen/dyVRvyW */
+
+.snow {
+  width: 100%;
+  height: auto;
+  background-image: url("data:image/svg+xml,%3Csvg version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' x='0px' y='0px' viewBox='0 0 50 50' style='enable-background:new 0 0 50 50%3B' xml:space='preserve'%3E%3Cstyle type='text/css'%3E.st1%7Bopacity:0.3%3Bfill:%23FFFFFF%3B%7D.st3%7Bopacity:0.1%3Bfill:%23FFFFFF%3B%7D%3C/style%3E%3Ccircle class='st1' cx='5' cy='8' r='1'/%3E%3Ccircle class='st1' cx='38' cy='3' r='1'/%3E%3Ccircle class='st1' cx='12' cy='4' r='1'/%3E%3Ccircle class='st1' cx='16' cy='16' r='1'/%3E%3Ccircle class='st1' cx='47' cy='46' r='1'/%3E%3Ccircle class='st1' cx='32' cy='10' r='1'/%3E%3Ccircle class='st1' cx='3' cy='46' r='1'/%3E%3Ccircle class='st1' cx='45' cy='13' r='1'/%3E%3Ccircle class='st1' cx='10' cy='28' r='1'/%3E%3Ccircle class='st1' cx='22' cy='35' r='1'/%3E%3Ccircle class='st1' cx='3' cy='21' r='1'/%3E%3Ccircle class='st1' cx='26' cy='20' r='1'/%3E%3Ccircle class='st1' cx='30' cy='45' r='1'/%3E%3Ccircle class='st1' cx='15' cy='45' r='1'/%3E%3Ccircle class='st1' cx='34' cy='36' r='1'/%3E%3Ccircle class='st1' cx='41' cy='32' r='1'/%3E%3C/svg%3E");
+  background-position: 0px 0px;
+  background-size: 100px;
+  animation: animatedBackground 10s linear infinite;
+}
+
+@keyframes animatedBackground {
+  0% {
+    background-position: 0 0;
+  }
+
+  100% {
+    background-position: 0px 300px;
+  }
+}


### PR DESCRIPTION
# Description
Adds a temporary banner to drive traffic to Discord for Advent of Jazz

## Manual testing instructions
View the homepage preview. Use the 'No Thanks' button to dismiss the banner. Click the link to follow the Discord invite

## Tests

- [ ] Tests have been added and/or updated
- [X] Tests have not been updated, because: N/A
- [ ] I need help with writing tests


## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [ ] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a dismissible, date-gated Discord promo banner with animated snow and integrates it into RootLayout.
> 
> - **Frontend**:
>   - **New `AdventOfJazzBanner` component** (`components/AdventOfJazzBanner.tsx`):
>     - Client-side banner shown until `2026-01-01`, persists dismissal via `localStorage`, adjusts `document.body` padding, includes Discord link and dismiss button.
>     - Imports `snowflake.css` for animated snow background.
>   - **Integration**: Renders `AdventOfJazzBanner` in `app/layout.tsx` within `ThemeProvider`, below `PagefindSearch`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 91b7fdf71db6ac4d873574b96fbe2fc9ac340fe6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->