### PR TITLE
docs: meeting 2026-02-12 discussion capture

### DIFF
--- a/specs/concerns.md
+++ b/specs/concerns.md
@@ -52,3 +52,23 @@ Open questions:
 
 - permissions
   - DX around optimistic updates is crucial
+
+
+- re-evaluate other storage backends
+- storage & object manager need benchmarks to de-risk perf
+  - validate full obj snapshots vs delta commits
+- design & define when and how merges happen
+  - intent hard to extract from snapshot diffing?
+    - multi parents?
+  - how often do we commit in real apps?
+    - mostly relevant for real-time text and canvas editing & presence
+
+- new stub: what does minimal CI look like? -> first tests -> Gio
+
+- double check that examples persist IRL
+
+- let frameworks do the patch merging
+  - provide granular runes, signals, etc
+  - explore useReducer vs useSyncExternalStore
+    - transitions, suspense, etc.
+

--- a/specs/todo/a_week_2026_02_09/general_cleanup.md
+++ b/specs/todo/a_week_2026_02_09/general_cleanup.md
@@ -82,7 +82,13 @@ These files are getting unwieldy but don't need immediate action:
 
 Action: either use it to implement the schema hash, or remove the dependency.
 
-## 10. Worker Bridge Error Swallowing (LOW)
+## 10. Examples Lose Data on Reload (MEDIUM)
+
+The example apps (e.g., `todo-client-localfirst-ts`) lose all data when the page reloads, despite browser persistence tests passing. Likely related to the hardcoded-zeros issue in item 3 (schema hash and client ID are all zeros → branch mismatch between sessions, so the new session can't find data written by the old one).
+
+Investigate: does fixing the schema hash / client ID placeholders also fix persistence in the examples?
+
+## 11. Worker Bridge Error Swallowing (LOW)
 
 `db.ts:198–204` catches worker bridge init errors with `console.error` but doesn't propagate them. If the bridge fails to init, subsequent operations will fail with unrelated errors instead of a clear "bridge not initialized" failure.
 

--- a/specs/todo/a_week_2026_02_09/storage_benchmarking_spike.md
+++ b/specs/todo/a_week_2026_02_09/storage_benchmarking_spike.md
@@ -1,0 +1,45 @@
+# Storage Benchmarking Spike — TODO (This Week)
+
+Establish baseline performance numbers for bf-tree and identify whether it's the right long-term storage backend.
+
+## Motivation
+
+We need to de-risk storage before building more on top. Specific concerns:
+
+- bf-tree performance characteristics under realistic workloads are unknown
+- Objects with long commit histories (many snapshots) may blow up storage/memory
+- Memory duplication if similar snapshots are retained in history
+- Alternative backends (fjall, LSM-based) may be better suited
+
+## Benchmarks to Run
+
+### 1. bf-tree baseline
+
+- Write throughput: insert N objects of varying sizes
+- Read throughput: random and sequential object_get
+- Index operations: insert/remove/range scan under load
+- Flush/snapshot timing (native + OPFS)
+
+### 2. Long commit histories
+
+- Create objects with 10, 100, 1000 commits
+- Measure: storage size growth, read latency, snapshot size
+- Check for memory duplication across similar snapshots
+
+### 3. Comparison point
+
+- Run same workloads against fjall (or its underlying LSM tree)
+- Focus on: write amplification, read latency, space efficiency
+- Don't need a full integration — standalone benchmarks are fine
+
+## Expected Output
+
+- Numbers in a markdown table (rough is fine, not publishable)
+- Go/no-go recommendation: keep bf-tree, investigate alternatives, or both
+- Identified bottlenecks to feed into `../b_mvp/benchmarks_and_performance.md`
+
+## Non-Goals
+
+- Publishable benchmarks (that's launch-phase)
+- Full integration of an alternative backend
+- Optimizing bf-tree (first understand, then decide)

--- a/specs/todo/c_launch/granular_reactivity.md
+++ b/specs/todo/c_launch/granular_reactivity.md
@@ -1,0 +1,43 @@
+# Granular Reactivity & Framework Bindings — TODO (Launch)
+
+Design the subscribe/patch system so framework bindings can do fine-grained state updates.
+
+## Problem
+
+Today, query subscriptions emit full result sets. Framework integrations (React, Svelte, Vue, Solid) re-render by diffing the entire array. This works but leaves performance and DX on the table:
+
+- React: `useSyncExternalStore` forces full snapshot comparison. `useReducer` with patches would unlock view transitions, suspense, and concurrent features.
+- Svelte: runes/stores work best with granular signals, not wholesale replacement.
+- Solid: signals are inherently granular — feeding them full snapshots defeats the purpose.
+
+## Design Direction
+
+The core subscribe system should emit **patches** (row inserted, row updated with changed fields, row removed) rather than full snapshots. Each framework binding translates patches into its native reactivity primitive:
+
+- **React**: `useReducer` that applies patches → supports transitions, suspense, startTransition
+- **Svelte**: runes or writable stores updated per-field
+- **Solid**: signals per row/field
+- **Vue**: reactive refs updated granularly
+
+### Patch shape (strawman)
+
+```ts
+type Patch<T> =
+  | { op: "insert"; row: T }
+  | { op: "update"; id: string; fields: Partial<T> }
+  | { op: "delete"; id: string };
+```
+
+## Relationship to Existing Work
+
+- `a_week_2026_02_09/minimal_react_bindings.md` ships first with `useSyncExternalStore` — that's fine for MVP
+- This spec upgrades the plumbing so bindings can be smarter post-MVP
+- The Rust query graph's `Materialize` node already knows which rows changed — the patch info exists, it just isn't surfaced through the subscription API yet
+
+## Open Questions
+
+- Where does patch computation live? Rust (QueryGraph emits patches) vs. TypeScript (diff in the binding)?
+- How do patches interact with the worker bridge? (Today: full result sets over postMessage)
+- Can we keep the simple `T[]` API as sugar on top of the patch stream?
+- Does `useReducer` actually work with external subscription patterns, or does it fight React's ownership model?
+- How to handle initial load (full snapshot) vs. subsequent updates (patches)?


### PR DESCRIPTION
## Summary

Captures discussion points from the Feb 12 meeting into actionable specs:

- **`specs/concerns.md`**: added new points on storage evaluation, merge design, CI, example persistence, and granular reactivity
- **`specs/todo/a_week_2026_02_09/storage_benchmarking_spike.md`** (new): focused spike to benchmark bf-tree, stress-test long commit histories, and compare against fjall/LSM
- **`specs/todo/c_launch/granular_reactivity.md`** (new): patch-based subscribe system for framework bindings — `useReducer` (React), runes (Svelte), signals (Solid)
- **`specs/todo/a_week_2026_02_09/general_cleanup.md`**: added item 10 — examples lose data on reload, likely caused by hardcoded-zeros schema hash / client ID (item 3)

### Not in this PR

- Merge design (snapshots vs deltas, three-way merge, commit frequency) → will go on Guido's PR #44 branch
- CLI fallback → Nico's PR #45
- CI setup → PR #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)