### PR TITLE
Remove `@manuscripts/prosemirror-recreate-steps` and replace with local implementation

### DIFF
--- a/.changeset/remove-prosemirror-recreate-steps.md
+++ b/.changeset/remove-prosemirror-recreate-steps.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Replaced a vulnerable dependency with a local implementation, removing transitive vulnerabilities.

--- a/packages/jazz-tools/package.json
+++ b/packages/jazz-tools/package.json
@@ -198,7 +198,6 @@
   "license": "MIT",
   "version": "0.20.9",
   "dependencies": {
-    "@manuscripts/prosemirror-recreate-steps": "^0.1.4",
     "@scure/base": "1.2.1",
     "@scure/bip39": "^1.3.0",
     "@tiptap/core": "^2.12.0",

--- a/packages/jazz-tools/src/prosemirror/lib/recreateTransform.ts
+++ b/packages/jazz-tools/src/prosemirror/lib/recreateTransform.ts
@@ -1,0 +1,48 @@
+import type { Node } from "prosemirror-model";
+import { ReplaceStep, Transform } from "prosemirror-transform";
+
+/**
+ * Given two ProseMirror documents, produce a Transform containing the steps
+ * needed to convert fromDoc into toDoc.
+ *
+ * Uses ProseMirror's built-in Fragment diffing to locate the changed region
+ * and creates a ReplaceStep to reconcile it.
+ */
+export function recreateTransform(fromDoc: Node, toDoc: Node): Transform {
+  const tr = new Transform(fromDoc);
+
+  if (fromDoc.eq(toDoc)) {
+    return tr;
+  }
+
+  let start = toDoc.content.findDiffStart(fromDoc.content);
+  if (start === null) {
+    return tr;
+  }
+
+  const diffEnd = toDoc.content.findDiffEnd(fromDoc.content);
+  if (diffEnd === null) {
+    return tr;
+  }
+
+  let { a: endA, b: endB } = diffEnd;
+
+  // When start overshoots the end positions, we have overlapping boundaries.
+  // Resolve by choosing the side with the shallowest depth.
+  const overlap = start - Math.min(endA, endB);
+  if (overlap > 0) {
+    if (
+      fromDoc.resolve(start - overlap).depth <
+      toDoc.resolve(endA + overlap).depth
+    ) {
+      start -= overlap;
+    } else {
+      endA += overlap;
+      endB += overlap;
+    }
+  }
+
+  tr.step(new ReplaceStep(start, endB, toDoc.slice(start, endA)));
+
+  return tr;
+}

--- a/packages/jazz-tools/src/prosemirror/lib/sync.ts
+++ b/packages/jazz-tools/src/prosemirror/lib/sync.ts
@@ -1,4 +1,4 @@
-import { recreateTransform } from "@manuscripts/prosemirror-recreate-steps";
+import { recreateTransform } from "./recreateTransform.js";
 import { CoRichText } from "jazz-tools";
 import { EditorState, Transaction } from "prosemirror-state";
 import { EditorView } from "prosemirror-view";

--- a/packages/jazz-tools/src/prosemirror/tests/recreateTransform.test.ts
+++ b/packages/jazz-tools/src/prosemirror/tests/recreateTransform.test.ts
@@ -1,0 +1,228 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it } from "vitest";
+import { Schema } from "prosemirror-model";
+import { schema as basicSchema } from "prosemirror-schema-basic";
+import { addListNodes } from "prosemirror-schema-list";
+import { DOMParser as ProseMirrorDOMParser } from "prosemirror-model";
+import { recreateTransform } from "../lib/recreateTransform";
+
+const schema = new Schema({
+  nodes: addListNodes(basicSchema.spec.nodes, "paragraph block*", "block"),
+  marks: basicSchema.spec.marks,
+});
+
+function htmlToDoc(html: string) {
+  const dom = new DOMParser().parseFromString(html, "text/html");
+  return ProseMirrorDOMParser.fromSchema(schema).parse(dom.body);
+}
+
+function applyAndCompare(fromHtml: string, toHtml: string) {
+  const fromDoc = htmlToDoc(fromHtml);
+  const toDoc = htmlToDoc(toHtml);
+  const tr = recreateTransform(fromDoc, toDoc);
+  expect(tr.doc.eq(toDoc)).toBe(true);
+  return tr;
+}
+
+describe("recreateTransform", () => {
+  it("returns no steps for identical documents", () => {
+    const doc = htmlToDoc("<p>Hello</p>");
+    const tr = recreateTransform(doc, doc);
+    expect(tr.steps).toHaveLength(0);
+    expect(tr.doc.eq(doc)).toBe(true);
+  });
+
+  it("handles appending text", () => {
+    const tr = applyAndCompare("<p>Hello</p>", "<p>Hello World</p>");
+    expect(tr.steps).toHaveLength(1);
+  });
+
+  it("handles prepending text", () => {
+    const tr = applyAndCompare("<p>World</p>", "<p>Hello World</p>");
+    expect(tr.steps).toHaveLength(1);
+  });
+
+  it("handles text deletion", () => {
+    const tr = applyAndCompare("<p>Hello World</p>", "<p>Hello</p>");
+    expect(tr.steps).toHaveLength(1);
+  });
+
+  it("handles replacing text in the middle", () => {
+    applyAndCompare("<p>Hello World</p>", "<p>Hello Jazz</p>");
+  });
+
+  it("handles complete text replacement", () => {
+    applyAndCompare("<p>Hello</p>", "<p>Goodbye</p>");
+  });
+
+  it("handles empty to non-empty", () => {
+    applyAndCompare("<p></p>", "<p>Hello</p>");
+  });
+
+  it("handles non-empty to empty", () => {
+    applyAndCompare("<p>Hello</p>", "<p></p>");
+  });
+
+  it("handles adding a paragraph", () => {
+    applyAndCompare("<p>First</p>", "<p>First</p><p>Second</p>");
+  });
+
+  it("handles removing a paragraph", () => {
+    applyAndCompare("<p>First</p><p>Second</p>", "<p>First</p>");
+  });
+
+  it("handles changes in a middle paragraph", () => {
+    applyAndCompare(
+      "<p>One</p><p>Two</p><p>Three</p>",
+      "<p>One</p><p>Changed</p><p>Three</p>",
+    );
+  });
+
+  it("handles paragraph to list structural change", () => {
+    applyAndCompare("<p>Item one</p>", "<ol><li><p>Item one</p></li></ol>");
+  });
+
+  it("handles list to paragraph structural change", () => {
+    applyAndCompare("<ul><li><p>Item</p></li></ul>", "<p>Item</p>");
+  });
+
+  it("handles adding bold mark", () => {
+    applyAndCompare("<p>Hello</p>", "<p><strong>Hello</strong></p>");
+  });
+
+  it("handles removing bold mark", () => {
+    applyAndCompare("<p><strong>Hello</strong></p>", "<p>Hello</p>");
+  });
+
+  it("handles changing marks from bold to italic", () => {
+    applyAndCompare("<p><strong>Hello</strong></p>", "<p><em>Hello</em></p>");
+  });
+
+  it("handles nested mark changes", () => {
+    applyAndCompare(
+      "<p>A <strong>bold</strong> word</p>",
+      "<p>A <strong><em>bold</em></strong> word</p>",
+    );
+  });
+
+  it("handles emoji content", () => {
+    applyAndCompare("<p>Hello</p>", "<p>Hello 🌍</p>");
+  });
+
+  it("handles multi-byte unicode", () => {
+    applyAndCompare("<p>café</p>", "<p>naïve café</p>");
+  });
+
+  it("produces a valid transform that can be applied", () => {
+    const fromDoc = htmlToDoc("<p>Before</p>");
+    const toDoc = htmlToDoc("<p>After</p>");
+    const tr = recreateTransform(fromDoc, toDoc);
+
+    for (const step of tr.steps) {
+      const result = step.apply(fromDoc);
+      expect(result.failed).toBeNull();
+    }
+  });
+
+  // Tests adapted from @manuscripts/prosemirror-recreate-steps test suite.
+  // Our implementation produces a single ReplaceStep rather than granular
+  // addMark/removeMark/replaceAround steps, so we verify the resulting
+  // document matches rather than asserting exact step shapes.
+
+  describe("mark diffs (adapted from original library)", () => {
+    it("adds em to inline text", () => {
+      applyAndCompare(
+        "<p>Before textitalicAfter text</p>",
+        "<p>Before text<em>italic</em>After text</p>",
+      );
+    });
+
+    it("removes strong from inline text", () => {
+      applyAndCompare(
+        "<p>Before text<strong>bold</strong>After text</p>",
+        "<p>Before textboldAfter text</p>",
+      );
+    });
+
+    it("adds em and strong simultaneously", () => {
+      applyAndCompare(
+        "<p>Before textitalic/boldAfter text</p>",
+        "<p>Before text<strong><em>italic/bold</em></strong>After text</p>",
+      );
+    });
+
+    it("replaces em with strong", () => {
+      applyAndCompare(
+        "<p>Before text<em>styled</em>After text</p>",
+        "<p>Before text<strong>styled</strong>After text</p>",
+      );
+    });
+
+    it("replaces em with strong in different regions", () => {
+      applyAndCompare(
+        "<p>Before text<em>styledAfter text</em></p>",
+        "<p><strong>Before textstyled</strong>After text</p>",
+      );
+    });
+  });
+
+  describe("structural diffs (adapted from original library)", () => {
+    it("wraps paragraph in blockquote", () => {
+      applyAndCompare(
+        "<p>A quoted sentence</p>",
+        "<blockquote><p>A quoted sentence</p></blockquote>",
+      );
+    });
+
+    it("unwraps paragraph from blockquote", () => {
+      applyAndCompare(
+        "<blockquote><p>A quoted sentence</p></blockquote>",
+        "<p>A quoted sentence</p>",
+      );
+    });
+
+    it("changes heading level", () => {
+      applyAndCompare("<h1>A title</h1>", "<h2>A title</h2>");
+    });
+  });
+
+  describe("text diffs (adapted from original library)", () => {
+    it("replaces text in a single node", () => {
+      applyAndCompare(
+        "<blockquote><p>The start text</p></blockquote>",
+        "<blockquote><p>The end text</p></blockquote>",
+      );
+    });
+
+    it("replaces text across multiple nodes", () => {
+      applyAndCompare(
+        "<blockquote><p>The start text</p><p>The second text</p></blockquote>",
+        "<blockquote><p>The end text</p><p>The second sentence</p></blockquote>",
+      );
+    });
+
+    it("replaces multiple words in a single text node", () => {
+      applyAndCompare(
+        "<blockquote><p>The cat is barking at the house</p></blockquote>",
+        "<blockquote><p>The dog is meauwing in the ship</p></blockquote>",
+      );
+    });
+  });
+
+  describe("combined content and structure changes (adapted from original library)", () => {
+    it("changes both heading type and paragraph content", () => {
+      applyAndCompare(
+        "<h1>The title</h1><p>The fish are <em>great!</em></p>",
+        "<h2>A different title</h2><p>A <strong>different</strong> sentence.</p>",
+      );
+    });
+
+    it("restructures from heading+paragraph to paragraphs", () => {
+      applyAndCompare(
+        "<h1>The title</h1><p>The fish are <em>great!</em></p>",
+        "<p>Yet another <em>first</em> line.</p><p>With a second line that is not styled.</p>",
+      );
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2690,9 +2690,6 @@ importers:
       '@bam.tech/react-native-image-resizer':
         specifier: '*'
         version: 3.0.11(react-native@0.80.0(@babel/core@7.28.5)(@react-native-community/cli@20.0.1(typescript@5.6.2))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
-      '@manuscripts/prosemirror-recreate-steps':
-        specifier: ^0.1.4
-        version: 0.1.4
       '@op-engineering/op-sqlite':
         specifier: '*'
         version: 14.1.4(react-native@0.80.0(@babel/core@7.28.5)(@react-native-community/cli@20.0.1(typescript@5.6.2))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
@@ -6859,9 +6856,6 @@ packages:
     peerDependencies:
       svelte: ^5
 
-  '@manuscripts/prosemirror-recreate-steps@0.1.4':
-    resolution: {integrity: sha512-z3/PGcWB3SbOzhUkiZKAAMeWVz3jR1uacUXuYfJfSE+XgTUCtxB/xnbmx7SpTvtBEtw9EFXomTqjoG6DGlC2nQ==}
-
   '@manypkg/find-root@1.1.0':
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
 
@@ -10043,26 +10037,6 @@ packages:
     resolution: {integrity: sha512-EULJ8LApcVEPbrfND0cRQqutIOdiIgJ1Mgrhpy755r14xMohPTEpkV/k28SJvuOs9bHRFW8x+KeDAEPiGQPB9Q==}
     deprecated: This is a stub types definition. parse-path provides its own type definitions, so you do not need this installed.
 
-  '@types/prosemirror-model@1.17.0':
-    resolution: {integrity: sha512-lG5xEMkE8r8Soa80KdWPTbCLUaSHBHVHpTIEsQiebfONpvmS5061IMGzHUdb1oWjgrwh8EJq0GgMNwXHUx5mVg==}
-    deprecated: This is a stub types definition. prosemirror-model provides its own type definitions, so you do not need this installed.
-
-  '@types/prosemirror-schema-basic@1.2.0':
-    resolution: {integrity: sha512-WrQLRv3Ss48e2XBnocoZNMLw3xZwiW2cSjPvrZ/Ui6PicAMsabkb6EKTdLU0B52LuQjShNPtq0tFejrbLOMbpQ==}
-    deprecated: This is a stub types definition. prosemirror-schema-basic provides its own type definitions, so you do not need this installed.
-
-  '@types/prosemirror-schema-list@1.2.0':
-    resolution: {integrity: sha512-njvba73mgBanQOt2/piYMeP+nsu8lzomA350Lh7/sdr6NPsRvYPggwJDIZEG0Cb/MB0fnv4PdRaTi93PoLHArw==}
-    deprecated: This is a stub types definition. prosemirror-schema-list provides its own type definitions, so you do not need this installed.
-
-  '@types/prosemirror-state@1.4.0':
-    resolution: {integrity: sha512-71epLy1HD2H7Qn6iOoQrFdbdFP32Cg5U7OvlCXMuYO8ygUdz07dfqA1lNj1y+KLf3HkRCXVkfvi3OnNa/tFZ3A==}
-    deprecated: This is a stub types definition. prosemirror-state provides its own type definitions, so you do not need this installed.
-
-  '@types/prosemirror-transform@1.5.0':
-    resolution: {integrity: sha512-++krMS5bt3SxNOqjrftispPLRkvfXXw2BtVq4VPJ8Vpf+Sne1MhxVoj0EFCM+14MFlX0EHYQvX3k9AaQzob9ZQ==}
-    deprecated: This is a stub types definition. prosemirror-transform provides its own type definitions, so you do not need this installed.
-
   '@types/qrcode@1.5.5':
     resolution: {integrity: sha512-CdfBi/e3Qk+3Z/fXYShipBT13OJ2fDO2Q2w5CIP5anLTLIndQG9z6P1cnm+8zCWSpm5dnxMFd/uREtb0EXuQzg==}
 
@@ -12167,10 +12141,6 @@ packages:
   diff-sequences@29.6.3:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-
-  diff@3.5.0:
-    resolution: {integrity: sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==}
-    engines: {node: '>=0.3.1'}
 
   diff@4.0.2:
     resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
@@ -16271,9 +16241,6 @@ packages:
       yjs:
         optional: true
 
-  prosemirror-changeset@1.2.1:
-    resolution: {integrity: sha512-qqwG1z8z+KkM3PZWmANYhqvoZdstFmzfkr7FPJ6suBwKs/UvZbvnRvDBvJC5eDbXbE7MhIGO+LY1Dq29zBAbIw==}
-
   prosemirror-changeset@2.3.1:
     resolution: {integrity: sha512-j0kORIBm8ayJNl3zQvD1TTPHJX3g042et6y/KQhZhnPrruO8exkTgG8X+NRpj7kIyMMEx74Xb3DyMIBtO0IKkQ==}
 
@@ -16967,9 +16934,6 @@ packages:
   reusify@1.0.4:
     resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
-
-  rfc6902@5.1.2:
-    resolution: {integrity: sha512-zxcb+PWlE8PwX0tiKE6zP97THQ8/lHmeiwucRrJ3YFupWEmp25RmFSlB1dNTqjkovwqG4iq+u1gzJMBS3um8mA==}
 
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
@@ -19607,9 +19571,9 @@ snapshots:
       eslint-visitor-keys: 2.1.0
       semver: 6.3.1
 
-  '@babel/eslint-parser@7.27.0(@babel/core@7.28.5)(eslint@9.39.1(jiti@2.6.1))':
+  '@babel/eslint-parser@7.27.0(@babel/core@7.28.3)(eslint@9.39.1(jiti@2.6.1))':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.3
       '@nicolo-ribaudo/eslint-scope-5-internals': 5.1.1-v1
       eslint: 9.39.1(jiti@2.6.1)
       eslint-visitor-keys: 2.1.0
@@ -25291,24 +25255,6 @@ snapshots:
     dependencies:
       svelte: 5.46.4
 
-  '@manuscripts/prosemirror-recreate-steps@0.1.4':
-    dependencies:
-      '@types/prosemirror-model': 1.17.0
-      '@types/prosemirror-schema-basic': 1.2.0
-      '@types/prosemirror-schema-list': 1.2.0
-      '@types/prosemirror-state': 1.4.0
-      '@types/prosemirror-transform': 1.5.0
-      diff: 3.5.0
-      prosemirror-changeset: 1.2.1
-      prosemirror-example-setup: 1.2.3
-      prosemirror-model: 1.25.1
-      prosemirror-schema-basic: 1.2.4
-      prosemirror-schema-list: 1.5.1
-      prosemirror-state: 1.4.3
-      prosemirror-transform: 1.10.4
-      prosemirror-view: 1.39.2
-      rfc6902: 5.1.2
-
   '@manypkg/find-root@1.1.0':
     dependencies:
       '@babel/runtime': 7.28.4
@@ -27756,7 +27702,7 @@ snapshots:
   '@react-native/eslint-config@0.81.5(eslint@9.39.1(jiti@2.6.1))(jest@29.7.0(@types/node@24.3.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.11.29(@swc/helpers@0.5.17))(@types/node@24.3.0)(typescript@5.9.2)))(prettier@3.6.2)(typescript@5.9.2)':
     dependencies:
       '@babel/core': 7.28.3
-      '@babel/eslint-parser': 7.27.0(@babel/core@7.28.5)(eslint@9.39.1(jiti@2.6.1))
+      '@babel/eslint-parser': 7.27.0(@babel/core@7.28.3)(eslint@9.39.1(jiti@2.6.1))
       '@react-native/eslint-plugin': 0.81.5
       '@typescript-eslint/eslint-plugin': 7.18.0(@typescript-eslint/parser@7.18.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.2))(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.2)
       '@typescript-eslint/parser': 7.18.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.2)
@@ -29422,26 +29368,6 @@ snapshots:
   '@types/parse-path@7.1.0':
     dependencies:
       parse-path: 7.1.0
-
-  '@types/prosemirror-model@1.17.0':
-    dependencies:
-      prosemirror-model: 1.25.1
-
-  '@types/prosemirror-schema-basic@1.2.0':
-    dependencies:
-      prosemirror-schema-basic: 1.2.4
-
-  '@types/prosemirror-schema-list@1.2.0':
-    dependencies:
-      prosemirror-schema-list: 1.5.1
-
-  '@types/prosemirror-state@1.4.0':
-    dependencies:
-      prosemirror-state: 1.4.3
-
-  '@types/prosemirror-transform@1.5.0':
-    dependencies:
-      prosemirror-transform: 1.10.4
 
   '@types/qrcode@1.5.5':
     dependencies:
@@ -32524,8 +32450,6 @@ snapshots:
 
   diff-sequences@29.6.3: {}
 
-  diff@3.5.0: {}
-
   diff@4.0.2:
     optional: true
 
@@ -32951,7 +32875,7 @@ snapshots:
 
   eslint-plugin-ft-flow@2.0.3(@babel/eslint-parser@7.27.0(@babel/core@7.28.3)(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
-      '@babel/eslint-parser': 7.27.0(@babel/core@7.28.5)(eslint@9.39.1(jiti@2.6.1))
+      '@babel/eslint-parser': 7.27.0(@babel/core@7.28.3)(eslint@9.39.1(jiti@2.6.1))
       eslint: 9.39.1(jiti@2.6.1)
       lodash: 4.17.21
       string-natural-compare: 3.0.1
@@ -38138,10 +38062,6 @@ snapshots:
       - refractor
       - sugar-high
 
-  prosemirror-changeset@1.2.1:
-    dependencies:
-      prosemirror-transform: 1.10.4
-
   prosemirror-changeset@2.3.1:
     dependencies:
       prosemirror-transform: 1.10.4
@@ -39390,8 +39310,6 @@ snapshots:
   retry@0.13.1: {}
 
   reusify@1.0.4: {}
-
-  rfc6902@5.1.2: {}
 
   rfdc@1.4.1: {}
 


### PR DESCRIPTION
### Problem

The `@manuscripts/prosemirror-recreate-steps` package pulls in transitive dependencies with known vulnerabilities. The package is also unmaintained and provides significantly more functionality than we actually use.

### Solution

Replaced the external dependency with a local `recreateTransform` implementation that uses ProseMirror's built-in `Fragment.findDiffStart`/`findDiffEnd` to locate the changed region and produces a single `ReplaceStep` to reconcile it. The sync layer's existing fallback (rebuilding the entire editor state) handles any edge cases where the single-step approach can't produce a valid transform.

Ported the tests from the original library along with our own existing tests, all are passing.