### PR TITLE
Global tx for local and sync

### DIFF
--- a/.specs/atomic-transactions/design.md
+++ b/.specs/atomic-transactions/design.md
@@ -1,0 +1,620 @@
+# Design: Atomic Transactions for CoValue Mutations
+
+## Overview
+
+This design implements atomic transactions for CoValue mutations, allowing multiple mutations to be persisted together to IndexedDB and synced together to servers in a single network message. The core principle is **optimistic in-memory updates with atomic persistence** - mutations are applied immediately to memory, but persistence and sync happen atomically with automatic retry on failure.
+
+The key flow:
+1. User calls `account.withTransaction(callback)` with a **synchronous** callback
+2. Callback runs to completion (no await); mutations inside are applied to memory immediately
+3. All mutations are buffered in a `TransactionContext`
+4. After callback returns, all mutations are:
+   - Stored in a single IndexedDB transaction
+   - Sent in a single `BatchMessage` to sync servers
+5. If either fails, retry with exponential backoff (no rollback)
+
+## Architecture / Components
+
+### 1. Public API: `withTransaction()` Method
+
+**Location:** `packages/jazz-tools/src/tools/coValues/account.ts`
+
+Add method to `AccountJazzApi` class:
+
+```typescript
+class AccountJazzApi<A extends Account> extends CoValueJazzApi<A> {
+  /**
+   * Execute multiple mutations atomically.
+   * All mutations are applied immediately to memory, but persisted and synced as a batch.
+   *
+   * @param callback - Synchronous function containing mutations (no async/await)
+   * @returns Promise that resolves when all mutations are persisted and synced
+   *
+   * @example
+   * await account.withTransaction(() => {
+   *   map1.$jazz.set("key1", "value1");
+   *   map2.$jazz.set("key2", "value2");
+   *   list.$jazz.push(item);
+   * });
+   */
+  async withTransaction<T>(callback: () => T): Promise<T> {
+    return this.localNode.withTransaction(callback);
+  }
+}
+```
+
+### 2. Transaction Context
+
+**New File:** `packages/cojson/src/transactionContext.ts`
+
+```typescript
+import type { NewContentMessage, RawCoID } from "./types.js";
+
+export class TransactionContext {
+  private pendingMessages: NewContentMessage[] = [];
+  private pendingCoValues: Set<RawCoID> = new Set();
+
+  bufferMessage(msg: NewContentMessage): void {
+    this.pendingMessages.push(msg);
+    this.pendingCoValues.add(msg.id);
+  }
+
+  getPendingMessages(): NewContentMessage[] {
+    return this.pendingMessages;
+  }
+
+  getCoValueIds(): Set<RawCoID> {
+    return this.pendingCoValues;
+  }
+
+  isActive(): boolean {
+    return true;
+  }
+
+  clear(): void {
+    this.pendingMessages = [];
+    this.pendingCoValues.clear();
+  }
+}
+```
+
+Design notes:
+- The presence of a `TransactionContext` should be treated as the "active" signal.
+- The callback is **synchronous**; no other code can run until it returns, so there is
+  no read/write concurrency during the transaction window.
+
+### 3. LocalNode Integration
+
+**Location:** `packages/cojson/src/localNode.ts`
+
+Add transaction context support:
+
+```typescript
+export class LocalNode {
+  // ... existing properties ...
+
+  private transactionContext?: TransactionContext;
+
+  async withTransaction<T>(callback: () => T): Promise<T> {
+    // Check for nested transactions
+    if (this.transactionContext) {
+      throw new Error("Nested transactions are not supported");
+    }
+
+    // Create and activate transaction context
+    this.transactionContext = new TransactionContext();
+
+    try {
+      // Execute user callback synchronously (no concurrency while transaction is open)
+      const result = callback();
+
+      // Get buffered messages
+      const messages = this.transactionContext.getPendingMessages();
+
+      if (messages.length > 0) {
+        // Flush to storage and sync in parallel
+        await this.syncManager.syncAtomicBatch(messages);
+      }
+
+      return result;
+    } finally {
+      // Always clean up transaction context
+      this.transactionContext = undefined;
+    }
+  }
+
+  getTransactionContext(): TransactionContext | undefined {
+    return this.transactionContext;
+  }
+}
+```
+
+Design notes:
+- Empty batches should be treated as a no-op (avoid storage transaction / network).
+- If the callback throws, buffered messages are discarded; in-memory state diverges
+  from persisted state until future successful persistence.
+
+### 4. CoValueCore: Intercept makeTransaction
+
+**Location:** `packages/cojson/src/coValueCore/coValueCore.ts`
+
+Modify `makeTransaction()` (around line 1166):
+
+```typescript
+makeTransaction(changes: TransactionChanges): Transaction | undefined {
+  // ... existing validation ...
+
+  const transactionContext = this.node.getTransactionContext();
+
+  // Create the transaction content message
+  const content = this.newContentSince(knownStateBefore);
+
+  if (transactionContext?.isActive()) {
+    // Buffer the message instead of syncing immediately
+    for (const msg of content) {
+      transactionContext.bufferMessage(msg);
+    }
+    // Don't sync now - will be done when transaction completes
+  } else {
+    // Normal flow: sync immediately
+    this.node.syncManager.syncLocalTransaction(this.verified, knownStateBefore);
+  }
+
+  // ... rest of method (notify updates, etc.) ...
+}
+```
+
+### 5. New Message Type: BatchMessage
+
+**Location:** `packages/cojson/src/sync.ts` (around line 32)
+
+```typescript
+export type BatchMessage = {
+  action: "batch";
+  messages: NewContentMessage[];
+};
+
+export type SyncMessage =
+  | LoadMessage
+  | KnownStateMessage
+  | NewContentMessage
+  | DoneMessage
+  | BatchMessage; // Add this
+```
+
+### 6. SyncManager: Atomic Batch Sync
+
+**Location:** `packages/cojson/src/sync.ts`
+
+```typescript
+export class SyncManager {
+  /**
+   * Sync multiple mutations atomically.
+   * Stores all in IndexedDB in one transaction and sends as one BatchMessage to servers.
+   */
+  async syncAtomicBatch(messages: NewContentMessage[]): Promise<void> {
+    const storage = this.local.storage;
+    const coValueIds = new Set(messages.map(m => m.id));
+
+    if (messages.length === 0) {
+      return;
+    }
+
+    // Start both operations in parallel
+    const storagePromise = storage
+      ? this.storeAtomicBatchWithRetry(messages)
+      : Promise.resolve();
+
+    const syncPromise = this.syncBatchToServers(messages, coValueIds);
+
+    // Wait for both to complete
+    await Promise.all([storagePromise, syncPromise]);
+  }
+
+  private async storeAtomicBatchWithRetry(
+    messages: NewContentMessage[]
+  ): Promise<void> {
+    let attempt = 0;
+    const maxDelayMs = MAX_ATOMIC_BATCH_BACKOFF_MS;
+
+    while (true) {
+      try {
+        await this.local.storage!.storeAtomicBatch(messages);
+        return; // Success
+      } catch (error) {
+        attempt++;
+        const delay = Math.min(BASE_ATOMIC_BATCH_BACKOFF_MS * Math.pow(2, attempt), maxDelayMs);
+        logger.warn("IndexedDB atomic batch failed, retrying", {
+          attempt,
+          delay,
+          error
+        });
+        await new Promise(resolve => setTimeout(resolve, delay));
+      }
+    }
+  }
+
+  private async syncBatchToServers(
+    messages: NewContentMessage[],
+    coValueIds: Set<RawCoID>
+  ): Promise<void> {
+    // Create single batch message
+    const batchMessage: BatchMessage = {
+      action: "batch",
+      messages: messages
+    };
+
+    // Send to all server peers
+    for (const coValueId of coValueIds) {
+      for (const peer of this.getPeers(coValueId)) {
+        if (peer.role === "server") {
+          this.trySendToPeer(peer, batchMessage);
+        }
+      }
+    }
+
+    // Wait for all CoValues to be synced
+    await this.waitForBatchSynced(coValueIds);
+  }
+
+  private async waitForBatchSynced(coValueIds: Set<RawCoID>): Promise<void> {
+    let attempt = 0;
+    const maxDelayMs = MAX_ATOMIC_BATCH_BACKOFF_MS;
+
+    while (true) {
+      // Check if all CoValues are synced to all server peers
+      const allSynced = Array.from(coValueIds).every(id => {
+        const peers = this.getPersistentServerPeers(id);
+        return peers.length === 0 || peers.every(peer =>
+          this.syncState.isSynced(peer, id)
+        );
+      });
+
+      if (allSynced) {
+        return; // Success
+      }
+
+      // Not synced yet, wait and retry
+      attempt++;
+      const delay = Math.min(BASE_ATOMIC_BATCH_BACKOFF_MS * Math.pow(2, attempt), maxDelayMs);
+      await new Promise(resolve => setTimeout(resolve, delay));
+    }
+  }
+}
+```
+
+Design notes:
+- Storage and sync retry independently; if one succeeds, it must not be re-run on retry.
+- Backoff values should be defined as named constants (avoid magic numbers).
+- If a transaction timeout is configured, only the caller promise is rejected; retries
+  continue in the background until success.
+
+### 7. Server-Side: Handle Batch Messages
+
+**Location:** `packages/cojson/src/sync.ts`
+
+Update `handleSyncMessage()` switch statement (around line 215):
+
+```typescript
+handleSyncMessage(msg: SyncMessage, peer: PeerState) {
+  // ... existing validation ...
+
+  switch (msg.action) {
+    case "load":
+      return this.handleLoad(msg, peer);
+    case "known":
+      if (msg.isCorrection) {
+        return this.handleCorrection(msg, peer);
+      } else {
+        return this.handleKnownState(msg, peer);
+      }
+    case "content":
+      return this.handleNewContent(msg, peer);
+    case "batch":  // Add this
+      return this.handleBatch(msg, peer);
+    case "done":
+      return;
+    default:
+      throw new Error(
+        `Unknown message type ${(msg as { action: string }).action}`,
+      );
+  }
+}
+
+/**
+ * Handle a batch of content messages.
+ * Unpacks the batch and processes each message individually.
+ */
+handleBatch(msg: BatchMessage, peer: PeerState) {
+  for (const message of msg.messages) {
+    this.handleNewContent(message, peer); // Reuse existing logic!
+  }
+}
+```
+
+Design notes:
+- `handleBatch` must preserve per-CoValue ordering as sent by the client.
+- `handleNewContent` must update sync state per message so batch retries remain idempotent.
+
+### 8. Storage API: Atomic Batch Method
+
+**Location:** `packages/cojson/src/storage/storageAsync.ts`
+
+```typescript
+export class StorageApiAsync implements StorageAPI {
+  /**
+   * Store multiple messages atomically in a single IndexedDB transaction.
+   * If any operation fails, the entire transaction is rolled back and retried.
+   */
+  async storeAtomicBatch(messages: NewContentMessage[]): Promise<void> {
+    // Use the DB client's transaction method for atomicity
+    await this.dbClient.transaction(async (tx) => {
+      for (const msg of messages) {
+        // Store each message in the same transaction
+        await this.storeSingleInTransaction(msg, tx);
+      }
+    });
+  }
+
+  private async storeSingleInTransaction(
+    msg: NewContentMessage,
+    tx: IDBTransaction
+  ): Promise<void> {
+    // Store CoValue header
+    const storedCoValueRowID = await tx.upsertCoValue(msg.id, msg.header);
+
+    if (!storedCoValueRowID) {
+      throw new Error(`Failed to upsert CoValue ${msg.id}`);
+    }
+
+    // Store all sessions and transactions
+    for (const [sessionID, sessionContent] of Object.entries(msg.new)) {
+      const session = await tx.addSessionUpdate(
+        storedCoValueRowID,
+        sessionID,
+        sessionContent.after,
+        sessionContent.lastSignature
+      );
+
+      // Store transactions
+      for (let i = 0; i < sessionContent.newTransactions.length; i++) {
+        const transaction = sessionContent.newTransactions[i];
+        await tx.addTransaction(
+          session.rowID,
+          sessionContent.after + i + 1,
+          transaction
+        );
+      }
+
+      // Store signature if present
+      if (sessionContent.newTransactions.length > 0) {
+        await tx.addSignatureAfter(
+          session.rowID,
+          sessionContent.after + sessionContent.newTransactions.length,
+          sessionContent.lastSignature
+        );
+      }
+    }
+  }
+}
+```
+
+### 9. IndexedDB Client: Transaction Support
+
+**Location:** `packages/cojson-storage-indexeddb/src/idbClient.ts`
+
+The existing `transaction()` method (line 299) already supports this pattern:
+
+```typescript
+async transaction(
+  operationsCallback: (tx: IDBTransaction) => Promise<unknown>,
+  storeNames?: StoreName[],
+) {
+  const tx = new CoJsonIDBTransaction(this.db, storeNames);
+
+  try {
+    await operationsCallback(new IDBTransaction(tx));
+    tx.commit(); // Commit atomically
+  } catch (error) {
+    tx.rollback(); // Rollback on error
+    throw error; // Re-throw for retry logic
+  }
+}
+```
+
+## Data Flow
+
+### Complete Transaction Flow
+
+```
+User Code
+    ↓
+account.withTransaction(callback)
+    ↓
+LocalNode.withTransaction()
+    ↓
+    [Create TransactionContext]
+    ↓
+Execute callback
+    ↓
+    ├─> map1.$jazz.set()
+    │   ↓
+    │   CoValueCore.makeTransaction()
+    │   ↓
+    │   [Check transaction context active]
+    │   ↓
+    │   [Apply to memory immediately]
+    │   ↓
+    │   [Buffer NewContentMessage]
+    │
+    ├─> map2.$jazz.set() [same flow]
+    └─> list.$jazz.push() [same flow]
+    ↓
+[Callback complete, N messages buffered]
+    ↓
+SyncManager.syncAtomicBatch(messages)
+    ↓
+Parallel execution:
+    ├─> StorageApiAsync.storeAtomicBatch()
+    │   ↓
+    │   IDBClient.transaction()
+    │   ↓
+    │   [Store all messages in single transaction]
+    │   ↓
+    │   [Commit or rollback]
+    │   ↓
+    │   [Retry on failure]
+    │
+    └─> syncBatchToServers()
+        ↓
+        Create BatchMessage { action: "batch", messages: [...] }
+        ↓
+        peer.pushOutgoingMessage(batchMessage)
+        ↓
+        [Server receives ONE message]
+        ↓
+        Server.handleBatch()
+        ↓
+        For each message:
+          handleNewContent(message)
+        ↓
+        [Server optionally stores in transaction]
+        ↓
+        waitForBatchSynced()
+        ↓
+        [Check syncState.isSynced() for all CoValues]
+        ↓
+        [Retry if not synced]
+    ↓
+[Both storage and sync succeed]
+    ↓
+Return to user
+```
+
+## Error Handling / Retry Strategy
+
+### Core Principle: No Rollback, Only Retry
+
+In-memory mutations are permanent. If persistence or sync fails, the system retries until success.
+
+### Error Scenarios
+
+**1. Error During Callback Execution**
+- Mutations before the error remain in memory
+- Mutations after the error are not executed
+- No persistence or sync is attempted
+- Transaction context is cleaned up
+
+**2. IndexedDB Storage Failure**
+- Mutations already in memory (visible to user)
+- Storage operation fails atomically (no partial writes)
+- System retries with exponential backoff
+- Continues retrying until success
+
+**3. Network Sync Failure**
+- Mutations already in memory and persisted to IndexedDB
+- System queues for retry
+- Retries when network reconnects or with exponential backoff
+- Continues until all CoValues show as synced in `syncState`
+
+**4. Partial Sync (Multiple Server Peers)**
+- Track sync state for each server peer
+- Keep retrying to servers that haven't ACKed
+- Batch considered "fully synced" when all servers have it
+
+**5. Nested Transactions**
+- Throw error immediately
+- Alternative: flatten into outer transaction (not implemented)
+
+### Retry Strategy
+
+```typescript
+// Exponential backoff with max delay
+attempt = 1: wait 100ms
+attempt = 2: wait 200ms
+attempt = 3: wait 400ms
+attempt = 4: wait 800ms
+...
+max delay: 30 seconds
+continues indefinitely until success
+```
+
+## Testing Strategy
+
+### Unit Tests
+
+1. **TransactionContext:**
+   - Test bufferMessage() adds messages
+   - Test getPendingMessages() returns buffered messages
+   - Test clear() empties buffer
+
+2. **LocalNode.withTransaction():**
+   - Test creates and cleans up transaction context
+   - Test callback result is returned
+   - Test errors in callback are propagated
+   - Test nested transactions throw error
+
+3. **CoValueCore.makeTransaction():**
+   - Test buffers messages when transaction context active
+   - Test syncs immediately when no transaction context
+   - Test mutations are applied to memory in both cases
+
+4. **SyncManager.syncAtomicBatch():**
+   - Test calls storeAtomicBatch() and syncBatchToServers()
+   - Test retries storage on failure
+   - Test retries sync until all CoValues synced
+
+5. **StorageApiAsync.storeAtomicBatch():**
+   - Test stores all messages in single transaction
+   - Test rolls back on failure
+   - Test throws error for retry
+
+### Integration Tests
+
+1. **Successful Transaction:**
+   - Execute multiple mutations in transaction
+   - Verify all stored in IndexedDB atomically
+   - Verify all sent in single BatchMessage
+   - Verify all synced to server
+
+2. **Transaction with Error:**
+   - Execute mutations, throw error mid-callback
+   - Verify partial mutations remain in memory
+   - Verify no persistence or sync occurred
+
+3. **Storage Failure and Retry:**
+   - Mock IndexedDB failure
+   - Verify retry with exponential backoff
+   - Verify eventual success
+
+4. **Network Failure and Retry:**
+   - Mock network disconnection
+   - Verify retry when network returns
+   - Verify batch eventually syncs
+
+5. **Server Batch Processing:**
+   - Send BatchMessage to server
+   - Verify server unpacks and processes each message
+   - Verify existing handleNewContent() logic works
+
+### Performance Tests
+
+1. Benchmark transaction with 1, 10, 100, 1000 mutations
+2. Compare single transaction vs individual stores (IndexedDB)
+3. Compare BatchMessage vs individual messages (network)
+4. Memory usage with large transactions
+
+## Backward Compatibility
+
+- Servers that don't understand `BatchMessage` will ignore it (unknown action type)
+- No breaking changes to existing APIs
+
+## Constraints and Footguns
+
+- The transaction callback is **synchronous**; the implementation must not accept or
+  await an async callback, so that no other code can run until the callback returns
+  and the batch is fixed.
+- Batch size limits (count and/or payload size) must be enforced with explicit behavior
+  (reject, split, or fallback).
+- If storage succeeds but sync does not (or vice versa), the system must continue retrying
+  only the failing side without repeating the successful side.

--- a/.specs/atomic-transactions/requirements.md
+++ b/.specs/atomic-transactions/requirements.md
@@ -1,0 +1,126 @@
+# Atomic Transactions for CoValue Mutations
+
+**Context**
+Users need to guarantee that multiple CoValue mutations either all persist together or none of them do. This is critical for maintaining data consistency when changes span multiple CoValues or when a group of related changes must be atomic. Currently, each mutation is stored separately, which can lead to partial states if operations fail midway.
+
+## User Stories
+
+### US-1: Execute Multiple Mutations Atomically
+
+> **As a** Jazz application developer
+> **I want** to execute multiple CoValue mutations in a single atomic transaction
+> **So that** all changes either succeed together or fail together, preventing partial states
+
+**Acceptance Criteria:**
+* The system shall provide a `withTransaction()` method on the account that accepts a **synchronous** callback function (no async, no await; avoids read/write concurrency while the transaction is open)
+* When mutations are executed within the callback:
+  * All mutations shall be applied immediately to in-memory state (optimistic updates)
+  * All mutations shall be buffered and not immediately persisted
+* When the callback completes successfully:
+  * All mutations shall be persisted to IndexedDB in a single transaction
+  * All mutations shall be sent to sync servers in a single network message
+  * If either persistence or sync fails, the system shall retry until success
+* When the callback throws an error:
+  * Mutations executed before the error shall remain in memory
+  * No mutations shall be persisted or synced
+  * Buffered transaction messages shall be discarded on error
+  * The discrepancy between in-memory state and persisted state shall be documented
+* The method shall return a Promise that resolves when persistence and sync are complete
+* The method shall preserve the per-CoValue mutation order when buffering and sending
+
+---
+
+### US-2: Atomic IndexedDB Storage
+
+> **As a** Jazz application developer
+> **I want** all mutations in a transaction to be stored in a single IndexedDB transaction
+> **So that** local storage remains consistent even if storage operations fail
+
+**Acceptance Criteria:**
+* When storing a batch of mutations:
+  * The system shall open a single IndexedDB transaction
+  * All mutations shall be written within that transaction
+  * The transaction shall either commit all changes or rollback all changes
+* If the IndexedDB transaction fails:
+  * No partial data shall be written to storage
+  * The system shall retry the entire batch with exponential backoff
+  * In-memory state shall remain unchanged
+* The system shall continue retrying until the transaction succeeds
+* Storage implementations used in production (IndexedDB, SQLite) shall provide
+  equivalent atomic batch guarantees
+* Empty batches shall be treated as a no-op without opening a storage transaction
+
+---
+
+### US-3: Atomic Network Sync
+
+> **As a** Jazz application developer
+> **I want** all mutations in a transaction to be sent to sync servers as a single message
+> **So that** servers receive and process the entire batch together
+
+**Acceptance Criteria:**
+* When syncing a batch of mutations:
+  * The system shall create a single `BatchMessage` containing all mutations
+  * The message shall be sent as one network request per peer
+* When the server receives a `BatchMessage`:
+  * The system shall unpack the batch
+  * Each mutation shall be processed with existing `handleNewContent()` logic
+  * The server may optionally store all mutations in a single database transaction
+  * The server shall preserve the order of mutations within the batch
+* If network sync fails:
+  * The system shall retry sending the entire `BatchMessage`
+  * In-memory state and local storage shall remain unchanged
+  * The system shall use existing sync state tracking to know when all CoValues are synced
+* If a server does not support `BatchMessage`:
+  * The client shall fall back to sending individual `NewContentMessage`s
+  * The fallback shall preserve per-CoValue ordering
+  * The client shall continue retrying until the server acknowledges receipt
+
+---
+
+### US-4: Eventual Consistency with Retry
+
+> **As a** Jazz application developer
+> **I want** failed transactions to automatically retry until they succeed
+> **So that** I don't need to implement complex retry logic
+
+**Acceptance Criteria:**
+* When persistence or sync fails:
+  * The system shall NOT rollback in-memory changes
+  * The system shall retry with exponential backoff
+  * The system shall continue retrying indefinitely until success
+* Users shall be able to:
+  * Await the transaction promise to wait for full persistence
+  * Continue using the app with optimistic in-memory state
+  * Optionally specify a timeout for the transaction
+* If a timeout is reached:
+  * The promise shall reject with a timeout error
+  * Retry shall continue in the background until success
+
+---
+
+### US-5: Transaction Context Isolation
+
+> **As a** Jazz application developer
+> **I want** mutations outside of `withTransaction()` to behave normally
+> **So that** the transaction API is opt-in and doesn't affect existing code
+
+**Acceptance Criteria:**
+* Mutations executed outside of `withTransaction()`:
+  * Shall be applied immediately to memory
+  * Shall be persisted and synced individually (existing behavior)
+* Mutations executed inside `withTransaction()`:
+  * Shall be buffered and processed as a batch
+* The callback shall be synchronous; the system shall not await the callback (no async callbacks)
+* Nested transactions shall be handled:
+  * Either: flatten into the outer transaction
+  * Or: throw an error indicating nesting is not supported
+
+---
+
+## Global Constraints and Edge Cases
+
+* Batch size limits shall be defined (by message count and/or payload size),
+  with explicit behavior when exceeded (reject, split, or fallback).
+* Batching shall not weaken ordering guarantees for mutations within a CoValue.
+* Sync state tracking shall treat batch delivery as individual message delivery.

--- a/.specs/atomic-transactions/tasks.md
+++ b/.specs/atomic-transactions/tasks.md
@@ -1,0 +1,299 @@
+# Implementation Tasks
+
+## Phase 1: Core Infrastructure (US-5)
+
+- [ ] **Task 1**: Create TransactionContext class
+  - Create new file `packages/cojson/src/transactionContext.ts`
+  - Implement `TransactionContext` class with methods:
+    - `bufferMessage(msg: NewContentMessage): void`
+    - `getPendingMessages(): NewContentMessage[]`
+    - `getCoValueIds(): Set<RawCoID>`
+    - `isActive(): boolean`
+    - `clear(): void`
+  - Add unit tests for all methods
+
+- [ ] **Task 2**: Add transaction context to LocalNode
+  - Add `transactionContext?: TransactionContext` property to `LocalNode` in `packages/cojson/src/localNode.ts`
+  - Add `getTransactionContext(): TransactionContext | undefined` method
+  - Export for use by CoValueCore
+
+- [ ] **Task 3**: Implement LocalNode.withTransaction()
+  - Add `withTransaction<T>(callback: () => T): Promise<T>` method to `LocalNode`
+  - Callback must be **synchronous** (invoke with `callback()`, do not await)
+  - Create `TransactionContext` before executing callback
+  - Execute callback and capture result/errors
+  - Get buffered messages after callback completes
+  - Call `syncManager.syncAtomicBatch()` with messages
+  - Clean up transaction context in `finally` block
+  - Handle nested transactions (throw error)
+  - Support optional timeout (reject promise, keep retries running)
+  - Add unit tests
+
+## Phase 2: Intercept Mutations (US-1, US-5)
+
+- [ ] **Task 4**: Modify CoValueCore.makeTransaction()
+  - Update `makeTransaction()` in `packages/cojson/src/coValueCore/coValueCore.ts` (line ~1166)
+  - Check if `node.getTransactionContext()` is active
+  - If active: buffer `NewContentMessage` instead of syncing
+  - If not active: sync immediately (existing behavior)
+  - Ensure mutations still applied to memory in both cases
+  - Add unit tests for both paths
+
+## Phase 3: Protocol Extension (US-3)
+
+- [ ] **Task 5**: Add BatchMessage type
+  - Add `BatchMessage` type to `packages/cojson/src/sync.ts` (around line 32):
+    ```typescript
+    export type BatchMessage = {
+      action: "batch";
+      messages: NewContentMessage[];
+    };
+    ```
+  - Update `SyncMessage` union to include `BatchMessage`
+  - Export type from `packages/cojson/src/exports.ts`
+
+- [ ] **Task 6**: Add handleBatch() to SyncManager
+  - Add `handleBatch(msg: BatchMessage, peer: PeerState)` method to `SyncManager` in `packages/cojson/src/sync.ts`
+  - Loop through `msg.messages` and call `this.handleNewContent(message, peer)` for each
+  - Update `handleSyncMessage()` switch statement to route `"batch"` action
+  - Add unit tests
+
+## Phase 4: Storage Layer (US-2)
+
+- [ ] **Task 7**: Add storeAtomicBatch() to StorageAPI interface
+  - Add method signature to `StorageAPI` interface in `packages/cojson/src/storage/types.ts`:
+    ```typescript
+    storeAtomicBatch(messages: NewContentMessage[]): Promise<void>;
+    ```
+
+- [ ] **Task 8**: Implement storeAtomicBatch() in StorageApiAsync
+  - Implement method in `packages/cojson/src/storage/storageAsync.ts`
+  - Use `dbClient.transaction()` to wrap all stores
+  - Call `storeSingleInTransaction()` for each message
+  - Throw error on failure for retry logic
+  - Add unit tests
+
+- [ ] **Task 9**: Create storeSingleInTransaction() helper
+  - Add private method `storeSingleInTransaction(msg: NewContentMessage, tx: IDBTransaction)` to `StorageApiAsync`
+  - Extract logic from existing `storeSingle()` method
+  - Adapt to work within an existing transaction context
+  - Store CoValue header, sessions, transactions, and signatures
+
+- [ ] **Task 10**: Implement storeAtomicBatch() in StorageApiSync
+  - Implement method in `packages/cojson/src/storage/storageSync.ts`
+  - Similar to async version but synchronous
+  - Use SQLite transaction support
+  - Add unit tests
+
+## Phase 5: Sync Layer (US-3, US-4)
+
+- [ ] **Task 11**: Implement SyncManager.syncAtomicBatch()
+  - Add method to `SyncManager` in `packages/cojson/src/sync.ts`
+  - Extract CoValue IDs from messages
+  - Call `storeAtomicBatchWithRetry()` for IndexedDB persistence
+  - Call `syncBatchToServers()` for network sync
+  - Run both in parallel with `Promise.all()`
+  - Short-circuit empty batches (no-op)
+  - Ensure successful side is not re-run if the other side retries
+  - Return Promise that resolves when both complete
+
+- [ ] **Task 12**: Implement storeAtomicBatchWithRetry()
+  - Add private method to `SyncManager`
+  - Call `storage.storeAtomicBatch()` in a retry loop
+  - Implement exponential backoff using named constants
+  - Log warnings on retry
+  - Continue retrying indefinitely until success
+  - Add unit tests for retry logic
+
+- [ ] **Task 13**: Implement syncBatchToServers()
+  - Add private method to `SyncManager`
+  - Create single `BatchMessage` containing all messages
+  - Send to all server peers using `trySendToPeer()`
+  - Detect peers that do not support batching and fall back to ordered
+    `NewContentMessage`s
+  - Enforce batch size limits (reject or split) with explicit behavior
+  - Call `waitForBatchSynced()` to wait for completion
+  - Add unit tests
+
+- [ ] **Task 14**: Implement waitForBatchSynced()
+  - Add private method to `SyncManager`
+  - Check `syncState.isSynced(peer, coValueId)` for all CoValues and server peers
+  - If not synced, wait with exponential backoff and check again
+  - Continue until all CoValues are synced to all servers
+  - Ensure sync state is updated per message within a batch
+  - Add unit tests with mocked sync state
+
+## Phase 6: Public API (US-1)
+
+- [ ] **Task 15**: Add withTransaction() to AccountJazzApi
+  - Add method to `AccountJazzApi` class in `packages/jazz-tools/src/tools/coValues/account.ts`
+  - Delegate to `this.localNode.withTransaction(callback)`
+  - Signature: sync callback `() => T`; document that callback must not be async
+  - Accept and pass through optional timeout configuration
+  - Add JSDoc documentation with example (sync callback)
+  - Export for public use
+
+## Phase 7: Testing
+
+### Unit Tests
+
+- [ ] **Task 16**: Test TransactionContext
+  - Test bufferMessage() adds messages correctly
+  - Test getPendingMessages() returns all buffered messages
+  - Test getCoValueIds() returns unique CoValue IDs
+  - Test clear() empties the buffer
+  - Location: `packages/cojson/src/tests/transactionContext.test.ts`
+
+- [ ] **Task 17**: Test LocalNode.withTransaction()
+  - Test creates and cleans up transaction context
+  - Test callback is invoked synchronously (no await before it completes)
+  - Test callback result is returned
+  - Test errors in callback are propagated
+  - Test nested transactions throw error
+  - Test calls syncAtomicBatch() with buffered messages
+  - Location: `packages/cojson/src/tests/localNode.transactions.test.ts`
+
+- [ ] **Task 18**: Test CoValueCore mutation buffering
+  - Test makeTransaction() buffers when context active
+  - Test makeTransaction() syncs immediately when context inactive
+  - Test mutations applied to memory in both cases
+  - Location: `packages/cojson/src/tests/coValueCore.transactions.test.ts`
+
+- [ ] **Task 19**: Test SyncManager.handleBatch()
+  - Test unpacks BatchMessage correctly
+  - Test calls handleNewContent() for each message
+  - Test with empty batch
+  - Test with large batch
+  - Test preserves per-CoValue ordering
+  - Location: `packages/cojson/src/tests/sync.batch.test.ts`
+
+- [ ] **Task 20**: Test StorageApiAsync.storeAtomicBatch()
+  - Test stores all messages in single transaction
+  - Test rolls back on failure
+  - Test throws error for retry
+  - Test with empty batch
+  - Test with messages for different CoValues
+  - Location: `packages/cojson/src/tests/storageAsync.batch.test.ts`
+
+- [ ] **Task 21**: Test SyncManager retry logic
+  - Test storeAtomicBatchWithRetry() retries on failure
+  - Test exponential backoff timing
+  - Test waitForBatchSynced() polls sync state
+  - Test stops retrying after success
+  - Test timeout rejection without stopping retries
+  - Location: `packages/cojson/src/tests/sync.atomicBatch.test.ts`
+
+### Integration Tests
+
+- [ ] **Task 22**: Test successful transaction end-to-end
+  - Create account and CoValues
+  - Execute multiple mutations in withTransaction()
+  - Verify all mutations applied to memory
+  - Verify all stored in IndexedDB
+  - Verify BatchMessage sent to server
+  - Verify server receives and processes batch
+  - Location: `packages/jazz-tools/src/tools/tests/transactions.success.test.ts`
+
+- [ ] **Task 23**: Test transaction with error
+  - Execute mutations in withTransaction()
+  - Throw error mid-callback
+  - Verify mutations before error remain in memory
+  - Verify no persistence occurred
+  - Verify no sync occurred
+  - Location: `packages/jazz-tools/src/tools/tests/transactions.error.test.ts`
+
+- [ ] **Task 24**: Test storage failure and retry
+  - Mock IndexedDB to fail N times
+  - Execute transaction
+  - Verify retries occur with backoff
+  - Verify eventual success
+  - Verify mutations remain in memory during retries
+  - Location: `packages/jazz-tools/src/tools/tests/transactions.storageRetry.test.ts`
+
+- [ ] **Task 25**: Test network sync and retry
+  - Execute transaction with server disconnected
+  - Verify retry attempts
+  - Reconnect server
+  - Verify batch eventually syncs
+  - Location: `packages/jazz-tools/src/tools/tests/transactions.syncRetry.test.ts`
+
+- [ ] **Task 26**: Test server batch processing
+  - Client sends BatchMessage to server
+  - Verify server receives single message
+  - Verify server unpacks and processes each mutation
+  - Verify all CoValues updated on server
+  - Verify other clients receive updates
+  - Location: `tests/e2e/transactions.server.test.ts`
+
+- [ ] **Task 27**: Test nested transactions
+  - Execute withTransaction()
+  - Inside callback, call withTransaction() again
+  - Verify error is thrown
+  - Verify outer transaction is not affected
+  - Location: `packages/jazz-tools/src/tools/tests/transactions.nested.test.ts`
+
+- [ ] **Task 28**: Test sync callback semantics
+  - Verify callback is run to completion before any persistence/sync
+  - Verify no other code can run during callback (e.g. no microtask interleaving)
+  - Optionally: reject or document behavior if callback returns a Promise
+  - Location: `packages/jazz-tools/src/tools/tests/transactions.syncCallback.test.ts`
+
+### Performance Tests
+
+- [ ] **Task 29**: Benchmark transaction sizes
+  - Test with 1, 10, 100, 1000 mutations
+  - Measure time to complete
+  - Measure memory usage
+  - Compare with individual mutations
+  - Location: `bench/jazz-tools/transactions.bench.ts`
+
+- [ ] **Task 30**: Benchmark IndexedDB batching
+  - Compare single transaction vs individual stores
+  - Measure throughput (mutations/second)
+  - Test with concurrent transactions
+  - Location: `bench/cojson-storage-indexeddb/batch.bench.ts`
+
+- [ ] **Task 31**: Benchmark network batching
+  - Compare BatchMessage vs individual NewContentMessages
+  - Measure network payload size
+  - Measure server processing time
+  - Location: `bench/cojson-transport-ws/batch.bench.ts`
+
+## Phase 8: Documentation
+
+- [ ] **Task 32**: Add API documentation
+  - Document `withTransaction()` method
+  - Document that callback must be synchronous (no async/await)
+  - Add usage examples to docs site (sync callback)
+  - Document atomicity guarantees
+  - Document retry behavior
+  - Document error handling
+
+- [ ] **Task 33**: Update migration guide
+  - Explain when to use transactions
+  - Show before/after code examples
+  - Document performance considerations
+  - Add troubleshooting section
+
+- [ ] **Task 34**: Create example application
+  - Build simple app demonstrating transactions
+  - Show multi-CoValue updates
+  - Show error handling
+  - Add to `examples/` directory
+
+## Phase 9: Compatibility and Safety
+
+- [ ] **Task 35**: Define batch size limits
+  - Decide limits by count and/or payload size
+  - Implement explicit behavior when exceeded (reject, split, or fallback)
+  - Add unit tests for limit handling
+
+- [ ] **Task 36**: Add server batch capability detection
+  - Negotiate capability during connection
+  - Persist capability per peer
+  - Use capability to choose batch vs individual messages
+
+- [ ] **Task 37**: Add timeout option to transaction API
+  - Extend API signature to accept timeout configuration
+  - Implement rejection behavior without stopping retries
+  - Add unit tests

--- a/packages/cojson-storage-indexeddb/src/idbClient.ts
+++ b/packages/cojson-storage-indexeddb/src/idbClient.ts
@@ -52,6 +52,39 @@ export class IDBTransaction implements DBTransactionInterfaceAsync {
     );
   }
 
+  async upsertCoValue(
+    id: RawCoID,
+    header?: CojsonInternalTypes.CoValueHeader,
+  ): Promise<number | undefined> {
+    // If no header is provided, just look up the existing rowID within this transaction.
+    if (!header) {
+      const row: StoredCoValueRow | undefined = await this.run((tx) =>
+        tx.getObjectStore("coValues").index("coValuesById").get(id),
+      );
+
+      return row?.rowID;
+    }
+
+    try {
+      // Attempt to insert or update the coValue in the current transaction.
+      const row = await this.run<number>(
+        (tx) =>
+          tx
+            .getObjectStore("coValues")
+            .put({ id, header }) as IDBRequest<number>,
+      );
+
+      return row;
+    } catch (e) {
+      // On failure (e.g. uniqueness constraint), fall back to reading the existing row.
+      const row: StoredCoValueRow | undefined = await this.run((tx) =>
+        tx.getObjectStore("coValues").index("coValuesById").get(id),
+      );
+
+      return row?.rowID;
+    }
+  }
+
   async markCoValueAsDeleted(id: RawCoID): Promise<void> {
     await this.run((tx) =>
       tx.getObjectStore("deletedCoValues").put({
@@ -221,9 +254,6 @@ export class IDBTransaction implements DBTransactionInterfaceAsync {
 export class IDBClient implements DBClientInterfaceAsync {
   private db;
 
-  activeTransaction: CoJsonIDBTransaction | undefined;
-  autoBatchingTransaction: CoJsonIDBTransaction | undefined;
-
   constructor(db: IDBDatabase) {
     this.db = db;
   }
@@ -274,14 +304,7 @@ export class IDBClient implements DBClientInterfaceAsync {
     id: RawCoID,
     header?: CojsonInternalTypes.CoValueHeader,
   ): Promise<number | undefined> {
-    if (!header) {
-      return this.getCoValueRowID(id);
-    }
-
-    return putIndexedDbStore<CoValueRow, number>(this.db, "coValues", {
-      id,
-      header,
-    }).catch(() => this.getCoValueRowID(id));
+    return this.transaction(async (tx) => tx.upsertCoValue(id, header));
   }
 
   async getAllCoValuesWaitingForDelete(): Promise<RawCoID[]> {
@@ -296,17 +319,19 @@ export class IDBClient implements DBClientInterfaceAsync {
     return entries.map((e) => e.coValueID);
   }
 
-  async transaction(
-    operationsCallback: (tx: IDBTransaction) => Promise<unknown>,
+  async transaction<T>(
+    operationsCallback: (tx: IDBTransaction) => Promise<T>,
     storeNames?: StoreName[],
-  ) {
+  ): Promise<T> {
     const tx = new CoJsonIDBTransaction(this.db, storeNames);
 
     try {
-      await operationsCallback(new IDBTransaction(tx));
+      const result = await operationsCallback(new IDBTransaction(tx));
       tx.commit(); // Tells the browser to not wait for another possible request and commit the transaction immediately
+      return result;
     } catch (error) {
       tx.rollback();
+      throw error;
     }
   }
 

--- a/packages/cojson/src/coValueCore/coValueCore.ts
+++ b/packages/cojson/src/coValueCore/coValueCore.ts
@@ -1248,7 +1248,29 @@ export class CoValueCore {
     // force immediate notification because local updates may come from the UI
     // where we need synchronous updates
     this.notifyUpdate();
-    this.node.syncManager.syncLocalTransaction(this.verified, knownStateBefore);
+
+    // Check if we're inside a transaction context
+    const transactionContext = this.node.getTransactionContext();
+
+    if (transactionContext?.isActive()) {
+      // TODO: keeping the knownStateBefore can dedupe multiple changes into a single transaction
+      // as done in syncLocalTransaction
+
+      // Buffer the message instead of syncing immediately
+      const content = this.newContentSince(knownStateBefore);
+      if (content) {
+        for (const msg of content) {
+          transactionContext.bufferMessage(msg);
+        }
+      }
+      // Don't sync now - will be done when transaction completes
+    } else {
+      // Normal flow: sync immediately
+      this.node.syncManager.syncLocalTransaction(
+        this.verified,
+        knownStateBefore,
+      );
+    }
 
     if (madeAt === undefined) {
       // We don't revalidate the dependants transactions because we assume that transactions that you are

--- a/packages/cojson/src/coValueCore/coValueCore.ts
+++ b/packages/cojson/src/coValueCore/coValueCore.ts
@@ -1253,17 +1253,9 @@ export class CoValueCore {
     const transactionContext = this.node.getTransactionContext();
 
     if (transactionContext?.isActive()) {
-      // TODO: keeping the knownStateBefore can dedupe multiple changes into a single transaction
-      // as done in syncLocalTransaction
-
-      // Buffer the message instead of syncing immediately
-      const content = this.newContentSince(knownStateBefore);
-      if (content) {
-        for (const msg of content) {
-          transactionContext.bufferMessage(msg);
-        }
-      }
       // Don't sync now - will be done when transaction completes
+      // Buffer the message instead of syncing immediately
+      transactionContext.bufferMessage(this.verified, knownStateBefore);
     } else {
       // Normal flow: sync immediately
       this.node.syncManager.syncLocalTransaction(

--- a/packages/cojson/src/coValueCore/coValueCore.ts
+++ b/packages/cojson/src/coValueCore/coValueCore.ts
@@ -1252,7 +1252,7 @@ export class CoValueCore {
     // Check if we're inside a transaction context
     const transactionContext = this.node.getTransactionContext();
 
-    if (transactionContext?.isActive()) {
+    if (transactionContext) {
       // Don't sync now - will be done when transaction completes
       // Buffer the message instead of syncing immediately
       transactionContext.bufferMessage(this.verified, knownStateBefore);

--- a/packages/cojson/src/localNode.ts
+++ b/packages/cojson/src/localNode.ts
@@ -41,6 +41,7 @@ import { expectGroup } from "./typeUtils/expectGroup.js";
 import { canBeBranched } from "./coValueCore/branching.js";
 import { connectedPeers } from "./streamUtils.js";
 import { CoValueKnownState, emptyKnownState } from "./knownState.js";
+import { TransactionContext } from "./transactionContext.js";
 
 /** A `LocalNode` represents a local view of a set of loaded `CoValue`s, from the perspective of a particular account (or primitive cryptographic agent).
 
@@ -70,6 +71,13 @@ export class LocalNode {
   crashed: Error | undefined = undefined;
 
   storage?: StorageAPI;
+
+  /**
+   * The active transaction context, if any.
+   * When set, mutations are buffered instead of being synced immediately.
+   * @internal
+   */
+  private transactionContext?: TransactionContext;
 
   /** @category 3. Low-level */
   constructor(
@@ -115,6 +123,67 @@ export class LocalNode {
    */
   enableDeletedCoValuesErasure() {
     this.storage?.enableDeletedCoValuesErasure();
+  }
+
+  /**
+   * Get the active transaction context, if any.
+   * Used by CoValueCore to check if mutations should be buffered.
+   * @internal
+   */
+  getTransactionContext(): TransactionContext | undefined {
+    return this.transactionContext;
+  }
+
+  /**
+   * Execute multiple mutations atomically.
+   *
+   * All mutations within the callback are applied immediately to memory (optimistic updates),
+   * but persisted and synced as a single batch. If either persistence or sync fails,
+   * the system retries with exponential backoff until success.
+   *
+   * **Important:** The callback must be synchronous. Async callbacks are not supported
+   * because they would allow other code to run during the transaction, potentially
+   * causing read/write concurrency issues.
+   *
+   * @param callback - Synchronous function containing mutations (no async/await)
+   * @returns Promise that resolves when all mutations are persisted and synced
+   *
+   * @example
+   * ```typescript
+   * await localNode.withTransaction(() => {
+   *   coValue1.makeTransaction([change1], "trusting");
+   *   coValue2.makeTransaction([change2], "trusting");
+   * });
+   * ```
+   *
+   * @category 3. Low-level
+   */
+  async withTransaction<T>(callback: () => T): Promise<T> {
+    // Check for nested transactions
+    if (this.transactionContext) {
+      throw new Error("Nested transactions are not supported");
+    }
+
+    // Create and activate transaction context
+    this.transactionContext = new TransactionContext();
+
+    try {
+      // Execute user callback synchronously (no concurrency while transaction is open)
+      const result = callback();
+
+      return result;
+    } finally {
+      // Get buffered messages
+      const messages = this.transactionContext.getPendingMessages();
+
+      if (messages.length > 0) {
+        // Flush to storage and sync atomically
+        await this.syncManager.syncAtomicBatch(messages);
+      }
+
+      // Always clean up transaction context
+      this.transactionContext = undefined;
+    }
   }
 
   hasCoValue(id: RawCoID) {

--- a/packages/cojson/src/localNode.ts
+++ b/packages/cojson/src/localNode.ts
@@ -150,7 +150,7 @@ export class LocalNode {
    *
    * @example
    * ```typescript
-   * await localNode.withTransaction(() => {
+   * await localNode.unstable_withTransaction(() => {
    *   coValue1.makeTransaction([change1], "trusting");
    *   coValue2.makeTransaction([change2], "trusting");
    * });
@@ -158,7 +158,7 @@ export class LocalNode {
    *
    * @category 3. Low-level
    */
-  async withTransaction<T>(callback: () => T): Promise<T> {
+  async unstable_withTransaction<T>(callback: () => T): Promise<T> {
     // Check for nested transactions
     if (this.transactionContext) {
       throw new Error("Nested transactions are not supported");

--- a/packages/cojson/src/localNode.ts
+++ b/packages/cojson/src/localNode.ts
@@ -558,7 +558,7 @@ export class LocalNode {
     // Check if we're inside a transaction context
     const transactionContext = this.getTransactionContext();
 
-    if (transactionContext?.isActive()) {
+    if (transactionContext) {
       // Buffer the message instead of syncing immediately
       transactionContext.bufferMessage(coValue.verified, emptyKnownState(id));
       // Don't sync now - will be done when transaction completes

--- a/packages/cojson/src/queue/LocalTransactionsSyncQueue.ts
+++ b/packages/cojson/src/queue/LocalTransactionsSyncQueue.ts
@@ -18,7 +18,7 @@ export class LocalTransactionsSyncQueue {
   private lastUpdatedValue: VerifiedState | undefined;
   private lastUpdatedValueKnownState: CoValueKnownState | undefined;
 
-  constructor(private readonly sync: (content: NewContentMessage) => void) {}
+  constructor(private readonly sync: (contents: NewContentMessage[]) => void) {}
 
   syncTransaction = (
     coValue: VerifiedState,
@@ -80,9 +80,7 @@ export class LocalTransactionsSyncQueue {
       this.batch = [];
       this.nextBatchScheduled = false;
 
-      for (const content of batch) {
-        this.sync(content);
-      }
+      this.sync(batch);
     });
   }
 

--- a/packages/cojson/src/storage/sqlite/client.ts
+++ b/packages/cojson/src/storage/sqlite/client.ts
@@ -268,9 +268,13 @@ export class SQLiteClient
     );
   }
 
-  transaction(operationsCallback: (tx: DBTransactionInterfaceSync) => unknown) {
-    this.db.transaction(() => operationsCallback(this));
-    return undefined;
+  transaction<T>(operationsCallback: (tx: DBTransactionInterfaceSync) => T): T {
+    let result: T | undefined;
+    this.db.transaction(() => {
+      result = operationsCallback(this);
+    });
+
+    return result as T;
   }
 
   getUnsyncedCoValueIDs(): RawCoID[] {

--- a/packages/cojson/src/storage/sqliteAsync/client.ts
+++ b/packages/cojson/src/storage/sqliteAsync/client.ts
@@ -320,13 +320,14 @@ export class SQLiteClientAsync implements DBClientInterfaceAsync {
     return rows.map((r) => r.id);
   }
 
-  async transaction(
-    operationsCallback: (tx: DBTransactionInterfaceAsync) => Promise<unknown>,
-  ): Promise<unknown> {
-    return this.enqueueTx(() =>
-      this.db.transaction((tx) =>
-        operationsCallback(new SQLiteTransactionAsync(tx)),
-      ),
+  async transaction<T>(
+    operationsCallback: (tx: DBTransactionInterfaceAsync) => Promise<T>,
+  ): Promise<T> {
+    return this.enqueueTx(
+      () =>
+        this.db.transaction((tx) =>
+          operationsCallback(new SQLiteTransactionAsync(tx)),
+        ) as Promise<T>,
     );
   }
 

--- a/packages/cojson/src/storage/storageAsync.ts
+++ b/packages/cojson/src/storage/storageAsync.ts
@@ -585,8 +585,6 @@ export class StorageApiAsync implements StorageAPI {
       return; // No-op for empty batches
     }
 
-    console.trace("storeAtomicBatch", messages);
-
     this.interruptEraser("storeAtomicBatch");
 
     await this.dbClient.transaction(async (tx) => {
@@ -611,9 +609,9 @@ export class StorageApiAsync implements StorageAPI {
   ): Promise<void> {
     const id = msg.id;
 
-    // Upsert the CoValue header (must happen outside transaction for some DBs)
-    const storedCoValueRowID = await this.dbClient.upsertCoValue(
-      id,
+    // Upsert the CoValue header within the provided transaction
+    const storedCoValueRowID = await tx.upsertCoValue(
+      id as RawCoID,
       msg.header,
     );
 

--- a/packages/cojson/src/storage/storageAsync.ts
+++ b/packages/cojson/src/storage/storageAsync.ts
@@ -607,10 +607,6 @@ export class StorageApiAsync implements StorageAPI {
       }
     });
 
-    // // Update known states after successful commit
-    // for (const msg of messages) {
-    //   this.inMemoryCoValues.add(msg.id);
-    // }
   }
 
   close() {

--- a/packages/cojson/src/storage/storageSync.ts
+++ b/packages/cojson/src/storage/storageSync.ts
@@ -575,8 +575,6 @@ export class StorageApiSync implements StorageAPI {
       return; // No-op for empty batches
     }
 
-    console.trace("storeAtomicBatch", messages);
-
     this.dbClient.transaction((tx) => {
       for (const msg of messages) {
         this.storeMessageInTransaction(tx, msg);

--- a/packages/cojson/src/storage/types.ts
+++ b/packages/cojson/src/storage/types.ts
@@ -248,6 +248,8 @@ export interface DBClientInterfaceAsync {
 }
 
 export interface DBTransactionInterfaceSync {
+  upsertCoValue(id: RawCoID, header?: CoValueHeader): number | undefined;
+
   getSingleCoValueSession(
     coValueRowId: number,
     sessionID: SessionID,
@@ -308,7 +310,7 @@ export interface DBClientInterfaceSync {
     firstNewTxIdx: number,
   ): Pick<SignatureAfterRow, "idx" | "signature">[];
 
-  transaction(callback: (tx: DBTransactionInterfaceSync) => unknown): unknown;
+  transaction<T>(callback: (tx: DBTransactionInterfaceSync) => T): T;
 
   trackCoValuesSyncState(
     updates: { id: RawCoID; peerId: PeerID; synced: boolean }[],

--- a/packages/cojson/src/storage/types.ts
+++ b/packages/cojson/src/storage/types.ts
@@ -150,6 +150,11 @@ export interface DBTransactionInterfaceAsync {
     sessionID: SessionID,
   ): Promise<StoredSessionRow | undefined>;
 
+  upsertCoValue(
+    id: RawCoID,
+    header?: CoValueHeader,
+  ): Promise<number | undefined>;
+
   /**
    * Persist a "deleted coValue" marker in storage (work queue entry).
    * This is an enqueue signal: implementations should set status to `Pending`.

--- a/packages/cojson/src/storage/types.ts
+++ b/packages/cojson/src/storage/types.ts
@@ -58,6 +58,14 @@ export interface StorageAPI {
   ): void;
   store(data: NewContentMessage, handleCorrection: CorrectionCallback): void;
 
+  /**
+   * Store multiple messages atomically in a single transaction.
+   * All messages are committed together, or none are committed if an error occurs.
+   *
+   * Used by atomic transactions to ensure all mutations are persisted together.
+   */
+  storeAtomicBatch(messages: NewContentMessage[]): Promise<void>;
+
   streamingQueue?: StorageStreamingQueue;
 
   getKnownState(id: string): CoValueKnownState;

--- a/packages/cojson/src/sync.ts
+++ b/packages/cojson/src/sync.ts
@@ -1150,11 +1150,17 @@ export class SyncManager {
     }
   }
 
-  private syncQueue = new LocalTransactionsSyncQueue((content) =>
-    this.syncContent(content),
+  private syncQueue = new LocalTransactionsSyncQueue((contents) =>
+    this.syncContents(contents),
   );
   syncLocalTransaction = this.syncQueue.syncTransaction;
   trackDirtyCoValues = this.syncQueue.trackDirtyCoValues;
+
+  private syncContents(contents: NewContentMessage[]) {
+    for (const content of contents) {
+      this.syncContent(content);
+    }
+  }
 
   private syncContent(content: NewContentMessage) {
     const coValue = this.local.getCoValue(content.id);

--- a/packages/cojson/src/sync.ts
+++ b/packages/cojson/src/sync.ts
@@ -1131,6 +1131,8 @@ export class SyncManager {
     }
 
     // Send to all server peers for each CoValue
+    // `sentToPeers` is used to avoid sending the same message to the same peer multiple times
+    // e.g. this.getServerPeers(A) and this.getServerPeers(B) both contain the same peer P
     const sentToPeers = new Set<PeerID>();
     for (const coValueId of coValueIds) {
       for (const peer of this.getServerPeers(coValueId)) {

--- a/packages/cojson/src/sync.ts
+++ b/packages/cojson/src/sync.ts
@@ -1113,7 +1113,13 @@ export class SyncManager {
     });
 
     // Wait for both to complete
-    await Promise.allSettled([storagePromise, syncPromise]);
+    await Promise.allSettled([storagePromise, syncPromise]).then((results) => {
+      for (const result of results) {
+        if (result.status === "rejected") {
+          console.error(result.reason);
+        }
+      }
+    });
   }
 
   private syncQueue = new LocalTransactionsSyncQueue((contents) => {

--- a/packages/cojson/src/tests/coValueCore.loadFromStorage.test.ts
+++ b/packages/cojson/src/tests/coValueCore.loadFromStorage.test.ts
@@ -58,6 +58,7 @@ function createMockStorage(
     eraseAllDeletedCoValues: opts.eraseAllDeletedCoValues || vi.fn(),
     load: opts.load || vi.fn(),
     store: opts.store || vi.fn(),
+    storeAtomicBatch: vi.fn().mockResolvedValue(undefined),
     getKnownState: opts.getKnownState || vi.fn(),
     loadKnownState:
       opts.loadKnownState || vi.fn((id, callback) => callback(undefined)),

--- a/packages/cojson/src/tests/knownState.lazyLoading.test.ts
+++ b/packages/cojson/src/tests/knownState.lazyLoading.test.ts
@@ -36,6 +36,7 @@ function createMockStorage(
     eraseAllDeletedCoValues: opts.eraseAllDeletedCoValues || vi.fn(),
     load: opts.load || vi.fn(),
     store: opts.store || vi.fn(),
+    storeAtomicBatch: vi.fn().mockResolvedValue(undefined),
     getKnownState: opts.getKnownState || vi.fn(),
     loadKnownState:
       opts.loadKnownState || vi.fn((id, callback) => callback(undefined)),

--- a/packages/cojson/src/tests/localNode.transactions.test.ts
+++ b/packages/cojson/src/tests/localNode.transactions.test.ts
@@ -120,6 +120,19 @@ describe("LocalNode.unstable_withTransaction", () => {
             {
               id: result,
               action: "content",
+              header: {
+                createdAt: expect.any(String),
+                uniqueness: expect.any(String),
+                type: "comap",
+                ruleset: { type: "ownedByGroup", group: group.id },
+                meta: null,
+              },
+              priority: 3,
+              new: expect.any(Object),
+            },
+            {
+              id: result,
+              action: "content",
               header: undefined,
               priority: 3,
               new: expect.any(Object),
@@ -146,7 +159,7 @@ describe("LocalNode.unstable_withTransaction", () => {
     ]);
 
     const coMapCreationMessage = (batchMessages[0]!.msg as BatchMessage)
-      .messages[0]!;
+      .messages[1]!;
 
     const coMapCreationMessageSealedId = Object.keys(
       coMapCreationMessage.new,
@@ -164,7 +177,7 @@ describe("LocalNode.unstable_withTransaction", () => {
     });
 
     const coMapSetKey1Message = (batchMessages[0]!.msg as BatchMessage)
-      .messages[1]!;
+      .messages[2]!;
 
     const coMapSetKey1MessageSealedId = Object.keys(
       coMapSetKey1Message.new,
@@ -210,10 +223,10 @@ describe("LocalNode.unstable_withTransaction", () => {
         "server -> client | KNOWN CORRECTION Map sessions: empty",
         "client -> server | CONTENT Map header: true new: After: 0 New: 2",
         "server -> client | LOAD Group sessions: empty",
-        "client -> server | CONTENT Group header: true new: After: 0 New: 3",
-        "server -> client | KNOWN Group sessions: header/3",
-        "client -> server | CONTENT Group header: true new: After: 0 New: 3",
-        "server -> client | KNOWN Group sessions: header/3",
+        "client -> server | CONTENT Group header: true new: After: 0 New: 4",
+        "server -> client | KNOWN Group sessions: header/4",
+        "client -> server | CONTENT Group header: true new: After: 0 New: 4",
+        "server -> client | KNOWN Group sessions: header/4",
         "client -> server | CONTENT Map header: true new: After: 0 New: 2",
         "server -> client | KNOWN Map sessions: header/2",
         "server -> client | KNOWN Map sessions: header/2",

--- a/packages/cojson/src/tests/localNode.transactions.test.ts
+++ b/packages/cojson/src/tests/localNode.transactions.test.ts
@@ -223,15 +223,12 @@ describe("LocalNode.unstable_withTransaction", () => {
         expect(map.get("key1")).toBe("value1");
 
         throw new Error("Test error");
-
-        // This line won't be reached
-        // map.set("key2", "value2", "trusting");
       });
     } catch {
       // Expected error
     }
 
-    // First mutation should be in memory
+    // Mutation should be in memory
     expect(map.get("key1")).toBe("value1");
   });
 });

--- a/packages/cojson/src/tests/localNode.transactions.test.ts
+++ b/packages/cojson/src/tests/localNode.transactions.test.ts
@@ -1,0 +1,262 @@
+import { describe, expect, test, beforeEach, vi } from "vitest";
+import { SyncMessagesLog, setupTestNode } from "./testUtils.js";
+import { BatchMessage, NewContentMessage } from "../sync.js";
+import { SessionID } from "../exports.js";
+
+describe("LocalNode.withTransaction", () => {
+  beforeEach(() => {
+    SyncMessagesLog.clear();
+  });
+
+  test("executes callback synchronously and returns result", async () => {
+    const node = setupTestNode().node;
+
+    const result = await node.withTransaction(() => {
+      return "test-result";
+    });
+
+    expect(result).toBe("test-result");
+  });
+
+  test("throws error for nested transactions", async () => {
+    const node = setupTestNode().node;
+
+    await expect(
+      node.withTransaction(() => {
+        // Try to start a nested transaction
+        return node.withTransaction(() => {
+          return "nested";
+        });
+      }),
+    ).rejects.toThrow("Nested transactions are not supported");
+  });
+
+  test("cleans up transaction context on success", async () => {
+    const node = setupTestNode().node;
+
+    await node.withTransaction(() => {
+      // Transaction context should be active here
+      expect(node.getTransactionContext()).toBeDefined();
+    });
+
+    // Transaction context should be cleaned up
+    expect(node.getTransactionContext()).toBeUndefined();
+  });
+
+  test("cleans up transaction context on error", async () => {
+    const node = setupTestNode().node;
+    const error = new Error("Test error");
+
+    try {
+      await node.withTransaction(() => {
+        throw error;
+      });
+    } catch (e) {
+      expect(e).toBe(error);
+    }
+
+    // Transaction context should be cleaned up even on error
+    expect(node.getTransactionContext()).toBeUndefined();
+  });
+
+  test("transaction context is undefined outside of transaction", () => {
+    const node = setupTestNode().node;
+    expect(node.getTransactionContext()).toBeUndefined();
+  });
+
+  test("empty transaction is a no-op", async () => {
+    // Set up a sync server first
+    setupTestNode({ isSyncServer: true });
+    const { node, connectToSyncServer } = setupTestNode();
+    connectToSyncServer();
+
+    // Start capturing messages
+    const messagesBefore = SyncMessagesLog.messages.length;
+
+    await node.withTransaction(() => {
+      // Empty transaction - no mutations
+    });
+
+    const messagesAfter = SyncMessagesLog.messages.length;
+
+    expect(messagesAfter).toBe(messagesBefore);
+  });
+
+  test("buffers mutations and syncs them after callback completes", async () => {
+    // Set up a sync server first
+    setupTestNode({ isSyncServer: true });
+    const { node, connectToSyncServer } = setupTestNode();
+    const { peer } = connectToSyncServer();
+
+    // Create a group to test mutations
+    const group = node.createGroup();
+
+    // Clear previous messages
+    SyncMessagesLog.clear();
+
+    // Create a CoMap within a transaction
+    const result = await node.withTransaction(() => {
+      const map = group.createMap({ test: "value" });
+      map.set("key1", "value1", "trusting");
+      map.set("key2", "value2", "trusting");
+
+      return map.id;
+    });
+
+    // Mutations should have been synced as a batch
+    const batchMessages = SyncMessagesLog.messages.filter(
+      (m) => m.msg.action === "batch",
+    );
+
+    expect(batchMessages.length).toBe(1);
+    expect(batchMessages).toStrictEqual([
+      {
+        from: "client",
+        to: "server",
+        msg: {
+          action: "batch",
+          messages: [
+            // coMap creation
+            {
+              id: result,
+              action: "content",
+              header: undefined,
+              priority: 3,
+              new: expect.any(Object),
+            },
+            // key1
+            {
+              id: result,
+              action: "content",
+              header: undefined,
+              priority: 3,
+              new: expect.any(Object),
+            },
+            // key2
+            {
+              id: result,
+              action: "content",
+              header: undefined,
+              priority: 3,
+              new: expect.any(Object),
+            },
+          ],
+        },
+      },
+    ]);
+
+    const coMapCreationMessage = (batchMessages[0]!.msg as BatchMessage)
+      .messages[0]!;
+
+    const coMapCreationMessageSealedId = Object.keys(
+      coMapCreationMessage.new,
+    )[0] as SessionID;
+    expect(
+      coMapCreationMessage.new[coMapCreationMessageSealedId],
+    ).toStrictEqual({
+      after: 0,
+      lastSignature: expect.any(String),
+      newTransactions: [
+        expect.objectContaining({
+          privacy: "private",
+        }),
+      ],
+    });
+
+    const coMapSetKey1Message = (batchMessages[0]!.msg as BatchMessage)
+      .messages[1]!;
+
+    const coMapSetKey1MessageSealedId = Object.keys(
+      coMapSetKey1Message.new,
+    )[0] as SessionID;
+    expect(coMapSetKey1Message.new[coMapSetKey1MessageSealedId]).toStrictEqual({
+      after: 1,
+      lastSignature: expect.any(String),
+      newTransactions: [
+        expect.objectContaining({
+          privacy: "trusting",
+          changes: '[{"op":"set","key":"key1","value":"value1"}]',
+        }),
+      ],
+    });
+  });
+
+  test("emits a single batch SyncMessage for transaction mutations", async () => {
+    // Set up a sync server first
+    setupTestNode({ isSyncServer: true });
+    const { node, connectToSyncServer } = setupTestNode();
+    connectToSyncServer();
+
+    const group = node.createGroup();
+    const map = group.createMap();
+
+    SyncMessagesLog.clear();
+
+    await node.withTransaction(() => {
+      map.set("k1", "v1", "trusting");
+      map.set("k2", "v2", "trusting");
+    });
+
+    const simplified = SyncMessagesLog.getMessages({
+      Group: group.core,
+      Map: map.core,
+    });
+
+    expect(simplified).toMatchInlineSnapshot(`
+      [
+        "client -> server | BATCH [Map, Map]",
+        "server -> client | KNOWN CORRECTION Map sessions: empty",
+        "client -> server | CONTENT Map header: true new: After: 0 New: 2",
+        "server -> client | KNOWN CORRECTION Map sessions: empty",
+        "client -> server | CONTENT Map header: true new: After: 0 New: 2",
+        "server -> client | LOAD Group sessions: empty",
+        "client -> server | CONTENT Group header: true new: After: 0 New: 3",
+        "server -> client | KNOWN Group sessions: header/3",
+        "client -> server | CONTENT Group header: true new: After: 0 New: 3",
+        "server -> client | KNOWN Group sessions: header/3",
+        "client -> server | CONTENT Map header: true new: After: 0 New: 2",
+        "server -> client | KNOWN Map sessions: header/2",
+        "server -> client | KNOWN Map sessions: header/2",
+        "server -> client | KNOWN Map sessions: header/2",
+      ]
+    `);
+  });
+
+  test("mutations are applied to memory immediately", async () => {
+    const node = setupTestNode().node;
+    const group = node.createGroup();
+    const map = group.createMap();
+
+    await node.withTransaction(() => {
+      map.set("key", "value", "trusting");
+      // Value should be immediately visible in memory
+      expect(map.get("key")).toBe("value");
+    });
+
+    // Value should still be visible after transaction
+    expect(map.get("key")).toBe("value");
+  });
+
+  test("mutations before error are applied to memory", async () => {
+    const node = setupTestNode().node;
+    const group = node.createGroup();
+    const map = group.createMap();
+
+    try {
+      await node.withTransaction(() => {
+        map.set("key1", "value1", "trusting");
+        expect(map.get("key1")).toBe("value1");
+
+        throw new Error("Test error");
+
+        // This line won't be reached
+        // map.set("key2", "value2", "trusting");
+      });
+    } catch {
+      // Expected error
+    }
+
+    // First mutation should be in memory
+    expect(map.get("key1")).toBe("value1");
+  });
+});

--- a/packages/cojson/src/tests/localNode.transactions.test.ts
+++ b/packages/cojson/src/tests/localNode.transactions.test.ts
@@ -3,7 +3,7 @@ import { SyncMessagesLog, setupTestNode } from "./testUtils.js";
 import { BatchMessage, NewContentMessage } from "../sync.js";
 import { SessionID } from "../exports.js";
 
-describe("LocalNode.withTransaction", () => {
+describe("LocalNode.unstable_withTransaction", () => {
   beforeEach(() => {
     SyncMessagesLog.clear();
   });
@@ -11,7 +11,7 @@ describe("LocalNode.withTransaction", () => {
   test("executes callback synchronously and returns result", async () => {
     const node = setupTestNode().node;
 
-    const result = await node.withTransaction(() => {
+    const result = await node.unstable_withTransaction(() => {
       return "test-result";
     });
 
@@ -22,9 +22,9 @@ describe("LocalNode.withTransaction", () => {
     const node = setupTestNode().node;
 
     await expect(
-      node.withTransaction(() => {
+      node.unstable_withTransaction(() => {
         // Try to start a nested transaction
-        return node.withTransaction(() => {
+        return node.unstable_withTransaction(() => {
           return "nested";
         });
       }),
@@ -34,7 +34,7 @@ describe("LocalNode.withTransaction", () => {
   test("cleans up transaction context on success", async () => {
     const node = setupTestNode().node;
 
-    await node.withTransaction(() => {
+    await node.unstable_withTransaction(() => {
       // Transaction context should be active here
       expect(node.getTransactionContext()).toBeDefined();
     });
@@ -48,7 +48,7 @@ describe("LocalNode.withTransaction", () => {
     const error = new Error("Test error");
 
     try {
-      await node.withTransaction(() => {
+      await node.unstable_withTransaction(() => {
         throw error;
       });
     } catch (e) {
@@ -73,7 +73,7 @@ describe("LocalNode.withTransaction", () => {
     // Start capturing messages
     const messagesBefore = SyncMessagesLog.messages.length;
 
-    await node.withTransaction(() => {
+    await node.unstable_withTransaction(() => {
       // Empty transaction - no mutations
     });
 
@@ -95,7 +95,7 @@ describe("LocalNode.withTransaction", () => {
     SyncMessagesLog.clear();
 
     // Create a CoMap within a transaction
-    const result = await node.withTransaction(() => {
+    const result = await node.unstable_withTransaction(() => {
       const map = group.createMap({ test: "value" });
       map.set("key1", "value1", "trusting");
       map.set("key2", "value2", "trusting");
@@ -192,7 +192,7 @@ describe("LocalNode.withTransaction", () => {
 
     SyncMessagesLog.clear();
 
-    await node.withTransaction(() => {
+    await node.unstable_withTransaction(() => {
       map.set("k1", "v1", "trusting");
       map.set("k2", "v2", "trusting");
     });
@@ -227,7 +227,7 @@ describe("LocalNode.withTransaction", () => {
     const group = node.createGroup();
     const map = group.createMap();
 
-    await node.withTransaction(() => {
+    await node.unstable_withTransaction(() => {
       map.set("key", "value", "trusting");
       // Value should be immediately visible in memory
       expect(map.get("key")).toBe("value");
@@ -243,7 +243,7 @@ describe("LocalNode.withTransaction", () => {
     const map = group.createMap();
 
     try {
-      await node.withTransaction(() => {
+      await node.unstable_withTransaction(() => {
         map.set("key1", "value1", "trusting");
         expect(map.get("key1")).toBe("value1");
 

--- a/packages/cojson/src/tests/messagesTestUtils.ts
+++ b/packages/cojson/src/tests/messagesTestUtils.ts
@@ -46,7 +46,7 @@ export function toSimplifiedMessages(
     return `unknown/${id}`;
   }
 
-  function toDebugString(from: string, to: string, msg: TestMessage) {
+  function toDebugString(from: string, to: string, msg: TestMessage): string {
     switch (msg.action) {
       case "known":
         return `${from} -> ${to} | KNOWN ${msg.isCorrection ? "CORRECTION " : ""}${getCoValue(msg.id)} sessions: ${simplifySessions(msg)}`;
@@ -56,6 +56,8 @@ export function toSimplifiedMessages(
         return `${from} -> ${to} | DONE ${getCoValue(msg.id)}`;
       case "content":
         return `${from} -> ${to} | CONTENT ${getCoValue(msg.id)} header: ${Boolean(msg.header)} new: ${simplifyNewContent(msg.new)}${msg.expectContentUntil ? ` expectContentUntil: ${simplifySessions({ sessions: msg.expectContentUntil, header: true })}` : ""}`;
+      case "batch":
+        return `${from} -> ${to} | BATCH [${msg.messages.map((m) => `${getCoValue(m.id)}`).join(", ")}]`;
       case "lazyLoad":
         return `${from} -> ${to} | GET_KNOWN_STATE ${getCoValue(msg.id)}`;
       case "lazyLoadResult":

--- a/packages/cojson/src/tests/sync.storage.test.ts
+++ b/packages/cojson/src/tests/sync.storage.test.ts
@@ -291,6 +291,51 @@ describe("client with storage syncs with server", () => {
   });
 });
 
+describe("atomic batching transactions", () => {
+  let jazzCloud: ReturnType<typeof setupTestNode>;
+
+  beforeEach(async () => {
+    jazzCloud = setupTestNode({
+      isSyncServer: true,
+    });
+    SyncMessagesLog.clear();
+  });
+
+  test("atomic batch transactions should send a single message and transaction", async () => {
+    const client = setupTestNode();
+
+    const storage = await client.addAsyncStorage({
+      ourName: "client",
+    });
+
+    const transactionSpy = vi.spyOn(storage.dbClient, "transaction");
+
+    const [group, largeMap] = await client.node.unstable_withTransaction(() => {
+      const group = client.node.createGroup();
+      group.addMember("everyone", "writer");
+
+      const largeMap = group.createMap();
+
+      fillCoMapWithLargeData(largeMap);
+
+      return [group, largeMap];
+    });
+
+    expect(transactionSpy).toHaveBeenCalledOnce();
+
+    expect(
+      SyncMessagesLog.getMessages({
+        Group: group.core,
+        Map: largeMap.core,
+      }),
+    ).toMatchInlineSnapshot(`
+      [
+        "client -> storage | BATCH [Group, Map, Map, Map]",
+      ]
+    `);
+  });
+});
+
 describe("client syncs with a server with storage", () => {
   let jazzCloud: ReturnType<typeof setupTestNode>;
   let metricReader: ReturnType<typeof createTestMetricReader>;

--- a/packages/cojson/src/tests/sync.test.ts
+++ b/packages/cojson/src/tests/sync.test.ts
@@ -198,7 +198,7 @@ test("transaction mutations are sent together in a single batch message", async 
 
   SyncMessagesLog.clear();
 
-  await node.withTransaction(() => {
+  await node.unstable_withTransaction(() => {
     map.set("key1", "value1", "trusting");
     map.set("key2", "value2", "trusting");
   });

--- a/packages/cojson/src/tests/testUtils.ts
+++ b/packages/cojson/src/tests/testUtils.ts
@@ -518,7 +518,11 @@ export function setupTestNode(
     });
     node.setStorage(storage);
 
-    return { storage };
+    return {
+      storage,
+      // @ts-expect-error - dbClient is private
+      dbClient: storage.dbClient,
+    };
   }
 
   if (opts.connected) {
@@ -655,7 +659,11 @@ export async function setupTestAccount(
     });
     ctx.node.setStorage(storage);
 
-    return { storage };
+    return {
+      storage,
+      // @ts-expect-error - dbClient is private
+      dbClient: storage.dbClient,
+    };
   }
 
   if (opts.connected) {

--- a/packages/cojson/src/tests/transactionContext.test.ts
+++ b/packages/cojson/src/tests/transactionContext.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, test } from "vitest";
+import { TransactionContext } from "../transactionContext.js";
+import type { NewContentMessage } from "../sync.js";
+import type { RawCoID, SessionID } from "../ids.js";
+import { CO_VALUE_PRIORITY } from "../priority.js";
+
+function createTestMessage(id: RawCoID): NewContentMessage {
+  return {
+    action: "content",
+    id,
+    header: {
+      type: "comap",
+      ruleset: { type: "unsafeAllowAll" },
+      meta: null,
+      createdAt: new Date().toISOString() as `2${string}`,
+      uniqueness: "test",
+    },
+    priority: CO_VALUE_PRIORITY.MEDIUM,
+    new: {
+      ["test-session" as SessionID]: {
+        after: 0,
+        newTransactions: [],
+        lastSignature: "test-signature" as any,
+      },
+    },
+  };
+}
+
+describe("TransactionContext", () => {
+  test("bufferMessage adds messages to pending list", () => {
+    const context = new TransactionContext();
+    const msg1 = createTestMessage("co_test1" as RawCoID);
+    const msg2 = createTestMessage("co_test2" as RawCoID);
+
+    context.bufferMessage(msg1);
+    context.bufferMessage(msg2);
+
+    const messages = context.getPendingMessages();
+    expect(messages).toHaveLength(2);
+    expect(messages[0]).toBe(msg1);
+    expect(messages[1]).toBe(msg2);
+  });
+
+  test("getPendingMessages returns messages in order", () => {
+    const context = new TransactionContext();
+    const msg1 = createTestMessage("co_test1" as RawCoID);
+    const msg2 = createTestMessage("co_test2" as RawCoID);
+    const msg3 = createTestMessage("co_test3" as RawCoID);
+
+    context.bufferMessage(msg1);
+    context.bufferMessage(msg2);
+    context.bufferMessage(msg3);
+
+    const messages = context.getPendingMessages();
+    expect(messages).toEqual([msg1, msg2, msg3]);
+  });
+
+  test("getCoValueIds returns unique CoValue IDs", () => {
+    const context = new TransactionContext();
+    const id1 = "co_test1" as RawCoID;
+    const id2 = "co_test2" as RawCoID;
+
+    context.bufferMessage(createTestMessage(id1));
+    context.bufferMessage(createTestMessage(id1)); // Duplicate
+    context.bufferMessage(createTestMessage(id2));
+
+    const ids = context.getCoValueIds();
+    expect(ids.size).toBe(2);
+    expect(ids.has(id1)).toBe(true);
+    expect(ids.has(id2)).toBe(true);
+  });
+
+  test("isActive returns true for active context", () => {
+    const context = new TransactionContext();
+    expect(context.isActive()).toBe(true);
+  });
+
+  test("clear empties the buffer", () => {
+    const context = new TransactionContext();
+    context.bufferMessage(createTestMessage("co_test1" as RawCoID));
+    context.bufferMessage(createTestMessage("co_test2" as RawCoID));
+
+    expect(context.getPendingMessages()).toHaveLength(2);
+    expect(context.getCoValueIds().size).toBe(2);
+
+    context.clear();
+
+    expect(context.getPendingMessages()).toHaveLength(0);
+    expect(context.getCoValueIds().size).toBe(0);
+  });
+
+  test("messageCount returns correct count", () => {
+    const context = new TransactionContext();
+    expect(context.messageCount).toBe(0);
+
+    context.bufferMessage(createTestMessage("co_test1" as RawCoID));
+    expect(context.messageCount).toBe(1);
+
+    context.bufferMessage(createTestMessage("co_test2" as RawCoID));
+    expect(context.messageCount).toBe(2);
+  });
+
+  test("isEmpty returns true for empty context", () => {
+    const context = new TransactionContext();
+    expect(context.isEmpty).toBe(true);
+
+    context.bufferMessage(createTestMessage("co_test1" as RawCoID));
+    expect(context.isEmpty).toBe(false);
+
+    context.clear();
+    expect(context.isEmpty).toBe(true);
+  });
+
+  test("multiple messages for same CoValue are preserved in order", () => {
+    const context = new TransactionContext();
+    const id = "co_test1" as RawCoID;
+
+    const msg1 = createTestMessage(id);
+    const msg2 = createTestMessage(id);
+    const msg3 = createTestMessage(id);
+
+    context.bufferMessage(msg1);
+    context.bufferMessage(msg2);
+    context.bufferMessage(msg3);
+
+    const messages = context.getPendingMessages();
+    expect(messages).toHaveLength(3);
+    expect(messages[0]).toBe(msg1);
+    expect(messages[1]).toBe(msg2);
+    expect(messages[2]).toBe(msg3);
+
+    // But only one unique CoValue ID
+    expect(context.getCoValueIds().size).toBe(1);
+  });
+});

--- a/packages/cojson/src/tests/transactionContext.test.ts
+++ b/packages/cojson/src/tests/transactionContext.test.ts
@@ -46,11 +46,6 @@ describe("TransactionContext", () => {
     ]);
   });
 
-  test("isActive returns true for active context", () => {
-    const context = new TransactionContext();
-    expect(context.isActive()).toBe(true);
-  });
-
   test("clear empties the buffer", () => {
     const context = new TransactionContext();
     context.bufferMessage(

--- a/packages/cojson/src/tests/transactionContext.test.ts
+++ b/packages/cojson/src/tests/transactionContext.test.ts
@@ -1,73 +1,49 @@
 import { describe, expect, test } from "vitest";
 import { TransactionContext } from "../transactionContext.js";
-import type { NewContentMessage } from "../sync.js";
-import type { RawCoID, SessionID } from "../ids.js";
-import { CO_VALUE_PRIORITY } from "../priority.js";
+import type { VerifiedState } from "../coValueCore/verifiedState.js";
+import type { CoValueKnownState } from "../knownState.js";
 
-function createTestMessage(id: RawCoID): NewContentMessage {
-  return {
-    action: "content",
-    id,
-    header: {
-      type: "comap",
-      ruleset: { type: "unsafeAllowAll" },
-      meta: null,
-      createdAt: new Date().toISOString() as `2${string}`,
-      uniqueness: "test",
-    },
-    priority: CO_VALUE_PRIORITY.MEDIUM,
-    new: {
-      ["test-session" as SessionID]: {
-        after: 0,
-        newTransactions: [],
-        lastSignature: "test-signature" as any,
-      },
-    },
-  };
-}
+const createTestCoValue = (id: string) => ({ id }) as unknown as VerifiedState;
+
+const createTestKnownState = (label: string) =>
+  ({ label }) as unknown as CoValueKnownState;
 
 describe("TransactionContext", () => {
   test("bufferMessage adds messages to pending list", () => {
     const context = new TransactionContext();
-    const msg1 = createTestMessage("co_test1" as RawCoID);
-    const msg2 = createTestMessage("co_test2" as RawCoID);
+    const coValue1 = createTestCoValue("co_test1");
+    const state1 = createTestKnownState("state1");
+    const coValue2 = createTestCoValue("co_test2");
+    const state2 = createTestKnownState("state2");
 
-    context.bufferMessage(msg1);
-    context.bufferMessage(msg2);
+    context.bufferMessage(coValue1, state1);
+    context.bufferMessage(coValue2, state2);
 
     const messages = context.getPendingMessages();
     expect(messages).toHaveLength(2);
-    expect(messages[0]).toBe(msg1);
-    expect(messages[1]).toBe(msg2);
+    expect(messages[0]).toEqual([coValue1, state1]);
+    expect(messages[1]).toEqual([coValue2, state2]);
   });
 
   test("getPendingMessages returns messages in order", () => {
     const context = new TransactionContext();
-    const msg1 = createTestMessage("co_test1" as RawCoID);
-    const msg2 = createTestMessage("co_test2" as RawCoID);
-    const msg3 = createTestMessage("co_test3" as RawCoID);
+    const coValue1 = createTestCoValue("co_test1");
+    const state1 = createTestKnownState("state1");
+    const coValue2 = createTestCoValue("co_test2");
+    const state2 = createTestKnownState("state2");
+    const coValue3 = createTestCoValue("co_test3");
+    const state3 = createTestKnownState("state3");
 
-    context.bufferMessage(msg1);
-    context.bufferMessage(msg2);
-    context.bufferMessage(msg3);
+    context.bufferMessage(coValue1, state1);
+    context.bufferMessage(coValue2, state2);
+    context.bufferMessage(coValue3, state3);
 
     const messages = context.getPendingMessages();
-    expect(messages).toEqual([msg1, msg2, msg3]);
-  });
-
-  test("getCoValueIds returns unique CoValue IDs", () => {
-    const context = new TransactionContext();
-    const id1 = "co_test1" as RawCoID;
-    const id2 = "co_test2" as RawCoID;
-
-    context.bufferMessage(createTestMessage(id1));
-    context.bufferMessage(createTestMessage(id1)); // Duplicate
-    context.bufferMessage(createTestMessage(id2));
-
-    const ids = context.getCoValueIds();
-    expect(ids.size).toBe(2);
-    expect(ids.has(id1)).toBe(true);
-    expect(ids.has(id2)).toBe(true);
+    expect(messages).toEqual([
+      [coValue1, state1],
+      [coValue2, state2],
+      [coValue3, state3],
+    ]);
   });
 
   test("isActive returns true for active context", () => {
@@ -77,26 +53,36 @@ describe("TransactionContext", () => {
 
   test("clear empties the buffer", () => {
     const context = new TransactionContext();
-    context.bufferMessage(createTestMessage("co_test1" as RawCoID));
-    context.bufferMessage(createTestMessage("co_test2" as RawCoID));
+    context.bufferMessage(
+      createTestCoValue("co_test1"),
+      createTestKnownState("state1"),
+    );
+    context.bufferMessage(
+      createTestCoValue("co_test2"),
+      createTestKnownState("state2"),
+    );
 
     expect(context.getPendingMessages()).toHaveLength(2);
-    expect(context.getCoValueIds().size).toBe(2);
 
     context.clear();
 
     expect(context.getPendingMessages()).toHaveLength(0);
-    expect(context.getCoValueIds().size).toBe(0);
   });
 
   test("messageCount returns correct count", () => {
     const context = new TransactionContext();
     expect(context.messageCount).toBe(0);
 
-    context.bufferMessage(createTestMessage("co_test1" as RawCoID));
+    context.bufferMessage(
+      createTestCoValue("co_test1"),
+      createTestKnownState("state1"),
+    );
     expect(context.messageCount).toBe(1);
 
-    context.bufferMessage(createTestMessage("co_test2" as RawCoID));
+    context.bufferMessage(
+      createTestCoValue("co_test2"),
+      createTestKnownState("state2"),
+    );
     expect(context.messageCount).toBe(2);
   });
 
@@ -104,7 +90,10 @@ describe("TransactionContext", () => {
     const context = new TransactionContext();
     expect(context.isEmpty).toBe(true);
 
-    context.bufferMessage(createTestMessage("co_test1" as RawCoID));
+    context.bufferMessage(
+      createTestCoValue("co_test1"),
+      createTestKnownState("state1"),
+    );
     expect(context.isEmpty).toBe(false);
 
     context.clear();
@@ -113,23 +102,23 @@ describe("TransactionContext", () => {
 
   test("multiple messages for same CoValue are preserved in order", () => {
     const context = new TransactionContext();
-    const id = "co_test1" as RawCoID;
+    const id = "co_test1";
 
-    const msg1 = createTestMessage(id);
-    const msg2 = createTestMessage(id);
-    const msg3 = createTestMessage(id);
+    const coValue1 = createTestCoValue(id);
+    const state1 = createTestKnownState("state1");
+    const coValue2 = createTestCoValue(id);
+    const state2 = createTestKnownState("state2");
+    const coValue3 = createTestCoValue(id);
+    const state3 = createTestKnownState("state3");
 
-    context.bufferMessage(msg1);
-    context.bufferMessage(msg2);
-    context.bufferMessage(msg3);
+    context.bufferMessage(coValue1, state1);
+    context.bufferMessage(coValue2, state2);
+    context.bufferMessage(coValue3, state3);
 
     const messages = context.getPendingMessages();
     expect(messages).toHaveLength(3);
-    expect(messages[0]).toBe(msg1);
-    expect(messages[1]).toBe(msg2);
-    expect(messages[2]).toBe(msg3);
-
-    // But only one unique CoValue ID
-    expect(context.getCoValueIds().size).toBe(1);
+    expect(messages[0]).toEqual([coValue1, state1]);
+    expect(messages[1]).toEqual([coValue2, state2]);
+    expect(messages[2]).toEqual([coValue3, state3]);
   });
 });

--- a/packages/cojson/src/transactionContext.ts
+++ b/packages/cojson/src/transactionContext.ts
@@ -1,0 +1,74 @@
+import type { NewContentMessage } from "./sync.js";
+import type { RawCoID } from "./ids.js";
+
+/**
+ * TransactionContext manages the state of an active atomic transaction.
+ *
+ * When a transaction is active, mutations are applied immediately to memory
+ * but their NewContentMessages are buffered instead of being synced immediately.
+ * After the transaction callback completes, all buffered messages are:
+ * - Stored atomically in a single IndexedDB transaction
+ * - Sent to sync servers in a single BatchMessage
+ *
+ * The presence of a TransactionContext is treated as the "active" signal.
+ * The callback is synchronous, so no other code can run during the transaction window.
+ */
+export class TransactionContext {
+  private pendingMessages: NewContentMessage[] = [];
+  private pendingCoValues: Set<RawCoID> = new Set();
+
+  /**
+   * Buffer a NewContentMessage for later atomic persistence and sync.
+   * Messages are stored in order and will be processed as a batch.
+   */
+  bufferMessage(msg: NewContentMessage): void {
+    this.pendingMessages.push(msg);
+    this.pendingCoValues.add(msg.id);
+  }
+
+  /**
+   * Get all buffered messages in order.
+   * The order is preserved per CoValue for correct replay.
+   */
+  getPendingMessages(): NewContentMessage[] {
+    return this.pendingMessages;
+  }
+
+  /**
+   * Get the set of unique CoValue IDs affected by this transaction.
+   */
+  getCoValueIds(): Set<RawCoID> {
+    return this.pendingCoValues;
+  }
+
+  /**
+   * Check if this transaction context is active.
+   * A TransactionContext is always considered active when it exists.
+   */
+  isActive(): boolean {
+    return true;
+  }
+
+  /**
+   * Clear all buffered messages and CoValue IDs.
+   * Called when the transaction is discarded (e.g., on error).
+   */
+  clear(): void {
+    this.pendingMessages = [];
+    this.pendingCoValues.clear();
+  }
+
+  /**
+   * Get the count of buffered messages.
+   */
+  get messageCount(): number {
+    return this.pendingMessages.length;
+  }
+
+  /**
+   * Check if there are any buffered messages.
+   */
+  get isEmpty(): boolean {
+    return this.pendingMessages.length === 0;
+  }
+}

--- a/packages/cojson/src/transactionContext.ts
+++ b/packages/cojson/src/transactionContext.ts
@@ -38,14 +38,6 @@ export class TransactionContext {
   }
 
   /**
-   * Check if this transaction context is active.
-   * A TransactionContext is always considered active when it exists.
-   */
-  isActive(): boolean {
-    return true;
-  }
-
-  /**
    * Clear all buffered messages and CoValue IDs.
    * Called when the transaction is discarded (e.g., on error).
    */

--- a/packages/jazz-tools/src/tools/coValues/account.ts
+++ b/packages/jazz-tools/src/tools/coValues/account.ts
@@ -616,7 +616,7 @@ class AccountJazzApi<A extends Account> extends CoValueJazzApi<A> {
    *
    * @example
    * ```typescript
-   * await account.$jazz.withTransaction(() => {
+   * account.$jazz.unstable_withTransaction(() => {
    *   map1.set("key1", "value1");
    *   map2.set("key2", "value2");
    *   list.push(item);
@@ -625,8 +625,8 @@ class AccountJazzApi<A extends Account> extends CoValueJazzApi<A> {
    *
    * @category Content
    */
-  async withTransaction<T>(callback: () => T): Promise<T> {
-    return this.localNode.withTransaction(callback);
+  async unstable_withTransaction<T>(callback: () => T): Promise<T> {
+    return this.localNode.unstable_withTransaction(callback);
   }
 
   /** @internal */

--- a/packages/jazz-tools/src/tools/coValues/account.ts
+++ b/packages/jazz-tools/src/tools/coValues/account.ts
@@ -601,6 +601,34 @@ class AccountJazzApi<A extends Account> extends CoValueJazzApi<A> {
     return this.localNode.syncManager.waitForAllCoValuesSync(options?.timeout);
   }
 
+  /**
+   * Execute multiple mutations atomically.
+   *
+   * All mutations within the callback are applied immediately to memory (optimistic updates),
+   * but persisted to storage and synced to servers as a single batch.
+   *
+   * **Important:** The callback must be synchronous. Async callbacks are not supported
+   * because they would allow other code to run during the transaction, potentially
+   * causing read/write concurrency issues.
+   *
+   * @param callback - Synchronous function containing mutations (no async/await)
+   * @returns Promise that resolves when all mutations are persisted and synced
+   *
+   * @example
+   * ```typescript
+   * await account.$jazz.withTransaction(() => {
+   *   map1.set("key1", "value1");
+   *   map2.set("key2", "value2");
+   *   list.push(item);
+   * });
+   * ```
+   *
+   * @category Content
+   */
+  async withTransaction<T>(callback: () => T): Promise<T> {
+    return this.localNode.withTransaction(callback);
+  }
+
   /** @internal */
   get schema(): {
     profile: RefEncoded<Profile>;

--- a/packages/jazz-tools/src/tools/tests/account.test.ts
+++ b/packages/jazz-tools/src/tools/tests/account.test.ts
@@ -528,7 +528,7 @@ describe("createAs", () => {
   });
 });
 
-describe("account.withTransaction", () => {
+describe("account.unstable_withTransaction", () => {
   const TestMap = co.map({
     name: z.string(),
     value: z.number(),
@@ -539,7 +539,7 @@ describe("account.withTransaction", () => {
       isCurrentActiveAccount: true,
     });
 
-    const result = await account.$jazz.withTransaction(() => {
+    const result = await account.$jazz.unstable_withTransaction(() => {
       return "test-result";
     });
 
@@ -553,7 +553,7 @@ describe("account.withTransaction", () => {
 
     const map = TestMap.create({ name: "test", value: 0 }, { owner: account });
 
-    await account.$jazz.withTransaction(() => {
+    await account.$jazz.unstable_withTransaction(() => {
       map.$jazz.set("name", "updated");
       map.$jazz.set("value", 42);
 
@@ -579,7 +579,7 @@ describe("account.withTransaction", () => {
       { owner: clientAccount },
     );
 
-    await clientAccount.$jazz.withTransaction(() => {
+    await clientAccount.$jazz.unstable_withTransaction(() => {
       map1.$jazz.set("name", "map1-updated");
       map2.$jazz.set("name", "map2-updated");
     });
@@ -601,8 +601,8 @@ describe("account.withTransaction", () => {
     });
 
     await expect(
-      account.$jazz.withTransaction(() => {
-        return account.$jazz.withTransaction(() => {
+      account.$jazz.unstable_withTransaction(() => {
+        return account.$jazz.unstable_withTransaction(() => {
           return "nested";
         });
       }),
@@ -615,12 +615,12 @@ describe("account.withTransaction", () => {
     });
 
     // Should not throw and should complete quickly
-    await account.$jazz.withTransaction(() => {
+    await account.$jazz.unstable_withTransaction(() => {
       // Empty transaction
     });
   });
 
-  test("mutations outside withTransaction work normally (US-5)", async () => {
+  test("mutations outside unstable_withTransaction work normally (US-5)", async () => {
     const account = await createJazzTestAccount({
       isCurrentActiveAccount: true,
     });
@@ -632,7 +632,7 @@ describe("account.withTransaction", () => {
     expect(map.name).toBe("outside");
 
     // Mutation inside transaction
-    await account.$jazz.withTransaction(() => {
+    await account.$jazz.unstable_withTransaction(() => {
       map.$jazz.set("value", 42);
     });
     expect(map.value).toBe(42);
@@ -651,7 +651,7 @@ describe("account.withTransaction", () => {
     const map2 = TestMap.create({ name: "map2", value: 2 }, { owner: account });
     const map3 = TestMap.create({ name: "map3", value: 3 }, { owner: account });
 
-    await account.$jazz.withTransaction(() => {
+    await account.$jazz.unstable_withTransaction(() => {
       map1.$jazz.set("name", "updated1");
       map1.$jazz.set("value", 10);
 
@@ -678,7 +678,7 @@ describe("account.withTransaction", () => {
 
     const map = TestMap.create({ name: "test", value: 0 }, { owner: account });
 
-    await account.$jazz.withTransaction(() => {
+    await account.$jazz.unstable_withTransaction(() => {
       map.$jazz.set("value", 1);
       map.$jazz.set("value", 2);
       map.$jazz.set("value", 3);
@@ -699,7 +699,7 @@ describe("account.withTransaction", () => {
     );
 
     // withTransaction should wait for persistence and sync
-    await clientAccount.$jazz.withTransaction(() => {
+    await clientAccount.$jazz.unstable_withTransaction(() => {
       map.$jazz.set("name", "synced");
       map.$jazz.set("value", 100);
     });

--- a/packages/jazz-tools/src/tools/tests/account.test.ts
+++ b/packages/jazz-tools/src/tools/tests/account.test.ts
@@ -527,3 +527,185 @@ describe("createAs", () => {
     expect(createdAccount.account.$jazz.createdBy).toBe(undefined);
   });
 });
+
+describe("account.withTransaction", () => {
+  const TestMap = co.map({
+    name: z.string(),
+    value: z.number(),
+  });
+
+  test("executes synchronous callback and returns result", async () => {
+    const account = await createJazzTestAccount({
+      isCurrentActiveAccount: true,
+    });
+
+    const result = await account.$jazz.withTransaction(() => {
+      return "test-result";
+    });
+
+    expect(result).toBe("test-result");
+  });
+
+  test("mutations are applied to memory immediately", async () => {
+    const account = await createJazzTestAccount({
+      isCurrentActiveAccount: true,
+    });
+
+    const map = TestMap.create({ name: "test", value: 0 }, { owner: account });
+
+    await account.$jazz.withTransaction(() => {
+      map.$jazz.set("name", "updated");
+      map.$jazz.set("value", 42);
+
+      // Values should be immediately visible in memory
+      expect(map.name).toBe("updated");
+      expect(map.value).toBe(42);
+    });
+
+    // Values should persist after transaction
+    expect(map.name).toBe("updated");
+    expect(map.value).toBe(42);
+  });
+
+  test("multiple CoValue mutations are persisted together", async () => {
+    const { clientAccount, serverNode } = await setupTwoNodes();
+
+    const map1 = TestMap.create(
+      { name: "map1", value: 1 },
+      { owner: clientAccount },
+    );
+    const map2 = TestMap.create(
+      { name: "map2", value: 2 },
+      { owner: clientAccount },
+    );
+
+    await clientAccount.$jazz.withTransaction(() => {
+      map1.$jazz.set("name", "map1-updated");
+      map2.$jazz.set("name", "map2-updated");
+    });
+
+    // Wait for sync to complete
+    await clientAccount.$jazz.waitForAllCoValuesSync({ timeout: 1000 });
+
+    // Verify both mutations were synced to server
+    const loadedMap1 = await serverNode.load(map1.$jazz.raw.id);
+    const loadedMap2 = await serverNode.load(map2.$jazz.raw.id);
+
+    expect(loadedMap1).not.toBe(CoValueLoadingState.UNAVAILABLE);
+    expect(loadedMap2).not.toBe(CoValueLoadingState.UNAVAILABLE);
+  });
+
+  test("throws error for nested transactions (US-5)", async () => {
+    const account = await createJazzTestAccount({
+      isCurrentActiveAccount: true,
+    });
+
+    await expect(
+      account.$jazz.withTransaction(() => {
+        return account.$jazz.withTransaction(() => {
+          return "nested";
+        });
+      }),
+    ).rejects.toThrow("Nested transactions are not supported");
+  });
+
+  test("empty transaction is a no-op (US-2)", async () => {
+    const account = await createJazzTestAccount({
+      isCurrentActiveAccount: true,
+    });
+
+    // Should not throw and should complete quickly
+    await account.$jazz.withTransaction(() => {
+      // Empty transaction
+    });
+  });
+
+  test("mutations outside withTransaction work normally (US-5)", async () => {
+    const account = await createJazzTestAccount({
+      isCurrentActiveAccount: true,
+    });
+
+    const map = TestMap.create({ name: "test", value: 0 }, { owner: account });
+
+    // Mutation outside transaction
+    map.$jazz.set("name", "outside");
+    expect(map.name).toBe("outside");
+
+    // Mutation inside transaction
+    await account.$jazz.withTransaction(() => {
+      map.$jazz.set("value", 42);
+    });
+    expect(map.value).toBe(42);
+
+    // Another mutation outside transaction
+    map.$jazz.set("name", "after");
+    expect(map.name).toBe("after");
+  });
+
+  test("multiple mutations across different CoValues in single transaction (US-1)", async () => {
+    const account = await createJazzTestAccount({
+      isCurrentActiveAccount: true,
+    });
+
+    const map1 = TestMap.create({ name: "map1", value: 1 }, { owner: account });
+    const map2 = TestMap.create({ name: "map2", value: 2 }, { owner: account });
+    const map3 = TestMap.create({ name: "map3", value: 3 }, { owner: account });
+
+    await account.$jazz.withTransaction(() => {
+      map1.$jazz.set("name", "updated1");
+      map1.$jazz.set("value", 10);
+
+      map2.$jazz.set("name", "updated2");
+      map2.$jazz.set("value", 20);
+
+      map3.$jazz.set("name", "updated3");
+      map3.$jazz.set("value", 30);
+    });
+
+    // All mutations should be visible
+    expect(map1.name).toBe("updated1");
+    expect(map1.value).toBe(10);
+    expect(map2.name).toBe("updated2");
+    expect(map2.value).toBe(20);
+    expect(map3.name).toBe("updated3");
+    expect(map3.value).toBe(30);
+  });
+
+  test("per-CoValue mutation order is preserved (US-1)", async () => {
+    const account = await createJazzTestAccount({
+      isCurrentActiveAccount: true,
+    });
+
+    const map = TestMap.create({ name: "test", value: 0 }, { owner: account });
+
+    await account.$jazz.withTransaction(() => {
+      map.$jazz.set("value", 1);
+      map.$jazz.set("value", 2);
+      map.$jazz.set("value", 3);
+      map.$jazz.set("value", 4);
+      map.$jazz.set("value", 5);
+    });
+
+    // Final value should be 5, preserving the order
+    expect(map.value).toBe(5);
+  });
+
+  test("transaction promise resolves when persistence and sync complete (US-1)", async () => {
+    const { clientAccount, serverNode } = await setupTwoNodes();
+
+    const map = TestMap.create(
+      { name: "test", value: 0 },
+      { owner: clientAccount },
+    );
+
+    // withTransaction should wait for persistence and sync
+    await clientAccount.$jazz.withTransaction(() => {
+      map.$jazz.set("name", "synced");
+      map.$jazz.set("value", 100);
+    });
+
+    // After withTransaction resolves, data should be available on server
+    const loadedMap = await serverNode.load(map.$jazz.raw.id);
+    expect(loadedMap).not.toBe(CoValueLoadingState.UNAVAILABLE);
+  });
+});


### PR DESCRIPTION
This PR adds _atomic transactions_ for CoValue mutations: multiple mutations can be executed inside a single `withTransaction()` callback and are then persisted together in one IndexedDB transaction and synced together in one network `BatchMessage`. Mutations are applied to memory immediately (optimistic); persistence and sync happen once the callback returns, with a single attempt for each. No automatic retry and no rollback of in-memory state.

This is primarily to protect against the client being closed in the middle of a sync/store operation.

It is based on already existing concepts of `DBTransactionInterfaceAsync`.

## DX
```ts
account.$jazz.unstable_withTransaction(() => {
  const map = TestMap.create({ name: "test", value: 0 });
  map.$jazz.set("name", "updated");
  map.$jazz.set("value", 42);
});
```

## Critical changes

- The [addition](https://github.com/garden-co/jazz/pull/3428/changes#diff-cb2c887ce03124928dac24533bd2da3b6163ea137372165eea913ea2dd0f93d2R153-R157) of `upsertCoValue` based on an existing transaction.
- The addition of a [Batch message](https://github.com/garden-co/jazz/pull/3428/changes#diff-c90e0211d2243ec0555557cabc377441df15b3b8ca4b76caa07882039f29da68R71-R74), which is sent to every [remote peer](https://github.com/garden-co/jazz/pull/3428/changes#diff-c90e0211d2243ec0555557cabc377441df15b3b8ca4b76caa07882039f29da68R1118-R1151). The batch message is handled like a simple list of messages. Its role is to ensure messages arrive together; we can't guarantee they are stored successfully. 

## Limitations
- If coValues inside `withTransaction` interact with coValues mutated outside, the indexeddb tx might fail because `upsertCoValue` looks inside the database and may not find the CoValue due to transaction concurrency.
- The `Batch` message's payload sent to the sync server might be bigger than transport limits for a single message.
- In case of failure on store/sync, the in-memory state is inconsistent. But this is already the current behaviour for every coValue
- Callbacks must be synchronous, to avoid nested transactions or endless promises.
- No ACK from sync server for batch messages: since every message in the batch is processed as usual, the server will follow the common flow after a `NewContent` message is received.
