### PR TITLE
feat: implement indexed row state and update handling in output and sort nodes

### DIFF
--- a/crates/groove-wasm/src/runtime.rs
+++ b/crates/groove-wasm/src/runtime.rs
@@ -23,13 +23,19 @@ use wasm_bindgen::prelude::*;
 use groove::object::ObjectId;
 #[cfg(target_arch = "wasm32")]
 use groove::query_manager::encoding::decode_row;
+#[cfg(any(target_arch = "wasm32", test))]
+use groove::query_manager::graph_nodes::output::index_row_delta;
 use groove::query_manager::session::Session;
+#[cfg(any(target_arch = "wasm32", test))]
+use groove::query_manager::types::Row;
 #[cfg(target_arch = "wasm32")]
-use groove::query_manager::types::{Row, RowDescriptor};
+use groove::query_manager::types::RowDescriptor;
 use groove::query_manager::types::{Schema, Value};
 use groove::runtime_core::{RuntimeCore, Scheduler, SyncSender};
+#[cfg(any(target_arch = "wasm32", test))]
+use groove::runtime_core::SubscriptionDelta;
 #[cfg(target_arch = "wasm32")]
-use groove::runtime_core::{SubscriptionDelta, SubscriptionHandle};
+use groove::runtime_core::SubscriptionHandle;
 use groove::schema_manager::{AppId, SchemaManager};
 use groove::storage::BfTreeStorage;
 use groove::sync_manager::{
@@ -50,6 +56,73 @@ fn parse_tier(tier: &str) -> Result<PersistenceTier, JsError> {
             tier
         ))),
     }
+}
+
+#[cfg(any(target_arch = "wasm32", test))]
+fn build_wasm_delta_json<F>(
+    delta: &SubscriptionDelta,
+    current_ids: &mut Vec<ObjectId>,
+    mut row_to_json: F,
+) -> serde_json::Value
+where
+    F: FnMut(&Row) -> serde_json::Value,
+{
+    let indexed = index_row_delta(current_ids, &delta.delta);
+
+    let added = delta
+        .delta
+        .added
+        .iter()
+        .map(|row| {
+            let row_json = row_to_json(row);
+            let index = indexed.post_index_by_id.get(&row.id).copied().unwrap_or(0);
+            serde_json::json!({
+                "row": row_json,
+                "index": index
+            })
+        })
+        .collect::<Vec<_>>();
+
+    let removed = delta
+        .delta
+        .removed
+        .iter()
+        .map(|row| {
+            let row_json = row_to_json(row);
+            let index = indexed.pre_index_by_id.get(&row.id).copied().unwrap_or(0);
+            serde_json::json!({
+                "row": row_json,
+                "index": index
+            })
+        })
+        .collect::<Vec<_>>();
+
+    let updated = delta
+        .delta
+        .updated
+        .iter()
+        .map(|(old, new)| {
+            let old_json = row_to_json(old);
+            let new_json = row_to_json(new);
+            let old_index = indexed.pre_index_by_id.get(&old.id).copied().unwrap_or(0);
+            let new_index = indexed.post_index_by_id.get(&new.id).copied().unwrap_or(0);
+            serde_json::json!({
+                "old_row": old_json,
+                "new_row": new_json,
+                "old_index": old_index,
+                "new_index": new_index
+            })
+        })
+        .collect::<Vec<_>>();
+
+    *current_ids = indexed.post_ids;
+
+    serde_json::json!({
+        "added": added,
+        "removed": removed,
+        "updated": updated,
+        "pending": false
+    })
 }
 
 // ============================================================================
@@ -533,6 +606,9 @@ impl WasmRuntime {
 
         let tier = settled_tier.as_deref().map(parse_tier).transpose()?;
 
+        let current_ids: Rc<RefCell<Vec<ObjectId>>> = Rc::new(RefCell::new(Vec::new()));
+        let current_ids_for_callback = current_ids.clone();
+
         let callback = move |delta: SubscriptionDelta| {
             let row_to_json = |row: &Row, descriptor: &RowDescriptor| -> serde_json::Value {
                 let values = decode_row(descriptor, &row.data)
@@ -545,18 +621,8 @@ impl WasmRuntime {
             };
 
             let descriptor = &delta.descriptor;
-
-            let delta_json = serde_json::json!({
-                "added": delta.delta.added.iter()
-                    .map(|row| row_to_json(row, descriptor))
-                    .collect::<Vec<_>>(),
-                "removed": delta.delta.removed.iter()
-                    .map(|row| row_to_json(row, descriptor))
-                    .collect::<Vec<_>>(),
-                "updated": delta.delta.updated.iter()
-                    .map(|(old, new)| [row_to_json(old, descriptor), row_to_json(new, descriptor)])
-                    .collect::<Vec<_>>()
-            });
+            let mut ids = current_ids_for_callback.borrow_mut();
+            let delta_json = build_wasm_delta_json(&delta, &mut ids, |row| row_to_json(row, descriptor));
 
             if let Ok(json_str) = serde_json::to_string(&delta_json) {
                 let _ = on_update.call1(&JsValue::NULL, &JsValue::from_str(&json_str));
@@ -741,5 +807,167 @@ impl WasmRuntime {
         core_rc.borrow_mut().persist_schema();
 
         Ok(WasmRuntime { core: core_rc })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use groove::commit::CommitId;
+    use groove::object::ObjectId;
+    use groove::query_manager::types::{Row, RowDelta, RowDescriptor};
+    use groove::runtime_core::{SubscriptionDelta, SubscriptionHandle};
+
+    fn row(id: ObjectId) -> Row {
+        Row {
+            id,
+            data: vec![],
+            commit_id: CommitId([0; 32]),
+        }
+    }
+
+    fn delta(
+        added: Vec<Row>,
+        removed: Vec<Row>,
+        updated: Vec<(Row, Row)>,
+    ) -> SubscriptionDelta {
+        SubscriptionDelta {
+            handle: SubscriptionHandle(0),
+            delta: RowDelta {
+                added,
+                removed,
+                updated,
+            },
+            descriptor: RowDescriptor::new(vec![]),
+        }
+    }
+
+    #[test]
+    fn wasm_delta_json_add_uses_post_index_and_updates_state() {
+        let id_a = ObjectId::new();
+        let id_b = ObjectId::new();
+        let id_c = ObjectId::new();
+
+        let mut current_ids = vec![id_a, id_b];
+        let d = delta(vec![row(id_c)], vec![], vec![]);
+
+        let json = build_wasm_delta_json(&d, &mut current_ids, |r| {
+            serde_json::json!({ "id": r.id.uuid().to_string() })
+        });
+
+        assert_eq!(json["added"][0]["index"], serde_json::json!(2));
+        assert_eq!(json["pending"], serde_json::json!(false));
+        assert_eq!(current_ids, vec![id_a, id_b, id_c]);
+    }
+
+    #[test]
+    fn wasm_delta_json_remove_uses_pre_index() {
+        let id_a = ObjectId::new();
+        let id_b = ObjectId::new();
+        let id_c = ObjectId::new();
+
+        let mut current_ids = vec![id_a, id_b, id_c];
+        let d = delta(vec![], vec![row(id_b)], vec![]);
+
+        let json = build_wasm_delta_json(&d, &mut current_ids, |r| {
+            serde_json::json!({ "id": r.id.uuid().to_string() })
+        });
+
+        assert_eq!(json["removed"][0]["index"], serde_json::json!(1));
+        assert_eq!(current_ids, vec![id_a, id_c]);
+    }
+
+    #[test]
+    fn wasm_delta_json_updated_identity_change_has_old_and_new_indices() {
+        let id_a = ObjectId::new();
+        let id_b = ObjectId::new();
+        let id_c = ObjectId::new();
+
+        let mut current_ids = vec![id_a, id_b];
+        let d = delta(vec![], vec![], vec![(row(id_b), row(id_c))]);
+
+        let json = build_wasm_delta_json(&d, &mut current_ids, |r| {
+            serde_json::json!({ "id": r.id.uuid().to_string() })
+        });
+
+        assert_eq!(json["updated"][0]["old_index"], serde_json::json!(1));
+        assert_eq!(json["updated"][0]["new_index"], serde_json::json!(1));
+        assert_eq!(current_ids, vec![id_a, id_c]);
+    }
+
+    #[test]
+    fn wasm_delta_json_updated_identity_preserving_moves_row_to_end() {
+        let id_a = ObjectId::new();
+        let id_b = ObjectId::new();
+        let id_c = ObjectId::new();
+
+        // Pre: [A, B, C]
+        let mut current_ids = vec![id_a, id_b, id_c];
+
+        // Identity-preserving update for B.
+        // Expected post with current wasm delta semantics: [A, C, B]
+        let d = delta(vec![], vec![], vec![(row(id_b), row(id_b))]);
+
+        let json = build_wasm_delta_json(&d, &mut current_ids, |r| {
+            serde_json::json!({ "id": r.id.uuid().to_string() })
+        });
+
+        assert_eq!(json["updated"][0]["old_index"], serde_json::json!(1));
+        assert_eq!(json["updated"][0]["new_index"], serde_json::json!(2));
+        assert_eq!(current_ids, vec![id_a, id_c, id_b]);
+    }
+
+    #[test]
+    fn wasm_delta_json_add_and_move_via_readd() {
+        let id_a = ObjectId::new();
+        let id_b = ObjectId::new();
+        let id_new = ObjectId::new();
+
+        // Initial: [A, B]
+        let mut current_ids = vec![id_a, id_b];
+
+        // Operation: Remove B, Add New, Add B.
+        // This simulates moving B to the end and inserting New before it.
+        // Result should be [A, New, B].
+        let d = delta(
+            vec![row(id_new), row(id_b)],
+            vec![row(id_b)],
+            vec![],
+        );
+
+        let json = build_wasm_delta_json(&d, &mut current_ids, |r| {
+            serde_json::json!({ "id": r.id.uuid().to_string() })
+        });
+
+        // Verify State
+        assert_eq!(current_ids, vec![id_a, id_new, id_b]);
+
+        // Verify JSON Output
+        // Removed B from index 1
+        let removed_b = json["removed"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|x| x["row"]["id"] == id_b.uuid().to_string())
+            .unwrap();
+        assert_eq!(removed_b["index"], 1);
+
+        // Added New at index 1
+        let added_new = json["added"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|x| x["row"]["id"] == id_new.uuid().to_string())
+            .unwrap();
+        assert_eq!(added_new["index"], 1);
+
+        // Added B at index 2 (Moved)
+        let added_b = json["added"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|x| x["row"]["id"] == id_b.uuid().to_string())
+            .unwrap();
+        assert_eq!(added_b["index"], 2);
     }
 }

--- a/crates/groove-wasm/src/runtime.rs
+++ b/crates/groove-wasm/src/runtime.rs
@@ -31,11 +31,11 @@ use groove::query_manager::types::Row;
 #[cfg(target_arch = "wasm32")]
 use groove::query_manager::types::RowDescriptor;
 use groove::query_manager::types::{Schema, Value};
-use groove::runtime_core::{RuntimeCore, Scheduler, SyncSender};
 #[cfg(any(target_arch = "wasm32", test))]
 use groove::runtime_core::SubscriptionDelta;
 #[cfg(target_arch = "wasm32")]
 use groove::runtime_core::SubscriptionHandle;
+use groove::runtime_core::{RuntimeCore, Scheduler, SyncSender};
 use groove::schema_manager::{AppId, SchemaManager};
 use groove::storage::BfTreeStorage;
 use groove::sync_manager::{
@@ -621,7 +621,8 @@ impl WasmRuntime {
 
             let descriptor = &delta.descriptor;
             let mut ids = current_ids.borrow_mut();
-            let delta_json = build_wasm_delta_json(&delta, &mut ids, |row| row_to_json(row, descriptor));
+            let delta_json =
+                build_wasm_delta_json(&delta, &mut ids, |row| row_to_json(row, descriptor));
 
             if let Ok(json_str) = serde_json::to_string(&delta_json) {
                 let _ = on_update.call1(&JsValue::NULL, &JsValue::from_str(&json_str));
@@ -825,11 +826,7 @@ mod tests {
         }
     }
 
-    fn delta(
-        added: Vec<Row>,
-        removed: Vec<Row>,
-        updated: Vec<(Row, Row)>,
-    ) -> SubscriptionDelta {
+    fn delta(added: Vec<Row>, removed: Vec<Row>, updated: Vec<(Row, Row)>) -> SubscriptionDelta {
         SubscriptionDelta {
             handle: SubscriptionHandle(0),
             delta: RowDelta {
@@ -850,9 +847,11 @@ mod tests {
         let mut current_ids = vec![id_a, id_b];
         let d = delta(vec![row(id_c)], vec![], vec![]);
 
-        let json = build_wasm_delta_json(&d, &mut current_ids, |r| {
-            serde_json::json!({ "id": r.id.uuid().to_string() })
-        });
+        let json = build_wasm_delta_json(
+            &d,
+            &mut current_ids,
+            |r| serde_json::json!({ "id": r.id.uuid().to_string() }),
+        );
 
         assert_eq!(json["added"][0]["index"], serde_json::json!(2));
         assert_eq!(json["pending"], serde_json::json!(false));
@@ -868,9 +867,11 @@ mod tests {
         let mut current_ids = vec![id_a, id_b, id_c];
         let d = delta(vec![], vec![row(id_b)], vec![]);
 
-        let json = build_wasm_delta_json(&d, &mut current_ids, |r| {
-            serde_json::json!({ "id": r.id.uuid().to_string() })
-        });
+        let json = build_wasm_delta_json(
+            &d,
+            &mut current_ids,
+            |r| serde_json::json!({ "id": r.id.uuid().to_string() }),
+        );
 
         assert_eq!(json["removed"][0]["index"], serde_json::json!(1));
         assert_eq!(current_ids, vec![id_a, id_c]);
@@ -885,9 +886,11 @@ mod tests {
         let mut current_ids = vec![id_a, id_b];
         let d = delta(vec![], vec![], vec![(row(id_b), row(id_c))]);
 
-        let json = build_wasm_delta_json(&d, &mut current_ids, |r| {
-            serde_json::json!({ "id": r.id.uuid().to_string() })
-        });
+        let json = build_wasm_delta_json(
+            &d,
+            &mut current_ids,
+            |r| serde_json::json!({ "id": r.id.uuid().to_string() }),
+        );
 
         assert_eq!(json["updated"][0]["old_index"], serde_json::json!(1));
         assert_eq!(json["updated"][0]["new_index"], serde_json::json!(1));
@@ -907,9 +910,11 @@ mod tests {
         // Expected post with current wasm delta semantics: [A, C, B]
         let d = delta(vec![], vec![], vec![(row(id_b), row(id_b))]);
 
-        let json = build_wasm_delta_json(&d, &mut current_ids, |r| {
-            serde_json::json!({ "id": r.id.uuid().to_string() })
-        });
+        let json = build_wasm_delta_json(
+            &d,
+            &mut current_ids,
+            |r| serde_json::json!({ "id": r.id.uuid().to_string() }),
+        );
 
         assert_eq!(json["updated"][0]["old_index"], serde_json::json!(1));
         assert_eq!(json["updated"][0]["new_index"], serde_json::json!(2));
@@ -928,15 +933,13 @@ mod tests {
         // Operation: Remove B, Add New, Add B.
         // This simulates moving B to the end and inserting New before it.
         // Result should be [A, New, B].
-        let d = delta(
-            vec![row(id_new), row(id_b)],
-            vec![row(id_b)],
-            vec![],
-        );
+        let d = delta(vec![row(id_new), row(id_b)], vec![row(id_b)], vec![]);
 
-        let json = build_wasm_delta_json(&d, &mut current_ids, |r| {
-            serde_json::json!({ "id": r.id.uuid().to_string() })
-        });
+        let json = build_wasm_delta_json(
+            &d,
+            &mut current_ids,
+            |r| serde_json::json!({ "id": r.id.uuid().to_string() }),
+        );
 
         // Verify State
         assert_eq!(current_ids, vec![id_a, id_new, id_b]);

--- a/crates/groove-wasm/src/runtime.rs
+++ b/crates/groove-wasm/src/runtime.rs
@@ -607,7 +607,6 @@ impl WasmRuntime {
         let tier = settled_tier.as_deref().map(parse_tier).transpose()?;
 
         let current_ids: Rc<RefCell<Vec<ObjectId>>> = Rc::new(RefCell::new(Vec::new()));
-        let current_ids_for_callback = current_ids.clone();
 
         let callback = move |delta: SubscriptionDelta| {
             let row_to_json = |row: &Row, descriptor: &RowDescriptor| -> serde_json::Value {
@@ -621,7 +620,7 @@ impl WasmRuntime {
             };
 
             let descriptor = &delta.descriptor;
-            let mut ids = current_ids_for_callback.borrow_mut();
+            let mut ids = current_ids.borrow_mut();
             let delta_json = build_wasm_delta_json(&delta, &mut ids, |row| row_to_json(row, descriptor));
 
             if let Ok(json_str) = serde_json::to_string(&delta_json) {

--- a/crates/groove-wasm/src/types.rs
+++ b/crates/groove-wasm/src/types.rs
@@ -86,13 +86,39 @@ pub struct WasmRow {
     pub values: Vec<WasmValue>,
 }
 
+/// Row + post-delta index for added rows.
+#[derive(Debug, Clone, Serialize, Deserialize, Tsify)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+pub struct WasmIndexedRow {
+    pub row: WasmRow,
+    pub index: usize,
+}
+
+/// Updated row pair with pre/post indices.
+#[derive(Debug, Clone, Serialize, Deserialize, Tsify)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+pub struct WasmUpdatedIndexedRow {
+    pub old_row: WasmRow,
+    pub new_row: WasmRow,
+    pub old_index: usize,
+    pub new_index: usize,
+}
+
+/// Removed row + pre-delta index.
+#[derive(Debug, Clone, Serialize, Deserialize, Tsify)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+pub struct WasmRemovedIndexedRow {
+    pub row: WasmRow,
+    pub index: usize,
+}
+
 /// Delta for row-level changes (mirrors groove::query_manager::types::RowDelta).
 #[derive(Debug, Clone, Default, Serialize, Deserialize, Tsify)]
 #[tsify(into_wasm_abi, from_wasm_abi)]
 pub struct WasmRowDelta {
-    pub added: Vec<WasmRow>,
-    pub removed: Vec<WasmRow>,
-    pub updated: Vec<(WasmRow, WasmRow)>,
+    pub added: Vec<WasmIndexedRow>,
+    pub removed: Vec<WasmRemovedIndexedRow>,
+    pub updated: Vec<WasmUpdatedIndexedRow>,
     pub pending: bool,
 }
 

--- a/crates/groove/src/query_manager/graph_nodes/output.rs
+++ b/crates/groove/src/query_manager/graph_nodes/output.rs
@@ -153,7 +153,10 @@ pub struct IndexedRowState {
 /// - start from prior order and detach removed + updated-old ids
 /// - append `added` ids (stream order)
 /// - append `updated.new` ids (stream order, enables moves)
-pub fn index_row_delta(current_ids: &[crate::object::ObjectId], delta: &RowDelta) -> IndexedRowState {
+pub fn index_row_delta(
+    current_ids: &[crate::object::ObjectId],
+    delta: &RowDelta,
+) -> IndexedRowState {
     // ASCII flow:
     // pre:    [A, B, C]
     // detach:    ^B
@@ -307,10 +310,73 @@ mod tests {
         OutputNode::with_tuple_descriptor(tuple_desc, mode)
     }
 
+    fn make_row(id: ObjectId) -> Row {
+        Row {
+            id,
+            data: vec![],
+            commit_id: CommitId([0; 32]),
+        }
+    }
+
     fn ordered_ids(node: &OutputNode) -> Vec<ObjectId> {
         node.ordered_tuples.iter().map(|t| t.ids()[0]).collect()
     }
 
+    fn assert_indexed_invariants(
+        pre_ids: &[ObjectId],
+        delta: &RowDelta,
+        indexed: &IndexedRowState,
+    ) {
+        // pre_index_by_id must match pre_ids exactly
+        for (idx, id) in pre_ids.iter().enumerate() {
+            assert_eq!(indexed.pre_index_by_id.get(id), Some(&idx));
+        }
+
+        // post_index_by_id must be a perfect index map of post_ids
+        for (idx, id) in indexed.post_ids.iter().enumerate() {
+            assert_eq!(indexed.post_index_by_id.get(id), Some(&idx));
+        }
+        assert_eq!(indexed.post_index_by_id.len(), indexed.post_ids.len());
+
+        // post_ids must be unique
+        let unique: std::collections::HashSet<_> = indexed.post_ids.iter().copied().collect();
+        assert_eq!(unique.len(), indexed.post_ids.len());
+
+        // Length sanity: post = survivors + inserted_unique
+        let mut detached = std::collections::HashSet::new();
+        for row in &delta.removed {
+            detached.insert(row.id);
+        }
+        for (old, _) in &delta.updated {
+            detached.insert(old.id);
+        }
+        let survivors: Vec<_> = pre_ids
+            .iter()
+            .copied()
+            .filter(|id| !detached.contains(id))
+            .collect();
+
+        let mut seen: std::collections::HashSet<_> = survivors.iter().copied().collect();
+        let mut inserted_unique = 0usize;
+        for id in delta
+            .added
+            .iter()
+            .map(|r| r.id)
+            .chain(delta.updated.iter().map(|(_, new)| new.id))
+        {
+            if seen.insert(id) {
+                inserted_unique += 1;
+            }
+        }
+
+        assert_eq!(indexed.post_ids.len(), survivors.len() + inserted_unique);
+    }
+
+    // Scenario: output node stores any non-empty delta for subscribers.
+    //
+    // ASCII:
+    // input_delta:  +[Alice]
+    // pending:      [delta1]
     #[test]
     fn output_stores_deltas() {
         let mut node = make_output_node(OutputMode::Delta);
@@ -331,6 +397,11 @@ mod tests {
         assert_eq!(deltas[0].added.len(), 1);
     }
 
+    // Scenario: current rows decode to user values.
+    //
+    // ASCII:
+    // tuples:   [id1 -> (1, "Alice")]
+    // decoded:  [[1, "Alice"]]
     #[test]
     fn output_decodes_current() {
         let mut node = make_output_node(OutputMode::Full);
@@ -350,6 +421,11 @@ mod tests {
         assert_eq!(decoded[0][1], Value::Text("Alice".into()));
     }
 
+    // Scenario: decode_delta maps row bytes to typed value vectors.
+    //
+    // ASCII:
+    // row_delta.added: [id1]
+    // decoded.added:   [(id1, [1, "Alice"])]
     #[test]
     fn output_decodes_delta() {
         let node = make_output_node(OutputMode::Delta);
@@ -378,6 +454,11 @@ mod tests {
         assert_eq!(decoded.added[0].1[1], Value::Text("Alice".into()));
     }
 
+    // Scenario: empty deltas are not buffered for delivery.
+    //
+    // ASCII:
+    // input_delta:   empty
+    // pending_queue: []
     #[test]
     fn empty_delta_not_stored() {
         let mut node = make_output_node(OutputMode::Delta);
@@ -389,6 +470,11 @@ mod tests {
         assert!(deltas.is_empty());
     }
 
+    // Scenario: each non-empty process call is delivered immediately.
+    //
+    // ASCII:
+    // tick1: +A -> deliver [deltaA]
+    // tick2: +B -> deliver [deltaB]
     #[test]
     fn output_delivers_immediately() {
         let mut node = make_output_node(OutputMode::Delta);
@@ -425,34 +511,190 @@ mod tests {
         assert_eq!(deltas[0].added.len(), 1);
     }
 
+    // Scenario: append add keeps existing order and places new row at tail.
+    //
+    // ASCII:
+    // pre:   [A, B]
+    // delta: +C
+    // post:  [A, B, C]
     #[test]
-    fn index_row_delta_tracks_remove_add_and_move() {
+    fn index_row_delta_append_add_uses_tail_index() {
+        let id_a = ObjectId::new();
+        let id_b = ObjectId::new();
+        let id_c = ObjectId::new();
+        let delta = RowDelta {
+            added: vec![make_row(id_c)],
+            removed: vec![],
+            updated: vec![],
+        };
+
+        let indexed = index_row_delta(&[id_a, id_b], &delta);
+        assert_indexed_invariants(&[id_a, id_b], &delta, &indexed);
+        assert_eq!(indexed.post_ids, vec![id_a, id_b, id_c]);
+        assert_eq!(indexed.post_index_by_id.get(&id_c), Some(&2));
+    }
+
+    // Scenario: middle insert expressed as "add + move-updates".
+    //
+    // ASCII:
+    // pre:   [A, B, C]
+    // delta: +X, upd(B->B), upd(C->C)
+    // post:  [A, X, B, C]
+    #[test]
+    fn index_row_delta_middle_insert_via_shift_updates() {
+        let id_a = ObjectId::new();
+        let id_b = ObjectId::new();
+        let id_c = ObjectId::new();
+        let id_x = ObjectId::new();
+
+        // pre [A, B, C], add X, move B/C => post [A, X, B, C]
+        let delta = RowDelta {
+            added: vec![make_row(id_x)],
+            removed: vec![],
+            updated: vec![
+                (make_row(id_b), make_row(id_b)),
+                (make_row(id_c), make_row(id_c)),
+            ],
+        };
+
+        let indexed = index_row_delta(&[id_a, id_b, id_c], &delta);
+        assert_indexed_invariants(&[id_a, id_b, id_c], &delta, &indexed);
+        assert_eq!(indexed.post_ids, vec![id_a, id_x, id_b, id_c]);
+        assert_eq!(indexed.pre_index_by_id.get(&id_b), Some(&1));
+        assert_eq!(indexed.post_index_by_id.get(&id_b), Some(&2));
+    }
+
+    // Scenario: removing first row preserves pre-index semantics.
+    //
+    // ASCII:
+    // pre:   [A, B, C]
+    // delta: -A
+    // post:  [B, C]
+    #[test]
+    fn index_row_delta_remove_first_preserves_pre_indices() {
+        let id_a = ObjectId::new();
+        let id_b = ObjectId::new();
+        let id_c = ObjectId::new();
+        let delta = RowDelta {
+            added: vec![],
+            removed: vec![make_row(id_a)],
+            updated: vec![],
+        };
+
+        let indexed = index_row_delta(&[id_a, id_b, id_c], &delta);
+        assert_indexed_invariants(&[id_a, id_b, id_c], &delta, &indexed);
+        assert_eq!(indexed.pre_index_by_id.get(&id_a), Some(&0));
+        assert_eq!(indexed.post_ids, vec![id_b, id_c]);
+    }
+
+    // Scenario: identity-preserving update can still represent a move.
+    //
+    // ASCII:
+    // pre:   [A, B, C]
+    // delta: upd(B->B)
+    // post:  [A, C, B]
+    #[test]
+    fn index_row_delta_identity_preserving_update_moves_row() {
+        let id_a = ObjectId::new();
+        let id_b = ObjectId::new();
+        let id_c = ObjectId::new();
+
+        // pre [A, B, C], update B->B => post [A, C, B]
+        let delta = RowDelta {
+            added: vec![],
+            removed: vec![],
+            updated: vec![(make_row(id_b), make_row(id_b))],
+        };
+
+        let indexed = index_row_delta(&[id_a, id_b, id_c], &delta);
+        assert_indexed_invariants(&[id_a, id_b, id_c], &delta, &indexed);
+        assert_eq!(indexed.pre_index_by_id.get(&id_b), Some(&1));
+        assert_eq!(indexed.post_index_by_id.get(&id_b), Some(&2));
+        assert_eq!(indexed.post_ids, vec![id_a, id_c, id_b]);
+    }
+
+    // Scenario: identity change behaves like remove old + add new.
+    //
+    // ASCII:
+    // pre:   [A, B]
+    // delta: upd(B->N)
+    // post:  [A, N]
+    #[test]
+    fn index_row_delta_identity_change_behaves_like_remove_add() {
         let id_a = ObjectId::new();
         let id_b = ObjectId::new();
         let id_new = ObjectId::new();
-        let row = |id: ObjectId| Row {
-            id,
-            data: vec![],
-            commit_id: CommitId([0; 32]),
-        };
 
-        // pre: [A, B]
-        // delta: remove B, add New, update A->A (move)
-        // post: [New, A]
         let delta = RowDelta {
-            added: vec![row(id_new)],
-            removed: vec![row(id_b)],
-            updated: vec![(row(id_a), row(id_a))],
+            added: vec![],
+            removed: vec![],
+            updated: vec![(make_row(id_b), make_row(id_new))],
         };
-        let indexed = index_row_delta(&[id_a, id_b], &delta);
 
-        assert_eq!(indexed.pre_index_by_id.get(&id_a), Some(&0));
+        let indexed = index_row_delta(&[id_a, id_b], &delta);
+        assert_indexed_invariants(&[id_a, id_b], &delta, &indexed);
         assert_eq!(indexed.pre_index_by_id.get(&id_b), Some(&1));
-        assert_eq!(indexed.post_index_by_id.get(&id_new), Some(&0));
-        assert_eq!(indexed.post_index_by_id.get(&id_a), Some(&1));
-        assert_eq!(indexed.post_ids, vec![id_new, id_a]);
+        assert_eq!(indexed.post_index_by_id.get(&id_new), Some(&1));
+        assert_eq!(indexed.post_ids, vec![id_a, id_new]);
     }
 
+    // Scenario: mixed batch keeps deterministic final order.
+    //
+    // ASCII:
+    // pre:   [A, B, C]
+    // delta: -B, +D, upd(C->C)
+    // post:  [A, D, C]
+    #[test]
+    fn index_row_delta_mixed_batch_is_deterministic() {
+        let id_a = ObjectId::new();
+        let id_b = ObjectId::new();
+        let id_c = ObjectId::new();
+        let id_d = ObjectId::new();
+
+        // pre [A, B, C], remove B, add D, move C => post [A, D, C]
+        let delta = RowDelta {
+            added: vec![make_row(id_d)],
+            removed: vec![make_row(id_b)],
+            updated: vec![(make_row(id_c), make_row(id_c))],
+        };
+
+        let indexed = index_row_delta(&[id_a, id_b, id_c], &delta);
+        assert_indexed_invariants(&[id_a, id_b, id_c], &delta, &indexed);
+        assert_eq!(indexed.post_ids, vec![id_a, id_d, id_c]);
+    }
+
+    // Scenario: duplicate ids are deduped; first insertion point wins.
+    //
+    // ASCII:
+    // pre:   [A, B]
+    // delta: +X, +X, upd(B->X)
+    // post:  [A, X]
+    #[test]
+    fn index_row_delta_dedupes_duplicate_ids_first_occurrence_wins() {
+        let id_a = ObjectId::new();
+        let id_b = ObjectId::new();
+        let id_x = ObjectId::new();
+
+        // Duplicated X across added and updated-new should appear once, positioned
+        // at first insertion opportunity (added stream comes before updated stream).
+        let delta = RowDelta {
+            added: vec![make_row(id_x), make_row(id_x)],
+            removed: vec![],
+            updated: vec![(make_row(id_b), make_row(id_x))],
+        };
+
+        let indexed = index_row_delta(&[id_a, id_b], &delta);
+        assert_indexed_invariants(&[id_a, id_b], &delta, &indexed);
+        assert_eq!(indexed.post_ids, vec![id_a, id_x]);
+        assert_eq!(indexed.post_index_by_id.get(&id_x), Some(&1));
+    }
+
+    // Scenario: output node applies move updates for stable identity rows.
+    //
+    // ASCII:
+    // pre:   [A, B]
+    // delta: +C, upd(A->A), upd(B->B)
+    // post:  [C, A, B]
     #[test]
     fn output_applies_identity_updates_as_moves() {
         let mut node = make_output_node(OutputMode::Delta);
@@ -480,5 +722,119 @@ mod tests {
         });
 
         assert_eq!(ordered_ids(&node), vec![id_c, id_a, id_b]);
+    }
+
+    // Scenario: remove-only keeps survivors in original relative order.
+    //
+    // ASCII:
+    // pre:   [A, B, C]
+    // delta: -B
+    // post:  [A, C]
+    #[test]
+    fn output_remove_only_keeps_survivor_relative_order() {
+        let mut node = make_output_node(OutputMode::Delta);
+        let id_a = ObjectId::new();
+        let id_b = ObjectId::new();
+        let id_c = ObjectId::new();
+        let a = make_tuple(id_a, 1, "A");
+        let b = make_tuple(id_b, 2, "B");
+        let c = make_tuple(id_c, 3, "C");
+
+        node.process(TupleDelta {
+            added: vec![a, b.clone(), c],
+            removed: vec![],
+            updated: vec![],
+        });
+        node.process(TupleDelta {
+            added: vec![],
+            removed: vec![b],
+            updated: vec![],
+        });
+
+        assert_eq!(ordered_ids(&node), vec![id_a, id_c]);
+    }
+
+    // Scenario: identity-changing update swaps id after detach/reinsert.
+    //
+    // ASCII:
+    // pre:   [A, B]
+    // delta: upd(B->C)
+    // post:  [A, C]
+    #[test]
+    fn output_identity_change_update_replaces_id_in_place_after_detach() {
+        let mut node = make_output_node(OutputMode::Delta);
+        let id_a = ObjectId::new();
+        let id_b = ObjectId::new();
+        let id_c = ObjectId::new();
+        let a = make_tuple(id_a, 1, "A");
+        let b = make_tuple(id_b, 2, "B");
+        let c = make_tuple(id_c, 2, "C");
+
+        node.process(TupleDelta {
+            added: vec![a.clone(), b.clone()],
+            removed: vec![],
+            updated: vec![],
+        });
+        node.process(TupleDelta {
+            added: vec![],
+            removed: vec![],
+            updated: vec![(b, c)],
+        });
+
+        assert_eq!(ordered_ids(&node), vec![id_a, id_c]);
+    }
+
+    // Scenario: repeated updates for same id do not duplicate rows.
+    //
+    // ASCII:
+    // pre:   [A]
+    // delta: upd(A1->A2), upd(A3->A3)
+    // post:  [A]
+    #[test]
+    fn output_repeated_updates_same_id_in_one_delta_do_not_duplicate() {
+        let mut node = make_output_node(OutputMode::Delta);
+        let id_a = ObjectId::new();
+        let a_v1 = make_tuple(id_a, 1, "A1");
+        let a_v2 = make_tuple(id_a, 2, "A2");
+        let a_v3 = make_tuple(id_a, 3, "A3");
+
+        node.process(TupleDelta {
+            added: vec![a_v1.clone()],
+            removed: vec![],
+            updated: vec![],
+        });
+        node.process(TupleDelta {
+            added: vec![],
+            removed: vec![],
+            updated: vec![(a_v1, a_v2), (a_v3.clone(), a_v3)],
+        });
+
+        assert_eq!(ordered_ids(&node), vec![id_a]);
+    }
+
+    // Scenario: sequential add then remove of same id returns to empty state.
+    //
+    // ASCII:
+    // tick1: [] +A -> [A]
+    // tick2: [A] -A -> []
+    #[test]
+    fn output_add_then_remove_same_id_across_ticks_is_stable() {
+        let mut node = make_output_node(OutputMode::Delta);
+        let id_a = ObjectId::new();
+        let a = make_tuple(id_a, 1, "A");
+
+        node.process(TupleDelta {
+            added: vec![a.clone()],
+            removed: vec![],
+            updated: vec![],
+        });
+        assert_eq!(ordered_ids(&node), vec![id_a]);
+
+        node.process(TupleDelta {
+            added: vec![],
+            removed: vec![a],
+            updated: vec![],
+        });
+        assert!(ordered_ids(&node).is_empty());
     }
 }

--- a/crates/groove/src/query_manager/graph_nodes/output.rs
+++ b/crates/groove/src/query_manager/graph_nodes/output.rs
@@ -1,4 +1,5 @@
 use ahash::AHashSet;
+use std::collections::{HashMap, HashSet};
 
 use crate::query_manager::encoding::decode_row;
 use crate::query_manager::types::{
@@ -135,31 +136,121 @@ pub struct DecodedDelta {
     pub updated: Vec<(crate::object::ObjectId, Vec<Value>, Vec<Value>)>,
 }
 
+/// Indexed state derived from a row delta and previous output order.
+///
+/// This is used by adapters (e.g. wasm) to build stable index-based deltas
+/// without re-implementing output ordering logic.
+#[derive(Debug, Clone)]
+pub struct IndexedRowState {
+    pub pre_index_by_id: HashMap<crate::object::ObjectId, usize>,
+    pub post_index_by_id: HashMap<crate::object::ObjectId, usize>,
+    pub post_ids: Vec<crate::object::ObjectId>,
+}
+
+/// Compute pre/post index maps for a `RowDelta`, given the prior ordered ids.
+///
+/// Ordering rules:
+/// - start from prior order and detach removed + updated-old ids
+/// - append `added` ids (stream order)
+/// - append `updated.new` ids (stream order, enables moves)
+pub fn index_row_delta(current_ids: &[crate::object::ObjectId], delta: &RowDelta) -> IndexedRowState {
+    // ASCII flow:
+    // pre:    [A, B, C]
+    // detach:    ^B
+    // base:   [A, C]
+    // +added: [A, C, N]
+    // +upd:   [A, C, N, B]
+
+    let pre_index_by_id: HashMap<_, _> = current_ids
+        .iter()
+        .enumerate()
+        .map(|(index, id)| (*id, index))
+        .collect();
+
+    let mut ids_to_detach = HashSet::new();
+    for row in &delta.removed {
+        ids_to_detach.insert(row.id);
+    }
+    for (old, _) in &delta.updated {
+        ids_to_detach.insert(old.id);
+    }
+
+    let mut post_ids = Vec::with_capacity(current_ids.len() + delta.added.len());
+    let mut post_index_by_id = HashMap::new();
+
+    for id in current_ids {
+        if !ids_to_detach.contains(id) {
+            post_index_by_id.insert(*id, post_ids.len());
+            post_ids.push(*id);
+        }
+    }
+
+    let mut append_if_missing = |id: crate::object::ObjectId| {
+        if let std::collections::hash_map::Entry::Vacant(entry) = post_index_by_id.entry(id) {
+            entry.insert(post_ids.len());
+            post_ids.push(id);
+        }
+    };
+
+    for row in &delta.added {
+        append_if_missing(row.id);
+    }
+
+    for (_, new) in &delta.updated {
+        append_if_missing(new.id);
+    }
+
+    IndexedRowState {
+        pre_index_by_id,
+        post_index_by_id,
+        post_ids,
+    }
+}
+
 impl RowNode for OutputNode {
     fn output_descriptor(&self) -> &RowDescriptor {
         &self.descriptor
     }
 
     fn process(&mut self, input: TupleDelta) -> TupleDelta {
-        // Apply changes to current_tuples and ordered_tuples
+        // Build next ordered state in three phases:
+        // 1) detach removed + updated-old ids from pre-state,
+        // 2) reinsert updated-new tuples in stream order (enables moves),
+        // 3) append added tuples in stream order.
+        let mut detached = AHashSet::new();
         for tuple in &input.removed {
-            self.current_tuples.remove(tuple);
-            self.ordered_tuples.retain(|t| t != tuple);
+            detached.insert(tuple.ids());
         }
+        for (old_tuple, _) in &input.updated {
+            detached.insert(old_tuple.ids());
+        }
+
+        let mut next_ordered: Vec<Tuple> = self
+            .ordered_tuples
+            .iter()
+            .filter(|t| !detached.contains(&t.ids()))
+            .cloned()
+            .collect();
+        let mut next_ids: AHashSet<_> = next_ordered.iter().map(|t| t.ids()).collect();
 
         for tuple in &input.added {
-            self.current_tuples.insert(tuple.clone());
-            self.ordered_tuples.push(tuple.clone());
-        }
-
-        for (old_tuple, new_tuple) in &input.updated {
-            self.current_tuples.remove(old_tuple);
-            self.current_tuples.insert(new_tuple.clone());
-            // Update in place in ordered_tuples to preserve position
-            if let Some(pos) = self.ordered_tuples.iter().position(|t| t == old_tuple) {
-                self.ordered_tuples[pos] = new_tuple.clone();
+            let ids = tuple.ids();
+            if !next_ids.contains(&ids) {
+                next_ids.insert(ids);
+                next_ordered.push(tuple.clone());
             }
         }
+
+        for (_, new_tuple) in &input.updated {
+            let ids = new_tuple.ids();
+            if !next_ids.contains(&ids) {
+                next_ids.insert(ids);
+                next_ordered.push(new_tuple.clone());
+            }
+        }
+
+        self.ordered_tuples = next_ordered;
+        self.current_tuples = self.ordered_tuples.iter().cloned().collect();
 
         self.dirty = false;
 
@@ -214,6 +305,10 @@ mod tests {
         let descriptor = test_descriptor();
         let tuple_desc = TupleDescriptor::single_with_materialization("", descriptor, true);
         OutputNode::with_tuple_descriptor(tuple_desc, mode)
+    }
+
+    fn ordered_ids(node: &OutputNode) -> Vec<ObjectId> {
+        node.ordered_tuples.iter().map(|t| t.ids()[0]).collect()
     }
 
     #[test]
@@ -328,5 +423,62 @@ mod tests {
         let deltas = node.take_tuple_deltas();
         assert_eq!(deltas.len(), 1);
         assert_eq!(deltas[0].added.len(), 1);
+    }
+
+    #[test]
+    fn index_row_delta_tracks_remove_add_and_move() {
+        let id_a = ObjectId::new();
+        let id_b = ObjectId::new();
+        let id_new = ObjectId::new();
+        let row = |id: ObjectId| Row {
+            id,
+            data: vec![],
+            commit_id: CommitId([0; 32]),
+        };
+
+        // pre: [A, B]
+        // delta: remove B, add New, update A->A (move)
+        // post: [New, A]
+        let delta = RowDelta {
+            added: vec![row(id_new)],
+            removed: vec![row(id_b)],
+            updated: vec![(row(id_a), row(id_a))],
+        };
+        let indexed = index_row_delta(&[id_a, id_b], &delta);
+
+        assert_eq!(indexed.pre_index_by_id.get(&id_a), Some(&0));
+        assert_eq!(indexed.pre_index_by_id.get(&id_b), Some(&1));
+        assert_eq!(indexed.post_index_by_id.get(&id_new), Some(&0));
+        assert_eq!(indexed.post_index_by_id.get(&id_a), Some(&1));
+        assert_eq!(indexed.post_ids, vec![id_new, id_a]);
+    }
+
+    #[test]
+    fn output_applies_identity_updates_as_moves() {
+        let mut node = make_output_node(OutputMode::Delta);
+
+        let id_a = ObjectId::new();
+        let id_b = ObjectId::new();
+        let id_c = ObjectId::new();
+        let a = make_tuple(id_a, 1, "A");
+        let b = make_tuple(id_b, 2, "B");
+        let c = make_tuple(id_c, 0, "C");
+
+        // Seed [A, B]
+        node.process(TupleDelta {
+            added: vec![a.clone(), b.clone()],
+            removed: vec![],
+            updated: vec![],
+        });
+        assert_eq!(ordered_ids(&node), vec![id_a, id_b]);
+
+        // Represent reorder to [C, A, B] via add C + move A/B.
+        node.process(TupleDelta {
+            added: vec![c],
+            removed: vec![],
+            updated: vec![(a.clone(), a), (b.clone(), b)],
+        });
+
+        assert_eq!(ordered_ids(&node), vec![id_c, id_a, id_b]);
     }
 }

--- a/crates/groove/src/query_manager/graph_nodes/sort.rs
+++ b/crates/groove/src/query_manager/graph_nodes/sort.rs
@@ -112,10 +112,20 @@ impl RowNode for SortNode {
     }
 
     fn process(&mut self, input: TupleDelta) -> TupleDelta {
+        let old_sorted = self.sorted_tuples.clone();
+        let old_positions: ahash::AHashMap<_, _> = old_sorted
+            .iter()
+            .enumerate()
+            .map(|(idx, tuple)| (tuple.ids(), idx))
+            .collect();
+
         // Track which tuple IDs are added/removed
         let mut added_ids: AHashSet<_> = input.added.iter().map(|t| t.ids()).collect();
+        let added_ids_all = added_ids.clone();
         let mut removed_ids: AHashSet<_> = input.removed.iter().map(|t| t.ids()).collect();
+        let removed_ids_all = removed_ids.clone();
         let updated_old_ids: AHashSet<_> = input.updated.iter().map(|(old, _)| old.ids()).collect();
+        let mut emitted_updated_ids = updated_old_ids.clone();
 
         // Handle removals - find and remove
         for tuple in &input.removed {
@@ -168,6 +178,24 @@ impl RowNode for SortNode {
                     .find(|t| t.ids() == old_tuple.ids())
             {
                 result.updated.push((old_tuple.clone(), new_tuple.clone()));
+            }
+        }
+
+        // Emit identity-preserving updates when tuples shift position because of
+        // inserts/removals around them. This encodes move information for downstream
+        // nodes that only receive deltas.
+        for (new_idx, new_tuple) in self.sorted_tuples.iter().enumerate() {
+            let ids = new_tuple.ids();
+            if added_ids_all.contains(&ids) || removed_ids_all.contains(&ids) {
+                continue;
+            }
+            if emitted_updated_ids.contains(&ids) {
+                continue;
+            }
+            if let Some(old_idx) = old_positions.get(&ids) && *old_idx != new_idx {
+                let old_tuple = old_sorted[*old_idx].clone();
+                result.updated.push((old_tuple, new_tuple.clone()));
+                emitted_updated_ids.insert(ids);
             }
         }
 
@@ -454,5 +482,52 @@ mod tests {
         let sorted_ids = get_sorted_ids(&node);
         assert_eq!(sorted_ids[0], id2); // 50 first
         assert_eq!(sorted_ids[1], id1); // 100 second
+    }
+
+    #[test]
+    fn sort_emits_move_updates_when_insert_shifts_positions() {
+        let sort_keys = vec![SortKey {
+            col_index: 2, // score asc
+            direction: SortDirection::Ascending,
+        }];
+        let mut node = make_sort_node(sort_keys);
+
+        let id_a = ObjectId::new();
+        let id_b = ObjectId::new();
+        let id_c = ObjectId::new();
+        let a = make_tuple(
+            id_a,
+            &[Value::Integer(1), Value::Text("A".into()), Value::Integer(10)],
+        );
+        let b = make_tuple(
+            id_b,
+            &[Value::Integer(2), Value::Text("B".into()), Value::Integer(20)],
+        );
+        let c = make_tuple(
+            id_c,
+            &[Value::Integer(3), Value::Text("C".into()), Value::Integer(0)],
+        );
+
+        // Seed: [A, B]
+        node.process(TupleDelta {
+            added: vec![a.clone(), b.clone()],
+            removed: vec![],
+            updated: vec![],
+        });
+
+        // Insert C at front => [C, A, B]. A and B should be emitted as move updates.
+        let delta = node.process(TupleDelta {
+            added: vec![c],
+            removed: vec![],
+            updated: vec![],
+        });
+
+        assert_eq!(delta.added.len(), 1);
+        assert_eq!(delta.added[0].ids()[0], id_c);
+        assert_eq!(delta.updated.len(), 2);
+        assert_eq!(delta.updated[0].0.ids()[0], id_a);
+        assert_eq!(delta.updated[0].1.ids()[0], id_a);
+        assert_eq!(delta.updated[1].0.ids()[0], id_b);
+        assert_eq!(delta.updated[1].1.ids()[0], id_b);
     }
 }

--- a/crates/groove/src/query_manager/graph_nodes/sort.rs
+++ b/crates/groove/src/query_manager/graph_nodes/sort.rs
@@ -254,6 +254,11 @@ mod tests {
         SortNode::with_tuple_descriptor(tuple_desc, sort_keys)
     }
 
+    // Scenario: ascending sort by score.
+    //
+    // ASCII:
+    // input:   [A:100, B:50, C:75]
+    // sorted:  [B:50, C:75, A:100]
     #[test]
     fn sort_ascending() {
         let sort_keys = vec![SortKey {
@@ -305,6 +310,11 @@ mod tests {
         assert_eq!(sorted_ids[2], id1); // score 100
     }
 
+    // Scenario: descending sort by score.
+    //
+    // ASCII:
+    // input:   [A:100, B:50, C:75]
+    // sorted:  [A:100, C:75, B:50]
     #[test]
     fn sort_descending() {
         let sort_keys = vec![SortKey {
@@ -356,6 +366,12 @@ mod tests {
         assert_eq!(sorted_ids[2], id2); // score 50
     }
 
+    // Scenario: multi-key sort (dept asc, score desc).
+    //
+    // ASCII:
+    // dept1: [A:100, B:50]
+    // dept2: [D:90,  C:75]
+    // final: [A, B, D, C]
     #[test]
     fn sort_multiple_keys() {
         let descriptor = RowDescriptor::new(vec![
@@ -441,6 +457,12 @@ mod tests {
         assert_eq!(sorted_ids[3], id3); // dept 2, score 75
     }
 
+    // Scenario: insertion uses sorted position (not append order).
+    //
+    // ASCII:
+    // tick1: [A:100]
+    // tick2: +B:50
+    // final: [B:50, A:100]
     #[test]
     fn sort_maintains_order_on_insert() {
         let sort_keys = vec![SortKey {
@@ -486,6 +508,13 @@ mod tests {
         assert_eq!(sorted_ids[1], id1); // 100 second
     }
 
+    // Scenario: insert at front shifts existing survivors.
+    //
+    // ASCII:
+    // pre:    [A:10, B:20]
+    // delta:  +C:0
+    // post:   [C:0, A:10, B:20]
+    // moves:  A, B => emitted as identity updates
     #[test]
     fn sort_emits_move_updates_when_insert_shifts_positions() {
         let sort_keys = vec![SortKey {
@@ -543,5 +572,209 @@ mod tests {
         assert_eq!(delta.updated[0].1.ids()[0], id_a);
         assert_eq!(delta.updated[1].0.ids()[0], id_b);
         assert_eq!(delta.updated[1].1.ids()[0], id_b);
+    }
+
+    // Scenario: removing first row shifts remaining survivors left.
+    //
+    // ASCII:
+    // pre:    [A:10, B:20, C:30]
+    // delta:  -A
+    // post:   [B:20, C:30]
+    // moves:  B, C => emitted as identity updates
+    #[test]
+    fn sort_emits_move_updates_when_remove_shifts_positions() {
+        let sort_keys = vec![SortKey {
+            col_index: 2, // score asc
+            direction: SortDirection::Ascending,
+        }];
+        let mut node = make_sort_node(sort_keys);
+
+        let id_a = ObjectId::new();
+        let id_b = ObjectId::new();
+        let id_c = ObjectId::new();
+        let a = make_tuple(
+            id_a,
+            &[
+                Value::Integer(1),
+                Value::Text("A".into()),
+                Value::Integer(10),
+            ],
+        );
+        let b = make_tuple(
+            id_b,
+            &[
+                Value::Integer(2),
+                Value::Text("B".into()),
+                Value::Integer(20),
+            ],
+        );
+        let c = make_tuple(
+            id_c,
+            &[
+                Value::Integer(3),
+                Value::Text("C".into()),
+                Value::Integer(30),
+            ],
+        );
+
+        // Seed: [A, B, C]
+        node.process(TupleDelta {
+            added: vec![a.clone(), b.clone(), c.clone()],
+            removed: vec![],
+            updated: vec![],
+        });
+
+        // Remove A => [B, C]. B and C must be emitted as move updates.
+        let delta = node.process(TupleDelta {
+            added: vec![],
+            removed: vec![a],
+            updated: vec![],
+        });
+
+        assert_eq!(delta.removed.len(), 1);
+        assert_eq!(delta.removed[0].ids()[0], id_a);
+        assert_eq!(delta.updated.len(), 2);
+        assert_eq!(delta.updated[0].0.ids()[0], id_b);
+        assert_eq!(delta.updated[0].1.ids()[0], id_b);
+        assert_eq!(delta.updated[1].0.ids()[0], id_c);
+        assert_eq!(delta.updated[1].1.ids()[0], id_c);
+    }
+
+    // Scenario: explicit update should not be duplicated by move-emitter.
+    //
+    // ASCII:
+    // pre:    [A:10, B:20]
+    // delta:  upd(B:20 -> B:25)
+    // post:   [A:10, B:25]
+    // expect: one updated entry for B only
+    #[test]
+    fn sort_does_not_emit_extra_move_update_for_explicit_updated_row() {
+        let sort_keys = vec![SortKey {
+            col_index: 2, // score asc
+            direction: SortDirection::Ascending,
+        }];
+        let mut node = make_sort_node(sort_keys);
+
+        let id_a = ObjectId::new();
+        let id_b = ObjectId::new();
+        let a = make_tuple(
+            id_a,
+            &[
+                Value::Integer(1),
+                Value::Text("A".into()),
+                Value::Integer(10),
+            ],
+        );
+        let b_old = make_tuple(
+            id_b,
+            &[
+                Value::Integer(2),
+                Value::Text("B".into()),
+                Value::Integer(20),
+            ],
+        );
+        let b_new = make_tuple(
+            id_b,
+            &[
+                Value::Integer(2),
+                Value::Text("B".into()),
+                Value::Integer(25),
+            ],
+        );
+
+        // Seed: [A, B]
+        node.process(TupleDelta {
+            added: vec![a, b_old.clone()],
+            removed: vec![],
+            updated: vec![],
+        });
+
+        // Explicit update for B, no position shift.
+        let delta = node.process(TupleDelta {
+            added: vec![],
+            removed: vec![],
+            updated: vec![(b_old, b_new)],
+        });
+
+        // Should emit exactly the explicit update (no duplicate move update for same id).
+        assert_eq!(delta.updated.len(), 1);
+        assert_eq!(delta.updated[0].0.ids()[0], id_b);
+        assert_eq!(delta.updated[0].1.ids()[0], id_b);
+    }
+
+    // Scenario: mixed add/remove emits moves only for shifted survivors.
+    //
+    // ASCII:
+    // pre:    [A:10, B:20, C:30]
+    // delta:  -B, +D:5
+    // post:   [D:5, A:10, C:30]
+    // moves:  A (shifted), not C (same index), not D/B (added/removed)
+    #[test]
+    fn sort_mixed_add_remove_emits_moves_for_shifted_survivors_only() {
+        let sort_keys = vec![SortKey {
+            col_index: 2, // score asc
+            direction: SortDirection::Ascending,
+        }];
+        let mut node = make_sort_node(sort_keys);
+
+        let id_a = ObjectId::new();
+        let id_b = ObjectId::new();
+        let id_c = ObjectId::new();
+        let id_d = ObjectId::new();
+        let a = make_tuple(
+            id_a,
+            &[
+                Value::Integer(1),
+                Value::Text("A".into()),
+                Value::Integer(10),
+            ],
+        );
+        let b = make_tuple(
+            id_b,
+            &[
+                Value::Integer(2),
+                Value::Text("B".into()),
+                Value::Integer(20),
+            ],
+        );
+        let c = make_tuple(
+            id_c,
+            &[
+                Value::Integer(3),
+                Value::Text("C".into()),
+                Value::Integer(30),
+            ],
+        );
+        let d = make_tuple(
+            id_d,
+            &[
+                Value::Integer(4),
+                Value::Text("D".into()),
+                Value::Integer(5),
+            ],
+        );
+
+        // Seed: [A, B, C]
+        node.process(TupleDelta {
+            added: vec![a.clone(), b.clone(), c.clone()],
+            removed: vec![],
+            updated: vec![],
+        });
+
+        // Remove B, add D(5) => [D, A, C].
+        // A shifts from index 0 -> 1 and should be emitted as move update.
+        let delta = node.process(TupleDelta {
+            added: vec![d],
+            removed: vec![b],
+            updated: vec![],
+        });
+
+        assert_eq!(delta.added.len(), 1);
+        assert_eq!(delta.added[0].ids()[0], id_d);
+        assert_eq!(delta.removed.len(), 1);
+        assert_eq!(delta.removed[0].ids()[0], id_b);
+        assert_eq!(delta.updated.len(), 1);
+        assert_eq!(delta.updated[0].0.ids()[0], id_a);
+        assert_eq!(delta.updated[0].1.ids()[0], id_a);
     }
 }

--- a/crates/groove/src/query_manager/graph_nodes/sort.rs
+++ b/crates/groove/src/query_manager/graph_nodes/sort.rs
@@ -192,7 +192,9 @@ impl RowNode for SortNode {
             if emitted_updated_ids.contains(&ids) {
                 continue;
             }
-            if let Some(old_idx) = old_positions.get(&ids) && *old_idx != new_idx {
+            if let Some(old_idx) = old_positions.get(&ids)
+                && *old_idx != new_idx
+            {
                 let old_tuple = old_sorted[*old_idx].clone();
                 result.updated.push((old_tuple, new_tuple.clone()));
                 emitted_updated_ids.insert(ids);
@@ -497,15 +499,27 @@ mod tests {
         let id_c = ObjectId::new();
         let a = make_tuple(
             id_a,
-            &[Value::Integer(1), Value::Text("A".into()), Value::Integer(10)],
+            &[
+                Value::Integer(1),
+                Value::Text("A".into()),
+                Value::Integer(10),
+            ],
         );
         let b = make_tuple(
             id_b,
-            &[Value::Integer(2), Value::Text("B".into()), Value::Integer(20)],
+            &[
+                Value::Integer(2),
+                Value::Text("B".into()),
+                Value::Integer(20),
+            ],
         );
         let c = make_tuple(
             id_c,
-            &[Value::Integer(3), Value::Text("C".into()), Value::Integer(0)],
+            &[
+                Value::Integer(3),
+                Value::Text("C".into()),
+                Value::Integer(0),
+            ],
         );
 
         // Seed: [A, B]

--- a/crates/jazz-rs/src/client.rs
+++ b/crates/jazz-rs/src/client.rs
@@ -312,10 +312,7 @@ impl JazzClient {
         // Track subscription metadata
         {
             let mut subs = self.subscriptions.write().await;
-            subs.insert(
-                handle,
-                SubscriptionState { runtime_handle },
-            );
+            subs.insert(handle, SubscriptionState { runtime_handle });
         }
 
         Ok(SubscriptionStream::new(rx))

--- a/crates/jazz-rs/src/transport.rs
+++ b/crates/jazz-rs/src/transport.rs
@@ -149,7 +149,6 @@ impl ServerConnection {
     pub fn base_url(&self) -> &str {
         &self.base_url
     }
-
 }
 
 /// Check if a sync payload is for a catalogue object (schema or lens).
@@ -157,7 +156,9 @@ fn is_catalogue_payload(payload: &SyncPayload) -> bool {
     match payload {
         SyncPayload::ObjectUpdated { metadata, .. } => {
             if let Some(meta) = metadata
-                && let Some(type_str) = meta.metadata.get(groove::metadata::MetadataKey::Type.as_str())
+                && let Some(type_str) = meta
+                    .metadata
+                    .get(groove::metadata::MetadataKey::Type.as_str())
             {
                 return type_str == groove::metadata::ObjectType::CatalogueSchema.as_str()
                     || type_str == groove::metadata::ObjectType::CatalogueLens.as_str();

--- a/packages/jazz-ts/src/runtime/db.ts
+++ b/packages/jazz-ts/src/runtime/db.ts
@@ -92,7 +92,7 @@ export interface TableProxy<T, Init> {
  * // Subscriptions
  * const unsubscribe = db.subscribeAll(app.todos, (delta) => {
  *   console.log("All todos:", delta.all);
- *   console.log("Added:", delta.added);
+ *   console.log("Added:", delta.added.map(({ item, index }) => ({ item, index })));
  * });
  * ```
  */
@@ -391,7 +391,7 @@ export class Db {
    * const unsubscribe = db.subscribeAll(app.todos, (delta) => {
    *   setTodos(delta.all);
    *   if (delta.added.length > 0) {
-   *     console.log("New todos:", delta.added);
+   *     console.log("New todos:", delta.added.map(({ item }) => item));
    *   }
    * });
    *

--- a/packages/jazz-ts/src/runtime/index.ts
+++ b/packages/jazz-ts/src/runtime/index.ts
@@ -13,5 +13,10 @@ export { createDb, Db, type DbConfig, type QueryBuilder, type TableProxy } from 
 export { translateQuery } from "./query-adapter.js";
 export { transformRows, unwrapValue, type WasmValue } from "./row-transformer.js";
 export { toValue, toValueArray, toUpdateRecord } from "./value-converter.js";
-export { SubscriptionManager, type SubscriptionDelta } from "./subscription-manager.js";
+export {
+  SubscriptionManager,
+  type IndexedItem,
+  type SubscriptionDelta,
+  type UpdatedIndexedItem,
+} from "./subscription-manager.js";
 export { WorkerBridge, type WorkerBridgeOptions } from "./worker-bridge.js";

--- a/packages/jazz-ts/src/runtime/subscription-manager.test.ts
+++ b/packages/jazz-ts/src/runtime/subscription-manager.test.ts
@@ -33,224 +33,143 @@ function transform(row: WasmRow): TestItem {
 }
 
 describe("SubscriptionManager", () => {
-  describe("handleDelta with additions", () => {
-    it("tracks added items", () => {
-      const manager = new SubscriptionManager<TestItem>();
-
-      const delta: RowDelta = {
-        added: [makeRow("1", "item1", 10), makeRow("2", "item2", 20)],
-        removed: [],
-        updated: [],
-        pending: false,
-      };
-
-      const result = manager.handleDelta(delta, transform);
-
-      expect(result.added).toHaveLength(2);
-      expect(result.added[0]).toEqual({ id: "1", name: "item1", count: 10 });
-      expect(result.added[1]).toEqual({ id: "2", name: "item2", count: 20 });
-
-      expect(result.updated).toHaveLength(0);
-      expect(result.removed).toHaveLength(0);
-
-      expect(result.all).toHaveLength(2);
-      expect(manager.size).toBe(2);
-    });
-
-    it("accumulates items across multiple deltas", () => {
-      const manager = new SubscriptionManager<TestItem>();
-
-      // First delta
-      manager.handleDelta(
-        {
-          added: [makeRow("1", "item1", 10)],
-          removed: [],
-          updated: [],
-          pending: false,
-        },
-        transform,
-      );
-
-      // Second delta
-      const result = manager.handleDelta(
-        {
-          added: [makeRow("2", "item2", 20)],
-          removed: [],
-          updated: [],
-          pending: false,
-        },
-        transform,
-      );
-
-      expect(result.added).toHaveLength(1); // Only new item
-      expect(result.all).toHaveLength(2); // Full state
-      expect(manager.size).toBe(2);
-    });
+  const add = (id: string, name: string, count: number, index: number) => ({
+    row: makeRow(id, name, count),
+    index,
+  });
+  const remove = (id: string, name: string, count: number, index: number) => ({
+    row: makeRow(id, name, count),
+    index,
+  });
+  const update = (
+    oldId: string,
+    oldName: string,
+    oldCount: number,
+    oldIndex: number,
+    newId: string,
+    newName: string,
+    newCount: number,
+    newIndex: number,
+  ) => ({
+    old_row: makeRow(oldId, oldName, oldCount),
+    new_row: makeRow(newId, newName, newCount),
+    old_index: oldIndex,
+    new_index: newIndex,
+  });
+  const delta = (input: Partial<RowDelta>): RowDelta => ({
+    added: input.added ?? [],
+    removed: input.removed ?? [],
+    updated: input.updated ?? [],
+    pending: input.pending ?? false,
   });
 
-  describe("handleDelta with updates", () => {
-    it("tracks updated items", () => {
-      const manager = new SubscriptionManager<TestItem>();
+  it("append add reports tail index", () => {
+    const manager = new SubscriptionManager<TestItem>();
 
-      // First add an item
-      manager.handleDelta(
-        {
-          added: [makeRow("1", "item1", 10)],
-          removed: [],
-          updated: [],
-          pending: false,
-        },
-        transform,
-      );
+    manager.handleDelta(delta({ added: [add("1", "a", 1, 0), add("2", "b", 2, 1)] }), transform);
+    const result = manager.handleDelta(delta({ added: [add("3", "c", 3, 2)] }), transform);
 
-      // Then update it
-      const oldRow = makeRow("1", "item1", 10);
-      const newRow = makeRow("1", "item1", 15);
-      const result = manager.handleDelta(
-        {
-          added: [],
-          removed: [],
-          updated: [[oldRow, newRow]],
-          pending: false,
-        },
-        transform,
-      );
-
-      expect(result.updated).toHaveLength(1);
-      expect(result.updated[0]).toEqual({ id: "1", name: "item1", count: 15 });
-
-      expect(result.added).toHaveLength(0);
-      expect(result.removed).toHaveLength(0);
-
-      expect(result.all).toHaveLength(1);
-      expect(result.all[0].count).toBe(15);
-    });
-
-    it("updates items with new values", () => {
-      const manager = new SubscriptionManager<TestItem>();
-
-      // Add initial item
-      manager.handleDelta(
-        {
-          added: [makeRow("1", "original", 10)],
-          removed: [],
-          updated: [],
-          pending: false,
-        },
-        transform,
-      );
-
-      // Update with new name
-      const result = manager.handleDelta(
-        {
-          added: [],
-          removed: [],
-          updated: [[makeRow("1", "original", 10), makeRow("1", "updated", 100)]],
-          pending: false,
-        },
-        transform,
-      );
-
-      expect(result.all[0]).toEqual({ id: "1", name: "updated", count: 100 });
-    });
+    expect(result.added).toEqual([{ item: { id: "3", name: "c", count: 3 }, index: 2 }]);
+    expect(result.all.map((item) => item.id)).toEqual(["1", "2", "3"]);
   });
 
-  describe("handleDelta with removals", () => {
-    it("tracks removed items", () => {
-      const manager = new SubscriptionManager<TestItem>();
+  it("middle insert preserves order via index", () => {
+    const manager = new SubscriptionManager<TestItem>();
 
-      // Add items first
-      manager.handleDelta(
-        {
-          added: [makeRow("1", "item1", 10), makeRow("2", "item2", 20)],
-          removed: [],
-          updated: [],
-          pending: false,
-        },
-        transform,
-      );
+    manager.handleDelta(delta({ added: [add("1", "a", 10, 0), add("3", "c", 30, 1)] }), transform);
+    const result = manager.handleDelta(delta({ added: [add("2", "b", 20, 1)] }), transform);
 
-      // Remove one item
-      const result = manager.handleDelta(
-        {
-          added: [],
-          removed: [makeRow("1", "item1", 10)],
-          updated: [],
-          pending: false,
-        },
-        transform,
-      );
-
-      expect(result.removed).toHaveLength(1);
-      expect(result.removed[0]).toEqual({ id: "1", name: "item1", count: 10 });
-
-      expect(result.added).toHaveLength(0);
-      expect(result.updated).toHaveLength(0);
-
-      expect(result.all).toHaveLength(1);
-      expect(result.all[0].id).toBe("2");
-      expect(manager.size).toBe(1);
-    });
-
-    it("handles removing non-existent items gracefully", () => {
-      const manager = new SubscriptionManager<TestItem>();
-
-      // Try to remove an item that was never added
-      const result = manager.handleDelta(
-        {
-          added: [],
-          removed: [makeRow("nonexistent", "ghost", 0)],
-          updated: [],
-          pending: false,
-        },
-        transform,
-      );
-
-      expect(result.removed).toHaveLength(0);
-      expect(result.all).toHaveLength(0);
-    });
+    expect(result.added[0].index).toBe(1);
+    expect(result.all.map((item) => item.id)).toEqual(["1", "2", "3"]);
   });
 
-  describe("handleDelta with mixed operations", () => {
-    it("handles add, update, and remove in same delta", () => {
-      const manager = new SubscriptionManager<TestItem>();
+  it("update without move keeps oldIndex/newIndex equal", () => {
+    const manager = new SubscriptionManager<TestItem>();
 
-      // Add initial items
-      manager.handleDelta(
-        {
-          added: [makeRow("1", "item1", 10), makeRow("2", "item2", 20)],
-          removed: [],
-          updated: [],
-          pending: false,
-        },
-        transform,
-      );
+    manager.handleDelta(delta({ added: [add("1", "a", 10, 0), add("2", "b", 20, 1)] }), transform);
+    const result = manager.handleDelta(
+      delta({ updated: [update("2", "b", 20, 1, "2", "b", 25, 1)] }),
+      transform,
+    );
 
-      // Mixed delta: add "3", update "2", remove "1"
-      const result = manager.handleDelta(
-        {
-          added: [makeRow("3", "item3", 30)],
-          removed: [makeRow("1", "item1", 10)],
-          updated: [[makeRow("2", "item2", 20), makeRow("2", "item2", 25)]],
-          pending: false,
-        },
-        transform,
-      );
+    expect(result.updated).toEqual([
+      {
+        oldItem: { id: "2", name: "b", count: 20 },
+        newItem: { id: "2", name: "b", count: 25 },
+        oldIndex: 1,
+        newIndex: 1,
+      },
+    ]);
+    expect(result.all.map((item) => item.id)).toEqual(["1", "2"]);
+    expect(result.all[1]?.count).toBe(25);
+  });
 
-      expect(result.added).toHaveLength(1);
-      expect(result.added[0].id).toBe("3");
+  it("update with move applies old/new indices", () => {
+    const manager = new SubscriptionManager<TestItem>();
 
-      expect(result.updated).toHaveLength(1);
-      expect(result.updated[0].id).toBe("2");
-      expect(result.updated[0].count).toBe(25);
+    manager.handleDelta(
+      delta({ added: [add("1", "a", 10, 0), add("2", "b", 20, 1), add("3", "c", 30, 2)] }),
+      transform,
+    );
+    const result = manager.handleDelta(
+      delta({ updated: [update("3", "c", 30, 2, "3", "c", 5, 0)] }),
+      transform,
+    );
 
-      expect(result.removed).toHaveLength(1);
-      expect(result.removed[0].id).toBe("1");
+    expect(result.updated[0]?.oldIndex).toBe(2);
+    expect(result.updated[0]?.newIndex).toBe(0);
+    expect(result.all.map((item) => item.id)).toEqual(["3", "1", "2"]);
+  });
 
-      expect(result.all).toHaveLength(2);
-      const ids = result.all.map((item) => item.id).sort();
-      expect(ids).toEqual(["2", "3"]);
-    });
+  it("remove reports prior index", () => {
+    const manager = new SubscriptionManager<TestItem>();
+
+    manager.handleDelta(
+      delta({ added: [add("1", "a", 10, 0), add("2", "b", 20, 1), add("3", "c", 30, 2)] }),
+      transform,
+    );
+    const result = manager.handleDelta(delta({ removed: [remove("2", "b", 20, 1)] }), transform);
+
+    expect(result.removed).toEqual([{ item: { id: "2", name: "b", count: 20 }, index: 1 }]);
+    expect(result.all.map((item) => item.id)).toEqual(["1", "3"]);
+  });
+
+  it("mixed batch yields consistent indices and final all", () => {
+    const manager = new SubscriptionManager<TestItem>();
+
+    manager.handleDelta(
+      delta({ added: [add("1", "a", 10, 0), add("2", "b", 20, 1), add("3", "c", 30, 2)] }),
+      transform,
+    );
+    const result = manager.handleDelta(
+      delta({
+        removed: [remove("2", "b", 20, 1)],
+        updated: [update("3", "c", 30, 2, "3", "c", 31, 0)],
+        added: [add("4", "d", 40, 2)],
+      }),
+      transform,
+    );
+
+    expect(result.removed[0]?.index).toBe(1);
+    expect(result.updated[0]?.oldIndex).toBe(2);
+    expect(result.updated[0]?.newIndex).toBe(0);
+    expect(result.added[0]?.index).toBe(2);
+    expect(result.all.map((item) => item.id)).toEqual(["3", "1", "4"]);
+  });
+
+  it("identity-changing update is treated as remove+add", () => {
+    const manager = new SubscriptionManager<TestItem>();
+
+    manager.handleDelta(delta({ added: [add("1", "a", 10, 0)] }), transform);
+    const result = manager.handleDelta(
+      delta({ updated: [update("1", "a", 10, 0, "9", "z", 99, 0)] }),
+      transform,
+    );
+
+    expect(result.updated).toEqual([]);
+    expect(result.removed).toEqual([{ item: { id: "1", name: "a", count: 10 }, index: 0 }]);
+    expect(result.added).toEqual([{ item: { id: "9", name: "z", count: 99 }, index: 0 }]);
+    expect(result.all.map((item) => item.id)).toEqual(["9"]);
   });
 
   describe("clear", () => {
@@ -260,7 +179,7 @@ describe("SubscriptionManager", () => {
       // Add items
       manager.handleDelta(
         {
-          added: [makeRow("1", "item1", 10), makeRow("2", "item2", 20)],
+          added: [add("1", "item1", 10, 0), add("2", "item2", 20, 1)],
           removed: [],
           updated: [],
           pending: false,
@@ -277,7 +196,7 @@ describe("SubscriptionManager", () => {
       // Next delta should start fresh
       const result = manager.handleDelta(
         {
-          added: [makeRow("3", "item3", 30)],
+          added: [add("3", "item3", 30, 0)],
           removed: [],
           updated: [],
           pending: false,
@@ -296,7 +215,7 @@ describe("SubscriptionManager", () => {
 
       const result1 = manager.handleDelta(
         {
-          added: [makeRow("1", "item1", 10)],
+          added: [add("1", "item1", 10, 0)],
           removed: [],
           updated: [],
           pending: false,
@@ -308,7 +227,7 @@ describe("SubscriptionManager", () => {
 
       const result2 = manager.handleDelta(
         {
-          added: [makeRow("2", "item2", 20)],
+          added: [add("2", "item2", 20, 1)],
           removed: [],
           updated: [],
           pending: false,

--- a/packages/jazz-ts/src/runtime/subscription-manager.ts
+++ b/packages/jazz-ts/src/runtime/subscription-manager.ts
@@ -7,6 +7,18 @@
 
 import type { WasmRow, RowDelta } from "../drivers/types.js";
 
+export interface IndexedItem<T> {
+  item: T;
+  index: number;
+}
+
+export interface UpdatedIndexedItem<T> {
+  oldItem: T;
+  newItem: T;
+  oldIndex: number;
+  newIndex: number;
+}
+
 /**
  * Delta result from a subscription callback.
  *
@@ -17,11 +29,11 @@ export interface SubscriptionDelta<T> {
   /** Current full result set after applying this delta */
   all: T[];
   /** Items added in this delta */
-  added: T[];
-  /** Items updated in this delta (new values) */
-  updated: T[];
+  added: IndexedItem<T>[];
+  /** Items updated in this delta */
+  updated: UpdatedIndexedItem<T>[];
   /** Items removed in this delta */
-  removed: T[];
+  removed: IndexedItem<T>[];
 }
 
 /**
@@ -33,7 +45,7 @@ export interface SubscriptionDelta<T> {
  * @typeParam T - The typed object type (must have `id: string`)
  */
 export class SubscriptionManager<T extends { id: string }> {
-  private currentResults = new Map<string, T>();
+  private currentResults: T[] = [];
 
   /**
    * Process a row delta and return typed object delta.
@@ -43,39 +55,85 @@ export class SubscriptionManager<T extends { id: string }> {
    * @returns Typed delta with full state and changes
    */
   handleDelta(delta: RowDelta, transform: (row: WasmRow) => T): SubscriptionDelta<T> {
-    const added: T[] = [];
-    const updated: T[] = [];
-    const removed: T[] = [];
+    const added: IndexedItem<T>[] = [];
+    const updated: UpdatedIndexedItem<T>[] = [];
+    const removed: IndexedItem<T>[] = [];
 
-    // Process additions
-    for (const row of delta.added) {
-      const item = transform(row);
-      this.currentResults.set(item.id, item);
-      added.push(item);
+    for (const { row, index } of delta.added) {
+      added.push({ item: transform(row), index });
     }
 
-    // Process updates - delta.updated is array of [oldRow, newRow] tuples
-    for (const [_oldRow, newRow] of delta.updated) {
-      const newItem = transform(newRow);
-      this.currentResults.set(newItem.id, newItem);
-      updated.push(newItem);
-    }
-
-    // Process removals
-    for (const row of delta.removed) {
-      const item = this.currentResults.get(row.id);
-      if (item) {
-        this.currentResults.delete(row.id);
-        removed.push(item);
+    for (const { old_row, new_row, old_index, new_index } of delta.updated) {
+      const oldItem = transform(old_row);
+      const newItem = transform(new_row);
+      if (oldItem.id === newItem.id) {
+        updated.push({
+          oldItem,
+          newItem,
+          oldIndex: old_index,
+          newIndex: new_index,
+        });
+      } else {
+        // Identity changes are represented as remove+add for deterministic patching.
+        removed.push({ item: oldItem, index: old_index });
+        added.push({ item: newItem, index: new_index });
       }
     }
 
+    for (const { row, index } of delta.removed) {
+      removed.push({ item: transform(row), index });
+    }
+
+    this.currentResults = this.buildPostState(this.currentResults, added, updated, removed);
+
     return {
-      all: Array.from(this.currentResults.values()),
+      all: [...this.currentResults],
       added,
       updated,
       removed,
     };
+  }
+
+  private buildPostState(
+    previous: T[],
+    added: IndexedItem<T>[],
+    updated: UpdatedIndexedItem<T>[],
+    removed: IndexedItem<T>[],
+  ): T[] {
+    const removedIds = new Set(removed.map(({ item }) => item.id));
+    const updatedOldIds = new Set(updated.map(({ oldItem }) => oldItem.id));
+
+    const unchanged = previous.filter(
+      (item) => !removedIds.has(item.id) && !updatedOldIds.has(item.id),
+    );
+    const expectedLength = previous.length - removed.length + added.length;
+    const post: Array<T | undefined> = new Array(Math.max(expectedLength, 0));
+
+    for (const { newItem, newIndex } of updated) {
+      if (newIndex >= 0) {
+        post[newIndex] = newItem;
+      }
+    }
+
+    for (const { item, index } of added) {
+      if (index >= 0) {
+        post[index] = item;
+      }
+    }
+
+    let unchangedCursor = 0;
+    for (let i = 0; i < post.length; i += 1) {
+      if (post[i] === undefined && unchangedCursor < unchanged.length) {
+        post[i] = unchanged[unchangedCursor++];
+      }
+    }
+
+    // Fallback for sparse / out-of-range index payloads.
+    while (unchangedCursor < unchanged.length) {
+      post.push(unchanged[unchangedCursor++]);
+    }
+
+    return post.filter((item): item is T => item !== undefined);
   }
 
   /**
@@ -84,13 +142,13 @@ export class SubscriptionManager<T extends { id: string }> {
    * Called when unsubscribing to free memory.
    */
   clear(): void {
-    this.currentResults.clear();
+    this.currentResults = [];
   }
 
   /**
    * Get the current number of tracked items.
    */
   get size(): number {
-    return this.currentResults.size;
+    return this.currentResults.length;
   }
 }

--- a/packages/jazz-ts/src/runtime/subscription-manager.wasm-integration.test.ts
+++ b/packages/jazz-ts/src/runtime/subscription-manager.wasm-integration.test.ts
@@ -1,0 +1,250 @@
+/**
+ * Integration test: SubscriptionManager with real WASM runtime.
+ *
+ * This test verifies that SubscriptionManager correctly consumes row-level
+ * deltas from the actual groove-wasm runtime and produces typed SubscriptionDelta
+ * objects with accurate index positions for add/update/remove.
+ *
+ * Flow:
+ *   1. Create WASM runtime + subscribe to "todos ORDER BY rank ASC"
+ *   2. Insert "Buy milk"(10), "Call dentist"(20), "Fix bug"(30) → add deltas at indices 0,1,2
+ *   3. Update "Fix bug" rank to 0 → expect update delta (moves from index 2 → 0)
+ *   4. Delete "Buy milk" → remove delta at correct index; final state [Fix bug, Call dentist]
+ */
+import { describe, expect, it } from "vitest";
+import { SubscriptionManager } from "./subscription-manager.js";
+import { translateQuery } from "./query-adapter.js";
+import type { RowDelta, WasmRow, WasmSchema } from "../drivers/types.js";
+import { createWasmRuntime } from "./testing/wasm-runtime-test-utils.js";
+
+interface Todo {
+  id: string;
+  title: string;
+  rank: number;
+}
+
+/** Schema for the test: single table "todos" with title (Text) and rank (Integer). */
+const schema: WasmSchema = {
+  tables: {
+    todos: {
+      columns: [
+        { name: "title", column_type: { type: "Text" }, nullable: false },
+        { name: "rank", column_type: { type: "Integer" }, nullable: false },
+      ],
+    },
+  },
+};
+
+/** Build WASM query string: todos ordered by rank ascending. */
+function makeOrderedTodosQuery(): string {
+  return translateQuery(
+    JSON.stringify({
+      table: "todos",
+      conditions: [],
+      includes: {},
+      orderBy: [["rank", "asc"]],
+    }),
+    schema,
+  );
+}
+
+/** Convert raw WasmRow (id + typed values) to typed Todo. */
+function transformRow(row: WasmRow): Todo {
+  return {
+    id: row.id,
+    title: (row.values[0] as { type: "Text"; value: string }).value,
+    rank: (row.values[1] as { type: "Integer"; value: number }).value,
+  };
+}
+
+/** Poll an array until a matching item appears, or timeout. */
+async function pollUntil<T>(arr: T[], pred: (item: T) => boolean, timeoutMs = 2000): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const match = arr.find(pred);
+    if (match) return match;
+    await new Promise((r) => setTimeout(r, 10));
+  }
+  throw new Error(`Timed out waiting for matching delta: ${JSON.stringify(arr)}`);
+}
+
+describe("SubscriptionManager WASM integration", () => {
+  it("consumes real wasm runtime deltas with indexed add/update/remove", async () => {
+    const runtime = await createWasmRuntime(schema, {
+      appId: "test-sub-manager-wasm-integration",
+    });
+
+    const manager = new SubscriptionManager<Todo>();
+    const typedDeltas: Array<ReturnType<typeof manager.handleDelta>> = [];
+    const rawDeltas: RowDelta[] = [];
+
+    // Subscribe: every delta from WASM is pushed to rawDeltas and passed through
+    // SubscriptionManager.handleDelta; typed result goes to typedDeltas.
+    const subId = runtime.subscribe(
+      makeOrderedTodosQuery(),
+      (deltaJsonOrObject: RowDelta | string) => {
+        const raw: RowDelta =
+          typeof deltaJsonOrObject === "string" ? JSON.parse(deltaJsonOrObject) : deltaJsonOrObject;
+        rawDeltas.push(raw);
+        typedDeltas.push(manager.handleDelta(raw, transformRow));
+      },
+    );
+
+    // Give subscription time to register before mutations.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    // Insert realistic todos. Order by rank: Buy milk, Call dentist, Fix bug → indices 0, 1, 2.
+    const idBuyMilk = runtime.insert("todos", [
+      { type: "Text", value: "Buy milk" },
+      { type: "Integer", value: 10 },
+    ]);
+    const idCallDentist = runtime.insert("todos", [
+      { type: "Text", value: "Call dentist" },
+      { type: "Integer", value: 20 },
+    ]);
+    const idFixBug = runtime.insert("todos", [
+      { type: "Text", value: "Fix bug in subscription manager" },
+      { type: "Integer", value: 30 },
+    ]);
+
+    // Assert: add delta for "Fix bug" arrives with index 2 (last in sorted order).
+    const addFixBug = await pollUntil(typedDeltas, (delta) =>
+      delta.added.some((entry) => entry.item.id === idFixBug && entry.index === 2),
+    );
+    expect(addFixBug.added.find((entry) => entry.item.id === idFixBug)?.index).toBe(2);
+    expect(rawDeltas.some((delta) => delta.added.some((entry) => entry.row.id === idFixBug))).toBe(
+      true,
+    );
+
+    // Promote "Fix bug" to top: rank 30 → 0. New order: Fix bug, Buy milk, Call dentist.
+    runtime.update(idFixBug, { rank: { type: "Integer", value: 0 } });
+    const updated = await pollUntil(typedDeltas, (delta) =>
+      delta.updated.some((entry) => entry.newItem.id === idFixBug),
+    );
+    const updatedEntry = updated.updated.find((entry) => entry.newItem.id === idFixBug);
+    expect(updatedEntry).toBeDefined();
+    expect(typeof updatedEntry?.oldIndex).toBe("number");
+    expect(typeof updatedEntry?.newIndex).toBe("number");
+    expect(
+      rawDeltas.some((delta) =>
+        delta.updated.some(
+          (entry) => entry.old_row.id === idFixBug && entry.new_row.id === idFixBug,
+        ),
+      ),
+    ).toBe(true);
+
+    // Delete "Buy milk". Final order: Fix bug, Call dentist.
+    runtime.delete(idBuyMilk);
+    const removed = await pollUntil(typedDeltas, (delta) =>
+      delta.removed.some((entry) => entry.item.id === idBuyMilk),
+    );
+    const expectedRemovedIndex = updated.all.findIndex((item) => item.id === idBuyMilk);
+    expect(removed.removed.find((entry) => entry.item.id === idBuyMilk)?.index).toBe(
+      expectedRemovedIndex,
+    );
+    expect(removed.all.map((item) => item.id).sort()).toEqual([idCallDentist, idFixBug].sort());
+
+    runtime.unsubscribe(subId);
+  }, 15000);
+
+  it("adds first item and shifts prior second item to third position", async () => {
+    const runtime = await createWasmRuntime(schema, {
+      appId: "test-sub-manager-add-first-shift-second",
+    });
+    const manager = new SubscriptionManager<Todo>();
+    const typedDeltas: Array<ReturnType<typeof manager.handleDelta>> = [];
+
+    const subId = runtime.subscribe(
+      makeOrderedTodosQuery(),
+      (deltaJsonOrObject: RowDelta | string) => {
+        const raw: RowDelta =
+          typeof deltaJsonOrObject === "string" ? JSON.parse(deltaJsonOrObject) : deltaJsonOrObject;
+        typedDeltas.push(manager.handleDelta(raw, transformRow));
+      },
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    // Initial sorted state: [A(10), B(20)].
+    const idA = runtime.insert("todos", [
+      { type: "Text", value: "A" },
+      { type: "Integer", value: 10 },
+    ]);
+    const idB = runtime.insert("todos", [
+      { type: "Text", value: "B" },
+      { type: "Integer", value: 20 },
+    ]);
+    await pollUntil(
+      typedDeltas,
+      (d) => d.all.length === 2 && d.all[0].id === idA && d.all[1].id === idB,
+    );
+
+    // Add a new first item C(0): resulting order should be [C, A, B].
+    const idC = runtime.insert("todos", [
+      { type: "Text", value: "C" },
+      { type: "Integer", value: 0 },
+    ]);
+
+    const addFirstDelta = await pollUntil(typedDeltas, (d) =>
+      d.added.some((entry) => entry.item.id === idC && entry.index === 0),
+    );
+    expect(addFirstDelta.all.map((item) => item.id)).toEqual([idC, idA, idB]);
+    expect(addFirstDelta.all[2]?.id).toBe(idB);
+
+    runtime.unsubscribe(subId);
+  });
+
+  it("handles same-delta remove-first and move-second", () => {
+    const manager = new SubscriptionManager<Todo>();
+    const mkRow = (id: string, title: string, rank: number): WasmRow => ({
+      id,
+      values: [
+        { type: "Text", value: title },
+        { type: "Integer", value: rank },
+      ],
+    });
+
+    // Seed state: [A, B, C]
+    const seeded = manager.handleDelta(
+      {
+        added: [
+          { row: mkRow("a", "A", 10), index: 0 },
+          { row: mkRow("b", "B", 20), index: 1 },
+          { row: mkRow("c", "C", 30), index: 2 },
+        ],
+        updated: [],
+        removed: [],
+        pending: false,
+      },
+      transformRow,
+    );
+    expect(seeded.all.map((item) => item.id)).toEqual(["a", "b", "c"]);
+
+    // Same delta:
+    // - remove first item A (index 0)
+    // - move second item B from index 1 -> 0
+    // post should be [B, C]
+    const next = manager.handleDelta(
+      {
+        added: [],
+        updated: [
+          {
+            old_row: mkRow("b", "B", 20),
+            new_row: mkRow("b", "B", 20),
+            old_index: 1,
+            new_index: 0,
+          },
+        ],
+        removed: [{ row: mkRow("a", "A", 10), index: 0 }],
+        pending: false,
+      },
+      transformRow,
+    );
+
+    expect(next.removed.find((entry) => entry.item.id === "a")?.index).toBe(0);
+    const moved = next.updated.find((entry) => entry.newItem.id === "b");
+    expect(moved?.oldIndex).toBe(1);
+    expect(moved?.newIndex).toBe(0);
+    expect(next.all.map((item) => item.id)).toEqual(["b", "c"]);
+  });
+});

--- a/packages/jazz-ts/src/runtime/testing/wasm-runtime-test-utils.ts
+++ b/packages/jazz-ts/src/runtime/testing/wasm-runtime-test-utils.ts
@@ -1,0 +1,43 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { createRequire } from "node:module";
+import type { Runtime } from "../client.js";
+import type { WasmSchema } from "../../drivers/types.js";
+import { onTestFinished } from "vitest";
+
+export type TestRuntime = Runtime & { free?(): void };
+
+let wasmModulePromise: Promise<any> | null = null;
+
+function loadWasmModule(): Promise<any> {
+  if (!wasmModulePromise) {
+    wasmModulePromise = (async () => {
+      const require = createRequire(import.meta.url);
+      const wasmModule: any = await import("groove-wasm");
+      const wasmPath = resolve(dirname(require.resolve("groove-wasm")), "groove_wasm_bg.wasm");
+      wasmModule.initSync({ module: readFileSync(wasmPath) });
+      return wasmModule;
+    })();
+  }
+  return wasmModulePromise;
+}
+
+export async function createWasmRuntime(
+  schema: WasmSchema,
+  opts?: { appId?: string; env?: string; userBranch?: string; tier?: string },
+): Promise<TestRuntime> {
+  const wasmModule = await loadWasmModule();
+  const runtime = new wasmModule.WasmRuntime(
+    JSON.stringify(schema),
+    opts?.appId ?? "test-app",
+    opts?.env ?? "test",
+    opts?.userBranch ?? "main",
+    opts?.tier,
+  );
+
+  onTestFinished(async () => {
+    await runtime.free();
+  });
+
+  return runtime;
+}


### PR DESCRIPTION
## Overview

This PR upgrades subscription delta semantics from value-only change sets to **index-aware, order-stable deltas** across the full stack:

- `groove` query graph nodes (`SortNode`, `OutputNode`)
- `groove-wasm` runtime adapter
- `jazz-ts` runtime subscription manager and tests

The core objective is to make row-position transitions explicit and deterministic so clients can patch UI state without recomputing full ordered sets on every tick.

---

## Problem

Before this change:

- output deltas did not consistently encode positional effects from reordering,
- identity-preserving updates (`id` unchanged) could silently hide movement,
- WASM-to-TS delta payloads were not index-annotated,
- TS subscription state management lacked robust index-based reconstruction rules.

Result: consumers had to infer ordering changes, which was error-prone and could diverge from server/runtime ordering semantics.

---

## Solution (High-Level)

1. **Make sort movement explicit**  
   `SortNode` now emits identity-preserving `updated` entries for rows whose position changes due to surrounding adds/removes.

2. **Make output ordering state deterministic**  
   `OutputNode` now computes next ordered state by detaching removed/updated-old rows and reinserting rows in deterministic stream order.

3. **Centralize row-index transition logic**  
   Added `index_row_delta(...)` in `OutputNode` module to compute `pre_index`, `post_index`, and next ordered ids from a `RowDelta`.

4. **Keep WASM adapter thin**  
   `build_wasm_delta_json` now mostly serializes using shared indexed state from `groove`, rather than implementing index transitions itself.

5. **Adopt index-aware client contracts**  
   `jazz-ts` runtime now treats deltas as indexed operations and rebuilds post-state deterministically using add/update/remove index metadata.

---

## Out-of-scope

I've not been focusing much on the comms layer between Rust and TS

That layer is currently using JSON, which is sub-optimal performance-wise.

I try to takle this problem in future re-designs
