### PR TITLE
Fail .create() when user has no write access to owner group

### DIFF
--- a/.changeset/fail-create-without-write-access.md
+++ b/.changeset/fail-create-without-write-access.md
@@ -1,0 +1,5 @@
+---
+"cojson": patch
+---
+
+Throw immediately when calling `.create()` on a group where the current user does not have write permissions, instead of silently producing empty data.

--- a/packages/cojson/src/coValues/group.ts
+++ b/packages/cojson/src/coValues/group.ts
@@ -1499,6 +1499,15 @@ export class RawGroup<
     return inviteSecretFromSecretSeed(secretSeed);
   }
 
+  private assertCanWrite(): void {
+    const role = this.myRole();
+    if (role === undefined || role === "reader" || role === "revoked") {
+      throw new Error(
+        `Cannot create content: current user does not have write permissions`,
+      );
+    }
+  }
+
   /**
    * Creates a new `CoMap` within this group, with the specified specialized
    * `CoMap` type `M` and optional static metadata.
@@ -1512,6 +1521,7 @@ export class RawGroup<
     uniqueness: CoValueUniqueness = this.crypto.createdNowUnique(),
     initMeta?: JsonObject,
   ): M {
+    this.assertCanWrite();
     const map = this.core.node
       .createCoValue({
         type: "comap",
@@ -1550,6 +1560,7 @@ export class RawGroup<
     uniqueness: CoValueUniqueness = this.crypto.createdNowUnique(),
     initMeta?: JsonObject,
   ): L {
+    this.assertCanWrite();
     const list = this.core.node
       .createCoValue({
         type: "colist",
@@ -1586,6 +1597,7 @@ export class RawGroup<
     meta?: T["headerMeta"],
     initPrivacy: "trusting" | "private" = "private",
   ): T {
+    this.assertCanWrite();
     const text = this.core.node
       .createCoValue({
         type: "coplaintext",
@@ -1613,6 +1625,7 @@ export class RawGroup<
     uniqueness: CoValueUniqueness = this.crypto.createdNowUnique(),
     initMeta?: JsonObject,
   ): C {
+    this.assertCanWrite();
     const stream = this.core.node
       .createCoValue({
         type: "costream",
@@ -1643,6 +1656,7 @@ export class RawGroup<
     meta: C["headerMeta"] = { type: "binary" },
     uniqueness: CoValueUniqueness = this.crypto.createdNowUnique(),
   ): C {
+    this.assertCanWrite();
     return this.core.node
       .createCoValue({
         type: "costream",

--- a/packages/cojson/src/tests/group.test.ts
+++ b/packages/cojson/src/tests/group.test.ts
@@ -435,6 +435,93 @@ test("Should heal the missing key_for_everyone", async () => {
   );
 });
 
+describe("reader cannot create content", () => {
+  test("createMap throws for reader", async () => {
+    const { node1, node2 } = await createTwoConnectedNodes("server", "server");
+
+    const group = node1.node.createGroup();
+    group.addMember(
+      await loadCoValueOrFail(node1.node, node2.accountID),
+      "reader",
+    );
+
+    await group.core.waitForSync();
+
+    const groupOnNode2 = await loadCoValueOrFail(node2.node, group.id);
+    expect(groupOnNode2.myRole()).toBe("reader");
+    expect(() => groupOnNode2.createMap()).toThrow(
+      "does not have write permissions",
+    );
+  });
+
+  test("createList throws for reader", async () => {
+    const { node1, node2 } = await createTwoConnectedNodes("server", "server");
+
+    const group = node1.node.createGroup();
+    group.addMember(
+      await loadCoValueOrFail(node1.node, node2.accountID),
+      "reader",
+    );
+
+    await group.core.waitForSync();
+
+    const groupOnNode2 = await loadCoValueOrFail(node2.node, group.id);
+    expect(() => groupOnNode2.createList()).toThrow(
+      "does not have write permissions",
+    );
+  });
+
+  test("createStream throws for reader", async () => {
+    const { node1, node2 } = await createTwoConnectedNodes("server", "server");
+
+    const group = node1.node.createGroup();
+    group.addMember(
+      await loadCoValueOrFail(node1.node, node2.accountID),
+      "reader",
+    );
+
+    await group.core.waitForSync();
+
+    const groupOnNode2 = await loadCoValueOrFail(node2.node, group.id);
+    expect(() => groupOnNode2.createStream()).toThrow(
+      "does not have write permissions",
+    );
+  });
+
+  test("createBinaryStream throws for reader", async () => {
+    const { node1, node2 } = await createTwoConnectedNodes("server", "server");
+
+    const group = node1.node.createGroup();
+    group.addMember(
+      await loadCoValueOrFail(node1.node, node2.accountID),
+      "reader",
+    );
+
+    await group.core.waitForSync();
+
+    const groupOnNode2 = await loadCoValueOrFail(node2.node, group.id);
+    expect(() => groupOnNode2.createBinaryStream()).toThrow(
+      "does not have write permissions",
+    );
+  });
+
+  test("writer can still create content", async () => {
+    const { node1, node2 } = await createTwoConnectedNodes("server", "server");
+
+    const group = node1.node.createGroup();
+    group.addMember(
+      await loadCoValueOrFail(node1.node, node2.accountID),
+      "writer",
+    );
+
+    await group.core.waitForSync();
+
+    const groupOnNode2 = await loadCoValueOrFail(node2.node, group.id);
+    const map = groupOnNode2.createMap();
+    expect(map.type).toBe("comap");
+  });
+});
+
 describe("writeOnly", () => {
   test("Admins can invite writeOnly members", async () => {
     const { node1, node2 } = await createTwoConnectedNodes("server", "server");


### PR DESCRIPTION
## Summary

- Throw immediately when calling `.create()` on a group where the current user does not have write permissions (reader, revoked, or no role), instead of silently producing empty data
- Previously, creation would succeed locally but all transactions were marked invalid by `determineValidTransactions()`, resulting in `undefined` values and failed sync

## Test plan

- [x] cojson tests: reader throws for `createMap`, `createList`, `createStream`, `createBinaryStream`; writer still works
- [x] jazz-tools tests: reader throws for `co.map`, `co.list`, `co.feed`; nested inline creation throws; pre-created ref creation throws; writer still works
- [x] Full cojson test suite passes (1312 tests)
- [x] Full jazz-tools test suite passes (1818 tests)