### PR TITLE
Enforce sync before load (SvelteKit SSR)

### DIFF
--- a/.changeset/auto-sync-before-navigation.md
+++ b/.changeset/auto-sync-before-navigation.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Add optional `navigation` prop to `JazzSvelteProvider` that automatically waits for pending CoValue syncs before SvelteKit navigations, preventing stale data on SSR pages.

--- a/examples/jazz-sveltekit/src/routes/+layout.svelte
+++ b/examples/jazz-sveltekit/src/routes/+layout.svelte
@@ -2,13 +2,14 @@
   import { JazzSvelteProvider } from "jazz-tools/svelte";
   import { apiKey } from "$lib/apiKey";
   import type { SyncConfig } from "jazz-tools";
+  import { beforeNavigate, goto } from "$app/navigation";
 
   let { children } = $props();
   const sync: SyncConfig = { peer: `wss://cloud.jazz.tools/?key=${apiKey}` };
 </script>
 
 <!-- Add the enableSSR flag to allow Jazz to render data server side -->
-<JazzSvelteProvider {sync} enableSSR>
+<JazzSvelteProvider {sync} enableSSR navigation={{ goto, beforeNavigate }}>
   <main class="container" style="margin-top: 2rem;">
     {@render children?.()}
   </main>

--- a/examples/jazz-sveltekit/src/routes/+page.svelte
+++ b/examples/jazz-sveltekit/src/routes/+page.svelte
@@ -9,13 +9,6 @@
     },
   });
   const me = $derived(account.current);
-  const navigate = async (route: string) => {
-    // Flush the name to avoid SSR picking up the previous name
-    if (me.$isLoaded) {
-      await me.profile.$jazz.waitForSync();
-    }
-    await goto(route);
-  };
 </script>
 
 <div>
@@ -38,7 +31,9 @@
       }}
     />
   </label>
-  <button onclick={() => navigate(`/profile/${me.$isLoaded ? me.profile.$jazz.id : ""}`)}>
+  <button
+    onclick={() => me.$isLoaded && goto(`/profile/${me.profile.$jazz.id}`)}
+  >
     Your profile name in a Server Component &rarr;
   </button>
 </div>

--- a/homepage/homepage/content/docs/code-snippets/server-side/ssr/+layout-with-navigation.svelte
+++ b/homepage/homepage/content/docs/code-snippets/server-side/ssr/+layout-with-navigation.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+  import { JazzSvelteProvider } from "jazz-tools/svelte";
+  import { beforeNavigate, goto } from "$app/navigation"; // [!code ++]
+  import { apiKey } from "$lib/apiKey";
+  import { SyncConfig } from "jazz-tools";
+
+  let { children } = $props();
+  const sync: SyncConfig = { peer: `wss://cloud.jazz.tools/?key=${apiKey}` };
+</script>
+
+<JazzSvelteProvider {sync} enableSSR navigation={{ beforeNavigate, goto }}> <!--[!code ++]-->
+  {@render children?.()}
+</JazzSvelteProvider>

--- a/homepage/homepage/content/docs/server-side/ssr.mdx
+++ b/homepage/homepage/content/docs/server-side/ssr.mdx
@@ -127,6 +127,26 @@ The last step is to link to your server-rendered page from your `Festival` compo
 </TabbedCodeGroupItem>
 </TabbedCodeGroup>
 
+<ContentByFramework framework="svelte">
+## Syncing data before navigation [!framework=svelte]
+
+In some cases, especially on slow networks, and when navigating immediately after updating data, it is possible that updates to data may still be syncing to the sync server before the SSR agent renders the page. This results in old data appearing in the server-rendered page.
+
+To prevent this, you can pass SvelteKit's `beforeNavigate` and `goto` functions to the `JazzSvelteProvider` using the `navigation` prop. This automatically waits for any pending syncs to complete before allowing navigation.
+
+<FileName>src/routes/+layout.svelte</FileName>
+<CodeGroup className="mt-4 [&_span]:[tab-size:2]" preferWrap>
+```svelte +layout-with-navigation.svelte
+```
+</CodeGroup>
+
+<Alert variant="info" className="mt-4" title="Why do I have to do this manually?">
+  Since `$app/navigation` is a SvelteKit virtual module, you need to pass these to the Provider as props.
+
+The `navigation` prop can only be used in SvelteKit apps that use SSR.
+</Alert>
+</ContentByFramework>
+
 ## Start your app
 Let's fire up your app and see if it works!
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -350,7 +350,7 @@ importers:
         version: 1.2.3(@types/react@19.1.0)(react@19.1.0)
       better-auth:
         specifier: ^1.4.7
-        version: 1.4.7(@sveltejs/kit@2.49.5(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.1.0(svelte@5.46.4)(vite@6.3.5(@types/node@20.17.46)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.1)))(svelte@5.46.4)(typescript@5.6.2)(vite@6.3.5(@types/node@20.17.46)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.1)))(better-sqlite3@12.5.0)(next@15.5.8(@opentelemetry/api@1.9.0)(@playwright/test@1.50.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(solid-js@1.9.5)(svelte@5.46.4)(vitest@4.0.16)(vue@3.5.13(typescript@5.6.2))
+        version: 1.4.7(@sveltejs/kit@2.49.5(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.1.0(svelte@5.46.4)(vite@6.3.5(@types/node@20.17.46)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.1)))(svelte@5.46.4)(typescript@5.6.2)(vite@6.3.5(@types/node@20.17.46)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.1)))(better-sqlite3@12.5.0)(next@15.5.8(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.50.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(solid-js@1.9.5)(svelte@5.46.4)(vitest@4.0.16)(vue@3.5.13(typescript@5.6.2))
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -408,7 +408,7 @@ importers:
         version: link:../../packages/jazz-run
       react-email:
         specifier: ^4.0.11
-        version: 4.0.13(@opentelemetry/api@1.9.0)(@playwright/test@1.50.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 4.0.13(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.50.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       tailwindcss:
         specifier: ^4
         version: 4.1.10
@@ -420,7 +420,7 @@ importers:
     dependencies:
       better-auth:
         specifier: ^1.4.7
-        version: 1.4.7(@sveltejs/kit@2.49.5(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.1.0(svelte@5.46.4)(vite@6.3.5(@types/node@24.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.1)))(svelte@5.46.4)(typescript@5.9.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.1)))(better-sqlite3@12.5.0)(next@15.5.8(@opentelemetry/api@1.9.0)(@playwright/test@1.50.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(solid-js@1.9.5)(svelte@5.46.4)(vitest@4.0.16)(vue@3.5.13(typescript@5.9.2))
+        version: 1.4.7(@sveltejs/kit@2.49.5(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.1.0(svelte@5.46.4)(vite@6.3.5(@types/node@24.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.1)))(svelte@5.46.4)(typescript@5.9.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.1)))(better-sqlite3@12.5.0)(next@15.5.8(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.50.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(solid-js@1.9.5)(svelte@5.46.4)(vitest@4.0.16)(vue@3.5.13(typescript@5.9.2))
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -3286,6 +3286,9 @@ importers:
       globals:
         specifier: ^15.11.0
         version: 15.15.0
+      jazz-run:
+        specifier: workspace:*
+        version: link:../../packages/jazz-run
       jsdom:
         specifier: ^25.0.1
         version: 25.0.1
@@ -19571,9 +19574,9 @@ snapshots:
       eslint-visitor-keys: 2.1.0
       semver: 6.3.1
 
-  '@babel/eslint-parser@7.27.0(@babel/core@7.28.3)(eslint@9.39.1(jiti@2.6.1))':
+  '@babel/eslint-parser@7.27.0(@babel/core@7.28.5)(eslint@9.39.1(jiti@2.6.1))':
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.28.5
       '@nicolo-ribaudo/eslint-scope-5-internals': 5.1.1-v1
       eslint: 9.39.1(jiti@2.6.1)
       eslint-visitor-keys: 2.1.0
@@ -22408,7 +22411,7 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@better-auth/core@1.4.7(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.5(zod@4.1.13))(jose@6.1.0)(kysely@0.28.5)(nanostores@1.0.1)':
+  '@better-auth/core@1.4.7(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.5(zod@4.1.11))(jose@6.1.0)(kysely@0.28.5)(nanostores@1.0.1)':
     dependencies:
       '@better-auth/utils': 0.3.0
       '@better-fetch/fetch': 1.1.21
@@ -22419,9 +22422,9 @@ snapshots:
       nanostores: 1.0.1
       zod: 4.3.5
 
-  '@better-auth/telemetry@1.4.7(@better-auth/core@1.4.7(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.5(zod@4.1.13))(jose@6.1.0)(kysely@0.28.5)(nanostores@1.0.1))':
+  '@better-auth/telemetry@1.4.7(@better-auth/core@1.4.7(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.5(zod@4.1.11))(jose@6.1.0)(kysely@0.28.5)(nanostores@1.0.1))':
     dependencies:
-      '@better-auth/core': 1.4.7(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.5(zod@4.1.13))(jose@6.1.0)(kysely@0.28.5)(nanostores@1.0.1)
+      '@better-auth/core': 1.4.7(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.5(zod@4.1.11))(jose@6.1.0)(kysely@0.28.5)(nanostores@1.0.1)
       '@better-auth/utils': 0.3.0
       '@better-fetch/fetch': 1.1.21
 
@@ -27702,7 +27705,7 @@ snapshots:
   '@react-native/eslint-config@0.81.5(eslint@9.39.1(jiti@2.6.1))(jest@29.7.0(@types/node@24.3.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.11.29(@swc/helpers@0.5.17))(@types/node@24.3.0)(typescript@5.9.2)))(prettier@3.6.2)(typescript@5.9.2)':
     dependencies:
       '@babel/core': 7.28.3
-      '@babel/eslint-parser': 7.27.0(@babel/core@7.28.3)(eslint@9.39.1(jiti@2.6.1))
+      '@babel/eslint-parser': 7.27.0(@babel/core@7.28.5)(eslint@9.39.1(jiti@2.6.1))
       '@react-native/eslint-plugin': 0.81.5
       '@typescript-eslint/eslint-plugin': 7.18.0(@typescript-eslint/parser@7.18.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.2))(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.2)
       '@typescript-eslint/parser': 7.18.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.2)
@@ -27797,7 +27800,9 @@ snapshots:
       metro-runtime: 0.83.2
     transitivePeerDependencies:
       - '@babel/core'
+      - bufferutil
       - supports-color
+      - utf-8-validate
 
   '@react-native/metro-config@0.83.0(@babel/core@7.27.1)':
     dependencies:
@@ -30243,7 +30248,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vitest: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@24.3.0)(@vitest/browser-playwright@4.0.16)(@vitest/ui@4.0.16)(happy-dom@20.0.7)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.30.2)(msw@2.10.4(@types/node@24.3.0)(typescript@5.9.2))(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.1)
+      vitest: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@24.3.0)(@vitest/browser-playwright@4.0.16)(@vitest/ui@4.0.16)(happy-dom@20.0.7)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.30.2)(msw@2.10.4(@types/node@24.3.0)(typescript@5.6.2))(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.1)
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -31325,8 +31330,8 @@ snapshots:
 
   better-auth@1.4.7(@sveltejs/kit@2.49.5(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.1.0(svelte@5.38.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.1)))(svelte@5.38.2)(typescript@5.6.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.1)))(better-sqlite3@12.5.0)(next@15.5.8(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.50.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(solid-js@1.9.5)(svelte@5.38.2)(vitest@4.0.16)(vue@3.5.13(typescript@5.6.2)):
     dependencies:
-      '@better-auth/core': 1.4.7(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.5(zod@4.1.13))(jose@6.1.0)(kysely@0.28.5)(nanostores@1.0.1)
-      '@better-auth/telemetry': 1.4.7(@better-auth/core@1.4.7(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.5(zod@4.1.13))(jose@6.1.0)(kysely@0.28.5)(nanostores@1.0.1))
+      '@better-auth/core': 1.4.7(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.5(zod@4.1.11))(jose@6.1.0)(kysely@0.28.5)(nanostores@1.0.1)
+      '@better-auth/telemetry': 1.4.7(@better-auth/core@1.4.7(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.5(zod@4.1.11))(jose@6.1.0)(kysely@0.28.5)(nanostores@1.0.1))
       '@better-auth/utils': 0.3.0
       '@better-fetch/fetch': 1.1.21
       '@noble/ciphers': 2.0.1
@@ -31348,10 +31353,10 @@ snapshots:
       vitest: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@24.3.0)(@vitest/browser-playwright@4.0.16)(@vitest/ui@4.0.16)(happy-dom@20.0.7)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.30.2)(msw@2.10.3(@types/node@24.3.0)(typescript@5.6.2))(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.1)
       vue: 3.5.13(typescript@5.6.2)
 
-  better-auth@1.4.7(@sveltejs/kit@2.49.5(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.1.0(svelte@5.46.4)(vite@6.3.5(@types/node@20.17.46)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.1)))(svelte@5.46.4)(typescript@5.6.2)(vite@6.3.5(@types/node@20.17.46)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.1)))(better-sqlite3@12.5.0)(next@15.5.8(@opentelemetry/api@1.9.0)(@playwright/test@1.50.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(solid-js@1.9.5)(svelte@5.46.4)(vitest@4.0.16)(vue@3.5.13(typescript@5.6.2)):
+  better-auth@1.4.7(@sveltejs/kit@2.49.5(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.1.0(svelte@5.46.4)(vite@6.3.5(@types/node@20.17.46)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.1)))(svelte@5.46.4)(typescript@5.6.2)(vite@6.3.5(@types/node@20.17.46)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.1)))(better-sqlite3@12.5.0)(next@15.5.8(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.50.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(solid-js@1.9.5)(svelte@5.46.4)(vitest@4.0.16)(vue@3.5.13(typescript@5.6.2)):
     dependencies:
-      '@better-auth/core': 1.4.7(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.5(zod@4.1.13))(jose@6.1.0)(kysely@0.28.5)(nanostores@1.0.1)
-      '@better-auth/telemetry': 1.4.7(@better-auth/core@1.4.7(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.5(zod@4.1.13))(jose@6.1.0)(kysely@0.28.5)(nanostores@1.0.1))
+      '@better-auth/core': 1.4.7(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.5(zod@4.1.11))(jose@6.1.0)(kysely@0.28.5)(nanostores@1.0.1)
+      '@better-auth/telemetry': 1.4.7(@better-auth/core@1.4.7(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.5(zod@4.1.11))(jose@6.1.0)(kysely@0.28.5)(nanostores@1.0.1))
       '@better-auth/utils': 0.3.0
       '@better-fetch/fetch': 1.1.21
       '@noble/ciphers': 2.0.1
@@ -31373,10 +31378,10 @@ snapshots:
       vitest: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@20.17.46)(@vitest/browser-playwright@4.0.16)(@vitest/ui@4.0.16)(happy-dom@20.0.7)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.30.2)(msw@2.10.4(@types/node@20.17.46)(typescript@5.6.2))(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.1)
       vue: 3.5.13(typescript@5.6.2)
 
-  better-auth@1.4.7(@sveltejs/kit@2.49.5(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.1.0(svelte@5.46.4)(vite@6.3.5(@types/node@24.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.1)))(svelte@5.46.4)(typescript@5.9.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.1)))(better-sqlite3@12.5.0)(next@15.5.8(@opentelemetry/api@1.9.0)(@playwright/test@1.50.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(solid-js@1.9.5)(svelte@5.46.4)(vitest@4.0.16)(vue@3.5.13(typescript@5.9.2)):
+  better-auth@1.4.7(@sveltejs/kit@2.49.5(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.1.0(svelte@5.46.4)(vite@6.3.5(@types/node@24.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.1)))(svelte@5.46.4)(typescript@5.9.2)(vite@6.3.5(@types/node@24.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.1)))(better-sqlite3@12.5.0)(next@15.5.8(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.50.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(solid-js@1.9.5)(svelte@5.46.4)(vitest@4.0.16)(vue@3.5.13(typescript@5.9.2)):
     dependencies:
-      '@better-auth/core': 1.4.7(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.5(zod@4.1.13))(jose@6.1.0)(kysely@0.28.5)(nanostores@1.0.1)
-      '@better-auth/telemetry': 1.4.7(@better-auth/core@1.4.7(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.5(zod@4.1.13))(jose@6.1.0)(kysely@0.28.5)(nanostores@1.0.1))
+      '@better-auth/core': 1.4.7(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.5(zod@4.1.11))(jose@6.1.0)(kysely@0.28.5)(nanostores@1.0.1)
+      '@better-auth/telemetry': 1.4.7(@better-auth/core@1.4.7(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.5(zod@4.1.11))(jose@6.1.0)(kysely@0.28.5)(nanostores@1.0.1))
       '@better-auth/utils': 0.3.0
       '@better-fetch/fetch': 1.1.21
       '@noble/ciphers': 2.0.1
@@ -32875,7 +32880,7 @@ snapshots:
 
   eslint-plugin-ft-flow@2.0.3(@babel/eslint-parser@7.27.0(@babel/core@7.28.3)(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
-      '@babel/eslint-parser': 7.27.0(@babel/core@7.28.3)(eslint@9.39.1(jiti@2.6.1))
+      '@babel/eslint-parser': 7.27.0(@babel/core@7.28.5)(eslint@9.39.1(jiti@2.6.1))
       eslint: 9.39.1(jiti@2.6.1)
       lodash: 4.17.21
       string-natural-compare: 3.0.1
@@ -37171,7 +37176,7 @@ snapshots:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  next@15.5.7(@opentelemetry/api@1.9.0)(@playwright/test@1.50.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+  next@15.5.7(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.50.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
       '@next/env': 15.5.7
       '@swc/helpers': 0.5.15
@@ -38411,7 +38416,7 @@ snapshots:
       react: 19.1.0
       scheduler: 0.26.0
 
-  react-email@4.0.13(@opentelemetry/api@1.9.0)(@playwright/test@1.50.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+  react-email@4.0.13(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.50.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
       '@babel/parser': 7.27.2
       '@babel/traverse': 7.27.1
@@ -38423,7 +38428,7 @@ snapshots:
       glob: 11.0.2
       log-symbols: 7.0.0
       mime-types: 3.0.1
-      next: 15.5.7(@opentelemetry/api@1.9.0)(@playwright/test@1.50.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      next: 15.5.7(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.50.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       normalize-path: 3.0.0
       ora: 8.2.0
       socket.io: 4.8.1

--- a/tests/jazz-svelte/package.json
+++ b/tests/jazz-svelte/package.json
@@ -14,7 +14,8 @@
     "test": "vitest",
     "test:coverage": "vitest --coverage",
     "test:e2e": "playwright test",
-    "test:e2e:ui": "playwright test --ui"
+    "test:e2e:ui": "playwright test --ui",
+    "sync": "jazz-run sync"
   },
   "files": [
     "dist",
@@ -51,6 +52,7 @@
     "typescript": "catalog:default",
     "virtua": "^0.41.5",
     "vite": "^6.3.5",
+    "jazz-run": "workspace:*",
     "zod": "^4.1.11"
   },
   "dependencies": {

--- a/tests/jazz-svelte/playwright.config.ts
+++ b/tests/jazz-svelte/playwright.config.ts
@@ -27,7 +27,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: "http://localhost:5173/",
+    baseURL: "http://localhost:5174/",
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: "on-first-retry",
@@ -45,8 +45,13 @@ export default defineConfig({
   /* Run your local dev server before starting the tests */
   webServer: [
     {
-      command: "pnpm preview --port 5173",
-      url: "http://localhost:5173/",
+      command: "pnpm preview --port 5174",
+      url: "http://localhost:5174/",
+      reuseExistingServer: !isCI,
+    },
+    {
+      command: "pnpm sync --in-memory --port 4250",
+      url: "http://localhost:4250/health",
       reuseExistingServer: !isCI,
     },
   ],

--- a/tests/jazz-svelte/src/lib/jazzSSR.ts
+++ b/tests/jazz-svelte/src/lib/jazzSSR.ts
@@ -1,0 +1,5 @@
+import { createSSRJazzAgent } from "jazz-tools/ssr";
+
+export const jazzSSR = createSSRJazzAgent({
+  peer: "ws://localhost:4250/",
+});

--- a/tests/jazz-svelte/src/routes/+page.svelte
+++ b/tests/jazz-svelte/src/routes/+page.svelte
@@ -2,3 +2,4 @@
 <a href="/media">Media</a>
 <a href="/virtual-list">Virtual List</a>
 <a href="/connection-status">Connection Status</a>
+<a href="/ssr">SSR</a>

--- a/tests/jazz-svelte/src/routes/ssr/+layout.svelte
+++ b/tests/jazz-svelte/src/routes/ssr/+layout.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { JazzSvelteProvider } from "jazz-tools/svelte";
+  import { beforeNavigate, goto } from "$app/navigation";
   import { co } from "jazz-tools";
 
   if (typeof window !== "undefined") {
@@ -17,6 +18,7 @@
 <JazzSvelteProvider
   AccountSchema={TestAccount}
   sync={{ peer: "ws://localhost:4250/" }}
+  navigation={{ beforeNavigate, goto }}
 >
   {@render children()}
 </JazzSvelteProvider>

--- a/tests/jazz-svelte/src/routes/ssr/+layout.svelte
+++ b/tests/jazz-svelte/src/routes/ssr/+layout.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+  import { JazzSvelteProvider } from "jazz-tools/svelte";
+  import { co } from "jazz-tools";
+
+  if (typeof window !== "undefined") {
+    localStorage.clear();
+  }
+
+  const TestAccount = co.account({
+    profile: co.profile(),
+    root: co.map({}),
+  });
+
+  let { children } = $props();
+</script>
+
+<JazzSvelteProvider
+  AccountSchema={TestAccount}
+  sync={{ peer: "ws://localhost:4250/" }}
+>
+  {@render children()}
+</JazzSvelteProvider>

--- a/tests/jazz-svelte/src/routes/ssr/+page.svelte
+++ b/tests/jazz-svelte/src/routes/ssr/+page.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+  import { goto } from "$app/navigation";
+  import { Account } from "jazz-tools";
+  import { AccountCoState } from "jazz-tools/svelte";
+
+  const account = new AccountCoState(Account, {
+    resolve: {
+      profile: true,
+    },
+  });
+  const me = $derived(account.current);
+
+  let synced = $state(false);
+
+  const waitForSync = async () => {
+    if (me.$isLoaded) {
+      await me.profile.$jazz.waitForSync();
+      synced = true;
+    }
+  };
+
+  const navigate = () => {
+    if (me.$isLoaded) {
+      goto(`/ssr/profile/${me.profile.$jazz.id}`);
+    }
+  };
+</script>
+
+{#if me.$isLoaded}
+  <input
+    data-testid="name-input"
+    value={me.profile.name ?? ""}
+    oninput={(e) => me.profile.$jazz.set("name", e.currentTarget.value)}
+  />
+  <button data-testid="wait-for-sync" onclick={waitForSync}>
+    Wait for Sync
+  </button>
+  {#if synced}
+    <p data-testid="sync-status">synced</p>
+  {/if}
+  <button data-testid="navigate" onclick={navigate}>
+    View Profile SSR
+  </button>
+  <p data-testid="profile-id">{me.profile.$jazz.id}</p>
+{/if}

--- a/tests/jazz-svelte/src/routes/ssr/+page.svelte
+++ b/tests/jazz-svelte/src/routes/ssr/+page.svelte
@@ -32,14 +32,6 @@
     value={me.profile.name ?? ""}
     oninput={(e) => me.profile.$jazz.set("name", e.currentTarget.value)}
   />
-  <button data-testid="wait-for-sync" onclick={waitForSync}>
-    Wait for Sync
-  </button>
-  {#if synced}
-    <p data-testid="sync-status">synced</p>
-  {/if}
-  <button data-testid="navigate" onclick={navigate}>
-    View Profile SSR
-  </button>
+  <button data-testid="navigate" onclick={navigate}> View Profile SSR </button>
   <p data-testid="profile-id">{me.profile.$jazz.id}</p>
 {/if}

--- a/tests/jazz-svelte/src/routes/ssr/profile/[profileId]/+page.server.ts
+++ b/tests/jazz-svelte/src/routes/ssr/profile/[profileId]/+page.server.ts
@@ -1,0 +1,17 @@
+import type { PageServerLoad } from "./$types.js";
+
+import { jazzSSR } from "$lib/jazzSSR.js";
+import { co } from "jazz-tools";
+
+export const load: PageServerLoad = async ({ params }) => {
+  const { profileId } = params;
+  const profile = await co.profile().load(profileId, {
+    loadAs: jazzSSR,
+  });
+
+  return {
+    profile: {
+      name: profile.$isLoaded ? profile.name : "No name",
+    },
+  };
+};

--- a/tests/jazz-svelte/src/routes/ssr/profile/[profileId]/+page.svelte
+++ b/tests/jazz-svelte/src/routes/ssr/profile/[profileId]/+page.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+  import type { PageProps } from "./$types.js";
+
+  let { data }: PageProps = $props();
+</script>
+
+<p data-testid="ssr-profile-name">{data.profile.name}</p>
+<a href="/ssr" data-testid="back">&larr; Back</a>

--- a/tests/jazz-svelte/tests/ssr.spec.ts
+++ b/tests/jazz-svelte/tests/ssr.spec.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "@playwright/test";
+
+test("SSR should show the updated profile name after navigation", async ({
+  page,
+}) => {
+  await page.goto("/ssr");
+  const input = page.getByTestId("name-input");
+  await expect(input).toBeVisible({ timeout: 15000 });
+
+  await page.getByTestId("wait-for-sync").click();
+  await expect(page.getByTestId("sync-status")).toBeVisible();
+
+  // Throttle the network to ensure sync message is slow
+  const cdpSession = await page.context().newCDPSession(page);
+  await cdpSession.send("Network.emulateNetworkConditions", {
+    offline: false,
+    downloadThroughput: -1,
+    uploadThroughput: 1024,
+    latency: 500,
+  });
+
+  await input.fill("TestUpdatedName");
+  await page.getByTestId("navigate").click();
+
+  await expect(page.getByTestId("ssr-profile-name")).toHaveText(
+    "TestUpdatedName",
+  );
+});

--- a/tests/jazz-svelte/tests/ssr.spec.ts
+++ b/tests/jazz-svelte/tests/ssr.spec.ts
@@ -6,10 +6,6 @@ test("SSR should show the updated profile name after navigation", async ({
   await page.goto("/ssr");
   const input = page.getByTestId("name-input");
   await expect(input).toBeVisible({ timeout: 15000 });
-
-  await page.getByTestId("wait-for-sync").click();
-  await expect(page.getByTestId("sync-status")).toBeVisible();
-
   // Throttle the network to ensure sync message is slow
   const cdpSession = await page.context().newCDPSession(page);
   await cdpSession.send("Network.emulateNetworkConditions", {
@@ -21,6 +17,10 @@ test("SSR should show the updated profile name after navigation", async ({
 
   await input.fill("TestUpdatedName");
   await page.getByTestId("navigate").click();
+
+  await expect(page.getByTestId("ssr-profile-name")).not.toHaveText(
+    "Anonymous user",
+  );
 
   await expect(page.getByTestId("ssr-profile-name")).toHaveText(
     "TestUpdatedName",

--- a/tests/jazz-svelte/tests/virtual-list.spec.ts
+++ b/tests/jazz-svelte/tests/virtual-list.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "@playwright/test";
 
-test("should show the and update properties", async ({ page }) => {
+test("should show the list and update properties", async ({ page }) => {
   await page.goto("/virtual-list");
 
   await page.getByRole("combobox", { name: "List" }).selectOption("alice");


### PR DESCRIPTION
## Summary

- Add an optional navigation prop to `JazzSvelteProvider` that accepts SvelteKit's `beforeNavigate` and `goto` functions
- When provided, the provider automatically waits for pending CoValue syncs to complete before allowing navigation, preventing stale data on SSR pages
- Add documentation to the SSR guide explaining why and how to use this prop

##  Problem

When a user mutates a CoValue and navigates to an SSR page, the server load function may fetch stale data from the sync server because the client's mutation hasn't finished syncing. Previously, developers had to manually call `waitForSync()` before every `goto()`.

## How it works

The provider hooks into `beforeNavigate` and, if there are unsynced changes, cancels the navigation, waits for sync (up to 3s timeout), then replays the navigation via `goto()`. When everything is already synced, navigation proceeds immediately after the check.

Since `$app/navigation` is a SvelteKit virtual module that can't be imported from the pre-compiled `jazz-tools` package, the user has to pass these manually.