### PR TITLE
Replace hand-rolled singularize() with pluralize-esm

### DIFF
--- a/packages/jazz-tools/package.json
+++ b/packages/jazz-tools/package.json
@@ -55,6 +55,7 @@
   },
   "dependencies": {
     "jazz-wasm": "workspace:*",
+    "pluralize-esm": "^9.0.5",
     "tsx": "^4.0.0"
   },
   "devDependencies": {

--- a/packages/jazz-tools/src/codegen/codegen.test.ts
+++ b/packages/jazz-tools/src/codegen/codegen.test.ts
@@ -262,7 +262,7 @@ describe("generateTypes", () => {
     expect(output).toContain("export interface UserProfileInit {");
   });
 
-  it("removes trailing s for plurals", () => {
+  it("singularises plural table names", () => {
     table("categories", { name: col.string() });
     const schema = getCollectedSchema();
     const wasm = schemaToWasm(schema);
@@ -270,6 +270,26 @@ describe("generateTypes", () => {
 
     expect(output).toContain("export interface Category {");
     expect(output).toContain("export interface CategoryInit {");
+  });
+
+  it.each([
+    ["canvases", "Canvas"],
+    ["statuses", "Status"],
+    ["buses", "Bus"],
+    ["processes", "Process"],
+    ["heroes", "Hero"],
+    ["vertices", "Vertex"],
+    ["people", "Person"],
+    ["matrices", "Matrix"],
+    ["addresses", "Address"],
+  ])("singularises %s to %s", (tableName, expected) => {
+    table(tableName, { name: col.string() });
+    const schema = getCollectedSchema();
+    const wasm = schemaToWasm(schema);
+    const output = generateTypes(wasm);
+
+    expect(output).toContain(`export interface ${expected} {`);
+    expect(output).toContain(`export interface ${expected}Init {`);
   });
 
   it("maps boolean columns to boolean type", () => {

--- a/packages/jazz-tools/src/codegen/type-generator.ts
+++ b/packages/jazz-tools/src/codegen/type-generator.ts
@@ -2,6 +2,7 @@
  * Generate TypeScript interfaces from WasmSchema.
  */
 
+import pluralize from "pluralize-esm";
 import type { WasmSchema, ColumnType } from "../drivers/types.js";
 import { analyzeRelations, type Relation } from "./relation-analyzer.js";
 import {
@@ -41,40 +42,8 @@ function wasmTypeToTs(colType: ColumnType): string {
   }
 }
 
-/**
- * Singularize a word using simple heuristics.
- *
- * Examples:
- *   todos -> todo
- *   categories -> category
- *   users -> user
- *   data -> data (unchanged)
- */
 function singularize(word: string): string {
-  if (word.endsWith("ies")) {
-    // categories -> category
-    return word.slice(0, -3) + "y";
-  }
-  if (word.endsWith("es") && word.length > 3) {
-    // Some words ending in 'es' - be conservative
-    const stem = word.slice(0, -2);
-    // Only apply if it ends with common patterns like 'sses', 'xes', 'ches', 'shes'
-    if (
-      word.endsWith("sses") ||
-      word.endsWith("xes") ||
-      word.endsWith("ches") ||
-      word.endsWith("shes")
-    ) {
-      return stem;
-    }
-    // Otherwise just remove 's'
-    return word.slice(0, -1);
-  }
-  if (word.endsWith("s") && !word.endsWith("ss")) {
-    // todos -> todo, users -> user
-    return word.slice(0, -1);
-  }
-  return word;
+  return pluralize.singular(word);
 }
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -424,6 +424,9 @@ importers:
       jazz-wasm:
         specifier: workspace:*
         version: link:../../crates/jazz-wasm
+      pluralize-esm:
+        specifier: ^9.0.5
+        version: 9.0.5
       react:
         specifier: 19.2.4
         version: 19.2.4
@@ -7217,6 +7220,10 @@ packages:
   plist@3.1.0:
     resolution: {integrity: sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==}
     engines: {node: '>=10.4.0'}
+
+  pluralize-esm@9.0.5:
+    resolution: {integrity: sha512-Kb2dcpMsIutFw2hYrN0EhsAXOUJTd6FVMIxvNAkZCMQLVt9NGZqQczvGpYDxNWCZeCWLHUPxQIBudWzt1h7VVA==}
+    engines: {node: '>=14.0.0'}
 
   pngjs@3.4.0:
     resolution: {integrity: sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==}
@@ -16697,6 +16704,8 @@ snapshots:
       '@xmldom/xmldom': 0.8.11
       base64-js: 1.5.1
       xmlbuilder: 15.1.1
+
+  pluralize-esm@9.0.5: {}
 
   pngjs@3.4.0: {}
 

--- a/specs/todo/a_mvp/codegen_singularisation.md
+++ b/specs/todo/a_mvp/codegen_singularisation.md
@@ -17,20 +17,20 @@ It also has no handling for irregular plurals (`people`, `geese`, `mice`, `indic
 
 ## Design
 
-Replace the hand-rolled function with the [`pluralize`](https://www.npmjs.com/package/pluralize) npm package (MIT, 17.7 kB, zero dependencies, ~9M weekly downloads). It handles all the suffix rules we'd need to write ourselves plus hundreds of irregular forms, and exposes `addSingularRule()` / `addIrregularRule()` for extending.
+Replace the hand-rolled function with [`pluralize-esm`](https://www.npmjs.com/package/pluralize-esm) (MIT, ESM fork of `pluralize` maintained by Sanity.io, zero dependencies, ships with types). It handles all the suffix rules we'd need to write ourselves plus hundreds of irregular forms, and exposes `addSingularRule()` / `addIrregularRule()` for extending.
 
-All usage is codegen-only (`type-generator.ts` and `query-builder-generator.ts`), so `pluralize` is a devDependency.
+All usage is codegen-only (`type-generator.ts` and `query-builder-generator.ts`), so `pluralize-esm` is a devDependency.
 
 ## Changes
 
 ### 1. Add dependency
 
-Add `pluralize` (and `@types/pluralize`) as devDependencies to `packages/jazz-tools`.
+Add `pluralize-esm` as a devDependency to `packages/jazz-tools`.
 
 ### 2. Replace `singularize()`
 
 ```typescript
-import pluralize from "pluralize";
+import pluralize from "pluralize-esm";
 
 function singularize(word: string): string {
   return pluralize.singular(word);

--- a/specs/todo/a_mvp/codegen_singularisation.md
+++ b/specs/todo/a_mvp/codegen_singularisation.md
@@ -1,0 +1,62 @@
+# Codegen Singularisation — TODO (MVP)
+
+Table names are plural by convention (`todos`, `user_profiles`, `canvases`). The codegen singularises the last word to produce TypeScript interface names (`Todo`, `UserProfile`, `Canvas`). The current implementation is a handful of suffix rules that fail on common English words.
+
+## Problem
+
+`singularize()` in `type-generator.ts:53-78` uses four branches:
+
+1. `ies` → strip, add `y`
+2. `es` after `ss/x/ch/sh` → strip `es`
+3. Other `es` → strip just `s`
+4. Trailing `s` (not `ss`) → strip `s`
+
+Branch 3 produces wrong output for any word where `es` is the full plural suffix: `canvases` → `canvase`, `statuses` → `statuse`, `buses` → `buse`, `processes` → `processe`, `heroes` → `heroe`, `potatoes` → `potatoe`, `vertices` → `vertice`.
+
+It also has no handling for irregular plurals (`people`, `geese`, `mice`, `indices`, `data`).
+
+## Design
+
+Replace the hand-rolled function with the [`pluralize`](https://www.npmjs.com/package/pluralize) npm package (MIT, 17.7 kB, zero dependencies, ~9M weekly downloads). It handles all the suffix rules we'd need to write ourselves plus hundreds of irregular forms, and exposes `addSingularRule()` / `addIrregularRule()` for extending.
+
+All usage is codegen-only (`type-generator.ts` and `query-builder-generator.ts`), so `pluralize` is a devDependency.
+
+## Changes
+
+### 1. Add dependency
+
+Add `pluralize` (and `@types/pluralize`) as devDependencies to `packages/jazz-tools`.
+
+### 2. Replace `singularize()`
+
+```typescript
+import pluralize from "pluralize";
+
+function singularize(word: string): string {
+  return pluralize.singular(word);
+}
+```
+
+`tableNameToInterface` stays the same (split on `_`, singularise last part, PascalCase join).
+
+### 3. Update tests
+
+Rename the existing test from "removes trailing s for plurals" to something more descriptive. Add cases that previously broke:
+
+- `canvases` → `Canvas`
+- `statuses` → `Status`
+- `buses` → `Bus`
+- `processes` → `Process`
+- `heroes` → `Hero`
+- `vertices` → `Vertex`
+- `people` → `Person`
+- `matrices` → `Matrix`
+- `addresses` → `Address`
+
+Keep existing passing cases (`todos` → `Todo`, `categories` → `Category`, `user_profiles` → `UserProfile`).
+
+## Files touched
+
+- `packages/jazz-tools/package.json` — new devDependency
+- `packages/jazz-tools/src/codegen/type-generator.ts` — replace `singularize()`
+- `packages/jazz-tools/src/codegen/codegen.test.ts` — expanded test cases

--- a/specs/todo/c_later/codegen_singular_override.md
+++ b/specs/todo/c_later/codegen_singular_override.md
@@ -1,0 +1,22 @@
+# Codegen $singular Override — TODO (Later)
+
+Allow users to override the auto-singularised interface name for a table via a `$singular` annotation in the schema DSL.
+
+## Motivation
+
+Even with a proper inflection library, English has edge cases. A user escape hatch means no one is ever stuck with a wrong generated name.
+
+This also matters for non-English speakers. Table names may follow naming conventions from the user's own language, where English singularisation rules produce nonsense. A manual override lets users write whatever works best in their own language rather than enforcing English.
+
+## Proposed API
+
+```typescript
+table("canvases", { $singular: "Canvas", name: col.string() });
+```
+
+If `$singular` is present, `tableNameToInterface` uses it directly (PascalCased) instead of running singularisation.
+
+## Open questions
+
+- Should `$singular` be passed through the WASM schema boundary, or handled purely in the TS codegen layer?
+- Naming: `$singular` vs `$typeName` vs `$as`?


### PR DESCRIPTION
## Summary

While porting the chat app from Jazz 1, `canvases` was being singularised to `Canvase` instead of `Canvas`. The hand-rolled `singularize()` function in the codegen only handled a few suffix patterns and got common English plurals wrong.

- Replace the naive suffix-stripping with [`pluralize-esm`](https://www.npmjs.com/package/pluralize-esm) (MIT, zero-dep, ESM, maintained by Sanity.io)
- Fixes `canvases`, `statuses`, `buses`, `processes`, `heroes`, `vertices`, `people`, `matrices`, `addresses` and hundreds of other regular/irregular plurals
- Added as a regular dependency (not devDependency) since users run the codegen CLI as part of their build

## Test plan

- [x] All 255 existing tests pass with zero regressions
- [x] Added 9 new test cases for previously broken singularisations via `it.each`
- [x] Existing cases (`todos`, `categories`, `user_profiles`) still pass