### PR TITLE
fix: prevent concurrent logout attempts in ContextManager

### DIFF
--- a/.changeset/fix-concurrent-logout.md
+++ b/.changeset/fix-concurrent-logout.md
@@ -1,0 +1,6 @@
+---
+"jazz-tools": patch
+---
+
+Bugfix: fixed an issue where calling logOut multiple times concurrently could trigger duplicate logout operations
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+Released Jazz 0.19.17:
+- Bugfix: fixed an issue where calling logOut multiple times concurrently could trigger duplicate logout operations
+
 Released Jazz 0.19.16:
 - Improved sync timeout error messages to include known state, peer state, and any error information when waiting for sync times out
 - Bugfix: fixed a race condition in Clerk auth where the signup flow could trigger a duplicate login attempt

--- a/packages/jazz-tools/src/react-native-core/ReactNativeSessionProvider.ts
+++ b/packages/jazz-tools/src/react-native-core/ReactNativeSessionProvider.ts
@@ -16,6 +16,23 @@ export class ReactNativeSessionProvider implements SessionProvider {
     const kvStore = KvStoreContext.getInstance().getStorage();
     const existingSession = await kvStore.get(accountID as string);
 
+    if (!existingSession) {
+      const newSessionID = crypto.newRandomSessionID(
+        accountID as RawAccountID | AgentID,
+      );
+      await kvStore.set(accountID, newSessionID);
+      lockedSessions.add(newSessionID);
+
+      console.log("Created new session", newSessionID);
+
+      return Promise.resolve({
+        sessionID: newSessionID,
+        sessionDone: () => {
+          lockedSessions.delete(newSessionID);
+        },
+      });
+    }
+
     // Check if the session is already in use, should happen only if the dev
     // mounts multiple providers at the same time
     if (lockedSessions.has(existingSession as SessionID)) {
@@ -31,33 +48,13 @@ export class ReactNativeSessionProvider implements SessionProvider {
       });
     }
 
-    if (existingSession) {
-      console.log("Using existing session", existingSession);
-      lockedSessions.add(existingSession as SessionID);
-      return Promise.resolve({
-        sessionID: existingSession as SessionID,
-        sessionDone: () => {
-          lockedSessions.delete(existingSession as SessionID);
-        },
-      });
-    }
-
-    // We need to provide this for backwards compatibility with the old session provider
-    // With the current session provider we should never get here because:
-    // - New accounts provide their session and go through the persistSession method
-    // - Existing accounts should already have a session
-    const newSessionID = crypto.newRandomSessionID(
-      accountID as RawAccountID | AgentID,
-    );
-    await kvStore.set(accountID, newSessionID);
-    lockedSessions.add(newSessionID);
-
-    console.error("Created new session", newSessionID);
+    console.log("Using existing session", existingSession);
+    lockedSessions.add(existingSession as SessionID);
 
     return Promise.resolve({
-      sessionID: newSessionID,
+      sessionID: existingSession as SessionID,
       sessionDone: () => {
-        lockedSessions.delete(newSessionID);
+        lockedSessions.delete(existingSession as SessionID);
       },
     });
   }
@@ -69,6 +66,9 @@ export class ReactNativeSessionProvider implements SessionProvider {
     const kvStore = KvStoreContext.getInstance().getStorage();
     await kvStore.set(accountID, sessionID);
     lockedSessions.add(sessionID);
+
+    console.log("Persisted session", sessionID);
+
     return Promise.resolve({
       sessionDone: () => {
         lockedSessions.delete(sessionID);

--- a/packages/jazz-tools/src/tools/tests/ContextManager.test.ts
+++ b/packages/jazz-tools/src/tools/tests/ContextManager.test.ts
@@ -604,6 +604,22 @@ describe("ContextManager", () => {
       expect(onAnonymousAccountDiscarded).toHaveBeenCalledTimes(1);
     });
 
+    test("prevents concurrent logout attempts", async () => {
+      const onLogOut = vi.fn();
+      await manager.createContext({ onLogOut });
+
+      // Start multiple concurrent logout attempts
+      const promises = [];
+      for (let i = 0; i < 5; i++) {
+        promises.push(manager.logOut());
+      }
+
+      await Promise.all(promises);
+
+      // onLogOut should only be called once despite multiple logOut calls
+      expect(onLogOut).toHaveBeenCalledTimes(1);
+    });
+
     test("allows authentication after logout", async () => {
       const account = await createJazzTestAccount();
       const onAnonymousAccountDiscarded = vi.fn();


### PR DESCRIPTION
An Expo+Clerk user reported seeing the error "ERROR  Existing session in use, creating new one" and some sync issues.

Debugging I found that on logout the ContextManager.logOut function was called twice, leading to a double call of `createContext`.

This was making the app account migration running twice, killing the sync before pushing data to the network leading to have a partial sync of the account data.

Doing a fix for the logOut issue by preventing concurrent calls, and the sync issue in general should be solved by https://github.com/garden-co/jazz/pull/3320
