### PR TITLE
fix: `setDefaultSchemaPermissions` now modifies existing CoValue schemas

### DIFF
--- a/.changeset/khaki-suns-remain.md
+++ b/.changeset/khaki-suns-remain.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+`setDefaultSchemaPermissions` now modifies existing CoValue schemas

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/AccountSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/AccountSchema.ts
@@ -1,6 +1,5 @@
 import {
   Account,
-  AccountCreationProps,
   BranchDefinition,
   CoMapSchemaDefinition,
   coOptionalDefiner,
@@ -16,7 +15,6 @@ import {
 } from "../../../internal.js";
 import { AnonymousJazzAgent } from "../../anonymousJazzAgent.js";
 import { InstanceOrPrimitiveOfSchema } from "../typeConverters/InstanceOrPrimitiveOfSchema.js";
-import { InstanceOrPrimitiveOfSchemaCoValuesMaybeLoaded } from "../typeConverters/InstanceOrPrimitiveOfSchemaCoValuesMaybeLoaded.js";
 import { z } from "../zodReExport.js";
 import { AnyZodOrCoValueSchema, Loaded, ResolveQuery } from "../zodSchema.js";
 import {

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoFeedSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoFeedSchema.ts
@@ -42,11 +42,14 @@ export class CoFeedSchema<
    */
   resolveQuery: DefaultResolveQuery = true as DefaultResolveQuery;
 
+  #permissions: SchemaPermissions | null = null;
   /**
    * Permissions to be used when creating or composing CoValues
    * @internal
    */
-  permissions: SchemaPermissions = DEFAULT_SCHEMA_PERMISSIONS;
+  get permissions(): SchemaPermissions {
+    return this.#permissions ?? DEFAULT_SCHEMA_PERMISSIONS;
+  }
 
   constructor(
     public element: T,
@@ -209,7 +212,7 @@ export class CoFeedSchema<
       hydrateCoreCoValueSchema(coreSchema);
     // @ts-expect-error TS cannot infer that the resolveQuery type is valid
     copy.resolveQuery = resolveQuery ?? this.resolveQuery;
-    copy.permissions = permissions ?? this.permissions;
+    copy.#permissions = permissions ?? this.permissions;
     return copy;
   }
 }

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoFeedSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoFeedSchema.ts
@@ -212,7 +212,7 @@ export class CoFeedSchema<
       hydrateCoreCoValueSchema(coreSchema);
     // @ts-expect-error TS cannot infer that the resolveQuery type is valid
     copy.resolveQuery = resolveQuery ?? this.resolveQuery;
-    copy.#permissions = permissions ?? this.permissions;
+    copy.#permissions = permissions ?? this.#permissions;
     return copy;
   }
 }

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoListSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoListSchema.ts
@@ -265,7 +265,7 @@ export class CoListSchema<
       hydrateCoreCoValueSchema(coreSchema);
     // @ts-expect-error TS cannot infer that the resolveQuery type is valid
     copy.resolveQuery = resolveQuery ?? this.resolveQuery;
-    copy.#permissions = permissions ?? this.permissions;
+    copy.#permissions = permissions ?? this.#permissions;
     return copy;
   }
 }

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoListSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoListSchema.ts
@@ -44,11 +44,14 @@ export class CoListSchema<
    */
   resolveQuery: DefaultResolveQuery = true as DefaultResolveQuery;
 
+  #permissions: SchemaPermissions | null = null;
   /**
    * Permissions to be used when creating or composing CoValues
    * @internal
    */
-  permissions: SchemaPermissions = DEFAULT_SCHEMA_PERMISSIONS;
+  get permissions(): SchemaPermissions {
+    return this.#permissions ?? DEFAULT_SCHEMA_PERMISSIONS;
+  }
 
   constructor(
     public element: T,
@@ -262,7 +265,7 @@ export class CoListSchema<
       hydrateCoreCoValueSchema(coreSchema);
     // @ts-expect-error TS cannot infer that the resolveQuery type is valid
     copy.resolveQuery = resolveQuery ?? this.resolveQuery;
-    copy.permissions = permissions ?? this.permissions;
+    copy.#permissions = permissions ?? this.permissions;
     return copy;
   }
 }

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoMapSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoMapSchema.ts
@@ -409,7 +409,7 @@ export class CoMapSchema<
     copy.coValueClass.prototype.migrate = this.coValueClass.prototype.migrate;
     // @ts-expect-error TS cannot infer that the resolveQuery type is valid
     copy.resolveQuery = resolveQuery ?? this.resolveQuery;
-    copy.#permissions = permissions ?? this.permissions;
+    copy.#permissions = permissions ?? this.#permissions;
     return copy;
   }
 }

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoMapSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoMapSchema.ts
@@ -59,11 +59,14 @@ export class CoMapSchema<
    */
   resolveQuery: DefaultResolveQuery = true as DefaultResolveQuery;
 
+  #permissions: SchemaPermissions | null = null;
   /**
    * Permissions to be used when creating or composing CoValues
    * @internal
    */
-  permissions: SchemaPermissions = DEFAULT_SCHEMA_PERMISSIONS;
+  get permissions(): SchemaPermissions {
+    return this.#permissions ?? DEFAULT_SCHEMA_PERMISSIONS;
+  }
 
   constructor(
     coreSchema: CoreCoMapSchema<Shape, CatchAll>,
@@ -406,7 +409,7 @@ export class CoMapSchema<
     copy.coValueClass.prototype.migrate = this.coValueClass.prototype.migrate;
     // @ts-expect-error TS cannot infer that the resolveQuery type is valid
     copy.resolveQuery = resolveQuery ?? this.resolveQuery;
-    copy.permissions = permissions ?? this.permissions;
+    copy.#permissions = permissions ?? this.permissions;
     return copy;
   }
 }

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoVectorSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoVectorSchema.ts
@@ -36,10 +36,14 @@ export class CoVectorSchema implements CoreCoVectorSchema {
   readonly builtin = "CoVector" as const;
   readonly resolveQuery = true as const;
 
+  #permissions: SchemaPermissions | null = null;
   /**
    * Permissions to be used when creating or composing CoValues
+   * @internal
    */
-  permissions: SchemaPermissions = DEFAULT_SCHEMA_PERMISSIONS;
+  get permissions(): SchemaPermissions {
+    return this.#permissions ?? DEFAULT_SCHEMA_PERMISSIONS;
+  }
 
   constructor(
     public dimensions: number,
@@ -119,7 +123,7 @@ export class CoVectorSchema implements CoreCoVectorSchema {
    */
   withPermissions(permissions: SchemaPermissions): CoVectorSchema {
     const copy = new CoVectorSchema(this.dimensions, this.coValueClass);
-    copy.permissions = permissions;
+    copy.#permissions = permissions;
     return copy;
   }
 }

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/FileStreamSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/FileStreamSchema.ts
@@ -32,10 +32,14 @@ export class FileStreamSchema implements CoreFileStreamSchema {
   readonly builtin = "FileStream" as const;
   readonly resolveQuery = true as const;
 
+  #permissions: SchemaPermissions | null = null;
   /**
    * Permissions to be used when creating or composing CoValues
+   * @internal
    */
-  permissions: SchemaPermissions = DEFAULT_SCHEMA_PERMISSIONS;
+  get permissions(): SchemaPermissions {
+    return this.#permissions ?? DEFAULT_SCHEMA_PERMISSIONS;
+  }
 
   constructor(private coValueClass: typeof FileStream) {}
 
@@ -159,7 +163,7 @@ export class FileStreamSchema implements CoreFileStreamSchema {
     permissions: Omit<SchemaPermissions, "onInlineCreate">,
   ): FileStreamSchema {
     const copy = new FileStreamSchema(this.coValueClass);
-    copy.permissions = permissions;
+    copy.#permissions = permissions;
     return copy;
   }
 }

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/PlainTextSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/PlainTextSchema.ts
@@ -34,11 +34,14 @@ export class PlainTextSchema implements CorePlainTextSchema {
   readonly builtin = "CoPlainText" as const;
   readonly resolveQuery = true as const;
 
+  #permissions: SchemaPermissions | null = null;
   /**
    * Permissions to be used when creating or composing CoValues
    * @internal
    */
-  permissions: SchemaPermissions = DEFAULT_SCHEMA_PERMISSIONS;
+  get permissions(): SchemaPermissions {
+    return this.#permissions ?? DEFAULT_SCHEMA_PERMISSIONS;
+  }
 
   constructor(private coValueClass: typeof CoPlainText) {}
 
@@ -111,7 +114,7 @@ export class PlainTextSchema implements CorePlainTextSchema {
    */
   withPermissions(permissions: SchemaPermissions): PlainTextSchema {
     const copy = new PlainTextSchema(this.coValueClass);
-    copy.permissions = permissions;
+    copy.#permissions = permissions;
     return copy;
   }
 }

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/RichTextSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/RichTextSchema.ts
@@ -33,7 +33,14 @@ export class RichTextSchema implements CoreRichTextSchema {
   readonly builtin = "CoRichText" as const;
   readonly resolveQuery = true as const;
 
-  permissions: SchemaPermissions = DEFAULT_SCHEMA_PERMISSIONS;
+  #permissions: SchemaPermissions | null = null;
+  /**
+   * Permissions to be used when creating or composing CoValues
+   * @internal
+   */
+  get permissions(): SchemaPermissions {
+    return this.#permissions ?? DEFAULT_SCHEMA_PERMISSIONS;
+  }
 
   constructor(private coValueClass: typeof CoRichText) {}
 
@@ -102,7 +109,7 @@ export class RichTextSchema implements CoreRichTextSchema {
    */
   withPermissions(permissions: SchemaPermissions): RichTextSchema {
     const copy = new RichTextSchema(this.coValueClass);
-    copy.permissions = permissions;
+    copy.#permissions = permissions;
     return copy;
   }
 }

--- a/packages/jazz-tools/src/tools/tests/schema.withPermissions.test.ts
+++ b/packages/jazz-tools/src/tools/tests/schema.withPermissions.test.ts
@@ -843,7 +843,7 @@ describe("setDefaultSchemaPermissions", () => {
     expect(childOwner.getRoleOf(anotherAccount.$jazz.id)).toEqual("reader");
   });
 
-  test("does not modify permissions for existing schemas", () => {
+  test("modifies default permissions for existing schemas", () => {
     const ExistingMap = co.map({
       name: co.plainText(),
     });
@@ -852,8 +852,6 @@ describe("setDefaultSchemaPermissions", () => {
     });
 
     const map = ExistingMap.create({ name: "Hello" });
-    expect(
-      map.name.$jazz.owner.getParentGroups().map((group) => group.$jazz.id),
-    ).toContain(map.$jazz.owner.$jazz.id);
+    expect(map.name.$jazz.owner.$jazz.id).toContain(map.$jazz.owner.$jazz.id);
   });
 });


### PR DESCRIPTION
# Description

`setDefaultSchemaPermissions` does not currently affect existing CoValue schemas. This turned out to be a footgun when having schemas on multiple files, because it means a schema's default permission depends on where the import happens. E.g. in the `browser-perf-tests` app, `setDefaultSchemaPermissions` is used in the top-level schema file ([link](https://github.com/garden-co/jazz/blob/fix/default-schema-permissions/tests/browser-perf-tests/src/schema.ts#L9)), but since that file already imported other schema files, those schemas will have outdated default permissions. 

## Tests

- [x] Tests have been added and/or updated

## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [x] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing