### PR TITLE
poc: sqlite-wasm

### DIFF
--- a/.specs/sqlite-wasm-storage-adapter/design.md
+++ b/.specs/sqlite-wasm-storage-adapter/design.md
@@ -1,0 +1,481 @@
+# SQLite Wasm Storage Adapter for Jazz - Design Document
+
+## Overview
+
+This feature introduces a new storage adapter for Jazz applications running in browser environments, leveraging [SQLite Wasm](https://github.com/sqlite/sqlite-wasm) as an alternative to IndexedDB. SQLite Wasm provides a robust, SQL-based storage solution with support for OPFS (Origin Private File System) for persistence, offering better performance characteristics for certain workloads and improved debugging capabilities through standard SQL queries.
+
+The adapter will integrate seamlessly with Jazz's existing storage architecture, implementing the `SQLiteDatabaseDriverAsync` interface and working with the `getSqliteStorageAsync` factory from `cojson`. All browser-facing framework providers (React, Svelte, and their Clerk auth variants) will be updated to accept the new storage option.
+
+### Key Benefits
+
+- **Better Performance**: SQLite can offer superior performance for complex queries and large datasets compared to IndexedDB
+- **OPFS Support**: When available, provides persistent storage with better characteristics than IndexedDB
+- **SQL Debugging**: Developers can inspect storage using standard SQL queries
+- **Memory Fallback**: Gracefully falls back to in-memory storage when OPFS is unavailable
+- **Compatibility**: Works in modern browsers with SharedArrayBuffer support (requires COOP/COEP headers)
+
+## Architecture / Components
+
+### Package Structure
+
+A new package will be created: `packages/cojson-storage-sqlite-wasm/`
+
+```
+packages/cojson-storage-sqlite-wasm/
+├── src/
+│   ├── index.ts                           # Main entry point & getSqliteWasmStorage()
+│   ├── SqliteWasmDriver.ts                # SQLiteDatabaseDriverAsync implementation
+│   └── tests/
+│       ├── storage.sqlite-wasm.test.ts    # Driver + integration tests
+│       ├── testUtils.ts
+│       └── messagesTestUtils.ts
+├── package.json
+├── tsconfig.json
+├── vitest.config.ts                       # Browser mode via Playwright
+```
+
+### Component Interactions
+
+`sqlite3Worker1Promiser` from `@sqlite.org/sqlite-wasm` already spawns and manages its own internal Web Worker. The driver uses the promiser API directly from the main thread -- no custom worker is needed.
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│              Framework Providers (all browser)                │
+│                                                              │
+│  React: JazzReactProvider → JazzBrowserContextManager        │
+│  Svelte: Provider.svelte  → JazzBrowserContextManager        │
+│  Svelte+Clerk: JazzSvelteProviderWithClerk → same            │
+│                                                              │
+│  All accept:  storage?: "indexedDB" | "sqlite-wasm"          │
+└──────────────────────────┬──────────────────────────────────┘
+                           │
+                           ▼
+┌─────────────────────────────────────────────────────────────┐
+│        createBrowserContext.ts (setupPeers)                   │
+│                                                              │
+│  if (storage === "sqlite-wasm")                              │
+│    → dynamic import("cojson-storage-sqlite-wasm")            │
+│    → getSqliteWasmStorage()                                  │
+│  else                                                        │
+│    → getIndexedDBStorage()  (default)                        │
+└──────────────────────────┬──────────────────────────────────┘
+                           │
+                           ▼
+┌─────────────────────────────────────────────────────────────┐
+│            cojson-storage-sqlite-wasm                        │
+│  ┌────────────────────────────────────────────────────────┐ │
+│  │              SqliteWasmDriver                          │ │
+│  │  Implements: SQLiteDatabaseDriverAsync                │ │
+│  │  Uses: sqlite3Worker1Promiser (main thread)           │ │
+│  │                                                        │ │
+│  │  - initialize()  → promiser('open', {filename})       │ │
+│  │  - run(sql)       → promiser('exec', {sql, bind})     │ │
+│  │  - query<T>(sql)  → promiser('exec', {sql, rowMode})  │ │
+│  │  - get<T>(sql)    → query()[0]                        │ │
+│  │  - transaction()  → BEGIN / callback / COMMIT|ROLLBACK│ │
+│  │  - closeDb()      → promiser('close', {dbId})         │ │
+│  └────────────────────────────────────────────────────────┘ │
+│                             │                                │
+│             sqlite3Worker1Promiser manages                   │
+│             its own internal Web Worker                      │
+│                             │                                │
+│  ┌────────────────────────────────────────────────────────┐ │
+│  │  @sqlite.org/sqlite-wasm (internal worker)            │ │
+│  │  - OPFS persistence when available                    │ │
+│  │  - In-memory fallback                                 │ │
+│  └────────────────────────────────────────────────────────┘ │
+└─────────────────────────────────────────────────────────────┘
+                             │
+                             ▼
+┌─────────────────────────────────────────────────────────────┐
+│                   cojson/storage                             │
+│  ┌────────────────────────────────────────────────────────┐ │
+│  │  getSqliteStorageAsync(driver)                        │ │
+│  │  → runs migrations                                    │ │
+│  │  → returns StorageApiAsync(new SqliteAsyncClient(db)) │ │
+│  └────────────────────────────────────────────────────────┘ │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Core Implementation Files
+
+#### 1. SqliteWasmDriver.ts
+
+Implements the `SQLiteDatabaseDriverAsync` interface using `sqlite3Worker1Promiser` directly. The promiser handles all worker communication internally.
+
+```typescript
+import type { SQLiteDatabaseDriverAsync } from "cojson";
+import { sqlite3Worker1Promiser } from "@sqlite.org/sqlite-wasm";
+
+type Promiser = (
+  messageType: string,
+  args: Record<string, unknown>,
+) => Promise<{ dbId: string; result: Record<string, unknown> }>;
+
+export class SqliteWasmDriver implements SQLiteDatabaseDriverAsync {
+  private promiser!: Promiser;
+  private dbId!: string;
+  private readonly filename: string;
+  private readonly useOPFS: boolean;
+
+  constructor(filename = "jazz-cojson.sqlite3", useOPFS = true) {
+    this.filename = filename;
+    this.useOPFS = useOPFS;
+  }
+
+  async initialize(): Promise<void> {
+    // sqlite3Worker1Promiser spawns its own internal worker
+    this.promiser = await new Promise<Promiser>((resolve) => {
+      const _promiser = sqlite3Worker1Promiser({
+        onready: () => resolve(_promiser as Promiser),
+      });
+    });
+
+    // Try OPFS first, fall back to in-memory
+    const filename = this.useOPFS
+      ? `file:${this.filename}?vfs=opfs`
+      : ":memory:";
+
+    try {
+      const openResponse = await this.promiser("open", { filename });
+      this.dbId = openResponse.dbId;
+    } catch {
+      // OPFS unavailable — fall back to in-memory
+      console.warn(
+        "OPFS not available, falling back to in-memory storage",
+      );
+      const openResponse = await this.promiser("open", {
+        filename: ":memory:",
+      });
+      this.dbId = openResponse.dbId;
+    }
+  }
+
+  async run(sql: string, params: unknown[]): Promise<void> {
+    await this.promiser("exec", {
+      dbId: this.dbId,
+      sql,
+      bind: params,
+    });
+  }
+
+  async query<T>(sql: string, params: unknown[]): Promise<T[]> {
+    const response = await this.promiser("exec", {
+      dbId: this.dbId,
+      sql,
+      bind: params,
+      returnValue: "resultRows",
+      rowMode: "object",
+    });
+    return (response.result.resultRows ?? []) as T[];
+  }
+
+  async get<T>(sql: string, params: unknown[]): Promise<T | undefined> {
+    const rows = await this.query<T>(sql, params);
+    return rows[0];
+  }
+
+  async transaction(
+    callback: (tx: SQLiteDatabaseDriverAsync) => unknown,
+  ): Promise<unknown> {
+    await this.run("BEGIN TRANSACTION", []);
+    try {
+      const result = await callback(this);
+      await this.run("COMMIT", []);
+      return result;
+    } catch (error) {
+      await this.run("ROLLBACK", []);
+      throw error;
+    }
+  }
+
+  async closeDb(): Promise<void> {
+    await this.promiser("close", { dbId: this.dbId });
+  }
+
+  async getMigrationVersion(): Promise<number> {
+    const row = await this.get<{ user_version: number }>(
+      "PRAGMA user_version",
+      [],
+    );
+    return row?.user_version ?? 0;
+  }
+
+  async saveMigrationVersion(version: number): Promise<void> {
+    await this.run(`PRAGMA user_version = ${version}`, []);
+  }
+}
+```
+
+#### 2. index.ts
+
+Main entry point. Mirrors the pattern used by other storage adapters (e.g. `cojson-storage-sqlite` calling `getSqliteStorage`).
+
+```typescript
+import { getSqliteStorageAsync } from "cojson";
+import { SqliteWasmDriver } from "./SqliteWasmDriver.js";
+
+export { SqliteWasmDriver };
+
+/**
+ * Create a SQLite Wasm storage adapter for Jazz.
+ *
+ * Uses `sqlite3Worker1Promiser` from `@sqlite.org/sqlite-wasm`,
+ * which manages its own internal Web Worker. OPFS is used for
+ * persistence when available; otherwise falls back to in-memory.
+ *
+ * **Requirements:**
+ * - Server must set COOP/COEP headers for OPFS support
+ * - `@sqlite.org/sqlite-wasm` must be excluded from bundler
+ *   optimization (e.g. `optimizeDeps.exclude` in Vite)
+ *
+ * @param filename - Database file name for OPFS (default: `'jazz-cojson.sqlite3'`)
+ * @param useOPFS - Whether to attempt OPFS persistence (default: `true`)
+ */
+export async function getSqliteWasmStorage(
+  filename = "jazz-cojson.sqlite3",
+  useOPFS = true,
+) {
+  const driver = new SqliteWasmDriver(filename, useOPFS);
+  return await getSqliteStorageAsync(driver);
+}
+```
+
+### Framework Provider Updates
+
+The `storage` option needs to propagate through all browser-targeting framework providers. The type flows from `BaseBrowserContextOptions` → `JazzContextManagerProps` → each provider's props.
+
+#### `BaseBrowserContextOptions` (the source of truth)
+
+```typescript
+// packages/jazz-tools/src/browser/createBrowserContext.ts
+
+export type BaseBrowserContextOptions = {
+  sync: SyncConfig;
+  reconnectionTimeout?: number;
+  storage?: "indexedDB" | "sqlite-wasm";  // ← add "sqlite-wasm"
+  crypto?: CryptoProvider;
+  authSecretStorage: AuthSecretStorage;
+};
+
+async function setupPeers(options: BaseBrowserContextOptions) {
+  const crypto = options.crypto || (await WasmCrypto.create());
+  // ...
+
+  let storage;
+  if (options.storage === "sqlite-wasm") {
+    const { getSqliteWasmStorage } = await import("cojson-storage-sqlite-wasm");
+    storage = await getSqliteWasmStorage();
+  } else {
+    // Default to IndexedDB (backward compatible)
+    storage = await getIndexedDBStorage();
+  }
+
+  // ... rest unchanged
+}
+```
+
+#### Files that reference `BaseBrowserContextOptions["storage"]` (all inherit the new type automatically)
+
+These files already use `BaseBrowserContextOptions["storage"]` as their storage type, so they get `"sqlite-wasm"` support for free once the base type is updated:
+
+| File | How it references the type |
+|------|--------------------------|
+| `packages/jazz-tools/src/browser/BrowserContextManager.ts` | `storage?: BaseBrowserContextOptions["storage"]` in `JazzContextManagerProps` |
+| `packages/jazz-tools/src/react/provider.tsx` | `JazzProviderProps` extends `JazzContextManagerProps` — passes `storage` through |
+| `packages/jazz-tools/src/svelte/Provider.svelte` | Props include `storage` from `JazzContextManagerProps` — passes to `contextManager.createContext()` |
+| `packages/jazz-tools/src/svelte/auth/JazzSvelteProviderWithClerk.svelte` | `storage?: BaseBrowserContextOptions["storage"]` — passes to `JazzSvelteProvider` |
+
+**No changes needed in the React, Svelte, or Svelte+Clerk providers** — they all derive their storage type from `BaseBrowserContextOptions["storage"]` and forward the value to `createBrowserContext`, which handles the actual instantiation.
+
+#### React Native (out of scope)
+
+React Native already accepts `SQLiteDatabaseDriverAsync | "disabled"` directly (see `BaseReactNativeContextOptions`). Since `@sqlite.org/sqlite-wasm` requires a browser environment (Web Workers + OPFS), it is not applicable to React Native and no changes are needed there.
+
+## Data Models
+
+### Database Schema
+
+The adapter reuses the existing SQLite schema defined in `cojson/src/storage/sqliteAsync/sqliteMigrations.ts` via `getSqliteStorageAsync`. No schema changes are required -- the async migration runner handles everything.
+
+Key tables:
+- `coValues` — Stores CoValue headers and metadata
+- `sessions` — Stores session information for each CoValue
+- `transactions` — Stores individual transactions
+- `signatureAfter` — Stores signatures for transaction batches
+- `deletedCoValues` — Tracks CoValues pending deletion
+- `syncState` — Tracks sync status with peers
+
+## Testing Strategy
+
+### Vitest Browser Mode Configuration
+
+Tests **must** run in Vitest Browser Mode because `@sqlite.org/sqlite-wasm` requires a browser environment (Web Workers, Wasm). The configuration follows the exact pattern established by `cojson-storage-indexeddb`:
+
+```typescript
+// packages/cojson-storage-sqlite-wasm/vitest.config.ts
+import { defineProject } from "vitest/config";
+import { playwright } from "@vitest/browser-playwright";
+
+export default defineProject({
+  test: {
+    name: "cojson-storage-sqlite-wasm",
+    browser: {
+      enabled: true,
+      provider: playwright(),
+      instances: [
+        {
+          headless: process.env.HEADLESS !== "false",
+          browser: "chromium",
+        },
+      ],
+    },
+    include: ["src/**/*.test.ts"],
+  },
+});
+```
+
+### Driver Unit Tests
+
+```typescript
+// src/tests/storage.sqlite-wasm.test.ts
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { SqliteWasmDriver } from "../SqliteWasmDriver.js";
+
+describe("SqliteWasmDriver", () => {
+  let driver: SqliteWasmDriver;
+
+  beforeEach(async () => {
+    driver = new SqliteWasmDriver("test.db", false); // in-memory for tests
+    await driver.initialize();
+  });
+
+  afterEach(async () => {
+    await driver.closeDb();
+  });
+
+  it("should execute DDL and query", async () => {
+    await driver.run(
+      "CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)",
+      [],
+    );
+    await driver.run("INSERT INTO test (name) VALUES (?)", ["Alice"]);
+
+    const rows = await driver.query<{ id: number; name: string }>(
+      "SELECT * FROM test",
+      [],
+    );
+    expect(rows).toEqual([{ id: 1, name: "Alice" }]);
+  });
+
+  it("should return single row with get()", async () => {
+    await driver.run("CREATE TABLE kv (k TEXT PRIMARY KEY, v TEXT)", []);
+    await driver.run("INSERT INTO kv VALUES (?, ?)", ["key1", "val1"]);
+
+    const row = await driver.get<{ k: string; v: string }>(
+      "SELECT * FROM kv WHERE k = ?",
+      ["key1"],
+    );
+    expect(row).toEqual({ k: "key1", v: "val1" });
+  });
+
+  it("should commit transactions", async () => {
+    await driver.run("CREATE TABLE t (v INTEGER)", []);
+
+    await driver.transaction(async (tx) => {
+      await tx.run("INSERT INTO t VALUES (?)", [1]);
+      await tx.run("INSERT INTO t VALUES (?)", [2]);
+    });
+
+    const rows = await driver.query<{ v: number }>(
+      "SELECT v FROM t ORDER BY v",
+      [],
+    );
+    expect(rows).toEqual([{ v: 1 }, { v: 2 }]);
+  });
+
+  it("should rollback failed transactions", async () => {
+    await driver.run("CREATE TABLE t (v INTEGER)", []);
+
+    await expect(
+      driver.transaction(async (tx) => {
+        await tx.run("INSERT INTO t VALUES (?)", [1]);
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+
+    const rows = await driver.query<{ v: number }>(
+      "SELECT COUNT(*) as c FROM t",
+      [],
+    );
+    expect(rows[0]!.c).toBe(0);
+  });
+
+  it("should read and write migration version", async () => {
+    expect(await driver.getMigrationVersion()).toBe(0);
+    await driver.saveMigrationVersion(5);
+    expect(await driver.getMigrationVersion()).toBe(5);
+  });
+});
+```
+
+### Integration Tests
+
+Test the full storage API (`StorageApiAsync`) through `getSqliteWasmStorage()`, following the same patterns as `storage.indexeddb.test.ts`. These verify CoValue store/load roundtrips, dependency loading, transaction corrections, large data streaming, account persistence, sync state persistence, and sync resumption.
+
+```typescript
+// src/tests/storage-integration.test.ts
+import { LocalNode, cojsonInternals } from "cojson";
+import { WasmCrypto } from "cojson/crypto/WasmCrypto";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { getSqliteWasmStorage } from "../index.js";
+import { toSimplifiedMessages } from "./messagesTestUtils.js";
+import {
+  createTestNode,
+  trackMessages,
+  waitFor,
+} from "./testUtils.js";
+
+const Crypto = await WasmCrypto.create();
+let syncMessages: ReturnType<typeof trackMessages>;
+
+beforeEach(() => {
+  syncMessages = trackMessages();
+  cojsonInternals.setSyncStateTrackingBatchDelay(0);
+  cojsonInternals.setCoValueLoadingRetryDelay(10);
+});
+
+afterEach(async () => {
+  syncMessages.restore();
+});
+
+test("should sync and load data from storage", async () => {
+  const node1 = createTestNode();
+  node1.setStorage(await getSqliteWasmStorage("test.db", false));
+
+  const group = node1.createGroup();
+  const map = group.createMap();
+  map.set("hello", "world");
+  await map.core.waitForSync();
+
+  node1.gracefulShutdown();
+  syncMessages.clear();
+
+  const node2 = createTestNode({ secret: node1.agentSecret });
+  node2.setStorage(await getSqliteWasmStorage("test.db", false));
+
+  const map2 = await node2.load(map.id);
+  if (map2 === "unavailable") {
+    throw new Error("Map is unavailable");
+  }
+
+  expect(map2.get("hello")).toBe("world");
+});
+```
+
+### Testing Approach Summary
+
+1. **All tests run in Vitest Browser Mode** via `@vitest/browser-playwright` with headless Chromium, because `@sqlite.org/sqlite-wasm` requires browser APIs (Web Workers, Wasm instantiation)
+2. **Driver unit tests**: verify each method of the `SQLiteDatabaseDriverAsync` interface
+3. **Integration tests**: mirror the `storage.indexeddb.test.ts` test suite, covering store/load roundtrips, dependency loading, transaction corrections, large data streaming, account persistence, sync state tracking, and sync resumption
+4. **In-memory mode** (`useOPFS: false`) is used for all tests to avoid OPFS cross-test interference and ensure tests work in CI without COOP/COEP headers

--- a/.specs/sqlite-wasm-storage-adapter/tasks.md
+++ b/.specs/sqlite-wasm-storage-adapter/tasks.md
@@ -1,0 +1,23 @@
+# Implementation Tasks
+
+## Tasks
+
+- [ ] 1. **Scaffold the `cojson-storage-sqlite-wasm` package** — Create `packages/cojson-storage-sqlite-wasm/` with `package.json` (dependencies: `@sqlite.org/sqlite-wasm`, `cojson workspace:*`; devDependencies: `typescript`, `@vitest/browser-playwright`), `tsconfig.json`, and `vitest.config.ts` configured for Vitest Browser Mode with Playwright + headless Chromium (ref: Design § Package Structure, § Vitest Browser Mode Configuration)
+
+- [ ] 2. **Implement `SqliteWasmDriver`** — Create `src/SqliteWasmDriver.ts` implementing `SQLiteDatabaseDriverAsync` from `cojson`. Use `sqlite3Worker1Promiser` directly (no custom worker). Methods: `initialize()`, `run()`, `query()`, `get()`, `transaction()`, `closeDb()`, `getMigrationVersion()`, `saveMigrationVersion()`. Handle OPFS fallback to in-memory (ref: Design § SqliteWasmDriver.ts)
+
+- [ ] 3. **Create package entry point** — Create `src/index.ts` exporting `getSqliteWasmStorage()` factory (calls `getSqliteStorageAsync(driver)` from `cojson`) and re-exporting `SqliteWasmDriver`. Add JSDoc with `@param`, `@returns`, usage example, and COOP/COEP requirements note (ref: Design § index.ts)
+
+- [ ] 4. **Update `BaseBrowserContextOptions` storage type** — In `packages/jazz-tools/src/browser/createBrowserContext.ts`, extend `storage?: "indexedDB"` to `storage?: "indexedDB" | "sqlite-wasm"` (ref: Design § Framework Provider Updates)
+
+- [ ] 5. **Add `"sqlite-wasm"` branch to `setupPeers()`** — In the same `createBrowserContext.ts`, add a conditional branch in `setupPeers()` that does `const { getSqliteWasmStorage } = await import("cojson-storage-sqlite-wasm")` and calls `getSqliteWasmStorage()` when `options.storage === "sqlite-wasm"`. Default remains IndexedDB (ref: Design § BaseBrowserContextOptions)
+
+- [ ] 6. **Verify framework provider type propagation** — Confirm that `JazzBrowserContextManager` (`BrowserContextManager.ts`), `JazzReactProvider` (`provider.tsx`), `Provider.svelte`, and `JazzSvelteProviderWithClerk.svelte` all derive their `storage` type from `BaseBrowserContextOptions["storage"]` and require no code changes (ref: Design § Files that reference BaseBrowserContextOptions)
+
+- [ ] 7. **Write driver unit tests** — Create `src/tests/storage.sqlite-wasm.test.ts` with tests for: DDL + query, `get()` single row, transaction commit, transaction rollback, migration version read/write. All tests use in-memory mode (`useOPFS: false`). Must run in Vitest Browser Mode (ref: Design § Driver Unit Tests)
+
+- [ ] 8. **Port integration test utilities** — Create `src/tests/testUtils.ts` and `src/tests/messagesTestUtils.ts` adapted from `cojson-storage-indexeddb/src/tests/`, using `getSqliteWasmStorage("test.db", false)` instead of `getIndexedDBStorage()` (ref: Design § Integration Tests)
+
+- [ ] 9. **Write storage integration tests** — Create integration tests mirroring `storage.indexeddb.test.ts`: store & load CoValue, dependency loading (group inheritance), transaction correction recovery, multi-session content, large data streaming, account persistence, sync state tracking, sync resumption (ref: Design § Integration Tests)
+
+- [ ] 10. **Run lint, build, and test pipeline** — Execute `pnpm format-and-lint:fix`, `pnpm build:packages`, and `pnpm test --watch=false` to verify everything compiles and passes

--- a/packages/cojson-storage-sqlite-wasm/package.json
+++ b/packages/cojson-storage-sqlite-wasm/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "cojson-storage-sqlite-wasm",
+  "version": "0.0.1",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "license": "MIT",
+  "dependencies": {
+    "@sqlite.org/sqlite-wasm": "^3.51.2-build6",
+    "cojson": "workspace:*"
+  },
+  "devDependencies": {
+    "@vitest/browser-playwright": "catalog:default",
+    "typescript": "catalog:default"
+  },
+  "scripts": {
+    "dev": "tsc --watch --sourceMap --outDir dist",
+    "test": "vitest --run --root ../../ --project cojson-storage-sqlite-wasm",
+    "test:watch": "vitest --watch --root ../../ --project cojson-storage-sqlite-wasm",
+    "format-and-lint": "biome check .",
+    "format-and-lint:fix": "biome check . --write",
+    "build": "rm -rf ./dist && tsc --sourceMap --outDir dist"
+  }
+}

--- a/packages/cojson-storage-sqlite-wasm/src/SqliteWasmDriver.ts
+++ b/packages/cojson-storage-sqlite-wasm/src/SqliteWasmDriver.ts
@@ -1,0 +1,158 @@
+import type { SQLiteDatabaseDriverAsync } from "cojson";
+import sqlite3InitModule, {
+  type Database,
+  type SqlValue,
+} from "@sqlite.org/sqlite-wasm";
+
+/**
+ * SQLite Wasm storage driver for Jazz.
+ *
+ * Implements `SQLiteDatabaseDriverAsync` using the OO1 API from
+ * `@sqlite.org/sqlite-wasm`. The module is initialized via the default
+ * export `sqlite3InitModule`, then a `Database` (in-memory) or
+ * `OpfsSAHPoolDatabase` (OPFS-backed) is created.
+ *
+ * When `useOPFS` is `true` (default), the driver attempts to install
+ * the OPFS SAH pool VFS and open a persistent database. If OPFS is
+ * unavailable (e.g. missing COOP/COEP headers), it falls back to an
+ * in-memory database.
+ *
+ * All `Database.exec()` calls are synchronous — the async interface
+ * required by `SQLiteDatabaseDriverAsync` simply wraps them in promises.
+ *
+ * @example
+ * ```typescript
+ * const driver = new SqliteWasmDriver("my-app.sqlite3");
+ * await driver.initialize();
+ * ```
+ */
+export class SqliteWasmDriver implements SQLiteDatabaseDriverAsync {
+  private db!: Database;
+  private initialized = false;
+  private readonly filename: string;
+  private readonly useOPFS: boolean;
+
+  /**
+   * @param filename - Database file name for OPFS storage (default: `"jazz-cojson.sqlite3"`)
+   * @param useOPFS - Whether to attempt OPFS persistence (default: `true`)
+   */
+  constructor(filename = "jazz-cojson.sqlite3", useOPFS = true) {
+    this.filename = filename;
+    this.useOPFS = useOPFS;
+  }
+
+  /**
+   * Initialize the SQLite Wasm module and open the database.
+   * Must be called before any other method. Subsequent calls are no-ops.
+   */
+  async initialize(): Promise<void> {
+    if (this.initialized) return;
+
+    const sqlite3 = await sqlite3InitModule();
+
+    if (this.useOPFS) {
+      try {
+        const poolUtil = await sqlite3.installOpfsSAHPoolVfs({});
+        this.db = new poolUtil.OpfsSAHPoolDb(this.filename);
+        this.initialized = true;
+        return;
+      } catch {
+        console.warn(
+          "OPFS SAH pool not available, falling back to in-memory storage",
+        );
+      }
+    }
+
+    this.db = new sqlite3.oo1.DB(":memory:");
+    this.initialized = true;
+  }
+
+  /**
+   * Execute a SQL statement that does not return rows.
+   *
+   * @param sql - The SQL statement to execute
+   * @param params - Bind parameters
+   */
+  async run(sql: string, params: unknown[]): Promise<void> {
+    this.db.exec(sql, {
+      bind: params as SqlValue[],
+    });
+  }
+
+  /**
+   * Execute a SQL query and return all matching rows.
+   *
+   * @param sql - The SQL query to execute
+   * @param params - Bind parameters
+   * @returns Array of row objects
+   */
+  async query<T>(sql: string, params: unknown[]): Promise<T[]> {
+    return this.db.exec(sql, {
+      bind: params as SqlValue[],
+      returnValue: "resultRows",
+      rowMode: "object",
+    }) as T[];
+  }
+
+  /**
+   * Execute a SQL query and return the first matching row, or `undefined`.
+   *
+   * @param sql - The SQL query to execute
+   * @param params - Bind parameters
+   * @returns The first row, or `undefined` if no rows match
+   */
+  async get<T>(sql: string, params: unknown[]): Promise<T | undefined> {
+    const rows = await this.query<T>(sql, params);
+    return rows[0];
+  }
+
+  /**
+   * Execute a callback inside a database transaction.
+   * Automatically commits on success or rolls back on error.
+   *
+   * @param callback - Function to execute within the transaction
+   */
+  async transaction(
+    callback: (tx: SQLiteDatabaseDriverAsync) => unknown,
+  ): Promise<unknown> {
+    this.db.exec("BEGIN TRANSACTION");
+    try {
+      const result = await callback(this);
+      this.db.exec("COMMIT");
+      return result;
+    } catch (error) {
+      this.db.exec("ROLLBACK");
+      throw error;
+    }
+  }
+
+  /**
+   * Close the database connection.
+   */
+  async closeDb(): Promise<void> {
+    this.db.close();
+  }
+
+  /**
+   * Read the current schema migration version from `PRAGMA user_version`.
+   *
+   * @returns The current migration version number
+   */
+  async getMigrationVersion(): Promise<number> {
+    const rows = this.db.exec("PRAGMA user_version", {
+      returnValue: "resultRows",
+      rowMode: "object",
+    }) as Array<Record<string, SqlValue>>;
+    const row = rows[0];
+    return typeof row?.["user_version"] === "number" ? row["user_version"] : 0;
+  }
+
+  /**
+   * Persist the schema migration version via `PRAGMA user_version`.
+   *
+   * @param version - The migration version to set
+   */
+  async saveMigrationVersion(version: number): Promise<void> {
+    this.db.exec(`PRAGMA user_version = ${version}`);
+  }
+}

--- a/packages/cojson-storage-sqlite-wasm/src/SqliteWasmWorkerStorage.ts
+++ b/packages/cojson-storage-sqlite-wasm/src/SqliteWasmWorkerStorage.ts
@@ -1,0 +1,388 @@
+/**
+ * Main-thread `StorageAPI` proxy backed by a Web Worker.
+ *
+ * The worker runs the full SQLite WASM storage stack (driver + client +
+ * `StorageApiAsync`). This proxy only communicates at the `StorageAPI` level,
+ * dramatically reducing the number of postMessage round-trips compared to
+ * proxying individual SQL queries.
+ *
+ * Synchronous methods (`getKnownState`, `waitForSync`) are served from a
+ * local known-state mirror that the worker keeps up-to-date via
+ * `knownStateUpdate` messages.
+ */
+
+import type {
+  CoValueCore,
+  CojsonInternalTypes,
+  RawCoID,
+  StorageAPI,
+  CorrectionCallback,
+} from "cojson";
+import { emptyKnownState } from "cojson";
+
+type CoValueKnownState = CojsonInternalTypes.CoValueKnownState;
+type NewContentMessage = CojsonInternalTypes.NewContentMessage;
+import type {
+  WorkerToMainMessage,
+  MainToWorkerMessage,
+} from "./storage-worker.js";
+
+// ---------- known-state mirror -----------------------------------------------
+
+/**
+ * Lightweight mirror of the worker's `StorageKnownState`.
+ * Keeps track of what the worker has stored so that `getKnownState` and
+ * `waitForSync` can be answered synchronously on the main thread.
+ */
+class KnownStateMirror {
+  private states = new Map<string, CoValueKnownState>();
+  private waitRequests = new Map<
+    string,
+    Set<{ knownState: CoValueKnownState; resolve: () => void }>
+  >();
+
+  get(id: string): CoValueKnownState {
+    const existing = this.states.get(id);
+    if (existing) return existing;
+    const empty = emptyKnownState(id as RawCoID);
+    this.states.set(id, empty);
+    return empty;
+  }
+
+  getCached(id: string): CoValueKnownState | undefined {
+    const ks = this.states.get(id);
+    return ks?.header ? ks : undefined;
+  }
+
+  set(id: string, knownState: CoValueKnownState) {
+    this.states.set(id, knownState);
+    this.notifyWaiters(id, knownState);
+  }
+
+  delete(id: string) {
+    this.states.delete(id);
+  }
+
+  waitForSync(id: string, coValue: CoValueCore): Promise<void> {
+    const initialKnownState = coValue.knownState();
+    if (isInSync(initialKnownState, this.get(id))) {
+      return Promise.resolve();
+    }
+
+    const waiters = this.waitRequests.get(id) ?? new Set();
+    this.waitRequests.set(id, waiters);
+
+    return new Promise<void>((resolve) => {
+      const unsubscribe = coValue.subscribe((cv) => {
+        req.knownState = cv.knownState();
+        this.notifyWaiters(id, this.get(id));
+      }, false);
+
+      const handleResolve = () => {
+        resolve();
+        unsubscribe();
+      };
+
+      const req = { knownState: initialKnownState, resolve: handleResolve };
+      waiters.add(req);
+    });
+  }
+
+  private notifyWaiters(id: string, storageKnown: CoValueKnownState) {
+    const waiters = this.waitRequests.get(id);
+    if (!waiters) return;
+
+    for (const req of waiters) {
+      if (isInSync(req.knownState, storageKnown)) {
+        req.resolve();
+        waiters.delete(req);
+      }
+    }
+  }
+}
+
+function isInSync(
+  coValueKnown: CoValueKnownState,
+  storageKnown: CoValueKnownState,
+): boolean {
+  if (!storageKnown.header && coValueKnown.header) return false;
+
+  const storageSessions = storageKnown.sessions as Record<string, number>;
+  for (const [sessionId, count] of Object.entries(coValueKnown.sessions)) {
+    if ((storageSessions[sessionId] ?? 0) !== count) return false;
+  }
+  return true;
+}
+
+// ---------- proxy class ------------------------------------------------------
+
+export class SqliteWasmWorkerStorage implements StorageAPI {
+  private worker!: Worker;
+  private nextId = 0;
+  private readonly knownStates = new KnownStateMirror();
+
+  /** Pending load callbacks keyed by request id. */
+  private readonly loadCallbacks = new Map<
+    number,
+    {
+      onContent: (data: NewContentMessage) => void;
+      onDone?: (found: boolean) => void;
+    }
+  >();
+
+  /** Correction callbacks keyed by store request id. */
+  private readonly correctionCallbacks = new Map<number, CorrectionCallback>();
+
+  /** Generic promise-based pending requests. */
+  private readonly pending = new Map<
+    number,
+    { resolve: (value: unknown) => void; reject: (error: Error) => void }
+  >();
+
+  private readonly filename: string;
+
+  constructor(filename = "jazz-cojson.sqlite3") {
+    this.filename = filename;
+  }
+
+  // -- lifecycle --------------------------------------------------------------
+
+  /**
+   * Spawn the Web Worker and initialise the full storage stack inside it.
+   * Must be called before any other method.
+   */
+  async initialize(): Promise<void> {
+    this.worker = new Worker(new URL("./storage-worker.js", import.meta.url), {
+      type: "module",
+    });
+    this.worker.onmessage = this.handleMessage;
+    this.worker.onerror = (e) => console.error("Storage worker error:", e);
+
+    const id = this.nextId++;
+    await new Promise<void>((resolve, reject) => {
+      this.pending.set(id, {
+        resolve: () => resolve(),
+        reject,
+      });
+      this.post({ type: "initialize", id, filename: this.filename });
+    });
+  }
+
+  close(): Promise<unknown> {
+    const id = this.nextId++;
+    return new Promise((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+      this.post({ type: "close", id });
+    }).finally(() => this.worker.terminate());
+  }
+
+  // -- StorageAPI (synchronous, served locally) -------------------------------
+
+  getKnownState(id: string): CoValueKnownState {
+    return this.knownStates.get(id);
+  }
+
+  waitForSync(id: string, coValue: CoValueCore): Promise<void> {
+    return this.knownStates.waitForSync(id, coValue);
+  }
+
+  // -- StorageAPI (fire-and-forget) -------------------------------------------
+
+  load(
+    id: string,
+    callback: (data: NewContentMessage) => void,
+    done?: (found: boolean) => void,
+  ): void {
+    const reqId = this.nextId++;
+    this.loadCallbacks.set(reqId, { onContent: callback, onDone: done });
+    this.post({ type: "load", id: reqId, coValueId: id });
+  }
+
+  store(data: NewContentMessage, handleCorrection: CorrectionCallback): void {
+    const reqId = this.nextId++;
+    this.correctionCallbacks.set(reqId, handleCorrection);
+    this.post({ type: "store", id: reqId, msg: data });
+  }
+
+  markDeleteAsValid(id: RawCoID): void {
+    this.post({ type: "markDeleteAsValid", coValueId: id });
+  }
+
+  enableDeletedCoValuesErasure(): void {
+    this.post({ type: "enableDeletedCoValuesErasure" });
+  }
+
+  async eraseAllDeletedCoValues(): Promise<void> {
+    const id = this.nextId++;
+    await new Promise<void>((resolve, reject) => {
+      this.pending.set(id, { resolve: () => resolve(), reject });
+      this.post({ type: "eraseAllDeletedCoValues", id });
+    });
+  }
+
+  loadKnownState(
+    id: string,
+    callback: (knownState: CoValueKnownState | undefined) => void,
+  ): void {
+    // Fast path: check local cache first
+    const cached = this.knownStates.getCached(id);
+    if (cached) {
+      callback(cached);
+      return;
+    }
+
+    const reqId = this.nextId++;
+    this.pending.set(reqId, {
+      resolve: (ks) => callback(ks as CoValueKnownState | undefined),
+      reject: () => callback(undefined),
+    });
+    this.post({ type: "loadKnownState", id: reqId, coValueId: id });
+  }
+
+  trackCoValuesSyncState(
+    updates: { id: RawCoID; peerId: string; synced: boolean }[],
+    done?: () => void,
+  ): void {
+    const reqId = this.nextId++;
+    if (done) {
+      this.pending.set(reqId, { resolve: () => done(), reject: () => done() });
+    }
+    this.post({ type: "trackCoValuesSyncState", id: reqId, updates });
+  }
+
+  getUnsyncedCoValueIDs(callback: (ids: RawCoID[]) => void): void {
+    const reqId = this.nextId++;
+    this.pending.set(reqId, {
+      resolve: (ids) => callback(ids as RawCoID[]),
+      reject: () => callback([]),
+    });
+    this.post({ type: "getUnsyncedCoValueIDs", id: reqId });
+  }
+
+  stopTrackingSyncState(id: RawCoID): void {
+    this.post({ type: "stopTrackingSyncState", coValueId: id });
+  }
+
+  onCoValueUnmounted(id: RawCoID): void {
+    this.knownStates.delete(id);
+    this.post({ type: "onCoValueUnmounted", coValueId: id });
+  }
+
+  // -- internal ---------------------------------------------------------------
+
+  private post(msg: MainToWorkerMessage) {
+    this.worker.postMessage(msg);
+  }
+
+  private handleMessage = (event: MessageEvent<WorkerToMainMessage>) => {
+    const msg = event.data;
+
+    switch (msg.type) {
+      // -- lifecycle responses ------------------------------------------------
+
+      case "initialized": {
+        const p = this.pending.get(msg.id);
+        this.pending.delete(msg.id);
+        if (msg.success) {
+          p?.resolve(undefined);
+        } else {
+          p?.reject(new Error(msg.error ?? "Worker initialisation failed"));
+        }
+        break;
+      }
+
+      case "closeComplete": {
+        const p = this.pending.get(msg.id);
+        this.pending.delete(msg.id);
+        p?.resolve(undefined);
+        break;
+      }
+
+      // -- load responses -----------------------------------------------------
+
+      case "loadContent": {
+        this.loadCallbacks.get(msg.id)?.onContent(msg.data);
+        break;
+      }
+
+      case "loadDone": {
+        const cbs = this.loadCallbacks.get(msg.id);
+        this.loadCallbacks.delete(msg.id);
+        cbs?.onDone?.(msg.found);
+        break;
+      }
+
+      // -- store responses ----------------------------------------------------
+
+      case "correctionNeeded": {
+        const cb = this.correctionCallbacks.get(msg.id);
+        this.correctionCallbacks.delete(msg.id);
+        if (cb) {
+          const correctionMsgs = cb(msg.knownState);
+          if (correctionMsgs) {
+            for (const correctionMsg of correctionMsgs) {
+              // Send corrections as new stores (no further correction callback)
+              this.store(correctionMsg, () => []);
+            }
+          }
+        }
+        break;
+      }
+
+      // -- known-state updates ------------------------------------------------
+
+      case "knownStateUpdate": {
+        this.knownStates.set(msg.coValueId, msg.knownState);
+        break;
+      }
+
+      case "loadKnownStateResult": {
+        const p = this.pending.get(msg.id);
+        this.pending.delete(msg.id);
+        if (msg.knownState) {
+          this.knownStates.set(msg.knownState.id, msg.knownState);
+        }
+        p?.resolve(msg.knownState);
+        break;
+      }
+
+      // -- sync tracking responses --------------------------------------------
+
+      case "trackCoValuesSyncStateDone": {
+        const p = this.pending.get(msg.id);
+        this.pending.delete(msg.id);
+        p?.resolve(undefined);
+        break;
+      }
+
+      case "getUnsyncedCoValueIDsResult": {
+        const p = this.pending.get(msg.id);
+        this.pending.delete(msg.id);
+        p?.resolve(msg.ids);
+        break;
+      }
+
+      // -- deletion responses -------------------------------------------------
+
+      case "eraseComplete": {
+        const p = this.pending.get(msg.id);
+        this.pending.delete(msg.id);
+        p?.resolve(undefined);
+        break;
+      }
+
+      // -- errors -------------------------------------------------------------
+
+      case "error": {
+        const p = this.pending.get(msg.id);
+        this.pending.delete(msg.id);
+        p?.reject(new Error(msg.message));
+
+        // Also clean up load / correction maps
+        this.loadCallbacks.delete(msg.id);
+        this.correctionCallbacks.delete(msg.id);
+        break;
+      }
+    }
+  };
+}

--- a/packages/cojson-storage-sqlite-wasm/src/index.ts
+++ b/packages/cojson-storage-sqlite-wasm/src/index.ts
@@ -1,0 +1,66 @@
+import type { StorageAPI } from "cojson";
+import { getSqliteStorageAsync } from "cojson";
+import { SqliteWasmDriver } from "./SqliteWasmDriver.js";
+import { SqliteWasmWorkerStorage } from "./SqliteWasmWorkerStorage.js";
+
+export { SqliteWasmDriver, SqliteWasmWorkerStorage };
+
+/**
+ * Create a SQLite Wasm storage adapter for Jazz.
+ *
+ * When `useOPFS` is `true` (default), a **Web Worker** is spawned that runs
+ * the entire storage stack (`SqliteWasmDriver` → `SQLiteClientAsync` →
+ * `StorageApiAsync`). The main thread receives a thin `StorageAPI` proxy.
+ * Because communication happens at the `StorageAPI` level (not individual
+ * SQL queries), postMessage overhead is minimal.
+ *
+ * OPFS persistence requires APIs (`createSyncAccessHandle`,
+ * `Atomics.wait`) that are only available inside dedicated Web Workers,
+ * which is why the worker is required.
+ *
+ * When `useOPFS` is `false`, the database runs in-memory on the main
+ * thread (useful for tests).
+ *
+ * If OPFS initialisation fails inside the worker (e.g. missing
+ * COOP/COEP headers, unsupported browser), the worker falls back to
+ * an in-memory database automatically.
+ *
+ * **Requirements for OPFS persistence:**
+ * - Server must set `Cross-Origin-Opener-Policy: same-origin` and
+ *   `Cross-Origin-Embedder-Policy: require-corp` headers
+ * - `@sqlite.org/sqlite-wasm` must be excluded from bundler
+ *   optimisation (e.g. `optimizeDeps.exclude` in Vite)
+ *
+ * @param filenameOrDriver - Database file name for OPFS (default: `"jazz-cojson.sqlite3"`),
+ *   or a pre-created `SqliteWasmDriver` to reuse an existing in-memory connection.
+ * @param useOPFS - Whether to attempt OPFS persistence via a Web Worker (default: `true`).
+ *   Ignored when a driver instance is passed.
+ * @returns A fully initialised `StorageAPI` instance
+ *
+ * @example
+ * ```typescript
+ * import { getSqliteWasmStorage } from "cojson-storage-sqlite-wasm";
+ *
+ * const storage = await getSqliteWasmStorage();
+ * node.setStorage(storage);
+ * ```
+ */
+export async function getSqliteWasmStorage(
+  filenameOrDriver: string | SqliteWasmDriver = "jazz-cojson.sqlite3",
+  useOPFS = true,
+): Promise<StorageAPI> {
+  // Pre-created driver → always main-thread in-memory
+  if (filenameOrDriver instanceof SqliteWasmDriver) {
+    return await getSqliteStorageAsync(filenameOrDriver);
+  }
+
+  if (useOPFS) {
+    const workerStorage = new SqliteWasmWorkerStorage(filenameOrDriver);
+    await workerStorage.initialize();
+    return workerStorage;
+  }
+
+  // In-memory on main thread (tests, fallback)
+  const driver = new SqliteWasmDriver(filenameOrDriver, false);
+  return await getSqliteStorageAsync(driver);
+}

