### PR TITLE
chore: set tiptap and prosemirror deps as optional peer deps

### DIFF
--- a/packages/jazz-tools/package.json
+++ b/packages/jazz-tools/package.json
@@ -207,22 +207,14 @@
   "license": "MIT",
   "version": "0.19.18",
   "dependencies": {
-    "@manuscripts/prosemirror-recreate-steps": "^0.1.4",
     "@scure/base": "1.2.1",
     "@scure/bip39": "^1.3.0",
-    "@tiptap/core": "^2.12.0",
     "clsx": "^2.0.0",
     "cojson": "workspace:*",
     "cojson-storage-indexeddb": "workspace:*",
     "cojson-transport-ws": "workspace:*",
     "fast-myers-diff": "^3.2.0",
     "goober": "^2.1.18",
-    "prosemirror-example-setup": "^1.2.2",
-    "prosemirror-menu": "^1.2.4",
-    "prosemirror-model": "^1.21.1",
-    "prosemirror-schema-basic": "^1.2.2",
-    "prosemirror-state": "^1.4.3",
-    "prosemirror-transform": "^1.9.0",
     "use-sync-external-store": "^1.5.0",
     "zod": "4.1.11"
   },
@@ -262,13 +254,20 @@
   },
   "peerDependencies": {
     "@bam.tech/react-native-image-resizer": "*",
+    "@manuscripts/prosemirror-recreate-steps": "^0.1.4",
     "@op-engineering/op-sqlite": "*",
     "@react-native-community/netinfo": "*",
+    "@tiptap/core": "^2.12.0",
     "better-auth": "^1.3.2",
     "expo-file-system": "*",
     "expo-image-manipulator": "*",
     "expo-secure-store": "*",
     "expo-sqlite": "*",
+    "prosemirror-menu": "^1.2.4",
+    "prosemirror-model": "^1.21.1",
+    "prosemirror-schema-basic": "^1.2.2",
+    "prosemirror-state": "^1.4.3",
+    "prosemirror-transform": "^1.9.0",
     "react": "*",
     "react-dom": "*",
     "react-native": "*",
@@ -283,10 +282,16 @@
     "@bam.tech/react-native-image-resizer": {
       "optional": true
     },
+    "@manuscripts/prosemirror-recreate-steps": {
+      "optional": true
+    },
     "@op-engineering/op-sqlite": {
       "optional": true
     },
     "@react-native-community/netinfo": {
+      "optional": true
+    },
+    "@tiptap/core": {
       "optional": true
     },
     "better-auth": {
@@ -302,6 +307,21 @@
       "optional": true
     },
     "expo-sqlite": {
+      "optional": true
+    },
+    "prosemirror-menu": {
+      "optional": true
+    },
+    "prosemirror-model": {
+      "optional": true
+    },
+    "prosemirror-schema-basic": {
+      "optional": true
+    },
+    "prosemirror-state": {
+      "optional": true
+    },
+    "prosemirror-transform": {
       "optional": true
     },
     "react": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2488,9 +2488,6 @@ importers:
       goober:
         specifier: ^2.1.18
         version: 2.1.18(csstype@3.2.3)
-      prosemirror-example-setup:
-        specifier: ^1.2.2
-        version: 1.2.3
       prosemirror-menu:
         specifier: ^1.2.4
         version: 1.2.5


### PR DESCRIPTION
# Description
These package are only required by `jazz-tools/tiptap` and `jazz-tools/prosemirror` integrations, and are causing them to download a lot of packages when not needed.

The `@tiptap/*` and `prosemirror-*` packages being changed probably wont cause issues for existing users since they're quite likely to already be installed. Not sure about `@manuscripts/prosemirror-recreate-steps` though, should this be added to the docs as a package that needs to be installed manually or is that approach not preferable?

I'm sure you may have discussed this probably, but is it being considered at any point in the future to move to separate scoped packages like `@jazz/*`? This would make the dependency management much more straightforward, since even with the optional peer dependencies, packages like `clsx`, `cojson-core-rn`, etc. are still being included when they might not be needed.

This incurs a real cost since `node_modules` with only `jazz-tools` installed is 178Mb currently and slows down builds, deployments, and increases app container image sizes quite a bit.

## Tests

- [ ] Tests have been added and/or updated
- [ ] Tests have not been updated, because: <!-- Insert reason for not updating tests here -->
- [ ] I need help with writing tests


## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [ ] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing