### PR TITLE
feat: implement locking system for session IDs in React Native

### DIFF
--- a/.changeset/cool-foxes-smile.md
+++ b/.changeset/cool-foxes-smile.md
@@ -1,0 +1,8 @@
+---
+"jazz-tools": patch
+---
+
+Added a locking system for session IDs in React Native
+
+Now it should be safer to mount multiple JazzProviders, but still not advised as it is really expensive
+


### PR DESCRIPTION
Added a mechanism to lock session IDs, enhancing safety when multiple JazzProviders are mounted. This change prevents session conflicts and ensures that new sessions are created when an existing session is in use

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a session ID locking mechanism to React Native session management and validates it with tests.
> 
> - Introduces `lockedSessions` in `ReactNativeSessionProvider` to prevent reuse of an in-use `sessionID`; `acquireSession` creates a new session if the stored one is locked
> - Ensures sessions are locked on `acquireSession`/`persistSession` and unlocked via returned `sessionDone` callbacks (idempotent)
> - Updates `persistSession` to return `sessionDone` and lock the provided `sessionID`
> - Adds comprehensive tests covering lock behavior, reuse after `sessionDone`, and safety of multiple `sessionDone` calls
> - Adds a changeset marking a patch for `jazz-tools`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 94012a140054f6d0844751f0ed79b4fabff59afe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->