### PR TITLE
Fix side nav

### DIFF
--- a/homepage/homepage/components/SideNavContext.tsx
+++ b/homepage/homepage/components/SideNavContext.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { createContext, useContext, type RefObject } from "react";
+
+// Normalize path by removing framework segment (e.g., /docs/react/... -> /docs/...)
+export function normalizePath(path: string): string {
+  if (!path.startsWith("/docs/")) {
+    return path;
+  }
+  const parts = path.split("/");
+  // Check if second segment is a framework (after /docs/)
+  const frameworks = ["react", "svelte", "vue", "react-native", "react-native-expo", "vanilla"];
+  if (parts.length >= 3 && frameworks.includes(parts[2])) {
+    // Remove the framework segment
+    return "/docs/" + parts.slice(3).join("/");
+  }
+  return path;
+}
+
+export interface SideNavContextValue {
+  shouldScrollToActive: boolean;
+  scrollContainerRef: RefObject<HTMLDivElement | null> | null;
+}
+
+export const SideNavContext = createContext<SideNavContextValue>({
+  shouldScrollToActive: true,
+  scrollContainerRef: null,
+});
+
+export function useSideNav() {
+  return useContext(SideNavContext);
+}

--- a/homepage/homepage/components/SideNavItem.tsx
+++ b/homepage/homepage/components/SideNavItem.tsx
@@ -5,6 +5,7 @@ import { clsx } from "clsx";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { ReactNode, useEffect, useRef } from "react";
+import { useSideNav } from "./SideNavContext";
 
 export function SideNavItem({
   href,
@@ -16,28 +17,45 @@ export function SideNavItem({
   className?: string;
 }) {
   const classes = clsx(
-  className,
-  "py-1 px-2 group rounded-md flex items-center transition-colors relative",
-);
+    className,
+    "py-1 px-2 group rounded-md flex items-center transition-colors relative",
+  );
   const path = usePathname();
   const itemRef = useRef<HTMLElement>(null);
   const isActive = href && path === href;
+  const { shouldScrollToActive, scrollContainerRef } = useSideNav();
 
-  // Scroll into view when this item becomes active
+  // Scroll sidebar container to show active item (only on real navigation, not framework change)
   useEffect(() => {
-    if (isActive && itemRef.current) {
+    if (isActive && shouldScrollToActive && itemRef.current && scrollContainerRef?.current) {
       // Wait for parent details elements to expand and DOM to update
-      // Use requestAnimationFrame twice to ensure layout is complete
       requestAnimationFrame(() => {
         requestAnimationFrame(() => {
-          itemRef.current?.scrollIntoView({
+          const item = itemRef.current;
+          const container = scrollContainerRef.current;
+          if (!item || !container) return;
+
+          // Calculate position relative to container
+          const containerRect = container.getBoundingClientRect();
+          const itemRect = item.getBoundingClientRect();
+
+          // Calculate the item's position relative to the container's scroll position
+          const itemTopRelativeToContainer = itemRect.top - containerRect.top + container.scrollTop;
+
+          // Calculate desired scroll position to center the item
+          const containerHeight = container.clientHeight;
+          const itemHeight = itemRect.height;
+          const desiredScrollTop = itemTopRelativeToContainer - (containerHeight / 2) + (itemHeight / 2);
+
+          // Scroll the container smoothly (not the window)
+          container.scrollTo({
+            top: desiredScrollTop,
             behavior: "smooth",
-            block: "center",
           });
         });
       });
     }
-  }, [isActive, path]);
+  }, [isActive, shouldScrollToActive, scrollContainerRef]);
 
   if (href) {
     return (


### PR DESCRIPTION
# Description
We recently implemented side nav functionality to better display deeply-linked content. This caused some regressions with scroll jumping. This PR fixes.

## Manual testing instructions
1. Test normal navigation
2. Test cold-start navigation to a deeply linked path (eg: http://localhost:3000/docs/react/server-side/jazz-rpc). The nav should open the closed section and scroll smoothly to the content.
3. Navigate OUT from a deeply linked path. The section should remain open, and the nav should smoothly scroll to the new content
4. Switch frameworks, ensure no nav jumping. 

## Tests

- [ ] Tests have been added and/or updated
- [X] Tests have not been updated, because: Docs
- [ ] I need help with writing tests


## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [ ] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing