### PR TITLE
fix: removed spread operator in header

### DIFF
--- a/.changeset/fix-uniqueness-spread.md
+++ b/.changeset/fix-uniqueness-spread.md
@@ -1,0 +1,6 @@
+---
+"cojson": patch
+---
+
+Fixed an issue where spreading the uniqueness object when creating CoValues could introduce unexpected properties into the header
+

--- a/packages/cojson/src/coValues/group.ts
+++ b/packages/cojson/src/coValues/group.ts
@@ -1249,7 +1249,10 @@ export class RawGroup<
           group: this.id,
         },
         meta: meta || null,
-        ...uniqueness,
+        ...(uniqueness.createdAt !== undefined
+          ? { createdAt: uniqueness.createdAt }
+          : {}),
+        uniqueness: uniqueness.uniqueness,
       })
       .getCurrentContent() as M;
 
@@ -1283,7 +1286,10 @@ export class RawGroup<
           group: this.id,
         },
         meta: meta || null,
-        ...uniqueness,
+        ...(uniqueness.createdAt !== undefined
+          ? { createdAt: uniqueness.createdAt }
+          : {}),
+        uniqueness: uniqueness.uniqueness,
       })
       .getCurrentContent() as L;
 
@@ -1340,7 +1346,10 @@ export class RawGroup<
           group: this.id,
         },
         meta: meta || null,
-        ...uniqueness,
+        ...(uniqueness.createdAt !== undefined
+          ? { createdAt: uniqueness.createdAt }
+          : {}),
+        uniqueness: uniqueness.uniqueness,
       })
       .getCurrentContent() as C;
 
@@ -1365,7 +1374,10 @@ export class RawGroup<
           group: this.id,
         },
         meta: meta,
-        ...uniqueness,
+        ...(uniqueness.createdAt !== undefined
+          ? { createdAt: uniqueness.createdAt }
+          : {}),
+        uniqueness: uniqueness.uniqueness,
       })
       .getCurrentContent() as C;
   }

--- a/packages/cojson/src/localNode.ts
+++ b/packages/cojson/src/localNode.ts
@@ -738,7 +738,10 @@ export class LocalNode {
       type: "comap",
       ruleset: { type: "group", initialAdmin: account.id },
       meta: null,
-      ...uniqueness,
+      ...(uniqueness.createdAt !== undefined
+        ? { createdAt: uniqueness.createdAt }
+        : {}),
+      uniqueness: uniqueness.uniqueness,
     });
 
     const group = expectGroup(groupCoValue.getCurrentContent());


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed -->
<!-- Please also include relevant motivation and context -->
<!-- Include any links to documentation like RFC’s if necessary -->
<!-- Add a link to to relevant preview environments or anything that would simplify visual review process -->
<!-- Supplemental screenshots and video are encouraged, but the primary description should be in text -->
This PR removes spread operator to avoid issues like:
```ts
  const uniqueness = {
    uniqueness: uniquenessString,
    createdAt: createdAt,
    type: "InvalidType",
  };
  const map = group.createMap({test: 'string'}, {}, 'trusting', uniqueness);
```


## Manual testing instructions

<!-- Add any actions required to manually test the changes -->

## Tests

- [ ] Tests have been added and/or updated
- [ ] Tests have not been updated, because: <!-- Insert reason for not updating tests here -->
- [ ] I need help with writing tests


## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [ ] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Fix:** Avoids unintended header fields from `uniqueness` being spread into newly created values.
> 
> - In `group.ts`, `createMap`, `createList`, `createStream`, and `createBinaryStream` now set `createdAt` (only if defined) and `uniqueness` explicitly instead of spreading the whole object
> - In `localNode.ts`, `createGroup` applies the same explicit header construction
> - Adds a changeset documenting the patch
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 71ed9d62440cdf8c8b4aaed08b42c2ca16aab8a2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->