### PR TITLE
Add createdBy getter to CoValue and tests

### DIFF
--- a/.changeset/smooth-cloths-pump.md
+++ b/.changeset/smooth-cloths-pump.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Adds a createdBy getter

--- a/homepage/homepage/content/docs/code-snippets/key-features/history/index.ts
+++ b/homepage/homepage/content/docs/code-snippets/key-features/history/index.ts
@@ -56,3 +56,7 @@ console.log(`Started as: ${initialValue}`);
 console.log(new Date(task.$jazz.createdAt));
 console.log(new Date(task.$jazz.lastUpdatedAt));
 // #endregion
+
+// #region CreatedBy
+console.log(task.$jazz.createdBy);
+// #endregion

--- a/homepage/homepage/content/docs/key-features/history.mdx
+++ b/homepage/homepage/content/docs/key-features/history.mdx
@@ -72,6 +72,15 @@ To show created date and last updated date, use the `$jazz.createdAt` and `$jazz
 ```
 </CodeGroup>
 
+### Created By
+
+To show who created the value, use the `$jazz.createdBy` getter. This will return the ID of the user who created the value as a string.
+
+<CodeGroup>
+```tsx index.ts#CreatedBy
+```
+</CodeGroup>
+
 ## Requirements
 
 - CoValues must be loaded to access history (see [Subscription & Loading](/docs/core-concepts/subscription-and-loading))

--- a/packages/jazz-tools/src/tools/coValues/CoValueBase.ts
+++ b/packages/jazz-tools/src/tools/coValues/CoValueBase.ts
@@ -112,6 +112,18 @@ export abstract class CoValueJazzApi<V extends CoValue> {
     return this.raw.core.earliestTxMadeAt;
   }
 
+  get createdBy(): string | undefined {
+    const createdBy = this.raw.core.getValidSortedTransactions({
+      ignorePrivateTransactions: false,
+    })[0]?.author;
+
+    // Only return accounts, not sealer/signer strings
+    if (typeof createdBy === "string" && createdBy.startsWith("co_z"))
+      return createdBy;
+
+    return undefined;
+  }
+
   /**
    * The timestamp of the last updated time of the CoValue
    *

--- a/packages/jazz-tools/src/tools/coValues/CoValueBase.ts
+++ b/packages/jazz-tools/src/tools/coValues/CoValueBase.ts
@@ -112,6 +112,18 @@ export abstract class CoValueJazzApi<V extends CoValue> {
     return this.raw.core.earliestTxMadeAt;
   }
 
+  /**
+   * Returns the account ID of the user who created this CoValue.
+   *
+   * Creation is determined by inspecting the earliest valid transaction,
+   * Note: Where the author is a sealer/signer identifiers (e.g. accounts)
+   * nothing is returned intentionally
+   *
+   * @returns {string | undefined} The creating user's account ID, or
+   * `undefined` if no author can be determined
+   *
+   * @category Content
+   */
   get createdBy(): string | undefined {
     const createdBy = this.raw.core.getValidSortedTransactions({
       ignorePrivateTransactions: false,

--- a/packages/jazz-tools/src/tools/tests/account.test.ts
+++ b/packages/jazz-tools/src/tools/tests/account.test.ts
@@ -499,4 +499,23 @@ describe("createAs", () => {
     // Verify execution order
     expect(executionOrder).toEqual(["migration", "onCreate"]);
   });
+  test("createdBy returns undefined", async () => {
+    const CustomAccount = co.account({
+      profile: co.profile({
+        name: z.string(),
+      }),
+      root: co.map({}),
+    });
+
+    const worker = await createJazzTestAccount({
+      isCurrentActiveAccount: true,
+    });
+
+    const createdAccount = await CustomAccount.createAs(worker, {
+      creationProps: { name: "Test Account" },
+    });
+
+    assertLoaded(createdAccount);
+    expect(createdAccount.$jazz.createdBy).toBe(undefined);
+  });
 });

--- a/packages/jazz-tools/src/tools/tests/coMap.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coMap.test.ts
@@ -2316,28 +2316,59 @@ describe("CoMap migration", () => {
   });
 });
 
-describe("createdAt & lastUpdatedAt", () => {
+describe("createdAt, lastUpdatedAt, createdBy", () => {
   test("empty map created time", () => {
     const emptyMap = co.map({}).create({});
 
     expect(emptyMap.$jazz.lastUpdatedAt).toEqual(emptyMap.$jazz.createdAt);
   });
 
+  test("empty map created by", () => {
+    const emptyMap = co.map({}).create({});
+    const me = Account.getMe();
+    expect(emptyMap.$jazz.createdBy).toEqual(me.$jazz.id);
+  });
+
   test("created time and last updated time", async () => {
     const Person = co.map({
       name: z.string(),
     });
+    const me = Account.getMe();
 
     const person = Person.create({ name: "John" });
 
     const createdAt = person.$jazz.createdAt;
     expect(person.$jazz.lastUpdatedAt).toEqual(createdAt);
 
+    const createdBy = person.$jazz.createdBy;
+    expect(createdBy).toEqual(me.$jazz.id);
+
     await new Promise((r) => setTimeout(r, 10));
     person.$jazz.set("name", "Jane");
 
     expect(person.$jazz.createdAt).toEqual(createdAt);
     expect(person.$jazz.lastUpdatedAt).not.toEqual(createdAt);
+
+    // Double check after update.
+    expect(createdBy).toEqual(me.$jazz.id);
+  });
+
+  test("createdBy does not change when updated", async () => {
+    const Person = co.map({
+      name: z.string(),
+    });
+    const me = Account.getMe();
+
+    const person = Person.create({ name: "John" });
+
+    const createdBy = person.$jazz.createdBy;
+    expect(createdBy).toEqual(me.$jazz.id);
+
+    await new Promise((r) => setTimeout(r, 10));
+    person.$jazz.set("name", "Jane");
+
+    // Double check after update.
+    expect(createdBy).toEqual(me.$jazz.id);
   });
 });
 


### PR DESCRIPTION
# Description
Per suggestion from [Discord](https://discord.com/channels/1139617727565271160/1139621689882321009/1447411642806698004), implements a `createdBy` getter.

## Manual testing instructions
N/A, but you can check by using `myCoValue.$jazz.createdBy`

## Tests

- [x] Tests have been added and/or updated
- [ ] Tests have not been updated, because: <!-- Insert reason for not updating tests here -->
- [ ] I need help with writing tests

## Checklist

- [x] I've updated the part of the docs that are affected the PR changes
- [x] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing