### PR TITLE
Fix MDX parsing error by preserving indentation when replacing code snippet references

### DIFF
--- a/homepage/homepage/generate-docs/utils/replace-code-snippets.mjs
+++ b/homepage/homepage/generate-docs/utils/replace-code-snippets.mjs
@@ -220,9 +220,9 @@ export function replaceCodeSnippets(source, filePath) {
   
   // Regex to match code fences with snippet syntax
   // Matches: ```ts snippet=path/to/file.ts or ```tsx path/to/file.ts#Region
-  const codeFenceRegex = /```(\w+)\s+([^\n]+)\n([\s\S]*?)```/g;
+  const codeFenceRegex = /^([ \t]*)```(\w+)\s+([^\n]+)\n([\s\S]*?)^[ \t]*```/gm;
 
-  return source.replace(codeFenceRegex, (match, lang, meta, content) => {
+  return source.replace(codeFenceRegex, (match, indent, lang, meta, content) => {
     const params = parseMeta(meta);
     
     // If no snippet parameter, leave it unchanged
@@ -246,8 +246,13 @@ export function replaceCodeSnippets(source, filePath) {
 
       const cleanContent = processAnnotations(fileContent);
 
+      const indentedContent = cleanContent
+        .split("\n")
+        .map((line) => (line.length ? `${indent}${line}` : indent))
+        .join("\n");
+
       // Return the code fence with the actual content
-      return `\`\`\`${lang}\n${cleanContent}\n\`\`\``;
+      return `${indent}\`\`\`${lang}\n${indentedContent}\n${indent}\`\`\``;
     } catch (error) {
       console.warn(`Error processing snippet: ${error.message}`);
       return match;


### PR DESCRIPTION
## Problem
Code fences inside list items or <CodeGroup> blocks were causing MDX build failures with errors like:
```
✘ [ERROR] Cannot process MDX file with esbuild:
  739:51: Could not parse expression with acorn [plugin @mdx-js/esbuild]

    _mdx_bundler_entry_point-8e404fa8-6387-43fe-b25d-cec1e53bd575.mdx:739:50:
      739 │   console.log("Pet ID:", person.$jazz.refs.pet.id);
```

When replaceCodeSnippets replaced a snippet reference with actual code, it stripped the original fence's indentation. 

This caused the inserted code to appear at the MDX root level, where lines like `console.log("Pet ID:", person.$jazz.refs.pet.id);` were misinterpreted as JSX expressions.

## Fix

Updated the regex in replace-code-snippets.mjs to capture leading whitespace and re-apply it to: 
  1. Every line of the inserted snippet content 
  2. The opening and closing fence markers

This keeps snippets properly nested inside their parent MDX structures.