### PR TITLE
[Inspector] comap's transactions guessed as group's txs

### DIFF
--- a/.changeset/fast-cycles-ask.md
+++ b/.changeset/fast-cycles-ask.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Fix the inspector to guess correctly Group's transactions

--- a/packages/jazz-tools/src/inspector/tests/utils/transactions-changes.test.ts
+++ b/packages/jazz-tools/src/inspector/tests/utils/transactions-changes.test.ts
@@ -1,0 +1,102 @@
+import { assert, describe, expect, it } from "vitest";
+import { setActiveAccount, setupJazzTestSync } from "jazz-tools/testing";
+import { co, z } from "jazz-tools";
+import * as TransactionsChanges from "../../utils/transactions-changes";
+
+describe("transactions changes", async () => {
+  const account = await setupJazzTestSync();
+  setActiveAccount(account);
+
+  describe("ambiguous values in Group's transactions", () => {
+    it("isGroupExtension should return false for a CoMap", () => {
+      const value = co.map({ test: z.string() }).create({ test: "extend" })
+        .$jazz.raw;
+
+      const transactions = value.core.verifiedTransactions;
+      expect(
+        TransactionsChanges.isGroupExtension(
+          value,
+          transactions[0]?.changes?.[0],
+        ),
+      ).toBe(false);
+    });
+
+    it("isGroupExtendRevocation should return false for a CoMap", () => {
+      const value = co.map({ test: z.string() }).create({ test: "revoked" })
+        .$jazz.raw;
+
+      const transactions = value.core.verifiedTransactions;
+      expect(
+        TransactionsChanges.isGroupExtendRevocation(
+          value,
+          transactions[0]?.changes?.[0],
+        ),
+      ).toBe(false);
+    });
+
+    it("isGroupPromotion should return false for a CoMap", () => {
+      const value = co
+        .map({ parent_co_test: z.string() })
+        .create({ parent_co_test: "foo" }).$jazz.raw;
+
+      const transactions = value.core.verifiedTransactions;
+      expect(
+        TransactionsChanges.isGroupPromotion(
+          value,
+          transactions[0]?.changes?.[0],
+        ),
+      ).toBe(false);
+    });
+
+    it("isUserPromotion should return false for a CoMap", () => {
+      const value = co.map({ everyone: z.string() }).create({ everyone: "foo" })
+        .$jazz.raw;
+
+      const transactions = value.core.verifiedTransactions;
+      expect(
+        TransactionsChanges.isUserPromotion(
+          value,
+          transactions[0]?.changes?.[0],
+        ),
+      ).toBe(false);
+    });
+
+    it("isUserPromotion should return false for a CoMap", () => {
+      const value = co.map({ everyone: z.string() }).create({ everyone: "foo" })
+        .$jazz.raw;
+
+      const transactions = value.core.verifiedTransactions;
+      expect(
+        TransactionsChanges.isUserPromotion(
+          value,
+          transactions[0]?.changes?.[0],
+        ),
+      ).toBe(false);
+
+      const value2 = co.map({ co_z123: z.string() }).create({ co_z123: "foo" })
+        .$jazz.raw;
+
+      const transactions2 = value2.core.verifiedTransactions;
+      expect(
+        TransactionsChanges.isUserPromotion(
+          value2,
+          transactions2[0]?.changes?.[0],
+        ),
+      ).toBe(false);
+    });
+
+    it("isKeyRevelation should return false for a CoMap", () => {
+      const value = co
+        .map({ "123_for_test": z.string() })
+        .create({ "123_for_test": "foo" }).$jazz.raw;
+
+      const transactions = value.core.verifiedTransactions;
+      expect(
+        TransactionsChanges.isKeyRevelation(
+          value,
+          transactions[0]?.changes?.[0],
+        ),
+      ).toBe(false);
+    });
+  });
+});

