### PR TITLE
fix: include generated tsconfig.json files in turbo cache outputs

### DIFF
--- a/homepage/homepage/turbo.json
+++ b/homepage/homepage/turbo.json
@@ -3,7 +3,7 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build", "build:generate-docs"],
-      "outputs": [".next/**", "!.next/cache/**"],
+      "outputs": [".next/**", "!.next/cache/**", "content/docs/code-snippets/**/tsconfig.json"],
       "env": ["GRAFANA_SERVICE_ACCOUNT"]
     },
     "build:generate-docs": {


### PR DESCRIPTION
The homepage build fails occasionally with the following error:

```
Error: ENOENT: no such file or directory, lstat '/vercel/path0/homepage/homepage/content/docs/code-snippets/api-reference/tsconfig.json'
```

Example: https://vercel.com/garden-co/jazz-homepage/7UG1D3JpYZeFkCsvqW9GC4c6k6Cw

The turbo cache outputs only include .next/**, but the generated tsconfig.json files in code-snippets/ are not in the outputs. When the build is cached:
  1. Turbo restores .next/** from cache
  2. The pnpm check && next build doesn't actually run
  3. generate:snippet-paths never generates the tsconfig.json files
  4. Vercel's file tracing step fails because the files don't exist
  
Adding   generated tsconfig.json files in turbo cache outputs should fix the bug