### PR TITLE
fix: ensure that all the suspended promises are cached and port the chat example to Suspense

### DIFF
--- a/.changeset/curly-tables-brake.md
+++ b/.changeset/curly-tables-brake.md
@@ -1,0 +1,5 @@
+---
+"hash-slash": patch
+---
+
+Fix issues with hashchange propagation when suspending the component

--- a/.changeset/flat-foxes-invent.md
+++ b/.changeset/flat-foxes-invent.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Bugfix: ensure that the promises used for Suspense is always cached

--- a/examples/chat/src/app.tsx
+++ b/examples/chat/src/app.tsx
@@ -52,6 +52,8 @@ export function App() {
 
     // for https://jazz.tools marketing site demo only
     onChatLoad(chat);
+
+    return null;
   };
 
   const usernamePlaceholder = "Set username";
@@ -93,7 +95,7 @@ export function App() {
         )}
       </TopBar>
       {router.route({
-        "/": () => createChat() as never,
+        "/": () => createChat(),
         "/chat/:id": (id) => <ChatScreen chatID={id} />,
       })}
     </AppContainer>

--- a/examples/chat/src/app.tsx
+++ b/examples/chat/src/app.tsx
@@ -1,10 +1,14 @@
 import { apiKey } from "@/apiKey.ts";
 import { getRandomUsername, inIframe, onChatLoad } from "@/util.ts";
 import { useIframeHashRouter } from "hash-slash";
-import { co, getLoadedOrUndefined, Group } from "jazz-tools";
+import { co, Group } from "jazz-tools";
 import { JazzInspector } from "jazz-tools/inspector";
-import { JazzReactProvider, useAccount, useLogOut } from "jazz-tools/react";
-import { StrictMode, useId, useMemo, useState, useEffect, useRef } from "react";
+import {
+  JazzReactProvider,
+  useLogOut,
+  useSuspenseAccount,
+} from "jazz-tools/react";
+import { StrictMode, useId, useMemo } from "react";
 import { createRoot } from "react-dom/client";
 import Jazzicon from "react-jazzicon";
 import { ChatScreen } from "./chatScreen.tsx";
