### PR TITLE
fix(react): infinite re-render loop when accessing unresolved nested CoValues in React hooks

### DIFF
--- a/.changeset/fix-infinite-rerender-autoload.md
+++ b/.changeset/fix-infinite-rerender-autoload.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Fixed infinite re-render loop when accessing unresolved nested CoValues in React hooks


### PR DESCRIPTION

Fixed infinite re-render loop when accessing unresolved nested CoValues in React hooks

When using `useCoState` with an empty or partial resolve query and then accessing a nested CoValue property, the component would enter an infinite re-render loop. This was caused by `SubscriptionScope.subscribeToKey` mutating the resolve object, which invalidated the subscription cache lookup on subsequent renders.

The fix clones the resolve query before storing it in the cache, preventing mutations from affecting cache lookups.
