### PR TITLE
Add other frameworks to the version control page

### DIFF
--- a/homepage/homepage/content/docs/code-snippets/key-features/version-control/AccountModifications.svelte
+++ b/homepage/homepage/content/docs/code-snippets/key-features/version-control/AccountModifications.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+  import { AccountCoState } from "jazz-tools/svelte";
+  import { MyAccount } from "./schema";
+
+  const me = new AccountCoState(MyAccount, {
+    resolve: { root: true },
+    unstable_branch: { name: "feature-branch" },
+  });
+
+  me.current.$isLoaded && me.current.$jazz.set("root", { value: "Feature Branch" }); // Will also modify the main account
+  me.current.$isLoaded && me.current.root.$jazz.set("value", "Feature Branch"); // This only modifies the branch
+</script>

--- a/homepage/homepage/content/docs/code-snippets/key-features/version-control/EditOnBranch.svelte
+++ b/homepage/homepage/content/docs/code-snippets/key-features/version-control/EditOnBranch.svelte
@@ -11,39 +11,27 @@
     },
     unstable_branch: currentBranchName === 'main' ? undefined : { name: currentBranchName }
   }));
-
-  function handleTitleChange(e: Event) {
-    const target = e.target as HTMLInputElement;
-    // Won't be visible on main until merged
-    project.current.$isLoaded && project.current.$jazz.set("title", target.value);
-  }
-
-  function handleTaskTitleChange(index: number, e: Event) {
-    const target = e.target as HTMLInputElement;
-    const task = project.current.$isLoaded && project.current?.tasks[index];
-
-    // The task is also part of the branch because we used the `resolve` option
-    // with `tasks: { $each: true }`
-    // so the changes won't be visible on main until merged
-    task && task.$jazz.set("title", target.value);
-  }
 </script>
 
 <form>
