### PR TITLE
Autogenerate BETTER_AUTH_SECRET

### DIFF
--- a/examples/betterauth-svelte/package.json
+++ b/examples/betterauth-svelte/package.json
@@ -5,8 +5,9 @@
   "type": "module",
   "packageManager": "pnpm@10.16.1",
   "scripts": {
-    "dev": "vite dev",
-    "build": "pnpm check && vite build",
+    "ensure-env": "node scripts/ensure-env.js",
+    "dev": "pnpm ensure-env && vite dev",
+    "build": "pnpm ensure-env && pnpm check && vite build",
     "preview": "vite preview",
     "prepare": "svelte-kit sync || echo ''",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",

--- a/examples/betterauth-svelte/scripts/ensure-env.js
+++ b/examples/betterauth-svelte/scripts/ensure-env.js
@@ -1,0 +1,16 @@
+import { existsSync, writeFileSync } from "node:fs";
+import { randomBytes } from "node:crypto";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const envPath = join(__dirname, "..", ".env");
+
+if (!existsSync(envPath)) {
+  const secret = randomBytes(32).toString("hex");
+  const content = `BETTER_AUTH_SECRET=${secret}\nBETTER_AUTH_URL=http://localhost:5173\n`;
+  writeFileSync(envPath, content);
+  console.log(
+    "No .env detected. Generated .env with a random BETTER_AUTH_SECRET",
+  );
+}


### PR DESCRIPTION
Currently, building the monorepo fails because the `betterauth-svelte` example imports `BETTER_AUTH_SECRET` from `$env/static/private`, which requires a `.env` file to exist. Since `.env` is gitignored, fresh clones and CI always hit this error:

```
Error: Module '"$env/static/private"' has no exported member 'BETTER_AUTH_SECRET'.
```

This PR adds a small Node script (`scripts/ensure-env.js`) that runs before `build` and `dev`. It checks for a `.env` file and, if one doesn't exist, generates it with:

- `BETTER_AUTH_SECRET` — a random 32-byte hex string
- `BETTER_AUTH_URL` — defaulting to `http://localhost:5173`

If a `.env` file already exists, then it will not be overwritten.