### PR TITLE
fix: peer reconciliation load all covalues

### DIFF
--- a/.changeset/peer-reconciliation-unmount-refactor.md
+++ b/.changeset/peer-reconciliation-unmount-refactor.md
@@ -1,0 +1,17 @@
+---
+"cojson": patch
+---
+
+Optimized peer reconciliation to prevent unnecessary data transfer on reconnect.
+
+**Key improvements:**
+- Added new CoValue states `garbageCollected` and `onlyKnownState` to distinguish between CoValues we actively used versus ones we just heard about
+- Garbage-collected CoValues now cache their `knownState` before unmounting, enabling diff-only sync on reconnect instead of full content transfer
+- Unknown CoValues (IDs we encountered but never loaded) are now skipped during peer reconciliation, preventing unnecessary LOAD requests
+- The `knownState()` method now returns the cached state for GC'd/onlyKnownState CoValues, simplifying sync logic across the codebase
+- When `getKnownStateFromStorage()` finds data, it marks the CoValue as `onlyKnownState` making it eligible for subscription restoration
+- Refactored unmount logic into `LocalNode.internalUnmountCoValue()` for efficient single-operation map updates when creating GC shells
+
+**Before:** Client reconnects → sends LOAD with empty state for all CoValues → server sends ALL content for every ID ever heard of
+
+**After:** Client reconnects → sends LOAD with cached knownState for GC'd CoValues → server sends only the diff; unknown CoValues are skipped entirely

--- a/.specs/peer-reconciliation-lazy-load/design.md
+++ b/.specs/peer-reconciliation-lazy-load/design.md
@@ -1,0 +1,862 @@
+# Design: Peer Reconciliation Lazy Load Optimization (v2)
+
+## Overview
+
+This design introduces explicit CoValue states (`garbageCollected` and `onlyKnownState`) to distinguish between CoValues we actually care about versus ones we just heard about. This prevents unnecessary data transfer during peer reconciliation by only restoring subscriptions for CoValues that were actively used.
+
+**Problem with current approach:**
+```
+Client reconnects → iterates ALL CoValues in memory → for unavailable ones, sends LOAD
+→ "unavailable" includes truly unknown CoValues we never cared about
+→ Server loads and sends ALL content for every ID we ever heard of
+```
+
+**Root cause:** The original design treated all "unavailable" CoValues the same, but they're actually different:
+
+| Type | Meaning | Has lastKnownState? | Optimization |
+|------|---------|---------------------|--------------|
+| **Unknown** | Just heard the ID, never had/wanted the data | ❌ No | **SKIPPED** - no LOAD sent during reconciliation |
+| **GarbageCollected** | Had data in memory, was actively used, then GC'd | ✅ Yes | Sends last known state → server sends diff only |
+| **OnlyKnownState** | Checked storage, have knownState saved, but not full content | ✅ Yes | Sends last known state → server sends diff only |
+
+**New behavior:**
+```
+Client reconnects → iterates all CoValues → checks loadingState:
+  - "available" → send LOAD with in-memory knownState
+  - "garbageCollected" → send LOAD with lastKnownState (prevents full retransfer!)
+  - "onlyKnownState" → send LOAD with lastKnownState (prevents full retransfer!)
+  - "unknown" → SKIP (don't send LOAD - we never cared about this CoValue)
+  - "unavailable"/"loading"/"errored" → send LOAD with empty knownState
+```
+
+**Key optimization:** GC'd and onlyKnownState CoValues now send their `lastKnownState`, enabling the server to send only the diff instead of all content.
+
+**Design simplification:** The `knownState()` method is updated to return the `lastKnownState` when available, so callers can simply use `knownState()` in all cases without needing separate handling for different states.
+
+## Integration with Lazy Storage Load
+
+This design integrates with the **lazy-storage-load** spec (`/.specs/lazy-storage-load/design.md`). The `onlyKnownState` state emerges naturally from the existing `getKnownStateFromStorage` API:
+
+- When `getKnownStateFromStorage` is called and **finds data in storage**:
+  - Cache the returned knownState in `lastKnownState`
+  - Mark the CoValue as `onlyKnownState`
+
+This creates two complementary paths to the same outcome:
+
+| Trigger | State Set | When it happens |
+|---------|-----------|-----------------|
+| `getKnownStateFromStorage` returns data | `onlyKnownState` | Server handles LOAD, checks storage for knownState |
+| `unmount()` during GC | `garbageCollected` | Client GC removes full content from memory |
+
+Both states have `lastKnownState` available, enabling synchronous access during peer reconciliation.
+
+## Architecture / Components
+
+### 1. loadingStatuses Unchanged
+
+**Location:** `packages/cojson/src/coValueCore/coValueCore.ts`
+
+The `loadingStatuses` map remains unchanged - it only tracks loading state from sources (storage, peers):
+
+```typescript
+private readonly loadingStatuses = new Map<
+  PeerID | "storage",
+  | {
+      type:
+        | "unknown"
+        | "pending"
+        | "available"
+        | "unavailable";
+    }
+  | {
+      type: "errored";
+      error: unknown;
+    }
+>();
+```
+
+**Note:** Both `garbageCollected` and `onlyKnownState` are tracked separately via `#lastKnownStateSource` (see Section 2) because they represent CoValue lifecycle states, not loading states from sources.
+
+### 2. New Fields for Last Known State
+
+**Location:** `packages/cojson/src/coValueCore/coValueCore.ts`
+
+When a CoValue becomes `garbageCollected` or `onlyKnownState`, we cache its `knownState` so we can use it synchronously during reconciliation without needing async storage lookups.
+
+```typescript
+// Tracks why we have lastKnownState (separate from loadingStatuses)
+// - "garbageCollected": was in memory, got GC'd
+// - "onlyKnownState": checked storage, found knownState, but didn't load full content
+#lastKnownStateSource?: "garbageCollected" | "onlyKnownState";
+
+// Cache the knownState when transitioning to garbageCollected/onlyKnownState
+#lastKnownState?: CoValueKnownState;
+```
+
+**Why separate from `loadingStatuses`:**
+- `loadingStatuses` tracks loading state from various **sources** (storage, peers)
+- `garbageCollected` and `onlyKnownState` are about the **CoValue's state** - whether we have partial knowledge
+- Keeping them separate maintains cleaner semantics and avoids confusion
+- Both states share the same behavior: we have `lastKnownState` but not full content
+
+The `knownState()` method is updated to use this cache (see Section 7), so callers can simply call `knownState()` without special handling.
+
+### 3. Modified `unmount()` Method
+
+**Location:** `packages/cojson/src/coValueCore/coValueCore.ts`
+
+Instead of just removing the CoValue from the map entirely, we delete it and replace it with a fresh "shell" CoValueCore in the `garbageCollected` state. This ensures proper cleanup of all internal state.
+
+**Current code (problematic):**
+```typescript
+unmount(): boolean {
+  // ... checks ...
+  this.counter.add(-1, { state: this.loadingState });
+  this.node.internalDeleteCoValue(this.id);  // Removes from map entirely!
+  return true;
+}
+```
+
+**New approach:**
+```typescript
+unmount(): boolean {
+  if (this.listeners.size > 0) {
+    return false;
+  }
+
+  for (const dependant of this.dependant) {
+    if (this.node.hasCoValue(dependant)) {
+      return false;
+    }
+  }
+
+  if (!this.node.syncManager.isSyncedToServerPeers(this.id)) {
+    return false;
+  }
+
+  // Cache the knownState before deleting
+  const lastKnownState = this.knownState();
+  
+  this.counter.add(-1, { state: this.loadingState });
+  
+  // Delete the old CoValueCore (this also calls storage?.onCoValueUnmounted)
+  this.node.internalDeleteCoValue(this.id);
+  
+  // Create a new "shell" CoValueCore in garbageCollected state
+  this.node.createGarbageCollectedCoValue(this.id, lastKnownState);
+
+  return true;
+}
+```
+
+### 4. New Method in LocalNode: `createGarbageCollectedCoValue`
+
+**Location:** `packages/cojson/src/localNode.ts`
+
+```typescript
+/**
+ * Create a CoValueCore in the garbageCollected state.
+ * Used after unmounting to keep track of CoValues we care about.
+ */
+createGarbageCollectedCoValue(id: RawCoID, lastKnownState: CoValueKnownState) {
+  const coValue = new CoValueCore(id, this);
+  coValue.setGarbageCollectedState(lastKnownState);
+  this.coValues.set(id, coValue);
+  return coValue;
+}
+```
+
+### 5. New Method in CoValueCore: `setGarbageCollectedState`
+
+**Location:** `packages/cojson/src/coValueCore/coValueCore.ts`
+
+```typescript
+/**
+ * Initialize this CoValueCore as a garbageCollected shell.
+ * Called when creating a replacement CoValueCore after unmounting.
+ */
+setGarbageCollectedState(lastKnownState: CoValueKnownState) {
+  this.#lastKnownStateSource = "garbageCollected";
+  this.#lastKnownState = lastKnownState;
+  this.updateCounter(null);
+}
+```
+
+**Why use `#lastKnownStateSource` instead of `loadingStatuses`:**
+- `loadingStatuses` is for tracking loading state from sources (storage, peers)
+- `garbageCollected` is a lifecycle state - the CoValue existed, was used, then GC'd
+- This separation keeps the semantics clean and avoids confusion
+
+**Why delete and create new CoValueCore:**
+- CoValueCore has many internal fields (listeners, loadingStatuses for peers, dependencies, streaming state, etc.)
+- Just nulling `_verified` doesn't clean up all this state
+- A fresh CoValueCore starts with clean internal state
+- Only preserves what we need: ID + lastKnownState + lastKnownStateSource
+
+### 6. Updated `loadingState` Getter
+
+**Location:** `packages/cojson/src/coValueCore/coValueCore.ts`
+
+The getter is updated to handle the new states with correct priority ordering:
+
+```typescript
+get loadingState() {
+  if (this.verified) {
+    return "available";
+  }
+
+  // Check for pending peers FIRST - loading takes priority over other states
+  for (const peer of this.loadingStatuses.values()) {
+    if (peer.type === "pending") {
+      return "loading";
+    }
+  }
+
+  // Check for lastKnownStateSource (garbageCollected or onlyKnownState)
+  if (this.#lastKnownStateSource) {
+    return this.#lastKnownStateSource;
+  }
+
+  if (this.loadingStatuses.size === 0) {
+    return "unknown";
+  }
+
+  for (const peer of this.loadingStatuses.values()) {
+    if (peer.type === "unknown") {
+      return "unknown";
+    }
+  }
+
+  return "unavailable";
+}
+```
+
+**Important:** The `pending` check comes FIRST. This ensures that if a `garbageCollected` or `onlyKnownState` CoValue starts loading from a peer, it transitions to `"loading"` state correctly.
+
+### 7. Updated `knownState()` Method
+
+**Location:** `packages/cojson/src/coValueCore/coValueCore.ts`
+
+The `knownState()` method is updated to use `#lastKnownState` when the CoValue is in `garbageCollected` or `onlyKnownState` state. This simplifies the API - callers can always use `knownState()` to get the best known state.
+
+```typescript
+/**
+ * Returns the known state of the CoValue.
+ * 
+ * The return value identity is going to be stable as long as the CoValue is not modified.
+ * On change the knownState is invalidated and a new object is returned.
+ * 
+ * For garbageCollected/onlyKnownState CoValues, returns the #lastKnownState.
+ */
+knownState(): CoValueKnownState {
+  // 1. If we have verified content in memory, use that (authoritative)
+  if (this.verified) {
+    return this.verified.immutableKnownState();
+  }
+  
+  // 2. If we have last known state (GC'd or onlyKnownState), use that
+  if (this.#lastKnownState) {
+    return this.#lastKnownState;
+  }
+  
+  // 3. Fallback to empty state (truly unknown CoValue)
+  return emptyKnownState(this.id);
+}
+```
+
+**Benefits of this approach:**
+- Single method to get known state - no need for separate accessor methods
+- Callers don't need special handling for different states
+- Semantic meaning: "knownState" = "best knowledge we have about this CoValue"
+- Simpler code in `startPeerReconciliation`, `internalLoadFromPeer`, etc.
+
+### 8. Cleanup When Transitioning to Available
+
+**Location:** `packages/cojson/src/coValueCore/coValueCore.ts`
+
+When a `garbageCollected` or `onlyKnownState` CoValue becomes fully available, we need to clean up the cached state to avoid memory waste.
+
+```typescript
+/**
+ * Clean up lastKnownState when CoValue becomes available.
+ * Called after the CoValue transitions from garbageCollected/onlyKnownState to available.
+ */
+private cleanupLastKnownState() {
+  // Clear both fields - in-memory verified state is now authoritative
+  this.#lastKnownStateSource = undefined;
+  this.#lastKnownState = undefined;
+}
+```
+
+**Where to call it:** In `markFoundInPeer` after the CoValue becomes available:
+
+```typescript
+markFoundInPeer(peerId: PeerID, previousState: string) {
+  this.loadingStatuses.set(peerId, { type: "available" });
+  this.updateCounter(previousState);
+  this.scheduleNotifyUpdate();
+  
+  // Clean up if transitioning from garbageCollected/onlyKnownState
+  if (this.isAvailable()) {
+    this.cleanupLastKnownState();
+  }
+}
+```
+
+**Why this matters:**
+- Without cleanup, `#lastKnownState` stays in memory unnecessarily
+- Proper cleanup ensures clean state transitions and predictable behavior
+
+### 9. Modified `getKnownStateFromStorage` Method
+
+**Location:** `packages/cojson/src/coValueCore/coValueCore.ts`
+
+The existing `getKnownStateFromStorage` method (from lazy-storage-load spec) is modified to set `onlyKnownState` state when it finds data:
+
+```typescript
+/**
+ * Lazily load only the knownState from storage without loading full transaction data.
+ * If found, marks the CoValue as onlyKnownState and caches the knownState.
+ */
+getKnownStateFromStorage(done: (knownState: CoValueKnownState | undefined) => void) {
+  if (!this.node.storage) {
+    done(undefined);
+    return;
+  }
+
+  // If already available in memory or have last known state, return knownState()
+  // (knownState() handles both cases - verified content or lastKnownState)
+  const state = this.loadingState;
+  if (this.isAvailable() || state === "garbageCollected" || state === "onlyKnownState") {
+    done(this.knownState());
+    return;
+  }
+
+  // Delegate to storage - caching is handled at storage level
+  this.node.storage.loadKnownState(this.id, (knownState) => {
+    if (knownState) {
+      // Cache the knownState and mark as onlyKnownState
+      const previousState = this.loadingState;
+      this.#lastKnownStateSource = "onlyKnownState";
+      this.#lastKnownState = knownState;
+      this.updateCounter(previousState);
+    }
+    done(knownState);
+  });
+}
+```
+
+**Key behaviors:**
+1. If available in memory → `knownState()` returns verified state
+2. If already `garbageCollected` or `onlyKnownState` → `knownState()` returns `lastKnownState` (no storage lookup)
+3. Otherwise → loads from storage, caches result, sets `onlyKnownState` via `#lastKnownStateSource`
+
+This creates a natural integration point: any code path that calls `getKnownStateFromStorage` (e.g., server handling LOAD requests) will automatically mark the CoValue as `onlyKnownState`, making it eligible for subscription restoration on reconnect.
+
+### 10. Updated `startPeerReconciliation` Method
+
+**Location:** `packages/cojson/src/sync.ts`
+
+The key change: for `garbageCollected` and `onlyKnownState` CoValues, send LOAD with `lastKnownState` instead of empty state. Since `knownState()` now returns `lastKnownState` when available, the code is simplified.
+
+```typescript
+startPeerReconciliation(peer: PeerState) {
+  if (isPersistentServerPeer(peer)) {
+    this.resumeUnsyncedCoValues().catch((error) => {
+      logger.warn("Failed to resume unsynced CoValues:", error);
+    });
+  }
+
+  const coValuesOrderedByDependency: CoValueCore[] = [];
+
+  const seen = new Set<string>();
+  const buildOrderedCoValueList = (coValue: CoValueCore) => {
+    // ... unchanged ...
+  };
+
+  for (const coValue of this.local.allCoValues()) {
+    const state = coValue.loadingState;
+
+    if (coValue.isAvailable()) {
+      // In memory - build ordered list for dependency-aware sending
+      buildOrderedCoValueList(coValue);
+    } else if (state === "unknown") {
+      // Skip unknown CoValues - we never tried to load them, so don't
+      // restore a subscription we never had. This prevents loading
+      // content for CoValues we don't actually care about.
+      continue;
+    } else if (!peer.loadRequestSent.has(coValue.id)) {
+      // For unavailable/loading/errored states:
+      // knownState() returns empty state
+      peer.trackLoadRequestSent(coValue.id);
+      this.trySendToPeer(peer, {
+        action: "load",
+        ...coValue.knownState(),
+      });
+    }
+
+    // Fill the missing known states with empty known states
+    if (!peer.getKnownState(coValue.id)) {
+      peer.setKnownState(coValue.id, "empty");
+    }
+  }
+
+  // Available CoValues - send in dependency order (unchanged)
+  for (const coValue of coValuesOrderedByDependency) {
+    peer.trackLoadRequestSent(coValue.id);
+    this.trySendToPeer(peer, {
+      action: "load",
+      ...coValue.knownState(),
+    });
+  }
+}
+```
+
+**Simplified behavior (thanks to updated `knownState()`):**
+- `available` → `knownState()` returns in-memory verified state
+- `garbageCollected` or `onlyKnownState` → `knownState()` returns `lastKnownState` (the key optimization!)
+- `unknown` → **SKIPPED** (no LOAD sent - we never cared about this CoValue)
+- Other states (`unavailable`, `loading`, `errored`) → `knownState()` returns empty state
+
+**Key insight:** Unknown CoValues are ones we only "heard about" (e.g., saw the ID in a reference) but never actually tried to load. Sending LOAD requests for them during reconciliation would cause unnecessary data transfer for content we don't actually need.
+
+### 11. Updated `hasCoValueLoaded` in LocalNode
+
+**Location:** `packages/cojson/src/localNode.ts`
+
+The `hasCoValueLoaded` method must exclude `garbageCollected` and `onlyKnownState` states since they don't have actual content loaded:
+
+```typescript
+hasCoValueLoaded(id: RawCoID): boolean {
+  const coValue = this.coValues.get(id);
+  if (!coValue) {
+    return false;
+  }
+
+  const state = coValue.loadingState;
+  // garbageCollected and onlyKnownState shells don't have actual content loaded
+  return (
+    state !== "unknown" &&
+    state !== "garbageCollected" &&
+    state !== "onlyKnownState"
+  );
+}
+```
+
+### 12. Updated `loadFromStorageOrPeers` in CoValueCore
+
+**Location:** `packages/cojson/src/coValueCore/coValueCore.ts`
+
+The method is updated to properly handle the new states:
+
+```typescript
+loadFromStorageOrPeers(peers: PeerState[], done?: (found: boolean) => void) {
+  // ... storage check ...
+
+  const currentState = this.loadingState;
+
+  if (
+    currentState !== "unknown" &&
+    currentState !== "garbageCollected" &&
+    currentState !== "onlyKnownState"
+  ) {
+    done?.(currentState === "available");
+    return;
+  }
+
+  // ... continue with loading ...
+}
+```
+
+**Why:** A `garbageCollected` or `onlyKnownState` CoValue should proceed to load from storage/peers since it doesn't have full content in memory.
+
+### 13. Updated `loadFromPeers` in CoValueCore
+
+**Location:** `packages/cojson/src/coValueCore/coValueCore.ts`
+
+The method is updated to allow loading from peers when state is `garbageCollected` or `onlyKnownState`:
+
+```typescript
+for (const peer of peers) {
+  const currentState = this.getLoadingStateForPeer(peer.id);
+
+  if (
+    currentState === "unknown" ||
+    currentState === "unavailable" ||
+    currentState === "garbageCollected" ||
+    currentState === "onlyKnownState"
+  ) {
+    this.markPending(peer.id);
+    this.internalLoadFromPeer(peer);
+  }
+}
+```
+
+### 14. Updated `internalLoadFromPeer` (simplified)
+
+**Location:** `packages/cojson/src/coValueCore/coValueCore.ts`
+
+When sending LOAD requests, `internalLoadFromPeer` now simply uses `knownState()` which handles all cases:
+
+```typescript
+if (!peer.closed) {
+  // knownState() returns:
+  // - verified state if available in memory
+  // - lastKnownState if garbageCollected/onlyKnownState
+  // - empty state otherwise
+  peer.pushOutgoingMessage({
+    action: "load",
+    ...this.knownState(),
+  });
+  peer.trackLoadRequestSent(this.id);
+}
+```
+
+**Why this works:** With the updated `knownState()` method, it automatically returns the `lastKnownState` for garbageCollected/onlyKnownState shells. No special handling needed.
+
+### 15. Updated `internalLoadFromPeer` completion check
+
+**Location:** `packages/cojson/src/coValueCore/coValueCore.ts`
+
+The subscription in `internalLoadFromPeer` needs to recognize `garbageCollected` and `onlyKnownState` as terminal states:
+
+```typescript
+if (
+  state.isAvailable() ||
+  peerState === "available" ||
+  peerState === "errored" ||
+  peerState === "unavailable" ||
+  peerState === "garbageCollected" ||
+  peerState === "onlyKnownState"
+) {
+  unsubscribe();
+  removeCloseListener?.();
+}
+```
+
+### 16. Updated `loadCoValue` in LocalNode
+
+**Location:** `packages/cojson/src/localNode.ts`
+
+The method is updated to treat `garbageCollected` and `onlyKnownState` as states that need loading:
+
+```typescript
+if (
+  coValue.loadingState === "unknown" ||
+  coValue.loadingState === "unavailable" ||
+  coValue.loadingState === "garbageCollected" ||
+  coValue.loadingState === "onlyKnownState"
+) {
+  const peers = this.syncManager.getServerPeers(id, skipLoadingFromPeer);
+  // ... load from storage and peers ...
+}
+```
+
+## Data Model
+
+### New Fields in CoValueCore
+
+```typescript
+class CoValueCore {
+  // Existing - tracks loading state from sources (storage, peers)
+  private readonly loadingStatuses: Map<...>;
+  
+  // NEW: Tracks why we have lastKnownState (lifecycle state, not loading state)
+  #lastKnownStateSource?: "garbageCollected" | "onlyKnownState";
+  
+  // NEW: Cached knownState for garbageCollected/onlyKnownState CoValues
+  #lastKnownState?: CoValueKnownState;
+}
+```
+
+### State Transitions
+
+```
+                    ┌─────────────┐
+                    │   unknown   │ ← Initial state (just heard the ID)
+                    └──────┬──────┘
+                           │
+           ┌───────────────┼───────────────┐
+           │               │               │
+           │ getKnownState │               │ loadFromPeer/loadFromStorage
+           │ FromStorage   │               │
+           │ (found)       │               ▼
+           │               │        ┌─────────────┐
+           │               │        │   loading   │
+           │               │        └──────┬──────┘
+           │               │   ┌───────────┼───────────┐
+           ▼               │   ▼           ▼           ▼
+    ┌─────────────────┐    │ ┌─────────┐ ┌───────────┐ ┌─────────┐
+    │ onlyKnownState │    │ │available│ │unavailable│ │ errored │
+    └────────┬────────┘    │ └────┬────┘ └───────────┘ └─────────┘
+             │             │      │
+             │             │      │ GC unmount
+             │ reload      │      ▼
+             │             │ ┌───────────────────┐
+             │             │ │ garbageCollected  │ ← Keeps lastKnownState
+             │             │ └─────────┬─────────┘
+             │             │           │
+             │             │           │ reload
+             ▼             ▼           ▼
+           ┌─────────────────────────────┐
+           │          available          │
+           └─────────────────────────────┘
+```
+
+**Key transitions:**
+- `unknown` → `onlyKnownState`: When `getKnownStateFromStorage()` finds data in storage
+- `available` → `garbageCollected`: When GC unmounts a CoValue (caches knownState first)
+- Both `onlyKnownState` and `garbageCollected` → `available`: When fully loaded/reloaded
+
+### Reload Cycle for GarbageCollected CoValues
+
+When a `garbageCollected` CoValue is reloaded, the **same shell CoValueCore is reused** (not replaced). Here's the detailed flow:
+
+1. **GC unmounts the CoValue** (`unmount()` called):
+   - Original CoValueCore is deleted via `internalDeleteCoValue()`
+   - New shell CoValueCore is created via `createGarbageCollectedCoValue()`
+   - Shell has: `#lastKnownStateSource = "garbageCollected"`, `#lastKnownState` set
+
+2. **User requests the CoValue** (`loadCoValue()` or subscription):
+   - `loadingState` is `"garbageCollected"` → triggers load from storage/peers
+   - `loadFromPeers()` is called → marks peer as `pending`
+   - `loadingState` transitions to `"loading"` (pending check takes priority)
+
+3. **Content arrives from peer/storage**:
+   - `handleNewContent()` processes transactions
+   - `_verified` is populated with content
+   - `markFoundInPeer()` is called
+
+4. **Cleanup on becoming available** (`markFoundInPeer()`):
+   - Sets peer status to `available`
+   - Calls `cleanupLastKnownState()` which:
+     - Clears `#lastKnownStateSource` (no longer needed)
+     - Clears `#lastKnownState` (no longer needed)
+   - `loadingState` now returns `"available"` (because `verified` is set)
+
+5. **CoValue is fully available**:
+   - Same CoValueCore instance, now with full content
+   - Can be GC'd again later (clean cycle)
+
+```
+Shell CoValueCore                    After Reload
+┌─────────────────────────────┐     ┌─────────────────────────────┐
+│ _verified: null             │     │ _verified: {...}            │
+│ #lastKnownStateSource: "gc" │ ──> │ #lastKnownStateSource: null │
+│ #lastKnownState: {...}      │     │ #lastKnownState: null       │
+│ loadingStatuses: (empty)    │     │ loadingStatuses:            │
+│                             │     │   peer: "available"         │
+└─────────────────────────────┘     └─────────────────────────────┘
+```
+
+**Important:** The shell is NOT replaced during reload. The same CoValueCore instance is populated with content. This is efficient because:
+- No need to update references elsewhere
+- Listeners attached to the shell continue to work
+- The CoValue ID mapping in `node.coValues` stays stable
+
+## Sequence Diagrams
+
+### Scenario 1: GC'd CoValue Restoration
+
+```
+Client                    GC                      Server
+  |                        |                          |
+  |  [CoValue available]   |                          |
+  |                        |                          |
+  |  [no listeners]        |                          |
+  |<-- unmount() ----------|                          |
+  |                        |                          |
+  |  [state = garbageCollected]                       |
+  |  [lastKnownState saved: header/1]               |
+  |                        |                          |
+  |  [later: reconnect]    |                          |
+  |                        |                          |
+  |  [startPeerReconciliation]                        |
+  |                        |                          |
+  |  if garbageCollected:                             |
+  |-- LOAD (sessions: header/1) -------------------->|
+  |                        |   [compare knownStates]  |
+  |                        |   [server also has       |
+  |                        |    header/1, no diff]    |
+  |<-- KNOWN (sessions: header/1) -------------------|
+  |                        |                          |
+```
+
+**Before this change:** Client would send `LOAD (sessions: empty)`, causing server to send ALL content.
+
+**After this change:** Client sends `LOAD (sessions: header/1)`, server responds with KNOWN (no data transfer needed).
+
+### Scenario 2: Server-side `onlyKnownState` via getKnownStateFromStorage
+
+```
+Client                    Server                  Storage
+  |                          |                        |
+  |-- LOAD (knownState) ---->|                        |
+  |                          |                        |
+  |                          |  [CoValue not in memory]
+  |                          |                        |
+  |                          |-- getKnownStateFromStorage -->
+  |                          |                        |
+  |                          |<-- storageKnownState --|
+  |                          |                        |
+  |                          |  [state = onlyKnownState]
+  |                          |  [lastKnownState saved]
+  |                          |                        |
+  |                          |  [compare knownStates] |
+  |                          |                        |
+  |<-- KNOWN (or CONTENT) ---|                        |
+  |                          |                        |
+  |  [later: server reconnects to upstream]           |
+  |                          |                        |
+  |                          |  [startPeerReconciliation]
+  |                          |                        |
+  |                          |  if onlyKnownState:   |
+  |                          |-- LOAD (lastKnownState) ->
+```
+
+## Error Handling
+
+### Missing lastKnownState
+
+With the updated `knownState()` method, there's no need for explicit fallback handling. The method naturally handles all cases:
+
+```typescript
+knownState(): CoValueKnownState {
+  if (this.verified) {
+    return this.verified.immutableKnownState();
+  }
+  if (this.#lastKnownState) {
+    return this.#lastKnownState;
+  }
+  return emptyKnownState(this.id);  // Graceful fallback
+}
+```
+
+If `#lastKnownState` is somehow undefined for a `garbageCollected` CoValue (shouldn't happen), `knownState()` returns an empty state automatically. This degrades gracefully to the old behavior (server sends all content).
+
+### Memory Considerations
+
+Keeping CoValueCore instances in memory after GC uses minimal memory:
+- Only the shell remains (no verified content)
+- `#lastKnownState` is small (ID + header boolean + session counts)
+- `#lastKnownStateSource` is a simple string
+- Trade-off: small memory cost vs. preventing massive unnecessary loads
+
+## Testing Strategy
+
+### Implemented Tests
+
+Tests are located in `packages/cojson/src/tests/sync.peerReconciliation.test.ts`:
+
+#### 1. `sends lastKnownState for garbageCollected CoValues during reconciliation`
+
+**Setup:**
+- Client with storage and GC enabled
+- Create group and map, sync to server
+- Disconnect, then run GC to unmount CoValues
+
+**Assertions:**
+- `loadingState` is `"garbageCollected"` after GC
+- `knownState()` returns the `lastKnownState` from before GC (not empty)
+- On reconnect, LOAD is sent with last known sessions (e.g., `header/1`) not empty
+- Server responds with KNOWN (no content transfer needed)
+
+**Expected message flow:**
+```
+client -> server | LOAD Map sessions: header/1
+client -> server | LOAD Group sessions: header/3
+server -> client | KNOWN Group sessions: header/3
+server -> client | KNOWN Map sessions: header/1
+```
+
+#### 2. `unknown CoValues are skipped during reconciliation`
+
+**Setup:**
+- Create a fresh client that only calls `getCoValue(id)` without loading (i.e., just heard about the ID)
+
+**Assertions:**
+- `loadingState` is `"unknown"`
+- No LOAD messages are sent for this CoValue during peer reconciliation
+- The CoValue ID is skipped entirely (not tracked in `loadRequestSent`)
+
+**Rationale:** Unknown CoValues represent IDs we encountered (e.g., in references) but never actively tried to load. Sending LOAD requests for them during reconciliation would transfer unnecessary data for content we don't actually care about.
+
+#### 3. `garbageCollected CoValues restore subscription with minimal data transfer`
+
+**Setup:**
+- Client and server both have the same CoValue data
+- Client GCs the CoValue, then reconnects
+
+**Assertions:**
+- Client sends LOAD with `lastKnownState`
+- Server responds with KNOWN (not CONTENT) since both have same data
+- No actual content is transferred
+
+### Updated Existing Tests
+
+In `packages/cojson/src/tests/sync.garbageCollection.test.ts`:
+
+The test for "syncing after GC runs" was updated to expect:
+- `LOAD Map sessions: header/1` (last known state) instead of `LOAD Map sessions: empty`
+- Server uses `GET_KNOWN_STATE` instead of full `LOAD` when responding
+
+### Test File Locations
+
+- Peer reconciliation tests: `packages/cojson/src/tests/sync.peerReconciliation.test.ts`
+- GC-related tests: `packages/cojson/src/tests/sync.garbageCollection.test.ts`
+
+## Implementation Status
+
+The following components have been implemented:
+
+| Component | Status | Location |
+|-----------|--------|----------|
+| `#lastKnownStateSource` field | ✅ Done | `coValueCore.ts` |
+| `#lastKnownState` field | ✅ Done | `coValueCore.ts` |
+| `loadingState` getter update | ✅ Done | `coValueCore.ts` |
+| `knownState()` uses `#lastKnownState` | ✅ Done | `coValueCore.ts` |
+| `setGarbageCollectedState()` method | ✅ Done | `coValueCore.ts` |
+| `cleanupLastKnownState()` method | ✅ Done | `coValueCore.ts` |
+| `unmount()` creates GC shell | ✅ Done | `coValueCore.ts` |
+| `createGarbageCollectedCoValue()` | ✅ Done | `localNode.ts` |
+| `hasCoValueLoaded()` excludes GC states | ✅ Done | `localNode.ts` |
+| `loadCoValue()` handles GC states | ✅ Done | `localNode.ts` |
+| `loadFromStorageOrPeers()` handles GC states | ✅ Done | `coValueCore.ts` |
+| `loadFromPeers()` handles GC states | ✅ Done | `coValueCore.ts` |
+| `internalLoadFromPeer()` uses `knownState()` | ✅ Done | `coValueCore.ts` |
+| `getKnownStateFromStorage()` sets `onlyKnownState` | ✅ Done | `coValueCore.ts` |
+| `startPeerReconciliation()` uses `knownState()` | ✅ Done | `sync.ts` |
+| Unit tests | ✅ Done | `sync.peerReconciliation.test.ts` |
+
+## Migration / Compatibility
+
+This is a behavioral change that should be transparent to users:
+- No API changes
+- CoValues that were previously loaded unnecessarily will no longer be loaded
+- Existing subscriptions continue to work normally
+
+## Future Considerations
+
+### Persistent Subscription Tracking
+
+This design solves two in-session problems:
+1. **GC'd values** - CoValues that were in memory but got garbage collected
+2. **PartiallyLoaded values** - CoValues where we checked storage but didn't fully load
+
+For cross-restart persistence:
+- Could persist `garbageCollected` and `onlyKnownState` CoValue IDs to storage
+- On restart, read the list and restore CoValueCores with their last known states
+- This would enable true subscription restoration across app restarts
+
+### Memory Pressure
+
+If many CoValues are GC'd or onlyKnownState but kept as shells:
+- Could implement a second-level GC that removes very old shells
+- Or limit the number of entries with last known states
+- Priority should be given to `garbageCollected` (actively used) over `onlyKnownState` (only checked)
+
+### State Cleanup
+
+When a `onlyKnownState` or `garbageCollected` CoValue becomes fully `available`:
+- Clear `#lastKnownStateSource` (no longer needed)
+- Clear `#lastKnownState` (no longer needed, in-memory state is authoritative)

--- a/.specs/peer-reconciliation-lazy-load/requirements.md
+++ b/.specs/peer-reconciliation-lazy-load/requirements.md
@@ -1,0 +1,64 @@
+# Peer Reconciliation Lazy Load Optimization
+
+## Introduction
+
+When a client reconnects to a server peer, the `startPeerReconciliation` method iterates through all local CoValues and sends `LOAD` requests to synchronize state. Currently, for CoValues that are "unavailable" (lazy-loaded - known to the node but not loaded into memory), the system sends load requests with an **empty known state** (`sessions: {}`).
+
+This is problematic because:
+1. The server interprets an empty known state as "client has nothing"
+2. The server sends **all content** for that CoValue
+3. But the client may already have this data in local storage - it just hasn't loaded it into memory yet
+
+This causes unnecessary bandwidth usage and server load, especially for applications with many lazy-loaded CoValues that reconnect frequently.
+
+## User Stories
+
+### US-1: Check local storage before sending load requests during reconciliation
+
+> **As a** Jazz application user  
+> **I want** the client to check local storage for lazy-loaded CoValues during peer reconciliation  
+> **So that** reconnections don't cause unnecessary data transfer when I already have the data locally.
+
+**Acceptance Criteria:**
+
+- **When** peer reconciliation runs for an unavailable (lazy-loaded) CoValue:
+  - The system **shall** first check local storage for the CoValue's known state.
+- **If** the CoValue exists in local storage:
+  - The system **shall** send the load request with the known state from storage (not empty).
+- **If** the CoValue does not exist in local storage:
+  - The system **shall** send the load request with empty known state (current behavior).
+- **When** the CoValue is already available in memory:
+  - The system **shall** behave as before (send current in-memory known state).
+
+---
+
+### US-2: Maintain dependency ordering during async storage checks
+
+> **As a** Jazz developer  
+> **I want** peer reconciliation to maintain correct dependency ordering even with async storage checks  
+> **So that** CoValues are still synced in the correct order (dependencies before dependents).
+
+**Acceptance Criteria:**
+
+- **When** sending load requests during peer reconciliation:
+  - The system **shall** preserve the dependency ordering (dependencies sent before dependents).
+- **If** storage checks are async:
+  - The system **shall** not block the entire reconciliation process.
+  - The system **shall** ensure load requests are sent in dependency order within their category.
+
+---
+
+### US-3: Handle concurrent reconciliation and storage loads gracefully
+
+> **As a** Jazz developer  
+> **I want** the system to handle race conditions between reconciliation and ongoing storage operations  
+> **So that** the sync state remains consistent.
+
+**Acceptance Criteria:**
+
+- **If** a CoValue becomes available in memory while waiting for storage check:
+  - The system **shall** use the in-memory known state instead.
+- **If** multiple peer reconnections happen concurrently:
+  - The system **shall** not send duplicate or conflicting load requests.
+- **When** storage check fails:
+  - The system **shall** fall back to current behavior (empty known state) and log a warning.

--- a/.specs/peer-reconciliation-lazy-load/tasks.md
+++ b/.specs/peer-reconciliation-lazy-load/tasks.md
@@ -1,0 +1,86 @@
+# Implementation Tasks (v2)
+
+This is the updated task list for the new approach using explicit `garbageCollected` and `onlyKnownState` states.
+
+## Phase 1: Core State Changes
+
+- [x] **Task 1**: Add new states to `loadingStatuses` type in `CoValueCore`
+  - Location: `packages/cojson/src/coValueCore/coValueCore.ts`
+  - Add `"garbageCollected"` and `"onlyKnownState"` to the type union
+  - Add `lastKnownState?: CoValueKnownState` field to store the knownState
+
+- [x] **Task 2**: Update `loadingState` getter to handle new states
+  - Location: `packages/cojson/src/coValueCore/coValueCore.ts`
+  - Check storage status for `garbageCollected` or `onlyKnownState`
+  - Return the appropriate state string
+  - **Note:** `pending` check comes first so loading state is correctly detected
+
+- [x] **Task 3**: Update `knownState()` method to use `lastKnownState`
+  - Location: `packages/cojson/src/coValueCore/coValueCore.ts`
+  - Returns `lastKnownState` for `garbageCollected` or `onlyKnownState` CoValues
+  - Returns empty state for truly unknown CoValues
+
+- [x] **Task 4**: Modify `getKnownStateFromStorage` to set `onlyKnownState`
+  - Location: `packages/cojson/src/coValueCore/coValueCore.ts`
+  - When storage returns a knownState:
+    - Set `lastKnownState = knownState`
+    - Set storage status to `{ type: "onlyKnownState" }`
+    - Call `updateCounter(previousState)`
+  - Also returns last known state if already in `garbageCollected` or `onlyKnownState`
+
+- [x] **Task 5**: Add `cleanupLastKnownState()` method for transition to available
+  - Location: `packages/cojson/src/coValueCore/coValueCore.ts`
+  - Create private method that:
+    - Checks if storage status is `garbageCollected` or `onlyKnownState`
+    - Clears `lastKnownState` (set to undefined)
+    - Deletes the storage status entry from `loadingStatuses`
+  - Call this method in `markFoundInPeer` when `isAvailable()` returns true
+
+## Phase 2: GC Changes
+
+- [x] **Task 6**: Add `createGarbageCollectedCoValue` method to `LocalNode`
+  - Location: `packages/cojson/src/localNode.ts`
+  - Create a new CoValueCore with the given ID
+  - Call `setGarbageCollectedState` with the last known state
+  - Add it to the `coValues` map
+
+- [x] **Task 7**: Add `setGarbageCollectedState` method to `CoValueCore`
+  - Location: `packages/cojson/src/coValueCore/coValueCore.ts`
+  - Set `lastKnownState` to the provided value
+  - Set storage status to `{ type: "garbageCollected" }`
+  - Call `updateCounter(null)` to track metrics
+
+- [x] **Task 8**: Modify `unmount()` to delete and replace with garbageCollected shell
+  - Location: `packages/cojson/src/coValueCore/coValueCore.ts`
+  - Cache `knownState()` before deleting
+  - Call `internalDeleteCoValue` to remove the old CoValueCore
+  - Call `node.createGarbageCollectedCoValue(id, lastKnownState)` to create the shell
+  - **Note:** `storage?.onCoValueUnmounted` is called within `internalDeleteCoValue`
+
+## Phase 3: Reconciliation Changes
+
+- [x] **Task 9**: Update `startPeerReconciliation` to use `lastKnownState` for GC'd CoValues
+  - Location: `packages/cojson/src/sync.ts`
+  - Check `loadingState` for each CoValue:
+    - `"available"` → build ordered list (existing behavior)
+    - `"garbageCollected"` or `"onlyKnownState"` → send LOAD with `lastKnownState`
+    - Other states → send LOAD with empty state (existing behavior)
+
+- [x] **Task 10**: Update related loading methods
+  - `loadFromStorageOrPeers()` handles `garbageCollected`/`onlyKnownState`
+  - `loadFromPeers()` handles `garbageCollected`/`onlyKnownState`
+  - `internalLoadFromPeer()` recognizes new states as terminal
+  - `loadCoValue()` in LocalNode treats new states as needing load
+  - `hasCoValueLoaded()` excludes new states (no actual content loaded)
+
+## Phase 4: Testing
+
+- [x] **Task 11**: Peer reconciliation tests for garbageCollected CoValues
+  - Location: `packages/cojson/src/tests/sync.peerReconciliation.test.ts`
+  - Test: `sends lastKnownState for garbageCollected CoValues during reconciliation`
+  - Test: `unknown CoValues are skipped during reconciliation`
+  - Test: `garbageCollected CoValues restore subscription with minimal data transfer`
+
+- [x] **Task 12**: Update existing GC tests
+  - Location: `packages/cojson/src/tests/sync.garbageCollection.test.ts`
+  - Updated snapshot expectations for new behavior (lastKnownState sent instead of empty)

--- a/packages/cojson/src/GarbageCollector.ts
+++ b/packages/cojson/src/GarbageCollector.ts
@@ -1,6 +1,7 @@
 import { CoValueCore } from "./coValueCore/coValueCore.js";
 import { GARBAGE_COLLECTOR_CONFIG } from "./config.js";
 import { RawCoID } from "./ids.js";
+import type { LocalNode } from "./localNode.js";
 
 /**
  * TTL-based garbage collector for removing unused CoValues from memory.
@@ -8,7 +9,7 @@ import { RawCoID } from "./ids.js";
 export class GarbageCollector {
   private readonly interval: ReturnType<typeof setInterval>;
 
-  constructor(private readonly coValues: Map<RawCoID, CoValueCore>) {
+  constructor(private readonly node: LocalNode) {
     this.interval = setInterval(() => {
       this.collect();
     }, GARBAGE_COLLECTOR_CONFIG.INTERVAL);
@@ -26,7 +27,7 @@ export class GarbageCollector {
 
   collect() {
     const currentTime = this.getCurrentTime();
-    for (const coValue of this.coValues.values()) {
+    for (const coValue of this.node.allCoValues()) {
       const { verified } = coValue;
 
       if (!verified?.lastAccessed) {
@@ -36,7 +37,7 @@ export class GarbageCollector {
       const timeSinceLastAccessed = currentTime - verified.lastAccessed;
 
       if (timeSinceLastAccessed > GARBAGE_COLLECTOR_CONFIG.MAX_AGE) {
-        coValue.unmount();
+        this.node.internalUnmountCoValue(coValue.id);
       }
     }
   }

--- a/packages/cojson/src/coValueCore/coValueCore.ts
+++ b/packages/cojson/src/coValueCore/coValueCore.ts
@@ -282,6 +282,15 @@ export class CoValueCore {
       }
   >();
 
+  // Tracks why we have lastKnownState (separate from loadingStatuses)
+  // - "garbageCollected": was in memory, got GC'd
+  // - "onlyKnownState": checked storage, found knownState, but didn't load full content
+  #lastKnownStateSource?: "garbageCollected" | "onlyKnownState";
+
+  // Cache the knownState when transitioning to garbageCollected/onlyKnownState
+  // Used during peer reconciliation to send accurate LOAD requests
+  #lastKnownState?: CoValueKnownState;
+
   // cached state and listeners
   private _cachedContent?: RawCoValue;
   readonly listeners: Set<(core: CoValueCore, unsub: () => void) => void> =
@@ -308,14 +317,26 @@ export class CoValueCore {
   get loadingState() {
     if (this.verified) {
       return "available";
-    } else if (this.loadingStatuses.size === 0) {
+    }
+
+    // Check for pending peers FIRST - loading takes priority over other states
+    for (const peer of this.loadingStatuses.values()) {
+      if (peer.type === "pending") {
+        return "loading";
+      }
+    }
+
+    // Check for lastKnownStateSource (garbageCollected or onlyKnownState)
+    if (this.#lastKnownStateSource) {
+      return this.#lastKnownStateSource;
+    }
+
+    if (this.loadingStatuses.size === 0) {
       return "unknown";
     }
 
     for (const peer of this.loadingStatuses.values()) {
-      if (peer.type === "pending") {
-        return "loading";
-      } else if (peer.type === "unknown") {
+      if (peer.type === "unknown") {
         return "unknown";
       }
     }
@@ -429,32 +450,22 @@ export class CoValueCore {
   }
 
   /**
-   * Removes the CoValue from memory.
+   * Removes the CoValue content from memory but keeps a shell with cached knownState.
+   * This enables accurate LOAD requests during peer reconciliation.
    *
    * @returns true if the coValue was successfully unmounted, false otherwise
    */
   unmount(): boolean {
-    if (this.listeners.size > 0) {
-      // The coValue is still in use
-      return false;
-    }
+    return this.node.internalUnmountCoValue(this.id);
+  }
 
-    for (const dependant of this.dependant) {
-      if (this.node.hasCoValue(dependant)) {
-        // Another in-memory coValue depends on this coValue
-        return false;
-      }
-    }
-
-    if (!this.node.syncManager.isSyncedToServerPeers(this.id)) {
-      return false;
-    }
-
+  /**
+   * Decrements the counter for the current loading state.
+   * Used during unmount to properly track state transitions.
+   * @internal
+   */
+  decrementLoadingStateCounter() {
     this.counter.add(-1, { state: this.loadingState });
-
-    this.node.internalDeleteCoValue(this.id);
-
-    return true;
   }
 
   markNotFoundInPeer(peerId: PeerID) {
@@ -468,6 +479,35 @@ export class CoValueCore {
     this.loadingStatuses.set(peerId, { type: "available" });
     this.updateCounter(previousState);
     this.scheduleNotifyUpdate();
+  }
+
+  /**
+   * Clean up cached state when CoValue becomes available.
+   * Called after the CoValue transitions from garbageCollected/onlyKnownState to available.
+   */
+  private cleanupLastKnownState() {
+    // Clear both fields - in-memory verified state is now authoritative
+    this.#lastKnownStateSource = undefined;
+    this.#lastKnownState = undefined;
+  }
+
+  /**
+   * Initialize this CoValueCore as a garbageCollected shell.
+   * Called when creating a replacement CoValueCore after unmounting.
+   */
+  setGarbageCollectedState(knownState: CoValueKnownState) {
+    // Only set garbageCollected state if storage is active
+    // Without storage, we can't reload the CoValue anyway
+    if (!this.node.storage) {
+      return;
+    }
+
+    // Transition counter from 'unknown' (set by constructor) to 'garbageCollected'
+    // previousState will be 'unknown', newState will be 'garbageCollected'
+    const previousState = this.loadingState;
+    this.#lastKnownStateSource = "garbageCollected";
+    this.#lastKnownState = knownState;
+    this.updateCounter(previousState);
   }
 
   missingDependencies = new Set<RawCoID>();
@@ -576,6 +616,10 @@ export class CoValueCore {
       header,
       new SessionMap(this.id, this.node.crypto, streamingKnownState),
     );
+    // Clean up if transitioning from garbageCollected/onlyKnownState
+    if (this.isAvailable()) {
+      this.cleanupLastKnownState();
+    }
 
     return true;
   }
@@ -606,10 +650,11 @@ export class CoValueCore {
    * Used to correctly manage the content & subscriptions during the content streaming process
    */
   knownStateWithStreaming(): CoValueKnownState {
-    return (
-      this.verified?.immutableKnownStateWithStreaming() ??
-      emptyKnownState(this.id)
-    );
+    if (this.verified) {
+      return this.verified.immutableKnownStateWithStreaming();
+    }
+
+    return this.knownState();
   }
 
   /**
@@ -618,9 +663,22 @@ export class CoValueCore {
    * The return value identity is going to be stable as long as the CoValue is not modified.
    *
    * On change the knownState is invalidated and a new object is returned.
+   *
+   * For garbageCollected/onlyKnownState CoValues, returns the cached knownState.
    */
   knownState(): CoValueKnownState {
-    return this.verified?.immutableKnownState() ?? emptyKnownState(this.id);
+    // 1. If we have verified content in memory, use that (authoritative)
+    if (this.verified) {
+      return this.verified.immutableKnownState();
+    }
+
+    // 2. If we have last known state (GC'd or onlyKnownState), use that
+    if (this.#lastKnownState) {
+      return this.#lastKnownState;
+    }
+
+    // 3. Fallback to empty state (truly unknown CoValue)
+    return emptyKnownState(this.id);
   }
 
   /**
@@ -1891,7 +1949,16 @@ export class CoValueCore {
       return;
     }
 
-    if (currentState !== "unknown") {
+    // Check if we need to load from storage:
+    // - If storage state is not unknown (already tried), AND
+    // - Overall state is not garbageCollected/onlyKnownState (which need full content)
+    // Then return early
+    const overallState = this.loadingState;
+    if (
+      currentState !== "unknown" &&
+      overallState !== "garbageCollected" &&
+      overallState !== "onlyKnownState"
+    ) {
       done?.(currentState === "available");
       return;
     }
@@ -1916,7 +1983,8 @@ export class CoValueCore {
    * Lazily load only the knownState from storage without loading full transaction data.
    * This is useful for checking if a peer needs new content before committing to a full load.
    *
-   * Caching and deduplication are handled at the storage layer.
+   * If found in storage, marks the CoValue as onlyKnownState and caches the knownState.
+   * This enables accurate LOAD requests during peer reconciliation.
    *
    * @param done - Callback with the storage knownState, or undefined if not found in storage
    */
@@ -1928,14 +1996,26 @@ export class CoValueCore {
       return;
     }
 
-    // If already available in memory, return the current knownState
-    if (this.isAvailable()) {
-      done(this.knownState());
+    // If we already have knowledge about this CoValue (in memory or cached), return it
+    // knownState() returns verified state, lastKnownState, or empty state
+    const knownState = this.knownState();
+    if (knownState.header) {
+      done(knownState);
       return;
     }
 
     // Delegate to storage - caching is handled at storage level
-    this.node.storage.loadKnownState(this.id, done);
+    this.node.storage.loadKnownState(this.id, (knownState) => {
+      // The coValue could become available in the meantime.
+      if (knownState && !this.isAvailable()) {
+        // Cache the knownState and mark as onlyKnownState
+        const previousState = this.loadingState;
+        this.#lastKnownStateSource = "onlyKnownState";
+        this.#lastKnownState = knownState;
+        this.updateCounter(previousState);
+      }
+      done(knownState);
+    });
   }
 
   loadFromPeers(peers: PeerState[], mode?: LoadMode) {

--- a/packages/cojson/src/tests/sync.peerReconciliation.test.ts
+++ b/packages/cojson/src/tests/sync.peerReconciliation.test.ts
@@ -1,5 +1,6 @@
 import { assert, beforeEach, describe, expect, test, vi } from "vitest";
 import { expectMap } from "../coValue";
+import { setGarbageCollectorMaxAge } from "../config";
 import { RawCoMap } from "../exports";
 import {
   SyncMessagesLog,
@@ -17,6 +18,8 @@ let jazzCloud: ReturnType<typeof setupTestNode>;
 beforeEach(async () => {
   SyncMessagesLog.clear();
   jazzCloud = setupTestNode({ isSyncServer: true });
+  // Set GC max age to -1 so items are collected immediately when needed
+  setGarbageCollectorMaxAge(-1);
 });
 
 describe("peer reconciliation", () => {
@@ -334,5 +337,201 @@ describe("peer reconciliation", () => {
     expect(expectMap(mapOnSyncServer.getCurrentContent()).get("hello")).toEqual(
       "updated",
     );
+  });
+});
+
+describe("peer reconciliation with garbageCollected CoValues", () => {
+  test("sends cached known state for garbageCollected CoValues during reconciliation", async () => {
+    const client = setupTestNode();
+    client.addStorage({ ourName: "client" });
+    client.node.enableGarbageCollector();
+
+    const group = client.node.createGroup();
+    const map = group.createMap();
+    map.set("hello", "world", "trusting");
+
+    // Sync to server first
+    client.connectToSyncServer();
+    await client.node.syncManager.waitForAllCoValuesSync();
+
+    // Capture the known state before GC
+    const mapKnownState = map.core.knownState();
+    const groupKnownState = group.core.knownState();
+
+    // Disconnect first to avoid server reloading CoValues after GC
+    client.disconnect();
+
+    // Run GC to unmount the CoValues (creates garbageCollected shells)
+    // GC works because there are no persistent server peers (disconnected)
+    client.node.garbageCollector?.collect();
+    client.node.garbageCollector?.collect(); // Second pass for dependencies
+
+    // Verify CoValues are now garbageCollected
+    const gcMap = client.node.getCoValue(map.id);
+    const gcGroup = client.node.getCoValue(group.id);
+    expect(gcMap.loadingState).toBe("garbageCollected");
+    expect(gcGroup.loadingState).toBe("garbageCollected");
+
+    // Verify knownState() returns the cached state (not empty)
+    expect(gcMap.knownState()).toEqual(mapKnownState);
+    expect(gcGroup.knownState()).toEqual(groupKnownState);
+
+    // Reconnect to trigger peer reconciliation
+    SyncMessagesLog.clear();
+    client.connectToSyncServer();
+
+    // Wait for messages to be exchanged
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    // LOAD is sent with cached known state (no storage lookup needed)
+    expect(
+      SyncMessagesLog.getMessages({
+        Group: gcGroup,
+        Map: gcMap,
+      }),
+    ).toMatchInlineSnapshot(`
+      [
+        "client -> server | LOAD Group sessions: header/3",
+        "client -> server | LOAD Map sessions: header/1",
+        "server -> client | KNOWN Group sessions: header/3",
+        "server -> client | KNOWN Map sessions: header/1",
+      ]
+    `);
+  });
+
+  test("garbageCollected CoValues restore subscription with minimal data transfer", async () => {
+    // Setup: both client and server have the same data
+    const client = setupTestNode();
+    client.addStorage({ ourName: "client" });
+    client.node.enableGarbageCollector();
+
+    const group = client.node.createGroup();
+    const map = group.createMap();
+    map.set("hello", "world", "trusting");
+
+    // Sync to server
+    client.connectToSyncServer();
+    await client.node.syncManager.waitForAllCoValuesSync();
+
+    // Verify server has the data
+    const serverMap = jazzCloud.node.getCoValue(map.id);
+    expect(serverMap.isAvailable()).toBe(true);
+
+    // Capture known states before GC
+    const clientMapKnownState = map.core.knownState();
+    const clientGroupKnownState = group.core.knownState();
+
+    // Disconnect before GC to avoid server reloading CoValues
+    client.disconnect();
+
+    // Run GC
+    client.node.garbageCollector?.collect();
+    client.node.garbageCollector?.collect();
+
+    const gcMap = client.node.getCoValue(map.id);
+    const gcGroup = client.node.getCoValue(group.id);
+
+    // Verify garbageCollected state
+    expect(gcMap.loadingState).toBe("garbageCollected");
+    expect(gcGroup.loadingState).toBe("garbageCollected");
+
+    // Reconnect to trigger peer reconciliation
+    SyncMessagesLog.clear();
+    client.connectToSyncServer();
+
+    // Wait for messages to be exchanged
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    // LOAD is sent with cached known state
+    // Server responds with KNOWN since client and server have the same data
+    expect(
+      SyncMessagesLog.getMessages({
+        Group: gcGroup,
+        Map: gcMap,
+      }),
+    ).toMatchInlineSnapshot(`
+      [
+        "client -> server | LOAD Group sessions: header/3",
+        "client -> server | LOAD Map sessions: header/1",
+        "server -> client | KNOWN Group sessions: header/3",
+        "server -> client | KNOWN Map sessions: header/1",
+      ]
+    `);
+  });
+
+  test("unknown CoValues return empty knownState during reconciliation", async () => {
+    const client = setupTestNode();
+
+    // Create a CoValue on another node that we'll hear about but not load
+    const otherClient = setupTestNode();
+    const group = otherClient.node.createGroup();
+    const map = group.createMap();
+    map.set("hello", "world", "trusting");
+
+    // Sync other client to server
+    otherClient.connectToSyncServer();
+    await otherClient.node.syncManager.waitForAllCoValuesSync();
+
+    // Now client connects - it will hear about the CoValue IDs but not load them
+    // Create a reference to the CoValue without loading it
+    const unknownCoValue = client.node.getCoValue(map.id);
+
+    // Verify it's in unknown state
+    expect(unknownCoValue.loadingState).toBe("unknown");
+
+    // Verify knownState() returns empty state for unknown CoValues
+    const knownState = unknownCoValue.knownState();
+    expect(knownState.header).toBe(false);
+    expect(knownState.sessions).toEqual({});
+  });
+
+  test("unknown CoValues are skipped during peer reconciliation (no LOAD sent)", async () => {
+    const client = setupTestNode();
+
+    // Create a CoValue on another node
+    const otherClient = setupTestNode();
+    const group = otherClient.node.createGroup();
+    const map = group.createMap();
+    map.set("hello", "world", "trusting");
+
+    // Sync other client to server so the server knows about the CoValue
+    otherClient.connectToSyncServer();
+    await otherClient.node.syncManager.waitForAllCoValuesSync();
+
+    // Client creates its own group (so we have something to compare against)
+    const clientGroup = client.node.createGroup();
+    const clientMap = clientGroup.createMap();
+    clientMap.set("foo", "bar", "trusting");
+
+    // Create a reference to the other client's CoValue WITHOUT loading it
+    // This simulates "hearing about" a CoValue ID (e.g., from a reference)
+    const unknownCoValue = client.node.getCoValue(map.id);
+    expect(unknownCoValue.loadingState).toBe("unknown");
+
+    // Connect client to server - this triggers peer reconciliation
+    SyncMessagesLog.clear();
+    client.connectToSyncServer();
+
+    await client.node.syncManager.waitForAllCoValuesSync();
+
+    // Verify: LOAD sent for client's own CoValues, but NOT for the unknown CoValue
+    expect(
+      SyncMessagesLog.getMessages({
+        ClientGroup: clientGroup.core,
+        ClientMap: clientMap.core,
+        UnknownMap: unknownCoValue,
+      }),
+    ).toMatchInlineSnapshot(`
+      [
+        "client -> server | LOAD ClientGroup sessions: header/3",
+        "client -> server | LOAD ClientMap sessions: header/1",
+        "client -> server | CONTENT ClientGroup header: true new: After: 0 New: 3",
+        "client -> server | CONTENT ClientMap header: true new: After: 0 New: 1",
+        "server -> client | KNOWN ClientGroup sessions: empty",
+        "server -> client | KNOWN ClientMap sessions: empty",
+        "server -> client | KNOWN ClientGroup sessions: header/3",
+        "server -> client | KNOWN ClientMap sessions: header/1",
+      ]
+    `);
   });
 });


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and which issue is fixed -->
<!-- Please also include relevant motivation and context -->
<!-- Include any links to documentation like RFC’s if necessary -->
<!-- Add a link to to relevant preview environments or anything that would simplify visual review process -->
<!-- Supplemental screenshots and video are encouraged, but the primary description should be in text -->

This design introduces explicit CoValue states (`garbageCollected` and `onlyKnownState`) to distinguish between CoValues we actually care about versus ones we just heard about. This prevents unnecessary data transfer during peer reconciliation by only restoring subscriptions for CoValues that were actively used.

## Manual testing instructions

<!-- Add any actions required to manually test the changes -->

## Tests

- [ ] Tests have been added and/or updated
- [ ] Tests have not been updated, because: <!-- Insert reason for not updating tests here -->
- [ ] I need help with writing tests


## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [ ] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing