### PR TITLE
fix: correct CoList length descriptor implementation

### DIFF
--- a/.changeset/fix-colist-length-descriptor.md
+++ b/.changeset/fix-colist-length-descriptor.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Fixed `CoList` to return the correct length when calling `getOwnPropertyDescriptor` with `length`. Previously it was always returning 0.

--- a/packages/cojson/src/coValues/coList.ts
+++ b/packages/cojson/src/coValues/coList.ts
@@ -378,6 +378,10 @@ export class RawCoList<
     return arr;
   }
 
+  length() {
+    return this.entries().length;
+  }
+
   /** @internal */
   entriesUncached(): {
     value: Item;

--- a/packages/jazz-tools/src/tools/coValues/coList.ts
+++ b/packages/jazz-tools/src/tools/coValues/coList.ts
@@ -549,7 +549,7 @@ export class CoListJazzApi<L extends CoList> extends CoValueJazzApi<L> {
       "private",
     );
 
-    return this.raw.entries().length;
+    return this.raw.length();
   }
 
   /**
@@ -567,7 +567,7 @@ export class CoListJazzApi<L extends CoList> extends CoValueJazzApi<L> {
       this.raw.prepend(item);
     }
 
-    return this.raw.entries().length;
+    return this.raw.length();
   }
 
   /**
@@ -938,38 +938,57 @@ function toRawItems<Item>(
 
 const CoListProxyHandler: ProxyHandler<CoList> = {
   get(target, key, receiver) {
-    if (typeof key === "string" && !isNaN(+key)) {
-      const itemDescriptor = target.$jazz.schema[ItemsSym] as Schema;
+    if (typeof key === "symbol") {
+      return Reflect.get(target, key, receiver);
+    }
+
+    if (!isNaN(+key)) {
       const rawValue = target.$jazz.raw.get(Number(key));
+
+      if (rawValue === undefined) {
+        return undefined;
+      }
+
+      const itemDescriptor: Schema = target.$jazz.schema[ItemsSym];
+
       if (itemDescriptor === "json") {
         return rawValue;
       } else if ("encoded" in itemDescriptor) {
-        return rawValue === undefined
-          ? undefined
-          : itemDescriptor.encoded.decode(rawValue);
+        return itemDescriptor.encoded.decode(rawValue);
       } else if (isRefEncoded(itemDescriptor)) {
-        return rawValue === undefined || rawValue === null
-          ? undefined
-          : accessChildByKey(target, rawValue as string, key);
+        if (rawValue === null) {
+          return undefined;
+        }
+
+        return accessChildByKey(target, rawValue as string, key);
       }
     } else if (key === "length") {
-      return target.$jazz.raw.entries().length;
-    } else {
-      return Reflect.get(target, key, receiver);
+      return target.$jazz.raw.length();
     }
+
+    return Reflect.get(target, key, receiver);
   },
   set(target, key, value, receiver) {
-    if (key === ItemsSym && typeof value === "object" && SchemaInit in value) {
-      (target.constructor as typeof CoList)._schema ||= {};
-      (target.constructor as typeof CoList)._schema[ItemsSym] =
-        value[SchemaInit];
-      return true;
-    }
-    if (typeof key === "string" && !isNaN(+key)) {
-      throw Error("Cannot update a CoList directly. Use `$jazz.set` instead.");
-    } else {
+    if (typeof key === "symbol") {
       return Reflect.set(target, key, value, receiver);
     }
+
+    if (key === ItemsSym && typeof value === "object" && SchemaInit in value) {
+      const constructor = target.constructor as typeof CoList;
+
+      if (!constructor._schema) {
+        constructor._schema = {};
+      }
+
+      constructor._schema[ItemsSym] = value[SchemaInit];
+      return true;
+    }
+
+    if (!isNaN(+key)) {
+      throw Error("Cannot update a CoList directly. Use `$jazz.set` instead.");
+    }
+
+    return Reflect.set(target, key, value, receiver);
   },
   defineProperty(target, key, descriptor) {
     if (
@@ -978,9 +997,13 @@ const CoListProxyHandler: ProxyHandler<CoList> = {
       typeof descriptor.value === "object" &&
       SchemaInit in descriptor.value
     ) {
-      (target.constructor as typeof CoList)._schema ||= {};
-      (target.constructor as typeof CoList)._schema[ItemsSym] =
-        descriptor.value[SchemaInit];
+      const constructor = target.constructor as typeof CoList;
+
+      if (!constructor._schema) {
+        constructor._schema = {};
+      }
+
+      constructor._schema[ItemsSym] = descriptor.value[SchemaInit];
       return true;
     } else {
       return Reflect.defineProperty(target, key, descriptor);
@@ -988,7 +1011,7 @@ const CoListProxyHandler: ProxyHandler<CoList> = {
   },
   has(target, key) {
     if (typeof key === "string" && !isNaN(+key)) {
-      return Number(key) < target.$jazz.raw.entries().length;
+      return Number(key) < target.$jazz.raw.length();
     } else {
       return Reflect.has(target, key);
     }
@@ -996,11 +1019,17 @@ const CoListProxyHandler: ProxyHandler<CoList> = {
   ownKeys(target) {
     const keys = Reflect.ownKeys(target);
     // Add numeric indices for all entries in the list
-    const indexKeys = target.$jazz.raw.entries().map((_entry, i) => String(i));
-    keys.push(...indexKeys);
+    const length = target.$jazz.raw.length();
+    for (let i = 0; i < length; i++) {
+      keys.push(String(i));
+    }
     return keys;
   },
   getOwnPropertyDescriptor(target, key) {
+    if (typeof key === "symbol") {
+      return Reflect.getOwnPropertyDescriptor(target, key);
+    }
+
     if (key === TypeSym) {
       // Make TypeSym non-enumerable so it doesn't show up in Object.keys()
       return {
@@ -1009,23 +1038,24 @@ const CoListProxyHandler: ProxyHandler<CoList> = {
         writable: false,
         value: target[TypeSym],
       };
-    } else if (key in target) {
-      return Reflect.getOwnPropertyDescriptor(target, key);
-    } else if (typeof key === "string" && !isNaN(+key)) {
+    } else if (!isNaN(+key)) {
       const index = Number(key);
-      if (index >= 0 && index < target.$jazz.raw.entries().length) {
+      if (index >= 0 && index < target.$jazz.raw.length()) {
         return {
           enumerable: true,
           configurable: true,
-          writable: true,
+          writable: false,
+          value: target.$jazz.raw.get(index),
         };
       }
     } else if (key === "length") {
       return {
         enumerable: false,
         configurable: false,
-        writable: false,
+        writable: true, // Must be writable, otherwise JS complains
+        value: target.$jazz.raw.length(),
       };
     }
+    return Reflect.getOwnPropertyDescriptor(target, key);
   },
 };

--- a/packages/jazz-tools/src/tools/tests/coList.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coList.test.ts
@@ -1448,6 +1448,33 @@ describe("CoList proxy traps", () => {
     expect(enumerableKeys.sort()).toEqual(["0", "1", "2"]);
   });
 
+  test("Object.getOwnPropertyDescriptors returns the resolved references", () => {
+    const TestList = co.list(co.map({ name: z.string() }));
+    const list = TestList.create([{ name: "a" }, { name: "b" }, { name: "c" }]);
+
+    const descriptors = Object.getOwnPropertyDescriptors(list);
+
+    // Check numeric index descriptors
+    expect(descriptors["0"]).toEqual({
+      enumerable: true,
+      configurable: true,
+      writable: false,
+      value: list[0],
+    });
+    expect(descriptors["1"]).toEqual({
+      enumerable: true,
+      configurable: true,
+      writable: false,
+      value: list[1],
+    });
+    expect(descriptors["2"]).toEqual({
+      enumerable: true,
+      configurable: true,
+      writable: false,
+      value: list[2],
+    });
+  });
+
   test("setting the lenght to 0 has no effect", () => {
     const TestList = co.list(z.string());
     const list = TestList.create(["a", "b", "c"]);


### PR DESCRIPTION
- Updated the `CoList` class to properly return the correct length when accessing the `length` property via `getOwnPropertyDescriptor`.
- Refactored related proxy handler methods to make them more readable.
- Added tests to verify the correct behavior of `CoList` proxy traps and ensure proper functionality of length-related operations.
