### PR TITLE
docs: spec for coValue delete

### DIFF
--- a/.specs/data-delete-flow/design.md
+++ b/.specs/data-delete-flow/design.md
@@ -1,0 +1,515 @@
+# Design: Data Delete Flow for CoValues
+
+## Overview
+
+This design implements a secure, efficient data deletion flow for coValues that allows users to self-serve data deletion. The solution uses unencrypted delete transactions with specific metadata, immediate sync blocking, and eventual physical deletion through batch processing. Deleted coValues leave cryptographic tombstones that prevent data resurrection while enabling efficient cleanup.
+
+**Important Constraint**: Account and Group coValues cannot be deleted. This is required to keep the tombstone permissions verifiable.
+
+The design leverages existing transaction validation mechanisms, adding delete-specific checks in `tryAddTransactions`, and implements sync restrictions to prevent deleted content from propagating while allowing delete operations to sync.
+
+## Architecture / Components
+
+### 1. Delete API Method
+
+**Location**: `packages/cojson/src/coValueCore/coValueCore.ts`
+
+**Changes**:
+- Add method `deleteCoValue()` to `CoValueCore`:
+  - Checks that the coValue is not an Account or Group (throws error if it is)
+  - Checks that the current account has admin permissions on the coValue
+  - Throws error if not admin
+  - Creates delete transaction with meta `{ deleted: true }`
+  - Uses session naming pattern: `{accountId}_deleted_{uniqueId}`
+
+**Key Logic**:
+```typescript
+deleteCoValue(): void {
+  if (!this.verified) {
+    throw new Error("Cannot delete coValue without verified state");
+  }
+
+  const currentAccount = this.node.getCurrentAgent();
+  if (!currentAccount) {
+    throw new Error("No current account to perform delete");
+  }
+
+  // Check that coValue is not an Account or Group
+  if (this.verified.header.ruleset.type === "group") {
+    throw new Error("Cannot delete Group coValues");
+  } else if (this.verified.header.ruleset.type === "unsafeAllowAll") {
+    // For unsafeAllowAll, check if it's an account (should have been caught above)
+    // This should not be reachable since accounts are blocked earlier
+    throw new Error("Cannot delete coValue with unsafeAllowAll ruleset");
+  }
+
+  // Check admin permissions
+  const group = this.safeGetGroup()
+  
+  if (group) {
+    const role = group.getRoleOf(currentAccount.id);
+    if (role !== "admin") {
+      throw new Error("Only admins can delete coValues");
+    }
+  }
+
+  // Generate unique session ID for delete transaction
+  const uniqueId = this.crypto.newRandomSessionID(currentAccount.id).split('_session_z')[1];
+  const deleteSessionID = `${currentAccount.id}_deleted_${uniqueId}` as SessionID;
+
+  // Create unencrypted (trusting) transaction with delete meta
+  // Pass deleteSessionID to makeTransaction to use the delete session
+  this.makeTransaction(
+    [], // Empty changes array
+    "trusting", // Unencrypted
+    { deleted: true }, // Delete metadata
+    Date.now(),
+    deleteSessionID // Use the delete session ID
+  );
+}
+```
+
+### 2. Delete Transaction Creation
+
+**Location**: `packages/cojson/src/coValueCore/coValueCore.ts` - `makeTransaction()`
+
+**Changes**:
+- Modify `makeTransaction()` to accept optional `sessionID` parameter
+- When creating delete transaction, use the delete session ID pattern
+- Ensure delete transactions are always unencrypted (trusting)
+
+**Rationale for Special Delete Session**:
+The special session naming pattern (`{accountId}_deleted_{uniqueId}`) is used to provide a simple way to sync the delete marker without carrying extra data. By using a dedicated session for delete transactions, the system can:
+- Easily identify delete operations by session ID pattern
+- Sync only the delete marker without carrying any history
+- Maintain a clean separation between regular transactions and delete operations
+
+**Key Logic**:
+```typescript
+makeTransaction(
+  changes: JsonValue[],
+  privacy: "private" | "trusting",
+  meta?: JsonObject,
+  madeAt?: number,
+  sessionID?: SessionID, // Optional override for delete sessions
+): boolean {
+  // ... existing validation ...
+
+  const effectiveSessionID = sessionID || (
+    this.verified.header.meta?.type === "account"
+      ? (this.node.currentSessionID.replace(
+          this.node.getCurrentAgent().id,
+          this.node.getCurrentAgent().currentAgentID(),
+        ) as SessionID)
+      : this.node.currentSessionID
+  );
+
+  // ... rest of transaction creation ...
+}
+```
+
+### 3. Delete Transaction Validation in tryAddTransactions
+
+**Location**: `packages/cojson/src/coValueCore/coValueCore.ts` - `tryAddTransactions()`
+
+**Changes**:
+- After signature verification succeeds, check for delete transactions
+- Only parse transaction meta if sessionID contains `_deleted_` (optimization)
+- Validate that delete transaction author has admin permissions
+- Mark coValue as deleted if valid delete transaction found
+- Store delete state for sync blocking
+
+**Key Logic**:
+```typescript
+tryAddTransactions(
+  sessionID: SessionID,
+  newTransactions: Transaction[],
+  newSignature: Signature,
+  skipVerify: boolean = false,
+) {
+  // ... existing signature verification ...
+
+  try {
+    this.verified.tryAddTransactions(
+      sessionID,
+      signerID,
+      newTransactions,
+      newSignature,
+      skipVerify,
+    );
+
+    // Only check for delete transactions if sessionID contains '_deleted_'
+    if (sessionID.includes('_deleted_') && !this.isGroup() && !this.isAccount()) {
+      // Check for delete transactions after successful addition
+      for (const tx of newTransactions) {
+        const txMeta = this.parseTransactionMeta(tx);
+        if (txMeta?.deleted === true) {
+          // Validate admin permissions for delete
+          if (!skipVerify) {
+            const deleteAuthor = accountOrAgentIDfromSessionID(sessionID);
+            const hasAdminPermission = this.validateDeletePermission(deleteAuthor);
+            
+            if (!hasAdminPermission) {
+              // Mark transaction as invalid
+              // This should be handled in determineValidTransactions
+              continue;
+            }
+          }
+          
+          // Mark coValue as deleted
+          this.markAsDeleted(sessionID, tx);
+        }
+      }
+    }
+
+    this.processNewTransactions();
+    this.scheduleNotifyUpdate();
+    this.invalidateDependants();
+  } catch (e) {
+    return { type: "InvalidSignature", id: this.id, error: e } as const;
+  }
+}
+```
+
+### 4. Delete Permission Validation
+
+**Location**: `packages/cojson/src/permissions.ts` - `determineValidTransactions()`
+
+**Changes**:
+- Add validation for delete transactions in `determineValidTransactions()`
+- Check that transaction author has admin permissions when meta contains `{ deleted: true }`
+- Reject delete transactions from non-admin accounts
+
+**Key Logic**:
+```typescript
+export function determineValidTransactions(coValue: CoValueCore): void {
+  // ... existing validation logic ...
+
+  for (const tx of coValue.toValidateTransactions) {
+    // Check for delete transactions
+    if (tx.meta?.deleted === true) {
+      // Only admins can delete
+      if (transactorRoleAtTxTime !== "admin") {
+        tx.markInvalid("Only admins can delete coValues", {
+          transactor: tx.author,
+          transactorRole: transactorRoleAtTxTime ?? "undefined",
+        });
+        continue;
+      }
+    }
+    // ... existing transaction validation ...
+  }
+}
+```
+
+### 5. CoValue Deleted State Tracking
+
+**Location**: `packages/cojson/src/coValueCore/coValueCore.ts` and `packages/cojson/src/coValueCore/verifiedState.ts`
+
+**Changes**:
+- Add `isDeleted: boolean` property to `CoValueCore`
+- Add `deleteSessionID: SessionID | undefined` to track which session contains the delete transaction
+
+**Key Logic**:
+```typescript
+// In CoValueCore
+private _isDeleted = false;
+private _deleteSessionID: SessionID | undefined;
+
+get isDeleted(): boolean {
+  return this._isDeleted;
+}
+
+markAsDeleted(sessionID: SessionID, transaction: Transaction): void {
+  this._isDeleted = true;
+  this._deleteSessionID = sessionID;
+  this._deleteTransaction = transaction;
+}
+```
+
+### 6. Immediate Sync Blocking
+
+**Location**: `packages/cojson/src/sync.ts` - `SyncManager.handleNewContent()` and `SyncManager.syncLocalTransaction()`
+
+**Changes**:
+- Before syncing content, check if coValue is deleted
+- If deleted, only allow syncing the delete session/transaction
+- Block all other content from syncing
+
+**Key Logic**:
+```typescript
+// In handleNewContent
+handleNewContent(
+  msg: NewContentMessage,
+  from: PeerState | "storage" | "import",
+) {
+  const coValue = this.node.getCoValue(msg.id);
+  
+  // Check if coValue is deleted
+  if (coValue.isDeleted && coValue.deleteSessionID) {
+    return;
+  }
+
+  // ... rest of handleNewContent ...
+}
+
+// In syncLocalTransaction
+syncLocalTransaction(
+  coValue: VerifiedState,
+  knownStateBefore: CoValueKnownState,
+) {
+  const core = this.node.getCoValueCore(coValue.id);
+  
+  if (core.isDeleted && core.deleteSessionID) {
+    return;
+  }
+
+  // ... normal sync logic ...
+}
+```
+
+### 7. DBClient Deleted CoValue Tracking
+
+**Location**: `packages/cojson/src/storage/types.ts` and DBClient implementations
+
+**Changes**:
+- DBClient needs to track deleted coValues to enable quick scanning for batch delete operations
+- When a delete transaction is stored, mark the coValue as deleted in the database
+- This allows efficient querying of all deleted coValues without scanning all coValues
+
+**Key Logic**:
+```typescript
+// In DBClient interface (types.ts)
+export interface DBClientInterfaceAsync {
+  // ... existing methods ...
+  
+  // Mark coValue as deleted when delete transaction is stored
+  markCoValueAsDeleted(coValueRowID: number): Promise<void>;
+  
+  // Get all deleted coValue IDs for batch processing
+  getAllDeletedCoValueIDs(): Promise<RawCoID[]>;
+}
+
+export interface DBClientInterfaceSync {
+  // ... existing methods ...
+  
+  markCoValueAsDeleted(coValueRowID: number): void;
+  getAllDeletedCoValueIDs(): RawCoID[];
+}
+```
+
+**Implementation Notes**:
+- When storing a delete transaction, call `markCoValueAsDeleted()` to update the database
+- This can be done by adding a `deleted: boolean` column to the `coValues` table or a separate `deletedCoValues` table
+- The tracking happens automatically when delete transactions are stored via normal storage flow
+
+### 8. Storage API Batch Delete
+
+**Location**: `packages/cojson/src/storage/storageSync.ts` and `packages/cojson/src/storage/storageAsync.ts`
+
+**Changes**:
+- Storage API should expose a method to delete all deleted coValues
+- This method uses the DBClient's `getAllDeletedCoValueIDs()` to get the list
+- For each deleted coValue, perform physical deletion while preserving tombstone
+
+**Key Logic**:
+```typescript
+// In StorageAPI interface
+export interface StorageAPI {
+  // ... existing methods ...
+  
+  // Delete all deleted coValues (batch operation)
+  ereaseAllDeletedCoValues(): Promise<void>;
+}
+
+// Implementation in StorageApiAsync/StorageApiSync
+async ereaseAllDeletedCoValues(): Promise<void> {
+  const deletedCoValueIDs = await this.dbClient.getAllDeletedCoValueIDs();
+  
+  for (const coValueID of deletedCoValueIDs) {
+    // Perform physical deletion while preserving tombstone
+    await this.performPhysicalDelete(coValueID);
+  }
+}
+```
+
+### 9. DBDriver Deleted CoValue Extraction
+
+**Location**: `packages/cojson/src/storage/sqlite/types.ts` and DBDriver implementations
+
+**Changes**:
+- DBDriver should have a method to extract all deleted coValue IDs
+- This enables efficient batch processing without loading all coValues into memory
+- The method should return only the IDs, not full coValue data
+
+**Key Logic**:
+```typescript
+// In SQLiteDatabaseDriver interface
+export interface SQLiteDatabaseDriver {
+  // ... existing methods ...
+  
+  // Get all deleted coValue IDs
+  getAllDeletedCoValueIDs(): RawCoID[];
+}
+
+export interface SQLiteDatabaseDriverAsync {
+  // ... existing methods ...
+  
+  getAllDeletedCoValueIDs(): Promise<RawCoID[]>;
+}
+
+// Implementation example (SQL)
+// SELECT id FROM coValues WHERE deleted = true;
+// or
+// SELECT coValueID FROM deletedCoValues;
+```
+
+### 10. Delete Tombstone
+
+**Location**: `packages/cojson/src/storage/storageSync.ts` and `packages/cojson/src/storage/storageAsync.ts`
+
+**Changes**:
+- When storing delete transaction, ensure tombstone is preserved
+- Tombstone consists of: delete transaction + delete session + coValue header
+- Even after physical deletion, tombstone remains
+
+**Key Logic**:
+```typescript
+// When physical delete happens, preserve tombstone
+async performPhysicalDelete(coValueID: RawCoID) {
+  // Delete all sessions except delete session
+  // Delete all transactions except delete transaction
+  // Keep header and delete transaction (tombstone)
+  await this.dbClient.deleteCoValueContent(coValueID);
+}
+```
+
+### 11. Storage Shard Handling (skipVerify: true)
+
+**Location**: `packages/cojson/src/storage/storageSync.ts` and `packages/cojson/src/storage/storageAsync.ts`
+
+**Changes**:
+- Storage shards with `skipVerify: true` don't verify delete transactions
+- But they still delete the value and block sync
+
+## Data Models
+
+### Delete Transaction Metadata
+
+```typescript
+type DeleteTransactionMeta = {
+  deleted: true;
+};
+
+type DeleteSessionID = `${RawAccountID}_deleted_${string}`;
+```
+
+### CoValue Deleted State
+
+```typescript
+type CoValueDeletedState = {
+  isDeleted: boolean;
+  deleteSessionID: SessionID | undefined;
+};
+```
+
+
+## Error Handling / Testing Strategy
+
+### Error Cases
+
+1. **Account or Group Delete Attempt**:
+   - If trying to delete an Account or Group coValue
+   - **Handling**: Throw error immediately before creating transaction
+   - **Test**: Attempt delete on Account or Group, verify error thrown
+
+2. **Non-Admin Delete Attempt**:
+   - If non-admin tries to call `deleteCoValue()`
+   - **Handling**: Throw error immediately before creating transaction
+   - **Test**: Attempt delete as non-admin, verify error thrown
+
+3. **Invalid Delete Transaction**:
+   - If delete transaction from non-admin is received
+   - **Handling**: Mark transaction as invalid in `determineValidTransactions()`
+   - **Test**: Send delete transaction from non-admin, verify rejection
+
+4. **Delete on Already Deleted CoValue**:
+   - If trying to delete an already deleted coValue
+   - **Handling**: Allow (idempotent) or reject with error
+   - **Test**: Attempt delete on already deleted coValue
+
+5. **Sync Blocking Failure**:
+   - If sync blocking doesn't work correctly
+   - **Handling**: Ensure deleted coValues can only sync delete session
+   - **Test**: Try to sync non-delete content from deleted coValue, verify blocking
+
+### Testing Strategy
+
+1. **Unit Tests**:
+   - `deleteCoValue()` - verify Account/Group check, admin check and transaction creation
+   - `tryAddTransactions()` - verify delete detection and state marking
+   - `determineValidTransactions()` - verify delete permission validation
+   - Sync blocking logic - verify only delete session syncs
+   - Tombstone storage - verify tombstone preservation
+   - `DBClient.markCoValueAsDeleted()` - verify deleted coValues are tracked
+   - `DBClient.getAllDeletedCoValueIDs()` - verify correct IDs are returned
+   - `StorageAPI.ereaseAllDeletedCoValues()` - verify batch deletion
+
+2. **Integration Tests**:
+   - End-to-end delete flow: Create coValue, delete it, verify state
+   - Account deletion: Delete account, verify deletion state
+   - Sync blocking: Delete coValue, try to sync, verify blocking
+   - Batch delete: Multiple deletes, verify DBClient tracking and Storage API batch deletion
+   - Tombstone: Delete coValue, physically delete, verify tombstone
+
+3. **Edge Case Tests**:
+   - Delete during active sync: Ensure no race conditions
+   - Multiple delete transactions: Handle idempotency
+   - Delete on large coValues: Verify performance
+   - Storage shard deletes: Verify tombstone preservation
+   - Concurrent deletes: Ensure consistency
+
+4. **Stress Tests**:
+   - Many coValues deleted simultaneously
+   - Large accounts with many coValues
+   - Rapid delete/sync operations
+   - Storage performance with many tombstones
+
+### Test Scenarios
+
+**Scenario 1: Basic Delete Flow**
+1. Create a coValue
+2. Call `deleteCoValue()` as admin
+3. Verify delete transaction created with correct meta
+4. Verify coValue marked as deleted
+5. Verify sync blocking works
+6. Verify tombstone stored
+
+**Scenario 2: Account Self-Deletion**
+1. User clicks "Delete account" button
+2. System identifies sensitive coValues
+3. Delete operations performed on each
+4. Account itself deleted
+5. Verify account is marked as deleted
+
+**Scenario 3: Batch Delete Processing**
+1. Multiple coValues deleted (delete transactions stored)
+2. DBClient tracks deleted coValues
+3. Storage API calls `ereaseAllDeletedCoValues()`
+4. DBDriver extracts all deleted coValue IDs via `getAllDeletedCoValueIDs()`
+5. Physical deletion performed for each deleted coValue
+6. Tombstones preserved
+
+**Scenario 4: Storage Shard Delete**
+1. Delete transaction sent to storage shard (skipVerify: true)
+2. Shard doesn't verify but stores tombstone
+3. Tombstone preserved after physical delete
+4. CoValue marked as deleted
+
+**Scenario 5: Sync Restriction**
+1. CoValue deleted
+2. Try to sync non-delete content
+3. Verify sync blocked
+4. Try to sync delete session
+5. Verify delete session syncs successfully
+

--- a/.specs/data-delete-flow/requirements.md
+++ b/.specs/data-delete-flow/requirements.md
@@ -1,0 +1,104 @@
+# Requirements: Data Delete Flow for CoValues
+
+## Introduction
+
+Users need the ability to delete their data in Jazz applications. This requires a secure, efficient mechanism to mark coValues as deleted, prevent further synchronization of deleted data, and eventually remove the data physically while maintaining system integrity.
+
+The delete operation must work across all coValue types (CoMap, CoList, CoStream, etc.) and handle large accounts efficiently. Account and Group coValues cannot be deleted. The system must immediately block synchronization of deleted data to the public while allowing the delete operation itself to propagate. Deleted coValues leave a cryptographic tombstone that prevents data resurrection while enabling eventual physical deletion in batch operations.
+
+This specification defines the requirements for a data deletion flow that allows coValues to be deleted with proper permission checks, immediate sync blocking, and eventual physical deletion.
+
+## User Stories and Acceptance Criteria
+
+### US-1: Admin-Only Delete API
+
+**As a** developer  
+**I want to** provide a delete API method that only admins can use  
+**So that** delete operations are properly permissioned
+
+**Acceptance Criteria:**
+- WHEN code calls `coValue.$jazz.raw.core.deleteCoValue()`
+- THEN the method checks that the coValue is not an account or group coValue
+- AND if the coValue is an account or group, the operation throws an error
+- AND the method checks that the current account has admin permissions on the coValue
+- AND if the account is not an admin, the operation throws an error
+- AND if the account is an admin and the coValue is not an account or group, the delete operation proceeds
+
+### US-2: Delete Transaction Creation
+
+**As a** system  
+**I want to** create delete transactions with specific metadata and session naming  
+**So that** deleted coValues are properly marked and identifiable
+
+**Acceptance Criteria:**
+- WHEN a delete operation is performed on a coValue
+- THEN an unencrypted (trusting) transaction is created
+- AND the transaction has meta `{ deleted: true }`
+- AND the transaction is created in a session named `{accountId}_deleted_{uniqueId}`
+- AND the session naming works for all coValue types
+- AND the uniqueId ensures uniqueness across multiple delete operations
+
+### US-3: Sync Server Delete Processing
+
+**As a** sync server  
+**I want to** process delete transactions in batches and verify permissions  
+**So that** delete operations are efficiently handled and properly authorized
+
+**Acceptance Criteria:**
+- WHEN the sync server receives a transaction with meta `{ deleted: true }`
+- THEN the server stores the delete operation in a batch store
+- AND the server verifies that the transaction author has admin permissions on the coValue
+- AND if permissions are invalid, the delete transaction is rejected
+- AND if permissions are valid, the delete is queued for batch processing
+
+### US-4: Immediate Sync Blocking
+
+**As a** system  
+**I want to** immediately block synchronization of deleted coValues to the public  
+**So that** deleted data cannot be synced even before physical deletion
+
+**Acceptance Criteria:**
+- WHEN a coValue has a valid delete transaction
+- THEN any sync attempts for that coValue are immediately blocked
+- AND only the delete session/transaction can be synced
+- AND all other content from the coValue is prevented from syncing
+- AND this blocking happens immediately upon delete transaction creation, before physical deletion
+
+### US-5: Delete Tombstone
+
+**As a** system  
+**I want to** leave a tombstone when a coValue is deleted  
+**So that** the deletion is cryptographically verifiable and prevents data resurrection
+
+**Acceptance Criteria:**
+- WHEN a coValue is deleted
+- THEN a tombstone is created containing:
+  - The delete transaction
+  - The coValue header
+- AND the tombstone persists even after physical data deletion
+- AND the tombstone provides cryptographic proof of deletion
+
+### US-6: Storage Shard Delete Handling
+
+**As a** storage shard (node with skipVerify: true)  
+**I want to** handle delete transactions without verification but keep tombstones  
+**So that** storage shards can efficiently process deletes while maintaining deletion records
+
+**Acceptance Criteria:**
+- WHEN a storage shard receives a delete transaction
+- THEN it does not verify the delete transaction (due to skipVerify: true)
+- AND it stores the tombstone (delete transaction + coValue header)
+- AND the tombstone is preserved even though verification is skipped
+
+### US-7: Sync Restriction for Deleted CoValues
+
+**As a** system  
+**I want to** restrict what can be synced for deleted coValues  
+**So that** only deletion information propagates, not the deleted content
+
+**Acceptance Criteria:**
+- WHEN a coValue has a valid deleted session/transaction
+- AND the coValue is marked as deleted
+- THEN only the delete session/transaction can be synced
+- AND all other sessions and transactions from that coValue are blocked from syncing
+- AND this restriction is enforced on both clients and servers

