### PR TITLE
fix: update combined_descriptor after array subquery compilation

### DIFF
--- a/crates/jazz-tools/src/query_manager/graph.rs
+++ b/crates/jazz-tools/src/query_manager/graph.rs
@@ -538,6 +538,7 @@ impl QueryGraph {
         }
 
         // Output node
+        graph.combined_descriptor = current_descriptor.clone();
         let output_tuple_desc =
             TupleDescriptor::single_with_materialization("", current_descriptor, true);
         let output_node = OutputNode::with_tuple_descriptor(output_tuple_desc, OutputMode::Delta);
@@ -789,6 +790,7 @@ impl QueryGraph {
         }
 
         // Output node
+        graph.combined_descriptor = current_descriptor.clone();
         let output_tuple_desc =
             TupleDescriptor::single_with_materialization("", current_descriptor, true);
         let output_node = OutputNode::with_tuple_descriptor(output_tuple_desc, OutputMode::Delta);

--- a/crates/jazz-tools/src/query_manager/manager_tests.rs
+++ b/crates/jazz-tools/src/query_manager/manager_tests.rs
@@ -3524,6 +3524,65 @@ fn array_subquery_single_user_with_posts() {
 }
 
 #[test]
+fn array_subquery_update_descriptor_includes_array_column() {
+    let sync_manager = SyncManager::new();
+    let schema = users_posts_schema();
+    let (mut qm, mut storage) = create_query_manager(sync_manager, schema);
+
+    qm.insert(
+        &mut storage,
+        "users",
+        &[Value::Integer(1), Value::Text("Alice".into())],
+    )
+    .unwrap();
+    qm.insert(
+        &mut storage,
+        "posts",
+        &[
+            Value::Integer(100),
+            Value::Text("Hello world".into()),
+            Value::Integer(1),
+        ],
+    )
+    .unwrap();
+
+    let query = qm
+        .query("users")
+        .with_array("posts", |sub| {
+            sub.from("posts").correlate("author_id", "users.id")
+        })
+        .build();
+
+    let sub_id = qm.subscribe(query).unwrap();
+    qm.process(&mut storage);
+
+    let updates = qm.take_updates();
+    let update = updates
+        .iter()
+        .find(|u| u.subscription_id == sub_id)
+        .expect("should have subscription update");
+
+    assert_eq!(
+        update.descriptor.columns.len(),
+        3,
+        "Update descriptor should have 3 columns (base + array), got {}: {:?}",
+        update.descriptor.columns.len(),
+        update.descriptor.columns.iter().map(|c| &c.name).collect::<Vec<_>>()
+    );
+
+    let row_data = &update.delta.added[0].data;
+    let values =
+        decode_row(&update.descriptor, row_data).expect("should decode with update descriptor");
+
+    assert_eq!(values[0], Value::Integer(1), "user id");
+    assert_eq!(
+        values[1],
+        Value::Text("Alice".into()),
+        "user name should be 'Alice', not corrupted"
+    );
+}
+
+#[test]
 fn array_subquery_user_with_no_posts() {
     let sync_manager = SyncManager::new();
     let schema = users_posts_schema();

--- a/crates/jazz-tools/src/query_manager/manager_tests.rs
+++ b/crates/jazz-tools/src/query_manager/manager_tests.rs
@@ -3567,7 +3567,12 @@ fn array_subquery_update_descriptor_includes_array_column() {
         3,
         "Update descriptor should have 3 columns (base + array), got {}: {:?}",
         update.descriptor.columns.len(),
-        update.descriptor.columns.iter().map(|c| &c.name).collect::<Vec<_>>()
+        update
+            .descriptor
+            .columns
+            .iter()
+            .map(|c| &c.name)
+            .collect::<Vec<_>>()
     );
 
     let row_data = &update.delta.added[0].data;
@@ -3580,6 +3585,16 @@ fn array_subquery_update_descriptor_includes_array_column() {
         Value::Text("Alice".into()),
         "user name should be 'Alice', not corrupted"
     );
+
+    // The included posts array should contain the post we inserted
+    let posts = values[2]
+        .as_array()
+        .expect("third column should be the posts array");
+    assert_eq!(posts.len(), 1, "Alice should have 1 post");
+    let post_row = posts[0].as_row().expect("post element should be a Row");
+    assert_eq!(post_row[0], Value::Integer(100), "post id");
+    assert_eq!(post_row[1], Value::Text("Hello world".into()), "post title");
+    assert_eq!(post_row[2], Value::Integer(1), "post author_id");
 }
 
 #[test]

--- a/packages/jazz-tools/tests/ts-dsl/query-api.test.ts
+++ b/packages/jazz-tools/tests/ts-dsl/query-api.test.ts
@@ -58,13 +58,40 @@ describe("TS Query API", () => {
     expect(baseline[0].title).toBe("Hello world");
 
     const withInclude = await db.all(
-      app.todos
-        .where({ id: { eq: todoId } })
-        .include({ project: true }),
+      app.todos.where({ id: { eq: todoId } }).include({ project: true }),
     );
 
     expect(withInclude.length).toBe(1);
     expect(withInclude[0].title).toBe("Hello world");
+  });
+
+  it("include returns the related entity", async () => {
+    const db = track(
+      await createDb({
+        appId: "test-app",
+        dbName: uniqueDbName("include-returns-entity"),
+      }),
+    );
+
+    const projectId = db.insert(app.projects, { name: "Announcements" });
+    const todoId = db.insert(app.todos, {
+      title: "Write tests",
+      done: false,
+      tags: ["dev"],
+      project: projectId,
+    });
+
+    const results = await db.all(
+      app.todos.where({ id: { eq: todoId } }).include({ project: true }),
+    );
+
+    expect(results.length).toBe(1);
+    const todo = results[0] as Record<string, unknown>;
+    expect(todo.title).toBe("Write tests");
+
+    const project = todo.project as { name: string };
+    expect(project).toBeDefined();
+    expect(project.name).toBe("Announcements");
   });
 
   describe("query by array column", () => {

--- a/packages/jazz-tools/tests/ts-dsl/query-api.test.ts
+++ b/packages/jazz-tools/tests/ts-dsl/query-api.test.ts
@@ -38,6 +38,35 @@ describe("TS Query API", () => {
     expect(results[0].name).toBe("Project A");
   });
 
+  it("text is not corrupted when using include", async () => {
+    const db = track(
+      await createDb({
+        appId: "test-app",
+        dbName: uniqueDbName("include-corruption"),
+      }),
+    );
+
+    const projectId = db.insert(app.projects, { name: "Announcements" });
+    const todoId = db.insert(app.todos, {
+      title: "Hello world",
+      done: false,
+      tags: ["general"],
+      project: projectId,
+    });
+
+    const baseline = await db.all(app.todos.where({ id: { eq: todoId } }));
+    expect(baseline[0].title).toBe("Hello world");
+
+    const withInclude = await db.all(
+      app.todos
+        .where({ id: { eq: todoId } })
+        .include({ project: true }),
+    );
+
+    expect(withInclude.length).toBe(1);
+    expect(withInclude[0].title).toBe("Hello world");
+  });
+
   describe("query by array column", () => {
     it("using eq", async () => {
       const db = track(


### PR DESCRIPTION
## Summary

Using `.include({ sender: true })` on message queries in the chat app resulted in the message text being garbled. The root cause: `graph.combined_descriptor` was not updated after array subqueries were compiled, so `QueryUpdate.descriptor` reflected only the base table columns. Decoding rows with this stale descriptor corrupts variable-length column data because the offset table is shorter than expected, shifting `var_data_start`.

The fix adds `graph.combined_descriptor = current_descriptor.clone()` before the output node in both compilation paths (`compile_execution_plan_with_session` and `compile_execution_plan_with_schema_context`).

Includes a Rust test (`manager_tests`) and a TypeScript test (`query-api`) that both fail on the parent commit and pass with the fix.

## Test plan

- [x] Rust test: `cargo test -p jazz-tools --lib -- array_subquery_update_descriptor`
- [x] TS test: `pnpm --filter jazz-tools exec vitest run tests/ts-dsl/query-api.test.ts`
- [x] Both tests fail on the parent commit (stale descriptor / capacity overflow panic)
- [x] Both tests pass with the fix