### PR TITLE
fix(jazz-tools/tools): fix createdAt from covalue's header

### DIFF
--- a/.changeset/fix-createdat-getter.md
+++ b/.changeset/fix-createdat-getter.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Fixed createdAt getter to use CoValue's header

--- a/packages/cojson/src/tests/coList.test.ts
+++ b/packages/cojson/src/tests/coList.test.ts
@@ -210,6 +210,7 @@ test("init the list correctly", () => {
     "universe",
     "hello",
   ]);
+  expect(content.core.verified.header.createdAt).toBeDefined();
 });
 
 test("Items prepended to start appear with latest first", () => {

--- a/packages/jazz-tools/src/tools/coValues/CoValueBase.ts
+++ b/packages/jazz-tools/src/tools/coValues/CoValueBase.ts
@@ -103,7 +103,7 @@ export abstract class CoValueJazzApi<V extends CoValue> {
    * @category Content
    */
   get createdAt(): number {
-    const createdAt = this.raw.core.verified.header.meta?.createdAt;
+    const createdAt = this.raw.core.verified.header.createdAt;
 
     if (typeof createdAt === "string") {
       return new Date(createdAt).getTime();

--- a/packages/jazz-tools/src/tools/tests/coList.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coList.test.ts
@@ -47,6 +47,15 @@ describe("Simple CoList operations", async () => {
       "BUTTER",
       "ONION",
     ]);
+    expect(list.$jazz.createdAt).not.toBe(Number.MAX_SAFE_INTEGER);
+  });
+
+  test("construction with empty list", () => {
+    const List = co.list(z.string());
+    const list = List.create([]);
+    expect(list.length).toBe(0);
+
+    expect(list.$jazz.createdAt).not.toBe(Number.MAX_SAFE_INTEGER);
   });
 
   test("list with enum type", () => {

--- a/packages/jazz-tools/src/tools/tests/coMap.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coMap.test.ts
@@ -2339,7 +2339,9 @@ describe("createdAt, lastUpdatedAt, createdBy", () => {
     const person = Person.create({ name: "John" });
 
     const createdAt = person.$jazz.createdAt;
-    expect(person.$jazz.lastUpdatedAt).toEqual(createdAt);
+    const setNameJohnTx = person.$jazz.raw.core.verifiedTransactions[0];
+    expect(person.$jazz.createdAt).toEqual(createdAt);
+    expect(person.$jazz.lastUpdatedAt).toEqual(setNameJohnTx!.madeAt);
 
     const createdBy = person.$jazz.createdBy;
     expect(createdBy).toEqual(me.$jazz.id);
@@ -2347,8 +2349,9 @@ describe("createdAt, lastUpdatedAt, createdBy", () => {
     await new Promise((r) => setTimeout(r, 10));
     person.$jazz.set("name", "Jane");
 
+    const setNameJaneTx = person.$jazz.raw.core.verifiedTransactions[1];
     expect(person.$jazz.createdAt).toEqual(createdAt);
-    expect(person.$jazz.lastUpdatedAt).not.toEqual(createdAt);
+    expect(person.$jazz.lastUpdatedAt).toEqual(setNameJaneTx!.madeAt);
 
     // Double check after update.
     expect(createdBy).toEqual(me.$jazz.id);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small change to timestamp derivation that affects `createdAt`/`lastUpdatedAt` semantics; risk is limited to consumers relying on the old (incorrect) fallback behavior.
> 
> **Overview**
> Fixes `CoValueJazzApi.createdAt` to read from `raw.core.verified.header.createdAt` (instead of `header.meta?.createdAt`), aligning Jazz’s creation timestamp with the underlying CoValue header.
> 
> Updates tests to assert `createdAt` is populated for lists (including empty lists) and to make `coMap`’s `lastUpdatedAt` expectations track the latest verified transaction `madeAt` rather than always equaling `createdAt`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ae8580f2562101c3fe6719a547151849f92a3fd9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->