### PR TITLE
feat: resume interrupted CoValues sync on restart

### DIFF
--- a/.changeset/twelve-bats-repeat.md
+++ b/.changeset/twelve-bats-repeat.md
@@ -1,0 +1,28 @@
+---
+"cojson-core-napi-linux-arm-gnueabihf": patch
+"cojson-core-napi-linux-arm64-musl": patch
+"cojson-core-napi-linux-arm64-gnu": patch
+"cojson-core-napi-linux-x64-musl": patch
+"cojson-core-napi-linux-x64-gnu": patch
+"cojson-core-napi-darwin-arm64": patch
+"cojson-core-napi-darwin-x64": patch
+"cojson-storage-do-sqlite": patch
+"cojson-storage-indexeddb": patch
+"cojson-storage-sqlite": patch
+"cojson-transport-ws": patch
+"svelte-passkey-auth": patch
+"community-jazz-vue": patch
+"jazz-react-passkey-auth-starter": patch
+"cojson-core-napi": patch
+"cojson-core-wasm": patch
+"durable-object": patch
+"jazz-sveltekit": patch
+"cojson-core-rn": patch
+"jazz-webhook": patch
+"chat-svelte": patch
+"jazz-tools": patch
+"jazz-run": patch
+"cojson": patch
+---
+
+Resume interrupted CoValue sync on app restart (without requiring CoValues to be manually reloaded)

--- a/.changeset/twelve-bats-repeat.md
+++ b/.changeset/twelve-bats-repeat.md
@@ -1,27 +1,5 @@
 ---
-"cojson-core-napi-linux-arm-gnueabihf": patch
-"cojson-core-napi-linux-arm64-musl": patch
-"cojson-core-napi-linux-arm64-gnu": patch
-"cojson-core-napi-linux-x64-musl": patch
-"cojson-core-napi-linux-x64-gnu": patch
-"cojson-core-napi-darwin-arm64": patch
-"cojson-core-napi-darwin-x64": patch
-"cojson-storage-do-sqlite": patch
-"cojson-storage-indexeddb": patch
-"cojson-storage-sqlite": patch
-"cojson-transport-ws": patch
-"svelte-passkey-auth": patch
-"community-jazz-vue": patch
-"jazz-react-passkey-auth-starter": patch
-"cojson-core-napi": patch
-"cojson-core-wasm": patch
-"durable-object": patch
-"jazz-sveltekit": patch
-"cojson-core-rn": patch
-"jazz-webhook": patch
-"chat-svelte": patch
 "jazz-tools": patch
-"jazz-run": patch
 "cojson": patch
 ---
 

--- a/.specs/unsynced-covalues-tracking/design.md
+++ b/.specs/unsynced-covalues-tracking/design.md
@@ -1,0 +1,239 @@
+# Design: Track Unsynced CoValues & Resume Sync
+
+## Overview
+
+This design implements automatic tracking of CoValues with unsynced changes and provides mechanisms to resume syncing them on app restart. The solution integrates with the existing sync infrastructure and provides reactive APIs for monitoring sync status.
+
+The core idea is to maintain a set of CoValue IDs that have pending changes not yet fully synced to all peers. This set is persisted across app restarts and used to:
+1. Automatically resume syncing on startup
+2. Provide efficient sync status queries
+3. Enable reactive sync status subscriptions
+
+## Architecture / Components
+
+### 1. Extended StorageAPI Interface
+
+Extend the existing `StorageAPI` interface to include methods for tracking unsynced CoValues.
+
+**Location:** `packages/cojson/src/storage/types.ts`
+
+**New Methods:**
+```typescript
+export interface StorageAPI {
+  // ... existing methods ...
+  
+  trackCoValueSyncStatus(id: RawCoID, peerId: PeerID, synced: boolean): void;
+  getUnsyncedCoValueIDs(callback: (data: RawCoID[]) => void);
+}
+```
+
+**Implementation Strategy:**
+- Storage implementations will add these methods to persist the set of unsynced CoValue IDs
+- For IndexedDB: Add a new object store `"unsyncedCoValues"`
+- For SQLite: Add a table `unsynced_covalues`
+
+### 2. UnsyncedCoValuesTracker
+
+A new class that manages the set of unsynced CoValue IDs.
+
+**Location:** `packages/cojson/src/sync/UnsyncedCoValuesTracker.ts`
+
+**Responsibilities:**
+- Maintain an in-memory Set of unsynced CoValue IDs (including peers pending sync)
+- Persist the set to storage using `StorageAPI.trackCoValueSyncStatus` if available. Persistence can be batched and performed asynchronously, to avoid the cost of N extra storage writes per update (where N is the number of peers). 
+- Load persisted unsynced CoValues on initialization using `StorageAPI.getUnsyncedCoValueIDs` + `LocalNode.loadCoValueCore` if storage is available
+- Notify listeners when the set changes
+
+**Key Methods:**
+- `constructor(storage?: StorageAPI)`: Initialize with optional storage for persistence
+- `add(id: RawCoID, peerId: PeerID)`: Add a CoValue to the unsynced set (triggers persistence if storage available)
+- `remove(id: RawCoID, peerId: PeerID)`: Remove a CoValue from the unsynced set (triggers persistence if storage available)
+- `getAll()`: Returns all unsynced CoValue IDs 
+- `isAllSynced()`: Check if all CoValues are synced (O(1), returns `size() === 0`)
+- `subscribe(id: RawCoID, listener: (synced: boolean) => void)`: Subscribe to changes in whether a CoValue is synced
+- `subscribe(listener: (synced: boolean) => void)`: Subscribe to changes in whether all CoValues are synced
+
+### 3. Integration with SyncManager
+
+**Location:** `packages/cojson/src/sync.ts`
+
+**Changes:**
+- Add `unsyncedTracker: UnsyncedCoValuesTracker` property to `SyncManager`
+- Initialize tracker in `SyncManager` constructor: `new UnsyncedCoValuesTracker(local.storage, this)`
+- Update `syncContent()` method to keep track of unsynced CoValues:
+ ```ts
+ syncContent(content: NewContentMessage) {
+  const coValue = this.local.getCoValue(content.id);
+
+  this.storeContent(content);
+
+  const contentKnownState = knownStateFromContent(content);
+
+  for (const peer of this.getPeers(coValue.id)) {
+    this.unsyncedTracker.add(coValue.id, peer.id);
+
+    // ...
+
+    this.trySendToPeer(peer, content);
+    const unsubscribe = this.syncState.subscribeToPeerUpdates(
+      peer.id,
+      (knownState, syncState) => {
+        if (syncState.uploaded && knownState.id === coValue.id) {
+          this.unsyncedTracker.remove(coValue.id, peer.id);
+          unsubscribe();
+        }
+      },
+    );
+
+    peer.combineOptimisticWith(coValue.id, contentKnownState);
+    peer.trackToldKnownState(coValue.id);
+  }
+}
+ ```
+- Add method `async resumeUnsyncedCoValues()` to load and resume syncing unsynced CoValues. This happens asynchronously and doesn't block initialization
+- Call `resumeUnsyncedCoValues` as part of `SyncManager.startPeerReconciliation`.
+
+### 4. Sync Status Subscriptions
+
+**Location:** `packages/cojson/src/coValueCore/coValueCore.ts` and `packages/cojson/src/sync.ts`
+
+**CoValueCore.subscribeToSyncStatus:**
+- Subscribe to changes in whether this specific CoValue is synced
+- Uses `syncManager.unsyncedTracker.subscribe(coValueId)` to get notified when the CoValue's sync status changes
+- Calls listener immediately with current state on subscription
+
+**SyncManager.subscribeToSyncStatus:**
+- Subscribe to changes in whether all CoValues are synced
+- Uses `syncManager.unsyncedTracker.subscribe()` to get notified when the unsynced set changes
+- Calls listener immediately with current state on subscription (check `unsyncedTracker.isAllSynced()`)
+
+### 5. Refactored waitForSync
+
+**Location:** `packages/cojson/src/coValueCore/coValueCore.ts` and `packages/cojson/src/sync.ts`
+
+**Changes:**
+- Replace the current implementation of `CoValueCore.waitForSync()` based on CoValue subscription with a simple call to `syncManager.unsyncedTracker.subscribe(coValueId)`.
+
+## Data Model
+
+### UnsyncedCoValuesTracker In-Memory Representation
+
+The tracker maintains an in-memory data structure that maps each unsynced CoValue to the set of peers it's unsynced to:
+
+```typescript
+class UnsyncedCoValuesTracker {
+  // Map from CoValue ID to Set of Peer IDs that the CoValue is unsynced to
+  private unsynced: Map<RawCoID, Set<PeerID>> = new Map();
+  private coValueListeners: Map<RawCoID, (synced: boolean) => void> = new Map();
+  private globalListeners: (synced: boolean) => void = new Set();
+  private storage?: StorageAPI;
+}
+```
+
+### Storage Layout
+
+Storage persists unsynced CoValue-to-peer relationships as individual rows, with one row per (CoValue ID, Peer ID) pair.
+
+**IndexedDB Schema:**
+- Object store: `"unsyncedCoValues"`
+- Key: `[coValueId, peerId]` (composite key)
+- Value: `{ coValueId: RawCoID, peerId: PeerID }`
+- Indexes:
+  - Index on `coValueId` for efficient queries by CoValue
+  - Index on `peerId` for efficient queries by peer (optional, for cleanup)
+
+**SQLite Schema:**
+```sql
+CREATE TABLE unsynced_covalues (
+  co_value_id TEXT NOT NULL,
+  peer_id TEXT NOT NULL,
+  PRIMARY KEY (co_value_id, peer_id)
+);
+
+CREATE INDEX idx_unsynced_covalues_co_value_id ON unsynced_covalues(co_value_id);
+```
+
+**Storage Operations:**
+- `trackCoValueSyncStatus(coValueId, peerId, synced)`:
+  - If `synced === true`: DELETE row where `co_value_id = coValueId AND peer_id = peerId`
+  - If `synced === false`: INSERT OR REPLACE row with `(coValueId, peerId)`
+- `getUnsyncedCoValueIDs(callback)`:
+  - Query all distinct `co_value_id` values (SELECT DISTINCT co_value_id)
+  - Return array of unique CoValue IDs that have at least one unsynced peer
+
+**Example Storage Data:**
+```
+co_value_id    | peer_id
+---------------|----------
+co_abc123      | peer1
+co_abc123      | peer2
+co_def456      | peer1
+```
+
+This represents:
+- `co_abc123` is unsynced to `peer1` and `peer2`
+- `co_def456` is unsynced to `peer1`
+
+**Loading on Startup:**
+1. Call `getUnsyncedCoValueIDs()` to get all CoValue IDs with unsynced peers
+2. For each CoValue ID, query all peer IDs: `SELECT peer_id WHERE co_value_id = ?`
+3. Reconstruct the in-memory Map structure
+4. Load each CoValue and resume syncing
+
+## Error Handling / Testing Strategy
+
+### Error Handling
+
+1. **Storage Errors:**
+   - If persistence fails, log error but continue with in-memory tracking
+   - On load failure, start with empty set (graceful degradation)
+   - Don't block LocalNode initialization if persistence fails
+
+2. **Missing CoValues:**
+   - Handle gracefully when trying to load non-existent CoValues
+
+3. **Peer Connection Issues:**
+   - Continue tracking even when peers are disconnected
+   - Resume syncing when peers reconnect
+
+4. **Race Conditions:**
+   - Use atomic operations for add/remove from Set
+   - Ensure persistence operations don't interfere with tracking updates
+
+### Testing Strategy
+
+1. **Unit Tests:**
+   - Test `UnsyncedCoValuesTracker` operations
+   - Test persistence and loading
+   - Test subscription notifications
+   - Test sync state determination logic
+
+2. **Integration Tests:**
+   - Test integration with `SyncManager` and `SyncStateManager`
+   - Test that CoValues are tracked when they become unsynced
+   - Test that CoValues are removed when they become synced
+   - Test resumption on LocalNode initialization
+   - Test subscription APIs (`subscribeToSyncStatus`)
+   - Test refactored `waitForSync`
+
+3. **E2E Tests:**
+   - Test offline/online scenario with partial CoValue loading
+   - Test that unsynced CoValues are synced after app restart
+
+4. **Performance Tests:**
+   - Test with large numbers of unsynced CoValues
+   - Test persistence/loading performance
+   - Test subscription performance with many listeners
+   - Test polling performance in `waitForSync`
+
+5. **Platform Tests:**
+   - Test on web (IndexedDB storage)
+   - Test on Node.js (SQLite storage)
+
+### Edge Cases
+
+1. **Very large unsynced set** - Should handle efficiently, without a noticeable impact on app startup
+2. **Rapid sync state changes** - Should debounce/throttle persistence
+3. **Multiple sessions sharing storage** - IndexedDB is shared across tabs, but this shouldn't be a problem as we don't need to keep the in-memory unsynced CoValue list in sync with storage (we only use storage for persistence
+across app restarts)
+4. **Storage unavailable** - Should fall back to in-memory only

--- a/.specs/unsynced-covalues-tracking/design.md
+++ b/.specs/unsynced-covalues-tracking/design.md
@@ -22,7 +22,7 @@ Extend the existing `StorageAPI` interface to include methods for tracking unsyn
 export interface StorageAPI {
   // ... existing methods ...
   
-  trackCoValuesSyncState(operations: Array<{ id: RawCoID; peerId: PeerID; synced: boolean }>): void;
+  trackCoValuesSyncState(updates: { id: RawCoID; peerId: PeerID; synced: boolean }[]): void;
   getUnsyncedCoValueIDs(callback: (data: RawCoID[]) => void);
   stopTrackingSyncState(id: RawCoID): void;
 }
