### PR TITLE
Fix server hang: dedicated OS thread for batched_tick

### DIFF
--- a/crates/groove-tokio/src/lib.rs
+++ b/crates/groove-tokio/src/lib.rs
@@ -2,12 +2,12 @@
 //!
 //! Provides `TokioRuntime<S>` - a thin wrapper around
 //! `RuntimeCore<S, TokioScheduler<S>, CallbackSyncSender>`
-//! that handles async scheduling via `tokio::spawn`.
+//! that handles async scheduling via a dedicated tick thread.
 //!
 //! # Architecture
 //!
 //! - `S: Storage + Send + 'static` provides synchronous storage
-//! - `TokioScheduler<S>` implements `Scheduler` using tokio::spawn for batched ticks
+//! - `TokioScheduler<S>` implements `Scheduler` using a dedicated OS thread
 //! - `CallbackSyncSender` implements `SyncSender` with a user-provided callback
 //! - `TokioRuntime<S>` wraps `Arc<Mutex<RuntimeCore<...>>>`
 //! - Methods grab the lock, call RuntimeCore, and return
@@ -35,31 +35,79 @@ use groove::sync_manager::{ClientId, InboxEntry, OutboxEntry, PersistenceTier, S
 /// Type alias for the concrete RuntimeCore used by TokioRuntime.
 type TokioCoreType<S> = RuntimeCore<S, TokioScheduler<S>, CallbackSyncSender>;
 
-/// Scheduler implementation for Tokio.
+/// Scheduler implementation using a dedicated OS thread.
 ///
-/// Spawns a tokio task to call `batched_tick()` on the RuntimeCore.
-/// Debounced: only one task is scheduled at a time.
+/// A single background thread parks waiting for a channel signal. When
+/// `schedule_batched_tick()` is called it sends a wake-up; the thread
+/// acquires the core Mutex, runs `batched_tick()`, then parks again.
+///
+/// This avoids both:
+/// - blocking tokio worker threads (`tokio::spawn` + `std::sync::Mutex`)
+/// - thread-pool scheduling overhead (`spawn_blocking`)
 pub struct TokioScheduler<S: Storage + Send + 'static> {
-    /// Debounce flag for scheduled ticks.
+    /// Channel to wake the dedicated tick thread.
+    notify: std::sync::mpsc::Sender<()>,
+    /// Flag for checking if a tick is in flight (used by flush).
     scheduled: Arc<AtomicBool>,
-    /// Weak reference back to RuntimeCore for spawned tasks.
-    core_ref: Weak<Mutex<TokioCoreType<S>>>,
+    /// Receiver held until `set_core_ref` spawns the thread.
+    receiver: Option<std::sync::mpsc::Receiver<()>>,
+    _phantom: std::marker::PhantomData<S>,
 }
 
 impl<S: Storage + Send + 'static> TokioScheduler<S> {
     /// Create a new TokioScheduler.
     ///
-    /// Note: `core_ref` starts as empty and is set after RuntimeCore is created.
+    /// The dedicated thread is spawned later in `set_core_ref` once
+    /// the RuntimeCore reference is available.
     fn new() -> Self {
+        let (tx, rx) = std::sync::mpsc::channel();
         Self {
+            notify: tx,
             scheduled: Arc::new(AtomicBool::new(false)),
-            core_ref: Weak::new(),
+            receiver: Some(rx),
+            _phantom: std::marker::PhantomData,
         }
     }
 
