### PR TITLE
Avoid session duplication when authenticating twice

### DIFF
--- a/.changeset/light-apes-hide.md
+++ b/.changeset/light-apes-hide.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Context.authenticate now doesn't replace the context if the same AccountID is already logged in

--- a/packages/jazz-tools/src/tools/implementation/ContextManager.ts
+++ b/packages/jazz-tools/src/tools/implementation/ContextManager.ts
@@ -251,10 +251,30 @@ export class JazzContextManager<
 
   /**
    * Authenticates the user with the given credentials
+   * @param credentials - The credentials to authenticate with
+   * @param forceContextCreation - If true, the context will be created even if the same account is already authenticated
    */
-  authenticate = async (credentials: AuthCredentials) => {
+  authenticate = async (
+    credentials: AuthCredentials,
+    forceContextCreation: boolean = false,
+  ) => {
     if (!this.props) {
       throw new Error("Props required");
+    }
+
+    // Check if already authenticated with the same account
+    // to avoid the creation of a new session
+    if (
+      !forceContextCreation &&
+      this.context &&
+      "me" in this.context &&
+      this.context.me.$jazz.id === credentials.accountID
+    ) {
+      console.log(
+        "Already authenticated with the same account",
+        credentials.accountID,
+      );
+      return;
     }
 
     if (

--- a/packages/jazz-tools/src/tools/tests/ContextManager.test.ts
+++ b/packages/jazz-tools/src/tools/tests/ContextManager.test.ts
@@ -158,6 +158,56 @@ describe("ContextManager", () => {
     expect(getCurrentValue().me.$jazz.id).toBe(credentials.accountID);
   });
 
+  test("authenticating twice with the same credentials should not create a new session", async () => {
+    const account = await createJazzTestAccount();
+
+    // First create an initial context to get credentials
+    await manager.createContext({});
+
+    const credentials = {
+      accountID: account.$jazz.id,
+      accountSecret: account.$jazz.localNode.getCurrentAgent().agentSecret,
+      provider: "test",
+    };
+
+    // Authenticate with those credentials
+    await manager.authenticate(credentials);
+
+    const firstSessionID = getCurrentValue().me.$jazz.sessionID;
+
+    await manager.authenticate(credentials);
+
+    const secondSessionID = getCurrentValue().me.$jazz.sessionID;
+
+    expect(getCurrentValue().me.$jazz.id).toBe(credentials.accountID);
+    expect(secondSessionID).toBe(firstSessionID);
+  });
+
+  test("authenticating twice with the same credentials should create a new session if forced", async () => {
+    const account = await createJazzTestAccount();
+
+    // First create an initial context to get credentials
+    await manager.createContext({});
+
+    const credentials = {
+      accountID: account.$jazz.id,
+      accountSecret: account.$jazz.localNode.getCurrentAgent().agentSecret,
+      provider: "test",
+    };
+
+    // Authenticate with those credentials
+    await manager.authenticate(credentials);
+
+    const firstSessionID = getCurrentValue().me.$jazz.sessionID;
+
+    await manager.authenticate(credentials, true);
+
+    const secondSessionID = getCurrentValue().me.$jazz.sessionID;
+
+    expect(getCurrentValue().me.$jazz.id).toBe(credentials.accountID);
+    expect(secondSessionID).not.toBe(firstSessionID);
+  });
+
   test("calls onLogOut callback when logging out", async () => {
     const onLogOut = vi.fn();
     await manager.createContext({ onLogOut });
@@ -303,11 +353,14 @@ describe("ContextManager", () => {
       >
     ).me;
 
-    await customManager.authenticate({
-      accountID: account.$jazz.id,
-      accountSecret: account.$jazz.localNode.getCurrentAgent().agentSecret,
-      provider: "test",
-    });
+    await customManager.authenticate(
+      {
+        accountID: account.$jazz.id,
+        accountSecret: account.$jazz.localNode.getCurrentAgent().agentSecret,
+        provider: "test",
+      },
+      true,
+    );
 
     // The storage should be closed and set to undefined
     expect(prevContextNode.storage).toBeUndefined();
@@ -407,11 +460,14 @@ describe("ContextManager", () => {
       >
     ).me;
 
-    await customManager.authenticate({
-      accountID: account.$jazz.id,
-      accountSecret: account.$jazz.localNode.getCurrentAgent().agentSecret,
-      provider: "test",
-    });
+    await customManager.authenticate(
+      {
+        accountID: account.$jazz.id,
+        accountSecret: account.$jazz.localNode.getCurrentAgent().agentSecret,
+        provider: "test",
+      },
+      true,
+    );
 
     const me = await CustomAccount.getMe().$jazz.ensureLoaded({
       resolve: { root: true },
@@ -735,12 +791,15 @@ describe("ContextManager", () => {
       const promises = [];
       for (let i = 0; i < 3; i++) {
         promises.push(
-          customManager.authenticate({
-            accountID: account.$jazz.id,
-            accountSecret:
-              account.$jazz.localNode.getCurrentAgent().agentSecret,
-            provider: "test",
-          }),
+          customManager.authenticate(
+            {
+              accountID: account.$jazz.id,
+              accountSecret:
+                account.$jazz.localNode.getCurrentAgent().agentSecret,
+              provider: "test",
+            },
+            true,
+          ),
         );
       }
 

--- a/packages/jazz-tools/src/tools/types.ts
+++ b/packages/jazz-tools/src/tools/types.ts
@@ -8,8 +8,15 @@ export type AuthCredentials = {
   provider?: "anonymous" | "clerk" | "demo" | "passkey" | "passphrase" | string;
 };
 
+/**
+ * Authenticates the user with the given credentials
+ * @param credentials - The credentials to authenticate with
+ * @param forceContextCreation - If true, the context will be created even if the same account is already authenticated
+ * @returns A promise that resolves when the authentication is complete
+ */
 export type AuthenticateAccountFunction = (
   credentials: AuthCredentials,
+  forceContextCreation?: boolean,
 ) => Promise<void>;
 
 export type RegisterAccountFunction = (


### PR DESCRIPTION
# Description
When `ContextManager.authenticate()` was called with the same AccountID of the current user, a new session was always created. Now it is a no-op, unless forced.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents duplicate session creation when calling `ContextManager.authenticate` with the currently logged-in `AccountID`; adds an opt-in override.
> 
> - Extends `authenticate(credentials, forceContextCreation?)` to early-return when the same account is already authenticated; `forceContextCreation=true` forces a new session
> - Updates `AuthenticateAccountFunction` type and JSDoc to include the new flag
> - Adds tests verifying no-op on repeated auth, new session when forced, and updates migration/concurrency tests to use the flag where appropriate
> - Adds a changeset marking a patch release for `jazz-tools`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 41b2cf4ecec90c3ba5125ad77745f3ad6a45fb73. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->