### PR TITLE
fix: Make CoList iterator methods go through proxy

### DIFF
--- a/packages/jazz-tools/src/tools/coValues/coList.ts
+++ b/packages/jazz-tools/src/tools/coValues/coList.ts
@@ -954,6 +954,27 @@ const CoListProxyHandler: ProxyHandler<CoList> = {
       }
     } else if (key === "length") {
       return target.$jazz.raw.entries().length;
+    } else if (key === Symbol.iterator || key === "values") {
+      return function* () {
+        const length = target.$jazz.raw.entries().length;
+        for (let i = 0; i < length; i++) {
+          yield receiver[i];
+        }
+      };
+    } else if (key === "keys") {
+      return function* () {
+        const length = target.$jazz.raw.entries().length;
+        for (let i = 0; i < length; i++) {
+          yield i;
+        }
+      };
+    } else if (key === "entries") {
+      return function* () {
+        const length = target.$jazz.raw.entries().length;
+        for (let i = 0; i < length; i++) {
+          yield [i, receiver[i]] as [number, unknown];
+        }
+      };
     } else {
       return Reflect.get(target, key, receiver);
     }


### PR DESCRIPTION
# Description
We experienced an issue where under some conditions `.values()` would return an empty iterator. Before the iterator methods would go through the reflect which returned the internal array's slots returning nothing. Now we always go through the proxy ensuring consistent data access.

## Tests

- [ ] Tests have been added and/or updated
- [x] Tests have not been updated, because: I tried to create tests, but they couldn't capture the issue we experienced in production. Though this fix should work? Open to recommendations for tests.
- [ ] I need help with writing tests


## Checklist

- [ ] I've updated the part of the docs that are affected the PR changes
- [ ] I've generated a changeset, if a version bump is required
- [ ] I've updated the jsDoc comments to the public APIs I've modified, or added them when missing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures all iterator access goes through the `CoList` proxy rather than the underlying array slots, preventing empty/incorrect iteration results.
> 
> - Add proxy handlers for `Symbol.iterator`, `values`, `keys`, and `entries` to iterate via `receiver[i]` using `raw.entries().length`
> - Leaves other proxy behaviors intact (e.g., `length`, indexed access)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d573c52b9d8b7715d479a99acadecd378bcbf54a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->