### PR TITLE
perf(permissions): improve perf of writeKey revelations validation in groups with many writeOnlyKey

### DIFF
--- a/.changeset/perf-writekey-revelations.md
+++ b/.changeset/perf-writekey-revelations.md
@@ -1,0 +1,5 @@
+---
+"cojson": patch
+---
+
+Improved performance of writeKey revelations validation in groups with many writeOnlyKeys

--- a/packages/cojson/src/permissions.ts
+++ b/packages/cojson/src/permissions.ts
@@ -627,16 +627,16 @@ function isOwnWriteKeyRevelation(
 ): key is
   | `${KeyID}_for_${RawAccountID | AgentID}`
   | `${KeyID}_sealedFor_${SealerID}` {
-  if (Object.keys(writeOnlyKeys).length === 0) {
-    return false;
-  }
-
   let i = key.indexOf("_for_");
   if (i === -1) {
     i = key.indexOf("_sealedFor_");
   }
 
   const keyID = key.slice(0, i);
+
+  if (!keyID) {
+    return false;
+  }
 
   return writeOnlyKeys[memberKey] === keyID;
 }


### PR DESCRIPTION
Before:
<img width="836" height="541" alt="Screenshot 2026-02-09 at 16 49 18" src="https://github.com/user-attachments/assets/556f4768-408e-40fd-8c44-20b7e37da5c3" />
After:
<img width="545" height="485" alt="Screenshot 2026-02-09 at 16 51 17" src="https://github.com/user-attachments/assets/4740783f-d971-4440-8788-bb10da02172d" />
