### PR TITLE
Fix late-upstream query subscription replay

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,6 @@
 [workspace]
 resolver = "2"
 members = [
-  "crates/bf-tree",
   "crates/jazz-lsm",
   "crates/groove",
   "crates/groove-tokio",
@@ -13,4 +12,4 @@ members = [
   "crates/wasm-tracing",
   "examples/todo-server-rs",
 ]
-exclude = ["crates/bf-tree/tests/wasm"]
+exclude = ["crates/bf-tree", "crates/bf-tree/tests/wasm"]

--- a/crates/groove-napi/index.d.ts
+++ b/crates/groove-napi/index.d.ts
@@ -39,6 +39,7 @@ export declare class NapiRuntime {
   onSyncMessageReceivedFromClient(clientId: string, messageJson: string): void;
   onSyncMessageToSend(callback: (...args: any[]) => any): void;
   addServer(): void;
+  removeServer(): void;
   addClient(): string;
   /** Set a client's role ("user", "admin", or "peer"). */
   setClientRole(clientId: string, role: string): void;

--- a/crates/groove-napi/src/lib.rs
+++ b/crates/groove-napi/src/lib.rs
@@ -384,6 +384,7 @@ impl SyncSender for NapiSyncSender {
 #[napi]
 pub struct NapiRuntime {
     core: Arc<Mutex<NapiCoreType>>,
+    upstream_server_id: Mutex<Option<ServerId>>,
 }
 
 #[napi]
@@ -486,7 +487,10 @@ impl NapiRuntime {
             core_guard.persist_schema();
         }
 
-        Ok(NapiRuntime { core: core_arc })
+        Ok(NapiRuntime {
+            core: core_arc,
+            upstream_server_id: Mutex::new(None),
+        })
     }
 
     // =========================================================================
@@ -877,12 +881,45 @@ impl NapiRuntime {
 
     #[napi(js_name = "addServer")]
     pub fn add_server(&self) -> napi::Result<()> {
-        let server_id = ServerId::new();
+        let server_id = {
+            let mut slot = self
+                .upstream_server_id
+                .lock()
+                .map_err(|_| napi::Error::from_reason("lock"))?;
+            if let Some(server_id) = *slot {
+                server_id
+            } else {
+                let server_id = ServerId::new();
+                *slot = Some(server_id);
+                server_id
+            }
+        };
         let mut core = self
             .core
             .lock()
             .map_err(|_| napi::Error::from_reason("lock"))?;
+        // Re-attach semantics: remove existing upstream edge then add again so
+        // replay/full-sync runs on every successful reconnect.
+        core.remove_server(server_id);
         core.add_server(server_id);
+        Ok(())
+    }
+
+    #[napi(js_name = "removeServer")]
+    pub fn remove_server(&self) -> napi::Result<()> {
+        let Some(server_id) = *self
+            .upstream_server_id
+            .lock()
+            .map_err(|_| napi::Error::from_reason("lock"))?
+        else {
+            return Ok(());
+        };
+
+        let mut core = self
+            .core
+            .lock()
+            .map_err(|_| napi::Error::from_reason("lock"))?;
+        core.remove_server(server_id);
         Ok(())
     }
 

--- a/crates/groove-wasm/src/runtime.rs
+++ b/crates/groove-wasm/src/runtime.rs
@@ -238,6 +238,7 @@ impl SyncSender for JsSyncSender {
 #[wasm_bindgen]
 pub struct WasmRuntime {
     core: Rc<RefCell<WasmCoreType>>,
+    upstream_server_id: RefCell<Option<ServerId>>,
     /// Label for tracing (e.g. "worker", "edge", or "client").
     tier_label: &'static str,
 }
@@ -337,6 +338,7 @@ impl WasmRuntime {
 
         Ok(WasmRuntime {
             core: core_rc,
+            upstream_server_id: RefCell::new(None),
             tier_label,
         })
     }
@@ -707,10 +709,31 @@ impl WasmRuntime {
     #[wasm_bindgen(js_name = addServer)]
     pub fn add_server(&self) {
         let _span = info_span!("wasm::addServer", tier = self.tier_label).entered();
-        let server_id = ServerId::new();
+        let server_id = {
+            let mut slot = self.upstream_server_id.borrow_mut();
+            if let Some(server_id) = *slot {
+                server_id
+            } else {
+                let server_id = ServerId::new();
+                *slot = Some(server_id);
+                server_id
+            }
+        };
         let mut core = self.core.borrow_mut();
+        // Re-attach semantics: remove existing upstream edge then add again so
+        // replay/full-sync runs on every successful reconnect.
+        core.remove_server(server_id);
         core.add_server(server_id);
         core.batched_tick();
+    }
+
+    /// Remove the current upstream server connection.
+    #[wasm_bindgen(js_name = removeServer)]
+    pub fn remove_server(&self) {
+        let mut core = self.core.borrow_mut();
+        if let Some(server_id) = *self.upstream_server_id.borrow() {
+            core.remove_server(server_id);
+        }
     }
 
     /// Add a client connection (for server-side use in tests).
@@ -880,6 +903,7 @@ impl WasmRuntime {
 
         Ok(WasmRuntime {
             core: core_rc,
+            upstream_server_id: RefCell::new(None),
             tier_label,
         })
     }

--- a/crates/groove/src/query_manager/manager_tests.rs
+++ b/crates/groove/src/query_manager/manager_tests.rs
@@ -4891,6 +4891,53 @@ fn subscribe_with_sync_sends_to_servers() {
 }
 
 #[test]
+fn add_server_replays_existing_local_query_subscriptions() {
+    use crate::sync_manager::{Destination, QueryId, ServerId, SyncPayload};
+    use uuid::Uuid;
+
+    let sync_manager = SyncManager::new();
+    let schema = test_schema();
+    let (mut client_qm, _storage) = create_query_manager(sync_manager, schema);
+
+    let query = client_qm
+        .query("users")
+        .filter_gt("score", Value::Integer(50))
+        .build();
+    let sub_id = client_qm.subscribe_with_sync(query, None, None).unwrap();
+
+    // No server connected yet, so no outbound subscription forwarding.
+    let outbox_before_add_server = client_qm.sync_manager_mut().take_outbox();
+    assert!(
+        outbox_before_add_server
+            .iter()
+            .all(|e| !matches!(e.payload, SyncPayload::QuerySubscription { .. })),
+        "Should not forward QuerySubscription before any server is connected"
+    );
+
+    let server_id = ServerId(Uuid::new_v7(uuid::Timestamp::now(uuid::NoContext)));
+    client_qm.add_server(server_id);
+
+    let outbox = client_qm.sync_manager_mut().take_outbox();
+    let replayed: Vec<_> = outbox
+        .iter()
+        .filter(|e| matches!(e.destination, Destination::Server(id) if id == server_id))
+        .filter_map(|e| {
+            if let SyncPayload::QuerySubscription { query_id, .. } = &e.payload {
+                Some(*query_id)
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    assert_eq!(
+        replayed,
+        vec![QueryId(sub_id.0)],
+        "add_server should replay active local subscriptions to the new server"
+    );
+}
+
+#[test]
 fn unsubscribe_with_sync_sends_to_servers() {
     use crate::sync_manager::{Destination, ServerId, SyncPayload};
     use uuid::Uuid;

--- a/crates/groove/src/query_manager/subscriptions.rs
+++ b/crates/groove/src/query_manager/subscriptions.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 
 use crate::object_manager::AllObjectUpdate;
 use crate::storage::Storage;
-use crate::sync_manager::PersistenceTier;
+use crate::sync_manager::{PersistenceTier, QueryId, ServerId};
 
 #[cfg(test)]
 use super::encoding::decode_row;
@@ -176,19 +176,24 @@ impl QueryManager {
         // Create local subscription
         let sub_id = self.subscribe_with_session(query.clone(), session.clone(), settled_tier)?;
 
-        // Expand branches for sync payload - server needs explicit branch to resolve schema
-        let mut sync_query = query;
-        if sync_query.branches.is_empty() && self.schema_context.is_initialized() {
-            sync_query.branches = vec![self.schema_context.branch_name().as_str().to_string()];
-        }
+        let sync_query = self.sync_query_payload_for_upstream(&query);
 
         // Send QuerySubscription to all servers
         // Use the subscription ID as the query ID for simplicity
-        let query_id = crate::sync_manager::QueryId(sub_id.0);
+        let query_id = QueryId(sub_id.0);
         self.sync_manager
             .send_query_subscription_to_servers(query_id, sync_query, session);
 
         Ok(sub_id)
+    }
+
+    /// Add an upstream server and replay all active query subscriptions.
+    ///
+    /// This ensures subscriptions that became active before the server connection
+    /// are forwarded once the server is available.
+    pub fn add_server(&mut self, server_id: ServerId) {
+        self.sync_manager.add_server(server_id);
+        self.replay_active_query_subscriptions_to_server(server_id);
     }
 
     /// Unsubscribe from a synced query.
@@ -200,9 +205,53 @@ impl QueryManager {
         self.subscriptions.remove(&id);
 
         // Send QueryUnsubscription to all servers
-        let query_id = crate::sync_manager::QueryId(id.0);
+        let query_id = QueryId(id.0);
         self.sync_manager
             .send_query_unsubscription_to_servers(query_id);
+    }
+
+    /// Build the sync payload query for upstream forwarding.
+    ///
+    /// If branches are not explicitly set, upstream expects the current write branch
+    /// to be included so it can resolve schema context correctly.
+    fn sync_query_payload_for_upstream(&self, query: &Query) -> Query {
+        let mut sync_query = query.clone();
+        if sync_query.branches.is_empty() && self.schema_context.is_initialized() {
+            sync_query.branches = vec![self.schema_context.branch_name().as_str().to_string()];
+        }
+        sync_query
+    }
+
+    /// Replay all currently active local and downstream query subscriptions
+    /// to a newly added upstream server.
+    fn replay_active_query_subscriptions_to_server(&mut self, server_id: ServerId) {
+        let local_subs: Vec<(QueryId, Query, Option<Session>)> = self
+            .subscriptions
+            .iter()
+            .map(|(sub_id, sub)| {
+                (
+                    QueryId(sub_id.0),
+                    self.sync_query_payload_for_upstream(&sub.query),
+                    sub.session.clone(),
+                )
+            })
+            .collect();
+
+        for (query_id, query, session) in local_subs {
+            self.sync_manager
+                .send_query_subscription_to_server(server_id, query_id, query, session);
+        }
+
+        let downstream_subs: Vec<(QueryId, Query, Option<Session>)> = self
+            .server_subscriptions
+            .iter()
+            .map(|((_, query_id), sub)| (*query_id, sub.query.clone(), sub.session.clone()))
+            .collect();
+
+        for (query_id, query, session) in downstream_subs {
+            self.sync_manager
+                .send_query_subscription_to_server(server_id, query_id, query, session);
+        }
     }
 
     /// Take pending query updates.

--- a/crates/groove/src/runtime_core.rs
+++ b/crates/groove/src/runtime_core.rs
@@ -849,7 +849,6 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
         info!(%server_id, "adding server");
         self.schema_manager
             .query_manager_mut()
-            .sync_manager_mut()
             .add_server(server_id);
         self.immediate_tick();
     }
@@ -1357,6 +1356,135 @@ mod tests {
 
         // B → A
         pump_b_to_a(s);
+    }
+
+    #[test]
+    fn rc_replays_downstream_query_when_upstream_added_late() {
+        // Build A <-> B first (no B <-> C yet), so B processes a downstream
+        // query subscription before it has any upstream server.
+        let schema = test_schema();
+        let app_id = AppId::from_name("query-replay-test");
+
+        let mgr_a = SchemaManager::new(
+            SyncManager::new(),
+            schema.clone(),
+            app_id.clone(),
+            "dev",
+            "main",
+        )
+        .unwrap();
+        let mut a = RuntimeCore::new(
+            mgr_a,
+            MemoryStorage::new(),
+            NoopScheduler,
+            VecSyncSender::new(),
+        );
+
+        let mgr_b = SchemaManager::new(
+            SyncManager::new().with_tier(PersistenceTier::Worker),
+            schema.clone(),
+            app_id.clone(),
+            "dev",
+            "main",
+        )
+        .unwrap();
+        let mut b = RuntimeCore::new(
+            mgr_b,
+            MemoryStorage::new(),
+            NoopScheduler,
+            VecSyncSender::new(),
+        );
+
+        let mgr_c = SchemaManager::new(
+            SyncManager::new().with_tier(PersistenceTier::EdgeServer),
+            schema,
+            app_id,
+            "dev",
+            "main",
+        )
+        .unwrap();
+        let mut c = RuntimeCore::new(
+            mgr_c,
+            MemoryStorage::new(),
+            NoopScheduler,
+            VecSyncSender::new(),
+        );
+
+        let a_client_of_b = ClientId::new();
+        let b_server_for_a = ServerId::new();
+        let b_client_of_c = ClientId::new();
+        let c_server_for_b = ServerId::new();
+
+        {
+            let sm = b
+                .schema_manager_mut()
+                .query_manager_mut()
+                .sync_manager_mut();
+            sm.add_client(a_client_of_b);
+            sm.set_client_role(a_client_of_b, ClientRole::Peer);
+        }
+        a.schema_manager_mut()
+            .query_manager_mut()
+            .sync_manager_mut()
+            .add_server(b_server_for_a);
+
+        // Clear any startup sync traffic.
+        a.immediate_tick();
+        b.immediate_tick();
+        c.immediate_tick();
+        a.batched_tick();
+        b.batched_tick();
+        c.batched_tick();
+        a.sync_sender().take();
+        b.sync_sender().take();
+        c.sync_sender().take();
+
+        // Downstream client A subscribes before B has an upstream.
+        let _handle = a.subscribe(Query::new("users"), |_delta| {}, None).unwrap();
+
+        // Deliver only A -> B messages.
+        a.batched_tick();
+        for entry in a.sync_sender().take() {
+            if entry.destination == Destination::Server(b_server_for_a) {
+                b.park_sync_message(InboxEntry {
+                    source: Source::Client(a_client_of_b),
+                    payload: entry.payload,
+                });
+            }
+        }
+        b.batched_tick();
+        b.immediate_tick();
+        b.batched_tick();
+        b.sync_sender().take();
+
+        // Bring up B <-> C after B already has active downstream query state.
+        {
+            let sm = c
+                .schema_manager_mut()
+                .query_manager_mut()
+                .sync_manager_mut();
+            sm.add_client(b_client_of_c);
+            sm.set_client_role(b_client_of_c, ClientRole::Peer);
+        }
+        b.add_server(c_server_for_b);
+        b.batched_tick();
+
+        let forwarded_query_subscriptions = b
+            .sync_sender()
+            .take()
+            .into_iter()
+            .filter(|entry| {
+                matches!(
+                    &entry.destination,
+                    Destination::Server(server_id) if *server_id == c_server_for_b
+                ) && matches!(&entry.payload, SyncPayload::QuerySubscription { .. })
+            })
+            .count();
+
+        assert!(
+            forwarded_query_subscriptions > 0,
+            "Expected B to replay existing downstream QuerySubscription(s) when adding upstream"
+        );
     }
 
     #[test]

--- a/crates/groove/src/runtime_core.rs
+++ b/crates/groove/src/runtime_core.rs
@@ -1112,8 +1112,8 @@ mod tests {
     // =========================================================================
 
     use crate::sync_manager::{
-        ClientId, ClientRole, Destination, InboxEntry, PersistenceTier, ServerId, Source,
-        SyncPayload,
+        ClientId, ClientRole, Destination, InboxEntry, OutboxEntry, PersistenceTier, ServerId,
+        Source, SyncPayload,
     };
 
     /// Three-tier RuntimeCore setup for durability tests.
@@ -1358,6 +1358,18 @@ mod tests {
         pump_b_to_a(s);
     }
 
+    fn count_query_subscriptions_to_server(entries: &[OutboxEntry], server_id: ServerId) -> usize {
+        entries
+            .iter()
+            .filter(|entry| {
+                matches!(
+                    &entry.destination,
+                    Destination::Server(dest_server_id) if *dest_server_id == server_id
+                ) && matches!(&entry.payload, SyncPayload::QuerySubscription { .. })
+            })
+            .count()
+    }
+
     #[test]
     fn rc_replays_downstream_query_when_upstream_added_late() {
         // Build A <-> B first (no B <-> C yet), so B processes a downstream
@@ -1484,6 +1496,65 @@ mod tests {
         assert!(
             forwarded_query_subscriptions > 0,
             "Expected B to replay existing downstream QuerySubscription(s) when adding upstream"
+        );
+    }
+
+    #[test]
+    fn rc_replays_active_queries_on_upstream_reconnect() {
+        let mut s = create_3tier_rc();
+
+        let _handle =
+            s.a.subscribe(Query::new("users"), |_delta| {}, None)
+                .unwrap();
+        pump_a_to_b(&mut s);
+
+        let initial_forwarded = s.b.sync_sender().take();
+        assert!(
+            count_query_subscriptions_to_server(&initial_forwarded, s.c_server_for_b) > 0,
+            "Expected initial QuerySubscription forwarding from B to C"
+        );
+
+        // Simulate upstream disconnect/reconnect.
+        s.b.remove_server(s.c_server_for_b);
+        s.b.add_server(s.c_server_for_b);
+        s.b.batched_tick();
+
+        let replayed_forwarded = s.b.sync_sender().take();
+        assert!(
+            count_query_subscriptions_to_server(&replayed_forwarded, s.c_server_for_b) > 0,
+            "Expected active QuerySubscription replay after upstream reconnect"
+        );
+    }
+
+    #[test]
+    fn rc_does_not_replay_unsubscribed_queries_on_upstream_reconnect() {
+        let mut s = create_3tier_rc();
+
+        let handle =
+            s.a.subscribe(Query::new("users"), |_delta| {}, None)
+                .unwrap();
+        pump_a_to_b(&mut s);
+
+        let initial_forwarded = s.b.sync_sender().take();
+        assert!(
+            count_query_subscriptions_to_server(&initial_forwarded, s.c_server_for_b) > 0,
+            "Expected initial QuerySubscription forwarding from B to C"
+        );
+
+        s.a.unsubscribe(handle);
+        pump_a_to_b(&mut s);
+        s.b.sync_sender().take(); // Drain unsubscription forwarding and unrelated traffic.
+
+        // Reconnect upstream and ensure replay no longer includes this query.
+        s.b.remove_server(s.c_server_for_b);
+        s.b.add_server(s.c_server_for_b);
+        s.b.batched_tick();
+
+        let replayed_forwarded = s.b.sync_sender().take();
+        assert_eq!(
+            count_query_subscriptions_to_server(&replayed_forwarded, s.c_server_for_b),
+            0,
+            "Unsubscribed query must not be replayed after upstream reconnect"
         );
     }
 

--- a/crates/groove/src/sync_manager/mod.rs
+++ b/crates/groove/src/sync_manager/mod.rs
@@ -329,16 +329,39 @@ impl SyncManager {
         query: Query,
         session: Option<Session>,
     ) {
-        for &server_id in self.servers.keys() {
-            self.outbox.push(OutboxEntry {
-                destination: Destination::Server(server_id),
-                payload: SyncPayload::QuerySubscription {
-                    query_id,
-                    query: query.clone(),
-                    session: session.clone(),
-                },
-            });
+        let server_ids: Vec<ServerId> = self.servers.keys().copied().collect();
+        for server_id in server_ids {
+            self.send_query_subscription_to_server(
+                server_id,
+                query_id,
+                query.clone(),
+                session.clone(),
+            );
         }
+    }
+
+    /// Send a QuerySubscription to one specific server.
+    ///
+    /// Used when replaying existing subscriptions after a late server connect.
+    pub fn send_query_subscription_to_server(
+        &mut self,
+        server_id: ServerId,
+        query_id: QueryId,
+        query: Query,
+        session: Option<Session>,
+    ) {
+        if !self.servers.contains_key(&server_id) {
+            return;
+        }
+
+        self.outbox.push(OutboxEntry {
+            destination: Destination::Server(server_id),
+            payload: SyncPayload::QuerySubscription {
+                query_id,
+                query,
+                session,
+            },
+        });
     }
 
     /// Send a QueryUnsubscription to all connected servers.

--- a/crates/jazz-cli/src/routes.rs
+++ b/crates/jazz-cli/src/routes.rs
@@ -121,7 +121,6 @@ async fn events_handler(
 
     // Clone state for cleanup on drop
     let state_cleanup = state.clone();
-    let client_id_cleanup = client_id;
     let connection_id_cleanup = connection_id;
 
     // Capture client_id string for stream
@@ -174,8 +173,12 @@ async fn events_handler(
             let mut connections = state_cleanup.connections.write().await;
             connections.remove(&connection_id_cleanup);
         }
-        let _ = state_cleanup.runtime.remove_client(client_id_cleanup);
-        tracing::debug!("Stream connection {} closed, cleaned up", connection_id_cleanup);
+        // Keep logical client state across disconnects so reconnect with the same
+        // client_id can resume query forwarding state.
+        tracing::debug!(
+            "Stream connection {} closed (client state retained for resume)",
+            connection_id_cleanup
+        );
     };
 
     Ok(axum::response::Response::builder()

--- a/packages/jazz-ts/src/runtime/client.ts
+++ b/packages/jazz-ts/src/runtime/client.ts
@@ -37,6 +37,7 @@ export interface Runtime {
   onSyncMessageReceived(message_json: string): void;
   onSyncMessageToSend(callback: Function): void;
   addServer(): void;
+  removeServer(): void;
   addClient(): string;
   getSchema(): any;
   close?(): void | Promise<void>;
@@ -182,6 +183,12 @@ export class SessionClient {
 export class JazzClient {
   private runtime: Runtime;
   private streamAbortController: AbortController | null = null;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private reconnectAttempt = 0;
+  private streamConnecting = false;
+  private streamAttached = false;
+  private serverClientId: string | null = null;
+  private activeServerUrl: string | null = null;
   private subscriptions = new Map<number, SubscriptionCallback>();
   private context: AppContext;
 
@@ -507,6 +514,13 @@ export class JazzClient {
    * Shutdown the client and release resources.
    */
   async shutdown(): Promise<void> {
+    this.activeServerUrl = null;
+    this.detachServer();
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+
     // Abort stream connection
     if (this.streamAbortController) {
       this.streamAbortController.abort();
@@ -525,6 +539,8 @@ export class JazzClient {
   }
 
   private setupSync(serverUrl: string): void {
+    this.activeServerUrl = serverUrl;
+
     // Set up outgoing message handler
     this.runtime.onSyncMessageToSend((envelope: string) => {
       // Envelope is now {destination, payload}
@@ -538,17 +554,47 @@ export class JazzClient {
     });
 
     // Connect to binary stream for incoming messages
-    this.connectStream(serverUrl);
-
-    // Register server connection
-    this.runtime.addServer();
+    this.connectStream();
   }
 
   private async sendSyncMessage(serverUrl: string, payload: any): Promise<void> {
     await sendSyncPayload(serverUrl, payload, {
       jwtToken: this.context.jwtToken,
       adminSecret: this.context.adminSecret,
+      clientId: this.serverClientId ?? undefined,
     });
+  }
+
+  private detachServer(): void {
+    if (!this.streamAttached) return;
+    this.runtime.removeServer();
+    this.streamAttached = false;
+  }
+
+  private attachServer(): void {
+    // Re-attach every time the stream reconnects so query subscriptions replay.
+    if (this.streamAttached) {
+      this.runtime.removeServer();
+    }
+    this.runtime.addServer();
+    this.streamAttached = true;
+    this.reconnectAttempt = 0;
+  }
+
+  private scheduleReconnect(): void {
+    if (!this.activeServerUrl) return;
+    if (this.reconnectTimer) return;
+
+    const baseMs = 300;
+    const maxMs = 10_000;
+    const jitterMs = Math.floor(Math.random() * 200);
+    const delayMs = Math.min(maxMs, baseMs * 2 ** this.reconnectAttempt) + jitterMs;
+    this.reconnectAttempt += 1;
+
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      this.connectStream();
+    }, delayMs);
   }
 
   /**
@@ -557,7 +603,11 @@ export class JazzClient {
    * Uses length-prefixed binary frames over a long-lived HTTP response.
    * Supports auth via Authorization header (unlike EventSource).
    */
-  private async connectStream(serverUrl: string): Promise<void> {
+  private async connectStream(): Promise<void> {
+    if (this.streamConnecting || !this.activeServerUrl) return;
+    this.streamConnecting = true;
+
+    const serverUrl = this.activeServerUrl;
     const headers: Record<string, string> = {
       Accept: "application/octet-stream",
     };
@@ -568,29 +618,46 @@ export class JazzClient {
     this.streamAbortController = new AbortController();
 
     try {
-      const response = await fetch(`${serverUrl}/events`, {
+      const eventsUrl = this.serverClientId
+        ? `${serverUrl}/events?client_id=${encodeURIComponent(this.serverClientId)}`
+        : `${serverUrl}/events`;
+
+      const response = await fetch(eventsUrl, {
         headers,
         signal: this.streamAbortController.signal,
       });
 
       if (!response.ok) {
         console.error(`Stream connect failed: ${response.status}`);
-        setTimeout(() => this.connectStream(serverUrl), 5000);
+        this.detachServer();
+        this.streamConnecting = false;
+        this.scheduleReconnect();
         return;
       }
 
       const reader = response.body!.getReader();
+      let connected = false;
       await readBinaryFrames(reader, {
         onSyncMessage: (json) => this.runtime.onSyncMessageReceived(json),
+        onConnected: (clientId) => {
+          this.serverClientId = clientId;
+          if (!connected) {
+            connected = true;
+            this.attachServer();
+          }
+        },
       });
     } catch (e: any) {
       if (e?.name === "AbortError") return; // Intentional shutdown
       console.error("Stream error:", e);
+    } finally {
+      this.streamConnecting = false;
     }
 
     // Reconnect after delay (unless aborted)
     if (this.streamAbortController && !this.streamAbortController.signal.aborted) {
-      setTimeout(() => this.connectStream(serverUrl), 5000);
+      this.detachServer();
+      this.scheduleReconnect();
     }
   }
 }

--- a/packages/jazz-ts/src/worker/groove-worker.ts
+++ b/packages/jazz-ts/src/worker/groove-worker.ts
@@ -23,7 +23,14 @@ let jwtToken: string | undefined;
 let adminSecret: string | undefined;
 let streamAbortController: AbortController | null = null;
 let serverClientId: string | null = null; // Client ID assigned by server (from Connected frame)
+let activeServerUrl: string | null = null;
+let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+let reconnectAttempt = 0;
+let streamConnecting = false;
+let streamAttached = false;
+let isShuttingDown = false;
 let pendingSyncMessages: string[] = []; // Buffer sync messages until init completes
+let initComplete = false;
 
 function post(msg: WorkerToMainMessage): void {
   self.postMessage(msg);
@@ -54,6 +61,21 @@ async function startup(): Promise<void> {
 async function handleInit(msg: InitMessage): Promise<void> {
   try {
     const wasmModule: any = await import("groove-wasm");
+    initComplete = false;
+    isShuttingDown = false;
+    activeServerUrl = msg.serverUrl ?? null;
+    reconnectAttempt = 0;
+    streamAttached = false;
+    streamConnecting = false;
+    serverClientId = null;
+    if (reconnectTimer) {
+      clearTimeout(reconnectTimer);
+      reconnectTimer = null;
+    }
+    if (streamAbortController) {
+      streamAbortController.abort();
+      streamAbortController = null;
+    }
 
     // Open persistent OPFS-backed runtime with Worker tier
     runtime = await wasmModule.WasmRuntime.openPersistent(
@@ -82,28 +104,28 @@ async function handleInit(msg: InitMessage): Promise<void> {
         post({ type: "sync", payload: JSON.stringify(parsed.payload) });
       } else if (parsed.destination && "Server" in parsed.destination) {
         // Server-bound → HTTP POST to upstream
-        if (msg.serverUrl) {
-          sendToServer(msg.serverUrl, parsed.payload);
+        if (activeServerUrl) {
+          sendToServer(activeServerUrl, parsed.payload);
         }
       }
     });
 
-    // Connect to upstream server if URL provided.
-    // IMPORTANT: connectStream first to set serverClientId, THEN addServer.
-    // addServer() flushes the outbox synchronously (including catalogue sync),
-    // and those POSTs need serverClientId to be set.
-    if (msg.serverUrl) {
-      await connectStream(msg.serverUrl);
-      runtime.addServer();
-    }
+    // Runtime is now fully ready to ingest client sync traffic.
+    const bufferedSyncMessages = pendingSyncMessages;
+    pendingSyncMessages = [];
+    initComplete = true;
 
-    // Drain any sync messages that arrived before init completed
-    for (const payload of pendingSyncMessages) {
+    // Drain sync messages that arrived before init completed.
+    for (const payload of bufferedSyncMessages) {
       runtime.onSyncMessageReceivedFromClient(mainClientId!, payload);
     }
-    pendingSyncMessages = [];
 
     post({ type: "init-ok", clientId: mainClientId! });
+
+    // Connect upstream in background (do not block init).
+    if (activeServerUrl) {
+      void connectStream();
+    }
   } catch (e: any) {
     post({ type: "error", message: `Init failed: ${e.message}` });
   }
@@ -123,12 +145,44 @@ async function sendToServer(serverUrl: string, payload: any): Promise<void> {
   );
 }
 
-/**
- * Connect to the server's binary streaming endpoint.
- * Resolves once the Connected frame is received (serverClientId is set).
- * Stream reading continues in the background after resolution.
- */
-async function connectStream(serverUrl: string): Promise<void> {
+function attachServer(): void {
+  if (!runtime) return;
+  // Re-attach every time the stream reconnects so query subscriptions replay.
+  if (streamAttached) {
+    runtime.removeServer();
+  }
+  runtime.addServer();
+  streamAttached = true;
+  reconnectAttempt = 0;
+}
+
+function detachServer(): void {
+  if (!runtime || !streamAttached) return;
+  runtime.removeServer();
+  streamAttached = false;
+}
+
+function scheduleReconnect(): void {
+  if (isShuttingDown || !activeServerUrl) return;
+  if (reconnectTimer) return;
+
+  const baseMs = 300;
+  const maxMs = 10_000;
+  const jitterMs = Math.floor(Math.random() * 200);
+  const delayMs = Math.min(maxMs, baseMs * 2 ** reconnectAttempt) + jitterMs;
+  reconnectAttempt += 1;
+
+  reconnectTimer = setTimeout(() => {
+    reconnectTimer = null;
+    void connectStream();
+  }, delayMs);
+}
+
+/** Connect to the server's binary streaming endpoint. */
+async function connectStream(): Promise<void> {
+  if (streamConnecting || !activeServerUrl || isShuttingDown) return;
+  streamConnecting = true;
+
   const headers: Record<string, string> = {
     Accept: "application/octet-stream",
   };
@@ -139,63 +193,49 @@ async function connectStream(serverUrl: string): Promise<void> {
   streamAbortController = new AbortController();
 
   try {
-    const response = await fetch(`${serverUrl}/events`, {
+    const eventsUrl = serverClientId
+      ? `${activeServerUrl}/events?client_id=${encodeURIComponent(serverClientId)}`
+      : `${activeServerUrl}/events`;
+
+    const response = await fetch(eventsUrl, {
       headers,
       signal: streamAbortController.signal,
     });
 
     if (!response.ok) {
       console.error(`[worker] Stream connect failed: ${response.status}`);
-      setTimeout(() => connectStream(serverUrl), 5000);
+      detachServer();
+      streamConnecting = false;
+      scheduleReconnect();
       return;
     }
 
     const reader = response.body!.getReader();
-
-    // Read frames in background, resolve once Connected is received
-    await new Promise<void>((resolveConnected) => {
-      let resolved = false;
-
-      const resolve = () => {
-        if (!resolved) {
-          resolved = true;
-          resolveConnected();
-        }
-      };
-
-      const readLoop = async () => {
-        try {
-          await readBinaryFrames(
-            reader,
-            {
-              onSyncMessage: (json) => runtime?.onSyncMessageReceived(json),
-              onConnected: (clientId) => {
-                serverClientId = clientId;
-                resolve();
-              },
-            },
-            "[worker] ",
-          );
-        } catch (e: any) {
-          if (e?.name === "AbortError") {
-            resolve();
-            return;
+    let connected = false;
+    await readBinaryFrames(
+      reader,
+      {
+        onSyncMessage: (json) => runtime?.onSyncMessageReceived(json),
+        onConnected: (clientId) => {
+          serverClientId = clientId;
+          if (!connected) {
+            connected = true;
+            attachServer();
           }
-          console.error("[worker] Stream error:", e);
-        }
-
-        // Reconnect unless aborted
-        if (streamAbortController && !streamAbortController.signal.aborted) {
-          setTimeout(() => connectStream(serverUrl), 5000);
-        }
-        resolve();
-      };
-
-      readLoop();
-    });
+        },
+      },
+      "[worker] ",
+    );
   } catch (e: any) {
     if (e?.name === "AbortError") return;
     console.error("[worker] Stream connect error:", e);
+  } finally {
+    streamConnecting = false;
+  }
+
+  if (streamAbortController && !streamAbortController.signal.aborted) {
+    detachServer();
+    scheduleReconnect();
   }
 }
 
@@ -212,7 +252,7 @@ self.onmessage = async (event: MessageEvent<MainToWorkerMessage>) => {
       break;
 
     case "sync": {
-      if (runtime && mainClientId) {
+      if (runtime && mainClientId && initComplete) {
         runtime.onSyncMessageReceivedFromClient(mainClientId, msg.payload);
       } else {
         pendingSyncMessages.push(msg.payload);
@@ -222,15 +262,31 @@ self.onmessage = async (event: MessageEvent<MainToWorkerMessage>) => {
 
     case "update-auth":
       jwtToken = msg.jwtToken;
-      // TODO: Reconnect stream with new token if needed
+      // Reconnect stream to bind the new token.
+      if (streamAbortController) {
+        streamAbortController.abort();
+        streamAbortController = null;
+      }
+      detachServer();
+      if (activeServerUrl && !isShuttingDown) {
+        scheduleReconnect();
+      }
       break;
 
     case "shutdown":
+      isShuttingDown = true;
+      initComplete = false;
+      activeServerUrl = null;
+      if (reconnectTimer) {
+        clearTimeout(reconnectTimer);
+        reconnectTimer = null;
+      }
       if (streamAbortController) {
         streamAbortController.abort();
         streamAbortController = null;
       }
       if (runtime) {
+        detachServer();
         runtime.flush();
         runtime.free(); // Triggers Rust Drop → closes OPFS exclusive handles
         runtime = null;
@@ -243,11 +299,19 @@ self.onmessage = async (event: MessageEvent<MainToWorkerMessage>) => {
       // Flush WAL buffer to OPFS but do NOT write snapshot.
       // This simulates a crash where writes reached the WAL but no
       // clean checkpoint happened. Recovery must replay the WAL.
+      isShuttingDown = true;
+      initComplete = false;
+      activeServerUrl = null;
+      if (reconnectTimer) {
+        clearTimeout(reconnectTimer);
+        reconnectTimer = null;
+      }
       if (streamAbortController) {
         streamAbortController.abort();
         streamAbortController = null;
       }
       if (runtime) {
+        detachServer();
         runtime.flushWal(); // WAL buffer → OPFS, but no snapshot
         runtime.free(); // Drop → releases OPFS exclusive handles
         runtime = null;

--- a/specs/todo/b_mvp/reconnection_resubscription.md
+++ b/specs/todo/b_mvp/reconnection_resubscription.md
@@ -1,3 +1,59 @@
-# Reconnection Re-Subscription — TODO (MVP)
+# Reconnection Re-Subscription (MVP v2)
 
-When reconnect or dynamic server add/remove is implemented, the client should re-send all active subscriptions to newly connected servers.
+## Goal
+
+Ensure query forwarding converges in both cases:
+
+1. Local/downstream subscriptions become active before any upstream is connected.
+2. Upstream disconnects, local/downstream subscriptions change while offline, then upstream reconnects.
+
+This is a prototype protocol. We do not require wire/backward compatibility with earlier behavior.
+
+## Core Invariants
+
+1. A subscription is local desired state, not a best-effort transient network event.
+2. After every successful upstream (re)connect, upstream receives the current desired subscription set.
+3. Unsubscribed queries are not replayed.
+4. Convergence must not depend on timing between "subscribe" and "connect."
+
+## MVP Protocol
+
+### Stable stream identity
+
+- Client stores the server-assigned `client_id` from `Connected`.
+- Reconnects to `/events` with `?client_id=<last_client_id>` to resume identity.
+
+### Runtime attach/detach lifecycle
+
+- On stream `Connected`:
+  - (Re)attach upstream server in runtime.
+  - Attachment triggers full object sync + replay of active local/downstream query subscriptions.
+- On stream disconnect/error:
+  - Detach upstream server from runtime.
+  - Local writes/subscriptions continue locally while offline.
+
+### Why this converges
+
+- Offline window: subscriptions are kept in runtime desired state.
+- Reconnect: `add_server` replay re-asserts all active subscriptions.
+- Timing/order cannot drop query forwarding, because replay is anti-entropy.
+
+## Retry / Backoff
+
+- Stream reconnect uses exponential backoff with jitter.
+- Backoff applies to stream re-establishment, not to local desired-state retention.
+
+## Server-side behavior (MVP)
+
+- Do not immediately drop client state on event-stream disconnect.
+- Reconnect with same `client_id` continues that logical client state.
+
+## Future Optimization Stub (not in this MVP)
+
+Current MVP uses full replay on each reconnect. Later we can optimize with a resumable diff handshake:
+
+- Client sends `(client_id, desired_state_version, desired_state_digest, count)`.
+- Server replies `InSync` or `ReplayRequired`.
+- Client sends full replay only on mismatch.
+
+Correctness requirement stays the same: full replay must remain the fallback anti-entropy path.


### PR DESCRIPTION
## Summary
- add explicit upstream attach/detach lifecycle in all runtimes (`addServer` + `removeServer`) and use re-attach on reconnect to deterministically replay active query subscriptions
- implement reconnect-safe sync transport in TS client + worker:
  - keep a stable upstream `client_id`
  - reconnect `/events` with `?client_id=...`
  - detach server on stream loss, re-attach on `Connected`
  - exponential reconnect backoff
- persist and resume upstream identity in NAPI/WASM wrappers so reconnects replay through `RuntimeCore` consistently
- retain server-side logical client state across `/events` disconnect (do not eagerly remove client) to support resume/re-assertion
- add and document MVP reconnection/resubscription spec in `/specs/todo/b_mvp/reconnection_resubscription.md`
- add RuntimeCore regression coverage for reconnect invariants:
  - replay active queries after upstream reconnect
  - do not replay unsubscribed queries

## Backcompat
- none intentionally (prototype): TS runtime interface now requires `removeServer()` and optional guard paths were removed

## Validation
- `cargo fmt --all`
- `pnpm oxfmt packages/jazz-ts/src/runtime/client.ts packages/jazz-ts/src/worker/groove-worker.ts`
- `cargo test -p groove rc_replays_ -- --nocapture`
- `cargo test -p groove rc_does_not_replay_unsubscribed_queries_on_upstream_reconnect -- --nocapture`
- `pnpm --filter todo-server-ts test`
- `pnpm --filter todo-client-localfirst-react test`
- `pnpm --filter todo-client-localfirst-ts test`

## Notes
- browser example suites still print existing teardown noise (`close timed out after 10000ms`), but both suites completed with exit code 0 and all tests passed
