### PR TITLE
fix(tests): avoid closing storage before shutting down test nodes

### DIFF
--- a/packages/cojson/src/tests/sync.garbageCollection.test.ts
+++ b/packages/cojson/src/tests/sync.garbageCollection.test.ts
@@ -1,13 +1,11 @@
-import { assert, beforeEach, describe, expect, test, vi } from "vitest";
+import { beforeEach, describe, expect, test } from "vitest";
 
 import { setGarbageCollectorMaxAge } from "../config";
-import { emptyKnownState } from "../exports";
 import {
   SyncMessagesLog,
   TEST_NODE_CONFIG,
   loadCoValueOrFail,
   setupTestNode,
-  waitFor,
 } from "./testUtils";
 
 // We want to simulate a real world communication that happens asynchronously

--- a/packages/cojson/src/tests/sync.test.ts
+++ b/packages/cojson/src/tests/sync.test.ts
@@ -1,12 +1,4 @@
-import {
-  assert,
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  test,
-  vi,
-} from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { expectMap } from "../coValue.js";
 import { RawCoMap } from "../coValues/coMap.js";
 import { WasmCrypto } from "../crypto/WasmCrypto.js";

--- a/packages/cojson/src/tests/testUtils.ts
+++ b/packages/cojson/src/tests/testUtils.ts
@@ -652,8 +652,8 @@ export async function setupTestAccount(
     connectToSyncServer();
   }
 
-  onTestFinished(() => {
-    ctx.node.gracefulShutdown();
+  onTestFinished(async () => {
+    await ctx.node.gracefulShutdown();
   });
 
   return {


### PR DESCRIPTION
# Description

Started seeing this console errors in tests after merging https://github.com/garden-co/jazz/pull/3320:
```
stderr | src/tests/sync.garbageCollection.test.ts > sync after the garbage collector has run > loading a coValue from the sync server that was removed by the garbage collector
Failed to persist batched unsynced CoValue tracking {
  err: SqliteError: attempt to write a readonly database
      at convertError (/Users/guidodorsi/workspace/jazz/node_modules/libsql/index.js:59:12)
      at Statement.run (/Users/guidodorsi/workspace/jazz/node_modules/libsql/index.js:333:13)
      at LibSQLSqliteSyncDriver.run (/Users/guidodorsi/workspace/jazz/packages/cojson/src/tests/testStorage.ts:67:26)
      at SQLiteClient.trackCoValuesSyncState (/Users/guidodorsi/workspace/jazz/packages/cojson/src/storage/sqlite/client.ts:216:17)
      at StorageApiSync.trackCoValuesSyncState (/Users/guidodorsi/workspace/jazz/packages/cojson/src/storage/storageSync.ts:406:19)
      at /Users/guidodorsi/workspace/jazz/packages/cojson/src/UnsyncedCoValuesTracker.ts:153:17
      at new Promise (<anonymous>)
      at UnsyncedCoValuesTracker.flush (/Users/guidodorsi/workspace/jazz/packages/cojson/src/UnsyncedCoValuesTracker.ts:151:12)
      at UnsyncedCoValuesTracker.forcePersist (/Users/guidodorsi/workspace/jazz/packages/cojson/src/UnsyncedCoValuesTracker.ts:113:17)
      at SyncManager.gracefulShutdown (/Users/guidodorsi/workspace/jazz/packages/cojson/src/sync.ts:1154:33) {
    code: 'SQLITE_READONLY_DBMOVED',
    rawCode: 1032
  }
}
```

They were caused by vitest `onTestFinished` hooks closing storage before the node shutdown was actually completed (which includes tracking the CoValues' sync state in persistent storage).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures test nodes fully flush and persist sync state before storage is closed, preventing readonly DB errors during teardown.
> 
> - Make `onTestFinished` teardown async and `await` `node.gracefulShutdown()` in `testUtils.ts`
> - Remove unused `vitest` and helper imports in `sync.garbageCollection.test.ts` and `sync.test.ts`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c2b02103837c5ddfe6ef5d035a7a3f935f939b2a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->