### PR TITLE
investigate: BfTree WASM persistence failure

### DIFF
--- a/crates/groove/src/object_manager/mod.rs
+++ b/crates/groove/src/object_manager/mod.rs
@@ -184,7 +184,17 @@ impl ObjectManager {
         }
 
         // Load metadata
-        let metadata = storage.load_object_metadata(id).ok()??;
+        let metadata = match storage.load_object_metadata(id) {
+            Ok(Some(m)) => m,
+            Ok(None) => {
+                tracing::trace!(%id, "get_or_load: no metadata in storage");
+                return None;
+            }
+            Err(e) => {
+                tracing::warn!(%id, error = ?e, "get_or_load: storage error");
+                return None;
+            }
+        };
 
         // Build Object with branches
         let mut object = Object {
@@ -218,6 +228,9 @@ impl ObjectManager {
             }
         }
 
+        let branch_count = object.branches.len();
+        let commit_count: usize = object.branches.values().map(|b| b.commits.len()).sum();
+        tracing::trace!(%id, branch_count, commit_count, "get_or_load: loaded from storage");
         self.objects.insert(id, object);
         self.objects.get(&id)
     }

--- a/crates/groove/src/query_manager/graph_nodes/index_scan.rs
+++ b/crates/groove/src/query_manager/graph_nodes/index_scan.rs
@@ -112,6 +112,15 @@ impl SourceNode for IndexScanNode {
             .copied()
             .collect();
 
+        tracing::trace!(
+            table = %self.table,
+            branch = %self.branch,
+            scanned = new_ids.len(),
+            added = added.len(),
+            removed = removed.len(),
+            "IndexScan results"
+        );
+
         self.last_scanned_ids = new_ids;
         self.current_tuples = self
             .last_scanned_ids

--- a/crates/groove/src/query_manager/manager.rs
+++ b/crates/groove/src/query_manager/manager.rs
@@ -557,7 +557,12 @@ impl QueryManager {
             // For multi-branch subscriptions, uses LWW across branches
             // When schema context is present, applies lens transform for old schema branches
             let row_loader = |id: ObjectId| -> Option<(Vec<u8>, CommitId)> {
-                let obj = om.get_or_load(id, storage_ref, branches)?;
+                let obj = om.get_or_load(id, storage_ref, branches);
+                if obj.is_none() {
+                    tracing::trace!(%id, "row_loader: object not found");
+                    return None;
+                }
+                let obj = obj?;
                 // Find the newest commit across all subscription branches (LWW)
                 // Also track which branch it came from for schema transformation
                 let mut best: Option<(u64, Vec<u8>, CommitId, String)> = None;
@@ -616,6 +621,14 @@ impl QueryManager {
             };
 
             let delta = subscription.graph.settle(storage_ref, row_loader);
+            if !delta.added.is_empty() || !delta.removed.is_empty() {
+                tracing::debug!(
+                    sub_id = sub_id.0,
+                    added = delta.added.len(),
+                    removed = delta.removed.len(),
+                    "settle delta"
+                );
+            }
 
             let tier_satisfied = match &subscription.settled_tier {
                 None => true, // No tier requirement → immediate (current behavior)

--- a/crates/groove/src/runtime_core.rs
+++ b/crates/groove/src/runtime_core.rs
@@ -455,6 +455,10 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
         for msg in outbox {
             self.sync_sender.send_sync_message(msg);
         }
+
+        // Flush WAL so writes survive a hard kill (tab close, crash).
+        // This is cheap (append-only buffer → OPFS) vs snapshot which rewrites everything.
+        self.storage.flush_wal();
     }
 
     /// Apply parked sync messages and tick.

--- a/crates/groove/src/storage/bftree.rs
+++ b/crates/groove/src/storage/bftree.rs
@@ -106,7 +106,27 @@ impl BfTreeStorage {
 
         let tree = BfTree::open_with_opfs(tree_vfs, wal_vfs, config)
             .map_err(|e| StorageError::IoError(format!("bf-tree OPFS: {:?}", e)))?;
-        Ok(Self { tree })
+        let storage = Self { tree };
+        storage.log_key_stats();
+        Ok(storage)
+    }
+
+    /// Log key statistics after opening storage (for debugging persistence).
+    fn log_key_stats(&self) {
+        let count_prefix =
+            |pfx: &str| -> usize { self.tree_scan_keys(pfx).map(|v| v.len()).unwrap_or(0) };
+        let obj_count = count_prefix("obj:");
+        let idx_count = count_prefix("idx:");
+        let ack_count = count_prefix("ack:");
+        tracing::info!(obj_count, idx_count, ack_count, "BfTreeStorage opened");
+        // If there are index keys, log a sample
+        if idx_count > 0 {
+            if let Ok(keys) = self.tree_scan_keys("idx:") {
+                for key in keys.iter().take(5) {
+                    tracing::debug!(key, "sample index key");
+                }
+            }
+        }
     }
 
     fn configure(config: &mut Config) {
@@ -579,6 +599,7 @@ impl Storage for BfTreeStorage {
         row_id: ObjectId,
     ) -> Result<(), StorageError> {
         let key = Self::index_entry_key(table, column, branch, value, row_id);
+        tracing::trace!(table, column, branch, %row_id, %key, "index_insert");
         // Sentinel byte — bf-tree requires non-empty values; existence is the signal
         self.tree_insert(&key, &[0x01])
     }
@@ -673,12 +694,24 @@ impl Storage for BfTreeStorage {
 
     fn index_scan_all(&self, table: &str, column: &str, branch: &str) -> Vec<ObjectId> {
         let prefix = Self::index_prefix(table, column, branch);
+        tracing::trace!(table, column, branch, %prefix, "index_scan_all");
         match self.tree_scan_keys(&prefix) {
-            Ok(keys) => keys
-                .iter()
-                .filter_map(|k| parse_uuid_from_index_key(k))
-                .collect(),
-            Err(_) => Vec::new(),
+            Ok(keys) => {
+                let ids: Vec<ObjectId> = keys
+                    .iter()
+                    .filter_map(|k| parse_uuid_from_index_key(k))
+                    .collect();
+                tracing::trace!(
+                    prefix_matches = keys.len(),
+                    parsed_ids = ids.len(),
+                    "index_scan_all result"
+                );
+                ids
+            }
+            Err(e) => {
+                tracing::warn!(error = ?e, "index_scan_all error");
+                Vec::new()
+            }
         }
     }
 

--- a/crates/wasm-tracing/src/layer.rs
+++ b/crates/wasm-tracing/src/layer.rs
@@ -6,9 +6,8 @@ use tracing_log::NormalizeEvent as _;
 use tracing_subscriber::{layer::Context, registry::LookupSpan, Layer};
 
 use crate::{
-    debug1, debug4, error1, error4, group_collapsed1, group_collapsed4, group_end, log1, log4,
-    mark, mark_name, measure, prelude::*, recorder::StringRecorder, thread_display_suffix, warn1,
-    warn4,
+    debug1, debug4, error1, error4, log1, log4, mark, mark_name, measure, prelude::*,
+    recorder::StringRecorder, thread_display_suffix, warn1, warn4,
 };
 
 #[doc = r#"
@@ -195,31 +194,29 @@ impl<S: Subscriber + for<'a> LookupSpan<'a>> Layer<S> for WasmLayer {
                     .get::<StringRecorder>()
                     .map(|r| r.to_string())
                     .unwrap_or_default();
-                let label = format!(
-                    "\"{}\"{}{}",
+                let message = format!("▶ \"{}\"{}{}",
                     meta.name(),
                     thread_display_suffix(),
                     fields,
                 );
                 if self.config.color {
-                    group_collapsed4(
-                        format!("%c{}%c {}", level, label),
-                        level.color(),
-                        "color: inherit",
-                        "",
+                    log_with_color(
+                        format!("%c{}%c {}", level, message),
+                        level,
+                        self.config.use_console_methods,
                     );
                 } else {
-                    group_collapsed1(format!("{} {}", level, label));
+                    log(
+                        format!("{} {}", level, message),
+                        level,
+                        self.config.use_console_methods,
+                    );
                 }
             }
         }
     }
 
     fn on_exit(&self, id: &tracing::Id, ctx: Context<'_, S>) {
-        if self.config.console_group_spans {
-            group_end();
-        }
-
         if !self.config.report_logs_in_timings {
             return;
         }

--- a/specs/todo/a_week_2026_02_09/bftree_wasm_persistence_problem.md
+++ b/specs/todo/a_week_2026_02_09/bftree_wasm_persistence_problem.md
@@ -1,0 +1,56 @@
+# BfTree WASM persistence: fundamental viability problem
+
+## Finding
+
+BfTree's persistence model relies on two mechanisms working together:
+
+1. **WAL** (write-ahead log) — cheap append-only buffer flushed to disk, captures every write
+2. **Snapshot** — expensive full serialization of the tree to disk, after which the WAL can be safely truncated
+
+On **native**, the lifecycle is:
+- Open: load snapshot → replay WAL → create fresh WAL (offset 0)
+- Runtime: writes go to WAL (background flush thread)
+- Shutdown: `snapshot()` writes full tree state to disk, WAL is implicitly truncated on next open
+
+This works because `snapshot()` persists everything, so the WAL is ephemeral by design — it only needs to survive between snapshots.
+
+## The WASM problem
+
+`snapshot()` **cannot work on WASM**. It calls `CircularBuffer::drain()` which enters a multi-threaded spin loop (`try_bump_head_address_to_evicting_addr` in a `loop` with `backoff.snooze()`). On WASM's single-threaded runtime, this is an infinite busy-wait that blocks the event loop and hangs the worker.
+
+Without `snapshot()`:
+- WAL replay loads data into memory on open ✓
+- But `open_with_opfs` creates a fresh WAL at `file_offset: 0`, overwriting the old WAL
+- Since there's no snapshot, the replayed data only lives in memory
+- On the next reload, both WAL and snapshot are empty → data lost
+
+### Why "just keep appending to the WAL" isn't a solution
+
+An ever-growing WAL without compaction will:
+- Grow without bound (every mutation appended forever)
+- Make recovery increasingly slow (replay everything since first write)
+- Eventually exceed OPFS quota
+
+The WAL is architecturally a *delta log between snapshots*. Without snapshots, it becomes the only source of truth, which it was never designed to be.
+
+## Root cause
+
+BfTree's `CircularBuffer` and `snapshot()` are designed for multi-threaded native environments. The eviction/drain machinery uses locks, condition variables, and spin-wait patterns that assume other threads can make progress concurrently. None of this works on WASM's single-threaded, cooperative-multitasking runtime.
+
+## Options
+
+1. **Make snapshot work on WASM** — Rewrite `CircularBuffer::drain()` to not spin-wait. This is deep in bf-tree internals and may require rethinking the eviction design for single-threaded contexts.
+
+2. **Bypass CircularBuffer for WASM snapshots** — Write a WASM-specific snapshot path that directly serializes the tree without going through the CB drain. The tree structure (page table, inner nodes, leaf nodes) is all accessible; the CB drain is an optimization for evicting cached pages to disk, which may not be needed when we're writing everything anyway.
+
+3. **Replace BfTree on WASM** — Use a simpler key-value store that doesn't need multi-threaded buffer management. Options include a sorted log-structured store, a simple B-tree without the circular buffer, or direct OPFS key-value serialization.
+
+4. **Hybrid: WAL with periodic compaction** — Keep the WAL-only approach but add a compaction step that rewrites the WAL as a fresh minimal log (current state only, no history). This avoids the snapshot machinery but requires writing a custom compaction pass.
+
+## Current state
+
+- Writes reach BfTree in-memory ✓
+- `flush_wal()` writes WAL to OPFS ✓
+- WAL replay on open recovers data ✓
+- But fresh WAL overwrites old entries → data survives exactly one reload
+- `snapshot()` hangs on WASM → cannot use the designed persistence path

--- a/specs/todo/a_week_2026_02_09/scheduled_wal_flush.md
+++ b/specs/todo/a_week_2026_02_09/scheduled_wal_flush.md
@@ -1,0 +1,19 @@
+# Scheduled WAL flush
+
+Currently `flush_wal()` runs at the end of every `batched_tick`. This is correct but wasteful — a single keystroke can trigger multiple ticks.
+
+## Goal
+
+Debounce WAL flushes so they happen at most every N ms (e.g. 500ms or 1s) rather than on every tick.
+
+## Approach
+
+Extend the `Scheduler` trait with a `schedule_wal_flush(&self)` method. The WASM scheduler implementation would debounce this via `setTimeout`, similar to how `schedule_batched_tick` works. The native scheduler can flush synchronously or use a background thread.
+
+`batched_tick` calls `schedule_wal_flush()` instead of `flush_wal()` directly. The scheduler fires the actual flush after the debounce window.
+
+## Notes
+
+- `flush_wal()` is cheap (append buffer → OPFS) but still I/O — debouncing avoids redundant writes
+- `flush()` (full snapshot) remains explicit (shutdown only, or periodic on a longer cadence)
+- The current every-tick flush is a stopgap to unblock persistence debugging


### PR DESCRIPTION
## Summary

- Traced the full OPFS persistence path using the new tracing instrumentation
- Found that `BfTree::snapshot()` **deadlocks on WASM** — `CircularBuffer::drain()` spin-waits for concurrent threads that don't exist on single-threaded WASM
- Without snapshots, the WAL is the only persistence path, but `open_with_opfs` creates a fresh WAL at offset 0 on each open, overwriting previous entries
- Result: data survives exactly one reload (WAL replay into memory), then is lost on the second reload

## Key findings

1. **Write path works**: `index_insert` fires correctly on both client and worker, data is queryable in-session
2. **WAL flush works**: `flush_wal()` after `batched_tick` successfully writes to OPFS
3. **WAL replay works**: `open_with_opfs` correctly replays WAL entries on the first reload
4. **WAL overwrite kills data**: fresh WAL starts at `file_offset: 0`, overwriting old entries. Since no snapshot exists, replayed data only lives in memory.
5. **`snapshot()` hangs**: `CircularBuffer::drain()` → `try_bump_head_address_to_evicting_addr` busy-loops forever on WASM

## Changes

- Added tracing to `BfTreeStorage` (key stats on open, `index_insert`, `index_scan_all`)
- Added tracing to `ObjectManager::get_or_load` and query manager `row_loader`
- Added `flush_wal()` call at end of `batched_tick` (stopgap for debugging)
- Changed wasm-tracing span logging from `console.groupCollapsed` to flat log lines (avoids interleaving between main thread and worker)
- Spec: `bftree_wasm_persistence_problem.md` — documents the fundamental issue
- Spec: `scheduled_wal_flush.md` — stub for debounced WAL flush scheduling

## Test plan

- [x] 573 groove tests pass
- [x] wasm-pack builds
- [x] Traced end-to-end in browser: insert → WAL flush → reload → WAL replay → data visible → second reload → data gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)