### PR TITLE
feat: improved the error messages thrown when waitForSync times out

### DIFF
--- a/.changeset/improved-sync-timeout-errors.md
+++ b/.changeset/improved-sync-timeout-errors.md
@@ -1,0 +1,6 @@
+---
+"cojson": patch
+---
+
+Improved sync timeout error messages to include known state, peer state, and any error information when waiting for sync times out
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+Released Jazz 0.19.16:
+- Improved sync timeout error messages to include known state, peer state, and any error information when waiting for sync times out
+
 Released Jazz 0.19.15:
 - Added a locking system for session IDs in React Native to make mounting multiple JazzProviders safer (still not advised as duplicate the data loading effort)
 - Added a value.$jazz.createdBy getter to CoValues

--- a/packages/cojson/src/coValueCore/coValueCore.ts
+++ b/packages/cojson/src/coValueCore/coValueCore.ts
@@ -315,6 +315,14 @@ export class CoValueCore {
     return this.getLoadingStateForPeer(peerId) === "errored";
   }
 
+  getErroredInPeerError(peerId: PeerID) {
+    const loadingState = this.loadingStatuses.get(peerId);
+    if (loadingState?.type === "errored") {
+      return loadingState.error;
+    }
+    return undefined;
+  }
+
   waitFor(opts: {
     predicate: (value: CoValueCore) => boolean;
     onSuccess: (value: CoValueCore) => void;

--- a/packages/cojson/src/sync.ts
+++ b/packages/cojson/src/sync.ts
@@ -870,7 +870,20 @@ export class SyncManager {
       );
 
       const timeoutId = setTimeout(() => {
-        reject(new Error(`Timeout waiting for sync on ${peerId}/${id}`));
+        const coValue = this.local.getCoValue(id);
+        const erroredInPeer = coValue.getErroredInPeerError(peerId);
+        const knownState = coValue.knownState().sessions;
+        const peerKnownState = peerState.getKnownState(id)?.sessions ?? {};
+        let errorMessage = `Timeout on waiting for sync with peer ${peerId} for coValue ${id}:
+  Known state: ${JSON.stringify(knownState)}
+  Peer state: ${JSON.stringify(peerKnownState)}
+`;
+
+        if (erroredInPeer) {
+          errorMessage += `\nMarked as errored: "${erroredInPeer}"`;
+        }
+
+        reject(new Error(errorMessage));
         unsubscribe?.();
       }, timeout);
     });


### PR DESCRIPTION
Improved the error messages thrown when waitForSync times out to provide more actionable debugging information.

Before:
```
Timeout waiting for sync on peer123/co_abc123
```
After:
```
Timeout on waiting for sync with peer peer123 for coValue co_abc123:  
  Known state: {"session1": 5, "session2": 3}  
  Peer state: {"session1": 5}
  Marked as errored: "Error: InvalidSignature"
```

Why
When sync times out, developers need to understand why the sync didn't complete.

Most of the time it should be because connection issues, but in some cases it could be because an error has been encountered in the sync.

With these changes devs can know what has been synced, and if any sync errors have been encountered on that coValue.