### PR TITLE
perf: batch sync messages sent between main thread and worker

### DIFF
--- a/packages/jazz-tools/src/runtime/worker-bridge.ts
+++ b/packages/jazz-tools/src/runtime/worker-bridge.ts
@@ -38,6 +38,8 @@ export class WorkerBridge {
   private worker: Worker;
   private runtime: Runtime;
   private workerClientId: string | null = null;
+  private pendingSyncPayloadsForWorker: string[] = [];
+  private syncBatchFlushQueued = false;
 
   constructor(worker: Worker, runtime: Runtime) {
     this.worker = worker;
@@ -59,10 +61,7 @@ export class WorkerBridge {
       const parsed = JSON.parse(envelope);
       // Only forward server-bound messages (worker IS the server)
       if (parsed.destination && "Server" in parsed.destination) {
-        this.worker.postMessage({
-          type: "sync",
-          payload: JSON.stringify(parsed.payload),
-        });
+        this.enqueueSyncMessageForWorker(JSON.stringify(parsed.payload));
       }
     });
 
@@ -141,6 +140,24 @@ export class WorkerBridge {
    */
   getWorkerClientId(): string | null {
     return this.workerClientId;
+  }
+
+  private enqueueSyncMessageForWorker(payload: string): void {
+    this.pendingSyncPayloadsForWorker.push(payload);
+    if (this.syncBatchFlushQueued) return;
+
+    this.syncBatchFlushQueued = true;
+    queueMicrotask(() => {
+      this.syncBatchFlushQueued = false;
+      const payloads = this.pendingSyncPayloadsForWorker;
+      this.pendingSyncPayloadsForWorker = [];
+      if (payloads.length === 0) return;
+
+      this.worker.postMessage({
+        type: "sync",
+        payload: payloads,
+      });
+    });
   }
 }
 

--- a/packages/jazz-tools/src/runtime/worker-bridge.ts
+++ b/packages/jazz-tools/src/runtime/worker-bridge.ts
@@ -48,7 +48,9 @@ export class WorkerBridge {
       const msg = event.data;
       if (msg.type === "sync") {
         // Worker sends payload-only (it's the "server" for main thread)
-        this.runtime.onSyncMessageReceived(msg.payload);
+        for (const payload of msg.payload) {
+          this.runtime.onSyncMessageReceived(payload);
+        }
       }
     };
 

--- a/packages/jazz-tools/src/worker/groove-worker.ts
+++ b/packages/jazz-tools/src/worker/groove-worker.ts
@@ -287,10 +287,13 @@ self.onmessage = async (event: MessageEvent<MainToWorkerMessage>) => {
       break;
 
     case "sync": {
+      const payloads = msg.payload;
       if (runtime && mainClientId && initComplete) {
-        runtime.onSyncMessageReceivedFromClient(mainClientId, msg.payload);
+        for (const payload of payloads) {
+          runtime.onSyncMessageReceivedFromClient(mainClientId, payload);
+        }
       } else {
-        pendingSyncMessages.push(msg.payload);
+        pendingSyncMessages.push(...payloads);
       }
       break;
     }

--- a/packages/jazz-tools/src/worker/groove-worker.ts
+++ b/packages/jazz-tools/src/worker/groove-worker.ts
@@ -39,7 +39,23 @@ let streamConnecting = false;
 let streamAttached = false;
 let isShuttingDown = false;
 let pendingSyncMessages: string[] = []; // Buffer sync messages until init completes
+let pendingSyncPayloadsForMain: string[] = [];
+let syncBatchFlushQueued = false;
 let initComplete = false;
+
+function enqueueSyncMessageForMain(payload: string): void {
+  pendingSyncPayloadsForMain.push(payload);
+  if (syncBatchFlushQueued) return;
+
+  syncBatchFlushQueued = true;
+  queueMicrotask(() => {
+    syncBatchFlushQueued = false;
+    const payloads = pendingSyncPayloadsForMain;
+    pendingSyncPayloadsForMain = [];
+    if (payloads.length === 0) return;
+    post({ type: "sync", payload: payloads });
+  });
+}
 
 function post(msg: WorkerToMainMessage): void {
   self.postMessage(msg);
@@ -113,7 +129,7 @@ async function handleInit(msg: InitMessage): Promise<void> {
 
       if (parsed.destination && "Client" in parsed.destination) {
         // Client-bound → send payload to main thread
-        post({ type: "sync", payload: JSON.stringify(parsed.payload) });
+        enqueueSyncMessageForMain(JSON.stringify(parsed.payload));
       } else if (parsed.destination && "Server" in parsed.destination) {
         // Server-bound → HTTP POST to upstream
         if (activeServerUrl) {

--- a/packages/jazz-tools/src/worker/worker-protocol.ts
+++ b/packages/jazz-tools/src/worker/worker-protocol.ts
@@ -28,7 +28,7 @@ export interface InitMessage {
 /** Forward a sync payload from main thread to worker. */
 export interface SyncToWorkerMessage {
   type: "sync";
-  payload: string; // JSON-encoded SyncPayload
+  payload: string[]; // JSON-encoded SyncPayloads
 }
 
 /** Update auth credentials (e.g., token refresh). */

--- a/packages/jazz-tools/src/worker/worker-protocol.ts
+++ b/packages/jazz-tools/src/worker/worker-protocol.ts
@@ -78,7 +78,7 @@ export interface InitOkMessage {
 /** Forward a sync payload from worker to main thread. */
 export interface SyncToMainMessage {
   type: "sync";
-  payload: string; // JSON-encoded SyncPayload
+  payload: string[]; // JSON-encoded SyncPayloads
 }
 
 /** Worker encountered an error. */


### PR DESCRIPTION
Before this PR we were posting one message across workers for each sync message. Since the runtime already processes messages in batches, we can just batch all messages and send them in the next microtask.

**Before:**
<img width="1728" height="525" alt="before" src="https://github.com/user-attachments/assets/d50ca30d-2b65-45bc-bfcc-ac7a28a25453" />

**After:**
<img width="1728" height="525" alt="after" src="https://github.com/user-attachments/assets/c97181d3-1e12-41a0-a82f-eabaf0461226" />
