### PR TITLE
Fix: Edge must subscribe to core when handling client LOAD with lazy …

### DIFF
--- a/packages/cojson/src/sync.ts
+++ b/packages/cojson/src/sync.ts
@@ -626,6 +626,17 @@ export class SyncManager {
           action: "known",
           ...storageKnownState,
         });
+
+        // Subscribe to server peers (e.g., core) to receive future updates.
+        // Even though we responded with KNOWN (client has everything), we need
+        // to establish a subscription so that updates from core flow to us.
+        // We use sendLoadRequest directly (instead of loadFromPeers) to avoid
+        // marking the coValue as "pending" which would incorrectly affect loading
+        // state tracking and potentially trigger loading into memory.
+        for (const serverPeer of this.getServerPeers(msg.id, peer.id)) {
+          serverPeer.sendLoadRequest(coValue, "low-priority");
+        }
+
         return;
       }
 

--- a/packages/cojson/src/sync.ts
+++ b/packages/cojson/src/sync.ts
@@ -630,12 +630,8 @@ export class SyncManager {
         // Subscribe to server peers (e.g., core) to receive future updates.
         // Even though we responded with KNOWN (client has everything), we need
         // to establish a subscription so that updates from core flow to us.
-        // We use sendLoadRequest directly (instead of loadFromPeers) to avoid
-        // marking the coValue as "pending" which would incorrectly affect loading
-        // state tracking and potentially trigger loading into memory.
-        for (const serverPeer of this.getServerPeers(msg.id, peer.id)) {
-          serverPeer.sendLoadRequest(coValue, "low-priority");
-        }
+        const serverPeers = this.getServerPeers(msg.id, peer.id);
+        coValue.loadFromPeers(serverPeers);
 
         return;
       }

--- a/packages/cojson/src/tests/sync.mesh.test.ts
+++ b/packages/cojson/src/tests/sync.mesh.test.ts
@@ -730,7 +730,6 @@ describe("multiple clients syncing with the a cloud-like server mesh", () => {
     SyncMessagesLog.clear();
 
     // Now client2 connects directly to core and makes an update
-    // Without the fix, this update would NOT reach client1 through edge
     const client2 = setupTestNode();
     client2.connectToSyncServer({
       ourName: "client2",

--- a/packages/cojson/src/tests/sync.mesh.test.ts
+++ b/packages/cojson/src/tests/sync.mesh.test.ts
@@ -652,7 +652,6 @@ describe("multiple clients syncing with the a cloud-like server mesh", () => {
     // Client1 loads the covalue (syncs to edge storage)
     const mapOnClient1 = await loadCoValueOrFail(client1.node, map.id);
     expect(mapOnClient1.get("hello")).toEqual("world");
-    await mapOnClient1.core.waitForSync();
 
     // Verify the states match
     const client1KnownState = mapOnClient1.core.knownState();

--- a/packages/cojson/src/tests/sync.mesh.test.ts
+++ b/packages/cojson/src/tests/sync.mesh.test.ts
@@ -605,4 +605,161 @@ describe("multiple clients syncing with the a cloud-like server mesh", () => {
 
     expect(mapOnClient.core.knownState()).toEqual(largeMap.core.knownState());
   });
+
+  test("edge must subscribe to core when handling client LOAD with lazy loading", async () => {
+    // Topology: client1 -> edge -> core <- client2
+    //
+    // When edge uses lazy loading (getKnownStateFromStorage) to respond
+    // to a client's LOAD request with KNOWN, it MUST still subscribe to
+    // core by sending a LOAD request. Otherwise, edge won't receive
+    // future updates from core for that covalue.
+    //
+    // This test verifies that updates from client2 (connected to core)
+    // properly propagate to client1 (connected to edge).
+
+    // Setup: core server with storage
+    const core = setupTestNode();
+    core.addStorage({ ourName: "core" });
+
+    // Setup: edge server with storage, connected to core
+    const edge = setupTestNode();
+    edge.addStorage({ ourName: "edge" });
+    edge.connectToSyncServer({
+      ourName: "edge",
+      syncServerName: "core",
+      syncServer: core.node,
+      persistent: true,
+    });
+
+    // Setup: client1 connected to edge
+    const client1 = setupTestNode();
+    client1.connectToSyncServer({
+      ourName: "client1",
+      syncServerName: "edge",
+      syncServer: edge.node,
+    });
+
+    // Create covalue on core and sync to edge and client1
+    const group = core.node.createGroup();
+    group.addMember("everyone", "writer"); // Allow anyone to write
+    const map = group.createMap();
+    map.set("hello", "world", "trusting");
+    await map.core.waitForSync();
+
+    // Client1 loads the covalue (syncs to edge storage)
+    const mapOnClient1 = await loadCoValueOrFail(client1.node, map.id);
+    expect(mapOnClient1.get("hello")).toEqual("world");
+    await mapOnClient1.core.waitForSync();
+
+    // Verify the states match
+    const client1KnownState = mapOnClient1.core.knownState();
+    const edgeStorageKnownState = edge.node.storage!.getKnownState(map.id);
+    expect(client1KnownState).toEqual(edgeStorageKnownState);
+
+    // Disconnect client1 (keeps data in memory)
+    client1.disconnect();
+
+    // Restart edge (clears memory, keeps storage)
+    const edgeStorage = edge.node.storage!;
+    await edge.restart();
+    edge.node.setStorage(edgeStorage);
+    edge.connectToSyncServer({
+      ourName: "edge",
+      syncServerName: "core",
+      syncServer: core.node,
+      persistent: true,
+    });
+
+    SyncMessagesLog.clear();
+
+    // Client1 reconnects with existing data (same known state as edge's storage)
+    // This triggers the lazy loading path in handleLoad
+    client1.connectToSyncServer({
+      ourName: "client1",
+      syncServerName: "edge",
+      syncServer: edge.node,
+    });
+
+    await client1.node.syncManager.waitForAllCoValuesSync();
+
+    // Verify edge used lazy loading AND subscribed to core
+    // Key messages:
+    // - edge -> storage | GET_KNOWN_STATE (lazy loading)
+    // - edge -> client1 | KNOWN (responds with KNOWN, not CONTENT)
+    // - edge -> core | LOAD (subscribes to core for future updates)
+    expect(
+      SyncMessagesLog.getMessages({
+        Group: group.core,
+        Map: map.core,
+      }),
+    ).toMatchInlineSnapshot(`
+      [
+        "client1 -> edge | LOAD Group sessions: header/5",
+        "client1 -> edge | LOAD Map sessions: header/1",
+        "edge -> storage | GET_KNOWN_STATE Group",
+        "storage -> edge | GET_KNOWN_STATE_RESULT Group sessions: header/5",
+        "edge -> client1 | KNOWN Group sessions: header/5",
+        "edge -> core | LOAD Group sessions: header/5",
+        "edge -> storage | GET_KNOWN_STATE Map",
+        "storage -> edge | GET_KNOWN_STATE_RESULT Map sessions: header/1",
+        "edge -> client1 | KNOWN Map sessions: header/1",
+        "edge -> core | LOAD Map sessions: header/1",
+        "core -> edge | KNOWN Group sessions: header/5",
+      ]
+    `);
+
+    // IMPORTANT: Verify the coValue is NOT loaded into memory on edge yet.
+    // The lazy loading optimization means edge should only have the coValue
+    // in storage, not in memory, until actual content arrives.
+    const mapOnEdge = edge.node.getCoValue(map.id);
+    expect(mapOnEdge.isAvailable()).toBe(false);
+
+    SyncMessagesLog.clear();
+
+    // Now client2 connects directly to core and makes an update
+    // Without the fix, this update would NOT reach client1 through edge
+    const client2 = setupTestNode();
+    client2.connectToSyncServer({
+      ourName: "client2",
+      syncServerName: "core",
+      syncServer: core.node,
+    });
+
+    const mapOnClient2 = await loadCoValueOrFail(client2.node, map.id);
+    mapOnClient2.set("hello", "updated by client2", "trusting");
+    await mapOnClient2.core.waitForSync();
+
+    // Wait for propagation: core -> edge -> client1
+    await waitFor(() => mapOnClient1.get("hello") === "updated by client2");
+
+    expect(mapOnEdge.isAvailable()).toBe(true);
+
+    expect(mapOnClient1.get("hello")).toEqual("updated by client2");
+    expect(
+      SyncMessagesLog.getMessages({
+        Group: group.core,
+        Map: map.core,
+      }),
+    ).toMatchInlineSnapshot(`
+      [
+        "client2 -> core | LOAD Map sessions: empty",
+        "core -> edge | KNOWN Map sessions: header/1",
+        "core -> client2 | CONTENT Group header: true new: After: 0 New: 5",
+        "core -> client2 | CONTENT Map header: true new: After: 0 New: 1",
+        "client2 -> core | KNOWN Group sessions: header/5",
+        "client2 -> core | KNOWN Map sessions: header/1",
+        "client2 -> core | CONTENT Map header: false new: After: 0 New: 1",
+        "core -> client2 | KNOWN Map sessions: header/2",
+        "core -> storage | CONTENT Map header: false new: After: 0 New: 1",
+        "core -> edge | CONTENT Map header: false new: After: 0 New: 1",
+        "edge -> storage | LOAD Map sessions: empty",
+        "storage -> edge | CONTENT Group header: true new: After: 0 New: 5",
+        "storage -> edge | CONTENT Map header: true new: After: 0 New: 1",
+        "edge -> core | KNOWN Map sessions: header/2",
+        "edge -> storage | CONTENT Map header: false new: After: 0 New: 1",
+        "edge -> client1 | CONTENT Map header: false new: After: 0 New: 1",
+        "client1 -> edge | KNOWN Map sessions: header/2",
+      ]
+    `);
+  });
 });


### PR DESCRIPTION
### Problem
When an edge server uses lazy loading (getKnownStateFromStorage) to respond to a client's LOAD request, it was not subscribing to the core server for that coValue. This caused the edge to miss future updates from core, leaving clients connected to the edge with stale data.

```
Topology: client1 ──► edge ──► core ◄── client2

Timeline (before fix):
┌─────────────────────────────────────────────────────────────────┐
│ 1. client1 and edge both have coValue (synced)                  │
│ 2. edge restarts with new session (fresh peer, no subscriptions)│
│ 3. client1 reconnects and sends LOAD to edge                    │
│ 4. edge uses lazy loading: checks storage, sees client1 has all │
│    content, responds with KNOWN                                 │
│ 5. edge does NOT send LOAD to core ❌ (BUG!)                    │
│ 6. client2 updates coValue via core                             │
│ 7. core has no subscription from edge, doesn't forward update   │
│ 8. client1 never receives the update ❌                         │
└─────────────────────────────────────────────────────────────────┘
```
### Solution
After responding with KNOWN to the client (lazy loading path), the edge now sends a LOAD request to its server peers (core) to establish a subscription for future updates.
```
Timeline (after fix):
┌─────────────────────────────────────────────────────────────────┐
│ 1-4. Same as before...                                          │
│ 5. edge sends LOAD to core ✅ (subscribes for updates)          │
│ 6. client2 updates coValue via core                             │
│ 7. core sends update to edge (edge is subscribed!)              │
│ 8. edge forwards update to client1 ✅                           │
└─────────────────────────────────────────────────────────────────┘
```


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core sync subscription behavior; incorrect peer selection or extra `LOAD`s could cause missed updates or increased sync chatter, though the change is small and covered by a targeted mesh test.
> 
> **Overview**
> Fixes an edge-server sync gap in `SyncManager.handleLoad`: when storage-based lazy loading determines a client already has all content and the edge replies with `KNOWN`, the edge now also issues a `LOAD` to its server peers to establish/refresh the subscription for future updates.
> 
> Adds a regression test covering an edge restart/new-session scenario to ensure `core -> edge -> client` update propagation still works even when the edge responds via the lazy `KNOWN` path (and keeps the coValue unloaded in memory until real content arrives).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 25cc977592e842c7c857feed46d90aa8c0909421. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->