### PR TITLE
docs: spec for covalue resurrection

### DIFF
--- a/.specs/deleted-covalues-resurrection/design.md
+++ b/.specs/deleted-covalues-resurrection/design.md
@@ -1,0 +1,281 @@
+# Design: Deleted coValues resurrection
+
+## Overview
+
+This design adds **resurrection** as a new lifecycle phase for coValues.
+
+Resurrection lets users bring a deleted coValue back **without restoring old data**. Practically, this means:
+
+- we keep the coValue **header** (type + ownership metadata),
+- we keep lifecycle event markers (delete / resurrection),
+- but we treat the content history as partitioned into “lives”, and only the **active life** is considered when loading/syncing/applying updates.
+
+This design layers on top of `.specs/data-delete-flow` and reuses its key rollout strategy:
+
+- no new wire message types (`load`, `known`, `content`, `done` stay unchanged),
+- mixed-version safety by **ignoring** disallowed sessions,
+- and “quenching” via a known-state merge response to stop older peers from retrying forever.
+
+## Goals
+
+- Allow an admin to resurrect a deleted coValue while starting from an explicitly new life.
+- Make the “new life” easily identifiable in sync + storage by **session ID suffixes**.
+- Avoid storing/processing lots of irrelevant history uploaded by mixed-version peers.
+- Keep deterministic convergence when there are competing delete/resurrection events.
+
+## Non-goals
+
+- Restoring old data (“undelete with history”).
+- Resurrecting Account/Group coValues.
+- Adding protocol version negotiation.
+
+## Key design choices
+
+### 1) Lifecycle events are stackable
+
+Delete and resurrection are modeled as **events** that can happen multiple times. Peers may see them in different orders due to offline work. We resolve conflicts deterministically (see “Lifecycle resolution”).
+
+### 2) Session filtering is the core mechanism
+
+To separate “this life” from “old life (should have been deleted)”, we accept updates only from sessions tagged with the **active resurrection ID**.
+
+Session IDs for the active life must be of the form:
+
+- `${BaseSessionID}_r${ResurrectionID}`
+
+This enables cheap suffix checks in hot sync/storage paths.
+
+### 3) Resurrection begins with a trusting marker (txIndex === 0)
+
+A resurrection starts with a **trusting** transaction that carries `meta.resurrectionId`.
+
+Constraints:
+
+- it must be the **first transaction of its session** (`txIndex === 0`),
+- and `meta.resurrectionId` must match the `ResurrectionID` encoded in the session ID.
+
+This makes resurrection explicit and verifiable, and lets peers reject malformed resurrection attempts early.
+
+### 4) Admin-at-time validation
+
+Resurrection is valid only if the author was **admin at the time of the transaction** (`tx.madeAt`), just like delete.
+
+Account and Group coValues are not resurrectable.
+
+## Data model
+
+### IDs and session shapes
+
+We introduce:
+
+- `ResurrectionID`: an opaque ID (random, collision-resistant; format TBD but must be session-safe).
+- `ResurrectionSessionID`: `${SessionID}_r${ResurrectionID}`
+
+Existing:
+
+- `SessionID`: `${RawAccountID | AgentID}_session_z${string}`
+- `DeletedSessionID`: `${SessionID}_deleted`
+
+### Transaction meta
+
+Delete marker (existing, extended):
+
+```ts
+type DeleteMeta = {
+  deleted: true;
+  // New: which life is being deleted.
+  // If omitted/undefined, it means the “base life” (no resurrection suffix).
+  deletedResurrectionIds?: ResurrectionID;[]
+};
+```
+
+Resurrection marker:
+
+```ts
+type ResurrectionMeta = {
+  resurrectionId: ResurrectionID;
+};
+```
+
+Notes:
+
+- Both markers are **trusting** transactions.
+- The resurrection marker must be the first tx in its session.
+- The delete marker remains “one tx in a dedicated delete session” as in `.specs/data-delete-flow`.
+
+## Lifecycle resolution
+
+Each coValue has a computed lifecycle state:
+
+- `Active(base)` (no resurrection yet)
+- `Active(resurrectionId = R)`
+- `Deleted(deletedResurrectionId = undefined | R)`
+
+We define a deterministic rule to pick the current state from a set of observed events.
+
+### Valid event definitions
+
+An event is considered for lifecycle resolution only if:
+
+- The coValue is not Account/Group.
+- The marker transaction is syntactically valid:
+  - delete: trusting + meta.deleted === true + in a `_deleted` session + only tx in that session
+  - resurrection: trusting + `meta.resurrectionId` + `txIndex === 0` + session ID suffix `_r${meta.resurrectionId}`
+- The author was admin at `tx.madeAt` (unless `skipVerify` mode, see below).
+
+### Ordering
+
+We order valid events by:
+
+1. `tx.madeAt` ascending
+2. tie-breaker: `sessionID` lexicographically ascending
+3. tie-breaker: `txIndex` ascending (should be 0 for resurrection markers; delete is always “single tx”)
+
+### Applying events
+
+Start state is `Active(base)`.
+
+Apply events in order:
+
+- **Resurrection marker** with id `R`:
+  - sets state to `Active(resurrectionId = R)`
+- **Delete marker**:
+  - sets state to `Deleted(deletedResurrectionId = deletedResurrectionIdFromMetaOrCurrentState)`
+  - where `deletedResurrectionIdFromMetaOrCurrentState` is:
+    - `meta.deletedResurrectionId` if present
+    - otherwise “the resurrection id that was active when this delete was authored” (best-effort; for deterministic replay we recommend always writing it in meta)
+
+Final lifecycle state is the result after all events.
+
+## Sync + ingestion behavior
+
+The key rule is: **apply content only from allowed sessions**, but still allow lifecycle markers to arrive even when content is currently blocked.
+
+### Session classification helpers
+
+We treat sessions as:
+
+- **Delete sessions**: `sessionID.endsWith("_deleted")`
+- **Resurrection-tagged sessions**: `sessionID.includes("_r")` and ends with `_r${someResurrectionId}` (exact parsing helper)
+- **Base sessions**: everything else
+
+### Inbound `content` filtering
+
+When receiving a `content` message for a coValue:
+
+1. Always accept header if needed (header is required to validate permissions).
+2. Always consider delete sessions for ingestion (as in delete design).
+3. Consider resurrection markers:
+   - If a session looks like a resurrection-tagged session, we only accept `txIndex === 0` unless the session’s resurrection id is currently active.
+   - After ingesting a valid marker, recompute lifecycle resolution (it can flip from deleted → active).
+4. After lifecycle state is known:
+   - If state is `Deleted(...)`:
+     - accept only delete sessions and (potential) resurrection marker tx0.
+     - ignore all base sessions and all resurrection-tagged sessions except marker tx0.
+   - If state is `Active(base)`:
+     - accept base sessions
+     - accept delete sessions
+     - ignore resurrection-tagged sessions (unless they contain a valid marker tx0; marker ingestion is allowed to discover a newer resurrection event)
+   - If state is `Active(resurrectionId = R)`:
+     - accept delete sessions
+     - accept resurrection-tagged sessions **only** if they end with `_rR`
+     - ignore base sessions and any other resurrection-tagged sessions
+
+### Outbound known-state + quenching
+
+When we ignore sessions offered by a peer (because they’re not allowed by the current lifecycle state), older peers may retry indefinitely.
+
+We use the same quenching strategy as delete:
+
+- When we detect we are intentionally ignoring sessions, respond with a `known` message that merges our current knownState with the peer’s knownState sessions (“make them believe we already have it”).
+
+This should be used for:
+
+- `Deleted(...)` state (already implemented for delete)
+- `Active(resurrectionId = R)` where base sessions / non-matching resurrection sessions are ignored
+
+## Storage behavior
+
+### Storage must not “re-activate” ignored sessions
+
+Storage should follow the same acceptance rules as sync ingestion:
+
+- store and serve only sessions that would be accepted for the current lifecycle state,
+- plus lifecycle marker sessions needed for lifecycle resolution.
+
+This prevents older peers from flooding storage with irrelevant sessions.
+
+### Physical erasure (“space reclamation”) must be life-aware
+
+The existing delete erasure primitive deletes everything except the tombstone delete session(s).
+
+With resurrection, erasure must be more precise:
+
+- If the coValue is currently `Deleted(deletedResurrectionId = undefined)` (“base life deleted”):
+  - erase **base sessions only**
+  - keep delete sessions (`*_deleted`)
+  - keep all resurrection-tagged sessions (`*_r<...>`) (future or past resurrections must not be erased)
+- If the coValue is currently `Deleted(deletedResurrectionId = R)` (“resurrection life R deleted”):
+  - erase only sessions tagged with `_rR`
+  - keep delete sessions
+  - keep base sessions and other resurrection-tagged sessions (they belong to other lives)
+
+To make this safe and deterministic across peers, delete markers should include `meta.deletedResurrectionId` whenever the active life is a resurrection life.
+
+## Skip-verify environments
+
+Some storage shards run with `skipVerify: true` and do not verify permissions.
+
+For resurrection:
+
+- In skip-verify mode, shards may store lifecycle markers without validation.
+- Higher-trust nodes (clients/servers that verify) must still enforce admin-at-time validation when deciding lifecycle state and when serving/syncing.
+
+## Error handling / edge cases
+
+### Invalid resurrection marker
+
+Reject the marker (do not change lifecycle) if any of the following holds:
+
+- not trusting
+- missing `meta.resurrectionId`
+- `txIndex !== 0`
+- session suffix resurrection id doesn’t match `meta.resurrectionId`
+- author not admin at `tx.madeAt`
+
+### Competing offline events
+
+Competing delete/resurrection events may exist (e.g. two admins resurrect while offline).
+
+Resolution is deterministic (“latest valid event wins”), but partially deleted storage can cause temporary inconsistent UX:
+
+- one peer may have already physically erased sessions that another peer still considers relevant,
+- the system may surface “deleted”/“active” inconsistently until all peers converge on the same event set.
+
+This is a known risk (see “Risks”).
+
+## Testing strategy
+
+Add tests that mirror the existing delete tests (see `sync.deleted.test.ts`) but with resurrection:
+
+- Admin can resurrect a deleted coValue; post-resurrection only `_rR` sessions are accepted.
+- Old base sessions are ignored after resurrection (including unknown-at-delete sessions).
+- Quenching: older peers stop retrying ignored sessions when we send merged knownState.
+- Competing events: two resurrections, latest valid wins deterministically.
+- Storage erasure:
+  - base-life deletion preserves resurrection-tagged sessions
+  - deletion of resurrection life `R` erases only `_rR` sessions
+
+## Rollout notes
+
+- Avoid wire protocol changes.
+- Keep suffix checks cheap and on hot paths (`sync.ts`, storage adapters).
+- Ensure older peers do not get stuck: quench whenever we intentionally ignore sessions.
+
+## Risks
+
+- **Offline conflicts**: deterministic, but can surprise users if two admins resurrect/delete offline.
+- **Partial physical deletion**: may produce inconsistent statuses until systems re-sync and converge.
+- **Mixed-version flooding**: mitigated by suffix filtering + quenching, but still requires careful performance testing on noisy peers.
+
+