-    /// Set the core reference (called after RuntimeCore is wrapped in Arc<Mutex>).
+    /// Set the core reference and spawn the dedicated tick thread.
     fn set_core_ref(&mut self, core_ref: Weak<Mutex<TokioCoreType<S>>>) {
-        self.core_ref = core_ref;
+        if let Some(rx) = self.receiver.take() {
+            let scheduled = self.scheduled.clone();
+            let tokio_handle = tokio::runtime::Handle::current();
+            std::thread::Builder::new()
+                .name("groove-tick".into())
+                .spawn(move || {
+                    // Install tokio runtime context so sync callbacks
+                    // can use tokio::spawn, timers, etc. transparently.
+                    let _guard = tokio_handle.enter();
+                    // Park until woken. Exits when the Sender is dropped
+                    // (i.e. when the TokioScheduler/RuntimeCore is dropped).
+                    while rx.recv().is_ok() {
+                        // Drain any extra notifications (debounce)
+                        while rx.try_recv().is_ok() {}
+
+                        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                            if let Some(core_arc) = core_ref.upgrade()
+                                && let Ok(mut core) = core_arc.lock()
+                            {
+                                core.batched_tick();
+                            }
+                        }));
+
+                        if let Err(e) = result {
+                            let msg = e
+                                .downcast_ref::<&str>()
+                                .copied()
+                                .or_else(|| e.downcast_ref::<String>().map(|s| s.as_str()))
+                                .unwrap_or("unknown");
+                            tracing::error!("groove-tick panicked: {msg}");
+                        }
+
+                        scheduled.store(false, Ordering::SeqCst);
+                    }
+                })
+                .expect("failed to spawn groove-tick thread");
+        }
     }
 
     /// Check if a batched_tick is currently scheduled.
@@ -70,22 +118,10 @@ impl<S: Storage + Send + 'static> TokioScheduler<S> {
 
 impl<S: Storage + Send + 'static> Scheduler for TokioScheduler<S> {
     fn schedule_batched_tick(&self) {
-        // Debounce: only schedule if not already scheduled
         if !self.scheduled.swap(true, Ordering::SeqCst) {
-            let core_ref = self.core_ref.clone();
-            let flag = self.scheduled.clone();
-
-            tokio::spawn(async move {
-                // Call batched_tick on the core
-                if let Some(core_arc) = core_ref.upgrade()
-                    && let Ok(mut core) = core_arc.lock()
-                {
-                    core.batched_tick();
-                }
-
-                // Clear the scheduled flag AFTER tick completes
-                flag.store(false, Ordering::SeqCst);
-            });
+            // Wake the dedicated thread — non-blocking, can't fail
+            // unless the thread has exited (receiver dropped).
+            let _ = self.notify.send(());
         }
     }
 }
@@ -562,5 +598,74 @@ mod tests {
         // Cleanup
         drop(updates_vec);
         runtime.unsubscribe(handle).unwrap();
+    }
+
+    /// The server hang scenario: when batched_tick is slow (e.g. sync
+    /// callbacks doing I/O, WAL flush), the tokio event loop must remain
+    /// responsive. With a single-threaded tokio runtime and the old
+    /// tokio::spawn approach, a slow batched_tick blocks the only worker
+    /// thread, freezing all async progress. With a dedicated OS thread
+    /// for ticks, the tokio thread stays free.
+    ///
+    /// Setup:
+    ///   - current_thread tokio runtime (one worker, worst case)
+    ///   - sync callback sleeps 500ms (simulates slow I/O during tick)
+    ///   - insert triggers schedule_batched_tick
+    ///   - yield_now gives the executor a chance to run queued tasks
+    ///
+    /// Old behaviour (tokio::spawn): yield_now runs the spawned
+    /// batched_tick task on the tokio thread → blocks 500ms → FAIL.
+    ///
+    /// New behaviour (dedicated thread): no tokio tasks queued,
+    /// yield_now returns immediately → PASS.
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_slow_tick_does_not_block_tokio() {
+        use std::time::{Duration, Instant};
+
+        let schema = test_schema();
+        let app_id = AppId::from_name("test-slow-tick");
+        let sync_manager = SyncManager::new();
+        let schema_manager =
+            SchemaManager::new(sync_manager, schema, app_id, "dev", "main").unwrap();
+
+        let callback_fired = Arc::new(AtomicBool::new(false));
+        let callback_fired_clone = callback_fired.clone();
+
+        let runtime = TokioRuntime::new(schema_manager, MemoryStorage::new(), move |_msg| {
+            callback_fired_clone.store(true, Ordering::SeqCst);
+            // Simulate slow sync I/O (network send, WAL flush, etc.)
+            std::thread::sleep(Duration::from_millis(500));
+        });
+
+        // Add a server so the sync outbox has a destination
+        runtime.add_server(ServerId(uuid::Uuid::new_v4())).unwrap();
+
+        // Insert triggers schedule_batched_tick
+        let values = vec![
+            Value::Uuid(ObjectId::new()),
+            Value::Text("Alice".to_string()),
+        ];
+        runtime.insert("users", values, None).unwrap();
+
+        // Yield to the executor. With tokio::spawn, the spawned
+        // batched_tick task runs here and blocks the thread for 500ms.
+        // With the dedicated thread, nothing is queued — returns fast.
+        let start = Instant::now();
+        tokio::task::yield_now().await;
+        let elapsed = start.elapsed();
+
+        assert!(
+            elapsed < Duration::from_millis(100),
+            "Tokio thread was blocked for {elapsed:?} during batched_tick — \
+             slow ticks must not block the event loop"
+        );
+
+        // Wait for the dedicated thread to actually process the tick
+        tokio::time::sleep(Duration::from_millis(700)).await;
+
+        assert!(
+            callback_fired.load(Ordering::SeqCst),
+            "Sync callback should have fired (batched_tick should have run)"
+        );
     }
 }

--- a/specs/status-quo/batched_tick_orchestration.md
+++ b/specs/status-quo/batched_tick_orchestration.md
@@ -56,19 +56,31 @@ The second flush is critical: the scheduler's debounce prevents `immediate_tick(
 
 Both platform implementations use a boolean flag to prevent overlapping batched_tick calls:
 
-- **Tokio**: Sets flag before spawn, clears after completion
+- **Tokio**: Sets flag before signalling the tick thread, clears after tick completes
 - **WASM**: Sets flag before spawn_local, clears before calling batched_tick
 
-> `crates/groove-tokio/src/lib.rs:72-90` (TokioScheduler)
+> `crates/groove-tokio/src/lib.rs` (TokioScheduler)
 > `crates/groove-wasm/src/runtime.rs:91-106` (WasmScheduler)
 
 ## Platform Implementations
 
 ### Tokio (groove-tokio)
 
-`TokioScheduler` spawns `batched_tick()` via tokio task. `CallbackSyncSender` sends sync messages via closure.
+`TokioScheduler` runs `batched_tick()` on a dedicated OS thread (`groove-tick`), not via `tokio::spawn`. This is critical for server responsiveness.
 
-> `crates/groove-tokio/src/lib.rs:42-91` (TokioScheduler), `164-206` (TokioRuntime)
+**Problem.** `batched_tick()` acquires the `Arc<Mutex<RuntimeCore>>` and holds it while processing sync callbacks and flushing the WAL. Every HTTP request handler also needs this lock. The previous `tokio::spawn` approach ran ticks on tokio worker threads, so a slow tick would block a worker while holding the lock. Under load, all workers would end up parked waiting for the mutex, and the server would hang.
+
+**Solution.** A dedicated OS thread parks on `std::sync::mpsc::channel`, waiting for a wake signal. When `schedule_batched_tick()` is called, it sends a `()` through the channel. The thread wakes, drains any extra signals (debounce), acquires the mutex, runs `batched_tick()`, and parks again. Tokio workers never hold the lock during tick processing.
+
+**Tokio context.** The thread calls `tokio::runtime::Handle::enter()` on startup, installing the tokio runtime context. This means sync callbacks can use `tokio::spawn`, timers, and other tokio APIs transparently, exactly as if they were running on a tokio worker.
+
+**Panic resilience.** Each tick is wrapped in `std::panic::catch_unwind`. If a tick panics, the error is logged via `tracing::error!` and the thread continues to the next tick. Without this, a single panic would kill the thread and silently stop all future ticks.
+
+**Lifecycle.** The thread exits when the `mpsc::Sender` is dropped, which happens when the `TokioScheduler` (and thus the `RuntimeCore`) is dropped.
+
+**Trade-offs.** The coarse `Mutex<RuntimeCore>` still exists. Individual HTTP request handlers can still briefly block a tokio worker when they contend with a running tick for the lock. The improvement is that the tick itself never occupies a tokio worker, so the event loop stays responsive (accepting connections, parsing requests, running non-mutex tasks).
+
+> `crates/groove-tokio/src/lib.rs` (TokioScheduler, TokioRuntime)
 
 ### WASM (groove-wasm)
 
@@ -88,10 +100,14 @@ Each CRUD method (insert, update, delete) on RuntimeCore:
 
 ## Testing
 
-Tests use `NoopScheduler` (no-op scheduling) and `VecSyncSender` (collects messages in a Vec). Manual calls to `immediate_tick()` and `batched_tick()` drive execution.
+Core tests use `NoopScheduler` (no-op scheduling) and `VecSyncSender` (collects messages in a Vec). Manual calls to `immediate_tick()` and `batched_tick()` drive execution.
 
 > `crates/groove/src/runtime_core.rs:68-101` (NoopScheduler, VecSyncSender)
 > `crates/groove/src/runtime_core.rs:904-1049` (test setup)
+
+The TokioScheduler has a dedicated behavioural test (`test_slow_tick_does_not_block_tokio`) that verifies the core property: a slow `batched_tick` (simulated via a 500ms sleep in the sync callback) must not block the tokio event loop. The test uses a `current_thread` runtime (single worker, worst case) and asserts that `yield_now` returns within 100ms after triggering a tick. This test fails with the old `tokio::spawn` approach and passes with the dedicated thread.
+
+> `crates/groove-tokio/src/lib.rs` (test_slow_tick_does_not_block_tokio)
 
 ## Key Files
 


### PR DESCRIPTION
## Problem

While building the moon lander multiplayer example, where each participant hits the database with a position update every 200ms, the server would hang after some time.

Root cause: `TokioScheduler` ran `batched_tick()` via `tokio::spawn`. This acquires `Arc<Mutex<RuntimeCore>>` and holds it while processing sync callbacks and flushing the WAL. Every HTTP request handler also needs this lock. Under load, a slow tick blocks a tokio worker while holding the mutex, and other request handlers block further workers waiting for it. Eventually all tokio workers are parked on the mutex and the server stops responding entirely.

## Solution

Replace `tokio::spawn` with a dedicated OS thread (`groove-tick`) that parks on `std::sync::mpsc::channel`. When `schedule_batched_tick()` is called, it sends a wake signal. The thread wakes, acquires the mutex, runs `batched_tick()`, and parks again. Tokio workers never hold the lock during tick processing, so the event loop stays responsive.

Three details:

- **Tokio context**: the thread calls `Handle::enter()` on startup, so sync callbacks can use `tokio::spawn` and timers transparently.
- **Panic resilience**: each tick is wrapped in `catch_unwind`. A bad tick logs the error and continues rather than silently killing all future ticks.
- **Lifecycle**: the thread exits when the `Sender` drops (i.e. when the runtime is dropped).

The coarse `Mutex<RuntimeCore>` still exists — individual request handlers can still briefly contend with a running tick. The improvement is that the tick itself never occupies a tokio worker: degradation is gradual (higher latency under load) rather than catastrophic (complete hang).

## Testing

`test_slow_tick_does_not_block_tokio`: uses a `current_thread` tokio runtime (single worker, worst case) with a sync callback that sleeps 500ms (simulating slow I/O). After triggering a tick via insert, asserts that `yield_now` returns within 100ms. This test fails on main (blocked for ~500ms) and passes with the dedicated thread.

## Changes

- `crates/groove-tokio/src/lib.rs` — TokioScheduler rewritten from `tokio::spawn` to dedicated thread
- `specs/status-quo/batched_tick_orchestration.md` — updated to document the new architecture