### PR TITLE
feat(cojson): group name

### DIFF
--- a/.changeset/group-name-metadata.md
+++ b/.changeset/group-name-metadata.md
@@ -1,0 +1,6 @@
+---
+"cojson": patch
+"jazz-tools": patch
+---
+
+Added optional `name` metadata to Groups. Groups can now be created with a display name (e.g. `Group.create({ owner: account, name: "Engineering" })`)

--- a/examples/inspector/tests/inspector.spec.ts
+++ b/examples/inspector/tests/inspector.spec.ts
@@ -27,7 +27,7 @@ test("should add and delete account in dropdown", async ({ page }) => {
     page.getByText("Select an account to connect to the inspector."),
   ).toBeVisible();
   await expect(
-    page.getByText(`Inspector test account <${accountID}>`),
+    page.getByText(`👤Inspector test account <${accountID}>`),
   ).not.toBeVisible();
 });
 

--- a/examples/inspector/tests/inspector.spec.ts
+++ b/examples/inspector/tests/inspector.spec.ts
@@ -192,7 +192,7 @@ test("should show Group members", async ({ page }) => {
 
   const row2 = table.getByRole("row").nth(2);
   await expect(row2.getByRole("cell").nth(0)).toHaveText(
-    `Inspector test account <${account.$jazz.id}>`,
+    `👤Inspector test account <${account.$jazz.id}>`,
   );
   await expect(row2.getByRole("cell").nth(1)).toHaveText("admin");
 

--- a/examples/todo/src/3_NewProjectForm.tsx
+++ b/examples/todo/src/3_NewProjectForm.tsx
@@ -23,7 +23,7 @@ export function NewProjectForm() {
       // To create a new todo project, we first create a `Group`,
       // which is a scope for defining access rights (reader/writer/admin)
       // of its members, which will apply to all CoValues owned by that group.
-      const projectGroup = Group.create();
+      const projectGroup = Group.create({ name: `Project ${title}` });
 
       // Then we create an empty todo project within that group
       const project = TodoProject.create(

--- a/packages/cojson/src/coValues/group.ts
+++ b/packages/cojson/src/coValues/group.ts
@@ -338,6 +338,13 @@ export class RawGroup<
   }
 
   /**
+   * Optional display name set at group creation. Immutable; stored in plaintext in header meta.
+   */
+  get name(): string | undefined {
+    return (this.headerMeta as { name?: string } | null)?.name;
+  }
+
+  /**
    * Returns the current role of a given account.
    *
    * @category 1. Role reading

--- a/packages/cojson/src/localNode.ts
+++ b/packages/cojson/src/localNode.ts
@@ -824,13 +824,19 @@ export class LocalNode {
 
   createGroup(
     uniqueness: CoValueUniqueness = this.crypto.createdNowUnique(),
+    options?: { name?: string },
   ): RawGroup {
     const account = this.getCurrentAgent();
+
+    const meta =
+      options?.name != null && options.name !== ""
+        ? { name: options.name }
+        : null;
 
     const groupCoValue = this.createCoValue({
       type: "comap",
       ruleset: { type: "group", initialAdmin: account.id },
-      meta: null,
+      meta,
       ...(uniqueness.createdAt !== undefined
         ? { createdAt: uniqueness.createdAt }
         : {}),

--- a/packages/cojson/src/tests/group.test.ts
+++ b/packages/cojson/src/tests/group.test.ts
@@ -70,6 +70,34 @@ test("Can create a FileStream in a group", () => {
   expect(stream instanceof RawBinaryCoStream).toEqual(true);
 });
 
+test("Group without name has name undefined", () => {
+  const node = nodeWithRandomAgentAndSessionID();
+  const group = node.createGroup();
+  expect(group.name).toBeUndefined();
+});
+
+test("Group created with name returns that name", () => {
+  const node = nodeWithRandomAgentAndSessionID();
+  const group = node.createGroup(undefined, { name: "My Group" });
+  expect(group.name).toBe("My Group");
+});
+
+test("Group created with empty name has name undefined (meta not set)", () => {
+  const node = nodeWithRandomAgentAndSessionID();
+  const group = node.createGroup(undefined, { name: "" });
+  expect(group.name).toBeUndefined();
+});
+
+test("Group with name persists after sync and load", async () => {
+  const { node1, node2 } = await createTwoConnectedNodes("server", "server");
+  const group = node1.node.createGroup(undefined, { name: "Synced Group" });
+  expect(group.name).toBe("Synced Group");
+  await group.core.waitForSync();
+
+  const loaded = expectGroup(await loadCoValueOrFail(node2.node, group.id));
+  expect(loaded.name).toBe("Synced Group");
+});
+
 test("Remove a member from a group where the admin role is inherited", async () => {
   const { node1, node2, node3 } = await createThreeConnectedNodes(
     "server",

--- a/packages/jazz-tools/src/inspector/viewer/account-or-group-text.tsx
+++ b/packages/jazz-tools/src/inspector/viewer/account-or-group-text.tsx
@@ -1,4 +1,4 @@
-import { CoID, LocalNode, RawCoValue } from "cojson";
+import { CoID, LocalNode, RawCoValue, RawGroup } from "cojson";
 import { useEffect, useState } from "react";
 import { Button } from "../ui/button.js";
 import { resolveCoValue, useResolvedCoValue } from "./use-resolve-covalue.js";
@@ -14,7 +14,7 @@ export function AccountOrGroupText({
   showId?: boolean;
   onClick?: (name?: string) => void;
 }) {
-  const { snapshot, extendedType } = useResolvedCoValue(coId, node);
+  const { snapshot, extendedType, value } = useResolvedCoValue(coId, node);
   const [name, setName] = useState<string | null>(null);
 
   useEffect(() => {
@@ -37,16 +37,34 @@ export function AccountOrGroupText({
     return <span>CoID is not an account or group</span>;
   }
 
-  const displayName = extendedType === "account" ? name || "Account" : "Group";
+  const groupName =
+    extendedType === "group" && value && "name" in value
+      ? (value as RawGroup).name
+      : undefined;
+  const displayName =
+    extendedType === "account" ? name || "Account" : groupName || "Group";
   const displayText = showId ? `${displayName} <${coId}>` : displayName;
+  const icon = extendedType === "account" ? "👤" : "👥";
+  const iconAlt = extendedType === "account" ? "Account" : "Group";
+
+  const content = (
+    <span
+      style={{ display: "inline-flex", alignItems: "center", gap: "0.35rem" }}
+    >
+      <span role="img" aria-label={iconAlt} title={iconAlt}>
+        {icon}
+      </span>
+      {displayText}
+    </span>
+  );
 
   if (onClick) {
     return (
       <Button variant="link" onClick={() => onClick(displayName)}>
-        {displayText}
+        {content}
       </Button>
     );
   }
 
-  return <>{displayText}</>;
+  return content;
 }

--- a/packages/jazz-tools/src/inspector/viewer/page.tsx
+++ b/packages/jazz-tools/src/inspector/viewer/page.tsx
@@ -6,6 +6,7 @@ import {
   RawCoPlainText,
   RawCoStream,
   RawCoValue,
+  RawGroup,
 } from "cojson";
 import { styled } from "goober";
 import React from "react";
@@ -230,6 +231,13 @@ export function Page(props: PageProps) {
                 <span style={{ color: "#57534e", fontWeight: 500 }}>
                   {" "}
                   {(snapshot as { name: string }).name}
+                </span>
+              ) : extendedType === "group" &&
+                value &&
+                (value as RawGroup).name ? (
+                <span style={{ color: "#57534e", fontWeight: 500 }}>
+                  {" "}
+                  {(value as RawGroup).name}
                 </span>
               ) : null}
             </span>

--- a/packages/jazz-tools/src/tools/coValues/group.ts
+++ b/packages/jazz-tools/src/tools/coValues/group.ts
@@ -62,7 +62,9 @@ export class Group extends CoValueBase implements CoValue {
   declare $jazz: GroupJazzApi<this>;
 
   /** @deprecated Don't use constructor directly, use .create */
-  constructor(options: { fromRaw: RawGroup } | { owner: Account }) {
+  constructor(
+    options: { fromRaw: RawGroup } | { owner: Account; name?: string },
+  ) {
     super();
     let raw: RawGroup;
 
@@ -73,7 +75,9 @@ export class Group extends CoValueBase implements CoValue {
       if (!initOwner) throw new Error("No owner provided");
       if (initOwner[TypeSym] === "Account" && isControlledAccount(initOwner)) {
         const rawOwner = initOwner.$jazz.raw;
-        raw = rawOwner.core.node.createGroup();
+        const nameOptions =
+          options.name !== undefined ? { name: options.name } : undefined;
+        raw = rawOwner.core.node.createGroup(undefined, nameOptions);
       } else {
         throw new Error("Can only construct group as a controlled account");
       }
@@ -96,7 +100,7 @@ export class Group extends CoValueBase implements CoValue {
 
   static create<G extends Group>(
     this: CoValueClass<G>,
-    options?: { owner: Account } | Account,
+    options?: { owner?: Account; name?: string } | Account,
   ) {
     return new this(parseGroupCreateOptions(options));
   }
@@ -358,6 +362,15 @@ export class GroupJazzApi<G extends Group> extends CoValueJazzApi<G> {
    */
   get owner(): undefined {
     return undefined;
+  }
+
+  /**
+   * Optional display name set at group creation. Immutable; stored in plaintext.
+   *
+   * @category Content
+   */
+  get name(): string | undefined {
+    return this.raw.name;
   }
 
   /** @category Subscription & Loading */

--- a/packages/jazz-tools/src/tools/coValues/interfaces.ts
+++ b/packages/jazz-tools/src/tools/coValues/interfaces.ts
@@ -513,17 +513,21 @@ export function parseGroupCreateOptions(
   options:
     | {
         owner?: Account;
+        name?: string;
       }
     | Account
     | undefined,
-) {
+): { owner: Account; name?: string } {
   if (!options) {
     return { owner: activeAccountContext.get() };
   }
 
-  return TypeSym in options && isAccountInstance(options)
-    ? { owner: options }
-    : { owner: options.owner ?? activeAccountContext.get() };
+  if (TypeSym in options && isAccountInstance(options)) {
+    return { owner: options };
+  }
+
+  const owner = options.owner ?? activeAccountContext.get();
+  return options.name !== undefined ? { owner, name: options.name } : { owner };
 }
 
 export function getIdFromHeader(

--- a/packages/jazz-tools/src/tools/tests/interfaces.test.ts
+++ b/packages/jazz-tools/src/tools/tests/interfaces.test.ts
@@ -88,4 +88,38 @@ describe("parseGroupCreateOptions", () => {
     const result = parseGroupCreateOptions({ owner: account });
     expect(result.owner).toBe(account);
   });
+
+  it("should include name when provided in options", async () => {
+    const account = await createJazzTestAccount();
+    const result = parseGroupCreateOptions({
+      owner: account,
+      name: "My Group",
+    });
+    expect(result.owner).toBe(account);
+    expect(result.name).toBe("My Group");
+  });
+
+  it("should not include name when not provided", async () => {
+    const account = await createJazzTestAccount();
+    const result = parseGroupCreateOptions({ owner: account });
+    expect(result.name).toBeUndefined();
+  });
+});
+
+describe("Group name metadata", () => {
+  it("should have undefined name when created without name", async () => {
+    const account = await createJazzTestAccount({
+      isCurrentActiveAccount: true,
+    });
+    const group = Group.create({ owner: account });
+    expect(group.$jazz.name).toBeUndefined();
+  });
+
+  it("should have name when created with name", async () => {
+    const account = await createJazzTestAccount({
+      isCurrentActiveAccount: true,
+    });
+    const group = Group.create({ owner: account, name: "Jazz Group" });
+    expect(group.$jazz.name).toBe("Jazz Group");
+  });
 });


### PR DESCRIPTION
# Description
In apps with nested groups (e.g. workspace → project → space, or org → team → channel), the group hierarchy is often inspected as a long list of “Group” labels and CoIDs. That makes it hard to see which group is which and to debug permission or structure issues.
Allowing a name to be set when a group is created gives a stable, human-readable label for each group. Because the name is part of the group’s header and never changes, it stays a reliable reference when analyzing hierarchies in the inspector, logs, or other tooling.

Groups can now have an optional display name set at creation time and stored in the CoValue header, which makes it immutable. It is exposed as group.name in both cojson and jazz-tools and is shown in the Jazz inspector.

<img width="787" height="348" alt="immagine" src="https://github.com/user-attachments/assets/57ae6c86-d2b6-41c2-a45c-0b60bf438e97" />


## Manual testing instructions

Available in the Todo app when creating new projects.

## Missing
-  [ ] Docs
-  [ ] JSDoc 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches group creation and header metadata persistence, which can affect on-disk/on-wire compatibility and downstream consumers if assumptions about `header.meta` shape change. The change is additive and guarded (name optional, empty ignored), reducing but not eliminating risk.
> 
> **Overview**
> Adds optional, immutable `name` metadata for Groups, stored in the CoValue header meta and exposed via `RawGroup.name` and `Group.$jazz.name`.
> 
> Updates group creation APIs to accept `{ name }` (with empty strings treated as unset), wires this through `LocalNode.createGroup` and `jazz-tools` `Group.create`, and enhances the inspector to display group/account icons and show group names where available (with corresponding test updates).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8098d404543a5580a8dbb5a40489e42accf34102. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->