### PR TITLE
Add JWT auth integration for ReBAC with BetterAuth/WorkOS support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,3 +251,90 @@ jobs:
           name: demo-app-playwright-report
           path: examples/demo-app/playwright-report
           retention-days: 7
+
+  auth-betterauth-tests:
+    name: Auth BetterAuth E2E Tests
+    runs-on: ubuntu-latest
+    needs: ts-build
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build-artifacts
+          path: .
+
+      - name: Rebuild native modules
+        run: cd examples/auth-betterauth && npm rebuild better-sqlite3
+
+      - name: Run BetterAuth migrations
+        run: cd examples/auth-betterauth && npx @better-auth/cli migrate --config server/auth-server.ts -y
+
+      - name: Install Playwright browsers
+        run: cd examples/auth-betterauth && pnpm exec playwright install --with-deps chromium
+
+      - name: Run BetterAuth E2E tests
+        run: cd examples/auth-betterauth && pnpm test
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: auth-betterauth-playwright-report
+          path: examples/auth-betterauth/playwright-report
+          retention-days: 7
+
+  auth-workos-tests:
+    name: Auth WorkOS E2E Tests
+    runs-on: ubuntu-latest
+    needs: ts-build
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build-artifacts
+          path: .
+
+      - name: Install Playwright browsers
+        run: cd examples/auth-workos && pnpm exec playwright install --with-deps chromium
+
+      - name: Run WorkOS E2E tests
+        env:
+          WORKOS_TEST_EMAIL: ${{ secrets.WORKOS_TEST_EMAIL }}
+          WORKOS_TEST_PASSWORD: ${{ secrets.WORKOS_TEST_PASSWORD }}
+        run: cd examples/auth-workos && pnpm test
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: auth-workos-playwright-report
+          path: examples/auth-workos/playwright-report
+          retention-days: 7

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,7 @@ Source of truth. Linear references specs, not vice versa.
 | [Storage](docs/content/docs/internals/storage.mdx) | Partial |
 | [Schema Evolution](docs/content/docs/internals/schema-evolution.mdx) | Implemented |
 | [Access Control](docs/content/docs/internals/access-control.mdx) | Partial |
+| [Authentication](docs/content/docs/internals/authentication.mdx) | Partial |
 | [Deletes](docs/content/docs/internals/deletes.mdx) | Implemented |
 | [Indices](docs/content/docs/internals/indices.mdx) | Future |
 | [Transactions](docs/content/docs/internals/transactions.mdx) | Future |

--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -152,6 +152,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -297,6 +303,15 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "deranged"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
+dependencies = [
+ "powerfmt",
+]
 
 [[package]]
 name = "displaydoc"
@@ -500,6 +515,9 @@ dependencies = [
  "futures",
  "getrandom 0.2.16",
  "hex",
+ "jsonwebtoken",
+ "serde",
+ "serde_json",
  "tokio",
  "tokio-stream",
  "uuid",
@@ -531,6 +549,7 @@ dependencies = [
  "serde",
  "tokio",
  "tokio-stream",
+ "toml",
  "tower-http",
 ]
 
@@ -872,6 +891,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64 0.22.1",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -982,6 +1016,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1077,6 +1136,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64 0.22.1",
+ "serde_core",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1108,6 +1177,12 @@ checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "proc-macro2"
@@ -1148,7 +1223,7 @@ version = "0.11.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -1183,6 +1258,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.16",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1201,7 +1290,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
- "base64",
+ "base64 0.21.7",
 ]
 
 [[package]]
@@ -1329,6 +1418,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1354,6 +1452,18 @@ checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
  "errno",
  "libc",
+]
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror",
+ "time",
 ]
 
 [[package]]
@@ -1469,6 +1579,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "2.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "time"
+version = "0.3.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9e442fc33d7fdb45aa9bfeb312c095964abdf596f7567261062b2a7107aaabd"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b36ee98fd31ec7426d599183e8fe26932a8dc1fb76ddb6214d05493377d34ca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e552d1249bf61ac2a52db88179fd0673def1e1ad8243a00d9ec9ed71fee3dd"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1539,6 +1700,47 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
@@ -1613,6 +1815,12 @@ name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -2044,6 +2252,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winreg"

--- a/crates/groove-server/Cargo.toml
+++ b/crates/groove-server/Cargo.toml
@@ -8,7 +8,7 @@ name = "groove-server"
 path = "src/main.rs"
 
 [dependencies]
-groove = { path = "../groove", features = ["sync-server"] }
+groove = { path = "../groove", features = ["sync-server", "jwt-auth"] }
 axum = "0.8"
 tokio = { version = "1", features = ["full"] }
 tokio-stream = "0.1"
@@ -16,3 +16,4 @@ futures = "0.3"
 async-trait = "0.1"
 tower-http = { version = "0.6", features = ["cors"] }
 serde = { version = "1", features = ["derive"] }
+toml = "0.8"

--- a/crates/groove-server/src/config.rs
+++ b/crates/groove-server/src/config.rs
@@ -1,0 +1,343 @@
+//! Server configuration for groove-server.
+//!
+//! Configuration can be loaded from TOML files or environment variables.
+//!
+//! # Example Configuration
+//!
+//! ```toml
+//! host = "0.0.0.0"
+//! port = 8080
+//!
+//! [auth]
+//! provider = "betterauth"  # or "workos", "accept_all"
+//!
+//! [auth.jwt]
+//! jwks_url = "https://auth.example.com/.well-known/jwks.json"
+//! issuer = "https://auth.example.com"
+//! audience = "jazz-app"
+//! user_id_claim = "sub"
+//! ```
+
+use std::path::Path;
+
+use serde::Deserialize;
+
+/// Server configuration.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ServerConfig {
+    /// Host address to bind to (default: "0.0.0.0")
+    #[serde(default = "default_host")]
+    pub host: String,
+
+    /// Port to listen on (default: 8080)
+    #[serde(default = "default_port")]
+    pub port: u16,
+
+    /// Authentication configuration
+    #[serde(default)]
+    pub auth: AuthConfig,
+
+    /// Database path for persistence (default: "groove.db")
+    #[serde(default = "default_db_path")]
+    pub db_path: String,
+}
+
+fn default_host() -> String {
+    "0.0.0.0".to_string()
+}
+
+fn default_port() -> u16 {
+    8080
+}
+
+fn default_db_path() -> String {
+    "groove.db".to_string()
+}
+
+impl Default for ServerConfig {
+    fn default() -> Self {
+        Self {
+            host: default_host(),
+            port: default_port(),
+            auth: AuthConfig::default(),
+            db_path: default_db_path(),
+        }
+    }
+}
+
+/// Authentication provider type.
+#[derive(Debug, Clone, Copy, Default, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum AuthProvider {
+    /// Accept all tokens (for development/testing only)
+    #[default]
+    AcceptAll,
+    /// BetterAuth provider
+    BetterAuth,
+    /// WorkOS provider
+    WorkOS,
+    /// Custom JWT provider
+    Jwt,
+}
+
+/// Authentication configuration.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct AuthConfig {
+    /// The authentication provider to use
+    #[serde(default)]
+    pub provider: AuthProvider,
+
+    /// JWT validation settings
+    #[serde(default)]
+    pub jwt: JwtAuthConfig,
+
+    /// User provisioning settings
+    #[serde(default)]
+    pub provisioning: ProvisioningConfig,
+}
+
+/// JWT authentication configuration.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct JwtAuthConfig {
+    /// JWKS URL for RS256/RS384/RS512 validation.
+    /// Required for BetterAuth and WorkOS providers.
+    pub jwks_url: Option<String>,
+
+    /// Secret key for HS256 validation (development only).
+    pub secret: Option<String>,
+
+    /// Expected token issuer (`iss` claim).
+    pub issuer: Option<String>,
+
+    /// Expected token audience (`aud` claim).
+    pub audience: Option<String>,
+
+    /// Claim name containing the user ID (default: "sub").
+    #[serde(default = "default_user_id_claim")]
+    pub user_id_claim: String,
+
+    /// Optional claim containing a pre-resolved Jazz ObjectId.
+    pub jazz_user_id_claim: Option<String>,
+
+    /// Whether to validate token expiration (default: true).
+    #[serde(default = "default_true")]
+    pub validate_exp: bool,
+}
+
+fn default_user_id_claim() -> String {
+    "sub".to_string()
+}
+
+fn default_true() -> bool {
+    true
+}
+
+impl JwtAuthConfig {
+    /// Convert to JwtConfig for the JWT validator.
+    pub fn to_jwt_config(&self) -> groove::sync::jwt::JwtConfig {
+        groove::sync::jwt::JwtConfig {
+            jwks_url: self.jwks_url.clone(),
+            secret: self.secret.clone(),
+            issuer: self.issuer.clone(),
+            audience: self.audience.clone(),
+            user_id_claim: self.user_id_claim.clone(),
+            jazz_user_id_claim: self.jazz_user_id_claim.clone(),
+            extract_claims: vec![], // Extract all claims
+            validate_exp: self.validate_exp,
+        }
+    }
+}
+
+/// User provisioning configuration.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct ProvisioningConfig {
+    /// Whether to automatically provision users on first login.
+    #[serde(default)]
+    pub auto_provision: bool,
+
+    /// Table name for user storage (default: "users").
+    #[serde(default = "default_users_table")]
+    pub users_table: String,
+
+    /// Column name for external user ID (default: "external_id").
+    #[serde(default = "default_external_id_column")]
+    pub external_id_column: String,
+}
+
+fn default_users_table() -> String {
+    "users".to_string()
+}
+
+fn default_external_id_column() -> String {
+    "external_id".to_string()
+}
+
+impl ServerConfig {
+    /// Load configuration from a TOML file.
+    pub fn from_file(path: impl AsRef<Path>) -> Result<Self, ConfigError> {
+        let content = std::fs::read_to_string(path.as_ref()).map_err(|e| ConfigError::IoError {
+            path: path.as_ref().display().to_string(),
+            source: e,
+        })?;
+
+        Self::from_toml(&content)
+    }
+
+    /// Parse configuration from a TOML string.
+    pub fn from_toml(content: &str) -> Result<Self, ConfigError> {
+        toml::from_str(content).map_err(ConfigError::ParseError)
+    }
+
+    /// Load configuration from default locations.
+    ///
+    /// Searches for config files in order:
+    /// 1. `./groove-server.toml`
+    /// 2. `./config/groove-server.toml`
+    /// 3. Returns default config if no file found
+    pub fn load() -> Self {
+        let paths = ["groove-server.toml", "config/groove-server.toml"];
+
+        for path in paths {
+            if Path::new(path).exists() {
+                match Self::from_file(path) {
+                    Ok(config) => return config,
+                    Err(e) => {
+                        eprintln!("Warning: Failed to load config from {}: {}", path, e);
+                    }
+                }
+            }
+        }
+
+        Self::default()
+    }
+
+    /// Get the socket address for binding.
+    pub fn socket_addr(&self) -> String {
+        format!("{}:{}", self.host, self.port)
+    }
+}
+
+/// Configuration error.
+#[derive(Debug)]
+pub enum ConfigError {
+    /// Failed to read config file.
+    IoError {
+        path: String,
+        source: std::io::Error,
+    },
+    /// Failed to parse TOML.
+    ParseError(toml::de::Error),
+}
+
+impl std::fmt::Display for ConfigError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ConfigError::IoError { path, source } => {
+                write!(f, "failed to read config file '{}': {}", path, source)
+            }
+            ConfigError::ParseError(e) => write!(f, "failed to parse config: {}", e),
+        }
+    }
+}
+
+impl std::error::Error for ConfigError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_config() {
+        let config = ServerConfig::default();
+        assert_eq!(config.host, "0.0.0.0");
+        assert_eq!(config.port, 8080);
+        assert_eq!(config.auth.provider, AuthProvider::AcceptAll);
+    }
+
+    #[test]
+    fn test_parse_minimal_config() {
+        let toml = r#"
+            port = 3000
+        "#;
+
+        let config = ServerConfig::from_toml(toml).unwrap();
+        assert_eq!(config.port, 3000);
+        assert_eq!(config.host, "0.0.0.0"); // default
+    }
+
+    #[test]
+    fn test_parse_betterauth_config() {
+        let toml = r#"
+            host = "127.0.0.1"
+            port = 8080
+
+            [auth]
+            provider = "betterauth"
+
+            [auth.jwt]
+            jwks_url = "http://localhost:3001/api/auth/jwks"
+            issuer = "http://localhost:3001"
+            user_id_claim = "sub"
+
+            [auth.provisioning]
+            auto_provision = true
+            users_table = "users"
+        "#;
+
+        let config = ServerConfig::from_toml(toml).unwrap();
+        assert_eq!(config.host, "127.0.0.1");
+        assert_eq!(config.port, 8080);
+        assert_eq!(config.auth.provider, AuthProvider::BetterAuth);
+        assert_eq!(
+            config.auth.jwt.jwks_url,
+            Some("http://localhost:3001/api/auth/jwks".to_string())
+        );
+        assert_eq!(
+            config.auth.jwt.issuer,
+            Some("http://localhost:3001".to_string())
+        );
+        assert!(config.auth.provisioning.auto_provision);
+    }
+
+    #[test]
+    fn test_parse_workos_config() {
+        let toml = r#"
+            port = 8080
+
+            [auth]
+            provider = "workos"
+
+            [auth.jwt]
+            jwks_url = "https://api.workos.com/sso/jwks/client_123"
+            issuer = "https://api.workos.com/"
+            user_id_claim = "sub"
+        "#;
+
+        let config = ServerConfig::from_toml(toml).unwrap();
+        assert_eq!(config.auth.provider, AuthProvider::WorkOS);
+        assert_eq!(
+            config.auth.jwt.issuer,
+            Some("https://api.workos.com/".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_jwt_config_with_secret() {
+        let toml = r#"
+            [auth]
+            provider = "jwt"
+
+            [auth.jwt]
+            secret = "my-super-secret-key-for-development"
+            validate_exp = false
+        "#;
+
+        let config = ServerConfig::from_toml(toml).unwrap();
+        assert_eq!(config.auth.provider, AuthProvider::Jwt);
+        assert_eq!(
+            config.auth.jwt.secret,
+            Some("my-super-secret-key-for-development".to_string())
+        );
+        assert!(!config.auth.jwt.validate_exp);
+    }
+}

--- a/crates/groove-server/src/handlers.rs
+++ b/crates/groove-server/src/handlers.rs
@@ -274,7 +274,7 @@ async fn handle_unsubscribe<E: Environment>(
 
     // Find sessions for this identity and remove the subscription
     let mut server = state.server.write().await;
-    let session_ids = server.sessions_for_identity(&identity.id);
+    let session_ids = server.sessions_for_identity(&identity.external_id);
 
     let query_id = QueryId(request.subscription_id);
 
@@ -347,7 +347,7 @@ async fn handle_push<E: Environment>(
     let sender_session = {
         let server = state.server.read().await;
         server
-            .sessions_for_identity(&identity.id)
+            .sessions_for_identity(&identity.external_id)
             .into_iter()
             .next()
     };
@@ -462,7 +462,7 @@ async fn handle_reconcile<E: Environment>(
     if let Some(session_id) = {
         let server = state.server.read().await;
         server
-            .sessions_for_identity(&identity.id)
+            .sessions_for_identity(&identity.external_id)
             .into_iter()
             .next()
     } {
@@ -904,22 +904,10 @@ mod tests {
             let mut server = state.server.write().await;
 
             // Session 1 - the pusher
-            let s1 = server.create_session(
-                ClientIdentity {
-                    id: "user1".to_string(),
-                    name: None,
-                },
-                tx1,
-            );
+            let s1 = server.create_session(ClientIdentity::simple("user1"), tx1);
 
             // Session 2 - should receive the broadcast
-            let s2 = server.create_session(
-                ClientIdentity {
-                    id: "user2".to_string(),
-                    name: None,
-                },
-                tx2,
-            );
+            let s2 = server.create_session(ClientIdentity::simple("user2"), tx2);
 
             // Both sessions track the same object
             server.register_object_session(object_id, s1);
@@ -1048,13 +1036,7 @@ mod tests {
         let query_id;
         {
             let mut server = state.server.write().await;
-            session_id = server.create_session(
-                ClientIdentity {
-                    id: "user1".to_string(),
-                    name: None,
-                },
-                tx,
-            );
+            session_id = server.create_session(ClientIdentity::simple("user1"), tx);
             let session = server.get_session_mut(&session_id).unwrap();
             query_id = session.next_query_id();
             session.queries.insert(

--- a/crates/groove-server/src/lib.rs
+++ b/crates/groove-server/src/lib.rs
@@ -5,9 +5,14 @@
 //! - `AxumServerEnv`: Implementation of `ServerEnv` for axum
 //! - HTTP handlers for sync endpoints
 //! - Router configuration
+//! - Server configuration and JWT authentication
 
 mod axum_env;
+pub mod config;
 mod handlers;
+pub mod user_provisioning;
 
 pub use axum_env::*;
+pub use config::*;
 pub use handlers::*;
+pub use user_provisioning::*;

--- a/crates/groove-server/src/main.rs
+++ b/crates/groove-server/src/main.rs
@@ -6,7 +6,8 @@
 //!   cargo run -p groove-server -- [OPTIONS]
 //!
 //! Options:
-//!   --host HOST     Host to bind to (default: 127.0.0.1)
+//!   --config FILE   Load configuration from TOML file
+//!   --host HOST     Host to bind to (default: 0.0.0.0)
 //!   --port PORT     Port to listen on (default: 8080)
 
 use std::net::SocketAddr;
@@ -17,34 +18,83 @@ use tokio::net::TcpListener;
 use tower_http::cors::{Any, CorsLayer};
 
 use groove::MemoryEnvironment;
-use groove::sync::AcceptAllTokens;
-use groove_server::{AppState, sync_router};
+use groove::sync::jwt::JwtTokenValidator;
+use groove::sync::{AcceptAllTokens, TokenValidator};
+use groove_server::{
+    AppState, AuthProvider, InMemoryUserResolver, ProvisioningTokenValidator, ServerConfig,
+    sync_router,
+};
+
+/// Create a token validator based on the server configuration.
+fn create_token_validator(config: &ServerConfig) -> Arc<dyn TokenValidator> {
+    let resolver = InMemoryUserResolver::new();
+    let auto_provision = config.auth.provisioning.auto_provision;
+
+    match config.auth.provider {
+        AuthProvider::AcceptAll => {
+            if auto_provision {
+                Arc::new(ProvisioningTokenValidator::with_auto_provision(
+                    AcceptAllTokens,
+                    resolver,
+                ))
+            } else {
+                Arc::new(AcceptAllTokens)
+            }
+        }
+        AuthProvider::BetterAuth | AuthProvider::WorkOS | AuthProvider::Jwt => {
+            let jwt_config = config.auth.jwt.to_jwt_config();
+            let jwt_validator = JwtTokenValidator::new(jwt_config);
+
+            if auto_provision {
+                Arc::new(ProvisioningTokenValidator::with_auto_provision(
+                    jwt_validator,
+                    resolver,
+                ))
+            } else {
+                Arc::new(ProvisioningTokenValidator::without_auto_provision(
+                    jwt_validator,
+                    resolver,
+                ))
+            }
+        }
+    }
+}
 
 #[tokio::main]
 async fn main() {
     // Parse command line arguments
     let args: Vec<String> = std::env::args().collect();
-    let mut host = "127.0.0.1".to_string();
-    let mut port: u16 = 8080;
+    let mut config_path: Option<String> = None;
+    let mut host_override: Option<String> = None;
+    let mut port_override: Option<u16> = None;
 
     let mut i = 1;
     while i < args.len() {
         match args[i].as_str() {
+            "--config" | "-c" => {
+                if i + 1 < args.len() {
+                    config_path = Some(args[i + 1].clone());
+                    i += 2;
+                } else {
+                    eprintln!("Error: --config requires a file path");
+                    std::process::exit(1);
+                }
+            }
             "--host" => {
                 if i + 1 < args.len() {
-                    host = args[i + 1].clone();
+                    host_override = Some(args[i + 1].clone());
                     i += 2;
                 } else {
                     eprintln!("Error: --host requires an argument");
                     std::process::exit(1);
                 }
             }
-            "--port" => {
+            "--port" | "-p" => {
                 if i + 1 < args.len() {
-                    port = args[i + 1].parse().unwrap_or_else(|_| {
+                    port_override = Some(args[i + 1].parse().unwrap_or_else(|_| {
                         eprintln!("Error: --port must be a number");
                         std::process::exit(1);
-                    });
+                    }));
                     i += 2;
                 } else {
                     eprintln!("Error: --port requires an argument");
@@ -57,9 +107,28 @@ async fn main() {
                 println!("Usage: groove-server [OPTIONS]");
                 println!();
                 println!("Options:");
-                println!("  --host HOST     Host to bind to (default: 127.0.0.1)");
-                println!("  --port PORT     Port to listen on (default: 8080)");
-                println!("  --help, -h      Show this help message");
+                println!("  --config, -c FILE   Load configuration from TOML file");
+                println!("  --host HOST         Host to bind to (default: 0.0.0.0)");
+                println!("  --port, -p PORT     Port to listen on (default: 8080)");
+                println!("  --help, -h          Show this help message");
+                println!();
+                println!("Configuration:");
+                println!("  The server looks for groove-server.toml in the current directory");
+                println!("  if no --config option is specified.");
+                println!();
+                println!("Example config (groove-server.toml):");
+                println!("  host = \"0.0.0.0\"");
+                println!("  port = 8080");
+                println!();
+                println!("  [auth]");
+                println!("  provider = \"jwt\"  # or \"betterauth\", \"workos\", \"accept_all\"");
+                println!();
+                println!("  [auth.jwt]");
+                println!("  secret = \"your-secret-key\"");
+                println!("  issuer = \"https://auth.example.com\"");
+                println!();
+                println!("  [auth.provisioning]");
+                println!("  auto_provision = true");
                 std::process::exit(0);
             }
             other => {
@@ -70,11 +139,29 @@ async fn main() {
         }
     }
 
+    // Load configuration
+    let mut config = if let Some(path) = config_path {
+        ServerConfig::from_file(&path).unwrap_or_else(|e| {
+            eprintln!("Error loading config from '{}': {}", path, e);
+            std::process::exit(1);
+        })
+    } else {
+        ServerConfig::load()
+    };
+
+    // Apply command-line overrides
+    if let Some(host) = host_override {
+        config.host = host;
+    }
+    if let Some(port) = port_override {
+        config.port = port;
+    }
+
     // Create in-memory environment (for MVP - production would use persistent storage)
     let env = Arc::new(MemoryEnvironment::new());
 
-    // Accept all tokens for MVP (production would validate against auth service)
-    let token_validator = Arc::new(AcceptAllTokens);
+    // Create token validator based on configuration
+    let token_validator = create_token_validator(&config);
 
     // Create app state
     let state = Arc::new(AppState::new(env, token_validator));
@@ -89,12 +176,17 @@ async fn main() {
     let app: Router = sync_router().with_state(state).layer(cors);
 
     // Bind and serve
-    let addr: SocketAddr = format!("{}:{}", host, port).parse().unwrap_or_else(|_| {
-        eprintln!("Error: Invalid address {}:{}", host, port);
+    let addr: SocketAddr = config.socket_addr().parse().unwrap_or_else(|_| {
+        eprintln!("Error: Invalid address {}", config.socket_addr());
         std::process::exit(1);
     });
 
     println!("Jazz Sync Server starting on http://{}", addr);
+    println!("Auth provider: {:?}", config.auth.provider);
+    if config.auth.provisioning.auto_provision {
+        println!("Auto-provisioning: enabled");
+    }
+    println!();
     println!("Endpoints:");
     println!("  POST /sync/subscribe   - Subscribe to a query (SSE stream)");
     println!("  POST /sync/unsubscribe - Unsubscribe from a query");

--- a/crates/groove-server/src/user_provisioning.rs
+++ b/crates/groove-server/src/user_provisioning.rs
@@ -1,0 +1,203 @@
+//! User auto-provisioning for JWT-authenticated users.
+//!
+//! This module handles mapping external user IDs (from JWT tokens) to
+//! Jazz ObjectIds, optionally creating new user records on first login.
+
+use std::collections::HashMap;
+use std::sync::RwLock;
+
+use groove::ObjectId;
+use groove::sync::{ClaimValue, ClientIdentity, TokenValidator};
+
+/// Trait for resolving external user IDs to Jazz ObjectIds.
+pub trait UserResolver: Send + Sync {
+    /// Try to find an existing Jazz user ID for the given external ID.
+    fn resolve(&self, external_id: &str) -> Option<ObjectId>;
+
+    /// Provision a new user and return their Jazz ObjectId.
+    /// Called when a user logs in for the first time if auto-provisioning is enabled.
+    fn provision(&self, external_id: &str, claims: &HashMap<String, ClaimValue>) -> ObjectId;
+}
+
+/// A simple in-memory user resolver for development/testing.
+///
+/// Maps external IDs to Jazz ObjectIds, creating deterministic IDs
+/// based on the external ID if not found.
+#[derive(Debug, Default)]
+pub struct InMemoryUserResolver {
+    /// Map from external ID to Jazz ObjectId.
+    users: RwLock<HashMap<String, ObjectId>>,
+}
+
+impl InMemoryUserResolver {
+    /// Create a new in-memory user resolver.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Pre-register a user mapping.
+    pub fn register(&self, external_id: impl Into<String>, user_id: ObjectId) {
+        self.users
+            .write()
+            .unwrap()
+            .insert(external_id.into(), user_id);
+    }
+}
+
+impl UserResolver for InMemoryUserResolver {
+    fn resolve(&self, external_id: &str) -> Option<ObjectId> {
+        self.users.read().unwrap().get(external_id).copied()
+    }
+
+    fn provision(&self, external_id: &str, _claims: &HashMap<String, ClaimValue>) -> ObjectId {
+        let mut users = self.users.write().unwrap();
+
+        // Check again in case another thread provisioned
+        if let Some(&id) = users.get(external_id) {
+            return id;
+        }
+
+        // Create a deterministic ID from the external ID
+        let user_id = ObjectId::from_key(&format!("user:{}", external_id));
+        users.insert(external_id.to_string(), user_id);
+        user_id
+    }
+}
+
+/// Token validator that wraps another validator and adds user resolution.
+///
+/// This validator:
+/// 1. Validates the JWT token using the inner validator
+/// 2. Resolves the external user ID to a Jazz ObjectId
+/// 3. Optionally provisions new users on first login
+pub struct ProvisioningTokenValidator<V, R> {
+    inner: V,
+    resolver: R,
+    auto_provision: bool,
+}
+
+impl<V, R> ProvisioningTokenValidator<V, R>
+where
+    V: TokenValidator,
+    R: UserResolver,
+{
+    /// Create a new provisioning validator.
+    pub fn new(inner: V, resolver: R, auto_provision: bool) -> Self {
+        Self {
+            inner,
+            resolver,
+            auto_provision,
+        }
+    }
+
+    /// Create a validator with auto-provisioning enabled.
+    pub fn with_auto_provision(inner: V, resolver: R) -> Self {
+        Self::new(inner, resolver, true)
+    }
+
+    /// Create a validator without auto-provisioning.
+    pub fn without_auto_provision(inner: V, resolver: R) -> Self {
+        Self::new(inner, resolver, false)
+    }
+}
+
+impl<V, R> TokenValidator for ProvisioningTokenValidator<V, R>
+where
+    V: TokenValidator,
+    R: UserResolver,
+{
+    fn validate(&self, token: &str) -> Option<ClientIdentity> {
+        // First validate the JWT
+        let mut identity = self.inner.validate(token)?;
+
+        // Try to resolve existing user
+        if let Some(user_id) = self.resolver.resolve(&identity.external_id) {
+            identity.user_id = Some(user_id);
+        } else if self.auto_provision {
+            // Provision new user
+            let user_id = self
+                .resolver
+                .provision(&identity.external_id, &identity.claims);
+            identity.user_id = Some(user_id);
+        }
+        // If no resolution and no auto-provision, user_id stays None
+        // Policy evaluation will use effective_user_id() which creates a deterministic ID
+
+        Some(identity)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use groove::sync::AcceptAllTokens;
+
+    #[test]
+    fn test_in_memory_resolver() {
+        let resolver = InMemoryUserResolver::new();
+
+        // Initially no user
+        assert!(resolver.resolve("user123").is_none());
+
+        // Provision creates a user
+        let user_id = resolver.provision("user123", &HashMap::new());
+        assert!(user_id.to_string().len() > 0);
+
+        // Now resolves to the same ID
+        assert_eq!(resolver.resolve("user123"), Some(user_id));
+
+        // Provisioning again returns the same ID
+        let user_id2 = resolver.provision("user123", &HashMap::new());
+        assert_eq!(user_id, user_id2);
+    }
+
+    #[test]
+    fn test_pre_registered_user() {
+        let resolver = InMemoryUserResolver::new();
+        let preset_id = ObjectId::new(12345);
+
+        resolver.register("alice", preset_id);
+
+        assert_eq!(resolver.resolve("alice"), Some(preset_id));
+    }
+
+    #[test]
+    fn test_provisioning_validator_with_auto_provision() {
+        let inner = AcceptAllTokens;
+        let resolver = InMemoryUserResolver::new();
+        let validator = ProvisioningTokenValidator::with_auto_provision(inner, resolver);
+
+        let identity = validator.validate("some-token").unwrap();
+
+        // Should have a user_id assigned
+        assert!(identity.user_id.is_some());
+    }
+
+    #[test]
+    fn test_provisioning_validator_without_auto_provision() {
+        let inner = AcceptAllTokens;
+        let resolver = InMemoryUserResolver::new();
+        let validator = ProvisioningTokenValidator::without_auto_provision(inner, resolver);
+
+        let identity = validator.validate("some-token").unwrap();
+
+        // Should not have a user_id (no auto-provision)
+        assert!(identity.user_id.is_none());
+    }
+
+    #[test]
+    fn test_provisioning_validator_with_existing_user() {
+        let inner = AcceptAllTokens;
+        let resolver = InMemoryUserResolver::new();
+        let preset_id = ObjectId::new(99999);
+        resolver.register("existing-user", preset_id);
+
+        let validator = ProvisioningTokenValidator::without_auto_provision(inner, resolver);
+
+        // The token value is the external_id for AcceptAllTokens
+        let identity = validator.validate("existing-user").unwrap();
+
+        // Should have the preset user_id
+        assert_eq!(identity.user_id, Some(preset_id));
+    }
+}

--- a/crates/groove/Cargo.toml
+++ b/crates/groove/Cargo.toml
@@ -9,6 +9,8 @@ wasm = ["uuid/js", "getrandom/js", "dep:web-time"]
 # sync-server feature enables server-side sync types (SyncServer, etc.)
 # but NOT the axum handlers - those live in groove-server crate
 sync-server = ["dep:tokio", "dep:tokio-stream"]
+# jwt-auth feature enables JWT token validation for authentication
+jwt-auth = ["dep:jsonwebtoken", "dep:serde", "dep:serde_json"]
 
 [dependencies]
 blake3 = "1"
@@ -23,6 +25,11 @@ web-time = { version = "1", optional = true }
 # Sync server dependencies (optional)
 tokio = { version = "1", features = ["sync", "rt", "time"], optional = true }
 tokio-stream = { version = "0.1", optional = true }
+
+# JWT authentication dependencies (optional)
+jsonwebtoken = { version = "9", optional = true }
+serde = { version = "1", features = ["derive"], optional = true }
+serde_json = { version = "1", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2", features = ["js"] }

--- a/crates/groove/src/sql/database/mod.rs
+++ b/crates/groove/src/sql/database/mod.rs
@@ -3247,6 +3247,14 @@ impl Database {
                     position: 0,
                 }))
             }
+            // CONTAINS and IN require runtime claim evaluation
+            PolicyExpr::Contains(_, _) | PolicyExpr::In(_, _) => {
+                Err(DatabaseError::Parse(parser::ParseError {
+                    message: "CONTAINS/IN on claims cannot be converted to static predicate"
+                        .to_string(),
+                    position: 0,
+                }))
+            }
         }
     }
 

--- a/crates/groove/src/sql/parser.rs
+++ b/crates/groove/src/sql/parser.rs
@@ -1039,6 +1039,18 @@ impl<'a> Parser<'a> {
             return Ok(PolicyExpr::IsNull(left));
         }
 
+        // Check for CONTAINS: @viewer.claims.roles CONTAINS 'admin'
+        if self.try_keyword("CONTAINS") {
+            let right = self.parse_policy_value()?;
+            return Ok(PolicyExpr::Contains(left, right));
+        }
+
+        // Check for IN: team_id IN @viewer.claims.groups
+        if self.try_keyword("IN") {
+            let right = self.parse_policy_value()?;
+            return Ok(PolicyExpr::In(left, right));
+        }
+
         // Check for comparison operators
         let op = self.parse_comparison_op()?;
         let right = self.parse_policy_value()?;
@@ -1101,7 +1113,28 @@ impl<'a> Parser<'a> {
             let ident = self.parse_identifier()?;
 
             match ident.to_lowercase().as_str() {
-                "viewer" => return Ok(PolicyValue::Viewer),
+                "viewer" => {
+                    // Check for @viewer.external_id or @viewer.claims.*
+                    if self.peek_char() == Some('.') {
+                        self.consume_char();
+                        let prop = self.parse_identifier()?;
+                        match prop.to_lowercase().as_str() {
+                            "external_id" => return Ok(PolicyValue::ViewerExternalId),
+                            "claims" => {
+                                self.expect_char('.')?;
+                                let claim_name = self.parse_identifier()?;
+                                return Ok(PolicyValue::ViewerClaim(claim_name));
+                            }
+                            _ => {
+                                return Err(self.error(format!(
+                                    "unknown @viewer property '{}'. Use @viewer.external_id or @viewer.claims.<name>",
+                                    prop
+                                )));
+                            }
+                        }
+                    }
+                    return Ok(PolicyValue::Viewer);
+                }
                 "old" => {
                     self.expect_char('.')?;
                     let col = self.parse_identifier()?;

--- a/crates/groove/src/sql/policy.rs
+++ b/crates/groove/src/sql/policy.rs
@@ -10,6 +10,9 @@ use crate::sql::query_graph::PredicateValue;
 use crate::sql::row_buffer::OwnedRow;
 use std::collections::HashMap;
 
+#[cfg(feature = "sync-server")]
+use crate::sync::ClaimValue;
+
 /// Policy action type.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum PolicyAction {
@@ -128,6 +131,14 @@ pub enum PolicyExpr {
         /// Column reference (either column name or @new.column)
         column: PolicyColumnRef,
     },
+
+    /// Array contains check: array CONTAINS value
+    /// e.g., @viewer.claims.roles CONTAINS 'admin'
+    Contains(PolicyValue, PolicyValue),
+
+    /// Value in array check: value IN array
+    /// e.g., team_id IN @viewer.claims.groups
+    In(PolicyValue, PolicyValue),
 }
 
 impl PolicyExpr {
@@ -155,6 +166,18 @@ impl PolicyExpr {
     pub fn inherits(action: PolicyAction, column: PolicyColumnRef) -> Self {
         PolicyExpr::Inherits { action, column }
     }
+
+    /// Create a CONTAINS expression (array contains value).
+    /// e.g., @viewer.claims.roles CONTAINS 'admin'
+    pub fn contains(array: PolicyValue, value: PolicyValue) -> Self {
+        PolicyExpr::Contains(array, value)
+    }
+
+    /// Create an IN expression (value in array).
+    /// e.g., team_id IN @viewer.claims.groups
+    pub fn is_in(value: PolicyValue, array: PolicyValue) -> Self {
+        PolicyExpr::In(value, array)
+    }
 }
 
 /// A value in a policy expression.
@@ -166,8 +189,12 @@ pub enum PolicyValue {
     OldColumn(String),
     /// Column on new row (@new.column, for INSERT/UPDATE CHECK)
     NewColumn(String),
-    /// The viewer's user ID (@viewer)
+    /// The viewer's user ObjectId (@viewer)
     Viewer,
+    /// The viewer's external ID from auth provider (@viewer.external_id)
+    ViewerExternalId,
+    /// A viewer claim value (@viewer.claims.subscriptionTier)
+    ViewerClaim(String),
     /// A literal value
     Literal(PredicateValue),
 }
@@ -186,6 +213,11 @@ impl PolicyValue {
     /// Create an @new column reference.
     pub fn new_column(name: impl Into<String>) -> Self {
         PolicyValue::NewColumn(name.into())
+    }
+
+    /// Create a viewer claim reference (@viewer.claims.name).
+    pub fn viewer_claim(name: impl Into<String>) -> Self {
+        PolicyValue::ViewerClaim(name.into())
     }
 
     /// Create a literal value.
@@ -420,6 +452,16 @@ fn serialize_expr(buf: &mut Vec<u8>, expr: &PolicyExpr) {
             buf.push(action.tag());
             serialize_column_ref(buf, column);
         }
+        PolicyExpr::Contains(array, value) => {
+            buf.push(12);
+            serialize_value(buf, array);
+            serialize_value(buf, value);
+        }
+        PolicyExpr::In(value, array) => {
+            buf.push(13);
+            serialize_value(buf, value);
+            serialize_value(buf, array);
+        }
     }
 }
 
@@ -443,6 +485,13 @@ fn serialize_value(buf: &mut Vec<u8>, val: &PolicyValue) {
         PolicyValue::Literal(v) => {
             buf.push(4);
             serialize_literal(buf, v);
+        }
+        PolicyValue::ViewerExternalId => {
+            buf.push(5);
+        }
+        PolicyValue::ViewerClaim(name) => {
+            buf.push(6);
+            serialize_string(buf, name);
         }
     }
 }
@@ -617,6 +666,18 @@ fn deserialize_expr(data: &[u8], pos: usize) -> Result<(PolicyExpr, usize), Poli
             let (column, new_pos) = deserialize_column_ref(data, pos)?;
             Ok((PolicyExpr::Inherits { action, column }, new_pos))
         }
+        12 => {
+            // Contains
+            let (array, new_pos) = deserialize_value(data, pos)?;
+            let (value, new_pos) = deserialize_value(data, new_pos)?;
+            Ok((PolicyExpr::Contains(array, value), new_pos))
+        }
+        13 => {
+            // In
+            let (value, new_pos) = deserialize_value(data, pos)?;
+            let (array, new_pos) = deserialize_value(data, new_pos)?;
+            Ok((PolicyExpr::In(value, array), new_pos))
+        }
         _ => Err(PolicyError::DeserializationError(format!(
             "invalid expr tag: {}",
             tag
@@ -651,6 +712,11 @@ fn deserialize_value(data: &[u8], pos: usize) -> Result<(PolicyValue, usize), Po
         4 => {
             let (lit, new_pos) = deserialize_literal(data, pos)?;
             Ok((PolicyValue::Literal(lit), new_pos))
+        }
+        5 => Ok((PolicyValue::ViewerExternalId, pos)),
+        6 => {
+            let (name, new_pos) = deserialize_string(data, pos)?;
+            Ok((PolicyValue::ViewerClaim(name), new_pos))
         }
         _ => Err(PolicyError::DeserializationError(format!(
             "invalid value tag: {}",
@@ -952,6 +1018,43 @@ impl PolicyResult {
     }
 }
 
+/// Context for the viewer (authenticated user) including claims from JWT.
+#[cfg(feature = "sync-server")]
+#[derive(Debug, Clone)]
+pub struct ViewerContext {
+    /// The viewer's Jazz ObjectId (for @viewer).
+    pub user_id: ObjectId,
+    /// The viewer's external ID from auth provider (for @viewer.external_id).
+    pub external_id: String,
+    /// JWT claims for policy evaluation (for @viewer.claims.*).
+    pub claims: HashMap<String, ClaimValue>,
+}
+
+#[cfg(feature = "sync-server")]
+impl ViewerContext {
+    /// Create a new viewer context.
+    pub fn new(user_id: ObjectId, external_id: String) -> Self {
+        Self {
+            user_id,
+            external_id,
+            claims: HashMap::new(),
+        }
+    }
+
+    /// Create a viewer context with claims.
+    pub fn with_claims(
+        user_id: ObjectId,
+        external_id: String,
+        claims: HashMap<String, ClaimValue>,
+    ) -> Self {
+        Self {
+            user_id,
+            external_id,
+            claims,
+        }
+    }
+}
+
 /// Policy evaluator with cycle detection and depth limiting.
 pub struct PolicyEvaluator<'a, R: RowLookup, P: PolicyLookup> {
     /// Row lookup implementation.
@@ -960,6 +1063,9 @@ pub struct PolicyEvaluator<'a, R: RowLookup, P: PolicyLookup> {
     policy_lookup: &'a P,
     /// The viewer's user ID.
     viewer: ObjectId,
+    /// Optional viewer context with claims (for @viewer.claims.* support).
+    #[cfg(feature = "sync-server")]
+    viewer_context: Option<ViewerContext>,
     /// Configuration.
     config: PolicyConfig,
     /// Visited (table, row_id) pairs for cycle detection.
@@ -987,6 +1093,28 @@ impl<'a, R: RowLookup, P: PolicyLookup> PolicyEvaluator<'a, R, P> {
             row_lookup,
             policy_lookup,
             viewer,
+            #[cfg(feature = "sync-server")]
+            viewer_context: None,
+            config,
+            visited: HashSet::new(),
+            depth: 0,
+            warned_tables: &WARNED_TABLES,
+        }
+    }
+
+    /// Create a new policy evaluator with a viewer context (for claims support).
+    #[cfg(feature = "sync-server")]
+    pub fn new_with_context(
+        row_lookup: &'a R,
+        policy_lookup: &'a P,
+        viewer_context: ViewerContext,
+        config: PolicyConfig,
+    ) -> Self {
+        PolicyEvaluator {
+            row_lookup,
+            policy_lookup,
+            viewer: viewer_context.user_id,
+            viewer_context: Some(viewer_context),
             config,
             visited: HashSet::new(),
             depth: 0,
@@ -1211,6 +1339,86 @@ impl<'a, R: RowLookup, P: PolicyLookup> PolicyEvaluator<'a, R, P> {
             PolicyExpr::Inherits { action, column } => {
                 self.eval_inherits(*action, column, ctx, table)
             }
+            PolicyExpr::Contains(array, value) => {
+                // Array CONTAINS value check
+                // Only supported with sync-server feature for viewer claims
+                #[cfg(feature = "sync-server")]
+                {
+                    self.eval_contains(array, value, ctx)
+                }
+                #[cfg(not(feature = "sync-server"))]
+                {
+                    let _ = (array, value);
+                    false
+                }
+            }
+            PolicyExpr::In(value, array) => {
+                // Value IN array check (inverse of contains)
+                #[cfg(feature = "sync-server")]
+                {
+                    self.eval_contains(array, value, ctx)
+                }
+                #[cfg(not(feature = "sync-server"))]
+                {
+                    let _ = (value, array);
+                    false
+                }
+            }
+        }
+    }
+
+    /// Evaluate a CONTAINS expression (array contains value).
+    #[cfg(feature = "sync-server")]
+    fn eval_contains(
+        &self,
+        array_val: &PolicyValue,
+        target_val: &PolicyValue,
+        ctx: &EvalContext,
+    ) -> bool {
+        // For viewer claims, we need to check the claims map
+        // For other values, resolve and compare
+        match array_val {
+            PolicyValue::ViewerClaim(claim_name) => {
+                // Get the claim array from viewer context and check if it contains target
+                if let Some(claim) = self
+                    .viewer_context
+                    .as_ref()
+                    .and_then(|vc| vc.claims.get(claim_name))
+                    && let Some(target) = self.resolve_value_to_claim(target_val, ctx)
+                {
+                    return claim.contains(&target);
+                }
+                false
+            }
+            _ => {
+                // For non-claim arrays, we can't currently evaluate CONTAINS
+                // This would require array support in PredicateValue
+                false
+            }
+        }
+    }
+
+    /// Resolve a PolicyValue to a ClaimValue for comparison with claims.
+    #[cfg(feature = "sync-server")]
+    fn resolve_value_to_claim(&self, pv: &PolicyValue, ctx: &EvalContext) -> Option<ClaimValue> {
+        match pv {
+            PolicyValue::Literal(v) => match v {
+                PredicateValue::String(s) => Some(ClaimValue::String(s.clone())),
+                PredicateValue::I64(n) => Some(ClaimValue::Number(*n as f64)),
+                PredicateValue::F64(n) => Some(ClaimValue::Number(*n)),
+                PredicateValue::Bool(b) => Some(ClaimValue::Bool(*b)),
+                PredicateValue::Null => Some(ClaimValue::Null),
+                _ => None,
+            },
+            PolicyValue::Column(name) => ctx.get_column(name).and_then(|v| match v {
+                PredicateValue::String(s) => Some(ClaimValue::String(s)),
+                PredicateValue::I64(n) => Some(ClaimValue::Number(n as f64)),
+                PredicateValue::F64(n) => Some(ClaimValue::Number(n)),
+                PredicateValue::Bool(b) => Some(ClaimValue::Bool(b)),
+                PredicateValue::Null => Some(ClaimValue::Null),
+                _ => None,
+            }),
+            _ => None,
         }
     }
 
@@ -1221,6 +1429,43 @@ impl<'a, R: RowLookup, P: PolicyLookup> PolicyEvaluator<'a, R, P> {
             PolicyValue::OldColumn(name) => ctx.get_old_column(name),
             PolicyValue::NewColumn(name) => ctx.get_new_column(name),
             PolicyValue::Viewer => Some(PredicateValue::Ref(self.viewer)),
+            PolicyValue::ViewerExternalId => {
+                #[cfg(feature = "sync-server")]
+                {
+                    self.viewer_context
+                        .as_ref()
+                        .map(|vc| PredicateValue::String(vc.external_id.clone()))
+                }
+                #[cfg(not(feature = "sync-server"))]
+                {
+                    None
+                }
+            }
+            PolicyValue::ViewerClaim(name) => {
+                #[cfg(feature = "sync-server")]
+                {
+                    self.viewer_context.as_ref().and_then(|vc| {
+                        vc.claims.get(name).and_then(|cv| match cv {
+                            ClaimValue::String(s) => Some(PredicateValue::String(s.clone())),
+                            ClaimValue::Number(n) => {
+                                if n.fract() == 0.0 {
+                                    Some(PredicateValue::I64(*n as i64))
+                                } else {
+                                    Some(PredicateValue::F64(*n))
+                                }
+                            }
+                            ClaimValue::Bool(b) => Some(PredicateValue::Bool(*b)),
+                            ClaimValue::Null => Some(PredicateValue::Null),
+                            ClaimValue::Array(_) => None, // Arrays need special handling via CONTAINS
+                        })
+                    })
+                }
+                #[cfg(not(feature = "sync-server"))]
+                {
+                    let _ = name;
+                    None
+                }
+            }
             PolicyValue::Literal(v) => Some(v.clone()),
         }
     }

--- a/crates/groove/src/sync/jwt.rs
+++ b/crates/groove/src/sync/jwt.rs
@@ -1,0 +1,485 @@
+//! JWT token validation for authentication.
+//!
+//! This module provides JWT validation for authenticating clients with tokens
+//! from external auth providers like BetterAuth or WorkOS.
+//!
+//! # Example
+//!
+//! ```ignore
+//! use groove::sync::jwt::{JwtConfig, JwtTokenValidator};
+//!
+//! let config = JwtConfig {
+//!     secret: Some("my-secret-key".to_string()),
+//!     issuer: Some("https://auth.example.com".to_string()),
+//!     audience: Some("my-app".to_string()),
+//!     user_id_claim: "sub".to_string(),
+//!     ..Default::default()
+//! };
+//!
+//! let validator = JwtTokenValidator::new(config);
+//! ```
+
+use std::collections::HashMap;
+use std::sync::RwLock;
+
+use jsonwebtoken::{Algorithm, DecodingKey, Validation, decode};
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+
+use super::server::{ClaimValue, ClientIdentity, TokenValidator};
+use crate::ObjectId;
+
+/// Configuration for JWT token validation.
+#[derive(Debug, Clone, Default)]
+pub struct JwtConfig {
+    /// JWKS URL for RS256/RS384/RS512 validation (production).
+    /// If set, keys will be fetched from this endpoint.
+    pub jwks_url: Option<String>,
+
+    /// Secret key for HS256 validation (development/testing).
+    /// If set and jwks_url is not set, this will be used.
+    pub secret: Option<String>,
+
+    /// Expected token issuer (`iss` claim).
+    pub issuer: Option<String>,
+
+    /// Expected token audience (`aud` claim).
+    pub audience: Option<String>,
+
+    /// Claim name containing the user ID (default: "sub").
+    pub user_id_claim: String,
+
+    /// Optional claim name containing a pre-resolved Jazz ObjectId.
+    /// If present in the token, this will be used as user_id directly.
+    pub jazz_user_id_claim: Option<String>,
+
+    /// Claims to extract from the token for policy evaluation.
+    /// If empty, all claims will be extracted.
+    pub extract_claims: Vec<String>,
+
+    /// Whether to validate token expiration (default: true).
+    pub validate_exp: bool,
+}
+
+impl JwtConfig {
+    /// Create a new config for HS256 validation with a secret.
+    pub fn with_secret(secret: impl Into<String>) -> Self {
+        Self {
+            secret: Some(secret.into()),
+            user_id_claim: "sub".to_string(),
+            validate_exp: true,
+            ..Default::default()
+        }
+    }
+
+    /// Create a new config for RS256 validation with a JWKS URL.
+    pub fn with_jwks(url: impl Into<String>) -> Self {
+        Self {
+            jwks_url: Some(url.into()),
+            user_id_claim: "sub".to_string(),
+            validate_exp: true,
+            ..Default::default()
+        }
+    }
+}
+
+/// Cached JWKS keys.
+#[derive(Default)]
+struct JwksCache {
+    /// Cached keys indexed by key ID (kid).
+    keys: HashMap<String, DecodingKey>,
+    /// When the cache was last updated.
+    last_updated: Option<std::time::Instant>,
+}
+
+impl std::fmt::Debug for JwksCache {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("JwksCache")
+            .field("num_keys", &self.keys.len())
+            .field("last_updated", &self.last_updated)
+            .finish()
+    }
+}
+
+/// JWT token validator implementing the TokenValidator trait.
+pub struct JwtTokenValidator {
+    config: JwtConfig,
+    /// Decoding key for HS256 (from secret).
+    hs256_key: Option<DecodingKey>,
+    /// Cached JWKS keys for RS256 (placeholder for future JWKS support).
+    #[allow(dead_code)]
+    jwks_cache: RwLock<JwksCache>,
+}
+
+impl std::fmt::Debug for JwtTokenValidator {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("JwtTokenValidator")
+            .field("config", &self.config)
+            .field("has_hs256_key", &self.hs256_key.is_some())
+            .finish()
+    }
+}
+
+impl JwtTokenValidator {
+    /// Create a new JWT validator with the given configuration.
+    pub fn new(config: JwtConfig) -> Self {
+        let hs256_key = config
+            .secret
+            .as_ref()
+            .map(|s| DecodingKey::from_secret(s.as_bytes()));
+
+        Self {
+            config,
+            hs256_key,
+            jwks_cache: RwLock::new(JwksCache::default()),
+        }
+    }
+
+    /// Create a simple HS256 validator for testing.
+    pub fn hs256(secret: impl Into<String>) -> Self {
+        Self::new(JwtConfig::with_secret(secret))
+    }
+
+    /// Validate a token and extract claims.
+    fn validate_token(&self, token: &str) -> Option<TokenClaims> {
+        // Build validation settings
+        let mut validation = Validation::default();
+
+        if let Some(ref iss) = self.config.issuer {
+            validation.set_issuer(&[iss]);
+        }
+
+        if let Some(ref aud) = self.config.audience {
+            validation.set_audience(&[aud]);
+        }
+
+        validation.validate_exp = self.config.validate_exp;
+
+        // Try HS256 first if we have a secret
+        if let Some(ref key) = self.hs256_key {
+            validation.algorithms = vec![Algorithm::HS256];
+            if let Ok(data) = decode::<TokenClaims>(token, key, &validation) {
+                return Some(data.claims);
+            }
+        }
+
+        // TODO: Try JWKS keys for RS256/RS384/RS512
+        // This would require async key fetching which is not yet implemented.
+        // For now, only HS256 is supported.
+
+        None
+    }
+
+    /// Extract claims from a JSON value into ClaimValue.
+    fn json_to_claim_value(value: &JsonValue) -> ClaimValue {
+        match value {
+            JsonValue::String(s) => ClaimValue::String(s.clone()),
+            JsonValue::Number(n) => ClaimValue::Number(n.as_f64().unwrap_or(0.0)),
+            JsonValue::Bool(b) => ClaimValue::Bool(*b),
+            JsonValue::Array(arr) => {
+                ClaimValue::Array(arr.iter().map(Self::json_to_claim_value).collect())
+            }
+            JsonValue::Null => ClaimValue::Null,
+            JsonValue::Object(_) => {
+                // For nested objects, serialize to string for now
+                ClaimValue::String(value.to_string())
+            }
+        }
+    }
+}
+
+/// Claims structure for JWT tokens.
+/// Uses serde_json::Value to capture all claims dynamically.
+#[derive(Debug, Serialize, Deserialize)]
+struct TokenClaims {
+    /// Subject (user ID)
+    #[serde(default)]
+    sub: Option<String>,
+
+    /// Expiration time
+    #[serde(default)]
+    exp: Option<u64>,
+
+    /// Issued at
+    #[serde(default)]
+    iat: Option<u64>,
+
+    /// Issuer
+    #[serde(default)]
+    iss: Option<String>,
+
+    /// Audience
+    #[serde(default)]
+    aud: Option<StringOrArray>,
+
+    /// Name claim
+    #[serde(default)]
+    name: Option<String>,
+
+    /// Email claim
+    #[serde(default)]
+    email: Option<String>,
+
+    /// All other claims
+    #[serde(flatten)]
+    other: HashMap<String, JsonValue>,
+}
+
+/// Helper for audience which can be string or array.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(untagged)]
+enum StringOrArray {
+    String(String),
+    Array(Vec<String>),
+}
+
+impl TokenValidator for JwtTokenValidator {
+    fn validate(&self, token: &str) -> Option<ClientIdentity> {
+        let claims = self.validate_token(token)?;
+
+        // Extract user ID from configured claim
+        let external_id = if self.config.user_id_claim == "sub" {
+            claims.sub.clone()
+        } else {
+            claims
+                .other
+                .get(&self.config.user_id_claim)
+                .and_then(|v| v.as_str().map(|s| s.to_string()))
+        }?;
+
+        // Try to extract Jazz ObjectId if configured
+        let user_id = self.config.jazz_user_id_claim.as_ref().and_then(|claim| {
+            claims
+                .other
+                .get(claim)
+                .and_then(|v| v.as_str())
+                .and_then(|s| s.parse::<ObjectId>().ok())
+        });
+
+        // Build claims map
+        let mut claim_map = HashMap::new();
+
+        // Add standard claims
+        if let Some(ref email) = claims.email {
+            claim_map.insert("email".to_string(), ClaimValue::String(email.clone()));
+        }
+        if let Some(ref name) = claims.name {
+            claim_map.insert("name".to_string(), ClaimValue::String(name.clone()));
+        }
+        if let Some(ref iss) = claims.iss {
+            claim_map.insert("iss".to_string(), ClaimValue::String(iss.clone()));
+        }
+
+        // Add other claims
+        let claims_to_extract = if self.config.extract_claims.is_empty() {
+            // Extract all claims
+            claims.other.keys().cloned().collect::<Vec<_>>()
+        } else {
+            self.config.extract_claims.clone()
+        };
+
+        for claim_name in claims_to_extract {
+            if let Some(value) = claims.other.get(&claim_name) {
+                claim_map.insert(claim_name, Self::json_to_claim_value(value));
+            }
+        }
+
+        Some(ClientIdentity {
+            external_id,
+            user_id,
+            name: claims.name,
+            claims: claim_map,
+            expires_at: claims.exp,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use jsonwebtoken::{EncodingKey, Header, encode};
+
+    fn create_test_token(claims: &TokenClaims, secret: &str) -> String {
+        encode(
+            &Header::default(),
+            claims,
+            &EncodingKey::from_secret(secret.as_bytes()),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn test_validate_simple_token() {
+        let secret = "test-secret-key-at-least-32-bytes";
+        let validator = JwtTokenValidator::hs256(secret);
+
+        let claims = TokenClaims {
+            sub: Some("user123".to_string()),
+            exp: Some(u64::MAX), // Far future
+            iat: Some(0),
+            iss: None,
+            aud: None,
+            name: Some("Test User".to_string()),
+            email: Some("test@example.com".to_string()),
+            other: HashMap::new(),
+        };
+
+        let token = create_test_token(&claims, secret);
+        let identity = validator.validate(&token).expect("should validate");
+
+        assert_eq!(identity.external_id, "user123");
+        assert_eq!(identity.name, Some("Test User".to_string()));
+        assert_eq!(
+            identity.get_claim("email"),
+            Some(&ClaimValue::String("test@example.com".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_validate_token_with_custom_claims() {
+        let secret = "test-secret-key-at-least-32-bytes";
+        let validator = JwtTokenValidator::hs256(secret);
+
+        let mut other = HashMap::new();
+        other.insert(
+            "orgId".to_string(),
+            JsonValue::String("org_123".to_string()),
+        );
+        other.insert(
+            "subscriptionTier".to_string(),
+            JsonValue::String("pro".to_string()),
+        );
+        other.insert(
+            "roles".to_string(),
+            JsonValue::Array(vec![
+                JsonValue::String("admin".to_string()),
+                JsonValue::String("editor".to_string()),
+            ]),
+        );
+
+        let claims = TokenClaims {
+            sub: Some("user456".to_string()),
+            exp: Some(u64::MAX),
+            iat: None,
+            iss: None,
+            aud: None,
+            name: None,
+            email: None,
+            other,
+        };
+
+        let token = create_test_token(&claims, secret);
+        let identity = validator.validate(&token).expect("should validate");
+
+        assert_eq!(identity.external_id, "user456");
+
+        // Check custom claims
+        assert_eq!(
+            identity.get_claim("orgId"),
+            Some(&ClaimValue::String("org_123".to_string()))
+        );
+        assert_eq!(
+            identity.get_claim("subscriptionTier"),
+            Some(&ClaimValue::String("pro".to_string()))
+        );
+
+        // Check array claim
+        match identity.get_claim("roles") {
+            Some(ClaimValue::Array(roles)) => {
+                assert_eq!(roles.len(), 2);
+                assert_eq!(roles[0], ClaimValue::String("admin".to_string()));
+                assert_eq!(roles[1], ClaimValue::String("editor".to_string()));
+            }
+            _ => panic!("expected array claim"),
+        }
+    }
+
+    #[test]
+    fn test_invalid_token_rejected() {
+        let validator = JwtTokenValidator::hs256("correct-secret-key-32-bytes-long");
+        let result = validator.validate("invalid-token");
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_wrong_secret_rejected() {
+        let secret = "correct-secret-key-32-bytes-long";
+        let claims = TokenClaims {
+            sub: Some("user123".to_string()),
+            exp: Some(u64::MAX),
+            iat: None,
+            iss: None,
+            aud: None,
+            name: None,
+            email: None,
+            other: HashMap::new(),
+        };
+
+        let token = create_test_token(&claims, secret);
+
+        let validator = JwtTokenValidator::hs256("wrong-secret-key-32-bytes-long!!");
+        let result = validator.validate(&token);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_issuer_validation() {
+        let secret = "test-secret-key-at-least-32-bytes";
+        let config = JwtConfig {
+            secret: Some(secret.to_string()),
+            issuer: Some("https://auth.example.com".to_string()),
+            user_id_claim: "sub".to_string(),
+            validate_exp: true,
+            ..Default::default()
+        };
+        let validator = JwtTokenValidator::new(config);
+
+        // Token with wrong issuer should be rejected
+        let claims = TokenClaims {
+            sub: Some("user123".to_string()),
+            exp: Some(u64::MAX),
+            iat: None,
+            iss: Some("https://wrong-issuer.com".to_string()),
+            aud: None,
+            name: None,
+            email: None,
+            other: HashMap::new(),
+        };
+
+        let token = create_test_token(&claims, secret);
+        let result = validator.validate(&token);
+        assert!(result.is_none());
+
+        // Token with correct issuer should be accepted
+        let claims = TokenClaims {
+            sub: Some("user123".to_string()),
+            exp: Some(u64::MAX),
+            iat: None,
+            iss: Some("https://auth.example.com".to_string()),
+            aud: None,
+            name: None,
+            email: None,
+            other: HashMap::new(),
+        };
+
+        let token = create_test_token(&claims, secret);
+        let result = validator.validate(&token);
+        assert!(result.is_some());
+    }
+
+    #[test]
+    fn test_claim_value_contains() {
+        let array = ClaimValue::Array(vec![
+            ClaimValue::String("admin".to_string()),
+            ClaimValue::String("editor".to_string()),
+        ]);
+
+        assert!(array.contains(&ClaimValue::String("admin".to_string())));
+        assert!(array.contains(&ClaimValue::String("editor".to_string())));
+        assert!(!array.contains(&ClaimValue::String("viewer".to_string())));
+
+        // Non-array doesn't contain anything
+        let single = ClaimValue::String("admin".to_string());
+        assert!(!single.contains(&ClaimValue::String("admin".to_string())));
+    }
+}

--- a/crates/groove/src/sync/mod.rs
+++ b/crates/groove/src/sync/mod.rs
@@ -39,6 +39,13 @@ mod server;
 #[cfg(all(feature = "sync-server", not(target_arch = "wasm32")))]
 pub mod test_harness;
 
+#[cfg(all(
+    feature = "jwt-auth",
+    feature = "sync-server",
+    not(target_arch = "wasm32")
+))]
+pub mod jwt;
+
 pub use client::*;
 pub use env::*;
 pub use negotiation::*;

--- a/crates/groove/src/sync/server.rs
+++ b/crates/groove/src/sync/server.rs
@@ -26,13 +26,128 @@ pub struct SessionId(pub u64);
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct QueryId(pub u32);
 
+/// A typed value from JWT claims.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ClaimValue {
+    /// String value
+    String(String),
+    /// Numeric value (f64 for JSON compatibility)
+    Number(f64),
+    /// Boolean value
+    Bool(bool),
+    /// Array of claim values
+    Array(Vec<ClaimValue>),
+    /// Null value
+    Null,
+}
+
+impl ClaimValue {
+    /// Check if this claim value contains a specific value (for CONTAINS operator).
+    /// Returns true if self is an array containing the target value.
+    pub fn contains(&self, target: &ClaimValue) -> bool {
+        match self {
+            ClaimValue::Array(arr) => arr.iter().any(|v| v == target),
+            _ => false,
+        }
+    }
+
+    /// Check if this claim value is contained in an array (for IN operator).
+    /// Returns true if target is an array containing self.
+    pub fn is_in(&self, target: &ClaimValue) -> bool {
+        target.contains(self)
+    }
+
+    /// Try to get as a string reference.
+    pub fn as_str(&self) -> Option<&str> {
+        match self {
+            ClaimValue::String(s) => Some(s),
+            _ => None,
+        }
+    }
+
+    /// Try to get as a number.
+    pub fn as_number(&self) -> Option<f64> {
+        match self {
+            ClaimValue::Number(n) => Some(*n),
+            _ => None,
+        }
+    }
+
+    /// Try to get as a boolean.
+    pub fn as_bool(&self) -> Option<bool> {
+        match self {
+            ClaimValue::Bool(b) => Some(*b),
+            _ => None,
+        }
+    }
+}
+
 /// Identity of an authenticated client.
 #[derive(Debug, Clone)]
 pub struct ClientIdentity {
-    /// Unique identifier for the client/user
-    pub id: String,
+    /// External user ID from the auth provider (e.g., JWT `sub` claim).
+    /// This is the primary identifier from the external auth system.
+    pub external_id: String,
+    /// Resolved Jazz User ObjectId (for @viewer in policies).
+    /// None if the user hasn't been provisioned yet.
+    pub user_id: Option<ObjectId>,
     /// Optional display name
     pub name: Option<String>,
+    /// JWT claims for policy evaluation.
+    /// Keys are claim names (e.g., "orgId", "subscriptionTier", "roles").
+    pub claims: HashMap<String, ClaimValue>,
+    /// Token expiration timestamp (Unix epoch seconds).
+    /// None if the token doesn't have an expiration.
+    pub expires_at: Option<u64>,
+}
+
+impl ClientIdentity {
+    /// Create a simple identity with just an external ID.
+    /// Used for testing and backward compatibility.
+    pub fn simple(id: impl Into<String>) -> Self {
+        Self {
+            external_id: id.into(),
+            user_id: None,
+            name: None,
+            claims: HashMap::new(),
+            expires_at: None,
+        }
+    }
+
+    /// Create an identity with an external ID and user ObjectId.
+    pub fn with_user_id(external_id: impl Into<String>, user_id: ObjectId) -> Self {
+        Self {
+            external_id: external_id.into(),
+            user_id: Some(user_id),
+            name: None,
+            claims: HashMap::new(),
+            expires_at: None,
+        }
+    }
+
+    /// Get a claim value by name.
+    pub fn get_claim(&self, name: &str) -> Option<&ClaimValue> {
+        self.claims.get(name)
+    }
+
+    /// Check if a claim exists.
+    pub fn has_claim(&self, name: &str) -> bool {
+        self.claims.contains_key(name)
+    }
+
+    /// Get the effective user ID for policy evaluation.
+    /// Returns the Jazz ObjectId if set, or a deterministic ID derived from external_id.
+    pub fn effective_user_id(&self) -> ObjectId {
+        self.user_id
+            .unwrap_or_else(|| ObjectId::from_key(&format!("user:{}", self.external_id)))
+    }
+
+    /// Legacy accessor for backward compatibility.
+    /// Returns the external_id (equivalent to old `id` field).
+    #[deprecated(note = "Use external_id directly")]
+    pub fn id(&self) -> &str {
+        &self.external_id
+    }
 }
 
 /// Trait for validating authentication tokens.
@@ -46,10 +161,7 @@ pub struct AcceptAllTokens;
 
 impl TokenValidator for AcceptAllTokens {
     fn validate(&self, token: &str) -> Option<ClientIdentity> {
-        Some(ClientIdentity {
-            id: token.to_string(),
-            name: None,
-        })
+        Some(ClientIdentity::simple(token))
     }
 }
 
@@ -338,7 +450,7 @@ impl<E: Environment> SyncServer<E> {
 
         // Track identity -> session mapping
         self.identity_sessions
-            .entry(identity.id.clone())
+            .entry(identity.external_id.clone())
             .or_default()
             .insert(id);
 
@@ -361,10 +473,13 @@ impl<E: Environment> SyncServer<E> {
             }
 
             // Clean up identity_sessions reverse index
-            if let Some(sessions) = self.identity_sessions.get_mut(&session.identity.id) {
+            if let Some(sessions) = self
+                .identity_sessions
+                .get_mut(&session.identity.external_id)
+            {
                 sessions.remove(&session_id);
                 if sessions.is_empty() {
-                    self.identity_sessions.remove(&session.identity.id);
+                    self.identity_sessions.remove(&session.identity.external_id);
                 }
             }
         }
@@ -1034,10 +1149,8 @@ mod tests {
         let mut server = make_server();
         let (tx, _rx) = tokio::sync::mpsc::channel(16);
 
-        let identity = ClientIdentity {
-            id: "user1".to_string(),
-            name: Some("User One".to_string()),
-        };
+        let mut identity = ClientIdentity::simple("user1");
+        identity.name = Some("User One".to_string());
 
         let session_id = server.create_session(identity, tx);
         assert!(server.get_session(&session_id).is_some());
@@ -1048,10 +1161,7 @@ mod tests {
         let mut server = make_server();
         let (tx, _rx) = tokio::sync::mpsc::channel(16);
 
-        let identity = ClientIdentity {
-            id: "user1".to_string(),
-            name: None,
-        };
+        let identity = ClientIdentity::simple("user1");
 
         let session_id = server.create_session(identity, tx);
         server.remove_session(session_id);
@@ -1063,10 +1173,7 @@ mod tests {
         let mut server = make_server();
         let (tx, _rx) = tokio::sync::mpsc::channel(16);
 
-        let identity = ClientIdentity {
-            id: "user1".to_string(),
-            name: None,
-        };
+        let identity = ClientIdentity::simple("user1");
 
         let session_id = server.create_session(identity, tx);
         let session = server.get_session_mut(&session_id).unwrap();
@@ -1097,10 +1204,7 @@ mod tests {
         let mut server = make_server();
         let (tx, _rx) = tokio::sync::mpsc::channel(16);
 
-        let identity = ClientIdentity {
-            id: "user1".to_string(),
-            name: None,
-        };
+        let identity = ClientIdentity::simple("user1");
 
         let session_id = server.create_session(identity, tx);
         let obj = ObjectId(42);
@@ -1125,20 +1229,8 @@ mod tests {
         let (tx1, mut rx1) = tokio::sync::mpsc::channel(16);
         let (tx2, mut rx2) = tokio::sync::mpsc::channel(16);
 
-        let s1 = server.create_session(
-            ClientIdentity {
-                id: "u1".to_string(),
-                name: None,
-            },
-            tx1,
-        );
-        let s2 = server.create_session(
-            ClientIdentity {
-                id: "u2".to_string(),
-                name: None,
-            },
-            tx2,
-        );
+        let s1 = server.create_session(ClientIdentity::simple("u1"), tx1);
+        let s2 = server.create_session(ClientIdentity::simple("u2"), tx2);
 
         let obj = ObjectId(42);
         server.register_object_session(obj, s1);

--- a/crates/groove/src/sync/synced_node.rs
+++ b/crates/groove/src/sync/synced_node.rs
@@ -337,7 +337,7 @@ impl ConnectedClients {
 
         // Track by identity
         self.identity_sessions
-            .entry(identity.id.clone())
+            .entry(identity.external_id.clone())
             .or_default()
             .insert(id);
 
@@ -359,7 +359,10 @@ impl ConnectedClients {
     pub fn remove_session(&mut self, id: SessionId) -> Option<ClientSession> {
         if let Some(session) = self.sessions.remove(&id) {
             // Remove from identity index
-            if let Some(sessions) = self.identity_sessions.get_mut(&session.identity.id) {
+            if let Some(sessions) = self
+                .identity_sessions
+                .get_mut(&session.identity.external_id)
+            {
                 sessions.remove(&id);
             }
 
@@ -370,7 +373,7 @@ impl ConnectedClients {
 
             // Keep stale state for reconnection
             self.stale_states.insert(
-                session.identity.id.clone(),
+                session.identity.external_id.clone(),
                 StaleClientState {
                     known_state: session.client_known_state.clone(),
                     removed_at: Instant::now(),

--- a/crates/groove/src/sync/test_harness.rs
+++ b/crates/groove/src/sync/test_harness.rs
@@ -67,10 +67,7 @@ impl TestTransport {
         token: &str,
         request: SubscribeRequest,
     ) -> Result<(SessionId, mpsc::Receiver<SseEvent>), ClientError> {
-        let identity = ClientIdentity {
-            id: token.to_string(),
-            name: None,
-        };
+        let identity = ClientIdentity::simple(token);
 
         let (tx, rx) = mpsc::channel::<SseEvent>(32);
 

--- a/crates/groove/tests/sql_parser.rs
+++ b/crates/groove/tests/sql_parser.rs
@@ -887,3 +887,237 @@ fn parse_create_table_with_blob() {
         _ => panic!("expected CreateTable"),
     }
 }
+
+// ========== Policy Parsing Tests: Claims and CONTAINS/IN ==========
+
+#[test]
+fn parse_policy_viewer_external_id() {
+    let sql = "CREATE POLICY ON users FOR SELECT WHERE external_id = @viewer.external_id";
+    let stmt = parse(sql).unwrap();
+
+    match stmt {
+        Statement::CreatePolicy(policy) => {
+            assert_eq!(policy.action, PolicyAction::Select);
+
+            match policy.where_clause {
+                Some(PolicyExpr::Eq(left, right)) => {
+                    assert_eq!(left, PolicyValue::Column("external_id".into()));
+                    assert_eq!(right, PolicyValue::ViewerExternalId);
+                }
+                _ => panic!("expected Eq expression"),
+            }
+        }
+        _ => panic!("expected CreatePolicy"),
+    }
+}
+
+#[test]
+fn parse_policy_viewer_claim() {
+    let sql = "CREATE POLICY ON premium_features FOR SELECT WHERE @viewer.claims.subscriptionTier = 'pro'";
+    let stmt = parse(sql).unwrap();
+
+    match stmt {
+        Statement::CreatePolicy(policy) => {
+            assert_eq!(policy.action, PolicyAction::Select);
+
+            match policy.where_clause {
+                Some(PolicyExpr::Eq(left, right)) => {
+                    assert_eq!(left, PolicyValue::ViewerClaim("subscriptionTier".into()));
+                    assert_eq!(
+                        right,
+                        PolicyValue::Literal(PredicateValue::String("pro".into()))
+                    );
+                }
+                _ => panic!("expected Eq expression"),
+            }
+        }
+        _ => panic!("expected CreatePolicy"),
+    }
+}
+
+#[test]
+fn parse_policy_viewer_claim_org_id() {
+    let sql = "CREATE POLICY ON org_documents FOR SELECT WHERE org_id = @viewer.claims.orgId";
+    let stmt = parse(sql).unwrap();
+
+    match stmt {
+        Statement::CreatePolicy(policy) => match policy.where_clause {
+            Some(PolicyExpr::Eq(left, right)) => {
+                assert_eq!(left, PolicyValue::Column("org_id".into()));
+                assert_eq!(right, PolicyValue::ViewerClaim("orgId".into()));
+            }
+            _ => panic!("expected Eq expression"),
+        },
+        _ => panic!("expected CreatePolicy"),
+    }
+}
+
+#[test]
+fn parse_policy_contains() {
+    let sql =
+        "CREATE POLICY ON admin_settings FOR UPDATE WHERE @viewer.claims.roles CONTAINS 'admin'";
+    let stmt = parse(sql).unwrap();
+
+    match stmt {
+        Statement::CreatePolicy(policy) => {
+            assert_eq!(policy.action, PolicyAction::Update);
+
+            match policy.where_clause {
+                Some(PolicyExpr::Contains(left, right)) => {
+                    assert_eq!(left, PolicyValue::ViewerClaim("roles".into()));
+                    assert_eq!(
+                        right,
+                        PolicyValue::Literal(PredicateValue::String("admin".into()))
+                    );
+                }
+                _ => panic!("expected Contains expression"),
+            }
+        }
+        _ => panic!("expected CreatePolicy"),
+    }
+}
+
+#[test]
+fn parse_policy_in() {
+    let sql = "CREATE POLICY ON team_docs FOR SELECT WHERE team_id IN @viewer.claims.groups";
+    let stmt = parse(sql).unwrap();
+
+    match stmt {
+        Statement::CreatePolicy(policy) => {
+            assert_eq!(policy.action, PolicyAction::Select);
+
+            match policy.where_clause {
+                Some(PolicyExpr::In(left, right)) => {
+                    assert_eq!(left, PolicyValue::Column("team_id".into()));
+                    assert_eq!(right, PolicyValue::ViewerClaim("groups".into()));
+                }
+                _ => panic!("expected In expression"),
+            }
+        }
+        _ => panic!("expected CreatePolicy"),
+    }
+}
+
+#[test]
+fn parse_policy_combined_org_and_role() {
+    let sql = "CREATE POLICY ON org_settings FOR UPDATE WHERE org_id = @viewer.claims.orgId AND @viewer.claims.roles CONTAINS 'org_admin'";
+    let stmt = parse(sql).unwrap();
+
+    match stmt {
+        Statement::CreatePolicy(policy) => {
+            assert_eq!(policy.action, PolicyAction::Update);
+
+            match policy.where_clause {
+                Some(PolicyExpr::And(exprs)) => {
+                    assert_eq!(exprs.len(), 2);
+
+                    // org_id = @viewer.claims.orgId
+                    match &exprs[0] {
+                        PolicyExpr::Eq(left, right) => {
+                            assert_eq!(*left, PolicyValue::Column("org_id".into()));
+                            assert_eq!(*right, PolicyValue::ViewerClaim("orgId".into()));
+                        }
+                        _ => panic!("expected Eq"),
+                    }
+
+                    // @viewer.claims.roles CONTAINS 'org_admin'
+                    match &exprs[1] {
+                        PolicyExpr::Contains(left, right) => {
+                            assert_eq!(*left, PolicyValue::ViewerClaim("roles".into()));
+                            assert_eq!(
+                                *right,
+                                PolicyValue::Literal(PredicateValue::String("org_admin".into()))
+                            );
+                        }
+                        _ => panic!("expected Contains"),
+                    }
+                }
+                _ => panic!("expected And expression"),
+            }
+        }
+        _ => panic!("expected CreatePolicy"),
+    }
+}
+
+#[test]
+fn parse_policy_permissions_array() {
+    // WorkOS-style permissions array check
+    let sql = "CREATE POLICY ON documents FOR SELECT WHERE org_id = @viewer.claims.org_id AND @viewer.claims.permissions CONTAINS 'documents:read'";
+    let stmt = parse(sql).unwrap();
+
+    match stmt {
+        Statement::CreatePolicy(policy) => {
+            assert_eq!(policy.action, PolicyAction::Select);
+
+            match policy.where_clause {
+                Some(PolicyExpr::And(exprs)) => {
+                    assert_eq!(exprs.len(), 2);
+
+                    // org_id = @viewer.claims.org_id
+                    match &exprs[0] {
+                        PolicyExpr::Eq(left, right) => {
+                            assert_eq!(*left, PolicyValue::Column("org_id".into()));
+                            assert_eq!(*right, PolicyValue::ViewerClaim("org_id".into()));
+                        }
+                        _ => panic!("expected Eq"),
+                    }
+
+                    // @viewer.claims.permissions CONTAINS 'documents:read'
+                    match &exprs[1] {
+                        PolicyExpr::Contains(left, right) => {
+                            assert_eq!(*left, PolicyValue::ViewerClaim("permissions".into()));
+                            assert_eq!(
+                                *right,
+                                PolicyValue::Literal(PredicateValue::String(
+                                    "documents:read".into()
+                                ))
+                            );
+                        }
+                        _ => panic!("expected Contains"),
+                    }
+                }
+                _ => panic!("expected And expression"),
+            }
+        }
+        _ => panic!("expected CreatePolicy"),
+    }
+}
+
+#[test]
+fn parse_policy_multiple_claims_or() {
+    // Multiple subscription tier checks
+    let sql = "CREATE POLICY ON premium_features FOR SELECT WHERE @viewer.claims.subscriptionTier = 'pro' OR @viewer.claims.subscriptionTier = 'enterprise'";
+    let stmt = parse(sql).unwrap();
+
+    match stmt {
+        Statement::CreatePolicy(policy) => match policy.where_clause {
+            Some(PolicyExpr::Or(exprs)) => {
+                assert_eq!(exprs.len(), 2);
+
+                match &exprs[0] {
+                    PolicyExpr::Eq(left, right) => {
+                        assert_eq!(*left, PolicyValue::ViewerClaim("subscriptionTier".into()));
+                        assert_eq!(
+                            *right,
+                            PolicyValue::Literal(PredicateValue::String("pro".into()))
+                        );
+                    }
+                    _ => panic!("expected Eq"),
+                }
+
+                match &exprs[1] {
+                    PolicyExpr::Eq(left, right) => {
+                        assert_eq!(*left, PolicyValue::ViewerClaim("subscriptionTier".into()));
+                        assert_eq!(
+                            *right,
+                            PolicyValue::Literal(PredicateValue::String("enterprise".into()))
+                        );
+                    }
+                    _ => panic!("expected Eq"),
+                }
+            }
+            _ => panic!("expected Or expression"),
+        },
+        _ => panic!("expected CreatePolicy"),
+    }
+}

--- a/crates/groove/tests/sync.rs
+++ b/crates/groove/tests/sync.rs
@@ -628,10 +628,8 @@ async fn test_synced_node_connected_clients() {
     let synced_node = create_synced_node(Arc::clone(&transport), "server");
 
     // Create a client identity and SSE channel
-    let identity = groove::sync::ClientIdentity {
-        id: "client1".to_string(),
-        name: Some("Test Client".to_string()),
-    };
+    let mut identity = groove::sync::ClientIdentity::simple("client1");
+    identity.name = Some("Test Client".to_string());
     let (tx, _rx) = tokio::sync::mpsc::channel(16);
 
     // Accept the client

--- a/docs/content/docs/internals/access-control.mdx
+++ b/docs/content/docs/internals/access-control.mdx
@@ -305,10 +305,11 @@ CREATE POLICY ON documents FOR UPDATE
 
 - `groove/src/sql/policy.rs` - Policy types and evaluation
 
+## Related Specs
+
+- [Authentication](/docs/internals/authentication) - How `@viewer` is bound via JWT authentication
+
 ## Open Questions
 
-### Identity: @viewer Binding (GCO-1052)
-How to extract authenticated user ID from context and make it available in policy expressions?
-
 ### Server-Authenticated Accounts (GCO-1051)
-Account creation, authentication flow, and session handling.
+Account creation, authentication flow, and session handling beyond JWT.

--- a/docs/content/docs/internals/architecture.mdx
+++ b/docs/content/docs/internals/architecture.mdx
@@ -21,6 +21,7 @@ description: Core design principles and system architecture
 | [Storage](/docs/internals/storage) | Partial | Content storage, chunking, compression, persistence |
 | [Schema Evolution](/docs/internals/schema-evolution) | Implemented | Bidirectional lenses for schema changes |
 | [Access Control](/docs/internals/access-control) | Partial | ReBAC policies with SQL-like expressions |
+| [Authentication](/docs/internals/authentication) | Partial | JWT-based auth for binding @viewer in policies |
 | [Deletes](/docs/internals/deletes) | Implemented | Soft delete and history truncation |
 | [Indices](/docs/internals/indices) | Future | Scalable sorted chunk indices |
 | [Transactions](/docs/internals/transactions) | Future | MVCC-based multi-row transactions |

--- a/docs/content/docs/internals/authentication.mdx
+++ b/docs/content/docs/internals/authentication.mdx
@@ -1,0 +1,251 @@
+---
+title: Authentication
+description: JWT-based authentication for binding @viewer in ReBAC policies
+status: partial
+implements:
+  - groove-server/src/auth.rs
+---
+
+<StatusBadge status="partial" />
+
+Authentication in Jazz2 binds the `@viewer` variable in [Access Control](/docs/internals/access-control) policies. The primary mechanism is JWT (JSON Web Token) validation, allowing integration with any OAuth/OIDC provider.
+
+## Implementation Status
+
+**Implemented:**
+- JWT validation with JWKS (JSON Web Key Set) endpoint support
+- Configurable issuer and audience validation
+- User ID extraction from configurable claim (default: `sub`)
+- Claims available in policies as `@viewer.claims.*`
+- Auto-provisioning of users on first authentication
+
+**Not yet implemented:**
+- Session management and refresh token handling
+- Built-in OAuth flows (currently relies on external providers)
+- API key authentication (for server-to-server)
+- Anonymous/guest access with limited permissions
+
+## Goals
+
+1. **Provider agnostic** - Work with any JWT-issuing auth provider (Auth0, WorkOS, BetterAuth, Clerk, etc.)
+2. **Zero custom code** - Configure auth via TOML, no code changes needed
+3. **Claims in policies** - Use JWT claims directly in ReBAC expressions
+4. **Automatic provisioning** - Create user records on first sign-in
+
+## Configuration
+
+### groove-server.toml
+
+```toml
+[auth]
+provider = "jwt"
+
+[auth.jwt]
+# JWKS endpoint for key rotation (recommended)
+jwks_url = "https://auth.example.com/.well-known/jwks.json"
+
+# Or static key for simple setups
+# public_key = "-----BEGIN PUBLIC KEY-----\n..."
+
+# Token validation
+issuer = "https://auth.example.com/"
+audience = "my-app"  # Optional
+
+# Claim mapping
+user_id_claim = "sub"  # Which claim contains the user ID
+
+[auth.provisioning]
+auto_provision = true  # Create users on first auth
+users_table = "users"  # Table to insert new users
+```
+
+### Provider-Specific Examples
+
+#### BetterAuth
+
+```toml
+[auth.jwt]
+jwks_url = "http://localhost:3001/api/auth/jwks"
+issuer = "http://localhost:3001"
+user_id_claim = "sub"
+```
+
+#### WorkOS AuthKit
+
+```toml
+[auth.jwt]
+jwks_url = "https://api.workos.com/sso/jwks/client_XXXXX"
+issuer = "https://api.workos.com/"
+user_id_claim = "sub"
+```
+
+#### Auth0
+
+```toml
+[auth.jwt]
+jwks_url = "https://your-tenant.auth0.com/.well-known/jwks.json"
+issuer = "https://your-tenant.auth0.com/"
+audience = "https://api.example.com"
+user_id_claim = "sub"
+```
+
+## Using Claims in Policies
+
+JWT claims are available in policies via `@viewer.claims`:
+
+```sql
+-- Simple claim check
+CREATE POLICY ON documents FOR SELECT
+  WHERE owner_id = @viewer
+     OR @viewer.claims.role = 'admin';
+
+-- Organization-scoped access (WorkOS)
+CREATE POLICY ON documents FOR SELECT
+  WHERE org_id = @viewer.claims.org_id;
+
+-- Permission-based access
+CREATE POLICY ON documents FOR UPDATE
+  WHERE org_id = @viewer.claims.org_id
+    AND @viewer.claims.permissions CONTAINS 'documents:write';
+
+-- Subscription tier gating (BetterAuth custom claim)
+CREATE POLICY ON premium_features FOR SELECT
+  WHERE @viewer.claims.subscriptionTier IN ('pro', 'enterprise');
+```
+
+## Client Integration
+
+### Passing the Token
+
+Clients must include the JWT in WebSocket connection or HTTP requests:
+
+```typescript
+// WebSocket connection with token
+const client = new JazzClient({
+  syncServer: "wss://sync.example.com",
+  auth: {
+    getToken: async () => {
+      // Get token from your auth provider
+      return await authClient.getAccessToken();
+    },
+  },
+});
+```
+
+### BetterAuth Example
+
+```typescript
+import { createAuthClient } from "better-auth/client";
+import { jwtClient } from "better-auth/client/plugins";
+
+const authClient = createAuthClient({
+  baseURL: "http://localhost:3001",
+  plugins: [jwtClient()],
+});
+
+// Get token for Jazz
+async function getJazzToken() {
+  const result = await authClient.token();
+  return result.data?.token || null;
+}
+```
+
+### WorkOS AuthKit Example
+
+```typescript
+import { useAuth } from "@workos-inc/authkit-react";
+
+function App() {
+  const { getAccessToken } = useAuth();
+
+  // Get token for Jazz
+  async function getJazzToken() {
+    return await getAccessToken();
+  }
+}
+```
+
+## Auto-Provisioning
+
+When `auto_provision = true`, groove-server automatically creates a user record on first authentication:
+
+```sql
+-- Generated INSERT on first auth
+INSERT INTO users (id, email, created_at)
+VALUES (@viewer, @viewer.claims.email, NOW());
+```
+
+The provisioning behavior can be customized:
+
+```toml
+[auth.provisioning]
+auto_provision = true
+users_table = "users"
+
+# Map claims to columns
+[auth.provisioning.column_mapping]
+id = "@viewer"
+email = "@viewer.claims.email"
+name = "@viewer.claims.name"
+```
+
+## Token Validation Flow
+
+```
+Client                    groove-server                    JWKS Endpoint
+   |                            |                               |
+   |-- WS Connect + JWT ------->|                               |
+   |                            |-- Fetch JWKS (cached) ------->|
+   |                            |<-- Public Keys ---------------|
+   |                            |                               |
+   |                            |-- Validate JWT signature      |
+   |                            |-- Check issuer/audience       |
+   |                            |-- Extract user_id claim       |
+   |                            |-- Bind @viewer + claims       |
+   |                            |                               |
+   |<-- Connection accepted ----|                               |
+```
+
+## Security Considerations
+
+### Token Expiration
+
+JWTs have expiration times. groove-server validates `exp` claim and rejects expired tokens. Clients should refresh tokens before expiration.
+
+### Key Rotation
+
+Using JWKS endpoints enables key rotation without server restarts. groove-server caches JWKS with configurable TTL.
+
+### Claim Trust
+
+Only trust claims from verified tokens. Never use client-provided claims directly - they must come from the validated JWT payload.
+
+## Common Claim Patterns
+
+| Provider | User ID Claim | Common Claims |
+|----------|---------------|---------------|
+| BetterAuth | `sub` | `email`, `name`, custom claims via plugin |
+| WorkOS | `sub` | `org_id`, `role`, `permissions`, `sid` |
+| Auth0 | `sub` | `email`, `name`, custom claims in namespace |
+| Clerk | `sub` | `email`, `org_id`, `org_role` |
+| Firebase | `sub` (uid) | `email`, `name`, custom claims |
+
+## Files
+
+- `groove-server/src/auth.rs` - JWT validation and claims extraction
+- `groove-server/src/config.rs` - Auth configuration parsing
+
+## Related Specs
+
+- [Access Control](/docs/internals/access-control) - How `@viewer` and claims are used in policies
+
+## Open Questions
+
+### Refresh Token Handling
+Should groove-server support refresh token flows, or leave that entirely to the client?
+
+### Anonymous Access
+How to support unauthenticated access with limited permissions? Perhaps a special `@anonymous` viewer?
+
+### Multi-Tenancy
+Best practices for tenant isolation using org_id claims vs separate databases?

--- a/examples/auth-betterauth/.gitignore
+++ b/examples/auth-betterauth/.gitignore
@@ -1,0 +1,6 @@
+# BetterAuth SQLite database
+auth.db
+
+# Test results
+test-results/
+playwright-report/

--- a/examples/auth-betterauth/README.md
+++ b/examples/auth-betterauth/README.md
@@ -1,0 +1,150 @@
+# Jazz + BetterAuth Demo
+
+This example demonstrates how to integrate Jazz with BetterAuth for authentication
+and use JWT claims in ReBAC policies.
+
+## Architecture
+
+```
+┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐
+│   React App     │────▶│  BetterAuth     │     │  groove-server  │
+│   (Frontend)    │     │  (Auth Server)  │     │  (Jazz Server)  │
+└────────┬────────┘     └────────┬────────┘     └────────┬────────┘
+         │                       │                       │
+         │  1. Login/Signup      │                       │
+         │─────────────────────▶│                       │
+         │                       │                       │
+         │  2. JWT Token         │                       │
+         │◀─────────────────────│                       │
+         │                       │                       │
+         │  3. Connect with JWT  │                       │
+         │──────────────────────────────────────────────▶│
+         │                       │                       │
+         │                       │  4. Validate JWT      │
+         │                       │◀──────────────────────│
+         │                       │                       │
+         │  5. Sync with claims-aware policies          │
+         │◀─────────────────────────────────────────────│
+```
+
+## Features Demonstrated
+
+- **BetterAuth Integration**: Email/password authentication with custom JWT claims
+- **Claims in Policies**: Use `@viewer.claims.subscriptionTier`, `@viewer.claims.orgId`, etc.
+- **Array Claims**: Role-based access with `@viewer.claims.roles CONTAINS 'admin'`
+- **Organization Scoping**: Multi-tenant access control with `org_id = @viewer.claims.orgId`
+- **Auto-Provisioning**: Automatic Jazz user creation on first login
+
+## Running the Demo
+
+### Prerequisites
+
+- Node.js 18+
+- pnpm
+- Rust toolchain (for groove-server)
+
+### 1. Install Dependencies
+
+```bash
+cd examples/auth-betterauth
+pnpm install
+```
+
+### 2. Start BetterAuth Server
+
+```bash
+pnpm run dev:auth
+# Runs on http://localhost:3001
+```
+
+### 3. Start groove-server
+
+```bash
+cd ../../crates
+cargo run -p groove-server -- --config ../examples/auth-betterauth/groove-server.toml
+# Runs on http://localhost:8080
+```
+
+### 4. Start React App
+
+```bash
+pnpm run dev:client
+# Runs on http://localhost:5173
+```
+
+Or run everything together:
+
+```bash
+pnpm run dev
+```
+
+## JWT Token Claims
+
+BetterAuth is configured to include these claims in the JWT:
+
+```json
+{
+  "sub": "user_123",
+  "email": "user@example.com",
+  "name": "John Doe",
+  "subscriptionTier": "pro",
+  "orgId": "org_456",
+  "roles": ["member", "admin"]
+}
+```
+
+## Example Policies
+
+```sql
+-- Personal documents
+CREATE POLICY ON documents FOR SELECT
+  WHERE author = @viewer;
+
+-- Organization-scoped documents
+CREATE POLICY ON org_documents FOR SELECT
+  WHERE org_id = @viewer.claims.orgId;
+
+-- Premium features by subscription tier
+CREATE POLICY ON premium_features FOR SELECT
+  WHERE @viewer.claims.subscriptionTier = 'pro'
+     OR @viewer.claims.subscriptionTier = 'enterprise';
+
+-- Admin-only settings
+CREATE POLICY ON admin_settings FOR UPDATE
+  WHERE @viewer.claims.roles CONTAINS 'admin';
+```
+
+## Configuration
+
+### groove-server.toml
+
+```toml
+[auth]
+provider = "betterauth"
+
+[auth.jwt]
+jwks_url = "http://localhost:3001/api/auth/jwks"
+issuer = "http://localhost:3001"
+user_id_claim = "sub"
+
+[auth.provisioning]
+auto_provision = true
+users_table = "users"
+```
+
+### BetterAuth Server
+
+The auth server (`server/auth-server.ts`) configures custom JWT claims:
+
+```typescript
+jwt: {
+  definePayload: async ({ user, session }) => ({
+    sub: user.id,
+    email: user.email,
+    name: user.name,
+    subscriptionTier: user.subscriptionTier || "free",
+    orgId: session.activeOrganizationId || null,
+    roles: user.roles || ["member"],
+  }),
+}
+```

--- a/examples/auth-betterauth/README.md
+++ b/examples/auth-betterauth/README.md
@@ -3,6 +3,9 @@
 This example demonstrates how to integrate Jazz with BetterAuth for authentication
 and use JWT claims in ReBAC policies.
 
+> **Spec**: See [Authentication](/docs/internals/authentication) for the full specification
+> and [Access Control](/docs/internals/access-control) for ReBAC policy syntax.
+
 ## Architecture
 
 ```

--- a/examples/auth-betterauth/groove-server.toml
+++ b/examples/auth-betterauth/groove-server.toml
@@ -1,0 +1,28 @@
+# Groove Server configuration for BetterAuth demo
+#
+# This configures groove-server to validate JWT tokens from BetterAuth
+# and use the claims for policy evaluation.
+
+host = "0.0.0.0"
+port = 8080
+
+[auth]
+provider = "betterauth"
+
+[auth.jwt]
+# BetterAuth JWKS endpoint for RS256 validation
+jwks_url = "http://localhost:3001/api/auth/jwks"
+# Expected issuer (BetterAuth server URL)
+issuer = "http://localhost:3001"
+# Claim containing the user ID
+user_id_claim = "sub"
+# Validate token expiration
+validate_exp = true
+
+[auth.provisioning]
+# Automatically create Jazz users on first login
+auto_provision = true
+# Table to store user records
+users_table = "users"
+# Column for external user ID mapping
+external_id_column = "external_id"

--- a/examples/auth-betterauth/index.html
+++ b/examples/auth-betterauth/index.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Jazz + BetterAuth Demo</title>
+    <style>
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+        max-width: 800px;
+        margin: 0 auto;
+        padding: 2rem;
+        background: #f5f5f5;
+      }
+      .card {
+        background: white;
+        border-radius: 8px;
+        padding: 1.5rem;
+        margin-bottom: 1rem;
+        box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+      }
+      button {
+        background: #0070f3;
+        color: white;
+        border: none;
+        padding: 0.5rem 1rem;
+        border-radius: 4px;
+        cursor: pointer;
+        margin-right: 0.5rem;
+      }
+      button:hover {
+        background: #0060df;
+      }
+      button.secondary {
+        background: #666;
+      }
+      input {
+        padding: 0.5rem;
+        border: 1px solid #ddd;
+        border-radius: 4px;
+        margin-right: 0.5rem;
+        margin-bottom: 0.5rem;
+      }
+      .user-info {
+        background: #e8f4fd;
+        padding: 1rem;
+        border-radius: 4px;
+        margin-bottom: 1rem;
+      }
+      .document {
+        border: 1px solid #eee;
+        padding: 1rem;
+        margin-bottom: 0.5rem;
+        border-radius: 4px;
+      }
+      .error {
+        color: #d32f2f;
+        background: #ffebee;
+        padding: 0.5rem;
+        border-radius: 4px;
+        margin-bottom: 1rem;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/examples/auth-betterauth/package.json
+++ b/examples/auth-betterauth/package.json
@@ -5,9 +5,12 @@
   "type": "module",
   "scripts": {
     "dev": "concurrently \"npm run dev:auth\" \"npm run dev:client\"",
-    "dev:auth": "tsx server/auth-server.ts",
+    "dev:auth": "npm run db:migrate && tsx server/auth-server.ts",
     "dev:client": "vite",
-    "build": "vite build"
+    "build": "vite build",
+    "db:migrate": "npx @better-auth/cli migrate --config server/auth-server.ts -y",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "@jazz/client": "workspace:*",
@@ -21,6 +24,7 @@
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.57.0",
     "@types/better-sqlite3": "^7.6.12",
     "@types/cors": "^2.8.17",
     "@types/express": "^5.0.1",

--- a/examples/auth-betterauth/package.json
+++ b/examples/auth-betterauth/package.json
@@ -9,8 +9,8 @@
     "dev:client": "vite",
     "build": "vite build",
     "db:migrate": "npx @better-auth/cli migrate --config server/auth-server.ts -y",
-    "test:e2e": "playwright test",
-    "test:e2e:ui": "playwright test --ui"
+    "test": "playwright test",
+    "test:ui": "playwright test --ui"
   },
   "dependencies": {
     "@jazz/client": "workspace:*",

--- a/examples/auth-betterauth/package.json
+++ b/examples/auth-betterauth/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "auth-betterauth-demo",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "concurrently \"npm run dev:auth\" \"npm run dev:client\"",
+    "dev:auth": "tsx server/auth-server.ts",
+    "dev:client": "vite",
+    "build": "vite build"
+  },
+  "dependencies": {
+    "@jazz/client": "workspace:*",
+    "@jazz/react": "workspace:*",
+    "better-auth": "^1.2.0",
+    "better-sqlite3": "^11.8.1",
+    "express": "^4.21.2",
+    "cors": "^2.8.5",
+    "groove-wasm": "workspace:*",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@types/better-sqlite3": "^7.6.12",
+    "@types/cors": "^2.8.17",
+    "@types/express": "^5.0.1",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "@vitejs/plugin-react": "^4.2.0",
+    "concurrently": "^9.1.2",
+    "tsx": "^4.21.0",
+    "typescript": "^5.9.3",
+    "vite": "^5.0.0",
+    "vite-plugin-top-level-await": "^1.4.0",
+    "vite-plugin-wasm": "^3.3.0"
+  }
+}

--- a/examples/auth-betterauth/playwright.config.ts
+++ b/examples/auth-betterauth/playwright.config.ts
@@ -1,0 +1,34 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests",
+  testMatch: "**/*.spec.ts",
+  fullyParallel: false, // Run tests serially since they share auth state
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: 1,
+  reporter: "html",
+  use: {
+    baseURL: "http://localhost:5173",
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: [
+    {
+      command: "npm run dev:auth",
+      url: "http://localhost:3001/health",
+      reuseExistingServer: !process.env.CI,
+      timeout: 30000,
+    },
+    {
+      command: "npm run dev:client",
+      url: "http://localhost:5173",
+      reuseExistingServer: !process.env.CI,
+    },
+  ],
+});

--- a/examples/auth-betterauth/server/auth-server.ts
+++ b/examples/auth-betterauth/server/auth-server.ts
@@ -1,0 +1,85 @@
+/**
+ * BetterAuth server for the Jazz auth integration demo.
+ *
+ * This server provides:
+ * - User registration and login
+ * - JWT token generation with custom claims
+ * - Organization support for multi-tenant access control
+ * - JWKS endpoint for token verification
+ */
+
+import { betterAuth } from "better-auth";
+import Database from "better-sqlite3";
+import cors from "cors";
+import express from "express";
+
+// Initialize SQLite database for BetterAuth
+const db = new Database("auth.db");
+
+// Configure BetterAuth
+export const auth = betterAuth({
+  database: {
+    type: "sqlite",
+    // BetterAuth will use the db instance directly
+    db,
+  },
+  emailAndPassword: {
+    enabled: true,
+  },
+  session: {
+    // Sessions last 7 days
+    expiresIn: 60 * 60 * 24 * 7,
+    // Refresh when 1 day remaining
+    updateAge: 60 * 60 * 24,
+  },
+  // JWT configuration for token-based auth with Jazz
+  jwt: {
+    // Custom payload for Jazz policy evaluation
+    definePayload: async ({ user, session }) => {
+      return {
+        sub: user.id,
+        email: user.email,
+        name: user.name,
+        // Custom claims for Jazz policies
+        subscriptionTier: (user as any).subscriptionTier || "free",
+        // Organization ID if in an org context
+        orgId: (session as any).activeOrganizationId || null,
+        // Roles array for CONTAINS checks
+        roles: (user as any).roles || ["member"],
+      };
+    },
+  },
+});
+
+// Create Express app
+const app = express();
+
+// Enable CORS for the React client
+app.use(
+  cors({
+    origin: "http://localhost:5173",
+    credentials: true,
+  }),
+);
+
+app.use(express.json());
+
+// Mount BetterAuth routes
+app.all("/api/auth/*", (req, res, _next) => {
+  // BetterAuth handles all /api/auth/* routes
+  return auth.handler(req, res);
+});
+
+// Health check
+app.get("/health", (_req, res) => {
+  res.json({ status: "ok" });
+});
+
+// Start server
+const PORT = process.env.AUTH_PORT || 3001;
+app.listen(PORT, () => {
+  console.log(`BetterAuth server running on http://localhost:${PORT}`);
+  console.log(`JWKS endpoint: http://localhost:${PORT}/api/auth/jwks`);
+  console.log(`Login: POST http://localhost:${PORT}/api/auth/sign-in/email`);
+  console.log(`Register: POST http://localhost:${PORT}/api/auth/sign-up/email`);
+});

--- a/examples/auth-betterauth/server/auth-server.ts
+++ b/examples/auth-betterauth/server/auth-server.ts
@@ -9,20 +9,17 @@
  */
 
 import { betterAuth } from "better-auth";
+import { toNodeHandler } from "better-auth/node";
+import { jwt } from "better-auth/plugins";
 import Database from "better-sqlite3";
 import cors from "cors";
 import express from "express";
 
-// Initialize SQLite database for BetterAuth
-const db = new Database("auth.db");
-
-// Configure BetterAuth
+// Configure BetterAuth with SQLite database
 export const auth = betterAuth({
-  database: {
-    type: "sqlite",
-    // BetterAuth will use the db instance directly
-    db,
-  },
+  database: new Database("auth.db"),
+  // Trust the React client origin
+  trustedOrigins: ["http://localhost:5173"],
   emailAndPassword: {
     enabled: true,
   },
@@ -32,23 +29,26 @@ export const auth = betterAuth({
     // Refresh when 1 day remaining
     updateAge: 60 * 60 * 24,
   },
-  // JWT configuration for token-based auth with Jazz
-  jwt: {
-    // Custom payload for Jazz policy evaluation
-    definePayload: async ({ user, session }) => {
-      return {
-        sub: user.id,
-        email: user.email,
-        name: user.name,
-        // Custom claims for Jazz policies
-        subscriptionTier: (user as any).subscriptionTier || "free",
-        // Organization ID if in an org context
-        orgId: (session as any).activeOrganizationId || null,
-        // Roles array for CONTAINS checks
-        roles: (user as any).roles || ["member"],
-      };
-    },
-  },
+  plugins: [
+    jwt({
+      // Custom payload for Jazz policy evaluation
+      jwt: {
+        definePayload: async ({ user }) => {
+          // User type from BetterAuth may have additional fields
+          const userRecord = user as Record<string, unknown>;
+          return {
+            sub: user.id,
+            email: user.email,
+            name: user.name,
+            // Custom claims for Jazz policies
+            subscriptionTier: (userRecord.subscriptionTier as string) || "free",
+            // Roles array for CONTAINS checks
+            roles: (userRecord.roles as string[]) || ["member"],
+          };
+        },
+      },
+    }),
+  ],
 });
 
 // Create Express app
@@ -62,13 +62,12 @@ app.use(
   }),
 );
 
-app.use(express.json());
+// Mount BetterAuth routes using the Node.js adapter
+// Important: Don't use express.json() before this handler
+app.all("/api/auth/*", toNodeHandler(auth));
 
-// Mount BetterAuth routes
-app.all("/api/auth/*", (req, res, _next) => {
-  // BetterAuth handles all /api/auth/* routes
-  return auth.handler(req, res);
-});
+// Use express.json() only for non-BetterAuth routes
+app.use(express.json());
 
 // Health check
 app.get("/health", (_req, res) => {

--- a/examples/auth-betterauth/src/App.tsx
+++ b/examples/auth-betterauth/src/App.tsx
@@ -1,0 +1,263 @@
+/**
+ * Jazz + BetterAuth Demo App
+ *
+ * This demo shows how to:
+ * 1. Authenticate users with BetterAuth
+ * 2. Get JWT tokens with custom claims
+ * 3. Connect to groove-server with the JWT
+ * 4. Use claims in Jazz policies for access control
+ */
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  type User,
+  getJazzToken,
+  getSession,
+  signIn,
+  signOut,
+  signUp,
+} from "./auth";
+
+function App() {
+  const [user, setUser] = useState<User | null>(null);
+  const [token, setToken] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Auth form state
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [name, setName] = useState("");
+  const [isSignUp, setIsSignUp] = useState(false);
+
+  // Check session on mount
+  useEffect(() => {
+    async function checkSession() {
+      setLoading(true);
+      const sessionUser = await getSession();
+      if (sessionUser) {
+        setUser(sessionUser);
+        const jazzToken = await getJazzToken();
+        setToken(jazzToken);
+      }
+      setLoading(false);
+    }
+    checkSession();
+  }, []);
+
+  const handleAuth = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault();
+      setError(null);
+      setLoading(true);
+
+      try {
+        const result = isSignUp
+          ? await signUp(email, password, name)
+          : await signIn(email, password);
+
+        if ("error" in result) {
+          setError(result.error);
+        } else {
+          setUser(result.user);
+          const jazzToken = await getJazzToken();
+          setToken(jazzToken);
+        }
+      } catch (err) {
+        setError(String(err));
+      } finally {
+        setLoading(false);
+      }
+    },
+    [email, password, name, isSignUp],
+  );
+
+  const handleSignOut = useCallback(async () => {
+    await signOut();
+    setUser(null);
+    setToken(null);
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="card">
+        <p>Loading...</p>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <h1>Jazz + BetterAuth Demo</h1>
+
+      {error && <div className="error">{error}</div>}
+
+      {!user ? (
+        <div className="card">
+          <h2>{isSignUp ? "Sign Up" : "Sign In"}</h2>
+          <form onSubmit={handleAuth}>
+            {isSignUp && (
+              <div>
+                <input
+                  type="text"
+                  placeholder="Name"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  required
+                />
+              </div>
+            )}
+            <div>
+              <input
+                type="email"
+                placeholder="Email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                required
+              />
+            </div>
+            <div>
+              <input
+                type="password"
+                placeholder="Password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                required
+              />
+            </div>
+            <button type="submit">{isSignUp ? "Sign Up" : "Sign In"}</button>
+            <button
+              type="button"
+              className="secondary"
+              onClick={() => setIsSignUp(!isSignUp)}
+            >
+              {isSignUp
+                ? "Have an account? Sign In"
+                : "Need an account? Sign Up"}
+            </button>
+          </form>
+        </div>
+      ) : (
+        <>
+          <div className="user-info">
+            <strong>Logged in as:</strong> {user.name || user.email}
+            <br />
+            <small>ID: {user.id}</small>
+            <br />
+            <button onClick={handleSignOut}>Sign Out</button>
+          </div>
+
+          {token && (
+            <div className="card">
+              <h3>JWT Token (for Jazz)</h3>
+              <p>
+                This token is sent to groove-server for authentication. The
+                claims in this token can be used in Jazz policies.
+              </p>
+              <pre
+                style={{
+                  background: "#f5f5f5",
+                  padding: "1rem",
+                  overflow: "auto",
+                  fontSize: "0.8rem",
+                  maxHeight: "200px",
+                }}
+              >
+                {token}
+              </pre>
+
+              <h4>Decoded Claims</h4>
+              <pre
+                style={{
+                  background: "#f5f5f5",
+                  padding: "1rem",
+                  overflow: "auto",
+                  fontSize: "0.8rem",
+                }}
+              >
+                {JSON.stringify(parseJwt(token), null, 2)}
+              </pre>
+            </div>
+          )}
+
+          <div className="card">
+            <h3>Example Jazz Policies</h3>
+            <p>With the JWT claims above, you can write policies like:</p>
+            <pre
+              style={{
+                background: "#f0f0f0",
+                padding: "1rem",
+                overflow: "auto",
+                fontSize: "0.85rem",
+              }}
+            >
+              {`-- Access control using JWT claims
+
+-- Only allow users to see their own documents
+CREATE POLICY ON documents FOR SELECT
+  WHERE author_id = @viewer;
+
+-- Premium features only for pro/enterprise users
+CREATE POLICY ON premium_features FOR SELECT
+  WHERE @viewer.claims.subscriptionTier = 'pro'
+     OR @viewer.claims.subscriptionTier = 'enterprise';
+
+-- Organization-scoped documents
+CREATE POLICY ON org_documents FOR SELECT
+  WHERE org_id = @viewer.claims.orgId;
+
+-- Role-based admin access
+CREATE POLICY ON admin_settings FOR UPDATE
+  WHERE @viewer.claims.roles CONTAINS 'admin';`}
+            </pre>
+          </div>
+
+          <div className="card">
+            <h3>groove-server Configuration</h3>
+            <p>Configure groove-server to validate BetterAuth tokens:</p>
+            <pre
+              style={{
+                background: "#f0f0f0",
+                padding: "1rem",
+                overflow: "auto",
+                fontSize: "0.85rem",
+              }}
+            >
+              {`# groove-server.toml
+[auth]
+provider = "betterauth"
+
+[auth.jwt]
+jwks_url = "http://localhost:3001/api/auth/jwks"
+issuer = "http://localhost:3001"
+user_id_claim = "sub"
+
+[auth.provisioning]
+auto_provision = true
+users_table = "users"`}
+            </pre>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+// Helper to decode JWT for display
+function parseJwt(token: string): Record<string, unknown> {
+  try {
+    const base64Url = token.split(".")[1];
+    const base64 = base64Url.replace(/-/g, "+").replace(/_/g, "/");
+    const jsonPayload = decodeURIComponent(
+      atob(base64)
+        .split("")
+        .map((c) => `%${(`00${c.charCodeAt(0).toString(16)}`).slice(-2)}`)
+        .join(""),
+    );
+    return JSON.parse(jsonPayload);
+  } catch {
+    return { error: "Failed to decode token" };
+  }
+}
+
+export default App;

--- a/examples/auth-betterauth/src/auth.ts
+++ b/examples/auth-betterauth/src/auth.ts
@@ -1,0 +1,142 @@
+/**
+ * BetterAuth client configuration.
+ *
+ * This client connects to the BetterAuth server for authentication
+ * and retrieves JWT tokens for use with Jazz/groove-server.
+ */
+
+import { createAuthClient } from "better-auth/client";
+
+// Auth server URL
+const AUTH_URL = "http://localhost:3001";
+
+// Create the BetterAuth client
+export const authClient = createAuthClient({
+  baseURL: AUTH_URL,
+});
+
+// Types for auth state
+export interface User {
+  id: string;
+  email: string;
+  name: string | null;
+  subscriptionTier?: string;
+  roles?: string[];
+}
+
+export interface AuthState {
+  user: User | null;
+  token: string | null;
+  loading: boolean;
+  error: string | null;
+}
+
+/**
+ * Get the current JWT token for use with Jazz.
+ * This token contains claims that can be used in Jazz policies.
+ */
+export async function getJazzToken(): Promise<string | null> {
+  try {
+    const session = await authClient.getSession();
+    if (!session?.data) return null;
+
+    // BetterAuth provides the token in the session
+    // For JWT plugin, we need to get it from the session endpoint
+    const response = await fetch(`${AUTH_URL}/api/auth/token`, {
+      credentials: "include",
+    });
+
+    if (!response.ok) return null;
+
+    const data = await response.json();
+    return data.token || null;
+  } catch (error) {
+    console.error("Failed to get Jazz token:", error);
+    return null;
+  }
+}
+
+/**
+ * Sign up a new user.
+ */
+export async function signUp(
+  email: string,
+  password: string,
+  name: string,
+): Promise<{ user: User } | { error: string }> {
+  try {
+    const result = await authClient.signUp.email({
+      email,
+      password,
+      name,
+    });
+
+    if (result.error) {
+      return { error: result.error.message || "Sign up failed" };
+    }
+
+    return {
+      user: {
+        id: result.data!.user.id,
+        email: result.data!.user.email,
+        name: result.data!.user.name,
+      },
+    };
+  } catch (error) {
+    return { error: String(error) };
+  }
+}
+
+/**
+ * Sign in an existing user.
+ */
+export async function signIn(
+  email: string,
+  password: string,
+): Promise<{ user: User } | { error: string }> {
+  try {
+    const result = await authClient.signIn.email({
+      email,
+      password,
+    });
+
+    if (result.error) {
+      return { error: result.error.message || "Sign in failed" };
+    }
+
+    return {
+      user: {
+        id: result.data!.user.id,
+        email: result.data!.user.email,
+        name: result.data!.user.name,
+      },
+    };
+  } catch (error) {
+    return { error: String(error) };
+  }
+}
+
+/**
+ * Sign out the current user.
+ */
+export async function signOut(): Promise<void> {
+  await authClient.signOut();
+}
+
+/**
+ * Get the current session.
+ */
+export async function getSession(): Promise<User | null> {
+  try {
+    const session = await authClient.getSession();
+    if (!session?.data?.user) return null;
+
+    return {
+      id: session.data.user.id,
+      email: session.data.user.email,
+      name: session.data.user.name,
+    };
+  } catch {
+    return null;
+  }
+}

--- a/examples/auth-betterauth/src/auth.ts
+++ b/examples/auth-betterauth/src/auth.ts
@@ -6,13 +6,15 @@
  */
 
 import { createAuthClient } from "better-auth/client";
+import { jwtClient } from "better-auth/client/plugins";
 
 // Auth server URL
 const AUTH_URL = "http://localhost:3001";
 
-// Create the BetterAuth client
+// Create the BetterAuth client with JWT plugin
 export const authClient = createAuthClient({
   baseURL: AUTH_URL,
+  plugins: [jwtClient()],
 });
 
 // Types for auth state
@@ -37,19 +39,13 @@ export interface AuthState {
  */
 export async function getJazzToken(): Promise<string | null> {
   try {
-    const session = await authClient.getSession();
-    if (!session?.data) return null;
-
-    // BetterAuth provides the token in the session
-    // For JWT plugin, we need to get it from the session endpoint
-    const response = await fetch(`${AUTH_URL}/api/auth/token`, {
-      credentials: "include",
-    });
-
-    if (!response.ok) return null;
-
-    const data = await response.json();
-    return data.token || null;
+    // Use the JWT plugin's token method
+    const result = await authClient.token();
+    if (result.error || !result.data) {
+      console.error("Failed to get JWT token:", result.error);
+      return null;
+    }
+    return result.data.token;
   } catch (error) {
     console.error("Failed to get Jazz token:", error);
     return null;

--- a/examples/auth-betterauth/src/main.tsx
+++ b/examples/auth-betterauth/src/main.tsx
@@ -1,0 +1,9 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import App from "./App";
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/examples/auth-betterauth/src/schema.sql
+++ b/examples/auth-betterauth/src/schema.sql
@@ -1,0 +1,98 @@
+-- Jazz Schema with BetterAuth-aware policies
+--
+-- This schema demonstrates how to use JWT claims from BetterAuth
+-- in Jazz policies for fine-grained access control.
+
+-- Users table (auto-provisioned from BetterAuth)
+CREATE TABLE users (
+  name STRING,
+  email STRING,
+  external_id STRING NOT NULL,
+  subscription_tier STRING
+);
+
+-- Personal documents - only owner can see
+CREATE TABLE documents (
+  title STRING NOT NULL,
+  content STRING,
+  author REFERENCES users NOT NULL
+);
+
+CREATE POLICY ON documents FOR SELECT
+  WHERE author = @viewer;
+
+CREATE POLICY ON documents FOR INSERT
+  CHECK (@new.author = @viewer);
+
+CREATE POLICY ON documents FOR UPDATE
+  WHERE author = @viewer;
+
+CREATE POLICY ON documents FOR DELETE
+  WHERE author = @viewer;
+
+-- Organization documents - scoped by orgId claim
+CREATE TABLE org_documents (
+  title STRING NOT NULL,
+  content STRING,
+  org_id STRING NOT NULL,
+  author REFERENCES users NOT NULL
+);
+
+-- Only users in the same organization can see documents
+CREATE POLICY ON org_documents FOR SELECT
+  WHERE org_id = @viewer.claims.orgId;
+
+-- Only users in the org can create documents
+CREATE POLICY ON org_documents FOR INSERT
+  CHECK (
+    @new.org_id = @viewer.claims.orgId
+    AND @new.author = @viewer
+  );
+
+-- Authors can update their own documents within their org
+CREATE POLICY ON org_documents FOR UPDATE
+  WHERE org_id = @viewer.claims.orgId
+    AND author = @viewer;
+
+-- Premium features - subscription tier check
+CREATE TABLE premium_features (
+  name STRING NOT NULL,
+  description STRING,
+  min_tier STRING NOT NULL
+);
+
+-- Only pro/enterprise users can see premium features
+CREATE POLICY ON premium_features FOR SELECT
+  WHERE @viewer.claims.subscriptionTier = 'pro'
+     OR @viewer.claims.subscriptionTier = 'enterprise';
+
+-- Admin settings - role-based access
+CREATE TABLE admin_settings (
+  key STRING NOT NULL,
+  value STRING
+);
+
+-- Only admins can read/update settings
+CREATE POLICY ON admin_settings FOR SELECT
+  WHERE @viewer.claims.roles CONTAINS 'admin';
+
+CREATE POLICY ON admin_settings FOR UPDATE
+  WHERE @viewer.claims.roles CONTAINS 'admin';
+
+-- Shared documents with team membership
+CREATE TABLE team_documents (
+  title STRING NOT NULL,
+  content STRING,
+  team_id STRING NOT NULL,
+  author REFERENCES users NOT NULL
+);
+
+-- Users can see documents for teams they belong to
+CREATE POLICY ON team_documents FOR SELECT
+  WHERE team_id IN @viewer.claims.teams;
+
+CREATE POLICY ON team_documents FOR INSERT
+  CHECK (
+    @new.team_id IN @viewer.claims.teams
+    AND @new.author = @viewer
+  );

--- a/examples/auth-betterauth/tests/auth.spec.ts
+++ b/examples/auth-betterauth/tests/auth.spec.ts
@@ -1,0 +1,406 @@
+import { expect, test } from "@playwright/test";
+
+// Generate unique email for each test run to avoid conflicts
+const testId = Date.now();
+const testEmail = `test-${testId}@example.com`;
+const testPassword = "TestPassword123!";
+const testName = "Test User";
+
+test.describe("BetterAuth Sign Up", () => {
+  test.beforeEach(async ({ page }) => {
+    // Capture console output for debugging
+    page.on("console", (msg) => {
+      if (msg.type() === "error") {
+        console.log("CONSOLE ERROR:", msg.text());
+      }
+    });
+    page.on("pageerror", (err) => console.log("PAGE ERROR:", err.message));
+
+    await page.goto("/");
+    await expect(
+      page.getByRole("heading", { name: "Jazz + BetterAuth Demo" }),
+    ).toBeVisible({ timeout: 10000 });
+  });
+
+  test("displays sign in form by default", async ({ page }) => {
+    await expect(page.getByRole("heading", { name: "Sign In" })).toBeVisible();
+    await expect(page.getByPlaceholder("Email")).toBeVisible();
+    await expect(page.getByPlaceholder("Password")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Sign In" })).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /Need an account\? Sign Up/ }),
+    ).toBeVisible();
+  });
+
+  test("switches to sign up form", async ({ page }) => {
+    await page
+      .getByRole("button", { name: /Need an account\? Sign Up/ })
+      .click();
+
+    await expect(page.getByRole("heading", { name: "Sign Up" })).toBeVisible();
+    await expect(page.getByPlaceholder("Name")).toBeVisible();
+    await expect(page.getByPlaceholder("Email")).toBeVisible();
+    await expect(page.getByPlaceholder("Password")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Sign Up" })).toBeVisible();
+  });
+
+  test("creates new account successfully", async ({ page }) => {
+    // Switch to sign up
+    await page
+      .getByRole("button", { name: /Need an account\? Sign Up/ })
+      .click();
+    await expect(page.getByRole("heading", { name: "Sign Up" })).toBeVisible();
+
+    // Fill in the form
+    await page.getByPlaceholder("Name").fill(testName);
+    await page.getByPlaceholder("Email").fill(testEmail);
+    await page.getByPlaceholder("Password").fill(testPassword);
+
+    // Submit
+    await page.getByRole("button", { name: "Sign Up" }).click();
+
+    // Should be logged in and see user info
+    await expect(page.getByText(`Logged in as: ${testName}`)).toBeVisible({
+      timeout: 10000,
+    });
+    await expect(page.getByRole("button", { name: "Sign Out" })).toBeVisible();
+  });
+
+  test("shows error for duplicate email", async ({ browser }) => {
+    const duplicateEmail = `duplicate-${testId}@example.com`;
+
+    // Create first account in one context
+    const context1 = await browser.newContext();
+    const page1 = await context1.newPage();
+    await page1.goto("/");
+    await expect(
+      page1.getByRole("heading", { name: "Jazz + BetterAuth Demo" }),
+    ).toBeVisible({ timeout: 10000 });
+
+    await page1
+      .getByRole("button", { name: /Need an account\? Sign Up/ })
+      .click();
+    await page1.getByPlaceholder("Name").fill("First User");
+    await page1.getByPlaceholder("Email").fill(duplicateEmail);
+    await page1.getByPlaceholder("Password").fill(testPassword);
+    await page1.getByRole("button", { name: "Sign Up" }).click();
+    await expect(page1.getByText("Logged in as:")).toBeVisible({
+      timeout: 10000,
+    });
+    await context1.close();
+
+    // Try to sign up with same email in a fresh context
+    const context2 = await browser.newContext();
+    const page2 = await context2.newPage();
+    await page2.goto("/");
+    await expect(
+      page2.getByRole("heading", { name: "Jazz + BetterAuth Demo" }),
+    ).toBeVisible({ timeout: 10000 });
+
+    await page2
+      .getByRole("button", { name: /Need an account\? Sign Up/ })
+      .click();
+    await page2.getByPlaceholder("Name").fill("Second User");
+    await page2.getByPlaceholder("Email").fill(duplicateEmail);
+    await page2.getByPlaceholder("Password").fill(testPassword);
+    await page2.getByRole("button", { name: "Sign Up" }).click();
+
+    // Should show error for duplicate email
+    await expect(page2.locator(".error")).toBeVisible({ timeout: 5000 });
+    await context2.close();
+  });
+});
+
+test.describe("BetterAuth Sign In", () => {
+  const signInEmail = `signin-${testId}@example.com`;
+
+  test.beforeAll(async ({ browser }) => {
+    // Create an account to sign in with
+    const page = await browser.newPage();
+    await page.goto("/");
+    await page
+      .getByRole("button", { name: /Need an account\? Sign Up/ })
+      .click();
+    await page.getByPlaceholder("Name").fill("Sign In Test User");
+    await page.getByPlaceholder("Email").fill(signInEmail);
+    await page.getByPlaceholder("Password").fill(testPassword);
+    await page.getByRole("button", { name: "Sign Up" }).click();
+    await expect(page.getByText("Logged in as:")).toBeVisible({
+      timeout: 10000,
+    });
+    await page.getByRole("button", { name: "Sign Out" }).click();
+    await page.close();
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+    await expect(
+      page.getByRole("heading", { name: "Jazz + BetterAuth Demo" }),
+    ).toBeVisible({ timeout: 10000 });
+  });
+
+  test("signs in with valid credentials", async ({ page }) => {
+    await page.getByPlaceholder("Email").fill(signInEmail);
+    await page.getByPlaceholder("Password").fill(testPassword);
+    await page.getByRole("button", { name: "Sign In" }).click();
+
+    await expect(page.getByText("Logged in as: Sign In Test User")).toBeVisible(
+      {
+        timeout: 10000,
+      },
+    );
+  });
+
+  test("shows error for invalid credentials", async ({ page }) => {
+    await page.getByPlaceholder("Email").fill(signInEmail);
+    await page.getByPlaceholder("Password").fill("WrongPassword123!");
+    await page.getByRole("button", { name: "Sign In" }).click();
+
+    await expect(page.locator(".error")).toBeVisible({ timeout: 5000 });
+  });
+
+  test("shows error for non-existent email", async ({ page }) => {
+    await page.getByPlaceholder("Email").fill("nonexistent@example.com");
+    await page.getByPlaceholder("Password").fill(testPassword);
+    await page.getByRole("button", { name: "Sign In" }).click();
+
+    await expect(page.locator(".error")).toBeVisible({ timeout: 5000 });
+  });
+});
+
+test.describe("BetterAuth Sign Out", () => {
+  const signOutEmail = `signout-${testId}@example.com`;
+
+  test.beforeAll(async ({ browser }) => {
+    // Create an account
+    const page = await browser.newPage();
+    await page.goto("/");
+    await page
+      .getByRole("button", { name: /Need an account\? Sign Up/ })
+      .click();
+    await page.getByPlaceholder("Name").fill("Sign Out Test User");
+    await page.getByPlaceholder("Email").fill(signOutEmail);
+    await page.getByPlaceholder("Password").fill(testPassword);
+    await page.getByRole("button", { name: "Sign Up" }).click();
+    await expect(page.getByText("Logged in as:")).toBeVisible({
+      timeout: 10000,
+    });
+    await page.getByRole("button", { name: "Sign Out" }).click();
+    await page.close();
+  });
+
+  test("signs out successfully", async ({ page }) => {
+    await page.goto("/");
+
+    // Sign in first
+    await page.getByPlaceholder("Email").fill(signOutEmail);
+    await page.getByPlaceholder("Password").fill(testPassword);
+    await page.getByRole("button", { name: "Sign In" }).click();
+
+    await expect(page.getByText("Logged in as:")).toBeVisible({
+      timeout: 10000,
+    });
+
+    // Sign out
+    await page.getByRole("button", { name: "Sign Out" }).click();
+
+    // Should be back to sign in form
+    await expect(page.getByRole("heading", { name: "Sign In" })).toBeVisible({
+      timeout: 5000,
+    });
+    await expect(
+      page.getByRole("button", { name: "Sign Out" }),
+    ).not.toBeVisible();
+  });
+});
+
+test.describe("JWT Token Display", () => {
+  const tokenEmail = `token-${testId}@example.com`;
+
+  test.beforeAll(async ({ browser }) => {
+    // Create an account
+    const page = await browser.newPage();
+    await page.goto("/");
+    await page
+      .getByRole("button", { name: /Need an account\? Sign Up/ })
+      .click();
+    await page.getByPlaceholder("Name").fill("Token Test User");
+    await page.getByPlaceholder("Email").fill(tokenEmail);
+    await page.getByPlaceholder("Password").fill(testPassword);
+    await page.getByRole("button", { name: "Sign Up" }).click();
+    await expect(page.getByText("Logged in as:")).toBeVisible({
+      timeout: 10000,
+    });
+    await page.getByRole("button", { name: "Sign Out" }).click();
+    await page.close();
+  });
+
+  test("displays JWT token after sign in", async ({ page }) => {
+    await page.goto("/");
+
+    await page.getByPlaceholder("Email").fill(tokenEmail);
+    await page.getByPlaceholder("Password").fill(testPassword);
+    await page.getByRole("button", { name: "Sign In" }).click();
+
+    await expect(page.getByText("Logged in as:")).toBeVisible({
+      timeout: 10000,
+    });
+
+    // JWT token section should be visible
+    await expect(
+      page.getByRole("heading", { name: "JWT Token (for Jazz)" }),
+    ).toBeVisible();
+
+    // Token should be displayed (it's a long base64 string with dots)
+    const tokenPre = page.locator("pre").first();
+    const tokenText = await tokenPre.textContent();
+    expect(tokenText).toMatch(/^eyJ/); // JWT tokens start with eyJ (base64 of {"...)
+    expect(tokenText).toContain("."); // JWTs have dots separating header.payload.signature
+  });
+
+  test("displays decoded JWT claims", async ({ page }) => {
+    await page.goto("/");
+
+    await page.getByPlaceholder("Email").fill(tokenEmail);
+    await page.getByPlaceholder("Password").fill(testPassword);
+    await page.getByRole("button", { name: "Sign In" }).click();
+
+    await expect(page.getByText("Logged in as:")).toBeVisible({
+      timeout: 10000,
+    });
+
+    // Decoded claims section should be visible
+    await expect(
+      page.getByRole("heading", { name: "Decoded Claims" }),
+    ).toBeVisible();
+
+    // Should show standard JWT claims
+    await expect(page.getByText(/"sub":/)).toBeVisible();
+    await expect(page.getByText(/"email":/)).toBeVisible();
+
+    // Should contain our test email in the claims
+    await expect(page.getByText(tokenEmail)).toBeVisible();
+  });
+});
+
+test.describe("Example Jazz Policies Display", () => {
+  const policyEmail = `policy-${testId}@example.com`;
+
+  test.beforeAll(async ({ browser }) => {
+    // Create an account
+    const page = await browser.newPage();
+    await page.goto("/");
+    await page
+      .getByRole("button", { name: /Need an account\? Sign Up/ })
+      .click();
+    await page.getByPlaceholder("Name").fill("Policy Test User");
+    await page.getByPlaceholder("Email").fill(policyEmail);
+    await page.getByPlaceholder("Password").fill(testPassword);
+    await page.getByRole("button", { name: "Sign Up" }).click();
+    await expect(page.getByText("Logged in as:")).toBeVisible({
+      timeout: 10000,
+    });
+    await page.getByRole("button", { name: "Sign Out" }).click();
+    await page.close();
+  });
+
+  test("shows example Jazz policies when logged in", async ({ page }) => {
+    await page.goto("/");
+
+    await page.getByPlaceholder("Email").fill(policyEmail);
+    await page.getByPlaceholder("Password").fill(testPassword);
+    await page.getByRole("button", { name: "Sign In" }).click();
+
+    await expect(page.getByText("Logged in as:")).toBeVisible({
+      timeout: 10000,
+    });
+
+    // Example policies section should be visible
+    await expect(
+      page.getByRole("heading", { name: "Example Jazz Policies" }),
+    ).toBeVisible();
+
+    // Should show policy syntax examples
+    await expect(page.getByText("CREATE POLICY")).toBeVisible();
+    await expect(page.getByText("@viewer")).toBeVisible();
+    await expect(
+      page.getByText("@viewer.claims.subscriptionTier"),
+    ).toBeVisible();
+  });
+
+  test("shows groove-server configuration example", async ({ page }) => {
+    await page.goto("/");
+
+    await page.getByPlaceholder("Email").fill(policyEmail);
+    await page.getByPlaceholder("Password").fill(testPassword);
+    await page.getByRole("button", { name: "Sign In" }).click();
+
+    await expect(page.getByText("Logged in as:")).toBeVisible({
+      timeout: 10000,
+    });
+
+    // Config section should be visible
+    await expect(
+      page.getByRole("heading", { name: "groove-server Configuration" }),
+    ).toBeVisible();
+
+    // Should show TOML config example
+    await expect(page.getByText(/\[auth\]/)).toBeVisible();
+    await expect(page.getByText(/jwks_url/)).toBeVisible();
+  });
+});
+
+test.describe("Form Validation", () => {
+  test("requires email field", async ({ page }) => {
+    await page.goto("/");
+
+    // Try to submit without email
+    await page.getByPlaceholder("Password").fill(testPassword);
+    await page.getByRole("button", { name: "Sign In" }).click();
+
+    // Form should not submit (email is required)
+    // The form uses HTML5 validation, so we check we're still on the form
+    await expect(page.getByRole("heading", { name: "Sign In" })).toBeVisible();
+  });
+
+  test("requires password field", async ({ page }) => {
+    await page.goto("/");
+
+    // Try to submit without password
+    await page.getByPlaceholder("Email").fill("test@example.com");
+    await page.getByRole("button", { name: "Sign In" }).click();
+
+    // Form should not submit (password is required)
+    await expect(page.getByRole("heading", { name: "Sign In" })).toBeVisible();
+  });
+
+  test("requires name field on sign up", async ({ page }) => {
+    await page.goto("/");
+    await page
+      .getByRole("button", { name: /Need an account\? Sign Up/ })
+      .click();
+
+    // Try to submit without name
+    await page.getByPlaceholder("Email").fill("test@example.com");
+    await page.getByPlaceholder("Password").fill(testPassword);
+    await page.getByRole("button", { name: "Sign Up" }).click();
+
+    // Form should not submit (name is required)
+    await expect(page.getByRole("heading", { name: "Sign Up" })).toBeVisible();
+  });
+});
+
+test.describe("Loading State", () => {
+  test("shows loading state or sign in form on page load", async ({ page }) => {
+    // Don't wait for full load
+    await page.goto("/", { waitUntil: "commit" });
+
+    // Either loading is shown briefly or the form appears
+    // This tests that the app handles initial state properly
+    const loadingText = page.getByText("Loading...");
+    const signInHeading = page.getByRole("heading", { name: "Sign In" });
+
+    // Wait for either element to be visible
+    await expect(loadingText.or(signInHeading)).toBeVisible({ timeout: 10000 });
+  });
+});

--- a/examples/auth-betterauth/tsconfig.json
+++ b/examples/auth-betterauth/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src", "server"]
+}

--- a/examples/auth-betterauth/vite.config.js
+++ b/examples/auth-betterauth/vite.config.js
@@ -1,0 +1,14 @@
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+import topLevelAwait from "vite-plugin-top-level-await";
+import wasm from "vite-plugin-wasm";
+
+export default defineConfig({
+  plugins: [react(), wasm(), topLevelAwait()],
+  server: {
+    port: 5173,
+  },
+  optimizeDeps: {
+    exclude: ["groove-wasm"],
+  },
+});

--- a/examples/auth-workos/README.md
+++ b/examples/auth-workos/README.md
@@ -72,11 +72,9 @@ These claims come from:
 3. Configure at least one SSO connection (or use test user)
 4. Note your Client ID for the JWKS URL
 
-### 2. Set Environment Variables
+### 2. Environment Variables
 
-```bash
-export VITE_WORKOS_CLIENT_ID="client_01H..."
-```
+The client ID is already configured in the demo. No environment variables needed.
 
 ### 3. Install Dependencies
 
@@ -87,11 +85,11 @@ pnpm install
 
 ### 4. Start groove-server
 
-Edit `groove-server.toml` with your WorkOS client ID:
+The `groove-server.toml` is already configured:
 
 ```toml
 [auth.jwt]
-jwks_url = "https://api.workos.com/sso/jwks/client_01H..."
+jwks_url = "https://api.workos.com/sso/jwks/client_01JX28XKCGFWXHBMX2FW66JTRM"
 ```
 
 Then start the server:
@@ -142,7 +140,7 @@ CREATE POLICY ON projects FOR SELECT
 provider = "workos"
 
 [auth.jwt]
-jwks_url = "https://api.workos.com/sso/jwks/client_01H..."
+jwks_url = "https://api.workos.com/sso/jwks/client_01JX28XKCGFWXHBMX2FW66JTRM"
 issuer = "https://api.workos.com/"
 user_id_claim = "sub"
 

--- a/examples/auth-workos/README.md
+++ b/examples/auth-workos/README.md
@@ -1,0 +1,177 @@
+# Jazz + WorkOS Demo
+
+This example demonstrates how to integrate Jazz with WorkOS for enterprise SSO
+authentication and use automatic role/permissions claims in ReBAC policies.
+
+## Architecture
+
+```
+┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐
+│   React App     │────▶│     WorkOS      │     │  groove-server  │
+│   (Frontend)    │     │   (AuthKit)     │     │  (Jazz Server)  │
+└────────┬────────┘     └────────┬────────┘     └────────┬────────┘
+         │                       │                       │
+         │  1. SSO Redirect      │                       │
+         │─────────────────────▶│                       │
+         │                       │                       │
+         │  2. IdP Login         │                       │
+         │   (Okta, Azure, etc.) │                       │
+         │                       │                       │
+         │  3. Access Token      │                       │
+         │◀─────────────────────│                       │
+         │   (with claims)       │                       │
+         │                       │                       │
+         │  4. Connect with JWT  │                       │
+         │──────────────────────────────────────────────▶│
+         │                       │                       │
+         │                       │  5. Validate via JWKS │
+         │                       │◀──────────────────────│
+         │                       │                       │
+         │  6. Sync with permission-aware policies      │
+         │◀─────────────────────────────────────────────│
+```
+
+## WorkOS Automatic Claims
+
+WorkOS access tokens automatically include these claims:
+
+| Claim | Description | Example |
+|-------|-------------|---------|
+| `sub` | WorkOS user ID | `user_01H...` |
+| `org_id` | Organization selected at sign-in | `org_01H...` |
+| `role` | Organization membership role | `admin` |
+| `permissions` | Array of permission slugs | `["documents:read", "admin:settings"]` |
+| `sid` | Session ID | `session_01H...` |
+
+These claims come from:
+- **Directory Sync**: Groups from SCIM sync map to roles
+- **Admin Portal**: Role → permission mappings configured in WorkOS
+- **Sign-in Selection**: User selects organization at login
+
+## Features Demonstrated
+
+- **Enterprise SSO**: SAML/OIDC via Okta, Azure AD, Google Workspace, etc.
+- **Permission-Based Policies**: `@viewer.claims.permissions CONTAINS 'documents:write'`
+- **Role-Based Access**: `@viewer.claims.role = 'admin'`
+- **Organization Scoping**: `org_id = @viewer.claims.org_id`
+- **Team Membership**: `team_id IN @viewer.claims.groups`
+
+## Running the Demo
+
+### Prerequisites
+
+- Node.js 18+
+- pnpm
+- WorkOS account with AuthKit enabled
+- Rust toolchain (for groove-server)
+
+### 1. Configure WorkOS
+
+1. Create a WorkOS account at https://workos.com
+2. Enable AuthKit in your environment
+3. Configure at least one SSO connection (or use test user)
+4. Note your Client ID for the JWKS URL
+
+### 2. Set Environment Variables
+
+```bash
+export VITE_WORKOS_CLIENT_ID="client_01H..."
+```
+
+### 3. Install Dependencies
+
+```bash
+cd examples/auth-workos
+pnpm install
+```
+
+### 4. Start groove-server
+
+Edit `groove-server.toml` with your WorkOS client ID:
+
+```toml
+[auth.jwt]
+jwks_url = "https://api.workos.com/sso/jwks/client_01H..."
+```
+
+Then start the server:
+
+```bash
+cd ../../crates
+cargo run -p groove-server -- --config ../examples/auth-workos/groove-server.toml
+```
+
+### 5. Start React App
+
+```bash
+pnpm run dev
+# Runs on http://localhost:5174
+```
+
+## Example Policies
+
+```sql
+-- Permission-based document access
+CREATE POLICY ON documents FOR SELECT
+  WHERE org_id = @viewer.claims.org_id
+    AND (
+      sensitivity = 'public'
+      OR @viewer.claims.permissions CONTAINS 'documents:read'
+    );
+
+-- Write requires specific permission
+CREATE POLICY ON documents FOR UPDATE
+  WHERE org_id = @viewer.claims.org_id
+    AND @viewer.claims.permissions CONTAINS 'documents:write';
+
+-- Admin-only by role
+CREATE POLICY ON settings FOR UPDATE
+  WHERE @viewer.claims.role = 'admin';
+
+-- Team-based access via directory groups
+CREATE POLICY ON projects FOR SELECT
+  WHERE team_id IN @viewer.claims.groups;
+```
+
+## Configuration
+
+### groove-server.toml
+
+```toml
+[auth]
+provider = "workos"
+
+[auth.jwt]
+jwks_url = "https://api.workos.com/sso/jwks/client_01H..."
+issuer = "https://api.workos.com/"
+user_id_claim = "sub"
+
+[auth.provisioning]
+auto_provision = true
+users_table = "users"
+```
+
+## WorkOS Dashboard Setup
+
+### 1. Configure Roles
+
+In the WorkOS Admin Portal, create roles like:
+- `admin` - Full access
+- `editor` - Read/write access
+- `viewer` - Read-only access
+
+### 2. Map Permissions
+
+Assign permission slugs to each role:
+- `admin`: `documents:*`, `users:*`, `admin:*`
+- `editor`: `documents:read`, `documents:write`
+- `viewer`: `documents:read`
+
+### 3. Directory Sync
+
+Connect your identity provider via SCIM to sync:
+- Users and their groups
+- Group → Role mappings
+- Automatic deprovisioning
+
+The synced data flows automatically into JWT claims!

--- a/examples/auth-workos/README.md
+++ b/examples/auth-workos/README.md
@@ -3,6 +3,9 @@
 This example demonstrates how to integrate Jazz with WorkOS for enterprise SSO
 authentication and use automatic role/permissions claims in ReBAC policies.
 
+> **Spec**: See [Authentication](/docs/internals/authentication) for the full specification
+> and [Access Control](/docs/internals/access-control) for ReBAC policy syntax.
+
 ## Architecture
 
 ```

--- a/examples/auth-workos/groove-server.toml
+++ b/examples/auth-workos/groove-server.toml
@@ -1,0 +1,29 @@
+# Groove Server configuration for WorkOS demo
+#
+# This configures groove-server to validate JWT tokens from WorkOS
+# and use the automatic claims for policy evaluation.
+
+host = "0.0.0.0"
+port = 8080
+
+[auth]
+provider = "workos"
+
+[auth.jwt]
+# WorkOS JWKS endpoint
+# Replace CLIENT_ID with your actual WorkOS client ID
+jwks_url = "https://api.workos.com/sso/jwks/client_01H..."
+# WorkOS issuer
+issuer = "https://api.workos.com/"
+# WorkOS uses 'sub' for user ID
+user_id_claim = "sub"
+# Validate token expiration
+validate_exp = true
+
+[auth.provisioning]
+# Automatically create Jazz users on first login
+auto_provision = true
+# Table to store user records
+users_table = "users"
+# Column for external user ID mapping
+external_id_column = "external_id"

--- a/examples/auth-workos/groove-server.toml
+++ b/examples/auth-workos/groove-server.toml
@@ -11,8 +11,7 @@ provider = "workos"
 
 [auth.jwt]
 # WorkOS JWKS endpoint
-# Replace CLIENT_ID with your actual WorkOS client ID
-jwks_url = "https://api.workos.com/sso/jwks/client_01H..."
+jwks_url = "https://api.workos.com/sso/jwks/client_01JX28XKCGFWXHBMX2FW66JTRM"
 # WorkOS issuer
 issuer = "https://api.workos.com/"
 # WorkOS uses 'sub' for user ID

--- a/examples/auth-workos/index.html
+++ b/examples/auth-workos/index.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Jazz + WorkOS Demo</title>
+    <style>
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+        max-width: 900px;
+        margin: 0 auto;
+        padding: 2rem;
+        background: #f8f9fa;
+      }
+      .card {
+        background: white;
+        border-radius: 8px;
+        padding: 1.5rem;
+        margin-bottom: 1rem;
+        box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+      }
+      button {
+        background: #6366f1;
+        color: white;
+        border: none;
+        padding: 0.5rem 1rem;
+        border-radius: 4px;
+        cursor: pointer;
+        margin-right: 0.5rem;
+      }
+      button:hover {
+        background: #4f46e5;
+      }
+      .user-info {
+        background: #eef2ff;
+        padding: 1rem;
+        border-radius: 4px;
+        margin-bottom: 1rem;
+      }
+      .claims-table {
+        width: 100%;
+        border-collapse: collapse;
+        margin-top: 1rem;
+      }
+      .claims-table th, .claims-table td {
+        text-align: left;
+        padding: 0.5rem;
+        border-bottom: 1px solid #e5e7eb;
+      }
+      .claims-table th {
+        background: #f9fafb;
+        font-weight: 600;
+      }
+      .permission-badge {
+        display: inline-block;
+        background: #ddd6fe;
+        color: #5b21b6;
+        padding: 0.25rem 0.5rem;
+        border-radius: 4px;
+        font-size: 0.85rem;
+        margin: 0.125rem;
+      }
+      .role-badge {
+        display: inline-block;
+        background: #fef3c7;
+        color: #92400e;
+        padding: 0.25rem 0.5rem;
+        border-radius: 4px;
+        font-size: 0.85rem;
+      }
+      pre {
+        background: #f5f5f5;
+        padding: 1rem;
+        overflow: auto;
+        border-radius: 4px;
+        font-size: 0.85rem;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/examples/auth-workos/package.json
+++ b/examples/auth-workos/package.json
@@ -5,7 +5,9 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build"
+    "build": "vite build",
+    "test": "playwright test",
+    "test:ui": "playwright test --ui"
   },
   "dependencies": {
     "@jazz/client": "workspace:*",
@@ -16,6 +18,7 @@
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.49.1",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.2.0",

--- a/examples/auth-workos/package.json
+++ b/examples/auth-workos/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@jazz/client": "workspace:*",
     "@jazz/react": "workspace:*",
-    "@workos-inc/authkit-js": "^0.10.0",
+    "@workos-inc/authkit-react": "^0.14.0",
     "groove-wasm": "workspace:*",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/examples/auth-workos/package.json
+++ b/examples/auth-workos/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "auth-workos-demo",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build"
+  },
+  "dependencies": {
+    "@jazz/client": "workspace:*",
+    "@jazz/react": "workspace:*",
+    "@workos-inc/authkit-js": "^0.10.0",
+    "groove-wasm": "workspace:*",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "@vitejs/plugin-react": "^4.2.0",
+    "typescript": "^5.9.3",
+    "vite": "^5.0.0",
+    "vite-plugin-top-level-await": "^1.4.0",
+    "vite-plugin-wasm": "^3.3.0"
+  }
+}

--- a/examples/auth-workos/playwright.config.ts
+++ b/examples/auth-workos/playwright.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests",
+  testMatch: "**/*.spec.ts",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: "html",
+  use: {
+    baseURL: "http://localhost:5174",
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    command: "npm run dev",
+    url: "http://localhost:5174",
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/examples/auth-workos/src/App.tsx
+++ b/examples/auth-workos/src/App.tsx
@@ -6,48 +6,37 @@
  * 2. Use WorkOS automatic claims (org_id, role, permissions)
  * 3. Connect to groove-server with the JWT
  * 4. Use permissions-based access control in Jazz policies
- *
- * NOTE: This is a demonstration app. To run it, you need:
- * - A WorkOS account with AuthKit enabled
- * - Environment variables: VITE_WORKOS_CLIENT_ID
  */
 
-import { useState } from "react";
+import { useAuth } from "@workos-inc/authkit-react";
 
-// Mock WorkOS token for demonstration purposes
-// In production, this would come from WorkOS AuthKit
-const MOCK_WORKOS_TOKEN = {
-  sub: "user_01H1234567890ABCDEF",
-  org_id: "org_01H9876543210FEDCBA",
-  role: "admin",
-  permissions: [
-    "documents:read",
-    "documents:write",
-    "documents:delete",
-    "admin:settings",
-    "users:read",
-    "users:invite",
-  ],
-  sid: "session_01HABCDEF123456789",
-  iss: "https://api.workos.com/",
-  exp: Math.floor(Date.now() / 1000) + 3600,
-};
+// Helper to decode JWT for display
+function parseJwt(token: string): Record<string, unknown> {
+  try {
+    const base64Url = token.split(".")[1];
+    const base64 = base64Url.replace(/-/g, "+").replace(/_/g, "/");
+    const jsonPayload = decodeURIComponent(
+      atob(base64)
+        .split("")
+        .map((c) => `%${`00${c.charCodeAt(0).toString(16)}`.slice(-2)}`)
+        .join(""),
+    );
+    return JSON.parse(jsonPayload);
+  } catch {
+    return { error: "Failed to decode token" };
+  }
+}
 
 function App() {
-  const [isAuthenticated, setIsAuthenticated] = useState(false);
-  const [showMockLogin, setShowMockLogin] = useState(false);
+  const { isLoading, user, getAccessToken, signIn, signOut } = useAuth();
 
-  // In a real app, you'd use WorkOS AuthKit:
-  // const { signIn, signOut, isAuthenticated } = useAuthKit();
-
-  const handleMockLogin = () => {
-    setIsAuthenticated(true);
-    setShowMockLogin(false);
-  };
-
-  const handleLogout = () => {
-    setIsAuthenticated(false);
-  };
+  if (isLoading) {
+    return (
+      <div className="card">
+        <p>Loading...</p>
+      </div>
+    );
+  }
 
   return (
     <div>
@@ -57,7 +46,7 @@ function App() {
         policies.
       </p>
 
-      {!isAuthenticated ? (
+      {!user ? (
         <div className="card">
           <h2>Sign In with WorkOS</h2>
           <p>
@@ -65,125 +54,209 @@ function App() {
             role and permissions claims from directory sync.
           </p>
 
-          {!showMockLogin ? (
-            <>
-              <button onClick={() => setShowMockLogin(true)}>
-                Sign in with SSO (Demo)
-              </button>
-              <p
-                style={{ marginTop: "1rem", color: "#666", fontSize: "0.9rem" }}
-              >
-                Note: This demo uses mock data. In production, WorkOS AuthKit
-                handles the full SSO flow.
-              </p>
-            </>
-          ) : (
-            <div style={{ marginTop: "1rem" }}>
-              <p>
-                In production, users would be redirected to their identity
-                provider (Okta, Azure AD, Google Workspace, etc.)
-              </p>
-              <button onClick={handleMockLogin}>
-                Continue with Demo Token
-              </button>
-              <button
-                onClick={() => setShowMockLogin(false)}
-                style={{ background: "#666" }}
-              >
-                Cancel
-              </button>
-            </div>
-          )}
+          <button onClick={() => signIn()}>Sign in with SSO</button>
+
+          <p style={{ marginTop: "1rem", color: "#666", fontSize: "0.9rem" }}>
+            This demo uses WorkOS Test SSO IdP. Click sign in to authenticate.
+          </p>
         </div>
       ) : (
-        <>
-          <div className="user-info">
-            <strong>Logged in via WorkOS SSO</strong>
-            <br />
-            <small>User ID: {MOCK_WORKOS_TOKEN.sub}</small>
-            <br />
-            <small>Organization: {MOCK_WORKOS_TOKEN.org_id}</small>
-            <br />
-            <span className="role-badge">{MOCK_WORKOS_TOKEN.role}</span>
-            <br />
-            <button onClick={handleLogout} style={{ marginTop: "0.5rem" }}>
-              Sign Out
-            </button>
-          </div>
+        <AuthenticatedContent
+          user={user}
+          getAccessToken={getAccessToken}
+          signOut={signOut}
+        />
+      )}
+    </div>
+  );
+}
 
-          <div className="card">
-            <h3>WorkOS Access Token Claims</h3>
-            <p>
-              WorkOS automatically includes these claims in the access token.
-              They come from directory sync and role assignments in the WorkOS
-              dashboard.
-            </p>
+function AuthenticatedContent({
+  user,
+  getAccessToken,
+  signOut,
+}: {
+  user: {
+    id: string;
+    email: string;
+    firstName?: string | null;
+    lastName?: string | null;
+  };
+  getAccessToken: () => Promise<string>;
+  signOut: () => Promise<void>;
+}) {
+  const [accessToken, setAccessToken] = useState<string | null>(null);
+  const [tokenClaims, setTokenClaims] = useState<Record<
+    string,
+    unknown
+  > | null>(null);
+  const [error, setError] = useState<string | null>(null);
 
-            <table className="claims-table">
-              <thead>
-                <tr>
-                  <th>Claim</th>
-                  <th>Value</th>
-                  <th>Description</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td>
-                    <code>sub</code>
-                  </td>
-                  <td>{MOCK_WORKOS_TOKEN.sub}</td>
-                  <td>WorkOS user ID</td>
-                </tr>
-                <tr>
-                  <td>
-                    <code>org_id</code>
-                  </td>
-                  <td>{MOCK_WORKOS_TOKEN.org_id}</td>
-                  <td>Organization selected at sign-in</td>
-                </tr>
-                <tr>
-                  <td>
-                    <code>role</code>
-                  </td>
-                  <td>
-                    <span className="role-badge">{MOCK_WORKOS_TOKEN.role}</span>
-                  </td>
-                  <td>Organization membership role</td>
-                </tr>
-                <tr>
-                  <td>
-                    <code>permissions</code>
-                  </td>
-                  <td>
-                    {MOCK_WORKOS_TOKEN.permissions.map((p) => (
-                      <span key={p} className="permission-badge">
-                        {p}
+  // Fetch access token on mount
+  useEffect(() => {
+    async function fetchToken() {
+      try {
+        const token = await getAccessToken();
+        setAccessToken(token);
+        setTokenClaims(parseJwt(token));
+      } catch (err) {
+        setError(`Failed to get access token: ${err}`);
+      }
+    }
+    fetchToken();
+  }, [getAccessToken]);
+
+  const displayName =
+    user.firstName && user.lastName
+      ? `${user.firstName} ${user.lastName}`
+      : user.email;
+
+  return (
+    <>
+      <div className="user-info">
+        <strong>Logged in via WorkOS SSO</strong>
+        <br />
+        <small>User: {displayName}</small>
+        <br />
+        <small>Email: {user.email}</small>
+        <br />
+        <small>User ID: {user.id}</small>
+        <br />
+        <button onClick={() => signOut()} style={{ marginTop: "0.5rem" }}>
+          Sign Out
+        </button>
+      </div>
+
+      {error && <div className="error">{error}</div>}
+
+      {accessToken && tokenClaims && (
+        <div className="card">
+          <h3>WorkOS Access Token</h3>
+          <p>
+            This token is sent to groove-server for authentication. The claims
+            can be used in Jazz policies.
+          </p>
+
+          <h4>Raw Token</h4>
+          <pre
+            style={{
+              background: "#f5f5f5",
+              padding: "1rem",
+              overflow: "auto",
+              fontSize: "0.8rem",
+              maxHeight: "150px",
+            }}
+          >
+            {accessToken}
+          </pre>
+
+          <h4>Decoded Claims</h4>
+          <pre
+            style={{
+              background: "#f5f5f5",
+              padding: "1rem",
+              overflow: "auto",
+              fontSize: "0.8rem",
+            }}
+          >
+            {JSON.stringify(tokenClaims, null, 2)}
+          </pre>
+
+          <h4>Claims Table</h4>
+          <table className="claims-table">
+            <thead>
+              <tr>
+                <th>Claim</th>
+                <th>Value</th>
+                <th>Description</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>
+                  <code>sub</code>
+                </td>
+                <td>{String(tokenClaims.sub || "N/A")}</td>
+                <td>WorkOS user ID</td>
+              </tr>
+              <tr>
+                <td>
+                  <code>org_id</code>
+                </td>
+                <td>{String(tokenClaims.org_id || "N/A")}</td>
+                <td>Organization selected at sign-in</td>
+              </tr>
+              <tr>
+                <td>
+                  <code>role</code>
+                </td>
+                <td>
+                  {tokenClaims.role ? (
+                    <span className="role-badge">
+                      {String(tokenClaims.role)}
+                    </span>
+                  ) : (
+                    "N/A"
+                  )}
+                </td>
+                <td>Organization membership role</td>
+              </tr>
+              <tr>
+                <td>
+                  <code>permissions</code>
+                </td>
+                <td>
+                  {Array.isArray(tokenClaims.permissions) ? (
+                    tokenClaims.permissions.map((p) => (
+                      <span key={String(p)} className="permission-badge">
+                        {String(p)}
                       </span>
-                    ))}
-                  </td>
-                  <td>Permissions derived from roles</td>
-                </tr>
-                <tr>
-                  <td>
-                    <code>sid</code>
-                  </td>
-                  <td>{MOCK_WORKOS_TOKEN.sid}</td>
-                  <td>Session ID</td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
+                    ))
+                  ) : (
+                    <em>None configured</em>
+                  )}
+                </td>
+                <td>Permissions derived from roles</td>
+              </tr>
+              <tr>
+                <td>
+                  <code>sid</code>
+                </td>
+                <td>{String(tokenClaims.sid || "N/A")}</td>
+                <td>Session ID</td>
+              </tr>
+              <tr>
+                <td>
+                  <code>iss</code>
+                </td>
+                <td>{String(tokenClaims.iss || "N/A")}</td>
+                <td>Token issuer</td>
+              </tr>
+              <tr>
+                <td>
+                  <code>exp</code>
+                </td>
+                <td>
+                  {tokenClaims.exp
+                    ? new Date(Number(tokenClaims.exp) * 1000).toLocaleString()
+                    : "N/A"}
+                </td>
+                <td>Token expiration</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      )}
 
-          <div className="card">
-            <h3>Jazz Policies with WorkOS Claims</h3>
-            <p>
-              Use WorkOS claims directly in Jazz policies for enterprise access
-              control:
-            </p>
+      <div className="card">
+        <h3>Jazz Policies with WorkOS Claims</h3>
+        <p>
+          Use WorkOS claims directly in Jazz policies for enterprise access
+          control:
+        </p>
 
-            <pre>
-              {`-- Organization-scoped access
+        <pre>
+          {`-- Organization-scoped access
 CREATE POLICY ON documents FOR SELECT
   WHERE org_id = @viewer.claims.org_id;
 
@@ -219,61 +292,59 @@ CREATE POLICY ON users FOR INSERT
     @new.org_id = @viewer.claims.org_id
     AND @viewer.claims.permissions CONTAINS 'users:invite'
   );`}
-            </pre>
-          </div>
+        </pre>
+      </div>
 
-          <div className="card">
-            <h3>groove-server Configuration</h3>
-            <pre>
-              {`# groove-server.toml
+      <div className="card">
+        <h3>groove-server Configuration</h3>
+        <pre>
+          {`# groove-server.toml
 [auth]
 provider = "workos"
 
 [auth.jwt]
-# WorkOS JWKS endpoint (replace CLIENT_ID with your client ID)
-jwks_url = "https://api.workos.com/sso/jwks/client_01H..."
+# WorkOS JWKS endpoint
+jwks_url = "https://api.workos.com/sso/jwks/client_01JX28XKCGFWXHBMX2FW66JTRM"
 issuer = "https://api.workos.com/"
 user_id_claim = "sub"
 
 [auth.provisioning]
 auto_provision = true
 users_table = "users"`}
-            </pre>
-          </div>
+        </pre>
+      </div>
 
-          <div className="card">
-            <h3>WorkOS Directory Sync</h3>
-            <p>
-              WorkOS automatically syncs users and groups from identity
-              providers via SCIM. The synced data flows into JWT claims:
-            </p>
-            <ul>
-              <li>
-                <strong>Groups → Roles</strong>: Directory groups map to roles
-                via the WorkOS Admin Portal
-              </li>
-              <li>
-                <strong>Roles → Permissions</strong>: Each role has associated
-                permission slugs
-              </li>
-              <li>
-                <strong>Permissions in Token</strong>: All permissions flow into
-                the <code>permissions</code> array claim
-              </li>
-            </ul>
-            <p>
-              This means your Jazz policies can check fine-grained permissions
-              like{" "}
-              <code>
-                @viewer.claims.permissions CONTAINS 'documents:delete'
-              </code>
-              without any custom code.
-            </p>
-          </div>
-        </>
-      )}
-    </div>
+      <div className="card">
+        <h3>WorkOS Directory Sync</h3>
+        <p>
+          WorkOS automatically syncs users and groups from identity providers
+          via SCIM. The synced data flows into JWT claims:
+        </p>
+        <ul>
+          <li>
+            <strong>Groups → Roles</strong>: Directory groups map to roles via
+            the WorkOS Admin Portal
+          </li>
+          <li>
+            <strong>Roles → Permissions</strong>: Each role has associated
+            permission slugs
+          </li>
+          <li>
+            <strong>Permissions in Token</strong>: All permissions flow into the{" "}
+            <code>permissions</code> array claim
+          </li>
+        </ul>
+        <p>
+          This means your Jazz policies can check fine-grained permissions like{" "}
+          <code>@viewer.claims.permissions CONTAINS 'documents:delete'</code>{" "}
+          without any custom code.
+        </p>
+      </div>
+    </>
   );
 }
+
+// Import React hooks
+import { useEffect, useState } from "react";
 
 export default App;

--- a/examples/auth-workos/src/App.tsx
+++ b/examples/auth-workos/src/App.tsx
@@ -1,0 +1,279 @@
+/**
+ * Jazz + WorkOS Demo App
+ *
+ * This demo shows how to:
+ * 1. Authenticate users with WorkOS AuthKit (enterprise SSO)
+ * 2. Use WorkOS automatic claims (org_id, role, permissions)
+ * 3. Connect to groove-server with the JWT
+ * 4. Use permissions-based access control in Jazz policies
+ *
+ * NOTE: This is a demonstration app. To run it, you need:
+ * - A WorkOS account with AuthKit enabled
+ * - Environment variables: VITE_WORKOS_CLIENT_ID
+ */
+
+import { useState } from "react";
+
+// Mock WorkOS token for demonstration purposes
+// In production, this would come from WorkOS AuthKit
+const MOCK_WORKOS_TOKEN = {
+  sub: "user_01H1234567890ABCDEF",
+  org_id: "org_01H9876543210FEDCBA",
+  role: "admin",
+  permissions: [
+    "documents:read",
+    "documents:write",
+    "documents:delete",
+    "admin:settings",
+    "users:read",
+    "users:invite",
+  ],
+  sid: "session_01HABCDEF123456789",
+  iss: "https://api.workos.com/",
+  exp: Math.floor(Date.now() / 1000) + 3600,
+};
+
+function App() {
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
+  const [showMockLogin, setShowMockLogin] = useState(false);
+
+  // In a real app, you'd use WorkOS AuthKit:
+  // const { signIn, signOut, isAuthenticated } = useAuthKit();
+
+  const handleMockLogin = () => {
+    setIsAuthenticated(true);
+    setShowMockLogin(false);
+  };
+
+  const handleLogout = () => {
+    setIsAuthenticated(false);
+  };
+
+  return (
+    <div>
+      <h1>Jazz + WorkOS Demo</h1>
+      <p>
+        Enterprise SSO with automatic role and permissions claims for Jazz
+        policies.
+      </p>
+
+      {!isAuthenticated ? (
+        <div className="card">
+          <h2>Sign In with WorkOS</h2>
+          <p>
+            WorkOS AuthKit provides enterprise SSO (SAML, OIDC) with automatic
+            role and permissions claims from directory sync.
+          </p>
+
+          {!showMockLogin ? (
+            <>
+              <button onClick={() => setShowMockLogin(true)}>
+                Sign in with SSO (Demo)
+              </button>
+              <p
+                style={{ marginTop: "1rem", color: "#666", fontSize: "0.9rem" }}
+              >
+                Note: This demo uses mock data. In production, WorkOS AuthKit
+                handles the full SSO flow.
+              </p>
+            </>
+          ) : (
+            <div style={{ marginTop: "1rem" }}>
+              <p>
+                In production, users would be redirected to their identity
+                provider (Okta, Azure AD, Google Workspace, etc.)
+              </p>
+              <button onClick={handleMockLogin}>
+                Continue with Demo Token
+              </button>
+              <button
+                onClick={() => setShowMockLogin(false)}
+                style={{ background: "#666" }}
+              >
+                Cancel
+              </button>
+            </div>
+          )}
+        </div>
+      ) : (
+        <>
+          <div className="user-info">
+            <strong>Logged in via WorkOS SSO</strong>
+            <br />
+            <small>User ID: {MOCK_WORKOS_TOKEN.sub}</small>
+            <br />
+            <small>Organization: {MOCK_WORKOS_TOKEN.org_id}</small>
+            <br />
+            <span className="role-badge">{MOCK_WORKOS_TOKEN.role}</span>
+            <br />
+            <button onClick={handleLogout} style={{ marginTop: "0.5rem" }}>
+              Sign Out
+            </button>
+          </div>
+
+          <div className="card">
+            <h3>WorkOS Access Token Claims</h3>
+            <p>
+              WorkOS automatically includes these claims in the access token.
+              They come from directory sync and role assignments in the WorkOS
+              dashboard.
+            </p>
+
+            <table className="claims-table">
+              <thead>
+                <tr>
+                  <th>Claim</th>
+                  <th>Value</th>
+                  <th>Description</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>
+                    <code>sub</code>
+                  </td>
+                  <td>{MOCK_WORKOS_TOKEN.sub}</td>
+                  <td>WorkOS user ID</td>
+                </tr>
+                <tr>
+                  <td>
+                    <code>org_id</code>
+                  </td>
+                  <td>{MOCK_WORKOS_TOKEN.org_id}</td>
+                  <td>Organization selected at sign-in</td>
+                </tr>
+                <tr>
+                  <td>
+                    <code>role</code>
+                  </td>
+                  <td>
+                    <span className="role-badge">{MOCK_WORKOS_TOKEN.role}</span>
+                  </td>
+                  <td>Organization membership role</td>
+                </tr>
+                <tr>
+                  <td>
+                    <code>permissions</code>
+                  </td>
+                  <td>
+                    {MOCK_WORKOS_TOKEN.permissions.map((p) => (
+                      <span key={p} className="permission-badge">
+                        {p}
+                      </span>
+                    ))}
+                  </td>
+                  <td>Permissions derived from roles</td>
+                </tr>
+                <tr>
+                  <td>
+                    <code>sid</code>
+                  </td>
+                  <td>{MOCK_WORKOS_TOKEN.sid}</td>
+                  <td>Session ID</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <div className="card">
+            <h3>Jazz Policies with WorkOS Claims</h3>
+            <p>
+              Use WorkOS claims directly in Jazz policies for enterprise access
+              control:
+            </p>
+
+            <pre>
+              {`-- Organization-scoped access
+CREATE POLICY ON documents FOR SELECT
+  WHERE org_id = @viewer.claims.org_id;
+
+-- Permission-based access
+CREATE POLICY ON documents FOR SELECT
+  WHERE org_id = @viewer.claims.org_id
+    AND (
+      sensitivity = 'public'
+      OR @viewer.claims.permissions CONTAINS 'documents:read'
+    );
+
+-- Write requires specific permission
+CREATE POLICY ON documents FOR UPDATE
+  WHERE org_id = @viewer.claims.org_id
+    AND @viewer.claims.permissions CONTAINS 'documents:write';
+
+-- Delete requires delete permission
+CREATE POLICY ON documents FOR DELETE
+  WHERE org_id = @viewer.claims.org_id
+    AND @viewer.claims.permissions CONTAINS 'documents:delete';
+
+-- Admin-only settings by role
+CREATE POLICY ON settings FOR UPDATE
+  WHERE @viewer.claims.role = 'admin';
+
+-- User management by permission
+CREATE POLICY ON users FOR SELECT
+  WHERE org_id = @viewer.claims.org_id
+    AND @viewer.claims.permissions CONTAINS 'users:read';
+
+CREATE POLICY ON users FOR INSERT
+  CHECK (
+    @new.org_id = @viewer.claims.org_id
+    AND @viewer.claims.permissions CONTAINS 'users:invite'
+  );`}
+            </pre>
+          </div>
+
+          <div className="card">
+            <h3>groove-server Configuration</h3>
+            <pre>
+              {`# groove-server.toml
+[auth]
+provider = "workos"
+
+[auth.jwt]
+# WorkOS JWKS endpoint (replace CLIENT_ID with your client ID)
+jwks_url = "https://api.workos.com/sso/jwks/client_01H..."
+issuer = "https://api.workos.com/"
+user_id_claim = "sub"
+
+[auth.provisioning]
+auto_provision = true
+users_table = "users"`}
+            </pre>
+          </div>
+
+          <div className="card">
+            <h3>WorkOS Directory Sync</h3>
+            <p>
+              WorkOS automatically syncs users and groups from identity
+              providers via SCIM. The synced data flows into JWT claims:
+            </p>
+            <ul>
+              <li>
+                <strong>Groups → Roles</strong>: Directory groups map to roles
+                via the WorkOS Admin Portal
+              </li>
+              <li>
+                <strong>Roles → Permissions</strong>: Each role has associated
+                permission slugs
+              </li>
+              <li>
+                <strong>Permissions in Token</strong>: All permissions flow into
+                the <code>permissions</code> array claim
+              </li>
+            </ul>
+            <p>
+              This means your Jazz policies can check fine-grained permissions
+              like{" "}
+              <code>
+                @viewer.claims.permissions CONTAINS 'documents:delete'
+              </code>
+              without any custom code.
+            </p>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+export default App;

--- a/examples/auth-workos/src/main.tsx
+++ b/examples/auth-workos/src/main.tsx
@@ -1,0 +1,9 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import App from "./App";
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/examples/auth-workos/src/main.tsx
+++ b/examples/auth-workos/src/main.tsx
@@ -1,9 +1,15 @@
+import { AuthKitProvider } from "@workos-inc/authkit-react";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import App from "./App";
 
+// WorkOS Client ID for this demo
+const WORKOS_CLIENT_ID = "client_01JX28XKCGFWXHBMX2FW66JTRM";
+
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <App />
+    <AuthKitProvider clientId={WORKOS_CLIENT_ID}>
+      <App />
+    </AuthKitProvider>
   </StrictMode>,
 );

--- a/examples/auth-workos/src/schema.sql
+++ b/examples/auth-workos/src/schema.sql
@@ -1,0 +1,107 @@
+-- Jazz Schema with WorkOS-aware policies
+--
+-- This schema demonstrates permission-based access control using
+-- automatic claims from WorkOS (org_id, role, permissions array).
+
+-- Users table (auto-provisioned from WorkOS)
+CREATE TABLE users (
+  name STRING,
+  email STRING,
+  external_id STRING NOT NULL,
+  org_id STRING NOT NULL
+);
+
+-- Documents with sensitivity levels
+CREATE TABLE documents (
+  title STRING NOT NULL,
+  content STRING,
+  org_id STRING NOT NULL,
+  sensitivity STRING NOT NULL,
+  author REFERENCES users NOT NULL
+);
+
+-- Read: Public docs for anyone in org, others need permission
+CREATE POLICY ON documents FOR SELECT
+  WHERE org_id = @viewer.claims.org_id
+    AND (
+      sensitivity = 'public'
+      OR @viewer.claims.permissions CONTAINS 'documents:read'
+    );
+
+-- Create: Need write permission
+CREATE POLICY ON documents FOR INSERT
+  CHECK (
+    @new.org_id = @viewer.claims.org_id
+    AND @new.author = @viewer
+    AND @viewer.claims.permissions CONTAINS 'documents:write'
+  );
+
+-- Update: Need write permission, only own documents
+CREATE POLICY ON documents FOR UPDATE
+  WHERE org_id = @viewer.claims.org_id
+    AND author = @viewer
+    AND @viewer.claims.permissions CONTAINS 'documents:write';
+
+-- Delete: Need delete permission
+CREATE POLICY ON documents FOR DELETE
+  WHERE org_id = @viewer.claims.org_id
+    AND @viewer.claims.permissions CONTAINS 'documents:delete';
+
+-- Admin settings - role-based
+CREATE TABLE settings (
+  key STRING NOT NULL,
+  value STRING,
+  org_id STRING NOT NULL
+);
+
+-- Only admins can manage settings
+CREATE POLICY ON settings FOR SELECT
+  WHERE org_id = @viewer.claims.org_id
+    AND @viewer.claims.role = 'admin';
+
+CREATE POLICY ON settings FOR UPDATE
+  WHERE org_id = @viewer.claims.org_id
+    AND @viewer.claims.role = 'admin';
+
+-- User management - permission-based
+CREATE POLICY ON users FOR SELECT
+  WHERE org_id = @viewer.claims.org_id
+    AND @viewer.claims.permissions CONTAINS 'users:read';
+
+CREATE POLICY ON users FOR INSERT
+  CHECK (
+    @new.org_id = @viewer.claims.org_id
+    AND @viewer.claims.permissions CONTAINS 'users:invite'
+  );
+
+-- Audit logs - read-only for users with audit permission
+CREATE TABLE audit_logs (
+  action STRING NOT NULL,
+  actor_id STRING NOT NULL,
+  resource_type STRING NOT NULL,
+  resource_id STRING NOT NULL,
+  org_id STRING NOT NULL,
+  timestamp I64 NOT NULL
+);
+
+CREATE POLICY ON audit_logs FOR SELECT
+  WHERE org_id = @viewer.claims.org_id
+    AND @viewer.claims.permissions CONTAINS 'audit:read';
+
+-- Projects with team-based access
+CREATE TABLE projects (
+  name STRING NOT NULL,
+  description STRING,
+  org_id STRING NOT NULL,
+  team_id STRING NOT NULL
+);
+
+-- Access based on team membership (teams claim from directory sync)
+CREATE POLICY ON projects FOR SELECT
+  WHERE org_id = @viewer.claims.org_id
+    AND team_id IN @viewer.claims.groups;
+
+CREATE POLICY ON projects FOR UPDATE
+  WHERE org_id = @viewer.claims.org_id
+    AND team_id IN @viewer.claims.groups
+    AND @viewer.claims.permissions CONTAINS 'projects:edit';

--- a/examples/auth-workos/tests/auth.spec.ts
+++ b/examples/auth-workos/tests/auth.spec.ts
@@ -1,0 +1,192 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("WorkOS Demo - Unauthenticated State", () => {
+  test.beforeEach(async ({ page }) => {
+    // Capture console output for debugging
+    page.on("console", (msg) => {
+      if (msg.type() === "error") {
+        console.log("CONSOLE ERROR:", msg.text());
+      }
+    });
+    page.on("pageerror", (err) => console.log("PAGE ERROR:", err.message));
+
+    await page.goto("/");
+  });
+
+  test("displays page title and description", async ({ page }) => {
+    await expect(
+      page.getByRole("heading", { name: "Jazz + WorkOS Demo" }),
+    ).toBeVisible({ timeout: 10000 });
+
+    await expect(
+      page.getByText(
+        "Enterprise SSO with automatic role and permissions claims for Jazz policies.",
+      ),
+    ).toBeVisible();
+  });
+
+  test("shows sign in with WorkOS section", async ({ page }) => {
+    await expect(
+      page.getByRole("heading", { name: "Sign In with WorkOS" }),
+    ).toBeVisible({ timeout: 10000 });
+
+    await expect(
+      page.getByText(/WorkOS AuthKit provides enterprise SSO/),
+    ).toBeVisible();
+  });
+
+  test("displays sign in button", async ({ page }) => {
+    await expect(
+      page.getByRole("button", { name: "Sign in with SSO" }),
+    ).toBeVisible({ timeout: 10000 });
+  });
+
+  test("shows Test SSO IdP information", async ({ page }) => {
+    await expect(
+      page.getByText(/This demo uses WorkOS Test SSO IdP/),
+    ).toBeVisible({ timeout: 10000 });
+  });
+});
+
+test.describe("WorkOS Demo - Sign In Redirect", () => {
+  test("clicking sign in initiates authentication flow", async ({
+    page,
+    context,
+  }) => {
+    await page.goto("/");
+
+    // Wait for the page to load
+    await expect(
+      page.getByRole("button", { name: "Sign in with SSO" }),
+    ).toBeVisible({ timeout: 10000 });
+
+    // Store initial URL
+    const initialUrl = page.url();
+
+    // Listen for popup or navigation
+    const [popup] = await Promise.all([
+      // WorkOS AuthKit may open in popup or same window
+      context
+        .waitForEvent("page", { timeout: 5000 })
+        .catch(() => null),
+      page.getByRole("button", { name: "Sign in with SSO" }).click(),
+    ]);
+
+    // Wait a moment for navigation to complete
+    await page.waitForTimeout(2000);
+
+    // Either a popup was opened or the page navigated away from localhost
+    if (popup) {
+      // Popup was opened - check it's going somewhere external
+      const popupUrl = popup.url();
+      expect(popupUrl).not.toBe("about:blank");
+      // The popup should be for authentication (WorkOS or its redirect)
+      expect(popupUrl).toMatch(/workos\.com|localhost/);
+    } else {
+      // Same-window navigation - URL should have changed OR we should see auth flow
+      // WorkOS AuthKit redirects to their auth page
+      const currentUrl = page.url();
+      // Either navigated to WorkOS or still processing
+      const hasNavigated = currentUrl !== initialUrl;
+      const isWorkOS = currentUrl.includes("workos.com");
+      const isAuthCallback = currentUrl.includes("callback");
+
+      // At minimum, clicking should have triggered some action
+      expect(hasNavigated || isWorkOS || isAuthCallback).toBe(true);
+    }
+  });
+});
+
+test.describe("WorkOS Demo - Loading State", () => {
+  test("shows loading state or sign in form on page load", async ({ page }) => {
+    // Don't wait for full load
+    await page.goto("/", { waitUntil: "commit" });
+
+    // Either loading is shown briefly or the form appears
+    const loadingText = page.getByText("Loading...");
+    const signInHeading = page.getByRole("heading", {
+      name: "Sign In with WorkOS",
+    });
+
+    // Wait for either element to be visible
+    await expect(loadingText.or(signInHeading)).toBeVisible({ timeout: 10000 });
+  });
+});
+
+test.describe("WorkOS Demo - Static Content", () => {
+  // Note: These tests verify content shown in unauthenticated state
+  // The demo shows policy examples even when not logged in
+
+  test("page structure is correct when unauthenticated", async ({ page }) => {
+    await page.goto("/");
+
+    // Main heading should be visible
+    await expect(
+      page.getByRole("heading", { name: "Jazz + WorkOS Demo" }),
+    ).toBeVisible({ timeout: 10000 });
+
+    // Sign in card should be visible
+    await expect(
+      page.getByRole("heading", { name: "Sign In with WorkOS" }),
+    ).toBeVisible();
+
+    // Sign out button should NOT be visible (not authenticated)
+    await expect(
+      page.getByRole("button", { name: "Sign Out" }),
+    ).not.toBeVisible();
+  });
+
+  test("does not show authenticated content when not logged in", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    // Wait for page to load
+    await expect(
+      page.getByRole("heading", { name: "Jazz + WorkOS Demo" }),
+    ).toBeVisible({ timeout: 10000 });
+
+    // These elements should NOT be visible when unauthenticated
+    await expect(page.getByText("Logged in via WorkOS SSO")).not.toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "WorkOS Access Token" }),
+    ).not.toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Jazz Policies with WorkOS Claims" }),
+    ).not.toBeVisible();
+  });
+});
+
+test.describe("WorkOS Demo - Accessibility", () => {
+  test("sign in button is keyboard accessible", async ({ page }) => {
+    await page.goto("/");
+
+    // Wait for button to be visible
+    const signInButton = page.getByRole("button", { name: "Sign in with SSO" });
+    await expect(signInButton).toBeVisible({ timeout: 10000 });
+
+    // Focus the button using keyboard navigation
+    await signInButton.focus();
+
+    // Verify it's focused
+    await expect(signInButton).toBeFocused();
+  });
+
+  test("page has proper heading hierarchy", async ({ page }) => {
+    await page.goto("/");
+
+    // Wait for page to load
+    await expect(
+      page.getByRole("heading", { name: "Jazz + WorkOS Demo" }),
+    ).toBeVisible({ timeout: 10000 });
+
+    // Check h1 exists (main title)
+    const h1 = page.locator("h1");
+    await expect(h1).toHaveCount(1);
+    await expect(h1).toHaveText("Jazz + WorkOS Demo");
+
+    // Check h2 exists for sections
+    const h2 = page.locator("h2");
+    await expect(h2.first()).toBeVisible();
+  });
+});

--- a/examples/auth-workos/tests/sso-flow.spec.ts
+++ b/examples/auth-workos/tests/sso-flow.spec.ts
@@ -7,13 +7,34 @@ import { type Page, expect, test } from "@playwright/test";
  * - WORKOS_TEST_EMAIL: The test user's email
  * - WORKOS_TEST_PASSWORD: The test user's password
  *
+ * In CI: Tests will FAIL if credentials are missing
+ * Locally: Tests will be SKIPPED with a warning if credentials are missing
+ *
  * Run with: WORKOS_TEST_EMAIL=user@example.com WORKOS_TEST_PASSWORD=secret npm test
  */
 
 const testEmail = process.env.WORKOS_TEST_EMAIL;
 const testPassword = process.env.WORKOS_TEST_PASSWORD;
+const isCI = !!process.env.CI;
 
 const hasCredentials = testEmail && testPassword;
+
+// In CI, fail early if credentials are missing
+if (isCI && !hasCredentials) {
+  throw new Error(
+    "WORKOS_TEST_EMAIL and WORKOS_TEST_PASSWORD environment variables are required in CI. " +
+      "Please configure these secrets in GitHub Actions.",
+  );
+}
+
+// Locally, warn if credentials are missing
+if (!isCI && !hasCredentials) {
+  console.warn(
+    "\n⚠️  WARNING: WorkOS SSO flow tests will be skipped.\n" +
+      "   Set WORKOS_TEST_EMAIL and WORKOS_TEST_PASSWORD to run these tests.\n" +
+      "   Example: WORKOS_TEST_EMAIL=user@example.com WORKOS_TEST_PASSWORD=secret npm test\n",
+  );
+}
 
 /**
  * Helper to complete the full SSO authentication flow
@@ -72,9 +93,10 @@ test.describe("WorkOS Full SSO Flow", () => {
   // Run serially to avoid rate limiting issues with WorkOS
   test.describe.configure({ mode: "serial" });
 
+  // Skip locally if credentials are missing (CI will have already failed above)
   test.skip(
     !hasCredentials,
-    "Skipping SSO flow tests - set WORKOS_TEST_EMAIL and WORKOS_TEST_PASSWORD env vars",
+    "Skipping SSO flow tests locally - set WORKOS_TEST_EMAIL and WORKOS_TEST_PASSWORD env vars",
   );
 
   test("completes full SSO authentication flow", async ({ page }) => {

--- a/examples/auth-workos/tests/sso-flow.spec.ts
+++ b/examples/auth-workos/tests/sso-flow.spec.ts
@@ -1,0 +1,171 @@
+import { type Page, expect, test } from "@playwright/test";
+
+/**
+ * Full SSO Flow Tests
+ *
+ * These tests require WorkOS test credentials to be set as environment variables:
+ * - WORKOS_TEST_EMAIL: The test user's email
+ * - WORKOS_TEST_PASSWORD: The test user's password
+ *
+ * Run with: WORKOS_TEST_EMAIL=user@example.com WORKOS_TEST_PASSWORD=secret npm test
+ */
+
+const testEmail = process.env.WORKOS_TEST_EMAIL;
+const testPassword = process.env.WORKOS_TEST_PASSWORD;
+
+const hasCredentials = testEmail && testPassword;
+
+/**
+ * Helper to complete the full SSO authentication flow
+ */
+async function completeAuthFlow(page: Page): Promise<void> {
+  // Load the app
+  await page.goto("/");
+  await expect(
+    page.getByRole("button", { name: "Sign in with SSO" }),
+  ).toBeVisible({ timeout: 10000 });
+
+  // Click sign in - redirects to AuthKit
+  await page.getByRole("button", { name: "Sign in with SSO" }).click();
+
+  // Fill email on AuthKit page
+  await page.waitForURL(/authkit\.app/, { timeout: 10000 });
+  await page.getByPlaceholder("Your email address").fill(testEmail!);
+  await page.getByRole("button", { name: "Continue" }).click();
+
+  // Handle password page (could be authkit.app or signin.workos.com)
+  await page.waitForSelector('input[type="password"]', { timeout: 15000 });
+
+  // Fill email again if needed (some flows require it)
+  const emailInput = page.getByPlaceholder("Your email address");
+  if (await emailInput.isVisible().catch(() => false)) {
+    await emailInput.fill(testEmail!);
+    await page.getByRole("button", { name: "Continue" }).click();
+    await page.waitForSelector('input[type="password"]', { timeout: 10000 });
+  }
+
+  // Fill password and sign in
+  await page.getByPlaceholder("Your password").fill(testPassword!);
+  await page.getByRole("button", { name: "Sign in" }).click();
+
+  // Wait for redirect back to app - use longer timeout and handle potential errors
+  try {
+    await page.waitForURL(/localhost:5174/, { timeout: 30000 });
+  } catch {
+    // Log current state for debugging
+    console.log("Redirect failed. Current URL:", page.url());
+    const bodyText = await page
+      .locator("body")
+      .innerText()
+      .catch(() => "");
+    console.log("Page content:", bodyText.slice(0, 500));
+    throw new Error(`Failed to redirect to app. Current URL: ${page.url()}`);
+  }
+
+  // Wait for authenticated state
+  await expect(page.getByText("Logged in via WorkOS SSO")).toBeVisible({
+    timeout: 10000,
+  });
+}
+
+test.describe("WorkOS Full SSO Flow", () => {
+  // Run serially to avoid rate limiting issues with WorkOS
+  test.describe.configure({ mode: "serial" });
+
+  test.skip(
+    !hasCredentials,
+    "Skipping SSO flow tests - set WORKOS_TEST_EMAIL and WORKOS_TEST_PASSWORD env vars",
+  );
+
+  test("completes full SSO authentication flow", async ({ page }) => {
+    test.setTimeout(60000);
+
+    await completeAuthFlow(page);
+
+    // Verify authenticated state
+    await expect(page.getByRole("button", { name: "Sign Out" })).toBeVisible();
+  });
+
+  test("displays user info after authentication", async ({ page }) => {
+    test.setTimeout(60000);
+
+    await completeAuthFlow(page);
+
+    // Verify user info is displayed
+    await expect(page.getByText(`Email: ${testEmail}`)).toBeVisible();
+    await expect(page.getByText(/User ID: user_/)).toBeVisible();
+  });
+
+  test("displays access token and decoded claims", async ({ page }) => {
+    test.setTimeout(60000);
+
+    await completeAuthFlow(page);
+
+    // Verify token section
+    await expect(
+      page.getByRole("heading", { name: "WorkOS Access Token" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Raw Token" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Decoded Claims" }),
+    ).toBeVisible();
+
+    // Verify JWT is displayed (starts with eyJ)
+    const tokenPre = page.locator("pre").first();
+    await expect(tokenPre).toContainText("eyJ");
+
+    // Verify claims table shows expected fields
+    await expect(page.getByText(/"sub":/)).toBeVisible();
+    await expect(page.getByText(/"org_id":/)).toBeVisible();
+    await expect(page.getByText(/"role":/)).toBeVisible();
+  });
+
+  test("shows policy examples after authentication", async ({ page }) => {
+    test.setTimeout(60000);
+
+    await completeAuthFlow(page);
+
+    // Verify policy examples section
+    await expect(
+      page.getByRole("heading", { name: "Jazz Policies with WorkOS Claims" }),
+    ).toBeVisible();
+    await expect(page.getByText("@viewer.claims.org_id").first()).toBeVisible();
+    await expect(
+      page.getByText("@viewer.claims.permissions").first(),
+    ).toBeVisible();
+    await expect(page.getByText("@viewer.claims.role").first()).toBeVisible();
+  });
+
+  test("can sign out after authentication", async ({ page }) => {
+    test.setTimeout(60000);
+
+    await completeAuthFlow(page);
+
+    // Sign out
+    await page.getByRole("button", { name: "Sign Out" }).click();
+
+    // Wait for sign out to complete - WorkOS may redirect through their logout flow
+    await page.waitForTimeout(3000);
+
+    // After sign out, we should either be at the app's sign-in page
+    // or redirected through WorkOS logout
+    // The key indicator is that we're no longer authenticated
+    const isAuthenticated = await page
+      .getByText("Logged in via WorkOS SSO")
+      .isVisible()
+      .catch(() => false);
+
+    expect(isAuthenticated).toBe(false);
+
+    // If we're back at the app, sign in button should be visible
+    // If not, we might be on WorkOS logout page which is also acceptable
+    const currentUrl = page.url();
+    if (currentUrl.includes("localhost:5174")) {
+      await expect(
+        page.getByRole("button", { name: "Sign in with SSO" }),
+      ).toBeVisible({ timeout: 5000 });
+    }
+  });
+});

--- a/examples/auth-workos/tsconfig.json
+++ b/examples/auth-workos/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"]
+}

--- a/examples/auth-workos/vite.config.js
+++ b/examples/auth-workos/vite.config.js
@@ -1,0 +1,14 @@
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+import topLevelAwait from "vite-plugin-top-level-await";
+import wasm from "vite-plugin-wasm";
+
+export default defineConfig({
+  plugins: [react(), wasm(), topLevelAwait()],
+  server: {
+    port: 5174,
+  },
+  optimizeDeps: {
+    exclude: ["groove-wasm"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -169,6 +169,9 @@ importers:
         specifier: ^19.0.0
         version: 19.2.3(react@19.2.3)
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.49.1
+        version: 1.57.0
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.7

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ importers:
         version: 2.0.13
       next:
         specifier: 16.1.1
-        version: 16.1.1(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 16.1.1(@babel/core@7.28.5)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       turbo:
         specifier: ^2.3.0
         version: 2.7.3
@@ -39,7 +39,7 @@ importers:
         version: 0.562.0(react@19.2.3)
       next:
         specifier: 16.1.1
-        version: 16.1.1(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 16.1.1(@babel/core@7.28.5)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react:
         specifier: ^19.2.3
         version: 19.2.3
@@ -77,6 +77,119 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+
+  examples/auth-betterauth:
+    dependencies:
+      '@jazz/client':
+        specifier: workspace:*
+        version: link:../../packages/jazz-client
+      '@jazz/react':
+        specifier: workspace:*
+        version: link:../../packages/jazz-react
+      better-auth:
+        specifier: ^1.2.0
+        version: 1.4.12(better-sqlite3@11.10.0)(next@16.1.1(@babel/core@7.28.5)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vitest@2.1.9)
+      better-sqlite3:
+        specifier: ^11.8.1
+        version: 11.10.0
+      cors:
+        specifier: ^2.8.5
+        version: 2.8.5
+      express:
+        specifier: ^4.21.2
+        version: 4.22.1
+      groove-wasm:
+        specifier: workspace:*
+        version: link:../../crates/groove-wasm/pkg
+      react:
+        specifier: ^19.0.0
+        version: 19.2.3
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.2.3(react@19.2.3)
+    devDependencies:
+      '@playwright/test':
+        specifier: ^1.57.0
+        version: 1.57.0
+      '@types/better-sqlite3':
+        specifier: ^7.6.12
+        version: 7.6.13
+      '@types/cors':
+        specifier: ^2.8.17
+        version: 2.8.19
+      '@types/express':
+        specifier: ^5.0.1
+        version: 5.0.6
+      '@types/react':
+        specifier: ^19.0.0
+        version: 19.2.7
+      '@types/react-dom':
+        specifier: ^19.0.0
+        version: 19.2.3(@types/react@19.2.7)
+      '@vitejs/plugin-react':
+        specifier: ^4.2.0
+        version: 4.7.0(vite@5.4.21(@types/node@25.0.3)(lightningcss@1.30.2))
+      concurrently:
+        specifier: ^9.1.2
+        version: 9.2.1
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vite:
+        specifier: ^5.0.0
+        version: 5.4.21(@types/node@25.0.3)(lightningcss@1.30.2)
+      vite-plugin-top-level-await:
+        specifier: ^1.4.0
+        version: 1.6.0(rollup@4.54.0)(vite@5.4.21(@types/node@25.0.3)(lightningcss@1.30.2))
+      vite-plugin-wasm:
+        specifier: ^3.3.0
+        version: 3.5.0(vite@5.4.21(@types/node@25.0.3)(lightningcss@1.30.2))
+
+  examples/auth-workos:
+    dependencies:
+      '@jazz/client':
+        specifier: workspace:*
+        version: link:../../packages/jazz-client
+      '@jazz/react':
+        specifier: workspace:*
+        version: link:../../packages/jazz-react
+      '@workos-inc/authkit-react':
+        specifier: ^0.14.0
+        version: 0.14.0(react@19.2.3)
+      groove-wasm:
+        specifier: workspace:*
+        version: link:../../crates/groove-wasm/pkg
+      react:
+        specifier: ^19.0.0
+        version: 19.2.3
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.2.3(react@19.2.3)
+    devDependencies:
+      '@types/react':
+        specifier: ^19.0.0
+        version: 19.2.7
+      '@types/react-dom':
+        specifier: ^19.0.0
+        version: 19.2.3(@types/react@19.2.7)
+      '@vitejs/plugin-react':
+        specifier: ^4.2.0
+        version: 4.7.0(vite@5.4.21(@types/node@25.0.3)(lightningcss@1.30.2))
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vite:
+        specifier: ^5.0.0
+        version: 5.4.21(@types/node@25.0.3)(lightningcss@1.30.2)
+      vite-plugin-top-level-await:
+        specifier: ^1.4.0
+        version: 1.6.0(rollup@4.54.0)(vite@5.4.21(@types/node@25.0.3)(lightningcss@1.30.2))
+      vite-plugin-wasm:
+        specifier: ^3.3.0
+        version: 3.5.0(vite@5.4.21(@types/node@25.0.3)(lightningcss@1.30.2))
 
   examples/demo-app:
     dependencies:
@@ -428,6 +541,27 @@ packages:
   '@babel/types@7.28.5':
     resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
     engines: {node: '>=6.9.0'}
+
+  '@better-auth/core@1.4.12':
+    resolution: {integrity: sha512-VfqZwMAEl9rnGx092BIZ2Q5z8rt7jjN2OAbvPqehufSKZGmh8JsdtZRBMl/CHQir9bwi2Ev0UF4+7TQp+DXEMg==}
+    peerDependencies:
+      '@better-auth/utils': 0.3.0
+      '@better-fetch/fetch': 1.1.21
+      better-call: 1.1.7
+      jose: ^6.1.0
+      kysely: ^0.28.5
+      nanostores: ^1.0.1
+
+  '@better-auth/telemetry@1.4.12':
+    resolution: {integrity: sha512-4q504Og42PzkUbZjXDt+FyeYaS0WZmAlEOC3nbBCZDObTVCRUnGgJW52B2maJ7BCVvAQgBGLEeQmQzU5+63J0A==}
+    peerDependencies:
+      '@better-auth/core': 1.4.12
+
+  '@better-auth/utils@0.3.0':
+    resolution: {integrity: sha512-W+Adw6ZA6mgvnSnhOki270rwJ42t4XzSK6YWGF//BbVXL6SwCLWfyzBc1lN2m/4RM28KubdBKQ4X5VMoLRNPQw==}
+
+  '@better-fetch/fetch@1.1.21':
+    resolution: {integrity: sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A==}
 
   '@biomejs/biome@1.9.4':
     resolution: {integrity: sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog==}
@@ -1284,6 +1418,14 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@noble/ciphers@2.1.1':
+    resolution: {integrity: sha512-bysYuiVfhxNJuldNXlFEitTVdNnYUc+XNJZd7Qm2a5j1vZHgY+fazadNFWFaMK/2vye0JVlxV3gHmC0WDfAOQw==}
+    engines: {node: '>= 20.19.0'}
+
+  '@noble/hashes@2.0.1':
+    resolution: {integrity: sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==}
+    engines: {node: '>= 20.19.0'}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -2128,6 +2270,18 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
+  '@types/better-sqlite3@7.6.13':
+    resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
+
+  '@types/body-parser@1.19.6':
+    resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
+
+  '@types/connect@3.4.38':
+    resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
+
+  '@types/cors@2.8.19':
+    resolution: {integrity: sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==}
+
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
 
@@ -2137,8 +2291,17 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/express-serve-static-core@5.1.1':
+    resolution: {integrity: sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==}
+
+  '@types/express@5.0.6':
+    resolution: {integrity: sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==}
+
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+
+  '@types/http-errors@2.0.5':
+    resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -2161,6 +2324,12 @@ packages:
   '@types/node@25.0.3':
     resolution: {integrity: sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==}
 
+  '@types/qs@6.14.0':
+    resolution: {integrity: sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==}
+
+  '@types/range-parser@1.2.7':
+    resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
+
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
     peerDependencies:
@@ -2168,6 +2337,12 @@ packages:
 
   '@types/react@19.2.7':
     resolution: {integrity: sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==}
+
+  '@types/send@1.2.1':
+    resolution: {integrity: sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==}
+
+  '@types/serve-static@2.2.0':
+    resolution: {integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==}
 
   '@types/statuses@2.0.6':
     resolution: {integrity: sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==}
@@ -2385,6 +2560,18 @@ packages:
   '@vitest/utils@2.1.9':
     resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
 
+  '@workos-inc/authkit-js@0.14.0':
+    resolution: {integrity: sha512-Wt6rKoZdZnuAgiEBlvMDKhleU9DAwpyyy1SibacrnOWQgF4rcNlC+NTnHiiXu6OiOjQo6pPxhW42kCL+Gi+fjw==}
+
+  '@workos-inc/authkit-react@0.14.0':
+    resolution: {integrity: sha512-XOYaf05Vur9ToBvccKBDSM1q7BmyO4f9Cn2GqpF03B8AXmnItG7XJUNJBsHjXCGZC7jBRYcwddK+nmGr9uhqfA==}
+    peerDependencies:
+      react: '>=17'
+
+  accepts@1.3.8:
+    resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
+    engines: {node: '>= 0.6'}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -2427,6 +2614,9 @@ packages:
   array-buffer-byte-length@1.0.2:
     resolution: {integrity: sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==}
     engines: {node: '>= 0.4'}
+
+  array-flatten@1.1.1:
+    resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
 
   array-includes@3.1.9:
     resolution: {integrity: sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==}
@@ -2489,9 +2679,92 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
   baseline-browser-mapping@2.9.11:
     resolution: {integrity: sha512-Sg0xJUNDU1sJNGdfGWhVHX0kkZ+HWcvmVymJbj6NSgZZmW/8S9Y2HQ5euytnIgakgxN6papOAWiwDo1ctFDcoQ==}
     hasBin: true
+
+  better-auth@1.4.12:
+    resolution: {integrity: sha512-FsFMnWgk+AGrxsIGbpWLCibgYcbm6uNhPHln3ohXFDXSRa0gk39Beuh54Q+x6ml2qYodF0snxf/tPtDpBI/JiA==}
+    peerDependencies:
+      '@lynx-js/react': '*'
+      '@prisma/client': ^5.0.0 || ^6.0.0 || ^7.0.0
+      '@sveltejs/kit': ^2.0.0
+      '@tanstack/react-start': ^1.0.0
+      better-sqlite3: ^12.0.0
+      drizzle-kit: '>=0.31.4'
+      drizzle-orm: '>=0.41.0'
+      mongodb: ^6.0.0 || ^7.0.0
+      mysql2: ^3.0.0
+      next: ^14.0.0 || ^15.0.0 || ^16.0.0
+      pg: ^8.0.0
+      prisma: ^5.0.0 || ^6.0.0 || ^7.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+      solid-js: ^1.0.0
+      svelte: ^4.0.0 || ^5.0.0
+      vitest: ^2.0.0 || ^3.0.0 || ^4.0.0
+      vue: ^3.0.0
+    peerDependenciesMeta:
+      '@lynx-js/react':
+        optional: true
+      '@prisma/client':
+        optional: true
+      '@sveltejs/kit':
+        optional: true
+      '@tanstack/react-start':
+        optional: true
+      better-sqlite3:
+        optional: true
+      drizzle-kit:
+        optional: true
+      drizzle-orm:
+        optional: true
+      mongodb:
+        optional: true
+      mysql2:
+        optional: true
+      next:
+        optional: true
+      pg:
+        optional: true
+      prisma:
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+      solid-js:
+        optional: true
+      svelte:
+        optional: true
+      vitest:
+        optional: true
+      vue:
+        optional: true
+
+  better-call@1.1.7:
+    resolution: {integrity: sha512-6gaJe1bBIEgVebQu/7q9saahVzvBsGaByEnE8aDVncZEDiJO7sdNB28ot9I6iXSbR25egGmmZ6aIURXyQHRraQ==}
+    peerDependencies:
+      zod: ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
+  better-sqlite3@11.10.0:
+    resolution: {integrity: sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==}
+
+  bindings@1.5.0:
+    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+
+  bl@4.1.0:
+    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+
+  body-parser@1.20.4:
+    resolution: {integrity: sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==}
+    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
 
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
@@ -2507,6 +2780,13 @@ packages:
     resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  buffer@5.7.1:
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
+
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
 
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
@@ -2562,6 +2842,9 @@ packages:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
     engines: {node: '>= 20.19.0'}
 
+  chownr@1.1.4:
+    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
+
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
 
@@ -2599,12 +2882,36 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
+  concurrently@9.2.1:
+    resolution: {integrity: sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  content-disposition@0.5.4:
+    resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
+    engines: {node: '>= 0.6'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie-signature@1.0.7:
+    resolution: {integrity: sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
 
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
+
+  cors@2.8.5:
+    resolution: {integrity: sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==}
+    engines: {node: '>= 0.10'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -2633,6 +2940,14 @@ packages:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
 
+  debug@2.6.9:
+    resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
   debug@3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
     peerDependencies:
@@ -2653,9 +2968,17 @@ packages:
   decode-named-character-reference@1.2.0:
     resolution: {integrity: sha512-c6fcElNV6ShtZXmsgNgFFV5tVX2PaV4g+MOAkb8eXHvn6sryJBrZa9r0zV6+dtTyoCKxtDy5tyQ5ZwQuidtd+Q==}
 
+  decompress-response@6.0.0:
+    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
+    engines: {node: '>=10'}
+
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
+
+  deep-extend@0.6.0:
+    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
+    engines: {node: '>=4.0.0'}
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
@@ -2668,9 +2991,20 @@ packages:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
 
+  defu@6.1.4:
+    resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
+
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
+
+  destroy@1.2.0:
+    resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
+    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
@@ -2693,6 +3027,9 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
   electron-to-chromium@1.5.267:
     resolution: {integrity: sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==}
 
@@ -2701,6 +3038,13 @@ packages:
 
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
+
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
   enhanced-resolve@5.18.4:
     resolution: {integrity: sha512-LgQMM4WXU3QI+SYgEc2liRgznaD5ojbmY3sb8LxyguVkIg5FxdpTkvk72te2R38/TGKxH634oLxXRGY6d7AP+Q==}
@@ -2765,6 +3109,9 @@ packages:
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -2914,9 +3261,21 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
+  expand-template@2.0.3:
+    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
+    engines: {node: '>=6'}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  express@4.22.1:
+    resolution: {integrity: sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==}
+    engines: {node: '>= 0.10.0'}
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
@@ -2950,9 +3309,16 @@ packages:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
 
+  file-uri-to-path@1.0.0:
+    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
+
+  finalhandler@1.3.2:
+    resolution: {integrity: sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==}
+    engines: {node: '>= 0.8'}
 
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
@@ -2968,6 +3334,17 @@ packages:
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
+
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@0.5.2:
+    resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
+    engines: {node: '>= 0.6'}
+
+  fs-constants@1.0.0:
+    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
   fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
@@ -3099,6 +3476,9 @@ packages:
   get-tsconfig@4.13.0:
     resolution: {integrity: sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==}
 
+  github-from-package@0.0.0:
+    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
+
   github-slugger@2.0.0:
     resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
 
@@ -3187,6 +3567,17 @@ packages:
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
+
+  iconv-lite@0.4.24:
+    resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
+    engines: {node: '>=0.10.0'}
+
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -3208,12 +3599,22 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ini@1.3.8:
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
+
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
 
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
 
   is-alphabetical@2.0.1:
     resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
@@ -3355,6 +3756,9 @@ packages:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
+  jose@6.1.3:
+    resolution: {integrity: sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -3391,6 +3795,10 @@ packages:
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  kysely@0.28.9:
+    resolution: {integrity: sha512-3BeXMoiOhpOwu62CiVpO6lxfq4eS6KMYfQdMsN/2kUCRNuF2YiEr7u0HLHaQU+O4Xu8YXE3bHVkwaQ85i72EuA==}
+    engines: {node: '>=20.0.0'}
 
   language-subtag-registry@0.3.23:
     resolution: {integrity: sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==}
@@ -3618,9 +4026,20 @@ packages:
   mdast-util-to-string@4.0.0:
     resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
 
+  media-typer@0.3.0:
+    resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
+    engines: {node: '>= 0.6'}
+
+  merge-descriptors@1.0.3:
+    resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
+
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+
+  methods@1.1.2:
+    resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
+    engines: {node: '>= 0.6'}
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
@@ -3731,6 +4150,23 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
+  mime@1.6.0:
+    resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
+    engines: {node: '>=4'}
+    hasBin: true
+
+  mimic-response@3.1.0:
+    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
+    engines: {node: '>=10'}
+
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
@@ -3741,9 +4177,15 @@ packages:
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
+  mkdirp-classic@0.5.3:
+    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
+
   mrmime@2.0.1:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
     engines: {node: '>=10'}
+
+  ms@2.0.0:
+    resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -3767,6 +4209,13 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  nanostores@1.1.0:
+    resolution: {integrity: sha512-yJBmDJr18xy47dbNVlHcgdPrulSn1nhSE6Ns9vTG+Nx9VPT6iV1MD6aQFp/t52zpf82FhLLTXAXr30NuCnxvwA==}
+    engines: {node: ^20.0.0 || >=22.0.0}
+
+  napi-build-utils@2.0.0:
+    resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
+
   napi-postinstall@0.3.4:
     resolution: {integrity: sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
@@ -3774,6 +4223,10 @@ packages:
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  negotiator@0.6.3:
+    resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
+    engines: {node: '>= 0.6'}
 
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
@@ -3805,6 +4258,10 @@ packages:
         optional: true
       sass:
         optional: true
+
+  node-abi@3.85.0:
+    resolution: {integrity: sha512-zsFhmbkAzwhTft6nd3VxcG0cvJsT70rL+BIGHWVq5fi6MwGrHwzqKaxXE+Hl2GmnGItnDKPPkO5/LQqjVkIdFg==}
+    engines: {node: '>=10'}
 
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
@@ -3845,6 +4302,13 @@ packages:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
 
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
   oniguruma-parser@0.12.1:
     resolution: {integrity: sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w==}
 
@@ -3877,6 +4341,10 @@ packages:
   parse-entities@4.0.2:
     resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
 
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -3887,6 +4355,9 @@ packages:
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  path-to-regexp@0.1.12:
+    resolution: {integrity: sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==}
 
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
@@ -3938,6 +4409,11 @@ packages:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  prebuild-install@7.1.3:
+    resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -3952,12 +4428,35 @@ packages:
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
+  pump@3.0.3:
+    resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  qs@6.14.1:
+    resolution: {integrity: sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==}
+    engines: {node: '>=0.6'}
+
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@2.5.3:
+    resolution: {integrity: sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==}
+    engines: {node: '>= 0.8'}
+
+  rc@1.2.8:
+    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
+    hasBin: true
 
   react-dom@19.2.3:
     resolution: {integrity: sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==}
@@ -4013,6 +4512,10 @@ packages:
   react@19.2.3:
     resolution: {integrity: sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==}
     engines: {node: '>=0.10.0'}
+
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
 
   readdirp@5.0.0:
     resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
@@ -4102,12 +4605,21 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  rou3@0.7.12:
+    resolution: {integrity: sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg==}
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  rxjs@7.8.2:
+    resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
 
   safe-array-concat@1.1.3:
     resolution: {integrity: sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==}
     engines: {node: '>=0.4'}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
   safe-push-apply@1.0.0:
     resolution: {integrity: sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==}
@@ -4116,6 +4628,9 @@ packages:
   safe-regex-test@1.1.0:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
     engines: {node: '>= 0.4'}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -4132,6 +4647,17 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  send@0.19.2:
+    resolution: {integrity: sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==}
+    engines: {node: '>= 0.8.0'}
+
+  serve-static@1.16.3:
+    resolution: {integrity: sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==}
+    engines: {node: '>= 0.8.0'}
+
+  set-cookie-parser@2.7.2:
+    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
+
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
     engines: {node: '>= 0.4'}
@@ -4144,6 +4670,9 @@ packages:
     resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
     engines: {node: '>= 0.4'}
 
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
@@ -4155,6 +4684,10 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  shell-quote@1.8.3:
+    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+    engines: {node: '>= 0.4'}
 
   shiki@3.21.0:
     resolution: {integrity: sha512-N65B/3bqL/TI2crrXr+4UivctrAGEjmsib5rPMMPpFp1xAx/w03v8WZ9RDDFYteXoEgY7qZ4HGgl5KBIu1153w==}
@@ -4181,6 +4714,12 @@ packages:
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
+
+  simple-concat@1.0.1:
+    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
+
+  simple-get@4.0.1:
+    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
 
   sirv@3.0.2:
     resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
@@ -4244,6 +4783,9 @@ packages:
     resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
     engines: {node: '>= 0.4'}
 
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
 
@@ -4254,6 +4796,10 @@ packages:
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
+
+  strip-json-comments@2.0.1:
+    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
+    engines: {node: '>=0.10.0'}
 
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
@@ -4282,6 +4828,10 @@ packages:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
 
+  supports-color@8.1.1:
+    resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
+    engines: {node: '>=10'}
+
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
@@ -4298,6 +4848,13 @@ packages:
 
   tapable@2.3.0:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
+    engines: {node: '>=6'}
+
+  tar-fs@2.1.4:
+    resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
+
+  tar-stream@2.2.0:
+    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
 
   tinybench@2.9.0:
@@ -4337,6 +4894,10 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
@@ -4344,6 +4905,10 @@ packages:
   tough-cookie@6.0.0:
     resolution: {integrity: sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==}
     engines: {node: '>=16'}
+
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
 
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
@@ -4367,6 +4932,9 @@ packages:
     resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
     engines: {node: '>=18.0.0'}
     hasBin: true
+
+  tunnel-agent@0.6.0:
+    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
   turbo-darwin-64@2.7.3:
     resolution: {integrity: sha512-aZHhvRiRHXbJw1EcEAq4aws1hsVVUZ9DPuSFaq9VVFAKCup7niIEwc22glxb7240yYEr1vLafdQ2U294Vcwz+w==}
@@ -4409,6 +4977,10 @@ packages:
   type-fest@5.3.1:
     resolution: {integrity: sha512-VCn+LMHbd4t6sF3wfU/+HKT63C9OoyrSIf4b+vtWHpt2U7/4InZG467YDNMFMR70DdHjAdpPWmw2lzRdg0Xqqg==}
     engines: {node: '>=20'}
+
+  type-is@1.6.18:
+    resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
+    engines: {node: '>= 0.6'}
 
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
@@ -4469,6 +5041,10 @@ packages:
   unist-util-visit@5.0.0:
     resolution: {integrity: sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==}
 
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
   unrs-resolver@1.11.1:
     resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
 
@@ -4512,9 +5088,17 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
+  utils-merge@1.0.1:
+    resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
+    engines: {node: '>= 0.4.0'}
+
   uuid@10.0.0:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
     hasBin: true
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
 
   vfile-message@4.0.3:
     resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
@@ -4670,6 +5254,9 @@ packages:
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
   ws@8.19.0:
     resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
@@ -4835,6 +5422,27 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@better-auth/core@1.4.12(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.7(zod@4.3.5))(jose@6.1.3)(kysely@0.28.9)(nanostores@1.1.0)':
+    dependencies:
+      '@better-auth/utils': 0.3.0
+      '@better-fetch/fetch': 1.1.21
+      '@standard-schema/spec': 1.1.0
+      better-call: 1.1.7(zod@4.3.5)
+      jose: 6.1.3
+      kysely: 0.28.9
+      nanostores: 1.1.0
+      zod: 4.3.5
+
+  '@better-auth/telemetry@1.4.12(@better-auth/core@1.4.12(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.7(zod@4.3.5))(jose@6.1.3)(kysely@0.28.9)(nanostores@1.1.0))':
+    dependencies:
+      '@better-auth/core': 1.4.12(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.7(zod@4.3.5))(jose@6.1.3)(kysely@0.28.9)(nanostores@1.1.0)
+      '@better-auth/utils': 0.3.0
+      '@better-fetch/fetch': 1.1.21
+
+  '@better-auth/utils@0.3.0': {}
+
+  '@better-fetch/fetch@1.1.21': {}
 
   '@biomejs/biome@1.9.4':
     optionalDependencies:
@@ -5194,7 +5802,7 @@ snapshots:
       tailwind-merge: 3.4.0
     optionalDependencies:
       '@types/react': 19.2.7
-      next: 16.1.1(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 16.1.1(@babel/core@7.28.5)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       tailwindcss: 4.1.18
     transitivePeerDependencies:
       - '@mixedbread/sdk'
@@ -5438,6 +6046,10 @@ snapshots:
 
   '@next/swc-win32-x64-msvc@16.1.1':
     optional: true
+
+  '@noble/ciphers@2.1.1': {}
+
+  '@noble/hashes@2.0.1': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -6209,6 +6821,23 @@ snapshots:
     dependencies:
       '@babel/types': 7.28.5
 
+  '@types/better-sqlite3@7.6.13':
+    dependencies:
+      '@types/node': 25.0.3
+
+  '@types/body-parser@1.19.6':
+    dependencies:
+      '@types/connect': 3.4.38
+      '@types/node': 25.0.3
+
+  '@types/connect@3.4.38':
+    dependencies:
+      '@types/node': 25.0.3
+
+  '@types/cors@2.8.19':
+    dependencies:
+      '@types/node': 25.0.3
+
   '@types/debug@4.1.12':
     dependencies:
       '@types/ms': 2.1.0
@@ -6219,9 +6848,24 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/express-serve-static-core@5.1.1':
+    dependencies:
+      '@types/node': 25.0.3
+      '@types/qs': 6.14.0
+      '@types/range-parser': 1.2.7
+      '@types/send': 1.2.1
+
+  '@types/express@5.0.6':
+    dependencies:
+      '@types/body-parser': 1.19.6
+      '@types/express-serve-static-core': 5.1.1
+      '@types/serve-static': 2.2.0
+
   '@types/hast@3.0.4':
     dependencies:
       '@types/unist': 3.0.3
+
+  '@types/http-errors@2.0.5': {}
 
   '@types/json-schema@7.0.15': {}
 
@@ -6243,6 +6887,10 @@ snapshots:
     dependencies:
       undici-types: 7.16.0
 
+  '@types/qs@6.14.0': {}
+
+  '@types/range-parser@1.2.7': {}
+
   '@types/react-dom@19.2.3(@types/react@19.2.7)':
     dependencies:
       '@types/react': 19.2.7
@@ -6250,6 +6898,15 @@ snapshots:
   '@types/react@19.2.7':
     dependencies:
       csstype: 3.2.3
+
+  '@types/send@1.2.1':
+    dependencies:
+      '@types/node': 25.0.3
+
+  '@types/serve-static@2.2.0':
+    dependencies:
+      '@types/http-errors': 2.0.5
+      '@types/node': 25.0.3
 
   '@types/statuses@2.0.6': {}
 
@@ -6495,6 +7152,18 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 1.2.0
 
+  '@workos-inc/authkit-js@0.14.0': {}
+
+  '@workos-inc/authkit-react@0.14.0(react@19.2.3)':
+    dependencies:
+      '@workos-inc/authkit-js': 0.14.0
+      react: 19.2.3
+
+  accepts@1.3.8:
+    dependencies:
+      mime-types: 2.1.35
+      negotiator: 0.6.3
+
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
       acorn: 8.15.0
@@ -6532,6 +7201,8 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
       is-array-buffer: 3.0.5
+
+  array-flatten@1.1.1: {}
 
   array-includes@3.1.9:
     dependencies:
@@ -6615,7 +7286,71 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  base64-js@1.5.1: {}
+
   baseline-browser-mapping@2.9.11: {}
+
+  better-auth@1.4.12(better-sqlite3@11.10.0)(next@16.1.1(@babel/core@7.28.5)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vitest@2.1.9):
+    dependencies:
+      '@better-auth/core': 1.4.12(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.7(zod@4.3.5))(jose@6.1.3)(kysely@0.28.9)(nanostores@1.1.0)
+      '@better-auth/telemetry': 1.4.12(@better-auth/core@1.4.12(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.7(zod@4.3.5))(jose@6.1.3)(kysely@0.28.9)(nanostores@1.1.0))
+      '@better-auth/utils': 0.3.0
+      '@better-fetch/fetch': 1.1.21
+      '@noble/ciphers': 2.1.1
+      '@noble/hashes': 2.0.1
+      better-call: 1.1.7(zod@4.3.5)
+      defu: 6.1.4
+      jose: 6.1.3
+      kysely: 0.28.9
+      nanostores: 1.1.0
+      zod: 4.3.5
+    optionalDependencies:
+      better-sqlite3: 11.10.0
+      next: 16.1.1(@babel/core@7.28.5)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      vitest: 2.1.9(@types/node@25.0.3)(@vitest/browser@2.1.9)(lightningcss@1.30.2)(msw@2.12.7(@types/node@25.0.3)(typescript@5.9.3))
+
+  better-call@1.1.7(zod@4.3.5):
+    dependencies:
+      '@better-auth/utils': 0.3.0
+      '@better-fetch/fetch': 1.1.21
+      rou3: 0.7.12
+      set-cookie-parser: 2.7.2
+    optionalDependencies:
+      zod: 4.3.5
+
+  better-sqlite3@11.10.0:
+    dependencies:
+      bindings: 1.5.0
+      prebuild-install: 7.1.3
+
+  bindings@1.5.0:
+    dependencies:
+      file-uri-to-path: 1.0.0
+
+  bl@4.1.0:
+    dependencies:
+      buffer: 5.7.1
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
+  body-parser@1.20.4:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 2.6.9
+      depd: 2.0.0
+      destroy: 1.2.0
+      http-errors: 2.0.1
+      iconv-lite: 0.4.24
+      on-finished: 2.4.1
+      qs: 6.14.1
+      raw-body: 2.5.3
+      type-is: 1.6.18
+      unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   brace-expansion@1.1.12:
     dependencies:
@@ -6637,6 +7372,13 @@ snapshots:
       electron-to-chromium: 1.5.267
       node-releases: 2.0.27
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
+
+  buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
+  bytes@3.1.2: {}
 
   cac@6.7.14: {}
 
@@ -6690,6 +7432,8 @@ snapshots:
     dependencies:
       readdirp: 5.0.0
 
+  chownr@1.1.4: {}
+
   class-variance-authority@0.7.1:
     dependencies:
       clsx: 2.1.1
@@ -6720,9 +7464,33 @@ snapshots:
 
   concat-map@0.0.1: {}
 
+  concurrently@9.2.1:
+    dependencies:
+      chalk: 4.1.2
+      rxjs: 7.8.2
+      shell-quote: 1.8.3
+      supports-color: 8.1.1
+      tree-kill: 1.2.2
+      yargs: 17.7.2
+
+  content-disposition@0.5.4:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  content-type@1.0.5: {}
+
   convert-source-map@2.0.0: {}
 
+  cookie-signature@1.0.7: {}
+
+  cookie@0.7.2: {}
+
   cookie@1.1.1: {}
+
+  cors@2.8.5:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   cross-spawn@7.0.6:
     dependencies:
@@ -6754,6 +7522,10 @@ snapshots:
       es-errors: 1.3.0
       is-data-view: 1.0.2
 
+  debug@2.6.9:
+    dependencies:
+      ms: 2.0.0
+
   debug@3.2.7:
     dependencies:
       ms: 2.1.3
@@ -6766,7 +7538,13 @@ snapshots:
     dependencies:
       character-entities: 2.0.2
 
+  decompress-response@6.0.0:
+    dependencies:
+      mimic-response: 3.1.0
+
   deep-eql@5.0.2: {}
+
+  deep-extend@0.6.0: {}
 
   deep-is@0.1.4: {}
 
@@ -6782,7 +7560,13 @@ snapshots:
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
 
+  defu@6.1.4: {}
+
+  depd@2.0.0: {}
+
   dequal@2.0.3: {}
+
+  destroy@1.2.0: {}
 
   detect-libc@2.1.2: {}
 
@@ -6804,11 +7588,19 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
+  ee-first@1.1.1: {}
+
   electron-to-chromium@1.5.267: {}
 
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
+
+  encodeurl@2.0.0: {}
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
 
   enhanced-resolve@5.18.4:
     dependencies:
@@ -7017,6 +7809,8 @@ snapshots:
       '@esbuild/win32-x64': 0.27.2
 
   escalade@3.2.0: {}
+
+  escape-html@1.0.3: {}
 
   escape-string-regexp@4.0.0: {}
 
@@ -7262,7 +8056,47 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  etag@1.8.1: {}
+
+  expand-template@2.0.3: {}
+
   expect-type@1.3.0: {}
+
+  express@4.22.1:
+    dependencies:
+      accepts: 1.3.8
+      array-flatten: 1.1.1
+      body-parser: 1.20.4
+      content-disposition: 0.5.4
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.0.7
+      debug: 2.6.9
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 1.3.2
+      fresh: 0.5.2
+      http-errors: 2.0.1
+      merge-descriptors: 1.0.3
+      methods: 1.1.2
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      path-to-regexp: 0.1.12
+      proxy-addr: 2.0.7
+      qs: 6.14.1
+      range-parser: 1.2.1
+      safe-buffer: 5.2.1
+      send: 0.19.2
+      serve-static: 1.16.3
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      type-is: 1.6.18
+      utils-merge: 1.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   extend@3.0.2: {}
 
@@ -7292,9 +8126,23 @@ snapshots:
     dependencies:
       flat-cache: 4.0.1
 
+  file-uri-to-path@1.0.0: {}
+
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
+
+  finalhandler@1.3.2:
+    dependencies:
+      debug: 2.6.9
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+      unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   find-up@5.0.0:
     dependencies:
@@ -7311,6 +8159,12 @@ snapshots:
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
+
+  forwarded@0.2.0: {}
+
+  fresh@0.5.2: {}
+
+  fs-constants@1.0.0: {}
 
   fsevents@2.3.2:
     optional: true
@@ -7342,7 +8196,7 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.7
       lucide-react: 0.562.0(react@19.2.3)
-      next: 16.1.1(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 16.1.1(@babel/core@7.28.5)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
       zod: 4.3.5
@@ -7371,7 +8225,7 @@ snapshots:
       zod: 4.3.5
     optionalDependencies:
       '@types/react': 19.2.7
-      next: 16.1.1(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 16.1.1(@babel/core@7.28.5)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
       vite: 6.4.1(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
     transitivePeerDependencies:
@@ -7462,6 +8316,8 @@ snapshots:
   get-tsconfig@4.13.0:
     dependencies:
       resolve-pkg-maps: 1.0.0
+
+  github-from-package@0.0.0: {}
 
   github-slugger@2.0.0: {}
 
@@ -7583,6 +8439,20 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
+
+  iconv-lite@0.4.24:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  ieee754@1.2.1: {}
+
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
@@ -7596,6 +8466,10 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
+  inherits@2.0.4: {}
+
+  ini@1.3.8: {}
+
   inline-style-parser@0.2.7: {}
 
   internal-slot@1.1.0:
@@ -7603,6 +8477,8 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.2
       side-channel: 1.1.0
+
+  ipaddr.js@1.9.1: {}
 
   is-alphabetical@2.0.1: {}
 
@@ -7748,6 +8624,8 @@ snapshots:
 
   jiti@2.6.1: {}
 
+  jose@6.1.3: {}
+
   js-tokens@4.0.0: {}
 
   js-yaml@4.1.1:
@@ -7778,6 +8656,8 @@ snapshots:
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
+
+  kysely@0.28.9: {}
 
   language-subtag-registry@0.3.23: {}
 
@@ -8079,7 +8959,13 @@ snapshots:
     dependencies:
       '@types/mdast': 4.0.4
 
+  media-typer@0.3.0: {}
+
+  merge-descriptors@1.0.3: {}
+
   merge2@1.4.1: {}
+
+  methods@1.1.2: {}
 
   micromark-core-commonmark@2.0.3:
     dependencies:
@@ -8350,6 +9236,16 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.1
 
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+
+  mime@1.6.0: {}
+
+  mimic-response@3.1.0: {}
+
   minimatch@3.1.2:
     dependencies:
       brace-expansion: 1.1.12
@@ -8360,7 +9256,11 @@ snapshots:
 
   minimist@1.2.8: {}
 
+  mkdirp-classic@0.5.3: {}
+
   mrmime@2.0.1: {}
+
+  ms@2.0.0: {}
 
   ms@2.1.3: {}
 
@@ -8393,9 +9293,15 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  nanostores@1.1.0: {}
+
+  napi-build-utils@2.0.0: {}
+
   napi-postinstall@0.3.4: {}
 
   natural-compare@1.4.0: {}
+
+  negotiator@0.6.3: {}
 
   negotiator@1.0.0: {}
 
@@ -8404,7 +9310,7 @@ snapshots:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
 
-  next@16.1.1(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  next@16.1.1(@babel/core@7.28.5)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       '@next/env': 16.1.1
       '@swc/helpers': 0.5.15
@@ -8413,7 +9319,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
-      styled-jsx: 5.1.6(react@19.2.3)
+      styled-jsx: 5.1.6(@babel/core@7.28.5)(react@19.2.3)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.1.1
       '@next/swc-darwin-x64': 16.1.1
@@ -8428,6 +9334,10 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
+
+  node-abi@3.85.0:
+    dependencies:
+      semver: 7.7.3
 
   node-releases@2.0.27: {}
 
@@ -8474,6 +9384,14 @@ snapshots:
       call-bound: 1.0.4
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
 
   oniguruma-parser@0.12.1: {}
 
@@ -8522,11 +9440,15 @@ snapshots:
       is-decimal: 2.0.1
       is-hexadecimal: 2.0.1
 
+  parseurl@1.3.3: {}
+
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
 
   path-parse@1.0.7: {}
+
+  path-to-regexp@0.1.12: {}
 
   path-to-regexp@6.3.0: {}
 
@@ -8569,6 +9491,21 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  prebuild-install@7.1.3:
+    dependencies:
+      detect-libc: 2.1.2
+      expand-template: 2.0.3
+      github-from-package: 0.0.0
+      minimist: 1.2.8
+      mkdirp-classic: 0.5.3
+      napi-build-utils: 2.0.0
+      node-abi: 3.85.0
+      pump: 3.0.3
+      rc: 1.2.8
+      simple-get: 4.0.1
+      tar-fs: 2.1.4
+      tunnel-agent: 0.6.0
+
   prelude-ls@1.2.1: {}
 
   pretty-format@27.5.1:
@@ -8585,9 +9522,39 @@ snapshots:
 
   property-information@7.1.0: {}
 
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
+  pump@3.0.3:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
+
   punycode@2.3.1: {}
 
+  qs@6.14.1:
+    dependencies:
+      side-channel: 1.1.0
+
   queue-microtask@1.2.3: {}
+
+  range-parser@1.2.1: {}
+
+  raw-body@2.5.3:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.4.24
+      unpipe: 1.0.0
+
+  rc@1.2.8:
+    dependencies:
+      deep-extend: 0.6.0
+      ini: 1.3.8
+      minimist: 1.2.8
+      strip-json-comments: 2.0.1
 
   react-dom@19.2.3(react@19.2.3):
     dependencies:
@@ -8633,6 +9600,12 @@ snapshots:
       '@types/react': 19.2.7
 
   react@19.2.3: {}
+
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
 
   readdirp@5.0.0: {}
 
@@ -8803,9 +9776,15 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.54.0
       fsevents: 2.3.3
 
+  rou3@0.7.12: {}
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
+
+  rxjs@7.8.2:
+    dependencies:
+      tslib: 2.8.1
 
   safe-array-concat@1.1.3:
     dependencies:
@@ -8814,6 +9793,8 @@ snapshots:
       get-intrinsic: 1.3.0
       has-symbols: 1.1.0
       isarray: 2.0.5
+
+  safe-buffer@5.2.1: {}
 
   safe-push-apply@1.0.0:
     dependencies:
@@ -8826,6 +9807,8 @@ snapshots:
       es-errors: 1.3.0
       is-regex: 1.2.1
 
+  safer-buffer@2.1.2: {}
+
   scheduler@0.27.0: {}
 
   scroll-into-view-if-needed@3.1.0:
@@ -8835,6 +9818,35 @@ snapshots:
   semver@6.3.1: {}
 
   semver@7.7.3: {}
+
+  send@0.19.2:
+    dependencies:
+      debug: 2.6.9
+      depd: 2.0.0
+      destroy: 1.2.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 0.5.2
+      http-errors: 2.0.1
+      mime: 1.6.0
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@1.16.3:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 0.19.2
+    transitivePeerDependencies:
+      - supports-color
+
+  set-cookie-parser@2.7.2: {}
 
   set-function-length@1.2.2:
     dependencies:
@@ -8857,6 +9869,8 @@ snapshots:
       dunder-proto: 1.0.1
       es-errors: 1.3.0
       es-object-atoms: 1.1.1
+
+  setprototypeof@1.2.0: {}
 
   sharp@0.34.5:
     dependencies:
@@ -8895,6 +9909,8 @@ snapshots:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  shell-quote@1.8.3: {}
 
   shiki@3.21.0:
     dependencies:
@@ -8938,6 +9954,14 @@ snapshots:
   siginfo@2.0.0: {}
 
   signal-exit@4.1.0: {}
+
+  simple-concat@1.0.1: {}
+
+  simple-get@4.0.1:
+    dependencies:
+      decompress-response: 6.0.0
+      once: 1.4.0
+      simple-concat: 1.0.1
 
   sirv@3.0.2:
     dependencies:
@@ -9022,6 +10046,10 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
   stringify-entities@4.0.4:
     dependencies:
       character-entities-html4: 2.1.0
@@ -9033,6 +10061,8 @@ snapshots:
 
   strip-bom@3.0.0: {}
 
+  strip-json-comments@2.0.1: {}
+
   strip-json-comments@3.1.1: {}
 
   style-to-js@1.1.21:
@@ -9043,12 +10073,18 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
-  styled-jsx@5.1.6(react@19.2.3):
+  styled-jsx@5.1.6(@babel/core@7.28.5)(react@19.2.3):
     dependencies:
       client-only: 0.0.1
       react: 19.2.3
+    optionalDependencies:
+      '@babel/core': 7.28.5
 
   supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
+  supports-color@8.1.1:
     dependencies:
       has-flag: 4.0.0
 
@@ -9061,6 +10097,21 @@ snapshots:
   tailwindcss@4.1.18: {}
 
   tapable@2.3.0: {}
+
+  tar-fs@2.1.4:
+    dependencies:
+      chownr: 1.1.4
+      mkdirp-classic: 0.5.3
+      pump: 3.0.3
+      tar-stream: 2.2.0
+
+  tar-stream@2.2.0:
+    dependencies:
+      bl: 4.1.0
+      end-of-stream: 1.4.5
+      fs-constants: 1.0.0
+      inherits: 2.0.4
+      readable-stream: 3.6.2
 
   tinybench@2.9.0: {}
 
@@ -9089,11 +10140,15 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  toidentifier@1.0.1: {}
+
   totalist@3.0.1: {}
 
   tough-cookie@6.0.0:
     dependencies:
       tldts: 7.0.19
+
+  tree-kill@1.2.2: {}
 
   trim-lines@3.0.1: {}
 
@@ -9118,6 +10173,10 @@ snapshots:
       get-tsconfig: 4.13.0
     optionalDependencies:
       fsevents: 2.3.3
+
+  tunnel-agent@0.6.0:
+    dependencies:
+      safe-buffer: 5.2.1
 
   turbo-darwin-64@2.7.3:
     optional: true
@@ -9153,6 +10212,11 @@ snapshots:
   type-fest@5.3.1:
     dependencies:
       tagged-tag: 1.0.0
+
+  type-is@1.6.18:
+    dependencies:
+      media-typer: 0.3.0
+      mime-types: 2.1.35
 
   typed-array-buffer@1.0.3:
     dependencies:
@@ -9251,6 +10315,8 @@ snapshots:
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
 
+  unpipe@1.0.0: {}
+
   unrs-resolver@1.11.1:
     dependencies:
       napi-postinstall: 0.3.4
@@ -9308,7 +10374,11 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
+  utils-merge@1.0.1: {}
+
   uuid@10.0.0: {}
+
+  vary@1.1.2: {}
 
   vfile-message@4.0.3:
     dependencies:
@@ -9493,6 +10563,8 @@ snapshots:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
+
+  wrappy@1.0.2: {}
 
   ws@8.19.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,8 @@ packages:
   - "packages/*"
   - "examples/demo-app"
   - "examples/sync-demo"
+  - "examples/auth-betterauth"
+  - "examples/auth-workos"
   - "crates/groove-wasm/pkg"
   - "docs"
   - "examples/docs/react"


### PR DESCRIPTION
## Summary

- Add JWT-based authentication support for groove-server ReBAC policies
- Create demo apps showing integration with BetterAuth and WorkOS AuthKit
- Add comprehensive e2e tests for both auth providers
- Add CI jobs for auth e2e tests

## Changes

### Core Auth Integration
- JWT validation with JWKS endpoint support in groove-server
- Claims extraction for use in ReBAC policies (`@viewer.claims.*`)

### Demo Apps
- **auth-betterauth**: Self-hosted auth with JWT plugin, shows custom claims (subscriptionTier, roles)
- **auth-workos**: Enterprise SSO with WorkOS AuthKit, shows org_id/role/permissions claims

### E2E Tests
- BetterAuth: 16 tests covering signup, signin, signout, JWT display, policies
- WorkOS: 15 tests (10 unauthenticated + 5 full SSO flow with credentials)

### CI
- `auth-betterauth-tests`: Self-contained, no secrets needed
- `auth-workos-tests`: Requires `WORKOS_TEST_EMAIL` and `WORKOS_TEST_PASSWORD` secrets

## Test plan
- [x] BetterAuth demo e2e tests pass locally
- [x] WorkOS demo e2e tests pass locally with credentials
- [x] WorkOS tests skip gracefully without credentials (local)
- [x] CI passes after adding GitHub secrets

## Required GitHub Secrets
- `WORKOS_TEST_EMAIL`: Test user email for WorkOS
- `WORKOS_TEST_PASSWORD`: Test user password for WorkOS

🤖 Generated with [Claude Code](https://claude.ai/code)