### PR TITLE
fix(release): unblock linux musl and publish lock-stepped jazz packages

### DIFF
--- a/crates/jazz-tools/Cargo.toml
+++ b/crates/jazz-tools/Cargo.toml
@@ -77,7 +77,7 @@ async-stream = { version = "0.3", optional = true }
 jsonwebtoken = { version = "9", optional = true }
 base64 = { version = "0.22", optional = true }
 
-reqwest = { version = "0.12", features = ["json", "stream"], optional = true }
+reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "rustls-tls"], optional = true }
 thiserror = { version = "1", optional = true }
 
 opentelemetry = { version = "0.31", optional = true }
@@ -87,7 +87,7 @@ opentelemetry-stdout = { version = "0.31", features = ["trace"], optional = true
 tracing-opentelemetry = { version = "0.32", optional = true }
 
 [dev-dependencies]
-reqwest = { version = "0.12", features = ["json", "stream"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "rustls-tls"] }
 bytes = "1"
 tempfile = "3"
 jsonwebtoken = "9"


### PR DESCRIPTION
## Summary
This PR resolves three release blockers in the `Publish jazz-tools alpha` pipeline:

1. Linux MUSL CLI builds failed (`openssl-sys`/OpenSSL discovery)
2. `jazz-tools` npm publish could leak workspace deps and ship CLI-only artifacts
3. `jazz-wasm` and `jazz-napi` were not part of the release pipeline and were not lock-stepped with `jazz-tools`

## 1) Linux MUSL build fix
In run [22263193394](https://github.com/garden-co/jazz2/actions/runs/22263193394), Linux MUSL jobs failed while compiling `openssl-sys`.

### Root cause
`crates/jazz-tools/Cargo.toml` used `reqwest` default features, which pulled `native-tls` -> `openssl-sys`.

### Change
- Switch `reqwest` to rustls in `crates/jazz-tools/Cargo.toml`:
  - `default-features = false`
  - `features = ["json", "stream", "rustls-tls"]`
- Same update in dev-dependencies.

## 2) Library+CLI publish fix
### Root cause
The publish workflow used `npm publish` directly and did not build/stage all library artifacts before publishing.

### Change
- Release workflow now:
  - installs workspace deps with `pnpm install --frozen-lockfile`
  - builds and validates `jazz-wasm` package payload (`pkg/*`)
  - builds and validates `jazz-tools` package payload (`dist/*` + native CLI binaries)
  - uses `pnpm publish` so workspace protocol ranges are rewritten in packed manifests
- `packages/jazz-tools/package.json` keeps workspace links for monorepo dev, but published manifests now resolve concrete versions.
- `crates/jazz-wasm/package.json` moves `wasm-pack` from runtime `dependencies` to `devDependencies`.

## 3) Include `jazz-wasm` + `jazz-napi` in release flow with lock-step versions
### Changes
- `publish-jazz-tools-alpha.yml` now:
  - builds `jazz-napi` and validates native payload (`jazz-napi.node`)
  - lock-steps npm versions for `jazz-tools`, `jazz-wasm`, and `jazz-napi` to a single version each run
  - verifies lock-step + prerelease format
  - publishes in order: `jazz-wasm` -> `jazz-napi` -> `jazz-tools`
  - skips publish when that exact version already exists on npm
- `crates/jazz-napi/package.json` is now publishable (no longer private) with explicit payload files.
- `packages/jazz-tools/package.json` now includes optional `jazz-napi` (workspace) dependency for published Node usage.

## Validation
- `cargo check -p jazz-tools --bin jazz-tools --features cli`
- `cargo tree -p jazz-tools --features cli --target all` no longer includes `native-tls` / `openssl-sys`
- `pnpm install --frozen-lockfile` succeeds
- packed `jazz-tools` manifest rewrites:
  - `jazz-wasm: workspace:*` -> concrete version
  - `jazz-napi: workspace:*` (optional) -> concrete version
- packed `jazz-wasm` includes expected `pkg/*`
- packed `jazz-napi` includes `index.js`, `index.d.ts`, `jazz-napi.node`

## Risk / Notes
- `jazz-napi` package currently publishes the built native addon produced in the release job (linux x64 runner today). Wider cross-platform prebuild distribution can be added in a follow-up matrix.
