### PR TITLE
Fix coMap.getEdits.ownKeys to include deleted keys

### DIFF
--- a/.changeset/soft-doodles-yell.md
+++ b/.changeset/soft-doodles-yell.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Fix Object.keys(coMap.getEdits()) to return also deleted keys

--- a/packages/jazz-tools/src/tools/coValues/coMap.ts
+++ b/packages/jazz-tools/src/tools/coValues/coMap.ts
@@ -825,7 +825,7 @@ class CoMapJazzApi<M extends CoMap> extends CoValueJazzApi<M> {
           };
         },
         ownKeys(_target) {
-          return map.$jazz.raw.keys();
+          return Object.keys(map.$jazz.raw.ops);
         },
         getOwnPropertyDescriptor(target, key) {
           return {

--- a/packages/jazz-tools/src/tools/tests/coMap.record.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coMap.record.test.ts
@@ -194,6 +194,15 @@ describe("CoMap.Record", async () => {
         $jazz: expect.objectContaining({ id: me.$jazz.id }),
       });
     });
+
+    test("getEdits() keys should return deleted keys", () => {
+      const Person = co.record(z.string(), z.string());
+      const person = Person.create({ name: "John" });
+      person.$jazz.set("name", "Jane");
+      person.$jazz.delete("name");
+
+      expect(Object.keys(person.$jazz.getEdits())).toEqual(["name"]);
+    });
   });
 
   describe("Record resolution", async () => {

--- a/packages/jazz-tools/src/tools/tests/coMap.record.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coMap.record.test.ts
@@ -196,12 +196,46 @@ describe("CoMap.Record", async () => {
     });
 
     test("getEdits() keys should return deleted keys", () => {
+      const me = Account.getMe();
+
       const Person = co.record(z.string(), z.string());
       const person = Person.create({ name: "John" });
       person.$jazz.set("name", "Jane");
       person.$jazz.delete("name");
 
       expect(Object.keys(person.$jazz.getEdits())).toEqual(["name"]);
+
+      const edits = person.$jazz.getEdits().name?.all;
+
+      expect(edits).toEqual([
+        expect.objectContaining({
+          value: "John",
+          key: "name",
+          ref: undefined,
+          madeAt: expect.any(Date),
+        }),
+        expect.objectContaining({
+          value: "Jane",
+          key: "name",
+          ref: undefined,
+          madeAt: expect.any(Date),
+        }),
+        expect.objectContaining({
+          value: undefined,
+          key: "name",
+          ref: undefined,
+          madeAt: expect.any(Date),
+        }),
+      ]);
+
+      expect(edits?.[0]?.by).toMatchObject({
+        [TypeSym]: "Account",
+        $jazz: expect.objectContaining({ id: me.$jazz.id }),
+      });
+      expect(edits?.[1]?.by).toMatchObject({
+        [TypeSym]: "Account",
+        $jazz: expect.objectContaining({ id: me.$jazz.id }),
+      });
     });
   });
 


### PR DESCRIPTION
# Description

`Object.keys(coMap.getEdits()` wasn't returning the deleted keys

## Manual testing instructions

See tests to repro

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes `CoMap.$jazz.getEdits()` key enumeration so deleted keys are included.
> 
> - Update proxy `ownKeys` to return `Object.keys(map.$jazz.raw.ops)` instead of `map.$jazz.raw.keys()`
> - Add test verifying `Object.keys(getEdits())` includes deleted keys and edit history contains a delete
> - Add changeset marking a patch release for `jazz-tools`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9cc2770ba78c5c6b627762c9058cb06fda89cb77. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->