### PR TITLE
Add jazz-react package with minimal React bindings

### DIFF
--- a/examples/todo-client-localfirst-react/index.html
+++ b/examples/todo-client-localfirst-react/index.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Todo App - Jazz React Client</title>
+    <style>
+      body {
+        font-family: system-ui;
+        max-width: 600px;
+        margin: 2rem auto;
+        padding: 0 1rem;
+      }
+      .done {
+        text-decoration: line-through;
+        opacity: 0.6;
+      }
+      li {
+        padding: 0.5rem 0;
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+      }
+      .delete-btn {
+        margin-left: auto;
+        cursor: pointer;
+      }
+      small {
+        color: #666;
+      }
+      form {
+        margin-bottom: 1rem;
+        display: flex;
+        gap: 0.5rem;
+      }
+      input[type="text"] {
+        flex: 1;
+        padding: 0.5rem;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/examples/todo-client-localfirst-react/package.json
+++ b/examples/todo-client-localfirst-react/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "todo-client-localfirst-react",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "jazz-ts build --jazz-bin ../../target/debug/jazz && vite build",
+    "preview": "vite preview",
+    "test": "vitest run --config vitest.config.browser.ts"
+  },
+  "dependencies": {
+    "jazz-react": "workspace:*",
+    "jazz-ts": "workspace:*",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "@vitejs/plugin-react": "^4.0.0",
+    "@vitest/browser": "^1.6.1",
+    "playwright": "^1.58.2",
+    "typescript": "^5.8.0",
+    "vite": "^6.0.0",
+    "vite-plugin-top-level-await": "^1.6.0",
+    "vite-plugin-wasm": "^3.5.0",
+    "vitest": "^1.0.0"
+  }
+}

--- a/examples/todo-client-localfirst-react/schema/app.ts
+++ b/examples/todo-client-localfirst-react/schema/app.ts
@@ -1,0 +1,123 @@
+// AUTO-GENERATED FILE - DO NOT EDIT
+import type { WasmSchema, QueryBuilder } from "jazz-ts";
+
+export interface Todo {
+  id: string;
+  title: string;
+  done: boolean;
+  description?: string;
+}
+
+export interface TodoInit {
+  title: string;
+  done: boolean;
+  description?: string;
+}
+
+export interface TodoWhereInput {
+  id?: string | { eq?: string; ne?: string; in?: string[] };
+  title?: string | { eq?: string; ne?: string; contains?: string };
+  done?: boolean;
+  description?: string | { eq?: string; ne?: string; contains?: string };
+}
+
+export const wasmSchema: WasmSchema = {
+  tables: {
+    todos: {
+      columns: [
+        {
+          name: "title",
+          column_type: {
+            type: "Text",
+          },
+          nullable: false,
+        },
+        {
+          name: "done",
+          column_type: {
+            type: "Boolean",
+          },
+          nullable: false,
+        },
+        {
+          name: "description",
+          column_type: {
+            type: "Text",
+          },
+          nullable: true,
+        },
+      ],
+    },
+  },
+};
+
+export class TodoQueryBuilder<I extends Record<string, never> = {}> implements QueryBuilder<Todo> {
+  readonly _table = "todos";
+  readonly _schema: WasmSchema = wasmSchema;
+  private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
+  private _includes: Partial<Record<string, never>> = {};
+  private _orderBys: Array<[string, "asc" | "desc"]> = [];
+  private _limitVal?: number;
+  private _offsetVal?: number;
+
+  where(conditions: TodoWhereInput): TodoQueryBuilder<I> {
+    const clone = this._clone();
+    for (const [key, value] of Object.entries(conditions)) {
+      if (value === undefined) continue;
+      if (typeof value === "object" && value !== null && !Array.isArray(value)) {
+        for (const [op, opValue] of Object.entries(value)) {
+          if (opValue !== undefined) {
+            clone._conditions.push({ column: key, op, value: opValue });
+          }
+        }
+      } else {
+        clone._conditions.push({ column: key, op: "eq", value });
+      }
+    }
+    return clone;
+  }
+
+  orderBy(column: keyof Todo, direction: "asc" | "desc" = "asc"): TodoQueryBuilder<I> {
+    const clone = this._clone();
+    clone._orderBys.push([column as string, direction]);
+    return clone;
+  }
+
+  limit(n: number): TodoQueryBuilder<I> {
+    const clone = this._clone();
+    clone._limitVal = n;
+    return clone;
+  }
+
+  offset(n: number): TodoQueryBuilder<I> {
+    const clone = this._clone();
+    clone._offsetVal = n;
+    return clone;
+  }
+
+  _build(): string {
+    return JSON.stringify({
+      table: this._table,
+      conditions: this._conditions,
+      includes: this._includes,
+      orderBy: this._orderBys,
+      limit: this._limitVal,
+      offset: this._offsetVal,
+    });
+  }
+
+  private _clone(): TodoQueryBuilder<I> {
+    const clone = new TodoQueryBuilder<I>();
+    clone._conditions = [...this._conditions];
+    clone._includes = { ...this._includes };
+    clone._orderBys = [...this._orderBys];
+    clone._limitVal = this._limitVal;
+    clone._offsetVal = this._offsetVal;
+    return clone;
+  }
+}
+
+export const app = {
+  todos: new TodoQueryBuilder(),
+  wasmSchema,
+};

--- a/examples/todo-client-localfirst-react/schema/app.ts
+++ b/examples/todo-client-localfirst-react/schema/app.ts
@@ -54,6 +54,8 @@ export const wasmSchema: WasmSchema = {
 export class TodoQueryBuilder<I extends Record<string, never> = {}> implements QueryBuilder<Todo> {
   readonly _table = "todos";
   readonly _schema: WasmSchema = wasmSchema;
+  declare readonly _rowType: Todo;
+  declare readonly _initType: TodoInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<Record<string, never>> = {};
   private _orderBys: Array<[string, "asc" | "desc"]> = [];

--- a/examples/todo-client-localfirst-react/schema/current.sql
+++ b/examples/todo-client-localfirst-react/schema/current.sql
@@ -1,0 +1,5 @@
+CREATE TABLE todos (
+    title TEXT NOT NULL,
+    done BOOLEAN NOT NULL,
+    description TEXT
+);

--- a/examples/todo-client-localfirst-react/schema/current.ts
+++ b/examples/todo-client-localfirst-react/schema/current.ts
@@ -1,0 +1,7 @@
+import { table, col } from "jazz-ts";
+
+table("todos", {
+  title: col.string(),
+  done: col.boolean(),
+  description: col.string().optional(),
+});

--- a/examples/todo-client-localfirst-react/schema/schema_v1_311995e9a178.sql
+++ b/examples/todo-client-localfirst-react/schema/schema_v1_311995e9a178.sql
@@ -1,0 +1,5 @@
+CREATE TABLE todos (
+    title TEXT NOT NULL,
+    done BOOLEAN NOT NULL,
+    description TEXT
+);

--- a/examples/todo-client-localfirst-react/src/App.tsx
+++ b/examples/todo-client-localfirst-react/src/App.tsx
@@ -1,11 +1,11 @@
-import { JazzProvider } from "jazz-react";
+import { JazzProvider, type JazzProviderProps } from "jazz-react";
 import { TodoList } from "./TodoList.js";
 
-export function App() {
+export function App({ config, fallback }: Partial<JazzProviderProps> = {}) {
   return (
     <JazzProvider
-      config={{ appId: "todo-react-example", env: "dev", userBranch: "main" }}
-      fallback={<p>Loading...</p>}
+      config={config ?? { appId: "todo-react-example", env: "dev", userBranch: "main" }}
+      fallback={fallback ?? <p>Loading...</p>}
     >
       <h1>Todos</h1>
       <TodoList />

--- a/examples/todo-client-localfirst-react/src/App.tsx
+++ b/examples/todo-client-localfirst-react/src/App.tsx
@@ -1,0 +1,14 @@
+import { JazzProvider } from "jazz-react";
+import { TodoList } from "./TodoList.js";
+
+export function App() {
+  return (
+    <JazzProvider
+      config={{ appId: "todo-react-example", env: "dev", userBranch: "main" }}
+      fallback={<p>Loading...</p>}
+    >
+      <h1>Todos</h1>
+      <TodoList />
+    </JazzProvider>
+  );
+}

--- a/examples/todo-client-localfirst-react/src/TodoList.tsx
+++ b/examples/todo-client-localfirst-react/src/TodoList.tsx
@@ -1,0 +1,56 @@
+import { useState } from "react";
+import { useDb, useAll } from "jazz-react";
+import { app, type Todo } from "../schema/app.js";
+
+export function TodoList() {
+  const db = useDb();
+  const todos = useAll<Todo>(app.todos);
+  const [title, setTitle] = useState("");
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!title.trim()) return;
+    db.insert(app.todos, { title: title.trim(), done: false });
+    setTitle("");
+  };
+
+  const handleToggle = (todo: Todo) => {
+    db.update(app.todos, todo.id, { done: !todo.done });
+  };
+
+  const handleDelete = (id: string) => {
+    db.deleteFrom(app.todos, id);
+  };
+
+  return (
+    <>
+      <form onSubmit={handleSubmit}>
+        <input
+          type="text"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="What needs to be done?"
+          required
+        />
+        <button type="submit">Add</button>
+      </form>
+      <ul id="todo-list">
+        {todos.map((todo) => (
+          <li key={todo.id} className={todo.done ? "done" : ""}>
+            <input
+              type="checkbox"
+              checked={todo.done}
+              onChange={() => handleToggle(todo)}
+              className="toggle"
+            />
+            <span>{todo.title}</span>
+            {todo.description && <small>{todo.description}</small>}
+            <button className="delete-btn" onClick={() => handleDelete(todo.id)}>
+              &times;
+            </button>
+          </li>
+        ))}
+      </ul>
+    </>
+  );
+}

--- a/examples/todo-client-localfirst-react/src/TodoList.tsx
+++ b/examples/todo-client-localfirst-react/src/TodoList.tsx
@@ -1,10 +1,10 @@
 import { useState } from "react";
 import { useDb, useAll } from "jazz-react";
-import { app, type Todo } from "../schema/app.js";
+import { app } from "../schema/app.js";
 
 export function TodoList() {
   const db = useDb();
-  const todos = useAll<Todo>(app.todos);
+  const todos = useAll(app.todos);
   const [title, setTitle] = useState("");
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -12,14 +12,6 @@ export function TodoList() {
     if (!title.trim()) return;
     db.insert(app.todos, { title: title.trim(), done: false });
     setTitle("");
-  };
-
-  const handleToggle = (todo: Todo) => {
-    db.update(app.todos, todo.id, { done: !todo.done });
-  };
-
-  const handleDelete = (id: string) => {
-    db.deleteFrom(app.todos, id);
   };
 
   return (
@@ -40,12 +32,12 @@ export function TodoList() {
             <input
               type="checkbox"
               checked={todo.done}
-              onChange={() => handleToggle(todo)}
+              onChange={() => db.update(app.todos, todo.id, { done: !todo.done })}
               className="toggle"
             />
             <span>{todo.title}</span>
             {todo.description && <small>{todo.description}</small>}
-            <button className="delete-btn" onClick={() => handleDelete(todo.id)}>
+            <button className="delete-btn" onClick={() => db.deleteFrom(app.todos, todo.id)}>
               &times;
             </button>
           </li>

--- a/examples/todo-client-localfirst-react/src/main.tsx
+++ b/examples/todo-client-localfirst-react/src/main.tsx
@@ -1,0 +1,4 @@
+import { createRoot } from "react-dom/client";
+import { App } from "./App.js";
+
+createRoot(document.getElementById("root")!).render(<App />);

--- a/examples/todo-client-localfirst-react/tests/browser/global-setup.ts
+++ b/examples/todo-client-localfirst-react/tests/browser/global-setup.ts
@@ -1,0 +1,76 @@
+/**
+ * Global setup for browser tests — spawns a real jazz-cli server.
+ */
+
+import { spawn, type ChildProcess } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { TEST_PORT, JWT_SECRET, ADMIN_SECRET, APP_ID } from "./test-constants.js";
+
+export { TEST_PORT, JWT_SECRET, ADMIN_SECRET, APP_ID };
+
+let serverProcess: ChildProcess | null = null;
+let dataDir: string | null = null;
+
+async function waitForHealth(port: number): Promise<void> {
+  const url = `http://127.0.0.1:${port}/health`;
+  for (let i = 0; i < 100; i++) {
+    try {
+      const resp = await fetch(url);
+      if (resp.ok) return;
+    } catch {
+      // Server not ready yet
+    }
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  throw new Error(`Server failed to become ready on port ${port} within 10 seconds`);
+}
+
+export async function setup(): Promise<void> {
+  dataDir = mkdtempSync(join(tmpdir(), "jazz-react-test-"));
+
+  const jazzBinary = join(import.meta.dirname ?? __dirname, "../../../../target/debug/jazz");
+
+  serverProcess = spawn(
+    jazzBinary,
+    ["server", APP_ID, "--port", TEST_PORT.toString(), "--data-dir", dataDir],
+    {
+      env: {
+        ...process.env,
+        JAZZ_JWT_SECRET: JWT_SECRET,
+        JAZZ_ADMIN_SECRET: ADMIN_SECRET,
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+
+  serverProcess.stdout?.on("data", (data: Buffer) => {
+    process.stdout.write(`[jazz-server] ${data}`);
+  });
+  serverProcess.stderr?.on("data", (data: Buffer) => {
+    process.stderr.write(`[jazz-server] ${data}`);
+  });
+
+  await waitForHealth(TEST_PORT);
+}
+
+export async function teardown(): Promise<void> {
+  if (serverProcess) {
+    serverProcess.kill("SIGTERM");
+    await new Promise<void>((resolve) => {
+      serverProcess?.on("exit", () => resolve());
+      setTimeout(resolve, 2000);
+    });
+    serverProcess = null;
+  }
+
+  if (dataDir) {
+    try {
+      rmSync(dataDir, { recursive: true, force: true });
+    } catch {
+      // Best effort cleanup
+    }
+    dataDir = null;
+  }
+}

--- a/examples/todo-client-localfirst-react/tests/browser/test-constants.ts
+++ b/examples/todo-client-localfirst-react/tests/browser/test-constants.ts
@@ -1,0 +1,5 @@
+/** Shared constants for browser tests — no Node.js imports. */
+export const TEST_PORT = 19877;
+export const JWT_SECRET = "test-jwt-secret-for-react-browser-tests";
+export const ADMIN_SECRET = "test-admin-secret-for-react-browser-tests";
+export const APP_ID = "00000000-0000-0000-0000-000000000002";

--- a/examples/todo-client-localfirst-react/tests/browser/todo-app.test.tsx
+++ b/examples/todo-client-localfirst-react/tests/browser/todo-app.test.tsx
@@ -8,44 +8,8 @@
 import { describe, it, expect, afterEach } from "vitest";
 import { createRoot, type Root } from "react-dom/client";
 import { act } from "react";
-import { createDb, type QueryBuilder, type TableProxy } from "jazz-ts";
-import type { WasmSchema } from "jazz-ts";
 import { App } from "../../src/App.js";
 import { TEST_PORT, JWT_SECRET, ADMIN_SECRET, APP_ID } from "./test-constants.js";
-
-// ---------------------------------------------------------------------------
-// Schema helpers — for OPFS/server tests that operate outside React
-// ---------------------------------------------------------------------------
-
-const schema: WasmSchema = {
-  tables: {
-    todos: {
-      columns: [
-        { name: "title", column_type: { type: "Text" }, nullable: false },
-        { name: "done", column_type: { type: "Boolean" }, nullable: false },
-      ],
-    },
-  },
-};
-
-interface Todo {
-  id: string;
-  title: string;
-  done: boolean;
-}
-
-interface TodoInit {
-  title: string;
-  done: boolean;
-}
-
-const todos: TableProxy<Todo, TodoInit> = { _table: "todos", _schema: schema };
-
-const allTodos: QueryBuilder<Todo> = {
-  _table: "todos",
-  _schema: schema,
-  _build: () => JSON.stringify({ table: "todos", conditions: [], includes: {}, orderBy: [] }),
-};
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -99,18 +63,23 @@ function typeInto(input: HTMLInputElement, value: string) {
 // ---------------------------------------------------------------------------
 
 describe("React Todo App E2E", () => {
-  let root: Root | null = null;
-  let container: HTMLDivElement | null = null;
+  const mounts: Array<{ root: Root; container: HTMLDivElement }> = [];
 
-  /** Mount the real App with a unique dbName. Returns the container element. */
-  async function mountApp(dbName: string): Promise<HTMLDivElement> {
+  /** Mount the real App. Returns the container element. */
+  async function mountApp(config: {
+    appId?: string;
+    dbName?: string;
+    serverUrl?: string;
+    jwtToken?: string;
+    adminSecret?: string;
+  }): Promise<HTMLDivElement> {
     const el = document.createElement("div");
     document.body.appendChild(el);
-    container = el;
+    const r = createRoot(el);
+    mounts.push({ root: r, container: el });
 
     await act(async () => {
-      root = createRoot(el);
-      root.render(<App config={{ appId: "test-app", dbName }} />);
+      r.render(<App config={{ appId: config.appId ?? "test-app", ...config }} />);
     });
 
     // Wait for JazzProvider to initialize and TodoList to render
@@ -123,16 +92,28 @@ describe("React Todo App E2E", () => {
     return el;
   }
 
+  /** Unmount a specific app instance (triggers JazzProvider shutdown). */
+  async function unmountApp(el: HTMLDivElement): Promise<void> {
+    const idx = mounts.findIndex((m) => m.container === el);
+    if (idx === -1) return;
+    const { root } = mounts[idx];
+    await act(async () => root.unmount());
+    el.remove();
+    mounts.splice(idx, 1);
+    // Give OPFS handles time to release
+    await new Promise((r) => setTimeout(r, 200));
+  }
+
   afterEach(async () => {
-    if (root) {
-      // Unmounting triggers JazzProvider cleanup (db.shutdown)
-      await act(async () => root!.unmount());
-      root = null;
-    }
-    if (container) {
+    for (const { root, container } of mounts) {
+      try {
+        await act(async () => root.unmount());
+      } catch {
+        /* best effort */
+      }
       container.remove();
-      container = null;
     }
+    mounts.length = 0;
   });
 
   // -------------------------------------------------------------------------
@@ -140,7 +121,7 @@ describe("React Todo App E2E", () => {
   // -------------------------------------------------------------------------
 
   it("renders the app with an empty todo list", async () => {
-    const el = await mountApp(uniqueDbName("empty"));
+    const el = await mountApp({ dbName: uniqueDbName("empty") });
 
     expect(el.querySelector("h1")!.textContent).toBe("Todos");
     expect(el.querySelector("#todo-list")).toBeTruthy();
@@ -152,7 +133,7 @@ describe("React Todo App E2E", () => {
   // -------------------------------------------------------------------------
 
   it("adds a todo via the form", async () => {
-    const el = await mountApp(uniqueDbName("add"));
+    const el = await mountApp({ dbName: uniqueDbName("add") });
 
     const input = el.querySelector<HTMLInputElement>("input[type='text']")!;
     const form = input.closest("form")!;
@@ -178,7 +159,7 @@ describe("React Todo App E2E", () => {
   // -------------------------------------------------------------------------
 
   it("toggles a todo's done state via checkbox", async () => {
-    const el = await mountApp(uniqueDbName("toggle"));
+    const el = await mountApp({ dbName: uniqueDbName("toggle") });
 
     // Add a todo first
     const input = el.querySelector<HTMLInputElement>("input[type='text']")!;
@@ -213,7 +194,7 @@ describe("React Todo App E2E", () => {
   // -------------------------------------------------------------------------
 
   it("deletes a todo via the delete button", async () => {
-    const el = await mountApp(uniqueDbName("delete"));
+    const el = await mountApp({ dbName: uniqueDbName("delete") });
 
     // Add a todo
     const input = el.querySelector<HTMLInputElement>("input[type='text']")!;
@@ -245,7 +226,7 @@ describe("React Todo App E2E", () => {
   // -------------------------------------------------------------------------
 
   it("renders multiple todos with correct state", async () => {
-    const el = await mountApp(uniqueDbName("multi"));
+    const el = await mountApp({ dbName: uniqueDbName("multi") });
 
     const input = el.querySelector<HTMLInputElement>("input[type='text']")!;
     const form = input.closest("form")!;
@@ -272,46 +253,87 @@ describe("React Todo App E2E", () => {
   // 6. OPFS persistence across reload
   // -------------------------------------------------------------------------
 
-  it("persists data across shutdown and re-create (OPFS)", async () => {
+  it("persists todos across app unmount and remount (OPFS)", async () => {
     const dbName = uniqueDbName("opfs");
 
-    // First session: insert via raw Db
-    const db1 = await createDb({ appId: "test-app", dbName });
-    db1.insert(todos, { title: "Survive reload", done: true });
-    expect((await db1.all(allTodos)).length).toBe(1);
-    await db1.shutdown();
+    // First session: mount app, add a todo via the form
+    const el1 = await mountApp({ dbName });
+    const input1 = el1.querySelector<HTMLInputElement>("input[type='text']")!;
+    const form1 = input1.closest("form")!;
 
-    // Second session: mount the real app with same dbName, query at worker tier
-    const db2 = await createDb({ appId: "test-app", dbName });
-    const after = await db2.all(allTodos, "worker");
-    expect(after.length).toBe(1);
-    expect(after[0].title).toBe("Survive reload");
-    expect(after[0].done).toBe(true);
-    await db2.shutdown();
+    await act(async () => {
+      typeInto(input1, "Survive reload");
+      form1.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+    });
+
+    await waitFor(
+      () => el1.querySelectorAll("#todo-list li").length === 1,
+      3000,
+      "Todo should appear in first session",
+    );
+
+    // Unmount (triggers db.shutdown, flushes OPFS)
+    await unmountApp(el1);
+
+    // Second session: remount with same dbName — OPFS data should load
+    const el2 = await mountApp({ dbName });
+
+    await waitFor(
+      () => el2.querySelectorAll("#todo-list li").length === 1,
+      5000,
+      "Todo should survive remount from OPFS",
+    );
+
+    expect(el2.querySelector("#todo-list li span")!.textContent).toBe("Survive reload");
   });
 
   // -------------------------------------------------------------------------
-  // 7. Server sync
+  // 7. Server sync between two app instances
   // -------------------------------------------------------------------------
 
-  it("syncs data through the server", async () => {
+  it("syncs a todo between two app instances through the server", async () => {
     const serverUrl = `http://127.0.0.1:${TEST_PORT}`;
-    const token = await signJwt("react-user-a", JWT_SECRET);
+    const token1 = await signJwt("react-user-a", JWT_SECRET);
+    const token2 = await signJwt("react-user-b", JWT_SECRET);
 
-    const db1 = await createDb({
+    // Mount two independent app instances connected to the same server
+    const el1 = await mountApp({
       appId: APP_ID,
-      dbName: uniqueDbName("sync"),
+      dbName: uniqueDbName("sync-a"),
       serverUrl,
-      jwtToken: token,
+      jwtToken: token1,
+      adminSecret: ADMIN_SECRET,
+    });
+    const el2 = await mountApp({
+      appId: APP_ID,
+      dbName: uniqueDbName("sync-b"),
+      serverUrl,
+      jwtToken: token2,
       adminSecret: ADMIN_SECRET,
     });
 
-    const id = await db1.insertPersisted(todos, { title: "Server-synced", done: false }, "edge");
-    expect(id).toBeTruthy();
+    // Add a todo in app 1 via the form
+    const input1 = el1.querySelector<HTMLInputElement>("input[type='text']")!;
+    const form1 = input1.closest("form")!;
 
-    const results = await db1.all(allTodos, "edge");
-    expect(results.length).toBeGreaterThanOrEqual(1);
-    expect(results[0].title).toBe("Server-synced");
-    await db1.shutdown();
+    await act(async () => {
+      typeInto(input1, "Synced todo");
+      form1.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+    });
+
+    await waitFor(
+      () => el1.querySelectorAll("#todo-list li").length === 1,
+      3000,
+      "Todo should appear in app 1",
+    );
+
+    // Wait for it to appear in app 2 via server sync
+    await waitFor(
+      () => el2.querySelectorAll("#todo-list li").length === 1,
+      10000,
+      "Todo should sync to app 2 through the server",
+    );
+
+    expect(el2.querySelector("#todo-list li span")!.textContent).toBe("Synced todo");
   });
 });

--- a/examples/todo-client-localfirst-react/tests/browser/todo-app.test.tsx
+++ b/examples/todo-client-localfirst-react/tests/browser/todo-app.test.tsx
@@ -1,21 +1,20 @@
 /**
  * E2E browser tests for the React todo app.
  *
- * Renders real React components in a Chromium browser via @vitest/browser + playwright.
- * Uses real groove-wasm, real Workers, real OPFS.
+ * Mounts the real <App /> component in a Chromium browser via @vitest/browser + playwright.
+ * Interacts through the actual DOM the app renders — no test-only components.
  */
 
-import { useState } from "react";
 import { describe, it, expect, afterEach } from "vitest";
 import { createRoot, type Root } from "react-dom/client";
 import { act } from "react";
-import { createDb, Db, type QueryBuilder, type TableProxy } from "jazz-ts";
+import { createDb, type QueryBuilder, type TableProxy } from "jazz-ts";
 import type { WasmSchema } from "jazz-ts";
-import { JazzProvider, useDb, useAll } from "jazz-react";
+import { App } from "../../src/App.js";
 import { TEST_PORT, JWT_SECRET, ADMIN_SECRET, APP_ID } from "./test-constants.js";
 
 // ---------------------------------------------------------------------------
-// Test schema — inline to avoid depending on codegen in tests
+// Schema helpers — for OPFS/server tests that operate outside React
 // ---------------------------------------------------------------------------
 
 const schema: WasmSchema = {
@@ -40,22 +39,12 @@ interface TodoInit {
   done: boolean;
 }
 
-const todos: TableProxy<Todo, TodoInit> = {
-  _table: "todos",
-  _schema: schema,
-};
+const todos: TableProxy<Todo, TodoInit> = { _table: "todos", _schema: schema };
 
 const allTodos: QueryBuilder<Todo> = {
   _table: "todos",
   _schema: schema,
-  _build() {
-    return JSON.stringify({
-      table: "todos",
-      conditions: [],
-      includes: {},
-      orderBy: [],
-    });
-  },
+  _build: () => JSON.stringify({ table: "todos", conditions: [], includes: {}, orderBy: [] }),
 };
 
 // ---------------------------------------------------------------------------
@@ -66,11 +55,7 @@ function uniqueDbName(label: string): string {
   return `test-${label}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 }
 
-async function waitForCondition(
-  check: () => boolean,
-  timeoutMs: number,
-  message: string,
-): Promise<void> {
+async function waitFor(check: () => boolean, timeoutMs: number, message: string): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     if (check()) return;
@@ -102,35 +87,11 @@ async function signJwt(sub: string, secret: string): Promise<string> {
   return `${headerB64}.${payloadB64}.${base64url(new Uint8Array(sig))}`;
 }
 
-// ---------------------------------------------------------------------------
-// React test components
-// ---------------------------------------------------------------------------
-
-/** Renders a todo list using useAll + useDb. */
-function TestTodoList() {
-  const db = useDb();
-  const items = useAll<Todo>(allTodos);
-
-  return (
-    <div>
-      <ul data-testid="todo-list">
-        {items.map((todo) => (
-          <li key={todo.id} data-testid={`todo-${todo.id}`} className={todo.done ? "done" : ""}>
-            <input
-              type="checkbox"
-              checked={todo.done}
-              onChange={() => db.update(todos, todo.id, { done: !todo.done })}
-              data-testid={`toggle-${todo.id}`}
-            />
-            <span data-testid={`title-${todo.id}`}>{todo.title}</span>
-            <button data-testid={`delete-${todo.id}`} onClick={() => db.deleteFrom(todos, todo.id)}>
-              Delete
-            </button>
-          </li>
-        ))}
-      </ul>
-    </div>
-  );
+/** Type into an input controlled by React (triggers React's onChange). */
+function typeInto(input: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value")!.set!;
+  setter.call(input, value);
+  input.dispatchEvent(new Event("input", { bubbles: true }));
 }
 
 // ---------------------------------------------------------------------------
@@ -138,225 +99,110 @@ function TestTodoList() {
 // ---------------------------------------------------------------------------
 
 describe("React Todo App E2E", () => {
-  const dbs: Db[] = [];
   let root: Root | null = null;
   let container: HTMLDivElement | null = null;
 
-  function track(db: Db): Db {
-    dbs.push(db);
-    return db;
-  }
-
-  function mountContainer(): HTMLDivElement {
+  /** Mount the real App with a unique dbName. Returns the container element. */
+  async function mountApp(dbName: string): Promise<HTMLDivElement> {
     const el = document.createElement("div");
     document.body.appendChild(el);
     container = el;
+
+    await act(async () => {
+      root = createRoot(el);
+      root.render(<App config={{ appId: "test-app", dbName }} />);
+    });
+
+    // Wait for JazzProvider to initialize and TodoList to render
+    await waitFor(
+      () => el.querySelector("#todo-list") !== null,
+      5000,
+      "App should render the todo list",
+    );
+
     return el;
   }
 
   afterEach(async () => {
     if (root) {
-      root.unmount();
+      // Unmounting triggers JazzProvider cleanup (db.shutdown)
+      await act(async () => root!.unmount());
       root = null;
     }
     if (container) {
       container.remove();
       container = null;
     }
-    for (const db of dbs) {
-      try {
-        await db.shutdown();
-      } catch {
-        // Best effort
-      }
-    }
-    dbs.length = 0;
   });
 
   // -------------------------------------------------------------------------
-  // 1. Render todos from subscription
+  // 1. App renders with empty list
   // -------------------------------------------------------------------------
 
-  it("renders todos inserted via db.insert()", async () => {
-    const db = track(await createDb({ appId: "test-app", dbName: uniqueDbName("render") }));
+  it("renders the app with an empty todo list", async () => {
+    const el = await mountApp(uniqueDbName("empty"));
 
-    // Insert before rendering — useAll fires synchronously on subscribe
-    db.insert(todos, { title: "Buy milk", done: false });
-    db.insert(todos, { title: "Walk dog", done: true });
-
-    const el = mountContainer();
-    await act(async () => {
-      root = createRoot(el);
-      root.render(
-        <JazzProvider config={{ appId: "test-app", dbName: db["config"].dbName }}>
-          <TestTodoList />
-        </JazzProvider>,
-      );
-    });
-
-    // JazzProvider creates its own Db — we need to wait for it to initialize
-    // and for useAll to pick up the data. But since we used a different db
-    // for inserts, the provider's db won't have the data.
-    // Instead: render with an already-created db by using context directly.
-    root!.unmount();
-
-    // Simpler approach: insert after the component mounts
-    await act(async () => {
-      root = createRoot(el);
-      root.render(
-        <JazzProvider config={{ appId: "test-app", dbName: uniqueDbName("render2") }}>
-          <TestTodoList />
-        </JazzProvider>,
-      );
-    });
-
-    // Wait for provider to initialize
-    await waitForCondition(
-      () => el.querySelector("[data-testid='todo-list']") !== null,
-      5000,
-      "Todo list should render",
-    );
-
-    // The list should be empty initially (fresh db)
-    expect(el.querySelectorAll("li").length).toBe(0);
+    expect(el.querySelector("h1")!.textContent).toBe("Todos");
+    expect(el.querySelector("#todo-list")).toBeTruthy();
+    expect(el.querySelectorAll("#todo-list li").length).toBe(0);
   });
 
   // -------------------------------------------------------------------------
-  // 2. Insert triggers re-render
+  // 2. Add todo via form
   // -------------------------------------------------------------------------
 
-  it("re-renders when items are inserted via useDb", async () => {
-    const dbName = uniqueDbName("insert-rerender");
-    const el = mountContainer();
+  it("adds a todo via the form", async () => {
+    const el = await mountApp(uniqueDbName("add"));
 
-    // Component that exposes insert via a button
-    function TestApp() {
-      return (
-        <JazzProvider config={{ appId: "test-app", dbName }}>
-          <InsertAndList />
-        </JazzProvider>
-      );
-    }
-
-    function InsertAndList() {
-      const db = useDb();
-      const items = useAll<Todo>(allTodos);
-      return (
-        <div>
-          <button
-            data-testid="add-btn"
-            onClick={() => db.insert(todos, { title: "New todo", done: false })}
-          >
-            Add
-          </button>
-          <ul data-testid="list">
-            {items.map((t) => (
-              <li key={t.id} data-testid={`item-${t.id}`}>
-                {t.title}
-              </li>
-            ))}
-          </ul>
-        </div>
-      );
-    }
+    const input = el.querySelector<HTMLInputElement>("input[type='text']")!;
+    const form = input.closest("form")!;
 
     await act(async () => {
-      root = createRoot(el);
-      root.render(<TestApp />);
+      typeInto(input, "Buy milk");
+      form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
     });
 
-    // Wait for provider
-    await waitForCondition(
-      () => el.querySelector("[data-testid='list']") !== null,
-      5000,
-      "List should render",
-    );
-
-    expect(el.querySelectorAll("li").length).toBe(0);
-
-    // Click add button
-    await act(async () => {
-      el.querySelector<HTMLButtonElement>("[data-testid='add-btn']")!.click();
-    });
-
-    await waitForCondition(
-      () => el.querySelectorAll("li").length === 1,
+    await waitFor(
+      () => el.querySelectorAll("#todo-list li").length === 1,
       3000,
-      "Should have 1 todo after insert",
+      "Todo should appear after form submit",
     );
 
-    expect(el.querySelector("li")!.textContent).toContain("New todo");
+    const li = el.querySelector("#todo-list li")!;
+    expect(li.querySelector("span")!.textContent).toBe("Buy milk");
+    expect(li.classList.contains("done")).toBe(false);
   });
 
   // -------------------------------------------------------------------------
   // 3. Toggle todo
   // -------------------------------------------------------------------------
 
-  it("toggles todo done state on checkbox click", async () => {
-    const dbName = uniqueDbName("toggle");
-    const el = mountContainer();
+  it("toggles a todo's done state via checkbox", async () => {
+    const el = await mountApp(uniqueDbName("toggle"));
 
-    function TestApp() {
-      return (
-        <JazzProvider config={{ appId: "test-app", dbName }}>
-          <InsertThenList />
-        </JazzProvider>
-      );
-    }
-
-    let dbRef: Db | null = null;
-
-    function InsertThenList() {
-      const db = useDb();
-      dbRef = db;
-      const items = useAll<Todo>(allTodos);
-      return (
-        <ul>
-          {items.map((t) => (
-            <li key={t.id} className={t.done ? "done" : ""}>
-              <input
-                type="checkbox"
-                checked={t.done}
-                onChange={() => db.update(todos, t.id, { done: !t.done })}
-                data-testid={`toggle-${t.id}`}
-              />
-              <span data-testid={`title-${t.id}`}>{t.title}</span>
-            </li>
-          ))}
-        </ul>
-      );
-    }
-
+    // Add a todo first
+    const input = el.querySelector<HTMLInputElement>("input[type='text']")!;
+    const form = input.closest("form")!;
     await act(async () => {
-      root = createRoot(el);
-      root.render(<TestApp />);
+      typeInto(input, "Toggle me");
+      form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
     });
 
-    // Wait for provider
-    await waitForCondition(() => dbRef !== null, 5000, "Db should initialize");
-
-    // Insert a todo
-    await act(async () => {
-      dbRef!.insert(todos, { title: "Toggle me", done: false });
-    });
-
-    await waitForCondition(
-      () => el.querySelectorAll("li").length === 1,
+    await waitFor(
+      () => el.querySelectorAll("#todo-list li").length === 1,
       3000,
-      "Should have 1 todo",
+      "Todo should appear",
     );
 
-    const li = el.querySelector("li")!;
-    expect(li.className).toBe("");
+    const li = el.querySelector("#todo-list li")!;
+    expect(li.classList.contains("done")).toBe(false);
 
-    // Toggle
-    const checkbox = el.querySelector<HTMLInputElement>("input[type='checkbox']")!;
-    await act(async () => {
-      checkbox.click();
-    });
+    // Click the checkbox
+    const checkbox = li.querySelector<HTMLInputElement>("input.toggle")!;
+    await act(async () => checkbox.click());
 
-    await waitForCondition(
-      () => el.querySelector("li")!.className === "done",
+    await waitFor(
+      () => el.querySelector("#todo-list li")!.classList.contains("done"),
       3000,
       "Todo should be marked done",
     );
@@ -366,153 +212,60 @@ describe("React Todo App E2E", () => {
   // 4. Delete todo
   // -------------------------------------------------------------------------
 
-  it("removes todo from list on delete", async () => {
-    const dbName = uniqueDbName("delete");
-    const el = mountContainer();
-    let dbRef: Db | null = null;
+  it("deletes a todo via the delete button", async () => {
+    const el = await mountApp(uniqueDbName("delete"));
 
-    function TestApp() {
-      return (
-        <JazzProvider config={{ appId: "test-app", dbName }}>
-          <DeleteList />
-        </JazzProvider>
-      );
-    }
-
-    function DeleteList() {
-      const db = useDb();
-      dbRef = db;
-      const items = useAll<Todo>(allTodos);
-      return (
-        <ul>
-          {items.map((t) => (
-            <li key={t.id}>
-              <span>{t.title}</span>
-              <button data-testid={`del-${t.id}`} onClick={() => db.deleteFrom(todos, t.id)}>
-                X
-              </button>
-            </li>
-          ))}
-        </ul>
-      );
-    }
-
+    // Add a todo
+    const input = el.querySelector<HTMLInputElement>("input[type='text']")!;
+    const form = input.closest("form")!;
     await act(async () => {
-      root = createRoot(el);
-      root.render(<TestApp />);
+      typeInto(input, "Delete me");
+      form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
     });
 
-    await waitForCondition(() => dbRef !== null, 5000, "Db should initialize");
-
-    await act(async () => {
-      dbRef!.insert(todos, { title: "Delete me", done: false });
-    });
-
-    await waitForCondition(
-      () => el.querySelectorAll("li").length === 1,
+    await waitFor(
+      () => el.querySelectorAll("#todo-list li").length === 1,
       3000,
-      "Should have 1 todo",
+      "Todo should appear",
     );
 
-    // Delete
-    const deleteBtn = el.querySelector<HTMLButtonElement>("button")!;
-    await act(async () => {
-      deleteBtn.click();
-    });
+    // Click the delete button
+    const deleteBtn = el.querySelector<HTMLButtonElement>(".delete-btn")!;
+    await act(async () => deleteBtn.click());
 
-    await waitForCondition(
-      () => el.querySelectorAll("li").length === 0,
+    await waitFor(
+      () => el.querySelectorAll("#todo-list li").length === 0,
       3000,
       "Todo should be removed",
     );
   });
 
   // -------------------------------------------------------------------------
-  // 5. Add todo via form
+  // 5. Multiple todos render correctly
   // -------------------------------------------------------------------------
 
-  it("adds todo via form submission", async () => {
-    const dbName = uniqueDbName("form");
-    const el = mountContainer();
+  it("renders multiple todos with correct state", async () => {
+    const el = await mountApp(uniqueDbName("multi"));
 
-    function TestApp() {
-      return (
-        <JazzProvider config={{ appId: "test-app", dbName }}>
-          <FormAndList />
-        </JazzProvider>
-      );
+    const input = el.querySelector<HTMLInputElement>("input[type='text']")!;
+    const form = input.closest("form")!;
+
+    // Add three todos
+    for (const title of ["First", "Second", "Third"]) {
+      await act(async () => {
+        typeInto(input, title);
+        form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+      });
     }
 
-    function FormAndList() {
-      const db = useDb();
-      const items = useAll<Todo>(allTodos);
-      const [title, setTitle] = useState("");
-
-      return (
-        <div>
-          <form
-            data-testid="add-form"
-            onSubmit={(e) => {
-              e.preventDefault();
-              if (!title.trim()) return;
-              db.insert(todos, { title: title.trim(), done: false });
-              setTitle("");
-            }}
-          >
-            <input
-              data-testid="title-input"
-              value={title}
-              onChange={(e) => setTitle(e.target.value)}
-            />
-            <button type="submit" data-testid="submit-btn">
-              Add
-            </button>
-          </form>
-          <ul data-testid="list">
-            {items.map((t) => (
-              <li key={t.id}>{t.title}</li>
-            ))}
-          </ul>
-        </div>
-      );
-    }
-
-    await act(async () => {
-      root = createRoot(el);
-      root.render(<TestApp />);
-    });
-
-    await waitForCondition(
-      () => el.querySelector("[data-testid='list']") !== null,
-      5000,
-      "Form should render",
-    );
-
-    // Type into input and submit
-    const input = el.querySelector<HTMLInputElement>("[data-testid='title-input']")!;
-    const form = el.querySelector<HTMLFormElement>("[data-testid='add-form']")!;
-
-    await act(async () => {
-      // Simulate typing
-      const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
-        window.HTMLInputElement.prototype,
-        "value",
-      )!.set!;
-      nativeInputValueSetter.call(input, "From form");
-      input.dispatchEvent(new Event("input", { bubbles: true }));
-    });
-
-    await act(async () => {
-      form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
-    });
-
-    await waitForCondition(
-      () => el.querySelectorAll("li").length === 1,
+    await waitFor(
+      () => el.querySelectorAll("#todo-list li").length === 3,
       3000,
-      "Should have 1 todo from form",
+      "Should have 3 todos",
     );
 
-    expect(el.querySelector("li")!.textContent).toContain("From form");
+    const titles = [...el.querySelectorAll("#todo-list li span")].map((s) => s.textContent);
+    expect(titles.sort()).toEqual(["First", "Second", "Third"]);
   });
 
   // -------------------------------------------------------------------------
@@ -520,40 +273,38 @@ describe("React Todo App E2E", () => {
   // -------------------------------------------------------------------------
 
   it("persists data across shutdown and re-create (OPFS)", async () => {
-    const dbName = uniqueDbName("opfs-react");
+    const dbName = uniqueDbName("opfs");
 
-    // First session: insert data
+    // First session: insert via raw Db
     const db1 = await createDb({ appId: "test-app", dbName });
     db1.insert(todos, { title: "Survive reload", done: true });
-    const before = await db1.all(allTodos);
-    expect(before.length).toBe(1);
+    expect((await db1.all(allTodos)).length).toBe(1);
     await db1.shutdown();
 
-    // Second session: verify data survived via worker tier
-    const db2 = track(await createDb({ appId: "test-app", dbName }));
+    // Second session: mount the real app with same dbName, query at worker tier
+    const db2 = await createDb({ appId: "test-app", dbName });
     const after = await db2.all(allTodos, "worker");
     expect(after.length).toBe(1);
     expect(after[0].title).toBe("Survive reload");
     expect(after[0].done).toBe(true);
+    await db2.shutdown();
   });
 
   // -------------------------------------------------------------------------
   // 7. Server sync
   // -------------------------------------------------------------------------
 
-  it("syncs data between two clients through the server", async () => {
+  it("syncs data through the server", async () => {
     const serverUrl = `http://127.0.0.1:${TEST_PORT}`;
-    const token1 = await signJwt("react-user-a", JWT_SECRET);
+    const token = await signJwt("react-user-a", JWT_SECRET);
 
-    const db1 = track(
-      await createDb({
-        appId: APP_ID,
-        dbName: uniqueDbName("react-sync-a"),
-        serverUrl,
-        jwtToken: token1,
-        adminSecret: ADMIN_SECRET,
-      }),
-    );
+    const db1 = await createDb({
+      appId: APP_ID,
+      dbName: uniqueDbName("sync"),
+      serverUrl,
+      jwtToken: token,
+      adminSecret: ADMIN_SECRET,
+    });
 
     const id = await db1.insertPersisted(todos, { title: "Server-synced", done: false }, "edge");
     expect(id).toBeTruthy();
@@ -561,5 +312,6 @@ describe("React Todo App E2E", () => {
     const results = await db1.all(allTodos, "edge");
     expect(results.length).toBeGreaterThanOrEqual(1);
     expect(results[0].title).toBe("Server-synced");
+    await db1.shutdown();
   });
 });

--- a/examples/todo-client-localfirst-react/tests/browser/todo-app.test.tsx
+++ b/examples/todo-client-localfirst-react/tests/browser/todo-app.test.tsx
@@ -1,0 +1,565 @@
+/**
+ * E2E browser tests for the React todo app.
+ *
+ * Renders real React components in a Chromium browser via @vitest/browser + playwright.
+ * Uses real groove-wasm, real Workers, real OPFS.
+ */
+
+import { useState } from "react";
+import { describe, it, expect, afterEach } from "vitest";
+import { createRoot, type Root } from "react-dom/client";
+import { act } from "react";
+import { createDb, Db, type QueryBuilder, type TableProxy } from "jazz-ts";
+import type { WasmSchema } from "jazz-ts";
+import { JazzProvider, useDb, useAll } from "jazz-react";
+import { TEST_PORT, JWT_SECRET, ADMIN_SECRET, APP_ID } from "./test-constants.js";
+
+// ---------------------------------------------------------------------------
+// Test schema — inline to avoid depending on codegen in tests
+// ---------------------------------------------------------------------------
+
+const schema: WasmSchema = {
+  tables: {
+    todos: {
+      columns: [
+        { name: "title", column_type: { type: "Text" }, nullable: false },
+        { name: "done", column_type: { type: "Boolean" }, nullable: false },
+      ],
+    },
+  },
+};
+
+interface Todo {
+  id: string;
+  title: string;
+  done: boolean;
+}
+
+interface TodoInit {
+  title: string;
+  done: boolean;
+}
+
+const todos: TableProxy<Todo, TodoInit> = {
+  _table: "todos",
+  _schema: schema,
+};
+
+const allTodos: QueryBuilder<Todo> = {
+  _table: "todos",
+  _schema: schema,
+  _build() {
+    return JSON.stringify({
+      table: "todos",
+      conditions: [],
+      includes: {},
+      orderBy: [],
+    });
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function uniqueDbName(label: string): string {
+  return `test-${label}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+async function waitForCondition(
+  check: () => boolean,
+  timeoutMs: number,
+  message: string,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (check()) return;
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  throw new Error(`Timeout: ${message}`);
+}
+
+function base64url(input: string | Uint8Array): string {
+  const str = typeof input === "string" ? btoa(input) : btoa(String.fromCharCode(...input));
+  return str.replace(/=/g, "").replace(/\+/g, "-").replace(/\//g, "_");
+}
+
+async function signJwt(sub: string, secret: string): Promise<string> {
+  const header = { alg: "HS256", typ: "JWT" };
+  const payload = { sub, claims: {}, exp: Math.floor(Date.now() / 1000) + 3600 };
+  const enc = new TextEncoder();
+  const headerB64 = base64url(JSON.stringify(header));
+  const payloadB64 = base64url(JSON.stringify(payload));
+  const data = enc.encode(`${headerB64}.${payloadB64}`);
+  const key = await crypto.subtle.importKey(
+    "raw",
+    enc.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const sig = await crypto.subtle.sign("HMAC", key, data);
+  return `${headerB64}.${payloadB64}.${base64url(new Uint8Array(sig))}`;
+}
+
+// ---------------------------------------------------------------------------
+// React test components
+// ---------------------------------------------------------------------------
+
+/** Renders a todo list using useAll + useDb. */
+function TestTodoList() {
+  const db = useDb();
+  const items = useAll<Todo>(allTodos);
+
+  return (
+    <div>
+      <ul data-testid="todo-list">
+        {items.map((todo) => (
+          <li key={todo.id} data-testid={`todo-${todo.id}`} className={todo.done ? "done" : ""}>
+            <input
+              type="checkbox"
+              checked={todo.done}
+              onChange={() => db.update(todos, todo.id, { done: !todo.done })}
+              data-testid={`toggle-${todo.id}`}
+            />
+            <span data-testid={`title-${todo.id}`}>{todo.title}</span>
+            <button data-testid={`delete-${todo.id}`} onClick={() => db.deleteFrom(todos, todo.id)}>
+              Delete
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("React Todo App E2E", () => {
+  const dbs: Db[] = [];
+  let root: Root | null = null;
+  let container: HTMLDivElement | null = null;
+
+  function track(db: Db): Db {
+    dbs.push(db);
+    return db;
+  }
+
+  function mountContainer(): HTMLDivElement {
+    const el = document.createElement("div");
+    document.body.appendChild(el);
+    container = el;
+    return el;
+  }
+
+  afterEach(async () => {
+    if (root) {
+      root.unmount();
+      root = null;
+    }
+    if (container) {
+      container.remove();
+      container = null;
+    }
+    for (const db of dbs) {
+      try {
+        await db.shutdown();
+      } catch {
+        // Best effort
+      }
+    }
+    dbs.length = 0;
+  });
+
+  // -------------------------------------------------------------------------
+  // 1. Render todos from subscription
+  // -------------------------------------------------------------------------
+
+  it("renders todos inserted via db.insert()", async () => {
+    const db = track(await createDb({ appId: "test-app", dbName: uniqueDbName("render") }));
+
+    // Insert before rendering — useAll fires synchronously on subscribe
+    db.insert(todos, { title: "Buy milk", done: false });
+    db.insert(todos, { title: "Walk dog", done: true });
+
+    const el = mountContainer();
+    await act(async () => {
+      root = createRoot(el);
+      root.render(
+        <JazzProvider config={{ appId: "test-app", dbName: db["config"].dbName }}>
+          <TestTodoList />
+        </JazzProvider>,
+      );
+    });
+
+    // JazzProvider creates its own Db — we need to wait for it to initialize
+    // and for useAll to pick up the data. But since we used a different db
+    // for inserts, the provider's db won't have the data.
+    // Instead: render with an already-created db by using context directly.
+    root!.unmount();
+
+    // Simpler approach: insert after the component mounts
+    await act(async () => {
+      root = createRoot(el);
+      root.render(
+        <JazzProvider config={{ appId: "test-app", dbName: uniqueDbName("render2") }}>
+          <TestTodoList />
+        </JazzProvider>,
+      );
+    });
+
+    // Wait for provider to initialize
+    await waitForCondition(
+      () => el.querySelector("[data-testid='todo-list']") !== null,
+      5000,
+      "Todo list should render",
+    );
+
+    // The list should be empty initially (fresh db)
+    expect(el.querySelectorAll("li").length).toBe(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // 2. Insert triggers re-render
+  // -------------------------------------------------------------------------
+
+  it("re-renders when items are inserted via useDb", async () => {
+    const dbName = uniqueDbName("insert-rerender");
+    const el = mountContainer();
+
+    // Component that exposes insert via a button
+    function TestApp() {
+      return (
+        <JazzProvider config={{ appId: "test-app", dbName }}>
+          <InsertAndList />
+        </JazzProvider>
+      );
+    }
+
+    function InsertAndList() {
+      const db = useDb();
+      const items = useAll<Todo>(allTodos);
+      return (
+        <div>
+          <button
+            data-testid="add-btn"
+            onClick={() => db.insert(todos, { title: "New todo", done: false })}
+          >
+            Add
+          </button>
+          <ul data-testid="list">
+            {items.map((t) => (
+              <li key={t.id} data-testid={`item-${t.id}`}>
+                {t.title}
+              </li>
+            ))}
+          </ul>
+        </div>
+      );
+    }
+
+    await act(async () => {
+      root = createRoot(el);
+      root.render(<TestApp />);
+    });
+
+    // Wait for provider
+    await waitForCondition(
+      () => el.querySelector("[data-testid='list']") !== null,
+      5000,
+      "List should render",
+    );
+
+    expect(el.querySelectorAll("li").length).toBe(0);
+
+    // Click add button
+    await act(async () => {
+      el.querySelector<HTMLButtonElement>("[data-testid='add-btn']")!.click();
+    });
+
+    await waitForCondition(
+      () => el.querySelectorAll("li").length === 1,
+      3000,
+      "Should have 1 todo after insert",
+    );
+
+    expect(el.querySelector("li")!.textContent).toContain("New todo");
+  });
+
+  // -------------------------------------------------------------------------
+  // 3. Toggle todo
+  // -------------------------------------------------------------------------
+
+  it("toggles todo done state on checkbox click", async () => {
+    const dbName = uniqueDbName("toggle");
+    const el = mountContainer();
+
+    function TestApp() {
+      return (
+        <JazzProvider config={{ appId: "test-app", dbName }}>
+          <InsertThenList />
+        </JazzProvider>
+      );
+    }
+
+    let dbRef: Db | null = null;
+
+    function InsertThenList() {
+      const db = useDb();
+      dbRef = db;
+      const items = useAll<Todo>(allTodos);
+      return (
+        <ul>
+          {items.map((t) => (
+            <li key={t.id} className={t.done ? "done" : ""}>
+              <input
+                type="checkbox"
+                checked={t.done}
+                onChange={() => db.update(todos, t.id, { done: !t.done })}
+                data-testid={`toggle-${t.id}`}
+              />
+              <span data-testid={`title-${t.id}`}>{t.title}</span>
+            </li>
+          ))}
+        </ul>
+      );
+    }
+
+    await act(async () => {
+      root = createRoot(el);
+      root.render(<TestApp />);
+    });
+
+    // Wait for provider
+    await waitForCondition(() => dbRef !== null, 5000, "Db should initialize");
+
+    // Insert a todo
+    await act(async () => {
+      dbRef!.insert(todos, { title: "Toggle me", done: false });
+    });
+
+    await waitForCondition(
+      () => el.querySelectorAll("li").length === 1,
+      3000,
+      "Should have 1 todo",
+    );
+
+    const li = el.querySelector("li")!;
+    expect(li.className).toBe("");
+
+    // Toggle
+    const checkbox = el.querySelector<HTMLInputElement>("input[type='checkbox']")!;
+    await act(async () => {
+      checkbox.click();
+    });
+
+    await waitForCondition(
+      () => el.querySelector("li")!.className === "done",
+      3000,
+      "Todo should be marked done",
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // 4. Delete todo
+  // -------------------------------------------------------------------------
+
+  it("removes todo from list on delete", async () => {
+    const dbName = uniqueDbName("delete");
+    const el = mountContainer();
+    let dbRef: Db | null = null;
+
+    function TestApp() {
+      return (
+        <JazzProvider config={{ appId: "test-app", dbName }}>
+          <DeleteList />
+        </JazzProvider>
+      );
+    }
+
+    function DeleteList() {
+      const db = useDb();
+      dbRef = db;
+      const items = useAll<Todo>(allTodos);
+      return (
+        <ul>
+          {items.map((t) => (
+            <li key={t.id}>
+              <span>{t.title}</span>
+              <button data-testid={`del-${t.id}`} onClick={() => db.deleteFrom(todos, t.id)}>
+                X
+              </button>
+            </li>
+          ))}
+        </ul>
+      );
+    }
+
+    await act(async () => {
+      root = createRoot(el);
+      root.render(<TestApp />);
+    });
+
+    await waitForCondition(() => dbRef !== null, 5000, "Db should initialize");
+
+    await act(async () => {
+      dbRef!.insert(todos, { title: "Delete me", done: false });
+    });
+
+    await waitForCondition(
+      () => el.querySelectorAll("li").length === 1,
+      3000,
+      "Should have 1 todo",
+    );
+
+    // Delete
+    const deleteBtn = el.querySelector<HTMLButtonElement>("button")!;
+    await act(async () => {
+      deleteBtn.click();
+    });
+
+    await waitForCondition(
+      () => el.querySelectorAll("li").length === 0,
+      3000,
+      "Todo should be removed",
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // 5. Add todo via form
+  // -------------------------------------------------------------------------
+
+  it("adds todo via form submission", async () => {
+    const dbName = uniqueDbName("form");
+    const el = mountContainer();
+
+    function TestApp() {
+      return (
+        <JazzProvider config={{ appId: "test-app", dbName }}>
+          <FormAndList />
+        </JazzProvider>
+      );
+    }
+
+    function FormAndList() {
+      const db = useDb();
+      const items = useAll<Todo>(allTodos);
+      const [title, setTitle] = useState("");
+
+      return (
+        <div>
+          <form
+            data-testid="add-form"
+            onSubmit={(e) => {
+              e.preventDefault();
+              if (!title.trim()) return;
+              db.insert(todos, { title: title.trim(), done: false });
+              setTitle("");
+            }}
+          >
+            <input
+              data-testid="title-input"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+            />
+            <button type="submit" data-testid="submit-btn">
+              Add
+            </button>
+          </form>
+          <ul data-testid="list">
+            {items.map((t) => (
+              <li key={t.id}>{t.title}</li>
+            ))}
+          </ul>
+        </div>
+      );
+    }
+
+    await act(async () => {
+      root = createRoot(el);
+      root.render(<TestApp />);
+    });
+
+    await waitForCondition(
+      () => el.querySelector("[data-testid='list']") !== null,
+      5000,
+      "Form should render",
+    );
+
+    // Type into input and submit
+    const input = el.querySelector<HTMLInputElement>("[data-testid='title-input']")!;
+    const form = el.querySelector<HTMLFormElement>("[data-testid='add-form']")!;
+
+    await act(async () => {
+      // Simulate typing
+      const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
+        window.HTMLInputElement.prototype,
+        "value",
+      )!.set!;
+      nativeInputValueSetter.call(input, "From form");
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+
+    await act(async () => {
+      form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+    });
+
+    await waitForCondition(
+      () => el.querySelectorAll("li").length === 1,
+      3000,
+      "Should have 1 todo from form",
+    );
+
+    expect(el.querySelector("li")!.textContent).toContain("From form");
+  });
+
+  // -------------------------------------------------------------------------
+  // 6. OPFS persistence across reload
+  // -------------------------------------------------------------------------
+
+  it("persists data across shutdown and re-create (OPFS)", async () => {
+    const dbName = uniqueDbName("opfs-react");
+
+    // First session: insert data
+    const db1 = await createDb({ appId: "test-app", dbName });
+    db1.insert(todos, { title: "Survive reload", done: true });
+    const before = await db1.all(allTodos);
+    expect(before.length).toBe(1);
+    await db1.shutdown();
+
+    // Second session: verify data survived via worker tier
+    const db2 = track(await createDb({ appId: "test-app", dbName }));
+    const after = await db2.all(allTodos, "worker");
+    expect(after.length).toBe(1);
+    expect(after[0].title).toBe("Survive reload");
+    expect(after[0].done).toBe(true);
+  });
+
+  // -------------------------------------------------------------------------
+  // 7. Server sync
+  // -------------------------------------------------------------------------
+
+  it("syncs data between two clients through the server", async () => {
+    const serverUrl = `http://127.0.0.1:${TEST_PORT}`;
+    const token1 = await signJwt("react-user-a", JWT_SECRET);
+
+    const db1 = track(
+      await createDb({
+        appId: APP_ID,
+        dbName: uniqueDbName("react-sync-a"),
+        serverUrl,
+        jwtToken: token1,
+        adminSecret: ADMIN_SECRET,
+      }),
+    );
+
+    const id = await db1.insertPersisted(todos, { title: "Server-synced", done: false }, "edge");
+    expect(id).toBeTruthy();
+
+    const results = await db1.all(allTodos, "edge");
+    expect(results.length).toBeGreaterThanOrEqual(1);
+    expect(results[0].title).toBe("Server-synced");
+  });
+});

--- a/examples/todo-client-localfirst-react/tsconfig.json
+++ b/examples/todo-client-localfirst-react/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src", "schema"]
+}

--- a/examples/todo-client-localfirst-react/vite.config.ts
+++ b/examples/todo-client-localfirst-react/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  build: { target: "es2020" },
+  optimizeDeps: {
+    exclude: ["groove-wasm"],
+  },
+});

--- a/examples/todo-client-localfirst-react/vitest.config.browser.ts
+++ b/examples/todo-client-localfirst-react/vitest.config.browser.ts
@@ -1,0 +1,30 @@
+import { defineConfig } from "vitest/config";
+import wasm from "vite-plugin-wasm";
+import topLevelAwait from "vite-plugin-top-level-await";
+import react from "@vitejs/plugin-react";
+import { resolve } from "node:path";
+
+export default defineConfig({
+  plugins: [wasm(), topLevelAwait(), react()],
+  resolve: {
+    alias: {
+      "groove-wasm": resolve(__dirname, "../../crates/groove-wasm/pkg"),
+      "jazz-ts": resolve(__dirname, "../../packages/jazz-ts/src/index.ts"),
+      "jazz-react": resolve(__dirname, "../../packages/jazz-react/src/index.ts"),
+    },
+  },
+  worker: {
+    plugins: () => [wasm(), topLevelAwait()],
+  },
+  test: {
+    browser: {
+      enabled: true,
+      name: "chromium",
+      provider: "playwright",
+      headless: true,
+    },
+    include: ["tests/browser/**/*.test.tsx"],
+    globalSetup: ["tests/browser/global-setup.ts"],
+    testTimeout: 30000,
+  },
+});

--- a/examples/todo-client-localfirst-react/vitest.config.browser.ts
+++ b/examples/todo-client-localfirst-react/vitest.config.browser.ts
@@ -2,17 +2,9 @@ import { defineConfig } from "vitest/config";
 import wasm from "vite-plugin-wasm";
 import topLevelAwait from "vite-plugin-top-level-await";
 import react from "@vitejs/plugin-react";
-import { resolve } from "node:path";
 
 export default defineConfig({
   plugins: [wasm(), topLevelAwait(), react()],
-  resolve: {
-    alias: {
-      "groove-wasm": resolve(__dirname, "../../crates/groove-wasm/pkg"),
-      "jazz-ts": resolve(__dirname, "../../packages/jazz-ts/src/index.ts"),
-      "jazz-react": resolve(__dirname, "../../packages/jazz-react/src/index.ts"),
-    },
-  },
   worker: {
     plugins: () => [wasm(), topLevelAwait()],
   },

--- a/examples/todo-client-localfirst-ts/index.html
+++ b/examples/todo-client-localfirst-ts/index.html
@@ -40,12 +40,10 @@
     </style>
   </head>
   <body>
-    <h1>Todos</h1>
-    <form id="add-form">
-      <input type="text" id="title-input" placeholder="What needs to be done?" required />
-      <button type="submit">Add</button>
-    </form>
-    <ul id="todo-list"></ul>
-    <script type="module" src="/src/main.ts"></script>
+    <div id="app"></div>
+    <script type="module">
+      import { startApp } from "/src/main.ts";
+      startApp(document.getElementById("app"));
+    </script>
   </body>
 </html>

--- a/examples/todo-client-localfirst-ts/package.json
+++ b/examples/todo-client-localfirst-ts/package.json
@@ -6,13 +6,19 @@
   "scripts": {
     "dev": "vite",
     "build": "jazz-ts build --jazz-bin ../../target/debug/jazz && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run --config vitest.config.browser.ts"
   },
   "dependencies": {
     "jazz-ts": "workspace:*"
   },
   "devDependencies": {
+    "@vitest/browser": "^1.6.1",
+    "playwright": "^1.58.2",
     "typescript": "^5.8.0",
-    "vite": "^6.0.0"
+    "vite": "^6.0.0",
+    "vite-plugin-top-level-await": "^1.6.0",
+    "vite-plugin-wasm": "^3.5.0",
+    "vitest": "^1.0.0"
   }
 }

--- a/examples/todo-client-localfirst-ts/package.json
+++ b/examples/todo-client-localfirst-ts/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "jazz-ts build && vite build",
+    "build": "jazz-ts build --jazz-bin ../../target/debug/jazz && vite build",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/examples/todo-client-localfirst-ts/schema/app.ts
+++ b/examples/todo-client-localfirst-ts/schema/app.ts
@@ -54,6 +54,8 @@ export const wasmSchema: WasmSchema = {
 export class TodoQueryBuilder<I extends Record<string, never> = {}> implements QueryBuilder<Todo> {
   readonly _table = "todos";
   readonly _schema: WasmSchema = wasmSchema;
+  declare readonly _rowType: Todo;
+  declare readonly _initType: TodoInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<Record<string, never>> = {};
   private _orderBys: Array<[string, "asc" | "desc"]> = [];

--- a/examples/todo-client-localfirst-ts/schema/schema_v1_311995e9a178.sql
+++ b/examples/todo-client-localfirst-ts/schema/schema_v1_311995e9a178.sql
@@ -1,0 +1,5 @@
+CREATE TABLE todos (
+    title TEXT NOT NULL,
+    done BOOLEAN NOT NULL,
+    description TEXT
+);

--- a/examples/todo-client-localfirst-ts/src/main.ts
+++ b/examples/todo-client-localfirst-ts/src/main.ts
@@ -1,17 +1,42 @@
-import { createDb } from "jazz-ts";
+import { createDb, type DbConfig, type Db } from "jazz-ts";
 import { app, type Todo } from "../schema/app.js";
 
-async function main() {
-  // Create Db (pre-loads WASM, uses in-memory storage)
+export async function startApp(
+  container: HTMLElement,
+  config?: Partial<DbConfig>,
+): Promise<{ db: Db; destroy: () => Promise<void> }> {
   const db = await createDb({
     appId: "todo-client-example",
     env: "dev",
     userBranch: "main",
+    ...config,
   });
+
+  // Build DOM
+  const h1 = document.createElement("h1");
+  h1.textContent = "Todos";
+  container.appendChild(h1);
+
+  const form = document.createElement("form");
+  form.id = "add-form";
+  const input = document.createElement("input");
+  input.type = "text";
+  input.id = "title-input";
+  input.placeholder = "What needs to be done?";
+  input.required = true;
+  const btn = document.createElement("button");
+  btn.type = "submit";
+  btn.textContent = "Add";
+  form.appendChild(input);
+  form.appendChild(btn);
+  container.appendChild(form);
+
+  const list = document.createElement("ul");
+  list.id = "todo-list";
+  container.appendChild(list);
 
   // Render function
   function render(todos: Todo[]) {
-    const list = document.getElementById("todo-list")!;
     list.innerHTML = todos
       .map(
         (t) => `
@@ -31,9 +56,8 @@ async function main() {
   db.subscribeAll<Todo>(app.todos, ({ all }) => render(all));
 
   // Add todo form
-  document.getElementById("add-form")!.addEventListener("submit", (e) => {
+  form.addEventListener("submit", (e) => {
     e.preventDefault();
-    const input = document.getElementById("title-input") as HTMLInputElement;
     db.insert(app.todos, {
       title: input.value,
       done: false,
@@ -42,7 +66,7 @@ async function main() {
   });
 
   // Event delegation for toggle and delete
-  document.getElementById("todo-list")!.addEventListener("click", async (e) => {
+  list.addEventListener("click", async (e) => {
     const target = e.target as HTMLElement;
     const id = target.dataset.id;
     if (!id) return;
@@ -56,6 +80,12 @@ async function main() {
       db.deleteFrom(app.todos, id);
     }
   });
-}
 
-main().catch(console.error);
+  return {
+    db,
+    destroy: async () => {
+      await db.shutdown();
+      container.innerHTML = "";
+    },
+  };
+}

--- a/examples/todo-client-localfirst-ts/src/main.ts
+++ b/examples/todo-client-localfirst-ts/src/main.ts
@@ -1,5 +1,5 @@
 import { createDb, type DbConfig, type Db } from "jazz-ts";
-import { app, type Todo } from "../schema/app.js";
+import { app } from "../schema/app.js";
 
 export async function startApp(
   container: HTMLElement,
@@ -35,9 +35,9 @@ export async function startApp(
   list.id = "todo-list";
   container.appendChild(list);
 
-  // Render function
-  function render(todos: Todo[]) {
-    list.innerHTML = todos
+  // Subscribe to all todos
+  db.subscribeAll(app.todos, ({ all }) => {
+    list.innerHTML = all
       .map(
         (t) => `
       <li class="${t.done ? "done" : ""}">
@@ -50,10 +50,7 @@ export async function startApp(
     `,
       )
       .join("");
-  }
-
-  // Subscribe to all todos
-  db.subscribeAll<Todo>(app.todos, ({ all }) => render(all));
+  });
 
   // Add todo form
   form.addEventListener("submit", (e) => {
@@ -72,7 +69,7 @@ export async function startApp(
     if (!id) return;
 
     if (target.classList.contains("toggle")) {
-      const todo = await db.one<Todo>(app.todos.where({ id }));
+      const todo = await db.one(app.todos.where({ id }));
       if (todo) {
         db.update(app.todos, id, { done: !todo.done });
       }

--- a/examples/todo-client-localfirst-ts/tests/browser/global-setup.ts
+++ b/examples/todo-client-localfirst-ts/tests/browser/global-setup.ts
@@ -1,0 +1,76 @@
+/**
+ * Global setup for browser tests — spawns a real jazz-cli server.
+ */
+
+import { spawn, type ChildProcess } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { TEST_PORT, JWT_SECRET, ADMIN_SECRET, APP_ID } from "./test-constants.js";
+
+export { TEST_PORT, JWT_SECRET, ADMIN_SECRET, APP_ID };
+
+let serverProcess: ChildProcess | null = null;
+let dataDir: string | null = null;
+
+async function waitForHealth(port: number): Promise<void> {
+  const url = `http://127.0.0.1:${port}/health`;
+  for (let i = 0; i < 100; i++) {
+    try {
+      const resp = await fetch(url);
+      if (resp.ok) return;
+    } catch {
+      // Server not ready yet
+    }
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  throw new Error(`Server failed to become ready on port ${port} within 10 seconds`);
+}
+
+export async function setup(): Promise<void> {
+  dataDir = mkdtempSync(join(tmpdir(), "jazz-ts-test-"));
+
+  const jazzBinary = join(import.meta.dirname ?? __dirname, "../../../../target/debug/jazz");
+
+  serverProcess = spawn(
+    jazzBinary,
+    ["server", APP_ID, "--port", TEST_PORT.toString(), "--data-dir", dataDir],
+    {
+      env: {
+        ...process.env,
+        JAZZ_JWT_SECRET: JWT_SECRET,
+        JAZZ_ADMIN_SECRET: ADMIN_SECRET,
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+
+  serverProcess.stdout?.on("data", (data: Buffer) => {
+    process.stdout.write(`[jazz-server] ${data}`);
+  });
+  serverProcess.stderr?.on("data", (data: Buffer) => {
+    process.stderr.write(`[jazz-server] ${data}`);
+  });
+
+  await waitForHealth(TEST_PORT);
+}
+
+export async function teardown(): Promise<void> {
+  if (serverProcess) {
+    serverProcess.kill("SIGTERM");
+    await new Promise<void>((resolve) => {
+      serverProcess?.on("exit", () => resolve());
+      setTimeout(resolve, 2000);
+    });
+    serverProcess = null;
+  }
+
+  if (dataDir) {
+    try {
+      rmSync(dataDir, { recursive: true, force: true });
+    } catch {
+      // Best effort cleanup
+    }
+    dataDir = null;
+  }
+}

--- a/examples/todo-client-localfirst-ts/tests/browser/test-constants.ts
+++ b/examples/todo-client-localfirst-ts/tests/browser/test-constants.ts
@@ -1,0 +1,5 @@
+/** Shared constants for browser tests — no Node.js imports. */
+export const TEST_PORT = 19878;
+export const JWT_SECRET = "test-jwt-secret-for-ts-browser-tests";
+export const ADMIN_SECRET = "test-admin-secret-for-ts-browser-tests";
+export const APP_ID = "00000000-0000-0000-0000-000000000003";

--- a/examples/todo-client-localfirst-ts/tests/browser/todo-app.test.ts
+++ b/examples/todo-client-localfirst-ts/tests/browser/todo-app.test.ts
@@ -1,0 +1,286 @@
+/**
+ * E2E browser tests for the vanilla TS todo app.
+ *
+ * Calls startApp() to mount the real app into a container, then interacts
+ * through the actual DOM it produces — form, checkboxes, delete buttons.
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import { startApp } from "../../src/main.js";
+import { TEST_PORT, JWT_SECRET, ADMIN_SECRET, APP_ID } from "./test-constants.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function uniqueDbName(label: string): string {
+  return `test-${label}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+async function waitFor(check: () => boolean, timeoutMs: number, message: string): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (check()) return;
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  throw new Error(`Timeout: ${message}`);
+}
+
+function base64url(input: string | Uint8Array): string {
+  const str = typeof input === "string" ? btoa(input) : btoa(String.fromCharCode(...input));
+  return str.replace(/=/g, "").replace(/\+/g, "-").replace(/\//g, "_");
+}
+
+async function signJwt(sub: string, secret: string): Promise<string> {
+  const header = { alg: "HS256", typ: "JWT" };
+  const payload = { sub, claims: {}, exp: Math.floor(Date.now() / 1000) + 3600 };
+  const enc = new TextEncoder();
+  const headerB64 = base64url(JSON.stringify(header));
+  const payloadB64 = base64url(JSON.stringify(payload));
+  const data = enc.encode(`${headerB64}.${payloadB64}`);
+  const key = await crypto.subtle.importKey(
+    "raw",
+    enc.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const sig = await crypto.subtle.sign("HMAC", key, data);
+  return `${headerB64}.${payloadB64}.${base64url(new Uint8Array(sig))}`;
+}
+
+/** Submit a todo via the app's form. */
+function addTodo(container: HTMLElement, title: string) {
+  const input = container.querySelector<HTMLInputElement>("#title-input")!;
+  const form = container.querySelector<HTMLFormElement>("#add-form")!;
+  input.value = title;
+  form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("Vanilla TS Todo App E2E", () => {
+  const instances: Array<{ container: HTMLDivElement; destroy: () => Promise<void> }> = [];
+
+  /** Mount the app into a fresh container. */
+  async function mount(config?: Record<string, unknown>): Promise<HTMLDivElement> {
+    const el = document.createElement("div");
+    document.body.appendChild(el);
+
+    const { destroy } = await startApp(el, config);
+    instances.push({ container: el, destroy });
+
+    // Wait for the app to render
+    await waitFor(() => el.querySelector("#todo-list") !== null, 5000, "App should render");
+
+    return el;
+  }
+
+  /** Destroy a specific instance. */
+  async function destroyInstance(el: HTMLDivElement): Promise<void> {
+    const idx = instances.findIndex((i) => i.container === el);
+    if (idx === -1) return;
+    await instances[idx].destroy();
+    el.remove();
+    instances.splice(idx, 1);
+    // Give OPFS handles time to release
+    await new Promise((r) => setTimeout(r, 200));
+  }
+
+  afterEach(async () => {
+    for (const { container, destroy } of instances) {
+      try {
+        await destroy();
+      } catch {
+        /* best effort */
+      }
+      container.remove();
+    }
+    instances.length = 0;
+  });
+
+  // -------------------------------------------------------------------------
+  // 1. App renders with empty list
+  // -------------------------------------------------------------------------
+
+  it("renders the app with an empty todo list", async () => {
+    const el = await mount({ dbName: uniqueDbName("empty") });
+
+    expect(el.querySelector("h1")!.textContent).toBe("Todos");
+    expect(el.querySelector("#todo-list")).toBeTruthy();
+    expect(el.querySelectorAll("#todo-list li").length).toBe(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // 2. Add todo via form
+  // -------------------------------------------------------------------------
+
+  it("adds a todo via the form", async () => {
+    const el = await mount({ dbName: uniqueDbName("add") });
+
+    addTodo(el, "Buy milk");
+
+    await waitFor(
+      () => el.querySelectorAll("#todo-list li").length === 1,
+      3000,
+      "Todo should appear after form submit",
+    );
+
+    const li = el.querySelector("#todo-list li")!;
+    expect(li.querySelector("span")!.textContent).toBe("Buy milk");
+    expect(li.classList.contains("done")).toBe(false);
+  });
+
+  // -------------------------------------------------------------------------
+  // 3. Toggle todo
+  // -------------------------------------------------------------------------
+
+  // TODO: fails — the TS app's toggle handler uses db.one(app.todos.where({ id }))
+  // which returns null. The React app avoids this by keeping the todo in scope.
+  it("toggles a todo's done state via checkbox", async () => {
+    const el = await mount({ dbName: uniqueDbName("toggle") });
+
+    addTodo(el, "Toggle me");
+
+    await waitFor(
+      () => el.querySelectorAll("#todo-list li").length === 1,
+      3000,
+      "Todo should appear",
+    );
+
+    const li = el.querySelector("#todo-list li")!;
+    expect(li.classList.contains("done")).toBe(false);
+
+    // Click the checkbox — toggle handler is async (db.one then db.update)
+    const checkbox = li.querySelector<HTMLInputElement>("input.toggle")!;
+    checkbox.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+    await waitFor(
+      () => el.querySelector("#todo-list li")!.classList.contains("done"),
+      5000,
+      "Todo should be marked done",
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // 4. Delete todo
+  // -------------------------------------------------------------------------
+
+  it("deletes a todo via the delete button", async () => {
+    const el = await mount({ dbName: uniqueDbName("delete") });
+
+    addTodo(el, "Delete me");
+
+    await waitFor(
+      () => el.querySelectorAll("#todo-list li").length === 1,
+      3000,
+      "Todo should appear",
+    );
+
+    const deleteBtn = el.querySelector<HTMLButtonElement>(".delete-btn")!;
+    deleteBtn.click();
+
+    await waitFor(
+      () => el.querySelectorAll("#todo-list li").length === 0,
+      3000,
+      "Todo should be removed",
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // 5. Multiple todos
+  // -------------------------------------------------------------------------
+
+  it("renders multiple todos", async () => {
+    const el = await mount({ dbName: uniqueDbName("multi") });
+
+    addTodo(el, "First");
+    addTodo(el, "Second");
+    addTodo(el, "Third");
+
+    await waitFor(
+      () => el.querySelectorAll("#todo-list li").length === 3,
+      3000,
+      "Should have 3 todos",
+    );
+
+    const titles = [...el.querySelectorAll("#todo-list li span")].map((s) => s.textContent);
+    expect(titles.sort()).toEqual(["First", "Second", "Third"]);
+  });
+
+  // -------------------------------------------------------------------------
+  // 6. OPFS persistence across reload
+  // -------------------------------------------------------------------------
+
+  it("persists todos across app destroy and remount (OPFS)", async () => {
+    const dbName = uniqueDbName("opfs");
+
+    // First session: mount, add todo, destroy
+    const el1 = await mount({ dbName });
+    addTodo(el1, "Survive reload");
+
+    await waitFor(
+      () => el1.querySelectorAll("#todo-list li").length === 1,
+      3000,
+      "Todo should appear in first session",
+    );
+
+    await destroyInstance(el1);
+
+    // Second session: remount with same dbName — OPFS data should load
+    const el2 = await mount({ dbName });
+
+    await waitFor(
+      () => el2.querySelectorAll("#todo-list li").length === 1,
+      5000,
+      "Todo should survive remount from OPFS",
+    );
+
+    expect(el2.querySelector("#todo-list li span")!.textContent).toBe("Survive reload");
+  });
+
+  // -------------------------------------------------------------------------
+  // 7. Server sync between two app instances
+  // -------------------------------------------------------------------------
+
+  it("syncs a todo between two app instances through the server", async () => {
+    const serverUrl = `http://127.0.0.1:${TEST_PORT}`;
+    const token1 = await signJwt("ts-user-a", JWT_SECRET);
+    const token2 = await signJwt("ts-user-b", JWT_SECRET);
+
+    const el1 = await mount({
+      appId: APP_ID,
+      dbName: uniqueDbName("sync-a"),
+      serverUrl,
+      jwtToken: token1,
+      adminSecret: ADMIN_SECRET,
+    });
+    const el2 = await mount({
+      appId: APP_ID,
+      dbName: uniqueDbName("sync-b"),
+      serverUrl,
+      jwtToken: token2,
+      adminSecret: ADMIN_SECRET,
+    });
+
+    // Add a todo in app 1
+    addTodo(el1, "Synced todo");
+
+    await waitFor(
+      () => el1.querySelectorAll("#todo-list li").length === 1,
+      3000,
+      "Todo should appear in app 1",
+    );
+
+    // Wait for it to appear in app 2 via server sync
+    await waitFor(
+      () => el2.querySelectorAll("#todo-list li").length === 1,
+      10000,
+      "Todo should sync to app 2 through the server",
+    );
+
+    expect(el2.querySelector("#todo-list li span")!.textContent).toBe("Synced todo");
+  });
+});

--- a/examples/todo-client-localfirst-ts/vitest.config.browser.ts
+++ b/examples/todo-client-localfirst-ts/vitest.config.browser.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from "vitest/config";
+import wasm from "vite-plugin-wasm";
+import topLevelAwait from "vite-plugin-top-level-await";
+
+export default defineConfig({
+  plugins: [wasm(), topLevelAwait()],
+  worker: {
+    plugins: () => [wasm(), topLevelAwait()],
+  },
+  test: {
+    browser: {
+      enabled: true,
+      name: "chromium",
+      provider: "playwright",
+      headless: true,
+    },
+    include: ["tests/browser/**/*.test.ts"],
+    globalSetup: ["tests/browser/global-setup.ts"],
+    testTimeout: 30000,
+  },
+});

--- a/packages/jazz-react/package.json
+++ b/packages/jazz-react/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "jazz-react",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc"
+  },
+  "dependencies": {
+    "jazz-ts": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/react": "^19.0.0",
+    "typescript": "^5.3.0"
+  },
+  "peerDependencies": {
+    "react": "^18 || ^19"
+  }
+}

--- a/packages/jazz-react/src/index.ts
+++ b/packages/jazz-react/src/index.ts
@@ -1,0 +1,2 @@
+export { JazzProvider, useDb, type JazzProviderProps } from "./provider.js";
+export { useAll } from "./use-all.js";

--- a/packages/jazz-react/src/provider.tsx
+++ b/packages/jazz-react/src/provider.tsx
@@ -1,0 +1,44 @@
+import { createContext, useContext, useEffect, useState, type ReactNode } from "react";
+import { createDb, Db, type DbConfig } from "jazz-ts";
+
+export interface JazzProviderProps {
+  config: DbConfig;
+  children: ReactNode;
+  fallback?: ReactNode;
+}
+
+const JazzContext = createContext<Db | null>(null);
+
+export function JazzProvider({ config, children, fallback }: JazzProviderProps) {
+  const [db, setDb] = useState<Db | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    let instance: Db | null = null;
+
+    createDb(config).then((created) => {
+      if (cancelled) {
+        created.shutdown();
+        return;
+      }
+      instance = created;
+      setDb(created);
+    });
+
+    return () => {
+      cancelled = true;
+      if (instance) {
+        instance.shutdown();
+      }
+    };
+  }, []); // config is treated as stable (mount-only)
+
+  if (!db) return <>{fallback ?? null}</>;
+  return <JazzContext.Provider value={db}>{children}</JazzContext.Provider>;
+}
+
+export function useDb(): Db {
+  const db = useContext(JazzContext);
+  if (!db) throw new Error("useDb must be used within <JazzProvider>");
+  return db;
+}

--- a/packages/jazz-react/src/use-all.ts
+++ b/packages/jazz-react/src/use-all.ts
@@ -1,0 +1,36 @@
+import { useMemo, useSyncExternalStore } from "react";
+import type { QueryBuilder, PersistenceTier } from "jazz-ts";
+import { useDb } from "./provider.js";
+
+export function useAll<T extends { id: string }>(query: QueryBuilder<T>): T[];
+export function useAll<T extends { id: string }>(
+  query: QueryBuilder<T>,
+  tier: PersistenceTier,
+): T[] | undefined;
+export function useAll<T extends { id: string }>(
+  query: QueryBuilder<T>,
+  tier?: PersistenceTier,
+): T[] | undefined {
+  const db = useDb();
+  const queryKey = query._build();
+
+  const { subscribe, getSnapshot } = useMemo(() => {
+    let snapshot: T[] | undefined = tier ? undefined : [];
+    return {
+      subscribe: (onStoreChange: () => void) => {
+        return db.subscribeAll(
+          query,
+          (delta) => {
+            snapshot = delta.all;
+            onStoreChange();
+          },
+          tier,
+        );
+      },
+      getSnapshot: () => snapshot,
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [db, queryKey, tier]);
+
+  return useSyncExternalStore(subscribe, getSnapshot);
+}

--- a/packages/jazz-react/tsconfig.json
+++ b/packages/jazz-react/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/jazz-ts/package.json
+++ b/packages/jazz-ts/package.json
@@ -8,7 +8,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && cp src/worker/groove-worker.ts dist/worker/groove-worker.ts",
     "test": "vitest run"
   },
   "dependencies": {

--- a/packages/jazz-ts/src/codegen/codegen.test.ts
+++ b/packages/jazz-ts/src/codegen/codegen.test.ts
@@ -562,6 +562,8 @@ describe("generateQueryBuilderClasses", () => {
     const output = generateTypes(wasm);
 
     expect(output).toContain("export class TodoQueryBuilder<I extends Record<string, never> = {}>");
+    expect(output).toContain("declare readonly _rowType: Todo;");
+    expect(output).toContain("declare readonly _initType: TodoInit;");
     expect(output).toContain("where(conditions: TodoWhereInput)");
     expect(output).toContain("orderBy(column: keyof Todo");
     expect(output).toContain("limit(n: number)");

--- a/packages/jazz-ts/src/codegen/query-builder-generator.ts
+++ b/packages/jazz-ts/src/codegen/query-builder-generator.ts
@@ -91,6 +91,8 @@ function generateQueryBuilderClass(
   );
   lines.push(`  readonly _table = "${tableName}";`);
   lines.push(`  readonly _schema: WasmSchema = wasmSchema;`);
+  lines.push(`  declare readonly _rowType: ${interfaceName};`);
+  lines.push(`  declare readonly _initType: ${interfaceName}Init;`);
   lines.push(`  private _conditions: Array<{ column: string; op: string; value: unknown }> = [];`);
   lines.push(`  private _includes: Partial<${includeConstraint}> = {};`);
   lines.push(`  private _orderBys: Array<[string, "asc" | "desc"]> = [];`);

--- a/packages/jazz-ts/src/runtime/db.ts
+++ b/packages/jazz-ts/src/runtime/db.ts
@@ -44,13 +44,15 @@ export interface DbConfig {
  * Interface that QueryBuilder classes implement.
  * Generated builders expose these internal properties for Db to use.
  */
-export interface QueryBuilder<_T> {
+export interface QueryBuilder<T> {
   /** Table name for this query */
   readonly _table: string;
   /** Schema reference for translation and transformation */
   readonly _schema: WasmSchema;
   /** Build and return the query as JSON */
   _build(): string;
+  /** @internal Phantom brand — enables TypeScript to infer T from usage */
+  readonly _rowType: T;
 }
 
 /**
@@ -60,11 +62,15 @@ export interface QueryBuilder<_T> {
  * @typeParam T - The row type (e.g., `{ id: string; title: string; done: boolean }`)
  * @typeParam Init - The init type for inserts (e.g., `{ title: string; done: boolean }`)
  */
-export interface TableProxy<_T, _Init> {
+export interface TableProxy<T, Init> {
   /** Table name */
   readonly _table: string;
   /** Schema reference */
   readonly _schema: WasmSchema;
+  /** @internal Phantom brand — enables TypeScript to infer T from usage */
+  readonly _rowType: T;
+  /** @internal Phantom brand — enables TypeScript to infer Init from usage */
+  readonly _initType: Init;
 }
 
 /**

--- a/packages/jazz-ts/vitest.config.browser.ts
+++ b/packages/jazz-ts/vitest.config.browser.ts
@@ -7,6 +7,8 @@ export default defineConfig({
   plugins: [wasm(), topLevelAwait()],
   resolve: {
     alias: {
+      // Needed because jazz-ts browser tests import from source (../../src/),
+      // bypassing node_modules resolution. Consumers don't need this.
       "groove-wasm": resolve(__dirname, "../../crates/groove-wasm/pkg"),
     },
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,6 +31,65 @@ importers:
 
   crates/groove-wasm/pkg: {}
 
+  examples/todo-client-localfirst-react:
+    dependencies:
+      jazz-react:
+        specifier: workspace:*
+        version: link:../../packages/jazz-react
+      jazz-ts:
+        specifier: workspace:*
+        version: link:../../packages/jazz-ts
+      react:
+        specifier: ^19.0.0
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.2.4(react@19.2.4)
+    devDependencies:
+      '@types/react':
+        specifier: ^19.0.0
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.0.0
+        version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: ^4.0.0
+        version: 4.7.0(vite@6.4.1(@types/node@20.19.30)(tsx@4.21.0))
+      '@vitest/browser':
+        specifier: ^1.6.1
+        version: 1.6.1(playwright@1.58.2)(vitest@1.6.1)
+      playwright:
+        specifier: ^1.58.2
+        version: 1.58.2
+      typescript:
+        specifier: ^5.8.0
+        version: 5.9.3
+      vite:
+        specifier: ^6.0.0
+        version: 6.4.1(@types/node@20.19.30)(tsx@4.21.0)
+      vite-plugin-top-level-await:
+        specifier: ^1.6.0
+        version: 1.6.0(rollup@4.57.1)(vite@6.4.1(@types/node@20.19.30)(tsx@4.21.0))
+      vite-plugin-wasm:
+        specifier: ^3.5.0
+        version: 3.5.0(vite@6.4.1(@types/node@20.19.30)(tsx@4.21.0))
+      vitest:
+        specifier: ^1.0.0
+        version: 1.6.1(@types/node@20.19.30)(@vitest/browser@1.6.1)
+
+  examples/todo-client-localfirst-ts:
+    dependencies:
+      jazz-ts:
+        specifier: workspace:*
+        version: link:../../packages/jazz-ts
+    devDependencies:
+      typescript:
+        specifier: ^5.8.0
+        version: 5.9.3
+      vite:
+        specifier: ^6.0.0
+        version: 6.4.1(@types/node@20.19.30)(tsx@4.21.0)
+
   examples/todo-server-ts:
     dependencies:
       express:
@@ -59,18 +118,21 @@ importers:
         specifier: ^4.0.18
         version: 4.0.18(@types/node@20.19.30)(tsx@4.21.0)
 
-  examples/todo-ts-client:
+  packages/jazz-react:
     dependencies:
       jazz-ts:
         specifier: workspace:*
-        version: link:../../packages/jazz-ts
+        version: link:../jazz-ts
+      react:
+        specifier: ^18 || ^19
+        version: 19.2.4
     devDependencies:
+      '@types/react':
+        specifier: ^19.0.0
+        version: 19.2.14
       typescript:
-        specifier: ^5.8.0
+        specifier: ^5.3.0
         version: 5.9.3
-      vite:
-        specifier: ^6.0.0
-        version: 6.4.1(@types/node@20.19.30)(tsx@4.21.0)
 
   packages/jazz-ts:
     dependencies:
@@ -110,6 +172,89 @@ importers:
         version: 1.6.1(@types/node@20.19.30)(@vitest/browser@1.6.1)
 
 packages:
+
+  '@babel/code-frame@7.29.0':
+    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/compat-data@7.29.0':
+    resolution: {integrity: sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.29.0':
+    resolution: {integrity: sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.29.1':
+    resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.28.6':
+    resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@7.28.0':
+    resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.28.6':
+    resolution: {integrity: sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.28.6':
+    resolution: {integrity: sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-plugin-utils@7.28.6':
+    resolution: {integrity: sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-option@7.27.1':
+    resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.28.6':
+    resolution: {integrity: sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.0':
+    resolution: {integrity: sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/plugin-transform-react-jsx-self@7.27.1':
+    resolution: {integrity: sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx-source@7.27.1':
+    resolution: {integrity: sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/template@7.28.6':
+    resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.29.0':
+    resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.0':
+    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+    engines: {node: '>=6.9.0'}
 
   '@esbuild/aix-ppc64@0.21.5':
     resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
@@ -565,8 +710,21 @@ packages:
     resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
   '@napi-rs/cli@2.18.4':
     resolution: {integrity: sha512-SgJeA4df9DE2iAEpr3M2H0OKl/yjtg1BnRI5/JyowS71tUWhrfSu2LT0V3vlHET+g1hBVlrO60PmEXwUEKp8Mg==}
@@ -655,6 +813,9 @@ packages:
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
+
+  '@rolldown/pluginutils@1.0.0-beta.27':
+    resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
 
   '@rollup/plugin-virtual@3.0.2':
     resolution: {integrity: sha512-10monEYsBp3scM4/ND4LNH5Rxvh3e/cVeL3jWTgZ2SrQ+BmUoQcopVQvnaMcOnykb1VkxUFuDAN+0FnpTFRy2A==}
@@ -874,6 +1035,18 @@ packages:
   '@swc/wasm@1.15.11':
     resolution: {integrity: sha512-230rdYZf8ux3nIwISOQNCFrxzxpL/UFY4Khv/3UsvpEdo709j/+Tg80yXWW3DXETeZNPBV72QpvEBhXsl7Lc9g==}
 
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+
+  '@types/babel__traverse@7.28.0':
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
   '@types/body-parser@1.19.6':
     resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
 
@@ -910,6 +1083,14 @@ packages:
   '@types/range-parser@1.2.7':
     resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
 
+  '@types/react-dom@19.2.3':
+    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
+    peerDependencies:
+      '@types/react': ^19.2.0
+
+  '@types/react@19.2.14':
+    resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
   '@types/send@0.17.6':
     resolution: {integrity: sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==}
 
@@ -918,6 +1099,12 @@ packages:
 
   '@types/serve-static@1.15.10':
     resolution: {integrity: sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==}
+
+  '@vitejs/plugin-react@4.7.0':
+    resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
   '@vitest/browser@1.6.1':
     resolution: {integrity: sha512-9ZYW6KQ30hJ+rIfJoGH4wAub/KAb4YrFzX0kVLASvTm7nJWVC5EAv5SlzlXVl3h3DaUq5aqHlZl77nmOPnALUQ==}
@@ -1005,12 +1192,21 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  baseline-browser-mapping@2.9.19:
+    resolution: {integrity: sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==}
+    hasBin: true
+
   blake3@2.1.7:
     resolution: {integrity: sha512-5d+TdKJvju96IyEaGJ0eO6CHbckWi+NBrCezGYM/WsnI3R03aLL2TWfsuZSh1rs0fTv/L3ps/r0vykjYurcIwA==}
 
   body-parser@1.20.4:
     resolution: {integrity: sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+
+  browserslist@4.28.1:
+    resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
 
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
@@ -1027,6 +1223,9 @@ packages:
   call-bound@1.0.4:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
+
+  caniuse-lite@1.0.30001769:
+    resolution: {integrity: sha512-BCfFL1sHijQlBGWBMuJyhZUhzo7wer5sVj9hqekB/7xn0Ypy+pER/edCYQm4exbXj4WiySGp40P8UuTh6w1srg==}
 
   chai@4.5.0:
     resolution: {integrity: sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==}
@@ -1050,6 +1249,9 @@ packages:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
 
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
   cookie-signature@1.0.7:
     resolution: {integrity: sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==}
 
@@ -1060,6 +1262,9 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
   debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
@@ -1101,6 +1306,9 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
+  electron-to-chromium@1.5.286:
+    resolution: {integrity: sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==}
+
   encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
@@ -1134,6 +1342,10 @@ packages:
     resolution: {integrity: sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==}
     engines: {node: '>=18'}
     hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
 
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
@@ -1195,6 +1407,10 @@ packages:
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
+
   get-func-name@2.0.2:
     resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
 
@@ -1251,8 +1467,21 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
 
   lefthook-darwin-arm64@2.0.15:
     resolution: {integrity: sha512-ygAqG/NzOgY9bEiqeQtiOmCRTtp9AmOd3eyrpEaSrRB9V9f3RHRgWDrWbde9BiHSsCzcbeY9/X2NuKZ69eUsNA==}
@@ -1315,6 +1544,9 @@ packages:
   loupe@2.3.7:
     resolution: {integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==}
 
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -1374,6 +1606,9 @@ packages:
   negotiator@0.6.3:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
     engines: {node: '>= 0.6'}
+
+  node-releases@2.0.27:
+    resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
 
   npm-run-path@5.3.0:
     resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
@@ -1481,8 +1716,21 @@ packages:
     resolution: {integrity: sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==}
     engines: {node: '>= 0.8'}
 
+  react-dom@19.2.4:
+    resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
+    peerDependencies:
+      react: ^19.2.4
+
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+
+  react-refresh@0.17.0:
+    resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
+    engines: {node: '>=0.10.0'}
+
+  react@19.2.4:
+    resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
+    engines: {node: '>=0.10.0'}
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
@@ -1497,6 +1745,13 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
 
   send@0.19.2:
     resolution: {integrity: sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==}
@@ -1661,6 +1916,12 @@ packages:
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
+
+  update-browserslist-db@1.2.3:
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
 
   utils-merge@1.0.1:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
@@ -1869,11 +2130,126 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
   yocto-queue@1.2.2:
     resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
     engines: {node: '>=12.20'}
 
 snapshots:
+
+  '@babel/code-frame@7.29.0':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.28.5
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/compat-data@7.29.0': {}
+
+  '@babel/core@7.29.0':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-compilation-targets': 7.28.6
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
+      '@babel/helpers': 7.28.6
+      '@babel/parser': 7.29.0
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/generator@7.29.1':
+    dependencies:
+      '@babel/parser': 7.29.0
+      '@babel/types': 7.29.0
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/helper-compilation-targets@7.28.6':
+    dependencies:
+      '@babel/compat-data': 7.29.0
+      '@babel/helper-validator-option': 7.27.1
+      browserslist: 4.28.1
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-globals@7.28.0': {}
+
+  '@babel/helper-module-imports@7.28.6':
+    dependencies:
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/traverse': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-plugin-utils@7.28.6': {}
+
+  '@babel/helper-string-parser@7.27.1': {}
+
+  '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/helper-validator-option@7.27.1': {}
+
+  '@babel/helpers@7.28.6':
+    dependencies:
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
+
+  '@babel/parser@7.29.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/template@7.28.6':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/parser': 7.29.0
+      '@babel/types': 7.29.0
+
+  '@babel/traverse@7.29.0':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-globals': 7.28.0
+      '@babel/parser': 7.29.0
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/types@7.29.0':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
 
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
@@ -2104,7 +2480,24 @@ snapshots:
     dependencies:
       '@sinclair/typebox': 0.27.8
 
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
   '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@napi-rs/cli@2.18.4': {}
 
@@ -2157,6 +2550,8 @@ snapshots:
     optional: true
 
   '@polka/url@1.0.0-next.29': {}
+
+  '@rolldown/pluginutils@1.0.0-beta.27': {}
 
   '@rollup/plugin-virtual@3.0.2(rollup@4.57.1)':
     optionalDependencies:
@@ -2295,6 +2690,27 @@ snapshots:
 
   '@swc/wasm@1.15.11': {}
 
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.29.0
+      '@babel/types': 7.29.0
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.28.0
+
+  '@types/babel__generator@7.27.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.29.0
+      '@babel/types': 7.29.0
+
+  '@types/babel__traverse@7.28.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
   '@types/body-parser@1.19.6':
     dependencies:
       '@types/connect': 3.4.38
@@ -2339,6 +2755,14 @@ snapshots:
 
   '@types/range-parser@1.2.7': {}
 
+  '@types/react-dom@19.2.3(@types/react@19.2.14)':
+    dependencies:
+      '@types/react': 19.2.14
+
+  '@types/react@19.2.14':
+    dependencies:
+      csstype: 3.2.3
+
   '@types/send@0.17.6':
     dependencies:
       '@types/mime': 1.3.5
@@ -2353,6 +2777,18 @@ snapshots:
       '@types/http-errors': 2.0.5
       '@types/node': 20.19.30
       '@types/send': 0.17.6
+
+  '@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@20.19.30)(tsx@4.21.0))':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0)
+      '@rolldown/pluginutils': 1.0.0-beta.27
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.17.0
+      vite: 6.4.1(@types/node@20.19.30)(tsx@4.21.0)
+    transitivePeerDependencies:
+      - supports-color
 
   '@vitest/browser@1.6.1(playwright@1.58.2)(vitest@1.6.1)':
     dependencies:
@@ -2378,13 +2814,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@20.19.30)(tsx@4.21.0))':
+  '@vitest/mocker@4.0.18(vite@6.4.1(@types/node@20.19.30)(tsx@4.21.0))':
     dependencies:
       '@vitest/spy': 4.0.18
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@20.19.30)(tsx@4.21.0)
+      vite: 6.4.1(@types/node@20.19.30)(tsx@4.21.0)
 
   '@vitest/pretty-format@4.0.18':
     dependencies:
@@ -2450,6 +2886,8 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
+  baseline-browser-mapping@2.9.19: {}
+
   blake3@2.1.7: {}
 
   body-parser@1.20.4:
@@ -2469,6 +2907,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  browserslist@4.28.1:
+    dependencies:
+      baseline-browser-mapping: 2.9.19
+      caniuse-lite: 1.0.30001769
+      electron-to-chromium: 1.5.286
+      node-releases: 2.0.27
+      update-browserslist-db: 1.2.3(browserslist@4.28.1)
+
   bytes@3.1.2: {}
 
   cac@6.7.14: {}
@@ -2482,6 +2928,8 @@ snapshots:
     dependencies:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
+
+  caniuse-lite@1.0.30001769: {}
 
   chai@4.5.0:
     dependencies:
@@ -2507,6 +2955,8 @@ snapshots:
 
   content-type@1.0.5: {}
 
+  convert-source-map@2.0.0: {}
+
   cookie-signature@1.0.7: {}
 
   cookie@0.7.2: {}
@@ -2516,6 +2966,8 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  csstype@3.2.3: {}
 
   debug@2.6.9:
     dependencies:
@@ -2542,6 +2994,8 @@ snapshots:
       gopd: 1.2.0
 
   ee-first@1.1.1: {}
+
+  electron-to-chromium@1.5.286: {}
 
   encodeurl@2.0.0: {}
 
@@ -2639,6 +3093,8 @@ snapshots:
       '@esbuild/win32-ia32': 0.27.2
       '@esbuild/win32-x64': 0.27.2
 
+  escalade@3.2.0: {}
+
   escape-html@1.0.3: {}
 
   estree-walker@3.0.3:
@@ -2727,6 +3183,8 @@ snapshots:
 
   function-bind@1.1.2: {}
 
+  gensync@1.0.0-beta.2: {}
+
   get-func-name@2.0.2: {}
 
   get-intrinsic@1.3.0:
@@ -2783,7 +3241,13 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  js-tokens@4.0.0: {}
+
   js-tokens@9.0.1: {}
+
+  jsesc@3.1.0: {}
+
+  json5@2.2.3: {}
 
   lefthook-darwin-arm64@2.0.15:
     optional: true
@@ -2837,6 +3301,10 @@ snapshots:
     dependencies:
       get-func-name: 2.0.2
 
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -2877,6 +3345,8 @@ snapshots:
   nanoid@3.3.11: {}
 
   negotiator@0.6.3: {}
+
+  node-releases@2.0.27: {}
 
   npm-run-path@5.3.0:
     dependencies:
@@ -2984,7 +3454,16 @@ snapshots:
       iconv-lite: 0.4.24
       unpipe: 1.0.0
 
+  react-dom@19.2.4(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      scheduler: 0.27.0
+
   react-is@18.3.1: {}
+
+  react-refresh@0.17.0: {}
+
+  react@19.2.4: {}
 
   resolve-pkg-maps@1.0.0: {}
 
@@ -3022,6 +3501,10 @@ snapshots:
   safe-buffer@5.2.1: {}
 
   safer-buffer@2.1.2: {}
+
+  scheduler@0.27.0: {}
+
+  semver@6.3.1: {}
 
   send@0.19.2:
     dependencies:
@@ -3180,6 +3663,12 @@ snapshots:
 
   unpipe@1.0.0: {}
 
+  update-browserslist-db@1.2.3(browserslist@4.28.1):
+    dependencies:
+      browserslist: 4.28.1
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
   utils-merge@1.0.1: {}
 
   uuid@10.0.0: {}
@@ -3204,6 +3693,17 @@ snapshots:
       - supports-color
       - terser
 
+  vite-plugin-top-level-await@1.6.0(rollup@4.57.1)(vite@6.4.1(@types/node@20.19.30)(tsx@4.21.0)):
+    dependencies:
+      '@rollup/plugin-virtual': 3.0.2(rollup@4.57.1)
+      '@swc/core': 1.15.11
+      '@swc/wasm': 1.15.11
+      uuid: 10.0.0
+      vite: 6.4.1(@types/node@20.19.30)(tsx@4.21.0)
+    transitivePeerDependencies:
+      - '@swc/helpers'
+      - rollup
+
   vite-plugin-top-level-await@1.6.0(rollup@4.57.1)(vite@7.3.1(@types/node@20.19.30)(tsx@4.21.0)):
     dependencies:
       '@rollup/plugin-virtual': 3.0.2(rollup@4.57.1)
@@ -3214,6 +3714,10 @@ snapshots:
     transitivePeerDependencies:
       - '@swc/helpers'
       - rollup
+
+  vite-plugin-wasm@3.5.0(vite@6.4.1(@types/node@20.19.30)(tsx@4.21.0)):
+    dependencies:
+      vite: 6.4.1(@types/node@20.19.30)(tsx@4.21.0)
 
   vite-plugin-wasm@3.5.0(vite@7.3.1(@types/node@20.19.30)(tsx@4.21.0)):
     dependencies:
@@ -3292,7 +3796,7 @@ snapshots:
   vitest@4.0.18(@types/node@20.19.30)(tsx@4.21.0):
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@20.19.30)(tsx@4.21.0))
+      '@vitest/mocker': 4.0.18(vite@6.4.1(@types/node@20.19.30)(tsx@4.21.0))
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18
@@ -3309,7 +3813,7 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.3.1(@types/node@20.19.30)(tsx@4.21.0)
+      vite: 6.4.1(@types/node@20.19.30)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.19.30
@@ -3334,5 +3838,7 @@ snapshots:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  yallist@3.1.1: {}
 
   yocto-queue@1.2.2: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,12 +83,27 @@ importers:
         specifier: workspace:*
         version: link:../../packages/jazz-ts
     devDependencies:
+      '@vitest/browser':
+        specifier: ^1.6.1
+        version: 1.6.1(playwright@1.58.2)(vitest@1.6.1)
+      playwright:
+        specifier: ^1.58.2
+        version: 1.58.2
       typescript:
         specifier: ^5.8.0
         version: 5.9.3
       vite:
         specifier: ^6.0.0
         version: 6.4.1(@types/node@20.19.30)(tsx@4.21.0)
+      vite-plugin-top-level-await:
+        specifier: ^1.6.0
+        version: 1.6.0(rollup@4.57.1)(vite@6.4.1(@types/node@20.19.30)(tsx@4.21.0))
+      vite-plugin-wasm:
+        specifier: ^3.5.0
+        version: 3.5.0(vite@6.4.1(@types/node@20.19.30)(tsx@4.21.0))
+      vitest:
+        specifier: ^1.0.0
+        version: 1.6.1(@types/node@20.19.30)(@vitest/browser@1.6.1)
 
   examples/todo-server-ts:
     dependencies:

--- a/specs/todo/a_week_2026_02_09/jazz_ts_cli_monorepo_fallback.md
+++ b/specs/todo/a_week_2026_02_09/jazz_ts_cli_monorepo_fallback.md
@@ -1,0 +1,14 @@
+# jazz-ts CLI: monorepo-aware jazz binary fallback — TODO
+
+When `jazz-ts build` can't find `jazz` on PATH, it should try `target/debug/jazz` relative to the monorepo root before giving up. This avoids every example needing `--jazz-bin ../../target/debug/jazz` in its build script.
+
+## Behaviour
+
+1. Try `jazzBin` as given (default: `"jazz"`, i.e. PATH lookup)
+2. On ENOENT, walk up from `process.cwd()` looking for a directory that contains both `Cargo.toml` and `target/debug/jazz`
+3. If found, use it and print a note: `Using monorepo jazz binary at <path>`
+4. If not found, print the current warning and continue (versioned schemas skipped)
+
+## Scope
+
+Single change in `packages/jazz-ts/src/cli.ts` (`runJazzBuild` function). No new deps.

--- a/specs/todo/a_week_2026_02_09/minimal_react_bindings.md
+++ b/specs/todo/a_week_2026_02_09/minimal_react_bindings.md
@@ -1,39 +1,122 @@
 # Minimal React Bindings — TODO
 
-Smallest useful React integration: context, hooks, type inference from query builders.
+Smallest useful React integration: context, hook, type inference from query builders.
 
-## Scope
+New package: `packages/jazz-react/`. Depends on `jazz-ts` (workspace), `react` as peerDep. Build with tsc (matches jazz-ts). Entry: `dist/index.js` + `dist/index.d.ts`.
 
-### `<JazzProvider>` / app context
+## API
 
-- Wraps a `Db` instance (already handles worker bridge, OPFS, server sync)
-- Props: `appId`, `serverUrl`, optional config
-- Initializes `Db` on mount, calls `db.shutdown()` on unmount
+### `<JazzProvider>`
 
-### `useDb()`
+```tsx
+const JazzContext = createContext<Db | null>(null);
 
-- Consumes the provider context, returns the `Db` instance
-- Throws if used outside `<JazzProvider>`
+interface JazzProviderProps {
+  config: DbConfig; // pass-through to createDb
+  children: React.ReactNode;
+  fallback?: React.ReactNode; // shown while db initializes
+}
+```
 
-### `useAll(queryBuilder, tier?)`
+- Calls `createDb(config)` on mount, stores `Db` in state
+- Calls `db.shutdown()` on unmount
+- Renders `fallback` (or nothing) until db is ready, then renders `children`
 
-- Wraps `db.subscribeAll(query, tier, callback)`
-- Returns `T[] | undefined` (undefined until first emission)
-- Type `T` inferred from the query builder passed in
-- Unsubscribes on unmount / query identity change
+### `useDb(): Db`
 
-### `useOne(queryBuilder, tier?)`
+- Reads `JazzContext`, throws if null (outside provider or still loading)
 
-- Wraps `db.subscribeOne(query, tier, callback)` (or subscribeAll + take first)
-- Returns `T | undefined`
-- Same type inference and lifecycle as `useAll`
+### `useAll<T>(query, tier?)`
 
-### `todo-client-localfirst-react` example
+Two overloads:
 
-- React port of `examples/todo-client-localfirst-ts`
-- Same schema, same server — just swap vanilla TS DOM code for React + hooks
-- Demonstrates `<JazzProvider>`, `useAll`, `useOne`, and direct `db.update`/`db.insert` calls
-- Lives at `examples/todo-client-localfirst-react/`
+```ts
+function useAll<T extends { id: string }>(query: QueryBuilder<T>): T[];
+function useAll<T extends { id: string }>(
+  query: QueryBuilder<T>,
+  tier: PersistenceTier,
+): T[] | undefined;
+```
+
+**No tier → `T[]` (always defined).** `RuntimeCore.subscribe_impl()` calls `immediate_tick()` synchronously before `subscribeAll()` returns, so the first callback fires in the same call stack. Use `useSyncExternalStore` to wire this: the `subscribe` function calls `db.subscribeAll()`, which synchronously populates the snapshot before React calls `getSnapshot()`.
+
+**With tier → `T[] | undefined`.** `undefined` signals "not yet settled at requested tier." Data arrives asynchronously after the tier confirms.
+
+Query identity: memoize via `query._build()` string — if the user recreates `app.todos.where({ done: false })` every render, the JSON string stays stable. Unsubscribes on unmount or query change.
+
+## Example app: `todo-client-localfirst-react`
+
+React port of `examples/todo-client-localfirst-ts/`. Same schema, same todo CRUD.
+
+### Dependencies
+
+- `jazz-ts`, `jazz-react` (workspace)
+- `react`, `react-dom`
+- devDeps: `@vitejs/plugin-react`, `vite`, `typescript`, `@types/react`, `@types/react-dom`
+
+### Structure
+
+```
+examples/todo-client-localfirst-react/
+  package.json
+  tsconfig.json
+  vite.config.ts        # same as TS example + @vitejs/plugin-react
+  index.html            # <div id="root">, script tag
+  schema/               # copied from todo-client-localfirst-ts
+    current.ts
+    current.sql
+    app.ts
+  src/
+    main.tsx            # createRoot → <App />
+    App.tsx             # <JazzProvider config={...}> wrapping <TodoList />
+    TodoList.tsx        # useAll(app.todos) for list, useDb() for mutations
+```
+
+### Mutations
+
+Direct calls on the `Db` instance (mutations are synchronous):
+
+```tsx
+const db = useDb();
+db.insert(app.todos, { title: "New", done: false });
+db.update(app.todos, id, { done: !todo.done });
+db.deleteFrom(app.todos, id);
+```
+
+## E2E tests
+
+Browser e2e tests in the example app, following the pattern in `packages/jazz-ts/tests/browser/`:
+
+- Vitest browser mode + Playwright chromium (headless)
+- `global-setup.ts` spawns a real jazz CLI server on a test port
+- `vitest.config.browser.ts` with `vite-plugin-wasm` + `vite-plugin-top-level-await`
+
+### Test cases
+
+- **Render todos from subscription**: insert via `db.insert()`, verify the React component renders the item (useAll fires synchronously → immediate DOM update)
+- **Toggle todo**: click checkbox, verify `db.update()` triggers re-render with updated `done` state
+- **Delete todo**: click delete button, verify item removed from DOM
+- **Add todo via form**: submit form, verify new item appears in list
+- **OPFS persistence across reload**: insert, shutdown db, create new db with same `dbName`, verify todos survive (query with `"worker"` tier)
+- **Server sync**: two db instances with JWT tokens syncing through real server, verify insert on one appears on the other
+
+### Structure
+
+```
+examples/todo-client-localfirst-react/
+  tests/
+    browser/
+      global-setup.ts        # spawn jazz server (reuse pattern from jazz-ts)
+      test-constants.ts
+      todo-app.test.ts        # e2e tests against the React app
+  vitest.config.browser.ts
+```
+
+## Verification
+
+- `pnpm build` succeeds
+- Example e2e tests pass: `pnpm --filter todo-client-localfirst-react test`
+- `pnpm --filter todo-client-localfirst-react dev` shows working todo app in browser
 
 ## Non-goals (this week)
 


### PR DESCRIPTION
## Summary

- **`packages/jazz-react/`** — new library: `JazzProvider`, `useDb`, `useAll` (built on `useSyncExternalStore`)
- **`examples/todo-client-localfirst-react/`** — React port of the vanilla TS todo example
- E2E browser tests for both React (7/7 green) and vanilla TS (6/7, toggle test red — known `db.one` bug)
- Phantom brands on `QueryBuilder<T>` and `TableProxy<T, Init>` so generic params are always inferred (no more `useAll<Todo>(app.todos)`)
- Examples consume deps via normal pnpm workspace linking — zero vite aliases needed

## Test plan

- [x] `pnpm --filter jazz-ts test` — 129/129 (includes codegen tests for brands)
- [x] `pnpm --filter todo-client-localfirst-react test` — 7/7 browser tests pass
- [x] `pnpm --filter todo-client-localfirst-ts test` — 6/7 pass (toggle test is a known `db.one` bug, left red intentionally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)