### PR TITLE
fix: Typescript DSL integration tests

### DIFF
--- a/examples/todo-client-localfirst-react/schema/app.ts
+++ b/examples/todo-client-localfirst-react/schema/app.ts
@@ -151,7 +151,7 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
   readonly _table = "projects";
   readonly _schema: WasmSchema = wasmSchema;
   declare _rowType!: Project;
-  declare _initType!: ProjectInit;
+  declare readonly _initType: ProjectInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<ProjectInclude> = {};
   private _orderBys: Array<[string, "asc" | "desc"]> = [];
@@ -225,7 +225,7 @@ export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilde
   readonly _table = "todos";
   readonly _schema: WasmSchema = wasmSchema;
   declare _rowType!: Todo;
-  declare _initType!: TodoInit;
+  declare readonly _initType: TodoInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<TodoInclude> = {};
   private _orderBys: Array<[string, "asc" | "desc"]> = [];

--- a/examples/todo-client-localfirst-ts/schema/app.ts
+++ b/examples/todo-client-localfirst-ts/schema/app.ts
@@ -151,7 +151,7 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
   readonly _table = "projects";
   readonly _schema: WasmSchema = wasmSchema;
   declare _rowType!: Project;
-  declare _initType!: ProjectInit;
+  declare readonly _initType: ProjectInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<ProjectInclude> = {};
   private _orderBys: Array<[string, "asc" | "desc"]> = [];
@@ -225,7 +225,7 @@ export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilde
   readonly _table = "todos";
   readonly _schema: WasmSchema = wasmSchema;
   declare _rowType!: Todo;
-  declare _initType!: TodoInit;
+  declare readonly _initType: TodoInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<TodoInclude> = {};
   private _orderBys: Array<[string, "asc" | "desc"]> = [];

--- a/packages/jazz-tools/src/runtime/client.ts
+++ b/packages/jazz-tools/src/runtime/client.ts
@@ -702,17 +702,19 @@ export async function loadWasmModule(): Promise<WasmModule> {
   let nodeInitDone = false;
   if (typeof process !== "undefined" && process.versions?.node) {
     try {
-      const { readFileSync } = await import("node:fs");
-      const { fileURLToPath } = await import("node:url");
-      const { dirname, join } = await import("node:path");
+      const { existsSync, readFileSync } = await import("node:fs");
+      const { createRequire } = await import("node:module");
+      const { dirname, resolve } = await import("node:path");
 
-      const wasmPath = join(
-        dirname(fileURLToPath(import.meta.url)),
-        "../../node_modules/jazz-wasm/jazz_wasm_bg.wasm",
-      );
-      const wasmBytes = readFileSync(wasmPath);
-      wasmModule.initSync(wasmBytes);
-      nodeInitDone = true;
+      const require = createRequire(import.meta.url);
+      const packageJsonPath = require.resolve("jazz-wasm/package.json");
+      const packageDir = dirname(packageJsonPath);
+      const wasmPath = resolve(packageDir, "pkg/jazz_wasm_bg.wasm");
+
+      if (existsSync(wasmPath)) {
+        wasmModule.initSync({ module: readFileSync(wasmPath) });
+        nodeInitDone = true;
+      }
     } catch {
       // Node modules unavailable (e.g. React Native with process polyfill)
     }

--- a/packages/jazz-tools/tests/ts-dsl/query-api.test.ts
+++ b/packages/jazz-tools/tests/ts-dsl/query-api.test.ts
@@ -1,4 +1,4 @@
-import { createDb, Db } from "jazz-tools";
+import { createDb, type Db } from "../../src/runtime/db.js";
 import { afterEach, describe, it, expect } from "vitest";
 import { app } from "./fixtures/basic/app";
 


### PR DESCRIPTION
Use package-based resolution for `jazz-wasm` in `loadWasmModule()` (`require.resolve("jazz-wasm/package.json")`) instead of a brittle relative `node_modules` path, and update `query-api.test.ts` to import `createDb` from source runtime. This prevents Node/Vitest from falling back to fetch-based wasm init and fixes the test failures in Typescript DSL integration tests.