### PR TITLE
Document iOS Keychain behaviour

### DIFF
--- a/homepage/homepage/components/DemoToDo.tsx
+++ b/homepage/homepage/components/DemoToDo.tsx
@@ -22,7 +22,7 @@ export const DemoToDo = () => {
 
   return (
     <div className="my-4 grid w-full grid-cols-1 gap-6 p-1 md:grid-cols-2">
-      <div className="rounded-2xl outline-4">
+      <div className="overflow-hidden rounded-2xl outline-4">
         <iframe
           ref={frameA}
           src="/minimal-example/index.html"
@@ -32,7 +32,7 @@ export const DemoToDo = () => {
         />
       </div>
 
-      <div className="rounded-2xl outline-4">
+      <div className="overflow-hidden rounded-2xl outline-4">
         {activeListId ? (
           <iframe
             ref={frameB}

--- a/homepage/homepage/content/docs/code-snippets/key-features/authentication/authentication-states/expo.tsx
+++ b/homepage/homepage/content/docs/code-snippets/key-features/authentication/authentication-states/expo.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { JazzExpoProvider } from "jazz-tools/expo";
-import { View, Text } from "react-native";
+import { View, Text, Settings } from "react-native";
 
 const App = () => {
   return <View></View>;
@@ -8,6 +8,7 @@ const App = () => {
 
 // #region Basic
 import { useAgent, useIsAuthenticated } from "jazz-tools/expo";
+import { useState } from "react";
 
 function AuthStateIndicator() {
   const agent = useAgent();
@@ -85,3 +86,32 @@ function example3() {
 // #endregion
   );
 }
+
+// #region IsolateStorage
+function RootLayout() {
+  const [authSecretStorageKey, setAuthSecretStorageKey] = useState<
+    string | null
+  >(() => {
+    const stored = Settings.get("jazz-authSecretStorageKey");
+    if (stored) return stored;
+    const newKey = "jazz-" + new Date();
+    Settings.set({ "jazz-authSecretStorageKey": newKey });
+    return newKey;
+  });
+
+  if (!authSecretStorageKey) {
+    return null;
+  }
+  return (
+    <JazzExpoProvider
+      sync={{
+        peer: `wss://cloud.jazz.tools/?key=${apiKey}`,
+        when: "never",
+      }}
+      authSecretStorageKey={authSecretStorageKey}
+    >
+      <App />
+    </JazzExpoProvider>
+  );
+}
+// #endregion

--- a/homepage/homepage/content/docs/key-features/authentication/authentication-states.mdx
+++ b/homepage/homepage/content/docs/key-features/authentication/authentication-states.mdx
@@ -150,12 +150,21 @@ For example, you may want to give users with Anonymous Authentication the opport
 
 <ContentByFramework framework="react-native-expo">
   <Alert variant="warning" title="iOS Credential Persistence" className="mt-4">
-    When using `sync: 'never'` or `sync: 'signedUp'`, like all other data, the user's account exists only on their device, and is deleted if the user uninstalls your app. On iOS though, login credentials are saved to the Keychain, and are not deleted when the app is uninstalled. 
+    On iOS Jazz persists login credentials using Secure Store, which saves them to the Keychain. While this is secure, iOS does not clear the credentials along with other data if a user uninstalls your app.
     
-    If a user reinstalls your app, Jazz will try to re-use these credentials to sign in to an account that no longer exists, which will cause errors. 
+    User accounts *are* deleted, so if you are using `sync: 'never'` or `sync: 'signedUp'`, accounts for users who are not 'signed up' will be lost.
     
-    To avoid this, consider using `sync: 'always'` for your iOS users, or let them know they'll need to remove their credentials from Keychain before reinstalling.
+    If the user later re-installs your app, the credentials for the deleted account remain in the Keychain. Jazz will attempt to use these to sign in and fail, as the account no longer exists.
+    
+    To avoid this, consider using `sync: 'always'` for your iOS users.
   </Alert>
+  
+  If you want to offer a fully local mode, you can work around this by using the `Settings` API. Settings stored using the `Settings` API *are* cleared on an application uninstallation, which allows us to scope the credentials for the current installation. If the user uninstalls and reinstalls your app, the credentials will be regenerated correctly.
+  
+  <CodeGroup preferWrap>
+    ```tsx expo.tsx#IsolateStorage
+    ```
+  </CodeGroup>
 </ContentByFramework>
 
 <ContentByFramework framework={['react', 'react-native', 'react-native-expo', 'svelte']}>

--- a/homepage/homepage/content/docs/project-setup/providers.mdx
+++ b/homepage/homepage/content/docs/project-setup/providers.mdx
@@ -76,11 +76,13 @@ The `sync` property configures how your application connects to the Jazz network
 
 <ContentByFramework framework="react-native-expo">
 <Alert variant="warning" title="iOS Credential Persistence" className="mt-4">
-  When using `sync: 'never'` or `sync: 'signedUp'`, like all other data, the user's account exists only on their device, and is deleted if the user uninstalls your app. On iOS though, login credentials are saved to the Keychain, and are not deleted when the app is uninstalled. 
-  
-  If a user reinstalls your app, Jazz will try to re-use these credentials to sign in to an account that no longer exists, which will cause errors. 
-  
-  To avoid this, consider using `sync: 'always'` for your iOS users, or let them know they'll need to remove their credentials from Keychain before reinstalling.
+On iOS Jazz persists login credentials using Secure Store, which saves them to the Keychain. While this is secure, iOS does not clear the credentials along with other data if a user uninstalls your app.
+
+User accounts *are* deleted, so if you are using `sync: 'never'` or `sync: 'signedUp'`, accounts for users who are not 'signed up' will be lost.
+
+If the user later re-installs your app, the credentials for the deleted account remain in the Keychain. Jazz will attempt to use these to sign in and fail, as the account no longer exists.
+
+To avoid this, consider using `sync: 'always'` for your iOS users, or [check the work around here](/docs/key-features/authentication/authentication-states#disable-sync-for-anonymous-authentication).
 </Alert>
 </ContentByFramework>
 


### PR DESCRIPTION
# Description
Improves the existing warning on avoiding using `never` and `signedUp` for iOS to show a pattern that can be used to scope credentials to an installation.

## Manual testing instructions

N/A

## Tests

- [ ] Tests have been added and/or updated
- [x] Tests have not been updated, because: N/A
- [ ] I need help with writing tests


## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [ ] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing