### PR TITLE
Fix expo placeholders

### DIFF
--- a/.changeset/expo-placeholders.md
+++ b/.changeset/expo-placeholders.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Fix an issue when generating image placeholders from clients using Expo Image Manipulator

--- a/packages/jazz-tools/src/media/create-image/react-native.ts
+++ b/packages/jazz-tools/src/media/create-image/react-native.ts
@@ -1,8 +1,7 @@
-import { NativeModules } from "react-native";
 import type ImageResizerType from "@bam.tech/react-native-image-resizer";
 import type ImageManipulatorType from "expo-image-manipulator";
 import type { Account, Group } from "jazz-tools";
-import { FileStream } from "jazz-tools";
+import { co, FileStream } from "jazz-tools";
 import { Image } from "react-native";
 import { createImageFactory } from "../create-image-factory";
 
@@ -148,7 +147,7 @@ async function resize(
   }
 }
 
-function getMimeType(filePath: string): Promise<string> {
+async function getMimeType(filePath: string): Promise<string> {
   return fetch(filePath)
     .then((res) => res.blob())
     .then((blob) => blob.type);
@@ -168,9 +167,11 @@ export async function createFileStreamFromSource(
   const blob = await fetch(filePath).then((res) => res.blob());
   const arrayBuffer = await toArrayBuffer(blob);
 
-  return FileStream.createFromArrayBuffer(arrayBuffer, blob.type, undefined, {
-    owner,
-  });
+  return co
+    .fileStream()
+    .createFromArrayBuffer(arrayBuffer, blob.type, undefined, {
+      owner,
+    });
 }
 
 // TODO: look for more efficient way to do this as React Native hasn't blob.arrayBuffer()

--- a/packages/jazz-tools/src/media/create-image/react-native.ts
+++ b/packages/jazz-tools/src/media/create-image/react-native.ts
@@ -108,7 +108,8 @@ async function getPlaceholderBase64(filePath: string): Promise<string> {
       );
     }
 
-    return base64;
+    // Convert base64 to data URL
+    return "data:image/png;base64," + base64;
   }
 }
 

--- a/packages/jazz-tools/src/media/create-image/react-native.ts
+++ b/packages/jazz-tools/src/media/create-image/react-native.ts
@@ -1,7 +1,7 @@
 import type ImageResizerType from "@bam.tech/react-native-image-resizer";
 import type ImageManipulatorType from "expo-image-manipulator";
 import type { Account, Group } from "jazz-tools";
-import { co, FileStream } from "jazz-tools";
+import { co, type FileStream } from "jazz-tools";
 import { Image } from "react-native";
 import { createImageFactory } from "../create-image-factory";
 


### PR DESCRIPTION
# Description
Expo Image Manipulator returns a bare base64 string, which means that the images uploaded from Expo clients had invalid placeholders.

This fixes. 

## Manual testing instructions
Build and install the chat app, upload some images. Check that the placeholder URL is correctly set with the `data` prefix.

## Tests

- [ ] Tests have been added and/or updated
- [x] Tests have not been updated, because: RN testing is not fully ready yet.
- [ ] I need help with writing tests


## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [x] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing