### PR TITLE
Optimize CI workflow for faster builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,9 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  lint:
-    name: Lint
-    runs-on: ubuntu-latest
+  build:
+    name: Build
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v4
 
@@ -28,65 +28,13 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Check Rust formatting
-        run: cargo fmt --all --manifest-path crates/Cargo.toml -- --check
-
-      - name: Run Clippy
-        run: cargo clippy --all-targets --all-features --manifest-path crates/Cargo.toml -- -D warnings
-
-      - name: Run Biome
-        run: pnpm lint
-
-  rust-tests:
-    name: Rust Tests
-    runs-on: ubuntu-latest
-    needs: lint
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache Cargo
-        uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: |
-            crates/groove
-            crates/groove-server
-            crates/groove-wasm
-
-      - name: Run Rust tests (all features)
-        run: cargo test --all-features --workspace --exclude groove-wasm --manifest-path crates/Cargo.toml
-
-  ts-build:
-    name: TypeScript Build
-    runs-on: ubuntu-latest
-    needs: lint
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
           targets: wasm32-unknown-unknown
 
       - name: Cache Cargo
         uses: Swatinem/rust-cache@v2
         with:
-          workspaces: crates/groove-wasm
+          workspaces: crates
+          cache-on-failure: true
 
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
@@ -103,6 +51,17 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # Lint checks
+      - name: Check Rust formatting
+        run: cargo fmt --all --manifest-path crates/Cargo.toml -- --check
+
+      - name: Run Clippy
+        run: cargo clippy --all-targets --all-features --manifest-path crates/Cargo.toml -- -D warnings
+
+      - name: Run Biome
+        run: pnpm lint
+
+      # Build everything
       - name: Build WASM
         run: cd crates/groove-wasm && wasm-pack build --target web
 
@@ -112,6 +71,12 @@ jobs:
       - name: Type check
         run: pnpm typecheck
 
