### PR TITLE
Improve documentation around suspense hooks

### DIFF
--- a/homepage/homepage/content/docs/code-snippets/core-concepts/subscription-and-loading/ProjectView.tsx
+++ b/homepage/homepage/content/docs/code-snippets/core-concepts/subscription-and-loading/ProjectView.tsx
@@ -160,3 +160,42 @@ function ProfileName() {
   return <div>{profileName}</div>;
 }
 // #endregion
+
+// #region Suspense
+import { useSuspenseCoState } from "jazz-tools/react";
+
+function ProjectViewSuspense({ projectId }: { projectId: string }) {
+  // Subscribe to a project and resolve its tasks
+  const project = useSuspenseCoState(Project, projectId, {
+    resolve: { tasks: { $each: true } }, // Tell Jazz to load each task in the list
+  });
+
+  // [!code --:12]
+  // We don't need this block any more: 
+  // useSuspenseCoState cannot return anything other than a loaded CoValue.
+  if (!project.$isLoaded) {
+    switch (project.$jazz.loadingState) {
+      // @ts-expect-error Code is showing diffed out
+      case "unauthorized":
+        return "Project not accessible";
+      // @ts-expect-error Code is showing diffed out
+      case "unavailable":
+        return "Project not found";
+      // @ts-expect-error Code is showing diffed out
+      case "loading":
+        return "Loading project...";
+    }
+  }
+
+  return (
+    <div>
+      <h1>{project.name}</h1>
+      <ul>
+        {project.tasks.map((task) => (
+          <li key={task.$jazz.id}>{task.title}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+// #endregion

--- a/homepage/homepage/content/docs/code-snippets/core-concepts/subscription-and-loading/ProjectView.tsx
+++ b/homepage/homepage/content/docs/code-snippets/core-concepts/subscription-and-loading/ProjectView.tsx
@@ -171,7 +171,7 @@ function ProjectViewSuspense({ projectId }: { projectId: string }) {
   });
 
   // [!code --:12]
-  // We don't need this block any more: 
+  // We don't need to validate the loading state any more
   // useSuspenseCoState cannot return anything other than a loaded CoValue.
   if (!project.$isLoaded) {
     switch (project.$jazz.loadingState) {

--- a/homepage/homepage/content/docs/core-concepts/subscription-and-loading.mdx
+++ b/homepage/homepage/content/docs/core-concepts/subscription-and-loading.mdx
@@ -78,6 +78,23 @@ You can use the `$isLoaded` field to check whether a CoValue is loaded. For more
 
 See the examples above for practical demonstrations of how to handle these three states in your application.
 
+<ContentByFramework framework={["react", "react-native", "react-native-expo"]}>
+### Suspense Hooks [!framework=react,react-native,react-native-expo]
+
+`useSuspenseCoState` and `useSuspenseAccount` are the suspense-enabled counterparts for `useCoState` and `useAccount`. They integrate with React's Suspense API by suspending component rendering while the requested value loads. 
+
+Once the component renders successfully, all of the data requested is guaranteed to be loaded and accessible. In case the requested data **can't** be loaded, the hook will throw an error during rendering.
+
+To handle the various loading states, instead of checking `$isLoaded` or `$jazz.loadingState`, these hooks should be combined with `<Suspense>` and error boundaries.
+
+<CodeGroup preferWrap>
+```tsx ProjectView.tsx#Suspense 
+```
+</CodeGroup>
+
+[Check out an example error boundary here](https://github.com/garden-co/jazz/blob/main/examples/music-player/src/components/ErrorBoundary.tsx).
+</ContentByFramework>
+
 ## Deep Loading
 
 When you're working with related CoValues (like tasks in a project), you often need to load nested references as well as the top-level CoValue.


### PR DESCRIPTION
# Description
Add a simple explanation of the suspense hooks and how to use them

## Manual testing instructions

N/A

## Tests

- [ ] Tests have been added and/or updated
- [x] Tests have not been updated, because: Docs
- [ ] I need help with writing tests


## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [ ] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds React Suspense-focused docs and example for subscription/loading.
> 
> - Introduces a **Suspense Hooks** section in `subscription-and-loading.mdx` explaining `useSuspenseCoState`/`useSuspenseAccount`, how they suspend, and directing users to use `<Suspense>` and error boundaries (with link)
> - Adds `ProjectViewSuspense` in `ProjectView.tsx` showing `useSuspenseCoState` with `resolve` and removes manual `$isLoaded`/`$jazz.loadingState` handling in the example
> - Embeds the new example via `CodeGroup` in the docs
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f7ad95ae50b667cd43fabe11e841a4f83156f374. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->