### PR TITLE
fix: ensure onAnonymousAccountDiscarded hook is conditionally applied  in React providers

### DIFF
--- a/.changeset/tidy-streets-2.md
+++ b/.changeset/tidy-streets-2.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Bugfix: close the server peers before calling the onAnonymousAccountDiscarded hook, to ensure that there won't be conflicting issues with the new context sync

--- a/.changeset/tidy-streets-cut.md
+++ b/.changeset/tidy-streets-cut.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Bugfix: ensure onAnonymousAccountDiscarded hook is conditionally applied in React providers

--- a/packages/jazz-tools/src/react-native-core/provider.tsx
+++ b/packages/jazz-tools/src/react-native-core/provider.tsx
@@ -55,6 +55,9 @@ export function JazzProviderCore<
   );
   const logoutReplacementActiveRef = useRef(false);
   logoutReplacementActiveRef.current = Boolean(logOutReplacement);
+  const onAnonymousAccountDiscardedEnabled = Boolean(
+    onAnonymousAccountDiscarded,
+  );
 
   const value = React.useSyncExternalStore<
     JazzContextType<InstanceOfSchema<S>> | undefined
@@ -71,7 +74,9 @@ export function JazzProviderCore<
           logOutReplacement: logoutReplacementActiveRef.current
             ? logOutReplacementRefCallback
             : undefined,
-          onAnonymousAccountDiscarded: onAnonymousAccountDiscardedRefCallback,
+          onAnonymousAccountDiscarded: onAnonymousAccountDiscardedEnabled
+            ? onAnonymousAccountDiscardedRefCallback
+            : undefined,
           CryptoProvider,
         } satisfies JazzContextManagerProps<S>;
 

--- a/packages/jazz-tools/src/react/provider.tsx
+++ b/packages/jazz-tools/src/react/provider.tsx
@@ -58,6 +58,9 @@ export function JazzReactProvider<
   );
   const logoutReplacementActiveRef = useRef(false);
   logoutReplacementActiveRef.current = Boolean(logOutReplacement);
+  const onAnonymousAccountDiscardedEnabled = Boolean(
+    onAnonymousAccountDiscarded,
+  );
 
   const value = React.useSyncExternalStore<
     JazzContextType<InstanceOfSchema<S>> | undefined
@@ -74,7 +77,9 @@ export function JazzReactProvider<
           logOutReplacement: logoutReplacementActiveRef.current
             ? logOutReplacementRefCallback
             : undefined,
-          onAnonymousAccountDiscarded: onAnonymousAccountDiscardedRefCallback,
+          onAnonymousAccountDiscarded: onAnonymousAccountDiscardedEnabled
+            ? onAnonymousAccountDiscardedRefCallback
+            : undefined,
         } satisfies JazzContextManagerProps<S>;
 
         if (contextManager.propsChanged(props)) {

--- a/packages/jazz-tools/src/tools/implementation/ContextManager.ts
+++ b/packages/jazz-tools/src/tools/implementation/ContextManager.ts
@@ -351,6 +351,16 @@ export class JazzContextManager<
       // The storage is reachable through currentContext using the connectedPeers
       prevContext.node.removeStorage();
 
+      // Ensure that the new context is the only peer connected to the previous context
+      // This way all the changes made in the previous context are synced only to the new context
+      for (const peer of Object.values(prevContext.node.syncManager.peers)) {
+        if (!peer.closed) {
+          peer.gracefulShutdown();
+        }
+      }
+
+      prevContext.node.syncManager.peers = {};
+
       currentContext.node.syncManager.addPeer(prevAccountAsPeer);
       prevContext.node.syncManager.addPeer(currentAccountAsPeer);
 


### PR DESCRIPTION
The usage of onAnonymousAccountDiscardedRefCallback was always triggering the onAnonymousAccountDiscarded, adding unnecessary wait for the authentication operations.

Closed also the peers on the prevContext before connecting it to newContext, this way we are going to have a single WebSocket connection during the onAnonymousAccountDiscarded lifecycle making the sync flow more predictable.