### PR TITLE
fix: broken design-system CI build

### DIFF
--- a/homepage/design-system/package.json
+++ b/homepage/design-system/package.json
@@ -36,6 +36,7 @@
     "@types/node": "^20",
     "@types/react": "catalog:react",
     "@types/react-dom": "catalog:react",
+    "@playwright/test": "^1.52.0",
     "typescript": "catalog:default"
   }
 }

--- a/homepage/pnpm-lock.yaml
+++ b/homepage/pnpm-lock.yaml
@@ -97,6 +97,9 @@ importers:
       '@csstools/postcss-oklab-function':
         specifier: ^3.0.6
         version: 3.0.19(postcss@8.5.6)
+      '@playwright/test':
+        specifier: ^1.52.0
+        version: 1.55.0
       '@types/node':
         specifier: ^20
         version: 20.19.13


### PR DESCRIPTION
# Description

Vercel builds were failing when accessing Next.js files:
```
Error: ENOENT: no such file or directory, lstat '/vercel/path0/homepage/node_modules/.pnpm/next@15.5.8_@playwright+test@1.55.0_react-dom@19.1.0_react@19.1.0__react@19.1.0/node_modules/next/dist/client/components/app-router-headers.js'
```

The reason was that pnpm was creating a separate Next.js installation keyed by peer dependencies (next@15.5.8_@playwright+test@1.55.0_...). Since design-system didn't declare `@playwright/test`, pnpm resolved it transitively, creating an invalid installation.

Solved the issue by adding `@playwright/test` as a devDependency in `homepage/design-system` to match the homepage workspace and satisfy Next.js's peer dependency, ensuring a correct resolution.

I'm guessing this got introduced by the upgrade to vitest 4.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures proper Next.js peer dependency resolution in `design-system` to fix CI/build issues.
> 
> - Adds `@playwright/test` as a `devDependency` in `homepage/design-system/package.json`
> - Updates `pnpm-lock.yaml` to include the resolved Playwright version and associated dependency graph changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 09294d7dbf93a29d10d02a3227281063d9604227. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->