### PR TITLE
Fix `toJSON()` serialisation for `co.record`

### DIFF
--- a/.changeset/smooth-animals-rhyme.md
+++ b/.changeset/smooth-animals-rhyme.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Fix issue with CoRecord serialisation

--- a/packages/jazz-tools/src/tools/coValues/coMap.ts
+++ b/packages/jazz-tools/src/tools/coValues/coMap.ts
@@ -216,10 +216,9 @@ export class CoMap extends CoValueBase implements CoValue {
         if (
           ref &&
           typeof ref === "object" &&
-          "toJSON" in ref &&
-          typeof ref.toJSON === "function"
+          typeof (ref as any).toJSON === "function"
         ) {
-          const jsonedRef = ref.toJSON(tKey, [
+          const jsonedRef = (ref as any).toJSON(tKey, [
             ...(processedValues || []),
             this.$jazz.id,
           ]);
@@ -789,7 +788,11 @@ class CoMapJazzApi<M extends CoMap> extends CoValueJazzApi<M> {
    * @internal
    */
   getDescriptor(key: string): Schema | undefined {
-    return this.schema?.[key] || this.schema?.[ItemsSym];
+    return (
+      this.schema?.[key] ||
+      this.schema?.[ItemsSym] ||
+      (this.coMap as any)[ItemsSym]
+    );
   }
 
   /**
@@ -955,7 +958,7 @@ export type CoMapInit<Map extends object> = {
 // TODO: cache handlers per descriptor for performance?
 const CoMapProxyHandler: ProxyHandler<CoMap> = {
   get(target, key, receiver) {
-    if (key === "_schema") {
+    if (key === "_schema" || key === ItemsSym) {
       return Reflect.get(target, key);
     } else if (key in target) {
       return Reflect.get(target, key, receiver);
@@ -993,6 +996,10 @@ const CoMapProxyHandler: ProxyHandler<CoMap> = {
       (target.constructor as typeof CoMap)._schema ||= {};
       (target.constructor as typeof CoMap)._schema[key] = value[SchemaInit];
       return true;
+    }
+
+    if (typeof key !== "string") {
+      return Reflect.set(target, key, value, receiver);
     }
 
     const descriptor = target.$jazz.getDescriptor(key as string);

--- a/packages/jazz-tools/src/tools/coValues/coMap.ts
+++ b/packages/jazz-tools/src/tools/coValues/coMap.ts
@@ -1006,11 +1006,7 @@ const CoMapProxyHandler: ProxyHandler<CoMap> = {
 
     if (!descriptor) return false;
 
-    if (typeof key === "string") {
-      throw Error("Cannot update a CoMap directly. Use `$jazz.set` instead.");
-    } else {
-      return Reflect.set(target, key, value, receiver);
-    }
+    throw Error("Cannot update a CoMap directly. Use `$jazz.set` instead.");
   },
   defineProperty(target, key, attributes) {
     if (

--- a/packages/jazz-tools/src/tools/tests/coMap.record.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coMap.record.test.ts
@@ -631,4 +631,21 @@ describe("CoRecord unique methods", () => {
     const foundId = ItemRecord.findUnique("find-test", group.$jazz.id);
     expect(foundId).toBe(originalRecord.$jazz.id);
   });
+
+  test("co.record should toJSON correctly", () => {
+    const Item = co.map({ val: z.number() });
+    const RecordMap = co.record(z.string(), Item);
+
+    const record = RecordMap.create({
+      key1: Item.create({ val: 1 }),
+    });
+
+    expect(record.toJSON()).toEqual(
+      expect.objectContaining({
+        key1: expect.objectContaining({
+          val: 1,
+        }),
+      }),
+    );
+  });
 });

--- a/packages/jazz-tools/src/tools/tests/coMap.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coMap.test.ts
@@ -430,7 +430,6 @@ describe("CoMap", async () => {
         },
       });
 
-      console.log("Local root JSON:", root.toJSON());
 
       // Simulate loading in another context/component
       const loadedRoot = await ChatRoot.load(root.$jazz.id, {

--- a/packages/jazz-tools/src/tools/tests/coMap.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coMap.test.ts
@@ -442,7 +442,6 @@ describe("CoMap", async () => {
       if (!loadedRoot || !loadedRoot.$isLoaded)
         throw new Error("Failed to load root");
 
-      console.log("Loaded root JSON:", loadedRoot.toJSON());
 
       expect(loadedRoot.toJSON()).toEqual(
         expect.objectContaining({

--- a/packages/jazz-tools/src/tools/tests/coMap.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coMap.test.ts
@@ -430,7 +430,6 @@ describe("CoMap", async () => {
         },
       });
 
-
       // Simulate loading in another context/component
       const loadedRoot = await ChatRoot.load(root.$jazz.id, {
         resolve: {
@@ -440,7 +439,6 @@ describe("CoMap", async () => {
 
       if (!loadedRoot || !loadedRoot.$isLoaded)
         throw new Error("Failed to load root");
-
 
       expect(loadedRoot.toJSON()).toEqual(
         expect.objectContaining({


### PR DESCRIPTION
The catchall on CoRecords was trapping the `toJSON` call, resulting in incorrect serialisation behaviour of nested CoRecords.

Tests have been added.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to serialization/schema lookup logic and adds targeted test coverage; low risk aside from potential edge cases in proxy trapping for non-string keys.
> 
> **Overview**
> Fixes `toJSON()` serialization for `co.record` (and `co.map` containing nested records) by ensuring record item schema lookup works reliably (via `ItemsSym`) and by making `toJSON` calls on referenced CoValues resilient to proxy/catchall interception.
> 
> Adds regression tests covering `co.record.toJSON()` and `co.map` with a nested `co.record` after loading/resolution, and includes a patch changeset for `jazz-tools`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 14afa84d723ff849d4e953bda22029f3fa46b916. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->