### PR TITLE
feat(storage): mark CoValue as being in-memory after a store

### DIFF
--- a/packages/cojson/src/storage/storageAsync.ts
+++ b/packages/cojson/src/storage/storageAsync.ts
@@ -38,7 +38,7 @@ export class StorageApiAsync implements StorageAPI {
    * Keeps track of CoValues that are in memory, to avoid reloading them from storage
    * when it isn't necessary
    */
-  private loadedCoValues = new Set<RawCoID>();
+  private inMemoryCoValues = new Set<RawCoID>();
 
   // Track pending loads to deduplicate concurrent requests
   private pendingKnownStateLoads = new Map<
@@ -157,7 +157,7 @@ export class StorageApiAsync implements StorageAPI {
       );
     }
 
-    this.loadedCoValues.add(coValueRow.id);
+    this.inMemoryCoValues.add(coValueRow.id);
 
     let contentMessage = createContentMessage(coValueRow.id, coValueRow.header);
 
@@ -241,7 +241,7 @@ export class StorageApiAsync implements StorageAPI {
     const promises = [];
 
     for (const dependedOnCoValue of dependedOnCoValuesList) {
-      if (this.loadedCoValues.has(dependedOnCoValue)) {
+      if (this.inMemoryCoValues.has(dependedOnCoValue)) {
         continue;
       }
 
@@ -368,7 +368,7 @@ export class StorageApiAsync implements StorageAPI {
       });
     }
 
-    this.loadedCoValues.add(id);
+    this.inMemoryCoValues.add(id);
 
     this.knownStates.handleUpdate(id, knownState);
 
@@ -467,11 +467,11 @@ export class StorageApiAsync implements StorageAPI {
   }
 
   onCoValueUnmounted(id: RawCoID): void {
-    this.loadedCoValues.delete(id);
+    this.inMemoryCoValues.delete(id);
   }
 
   close() {
-    this.loadedCoValues.clear();
+    this.inMemoryCoValues.clear();
     return this.storeQueue.close();
   }
 }

