### PR TITLE
Add contextual error hints when CoValue can't load due to sync config

### DIFF
--- a/.changeset/sync-when-error-hint.md
+++ b/.changeset/sync-when-error-hint.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Add contextual hints to the "unable to load" error message when sync is disabled (`when: "never"`) or restricted (`when: "signedUp"`).

--- a/packages/jazz-tools/src/tools/subscribe/SubscriptionScope.ts
+++ b/packages/jazz-tools/src/tools/subscribe/SubscriptionScope.ts
@@ -270,7 +270,7 @@ export class SubscriptionScope<D extends CoValue> {
         const error = new JazzError(this.id, CoValueLoadingState.UNAVAILABLE, [
           {
             code: CoValueLoadingState.UNAVAILABLE,
-            message: `Jazz Unavailable Error: unable to load ${this.id}`,
+            message: `Jazz Unavailable Error: unable to load ${this.id}${this.node.syncWhen === "never" ? '. Sync is disabled (when: "never"), so this CoValue can only be loaded from local storage.' : this.node.syncWhen === "signedUp" ? ". Sync is set to when: \"signedUp\" — if the user hasn't signed up, the CoValue can't be loaded from the server." : ""}`,
             params: {
               id: this.id,
             },

--- a/packages/jazz-tools/src/tools/tests/load.test.ts
+++ b/packages/jazz-tools/src/tools/tests/load.test.ts
@@ -61,6 +61,36 @@ test("return 'unavailable' if id is invalid", async () => {
   );
 });
 
+test("return 'unavailable' with sync hint when syncWhen is 'never'", async () => {
+  const Person = co.map({
+    name: z.string(),
+  });
+
+  const account = Account.getMe();
+  (account.$jazz.localNode as { syncWhen: string }).syncWhen = "never";
+
+  const john = await Person.load("test");
+  expect(john.$jazz.loadingState).toBe(CoValueLoadingState.UNAVAILABLE);
+  expect(lastError?.message).toBe(
+    'Jazz Unavailable Error: unable to load test. Sync is disabled (when: "never"), so this CoValue can only be loaded from local storage.',
+  );
+});
+
+test("return 'unavailable' with sync hint when syncWhen is 'signedUp'", async () => {
+  const Person = co.map({
+    name: z.string(),
+  });
+
+  const account = Account.getMe();
+  (account.$jazz.localNode as { syncWhen: string }).syncWhen = "signedUp";
+
+  const john = await Person.load("test");
+  expect(john.$jazz.loadingState).toBe(CoValueLoadingState.UNAVAILABLE);
+  expect(lastError?.message).toBe(
+    "Jazz Unavailable Error: unable to load test. Sync is set to when: \"signedUp\" — if the user hasn't signed up, the CoValue can't be loaded from the server.",
+  );
+});
+
 test("load a missing optional value (co.optional)", async () => {
   const Dog = co.map({
     name: z.string(),


### PR DESCRIPTION
## Summary
- When `sync.when` is `"never"` or `"signedUp"`, the "unable to load" error message now includes a hint explaining why the CoValue couldn't be loaded, rather than a generic unavailable message.
- Adds two tests verifying the contextual hints for both `syncWhen` values.

## Test plan
- [x] `pnpm -F jazz-tools test` — all 1814 tests pass
- [x] New tests verify the error message includes sync config hints for `syncWhen: "never"` and `syncWhen: "signedUp"`
- [x] Existing tests unaffected (default `syncWhen` produces the same generic message as before)