--- a/.specs/deleted-covalues-resurrection/requirements.md
+++ b/.specs/deleted-covalues-resurrection/requirements.md
@@ -1,0 +1,97 @@
+# Requirements: Deleted coValues resurrection
+
+## Introduction
+
+We already support deleting coValues (see `.specs/data-delete-flow`). Deletion blocks sync of historical content and leaves a tombstone.
+
+This spec adds a new lifecycle phase: **resurrection**.
+
+Resurrection lets users bring a deleted coValue back **without restoring old data**. Instead, resurrection starts a new “life” from an explicit **init/reset transaction**. Anything from before that resurrection must stay ignored (even if older peers keep trying to upload it).
+
+Key constraints:
+
+- Delete and resurrection are **stackable events** (multiple deletes/resurrections may exist).
+- Delete and resurrection events must be created in **dedicated sessions** so they can be cheaply identified.
+- Updates are accepted only from sessions tagged with the **active resurrection ID** (suffix check is enough).
+- Resurrection is valid only if the author was **admin at the time of the transaction**.
+- Account and Group coValues are **not resurrectable**.
+
+## User stories + acceptance criteria (EARS)
+
+### US1 — Admin-only resurrection API
+
+As a developer, I want an explicit API to resurrect a deleted coValue so users can bring it back intentionally.
+
+- **AC1.1 (When/Then)**: When code calls `coValue.$jazz.raw.core.resurrectCoValue(...)`, then the method checks that the coValue is not an Account or Group coValue.
+- **AC1.2 (If/Then)**: If the coValue is an Account or Group coValue, then the method throws an error.
+- **AC1.3 (When/Then)**: When code calls `resurrectCoValue(...)`, then the method checks that the current account has admin permissions on the coValue.
+- **AC1.4 (If/Then)**: If the current account is not an admin, then the method throws an error.
+- **AC1.5 (When/Then)**: When `resurrectCoValue(...)` succeeds, then it creates a resurrection init/reset transaction as described in US3–US4.
+
+### US2 — Dedicated sessions for delete + resurrection events
+
+As the system, I want delete and resurrection to be modeled as dedicated-session events so peers can filter cheaply and deterministically.
+
+- **AC2.1 (When/Then)**: When a delete operation is performed, then the delete marker transaction is created in a dedicated delete session (as defined in `.specs/data-delete-flow`).
+- **AC2.2 (When/Then)**: When a resurrection is performed, then the resurrection init/reset transaction is created in a dedicated resurrection session of the form `${BaseSessionID}_r${ResurrectionID}`.
+- **AC2.3 (While)**: While syncing / storing content, the implementation can decide whether a session is “resurrection-scoped” using a cheap suffix check (no JSON parsing required for the common case).
+
+### US3 — Resurrection init/reset marker semantics
+
+As the system, I want resurrection to begin with a single trusting init/reset marker so a new life is explicit and can be validated.
+
+- **AC3.1 (When/Then)**: When a resurrection starts, then the first transaction in the resurrection session has `privacy: "trusting"` and includes `meta.resurrectionId` equal to the session’s `ResurrectionID`.
+- **AC3.2 (When/Then)**: When ingesting a resurrection session, then the transaction that carries `meta.resurrectionId` must be the first transaction in the session (`txIndex === 0`), otherwise the resurrection marker is invalid.
+- **AC3.3 (While)**: While processing transactions, resurrection marker detection must not require parsing meta for non-resurrection sessions.
+- **AC3.4 (When/Then)**: When a valid resurrection marker is accepted, then the coValue is considered “resurrected” and eligible to accept non-marker updates only from sessions allowed by US4.
+
+### US4 — Session filtering: accept only sessions for the active resurrection
+
+As the system, I want to accept updates only from sessions tagged with the active resurrection ID so old sessions stay ignored forever (even if discovered later).
+
+- **AC4.1 (When/Then)**: When a coValue is in a resurrected state with active `ResurrectionID = R`, then the system accepts new transactions only from:
+  - the current active resurrection session(s) tagged with `_rR`, and
+  - any other session types explicitly allowed by the protocol (e.g. future lifecycle events).
+- **AC4.2 (When/Then)**: When the system receives content for a session whose ID does not match the active resurrection suffix `_rR`, then it ignores that session’s content (it must not be applied, stored, or forwarded).
+- **AC4.3 (While)**: While interacting with mixed-version peers, this filtering must be sufficient to prevent uploading/storing lots of irrelevant history.
+
+### US5 — Admin-at-time validation for resurrection
+
+As the system, I want resurrection to be valid only if the author was admin at the time the resurrection marker was written so offline peers can’t resurrect with stale permissions.
+
+- **AC5.1 (When/Then)**: When ingesting a resurrection marker transaction, then the system validates that the author had admin permissions on the coValue at `tx.madeAt`.
+- **AC5.2 (If/Then)**: If admin-at-time validation fails, then the resurrection marker is rejected and must not change the coValue lifecycle state.
+- **AC5.3 (While)**: While running in `skipVerify: true` storage environments, the system may store the marker without validation, but higher-trust components must still enforce the validation semantics when serving/syncing.
+
+### US6 — Deterministic lifecycle resolution with competing deletes/resurrections
+
+As the system, I want a deterministic rule for resolving competing events (offline conflicts) so all peers converge.
+
+- **AC6.1 (When/Then)**: When multiple delete/resurrection events exist, then the active lifecycle phase is determined by ordering the **valid** events and taking the latest applicable one (“latest valid event wins”).
+- **AC6.2 (If/Then)**: If an event is invalid (e.g. non-admin-at-time resurrection), then it is ignored for lifecycle resolution.
+- **AC6.3 (While)**: While lifecycle resolution is deterministic, the system may temporarily surface inconsistent statuses if storage erasure partially removed content; this must be documented as a known risk.
+
+### US7 — Mixed-version safety + quenching
+
+As the system, I want mixed-version peers to stop endlessly trying to upload sessions that are ignored by resurrection filtering.
+
+- **AC7.1 (When/Then)**: When a peer offers content for sessions that are not allowed by US4, then the receiver ignores them.
+- **AC7.2 (When/Then)**: When interacting with older peers that keep retrying, then the receiver replies with a “quenching” known-state response that makes the sender believe the receiver already has the sender’s known sessions (even if they are intentionally ignored).
+- **AC7.3 (While)**: While rolling out, this must work without introducing new wire message types.
+
+### US8 — Storage safety: deletions must be able to erase only deleted sessions
+
+As the system, I want deletes to be able to erase only sessions that are actually part of the deleted life, without accidentally erasing the new life.
+
+- **AC8.1 (When/Then)**: When creating a delete marker, then it includes enough information about **known resurrections at the time of delete** to allow storage erasure to delete only the sessions belonging to the deleted life.
+- **AC8.2 (When/Then)**: When performing physical deletion/erasure for a deleted coValue, then storage deletes only sessions belonging to the deleted life and preserves tombstone(s) and any resurrected-life sessions.
+- **AC8.3 (While)**: While older peers may upload sessions not known at delete time, the filtering rules (US4, US7) must prevent these sessions from reappearing as “live” content.
+
+## Out of scope (for this feature)
+
+- Restoring historical content from before a delete (“undelete with old data”).
+- Making resurrection available for Account/Group coValues.
+- Introducing new sync wire message types or protocol version negotiation.
+- Guaranteeing perfect UX under partial erasure + offline conflicts (we only require deterministic convergence rules).
+
+


