### PR TITLE
perf(subscription): delay value content parsing to when it's fully downloaded

### DIFF
--- a/.changeset/add-get-or-create-unique.md
+++ b/.changeset/add-get-or-create-unique.md
@@ -1,5 +1,5 @@
 ---
-"jazz-tools": minor
+"jazz-tools": patch
 ---
 
 Add `getOrCreateUnique` method to CoMap, CoList, and CoFeed

--- a/.changeset/delay-subscription-content-parsing.md
+++ b/.changeset/delay-subscription-content-parsing.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Delayed CoValue content parsing in subscriptions until the value is fully downloaded, avoiding unnecessary intermediate parsing


### PR DESCRIPTION
In the dashboard we've found that the main perf issue is caused by the group content invalidation during the streaming.

<img width="1009" height="543" alt="Screenshot 2026-02-09 at 15 05 44" src="https://github.com/user-attachments/assets/180ef726-349e-4b4c-87f0-bf98d299f549" />
<img width="1002" height="840" alt="Screenshot 2026-02-09 at 15 05 56" src="https://github.com/user-attachments/assets/b3880534-b3f6-4c1d-934a-133a9fb957b2" />

We don't need to parse the content immediately, and delaying the parsing to when the value is fully completed should fix the biggest issue we have there.