### PR TITLE
feat: add getJazzErrorType to simplify error handing in React error boundaries

### DIFF
--- a/.changeset/jazz-error-type.md
+++ b/.changeset/jazz-error-type.md
@@ -1,0 +1,6 @@
+---
+"jazz-tools": patch
+---
+
+Added `getJazzErrorType` helper function to identify the type of Jazz error from an Error object thrown by suspense hooks. This enables error boundaries to display appropriate UI based on whether the error is "unauthorized", "unavailable", or "unknown".
+

--- a/examples/music-player/src/components/ErrorBoundary.tsx
+++ b/examples/music-player/src/components/ErrorBoundary.tsx
@@ -1,9 +1,12 @@
+import { getJazzErrorType } from "jazz-tools";
+import { CoValueErrorState } from "node_modules/jazz-tools/dist/tools/internal";
 import React from "react";
 
 interface ErrorBoundaryState {
   hasError: boolean;
   isAuthorizationError?: boolean;
   error?: Error;
+  errorType?: CoValueErrorState | "unknown";
 }
 
 interface ErrorBoundaryProps {
@@ -21,11 +24,7 @@ export class ErrorBoundary extends React.Component<
   }
 
   static getDerivedStateFromError(error: Error): ErrorBoundaryState {
-    if (error.message.includes("Jazz Authorization Error")) {
-      return { hasError: true, isAuthorizationError: true, error };
-    }
-
-    return { hasError: true, error };
+    return { hasError: true, error, errorType: getJazzErrorType(error) };
   }
 
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo): void {
@@ -38,12 +37,32 @@ export class ErrorBoundary extends React.Component<
         return this.props.fallback(this.state.error);
       }
 
