### PR TITLE
Add rust-toolchain.toml for consistent WASM builds

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.90.0"
+targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
## Summary
- Pins Rust 1.90.0 and wasm32-unknown-unknown target
- Ensures all developers produce identical `groove-wasm/pkg` artifacts
- Complements #10 (Cargo.lock) for fully reproducible builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)