### PR TITLE
Schema validation with superRefine

### DIFF
--- a/packages/jazz-tools/src/tools/coValues/coFeed.ts
+++ b/packages/jazz-tools/src/tools/coValues/coFeed.ts
@@ -64,7 +64,7 @@ import {
   type LocalValidationMode,
 } from "../implementation/zodSchema/validationSettings.js";
 import {
-  extractFieldElementFromUnionSchema,
+  expectArraySchema,
   normalizeZodSchema,
 } from "../implementation/zodSchema/schemaTypes/schemaValidators.js";
 import { assertCoValueSchema } from "../implementation/zodSchema/schemaInvariant.js";
@@ -477,18 +477,9 @@ export class CoFeedJazzApi<F extends CoFeed> extends CoValueJazzApi<F> {
   }
 
   private getItemSchema(): z.ZodType {
-    /**
-     * coFeedSchema may be undefined if the CoFeed is created directly with its constructor,
-     * without using a co.feed().create() to create it.
-     * In that case, we can't validate the values.
-     */
-    if (this.coFeedSchema === undefined) {
-      return z.any();
-    }
-
-    const fieldSchema = extractFieldElementFromUnionSchema(
+    const fieldSchema = expectArraySchema(
       this.coFeedSchema.getValidationSchema(),
-    );
+    ).element;
 
     return normalizeZodSchema(fieldSchema);
   }

--- a/packages/jazz-tools/src/tools/coValues/coList.ts
+++ b/packages/jazz-tools/src/tools/coValues/coList.ts
@@ -47,7 +47,7 @@ import {
   type LocalValidationMode,
 } from "../implementation/zodSchema/validationSettings.js";
 import {
-  extractFieldElementFromUnionSchema,
+  expectArraySchema,
   normalizeZodSchema,
 } from "../implementation/zodSchema/schemaTypes/schemaValidators.js";
 import { assertCoValueSchema } from "../implementation/zodSchema/schemaInvariant.js";
@@ -542,18 +542,9 @@ export class CoListJazzApi<L extends CoList> extends CoValueJazzApi<L> {
   }
 
   private getItemSchema(): z.ZodType {
-    /**
-     * coListSchema may be undefined if the CoList is created directly with its constructor,
-     * without using a co.list().create() to create it.
-     * In that case, we can't validate the values.
-     */
-    if (this.coListSchema === undefined) {
-      return z.any();
-    }
-
-    const fieldSchema = extractFieldElementFromUnionSchema(
+    const fieldSchema = expectArraySchema(
       this.coListSchema.getValidationSchema(),
-    );
+    ).element;
 
     return normalizeZodSchema(fieldSchema);
   }

--- a/packages/jazz-tools/src/tools/coValues/coMap.ts
+++ b/packages/jazz-tools/src/tools/coValues/coMap.ts
@@ -61,7 +61,7 @@ import {
   type LocalValidationMode,
 } from "../implementation/zodSchema/validationSettings.js";
 import {
-  extractFieldShapeFromUnionSchema,
+  expectObjectSchema,
   normalizeZodSchema,
 } from "../implementation/zodSchema/schemaTypes/schemaValidators.js";
 import { assertCoValueSchema } from "../implementation/zodSchema/schemaInvariant.js";
@@ -608,7 +608,7 @@ class CoMapJazzApi<M extends CoMap> extends CoValueJazzApi<M> {
     let objectValidation: z.ZodObject | undefined;
 
     try {
-      objectValidation = extractFieldShapeFromUnionSchema(fullSchema);
+      objectValidation = expectObjectSchema(fullSchema);
     } catch {
       // Base/core schemas may expose a non-union validation schema (e.g. z.any()).
       // In those cases we keep legacy dynamic behavior and skip strict per-field validation.

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoDiscriminatedUnionSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoDiscriminatedUnionSchema.ts
@@ -19,6 +19,7 @@ import { z } from "../zodReExport.js";
 import { CoOptionalSchema } from "./CoOptionalSchema.js";
 import { CoreCoValueSchema, CoreResolveQuery } from "./CoValueSchema.js";
 import { withSchemaResolveQuery } from "../../schemaUtils.js";
+import { extractPlainSchema } from "./schemaValidators.js";
 
 export interface DiscriminableCoValueSchemaDefinition {
   discriminatorMap: z.core.$ZodDiscriminatedUnionInternals["propValues"];
@@ -68,21 +69,7 @@ export class CoDiscriminatedUnionSchema<
       // @ts-expect-error
       options.map((schema) => {
         const validationSchema = schema.getValidationSchema();
-
-        if (validationSchema.def.type === "union") {
-          const def = validationSchema.def as
-            | z.core.$ZodUnionDef<z.core.$ZodType[]>
-            | z.core.$ZodDiscriminatedUnionDef<z.core.$ZodType[]>;
-          // in case of nested co.discriminatedUnion
-          // the nested `validationSchema` is already a z.discriminatedUnion
-          if ("discriminator" in def) {
-            return validationSchema;
-          }
-
-          return def.options[1];
-        }
-
-        throw new Error("Invalid schema type");
+        return extractPlainSchema(validationSchema);
       }),
     );
 

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoFeedSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoFeedSchema.ts
@@ -71,11 +71,7 @@ export class CoFeedSchema<
       generateValidationSchemaFromItem(this.element),
     );
 
-    this.#validationSchema = coValueValidationSchema(
-      validationSchema,
-      CoFeed,
-      "CoFeed",
-    );
+    this.#validationSchema = coValueValidationSchema(validationSchema, CoFeed);
     return this.#validationSchema;
   };
 

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoFeedSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoFeedSchema.ts
@@ -30,8 +30,10 @@ import {
   SchemaPermissions,
 } from "../schemaPermissions.js";
 import { z } from "../zodReExport.js";
-import { generateValidationSchemaFromItem } from "./schemaValidators.js";
-import { type LocalValidationMode } from "../validationSettings.js";
+import {
+  coValueValidationSchema,
+  generateValidationSchemaFromItem,
+} from "./schemaValidators.js";
 import { resolveSchemaField } from "../runtimeConverters/schemaFieldToCoFieldDef.js";
 
 export class CoFeedSchema<
@@ -65,9 +67,15 @@ export class CoFeedSchema<
       return this.#validationSchema;
     }
 
-    this.#validationSchema = z
-      .instanceof(CoFeed)
-      .or(z.array(generateValidationSchemaFromItem(this.element)));
+    const validationSchema = z.array(
+      generateValidationSchemaFromItem(this.element),
+    );
+
+    this.#validationSchema = coValueValidationSchema(
+      validationSchema,
+      CoFeed,
+      "CoFeed",
+    );
     return this.#validationSchema;
   };
 

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoListSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoListSchema.ts
@@ -72,11 +72,7 @@ export class CoListSchema<
       generateValidationSchemaFromItem(this.element),
     );
 
-    this.#validationSchema = coValueValidationSchema(
-      validationSchema,
-      CoList,
-      "CoList",
-    );
+    this.#validationSchema = coValueValidationSchema(validationSchema, CoList);
     return this.#validationSchema;
   };
 

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoListSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoListSchema.ts
@@ -31,8 +31,10 @@ import {
   SchemaPermissions,
 } from "../schemaPermissions.js";
 import { z } from "../zodReExport.js";
-import { generateValidationSchemaFromItem } from "./schemaValidators.js";
-import type { LocalValidationMode } from "../validationSettings.js";
+import {
+  coValueValidationSchema,
+  generateValidationSchemaFromItem,
+} from "./schemaValidators.js";
 import { resolveSchemaField } from "../runtimeConverters/schemaFieldToCoFieldDef.js";
 
 export class CoListSchema<
@@ -66,11 +68,15 @@ export class CoListSchema<
       return this.#validationSchema;
     }
 