-      if (this.state.isAuthorizationError) {
+      if (this.state.errorType === "unauthorized") {
         return (
           <div className="flex min-h-screen items-center justify-center p-8">
             <div className="max-w-2xl space-y-4">
               <h1 className="text-2xl font-semibold text-red-600">
                 You are not authorized to access this page
+              </h1>
+              <button
+                onClick={() => {
+                  window.location.href = "/";
+                }}
+                className="mt-4 rounded-md bg-primary px-4 py-2 text-primary-foreground hover:bg-primary/90"
+              >
+                Go to home page
+              </button>
+            </div>
+          </div>
+        );
+      }
+
+      if (this.state.errorType === "unavailable") {
+        return (
+          <div className="flex min-h-screen items-center justify-center p-8">
+            <div className="max-w-2xl space-y-4">
+              <h1 className="text-2xl font-semibold text-red-600">
+                The page you are trying to access is unavailable
               </h1>
               <button
                 onClick={() => {

--- a/packages/jazz-tools/src/react-core/tests/useSuspenseCoState.test.tsx
+++ b/packages/jazz-tools/src/react-core/tests/useSuspenseCoState.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 
 import { cojsonInternals } from "cojson";
-import { Group, Loaded, co, z } from "jazz-tools";
+import { Group, Loaded, co, getJazzErrorType, z } from "jazz-tools";
 import { assertLoaded, disableJazzTestSync } from "jazz-tools/testing";
 import { beforeEach, describe, expect, expectTypeOf, it } from "vitest";
 import React, { Suspense, useRef } from "react";
@@ -41,6 +41,10 @@ beforeEach(async () => {
     isCurrentActiveAccount: true,
   });
 });
+
+function ErrorFallback(props: { error: Error }) {
+  return <div>Error: {getJazzErrorType(props.error)}</div>;
+}
 
 describe("useSuspenseCoState", () => {
   it("should return loaded value without suspending when data is available", async () => {
@@ -194,7 +198,7 @@ describe("useSuspenseCoState", () => {
 
     const { container } = await act(async () => {
       return render(
-        <ErrorBoundary fallback={<div>Error!</div>}>
+        <ErrorBoundary FallbackComponent={ErrorFallback}>
           <Suspense fallback={<div>Loading...</div>}>
             <TestComponent />
           </Suspense>
@@ -208,7 +212,7 @@ describe("useSuspenseCoState", () => {
     // Verify error is displayed in error boundary
     await waitFor(
       () => {
-        expect(container.textContent).toContain("Error");
+        expect(container.textContent).toContain("Error: unavailable");
       },
       { timeout: 10_000 },
     );
@@ -241,7 +245,7 @@ describe("useSuspenseCoState", () => {
 
     const { container } = await act(async () => {
       return render(
-        <ErrorBoundary fallback={<div>Error!</div>}>
+        <ErrorBoundary FallbackComponent={ErrorFallback}>
           <Suspense fallback={<div>Loading...</div>}>
             <TestComponent />
           </Suspense>
@@ -255,7 +259,7 @@ describe("useSuspenseCoState", () => {
     // Verify error is displayed in error boundary
     await waitFor(
       () => {
-        expect(container.textContent).toContain("Error!");
+        expect(container.textContent).toContain("Error: unavailable");
       },
       { timeout: 10_000 },
     );
@@ -286,7 +290,7 @@ describe("useSuspenseCoState", () => {
 
     const { container } = await act(async () => {
       return render(
-        <ErrorBoundary fallback={<div>Error!</div>}>
+        <ErrorBoundary FallbackComponent={ErrorFallback}>
           <Suspense fallback={<div>Loading...</div>}>
             <TestComponent />
           </Suspense>
@@ -299,7 +303,7 @@ describe("useSuspenseCoState", () => {
 
     // Verify error is displayed in error boundary
     await waitFor(() => {
-      expect(container.textContent).toContain("Error!");
+      expect(container.textContent).toContain("Error: unavailable");
     });
   });
 
@@ -315,7 +319,7 @@ describe("useSuspenseCoState", () => {
 
     const { container } = await act(async () => {
       return render(
-        <ErrorBoundary fallback={<div>Error!</div>}>
+        <ErrorBoundary FallbackComponent={ErrorFallback}>
           <Suspense fallback={<div>Loading...</div>}>
             <TestComponent />
           </Suspense>
@@ -326,7 +330,7 @@ describe("useSuspenseCoState", () => {
     // Wait for error to be thrown
     await waitFor(
       () => {
-        expect(container.textContent).toContain("Error!");
+        expect(container.textContent).toContain("Error: unavailable");
       },
       { timeout: 1000 },
     );
@@ -356,7 +360,7 @@ describe("useSuspenseCoState", () => {
 
     const { container } = await act(async () => {
       return render(
-        <ErrorBoundary fallback={<div>Error!</div>}>
+        <ErrorBoundary FallbackComponent={ErrorFallback}>
           <Suspense fallback={<div>Loading...</div>}>
             <TestComponent />
           </Suspense>
@@ -366,7 +370,7 @@ describe("useSuspenseCoState", () => {
 
     // Wait for error to be thrown (unauthorized access)
     await waitFor(() => {
-      expect(container.textContent).toContain("Error!");
+      expect(container.textContent).toContain("Error: unauthorized");
     });
   });
 
@@ -397,7 +401,7 @@ describe("useSuspenseCoState", () => {
 
     const { container } = await act(async () => {
       return render(
-        <ErrorBoundary fallback={<div>Error!</div>}>
+        <ErrorBoundary FallbackComponent={ErrorFallback}>
           <Suspense fallback={<div>Loading...</div>}>
             <TestComponent />
           </Suspense>
@@ -413,7 +417,7 @@ describe("useSuspenseCoState", () => {
 
     // Wait for error to be thrown (unauthorized access)
     await waitFor(() => {
-      expect(container.textContent).toContain("Error!");
+      expect(container.textContent).toContain("Error: unauthorized");
     });
   });
 

--- a/packages/jazz-tools/src/tools/exports.ts
+++ b/packages/jazz-tools/src/tools/exports.ts
@@ -67,6 +67,7 @@ export {
   unstable_loadUnique,
   getUnloadedCoValueWithoutId,
   setDefaultSchemaPermissions,
+  getJazzErrorType,
 } from "./internal.js";
 
 export {

--- a/packages/jazz-tools/src/tools/internal.ts
+++ b/packages/jazz-tools/src/tools/internal.ts
@@ -58,4 +58,6 @@ export * from "./coValues/extensions/imageDef.js";
 
 export * from "./implementation/ContextManager.js";
 
+export * from "./subscribe/JazzError.js";
+
 import "./implementation/devtoolsFormatters.js";

--- a/packages/jazz-tools/src/tools/subscribe/JazzError.ts
+++ b/packages/jazz-tools/src/tools/subscribe/JazzError.ts
@@ -70,7 +70,10 @@ export function fillErrorWithJazzErrorInfo(
   }
 
   errorBase.message = jazzError.toString();
-  errorBase.name = `jazz-error-${jazzError.type}`;
+
+  Object.defineProperty(errorBase, "@jazzErrorType", {
+    value: jazzError.type,
+  });
 
   return errorBase;
 }
@@ -78,8 +81,12 @@ export function fillErrorWithJazzErrorInfo(
 export function getJazzErrorType(
   error: unknown,
 ): CoValueErrorState | "unknown" {
-  if (error instanceof Error && error.name.startsWith("jazz-error-")) {
-    return error.name.replace("jazz-error-", "") as CoValueErrorState;
+  if (
+    error instanceof Error &&
+    "@jazzErrorType" in error &&
+    typeof error["@jazzErrorType"] === "string"
+  ) {
+    return error["@jazzErrorType"] as CoValueErrorState;
   }
 
   return "unknown";

--- a/packages/jazz-tools/src/tools/subscribe/JazzError.ts
+++ b/packages/jazz-tools/src/tools/subscribe/JazzError.ts
@@ -1,4 +1,4 @@
-import type { CoValue, ID } from "../internal.js";
+import type { CoValue, CoValueErrorState, ID } from "../internal.js";
 import { CoValueLoadingState } from "./types.js";
 
 export class JazzError {
@@ -55,3 +55,32 @@ export type JazzErrorIssue = {
   params: Record<string, any>;
   path: string[];
 };
+
+export function fillErrorWithJazzErrorInfo(
+  /**
+   * The error we are going to fill with the jazz error info.
+   *
+   * Passed externally to provide a better stack trace.
+   */
+  errorBase: Error,
+  jazzError: JazzError | undefined,
+): Error {
+  if (!jazzError) {
+    return errorBase;
+  }
+
+  errorBase.message = jazzError.toString();
+  errorBase.name = `jazz-error-${jazzError.type}`;
+
+  return errorBase;
+}
+
+export function getJazzErrorType(
+  error: unknown,
+): CoValueErrorState | "unknown" {
+  if (error instanceof Error && error.name.startsWith("jazz-error-")) {
+    return error.name.replace("jazz-error-", "") as CoValueErrorState;
+  }
+
+  return "unknown";
+}


### PR DESCRIPTION
Added `getJazzErrorType` helper function to identify the type of Jazz error from an Error object thrown by suspense hooks. 

This enables error boundaries to display appropriate UI based on whether the error is "unauthorized", "unavailable", or "unknown".

