### PR TITLE
fix: page size 16KB android

### DIFF
--- a/.changeset/support-flexible-page-sizes-android.md
+++ b/.changeset/support-flexible-page-sizes-android.md
@@ -1,0 +1,5 @@
+---
+"cojson-core-rn": patch
+---
+
+Enabled flexible page-size support for Android builds, enabling support for 16KB page sizes to ensure compatibility with upcoming Android hardware and Google Play requirements for cojson-core-rn.

--- a/crates/cojson-core-rn/android/build.gradle
+++ b/crates/cojson-core-rn/android/build.gradle
@@ -74,7 +74,7 @@ android {
     }
     externalNativeBuild {
       cmake {
-        arguments '-DANDROID_STL=c++_shared'
+        arguments '-DANDROID_STL=c++_shared', '-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON'
         abiFilters (*reactNativeArchitectures())
       }
     }

--- a/crates/cojson-core-rn/ubrn.config.yaml
+++ b/crates/cojson-core-rn/ubrn.config.yaml
@@ -2,3 +2,8 @@
 rust:
   directory: .
   manifestPath: rust/Cargo.toml
+
+# This has been made to allow compilation with -DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON
+# Once the new Uniffi version 0.30.0, which supports this flag, is released, we will be able to remove it.
+noOverwrite:
+  - "android/build.gradle"


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed -->
<!-- Please also include relevant motivation and context -->
<!-- Include any links to documentation like RFC’s if necessary -->
<!-- Add a link to to relevant preview environments or anything that would simplify visual review process -->
<!-- Supplemental screenshots and video are encouraged, but the primary description should be in text -->

This PR enables support for 16KB page sizes to ensure compatibility with upcoming Android hardware and Google Play requirements for our native modules.


## Manual testing instructions

<!-- Add any actions required to manually test the changes -->

## Tests

- [ ] Tests have been added and/or updated
- [ ] Tests have not been updated, because: <!-- Insert reason for not updating tests here -->
- [ ] I need help with writing tests


## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [ ] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing