### PR TITLE
Add Linear MCP server configuration

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "linear": {
+      "type": "sse",
+      "url": "https://mcp.linear.app/sse"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `.mcp.json` with Linear MCP server config (SSE transport)
- Enables team members to access Linear issues/projects from Claude Code
- Each team member still needs to complete OAuth auth on first use

## Test plan
- [x] Verified MCP server connects (`claude mcp list` shows ✓ Connected)
- [ ] Team members can run `claude mcp auth linear` to authenticate

🤖 Generated with [Claude Code](https://claude.com/claude-code)