### PR TITLE
fix: remove Prettier from the homepage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ We welcome all ideas! If you have suggestions, feel free to open an issue marked
 
 1. **Fork the repository** and create your feature branch (see [GitHub's guide on forking a repository](https://docs.github.com/en/get-started/quickstart/fork-a-repo) if you're unfamiliar with the process):
 
-2. **Make your changes**, ensuring that you follow our coding standards (`pnpm format` (prettier) and `pnpm lint` (eslint) will automatically let you know there are issues).
+2. **Make your changes**, ensuring that you follow our coding standards (`pnpm format` (Biome) and `pnpm lint` (eslint) will automatically let you know there are issues).
 
 3. **Commit your changes** with a descriptive commit message.
 
@@ -31,7 +31,7 @@ We welcome all ideas! If you have suggestions, feel free to open an issue marked
 
 ### 4. Code Style Guidelines
 
-- We use [Prettier](https://prettier.io/) for formatting. Please ensure your code is formatted before submitting.
+- We use [Biome](https://biomejs.dev/) for formatting. Please ensure your code is formatted before submitting.
 - Write descriptive comments where necessary.
 
 ### 5. Local Setup

--- a/examples/file-share-svelte/.prettierrc
+++ b/examples/file-share-svelte/.prettierrc
@@ -4,7 +4,7 @@
   "singleQuote": true,
   "trailingComma": "none",
   "printWidth": 100,
-  "plugins": ["prettier-plugin-svelte", "prettier-plugin-tailwindcss"],
+  "plugins": ["prettier-plugin-svelte"],
   "overrides": [
     {
       "files": "*.svelte",

--- a/examples/file-share-svelte/package.json
+++ b/examples/file-share-svelte/package.json
@@ -28,7 +28,6 @@
     "is-ci": "^3.0.1",
     "prettier": "^3.3.2",
     "prettier-plugin-svelte": "^3.2.6",
-    "prettier-plugin-tailwindcss": "^0.6.5",
     "svelte": "catalog:svelte",
     "svelte-check": "catalog:svelte",
     "@tailwindcss/postcss": "^4.1.10",

--- a/homepage/homepage/.prettierrc.json
+++ b/homepage/homepage/.prettierrc.json
@@ -1,5 +1,0 @@
-{
-  "plugins": ["prettier-plugin-tailwindcss"],
-  "tailwindConfig": "./tailwind.config.ts",
-  "tailwindFunctions": ["clsx", "cva", "tw"]
-}

--- a/homepage/homepage/package.json
+++ b/homepage/homepage/package.json
@@ -80,8 +80,6 @@
     "hast-util-to-string": "^3.0.1",
     "pagefind": "1.3.0",
     "postcss": "^8",
-    "prettier": "^3.6.2",
-    "prettier-plugin-tailwindcss": "^0.7.1",
     "tailwindcss": "^4.1.16",
     "svelte-check": "^4.3.3",
     "turbo": "^2.3.1",

--- a/homepage/pnpm-lock.yaml
+++ b/homepage/pnpm-lock.yaml
@@ -384,12 +384,6 @@ importers:
       postcss:
         specifier: ^8
         version: 8.5.6
-      prettier:
-        specifier: ^3.6.2
-        version: 3.6.2
-      prettier-plugin-tailwindcss:
-        specifier: ^0.7.1
-        version: 0.7.1(prettier@3.6.2)
       svelte-check:
         specifier: ^4.3.3
         version: 4.3.3(picomatch@4.0.3)(svelte@5.41.1)(typescript@5.6.2)
@@ -4035,61 +4029,6 @@ packages:
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
-
-  prettier-plugin-tailwindcss@0.7.1:
-    resolution: {integrity: sha512-Bzv1LZcuiR1Sk02iJTS1QzlFNp/o5l2p3xkopwOrbPmtMeh3fK9rVW5M3neBQzHq+kGKj/4LGQMTNcTH4NGPtQ==}
-    engines: {node: '>=20.19'}
-    peerDependencies:
-      '@ianvs/prettier-plugin-sort-imports': '*'
-      '@prettier/plugin-hermes': '*'
-      '@prettier/plugin-oxc': '*'
-      '@prettier/plugin-pug': '*'
-      '@shopify/prettier-plugin-liquid': '*'
-      '@trivago/prettier-plugin-sort-imports': '*'
-      '@zackad/prettier-plugin-twig': '*'
-      prettier: ^3.0
-      prettier-plugin-astro: '*'
-      prettier-plugin-css-order: '*'
-      prettier-plugin-jsdoc: '*'
-      prettier-plugin-marko: '*'
-      prettier-plugin-multiline-arrays: '*'
-      prettier-plugin-organize-attributes: '*'
-      prettier-plugin-organize-imports: '*'
-      prettier-plugin-sort-imports: '*'
-      prettier-plugin-svelte: '*'
-    peerDependenciesMeta:
-      '@ianvs/prettier-plugin-sort-imports':
-        optional: true
-      '@prettier/plugin-hermes':
-        optional: true
-      '@prettier/plugin-oxc':
-        optional: true
-      '@prettier/plugin-pug':
-        optional: true
-      '@shopify/prettier-plugin-liquid':
-        optional: true
-      '@trivago/prettier-plugin-sort-imports':
-        optional: true
-      '@zackad/prettier-plugin-twig':
-        optional: true
-      prettier-plugin-astro:
-        optional: true
-      prettier-plugin-css-order:
-        optional: true
-      prettier-plugin-jsdoc:
-        optional: true
-      prettier-plugin-marko:
-        optional: true
-      prettier-plugin-multiline-arrays:
-        optional: true
-      prettier-plugin-organize-attributes:
-        optional: true
-      prettier-plugin-organize-imports:
-        optional: true
-      prettier-plugin-sort-imports:
-        optional: true
-      prettier-plugin-svelte:
-        optional: true
 
   prettier@3.6.2:
     resolution: {integrity: sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==}
@@ -9694,10 +9633,6 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
-
-  prettier-plugin-tailwindcss@0.7.1(prettier@3.6.2):
-    dependencies:
-      prettier: 3.6.2
 
   prettier@3.6.2: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1114,9 +1114,6 @@ importers:
       prettier-plugin-svelte:
         specifier: ^3.2.6
         version: 3.4.0(prettier@3.5.3)(svelte@5.38.2)
-      prettier-plugin-tailwindcss:
-        specifier: ^0.6.5
-        version: 0.6.9(prettier-plugin-svelte@3.4.0(prettier@3.5.3)(svelte@5.38.2))(prettier@3.5.3)
       svelte:
         specifier: catalog:svelte
         version: 5.38.2
@@ -16018,61 +16015,6 @@ packages:
       prettier: ^3.0.0
       svelte: ^3.2.0 || ^4.0.0-next.0 || ^5.0.0-next.0
 
-  prettier-plugin-tailwindcss@0.6.9:
-    resolution: {integrity: sha512-r0i3uhaZAXYP0At5xGfJH876W3HHGHDp+LCRUJrs57PBeQ6mYHMwr25KH8NPX44F2yGTvdnH7OqCshlQx183Eg==}
-    engines: {node: '>=14.21.3'}
-    peerDependencies:
-      '@ianvs/prettier-plugin-sort-imports': '*'
-      '@prettier/plugin-pug': '*'
-      '@shopify/prettier-plugin-liquid': '*'
-      '@trivago/prettier-plugin-sort-imports': '*'
-      '@zackad/prettier-plugin-twig-melody': '*'
-      prettier: ^3.0
-      prettier-plugin-astro: '*'
-      prettier-plugin-css-order: '*'
-      prettier-plugin-import-sort: '*'
-      prettier-plugin-jsdoc: '*'
-      prettier-plugin-marko: '*'
-      prettier-plugin-multiline-arrays: '*'
-      prettier-plugin-organize-attributes: '*'
-      prettier-plugin-organize-imports: '*'
-      prettier-plugin-sort-imports: '*'
-      prettier-plugin-style-order: '*'
-      prettier-plugin-svelte: '*'
-    peerDependenciesMeta:
-      '@ianvs/prettier-plugin-sort-imports':
-        optional: true
-      '@prettier/plugin-pug':
-        optional: true
-      '@shopify/prettier-plugin-liquid':
-        optional: true
-      '@trivago/prettier-plugin-sort-imports':
-        optional: true
-      '@zackad/prettier-plugin-twig-melody':
-        optional: true
-      prettier-plugin-astro:
-        optional: true
-      prettier-plugin-css-order:
-        optional: true
-      prettier-plugin-import-sort:
-        optional: true
-      prettier-plugin-jsdoc:
-        optional: true
-      prettier-plugin-marko:
-        optional: true
-      prettier-plugin-multiline-arrays:
-        optional: true
-      prettier-plugin-organize-attributes:
-        optional: true
-      prettier-plugin-organize-imports:
-        optional: true
-      prettier-plugin-sort-imports:
-        optional: true
-      prettier-plugin-style-order:
-        optional: true
-      prettier-plugin-svelte:
-        optional: true
-
   prettier@2.8.8:
     resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
     engines: {node: '>=10.13.0'}
@@ -19507,9 +19449,9 @@ snapshots:
       eslint-visitor-keys: 2.1.0
       semver: 6.3.1
 
-  '@babel/eslint-parser@7.27.0(@babel/core@7.28.5)(eslint@9.39.1(jiti@2.6.1))':
+  '@babel/eslint-parser@7.27.0(@babel/core@7.28.3)(eslint@9.39.1(jiti@2.6.1))':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.3
       '@nicolo-ribaudo/eslint-scope-5-internals': 5.1.1-v1
       eslint: 9.39.1(jiti@2.6.1)
       eslint-visitor-keys: 2.1.0
@@ -27476,7 +27418,7 @@ snapshots:
   '@react-native/eslint-config@0.81.5(eslint@9.39.1(jiti@2.6.1))(jest@29.7.0(@types/node@24.3.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.11.29(@swc/helpers@0.5.17))(@types/node@24.3.0)(typescript@5.9.2)))(prettier@3.6.2)(typescript@5.9.2)':
     dependencies:
       '@babel/core': 7.28.3
-      '@babel/eslint-parser': 7.27.0(@babel/core@7.28.5)(eslint@9.39.1(jiti@2.6.1))
+      '@babel/eslint-parser': 7.27.0(@babel/core@7.28.3)(eslint@9.39.1(jiti@2.6.1))
       '@react-native/eslint-plugin': 0.81.5
       '@typescript-eslint/eslint-plugin': 7.18.0(@typescript-eslint/parser@7.18.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.2))(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.2)
       '@typescript-eslint/parser': 7.18.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.2)
@@ -32504,7 +32446,7 @@ snapshots:
 
   eslint-plugin-ft-flow@2.0.3(@babel/eslint-parser@7.27.0(@babel/core@7.28.3)(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
-      '@babel/eslint-parser': 7.27.0(@babel/core@7.28.5)(eslint@9.39.1(jiti@2.6.1))
+      '@babel/eslint-parser': 7.27.0(@babel/core@7.28.3)(eslint@9.39.1(jiti@2.6.1))
       eslint: 9.39.1(jiti@2.6.1)
       lodash: 4.17.21
       string-natural-compare: 3.0.1
@@ -37507,12 +37449,6 @@ snapshots:
     dependencies:
       prettier: 3.5.3
       svelte: 5.38.2
-
-  prettier-plugin-tailwindcss@0.6.9(prettier-plugin-svelte@3.4.0(prettier@3.5.3)(svelte@5.38.2))(prettier@3.5.3):
-    dependencies:
-      prettier: 3.5.3
-    optionalDependencies:
-      prettier-plugin-svelte: 3.4.0(prettier@3.5.3)(svelte@5.38.2)
 
   prettier@2.8.8: {}
 


### PR DESCRIPTION
# Description

We were getting this error when running `pnpm changeset`:
```bash
🦋  Is this your desired changeset? (Y/n) · true
🦋  error Error [ERR_REQUIRE_ASYNC_MODULE]: require() cannot be used on an ESM graph with top-level await. Use import() instead. To see where the top-level await comes from, use --experimental-print-required-tla.
🦋  error   From /Users/nicolasr/Desktop/Jazz/jazz/node_modules/prettier/index.js 
🦋  error   Requiring /Users/nicolasr/Desktop/Jazz/jazz/node_modules/prettier-plugin-tailwindcss/dist/index.mjs 
🦋  error     at ModuleJobSync.runSync (node:internal/modules/esm/module_job:432:13)
🦋  error     at ModuleLoader.importSyncForRequire (node:internal/modules/esm/loader:427:47)
🦋  error     at loadESMFromCJS (node:internal/modules/cjs/loader:1561:24)
🦋  error     at Module._compile (node:internal/modules/cjs/loader:1712:5)
🦋  error     at Object..js (node:internal/modules/cjs/loader:1895:10)
🦋  error     at Module.load (node:internal/modules/cjs/loader:1465:32)
🦋  error     at Function._load (node:internal/modules/cjs/loader:1282:12)
🦋  error     at TracingChannel.traceSync (node:diagnostics_channel:322:14)
🦋  error     at wrapModuleLoad (node:internal/modules/cjs/loader:235:24)
🦋  error     at Module.require (node:internal/modules/cjs/loader:1487:12) {
🦋  error   code: 'ERR_REQUIRE_ASYNC_MODULE'
🦋  error }
``` 

It looks like the changeset package was picking up a prettier plugin from our repo. This plugin is used in two places:
- `homepage/homepage`: from what I can see we're just using biome in this project now, so I removed prettier altogether
- `examples/file-share-svelte`: this example does use prettier (because our current biome version does not support svelte). Removed the plugin, since I don't think it makes much of a difference