### PR TITLE
fix: prevent issues with concurrent async SQLite transactions

### DIFF
--- a/.changeset/fruity-words-worry.md
+++ b/.changeset/fruity-words-worry.md
@@ -1,0 +1,6 @@
+---
+"jazz-tools": patch
+"cojson": patch
+---
+
+fix: prevent conflicts between concurrent async SQLite transactions

--- a/packages/cojson/src/storage/sqliteAsync/client.ts
+++ b/packages/cojson/src/storage/sqliteAsync/client.ts
@@ -165,7 +165,7 @@ export class SQLiteClientAsync implements DBClientInterfaceAsync {
   }
 
   private enqueueTx<T>(fn: () => Promise<T>): Promise<T> {
-    const next = this.txQueue.then(fn);
+    const next = this.txQueue.then(fn, fn);
     this.txQueue = next;
     return next;
   }

--- a/packages/cojson/src/storage/sqliteAsync/types.ts
+++ b/packages/cojson/src/storage/sqliteAsync/types.ts
@@ -3,7 +3,9 @@ export interface SQLiteDatabaseDriverAsync {
   run(sql: string, params: unknown[]): Promise<void>;
   query<T>(sql: string, params: unknown[]): Promise<T[]>;
   get<T>(sql: string, params: unknown[]): Promise<T | undefined>;
-  transaction(callback: () => unknown): Promise<unknown>;
+  transaction(
+    callback: (tx: SQLiteDatabaseDriverAsync) => unknown,
+  ): Promise<unknown>;
   closeDb(): Promise<unknown>;
   getMigrationVersion?(): Promise<number>;
   saveMigrationVersion?(version: number): Promise<void>;

--- a/packages/cojson/src/storage/types.ts
+++ b/packages/cojson/src/storage/types.ts
@@ -172,6 +172,10 @@ export interface DBTransactionInterfaceAsync {
     idx: number;
     signature: Signature;
   }): Promise<unknown>;
+
+  deleteCoValueContent(
+    coValueRow: Pick<StoredCoValueRow, "rowID" | "id">,
+  ): Promise<unknown>;
 }
 
 export interface DBClientInterfaceAsync {

--- a/packages/cojson/src/tests/SQLiteClientAsync.test.ts
+++ b/packages/cojson/src/tests/SQLiteClientAsync.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "vitest";
+import { getDbPath } from "./testStorage.js";
+import { setupTestNode } from "./testUtils.js";
+
+describe("SQLiteClientAsync", () => {
+  describe("transaction", () => {
+    test("serializes concurrent transactions to avoid SQLITE_BUSY errors", async () => {
+      const node = setupTestNode();
+      const { storage } = await node.addAsyncStorage({
+        ourName: "test",
+        storageName: "test-storage",
+        filename: getDbPath(),
+      });
+
+      // @ts-expect-error - dbClient is private
+      const dbClient = storage.dbClient;
+
+      const times = Array.from({ length: 10 });
+      await Promise.all(
+        times.map(async (_, i) => {
+          return dbClient.transaction(async (tx) => {
+            // Sleep between 0 and 100ms to force interleaving
+            await new Promise((r) => setTimeout(r, Math.random() * 100));
+            tx.addSignatureAfter({
+              sessionRowID: 0,
+              idx: i,
+              signature: `signature_z${i}`,
+            });
+          });
+        }),
+      );
+
+      const signatures = await dbClient.getSignatures(0, 0);
+      expect(signatures.length).toBe(10);
+      signatures.forEach(async ({ signature }, i) => {
+        expect(signature).toBe(`signature_z${i}`);
+      });
+    });
+  });
+});

--- a/packages/cojson/src/tests/SQLiteClientAsync.test.ts
+++ b/packages/cojson/src/tests/SQLiteClientAsync.test.ts
@@ -1,27 +1,31 @@
-import { describe, expect, test } from "vitest";
+import { beforeEach, describe, expect, test } from "vitest";
 import { getDbPath } from "./testStorage.js";
 import { setupTestNode } from "./testUtils.js";
+import { DBClientInterfaceAsync } from "../exports.js";
 
 describe("SQLiteClientAsync", () => {
   describe("transaction", () => {
-    test("serializes concurrent transactions to avoid SQLITE_BUSY errors", async () => {
+    let dbClient: DBClientInterfaceAsync;
+
+    beforeEach(async () => {
       const node = setupTestNode();
       const { storage } = await node.addAsyncStorage({
         ourName: "test",
         storageName: "test-storage",
         filename: getDbPath(),
       });
-
       // @ts-expect-error - dbClient is private
-      const dbClient = storage.dbClient;
+      dbClient = storage.dbClient;
+    });
 
+    test("serializes concurrent transactions to avoid SQLITE_BUSY errors", async () => {
       const times = Array.from({ length: 10 });
       await Promise.all(
         times.map(async (_, i) => {
           return dbClient.transaction(async (tx) => {
             // Sleep between 0 and 100ms to force interleaving
             await new Promise((r) => setTimeout(r, Math.random() * 100));
-            tx.addSignatureAfter({
+            return tx.addSignatureAfter({
               sessionRowID: 0,
               idx: i,
               signature: `signature_z${i}`,
@@ -34,6 +38,37 @@ describe("SQLiteClientAsync", () => {
       expect(signatures.length).toBe(10);
       signatures.forEach(async ({ signature }, i) => {
         expect(signature).toBe(`signature_z${i}`);
+      });
+    });
+
+    test("continues to serialize transactions even if one fails", async () => {
+      // First transaction succeeds
+      await dbClient.transaction(async (tx) => {
+        return tx.addSignatureAfter({
+          sessionRowID: 0,
+          idx: 0,
+          signature: `signature_z0`,
+        });
+      });
+      // Second transaction fails (duplicate primary key)
+      await expect(
+        dbClient.transaction(async (tx) => {
+          return tx.addSignatureAfter({
+            sessionRowID: 0,
+            idx: 0,
+            signature: `signature_z0`,
+          });
+        }),
+      ).rejects.toThrow(
+        /UNIQUE constraint failed: signatureAfter\.ses, signatureAfter\.idx/,
+      );
+      // Third transaction succeeds
+      await dbClient.transaction(async (tx) => {
+        return tx.addSignatureAfter({
+          sessionRowID: 0,
+          idx: 1,
+          signature: `signature_z1`,
+        });
       });
     });
   });

--- a/packages/cojson/src/tests/StorageApiAsync.test.ts
+++ b/packages/cojson/src/tests/StorageApiAsync.test.ts
@@ -945,15 +945,10 @@ describe("StorageApiAsync", () => {
         return true;
       });
 
-      let releaseBarrier!: () => void;
-      const barrier = new Promise<void>((resolve) => {
-        releaseBarrier = resolve;
-      });
-
-      let firstTxStartedResolve!: () => void;
-      const firstTxStarted = new Promise<void>((resolve) => {
-        firstTxStartedResolve = resolve;
-      });
+      const { promise: barrier, resolve: releaseBarrier } =
+        Promise.withResolvers<void>();
+      const { promise: firstTxStarted, resolve: firstTxStartedResolve } =
+        Promise.withResolvers<void>();
 
       // @ts-expect-error - dbClient is private
       const dbClient = storage.dbClient;

--- a/packages/cojson/src/tests/setup.ts
+++ b/packages/cojson/src/tests/setup.ts
@@ -1,4 +1,10 @@
+import { beforeEach } from "vitest";
 import { cojsonInternals } from "../exports.js";
+import { registerStorageCleanupRunner } from "./testStorage.js";
 
 // Use a very high budget to avoid that slow tests fail due to the budget being exceeded.
 cojsonInternals.setIncomingMessagesTimeBudget(10000); // 10 seconds
+
+beforeEach(() => {
+  registerStorageCleanupRunner();
+});

--- a/packages/cojson/src/tests/testStorage.ts
+++ b/packages/cojson/src/tests/testStorage.ts
@@ -11,7 +11,7 @@ import {
   SQLiteDatabaseDriverAsync,
   getSqliteStorageAsync,
 } from "../storage/sqliteAsync";
-import { SyncMessagesLog, SyncTestMessage } from "./testUtils";
+import { SyncMessagesLog } from "./testUtils";
 import { knownStateFromContent } from "../coValueContentMessage";
 
 class LibSQLSqliteAsyncDriver implements SQLiteDatabaseDriverAsync {
@@ -37,11 +37,11 @@ class LibSQLSqliteAsyncDriver implements SQLiteDatabaseDriverAsync {
     return this.db.prepare(sql).get(params) as T | undefined;
   }
 
-  async transaction(callback: () => unknown) {
+  async transaction(callback: (tx: LibSQLSqliteAsyncDriver) => unknown) {
     await this.run("BEGIN TRANSACTION", []);
 
     try {
-      await callback();
+      await callback(this);
       await this.run("COMMIT", []);
     } catch (error) {
       await this.run("ROLLBACK", []);

--- a/packages/cojson/src/tests/testStorage.ts
+++ b/packages/cojson/src/tests/testStorage.ts
@@ -92,10 +92,39 @@ class LibSQLSqliteSyncDriver implements SQLiteDatabaseDriver {
   }
 }
 
-function deleteDb(dbPath: string) {
+/** Cleanup functions registered by createAsyncStorage/createSyncStorage; run by the runner hook (registered first so it runs last). */
+const storageCleanupFns: Array<() => void | Promise<void>> = [];
+
+function registerStorageCleanup(fn: () => void | Promise<void>): void {
+  storageCleanupFns.push(fn);
+}
+
+/** Call from beforeEach so this hook is registered first and thus runs last (LIFO), after node shutdown hooks. */
+export function registerStorageCleanupRunner(): void {
+  // Clear cleanup functions from previous test
+  storageCleanupFns.length = 0;
+  onTestFinished(async () => {
+    for (const fn of storageCleanupFns) {
+      await fn();
+    }
+  });
+}
+
+function unlinkIfExists(path: string): void {
   try {
-    unlinkSync(dbPath);
-  } catch {}
+    unlinkSync(path);
+  } catch (error: unknown) {
+    const err = error as NodeJS.ErrnoException;
+    if (err?.code !== "ENOENT") {
+      console.error(error);
+    }
+  }
+}
+
+function deleteDb(dbPath: string): void {
+  unlinkIfExists(dbPath);
+  unlinkIfExists(`${dbPath}-wal`);
+  unlinkIfExists(`${dbPath}-shm`);
 }
 
 export async function createAsyncStorage({
@@ -108,11 +137,12 @@ export async function createAsyncStorage({
   storageName: string;
 }) {
   const dbPath = getDbPath(filename);
+
   const storage = await getSqliteStorageAsync(
     new LibSQLSqliteAsyncDriver(dbPath),
   );
 
-  onTestFinished(async () => {
+  registerStorageCleanup(async () => {
     await storage.close();
     deleteDb(dbPath);
   });
@@ -132,11 +162,12 @@ export function createSyncStorage({
   storageName: string;
 }) {
   const dbPath = getDbPath(filename);
+
   const storage = getSqliteStorage(
     new LibSQLSqliteSyncDriver(getDbPath(filename)),
   );
 
-  onTestFinished(() => {
+  registerStorageCleanup(() => {
     storage.close();
     deleteDb(dbPath);
   });

--- a/packages/cojson/src/tests/testStorage.ts
+++ b/packages/cojson/src/tests/testStorage.ts
@@ -45,6 +45,7 @@ class LibSQLSqliteAsyncDriver implements SQLiteDatabaseDriverAsync {
       await this.run("COMMIT", []);
     } catch (error) {
       await this.run("ROLLBACK", []);
+      throw error;
     }
   }
 

--- a/packages/jazz-tools/src/expo/storage/expo-sqlite-adapter.ts
+++ b/packages/jazz-tools/src/expo/storage/expo-sqlite-adapter.ts
@@ -6,6 +6,12 @@ export class ExpoSQLiteAdapter implements SQLiteDatabaseDriverAsync {
   private db: SQLiteDatabase | null = null;
   private dbName: string;
 
+  static withDB(db: SQLiteDatabase): ExpoSQLiteAdapter {
+    const adapter = new ExpoSQLiteAdapter();
+    adapter.db = db;
+    return adapter;
+  }
+
   public constructor(dbName: string = "jazz-storage") {
     this.dbName = dbName;
   }
@@ -56,13 +62,13 @@ export class ExpoSQLiteAdapter implements SQLiteDatabaseDriverAsync {
     await this.db.runAsync(sql, params?.map((p) => p as SQLiteBindValue) ?? []);
   }
 
-  public async transaction(callback: () => unknown) {
+  public async transaction(callback: (tx: ExpoSQLiteAdapter) => unknown) {
     if (!this.db) {
       throw new Error("Database not initialized");
     }
 
-    await this.db.withTransactionAsync(async () => {
-      await callback();
+    await this.db.withExclusiveTransactionAsync(async (tx) => {
+      await callback(ExpoSQLiteAdapter.withDB(tx));
     });
   }
 

--- a/packages/jazz-tools/src/react-core/tests/testUtils.tsx
+++ b/packages/jazz-tools/src/react-core/tests/testUtils.tsx
@@ -98,6 +98,7 @@ class LibSQLSqliteAsyncDriver implements SQLiteDatabaseDriverAsync {
       await this.run("COMMIT", []);
     } catch (error) {
       await this.run("ROLLBACK", []);
+      throw error;
     }
   }
 

--- a/packages/jazz-tools/src/react-core/tests/testUtils.tsx
+++ b/packages/jazz-tools/src/react-core/tests/testUtils.tsx
@@ -90,11 +90,11 @@ class LibSQLSqliteAsyncDriver implements SQLiteDatabaseDriverAsync {
     return this.db.prepare(sql).get(params) as T | undefined;
   }
 
-  async transaction(callback: () => unknown) {
+  async transaction(callback: (tx: LibSQLSqliteAsyncDriver) => unknown) {
     await this.run("BEGIN TRANSACTION", []);
 
     try {
-      await callback();
+      await callback(this);
       await this.run("COMMIT", []);
     } catch (error) {
       await this.run("ROLLBACK", []);

--- a/packages/jazz-tools/src/tools/tests/testStorage.ts
+++ b/packages/jazz-tools/src/tools/tests/testStorage.ts
@@ -9,7 +9,7 @@ import { onTestFinished } from "vitest";
 /** Cleanup functions registered by createAsyncStorage; run by the runner hook (registered first so it runs last). */
 const storageCleanupFns: Array<() => void | Promise<void>> = [];
 
-export function registerStorageCleanup(fn: () => void | Promise<void>): void {
+function registerStorageCleanup(fn: () => void | Promise<void>): void {
   storageCleanupFns.push(fn);
 }
 
@@ -54,6 +54,7 @@ class LibSQLSqliteAsyncDriver implements SQLiteDatabaseDriverAsync {
       await this.run("COMMIT", []);
     } catch (error) {
       await this.run("ROLLBACK", []);
+      throw error;
     }
   }
 

--- a/packages/jazz-tools/src/tools/tests/testStorage.ts
+++ b/packages/jazz-tools/src/tools/tests/testStorage.ts
@@ -29,11 +29,11 @@ class LibSQLSqliteAsyncDriver implements SQLiteDatabaseDriverAsync {
     return this.db.prepare(sql).get(params) as T | undefined;
   }
 
-  async transaction(callback: () => unknown) {
+  async transaction(callback: (tx: LibSQLSqliteAsyncDriver) => unknown) {
     await this.run("BEGIN TRANSACTION", []);
 
     try {
-      await callback();
+      await callback(this);
       await this.run("COMMIT", []);
     } catch (error) {
       await this.run("ROLLBACK", []);

--- a/packages/jazz-tools/src/tools/tests/testStorage.ts
+++ b/packages/jazz-tools/src/tools/tests/testStorage.ts
@@ -6,6 +6,23 @@ import { SQLiteDatabaseDriverAsync, getSqliteStorageAsync } from "cojson";
 import Database, { type Database as DatabaseT } from "libsql";
 import { onTestFinished } from "vitest";
 
+/** Cleanup functions registered by createAsyncStorage; run by the runner hook (registered first so it runs last). */
+const storageCleanupFns: Array<() => void | Promise<void>> = [];
+
+export function registerStorageCleanup(fn: () => void | Promise<void>): void {
+  storageCleanupFns.push(fn);
+}
+
+/** Call from beforeEach so this hook is registered first and thus runs last (LIFO), after node shutdown hooks. */
+export function registerStorageCleanupRunner(): void {
+  // Clear cleanup functions from previous test
+  storageCleanupFns.length = 0;
+  onTestFinished(async () => {
+    for (const fn of storageCleanupFns) {
+      await fn();
+    }
+  });
+}
 class LibSQLSqliteAsyncDriver implements SQLiteDatabaseDriverAsync {
   private readonly db: DatabaseT;
 
@@ -45,12 +62,21 @@ class LibSQLSqliteAsyncDriver implements SQLiteDatabaseDriverAsync {
   }
 }
 
-function deleteDb(dbPath: string) {
+function unlinkIfExists(path: string): void {
   try {
-    unlinkSync(dbPath);
-  } catch (error) {
-    console.error(error);
+    unlinkSync(path);
+  } catch (error: unknown) {
+    const err = error as NodeJS.ErrnoException;
+    if (err?.code !== "ENOENT") {
+      console.error(error);
+    }
   }
+}
+
+function deleteDb(dbPath: string): void {
+  unlinkIfExists(dbPath);
+  unlinkIfExists(`${dbPath}-wal`);
+  unlinkIfExists(`${dbPath}-shm`);
 }
 
 export async function createAsyncStorage({ filename }: { filename?: string }) {
@@ -59,7 +85,7 @@ export async function createAsyncStorage({ filename }: { filename?: string }) {
     new LibSQLSqliteAsyncDriver(dbPath),
   );
 
-  onTestFinished(async () => {
+  registerStorageCleanup(async () => {
     await storage.close();
     deleteDb(dbPath);
   });

--- a/packages/jazz-tools/testSetup.ts
+++ b/packages/jazz-tools/testSetup.ts
@@ -1,4 +1,10 @@
+import { beforeEach } from "vitest";
 import { cojsonInternals } from "cojson";
+import { registerStorageCleanupRunner } from "./src/tools/tests/testStorage.js";
 
 // Use a very high budget to avoid that slow tests fail due to the budget being exceeded.
 cojsonInternals.setIncomingMessagesTimeBudget(10000); // 10 seconds
+
+beforeEach(() => {
+  registerStorageCleanupRunner();
+});


### PR DESCRIPTION
## Description

While working on https://github.com/garden-co/jazz/pull/3422, I noticed that DB operations inside interleaved async js tasks could end up inside the same transaction when using the async SQLite client. I solved that by modifying `SQLiteClientAsync.transaction` to pass a tx object to its callback instead of performing all the operation on the same DB client, and splitting the Client and Transaction APIs. Under the hood, different clients now handle concurrent txs differently:
- `op-sqlite` serializes all transactions: https://github.com/OP-Engineering/op-sqlite/blob/main/src/functions.ts#L352
- `expo-sqlite` creates a new connection to avoid concurrent js tasks from submitting operations to the same client: https://docs.expo.dev/versions/latest/sdk/sqlite/#withexclusivetransactionasynctask
  - it does not prevent concurrent txs though, so running into SQLITE_BUSY errors is still possible (1)
- `libsql` does not solve this (2). I tried switching to https://github.com/tursodatabase/libsql-client-ts, but that turned out to be a rabbit hole, so I'm keeping this one as-is (considering we use it only for testing)

Due to (1) and (2) still making it possible to run into SQLITE_BUSY errors, I also modified `SQLiteClientAsync.transaction` to serialize transactions.

I also made some improvements to DB cleanup in tests:
- prevented stores from being closed before the node is shut down
- `-wal` and `-shm` SQLite files were not being cleaned up 


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core persistence transaction boundaries and driver adapters; serialization and tx-scoping could change concurrency behavior/performance and may surface driver-specific transaction edge cases.
> 
> **Overview**
> Prevents async JS tasks from accidentally sharing a single SQLite transaction by splitting `SQLiteClientAsync` into a client + `SQLiteTransactionAsync`, and changing `SQLiteDatabaseDriverAsync.transaction` to pass a tx-scoped driver into the callback.
> 
> Adds a per-client transaction queue to **serialize concurrent async transactions** (reducing `SQLITE_BUSY`/interleaving issues), updates Expo/OP-SQLite adapters to provide tx-specific adapters (using Expo’s exclusive transactions and OP-SQLite’s transaction object), and introduces a focused regression test for concurrent `transaction()` calls.
> 
> Improves test DB lifecycle cleanup by deferring storage close/delete until after node shutdown hooks and by also removing `-wal`/`-shm` files; test code is updated accordingly (including `Promise.withResolvers` usage).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b38a52649bfb4c131100b3774aef2fee47974567. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->