-    // since validation is not used on read, we can't validate already existing CoValues
-    // so we accept every CoList instance
-    this.#validationSchema = z
-      .instanceof(CoList)
-      .or(z.array(generateValidationSchemaFromItem(this.element)));
+    const validationSchema = z.array(
+      generateValidationSchemaFromItem(this.element),
+    );
+
+    this.#validationSchema = coValueValidationSchema(
+      validationSchema,
+      CoList,
+      "CoList",
+    );
     return this.#validationSchema;
   };
 

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoMapSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoMapSchema.ts
@@ -92,11 +92,7 @@ export class CoMapSchema<
       );
     }
 
-    this.#validationSchema = coValueValidationSchema(
-      validationSchema,
-      CoMap,
-      "CoMap",
-    );
+    this.#validationSchema = coValueValidationSchema(validationSchema, CoMap);
 
     return this.#validationSchema;
   };

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoMapSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoMapSchema.ts
@@ -36,8 +36,10 @@ import {
   DEFAULT_SCHEMA_PERMISSIONS,
   SchemaPermissions,
 } from "../schemaPermissions.js";
-import { generateValidationSchemaFromItem } from "./schemaValidators.js";
-import type { LocalValidationMode } from "../validationSettings.js";
+import {
+  coValueValidationSchema,
+  generateValidationSchemaFromItem,
+} from "./schemaValidators.js";
 import { resolveSchemaField } from "../runtimeConverters/schemaFieldToCoFieldDef.js";
 
 type CoMapSchemaInstance<Shape extends z.core.$ZodLooseShape> = Simplify<
@@ -90,9 +92,12 @@ export class CoMapSchema<
       );
     }
 
-    // since validation is not used on read, we can't validate already existing CoValues
-    // so we accept every CoMap instance
-    this.#validationSchema = z.instanceof(CoMap).or(validationSchema);
+    this.#validationSchema = coValueValidationSchema(
+      validationSchema,
+      CoMap,
+      "CoMap",
+    );
+
     return this.#validationSchema;
   };
 

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoVectorSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoVectorSchema.ts
@@ -15,6 +15,7 @@ import {
   SchemaPermissions,
 } from "../schemaPermissions.js";
 import { z } from "../zodReExport.js";
+import { coValueValidationSchema } from "./schemaValidators.js";
 
 export interface CoreCoVectorSchema extends CoreCoValueSchema {
   builtin: "CoVector";
@@ -45,10 +46,13 @@ export class CoVectorSchema implements CoreCoVectorSchema {
       return this.#validationSchema;
     }
 
-    this.#validationSchema = z
-      .instanceof(CoVector)
-      .or(z.instanceof(Float32Array))
-      .or(z.array(z.number()));
+    const validationSchema = z.instanceof(Float32Array).or(z.array(z.number()));
+
+    this.#validationSchema = coValueValidationSchema(
+      validationSchema,
+      CoVector,
+      "CoVector",
+    );
 
     return this.#validationSchema;
   };

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoVectorSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoVectorSchema.ts
@@ -51,7 +51,6 @@ export class CoVectorSchema implements CoreCoVectorSchema {
     this.#validationSchema = coValueValidationSchema(
       validationSchema,
       CoVector,
-      "CoVector",
     );
 
     return this.#validationSchema;

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/PlainTextSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/PlainTextSchema.ts
@@ -17,6 +17,7 @@ import {
   SchemaPermissions,
 } from "../schemaPermissions.js";
 import { z } from "../zodReExport.js";
+import { coValueValidationSchema } from "./schemaValidators.js";
 
 export interface CorePlainTextSchema extends CoreCoValueSchema {
   builtin: "CoPlainText";
@@ -43,7 +44,13 @@ export class PlainTextSchema implements CorePlainTextSchema {
       return this.#validationSchema;
     }
 
-    this.#validationSchema = z.string().or(z.instanceof(CoPlainText));
+    const validationSchema = z.string();
+
+    this.#validationSchema = coValueValidationSchema(
+      validationSchema,
+      CoPlainText,
+      "CoPlainText",
+    );
     return this.#validationSchema;
   };
 

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/PlainTextSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/PlainTextSchema.ts
@@ -49,7 +49,6 @@ export class PlainTextSchema implements CorePlainTextSchema {
     this.#validationSchema = coValueValidationSchema(
       validationSchema,
       CoPlainText,
-      "CoPlainText",
     );
     return this.#validationSchema;
   };

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/RichTextSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/RichTextSchema.ts
@@ -16,6 +16,7 @@ import {
   SchemaPermissions,
 } from "../schemaPermissions.js";
 import { z } from "../zodReExport.js";
+import { coValueValidationSchema } from "./schemaValidators.js";
 
 export interface CoreRichTextSchema extends CoreCoValueSchema {
   builtin: "CoRichText";
@@ -36,6 +37,7 @@ export class RichTextSchema implements CoreRichTextSchema {
   readonly resolveQuery = true as const;
 
   #permissions: SchemaPermissions | null = null;
+  #validationSchema: z.ZodType | undefined = undefined;
   /**
    * Permissions to be used when creating or composing CoValues
    * @internal
@@ -46,14 +48,18 @@ export class RichTextSchema implements CoreRichTextSchema {
 
   constructor(private coValueClass: typeof CoRichText) {}
 
-  #validationSchema: z.ZodType | undefined = undefined;
-
   getValidationSchema = () => {
     if (this.#validationSchema) {
       return this.#validationSchema;
     }
 
-    this.#validationSchema = z.string().or(z.instanceof(CoRichText));
+    const validationSchema = z.string();
+
+    this.#validationSchema = coValueValidationSchema(
+      validationSchema,
+      CoRichText,
+      "CoRichText",
+    );
     return this.#validationSchema;
   };
 

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/RichTextSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/RichTextSchema.ts
@@ -58,7 +58,6 @@ export class RichTextSchema implements CoreRichTextSchema {
     this.#validationSchema = coValueValidationSchema(
       validationSchema,
       CoRichText,
-      "CoRichText",
     );
     return this.#validationSchema;
   };

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/schemaValidators.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/schemaValidators.ts
@@ -55,7 +55,6 @@ export function generateValidationSchemaFromItem(item: InputSchema): z.ZodType {
 export function coValueValidationSchema(
   plainSchema: z.ZodType,
   expectedCoValueClass: new (...args: any[]) => unknown,
-  type: string,
 ): z.ZodType {
   return z
     .unknown()
@@ -64,7 +63,7 @@ export function coValueValidationSchema(
         if (!(value instanceof expectedCoValueClass)) {
           ctx.addIssue({
             code: "custom",
-            message: `Expected a ${type} when providing a CoValue instance`,
+            message: `Expected a ${expectedCoValueClass.name} when providing a CoValue instance`,
           });
         }
         return;

--- a/packages/jazz-tools/src/tools/tests/coDiscriminatedUnion.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coDiscriminatedUnion.test.ts
@@ -704,8 +704,6 @@ describe("co.discriminatedUnion", () => {
         },
       });
 
-      console.log(loadedSpecies.$isLoaded);
-
       assertLoaded(loadedSpecies);
 
       for (const animal of loadedSpecies) {

--- a/packages/jazz-tools/src/tools/tests/coOptional.test.ts
+++ b/packages/jazz-tools/src/tools/tests/coOptional.test.ts
@@ -124,4 +124,16 @@ describe("co.optional", () => {
 
     expect(person?.preferredName?.toString()).toEqual("John");
   });
+
+  test("can set undefined to an optional field", () => {
+    const Person = co.map({
+      name: co.optional(co.plainText()),
+    });
+
+    const person = Person.create({});
+
+    person.$jazz.set("name", undefined);
+
+    expect(person.name).toBeUndefined();
+  });
 });


### PR DESCRIPTION
While exploring the possibility of using zod transforms during schema validation, I encountered a case not handled by the validation `z.instanceOf(CoMap).or(plainSchema)`.

If the data is a coValue but not a CoMap, it was validated against the plain schema. The result wasn't wrong: the validation threw an error, but it made no sense to validate the `coValue.toJSON`.

This PR replaces the `z.instanceOf(CoMap).or(plainSchema)` pattern with `z.unknown().superRefine` and uses zod metadata to store a reference to the plainSchema. Same output, better readability.