@@ -250,7 +250,7 @@ CREATE INDEX idx_unsynced_covalues_co_value_id ON unsynced_covalues(co_value_id)
 ```
 
 **Storage Operations:**
-- `trackCoValuesSyncState(operations)`:
+- `trackCoValuesSyncState(updates)`:
   - Takes an array of operations `{ id: RawCoID, peerId: PeerID, synced: boolean }[]`
   - Executes all operations in a single transaction
   - For each operation:

--- a/.specs/unsynced-covalues-tracking/requirements.md
+++ b/.specs/unsynced-covalues-tracking/requirements.md
@@ -6,7 +6,7 @@ Currently, Jazz only resumes sync on CoValues that are loaded in memory. This cr
 
 This feature will implement automatic tracking and resumption of sync for all CoValues with pending changes, regardless of whether they are currently loaded in memory. The solution must work across all platforms (web, React Native, Node.js, cloud workers) and be performant enough to run in cloud environments.
 
-Tracking unsynced CoValues also allows providing reactive APIs for tracking if CoValues have been synced. This includes refactoring `waitForSync` so that we don't need to create a subscription, and adding new subscription APIs for monitoring sync state at different levels of granularity: `CoValueCore.subscribeToSyncStatus` and `SyncManager.subscribeToSyncStatus`.
+Tracking unsynced CoValues also allows providing reactive APIs for tracking if CoValues have been synced. This includes refactoring `waitForSync` so that we don't need to create a subscription, and adding new subscription APIs for monitoring sync state at different levels of granularity: `CoValueCore.subscribeToSyncState` and `SyncManager.subscribeToSyncState`.
 
 ## User Stories
 
@@ -36,7 +36,7 @@ Tracking unsynced CoValues also allows providing reactive APIs for tracking if C
 **So that** I can reactively monitor when a CoValue becomes synced
 
 **Acceptance Criteria:**
-- [ ] `CoValueCore.subscribeToSyncStatus(listener)` method subscribes to sync state changes
+- [ ] `CoValueCore.subscribeToSyncState(listener)` method subscribes to sync state changes
 - [ ] The listener receives a boolean indicating if the CoValue is synced to all persistent server peers
 - [ ] The method returns an unsubscribe function
 - [ ] The subscription uses the unsynced CoValues tracking for efficient updates
@@ -48,7 +48,7 @@ Tracking unsynced CoValues also allows providing reactive APIs for tracking if C
 **So that** I can reactively determine when all pending changes have been uploaded
 
 **Acceptance Criteria:**
-- [ ] `SyncManager.subscribeToSyncStatus(listener)` method subscribes to global sync state changes
+- [ ] `SyncManager.subscribeToSyncState(listener)` method subscribes to global sync state changes
 - [ ] The listener receives a boolean indicating if all CoValues are synced
 - [ ] The method returns an unsubscribe function
 - [ ] The subscription uses the unsynced CoValues tracking for efficient implementation

--- a/.specs/unsynced-covalues-tracking/requirements.md
+++ b/.specs/unsynced-covalues-tracking/requirements.md
@@ -1,0 +1,66 @@
+# Track Unsynced CoValues & Resume Sync
+
+## Introduction
+
+Currently, Jazz only resumes sync on CoValues that are loaded in memory. This creates a problem when users partially upload a CoValue graph, go offline, restart the app and then come back online. In this scenario, only the loaded parts of the CoValue graph resume syncing, leaving unloaded parts unsynced even though they may have pending changes.
+
+This feature will implement automatic tracking and resumption of sync for all CoValues with pending changes, regardless of whether they are currently loaded in memory. The solution must work across all platforms (web, React Native, Node.js, cloud workers) and be performant enough to run in cloud environments.
+
+Tracking unsynced CoValues also allows providing reactive APIs for tracking if CoValues have been synced. This includes refactoring `waitForSync` so that we don't need to create a subscription, and adding new subscription APIs for monitoring sync state at different levels of granularity: `CoValueCore.subscribeToSyncStatus` and `SyncManager.subscribeToSyncStatus`.
+
+## User Stories
+
+### US1: Track Unsynced CoValues
+**As a** Jazz user  
+**I want** Jazz to automatically track CoValues that have unsynced changes  
+**So that** these CoValues can be synced even if they're not currently loaded in memory
+
+**Acceptance Criteria:**
+- [ ] When a CoValue has local changes that haven't been fully uploaded to at least one peer, it is tracked as unsynced
+- [ ] When a CoValue becomes fully synced to all peers, it is removed from the unsynced tracking
+- [ ] The tracking persists across app restarts using platform-appropriate storage
+
+### US2: Resume Sync on App Start
+**As a** Jazz user  
+**I want** Jazz to automatically resume syncing all unsynced CoValues when the app starts  
+**So that** all pending changes are eventually synced, even if the CoValues aren't loaded after going back online
+
+**Acceptance Criteria:**
+- [ ] On LocalNode initialization, all previously tracked unsynced CoValues are loaded and syncing is resumed
+- [ ] The resumption happens asynchronously and doesn't block LocalNode initialization
+- [ ] The resumption is efficient and doesn't cause performance issues when running in sync servers
+
+### US3: Subscribe to CoValue Sync Status
+**As a** Jazz user  
+**I want** to subscribe to changes in a CoValue's sync status  
+**So that** I can reactively monitor when a CoValue becomes synced
+
+**Acceptance Criteria:**
+- [ ] `CoValueCore.subscribeToSyncStatus(listener)` method subscribes to sync status changes
+- [ ] The listener receives a boolean indicating if the CoValue is synced to all peers
+- [ ] The method returns an unsubscribe function
+- [ ] The subscription uses the unsynced CoValues tracking for efficient updates
+- [ ] The listener is called immediately with the current sync status when subscribing
+
+### US4: Subscribe to All CoValues Sync Status
+**As a** Jazz user  
+**I want** to subscribe to changes in whether all CoValues are synced  
+**So that** I can reactively determine when all pending changes have been uploaded
+
+**Acceptance Criteria:**
+- [ ] `SyncManager.subscribeToSyncStatus(listener)` method subscribes to global sync status changes
+- [ ] The listener receives a boolean indicating if all CoValues are synced
+- [ ] The method returns an unsubscribe function
+- [ ] The subscription uses the unsynced CoValues tracking for efficient implementation
+- [ ] The subscription works correctly even when some CoValues are not loaded in memory
+- [ ] The listener is called immediately with the current sync status when subscribing
+
+### US5: Refactor waitForSync Without Subscriptions
+**As a** Jazz developer  
+**I want** `waitForSync` to work without creating subscriptions  
+**So that** it's simpler and more efficient
+
+**Acceptance Criteria:**
+- [ ] `CoValueCore.waitForSync` is refactored to use unsynced CoValues tracking instead of CoValue subscriptions
+- [ ] The method maintains backward compatibility with existing API
+- [ ] Performance is improved compared to the subscription-based approach

--- a/.specs/unsynced-covalues-tracking/requirements.md
+++ b/.specs/unsynced-covalues-tracking/requirements.md
@@ -17,7 +17,7 @@ Tracking unsynced CoValues also allows providing reactive APIs for tracking if C
 
 **Acceptance Criteria:**
 - [ ] When a CoValue has local changes that haven't been fully uploaded to at least one peer, it is tracked as unsynced
-- [ ] When a CoValue becomes fully synced to all peers, it is removed from the unsynced tracking
+- [ ] When a CoValue becomes fully synced to all persistent server peers, it is removed from the unsynced tracking
 - [ ] The tracking persists across app restarts using platform-appropriate storage
 
 ### US2: Resume Sync on App Start
@@ -32,15 +32,15 @@ Tracking unsynced CoValues also allows providing reactive APIs for tracking if C
 
 ### US3: Subscribe to CoValue Sync Status
 **As a** Jazz user  
-**I want** to subscribe to changes in a CoValue's sync status  
+**I want** to subscribe to changes in a CoValue's sync state  
 **So that** I can reactively monitor when a CoValue becomes synced
 
 **Acceptance Criteria:**
-- [ ] `CoValueCore.subscribeToSyncStatus(listener)` method subscribes to sync status changes
-- [ ] The listener receives a boolean indicating if the CoValue is synced to all peers
+- [ ] `CoValueCore.subscribeToSyncStatus(listener)` method subscribes to sync state changes
+- [ ] The listener receives a boolean indicating if the CoValue is synced to all persistent server peers
 - [ ] The method returns an unsubscribe function
 - [ ] The subscription uses the unsynced CoValues tracking for efficient updates
-- [ ] The listener is called immediately with the current sync status when subscribing
+- [ ] The listener is called immediately with the current sync state when subscribing
 
 ### US4: Subscribe to All CoValues Sync Status
 **As a** Jazz user  
@@ -48,12 +48,12 @@ Tracking unsynced CoValues also allows providing reactive APIs for tracking if C
 **So that** I can reactively determine when all pending changes have been uploaded
 
 **Acceptance Criteria:**
-- [ ] `SyncManager.subscribeToSyncStatus(listener)` method subscribes to global sync status changes
+- [ ] `SyncManager.subscribeToSyncStatus(listener)` method subscribes to global sync state changes
 - [ ] The listener receives a boolean indicating if all CoValues are synced
 - [ ] The method returns an unsubscribe function
 - [ ] The subscription uses the unsynced CoValues tracking for efficient implementation
 - [ ] The subscription works correctly even when some CoValues are not loaded in memory
-- [ ] The listener is called immediately with the current sync status when subscribing
+- [ ] The listener is called immediately with the current sync state when subscribing
 
 ### US5: Refactor waitForSync Without Subscriptions
 **As a** Jazz developer  

--- a/.specs/unsynced-covalues-tracking/tasks.md
+++ b/.specs/unsynced-covalues-tracking/tasks.md
@@ -3,29 +3,30 @@
 ## Core Infrastructure
 
 - [x] **Task 1**: Extend `StorageAPI` interface with unsynced CoValues tracking methods (US1)
-  - Add `trackCoValueSyncState(id: RawCoID, peerId: PeerID, synced: boolean): void` to `StorageAPI` interface in `packages/cojson/src/storage/types.ts`
+  - Add `trackCoValuesSyncState(operations: Array<{ id: RawCoID; peerId: PeerID; synced: boolean }>): void` to `StorageAPI` interface in `packages/cojson/src/storage/types.ts`
   - Add `getUnsyncedCoValueIDs(callback: (data: RawCoID[]) => void)` to `StorageAPI` interface
   - Add `stopTrackingSyncState(id: RawCoID): void` to `StorageAPI` interface
 
-- [x] **Task 2**: Implement `trackCoValueSyncState`, `getUnsyncedCoValueIDs`, and `stopTrackingSyncState` for IndexedDB storage (US1)
+- [x] **Task 2**: Implement `trackCoValuesSyncState`, `getUnsyncedCoValueIDs`, and `stopTrackingSyncState` for IndexedDB storage (US1)
   - Add new object store `"unsyncedCoValues"` in IndexedDB schema (upgrade version)
-  - Implement `trackCoValueSyncState` in `StorageApiAsync` to upsert/delete records
+  - Implement `trackCoValuesSyncState` in `StorageApiAsync` to batch upsert/delete records in a single transaction
   - Implement `getUnsyncedCoValueIDs` to query all unsynced CoValue IDs
   - Implement `stopTrackingSyncState` to delete all records for a CoValue ID
   - Update `packages/cojson-storage-indexeddb/src/idbNode.ts` for schema migration
 
-- [x] **Task 3**: Implement `trackCoValueSyncState`, `getUnsyncedCoValueIDs`, and `stopTrackingSyncState` for SQLite storage (US1)
+- [x] **Task 3**: Implement `trackCoValuesSyncState`, `getUnsyncedCoValueIDs`, and `stopTrackingSyncState` for SQLite storage (US1)
   - Add `unsynced_covalues` table to SQLite schema
-  - Implement `trackCoValueSyncState` in `StorageApiAsync` and `StorageApiSync` for SQLite
+  - Implement `trackCoValuesSyncState` in `StorageApiAsync` and `StorageApiSync` for SQLite (batch operations in transaction)
   - Implement `getUnsyncedCoValueIDs` in `StorageApiAsync` and `StorageApiSync` for SQLite
   - Implement `stopTrackingSyncState` in `StorageApiAsync` and `StorageApiSync` for SQLite
   - Update SQLite client implementations in `packages/cojson/src/storage/sqlite/` and `packages/cojson/src/storage/sqliteAsync/`
 
 - [x] **Task 4**: Create `UnsyncedCoValuesTracker` class (US1, US3, US4)
-  - Create `packages/cojson/src/sync/UnsyncedCoValuesTracker.ts`
+  - Create `packages/cojson/src/UnsyncedCoValuesTracker.ts`
   - Implement in-memory `Map<RawCoID, Set<PeerID>>` for tracking unsynced CoValues per peer
   - Implement `add(id, peerId)`, `remove(id, peerId)`, `getAll()`, `isAllSynced()` methods
-  - Implement batched/async persistence using `StorageAPI.trackCoValueSyncState`
+  - Implement batched persistence using `StorageAPI.trackCoValuesSyncState` with automatic flushing (1s delay or on shutdown)
+  - Implement `flush()` method to immediately persist pending operations
   - Implement `subscribe(id, listener)` for per-CoValue subscriptions
   - Implement `subscribe(listener)` for global "all synced" subscriptions
   - Handle storage errors gracefully (fallback to in-memory only)
@@ -83,11 +84,13 @@
 
 - [ ] **Task 10**: Write unit tests for `UnsyncedCoValuesTracker` (US1, US3, US4)
   - Test `add(id, peerId)`, `remove(id, peerId)`, `getAll()`, `isAllSynced()` operations
-  - Test persistence using `StorageAPI.trackCoValueSyncState`
+  - Test batched persistence using `StorageAPI.trackCoValuesSyncState`
+  - Test automatic flushing after delay
+  - Test `flush()` method for immediate persistence
   - Test subscription notifications (both per-CoValue and global)
   - Test that listeners are called immediately with current state on subscription
   - Test error handling when storage is unavailable (fallback to in-memory only)
-  - Create `packages/cojson/src/sync/__tests__/UnsyncedCoValuesTracker.test.ts`
+  - Create `packages/cojson/src/__tests__/UnsyncedCoValuesTracker.test.ts`
 
 - [ ] **Task 11**: Write integration tests for sync tracking (US1, US2)
   - Test that CoValues are tracked when `syncContent()` is called

--- a/.specs/unsynced-covalues-tracking/tasks.md
+++ b/.specs/unsynced-covalues-tracking/tasks.md
@@ -3,29 +3,29 @@
 ## Core Infrastructure
 
 - [x] **Task 1**: Extend `StorageAPI` interface with unsynced CoValues tracking methods (US1)
-  - Add `trackCoValueSyncStatus(id: RawCoID, peerId: PeerID, synced: boolean): void` to `StorageAPI` interface in `packages/cojson/src/storage/types.ts`
+  - Add `trackCoValueSyncState(id: RawCoID, peerId: PeerID, synced: boolean): void` to `StorageAPI` interface in `packages/cojson/src/storage/types.ts`
   - Add `getUnsyncedCoValueIDs(callback: (data: RawCoID[]) => void)` to `StorageAPI` interface
-  - Add `stopTrackingSyncStatus(id: RawCoID): void` to `StorageAPI` interface
+  - Add `stopTrackingSyncState(id: RawCoID): void` to `StorageAPI` interface
 
-- [x] **Task 2**: Implement `trackCoValueSyncStatus`, `getUnsyncedCoValueIDs`, and `stopTrackingSyncStatus` for IndexedDB storage (US1)
+- [x] **Task 2**: Implement `trackCoValueSyncState`, `getUnsyncedCoValueIDs`, and `stopTrackingSyncState` for IndexedDB storage (US1)
   - Add new object store `"unsyncedCoValues"` in IndexedDB schema (upgrade version)
-  - Implement `trackCoValueSyncStatus` in `StorageApiAsync` to upsert/delete records
+  - Implement `trackCoValueSyncState` in `StorageApiAsync` to upsert/delete records
   - Implement `getUnsyncedCoValueIDs` to query all unsynced CoValue IDs
-  - Implement `stopTrackingSyncStatus` to delete all records for a CoValue ID
+  - Implement `stopTrackingSyncState` to delete all records for a CoValue ID
   - Update `packages/cojson-storage-indexeddb/src/idbNode.ts` for schema migration
 
-- [x] **Task 3**: Implement `trackCoValueSyncStatus`, `getUnsyncedCoValueIDs`, and `stopTrackingSyncStatus` for SQLite storage (US1)
+- [x] **Task 3**: Implement `trackCoValueSyncState`, `getUnsyncedCoValueIDs`, and `stopTrackingSyncState` for SQLite storage (US1)
   - Add `unsynced_covalues` table to SQLite schema
-  - Implement `trackCoValueSyncStatus` in `StorageApiAsync` and `StorageApiSync` for SQLite
+  - Implement `trackCoValueSyncState` in `StorageApiAsync` and `StorageApiSync` for SQLite
   - Implement `getUnsyncedCoValueIDs` in `StorageApiAsync` and `StorageApiSync` for SQLite
-  - Implement `stopTrackingSyncStatus` in `StorageApiAsync` and `StorageApiSync` for SQLite
+  - Implement `stopTrackingSyncState` in `StorageApiAsync` and `StorageApiSync` for SQLite
   - Update SQLite client implementations in `packages/cojson/src/storage/sqlite/` and `packages/cojson/src/storage/sqliteAsync/`
 
 - [x] **Task 4**: Create `UnsyncedCoValuesTracker` class (US1, US3, US4)
   - Create `packages/cojson/src/sync/UnsyncedCoValuesTracker.ts`
   - Implement in-memory `Map<RawCoID, Set<PeerID>>` for tracking unsynced CoValues per peer
   - Implement `add(id, peerId)`, `remove(id, peerId)`, `getAll()`, `isAllSynced()` methods
-  - Implement batched/async persistence using `StorageAPI.trackCoValueSyncStatus`
+  - Implement batched/async persistence using `StorageAPI.trackCoValueSyncState`
   - Implement `subscribe(id, listener)` for per-CoValue subscriptions
   - Implement `subscribe(listener)` for global "all synced" subscriptions
   - Handle storage errors gracefully (fallback to in-memory only)
@@ -49,22 +49,22 @@
   - Process CoValues in batches (e.g., 10 at a time) to avoid blocking
   - For each unsynced CoValue ID, load the CoValue using `local.loadCoValueCore()`
   - If CoValue loads successfully, call `trackSyncState()` to resume tracking
-  - If CoValue fails to load or is unavailable, call `storage.stopTrackingSyncStatus()` to clean up
+  - If CoValue fails to load or is unavailable, call `storage.stopTrackingSyncState()` to clean up
   - Use `setTimeout(processBatch, 0)` to yield control between batches
   - Call `resumeUnsyncedCoValues()` in `startPeerReconciliation()` method
   - Ensure it runs asynchronously and doesn't block initialization
 
 ## Subscription APIs
 
-- [ ] **Task 7**: Implement `CoValueCore.subscribeToSyncStatus()` (US3)
-  - Add `subscribeToSyncStatus(listener)` method to `CoValueCore` class
+- [ ] **Task 7**: Implement `CoValueCore.subscribeToSyncState()` (US3)
+  - Add `subscribeToSyncState(listener)` method to `CoValueCore` class
   - Use `syncManager.unsyncedTracker.subscribe(this.id, listener)` internally
   - Call listener immediately with current state (check if CoValue ID is in `unsyncedTracker.getAll()`)
   - Return unsubscribe function
   - Update `packages/cojson/src/coValueCore/coValueCore.ts`
 
-- [ ] **Task 8**: Implement `SyncManager.subscribeToSyncStatus()` (US4)
-  - Add `subscribeToSyncStatus(listener)` method to `SyncManager` class
+- [ ] **Task 8**: Implement `SyncManager.subscribeToSyncState()` (US4)
+  - Add `subscribeToSyncState(listener)` method to `SyncManager` class
   - Use `unsyncedTracker.subscribe(listener)` internally
   - Call listener immediately with current state (`unsyncedTracker.isAllSynced()`)
   - Return unsubscribe function
@@ -83,7 +83,7 @@
 
 - [ ] **Task 10**: Write unit tests for `UnsyncedCoValuesTracker` (US1, US3, US4)
   - Test `add(id, peerId)`, `remove(id, peerId)`, `getAll()`, `isAllSynced()` operations
-  - Test persistence using `StorageAPI.trackCoValueSyncStatus`
+  - Test persistence using `StorageAPI.trackCoValueSyncState`
   - Test subscription notifications (both per-CoValue and global)
   - Test that listeners are called immediately with current state on subscription
   - Test error handling when storage is unavailable (fallback to in-memory only)
@@ -97,8 +97,8 @@
   - Create/update integration tests in `packages/cojson/src/tests/`
 
 - [ ] **Task 12**: Write tests for subscription APIs (US3, US4)
-  - Test `CoValueCore.subscribeToSyncStatus()` notifies on status changes
-  - Test `SyncManager.subscribeToSyncStatus()` notifies when all synced
+  - Test `CoValueCore.subscribeToSyncState()` notifies on status changes
+  - Test `SyncManager.subscribeToSyncState()` notifies when all synced
   - Test immediate callback with current state on subscription
   - Test unsubscribe functionality
 

--- a/.specs/unsynced-covalues-tracking/tasks.md
+++ b/.specs/unsynced-covalues-tracking/tasks.md
@@ -3,7 +3,7 @@
 ## Core Infrastructure
 
 - [x] **Task 1**: Extend `StorageAPI` interface with unsynced CoValues tracking methods (US1)
-  - Add `trackCoValuesSyncState(operations: Array<{ id: RawCoID; peerId: PeerID; synced: boolean }>): void` to `StorageAPI` interface in `packages/cojson/src/storage/types.ts`
+  - Add `trackCoValuesSyncState(updates: { id: RawCoID; peerId: PeerID; synced: boolean }[]): void` to `StorageAPI` interface in `packages/cojson/src/storage/types.ts`
   - Add `getUnsyncedCoValueIDs(callback: (data: RawCoID[]) => void)` to `StorageAPI` interface
   - Add `stopTrackingSyncState(id: RawCoID): void` to `StorageAPI` interface
 

--- a/.specs/unsynced-covalues-tracking/tasks.md
+++ b/.specs/unsynced-covalues-tracking/tasks.md
@@ -21,7 +21,7 @@
   - Implement `stopTrackingSyncStatus` in `StorageApiAsync` and `StorageApiSync` for SQLite
   - Update SQLite client implementations in `packages/cojson/src/storage/sqlite/` and `packages/cojson/src/storage/sqliteAsync/`
 
-- [ ] **Task 4**: Create `UnsyncedCoValuesTracker` class (US1, US3, US4)
+- [x] **Task 4**: Create `UnsyncedCoValuesTracker` class (US1, US3, US4)
   - Create `packages/cojson/src/sync/UnsyncedCoValuesTracker.ts`
   - Implement in-memory `Map<RawCoID, Set<PeerID>>` for tracking unsynced CoValues per peer
   - Implement `add(id, peerId)`, `remove(id, peerId)`, `getAll()`, `isAllSynced()` methods

--- a/.specs/unsynced-covalues-tracking/tasks.md
+++ b/.specs/unsynced-covalues-tracking/tasks.md
@@ -32,7 +32,7 @@
 
 ## Integration with Sync System
 
-- [ ] **Task 5**: Integrate `UnsyncedCoValuesTracker` into `SyncManager` (US1)
+- [x] **Task 5**: Integrate `UnsyncedCoValuesTracker` into `SyncManager` (US1)
   - Add `unsyncedTracker` property to `SyncManager` class
   - Initialize tracker in `SyncManager` constructor: `new UnsyncedCoValuesTracker(local.storage, this)`
   - Create `trackSyncState(coValueId)` helper method that:

--- a/.specs/unsynced-covalues-tracking/tasks.md
+++ b/.specs/unsynced-covalues-tracking/tasks.md
@@ -43,7 +43,7 @@
   - Update `syncContent()` method to call `trackSyncState(coValue.id)` after storing content
   - Update `handleNewContent()` method to call `trackSyncState(coValue.id)` when receiving content from client peers
 
-- [ ] **Task 6**: Implement `resumeUnsyncedCoValues()` method (US2)
+- [x] **Task 6**: Implement `resumeUnsyncedCoValues()` method (US2)
   - Add `async resumeUnsyncedCoValues()` method to `SyncManager`
   - Load persisted unsynced CoValue IDs from storage using `storage.getUnsyncedCoValueIDs()`
   - Process CoValues in batches (e.g., 10 at a time) to avoid blocking

--- a/.specs/unsynced-covalues-tracking/tasks.md
+++ b/.specs/unsynced-covalues-tracking/tasks.md
@@ -2,19 +2,19 @@
 
 ## Core Infrastructure
 
-- [ ] **Task 1**: Extend `StorageAPI` interface with unsynced CoValues tracking methods (US1)
+- [x] **Task 1**: Extend `StorageAPI` interface with unsynced CoValues tracking methods (US1)
   - Add `trackCoValueSyncStatus(id: RawCoID, peerId: PeerID, synced: boolean): void` to `StorageAPI` interface in `packages/cojson/src/storage/types.ts`
   - Add `getUnsyncedCoValueIDs(callback: (data: RawCoID[]) => void)` to `StorageAPI` interface
   - Add `stopTrackingSyncStatus(id: RawCoID): void` to `StorageAPI` interface
 
-- [ ] **Task 2**: Implement `trackCoValueSyncStatus`, `getUnsyncedCoValueIDs`, and `stopTrackingSyncStatus` for IndexedDB storage (US1)
+- [x] **Task 2**: Implement `trackCoValueSyncStatus`, `getUnsyncedCoValueIDs`, and `stopTrackingSyncStatus` for IndexedDB storage (US1)
   - Add new object store `"unsyncedCoValues"` in IndexedDB schema (upgrade version)
   - Implement `trackCoValueSyncStatus` in `StorageApiAsync` to upsert/delete records
   - Implement `getUnsyncedCoValueIDs` to query all unsynced CoValue IDs
   - Implement `stopTrackingSyncStatus` to delete all records for a CoValue ID
   - Update `packages/cojson-storage-indexeddb/src/idbNode.ts` for schema migration
 
-- [ ] **Task 3**: Implement `trackCoValueSyncStatus`, `getUnsyncedCoValueIDs`, and `stopTrackingSyncStatus` for SQLite storage (US1)
+- [x] **Task 3**: Implement `trackCoValueSyncStatus`, `getUnsyncedCoValueIDs`, and `stopTrackingSyncStatus` for SQLite storage (US1)
   - Add `unsynced_covalues` table to SQLite schema
   - Implement `trackCoValueSyncStatus` in `StorageApiAsync` and `StorageApiSync` for SQLite
   - Implement `getUnsyncedCoValueIDs` in `StorageApiAsync` and `StorageApiSync` for SQLite

--- a/packages/cojson-storage-indexeddb/src/CoJsonIDBTransaction.ts
+++ b/packages/cojson-storage-indexeddb/src/CoJsonIDBTransaction.ts
@@ -2,7 +2,8 @@ export type StoreName =
   | "coValues"
   | "sessions"
   | "transactions"
-  | "signatureAfter";
+  | "signatureAfter"
+  | "unsyncedCoValues";
 
 // A access unit for the IndexedDB Jazz database
 // It's a wrapper around the IDBTransaction object that helps on batching multiple operations
@@ -28,7 +29,13 @@ export class CoJsonIDBTransaction {
 
   refresh() {
     this.tx = this.db.transaction(
-      ["coValues", "sessions", "transactions", "signatureAfter"],
+      [
+        "coValues",
+        "sessions",
+        "transactions",
+        "signatureAfter",
+        "unsyncedCoValues",
+      ],
       "readwrite",
     );
 

--- a/packages/cojson-storage-indexeddb/src/CoJsonIDBTransaction.ts
+++ b/packages/cojson-storage-indexeddb/src/CoJsonIDBTransaction.ts
@@ -5,13 +5,19 @@ export type StoreName =
   | "signatureAfter"
   | "unsyncedCoValues";
 
+const DEFAULT_TX_STORES: StoreName[] = [
+  "coValues",
+  "sessions",
+  "transactions",
+  "signatureAfter",
+];
+
 /**
  * An access unit for the IndexedDB Jazz database.
  * It's a wrapper around the IDBTransaction object that helps on batching multiple operations
  * in a single transaction.
  */
 export class CoJsonIDBTransaction {
-  db: IDBDatabase;
   declare tx: IDBTransaction;
 
   pendingRequests: ((txEntry: this) => void)[] = [];
@@ -23,23 +29,16 @@ export class CoJsonIDBTransaction {
   failed = false;
   done = false;
 
-  constructor(db: IDBDatabase) {
-    this.db = db;
-
+  constructor(
+    public db: IDBDatabase,
+    // The object stores this transaction will operate on
+    private storeNames: StoreName[] = DEFAULT_TX_STORES,
+  ) {
     this.refresh();
   }
 
   refresh() {
-    this.tx = this.db.transaction(
-      [
-        "coValues",
-        "sessions",
-        "transactions",
-        "signatureAfter",
-        "unsyncedCoValues",
-      ],
-      "readwrite",
-    );
+    this.tx = this.db.transaction(this.storeNames, "readwrite");
 
     this.tx.oncomplete = () => {
       this.done = true;

--- a/packages/cojson-storage-indexeddb/src/CoJsonIDBTransaction.ts
+++ b/packages/cojson-storage-indexeddb/src/CoJsonIDBTransaction.ts
@@ -5,9 +5,11 @@ export type StoreName =
   | "signatureAfter"
   | "unsyncedCoValues";
 
-// A access unit for the IndexedDB Jazz database
-// It's a wrapper around the IDBTransaction object that helps on batching multiple operations
-// in a single transaction.
+/**
+ * An access unit for the IndexedDB Jazz database.
+ * It's a wrapper around the IDBTransaction object that helps on batching multiple operations
+ * in a single transaction.
+ */
 export class CoJsonIDBTransaction {
   db: IDBDatabase;
   declare tx: IDBTransaction;
@@ -49,12 +51,6 @@ export class CoJsonIDBTransaction {
 
   rollback() {
     this.tx.abort();
-  }
-
-  startedAt = performance.now();
-  isReusable() {
-    const delta = performance.now() - this.startedAt;
-    return !this.done && !this.failed && delta <= 100;
   }
 
   getObjectStore(name: StoreName) {

--- a/packages/cojson-storage-indexeddb/src/idbClient.ts
+++ b/packages/cojson-storage-indexeddb/src/idbClient.ts
@@ -218,12 +218,14 @@ export class IDBClient implements DBClientInterfaceAsync {
   }
 
   async getUnsyncedCoValueIDs(): Promise<RawCoID[]> {
-    return queryIndexedDbStore<RawCoID[]>(
-      this.db,
-      "unsyncedCoValues",
-      (store) =>
-        store.index("byCoValueId").getAllKeys() as IDBRequest<RawCoID[]>,
-    );
+    const records = await queryIndexedDbStore<
+      Array<{ rowID: number; coValueId: RawCoID; peerId: string }>
+    >(this.db, "unsyncedCoValues", (store) => store.getAll());
+    const uniqueIds = new Set<RawCoID>();
+    for (const record of records) {
+      uniqueIds.add(record.coValueId);
+    }
+    return Array.from(uniqueIds);
   }
 
   async stopTrackingSyncState(id: RawCoID): Promise<void> {

--- a/packages/cojson-storage-indexeddb/src/idbClient.ts
+++ b/packages/cojson-storage-indexeddb/src/idbClient.ts
@@ -276,6 +276,7 @@ export class IDBClient implements DBClientInterfaceAsync {
         for (const record of records) {
           const deleteRequest = store.delete(record.rowID);
           deleteRequest.onerror = () => {
+            console.error(deleteRequest.error);
             if (!hasError) {
               hasError = true;
               reject(deleteRequest.error);

--- a/packages/cojson-storage-indexeddb/src/idbNode.ts
+++ b/packages/cojson-storage-indexeddb/src/idbNode.ts
@@ -53,7 +53,6 @@ export async function getIndexedDBStorage(name = DATABASE_NAME) {
           keyPath: "rowID",
         });
         unsyncedCoValues.createIndex("byCoValueId", "coValueId");
-        unsyncedCoValues.createIndex("byPeerId", "peerId");
         unsyncedCoValues.createIndex(
           "uniqueUnsyncedCoValues",
           ["coValueId", "peerId"],

--- a/packages/cojson-storage-indexeddb/src/idbNode.ts
+++ b/packages/cojson-storage-indexeddb/src/idbNode.ts
@@ -9,7 +9,7 @@ export function internal_setDatabaseName(name: string) {
 
 export async function getIndexedDBStorage(name = DATABASE_NAME) {
   const dbPromise = new Promise<IDBDatabase>((resolve, reject) => {
-    const request = indexedDB.open(name, 4);
+    const request = indexedDB.open(name, 5);
     request.onerror = () => {
       reject(request.error);
     };
@@ -46,6 +46,14 @@ export async function getIndexedDBStorage(name = DATABASE_NAME) {
         db.createObjectStore("signatureAfter", {
           keyPath: ["ses", "idx"],
         });
+      }
+      if (ev.oldVersion <= 4) {
+        const unsyncedCoValues = db.createObjectStore("unsyncedCoValues", {
+          autoIncrement: true,
+          keyPath: "rowID",
+        });
+        unsyncedCoValues.createIndex("byCoValueId", "coValueId");
+        unsyncedCoValues.createIndex("byPeerId", "peerId");
       }
     };
   });

--- a/packages/cojson-storage-indexeddb/src/idbNode.ts
+++ b/packages/cojson-storage-indexeddb/src/idbNode.ts
@@ -54,6 +54,13 @@ export async function getIndexedDBStorage(name = DATABASE_NAME) {
         });
         unsyncedCoValues.createIndex("byCoValueId", "coValueId");
         unsyncedCoValues.createIndex("byPeerId", "peerId");
+        unsyncedCoValues.createIndex(
+          "uniqueUnsyncedCoValues",
+          ["coValueId", "peerId"],
+          {
+            unique: true,
+          },
+        );
       }
     };
   });

--- a/packages/cojson-storage-indexeddb/src/tests/CoJsonIDBTransaction.test.ts
+++ b/packages/cojson-storage-indexeddb/src/tests/CoJsonIDBTransaction.test.ts
@@ -23,6 +23,18 @@ describe("CoJsonIDBTransaction", () => {
         });
         db.createObjectStore("transactions", { keyPath: "id" });
         db.createObjectStore("signatureAfter", { keyPath: "id" });
+        const unsyncedCoValues = db.createObjectStore("unsyncedCoValues", {
+          keyPath: "rowID",
+        });
+        unsyncedCoValues.createIndex("byCoValueId", "coValueId");
+        unsyncedCoValues.createIndex("byPeerId", "peerId");
+        unsyncedCoValues.createIndex(
+          "uniqueUnsyncedCoValues",
+          ["coValueId", "peerId"],
+          {
+            unique: true,
+          },
+        );
       };
 
       request.onsuccess = () => {

--- a/packages/cojson-storage-indexeddb/src/tests/CoJsonIDBTransaction.test.ts
+++ b/packages/cojson-storage-indexeddb/src/tests/CoJsonIDBTransaction.test.ts
@@ -27,7 +27,6 @@ describe("CoJsonIDBTransaction", () => {
           keyPath: "rowID",
         });
         unsyncedCoValues.createIndex("byCoValueId", "coValueId");
-        unsyncedCoValues.createIndex("byPeerId", "peerId");
         unsyncedCoValues.createIndex(
           "uniqueUnsyncedCoValues",
           ["coValueId", "peerId"],

--- a/packages/cojson-storage-indexeddb/src/tests/storage.indexeddb.test.ts
+++ b/packages/cojson-storage-indexeddb/src/tests/storage.indexeddb.test.ts
@@ -589,6 +589,27 @@ describe("sync state persistence", () => {
     await client.gracefulShutdown();
     await syncServer.gracefulShutdown();
   });
+
+  test("unsynced coValues are persisted to storage when the node is shutdown", async () => {
+    const client = createTestNode();
+    client.setStorage(await getIndexedDBStorage());
+
+    const group = client.createGroup();
+    const map = group.createMap();
+    map.set("key", "value");
+
+    // Wait for local transaction to trigger sync
+    await new Promise<void>((resolve) => queueMicrotask(resolve));
+
+    await client.gracefulShutdown();
+
+    const unsyncedCoValueIDs = await new Promise((resolve) =>
+      client.storage?.getUnsyncedCoValueIDs(resolve),
+    );
+    expect(unsyncedCoValueIDs).toHaveLength(2);
+    expect(unsyncedCoValueIDs).toContain(map.id);
+    expect(unsyncedCoValueIDs).toContain(group.id);
+  });
 });
 
 describe("sync resumption", () => {

--- a/packages/cojson-storage-indexeddb/vitest.config.ts
+++ b/packages/cojson-storage-indexeddb/vitest.config.ts
@@ -7,7 +7,12 @@ export default defineProject({
     browser: {
       enabled: true,
       provider: playwright(),
-      instances: [{ browser: "chromium", headless: true }],
+      instances: [
+        {
+          headless: process.env.HEADLESS !== "false",
+          browser: "chromium",
+        },
+      ],
     },
     include: ["src/**/*.test.ts"],
   },

--- a/packages/cojson/src/PeerState.ts
+++ b/packages/cojson/src/PeerState.ts
@@ -1,5 +1,5 @@
 import { PeerKnownState } from "./coValueCore/PeerKnownState.js";
-import { RawCoID, SessionID } from "./ids.js";
+import { RawCoID } from "./ids.js";
 import { CoValueKnownState } from "./knownState.js";
 import { logger } from "./logger.js";
 import { Peer, SyncMessage } from "./sync.js";

--- a/packages/cojson/src/PeerState.ts
+++ b/packages/cojson/src/PeerState.ts
@@ -181,7 +181,7 @@ export class PeerState {
     this.closeListeners.clear();
   }
 
-  gracefulShutdown() {
+  gracefulShutdown(): void {
     if (this.closed) {
       return;
     }

--- a/packages/cojson/src/UnsyncedCoValuesTracker.ts
+++ b/packages/cojson/src/UnsyncedCoValuesTracker.ts
@@ -9,8 +9,8 @@ import type { StorageAPI } from "./storage/types.js";
  */
 const ANY_PEER_ID: PeerID = "any";
 
-// Flush pending updates to storage after 1 second
-let BATCH_DELAY_MS = 1000;
+// Flush pending updates to storage after 200ms
+let BATCH_DELAY_MS = 200;
 
 /**
  * Set the delay for flushing pending sync state updates to storage.

--- a/packages/cojson/src/UnsyncedCoValuesTracker.ts
+++ b/packages/cojson/src/UnsyncedCoValuesTracker.ts
@@ -92,6 +92,23 @@ export class UnsyncedCoValuesTracker {
     this.notifyGlobalListeners(this.isAllSynced());
   }
 
+  /**
+   * Remove all tracking for a CoValue (all peers).
+   * Triggers persistence if storage is available.
+   */
+  removeAll(id: RawCoID): void {
+    const peerSet = this.unsynced.get(id);
+    if (!peerSet) {
+      return;
+    }
+
+    // Remove all peers for this CoValue
+    const peersToRemove = Array.from(peerSet);
+    for (const peerId of peersToRemove) {
+      this.remove(id, peerId);
+    }
+  }
+
   forcePersist(): Promise<void> | undefined {
     return this.flush();
   }

--- a/packages/cojson/src/UnsyncedCoValuesTracker.ts
+++ b/packages/cojson/src/UnsyncedCoValuesTracker.ts
@@ -14,7 +14,7 @@ export class UnsyncedCoValuesTracker {
   // Listeners for global "all synced" status changes
   private globalListeners: Set<(synced: boolean) => void> = new Set();
 
-  constructor(private storage?: StorageAPI) {}
+  constructor(private getStorage: () => StorageAPI | undefined) {}
 
   /**
    * Add a CoValue as unsynced to a specific peer.
@@ -62,9 +62,10 @@ export class UnsyncedCoValuesTracker {
   }
 
   private persist(id: RawCoID, peerId: PeerID, synced: boolean): void {
-    if (this.storage) {
+    const storage = this.storage;
+    if (storage) {
       try {
-        this.storage.trackCoValueSyncStatus(id, peerId, synced);
+        storage.trackCoValueSyncState(id, peerId, synced);
       } catch (error) {
         logger.warn("Failed to persist unsynced CoValue tracking", {
           err: error,
@@ -155,5 +156,9 @@ export class UnsyncedCoValuesTracker {
     for (const listener of this.globalListeners) {
       listener(allSynced);
     }
+  }
+
+  private get storage(): StorageAPI | undefined {
+    return this.getStorage?.();
   }
 }

--- a/packages/cojson/src/UnsyncedCoValuesTracker.ts
+++ b/packages/cojson/src/UnsyncedCoValuesTracker.ts
@@ -1,0 +1,159 @@
+import type { RawCoID } from "./ids.js";
+import { logger } from "./logger.js";
+import type { PeerID } from "./sync.js";
+import type { StorageAPI } from "./storage/types.js";
+
+/**
+ * Tracks CoValues that have unsynced changes to specific peers.
+ * Maintains an in-memory map and periodically persists to storage.
+ */
+export class UnsyncedCoValuesTracker {
+  private unsynced: Map<RawCoID, Set<PeerID>> = new Map();
+  private coValueListeners: Map<RawCoID, Set<(synced: boolean) => void>> =
+    new Map();
+  // Listeners for global "all synced" status changes
+  private globalListeners: Set<(synced: boolean) => void> = new Set();
+
+  constructor(private storage?: StorageAPI) {}
+
+  /**
+   * Add a CoValue as unsynced to a specific peer.
+   * Triggers persistence if storage is available.
+   */
+  add(id: RawCoID, peerId: PeerID): void {
+    if (!this.unsynced.has(id)) {
+      this.unsynced.set(id, new Set());
+    }
+    const peerSet = this.unsynced.get(id)!;
+
+    // Only update if this is a new peer
+    if (!peerSet.has(peerId)) {
+      peerSet.add(peerId);
+
+      this.persist(id, peerId, false);
+
+      this.notifyCoValueListeners(id, false);
+      this.notifyGlobalListeners(false);
+    }
+  }
+
+  /**
+   * Remove a CoValue from being unsynced to a specific peer.
+   * Triggers persistence if storage is available.
+   */
+  remove(id: RawCoID, peerId: PeerID): void {
+    const peerSet = this.unsynced.get(id);
+    if (!peerSet || !peerSet.has(peerId)) {
+      return;
+    }
+
+    peerSet.delete(peerId);
+
+    // If no more unsynced peers for this CoValue, remove the entry
+    if (peerSet.size === 0) {
+      this.unsynced.delete(id);
+    }
+
+    this.persist(id, peerId, true);
+
+    const isSynced = !this.unsynced.has(id);
+    this.notifyCoValueListeners(id, isSynced);
+    this.notifyGlobalListeners(this.isAllSynced());
+  }
+
+  private persist(id: RawCoID, peerId: PeerID, synced: boolean): void {
+    if (this.storage) {
+      try {
+        this.storage.trackCoValueSyncStatus(id, peerId, synced);
+      } catch (error) {
+        logger.warn("Failed to persist unsynced CoValue tracking", {
+          err: error,
+        });
+      }
+    }
+  }
+
+  /**
+   * Get all CoValue IDs that have at least one unsynced peer.
+   */
+  getAll(): RawCoID[] {
+    return Array.from(this.unsynced.keys());
+  }
+
+  /**
+   * Check if all CoValues are synced (O(1)).
+   */
+  isAllSynced(): boolean {
+    return this.unsynced.size === 0;
+  }
+
+  /**
+   * Subscribe to changes in whether a specific CoValue is synced.
+   * The listener is called immediately with the current state.
+   * @returns Unsubscribe function
+   */
+  subscribe(id: RawCoID, listener: (synced: boolean) => void): () => void;
+  /**
+   * Subscribe to changes in whether all CoValues are synced.
+   * The listener is called immediately with the current state.
+   * @returns Unsubscribe function
+   */
+  subscribe(listener: (synced: boolean) => void): () => void;
+  subscribe(
+    idOrListener: RawCoID | ((synced: boolean) => void),
+    listener?: (synced: boolean) => void,
+  ): () => void {
+    if (typeof idOrListener === "string" && listener) {
+      const id = idOrListener;
+      if (!this.coValueListeners.has(id)) {
+        this.coValueListeners.set(id, new Set());
+      }
+      this.coValueListeners.get(id)!.add(listener);
+
+      // Call immediately with current state
+      const isSynced = !this.unsynced.has(id);
+      listener(isSynced);
+
+      return () => {
+        const listeners = this.coValueListeners.get(id);
+        if (listeners) {
+          listeners.delete(listener);
+          if (listeners.size === 0) {
+            this.coValueListeners.delete(id);
+          }
+        }
+      };
+    }
+
+    const globalListener = idOrListener as (synced: boolean) => void;
+    this.globalListeners.add(globalListener);
+
+    // Call immediately with current state
+    globalListener(this.isAllSynced());
+
+    return () => {
+      this.globalListeners.delete(globalListener);
+    };
+  }
+
+  /**
+   * Notify all listeners for a specific CoValue about sync status change.
+   */
+  private notifyCoValueListeners(id: RawCoID, synced: boolean): void {
+    const listeners = this.coValueListeners.get(id);
+    if (listeners) {
+      for (const listener of listeners) {
+        listener(synced);
+      }
+    }
+  }
+
+  /**
+   * Notify all global listeners about "all synced" status change.
+   */
+  private notifyGlobalListeners(allSynced: boolean): void {
+    for (const listener of this.globalListeners) {
+      listener(allSynced);
+    }
+  }
+}

--- a/packages/cojson/src/UnsyncedCoValuesTracker.ts
+++ b/packages/cojson/src/UnsyncedCoValuesTracker.ts
@@ -41,7 +41,7 @@ export class UnsyncedCoValuesTracker {
   private pendingUpdates: PendingUpdate[] = [];
   private flushTimer: ReturnType<typeof setTimeout> | undefined;
 
-  constructor(private getStorage: () => StorageAPI | undefined) {}
+  private storage?: StorageAPI;
 
   /**
    * Add a CoValue as unsynced to a specific peer.
@@ -210,6 +210,14 @@ export class UnsyncedCoValuesTracker {
     };
   }
 
+  setStorage(storage: StorageAPI) {
+    this.storage = storage;
+  }
+
+  removeStorage() {
+    this.storage = undefined;
+  }
+
   /**
    * Notify all listeners for a specific CoValue about sync status change.
    */
@@ -240,9 +248,5 @@ export class UnsyncedCoValuesTracker {
       latestUpdates.set(`${update.id}|${update.peerId}`, update);
     }
     return Array.from(latestUpdates.values());
-  }
-
-  private get storage(): StorageAPI | undefined {
-    return this.getStorage?.();
   }
 }

--- a/packages/cojson/src/UnsyncedCoValuesTracker.ts
+++ b/packages/cojson/src/UnsyncedCoValuesTracker.ts
@@ -138,10 +138,17 @@ export class UnsyncedCoValuesTracker {
   }
 
   /**
-   * Check if all CoValues are synced (O(1)).
+   * Check if all CoValues are synced
    */
   isAllSynced(): boolean {
     return this.unsynced.size === 0;
+  }
+
+  /**
+   * Check if a specific CoValue is tracked as unsynced.
+   */
+  has(id: RawCoID): boolean {
+    return this.unsynced.has(id);
   }
 
   /**

--- a/packages/cojson/src/UnsyncedCoValuesTracker.ts
+++ b/packages/cojson/src/UnsyncedCoValuesTracker.ts
@@ -30,15 +30,17 @@ export class UnsyncedCoValuesTracker {
   /**
    * Add a CoValue as unsynced to a specific peer.
    * Triggers persistence if storage is available.
+   * @returns true if the CoValue was already tracked, false otherwise.
    */
-  add(id: RawCoID, peerId: PeerID): void {
+  add(id: RawCoID, peerId: PeerID): boolean {
     if (!this.unsynced.has(id)) {
       this.unsynced.set(id, new Set());
     }
     const peerSet = this.unsynced.get(id)!;
 
-    // Only update if this is a new peer
-    if (!peerSet.has(peerId)) {
+    const alreadyTracked = peerSet.has(peerId);
+    if (!alreadyTracked) {
+      // Only update if this is a new peer
       peerSet.add(peerId);
 
       this.schedulePersist(id, peerId, false);
@@ -46,6 +48,8 @@ export class UnsyncedCoValuesTracker {
       this.notifyCoValueListeners(id, false);
       this.notifyGlobalListeners(false);
     }
+
+    return alreadyTracked;
   }
 
   /**

--- a/packages/cojson/src/UnsyncedCoValuesTracker.ts
+++ b/packages/cojson/src/UnsyncedCoValuesTracker.ts
@@ -4,6 +4,12 @@ import type { PeerID } from "./sync.js";
 import type { StorageAPI } from "./storage/types.js";
 
 /**
+ * Used to track a CoValue that hasn't been synced to any peer,
+ * because none is currently connected.
+ */
+const ANY_PEER_ID: PeerID = "any";
+
+/**
  * Tracks CoValues that have unsynced changes to specific peers.
  * Maintains an in-memory map and periodically persists to storage.
  */
@@ -32,7 +38,7 @@ export class UnsyncedCoValuesTracker {
    * Triggers persistence if storage is available.
    * @returns true if the CoValue was already tracked, false otherwise.
    */
-  add(id: RawCoID, peerId: PeerID): boolean {
+  add(id: RawCoID, peerId: PeerID = ANY_PEER_ID): boolean {
     if (!this.unsynced.has(id)) {
       this.unsynced.set(id, new Set());
     }
@@ -56,7 +62,7 @@ export class UnsyncedCoValuesTracker {
    * Remove a CoValue from being unsynced to a specific peer.
    * Triggers persistence if storage is available.
    */
-  remove(id: RawCoID, peerId: PeerID): void {
+  remove(id: RawCoID, peerId: PeerID = ANY_PEER_ID): void {
     const peerSet = this.unsynced.get(id);
     if (!peerSet || !peerSet.has(peerId)) {
       return;

--- a/packages/cojson/src/UnsyncedCoValuesTracker.ts
+++ b/packages/cojson/src/UnsyncedCoValuesTracker.ts
@@ -9,6 +9,17 @@ import type { StorageAPI } from "./storage/types.js";
  */
 const ANY_PEER_ID: PeerID = "any";
 
+// Flush pending updates to storage after 1 second
+let BATCH_DELAY_MS = 1000;
+
+/**
+ * Set the delay for flushing pending sync state updates to storage.
+ * @internal
+ */
+export function setSyncStateTrackingBatchDelay(delay: number): void {
+  BATCH_DELAY_MS = delay;
+}
+
 type PendingUpdate = {
   id: RawCoID;
   peerId: PeerID;
@@ -29,7 +40,6 @@ export class UnsyncedCoValuesTracker {
   // Pending updates to be persisted
   private pendingUpdates: PendingUpdate[] = [];
   private flushTimer: ReturnType<typeof setTimeout> | undefined;
-  private readonly BATCH_DELAY_MS = 1000; // Flush after 1s
 
   constructor(private getStorage: () => StorageAPI | undefined) {}
 
@@ -92,7 +102,7 @@ export class UnsyncedCoValuesTracker {
     if (!this.flushTimer) {
       this.flushTimer = setTimeout(() => {
         this.flush();
-      }, this.BATCH_DELAY_MS);
+      }, BATCH_DELAY_MS);
     }
   }
 

--- a/packages/cojson/src/exports.ts
+++ b/packages/cojson/src/exports.ts
@@ -65,7 +65,7 @@ import type { AgentID, RawCoID, SessionID } from "./ids.js";
 import type { JsonObject, JsonValue } from "./jsonValue.js";
 import type * as Media from "./media.js";
 import { isAccountRole } from "./permissions.js";
-import type { Peer, SyncMessage } from "./sync.js";
+import type { Peer, SyncMessage, SyncWhen } from "./sync.js";
 import {
   DisconnectedError,
   SyncManager,
@@ -193,6 +193,7 @@ export type {
   AccountRole,
   AvailableCoValueCore,
   PeerState,
+  SyncWhen,
   CoValueHeader,
 };
 

--- a/packages/cojson/src/exports.ts
+++ b/packages/cojson/src/exports.ts
@@ -71,6 +71,7 @@ import {
   SyncManager,
   hwrServerPeerSelector,
 } from "./sync.js";
+import { setSyncStateTrackingBatchDelay } from "./UnsyncedCoValuesTracker.js";
 import { emptyKnownState } from "./knownState.js";
 
 import {
@@ -125,6 +126,7 @@ export const cojsonInternals = {
   setCoValueLoadingRetryDelay,
   setCoValueLoadingMaxRetries,
   setCoValueLoadingTimeout,
+  setSyncStateTrackingBatchDelay,
   ConnectedPeerChannel,
   textEncoder,
   textDecoder,

--- a/packages/cojson/src/localNode.ts
+++ b/packages/cojson/src/localNode.ts
@@ -830,9 +830,10 @@ export class LocalNode {
    * @returns Promise of the current pending store operation, if any.
    */
   gracefulShutdown(): Promise<unknown> | undefined {
-    this.syncManager.gracefulShutdown();
     this.garbageCollector?.stop();
-    return this.storage?.close();
+    return this.syncManager
+      .gracefulShutdown()
+      ?.then(() => this.storage?.close());
   }
 }
 

--- a/packages/cojson/src/localNode.ts
+++ b/packages/cojson/src/localNode.ts
@@ -829,11 +829,10 @@ export class LocalNode {
    *
    * @returns Promise of the current pending store operation, if any.
    */
-  gracefulShutdown(): Promise<unknown> | undefined {
+  async gracefulShutdown(): Promise<unknown> {
     this.garbageCollector?.stop();
-    return this.syncManager
-      .gracefulShutdown()
-      ?.then(() => this.storage?.close());
+    await this.syncManager.gracefulShutdown();
+    return this.storage?.close();
   }
 }
 

--- a/packages/cojson/src/localNode.ts
+++ b/packages/cojson/src/localNode.ts
@@ -95,11 +95,13 @@ export class LocalNode {
 
   setStorage(storage: StorageAPI) {
     this.storage = storage;
+    this.syncManager.setStorage(storage);
   }
 
   removeStorage() {
     this.storage?.close();
     this.storage = undefined;
+    this.syncManager.removeStorage();
   }
 
   hasCoValue(id: RawCoID) {

--- a/packages/cojson/src/localNode.ts
+++ b/packages/cojson/src/localNode.ts
@@ -34,7 +34,7 @@ import { AgentSecret, CryptoProvider } from "./crypto/crypto.js";
 import { AgentID, RawCoID, SessionID, isAgentID, isRawCoID } from "./ids.js";
 import { logger } from "./logger.js";
 import { StorageAPI } from "./storage/index.js";
-import { Peer, PeerID, SyncManager } from "./sync.js";
+import { Peer, PeerID, SyncManager, type SyncWhen } from "./sync.js";
 import { accountOrAgentIDfromSessionID } from "./typeUtils/accountOrAgentIDfromSessionID.js";
 import { expectGroup } from "./typeUtils/expectGroup.js";
 import { canBeBranched } from "./coValueCore/branching.js";
@@ -75,6 +75,7 @@ export class LocalNode {
     agentSecret: AgentSecret,
     currentSessionID: SessionID,
     crypto: CryptoProvider,
+    public readonly syncWhen?: SyncWhen,
   ) {
     this.agentSecret = agentSecret;
     this.currentSessionID = currentSessionID;
@@ -178,12 +179,14 @@ export class LocalNode {
     crypto: CryptoProvider;
     initialAgentSecret?: AgentSecret;
     peers?: Peer[];
+    syncWhen?: SyncWhen;
     storage?: StorageAPI;
   }): RawAccount {
     const {
       crypto,
       initialAgentSecret = crypto.newRandomAgentSecret(),
       peers = [],
+      syncWhen,
     } = opts;
     const accountHeader = accountHeaderForInitialAgentSecret(
       initialAgentSecret,
@@ -195,6 +198,7 @@ export class LocalNode {
       initialAgentSecret,
       crypto.newRandomSessionID(accountID as RawAccountID),
       crypto,
+      syncWhen,
     );
 
     if (opts.storage) {
@@ -236,6 +240,7 @@ export class LocalNode {
   static async withNewlyCreatedAccount({
     creationProps,
     peers,
+    syncWhen,
     migration,
     crypto,
     initialAgentSecret = crypto.newRandomAgentSecret(),
@@ -243,6 +248,7 @@ export class LocalNode {
   }: {
     creationProps: { name: string };
     peers?: Peer[];
+    syncWhen?: SyncWhen;
     migration?: RawAccountMigration<AccountMeta>;
     crypto: CryptoProvider;
     initialAgentSecret?: AgentSecret;
@@ -257,6 +263,7 @@ export class LocalNode {
       crypto,
       initialAgentSecret,
       peers,
+      syncWhen,
       storage,
     });
     const node = account.core.node;
@@ -299,6 +306,7 @@ export class LocalNode {
     accountSecret,
     sessionID,
     peers,
+    syncWhen,
     crypto,
     migration,
     storage,
@@ -307,6 +315,7 @@ export class LocalNode {
     accountSecret: AgentSecret;
     sessionID: SessionID | undefined;
     peers: Peer[];
+    syncWhen?: SyncWhen;
     crypto: CryptoProvider;
     migration?: RawAccountMigration<AccountMeta>;
     storage?: StorageAPI;
@@ -318,6 +327,7 @@ export class LocalNode {
         accountSecret,
         sessionID || crypto.newRandomSessionID(accountID),
         crypto,
+        syncWhen,
       );
 
       if (storage) {

--- a/packages/cojson/src/storage/sqlite/client.ts
+++ b/packages/cojson/src/storage/sqlite/client.ts
@@ -195,7 +195,7 @@ export class SQLiteClient
     return undefined;
   }
 
-  trackCoValueSyncStatus(id: RawCoID, peerId: PeerID, synced: boolean): void {
+  trackCoValueSyncState(id: RawCoID, peerId: PeerID, synced: boolean): void {
     if (synced) {
       // Delete the record if synced
       this.db.run(
@@ -219,7 +219,7 @@ export class SQLiteClient
     return rows.map((row) => row.co_value_id);
   }
 
-  stopTrackingSyncStatus(id: RawCoID): void {
+  stopTrackingSyncState(id: RawCoID): void {
     this.db.run("DELETE FROM unsynced_covalues WHERE co_value_id = ?", [id]);
   }
 }

--- a/packages/cojson/src/storage/sqlite/client.ts
+++ b/packages/cojson/src/storage/sqlite/client.ts
@@ -204,27 +204,21 @@ export class SQLiteClient
   }
 
   trackCoValuesSyncState(
-    operations: Array<{ id: RawCoID; peerId: PeerID; synced: boolean }>,
+    updates: { id: RawCoID; peerId: PeerID; synced: boolean }[],
   ): void {
-    if (operations.length === 0) {
-      return;
-    }
-
-    this.db.transaction(() => {
-      for (const op of operations) {
-        if (op.synced) {
-          this.db.run(
-            "DELETE FROM unsynced_covalues WHERE co_value_id = ? AND peer_id = ?",
-            [op.id, op.peerId],
-          );
-        } else {
-          this.db.run(
-            "INSERT OR REPLACE INTO unsynced_covalues (co_value_id, peer_id) VALUES (?, ?)",
-            [op.id, op.peerId],
-          );
-        }
+    for (const update of updates) {
+      if (update.synced) {
+        this.db.run(
+          "DELETE FROM unsynced_covalues WHERE co_value_id = ? AND peer_id = ?",
+          [update.id, update.peerId],
+        );
+      } else {
+        this.db.run(
+          "INSERT OR REPLACE INTO unsynced_covalues (co_value_id, peer_id) VALUES (?, ?)",
+          [update.id, update.peerId],
+        );
       }
-    });
+    }
   }
 
   stopTrackingSyncState(id: RawCoID): void {

--- a/packages/cojson/src/storage/sqlite/sqliteMigrations.ts
+++ b/packages/cojson/src/storage/sqlite/sqliteMigrations.ts
@@ -39,7 +39,6 @@ export const migrations: Record<number, string[]> = {
       UNIQUE (co_value_id, peer_id)
     );`,
     "CREATE INDEX IF NOT EXISTS idx_unsynced_covalues_co_value_id ON unsynced_covalues(co_value_id);",
