### PR TITLE
POC: Add `node:sqlite` database driver for the sync server 

### DIFF
--- a/packages/cojson-storage-sqlite/src/index.ts
+++ b/packages/cojson-storage-sqlite/src/index.ts
@@ -1,6 +1,7 @@
 import Database, { type Database as DatabaseT } from "better-sqlite3";
 import type { SQLiteDatabaseDriver } from "cojson";
 import { getSqliteStorage } from "cojson";
+import { DatabaseSync } from "node:sqlite";
 
 export class BetterSqliteDriver implements SQLiteDatabaseDriver {
   private readonly db: DatabaseT;
@@ -35,5 +36,52 @@ export class BetterSqliteDriver implements SQLiteDatabaseDriver {
 export function getBetterSqliteStorage(filename: string) {
   const db = new BetterSqliteDriver(filename);
 
+  return getSqliteStorage(db);
+}
+
+export class NodeSqliteDriver implements SQLiteDatabaseDriver {
+  private db: DatabaseSync;
+  private readonly filename: string;
+
+  constructor(filename: string) {
+    this.filename = filename;
+    this.db = new DatabaseSync(this.filename);
+    this.db.exec("PRAGMA journal_mode = WAL");
+  }
+
+  run(sql: string, params: unknown[]) {
+    const stmt = this.db.prepare(sql);
+    stmt.run(...(params as any[]));
+  }
+
+  query<T>(sql: string, params: unknown[]): T[] {
+    const stmt = this.db.prepare(sql);
+    return stmt.all(...(params as any[])) as T[];
+  }
+
+  get<T>(sql: string, params: unknown[]): T | undefined {
+    const stmt = this.db.prepare(sql);
+    return stmt.get(...(params as any[])) as T | undefined;
+  }
+
+  transaction(callback: () => unknown) {
+    this.run("BEGIN IMMEDIATE", []);
+    try {
+      const result = callback();
+      this.run("COMMIT", []);
+      return result;
+    } catch (error) {
+      this.run("ROLLBACK", []);
+      throw error;
+    }
+  }
+
+  closeDb() {
+    this.db.close();
+  }
+}
+
+export function getNodeSqliteStorage(filename: string) {
+  const db = new NodeSqliteDriver(filename);
   return getSqliteStorage(db);
 }

--- a/packages/jazz-run/src/index.ts
+++ b/packages/jazz-run/src/index.ts
@@ -18,6 +18,15 @@ const peerOption = Options.text("peer")
   .pipe(Options.withAlias("p"))
   .pipe(Options.withDefault("wss://cloud.jazz.tools"));
 
+const driverOption = Options.choice("driver", ["better-sqlite3", "node:sqlite"])
+  .pipe(Options.withAlias("d"))
+  .pipe(
+    Options.withDescription(
+      "The database driver to use. Defaults to 'better-sqlite3' if not specified.",
+    ),
+  )
+  .pipe(Options.withDefault("better-sqlite3"));
+
 const createAccountCommand = Command.make(
   "create",
   { name: nameOption, peer: peerOption, json: jsonOption },
@@ -81,11 +90,12 @@ const startSyncServerCommand = Command.make(
     port: portOption,
     inMemory: inMemoryOption,
     db: dbOption,
+    driver: driverOption,
   },
-  ({ host, port, inMemory, db }) => {
+  ({ host, port, inMemory, db, driver }) => {
     return Effect.gen(function* () {
       const server = yield* Effect.promise(() =>
-        startSyncServer({ host, port, inMemory, db }),
+        startSyncServer({ host, port, inMemory, db, driver }),
       );
 
       const serverAddress = server.address();

--- a/packages/jazz-run/src/startSyncServer.ts
+++ b/packages/jazz-run/src/startSyncServer.ts
@@ -2,7 +2,10 @@ import { createServer } from "node:http";
 import { mkdir } from "node:fs/promises";
 import { dirname } from "node:path";
 import { LocalNode } from "cojson";
-import { getBetterSqliteStorage } from "cojson-storage-sqlite";
+import {
+  getBetterSqliteStorage,
+  getNodeSqliteStorage,
+} from "cojson-storage-sqlite";
 import { createWebSocketPeer } from "cojson-transport-ws";
 import { WasmCrypto } from "cojson/crypto/WasmCrypto";
 import { WebSocketServer } from "ws";
@@ -13,11 +16,13 @@ export const startSyncServer = async ({
   port,
   inMemory,
   db,
+  driver = "better-sqlite3",
 }: {
   host: string | undefined;
   port: string | undefined;
   inMemory: boolean;
   db: string;
+  driver?: "better-sqlite3" | "node:sqlite";
 }): Promise<SyncServer> => {
   const crypto = await WasmCrypto.create();
 
@@ -41,7 +46,10 @@ export const startSyncServer = async ({
   if (!inMemory) {
     await mkdir(dirname(db), { recursive: true });
 
-    const storage = getBetterSqliteStorage(db);
+    const storage =
+      driver === "better-sqlite3"
+        ? getBetterSqliteStorage(db)
+        : getNodeSqliteStorage(db);
 
     localNode.setStorage(storage);
   }

--- a/tests/stress-test/src/generate.ts
+++ b/tests/stress-test/src/generate.ts
@@ -5,6 +5,7 @@ import { Task, TodoProject } from "./1_schema";
 export function generateRandomProject(numTasks: number) {
   // Create a list of tasks
   const tasks = TodoProject.shape.tasks.create([]);
+  const start = performance.now();
 
   // Generate random tasks
   function populateTasks() {
@@ -29,7 +30,12 @@ export function generateRandomProject(numTasks: number) {
     done: new Promise((resolve) => {
       setTimeout(() => {
         populateTasks();
-        resolve(true);
+        tasks.$jazz.localNode.syncManager.waitForAllCoValuesSync().then(() => {
+          console.log(
+            `Generated and synced ${numTasks} tasks in ${performance.now() - start}ms`,
+          );
+          resolve(true);
+        });
       }, 10);
     }),
   };


### PR DESCRIPTION
# Description
Adds an option to use `node:sqlite` as a database driver to avoid needing better-sqlite3

Results:
node:sqlite: Generated and synced 10000 tasks in 81180ms
better-sqlite3: Generated and synced 10000 tasks in 54358.5ms

## Manual testing instructions

Run the stress-test

## Tests

- [ ] Tests have been added and/or updated
- [x] Tests have not been updated, because: POC, and the existing `cojson-storage-sqlite` tests should cover it. If we decide to advance, probably worth checking more closely if we need additional tests
- [ ] I need help with writing tests

## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [ ] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing