### PR TITLE
feat: remove error callbacks from subscription API

### DIFF
--- a/.changeset/simplified-subscribe-api.md
+++ b/.changeset/simplified-subscribe-api.md
@@ -1,0 +1,28 @@
+---
+"jazz-tools": minor
+---
+
+Simplified the subscribe API by removing error callbacks (`onError`, `onUnauthorized`, `onUnavailable`).
+
+The subscription listener now receives a `Settled` value that includes both loaded and error states. Use `$isLoaded` to check if the value is loaded, and `$jazz.loadingState` for details about error states (`"unauthorized"`, `"unavailable"`, or `"deleted"`).
+
+**Migration example:**
+
+```ts
+// Before
+MyCoMap.subscribe(id, {
+  onUnavailable: (value) => console.log("Unavailable"),
+  onUnauthorized: (value) => console.log("Unauthorized"),
+}, (value) => {
+  console.log(value.field);
+});
+
+// After
+MyCoMap.subscribe(id, (value) => {
+  if (!value.$isLoaded) {
+    console.log("Error:", value.$jazz.loadingState);
+    return;
+  }
+  console.log(value.field);
+});
+```

--- a/examples/music-player/src/components/WaveformCanvas.tsx
+++ b/examples/music-player/src/components/WaveformCanvas.tsx
@@ -201,10 +201,11 @@ async function renderWaveform(props: WaveformCanvasProps) {
 
   const unsubscribeFromWaveform = MusicTrackWaveform.subscribe(
     waveformId,
-    {},
     (newResult) => {
-      waveformData = newResult.data;
-      draw();
+      if (newResult.$isLoaded) {
+        waveformData = newResult.data;
+        draw();
+      }
     },
   );
 

--- a/homepage/homepage/content/docs/code-snippets/core-concepts/covalues/filestreams/index.ts
+++ b/homepage/homepage/content/docs/code-snippets/core-concepts/covalues/filestreams/index.ts
@@ -171,7 +171,9 @@ if (fileStream.$isLoaded) {
 // #region SubscribeById
 const unsubscribe = co
   .fileStream()
-  .subscribe(fileStreamId, (fileStream: FileStream) => {
+  .subscribe(fileStreamId, (fileStream) => {
+    if (!fileStream.$isLoaded) return; // Handle loading/error states
+
     // Called whenever the FileStream changes
     console.log("FileStream updated");
 

--- a/homepage/homepage/content/docs/code-snippets/core-concepts/covalues/imagedef/index.ts
+++ b/homepage/homepage/content/docs/code-snippets/core-concepts/covalues/imagedef/index.ts
@@ -139,7 +139,9 @@ if (progressiveImage.placeholderDataURL) {
 }
 
 // then listen to the image changes
-progressiveImage.$jazz.subscribe({}, (image) => {
+progressiveImage.$jazz.subscribe((image) => {
+  if (!image.$isLoaded) return; // Handle loading/error states
+
   // @ts-expect-error Issue with typing for catch-all. No runtime impact.
   const bestImage = highestResAvailable(image, 600, 600);
 

--- a/homepage/homepage/content/docs/code-snippets/core-concepts/schemas/accounts-and-migrations/dashboard.ts
+++ b/homepage/homepage/content/docs/code-snippets/core-concepts/schemas/accounts-and-migrations/dashboard.ts
@@ -10,6 +10,7 @@ const unsubscribe = MyAppAccount.getMe().$jazz.subscribe(
     },
   },
   (account) => {
+    if (!account.$isLoaded) return; // Handle loading/error states
     const myNameElement = document.getElementById("my-name");
     if (myNameElement) {
       myNameElement.textContent = account.profile.name;

--- a/homepage/homepage/content/docs/code-snippets/core-concepts/schemas/schemaunions/index.ts
+++ b/homepage/homepage/content/docs/code-snippets/core-concepts/schemas/schemaunions/index.ts
@@ -33,7 +33,8 @@ const widgetId = "";
 const widget = await WidgetUnion.load(widgetId);
 
 // Subscribe to updates
-const unsubscribe = WidgetUnion.subscribe(widgetId, {}, (widget) => {
+const unsubscribe = WidgetUnion.subscribe(widgetId, (widget) => {
+  if (!widget.$isLoaded) return; // Handle loading/error states
   console.log("Widget updated:", widget);
 });
 // #endregion

--- a/homepage/homepage/content/docs/code-snippets/core-concepts/subscription-and-loading/error-handling-in-manual.ts
+++ b/homepage/homepage/content/docs/code-snippets/core-concepts/subscription-and-loading/error-handling-in-manual.ts
@@ -2,11 +2,13 @@ import { Task, Project } from "./schema";
 const taskId = "";
 
 // #region ErrorHandling
-const unsubscribe = Task.subscribe(taskId, {
-  onUnauthorized: (err) => console.error(err),
-  onUnavailable: (err) => console.error(err)
-}, (updatedTask) => {
-  console.log("Updated task:", updatedTask);
+const unsubscribe = Task.subscribe(taskId, (task) => {
+  if (!task.$isLoaded) {
+    // Handle error states
+    console.error("Error loading task:", task.$jazz.loadingState);
+    return;
+  }
+  console.log("Updated task:", task);
 });
 
 // Always clean up when finished

--- a/homepage/homepage/content/docs/code-snippets/core-concepts/subscription-and-loading/index.ts
+++ b/homepage/homepage/content/docs/code-snippets/core-concepts/subscription-and-loading/index.ts
@@ -4,8 +4,9 @@ const taskId = "";
 // #region ManualSubscription
 // Subscribe by ID
 // @ts-expect-error Redeclared
-const unsubscribe = Task.subscribe(taskId, {}, (updatedTask) => {
-  console.log("Updated task:", updatedTask);
+const unsubscribe = Task.subscribe(taskId, (task) => {
+  if (!task.$isLoaded) return; // Handle loading/error states
+  console.log("Updated task:", task);
 });
 
 // Always clean up when finished
@@ -19,8 +20,9 @@ const myTask = Task.create({
 
 // Subscribe using $jazz.subscribe
 // @ts-expect-error Redeclared
-const unsubscribe = myTask.$jazz.subscribe((updatedTask) => {
-  console.log("Updated task:", updatedTask);
+const unsubscribe = myTask.$jazz.subscribe((task) => {
+  if (!task.$isLoaded) return; // Handle loading/error states
+  console.log("Updated task:", task);
 });
 
 // Always clean up when finished

--- a/homepage/homepage/content/docs/code-snippets/index.ts
+++ b/homepage/homepage/content/docs/code-snippets/index.ts
@@ -74,6 +74,8 @@ const unsubscribe = ToDoList.subscribe(
   listId,
   { resolve: { $each: true } },
   (toDoList) => {
+    if (!toDoList.$isLoaded) return; // Handle loading/error states
+
     const addForm = newToDoFormElement(toDoList);
     listContainer.replaceChildren(
       ...toDoList.map((todo) => {

--- a/homepage/homepage/content/docs/core-concepts/subscription-and-loading.mdx
+++ b/homepage/homepage/content/docs/core-concepts/subscription-and-loading.mdx
@@ -75,8 +75,9 @@ You can use the `$isLoaded` field to check whether a CoValue is loaded. For more
 - `"loading"` → The CoValue is still being fetched
 - `"unauthorized"` → The current user doesn't have permission to access this CoValue
 - `"unavailable"` → The CoValue couldn't be found or an error (e.g. a network timeout) occurred while loading
+- `"deleted"` → The CoValue has been permanently deleted
 
-See the examples above for practical demonstrations of how to handle these three states in your application.
+See the examples above for practical demonstrations of how to handle these states in your application.
 
 <ContentByFramework framework={["react", "react-native", "react-native-expo"]}>
 ### Suspense Hooks [!framework=react,react-native,react-native-expo]
@@ -288,7 +289,8 @@ You can also subscribe to an existing CoValue instance using the `$jazz.subscrib
 </CodeGroup>
 
 ### Error handling for manual subscriptions
-You can also pass `onUnauthorized` and `onUnavailable` handlers as options to your subscription which will run reactively whenever the CoValue you're subscribing to is unavailable, or you do not have the appropriate permissions to read it.
+
+The subscription listener receives a `Settled` value that can be either loaded or in an error state. You can check `$isLoaded` to see if the value is ready, and `$jazz.loadingState` for details about why it might not be loaded (e.g., `"unauthorized"`, `"unavailable"`, or `"deleted"`).
 
 <CodeGroup preferWrap>
 ```ts error-handling-in-manual.ts#ErrorHandling

--- a/homepage/homepage/content/docs/upgrade/0-20-0.mdx
+++ b/homepage/homepage/content/docs/upgrade/0-20-0.mdx
@@ -24,6 +24,7 @@ This also helps us speed up the migration of Jazz Core to Rust which will help u
 **NB**: if you use WASM crypto on Edge runtimes, you need to ensure that WASM is available and initialized. See more details at [WASM on Edge runtimes](/docs/react/server-side/setup#wasm-on-edge-runtimes).
 - We have intruduced a way to permanently [delete CoValues](/docs/core-concepts/covalues/deleting). This brings a new `deleted` loading state.
 - You can now only use strings or records of strings as [`unique` parameters](/docs/react/core-concepts/covalues/comaps#uniqueness). This ensures that serialisation is deterministic.
+- The `subscribe` API has been simplified: error callbacks (`onError`, `onUnauthorized`, `onUnavailable`) have been removed, and the listener now receives a `Settled` value that includes both loaded and error states.
 
 ## Breaking changes
 
@@ -197,5 +198,62 @@ export function MyJazzProvider({ children }: { children: React.ReactNode }) {
     </JazzReactNativeProvider>
   );
 }
+```
+</CodeGroup>
+
+### Simplified subscribe API
+
+The `subscribe` API has been simplified. The error callbacks (`onError`, `onUnauthorized`, `onUnavailable`) have been removed, and the listener now receives a `Settled` value that includes both loaded and error states.
+
+A `Settled` value represents a CoValue that has reached a terminal state - either successfully loaded or in an error state (deleted, unavailable, or unauthorized). You can check if the value is loaded using the `$isLoaded` property.
+
+<CodeGroup>
+```ts
+// Before - Using separate error callbacks
+MyCoMap.subscribe(id, {
+  onUnavailable: (value) => {
+    console.log("Value is unavailable");
+  },
+  onUnauthorized: (value) => {
+    console.log("Not authorized to access this value");
+  },
+}, (value) => {
+  // Only called when loaded
+  console.log(value.field);
+});
+
+// After - Using Settled value with $isLoaded check
+MyCoMap.subscribe(id, (value) => {
+  if (!value.$isLoaded) {
+    // Handle error states
+    switch (value.$jazz.loadingState) {
+      case "deleted":
+        console.log("Value was deleted");
+        break;
+      case "unavailable":
+        console.log("Value is unavailable");
+        break;
+      case "unauthorized":
+        console.log("Not authorized to access this value");
+        break;
+    }
+    return;
+  }
+  // Value is loaded
+  console.log(value.field);
+});
+```
+</CodeGroup>
+
+For most use cases, you can simply return early when the value is not loaded:
+
+<CodeGroup>
+```ts
+MyCoMap.subscribe(id, (value) => {
+  if (!value.$isLoaded) return; // Handle loading/error states
+
+  // Work with the loaded value
+  console.log(value.field);
+});
 ```
 </CodeGroup>

--- a/homepage/homepage/content/docs/upgrade/0-20-0.mdx
+++ b/homepage/homepage/content/docs/upgrade/0-20-0.mdx
@@ -24,7 +24,7 @@ This also helps us speed up the migration of Jazz Core to Rust which will help u
 **NB**: if you use WASM crypto on Edge runtimes, you need to ensure that WASM is available and initialized. See more details at [WASM on Edge runtimes](/docs/react/server-side/setup#wasm-on-edge-runtimes).
 - We have intruduced a way to permanently [delete CoValues](/docs/core-concepts/covalues/deleting). This brings a new `deleted` loading state.
 - You can now only use strings or records of strings as [`unique` parameters](/docs/react/core-concepts/covalues/comaps#uniqueness). This ensures that serialisation is deterministic.
-- The `subscribe` API has been simplified: error callbacks (`onError`, `onUnauthorized`, `onUnavailable`) have been removed, and the listener now receives a `Settled` value that includes both loaded and error states.
+- The errors ins `subscribe` API has been made more explicit: error callbacks (`onError`, `onUnauthorized`, `onUnavailable`) have been removed, and the listener now receives a `Settled` value that includes both loaded and error states.
 
 ## Breaking changes
 
@@ -201,7 +201,7 @@ export function MyJazzProvider({ children }: { children: React.ReactNode }) {
 ```
 </CodeGroup>
 
-### Simplified subscribe API
+### More explicit errors in subscribe API
 
 The `subscribe` API has been simplified. The error callbacks (`onError`, `onUnauthorized`, `onUnavailable`) have been removed, and the listener now receives a `Settled` value that includes both loaded and error states.
 

--- a/packages/community-jazz-vue/src/composables.ts
+++ b/packages/community-jazz-vue/src/composables.ts
@@ -215,9 +215,6 @@ export function useCoState<
           {
             resolve: options?.resolve as any,
             loadAs: safeLoadAsAgent,
-            onError: (value) => {
-              updateState(value);
-            },
             syncResolution: true,
           },
           (value: any) => {

--- a/packages/jazz-tools/src/prosemirror/lib/plugin.ts
+++ b/packages/jazz-tools/src/prosemirror/lib/plugin.ts
@@ -57,7 +57,9 @@ export function createJazzPlugin(
       setView(editorView);
 
       if (coRichText) {
-        const unsubscribe = coRichText.$jazz.subscribe(handleCoRichTextChange);
+        const unsubscribe = coRichText.$jazz.subscribe((value) => {
+          if (value.$isLoaded) handleCoRichTextChange(value);
+        });
         return {
           destroy() {
             setView(undefined);

--- a/packages/jazz-tools/src/react-native-core/media/image.tsx
+++ b/packages/jazz-tools/src/react-native-core/media/image.tsx
@@ -130,6 +130,8 @@ export const Image = forwardRef<RNImage, ImageProps>(function Image(
       image?.placeholderDataURL ?? placeholder;
 
     const unsub = image.$jazz.subscribe({}, (update) => {
+      if (!update.$isLoaded) return;
+
       if (lastBestImage === undefined && update.placeholderDataURL) {
         setSrc(update.placeholderDataURL);
         lastBestImage = update.placeholderDataURL;

--- a/packages/jazz-tools/src/svelte/jazz.class.svelte.ts
+++ b/packages/jazz-tools/src/svelte/jazz.class.svelte.ts
@@ -99,9 +99,6 @@ export class CoState<
             // @ts-expect-error The resolve query type isn't compatible with the coValueClassFromCoValueClassOrSchema conversion
             resolve,
             loadAs: agent,
-            onError: (value) => {
-              this.update(value);
-            },
             syncResolution: true,
             unstable_branch: options?.unstable_branch,
           },
@@ -178,9 +175,6 @@ export class AccountCoState<
           {
             resolve,
             loadAs: me,
-            onError: (value) => {
-              this.update(value);
-            },
             syncResolution: true,
             unstable_branch: options?.unstable_branch,
           },

--- a/packages/jazz-tools/src/tools/coValues/account.ts
+++ b/packages/jazz-tools/src/tools/coValues/account.ts
@@ -29,6 +29,7 @@ import {
   InstanceOrPrimitiveOfSchema,
   MaybeLoaded,
   Settled,
+  SubscribeCallback,
   Profile,
   Ref,
   type RefEncoded,
@@ -402,13 +403,13 @@ export class Account extends CoValueBase implements CoValue {
   static subscribe<A extends Account, const R extends RefsToResolve<A> = true>(
     this: CoValueClass<A>,
     id: ID<A>,
-    listener: (value: Settled<Resolved<A, R>>, unsubscribe: () => void) => void,
+    listener: SubscribeCallback<Resolved<A, R>>,
   ): () => void;
   static subscribe<A extends Account, const R extends RefsToResolve<A> = true>(
     this: CoValueClass<A>,
     id: ID<A>,
     options: SubscribeListenerOptions<A, R>,
-    listener: (value: Settled<Resolved<A, R>>, unsubscribe: () => void) => void,
+    listener: SubscribeCallback<Resolved<A, R>>,
   ): () => void;
   static subscribe<A extends Account, const R extends RefsToResolve<A>>(
     this: CoValueClass<A>,
@@ -557,7 +558,7 @@ class AccountJazzApi<A extends Account> extends CoValueJazzApi<A> {
   /** @category Subscription & Loading */
   subscribe<A extends Account, const R extends RefsToResolve<A>>(
     this: AccountJazzApi<A>,
-    listener: (value: Settled<Resolved<A, R>>, unsubscribe: () => void) => void,
+    listener: SubscribeCallback<Resolved<A, R>>,
   ): () => void;
   subscribe<A extends Account, const R extends RefsToResolve<A>>(
     this: AccountJazzApi<A>,
@@ -565,7 +566,7 @@ class AccountJazzApi<A extends Account> extends CoValueJazzApi<A> {
       resolve?: RefsToResolveStrict<A, R>;
       unstable_branch?: BranchDefinition;
     },
-    listener: (value: Settled<Resolved<A, R>>, unsubscribe: () => void) => void,
+    listener: SubscribeCallback<Resolved<A, R>>,
   ): () => void;
   subscribe<A extends Account, const R extends RefsToResolve<A>>(
     this: AccountJazzApi<A>,

--- a/packages/jazz-tools/src/tools/coValues/account.ts
+++ b/packages/jazz-tools/src/tools/coValues/account.ts
@@ -402,13 +402,13 @@ export class Account extends CoValueBase implements CoValue {
   static subscribe<A extends Account, const R extends RefsToResolve<A> = true>(
     this: CoValueClass<A>,
     id: ID<A>,
-    listener: (value: Resolved<A, R>, unsubscribe: () => void) => void,
+    listener: (value: Settled<Resolved<A, R>>, unsubscribe: () => void) => void,
   ): () => void;
   static subscribe<A extends Account, const R extends RefsToResolve<A> = true>(
     this: CoValueClass<A>,
     id: ID<A>,
     options: SubscribeListenerOptions<A, R>,
-    listener: (value: Resolved<A, R>, unsubscribe: () => void) => void,
+    listener: (value: Settled<Resolved<A, R>>, unsubscribe: () => void) => void,
   ): () => void;
   static subscribe<A extends Account, const R extends RefsToResolve<A>>(
     this: CoValueClass<A>,
@@ -557,7 +557,7 @@ class AccountJazzApi<A extends Account> extends CoValueJazzApi<A> {
   /** @category Subscription & Loading */
   subscribe<A extends Account, const R extends RefsToResolve<A>>(
     this: AccountJazzApi<A>,
-    listener: (value: Resolved<A, R>, unsubscribe: () => void) => void,
+    listener: (value: Settled<Resolved<A, R>>, unsubscribe: () => void) => void,
   ): () => void;
   subscribe<A extends Account, const R extends RefsToResolve<A>>(
     this: AccountJazzApi<A>,
@@ -565,7 +565,7 @@ class AccountJazzApi<A extends Account> extends CoValueJazzApi<A> {
       resolve?: RefsToResolveStrict<A, R>;
       unstable_branch?: BranchDefinition;
     },
-    listener: (value: Resolved<A, R>, unsubscribe: () => void) => void,
+    listener: (value: Settled<Resolved<A, R>>, unsubscribe: () => void) => void,
   ): () => void;
   subscribe<A extends Account, const R extends RefsToResolve<A>>(
     this: AccountJazzApi<A>,

--- a/packages/jazz-tools/src/tools/coValues/coFeed.ts
+++ b/packages/jazz-tools/src/tools/coValues/coFeed.ts
@@ -21,6 +21,7 @@ import {
   ID,
   MaybeLoaded,
   Settled,
+  SubscribeCallback,
   LoadedAndRequired,
   unstable_mergeBranch,
   RefsToResolve,
@@ -308,13 +309,13 @@ export class CoFeed<out Item = any> extends CoValueBase implements CoValue {
   static subscribe<F extends CoFeed, const R extends RefsToResolve<F> = true>(
     this: CoValueClass<F>,
     id: ID<F>,
-    listener: (value: Settled<Resolved<F, R>>, unsubscribe: () => void) => void,
+    listener: SubscribeCallback<Resolved<F, R>>,
   ): () => void;
   static subscribe<F extends CoFeed, const R extends RefsToResolve<F> = true>(
     this: CoValueClass<F>,
     id: ID<F>,
     options: SubscribeListenerOptions<F, R>,
-    listener: (value: Settled<Resolved<F, R>>, unsubscribe: () => void) => void,
+    listener: SubscribeCallback<Resolved<F, R>>,
   ): () => void;
   static subscribe<F extends CoFeed, const R extends RefsToResolve<F>>(
     this: CoValueClass<F>,
@@ -417,7 +418,7 @@ export class CoFeedJazzApi<F extends CoFeed> extends CoValueJazzApi<F> {
    */
   subscribe<F extends CoFeed, const R extends RefsToResolve<F>>(
     this: CoFeedJazzApi<F>,
-    listener: (value: Settled<Resolved<F, R>>, unsubscribe: () => void) => void,
+    listener: SubscribeCallback<Resolved<F, R>>,
   ): () => void;
   subscribe<F extends CoFeed, const R extends RefsToResolve<F>>(
     this: CoFeedJazzApi<F>,
@@ -425,7 +426,7 @@ export class CoFeedJazzApi<F extends CoFeed> extends CoValueJazzApi<F> {
       resolve?: RefsToResolveStrict<F, R>;
       unstable_branch?: BranchDefinition;
     },
-    listener: (value: Settled<Resolved<F, R>>, unsubscribe: () => void) => void,
+    listener: SubscribeCallback<Resolved<F, R>>,
   ): () => void;
   subscribe<F extends CoFeed, const R extends RefsToResolve<F>>(
     this: CoFeedJazzApi<F>,
@@ -1031,13 +1032,13 @@ export class FileStream extends CoValueBase implements CoValue {
   static subscribe<F extends FileStream, const R extends RefsToResolve<F>>(
     this: CoValueClass<F>,
     id: ID<F>,
-    listener: (value: Settled<Resolved<F, R>>, unsubscribe: () => void) => void,
+    listener: SubscribeCallback<Resolved<F, R>>,
   ): () => void;
   static subscribe<F extends FileStream, const R extends RefsToResolve<F>>(
     this: CoValueClass<F>,
     id: ID<F>,
     options: SubscribeListenerOptions<F, R>,
-    listener: (value: Settled<Resolved<F, R>>, unsubscribe: () => void) => void,
+    listener: SubscribeCallback<Resolved<F, R>>,
   ): () => void;
   static subscribe<F extends FileStream, const R extends RefsToResolve<F>>(
     this: CoValueClass<F>,

--- a/packages/jazz-tools/src/tools/coValues/coFeed.ts
+++ b/packages/jazz-tools/src/tools/coValues/coFeed.ts
@@ -308,13 +308,13 @@ export class CoFeed<out Item = any> extends CoValueBase implements CoValue {
   static subscribe<F extends CoFeed, const R extends RefsToResolve<F> = true>(
     this: CoValueClass<F>,
     id: ID<F>,
-    listener: (value: Resolved<F, R>, unsubscribe: () => void) => void,
+    listener: (value: Settled<Resolved<F, R>>, unsubscribe: () => void) => void,
   ): () => void;
   static subscribe<F extends CoFeed, const R extends RefsToResolve<F> = true>(
     this: CoValueClass<F>,
     id: ID<F>,
     options: SubscribeListenerOptions<F, R>,
-    listener: (value: Resolved<F, R>, unsubscribe: () => void) => void,
+    listener: (value: Settled<Resolved<F, R>>, unsubscribe: () => void) => void,
   ): () => void;
   static subscribe<F extends CoFeed, const R extends RefsToResolve<F>>(
     this: CoValueClass<F>,
@@ -417,7 +417,7 @@ export class CoFeedJazzApi<F extends CoFeed> extends CoValueJazzApi<F> {
    */
   subscribe<F extends CoFeed, const R extends RefsToResolve<F>>(
     this: CoFeedJazzApi<F>,
-    listener: (value: Resolved<F, R>, unsubscribe: () => void) => void,
+    listener: (value: Settled<Resolved<F, R>>, unsubscribe: () => void) => void,
   ): () => void;
   subscribe<F extends CoFeed, const R extends RefsToResolve<F>>(
     this: CoFeedJazzApi<F>,
@@ -425,7 +425,7 @@ export class CoFeedJazzApi<F extends CoFeed> extends CoValueJazzApi<F> {
       resolve?: RefsToResolveStrict<F, R>;
       unstable_branch?: BranchDefinition;
     },
-    listener: (value: Resolved<F, R>, unsubscribe: () => void) => void,
+    listener: (value: Settled<Resolved<F, R>>, unsubscribe: () => void) => void,
   ): () => void;
   subscribe<F extends CoFeed, const R extends RefsToResolve<F>>(
     this: CoFeedJazzApi<F>,
@@ -1001,12 +1001,16 @@ export class FileStream extends CoValueBase implements CoValue {
       stream.$isLoaded &&
       !stream.isBinaryStreamEnded()
     ) {
-      return new Promise<FileStream>((resolve) => {
+      return new Promise<FileStream>((resolve, reject) => {
         subscribeToCoValueWithoutMe(
           this,
           id,
           options || {},
-          (value, unsubscribe) => {
+          (value, unsubscribe, subscriptionScope) => {
+            if (!value.$isLoaded) {
+              return reject(subscriptionScope.getPromise());
+            }
+
             if (value.isBinaryStreamEnded()) {
               unsubscribe();
               resolve(value);
@@ -1027,13 +1031,13 @@ export class FileStream extends CoValueBase implements CoValue {
   static subscribe<F extends FileStream, const R extends RefsToResolve<F>>(
     this: CoValueClass<F>,
     id: ID<F>,
-    listener: (value: Resolved<F, R>, unsubscribe: () => void) => void,
+    listener: (value: Settled<Resolved<F, R>>, unsubscribe: () => void) => void,
   ): () => void;
   static subscribe<F extends FileStream, const R extends RefsToResolve<F>>(
     this: CoValueClass<F>,
     id: ID<F>,
     options: SubscribeListenerOptions<F, R>,
-    listener: (value: Resolved<F, R>, unsubscribe: () => void) => void,
+    listener: (value: Settled<Resolved<F, R>>, unsubscribe: () => void) => void,
   ): () => void;
   static subscribe<F extends FileStream, const R extends RefsToResolve<F>>(
     this: CoValueClass<F>,
@@ -1063,7 +1067,7 @@ export class FileStreamJazzApi<F extends FileStream> extends CoValueJazzApi<F> {
    */
   subscribe<B extends FileStream>(
     this: FileStreamJazzApi<B>,
-    listener: (value: Resolved<B, true>) => void,
+    listener: (value: Settled<Resolved<B, true>>) => void,
   ): () => void {
     return subscribeToExistingCoValue(this.fileStream, {}, listener);
   }

--- a/packages/jazz-tools/src/tools/coValues/coList.ts
+++ b/packages/jazz-tools/src/tools/coValues/coList.ts
@@ -12,6 +12,7 @@ import {
   ID,
   AsLoaded,
   Settled,
+  SubscribeCallback,
   unstable_mergeBranch,
   RefEncoded,
   RefsToResolve,
@@ -302,13 +303,13 @@ export class CoList<out Item = any>
   static subscribe<L extends CoList, const R extends RefsToResolve<L> = true>(
     this: CoValueClass<L>,
     id: ID<L>,
-    listener: (value: Settled<Resolved<L, R>>, unsubscribe: () => void) => void,
+    listener: SubscribeCallback<Resolved<L, R>>,
   ): () => void;
   static subscribe<L extends CoList, const R extends RefsToResolve<L> = true>(
     this: CoValueClass<L>,
     id: ID<L>,
     options: SubscribeListenerOptions<L, R>,
-    listener: (value: Settled<Resolved<L, R>>, unsubscribe: () => void) => void,
+    listener: SubscribeCallback<Resolved<L, R>>,
   ): () => void;
   static subscribe<L extends CoList, const R extends RefsToResolve<L>>(
     this: CoValueClass<L>,
@@ -790,7 +791,7 @@ export class CoListJazzApi<L extends CoList> extends CoValueJazzApi<L> {
    **/
   subscribe<L extends CoList, const R extends RefsToResolve<L> = true>(
     this: CoListJazzApi<L>,
-    listener: (value: Settled<Resolved<L, R>>, unsubscribe: () => void) => void,
+    listener: SubscribeCallback<Resolved<L, R>>,
   ): () => void;
   subscribe<L extends CoList, const R extends RefsToResolve<L> = true>(
     this: CoListJazzApi<L>,
@@ -798,7 +799,7 @@ export class CoListJazzApi<L extends CoList> extends CoValueJazzApi<L> {
       resolve?: RefsToResolveStrict<L, R>;
       unstable_branch?: BranchDefinition;
     },
-    listener: (value: Settled<Resolved<L, R>>, unsubscribe: () => void) => void,
+    listener: SubscribeCallback<Resolved<L, R>>,
   ): () => void;
   subscribe<L extends CoList, const R extends RefsToResolve<L>>(
     this: CoListJazzApi<L>,

--- a/packages/jazz-tools/src/tools/coValues/coList.ts
+++ b/packages/jazz-tools/src/tools/coValues/coList.ts
@@ -302,13 +302,13 @@ export class CoList<out Item = any>
   static subscribe<L extends CoList, const R extends RefsToResolve<L> = true>(
     this: CoValueClass<L>,
     id: ID<L>,
-    listener: (value: Resolved<L, R>, unsubscribe: () => void) => void,
+    listener: (value: Settled<Resolved<L, R>>, unsubscribe: () => void) => void,
   ): () => void;
   static subscribe<L extends CoList, const R extends RefsToResolve<L> = true>(
     this: CoValueClass<L>,
     id: ID<L>,
     options: SubscribeListenerOptions<L, R>,
-    listener: (value: Resolved<L, R>, unsubscribe: () => void) => void,
+    listener: (value: Settled<Resolved<L, R>>, unsubscribe: () => void) => void,
   ): () => void;
   static subscribe<L extends CoList, const R extends RefsToResolve<L>>(
     this: CoValueClass<L>,
@@ -790,7 +790,7 @@ export class CoListJazzApi<L extends CoList> extends CoValueJazzApi<L> {
    **/
   subscribe<L extends CoList, const R extends RefsToResolve<L> = true>(
     this: CoListJazzApi<L>,
-    listener: (value: Resolved<L, R>, unsubscribe: () => void) => void,
+    listener: (value: Settled<Resolved<L, R>>, unsubscribe: () => void) => void,
   ): () => void;
   subscribe<L extends CoList, const R extends RefsToResolve<L> = true>(
     this: CoListJazzApi<L>,
@@ -798,7 +798,7 @@ export class CoListJazzApi<L extends CoList> extends CoValueJazzApi<L> {
       resolve?: RefsToResolveStrict<L, R>;
       unstable_branch?: BranchDefinition;
     },
-    listener: (value: Resolved<L, R>, unsubscribe: () => void) => void,
+    listener: (value: Settled<Resolved<L, R>>, unsubscribe: () => void) => void,
   ): () => void;
   subscribe<L extends CoList, const R extends RefsToResolve<L>>(
     this: CoListJazzApi<L>,

--- a/packages/jazz-tools/src/tools/coValues/coMap.ts
+++ b/packages/jazz-tools/src/tools/coValues/coMap.ts
@@ -418,13 +418,13 @@ export class CoMap extends CoValueBase implements CoValue {
   static subscribe<M extends CoMap, const R extends RefsToResolve<M> = true>(
     this: CoValueClass<M>,
     id: ID<M>,
-    listener: (value: Resolved<M, R>, unsubscribe: () => void) => void,
+    listener: (value: Settled<Resolved<M, R>>, unsubscribe: () => void) => void,
   ): () => void;
   static subscribe<M extends CoMap, const R extends RefsToResolve<M> = true>(
     this: CoValueClass<M>,
     id: ID<M>,
     options: SubscribeListenerOptions<M, R>,
-    listener: (value: Resolved<M, R>, unsubscribe: () => void) => void,
+    listener: (value: Settled<Resolved<M, R>>, unsubscribe: () => void) => void,
   ): () => void;
   static subscribe<M extends CoMap, const R extends RefsToResolve<M>>(
     this: CoValueClass<M>,
@@ -715,7 +715,10 @@ class CoMapJazzApi<M extends CoMap> extends CoValueJazzApi<M> {
    **/
   subscribe<Map extends CoMap, const R extends RefsToResolve<Map> = true>(
     this: CoMapJazzApi<Map>,
-    listener: (value: Resolved<Map, R>, unsubscribe: () => void) => void,
+    listener: (
+      value: Settled<Resolved<Map, R>>,
+      unsubscribe: () => void,
+    ) => void,
   ): () => void;
   subscribe<Map extends CoMap, const R extends RefsToResolve<Map> = true>(
     this: CoMapJazzApi<Map>,
@@ -723,7 +726,10 @@ class CoMapJazzApi<M extends CoMap> extends CoValueJazzApi<M> {
       resolve?: RefsToResolveStrict<Map, R>;
       unstable_branch?: BranchDefinition;
     },
-    listener: (value: Resolved<Map, R>, unsubscribe: () => void) => void,
+    listener: (
+      value: Settled<Resolved<Map, R>>,
+      unsubscribe: () => void,
+    ) => void,
   ): () => void;
   subscribe<Map extends CoMap, const R extends RefsToResolve<Map>>(
     this: CoMapJazzApi<Map>,

--- a/packages/jazz-tools/src/tools/coValues/coMap.ts
+++ b/packages/jazz-tools/src/tools/coValues/coMap.ts
@@ -19,6 +19,7 @@ import {
   Group,
   ID,
   Settled,
+  SubscribeCallback,
   PartialOnUndefined,
   RefEncoded,
   RefIfCoValue,
@@ -418,13 +419,13 @@ export class CoMap extends CoValueBase implements CoValue {
   static subscribe<M extends CoMap, const R extends RefsToResolve<M> = true>(
     this: CoValueClass<M>,
     id: ID<M>,
-    listener: (value: Settled<Resolved<M, R>>, unsubscribe: () => void) => void,
+    listener: SubscribeCallback<Resolved<M, R>>,
   ): () => void;
   static subscribe<M extends CoMap, const R extends RefsToResolve<M> = true>(
     this: CoValueClass<M>,
     id: ID<M>,
     options: SubscribeListenerOptions<M, R>,
-    listener: (value: Settled<Resolved<M, R>>, unsubscribe: () => void) => void,
+    listener: SubscribeCallback<Resolved<M, R>>,
   ): () => void;
   static subscribe<M extends CoMap, const R extends RefsToResolve<M>>(
     this: CoValueClass<M>,

--- a/packages/jazz-tools/src/tools/coValues/coPlainText.ts
+++ b/packages/jazz-tools/src/tools/coValues/coPlainText.ts
@@ -185,13 +185,19 @@ export class CoPlainText extends String implements CoValue {
   static subscribe<T extends CoPlainText>(
     this: CoValueClass<T>,
     id: ID<T>,
-    listener: (value: Resolved<T, true>, unsubscribe: () => void) => void,
+    listener: (
+      value: Settled<Resolved<T, true>>,
+      unsubscribe: () => void,
+    ) => void,
   ): () => void;
   static subscribe<T extends CoPlainText>(
     this: CoValueClass<T>,
     id: ID<T>,
     options: Omit<SubscribeListenerOptions<T, true>, "resolve">,
-    listener: (value: Resolved<T, true>, unsubscribe: () => void) => void,
+    listener: (
+      value: Settled<Resolved<T, true>>,
+      unsubscribe: () => void,
+    ) => void,
   ): () => void;
   static subscribe<T extends CoPlainText>(
     this: CoValueClass<T>,
@@ -281,7 +287,10 @@ export class CoTextJazzApi<T extends CoPlainText> extends CoValueJazzApi<T> {
    **/
   subscribe<T extends CoPlainText>(
     this: CoTextJazzApi<T>,
-    listener: (value: Resolved<T, true>, unsubscribe: () => void) => void,
+    listener: (
+      value: Settled<Resolved<T, true>>,
+      unsubscribe: () => void,
+    ) => void,
   ): () => void {
     return subscribeToExistingCoValue(this.coText, {}, listener);
   }

--- a/packages/jazz-tools/src/tools/coValues/coVector.ts
+++ b/packages/jazz-tools/src/tools/coValues/coVector.ts
@@ -241,12 +241,16 @@ export class CoVector
      * we can wait for the stream to be complete before returning the vector
      */
     if (!coVector.$isLoaded || !coVector.$jazz.raw.isBinaryStreamEnded()) {
-      return new Promise((resolve) => {
+      return new Promise((resolve, reject) => {
         subscribeToCoValueWithoutMe(
           this,
           id,
           options || {},
-          (value, unsubscribe) => {
+          (value, unsubscribe, subscriptionScope) => {
+            if (!value.$isLoaded) {
+              return reject(subscriptionScope.getPromise());
+            }
+
             if (value.$jazz.raw.isBinaryStreamEnded()) {
               unsubscribe();
               resolve(value);
@@ -341,7 +345,7 @@ export class CoVectorJazzApi<V extends CoVector> extends CoValueJazzApi<V> {
    */
   subscribe<B extends CoVector>(
     this: CoVectorJazzApi<B>,
-    listener: (value: Resolved<B, true>) => void,
+    listener: (value: Settled<Resolved<B, true>>) => void,
   ): () => void {
     return subscribeToExistingCoValue(this.coVector, {}, listener);
   }

--- a/packages/jazz-tools/src/tools/coValues/group.ts
+++ b/packages/jazz-tools/src/tools/coValues/group.ts
@@ -15,6 +15,7 @@ import {
   CoValueClass,
   ID,
   Settled,
+  SubscribeCallback,
   RefEncoded,
   RefsToResolve,
   RefsToResolveStrict,
@@ -296,13 +297,13 @@ export class Group extends CoValueBase implements CoValue {
   static subscribe<G extends Group, const R extends RefsToResolve<G>>(
     this: CoValueClass<G>,
     id: ID<G>,
-    listener: (value: Settled<Resolved<G, R>>, unsubscribe: () => void) => void,
+    listener: SubscribeCallback<Resolved<G, R>>,
   ): () => void;
   static subscribe<G extends Group, const R extends RefsToResolve<G>>(
     this: CoValueClass<G>,
     id: ID<G>,
     options: SubscribeListenerOptions<G, R>,
-    listener: (value: Settled<Resolved<G, R>>, unsubscribe: () => void) => void,
+    listener: SubscribeCallback<Resolved<G, R>>,
   ): () => void;
   static subscribe<G extends Group, const R extends RefsToResolve<G>>(
     this: CoValueClass<G>,
@@ -371,12 +372,12 @@ export class GroupJazzApi<G extends Group> extends CoValueJazzApi<G> {
   /** @category Subscription & Loading */
   subscribe<G extends Group, const R extends RefsToResolve<G>>(
     this: GroupJazzApi<G>,
-    listener: (value: Settled<Resolved<G, R>>, unsubscribe: () => void) => void,
+    listener: SubscribeCallback<Resolved<G, R>>,
   ): () => void;
   subscribe<G extends Group, const R extends RefsToResolve<G>>(
     this: GroupJazzApi<G>,
     options: { resolve?: RefsToResolveStrict<G, R> },
-    listener: (value: Settled<Resolved<G, R>>, unsubscribe: () => void) => void,
+    listener: SubscribeCallback<Resolved<G, R>>,
   ): () => void;
   subscribe<G extends Group, const R extends RefsToResolve<G>>(
     this: GroupJazzApi<G>,

--- a/packages/jazz-tools/src/tools/coValues/group.ts
+++ b/packages/jazz-tools/src/tools/coValues/group.ts
@@ -296,13 +296,13 @@ export class Group extends CoValueBase implements CoValue {
   static subscribe<G extends Group, const R extends RefsToResolve<G>>(
     this: CoValueClass<G>,
     id: ID<G>,
-    listener: (value: Resolved<G, R>, unsubscribe: () => void) => void,
+    listener: (value: Settled<Resolved<G, R>>, unsubscribe: () => void) => void,
   ): () => void;
   static subscribe<G extends Group, const R extends RefsToResolve<G>>(
     this: CoValueClass<G>,
     id: ID<G>,
     options: SubscribeListenerOptions<G, R>,
-    listener: (value: Resolved<G, R>, unsubscribe: () => void) => void,
+    listener: (value: Settled<Resolved<G, R>>, unsubscribe: () => void) => void,
   ): () => void;
   static subscribe<G extends Group, const R extends RefsToResolve<G>>(
     this: CoValueClass<G>,
@@ -371,12 +371,12 @@ export class GroupJazzApi<G extends Group> extends CoValueJazzApi<G> {
   /** @category Subscription & Loading */
   subscribe<G extends Group, const R extends RefsToResolve<G>>(
     this: GroupJazzApi<G>,
-    listener: (value: Resolved<G, R>, unsubscribe: () => void) => void,
+    listener: (value: Settled<Resolved<G, R>>, unsubscribe: () => void) => void,
   ): () => void;
   subscribe<G extends Group, const R extends RefsToResolve<G>>(
     this: GroupJazzApi<G>,
     options: { resolve?: RefsToResolveStrict<G, R> },
-    listener: (value: Resolved<G, R>, unsubscribe: () => void) => void,
+    listener: (value: Settled<Resolved<G, R>>, unsubscribe: () => void) => void,
   ): () => void;
   subscribe<G extends Group, const R extends RefsToResolve<G>>(
     this: GroupJazzApi<G>,

--- a/packages/jazz-tools/src/tools/coValues/interfaces.ts
+++ b/packages/jazz-tools/src/tools/coValues/interfaces.ts
@@ -222,6 +222,15 @@ type SubscribeListener<V extends CoValue, R extends RefsToResolve<V>> = (
   subscriptionScope: SubscriptionScope<V>,
 ) => void;
 
+/**
+ * A listener callback that receives a Settled value (either loaded or in an error state).
+ * Use `$isLoaded` to check if the value is loaded.
+ */
+export type SubscribeCallback<V> = (
+  value: Settled<V>,
+  unsubscribe: () => void,
+) => void;
+
 export type SubscribeListenerOptions<
   V extends CoValue,
   R extends RefsToResolve<V>,

--- a/packages/jazz-tools/src/tools/exports.ts
+++ b/packages/jazz-tools/src/tools/exports.ts
@@ -123,6 +123,7 @@ export {
   type MaybeLoaded,
   type NotLoaded,
   type Loaded,
+  type Settled,
   type BaseAccountShape,
   type DefaultAccountShape,
   type CoreAccountSchema as AnyAccountSchema,

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/AccountSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/AccountSchema.ts
@@ -12,6 +12,7 @@ import {
   Simplify,
   SubscribeListenerOptions,
   unstable_mergeBranchWithResolve,
+  SubscribeCallback,
 } from "../../../internal.js";
 import { AnonymousJazzAgent } from "../../anonymousJazzAgent.js";
 import { InstanceOrPrimitiveOfSchema } from "../typeConverters/InstanceOrPrimitiveOfSchema.js";
@@ -43,6 +44,10 @@ export type DefaultAccountShape = {
   profile: CoMapSchema<BaseProfileShape>;
   root: CoMapSchema<{}>;
 };
+
+type AccountSchemaInstance<Shape extends BaseAccountShape> = Simplify<
+  AccountInstance<Shape>
+>;
 
 export class AccountSchema<
   Shape extends BaseAccountShape = DefaultAccountShape,
@@ -137,41 +142,31 @@ export class AccountSchema<
 
   subscribe<
     const R extends RefsToResolve<
-      Simplify<AccountInstance<Shape>>
+      AccountSchemaInstance<Shape>
       // @ts-expect-error we can't statically enforce the schema's resolve query is a valid resolve query, but in practice it is
     > = DefaultResolveQuery,
   >(
     id: string,
-    listener: (
-      value: Settled<Resolved<Simplify<AccountInstance<Shape>>, R>>,
-      unsubscribe: () => void,
-    ) => void,
+    listener: SubscribeCallback<Resolved<AccountSchemaInstance<Shape>, R>>,
   ): () => void;
   subscribe<
     const R extends RefsToResolve<
-      Simplify<AccountInstance<Shape>>
+      AccountSchemaInstance<Shape>
       // @ts-expect-error we can't statically enforce the schema's resolve query is a valid resolve query, but in practice it is
     > = DefaultResolveQuery,
   >(
     id: string,
-    options: SubscribeListenerOptions<Simplify<AccountInstance<Shape>>, R>,
-    listener: (
-      value: Settled<Resolved<Simplify<AccountInstance<Shape>>, R>>,
-      unsubscribe: () => void,
-    ) => void,
+    options: SubscribeListenerOptions<AccountSchemaInstance<Shape>, R>,
+    listener: SubscribeCallback<Resolved<AccountSchemaInstance<Shape>, R>>,
   ): () => void;
-  subscribe<const R extends RefsToResolve<Simplify<AccountInstance<Shape>>>>(
+  subscribe<const R extends RefsToResolve<AccountSchemaInstance<Shape>>>(
     id: string,
     optionsOrListener:
-      | SubscribeListenerOptions<Simplify<AccountInstance<Shape>>, R>
-      | ((
-          value: Settled<Resolved<Simplify<AccountInstance<Shape>>, R>>,
-          unsubscribe: () => void,
-        ) => void),
-    maybeListener?: (
-      value: Settled<Resolved<Simplify<AccountInstance<Shape>>, R>>,
-      unsubscribe: () => void,
-    ) => void,
+      | SubscribeListenerOptions<AccountSchemaInstance<Shape>, R>
+      | SubscribeCallback<Resolved<AccountSchemaInstance<Shape>, R>>,
+    maybeListener?: SubscribeCallback<
+      Resolved<AccountSchemaInstance<Shape>, R>
+    >,
   ): () => void {
     if (typeof optionsOrListener === "function") {
       return this.coValueClass.subscribe(

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/AccountSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/AccountSchema.ts
@@ -142,17 +142,50 @@ export class AccountSchema<
     > = DefaultResolveQuery,
   >(
     id: string,
+    listener: (
+      value: Settled<Resolved<Simplify<AccountInstance<Shape>>, R>>,
+      unsubscribe: () => void,
+    ) => void,
+  ): () => void;
+  subscribe<
+    const R extends RefsToResolve<
+      Simplify<AccountInstance<Shape>>
+      // @ts-expect-error we can't statically enforce the schema's resolve query is a valid resolve query, but in practice it is
+    > = DefaultResolveQuery,
+  >(
+    id: string,
     options: SubscribeListenerOptions<Simplify<AccountInstance<Shape>>, R>,
     listener: (
-      value: Resolved<Simplify<AccountInstance<Shape>>, R>,
+      value: Settled<Resolved<Simplify<AccountInstance<Shape>>, R>>,
+      unsubscribe: () => void,
+    ) => void,
+  ): () => void;
+  subscribe<const R extends RefsToResolve<Simplify<AccountInstance<Shape>>>>(
+    id: string,
+    optionsOrListener:
+      | SubscribeListenerOptions<Simplify<AccountInstance<Shape>>, R>
+      | ((
+          value: Settled<Resolved<Simplify<AccountInstance<Shape>>, R>>,
+          unsubscribe: () => void,
+        ) => void),
+    maybeListener?: (
+      value: Settled<Resolved<Simplify<AccountInstance<Shape>>, R>>,
       unsubscribe: () => void,
     ) => void,
   ): () => void {
+    if (typeof optionsOrListener === "function") {
+      return this.coValueClass.subscribe(
+        id,
+        withSchemaResolveQuery({}, this.resolveQuery),
+        // @ts-expect-error
+        optionsOrListener,
+      );
+    }
     return this.coValueClass.subscribe(
       id,
       // @ts-expect-error
-      withSchemaResolveQuery(options, this.resolveQuery),
-      listener,
+      withSchemaResolveQuery(optionsOrListener, this.resolveQuery),
+      maybeListener,
     );
   }
 

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoDiscriminatedUnionSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoDiscriminatedUnionSchema.ts
@@ -108,23 +108,85 @@ export class CoDiscriminatedUnionSchema<
     > = DefaultResolveQuery,
   >(
     id: string,
+    listener: (
+      value: Settled<
+        Resolved<
+          CoDiscriminatedUnionInstanceCoValuesMaybeLoaded<Options> &
+            SchemaUnion,
+          R
+        >
+      >,
+      unsubscribe: () => void,
+    ) => void,
+  ): () => void;
+  subscribe<
+    const R extends RefsToResolve<
+      CoDiscriminatedUnionInstanceCoValuesMaybeLoaded<Options> & SchemaUnion
+      // @ts-expect-error
+    > = DefaultResolveQuery,
+  >(
+    id: string,
     options: SubscribeListenerOptions<
       CoDiscriminatedUnionInstanceCoValuesMaybeLoaded<Options> & SchemaUnion,
       R
     >,
     listener: (
-      value: Resolved<
-        CoDiscriminatedUnionInstanceCoValuesMaybeLoaded<Options> & SchemaUnion,
-        R
+      value: Settled<
+        Resolved<
+          CoDiscriminatedUnionInstanceCoValuesMaybeLoaded<Options> &
+            SchemaUnion,
+          R
+        >
+      >,
+      unsubscribe: () => void,
+    ) => void,
+  ): () => void;
+  subscribe<
+    const R extends RefsToResolve<
+      CoDiscriminatedUnionInstanceCoValuesMaybeLoaded<Options> & SchemaUnion
+    >,
+  >(
+    id: string,
+    optionsOrListener:
+      | SubscribeListenerOptions<
+          CoDiscriminatedUnionInstanceCoValuesMaybeLoaded<Options> &
+            SchemaUnion,
+          R
+        >
+      | ((
+          value: Settled<
+            Resolved<
+              CoDiscriminatedUnionInstanceCoValuesMaybeLoaded<Options> &
+                SchemaUnion,
+              R
+            >
+          >,
+          unsubscribe: () => void,
+        ) => void),
+    maybeListener?: (
+      value: Settled<
+        Resolved<
+          CoDiscriminatedUnionInstanceCoValuesMaybeLoaded<Options> &
+            SchemaUnion,
+          R
+        >
       >,
       unsubscribe: () => void,
     ) => void,
   ): () => void {
-    // @ts-expect-error
+    if (typeof optionsOrListener === "function") {
+      return this.coValueClass.subscribe(
+        id,
+        withSchemaResolveQuery({}, this.resolveQuery),
+        // @ts-expect-error
+        optionsOrListener,
+      );
+    }
     return this.coValueClass.subscribe(
       id,
-      withSchemaResolveQuery(options, this.resolveQuery),
-      listener,
+      // @ts-expect-error
+      withSchemaResolveQuery(optionsOrListener, this.resolveQuery),
+      maybeListener,
     );
   }
 

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoDiscriminatedUnionSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoDiscriminatedUnionSchema.ts
@@ -1,16 +1,17 @@
 import {
   Account,
   AnonymousJazzAgent,
-  LoadedAndRequired,
   BranchDefinition,
   InstanceOfSchema,
   InstanceOrPrimitiveOfSchemaCoValuesMaybeLoaded,
-  Settled,
+  LoadedAndRequired,
   RefsToResolve,
   RefsToResolveStrict,
   Resolved,
   SchemaUnion,
   SchemaUnionConcreteSubclass,
+  Settled,
+  SubscribeCallback,
   SubscribeListenerOptions,
   coOptionalDefiner,
 } from "../../../internal.js";
@@ -38,6 +39,10 @@ export type DiscriminableCoValueSchemas = [
   DiscriminableCoreCoValueSchema,
   ...DiscriminableCoreCoValueSchema[],
 ];
+
+type CoDiscriminatedUnionSchemaInstance<
+  Options extends DiscriminableCoValueSchemas,
+> = CoDiscriminatedUnionInstanceCoValuesMaybeLoaded<Options> & SchemaUnion;
 
 export interface CoreCoDiscriminatedUnionSchema<
   Options extends DiscriminableCoValueSchemas = DiscriminableCoValueSchemas,
@@ -108,16 +113,9 @@ export class CoDiscriminatedUnionSchema<
     > = DefaultResolveQuery,
   >(
     id: string,
-    listener: (
-      value: Settled<
-        Resolved<
-          CoDiscriminatedUnionInstanceCoValuesMaybeLoaded<Options> &
-            SchemaUnion,
-          R
-        >
-      >,
-      unsubscribe: () => void,
-    ) => void,
+    listener: SubscribeCallback<
+      Resolved<CoDiscriminatedUnionSchemaInstance<Options>, R>
+    >,
   ): () => void;
   subscribe<
     const R extends RefsToResolve<
@@ -130,16 +128,9 @@ export class CoDiscriminatedUnionSchema<
       CoDiscriminatedUnionInstanceCoValuesMaybeLoaded<Options> & SchemaUnion,
       R
     >,
-    listener: (
-      value: Settled<
-        Resolved<
-          CoDiscriminatedUnionInstanceCoValuesMaybeLoaded<Options> &
-            SchemaUnion,
-          R
-        >
-      >,
-      unsubscribe: () => void,
-    ) => void,
+    listener: SubscribeCallback<
+      Resolved<CoDiscriminatedUnionSchemaInstance<Options>, R>
+    >,
   ): () => void;
   subscribe<
     const R extends RefsToResolve<
@@ -153,26 +144,12 @@ export class CoDiscriminatedUnionSchema<
             SchemaUnion,
           R
         >
-      | ((
-          value: Settled<
-            Resolved<
-              CoDiscriminatedUnionInstanceCoValuesMaybeLoaded<Options> &
-                SchemaUnion,
-              R
-            >
-          >,
-          unsubscribe: () => void,
-        ) => void),
-    maybeListener?: (
-      value: Settled<
-        Resolved<
-          CoDiscriminatedUnionInstanceCoValuesMaybeLoaded<Options> &
-            SchemaUnion,
-          R
-        >
-      >,
-      unsubscribe: () => void,
-    ) => void,
+      | SubscribeCallback<
+          Resolved<CoDiscriminatedUnionSchemaInstance<Options>, R>
+        >,
+    maybeListener?: SubscribeCallback<
+      Resolved<CoDiscriminatedUnionSchemaInstance<Options>, R>
+    >,
   ): () => void {
     if (typeof optionsOrListener === "function") {
       return this.coValueClass.subscribe(

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoListSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoListSchema.ts
@@ -5,10 +5,11 @@ import {
   Group,
   hydrateCoreCoValueSchema,
   ID,
-  Settled,
   RefsToResolve,
   RefsToResolveStrict,
   Resolved,
+  Settled,
+  SubscribeCallback,
   SubscribeListenerOptions,
   coOptionalDefiner,
   unstable_mergeBranchWithResolve,
@@ -131,10 +132,9 @@ export class CoListSchema<
     > = DefaultResolveQuery,
   >(
     id: string,
-    listener: (
-      value: Settled<Resolved<CoListInstanceCoValuesMaybeLoaded<T>, R>>,
-      unsubscribe: () => void,
-    ) => void,
+    listener: SubscribeCallback<
+      Resolved<CoListInstanceCoValuesMaybeLoaded<T>, R>
+    >,
   ): () => void;
   subscribe<
     const R extends RefsToResolve<
@@ -143,10 +143,9 @@ export class CoListSchema<
   >(
     id: string,
     options: SubscribeListenerOptions<CoListInstanceCoValuesMaybeLoaded<T>, R>,
-    listener: (
-      value: Settled<Resolved<CoListInstanceCoValuesMaybeLoaded<T>, R>>,
-      unsubscribe: () => void,
-    ) => void,
+    listener: SubscribeCallback<
+      Resolved<CoListInstanceCoValuesMaybeLoaded<T>, R>
+    >,
   ): () => void;
   subscribe<
     const R extends RefsToResolve<CoListInstanceCoValuesMaybeLoaded<T>>,
@@ -154,14 +153,10 @@ export class CoListSchema<
     id: string,
     optionsOrListener:
       | SubscribeListenerOptions<CoListInstanceCoValuesMaybeLoaded<T>, R>
-      | ((
-          value: Settled<Resolved<CoListInstanceCoValuesMaybeLoaded<T>, R>>,
-          unsubscribe: () => void,
-        ) => void),
-    maybeListener?: (
-      value: Settled<Resolved<CoListInstanceCoValuesMaybeLoaded<T>, R>>,
-      unsubscribe: () => void,
-    ) => void,
+      | SubscribeCallback<Resolved<CoListInstanceCoValuesMaybeLoaded<T>, R>>,
+    maybeListener?: SubscribeCallback<
+      Resolved<CoListInstanceCoValuesMaybeLoaded<T>, R>
+    >,
   ): () => void {
     if (typeof optionsOrListener === "function") {
       return this.coValueClass.subscribe(

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoListSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoListSchema.ts
@@ -131,16 +131,49 @@ export class CoListSchema<
     > = DefaultResolveQuery,
   >(
     id: string,
+    listener: (
+      value: Settled<Resolved<CoListInstanceCoValuesMaybeLoaded<T>, R>>,
+      unsubscribe: () => void,
+    ) => void,
+  ): () => void;
+  subscribe<
+    const R extends RefsToResolve<
+      CoListInstanceCoValuesMaybeLoaded<T>
+    > = DefaultResolveQuery,
+  >(
+    id: string,
     options: SubscribeListenerOptions<CoListInstanceCoValuesMaybeLoaded<T>, R>,
     listener: (
-      value: Resolved<CoListInstanceCoValuesMaybeLoaded<T>, R>,
+      value: Settled<Resolved<CoListInstanceCoValuesMaybeLoaded<T>, R>>,
+      unsubscribe: () => void,
+    ) => void,
+  ): () => void;
+  subscribe<
+    const R extends RefsToResolve<CoListInstanceCoValuesMaybeLoaded<T>>,
+  >(
+    id: string,
+    optionsOrListener:
+      | SubscribeListenerOptions<CoListInstanceCoValuesMaybeLoaded<T>, R>
+      | ((
+          value: Settled<Resolved<CoListInstanceCoValuesMaybeLoaded<T>, R>>,
+          unsubscribe: () => void,
+        ) => void),
+    maybeListener?: (
+      value: Settled<Resolved<CoListInstanceCoValuesMaybeLoaded<T>, R>>,
       unsubscribe: () => void,
     ) => void,
   ): () => void {
+    if (typeof optionsOrListener === "function") {
+      return this.coValueClass.subscribe(
+        id,
+        withSchemaResolveQuery({}, this.resolveQuery),
+        optionsOrListener,
+      );
+    }
     return this.coValueClass.subscribe(
       id,
-      withSchemaResolveQuery(options, this.resolveQuery),
-      listener,
+      withSchemaResolveQuery(optionsOrListener, this.resolveQuery),
+      maybeListener!,
     );
   }
 

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoMapSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoMapSchema.ts
@@ -6,10 +6,11 @@ import {
   DiscriminableCoValueSchemaDefinition,
   DiscriminableCoreCoValueSchema,
   Group,
-  Settled,
   RefsToResolve,
   RefsToResolveStrict,
   Resolved,
+  Settled,
+  SubscribeCallback,
   Simplify,
   SubscribeListenerOptions,
   coMapDefiner,
@@ -32,6 +33,11 @@ import {
   DEFAULT_SCHEMA_PERMISSIONS,
   SchemaPermissions,
 } from "../schemaPermissions.js";
+
+type CoMapSchemaInstance<Shape extends z.core.$ZodLooseShape> = Simplify<
+  CoMapInstanceCoValuesMaybeLoaded<Shape>
+> &
+  CoMap;
 
 export class CoMapSchema<
   Shape extends z.core.$ZodLooseShape,
@@ -97,25 +103,18 @@ export class CoMapSchema<
 
   load<
     const R extends RefsToResolve<
-      Simplify<CoMapInstanceCoValuesMaybeLoaded<Shape>> & CoMap
+      CoMapSchemaInstance<Shape>
       // @ts-expect-error
     > = DefaultResolveQuery,
   >(
     id: string,
     options?: {
-      resolve?: RefsToResolveStrict<
-        Simplify<CoMapInstanceCoValuesMaybeLoaded<Shape>> & CoMap,
-        R
-      >;
+      resolve?: RefsToResolveStrict<CoMapSchemaInstance<Shape>, R>;
       loadAs?: Account | AnonymousJazzAgent;
       skipRetry?: boolean;
       unstable_branch?: BranchDefinition;
     },
-  ): Promise<
-    Settled<
-      Resolved<Simplify<CoMapInstanceCoValuesMaybeLoaded<Shape>> & CoMap, R>
-    >
-  > {
+  ): Promise<Settled<Resolved<CoMapSchemaInstance<Shape>, R>>> {
     // @ts-expect-error
     return this.coValueClass.load(
       id,
@@ -126,16 +125,13 @@ export class CoMapSchema<
 
   unstable_merge<
     const R extends RefsToResolve<
-      Simplify<CoMapInstanceCoValuesMaybeLoaded<Shape>> & CoMap
+      CoMapSchemaInstance<Shape>
       // @ts-expect-error we can't statically enforce the schema's resolve query is a valid resolve query, but in practice it is
     > = DefaultResolveQuery,
   >(
     id: string,
     options: {
-      resolve?: RefsToResolveStrict<
-        Simplify<CoMapInstanceCoValuesMaybeLoaded<Shape>> & CoMap,
-        R
-      >;
+      resolve?: RefsToResolveStrict<CoMapSchemaInstance<Shape>, R>;
       loadAs?: Account | AnonymousJazzAgent;
       branch: BranchDefinition;
     },
@@ -150,62 +146,29 @@ export class CoMapSchema<
 
   subscribe<
     const R extends RefsToResolve<
-      Simplify<CoMapInstanceCoValuesMaybeLoaded<Shape>> & CoMap
+      CoMapSchemaInstance<Shape>
       // @ts-expect-error we can't statically enforce the schema's resolve query is a valid resolve query, but in practice it is
     > = DefaultResolveQuery,
   >(
     id: string,
-    listener: (
-      value: Settled<
-        Resolved<Simplify<CoMapInstanceCoValuesMaybeLoaded<Shape>> & CoMap, R>
-      >,
-      unsubscribe: () => void,
-    ) => void,
+    listener: SubscribeCallback<Resolved<CoMapSchemaInstance<Shape>, R>>,
   ): () => void;
   subscribe<
     const R extends RefsToResolve<
-      Simplify<CoMapInstanceCoValuesMaybeLoaded<Shape>> & CoMap
+      CoMapSchemaInstance<Shape>
       // @ts-expect-error we can't statically enforce the schema's resolve query is a valid resolve query, but in practice it is
     > = DefaultResolveQuery,
   >(
     id: string,
-    options: SubscribeListenerOptions<
-      Simplify<CoMapInstanceCoValuesMaybeLoaded<Shape>> & CoMap,
-      R
-    >,
-    listener: (
-      value: Settled<
-        Resolved<Simplify<CoMapInstanceCoValuesMaybeLoaded<Shape>> & CoMap, R>
-      >,
-      unsubscribe: () => void,
-    ) => void,
+    options: SubscribeListenerOptions<CoMapSchemaInstance<Shape>, R>,
+    listener: SubscribeCallback<Resolved<CoMapSchemaInstance<Shape>, R>>,
   ): () => void;
-  subscribe<
-    const R extends RefsToResolve<
-      Simplify<CoMapInstanceCoValuesMaybeLoaded<Shape>> & CoMap
-    >,
-  >(
+  subscribe<const R extends RefsToResolve<CoMapSchemaInstance<Shape>>>(
     id: string,
     optionsOrListener:
-      | SubscribeListenerOptions<
-          Simplify<CoMapInstanceCoValuesMaybeLoaded<Shape>> & CoMap,
-          R
-        >
-      | ((
-          value: Settled<
-            Resolved<
-              Simplify<CoMapInstanceCoValuesMaybeLoaded<Shape>> & CoMap,
-              R
-            >
-          >,
-          unsubscribe: () => void,
-        ) => void),
-    maybeListener?: (
-      value: Settled<
-        Resolved<Simplify<CoMapInstanceCoValuesMaybeLoaded<Shape>> & CoMap, R>
-      >,
-      unsubscribe: () => void,
-    ) => void,
+      | SubscribeListenerOptions<CoMapSchemaInstance<Shape>, R>
+      | SubscribeCallback<Resolved<CoMapSchemaInstance<Shape>, R>>,
+    maybeListener?: SubscribeCallback<Resolved<CoMapSchemaInstance<Shape>, R>>,
   ): () => void {
     if (typeof optionsOrListener === "function") {
       // @ts-expect-error
@@ -234,22 +197,15 @@ export class CoMapSchema<
 
   upsertUnique<
     const R extends RefsToResolve<
-      Simplify<CoMapInstanceCoValuesMaybeLoaded<Shape>> & CoMap
+      CoMapSchemaInstance<Shape>
       // @ts-expect-error we can't statically enforce the schema's resolve query is a valid resolve query, but in practice it is
     > = DefaultResolveQuery,
   >(options: {
     value: Simplify<CoMapSchemaInit<Shape>>;
     unique: CoValueUniqueness["uniqueness"];
     owner: Owner;
-    resolve?: RefsToResolveStrict<
-      Simplify<CoMapInstanceCoValuesMaybeLoaded<Shape>> & CoMap,
-      R
-    >;
-  }): Promise<
-    Settled<
-      Resolved<Simplify<CoMapInstanceCoValuesMaybeLoaded<Shape>> & CoMap, R>
-    >
-  > {
+    resolve?: RefsToResolveStrict<CoMapSchemaInstance<Shape>, R>;
+  }): Promise<Settled<Resolved<CoMapSchemaInstance<Shape>, R>>> {
     // @ts-expect-error
     return this.coValueClass.upsertUnique(
       // @ts-expect-error
@@ -259,24 +215,17 @@ export class CoMapSchema<
 
   loadUnique<
     const R extends RefsToResolve<
-      Simplify<CoMapInstanceCoValuesMaybeLoaded<Shape>> & CoMap
+      CoMapSchemaInstance<Shape>
       // @ts-expect-error we can't statically enforce the schema's resolve query is a valid resolve query, but in practice it is
     > = DefaultResolveQuery,
   >(
     unique: CoValueUniqueness["uniqueness"],
     ownerID: string,
     options?: {
-      resolve?: RefsToResolveStrict<
-        Simplify<CoMapInstanceCoValuesMaybeLoaded<Shape>> & CoMap,
-        R
-      >;
+      resolve?: RefsToResolveStrict<CoMapSchemaInstance<Shape>, R>;
       loadAs?: Account | AnonymousJazzAgent;
     },
-  ): Promise<
-    Settled<
-      Resolved<Simplify<CoMapInstanceCoValuesMaybeLoaded<Shape>> & CoMap, R>
-    >
-  > {
+  ): Promise<Settled<Resolved<CoMapSchemaInstance<Shape>, R>>> {
     // @ts-expect-error
     return this.coValueClass.loadUnique(
       unique,
@@ -311,12 +260,7 @@ export class CoMapSchema<
   }
 
   withMigration(
-    migration: (
-      value: Resolved<
-        Simplify<CoMapInstanceCoValuesMaybeLoaded<Shape>> & CoMap,
-        true
-      >,
-    ) => undefined,
+    migration: (value: Resolved<CoMapSchemaInstance<Shape>, true>) => undefined,
   ): this {
     // @ts-expect-error avoid exposing 'migrate' at the type level
     this.coValueClass.prototype.migrate = migration;
@@ -393,15 +337,8 @@ export class CoMapSchema<
    * Adds a default resolve query to be used when loading instances of this schema.
    * This resolve query will be used when no resolve query is provided to the load method.
    */
-  resolved<
-    const R extends RefsToResolve<
-      Simplify<CoMapInstanceCoValuesMaybeLoaded<Shape>> & CoMap
-    > = true,
-  >(
-    resolveQuery: RefsToResolveStrict<
-      Simplify<CoMapInstanceCoValuesMaybeLoaded<Shape>> & CoMap,
-      R
-    >,
+  resolved<const R extends RefsToResolve<CoMapSchemaInstance<Shape>> = true>(
+    resolveQuery: RefsToResolveStrict<CoMapSchemaInstance<Shape>, R>,
   ): CoMapSchema<Shape, CatchAll, Owner, R> {
     return this.copy({ resolveQuery: resolveQuery as R });
   }

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoMapSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoMapSchema.ts
@@ -155,23 +155,71 @@ export class CoMapSchema<
     > = DefaultResolveQuery,
   >(
     id: string,
+    listener: (
+      value: Settled<
+        Resolved<Simplify<CoMapInstanceCoValuesMaybeLoaded<Shape>> & CoMap, R>
+      >,
+      unsubscribe: () => void,
+    ) => void,
+  ): () => void;
+  subscribe<
+    const R extends RefsToResolve<
+      Simplify<CoMapInstanceCoValuesMaybeLoaded<Shape>> & CoMap
+      // @ts-expect-error we can't statically enforce the schema's resolve query is a valid resolve query, but in practice it is
+    > = DefaultResolveQuery,
+  >(
+    id: string,
     options: SubscribeListenerOptions<
       Simplify<CoMapInstanceCoValuesMaybeLoaded<Shape>> & CoMap,
       R
     >,
     listener: (
-      value: Resolved<
-        Simplify<CoMapInstanceCoValuesMaybeLoaded<Shape>> & CoMap,
-        R
+      value: Settled<
+        Resolved<Simplify<CoMapInstanceCoValuesMaybeLoaded<Shape>> & CoMap, R>
+      >,
+      unsubscribe: () => void,
+    ) => void,
+  ): () => void;
+  subscribe<
+    const R extends RefsToResolve<
+      Simplify<CoMapInstanceCoValuesMaybeLoaded<Shape>> & CoMap
+    >,
+  >(
+    id: string,
+    optionsOrListener:
+      | SubscribeListenerOptions<
+          Simplify<CoMapInstanceCoValuesMaybeLoaded<Shape>> & CoMap,
+          R
+        >
+      | ((
+          value: Settled<
+            Resolved<
+              Simplify<CoMapInstanceCoValuesMaybeLoaded<Shape>> & CoMap,
+              R
+            >
+          >,
+          unsubscribe: () => void,
+        ) => void),
+    maybeListener?: (
+      value: Settled<
+        Resolved<Simplify<CoMapInstanceCoValuesMaybeLoaded<Shape>> & CoMap, R>
       >,
       unsubscribe: () => void,
     ) => void,
   ): () => void {
+    if (typeof optionsOrListener === "function") {
+      // @ts-expect-error
+      return this.coValueClass.subscribe(
+        id,
+        withSchemaResolveQuery({}, this.resolveQuery),
+        optionsOrListener,
+      );
+    }
     // @ts-expect-error
     return this.coValueClass.subscribe(
       id,
-      withSchemaResolveQuery(options, this.resolveQuery),
-      listener,
+      withSchemaResolveQuery(optionsOrListener, this.resolveQuery),
+      maybeListener,
     );
   }
 

--- a/packages/jazz-tools/src/tools/tests/coDiscriminatedUnion.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coDiscriminatedUnion.test.ts
@@ -350,6 +350,7 @@ describe("co.discriminatedUnion", () => {
     const spy = vi.fn((pet) => updates.push(pet));
 
     Pet.subscribe(dog.$jazz.id, {}, (pet) => {
+      if (!pet.$isLoaded) return;
       expect(pet.type).toEqual("dog");
       spy(pet);
     });
@@ -386,6 +387,7 @@ describe("co.discriminatedUnion", () => {
 
     const spy = vi.fn();
     Pet.subscribe(dog.$jazz.id, { resolve: { owner: true } }, (pet) => {
+      if (!pet.$isLoaded) return;
       expect(pet.owner.name).toEqual("John Doe");
       spy(pet);
     });

--- a/packages/jazz-tools/src/tools/tests/coFeed.branch.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coFeed.branch.test.ts
@@ -485,6 +485,7 @@ describe("CoFeed Branching", async () => {
 
       const spy = vi.fn();
       const unsubscribe = branch.$jazz.subscribe((feed, unsubscribe) => {
+        if (!feed.$isLoaded) return;
         expect(feed.$jazz.branchName).not.toBe("subscribe-branch");
         expect(feed.$jazz.isBranched).toBe(false);
         spy();
@@ -496,6 +497,7 @@ describe("CoFeed Branching", async () => {
           unstable_branch: { name: "subscribe-branch" },
         },
         (feed, unsubscribe) => {
+          if (!feed.$isLoaded) return;
           expect(feed.$jazz.branchName).toBe("subscribe-branch");
           expect(feed.$jazz.isBranched).toBe(true);
           spy();

--- a/packages/jazz-tools/src/tools/tests/coList.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coList.test.ts
@@ -1131,6 +1131,7 @@ describe("CoList subscription", async () => {
         },
       },
       (update) => {
+        if (!update.$isLoaded) return;
         spy(update);
 
         // The update should be triggered only when the new item is loaded

--- a/packages/jazz-tools/src/tools/tests/deepLoading.test.ts
+++ b/packages/jazz-tools/src/tools/tests/deepLoading.test.ts
@@ -609,6 +609,7 @@ describe("Deep loading with unauthorized account", async () => {
     const result: MaybeLoaded<Loaded<typeof InnermostMap>> | undefined =
       await new Promise((resolve) => {
         const unsub = mapOnAlice.$jazz.subscribe((value) => {
+          if (!value.$isLoaded) return;
           resolve(value.optionalRef);
           unsub();
         });

--- a/packages/jazz-tools/src/tools/tests/deletedState.test.ts
+++ b/packages/jazz-tools/src/tools/tests/deletedState.test.ts
@@ -1,9 +1,18 @@
-import { beforeEach, describe, expect, it, onTestFinished, vi } from "vitest";
+import {
+  assert,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  onTestFinished,
+  vi,
+} from "vitest";
 import { cojsonInternals } from "cojson";
 
 import { Account, Group, z } from "../index.js";
 import {
   CoValueLoadingState,
+  Settled,
   co,
   coValueClassFromCoValueClassOrSchema,
   subscribeToCoValue,
@@ -31,7 +40,7 @@ describe("deleted loading state", () => {
     const map = TestMap.create({ value: "hello" }, me);
 
     let loadedCallCount = 0;
-    let deletedValue: unknown = null;
+    let deletedValue = null as Settled<co.loaded<typeof TestMap>> | null;
 
     const listener = vi.fn().mockImplementation((value) => {
       if (value.$isLoaded) {
@@ -65,10 +74,9 @@ describe("deleted loading state", () => {
       expect(deletedValue).not.toBeNull();
     });
 
-    // @ts-expect-error - we know deletedValue is not null here
-    expect(deletedValue?.$isLoaded).toBe(false);
-    // @ts-expect-error - we know deletedValue is not null here
-    expect(deletedValue?.$jazz.loadingState).toBe(CoValueLoadingState.DELETED);
+    assert(deletedValue);
+    expect(deletedValue.$isLoaded).toBe(false);
+    expect(deletedValue.$jazz.loadingState).toBe(CoValueLoadingState.DELETED);
 
     // Give the system a moment; we should not emit additional loaded updates after deletion.
     await new Promise((resolve) => setTimeout(resolve, 50));

--- a/packages/jazz-tools/src/tools/tests/schema.resolved.test.ts
+++ b/packages/jazz-tools/src/tools/tests/schema.resolved.test.ts
@@ -12,6 +12,7 @@ import {
   CoPlainText,
   CoValueLoadingState,
   Group,
+  Settled,
   z,
 } from "../exports";
 import { createJazzTestAccount, setupJazzTestSync } from "../testing";
@@ -315,20 +316,22 @@ describe("Schema.resolved()", () => {
 
         const map = TestMapWithName.create({ name: "Test" }, publicGroup);
 
-        const updates: co.loaded<typeof TestMapWithName>[] = [];
+        const updates: Settled<co.loaded<typeof TestMapWithName>>[] = [];
         TestMapWithName.subscribe(
           map.$jazz.id,
           {
             loadAs: clientAccount,
           },
           (map) => {
-            expectTypeOf<typeof map.name>().toEqualTypeOf<CoPlainText>();
             updates.push(map);
           },
         );
 
         await waitFor(() => expect(updates.length).toBe(1));
-        expect(updates[0]?.name.toUpperCase()).toEqual("TEST");
+        const loaded = updates[0];
+        assert(loaded?.$isLoaded);
+        expectTypeOf<typeof loaded.name>().toEqualTypeOf<CoPlainText>();
+        expect(loaded.name.toUpperCase()).toEqual("TEST");
       });
 
       test("for CoRecord", async () => {
@@ -361,20 +364,22 @@ describe("Schema.resolved()", () => {
 
         const list = TestListWithItems.create(["Test"], publicGroup);
 
-        const updates: co.loaded<typeof TestListWithItems>[] = [];
+        const updates: Settled<co.loaded<typeof TestListWithItems>>[] = [];
         TestListWithItems.subscribe(
           list.$jazz.id,
           {
             loadAs: clientAccount,
           },
           (list) => {
-            expectTypeOf<(typeof list)[0]>().toEqualTypeOf<CoPlainText>();
             updates.push(list);
           },
         );
 
         await waitFor(() => expect(updates.length).toBe(1));
-        expect(updates[0]?.[0]?.toUpperCase()).toEqual("TEST");
+        const loaded = updates[0];
+        assert(loaded?.$isLoaded);
+        expectTypeOf<(typeof loaded)[0]>().toEqualTypeOf<CoPlainText>();
+        expect(loaded[0]?.toUpperCase()).toEqual("TEST");
       });
 
       // TODO fix - `$each` does not load nested CoValues when providing an explicit resolve query either
@@ -415,7 +420,7 @@ describe("Schema.resolved()", () => {
           },
         });
 
-        const updates: co.loaded<typeof AccountWithProfile>[] = [];
+        const updates: Settled<co.loaded<typeof AccountWithProfile>>[] = [];
         AccountWithProfile.subscribe(
           account.$jazz.id,
           {
@@ -427,7 +432,9 @@ describe("Schema.resolved()", () => {
         );
 
         await waitFor(() => expect(updates.length).toBe(1));
-        expect(updates[0]?.profile.name).toBe("Hermes Puggington");
+        const loaded = updates[0];
+        assert(loaded?.$isLoaded);
+        expect(loaded.profile.name).toBe("Hermes Puggington");
       });
     });
 

--- a/packages/jazz-tools/src/tools/tests/schemaUnion.test.ts
+++ b/packages/jazz-tools/src/tools/tests/schemaUnion.test.ts
@@ -4,6 +4,7 @@ import {
   Account,
   CryptoProvider,
   Loaded,
+  Settled,
   co,
   coValueClassFromCoValueClassOrSchema,
   subscribeToCoValue,
@@ -106,7 +107,10 @@ describe("SchemaUnion", () => {
       coValueClassFromCoValueClassOrSchema(WidgetUnion),
       buttonWidget.$jazz.id,
       { loadAs: me, syncResolution: true },
-      (value: Loaded<typeof WidgetUnion>) => {
+      (value: Settled<Loaded<typeof WidgetUnion>>) => {
+        if (!value.$isLoaded) {
+          throw new Error("Expected loaded value");
+        }
         if (value.type === "button") {
           expect(value.label).toBe(currentValue);
           assert(value.color === "blue");

--- a/packages/jazz-webhook/src/webhook.ts
+++ b/packages/jazz-webhook/src/webhook.ts
@@ -79,6 +79,7 @@ export class WebhookRegistry {
     // wait for registration to become visible in the registry
     return new Promise((resolve) => {
       this.state.$jazz.subscribe((state, unsubscribe) => {
+        if (!state.$isLoaded) return;
         if (state.$jazz.refs[registrationId]) {
           resolve(registrationId);
           unsubscribe();
@@ -131,8 +132,11 @@ export class WebhookRegistry {
 
     // TODO: this would be much more efficient with subscription diffs
     const createAndDeleteSubscriptions = (
-      registry: co.loaded<typeof RegistryState, { $each: true }>,
+      registry: import("jazz-tools").Settled<
+        co.loaded<typeof RegistryState, { $each: true }>
+      >,
     ) => {
+      if (!registry.$isLoaded) return;
       for (const webhook of Object.values(registry)) {
         const exists = this.activeSubscriptions.has(webhook.$jazz.id);
         if (webhook.active && !exists) {
@@ -196,6 +200,7 @@ class WebhookEmitter {
     private options: JazzWebhookOptions = {},
   ) {
     const unsubscribeWebhook = this.webhook.$jazz.subscribe((webhook) => {
+      if (!webhook.$isLoaded) return;
       this.webhook = webhook;
     });
     const unsubscribeValue = this.webhook.$jazz.localNode.subscribe(

--- a/tests/e2e/src/lib/waitForCoValue.ts
+++ b/tests/e2e/src/lib/waitForCoValue.ts
@@ -21,7 +21,7 @@ export function waitForCoValue<
     resolve?: RefsToResolveStrict<T, R>;
   },
 ) {
-  return new Promise<T>((resolve, reject) => {
+  return new Promise<T>((resolve) => {
     function subscribe() {
       subscribeToCoValue(
         coMap,
@@ -29,15 +29,9 @@ export function waitForCoValue<
         {
           loadAs: options.loadAs,
           resolve: options.resolve,
-          onUnavailable: () => {
-            setTimeout(subscribe, 100);
-          },
-          onUnauthorized: () => {
-            reject(new Error("Unauthorized"));
-          },
         },
         (value, unsubscribe) => {
-          if (predicate(value)) {
+          if (value.$isLoaded && predicate(value)) {
             resolve(value);
             unsubscribe();
           }


### PR DESCRIPTION
 ## Summary

  - Remove onError, onUnauthorized, and onUnavailable callback options from all subscribe functions
  - Change the subscription listener to receive Settled<Resolved<V, R>> instead of just Resolved<V, R>
  - Add (id, listener) overloads to Schema types that only had (id, options, listener)

 ## Breaking Changes

  The subscribe API has been simplified. Error callbacks have been removed, and the listener now receives a Settled value that includes both loaded and error states.

```ts
  // Before
  MyCoMap.subscribe(id, {
    onUnavailable: (value) => console.log("Unavailable"),
    onUnauthorized: (value) => console.log("Unauthorized"),
  }, (value) => {
    console.log(value.field);
  });

  // After
  MyCoMap.subscribe(id, (value) => {
    if (!value.$isLoaded) {
      console.log("Error:", value.$jazz.loadingState);
      return;
    }
    console.log(value.field);
  });
 ```