### PR TITLE
perf: cache groups readkey access

### DIFF
--- a/.changeset/prevent-private-transactions-in-groups.md
+++ b/.changeset/prevent-private-transactions-in-groups.md
@@ -1,0 +1,6 @@
+---
+"cojson": patch
+---
+
+Added caching for groups when accessing a readKey.
+Marked private transactions in groups as invalid.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Released Jazz 0.20.3:
+- Added caching for groups when accessing a readKey
+
+Released Jazz 0.20.2:
+- Added a Performance tab in the Jazz tools inspector
+- Optimized peer reconciliation to prevent unnecessary data transfer on reconnect.
 
 Released Jazz 0.20.1:
 - Added client-side load request throttling to improve the loading experience when loading a lot of data concurrently. When a client requests more than 1k CoValues concurrently, load requests are now queued locally and sent as capacity becomes available.

--- a/packages/cojson/src/permissions.ts
+++ b/packages/cojson/src/permissions.ts
@@ -235,6 +235,7 @@ function determineValidTransactionsForGroup(
   const writeOnlyKeys: Record<RawAccountID | AgentID, KeyID> = {};
   const writeKeys = new Set<string>();
   const memberRoleResolver = new MemberRoleResolver();
+  const isGroup = coValue.isGroup();
 
   for (const transaction of coValue.verifiedTransactions) {
     const transactor = transaction.author;
@@ -247,6 +248,11 @@ function determineValidTransactionsForGroup(
     const tx = transaction.tx;
 
     if (tx.privacy === "private") {
+      if (isGroup) {
+        transaction.markInvalid("Can't make private transactions in groups");
+        continue;
+      }
+
       if (transactorRole === "admin") {
         transaction.markValid();
         continue;

--- a/packages/cojson/src/tests/group.parentGroupCache.test.ts
+++ b/packages/cojson/src/tests/group.parentGroupCache.test.ts
@@ -140,7 +140,7 @@ describe("Parent Group Cache", () => {
             value: "revoked",
           },
         ],
-        "private",
+        "trusting",
         undefined,
         t2,
       );
@@ -153,7 +153,7 @@ describe("Parent Group Cache", () => {
             value: "extend",
           },
         ],
-        "private",
+        "trusting",
         undefined,
         t1,
       );


### PR DESCRIPTION
# Description

This PR improves performance when accessing read keys in groups, by caching their content validation.

Fixes the performance issue in the following case:
<img width="1962" height="561" alt="Screenshot 2026-01-23 at 12 36 59" src="https://github.com/user-attachments/assets/3e99d8cf-8509-42e1-9102-23a78b47c724" />

Here the group content was never cached because it was called with `ignorePrivateTransactions` which skips caching.

## Changes

- Removed `ignorePrivateTransactions` when accessing group content inside `CoValueCore.getReadKey()`
- Private transactions are now explicitly marked as invalid when attempted directly on groups
- Private transactions remain valid in accounts (for backward compat with private root)
