### PR TITLE
feat: implement StorageReconciliationAckTracker for managing reconciliation acks

### DIFF
--- a/packages/cojson/src/StorageReconciliationAckTracker.ts
+++ b/packages/cojson/src/StorageReconciliationAckTracker.ts
@@ -1,0 +1,81 @@
+import { PeerState } from "./PeerState.js";
+
+export class StorageReconciliationAckTracker {
+  /**
+   * Tracks pending reconcile acks: "batchId#peerId->offset".
+   * Cleared in handleAck.
+   */
+  pendingReconciliationAck: Map<string, number> = new Map();
+  private batchAckListeners: Map<string, Set<() => void>> = new Map();
+
+  trackBatch(batchId: string, peerId: string, nextOffset: number): void {
+    const key = this.key(batchId, peerId);
+    this.pendingReconciliationAck.set(key, nextOffset);
+    if (!this.batchAckListeners.has(key)) {
+      this.batchAckListeners.set(key, new Set());
+    }
+  }
+
+  handleAck(batchId: string, peerId: string): number | undefined {
+    const key = this.key(batchId, peerId);
+    const nextOffset = this.pendingReconciliationAck.get(key);
+
+    this.pendingReconciliationAck.delete(key);
+
+    const listeners = this.batchAckListeners.get(key);
+    if (listeners) {
+      for (const listener of listeners) {
+        listener();
+      }
+      this.batchAckListeners.delete(key);
+    }
+
+    return nextOffset;
+  }
+
+  waitForAck(batchId: string, peer: PeerState, callback: () => void): void {
+    const key = this.key(batchId, peer.id);
+    const listeners = this.batchAckListeners.get(key);
+    if (!this.pendingReconciliationAck.has(key) || !listeners) {
+      callback();
+      return;
+    }
+
+    let finished = false;
+    let unsubscribeCloseListener: () => void = () => {};
+
+    const finish = () => {
+      if (finished) {
+        return false;
+      }
+      finished = true;
+      unsubscribeCloseListener();
+      return true;
+    };
+
+    const onAck = () => {
+      if (!finish()) {
+        return;
+      }
+      callback();
+    };
+
+    const onPeerClose = () => {
+      if (!finish()) {
+        return;
+      }
+      listeners.delete(onAck);
+      this.pendingReconciliationAck.delete(key);
+      if (listeners.size === 0) {
+        this.batchAckListeners.delete(key);
+      }
+    };
+
+    listeners.add(onAck);
+    unsubscribeCloseListener = peer.addCloseListener(onPeerClose);
+  }
+
+  private key(batchId: string, peerId: string): string {
+    return `${batchId}#${peerId}`;
+  }
+}

--- a/packages/cojson/src/config.ts
+++ b/packages/cojson/src/config.ts
@@ -69,7 +69,6 @@ export const STORAGE_RECONCILIATION_CONFIG = {
   BATCH_SIZE: 100,
   LOCK_TTL_MS: 24 * 60 * 60 * 1000, // 1 day
   RECONCILIATION_INTERVAL_MS: 30 * 24 * 60 * 60 * 1000, // 30 days
-  BATCH_ACK_POLLING_INTERVAL_MS: 10,
 };
 
 export function setStorageReconciliationBatchSize(size: number) {

--- a/packages/cojson/src/queue/PriorityBasedMessageQueue.ts
+++ b/packages/cojson/src/queue/PriorityBasedMessageQueue.ts
@@ -32,7 +32,11 @@ export class PriorityBasedMessageQueue {
   }
 
   public push(msg: SyncMessage) {
-    const priority = "priority" in msg ? msg.priority : this.defaultPriority;
+    let priority = "priority" in msg ? msg.priority : this.defaultPriority;
+
+    if (msg.action === "reconcile") {
+      priority = CO_VALUE_PRIORITY.LOW;
+    }
 
     this.getQueue(priority).push(msg);
   }

--- a/packages/cojson/src/tests/StorageReconciliationAckTracker.test.ts
+++ b/packages/cojson/src/tests/StorageReconciliationAckTracker.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test, vi } from "vitest";
+import { PeerState } from "../PeerState.js";
+import { StorageReconciliationAckTracker } from "../StorageReconciliationAckTracker.js";
+import { ConnectedPeerChannel } from "../streamUtils.js";
+import { Peer } from "../sync.js";
+
+function createPeerState(id = "peer-1"): PeerState {
+  const peer: Peer = {
+    id,
+    role: "server",
+    persistent: true,
+    incoming: new ConnectedPeerChannel(),
+    outgoing: new ConnectedPeerChannel(),
+  };
+
+  return new PeerState(peer, undefined);
+}
+
+describe("StorageReconciliationAckTracker", () => {
+  test("tracks pending acks and returns next offset on ack", () => {
+    const tracker = new StorageReconciliationAckTracker();
+
+    tracker.trackBatch("batch-1", "peer-1", 100);
+
+    expect(tracker.pendingReconciliationAck.get("batch-1#peer-1")).toBe(100);
+
+    const nextOffset = tracker.handleAck("batch-1", "peer-1");
+
+    expect(nextOffset).toBe(100);
+    expect(tracker.pendingReconciliationAck.has("batch-1#peer-1")).toBe(false);
+  });
+
+  test("invokes registered callback when ack is received", () => {
+    const tracker = new StorageReconciliationAckTracker();
+    const peer = createPeerState("peer-1");
+    const onAck = vi.fn();
+
+    tracker.trackBatch("batch-1", peer.id, 50);
+    tracker.waitForAck("batch-1", peer, onAck);
+
+    expect(onAck).not.toHaveBeenCalled();
+
+    tracker.handleAck("batch-1", peer.id);
+
+    expect(onAck).toHaveBeenCalledTimes(1);
+  });
+
+  test("invokes callback only once even if peer closes after ack", () => {
+    const tracker = new StorageReconciliationAckTracker();
+    const peer = createPeerState("peer-1");
+    const onAck = vi.fn();
+
+    tracker.trackBatch("batch-1", peer.id, 50);
+    tracker.waitForAck("batch-1", peer, onAck);
+    tracker.handleAck("batch-1", peer.id);
+    peer.gracefulShutdown();
+
+    expect(onAck).toHaveBeenCalledTimes(1);
+  });
+
+  test("invokes all listeners registered for a batch", () => {
+    const tracker = new StorageReconciliationAckTracker();
+    const peer = createPeerState("peer-1");
+    const first = vi.fn();
+    const second = vi.fn();
+
+    tracker.trackBatch("batch-1", peer.id, 50);
+    tracker.waitForAck("batch-1", peer, first);
+    tracker.waitForAck("batch-1", peer, second);
+    tracker.handleAck("batch-1", peer.id);
+
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+
+  test("calls callback immediately when batch is not pending", () => {
+    const tracker = new StorageReconciliationAckTracker();
+    const peer = createPeerState("peer-1");
+    const onAck = vi.fn();
+
+    tracker.waitForAck("missing-batch", peer, onAck);
+
+    expect(onAck).toHaveBeenCalledTimes(1);
+  });
+
+  test("aborts wait on peer close and clears pending ack", () => {
+    const tracker = new StorageReconciliationAckTracker();
+    const peer = createPeerState("peer-1");
+    const onAck = vi.fn();
+
+    tracker.trackBatch("batch-1", peer.id, 50);
+    tracker.waitForAck("batch-1", peer, onAck);
+
+    peer.gracefulShutdown();
+
+    expect(onAck).not.toHaveBeenCalled();
+    expect(tracker.pendingReconciliationAck.has("batch-1#peer-1")).toBe(false);
+  });
+});


### PR DESCRIPTION
- Introduced `StorageReconciliationAckTracker` class to track pending reconciliation acknowledgments and manage callbacks.
- Adjusted message priority for reconciliation actions in `PriorityBasedMessageQueue`.
- Removed hasUnsentMessages, replaced with the reconcile message being low priority
- Added unit tests for `StorageReconciliationAckTracker` to ensure correct functionality.