+      - name: Build groove-server
+        run: cargo build --release -p groove-server --manifest-path crates/Cargo.toml
+
+      - name: Run Rust tests
+        run: cargo test --all-features --workspace --exclude groove-wasm --manifest-path crates/Cargo.toml
+
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -119,12 +84,13 @@ jobs:
           path: |
             packages/*/dist
             crates/groove-wasm/pkg
+            crates/target/release/groove-server
           retention-days: 1
 
   ts-lib-tests:
     name: TypeScript Lib Tests
-    runs-on: ubuntu-latest
-    needs: ts-build
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    needs: build
     steps:
       - uses: actions/checkout@v4
 
@@ -146,26 +112,30 @@ jobs:
           name: build-artifacts
           path: .
 
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+
       - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: pnpm --filter="@jazz/client" exec playwright install --with-deps chromium
+
+      - name: Install Playwright system deps
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: pnpm --filter="@jazz/client" exec playwright install-deps chromium
 
       - name: Run lib tests
         run: pnpm test --filter="@jazz/*"
 
   sync-demo-tests:
     name: Sync Demo E2E Tests
-    runs-on: ubuntu-latest
-    needs: ts-build
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    needs: ts-lib-tests
     steps:
       - uses: actions/checkout@v4
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache Cargo
-        uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: crates/groove-server
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
@@ -185,16 +155,28 @@ jobs:
           name: build-artifacts
           path: .
 
-      - name: Build groove-server
-        run: cargo build --release -p groove-server --manifest-path crates/Cargo.toml
+      - name: Make groove-server executable
+        run: chmod +x crates/target/release/groove-server
 
       - name: Start groove-server
         run: |
           ./crates/target/release/groove-server &
           sleep 2
 
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+
       - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: cd examples/sync-demo && pnpm exec playwright install --with-deps
+
+      - name: Install Playwright system deps
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: cd examples/sync-demo && pnpm exec playwright install-deps
 
       - name: Run sync-demo E2E tests
         run: cd examples/sync-demo && pnpm test
@@ -209,7 +191,7 @@ jobs:
 
   demo-app-tests:
     name: Demo App Tests
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     needs: ts-lib-tests
     steps:
       - uses: actions/checkout@v4
@@ -235,8 +217,20 @@ jobs:
       - name: Generate schema
         run: cd examples/demo-app && pnpm generate
 
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+
       - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: cd examples/demo-app && pnpm exec playwright install --with-deps chromium
+
+      - name: Install Playwright system deps
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: cd examples/demo-app && pnpm exec playwright install-deps chromium
 
       - name: Run unit tests
         run: cd examples/demo-app && pnpm test
@@ -254,8 +248,8 @@ jobs:
 
   auth-betterauth-tests:
     name: Auth BetterAuth E2E Tests
-    runs-on: ubuntu-latest
-    needs: ts-build
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    needs: ts-lib-tests
     steps:
       - uses: actions/checkout@v4
 
@@ -283,8 +277,20 @@ jobs:
       - name: Run BetterAuth migrations
         run: cd examples/auth-betterauth && npx @better-auth/cli migrate --config server/auth-server.ts -y
 
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+
       - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: cd examples/auth-betterauth && pnpm exec playwright install --with-deps chromium
+
+      - name: Install Playwright system deps
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: cd examples/auth-betterauth && pnpm exec playwright install-deps chromium
 
       - name: Run BetterAuth E2E tests
         run: cd examples/auth-betterauth && pnpm test
@@ -299,8 +305,8 @@ jobs:
 
   auth-workos-tests:
     name: Auth WorkOS E2E Tests
-    runs-on: ubuntu-latest
-    needs: ts-build
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    needs: ts-lib-tests
     steps:
       - uses: actions/checkout@v4
 
@@ -322,8 +328,20 @@ jobs:
           name: build-artifacts
           path: .
 
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+
       - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: cd examples/auth-workos && pnpm exec playwright install --with-deps chromium
+
+      - name: Install Playwright system deps
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: cd examples/auth-workos && pnpm exec playwright install-deps chromium
 
       - name: Run WorkOS E2E tests
         env:

--- a/docs/content/docs/internals/access-control.mdx
+++ b/docs/content/docs/internals/access-control.mdx
@@ -25,6 +25,7 @@ Relationship-Based Access Control (ReBAC) for Jazz2, where permissions are deriv
 - RecursiveFilter for self-referential INHERITS
 
 **Not yet implemented:**
+- Claims wiring (`@viewer.claims.*` expressions parse but claims aren't passed from authenticated sessions to `PolicyEvaluator`)
 - SQL parser for `CREATE POLICY` syntax
 - Sync integration (policy-filtered data sync)
 - `EXPLAIN POLICY` command

--- a/docs/content/docs/internals/authentication.mdx
+++ b/docs/content/docs/internals/authentication.mdx
@@ -20,6 +20,8 @@ Authentication in Jazz2 binds the `@viewer` variable in [Access Control](/docs/i
 - Auto-provisioning of users on first authentication
 
 **Not yet implemented:**
+- Wiring claims to policy evaluation (claims are extracted but not passed to `PolicyEvaluator`)
+- JWKS fetching for RS256 (only HS256 secret validation works currently)
 - Session management and refresh token handling
 - Built-in OAuth flows (currently relies on external providers)
 - API key authentication (for server-to-server)


### PR DESCRIPTION
## Summary

Optimizes CI workflow from ~8 minutes to ~5.5 minutes through several improvements:

- **4vcpu Blacksmith runner for build job** - Faster Cargo compilation with more parallelism
- **Merge Rust tests into build job** - Eliminates separate job startup overhead and cache restore
- **Proper job dependency chain** - `build → ts-lib-tests → all E2E tests in parallel`
- **Swatinem/rust-cache** for Cargo - Reliable cross-runner caching
- **actions/cache** for Playwright browsers - Shared cache with conditional install

## Experiments Performed

| Experiment | Result |
|------------|--------|
| Sticky disks for Cargo | ❌ Regression (7m vs 5m baseline) |
| Sticky disks for Playwright | ❌ Didn't work - no runner affinity between runs |
| 4vcpu build runner | ✅ Improvement for compilation |
| Merge rust-tests into build | ✅ Saves job startup overhead |

### Why sticky disks didn't work

Sticky disks are **per-runner**, not shared across the runner pool. Each parallel job lands on a different runner with separate storage, and there's no guarantee the next CI run hits the same runners. This caused browsers to be re-downloaded (~110 MiB) on every "warm" run.

## Test Plan

- [x] Cold run passes (~6m)
- [x] Warm run passes (~5.5m)
- [x] All E2E tests pass
- [x] Playwright cache hits on warm runs

🤖 Generated with [Claude Code](https://claude.ai/code)