### PR DESCRIPTION
### Short design summary (Deleted coValues resurrection)

This design adds **resurrection** as a new lifecycle phase for coValues: users can bring a deleted coValue back **without restoring old data**, starting a new “life” from an **explicit init/reset transaction**.

#### Key design choices

- **Resurrection transaction**: delete and resurrection are modeled as stackable events; Both need a specific named session, and resurrection sessions must contain a ResurrectionID
- **Session filtering**: updates are accepted only from sessions tagged with the active resurrection ID: `${SessionID}_r${ResurrectionID}`. This is required because we want to identify the sessions that are part of the new life VS the sessions that should have been deleted, including the ones not known at the time of the delete action. This enables cheap suffix checks in sync/storage paths (important with mixed-version peers that may upload lots of irrelevant history).
- **Resurrection marker + init**: resurrection starts with a **trusting** init/reset transaction that carries `meta.resurrectionId`. It **must be the first tx in its session (`txIndex === 0`)**.
- **Admin-at-time validation**: resurrection is valid only if the author was **admin at the time of the tx**. Account/Group coValues are **not resurrectable**.
- **Mixed-version safety + quenching**: peers ignore non-allowed sessions; a “quenching” known-state response prevents older peers from endlessly trying to re-upload ignored sessions.
- **Storage safety**: Delete operations should mention the resurrections known at the time of the delete, so the erease from storage can delete only the deleted sessions.

#### Main risks called out

- **Offline conflicts** can create competing resurrections/deletes; the design resolves deterministically by ordering (latest valid event wins), but might produce inconsistent statuses by partially deleting CoValue content.
- **Sessions ordering** an account might try to sync sessions that refer to a resurrection that have not been synced yet. We should try to nullify this risk, or provide an alternative solution to quenching when working with resurrected sessions

