### PR TITLE
test(jazz-tools/tools): fix flaky tests evaluation covalue creation date

### DIFF
--- a/packages/jazz-tools/src/tools/tests/coMap.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coMap.test.ts
@@ -2321,7 +2321,11 @@ describe("createdAt, lastUpdatedAt, createdBy", () => {
   test("empty map created time", () => {
     const emptyMap = co.map({}).create({});
 
-    expect(emptyMap.$jazz.lastUpdatedAt).toEqual(emptyMap.$jazz.createdAt);
+    const firstTx = emptyMap.$jazz.raw.core.verifiedTransactions.at(0);
+    expect(emptyMap.$jazz.createdAt).toEqual(firstTx!.madeAt);
+
+    const lastTx = emptyMap.$jazz.raw.core.verifiedTransactions.at(-1);
+    expect(emptyMap.$jazz.lastUpdatedAt).toEqual(lastTx!.madeAt);
   });
 
   test("empty map created by", () => {

--- a/packages/jazz-tools/src/tools/tests/coPlainText.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coPlainText.test.ts
@@ -273,6 +273,9 @@ describe("lastUpdatedAt", () => {
   test("empty text last updated time", () => {
     const text = co.plainText().create("");
 
+    expect(text.$jazz.createdAt).toEqual(
+      new Date(text.$jazz.raw.core.verified.header.createdAt!).getTime(),
+    );
     expect(text.$jazz.lastUpdatedAt).toEqual(text.$jazz.createdAt);
     expect(text.$jazz.lastUpdatedAt).not.toEqual(0);
   });


### PR DESCRIPTION
Fix #3423 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that adjust assertions to use deterministic internal timestamps; no production logic is modified.
> 
> **Overview**
> Updates `coMap` and `coPlainText` tests to assert `createdAt`/`lastUpdatedAt` against underlying verified transaction/header timestamps rather than assuming equality or relying on timing-sensitive behavior.
> 
> This reduces flakiness by tying expectations to the actual first/last verified transaction times during CoValue creation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f60570bc49935176a563992d8e502b23a3c682f0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->