### PR TITLE
fix: flickering when sending messages in chat example

### DIFF
--- a/examples/chat/src/chatScreen.tsx
+++ b/examples/chat/src/chatScreen.tsx
@@ -1,7 +1,7 @@
 import { Account } from "jazz-tools";
 import { createImage } from "jazz-tools/media";
 import { useSuspenseAccount, useSuspenseCoState } from "jazz-tools/react";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { Chat, Message } from "./schema.ts";
 import {
   BubbleBody,
@@ -25,6 +25,7 @@ export function ChatScreen(props: { chatID: string }) {
   const [showNLastMessages, setShowNLastMessages] = useState(
     INITIAL_MESSAGES_TO_SHOW,
   );
+  const initialLoadCompletedRef = useRef(false);
 
   const messageIds = Array.from(chat.$jazz.refs)
     // We call slice before reverse to avoid mutating the original array
@@ -36,10 +37,16 @@ export function ChatScreen(props: { chatID: string }) {
   const messages = useCoStates(Message, messageIds);
 
   // The initial messages should be loaded all at once, so we can avoid flickering
-  if (
-    messages.slice(0, INITIAL_MESSAGES_TO_SHOW).some((msg) => !msg.$isLoaded)
-  ) {
-    return null;
+  // Only gate the initial render, not subsequent renders when new messages arrive
+  if (!initialLoadCompletedRef.current) {
+    const initialMessagesLoaded = messages
+      .slice(0, INITIAL_MESSAGES_TO_SHOW)
+      .every((msg) => msg.$isLoaded);
+    if (initialMessagesLoaded) {
+      initialLoadCompletedRef.current = true;
+    } else {
+      return null;
+    }
   }
 
   const sendImage = (event: React.ChangeEvent<HTMLInputElement>) => {

--- a/examples/chat/src/chatScreen.tsx
+++ b/examples/chat/src/chatScreen.tsx
@@ -1,7 +1,7 @@
 import { Account } from "jazz-tools";
 import { createImage } from "jazz-tools/media";
 import { useSuspenseAccount, useSuspenseCoState } from "jazz-tools/react";
-import { useRef, useState } from "react";
+import { useState } from "react";
 import { Chat, Message } from "./schema.ts";
 import {
   BubbleBody,
@@ -25,7 +25,6 @@ export function ChatScreen(props: { chatID: string }) {
   const [showNLastMessages, setShowNLastMessages] = useState(
     INITIAL_MESSAGES_TO_SHOW,
   );
-  const initialLoadCompletedRef = useRef(false);
 
   const messageIds = Array.from(chat.$jazz.refs)
     // We call slice before reverse to avoid mutating the original array
@@ -35,19 +34,6 @@ export function ChatScreen(props: { chatID: string }) {
     .map((msgRef) => msgRef.id);
 
   const messages = useCoStates(Message, messageIds);
-
-  // The initial messages should be loaded all at once, so we can avoid flickering
-  // Only gate the initial render, not subsequent renders when new messages arrive
-  if (!initialLoadCompletedRef.current) {
-    const initialMessagesLoaded = messages
-      .slice(0, INITIAL_MESSAGES_TO_SHOW)
-      .every((msg) => msg.$isLoaded);
-    if (initialMessagesLoaded) {
-      initialLoadCompletedRef.current = true;
-    } else {
-      return null;
-    }
-  }
 
   const sendImage = (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.currentTarget.files?.[0];

--- a/examples/chat/src/ui.tsx
+++ b/examples/chat/src/ui.tsx
@@ -105,11 +105,14 @@ export function BubbleImage(props: { image: ImageDefinition }) {
 export function BubbleInfo(props: { by: string | undefined; madeAt: number }) {
   const by = useCoState(Account, props.by, { resolve: { profile: true } });
   return (
-    <div className="text-xs text-neutral-500 mb-1.5">
-      {by.$isLoaded ? by.profile.name : ""} ·{" "}
-      {new Date(props.madeAt).toLocaleTimeString("en-US", {
-        hour12: false,
-      })}
+    <div className="text-xs text-neutral-500 mb-1.5 h-4">
+      {by.$isLoaded
+        ? by.profile.name +
+          " · " +
+          new Date(props.madeAt).toLocaleTimeString("en-US", {
+            hour12: false,
+          })
+        : ""}
     </div>
   );
 }


### PR DESCRIPTION
# Description

When sending messages in the chat example, the whole chat flickers for an instant:

https://github.com/user-attachments/assets/4532299a-fa88-4632-a4aa-b0c67c94f2fb

This regression was introduced by https://github.com/garden-co/jazz/pull/3353, which refactored the chat example to use pagination and avoid fetching all messages at once. 

## Manual Testing

https://github.com/user-attachments/assets/e6e2400f-b747-4657-aa0a-003972fc6ce7