--- a/.specs/data-delete-flow/requirements.md
+++ b/.specs/data-delete-flow/requirements.md
@@ -34,7 +34,7 @@ This specification defines the requirements for a data deletion flow that allows
 - WHEN a delete operation is performed on a coValue
 - THEN an unencrypted (trusting) transaction is created
 - AND the transaction has meta `{ deleted: true }`
-- AND the transaction is created in a session named `{accountId}_deleted_{uniqueId}`
+- AND the transaction is created in a session named `{accountId}_session_z{uniqueId}_deleted`
 - AND the session naming works for all coValue types
 - AND the uniqueId ensures uniqueness across multiple delete operations
 

--- a/.specs/data-delete-flow/tasks.md
+++ b/.specs/data-delete-flow/tasks.md
@@ -1,0 +1,94 @@
+# Tasks: Data Delete Flow for CoValues
+
+Numbered checklist of **coding tasks** only. Each task references the relevant requirements in `requirements.md` (US-1…US-7).
+
+1. [ ] **Add admin-only delete API on CoValueCore** (Req: US-1)
+   - Implement `CoValueCore.deleteCoValue()` in `packages/cojson/src/coValueCore/coValueCore.ts`.
+   - Hard-block deletion for **Account** and **Group** coValues (throw).
+   - Enforce **admin-only** permissions (throw if not admin).
+
+2. [ ] **Create delete transaction with correct meta + session naming** (Req: US-2)
+   - Ensure delete creates an **unencrypted/trusting** transaction with `meta: { deleted: true }`.
+   - Generate a delete session ID with pattern `{accountId}_deleted_{uniqueId}` that is unique per delete.
+   - Ensure the mechanism works across all coValue types.
+
+3. [ ] **Allow overriding session ID for transaction creation (delete sessions)** (Req: US-2)
+   - Update `makeTransaction(...)` in `packages/cojson/src/coValueCore/coValueCore.ts` to accept an optional `sessionID?: SessionID`.
+   - Ensure delete uses the delete session ID and cannot accidentally fall back to the regular session.
+
+4. [ ] **Detect delete transactions and validate delete permissions during ingestion** (Req: US-3)
+   - In `packages/cojson/src/coValueCore/coValueCore.ts` (`tryAddTransactions` and/or the validity pipeline), detect delete transactions via:
+     - session ID containing `_deleted_`, and
+     - trusting tx with `meta.deleted === true`.
+   - When not `skipVerify`, verify the delete author has **admin** permissions on the coValue.
+   - Reject invalid delete transactions (non-admin) with an explicit error result.
+
+5. [ ] **Track “deleted” state on CoValueCore and surface it for sync decisions** (Req: US-4, US-7)
+   - Add and wire `isDeleted: boolean` and `deleteSessionID?: SessionID` on `CoValueCore` (and any necessary persistence/derivation via `verifiedState`).
+   - Mark the coValue as deleted when a valid delete transaction is accepted.
+
+6. [ ] **Client-side immediate sync blocking: only allow delete session/tx to sync** (Req: US-4, US-7)
+   - In sync logic (per design: `packages/cojson/src/sync.ts`), ensure that once `isDeleted` is true:
+     - inbound `content` ignores any non-delete sessions/transactions
+     - outbound sync only uploads the delete session/transaction (tombstone) for that coValue
+     - historical content is blocked from syncing immediately
+
+7. [ ] **Implement “poisoned knownState” quenching for deleted coValues** (Req: US-4, US-7)
+   - In `load` handling, when local coValue is deleted:
+     - respond with `deleteSessionID` counter, and
+     - poison counters for other sessions present in the requester’s `msg.sessions` to stop repeated uploads of historical content.
+   - Ensure this remains wire-compatible with existing `load/known/content/done` shapes.
+
+8. [ ] **Update `waitForSync` semantics for deleted coValues** (Req: US-7)
+   - Once a delete session exists, `waitForSync()` must wait only for:
+     - tombstone/header as applicable, and
+     - the delete session counter to be uploaded/stored.
+   - Ensure it does **not** wait for historical sessions for deleted values.
+
+9. [ ] **Persist “deleted coValue” marker in storage when delete tx is stored** (Req: US-3, US-6)
+   - Extend DB client interfaces in `packages/cojson/src/storage/types.ts`:
+     - `markCoValueAsDeleted(...)`
+     - `getAllDeletedCoValueIDs(...)`
+   - Wire these calls into the normal storage path when a delete transaction is committed/stored.
+   - Ensure storage shards (`skipVerify: true`) still persist the deleted marker and tombstone without doing permission verification.
+
+10. [ ] **Expose batch erase API for physically deleting deleted coValues (preserve tombstones)** (Req: US-5, US-6)
+   - Add a storage API method (per design) in:
+     - `packages/cojson/src/storage/storageSync.ts`
+     - `packages/cojson/src/storage/storageAsync.ts`
+   - Implementation should:
+     - enumerate deleted IDs via `getAllDeletedCoValueIDs()`
+     - perform physical deletion per coValue while preserving tombstone (delete tx + header).
+
+11. [ ] **Implement physical deletion primitive that preserves tombstone** (Req: US-5, US-6)
+   - Add/extend storage deletion functions to remove:
+     - all non-delete sessions and their transactions
+   - Preserve:
+     - header
+     - delete session + delete transaction
+   - Ensure post-delete sync behavior still advertises/serves the tombstone but never historical content.
+
+12. [ ] **Implement “get all deleted IDs” efficiently in DB drivers/implementations** (Req: US-3, US-6)
+   - Add driver-level support where appropriate (per design section 9), e.g. sqlite driver types + query.
+   - Implement for each relevant storage backend in-repo (sqlite/indexeddb/etc.), keeping interface parity between sync + async DB clients.
+
+13. [ ] **Add unit + integration tests for the full delete flow** (Req: US-1, US-2, US-3, US-4, US-5, US-6, US-7)
+   - `deleteCoValue()`:
+     - rejects Account/Group deletion
+     - rejects non-admin
+     - produces trusting tx with `{ deleted: true }` in `{accountId}_deleted_{uniqueId}` session
+   - Transaction ingestion:
+     - accepts valid admin delete
+     - rejects non-admin delete (when verifying)
+     - sets `isDeleted/deleteSessionID`
+   - Sync behavior:
+     - blocks non-delete sessions immediately
+     - accepts/syncs delete session only
+     - quenching via poisoned knownState works against peers sending historical sessions
+     - `waitForSync` completes based on delete session only
+   - Storage behavior:
+     - deleted marker persisted
+     - batch erase removes content but preserves tombstone
+     - storage shard (`skipVerify`) keeps tombstone + deleted marker
+
+


### PR DESCRIPTION
## Overview

Spec for a data deletion flow for coValues with immediate sync blocking and scheduled physical deletion. Deleted coValues leave tombstones sessions that prevent data resurrection.

## Key Design Choices

**Important Constraint**: Account and Group coValues cannot be deleted, otherwise we might not be able to verify the delete transactions.

- **Admin-only deletion**: Only admins can delete coValues, validated in `determineValidTransactions()`
- **Special delete session**: Uses `{accountId}_deleted_{uniqueId}` session naming to sync delete markers without carrying extra data or history
- **Unencrypted transactions**: Delete transactions are trusting (unencrypted) with meta `{ deleted: true }`
- **Immediate sync blocking**: Deleted coValues block all sync immediately, only delete session/transaction can sync
- **Storage API batch deletion**: `ereaseAllDeletedCoValues()` performs physical deletion while preserving tombstones
- **Tombstone preservation**: Delete session + coValue header preserved even after physical deletion
- **Storage shard support**: Shards with `skipVerify: true` mark as deleted and block sync without verification

Documents preview:
- Requirements https://github.com/garden-co/jazz/blob/spec/delete-coValues/.specs/data-delete-flow/requirements.md
- Design https://github.com/garden-co/jazz/blob/spec/delete-coValues/.specs/data-delete-flow/design.md