### PR TITLE
Fix links to Jazz Cloud and Pricing

### DIFF
--- a/examples/chat-svelte/README.md
+++ b/examples/chat-svelte/README.md
@@ -63,6 +63,6 @@ If you have feedback, let us know on [Discord](https://discord.gg/utDMjHYg42) or
 
 ## Configuration: sync server
 
-By default, the example app uses [Jazz Cloud](https://jazz.tools/cloud) (`wss://cloud.jazz.tools`) - so cross-device use, invites and collaboration should just work.
+By default, the example app uses [Jazz Cloud](https://dashboard.jazz.tools) (`wss://cloud.jazz.tools`) - so cross-device use, invites and collaboration should just work.
 
 You can also run a local sync server by running `npx jazz-run sync`, and setting the `sync` parameter of `JazzSvelteProvider` in [./src/routes/+layout.svelte](./src/routes/+layout.svelte) to `{ peer: "ws://localhost:4200" }`.

--- a/examples/chat/README.md
+++ b/examples/chat/README.md
@@ -68,6 +68,6 @@ If you have feedback, let us know on [Discord](https://discord.gg/utDMjHYg42) or
 
 ## Configuration: sync server
 
-By default, the example app uses [Jazz Cloud](https://jazz.tools/cloud) (`wss://cloud.jazz.tools`) - so cross-device use, invites and collaboration should just work.
+By default, the example app uses [Jazz Cloud](https://dashboard.jazz.tools) (`wss://cloud.jazz.tools`) - so cross-device use, invites and collaboration should just work.
 
 You can also run a local sync server by running `npx jazz-run sync`, and setting the `sync` parameter of `JazzReactProvider` in [./src/app.tsx](./src/app.tsx) to `{ peer: "ws://localhost:4200" }`.

--- a/examples/community-chat-vue/README.md
+++ b/examples/community-chat-vue/README.md
@@ -55,6 +55,6 @@ If you have feedback, let us know on [Discord](https://discord.gg/utDMjHYg42) or
 
 ## Configuration: sync server
 
-By default, the example app uses [Jazz Cloud](https://jazz.tools/cloud) (`wss://cloud.jazz.tools`) - so cross-device use, invites and collaboration should just work.
+By default, the example app uses [Jazz Cloud](https://dashboard.jazz.tools) (`wss://cloud.jazz.tools`) - so cross-device use, invites and collaboration should just work.
 
 You can also run a local sync server by running `npx jazz-run sync`, and setting the `sync` parameter of `JazzProvider` in [./src/main.ts](./src/main.ts) to `{ peer: "ws://localhost:4200" }`.

--- a/examples/community-todo-vue/README.md
+++ b/examples/community-todo-vue/README.md
@@ -56,6 +56,6 @@ If you have feedback, let us know on [Discord](https://discord.gg/utDMjHYg42) or
 
 ## Configuration: sync server
 
-By default, the example app uses [Jazz Cloud](https://jazz.tools/cloud) (`wss://cloud.jazz.tools`) - so cross-device use, invites and collaboration should just work.
+By default, the example app uses [Jazz Cloud](https://dashboard.jazz.tools) (`wss://cloud.jazz.tools`) - so cross-device use, invites and collaboration should just work.
 
 You can also run a local sync server by running`npx jazz-run sync`, and setting the `sync` parameter of`JazzProvider` in [./src/main.ts](./src/main.ts) to`{ peer: "ws://localhost:4200" }`.

--- a/examples/filestream/README.md
+++ b/examples/filestream/README.md
@@ -68,9 +68,8 @@ Open [http://localhost:5173](http://localhost:5173) with your browser to see the
 
 If you have feedback, let us know on [Discord](https://discord.gg/utDMjHYg42) or open an issue or PR to fix something that seems wrong.
 
-
 ## Configuration: sync server
 
-By default, the example app uses [Jazz Cloud](https://jazz.tools/cloud) (`wss://cloud.jazz.tools`) - so cross-device use, invites and collaboration should just work.
+By default, the example app uses [Jazz Cloud](https://dashboard.jazz.tools) (`wss://cloud.jazz.tools`) - so cross-device use, invites and collaboration should just work.
 
 You can also run a local sync server by running `npx jazz-run sync`, and setting the `sync` parameter of `JazzReactProvider` in [./src/main.tsx](./src/main.tsx) to `{ peer: "ws://localhost:4200" }`.

--- a/examples/form/README.md
+++ b/examples/form/README.md
@@ -83,6 +83,6 @@ If you have feedback, let us know on [Discord](https://discord.gg/utDMjHYg42) or
 
 ## Configuration: sync server
 
-By default, the example app uses [Jazz Cloud](https://jazz.tools/cloud) (`wss://cloud.jazz.tools`) - so cross-device use, invites and collaboration should just work.
+By default, the example app uses [Jazz Cloud](https://dashboard.jazz.tools) (`wss://cloud.jazz.tools`) - so cross-device use, invites and collaboration should just work.
 
 You can also run a local sync server by running `npx jazz-run sync`, and setting the `sync` parameter of `JazzReactProvider` in [./src/main.tsx](./src/main.tsx) to `{ peer: "ws://localhost:4200" }`.

--- a/examples/image-upload/README.md
+++ b/examples/image-upload/README.md
@@ -71,6 +71,6 @@ If you have feedback, let us know on [Discord](https://discord.gg/utDMjHYg42) or
 
 ## Configuration: sync server
 
-By default, the example app uses [Jazz Cloud](https://jazz.tools/cloud) (`wss://cloud.jazz.tools`) - so cross-device use, invites and collaboration should just work.
+By default, the example app uses [Jazz Cloud](https://dashboard.jazz.tools) (`wss://cloud.jazz.tools`) - so cross-device use, invites and collaboration should just work.
 
 You can also run a local sync server by running `npx jazz-run sync`, and setting the `sync` parameter of `JazzReactProvider` in [./src/main.tsx](./src/main.tsx) to `{ peer: "ws://localhost:4200" }`.

--- a/examples/jazz-sveltekit/README.md
+++ b/examples/jazz-sveltekit/README.md
@@ -63,6 +63,6 @@ If you have feedback, let us know on [Discord](https://discord.gg/utDMjHYg42) or
 
 ## Configuration: sync server
 
-By default, the example app uses [Jazz Cloud](https://jazz.tools/cloud) (`wss://cloud.jazz.tools`) - so cross-device use, invites and collaboration should just work.
+By default, the example app uses [Jazz Cloud](https://dashboard.jazz.tools) (`wss://cloud.jazz.tools`) - so cross-device use, invites and collaboration should just work.
 
 You can also run a local sync server by running `npx jazz-run sync`, and setting the `sync` parameter of `JazzSvelteProvider` in [./src/routes/+layout.svelte](./src/routes/+layout.svelte) and in [./src/lib/jazzSSR.ts](./src/lib/jazzSSR.ts) to `{ peer: "ws://localhost:4200" }`.

--- a/examples/multi-cursors/README.md
+++ b/examples/multi-cursors/README.md
@@ -92,6 +92,6 @@ If you have feedback, let us know on [Discord](https://discord.gg/utDMjHYg42) or
 
 ## Configuration: sync server
 
-By default, the example app uses [Jazz Cloud](https://jazz.tools/cloud) (`wss://cloud.jazz.tools`) - so cross-device use, invites and collaboration should just work.
+By default, the example app uses [Jazz Cloud](https://dashboard.jazz.tools) (`wss://cloud.jazz.tools`) - so cross-device use, invites and collaboration should just work.
 
 You can also run a local sync server by running `npx jazz-run sync`, and setting the `sync` parameter of `JazzReactProvider` in [./src/main.tsx](./src/main.tsx) to `{ peer: "ws://localhost:4200" }`.

--- a/examples/music-player/README.md
+++ b/examples/music-player/README.md
@@ -68,6 +68,6 @@ If you have feedback, let us know on [Discord](https://discord.gg/utDMjHYg42) or
 
 ## Configuration: sync server
 
-By default, the example app uses [Jazz Cloud](https://jazz.tools/cloud) (`wss://cloud.jazz.tools`) - so cross-device use, invites and collaboration should just work.
+By default, the example app uses [Jazz Cloud](https://dashboard.jazz.tools) (`wss://cloud.jazz.tools`) - so cross-device use, invites and collaboration should just work.
 
 You can also run a local sync server by running `npx jazz-run sync`, and setting the `sync` parameter of `JazzReactProvider` in [./src/2_main.tsx](./src/2_main.tsx) to `{ peer: "ws://localhost:4200" }`.

--- a/examples/organization/README.md
+++ b/examples/organization/README.md
@@ -71,7 +71,7 @@ If you have feedback, let us know on [Discord](https://discord.gg/utDMjHYg42) or
 
 ## Configuration: sync server
 
-By default, the example app uses [Jazz Cloud](https://jazz.tools/cloud) (`wss://cloud.jazz.tools`) - so cross-device use, invites and collaboration should just work.
+By default, the example app uses [Jazz Cloud](https://dashboard.jazz.tools) (`wss://cloud.jazz.tools`) - so cross-device use, invites and collaboration should just work.
 
 You can also run a local sync server by running `npx jazz-run sync`, and setting the `sync` parameter of `JazzReactProvider` in [./src/main.tsx](./src/main.tsx) to `{ peer: "ws://localhost:4200" }`.
 

--- a/examples/reactions/README.md
+++ b/examples/reactions/README.md
@@ -68,6 +68,6 @@ If you have feedback, let us know on [Discord](https://discord.gg/utDMjHYg42) or
 
 ## Configuration: sync server
 
-By default, the example app uses [Jazz Cloud](https://jazz.tools/cloud) (`wss://cloud.jazz.tools`) - so cross-device use, invites and collaboration should just work.
+By default, the example app uses [Jazz Cloud](https://dashboard.jazz.tools) (`wss://cloud.jazz.tools`) - so cross-device use, invites and collaboration should just work.
 
 You can also run a local sync server by running`npx jazz-run sync`, and setting the `sync` parameter of`JazzReactProvider` in [./src/main.tsx](./src/main.tsx) to`{ peer: "ws://localhost:4200" }`.

--- a/examples/richtext-prosekit/README.md
+++ b/examples/richtext-prosekit/README.md
@@ -113,7 +113,7 @@ You can extend this example by:
 
 ## Configuration: sync server
 
-By default, the app uses [Jazz Cloud](https://jazz.tools/cloud) (`wss://cloud.jazz.tools`) - so cross-device use, invites and collaboration should just work.
+By default, the app uses [Jazz Cloud](https://dashboard.jazz.tools) (`wss://cloud.jazz.tools`) - so cross-device use, invites and collaboration should just work.
 
 You can also run a local sync server by running`npx jazz-run sync`, and setting the `sync` parameter of`JazzReactProvider` in [./src/main.tsx](./src/main.tsx) to`{ peer: "ws://localhost:4200" }`.
 

--- a/examples/richtext-prosemirror/README.md
+++ b/examples/richtext-prosemirror/README.md
@@ -110,7 +110,7 @@ You can extend this example by:
 
 ## Configuration: sync server
 
-By default, the app uses [Jazz Cloud](https://jazz.tools/cloud) (`wss://cloud.jazz.tools`) - so cross-device use, invites and collaboration should just work.
+By default, the app uses [Jazz Cloud](https://dashboard.jazz.tools) (`wss://cloud.jazz.tools`) - so cross-device use, invites and collaboration should just work.
 
 You can also run a local sync server by running`npx jazz-run sync`, and setting the `sync` parameter of`JazzReactProvider` in [./src/main.tsx](./src/main.tsx) to`{ peer: "ws://localhost:4200" }`.
 

--- a/examples/richtext-tiptap/README.md
+++ b/examples/richtext-tiptap/README.md
@@ -117,7 +117,7 @@ You can extend this example by:
 
 ## Configuration: sync server
 
-By default, the app uses [Jazz Cloud](https://jazz.tools/cloud) (`wss://cloud.jazz.tools`) - so cross-device use, invites and collaboration should just work.
+By default, the app uses [Jazz Cloud](https://dashboard.jazz.tools) (`wss://cloud.jazz.tools`) - so cross-device use, invites and collaboration should just work.
 
 You can also run a local sync server by running`npx jazz-run sync`, and setting the `sync` parameter of`JazzReactProvider` in [./src/main.tsx](./src/main.tsx) to`{ peer: "ws://localhost:4200" }`.
 

--- a/examples/todo/README.md
+++ b/examples/todo/README.md
@@ -85,7 +85,7 @@ Open [http://localhost:5173](http://localhost:5173) with your browser to see the
 
 ### Helpers
 
--   (not yet explained) Creating Invite Links/QR codes with `<InviteButton/>`: [`src/components/InviteButton.tsx`](./src/components/InviteButton.tsx)
+- (not yet explained) Creating Invite Links/QR codes with `<InviteButton/>`: [`src/components/InviteButton.tsx`](./src/components/InviteButton.tsx)
 
 This is the whole Todo List app!
 
@@ -95,6 +95,6 @@ If you have feedback, let us know on [Discord](https://discord.gg/utDMjHYg42) or
 
 ## Configuration: sync server
 
-By default, the example app uses [Jazz Cloud](https://jazz.tools/cloud) (`wss://cloud.jazz.tools`) - so cross-device use, invites and collaboration should just work.
+By default, the example app uses [Jazz Cloud](https://dashboard.jazz.tools) (`wss://cloud.jazz.tools`) - so cross-device use, invites and collaboration should just work.
 
 You can also run a local sync server by running`npx jazz-run sync`, and setting the `sync` parameter of`JazzReactProvider` in [./src/2_main.tsx](./src/2_main.tsx) to`{ peer: "ws://localhost:4200" }`.

--- a/examples/vector-search/README.md
+++ b/examples/vector-search/README.md
@@ -72,7 +72,7 @@ If you have feedback, let us know on [Discord](https://discord.gg/utDMjHYg42) or
 
 ## Configuration: sync server
 
-By default, the example app uses [Jazz Cloud](https://jazz.tools/cloud) (`wss://cloud.jazz.tools`) - so cross-device use, invites and collaboration should just work.
+By default, the example app uses [Jazz Cloud](https://dashboard.jazz.tools) (`wss://cloud.jazz.tools`) - so cross-device use, invites and collaboration should just work.
 
 You can also run a local sync server by running `npx jazz-run sync`, and setting the `sync` parameter of `JazzReactProvider` in [./src/Main.tsx](./src/Main.tsx) to `{ peer: "ws://localhost:4200" }`.
 

--- a/examples/version-history/README.md
+++ b/examples/version-history/README.md
@@ -70,6 +70,6 @@ If you have feedback, let us know on [Discord](https://discord.gg/utDMjHYg42) or
 
 ## Configuration: sync server
 
-By default, the example app uses [Jazz Cloud](https://jazz.tools/cloud) (`wss://cloud.jazz.tools`) - so cross-device use, invites and collaboration should just work.
+By default, the example app uses [Jazz Cloud](https://dashboard.jazz.tools) (`wss://cloud.jazz.tools`) - so cross-device use, invites and collaboration should just work.
 
 You can also run a local sync server by running`npx jazz-run sync`, and setting the `sync` parameter of`JazzReactProvider` in [./src/main.tsx](./src/main.tsx) to`{ peer: "ws://localhost:4200" }`.

--- a/homepage/homepage/content/docs/core-concepts/sync-and-storage.mdx
+++ b/homepage/homepage/content/docs/core-concepts/sync-and-storage.mdx
@@ -58,7 +58,7 @@ Jazz Cloud will
 
 - Jazz Cloud is free during the public alpha, with no strict usage limits
 - We plan to keep a free tier, so you'll always be able to get started with zero setup
-- See [Jazz Cloud pricing](/cloud#pricing) for more details
+- See [Jazz Cloud pricing](/pricing) for more details
 
 ## Self-hosting your sync server
 

--- a/homepage/homepage/content/docs/key-features/authentication/better-auth-database-adapter.mdx
+++ b/homepage/homepage/content/docs/key-features/authentication/better-auth-database-adapter.mdx
@@ -2,7 +2,7 @@ import { Alert, CodeGroup } from "@/components/forMdx";
 
 # Jazz database adapter for Better Auth
 
-The package `jazz-tools/better-auth/database-adapter` is a database adapter for Better Auth based on Jazz. Better Auth's data will be stored in CoValues encrypted by [Server Worker](/docs/server-side/setup), synced on our distributed [cloud infrastructure](/cloud).
+The package `jazz-tools/better-auth/database-adapter` is a database adapter for Better Auth based on Jazz. Better Auth's data will be stored in CoValues encrypted by [Server Worker](/docs/server-side/setup), synced on our distributed [cloud infrastructure](https://dashboard.jazz.tools).
 
 ## Getting started
 

--- a/homepage/homepage/tests/routes.spec.ts
+++ b/homepage/homepage/tests/routes.spec.ts
@@ -16,7 +16,7 @@ test.describe("Top-level pages load", () => {
     expect(response?.ok()).toBeTruthy();
   });
 
-  test("cloud page loads", async ({ page }) => {
+  test.skip("cloud page loads", async ({ page }) => {
     const response = await page.goto("/cloud");
     expect(response?.ok()).toBeTruthy();
   });

--- a/starters/react-passkey-auth/README.md
+++ b/starters/react-passkey-auth/README.md
@@ -41,6 +41,6 @@ If you have feedback, let us know on [Discord](https://discord.gg/utDMjHYg42) or
 
 ## Configuration: sync server
 
-By default, the React starter app uses [Jazz Cloud](https://jazz.tools/cloud) (`wss://cloud.jazz.tools`) - so cross-device use, invites and collaboration should just work.
+By default, the React starter app uses [Jazz Cloud](https://dashboard.jazz.tools) (`wss://cloud.jazz.tools`) - so cross-device use, invites and collaboration should just work.
 
 You can also run a local sync server by running `npx jazz-run sync`, and setting the `sync` parameter of `JazzReactProvider` in [./src/app.tsx](./src/app.tsx) to `{ peer: "ws://localhost:4200" }`.

--- a/starters/svelte-passkey-auth/README.md
+++ b/starters/svelte-passkey-auth/README.md
@@ -41,6 +41,6 @@ If you have feedback, let us know on [Discord](https://discord.gg/utDMjHYg42) or
 
 ## Configuration: sync server
 
-By default, the Svelte starter app uses [Jazz Cloud](https://jazz.tools/cloud) (`wss://cloud.jazz.tools`) - so cross-device use, invites and collaboration should just work.
+By default, the Svelte starter app uses [Jazz Cloud](https://dashboard.jazz.tools) (`wss://cloud.jazz.tools`) - so cross-device use, invites and collaboration should just work.
 
 You can also run a local sync server by running `npx jazz-run sync`, and setting the `sync` parameter of `JazzSvelteProvider` in [./src/routes/+layout.svelte](./src/routes/+layout.svelte) to `{ peer: "ws://localhost:4200" }`.


### PR DESCRIPTION
# Description

The `/cloud` route was hidden in October (redirects to `/` now) but not all links were updated, including those to the pricing page. This PR fixes those, skips the Playwright test for `/cloud` and hopefully helps you guys earn at least $1 more ARR through fixed pricing links 😄

## Manual testing instructions

1. Go to `<preview link>`/docs/react/core-concepts/sync-and-storage#free-public-alpha
- [ ] The hyperlink for "Jazz Cloud pricing" should be `/pricing`

## Tests

- [ ] `"cloud page loads"` test skipped


## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [ ] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Docs/Examples**
> 
> - Replace Jazz Cloud links from `https://jazz.tools/cloud` to `https://dashboard.jazz.tools` across example and starter `README.md`s and Better Auth docs
> - Update pricing reference in `docs/core-concepts/sync-and-storage.mdx` from `/cloud#pricing` to `/pricing`
> 
> **Tests**
> 
> - Skip `"cloud page loads"` Playwright test in `homepage/homepage/tests/routes.spec.ts` since `/cloud` is deprecated
> 
> *Minor:* small README formatting cleanups (e.g., bullet indentation, stray hyphen removal).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 11e9b5631d506bebacb09ace30718b2c860b15f0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->