-  <!-- Edit form fields -->
   {#if project.current.$isLoaded}
-  <input
-    type="text"
-    value={project.current.title || ''}
-    oninput={handleTitleChange}
-  />
-
-  {#each project.current.tasks as task, index}
     <input
       type="text"
-      value={task.title || ''}
-      oninput={(e) => handleTaskTitleChange(index, e)}
+      bind:value={
+        () => (project.current.$isLoaded && project.current.title) || "",
+        (v) =>
+          project.current.$isLoaded && project.current.$jazz.set("title", v)
+      }
     />
-  {/each}
+
+    {#each project.current.tasks as task (task.$jazz.id)}
+      <input
+        type="text"
+        bind:value={
+          () => task.title || "",
+          (v) => task.$isLoaded && task.$jazz.set("title", v)
+        }
+      />
+    {/each}
   {/if}
 </form>

--- a/homepage/homepage/content/docs/code-snippets/key-features/version-control/index.ts
+++ b/homepage/homepage/content/docs/code-snippets/key-features/version-control/index.ts
@@ -1,5 +1,5 @@
-import { Group } from "jazz-tools";
-import { Project } from "./schema";
+import { co, Group } from "jazz-tools";
+import { MyAccount, Project } from "./schema";
 import { createJazzTestAccount } from "jazz-tools/testing";
 const projectId = "";
 const member = await createJazzTestAccount();
@@ -9,6 +9,13 @@ const branch = await Project.load(projectId, {
   unstable_branch: { name: "feature-branch" },
 });
 // #endregion
+
+// #region EditOnBranch
+const editBranch = await Project.load(projectId, {
+  unstable_branch: { name: "feature-branch" },
+});
+// #endregion
+
 
 // #region Permissions
 const featureBranch = await Project.load(projectId, {
@@ -91,4 +98,16 @@ const myBranch = await Project.load(projectId, {
 console.log(myBranch.$jazz.id); // Branch ID is the same as source
 console.log(myBranch.$isLoaded && myBranch.$jazz.branchName); // "feature-branch"
 console.log(myBranch.$isLoaded && myBranch.$jazz.isBranched); // true
+// #endregion
+
+
+// #region AccountModifications
+const myAcct = MyAccount.getMe();
+const me = await myAcct.$jazz.ensureLoaded({
+  resolve: { root: true },
+  unstable_branch: { name: "feature-branch" },
+});
+
+me.$isLoaded && me.$jazz.set("root", { value: "Feature Branch" }); // Will also modify the main account
+me.$isLoaded && me.root.$jazz.set("value", "Feature Branch"); // This only modifies the branch
 // #endregion

--- a/homepage/homepage/content/docs/code-snippets/key-features/version-control/react-snippet.tsx
+++ b/homepage/homepage/content/docs/code-snippets/key-features/version-control/react-snippet.tsx
@@ -1,7 +1,9 @@
 import { ID } from "jazz-tools";
 import { MyAccount, Project } from "./schema";
 const projectId = "";
-import { useAccount, useCoState } from "jazz-tools/react";
+import { useAccount, useCoState, useSuspenseCoState } from "jazz-tools/react";
+import { Text, TextInput, View } from "react-native";
+import { Suspense } from "react";
 
 // #region UseCoState
 const branch = useCoState(Project, projectId, {
@@ -17,7 +19,7 @@ function EditProject({
   projectId: ID<typeof Project>;
   currentBranchName: string;
 }) {
-  const project = useCoState(Project, projectId, {
+  const project = useSuspenseCoState(Project, projectId, {
     resolve: {
       tasks: { $each: true },
     },
@@ -43,8 +45,25 @@ function EditProject({
     task && task.$jazz.set("title", e.target.value);
   };
 
-  // @ts-expect-error handleSave not implemented
-  return <form onSubmit={handleSave}>{/* Edit form fields */}</form>;
+  // [!code hide]
+  const handleSave = () => null;
+  return (
+    <Suspense fallback={<p>Loading...</p>}>
+      <form onSubmit={handleSave}>
+        <label>Project Title
+          <input
+            value={project.title}
+            onChange={(evt) => project.$jazz.set('title', evt.currentTarget.value)} />
+        </label>
+        {project.tasks.map((task, i) => {
+          return <input
+            key={task.$jazz.id}
+            value={task.title}
+            onChange={(evt) => task.$jazz.set('title', evt.currentTarget.value)} />
+        })}
+      </form>;
+    </Suspense>
+  )
 }
 // #endregion
 
@@ -56,4 +75,40 @@ const me = useAccount(MyAccount, {
 
 me.$isLoaded && me.$jazz.set("root", { value: "Feature Branch" }); // Will also modify the main account
 me.$isLoaded && me.root.$jazz.set("value", "Feature Branch"); // This only modifies the branch
+// #endregion
+
+// #region EditOnBranchRN
+function EditProjectComponent({
+  projectId,
+  currentBranchName,
+}: {
+  projectId: ID<typeof Project>;
+  currentBranchName: string;
+}) {
+  const project = useCoState(Project, projectId, {
+    resolve: {
+      // When we use a 'resolve' query with a branch, all of the 'resolved' CoValues are also part of the new branch
+      tasks: { $each: true },
+    },
+    unstable_branch: {
+      name: currentBranchName,
+    },
+  });
+
+  return (
+    <View>
+      {project.$isLoaded &&
+        <View>
+          <Text>Project</Text>
+          <TextInput value={project.title} onChangeText={v => project.$jazz.set("title", v)} />
+          {project.tasks.map(task => {
+            return (
+              <TextInput key={task.$jazz.id} value={task.title} onChangeText={v => { task.$jazz.set('title', v) }} />
+            )
+          })}
+        </View>
+      }
+    </View>
+  );
+}
 // #endregion

--- a/homepage/homepage/content/docs/docNavigationItems.js
+++ b/homepage/homepage/content/docs/docNavigationItems.js
@@ -41,6 +41,7 @@ export const docNavigationItems = [
   {
     name: "Upgrade guides",
     collapse: true,
+    startClosed: true,
     prefix: "/docs/upgrade",
     items: [
       {
@@ -58,21 +59,21 @@ export const docNavigationItems = [
         href: "/docs/upgrade/0-17-0",
         done: 100,
       },
-      {
-        name: "0.16.0 - Cleaner separation between Zod and CoValue schemas",
-        href: "/docs/upgrade/0-16-0",
-        done: 100,
-      },
-      {
-        name: "0.15.0 - Everything inside `jazz-tools`",
-        href: "/docs/upgrade/0-15-0",
-        done: 100,
-      },
-      {
-        name: "0.14.0 - Zod-based schemas",
-        href: "/docs/upgrade/0-14-0",
-        done: 100,
-      },
+      // {
+      //  name: "0.16.0 - Cleaner separation between Zod and CoValue schemas",
+      //  href: "/docs/upgrade/0-16-0",
+      //  done: 100,
+      // },
+      // {
+      //  name: "0.15.0 - Everything inside `jazz-tools`",
+      //  href: "/docs/upgrade/0-15-0",
+      //  done: 100,
+      // },
+      // {
+      //  name: "0.14.0 - Zod-based schemas",
+      //  href: "/docs/upgrade/0-14-0",
+      //  done: 100,
+      // },
       // {
       //   name: "0.13.0 - React Native Split",
       //   href: "/docs/upgrade/0-13-0",

--- a/homepage/homepage/content/docs/key-features/version-control.mdx
+++ b/homepage/homepage/content/docs/key-features/version-control.mdx
@@ -1,4 +1,4 @@
-import { Alert, CodeGroup, ContentByFramework } from "@/components/forMdx";
+import { Alert, CodeGroup, ContentByFramework, TabbedCodeGroup, TabbedCodeGroupItem, VanillaLogo, ReactLogo, RNLogo, SvelteLogo, ExpoLogo } from "@/components/forMdx";
 
 export const metadata = {
   description: "Learn how to use branching and merging in Jazz"
@@ -8,39 +8,50 @@ export const metadata = {
 
 Jazz provides built-in version control through branching and merging, allowing multiple users to work on the same resource in isolation and merge their changes when they are ready.
 
-This enables the design of new editing workflows where users (or agents!) can create branches, make changes, and merge them back to the main version.
+You can use this to design new editing workflows where users (or agents!) can create branches, make changes, and merge them back to the main version.
 
-<Alert variant="info" className="mt-4 flex gap-2 items-center">
-  <strong>Important:</strong> Version control is currently unstable and we may ship breaking changes in patch releases.
+<Alert variant="info" className="mt-4 flex gap-2 items-center" title="Important">
+  Version control is currently unstable and we may ship breaking changes in patch releases.
 </Alert>
 
 ## Working with branches
 
 ### Creating Branches
 
+<ContentByFramework framework={["vanilla"]}>
 To create a branch, use the `unstable_branch` option when loading a CoValue:
+</ContentByFramework>
 
-<CodeGroup>
-```ts index.ts#Branch
-```
-</CodeGroup>
+<ContentByFramework framework={["svelte"]}>
+You can also create a branch via `CoState`:
+</ContentByFramework>
 
 <ContentByFramework framework={["react", "react-native", "expo"]}>
 You can also create a branch via the `useCoState` hook:
-
-<CodeGroup>
-```ts react-snippet.tsx#UseCoState
-```
-</CodeGroup>
 </ContentByFramework>
-<ContentByFramework framework={["svelte"]}>
-You can also create a branch via `CoState`:
 
-<CodeGroup>
+<TabbedCodeGroup default="react" savedPreferenceKey="framework" id="load-a-branch">
+<TabbedCodeGroupItem icon={<VanillaLogo />} label="Vanilla" value="vanilla" preferWrap>
+```ts index.ts#Branch
+```
+</TabbedCodeGroupItem>
+<TabbedCodeGroupItem icon={<ReactLogo />} label="React" value="react" preferWrap>
+```tsx react-snippet.tsx#UseCoState
+```
+</TabbedCodeGroupItem>
+<TabbedCodeGroupItem icon={<SvelteLogo />} label="Svelte" value="svelte" preferWrap>
 ```ts svelte.svelte#CoState
 ```
-</CodeGroup>
-</ContentByFramework>
+</TabbedCodeGroupItem>
+<TabbedCodeGroupItem icon={<RNLogo />} label="React Native" value="react-native" preferWrap>
+```tsx react-snippet.tsx#UseCoState
+```
+</TabbedCodeGroupItem>
+<TabbedCodeGroupItem icon={<ExpoLogo />} label="React Native (Expo)" value="react-native-expo" preferWrap>
+```tsx react-snippet.tsx#UseCoState
+```
+</TabbedCodeGroupItem>
+</TabbedCodeGroup>
 
 You can also include nested CoValues in your branch by using a [`resolve` query](/docs/core-concepts/subscription-and-loading#resolve-queries).
 

--- a/homepage/homepage/content/docs/key-features/version-control.mdx
+++ b/homepage/homepage/content/docs/key-features/version-control.mdx
@@ -68,18 +68,28 @@ In order to access branched nested CoValues, you should access them in the same 
 Once you have a branch, you can make changes just as you would with the original CoValue:
 
 {/* TODO: this is not suitable for vanilla */}
-<ContentByFramework framework={["react", "react-native", "expo", "vanilla"]}>
-<CodeGroup>
+<TabbedCodeGroup default="react" savedPreferenceKey="framework" id="edit-on-branch">
+<TabbedCodeGroupItem icon={<VanillaLogo />} label="Vanilla" value="vanilla" preferWrap>
+```ts index.ts#EditOnBranch
+```
+</TabbedCodeGroupItem>
+<TabbedCodeGroupItem icon={<ReactLogo />} label="React" value="react" preferWrap>
 ```tsx react-snippet.tsx#EditOnBranch
 ```
-</CodeGroup>
-</ContentByFramework>
-<ContentByFramework framework={["svelte"]}>
-<CodeGroup>
-```svelte EditOnBranch.svelte
+</TabbedCodeGroupItem>
+<TabbedCodeGroupItem icon={<SvelteLogo />} label="Svelte" value="svelte" preferWrap>
+```ts EditOnBranch.svelte
 ```
-</CodeGroup>
-</ContentByFramework>
+</TabbedCodeGroupItem>
+<TabbedCodeGroupItem icon={<RNLogo />} label="React Native" value="react-native" preferWrap>
+```tsx react-snippet.tsx#EditOnBranchRN
+```
+</TabbedCodeGroupItem>
+<TabbedCodeGroupItem icon={<ExpoLogo />} label="React Native (Expo)" value="react-native-expo" preferWrap>
+```tsx react-snippet.tsx#EditOnBranchRN
+```
+</TabbedCodeGroupItem>
+</TabbedCodeGroup>
 
 ### Account & Group
 
@@ -95,10 +105,28 @@ This means that, adding a member on a branched Group will also add the member to
 If you are modifying an account, be aware that replacing the root or profile  will also modify the main account (although updating the properties will happen on the branch).
 
 {/* TODO: Not framework friendly */}
-<CodeGroup>
+<TabbedCodeGroup default="react" savedPreferenceKey="framework" id="edit-on-branch">
+<TabbedCodeGroupItem icon={<VanillaLogo />} label="Vanilla" value="vanilla" preferWrap>
+```ts index.ts#AccountModifications
+```
+</TabbedCodeGroupItem>
+<TabbedCodeGroupItem icon={<ReactLogo />} label="React" value="react" preferWrap>
 ```tsx react-snippet.tsx#AccountModifications
 ```
-</CodeGroup>
+</TabbedCodeGroupItem>
+<TabbedCodeGroupItem icon={<SvelteLogo />} label="Svelte" value="svelte" preferWrap>
+```svelte AccountModifications.svelte
+```
+</TabbedCodeGroupItem>
+<TabbedCodeGroupItem icon={<RNLogo />} label="React Native" value="react-native" preferWrap>
+```tsx react-snippet.tsx#AccountModifications
+```
+</TabbedCodeGroupItem>
+<TabbedCodeGroupItem icon={<ExpoLogo />} label="React Native (Expo)" value="react-native-expo" preferWrap>
+```tsx react-snippet.tsx#AccountModifications
+```
+</TabbedCodeGroupItem>
+</TabbedCodeGroup>
 
 ### Merging Branches
 


### PR DESCRIPTION
# Description
Adds other framework walkthroughs to the Version Control docs

## Manual testing instructions
Check the version control page, and ensure that it is updated for all frameworks as appropriate.

## Tests

- [ ] Tests have been added and/or updated
- [x] Tests have not been updated, because: N/A
- [ ] I need help with writing tests


## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [ ] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing