### PR TITLE
fix: reuse Expo & OP-SQLite DB client on multiple providers

### DIFF
--- a/.changeset/stale-kiwis-eat.md
+++ b/.changeset/stale-kiwis-eat.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Reuse Expo & OP-SQLite DB client across Jazz providers

--- a/packages/jazz-tools/src/expo/provider.tsx
+++ b/packages/jazz-tools/src/expo/provider.tsx
@@ -18,7 +18,7 @@ export function JazzExpoProvider<
     | AnyAccountSchema,
 >(props: JazzProviderProps<S>) {
   const storage = useMemo(() => {
-    return props.storage ?? new ExpoSQLiteAdapter();
+    return props.storage ?? ExpoSQLiteAdapter.getInstance();
   }, [props.storage]);
 
   const kvStore = useMemo(() => {

--- a/packages/jazz-tools/src/expo/tests/expo-sqlite-adapter.test.ts
+++ b/packages/jazz-tools/src/expo/tests/expo-sqlite-adapter.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("expo-sqlite", () => ({
+  openDatabaseAsync: vi.fn().mockResolvedValue({
+    execAsync: vi.fn(),
+  }),
+  deleteDatabaseAsync: vi.fn(),
+}));
+
+import { ExpoSQLiteAdapter } from "../storage/expo-sqlite-adapter.js";
+
+describe("ExpoSQLiteAdapter", () => {
+  describe("getInstance", () => {
+    it("returns the same instance for the same database name", async () => {
+      const adapter1 = ExpoSQLiteAdapter.getInstance("test-db");
+      const adapter2 = ExpoSQLiteAdapter.getInstance("test-db");
+
+      expect(adapter1).toBe(adapter2);
+    });
+
+    it("returns different instances for different database names", async () => {
+      const adapter1 = ExpoSQLiteAdapter.getInstance("test-db-a");
+      const adapter2 = ExpoSQLiteAdapter.getInstance("test-db-b");
+
+      expect(adapter1).not.toBe(adapter2);
+    });
+
+    it("initializes the database connection only once", async () => {
+      const adapter1 = ExpoSQLiteAdapter.getInstance("test-db");
+      const adapter2 = ExpoSQLiteAdapter.getInstance("test-db");
+      const promise1 = adapter1.initialize();
+      const promise2 = adapter2.initialize();
+
+      await promise1;
+      await promise2;
+
+      // @ts-expect-error - db is private
+      expect(adapter1.db?.execAsync).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/jazz-tools/src/react-native/provider.tsx
+++ b/packages/jazz-tools/src/react-native/provider.tsx
@@ -19,7 +19,7 @@ export function JazzReactNativeProvider<
 >(props: JazzProviderProps<S>) {
   // Destructure kvStore and pass everything else via rest
   const storage = useMemo(() => {
-    return props.storage ?? new OPSQLiteAdapter();
+    return props.storage ?? OPSQLiteAdapter.getInstance();
   }, [props.storage]);
 
   const kvStore = useMemo(() => {


### PR DESCRIPTION
I've been investigating SQLite locking errors reported by Expo users: https://discord.com/channels/1139617727565271160/1470520774841467008/1471508275093704850.

I managed to repro the issue in our `chat-rn-expo` example by creating two Jazz contexts and performing concurrent writes. The bullet-proof way of solving the issue would be to serialize all SQLite operations (or at least writes), but that would also cause a noticeable performance degradation.

As a workaround, in my tests I managed to also avoid SQLite locking errors by reusing the DB client (and the underlying SQLite connection) in all Jazz contexts. I'm not 100% certain why this works (could be our own internal stores & transaction serialization, or something in the underlying adapters), but since this is something we've wanted to do for a while, we can release this change now and keep an eye out for any new errors that pop up.