### PR TITLE
fix: remove addnab/docker-run unmaintained action

### DIFF
--- a/.github/workflows/napi-build-reusable.yml
+++ b/.github/workflows/napi-build-reusable.yml
@@ -276,8 +276,11 @@ jobs:
       - run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
         if: ${{ contains(matrix.target, 'armv7') }}
       - name: Test bindings
-        uses: addnab/docker-run-action@v3
-        with:
-          image: ${{ steps.docker.outputs.IMAGE }}
-          options: '-v ${{ github.workspace }}:${{ github.workspace }} -w ${{ github.workspace }} --platform ${{ steps.docker.outputs.PLATFORM }}'
-          run: cd ${{ env.PATH_BUILD }} && npm run test:ci && cd -
+        run: |
+          docker run \
+            -v "/var/run/docker.sock":"/var/run/docker.sock" \
+            -v "${{ github.workspace }}:${{ github.workspace }}" \
+            -w "${{ github.workspace }}" \
+            --platform ${{ steps.docker.outputs.PLATFORM }} \
+            ${{ steps.docker.outputs.IMAGE }} \
+            sh -c "cd ${{ env.PATH_BUILD }} && npm run test:ci"


### PR DESCRIPTION
NAPI build action used `addnab/docker-run-action@v3`, which is [unmaintained](https://github.com/addnab/docker-run-action). It started throwing errors related to the Docker version: https://github.com/garden-co/jazz/actions/runs/22135271777/job/63985851792#step:13:17

Since it was a very simple wrapper around docker run, I replaced it with `docker run` command.


Known issue: https://github.com/addnab/docker-run-action/issues/62