### PR TITLE
feat: automate browser performance benchmarks with Playwright

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3044,6 +3044,12 @@ importers:
         specifier: ^6.16.0
         version: 6.28.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.50.1
+        version: 1.50.1
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.16.5
       '@types/qrcode':
         specifier: ^1.5.1
         version: 1.5.5
@@ -3055,13 +3061,19 @@ importers:
         version: 19.1.0(@types/react@19.1.0)
       '@vitejs/plugin-react-swc':
         specifier: ^3.10.1
-        version: 3.10.1(@swc/helpers@0.5.17)(vite@6.3.5(@types/node@24.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.1))
+        version: 3.10.1(@swc/helpers@0.5.17)(vite@6.3.5(@types/node@22.16.5)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.1))
+      is-ci:
+        specifier: ^3.0.1
+        version: 3.0.1
+      jstat:
+        specifier: ^1.9.6
+        version: 1.9.6
       typescript:
         specifier: 5.6.2
         version: 5.6.2
       vite:
         specifier: 6.3.5
-        version: 6.3.5(@types/node@24.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.1)
+        version: 6.3.5(@types/node@22.16.5)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.1)
 
   tests/cloudflare-workers:
     dependencies:
@@ -29513,6 +29525,14 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.9
       '@swc/core': 1.11.29(@swc/helpers@0.5.17)
       vite: 6.3.5(@types/node@22.15.18)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.1)
+    transitivePeerDependencies:
+      - '@swc/helpers'
+
+  '@vitejs/plugin-react-swc@3.10.1(@swc/helpers@0.5.17)(vite@6.3.5(@types/node@22.16.5)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.1))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.0-beta.9
+      '@swc/core': 1.11.29(@swc/helpers@0.5.17)
+      vite: 6.3.5(@types/node@22.16.5)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.1)
     transitivePeerDependencies:
       - '@swc/helpers'
 

--- a/tests/browser-perf-tests/README.md
+++ b/tests/browser-perf-tests/README.md
@@ -44,7 +44,7 @@ pnpm bench <scenario> [options]
 | `--runs, -n <n>` | Number of benchmark runs | 50 |
 | `--id <covalue-id>` | Use existing CoValue ID (skips fixture generation) | - |
 | `--sync, -s <url>` | Sync server URL | ws://localhost:4200 |
-| `--headless` | Run browser in headless mode | true |
+| `--headful` | Run browser with visible window | false (headless) |
 | `--cold-storage` | Clear browser storage between runs | false |
 
 ### Grid Scenario Options

--- a/tests/browser-perf-tests/README.md
+++ b/tests/browser-perf-tests/README.md
@@ -1,23 +1,93 @@
-# Jazz Stress Test
+# Jazz Browser Performance Tests
 
-A multi-scenario stress test app for testing Jazz performance.
+A browser-based performance testing app for Jazz with automated benchmarking CLI.
 
 ## Scenarios
-
-### Todo Projects
-Generate random todo projects with configurable task counts for testing list rendering and sync performance.
 
 ### Pixel Grid
 Generate NxN pixel grids with random colors and configurable payload sizes for testing canvas rendering and data loading.
 
-## Usage
+## Development
 
 ```bash
-# Start the development server
+# Start the development server (web app + sync server)
 pnpm dev
 
 # Build for production
 pnpm build
+```
+
+## Benchmark CLI
+
+Run automated benchmarks with statistically rigorous analysis (confidence intervals, percentiles).
+
+### Prerequisites
+
+Before running benchmarks, start the servers:
+
+```bash
+pnpm build
+pnpm preview --port 5173 &
+pnpm sync --in-memory &
+```
+
+### Usage
+
+```bash
+pnpm bench <scenario> [options]
+```
+
+### Options
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--runs, -n <n>` | Number of benchmark runs | 50 |
+| `--id <covalue-id>` | Use existing CoValue ID (skips fixture generation) | - |
+| `--sync, -s <url>` | Sync server URL | ws://localhost:4200 |
+| `--headless` | Run browser in headless mode | true |
+| `--cold-storage` | Clear browser storage between runs | false |
+
+### Grid Scenario Options
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--size <n>` | Grid size NxN | 10 |
+| `--min-padding <n>` | Minimum padding bytes per cell | 0 |
+| `--max-padding <n>` | Maximum padding bytes per cell | 100 |
+
+### Examples
+
+```bash
+# Run grid benchmark with 50 runs
+pnpm bench grid --size 20 --runs 50
+
+# Reuse an existing grid (skip generation)
+pnpm bench grid --id co_z1234567890abcdef --runs 100
+
+# Run with cold storage (fresh browser state each run)
+pnpm bench grid --id co_z1234567890abcdef --cold-storage --runs 50
+```
+
+### Output
+
+The benchmark outputs statistical analysis including:
+- Mean and 95% confidence interval
+- Median, p75, p90, p95, p99 percentiles
+- Min/Max values
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Grid Benchmark Results (50 runs)                               │
+├─────────────────────────────────────────────────────────────────┤
+│  CoValue ID: co_z1234567890abcdef                               │
+│  Metric: loadTimeMs                                             │
+│                                                                 │
+│  Mean:     234.5ms                                              │
+│  95% CI:   228.3ms - 240.7ms (±2.6%)                            │
+│  Median:   232.0ms                                              │
+│  p95:      289.0ms                                              │
+│  Min/Max:  198.0ms - 312.0ms                                    │
+└─────────────────────────────────────────────────────────────────┘
 ```
 
 ## Sync Server

--- a/tests/browser-perf-tests/package.json
+++ b/tests/browser-perf-tests/package.json
@@ -9,7 +9,8 @@
     "format-and-lint": "biome check .",
     "format-and-lint:fix": "biome check . --write",
     "preview": "vite preview",
-    "sync": "NODE_OPTIONS='--inspect' jazz-run sync"
+    "sync": "NODE_OPTIONS='--inspect' jazz-run sync",
+    "bench": "node --experimental-strip-types src/cli/cli.ts"
   },
   "dependencies": {
     "@faker-js/faker": "^9.7.0",
@@ -22,10 +23,14 @@
     "react-dom": "19.0.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.50.1",
+    "@types/node": "^22.0.0",
     "@types/qrcode": "^1.5.1",
     "@types/react": "19.0.0",
     "@types/react-dom": "19.0.0",
     "@vitejs/plugin-react-swc": "^3.10.1",
+    "is-ci": "^3.0.1",
+    "jstat": "^1.9.6",
     "typescript": "5.6.2",
     "vite": "^6.3.5"
   }

--- a/tests/browser-perf-tests/playwright.config.ts
+++ b/tests/browser-perf-tests/playwright.config.ts
@@ -1,0 +1,63 @@
+import { defineConfig, devices } from "@playwright/test";
+import isCI from "is-ci";
+
+/**
+ * Playwright configuration for browser benchmarks.
+ * Note: This config is primarily for the benchmark CLI, not for running tests.
+ * The benchmark CLI uses Playwright directly, not through the test runner.
+ */
+export default defineConfig({
+  testDir: "./src/cli",
+
+  /* Run tests in files in parallel */
+  fullyParallel: false, // Benchmarks should run sequentially for consistency
+
+  /* Fail the build on CI if you accidentally left test.only in the source code */
+  forbidOnly: isCI,
+
+  /* Retry on CI only */
+  retries: 0, // No retries for benchmarks
+
+  /* Single worker for consistent benchmark results */
+  workers: 1,
+
+  /* Reporter to use */
+  reporter: "list",
+
+  /* Shared settings for all the projects below */
+  use: {
+    /* Base URL to use in actions like `await page.goto('/')` */
+    baseURL: "http://localhost:5173/",
+
+    /* Collect trace when retrying the failed test */
+    trace: "off",
+
+    /* No screenshots for benchmarks */
+    screenshot: "off",
+
+    /* No video for benchmarks */
+    video: "off",
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+
+  /* Run your local dev server before starting the tests */
+  webServer: [
+    {
+      command: "pnpm preview --port 5173",
+      url: "http://localhost:5173/",
+      reuseExistingServer: !isCI,
+    },
+    {
+      command: "pnpm sync --in-memory",
+      url: "http://localhost:4200/health",
+      reuseExistingServer: !isCI,
+    },
+  ],
+});

--- a/tests/browser-perf-tests/src/cli/cli.ts
+++ b/tests/browser-perf-tests/src/cli/cli.ts
@@ -12,7 +12,7 @@ const argsConfig = {
     runs: { type: "string" as const, short: "n" },
     id: { type: "string" as const },
     sync: { type: "string" as const, short: "s" },
-    headless: { type: "boolean" as const, default: true },
+    headful: { type: "boolean" as const, default: false },
     "cold-storage": { type: "boolean" as const, default: false },
     help: { type: "boolean" as const, short: "h" },
     // Grid scenario options
@@ -47,7 +47,7 @@ function buildConfig(
   const runs = values.runs ? parseInt(String(values.runs), 10) : 50;
   const id = values.id ? String(values.id) : undefined;
   const sync = values.sync ? String(values.sync) : undefined;
-  const headless = values.headless !== false; // Default to true
+  const headless = values.headful !== true; // Default to headless (true)
   const coldStorage = values["cold-storage"] === true; // Default to false (warm storage)
 
   // Build scenario-specific options
@@ -103,7 +103,7 @@ async function main(): Promise<void> {
     if (config.sync) {
       console.log(`  Sync Server: ${config.sync}`);
     }
-    console.log(`  Headless: ${config.headless}`);
+    console.log(`  Headful: ${!config.headless}`);
     console.log(
       `  Storage: ${config.coldStorage ? "cold (fresh each run)" : "warm (reused)"}`,
     );

--- a/tests/browser-perf-tests/src/cli/cli.ts
+++ b/tests/browser-perf-tests/src/cli/cli.ts
@@ -1,0 +1,124 @@
+import { parseArgs } from "node:util";
+import { runBenchmark } from "./runner.ts";
+import { printResults, printUsage, printError } from "./reporter.ts";
+import { listScenarios } from "./scenarios/index.ts";
+import type { BenchmarkConfig } from "./scenarios/types.ts";
+
+/**
+ * CLI argument options configuration
+ */
+const argsConfig = {
+  options: {
+    runs: { type: "string" as const, short: "n" },
+    id: { type: "string" as const },
+    sync: { type: "string" as const, short: "s" },
+    headless: { type: "boolean" as const, default: true },
+    "cold-storage": { type: "boolean" as const, default: false },
+    help: { type: "boolean" as const, short: "h" },
+    // Grid scenario options
+    size: { type: "string" as const },
+    "min-padding": { type: "string" as const },
+    "max-padding": { type: "string" as const },
+  },
+  allowPositionals: true,
+};
+
+/**
+ * Build benchmark config from parsed arguments
+ */
+function buildConfig(
+  values: Record<string, unknown>,
+  positionals: string[],
+): BenchmarkConfig {
+  const scenario = positionals[0];
+
+  if (!scenario) {
+    throw new Error("No scenario specified");
+  }
+
+  const availableScenarios = listScenarios();
+  if (!availableScenarios.includes(scenario)) {
+    throw new Error(
+      `Unknown scenario: ${scenario}. Available: ${availableScenarios.join(", ")}`,
+    );
+  }
+
+  // Parse common options
+  const runs = values.runs ? parseInt(String(values.runs), 10) : 50;
+  const id = values.id ? String(values.id) : undefined;
+  const sync = values.sync ? String(values.sync) : undefined;
+  const headless = values.headless !== false; // Default to true
+  const coldStorage = values["cold-storage"] === true; // Default to false (warm storage)
+
+  // Build scenario-specific options
+  const scenarioOptions: Record<string, unknown> = {};
+
+  if (scenario === "grid") {
+    if (values.size) {
+      scenarioOptions.size = parseInt(String(values.size), 10);
+    }
+    if (values["min-padding"]) {
+      scenarioOptions.minPadding = parseInt(String(values["min-padding"]), 10);
+    }
+    if (values["max-padding"]) {
+      scenarioOptions.maxPadding = parseInt(String(values["max-padding"]), 10);
+    }
+  }
+
+  return {
+    scenario,
+    runs,
+    id,
+    sync,
+    headless,
+    coldStorage,
+    scenarioOptions,
+  };
+}
+
+/**
+ * Main entry point
+ */
+async function main(): Promise<void> {
+  try {
+    const { values, positionals } = parseArgs({
+      args: process.argv.slice(2),
+      ...argsConfig,
+    });
+
+    // Handle help flag or no arguments
+    if (values.help || positionals.length === 0) {
+      printUsage();
+      process.exit(0);
+    }
+
+    const config = buildConfig(values, positionals);
+
+    console.log(`\nBenchmark Configuration:`);
+    console.log(`  Scenario: ${config.scenario}`);
+    console.log(`  Runs: ${config.runs}`);
+    if (config.id) {
+      console.log(`  CoValue ID: ${config.id}`);
+    }
+    if (config.sync) {
+      console.log(`  Sync Server: ${config.sync}`);
+    }
+    console.log(`  Headless: ${config.headless}`);
+    console.log(
+      `  Storage: ${config.coldStorage ? "cold (fresh each run)" : "warm (reused)"}`,
+    );
+    if (Object.keys(config.scenarioOptions).length > 0) {
+      console.log(`  Options: ${JSON.stringify(config.scenarioOptions)}`);
+    }
+
+    const results = await runBenchmark(config);
+    printResults(results);
+
+    process.exit(0);
+  } catch (error) {
+    printError(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}
+
+main();

--- a/tests/browser-perf-tests/src/cli/reporter.ts
+++ b/tests/browser-perf-tests/src/cli/reporter.ts
@@ -157,7 +157,7 @@ Options:
   --runs, -n <n>       Number of benchmark runs (default: 50)
   --id <covalue-id>    Use existing CoValue ID (skips fixture generation)
   --sync, -s <url>     Sync server URL (default: ws://localhost:4200)
-  --headless           Run browser in headless mode (default: true)
+  --headful            Run browser with visible window (default: headless)
   --cold-storage       Clear browser storage between runs (default: false)
 
 Grid scenario options (when not using --id):

--- a/tests/browser-perf-tests/src/cli/reporter.ts
+++ b/tests/browser-perf-tests/src/cli/reporter.ts
@@ -1,0 +1,173 @@
+import type { BenchmarkResults, BenchmarkStats } from "./scenarios/types.ts";
+
+/**
+ * Format a number with appropriate precision
+ */
+function formatNumber(value: number, decimals: number = 1): string {
+  return value.toFixed(decimals);
+}
+
+/**
+ * Format a duration in milliseconds
+ */
+function formatMs(ms: number): string {
+  return `${formatNumber(ms, 1)}ms`;
+}
+
+/**
+ * Format percentage
+ */
+function formatPercent(value: number): string {
+  return `±${formatNumber(value, 1)}%`;
+}
+
+/**
+ * Create a horizontal line for the table
+ */
+function horizontalLine(width: number, char: string = "─"): string {
+  return char.repeat(width);
+}
+
+/**
+ * Print a progress bar to stdout
+ */
+export function printProgress(current: number, total: number): void {
+  const width = 50;
+  const progress = Math.floor((current / total) * width);
+  const bar = "=".repeat(progress) + "-".repeat(width - progress);
+  process.stdout.write(`\r[${bar}] ${current}/${total}`);
+  if (current === total) {
+    process.stdout.write("\n");
+  }
+}
+
+/**
+ * Print that a fixture was generated
+ */
+export function printGeneratedFixture(
+  scenario: string,
+  coValueId: string,
+): void {
+  console.log(`\nGenerated ${scenario}: ${coValueId}`);
+  console.log(`(reuse with: pnpm bench ${scenario} --id ${coValueId})\n`);
+}
+
+/**
+ * Print benchmark results in a formatted table
+ */
+export function printResults(results: BenchmarkResults): void {
+  const boxWidth = 67;
+  const innerWidth = boxWidth - 4; // Account for "│  " and "  │"
+
+  const topBorder = `┌${horizontalLine(boxWidth - 2)}┐`;
+  const midBorder = `├${horizontalLine(boxWidth - 2)}┤`;
+  const bottomBorder = `└${horizontalLine(boxWidth - 2)}┘`;
+
+  const padLine = (content: string): string => {
+    const padding = innerWidth - content.length;
+    return `│  ${content}${" ".repeat(Math.max(0, padding))}  │`;
+  };
+
+  console.log("");
+  console.log(topBorder);
+  console.log(
+    padLine(
+      `${capitalize(results.scenario)} Benchmark Results (${results.runs} runs)`,
+    ),
+  );
+  console.log(midBorder);
+  console.log(padLine(`CoValue ID: ${results.coValueId}`));
+
+  // Print stats for each metric
+  for (const [metricName, stats] of Object.entries(results.stats)) {
+    console.log(padLine(`Metric: ${metricName}`));
+    console.log(padLine(""));
+    printMetricStats(stats, padLine);
+  }
+
+  console.log(bottomBorder);
+  console.log("");
+}
+
+/**
+ * Print statistics for a single metric
+ */
+function printMetricStats(
+  stats: BenchmarkStats,
+  padLine: (content: string) => string,
+): void {
+  // Mean
+  console.log(padLine(`Mean:     ${formatMs(stats.mean)}`));
+
+  // 95% Confidence Interval
+  const ciStr = `${formatMs(stats.ciLower)} - ${formatMs(stats.ciUpper)} (${formatPercent(stats.marginOfErrorPercent)})`;
+  console.log(padLine(`95% CI:   ${ciStr}`));
+
+  // Median
+  console.log(padLine(`Median:   ${formatMs(stats.median)}`));
+
+  // p95
+  console.log(padLine(`p95:      ${formatMs(stats.p95)}`));
+
+  // Min/Max
+  console.log(
+    padLine(`Min/Max:  ${formatMs(stats.min)} - ${formatMs(stats.max)}`),
+  );
+}
+
+/**
+ * Capitalize first letter of a string
+ */
+function capitalize(str: string): string {
+  return str.charAt(0).toUpperCase() + str.slice(1);
+}
+
+/**
+ * Print an error message
+ */
+export function printError(message: string): void {
+  console.error(`\nError: ${message}\n`);
+}
+
+/**
+ * Print warmup run info
+ */
+export function printWarmupStart(): void {
+  console.log("\nPerforming warmup run (not included in results)...");
+}
+
+/**
+ * Print warmup complete
+ */
+export function printWarmupComplete(timeMs: number): void {
+  console.log(`Warmup complete (${timeMs.toFixed(0)}ms)\n`);
+}
+
+/**
+ * Print usage information
+ */
+export function printUsage(): void {
+  console.log(`
+Usage: pnpm bench <scenario> [options]
+
+Scenarios:
+  grid    Run the pixel grid load benchmark
+
+Options:
+  --runs, -n <n>       Number of benchmark runs (default: 50)
+  --id <covalue-id>    Use existing CoValue ID (skips fixture generation)
+  --sync, -s <url>     Sync server URL (default: ws://localhost:4200)
+  --headless           Run browser in headless mode (default: true)
+  --cold-storage       Clear browser storage between runs (default: false)
+
+Grid scenario options (when not using --id):
+  --size <n>           Grid size NxN (default: 10)
+  --min-padding <n>    Minimum padding bytes (default: 0)
+  --max-padding <n>    Maximum padding bytes (default: 100)
+
+Examples:
+  pnpm bench grid --size 20 --runs 50
+  pnpm bench grid --id co_z1234567890abcdef --runs 100
+  pnpm bench grid --id co_z1234567890abcdef --cold-storage --runs 50
+`);
+}

--- a/tests/browser-perf-tests/src/cli/runner.ts
+++ b/tests/browser-perf-tests/src/cli/runner.ts
@@ -1,0 +1,207 @@
+import { chromium, type Browser, type BrowserContext } from "@playwright/test";
+import type {
+  BenchmarkConfig,
+  BenchmarkResults,
+  ScenarioDefinition,
+} from "./scenarios/types.ts";
+import { getScenario } from "./scenarios/index.ts";
+import { calculateBenchmarkStats } from "./stats.ts";
+import {
+  printProgress,
+  printGeneratedFixture,
+  printWarmupStart,
+  printWarmupComplete,
+} from "./reporter.ts";
+
+/**
+ * Run a benchmark session
+ */
+export async function runBenchmark(
+  config: BenchmarkConfig,
+): Promise<BenchmarkResults> {
+  const scenario = getScenario(config.scenario);
+  if (!scenario) {
+    throw new Error(
+      `Unknown scenario: ${config.scenario}. Available: grid, todo`,
+    );
+  }
+
+  // Build the base URL with sync parameter if provided
+  const baseURL = config.sync
+    ? `http://localhost:5173/?sync=${encodeURIComponent(config.sync)}`
+    : "http://localhost:5173/";
+
+  // Launch browser
+  const browser = await chromium.launch({
+    headless: config.headless ?? true,
+  });
+
+  try {
+    // Get or generate the CoValue ID
+    const coValueId = await getOrGenerateCoValueId(
+      browser,
+      scenario,
+      config,
+      baseURL,
+    );
+
+    // Perform warmup run (not included in results)
+    await performWarmupRun(browser, scenario, coValueId, baseURL);
+
+    // Run the benchmark iterations
+    const rawMetrics = await runIterations(
+      browser,
+      scenario,
+      coValueId,
+      config.runs,
+      baseURL,
+      config.coldStorage ?? false,
+    );
+
+    // Calculate statistics for each metric
+    const stats: Record<
+      string,
+      ReturnType<typeof calculateBenchmarkStats>
+    > = {};
+    for (const [metricName, values] of Object.entries(rawMetrics)) {
+      stats[metricName] = calculateBenchmarkStats(values);
+    }
+
+    return {
+      scenario: config.scenario,
+      coValueId,
+      runs: config.runs,
+      rawMetrics,
+      stats,
+    };
+  } finally {
+    await browser.close();
+  }
+}
+
+/**
+ * Get existing CoValue ID or generate a new fixture
+ */
+async function getOrGenerateCoValueId(
+  browser: Browser,
+  scenario: ScenarioDefinition,
+  config: BenchmarkConfig,
+  baseURL: string,
+): Promise<string> {
+  if (config.id) {
+    return config.id;
+  }
+
+  console.log(`\nGenerating ${scenario.name} fixture...`);
+
+  // Create a context for generation
+  const context = await browser.newContext({ baseURL });
+  const page = await context.newPage();
+
+  try {
+    // Navigate to the app first to initialize
+    await page.goto("/");
+    // Wait for the app to load
+    await page.waitForSelector("h1", { timeout: 30000 });
+
+    // Generate the fixture
+    const coValueId = await scenario.generate(page, config.scenarioOptions);
+
+    printGeneratedFixture(scenario.name, coValueId);
+
+    return coValueId;
+  } finally {
+    await context.close();
+  }
+}
+
+/**
+ * Perform a warmup run (not included in benchmark results)
+ */
+async function performWarmupRun(
+  browser: Browser,
+  scenario: ScenarioDefinition,
+  coValueId: string,
+  baseURL: string,
+): Promise<void> {
+  printWarmupStart();
+
+  const startTime = Date.now();
+  const context = await browser.newContext({ baseURL });
+
+  try {
+    const page = await context.newPage();
+    await scenario.run(page, coValueId);
+  } finally {
+    await context.close();
+  }
+
+  printWarmupComplete(Date.now() - startTime);
+}
+
+/**
+ * Run benchmark iterations
+ */
+async function runIterations(
+  browser: Browser,
+  scenario: ScenarioDefinition,
+  coValueId: string,
+  runs: number,
+  baseURL: string,
+  coldStorage: boolean,
+): Promise<Record<string, number[]>> {
+  const rawMetrics: Record<string, number[]> = {};
+
+  console.log(`Running ${runs} iterations...`);
+
+  // For warm storage mode (default), create a single context and reuse it
+  let sharedContext: BrowserContext | null = null;
+  if (!coldStorage) {
+    sharedContext = await browser.newContext({ baseURL });
+  }
+
+  try {
+    for (let i = 0; i < runs; i++) {
+      printProgress(i + 1, runs);
+
+      // Either use shared context (warm, default) or create fresh context (cold)
+      const context = coldStorage
+        ? await browser.newContext({
+            baseURL,
+            // Clear storage to simulate cold load
+            storageState: undefined,
+          })
+        : sharedContext!;
+
+      try {
+        const page = await context.newPage();
+
+        // Run the scenario
+        const result = await scenario.run(page, coValueId);
+
+        // Collect metrics
+        for (const [metricName, value] of Object.entries(result.metrics)) {
+          if (!rawMetrics[metricName]) {
+            rawMetrics[metricName] = [];
+          }
+          rawMetrics[metricName].push(value);
+        }
+
+        // Close the page (but not context in warm mode)
+        await page.close();
+      } finally {
+        // Only close context in cold mode
+        if (coldStorage) {
+          await context.close();
+        }
+      }
+    }
+  } finally {
+    // Close shared context at the end in warm mode
+    if (sharedContext) {
+      await sharedContext.close();
+    }
+  }
+
+  return rawMetrics;
+}

--- a/tests/browser-perf-tests/src/cli/scenarios/grid.ts
+++ b/tests/browser-perf-tests/src/cli/scenarios/grid.ts
@@ -1,0 +1,109 @@
+import type { Page } from "@playwright/test";
+import type { ScenarioDefinition, ScenarioResult } from "./types.ts";
+
+/**
+ * Grid scenario configuration options
+ */
+export interface GridScenarioOptions {
+  /** Grid size NxN */
+  size: number;
+  /** Minimum padding bytes per cell */
+  minPadding: number;
+  /** Maximum padding bytes per cell */
+  maxPadding: number;
+}
+
+/**
+ * Default options for grid scenario
+ */
+export const defaultGridOptions: GridScenarioOptions = {
+  size: 10,
+  minPadding: 0,
+  maxPadding: 100,
+};
+
+/**
+ * Grid scenario definition
+ */
+export const gridScenario: ScenarioDefinition = {
+  name: "grid",
+
+  async generate(page: Page, config: Record<string, unknown>): Promise<string> {
+    const options = {
+      ...defaultGridOptions,
+      ...config,
+    } as GridScenarioOptions;
+
+    // Navigate to grid home
+    await page.goto("/grid");
+
+    // Fill in the form
+    await page.locator("#size").fill(String(options.size));
+    await page.locator("#minPadding").fill(String(options.minPadding));
+    await page.locator("#maxPadding").fill(String(options.maxPadding));
+
+    // Click generate button and wait for it to complete
+    await page.getByRole("button", { name: "Generate Grid" }).click();
+
+    // Wait for the button to show "Generate Grid" again (not "Generating...")
+    await page.getByRole("button", { name: "Generate Grid" }).waitFor({
+      state: "visible",
+      timeout: 120000, // Allow up to 2 minutes for large grids
+    });
+
+    // Wait a bit for the grid to appear in the list
+    await page.waitForTimeout(500);
+
+    // Find the newly created grid and click on it
+    const gridCard = page
+      .locator(`text=${options.size}x${options.size}`)
+      .first();
+    await gridCard.click();
+
+    // Wait for navigation to the grid screen
+    await page.waitForURL(/\/grid\/co_z/);
+
+    // Extract the CoValue ID from the URL
+    const url = page.url();
+    const match = url.match(/\/grid\/(co_z[a-zA-Z0-9]+)/);
+    if (!match) {
+      throw new Error(`Could not extract grid CoValue ID from URL: ${url}`);
+    }
+
+    return match[1];
+  },
+
+  async run(page: Page, coValueId: string): Promise<ScenarioResult> {
+    // Navigate directly to the grid
+    await page.goto(`/grid/${coValueId}`);
+
+    // Wait for the load time element to have the data attribute set
+    const loadTimeElement = page.locator('[data-testid="load-time"]');
+
+    // Wait for the element to have a non-null data-load-time-ms attribute
+    await loadTimeElement.waitFor({ state: "visible", timeout: 120000 });
+
+    // Poll until the attribute is set (not null)
+    const loadTimeMs = await page.waitForFunction(
+      () => {
+        const el = document.querySelector('[data-testid="load-time"]');
+        if (!el) return null;
+        const value = el.getAttribute("data-load-time-ms");
+        if (value === null) return null;
+        return parseFloat(value);
+      },
+      { timeout: 120000 },
+    );
+
+    const value = await loadTimeMs.jsonValue();
+    if (value === null) {
+      throw new Error("Failed to get load time metric");
+    }
+
+    return {
+      metrics: {
+        loadTimeMs: value,
+      },
+    };
+  },
+};

--- a/tests/browser-perf-tests/src/cli/scenarios/index.ts
+++ b/tests/browser-perf-tests/src/cli/scenarios/index.ts
@@ -1,0 +1,26 @@
+import type { ScenarioDefinition } from "./types.ts";
+import { gridScenario } from "./grid.ts";
+
+export * from "./types.ts";
+export { gridScenario, defaultGridOptions } from "./grid.ts";
+
+/**
+ * Registry of all available scenarios
+ */
+export const scenarios: Record<string, ScenarioDefinition> = {
+  grid: gridScenario,
+};
+
+/**
+ * Get a scenario by name
+ */
+export function getScenario(name: string): ScenarioDefinition | undefined {
+  return scenarios[name];
+}
+
+/**
+ * List all available scenario names
+ */
+export function listScenarios(): string[] {
+  return Object.keys(scenarios);
+}

--- a/tests/browser-perf-tests/src/cli/scenarios/types.ts
+++ b/tests/browser-perf-tests/src/cli/scenarios/types.ts
@@ -1,0 +1,122 @@
+import type { Page } from "@playwright/test";
+
+/**
+ * Result of a single benchmark run
+ */
+export interface ScenarioResult {
+  /** Metrics collected from this run, e.g., { loadTimeMs: 1234 } */
+  metrics: Record<string, number>;
+}
+
+/**
+ * Definition of a benchmark scenario
+ */
+export interface ScenarioDefinition {
+  /** Unique name of the scenario */
+  name: string;
+
+  /**
+   * Generate a new fixture and return its CoValue ID.
+   * Called once before benchmark runs if no --id is provided.
+   */
+  generate: (page: Page, config: Record<string, unknown>) => Promise<string>;
+
+  /**
+   * Run the benchmark on an existing CoValue ID.
+   * Called for each benchmark iteration.
+   */
+  run: (page: Page, coValueId: string) => Promise<ScenarioResult>;
+}
+
+/**
+ * Configuration for a benchmark session
+ */
+export interface BenchmarkConfig {
+  /** Name of the scenario to run (e.g., "grid" or "todo") */
+  scenario: string;
+
+  /** Number of benchmark runs */
+  runs: number;
+
+  /** Optional: existing CoValue ID to reuse (skips generation) */
+  id?: string;
+
+  /** Optional: sync server URL */
+  sync?: string;
+
+  /** Optional: run in headless mode */
+  headless?: boolean;
+
+  /**
+   * If true, create a fresh context for each run (cold load).
+   * If false (default), reuse the same browser context across runs (warm storage).
+   */
+  coldStorage?: boolean;
+
+  /** Scenario-specific options (only used if no id provided) */
+  scenarioOptions: Record<string, unknown>;
+}
+
+/**
+ * Statistical results from benchmark analysis
+ */
+export interface BenchmarkStats {
+  /** Number of samples */
+  count: number;
+
+  /** Arithmetic mean */
+  mean: number;
+
+  /** Standard deviation */
+  stdDev: number;
+
+  /** 95% confidence interval lower bound */
+  ciLower: number;
+
+  /** 95% confidence interval upper bound */
+  ciUpper: number;
+
+  /** Margin of error as percentage of mean */
+  marginOfErrorPercent: number;
+
+  /** Minimum value */
+  min: number;
+
+  /** Maximum value */
+  max: number;
+
+  /** Median (p50) */
+  median: number;
+
+  /** 75th percentile */
+  p75: number;
+
+  /** 90th percentile */
+  p90: number;
+
+  /** 95th percentile */
+  p95: number;
+
+  /** 99th percentile */
+  p99: number;
+}
+
+/**
+ * Complete benchmark results
+ */
+export interface BenchmarkResults {
+  /** Scenario name */
+  scenario: string;
+
+  /** CoValue ID used for the benchmark */
+  coValueId: string;
+
+  /** Number of runs performed */
+  runs: number;
+
+  /** Raw metric values from each run */
+  rawMetrics: Record<string, number[]>;
+
+  /** Statistical analysis for each metric */
+  stats: Record<string, BenchmarkStats>;
+}

--- a/tests/browser-perf-tests/src/cli/stats.ts
+++ b/tests/browser-perf-tests/src/cli/stats.ts
@@ -1,0 +1,123 @@
+// @ts-expect-error - jstat doesn't have type definitions
+import jStat from "jstat";
+import type { BenchmarkStats } from "./scenarios/types.ts";
+
+/**
+ * Calculate percentile from sorted array of numbers.
+ * @param sorted - Array of numbers, already sorted in ascending order
+ * @param p - Percentile to calculate (0-100)
+ */
+export function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  if (sorted.length === 1) return sorted[0]!;
+
+  const index = (p / 100) * (sorted.length - 1);
+  const lower = Math.floor(index);
+  const upper = Math.ceil(index);
+  const weight = index - lower;
+
+  if (lower === upper) return sorted[lower]!;
+  return sorted[lower]! * (1 - weight) + sorted[upper]! * weight;
+}
+
+/**
+ * Calculate median from sorted array of numbers.
+ */
+export function median(sorted: number[]): number {
+  return percentile(sorted, 50);
+}
+
+/**
+ * Calculate standard deviation of an array of numbers.
+ */
+export function standardDeviation(values: number[], mean: number): number {
+  if (values.length <= 1) return 0;
+
+  const squaredDiffs = values.map((v) => Math.pow(v - mean, 2));
+  const variance =
+    squaredDiffs.reduce((a, b) => a + b, 0) / (values.length - 1);
+  return Math.sqrt(variance);
+}
+
+/**
+ * Calculate 95% confidence interval using Student's t-distribution.
+ * This is the same approach used by Google's Tachometer.
+ */
+export function confidenceInterval(
+  values: number[],
+  confidenceLevel: number = 0.95,
+): { lower: number; upper: number; marginOfError: number } {
+  if (values.length < 2) {
+    const value = values[0] ?? 0;
+    return { lower: value, upper: value, marginOfError: 0 };
+  }
+
+  const n = values.length;
+  const mean = values.reduce((a, b) => a + b, 0) / n;
+  const stdDev = standardDeviation(values, mean);
+  const standardError = stdDev / Math.sqrt(n);
+
+  // Get t-critical value for the given confidence level and degrees of freedom
+  const alpha = 1 - confidenceLevel;
+  const degreesOfFreedom = n - 1;
+
+  // jStat.studentt.inv gives the inverse CDF (quantile function)
+  // We want the two-tailed critical value
+  const tCritical = jStat.studentt.inv(1 - alpha / 2, degreesOfFreedom);
+
+  const marginOfError = tCritical * standardError;
+
+  return {
+    lower: mean - marginOfError,
+    upper: mean + marginOfError,
+    marginOfError,
+  };
+}
+
+/**
+ * Calculate comprehensive statistics for benchmark results.
+ * Inspired by Google's Tachometer statistical analysis.
+ */
+export function calculateBenchmarkStats(values: number[]): BenchmarkStats {
+  if (values.length === 0) {
+    return {
+      count: 0,
+      mean: 0,
+      stdDev: 0,
+      ciLower: 0,
+      ciUpper: 0,
+      marginOfErrorPercent: 0,
+      min: 0,
+      max: 0,
+      median: 0,
+      p75: 0,
+      p90: 0,
+      p95: 0,
+      p99: 0,
+    };
+  }
+
+  const sorted = [...values].sort((a, b) => a - b);
+  const sum = sorted.reduce((a, b) => a + b, 0);
+  const mean = sum / sorted.length;
+  const stdDev = standardDeviation(values, mean);
+  const ci = confidenceInterval(values);
+
+  const marginOfErrorPercent = mean !== 0 ? (ci.marginOfError / mean) * 100 : 0;
+
+  return {
+    count: values.length,
+    mean,
+    stdDev,
+    ciLower: ci.lower,
+    ciUpper: ci.upper,
+    marginOfErrorPercent,
+    min: sorted[0]!,
+    max: sorted[sorted.length - 1]!,
+    median: median(sorted),
+    p75: percentile(sorted, 75),
+    p90: percentile(sorted, 90),
+    p95: percentile(sorted, 95),
+    p99: percentile(sorted, 99),
+  };
+}

--- a/tests/browser-perf-tests/src/scenarios/grid/schema.ts
+++ b/tests/browser-perf-tests/src/scenarios/grid/schema.ts
@@ -1,8 +1,4 @@
-import { co, setDefaultSchemaPermissions, z } from "jazz-tools";
-
-setDefaultSchemaPermissions({
-  onInlineCreate: "sameAsContainer",
-});
+import { co, z } from "jazz-tools";
 
 /**
  * PixelCell: Each cell in the grid
@@ -20,8 +16,14 @@ export type PixelCell = co.loaded<typeof PixelCell>;
  * - size: N (grid is NxN)
  * - cells: flat list of PixelCells, accessed as [row * N + col]
  */
-export const GridRoot = co.map({
-  size: z.number(),
-  cells: co.list(PixelCell),
-});
+export const GridRoot = co
+  .map({
+    size: z.number(),
+    cells: co.list(PixelCell),
+  })
+  .withPermissions({
+    onCreate: (newGroup) => {
+      newGroup.makePublic();
+    },
+  });
 export type GridRoot = co.loaded<typeof GridRoot>;

--- a/tests/browser-perf-tests/src/scenarios/todo/schema.ts
+++ b/tests/browser-perf-tests/src/scenarios/todo/schema.ts
@@ -7,7 +7,13 @@ export const Task = co.map({
 });
 
 /** Our top level object: a project with a title, referencing a list of tasks */
-export const TodoProject = co.map({
-  title: z.string(),
-  tasks: co.list(Task),
-});
+export const TodoProject = co
+  .map({
+    title: z.string(),
+    tasks: co.list(Task),
+  })
+  .withPermissions({
+    onCreate: (newGroup) => {
+      newGroup.makePublic();
+    },
+  });

--- a/tests/browser-perf-tests/src/schema.ts
+++ b/tests/browser-perf-tests/src/schema.ts
@@ -1,4 +1,4 @@
-import { co, z } from "jazz-tools";
+import { co, setDefaultSchemaPermissions, z } from "jazz-tools";
 import { TodoProject } from "./scenarios/todo/schema";
 import { GridRoot } from "./scenarios/grid/schema";
 
@@ -6,16 +6,24 @@ import { GridRoot } from "./scenarios/grid/schema";
 export { Task, TodoProject } from "./scenarios/todo/schema";
 export { PixelCell, GridRoot } from "./scenarios/grid/schema";
 
+setDefaultSchemaPermissions({
+  onInlineCreate: "sameAsContainer",
+});
+
 /**
  * Combined account root supporting both Todo and Grid scenarios
  */
-export const AppAccountRoot = co.map({
-  // Todo scenario data
-  projects: co.list(TodoProject),
-  profilingEnabled: z.boolean(),
-  // Grid scenario data
-  grids: co.list(GridRoot),
-});
+export const AppAccountRoot = co
+  .map({
+    // Todo scenario data
+    projects: co.list(TodoProject),
+    profilingEnabled: z.boolean(),
+    // Grid scenario data
+    grids: co.list(GridRoot),
+  })
+  .withPermissions({
+    onInlineCreate: "newGroup",
+  });
 
 export const AppAccount = co
   .account({


### PR DESCRIPTION
Adds a browser automation CLI for running statistically rigorous performance benchmarks on the browser-perf-tests scenarios.
- Implements Playwright-based browser automation to run grid load benchmarks
- Provides Tachometer-inspired statistical analysis with 95% confidence intervals, percentiles, and mean/median
- Supports warm storage (default) and cold storage modes for different testing scenarios
- Includes warmup run before benchmarking to ensure consistent results
- Allows reusing existing CoValue IDs to skip fixture generation

Running two subsequent test runs has given me the following results:

<img width="655" height="236" alt="Screenshot 2026-01-19 at 17 47 08" src="https://github.com/user-attachments/assets/33cb895f-6821-448d-83b6-344d816f3cf1" />
<img width="644" height="232" alt="Screenshot 2026-01-19 at 17 48 45" src="https://github.com/user-attachments/assets/5a4b12b2-ab6f-4726-acff-b0de80e4db5a" />

The results are quite stable, used 100 runs on a 20x20 grid and took only 2s to run the suite.