### PR TITLE
Add a 512px progressive image variant

### DIFF
--- a/.changeset/add-512-variant.md
+++ b/.changeset/add-512-variant.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Adds a 512 variant for progressive image loading.

--- a/.changeset/expo-placeholders.md
+++ b/.changeset/expo-placeholders.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Fix an issue when generating image placeholders from clients using Expo Image Manipulator

--- a/homepage/homepage/content/docs/core-concepts/covalues/imagedef.mdx
+++ b/homepage/homepage/content/docs/core-concepts/covalues/imagedef.mdx
@@ -203,7 +203,7 @@ If the image was generated with progressive loading, the `width` and `height` pr
 <ContentByFramework framework={['react', 'svelte']}>
 #### Lazy loading [!framework=react,svelte]
 
-The `Image` component supports lazy loading with the [same options as the native browser `loading` attribute].(https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/img#loading). It will generate the blob url for the image when the browser's viewport reaches the image.
+The `Image` component supports lazy loading with the [same options as the native browser `loading` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/img#loading). It will generate the blob url for the image when the browser's viewport reaches the image.
 
 <CodeGroup className="[&_span]:whitespace-normal">
 ```tsx react-snippet.tsx#LazyLoad

--- a/packages/jazz-tools/src/media/create-image-factory.test.ts
+++ b/packages/jazz-tools/src/media/create-image-factory.test.ts
@@ -162,8 +162,8 @@ describe("createImage", async () => {
     expect(image).toBeDefined();
     expect(image.originalSize).toEqual([1920, 400]);
     expect(image.placeholderDataURL).not.toBeDefined();
-
     expect(image[`256x53`]).toBeDefined();
+    expect(image[`512x107`]).toBeDefined();
     expect(image[`1024x213`]).toBeDefined();
     expect(image[`2048x427`]).not.toBeDefined();
 

--- a/packages/jazz-tools/src/media/create-image-factory.ts
+++ b/packages/jazz-tools/src/media/create-image-factory.ts
@@ -154,7 +154,7 @@ async function createImage<TSourceType, TResizeOutput>(
   if (options?.progressive) {
     imageCoValue.$jazz.set("progressive", true);
 
-    const resizes = ([256, 1024, 2048] as const).filter(
+    const resizes = ([256, 512, 1024, 2048] as const).filter(
       (s) =>
         s <
         Math.max(imageCoValue.originalSize[0], imageCoValue.originalSize[1]),

--- a/packages/jazz-tools/src/media/create-image/react-native.ts
+++ b/packages/jazz-tools/src/media/create-image/react-native.ts
@@ -1,8 +1,7 @@
-import { NativeModules } from "react-native";
 import type ImageResizerType from "@bam.tech/react-native-image-resizer";
 import type ImageManipulatorType from "expo-image-manipulator";
 import type { Account, Group } from "jazz-tools";
-import { FileStream } from "jazz-tools";
+import { co, FileStream } from "jazz-tools";
 import { Image } from "react-native";
 import { createImageFactory } from "../create-image-factory";
 
@@ -148,7 +147,7 @@ async function resize(
   }
 }
 
-function getMimeType(filePath: string): Promise<string> {
+async function getMimeType(filePath: string): Promise<string> {
   return fetch(filePath)
     .then((res) => res.blob())
     .then((blob) => blob.type);
@@ -168,9 +167,11 @@ export async function createFileStreamFromSource(
   const blob = await fetch(filePath).then((res) => res.blob());
   const arrayBuffer = await toArrayBuffer(blob);
 
-  return FileStream.createFromArrayBuffer(arrayBuffer, blob.type, undefined, {
-    owner,
-  });
+  return co
+    .fileStream()
+    .createFromArrayBuffer(arrayBuffer, blob.type, undefined, {
+      owner,
+    });
 }
 
 // TODO: look for more efficient way to do this as React Native hasn't blob.arrayBuffer()

--- a/packages/jazz-tools/src/media/create-image/react-native.ts
+++ b/packages/jazz-tools/src/media/create-image/react-native.ts
@@ -108,7 +108,8 @@ async function getPlaceholderBase64(filePath: string): Promise<string> {
       );
     }
 
-    return base64;
+    // Convert base64 to data URL
+    return "data:image/png;base64," + base64;
   }
 }
 


### PR DESCRIPTION
# Description
Currently, we resize images to 256, 1024, and 2048 (plus the original).

This is generally reasonable for thumbnails and full width content on different devices, but there's a big jump between 256 and 1024 for content that does not fill the width of a screen. This PR introduces the additional variant for users who opt in to progressive images

## Manual testing instructions
Upload an image with progressive enabled, check that a 512 variant is created

## Tests

- [x] Tests have been added and/or updated
- [ ] Tests have not been updated, because: <!-- Insert reason for not updating tests here -->
- [ ] I need help with writing tests


## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [x] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing