### PR TITLE
chore: add a new Cursor rule to generate changeset without cli

### DIFF
--- a/.cursor/rules/generate-changeset.mdc
+++ b/.cursor/rules/generate-changeset.mdc
@@ -1,0 +1,84 @@
+---
+description: "Guide for generating changeset files for versioning and changelog management"
+---
+
+# Generating Changesets
+
+When the user asks to create a changeset or add a changeset, help them generate a changeset file in the `.changeset/` directory.
+
+## What is a Changeset?
+
+A changeset is a markdown file with YAML front matter that documents:
+- Which packages need to be released
+- What semver bump type (major, minor, or patch) each package should receive
+- A changelog entry describing the changes
+
+## Changeset File Format
+
+Changeset files are stored in `.changeset/` directory with the naming pattern: `{unique-id}.md`
+
+The file format is:
+
+```markdown
+---
+"package-name": major|minor|patch
+"another-package": minor
+---
+
+A description of the changes that will appear in the changelog.
+```
+
+## Package Names
+
+When generating a changeset, use the exact package name from the package's `package.json` file. Common packages in this monorepo include:
+
+- `cojson`
+- `jazz-tools`
+- `jazz-run`
+- `jazz-webhook`
+- `cojson-core-wasm`
+- `cojson-core-rn`
+- `cojson-core-napi`
+- `cojson-storage-indexeddb`
+- `cojson-storage-sqlite`
+- `cojson-storage-do-sqlite`
+- `cojson-transport-ws`
+- `community-jazz-vue`
+- `create-jazz-app`
+- `hash-slash`
+- `quint-ui`
+
+**Important**: Always check the actual `package.json` file to get the exact package name, as package names must match exactly.
+
+## Semver Bump Types
+
+- **major**: Never use this, we are still in v0
+- **minor**: Breaking changes that require users to update their code
+- **patch**: New features that are backward compatible, bug fixes and small changes that are backward compatible
+
+**Important**: minor is only for breaking changes, the rest should be considered a patch
+
+## Example Changeset
+
+```markdown
+---
+"jazz-tools": patch
+---
+
+Added new `useSuspenseCoState` hook for data fetching using Suspense
+```
+
+## Best Practices
+
+- Write clear, user-facing changelog entries (not technical commit messages)
+- Use past tense ("Added feature" not "Add feature")
+- Be specific about what changed
+- If multiple packages are affected, list them all in the front matter
+
+## Workflow
+
+1. User describes the change they made
+2. You identify which packages are affected
+3. You determine the appropriate semver bump type
+4. You create the changeset file in `.changeset/`
+5. The changeset will be processed during the next release cycle


### PR DESCRIPTION
This Cursor rule gives the knowledge to Cursor on how to properly generate changesets.

This can be helpful because lets us to avoiding interruptin our flow and reach out the CLI when we need to push a PR, and help on generating the changelog texts.

Started with basic rules, which we can improve to give direction to humans and bots on how to write proper changesets.