@@ -27,34 +31,17 @@ const AccountWithProfile = co.account().resolved({
 });
 
 export function App() {
-  const me = useAccount(AccountWithProfile);
+  const me = useSuspenseAccount(AccountWithProfile);
   const logOut = useLogOut();
   const router = useIframeHashRouter();
-  const inputId = useId();
-  const [localValue, setLocalValue] = useState("");
-  const [inputWidth, setInputWidth] = useState(120);
-  const spanRef = useRef<HTMLSpanElement>(null);
 
-  const profile = getLoadedOrUndefined(me)?.profile;
+  const inputId = useId();
 
   const avatarSeed = useMemo(() => {
-    if (!me?.$jazz?.id) return 0;
     return stringToSeed(me.$jazz.id);
-  }, [me?.$jazz?.id]);
-
-  useEffect(() => {
-    setLocalValue(profile?.name ?? "");
-  }, [profile?.name]);
-
-  useEffect(() => {
-    if (spanRef.current) {
-      const width = spanRef.current.offsetWidth;
-      setInputWidth(Math.max(width + 4, 20));
-    }
-  }, [localValue]);
+  }, [me.$jazz.id]);
 
   const createChat = () => {
-    if (!me) return;
     const group = Group.create();
     group.makePublic("writer");
     const chat = Chat.create([], group);
@@ -78,22 +65,19 @@ export function App() {
         </label>
         <div className="relative">
           <span
-            ref={spanRef}
             className="absolute invisible whitespace-pre text-lg"
             aria-hidden="true"
           >
-            {localValue || usernamePlaceholder}
+            {usernamePlaceholder}
           </span>
           <input
             type="text"
             id={inputId}
-            value={localValue}
-            style={{ width: `${inputWidth}px` }}
+            value={me.profile.name}
+            style={{ width: `${me.profile.name.length}ch` }}
             className="bg-transparent text-lg outline-none min-w-0 max-w-full"
             onChange={(e) => {
-              setLocalValue(e.target.value);
-              if (!profile) return;
-              profile.$jazz.set("name", e.target.value);
+              me.profile.$jazz.set("name", e.target.value);
             }}
             placeholder={usernamePlaceholder}
           />

--- a/examples/chat/src/chatScreen.tsx
+++ b/examples/chat/src/chatScreen.tsx
@@ -1,6 +1,6 @@
 import { Account, getLoadedOrUndefined } from "jazz-tools";
 import { createImage } from "jazz-tools/media";
-import { useAccount, useCoState } from "jazz-tools/react";
+import { useSuspenseAccount, useSuspenseCoState } from "jazz-tools/react";
 import { useEffect, useState } from "react";
 import { Chat, Message } from "./schema.ts";
 import {
@@ -23,14 +23,14 @@ const ChatWithMessages = Chat.resolved({
 });
 
 export function ChatScreen(props: { chatID: string }) {
-  const chat = useCoState(ChatWithMessages, props.chatID);
-  const me = useAccount();
+  const chat = useSuspenseCoState(ChatWithMessages, props.chatID);
+  const me = useSuspenseAccount();
   const [showNLastMessages, setShowNLastMessages] = useState(
     INITIAL_MESSAGES_TO_SHOW,
   );
   const isLoading = useMessagesPreload(props.chatID);
 
-  if (!me.$isLoaded || !chat.$isLoaded || isLoading)
+  if (isLoading)
     return (
       <div className="flex-1 flex justify-center items-center">Loading...</div>
     );
@@ -61,10 +61,6 @@ export function ChatScreen(props: { chatID: string }) {
       );
     });
   };
-
-  if (!me) {
-    return <div>Loading...</div>;
-  }
 
   return (
     <>

--- a/examples/chat/src/chatScreen.tsx
+++ b/examples/chat/src/chatScreen.tsx
@@ -23,17 +23,13 @@ const ChatWithMessages = Chat.resolved({
 });
 
 export function ChatScreen(props: { chatID: string }) {
+  useMessagesPreload(props.chatID);
+
   const chat = useSuspenseCoState(ChatWithMessages, props.chatID);
   const me = useSuspenseAccount();
   const [showNLastMessages, setShowNLastMessages] = useState(
     INITIAL_MESSAGES_TO_SHOW,
   );
-  const isLoading = useMessagesPreload(props.chatID);
-
-  if (isLoading)
-    return (
-      <div className="flex-1 flex justify-center items-center">Loading...</div>
-    );
 
   const sendImage = (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.currentTarget.files?.[0];

--- a/examples/chat/src/ui.tsx
+++ b/examples/chat/src/ui.tsx
@@ -95,7 +95,7 @@ export function BubbleImage(props: { image: ImageDefinition }) {
   return (
     <Image
       imageId={props.image.$jazz.id}
-      className="h-auto max-h-80 max-w-full rounded-t-xl mb-1"
+      className="h-auto max-h-80 max-w-full rounded-t-xl mb-1 object-contain"
       height="original"
       width="original"
     />

--- a/examples/form/src/App.tsx
+++ b/examples/form/src/App.tsx
@@ -1,10 +1,10 @@
-import { useIframeHashRouter } from "hash-slash";
+import { useHashRouter } from "hash-slash";
 import { CreateOrder } from "./CreateOrder.tsx";
 import { EditOrder } from "./EditOrder.tsx";
 import { Orders } from "./Orders.tsx";
 
 function App() {
-  const router = useIframeHashRouter();
+  const router = useHashRouter();
 
   return (
     <>

--- a/examples/form/src/CreateOrder.tsx
+++ b/examples/form/src/CreateOrder.tsx
@@ -1,4 +1,4 @@
-import { useIframeHashRouter } from "hash-slash";
+import { useHashRouter } from "hash-slash";
 import { useAccount, useCoState } from "jazz-tools/react";
 import { useState } from "react";
 import { Errors } from "./Errors.tsx";
@@ -21,7 +21,7 @@ export function CreateOrder(props: { id: string }) {
       return account.root.orders;
     },
   });
-  const router = useIframeHashRouter();
+  const router = useHashRouter();
   const [errors, setErrors] = useState<string[]>([]);
 
   const newOrder = useCoState(PartialBubbleTeaOrder, props.id);

--- a/examples/form/src/EditOrder.tsx
+++ b/examples/form/src/EditOrder.tsx
@@ -5,10 +5,10 @@ import { OrderForm } from "./OrderForm.tsx";
 import { OrderThumbnail } from "./OrderThumbnail.tsx";
 import { BubbleTeaOrder } from "./schema.ts";
 import { useMemo } from "react";
-import { useIframeHashRouter } from "hash-slash";
+import { useHashRouter } from "hash-slash";
 
 export function EditOrder(props: { id: string }) {
-  const router = useIframeHashRouter();
+  const router = useHashRouter();
 
   // Create a new group for the branch, so that every time we open the edit order page, we create a new private branch
   const owner = useMemo(() => Group.create(), []);

--- a/examples/reactions/src/App.tsx
+++ b/examples/reactions/src/App.tsx
@@ -1,4 +1,4 @@
-import { useIframeHashRouter } from "hash-slash";
+import { useHashRouter } from "hash-slash";
 import { Account, Group } from "jazz-tools";
 import { useAccount, useLogOut } from "jazz-tools/react";
 import { ReactionsScreen } from "./ReactionsScreen.tsx";
@@ -11,7 +11,7 @@ function App() {
     },
   });
   const logOut = useLogOut();
-  const router = useIframeHashRouter();
+  const router = useHashRouter();
 
   const createReactions = () => {
     const group = Group.create();

--- a/packages/jazz-tools/src/react-core/hooks.ts
+++ b/packages/jazz-tools/src/react-core/hooks.ts
@@ -489,7 +489,7 @@ export function useSuspenseCoState<
     throw new Error("Subscription not found");
   }
 
-  use(subscription.getPromise());
+  use(subscription.getCachedPromise());
 
   const getCurrentValue = () => {
     const value = subscription.getCurrentValue();
@@ -824,7 +824,7 @@ export function useSuspenseAccount<
     );
   }
 
-  use(subscription.getPromise());
+  use(subscription.getCachedPromise());
 
   const getCurrentValue = () => {
     const value = subscription.getCurrentValue();

--- a/packages/jazz-tools/src/react-core/tests/useSuspenseCoState.test.tsx
+++ b/packages/jazz-tools/src/react-core/tests/useSuspenseCoState.test.tsx
@@ -370,7 +370,7 @@ describe("useSuspenseCoState", () => {
     });
   });
 
-  it.only("should throw error when CoValue becomes unauthorized", async () => {
+  it("should throw error when CoValue becomes unauthorized", async () => {
     const TestMap = co.map({
       value: z.string(),
     });

--- a/packages/jazz-tools/src/react-core/tests/useSuspenseCoState.test.tsx
+++ b/packages/jazz-tools/src/react-core/tests/useSuspenseCoState.test.tsx
@@ -370,6 +370,53 @@ describe("useSuspenseCoState", () => {
     });
   });
 
+  it.only("should throw error when CoValue becomes unauthorized", async () => {
+    const TestMap = co.map({
+      value: z.string(),
+    });
+
+    const group = Group.create();
+    group.addMember("everyone", "reader");
+
+    // Create CoValue owned by another account without sharing
+    const map = TestMap.create(
+      {
+        value: "123",
+      },
+      group,
+    );
+
+    await createJazzTestAccount({
+      isCurrentActiveAccount: true,
+    });
+
+    const TestComponent = () => {
+      const value = useSuspenseCoState(TestMap, map.$jazz.id);
+      return <div>{value.value}</div>;
+    };
+
+    const { container } = await act(async () => {
+      return render(
+        <ErrorBoundary fallback={<div>Error!</div>}>
+          <Suspense fallback={<div>Loading...</div>}>
+            <TestComponent />
+          </Suspense>
+        </ErrorBoundary>,
+      );
+    });
+    await waitFor(() => {
+      expect(container.textContent).toContain("123");
+      expect(container.textContent).not.toContain("Loading...");
+    });
+
+    group.removeMember("everyone");
+
+    // Wait for error to be thrown (unauthorized access)
+    await waitFor(() => {
+      expect(container.textContent).toContain("Error!");
+    });
+  });
+
   it("should update value when CoValue changes", async () => {
     const TestMap = co.map({
       value: z.string(),


### PR DESCRIPTION
Last migration to Suspense has broken the chat example.

Digging into the problem I found two issues:
1. React was nagging that promises weren't properly cached
2. The router.navigate in useHashRouter doesn't work when the target route is suspended

The first one was only a warning, because while we didn't cache the promises the data was.
But the checks on React are based on the promise identity, so I've changed the API to make them happy.

On the second one it's the comeback of the event propagation issue we had in the past with the same router.
Calling directly `onHashChange` fixes the bug, and I've added a `startTransition` to make it work better with Suspense.