### PR TITLE
fix: hanging in-flight load on gc values

### DIFF
--- a/packages/cojson/src/PeerState.ts
+++ b/packages/cojson/src/PeerState.ts
@@ -3,7 +3,11 @@ import { CoValueCore } from "./exports.js";
 import { RawCoID } from "./ids.js";
 import { CoValueKnownState } from "./knownState.js";
 import { logger } from "./logger.js";
-import { type LoadMode, OutgoingLoadQueue } from "./queue/OutgoingLoadQueue.js";
+import {
+  type LoadCompletionSource,
+  type LoadMode,
+  OutgoingLoadQueue,
+} from "./queue/OutgoingLoadQueue.js";
 import { Peer, SyncMessage } from "./sync.js";
 
 export class PeerState {
@@ -78,8 +82,11 @@ export class PeerState {
     this.loadQueue.trackUpdate(coValue);
   }
 
-  trackLoadRequestComplete(coValue: CoValueCore) {
-    this.loadQueue.trackComplete(coValue);
+  trackLoadRequestComplete(
+    coValue: CoValueCore,
+    source: LoadCompletionSource = "content",
+  ) {
+    this.loadQueue.trackComplete(coValue, source);
   }
 
   trackToldKnownState(id: RawCoID) {

--- a/packages/cojson/src/SyncStateManager.ts
+++ b/packages/cojson/src/SyncStateManager.ts
@@ -143,11 +143,11 @@ export class SyncStateManager {
   ) {
     const entry = this.syncManager.local.getCoValue(id);
 
-    if (!entry.hasVerifiedContent()) {
+    const knownState = entry.knownState();
+
+    if (!knownState.header) {
       return false;
     }
-
-    const knownState = entry.verified.knownState();
 
     return areCurrentSessionsInSyncWith(
       knownState.sessions,

--- a/packages/cojson/src/coValueCore/coValueCore.ts
+++ b/packages/cojson/src/coValueCore/coValueCore.ts
@@ -345,6 +345,14 @@ export class CoValueCore {
     return this.hasVerifiedContent();
   }
 
+  isKnownStateAvailable(): boolean {
+    return (
+      this.loadingState === "available" ||
+      this.loadingState === "onlyKnownState" ||
+      this.loadingState === "garbageCollected"
+    );
+  }
+
   isCompletelyDownloaded(): boolean {
     if (!this.hasVerifiedContent()) {
       return false;

--- a/packages/cojson/src/coValueCore/coValueCore.ts
+++ b/packages/cojson/src/coValueCore/coValueCore.ts
@@ -312,16 +312,16 @@ export class CoValueCore {
       return "available";
     }
 
+    // Check for lastKnownStateSource (garbageCollected or onlyKnownState)
+    if (this.#lastKnownStateSource) {
+      return this.#lastKnownStateSource;
+    }
+
     // Check for pending peers FIRST - loading takes priority over other states
     for (const peer of this.loadingStatuses.values()) {
       if (peer.type === "pending") {
         return "loading";
       }
-    }
-
-    // Check for lastKnownStateSource (garbageCollected or onlyKnownState)
-    if (this.#lastKnownStateSource) {
-      return this.#lastKnownStateSource;
     }
 
     if (this.loadingStatuses.size === 0) {

--- a/packages/cojson/src/coValueCore/coValueCore.ts
+++ b/packages/cojson/src/coValueCore/coValueCore.ts
@@ -36,12 +36,7 @@ import {
   getDependenciesFromGroupRawTransactions,
   getDependenciesFromHeader,
 } from "./utils.js";
-import {
-  CoValueHeader,
-  Transaction,
-  Uniqueness,
-  VerifiedState,
-} from "./verifiedState.js";
+import { CoValueHeader, Transaction, VerifiedState } from "./verifiedState.js";
 import {
   MergeCommit,
   BranchPointerCommit,

--- a/packages/cojson/src/queue/OutgoingLoadQueue.ts
+++ b/packages/cojson/src/queue/OutgoingLoadQueue.ts
@@ -11,6 +11,11 @@ interface PendingLoad {
   sendCallback: () => void;
 }
 
+interface InFlightLoad {
+  value: CoValueCore;
+  sentAt: number;
+}
+
 /**
  * Mode for enqueuing load requests:
  * - "high-priority" (default): high priority, processed in order
@@ -29,7 +34,7 @@ export type LoadMode = "low-priority" | "immediate" | "high-priority";
  * - Manages timeouts for in-flight loads with a single timer
  */
 export class OutgoingLoadQueue {
-  private inFlightLoads: Map<CoValueCore, number> = new Map();
+  private inFlightLoads: Map<RawCoID, InFlightLoad> = new Map();
   private inFlightCounter: UpDownCounter;
   private highPriorityPending: LinkedList<PendingLoad> = meteredList(
     "load-requests-queue",
@@ -79,13 +84,13 @@ export class OutgoingLoadQueue {
    */
   private trackSent(coValue: CoValueCore): void {
     const now = performance.now();
-    this.inFlightLoads.set(coValue, now);
+    this.inFlightLoads.set(coValue.id, { value: coValue, sentAt: now });
     this.inFlightCounter.add(1);
     this.scheduleTimeoutCheck(CO_VALUE_LOADING_CONFIG.TIMEOUT);
   }
 
-  private untrackInFlight(coValue: CoValueCore): boolean {
-    if (!this.inFlightLoads.delete(coValue)) {
+  private untrackInFlight(id: RawCoID): boolean {
+    if (!this.inFlightLoads.delete(id)) {
       return false;
     }
 
@@ -115,7 +120,7 @@ export class OutgoingLoadQueue {
     const now = performance.now();
 
     let nextTimeout: number | undefined;
-    for (const [coValue, sentAt] of this.inFlightLoads.entries()) {
+    for (const { value: coValue, sentAt } of this.inFlightLoads.values()) {
       const timeout = sentAt + CO_VALUE_LOADING_CONFIG.TIMEOUT;
 
       if (now >= timeout) {
@@ -124,7 +129,7 @@ export class OutgoingLoadQueue {
             id: coValue.id,
             peerId: this.peerId,
           });
-          coValue.markNotFoundInPeer(this.peerId);
+          coValue.node.getCoValue(coValue.id).markNotFoundInPeer(this.peerId);
         } else if (coValue.isStreaming()) {
           logger.warn(
             "Content streaming is taking more than " +
@@ -139,7 +144,7 @@ export class OutgoingLoadQueue {
           );
         }
 
-        if (this.untrackInFlight(coValue)) {
+        if (this.untrackInFlight(coValue.id)) {
           this.processQueue();
         }
       } else {
@@ -154,12 +159,15 @@ export class OutgoingLoadQueue {
   }
 
   trackUpdate(coValue: CoValueCore): void {
-    if (!this.inFlightLoads.has(coValue)) {
+    if (!this.inFlightLoads.has(coValue.id)) {
       return;
     }
 
     // Refresh the timeout for the in-flight load
-    this.inFlightLoads.set(coValue, performance.now());
+    this.inFlightLoads.set(coValue.id, {
+      value: coValue,
+      sentAt: performance.now(),
+    });
   }
 
   /**
@@ -167,7 +175,7 @@ export class OutgoingLoadQueue {
    * Triggers processing of pending requests.
    */
   trackComplete(coValue: CoValueCore): void {
-    if (!this.inFlightLoads.has(coValue)) {
+    if (!this.inFlightLoads.has(coValue.id)) {
       return;
     }
 
@@ -176,7 +184,7 @@ export class OutgoingLoadQueue {
       return;
     }
 
-    if (this.untrackInFlight(coValue)) {
+    if (this.untrackInFlight(coValue.id)) {
       this.processQueue();
     }
   }
@@ -195,7 +203,7 @@ export class OutgoingLoadQueue {
     sendCallback: () => void,
     mode: LoadMode = "high-priority",
   ): void {
-    if (this.inFlightLoads.has(value)) {
+    if (this.inFlightLoads.has(value.id)) {
       return;
     }
 

--- a/packages/cojson/src/queue/OutgoingLoadQueue.ts
+++ b/packages/cojson/src/queue/OutgoingLoadQueue.ts
@@ -130,6 +130,7 @@ export class OutgoingLoadQueue {
             id: coValue.id,
             peerId: this.peerId,
           });
+          // Re-resolve by ID to avoid mutating a stale CoValue instance.
           coValue.node.getCoValue(coValue.id).markNotFoundInPeer(this.peerId);
         } else if (coValue.isStreaming()) {
           logger.warn(

--- a/packages/cojson/src/queue/OutgoingLoadQueue.ts
+++ b/packages/cojson/src/queue/OutgoingLoadQueue.ts
@@ -23,6 +23,7 @@ interface InFlightLoad {
  * - "immediate": bypasses the queue entirely, executes immediately
  */
 export type LoadMode = "low-priority" | "immediate" | "high-priority";
+export type LoadCompletionSource = "content" | "known";
 
 /**
  * A queue that manages outgoing load requests with throttling.
@@ -174,12 +175,15 @@ export class OutgoingLoadQueue {
    * Track that a load request has completed.
    * Triggers processing of pending requests.
    */
-  trackComplete(coValue: CoValueCore): void {
+  trackComplete(
+    coValue: CoValueCore,
+    source: LoadCompletionSource = "content",
+  ): void {
     if (!this.inFlightLoads.has(coValue.id)) {
       return;
     }
 
-    if (coValue.isStreaming()) {
+    if (source === "content" && coValue.isStreaming()) {
       // wait for the next chunk
       return;
     }

--- a/packages/cojson/src/sync.ts
+++ b/packages/cojson/src/sync.ts
@@ -951,7 +951,7 @@ export class SyncManager {
 
     if (coValue.isAvailable()) {
       this.sendNewContent(msg.id, peer);
-    } else if (coValue.loadingState === "onlyKnownState") {
+    } else if (coValue.isKnownStateAvailable()) {
       // Validate if content is missing before loading it from storage
       if (!this.syncState.isSynced(peer, msg.id)) {
         this.local.loadCoValueCore(msg.id).then(() => {

--- a/packages/cojson/src/sync.ts
+++ b/packages/cojson/src/sync.ts
@@ -960,12 +960,7 @@ export class SyncManager {
       }
     }
 
-    // KNOWN with header=true does not guarantee that content arrived.
-    // Keep the request in-flight until content (or a terminal state) lands,
-    // so queue timeout logic can mark this peer as unavailable if needed.
-    if (!availableOnPeer || coValue.isKnownStateAvailable()) {
-      peer.trackLoadRequestComplete(coValue);
-    }
+    peer.trackLoadRequestComplete(coValue);
   }
 
   handleReconcile(msg: ReconcileMessage, peer: PeerState): void {

--- a/packages/cojson/src/sync.ts
+++ b/packages/cojson/src/sync.ts
@@ -963,7 +963,7 @@ export class SyncManager {
     // KNOWN with header=true does not guarantee that content arrived.
     // Keep the request in-flight until content (or a terminal state) lands,
     // so queue timeout logic can mark this peer as unavailable if needed.
-    if (!availableOnPeer || coValue.isAvailable()) {
+    if (!availableOnPeer || coValue.isKnownStateAvailable()) {
       peer.trackLoadRequestComplete(coValue);
     }
   }

--- a/packages/cojson/src/sync.ts
+++ b/packages/cojson/src/sync.ts
@@ -960,7 +960,7 @@ export class SyncManager {
       }
     }
 
-    peer.trackLoadRequestComplete(coValue);
+    peer.trackLoadRequestComplete(coValue, "known");
   }
 
   handleReconcile(msg: ReconcileMessage, peer: PeerState): void {
@@ -1337,7 +1337,7 @@ export class SyncManager {
       }
     }
 
-    peer?.trackLoadRequestComplete(coValue);
+    peer?.trackLoadRequestComplete(coValue, "content");
 
     for (const peer of this.getPeers(coValue.id)) {
       /**

--- a/packages/cojson/src/tests/coValueCore.loadFromStorage.test.ts
+++ b/packages/cojson/src/tests/coValueCore.loadFromStorage.test.ts
@@ -553,6 +553,22 @@ describe("CoValueCore.loadFromStorage", () => {
 
       expect(loadSpy).toHaveBeenCalledTimes(1);
     });
+
+    test("should keep garbageCollected loadingState even when a peer is pending", () => {
+      const { state, node, id } = setup();
+      const storage = createMockStorage();
+      node.setStorage(storage);
+
+      state.setGarbageCollectedState({
+        id,
+        header: true,
+        sessions: {},
+      });
+      state.markPending("peer1");
+
+      expect(state.getLoadingStateForPeer("peer1")).toBe("pending");
+      expect(state.loadingState).toBe("garbageCollected");
+    });
   });
 
   describe("when state is onlyKnownState", () => {
@@ -610,6 +626,26 @@ describe("CoValueCore.loadFromStorage", () => {
       state.loadFromStorage();
 
       expect(loadSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test("should keep onlyKnownState loadingState even when a peer is pending", () => {
+      const { state, node, id } = setup();
+      const storage = createMockStorage({
+        loadKnownState: (id, callback) => {
+          callback({
+            id,
+            header: true,
+            sessions: { session1: 1 },
+          });
+        },
+      });
+      node.setStorage(storage);
+
+      state.getKnownStateFromStorage(() => {});
+      state.markPending("peer1");
+
+      expect(state.getLoadingStateForPeer("peer1")).toBe("pending");
+      expect(state.loadingState).toBe("onlyKnownState");
     });
   });
 

--- a/packages/cojson/src/tests/sync.garbageCollection.test.ts
+++ b/packages/cojson/src/tests/sync.garbageCollection.test.ts
@@ -205,6 +205,8 @@ describe("sync after the garbage collector has run", () => {
         "server -> storage | CONTENT Group header: true new: After: 0 New: 4",
         "server -> client | KNOWN Map sessions: header/1",
         "server -> storage | CONTENT Map header: true new: After: 0 New: 1",
+        "client -> storage | LOAD Map sessions: empty",
+        "storage -> client | CONTENT Map header: true new: After: 0 New: 1",
       ]
     `);
   });

--- a/packages/cojson/src/tests/sync.peerReconciliation.test.ts
+++ b/packages/cojson/src/tests/sync.peerReconciliation.test.ts
@@ -395,6 +395,10 @@ describe("peer reconciliation with garbageCollected CoValues", () => {
         "client -> server | LOAD Map sessions: header/1",
         "server -> client | KNOWN Group sessions: header/4",
         "server -> client | KNOWN Map sessions: header/1",
+        "client -> storage | LOAD Group sessions: empty",
+        "storage -> client | CONTENT Group header: true new: After: 0 New: 4",
+        "client -> storage | LOAD Map sessions: empty",
+        "storage -> client | CONTENT Map header: true new: After: 0 New: 1",
       ]
     `);
   });
@@ -455,6 +459,10 @@ describe("peer reconciliation with garbageCollected CoValues", () => {
         "client -> server | LOAD Map sessions: header/1",
         "server -> client | KNOWN Group sessions: header/4",
         "server -> client | KNOWN Map sessions: header/1",
+        "client -> storage | LOAD Group sessions: empty",
+        "storage -> client | CONTENT Group header: true new: After: 0 New: 4",
+        "client -> storage | LOAD Map sessions: empty",
+        "storage -> client | CONTENT Map header: true new: After: 0 New: 1",
       ]
     `);
   });

--- a/packages/cojson/src/tests/sync.peerReconciliation.test.ts
+++ b/packages/cojson/src/tests/sync.peerReconciliation.test.ts
@@ -395,10 +395,6 @@ describe("peer reconciliation with garbageCollected CoValues", () => {
         "client -> server | LOAD Map sessions: header/1",
         "server -> client | KNOWN Group sessions: header/4",
         "server -> client | KNOWN Map sessions: header/1",
-        "client -> storage | LOAD Group sessions: empty",
-        "storage -> client | CONTENT Group header: true new: After: 0 New: 4",
-        "client -> storage | LOAD Map sessions: empty",
-        "storage -> client | CONTENT Map header: true new: After: 0 New: 1",
       ]
     `);
   });
@@ -459,10 +455,6 @@ describe("peer reconciliation with garbageCollected CoValues", () => {
         "client -> server | LOAD Map sessions: header/1",
         "server -> client | KNOWN Group sessions: header/4",
         "server -> client | KNOWN Map sessions: header/1",
-        "client -> storage | LOAD Group sessions: empty",
-        "storage -> client | CONTENT Group header: true new: After: 0 New: 4",
-        "client -> storage | LOAD Map sessions: empty",
-        "storage -> client | CONTENT Map header: true new: After: 0 New: 1",
       ]
     `);
   });


### PR DESCRIPTION
Track a load message as complete when the server replies with a known state message and the value has been garbage collected in the meantime