--- a/packages/jazz-tools/src/inspector/ui/icons/add-icon.tsx
+++ b/packages/jazz-tools/src/inspector/ui/icons/add-icon.tsx
@@ -12,9 +12,9 @@ export function AddIcon(props: React.SVGProps<SVGSVGElement>) {
     >
       <path
         d="M4 12H20M12 4V20"
-        stroke-width="2"
-        stroke-linecap="round"
-        stroke-linejoin="round"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
       />
     </svg>
   );

--- a/packages/jazz-tools/src/inspector/utils/history.ts
+++ b/packages/jazz-tools/src/inspector/utils/history.ts
@@ -62,10 +62,10 @@ export function getTransactionChanges(
     const firstChange = tx.changes[0]!;
 
     if (
-      TransactionChanges.isItemAppend(firstChange) &&
+      TransactionChanges.isItemAppend(coValue, firstChange) &&
       tx.changes.every(
         (c) =>
-          TransactionChanges.isItemAppend(c) &&
+          TransactionChanges.isItemAppend(coValue, c) &&
           areSameOpIds(c.after, firstChange.after),
       )
     ) {
@@ -84,10 +84,10 @@ export function getTransactionChanges(
     }
 
     if (
-      TransactionChanges.isItemPrepend(firstChange) &&
+      TransactionChanges.isItemPrepend(coValue, firstChange) &&
       tx.changes.every(
         (c) =>
-          TransactionChanges.isItemPrepend(c) &&
+          TransactionChanges.isItemPrepend(coValue, c) &&
           areSameOpIds(c.before, firstChange.before),
       )
     ) {
@@ -106,8 +106,8 @@ export function getTransactionChanges(
     }
 
     if (
-      TransactionChanges.isItemDeletion(firstChange) &&
-      tx.changes.every((c) => TransactionChanges.isItemDeletion(c))
+      TransactionChanges.isItemDeletion(coValue, firstChange) &&
+      tx.changes.every((c) => TransactionChanges.isItemDeletion(coValue, c))
     ) {
       const coValueBeforeDeletions = coValue.atTime(tx.madeAt - 1);
 

--- a/packages/jazz-tools/src/inspector/utils/transactions-changes.ts
+++ b/packages/jazz-tools/src/inspector/utils/transactions-changes.ts
@@ -14,85 +14,119 @@ import type {
 import { isCoId } from "../viewer/types";
 
 export const isGroupExtension = (
+  coValue: RawCoValue,
   change: any,
 ): change is Extract<
   MapOpPayload<`child_${string}`, "extend">,
   { op: "set" }
 > => {
+  if (coValue.core.isGroup() === false) return false;
   return change?.op === "set" && change?.value === "extend";
 };
 
 export const isGroupExtendRevocation = (
+  coValue: RawCoValue,
   change: any,
 ): change is Extract<
   MapOpPayload<`child_${string}`, "revoked">,
   { op: "set" }
 > => {
+  if (coValue.core.isGroup() === false) return false;
   return change?.op === "set" && change?.value === "revoked";
 };
 
 export const isGroupPromotion = (
+  coValue: RawCoValue,
   change: any,
 ): change is Extract<
   MapOpPayload<`parent_co_${string}`, AccountRole>,
   { op: "set" }
 > => {
+  if (coValue.core.isGroup() === false) return false;
   return change?.op === "set" && change?.key.startsWith("parent_co_");
 };
 
 export const isUserPromotion = (
+  coValue: RawCoValue,
   change: any,
 ): change is Extract<MapOpPayload<CoID<RawCoValue>, Role>, { op: "set" }> => {
+  if (coValue.core.isGroup() === false) return false;
   return (
     change?.op === "set" && (isCoId(change?.key) || change?.key === "everyone")
   );
 };
 
 export const isKeyRevelation = (
+  coValue: RawCoValue,
   change: any,
 ): change is Extract<
   MapOpPayload<`${string}_for_${string}`, string>,
   { op: "set" }
 > => {
+  if (
+    coValue.core.isGroup() === false &&
+    coValue.headerMeta?.type !== "account"
+  )
+    return false;
   return change?.op === "set" && change?.key.includes("_for_");
 };
 
 export const isPropertySet = (
+  coValue: RawCoValue,
   change: any,
 ): change is Extract<MapOpPayload<string, any>, { op: "set" }> => {
   return change?.op === "set" && "key" in change && "value" in change;
 };
 export const isPropertyDeletion = (
+  coValue: RawCoValue,
   change: any,
 ): change is Extract<MapOpPayload<string, any>, { op: "del" }> => {
   return change?.op === "del" && "key" in change;
 };
 
 export const isItemAppend = (
+  coValue: RawCoValue,
   change: any,
 ): change is Extract<ListOpPayload<any>, { op: "app" }> => {
+  if (coValue.type !== "colist" && coValue.type !== "coplaintext") return false;
   return change?.op === "app" && "after" in change && "value" in change;
 };
 export const isItemPrepend = (
+  coValue: RawCoValue,
   change: any,
 ): change is Extract<ListOpPayload<any>, { op: "pre" }> => {
+  if (coValue.type !== "colist" && coValue.type !== "coplaintext") return false;
   return change?.op === "pre" && "before" in change && "value" in change;
 };
 
 export const isItemDeletion = (
+  coValue: RawCoValue,
   change: any,
 ): change is Extract<ListOpPayload<any>, { op: "del" }> => {
+  if (coValue.type !== "colist" && coValue.type !== "coplaintext") return false;
   return change?.op === "del" && "insertion" in change;
 };
 
-export const isStreamStart = (change: any): change is BinaryStreamStart => {
+export const isStreamStart = (
+  coValue: RawCoValue,
+  change: any,
+): change is BinaryStreamStart => {
+  if (coValue.type !== "coStream") return false;
   return change?.type === "start" && "mimeType" in change;
 };
 
-export const isStreamChunk = (change: any): change is BinaryStreamChunk => {
+export const isStreamChunk = (
+  coValue: RawCoValue,
+  change: any,
+): change is BinaryStreamChunk => {
+  if (coValue.type !== "coStream") return false;
   return change?.type === "chunk" && "chunk" in change;
 };
 
-export const isStreamEnd = (change: any): change is BinaryStreamEnd => {
+export const isStreamEnd = (
+  coValue: RawCoValue,
+  change: any,
+): change is BinaryStreamEnd => {
+  if (coValue.type !== "coStream") return false;
   return change?.type === "end";
 };

--- a/packages/jazz-tools/src/inspector/viewer/history-view.tsx
+++ b/packages/jazz-tools/src/inspector/viewer/history-view.tsx
@@ -128,7 +128,7 @@ function mapTransactionToAction(
   coValue: RawCoValue,
 ): string {
   // Group changes
-  if (TransactionChanges.isUserPromotion(change)) {
+  if (TransactionChanges.isUserPromotion(coValue, change)) {
     if (change.value === "revoked") {
       return `${change.key} has been revoked`;
     }
@@ -136,28 +136,28 @@ function mapTransactionToAction(
     return `${change.key} has been promoted to ${change.value}`;
   }
 
-  if (TransactionChanges.isGroupExtension(change)) {
+  if (TransactionChanges.isGroupExtension(coValue, change)) {
     const child = change.key.slice(6);
     return `Group became a member of ${child}`;
   }
 
-  if (TransactionChanges.isGroupExtendRevocation(change)) {
+  if (TransactionChanges.isGroupExtendRevocation(coValue, change)) {
     const child = change.key.slice(6);
     return `Group's membership of ${child} has been revoked.`;
   }
 
-  if (TransactionChanges.isGroupPromotion(change)) {
+  if (TransactionChanges.isGroupPromotion(coValue, change)) {
     const parent = change.key.slice(7);
     return `Group ${parent} has been promoted to ${change.value}`;
   }
 
-  if (TransactionChanges.isKeyRevelation(change)) {
+  if (TransactionChanges.isKeyRevelation(coValue, change)) {
     const [key, target] = change.key.split("_for_");
     return `Key "${key}" has been revealed to "${target}"`;
   }
 
   // coList changes
-  if (TransactionChanges.isItemAppend(change)) {
+  if (TransactionChanges.isItemAppend(coValue, change)) {
     if (change.after === "start") {
       return `"${change.value}" has been appended`;
     }
@@ -171,7 +171,7 @@ function mapTransactionToAction(
     return `"${change.value}" has been inserted after "${(after as any).value}"`;
   }
 
-  if (TransactionChanges.isItemPrepend(change)) {
+  if (TransactionChanges.isItemPrepend(coValue, change)) {
     if (change.before === "end") {
       return `"${change.value}" has been prepended`;
     }
@@ -185,7 +185,7 @@ function mapTransactionToAction(
     return `"${change.value}" has been inserted before "${(before as any).value}"`;
   }
 
-  if (TransactionChanges.isItemDeletion(change)) {
+  if (TransactionChanges.isItemDeletion(coValue, change)) {
     const insertion = findListChange(change.insertion, coValue);
     if (insertion === undefined) {
       return `An undefined item has been deleted`;
@@ -195,24 +195,24 @@ function mapTransactionToAction(
   }
 
   // coStream changes
-  if (TransactionChanges.isStreamStart(change)) {
+  if (TransactionChanges.isStreamStart(coValue, change)) {
     return `Stream started with mime type "${change.mimeType}" and file name "${change.fileName}"`;
   }
 
-  if (TransactionChanges.isStreamChunk(change)) {
+  if (TransactionChanges.isStreamChunk(coValue, change)) {
     return `Stream chunk added`;
   }
 
-  if (TransactionChanges.isStreamEnd(change)) {
+  if (TransactionChanges.isStreamEnd(coValue, change)) {
     return `Stream ended`;
   }
 
   // coMap changes
-  if (TransactionChanges.isPropertySet(change)) {
+  if (TransactionChanges.isPropertySet(coValue, change)) {
     return `Property "${change.key}" has been set to ${JSON.stringify(change.value)}`;
   }
 
-  if (TransactionChanges.isPropertyDeletion(change)) {
+  if (TransactionChanges.isPropertyDeletion(coValue, change)) {
     return `Property "${change.key}" has been deleted`;
   }
 


### PR DESCRIPTION
# Description
The Inspector's history guesses the transaction type based on its internal properties, such as `op`, `value`, and `key`.
If a `CoMap` has ambiguous properties, they can be considered as a Group's transaction.

Now we check if the coValue `isGroup` before checking their transaction's properties.


## Manual testing instructions
`co_zfxbzox6HVxGKLUiPC4wpUiFcCE` is a CoMap with numeric keys. The online inspector fails while checking `isGroupPromotion`.

## Tests

- [x] Tests have been added and/or updated
- [ ] Tests have not been updated, because: <!-- Insert reason for not updating tests here -->
- [ ] I need help with writing tests


## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [x] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Hardened inspector transaction detection by adding coValue-aware predicates, updating call sites, and adding tests to prevent CoMap changes being treated as Group transactions.
> 
> - **Inspector utils**:
>   - Add `coValue`-aware guards in `utils/transactions-changes.ts` (Group, list, stream, and map predicates) to ensure checks only apply to correct types.
>   - Update `viewer/history-view.tsx` and `utils/history.ts` to pass `coValue` into all `TransactionChanges.*` calls and maintain plaintext change collapsing.
> - **Tests**:
>   - Add `transactions-changes.test.ts` to verify ambiguous `CoMap` changes are not classified as Group transactions.
> - **UI**:
>   - Fix SVG prop casing in `ui/icons/add-icon.tsx`.
> - **Release**:
>   - Add changeset for a patch bump of `jazz-tools`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9ca9e723976cfb12833761575db95217f9ce7002. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->