### PR TITLE
Add Clerk support for Svelte

### DIFF
--- a/.changeset/svelte-clerk-auth.md
+++ b/.changeset/svelte-clerk-auth.md
@@ -1,5 +1,5 @@
 ---
-"jazz-tools": minor
+"jazz-tools": patch
 ---
 
 Add Clerk authentication support for Svelte with `useClerkAuth` hook and `JazzSvelteProviderWithClerk` component

--- a/.changeset/svelte-clerk-auth.md
+++ b/.changeset/svelte-clerk-auth.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": minor
+---
+
+Add Clerk authentication support for Svelte with `useClerkAuth` hook and `JazzSvelteProviderWithClerk` component

--- a/homepage/homepage/content/docs/code-snippets/key-features/authentication/clerk/AuthButton.svelte
+++ b/homepage/homepage/content/docs/code-snippets/key-features/authentication/clerk/AuthButton.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+  import { SignedIn, SignedOut, SignInButton, SignOutButton } from "svelte-clerk";
+</script>
+
+<SignedIn>
+  <SignOutButton />
+</SignedIn>
+<SignedOut>
+  <SignInButton />
+</SignedOut>

--- a/homepage/homepage/content/docs/code-snippets/key-features/authentication/clerk/JazzClerkWrapper.svelte
+++ b/homepage/homepage/content/docs/code-snippets/key-features/authentication/clerk/JazzClerkWrapper.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  import { useClerkContext } from "svelte-clerk";
+  import { JazzSvelteProviderWithClerk } from "jazz-tools/svelte";
+
+  const apiKey = "you@example.com";
+
+  const ctx = useClerkContext();
+  const clerk = $derived(ctx.clerk);
+
+  let { children } = $props();
+</script>
+
+<JazzSvelteProviderWithClerk
+  {clerk}
+  sync={{ peer: `wss://cloud.jazz.tools/?key=${apiKey}` }}
+>
+  {@render children?.()}
+</JazzSvelteProviderWithClerk>

--- a/homepage/homepage/content/docs/code-snippets/key-features/authentication/clerk/JazzClerkWrapper.svelte
+++ b/homepage/homepage/content/docs/code-snippets/key-features/authentication/clerk/JazzClerkWrapper.svelte
@@ -10,9 +10,14 @@
   let { children } = $props();
 </script>
 
+{#snippet loading()}
+  <p>Loading...</p>
+{/snippet}
+
 <JazzSvelteProviderWithClerk
   {clerk}
   sync={{ peer: `wss://cloud.jazz.tools/?key=${apiKey}` }}
+  fallback={loading}
 >
   {@render children?.()}
 </JazzSvelteProviderWithClerk>

--- a/homepage/homepage/content/docs/code-snippets/key-features/authentication/clerk/svelte.svelte
+++ b/homepage/homepage/content/docs/code-snippets/key-features/authentication/clerk/svelte.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  import { ClerkProvider } from "svelte-clerk";
+  // @ts-expect-error This is available in a real app.
+  import { PUBLIC_CLERK_PUBLISHABLE_KEY } from "$env/static/public";
+  import JazzClerkWrapper from "./JazzClerkWrapper.svelte";
+
+  let { children } = $props();
+</script>
+
+<ClerkProvider publishableKey={PUBLIC_CLERK_PUBLISHABLE_KEY}>
+  <JazzClerkWrapper>
+    {@render children?.()}
+  </JazzClerkWrapper>
+</ClerkProvider>

--- a/homepage/homepage/content/docs/code-snippets/key-features/authentication/clerk/svelte.svelte
+++ b/homepage/homepage/content/docs/code-snippets/key-features/authentication/clerk/svelte.svelte
@@ -2,7 +2,7 @@
   import { ClerkProvider } from "svelte-clerk";
   // @ts-expect-error This is available in a real app.
   import { PUBLIC_CLERK_PUBLISHABLE_KEY } from "$env/static/public";
-  import JazzClerkWrapper from "./JazzClerkWrapper.svelte";
+  import JazzClerkWrapper from "$lib/components/JazzClerkWrapper.svelte";
 
   let { children } = $props();
 </script>

--- a/homepage/homepage/content/docs/key-features/authentication/clerk.mdx
+++ b/homepage/homepage/content/docs/key-features/authentication/clerk.mdx
@@ -11,6 +11,7 @@ Jazz can be integrated with [Clerk](https://clerk.com/) to authenticate users. T
 ## How it works
 
 When using Clerk authentication:
+
 1. Users sign up or sign in through Clerk's authentication system
 2. Jazz securely stores the user's account keys with Clerk
 3. When logging in, Jazz retrieves these keys from Clerk
@@ -29,15 +30,31 @@ This authentication method is not fully local-first, as login and signup need to
 ## Implementation
 
 <ContentByFramework framework="react">
-Use `<JazzReactProviderWithClerk />` to wrap your app:
+  Use `<JazzReactProviderWithClerk />` to wrap your app:
 </ContentByFramework>
 
 <ContentByFramework framework="react-native-expo">
-Use `<JazzExpoProviderWithClerk />` to wrap your app.
+  Use `<JazzExpoProviderWithClerk />` to wrap your app.
 </ContentByFramework>
 
 <ContentByFramework framework="svelte">
-Wrap your app with `ClerkProvider` and a wrapper component that uses `<JazzSvelteProviderWithClerk />`:
+The Clerk provider for Svelte depends on the community package `svelte-clerk`. Install it first:
+
+<TabbedCodeGroup
+  id="install-svelte-clerk"
+  default="pnpm"
+  savedPreferenceKey="package-manager"
+>
+  <TabbedCodeGroupItem label="npm">
+    ```sh npm install svelte-clerk ```
+  </TabbedCodeGroupItem>
+  <TabbedCodeGroupItem label="pnpm">
+    ```sh pnpm add svelte-clerk ```
+  </TabbedCodeGroupItem>
+</TabbedCodeGroup>
+
+Then wrap your app with `ClerkProvider` and a wrapper component that uses `<JazzSvelteProviderWithClerk />`:
+
 </ContentByFramework>
 
 <ContentByFramework framework="react">

--- a/homepage/homepage/content/docs/key-features/authentication/clerk.mdx
+++ b/homepage/homepage/content/docs/key-features/authentication/clerk.mdx
@@ -37,7 +37,7 @@ Use `<JazzExpoProviderWithClerk />` to wrap your app.
 </ContentByFramework>
 
 <ContentByFramework framework="svelte">
-Use `<JazzSvelteProviderWithClerk />` to wrap your app:
+Wrap your app with `ClerkProvider` and a wrapper component that uses `<JazzSvelteProviderWithClerk />`:
 </ContentByFramework>
 
 <ContentByFramework framework="react">
@@ -62,10 +62,17 @@ Use `<JazzSvelteProviderWithClerk />` to wrap your app:
 <TabbedCodeGroupItem icon={<SvelteLogo />} label="Svelte" value="svelte" preferWrap>
 ```svelte svelte.svelte
 ```
-```svelte JazzClerkWrapper.svelte
-```
 </TabbedCodeGroupItem>
 </TabbedCodeGroup>
+
+<ContentByFramework framework="svelte">
+  <FileName>src/lib/components/JazzClerkWrapper.svelte</FileName>
+</ContentByFramework>
+
+<ContentByFramework framework="svelte">
+```svelte JazzClerkWrapper.svelte
+```
+</ContentByFramework>
 
 <ContentByFramework framework="react">
   <FileName>AuthButton.tsx</FileName>

--- a/homepage/homepage/content/docs/key-features/authentication/clerk.mdx
+++ b/homepage/homepage/content/docs/key-features/authentication/clerk.mdx
@@ -2,7 +2,7 @@ export const metadata = {
   description: "Integrate Clerk with your Jazz app to authenticate users. This method combines Clerk's comprehensive authentication services with Jazz's local-first capabilities."
 };
 
-import { CodeGroup, ContentByFramework, FileName, ReactLogo, ExpoLogo, RNLogo, TabbedCodeGroup, TabbedCodeGroupItem } from "@/components/forMdx";
+import { CodeGroup, ContentByFramework, FileName, ReactLogo, ExpoLogo, RNLogo, SvelteLogo, TabbedCodeGroup, TabbedCodeGroupItem } from "@/components/forMdx";
 
 # Clerk Authentication
 
@@ -36,7 +36,19 @@ Use `<JazzReactProviderWithClerk />` to wrap your app:
 Use `<JazzExpoProviderWithClerk />` to wrap your app.
 </ContentByFramework>
 
-<FileName>App.tsx</FileName>
+<ContentByFramework framework="svelte">
+Use `<JazzSvelteProviderWithClerk />` to wrap your app:
+</ContentByFramework>
+
+<ContentByFramework framework="react">
+  <FileName>App.tsx</FileName>
+</ContentByFramework>
+<ContentByFramework framework="react-native-expo">
+  <FileName>App.tsx</FileName>
+</ContentByFramework>
+<ContentByFramework framework="svelte">
+  <FileName>src/routes/+layout.svelte</FileName>
+</ContentByFramework>
 
 <TabbedCodeGroup default="react" savedPreferenceKey="framework" id="wrap-in-provider" className="mb-4">
 <TabbedCodeGroupItem icon={<ReactLogo />} label="React" value="react" preferWrap>
@@ -47,10 +59,25 @@ Use `<JazzExpoProviderWithClerk />` to wrap your app.
 ```tsx expo.tsx#Basic
 ```
 </TabbedCodeGroupItem>
+<TabbedCodeGroupItem icon={<SvelteLogo />} label="Svelte" value="svelte" preferWrap>
+```svelte svelte.svelte
+```
+```svelte JazzClerkWrapper.svelte
+```
+</TabbedCodeGroupItem>
 </TabbedCodeGroup>
 
-<FileName>AuthButton.tsx</FileName>
-<TabbedCodeGroup default="react" savedPreferenceKey="framework" id="wrap-in-provider" >
+<ContentByFramework framework="react">
+  <FileName>AuthButton.tsx</FileName>
+</ContentByFramework>
+<ContentByFramework framework="react-native-expo">
+  <FileName>AuthButton.tsx</FileName>
+</ContentByFramework>
+<ContentByFramework framework="svelte">
+  <FileName>src/lib/components/AuthButton.svelte</FileName>
+</ContentByFramework>
+
+<TabbedCodeGroup default="react" savedPreferenceKey="framework" id="auth-button" >
 <TabbedCodeGroupItem icon={<ReactLogo />} label="React" value="react" preferWrap>
 ```tsx react-snippet.tsx#AuthButton
 ```
@@ -58,6 +85,10 @@ Use `<JazzExpoProviderWithClerk />` to wrap your app.
 </TabbedCodeGroupItem>
 <TabbedCodeGroupItem icon={<ExpoLogo />} label="Expo" value="react-native-expo" preferWrap>
 ```tsx expo.tsx#AuthButton
+```
+</TabbedCodeGroupItem>
+<TabbedCodeGroupItem icon={<SvelteLogo />} label="Svelte" value="svelte" preferWrap>
+```svelte AuthButton.svelte
 ```
 </TabbedCodeGroupItem>
 </TabbedCodeGroup>

--- a/packages/jazz-tools/src/svelte/auth/ClerkAuth.svelte.ts
+++ b/packages/jazz-tools/src/svelte/auth/ClerkAuth.svelte.ts
@@ -1,0 +1,67 @@
+import { JazzClerkAuth, type MinimalClerkClient } from "jazz-tools";
+import { getAuthSecretStorage, getJazzContext } from "../jazz.svelte.js";
+import { useIsAuthenticated } from "./useIsAuthenticated.svelte.js";
+
+/**
+ * Authentication state returned by {@link useClerkAuth}.
+ *
+ * - `"anonymous"`: User is not authenticated with Jazz (may or may not be signed into Clerk)
+ * - `"signedIn"`: User is authenticated with both Clerk and Jazz
+ */
+export type ClerkAuth = {
+  state: "anonymous" | "signedIn";
+};
+
+/**
+ * Registers a Clerk authentication listener and provides reactive auth state.
+ *
+ * Must be used within a component that is a child of `JazzSvelteProvider`.
+ * Automatically syncs Clerk authentication state with Jazz.
+ *
+ * @example
+ * ```svelte
+ * <script>
+ *   import { useClerkAuth } from "jazz-tools/svelte";
+ *
+ *   const auth = useClerkAuth(clerk);
+ * </script>
+ *
+ * {#if auth.state === "signedIn"}
+ *   <p>Welcome back!</p>
+ * {:else}
+ *   <p>Please sign in</p>
+ * {/if}
+ * ```
+ *
+ * @param clerk - The Clerk client instance
+ * @returns An object with a reactive `state` property
+ * @throws Error if used in guest mode
+ * @category Auth Providers
+ */
+export function useClerkAuth(clerk: MinimalClerkClient): ClerkAuth {
+  const context = getJazzContext();
+  const authSecretStorage = getAuthSecretStorage();
+
+  if ("guest" in context.current) {
+    throw new Error("Clerk auth is not supported in guest mode");
+  }
+
+  const authMethod = new JazzClerkAuth(
+    context.current.authenticate,
+    context.current.logOut,
+    authSecretStorage,
+  );
+
+  $effect(() => {
+    return authMethod.registerListener(clerk);
+  });
+
+  const isAuthenticated = useIsAuthenticated();
+  const state = $derived(isAuthenticated.current ? "signedIn" : "anonymous");
+
+  return {
+    get state() {
+      return state;
+    },
+  };
+}

--- a/packages/jazz-tools/src/svelte/auth/JazzSvelteProviderWithClerk.svelte
+++ b/packages/jazz-tools/src/svelte/auth/JazzSvelteProviderWithClerk.svelte
@@ -46,8 +46,8 @@
   import RegisterClerkAuth from "./RegisterClerkAuth.svelte";
 
   type Props = {
-    /** The Clerk client instance for authentication */
-    clerk: MinimalClerkClient;
+    /** The Clerk client instance for authentication (can be null while Clerk is initializing) */
+    clerk: MinimalClerkClient | null;
     /** Content to render when provider is initialized */
     children?: Snippet;
     /** Content to render while Clerk auth is loading */
@@ -106,6 +106,8 @@
   $effect(() => {
     setupKvStore();
 
+    if (!clerk) return;
+
     let cancelled = false;
 
     JazzClerkAuth.initializeAuth(clerk)
@@ -143,7 +145,7 @@
       later.
     </div>
   {/if}
-{:else if isLoaded}
+{:else if isLoaded && clerk}
   <JazzSvelteProvider {...providerProps} onLogOut={clerk.signOut}>
     <RegisterClerkAuth {clerk}>
       {@render children?.()}

--- a/packages/jazz-tools/src/svelte/auth/JazzSvelteProviderWithClerk.svelte
+++ b/packages/jazz-tools/src/svelte/auth/JazzSvelteProviderWithClerk.svelte
@@ -11,7 +11,7 @@
   @example
   ```svelte
   <JazzSvelteProviderWithClerk
-    clerk={$clerk}
+    {clerk}
     sync={{ peer: "wss://cloud.jazz.tools/?key=your-key" }}
     AccountSchema={MyAccountSchema}
   >

--- a/packages/jazz-tools/src/svelte/auth/JazzSvelteProviderWithClerk.svelte
+++ b/packages/jazz-tools/src/svelte/auth/JazzSvelteProviderWithClerk.svelte
@@ -1,0 +1,154 @@
+<!--
+  @component
+  A pre-configured Jazz provider that integrates with Clerk authentication.
+
+  Use this component instead of `JazzSvelteProvider` when using Clerk for authentication.
+  It handles:
+  - Pre-loading Jazz credentials from Clerk before rendering children
+  - Registering Clerk auth state listeners
+  - Wiring up logout functionality to Clerk's signOut
+
+  @example
+  ```svelte
+  <JazzSvelteProviderWithClerk
+    clerk={$clerk}
+    sync={{ peer: "wss://cloud.jazz.tools/?key=your-key" }}
+    AccountSchema={MyAccountSchema}
+  >
+    <App />
+  </JazzSvelteProviderWithClerk>
+  ```
+
+  @category Auth Providers
+-->
+<script
+  lang="ts"
+  generics="S extends (AccountClass<Account> & CoValueFromRaw<Account>) | AnyAccountSchema"
+>
+  import {
+    Account,
+    type AccountClass,
+    type AnyAccountSchema,
+    type CoValueFromRaw,
+    InMemoryKVStore,
+    type InstanceOfSchema,
+    JazzClerkAuth,
+    KvStoreContext,
+    type MinimalClerkClient,
+    type SyncConfig,
+  } from "jazz-tools";
+  import {
+    type BaseBrowserContextOptions,
+    LocalStorageKVStore,
+  } from "jazz-tools/browser";
+  import type { Snippet } from "svelte";
+  import { JazzSvelteProvider } from "../jazz.svelte.js";
+  import RegisterClerkAuth from "./RegisterClerkAuth.svelte";
+
+  type Props = {
+    /** The Clerk client instance for authentication */
+    clerk: MinimalClerkClient;
+    /** Content to render when provider is initialized */
+    children?: Snippet;
+    /** Content to render while Clerk auth is loading */
+    fallback?: Snippet;
+    /** Content to render when authentication initialization fails */
+    errorFallback?: Snippet<[Error]>;
+    /** Callback when authentication initialization fails */
+    onAuthError?: (error: Error) => void;
+    /** Enable server-side rendering support with anonymous fallback */
+    enableSSR?: boolean;
+    /** Custom key for storing auth secrets in KvStore */
+    authSecretStorageKey?: string;
+    /** Jazz sync configuration (peer URL and key) */
+    sync: SyncConfig;
+    /** Custom storage implementation for auth secrets */
+    storage?: BaseBrowserContextOptions["storage"];
+    /** Account schema class for typed account access */
+    AccountSchema?: S;
+    /** Default profile name for new accounts */
+    defaultProfileName?: string;
+    /** Callback when an anonymous account is discarded during sign-in */
+    onAnonymousAccountDiscarded?: (
+      anonymousAccount: InstanceOfSchema<S>,
+    ) => Promise<void>;
+  };
+
+  let {
+    clerk,
+    children,
+    fallback,
+    errorFallback,
+    onAuthError,
+    ...providerProps
+  }: Props = $props();
+
+  let isLoaded = $state(false);
+  let initError = $state<Error | null>(null);
+
+  function setupKvStore() {
+    const isSSR = typeof window === "undefined";
+    if (isSSR) {
+      console.debug("[Jazz] Using InMemoryKVStore for SSR context");
+    }
+    KvStoreContext.getInstance().initialize(
+      isSSR ? new InMemoryKVStore() : new LocalStorageKVStore(),
+    );
+  }
+
+  /**
+   * Pre-loads Jazz authentication data from Clerk before mounting JazzSvelteProvider.
+   *
+   * For authenticated Clerk users with existing Jazz credentials, this populates the auth
+   * secret storage before rendering children, avoiding a flash of unauthenticated state.
+   * For unauthenticated users, the initialization completes immediately with no effect.
+   */
+  $effect(() => {
+    setupKvStore();
+
+    let cancelled = false;
+
+    JazzClerkAuth.initializeAuth(clerk)
+      .then(() => {
+        if (!cancelled) {
+          isLoaded = true;
+          initError = null;
+        }
+      })
+      .catch((error) => {
+        console.error(
+          "[Jazz] Clerk authentication initialization failed:",
+          error,
+        );
+        if (!cancelled) {
+          const errorObj =
+            error instanceof Error ? error : new Error(String(error));
+          initError = errorObj;
+          onAuthError?.(errorObj);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  });
+</script>
+
+{#if initError}
+  {#if errorFallback}
+    {@render errorFallback(initError)}
+  {:else}
+    <div data-testid="jazz-clerk-auth-error">
+      Authentication initialization failed. Please refresh the page or try again
+      later.
+    </div>
+  {/if}
+{:else if isLoaded}
+  <JazzSvelteProvider {...providerProps} onLogOut={clerk.signOut}>
+    <RegisterClerkAuth {clerk}>
+      {@render children?.()}
+    </RegisterClerkAuth>
+  </JazzSvelteProvider>
+{:else if fallback}
+  {@render fallback?.()}
+{/if}

--- a/packages/jazz-tools/src/svelte/auth/RegisterClerkAuth.svelte
+++ b/packages/jazz-tools/src/svelte/auth/RegisterClerkAuth.svelte
@@ -1,0 +1,27 @@
+<!--
+  @component
+  Internal component that registers the Clerk auth listener.
+
+  This component exists because `useClerkAuth` requires access to the Jazz context,
+  which is only available inside `JazzSvelteProvider`'s children. By placing the
+  hook call in this child component, we ensure the context is properly initialized.
+-->
+<script lang="ts">
+  import type { MinimalClerkClient } from "jazz-tools";
+  import type { Snippet } from "svelte";
+  import { useClerkAuth } from "./ClerkAuth.svelte.js";
+
+  interface Props {
+    clerk: MinimalClerkClient;
+    children?: Snippet;
+  }
+
+  let { clerk, children }: Props = $props();
+
+  // Register the Clerk auth listener after JazzSvelteProvider context is available.
+  // The return value (auth state) is intentionally unused here - this component's
+  // sole purpose is to register the listener that syncs Clerk and Jazz auth state.
+  useClerkAuth(clerk);
+</script>
+
+{@render children?.()}

--- a/packages/jazz-tools/src/svelte/auth/index.ts
+++ b/packages/jazz-tools/src/svelte/auth/index.ts
@@ -1,3 +1,5 @@
 export * from "./PasskeyAuth.svelte.js";
 export * from "./PassphraseAuth.svelte.js";
+export * from "./ClerkAuth.svelte.js";
 export { default as PasskeyAuthBasicUI } from "./PasskeyAuthBasicUI.svelte";
+export { default as JazzSvelteProviderWithClerk } from "./JazzSvelteProviderWithClerk.svelte";

--- a/packages/jazz-tools/src/svelte/tests/ClerkAuth.svelte.test.ts
+++ b/packages/jazz-tools/src/svelte/tests/ClerkAuth.svelte.test.ts
@@ -1,0 +1,305 @@
+// @vitest-environment happy-dom
+
+import {
+  Account,
+  InMemoryKVStore,
+  JazzClerkAuth,
+  KvStoreContext,
+} from "jazz-tools";
+import type { MinimalClerkClient } from "jazz-tools";
+import { render as renderSvelte, waitFor } from "@testing-library/svelte";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createJazzTestAccount,
+  createJazzTestGuest,
+  setupJazzTestSync,
+} from "../testing";
+import { render, screen } from "./testUtils";
+import TestClerkAuthWrapper from "./TestClerkAuthWrapper.svelte";
+import JazzSvelteProviderWithClerk from "../auth/JazzSvelteProviderWithClerk.svelte";
+
+KvStoreContext.getInstance().initialize(new InMemoryKVStore());
+
+function createMockClerkClient(
+  user: MinimalClerkClient["user"] = null,
+): MinimalClerkClient {
+  return {
+    user,
+    signOut: vi.fn(),
+    addListener: vi.fn(() => () => {}),
+  };
+}
+
+describe("useClerkAuth", () => {
+  let account: Account;
+
+  beforeEach(async () => {
+    await setupJazzTestSync();
+    account = await createJazzTestAccount({
+      isCurrentActiveAccount: true,
+    });
+  });
+
+  it("should return anonymous state when not authenticated", async () => {
+    const mockClerk = createMockClerkClient();
+
+    render(
+      TestClerkAuthWrapper,
+      { clerk: mockClerk },
+      { account, isAuthenticated: false },
+    );
+
+    expect(screen.getByTestId("auth-state").textContent).toBe("anonymous");
+  });
+
+  it("should return signedIn state when authenticated", async () => {
+    const mockClerk = createMockClerkClient({
+      id: "user_123",
+      fullName: "Test User",
+      username: "testuser",
+      firstName: "Test",
+      lastName: "User",
+      primaryEmailAddress: { emailAddress: "test@example.com" },
+      unsafeMetadata: {
+        jazzAccountID: "test123",
+        jazzAccountSecret: "secret123",
+      },
+      update: vi.fn(),
+    });
+
+    render(
+      TestClerkAuthWrapper,
+      { clerk: mockClerk },
+      { account, isAuthenticated: true },
+    );
+
+    expect(screen.getByTestId("auth-state").textContent).toBe("signedIn");
+  });
+
+  it("should register the clerk listener", async () => {
+    const mockClerk = createMockClerkClient();
+
+    render(
+      TestClerkAuthWrapper,
+      { clerk: mockClerk },
+      { account, isAuthenticated: false },
+    );
+
+    expect(mockClerk.addListener).toHaveBeenCalled();
+  });
+
+  it("should cleanup listener on unmount", async () => {
+    const mockUnsubscribe = vi.fn();
+    const mockClerk = createMockClerkClient();
+    mockClerk.addListener = vi.fn(() => mockUnsubscribe);
+
+    const { unmount } = render(
+      TestClerkAuthWrapper,
+      { clerk: mockClerk },
+      { account, isAuthenticated: false },
+    );
+
+    expect(mockClerk.addListener).toHaveBeenCalled();
+    unmount();
+    expect(mockUnsubscribe).toHaveBeenCalled();
+  });
+
+  it("should throw error in guest mode", async () => {
+    const guest = await createJazzTestGuest();
+    const mockClerk = createMockClerkClient();
+
+    expect(() => {
+      render(TestClerkAuthWrapper, { clerk: mockClerk }, { account: guest });
+    }).toThrow("Clerk auth is not supported in guest mode");
+  });
+
+  it("should call listener with clerk client events", async () => {
+    const mockClerk = createMockClerkClient();
+    let listenerCallback: ((data: unknown) => void) | undefined;
+    mockClerk.addListener = vi.fn((callback) => {
+      listenerCallback = callback;
+      return () => {};
+    });
+
+    render(
+      TestClerkAuthWrapper,
+      { clerk: mockClerk },
+      { account, isAuthenticated: false },
+    );
+
+    expect(mockClerk.addListener).toHaveBeenCalled();
+    expect(listenerCallback).toBeDefined();
+  });
+});
+
+describe("JazzClerkAuth.initializeAuth", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should handle initialization errors gracefully", async () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const initializeAuthSpy = vi
+      .spyOn(JazzClerkAuth, "initializeAuth")
+      .mockRejectedValue(new Error("Test error"));
+
+    const mockClerk = createMockClerkClient();
+
+    // The error should be thrown by the mock
+    await expect(JazzClerkAuth.initializeAuth(mockClerk)).rejects.toThrow(
+      "Test error",
+    );
+
+    // Restore using vitest's cleanup
+    initializeAuthSpy.mockRestore();
+    consoleSpy.mockRestore();
+  });
+});
+
+describe("JazzSvelteProviderWithClerk", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should render children after successful initialization", async () => {
+    const mockClerk = createMockClerkClient();
+    vi.spyOn(JazzClerkAuth, "initializeAuth").mockResolvedValue(undefined);
+
+    const { container } = renderSvelte(JazzSvelteProviderWithClerk, {
+      props: {
+        clerk: mockClerk,
+        sync: { peer: "wss://test.example.com" },
+      },
+    });
+
+    await waitFor(() => {
+      // After initialization, the provider should render (even without children)
+      // The error div should not be present
+      expect(
+        container.querySelector('[data-testid="jazz-clerk-auth-error"]'),
+      ).toBeNull();
+    });
+  });
+
+  it("should show default error message when initialization fails", async () => {
+    const mockClerk = createMockClerkClient();
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(JazzClerkAuth, "initializeAuth").mockRejectedValue(
+      new Error("Init failed"),
+    );
+
+    const { container } = renderSvelte(JazzSvelteProviderWithClerk, {
+      props: {
+        clerk: mockClerk,
+        sync: { peer: "wss://test.example.com" },
+      },
+    });
+
+    await waitFor(() => {
+      const errorDiv = container.querySelector(
+        '[data-testid="jazz-clerk-auth-error"]',
+      );
+      expect(errorDiv).not.toBeNull();
+      expect(errorDiv?.textContent).toContain(
+        "Authentication initialization failed",
+      );
+    });
+
+    consoleSpy.mockRestore();
+  });
+
+  it("should call onAuthError callback when initialization fails", async () => {
+    const mockClerk = createMockClerkClient();
+    const onAuthError = vi.fn();
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(JazzClerkAuth, "initializeAuth").mockRejectedValue(
+      new Error("Init failed"),
+    );
+
+    renderSvelte(JazzSvelteProviderWithClerk, {
+      props: {
+        clerk: mockClerk,
+        sync: { peer: "wss://test.example.com" },
+        onAuthError,
+      },
+    });
+
+    await waitFor(() => {
+      expect(onAuthError).toHaveBeenCalledWith(expect.any(Error));
+      expect(onAuthError).toHaveBeenCalledWith(
+        expect.objectContaining({ message: "Init failed" }),
+      );
+    });
+
+    consoleSpy.mockRestore();
+  });
+
+  it("should not update state after unmount (cancellation)", async () => {
+    const mockClerk = createMockClerkClient();
+    let resolveInit: () => void;
+    const initPromise = new Promise<void>((resolve) => {
+      resolveInit = resolve;
+    });
+    vi.spyOn(JazzClerkAuth, "initializeAuth").mockReturnValue(initPromise);
+
+    const { unmount } = renderSvelte(JazzSvelteProviderWithClerk, {
+      props: {
+        clerk: mockClerk,
+        sync: { peer: "wss://test.example.com" },
+      },
+    });
+
+    // Unmount before initialization completes
+    unmount();
+
+    // Resolve the promise after unmount - should not cause errors
+    resolveInit!();
+
+    // Give time for any potential state updates
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    // If we get here without errors, the cancellation worked
+    expect(true).toBe(true);
+  });
+});
+
+describe("useClerkAuth reactive state transitions", () => {
+  let account: Account;
+
+  beforeEach(async () => {
+    await setupJazzTestSync();
+    account = await createJazzTestAccount({
+      isCurrentActiveAccount: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should update state reactively when listener callback fires", async () => {
+    const mockClerk = createMockClerkClient();
+    let listenerCallback: ((data: unknown) => void) | undefined;
+    mockClerk.addListener = vi.fn((callback) => {
+      listenerCallback = callback;
+      return () => {};
+    });
+
+    const { container } = render(
+      TestClerkAuthWrapper,
+      { clerk: mockClerk },
+      { account, isAuthenticated: false },
+    );
+
+    // Initial state should be anonymous
+    expect(screen.getByTestId("auth-state").textContent).toBe("anonymous");
+
+    // Verify listener was registered
+    expect(listenerCallback).toBeDefined();
+
+    // Note: Full state transition testing would require more complex setup
+    // involving the actual JazzClerkAuth.onClerkUserChange flow.
+    // This test verifies the listener registration which is the foundation
+    // for reactive updates.
+  });
+});

--- a/packages/jazz-tools/src/svelte/tests/TestClerkAuthWrapper.svelte
+++ b/packages/jazz-tools/src/svelte/tests/TestClerkAuthWrapper.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  import type { MinimalClerkClient } from "jazz-tools";
+  import { useClerkAuth } from "../auth/ClerkAuth.svelte.js";
+
+  type Props = {
+    clerk: MinimalClerkClient;
+  };
+
+  let { clerk }: Props = $props();
+
+  const auth = useClerkAuth(clerk);
+</script>
+
+<div data-testid="clerk-auth-wrapper">
+  <div data-testid="auth-state">{auth.state}</div>
+</div>

--- a/packages/jazz-tools/src/svelte/tests/testUtils.ts
+++ b/packages/jazz-tools/src/svelte/tests/testUtils.ts
@@ -6,6 +6,7 @@ import { JAZZ_AUTH_CTX, JAZZ_CTX } from "../jazz.svelte";
 
 type JazzExtendedOptions = {
   account: Account | { guest: AnonymousJazzAgent };
+  isAuthenticated?: boolean;
 };
 
 const render = <T extends Component>(
@@ -13,7 +14,9 @@ const render = <T extends Component>(
   props: ComponentProps<T>,
   jazzOptions: JazzExtendedOptions,
 ) => {
-  const ctx = TestJazzContextManager.fromAccountOrGuest(jazzOptions.account);
+  const ctx = TestJazzContextManager.fromAccountOrGuest(jazzOptions.account, {
+    isAuthenticated: jazzOptions.isAuthenticated,
+  });
 
   return renderSvelte(
     // @ts-expect-error Svelte new Component type is not compatible with @testing-library/svelte

--- a/packages/jazz-tools/src/tools/auth/clerk/types.ts
+++ b/packages/jazz-tools/src/tools/auth/clerk/types.ts
@@ -22,7 +22,7 @@ export type MinimalClerkClient = {
     | null
     | undefined;
   signOut: () => Promise<void>;
-  addListener: (listener: (data: unknown) => void) => void;
+  addListener: (listener: (data: unknown) => void) => (() => void) | void;
 };
 
 export type ClerkCredentials = {


### PR DESCRIPTION
# Description

Adds Clerk authentication support for Svelte, bringing feature parity with React and Expo implementations.

This integration works with https://github.com/wobsoriano/svelte-clerk, the community Svelte SDK for Clerk.

This PR introduces:
- useClerkAuth hook - reactive auth state management for Svelte
- JazzSvelteProviderWithClerk component - pre-configured provider that handles Clerk integration
- RegisterClerkAuth component - internal component for context registration

Also includes a small fix to MinimalClerkClient.addListener return type to support listeners that return unsubscribe functions (aligns with Clerk's actual API).

## Usage Pattern

  Because svelte-clerk exposes the Clerk client through Svelte context (via useClerkContext()), you need a wrapper component inside ClerkProvider to access it and pass it to JazzSvelteProviderWithClerk:

```svelte
  <!-- +layout.svelte -->
  <ClerkProvider publishableKey={PUBLIC_CLERK_PUBLISHABLE_KEY}>
    <JazzClerkWrapper>
      {@render children?.()}
    </JazzClerkWrapper>
  </ClerkProvider>

```
```svelte
  <!-- JazzClerkWrapper.svelte -->
  <script lang="ts">
    import { useClerkContext } from "svelte-clerk";
    import { JazzSvelteProviderWithClerk } from "jazz-tools/svelte";

    const ctx = useClerkContext();
    const clerk = $derived(ctx.clerk);
    let { children } = $props();
  </script>

  <JazzSvelteProviderWithClerk {clerk} sync={{ peer: "wss://cloud.jazz.tools/?key=..." }}>
    {@render children?.()}
  </JazzSvelteProviderWithClerk>
```

## Manual testing instructions

 1. Create a Svelte app with https://github.com/wobsoriano/svelte-clerk configured
  2. Create a JazzClerkWrapper component that uses useClerkContext() to get the clerk client
  3. Pass the clerk client to JazzSvelteProviderWithClerk
  4. Verify sign-in/sign-out flows work correctly
  5. Verify auth state updates reactively
## Tests

- [x] Tests have been added and/or updated
- [ ] Tests have not been updated, because: <!-- Insert reason for not updating tests here -->
- [ ] I need help with writing tests


## Checklist

- [x] I've updated the part of the docs that are affected the PR changes
- [x] I've generated a changeset, if a version bump is required
- [x] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Svelte Clerk auth integration and docs with a ready-to-use provider and hook.
> 
> - **Svelte auth**: New `useClerkAuth` hook and `JazzSvelteProviderWithClerk` component to sync Clerk with Jazz; internal `RegisterClerkAuth` for context-safe listener registration; exported via `svelte/auth/index.ts`
> - **Type fix**: `MinimalClerkClient.addListener` now supports returning an unsubscribe function
> - **Docs & snippets**: Svelte setup guides and code samples (`+layout.svelte`, `JazzClerkWrapper.svelte`, `AuthButton.svelte`) added to Clerk docs
> - **Tests**: Comprehensive Svelte tests for auth state, listener registration/cleanup, provider init and error handling
> - **Changeset**: Patch release for `jazz-tools`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a739bc46a6a127bcbc65466db095d0799b0249d8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->