-    "CREATE INDEX IF NOT EXISTS idx_unsynced_covalues_peer_id ON unsynced_covalues(peer_id);",
   ],
 };
 

--- a/packages/cojson/src/storage/sqlite/sqliteMigrations.ts
+++ b/packages/cojson/src/storage/sqlite/sqliteMigrations.ts
@@ -31,6 +31,16 @@ export const migrations: Record<number, string[]> = {
     ) WITHOUT ROWID;`,
     "ALTER TABLE sessions ADD COLUMN bytesSinceLastSignature INTEGER;",
   ],
+  4: [
+    `CREATE TABLE IF NOT EXISTS unsynced_covalues (
+      rowID INTEGER PRIMARY KEY,
+      co_value_id TEXT NOT NULL,
+      peer_id TEXT NOT NULL,
+      UNIQUE (co_value_id, peer_id)
+    );`,
+    "CREATE INDEX IF NOT EXISTS idx_unsynced_covalues_co_value_id ON unsynced_covalues(co_value_id);",
+    "CREATE INDEX IF NOT EXISTS idx_unsynced_covalues_peer_id ON unsynced_covalues(peer_id);",
+  ],
 };
 
 type Migration = {

--- a/packages/cojson/src/storage/sqliteAsync/client.ts
+++ b/packages/cojson/src/storage/sqliteAsync/client.ts
@@ -203,7 +203,7 @@ export class SQLiteClientAsync
     return this.db.transaction(() => operationsCallback(this));
   }
 
-  async trackCoValueSyncStatus(
+  async trackCoValueSyncState(
     id: RawCoID,
     peerId: PeerID,
     synced: boolean,
@@ -231,7 +231,7 @@ export class SQLiteClientAsync
     return rows.map((row) => row.co_value_id);
   }
 
-  async stopTrackingSyncStatus(id: RawCoID): Promise<void> {
+  async stopTrackingSyncState(id: RawCoID): Promise<void> {
     await this.db.run("DELETE FROM unsynced_covalues WHERE co_value_id = ?", [
       id,
     ]);

--- a/packages/cojson/src/storage/storageAsync.ts
+++ b/packages/cojson/src/storage/storageAsync.ts
@@ -394,8 +394,9 @@ export class StorageApiAsync implements StorageAPI {
 
   trackCoValuesSyncState(
     updates: { id: RawCoID; peerId: PeerID; synced: boolean }[],
+    done?: () => void,
   ): void {
-    this.dbClient.trackCoValuesSyncState(updates);
+    this.dbClient.trackCoValuesSyncState(updates).then(() => done?.());
   }
 
   getUnsyncedCoValueIDs(

--- a/packages/cojson/src/storage/storageAsync.ts
+++ b/packages/cojson/src/storage/storageAsync.ts
@@ -392,8 +392,8 @@ export class StorageApiAsync implements StorageAPI {
     return this.knownStates.waitForSync(id, coValue);
   }
 
-  trackCoValueSyncStatus(id: RawCoID, peerId: PeerID, synced: boolean): void {
-    this.dbClient.trackCoValueSyncStatus(id, peerId, synced);
+  trackCoValueSyncState(id: RawCoID, peerId: PeerID, synced: boolean): void {
+    this.dbClient.trackCoValueSyncState(id, peerId, synced);
   }
 
   getUnsyncedCoValueIDs(
@@ -402,8 +402,8 @@ export class StorageApiAsync implements StorageAPI {
     this.dbClient.getUnsyncedCoValueIDs().then(callback);
   }
 
-  stopTrackingSyncStatus(id: RawCoID): void {
-    this.dbClient.stopTrackingSyncStatus(id);
+  stopTrackingSyncState(id: RawCoID): void {
+    this.dbClient.stopTrackingSyncState(id);
   }
 
   close() {

--- a/packages/cojson/src/storage/storageAsync.ts
+++ b/packages/cojson/src/storage/storageAsync.ts
@@ -392,8 +392,10 @@ export class StorageApiAsync implements StorageAPI {
     return this.knownStates.waitForSync(id, coValue);
   }
 
-  trackCoValueSyncState(id: RawCoID, peerId: PeerID, synced: boolean): void {
-    this.dbClient.trackCoValueSyncState(id, peerId, synced);
+  trackCoValuesSyncState(
+    operations: Array<{ id: RawCoID; peerId: PeerID; synced: boolean }>,
+  ): void {
+    this.dbClient.trackCoValuesSyncState(operations);
   }
 
   getUnsyncedCoValueIDs(

--- a/packages/cojson/src/storage/storageAsync.ts
+++ b/packages/cojson/src/storage/storageAsync.ts
@@ -10,7 +10,7 @@ import {
   logger,
 } from "../exports.js";
 import { StoreQueue } from "../queue/StoreQueue.js";
-import { NewContentMessage } from "../sync.js";
+import { NewContentMessage, type PeerID } from "../sync.js";
 import {
   CoValueKnownState,
   emptyKnownState,
@@ -390,6 +390,20 @@ export class StorageApiAsync implements StorageAPI {
 
   waitForSync(id: string, coValue: CoValueCore) {
     return this.knownStates.waitForSync(id, coValue);
+  }
+
+  trackCoValueSyncStatus(id: RawCoID, peerId: PeerID, synced: boolean): void {
+    this.dbClient.trackCoValueSyncStatus(id, peerId, synced);
+  }
+
+  getUnsyncedCoValueIDs(
+    callback: (unsyncedCoValueIDs: RawCoID[]) => void,
+  ): void {
+    this.dbClient.getUnsyncedCoValueIDs().then(callback);
+  }
+
+  stopTrackingSyncStatus(id: RawCoID): void {
+    this.dbClient.stopTrackingSyncStatus(id);
   }
 
   close() {

--- a/packages/cojson/src/storage/storageAsync.ts
+++ b/packages/cojson/src/storage/storageAsync.ts
@@ -393,9 +393,9 @@ export class StorageApiAsync implements StorageAPI {
   }
 
   trackCoValuesSyncState(
-    operations: Array<{ id: RawCoID; peerId: PeerID; synced: boolean }>,
+    updates: { id: RawCoID; peerId: PeerID; synced: boolean }[],
   ): void {
-    this.dbClient.trackCoValuesSyncState(operations);
+    this.dbClient.trackCoValuesSyncState(updates);
   }
 
   getUnsyncedCoValueIDs(

--- a/packages/cojson/src/storage/storageSync.ts
+++ b/packages/cojson/src/storage/storageSync.ts
@@ -10,7 +10,7 @@ import {
   type StorageAPI,
   logger,
 } from "../exports.js";
-import { NewContentMessage } from "../sync.js";
+import { NewContentMessage, type PeerID } from "../sync.js";
 import { StorageKnownState } from "./knownState.js";
 import {
   CoValueKnownState,
@@ -363,6 +363,21 @@ export class StorageApiSync implements StorageAPI {
 
   waitForSync(id: string, coValue: CoValueCore) {
     return this.knownStates.waitForSync(id, coValue);
+  }
+
+  trackCoValueSyncStatus(id: RawCoID, peerId: PeerID, synced: boolean): void {
+    this.dbClient.trackCoValueSyncStatus(id, peerId, synced);
+  }
+
+  getUnsyncedCoValueIDs(
+    callback: (unsyncedCoValueIDs: RawCoID[]) => void,
+  ): void {
+    const ids = this.dbClient.getUnsyncedCoValueIDs();
+    callback(ids);
+  }
+
+  stopTrackingSyncStatus(id: RawCoID): void {
+    this.dbClient.stopTrackingSyncStatus(id);
   }
 
   close() {

--- a/packages/cojson/src/storage/storageSync.ts
+++ b/packages/cojson/src/storage/storageSync.ts
@@ -367,8 +367,10 @@ export class StorageApiSync implements StorageAPI {
 
   trackCoValuesSyncState(
     updates: { id: RawCoID; peerId: PeerID; synced: boolean }[],
+    done?: () => void,
   ): void {
     this.dbClient.trackCoValuesSyncState(updates);
+    done?.();
   }
 
   getUnsyncedCoValueIDs(

--- a/packages/cojson/src/storage/storageSync.ts
+++ b/packages/cojson/src/storage/storageSync.ts
@@ -365,8 +365,10 @@ export class StorageApiSync implements StorageAPI {
     return this.knownStates.waitForSync(id, coValue);
   }
 
-  trackCoValueSyncState(id: RawCoID, peerId: PeerID, synced: boolean): void {
-    this.dbClient.trackCoValueSyncState(id, peerId, synced);
+  trackCoValuesSyncState(
+    operations: Array<{ id: RawCoID; peerId: PeerID; synced: boolean }>,
+  ): void {
+    this.dbClient.trackCoValuesSyncState(operations);
   }
 
   getUnsyncedCoValueIDs(

--- a/packages/cojson/src/storage/storageSync.ts
+++ b/packages/cojson/src/storage/storageSync.ts
@@ -366,9 +366,9 @@ export class StorageApiSync implements StorageAPI {
   }
 
   trackCoValuesSyncState(
-    operations: Array<{ id: RawCoID; peerId: PeerID; synced: boolean }>,
+    updates: { id: RawCoID; peerId: PeerID; synced: boolean }[],
   ): void {
-    this.dbClient.trackCoValuesSyncState(operations);
+    this.dbClient.trackCoValuesSyncState(updates);
   }
 
   getUnsyncedCoValueIDs(

--- a/packages/cojson/src/storage/storageSync.ts
+++ b/packages/cojson/src/storage/storageSync.ts
@@ -365,8 +365,8 @@ export class StorageApiSync implements StorageAPI {
     return this.knownStates.waitForSync(id, coValue);
   }
 
-  trackCoValueSyncStatus(id: RawCoID, peerId: PeerID, synced: boolean): void {
-    this.dbClient.trackCoValueSyncStatus(id, peerId, synced);
+  trackCoValueSyncState(id: RawCoID, peerId: PeerID, synced: boolean): void {
+    this.dbClient.trackCoValueSyncState(id, peerId, synced);
   }
 
   getUnsyncedCoValueIDs(
@@ -376,8 +376,8 @@ export class StorageApiSync implements StorageAPI {
     callback(ids);
   }
 
-  stopTrackingSyncStatus(id: RawCoID): void {
-    this.dbClient.stopTrackingSyncStatus(id);
+  stopTrackingSyncState(id: RawCoID): void {
+    this.dbClient.stopTrackingSyncState(id);
   }
 
   close() {

--- a/packages/cojson/src/storage/types.ts
+++ b/packages/cojson/src/storage/types.ts
@@ -31,9 +31,11 @@ export interface StorageAPI {
   waitForSync(id: string, coValue: CoValueCore): Promise<void>;
 
   /**
-   * Track the sync status of a CoValue for a specific peer.
+   * Track multiple sync status updates in a single transaction
    */
-  trackCoValueSyncState(id: RawCoID, peerId: PeerID, synced: boolean): void;
+  trackCoValuesSyncState(
+    operations: Array<{ id: RawCoID; peerId: PeerID; synced: boolean }>,
+  ): void;
 
   /**
    * Get all CoValue IDs that have at least one unsynced peer.
@@ -137,10 +139,8 @@ export interface DBClientInterfaceAsync {
     callback: (tx: DBTransactionInterfaceAsync) => Promise<unknown>,
   ): Promise<unknown>;
 
-  trackCoValueSyncState(
-    id: RawCoID,
-    peerId: PeerID,
-    synced: boolean,
+  trackCoValuesSyncState(
+    operations: Array<{ id: RawCoID; peerId: PeerID; synced: boolean }>,
   ): Promise<void>;
 
   getUnsyncedCoValueIDs(): Promise<RawCoID[]>;
@@ -199,7 +199,9 @@ export interface DBClientInterfaceSync {
 
   transaction(callback: (tx: DBTransactionInterfaceSync) => unknown): unknown;
 
-  trackCoValueSyncState(id: RawCoID, peerId: PeerID, synced: boolean): void;
+  trackCoValuesSyncState(
+    operations: Array<{ id: RawCoID; peerId: PeerID; synced: boolean }>,
+  ): void;
 
   getUnsyncedCoValueIDs(): RawCoID[];
 

--- a/packages/cojson/src/storage/types.ts
+++ b/packages/cojson/src/storage/types.ts
@@ -33,7 +33,7 @@ export interface StorageAPI {
   /**
    * Track the sync status of a CoValue for a specific peer.
    */
-  trackCoValueSyncStatus(id: RawCoID, peerId: PeerID, synced: boolean): void;
+  trackCoValueSyncState(id: RawCoID, peerId: PeerID, synced: boolean): void;
 
   /**
    * Get all CoValue IDs that have at least one unsynced peer.
@@ -45,7 +45,7 @@ export interface StorageAPI {
   /**
    * Stop tracking sync status for a CoValue (remove all peer entries).
    */
-  stopTrackingSyncStatus(id: RawCoID): void;
+  stopTrackingSyncState(id: RawCoID): void;
 
   close(): Promise<unknown> | undefined;
 }
@@ -137,7 +137,7 @@ export interface DBClientInterfaceAsync {
     callback: (tx: DBTransactionInterfaceAsync) => Promise<unknown>,
   ): Promise<unknown>;
 
-  trackCoValueSyncStatus(
+  trackCoValueSyncState(
     id: RawCoID,
     peerId: PeerID,
     synced: boolean,
@@ -145,7 +145,7 @@ export interface DBClientInterfaceAsync {
 
   getUnsyncedCoValueIDs(): Promise<RawCoID[]>;
 
-  stopTrackingSyncStatus(id: RawCoID): Promise<void>;
+  stopTrackingSyncState(id: RawCoID): Promise<void>;
 }
 
 export interface DBTransactionInterfaceSync {
@@ -199,9 +199,9 @@ export interface DBClientInterfaceSync {
 
   transaction(callback: (tx: DBTransactionInterfaceSync) => unknown): unknown;
 
-  trackCoValueSyncStatus(id: RawCoID, peerId: PeerID, synced: boolean): void;
+  trackCoValueSyncState(id: RawCoID, peerId: PeerID, synced: boolean): void;
 
   getUnsyncedCoValueIDs(): RawCoID[];
 
-  stopTrackingSyncStatus(id: RawCoID): void;
+  stopTrackingSyncState(id: RawCoID): void;
 }

--- a/packages/cojson/src/storage/types.ts
+++ b/packages/cojson/src/storage/types.ts
@@ -5,6 +5,7 @@ import type {
 import { Signature } from "../crypto/crypto.js";
 import type { CoValueCore, RawCoID, SessionID } from "../exports.js";
 import { NewContentMessage } from "../sync.js";
+import type { PeerID } from "../sync.js";
 import { CoValueKnownState } from "../knownState.js";
 
 export type CorrectionCallback = (
@@ -28,6 +29,23 @@ export interface StorageAPI {
   getKnownState(id: string): CoValueKnownState;
 
   waitForSync(id: string, coValue: CoValueCore): Promise<void>;
+
+  /**
+   * Track the sync status of a CoValue for a specific peer.
+   */
+  trackCoValueSyncStatus(id: RawCoID, peerId: PeerID, synced: boolean): void;
+
+  /**
+   * Get all CoValue IDs that have at least one unsynced peer.
+   */
+  getUnsyncedCoValueIDs(
+    callback: (unsyncedCoValueIDs: RawCoID[]) => void,
+  ): void;
+
+  /**
+   * Stop tracking sync status for a CoValue (remove all peer entries).
+   */
+  stopTrackingSyncStatus(id: RawCoID): void;
 
   close(): Promise<unknown> | undefined;
 }
@@ -118,6 +136,16 @@ export interface DBClientInterfaceAsync {
   transaction(
     callback: (tx: DBTransactionInterfaceAsync) => Promise<unknown>,
   ): Promise<unknown>;
+
+  trackCoValueSyncStatus(
+    id: RawCoID,
+    peerId: PeerID,
+    synced: boolean,
+  ): Promise<void>;
+
+  getUnsyncedCoValueIDs(): Promise<RawCoID[]>;
+
+  stopTrackingSyncStatus(id: RawCoID): Promise<void>;
 }
 
 export interface DBTransactionInterfaceSync {
@@ -170,4 +198,10 @@ export interface DBClientInterfaceSync {
   ): Pick<SignatureAfterRow, "idx" | "signature">[];
 
   transaction(callback: (tx: DBTransactionInterfaceSync) => unknown): unknown;
+
+  trackCoValueSyncStatus(id: RawCoID, peerId: PeerID, synced: boolean): void;
+
+  getUnsyncedCoValueIDs(): RawCoID[];
+
+  stopTrackingSyncStatus(id: RawCoID): void;
 }

--- a/packages/cojson/src/storage/types.ts
+++ b/packages/cojson/src/storage/types.ts
@@ -31,10 +31,12 @@ export interface StorageAPI {
   waitForSync(id: string, coValue: CoValueCore): Promise<void>;
 
   /**
-   * Track multiple sync status updates in a single transaction
+   * Track multiple sync status updates.
+   * Does not guarantee the updates will be applied in order, so only one
+   * update per CoValue ID + Peer ID combination should be tracked at a time.
    */
   trackCoValuesSyncState(
-    operations: Array<{ id: RawCoID; peerId: PeerID; synced: boolean }>,
+    updates: { id: RawCoID; peerId: PeerID; synced: boolean }[],
   ): void;
 
   /**
@@ -140,7 +142,7 @@ export interface DBClientInterfaceAsync {
   ): Promise<unknown>;
 
   trackCoValuesSyncState(
-    operations: Array<{ id: RawCoID; peerId: PeerID; synced: boolean }>,
+    updates: { id: RawCoID; peerId: PeerID; synced: boolean }[],
   ): Promise<void>;
 
   getUnsyncedCoValueIDs(): Promise<RawCoID[]>;
@@ -200,7 +202,7 @@ export interface DBClientInterfaceSync {
   transaction(callback: (tx: DBTransactionInterfaceSync) => unknown): unknown;
 
   trackCoValuesSyncState(
-    operations: Array<{ id: RawCoID; peerId: PeerID; synced: boolean }>,
+    updates: { id: RawCoID; peerId: PeerID; synced: boolean }[],
   ): void;
 
   getUnsyncedCoValueIDs(): RawCoID[];

--- a/packages/cojson/src/storage/types.ts
+++ b/packages/cojson/src/storage/types.ts
@@ -37,6 +37,7 @@ export interface StorageAPI {
    */
   trackCoValuesSyncState(
     updates: { id: RawCoID; peerId: PeerID; synced: boolean }[],
+    done?: () => void,
   ): void;
 
   /**

--- a/packages/cojson/src/sync.ts
+++ b/packages/cojson/src/sync.ts
@@ -921,6 +921,9 @@ export class SyncManager {
     }
 
     for (const peer of peers) {
+      if (this.syncState.isSynced(peer, coValueId)) {
+        continue;
+      }
       const alreadyTracked = this.unsyncedTracker.add(coValueId, peer.id);
       if (alreadyTracked) {
         continue;

--- a/packages/cojson/src/sync.ts
+++ b/packages/cojson/src/sync.ts
@@ -898,9 +898,9 @@ export class SyncManager {
 
       const unsubscribe = this.syncState.subscribeToPeerUpdates(
         peer.id,
-        (knownState, syncState) => {
-          // Only handle updates for this specific CoValue
-          if (knownState.id === coValueId && syncState.uploaded) {
+        coValueId,
+        (_knownState, syncState) => {
+          if (syncState.uploaded) {
             this.unsyncedTracker.remove(coValueId, peer.id);
             unsubscribe();
           }
@@ -958,8 +958,9 @@ export class SyncManager {
     return new Promise((resolve, reject) => {
       const unsubscribe = this.syncState.subscribeToPeerUpdates(
         peerId,
-        (knownState, syncState) => {
-          if (syncState.uploaded && knownState.id === id) {
+        id,
+        (_knownState, syncState) => {
+          if (syncState.uploaded) {
             resolve(true);
             unsubscribe?.();
             clearTimeout(timeoutId);

--- a/packages/cojson/src/sync.ts
+++ b/packages/cojson/src/sync.ts
@@ -1059,10 +1059,15 @@ export class SyncManager {
     this.unsyncedTracker.removeStorage();
   }
 
-  gracefulShutdown() {
+  /**
+   * Closes all the peer connections and ensures the list of unsynced coValues is persisted to storage.
+   * @returns Promise of the current pending store operation, if any.
+   */
+  gracefulShutdown(): Promise<void> | undefined {
     for (const peer of Object.values(this.peers)) {
       peer.gracefulShutdown();
     }
+    return this.unsyncedTracker.forcePersist();
   }
 }
 

--- a/packages/cojson/src/sync.ts
+++ b/packages/cojson/src/sync.ts
@@ -817,10 +817,6 @@ export class SyncManager {
       this.storeContent(validNewContent);
     }
 
-    if (sourceRole === "client" && hasNewContent) {
-      this.trackSyncState(coValue.id);
-    }
-
     for (const peer of this.getPeers(coValue.id)) {
       /**
        * We sync the content against the source peer if it is a client or server peers

--- a/packages/cojson/src/sync.ts
+++ b/packages/cojson/src/sync.ts
@@ -905,16 +905,6 @@ export class SyncManager {
     const isSyncRequired = this.local.syncWhen !== "never";
     if (isSyncRequired && peers.length === 0) {
       this.unsyncedTracker.add(coValueId);
-
-      const unsubscribe = this.syncState.subscribeToCoValueUpdates(
-        coValueId,
-        (_peerId, _knownState, syncState) => {
-          if (syncState.uploaded) {
-            this.unsyncedTracker.remove(coValueId);
-            unsubscribe();
-          }
-        },
-      );
       return;
     }
 

--- a/packages/cojson/src/sync.ts
+++ b/packages/cojson/src/sync.ts
@@ -894,7 +894,10 @@ export class SyncManager {
 
   private trackSyncState(coValueId: RawCoID): void {
     for (const peer of this.getPersistentServerPeers(coValueId)) {
-      this.unsyncedTracker.add(coValueId, peer.id);
+      const alreadyTracked = this.unsyncedTracker.add(coValueId, peer.id);
+      if (alreadyTracked) {
+        continue;
+      }
 
       const unsubscribe = this.syncState.subscribeToPeerUpdates(
         peer.id,

--- a/packages/cojson/src/sync.ts
+++ b/packages/cojson/src/sync.ts
@@ -316,7 +316,7 @@ export class SyncManager {
                     coValue.loadFromStorage((found) => {
                       if (!found) {
                         // CoValue could not be loaded from storage, stop tracking
-                        this.local.storage?.stopTrackingSyncState(coValueId);
+                        this.unsyncedTracker.removeAll(coValueId);
                       }
                       resolve();
                     });
@@ -329,7 +329,7 @@ export class SyncManager {
                         coValueId,
                       },
                     );
-                    this.local.storage?.stopTrackingSyncState(coValueId);
+                    this.unsyncedTracker.removeAll(coValueId);
                     resolve();
                   }
                 }),

--- a/packages/cojson/src/sync.ts
+++ b/packages/cojson/src/sync.ts
@@ -318,7 +318,7 @@ export class SyncManager {
 
           if (processed < unsyncedCoValueIDs.length) {
             // Process next batch asynchronously to avoid blocking
-            setTimeout(processBatch, 0);
+            setTimeout(() => processBatch().catch(reject), 0);
           } else {
             resolve();
           }
@@ -899,7 +899,6 @@ export class SyncManager {
       const unsubscribe = this.syncState.subscribeToPeerUpdates(
         peer.id,
         (knownState, syncState) => {
-          console.log("peer state updated", knownState, syncState);
           // Only handle updates for this specific CoValue
           if (knownState.id === coValueId && syncState.uploaded) {
             this.unsyncedTracker.remove(coValueId, peer.id);

--- a/packages/cojson/src/sync.ts
+++ b/packages/cojson/src/sync.ts
@@ -830,6 +830,9 @@ export class SyncManager {
 
     if (from !== "storage" && hasNewContent) {
       this.storeContent(validNewContent);
+      if (from === "import") {
+        this.trackSyncState(coValue.id);
+      }
     }
 
     for (const peer of this.getPeers(coValue.id)) {

--- a/packages/cojson/src/sync.ts
+++ b/packages/cojson/src/sync.ts
@@ -283,7 +283,7 @@ export class SyncManager {
 
     await new Promise<void>((resolve, reject) => {
       // Load all persisted unsynced CoValues from storage
-      this.local.storage!.getUnsyncedCoValueIDs((unsyncedCoValueIDs) => {
+      this.local.storage?.getUnsyncedCoValueIDs((unsyncedCoValueIDs) => {
         const coValuesToLoad = unsyncedCoValueIDs.filter(
           (coValueId) => !this.local.hasCoValue(coValueId),
         );
@@ -304,14 +304,12 @@ export class SyncManager {
                 // Load the CoValue from storage (this will trigger sync if peers are connected)
                 const coValue = await this.local.loadCoValueCore(coValueId);
 
+                // Clear previous tracking
+                this.local.storage?.stopTrackingSyncState(coValueId);
                 if (coValue.isAvailable()) {
                   // CoValue was successfully loaded. Resume tracking sync state for this CoValue
                   // This will add it back to the tracker and set up subscriptions
-                  // TODO delete outdated tracking before new tracking
                   this.trackSyncState(coValueId);
-                } else {
-                  // CoValue not found in storage. Remove all peer entries for this CoValue
-                  this.local.storage!.stopTrackingSyncState(coValueId);
                 }
               } catch (error) {
                 // Handle errors gracefully - log but don't fail the entire resumption
@@ -319,7 +317,7 @@ export class SyncManager {
                   err: error,
                   coValueId,
                 });
-                this.local.storage!.stopTrackingSyncState(coValueId);
+                this.local.storage?.stopTrackingSyncState(coValueId);
               }
             }),
           );

--- a/packages/cojson/src/sync.ts
+++ b/packages/cojson/src/sync.ts
@@ -24,6 +24,7 @@ import {
   knownStateFrom,
   KnownStateSessions,
 } from "./knownState.js";
+import { StorageAPI } from "./storage/index.js";
 
 export type SyncMessage =
   | LoadMessage
@@ -131,7 +132,7 @@ export class SyncManager {
   constructor(local: LocalNode) {
     this.local = local;
     this.syncState = new SyncStateManager(this);
-    this.unsyncedTracker = new UnsyncedCoValuesTracker(() => local.storage);
+    this.unsyncedTracker = new UnsyncedCoValuesTracker();
 
     this.transactionsSizeHistogram = metrics
       .getMeter("cojson")
@@ -1033,6 +1034,14 @@ export class SyncManager {
     return Promise.all(
       validCoValues.map((coValue) => this.waitForSync(coValue.id, timeout)),
     );
+  }
+
+  setStorage(storage: StorageAPI) {
+    this.unsyncedTracker.setStorage(storage);
+  }
+
+  removeStorage() {
+    this.unsyncedTracker.removeStorage();
   }
 
   gracefulShutdown() {

--- a/packages/cojson/src/sync.ts
+++ b/packages/cojson/src/sync.ts
@@ -341,10 +341,12 @@ export class SyncManager {
   }
 
   startPeerReconciliation(peer: PeerState) {
-    // Resume syncing unsynced CoValues asynchronously
-    this.resumeUnsyncedCoValues().catch((error) => {
-      logger.warn("Failed to resume unsynced CoValues:", error);
-    });
+    if (peer.role === "server" && peer.persistent) {
+      // Resume syncing unsynced CoValues asynchronously
+      this.resumeUnsyncedCoValues().catch((error) => {
+        logger.warn("Failed to resume unsynced CoValues:", error);
+      });
+    }
 
     const coValuesOrderedByDependency: CoValueCore[] = [];
 

--- a/packages/cojson/src/tests/SyncStateManager.test.ts
+++ b/packages/cojson/src/tests/SyncStateManager.test.ts
@@ -78,10 +78,12 @@ describe("SyncStateManager", () => {
     const updateToStorageSpy: PeerSyncStateListenerCallback = vi.fn();
     const unsubscribe1 = subscriptionManager.subscribeToPeerUpdates(
       peerState.id,
+      map.core.id,
       updateToJazzCloudSpy,
     );
     const unsubscribe2 = subscriptionManager.subscribeToPeerUpdates(
       serverPeer.id,
+      group.core.id,
       updateToStorageSpy,
     );
 
@@ -141,6 +143,7 @@ describe("SyncStateManager", () => {
     const unsubscribe1 = subscriptionManager.subscribeToUpdates(anyUpdateSpy);
     const unsubscribe2 = subscriptionManager.subscribeToPeerUpdates(
       peerState.id,
+      map.core.id,
       anyUpdateSpy,
     );
 

--- a/packages/cojson/src/tests/coValueCore.loadFromStorage.test.ts
+++ b/packages/cojson/src/tests/coValueCore.loadFromStorage.test.ts
@@ -37,7 +37,7 @@ function createMockStorage(
     store?: (data: any, correctionCallback: any) => void;
     getKnownState?: (id: RawCoID) => any;
     waitForSync?: (id: string, coValue: any) => Promise<void>;
-    trackCoValueSyncStatus?: (
+    trackCoValueSyncState?: (
       id: RawCoID,
       peerId: PeerID,
       synced: boolean,
@@ -45,7 +45,7 @@ function createMockStorage(
     getUnsyncedCoValueIDs?: (
       callback: (unsyncedCoValueIDs: RawCoID[]) => void,
     ) => void;
-    stopTrackingSyncStatus?: (id: RawCoID) => void;
+    stopTrackingSyncState?: (id: RawCoID) => void;
     close?: () => Promise<unknown> | undefined;
   } = {},
 ): StorageAPI {
@@ -54,9 +54,9 @@ function createMockStorage(
     store: opts.store || vi.fn(),
     getKnownState: opts.getKnownState || vi.fn(),
     waitForSync: opts.waitForSync || vi.fn().mockResolvedValue(undefined),
-    trackCoValueSyncStatus: opts.trackCoValueSyncStatus || vi.fn(),
+    trackCoValueSyncState: opts.trackCoValueSyncState || vi.fn(),
     getUnsyncedCoValueIDs: opts.getUnsyncedCoValueIDs || vi.fn(),
-    stopTrackingSyncStatus: opts.stopTrackingSyncStatus || vi.fn(),
+    stopTrackingSyncState: opts.stopTrackingSyncState || vi.fn(),
     close: opts.close || vi.fn().mockResolvedValue(undefined),
   };
 }

--- a/packages/cojson/src/tests/coValueCore.loadFromStorage.test.ts
+++ b/packages/cojson/src/tests/coValueCore.loadFromStorage.test.ts
@@ -37,10 +37,8 @@ function createMockStorage(
     store?: (data: any, correctionCallback: any) => void;
     getKnownState?: (id: RawCoID) => any;
     waitForSync?: (id: string, coValue: any) => Promise<void>;
-    trackCoValueSyncState?: (
-      id: RawCoID,
-      peerId: PeerID,
-      synced: boolean,
+    trackCoValuesSyncState?: (
+      operations: Array<{ id: RawCoID; peerId: PeerID; synced: boolean }>,
     ) => void;
     getUnsyncedCoValueIDs?: (
       callback: (unsyncedCoValueIDs: RawCoID[]) => void,
@@ -54,7 +52,7 @@ function createMockStorage(
     store: opts.store || vi.fn(),
     getKnownState: opts.getKnownState || vi.fn(),
     waitForSync: opts.waitForSync || vi.fn().mockResolvedValue(undefined),
-    trackCoValueSyncState: opts.trackCoValueSyncState || vi.fn(),
+    trackCoValuesSyncState: opts.trackCoValuesSyncState || vi.fn(),
     getUnsyncedCoValueIDs: opts.getUnsyncedCoValueIDs || vi.fn(),
     stopTrackingSyncState: opts.stopTrackingSyncState || vi.fn(),
     close: opts.close || vi.fn().mockResolvedValue(undefined),

--- a/packages/cojson/src/tests/coValueCore.loadFromStorage.test.ts
+++ b/packages/cojson/src/tests/coValueCore.loadFromStorage.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { RawCoID } from "../ids";
+import { PeerID } from "../sync";
 import { StorageAPI } from "../storage/types";
 import {
   createTestMetricReader,
@@ -36,6 +37,15 @@ function createMockStorage(
     store?: (data: any, correctionCallback: any) => void;
     getKnownState?: (id: RawCoID) => any;
     waitForSync?: (id: string, coValue: any) => Promise<void>;
+    trackCoValueSyncStatus?: (
+      id: RawCoID,
+      peerId: PeerID,
+      synced: boolean,
+    ) => void;
+    getUnsyncedCoValueIDs?: (
+      callback: (unsyncedCoValueIDs: RawCoID[]) => void,
+    ) => void;
+    stopTrackingSyncStatus?: (id: RawCoID) => void;
     close?: () => Promise<unknown> | undefined;
   } = {},
 ): StorageAPI {
@@ -44,6 +54,9 @@ function createMockStorage(
     store: opts.store || vi.fn(),
     getKnownState: opts.getKnownState || vi.fn(),
     waitForSync: opts.waitForSync || vi.fn().mockResolvedValue(undefined),
+    trackCoValueSyncStatus: opts.trackCoValueSyncStatus || vi.fn(),
+    getUnsyncedCoValueIDs: opts.getUnsyncedCoValueIDs || vi.fn(),
+    stopTrackingSyncStatus: opts.stopTrackingSyncStatus || vi.fn(),
     close: opts.close || vi.fn().mockResolvedValue(undefined),
   };
 }

--- a/packages/cojson/src/tests/sync.tracking.test.ts
+++ b/packages/cojson/src/tests/sync.tracking.test.ts
@@ -126,42 +126,6 @@ describe("coValue sync state tracking", () => {
     const unsyncedTracker = client.syncManager.unsyncedTracker;
     expect(unsyncedTracker.has(map.id)).toBe(false);
   });
-
-  test("coValues modified by client peers are tracked as unsynced", async () => {
-    const {
-      node: edgeSyncServer,
-      connectToSyncServer: edgeConnectToSyncServer,
-    } = setupTestNode({ isSyncServer: true });
-    const { peerState: coreServerPeerState } = edgeConnectToSyncServer({
-      syncServer: jazzCloud.node,
-      syncServerName: "core",
-    });
-
-    const { node: client, connectToSyncServer: clientConnectToSyncServer } =
-      setupTestNode();
-    clientConnectToSyncServer({
-      syncServer: edgeSyncServer,
-      syncServerName: "edge",
-    });
-
-    const group = client.createGroup();
-    const map = group.createMap();
-    map.set("key", "value");
-
-    await map.core.waitForSync();
-
-    const unsyncedTracker = edgeSyncServer.syncManager.unsyncedTracker;
-    expect(unsyncedTracker.has(map.id)).toBe(true);
-
-    // Wait for the map to sync to jazzCloud (the core server)
-    await waitFor(() =>
-      edgeSyncServer.syncManager.syncState.isSynced(
-        coreServerPeerState,
-        map.id,
-      ),
-    );
-    expect(unsyncedTracker.has(map.id)).toBe(false);
-  });
 });
 
 describe("sync state persistence", () => {

--- a/packages/cojson/src/tests/sync.tracking.test.ts
+++ b/packages/cojson/src/tests/sync.tracking.test.ts
@@ -1,0 +1,158 @@
+import { beforeEach, describe, expect, test } from "vitest";
+import {
+  blockMessageTypeOnOutgoingPeer,
+  SyncMessagesLog,
+  TEST_NODE_CONFIG,
+  setupTestNode,
+  waitFor,
+} from "./testUtils";
+
+let jazzCloud: ReturnType<typeof setupTestNode>;
+
+beforeEach(async () => {
+  // We want to simulate a real world communication that happens asynchronously
+  TEST_NODE_CONFIG.withAsyncPeers = true;
+
+  SyncMessagesLog.clear();
+  jazzCloud = setupTestNode({ isSyncServer: true });
+});
+
+describe("coValue sync state tracking", () => {
+  test("coValues with unsynced local changes are tracked as unsynced", async () => {
+    const { node: client } = setupTestNode({ connected: true });
+
+    const group = client.createGroup();
+    const map = group.createMap();
+    map.set("key", "value");
+
+    // Wait for local transaction to trigger sync
+    await new Promise<void>((resolve) => queueMicrotask(resolve));
+
+    const unsyncedTracker = client.syncManager.unsyncedTracker;
+    expect(unsyncedTracker.has(map.id)).toBe(true);
+  });
+
+  test("coValue is marked as synced when all persistent server peers have received the content", async () => {
+    const { node: client } = setupTestNode({ connected: true });
+
+    const group = client.createGroup();
+    const map = group.createMap();
+    map.set("key", "value");
+
+    // Wait for local transaction to trigger sync
+    await new Promise<void>((resolve) => queueMicrotask(resolve));
+
+    const unsyncedTracker = client.syncManager.unsyncedTracker;
+    expect(unsyncedTracker.has(map.id)).toBe(true);
+
+    const serverPeer =
+      client.syncManager.peers[jazzCloud.node.currentSessionID]!;
+    await waitFor(() =>
+      client.syncManager.syncState.isSynced(serverPeer, map.id),
+    );
+    expect(unsyncedTracker.has(map.id)).toBe(false);
+  });
+
+  test("coValues are tracked as unsynced even if there are no persistent server peers", async () => {
+    const { node: client } = setupTestNode({ connected: false });
+
+    const group = client.createGroup();
+    const map = group.createMap();
+    map.set("key", "value");
+
+    await new Promise<void>((resolve) => queueMicrotask(resolve));
+
+    const unsyncedTracker = client.syncManager.unsyncedTracker;
+    expect(unsyncedTracker.has(map.id)).toBe(true);
+  });
+
+  test("only tracks sync state for persistent servers peers", async () => {
+    const { node: client, connectToSyncServer } = setupTestNode({
+      connected: true,
+    });
+
+    // Add a second server peer that is NOT persistent
+    const server2 = setupTestNode({ isSyncServer: true });
+    const { peer: server2PeerOnClient, peerState: server2PeerStateOnClient } =
+      connectToSyncServer({
+        syncServer: server2.node,
+        syncServerName: "server2",
+        persistent: false,
+      });
+
+    // Do not deliver new content messages to the second server peer
+    blockMessageTypeOnOutgoingPeer(server2PeerOnClient, "content", {});
+
+    const group = client.createGroup();
+    const map = group.createMap();
+    map.set("key", "value");
+
+    await new Promise<void>((resolve) => queueMicrotask(resolve));
+
+    const unsyncedTracker = client.syncManager.unsyncedTracker;
+    expect(unsyncedTracker.has(map.id)).toBe(true);
+
+    const serverPeer =
+      client.syncManager.peers[jazzCloud.node.currentSessionID]!;
+    await waitFor(() =>
+      client.syncManager.syncState.isSynced(serverPeer, map.id),
+    );
+
+    expect(
+      client.syncManager.syncState.isSynced(server2PeerStateOnClient, map.id),
+    ).toBe(false);
+    expect(unsyncedTracker.has(map.id)).toBe(false);
+  });
+
+  test("coValues are not tracked as unsynced if sync is disabled", async () => {
+    const { node: client } = setupTestNode({
+      connected: false,
+      syncWhen: "never",
+    });
+
+    const group = client.createGroup();
+    const map = group.createMap();
+    map.set("key", "value");
+
+    await new Promise<void>((resolve) => queueMicrotask(resolve));
+
+    const unsyncedTracker = client.syncManager.unsyncedTracker;
+    expect(unsyncedTracker.has(map.id)).toBe(false);
+  });
+
+  test("coValues modified by client peers are tracked as unsynced", async () => {
+    const {
+      node: edgeSyncServer,
+      connectToSyncServer: edgeConnectToSyncServer,
+    } = setupTestNode({ isSyncServer: true });
+    const { peerState: coreServerPeerState } = edgeConnectToSyncServer({
+      syncServer: jazzCloud.node,
+      syncServerName: "core",
+    });
+
+    const { node: client, connectToSyncServer: clientConnectToSyncServer } =
+      setupTestNode();
+    clientConnectToSyncServer({
+      syncServer: edgeSyncServer,
+      syncServerName: "edge",
+    });
+
+    const group = client.createGroup();
+    const map = group.createMap();
+    map.set("key", "value");
+
+    await map.core.waitForSync();
+
+    const unsyncedTracker = edgeSyncServer.syncManager.unsyncedTracker;
+    expect(unsyncedTracker.has(map.id)).toBe(true);
+
+    // Wait for the map to sync to jazzCloud (the core server)
+    await waitFor(() =>
+      edgeSyncServer.syncManager.syncState.isSynced(
+        coreServerPeerState,
+        map.id,
+      ),
+    );
+    expect(unsyncedTracker.has(map.id)).toBe(false);
+  });
+});

--- a/packages/cojson/src/tests/sync.tracking.test.ts
+++ b/packages/cojson/src/tests/sync.tracking.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test } from "vitest";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import { setSyncStateTrackingBatchDelay } from "../UnsyncedCoValuesTracker";
 import {
   blockMessageTypeOnOutgoingPeer,
@@ -16,6 +16,12 @@ beforeEach(async () => {
 
   SyncMessagesLog.clear();
   jazzCloud = setupTestNode({ isSyncServer: true });
+
+  setSyncStateTrackingBatchDelay(0);
+});
+
+afterEach(() => {
+  setSyncStateTrackingBatchDelay(1000);
 });
 
 describe("coValue sync state tracking", () => {
@@ -159,14 +165,6 @@ describe("coValue sync state tracking", () => {
 });
 
 describe("sync state persistence", () => {
-  beforeEach(() => {
-    setSyncStateTrackingBatchDelay(0);
-  });
-
-  afterEach(() => {
-    setSyncStateTrackingBatchDelay(1000);
-  });
-
   test("unsynced coValues are asynchronously persisted to storage", async () => {
     const { node: client, addStorage } = setupTestNode({ connected: false });
     addStorage();
@@ -202,5 +200,81 @@ describe("sync state persistence", () => {
     );
     expect(unsyncedCoValueIDs).toHaveLength(0);
     expect(client.syncManager.unsyncedTracker.has(map.id)).toBe(false);
+  });
+});
+
+describe("sync resumption", () => {
+  test("unsynced coValues are resumed when the node is restarted", async () => {
+    const client = setupTestNode({ connected: false });
+    const { storage } = client.addStorage();
+
+    const getUnsyncedCoValueIDsFromStorage = async () =>
+      new Promise<string[]>((resolve) =>
+        client.node.storage?.getUnsyncedCoValueIDs(resolve),
+      );
+
+    const group = client.node.createGroup();
+    const map = group.createMap();
+    map.set("key", "value");
+
+    // Wait for the unsynced coValues to be persisted to storage
+    await new Promise<void>((resolve) => setTimeout(resolve, 100));
+
+    const unsyncedTracker = client.node.syncManager.unsyncedTracker;
+    expect(unsyncedTracker.has(map.id)).toBe(true);
+    expect(await getUnsyncedCoValueIDsFromStorage()).toHaveLength(2);
+
+    client.restart();
+    client.addStorage({ storage });
+    const { peerState: serverPeerState } = client.connectToSyncServer();
+
+    // Wait for sync to resume & complete
+    await waitFor(
+      async () => (await getUnsyncedCoValueIDsFromStorage()).length === 0,
+    );
+    expect(
+      client.node.syncManager.syncState.isSynced(serverPeerState, map.id),
+    ).toBe(true);
+  });
+
+  test("old peer entries are removed from storage when restarting with new peers", async () => {
+    const client = setupTestNode();
+    const { peer: serverPeer } = client.connectToSyncServer({
+      persistent: true,
+    });
+    const { storage } = client.addStorage();
+
+    // Do not deliver new content messages to the sync server
+    blockMessageTypeOnOutgoingPeer(serverPeer, "content", {});
+
+    const getUnsyncedCoValueIDsFromStorage = async () =>
+      new Promise<string[]>((resolve) =>
+        client.node.storage?.getUnsyncedCoValueIDs(resolve),
+      );
+
+    const group = client.node.createGroup();
+    const map = group.createMap();
+    map.set("key", "value");
+
+    // Wait for the unsynced coValues to be persisted to storage
+    await new Promise<void>((resolve) => setTimeout(resolve, 100));
+
+    expect(await getUnsyncedCoValueIDsFromStorage()).toHaveLength(2);
+
+    client.restart();
+    client.addStorage({ storage });
+    const newSyncServer = setupTestNode({ isSyncServer: true });
+    const { peerState: newServerPeerState } = client.connectToSyncServer({
+      syncServer: newSyncServer.node,
+      persistent: true,
+    });
+
+    // Wait for sync to resume & complete
+    await waitFor(
+      async () => (await getUnsyncedCoValueIDsFromStorage()).length === 0,
+    );
+    expect(
+      client.node.syncManager.syncState.isSynced(newServerPeerState, map.id),
+    ).toBe(true);
   });
 });

--- a/packages/cojson/src/tests/testUtils.ts
+++ b/packages/cojson/src/tests/testUtils.ts
@@ -22,7 +22,7 @@ import {
 import type { SessionID } from "../ids.js";
 import { LocalNode } from "../localNode.js";
 import { connectedPeers } from "../streamUtils.js";
-import type { Peer, SyncMessage } from "../sync.js";
+import type { Peer, SyncMessage, SyncWhen } from "../sync.js";
 import { expectGroup } from "../typeUtils/expectGroup.js";
 import { toSimplifiedMessages } from "./messagesTestUtils.js";
 import { createAsyncStorage, createSyncStorage } from "./testStorage.js";
@@ -449,13 +449,14 @@ export function setupTestNode(
     isSyncServer?: boolean;
     connected?: boolean;
     secret?: AgentSecret;
+    syncWhen?: SyncWhen;
   } = {},
 ) {
   const [admin, session] = opts.secret
     ? agentAndSessionIDFromSecret(opts.secret)
     : randomAgentAndSessionID();
 
-  let node = new LocalNode(admin.agentSecret, session, Crypto);
+  let node = new LocalNode(admin.agentSecret, session, Crypto, opts.syncWhen);
 
   if (opts.isSyncServer) {
     syncServer.current = node;

--- a/packages/cojson/src/tests/testUtils.ts
+++ b/packages/cojson/src/tests/testUtils.ts
@@ -528,7 +528,12 @@ export function setupTestNode(
     addAsyncStorage,
     restart: () => {
       node.gracefulShutdown();
-      ctx.node = node = new LocalNode(admin.agentSecret, session, Crypto);
+      ctx.node = node = new LocalNode(
+        admin.agentSecret,
+        session,
+        Crypto,
+        opts.syncWhen,
+      );
 
       if (opts.isSyncServer) {
         syncServer.current = node;

--- a/packages/jazz-tools/src/browser/createBrowserContext.ts
+++ b/packages/jazz-tools/src/browser/createBrowserContext.ts
@@ -64,6 +64,7 @@ async function setupPeers(options: BaseBrowserContextOptions) {
       connected: () => false,
       toggleNetwork: () => {},
       peers,
+      syncWhen: options.sync.when,
       storage,
       setNode: () => {},
       crypto,
@@ -114,6 +115,7 @@ async function setupPeers(options: BaseBrowserContextOptions) {
       return wsPeer.connected;
     },
     peers,
+    syncWhen: options.sync.when,
     storage,
     setNode,
     crypto,
@@ -126,6 +128,7 @@ export async function createJazzBrowserGuestContext(
   const {
     toggleNetwork,
     peers,
+    syncWhen,
     setNode,
     crypto,
     storage,
@@ -136,6 +139,7 @@ export async function createJazzBrowserGuestContext(
   const context = await createAnonymousJazzContext({
     crypto,
     peers,
+    syncWhen,
     storage,
   });
 
@@ -178,6 +182,7 @@ export async function createJazzBrowserContext<
   const {
     toggleNetwork,
     peers,
+    syncWhen,
     setNode,
     crypto,
     storage,
@@ -207,6 +212,7 @@ export async function createJazzBrowserContext<
     credentials: options.credentials,
     newAccountProps: options.newAccountProps,
     peers,
+    syncWhen,
     storage,
     crypto,
     defaultProfileName: options.defaultProfileName,

--- a/packages/jazz-tools/src/react-native-core/platform.ts
+++ b/packages/jazz-tools/src/react-native-core/platform.ts
@@ -57,6 +57,7 @@ async function setupPeers(options: BaseReactNativeContextOptions) {
       addConnectionListener: () => () => {},
       connected: () => false,
       peers,
+      syncWhen: options.sync.when,
       setNode: () => {},
       crypto,
       storage,
@@ -105,6 +106,7 @@ async function setupPeers(options: BaseReactNativeContextOptions) {
     },
     connected: () => wsPeer.connected,
     peers,
+    syncWhen: options.sync.when,
     setNode,
     crypto,
     storage,
@@ -117,6 +119,7 @@ export async function createJazzReactNativeGuestContext(
   const {
     toggleNetwork,
     peers,
+    syncWhen,
     setNode,
     crypto,
     storage,
@@ -127,6 +130,7 @@ export async function createJazzReactNativeGuestContext(
   const context = createAnonymousJazzContext({
     crypto,
     peers,
+    syncWhen,
     storage,
   });
 
@@ -169,6 +173,7 @@ export async function createJazzReactNativeContext<
   const {
     toggleNetwork,
     peers,
+    syncWhen,
     setNode,
     crypto,
     storage,
@@ -203,6 +208,7 @@ export async function createJazzReactNativeContext<
     credentials: options.credentials,
     newAccountProps: options.newAccountProps,
     peers,
+    syncWhen,
     crypto,
     defaultProfileName: options.defaultProfileName,
     AccountSchema: options.AccountSchema,

--- a/packages/jazz-tools/src/tools/implementation/createContext.ts
+++ b/packages/jazz-tools/src/tools/implementation/createContext.ts
@@ -171,7 +171,7 @@ export async function createJazzContextFromExistingCredentials<
       sessionDone();
     },
     logOut: async () => {
-      node.gracefulShutdown();
+      await node.gracefulShutdown();
       sessionDone();
       await onLogOut?.();
     },
@@ -240,7 +240,7 @@ export async function createJazzContextForNewAccount<
       sessionDone();
     },
     logOut: async () => {
-      node.gracefulShutdown();
+      await node.gracefulShutdown();
       await onLogOut?.();
     },
   };

--- a/packages/jazz-tools/src/tools/implementation/createContext.ts
+++ b/packages/jazz-tools/src/tools/implementation/createContext.ts
@@ -18,6 +18,7 @@ import {
   type ID,
   type InstanceOfSchema,
   coValueClassFromCoValueClassOrSchema,
+  type SyncWhen,
 } from "../internal.js";
 import { AuthCredentials, NewAccountProps } from "../types.js";
 import { activeAccountContext } from "./activeAccountContext.js";
@@ -110,6 +111,7 @@ export async function createJazzContextFromExistingCredentials<
 >({
   credentials,
   peers,
+  syncWhen,
   crypto,
   storage,
   AccountSchema: PropsAccountSchema,
@@ -119,6 +121,7 @@ export async function createJazzContextFromExistingCredentials<
 }: {
   credentials: Credentials;
   peers: Peer[];
+  syncWhen?: SyncWhen;
   crypto: CryptoProvider;
   AccountSchema?: S;
   sessionProvider: SessionProvider;
@@ -140,9 +143,10 @@ export async function createJazzContextFromExistingCredentials<
   const node = await LocalNode.withLoadedAccount({
     accountID: credentials.accountID as unknown as CoID<RawAccount>,
     accountSecret: credentials.secret,
-    sessionID: sessionID,
-    peers: peers,
-    crypto: crypto,
+    sessionID,
+    peers,
+    syncWhen,
+    crypto,
     storage,
     migration: async (rawAccount, _node, creationProps) => {
       const account = AccountClass.fromRaw(rawAccount) as InstanceOfSchema<S>;
@@ -182,6 +186,7 @@ export async function createJazzContextForNewAccount<
   creationProps,
   initialAgentSecret,
   peers,
+  syncWhen,
   crypto,
   AccountSchema: PropsAccountSchema,
   onLogOut,
@@ -191,6 +196,7 @@ export async function createJazzContextForNewAccount<
   creationProps: { name: string };
   initialAgentSecret?: AgentSecret;
   peers: Peer[];
+  syncWhen?: SyncWhen;
   crypto: CryptoProvider;
   AccountSchema?: S;
   onLogOut?: () => Promise<void>;
@@ -206,6 +212,7 @@ export async function createJazzContextForNewAccount<
   const { node } = await LocalNode.withNewlyCreatedAccount({
     creationProps,
     peers,
+    syncWhen,
     crypto,
     initialAgentSecret,
     storage,
@@ -247,6 +254,7 @@ export async function createJazzContext<
   credentials?: AuthCredentials;
   newAccountProps?: NewAccountProps;
   peers: Peer[];
+  syncWhen?: SyncWhen;
   crypto: CryptoProvider;
   defaultProfileName?: string;
   AccountSchema?: S;
@@ -271,6 +279,7 @@ export async function createJazzContext<
         secret: credentials.accountSecret,
       },
       peers: options.peers,
+      syncWhen: options.syncWhen,
       crypto,
       AccountSchema: options.AccountSchema,
       sessionProvider: options.sessionProvider,
@@ -295,6 +304,7 @@ export async function createJazzContext<
       creationProps,
       initialAgentSecret,
       peers: options.peers,
+      syncWhen: options.syncWhen,
       crypto,
       AccountSchema: options.AccountSchema,
       sessionProvider: options.sessionProvider,
@@ -322,10 +332,12 @@ export async function createJazzContext<
 
 export function createAnonymousJazzContext({
   peers,
+  syncWhen,
   crypto,
   storage,
 }: {
   peers: Peer[];
+  syncWhen?: SyncWhen;
   crypto: CryptoProvider;
   storage?: StorageAPI;
 }): JazzContextWithAgent {
@@ -335,6 +347,7 @@ export function createAnonymousJazzContext({
     agentSecret,
     crypto.newRandomSessionID(crypto.getAgentID(agentSecret)),
     crypto,
+    syncWhen,
   );
 
   for (const peer of peers) {

--- a/packages/jazz-tools/src/tools/types.ts
+++ b/packages/jazz-tools/src/tools/types.ts
@@ -1,6 +1,8 @@
 import type { AgentSecret, LocalNode } from "cojson";
 import type { Account, AnonymousJazzAgent, ID } from "./internal.js";
 
+export type { SyncWhen } from "cojson";
+
 export type AuthCredentials = {
   accountID: ID<Account>;
   secretSeed?: Uint8Array;

--- a/tests/stress-test/src/2_main.tsx
+++ b/tests/stress-test/src/2_main.tsx
@@ -170,6 +170,14 @@ function HomeScreen() {
                   e.currentTarget.style.borderColor = "#e1e5e9";
                 }}
               >
+                <DeleteButton
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    me.root.projects.$jazz.remove(
+                      (p) => p.$jazz.id === project.$jazz.id,
+                    );
+                  }}
+                />
                 <div
                   style={{
                     position: "absolute",
@@ -239,5 +247,48 @@ function HomeScreen() {
           })}
       </div>
     </div>
+  );
+}
+
+function DeleteButton({
+  onClick,
+}: {
+  onClick: (e: React.MouseEvent<HTMLButtonElement>) => void;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      style={{
+        position: "absolute",
+        top: "24px",
+        right: "24px",
+        background: "white",
+        border: "1px solid #e1e5e9",
+        borderRadius: "6px",
+        padding: "6px",
+        cursor: "pointer",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        transition: "all 0.2s ease-in-out",
+        zIndex: 10,
+      }}
+      title="Delete project"
+    >
+      <svg
+        width="16"
+        height="16"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="#6b7280"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <path d="M3 6h18" />
+        <path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6" />
+        <path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2" />
+      </svg>
+    </button>
   );
 }


### PR DESCRIPTION
# Description

Currently, if CoValue sync is interrupted and the app is restarted, the sync process won't resume until the unsynced CoValue is loaded again.

This PR implements sync state tracking for CoValues in persistent storage, so that the sync process can be automatically resumed when the app restarts. Sync resumption is performed in batches, to avoid slowing down the performance of the app on startup.

## Manual testing

Ran some performance testing in the browser to analyze the additional cost of tracking CoValue sync state. After applying some performance optimizations (persist pending sync updates in batches, minimize the number of times the sync state tracking callbacks are executed), managed to reduce it to what I consider a reasonable cost:

<img width="1728" height="551" alt="Screenshot_2025-12-30_at_2 56 34_PM" src="https://github.com/user-attachments/assets/ad1a0f53-4fa0-4327-b86d-95d501d45778" />

This measures the time it takes to create 10k tasks in the stress test app (which means creating 30k CoValues, including the tasks themselves, their group owners & their text content).

## Tests

- [x] Tests have been added and/or updated

## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes => don't think it's necessary. If you do, let me know
- [x] I've generated a changeset, if a version bump is required
- [x] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces persisted tracking of unsynced `CoValue`s and automatic sync resumption after restart, focused on persistent server peers and batched writes for performance.
> 
> - New `UnsyncedCoValuesTracker` with batched storage persistence, per-`CoValue`/global subscriptions, and flush on `gracefulShutdown`
> - Extend `StorageAPI` with `trackCoValuesSyncState`, `getUnsyncedCoValueIDs`, `stopTrackingSyncState`
> - IndexedDB: new `unsyncedCoValues` store, schema v5, CRUD in `idbClient`; SQLite: new `unsynced_covalues` table + migrations and client methods
> - `SyncManager` integration: `trackSyncState`, `resumeUnsyncedCoValues()` (batched), only track persistent server peers, resume during `startPeerReconciliation`
> - `SyncStateManager.subscribeToPeerUpdates` now keyed by `(peerId, coValueId)`; related call sites updated
> - `LocalNode`/contexts accept `syncWhen` and propagate; logout/shutdown now awaits tracker flush
> - Tests added for tracking, persistence, resumption; IDB transaction supports custom store sets; minor test/config updates
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 633321e69f7c0dbab3a58c3f2ece766019e97daa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->