### PR TITLE
perf(resolveAgent): use initialAdmin to skip account content parsing

### DIFF
--- a/packages/cojson/src/ids.ts
+++ b/packages/cojson/src/ids.ts
@@ -28,7 +28,7 @@ export type TransactionID = {
 
 export type AgentID = `sealer_z${string}/signer_z${string}`;
 
-export function isAgentID(id: string): id is AgentID {
+export function isAgentID(id: unknown): id is AgentID {
   return (
     typeof id === "string" &&
     id.startsWith("sealer_") &&

--- a/packages/cojson/src/localNode.ts
+++ b/packages/cojson/src/localNode.ts
@@ -736,9 +736,16 @@ export class LocalNode {
       };
     }
 
-    const account = coValue.getCurrentContent() as RawAccount;
+    const agentId = coValue.verified.header.ruleset.initialAdmin;
 
-    return { value: account.currentAgentID(), error: undefined };
+    if (!isAgentID(agentId)) {
+      return {
+        value: undefined,
+        error: new Error(`Unexpectedly not account: ${expectation}`),
+      };
+    }
+
+    return { value: agentId, error: undefined };
   }
 
   createGroup(


### PR DESCRIPTION
This PR changes the way we retrieve the agentID from accounts in order to avoid doing getCurrentContent inside the sync server.

The value we store iniside ruleset.initialAdmin is the same as we try to read accessing the coValue content.

The current implementation loads the content because it was initially designed to support multiple keys, but when we are going to support key rotation for accounts we are going to need anyway to mark the sessions to tag the used key, so it would follow a separate code-path.