--- a/packages/cojson-storage-sqlite-wasm/src/sqlite-worker.ts
+++ b/packages/cojson-storage-sqlite-wasm/src/sqlite-worker.ts
@@ -1,0 +1,121 @@
+import sqlite3InitModule, {
+  type Database,
+  type SqlValue,
+} from "@sqlite.org/sqlite-wasm";
+
+export interface WorkerRequest {
+  id: number;
+  type: string;
+  sql?: string;
+  params?: unknown[];
+  filename?: string;
+  version?: number;
+}
+
+export interface WorkerResponse {
+  id: number;
+  success: boolean;
+  result?: unknown;
+  error?: string;
+}
+
+// Type-safe reference to the worker global scope
+const workerScope: {
+  onmessage: ((event: MessageEvent) => void) | null;
+  postMessage(message: WorkerResponse): void;
+} = self as never;
+
+let db: Database;
+
+async function handleInitialize(
+  filename: string,
+): Promise<{ opfsAvailable: boolean }> {
+  const sqlite3 = await sqlite3InitModule();
+
+  try {
+    const poolUtil = await sqlite3.installOpfsSAHPoolVfs({});
+    db = new poolUtil.OpfsSAHPoolDb(filename);
+    return { opfsAvailable: true };
+  } catch {
+    console.warn(
+      "OPFS SAH pool not available in worker, falling back to in-memory storage",
+    );
+  }
+
+  db = new sqlite3.oo1.DB(":memory:");
+  return { opfsAvailable: false };
+}
+
+function handleRun(sql: string, params: unknown[]): void {
+  db.exec(sql, { bind: params as SqlValue[] });
+}
+
+function handleQuery(sql: string, params: unknown[]): unknown[] {
+  return db.exec(sql, {
+    bind: params as SqlValue[],
+    returnValue: "resultRows",
+    rowMode: "object",
+  }) as unknown[];
+}
+
+function handleGetMigrationVersion(): number {
+  const rows = db.exec("PRAGMA user_version", {
+    returnValue: "resultRows",
+    rowMode: "object",
+  }) as Array<Record<string, SqlValue>>;
+  const row = rows[0];
+  return typeof row?.["user_version"] === "number" ? row["user_version"] : 0;
+}
+
+workerScope.onmessage = async (event: MessageEvent<WorkerRequest>) => {
+  const { id, type } = event.data;
+
+  try {
+    let result: unknown;
+
+    switch (type) {
+      case "initialize":
+        result = await handleInitialize(event.data.filename!);
+        break;
+      case "run":
+        handleRun(event.data.sql!, event.data.params!);
+        break;
+      case "query":
+        result = handleQuery(event.data.sql!, event.data.params!);
+        break;
+      case "get": {
+        const rows = handleQuery(event.data.sql!, event.data.params!);
+        result = rows[0];
+        break;
+      }
+      case "beginTransaction":
+        db.exec("BEGIN TRANSACTION");
+        break;
+      case "commitTransaction":
+        db.exec("COMMIT");
+        break;
+      case "rollbackTransaction":
+        db.exec("ROLLBACK");
+        break;
+      case "closeDb":
+        db.close();
+        break;
+      case "getMigrationVersion":
+        result = handleGetMigrationVersion();
+        break;
+      case "saveMigrationVersion":
+        db.exec(`PRAGMA user_version = ${event.data.version}`);
+        break;
+      default:
+        throw new Error(`Unknown message type: ${type}`);
+    }
+
+    workerScope.postMessage({ id, success: true, result });
+  } catch (error) {
+    workerScope.postMessage({
+      id,
+      success: false,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+};

--- a/packages/cojson-storage-sqlite-wasm/src/storage-worker.ts
+++ b/packages/cojson-storage-sqlite-wasm/src/storage-worker.ts
@@ -1,0 +1,258 @@
+/**
+ * Web Worker that runs the complete SQLite WASM storage stack.
+ *
+ * Initialises `SqliteWasmDriver` → `getSqliteStorageAsync` → `StorageApiAsync`.
+ * All storage logic (load, store, migrations, queues, erasure) runs inside
+ * this worker so the main thread only communicates at the `StorageAPI` level.
+ *
+ * The OPFS SyncAccessHandle Pool VFS requires a dedicated Web Worker context;
+ * this is why the entire storage layer lives here.
+ */
+
+import {
+  getSqliteStorageAsync,
+  type StorageApiAsync,
+  type CojsonInternalTypes,
+  type RawCoID,
+} from "cojson";
+
+type CoValueKnownState = CojsonInternalTypes.CoValueKnownState;
+type NewContentMessage = CojsonInternalTypes.NewContentMessage;
+import { SqliteWasmDriver } from "./SqliteWasmDriver.js";
+
+// ---------- message types (shared vocabulary with the main-thread proxy) ------
+
+export type MainToWorkerMessage =
+  | { type: "initialize"; id: number; filename: string }
+  | { type: "load"; id: number; coValueId: string }
+  | { type: "store"; id: number; msg: NewContentMessage }
+  | { type: "markDeleteAsValid"; coValueId: string }
+  | { type: "enableDeletedCoValuesErasure" }
+  | { type: "eraseAllDeletedCoValues"; id: number }
+  | { type: "loadKnownState"; id: number; coValueId: string }
+  | {
+      type: "trackCoValuesSyncState";
+      id: number;
+      updates: { id: RawCoID; peerId: string; synced: boolean }[];
+    }
+  | { type: "getUnsyncedCoValueIDs"; id: number }
+  | { type: "stopTrackingSyncState"; coValueId: string }
+  | { type: "onCoValueUnmounted"; coValueId: string }
+  | { type: "close"; id: number };
+
+export type WorkerToMainMessage =
+  | { type: "initialized"; id: number; success: boolean; error?: string }
+  | { type: "loadContent"; id: number; data: NewContentMessage }
+  | { type: "loadDone"; id: number; found: boolean }
+  | { type: "storeComplete"; id: number }
+  | {
+      type: "correctionNeeded";
+      id: number;
+      knownState: CoValueKnownState;
+    }
+  | {
+      type: "knownStateUpdate";
+      coValueId: string;
+      knownState: CoValueKnownState;
+    }
+  | {
+      type: "loadKnownStateResult";
+      id: number;
+      knownState: CoValueKnownState | undefined;
+    }
+  | { type: "trackCoValuesSyncStateDone"; id: number }
+  | { type: "getUnsyncedCoValueIDsResult"; id: number; ids: RawCoID[] }
+  | { type: "eraseComplete"; id: number }
+  | { type: "closeComplete"; id: number }
+  | { type: "error"; id: number; message: string };
+
+// ---------- worker-safe `self` reference -------------------------------------
+
+const workerScope: {
+  onmessage: ((event: MessageEvent) => void) | null;
+  postMessage(message: WorkerToMainMessage): void;
+} = self as never;
+
+// ---------- state ------------------------------------------------------------
+
+let storage: StorageApiAsync;
+
+// ---------- helpers ----------------------------------------------------------
+
+function post(msg: WorkerToMainMessage) {
+  workerScope.postMessage(msg);
+}
+
+/**
+ * Patch `StorageApiAsync.knownStates` so that every update is relayed to the
+ * main thread, keeping its mirror in sync.
+ */
+function patchKnownStateNotifications(storageApi: StorageApiAsync) {
+  const ks = storageApi.knownStates;
+
+  const origHandleUpdate = ks.handleUpdate.bind(ks);
+  ks.handleUpdate = (id: string, knownState: CoValueKnownState) => {
+    origHandleUpdate(id, knownState);
+    post({
+      type: "knownStateUpdate",
+      coValueId: id,
+      knownState: {
+        id: knownState.id,
+        header: knownState.header,
+        sessions: { ...knownState.sessions },
+      },
+    });
+  };
+
+  const origSetKnownState = ks.setKnownState.bind(ks);
+  ks.setKnownState = (id: string, knownState: CoValueKnownState) => {
+    origSetKnownState(id, knownState);
+    post({
+      type: "knownStateUpdate",
+      coValueId: id,
+      knownState: {
+        id: knownState.id,
+        header: knownState.header,
+        sessions: { ...knownState.sessions },
+      },
+    });
+  };
+}
+
+// ---------- message handler --------------------------------------------------
+
+workerScope.onmessage = async (event: MessageEvent<MainToWorkerMessage>) => {
+  const msg = event.data;
+
+  try {
+    switch (msg.type) {
+      // -- lifecycle ----------------------------------------------------------
+
+      case "initialize": {
+        const driver = new SqliteWasmDriver(msg.filename, true);
+        const storageApi = (await getSqliteStorageAsync(
+          driver,
+        )) as StorageApiAsync;
+        patchKnownStateNotifications(storageApi);
+        storage = storageApi;
+        post({ type: "initialized", id: msg.id, success: true });
+        break;
+      }
+
+      case "close": {
+        await storage.close();
+        post({ type: "closeComplete", id: msg.id });
+        break;
+      }
+
+      // -- load / store -------------------------------------------------------
+
+      case "load": {
+        storage.load(
+          msg.coValueId,
+          (data) => post({ type: "loadContent", id: msg.id, data }),
+          (found) => post({ type: "loadDone", id: msg.id, found }),
+        );
+        break;
+      }
+
+      case "store": {
+        storage.store(msg.msg, (knownState) => {
+          // We cannot call back to the main thread synchronously, so we
+          // notify it and return an empty correction.  The main thread
+          // will compute the real correction and re-send as new stores.
+          post({
+            type: "correctionNeeded",
+            id: msg.id,
+            knownState: {
+              id: knownState.id,
+              header: knownState.header,
+              sessions: { ...knownState.sessions },
+            },
+          });
+          return [];
+        });
+        break;
+      }
+
+      // -- known-state --------------------------------------------------------
+
+      case "loadKnownState": {
+        storage.loadKnownState(msg.coValueId, (knownState) => {
+          post({
+            type: "loadKnownStateResult",
+            id: msg.id,
+            knownState: knownState
+              ? {
+                  id: knownState.id,
+                  header: knownState.header,
+                  sessions: { ...knownState.sessions },
+                }
+              : undefined,
+          });
+        });
+        break;
+      }
+
+      // -- deletion -----------------------------------------------------------
+
+      case "markDeleteAsValid": {
+        storage.markDeleteAsValid(msg.coValueId as RawCoID);
+        break;
+      }
+
+      case "enableDeletedCoValuesErasure": {
+        storage.enableDeletedCoValuesErasure();
+        break;
+      }
+
+      case "eraseAllDeletedCoValues": {
+        await storage.eraseAllDeletedCoValues();
+        post({ type: "eraseComplete", id: msg.id });
+        break;
+      }
+
+      // -- sync tracking ------------------------------------------------------
+
+      case "trackCoValuesSyncState": {
+        storage.trackCoValuesSyncState(msg.updates, () => {
+          post({ type: "trackCoValuesSyncStateDone", id: msg.id });
+        });
+        break;
+      }
+
+      case "getUnsyncedCoValueIDs": {
+        storage.getUnsyncedCoValueIDs((ids) => {
+          post({ type: "getUnsyncedCoValueIDsResult", id: msg.id, ids });
+        });
+        break;
+      }
+
+      case "stopTrackingSyncState": {
+        storage.stopTrackingSyncState(msg.coValueId as RawCoID);
+        break;
+      }
+
+      // -- misc ---------------------------------------------------------------
+
+      case "onCoValueUnmounted": {
+        storage.onCoValueUnmounted(msg.coValueId as RawCoID);
+        break;
+      }
+
+      default: {
+        const _exhaustive: never = msg;
+        throw new Error(
+          `Unknown message type: ${(_exhaustive as { type: string }).type}`,
+        );
+      }
+    }
+  } catch (error) {
+    const id = "id" in msg ? (msg as { id: number }).id : -1;
+    post({
+      type: "error",
+      id,
+      message: error instanceof Error ? error.message : String(error),
+    });
+  }
+};

--- a/packages/cojson-storage-sqlite-wasm/src/tests/messagesTestUtils.ts
+++ b/packages/cojson-storage-sqlite-wasm/src/tests/messagesTestUtils.ts
@@ -1,0 +1,72 @@
+import type { CoValueCore, CojsonInternalTypes, SyncMessage } from "cojson";
+
+function simplifySessions(msg: CojsonInternalTypes.CoValueKnownState) {
+  const count = Object.values(msg.sessions).reduce(
+    (acc: number, session: number) => acc + session,
+    0,
+  );
+
+  if (msg.header) {
+    return `header/${count}`;
+  }
+
+  return "empty";
+}
+
+function simplifyNewContent(
+  content: CojsonInternalTypes.NewContentMessage["new"],
+) {
+  if (!content) {
+    return undefined;
+  }
+
+  return Object.values(content)
+    .map((c) => `After: ${c.after} New: ${c.newTransactions.length}`)
+    .join(" | ");
+}
+
+export function toSimplifiedMessages(
+  coValues: Record<string, CoValueCore>,
+  messages: {
+    from: "client" | "server" | "storage";
+    msg: SyncMessage;
+  }[],
+) {
+  function getCoValue(id: string) {
+    for (const [name, coValue] of Object.entries(coValues)) {
+      if (coValue.id === id) {
+        return name;
+      }
+    }
+
+    return `unknown/${id}`;
+  }
+
+  function toDebugString(
+    from: "client" | "server" | "storage",
+    msg: SyncMessage,
+  ) {
+    switch (msg.action) {
+      case "known":
+        return `${from} -> KNOWN ${msg.isCorrection ? "CORRECTION " : ""}${getCoValue(msg.id)} sessions: ${simplifySessions(msg)}`;
+      case "load":
+        return `${from} -> LOAD ${getCoValue(msg.id)} sessions: ${simplifySessions(msg)}`;
+      case "done":
+        return `${from} -> DONE ${getCoValue(msg.id)}`;
+      case "content":
+        return `${from} -> CONTENT ${getCoValue(msg.id)} header: ${Boolean(msg.header)} new: ${simplifyNewContent(msg.new)}`;
+    }
+  }
+
+  return messages.map((m) => toDebugString(m.from, m.msg));
+}
+
+export function debugMessages(
+  coValues: Record<string, CoValueCore>,
+  messages: {
+    from: "client" | "server" | "storage";
+    msg: SyncMessage;
+  }[],
+) {
+  console.log(toSimplifiedMessages(coValues, messages));
+}

--- a/packages/cojson-storage-sqlite-wasm/src/tests/storage.sqlite-wasm.test.ts
+++ b/packages/cojson-storage-sqlite-wasm/src/tests/storage.sqlite-wasm.test.ts
@@ -1,0 +1,854 @@
+import { LocalNode, StorageApiAsync, cojsonInternals } from "cojson";
+import { WasmCrypto } from "cojson/crypto/WasmCrypto";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { getSqliteWasmStorage } from "../index.js";
+import { SqliteWasmDriver } from "../SqliteWasmDriver.js";
+import { toSimplifiedMessages } from "./messagesTestUtils.js";
+import {
+  connectToSyncServer,
+  createTestNode,
+  getAllCoValuesWaitingForDelete,
+  getCoValueStoredSessions,
+  trackMessages,
+  waitFor,
+} from "./testUtils.js";
+
+const Crypto = await WasmCrypto.create();
+
+// Helper: create a shared in-memory driver instance.
+// Each call to `getSqliteWasmStorage(driver)` creates a new `StorageApiAsync`
+// wrapper over the same underlying DB — mirroring how IndexedDB tests work
+// (each `getIndexedDBStorage()` creates a fresh wrapper over the same IDB).
+async function createSharedDriver() {
+  const driver = new SqliteWasmDriver("test.db", false);
+  await driver.initialize();
+  return driver;
+}
+
+async function createInMemoryStorage(driver?: SqliteWasmDriver) {
+  if (driver) {
+    return getSqliteWasmStorage(driver);
+  }
+  return getSqliteWasmStorage("test.db", false);
+}
+
+// ─── Driver Unit Tests ──────────────────────────────────────────────────────
+
+describe("SqliteWasmDriver", () => {
+  let driver: SqliteWasmDriver;
+
+  beforeEach(async () => {
+    driver = new SqliteWasmDriver("test.db", false);
+    await driver.initialize();
+  });
+
+  afterEach(async () => {
+    await driver.closeDb();
+  });
+
+  test("should execute DDL and query", async () => {
+    await driver.run(
+      "CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)",
+      [],
+    );
+    await driver.run("INSERT INTO test (name) VALUES (?)", ["Alice"]);
+
+    const rows = await driver.query<{ id: number; name: string }>(
+      "SELECT * FROM test",
+      [],
+    );
+    expect(rows).toEqual([{ id: 1, name: "Alice" }]);
+  });
+
+  test("should return single row with get()", async () => {
+    await driver.run("CREATE TABLE kv (k TEXT PRIMARY KEY, v TEXT)", []);
+    await driver.run("INSERT INTO kv VALUES (?, ?)", ["key1", "val1"]);
+
+    const row = await driver.get<{ k: string; v: string }>(
+      "SELECT * FROM kv WHERE k = ?",
+      ["key1"],
+    );
+    expect(row).toEqual({ k: "key1", v: "val1" });
+  });
+
+  test("should return undefined for missing row", async () => {
+    await driver.run("CREATE TABLE kv (k TEXT PRIMARY KEY, v TEXT)", []);
+
+    const row = await driver.get<{ k: string; v: string }>(
+      "SELECT * FROM kv WHERE k = ?",
+      ["missing"],
+    );
+    expect(row).toBeUndefined();
+  });
+
+  test("should commit transactions", async () => {
+    await driver.run("CREATE TABLE t (v INTEGER)", []);
+
+    await driver.transaction(async (tx) => {
+      await tx.run("INSERT INTO t VALUES (?)", [1]);
+      await tx.run("INSERT INTO t VALUES (?)", [2]);
+    });
+
+    const rows = await driver.query<{ v: number }>(
+      "SELECT v FROM t ORDER BY v",
+      [],
+    );
+    expect(rows).toEqual([{ v: 1 }, { v: 2 }]);
+  });
+
+  test("should rollback failed transactions", async () => {
+    await driver.run("CREATE TABLE t (v INTEGER)", []);
+
+    await expect(
+      driver.transaction(async (tx) => {
+        await tx.run("INSERT INTO t VALUES (?)", [1]);
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+
+    const rows = await driver.query<{ c: number }>(
+      "SELECT COUNT(*) as c FROM t",
+      [],
+    );
+    expect(rows[0]!.c).toBe(0);
+  });
+
+  test("should read and write migration version", async () => {
+    expect(await driver.getMigrationVersion()).toBe(0);
+    await driver.saveMigrationVersion(5);
+    expect(await driver.getMigrationVersion()).toBe(5);
+  });
+});
+
+// ─── Storage Integration Tests ──────────────────────────────────────────────
+
+let syncMessages: ReturnType<typeof trackMessages>;
+
+beforeEach(() => {
+  syncMessages = trackMessages();
+  cojsonInternals.setSyncStateTrackingBatchDelay(0);
+  cojsonInternals.setCoValueLoadingRetryDelay(10);
+});
+
+afterEach(async () => {
+  syncMessages.restore();
+});
+
+test("should sync and load data from storage", async () => {
+  const storage = await createInMemoryStorage();
+
+  const node1 = createTestNode();
+  node1.setStorage(storage);
+
+  const group = node1.createGroup();
+  const map = group.createMap();
+
+  map.set("hello", "world");
+
+  await map.core.waitForSync();
+
+  expect(
+    toSimplifiedMessages(
+      {
+        Map: map.core,
+        Group: group.core,
+      },
+      syncMessages.messages,
+    ),
+  ).toMatchInlineSnapshot(`
+    [
+      "client -> CONTENT Group header: true new: After: 0 New: 4",
+      "client -> CONTENT Map header: true new: After: 0 New: 1",
+    ]
+  `);
+
+  node1.gracefulShutdown();
+  syncMessages.clear();
+
+  const node2 = createTestNode({ secret: node1.agentSecret });
+  node2.setStorage(storage);
+
+  const map2 = await node2.load(map.id);
+  if (map2 === "unavailable") {
+    throw new Error("Map is unavailable");
+  }
+
+  expect(map2.get("hello")).toBe("world");
+
+  expect(
+    toSimplifiedMessages(
+      {
+        Map: map.core,
+        Group: group.core,
+      },
+      syncMessages.messages,
+    ),
+  ).toMatchInlineSnapshot(`
+    [
+      "client -> LOAD Map sessions: empty",
+      "storage -> CONTENT Group header: true new: After: 0 New: 4",
+      "storage -> CONTENT Map header: true new: After: 0 New: 1",
+    ]
+  `);
+});
+
+test("should send an empty content message if there is no content", async () => {
+  const storage = await createInMemoryStorage();
+
+  const node1 = createTestNode();
+  node1.setStorage(storage);
+
+  const group = node1.createGroup();
+  const map = group.createMap();
+
+  await map.core.waitForSync();
+
+  expect(
+    toSimplifiedMessages(
+      {
+        Map: map.core,
+        Group: group.core,
+      },
+      syncMessages.messages,
+    ),
+  ).toMatchInlineSnapshot(`
+    [
+      "client -> CONTENT Group header: true new: After: 0 New: 4",
+      "client -> CONTENT Map header: true new: ",
+    ]
+  `);
+
+  syncMessages.clear();
+  node1.gracefulShutdown();
+
+  const node2 = createTestNode({ secret: node1.agentSecret });
+  node2.setStorage(storage);
+
+  const map2 = await node2.load(map.id);
+  if (map2 === "unavailable") {
+    throw new Error("Map is unavailable");
+  }
+
+  expect(
+    toSimplifiedMessages(
+      {
+        Map: map.core,
+        Group: group.core,
+      },
+      syncMessages.messages,
+    ),
+  ).toMatchInlineSnapshot(`
+    [
+      "client -> LOAD Map sessions: empty",
+      "storage -> CONTENT Group header: true new: After: 0 New: 4",
+      "storage -> CONTENT Map header: true new: ",
+    ]
+  `);
+});
+
+test("persists deleted coValue marker as a deletedCoValues work queue entry", async () => {
+  const agentSecret = Crypto.newRandomAgentSecret();
+
+  const node = new LocalNode(
+    agentSecret,
+    Crypto.newRandomSessionID(Crypto.getAgentID(agentSecret)),
+    Crypto,
+  );
+  const storage = await createInMemoryStorage();
+  node.setStorage(storage);
+
+  const group = node.createGroup();
+  const map = group.createMap();
+  map.set("hello", "world");
+
+  const map2 = group.createMap();
+  map2.set("hello2", "world2");
+
+  await map.core.waitForSync();
+  await map2.core.waitForSync();
+
+  map.core.deleteCoValue();
+  map2.core.deleteCoValue();
+
+  await map.core.waitForSync();
+  await map2.core.waitForSync();
+
+  const deletedCoValueIDs = await getAllCoValuesWaitingForDelete(storage);
+  expect(deletedCoValueIDs).toContain(map.id);
+  expect(deletedCoValueIDs).toContain(map2.id);
+});
+
+test("delete flow: eraseAllDeletedCoValues removes history, preserves tombstone", async () => {
+  const agentSecret = Crypto.newRandomAgentSecret();
+
+  const storage = await createInMemoryStorage();
+
+  const node1 = new LocalNode(
+    agentSecret,
+    Crypto.newRandomSessionID(Crypto.getAgentID(agentSecret)),
+    Crypto,
+  );
+  node1.setStorage(storage);
+
+  const group = node1.createGroup();
+  const map = group.createMap();
+  map.set("hello", "world");
+  await map.core.waitForSync();
+
+  map.core.deleteCoValue();
+  await map.core.waitForSync();
+
+  await waitFor(async () => {
+    const queued = await getAllCoValuesWaitingForDelete(storage);
+    expect(queued).toContain(map.id);
+    return true;
+  });
+
+  await storage.eraseAllDeletedCoValues();
+
+  // Queue drained
+  await waitFor(async () => {
+    const queued = await getAllCoValuesWaitingForDelete(storage);
+    expect(queued).not.toContain(map.id);
+    return true;
+  });
+
+  // Tombstone-only load from storage
+  node1.gracefulShutdown();
+  syncMessages.clear();
+
+  const node2 = new LocalNode(
+    agentSecret,
+    Crypto.newRandomSessionID(Crypto.getAgentID(agentSecret)),
+    Crypto,
+  );
+  node2.setStorage(storage);
+
+  const map2 = await node2.load(map.id);
+  if (map2 === "unavailable") {
+    throw new Error("Map is unavailable");
+  }
+
+  expect(map2.core.isDeleted).toBe(true);
+  expect(map2.get("hello")).toBeUndefined();
+
+  const sessionIDs = await getCoValueStoredSessions(storage, map.id);
+  expect(sessionIDs).toHaveLength(1);
+  expect(sessionIDs[0]).toMatch(/_session_d[1-9A-HJ-NP-Za-km-z]+\$$/);
+});
+
+test("should load dependencies correctly (group inheritance)", async () => {
+  const storage = await createInMemoryStorage();
+
+  const node1 = createTestNode();
+  node1.setStorage(storage);
+  const group = node1.createGroup();
+  const parentGroup = node1.createGroup();
+
+  group.extend(parentGroup);
+
+  const map = group.createMap();
+
+  map.set("hello", "world");
+
+  await map.core.waitForSync();
+
+  expect(
+    toSimplifiedMessages(
+      {
+        Map: map.core,
+        Group: group.core,
+        ParentGroup: parentGroup.core,
+      },
+      syncMessages.messages,
+    ),
+  ).toMatchInlineSnapshot(`
+    [
+      "client -> CONTENT Group header: true new: After: 0 New: 4",
+      "client -> CONTENT ParentGroup header: true new: After: 0 New: 4",
+      "client -> CONTENT Group header: false new: After: 4 New: 2",
+      "client -> CONTENT Map header: true new: After: 0 New: 1",
+    ]
+  `);
+
+  syncMessages.clear();
+  node1.gracefulShutdown();
+
+  const node2 = createTestNode({ secret: node1.agentSecret });
+  node2.setStorage(storage);
+
+  await node2.load(map.id);
+
+  expect(node2.expectCoValueLoaded(map.id)).toBeTruthy();
+  expect(node2.expectCoValueLoaded(group.id)).toBeTruthy();
+  expect(node2.expectCoValueLoaded(parentGroup.id)).toBeTruthy();
+
+  expect(
+    toSimplifiedMessages(
+      {
+        Map: map.core,
+        Group: group.core,
+        ParentGroup: parentGroup.core,
+      },
+      syncMessages.messages,
+    ),
+  ).toMatchInlineSnapshot(`
+    [
+      "client -> LOAD Map sessions: empty",
+      "storage -> CONTENT ParentGroup header: true new: After: 0 New: 4",
+      "storage -> CONTENT Group header: true new: After: 0 New: 6",
+      "storage -> CONTENT Map header: true new: After: 0 New: 1",
+    ]
+  `);
+});
+
+test("should not send the same dependency value twice", async () => {
+  const storage = await createInMemoryStorage();
+
+  const node1 = createTestNode();
+  node1.setStorage(storage);
+
+  const group = node1.createGroup();
+  const parentGroup = node1.createGroup();
+
+  group.extend(parentGroup);
+
+  const mapFromParent = parentGroup.createMap();
+  const map = group.createMap();
+
+  map.set("hello", "world");
+  mapFromParent.set("hello", "world");
+
+  await map.core.waitForSync();
+  await mapFromParent.core.waitForSync();
+
+  syncMessages.clear();
+  node1.gracefulShutdown();
+
+  const node2 = createTestNode({ secret: node1.agentSecret });
+  node2.setStorage(storage);
+
+  await node2.load(map.id);
+  await node2.load(mapFromParent.id);
+
+  expect(node2.expectCoValueLoaded(map.id)).toBeTruthy();
+  expect(node2.expectCoValueLoaded(mapFromParent.id)).toBeTruthy();
+  expect(node2.expectCoValueLoaded(group.id)).toBeTruthy();
+  expect(node2.expectCoValueLoaded(parentGroup.id)).toBeTruthy();
+
+  expect(
+    toSimplifiedMessages(
+      {
+        Map: map.core,
+        Group: group.core,
+        ParentGroup: parentGroup.core,
+        MapFromParent: mapFromParent.core,
+      },
+      syncMessages.messages,
+    ),
+  ).toMatchInlineSnapshot(`
+    [
+      "client -> LOAD Map sessions: empty",
+      "storage -> CONTENT ParentGroup header: true new: After: 0 New: 4",
+      "storage -> CONTENT Group header: true new: After: 0 New: 6",
+      "storage -> CONTENT Map header: true new: After: 0 New: 1",
+      "client -> LOAD MapFromParent sessions: empty",
+      "storage -> CONTENT MapFromParent header: true new: After: 0 New: 1",
+    ]
+  `);
+});
+
+test("should recover from data loss", async () => {
+  const storage = await createInMemoryStorage();
+
+  const node1 = createTestNode();
+  node1.setStorage(storage);
+
+  const group = node1.createGroup();
+
+  const map = group.createMap();
+
+  map.set("0", 0);
+
+  await map.core.waitForSync();
+
+  const mock = vi
+    .spyOn(StorageApiAsync.prototype, "store")
+    .mockImplementation(() => Promise.resolve(undefined));
+
+  map.set("1", 1);
+  map.set("2", 2);
+
+  await new Promise((resolve) => setTimeout(resolve, 200));
+
+  const knownState = storage.getKnownState(map.id);
+  Object.assign(knownState, map.core.knownState());
+
+  mock.mockReset();
+
+  map.set("3", 3);
+
+  await map.core.waitForSync();
+
+  expect(
+    toSimplifiedMessages(
+      {
+        Map: map.core,
+        Group: group.core,
+      },
+      syncMessages.messages,
+    ),
+  ).toMatchInlineSnapshot(`
+    [
+      "client -> CONTENT Group header: true new: After: 0 New: 4",
+      "client -> CONTENT Map header: true new: After: 0 New: 1",
+      "client -> CONTENT Map header: false new: After: 3 New: 1",
+      "storage -> KNOWN CORRECTION Map sessions: header/4",
+      "client -> CONTENT Map header: false new: After: 1 New: 3",
+    ]
+  `);
+
+  syncMessages.clear();
+  node1.gracefulShutdown();
+
+  const node2 = createTestNode({ secret: node1.agentSecret });
+  node2.setStorage(storage);
+
+  const map2 = await node2.load(map.id);
+
+  if (map2 === "unavailable") {
+    throw new Error("Map is unavailable");
+  }
+
+  expect(map2.toJSON()).toEqual({
+    "0": 0,
+    "1": 1,
+    "2": 2,
+    "3": 3,
+  });
+
+  expect(
+    toSimplifiedMessages(
+      {
+        Map: map.core,
+        Group: group.core,
+      },
+      syncMessages.messages,
+    ),
+  ).toMatchInlineSnapshot(`
+    [
+      "client -> LOAD Map sessions: empty",
+      "storage -> CONTENT Group header: true new: After: 0 New: 4",
+      "storage -> CONTENT Map header: true new: After: 0 New: 4",
+    ]
+  `);
+});
+
+test("should sync multiple sessions in a single content message", async () => {
+  const driver = await createSharedDriver();
+
+  const node1 = createTestNode();
+  node1.setStorage(await createInMemoryStorage(driver));
+
+  const group = node1.createGroup();
+
+  const map = group.createMap();
+
+  map.set("hello", "world");
+
+  await map.core.waitForSync();
+
+  node1.gracefulShutdown();
+
+  const node2 = createTestNode({ secret: node1.agentSecret });
+  node2.setStorage(await createInMemoryStorage(driver));
+
+  const map2 = await node2.load(map.id);
+  if (map2 === "unavailable") {
+    throw new Error("Map is unavailable");
+  }
+
+  expect(map2.get("hello")).toBe("world");
+
+  map2.set("hello", "world2");
+
+  await map2.core.waitForSync();
+
+  node2.gracefulShutdown();
+
+  const node3 = createTestNode({ secret: node1.agentSecret });
+
+  syncMessages.clear();
+
+  node3.setStorage(await createInMemoryStorage(driver));
+
+  const map3 = await node3.load(map.id);
+  if (map3 === "unavailable") {
+    throw new Error("Map is unavailable");
+  }
+
+  expect(map3.get("hello")).toBe("world2");
+
+  expect(
+    toSimplifiedMessages(
+      {
+        Map: map.core,
+        Group: group.core,
+      },
+      syncMessages.messages,
+    ),
+  ).toMatchInlineSnapshot(`
+    [
+      "client -> LOAD Map sessions: empty",
+      "storage -> CONTENT Group header: true new: After: 0 New: 4",
+      "storage -> CONTENT Map header: true new: After: 0 New: 1 | After: 0 New: 1",
+    ]
+  `);
+});
+
+test("large coValue upload streaming", async () => {
+  const storage = await createInMemoryStorage();
+
+  const node1 = createTestNode();
+  node1.setStorage(storage);
+
+  const group = node1.createGroup();
+  const largeMap = group.createMap();
+
+  // Generate a large amount of data (about 200KB)
+  const dataSize = 1 * 1024 * 200;
+  const chunkSize = 1024; // 1KB chunks
+  const chunks = dataSize / chunkSize;
+
+  const value = "a".repeat(chunkSize);
+
+  for (let i = 0; i < chunks; i++) {
+    const key = `key${i}`;
+    largeMap.set(key, value, "trusting");
+  }
+
+  await largeMap.core.waitForSync();
+
+  const knownState = largeMap.core.knownState();
+
+  node1.gracefulShutdown();
+
+  const node2 = createTestNode({ secret: node1.agentSecret });
+
+  syncMessages.clear();
+
+  node2.setStorage(storage);
+
+  const largeMapOnNode2 = await node2.load(largeMap.id);
+
+  if (largeMapOnNode2 === "unavailable") {
+    throw new Error("Map is unavailable");
+  }
+
+  await waitFor(() => {
+    expect(largeMapOnNode2.core.knownState()).toEqual(knownState);
+
+    return true;
+  });
+
+  expect(
+    toSimplifiedMessages(
+      {
+        Map: largeMap.core,
+        Group: group.core,
+      },
+      syncMessages.messages,
+    ),
+  ).toMatchInlineSnapshot(`
+    [
+      "client -> LOAD Map sessions: empty",
+      "storage -> CONTENT Group header: true new: After: 0 New: 4",
+      "storage -> CONTENT Map header: true new: After: 0 New: 97",
+      "storage -> CONTENT Map header: true new: After: 97 New: 97",
+      "storage -> CONTENT Map header: true new: After: 194 New: 6",
+    ]
+  `);
+});
+
+test("should sync and load accounts from storage", async () => {
+  const agentSecret = Crypto.newRandomAgentSecret();
+  const storage = await createInMemoryStorage();
+
+  const { node: node1, accountID } = await LocalNode.withNewlyCreatedAccount({
+    crypto: Crypto,
+    initialAgentSecret: agentSecret,
+    storage,
+    creationProps: {
+      name: "test",
+    },
+  });
+
+  const account1 = node1.getCoValue(accountID);
+  const profile = node1.expectProfileLoaded(accountID);
+  const profileGroup = profile.group;
+
+  expect(
+    toSimplifiedMessages(
+      {
+        Account: account1,
+        Profile: profile.core,
+        ProfileGroup: profileGroup.core,
+      },
+      syncMessages.messages,
+    ),
+  ).toMatchInlineSnapshot(`
+    [
+      "client -> CONTENT Account header: true new: After: 0 New: 3",
+      "client -> CONTENT ProfileGroup header: true new: After: 0 New: 6",
+      "client -> CONTENT Profile header: true new: After: 0 New: 1",
+      "client -> CONTENT Account header: false new: After: 3 New: 1",
+    ]
+  `);
+
+  node1.gracefulShutdown();
+  syncMessages.restore();
+  syncMessages = trackMessages();
+
+  const node2 = await LocalNode.withLoadedAccount({
+    crypto: Crypto,
+    accountSecret: agentSecret,
+    accountID,
+    peers: [],
+    storage,
+    sessionID: Crypto.newRandomSessionID(Crypto.getAgentID(agentSecret)),
+  });
+
+  expect(
+    toSimplifiedMessages(
+      {
+        Account: account1,
+        Profile: profile.core,
+        ProfileGroup: profileGroup.core,
+      },
+      syncMessages.messages,
+    ),
+  ).toMatchInlineSnapshot(`
+    [
+      "client -> LOAD Account sessions: empty",
+      "storage -> CONTENT Account header: true new: After: 0 New: 4",
+      "client -> LOAD Profile sessions: empty",
+      "storage -> CONTENT ProfileGroup header: true new: After: 0 New: 6",
+      "storage -> CONTENT Profile header: true new: After: 0 New: 1",
+    ]
+  `);
+
+  expect(node2.getCoValue(accountID).isAvailable()).toBeTruthy();
+});
+
+describe("sync state persistence", () => {
+  test("unsynced coValues are asynchronously persisted to storage", async () => {
+    const client = createTestNode();
+    const storage = await createInMemoryStorage();
+    client.setStorage(storage);
+
+    const group = client.createGroup();
+    const map = group.createMap();
+    map.set("key", "value");
+
+    // Wait for the unsynced coValues to be persisted to storage
+    await new Promise<void>((resolve) => setTimeout(resolve, 500));
+
+    const unsyncedCoValueIDs = await new Promise((resolve) =>
+      client.storage?.getUnsyncedCoValueIDs(resolve),
+    );
+    expect(unsyncedCoValueIDs).toHaveLength(2);
+    expect(unsyncedCoValueIDs).toContain(map.id);
+    expect(unsyncedCoValueIDs).toContain(group.id);
+
+    await client.gracefulShutdown();
+  });
+
+  test("synced coValues are removed from storage", async () => {
+    const syncServer = createTestNode();
+    const client = createTestNode();
+    const storage = await createInMemoryStorage();
+    client.setStorage(storage);
+
+    connectToSyncServer(client, syncServer);
+
+    const group = client.createGroup();
+    const map = group.createMap();
+    map.set("key", "value");
+
+    // Wait enough time for the coValue to be synced
+    await new Promise<void>((resolve) => setTimeout(resolve, 500));
+
+    const unsyncedCoValueIDs = await new Promise((resolve) =>
+      client.storage?.getUnsyncedCoValueIDs(resolve),
+    );
+    expect(unsyncedCoValueIDs).toHaveLength(0);
+    expect(client.syncManager.unsyncedTracker.has(map.id)).toBe(false);
+
+    await client.gracefulShutdown();
+    await syncServer.gracefulShutdown();
+  });
+
+  test("unsynced coValues are persisted to storage when the node is shutdown", async () => {
+    const client = createTestNode();
+    const storage = await createInMemoryStorage();
+    client.setStorage(storage);
+
+    const group = client.createGroup();
+    const map = group.createMap();
+    map.set("key", "value");
+
+    // Wait for local transaction to trigger sync
+    await new Promise<void>((resolve) => queueMicrotask(resolve));
+
+    await client.gracefulShutdown();
+
+    const unsyncedCoValueIDs = await new Promise((resolve) =>
+      client.storage?.getUnsyncedCoValueIDs(resolve),
+    );
+    expect(unsyncedCoValueIDs).toHaveLength(2);
+    expect(unsyncedCoValueIDs).toContain(map.id);
+    expect(unsyncedCoValueIDs).toContain(group.id);
+  });
+});
+
+describe("sync resumption", () => {
+  test("unsynced coValues are resumed when the node is restarted", async () => {
+    const node1 = createTestNode();
+    const storage = await createInMemoryStorage();
+    node1.setStorage(storage);
+
+    const getUnsyncedCoValueIDsFromStorage = async () =>
+      new Promise<string[]>((resolve) =>
+        node1.storage?.getUnsyncedCoValueIDs(resolve),
+      );
+
+    const group = node1.createGroup();
+    const map = group.createMap();
+    map.set("key", "value");
+
+    // Wait for the unsynced coValues to be persisted to storage
+    await new Promise<void>((resolve) => setTimeout(resolve, 100));
+
+    const unsyncedTracker = node1.syncManager.unsyncedTracker;
+    expect(unsyncedTracker.has(map.id)).toBe(true);
+    expect(await getUnsyncedCoValueIDsFromStorage()).toHaveLength(2);
+
+    node1.gracefulShutdown();
+
+    // Create second node with the same storage
+    const node2 = createTestNode();
+    node2.setStorage(storage);
+
+    // Connect to sync server
+    const syncServer = createTestNode();
+    connectToSyncServer(node2, syncServer);
+
+    await node2.syncManager.waitForAllCoValuesSync();
+    // Wait for sync to resume & complete
+    await waitFor(
+      async () => (await getUnsyncedCoValueIDsFromStorage()).length === 0,
+    );
+
+    await node2.gracefulShutdown();
+  });
+});

--- a/packages/cojson-storage-sqlite-wasm/src/tests/testUtils.ts
+++ b/packages/cojson-storage-sqlite-wasm/src/tests/testUtils.ts
@@ -1,0 +1,207 @@
+import type {
+  AgentSecret,
+  RawCoID,
+  RawCoMap,
+  SessionID,
+  SyncMessage,
+} from "cojson";
+import {
+  cojsonInternals,
+  ControlledAgent,
+  LocalNode,
+  StorageApiAsync,
+  StorageAPI,
+} from "cojson";
+import { WasmCrypto } from "cojson/crypto/WasmCrypto";
+import { onTestFinished } from "vitest";
+
+const { knownStateFromContent } = cojsonInternals;
+
+export function trackMessages() {
+  const messages: {
+    from: "client" | "server" | "storage";
+    msg: SyncMessage;
+  }[] = [];
+
+  const originalLoad = StorageApiAsync.prototype.load;
+  const originalStore = StorageApiAsync.prototype.store;
+
+  StorageApiAsync.prototype.load = async function (id, callback, done) {
+    messages.push({
+      from: "client",
+      msg: {
+        action: "load",
+        id: id as RawCoID,
+        header: false,
+        sessions: {},
+      },
+    });
+    return originalLoad.call(
+      this,
+      id,
+      (msg) => {
+        messages.push({
+          from: "storage",
+          msg,
+        });
+        callback(msg);
+      },
+      done,
+    );
+  };
+
+  StorageApiAsync.prototype.store = async function (data, correctionCallback) {
+    messages.push({
+      from: "client",
+      msg: data,
+    });
+
+    return originalStore.call(this, data, (msg) => {
+      messages.push({
+        from: "storage",
+        msg: {
+          action: "known",
+          isCorrection: true,
+          ...msg,
+        },
+      });
+      const correctionMessages = correctionCallback(msg);
+
+      if (correctionMessages) {
+        for (const msg of correctionMessages) {
+          messages.push({
+            from: "client",
+            msg,
+          });
+        }
+      }
+
+      return correctionMessages;
+    });
+  };
+
+  const restore = () => {
+    StorageApiAsync.prototype.load = originalLoad;
+    StorageApiAsync.prototype.store = originalStore;
+    messages.length = 0;
+  };
+
+  const clear = () => {
+    messages.length = 0;
+  };
+
+  onTestFinished(() => {
+    restore();
+  });
+
+  return {
+    messages,
+    restore,
+    clear,
+  };
+}
+
+export function getAllCoValuesWaitingForDelete(
+  storage: StorageAPI,
+): Promise<RawCoID[]> {
+  // @ts-expect-error - dbClient is private
+  return storage.dbClient.getAllCoValuesWaitingForDelete();
+}
+
+export async function getCoValueStoredSessions(
+  storage: StorageAPI,
+  id: RawCoID,
+): Promise<SessionID[]> {
+  return new Promise<SessionID[]>((resolve) => {
+    storage.load(
+      id,
+      (content) => {
+        if (content.id === id) {
+          resolve(
+            Object.keys(knownStateFromContent(content).sessions) as SessionID[],
+          );
+        }
+      },
+      () => {},
+    );
+  });
+}
+
+export function waitFor(
+  callback: () => boolean | undefined | Promise<boolean | undefined>,
+) {
+  return new Promise<void>((resolve, reject) => {
+    const checkPassed = async () => {
+      try {
+        return { ok: await callback(), error: null };
+      } catch (error) {
+        return { ok: false, error };
+      }
+    };
+
+    let retries = 0;
+
+    const interval = setInterval(async () => {
+      const { ok, error } = await checkPassed();
+
+      if (ok !== false) {
+        clearInterval(interval);
+        resolve();
+      }
+
+      if (++retries > 10) {
+        clearInterval(interval);
+        reject(error);
+      }
+    }, 100);
+  });
+}
+
+export function fillCoMapWithLargeData(map: RawCoMap) {
+  const dataSize = 1 * 1024 * 200;
+  const chunkSize = 1024; // 1KB chunks
+  const chunks = dataSize / chunkSize;
+
+  const value = btoa(
+    new Array(chunkSize).fill("value$").join("").slice(0, chunkSize),
+  );
+
+  for (let i = 0; i < chunks; i++) {
+    const key = `key${i}`;
+    map.set(key, value, "trusting");
+  }
+
+  return map;
+}
+
+const Crypto = await WasmCrypto.create();
+
+export function getAgentAndSessionID(
+  secret: AgentSecret = Crypto.newRandomAgentSecret(),
+): [ControlledAgent, SessionID] {
+  const sessionID = Crypto.newRandomSessionID(Crypto.getAgentID(secret));
+  return [new ControlledAgent(secret, Crypto), sessionID];
+}
+
+export function createTestNode(opts?: { secret?: AgentSecret }) {
+  const [admin, session] = getAgentAndSessionID(opts?.secret);
+  return new LocalNode(admin.agentSecret, session, Crypto);
+}
+
+export function connectToSyncServer(
+  client: LocalNode,
+  syncServer: LocalNode,
+): void {
+  const [clientPeer, serverPeer] = cojsonInternals.connectedPeers(
+    client.currentSessionID,
+    syncServer.currentSessionID,
+    {
+      peer1role: "client",
+      peer2role: "server",
+      persistent: true,
+    },
+  );
+
+  client.syncManager.addPeer(serverPeer);
+  syncServer.syncManager.addPeer(clientPeer);
+}

--- a/packages/cojson-storage-sqlite-wasm/tsconfig.json
+++ b/packages/cojson-storage-sqlite-wasm/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "lib": ["ESNext", "DOM"],
+    "module": "esnext",
+    "target": "ES2020",
+    "moduleResolution": "bundler",
+    "moduleDetection": "force",
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noUncheckedIndexedAccess": true,
+    "esModuleInterop": true,
+    "declaration": true,
+    "declarationMap": true
+  },
+  "include": ["./src/**/*"]
+}

--- a/packages/cojson-storage-sqlite-wasm/vitest.config.ts
+++ b/packages/cojson-storage-sqlite-wasm/vitest.config.ts
@@ -1,0 +1,22 @@
+import { defineProject } from "vitest/config";
+import { playwright } from "@vitest/browser-playwright";
+
+export default defineProject({
+  optimizeDeps: {
+    exclude: ["@sqlite.org/sqlite-wasm"],
+  },
+  test: {
+    name: "cojson-storage-sqlite-wasm",
+    browser: {
+      enabled: true,
+      provider: playwright(),
+      instances: [
+        {
+          headless: process.env.HEADLESS !== "false",
+          browser: "chromium",
+        },
+      ],
+    },
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/packages/jazz-tools/package.json
+++ b/packages/jazz-tools/package.json
@@ -268,10 +268,14 @@
     "react-native-mmkv": "^3.3.0",
     "react-native-nitro-modules": "^0.26.4",
     "react-native-passkey": "^3.0.0",
+    "cojson-storage-sqlite-wasm": "workspace:*",
     "sharp": "^0.33.5",
     "svelte": "^5.0.0"
   },
   "peerDependenciesMeta": {
+    "cojson-storage-sqlite-wasm": {
+      "optional": true
+    },
     "@bam.tech/react-native-image-resizer": {
       "optional": true
     },

--- a/packages/jazz-tools/src/browser/createBrowserContext.ts
+++ b/packages/jazz-tools/src/browser/createBrowserContext.ts
@@ -29,7 +29,7 @@ setupInspector();
 export type BaseBrowserContextOptions = {
   sync: SyncConfig;
   reconnectionTimeout?: number;
-  storage?: "indexedDB";
+  storage?: "indexedDB" | "sqlite-wasm";
   crypto?: CryptoProvider;
   authSecretStorage: AuthSecretStorage;
 };
@@ -53,7 +53,13 @@ async function setupPeers(options: BaseBrowserContextOptions) {
 
   const peers: Peer[] = [];
 
-  const storage = await getIndexedDBStorage();
+  let storage;
+  if (options.storage === "sqlite-wasm") {
+    const { getSqliteWasmStorage } = await import("cojson-storage-sqlite-wasm");
+    storage = await getSqliteWasmStorage();
+  } else {
+    storage = await getIndexedDBStorage();
+  }
 
   if (options.sync.when === "never") {
     return {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2523,6 +2523,22 @@ importers:
         specifier: catalog:default
         version: 5.6.2
 
+  packages/cojson-storage-sqlite-wasm:
+    dependencies:
+      '@sqlite.org/sqlite-wasm':
+        specifier: ^3.51.2-build6
+        version: 3.51.2-build6
+      cojson:
+        specifier: workspace:*
+        version: link:../cojson
+    devDependencies:
+      '@vitest/browser-playwright':
+        specifier: catalog:default
+        version: 4.0.16(msw@2.10.4(@types/node@24.3.0)(typescript@5.6.2))(playwright@1.50.1)(vite@6.3.5(@types/node@24.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.1))(vitest@4.0.16)
+      typescript:
+        specifier: catalog:default
+        version: 5.6.2
+
   packages/cojson-transport-ws:
     dependencies:
       '@opentelemetry/api':
@@ -2720,6 +2736,9 @@ importers:
       cojson-storage-indexeddb:
         specifier: workspace:*
         version: link:../cojson-storage-indexeddb
+      cojson-storage-sqlite-wasm:
+        specifier: workspace:*
+        version: link:../cojson-storage-sqlite-wasm
       cojson-transport-ws:
         specifier: workspace:*
         version: link:../cojson-transport-ws
@@ -9147,6 +9166,10 @@ packages:
 
   '@speed-highlight/core@1.2.7':
     resolution: {integrity: sha512-0dxmVj4gxg3Jg879kvFS/msl4s9F3T9UXC1InxgOf7t5NvcPD97u/WTA5vL/IxWHMn7qSxBozqrnnE2wvl1m8g==}
+
+  '@sqlite.org/sqlite-wasm@3.51.2-build6':
+    resolution: {integrity: sha512-5ibsgipkqcLINZ5qNSp5KfrtL6KwiNVtwBksNO6zhTghhLmEf3/u1sPoAkgH5RzuLpMw7zi50IWgkZ0WhfqpaA==}
+    engines: {node: '>=22'}
 
   '@stablelib/base64@1.0.1':
     resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
@@ -28387,6 +28410,8 @@ snapshots:
 
   '@speed-highlight/core@1.2.7': {}
 
+  '@sqlite.org/sqlite-wasm@3.51.2-build6': {}
+
   '@stablelib/base64@1.0.1': {}
 
   '@standard-schema/spec@1.0.0': {}
@@ -30043,7 +30068,6 @@ snapshots:
       - msw
       - utf-8-validate
       - vite
-    optional: true
 
   '@vitest/browser-playwright@4.0.16(msw@2.10.4(@types/node@24.3.0)(typescript@5.9.2))(playwright@1.50.1)(vite@6.3.5(@types/node@24.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.1))(vitest@4.0.16)':
     dependencies:
@@ -30149,7 +30173,6 @@ snapshots:
       - msw
       - utf-8-validate
       - vite
-    optional: true
 
   '@vitest/browser@4.0.16(msw@2.10.4(@types/node@24.3.0)(typescript@5.9.2))(vite@6.3.5(@types/node@24.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.1))(vitest@4.0.16)':
     dependencies:

--- a/tests/browser-perf-tests/vite.config.ts
+++ b/tests/browser-perf-tests/vite.config.ts
@@ -5,6 +5,15 @@ import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    headers: {
+      "Cross-Origin-Opener-Policy": "same-origin",
+      "Cross-Origin-Embedder-Policy": "require-corp",
+    },
+  },
+  optimizeDeps: {
+    exclude: ["@sqlite.org/sqlite-wasm"],
+  },
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),


### PR DESCRIPTION
A vibe-coded POC to validate a storage on OPFS

I tried at first to just put the DBDriver behind a worker, but perf got worse.

Then tried to put the StorageAPI in the worker and got around 2x perf improvement in a 50x50 grid.

Due to the inizialization cost of loading sqlite loading a 20x20 grid is actually 2x times slower compared to IndexedDB.