--- a/packages/cojson/src/storage/storageSync.ts
+++ b/packages/cojson/src/storage/storageSync.ts
@@ -37,6 +37,10 @@ import { getPriorityFromHeader } from "../priority.js";
 
 export class StorageApiSync implements StorageAPI {
   private readonly dbClient: DBClientInterfaceSync;
+  /**
+   * Keeps track of CoValues that are in memory, to avoid reloading them from storage
+   * when it isn't necessary
+   */
   private loadedCoValues = new Set<RawCoID>();
 
   /**
@@ -244,7 +248,7 @@ export class StorageApiSync implements StorageAPI {
     });
   }
 
-  async pushContentWithDependencies(
+  private async pushContentWithDependencies(
     coValueRow: StoredCoValueRow,
     contentMessage: NewContentMessage,
     pushCallback: (data: NewContentMessage) => void,
@@ -353,6 +357,8 @@ export class StorageApiSync implements StorageAPI {
       });
     }
 
+    this.loadedCoValues.add(id);
+
     this.knownStates.handleUpdate(id, knownState);
 
     if (invalidAssumptions) {
@@ -455,6 +461,7 @@ export class StorageApiSync implements StorageAPI {
   }
 
   close() {
+    this.loadedCoValues.clear();
     return undefined;
   }
 }

--- a/packages/cojson/src/storage/storageSync.ts
+++ b/packages/cojson/src/storage/storageSync.ts
@@ -41,7 +41,7 @@ export class StorageApiSync implements StorageAPI {
    * Keeps track of CoValues that are in memory, to avoid reloading them from storage
    * when it isn't necessary
    */
-  private loadedCoValues = new Set<RawCoID>();
+  private inMemoryCoValues = new Set<RawCoID>();
 
   /**
    * Queue for streaming content that will be pulled by SyncManager.
@@ -142,7 +142,7 @@ export class StorageApiSync implements StorageAPI {
       );
     }
 
-    this.loadedCoValues.add(coValueRow.id);
+    this.inMemoryCoValues.add(coValueRow.id);
 
     const priority = getPriorityFromHeader(coValueRow.header);
     const contentMessage = createContentMessage(
@@ -259,7 +259,7 @@ export class StorageApiSync implements StorageAPI {
     );
 
     for (const dependedOnCoValue of dependedOnCoValuesList) {
-      if (this.loadedCoValues.has(dependedOnCoValue)) {
+      if (this.inMemoryCoValues.has(dependedOnCoValue)) {
         continue;
       }
 
@@ -357,7 +357,7 @@ export class StorageApiSync implements StorageAPI {
       });
     }
 
-    this.loadedCoValues.add(id);
+    this.inMemoryCoValues.add(id);
 
     this.knownStates.handleUpdate(id, knownState);
 
@@ -457,11 +457,11 @@ export class StorageApiSync implements StorageAPI {
   }
 
   onCoValueUnmounted(id: RawCoID): void {
-    this.loadedCoValues.delete(id);
+    this.inMemoryCoValues.delete(id);
   }
 
   close() {
-    this.loadedCoValues.clear();
+    this.inMemoryCoValues.clear();
     return undefined;
   }
 }

--- a/packages/cojson/src/tests/SyncManager.processQueues.test.ts
+++ b/packages/cojson/src/tests/SyncManager.processQueues.test.ts
@@ -70,7 +70,7 @@ describe("SyncManager.processQueues", () => {
       await loadCoValueOrFail(client.node, map.id);
 
       // Restart and load from storage
-      client.restart();
+      await client.restart();
       client.connectToSyncServer();
       client.addStorage({ storage });
 

--- a/packages/cojson/src/tests/coPlainText.test.ts
+++ b/packages/cojson/src/tests/coPlainText.test.ts
@@ -355,7 +355,7 @@ test("chunks transactions when when the chars are longer than MAX_RECOMMENDED_TX
 
   await coValue.waitForSync();
 
-  client.restart();
+  await client.restart();
   client.addStorage({
     storage,
   });

--- a/packages/cojson/src/tests/sync.garbageCollection.test.ts
+++ b/packages/cojson/src/tests/sync.garbageCollection.test.ts
@@ -59,7 +59,6 @@ describe("sync after the garbage collector has run", () => {
       [
         "client -> server | LOAD Map sessions: empty",
         "server -> storage | LOAD Map sessions: empty",
-        "storage -> server | CONTENT Group header: true new: After: 0 New: 3",
         "storage -> server | CONTENT Map header: true new: After: 0 New: 1",
         "server -> client | CONTENT Group header: true new: After: 0 New: 3",
         "server -> client | CONTENT Map header: true new: After: 0 New: 1",
@@ -145,7 +144,6 @@ describe("sync after the garbage collector has run", () => {
       [
         "client -> server | CONTENT Map header: false new: After: 0 New: 1",
         "server -> storage | LOAD Map sessions: empty",
-        "storage -> server | CONTENT Group header: true new: After: 0 New: 5",
         "storage -> server | CONTENT Map header: true new: After: 0 New: 1",
         "server -> client | KNOWN Map sessions: header/2",
         "server -> storage | CONTENT Map header: false new: After: 0 New: 1",

--- a/packages/cojson/src/tests/sync.load.test.ts
+++ b/packages/cojson/src/tests/sync.load.test.ts
@@ -1643,7 +1643,6 @@ describe("lazy storage load optimization", () => {
       [
         "client -> server | CONTENT Map header: false new: After: 0 New: 1",
         "server -> storage | LOAD Map sessions: empty",
-        "storage -> server | CONTENT Group header: true new: After: 0 New: 5",
         "storage -> server | CONTENT Map header: true new: After: 0 New: 1",
         "server -> client | KNOWN Map sessions: header/2",
         "server -> storage | CONTENT Map header: false new: After: 0 New: 1",
@@ -1702,7 +1701,6 @@ describe("lazy storage load optimization", () => {
       [
         "client -> server | CONTENT Map header: false new: After: 0 New: 1",
         "server -> storage | LOAD Map sessions: empty",
-        "storage -> server | CONTENT Group header: true new: After: 0 New: 5",
         "storage -> server | CONTENT Map header: true new: After: 0 New: 73 expectContentUntil: header/201",
         "server -> client | KNOWN Map sessions: header/74",
         "server -> storage | CONTENT Map header: false new: After: 0 New: 1",

--- a/packages/cojson/src/tests/sync.load.test.ts
+++ b/packages/cojson/src/tests/sync.load.test.ts
@@ -514,7 +514,7 @@ describe("loading coValues from server", () => {
     });
 
     // Makes the CoValues unavailable on the server
-    jazzCloud.restart();
+    await jazzCloud.restart();
 
     const client = setupTestNode({
       connected: true,
@@ -1476,7 +1476,7 @@ describe("lazy storage load optimization", () => {
 
     // Restart the server to clear memory (keeping storage)
     // Now the server has no CoValues in memory, only in storage
-    jazzCloud.restart();
+    await jazzCloud.restart();
     jazzCloud.node.setStorage(storage);
 
     SyncMessagesLog.clear();
@@ -1519,7 +1519,7 @@ describe("lazy storage load optimization", () => {
     await map.core.waitForSync();
 
     // Restart the server to clear memory (keeping storage)
-    jazzCloud.restart();
+    await jazzCloud.restart();
     jazzCloud.node.setStorage(storage);
 
     SyncMessagesLog.clear();

--- a/packages/cojson/src/tests/sync.mesh.test.ts
+++ b/packages/cojson/src/tests/sync.mesh.test.ts
@@ -506,7 +506,7 @@ describe("multiple clients syncing with the a cloud-like server mesh", () => {
       ]
     `);
 
-    edge.restart();
+    await edge.restart();
 
     edge.connectToSyncServer({
       syncServerName: "core",

--- a/packages/cojson/src/tests/sync.peerReconciliation.test.ts
+++ b/packages/cojson/src/tests/sync.peerReconciliation.test.ts
@@ -167,7 +167,7 @@ describe("peer reconciliation", () => {
 
     await map.core.waitForSync();
 
-    jazzCloud.restart();
+    await jazzCloud.restart();
     SyncMessagesLog.clear();
     client.connectToSyncServer();
 
@@ -222,7 +222,7 @@ describe("peer reconciliation", () => {
 
     await map.core.waitForSync();
 
-    jazzCloud.restart();
+    await jazzCloud.restart();
     SyncMessagesLog.clear();
     client.connectToSyncServer();
 
@@ -305,7 +305,7 @@ describe("peer reconciliation", () => {
 
     await map.core.waitForSync();
 
-    jazzCloud.restart();
+    await jazzCloud.restart();
 
     SyncMessagesLog.clear();
     client.connectToSyncServer();

--- a/packages/cojson/src/tests/sync.storage.test.ts
+++ b/packages/cojson/src/tests/sync.storage.test.ts
@@ -83,7 +83,7 @@ describe("client with storage syncs with server", () => {
 
     await loadCoValueOrFail(client.node, map.id);
 
-    client.restart();
+    await client.restart();
 
     client.connectToSyncServer();
     client.addStorage({
@@ -167,7 +167,7 @@ describe("client with storage syncs with server", () => {
 
     await map.core.waitForSync();
 
-    client.restart();
+    await client.restart();
 
     client.addStorage({
       storage,
@@ -217,7 +217,7 @@ describe("client with storage syncs with server", () => {
     branch.set("branchKey", "branchValue");
     await branch.core.waitForSync();
 
-    client.restart();
+    await client.restart();
     client.addStorage({
       storage,
     });
@@ -388,7 +388,7 @@ describe("client syncs with a server with storage", () => {
 
     SyncMessagesLog.clear();
 
-    client.restart();
+    await client.restart();
 
     client.connectToSyncServer({
       ourName: "client",
@@ -457,7 +457,7 @@ describe("client syncs with a server with storage", () => {
 
     expect(correctionSpy).not.toHaveBeenCalled();
 
-    client.restart();
+    await client.restart();
 
     client.connectToSyncServer({
       ourName: "client",
@@ -771,7 +771,7 @@ describe("client syncs with a server with storage", () => {
 
     SyncMessagesLog.clear();
 
-    syncServer.restart();
+    await syncServer.restart();
     syncServer.addStorage({
       ourName: "syncServer",
       storage,
@@ -848,7 +848,7 @@ describe("client syncs with a server with storage", () => {
       ]);
 
       // Restart to load from storage
-      client.restart();
+      await client.restart();
       client.addStorage({ storage });
 
       // Load all maps concurrently from storage
@@ -892,7 +892,7 @@ describe("client syncs with a server with storage", () => {
       SyncMessagesLog.clear();
 
       // Restart client with storage
-      client.restart();
+      await client.restart();
       client.connectToSyncServer();
       client.addStorage({ storage });
 
@@ -985,7 +985,7 @@ describe("client syncs with a server with storage", () => {
 
       SyncMessagesLog.clear();
 
-      syncServer.restart();
+      await syncServer.restart();
       syncServer.addStorage({
         ourName: "syncServer",
         storage,

--- a/packages/cojson/src/tests/sync.storageAsync.test.ts
+++ b/packages/cojson/src/tests/sync.storageAsync.test.ts
@@ -72,7 +72,7 @@ describe("client with storage syncs with server", () => {
     const firstLoad = await loadCoValueOrFail(client.node, map.id);
     await firstLoad.core.waitForSync(); // Need to wait for sync with storage
 
-    client.restart();
+    await client.restart();
 
     client.connectToSyncServer();
     client.addStorage({
@@ -311,7 +311,7 @@ describe("client syncs with a server with storage", () => {
 
     SyncMessagesLog.clear();
 
-    client.restart();
+    await client.restart();
 
     client.connectToSyncServer({
       ourName: "client",
@@ -406,7 +406,7 @@ describe("client syncs with a server with storage", () => {
     const largeMapContent =
       largeMap.core.newContentSince(undefined)?.slice(0, 4) ?? [];
 
-    client.restart();
+    await client.restart();
 
     const newSyncServer = setupTestNode({
       isSyncServer: true,
@@ -518,7 +518,7 @@ describe("client syncs with a server with storage", () => {
 
     expect(correctionSpy).not.toHaveBeenCalled();
 
-    client.restart();
+    await client.restart();
 
     client.connectToSyncServer({
       ourName: "client",
@@ -566,14 +566,14 @@ describe("client syncs with a server with storage", () => {
 
     await largeMap.core.waitForSync();
 
-    server.restart();
+    await server.restart();
 
     server.addStorage({
       ourName: "server",
       storage: serverStorage,
     });
 
-    client.restart();
+    await client.restart();
 
     client.connectToSyncServer({
       ourName: "client",
@@ -703,7 +703,7 @@ describe("client syncs with a server with storage", () => {
 
     SyncMessagesLog.clear();
 
-    syncServer.restart();
+    await syncServer.restart();
     syncServer.addStorage({
       ourName: "syncServer",
       storage,

--- a/packages/cojson/src/tests/sync.tracking.test.ts
+++ b/packages/cojson/src/tests/sync.tracking.test.ts
@@ -312,7 +312,7 @@ describe("sync resumption", () => {
     expect(unsyncedTracker.has(map.id)).toBe(true);
     expect(await getUnsyncedCoValueIDsFromStorage()).toHaveLength(2);
 
-    client.restart();
+    await client.restart();
     client.addStorage({ storage });
     const { peerState: serverPeerState } = client.connectToSyncServer();
 
@@ -350,7 +350,7 @@ describe("sync resumption", () => {
     }
     expect(await getUnsyncedCoValueIDsFromStorage()).toHaveLength(101);
 
-    client.restart();
+    await client.restart();
     client.addStorage({ storage });
     const { peerState: serverPeerState } = client.connectToSyncServer();
 
@@ -389,7 +389,7 @@ describe("sync resumption", () => {
 
     expect(await getUnsyncedCoValueIDsFromStorage()).toHaveLength(2);
 
-    client.restart();
+    await client.restart();
     client.addStorage({ storage });
     const newSyncServer = setupTestNode({ isSyncServer: true });
     const { peerState: newServerPeerState } = client.connectToSyncServer({
@@ -427,7 +427,7 @@ describe("sync resumption", () => {
     expect(unsyncedCoValueIDs).toContain(map.id);
     expect(unsyncedCoValueIDs).toContain(group.id);
 
-    client.restart();
+    await client.restart();
     client.addStorage({ storage });
     const newPeer = setupTestNode({ isSyncServer: true });
     client.connectToSyncServer({

--- a/packages/cojson/src/tests/testUtils.ts
+++ b/packages/cojson/src/tests/testUtils.ts
@@ -526,8 +526,8 @@ export function setupTestNode(
     connectToSyncServer,
     addStorage,
     addAsyncStorage,
-    restart: () => {
-      node.gracefulShutdown();
+    restart: async () => {
+      await node.gracefulShutdown();
       ctx.node = node = new LocalNode(
         admin.agentSecret,
         session,


### PR DESCRIPTION
# Description

While working on https://github.com/garden-co/jazz/pull/3371, I noticed that when storing CoValue content into storage, we're not tracking those CoValues as being in memory. We only tracked them as being in memory after a load. This led to unnecessarily reloading CoValue dependencies from storage.

This change also uncovered an issue: we should clear the in-memory CoValues set when closing the storage, otherwise we may carry state over to a new node that doesn't have those CoValues in memory (this is just a concern for tests, because we are not closing and reattaching storages at runtime in prod).

I also made node restart async in tests, otherwise we were not waiting for the storage to be closed.

## Tests

- [x] Tests have been added and/or updated

## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [ ] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing