### PR TITLE
docs: add export example on ssr

### DIFF
--- a/homepage/homepage/content/docs/code-snippets/server-side/ssr/FestivalComponent.tsx
+++ b/homepage/homepage/content/docs/code-snippets/server-side/ssr/FestivalComponent.tsx
@@ -1,0 +1,34 @@
+"use client";
+import { Festival } from "@/app/schema";
+// [!code ++:2]
+import { ExportedCoValue, co } from "jazz-tools";
+import { useCoState } from "jazz-tools/react";
+
+// [!code ++:1]
+type ExportedFestival = ExportedCoValue<co.loaded<typeof Festival, { $each: { $onError: "catch" } }>>;
+
+export function FestivalComponent(props: { preloaded: ExportedFestival, festivalId: string }) {
+  const festival = useCoState(Festival, props.festivalId, {
+    // [!code ++:1]
+    preloaded: props.preloaded,
+    resolve: {
+      $each: {
+        $onError: "catch",
+      },
+    },
+  });
+
+  return (
+    <main>
+      <h1>🎪 Server-rendered Festival {props.festivalId}</h1>
+
+      <ul>
+        {festival.$isLoaded &&
+          festival.map((band) => {
+            if (!band.$isLoaded) return null;
+            return <li key={band.$jazz.id}>🎶 {band.name}</li>;
+          })}
+      </ul>
+    </main>
+  );
+}

--- a/homepage/homepage/content/docs/code-snippets/server-side/ssr/dynamicPage.tsx
+++ b/homepage/homepage/content/docs/code-snippets/server-side/ssr/dynamicPage.tsx
@@ -1,0 +1,24 @@
+import { jazzSSR } from "@/app/jazzSSR";
+import { Festival } from "@/app/schema";
+import { FestivalComponent } from "./FestivalComponent";
+
+export default async function ServerSidePage(props: {
+  params: { festivalId: string };
+}) {
+  const { festivalId } = await props.params;
+  const festival = await Festival.load(festivalId, {
+    loadAs: jazzSSR,
+    resolve: {
+      $each: {
+        $onError: "catch",
+      },
+    },
+  });
+
+  if (!festival.$isLoaded) return <div>Festival not found</div>;
+
+  return (
+    // [!code ++:1]
+    <FestivalComponent preloaded={festival.$jazz.export()} festivalId={festivalId} />
+  );
+}

--- a/homepage/homepage/content/docs/server-side/ssr.mdx
+++ b/homepage/homepage/content/docs/server-side/ssr.mdx
@@ -133,9 +133,9 @@ If everything's going according to plan, your app will load with the home page. 
 <ContentByFramework framework="react">
 ## Bonus: making the server-rendered page dynamic
 
-We can leverage the properties of Jazz to make the server-rendered pages updated in real-time, like we do with the client-side pages.
+Just like client-side pages, Jazz can update server-rendered pages in real-time.
 
-For that we can use `export` to serialize the Jazz values and pass them to a client component:
+For that we can use `export` to serialize values from Jazz and pass them to a client component:
 
 <FileName>app/festival/[festivalId]/page.tsx</FileName>
 <CodeGroup>
@@ -145,7 +145,7 @@ For that we can use `export` to serialize the Jazz values and pass them to a cli
 
 Then we can pass the exported value to the preloaded option of the `useCoState` hook.
 
-This way Jazz can syncronously hydrate the CoValue data directly from the component props, avoiding the need to load the data:
+This way Jazz can synchronously hydrate the CoValue data directly from the component props, avoiding the need to load the data:
 
 <FileName>app/festival/[festivalId]/FestivalComponent.tsx</FileName>
 <CodeGroup>
@@ -153,7 +153,7 @@ This way Jazz can syncronously hydrate the CoValue data directly from the compon
 ```
 </CodeGroup>
 
-Now the updates on your festival page will be reflected in real-time, without the need to reload the page.
+Now your festival page will update in real-time, without needing to reload the page.
 
 </ContentByFramework>
 

--- a/homepage/homepage/content/docs/server-side/ssr.mdx
+++ b/homepage/homepage/content/docs/server-side/ssr.mdx
@@ -130,6 +130,34 @@ If everything's going according to plan, your app will load with the home page. 
 
 <StuckCTA />
 
+<ContentByFramework framework="react">
+## Bonus: making the server-rendered page dynamic
+
+We can leverage the properties of Jazz to make the server-rendered pages updated in real-time, like we do with the client-side pages.
+
+For that we can use `export` to serialize the Jazz values and pass them to a client component:
+
+<FileName>app/festival/[festivalId]/page.tsx</FileName>
+<CodeGroup>
+```tsx dynamicPage.tsx
+```
+</CodeGroup>
+
+Then we can pass the exported value to the preloaded option of the `useCoState` hook.
+
+This way Jazz can syncronously hydrate the CoValue data directly from the component props, avoiding the need to load the data:
+
+<FileName>app/festival/[festivalId]/FestivalComponent.tsx</FileName>
+<CodeGroup>
+```tsx FestivalComponent.tsx
+```
+</CodeGroup>
+
+Now the updates on your festival page will be reflected in real-time, without the need to reload the page.
+
+</ContentByFramework>
+
+
 ## Next steps
 - Learn more about how to [manage complex permissions](/docs/permissions-and-sharing/overview) using groups and roles
 - Dive deeper into the collaborative data structures we call [CoValues](/docs/core-concepts/covalues/overview)


### PR DESCRIPTION
Adding the docs to explain how to do SSR of real-time updated data.

Docs preview: https://jazz-homepage-q93prekml-garden-co.vercel.app/docs/react/server-side/ssr#bonus-making-the-server-rendered-page-dynamic


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds React docs and snippets showing how to export server-loaded data and hydrate a client component via preloaded for real-time SSR updates.
> 
> - **Docs (SSR guide)**:
>   - Add React-only bonus section: *making the server-rendered page dynamic* in `content/docs/server-side/ssr.mdx`.
>   - Include instructions and code groups referencing `app/festival/[festivalId]/page.tsx` and `FestivalComponent.tsx`.
> - **Code Snippets**:
>   - `content/docs/code-snippets/server-side/ssr/dynamicPage.tsx`: Load `Festival` with `loadAs: jazzSSR`, handle `$each.$onError: "catch"`, export via `festival.$jazz.export()`, and pass to `FestivalComponent`.
>   - `content/docs/code-snippets/server-side/ssr/FestivalComponent.tsx`: Client component using `useCoState` with `preloaded` `ExportedCoValue` and `resolve` options; renders loaded bands list.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 535a17d2b259b03713541adcf2b36c51925bd89e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->