### PR TITLE
Use hash fragment in invite URL example

### DIFF
--- a/homepage/homepage/content/docs/permissions-and-sharing/sharing.mdx
+++ b/homepage/homepage/content/docs/permissions-and-sharing/sharing.mdx
@@ -59,7 +59,7 @@ This is used in the [todo example](https://github.com/garden-co/jazz/tree/main/e
   </TabbedCodeGroupItem>
 </TabbedCodeGroup>
 
-It generates a URL that looks like `.../invite/[CoValue ID]/[inviteSecret]`
+It generates a URL that looks like `.../#/invite/[CoValue ID]/[inviteSecret]`
 
 In your app, you need to handle this route, and let the user accept the invitation,
 as done [here](https://github.com/garden-co/jazz/tree/main/examples/todo/src/2_main.tsx).


### PR DESCRIPTION
# Description
Tiny PR based on @ammmir's comments

## Manual testing instructions
Check the permissions and sharings to see the correct illustrated example of an invite link.

## Tests

- [ ] Tests have been added and/or updated
- [x] Tests have not been updated, because: Docs
- [ ] I need help with writing tests


## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [ ] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing