### PR TITLE
fix(browser-perf-test): ensure that the covalues are synced before the scenario end and add timeout option

### DIFF
--- a/tests/browser-perf-tests/src/cli/cli.ts
+++ b/tests/browser-perf-tests/src/cli/cli.ts
@@ -14,6 +14,7 @@ const argsConfig = {
     sync: { type: "string" as const, short: "s" },
     headful: { type: "boolean" as const, default: false },
     "cold-storage": { type: "boolean" as const, default: false },
+    timeout: { type: "string" as const, short: "t" },
     help: { type: "boolean" as const, short: "h" },
     // Grid scenario options
     size: { type: "string" as const },
@@ -49,6 +50,9 @@ function buildConfig(
   const sync = values.sync ? String(values.sync) : undefined;
   const headless = values.headful !== true; // Default to headless (true)
   const coldStorage = values["cold-storage"] === true; // Default to false (warm storage)
+  const timeout = values.timeout
+    ? parseInt(String(values.timeout), 10)
+    : undefined;
 
   // Build scenario-specific options
   const scenarioOptions: Record<string, unknown> = {};
@@ -72,6 +76,7 @@ function buildConfig(
     sync,
     headless,
     coldStorage,
+    timeout,
     scenarioOptions,
   };
 }
@@ -106,6 +111,9 @@ async function main(): Promise<void> {
     console.log(`  Headful: ${!config.headless}`);
     console.log(
       `  Storage: ${config.coldStorage ? "cold (fresh each run)" : "warm (reused)"}`,
+    );
+    console.log(
+      `  Timeout: ${config.timeout === 0 ? "disabled" : config.timeout ? `${config.timeout}ms` : "default"}`,
     );
     if (Object.keys(config.scenarioOptions).length > 0) {
       console.log(`  Options: ${JSON.stringify(config.scenarioOptions)}`);

--- a/tests/browser-perf-tests/src/cli/runner.ts
+++ b/tests/browser-perf-tests/src/cli/runner.ts
@@ -46,7 +46,13 @@ export async function runBenchmark(
     );
 
     // Perform warmup run (not included in results)
-    await performWarmupRun(browser, scenario, coValueId, baseURL);
+    await performWarmupRun(
+      browser,
+      scenario,
+      coValueId,
+      baseURL,
+      config.timeout,
+    );
 
     // Run the benchmark iterations
     const rawMetrics = await runIterations(
@@ -56,6 +62,7 @@ export async function runBenchmark(
       config.runs,
       baseURL,
       config.coldStorage ?? false,
+      config.timeout,
     );
 
     // Calculate statistics for each metric
@@ -123,11 +130,13 @@ async function performWarmupRun(
   scenario: ScenarioDefinition,
   coValueId: string,
   baseURL: string,
+  timeout?: number,
 ): Promise<void> {
   printWarmupStart();
 
   const startTime = Date.now();
   const context = await browser.newContext({ baseURL });
+  context.setDefaultTimeout(timeout ?? 120000);
 
   try {
     const page = await context.newPage();
@@ -149,6 +158,7 @@ async function runIterations(
   runs: number,
   baseURL: string,
   coldStorage: boolean,
+  timeout?: number,
 ): Promise<Record<string, number[]>> {
   const rawMetrics: Record<string, number[]> = {};
 
@@ -172,6 +182,8 @@ async function runIterations(
             storageState: undefined,
           })
         : sharedContext!;
+
+      context.setDefaultTimeout(timeout ?? 120000);
 
       try {
         const page = await context.newPage();

--- a/tests/browser-perf-tests/src/cli/scenarios/grid.ts
+++ b/tests/browser-perf-tests/src/cli/scenarios/grid.ts
@@ -48,7 +48,6 @@ export const gridScenario: ScenarioDefinition = {
     // Wait for the button to show "Generate Grid" again (not "Generating...")
     await page.getByRole("button", { name: "Generate Grid" }).waitFor({
       state: "visible",
-      timeout: 120000, // Allow up to 2 minutes for large grids
     });
 
     // Wait a bit for the grid to appear in the list
@@ -81,19 +80,16 @@ export const gridScenario: ScenarioDefinition = {
     const loadTimeElement = page.locator('[data-testid="load-time"]');
 
     // Wait for the element to have a non-null data-load-time-ms attribute
-    await loadTimeElement.waitFor({ state: "visible", timeout: 120000 });
+    await loadTimeElement.waitFor({ state: "visible" });
 
     // Poll until the attribute is set (not null)
-    const loadTimeMs = await page.waitForFunction(
-      () => {
-        const el = document.querySelector('[data-testid="load-time"]');
-        if (!el) return null;
-        const value = el.getAttribute("data-load-time-ms");
-        if (value === null) return null;
-        return parseFloat(value);
-      },
-      { timeout: 120000 },
-    );
+    const loadTimeMs = await page.waitForFunction(() => {
+      const el = document.querySelector('[data-testid="load-time"]');
+      if (!el) return null;
+      const value = el.getAttribute("data-load-time-ms");
+      if (value === null) return null;
+      return parseFloat(value);
+    });
 
     const value = await loadTimeMs.jsonValue();
     if (value === null) {

--- a/tests/browser-perf-tests/src/cli/scenarios/types.ts
+++ b/tests/browser-perf-tests/src/cli/scenarios/types.ts
@@ -55,6 +55,8 @@ export interface BenchmarkConfig {
 
   /** Scenario-specific options (only used if no id provided) */
   scenarioOptions: Record<string, unknown>;
+
+  timeout?: number;
 }
 
 /**


### PR DESCRIPTION
Fixes a timing issue we had on the grid test, that was causing the coValues to be not persisted in the initial runs when the grid size was above 30x30