### PR TITLE
Add BLOB columns, persistence system, and catalog

### DIFF
--- a/groove-wasm/Cargo.toml
+++ b/groove-wasm/Cargo.toml
@@ -13,6 +13,8 @@ js-sys = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde-wasm-bindgen = "0.6"
 console_error_panic_hook = "0.1"
+bytes = "1"
+futures = "0.3"
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"

--- a/groove-wasm/blob-helpers.ts
+++ b/groove-wasm/blob-helpers.ts
@@ -1,0 +1,284 @@
+/**
+ * Blob helper functions for working with ReadableStream/WritableStream in JavaScript.
+ *
+ * These helpers wrap the WASM blob APIs to provide a more ergonomic JS interface.
+ */
+
+import type { WasmDatabase, WasmBlobWriter } from "./pkg/groove_wasm.js";
+
+/** Blob information returned from get_blob_info */
+export interface BlobInfo {
+  isInline: boolean;
+  chunkCount: number;
+  size?: number;
+}
+
+/** Stream configuration returned from create_blob_readable_stream */
+interface StreamConfig {
+  handleId: bigint;
+  isInline: boolean;
+  chunkCount: number;
+}
+
+/**
+ * Create a ReadableStream from a blob handle.
+ *
+ * For small inline blobs, reads all data in one chunk.
+ * For large chunked blobs, streams chunks one at a time.
+ *
+ * @example
+ * ```typescript
+ * const handleId = db.create_blob(myData);
+ * const stream = blobToReadableStream(db, handleId);
+ *
+ * // Use with fetch Response
+ * const response = new Response(stream);
+ * const blob = await response.blob();
+ *
+ * // Or read manually
+ * const reader = stream.getReader();
+ * while (true) {
+ *   const { done, value } = await reader.read();
+ *   if (done) break;
+ *   processChunk(value);
+ * }
+ * ```
+ */
+export function blobToReadableStream(db: WasmDatabase, handleId: bigint): ReadableStream<Uint8Array> {
+  // Get blob configuration
+  const config = db.get_blob_info(handleId) as unknown as BlobInfo;
+  let chunkIndex = 0;
+
+  return new ReadableStream({
+    pull(controller) {
+      if (chunkIndex >= config.chunkCount) {
+        controller.close();
+        return;
+      }
+      try {
+        const chunk = db.read_blob_chunk(handleId, chunkIndex);
+        controller.enqueue(chunk);
+        chunkIndex++;
+      } catch (e) {
+        controller.error(e);
+      }
+    },
+  });
+}
+
+/**
+ * Create a blob from a ReadableStream.
+ *
+ * Reads all chunks from the stream and creates a blob handle.
+ * The blob can then be used in insert_with_blobs or update_row_blob.
+ *
+ * @example
+ * ```typescript
+ * // From fetch response
+ * const response = await fetch('/large-file.bin');
+ * const handleId = await readableStreamToBlob(db, response.body!);
+ *
+ * // Use in insert
+ * db.insert_with_blobs('files', [['name', 'large-file.bin']], [['content', handleId]]);
+ * ```
+ */
+export async function readableStreamToBlob(
+  db: WasmDatabase,
+  stream: ReadableStream<Uint8Array>
+): Promise<bigint> {
+  const writer = db.create_blob_writer();
+  const reader = stream.getReader();
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      writer.write(value);
+    }
+    return writer.finish();
+  } catch (e) {
+    writer.abort();
+    throw e;
+  }
+}
+
+/**
+ * Wrapper class for convenient blob access.
+ *
+ * @example
+ * ```typescript
+ * // Create from data
+ * const blob = GrooveBlob.fromData(db, myData);
+ *
+ * // Get info
+ * console.log(blob.info); // { isInline: true, chunkCount: 1, size: 1024 }
+ *
+ * // Read entire blob
+ * const data = await blob.arrayBuffer();
+ *
+ * // Stream large blob
+ * const stream = blob.stream();
+ *
+ * // Use in database operations
+ * db.insert_with_blobs('files', [['name', 'test.txt']], [['content', blob.handleId]]);
+ *
+ * // Release when done
+ * blob.release();
+ * ```
+ */
+export class GrooveBlob {
+  constructor(
+    private db: WasmDatabase,
+    public readonly handleId: bigint
+  ) {}
+
+  /**
+   * Create a blob from raw byte data.
+   */
+  static fromData(db: WasmDatabase, data: Uint8Array): GrooveBlob {
+    const handleId = db.create_blob(data);
+    return new GrooveBlob(db, handleId);
+  }
+
+  /**
+   * Create a blob from a ReadableStream.
+   */
+  static async fromStream(db: WasmDatabase, stream: ReadableStream<Uint8Array>): Promise<GrooveBlob> {
+    const handleId = await readableStreamToBlob(db, stream);
+    return new GrooveBlob(db, handleId);
+  }
+
+  /**
+   * Get blob metadata.
+   */
+  get info(): BlobInfo {
+    return this.db.get_blob_info(this.handleId) as unknown as BlobInfo;
+  }
+
+  /**
+   * Read entire blob as Uint8Array.
+   *
+   * For large chunked blobs, this concatenates all chunks.
+   * Consider using stream() for better memory efficiency with large blobs.
+   */
+  async arrayBuffer(): Promise<Uint8Array> {
+    // read_blob handles both inline and chunked blobs
+    return this.db.read_blob(this.handleId);
+  }
+
+  /**
+   * Get a ReadableStream for streaming reads.
+   *
+   * Preferred for large blobs to avoid loading everything into memory.
+   */
+  stream(): ReadableStream<Uint8Array> {
+    return blobToReadableStream(this.db, this.handleId);
+  }
+
+  /**
+   * Release the blob handle.
+   *
+   * Call this when you're done with the blob to free memory.
+   * The blob cannot be used after release.
+   */
+  release(): void {
+    this.db.release_blob(this.handleId);
+  }
+}
+
+/**
+ * Helper class for streaming blob creation with WritableStream.
+ *
+ * @example
+ * ```typescript
+ * const writer = new GrooveBlobWriter(db);
+ * const writableStream = writer.getWritableStream();
+ *
+ * // Pipe data to it
+ * await someReadableStream.pipeTo(writableStream);
+ *
+ * // Get the blob handle
+ * const blob = writer.getBlob();
+ * db.insert_with_blobs('files', [['name', 'streamed.bin']], [['content', blob.handleId]]);
+ * ```
+ */
+export class GrooveBlobWriter {
+  private wasmWriter: WasmBlobWriter;
+  private finished = false;
+  private blob: GrooveBlob | null = null;
+
+  constructor(private db: WasmDatabase) {
+    this.wasmWriter = db.create_blob_writer();
+  }
+
+  /**
+   * Write a chunk of data.
+   */
+  write(chunk: Uint8Array): void {
+    if (this.finished) {
+      throw new Error("Blob writer already finished");
+    }
+    this.wasmWriter.write(chunk);
+  }
+
+  /**
+   * Get the current size of written data.
+   */
+  get size(): number {
+    return this.wasmWriter.size();
+  }
+
+  /**
+   * Finish writing and get the blob.
+   */
+  finish(): GrooveBlob {
+    if (this.finished) {
+      if (this.blob) return this.blob;
+      throw new Error("Blob writer was aborted");
+    }
+    this.finished = true;
+    const handleId = this.wasmWriter.finish();
+    this.blob = new GrooveBlob(this.db, handleId);
+    return this.blob;
+  }
+
+  /**
+   * Abort writing and discard all data.
+   */
+  abort(): void {
+    if (!this.finished) {
+      this.finished = true;
+      this.wasmWriter.abort();
+    }
+  }
+
+  /**
+   * Get a WritableStream for this blob writer.
+   *
+   * Data written to the stream will be accumulated into the blob.
+   * After the stream closes, call getBlob() to get the finished blob.
+   */
+  getWritableStream(): WritableStream<Uint8Array> {
+    return new WritableStream({
+      write: (chunk) => {
+        this.write(chunk);
+      },
+      close: () => {
+        this.finish();
+      },
+      abort: () => {
+        this.abort();
+      },
+    });
+  }
+
+  /**
+   * Get the blob after the writable stream has closed.
+   */
+  getBlob(): GrooveBlob {
+    if (!this.finished || !this.blob) {
+      throw new Error("Blob writer not finished yet");
+    }
+    return this.blob;
+  }
+}

--- a/groove-wasm/src/lib.rs
+++ b/groove-wasm/src/lib.rs
@@ -9,18 +9,16 @@ use js_sys::{Array, Uint8Array};
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
+use bytes::Bytes;
 
 // ==================== Blob Registry ====================
 
-/// Registry for tracking blob handles and chunk data.
-/// Blobs returned from queries are registered here so JS can stream their contents.
+/// Registry for tracking blob handles.
+/// Maps handle IDs to ContentRefs. Actual chunk data is stored in the Environment's ChunkStore.
 #[derive(Default)]
 struct BlobRegistry {
     next_id: u64,
     blobs: HashMap<u64, ContentRef>,
-    /// Chunk storage: maps ChunkHash -> chunk data
-    /// This stores the actual bytes for chunked blobs created in this session.
-    chunks: HashMap<ChunkHash, Vec<u8>>,
 }
 
 impl BlobRegistry {
@@ -35,28 +33,11 @@ impl BlobRegistry {
         id
     }
 
-    /// Register a blob and store its chunk data.
-    fn register_with_chunks(&mut self, content_ref: ContentRef, chunk_data: Vec<Vec<u8>>) -> u64 {
-        // Store chunk data by hash
-        if let ContentRef::Chunked(hashes) = &content_ref {
-            for (hash, data) in hashes.iter().zip(chunk_data.into_iter()) {
-                self.chunks.insert(hash.clone(), data);
-            }
-        }
-        self.register(content_ref)
-    }
-
     fn get(&self, id: u64) -> Option<&ContentRef> {
         self.blobs.get(&id)
     }
 
-    fn get_chunk(&self, hash: &ChunkHash) -> Option<&Vec<u8>> {
-        self.chunks.get(hash)
-    }
-
     fn remove(&mut self, id: u64) -> Option<ContentRef> {
-        // Note: We don't remove chunks here since they might be shared.
-        // In a real implementation, we'd need reference counting.
         self.blobs.remove(&id)
     }
 }
@@ -251,23 +232,26 @@ impl WasmDatabase {
 
     /// Create a blob from raw bytes.
     /// Returns a blob handle ID that can be used in insert/update operations.
+    /// Chunks are stored in the Environment's ChunkStore for persistence.
     #[wasm_bindgen]
     pub fn create_blob(&self, data: &[u8]) -> u64 {
+        use futures::executor::block_on;
+
         if data.len() <= INLINE_THRESHOLD {
             let content_ref = ContentRef::inline(data.to_vec());
             self.blob_registry.borrow_mut().register(content_ref)
         } else {
-            // For large data, chunk it and store both hashes and data
-            let chunk_data: Vec<Vec<u8>> = data
+            // For large data, chunk it and store in Environment
+            let env = self.db.node().env();
+            let hashes: Vec<ChunkHash> = data
                 .chunks(INLINE_THRESHOLD)
-                .map(|chunk| chunk.to_vec())
-                .collect();
-            let hashes: Vec<ChunkHash> = chunk_data
-                .iter()
-                .map(|chunk| ChunkHash::compute(chunk))
+                .map(|chunk| {
+                    // Store each chunk in Environment's ChunkStore
+                    block_on(env.put_chunk(Bytes::copy_from_slice(chunk)))
+                })
                 .collect();
             let content_ref = ContentRef::chunked(hashes);
-            self.blob_registry.borrow_mut().register_with_chunks(content_ref, chunk_data)
+            self.blob_registry.borrow_mut().register(content_ref)
         }
     }
 
@@ -275,15 +259,17 @@ impl WasmDatabase {
     /// Call write_blob_chunk() to add data, then finish_blob() to get the handle.
     #[wasm_bindgen]
     pub fn create_blob_writer(&self) -> WasmBlobWriter {
-        WasmBlobWriter::new(Rc::clone(&self.blob_registry))
+        WasmBlobWriter::new(Rc::clone(&self.blob_registry), self.db.node().env().clone())
     }
 
     /// Read all bytes from a blob handle.
     /// For small blobs this returns the inline data directly.
-    /// For large chunked blobs, this reads and concatenates all chunks.
+    /// For large chunked blobs, this reads and concatenates all chunks from Environment.
     /// Use read_blob_chunk() for streaming reads of large blobs.
     #[wasm_bindgen]
     pub fn read_blob(&self, handle_id: u64) -> Result<Uint8Array, JsValue> {
+        use futures::executor::block_on;
+
         let registry = self.blob_registry.borrow();
         let content_ref = registry.get(handle_id)
             .ok_or_else(|| JsValue::from_str("invalid blob handle"))?;
@@ -291,12 +277,13 @@ impl WasmDatabase {
         match content_ref {
             ContentRef::Inline(data) => Ok(Uint8Array::from(data.as_ref())),
             ContentRef::Chunked(hashes) => {
-                // Concatenate all chunks
+                // Concatenate all chunks from Environment
+                let env = self.db.node().env();
                 let mut result = Vec::new();
                 for hash in hashes {
-                    let chunk = registry.get_chunk(hash)
-                        .ok_or_else(|| JsValue::from_str("chunk not found in registry"))?;
-                    result.extend_from_slice(chunk);
+                    let chunk = block_on(env.get_chunk(hash))
+                        .ok_or_else(|| JsValue::from_str("chunk not found in environment"))?;
+                    result.extend_from_slice(&chunk);
                 }
                 Ok(Uint8Array::from(result.as_slice()))
             }
@@ -334,9 +321,11 @@ impl WasmDatabase {
 
     /// Read a specific chunk of a blob by index.
     /// For inline blobs, index 0 returns all data.
-    /// For chunked blobs, returns the chunk at the given index.
+    /// For chunked blobs, returns the chunk at the given index from Environment.
     #[wasm_bindgen]
     pub fn read_blob_chunk(&self, handle_id: u64, chunk_index: u32) -> Result<Uint8Array, JsValue> {
+        use futures::executor::block_on;
+
         let registry = self.blob_registry.borrow();
         let content_ref = registry.get(handle_id)
             .ok_or_else(|| JsValue::from_str("invalid blob handle"))?;
@@ -353,9 +342,10 @@ impl WasmDatabase {
                 let idx = chunk_index as usize;
                 if idx < hashes.len() {
                     let hash = &hashes[idx];
-                    let chunk = registry.get_chunk(hash)
-                        .ok_or_else(|| JsValue::from_str("chunk not found in registry"))?;
-                    Ok(Uint8Array::from(chunk.as_slice()))
+                    let env = self.db.node().env();
+                    let chunk = block_on(env.get_chunk(hash))
+                        .ok_or_else(|| JsValue::from_str("chunk not found in environment"))?;
+                    Ok(Uint8Array::from(chunk.as_ref()))
                 } else {
                     Err(JsValue::from_str("chunk index out of bounds"))
                 }
@@ -368,12 +358,6 @@ impl WasmDatabase {
     #[wasm_bindgen]
     pub fn release_blob(&self, handle_id: u64) {
         self.blob_registry.borrow_mut().remove(handle_id);
-    }
-
-    /// Register an existing ContentRef as a blob handle.
-    /// Used internally when extracting blobs from query results.
-    fn register_blob(&self, content_ref: ContentRef) -> u64 {
-        self.blob_registry.borrow_mut().register(content_ref)
     }
 
     /// Insert a row with blob values.
@@ -600,14 +584,16 @@ struct BlobInfo {
 pub struct WasmBlobWriter {
     state: Option<BlobWriterState>,
     registry: Rc<RefCell<BlobRegistry>>,
+    env: std::sync::Arc<dyn groove::Environment>,
 }
 
 #[wasm_bindgen]
 impl WasmBlobWriter {
-    fn new(registry: Rc<RefCell<BlobRegistry>>) -> Self {
+    fn new(registry: Rc<RefCell<BlobRegistry>>, env: std::sync::Arc<dyn groove::Environment>) -> Self {
         Self {
             state: Some(BlobWriterState::new()),
             registry,
+            env,
         }
     }
 
@@ -630,13 +616,26 @@ impl WasmBlobWriter {
     }
 
     /// Finish writing and get a blob handle.
+    /// Stores chunks in the Environment's ChunkStore for persistence.
     /// The writer cannot be used after this.
     #[wasm_bindgen]
     pub fn finish(&mut self) -> Result<u64, JsValue> {
+        use futures::executor::block_on;
+
         let state = self.state.take()
             .ok_or_else(|| JsValue::from_str("blob writer already finished"))?;
         let (content_ref, chunk_data) = state.finish();
-        let handle = self.registry.borrow_mut().register_with_chunks(content_ref, chunk_data);
+
+        // Store chunks in Environment if this is a chunked blob
+        if let ContentRef::Chunked(hashes) = &content_ref {
+            for (hash, data) in hashes.iter().zip(chunk_data.into_iter()) {
+                // Verify hash matches (put_chunk returns the computed hash)
+                let stored_hash = block_on(self.env.put_chunk(Bytes::copy_from_slice(&data)));
+                debug_assert_eq!(hash, &stored_hash, "chunk hash mismatch");
+            }
+        }
+
+        let handle = self.registry.borrow_mut().register(content_ref);
         Ok(handle)
     }
 

--- a/groove-wasm/src/lib.rs
+++ b/groove-wasm/src/lib.rs
@@ -3,14 +3,114 @@ use groove::sql::{
     Database, IncrementalQuery, Value, ExecuteResult, Row,
     encode_rows, encode_delta,
 };
-use groove::ObjectId;
+use groove::{ObjectId, ContentRef, ChunkHash, INLINE_THRESHOLD};
 use groove::ListenerId;
 use js_sys::{Array, Uint8Array};
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::rc::Rc;
+
+// ==================== Blob Registry ====================
+
+/// Registry for tracking blob handles and chunk data.
+/// Blobs returned from queries are registered here so JS can stream their contents.
+#[derive(Default)]
+struct BlobRegistry {
+    next_id: u64,
+    blobs: HashMap<u64, ContentRef>,
+    /// Chunk storage: maps ChunkHash -> chunk data
+    /// This stores the actual bytes for chunked blobs created in this session.
+    chunks: HashMap<ChunkHash, Vec<u8>>,
+}
+
+impl BlobRegistry {
+    fn new() -> Self {
+        Self::default()
+    }
+
+    fn register(&mut self, content_ref: ContentRef) -> u64 {
+        let id = self.next_id;
+        self.next_id += 1;
+        self.blobs.insert(id, content_ref);
+        id
+    }
+
+    /// Register a blob and store its chunk data.
+    fn register_with_chunks(&mut self, content_ref: ContentRef, chunk_data: Vec<Vec<u8>>) -> u64 {
+        // Store chunk data by hash
+        if let ContentRef::Chunked(hashes) = &content_ref {
+            for (hash, data) in hashes.iter().zip(chunk_data.into_iter()) {
+                self.chunks.insert(hash.clone(), data);
+            }
+        }
+        self.register(content_ref)
+    }
+
+    fn get(&self, id: u64) -> Option<&ContentRef> {
+        self.blobs.get(&id)
+    }
+
+    fn get_chunk(&self, hash: &ChunkHash) -> Option<&Vec<u8>> {
+        self.chunks.get(hash)
+    }
+
+    fn remove(&mut self, id: u64) -> Option<ContentRef> {
+        // Note: We don't remove chunks here since they might be shared.
+        // In a real implementation, we'd need reference counting.
+        self.blobs.remove(&id)
+    }
+}
+
+// ==================== Blob Writer ====================
+
+/// State for incrementally building a blob from chunks.
+struct BlobWriterState {
+    chunks: Vec<Vec<u8>>,
+    total_size: usize,
+}
+
+impl BlobWriterState {
+    fn new() -> Self {
+        Self {
+            chunks: Vec::new(),
+            total_size: 0,
+        }
+    }
+
+    fn write(&mut self, data: &[u8]) {
+        self.total_size += data.len();
+        self.chunks.push(data.to_vec());
+    }
+
+    /// Finish building the blob, returning the ContentRef and chunk data.
+    /// For inline blobs, chunk_data will be empty.
+    /// For chunked blobs, chunk_data contains the actual bytes for each chunk.
+    fn finish(self) -> (ContentRef, Vec<Vec<u8>>) {
+        // If total size is small enough, inline it
+        if self.total_size <= INLINE_THRESHOLD {
+            let mut combined = Vec::with_capacity(self.total_size);
+            for chunk in self.chunks {
+                combined.extend(chunk);
+            }
+            (ContentRef::inline(combined), Vec::new())
+        } else {
+            // Hash each chunk and create a chunked ContentRef
+            let hashes: Vec<ChunkHash> = self.chunks
+                .iter()
+                .map(|chunk| ChunkHash::compute(chunk))
+                .collect();
+            (ContentRef::chunked(hashes), self.chunks)
+        }
+    }
+}
+
+// ==================== WASM Database ====================
 
 /// WASM-exposed database wrapper.
 #[wasm_bindgen]
 pub struct WasmDatabase {
     db: Database,
+    blob_registry: Rc<RefCell<BlobRegistry>>,
 }
 
 #[wasm_bindgen]
@@ -20,6 +120,7 @@ impl WasmDatabase {
     pub fn new() -> Self {
         WasmDatabase {
             db: Database::in_memory(),
+            blob_registry: Rc::new(RefCell::new(BlobRegistry::new())),
         }
     }
 
@@ -144,6 +245,204 @@ impl WasmDatabase {
             .map_err(|e| JsValue::from_str(&format!("{:?}", e)))?;
 
         Ok(WasmQueryHandleDelta::new(query, callback))
+    }
+
+    // ==================== Blob APIs ====================
+
+    /// Create a blob from raw bytes.
+    /// Returns a blob handle ID that can be used in insert/update operations.
+    #[wasm_bindgen]
+    pub fn create_blob(&self, data: &[u8]) -> u64 {
+        if data.len() <= INLINE_THRESHOLD {
+            let content_ref = ContentRef::inline(data.to_vec());
+            self.blob_registry.borrow_mut().register(content_ref)
+        } else {
+            // For large data, chunk it and store both hashes and data
+            let chunk_data: Vec<Vec<u8>> = data
+                .chunks(INLINE_THRESHOLD)
+                .map(|chunk| chunk.to_vec())
+                .collect();
+            let hashes: Vec<ChunkHash> = chunk_data
+                .iter()
+                .map(|chunk| ChunkHash::compute(chunk))
+                .collect();
+            let content_ref = ContentRef::chunked(hashes);
+            self.blob_registry.borrow_mut().register_with_chunks(content_ref, chunk_data)
+        }
+    }
+
+    /// Create a blob writer for streaming blob creation.
+    /// Call write_blob_chunk() to add data, then finish_blob() to get the handle.
+    #[wasm_bindgen]
+    pub fn create_blob_writer(&self) -> WasmBlobWriter {
+        WasmBlobWriter::new(Rc::clone(&self.blob_registry))
+    }
+
+    /// Read all bytes from a blob handle.
+    /// For small blobs this returns the inline data directly.
+    /// For large chunked blobs, this reads and concatenates all chunks.
+    /// Use read_blob_chunk() for streaming reads of large blobs.
+    #[wasm_bindgen]
+    pub fn read_blob(&self, handle_id: u64) -> Result<Uint8Array, JsValue> {
+        let registry = self.blob_registry.borrow();
+        let content_ref = registry.get(handle_id)
+            .ok_or_else(|| JsValue::from_str("invalid blob handle"))?;
+
+        match content_ref {
+            ContentRef::Inline(data) => Ok(Uint8Array::from(data.as_ref())),
+            ContentRef::Chunked(hashes) => {
+                // Concatenate all chunks
+                let mut result = Vec::new();
+                for hash in hashes {
+                    let chunk = registry.get_chunk(hash)
+                        .ok_or_else(|| JsValue::from_str("chunk not found in registry"))?;
+                    result.extend_from_slice(chunk);
+                }
+                Ok(Uint8Array::from(result.as_slice()))
+            }
+        }
+    }
+
+    /// Get information about a blob.
+    /// Returns a JS object with: { isInline: bool, chunkCount: number, size?: number }
+    #[wasm_bindgen]
+    pub fn get_blob_info(&self, handle_id: u64) -> Result<JsValue, JsValue> {
+        let registry = self.blob_registry.borrow();
+        let content_ref = registry.get(handle_id)
+            .ok_or_else(|| JsValue::from_str("invalid blob handle"))?;
+
+        let info = match content_ref {
+            ContentRef::Inline(data) => {
+                BlobInfo {
+                    is_inline: true,
+                    chunk_count: 1,
+                    size: Some(data.len() as u64),
+                }
+            }
+            ContentRef::Chunked(hashes) => {
+                BlobInfo {
+                    is_inline: false,
+                    chunk_count: hashes.len() as u32,
+                    size: None, // Size unknown without reading chunks
+                }
+            }
+        };
+
+        serde_wasm_bindgen::to_value(&info)
+            .map_err(|e| JsValue::from_str(&format!("serialization error: {:?}", e)))
+    }
+
+    /// Read a specific chunk of a blob by index.
+    /// For inline blobs, index 0 returns all data.
+    /// For chunked blobs, returns the chunk at the given index.
+    #[wasm_bindgen]
+    pub fn read_blob_chunk(&self, handle_id: u64, chunk_index: u32) -> Result<Uint8Array, JsValue> {
+        let registry = self.blob_registry.borrow();
+        let content_ref = registry.get(handle_id)
+            .ok_or_else(|| JsValue::from_str("invalid blob handle"))?;
+
+        match content_ref {
+            ContentRef::Inline(data) => {
+                if chunk_index == 0 {
+                    Ok(Uint8Array::from(data.as_ref()))
+                } else {
+                    Err(JsValue::from_str("chunk index out of bounds for inline blob"))
+                }
+            }
+            ContentRef::Chunked(hashes) => {
+                let idx = chunk_index as usize;
+                if idx < hashes.len() {
+                    let hash = &hashes[idx];
+                    let chunk = registry.get_chunk(hash)
+                        .ok_or_else(|| JsValue::from_str("chunk not found in registry"))?;
+                    Ok(Uint8Array::from(chunk.as_slice()))
+                } else {
+                    Err(JsValue::from_str("chunk index out of bounds"))
+                }
+            }
+        }
+    }
+
+    /// Release a blob handle, freeing the associated memory.
+    /// Call this when you're done with a blob to prevent memory leaks.
+    #[wasm_bindgen]
+    pub fn release_blob(&self, handle_id: u64) {
+        self.blob_registry.borrow_mut().remove(handle_id);
+    }
+
+    /// Register an existing ContentRef as a blob handle.
+    /// Used internally when extracting blobs from query results.
+    fn register_blob(&self, content_ref: ContentRef) -> u64 {
+        self.blob_registry.borrow_mut().register(content_ref)
+    }
+
+    /// Insert a row with blob values.
+    /// string_columns is an array of [column_name, value] pairs for string columns.
+    /// blob_columns is an array of [column_name, blob_handle_id] pairs.
+    #[wasm_bindgen]
+    pub fn insert_with_blobs(
+        &self,
+        table: &str,
+        string_columns: JsValue,
+        blob_columns: JsValue,
+    ) -> Result<String, JsValue> {
+        // Parse string columns: [[name, value], ...]
+        let string_cols: Vec<(String, String)> = serde_wasm_bindgen::from_value(string_columns)
+            .map_err(|e| JsValue::from_str(&format!("invalid string_columns: {:?}", e)))?;
+
+        // Parse blob columns: [[name, handle_id], ...]
+        let blob_cols: Vec<(String, u64)> = serde_wasm_bindgen::from_value(blob_columns)
+            .map_err(|e| JsValue::from_str(&format!("invalid blob_columns: {:?}", e)))?;
+
+        // Build column names and values
+        let mut column_names: Vec<String> = Vec::new();
+        let mut values: Vec<Value> = Vec::new();
+
+        // Add string columns
+        for (name, value) in string_cols {
+            column_names.push(name);
+            values.push(Value::String(value));
+        }
+
+        // Add blob columns
+        let registry = self.blob_registry.borrow();
+        for (name, handle_id) in blob_cols {
+            let content_ref = registry.get(handle_id)
+                .ok_or_else(|| JsValue::from_str(&format!("invalid blob handle: {}", handle_id)))?;
+            column_names.push(name);
+            values.push(Value::Blob(content_ref.clone()));
+        }
+        drop(registry);
+
+        // Convert to &str slice for the API
+        let column_refs: Vec<&str> = column_names.iter().map(|s| s.as_str()).collect();
+
+        // Execute insert
+        let id = self.db.insert(table, &column_refs, values)
+            .map_err(|e| JsValue::from_str(&format!("{:?}", e)))?;
+
+        Ok(id.to_string())
+    }
+
+    /// Update a row's blob column.
+    #[wasm_bindgen]
+    pub fn update_row_blob(
+        &self,
+        table: &str,
+        row_id: &str,
+        column: &str,
+        blob_handle_id: u64,
+    ) -> Result<bool, JsValue> {
+        let id: ObjectId = row_id.parse()
+            .map_err(|e| JsValue::from_str(&format!("invalid row_id: {:?}", e)))?;
+
+        let registry = self.blob_registry.borrow();
+        let content_ref = registry.get(blob_handle_id)
+            .ok_or_else(|| JsValue::from_str("invalid blob handle"))?;
+
+        self.db
+            .update(table, id, &[(column, Value::Blob(content_ref.clone()))])
+            .map_err(|e| JsValue::from_str(&format!("{:?}", e)))
     }
 }
 
@@ -283,8 +582,117 @@ impl WasmQueryHandleDelta {
     }
 }
 
+// ==================== Blob Types ====================
+
+/// Information about a blob.
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct BlobInfo {
+    is_inline: bool,
+    chunk_count: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    size: Option<u64>,
+}
+
+/// Handle for streaming blob creation.
+/// Use write() to add chunks, then finish() to get a blob handle.
+#[wasm_bindgen]
+pub struct WasmBlobWriter {
+    state: Option<BlobWriterState>,
+    registry: Rc<RefCell<BlobRegistry>>,
+}
+
+#[wasm_bindgen]
+impl WasmBlobWriter {
+    fn new(registry: Rc<RefCell<BlobRegistry>>) -> Self {
+        Self {
+            state: Some(BlobWriterState::new()),
+            registry,
+        }
+    }
+
+    /// Write a chunk of data to the blob.
+    /// Can be called multiple times before finish().
+    #[wasm_bindgen]
+    pub fn write(&mut self, data: &[u8]) -> Result<(), JsValue> {
+        let state = self.state.as_mut()
+            .ok_or_else(|| JsValue::from_str("blob writer already finished"))?;
+        state.write(data);
+        Ok(())
+    }
+
+    /// Get the current total size of data written.
+    #[wasm_bindgen]
+    pub fn size(&self) -> Result<u32, JsValue> {
+        let state = self.state.as_ref()
+            .ok_or_else(|| JsValue::from_str("blob writer already finished"))?;
+        Ok(state.total_size as u32)
+    }
+
+    /// Finish writing and get a blob handle.
+    /// The writer cannot be used after this.
+    #[wasm_bindgen]
+    pub fn finish(&mut self) -> Result<u64, JsValue> {
+        let state = self.state.take()
+            .ok_or_else(|| JsValue::from_str("blob writer already finished"))?;
+        let (content_ref, chunk_data) = state.finish();
+        let handle = self.registry.borrow_mut().register_with_chunks(content_ref, chunk_data);
+        Ok(handle)
+    }
+
+    /// Abort the blob creation, discarding all written data.
+    #[wasm_bindgen]
+    pub fn abort(&mut self) {
+        self.state = None;
+    }
+}
+
+// ==================== JS Stream Helpers ====================
+
+/// Create a ReadableStream that reads from a blob.
+/// This is a convenience wrapper for JS interop.
+#[wasm_bindgen]
+pub fn create_blob_readable_stream(db: &WasmDatabase, handle_id: u64) -> Result<JsValue, JsValue> {
+    // Get blob info first
+    let registry = db.blob_registry.borrow();
+    let content_ref = registry.get(handle_id)
+        .ok_or_else(|| JsValue::from_str("invalid blob handle"))?;
+
+    let (is_inline, chunk_count) = match content_ref {
+        ContentRef::Inline(_) => (true, 1u32),
+        ContentRef::Chunked(hashes) => (false, hashes.len() as u32),
+    };
+    drop(registry);
+
+    // Create a JS ReadableStream using the Streams API
+    // We'll return a configuration object that JS can use to create the stream
+    let config = StreamConfig {
+        handle_id,
+        is_inline,
+        chunk_count,
+    };
+
+    serde_wasm_bindgen::to_value(&config)
+        .map_err(|e| JsValue::from_str(&format!("serialization error: {:?}", e)))
+}
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct StreamConfig {
+    handle_id: u64,
+    is_inline: bool,
+    chunk_count: u32,
+}
+
 /// Initialize panic hook for better error messages.
 #[wasm_bindgen(start)]
 pub fn init() {
     console_error_panic_hook::set_once();
 }
+
+// ==================== JS Helper Code ====================
+// See blob-helpers.ts for TypeScript convenience wrappers around these WASM APIs:
+// - blobToReadableStream(): Convert blob handle to ReadableStream
+// - readableStreamToBlob(): Create blob from ReadableStream
+// - GrooveBlob: Wrapper class for blob access
+// - GrooveBlobWriter: Wrapper for streaming blob creation with WritableStream

--- a/groove/Cargo.toml
+++ b/groove/Cargo.toml
@@ -18,3 +18,7 @@ web-time = { version = "1", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2", features = ["js"] }
+
+[dev-dependencies]
+bytes = "1"
+futures = "0.3"

--- a/groove/src/branch.rs
+++ b/groove/src/branch.rs
@@ -68,6 +68,28 @@ impl Branch {
             .expect("commit has parents before truncation point")
     }
 
+    /// Restore a commit to this branch without updating frontier.
+    /// Used for loading commits from storage where frontier will be set separately.
+    pub fn restore_commit(&mut self, commit: Commit) -> CommitId {
+        let id = commit.compute_id();
+
+        // Update parent->child relationships
+        for parent_id in &commit.parents {
+            self.children
+                .entry(*parent_id)
+                .or_default()
+                .push(id);
+        }
+
+        self.commits.insert(id, commit);
+        id
+    }
+
+    /// Set the frontier explicitly. Used for restoring from storage.
+    pub fn set_frontier(&mut self, frontier: Vec<CommitId>) {
+        self.frontier = frontier;
+    }
+
     /// Try to add a commit to this branch. Returns the commit ID or an error.
     /// Updates frontier: removes parents from frontier, adds new commit if it has no children.
     ///

--- a/groove/src/commit.rs
+++ b/groove/src/commit.rs
@@ -1,7 +1,5 @@
 use std::collections::BTreeMap;
 
-use crate::storage::ContentRef;
-
 /// A commit ID is the BLAKE3 hash of the commit's canonical representation.
 /// Using full 256-bit hash for now (naive implementation).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -18,13 +16,16 @@ impl CommitId {
 }
 
 /// A commit in the object's history.
-/// Contains a full snapshot of the object state.
+/// Contains a full snapshot of the object state as encoded row bytes.
+///
+/// Note: Commits store row data directly. Large binary data should use
+/// BLOB columns which handle their own chunking via ContentRef.
 #[derive(Debug, Clone)]
 pub struct Commit {
     /// Parent commit IDs (empty for root commits, multiple for merge commits)
     pub parents: Vec<CommitId>,
-    /// Snapshot of the object state (inline for small, chunked for large)
-    pub content: ContentRef,
+    /// Snapshot of the object state as encoded row bytes
+    pub content: Box<[u8]>,
     /// Author identifier (account/device ID)
     pub author: String,
     /// Timestamp (milliseconds since epoch)
@@ -44,21 +45,9 @@ impl Commit {
             hasher.update(parent.as_bytes());
         }
 
-        // Hash content ref
-        match &self.content {
-            ContentRef::Inline(data) => {
-                hasher.update(&[0u8]); // Tag for inline
-                hasher.update(&(data.len() as u64).to_le_bytes());
-                hasher.update(data);
-            }
-            ContentRef::Chunked(hashes) => {
-                hasher.update(&[1u8]); // Tag for chunked
-                hasher.update(&(hashes.len() as u64).to_le_bytes());
-                for hash in hashes {
-                    hasher.update(hash.as_bytes());
-                }
-            }
-        }
+        // Hash content directly
+        hasher.update(&(self.content.len() as u64).to_le_bytes());
+        hasher.update(&self.content);
 
         // Hash author
         hasher.update(&(self.author.len() as u64).to_le_bytes());

--- a/groove/src/lib.rs
+++ b/groove/src/lib.rs
@@ -17,6 +17,6 @@ pub use merge::{LastWriterWins, MergeStrategy};
 pub use node::{generate_object_id, LocalNode};
 pub use object::{Object, ObjectId, ObjectIdParseError, SchemaId};
 pub use storage::{
-    ChunkHash, CommitMeta, CommitStore, ContentRef, ContentStore, Environment, MemoryContentStore,
+    ChunkHash, ChunkStore, CommitMeta, CommitStore, ContentRef, Environment, MemoryContentStore,
     MemoryEnvironment, Storage, INLINE_THRESHOLD,
 };

--- a/groove/src/lib.rs
+++ b/groove/src/lib.rs
@@ -15,7 +15,7 @@ pub use listener::{
 };
 pub use merge::{LastWriterWins, MergeStrategy};
 pub use node::{generate_object_id, LocalNode};
-pub use object::{ContentStream, Object, ObjectId, ObjectIdParseError, SchemaId};
+pub use object::{Object, ObjectId, ObjectIdParseError, SchemaId};
 pub use storage::{
     ChunkHash, CommitMeta, CommitStore, ContentRef, ContentStore, Environment, MemoryContentStore,
     MemoryEnvironment, Storage, INLINE_THRESHOLD,

--- a/groove/src/listener.rs
+++ b/groove/src/listener.rs
@@ -187,8 +187,7 @@ impl ObjectState {
 
         let current = self.tips.first()
             .and_then(|id| branch.get_commit(id))
-            .and_then(|c| c.content.as_inline())
-            .map(|b| Bytes::copy_from_slice(b))
+            .map(|c| Bytes::copy_from_slice(&c.content))
             .unwrap_or_else(Bytes::new);
 
         match &self.previous_tips {
@@ -199,8 +198,7 @@ impl ObjectState {
                 }
                 let previous = prev_tips.first()
                     .and_then(|id| branch.get_commit(id))
-                    .and_then(|c| c.content.as_inline())
-                    .map(|b| Bytes::copy_from_slice(b))
+                    .map(|c| Bytes::copy_from_slice(&c.content))
                     .unwrap_or_else(Bytes::new);
 
                 if previous == current {
@@ -216,32 +214,17 @@ impl ObjectState {
         }
     }
 
-    /// Get the content of a specific tip by commit ID (sync, inline only).
+    /// Get the content of a specific tip by commit ID.
     pub fn get_tip_content(&self, commit_id: &CommitId) -> Option<Bytes> {
         let branch = self.branch.read().unwrap();
         branch.get_commit(commit_id)
-            .and_then(|c| c.content.as_inline())
-            .map(|b| Bytes::copy_from_slice(b))
+            .map(|c| Bytes::copy_from_slice(&c.content))
     }
 
-    /// Get the content of a specific tip by commit ID (async, supports chunked).
+    /// Get the content of a specific tip by commit ID (async).
+    /// Note: Now equivalent to get_tip_content since commits store content directly.
     pub async fn get_tip_content_async(&self, commit_id: &CommitId) -> Option<Bytes> {
-        let content_ref = {
-            let branch = self.branch.read().unwrap();
-            branch.get_commit(commit_id).map(|c| c.content.clone())
-        }?;
-
-        match content_ref {
-            crate::storage::ContentRef::Inline(data) => Some(Bytes::copy_from_slice(&data)),
-            crate::storage::ContentRef::Chunked(hashes) => {
-                let mut result = Vec::new();
-                for hash in hashes {
-                    let chunk = self.env.get_chunk(&hash).await?;
-                    result.extend_from_slice(&chunk);
-                }
-                Some(Bytes::from(result))
-            }
-        }
+        self.get_tip_content(commit_id)
     }
 
     /// Get author of a specific tip.
@@ -537,7 +520,7 @@ impl ObjectListenerRegistry {
 
 // ========== Helper functions ==========
 
-/// Helper to compute merged content from commit IDs using a merge strategy (sync, inline only).
+/// Helper to compute merged content from commit IDs using a merge strategy.
 pub fn merge_commit_ids(
     tips: &[CommitId],
     strategy: &dyn crate::merge::MergeStrategy,
@@ -550,13 +533,11 @@ pub fn merge_commit_ids(
     let tip_contents: Vec<Vec<u8>> = tips
         .iter()
         .filter_map(|id| branch.get_commit(id))
-        .filter_map(|c| c.content.as_inline().map(|b| b.to_vec()))
+        .map(|c| c.content.to_vec())
         .collect();
 
     if tip_contents.len() != tips.len() {
-        return Err(ListenerError::StorageError(
-            "Some commits have chunked content".to_string(),
-        ));
+        return Err(ListenerError::NotFound);
     }
 
     if tip_contents.len() == 1 {
@@ -569,56 +550,10 @@ pub fn merge_commit_ids(
         vec![]
     };
 
-    let base: Option<&[u8]> = lca
+    let base: Option<Vec<u8>> = lca
         .first()
         .and_then(|id| branch.get_commit(id))
-        .and_then(|c| c.content.as_inline());
-
-    let tip_refs: Vec<&[u8]> = tip_contents.iter().map(|v| v.as_slice()).collect();
-
-    strategy
-        .merge(base, &tip_refs)
-        .map(Bytes::from)
-        .map_err(|e| ListenerError::MergeError(e.to_string()))
-}
-
-/// Helper to compute merged content from commit IDs (async, supports chunked).
-pub async fn merge_commit_ids_async(
-    tips: &[CommitId],
-    strategy: &dyn crate::merge::MergeStrategy,
-    branch: &Branch,
-    env: &dyn Environment,
-) -> Result<Bytes, ListenerError> {
-    if tips.is_empty() {
-        return Err(ListenerError::BranchNotFound);
-    }
-
-    let mut tip_contents: Vec<Vec<u8>> = Vec::new();
-    for id in tips {
-        let commit = branch.get_commit(id).ok_or(ListenerError::NotFound)?;
-        let content = load_content_ref(&commit.content, env).await?;
-        tip_contents.push(content);
-    }
-
-    if tip_contents.len() == 1 {
-        return Ok(Bytes::from(tip_contents.into_iter().next().unwrap()));
-    }
-
-    let lca = if tips.len() >= 2 {
-        branch.find_lca(&tips[0], &tips[1])
-    } else {
-        vec![]
-    };
-
-    let base: Option<Vec<u8>> = if let Some(lca_id) = lca.first() {
-        if let Some(commit) = branch.get_commit(lca_id) {
-            Some(load_content_ref(&commit.content, env).await?)
-        } else {
-            None
-        }
-    } else {
-        None
-    };
+        .map(|c| c.content.to_vec());
 
     let tip_refs: Vec<&[u8]> = tip_contents.iter().map(|v| v.as_slice()).collect();
 
@@ -628,25 +563,16 @@ pub async fn merge_commit_ids_async(
         .map_err(|e| ListenerError::MergeError(e.to_string()))
 }
 
-/// Load content from a ContentRef.
-async fn load_content_ref(
-    content: &crate::storage::ContentRef,
+/// Helper to compute merged content from commit IDs (async).
+/// Note: Now equivalent to merge_commit_ids since commits store content directly.
+#[allow(unused_variables)]
+pub async fn merge_commit_ids_async(
+    tips: &[CommitId],
+    strategy: &dyn crate::merge::MergeStrategy,
+    branch: &Branch,
     env: &dyn Environment,
-) -> Result<Vec<u8>, ListenerError> {
-    match content {
-        crate::storage::ContentRef::Inline(data) => Ok(data.to_vec()),
-        crate::storage::ContentRef::Chunked(hashes) => {
-            let mut result = Vec::new();
-            for hash in hashes {
-                let chunk = env
-                    .get_chunk(hash)
-                    .await
-                    .ok_or_else(|| ListenerError::StorageError("Chunk not found".to_string()))?;
-                result.extend_from_slice(&chunk);
-            }
-            Ok(result)
-        }
-    }
+) -> Result<Bytes, ListenerError> {
+    merge_commit_ids(tips, strategy, branch)
 }
 
 // Tests have been moved to tests/listener.rs

--- a/groove/src/listener.rs
+++ b/groove/src/listener.rs
@@ -137,19 +137,10 @@ impl ObjectState {
         &self.env
     }
 
-    /// Compute merged content using a merge strategy (sync, inline content only).
+    /// Compute merged content using a merge strategy.
     pub fn merge(&self, strategy: &dyn crate::merge::MergeStrategy) -> Result<Bytes, ListenerError> {
         let branch = self.branch.read().unwrap();
         merge_commit_ids(&self.tips, strategy, &branch)
-    }
-
-    /// Compute merged content using a merge strategy (async, supports chunked content).
-    pub async fn merge_async(
-        &self,
-        strategy: &dyn crate::merge::MergeStrategy,
-    ) -> Result<Bytes, ListenerError> {
-        let branch = self.branch.read().unwrap();
-        merge_commit_ids_async(&self.tips, strategy, &branch, self.env.as_ref()).await
     }
 
     /// Compute byte-level diff between previous and current merged content.
@@ -221,12 +212,6 @@ impl ObjectState {
             .map(|c| Bytes::copy_from_slice(&c.content))
     }
 
-    /// Get the content of a specific tip by commit ID (async).
-    /// Note: Now equivalent to get_tip_content since commits store content directly.
-    pub async fn get_tip_content_async(&self, commit_id: &CommitId) -> Option<Bytes> {
-        self.get_tip_content(commit_id)
-    }
-
     /// Get author of a specific tip.
     pub fn get_tip_author(&self, commit_id: &CommitId) -> Option<String> {
         let branch = self.branch.read().unwrap();
@@ -239,15 +224,11 @@ impl ObjectState {
         branch.get_commit(commit_id).map(|c| c.timestamp)
     }
 
-    /// Load content for all current tips (async, supports chunked).
-    pub async fn load_all_tips(&self) -> Vec<(CommitId, Bytes)> {
-        let mut results = Vec::new();
-        for tip in &self.tips {
-            if let Some(content) = self.get_tip_content_async(tip).await {
-                results.push((*tip, content));
-            }
-        }
-        results
+    /// Load content for all current tips.
+    pub fn load_all_tips(&self) -> Vec<(CommitId, Bytes)> {
+        self.tips.iter()
+            .filter_map(|tip| self.get_tip_content(tip).map(|content| (*tip, content)))
+            .collect()
     }
 
     /// Read the current content (merged if multiple tips, or single tip content).
@@ -561,18 +542,6 @@ pub fn merge_commit_ids(
         .merge(base.as_deref(), &tip_refs)
         .map(Bytes::from)
         .map_err(|e| ListenerError::MergeError(e.to_string()))
-}
-
-/// Helper to compute merged content from commit IDs (async).
-/// Note: Now equivalent to merge_commit_ids since commits store content directly.
-#[allow(unused_variables)]
-pub async fn merge_commit_ids_async(
-    tips: &[CommitId],
-    strategy: &dyn crate::merge::MergeStrategy,
-    branch: &Branch,
-    env: &dyn Environment,
-) -> Result<Bytes, ListenerError> {
-    merge_commit_ids(tips, strategy, branch)
 }
 
 // Tests have been moved to tests/listener.rs

--- a/groove/src/node.rs
+++ b/groove/src/node.rs
@@ -2,7 +2,6 @@ use std::collections::BTreeMap;
 use std::sync::{Arc, RwLock};
 
 use bytes::Bytes;
-use futures::io::AsyncRead;
 
 use crate::commit::CommitId;
 use crate::listener::{ListenerId, ListenerError, ObjectCallback, ObjectKey, ObjectListenerRegistry, ObjectState};
@@ -152,9 +151,9 @@ impl LocalNode {
 
     // ========== Read API ==========
 
-    /// Read content from the frontier of an object's branch (sync).
-    /// Returns None if the branch is empty, has multiple tips, or content is chunked.
-    pub fn read_sync(
+    /// Read content from the frontier of an object's branch.
+    /// Returns None if the branch is empty or has multiple tips.
+    pub fn read(
         &self,
         object_id: ObjectId,
         branch: &str,
@@ -171,37 +170,11 @@ impl LocalNode {
         Ok(obj.read_sync(branch))
     }
 
-    /// Read content from the frontier of an object's branch (async).
-    /// Loads chunked content from storage if needed.
-    pub async fn read(
-        &self,
-        object_id: ObjectId,
-        branch: &str,
-    ) -> Result<Option<Vec<u8>>, ListenerError> {
-        let obj_lock = self
-            .objects
-            .read()
-            .unwrap()
-            .get(&object_id)
-            .cloned()
-            .ok_or(ListenerError::NotFound)?;
-
-        let obj = obj_lock.read().unwrap();
-        Ok(obj.read(branch).await)
-    }
-
-    // Note: Streaming read methods are available directly on Object.
-    // Due to lifetime constraints with Arc<RwLock<Object>>, streaming
-    // must be done by obtaining the object reference directly:
-    //   let obj = node.get_object(id)?;
-    //   let guard = obj.read().unwrap();
-    //   let stream = guard.read_stream(branch);
-
     // ========== Write API with Auto-Notify ==========
 
     /// Write content to an object's branch and notify all listeners.
     /// Returns the new commit ID.
-    pub fn write_sync(
+    pub fn write(
         &self,
         object_id: ObjectId,
         branch: &str,
@@ -209,12 +182,12 @@ impl LocalNode {
         author: &str,
         timestamp: u64,
     ) -> Result<CommitId, ListenerError> {
-        self.write_sync_with_meta(object_id, branch, content, author, timestamp, None)
+        self.write_with_meta(object_id, branch, content, author, timestamp, None)
     }
 
     /// Write content to an object's branch with optional metadata and notify all listeners.
     /// Returns the new commit ID.
-    pub fn write_sync_with_meta(
+    pub fn write_with_meta(
         &self,
         object_id: ObjectId,
         branch: &str,
@@ -236,72 +209,6 @@ impl LocalNode {
 
         // Notify listeners synchronously
         self.notify_listeners(object_id, branch, &obj);
-
-        Ok(commit_id)
-    }
-
-    /// Write content to an object's branch (async) and notify all listeners.
-    pub async fn write(
-        &self,
-        object_id: ObjectId,
-        branch: &str,
-        content: &[u8],
-        author: &str,
-        timestamp: u64,
-    ) -> Result<CommitId, ListenerError> {
-        let obj_lock = self
-            .objects
-            .read()
-            .unwrap()
-            .get(&object_id)
-            .cloned()
-            .ok_or(ListenerError::NotFound)?;
-
-        let commit_id = {
-            let obj = obj_lock.read().unwrap();
-            obj.write(branch, content, author, timestamp)
-                .await
-        };
-
-        // Notify listeners synchronously
-        {
-            let obj = obj_lock.read().unwrap();
-            self.notify_listeners(object_id, branch, &obj);
-        }
-
-        Ok(commit_id)
-    }
-
-    /// Write content from an async reader to an object's branch.
-    /// Chunks the content as it streams in.
-    pub async fn write_stream<R: AsyncRead + Unpin>(
-        &self,
-        object_id: ObjectId,
-        branch: &str,
-        reader: R,
-        author: &str,
-        timestamp: u64,
-    ) -> Result<CommitId, ListenerError> {
-        let obj_lock = self
-            .objects
-            .read()
-            .unwrap()
-            .get(&object_id)
-            .cloned()
-            .ok_or(ListenerError::NotFound)?;
-
-        let commit_id = {
-            let obj = obj_lock.read().unwrap();
-            obj.write_stream(branch, reader, author, timestamp)
-                .await
-                .map_err(|e| ListenerError::StorageError(e.to_string()))?
-        };
-
-        // Notify listeners synchronously
-        {
-            let obj = obj_lock.read().unwrap();
-            self.notify_listeners(object_id, branch, &obj);
-        }
 
         Ok(commit_id)
     }

--- a/groove/src/node.rs
+++ b/groove/src/node.rs
@@ -74,6 +74,57 @@ impl LocalNode {
         &self.env
     }
 
+    /// Load an object from the Environment by reading its commits and frontier.
+    /// Returns the object ID if the object was found and loaded successfully.
+    pub fn load_object(&self, id: ObjectId, prefix: impl Into<String>, branch: &str) -> Option<ObjectId> {
+        use futures::executor::block_on;
+
+        // Get frontier from Environment
+        let frontier = block_on(self.env.get_frontier(id.into(), branch));
+        if frontier.is_empty() {
+            return None;
+        }
+
+        // Create a new Object
+        let object = Object::new(id, prefix);
+
+        // Load all commits from the Environment and add them to the Object
+        let branch_ref = object.branch_ref(branch)?;
+        {
+            let mut branch_guard = branch_ref.write().unwrap();
+
+            // Walk the commit graph starting from frontier
+            let mut to_load = frontier.clone();
+            let mut loaded = std::collections::HashSet::new();
+
+            while let Some(commit_id) = to_load.pop() {
+                if loaded.contains(&commit_id) {
+                    continue;
+                }
+                loaded.insert(commit_id);
+
+                if let Some(commit) = block_on(self.env.get_commit(&commit_id)) {
+                    // Add parent commits to load queue
+                    for parent_id in &commit.parents {
+                        if !loaded.contains(parent_id) {
+                            to_load.push(*parent_id);
+                        }
+                    }
+                    // Restore commit without updating frontier
+                    branch_guard.restore_commit(commit);
+                }
+            }
+
+            // Set frontier explicitly from Environment
+            branch_guard.set_frontier(frontier);
+        }
+
+        // Register the object
+        self.objects.write().unwrap().insert(id, Arc::new(RwLock::new(object)));
+
+        Some(id)
+    }
+
     /// Create a new object with the given prefix. Returns the object ID.
     /// Uses internal mutability so it can be called with just &self.
     pub fn create_object(&self, prefix: impl Into<String>) -> ObjectId {
@@ -206,6 +257,21 @@ impl LocalNode {
 
         let obj = obj_lock.read().unwrap();
         let commit_id = obj.write_sync_with_meta(branch, content, author, timestamp, meta);
+
+        // Persist commit and frontier to Environment
+        if let Some(branch_ref) = obj.branch_ref(branch) {
+            let branch_guard = branch_ref.read().unwrap();
+            if let Some(commit) = branch_guard.get_commit(&commit_id) {
+                use futures::executor::block_on;
+
+                // Persist commit
+                block_on(self.env.put_commit(commit));
+
+                // Persist frontier
+                let frontier = branch_guard.frontier();
+                block_on(self.env.set_frontier(object_id.into(), branch, frontier));
+            }
+        }
 
         // Notify listeners synchronously
         self.notify_listeners(object_id, branch, &obj);

--- a/groove/src/node.rs
+++ b/groove/src/node.rs
@@ -187,7 +187,7 @@ impl LocalNode {
             .ok_or(ListenerError::NotFound)?;
 
         let obj = obj_lock.read().unwrap();
-        Ok(obj.read(branch, self.env.as_ref()).await)
+        Ok(obj.read(branch).await)
     }
 
     // Note: Streaming read methods are available directly on Object.
@@ -195,13 +195,12 @@ impl LocalNode {
     // must be done by obtaining the object reference directly:
     //   let obj = node.get_object(id)?;
     //   let guard = obj.read().unwrap();
-    //   let stream = guard.read_stream(branch, env);
+    //   let stream = guard.read_stream(branch);
 
     // ========== Write API with Auto-Notify ==========
 
     /// Write content to an object's branch and notify all listeners.
     /// Returns the new commit ID.
-    /// Panics if content exceeds INLINE_THRESHOLD.
     pub fn write_sync(
         &self,
         object_id: ObjectId,
@@ -215,7 +214,6 @@ impl LocalNode {
 
     /// Write content to an object's branch with optional metadata and notify all listeners.
     /// Returns the new commit ID.
-    /// Panics if content exceeds INLINE_THRESHOLD.
     pub fn write_sync_with_meta(
         &self,
         object_id: ObjectId,
@@ -243,7 +241,6 @@ impl LocalNode {
     }
 
     /// Write content to an object's branch (async) and notify all listeners.
-    /// Automatically chunks content that exceeds INLINE_THRESHOLD.
     pub async fn write(
         &self,
         object_id: ObjectId,
@@ -262,7 +259,7 @@ impl LocalNode {
 
         let commit_id = {
             let obj = obj_lock.read().unwrap();
-            obj.write(branch, content, author, timestamp, self.env.as_ref())
+            obj.write(branch, content, author, timestamp)
                 .await
         };
 
@@ -295,7 +292,7 @@ impl LocalNode {
 
         let commit_id = {
             let obj = obj_lock.read().unwrap();
-            obj.write_stream(branch, reader, author, timestamp, self.env.as_ref())
+            obj.write_stream(branch, reader, author, timestamp)
                 .await
                 .map_err(|e| ListenerError::StorageError(e.to_string()))?
         };
@@ -393,28 +390,13 @@ impl LocalNode {
 
     // ========== Helper: Load content for a commit ==========
 
-    /// Load content for a commit (handles both inline and chunked).
-    pub async fn load_content(&self, object_id: ObjectId, branch: &str, commit_id: &CommitId) -> Option<Bytes> {
+    /// Load content for a commit.
+    pub fn load_content(&self, object_id: ObjectId, branch: &str, commit_id: &CommitId) -> Option<Bytes> {
         let obj_lock = self.objects.read().unwrap().get(&object_id).cloned()?;
         let obj = obj_lock.read().unwrap();
         let branch = obj.branch(branch)?;
         let commit = branch.get_commit(commit_id)?;
-
-        match &commit.content {
-            crate::storage::ContentRef::Inline(data) => Some(Bytes::copy_from_slice(&data)),
-            crate::storage::ContentRef::Chunked(hashes) => {
-                let hashes = hashes.clone();
-                drop(branch);
-                drop(obj);
-
-                let mut result = Vec::new();
-                for hash in hashes {
-                    let chunk = self.env.get_chunk(&hash).await?;
-                    result.extend_from_slice(&chunk);
-                }
-                Some(Bytes::from(result))
-            }
-        }
+        Some(Bytes::copy_from_slice(&commit.content))
     }
 }
 

--- a/groove/src/object.rs
+++ b/groove/src/object.rs
@@ -12,7 +12,6 @@ use futures::stream::Stream;
 use crate::branch::Branch;
 use crate::commit::{Commit, CommitId};
 use crate::merge::MergeStrategy;
-use crate::storage::{ChunkHash, ContentRef, ContentStore, INLINE_THRESHOLD};
 
 // ========== ObjectId Type ==========
 
@@ -418,22 +417,17 @@ impl Object {
         }
 
         // Get base content (from first LCA if exists)
-        // Note: This only works with inline content. Chunked content would need async loading.
         let base_content: Option<Vec<u8>> = lca_commits
             .first()
             .and_then(|id| target.commits.get(id))
-            .and_then(|c| c.content.as_inline().map(|b| b.to_vec()));
+            .map(|c| c.content.to_vec());
 
-        // Collect tip contents (only inline supported for sync merge)
+        // Collect tip contents
         let tip_contents: Vec<Vec<u8>> = all_tips
             .iter()
             .filter_map(|id| target.commits.get(id))
-            .filter_map(|c| c.content.as_inline().map(|b| b.to_vec()))
+            .map(|c| c.content.to_vec())
             .collect();
-
-        if tip_contents.len() != all_tips.len() {
-            return Err("cannot merge: some commits have chunked content (use async merge)");
-        }
 
         let tip_refs: Vec<&[u8]> = tip_contents.iter().map(|v| v.as_slice()).collect();
 
@@ -443,7 +437,7 @@ impl Object {
         // Create merge commit
         let merge_commit = Commit {
             parents: all_tips,
-            content: ContentRef::inline(merged_content),
+            content: merged_content,
             author: author.to_string(),
             timestamp,
             meta: None,
@@ -467,7 +461,7 @@ impl Object {
     // ========== Sync Read/Write Methods ==========
 
     /// Read content from the frontier of a branch (sync).
-    /// Returns None if the branch is empty, has multiple tips, or content is not inline.
+    /// Returns None if the branch is empty or has multiple tips.
     pub fn read_sync(&self, branch_name: &str) -> Option<Vec<u8>> {
         let branch = self.branches.get(branch_name)?.read().unwrap();
         let frontier = branch.frontier();
@@ -478,11 +472,10 @@ impl Object {
         }
 
         let commit = branch.get_commit(&frontier[0])?;
-        commit.content.as_inline().map(|b| b.to_vec())
+        Some(commit.content.to_vec())
     }
 
     /// Write content to a branch (sync).
-    /// Panics if content exceeds INLINE_THRESHOLD.
     /// Returns the new commit ID.
     pub fn write_sync(
         &self,
@@ -495,7 +488,6 @@ impl Object {
     }
 
     /// Write content to a branch with optional metadata (sync).
-    /// Panics if content exceeds INLINE_THRESHOLD.
     /// Returns the new commit ID.
     pub fn write_sync_with_meta(
         &self,
@@ -505,12 +497,6 @@ impl Object {
         timestamp: u64,
         meta: Option<std::collections::BTreeMap<String, String>>,
     ) -> CommitId {
-        assert!(
-            content.len() <= INLINE_THRESHOLD,
-            "content exceeds INLINE_THRESHOLD ({} bytes), use write() for large content",
-            INLINE_THRESHOLD
-        );
-
         let mut branch = self
             .branches
             .get(branch_name)
@@ -522,7 +508,7 @@ impl Object {
 
         let commit = Commit {
             parents,
-            content: ContentRef::inline(content.to_vec()),
+            content: content.to_vec().into_boxed_slice(),
             author: author.to_string(),
             timestamp,
             meta,
@@ -534,180 +520,51 @@ impl Object {
     // ========== Async Read/Write Methods ==========
 
     /// Read content from the frontier of a branch (async).
-    /// Loads chunked content from storage if needed.
-    pub async fn read(&self, branch_name: &str, store: &dyn ContentStore) -> Option<Vec<u8>> {
-        let branch = self.branches.get(branch_name)?.read().unwrap();
-        let frontier = branch.frontier();
-
-        // Only return content if there's exactly one tip
-        if frontier.len() != 1 {
-            return None;
-        }
-
-        let commit = branch.get_commit(&frontier[0])?;
-
-        match &commit.content {
-            ContentRef::Inline(data) => Some(data.to_vec()),
-            ContentRef::Chunked(hashes) => {
-                // Load all chunks and concatenate
-                let hashes = hashes.clone();
-                drop(branch); // Release lock before async ops
-
-                let mut result = Vec::new();
-                for hash in hashes {
-                    let chunk = store.get_chunk(&hash).await?;
-                    result.extend_from_slice(&chunk);
-                }
-                Some(result)
-            }
-        }
+    /// Returns None if the branch is empty or has multiple tips.
+    ///
+    /// Note: This method is now equivalent to read_sync() since commits
+    /// store content directly. Kept for API compatibility.
+    pub async fn read(&self, branch_name: &str) -> Option<Vec<u8>> {
+        self.read_sync(branch_name)
     }
 
     /// Write content to a branch (async).
-    /// Automatically chunks content that exceeds INLINE_THRESHOLD.
+    ///
+    /// Note: This method is now equivalent to write_sync() since commits
+    /// store content directly. Kept for API compatibility.
     pub async fn write(
         &self,
         branch_name: &str,
         content: &[u8],
         author: &str,
         timestamp: u64,
-        store: &dyn ContentStore,
     ) -> CommitId {
-        let content_ref = if content.len() <= INLINE_THRESHOLD {
-            ContentRef::inline(content.to_vec())
-        } else {
-            // For now, simple fixed-size chunking
-            // TODO: Use FastCDC for content-defined chunking
-            let mut hashes = Vec::new();
-            for chunk in content.chunks(INLINE_THRESHOLD) {
-                let hash = store.put_chunk(chunk.to_vec().into()).await;
-                hashes.push(hash);
-            }
-            ContentRef::chunked(hashes)
-        };
-
-        let mut branch = self
-            .branches
-            .get(branch_name)
-            .expect("branch not found")
-            .write()
-            .unwrap();
-
-        let parents = branch.frontier().to_vec();
-
-        let commit = Commit {
-            parents,
-            content: content_ref,
-            author: author.to_string(),
-            timestamp,
-            meta: None,
-        };
-
-        branch.add_commit(commit)
+        self.write_sync(branch_name, content, author, timestamp)
     }
 
     // ========== Streaming Read/Write Methods ==========
 
     /// Write content from an async reader to a branch.
-    /// Chunks the content as it streams in using fixed-size chunks.
+    /// Reads all content into memory and stores it directly in the commit.
     pub async fn write_stream<R: AsyncRead + Unpin>(
         &self,
         branch_name: &str,
         mut reader: R,
         author: &str,
         timestamp: u64,
-        store: &dyn ContentStore,
     ) -> std::io::Result<CommitId> {
         use futures::io::AsyncReadExt;
 
-        let mut hashes = Vec::new();
-        let mut buffer = vec![0u8; INLINE_THRESHOLD];
-        let mut first_chunk: Option<Vec<u8>> = None;
+        // Read all content into memory
+        let mut content = Vec::new();
+        reader.read_to_end(&mut content).await?;
 
-        loop {
-            let mut chunk_data = Vec::new();
-            let mut remaining = INLINE_THRESHOLD;
-
-            // Fill the buffer up to INLINE_THRESHOLD
-            while remaining > 0 {
-                let to_read = remaining.min(buffer.len());
-                let n = reader.read(&mut buffer[..to_read]).await?;
-                if n == 0 {
-                    break;
-                }
-                chunk_data.extend_from_slice(&buffer[..n]);
-                remaining -= n;
-            }
-
-            if chunk_data.is_empty() {
-                break;
-            }
-
-            // If this is the first chunk and it's the only one, we might inline it
-            if first_chunk.is_none() && remaining > 0 {
-                // This is the first and last chunk (didn't fill the buffer)
-                first_chunk = Some(chunk_data);
-                break;
-            } else if first_chunk.is_none() {
-                // First chunk but more data coming - store it
-                first_chunk = Some(chunk_data);
-            } else {
-                // Store the previous first_chunk if we haven't yet
-                if let Some(fc) = first_chunk.take() {
-                    let hash = store.put_chunk(fc.into()).await;
-                    hashes.push(hash);
-                }
-                // Store current chunk
-                let hash = store.put_chunk(chunk_data.into()).await;
-                hashes.push(hash);
-            }
-        }
-
-        // Determine content ref based on what we collected
-        let content_ref = if let Some(fc) = first_chunk {
-            if hashes.is_empty() && fc.len() <= INLINE_THRESHOLD {
-                // Small enough to inline
-                ContentRef::inline(fc)
-            } else {
-                // Need to store first chunk too
-                let hash = store.put_chunk(fc.into()).await;
-                hashes.insert(0, hash);
-                ContentRef::chunked(hashes)
-            }
-        } else if hashes.is_empty() {
-            // Empty content
-            ContentRef::inline(Vec::new())
-        } else {
-            ContentRef::chunked(hashes)
-        };
-
-        let mut branch = self
-            .branches
-            .get(branch_name)
-            .expect("branch not found")
-            .write()
-            .unwrap();
-
-        let parents = branch.frontier().to_vec();
-
-        let commit = Commit {
-            parents,
-            content: content_ref,
-            author: author.to_string(),
-            timestamp,
-            meta: None,
-        };
-
-        Ok(branch.add_commit(commit))
+        Ok(self.write_sync(branch_name, &content, author, timestamp))
     }
 
     /// Stream content from the frontier of a branch.
-    /// Returns a stream of chunks, or None if branch is empty or has multiple tips.
-    pub fn read_stream<'a>(
-        &'a self,
-        branch_name: &str,
-        store: &'a dyn ContentStore,
-    ) -> Option<ContentStream<'a>> {
+    /// Returns a stream that yields a single chunk, or None if branch is empty or has multiple tips.
+    pub fn read_stream(&self, branch_name: &str) -> Option<ContentStream> {
         let branch = self.branches.get(branch_name)?.read().unwrap();
         let frontier = branch.frontier();
 
@@ -720,7 +577,7 @@ impl Object {
         let content = commit.content.clone();
         drop(branch); // Release lock before returning stream
 
-        Some(ContentStream::new(content, store))
+        Some(ContentStream::new(content))
     }
 
     /// Get the frontier commit IDs for a branch.
@@ -730,94 +587,31 @@ impl Object {
     }
 }
 
-/// A stream that yields chunks of content.
+/// A stream that yields content as a single chunk.
 ///
-/// For inline content, yields a single chunk containing all data.
-/// For chunked content, yields each chunk as it's loaded from the store.
-pub struct ContentStream<'a> {
-    inner: ContentStreamInner<'a>,
+/// Since commits store content directly, this always yields once then completes.
+pub struct ContentStream {
+    content: Option<Bytes>,
 }
 
-enum ContentStreamInner<'a> {
-    /// Inline content - yields once then done
-    Inline(Option<Bytes>),
-    /// Chunked content - yields each chunk
-    Chunked {
-        hashes: Vec<ChunkHash>,
-        index: usize,
-        store: &'a dyn ContentStore,
-    },
-    /// Stream exhausted
-    Done,
-}
-
-impl<'a> ContentStream<'a> {
-    fn new(content: ContentRef, store: &'a dyn ContentStore) -> Self {
-        let inner = match content {
-            ContentRef::Inline(data) => {
-                ContentStreamInner::Inline(Some(Bytes::copy_from_slice(&data)))
-            }
-            ContentRef::Chunked(hashes) => ContentStreamInner::Chunked {
-                hashes,
-                index: 0,
-                store,
-            },
-        };
-        ContentStream { inner }
+impl ContentStream {
+    fn new(content: Box<[u8]>) -> Self {
+        ContentStream {
+            content: Some(Bytes::copy_from_slice(&content)),
+        }
     }
 
-    /// Collect all chunks into a single Vec<u8>.
+    /// Collect the content into a Vec<u8>.
     pub async fn collect_bytes(self) -> Vec<u8> {
-        use futures::stream::StreamExt;
-        let chunks: Vec<Bytes> = self.collect().await;
-        chunks.iter().flat_map(|c| c.iter().copied()).collect()
+        self.content.map(|b| b.to_vec()).unwrap_or_default()
     }
 }
 
-impl<'a> Stream for ContentStream<'a> {
+impl Stream for ContentStream {
     type Item = Bytes;
 
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        match &mut self.inner {
-            ContentStreamInner::Inline(data) => match data.take() {
-                Some(d) => Poll::Ready(Some(d)),
-                None => {
-                    self.inner = ContentStreamInner::Done;
-                    Poll::Ready(None)
-                }
-            },
-            ContentStreamInner::Chunked {
-                hashes,
-                index,
-                store,
-            } => {
-                if *index >= hashes.len() {
-                    self.inner = ContentStreamInner::Done;
-                    return Poll::Ready(None);
-                }
-
-                let hash = hashes[*index];
-                let store_ref = *store;
-
-                // Create and poll a future to fetch the chunk
-                let fut = async move { store_ref.get_chunk(&hash).await };
-                let mut pinned = Box::pin(fut);
-
-                match pinned.as_mut().poll(cx) {
-                    Poll::Ready(Some(bytes)) => {
-                        *index += 1;
-                        Poll::Ready(Some(bytes))
-                    }
-                    Poll::Ready(None) => {
-                        // Chunk not found
-                        self.inner = ContentStreamInner::Done;
-                        Poll::Ready(None)
-                    }
-                    Poll::Pending => Poll::Pending,
-                }
-            }
-            ContentStreamInner::Done => Poll::Ready(None),
-        }
+    fn poll_next(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        Poll::Ready(self.content.take())
     }
 }
 

--- a/groove/src/object.rs
+++ b/groove/src/object.rs
@@ -1,13 +1,7 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt;
-use std::pin::Pin;
 use std::str::FromStr;
 use std::sync::{Arc, RwLock};
-use std::task::{Context, Poll};
-
-use bytes::Bytes;
-use futures::io::AsyncRead;
-use futures::stream::Stream;
 
 use crate::branch::Branch;
 use crate::commit::{Commit, CommitId};
@@ -517,101 +511,10 @@ impl Object {
         branch.add_commit(commit)
     }
 
-    // ========== Async Read/Write Methods ==========
-
-    /// Read content from the frontier of a branch (async).
-    /// Returns None if the branch is empty or has multiple tips.
-    ///
-    /// Note: This method is now equivalent to read_sync() since commits
-    /// store content directly. Kept for API compatibility.
-    pub async fn read(&self, branch_name: &str) -> Option<Vec<u8>> {
-        self.read_sync(branch_name)
-    }
-
-    /// Write content to a branch (async).
-    ///
-    /// Note: This method is now equivalent to write_sync() since commits
-    /// store content directly. Kept for API compatibility.
-    pub async fn write(
-        &self,
-        branch_name: &str,
-        content: &[u8],
-        author: &str,
-        timestamp: u64,
-    ) -> CommitId {
-        self.write_sync(branch_name, content, author, timestamp)
-    }
-
-    // ========== Streaming Read/Write Methods ==========
-
-    /// Write content from an async reader to a branch.
-    /// Reads all content into memory and stores it directly in the commit.
-    pub async fn write_stream<R: AsyncRead + Unpin>(
-        &self,
-        branch_name: &str,
-        mut reader: R,
-        author: &str,
-        timestamp: u64,
-    ) -> std::io::Result<CommitId> {
-        use futures::io::AsyncReadExt;
-
-        // Read all content into memory
-        let mut content = Vec::new();
-        reader.read_to_end(&mut content).await?;
-
-        Ok(self.write_sync(branch_name, &content, author, timestamp))
-    }
-
-    /// Stream content from the frontier of a branch.
-    /// Returns a stream that yields a single chunk, or None if branch is empty or has multiple tips.
-    pub fn read_stream(&self, branch_name: &str) -> Option<ContentStream> {
-        let branch = self.branches.get(branch_name)?.read().unwrap();
-        let frontier = branch.frontier();
-
-        // Only return content if there's exactly one tip
-        if frontier.len() != 1 {
-            return None;
-        }
-
-        let commit = branch.get_commit(&frontier[0])?;
-        let content = commit.content.clone();
-        drop(branch); // Release lock before returning stream
-
-        Some(ContentStream::new(content))
-    }
-
     /// Get the frontier commit IDs for a branch.
     pub fn frontier(&self, branch_name: &str) -> Option<Vec<CommitId>> {
         let branch = self.branches.get(branch_name)?.read().unwrap();
         Some(branch.frontier().to_vec())
-    }
-}
-
-/// A stream that yields content as a single chunk.
-///
-/// Since commits store content directly, this always yields once then completes.
-pub struct ContentStream {
-    content: Option<Bytes>,
-}
-
-impl ContentStream {
-    fn new(content: Box<[u8]>) -> Self {
-        ContentStream {
-            content: Some(Bytes::copy_from_slice(&content)),
-        }
-    }
-
-    /// Collect the content into a Vec<u8>.
-    pub async fn collect_bytes(self) -> Vec<u8> {
-        self.content.map(|b| b.to_vec()).unwrap_or_default()
-    }
-}
-
-impl Stream for ContentStream {
-    type Item = Bytes;
-
-    fn poll_next(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        Poll::Ready(self.content.take())
     }
 }
 

--- a/groove/src/sql/binary.rs
+++ b/groove/src/sql/binary.rs
@@ -180,6 +180,22 @@ fn encode_value(buf: &mut Vec<u8>, value: &Value) {
                 encode_value(buf, elem);
             }
         }
+        Value::Blob(content_ref) => {
+            // Blob: serialize ContentRef bytes with length prefix
+            // Format: u32 length + ContentRef bytes
+            let blob_bytes = content_ref.to_row_bytes();
+            buf.extend_from_slice(&(blob_bytes.len() as u32).to_le_bytes());
+            buf.extend_from_slice(&blob_bytes);
+        }
+        Value::BlobArray(refs) => {
+            // BlobArray: count + each blob's serialized ContentRef
+            buf.extend_from_slice(&(refs.len() as u32).to_le_bytes());
+            for content_ref in refs {
+                let blob_bytes = content_ref.to_row_bytes();
+                buf.extend_from_slice(&(blob_bytes.len() as u32).to_le_bytes());
+                buf.extend_from_slice(&blob_bytes);
+            }
+        }
     }
 }
 

--- a/groove/src/sql/catalog.rs
+++ b/groove/src/sql/catalog.rs
@@ -1,0 +1,336 @@
+//! Database catalog for persistence.
+//!
+//! The catalog stores metadata about tables, allowing a Database to be
+//! restored from an Environment after being thrown away.
+
+use std::collections::HashMap;
+
+use crate::object::ObjectId;
+use crate::sql::policy::TablePolicies;
+use crate::sql::schema::TableSchema;
+
+/// Database catalog - stored in a well-known object.
+///
+/// Maps table names to their descriptor object IDs.
+#[derive(Debug, Clone, Default)]
+pub struct Catalog {
+    /// Table name → descriptor object ID
+    pub tables: HashMap<String, ObjectId>,
+}
+
+impl Catalog {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Serialize catalog to bytes.
+    ///
+    /// Format:
+    /// - u32: number of tables
+    /// - For each table:
+    ///   - u32: name length
+    ///   - bytes: name (UTF-8)
+    ///   - 16 bytes: ObjectId
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let mut buf = Vec::new();
+
+        // Number of tables
+        buf.extend_from_slice(&(self.tables.len() as u32).to_le_bytes());
+
+        for (name, id) in &self.tables {
+            // Name length + name
+            let name_bytes = name.as_bytes();
+            buf.extend_from_slice(&(name_bytes.len() as u32).to_le_bytes());
+            buf.extend_from_slice(name_bytes);
+
+            // ObjectId (u128)
+            buf.extend_from_slice(&u128::from(*id).to_le_bytes());
+        }
+
+        buf
+    }
+
+    /// Deserialize catalog from bytes.
+    pub fn from_bytes(data: &[u8]) -> Result<Self, CatalogError> {
+        if data.len() < 4 {
+            return Err(CatalogError::UnexpectedEof);
+        }
+
+        let mut pos = 0;
+
+        // Number of tables
+        let num_tables = u32::from_le_bytes(data[pos..pos + 4].try_into().unwrap()) as usize;
+        pos += 4;
+
+        let mut tables = HashMap::with_capacity(num_tables);
+
+        for _ in 0..num_tables {
+            // Name length
+            if data.len() < pos + 4 {
+                return Err(CatalogError::UnexpectedEof);
+            }
+            let name_len = u32::from_le_bytes(data[pos..pos + 4].try_into().unwrap()) as usize;
+            pos += 4;
+
+            // Name
+            if data.len() < pos + name_len {
+                return Err(CatalogError::UnexpectedEof);
+            }
+            let name = String::from_utf8(data[pos..pos + name_len].to_vec())
+                .map_err(|_| CatalogError::InvalidUtf8)?;
+            pos += name_len;
+
+            // ObjectId
+            if data.len() < pos + 16 {
+                return Err(CatalogError::UnexpectedEof);
+            }
+            let id_bytes: [u8; 16] = data[pos..pos + 16].try_into().unwrap();
+            let id = ObjectId::new(u128::from_le_bytes(id_bytes));
+            pos += 16;
+
+            tables.insert(name, id);
+        }
+
+        Ok(Catalog { tables })
+    }
+}
+
+/// Per-table descriptor - stored in descriptor object.
+///
+/// Contains all metadata needed to restore a table.
+#[derive(Debug, Clone)]
+pub struct TableDescriptor {
+    /// The table schema.
+    pub schema: TableSchema,
+    /// Access control policies for this table.
+    pub policies: TablePolicies,
+    /// Object ID for the TableRows (set of row IDs).
+    pub rows_object_id: ObjectId,
+    /// Schema object ID (where schema is stored).
+    pub schema_object_id: ObjectId,
+    /// Index object IDs: column name → object ID.
+    pub index_object_ids: HashMap<String, ObjectId>,
+}
+
+impl TableDescriptor {
+    /// Serialize descriptor to bytes.
+    ///
+    /// Format:
+    /// - schema bytes (with length prefix)
+    /// - policies bytes (with length prefix)
+    /// - 16 bytes: rows_object_id
+    /// - 16 bytes: schema_object_id
+    /// - u32: number of indexes
+    /// - For each index:
+    ///   - u32: column name length
+    ///   - bytes: column name (UTF-8)
+    ///   - 16 bytes: ObjectId
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let mut buf = Vec::new();
+
+        // Schema (length-prefixed)
+        let schema_bytes = self.schema.to_bytes();
+        buf.extend_from_slice(&(schema_bytes.len() as u32).to_le_bytes());
+        buf.extend_from_slice(&schema_bytes);
+
+        // Policies (length-prefixed)
+        let policies_bytes = self.policies.to_bytes();
+        buf.extend_from_slice(&(policies_bytes.len() as u32).to_le_bytes());
+        buf.extend_from_slice(&policies_bytes);
+
+        // rows_object_id
+        buf.extend_from_slice(&u128::from(self.rows_object_id).to_le_bytes());
+
+        // schema_object_id
+        buf.extend_from_slice(&u128::from(self.schema_object_id).to_le_bytes());
+
+        // Index objects
+        buf.extend_from_slice(&(self.index_object_ids.len() as u32).to_le_bytes());
+        for (col_name, id) in &self.index_object_ids {
+            let name_bytes = col_name.as_bytes();
+            buf.extend_from_slice(&(name_bytes.len() as u32).to_le_bytes());
+            buf.extend_from_slice(name_bytes);
+            buf.extend_from_slice(&u128::from(*id).to_le_bytes());
+        }
+
+        buf
+    }
+
+    /// Deserialize descriptor from bytes.
+    pub fn from_bytes(data: &[u8]) -> Result<Self, CatalogError> {
+        let mut pos = 0;
+
+        // Schema length
+        if data.len() < pos + 4 {
+            return Err(CatalogError::UnexpectedEof);
+        }
+        let schema_len = u32::from_le_bytes(data[pos..pos + 4].try_into().unwrap()) as usize;
+        pos += 4;
+
+        // Schema bytes
+        if data.len() < pos + schema_len {
+            return Err(CatalogError::UnexpectedEof);
+        }
+        let schema = TableSchema::from_bytes(&data[pos..pos + schema_len])
+            .map_err(|e| CatalogError::SchemaError(e.to_string()))?;
+        pos += schema_len;
+
+        // Policies length
+        if data.len() < pos + 4 {
+            return Err(CatalogError::UnexpectedEof);
+        }
+        let policies_len = u32::from_le_bytes(data[pos..pos + 4].try_into().unwrap()) as usize;
+        pos += 4;
+
+        // Policies bytes
+        if data.len() < pos + policies_len {
+            return Err(CatalogError::UnexpectedEof);
+        }
+        let policies = TablePolicies::from_bytes(&data[pos..pos + policies_len], &schema.name)
+            .map_err(|e| CatalogError::PolicyError(e.to_string()))?;
+        pos += policies_len;
+
+        // rows_object_id
+        if data.len() < pos + 16 {
+            return Err(CatalogError::UnexpectedEof);
+        }
+        let rows_id_bytes: [u8; 16] = data[pos..pos + 16].try_into().unwrap();
+        let rows_object_id = ObjectId::new(u128::from_le_bytes(rows_id_bytes));
+        pos += 16;
+
+        // schema_object_id
+        if data.len() < pos + 16 {
+            return Err(CatalogError::UnexpectedEof);
+        }
+        let schema_id_bytes: [u8; 16] = data[pos..pos + 16].try_into().unwrap();
+        let schema_object_id = ObjectId::new(u128::from_le_bytes(schema_id_bytes));
+        pos += 16;
+
+        // Number of indexes
+        if data.len() < pos + 4 {
+            return Err(CatalogError::UnexpectedEof);
+        }
+        let num_indexes = u32::from_le_bytes(data[pos..pos + 4].try_into().unwrap()) as usize;
+        pos += 4;
+
+        let mut index_object_ids = HashMap::with_capacity(num_indexes);
+        for _ in 0..num_indexes {
+            // Column name length
+            if data.len() < pos + 4 {
+                return Err(CatalogError::UnexpectedEof);
+            }
+            let name_len = u32::from_le_bytes(data[pos..pos + 4].try_into().unwrap()) as usize;
+            pos += 4;
+
+            // Column name
+            if data.len() < pos + name_len {
+                return Err(CatalogError::UnexpectedEof);
+            }
+            let col_name = String::from_utf8(data[pos..pos + name_len].to_vec())
+                .map_err(|_| CatalogError::InvalidUtf8)?;
+            pos += name_len;
+
+            // ObjectId
+            if data.len() < pos + 16 {
+                return Err(CatalogError::UnexpectedEof);
+            }
+            let id_bytes: [u8; 16] = data[pos..pos + 16].try_into().unwrap();
+            let id = ObjectId::new(u128::from_le_bytes(id_bytes));
+            pos += 16;
+
+            index_object_ids.insert(col_name, id);
+        }
+
+        Ok(TableDescriptor {
+            schema,
+            policies,
+            rows_object_id,
+            schema_object_id,
+            index_object_ids,
+        })
+    }
+}
+
+/// Errors during catalog operations.
+#[derive(Debug, Clone)]
+pub enum CatalogError {
+    UnexpectedEof,
+    InvalidUtf8,
+    SchemaError(String),
+    PolicyError(String),
+}
+
+impl std::fmt::Display for CatalogError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CatalogError::UnexpectedEof => write!(f, "unexpected end of catalog data"),
+            CatalogError::InvalidUtf8 => write!(f, "invalid UTF-8 in catalog"),
+            CatalogError::SchemaError(e) => write!(f, "schema error: {}", e),
+            CatalogError::PolicyError(e) => write!(f, "policy error: {}", e),
+        }
+    }
+}
+
+impl std::error::Error for CatalogError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sql::schema::{ColumnDef, ColumnType};
+
+    #[test]
+    fn catalog_roundtrip() {
+        let mut catalog = Catalog::new();
+        catalog.tables.insert("users".to_string(), ObjectId::new(100));
+        catalog.tables.insert("posts".to_string(), ObjectId::new(200));
+
+        let bytes = catalog.to_bytes();
+        let restored = Catalog::from_bytes(&bytes).unwrap();
+
+        assert_eq!(restored.tables.len(), 2);
+        assert_eq!(restored.tables.get("users"), Some(&ObjectId::new(100)));
+        assert_eq!(restored.tables.get("posts"), Some(&ObjectId::new(200)));
+    }
+
+    #[test]
+    fn table_descriptor_roundtrip() {
+        let schema = TableSchema {
+            name: "users".to_string(),
+            columns: vec![
+                ColumnDef {
+                    name: "id".to_string(),
+                    ty: ColumnType::I32,
+                    nullable: false,
+                },
+                ColumnDef {
+                    name: "name".to_string(),
+                    ty: ColumnType::String,
+                    nullable: false,
+                },
+            ],
+        };
+
+        let mut index_ids = HashMap::new();
+        index_ids.insert("org_id".to_string(), ObjectId::new(300));
+
+        let descriptor = TableDescriptor {
+            schema: schema.clone(),
+            policies: TablePolicies::default(),
+            rows_object_id: ObjectId::new(100),
+            schema_object_id: ObjectId::new(200),
+            index_object_ids: index_ids,
+        };
+
+        let bytes = descriptor.to_bytes();
+        let restored = TableDescriptor::from_bytes(&bytes).unwrap();
+
+        assert_eq!(restored.schema.name, "users");
+        assert_eq!(restored.schema.columns.len(), 2);
+        assert_eq!(restored.rows_object_id, ObjectId::new(100));
+        assert_eq!(restored.schema_object_id, ObjectId::new(200));
+        assert_eq!(
+            restored.index_object_ids.get("org_id"),
+            Some(&ObjectId::new(300))
+        );
+    }
+}

--- a/groove/src/sql/database/mod.rs
+++ b/groove/src/sql/database/mod.rs
@@ -432,7 +432,7 @@ impl DatabaseState {
         let row_ids: Vec<ObjectId> = {
             let table_rows_objects = self.table_rows_objects.read().unwrap();
             if let Some(rows_id) = table_rows_objects.get(table) {
-                if let Ok(Some(data)) = self.node.read_sync(*rows_id, "main") {
+                if let Ok(Some(data)) = self.node.read(*rows_id, "main") {
                     if !data.is_empty() {
                         if let Ok(table_rows) = TableRows::from_bytes(&data) {
                             table_rows.into_vec()
@@ -452,7 +452,7 @@ impl DatabaseState {
 
         let mut rows = Vec::new();
         for row_id in row_ids {
-            let data = match self.node.read_sync(row_id, "main") {
+            let data = match self.node.read(row_id, "main") {
                 Ok(Some(data)) if !data.is_empty() => data,
                 _ => continue,
             };
@@ -481,7 +481,7 @@ impl DatabaseState {
             }
         }
 
-        let data = match self.node.read_sync(id, "main") {
+        let data = match self.node.read(id, "main") {
             Ok(Some(data)) if !data.is_empty() => data,
             _ => return None,
         };
@@ -1299,7 +1299,7 @@ impl Database {
         let data = self
             .state
             .node
-            .read_sync(*index_id, "main")
+            .read(*index_id, "main")
             .map_err(|e| DatabaseError::Storage(format!("{:?}", e)))?
             .unwrap_or_default();
 
@@ -1320,7 +1320,7 @@ impl Database {
 
         self.state
             .node
-            .write_sync(
+            .write(
                 *index_id,
                 "main",
                 &index.to_bytes(),
@@ -1349,7 +1349,7 @@ impl Database {
         let data = self
             .state
             .node
-            .read_sync(*rows_id, "main")
+            .read(*rows_id, "main")
             .map_err(|e| DatabaseError::Storage(format!("{:?}", e)))?
             .unwrap_or_default();
 
@@ -1370,7 +1370,7 @@ impl Database {
 
         self.state
             .node
-            .write_sync(
+            .write(
                 *rows_id,
                 "main",
                 &rows.to_bytes(),
@@ -1422,7 +1422,7 @@ impl Database {
         let schema_bytes = schema.to_bytes();
         self.state
             .node
-            .write_sync(schema_id, "main", &schema_bytes, "system", timestamp_now())
+            .write(schema_id, "main", &schema_bytes, "system", timestamp_now())
             .map_err(|e| DatabaseError::Storage(format!("{:?}", e)))?;
 
         // Create table rows object to track row membership
@@ -1433,7 +1433,7 @@ impl Database {
         let empty_rows = TableRows::new();
         self.state
             .node
-            .write_sync(
+            .write(
                 rows_id,
                 "main",
                 &empty_rows.to_bytes(),
@@ -1460,7 +1460,7 @@ impl Database {
                 let empty_index = RefIndex::new();
                 self.state
                     .node
-                    .write_sync(
+                    .write(
                         index_id,
                         "main",
                         &empty_index.to_bytes(),
@@ -1607,7 +1607,7 @@ impl Database {
         // Store row data
         self.state
             .node
-            .write_sync(row_id, "main", &row_bytes, "system", timestamp_now())
+            .write(row_id, "main", &row_bytes, "system", timestamp_now())
             .map_err(|e| DatabaseError::Storage(format!("{:?}", e)))?;
 
         // Track row -> table mapping
@@ -1662,7 +1662,7 @@ impl Database {
         }
 
         // Read row data
-        let data = match self.state.node.read_sync(id, "main") {
+        let data = match self.state.node.read(id, "main") {
             Ok(Some(data)) => data,
             Ok(None) => return Ok(None),
             Err(e) => return Err(DatabaseError::Storage(format!("{:?}", e))),
@@ -1695,7 +1695,7 @@ impl Database {
         }
 
         // Read current row data
-        let data = match self.state.node.read_sync(id, "main") {
+        let data = match self.state.node.read(id, "main") {
             Ok(Some(data)) => data,
             Ok(None) => return Ok(false),
             Err(e) => return Err(DatabaseError::Storage(format!("{:?}", e))),
@@ -1745,7 +1745,7 @@ impl Database {
         // Write updated row
         self.state
             .node
-            .write_sync(id, "main", &row_bytes, "system", timestamp_now())
+            .write(id, "main", &row_bytes, "system", timestamp_now())
             .map_err(|e| DatabaseError::Storage(format!("{:?}", e)))?;
 
         // Update indexes for changed Ref columns
@@ -1818,7 +1818,7 @@ impl Database {
         }
 
         // Read current row data to get ref values for index cleanup
-        let data = match self.state.node.read_sync(id, "main") {
+        let data = match self.state.node.read(id, "main") {
             Ok(Some(data)) if !data.is_empty() => Some(data),
             _ => None,
         };
@@ -1848,7 +1848,7 @@ impl Database {
         // Write soft delete commit with metadata marker
         let commit_id = self.state
             .node
-            .write_sync_with_meta(id, "main", &[], "system", timestamp_now(), Some(meta))
+            .write_with_meta(id, "main", &[], "system", timestamp_now(), Some(meta))
             .map_err(|e| DatabaseError::Storage(format!("{:?}", e)))?;
 
         // If hard delete, truncate history at the delete commit
@@ -1897,7 +1897,7 @@ impl Database {
             }
 
             // Read row data
-            let data = match self.state.node.read_sync(row_id, "main") {
+            let data = match self.state.node.read(row_id, "main") {
                 Ok(Some(data)) if !data.is_empty() => data,
                 _ => continue, // Skip deleted or missing rows
             };
@@ -1953,7 +1953,7 @@ impl Database {
                 continue;
             }
 
-            let data = match self.state.node.read_sync(row_id, "main") {
+            let data = match self.state.node.read(row_id, "main") {
                 Ok(Some(data)) if !data.is_empty() => data,
                 _ => continue,
             };

--- a/groove/src/sql/database/mod.rs
+++ b/groove/src/sql/database/mod.rs
@@ -4,6 +4,7 @@ use std::sync::{Arc, RwLock};
 use crate::listener::ListenerId;
 use crate::node::{LocalNode, generate_object_id};
 use crate::object::ObjectId;
+use crate::sql::catalog::{Catalog, TableDescriptor};
 use crate::sql::index::RefIndex;
 use crate::sql::parser::{self, Condition, ConditionValue, Join, Projection, Select, SelectExpr, Statement};
 use crate::sql::policy::{
@@ -360,12 +361,16 @@ impl Drop for IncrementalQuery {
 /// This is the core data that queries need access to.
 pub struct DatabaseState {
     node: LocalNode,
+    /// Object ID for the database catalog.
+    catalog_object_id: ObjectId,
     /// Map from table name to schema object ID.
     tables: RwLock<HashMap<String, SchemaId>>,
     /// Cached schemas by ID.
     schemas: RwLock<HashMap<SchemaId, TableSchema>>,
     /// Map from table name to table rows object ID.
     table_rows_objects: RwLock<HashMap<String, ObjectId>>,
+    /// Map from table name to table descriptor object ID.
+    descriptor_objects: RwLock<HashMap<String, ObjectId>>,
     /// Map from row object ID to its table name.
     row_table: RwLock<HashMap<ObjectId, String>>,
     /// Reference index objects: (source_table, source_column) -> object ID.
@@ -389,11 +394,29 @@ impl std::fmt::Debug for DatabaseState {
 
 impl DatabaseState {
     fn new(env: Arc<dyn Environment>) -> Self {
+        let node = LocalNode::new(env);
+
+        // Create catalog object
+        let catalog_object_id = node.create_object("catalog");
+
+        // Initialize empty catalog
+        let empty_catalog = Catalog::new();
+        node.write(
+            catalog_object_id,
+            "main",
+            &empty_catalog.to_bytes(),
+            "system",
+            timestamp_now(),
+        )
+        .expect("failed to initialize catalog");
+
         DatabaseState {
-            node: LocalNode::new(env),
+            node,
+            catalog_object_id,
             tables: RwLock::new(HashMap::new()),
             schemas: RwLock::new(HashMap::new()),
             table_rows_objects: RwLock::new(HashMap::new()),
+            descriptor_objects: RwLock::new(HashMap::new()),
             row_table: RwLock::new(HashMap::new()),
             index_objects: RwLock::new(HashMap::new()),
             policies: RwLock::new(HashMap::new()),
@@ -402,11 +425,29 @@ impl DatabaseState {
     }
 
     fn in_memory() -> Self {
+        let node = LocalNode::in_memory();
+
+        // Create catalog object
+        let catalog_object_id = node.create_object("catalog");
+
+        // Initialize empty catalog
+        let empty_catalog = Catalog::new();
+        node.write(
+            catalog_object_id,
+            "main",
+            &empty_catalog.to_bytes(),
+            "system",
+            timestamp_now(),
+        )
+        .expect("failed to initialize catalog");
+
         DatabaseState {
-            node: LocalNode::in_memory(),
+            node,
+            catalog_object_id,
             tables: RwLock::new(HashMap::new()),
             schemas: RwLock::new(HashMap::new()),
             table_rows_objects: RwLock::new(HashMap::new()),
+            descriptor_objects: RwLock::new(HashMap::new()),
             row_table: RwLock::new(HashMap::new()),
             index_objects: RwLock::new(HashMap::new()),
             policies: RwLock::new(HashMap::new()),
@@ -1277,6 +1318,117 @@ impl Database {
         }
     }
 
+    /// Restore database from an existing environment with a known catalog object ID.
+    ///
+    /// This method loads the catalog and all table descriptors from the environment,
+    /// restoring the database to its previous state.
+    pub fn from_env(env: Arc<dyn Environment>, catalog_object_id: ObjectId) -> Result<Self, DatabaseError> {
+        let node = LocalNode::new(env);
+
+        // Load catalog object from Environment
+        node.load_object(catalog_object_id, "catalog", "main")
+            .ok_or_else(|| DatabaseError::Storage("catalog not found in environment".to_string()))?;
+
+        // Read catalog content
+        let catalog_bytes = node
+            .read(catalog_object_id, "main")
+            .map_err(|e| DatabaseError::Storage(format!("{:?}", e)))?
+            .ok_or_else(|| DatabaseError::Storage("catalog content not found".to_string()))?;
+
+        let catalog = Catalog::from_bytes(&catalog_bytes)
+            .map_err(|e| DatabaseError::Storage(format!("catalog parse error: {}", e)))?;
+
+        // Initialize state maps
+        let mut tables = HashMap::new();
+        let mut schemas = HashMap::new();
+        let mut table_rows_objects = HashMap::new();
+        let mut descriptor_objects = HashMap::new();
+        let mut row_table = HashMap::new();
+        let mut index_objects = HashMap::new();
+        let mut policies = HashMap::new();
+
+        // Restore each table from its descriptor
+        for (table_name, descriptor_id) in &catalog.tables {
+            // Load descriptor object from Environment
+            node.load_object(*descriptor_id, format!("descriptor:{}", table_name), "main")
+                .ok_or_else(|| {
+                    DatabaseError::Storage(format!("descriptor for {} not found in env", table_name))
+                })?;
+
+            // Read descriptor content
+            let descriptor_bytes = node
+                .read(*descriptor_id, "main")
+                .map_err(|e| DatabaseError::Storage(format!("{:?}", e)))?
+                .ok_or_else(|| {
+                    DatabaseError::Storage(format!("descriptor for {} not found", table_name))
+                })?;
+
+            let descriptor = TableDescriptor::from_bytes(&descriptor_bytes)
+                .map_err(|e| DatabaseError::Storage(format!("descriptor parse error: {}", e)))?;
+
+            // Load schema object
+            node.load_object(descriptor.schema_object_id, format!("schema:{}", table_name), "main");
+
+            // Load rows object
+            node.load_object(descriptor.rows_object_id, format!("rows:{}", table_name), "main");
+
+            // Load index objects
+            for (col_name, index_id) in &descriptor.index_object_ids {
+                node.load_object(*index_id, format!("index:{}:{}", table_name, col_name), "main");
+                let key = IndexKey::new(table_name, col_name);
+                index_objects.insert(key, *index_id);
+            }
+
+            // Restore table metadata
+            tables.insert(table_name.clone(), descriptor.schema_object_id);
+            schemas.insert(descriptor.schema_object_id, descriptor.schema.clone());
+            table_rows_objects.insert(table_name.clone(), descriptor.rows_object_id);
+            descriptor_objects.insert(table_name.clone(), *descriptor_id);
+
+            // Restore policies
+            if !descriptor.policies.is_empty() {
+                policies.insert(table_name.clone(), descriptor.policies.clone());
+            }
+
+            // Restore row_table mapping by reading table_rows
+            let rows_bytes = node
+                .read(descriptor.rows_object_id, "main")
+                .map_err(|e| DatabaseError::Storage(format!("{:?}", e)))?;
+
+            if let Some(bytes) = rows_bytes {
+                let table_rows = TableRows::from_bytes(&bytes)
+                    .map_err(|e| DatabaseError::Storage(format!("table_rows parse error: {}", e)))?;
+                for row_id in table_rows.iter() {
+                    // Load row object
+                    node.load_object(row_id, format!("row:{}:{}", table_name, row_id), "main");
+                    row_table.insert(row_id, table_name.clone());
+                }
+            }
+        }
+
+        let state = DatabaseState {
+            node,
+            catalog_object_id,
+            tables: RwLock::new(tables),
+            schemas: RwLock::new(schemas),
+            table_rows_objects: RwLock::new(table_rows_objects),
+            descriptor_objects: RwLock::new(descriptor_objects),
+            row_table: RwLock::new(row_table),
+            index_objects: RwLock::new(index_objects),
+            policies: RwLock::new(policies),
+            graph_registry: GraphRegistry::new(),
+        };
+
+        Ok(Database {
+            state: Arc::new(state),
+        })
+    }
+
+    /// Get the catalog object ID (for use with from_env).
+    pub fn catalog_object_id(&self) -> ObjectId {
+        self.state.catalog_object_id
+    }
+
     /// Get the underlying LocalNode.
     pub fn node(&self) -> &LocalNode {
         &self.state.node
@@ -1448,6 +1600,7 @@ impl Database {
             .insert(schema.name.clone(), rows_id);
 
         // Create index objects for Ref columns
+        let mut index_object_ids: HashMap<String, ObjectId> = HashMap::new();
         for col in &schema.columns {
             if matches!(col.ty, ColumnType::Ref(_)) {
                 let key = IndexKey::new(&schema.name, &col.name);
@@ -1469,6 +1622,8 @@ impl Database {
                     )
                     .map_err(|e| DatabaseError::Storage(format!("{:?}", e)))?;
 
+                index_object_ids.insert(col.name.clone(), index_id);
+
                 self.state
                     .index_objects
                     .write()
@@ -1476,6 +1631,39 @@ impl Database {
                     .insert(key, index_id);
             }
         }
+
+        // Create table descriptor object
+        let descriptor_id = self
+            .state
+            .node
+            .create_object(&format!("descriptor:{}", schema.name));
+
+        let descriptor = TableDescriptor {
+            schema: schema.clone(),
+            policies: TablePolicies::default(),
+            rows_object_id: rows_id,
+            schema_object_id: schema_id,
+            index_object_ids,
+        };
+        self.state
+            .node
+            .write(
+                descriptor_id,
+                "main",
+                &descriptor.to_bytes(),
+                "system",
+                timestamp_now(),
+            )
+            .map_err(|e| DatabaseError::Storage(format!("{:?}", e)))?;
+
+        self.state
+            .descriptor_objects
+            .write()
+            .unwrap()
+            .insert(schema.name.clone(), descriptor_id);
+
+        // Update catalog with the new table
+        self.update_catalog_add_table(&schema.name, descriptor_id)?;
 
         // Cache schema
         self.state
@@ -1490,6 +1678,41 @@ impl Database {
             .insert(schema_id, schema);
 
         Ok(schema_id)
+    }
+
+    /// Update the catalog to add a new table.
+    fn update_catalog_add_table(
+        &self,
+        table_name: &str,
+        descriptor_id: ObjectId,
+    ) -> Result<(), DatabaseError> {
+        // Read current catalog
+        let catalog_bytes = self
+            .state
+            .node
+            .read(self.state.catalog_object_id, "main")
+            .map_err(|e| DatabaseError::Storage(format!("{:?}", e)))?
+            .ok_or_else(|| DatabaseError::Storage("catalog not found".to_string()))?;
+
+        let mut catalog = Catalog::from_bytes(&catalog_bytes)
+            .map_err(|e| DatabaseError::Storage(format!("catalog parse error: {}", e)))?;
+
+        // Add the new table
+        catalog.tables.insert(table_name.to_string(), descriptor_id);
+
+        // Write updated catalog
+        self.state
+            .node
+            .write(
+                self.state.catalog_object_id,
+                "main",
+                &catalog.to_bytes(),
+                "system",
+                timestamp_now(),
+            )
+            .map_err(|e| DatabaseError::Storage(format!("{:?}", e)))?;
+
+        Ok(())
     }
 
     /// Get table schema by name.
@@ -1507,21 +1730,74 @@ impl Database {
 
     /// Create a policy for a table.
     pub fn create_policy(&self, policy: Policy) -> Result<(), DatabaseError> {
+        let table_name = policy.table.clone();
+
         // Verify table exists
         {
             let tables = self.state.tables.read().unwrap();
-            if !tables.contains_key(&policy.table) {
-                return Err(DatabaseError::TableNotFound(policy.table.clone()));
+            if !tables.contains_key(&table_name) {
+                return Err(DatabaseError::TableNotFound(table_name.clone()));
             }
         }
 
         // Add policy to table's policy collection
-        let mut policies = self.state.policies.write().unwrap();
-        let table_policies = policies
-            .entry(policy.table.clone())
-            .or_insert_with(TablePolicies::new);
+        {
+            let mut policies = self.state.policies.write().unwrap();
+            let table_policies = policies
+                .entry(table_name.clone())
+                .or_insert_with(TablePolicies::new);
 
-        table_policies.add(policy)?;
+            table_policies.add(policy)?;
+        }
+
+        // Update the table descriptor to persist the policy
+        self.update_table_descriptor_policies(&table_name)?;
+
+        Ok(())
+    }
+
+    /// Update the table descriptor with current policies.
+    fn update_table_descriptor_policies(&self, table_name: &str) -> Result<(), DatabaseError> {
+        // Get descriptor object ID
+        let descriptor_id = self
+            .state
+            .descriptor_objects
+            .read()
+            .unwrap()
+            .get(table_name)
+            .copied()
+            .ok_or_else(|| DatabaseError::TableNotFound(table_name.to_string()))?;
+
+        // Read current descriptor
+        let descriptor_bytes = self
+            .state
+            .node
+            .read(descriptor_id, "main")
+            .map_err(|e| DatabaseError::Storage(format!("{:?}", e)))?
+            .ok_or_else(|| DatabaseError::Storage("descriptor not found".to_string()))?;
+
+        let mut descriptor = TableDescriptor::from_bytes(&descriptor_bytes)
+            .map_err(|e| DatabaseError::Storage(format!("descriptor parse error: {}", e)))?;
+
+        // Update policies from current in-memory state
+        let policies = self.state.policies.read().unwrap();
+        descriptor.policies = policies
+            .get(table_name)
+            .cloned()
+            .unwrap_or_default();
+
+        // Write updated descriptor
+        self.state
+            .node
+            .write(
+                descriptor_id,
+                "main",
+                &descriptor.to_bytes(),
+                "system",
+                timestamp_now(),
+            )
+            .map_err(|e| DatabaseError::Storage(format!("{:?}", e)))?;
+
         Ok(())
     }
 

--- a/groove/src/sql/mod.rs
+++ b/groove/src/sql/mod.rs
@@ -1,4 +1,5 @@
 mod binary;
+mod catalog;
 mod database;
 mod index;
 mod parser;
@@ -13,6 +14,7 @@ pub use binary::{
     encode_delta, encode_delta_batch, encode_rows, encode_single_row, DELTA_ADDED, DELTA_REMOVED,
     DELTA_UPDATED,
 };
+pub use catalog::{Catalog, CatalogError, TableDescriptor};
 pub use database::{Database, DatabaseError, DatabaseState, ExecuteResult, IncrementalQuery};
 pub use index::RefIndex;
 pub use parser::{

--- a/groove/src/sql/parser.rs
+++ b/groove/src/sql/parser.rs
@@ -401,6 +401,20 @@ impl<'a> Parser<'a> {
         if self.try_keyword("BYTES") {
             return Ok(ColumnType::Bytes);
         }
+        if self.try_keyword("BLOB") {
+            // Check for array suffix []
+            self.skip_whitespace();
+            if self.peek_char() == Some('[') {
+                self.consume_char();
+                self.skip_whitespace();
+                if self.peek_char() != Some(']') {
+                    return Err(self.error("expected ']' after '[' in BLOB[]"));
+                }
+                self.consume_char();
+                return Ok(ColumnType::BlobArray);
+            }
+            return Ok(ColumnType::Blob);
+        }
         if self.try_keyword("REFERENCES") {
             let target = self.parse_identifier()?;
             return Ok(ColumnType::Ref(target));

--- a/groove/src/sql/policy.rs
+++ b/groove/src/sql/policy.rs
@@ -501,9 +501,9 @@ fn serialize_literal(buf: &mut Vec<u8>, val: &Value) {
         }
         // NullableSome: serialize the inner value
         Value::NullableSome(inner) => serialize_literal(buf, inner),
-        // Row and Array are not valid in policy literals - they're only for query results
-        Value::Row(_) | Value::Array(_) => {
-            panic!("Row and Array values cannot be used in policy literals");
+        // Row, Array, Blob, BlobArray are not valid in policy literals - they're only for query results
+        Value::Row(_) | Value::Array(_) | Value::Blob(_) | Value::BlobArray(_) => {
+            panic!("Row, Array, Blob, and BlobArray values cannot be used in policy literals");
         }
     }
 }

--- a/groove/src/sql/query_graph/predicate.rs
+++ b/groove/src/sql/query_graph/predicate.rs
@@ -19,6 +19,14 @@ fn value_to_display(value: &Value) -> String {
         Value::NullableSome(inner) => value_to_display(inner),
         Value::Array(arr) => format!("[{} items]", arr.len()),
         Value::Row(row) => format!("<Row {}>", row.id),
+        Value::Blob(content_ref) => {
+            if content_ref.is_inline() {
+                format!("<Blob inline>")
+            } else {
+                format!("<Blob chunked>")
+            }
+        }
+        Value::BlobArray(refs) => format!("<{} blobs>", refs.len()),
     }
 }
 

--- a/groove/src/sql/row.rs
+++ b/groove/src/sql/row.rs
@@ -1,5 +1,6 @@
 use crate::object::ObjectId;
 use crate::sql::schema::{ColumnType, TableSchema};
+use crate::storage::ContentRef;
 
 /// Runtime value representation.
 #[derive(Debug, Clone, PartialEq)]
@@ -24,6 +25,12 @@ pub enum Value {
     /// A nullable column that is null.
     /// The encoder writes presence byte 0.
     NullableNone,
+    /// Large binary data, potentially chunked via ContentRef.
+    /// Unlike Bytes (always inline), Blob can be large and is stored as
+    /// either inline bytes or a list of chunk hashes.
+    Blob(ContentRef),
+    /// Array of blobs.
+    BlobArray(Vec<ContentRef>),
 }
 
 impl Value {
@@ -129,6 +136,22 @@ impl Value {
     pub fn as_array(&self) -> Option<&[Value]> {
         match self {
             Value::Array(arr) => Some(arr),
+            _ => None,
+        }
+    }
+
+    /// Try to get as blob.
+    pub fn as_blob(&self) -> Option<&ContentRef> {
+        match self {
+            Value::Blob(content_ref) => Some(content_ref),
+            _ => None,
+        }
+    }
+
+    /// Try to get as blob array.
+    pub fn as_blob_array(&self) -> Option<&[ContentRef]> {
+        match self {
+            Value::BlobArray(refs) => Some(refs),
             _ => None,
         }
     }
@@ -299,6 +322,18 @@ fn encode_column_value(
         (Value::Ref(id), ColumnType::Ref(_)) => {
             buf.extend_from_slice(&id.0.to_le_bytes());
         }
+        (Value::Blob(content_ref), ColumnType::Blob) => {
+            buf.extend_from_slice(&content_ref.to_row_bytes());
+        }
+        (Value::BlobArray(refs), ColumnType::BlobArray) => {
+            // Count of blobs
+            encode_varint(refs.len(), &mut buf);
+            // Each blob's serialized ContentRef
+            for content_ref in refs {
+                let blob_bytes = content_ref.to_row_bytes();
+                buf.extend_from_slice(&blob_bytes);
+            }
+        }
         _ => {
             return Err(RowError::TypeMismatch {
                 expected: format!("{:?}", ty),
@@ -449,6 +484,26 @@ fn decode_variable_column(data: &[u8], ty: &ColumnType, nullable: bool) -> Resul
             Value::String(s.to_string())
         }
         ColumnType::Bytes => Value::Bytes(data[pos..].to_vec()),
+        ColumnType::Blob => {
+            let (content_ref, _consumed) = ContentRef::from_row_bytes(&data[pos..])
+                .map_err(|e| RowError::BlobDecodeError(e.to_string()))?;
+            Value::Blob(content_ref)
+        }
+        ColumnType::BlobArray => {
+            // Decode count
+            let (count, consumed) = decode_varint(&data[pos..])?;
+            pos += consumed;
+
+            // Decode each blob
+            let mut refs = Vec::with_capacity(count);
+            for _ in 0..count {
+                let (content_ref, consumed) = ContentRef::from_row_bytes(&data[pos..])
+                    .map_err(|e| RowError::BlobDecodeError(e.to_string()))?;
+                refs.push(content_ref);
+                pos += consumed;
+            }
+            Value::BlobArray(refs)
+        }
         _ => {
             return Err(RowError::TypeMismatch {
                 expected: "variable-size type".into(),
@@ -474,6 +529,7 @@ pub enum RowError {
     ColumnCountMismatch { expected: usize, got: usize },
     NullInNonNullable { column: String },
     TypeMismatch { expected: String, got: String },
+    BlobDecodeError(String),
 }
 
 impl std::fmt::Display for RowError {
@@ -494,6 +550,9 @@ impl std::fmt::Display for RowError {
             }
             RowError::TypeMismatch { expected, got } => {
                 write!(f, "type mismatch: expected {}, got {}", expected, got)
+            }
+            RowError::BlobDecodeError(msg) => {
+                write!(f, "blob decode error: {}", msg)
             }
         }
     }

--- a/groove/src/sql/schema.rs
+++ b/groove/src/sql/schema.rs
@@ -17,6 +17,12 @@ pub enum ColumnType {
     Bytes,
     /// Reference to another table: 16 bytes (u128 object ID)
     Ref(String),
+    /// Large binary data, potentially chunked via ContentRef.
+    /// Unlike Bytes (always inline), Blob can be large and is stored as
+    /// either inline bytes or a list of chunk hashes.
+    Blob,
+    /// Array of blobs.
+    BlobArray,
 }
 
 impl ColumnType {
@@ -41,7 +47,9 @@ impl ColumnType {
             ColumnType::I64 => Some(8),
             ColumnType::F64 => Some(8),
             ColumnType::Ref(_) => Some(16),
-            ColumnType::String | ColumnType::Bytes => None,
+            ColumnType::String | ColumnType::Bytes | ColumnType::Blob | ColumnType::BlobArray => {
+                None
+            }
         }
     }
 }
@@ -183,6 +191,8 @@ impl TableSchema {
                 ColumnType::Ref(_) => 5,
                 ColumnType::I32 => 6,
                 ColumnType::U32 => 7,
+                ColumnType::Blob => 8,
+                ColumnType::BlobArray => 9,
             };
             buf.push(type_tag);
 
@@ -277,6 +287,8 @@ impl TableSchema {
                 }
                 6 => ColumnType::I32,
                 7 => ColumnType::U32,
+                8 => ColumnType::Blob,
+                9 => ColumnType::BlobArray,
                 _ => return Err(SchemaError::InvalidTypeTag(type_tag)),
             };
 

--- a/groove/src/storage.rs
+++ b/groove/src/storage.rs
@@ -197,15 +197,15 @@ fn decode_varint(data: &[u8]) -> Result<(usize, usize), ContentRefError> {
     Err(ContentRefError::UnexpectedEof)
 }
 
-/// Metadata about a commit (without content).
+/// Metadata about a commit (without full content bytes).
 #[derive(Debug, Clone)]
 pub struct CommitMeta {
     pub id: CommitId,
     pub parents: Vec<CommitId>,
     pub author: String,
     pub timestamp: u64,
-    /// Whether content is inline or chunked.
-    pub content_ref: ContentRef,
+    /// Size of the commit content in bytes.
+    pub content_size: usize,
 }
 
 /// Storage interface for content chunks.
@@ -309,7 +309,7 @@ impl CommitStore for MemoryEnvironment {
             parents: c.parents.clone(),
             author: c.author.clone(),
             timestamp: c.timestamp,
-            content_ref: c.content.clone(),
+            content_size: c.content.len(),
         })
     }
 

--- a/groove/src/storage.rs
+++ b/groove/src/storage.rs
@@ -210,7 +210,7 @@ pub struct CommitMeta {
 
 /// Storage interface for content chunks.
 #[async_trait]
-pub trait ContentStore: Send + Sync {
+pub trait ChunkStore: Send + Sync {
     /// Get chunk by hash, returns None if not found.
     async fn get_chunk(&self, hash: &ChunkHash) -> Option<Bytes>;
 
@@ -247,35 +247,43 @@ pub trait CommitStore: Send + Sync {
 
     /// Stream commit IDs for an object's branch (for partial loading).
     fn list_commits(&self, object_id: u128, branch: &str) -> BoxStream<'_, CommitId>;
+
+    /// List all object IDs that have data in this store.
+    fn list_objects(&self) -> BoxStream<'_, u128>;
+
+    /// List all branch names for an object.
+    async fn list_branches(&self, object_id: u128) -> Vec<String>;
 }
 
 /// Combined storage interface (legacy alias).
 #[async_trait]
-pub trait Storage: ContentStore + CommitStore {}
+pub trait Storage: ChunkStore + CommitStore {}
 
 // Blanket impl
-impl<T: ContentStore + CommitStore> Storage for T {}
+impl<T: ChunkStore + CommitStore> Storage for T {}
 
 /// Environment trait - combines all storage capabilities.
 /// This is the main trait that LocalNode uses for storage.
-pub trait Environment: ContentStore + CommitStore + Send + Sync + std::fmt::Debug {}
+pub trait Environment: ChunkStore + CommitStore + Send + Sync + std::fmt::Debug {}
 
 // Blanket impl for Environment
-impl<T: ContentStore + CommitStore + Send + Sync + std::fmt::Debug> Environment for T {}
+impl<T: ChunkStore + CommitStore + Send + Sync + std::fmt::Debug> Environment for T {}
 
 // ========== In-Memory Environment for Testing ==========
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::RwLock;
 
 /// In-memory environment for testing.
-/// Implements both ContentStore and CommitStore.
+/// Implements both ChunkStore and CommitStore.
 #[derive(Debug, Default)]
 pub struct MemoryEnvironment {
     chunks: RwLock<HashMap<ChunkHash, Bytes>>,
     commits: RwLock<HashMap<CommitId, crate::commit::Commit>>,
     frontiers: RwLock<HashMap<(u128, String), Vec<CommitId>>>,
     truncations: RwLock<HashMap<(u128, String), CommitId>>,
+    /// Track which objects exist (object IDs that have at least one branch).
+    objects: RwLock<HashSet<u128>>,
 }
 
 impl MemoryEnvironment {
@@ -285,7 +293,7 @@ impl MemoryEnvironment {
 }
 
 #[async_trait]
-impl ContentStore for MemoryEnvironment {
+impl ChunkStore for MemoryEnvironment {
     async fn get_chunk(&self, hash: &ChunkHash) -> Option<Bytes> {
         self.chunks.read().unwrap().get(hash).cloned()
     }
@@ -337,6 +345,8 @@ impl CommitStore for MemoryEnvironment {
             .write()
             .unwrap()
             .insert((object_id, branch.to_string()), frontier.to_vec());
+        // Track that this object exists
+        self.objects.write().unwrap().insert(object_id);
     }
 
     async fn get_truncation(&self, object_id: u128, branch: &str) -> Option<CommitId> {
@@ -393,6 +403,26 @@ impl CommitStore for MemoryEnvironment {
 
         Box::pin(futures::stream::iter(all_commits))
     }
+
+    fn list_objects(&self) -> BoxStream<'_, u128> {
+        let objects: Vec<u128> = self.objects.read().unwrap().iter().copied().collect();
+        Box::pin(futures::stream::iter(objects))
+    }
+
+    async fn list_branches(&self, object_id: u128) -> Vec<String> {
+        self.frontiers
+            .read()
+            .unwrap()
+            .keys()
+            .filter_map(|(oid, branch)| {
+                if *oid == object_id {
+                    Some(branch.clone())
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
 }
 
 /// Simple in-memory content store (legacy, for backwards compatibility).
@@ -408,7 +438,7 @@ impl MemoryContentStore {
 }
 
 #[async_trait]
-impl ContentStore for MemoryContentStore {
+impl ChunkStore for MemoryContentStore {
     async fn get_chunk(&self, hash: &ChunkHash) -> Option<Bytes> {
         self.chunks.read().unwrap().get(hash).cloned()
     }

--- a/groove/src/storage.rs
+++ b/groove/src/storage.rs
@@ -30,7 +30,7 @@ impl ChunkHash {
 }
 
 /// Reference to commit content - either inline or chunked.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum ContentRef {
     /// Small content stored directly in the commit.
     Inline(Box<[u8]>),
@@ -70,6 +70,131 @@ impl ContentRef {
             ContentRef::Chunked(hashes) => Some(hashes),
         }
     }
+
+    /// Serialize ContentRef for embedding in row data.
+    ///
+    /// Format:
+    /// - Inline:  0x00 + varint(length) + bytes
+    /// - Chunked: 0x01 + varint(chunk_count) + [32-byte ChunkHash]*count
+    pub fn to_row_bytes(&self) -> Vec<u8> {
+        let mut buf = Vec::new();
+        match self {
+            ContentRef::Inline(data) => {
+                buf.push(0x00); // Tag: inline
+                encode_varint(data.len(), &mut buf);
+                buf.extend_from_slice(data);
+            }
+            ContentRef::Chunked(hashes) => {
+                buf.push(0x01); // Tag: chunked
+                encode_varint(hashes.len(), &mut buf);
+                for hash in hashes {
+                    buf.extend_from_slice(hash.as_bytes());
+                }
+            }
+        }
+        buf
+    }
+
+    /// Deserialize ContentRef from row data.
+    ///
+    /// Returns the ContentRef and the number of bytes consumed.
+    pub fn from_row_bytes(data: &[u8]) -> Result<(Self, usize), ContentRefError> {
+        if data.is_empty() {
+            return Err(ContentRefError::UnexpectedEof);
+        }
+
+        let tag = data[0];
+        let mut pos = 1;
+
+        match tag {
+            0x00 => {
+                // Inline
+                let (len, consumed) = decode_varint(&data[pos..])?;
+                pos += consumed;
+
+                if data.len() < pos + len {
+                    return Err(ContentRefError::UnexpectedEof);
+                }
+                let content = data[pos..pos + len].to_vec().into_boxed_slice();
+                pos += len;
+
+                Ok((ContentRef::Inline(content), pos))
+            }
+            0x01 => {
+                // Chunked
+                let (count, consumed) = decode_varint(&data[pos..])?;
+                pos += consumed;
+
+                let mut hashes = Vec::with_capacity(count);
+                for _ in 0..count {
+                    if data.len() < pos + 32 {
+                        return Err(ContentRefError::UnexpectedEof);
+                    }
+                    let mut hash_bytes = [0u8; 32];
+                    hash_bytes.copy_from_slice(&data[pos..pos + 32]);
+                    hashes.push(ChunkHash::from_bytes(hash_bytes));
+                    pos += 32;
+                }
+
+                Ok((ContentRef::Chunked(hashes), pos))
+            }
+            _ => Err(ContentRefError::InvalidTag(tag)),
+        }
+    }
+}
+
+/// Errors during ContentRef deserialization.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ContentRefError {
+    UnexpectedEof,
+    VarintOverflow,
+    InvalidTag(u8),
+}
+
+impl std::fmt::Display for ContentRefError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ContentRefError::UnexpectedEof => write!(f, "unexpected end of ContentRef data"),
+            ContentRefError::VarintOverflow => write!(f, "varint overflow"),
+            ContentRefError::InvalidTag(tag) => write!(f, "invalid ContentRef tag: {}", tag),
+        }
+    }
+}
+
+impl std::error::Error for ContentRefError {}
+
+/// Encode a varint (LEB128 unsigned).
+fn encode_varint(mut value: usize, buf: &mut Vec<u8>) {
+    loop {
+        let mut byte = (value & 0x7f) as u8;
+        value >>= 7;
+        if value != 0 {
+            byte |= 0x80;
+        }
+        buf.push(byte);
+        if value == 0 {
+            break;
+        }
+    }
+}
+
+/// Decode a varint (LEB128 unsigned). Returns (value, bytes_consumed).
+fn decode_varint(data: &[u8]) -> Result<(usize, usize), ContentRefError> {
+    let mut result: usize = 0;
+    let mut shift = 0;
+
+    for (i, &byte) in data.iter().enumerate() {
+        result |= ((byte & 0x7f) as usize) << shift;
+        if byte & 0x80 == 0 {
+            return Ok((result, i + 1));
+        }
+        shift += 7;
+        if shift >= 64 {
+            return Err(ContentRefError::VarintOverflow);
+        }
+    }
+
+    Err(ContentRefError::UnexpectedEof)
 }
 
 /// Metadata about a commit (without content).

--- a/groove/tests/branch.rs
+++ b/groove/tests/branch.rs
@@ -1,11 +1,11 @@
 //! Integration tests for Branch.
 
-use groove::{Branch, BranchError, Commit, CommitId, ContentRef};
+use groove::{Branch, BranchError, Commit, CommitId};
 
 fn make_commit(content: &[u8], parents: Vec<CommitId>) -> Commit {
     Commit {
         parents,
-        content: ContentRef::inline(content.to_vec()),
+        content: content.to_vec().into_boxed_slice(),
         author: "test-author".to_string(),
         timestamp: 1000,
         meta: None,
@@ -57,7 +57,7 @@ fn branch_concurrent_commits_need_merge() {
     // Two concurrent commits from root
     let c1 = Commit {
         parents: vec![root_id],
-        content: ContentRef::inline(b"branch-a".to_vec()),
+        content: b"branch-a".to_vec().into_boxed_slice(),
         author: "alice".to_string(),
         timestamp: 2000,
         meta: None,
@@ -66,7 +66,7 @@ fn branch_concurrent_commits_need_merge() {
 
     let c2 = Commit {
         parents: vec![root_id],
-        content: ContentRef::inline(b"branch-b".to_vec()),
+        content: b"branch-b".to_vec().into_boxed_slice(),
         author: "bob".to_string(),
         timestamp: 2001,
         meta: None,
@@ -90,7 +90,7 @@ fn branch_merge_commit() {
     // Two concurrent branches
     let c1 = Commit {
         parents: vec![root_id],
-        content: ContentRef::inline(b"a".to_vec()),
+        content: b"a".to_vec().into_boxed_slice(),
         author: "alice".to_string(),
         timestamp: 2000,
         meta: None,
@@ -99,7 +99,7 @@ fn branch_merge_commit() {
 
     let c2 = Commit {
         parents: vec![root_id],
-        content: ContentRef::inline(b"b".to_vec()),
+        content: b"b".to_vec().into_boxed_slice(),
         author: "bob".to_string(),
         timestamp: 2001,
         meta: None,
@@ -111,7 +111,7 @@ fn branch_merge_commit() {
     // Merge commit
     let merge = Commit {
         parents: vec![id1, id2],
-        content: ContentRef::inline(b"merged".to_vec()),
+        content: b"merged".to_vec().into_boxed_slice(),
         author: "alice".to_string(),
         timestamp: 3000,
         meta: None,
@@ -169,7 +169,7 @@ fn find_lca_diamond() {
 
     let c2 = Commit {
         parents: vec![id1],
-        content: ContentRef::inline(b"left".to_vec()),
+        content: b"left".to_vec().into_boxed_slice(),
         author: "alice".to_string(),
         timestamp: 2000,
         meta: None,
@@ -178,7 +178,7 @@ fn find_lca_diamond() {
 
     let c3 = Commit {
         parents: vec![id1],
-        content: ContentRef::inline(b"right".to_vec()),
+        content: b"right".to_vec().into_boxed_slice(),
         author: "bob".to_string(),
         timestamp: 2001,
         meta: None,
@@ -192,7 +192,7 @@ fn find_lca_diamond() {
     // Now merge them
     let c4 = Commit {
         parents: vec![id2, id3],
-        content: ContentRef::inline(b"merged".to_vec()),
+        content: b"merged".to_vec().into_boxed_slice(),
         author: "alice".to_string(),
         timestamp: 3000,
         meta: None,
@@ -271,7 +271,7 @@ fn truncate_rejects_non_ancestor_of_frontier() {
 
     let c1 = Commit {
         parents: vec![root_id],
-        content: ContentRef::inline(b"branch-a".to_vec()),
+        content: b"branch-a".to_vec().into_boxed_slice(),
         author: "alice".to_string(),
         timestamp: 2000,
         meta: None,
@@ -280,7 +280,7 @@ fn truncate_rejects_non_ancestor_of_frontier() {
 
     let c2 = Commit {
         parents: vec![root_id],
-        content: ContentRef::inline(b"branch-b".to_vec()),
+        content: b"branch-b".to_vec().into_boxed_slice(),
         author: "bob".to_string(),
         timestamp: 2001,
         meta: None,
@@ -437,7 +437,7 @@ fn find_frontier_lca() {
     // Two divergent branches: LCA is the common ancestor
     let c2 = Commit {
         parents: vec![id1],
-        content: ContentRef::inline(b"branch-a".to_vec()),
+        content: b"branch-a".to_vec().into_boxed_slice(),
         author: "alice".to_string(),
         timestamp: 2000,
         meta: None,
@@ -446,7 +446,7 @@ fn find_frontier_lca() {
 
     let c3 = Commit {
         parents: vec![id1],
-        content: ContentRef::inline(b"branch-b".to_vec()),
+        content: b"branch-b".to_vec().into_boxed_slice(),
         author: "bob".to_string(),
         timestamp: 2001,
         meta: None,

--- a/groove/tests/commit.rs
+++ b/groove/tests/commit.rs
@@ -1,11 +1,11 @@
 //! Integration tests for Commit.
 
-use groove::{ChunkHash, Commit, CommitId, ContentRef};
+use groove::{Commit, CommitId};
 
 fn make_commit(content: &[u8], parents: Vec<CommitId>) -> Commit {
     Commit {
         parents,
-        content: ContentRef::inline(content.to_vec()),
+        content: content.to_vec().into_boxed_slice(),
         author: "test-author".to_string(),
         timestamp: 1000,
         meta: None,
@@ -29,26 +29,43 @@ fn different_content_different_id() {
 }
 
 #[test]
-fn inline_vs_chunked_different_id() {
-    let data = b"hello";
-    let commit_inline = Commit {
+fn different_author_different_id() {
+    let commit1 = Commit {
         parents: vec![],
-        content: ContentRef::inline(data.to_vec()),
+        content: b"hello".to_vec().into_boxed_slice(),
+        author: "alice".to_string(),
+        timestamp: 1000,
+        meta: None,
+    };
+
+    let commit2 = Commit {
+        parents: vec![],
+        content: b"hello".to_vec().into_boxed_slice(),
+        author: "bob".to_string(),
+        timestamp: 1000,
+        meta: None,
+    };
+
+    assert_ne!(commit1.compute_id(), commit2.compute_id());
+}
+
+#[test]
+fn different_timestamp_different_id() {
+    let commit1 = Commit {
+        parents: vec![],
+        content: b"hello".to_vec().into_boxed_slice(),
         author: "test".to_string(),
         timestamp: 1000,
         meta: None,
     };
 
-    // Same content but as a single "chunk"
-    let chunk_hash = ChunkHash::compute(data);
-    let commit_chunked = Commit {
+    let commit2 = Commit {
         parents: vec![],
-        content: ContentRef::chunked(vec![chunk_hash]),
+        content: b"hello".to_vec().into_boxed_slice(),
         author: "test".to_string(),
-        timestamp: 1000,
+        timestamp: 2000,
         meta: None,
     };
 
-    // These should have different IDs because the storage format differs
-    assert_ne!(commit_inline.compute_id(), commit_chunked.compute_id());
+    assert_ne!(commit1.compute_id(), commit2.compute_id());
 }

--- a/groove/tests/listener.rs
+++ b/groove/tests/listener.rs
@@ -1,6 +1,6 @@
 //! Integration tests for ObjectListenerRegistry.
 
-use groove::{Branch, Commit, ContentRef, Environment, MemoryEnvironment, ObjectKey, ObjectListenerRegistry, ObjectState, ObjectId};
+use groove::{Branch, Commit, Environment, MemoryEnvironment, ObjectKey, ObjectListenerRegistry, ObjectState, ObjectId};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, RwLock};
 
@@ -12,7 +12,7 @@ fn make_branch_with_commit(content: &[u8]) -> (Arc<RwLock<Branch>>, groove::Comm
     let mut branch = Branch::new("main");
     let commit = Commit {
         parents: vec![],
-        content: ContentRef::inline(content.to_vec()),
+        content: content.to_vec().into_boxed_slice(),
         author: "alice".to_string(),
         timestamp: 1000,
         meta: None,
@@ -117,7 +117,7 @@ fn state_tracks_previous_tips() {
         let mut b = branch.write().unwrap();
         let commit = Commit {
             parents: vec![id1],
-            content: ContentRef::inline(b"second".to_vec()),
+            content: b"second".to_vec().into_boxed_slice(),
             author: "alice".to_string(),
             timestamp: 2000,
             meta: None,
@@ -177,7 +177,7 @@ fn unsubscribe_removes_listener() {
         let mut b = branch.write().unwrap();
         b.add_commit(Commit {
             parents: vec![],
-            content: ContentRef::inline(b"world".to_vec()),
+            content: b"world".to_vec().into_boxed_slice(),
             author: "alice".to_string(),
             timestamp: 2000,
             meta: None,
@@ -203,7 +203,7 @@ fn diff_raw_detects_changes() {
         let mut b = branch.write().unwrap();
         b.add_commit(Commit {
             parents: vec![id1],
-            content: ContentRef::inline(b"hello".to_vec()),
+            content: b"hello".to_vec().into_boxed_slice(),
             author: "alice".to_string(),
             timestamp: 2000,
             meta: None,
@@ -219,7 +219,7 @@ fn diff_raw_detects_changes() {
         let mut b = branch.write().unwrap();
         b.add_commit(Commit {
             parents: vec![id2],
-            content: ContentRef::inline(b"world".to_vec()),
+            content: b"world".to_vec().into_boxed_slice(),
             author: "alice".to_string(),
             timestamp: 3000,
             meta: None,

--- a/groove/tests/node.rs
+++ b/groove/tests/node.rs
@@ -86,7 +86,7 @@ fn subscribe_nonexistent_branch_errors() {
 }
 
 #[test]
-fn write_sync_notifies_listener() {
+fn write_notifies_listener() {
     let node = LocalNode::in_memory();
     let id = node.create_object("test");
 
@@ -111,7 +111,7 @@ fn write_sync_notifies_listener() {
     assert_eq!(*tip_counts.read().unwrap(), vec![0]); // empty initially
 
     // Write through node (auto-notifies)
-    node.write_sync(id, "main", b"hello", "alice", 1000)
+    node.write(id, "main", b"hello", "alice", 1000)
         .unwrap();
 
     // Callback should be called synchronously
@@ -119,7 +119,7 @@ fn write_sync_notifies_listener() {
     assert_eq!(*tip_counts.read().unwrap(), vec![0, 1]); // now has 1 tip
 
     // Write again
-    node.write_sync(id, "main", b"world", "alice", 2000)
+    node.write(id, "main", b"world", "alice", 2000)
         .unwrap();
 
     assert_eq!(call_count.load(Ordering::SeqCst), 3);
@@ -133,7 +133,7 @@ fn write_without_subscriber() {
 
     // Write without subscribing - should not error
     let commit_id = node
-        .write_sync(id, "main", b"hello", "alice", 1000)
+        .write(id, "main", b"hello", "alice", 1000)
         .unwrap();
 
     // Now subscribe and verify content in callback
@@ -229,7 +229,7 @@ fn multiple_subscribers_all_notified() {
     assert_eq!(count2.load(Ordering::SeqCst), 1);
 
     // Write
-    node.write_sync(id, "main", b"hello", "alice", 1000)
+    node.write(id, "main", b"hello", "alice", 1000)
         .unwrap();
 
     // Both should be notified
@@ -242,10 +242,10 @@ fn read_write_roundtrip() {
     let node = LocalNode::in_memory();
     let id = node.create_object("test");
 
-    node.write_sync(id, "main", b"hello world", "alice", 1000)
+    node.write(id, "main", b"hello world", "alice", 1000)
         .unwrap();
 
-    let content = node.read_sync(id, "main").unwrap().unwrap();
+    let content = node.read(id, "main").unwrap().unwrap();
     assert_eq!(content, b"hello world");
 }
 
@@ -269,7 +269,7 @@ fn unsubscribe_stops_notifications() {
 
     assert_eq!(call_count.load(Ordering::SeqCst), 1); // initial
 
-    node.write_sync(id, "main", b"hello", "alice", 1000)
+    node.write(id, "main", b"hello", "alice", 1000)
         .unwrap();
     assert_eq!(call_count.load(Ordering::SeqCst), 2);
 
@@ -277,7 +277,7 @@ fn unsubscribe_stops_notifications() {
     assert!(node.unsubscribe(id, "main", listener_id));
 
     // Write again - should not notify
-    node.write_sync(id, "main", b"world", "alice", 2000)
+    node.write(id, "main", b"world", "alice", 2000)
         .unwrap();
     assert_eq!(call_count.load(Ordering::SeqCst), 2); // still 2
 }
@@ -304,10 +304,10 @@ fn callback_called_synchronously() {
 
     was_called.store(false, Ordering::SeqCst);
 
-    // Write - callback should be called SYNCHRONOUSLY (before write_sync returns)
-    node.write_sync(id, "main", b"test", "alice", 1000).unwrap();
+    // Write - callback should be called SYNCHRONOUSLY (before write returns)
+    node.write(id, "main", b"test", "alice", 1000).unwrap();
 
-    // This assertion happens IMMEDIATELY after write_sync returns
+    // This assertion happens IMMEDIATELY after write returns
     // If callback was async, this would fail
     assert!(
         was_called.load(Ordering::SeqCst),

--- a/groove/tests/object.rs
+++ b/groove/tests/object.rs
@@ -1,11 +1,6 @@
 //! Integration tests for Object.
 
-use bytes::Bytes;
-use futures::executor::block_on;
-use futures::io::AllowStdIo;
-use futures::stream::StreamExt;
 use groove::{Commit, CommitId, LastWriterWins, Object, ObjectId};
-use std::io::Cursor;
 
 fn make_commit(content: &[u8], parents: Vec<CommitId>) -> Commit {
     Commit {
@@ -116,7 +111,7 @@ fn merge_branches_simple() {
 }
 
 #[test]
-fn sync_write_and_read() {
+fn write_and_read() {
     let obj = Object::new(ObjectId::new(1), "test");
 
     // Write some content
@@ -142,161 +137,22 @@ fn sync_write_and_read() {
 }
 
 #[test]
-fn read_sync_empty_branch_returns_none() {
+fn read_empty_branch_returns_none() {
     let obj = Object::new(ObjectId::new(1), "test");
     assert!(obj.read_sync("main").is_none());
 }
 
 #[test]
-fn sync_write_large_content() {
+fn write_large_content() {
     let obj = Object::new(ObjectId::new(1), "test");
 
-    // Large content is now stored directly (no chunking at commit level)
+    // Large content is stored directly (no chunking at commit level)
     let large_content: Vec<u8> = (0..1024 * 1024).map(|i| (i % 256) as u8).collect();
     obj.write_sync("main", &large_content, "alice", 1000);
 
     // Should be readable
     let content = obj.read_sync("main").unwrap();
     assert_eq!(content, large_content);
-}
-
-#[test]
-fn async_write_content() {
-    let obj = Object::new(ObjectId::new(1), "test");
-
-    // Write content
-    block_on(async {
-        obj.write("main", b"hello", "alice", 1000).await;
-    });
-
-    // Read back
-    let content = obj.read_sync("main").unwrap();
-    assert_eq!(content, b"hello");
-}
-
-#[test]
-fn async_write_large_content() {
-    let obj = Object::new(ObjectId::new(1), "test");
-
-    // Large content stored directly
-    let large_content: Vec<u8> = (0..1024 * 1024 * 3).map(|i| (i % 256) as u8).collect();
-
-    block_on(async {
-        obj.write("main", &large_content, "alice", 1000).await;
-    });
-
-    // Should be readable via sync (no chunking anymore)
-    let content = obj.read_sync("main").unwrap();
-    assert_eq!(content, large_content);
-
-    // Async read should also work
-    let content = block_on(async { obj.read("main").await });
-    assert_eq!(content.unwrap(), large_content);
-}
-
-#[test]
-fn async_read_content() {
-    let obj = Object::new(ObjectId::new(1), "test");
-
-    // Write using sync
-    obj.write_sync("main", b"hello", "alice", 1000);
-
-    // Read using async should also work
-    let content = block_on(async { obj.read("main").await });
-    assert_eq!(content.unwrap(), b"hello");
-}
-
-#[test]
-fn stream_write_content() {
-    let obj = Object::new(ObjectId::new(1), "test");
-
-    let data = b"hello streaming world";
-    let cursor = AllowStdIo::new(Cursor::new(data.to_vec()));
-
-    block_on(async {
-        obj.write_stream("main", cursor, "alice", 1000)
-            .await
-            .unwrap();
-    });
-
-    let content = obj.read_sync("main").unwrap();
-    assert_eq!(content, data);
-}
-
-#[test]
-fn stream_write_large_content() {
-    let obj = Object::new(ObjectId::new(1), "test");
-
-    let large_content: Vec<u8> = (0..1024 * 1024 * 5).map(|i| (i % 256) as u8).collect();
-    let cursor = AllowStdIo::new(Cursor::new(large_content.clone()));
-
-    block_on(async {
-        obj.write_stream("main", cursor, "alice", 1000)
-            .await
-            .unwrap();
-    });
-
-    // Should be readable (content stored directly, no chunking)
-    let content = obj.read_sync("main").unwrap();
-    assert_eq!(content, large_content);
-}
-
-#[test]
-fn stream_write_empty_content() {
-    let obj = Object::new(ObjectId::new(1), "test");
-
-    let cursor = AllowStdIo::new(Cursor::new(Vec::<u8>::new()));
-
-    block_on(async {
-        obj.write_stream("main", cursor, "alice", 1000)
-            .await
-            .unwrap();
-    });
-
-    let content = obj.read_sync("main").unwrap();
-    assert_eq!(content, b"");
-}
-
-#[test]
-fn stream_read_content() {
-    let obj = Object::new(ObjectId::new(1), "test");
-
-    // Write content
-    obj.write_sync("main", b"hello", "alice", 1000);
-
-    // Stream read should work (returns single chunk now)
-    let chunks: Vec<Bytes> = block_on(async {
-        let stream = obj.read_stream("main").unwrap();
-        stream.collect().await
-    });
-
-    assert_eq!(chunks.len(), 1);
-    assert_eq!(&chunks[0][..], b"hello");
-}
-
-#[test]
-fn stream_read_large_content() {
-    let obj = Object::new(ObjectId::new(1), "test");
-
-    // Write large content
-    let large_content: Vec<u8> = (0..1024 * 1024 * 3).map(|i| (i % 256) as u8).collect();
-    obj.write_sync("main", &large_content, "alice", 1000);
-
-    // Stream read yields single chunk (no chunking at commit level)
-    let chunks: Vec<Bytes> = block_on(async {
-        let stream = obj.read_stream("main").unwrap();
-        stream.collect().await
-    });
-
-    // Single chunk containing all content
-    assert_eq!(chunks.len(), 1);
-    assert_eq!(&chunks[0][..], &large_content[..]);
-}
-
-#[test]
-fn stream_read_empty_branch_returns_none() {
-    let obj = Object::new(ObjectId::new(1), "test");
-    assert!(obj.read_stream("main").is_none());
 }
 
 #[test]

--- a/groove/tests/object.rs
+++ b/groove/tests/object.rs
@@ -4,15 +4,13 @@ use bytes::Bytes;
 use futures::executor::block_on;
 use futures::io::AllowStdIo;
 use futures::stream::StreamExt;
-use groove::{
-    Commit, CommitId, ContentRef, LastWriterWins, MemoryContentStore, Object, ObjectId, INLINE_THRESHOLD,
-};
+use groove::{Commit, CommitId, LastWriterWins, Object, ObjectId};
 use std::io::Cursor;
 
 fn make_commit(content: &[u8], parents: Vec<CommitId>) -> Commit {
     Commit {
         parents,
-        content: ContentRef::inline(content.to_vec()),
+        content: content.to_vec().into_boxed_slice(),
         author: "test-author".to_string(),
         timestamp: 1000,
         meta: None,
@@ -84,7 +82,7 @@ fn merge_branches_simple() {
     // Add commit to main
     let c2 = Commit {
         parents: vec![id1],
-        content: ContentRef::inline(b"main-change".to_vec()),
+        content: b"main-change".to_vec().into_boxed_slice(),
         author: "alice".to_string(),
         timestamp: 2000,
         meta: None,
@@ -94,7 +92,7 @@ fn merge_branches_simple() {
     // Add commit to feature
     let c3 = Commit {
         parents: vec![id1],
-        content: ContentRef::inline(b"feature-change".to_vec()),
+        content: b"feature-change".to_vec().into_boxed_slice(),
         author: "bob".to_string(),
         timestamp: 2001,
         meta: None,
@@ -150,21 +148,25 @@ fn read_sync_empty_branch_returns_none() {
 }
 
 #[test]
-#[should_panic(expected = "content exceeds INLINE_THRESHOLD")]
-fn write_sync_panics_on_large_content() {
+fn sync_write_large_content() {
     let obj = Object::new(ObjectId::new(1), "test");
-    let large_content = vec![0u8; INLINE_THRESHOLD + 1];
+
+    // Large content is now stored directly (no chunking at commit level)
+    let large_content: Vec<u8> = (0..1024 * 1024).map(|i| (i % 256) as u8).collect();
     obj.write_sync("main", &large_content, "alice", 1000);
+
+    // Should be readable
+    let content = obj.read_sync("main").unwrap();
+    assert_eq!(content, large_content);
 }
 
 #[test]
-fn async_write_small_content() {
+fn async_write_content() {
     let obj = Object::new(ObjectId::new(1), "test");
-    let store = MemoryContentStore::new();
 
-    // Write small content (should be inline)
+    // Write content
     block_on(async {
-        obj.write("main", b"hello", "alice", 1000, &store).await;
+        obj.write("main", b"hello", "alice", 1000).await;
     });
 
     // Read back
@@ -175,53 +177,48 @@ fn async_write_small_content() {
 #[test]
 fn async_write_large_content() {
     let obj = Object::new(ObjectId::new(1), "test");
-    let store = MemoryContentStore::new();
 
-    // Write large content (should be chunked)
-    let large_content: Vec<u8> = (0..INLINE_THRESHOLD * 3).map(|i| (i % 256) as u8).collect();
+    // Large content stored directly
+    let large_content: Vec<u8> = (0..1024 * 1024 * 3).map(|i| (i % 256) as u8).collect();
 
     block_on(async {
-        obj.write("main", &large_content, "alice", 1000, &store)
-            .await;
+        obj.write("main", &large_content, "alice", 1000).await;
     });
 
-    // Read sync should return None (content is chunked)
-    assert!(obj.read_sync("main").is_none());
+    // Should be readable via sync (no chunking anymore)
+    let content = obj.read_sync("main").unwrap();
+    assert_eq!(content, large_content);
 
-    // Read async should work
-    let content = block_on(async { obj.read("main", &store).await });
+    // Async read should also work
+    let content = block_on(async { obj.read("main").await });
     assert_eq!(content.unwrap(), large_content);
 }
 
 #[test]
-fn async_read_inline_content() {
+fn async_read_content() {
     let obj = Object::new(ObjectId::new(1), "test");
-    let store = MemoryContentStore::new();
 
-    // Write using sync (inline)
+    // Write using sync
     obj.write_sync("main", b"hello", "alice", 1000);
 
     // Read using async should also work
-    let content = block_on(async { obj.read("main", &store).await });
+    let content = block_on(async { obj.read("main").await });
     assert_eq!(content.unwrap(), b"hello");
 }
 
 #[test]
-fn stream_write_small_content() {
+fn stream_write_content() {
     let obj = Object::new(ObjectId::new(1), "test");
-    let store = MemoryContentStore::new();
 
-    // Small content should be inlined
     let data = b"hello streaming world";
     let cursor = AllowStdIo::new(Cursor::new(data.to_vec()));
 
     block_on(async {
-        obj.write_stream("main", cursor, "alice", 1000, &store)
+        obj.write_stream("main", cursor, "alice", 1000)
             .await
             .unwrap();
     });
 
-    // Should be readable via sync (inline)
     let content = obj.read_sync("main").unwrap();
     assert_eq!(content, data);
 }
@@ -229,55 +226,47 @@ fn stream_write_small_content() {
 #[test]
 fn stream_write_large_content() {
     let obj = Object::new(ObjectId::new(1), "test");
-    let store = MemoryContentStore::new();
 
-    // Large content should be chunked
-    let large_content: Vec<u8> = (0..INLINE_THRESHOLD * 5).map(|i| (i % 256) as u8).collect();
+    let large_content: Vec<u8> = (0..1024 * 1024 * 5).map(|i| (i % 256) as u8).collect();
     let cursor = AllowStdIo::new(Cursor::new(large_content.clone()));
 
     block_on(async {
-        obj.write_stream("main", cursor, "alice", 1000, &store)
+        obj.write_stream("main", cursor, "alice", 1000)
             .await
             .unwrap();
     });
 
-    // Should NOT be readable via sync (chunked)
-    assert!(obj.read_sync("main").is_none());
-
-    // But should be readable via async
-    let content = block_on(async { obj.read("main", &store).await });
-    assert_eq!(content.unwrap(), large_content);
+    // Should be readable (content stored directly, no chunking)
+    let content = obj.read_sync("main").unwrap();
+    assert_eq!(content, large_content);
 }
 
 #[test]
 fn stream_write_empty_content() {
     let obj = Object::new(ObjectId::new(1), "test");
-    let store = MemoryContentStore::new();
 
     let cursor = AllowStdIo::new(Cursor::new(Vec::<u8>::new()));
 
     block_on(async {
-        obj.write_stream("main", cursor, "alice", 1000, &store)
+        obj.write_stream("main", cursor, "alice", 1000)
             .await
             .unwrap();
     });
 
-    // Empty content should be inline
     let content = obj.read_sync("main").unwrap();
     assert_eq!(content, b"");
 }
 
 #[test]
-fn stream_read_inline_content() {
+fn stream_read_content() {
     let obj = Object::new(ObjectId::new(1), "test");
-    let store = MemoryContentStore::new();
 
-    // Write inline content
+    // Write content
     obj.write_sync("main", b"hello", "alice", 1000);
 
-    // Stream read should work
+    // Stream read should work (returns single chunk now)
     let chunks: Vec<Bytes> = block_on(async {
-        let stream = obj.read_stream("main", &store).unwrap();
+        let stream = obj.read_stream("main").unwrap();
         stream.collect().await
     });
 
@@ -286,86 +275,28 @@ fn stream_read_inline_content() {
 }
 
 #[test]
-fn stream_read_chunked_content() {
+fn stream_read_large_content() {
     let obj = Object::new(ObjectId::new(1), "test");
-    let store = MemoryContentStore::new();
 
-    // Write chunked content
-    let large_content: Vec<u8> = (0..INLINE_THRESHOLD * 3).map(|i| (i % 256) as u8).collect();
+    // Write large content
+    let large_content: Vec<u8> = (0..1024 * 1024 * 3).map(|i| (i % 256) as u8).collect();
+    obj.write_sync("main", &large_content, "alice", 1000);
 
-    block_on(async {
-        obj.write("main", &large_content, "alice", 1000, &store)
-            .await;
-    });
-
-    // Stream read should yield multiple chunks
+    // Stream read yields single chunk (no chunking at commit level)
     let chunks: Vec<Bytes> = block_on(async {
-        let stream = obj.read_stream("main", &store).unwrap();
+        let stream = obj.read_stream("main").unwrap();
         stream.collect().await
     });
 
-    // Should have 3 chunks
-    assert_eq!(chunks.len(), 3);
-
-    // Concatenated should equal original
-    let reassembled: Vec<u8> = chunks.iter().flat_map(|c| c.iter().copied()).collect();
-    assert_eq!(reassembled, large_content);
+    // Single chunk containing all content
+    assert_eq!(chunks.len(), 1);
+    assert_eq!(&chunks[0][..], &large_content[..]);
 }
 
 #[test]
 fn stream_read_empty_branch_returns_none() {
     let obj = Object::new(ObjectId::new(1), "test");
-    let store = MemoryContentStore::new();
-
-    assert!(obj.read_stream("main", &store).is_none());
-}
-
-#[test]
-fn stream_roundtrip_exact_threshold() {
-    let obj = Object::new(ObjectId::new(1), "test");
-    let store = MemoryContentStore::new();
-
-    // Content exactly at threshold should be inline
-    let data: Vec<u8> = (0..INLINE_THRESHOLD).map(|i| (i % 256) as u8).collect();
-    let cursor = AllowStdIo::new(Cursor::new(data.clone()));
-
-    block_on(async {
-        obj.write_stream("main", cursor, "alice", 1000, &store)
-            .await
-            .unwrap();
-    });
-
-    // Should be inline
-    let content = obj.read_sync("main").unwrap();
-    assert_eq!(content, data);
-}
-
-#[test]
-fn stream_roundtrip_just_over_threshold() {
-    let obj = Object::new(ObjectId::new(1), "test");
-    let store = MemoryContentStore::new();
-
-    // Content just over threshold should be chunked
-    let data: Vec<u8> = (0..INLINE_THRESHOLD + 1).map(|i| (i % 256) as u8).collect();
-    let cursor = AllowStdIo::new(Cursor::new(data.clone()));
-
-    block_on(async {
-        obj.write_stream("main", cursor, "alice", 1000, &store)
-            .await
-            .unwrap();
-    });
-
-    // Should be chunked (not readable via sync)
-    assert!(obj.read_sync("main").is_none());
-
-    // But readable via stream
-    let chunks: Vec<Bytes> = block_on(async {
-        let stream = obj.read_stream("main", &store).unwrap();
-        stream.collect().await
-    });
-
-    let reassembled: Vec<u8> = chunks.iter().flat_map(|c| c.iter().copied()).collect();
-    assert_eq!(reassembled, data);
+    assert!(obj.read_stream("main").is_none());
 }
 
 #[test]

--- a/groove/tests/persistence.rs
+++ b/groove/tests/persistence.rs
@@ -1,0 +1,463 @@
+//! Roundtrip persistence tests.
+//!
+//! These tests verify that a Database can be created, populated,
+//! dropped, and then restored from the same Environment.
+
+use std::sync::Arc;
+
+use bytes::Bytes;
+use groove::sql::{Database, ExecuteResult, Row, Value};
+use groove::{ChunkStore, ContentRef, MemoryEnvironment, INLINE_THRESHOLD};
+
+/// Helper to extract rows from ExecuteResult
+fn get_rows(result: ExecuteResult) -> Vec<Row> {
+    match result {
+        ExecuteResult::Selected(rows) => rows,
+        other => panic!("expected Selected, got {:?}", other),
+    }
+}
+
+/// Helper to extract inserted ID from ExecuteResult
+fn get_inserted_id(result: ExecuteResult) -> groove::ObjectId {
+    match result {
+        ExecuteResult::Inserted(id) => id,
+        other => panic!("expected Inserted, got {:?}", other),
+    }
+}
+
+#[test]
+fn database_roundtrip_simple() {
+    let env = Arc::new(MemoryEnvironment::new());
+
+    // Create and populate database
+    let catalog_id = {
+        let db = Database::new(env.clone());
+
+        db.execute("CREATE TABLE users (id I64 NOT NULL, name STRING NOT NULL)")
+            .unwrap();
+
+        db.execute("INSERT INTO users (id, name) VALUES (1, 'Alice')")
+            .unwrap();
+        db.execute("INSERT INTO users (id, name) VALUES (2, 'Bob')")
+            .unwrap();
+
+        db.catalog_object_id()
+    };
+
+    // Database dropped here - restore from same environment
+    let db = Database::from_env(env.clone(), catalog_id).unwrap();
+
+    // Verify table exists
+    let tables = db.list_tables();
+    assert_eq!(tables.len(), 1);
+    assert!(tables.contains(&"users".to_string()));
+
+    // Verify schema
+    let schema = db.get_table("users").unwrap();
+    assert_eq!(schema.columns.len(), 2);
+    assert_eq!(schema.columns[0].name, "id");
+    assert_eq!(schema.columns[1].name, "name");
+
+    // Verify data
+    let result = db.execute("SELECT * FROM users").unwrap();
+    let rows = get_rows(result);
+    assert_eq!(rows.len(), 2, "should have 2 rows");
+
+    // Check row values
+    let names: Vec<&Value> = rows.iter().map(|r| &r.values[1]).collect();
+    assert!(
+        names.contains(&&Value::String("Alice".to_string())),
+        "should contain Alice"
+    );
+    assert!(
+        names.contains(&&Value::String("Bob".to_string())),
+        "should contain Bob"
+    );
+}
+
+#[test]
+fn database_roundtrip_multiple_tables() {
+    let env = Arc::new(MemoryEnvironment::new());
+
+    // Create and populate database
+    let catalog_id = {
+        let db = Database::new(env.clone());
+
+        db.execute("CREATE TABLE orgs (id I64 NOT NULL, name STRING NOT NULL)")
+            .unwrap();
+        db.execute("CREATE TABLE users (id I64 NOT NULL, name STRING NOT NULL, org_id REFERENCES orgs NOT NULL)")
+            .unwrap();
+
+        let acme_id = get_inserted_id(
+            db.execute("INSERT INTO orgs (id, name) VALUES (1, 'Acme')")
+                .unwrap(),
+        );
+        let globex_id = get_inserted_id(
+            db.execute("INSERT INTO orgs (id, name) VALUES (2, 'Globex')")
+                .unwrap(),
+        );
+
+        db.execute(&format!(
+            "INSERT INTO users (id, name, org_id) VALUES (1, 'Alice', '{}')",
+            acme_id
+        ))
+        .unwrap();
+        db.execute(&format!(
+            "INSERT INTO users (id, name, org_id) VALUES (2, 'Bob', '{}')",
+            globex_id
+        ))
+        .unwrap();
+
+        db.catalog_object_id()
+    };
+
+    // Restore database
+    let db = Database::from_env(env.clone(), catalog_id).unwrap();
+
+    // Verify both tables exist
+    let tables = db.list_tables();
+    assert_eq!(tables.len(), 2);
+    assert!(tables.contains(&"orgs".to_string()));
+    assert!(tables.contains(&"users".to_string()));
+
+    // Verify orgs data
+    let orgs = get_rows(db.execute("SELECT * FROM orgs").unwrap());
+    assert_eq!(orgs.len(), 2);
+
+    // Verify users data
+    let users = get_rows(db.execute("SELECT * FROM users").unwrap());
+    assert_eq!(users.len(), 2);
+
+    // Verify ref column type was preserved
+    let users_schema = db.get_table("users").unwrap();
+    assert!(
+        matches!(users_schema.columns[2].ty, groove::sql::ColumnType::Ref(_)),
+        "org_id should be Ref type"
+    );
+}
+
+#[test]
+fn database_roundtrip_with_policies() {
+    let env = Arc::new(MemoryEnvironment::new());
+
+    // Create database with policies
+    let catalog_id = {
+        let db = Database::new(env.clone());
+
+        db.execute("CREATE TABLE users (id I64 NOT NULL, name STRING NOT NULL)")
+            .unwrap();
+        db.execute("CREATE TABLE documents (id I64 NOT NULL, title STRING NOT NULL, owner_id REFERENCES users NOT NULL)")
+            .unwrap();
+
+        // Create users
+        let alice_id = get_inserted_id(
+            db.execute("INSERT INTO users (id, name) VALUES (100, 'Alice')")
+                .unwrap(),
+        );
+        let bob_id = get_inserted_id(
+            db.execute("INSERT INTO users (id, name) VALUES (200, 'Bob')")
+                .unwrap(),
+        );
+
+        // Create documents
+        db.execute(&format!(
+            "INSERT INTO documents (id, title, owner_id) VALUES (1, 'Doc1', '{}')",
+            alice_id
+        ))
+        .unwrap();
+        db.execute(&format!(
+            "INSERT INTO documents (id, title, owner_id) VALUES (2, 'Doc2', '{}')",
+            bob_id
+        ))
+        .unwrap();
+
+        // Create policy
+        db.execute("CREATE POLICY ON documents FOR SELECT WHERE owner_id = @viewer")
+            .unwrap();
+
+        db.catalog_object_id()
+    };
+
+    // Restore database
+    let db = Database::from_env(env.clone(), catalog_id).unwrap();
+
+    // Verify policies are restored
+    let policies = db.get_policies("documents").unwrap();
+    assert!(!policies.is_empty(), "policies should be restored");
+
+    // Get Alice's ID to use as viewer
+    let users = get_rows(db.execute("SELECT * FROM users").unwrap());
+    let alice_id = users
+        .iter()
+        .find(|r| r.values[1] == Value::String("Alice".to_string()))
+        .unwrap()
+        .id;
+
+    // Verify policy works (select_all_as should filter)
+    let rows = db.select_all_as("documents", alice_id).unwrap();
+    assert_eq!(rows.len(), 1, "policy should filter to owner's docs");
+    assert_eq!(
+        rows[0].values[1],
+        Value::String("Doc1".to_string()),
+        "should see Doc1"
+    );
+}
+
+#[test]
+fn database_roundtrip_after_delete() {
+    let env = Arc::new(MemoryEnvironment::new());
+
+    // Create, populate, then delete some rows
+    let catalog_id = {
+        let db = Database::new(env.clone());
+
+        db.execute("CREATE TABLE items (id I64 NOT NULL, name STRING NOT NULL)")
+            .unwrap();
+
+        db.execute("INSERT INTO items (id, name) VALUES (1, 'Item1')")
+            .unwrap();
+        db.execute("INSERT INTO items (id, name) VALUES (2, 'Item2')")
+            .unwrap();
+        db.execute("INSERT INTO items (id, name) VALUES (3, 'Item3')")
+            .unwrap();
+
+        // Get ID of Item2 to delete
+        let items = get_rows(db.execute("SELECT * FROM items").unwrap());
+        let item2_id = items
+            .iter()
+            .find(|r| r.values[1] == Value::String("Item2".to_string()))
+            .unwrap()
+            .id;
+
+        db.execute(&format!("DELETE FROM items WHERE id = '{}'", item2_id))
+            .unwrap();
+
+        // Verify delete worked
+        let items = get_rows(db.execute("SELECT * FROM items").unwrap());
+        assert_eq!(items.len(), 2);
+
+        db.catalog_object_id()
+    };
+
+    // Restore and verify delete was persisted
+    let db = Database::from_env(env.clone(), catalog_id).unwrap();
+
+    let items = get_rows(db.execute("SELECT * FROM items").unwrap());
+    assert_eq!(items.len(), 2, "delete should be persisted");
+
+    let names: Vec<&Value> = items.iter().map(|r| &r.values[1]).collect();
+    assert!(
+        !names.contains(&&Value::String("Item2".to_string())),
+        "Item2 should be deleted"
+    );
+}
+
+#[test]
+fn database_roundtrip_after_update() {
+    let env = Arc::new(MemoryEnvironment::new());
+
+    // Create, populate, then update some rows
+    let catalog_id = {
+        let db = Database::new(env.clone());
+
+        db.execute("CREATE TABLE settings (id I64 NOT NULL, value STRING NOT NULL)")
+            .unwrap();
+
+        db.execute("INSERT INTO settings (id, value) VALUES (1, 'old_value')")
+            .unwrap();
+
+        // Get ID of the row
+        let settings = get_rows(db.execute("SELECT * FROM settings").unwrap());
+        let row_id = settings[0].id;
+
+        db.execute(&format!(
+            "UPDATE settings SET value = 'new_value' WHERE id = '{}'",
+            row_id
+        ))
+        .unwrap();
+
+        // Verify update worked
+        let settings = get_rows(db.execute("SELECT * FROM settings").unwrap());
+        assert_eq!(
+            settings[0].values[1],
+            Value::String("new_value".to_string())
+        );
+
+        db.catalog_object_id()
+    };
+
+    // Restore and verify update was persisted
+    let db = Database::from_env(env.clone(), catalog_id).unwrap();
+
+    let settings = get_rows(db.execute("SELECT * FROM settings").unwrap());
+    assert_eq!(settings.len(), 1);
+    assert_eq!(
+        settings[0].values[1],
+        Value::String("new_value".to_string()),
+        "update should be persisted"
+    );
+}
+
+#[test]
+fn database_roundtrip_with_nullable() {
+    let env = Arc::new(MemoryEnvironment::new());
+
+    // Create table with nullable column
+    let catalog_id = {
+        let db = Database::new(env.clone());
+
+        db.execute("CREATE TABLE contacts (id I64 NOT NULL, name STRING NOT NULL, phone STRING)")
+            .unwrap();
+
+        db.execute("INSERT INTO contacts (id, name, phone) VALUES (1, 'Alice', '555-1234')")
+            .unwrap();
+        db.execute("INSERT INTO contacts (id, name) VALUES (2, 'Bob')")
+            .unwrap();
+
+        db.catalog_object_id()
+    };
+
+    // Restore and verify nulls are preserved
+    let db = Database::from_env(env.clone(), catalog_id).unwrap();
+
+    let contacts = get_rows(db.execute("SELECT * FROM contacts").unwrap());
+    assert_eq!(contacts.len(), 2);
+
+    // Find Alice and Bob
+    let alice = contacts
+        .iter()
+        .find(|r| r.values[1] == Value::String("Alice".to_string()))
+        .unwrap();
+    let bob = contacts
+        .iter()
+        .find(|r| r.values[1] == Value::String("Bob".to_string()))
+        .unwrap();
+
+    // Alice has phone
+    assert!(
+        matches!(&alice.values[2], Value::NullableSome(_)),
+        "Alice should have phone"
+    );
+
+    // Bob doesn't have phone (should be NullableNone)
+    assert!(
+        matches!(&bob.values[2], Value::NullableNone),
+        "Bob should have null phone"
+    );
+}
+
+#[test]
+fn database_roundtrip_with_inline_blob() {
+    let env = Arc::new(MemoryEnvironment::new());
+
+    // Small blob data (will be stored inline)
+    let small_data: Vec<u8> = (0..100).map(|i| i as u8).collect();
+
+    let catalog_id = {
+        let db = Database::new(env.clone());
+
+        db.execute("CREATE TABLE files (id I64 NOT NULL, name STRING NOT NULL, data BLOB NOT NULL)")
+            .unwrap();
+
+        // Create inline blob
+        let blob_ref = ContentRef::inline(small_data.clone());
+
+        // Insert with blob
+        db.insert(
+            "files",
+            &["id", "name", "data"],
+            vec![
+                Value::I64(1),
+                Value::String("small.bin".to_string()),
+                Value::Blob(blob_ref),
+            ],
+        )
+        .unwrap();
+
+        db.catalog_object_id()
+    };
+
+    // Restore database
+    let db = Database::from_env(env.clone(), catalog_id).unwrap();
+
+    // Verify blob data
+    let rows = get_rows(db.execute("SELECT * FROM files").unwrap());
+    assert_eq!(rows.len(), 1, "should have 1 file");
+
+    // Check blob content
+    if let Value::Blob(content_ref) = &rows[0].values[2] {
+        let data = content_ref.as_inline().expect("should be inline blob");
+        assert_eq!(data, small_data.as_slice(), "blob data should match");
+    } else {
+        panic!("expected Blob value, got {:?}", rows[0].values[2]);
+    }
+}
+
+#[test]
+fn database_roundtrip_with_chunked_blob() {
+    use futures::executor::block_on;
+
+    let env = Arc::new(MemoryEnvironment::new());
+
+    // Large blob data (will be chunked) - 2 chunks worth
+    let large_data: Vec<u8> = (0..(INLINE_THRESHOLD + 1000))
+        .map(|i| (i % 256) as u8)
+        .collect();
+
+    let catalog_id = {
+        let db = Database::new(env.clone());
+
+        db.execute("CREATE TABLE files (id I64 NOT NULL, name STRING NOT NULL, data BLOB NOT NULL)")
+            .unwrap();
+
+        // Manually chunk the data and store in environment
+        let chunk_size = INLINE_THRESHOLD;
+        let mut hashes = Vec::new();
+        for chunk in large_data.chunks(chunk_size) {
+            let hash = block_on(env.put_chunk(Bytes::copy_from_slice(chunk)));
+            hashes.push(hash);
+        }
+
+        // Create chunked blob reference
+        let blob_ref = ContentRef::chunked(hashes);
+
+        // Insert with blob
+        db.insert(
+            "files",
+            &["id", "name", "data"],
+            vec![
+                Value::I64(1),
+                Value::String("large.bin".to_string()),
+                Value::Blob(blob_ref),
+            ],
+        )
+        .unwrap();
+
+        db.catalog_object_id()
+    };
+
+    // Restore database
+    let db = Database::from_env(env.clone(), catalog_id).unwrap();
+
+    // Verify blob data
+    let rows = get_rows(db.execute("SELECT * FROM files").unwrap());
+    assert_eq!(rows.len(), 1, "should have 1 file");
+
+    // Check blob content - need to read chunks from environment
+    if let Value::Blob(content_ref) = &rows[0].values[2] {
+        let chunk_hashes = content_ref.as_chunks().expect("should be chunked blob");
+        assert_eq!(chunk_hashes.len(), 2, "should have 2 chunks");
+
+        // Read and concatenate chunks
+        let mut restored_data = Vec::new();
+        for hash in chunk_hashes {
+            let chunk = block_on(env.get_chunk(hash)).expect("chunk should exist");
+            restored_data.extend_from_slice(&chunk);
+        }
+
+        assert_eq!(restored_data.len(), large_data.len(), "blob size should match");
+        assert_eq!(restored_data, large_data, "blob data should match");
+    } else {
+        panic!("expected Blob value, got {:?}", rows[0].values[2]);
+    }
+}

--- a/groove/tests/sql_blob.rs
+++ b/groove/tests/sql_blob.rs
@@ -1,0 +1,164 @@
+//! Tests for BLOB and BLOB[] column types.
+
+use groove::sql::{decode_row, encode_row, ColumnDef, ColumnType, TableSchema, Value};
+use groove::{ChunkHash, ContentRef};
+
+fn blob_schema() -> TableSchema {
+    TableSchema::new(
+        "files",
+        vec![
+            ColumnDef::required("name", ColumnType::String),
+            ColumnDef::required("content", ColumnType::Blob),
+        ],
+    )
+}
+
+fn blob_array_schema() -> TableSchema {
+    TableSchema::new(
+        "documents",
+        vec![
+            ColumnDef::required("title", ColumnType::String),
+            ColumnDef::required("attachments", ColumnType::BlobArray),
+        ],
+    )
+}
+
+#[test]
+fn encode_decode_blob_inline() {
+    let schema = blob_schema();
+
+    // Create a small inline blob
+    let content = ContentRef::inline(vec![1, 2, 3, 4, 5]);
+    let values = vec![Value::String("test.txt".into()), Value::Blob(content)];
+
+    let encoded = encode_row(&values, &schema).expect("encode should succeed");
+    let decoded = decode_row(&encoded, &schema).expect("decode should succeed");
+
+    assert_eq!(decoded.len(), 2);
+    assert_eq!(decoded[0].as_str(), Some("test.txt"));
+
+    let blob = decoded[1].as_blob().expect("should be blob");
+    assert!(blob.is_inline());
+    assert_eq!(blob.as_inline(), Some(&[1, 2, 3, 4, 5][..]));
+}
+
+#[test]
+fn encode_decode_blob_chunked() {
+    let schema = blob_schema();
+
+    // Create a chunked blob with fake hashes
+    let hashes = vec![
+        ChunkHash::from_bytes([1u8; 32]),
+        ChunkHash::from_bytes([2u8; 32]),
+    ];
+    let content = ContentRef::chunked(hashes);
+    let values = vec![Value::String("large.bin".into()), Value::Blob(content)];
+
+    let encoded = encode_row(&values, &schema).expect("encode should succeed");
+    let decoded = decode_row(&encoded, &schema).expect("decode should succeed");
+
+    assert_eq!(decoded.len(), 2);
+    assert_eq!(decoded[0].as_str(), Some("large.bin"));
+
+    let blob = decoded[1].as_blob().expect("should be blob");
+    assert!(!blob.is_inline());
+    let chunks = blob.as_chunks().expect("should have chunks");
+    assert_eq!(chunks.len(), 2);
+    assert_eq!(chunks[0].as_bytes(), &[1u8; 32]);
+    assert_eq!(chunks[1].as_bytes(), &[2u8; 32]);
+}
+
+#[test]
+fn encode_decode_blob_array() {
+    let schema = blob_array_schema();
+
+    // Create a blob array with mixed inline blobs
+    let refs = vec![
+        ContentRef::inline(vec![10, 20, 30]),
+        ContentRef::inline(vec![40, 50]),
+        ContentRef::chunked(vec![ChunkHash::from_bytes([99u8; 32])]),
+    ];
+    let values = vec![Value::String("report.doc".into()), Value::BlobArray(refs)];
+
+    let encoded = encode_row(&values, &schema).expect("encode should succeed");
+    let decoded = decode_row(&encoded, &schema).expect("decode should succeed");
+
+    assert_eq!(decoded.len(), 2);
+    assert_eq!(decoded[0].as_str(), Some("report.doc"));
+
+    let blobs = decoded[1].as_blob_array().expect("should be blob array");
+    assert_eq!(blobs.len(), 3);
+
+    assert!(blobs[0].is_inline());
+    assert_eq!(blobs[0].as_inline(), Some(&[10, 20, 30][..]));
+
+    assert!(blobs[1].is_inline());
+    assert_eq!(blobs[1].as_inline(), Some(&[40, 50][..]));
+
+    assert!(!blobs[2].is_inline());
+    assert_eq!(blobs[2].as_chunks().unwrap().len(), 1);
+}
+
+#[test]
+fn encode_decode_nullable_blob() {
+    let schema = TableSchema::new(
+        "files",
+        vec![
+            ColumnDef::required("name", ColumnType::String),
+            ColumnDef::optional("content", ColumnType::Blob),
+        ],
+    );
+
+    // Null blob
+    let values = vec![
+        Value::String("empty.txt".into()),
+        Value::NullableNone,
+    ];
+
+    let encoded = encode_row(&values, &schema).expect("encode should succeed");
+    let decoded = decode_row(&encoded, &schema).expect("decode should succeed");
+
+    assert_eq!(decoded.len(), 2);
+    assert_eq!(decoded[0].as_str(), Some("empty.txt"));
+    assert!(decoded[1].is_null());
+}
+
+#[test]
+fn content_ref_roundtrip() {
+    // Test inline roundtrip
+    let inline = ContentRef::inline(vec![1, 2, 3, 4, 5, 6, 7, 8]);
+    let bytes = inline.to_row_bytes();
+    let (decoded, consumed) = ContentRef::from_row_bytes(&bytes).expect("decode should succeed");
+    assert_eq!(consumed, bytes.len());
+    assert_eq!(decoded, inline);
+
+    // Test chunked roundtrip
+    let hashes = vec![
+        ChunkHash::from_bytes([1u8; 32]),
+        ChunkHash::from_bytes([2u8; 32]),
+        ChunkHash::from_bytes([3u8; 32]),
+    ];
+    let chunked = ContentRef::chunked(hashes);
+    let bytes = chunked.to_row_bytes();
+    let (decoded, consumed) = ContentRef::from_row_bytes(&bytes).expect("decode should succeed");
+    assert_eq!(consumed, bytes.len());
+    assert_eq!(decoded, chunked);
+}
+
+#[test]
+fn blob_column_type_serialization() {
+    let schema = TableSchema::new(
+        "test",
+        vec![
+            ColumnDef::required("data", ColumnType::Blob),
+            ColumnDef::required("attachments", ColumnType::BlobArray),
+        ],
+    );
+
+    let bytes = schema.to_bytes();
+    let decoded = TableSchema::from_bytes(&bytes).expect("decode should succeed");
+
+    assert_eq!(decoded.columns.len(), 2);
+    assert_eq!(decoded.columns[0].ty, ColumnType::Blob);
+    assert_eq!(decoded.columns[1].ty, ColumnType::BlobArray);
+}

--- a/groove/tests/sql_parser.rs
+++ b/groove/tests/sql_parser.rs
@@ -843,3 +843,26 @@ fn parse_select_limit_offset_with_where() {
         _ => panic!("expected Select"),
     }
 }
+
+#[test]
+fn parse_create_table_with_blob() {
+    let sql = "CREATE TABLE documents (title STRING NOT NULL, content BLOB, attachments BLOB[])";
+    let stmt = parse(sql).unwrap();
+
+    match stmt {
+        Statement::CreateTable(ct) => {
+            assert_eq!(ct.name, "documents");
+            assert_eq!(ct.columns.len(), 3);
+            assert_eq!(ct.columns[0].name, "title");
+            assert_eq!(ct.columns[0].ty, ColumnType::String);
+            assert!(!ct.columns[0].nullable);
+            assert_eq!(ct.columns[1].name, "content");
+            assert_eq!(ct.columns[1].ty, ColumnType::Blob);
+            assert!(ct.columns[1].nullable);
+            assert_eq!(ct.columns[2].name, "attachments");
+            assert_eq!(ct.columns[2].ty, ColumnType::BlobArray);
+            assert!(ct.columns[2].nullable);
+        }
+        _ => panic!("expected CreateTable"),
+    }
+}

--- a/groove/tests/storage.rs
+++ b/groove/tests/storage.rs
@@ -3,6 +3,7 @@
 use futures::executor::block_on;
 use futures::stream::StreamExt;
 use groove::{ChunkHash, Commit, CommitId, CommitStore, ContentRef, MemoryEnvironment};
+use std::collections::HashSet;
 
 #[test]
 fn chunk_hash_deterministic() {
@@ -90,4 +91,104 @@ fn list_commits_returns_all_commits_not_just_frontier() {
         commits.contains(&id3),
         "should contain third commit (frontier)"
     );
+}
+
+#[test]
+fn list_objects_returns_all_objects() {
+    let env = MemoryEnvironment::new();
+
+    // Create commits for multiple objects
+    let c1 = Commit {
+        parents: vec![],
+        content: b"obj1".to_vec().into_boxed_slice(),
+        author: "alice".to_string(),
+        timestamp: 1000,
+        meta: None,
+    };
+    let id1 = block_on(env.put_commit(&c1));
+
+    let c2 = Commit {
+        parents: vec![],
+        content: b"obj2".to_vec().into_boxed_slice(),
+        author: "alice".to_string(),
+        timestamp: 1000,
+        meta: None,
+    };
+    let id2 = block_on(env.put_commit(&c2));
+
+    let c3 = Commit {
+        parents: vec![],
+        content: b"obj3".to_vec().into_boxed_slice(),
+        author: "alice".to_string(),
+        timestamp: 1000,
+        meta: None,
+    };
+    let id3 = block_on(env.put_commit(&c3));
+
+    // Set frontiers for different objects
+    block_on(env.set_frontier(100, "main", &[id1]));
+    block_on(env.set_frontier(200, "main", &[id2]));
+    block_on(env.set_frontier(300, "main", &[id3]));
+
+    // list_objects should return all 3 object IDs
+    let objects: HashSet<u128> = block_on(async { env.list_objects().collect().await });
+
+    assert_eq!(objects.len(), 3);
+    assert!(objects.contains(&100));
+    assert!(objects.contains(&200));
+    assert!(objects.contains(&300));
+}
+
+#[test]
+fn list_branches_returns_all_branches_for_object() {
+    let env = MemoryEnvironment::new();
+
+    // Create commits
+    let c1 = Commit {
+        parents: vec![],
+        content: b"main".to_vec().into_boxed_slice(),
+        author: "alice".to_string(),
+        timestamp: 1000,
+        meta: None,
+    };
+    let id1 = block_on(env.put_commit(&c1));
+
+    let c2 = Commit {
+        parents: vec![],
+        content: b"feature".to_vec().into_boxed_slice(),
+        author: "alice".to_string(),
+        timestamp: 2000,
+        meta: None,
+    };
+    let id2 = block_on(env.put_commit(&c2));
+
+    let c3 = Commit {
+        parents: vec![],
+        content: b"other_object".to_vec().into_boxed_slice(),
+        author: "alice".to_string(),
+        timestamp: 3000,
+        meta: None,
+    };
+    let id3 = block_on(env.put_commit(&c3));
+
+    // Set frontiers for object 100 with two branches
+    block_on(env.set_frontier(100, "main", &[id1]));
+    block_on(env.set_frontier(100, "feature", &[id2]));
+    // Different object with one branch
+    block_on(env.set_frontier(200, "main", &[id3]));
+
+    // list_branches for object 100 should return both branches
+    let branches: HashSet<String> = block_on(env.list_branches(100)).into_iter().collect();
+    assert_eq!(branches.len(), 2);
+    assert!(branches.contains("main"));
+    assert!(branches.contains("feature"));
+
+    // list_branches for object 200 should return only main
+    let branches: Vec<String> = block_on(env.list_branches(200));
+    assert_eq!(branches.len(), 1);
+    assert_eq!(branches[0], "main");
+
+    // list_branches for non-existent object should return empty
+    let branches: Vec<String> = block_on(env.list_branches(999));
+    assert!(branches.is_empty());
 }

--- a/groove/tests/storage.rs
+++ b/groove/tests/storage.rs
@@ -48,7 +48,7 @@ fn list_commits_returns_all_commits_not_just_frontier() {
     // Create a chain of 3 commits: c1 <- c2 <- c3
     let c1 = Commit {
         parents: vec![],
-        content: ContentRef::inline(b"first".to_vec()),
+        content: b"first".to_vec().into_boxed_slice(),
         author: "alice".to_string(),
         timestamp: 1000,
         meta: None,
@@ -57,7 +57,7 @@ fn list_commits_returns_all_commits_not_just_frontier() {
 
     let c2 = Commit {
         parents: vec![id1],
-        content: ContentRef::inline(b"second".to_vec()),
+        content: b"second".to_vec().into_boxed_slice(),
         author: "alice".to_string(),
         timestamp: 2000,
         meta: None,
@@ -66,7 +66,7 @@ fn list_commits_returns_all_commits_not_just_frontier() {
 
     let c3 = Commit {
         parents: vec![id2],
-        content: ContentRef::inline(b"third".to_vec()),
+        content: b"third".to_vec().into_boxed_slice(),
         author: "alice".to_string(),
         timestamp: 3000,
         meta: None,

--- a/plan.md
+++ b/plan.md
@@ -316,7 +316,7 @@ Current test count: **276 tests** passing across all modules
 
 - [ ] Truncation on UPDATE: Should UPDATE support a HARD modifier like DELETE? This would allow truncating history after any mutation, not just deletes. Need to unify the semantics with DELETE HARD.
 
-- [ ] Binary files (especially larger than RAM): Should this be a column type (e.g., `BLOB` with streaming support) or a separate raw Object that rows reference? See `specs/binary-data-and-blobs.md` for the proposed row-first design with blob columns.
+- [x] Binary files (especially larger than RAM): Implemented as `BLOB` and `BLOB[]` column types with streaming support. Uses existing `ContentRef` for inline/chunked storage. See `specs/binary-data-and-blobs.md` for design. WASM handle-based streaming API is pending.
 
 - [ ] Edit & history API via "magic columns" and "magic filters": Expose commit graph metadata through virtual columns (e.g., `_commit_id`, `_author`, `_timestamp`, `_deleted`) and special WHERE filters (e.g., `WHERE _as_of = '2024-01-01'`, `WHERE _include_deleted = true`). Would enable time-travel queries and audit trails without separate APIs.
 

--- a/specs/binary-data-and-blobs.md
+++ b/specs/binary-data-and-blobs.md
@@ -2,7 +2,35 @@
 
 ## Implementation Status
 
-**Not yet implemented** - This is a design proposal.
+**Implementation complete.** The following are implemented:
+
+**Core Types:**
+- [x] `BLOB` and `BLOB[]` column types in schema
+- [x] `Value::Blob(ContentRef)` and `Value::BlobArray(Vec<ContentRef>)` variants
+- [x] Row encoding/decoding for blob columns
+- [x] SQL parser recognizes `BLOB` and `BLOB[]` keywords
+- [x] Binary WASM encoding for blob values (sends serialized ContentRef)
+
+**WASM Handle-based API:**
+- [x] `BlobRegistry` for tracking blob handles across WASM boundary
+- [x] `create_blob(data)` - Create blob from raw bytes
+- [x] `create_blob_writer()` - Streaming blob creation
+- [x] `read_blob(handle)` - Read entire blob (small blobs)
+- [x] `read_blob_chunk(handle, idx)` - Stream chunks (large blobs)
+- [x] `get_blob_info(handle)` - Get blob metadata
+- [x] `release_blob(handle)` - Free blob handle
+- [x] `insert_with_blobs()` - Insert row with blob columns
+- [x] `update_row_blob()` - Update blob column
+
+**JavaScript Helpers (`groove-wasm/blob-helpers.ts`):**
+- [x] `blobToReadableStream()` - Convert blob handle to ReadableStream
+- [x] `readableStreamToBlob()` - Create blob from ReadableStream
+- [x] `GrooveBlob` - Wrapper class for convenient blob access
+- [x] `GrooveBlobWriter` - Wrapper for streaming blob creation with WritableStream
+
+**Pending (can defer):**
+- [ ] Blob chunk garbage collection when rows deleted
+- [ ] Persistent chunk storage (currently in-memory only per session)
 
 ## Problem Statement
 


### PR DESCRIPTION
## Summary
- Add BLOB and BLOB[] column types with streaming API for large binary data
- Implement full database persistence via catalog system
- Migrate WASM blob storage to use Environment's ChunkStore
- Simplify commit architecture: commits now store encoded rows directly as bytes

## Persistence System
- **Catalog**: Maps table names to descriptor object IDs, stored in a well-known object
- **TableDescriptor**: Stores schema, policies, rows_object_id, index_object_ids per table
- **Database::from_env()**: Restore a database from an Environment using catalog ID
- **LocalNode persistence**: Commits and frontiers now persisted to Environment on write
- **Branch restoration**: New `restore_commit()` and `set_frontier()` for loading from storage

## Storage Changes
- Renamed `ContentStore` → `ChunkStore` for clarity
- Added `list_objects()` and `list_branches()` to CommitStore trait
- WASM BlobRegistry no longer stores chunks locally - uses Environment's ChunkStore

## Other Changes
- `Commit.content` changed from `ContentRef` to `Box<[u8]>`
- LocalNode API simplified: `read_sync`→`read`, `write_sync`→`write`
- ~750 lines removed in refactoring, ~1300 lines added for persistence

## Test plan
- [x] All existing tests pass (318 tests)
- [x] BLOB column encoding/decoding works
- [x] 8 roundtrip persistence tests:
  - Simple table/row persistence
  - Multiple tables with REFERENCES
  - Policy persistence and enforcement
  - Delete/update persistence
  - Nullable column preservation
  - Inline blob persistence
  - Chunked blob persistence

🤖 Generated with [Claude Code](https://claude.com/claude-code)