### PR TITLE
perf: optimize group iteration for getUncachedReadKey

### DIFF
--- a/.changeset/perf-group-key-lookup.md
+++ b/.changeset/perf-group-key-lookup.md
@@ -1,0 +1,5 @@
+---
+"cojson": patch
+---
+
+Improve performance of read key lookups in groups by using cached indices instead of iterating through all keys


### PR DESCRIPTION
Doing this change in order to optimize read key resolution on big groups.

The problem is, iterating all the keys when we need to access a given readKey is too slow for big groups, so I've added an incremental cache built at transaction processing time to skip the iteration and resolve the key directly.