### PR TITLE
permissions API prototype: allowedTo DSL, tests, and docs refresh

### DIFF
--- a/crates/groove/src/query_manager/graph.rs
+++ b/crates/groove/src/query_manager/graph.rs
@@ -1034,7 +1034,7 @@ impl QueryGraph {
             self.mark_downstream_dirty(node_id);
         }
 
-        // Mark PolicyFilter nodes whose INHERITS-referenced tables changed
+        // Mark PolicyFilter nodes whose policy dependency tables changed
         let affected_policy_filters: Vec<NodeId> = self
             .policy_filter_tables
             .iter()
@@ -1049,7 +1049,7 @@ impl QueryGraph {
 
         for node_id in affected_policy_filters {
             self.mark_dirty(node_id);
-            // Mark the node as needing INHERITS re-evaluation
+            // Mark the node as needing policy re-evaluation
             if let Some(GraphNode::PolicyFilter(node)) = self.get_node_mut(node_id) {
                 node.mark_inherits_dirty();
             }

--- a/crates/groove/src/query_manager/graph_nodes/policy_filter.rs
+++ b/crates/groove/src/query_manager/graph_nodes/policy_filter.rs
@@ -9,11 +9,13 @@ use std::collections::HashSet;
 use crate::commit::CommitId;
 use crate::object::ObjectId;
 use crate::query_manager::encoding::{column_is_null, decode_column};
-use crate::query_manager::policy::{Operation, PolicyExpr, evaluate_expr_recursive};
+use crate::query_manager::policy::{
+    Operation, PolicyExpr, bind_outer_row_refs, evaluate_expr_recursive,
+};
 use crate::query_manager::policy_graph::PolicyGraph;
 use crate::query_manager::session::Session;
 use crate::query_manager::types::{
-    Row, RowDescriptor, Schema, Tuple, TupleDelta, TupleElement, Value,
+    Row, RowDescriptor, Schema, TableName, Tuple, TupleDelta, TupleElement, Value,
 };
 
 use crate::storage::Storage;
@@ -38,11 +40,11 @@ pub struct PolicyFilterNode {
     /// Current tuples that pass the policy.
     current_tuples: AHashSet<Tuple>,
     dirty: bool,
-    /// Whether the policy contains INHERITS clauses that need context for evaluation.
+    /// Whether the policy contains clauses that need graph-backed context evaluation.
     has_inherits: bool,
-    /// Tables referenced by INHERITS clauses (for dirty tracking).
+    /// Tables referenced by INHERITS / EXISTS clauses (for dirty tracking).
     inherits_tables: HashSet<String>,
-    /// Whether any INHERITS-referenced table has changed.
+    /// Whether any dependency table has changed.
     inherits_dirty: bool,
 }
 
@@ -85,17 +87,17 @@ impl PolicyFilterNode {
         }
     }
 
-    /// Returns true if this policy contains INHERITS clauses.
+    /// Returns true if this policy contains clauses requiring context evaluation.
     pub fn has_inherits(&self) -> bool {
         self.has_inherits
     }
 
-    /// Returns the tables referenced by INHERITS clauses.
+    /// Returns the tables referenced by INHERITS / EXISTS clauses.
     pub fn inherits_tables(&self) -> &HashSet<String> {
         &self.inherits_tables
     }
 
-    /// Mark that an INHERITS-referenced table has changed.
+    /// Mark that a dependency table has changed.
     pub fn mark_inherits_dirty(&mut self) {
         self.inherits_dirty = true;
     }
@@ -129,9 +131,11 @@ impl PolicyFilterNode {
 
         // Process added tuples
         for tuple in input.added {
-            if let Some(row) = tuple_to_row(&tuple)
-                && self.evaluate_with_context(&row, io, &mut row_loader)
-            {
+            let Some(row) = tuple_to_row(&tuple) else {
+                continue;
+            };
+
+            if self.evaluate_with_context(&row, io, &mut row_loader) {
                 self.current_tuples.insert(tuple.clone());
                 result.added.push(tuple);
             }
@@ -230,6 +234,9 @@ impl PolicyFilterNode {
                 via_column,
             } => self
                 .evaluate_inherits_with_context(*operation, via_column, row, io, row_loader, depth),
+            PolicyExpr::Exists { table, condition } => {
+                self.evaluate_exists_with_context(table, condition, row, io, row_loader, depth)
+            }
             PolicyExpr::And(exprs) => exprs
                 .iter()
                 .all(|e| self.evaluate_expr_with_context(e, row, io, row_loader, depth)),
@@ -336,6 +343,47 @@ impl PolicyFilterNode {
         graph.result()
     }
 
+    /// Evaluate EXISTS by creating and settling a PolicyGraph for the target table.
+    #[allow(clippy::too_many_arguments)]
+    fn evaluate_exists_with_context(
+        &self,
+        table: &str,
+        condition: &PolicyExpr,
+        row: &Row,
+        io: &dyn Storage,
+        row_loader: &mut dyn FnMut(ObjectId) -> Option<(Vec<u8>, CommitId)>,
+        depth: usize,
+    ) -> bool {
+        if depth >= 32 {
+            return false;
+        }
+
+        let bound_condition = match bind_outer_row_refs(condition, &row.data, &self.descriptor) {
+            Some(expr) => expr,
+            None => return false,
+        };
+
+        let table_name = TableName::new(table);
+        let mut graph = match PolicyGraph::for_exists(
+            &table_name,
+            &bound_condition,
+            &self.session,
+            &self.schema,
+            &self.branch,
+        ) {
+            Some(g) => g,
+            None => return false,
+        };
+
+        for _ in 0..100 {
+            if graph.settle(io, row_loader) {
+                break;
+            }
+        }
+
+        graph.result()
+    }
+
     /// Evaluate the policy expression against a row.
     pub fn evaluate(&self, row: &Row) -> bool {
         self.evaluate_expr(&self.policy, row, 0)
@@ -357,6 +405,7 @@ impl PolicyFilterNode {
                 operation,
                 via_column,
             } => self.evaluate_inherits(*operation, via_column, row, depth),
+            PolicyExpr::Exists { .. } => false, // Without context, fail closed.
 
             // And/Or/Not need to recurse through this method for INHERITS support
             PolicyExpr::And(exprs) => exprs.iter().all(|e| self.evaluate_expr(e, row, depth)),
@@ -407,9 +456,11 @@ impl PolicyFilterNode {
     }
 }
 
-/// Collect all tables referenced by INHERITS clauses in a policy expression.
-/// Traverses the policy tree recursively to find all INHERITS via_column references
-/// and resolves them to their target tables through the descriptor's FK references.
+/// Collect all tables referenced by policy clauses that require contextual re-evaluation.
+///
+/// Includes:
+/// - INHERITS target tables (resolved from FK metadata)
+/// - EXISTS target tables (explicit in the expression)
 fn collect_inherits_tables(policy: &PolicyExpr, descriptor: &RowDescriptor) -> HashSet<String> {
     let mut tables = HashSet::new();
     collect_inherits_tables_recursive(policy, descriptor, &mut tables);
@@ -424,9 +475,10 @@ fn collect_inherits_tables_recursive(
     match policy {
         PolicyExpr::Inherits { via_column, .. } => {
             // Look up the FK column to find the referenced table
-            if let Some(col_index) = descriptor.column_index(via_column)
-                && let Some(ref references) = descriptor.columns[col_index].references
-            {
+            let Some(col_index) = descriptor.column_index(via_column) else {
+                return;
+            };
+            if let Some(ref references) = descriptor.columns[col_index].references {
                 tables.insert(references.as_str().to_string());
             }
         }
@@ -434,6 +486,10 @@ fn collect_inherits_tables_recursive(
             for expr in exprs {
                 collect_inherits_tables_recursive(expr, descriptor, tables);
             }
+        }
+        PolicyExpr::Exists { table, condition } => {
+            tables.insert(table.clone());
+            collect_inherits_tables_recursive(condition, descriptor, tables);
         }
         PolicyExpr::Not(inner) => {
             collect_inherits_tables_recursive(inner, descriptor, tables);
@@ -460,9 +516,10 @@ impl RowNode for PolicyFilterNode {
 
         // Process added tuples
         for tuple in input.added {
-            if let Some(row) = tuple_to_row(&tuple)
-                && self.evaluate(&row)
-            {
+            let Some(row) = tuple_to_row(&tuple) else {
+                continue;
+            };
+            if self.evaluate(&row) {
                 self.current_tuples.insert(tuple.clone());
                 result.added.push(tuple);
             }
@@ -715,5 +772,43 @@ mod tests {
         // Only in team
         let row3 = make_row("user2", "eng", "Doc 3");
         assert!(!node.evaluate(&row3));
+    }
+
+    #[test]
+    fn test_policy_exists_fails_closed_without_context() {
+        let session = Session::new("user1");
+        let policy = PolicyExpr::Exists {
+            table: "memberships".into(),
+            condition: Box::new(PolicyExpr::True),
+        };
+        let node = PolicyFilterNode::new(
+            test_descriptor(),
+            policy,
+            session,
+            test_schema(),
+            "documents",
+        );
+
+        let row = make_row("user1", "eng", "Doc 1");
+        assert!(!node.evaluate(&row));
+    }
+
+    #[test]
+    fn test_policy_exists_registers_dependency_table() {
+        let session = Session::new("user1");
+        let policy = PolicyExpr::Exists {
+            table: "memberships".into(),
+            condition: Box::new(PolicyExpr::True),
+        };
+        let node = PolicyFilterNode::new(
+            test_descriptor(),
+            policy,
+            session,
+            test_schema(),
+            "documents",
+        );
+
+        assert!(node.has_inherits());
+        assert!(node.inherits_tables().contains("memberships"));
     }
 }

--- a/crates/groove/src/query_manager/policy.rs
+++ b/crates/groove/src/query_manager/policy.rs
@@ -30,6 +30,9 @@ pub enum PolicyValue {
     SessionRef(Vec<String>),
 }
 
+/// Reserved session path prefix used to encode outer-row references in correlated EXISTS clauses.
+pub const OUTER_ROW_SESSION_PREFIX: &str = "__jazz_outer_row";
+
 /// Database operation type for policy evaluation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Operation {
@@ -499,6 +502,101 @@ pub fn evaluate_cmp(
     }
 }
 
+/// Bind outer-row references encoded as `@session.__jazz_outer_row.<column>` to literals.
+///
+/// Returns `None` if a referenced outer column cannot be resolved.
+pub fn bind_outer_row_refs(
+    expr: &PolicyExpr,
+    outer_content: &[u8],
+    outer_descriptor: &RowDescriptor,
+) -> Option<PolicyExpr> {
+    match expr {
+        PolicyExpr::Cmp { column, op, value } => {
+            let bound_value = match value {
+                PolicyValue::Literal(v) => PolicyValue::Literal(v.clone()),
+                PolicyValue::SessionRef(path) => {
+                    if let Some(outer_col) = outer_row_ref_column(path) {
+                        let col_index = outer_descriptor.column_index(outer_col)?;
+                        let resolved =
+                            decode_column(outer_descriptor, outer_content, col_index).ok()?;
+                        PolicyValue::Literal(resolved)
+                    } else {
+                        PolicyValue::SessionRef(path.clone())
+                    }
+                }
+            };
+
+            Some(PolicyExpr::Cmp {
+                column: column.clone(),
+                op: op.clone(),
+                value: bound_value,
+            })
+        }
+        PolicyExpr::IsNull { column } => Some(PolicyExpr::IsNull {
+            column: column.clone(),
+        }),
+        PolicyExpr::IsNotNull { column } => Some(PolicyExpr::IsNotNull {
+            column: column.clone(),
+        }),
+        PolicyExpr::In {
+            column,
+            session_path,
+        } => {
+            if outer_row_ref_column(session_path).is_some() {
+                return None;
+            }
+            Some(PolicyExpr::In {
+                column: column.clone(),
+                session_path: session_path.clone(),
+            })
+        }
+        PolicyExpr::Exists { table, condition } => Some(PolicyExpr::Exists {
+            table: table.clone(),
+            condition: Box::new(bind_outer_row_refs(
+                condition,
+                outer_content,
+                outer_descriptor,
+            )?),
+        }),
+        PolicyExpr::Inherits {
+            operation,
+            via_column,
+        } => Some(PolicyExpr::Inherits {
+            operation: *operation,
+            via_column: via_column.clone(),
+        }),
+        PolicyExpr::And(exprs) => Some(PolicyExpr::And(
+            exprs
+                .iter()
+                .map(|expr| bind_outer_row_refs(expr, outer_content, outer_descriptor))
+                .collect::<Option<Vec<_>>>()?,
+        )),
+        PolicyExpr::Or(exprs) => Some(PolicyExpr::Or(
+            exprs
+                .iter()
+                .map(|expr| bind_outer_row_refs(expr, outer_content, outer_descriptor))
+                .collect::<Option<Vec<_>>>()?,
+        )),
+        PolicyExpr::Not(expr) => Some(PolicyExpr::Not(Box::new(bind_outer_row_refs(
+            expr,
+            outer_content,
+            outer_descriptor,
+        )?))),
+        PolicyExpr::True => Some(PolicyExpr::True),
+        PolicyExpr::False => Some(PolicyExpr::False),
+    }
+}
+
+fn outer_row_ref_column(path: &[String]) -> Option<&str> {
+    if path.len() != 2 {
+        return None;
+    }
+    if path[0] != OUTER_ROW_SESSION_PREFIX {
+        return None;
+    }
+    Some(path[1].as_str())
+}
+
 /// Evaluate an IN expression. Public for use by PolicyFilterNode.
 pub fn evaluate_in(
     column: &str,
@@ -782,9 +880,14 @@ fn evaluate_simple_recursive(
         }),
 
         PolicyExpr::Exists { table, condition } => {
+            let bound = match bind_outer_row_refs(condition, content, descriptor) {
+                Some(expr) => expr,
+                None => return SimpleEvalResult::fail(),
+            };
+
             SimpleEvalResult::with_complex(ComplexClause::Exists {
                 table: table.clone(),
-                condition: condition.clone(),
+                condition: Box::new(bound),
             })
         }
     }
@@ -856,6 +959,70 @@ mod tests {
 
         let or_expr = PolicyExpr::or(vec![PolicyExpr::True, PolicyExpr::False]);
         assert!(matches!(or_expr, PolicyExpr::Or(v) if v.len() == 2));
+    }
+
+    #[test]
+    fn test_exists_outer_row_refs_are_bound_to_literals() {
+        let descriptor = RowDescriptor::new(vec![
+            ColumnDescriptor::new("id", ColumnType::Text),
+            ColumnDescriptor::new("owner_id", ColumnType::Text),
+        ]);
+        let content = encode_row(
+            &descriptor,
+            &[Value::Text("todo-1".into()), Value::Text("user-1".into())],
+        )
+        .unwrap();
+        let session = Session::new("user-1");
+
+        let expr = PolicyExpr::Exists {
+            table: "todo_shares".into(),
+            condition: Box::new(PolicyExpr::Cmp {
+                column: "todo_id".into(),
+                op: CmpOp::Eq,
+                value: PolicyValue::SessionRef(vec![OUTER_ROW_SESSION_PREFIX.into(), "id".into()]),
+            }),
+        };
+
+        let result = evaluate_simple_parts(&expr, &content, &descriptor, &session);
+        assert!(result.passed);
+        assert_eq!(result.complex_clauses.len(), 1);
+
+        match &result.complex_clauses[0] {
+            ComplexClause::Exists { table, condition } => {
+                assert_eq!(table, "todo_shares");
+                assert!(matches!(
+                    condition.as_ref(),
+                    PolicyExpr::Cmp {
+                        column,
+                        op: CmpOp::Eq,
+                        value: PolicyValue::Literal(Value::Text(value))
+                    } if column == "todo_id" && value == "todo-1"
+                ));
+            }
+            _ => panic!("expected EXISTS complex clause"),
+        }
+    }
+
+    #[test]
+    fn test_exists_outer_row_ref_to_missing_column_fails() {
+        let descriptor = RowDescriptor::new(vec![ColumnDescriptor::new("id", ColumnType::Text)]);
+        let content = encode_row(&descriptor, &[Value::Text("todo-1".into())]).unwrap();
+        let session = Session::new("user-1");
+
+        let expr = PolicyExpr::Exists {
+            table: "todo_shares".into(),
+            condition: Box::new(PolicyExpr::Cmp {
+                column: "todo_id".into(),
+                op: CmpOp::Eq,
+                value: PolicyValue::SessionRef(vec![
+                    OUTER_ROW_SESSION_PREFIX.into(),
+                    "missing_col".into(),
+                ]),
+            }),
+        };
+
+        let result = evaluate_simple_parts(&expr, &content, &descriptor, &session);
+        assert!(!result.passed);
     }
 
     // ========================================================================

--- a/crates/groove/src/query_manager/server_queries.rs
+++ b/crates/groove/src/query_manager/server_queries.rs
@@ -663,7 +663,7 @@ impl QueryManager {
                     to_approve.push(*pending_id);
                 } else {
                     let reason = format!(
-                        "{:?} denied by policy on table {} (INHERITS check failed)",
+                        "{:?} denied by policy on table {} (complex policy check failed)",
                         state.pending_check.operation, state.table.0
                     );
                     to_reject.push((*pending_id, reason));

--- a/docs/content/docs/migrations.mdx
+++ b/docs/content/docs/migrations.mdx
@@ -44,12 +44,21 @@ For SQL migrations, keep explicit forward/backward files and edit each direction
     </include>
   </Tab>
   <Tab value="SQL">
+    Forward:
     <include
       cwd
       lang="sql"
       meta='title="examples/docs/todo-server-rs/schema/migration_v1_v2_fwd_455a1f10a158_357c464c4c43.sql"'
     >
       ../examples/docs/todo-server-rs/schema/migration_v1_v2_fwd_455a1f10a158_357c464c4c43.sql
+    </include>
+    Backward:
+    <include
+      cwd
+      lang="sql"
+      meta='title="examples/docs/todo-server-rs/schema/migration_v1_v2_bwd_455a1f10a158_357c464c4c43.sql"'
+    >
+      ../examples/docs/todo-server-rs/schema/migration_v1_v2_bwd_455a1f10a158_357c464c4c43.sql
     </include>
   </Tab>
 </Tabs>
@@ -67,12 +76,21 @@ For SQL migrations, keep explicit forward/backward files and edit each direction
     </include>
   </Tab>
   <Tab value="SQL">
+    Forward:
     <include
       cwd
       lang="sql"
       meta='title="examples/docs/todo-server-rs/schema/migration_v1_v2_customized_example_fwd.sql"'
     >
       ../examples/docs/todo-server-rs/schema/migration_v1_v2_customized_example_fwd.sql
+    </include>
+    Backward:
+    <include
+      cwd
+      lang="sql"
+      meta='title="examples/docs/todo-server-rs/schema/migration_v1_v2_bwd_455a1f10a158_357c464c4c43.sql"'
+    >
+      ../examples/docs/todo-server-rs/schema/migration_v1_v2_bwd_455a1f10a158_357c464c4c43.sql
     </include>
   </Tab>
 </Tabs>

--- a/docs/content/docs/permissions.mdx
+++ b/docs/content/docs/permissions.mdx
@@ -1,16 +1,16 @@
 ---
 title: Permissions
-description: Fast RLS (ReBAC), simple policies, and INHERITS policies.
+description: Fast RLS (ReBAC), simple policies, and inherited access policies.
 ---
 
 ## Schema Policy Syntax
 
-Define policies directly in your schema, in either TypeScript DSL or SQL.
+Define policies in `permissions.ts` for TypeScript DSL apps, or directly in SQL.
 
 <Tabs groupId="jazz-schema-format" items={["TypeScript", "SQL"]} persist>
   <Tab value="TypeScript">
     <include cwd lang="ts">
-      ../examples/docs/todo-server-ts/schema/current.ts
+      ../examples/docs/todo-server-ts/schema/permissions.ts
     </include>
   </Tab>
   <Tab value="SQL">
@@ -44,7 +44,7 @@ Jazz permissions use relationship-based policy evaluation with requester session
 <Tabs groupId="jazz-environment" items={["TypeScript", "Rust"]} persist>
   <Tab value="TypeScript">
     <include cwd lang="ts">
-      ../examples/docs/todo-server-ts/src/request-context.ts#permissions-simple-ts
+      ../examples/docs/todo-server-ts/schema/permissions.ts#permissions-simple-ts
     </include>
   </Tab>
   <Tab value="Rust">
@@ -54,12 +54,14 @@ Jazz permissions use relationship-based policy evaluation with requester session
   </Tab>
 </Tabs>
 
-## INHERITS Policies
+## Inherited Access Policies (`allowedTo.*`)
+
+TypeScript DSL exposes inherited access via `allowedTo.read/insert/update/delete(...)`, which compiles to `INHERITS` policy expressions.
 
 <Tabs groupId="jazz-environment" items={["TypeScript", "Rust"]} persist>
   <Tab value="TypeScript">
     <include cwd lang="ts">
-      ../examples/docs/todo-server-ts/src/request-context.ts#permissions-inherits-ts
+      ../examples/docs/todo-server-ts/schema/permissions.ts#permissions-allowed-to-ts
     </include>
   </Tab>
   <Tab value="Rust">

--- a/docs/content/docs/permissions.mdx
+++ b/docs/content/docs/permissions.mdx
@@ -5,13 +5,22 @@ description: Fast RLS (ReBAC), simple policies, and inherited access policies.
 
 ## Schema Policy Syntax
 
-Define policies in `permissions.ts` for TypeScript DSL apps, or directly in SQL.
+Define policies in `schema/permissions.ts` for TypeScript DSL apps, or directly in SQL.
 
 <Tabs groupId="jazz-schema-format" items={["TypeScript", "SQL"]} persist>
   <Tab value="TypeScript">
+    Assuming the following schema:
+
+    <include cwd lang="ts">
+      ../examples/docs/todo-server-ts/src/permissions-snippets.ts#permissions-schema-ts
+    </include>
+
+    We can define permissions in a file called `schema/permissions.ts`:
+
     <include cwd lang="ts">
       ../examples/docs/todo-server-ts/schema/permissions.ts
     </include>
+
   </Tab>
   <Tab value="SQL">
     <include cwd lang="sql">
@@ -22,9 +31,43 @@ Define policies in `permissions.ts` for TypeScript DSL apps, or directly in SQL.
 
 Apps that do not need user-scoped filtering can still define explicit allow-all policies (`policy.allow()` / `USING (TRUE)`).
 
-## Fast RLS (ReBAC)
+## Simple Policies
+
+<Tabs groupId="jazz-schema-format" items={["TypeScript", "SQL"]} persist>
+  <Tab value="TypeScript">
+    <include cwd lang="ts">
+      ../examples/docs/todo-server-ts/src/permissions-snippets.ts#permissions-simple-ts
+    </include>
+  </Tab>
+  <Tab value="SQL">
+    <include cwd lang="sql">
+      ../examples/docs/todo-server-ts/docs/permissions-snippets.sql#permissions-simple-sql
+    </include>
+  </Tab>
+</Tabs>
+
+## Inherited Access Policies (`allowedTo.*`)
+
+TypeScript DSL exposes inherited access via `allowedTo.read/insert/update/delete(...)`, which compiles to `INHERITS` policy expressions.
+
+<Tabs groupId="jazz-schema-format" items={["TypeScript", "SQL"]} persist>
+  <Tab value="TypeScript">
+    <include cwd lang="ts">
+      ../examples/docs/todo-server-ts/src/permissions-snippets.ts#permissions-allowed-to-ts
+    </include>
+  </Tab>
+  <Tab value="SQL">
+    <include cwd lang="sql">
+      ../examples/docs/todo-server-ts/docs/permissions-snippets.sql#permissions-inherits-sql
+    </include>
+  </Tab>
+</Tabs>
+
+## Policy enforcement and request context
 
 Jazz permissions use relationship-based policy evaluation with requester session context.
+Backend endpoints should scope a client/session per request before reads and writes.
+Frontend clients are evaluated with the auth/session identity used to initialize context at the server boundary.
 
 <Tabs groupId="jazz-environment" items={["TypeScript", "Rust"]} persist>
   <Tab value="TypeScript">
@@ -39,39 +82,4 @@ Jazz permissions use relationship-based policy evaluation with requester session
   </Tab>
 </Tabs>
 
-## Simple Policies
-
-<Tabs groupId="jazz-environment" items={["TypeScript", "Rust"]} persist>
-  <Tab value="TypeScript">
-    <include cwd lang="ts">
-      ../examples/docs/todo-server-ts/schema/permissions.ts#permissions-simple-ts
-    </include>
-  </Tab>
-  <Tab value="Rust">
-    <include cwd lang="rs">
-      ../examples/docs/todo-server-rs/src/docs_snippets.rs#permissions-simple-rust
-    </include>
-  </Tab>
-</Tabs>
-
-## Inherited Access Policies (`allowedTo.*`)
-
-TypeScript DSL exposes inherited access via `allowedTo.read/insert/update/delete(...)`, which compiles to `INHERITS` policy expressions.
-
-<Tabs groupId="jazz-environment" items={["TypeScript", "Rust"]} persist>
-  <Tab value="TypeScript">
-    <include cwd lang="ts">
-      ../examples/docs/todo-server-ts/schema/permissions.ts#permissions-allowed-to-ts
-    </include>
-  </Tab>
-  <Tab value="Rust">
-    <include cwd lang="rs">
-      ../examples/docs/todo-server-rs/src/docs_snippets.rs#permissions-inherits-rust
-    </include>
-  </Tab>
-</Tabs>
-
-## Backend Request Context Reminder
-
-Backend endpoints must extract requester identity and use a user-scoped client/session before reads and writes.
 See [Setup](/docs/setup) for context setup details.

--- a/examples/docs/todo-server-ts/docs/permissions-snippets.sql
+++ b/examples/docs/todo-server-ts/docs/permissions-snippets.sql
@@ -1,0 +1,11 @@
+-- #region permissions-simple-sql
+CREATE POLICY todos_select_policy ON todos FOR SELECT USING (owner_id = @session.user_id);
+CREATE POLICY todos_insert_policy ON todos FOR INSERT WITH CHECK (owner_id = @session.user_id);
+CREATE POLICY todos_update_policy ON todos FOR UPDATE USING ((owner_id = @session.user_id) AND (done = FALSE)) WITH CHECK (owner_id = @session.user_id);
+CREATE POLICY todos_delete_policy ON todos FOR DELETE USING (owner_id = @session.user_id);
+-- #endregion permissions-simple-sql
+
+-- #region permissions-inherits-sql
+CREATE POLICY todos_select_policy ON todos FOR SELECT USING ((done = FALSE) OR (INHERITS SELECT VIA project));
+CREATE POLICY todos_update_policy ON todos FOR UPDATE USING ((INHERITS UPDATE VIA project) AND (done = FALSE)) WITH CHECK (INHERITS UPDATE VIA project);
+-- #endregion permissions-inherits-sql

--- a/examples/docs/todo-server-ts/schema/app.ts
+++ b/examples/docs/todo-server-ts/schema/app.ts
@@ -156,13 +156,35 @@ export const wasmSchema: WasmSchema = {
       policies: {
         select: {
           using: {
-            type: "Cmp",
-            column: "owner_id",
-            op: "Eq",
-            value: {
-              type: "SessionRef",
-              path: ["user_id"],
-            },
+            type: "Or",
+            exprs: [
+              {
+                type: "Cmp",
+                column: "owner_id",
+                op: "Eq",
+                value: {
+                  type: "SessionRef",
+                  path: ["user_id"],
+                },
+              },
+              {
+                type: "Cmp",
+                column: "done",
+                op: "Eq",
+                value: {
+                  type: "Literal",
+                  value: {
+                    type: "Boolean",
+                    value: false,
+                  },
+                },
+              },
+              {
+                type: "Inherits",
+                operation: "Select",
+                via_column: "project",
+              },
+            ],
           },
         },
         insert: {
@@ -178,22 +200,76 @@ export const wasmSchema: WasmSchema = {
         },
         update: {
           using: {
-            type: "Cmp",
-            column: "owner_id",
-            op: "Eq",
-            value: {
-              type: "SessionRef",
-              path: ["user_id"],
-            },
+            type: "Or",
+            exprs: [
+              {
+                type: "And",
+                exprs: [
+                  {
+                    type: "Cmp",
+                    column: "owner_id",
+                    op: "Eq",
+                    value: {
+                      type: "SessionRef",
+                      path: ["user_id"],
+                    },
+                  },
+                  {
+                    type: "Cmp",
+                    column: "done",
+                    op: "Eq",
+                    value: {
+                      type: "Literal",
+                      value: {
+                        type: "Boolean",
+                        value: false,
+                      },
+                    },
+                  },
+                ],
+              },
+              {
+                type: "And",
+                exprs: [
+                  {
+                    type: "Inherits",
+                    operation: "Update",
+                    via_column: "project",
+                  },
+                  {
+                    type: "Cmp",
+                    column: "done",
+                    op: "Eq",
+                    value: {
+                      type: "Literal",
+                      value: {
+                        type: "Boolean",
+                        value: false,
+                      },
+                    },
+                  },
+                ],
+              },
+            ],
           },
           with_check: {
-            type: "Cmp",
-            column: "owner_id",
-            op: "Eq",
-            value: {
-              type: "SessionRef",
-              path: ["user_id"],
-            },
+            type: "Or",
+            exprs: [
+              {
+                type: "Cmp",
+                column: "owner_id",
+                op: "Eq",
+                value: {
+                  type: "SessionRef",
+                  path: ["user_id"],
+                },
+              },
+              {
+                type: "Inherits",
+                operation: "Update",
+                via_column: "project",
+              },
+            ],
           },
         },
         delete: {

--- a/examples/docs/todo-server-ts/schema/current.sql
+++ b/examples/docs/todo-server-ts/schema/current.sql
@@ -10,7 +10,7 @@ CREATE TABLE todos (
     project UUID REFERENCES projects,
     owner_id TEXT NOT NULL
 );
-CREATE POLICY todos_select_policy ON todos FOR SELECT USING (owner_id = @session.user_id);
+CREATE POLICY todos_select_policy ON todos FOR SELECT USING ((owner_id = @session.user_id) OR (done = FALSE) OR (INHERITS SELECT VIA project));
 CREATE POLICY todos_insert_policy ON todos FOR INSERT WITH CHECK (owner_id = @session.user_id);
-CREATE POLICY todos_update_policy ON todos FOR UPDATE USING (owner_id = @session.user_id) WITH CHECK (owner_id = @session.user_id);
+CREATE POLICY todos_update_policy ON todos FOR UPDATE USING (((owner_id = @session.user_id) AND (done = FALSE)) OR ((INHERITS UPDATE VIA project) AND (done = FALSE))) WITH CHECK ((owner_id = @session.user_id) OR (INHERITS UPDATE VIA project));
 CREATE POLICY todos_delete_policy ON todos FOR DELETE USING (owner_id = @session.user_id);

--- a/examples/docs/todo-server-ts/schema/current.ts
+++ b/examples/docs/todo-server-ts/schema/current.ts
@@ -1,28 +1,14 @@
-import { table, col, policy } from "jazz-tools";
+import { table, col } from "jazz-tools";
 
 table("projects", {
   name: col.string(),
 });
 
-table(
-  "todos",
-  {
-    title: col.string(),
-    done: col.boolean(),
-    description: col.string().optional(),
-    parent: col.ref("todos").optional(),
-    project: col.ref("projects").optional(),
-    owner_id: col.string(),
-  },
-  {
-    permissions: {
-      select: policy.eqSession("owner_id", "user_id"),
-      insert: policy.eqSession("owner_id", "user_id"),
-      update: {
-        using: policy.eqSession("owner_id", "user_id"),
-        withCheck: policy.eqSession("owner_id", "user_id"),
-      },
-      delete: policy.eqSession("owner_id", "user_id"),
-    },
-  },
-);
+table("todos", {
+  title: col.string(),
+  done: col.boolean(),
+  description: col.string().optional(),
+  parent: col.ref("todos").optional(),
+  project: col.ref("projects").optional(),
+  owner_id: col.string(),
+});

--- a/examples/docs/todo-server-ts/schema/permissions.test.ts
+++ b/examples/docs/todo-server-ts/schema/permissions.test.ts
@@ -1,0 +1,10 @@
+/**
+ * Permissions test starter.
+ *
+ * Suggested shape:
+ * - boot a disposable Jazz server/runtime for the test
+ * - seed synthetic rows for policy edge-cases
+ * - mint scoped clients with representative JWT claims
+ * - assert allow/deny behavior for queries and mutations
+ */
+export {};

--- a/examples/docs/todo-server-ts/schema/permissions.ts
+++ b/examples/docs/todo-server-ts/schema/permissions.ts
@@ -1,11 +1,20 @@
 import { definePermissions } from "jazz-tools/permissions";
 import { app } from "./app";
 
-export default definePermissions(app, ({ policy, session }) => [
+export default definePermissions(app, ({ policy, either, both, allowedTo, session }) => [
+  // #region permissions-simple-ts
   policy.todos.allowRead.where({ owner_id: session.user_id }),
   policy.todos.allowInsert.where({ owner_id: session.user_id }),
   policy.todos.allowUpdate
-    .whereOld({ owner_id: session.user_id })
+    .whereOld(both({ owner_id: session.user_id }).and({ done: false }))
     .whereNew({ owner_id: session.user_id }),
   policy.todos.allowDelete.where({ owner_id: session.user_id }),
+  // #endregion permissions-simple-ts
+
+  // #region permissions-allowed-to-ts
+  policy.todos.allowRead.where(either({ done: false }).or(allowedTo.read("project"))),
+  policy.todos.allowUpdate
+    .whereOld(both(allowedTo.update("project")).and({ done: false }))
+    .whereNew(allowedTo.update("project")),
+  // #endregion permissions-allowed-to-ts
 ]);

--- a/examples/docs/todo-server-ts/schema/permissions.ts
+++ b/examples/docs/todo-server-ts/schema/permissions.ts
@@ -1,20 +1,16 @@
 import { definePermissions } from "jazz-tools/permissions";
-import { app } from "./app";
+import { app } from "./app.js";
 
 export default definePermissions(app, ({ policy, either, both, allowedTo, session }) => [
-  // #region permissions-simple-ts
   policy.todos.allowRead.where({ owner_id: session.user_id }),
   policy.todos.allowInsert.where({ owner_id: session.user_id }),
   policy.todos.allowUpdate
     .whereOld(both({ owner_id: session.user_id }).and({ done: false }))
     .whereNew({ owner_id: session.user_id }),
   policy.todos.allowDelete.where({ owner_id: session.user_id }),
-  // #endregion permissions-simple-ts
 
-  // #region permissions-allowed-to-ts
   policy.todos.allowRead.where(either({ done: false }).or(allowedTo.read("project"))),
   policy.todos.allowUpdate
     .whereOld(both(allowedTo.update("project")).and({ done: false }))
     .whereNew(allowedTo.update("project")),
-  // #endregion permissions-allowed-to-ts
 ]);

--- a/examples/docs/todo-server-ts/schema/permissions.ts
+++ b/examples/docs/todo-server-ts/schema/permissions.ts
@@ -1,0 +1,11 @@
+import { definePermissions } from "jazz-tools/permissions";
+import { app } from "./app";
+
+export default definePermissions(app, ({ policy, session }) => [
+  policy.todos.allowRead.where({ owner_id: session.user_id }),
+  policy.todos.allowInsert.where({ owner_id: session.user_id }),
+  policy.todos.allowUpdate
+    .whereOld({ owner_id: session.user_id })
+    .whereNew({ owner_id: session.user_id }),
+  policy.todos.allowDelete.where({ owner_id: session.user_id }),
+]);

--- a/examples/docs/todo-server-ts/src/permissions-snippets.ts
+++ b/examples/docs/todo-server-ts/src/permissions-snippets.ts
@@ -1,0 +1,43 @@
+import { col, table } from "jazz-tools";
+import { definePermissions } from "jazz-tools/permissions";
+import { app } from "../schema/app.js";
+
+// #region permissions-schema-ts
+table("projects", {
+  name: col.string(),
+  owner_id: col.string(),
+});
+
+table("todos", {
+  title: col.string(),
+  done: col.boolean(),
+  project: col.ref("projects").optional(),
+  owner_id: col.string(),
+});
+
+table("todoShares", {
+  todo: col.ref("todos"),
+  user_id: col.string(),
+  can_read: col.boolean(),
+});
+// #endregion permissions-schema-ts
+
+// #region permissions-simple-ts
+definePermissions(app, ({ policy, both, session }) => [
+  policy.todos.allowRead.where({ owner_id: session.user_id }),
+  policy.todos.allowInsert.where({ owner_id: session.user_id }),
+  policy.todos.allowUpdate
+    .whereOld(both({ owner_id: session.user_id }).and({ done: false }))
+    .whereNew({ owner_id: session.user_id }),
+  policy.todos.allowDelete.where({ owner_id: session.user_id }),
+]);
+// #endregion permissions-simple-ts
+
+// #region permissions-allowed-to-ts
+definePermissions(app, ({ policy, either, both, allowedTo }) => [
+  policy.todos.allowRead.where(either({ done: false }).or(allowedTo.read("project"))),
+  policy.todos.allowUpdate
+    .whereOld(both(allowedTo.update("project")).and({ done: false }))
+    .whereNew(allowedTo.update("project")),
+]);
+// #endregion permissions-allowed-to-ts

--- a/packages/jazz-tools/package.json
+++ b/packages/jazz-tools/package.json
@@ -30,6 +30,10 @@
       "types": "./dist/permissions/index.d.ts",
       "default": "./dist/permissions/index.js"
     },
+    "./testing": {
+      "types": "./dist/testing/index.d.ts",
+      "default": "./dist/testing/index.js"
+    },
     "./package.json": "./package.json"
   },
   "publishConfig": {

--- a/packages/jazz-tools/package.json
+++ b/packages/jazz-tools/package.json
@@ -26,6 +26,10 @@
       "types": "./dist/react/index.d.ts",
       "default": "./dist/react/index.js"
     },
+    "./permissions": {
+      "types": "./dist/permissions/index.d.ts",
+      "default": "./dist/permissions/index.js"
+    },
     "./package.json": "./package.json"
   },
   "publishConfig": {

--- a/packages/jazz-tools/src/cli.test.ts
+++ b/packages/jazz-tools/src/cli.test.ts
@@ -72,6 +72,43 @@ export default definePermissions(app, ({ policy, session }) => [
 `;
 }
 
+function permissionsSchemaUnknownTable(): string {
+  return `
+export default {
+  ghosts: {
+    select: {
+      using: { type: "True" },
+    },
+  },
+};
+`;
+}
+
+function permissionsSchemaMissingExport(): string {
+  return `
+export const nope = 42;
+`;
+}
+
+function permissionsSchemaNamedExport(): string {
+  return `
+import { definePermissions } from ${JSON.stringify(permissionsDslPath)};
+import { app } from "./app";
+
+export const permissions = definePermissions(app, ({ policy, session }) => [
+  policy.todos.allowRead.where({ owner_id: session.user_id }),
+]);
+`;
+}
+
+function permissionsSchemaInvalidShape(): string {
+  return `
+export default {
+  todos: 123,
+};
+`;
+}
+
 describe("cli build permissions generation", () => {
   it("loads permissions.ts, merges policies, and creates permissions.test.ts stub", async () => {
     const { schemaDir, jazzBin } = await createWorkspace();
@@ -113,5 +150,44 @@ describe("cli build permissions generation", () => {
 
     const permissionsTest = await readFile(join(schemaDir, "permissions.test.ts"), "utf8");
     expect(permissionsTest).toBe("// keep-existing-test\n");
+  });
+
+  it("fails when permissions.ts has no default/permissions export", async () => {
+    const { schemaDir, jazzBin } = await createWorkspace();
+    await writeFile(join(schemaDir, "current.ts"), currentSchemaWithoutInlinePermissions());
+    await writeFile(join(schemaDir, "permissions.ts"), permissionsSchemaMissingExport());
+
+    await expect(build({ schemaDir, jazzBin })).rejects.toThrow(/missing permissions export/i);
+  });
+
+  it("fails when permissions.ts references unknown tables", async () => {
+    const { schemaDir, jazzBin } = await createWorkspace();
+    await writeFile(join(schemaDir, "current.ts"), currentSchemaWithoutInlinePermissions());
+    await writeFile(join(schemaDir, "permissions.ts"), permissionsSchemaUnknownTable());
+
+    await expect(build({ schemaDir, jazzBin })).rejects.toThrow(
+      /permissions\.ts defines permissions for unknown table\(s\): ghosts/i,
+    );
+  });
+
+  it("accepts named permissions export for transitional ergonomics", async () => {
+    const { schemaDir, jazzBin } = await createWorkspace();
+    await writeFile(join(schemaDir, "current.ts"), currentSchemaWithoutInlinePermissions());
+    await writeFile(join(schemaDir, "permissions.ts"), permissionsSchemaNamedExport());
+
+    await build({ schemaDir, jazzBin });
+
+    const sql = await readFile(join(schemaDir, "current.sql"), "utf8");
+    expect(sql).toContain(
+      "CREATE POLICY todos_select_policy ON todos FOR SELECT USING (owner_id = @session.user_id);",
+    );
+  });
+
+  it("fails when permissions.ts export shape is invalid", async () => {
+    const { schemaDir, jazzBin } = await createWorkspace();
+    await writeFile(join(schemaDir, "current.ts"), currentSchemaWithoutInlinePermissions());
+    await writeFile(join(schemaDir, "permissions.ts"), permissionsSchemaInvalidShape());
+
+    await expect(build({ schemaDir, jazzBin })).rejects.toThrow(/invalid permissions export/i);
   });
 });

--- a/packages/jazz-tools/src/cli.test.ts
+++ b/packages/jazz-tools/src/cli.test.ts
@@ -1,0 +1,117 @@
+import { chmod, mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import { build } from "./cli.js";
+
+const dslPath = fileURLToPath(new URL("./dsl.ts", import.meta.url));
+const permissionsDslPath = fileURLToPath(new URL("./permissions/index.ts", import.meta.url));
+
+const tempRoots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+async function createWorkspace(): Promise<{ root: string; schemaDir: string; jazzBin: string }> {
+  const root = await mkdtemp(join(tmpdir(), "jazz-tools-cli-test-"));
+  tempRoots.push(root);
+  const schemaDir = join(root, "schema");
+  await mkdir(schemaDir, { recursive: true });
+
+  const jazzBin = join(root, "fake-jazz");
+  await writeFile(jazzBin, "#!/bin/sh\nexit 0\n");
+  await chmod(jazzBin, 0o755);
+
+  return { root, schemaDir, jazzBin };
+}
+
+function currentSchemaWithoutInlinePermissions(): string {
+  return `
+import { table, col } from ${JSON.stringify(dslPath)};
+
+table("projects", {
+  name: col.string(),
+});
+
+table("todos", {
+  title: col.string(),
+  owner_id: col.string(),
+});
+`;
+}
+
+function currentSchemaWithInlinePermissions(): string {
+  return `
+import { table, col, policy } from ${JSON.stringify(dslPath)};
+
+table("projects", {
+  name: col.string(),
+});
+
+table("todos", {
+  title: col.string(),
+  owner_id: col.string(),
+}, {
+  permissions: {
+    select: policy.eqSession("owner_id", "user_id"),
+  },
+});
+`;
+}
+
+function permissionsSchema(): string {
+  return `
+import { definePermissions } from ${JSON.stringify(permissionsDslPath)};
+import { app } from "./app";
+
+export default definePermissions(app, ({ policy, session }) => [
+  policy.todos.allowRead.where({ owner_id: session.user_id }),
+]);
+`;
+}
+
+describe("cli build permissions generation", () => {
+  it("loads permissions.ts, merges policies, and creates permissions.test.ts stub", async () => {
+    const { schemaDir, jazzBin } = await createWorkspace();
+    await writeFile(join(schemaDir, "current.ts"), currentSchemaWithoutInlinePermissions());
+    await writeFile(join(schemaDir, "permissions.ts"), permissionsSchema());
+
+    await build({ schemaDir, jazzBin });
+
+    const sql = await readFile(join(schemaDir, "current.sql"), "utf8");
+    const appTs = await readFile(join(schemaDir, "app.ts"), "utf8");
+    const permissionsTest = await readFile(join(schemaDir, "permissions.test.ts"), "utf8");
+
+    expect(sql).toContain(
+      "CREATE POLICY todos_select_policy ON todos FOR SELECT USING (owner_id = @session.user_id);",
+    );
+    expect(appTs).toContain('"policies"');
+    expect(appTs).toContain('"type": "SessionRef"');
+    expect(appTs).toContain('"column": "owner_id"');
+    expect(permissionsTest).toContain("Permissions test starter.");
+  });
+
+  it("fails when inline table permissions and permissions.ts both define the same table", async () => {
+    const { schemaDir, jazzBin } = await createWorkspace();
+    await writeFile(join(schemaDir, "current.ts"), currentSchemaWithInlinePermissions());
+    await writeFile(join(schemaDir, "permissions.ts"), permissionsSchema());
+
+    await expect(build({ schemaDir, jazzBin })).rejects.toThrow(
+      /defines permissions in both current.ts and permissions.ts/i,
+    );
+  });
+
+  it("does not overwrite an existing permissions.test.ts file", async () => {
+    const { schemaDir, jazzBin } = await createWorkspace();
+    await writeFile(join(schemaDir, "current.ts"), currentSchemaWithoutInlinePermissions());
+    await writeFile(join(schemaDir, "permissions.ts"), permissionsSchema());
+    await writeFile(join(schemaDir, "permissions.test.ts"), "// keep-existing-test\n");
+
+    await build({ schemaDir, jazzBin });
+
+    const permissionsTest = await readFile(join(schemaDir, "permissions.test.ts"), "utf8");
+    expect(permissionsTest).toBe("// keep-existing-test\n");
+  });
+});

--- a/packages/jazz-tools/src/cli.ts
+++ b/packages/jazz-tools/src/cli.ts
@@ -10,7 +10,7 @@ import { register } from "tsx/esm/api";
 import { schemaToSql, lensToSql } from "./sql-gen.js";
 import { getCollectedSchema, getCollectedMigration, resetCollectedState } from "./dsl.js";
 import { generateClient } from "./codegen/index.js";
-import type { Lens, Schema, TablePolicies } from "./schema.js";
+import type { Lens, Schema, TablePolicies, OperationPolicy } from "./schema.js";
 
 // Allow loading `.ts` schema files when invoked via `node dist/cli.js`.
 register();
@@ -124,8 +124,26 @@ async function generateSqlForMigrationFile(tsFile: string): Promise<void> {
   console.log(`Generated: ${basename(bwdFile)}`);
 }
 
+function isOperationPolicyLike(input: unknown): input is OperationPolicy {
+  if (typeof input !== "object" || input === null || Array.isArray(input)) {
+    return false;
+  }
+  const opPolicy = input as Record<string, unknown>;
+  return Object.keys(opPolicy).every((key) => key === "using" || key === "with_check");
+}
+
 function isTablePoliciesLike(input: unknown): input is TablePolicies {
-  return typeof input === "object" && input !== null;
+  if (typeof input !== "object" || input === null || Array.isArray(input)) {
+    return false;
+  }
+  const tablePolicy = input as Record<string, unknown>;
+  const validOperationKeys = ["select", "insert", "update", "delete"];
+  return Object.entries(tablePolicy).every(([key, value]) => {
+    if (!validOperationKeys.includes(key)) {
+      return false;
+    }
+    return isOperationPolicyLike(value);
+  });
 }
 
 function isPermissionsMap(input: unknown): input is Record<string, TablePolicies> {
@@ -135,14 +153,15 @@ function isPermissionsMap(input: unknown): input is Record<string, TablePolicies
   return Object.values(input).every((value) => isTablePoliciesLike(value));
 }
 
-async function loadPermissionsModule(
-  filePath: string,
-): Promise<Record<string, TablePolicies> | null> {
+async function loadPermissionsModule(filePath: string): Promise<Record<string, TablePolicies>> {
   const url = pathToFileURL(filePath).href + `?v=${++importCounter}`;
   const module = await import(url);
   const candidate = module.default ?? module.permissions ?? null;
   if (!candidate) {
-    return null;
+    throw new Error(
+      `Missing permissions export in ${basename(filePath)}. ` +
+        `Export default definePermissions(...) (or export const permissions = definePermissions(...)).`,
+    );
   }
   if (!isPermissionsMap(candidate)) {
     throw new Error(
@@ -156,6 +175,16 @@ function mergePermissionsIntoSchema(
   schema: Schema,
   compiledPermissions: Record<string, TablePolicies>,
 ): Schema {
+  const schemaTableNames = new Set(schema.tables.map((table) => table.name));
+  const unknownTables = Object.keys(compiledPermissions).filter(
+    (tableName) => !schemaTableNames.has(tableName),
+  );
+  if (unknownTables.length > 0) {
+    throw new Error(
+      `permissions.ts defines permissions for unknown table(s): ${unknownTables.join(", ")}.`,
+    );
+  }
+
   return {
     tables: schema.tables.map((table) => {
       const external = compiledPermissions[table.name];
@@ -316,9 +345,7 @@ export async function build(options: BuildOptions): Promise<void> {
   const permissionsFile = join(schemaDir, "permissions.ts");
   if (await pathExists(permissionsFile)) {
     const permissions = await loadPermissionsModule(permissionsFile);
-    if (permissions) {
-      schema = mergePermissionsIntoSchema(schema, permissions);
-    }
+    schema = mergePermissionsIntoSchema(schema, permissions);
   }
 
   await generateSqlForSchemaFile(schemaFile, schema);

--- a/packages/jazz-tools/src/cli.ts
+++ b/packages/jazz-tools/src/cli.ts
@@ -10,7 +10,7 @@ import { register } from "tsx/esm/api";
 import { schemaToSql, lensToSql } from "./sql-gen.js";
 import { getCollectedSchema, getCollectedMigration, resetCollectedState } from "./dsl.js";
 import { generateClient } from "./codegen/index.js";
-import type { Lens } from "./schema.js";
+import type { Lens, Schema, TablePolicies } from "./schema.js";
 
 // Allow loading `.ts` schema files when invoked via `node dist/cli.js`.
 register();
@@ -47,6 +47,11 @@ async function loadSchemaModule(filePath: string): Promise<void> {
   await import(url);
 }
 
+async function loadSchema(filePath: string): Promise<Schema> {
+  await loadSchemaModule(filePath);
+  return getCollectedSchema();
+}
+
 async function loadMigrationModule(filePath: string): Promise<Lens | null> {
   resetCollectedState();
   // Add cache-busting query param since Node.js caches dynamic imports
@@ -55,20 +60,14 @@ async function loadMigrationModule(filePath: string): Promise<Lens | null> {
   return getCollectedMigration();
 }
 
-async function generateSqlForSchemaFile(tsFile: string): Promise<void> {
-  await loadSchemaModule(tsFile);
-  const schema = getCollectedSchema();
+async function generateSqlForSchemaFile(tsFile: string, schema: Schema): Promise<void> {
   const sql = schemaToSql(schema);
   const sqlFile = tsFile.replace(/\.ts$/, ".sql");
   await writeFile(sqlFile, sql);
   console.log(`Generated: ${basename(sqlFile)}`);
 }
 
-async function generateAppTs(schemaDir: string): Promise<void> {
-  // Reload the schema since SQL generation consumed the collected state
-  const schemaFile = join(schemaDir, "current.ts");
-  await loadSchemaModule(schemaFile);
-  const schema = getCollectedSchema();
+async function generateAppTs(schemaDir: string, schema: Schema): Promise<void> {
   const output = generateClient(schema);
   const appTsPath = join(schemaDir, "app.ts");
   await writeFile(appTsPath, output);
@@ -125,6 +124,57 @@ async function generateSqlForMigrationFile(tsFile: string): Promise<void> {
   console.log(`Generated: ${basename(bwdFile)}`);
 }
 
+function isTablePoliciesLike(input: unknown): input is TablePolicies {
+  return typeof input === "object" && input !== null;
+}
+
+function isPermissionsMap(input: unknown): input is Record<string, TablePolicies> {
+  if (typeof input !== "object" || input === null) {
+    return false;
+  }
+  return Object.values(input).every((value) => isTablePoliciesLike(value));
+}
+
+async function loadPermissionsModule(
+  filePath: string,
+): Promise<Record<string, TablePolicies> | null> {
+  const url = pathToFileURL(filePath).href + `?v=${++importCounter}`;
+  const module = await import(url);
+  const candidate = module.default ?? module.permissions ?? null;
+  if (!candidate) {
+    return null;
+  }
+  if (!isPermissionsMap(candidate)) {
+    throw new Error(
+      `Invalid permissions export in ${basename(filePath)}. Expected default export from definePermissions(...).`,
+    );
+  }
+  return candidate;
+}
+
+function mergePermissionsIntoSchema(
+  schema: Schema,
+  compiledPermissions: Record<string, TablePolicies>,
+): Schema {
+  return {
+    tables: schema.tables.map((table) => {
+      const external = compiledPermissions[table.name];
+      if (!external) {
+        return table;
+      }
+      if (table.policies) {
+        throw new Error(
+          `Table "${table.name}" defines permissions in both current.ts and permissions.ts. Keep only one source.`,
+        );
+      }
+      return {
+        ...table,
+        policies: external,
+      };
+    }),
+  };
+}
+
 /**
  * Check if a path exists
  */
@@ -160,6 +210,33 @@ const findMonorepoJazzBinary = async (): Promise<string | null> => {
     currentDir = parentDir;
   }
 };
+
+async function ensurePermissionsTestStub(schemaDir: string): Promise<void> {
+  const permissionsFile = join(schemaDir, "permissions.ts");
+  if (!(await pathExists(permissionsFile))) {
+    return;
+  }
+
+  const testFile = join(schemaDir, "permissions.test.ts");
+  if (await pathExists(testFile)) {
+    return;
+  }
+
+  const template = `/**
+ * Permissions test starter.
+ *
+ * Suggested shape:
+ * - boot a disposable Jazz server/runtime for the test
+ * - seed synthetic rows for policy edge-cases
+ * - mint scoped clients with representative JWT claims
+ * - assert allow/deny behavior for queries and mutations
+ */
+export {};
+`;
+
+  await writeFile(testFile, template);
+  console.log(`Generated: permissions.test.ts`);
+}
 
 type JazzBuildResult = { type: "close"; code: number | null } | { type: "error"; error: Error };
 
@@ -221,16 +298,32 @@ async function build(options: BuildOptions): Promise<void> {
 
   const tsFiles = files.filter((f) => f.endsWith(".ts"));
 
-  for (const file of tsFiles) {
-    const filePath = join(schemaDir, file);
+  for (const file of tsFiles.filter((name) => isMigrationTsStub(name))) {
+    await generateSqlForMigrationFile(join(schemaDir, file));
+  }
 
-    if (isMigrationTsStub(file)) {
-      await generateSqlForMigrationFile(filePath);
-    } else if (file === "current.ts") {
-      await generateSqlForSchemaFile(filePath);
-      await generateAppTs(schemaDir);
+  const schemaFile = join(schemaDir, "current.ts");
+  if (!(await pathExists(schemaFile))) {
+    console.error(`Schema file not found: ${schemaFile}`);
+    process.exit(1);
+  }
+
+  let schema = await loadSchema(schemaFile);
+
+  // Generate app.ts before loading permissions.ts so permissions can import it for typing.
+  await generateAppTs(schemaDir, schema);
+
+  const permissionsFile = join(schemaDir, "permissions.ts");
+  if (await pathExists(permissionsFile)) {
+    const permissions = await loadPermissionsModule(permissionsFile);
+    if (permissions) {
+      schema = mergePermissionsIntoSchema(schema, permissions);
     }
   }
+
+  await generateSqlForSchemaFile(schemaFile, schema);
+  await generateAppTs(schemaDir, schema);
+  await ensurePermissionsTestStub(schemaDir);
 
   await runJazzBuild(jazzBin, schemaDir);
 }

--- a/packages/jazz-tools/src/cli.ts
+++ b/packages/jazz-tools/src/cli.ts
@@ -15,7 +15,7 @@ import type { Lens, Schema, TablePolicies } from "./schema.js";
 // Allow loading `.ts` schema files when invoked via `node dist/cli.js`.
 register();
 
-interface BuildOptions {
+export interface BuildOptions {
   jazzBin: string;
   schemaDir: string;
 }
@@ -225,11 +225,11 @@ async function ensurePermissionsTestStub(schemaDir: string): Promise<void> {
   const template = `/**
  * Permissions test starter.
  *
- * Suggested shape:
- * - boot a disposable Jazz server/runtime for the test
- * - seed synthetic rows for policy edge-cases
- * - mint scoped clients with representative JWT claims
- * - assert allow/deny behavior for queries and mutations
+ * Suggested shape (jazz-tools/testing):
+ * - startLocalJazzServer(...) for an isolated server
+ * - seedRows(...) to set up synthetic fixtures
+ * - scopedClientForClaims(...) for request-scoped user clients
+ * - expectAllowed(...) / expectDenied(...) assertions
  */
 export {};
 `;
@@ -285,7 +285,7 @@ async function runJazzBuild(
   console.warn(`jazz-tools build failed: ${error.message}`);
 }
 
-async function build(options: BuildOptions): Promise<void> {
+export async function build(options: BuildOptions): Promise<void> {
   const { jazzBin, schemaDir } = options;
 
   let files: string[];
@@ -328,21 +328,31 @@ async function build(options: BuildOptions): Promise<void> {
   await runJazzBuild(jazzBin, schemaDir);
 }
 
-const { command, options } = parseArgs();
+function isMainModule(): boolean {
+  const entry = process.argv[1];
+  if (!entry) {
+    return false;
+  }
+  return pathToFileURL(entry).href === import.meta.url;
+}
 
-switch (command) {
-  case "build":
-    build(options).catch((err) => {
-      console.error(err.message);
-      process.exit(1);
-    });
-    break;
-  default:
-    console.log("Usage: node <path-to-jazz-tools>/dist/cli.js build [options]");
-    console.log("\nCommands:");
-    console.log("  build    Generate SQL from TypeScript schemas and run jazz-tools build");
-    console.log("\nOptions:");
-    console.log("  --jazz-bin <path>    Path to jazz binary (default: jazz-tools)");
-    console.log("  --schema-dir <path>  Path to schema directory (default: ./schema)");
-    process.exit(command ? 1 : 0);
+if (isMainModule()) {
+  const { command, options } = parseArgs();
+
+  switch (command) {
+    case "build":
+      build(options).catch((err) => {
+        console.error(err.message);
+        process.exit(1);
+      });
+      break;
+    default:
+      console.log("Usage: node <path-to-jazz-tools>/dist/cli.js build [options]");
+      console.log("\nCommands:");
+      console.log("  build    Generate SQL from TypeScript schemas and run jazz-tools build");
+      console.log("\nOptions:");
+      console.log("  --jazz-bin <path>    Path to jazz binary (default: jazz-tools)");
+      console.log("  --schema-dir <path>  Path to schema directory (default: ./schema)");
+      process.exit(command ? 1 : 0);
+  }
 }

--- a/packages/jazz-tools/src/codegen/schema-reader.ts
+++ b/packages/jazz-tools/src/codegen/schema-reader.ts
@@ -89,6 +89,12 @@ function clonePolicyExpr(expr: DslPolicyExpr): PolicyExpr {
         column: expr.column,
         session_path: [...expr.session_path],
       };
+    case "Exists":
+      return {
+        type: "Exists",
+        table: expr.table,
+        condition: clonePolicyExpr(expr.condition),
+      };
     case "Inherits":
       return {
         type: "Inherits",

--- a/packages/jazz-tools/src/drivers/types.ts
+++ b/packages/jazz-tools/src/drivers/types.ts
@@ -55,6 +55,11 @@ export type PolicyExpr =
       session_path: string[];
     }
   | {
+      type: "Exists";
+      table: string;
+      condition: PolicyExpr;
+    }
+  | {
       type: "Inherits";
       operation: PolicyOperation;
       via_column: string;

--- a/packages/jazz-tools/src/dsl.ts
+++ b/packages/jazz-tools/src/dsl.ts
@@ -200,6 +200,14 @@ export const policy = {
     };
   },
 
+  exists(table: string, condition: PolicyExpr): PolicyExpr {
+    return {
+      type: "Exists",
+      table,
+      condition,
+    };
+  },
+
   isNull(column: string): PolicyExpr {
     return { type: "IsNull", column };
   },

--- a/packages/jazz-tools/src/index.ts
+++ b/packages/jazz-tools/src/index.ts
@@ -39,3 +39,6 @@ export * from "./drivers/index.js";
 
 // Runtime client
 export * from "./runtime/index.js";
+
+// Permissions DSL
+export * from "./permissions/index.js";

--- a/packages/jazz-tools/src/permissions/index.test.ts
+++ b/packages/jazz-tools/src/permissions/index.test.ts
@@ -210,19 +210,68 @@ describe("permissions DSL", () => {
     });
   });
 
-  it("throws for correlated row references inside exists clauses", () => {
-    expect(() =>
-      definePermissions(app, ({ policy, either, session }) => [
-        policy.todos.allowRead.where((todo) =>
-          either({ ownerId: session.userId }).or(
-            policy.todoShares.exists.where({
-              todoId: todo.id,
-              userId: session.userId,
-              canRead: true,
-            }),
-          ),
+  it("compiles correlated exists row references", () => {
+    const compiled = definePermissions(app, ({ policy, either, session }) => [
+      policy.todos.allowRead.where((todo) =>
+        either({ ownerId: session.userId }).or(
+          policy.todoShares.exists.where({
+            todoId: todo.id,
+            userId: session.userId,
+            canRead: true,
+          }),
         ),
-      ]),
-    ).toThrow(/Correlated row references in exists/);
+      ),
+    ]);
+
+    expect(compiled.todos.select?.using).toEqual({
+      type: "Or",
+      exprs: [
+        {
+          type: "Cmp",
+          column: "ownerId",
+          op: "Eq",
+          value: {
+            type: "SessionRef",
+            path: ["userId"],
+          },
+        },
+        {
+          type: "Exists",
+          table: "todoShares",
+          condition: {
+            type: "And",
+            exprs: [
+              {
+                type: "Cmp",
+                column: "todoId",
+                op: "Eq",
+                value: {
+                  type: "SessionRef",
+                  path: ["__jazz_outer_row", "id"],
+                },
+              },
+              {
+                type: "Cmp",
+                column: "userId",
+                op: "Eq",
+                value: {
+                  type: "SessionRef",
+                  path: ["userId"],
+                },
+              },
+              {
+                type: "Cmp",
+                column: "canRead",
+                op: "Eq",
+                value: {
+                  type: "Literal",
+                  value: true,
+                },
+              },
+            ],
+          },
+        },
+      ],
+    });
   });
 });

--- a/packages/jazz-tools/src/permissions/index.test.ts
+++ b/packages/jazz-tools/src/permissions/index.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from "vitest";
+import { definePermissions } from "./index.js";
+
+interface Todo {
+  id: string;
+  ownerId: string;
+  archived: boolean;
+  done: boolean;
+}
+
+interface TodoWhere {
+  id?: string;
+  ownerId?: string;
+  archived?: boolean;
+  done?: boolean;
+}
+
+interface TodoShare {
+  id: string;
+  todoId: string;
+  userId: string;
+  canRead: boolean;
+}
+
+interface TodoShareWhere {
+  id?: string;
+  todoId?: string;
+  userId?: string;
+  canRead?: boolean;
+}
+
+class TodoQueryBuilder {
+  declare readonly _rowType: Todo;
+  where(_input: TodoWhere): TodoQueryBuilder {
+    return this;
+  }
+}
+
+class TodoShareQueryBuilder {
+  declare readonly _rowType: TodoShare;
+  where(_input: TodoShareWhere): TodoShareQueryBuilder {
+    return this;
+  }
+}
+
+const app = {
+  todos: new TodoQueryBuilder(),
+  todoShares: new TodoShareQueryBuilder(),
+  wasmSchema: {},
+};
+
+describe("permissions DSL", () => {
+  it("compiles read/insert/update/delete policies", () => {
+    const compiled = definePermissions(app, ({ policy, both, session }) => [
+      policy.todos.allowRead.where({ ownerId: session.userId }),
+      policy.todos.allowInsert.where({ ownerId: session.userId }),
+      policy.todos.allowUpdate
+        .whereOld(both({ ownerId: session.userId }).and({ archived: false }))
+        .whereNew({ ownerId: session.userId }),
+      policy.todos.allowDelete.where({ ownerId: session.userId }),
+    ]);
+
+    expect(compiled.todos.select?.using).toEqual({
+      type: "Cmp",
+      column: "ownerId",
+      op: "Eq",
+      value: {
+        type: "SessionRef",
+        path: ["userId"],
+      },
+    });
+    expect(compiled.todos.insert?.with_check).toEqual({
+      type: "Cmp",
+      column: "ownerId",
+      op: "Eq",
+      value: {
+        type: "SessionRef",
+        path: ["userId"],
+      },
+    });
+    expect(compiled.todos.update?.using).toEqual({
+      type: "And",
+      exprs: [
+        {
+          type: "Cmp",
+          column: "ownerId",
+          op: "Eq",
+          value: {
+            type: "SessionRef",
+            path: ["userId"],
+          },
+        },
+        {
+          type: "Cmp",
+          column: "archived",
+          op: "Eq",
+          value: {
+            type: "Literal",
+            value: false,
+          },
+        },
+      ],
+    });
+    expect(compiled.todos.update?.with_check).toEqual({
+      type: "Cmp",
+      column: "ownerId",
+      op: "Eq",
+      value: {
+        type: "SessionRef",
+        path: ["userId"],
+      },
+    });
+    expect(compiled.todos.delete?.using).toEqual({
+      type: "Cmp",
+      column: "ownerId",
+      op: "Eq",
+      value: {
+        type: "SessionRef",
+        path: ["userId"],
+      },
+    });
+  });
+
+  it("supports plural action aliases and OR-merges repeated rules", () => {
+    const compiled = definePermissions(app, ({ policy, either, session }) => [
+      policy.todos.allowReads.where({ ownerId: session.userId }),
+      policy.todos.allowReads.where(either({ done: true }).or({ archived: false })),
+      policy.todos.allowInserts.where({ ownerId: session.userId }),
+    ]);
+
+    expect(compiled.todos.select?.using).toEqual({
+      type: "Or",
+      exprs: [
+        {
+          type: "Cmp",
+          column: "ownerId",
+          op: "Eq",
+          value: {
+            type: "SessionRef",
+            path: ["userId"],
+          },
+        },
+        {
+          type: "Cmp",
+          column: "done",
+          op: "Eq",
+          value: {
+            type: "Literal",
+            value: true,
+          },
+        },
+        {
+          type: "Cmp",
+          column: "archived",
+          op: "Eq",
+          value: {
+            type: "Literal",
+            value: false,
+          },
+        },
+      ],
+    });
+    expect(compiled.todos.insert?.with_check).toEqual({
+      type: "Cmp",
+      column: "ownerId",
+      op: "Eq",
+      value: {
+        type: "SessionRef",
+        path: ["userId"],
+      },
+    });
+  });
+
+  it("throws for exists clauses until compiler support lands", () => {
+    expect(() =>
+      definePermissions(app, ({ policy, either, session }) => [
+        policy.todos.allowRead.where((todo) =>
+          either({ ownerId: session.userId }).or(
+            policy.todoShares.exists.where({
+              todoId: todo.id,
+              userId: session.userId,
+              canRead: true,
+            }),
+          ),
+        ),
+      ]),
+    ).toThrow(/exists\(\.\.\.\) clauses are not compiled yet/);
+  });
+});

--- a/packages/jazz-tools/src/permissions/index.test.ts
+++ b/packages/jazz-tools/src/permissions/index.test.ts
@@ -171,7 +171,46 @@ describe("permissions DSL", () => {
     });
   });
 
-  it("throws for exists clauses until compiler support lands", () => {
+  it("compiles non-correlated exists clauses", () => {
+    const compiled = definePermissions(app, ({ policy, session }) => [
+      policy.todos.allowRead.where(
+        policy.todoShares.exists.where({
+          userId: session.userId,
+          canRead: true,
+        }),
+      ),
+    ]);
+
+    expect(compiled.todos.select?.using).toEqual({
+      type: "Exists",
+      table: "todoShares",
+      condition: {
+        type: "And",
+        exprs: [
+          {
+            type: "Cmp",
+            column: "userId",
+            op: "Eq",
+            value: {
+              type: "SessionRef",
+              path: ["userId"],
+            },
+          },
+          {
+            type: "Cmp",
+            column: "canRead",
+            op: "Eq",
+            value: {
+              type: "Literal",
+              value: true,
+            },
+          },
+        ],
+      },
+    });
+  });
+
+  it("throws for correlated row references inside exists clauses", () => {
     expect(() =>
       definePermissions(app, ({ policy, either, session }) => [
         policy.todos.allowRead.where((todo) =>
@@ -184,6 +223,6 @@ describe("permissions DSL", () => {
           ),
         ),
       ]),
-    ).toThrow(/exists\(\.\.\.\) clauses are not compiled yet/);
+    ).toThrow(/Correlated row references in exists/);
   });
 });

--- a/packages/jazz-tools/src/permissions/index.test.ts
+++ b/packages/jazz-tools/src/permissions/index.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { definePermissions } from "./index.js";
+import type { PolicyExpr } from "../schema.js";
 
 interface Todo {
   id: string;
@@ -79,6 +80,11 @@ const app = {
       },
     },
   },
+};
+
+const appWithoutSchema = {
+  todos: new TodoQueryBuilder(),
+  todoShares: new TodoShareQueryBuilder(),
 };
 
 describe("permissions DSL", () => {
@@ -253,7 +259,73 @@ describe("permissions DSL", () => {
       definePermissions(app, ({ policy, allowedTo }) => [
         policy.todos.allowRead.where(allowedTo.read("ownerId")),
       ]),
-    ).toThrow(/column is not a foreign key reference/i);
+    ).toThrow(/available fk columns: projectId/i);
+  });
+
+  it("rejects allowedTo when app.wasmSchema metadata is missing", () => {
+    expect(() =>
+      definePermissions(appWithoutSchema, ({ policy, allowedTo }) => [
+        policy.todos.allowRead.where(allowedTo.read("projectId")),
+      ]),
+    ).toThrow(/table metadata is missing in app\.wasmSchema/i);
+  });
+
+  it("rejects row references outside exists clauses", () => {
+    expect(() =>
+      definePermissions(app, ({ policy }) => [
+        policy.todos.allowRead.where((todo) => ({ ownerId: todo.id })),
+      ]),
+    ).toThrow(/row references are only valid inside exists\(\) clauses/i);
+  });
+
+  it("supports update rules with only whereOld or whereNew", () => {
+    const oldOnly = definePermissions(app, ({ policy, session }) => [
+      policy.todos.allowUpdate.whereOld({ ownerId: session.userId }),
+    ]);
+    expect(oldOnly.todos.update?.using).toEqual({
+      type: "Cmp",
+      column: "ownerId",
+      op: "Eq",
+      value: {
+        type: "SessionRef",
+        path: ["userId"],
+      },
+    });
+    expect(oldOnly.todos.update?.with_check).toEqual(oldOnly.todos.update?.using);
+
+    const newOnly = definePermissions(app, ({ policy, session }) => [
+      policy.todos.allowUpdate.whereNew({ ownerId: session.userId }),
+    ]);
+    expect(newOnly.todos.update?.with_check).toEqual({
+      type: "Cmp",
+      column: "ownerId",
+      op: "Eq",
+      value: {
+        type: "SessionRef",
+        path: ["userId"],
+      },
+    });
+    expect(newOnly.todos.update?.using).toEqual(newOnly.todos.update?.with_check);
+  });
+
+  it("rejects unsupported where operators and invalid compound chains", () => {
+    expect(() =>
+      definePermissions(app, ({ policy }) => [
+        policy.todos.allowRead.where({ done: { contains: true } } as unknown as TodoWhere),
+      ]),
+    ).toThrow(/where operator "contains" is not yet supported/i);
+
+    expect(() =>
+      definePermissions(app, ({ policy, both }) => [
+        policy.todos.allowRead.where(both({ done: true }).or({ archived: false })),
+      ]),
+    ).toThrow(/use "either\(\.\.\.\)" for OR chains/i);
+
+    expect(() =>
+      definePermissions(app, ({ policy, either }) => [
+        policy.todos.allowRead.where(either({ done: true }).and({ archived: false })),
+      ]),
+    ).toThrow(/use "both\(\.\.\.\)" for AND chains/i);
   });
 
   it("compiles correlated exists row references", () => {
@@ -315,5 +387,41 @@ describe("permissions DSL", () => {
         },
       ],
     });
+  });
+
+  it("validates inherits against the exists table when nested in raw PolicyExpr", () => {
+    const manualExistsExpr: PolicyExpr = {
+      type: "Exists",
+      table: "todoShares",
+      condition: {
+        type: "Inherits",
+        operation: "Select",
+        via_column: "todoId",
+      },
+    };
+
+    const compiled = definePermissions(app, ({ policy }) => [
+      policy.todos.allowRead.where(manualExistsExpr),
+    ]);
+
+    expect(compiled.todos.select?.using).toEqual(manualExistsExpr);
+  });
+
+  it("rejects invalid nested inherits columns against exists table metadata", () => {
+    const invalidManualExistsExpr: PolicyExpr = {
+      type: "Exists",
+      table: "todoShares",
+      condition: {
+        type: "Inherits",
+        operation: "Select",
+        via_column: "projectId",
+      },
+    };
+
+    expect(() =>
+      definePermissions(app, ({ policy }) => [
+        policy.todos.allowRead.where(invalidManualExistsExpr),
+      ]),
+    ).toThrow(/available fk columns: todoId/i);
   });
 });

--- a/packages/jazz-tools/src/permissions/index.test.ts
+++ b/packages/jazz-tools/src/permissions/index.test.ts
@@ -6,6 +6,7 @@ interface Todo {
   ownerId: string;
   archived: boolean;
   done: boolean;
+  projectId?: string;
 }
 
 interface TodoWhere {
@@ -13,6 +14,7 @@ interface TodoWhere {
   ownerId?: string;
   archived?: boolean;
   done?: boolean;
+  projectId?: string;
 }
 
 interface TodoShare {
@@ -46,17 +48,47 @@ class TodoShareQueryBuilder {
 const app = {
   todos: new TodoQueryBuilder(),
   todoShares: new TodoShareQueryBuilder(),
-  wasmSchema: {},
+  wasmSchema: {
+    tables: {
+      todos: {
+        columns: [
+          { name: "id", column_type: { type: "Uuid" }, nullable: false },
+          { name: "ownerId", column_type: { type: "Text" }, nullable: false },
+          { name: "archived", column_type: { type: "Boolean" }, nullable: false },
+          { name: "done", column_type: { type: "Boolean" }, nullable: false },
+          {
+            name: "projectId",
+            column_type: { type: "Uuid" },
+            nullable: true,
+            references: "projects",
+          },
+        ],
+      },
+      todoShares: {
+        columns: [
+          { name: "id", column_type: { type: "Uuid" }, nullable: false },
+          {
+            name: "todoId",
+            column_type: { type: "Uuid" },
+            nullable: false,
+            references: "todos",
+          },
+          { name: "userId", column_type: { type: "Text" }, nullable: false },
+          { name: "canRead", column_type: { type: "Boolean" }, nullable: false },
+        ],
+      },
+    },
+  },
 };
 
 describe("permissions DSL", () => {
   it("compiles read/insert/update/delete policies", () => {
-    const compiled = definePermissions(app, ({ policy, both, session }) => [
+    const compiled = definePermissions(app, ({ policy, both, allowedTo, session }) => [
       policy.todos.allowRead.where({ ownerId: session.userId }),
       policy.todos.allowInsert.where({ ownerId: session.userId }),
       policy.todos.allowUpdate
-        .whereOld(both({ ownerId: session.userId }).and({ archived: false }))
-        .whereNew({ ownerId: session.userId }),
+        .whereOld(both(allowedTo.update("projectId")).and({ archived: false }))
+        .whereNew(allowedTo.update("projectId")),
       policy.todos.allowDelete.where({ ownerId: session.userId }),
     ]);
 
@@ -82,13 +114,9 @@ describe("permissions DSL", () => {
       type: "And",
       exprs: [
         {
-          type: "Cmp",
-          column: "ownerId",
-          op: "Eq",
-          value: {
-            type: "SessionRef",
-            path: ["userId"],
-          },
+          type: "Inherits",
+          operation: "Update",
+          via_column: "projectId",
         },
         {
           type: "Cmp",
@@ -102,13 +130,9 @@ describe("permissions DSL", () => {
       ],
     });
     expect(compiled.todos.update?.with_check).toEqual({
-      type: "Cmp",
-      column: "ownerId",
-      op: "Eq",
-      value: {
-        type: "SessionRef",
-        path: ["userId"],
-      },
+      type: "Inherits",
+      operation: "Update",
+      via_column: "projectId",
     });
     expect(compiled.todos.delete?.using).toEqual({
       type: "Cmp",
@@ -122,9 +146,9 @@ describe("permissions DSL", () => {
   });
 
   it("supports plural action aliases and OR-merges repeated rules", () => {
-    const compiled = definePermissions(app, ({ policy, either, session }) => [
+    const compiled = definePermissions(app, ({ policy, either, allowedTo, session }) => [
       policy.todos.allowReads.where({ ownerId: session.userId }),
-      policy.todos.allowReads.where(either({ done: true }).or({ archived: false })),
+      policy.todos.allowReads.where(either({ done: true }).or(allowedTo.read("projectId"))),
       policy.todos.allowInserts.where({ ownerId: session.userId }),
     ]);
 
@@ -150,13 +174,9 @@ describe("permissions DSL", () => {
           },
         },
         {
-          type: "Cmp",
-          column: "archived",
-          op: "Eq",
-          value: {
-            type: "Literal",
-            value: false,
-          },
+          type: "Inherits",
+          operation: "Select",
+          via_column: "projectId",
         },
       ],
     });
@@ -210,10 +230,36 @@ describe("permissions DSL", () => {
     });
   });
 
+  it("supports allowedTo.insert and allowedTo.delete helpers", () => {
+    const compiled = definePermissions(app, ({ policy, allowedTo }) => [
+      policy.todos.allowInsert.where(allowedTo.insert("projectId")),
+      policy.todos.allowDelete.where(allowedTo.delete("projectId")),
+    ]);
+
+    expect(compiled.todos.insert?.with_check).toEqual({
+      type: "Inherits",
+      operation: "Insert",
+      via_column: "projectId",
+    });
+    expect(compiled.todos.delete?.using).toEqual({
+      type: "Inherits",
+      operation: "Delete",
+      via_column: "projectId",
+    });
+  });
+
+  it("rejects allowedTo when column is not a foreign key", () => {
+    expect(() =>
+      definePermissions(app, ({ policy, allowedTo }) => [
+        policy.todos.allowRead.where(allowedTo.read("ownerId")),
+      ]),
+    ).toThrow(/column is not a foreign key reference/i);
+  });
+
   it("compiles correlated exists row references", () => {
-    const compiled = definePermissions(app, ({ policy, either, session }) => [
+    const compiled = definePermissions(app, ({ policy, either, allowedTo, session }) => [
       policy.todos.allowRead.where((todo) =>
-        either({ ownerId: session.userId }).or(
+        either(allowedTo.read("projectId")).or(
           policy.todoShares.exists.where({
             todoId: todo.id,
             userId: session.userId,
@@ -227,13 +273,9 @@ describe("permissions DSL", () => {
       type: "Or",
       exprs: [
         {
-          type: "Cmp",
-          column: "ownerId",
-          op: "Eq",
-          value: {
-            type: "SessionRef",
-            path: ["userId"],
-          },
+          type: "Inherits",
+          operation: "Select",
+          via_column: "projectId",
         },
         {
           type: "Exists",

--- a/packages/jazz-tools/src/permissions/index.ts
+++ b/packages/jazz-tools/src/permissions/index.ts
@@ -81,6 +81,7 @@ interface ExistsBuilder<WhereInput> {
 interface ActionBuilder<WhereInput, Row> {
   where(
     input:
+      | Condition
       | PermissionWhereInput<WhereInput>
       | ((row: RowContext<Row>) => unknown)
       | ConditionBuilder,
@@ -128,6 +129,7 @@ class UpdateRuleBuilder<WhereInput, Row> {
 
   where(
     input:
+      | Condition
       | PermissionWhereInput<WhereInput>
       | ((row: RowContext<Row>) => unknown)
       | ConditionBuilder,
@@ -143,6 +145,7 @@ class UpdateRuleBuilder<WhereInput, Row> {
 
   whereOld(
     input:
+      | Condition
       | PermissionWhereInput<WhereInput>
       | ((row: RowContext<Row>) => unknown)
       | ConditionBuilder,
@@ -153,6 +156,7 @@ class UpdateRuleBuilder<WhereInput, Row> {
 
   whereNew(
     input:
+      | Condition
       | PermissionWhereInput<WhereInput>
       | ((row: RowContext<Row>) => unknown)
       | ConditionBuilder,
@@ -315,7 +319,7 @@ function columnFilterToExprs(column: string, raw: unknown): PolicyExpr[] {
   }
   if (isRowRefValue(raw)) {
     throw new Error(
-      `Row references (for column "${column}") are only valid inside exists() clauses, which are not yet compiled.`,
+      `Correlated row references in exists(...) are not yet supported ("${column}").`,
     );
   }
   if (isPlainObject(raw)) {
@@ -511,9 +515,17 @@ function compileCondition(condition: Condition | undefined): PolicyExpr | undefi
     return condition;
   }
   if (isExistsCondition(condition)) {
-    throw new Error(
-      `exists(...) clauses are not compiled yet for permissions.ts (table "${condition.table}").`,
-    );
+    const compiledCondition = compileCondition(resolveWhereInput(condition.where));
+    if (!compiledCondition) {
+      throw new Error(
+        `Failed to compile exists(...) condition for table "${condition.table}" in permissions.ts`,
+      );
+    }
+    return {
+      type: "Exists",
+      table: condition.table,
+      condition: compiledCondition,
+    };
   }
   if (isCompoundCondition(condition)) {
     const compiledChildren = condition.conditions.map((child) => compileCondition(child));

--- a/packages/jazz-tools/src/permissions/index.ts
+++ b/packages/jazz-tools/src/permissions/index.ts
@@ -5,6 +5,7 @@ import type {
   PolicyValue,
   TablePolicies,
 } from "../schema.js";
+import type { WasmSchema } from "../drivers/types.js";
 
 type QueryBuilderLike = {
   _rowType: unknown;
@@ -76,6 +77,13 @@ export interface ConditionBuilder {
 
 export type SessionContext = Record<string, SessionRefValue>;
 
+export interface AllowedToContext {
+  read(fkColumn: string): PolicyExpr;
+  insert(fkColumn: string): PolicyExpr;
+  update(fkColumn: string): PolicyExpr;
+  delete(fkColumn: string): PolicyExpr;
+}
+
 interface ExistsBuilder<WhereInput> {
   where(input: PermissionWhereInput<WhereInput>): ExistsCondition;
 }
@@ -111,6 +119,7 @@ export type PolicyContext<TApp extends AppLike> = {
   };
   either: (input: unknown) => ConditionBuilder;
   both: (input: unknown) => ConditionBuilder;
+  allowedTo: AllowedToContext;
   session: SessionContext;
 };
 
@@ -184,16 +193,43 @@ export function definePermissions<TApp extends AppLike>(
   app: TApp,
   factory: (ctx: PolicyContext<TApp>) => RuleLike[] | RuleLike,
 ): CompiledPermissions {
+  const fkColumnsByTable = collectFkColumnsByTable(app);
   const tableNames = Object.keys(app).filter((key) => key !== "wasmSchema");
   const ctx = {
     policy: buildPolicyContext(tableNames),
     either,
     both,
+    allowedTo: createAllowedToContext(),
     session: createSessionContext(),
   } as unknown as PolicyContext<TApp>;
   const output = factory(ctx);
   const rules = Array.isArray(output) ? output : [output];
-  return compileRules(rules);
+  return compileRules(rules, fkColumnsByTable);
+}
+
+function collectFkColumnsByTable(app: AppLike): Map<string, Set<string>> {
+  const result = new Map<string, Set<string>>();
+  const schema = (app as { wasmSchema?: unknown }).wasmSchema;
+  if (!schema || typeof schema !== "object") {
+    return result;
+  }
+
+  const typedSchema = schema as WasmSchema;
+  if (!typedSchema.tables || typeof typedSchema.tables !== "object") {
+    return result;
+  }
+
+  for (const [tableName, table] of Object.entries(typedSchema.tables)) {
+    const fkColumns = new Set<string>();
+    for (const column of table.columns ?? []) {
+      if (column.references) {
+        fkColumns.add(column.name);
+      }
+    }
+    result.set(tableName, fkColumns);
+  }
+
+  return result;
 }
 
 function buildPolicyContext(tableNames: string[]): Record<string, unknown> {
@@ -253,6 +289,39 @@ function createSessionContext(): SessionContext {
       return undefined;
     },
   });
+}
+
+function createAllowedToContext(): AllowedToContext {
+  return {
+    read(fkColumn: string): PolicyExpr {
+      return {
+        type: "Inherits",
+        operation: "Select",
+        via_column: fkColumn,
+      };
+    },
+    insert(fkColumn: string): PolicyExpr {
+      return {
+        type: "Inherits",
+        operation: "Insert",
+        via_column: fkColumn,
+      };
+    },
+    update(fkColumn: string): PolicyExpr {
+      return {
+        type: "Inherits",
+        operation: "Update",
+        via_column: fkColumn,
+      };
+    },
+    delete(fkColumn: string): PolicyExpr {
+      return {
+        type: "Inherits",
+        operation: "Delete",
+        via_column: fkColumn,
+      };
+    },
+  };
 }
 
 function normalizeSessionPath(path: string | string[]): string[] {
@@ -460,7 +529,10 @@ function compoundBuilder(op: "And" | "Or", input: unknown): ConditionBuilder {
   };
 }
 
-function compileRules(rules: RuleLike[]): CompiledPermissions {
+function compileRules(
+  rules: RuleLike[],
+  fkColumnsByTable: Map<string, Set<string>>,
+): CompiledPermissions {
   const compiled: CompiledPermissions = {};
   for (const ruleLike of rules) {
     const rule = isUpdateRuleBuilder(ruleLike) ? ruleLike.toRule() : ruleLike;
@@ -471,23 +543,23 @@ function compileRules(rules: RuleLike[]): CompiledPermissions {
     switch (rule.action) {
       case "read":
         tablePolicies.select = mergeOperationPolicy(tablePolicies.select, {
-          using: compileCondition(rule.using),
+          using: compileCondition(rule.using, rule.table, fkColumnsByTable),
         });
         break;
       case "insert":
         tablePolicies.insert = mergeOperationPolicy(tablePolicies.insert, {
-          with_check: compileCondition(rule.withCheck),
+          with_check: compileCondition(rule.withCheck, rule.table, fkColumnsByTable),
         });
         break;
       case "update":
         tablePolicies.update = mergeOperationPolicy(tablePolicies.update, {
-          using: compileCondition(rule.using),
-          with_check: compileCondition(rule.withCheck),
+          using: compileCondition(rule.using, rule.table, fkColumnsByTable),
+          with_check: compileCondition(rule.withCheck, rule.table, fkColumnsByTable),
         });
         break;
       case "delete":
         tablePolicies.delete = mergeOperationPolicy(tablePolicies.delete, {
-          using: compileCondition(rule.using),
+          using: compileCondition(rule.using, rule.table, fkColumnsByTable),
         });
         break;
       default:
@@ -528,15 +600,21 @@ function mergeExprWithOr(left?: PolicyExpr, right?: PolicyExpr): PolicyExpr | un
   return { type: "Or", exprs };
 }
 
-function compileCondition(condition: Condition | undefined): PolicyExpr | undefined {
+function compileCondition(
+  condition: Condition | undefined,
+  table: string,
+  fkColumnsByTable: Map<string, Set<string>>,
+): PolicyExpr | undefined {
   if (!condition) {
     return undefined;
   }
   if (isPolicyExpr(condition)) {
+    assertInheritsColumns(condition, table, fkColumnsByTable);
     return condition;
   }
   if (isExistsCondition(condition)) {
     const compiledCondition = whereObjectToCondition(condition.where, { allowRowRefs: true });
+    assertInheritsColumns(compiledCondition, table, fkColumnsByTable);
     if (!compiledCondition) {
       throw new Error(
         `Failed to compile exists(...) condition for table "${condition.table}" in permissions.ts`,
@@ -549,7 +627,9 @@ function compileCondition(condition: Condition | undefined): PolicyExpr | undefi
     };
   }
   if (isCompoundCondition(condition)) {
-    const compiledChildren = condition.conditions.map((child) => compileCondition(child));
+    const compiledChildren = condition.conditions.map((child) =>
+      compileCondition(child, table, fkColumnsByTable),
+    );
     const exprs = compiledChildren.filter((expr): expr is PolicyExpr => Boolean(expr));
     if (exprs.length === 0) {
       return condition.op === "And" ? { type: "True" } : { type: "False" };
@@ -560,6 +640,42 @@ function compileCondition(condition: Condition | undefined): PolicyExpr | undefi
     return condition.op === "And" ? { type: "And", exprs } : { type: "Or", exprs };
   }
   throw new Error("Unsupported condition in permissions compiler.");
+}
+
+function assertInheritsColumns(
+  expr: PolicyExpr,
+  table: string,
+  fkColumnsByTable: Map<string, Set<string>>,
+): void {
+  const check = (node: PolicyExpr): void => {
+    switch (node.type) {
+      case "Inherits": {
+        const fkColumns = fkColumnsByTable.get(table);
+        if (!fkColumns || !fkColumns.has(node.via_column)) {
+          throw new Error(
+            `allowedTo.${node.operation.toLowerCase()}("${node.via_column}") is invalid for table "${table}": column is not a foreign key reference.`,
+          );
+        }
+        break;
+      }
+      case "And":
+      case "Or":
+        for (const child of node.exprs) {
+          check(child);
+        }
+        break;
+      case "Not":
+        check(node.expr);
+        break;
+      case "Exists":
+        check(node.condition);
+        break;
+      default:
+        break;
+    }
+  };
+
+  check(expr);
 }
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {

--- a/packages/jazz-tools/src/permissions/index.ts
+++ b/packages/jazz-tools/src/permissions/index.ts
@@ -1,0 +1,580 @@
+import type {
+  OperationPolicy,
+  PolicyCmpOp,
+  PolicyExpr,
+  PolicyValue,
+  TablePolicies,
+} from "../schema.js";
+
+type QueryBuilderLike = {
+  _rowType: unknown;
+  where(input: unknown): unknown;
+};
+
+type AppLike = Record<string, QueryBuilderLike | unknown> & {
+  wasmSchema?: unknown;
+};
+
+type TableKey<TApp extends AppLike> = Exclude<keyof TApp, "wasmSchema">;
+type QueryBuilderFor<TApp extends AppLike, K extends TableKey<TApp>> = Extract<
+  TApp[K],
+  QueryBuilderLike
+>;
+type RowFor<QB> = QB extends { _rowType: infer R } ? R : never;
+type WhereFor<QB> = QB extends { where(input: infer W): unknown } ? W : never;
+
+type PolicyAction = "read" | "insert" | "update" | "delete";
+
+interface SessionRefValue {
+  readonly __jazzPermissionKind: "session-ref";
+  readonly path: string[];
+}
+
+interface RowRefValue {
+  readonly __jazzPermissionKind: "row-ref";
+  readonly column: string;
+}
+
+interface ExistsCondition {
+  readonly __jazzPermissionKind: "exists";
+  readonly table: string;
+  readonly where: Record<string, unknown>;
+}
+
+interface CompoundCondition {
+  readonly __jazzPermissionKind: "compound";
+  readonly op: "And" | "Or";
+  readonly conditions: Condition[];
+}
+
+type Condition = PolicyExpr | CompoundCondition | ExistsCondition;
+
+interface Rule {
+  table: string;
+  action: PolicyAction;
+  using?: Condition;
+  withCheck?: Condition;
+}
+
+type RuleLike = Rule | UpdateRuleBuilder<unknown, unknown>;
+
+type RowContext<Row> = {
+  [K in keyof Row & string]: RowRefValue;
+};
+
+export type WhereInputOrCallback<WhereInput, Row> =
+  | WhereInput
+  | ((row: RowContext<Row>) => WhereInput | ConditionBuilder);
+
+export interface ConditionBuilder {
+  and(input: unknown): ConditionBuilder;
+  or(input: unknown): ConditionBuilder;
+  _condition(): Condition;
+}
+
+export type SessionContext = Record<string, SessionRefValue>;
+
+interface ExistsBuilder<WhereInput> {
+  where(input: PermissionWhereInput<WhereInput>): ExistsCondition;
+}
+
+interface ActionBuilder<WhereInput, Row> {
+  where(
+    input:
+      | PermissionWhereInput<WhereInput>
+      | ((row: RowContext<Row>) => unknown)
+      | ConditionBuilder,
+  ): Rule;
+}
+
+interface TablePolicyBuilder<WhereInput, Row> {
+  allowRead: ActionBuilder<WhereInput, Row>;
+  allowReads: ActionBuilder<WhereInput, Row>;
+  allowInsert: ActionBuilder<WhereInput, Row>;
+  allowInserts: ActionBuilder<WhereInput, Row>;
+  allowDelete: ActionBuilder<WhereInput, Row>;
+  allowDeletes: ActionBuilder<WhereInput, Row>;
+  allowUpdate: UpdateRuleBuilder<WhereInput, Row>;
+  allowUpdates: UpdateRuleBuilder<WhereInput, Row>;
+  exists: ExistsBuilder<WhereInput>;
+}
+
+export type PolicyContext<TApp extends AppLike> = {
+  policy: {
+    [K in TableKey<TApp>]: TablePolicyBuilder<
+      WhereFor<QueryBuilderFor<TApp, K>>,
+      RowFor<QueryBuilderFor<TApp, K>>
+    >;
+  };
+  either: (input: unknown) => ConditionBuilder;
+  both: (input: unknown) => ConditionBuilder;
+  session: SessionContext;
+};
+
+export type CompiledPermissions = Record<string, TablePolicies>;
+
+type PermissionWhereInput<T> =
+  T extends Array<infer U>
+    ? Array<PermissionWhereInput<U>>
+    : T extends object
+      ? { [K in keyof T]?: PermissionWhereInput<T[K]> | SessionRefValue | RowRefValue }
+      : T | SessionRefValue | RowRefValue;
+
+class UpdateRuleBuilder<WhereInput, Row> {
+  private oldCondition?: Condition;
+  private newCondition?: Condition;
+
+  constructor(private readonly table: string) {}
+
+  where(
+    input:
+      | PermissionWhereInput<WhereInput>
+      | ((row: RowContext<Row>) => unknown)
+      | ConditionBuilder,
+  ): Rule {
+    const condition = resolveWhereInput(input);
+    return {
+      table: this.table,
+      action: "update",
+      using: condition,
+      withCheck: condition,
+    };
+  }
+
+  whereOld(
+    input:
+      | PermissionWhereInput<WhereInput>
+      | ((row: RowContext<Row>) => unknown)
+      | ConditionBuilder,
+  ): this {
+    this.oldCondition = resolveWhereInput(input);
+    return this;
+  }
+
+  whereNew(
+    input:
+      | PermissionWhereInput<WhereInput>
+      | ((row: RowContext<Row>) => unknown)
+      | ConditionBuilder,
+  ): this {
+    this.newCondition = resolveWhereInput(input);
+    return this;
+  }
+
+  toRule(): Rule {
+    if (!this.oldCondition && !this.newCondition) {
+      throw new Error(`Missing update policy conditions for table "${this.table}"`);
+    }
+    return {
+      table: this.table,
+      action: "update",
+      using: this.oldCondition ?? this.newCondition,
+      withCheck: this.newCondition ?? this.oldCondition,
+    };
+  }
+}
+
+export function definePermissions<TApp extends AppLike>(
+  app: TApp,
+  factory: (ctx: PolicyContext<TApp>) => RuleLike[] | RuleLike,
+): CompiledPermissions {
+  const tableNames = Object.keys(app).filter((key) => key !== "wasmSchema");
+  const ctx = {
+    policy: buildPolicyContext(tableNames),
+    either,
+    both,
+    session: createSessionContext(),
+  } as unknown as PolicyContext<TApp>;
+  const output = factory(ctx);
+  const rules = Array.isArray(output) ? output : [output];
+  return compileRules(rules);
+}
+
+function buildPolicyContext(tableNames: string[]): Record<string, unknown> {
+  const context: Record<string, unknown> = {};
+  for (const table of tableNames) {
+    context[table] = buildTablePolicyBuilder(table);
+  }
+  return context;
+}
+
+function buildTablePolicyBuilder(table: string): Record<string, unknown> {
+  const read: ActionBuilder<unknown, unknown> = {
+    where: (input) => ({ table, action: "read", using: resolveWhereInput(input) }),
+  };
+  const insert: ActionBuilder<unknown, unknown> = {
+    where: (input) => ({ table, action: "insert", withCheck: resolveWhereInput(input) }),
+  };
+  const del: ActionBuilder<unknown, unknown> = {
+    where: (input) => ({ table, action: "delete", using: resolveWhereInput(input) }),
+  };
+  const updateFactory = (): UpdateRuleBuilder<unknown, unknown> => new UpdateRuleBuilder(table);
+  const exists: ExistsBuilder<unknown> = {
+    where: (input) => ({
+      __jazzPermissionKind: "exists",
+      table,
+      where: normalizeWhereObject(input),
+    }),
+  };
+
+  return {
+    allowRead: read,
+    allowReads: read,
+    allowInsert: insert,
+    allowInserts: insert,
+    allowDelete: del,
+    allowDeletes: del,
+    get allowUpdate() {
+      return updateFactory();
+    },
+    get allowUpdates() {
+      return updateFactory();
+    },
+    exists,
+  };
+}
+
+function createSessionContext(): SessionContext {
+  const claimRef = (path: string): SessionRefValue => ({
+    __jazzPermissionKind: "session-ref",
+    path: normalizeSessionPath(path),
+  });
+  return new Proxy({} as SessionContext, {
+    get(_target, prop, _receiver) {
+      if (typeof prop === "string") {
+        return claimRef(prop);
+      }
+      return undefined;
+    },
+  });
+}
+
+function normalizeSessionPath(path: string | string[]): string[] {
+  const parts = Array.isArray(path) ? path : path.split(".");
+  return parts.map((part) => part.trim()).filter((part) => part.length > 0);
+}
+
+function createRowContext(): RowContext<Record<string, unknown>> {
+  return new Proxy({} as RowContext<Record<string, unknown>>, {
+    get(_target, prop) {
+      if (typeof prop === "string") {
+        return {
+          __jazzPermissionKind: "row-ref",
+          column: prop,
+        } satisfies RowRefValue;
+      }
+      return undefined;
+    },
+  });
+}
+
+function normalizeWhereObject(input: unknown): Record<string, unknown> {
+  if (!isPlainObject(input)) {
+    throw new Error("Expected a where-object condition.");
+  }
+  return input;
+}
+
+function resolveWhereInput(input: unknown): Condition {
+  if (isConditionBuilder(input)) {
+    return input._condition();
+  }
+  if (typeof input === "function") {
+    const result = input(createRowContext());
+    return resolveWhereInput(result);
+  }
+  if (isExistsCondition(input)) {
+    return input;
+  }
+  if (isPolicyExpr(input)) {
+    return input;
+  }
+  if (isPlainObject(input)) {
+    return whereObjectToCondition(input);
+  }
+  throw new Error("Unsupported permission condition input.");
+}
+
+function whereObjectToCondition(where: Record<string, unknown>): Condition {
+  const exprs: PolicyExpr[] = [];
+  for (const [column, raw] of Object.entries(where)) {
+    if (raw === undefined) {
+      continue;
+    }
+    exprs.push(...columnFilterToExprs(column, raw));
+  }
+  return andExpr(exprs);
+}
+
+function columnFilterToExprs(column: string, raw: unknown): PolicyExpr[] {
+  if (raw === null) {
+    return [{ type: "IsNull", column }];
+  }
+  if (isSessionRefValue(raw)) {
+    return [cmpExpr(column, "Eq", raw)];
+  }
+  if (isRowRefValue(raw)) {
+    throw new Error(
+      `Row references (for column "${column}") are only valid inside exists() clauses, which are not yet compiled.`,
+    );
+  }
+  if (isPlainObject(raw)) {
+    const exprs: PolicyExpr[] = [];
+    for (const [op, value] of Object.entries(raw)) {
+      if (value === undefined) {
+        continue;
+      }
+      switch (op) {
+        case "eq":
+          if (value === null) {
+            exprs.push({ type: "IsNull", column });
+          } else {
+            exprs.push(cmpExpr(column, "Eq", value));
+          }
+          break;
+        case "ne":
+          if (value === null) {
+            exprs.push({ type: "IsNotNull", column });
+          } else {
+            exprs.push(cmpExpr(column, "Ne", value));
+          }
+          break;
+        case "gt":
+          exprs.push(cmpExpr(column, "Gt", value));
+          break;
+        case "gte":
+          exprs.push(cmpExpr(column, "Ge", value));
+          break;
+        case "lt":
+          exprs.push(cmpExpr(column, "Lt", value));
+          break;
+        case "lte":
+          exprs.push(cmpExpr(column, "Le", value));
+          break;
+        case "isNull":
+          if (typeof value !== "boolean") {
+            throw new Error(`"${column}.isNull" expects a boolean value.`);
+          }
+          exprs.push(value ? { type: "IsNull", column } : { type: "IsNotNull", column });
+          break;
+        case "contains":
+        case "in":
+          throw new Error(
+            `Where operator "${op}" is not yet supported in permissions DSL for "${column}".`,
+          );
+        default:
+          throw new Error(`Unsupported where operator "${op}" in permissions DSL.`);
+      }
+    }
+    return exprs.length === 0 ? [{ type: "True" }] : exprs;
+  }
+  return [cmpExpr(column, "Eq", raw)];
+}
+
+function cmpExpr(column: string, op: PolicyCmpOp, value: unknown): PolicyExpr {
+  return {
+    type: "Cmp",
+    column,
+    op,
+    value: toPolicyValue(value),
+  };
+}
+
+function toPolicyValue(value: unknown): PolicyValue {
+  if (isSessionRefValue(value)) {
+    return { type: "SessionRef", path: value.path };
+  }
+  if (isRowRefValue(value)) {
+    throw new Error("Row references are only valid inside exists() clauses.");
+  }
+  return { type: "Literal", value };
+}
+
+function andExpr(exprs: PolicyExpr[]): PolicyExpr {
+  if (exprs.length === 0) {
+    return { type: "True" };
+  }
+  if (exprs.length === 1) {
+    return exprs[0];
+  }
+  return { type: "And", exprs };
+}
+
+export function either(input: unknown): ConditionBuilder {
+  return compoundBuilder("Or", input);
+}
+
+export function both(input: unknown): ConditionBuilder {
+  return compoundBuilder("And", input);
+}
+
+function compoundBuilder(op: "And" | "Or", input: unknown): ConditionBuilder {
+  const conditions: Condition[] = [resolveWhereInput(input)];
+  return {
+    and(next) {
+      if (op !== "And") {
+        throw new Error('Use "both(...)" for AND chains.');
+      }
+      conditions.push(resolveWhereInput(next));
+      return this;
+    },
+    or(next) {
+      if (op !== "Or") {
+        throw new Error('Use "either(...)" for OR chains.');
+      }
+      conditions.push(resolveWhereInput(next));
+      return this;
+    },
+    _condition() {
+      return {
+        __jazzPermissionKind: "compound",
+        op,
+        conditions: [...conditions],
+      };
+    },
+  };
+}
+
+function compileRules(rules: RuleLike[]): CompiledPermissions {
+  const compiled: CompiledPermissions = {};
+  for (const ruleLike of rules) {
+    const rule = isUpdateRuleBuilder(ruleLike) ? ruleLike.toRule() : ruleLike;
+    if (!compiled[rule.table]) {
+      compiled[rule.table] = {};
+    }
+    const tablePolicies = compiled[rule.table];
+    switch (rule.action) {
+      case "read":
+        tablePolicies.select = mergeOperationPolicy(tablePolicies.select, {
+          using: compileCondition(rule.using),
+        });
+        break;
+      case "insert":
+        tablePolicies.insert = mergeOperationPolicy(tablePolicies.insert, {
+          with_check: compileCondition(rule.withCheck),
+        });
+        break;
+      case "update":
+        tablePolicies.update = mergeOperationPolicy(tablePolicies.update, {
+          using: compileCondition(rule.using),
+          with_check: compileCondition(rule.withCheck),
+        });
+        break;
+      case "delete":
+        tablePolicies.delete = mergeOperationPolicy(tablePolicies.delete, {
+          using: compileCondition(rule.using),
+        });
+        break;
+      default:
+        throw new Error(`Unsupported action ${(rule as { action: string }).action}`);
+    }
+  }
+  return compiled;
+}
+
+function mergeOperationPolicy(
+  existing: OperationPolicy | undefined,
+  incoming: OperationPolicy,
+): OperationPolicy {
+  return {
+    using: mergeExprWithOr(existing?.using, incoming.using),
+    with_check: mergeExprWithOr(existing?.with_check, incoming.with_check),
+  };
+}
+
+function mergeExprWithOr(left?: PolicyExpr, right?: PolicyExpr): PolicyExpr | undefined {
+  if (!left) {
+    return right;
+  }
+  if (!right) {
+    return left;
+  }
+  const exprs: PolicyExpr[] = [];
+  if (left.type === "Or") {
+    exprs.push(...left.exprs);
+  } else {
+    exprs.push(left);
+  }
+  if (right.type === "Or") {
+    exprs.push(...right.exprs);
+  } else {
+    exprs.push(right);
+  }
+  return { type: "Or", exprs };
+}
+
+function compileCondition(condition: Condition | undefined): PolicyExpr | undefined {
+  if (!condition) {
+    return undefined;
+  }
+  if (isPolicyExpr(condition)) {
+    return condition;
+  }
+  if (isExistsCondition(condition)) {
+    throw new Error(
+      `exists(...) clauses are not compiled yet for permissions.ts (table "${condition.table}").`,
+    );
+  }
+  if (isCompoundCondition(condition)) {
+    const compiledChildren = condition.conditions.map((child) => compileCondition(child));
+    const exprs = compiledChildren.filter((expr): expr is PolicyExpr => Boolean(expr));
+    if (exprs.length === 0) {
+      return condition.op === "And" ? { type: "True" } : { type: "False" };
+    }
+    if (exprs.length === 1) {
+      return exprs[0];
+    }
+    return condition.op === "And" ? { type: "And", exprs } : { type: "Or", exprs };
+  }
+  throw new Error("Unsupported condition in permissions compiler.");
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return Object.prototype.toString.call(value) === "[object Object]";
+}
+
+function isPolicyExpr(input: unknown): input is PolicyExpr {
+  return isPlainObject(input) && typeof input.type === "string";
+}
+
+function isSessionRefValue(input: unknown): input is SessionRefValue {
+  return (
+    isPlainObject(input) &&
+    input.__jazzPermissionKind === "session-ref" &&
+    Array.isArray(input.path)
+  );
+}
+
+function isRowRefValue(input: unknown): input is RowRefValue {
+  return (
+    isPlainObject(input) &&
+    input.__jazzPermissionKind === "row-ref" &&
+    typeof input.column === "string"
+  );
+}
+
+function isExistsCondition(input: unknown): input is ExistsCondition {
+  return (
+    isPlainObject(input) &&
+    input.__jazzPermissionKind === "exists" &&
+    typeof input.table === "string" &&
+    isPlainObject(input.where)
+  );
+}
+
+function isCompoundCondition(input: unknown): input is CompoundCondition {
+  return (
+    isPlainObject(input) &&
+    input.__jazzPermissionKind === "compound" &&
+    (input.op === "And" || input.op === "Or") &&
+    Array.isArray(input.conditions)
+  );
+}
+
+function isConditionBuilder(input: unknown): input is ConditionBuilder {
+  return isPlainObject(input) && typeof input._condition === "function";
+}
+
+function isUpdateRuleBuilder(input: unknown): input is UpdateRuleBuilder<unknown, unknown> {
+  return isPlainObject(input) && typeof input.toRule === "function";
+}

--- a/packages/jazz-tools/src/permissions/index.ts
+++ b/packages/jazz-tools/src/permissions/index.ts
@@ -647,13 +647,22 @@ function assertInheritsColumns(
   table: string,
   fkColumnsByTable: Map<string, Set<string>>,
 ): void {
-  const check = (node: PolicyExpr): void => {
+  const check = (node: PolicyExpr, currentTable: string): void => {
     switch (node.type) {
       case "Inherits": {
-        const fkColumns = fkColumnsByTable.get(table);
-        if (!fkColumns || !fkColumns.has(node.via_column)) {
+        const fkColumns = fkColumnsByTable.get(currentTable);
+        if (!fkColumns) {
           throw new Error(
-            `allowedTo.${node.operation.toLowerCase()}("${node.via_column}") is invalid for table "${table}": column is not a foreign key reference.`,
+            `allowedTo.${node.operation.toLowerCase()}("${node.via_column}") is invalid for table "${currentTable}": ` +
+              `table metadata is missing in app.wasmSchema.`,
+          );
+        }
+        if (!fkColumns.has(node.via_column)) {
+          const fkList = [...fkColumns].sort();
+          const available = fkList.length > 0 ? fkList.join(", ") : "(none)";
+          throw new Error(
+            `allowedTo.${node.operation.toLowerCase()}("${node.via_column}") is invalid for table "${currentTable}": ` +
+              `column is not a foreign key reference. Available FK columns: ${available}.`,
           );
         }
         break;
@@ -661,21 +670,21 @@ function assertInheritsColumns(
       case "And":
       case "Or":
         for (const child of node.exprs) {
-          check(child);
+          check(child, currentTable);
         }
         break;
       case "Not":
-        check(node.expr);
+        check(node.expr, currentTable);
         break;
       case "Exists":
-        check(node.condition);
+        check(node.condition, node.table);
         break;
       default:
         break;
     }
   };
 
-  check(expr);
+  check(expr, table);
 }
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {

--- a/packages/jazz-tools/src/permissions/index.ts
+++ b/packages/jazz-tools/src/permissions/index.ts
@@ -25,6 +25,8 @@ type WhereFor<QB> = QB extends { where(input: infer W): unknown } ? W : never;
 
 type PolicyAction = "read" | "insert" | "update" | "delete";
 
+const OUTER_ROW_SESSION_PREFIX = "__jazz_outer_row";
+
 interface SessionRefValue {
   readonly __jazzPermissionKind: "session-ref";
   readonly path: string[];
@@ -294,33 +296,41 @@ function resolveWhereInput(input: unknown): Condition {
     return input;
   }
   if (isPlainObject(input)) {
-    return whereObjectToCondition(input);
+    return whereObjectToCondition(input, { allowRowRefs: false });
   }
   throw new Error("Unsupported permission condition input.");
 }
 
-function whereObjectToCondition(where: Record<string, unknown>): Condition {
+function whereObjectToCondition(
+  where: Record<string, unknown>,
+  options: { allowRowRefs: boolean },
+): PolicyExpr {
   const exprs: PolicyExpr[] = [];
   for (const [column, raw] of Object.entries(where)) {
     if (raw === undefined) {
       continue;
     }
-    exprs.push(...columnFilterToExprs(column, raw));
+    exprs.push(...columnFilterToExprs(column, raw, options));
   }
   return andExpr(exprs);
 }
 
-function columnFilterToExprs(column: string, raw: unknown): PolicyExpr[] {
+function columnFilterToExprs(
+  column: string,
+  raw: unknown,
+  options: { allowRowRefs: boolean },
+): PolicyExpr[] {
   if (raw === null) {
     return [{ type: "IsNull", column }];
   }
   if (isSessionRefValue(raw)) {
-    return [cmpExpr(column, "Eq", raw)];
+    return [cmpExpr(column, "Eq", raw, options)];
   }
   if (isRowRefValue(raw)) {
-    throw new Error(
-      `Correlated row references in exists(...) are not yet supported ("${column}").`,
-    );
+    if (!options.allowRowRefs) {
+      throw new Error("Row references are only valid inside exists() clauses.");
+    }
+    return [cmpExpr(column, "Eq", raw, options)];
   }
   if (isPlainObject(raw)) {
     const exprs: PolicyExpr[] = [];
@@ -333,27 +343,27 @@ function columnFilterToExprs(column: string, raw: unknown): PolicyExpr[] {
           if (value === null) {
             exprs.push({ type: "IsNull", column });
           } else {
-            exprs.push(cmpExpr(column, "Eq", value));
+            exprs.push(cmpExpr(column, "Eq", value, options));
           }
           break;
         case "ne":
           if (value === null) {
             exprs.push({ type: "IsNotNull", column });
           } else {
-            exprs.push(cmpExpr(column, "Ne", value));
+            exprs.push(cmpExpr(column, "Ne", value, options));
           }
           break;
         case "gt":
-          exprs.push(cmpExpr(column, "Gt", value));
+          exprs.push(cmpExpr(column, "Gt", value, options));
           break;
         case "gte":
-          exprs.push(cmpExpr(column, "Ge", value));
+          exprs.push(cmpExpr(column, "Ge", value, options));
           break;
         case "lt":
-          exprs.push(cmpExpr(column, "Lt", value));
+          exprs.push(cmpExpr(column, "Lt", value, options));
           break;
         case "lte":
-          exprs.push(cmpExpr(column, "Le", value));
+          exprs.push(cmpExpr(column, "Le", value, options));
           break;
         case "isNull":
           if (typeof value !== "boolean") {
@@ -372,24 +382,35 @@ function columnFilterToExprs(column: string, raw: unknown): PolicyExpr[] {
     }
     return exprs.length === 0 ? [{ type: "True" }] : exprs;
   }
-  return [cmpExpr(column, "Eq", raw)];
+  return [cmpExpr(column, "Eq", raw, options)];
 }
 
-function cmpExpr(column: string, op: PolicyCmpOp, value: unknown): PolicyExpr {
+function cmpExpr(
+  column: string,
+  op: PolicyCmpOp,
+  value: unknown,
+  options: { allowRowRefs: boolean },
+): PolicyExpr {
   return {
     type: "Cmp",
     column,
     op,
-    value: toPolicyValue(value),
+    value: toPolicyValue(value, options),
   };
 }
 
-function toPolicyValue(value: unknown): PolicyValue {
+function toPolicyValue(value: unknown, options: { allowRowRefs: boolean }): PolicyValue {
   if (isSessionRefValue(value)) {
     return { type: "SessionRef", path: value.path };
   }
   if (isRowRefValue(value)) {
-    throw new Error("Row references are only valid inside exists() clauses.");
+    if (!options.allowRowRefs) {
+      throw new Error("Row references are only valid inside exists() clauses.");
+    }
+    return {
+      type: "SessionRef",
+      path: [OUTER_ROW_SESSION_PREFIX, value.column],
+    };
   }
   return { type: "Literal", value };
 }
@@ -515,7 +536,7 @@ function compileCondition(condition: Condition | undefined): PolicyExpr | undefi
     return condition;
   }
   if (isExistsCondition(condition)) {
-    const compiledCondition = compileCondition(resolveWhereInput(condition.where));
+    const compiledCondition = whereObjectToCondition(condition.where, { allowRowRefs: true });
     if (!compiledCondition) {
       throw new Error(
         `Failed to compile exists(...) condition for table "${condition.table}" in permissions.ts`,

--- a/packages/jazz-tools/src/permissions/type-inference.test.ts
+++ b/packages/jazz-tools/src/permissions/type-inference.test.ts
@@ -105,6 +105,12 @@ describe("permissions type inference", () => {
 
         // @ts-expect-error invalid action name
         policy.todos.allowPublish.where({ done: true });
+
+        // @ts-expect-error invalid exists where key for projects
+        policy.projects.exists.where({ missingColumn: true });
+
+        // @ts-expect-error row callback should expose only known todo columns
+        policy.todos.allowRead.where((todo) => ({ ownerId: todo.missingColumn }));
       }
 
       return [];

--- a/packages/jazz-tools/src/permissions/type-inference.test.ts
+++ b/packages/jazz-tools/src/permissions/type-inference.test.ts
@@ -1,0 +1,113 @@
+import { describe, expectTypeOf, it } from "vitest";
+import { definePermissions } from "./index.js";
+
+interface Todo {
+  id: string;
+  ownerId: string;
+  done: boolean;
+  projectId?: string;
+}
+
+interface TodoWhere {
+  id?: string;
+  ownerId?: string;
+  done?: boolean;
+  projectId?: string;
+}
+
+interface Project {
+  id: string;
+  ownerId: string;
+}
+
+interface ProjectWhere {
+  id?: string;
+  ownerId?: string;
+}
+
+class TodoQueryBuilder {
+  declare readonly _rowType: Todo;
+  where(_input: TodoWhere): TodoQueryBuilder {
+    return this;
+  }
+}
+
+class ProjectQueryBuilder {
+  declare readonly _rowType: Project;
+  where(_input: ProjectWhere): ProjectQueryBuilder {
+    return this;
+  }
+}
+
+const app = {
+  todos: new TodoQueryBuilder(),
+  projects: new ProjectQueryBuilder(),
+  wasmSchema: {
+    tables: {
+      todos: {
+        columns: [
+          { name: "id", column_type: { type: "Uuid" }, nullable: false },
+          { name: "ownerId", column_type: { type: "Text" }, nullable: false },
+          { name: "done", column_type: { type: "Boolean" }, nullable: false },
+          {
+            name: "projectId",
+            column_type: { type: "Uuid" },
+            nullable: true,
+            references: "projects",
+          },
+        ],
+      },
+      projects: {
+        columns: [
+          { name: "id", column_type: { type: "Uuid" }, nullable: false },
+          { name: "ownerId", column_type: { type: "Text" }, nullable: false },
+        ],
+      },
+    },
+  },
+} as const;
+
+describe("permissions type inference", () => {
+  it("infers row callback and where key types", () => {
+    definePermissions(app, ({ policy, either, allowedTo, session }) => {
+      expectTypeOf(session.userId.path).toEqualTypeOf<string[]>();
+
+      return [
+        policy.todos.allowRead.where((todo) =>
+          either({ done: false }).or(
+            policy.projects.exists.where({
+              id: todo.projectId,
+              ownerId: session.userId,
+            }),
+          ),
+        ),
+        policy.todos.allowUpdate
+          .whereOld(allowedTo.update("projectId"))
+          .whereNew(allowedTo.update("projectId")),
+      ];
+    });
+  });
+
+  it("rejects invalid table/column usage at compile time where possible", () => {
+    definePermissions(app, ({ policy, allowedTo }) => [
+      policy.todos.allowRead.where({ done: true }),
+      policy.todos.allowRead.where(allowedTo.read("projectId")),
+    ]);
+
+    definePermissions(app, ({ policy }) => {
+      // Type-level negative checks only: keep unreachable in normal runs.
+      if ((globalThis as { __typecheck_only__?: boolean }).__typecheck_only__) {
+        // @ts-expect-error unknown table key
+        policy.unknown.allowRead.where({});
+
+        // @ts-expect-error invalid where key for todos
+        policy.todos.allowRead.where({ missingColumn: true });
+
+        // @ts-expect-error invalid action name
+        policy.todos.allowPublish.where({ done: true });
+      }
+
+      return [];
+    });
+  });
+});

--- a/packages/jazz-tools/src/schema.ts
+++ b/packages/jazz-tools/src/schema.ts
@@ -43,6 +43,11 @@ export type PolicyExpr =
       session_path: string[];
     }
   | {
+      type: "Exists";
+      table: string;
+      condition: PolicyExpr;
+    }
+  | {
       type: "Inherits";
       operation: PolicyOperation;
       via_column: string;

--- a/packages/jazz-tools/src/sql-gen.ts
+++ b/packages/jazz-tools/src/sql-gen.ts
@@ -52,6 +52,8 @@ function policyExprToSql(expr: PolicyExpr): string {
       return `${expr.column} IS NOT NULL`;
     case "In":
       return `${expr.column} IN @session.${expr.session_path.join(".")}`;
+    case "Exists":
+      return `EXISTS (SELECT FROM ${expr.table} WHERE ${policyExprToSql(expr.condition)})`;
     case "Inherits":
       return `INHERITS ${expr.operation.toUpperCase()} VIA ${expr.via_column}`;
     case "And":

--- a/packages/jazz-tools/src/testing/index.test.ts
+++ b/packages/jazz-tools/src/testing/index.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createTestJwt,
+  expectAllowed,
+  expectDenied,
+  requestForClaims,
+  scopedClientForClaims,
+  seedRows,
+} from "./index.js";
+
+function decodeJwtPayload(token: string): Record<string, unknown> {
+  const payload = token.split(".")[1];
+  const base64 = payload.replace(/-/g, "+").replace(/_/g, "/");
+  const padded = base64 + "=".repeat((4 - (base64.length % 4)) % 4);
+  return JSON.parse(Buffer.from(padded, "base64").toString("utf8")) as Record<string, unknown>;
+}
+
+describe("testing helpers", () => {
+  it("creates a request with bearer token claims", () => {
+    const request = requestForClaims({
+      sub: "user-123",
+      claims: { role: "admin" },
+    });
+
+    const auth = (request.headers as Record<string, string>).authorization;
+    expect(auth).toMatch(/^Bearer /);
+    const token = auth.slice("Bearer ".length);
+    expect(decodeJwtPayload(token)).toEqual({
+      sub: "user-123",
+      claims: { role: "admin" },
+    });
+  });
+
+  it("creates a scoped client via forRequest", () => {
+    const scoped = { query: vi.fn() };
+    const forRequest = vi.fn((request: unknown) => {
+      void request;
+      return scoped;
+    });
+    const client = { forRequest } as unknown as Parameters<typeof scopedClientForClaims>[0];
+
+    const result = scopedClientForClaims(client, { sub: "user-9" });
+
+    expect(result).toBe(scoped);
+    expect(forRequest).toHaveBeenCalledTimes(1);
+    const firstCall = forRequest.mock.calls.at(0);
+    expect(firstCall).toBeDefined();
+    const request = firstCall![0] as { headers: Record<string, string> };
+    expect(request.headers.authorization).toMatch(/^Bearer /);
+  });
+
+  it("supports allow/deny assertions", async () => {
+    await expect(expectAllowed(async () => "ok")).resolves.toBeUndefined();
+    await expect(
+      expectDenied(async () => {
+        throw new Error("permission denied");
+      }),
+    ).resolves.toBeInstanceOf(Error);
+
+    await expect(
+      expectDenied(
+        async () => {
+          throw new Error("denied by policy");
+        },
+        { match: /policy/ },
+      ),
+    ).resolves.toBeInstanceOf(Error);
+
+    await expect(expectDenied(async () => "ok")).rejects.toThrow(
+      "Expected operation to be denied, but it succeeded.",
+    );
+  });
+
+  it("seeds rows through db.insert", async () => {
+    const insert = vi.fn((_table: unknown, row: unknown) => JSON.stringify(row));
+    const db = { insert } as unknown as Parameters<typeof seedRows>[0];
+    const table = { _table: "todos" } as unknown as Parameters<typeof seedRows>[1];
+
+    const ids = await seedRows(db, table, [
+      { title: "a", owner_id: "u1" },
+      { title: "b", owner_id: "u2" },
+    ]);
+
+    expect(insert).toHaveBeenCalledTimes(2);
+    expect(ids).toEqual([
+      JSON.stringify({ title: "a", owner_id: "u1" }),
+      JSON.stringify({ title: "b", owner_id: "u2" }),
+    ]);
+  });
+
+  it("creates unsigned JWT fixtures", () => {
+    const token = createTestJwt({ sub: "user-1", claims: { org: "acme" } });
+    expect(token.split(".")).toHaveLength(3);
+    expect(decodeJwtPayload(token)).toEqual({
+      sub: "user-1",
+      claims: { org: "acme" },
+    });
+  });
+});

--- a/packages/jazz-tools/src/testing/index.test.ts
+++ b/packages/jazz-tools/src/testing/index.test.ts
@@ -1,4 +1,7 @@
-import { describe, expect, it, vi } from "vitest";
+import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   createTestJwt,
   expectAllowed,
@@ -6,6 +9,7 @@ import {
   requestForClaims,
   scopedClientForClaims,
   seedRows,
+  startLocalJazzServer,
 } from "./index.js";
 
 function decodeJwtPayload(token: string): Record<string, unknown> {
@@ -13,6 +17,52 @@ function decodeJwtPayload(token: string): Record<string, unknown> {
   const base64 = payload.replace(/-/g, "+").replace(/_/g, "/");
   const padded = base64 + "=".repeat((4 - (base64.length % 4)) % 4);
   return JSON.parse(Buffer.from(padded, "base64").toString("utf8")) as Record<string, unknown>;
+}
+
+const tempRoots: string[] = [];
+const managedServers: Array<{ stop(): Promise<void> }> = [];
+
+afterEach(async () => {
+  await Promise.all(
+    managedServers.splice(0).map(async (server) => {
+      await server.stop();
+    }),
+  );
+  await Promise.all(
+    tempRoots.splice(0).map(async (root) => {
+      await rm(root, { recursive: true, force: true });
+    }),
+  );
+});
+
+async function createFakeJazzBin(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "jazz-tools-fake-bin-"));
+  tempRoots.push(root);
+  const scriptPath = join(root, "fake-jazz");
+
+  const script = `#!/bin/sh
+PORT="$4"
+node -e '
+const http = require("http");
+const port = Number(process.argv[1]);
+const server = http.createServer((req, res) => {
+  if (req.url === "/health") {
+    res.statusCode = 200;
+    res.end("ok");
+    return;
+  }
+  res.statusCode = 404;
+  res.end("missing");
+});
+server.listen(port, "127.0.0.1");
+process.on("SIGTERM", () => server.close(() => process.exit(0)));
+setInterval(() => {}, 1000);
+' "$PORT"
+`;
+
+  await writeFile(scriptPath, script);
+  await chmod(scriptPath, 0o755);
+  return scriptPath;
 }
 
 describe("testing helpers", () => {
@@ -95,5 +145,66 @@ describe("testing helpers", () => {
       sub: "user-1",
       claims: { org: "acme" },
     });
+  });
+
+  it("combines scoped clients with deny assertions in a realistic flow", async () => {
+    const scoped = {
+      query: vi.fn(async () => {
+        throw new Error("denied by policy");
+      }),
+    };
+    const forRequest = vi.fn(() => scoped);
+    const client = { forRequest } as unknown as Parameters<typeof scopedClientForClaims>[0];
+
+    const userClient = scopedClientForClaims(client, {
+      sub: "user-42",
+      claims: { role: "member", org: "acme" },
+    });
+
+    await expect(
+      expectDenied(() => userClient.query('{"table":"todos"}'), { match: /policy/ }),
+    ).resolves.toBeInstanceOf(Error);
+    expect(scoped.query).toHaveBeenCalledTimes(1);
+  });
+
+  it("combines seedRows with expectAllowed", async () => {
+    const inserted: Array<{ title: string; owner_id: string }> = [];
+    const insert = vi.fn((_table: unknown, row: unknown) => {
+      inserted.push(row as { title: string; owner_id: string });
+      return `id-${inserted.length}`;
+    });
+    const db = { insert } as unknown as Parameters<typeof seedRows>[0];
+    const table = { _table: "todos" } as unknown as Parameters<typeof seedRows>[1];
+
+    await expect(
+      expectAllowed(async () => {
+        const ids = await seedRows(db, table, [
+          { title: "a", owner_id: "u1" },
+          { title: "b", owner_id: "u1" },
+        ]);
+        expect(ids).toEqual(["id-1", "id-2"]);
+      }),
+    ).resolves.toBeUndefined();
+    expect(inserted).toEqual([
+      { title: "a", owner_id: "u1" },
+      { title: "b", owner_id: "u1" },
+    ]);
+  });
+
+  it("starts and stops a local server process", async () => {
+    const fakeJazzBin = await createFakeJazzBin();
+    const server = await startLocalJazzServer({
+      appId: "test-app",
+      jazzBin: fakeJazzBin,
+      startupTimeoutMs: 3_000,
+    });
+
+    managedServers.push(server);
+
+    const health = await fetch(`${server.url}/health`);
+    expect(health.status).toBe(200);
+
+    await server.stop();
+    managedServers.pop();
   });
 });

--- a/packages/jazz-tools/src/testing/index.test.ts
+++ b/packages/jazz-tools/src/testing/index.test.ts
@@ -65,6 +65,51 @@ setInterval(() => {}, 1000);
   return scriptPath;
 }
 
+async function createFailingJazzBin(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "jazz-tools-fake-bin-fail-"));
+  tempRoots.push(root);
+  const scriptPath = join(root, "fake-jazz-fail");
+
+  const script = `#!/bin/sh
+exit 13
+`;
+
+  await writeFile(scriptPath, script);
+  await chmod(scriptPath, 0o755);
+  return scriptPath;
+}
+
+async function createIgnoreTermJazzBin(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "jazz-tools-fake-bin-ignore-term-"));
+  tempRoots.push(root);
+  const scriptPath = join(root, "fake-jazz-ignore-term");
+
+  const script = `#!/bin/sh
+PORT="$4"
+node -e '
+const http = require("http");
+process.on("SIGTERM", () => {
+  // Intentionally ignore SIGTERM to force SIGKILL fallback paths.
+});
+const server = http.createServer((req, res) => {
+  if (req.url === "/health") {
+    res.statusCode = 200;
+    res.end("ok");
+    return;
+  }
+  res.statusCode = 404;
+  res.end("missing");
+});
+server.listen(Number(process.argv[1]), "127.0.0.1");
+setInterval(() => {}, 1000);
+' "$PORT"
+`;
+
+  await writeFile(scriptPath, script);
+  await chmod(scriptPath, 0o755);
+  return scriptPath;
+}
+
 describe("testing helpers", () => {
   it("creates a request with bearer token claims", () => {
     const request = requestForClaims({
@@ -206,5 +251,39 @@ describe("testing helpers", () => {
 
     await server.stop();
     managedServers.pop();
+  });
+
+  it("fails fast when the server process exits before health checks pass", async () => {
+    const failingJazzBin = await createFailingJazzBin();
+    const startedAt = Date.now();
+
+    await expect(
+      startLocalJazzServer({
+        appId: "test-app-fail-fast",
+        jazzBin: failingJazzBin,
+        startupTimeoutMs: 5_000,
+      }),
+    ).rejects.toThrow(/exited before becoming healthy/i);
+
+    const elapsedMs = Date.now() - startedAt;
+    expect(elapsedMs).toBeLessThan(1_500);
+  });
+
+  it("force-stops stubborn server processes that ignore SIGTERM", async () => {
+    const stubbornJazzBin = await createIgnoreTermJazzBin();
+    const server = await startLocalJazzServer({
+      appId: "test-app-ignore-term",
+      jazzBin: stubbornJazzBin,
+      startupTimeoutMs: 3_000,
+    });
+
+    const pid = server.process.pid;
+    expect(pid).toBeTypeOf("number");
+
+    await server.stop();
+
+    if (typeof pid === "number") {
+      expect(() => process.kill(pid, 0)).toThrow();
+    }
   });
 });

--- a/packages/jazz-tools/src/testing/index.ts
+++ b/packages/jazz-tools/src/testing/index.ts
@@ -1,0 +1,202 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import { createServer } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { RequestLike, SessionClient, JazzClient } from "../runtime/client.js";
+import type { Db, TableProxy } from "../runtime/db.js";
+
+export interface TestClaims {
+  sub: string;
+  claims?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+export interface LocalJazzServerOptions {
+  appId: string;
+  jazzBin?: string;
+  port?: number;
+  dataDir?: string;
+  jwtSecret?: string;
+  adminSecret?: string;
+  startupTimeoutMs?: number;
+  env?: NodeJS.ProcessEnv;
+}
+
+export interface LocalJazzServer {
+  appId: string;
+  url: string;
+  port: number;
+  dataDir: string;
+  jwtSecret: string;
+  adminSecret: string;
+  process: ChildProcess;
+  stop(): Promise<void>;
+}
+
+function toBase64Url(value: unknown): string {
+  const encoded = Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+  return encoded.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+}
+
+export function createTestJwt(payload: TestClaims): string {
+  const header = { alg: "HS256", typ: "JWT" };
+  return `${toBase64Url(header)}.${toBase64Url(payload)}.test-signature`;
+}
+
+export function requestForClaims(payload: TestClaims): RequestLike {
+  const token = createTestJwt(payload);
+  return {
+    headers: {
+      authorization: `Bearer ${token}`,
+    },
+  };
+}
+
+export function scopedClientForClaims(client: JazzClient, payload: TestClaims): SessionClient {
+  return client.forRequest(requestForClaims(payload));
+}
+
+export async function seedRows<T, Init>(
+  db: Db,
+  table: TableProxy<T, Init>,
+  rows: Init[],
+): Promise<string[]> {
+  return rows.map((row) => db.insert(table, row));
+}
+
+export async function expectAllowed(op: () => Promise<unknown> | unknown): Promise<void> {
+  await op();
+}
+
+export async function expectDenied(
+  op: () => Promise<unknown> | unknown,
+  options?: { match?: RegExp | string },
+): Promise<Error> {
+  try {
+    await op();
+  } catch (error) {
+    if (!options?.match) {
+      return toError(error);
+    }
+    const err = toError(error);
+    const message = err.message;
+    if (typeof options.match === "string") {
+      if (!message.includes(options.match)) {
+        throw new Error(
+          `Operation failed, but error did not include expected text: "${options.match}". Actual: "${message}"`,
+        );
+      }
+      return err;
+    }
+    if (!options.match.test(message)) {
+      throw new Error(
+        `Operation failed, but error did not match ${options.match}. Actual: "${message}"`,
+      );
+    }
+    return err;
+  }
+  throw new Error("Expected operation to be denied, but it succeeded.");
+}
+
+function toError(error: unknown): Error {
+  if (error instanceof Error) {
+    return error;
+  }
+  return new Error(String(error));
+}
+
+async function pickOpenPort(): Promise<number> {
+  return await new Promise<number>((resolve, reject) => {
+    const server = createServer();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        server.close(() => reject(new Error("Failed to resolve an open port.")));
+        return;
+      }
+      const { port } = address;
+      server.close((closeErr) => {
+        if (closeErr) {
+          reject(closeErr);
+          return;
+        }
+        resolve(port);
+      });
+    });
+  });
+}
+
+async function waitForHealth(url: string, timeoutMs: number): Promise<void> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    try {
+      const resp = await fetch(url);
+      if (resp.ok) {
+        return;
+      }
+    } catch {
+      // Server not ready yet.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`Jazz server did not become healthy within ${timeoutMs}ms (${url}).`);
+}
+
+export async function startLocalJazzServer(
+  options: LocalJazzServerOptions,
+): Promise<LocalJazzServer> {
+  const jazzBin = options.jazzBin ?? "jazz-tools";
+  const port = options.port ?? (await pickOpenPort());
+  const jwtSecret = options.jwtSecret ?? "test-jwt-secret";
+  const adminSecret = options.adminSecret ?? "test-admin-secret";
+  const ownsDataDir = !options.dataDir;
+  const dataDir = options.dataDir ?? (await mkdtemp(join(tmpdir(), "jazz-policy-test-")));
+
+  const child = spawn(
+    jazzBin,
+    ["server", options.appId, "--port", String(port), "--data-dir", dataDir],
+    {
+      env: {
+        ...process.env,
+        ...options.env,
+        JAZZ_JWT_SECRET: jwtSecret,
+        JAZZ_ADMIN_SECRET: adminSecret,
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+
+  const healthUrl = `http://127.0.0.1:${port}/health`;
+
+  try {
+    await waitForHealth(healthUrl, options.startupTimeoutMs ?? 10_000);
+  } catch (error) {
+    child.kill("SIGTERM");
+    if (ownsDataDir) {
+      await rm(dataDir, { recursive: true, force: true });
+    }
+    throw error;
+  }
+
+  return {
+    appId: options.appId,
+    url: `http://127.0.0.1:${port}`,
+    port,
+    dataDir,
+    jwtSecret,
+    adminSecret,
+    process: child,
+    async stop() {
+      child.kill("SIGTERM");
+      await new Promise<void>((resolve) => {
+        child.once("exit", () => resolve());
+        setTimeout(resolve, 2_000);
+      });
+      if (ownsDataDir) {
+        await rm(dataDir, { recursive: true, force: true });
+      }
+    },
+  };
+}

--- a/packages/jazz-tools/src/testing/index.ts
+++ b/packages/jazz-tools/src/testing/index.ts
@@ -34,6 +34,42 @@ export interface LocalJazzServer {
   stop(): Promise<void>;
 }
 
+async function terminateProcess(child: ChildProcess, timeoutMs: number): Promise<void> {
+  const exited = await new Promise<boolean>((resolve) => {
+    if (child.exitCode !== null || child.signalCode !== null) {
+      resolve(true);
+      return;
+    }
+    const onExit = (): void => {
+      clearTimeout(timer);
+      resolve(true);
+    };
+    const timer = setTimeout(() => {
+      child.off("exit", onExit);
+      resolve(false);
+    }, timeoutMs);
+    child.once("exit", onExit);
+    child.kill("SIGTERM");
+  });
+
+  if (exited) {
+    return;
+  }
+
+  await new Promise<void>((resolve) => {
+    const onExit = (): void => {
+      clearTimeout(timer);
+      resolve();
+    };
+    const timer = setTimeout(() => {
+      child.off("exit", onExit);
+      resolve();
+    }, timeoutMs);
+    child.once("exit", onExit);
+    child.kill("SIGKILL");
+  });
+}
+
 function toBase64Url(value: unknown): string {
   const encoded = Buffer.from(JSON.stringify(value), "utf8").toString("base64");
   return encoded.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
@@ -128,20 +164,79 @@ async function pickOpenPort(): Promise<number> {
   });
 }
 
-async function waitForHealth(url: string, timeoutMs: number): Promise<void> {
+async function waitForHealth(child: ChildProcess, url: string, timeoutMs: number): Promise<void> {
   const startedAt = Date.now();
-  while (Date.now() - startedAt < timeoutMs) {
-    try {
-      const resp = await fetch(url);
-      if (resp.ok) {
+  let lastHealthError: unknown;
+
+  await new Promise<void>((resolve, reject) => {
+    let settled = false;
+    let timer: NodeJS.Timeout | undefined;
+
+    const cleanup = (): void => {
+      child.off("exit", onExit);
+      child.off("error", onError);
+      if (timer) {
+        clearTimeout(timer);
+      }
+    };
+
+    const finish = (error?: Error): void => {
+      if (settled) {
         return;
       }
-    } catch {
-      // Server not ready yet.
-    }
-    await new Promise((resolve) => setTimeout(resolve, 100));
-  }
-  throw new Error(`Jazz server did not become healthy within ${timeoutMs}ms (${url}).`);
+      settled = true;
+      cleanup();
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    };
+
+    const onExit = (code: number | null, signal: NodeJS.Signals | null): void => {
+      finish(
+        new Error(
+          `Jazz server exited before becoming healthy (code: ${code ?? "null"}, signal: ${signal ?? "none"}).`,
+        ),
+      );
+    };
+
+    const onError = (error: Error): void => {
+      finish(new Error(`Failed to start Jazz server process: ${error.message}`));
+    };
+
+    const poll = async (): Promise<void> => {
+      if (settled) {
+        return;
+      }
+      if (Date.now() - startedAt >= timeoutMs) {
+        const detail =
+          lastHealthError instanceof Error ? ` Last health error: ${lastHealthError.message}` : "";
+        finish(
+          new Error(`Jazz server did not become healthy within ${timeoutMs}ms (${url}).${detail}`),
+        );
+        return;
+      }
+
+      try {
+        const resp = await fetch(url);
+        if (resp.ok) {
+          finish();
+          return;
+        }
+      } catch (error) {
+        lastHealthError = error;
+      }
+
+      timer = setTimeout(() => {
+        void poll();
+      }, 100);
+    };
+
+    child.once("exit", onExit);
+    child.once("error", onError);
+    void poll();
+  });
 }
 
 export async function startLocalJazzServer(
@@ -167,13 +262,16 @@ export async function startLocalJazzServer(
       stdio: ["ignore", "pipe", "pipe"],
     },
   );
+  // Prevent child stdio backpressure from stalling long-lived test servers.
+  child.stdout?.on("data", () => {});
+  child.stderr?.on("data", () => {});
 
   const healthUrl = `http://127.0.0.1:${port}/health`;
 
   try {
-    await waitForHealth(healthUrl, options.startupTimeoutMs ?? 10_000);
+    await waitForHealth(child, healthUrl, options.startupTimeoutMs ?? 10_000);
   } catch (error) {
-    child.kill("SIGTERM");
+    await terminateProcess(child, 1_000);
     if (ownsDataDir) {
       await rm(dataDir, { recursive: true, force: true });
     }
@@ -189,11 +287,7 @@ export async function startLocalJazzServer(
     adminSecret,
     process: child,
     async stop() {
-      child.kill("SIGTERM");
-      await new Promise<void>((resolve) => {
-        child.once("exit", () => resolve());
-        setTimeout(resolve, 2_000);
-      });
+      await terminateProcess(child, 2_000);
       if (ownsDataDir) {
         await rm(dataDir, { recursive: true, force: true });
       }

--- a/specs/todo/a_mvp/permissions_ts_policy_dsl.md
+++ b/specs/todo/a_mvp/permissions_ts_policy_dsl.md
@@ -1,0 +1,146 @@
+# TypeScript Permissions DSL Redesign (permissions.ts) — TODO (MVP)
+
+Move policy authoring out of `schema/current.ts` into a dedicated `schema/permissions.ts` file, with policy expressions written in a query-like TypeScript DSL that is schema-aware and testable.
+
+## Goals
+
+- Keep schema structure and policy logic separate.
+- Make policy code read like query code.
+- Reuse generated TypeScript client types for table/column safety.
+- Encourage policy tests by convention (`schema/permissions.test.ts`).
+- Compile to the existing policy AST/runtime (no Rust permission engine rewrite).
+
+## Non-goals
+
+- Changing SQL policy semantics in Groove.
+- Introducing a second runtime enforcement path.
+- Replacing SQL schema permissions in this phase.
+
+## File Conventions
+
+- `schema/current.ts`: tables, columns, relations, indexes.
+- `schema/permissions.ts`: policy definitions for those tables.
+- `schema/permissions.test.ts`: generated starter test (single stub + comment guidance).
+
+## Proposed API Shape
+
+```ts
+import { app } from "./app";
+import { definePermissions } from "jazz-tools/permissions";
+
+export default definePermissions(app, ({ policy, either, both, session }) => [
+  policy.todos.allowRead.where((todo) =>
+    either({ ownerId: session.userId }).or(
+      policy.todoShares.exists.where({
+        todoId: todo.id,
+        userId: session.userId,
+        canRead: true,
+      }),
+    ),
+  ),
+
+  policy.todos.allowInsert.where({ ownerId: session.userId }),
+
+  policy.todos.allowUpdate
+    .whereOld(both({ ownerId: session.userId }).and({ archived: false }))
+    .whereNew({ ownerId: session.userId }), // prevent owner reassignment
+
+  policy.todos.allowDelete.where({ ownerId: session.userId }),
+]);
+```
+
+## Expression Rules
+
+`where(...)`, `whereOld(...)`, and `whereNew(...)` accept either:
+
+- A normal query-style filter object.
+- A callback that receives row context and returns a condition.
+
+`either(...)` and `both(...)` create composable condition builders:
+
+- `either(a).or(b).or(c)` => OR chain.
+- `both(a).and(b).and(c)` => AND chain.
+
+`policy.<table>.exists.where(...)` expresses existence checks against related tables.
+
+`session.*` resolves JWT claims in policy expressions (`session.userId` maps to claim key configured by auth mapping; default: `sub`).
+
+## Update Semantics
+
+- `allowUpdate.whereOld(...)` compiles to `USING`.
+- `allowUpdate.whereNew(...)` compiles to `WITH CHECK`.
+- If `whereNew` is omitted, default behavior matches current semantics (fallback to old/update USING rule).
+
+## Compilation Strategy
+
+Keep backend runtime unchanged by compiling new TS DSL to existing `PolicyExpr` AST:
+
+1. Parse permission builder calls into an intermediate TS policy IR.
+2. Normalize IR into existing schema policy shape (`select/insert/update/delete` with `using`/`with_check`).
+3. Reuse existing SQL generation and runtime policy evaluation.
+
+## Build Pipeline Changes
+
+Need multi-phase build to avoid circular dependency:
+
+1. Load `schema/current.ts`.
+2. Generate temporary typed app client artifact for permissions authoring.
+3. Load/compile `schema/permissions.ts`.
+4. Emit final schema artifacts and client.
+5. If missing, generate `schema/permissions.test.ts` stub once (do not overwrite user edits).
+
+## Generated Client / Typegen Lift
+
+Extend generated typings for policy contexts:
+
+- Row callback parameter typing per table (`todo.id`, etc.).
+- `session` claim references as typed placeholders.
+- `exists` condition typing across tables and refs.
+- Shared filter-object type between query `.where` and policy `.where`.
+
+## Testing Helpers (new package surface)
+
+Target helper API:
+
+```ts
+import { createPolicyTestApp } from "jazz-tools/testing";
+
+const t = await createPolicyTestApp({ schema, permissions });
+await t.seed(({ db }) => db.todos.insert({ id: "t1", ownerId: "u1" }));
+
+const alice = t.as({ sub: "u1" });
+await t.expectAllowed(() => alice.query(t.app.todos).all());
+await t.expectDenied(() => alice.mutate(t.app.todos).delete({ id: "t2" }));
+```
+
+Helper responsibilities:
+
+- Spin up disposable local Jazz server/runtime.
+- Seed synthetic data.
+- Mint request-scoped clients with custom claims.
+- Assert allow/deny for queries and mutations.
+
+## Rollout Plan
+
+1. Add new DSL package surface (`jazz-tools/permissions`) with typed builders and IR.
+2. Add compiler from new DSL IR to existing `PolicyExpr`.
+3. Add CLI support for `schema/permissions.ts`.
+4. Add `permissions.test.ts` stub generation + testing helpers.
+5. Migrate docs examples and `examples/docs/*` to new pattern.
+6. Add compatibility path:
+   - Continue supporting inline `permissions` in `current.ts` during transition.
+   - If both are present, fail with clear error.
+
+## Open Questions
+
+- Session claim mapping: global config only, or per-policy override?
+- Whether callback `where((row) => ...)` should allow arbitrary logic or only condition-builder returns.
+- How far to support nested include-style predicates in MVP.
+- Exact error model for `expectDenied` assertions (status code vs structured reason).
+
+## Success Criteria
+
+- New example app policies read like query logic and typecheck.
+- Existing SQL/runtime permission behavior remains unchanged.
+- Policy tests can be authored with <20 lines for common allow/deny cases.
+- Docs can teach permissions without exposing hashed migration filenames or snippet artifacts.

--- a/specs/todo/a_mvp/permissions_ts_policy_dsl.md
+++ b/specs/todo/a_mvp/permissions_ts_policy_dsl.md
@@ -28,7 +28,7 @@ Move policy authoring out of `schema/current.ts` into a dedicated `schema/permis
 import { app } from "./app";
 import { definePermissions } from "jazz-tools/permissions";
 
-export default definePermissions(app, ({ policy, either, both, session }) => [
+export default definePermissions(app, ({ policy, either, both, allowedTo, session }) => [
   policy.todos.allowRead.where((todo) =>
     either({ ownerId: session.userId }).or(
       policy.todoShares.exists.where({
@@ -39,11 +39,13 @@ export default definePermissions(app, ({ policy, either, both, session }) => [
     ),
   ),
 
+  policy.todos.allowRead.where(allowedTo.read("projectId")),
+
   policy.todos.allowInsert.where({ ownerId: session.userId }),
 
   policy.todos.allowUpdate
-    .whereOld(both({ ownerId: session.userId }).and({ archived: false }))
-    .whereNew({ ownerId: session.userId }), // prevent owner reassignment
+    .whereOld(both(allowedTo.update("projectId")).and({ ownerId: session.userId }))
+    .whereNew(allowedTo.update("projectId")), // parent update permission required
 
   policy.todos.allowDelete.where({ ownerId: session.userId }),
 ]);
@@ -61,6 +63,18 @@ export default definePermissions(app, ({ policy, either, both, session }) => [
 - `either(a).or(b).or(c)` => OR chain.
 - `both(a).and(b).and(c)` => AND chain.
 
+`allowedTo.<operation>(fkColumn)` creates INHERITS conditions:
+
+- `allowedTo.read("projectId")` -> `INHERITS SELECT VIA projectId`
+- `allowedTo.insert("projectId")` -> `INHERITS INSERT VIA projectId`
+- `allowedTo.update("projectId")` -> `INHERITS UPDATE VIA projectId`
+- `allowedTo.delete("projectId")` -> `INHERITS DELETE VIA projectId`
+
+Design notes:
+
+- `fkColumn` is typed to FK columns of the current table only.
+- No compatibility alias for `inherits(...)` in this prototype.
+
 `policy.<table>.exists.where(...)` expresses existence checks against related tables.
 
 `session.*` resolves JWT claims in policy expressions (`session.userId` maps to claim key configured by auth mapping; default: `sub`).
@@ -70,6 +84,7 @@ export default definePermissions(app, ({ policy, either, both, session }) => [
 - `allowUpdate.whereOld(...)` compiles to `USING`.
 - `allowUpdate.whereNew(...)` compiles to `WITH CHECK`.
 - If `whereNew` is omitted, default behavior matches current semantics (fallback to old/update USING rule).
+- `allowedTo.update(fk)` follows parent `UPDATE USING` semantics for inherited checks.
 
 ## Compilation Strategy
 


### PR DESCRIPTION
## Summary
- add the TypeScript `permissions.ts` DSL flow and compile path, including correlated `exists` support
- introduce `allowedTo.read/insert/update/delete` helpers and FK validation
- expand coverage with permissions unit tests, CLI generation tests, and type-inference tests
- refresh permissions and migrations docs/snippets (TS + SQL policy sections, schema + `permissions.ts` framing, SQL forward/backward stub examples)

## Validation
- `pnpm --filter jazz-tools exec tsc -p tsconfig.json --noEmit`
- `pnpm --filter jazz-tools exec vitest run --config vitest.config.ts src/permissions/index.test.ts src/permissions/type-inference.test.ts src/cli.test.ts src/testing/index.test.ts`
- `pnpm --dir examples/docs/todo-server-ts exec tsc -p tsconfig.json --noEmit`
- docs dev server smoke check: `/docs/permissions` and `/docs/migrations` return 200
