### PR TITLE
feat: wait for dependencies to be gc-ed before collecting a CoValue

### DIFF
--- a/.changeset/clever-rice-turn.md
+++ b/.changeset/clever-rice-turn.md
@@ -1,0 +1,6 @@
+---
+"jazz-run": patch
+"cojson": patch
+---
+
+Wait for CoValues' dependencies to be garbage-collected before collecting them. This makes accounts and groups safe to be collected.

--- a/packages/cojson/src/GarbageCollector.ts
+++ b/packages/cojson/src/GarbageCollector.ts
@@ -8,10 +8,7 @@ import { RawCoID } from "./ids.js";
 export class GarbageCollector {
   private readonly interval: ReturnType<typeof setInterval>;
 
-  constructor(
-    private readonly coValues: Map<RawCoID, CoValueCore>,
-    private readonly garbageCollectGroups: boolean,
-  ) {
+  constructor(private readonly coValues: Map<RawCoID, CoValueCore>) {
     this.interval = setInterval(() => {
       this.collect();
     }, GARBAGE_COLLECTOR_CONFIG.INTERVAL);
@@ -39,7 +36,7 @@ export class GarbageCollector {
       const timeSinceLastAccessed = currentTime - verified.lastAccessed;
 
       if (timeSinceLastAccessed > GARBAGE_COLLECTOR_CONFIG.MAX_AGE) {
-        coValue.unmount(this.garbageCollectGroups);
+        coValue.unmount();
       }
     }
   }

--- a/packages/cojson/src/coValueCore/coValueCore.ts
+++ b/packages/cojson/src/coValueCore/coValueCore.ts
@@ -378,16 +378,17 @@ export class CoValueCore {
    *
    * @returns true if the coValue was successfully unmounted, false otherwise
    */
-  unmount(garbageCollectGroups = false): boolean {
-    if (
-      !garbageCollectGroups &&
-      this.verified?.header.ruleset.type === "group"
-    ) {
+  unmount(): boolean {
+    if (this.listeners.size > 0) {
+      // The coValue is still in use
       return false;
     }
 
-    if (this.listeners.size > 0) {
-      return false; // The coValue is still in use
+    for (const dependant of this.dependant) {
+      if (this.node.hasCoValue(dependant)) {
+        // Another in-memory coValue depends on this coValue
+        return false;
+      }
     }
 
     if (!this.node.syncManager.isSyncedToServerPeers(this.id)) {
@@ -1202,6 +1203,15 @@ export class CoValueCore {
     return matchingTransactions;
   }
 
+  /**
+   * The CoValues that this CoValue depends on.
+   * We currently track dependencies for:
+   * - Ownership (a CoValue depends on its account/group owner)
+   * - Group membership (a group depends on its direct account/group members)
+   * - Sessions (a CoValue depends on Accounts that made changes to it)
+   * - Branches (a branched CoValue depends on its branch source)
+   * See {@link dependant} for the CoValues that depend on this CoValue.
+   */
   dependencies: Set<RawCoID> = new Set();
   incompleteDependencies: Set<RawCoID> = new Set();
   private addDependency(dependency: RawCoID) {
@@ -1247,6 +1257,10 @@ export class CoValueCore {
     }
   }
 
+  /**
+   * The CoValues that depend on this CoValue.
+   * This is the inverse relationship of {@link dependencies}.
+   */
   dependant: Set<RawCoID> = new Set();
   private addDependant(dependant: RawCoID) {
     this.dependant.add(dependant);

--- a/packages/cojson/src/localNode.ts
+++ b/packages/cojson/src/localNode.ts
@@ -82,15 +82,12 @@ export class LocalNode {
     this.crypto = crypto;
   }
 
-  enableGarbageCollector(opts?: { garbageCollectGroups?: boolean }) {
+  enableGarbageCollector() {
     if (this.garbageCollector) {
       return;
     }
 
-    this.garbageCollector = new GarbageCollector(
-      this.coValues,
-      opts?.garbageCollectGroups ?? false,
-    );
+    this.garbageCollector = new GarbageCollector(this.coValues);
   }
 
   setStorage(storage: StorageAPI) {

--- a/packages/cojson/src/localNode.ts
+++ b/packages/cojson/src/localNode.ts
@@ -130,6 +130,7 @@ export class LocalNode {
 
   internalDeleteCoValue(id: RawCoID) {
     this.coValues.delete(id);
+    this.storage?.onCoValueUnmounted(id);
   }
 
   getCurrentAccountOrAgentID(): RawAccountID | AgentID {

--- a/packages/cojson/src/storage/storageAsync.ts
+++ b/packages/cojson/src/storage/storageAsync.ts
@@ -460,6 +460,10 @@ export class StorageApiAsync implements StorageAPI {
     this.dbClient.stopTrackingSyncState(id);
   }
 
+  onCoValueUnmounted(id: RawCoID): void {
+    this.loadedCoValues.delete(id);
+  }
+
   close() {
     return this.storeQueue.close();
   }

--- a/packages/cojson/src/storage/storageSync.ts
+++ b/packages/cojson/src/storage/storageSync.ts
@@ -450,6 +450,10 @@ export class StorageApiSync implements StorageAPI {
     this.dbClient.stopTrackingSyncState(id);
   }
 
+  onCoValueUnmounted(id: RawCoID): void {
+    this.loadedCoValues.delete(id);
+  }
+
   close() {
     return undefined;
   }

--- a/packages/cojson/src/storage/types.ts
+++ b/packages/cojson/src/storage/types.ts
@@ -67,6 +67,12 @@ export interface StorageAPI {
     callback: (knownState: CoValueKnownState | undefined) => void,
   ): void;
 
+  /**
+   * Called when a CoValue is unmounted from memory.
+   * Used to clean up the metadata associated with that CoValue.
+   */
+  onCoValueUnmounted(id: RawCoID): void;
+
   close(): Promise<unknown> | undefined;
 }
 

--- a/packages/cojson/src/tests/StorageApiAsync.test.ts
+++ b/packages/cojson/src/tests/StorageApiAsync.test.ts
@@ -782,6 +782,55 @@ describe("StorageApiAsync", () => {
       const mapOnNode = await loadCoValueOrFail(node, map.id);
       expect(mapOnNode.get("test")).toEqual("value");
     });
+
+    test("should load dependencies again if they were unmounted", async () => {
+      const { fixturesNode, dbPath } = await createFixturesNode();
+      const { node, storage } = await createTestNode(dbPath);
+
+      // Create a group and a map owned by that group
+      const group = fixturesNode.createGroup();
+      group.addMember("everyone", "reader");
+      const map = group.createMap({ test: "value" });
+      await group.core.waitForSync();
+      await map.core.waitForSync();
+
+      const callback = vi.fn((content) =>
+        node.syncManager.handleNewContent(content, "storage"),
+      );
+      const done = vi.fn();
+
+      // Load the map (and its group)
+      await storage.load(map.id, callback, done);
+      callback.mockClear();
+      done.mockClear();
+
+      // Unmount the map and its group
+      storage.onCoValueUnmounted(map.id);
+      storage.onCoValueUnmounted(group.id);
+
+      // Load the map. The group dependency should be loaded again
+      await storage.load(map.id, callback, done);
+
+      expect(callback).toHaveBeenCalledTimes(2);
+      expect(callback).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          id: group.id,
+        }),
+      );
+      expect(callback).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          id: map.id,
+        }),
+      );
+
+      expect(done).toHaveBeenCalledWith(true);
+
+      node.setStorage(storage);
+      const mapOnNode = await loadCoValueOrFail(node, map.id);
+      expect(mapOnNode.get("test")).toEqual("value");
+    });
   });
 
   describe("waitForSync", () => {

--- a/packages/cojson/src/tests/StorageApiSync.test.ts
+++ b/packages/cojson/src/tests/StorageApiSync.test.ts
@@ -578,6 +578,55 @@ describe("StorageApiSync", () => {
       const mapOnNode = await loadCoValueOrFail(node, map.id);
       expect(mapOnNode.get("test")).toEqual("value");
     });
+
+    test("should load dependencies again if they were unmounted", async () => {
+      const { fixturesNode, dbPath } = await createFixturesNode();
+      const { node, storage } = await createTestNode(dbPath);
+
+      // Create a group and a map owned by that group
+      const group = fixturesNode.createGroup();
+      group.addMember("everyone", "reader");
+      const map = group.createMap({ test: "value" });
+      await group.core.waitForSync();
+      await map.core.waitForSync();
+
+      const callback = vi.fn((content) =>
+        node.syncManager.handleNewContent(content, "storage"),
+      );
+      const done = vi.fn();
+
+      // Load the map (and its group)
+      await storage.load(map.id, callback, done);
+      callback.mockClear();
+      done.mockClear();
+
+      // Unmount the map and its group
+      storage.onCoValueUnmounted(map.id);
+      storage.onCoValueUnmounted(group.id);
+
+      // Load the map. The group dependency should be loaded again
+      await storage.load(map.id, callback, done);
+
+      expect(callback).toHaveBeenCalledTimes(2);
+      expect(callback).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          id: group.id,
+        }),
+      );
+      expect(callback).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          id: map.id,
+        }),
+      );
+
+      expect(done).toHaveBeenCalledWith(true);
+
+      node.setStorage(storage);
+      const mapOnNode = await loadCoValueOrFail(node, map.id);
+      expect(mapOnNode.get("test")).toEqual("value");
+    });
   });
 
   describe("waitForSync", () => {

--- a/packages/cojson/src/tests/coValueCore.loadFromStorage.test.ts
+++ b/packages/cojson/src/tests/coValueCore.loadFromStorage.test.ts
@@ -45,6 +45,7 @@ function createMockStorage(
       callback: (unsyncedCoValueIDs: RawCoID[]) => void,
     ) => void;
     stopTrackingSyncState?: (id: RawCoID) => void;
+    onCoValueUnmounted?: (id: RawCoID) => void;
     close?: () => Promise<unknown> | undefined;
   } = {},
 ): StorageAPI {
@@ -58,6 +59,7 @@ function createMockStorage(
     trackCoValuesSyncState: opts.trackCoValuesSyncState || vi.fn(),
     getUnsyncedCoValueIDs: opts.getUnsyncedCoValueIDs || vi.fn(),
     stopTrackingSyncState: opts.stopTrackingSyncState || vi.fn(),
+    onCoValueUnmounted: opts.onCoValueUnmounted || vi.fn(),
     close: opts.close || vi.fn().mockResolvedValue(undefined),
   };
 }

--- a/packages/cojson/src/tests/knownState.lazyLoading.test.ts
+++ b/packages/cojson/src/tests/knownState.lazyLoading.test.ts
@@ -23,6 +23,7 @@ function createMockStorage(
       callback: (unsyncedCoValueIDs: RawCoID[]) => void,
     ) => void;
     stopTrackingSyncState?: (id: RawCoID) => void;
+    onCoValueUnmounted?: (id: RawCoID) => void;
     close?: () => Promise<unknown> | undefined;
   } = {},
 ): StorageAPI {
@@ -36,6 +37,7 @@ function createMockStorage(
     trackCoValuesSyncState: opts.trackCoValuesSyncState || vi.fn(),
     getUnsyncedCoValueIDs: opts.getUnsyncedCoValueIDs || vi.fn(),
     stopTrackingSyncState: opts.stopTrackingSyncState || vi.fn(),
+    onCoValueUnmounted: opts.onCoValueUnmounted || vi.fn(),
     close: opts.close || vi.fn().mockResolvedValue(undefined),
   };
 }

--- a/packages/jazz-run/src/startSyncServer.ts
+++ b/packages/jazz-run/src/startSyncServer.ts
@@ -53,9 +53,7 @@ export const startSyncServer = async ({
     localNode.setStorage(storage);
   }
 
-  localNode.enableGarbageCollector({
-    garbageCollectGroups: true,
-  });
+  localNode.enableGarbageCollector();
 
   wss.on("connection", function connection(ws, req) {
     // ping/pong for the connection liveness


### PR DESCRIPTION
# Description

Wait for CoValues' dependencies to be garbage-collected before collecting them. This makes accounts and groups safe to be collected.

This PR also:
- cleans up storage metadata (`loadedCoValues`) when a CoValue is unmounted
- removes the `garbageCollectGroups` option from `enableGarbageCollector`, since it's now always safe to collect groups and accounts

## Tests

- [x] Tests have been added and/or updated

## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [x] I've generated a changeset, if a version bump is required
- [x] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing