### PR TITLE
spec: define Jazz introspection/devtools architecture

### DIFF
--- a/crates/groove-tokio/src/lib.rs
+++ b/crates/groove-tokio/src/lib.rs
@@ -374,6 +374,13 @@ impl<S: Storage + Send + 'static> TokioRuntime<S> {
         Ok(())
     }
 
+    /// Ensure a client exists without modifying session/role.
+    pub fn ensure_client(&self, client_id: ClientId) -> Result<(), RuntimeError> {
+        let mut core = self.core.lock().map_err(|_| RuntimeError::LockError)?;
+        core.ensure_client(client_id);
+        Ok(())
+    }
+
     /// Ensure a client exists with the given session.
     ///
     /// A session is always required — callers must authenticate before
@@ -402,6 +409,17 @@ impl<S: Storage + Send + 'static> TokioRuntime<S> {
         Ok(())
     }
 
+    /// Mark whether the client is in inspector mode.
+    pub fn set_client_inspector_mode(
+        &self,
+        client_id: ClientId,
+        enabled: bool,
+    ) -> Result<(), RuntimeError> {
+        let mut core = self.core.lock().map_err(|_| RuntimeError::LockError)?;
+        core.set_client_inspector_mode(client_id, enabled);
+        Ok(())
+    }
+
     // =========================================================================
     // Schema Access
     // =========================================================================
@@ -410,6 +428,15 @@ impl<S: Storage + Send + 'static> TokioRuntime<S> {
     pub fn current_schema(&self) -> Result<Schema, RuntimeError> {
         let core = self.core.lock().map_err(|_| RuntimeError::LockError)?;
         Ok(core.current_schema().clone())
+    }
+
+    /// List active live queries for introspection.
+    pub fn list_live_queries(
+        &self,
+        include_hidden: bool,
+    ) -> Result<Vec<groove::query_manager::manager::LiveQueryInfo>, RuntimeError> {
+        let core = self.core.lock().map_err(|_| RuntimeError::LockError)?;
+        Ok(core.list_live_queries(include_hidden))
     }
 
     /// Access the underlying storage (for flushing, etc).

--- a/crates/groove/src/query_manager/manager.rs
+++ b/crates/groove/src/query_manager/manager.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::commit::CommitId;
 use crate::metadata::{MetadataKey, ObjectType};
@@ -126,6 +127,114 @@ impl InsertHandle {
     }
 }
 
+/// Current unix timestamp in milliseconds.
+fn current_timestamp_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
+
+/// Origin of a live query subscription.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SubscriptionOrigin {
+    #[default]
+    App,
+    Inspector,
+}
+
+/// Visibility of a live query subscription in introspection views.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SubscriptionVisibility {
+    #[default]
+    Public,
+    Hidden,
+}
+
+/// Metadata attached to a query subscription.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SubscriptionMetadata {
+    pub origin: SubscriptionOrigin,
+    pub visibility: SubscriptionVisibility,
+    /// Creation timestamp (unix ms).
+    pub created_at_ms: u64,
+}
+
+impl SubscriptionMetadata {
+    /// Metadata for normal app-owned subscriptions.
+    pub fn app() -> Self {
+        Self {
+            origin: SubscriptionOrigin::App,
+            visibility: SubscriptionVisibility::Public,
+            created_at_ms: current_timestamp_ms(),
+        }
+    }
+
+    /// Metadata for inspector-owned meta subscriptions.
+    pub fn inspector_hidden() -> Self {
+        Self {
+            origin: SubscriptionOrigin::Inspector,
+            visibility: SubscriptionVisibility::Hidden,
+            created_at_ms: current_timestamp_ms(),
+        }
+    }
+}
+
+/// Options that control subscription behavior.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SubscriptionOptions {
+    /// Metadata used by live-query introspection.
+    pub metadata: SubscriptionMetadata,
+    /// Whether this subscription should be forwarded/replayed to upstream servers.
+    pub propagate_to_servers: bool,
+}
+
+impl Default for SubscriptionOptions {
+    fn default() -> Self {
+        Self {
+            metadata: SubscriptionMetadata::app(),
+            propagate_to_servers: true,
+        }
+    }
+}
+
+impl SubscriptionOptions {
+    /// Options for local-only inspector meta-queries.
+    pub fn inspector_hidden_local() -> Self {
+        Self {
+            metadata: SubscriptionMetadata::inspector_hidden(),
+            propagate_to_servers: false,
+        }
+    }
+}
+
+/// Source of a live query entry in introspection output.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LiveQuerySource {
+    /// Subscription created locally in this QueryManager instance.
+    Local,
+    /// Subscription created by a downstream client and tracked on this server.
+    DownstreamClient,
+}
+
+/// Introspection snapshot entry for an active query.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LiveQueryInfo {
+    /// Local subscription ID for local entries, or downstream query ID for server entries.
+    pub query_id: QueryId,
+    pub source: LiveQuerySource,
+    /// Downstream client ID (only set for server-side client subscriptions).
+    pub client_id: Option<ClientId>,
+    pub table: String,
+    pub branches: Vec<String>,
+    pub has_session: bool,
+    pub settled_once: bool,
+    pub settled_tier: Option<PersistenceTier>,
+    pub origin: SubscriptionOrigin,
+    pub visibility: SubscriptionVisibility,
+    pub created_at_ms: u64,
+}
+
 /// Query subscription info.
 #[derive(Debug)]
 pub(crate) struct QuerySubscription {
@@ -146,6 +255,10 @@ pub(crate) struct QuerySubscription {
     pub(crate) settled_tier: Option<PersistenceTier>,
     /// Tiers that have confirmed settlement for this query.
     pub(crate) achieved_tiers: HashSet<PersistenceTier>,
+    /// Introspection metadata for this subscription.
+    pub(crate) metadata: SubscriptionMetadata,
+    /// Whether this subscription should be forwarded/replayed to upstream servers.
+    pub(crate) propagate_to_servers: bool,
 }
 
 /// Update for a query subscription.
@@ -190,6 +303,8 @@ pub(super) struct ServerQuerySubscription {
     /// Flag indicating this server subscription has settled at least once.
     /// Used to emit QuerySettled to the client on first settlement.
     pub(super) settled_once: bool,
+    /// Introspection metadata for this subscription.
+    pub(super) metadata: SubscriptionMetadata,
 }
 
 /// A catalogue object update received via sync.
@@ -465,6 +580,54 @@ impl QueryManager {
     /// Get the schema.
     pub fn schema(&self) -> &Schema {
         &self.schema
+    }
+
+    /// List currently active live queries.
+    ///
+    /// Inspector-owned meta queries can be hidden by default via `include_hidden=false`.
+    pub fn list_live_queries(&self, include_hidden: bool) -> Vec<LiveQueryInfo> {
+        let mut out = Vec::new();
+
+        for (sub_id, sub) in &self.subscriptions {
+            if !include_hidden && sub.metadata.visibility == SubscriptionVisibility::Hidden {
+                continue;
+            }
+            out.push(LiveQueryInfo {
+                query_id: QueryId(sub_id.0),
+                source: LiveQuerySource::Local,
+                client_id: None,
+                table: sub.query.table.as_str().to_string(),
+                branches: sub.branches.clone(),
+                has_session: sub.session.is_some(),
+                settled_once: sub.settled_once,
+                settled_tier: sub.settled_tier,
+                origin: sub.metadata.origin,
+                visibility: sub.metadata.visibility,
+                created_at_ms: sub.metadata.created_at_ms,
+            });
+        }
+
+        for ((client_id, query_id), sub) in &self.server_subscriptions {
+            if !include_hidden && sub.metadata.visibility == SubscriptionVisibility::Hidden {
+                continue;
+            }
+            out.push(LiveQueryInfo {
+                query_id: *query_id,
+                source: LiveQuerySource::DownstreamClient,
+                client_id: Some(*client_id),
+                table: sub.query.table.as_str().to_string(),
+                branches: sub.branches.clone(),
+                has_session: sub.session.is_some(),
+                settled_once: sub.settled_once,
+                settled_tier: None,
+                origin: sub.metadata.origin,
+                visibility: sub.metadata.visibility,
+                created_at_ms: sub.metadata.created_at_ms,
+            });
+        }
+
+        out.sort_by_key(|entry| entry.created_at_ms);
+        out
     }
 
     /// Get subscription results as decoded rows with ObjectIds (for testing).

--- a/crates/groove/src/query_manager/manager.rs
+++ b/crates/groove/src/query_manager/manager.rs
@@ -2,6 +2,8 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use serde::{Deserialize, Serialize};
+
 use crate::commit::CommitId;
 use crate::metadata::{MetadataKey, ObjectType};
 use crate::object::{BranchName, ObjectId};
@@ -136,7 +138,7 @@ fn current_timestamp_ms() -> u64 {
 }
 
 /// Origin of a live query subscription.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub enum SubscriptionOrigin {
     #[default]
     App,
@@ -144,7 +146,7 @@ pub enum SubscriptionOrigin {
 }
 
 /// Visibility of a live query subscription in introspection views.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub enum SubscriptionVisibility {
     #[default]
     Public,
@@ -152,7 +154,7 @@ pub enum SubscriptionVisibility {
 }
 
 /// Metadata attached to a query subscription.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SubscriptionMetadata {
     pub origin: SubscriptionOrigin,
     pub visibility: SubscriptionVisibility,
@@ -209,7 +211,7 @@ impl SubscriptionOptions {
 }
 
 /// Source of a live query entry in introspection output.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum LiveQuerySource {
     /// Subscription created locally in this QueryManager instance.
     Local,
@@ -218,7 +220,7 @@ pub enum LiveQuerySource {
 }
 
 /// Introspection snapshot entry for an active query.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LiveQueryInfo {
     /// Local subscription ID for local entries, or downstream query ID for server entries.
     pub query_id: QueryId,
@@ -230,6 +232,7 @@ pub struct LiveQueryInfo {
     pub has_session: bool,
     pub settled_once: bool,
     pub settled_tier: Option<PersistenceTier>,
+    pub propagate_to_servers: bool,
     pub origin: SubscriptionOrigin,
     pub visibility: SubscriptionVisibility,
     pub created_at_ms: u64,
@@ -303,6 +306,8 @@ pub(super) struct ServerQuerySubscription {
     /// Flag indicating this server subscription has settled at least once.
     /// Used to emit QuerySettled to the client on first settlement.
     pub(super) settled_once: bool,
+    /// Whether this subscription should be forwarded/replayed to upstream servers.
+    pub(super) propagate_to_servers: bool,
     /// Introspection metadata for this subscription.
     pub(super) metadata: SubscriptionMetadata,
 }
@@ -601,6 +606,7 @@ impl QueryManager {
                 has_session: sub.session.is_some(),
                 settled_once: sub.settled_once,
                 settled_tier: sub.settled_tier,
+                propagate_to_servers: sub.propagate_to_servers,
                 origin: sub.metadata.origin,
                 visibility: sub.metadata.visibility,
                 created_at_ms: sub.metadata.created_at_ms,
@@ -620,6 +626,7 @@ impl QueryManager {
                 has_session: sub.session.is_some(),
                 settled_once: sub.settled_once,
                 settled_tier: None,
+                propagate_to_servers: sub.propagate_to_servers,
                 origin: sub.metadata.origin,
                 visibility: sub.metadata.visibility,
                 created_at_ms: sub.metadata.created_at_ms,

--- a/crates/groove/src/query_manager/manager_tests.rs
+++ b/crates/groove/src/query_manager/manager_tests.rs
@@ -5324,6 +5324,102 @@ fn mid_tier_forwards_query_unsubscription_upstream() {
     );
 }
 
+/// Inspector-mode client subscriptions stay local and hidden.
+#[test]
+fn mid_tier_inspector_subscriptions_do_not_propagate_upstream() {
+    use crate::sync_manager::{
+        ClientId, ClientRole, Destination, InboxEntry, QueryId, ServerId, Source, SyncPayload,
+    };
+    use uuid::Uuid;
+
+    // Setup mid-tier server
+    let sync_manager = SyncManager::new();
+    let schema = test_schema();
+    let (mut mid_tier, mut storage) = create_query_manager(sync_manager, schema);
+
+    // Add upstream server and inspector client
+    let upstream_id = ServerId(Uuid::new_v7(uuid::Timestamp::now(uuid::NoContext)));
+    let client_id = ClientId(Uuid::new_v7(uuid::Timestamp::now(uuid::NoContext)));
+    mid_tier.sync_manager_mut().add_server(upstream_id);
+    mid_tier.sync_manager_mut().add_client(client_id);
+    mid_tier
+        .sync_manager_mut()
+        .set_client_role(client_id, ClientRole::Admin);
+    mid_tier
+        .sync_manager_mut()
+        .set_client_inspector_mode(client_id, true);
+
+    // Clear outbox (add_server queues full sync)
+    let _ = mid_tier.sync_manager_mut().take_outbox();
+
+    let query = mid_tier
+        .query("users")
+        .filter_gt("score", Value::Integer(50))
+        .build();
+    let query_id = QueryId(77);
+
+    mid_tier.sync_manager_mut().push_inbox(InboxEntry {
+        source: Source::Client(client_id),
+        payload: SyncPayload::QuerySubscription {
+            query_id,
+            query,
+            session: None,
+        },
+    });
+    mid_tier.process(&mut storage);
+
+    // Inspector subscription should not be forwarded upstream.
+    let outbox_after_subscribe = mid_tier.sync_manager_mut().take_outbox();
+    let forwarded_subs: Vec<_> = outbox_after_subscribe
+        .iter()
+        .filter(|e| matches!(e.destination, Destination::Server(id) if id == upstream_id))
+        .filter(|e| matches!(e.payload, SyncPayload::QuerySubscription { .. }))
+        .collect();
+    assert!(
+        forwarded_subs.is_empty(),
+        "Inspector subscriptions should remain local and not be forwarded"
+    );
+
+    // Hidden by default in live-query introspection.
+    let visible_live = mid_tier.list_live_queries(false);
+    assert!(
+        visible_live
+            .iter()
+            .all(|q| !(q.query_id == query_id && q.source == LiveQuerySource::DownstreamClient)),
+        "Inspector subscriptions should be hidden by default"
+    );
+
+    let all_live = mid_tier.list_live_queries(true);
+    let inspector_live = all_live
+        .iter()
+        .find(|q| q.query_id == query_id && q.source == LiveQuerySource::DownstreamClient)
+        .expect("Inspector subscription should appear when include_hidden=true");
+    assert_eq!(inspector_live.origin, SubscriptionOrigin::Inspector);
+    assert_eq!(inspector_live.visibility, SubscriptionVisibility::Hidden);
+    assert!(
+        !inspector_live.propagate_to_servers,
+        "Inspector subscription should be marked non-propagating"
+    );
+
+    // Unsubscription should also stay local.
+    mid_tier.sync_manager_mut().push_inbox(InboxEntry {
+        source: Source::Client(client_id),
+        payload: SyncPayload::QueryUnsubscription { query_id },
+    });
+    mid_tier.process(&mut storage);
+
+    let outbox_after_unsubscribe = mid_tier.sync_manager_mut().take_outbox();
+    let forwarded_unsubs: Vec<_> = outbox_after_unsubscribe
+        .iter()
+        .filter(|e| matches!(e.destination, Destination::Server(id) if id == upstream_id))
+        .filter(|e| matches!(e.payload, SyncPayload::QueryUnsubscription { .. }))
+        .collect();
+    assert!(
+        forwarded_unsubs.is_empty(),
+        "Inspector unsubscriptions should remain local and not be forwarded"
+    );
+}
+
 /// Test that objects from upstream are relayed to downstream clients with matching scope.
 #[test]
 fn mid_tier_relays_objects_to_clients_with_matching_scope() {
@@ -5978,13 +6074,14 @@ fn inspector_local_only_subscription_is_not_forwarded_or_replayed() {
     let _ = qm.sync_manager_mut().take_outbox();
 
     let query = qm.query("users").build();
-    qm.subscribe_with_sync_options(
-        query,
-        None,
-        None,
-        SubscriptionOptions::inspector_hidden_local(),
-    )
-    .unwrap();
+    let sub_id = qm
+        .subscribe_with_sync_options(
+            query,
+            None,
+            None,
+            SubscriptionOptions::inspector_hidden_local(),
+        )
+        .unwrap();
 
     let outbox_after_subscribe = qm.sync_manager_mut().take_outbox();
     assert!(
@@ -6002,5 +6099,14 @@ fn inspector_local_only_subscription_is_not_forwarded_or_replayed() {
             .iter()
             .all(|e| !matches!(e.payload, SyncPayload::QuerySubscription { .. })),
         "Inspector local-only subscriptions should not be replayed upstream"
+    );
+
+    qm.unsubscribe_with_sync(sub_id);
+    let outbox_after_unsubscribe = qm.sync_manager_mut().take_outbox();
+    assert!(
+        outbox_after_unsubscribe
+            .iter()
+            .all(|e| !matches!(e.payload, SyncPayload::QueryUnsubscription { .. })),
+        "Inspector local-only subscriptions should not send upstream unsubscriptions"
     );
 }

--- a/crates/groove/src/query_manager/manager_tests.rs
+++ b/crates/groove/src/query_manager/manager_tests.rs
@@ -10,8 +10,9 @@ use crate::storage::MemoryStorage;
 use crate::sync_manager::SyncManager;
 
 use super::{
-    ColumnDescriptor, ColumnType, PolicyExpr, QueryError, QueryManager, RowDescriptor, Schema,
-    Session as PolicySession, TableName, TablePolicies, TableSchema, Value, decode_row,
+    ColumnDescriptor, ColumnType, LiveQuerySource, PolicyExpr, QueryError, QueryManager,
+    RowDescriptor, Schema, Session as PolicySession, SubscriptionOptions, SubscriptionOrigin,
+    SubscriptionVisibility, TableName, TablePolicies, TableSchema, Value, decode_row,
 };
 
 fn test_schema() -> Schema {
@@ -5915,4 +5916,91 @@ fn e2e_permissions_prevent_new_row_sync() {
     let results = client.get_subscription_results(sub_id);
     assert_eq!(results.len(), 1, "Client should NOT receive Bob's doc");
     assert_eq!(results[0].1[0], Value::Text("Alice's doc".into()));
+}
+
+#[test]
+fn live_queries_include_app_queries_by_default() {
+    let sync_manager = SyncManager::new();
+    let schema = test_schema();
+    let (mut qm, _storage) = create_query_manager(sync_manager, schema);
+
+    let sub_id = qm.query("users").build();
+    let sub_id = qm.subscribe(sub_id).unwrap();
+
+    let live = qm.list_live_queries(false);
+    assert_eq!(live.len(), 1);
+    assert_eq!(live[0].query_id.0, sub_id.0);
+    assert_eq!(live[0].source, LiveQuerySource::Local);
+    assert_eq!(live[0].origin, SubscriptionOrigin::App);
+    assert_eq!(live[0].visibility, SubscriptionVisibility::Public);
+}
+
+#[test]
+fn live_queries_hide_inspector_owned_subscriptions_by_default() {
+    let sync_manager = SyncManager::new();
+    let schema = test_schema();
+    let (mut qm, _storage) = create_query_manager(sync_manager, schema);
+
+    let query = qm.query("users").build();
+    let sub_id = qm
+        .subscribe_with_session_options(
+            query,
+            None,
+            None,
+            SubscriptionOptions::inspector_hidden_local(),
+        )
+        .unwrap();
+
+    let visible = qm.list_live_queries(false);
+    assert!(
+        visible.is_empty(),
+        "Hidden inspector subscription should not appear by default"
+    );
+
+    let all = qm.list_live_queries(true);
+    assert_eq!(all.len(), 1);
+    assert_eq!(all[0].query_id.0, sub_id.0);
+    assert_eq!(all[0].source, LiveQuerySource::Local);
+    assert_eq!(all[0].origin, SubscriptionOrigin::Inspector);
+    assert_eq!(all[0].visibility, SubscriptionVisibility::Hidden);
+}
+
+#[test]
+fn inspector_local_only_subscription_is_not_forwarded_or_replayed() {
+    use crate::sync_manager::{ServerId, SyncPayload};
+
+    let sync_manager = SyncManager::new();
+    let schema = test_schema();
+    let (mut qm, _storage) = create_query_manager(sync_manager, schema);
+
+    // Attach an upstream server and clear initial full-sync outbox noise.
+    qm.add_server(ServerId::new());
+    let _ = qm.sync_manager_mut().take_outbox();
+
+    let query = qm.query("users").build();
+    qm.subscribe_with_sync_options(
+        query,
+        None,
+        None,
+        SubscriptionOptions::inspector_hidden_local(),
+    )
+    .unwrap();
+
+    let outbox_after_subscribe = qm.sync_manager_mut().take_outbox();
+    assert!(
+        outbox_after_subscribe
+            .iter()
+            .all(|e| !matches!(e.payload, SyncPayload::QuerySubscription { .. })),
+        "Inspector local-only subscriptions should not forward upstream"
+    );
+
+    // Add another upstream server; replay should still skip local-only subscriptions.
+    qm.add_server(ServerId::new());
+    let outbox_after_replay = qm.sync_manager_mut().take_outbox();
+    assert!(
+        outbox_after_replay
+            .iter()
+            .all(|e| !matches!(e.payload, SyncPayload::QuerySubscription { .. })),
+        "Inspector local-only subscriptions should not be replayed upstream"
+    );
 }

--- a/crates/groove/src/query_manager/server_queries.rs
+++ b/crates/groove/src/query_manager/server_queries.rs
@@ -28,6 +28,13 @@ impl QueryManager {
         let mut deferred = Vec::new();
 
         for sub in pending {
+            let metadata = if sub.inspector_mode {
+                SubscriptionMetadata::inspector_hidden()
+            } else {
+                SubscriptionMetadata::app()
+            };
+            let propagate_to_servers = !sub.inspector_mode;
+
             // Resolve schema: use self.schema if available, otherwise look up from known_schemas (server mode)
             let schema_for_compile: Arc<Schema> = if !self.schema.is_empty() {
                 self.schema.clone()
@@ -131,11 +138,13 @@ impl QueryManager {
 
             // Forward QuerySubscription to upstream servers (multi-tier forwarding)
             // This allows hub servers to know about the query and push matching data
-            self.sync_manager.send_query_subscription_to_servers(
-                sub.query_id,
-                sub.query.clone(),
-                sub.session.clone(),
-            );
+            if propagate_to_servers {
+                self.sync_manager.send_query_subscription_to_servers(
+                    sub.query_id,
+                    sub.query.clone(),
+                    sub.session.clone(),
+                );
+            }
 
             // Store the server subscription for reactive updates
             self.server_subscriptions.insert(
@@ -148,7 +157,8 @@ impl QueryManager {
                     last_scope: scope,
                     needs_recompile: false,
                     settled_once: false,
-                    metadata: SubscriptionMetadata::app(),
+                    propagate_to_servers,
+                    metadata,
                 },
             );
         }
@@ -170,12 +180,19 @@ impl QueryManager {
 
         for unsub in pending {
             // Remove the server subscription
-            self.server_subscriptions
+            let removed = self
+                .server_subscriptions
                 .remove(&(unsub.client_id, unsub.query_id));
 
             // Forward unsubscription to upstream servers
-            self.sync_manager
-                .send_query_unsubscription_to_servers(unsub.query_id);
+            if removed
+                .as_ref()
+                .map(|sub| sub.propagate_to_servers)
+                .unwrap_or(true)
+            {
+                self.sync_manager
+                    .send_query_unsubscription_to_servers(unsub.query_id);
+            }
         }
     }
 

--- a/crates/groove/src/query_manager/server_queries.rs
+++ b/crates/groove/src/query_manager/server_queries.rs
@@ -8,7 +8,9 @@ use crate::storage::Storage;
 use crate::sync_manager::{ClientId, PendingPermissionCheck, QueryId};
 
 use super::graph::QueryGraph;
-use super::manager::{PolicyCheckState, QueryManager, ServerQuerySubscription};
+use super::manager::{
+    PolicyCheckState, QueryManager, ServerQuerySubscription, SubscriptionMetadata,
+};
 use super::policy::{ComplexClause, Operation, evaluate_simple_parts};
 use super::policy_graph::PolicyGraph;
 use super::session::Session;
@@ -146,6 +148,7 @@ impl QueryManager {
                     last_scope: scope,
                     needs_recompile: false,
                     settled_once: false,
+                    metadata: SubscriptionMetadata::app(),
                 },
             );
         }

--- a/crates/groove/src/query_manager/subscriptions.rs
+++ b/crates/groove/src/query_manager/subscriptions.rs
@@ -264,12 +264,19 @@ impl QueryManager {
     /// 1. Removes the local subscription
     /// 2. Sends a QueryUnsubscription to all connected servers
     pub fn unsubscribe_with_sync(&mut self, id: QuerySubscriptionId) {
+        let should_propagate = self
+            .subscriptions
+            .get(&id)
+            .map(|sub| sub.propagate_to_servers)
+            .unwrap_or(true);
         self.subscriptions.remove(&id);
 
-        // Send QueryUnsubscription to all servers
-        let query_id = QueryId(id.0);
-        self.sync_manager
-            .send_query_unsubscription_to_servers(query_id);
+        if should_propagate {
+            // Send QueryUnsubscription to all servers
+            let query_id = QueryId(id.0);
+            self.sync_manager
+                .send_query_unsubscription_to_servers(query_id);
+        }
     }
 
     /// Build the sync payload query for upstream forwarding.
@@ -308,6 +315,7 @@ impl QueryManager {
         let downstream_subs: Vec<(QueryId, Query, Option<Session>)> = self
             .server_subscriptions
             .iter()
+            .filter(|(_, sub)| sub.propagate_to_servers)
             .map(|((_, query_id), sub)| (*query_id, sub.query.clone(), sub.session.clone()))
             .collect();
 

--- a/crates/groove/src/query_manager/subscriptions.rs
+++ b/crates/groove/src/query_manager/subscriptions.rs
@@ -8,7 +8,9 @@ use crate::sync_manager::{PersistenceTier, QueryId, ServerId};
 use super::encoding::decode_row;
 use super::graph::QueryGraph;
 use super::graph_nodes::output::QuerySubscriptionId;
-use super::manager::{CatalogueUpdate, QueryError, QueryManager, QuerySubscription, QueryUpdate};
+use super::manager::{
+    CatalogueUpdate, QueryError, QueryManager, QuerySubscription, QueryUpdate, SubscriptionOptions,
+};
 use super::query::{Query, QueryBuilder};
 use super::session::Session;
 #[cfg(test)]
@@ -44,6 +46,22 @@ impl QueryManager {
         query: Query,
         session: Option<Session>,
         settled_tier: Option<PersistenceTier>,
+    ) -> Result<QuerySubscriptionId, QueryError> {
+        self.subscribe_with_session_options(
+            query,
+            session,
+            settled_tier,
+            SubscriptionOptions::default(),
+        )
+    }
+
+    /// Subscribe to query results with explicit execution options.
+    pub fn subscribe_with_session_options(
+        &mut self,
+        query: Query,
+        session: Option<Session>,
+        settled_tier: Option<PersistenceTier>,
+        options: SubscriptionOptions,
     ) -> Result<QuerySubscriptionId, QueryError> {
         let _span =
             tracing::debug_span!("QM::subscribe", table = %query.table, ?settled_tier).entered();
@@ -86,6 +104,8 @@ impl QueryManager {
                 settled_once: false,
                 settled_tier,
                 achieved_tiers: HashSet::new(),
+                metadata: options.metadata,
+                propagate_to_servers: options.propagate_to_servers,
             },
         );
 
@@ -110,6 +130,24 @@ impl QueryManager {
         schema: &Schema,
         schema_context: &crate::schema_manager::SchemaContext,
         session: Option<Session>,
+    ) -> Result<QuerySubscriptionId, QueryError> {
+        self.subscribe_with_explicit_context_options(
+            query,
+            schema,
+            schema_context,
+            session,
+            SubscriptionOptions::default(),
+        )
+    }
+
+    /// Subscribe with explicit schema/context and execution options.
+    pub fn subscribe_with_explicit_context_options(
+        &mut self,
+        query: Query,
+        schema: &Schema,
+        schema_context: &crate::schema_manager::SchemaContext,
+        session: Option<Session>,
+        options: SubscriptionOptions,
     ) -> Result<QuerySubscriptionId, QueryError> {
         let table_name = &query.table;
         let _table_schema = schema
@@ -150,6 +188,8 @@ impl QueryManager {
                 settled_once: false,
                 settled_tier: None,
                 achieved_tiers: HashSet::new(),
+                metadata: options.metadata,
+                propagate_to_servers: options.propagate_to_servers,
             },
         );
 
@@ -173,16 +213,38 @@ impl QueryManager {
         session: Option<Session>,
         settled_tier: Option<PersistenceTier>,
     ) -> Result<QuerySubscriptionId, QueryError> {
+        self.subscribe_with_sync_options(
+            query,
+            session,
+            settled_tier,
+            SubscriptionOptions::default(),
+        )
+    }
+
+    /// Subscribe to query results and sync with explicit execution options.
+    pub fn subscribe_with_sync_options(
+        &mut self,
+        query: Query,
+        session: Option<Session>,
+        settled_tier: Option<PersistenceTier>,
+        options: SubscriptionOptions,
+    ) -> Result<QuerySubscriptionId, QueryError> {
         // Create local subscription
-        let sub_id = self.subscribe_with_session(query.clone(), session.clone(), settled_tier)?;
+        let sub_id = self.subscribe_with_session_options(
+            query.clone(),
+            session.clone(),
+            settled_tier,
+            options,
+        )?;
 
-        let sync_query = self.sync_query_payload_for_upstream(&query);
-
-        // Send QuerySubscription to all servers
-        // Use the subscription ID as the query ID for simplicity
-        let query_id = QueryId(sub_id.0);
-        self.sync_manager
-            .send_query_subscription_to_servers(query_id, sync_query, session);
+        if options.propagate_to_servers {
+            let sync_query = self.sync_query_payload_for_upstream(&query);
+            // Send QuerySubscription to all servers
+            // Use the subscription ID as the query ID for simplicity
+            let query_id = QueryId(sub_id.0);
+            self.sync_manager
+                .send_query_subscription_to_servers(query_id, sync_query, session);
+        }
 
         Ok(sub_id)
     }
@@ -228,6 +290,7 @@ impl QueryManager {
         let local_subs: Vec<(QueryId, Query, Option<Session>)> = self
             .subscriptions
             .iter()
+            .filter(|(_, sub)| sub.propagate_to_servers)
             .map(|(sub_id, sub)| {
                 (
                     QueryId(sub_id.0),

--- a/crates/groove/src/runtime_core.rs
+++ b/crates/groove/src/runtime_core.rs
@@ -871,6 +871,15 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
         self.immediate_tick();
     }
 
+    /// Ensure a client exists without modifying session or role.
+    pub fn ensure_client(&mut self, client_id: ClientId) {
+        let sm = self.schema_manager.query_manager_mut().sync_manager_mut();
+        if sm.get_client(client_id).is_none() {
+            sm.add_client(client_id);
+            self.immediate_tick();
+        }
+    }
+
     /// Ensure a client exists with the given session.
     ///
     /// If the client already exists, updates the session. This is idempotent —
@@ -907,6 +916,14 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
             .set_client_role(client_id, ClientRole::Admin);
     }
 
+    /// Mark whether the client is in inspector mode.
+    pub fn set_client_inspector_mode(&mut self, client_id: ClientId, enabled: bool) {
+        self.schema_manager
+            .query_manager_mut()
+            .sync_manager_mut()
+            .set_client_inspector_mode(client_id, enabled);
+    }
+
     /// Set a client's role.
     pub fn set_client_role_by_name(
         &mut self,
@@ -926,6 +943,16 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
     /// Get the current schema.
     pub fn current_schema(&self) -> &Schema {
         self.schema_manager.current_schema()
+    }
+
+    /// List active live queries for introspection.
+    pub fn list_live_queries(
+        &self,
+        include_hidden: bool,
+    ) -> Vec<crate::query_manager::manager::LiveQueryInfo> {
+        self.schema_manager
+            .query_manager()
+            .list_live_queries(include_hidden)
     }
 
     /// Get mutable access to the underlying SchemaManager.

--- a/crates/groove/src/sync_manager/inbox.rs
+++ b/crates/groove/src/sync_manager/inbox.rs
@@ -290,6 +290,7 @@ impl SyncManager {
                         query_id: *query_id,
                         query: query.clone(),
                         session: session.clone(),
+                        inspector_mode: client.inspector_mode,
                     });
             }
             // Handle query unsubscription

--- a/crates/groove/src/sync_manager/mod.rs
+++ b/crates/groove/src/sync_manager/mod.rs
@@ -142,7 +142,7 @@ impl SyncManager {
 
     /// Add a client connection.
     pub fn add_client(&mut self, client_id: ClientId) {
-        self.clients.insert(client_id, ClientState::default());
+        self.clients.entry(client_id).or_default();
     }
 
     /// Remove a client connection.
@@ -181,6 +181,13 @@ impl SyncManager {
     pub fn set_client_role(&mut self, client_id: ClientId, role: ClientRole) {
         if let Some(client) = self.clients.get_mut(&client_id) {
             client.role = role;
+        }
+    }
+
+    /// Mark whether a client is using inspector mode.
+    pub fn set_client_inspector_mode(&mut self, client_id: ClientId, enabled: bool) {
+        if let Some(client) = self.clients.get_mut(&client_id) {
+            client.inspector_mode = enabled;
         }
     }
 

--- a/crates/groove/src/sync_manager/types.rs
+++ b/crates/groove/src/sync_manager/types.rs
@@ -137,6 +137,11 @@ pub struct QueryScope {
 pub struct ClientState {
     /// Client's role for access control.
     pub role: ClientRole,
+    /// True when this client is an inspector connection.
+    ///
+    /// Inspector query subscriptions are hidden by default and should stay
+    /// local to this server unless explicitly requested otherwise.
+    pub inspector_mode: bool,
     /// Client's session for policy evaluation.
     pub session: Option<Session>,
     /// Active queries from this client.
@@ -319,6 +324,8 @@ pub struct PendingQuerySubscription {
     pub query_id: QueryId,
     pub query: Query,
     pub session: Option<Session>,
+    /// Snapshot of whether the originating client was in inspector mode.
+    pub inspector_mode: bool,
 }
 
 /// A pending query unsubscription that needs cleanup.

--- a/crates/jazz-cli/src/routes.rs
+++ b/crates/jazz-cli/src/routes.rs
@@ -28,6 +28,11 @@ pub fn create_router(state: Arc<ServerState>) -> Router {
         .route("/events", get(events_handler))
         // Unified sync endpoint - all client→server communication flows through here
         .route("/sync", post(sync_handler))
+        // Admin-only introspection endpoints
+        .route(
+            "/admin/introspection/live-queries",
+            get(admin_live_queries_handler),
+        )
         // Health check
         .route("/health", get(health_handler))
         // Add middleware
@@ -41,6 +46,21 @@ pub fn create_router(state: Arc<ServerState>) -> Router {
 struct EventsParams {
     /// Client-provided ID for reconnect support.
     client_id: Option<String>,
+}
+
+/// Query parameters for admin live-queries endpoint.
+#[derive(Debug, Deserialize)]
+struct AdminLiveQueriesParams {
+    /// Include hidden inspector-owned subscriptions in results.
+    include_hidden: Option<bool>,
+}
+
+fn has_inspector_header(headers: &HeaderMap) -> bool {
+    headers
+        .get("X-Jazz-Inspector")
+        .and_then(|v| v.to_str().ok())
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
 }
 
 /// Encode a ServerEvent as a length-prefixed binary frame.
@@ -201,6 +221,8 @@ async fn sync_handler(
     use groove::sync_manager::{InboxEntry, Source};
     tracing::info!(client_id = %request.client_id, payload = request.payload.variant_name(), "sync request");
 
+    let inspector_mode = has_inspector_header(&headers);
+
     // Check admin secret — if present and valid, promote client to Admin role
     let is_admin = {
         let admin_secret = headers
@@ -217,10 +239,20 @@ async fn sync_handler(
         }
     };
 
+    if inspector_mode && !is_admin {
+        return (
+            StatusCode::UNAUTHORIZED,
+            Json(ErrorResponse::unauthorized(
+                "X-Jazz-Inspector mode requires a valid X-Jazz-Admin-Secret",
+            )),
+        )
+            .into_response();
+    }
+
     // Admin-authenticated requests (server-to-server catalogue sync) don't need a session.
     // Regular clients must provide JWT or backend secret.
     if is_admin {
-        if let Err(e) = state.runtime.add_client(request.client_id, None) {
+        if let Err(e) = state.runtime.ensure_client(request.client_id) {
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(ErrorResponse::internal(e.to_string())),
@@ -228,6 +260,16 @@ async fn sync_handler(
                 .into_response();
         }
         if let Err(e) = state.runtime.set_client_admin(request.client_id) {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::internal(e.to_string())),
+            )
+                .into_response();
+        }
+        if let Err(e) = state
+            .runtime
+            .set_client_inspector_mode(request.client_id, inspector_mode)
+        {
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(ErrorResponse::internal(e.to_string())),
@@ -267,6 +309,16 @@ async fn sync_handler(
             )
                 .into_response();
         }
+        if let Err(e) = state
+            .runtime
+            .set_client_inspector_mode(request.client_id, false)
+        {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::internal(e.to_string())),
+            )
+                .into_response();
+        }
     }
 
     let entry = InboxEntry {
@@ -276,6 +328,46 @@ async fn sync_handler(
 
     match state.runtime.push_sync_inbox(entry) {
         Ok(()) => Json(SuccessResponse::default()).into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse::internal(e.to_string())),
+        )
+            .into_response(),
+    }
+}
+
+/// Admin-only live query introspection endpoint.
+///
+/// Requires BOTH:
+/// - `X-Jazz-Admin-Secret` (valid)
+/// - `X-Jazz-Inspector: 1` (explicit inspector mode)
+async fn admin_live_queries_handler(
+    State(state): State<Arc<ServerState>>,
+    headers: HeaderMap,
+    Query(params): Query<AdminLiveQueriesParams>,
+) -> impl IntoResponse {
+    let inspector_mode = has_inspector_header(&headers);
+
+    if !inspector_mode {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse::bad_request(
+                "X-Jazz-Inspector: 1 header required for admin introspection endpoints",
+            )),
+        )
+            .into_response();
+    }
+
+    let admin_secret = headers
+        .get("X-Jazz-Admin-Secret")
+        .and_then(|v| v.to_str().ok());
+    if let Err((status, msg)) = validate_admin_secret(admin_secret, &state.auth_config) {
+        return (status, Json(ErrorResponse::unauthorized(msg))).into_response();
+    }
+
+    let include_hidden = params.include_hidden.unwrap_or(false);
+    match state.runtime.list_live_queries(include_hidden) {
+        Ok(queries) => Json(queries).into_response(),
         Err(e) => (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(ErrorResponse::internal(e.to_string())),

--- a/crates/jazz-cli/tests/auth_test.rs
+++ b/crates/jazz-cli/tests/auth_test.rs
@@ -356,4 +356,83 @@ mod integration_tests {
 
         assert_eq!(resp.status(), StatusCode::OK);
     }
+
+    /// Inspector mode on /sync requires admin authentication.
+    #[tokio::test]
+    async fn test_sync_inspector_mode_requires_admin_secret() {
+        let server = TestServer::start().await;
+        let token = make_jwt("jwt-user", json!({"role": "user"}), JWT_SECRET);
+
+        let resp = client()
+            .post(format!("{}/sync", server.base_url()))
+            .header("Authorization", format!("Bearer {}", token))
+            .header("X-Jazz-Inspector", "1")
+            .header("Content-Type", "application/json")
+            .body(sync_body())
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    /// Admin introspection endpoint requires explicit inspector header.
+    #[tokio::test]
+    async fn test_admin_introspection_requires_inspector_header() {
+        let server = TestServer::start().await;
+
+        let resp = client()
+            .get(format!(
+                "{}/admin/introspection/live-queries",
+                server.base_url()
+            ))
+            .header("X-Jazz-Admin-Secret", ADMIN_SECRET)
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    /// Admin introspection endpoint requires valid admin secret.
+    #[tokio::test]
+    async fn test_admin_introspection_requires_admin_secret() {
+        let server = TestServer::start().await;
+
+        let resp = client()
+            .get(format!(
+                "{}/admin/introspection/live-queries",
+                server.base_url()
+            ))
+            .header("X-Jazz-Inspector", "1")
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    /// Admin introspection endpoint returns live query list with both headers.
+    #[tokio::test]
+    async fn test_admin_introspection_live_queries_success() {
+        let server = TestServer::start().await;
+
+        let resp = client()
+            .get(format!(
+                "{}/admin/introspection/live-queries",
+                server.base_url()
+            ))
+            .header("X-Jazz-Inspector", "1")
+            .header("X-Jazz-Admin-Secret", ADMIN_SECRET)
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body: serde_json::Value = resp.json().await.unwrap();
+        assert!(
+            body.is_array(),
+            "live query introspection response should be a JSON array"
+        );
+    }
 }

--- a/crates/jazz-multi-server/src/server.rs
+++ b/crates/jazz-multi-server/src/server.rs
@@ -19,6 +19,7 @@ use groove::jazz_transport::{
     ConnectionId, ErrorResponse, ServerEvent, SuccessResponse, SyncPayloadRequest,
 };
 use groove::object::ObjectId;
+use groove::query_manager::manager::LiveQueryInfo;
 use groove::query_manager::query::QueryBuilder;
 use groove::query_manager::session::Session;
 use groove::query_manager::types::{ColumnType, SchemaBuilder, TableSchema, Value};
@@ -92,8 +93,14 @@ enum WorkerCommand {
     SyncAsAdmin {
         app_id: AppId,
         client_id: ClientId,
+        inspector_mode: bool,
         payload: SyncPayload,
         response: tokio::sync::oneshot::Sender<Result<(), String>>,
+    },
+    ListLiveQueries {
+        app_id: AppId,
+        include_hidden: bool,
+        response: tokio::sync::oneshot::Sender<Result<Vec<LiveQueryInfo>, String>>,
     },
 }
 
@@ -103,7 +110,8 @@ impl WorkerCommand {
             WorkerCommand::CreateRuntime { app_id, .. }
             | WorkerCommand::EnsureClientWithSession { app_id, .. }
             | WorkerCommand::SyncAsSession { app_id, .. }
-            | WorkerCommand::SyncAsAdmin { app_id, .. } => *app_id,
+            | WorkerCommand::SyncAsAdmin { app_id, .. }
+            | WorkerCommand::ListLiveQueries { app_id, .. } => *app_id,
         }
     }
 }
@@ -289,17 +297,38 @@ impl WorkerPool {
         &self,
         app_id: AppId,
         client_id: ClientId,
+        inspector_mode: bool,
         payload: SyncPayload,
     ) -> Result<(), WorkerDispatchError> {
         let (response_tx, response_rx) = tokio::sync::oneshot::channel();
         let command = WorkerCommand::SyncAsAdmin {
             app_id,
             client_id,
+            inspector_mode,
             payload,
             response: response_tx,
         };
         let worker = self.send_command(command)?;
         Self::await_result(worker, response_rx).await
+    }
+
+    async fn list_live_queries(
+        &self,
+        app_id: AppId,
+        include_hidden: bool,
+    ) -> Result<Vec<LiveQueryInfo>, WorkerDispatchError> {
+        let (response_tx, response_rx) = tokio::sync::oneshot::channel();
+        let command = WorkerCommand::ListLiveQueries {
+            app_id,
+            include_hidden,
+            response: response_tx,
+        };
+        let worker = self.send_command(command)?;
+        match response_rx.await {
+            Ok(Ok(entries)) => Ok(entries),
+            Ok(Err(message)) => Err(WorkerDispatchError::RuntimeError { worker, message }),
+            Err(_) => Err(WorkerDispatchError::WorkerUnavailable { worker }),
+        }
     }
 
     fn worker_count(&self) -> usize {
@@ -800,6 +829,10 @@ async fn run_worker_loop(
                                 .ensure_client_with_session(client_id, session)
                             {
                                 Err(err.to_string())
+                            } else if let Err(err) =
+                                runtime.runtime.set_client_inspector_mode(client_id, false)
+                            {
+                                Err(err.to_string())
                             } else if let Err(err) = runtime.runtime.push_sync_inbox(InboxEntry {
                                 source: Source::Client(client_id),
                                 payload,
@@ -823,14 +856,20 @@ async fn run_worker_loop(
                 WorkerCommand::SyncAsAdmin {
                     app_id,
                     client_id,
+                    inspector_mode,
                     payload,
                     response,
                 } => {
                     let result = match app_runtimes.get(&app_id) {
                         Some(runtime) => {
-                            if let Err(err) = runtime.runtime.add_client(client_id, None) {
+                            if let Err(err) = runtime.runtime.ensure_client(client_id) {
                                 Err(err.to_string())
                             } else if let Err(err) = runtime.runtime.set_client_admin(client_id) {
+                                Err(err.to_string())
+                            } else if let Err(err) = runtime
+                                .runtime
+                                .set_client_inspector_mode(client_id, inspector_mode)
+                            {
                                 Err(err.to_string())
                             } else if let Err(err) = runtime.runtime.push_sync_inbox(InboxEntry {
                                 source: Source::Client(client_id),
@@ -849,6 +888,28 @@ async fn run_worker_loop(
                             app_id = %app_id,
                             client_id = %client_id,
                             "admin-sync response receiver dropped"
+                        );
+                    }
+                }
+                WorkerCommand::ListLiveQueries {
+                    app_id,
+                    include_hidden,
+                    response,
+                } => {
+                    let result = app_runtimes
+                        .get(&app_id)
+                        .ok_or_else(|| format!("missing runtime for app {app_id}"))
+                        .and_then(|runtime| {
+                            runtime
+                                .runtime
+                                .list_live_queries(include_hidden)
+                                .map_err(|err| err.to_string())
+                        });
+                    if response.send(result).is_err() {
+                        warn!(
+                            worker,
+                            app_id = %app_id,
+                            "list-live-queries response receiver dropped"
                         );
                     }
                 }
@@ -891,6 +952,11 @@ struct AppPath {
 #[derive(Debug, Deserialize)]
 struct EventsParams {
     client_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AdminLiveQueriesParams {
+    include_hidden: Option<bool>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1021,6 +1087,10 @@ fn create_router(state: Arc<ServerState>) -> Router {
     Router::new()
         .route("/apps/:app_id/events", get(events_handler))
         .route("/apps/:app_id/sync", post(sync_handler))
+        .route(
+            "/apps/:app_id/admin/introspection/live-queries",
+            get(admin_live_queries_handler),
+        )
         .route(
             "/internal/apps",
             post(create_app_handler).get(list_apps_handler),
@@ -1374,6 +1444,14 @@ fn validate_admin_secret(
     }
 }
 
+fn has_inspector_header(headers: &HeaderMap) -> bool {
+    headers
+        .get("X-Jazz-Inspector")
+        .and_then(|v| v.to_str().ok())
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+}
+
 fn validate_internal_secret(
     headers: &HeaderMap,
     expected_secret: &str,
@@ -1541,6 +1619,8 @@ async fn sync_handler(
     headers: HeaderMap,
     Json(request): Json<SyncPayloadRequest>,
 ) -> impl IntoResponse {
+    let inspector_mode = has_inspector_header(&headers);
+
     let app_id = match parse_app_id(&path.app_id) {
         Ok(id) => id,
         Err((status, msg)) => {
@@ -1578,10 +1658,20 @@ async fn sync_handler(
         }
     };
 
+    if inspector_mode && !is_admin {
+        return (
+            StatusCode::UNAUTHORIZED,
+            Json(ErrorResponse::unauthorized(
+                "X-Jazz-Inspector mode requires a valid X-Jazz-Admin-Secret",
+            )),
+        )
+            .into_response();
+    }
+
     let dispatch_result = if is_admin {
         state
             .workers
-            .sync_as_admin(app_id, request.client_id, request.payload)
+            .sync_as_admin(app_id, request.client_id, inspector_mode, request.payload)
             .await
     } else {
         let session = match extract_session(&headers, app_id, &cfg, &state).await {
@@ -1608,6 +1698,74 @@ async fn sync_handler(
 
     match dispatch_result {
         Ok(()) => Json(SuccessResponse::default()).into_response(),
+        Err(err) => {
+            let (status, message) = worker_dispatch_status_and_message(err);
+            (status, Json(ErrorResponse::internal(message))).into_response()
+        }
+    }
+}
+
+async fn admin_live_queries_handler(
+    State(state): State<Arc<ServerState>>,
+    AxumPath(path): AxumPath<AppPath>,
+    headers: HeaderMap,
+    Query(params): Query<AdminLiveQueriesParams>,
+) -> impl IntoResponse {
+    let inspector_mode = has_inspector_header(&headers);
+    if !inspector_mode {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse::bad_request(
+                "X-Jazz-Inspector: 1 header required for admin introspection endpoints",
+            )),
+        )
+            .into_response();
+    }
+
+    let app_id = match parse_app_id(&path.app_id) {
+        Ok(id) => id,
+        Err((status, msg)) => {
+            return (status, Json(ErrorResponse::bad_request(msg))).into_response();
+        }
+    };
+
+    let app = match state.get_app(app_id).await {
+        Some(app) => app,
+        None => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse::not_found(format!(
+                    "unknown app_id: {}",
+                    path.app_id
+                ))),
+            )
+                .into_response();
+        }
+    };
+
+    let cfg = app.config.read().await.clone();
+    let is_admin = match validate_admin_secret(&headers, &cfg, &state.meta_store) {
+        Ok(value) => value,
+        Err((status, msg)) => {
+            return (status, Json(ErrorResponse::unauthorized(msg))).into_response();
+        }
+    };
+
+    if !is_admin {
+        return (
+            StatusCode::UNAUTHORIZED,
+            Json(ErrorResponse::unauthorized("Missing admin secret")),
+        )
+            .into_response();
+    }
+
+    let include_hidden = params.include_hidden.unwrap_or(false);
+    match state
+        .workers
+        .list_live_queries(app_id, include_hidden)
+        .await
+    {
+        Ok(entries) => Json(entries).into_response(),
         Err(err) => {
             let (status, message) = worker_dispatch_status_and_message(err);
             (status, Json(ErrorResponse::internal(message))).into_response()

--- a/crates/jazz-multi-server/tests/server_integration.rs
+++ b/crates/jazz-multi-server/tests/server_integration.rs
@@ -187,6 +187,56 @@ impl ServerProcess {
             .await
             .expect("sync request")
     }
+
+    async fn sync_with_backend_session_inspector(
+        &self,
+        app_id: &str,
+        backend_secret: &str,
+        user_id: &str,
+    ) -> reqwest::Response {
+        self.client
+            .post(format!("{}/apps/{app_id}/sync", self.base_url()))
+            .header("X-Jazz-Backend-Secret", backend_secret)
+            .header("X-Jazz-Session", encode_session(user_id))
+            .header("X-Jazz-Inspector", "1")
+            .json(&sync_body())
+            .send()
+            .await
+            .expect("sync request")
+    }
+
+    async fn sync_as_admin_inspector(&self, app_id: &str, admin_secret: &str) -> reqwest::Response {
+        self.client
+            .post(format!("{}/apps/{app_id}/sync", self.base_url()))
+            .header("X-Jazz-Admin-Secret", admin_secret)
+            .header("X-Jazz-Inspector", "1")
+            .json(&sync_body())
+            .send()
+            .await
+            .expect("sync request")
+    }
+
+    async fn admin_live_queries(
+        &self,
+        app_id: &str,
+        admin_secret: Option<&str>,
+        inspector_header: bool,
+        include_hidden: bool,
+    ) -> reqwest::Response {
+        let mut request = self.client.get(format!(
+            "{}/apps/{app_id}/admin/introspection/live-queries?include_hidden={include_hidden}",
+            self.base_url()
+        ));
+
+        if let Some(secret) = admin_secret {
+            request = request.header("X-Jazz-Admin-Secret", secret);
+        }
+        if inspector_header {
+            request = request.header("X-Jazz-Inspector", "1");
+        }
+
+        request.send().await.expect("admin live queries request")
+    }
 }
 
 impl Drop for ServerProcess {
@@ -334,6 +384,70 @@ async fn backend_session_auth_works_and_secret_rotation_is_enforced() {
         new_secret_sync.status(),
         StatusCode::UNAUTHORIZED,
         "new backend secret should be accepted after rotation"
+    );
+}
+
+#[tokio::test]
+async fn admin_introspection_live_queries_requires_inspector_header_and_admin_secret() {
+    let temp_dir = TempDir::new().expect("temp dir");
+    let server = ServerProcess::start(temp_dir.path()).await;
+
+    let created = server
+        .create_app(
+            "inspector-app",
+            "http://example.invalid/jwks",
+            Some("backend-v1"),
+            Some("admin-v1"),
+        )
+        .await;
+
+    let missing_header = server
+        .admin_live_queries(&created.app_id, Some("admin-v1"), false, false)
+        .await;
+    assert_eq!(missing_header.status(), StatusCode::BAD_REQUEST);
+
+    let missing_secret = server
+        .admin_live_queries(&created.app_id, None, true, false)
+        .await;
+    assert_eq!(missing_secret.status(), StatusCode::UNAUTHORIZED);
+
+    let ok = server
+        .admin_live_queries(&created.app_id, Some("admin-v1"), true, false)
+        .await;
+    assert_eq!(ok.status(), StatusCode::OK);
+    let body: Value = ok.json().await.expect("live query list json");
+    assert!(
+        body.is_array(),
+        "live query introspection should return array"
+    );
+}
+
+#[tokio::test]
+async fn sync_inspector_mode_requires_admin_secret() {
+    let temp_dir = TempDir::new().expect("temp dir");
+    let server = ServerProcess::start(temp_dir.path()).await;
+
+    let created = server
+        .create_app(
+            "inspector-sync-app",
+            "http://example.invalid/jwks",
+            Some("backend-v1"),
+            Some("admin-v1"),
+        )
+        .await;
+
+    let unauthorized = server
+        .sync_with_backend_session_inspector(&created.app_id, "backend-v1", "backend-user")
+        .await;
+    assert_eq!(unauthorized.status(), StatusCode::UNAUTHORIZED);
+
+    let admin_ok = server
+        .sync_as_admin_inspector(&created.app_id, "admin-v1")
+        .await;
+    assert_ne!(
+        admin_ok.status(),
+        StatusCode::UNAUTHORIZED,
+        "admin-authenticated inspector sync should be accepted"
     );
 }
 

--- a/specs/todo/b_mvp/database_viewer_editor.md
+++ b/specs/todo/b_mvp/database_viewer_editor.md
@@ -22,6 +22,7 @@ Developers need a "what is in the system now" tool that works both for local bro
 
 - Reuse existing query/mutation code paths as much as possible.
 - Keep inspector read/write behavior aligned with normal runtime behavior.
+- Make inspector data views real-time by default via subscriptions.
 - Support admin-only auth bypass for inspector operations where required.
 - Add live-query introspection without polluting that introspection with inspector-owned meta-queries.
 - Provide one conceptual inspector model that can be rendered in:
@@ -92,6 +93,14 @@ Inspector meta-queries use:
 - `local_only` (do not forward upstream)
 - `origin=inspector`
 
+### Subscription-First Inspector UX
+
+Inspector data display should be subscription-driven by default:
+
+- default inspector reads use subscriptions (reactive/live)
+- one-shot inspector queries are explicit opt-in for ad-hoc fetch/export flows
+- inspector subscriptions should be marked hidden/local-only unless explicitly requested otherwise
+
 ## Live Query Introspection Without Self-Pollution
 
 ### Requirement
@@ -125,7 +134,8 @@ Examples:
 - `getInspectorSchemas()`
 - `getInspectorPolicies()`
 - `listInspectorLiveQueries(includeHidden?: boolean)`
-- `inspectTableRows(table, filters, pagination, options)`
+- `subscribeInspectorTableRows(table, filters, options)` (default path)
+- `inspectTableRowsOnce(table, filters, pagination, options)` (explicit one-shot)
 - `inspectMutate(table/object, operation, payload, options)`
 
 These should route to existing `RuntimeCore`/`SchemaManager`/`QueryManager` operations with execution options.
@@ -138,7 +148,10 @@ Examples:
 
 - `GET /admin/introspection/schemas`
 - `GET /admin/introspection/policies`
-- `POST /admin/introspection/query`
+- `POST /admin/introspection/subscribe`
+- `POST /admin/introspection/unsubscribe`
+- `GET /admin/introspection/events` (inspector stream)
+- `POST /admin/introspection/query-once` (explicit one-shot)
 - `POST /admin/introspection/mutate`
 - `GET /admin/introspection/live-queries`
 - `GET /admin/introspection/sync-state`
@@ -154,6 +167,7 @@ This avoids accidental policy bypass through generic endpoints.
 
 - Admin bypass is allowed only on explicit admin introspection routes (or equivalent internal API paths).
 - Normal `/sync` and app query APIs keep current auth semantics.
+- If inspector mode is enabled over `/sync` (`X-Jazz-Inspector: 1`), it must require valid admin secret and default inspector subscriptions to hidden + `local_only`.
 - Inspector endpoints should be deny-by-default if admin auth is not configured.
 - CORS for admin introspection routes should be more restrictive than current permissive defaults.
 
@@ -233,7 +247,6 @@ Initial approach:
 
 - Should inspector-origin writes be tagged in commit metadata for explicit audit trails?
 - Should admin introspection have rate limits separate from app traffic?
-- Do we need a dedicated streaming endpoint for live-query/sync diagnostics, or is polling sufficient for MVP?
 - How much of sync-manager internal state should be exposed vs summarized?
 
 ## Immediate Next Steps

--- a/specs/todo/b_mvp/database_viewer_editor.md
+++ b/specs/todo/b_mvp/database_viewer_editor.md
@@ -1,34 +1,244 @@
-# Database Viewer & Editor — TODO
+# Database Explorer, Introspection, and DevTools
 
-Visual tool for inspecting and editing jazz2 database contents.
+Add first-class introspection tooling for Jazz in two forms:
+
+1. Chrome DevTools extension for local client Jazz state.
+2. Standalone web app for remote Jazz server state (admin-authenticated, tier-aware).
+
+This document supersedes the previous minimal TODO and captures the current design direction.
+
+## Problem
+
+Today we can query and mutate data, but we do not have a dedicated way to inspect:
+
+- live schema versions and branch mappings
+- policy definitions and effective policy paths
+- actual data in tables (including soft/hard delete state)
+- live query subscriptions and settlement behavior across tiers
+
+Developers need a "what is in the system now" tool that works both for local browser state and remote servers.
+
+## Goals
+
+- Reuse existing query/mutation code paths as much as possible.
+- Keep inspector read/write behavior aligned with normal runtime behavior.
+- Support admin-only auth bypass for inspector operations where required.
+- Add live-query introspection without polluting that introspection with inspector-owned meta-queries.
+- Provide one conceptual inspector model that can be rendered in:
+  - Chrome DevTools panel
+  - standalone admin web app
+
+## Non-goals (MVP)
+
+- Full SQL playground beyond existing `Query` model.
+- Full conflict-resolution UI.
+- Policy authoring/editing UX.
+- Time travel and branch graph visualization.
+
+## Current System Snapshot (Important Constraints)
+
+- Query execution and subscriptions are handled by `QueryManager`.
+- Sync transport is `/sync` (POST) and `/events` (binary stream).
+- Server auth currently supports JWT, backend impersonation, and admin secret (admin currently used for catalogue writes).
+- Schema evolution is managed by `SchemaManager` with lenses and hash-based composed branches.
+- Query settlement already supports persistence tiers (`worker`, `edge`, `core`) via `QuerySettled` and `PersistenceAck`.
+- `WasmSchema`/JS schema surfaces currently expose table/column structure but not policy AST.
+- Catalogue schema encoding currently drops policy data.
+
+## Product Shape
+
+Use a shared inspector core with two adapters, not two separate implementations.
+
+### Shared Core
+
+`jazz-inspector-core` (UI state + data model):
+
+- schema explorer
+- table data grid
+- row inspector
+- policy viewer
+- live query viewer
+- sync/tier status viewer
+
+### Adapter A: Chrome DevTools (local)
+
+Connects to local client Jazz runtime state in page context.
+
+### Adapter B: Standalone Web App (server)
+
+Connects to a Jazz server via dedicated admin introspection endpoints.
+
+## Integration Strategy: Reuse Existing Execution Paths
+
+### Principle
+
+Inspector query/mutation should call the same internals used by normal app queries/mutations, with explicit execution options.
+
+### New Internal Execution Options
+
+Add an execution context/options object passed through query and mutation entry points:
+
+- `auth_mode`: `enforced | admin_bypass`
+- `visibility`: `public | hidden_from_live_query_list`
+- `propagation`: `normal | local_only`
+- `origin`: `app | inspector`
+
+Default app behavior remains unchanged (`enforced + public + normal + app`).
+
+Inspector meta-queries use:
+
+- `admin_bypass` (server-only, with strict auth gate)
+- `hidden_from_live_query_list`
+- `local_only` (do not forward upstream)
+- `origin=inspector`
+
+## Live Query Introspection Without Self-Pollution
+
+### Requirement
+
+When viewing live queries, inspector-owned subscription traffic must not appear in the list by default.
+
+### Plan
+
+Extend subscription state metadata (local and server-side) with:
+
+- `origin`
+- `visibility`
+- `created_at`
+- `query_id` and context info
+
+Add list APIs:
+
+- `list_live_queries(include_hidden: bool)`
+- default `include_hidden=false`
+
+Inspector meta-queries always set hidden visibility.
+
+## API Surfaces
+
+## Local Runtime Introspection Surface (WASM/NAPI)
+
+Add read-only inspector APIs exposed to JS from runtime bindings.
+
+Examples:
+
+- `getInspectorSchemas()`
+- `getInspectorPolicies()`
+- `listInspectorLiveQueries(includeHidden?: boolean)`
+- `inspectTableRows(table, filters, pagination, options)`
+- `inspectMutate(table/object, operation, payload, options)`
+
+These should route to existing `RuntimeCore`/`SchemaManager`/`QueryManager` operations with execution options.
+
+## Server Admin Introspection Endpoints
+
+Add dedicated endpoints under `/admin/introspection/*`.
+
+Examples:
+
+- `GET /admin/introspection/schemas`
+- `GET /admin/introspection/policies`
+- `POST /admin/introspection/query`
+- `POST /admin/introspection/mutate`
+- `GET /admin/introspection/live-queries`
+- `GET /admin/introspection/sync-state`
+
+Auth requirements:
+
+- `X-Jazz-Admin-Secret` required
+- plus explicit inspector opt-in header (example: `X-Jazz-Inspector: 1`)
+
+This avoids accidental policy bypass through generic endpoints.
+
+## Auth and Safety Model
+
+- Admin bypass is allowed only on explicit admin introspection routes (or equivalent internal API paths).
+- Normal `/sync` and app query APIs keep current auth semantics.
+- Inspector endpoints should be deny-by-default if admin auth is not configured.
+- CORS for admin introspection routes should be more restrictive than current permissive defaults.
+
+## Policy Visibility
+
+We need policy data in inspector payloads.
+
+Current blockers:
+
+- WASM/JS schema export omits policies.
+- catalogue schema encoding currently omits policies.
+
+MVP approach:
+
+- expose policy metadata directly from in-memory runtime/schema manager for introspection APIs.
+- do not wait for catalogue format changes to ship local/server inspector read-only policy views.
+
+Follow-up:
+
+- version schema encoding to include policies for full syncable policy introspection.
+
+## Multi-tier Awareness
+
+Standalone inspector should support tier-aware views by:
+
+- surfacing node tier (`worker`, `edge`, `core`) in responses
+- surfacing settlement tier for live queries
+- optionally comparing snapshots from multiple nodes to highlight divergence
+
+Initial approach:
+
+- one node per connection, with optional multi-node compare mode in UI.
+
+## UX Scope (MVP)
+
+- Schemas tab: schema hashes, branch names, current/live/pending status, lens links.
+- Policies tab: table policies (SELECT/INSERT/UPDATE/DELETE, effective delete fallback).
+- Data tab: table list, row grid, filters/sort/pagination, row details.
+- Live Queries tab: active subscriptions, origin, table, branches, settled tier.
+- Sync tab: connected clients/servers, outbox/inbox counters, recent acks/query-settled.
 
 ## Phasing
 
-- **MVP**: Minimal read-only viewer — browse tables, schemas, rows. Enough for developers to see their data.
-- **Launch**: Polished, full-featured editor with inline editing, history, sync state, query playground.
+### Phase 1: Local DevTools Read-only
 
-## MVP: Minimal Viewer
+- add runtime inspector APIs in WASM/NAPI
+- add JS hook registration for DevTools discovery
+- implement extension panel (schema + data + live queries)
 
-A basic web UI that connects to a running Jazz instance and shows:
+### Phase 2: Server Standalone Read-only
 
-- Table list and schema definitions
-- Row data with filtering and sorting
-- Enough to answer "what's in my database?" during development
+- add `/admin/introspection/*` routes
+- add admin auth + inspector header gate
+- implement standalone app against these endpoints
 
-Keep it simple — even a single-page app with a table grid is valuable.
+### Phase 3: Controlled Mutations
 
-## Launch: Full Editor
+- enable inspector mutations through normal write paths + execution options
+- keep audit metadata (`origin=inspector`)
 
-- Editing data inline (writes go through the normal sync path)
-- Viewing object history and edit provenance
-- Inspecting sync state (which peers have which data)
-- Schema migration status and lens chains
-- Query playground (run SQL, see results live with reactivity)
-- Branch visualization (tree/graph of branches)
+### Phase 4: Policy/Schema Fidelity and Advanced Views
+
+- include policies in encoded schema catalogue format
+- improve multi-tier compare and sync diagnostics
+
+## Testing Plan
+
+- Unit tests for execution option propagation defaults and inspector overrides.
+- Unit tests that hidden inspector subscriptions do not appear in default live-query listings.
+- Auth tests for admin introspection route gating (missing/invalid headers).
+- Integration tests that inspector query/mutation reuses existing code paths and behavior.
+- End-to-end tests:
+  - local DevTools runtime introspection
+  - standalone admin introspection against server
 
 ## Open Questions
 
-- Standalone app vs. embedded in the developer dashboard?
-- Built with jazz2 React bindings (dogfooding)?
-- How to visualize merge conflicts and resolution?
-- Can it connect to both local dev servers and hosted infra?
+- Should inspector-origin writes be tagged in commit metadata for explicit audit trails?
+- Should admin introspection have rate limits separate from app traffic?
+- Do we need a dedicated streaming endpoint for live-query/sync diagnostics, or is polling sufficient for MVP?
+- How much of sync-manager internal state should be exposed vs summarized?
+
+## Immediate Next Steps
+
+1. Add execution options plumbing with no behavior change under default options.
+2. Add hidden/origin metadata to subscription state and live-query list API.
+3. Add minimal server admin introspection endpoints for schemas, rows, and live queries.
+4. Expose corresponding WASM/NAPI APIs for Chrome DevTools local mode.


### PR DESCRIPTION
## Summary
- expand `specs/todo/b_mvp/database_viewer_editor.md` into a full design spec for Jazz introspection tooling
- define two delivery forms: Chrome DevTools (local runtime) and standalone webapp (admin server)
- specify execution-option model for auth bypass + hidden inspector meta-queries
- document integration points, auth model, API surfaces, phasing, and test plan

## Notes
- this PR is spec-only and sets up implementation sequencing for follow-up commits