### PR TITLE
feat: add debug info for wasm profiling

### DIFF
--- a/crates/jazz-wasm/Cargo.toml
+++ b/crates/jazz-wasm/Cargo.toml
@@ -43,3 +43,8 @@ web-sys = { version = "0.3", features = [
 
 [features]
 default = ["console_error_panic_hook"]
+
+# Even if the profiling profile is set, wasm-opt will strip off debug info unless the `-g` param is provided. 
+# See https://github.com/DataDog/js-instrumentation-wasm/pull/12
+[package.metadata.wasm-pack.profile.profiling]
+wasm-opt = ["-g"]

--- a/crates/jazz-wasm/package.json
+++ b/crates/jazz-wasm/package.json
@@ -22,7 +22,8 @@
   "main": "pkg/jazz_wasm.js",
   "types": "pkg/jazz_wasm.d.ts",
   "scripts": {
-    "build": "wasm-pack build --target web"
+    "build": "wasm-pack build --target web",
+    "build:profiling": "wasm-pack build --target web --profiling"
   },
   "dependencies": {
     "wasm-pack": "^0.14.0"

--- a/crates/jazz-wasm/package.json
+++ b/crates/jazz-wasm/package.json
@@ -22,8 +22,7 @@
   "main": "pkg/jazz_wasm.js",
   "types": "pkg/jazz_wasm.d.ts",
   "scripts": {
-    "build": "wasm-pack build --target web",
-    "build:profiling": "wasm-pack build --target web --profiling"
+    "build": "wasm-pack build --target web --profiling"
   },
   "dependencies": {
     "wasm-pack": "^0.14.0"


### PR DESCRIPTION
Modifies the `build` command in `jazz-wasm` to preserve Rust function names for profiling.

**Before:**
<img width="1728" height="525" alt="Screenshot 2026-02-20 at 4 24 28 PM" src="https://github.com/user-attachments/assets/ac76c01d-ecbd-405c-a419-2c48f12245b5" />

**After:**
<img width="1728" height="525" alt="Screenshot 2026-02-20 at 4 21 55 PM" src="https://github.com/user-attachments/assets/bd8512c9-1d4d-4db7-9767-380ed6460ff5" />
