### PR TITLE
Serialize secretSeed as array in auth header

### DIFF
--- a/.changeset/ba-fix-serialisation.md
+++ b/.changeset/ba-fix-serialisation.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Fix serialisation of secret seed in Better Auth

--- a/packages/jazz-tools/src/better-auth/auth/client.ts
+++ b/packages/jazz-tools/src/better-auth/auth/client.ts
@@ -102,7 +102,9 @@ export const jazzPluginClient = () => {
                 "x-jazz-auth",
                 JSON.stringify({
                   accountID: credentials.accountID,
-                  secretSeed: credentials.secretSeed,
+                  secretSeed: credentials.secretSeed
+                    ? Array.from(credentials.secretSeed)
+                    : undefined,
                   accountSecret: credentials.accountSecret,
                 }),
               );

--- a/packages/jazz-tools/src/better-auth/auth/tests/client.test.ts
+++ b/packages/jazz-tools/src/better-auth/auth/tests/client.test.ts
@@ -1,5 +1,5 @@
 import { createAuthClient } from "better-auth/client";
-import { Account, AuthSecretStorage, co, createJazzContext } from "jazz-tools";
+import { Account, AuthSecretStorage } from "jazz-tools";
 import {
   TestJazzContextManager,
   createJazzTestAccount,

--- a/packages/jazz-tools/src/better-auth/auth/tests/client.test.ts
+++ b/packages/jazz-tools/src/better-auth/auth/tests/client.test.ts
@@ -1,5 +1,5 @@
 import { createAuthClient } from "better-auth/client";
-import type { Account, AuthSecretStorage } from "jazz-tools";
+import { Account, AuthSecretStorage, co, createJazzContext } from "jazz-tools";
 import {
   TestJazzContextManager,
   createJazzTestAccount,
@@ -9,7 +9,6 @@ import {
 import { assert, beforeEach, describe, expect, it, vi } from "vitest";
 import { jazzPluginClient } from "../client.js";
 import { emailOTPClient, genericOAuthClient } from "better-auth/client/plugins";
-
 describe("Better-Auth client plugin", () => {
   let account: Account;
   let jazzContextManager: TestJazzContextManager<Account>;
@@ -153,6 +152,71 @@ describe("Better-Auth client plugin", () => {
       accountID: credentials!.accountID,
       provider: "better-auth",
     });
+  });
+
+  it("should preserve secretSeed over signup", async () => {
+    const secretSeed = new Uint8Array([1, 2, 3]);
+    await authSecretStorage.set({
+      accountID: account.$jazz.id,
+      secretSeed: secretSeed,
+      accountSecret: account.$jazz.localNode.getCurrentAgent().agentSecret,
+      provider: "test",
+    });
+    const credentials = await authSecretStorage.get();
+    assert(credentials, "Jazz credentials are not available");
+    expect(credentials.secretSeed).toBeInstanceOf(Uint8Array);
+
+    customFetchImpl.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          token: "6diDScDDcLJLl3sxAEestZz63mrw9Azy",
+          user: {
+            id: "S6SDKApdnh746gUnP3zujzsEY53tjuTm",
+            email: "test@jazz.dev",
+            name: "Matteo",
+            image: null,
+            emailVerified: false,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          },
+          jazzAuth: {
+            accountID: credentials.accountID,
+            secretSeed: credentials.secretSeed,
+            accountSecret: credentials.accountSecret,
+          },
+        }),
+      ),
+    );
+
+    // Sign up
+    await authClient.signUp.email({
+      email: "test@jazz.dev",
+      password: "12345678",
+      name: "Matteo",
+    });
+
+    expect(customFetchImpl).toHaveBeenCalledTimes(1);
+    expect(customFetchImpl.mock.calls[0]![0].toString()).toBe(
+      "http://localhost:3000/api/auth/sign-up/email",
+    );
+
+    // Verify the credentials have been injected in the request body
+    expect(
+      customFetchImpl.mock.calls[0]![1].headers.get("x-jazz-auth")!,
+    ).toEqual(
+      JSON.stringify({
+        accountID: credentials!.accountID,
+        secretSeed: Array.from(credentials.secretSeed!),
+        accountSecret: credentials!.accountSecret,
+      }),
+    );
+
+    expect(authSecretStorage.isAuthenticated).toBe(true);
+
+    // Verify the profile name has been updated
+    const context = jazzContextManager.getCurrentValue();
+    assert(context && "me" in context);
+    expect(context.me.$jazz.id).toBe(credentials!.accountID);
   });
 
   it("should logout from Jazz after BetterAuth sign-out", async () => {


### PR DESCRIPTION
# Description
Secret Seeds are stored as Uint8Arrays which leads to them being serialised as objects not arrays. This fix ensures they are correctly serialised so that they can be restored on the client (e.g. for passphrase/passkey generation for a BetterAuth user).

## Manual testing instructions
N/A

## Tests

- [x] Tests have been added and/or updated
- [ ] Tests have not been updated, because: <!-- Insert reason for not updating tests here -->
- [ ] I need help with writing tests


## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [x] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing