### PR TITLE
Account.createAs timeout + onCreate credentials

### DIFF
--- a/.changeset/calm-carpets-swim.md
+++ b/.changeset/calm-carpets-swim.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+createAs now accept waitForSync's timeout option, and returns credentials in onCreate callback

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/AccountSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/AccountSchema.ts
@@ -94,7 +94,31 @@ export class AccountSchema<
     );
   }
 
-  // Create an account via worker, useful to generate controlled accounts from the server
+  /**
+   * Creates a new account as a worker account, useful for generating controlled accounts from a server environment.
+   * This method initializes a new account, applies migrations, invokes the `onCreate` callback, and then shuts down the temporary node to avoid memory leaks.
+   * Returns the created account (loaded on the worker) and its credentials.
+   *
+   * The method internally calls `waitForAllCoValuesSync` on the new account. If many CoValues are created during `onCreate`,
+   * consider adjusting the timeout using the `waitForSyncTimeout` option.
+   *
+   * @param worker - The worker account to create the new account from
+   * @param options.creationProps - The creation properties for the new account
+   * @param options.onCreate - The callback to use to initialize the account after it is created
+   * @param options.waitForSyncTimeout - The timeout for the sync to complete
+   * @returns The credentials and the created account
+   *
+   *
+   * @example
+   * ```ts
+   * const { credentials, account } = await AccountSchema.createAs(worker, {
+   *   creationProps: { name: "My Account" },
+   *   onCreate: async (account, worker, credentials) => {
+   *     account.root.$jazz.owner.addMember(worker, "writer");
+   *   },
+   * });
+   * ```
+   */
   createAs(
     worker: Account,
     options: {

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/AccountSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/AccountSchema.ts
@@ -106,7 +106,7 @@ export class AccountSchema<
    * @param options.creationProps - The creation properties for the new account
    * @param options.onCreate - The callback to use to initialize the account after it is created
    * @param options.waitForSyncTimeout - The timeout for the sync to complete
-   * @returns The credentials and the created account
+   * @returns The credentials and the created account loaded by the worker account
    *
    *
    * @example

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/AccountSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/AccountSchema.ts
@@ -102,7 +102,9 @@ export class AccountSchema<
       onCreate?: (
         account: AccountInstance<Shape>,
         worker: Account,
+        credentials: { accountID: string; accountSecret: AgentSecret },
       ) => Promise<void>;
+      waitForSyncTimeout?: number;
     },
   ): Promise<{
     credentials: {

--- a/packages/jazz-tools/src/tools/tests/account.test.ts
+++ b/packages/jazz-tools/src/tools/tests/account.test.ts
@@ -469,8 +469,9 @@ describe("createAs", () => {
 
     const created = await CustomAccount.createAs(worker, {
       creationProps: { name: "Test Account" },
-      onCreate: async (account, loadedWorker) => {
+      onCreate: async (account, loadedWorker, credentials) => {
         executionOrder.push("onCreate");
+        expect(credentials.accountID).toBe(account.$jazz.id);
 
         // Verify migration ran before onCreate
         expect(executionOrder).toEqual(["migration", "onCreate"]);


### PR DESCRIPTION
# Description
This PR adds a timeout option to `Account.createAs` method and use it in `waitForAllCoValuesSync`. This is needed because in the `onCreate` callback, we can't know what will happen. 

Additionally, the created account's credentials are passed to the `onCreate` callback, as they might be useful inside.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enhances account creation APIs and tests to support initialization hooks with credentials and configurable sync timing.
> 
> - Expands `Account.createAs` to pass `credentials` to `onCreate` and adds `waitForSyncTimeout`, forwarding it to `account.$jazz.waitForAllCoValuesSync({ timeout })`
> - Mirrors these options/signature in `AccountSchema.createAs` with detailed docs and example
> - Updates tests to validate credential propagation, migration-before-`onCreate` ordering, and root modifications from the worker
> - Adds a changeset for a patch release
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 69e23bb3cda62072cc0dfec9c118bca5ac7ebeaa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->