### PR TITLE
feat: narrow accepted types for the `uniqueness` parameter

### DIFF
--- a/.changeset/strict-uniqueness-type.md
+++ b/.changeset/strict-uniqueness-type.md
@@ -1,0 +1,11 @@
+---
+"cojson": minor
+---
+
+Restricted the `Uniqueness` type to only accept specific values instead of any `JsonValue`. 
+The allowed types are now: `string`, `number` (as integers), `boolean`, `null`, `undefined`, 
+or an object with string values. Arrays, non-integer numbers, and objects with non-string values are no longer 
+accepted and will throw an error.
+
+Deprecated `number`, even if it is an integer, as it is not a valid uniqueness type in TS, if you want to continue using numbers, 
+use a string instead or ignore the type check.

--- a/homepage/homepage/content/docs/upgrade/0-20-0.mdx
+++ b/homepage/homepage/content/docs/upgrade/0-20-0.mdx
@@ -160,3 +160,19 @@ export function MyJazzProvider({ children }: { children: React.ReactNode }) {
 ```
 </CodeGroup>
 
+### unique validation
+
+The `unique` value is now strict to only accept specific values instead of any `JsonValue`.
+The allowed types are now: `string`, `boolean`, `null`, `undefined`, or an object with string values.
+If you were using numbers, we suggest you to use a string instead or ignore the type check.
+
+<CodeGroup>
+```ts
+import { CoMap } from "jazz-tools/tools/coValues";
+
+const comap = CoMap.create({}, {
+  // @ts-ignore
+  unique: 123,
+});
+```
+</CodeGroup>

--- a/packages/cojson/src/coValueCore/verifiedState.ts
+++ b/packages/cojson/src/coValueCore/verifiedState.ts
@@ -35,9 +35,18 @@ export type CoValueHeader = {
 } & CoValueUniqueness;
 
 export type CoValueUniqueness = {
-  uniqueness: JsonValue;
+  uniqueness: Uniqueness;
   createdAt?: `2${string}` | null;
 };
+
+export type Uniqueness =
+  | string
+  | boolean
+  | null
+  | undefined
+  | {
+      [key: string]: string;
+    };
 
 export type PrivateTransaction = {
   privacy: "private";

--- a/packages/cojson/src/tests/coValueCore.test.ts
+++ b/packages/cojson/src/tests/coValueCore.test.ts
@@ -16,6 +16,7 @@ import {
   createTestMetricReader,
   createTestNode,
   createTwoConnectedNodes,
+  createUnloadedCoValue,
   loadCoValueOrFail,
   nodeWithRandomAgentAndSessionID,
   randomAgentAndSessionID,
@@ -905,4 +906,42 @@ test("knownState should return the same object until the CoValue is modified", (
   const knownState6 = map.core.knownState();
   expect(knownState6).not.toBe(knownState4);
   expect(knownState6).not.toBe(knownState1);
+});
+
+describe("provideHeader uniqueness validation", () => {
+  test("should reject number uniqueness", () => {
+    const node = createTestNode();
+    const { coValue, header } = createUnloadedCoValue(node);
+
+    const invalidHeader = {
+      ...header,
+      uniqueness: 1.5 as any, // non-integer
+    };
+
+    expect(coValue.provideHeader(invalidHeader)).toBe(false);
+  });
+
+  test("should reject array uniqueness", () => {
+    const node = createTestNode();
+    const { coValue, header } = createUnloadedCoValue(node);
+
+    const invalidHeader = {
+      ...header,
+      uniqueness: [1, 2, 3] as any,
+    };
+
+    expect(coValue.provideHeader(invalidHeader)).toBe(false);
+  });
+
+  test("should reject object uniqueness with non-string values", () => {
+    const node = createTestNode();
+    const { coValue, header } = createUnloadedCoValue(node);
+
+    const invalidHeader = {
+      ...header,
+      uniqueness: { key: 123 } as any,
+    };
+
+    expect(coValue.provideHeader(invalidHeader)).toBe(false);
+  });
 });


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed -->
<!-- Please also include relevant motivation and context -->
<!-- Include any links to documentation like RFC’s if necessary -->
<!-- Add a link to to relevant preview environments or anything that would simplify visual review process -->
<!-- Supplemental screenshots and video are encouraged, but the primary description should be in text -->

This PR restricts the types accepted by the `uniqueness` parameter, moving from a generic `JsonValue` to a stricter union type.

**New Type Definition:**
```ts
type Uniqueness = 
  | string
  | boolean
  | null
  | undefined
  | { [key: string]: string };
 ```

**Motivation**

- **Performance & Simplification**: This change allows us to remove the dependency on stableStringify. Serializing static data is significantly easier and more efficient especially, regarding our Rust integration, compared to handling dynamic JsonValue structures.
- **Use Case Optimization**: Deeply nested objects were found to be unnecessary for this specific purpose.
- **Precision**: We have explicitly excluded the number type to prevent potential issues with floating-point precision.

**Backward Compatibility**

To ensure this is not a breaking change, we performed an analysis of the production database. The investigation confirmed that all existing uniqueness values comply with this new strict typing, ensuring no regressions for current users.
  
## Manual testing instructions

<!-- Add any actions required to manually test the changes -->

## Tests

- [ ] Tests have been added and/or updated
- [ ] Tests have not been updated, because: <!-- Insert reason for not updating tests here -->
- [ ] I need help with writing tests


## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [ ] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - **Type narrowing**: Replace `JsonValue` with strict `Uniqueness` (`string | boolean | null | undefined | { [key: string]: string }`) in `verifiedState.ts`.
> - **Runtime validation**: Add `validateUniqueness` and enforce it in `CoValueCore.provideHeader`; invalid values are logged and headers rejected (arrays, non-integer numbers, objects with non-string values).
> - **Tests**: New tests cover rejection of invalid `uniqueness` values.
> - **Docs/changeset**: Upgrade guide adds a "unique validation" note; changeset marks a minor release and deprecates numeric uniqueness.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6c5ebbb35e87f9e5c472688a8ff096a85cb635c4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->