### PR TITLE
feat(jazz-tools): add text contains filter and fix query updates on useAll

### DIFF
--- a/crates/jazz-tools/src/query_manager/graph_nodes/filter.rs
+++ b/crates/jazz-tools/src/query_manager/graph_nodes/filter.rs
@@ -24,7 +24,7 @@ pub enum Predicate {
     Gt { col_index: usize, value: Vec<u8> },
     /// Column greater than or equal to value.
     Ge { col_index: usize, value: Vec<u8> },
-    /// Array column contains value.
+    /// Array column contains value, or text column contains substring.
     Contains { col_index: usize, value: Value },
     /// Column is null.
     IsNull { col_index: usize },
@@ -105,6 +105,10 @@ impl Predicate {
             Predicate::Contains { col_index, value } => {
                 match decode_column(descriptor, &row.data, *col_index) {
                     Ok(Value::Array(elements)) => elements.iter().any(|element| element == value),
+                    Ok(Value::Text(text)) => match value {
+                        Value::Text(substr) => text.contains(substr),
+                        _ => false,
+                    },
                     _ => false,
                 }
             }
@@ -247,6 +251,10 @@ impl FilterNode {
             Predicate::Contains { col_index, value } => {
                 match self.get_column_value(tuple, *col_index) {
                     Some(Value::Array(elements)) => elements.iter().any(|element| element == value),
+                    Some(Value::Text(text)) => match value {
+                        Value::Text(substr) => text.contains(substr),
+                        _ => false,
+                    },
                     _ => false,
                 }
             }
@@ -429,6 +437,23 @@ mod tests {
 
     fn make_array_tuple(id: ObjectId, values: &[Value]) -> Tuple {
         let descriptor = array_descriptor();
+        let data = encode_row(&descriptor, values).unwrap();
+        Tuple::new(vec![TupleElement::Row {
+            id,
+            content: data,
+            commit_id: CommitId([0; 32]),
+        }])
+    }
+
+    fn text_descriptor() -> RowDescriptor {
+        RowDescriptor::new(vec![
+            ColumnDescriptor::new("id", ColumnType::Integer),
+            ColumnDescriptor::new("title", ColumnType::Text),
+        ])
+    }
+
+    fn make_text_tuple(id: ObjectId, values: &[Value]) -> Tuple {
+        let descriptor = text_descriptor();
         let data = encode_row(&descriptor, values).unwrap();
         Tuple::new(vec![TupleElement::Row {
             id,
@@ -719,6 +744,112 @@ mod tests {
         let result = node.process(delta);
         assert_eq!(result.added.len(), 1);
         assert!(contains_id(&result.added, id1));
+    }
+
+    #[test]
+    fn filter_contains_text_substring() {
+        let predicate = Predicate::Contains {
+            col_index: 1,
+            value: Value::Text("rust".into()),
+        };
+        let tuple_desc = TupleDescriptor::single_with_materialization("", text_descriptor(), true);
+        let mut node = FilterNode::with_tuple_descriptor(tuple_desc, predicate);
+
+        let id1 = ObjectId::new();
+        let id2 = ObjectId::new();
+        let tuple1 = make_text_tuple(
+            id1,
+            &[Value::Integer(1), Value::Text("rust query engine".into())],
+        );
+        let tuple2 = make_text_tuple(id2, &[Value::Integer(2), Value::Text("typescript".into())]);
+
+        let result = node.process(TupleDelta {
+            added: vec![tuple1, tuple2],
+            removed: vec![],
+            updated: vec![],
+        });
+
+        assert_eq!(result.added.len(), 1);
+        assert!(contains_id(&result.added, id1));
+    }
+
+    #[test]
+    fn filter_contains_text_empty_substring_matches() {
+        let predicate = Predicate::Contains {
+            col_index: 1,
+            value: Value::Text("".into()),
+        };
+        let tuple_desc = TupleDescriptor::single_with_materialization("", text_descriptor(), true);
+        let mut node = FilterNode::with_tuple_descriptor(tuple_desc, predicate);
+
+        let id = ObjectId::new();
+        let tuple = make_text_tuple(id, &[Value::Integer(1), Value::Text("any text".into())]);
+
+        let result = node.process(TupleDelta {
+            added: vec![tuple],
+            removed: vec![],
+            updated: vec![],
+        });
+
+        assert_eq!(result.added.len(), 1);
+        assert!(contains_id(&result.added, id));
+    }
+
+    #[test]
+    fn filter_contains_text_update_transitions() {
+        let predicate = Predicate::Contains {
+            col_index: 1,
+            value: Value::Text("needle".into()),
+        };
+        let tuple_desc = TupleDescriptor::single_with_materialization("", text_descriptor(), true);
+        let mut node = FilterNode::with_tuple_descriptor(tuple_desc, predicate);
+
+        let id = ObjectId::new();
+        let non_matching = make_text_tuple(
+            id,
+            &[
+                Value::Integer(1),
+                Value::Text("completely unrelated".into()),
+            ],
+        );
+        let matching = make_text_tuple(
+            id,
+            &[Value::Integer(1), Value::Text("hay needle value".into())],
+        );
+        let non_matching_again = make_text_tuple(
+            id,
+            &[Value::Integer(1), Value::Text("different text".into())],
+        );
+
+        // Initial add does not match "contains", so nothing is added.
+        let initial = node.process(TupleDelta {
+            added: vec![non_matching.clone()],
+            removed: vec![],
+            updated: vec![],
+        });
+        assert!(initial.added.is_empty());
+
+        // Update to matching text should be emitted as an addition.
+        let to_matching = node.process(TupleDelta {
+            added: vec![],
+            removed: vec![],
+            updated: vec![(non_matching, matching.clone())],
+        });
+        assert_eq!(to_matching.added.len(), 1);
+        assert!(contains_id(&to_matching.added, id));
+        assert!(to_matching.removed.is_empty());
+        assert!(to_matching.updated.is_empty());
+
+        // Update back to non-matching text should be emitted as a removal.
+        let to_non_matching = node.process(TupleDelta {
+            added: vec![],
+            removed: vec![],
+            updated: vec![(matching, non_matching_again)],
+        });
+        assert_eq!(to_non_matching.removed.len(), 1);
+        assert!(contains_id(&to_non_matching.removed, id));
+        assert!(to_non_matching.added.is_empty());
+        assert!(to_non_matching.updated.is_empty());
     }
 
     // ========================================================================

--- a/crates/jazz-tools/src/query_manager/graph_nodes/filter.rs
+++ b/crates/jazz-tools/src/query_manager/graph_nodes/filter.rs
@@ -5,7 +5,7 @@ use std::collections::HashSet;
 use crate::query_manager::encoding::{
     column_bytes, column_is_null, compare_column_to_value, decode_column,
 };
-use crate::query_manager::types::{Row, RowDescriptor, Tuple, TupleDelta, TupleDescriptor, Value};
+use crate::query_manager::types::{RowDescriptor, Tuple, TupleDelta, TupleDescriptor, Value};
 
 use super::RowNode;
 
@@ -59,69 +59,6 @@ impl Predicate {
             }
             Predicate::Not(pred) => pred.required_columns(),
             Predicate::True => HashSet::new(),
-        }
-    }
-
-    /// Evaluate the predicate against a row.
-    pub fn evaluate(&self, descriptor: &RowDescriptor, row: &Row) -> bool {
-        match self {
-            Predicate::Eq { col_index, value } => {
-                match column_bytes(descriptor, &row.data, *col_index) {
-                    Ok(Some(bytes)) => bytes == value.as_slice(),
-                    _ => false,
-                }
-            }
-            Predicate::Ne { col_index, value } => {
-                match column_bytes(descriptor, &row.data, *col_index) {
-                    Ok(Some(bytes)) => bytes != value.as_slice(),
-                    Ok(None) => true, // null != value
-                    Err(_) => false,
-                }
-            }
-            Predicate::Lt { col_index, value } => {
-                matches!(
-                    compare_column_to_value(descriptor, &row.data, *col_index, value),
-                    Ok(Ordering::Less)
-                )
-            }
-            Predicate::Le { col_index, value } => {
-                matches!(
-                    compare_column_to_value(descriptor, &row.data, *col_index, value),
-                    Ok(Ordering::Less) | Ok(Ordering::Equal)
-                )
-            }
-            Predicate::Gt { col_index, value } => {
-                matches!(
-                    compare_column_to_value(descriptor, &row.data, *col_index, value),
-                    Ok(Ordering::Greater)
-                )
-            }
-            Predicate::Ge { col_index, value } => {
-                matches!(
-                    compare_column_to_value(descriptor, &row.data, *col_index, value),
-                    Ok(Ordering::Greater) | Ok(Ordering::Equal)
-                )
-            }
-            Predicate::Contains { col_index, value } => {
-                match decode_column(descriptor, &row.data, *col_index) {
-                    Ok(Value::Array(elements)) => elements.iter().any(|element| element == value),
-                    Ok(Value::Text(text)) => match value {
-                        Value::Text(substr) => text.contains(substr),
-                        _ => false,
-                    },
-                    _ => false,
-                }
-            }
-            Predicate::IsNull { col_index } => {
-                column_is_null(descriptor, &row.data, *col_index).unwrap_or(false)
-            }
-            Predicate::IsNotNull { col_index } => {
-                !column_is_null(descriptor, &row.data, *col_index).unwrap_or(true)
-            }
-            Predicate::And(predicates) => predicates.iter().all(|p| p.evaluate(descriptor, row)),
-            Predicate::Or(predicates) => predicates.iter().any(|p| p.evaluate(descriptor, row)),
-            Predicate::Not(predicate) => !predicate.evaluate(descriptor, row),
-            Predicate::True => true,
         }
     }
 }

--- a/examples/todo-client-localfirst-react/src/TodoList.tsx
+++ b/examples/todo-client-localfirst-react/src/TodoList.tsx
@@ -3,9 +3,20 @@ import { useDb, useAll, useSession } from "jazz-tools/react";
 import { app } from "../schema/app.js";
 
 export function TodoList() {
+  const [filterTitle, setFilterTitle] = useState("");
+  const [showDoneOnly, setShowDoneOnly] = useState(false);
+  const trimmedFilterTitle = filterTitle.trim();
+  let todosQuery = app.todos;
+  if (trimmedFilterTitle) {
+    todosQuery = todosQuery.where({ title: { contains: trimmedFilterTitle } });
+  }
+  if (showDoneOnly) {
+    todosQuery = todosQuery.where({ done: true });
+  }
+
   // #region reading-reactive-hooks-react
   const db = useDb();
-  const todos = useAll(app.todos);
+  const todos = useAll(todosQuery);
   // #endregion reading-reactive-hooks-react
   const session = useSession();
   const sessionUserId = session?.user_id ?? null;
@@ -32,6 +43,23 @@ export function TodoList() {
           Add
         </button>
       </form>
+      <div>
+        <input
+          type="text"
+          value={filterTitle}
+          onChange={(e) => setFilterTitle(e.target.value)}
+          placeholder="Filter by title (contains)"
+          aria-label="Filter by title"
+        />
+        <label>
+          <input
+            type="checkbox"
+            checked={showDoneOnly}
+            onChange={(e) => setShowDoneOnly(e.target.checked)}
+          />
+          Done only
+        </label>
+      </div>
       <ul id="todo-list">
         {todos.map((todo) => (
           <li key={todo.id} className={todo.done ? "done" : ""}>

--- a/packages/jazz-tools/src/react-core/use-all.ts
+++ b/packages/jazz-tools/src/react-core/use-all.ts
@@ -1,32 +1,52 @@
 import * as React from "react";
 import { type Usable, use } from "react";
-import type { PersistenceTier } from "../runtime/client.js";
 import type { QueryBuilder } from "../runtime/db.js";
 import type { SubscriptionDelta } from "../runtime/subscription-manager.js";
-import type { UseAllState } from "../subscriptions-orchestrator.js";
+import type { TrackedPromise, UseAllState } from "../subscriptions-orchestrator.js";
 import { useJazzClient } from "./provider.js";
 
-type UseAllOptions = {
-  tier?: PersistenceTier;
-  suspense?: boolean;
-};
-
-type UseAllSuspenseOptions = Omit<UseAllOptions, "suspense">;
-
 type UseAllAction<T extends { id: string }> =
+  | { type: "entry_pending"; promise: TrackedPromise<T[]> }
   | { type: "entry_fulfilled"; data: T[] }
-  | { type: "entry_delta"; data: T[] }
+  | { type: "entry_delta"; delta: SubscriptionDelta<T> }
   | { type: "entry_error"; error: unknown };
+
+function applyDelta<T extends { id: string }>(
+  prev: UseAllState<T>,
+  delta: SubscriptionDelta<T>,
+): T[] {
+  if (prev.status !== "fulfilled") {
+    return delta.all;
+  }
+
+  const byId = new Map(prev.data.map((item) => [item.id, item]));
+
+  for (const item of delta.added) {
+    byId.set(item.id, item);
+  }
+
+  for (const item of delta.updated) {
+    byId.set(item.id, item);
+  }
+
+  for (const item of delta.removed) {
+    byId.delete(item.id);
+  }
+
+  return Array.from(byId.values());
+}
 
 function reducer<T extends { id: string }>(
   prev: UseAllState<T>,
   action: UseAllAction<T>,
 ): UseAllState<T> {
   switch (action.type) {
+    case "entry_pending":
+      return { status: "pending", data: undefined, promise: action.promise, error: null };
     case "entry_fulfilled":
       return { status: "fulfilled", data: action.data, error: null };
     case "entry_delta":
-      return { status: "fulfilled", data: action.data, error: null };
+      return { status: "fulfilled", data: applyDelta(prev, action.delta), error: null };
     case "entry_error":
       return { status: "rejected", data: undefined, error: action.error };
     default:
@@ -45,12 +65,20 @@ function useAllBase<T extends { id: string }>(
   const [state, dispatch] = React.useReducer(reducer<T>, entry.state);
 
   React.useLayoutEffect(() => {
+    if (entry.state.status === "pending") {
+      dispatch({ type: "entry_pending", promise: entry.state.promise });
+    } else if (entry.state.status === "fulfilled") {
+      dispatch({ type: "entry_fulfilled", data: entry.state.data });
+    } else if (entry.state.status === "rejected") {
+      dispatch({ type: "entry_error", error: entry.state.error });
+    }
+
     const unsubscribe = entry.subscribe({
       onfulfilled: (data: T[]) => {
         dispatch({ type: "entry_fulfilled", data });
       },
       onDelta: (delta: SubscriptionDelta<T>) => {
-        dispatch({ type: "entry_delta", data: delta.all });
+        dispatch({ type: "entry_delta", delta });
       },
       onError: (error: unknown) => {
         dispatch({ type: "entry_error", error });

--- a/packages/jazz-tools/tests/browser/db.all.test.ts
+++ b/packages/jazz-tools/tests/browser/db.all.test.ts
@@ -1,0 +1,355 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createDb, type Db, type QueryBuilder, type TableProxy } from "../../src/runtime/db.js";
+import type { WasmSchema } from "../../src/drivers/types.js";
+
+const schema: WasmSchema = {
+  tables: {
+    orgs: {
+      columns: [{ name: "name", column_type: { type: "Text" }, nullable: false }],
+    },
+    teams: {
+      columns: [
+        { name: "name", column_type: { type: "Text" }, nullable: false },
+        { name: "org_id", column_type: { type: "Uuid" }, nullable: true, references: "orgs" },
+        {
+          name: "parent_id",
+          column_type: { type: "Uuid" },
+          nullable: true,
+          references: "teams",
+        },
+      ],
+    },
+    users: {
+      columns: [
+        { name: "name", column_type: { type: "Text" }, nullable: false },
+        { name: "team_id", column_type: { type: "Uuid" }, nullable: true, references: "teams" },
+      ],
+    },
+    todos: {
+      columns: [
+        { name: "title", column_type: { type: "Text" }, nullable: false },
+        { name: "done", column_type: { type: "Boolean" }, nullable: false },
+        { name: "priority", column_type: { type: "Integer" }, nullable: true },
+        { name: "owner_id", column_type: { type: "Uuid" }, nullable: true, references: "users" },
+        {
+          name: "tags",
+          column_type: { type: "Array", element: { type: "Text" } },
+          nullable: false,
+        },
+      ],
+    },
+  },
+};
+
+interface Org {
+  id: string;
+  name: string;
+}
+
+interface Team {
+  id: string;
+  name: string;
+  org_id?: string;
+  parent_id?: string;
+}
+
+interface User {
+  id: string;
+  name: string;
+  team_id?: string;
+  todosViaOwner?: Todo[];
+}
+
+interface Todo {
+  id: string;
+  title: string;
+  done: boolean;
+  priority?: number;
+  owner_id?: string;
+  tags: string[];
+  owner?: User;
+}
+
+const orgs: TableProxy<Org, Omit<Org, "id">> = {
+  _table: "orgs",
+  _schema: schema,
+  _rowType: {} as Org,
+  _initType: {} as Omit<Org, "id">,
+};
+
+const teams: TableProxy<Team, Omit<Team, "id">> = {
+  _table: "teams",
+  _schema: schema,
+  _rowType: {} as Team,
+  _initType: {} as Omit<Team, "id">,
+};
+
+const users: TableProxy<User, Omit<User, "id">> = {
+  _table: "users",
+  _schema: schema,
+  _rowType: {} as User,
+  _initType: {} as Omit<User, "id">,
+};
+
+const todos: TableProxy<Todo, Omit<Todo, "id" | "owner">> = {
+  _table: "todos",
+  _schema: schema,
+  _rowType: {} as Todo,
+  _initType: {} as Omit<Todo, "id" | "owner">,
+};
+
+function uniqueDbName(label: string): string {
+  return `db-all-${label}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function makeQuery<T>(
+  table: string,
+  body: {
+    conditions?: Array<{ column: string; op: string; value?: unknown }>;
+    includes?: Record<string, boolean | object>;
+    orderBy?: Array<[string, "asc" | "desc"]>;
+    limit?: number;
+    offset?: number;
+    hops?: string[];
+    gather?: {
+      max_depth: number;
+      step_table: string;
+      step_current_column: string;
+      step_conditions: Array<{ column: string; op: string; value: unknown }>;
+      step_hops: string[];
+    };
+  },
+): QueryBuilder<T> {
+  return {
+    _table: table,
+    _schema: schema,
+    _rowType: {} as T,
+    _build() {
+      return JSON.stringify({
+        table,
+        conditions: body.conditions ?? [],
+        includes: body.includes ?? {},
+        orderBy: body.orderBy ?? [],
+        limit: body.limit,
+        offset: body.offset,
+        hops: body.hops,
+        gather: body.gather,
+      });
+    },
+  };
+}
+
+describe("db.all browser integration", () => {
+  const dbs: Db[] = [];
+
+  function track(db: Db): Db {
+    dbs.push(db);
+    return db;
+  }
+
+  afterEach(async () => {
+    for (const db of dbs.splice(0).reverse()) {
+      await db.shutdown();
+    }
+  });
+
+  it("supports all condition operators", async () => {
+    const db = track(await createDb({ appId: "db-all-test", dbName: uniqueDbName("ops") }));
+
+    const orgId = db.insert(orgs, { name: "Acme" });
+    const teamId = db.insert(teams, { name: "Core", org_id: orgId, parent_id: undefined });
+    const userId = db.insert(users, { name: "Alice", team_id: teamId });
+
+    const idA = db.insert(todos, {
+      title: "alpha",
+      done: false,
+      priority: 1,
+      owner_id: userId,
+      tags: ["work", "backend"],
+    });
+    const idB = db.insert(todos, {
+      title: "beta",
+      done: true,
+      priority: 2,
+      owner_id: userId,
+      tags: ["home"],
+    });
+    const idC = db.insert(todos, {
+      title: "gamma",
+      done: true,
+      priority: undefined,
+      owner_id: userId,
+      tags: ["work", "urgent"],
+    });
+
+    const cases: Array<{
+      name: string;
+      conditions: Array<{ column: string; op: string; value?: unknown }>;
+      expectedIds: string[];
+    }> = [
+      {
+        name: "eq",
+        conditions: [{ column: "title", op: "eq", value: "alpha" }],
+        expectedIds: [idA],
+      },
+      {
+        name: "ne",
+        conditions: [{ column: "title", op: "ne", value: "alpha" }],
+        expectedIds: [idB, idC],
+      },
+      { name: "gt", conditions: [{ column: "priority", op: "gt", value: 1 }], expectedIds: [idB] },
+      {
+        name: "gte",
+        conditions: [{ column: "priority", op: "gte", value: 2 }],
+        expectedIds: [idB],
+      },
+      { name: "lt", conditions: [{ column: "priority", op: "lt", value: 2 }], expectedIds: [idA] },
+      {
+        name: "lte",
+        conditions: [{ column: "priority", op: "lte", value: 1 }],
+        expectedIds: [idA],
+      },
+      { name: "isNull", conditions: [{ column: "priority", op: "isNull" }], expectedIds: [idC] },
+      {
+        name: "contains-array",
+        conditions: [{ column: "tags", op: "contains", value: "work" }],
+        expectedIds: [idA, idC],
+      },
+      {
+        name: "contains-text",
+        conditions: [{ column: "title", op: "contains", value: "alp" }],
+        expectedIds: [idA],
+      },
+      {
+        name: "contains-text-empty",
+        conditions: [{ column: "title", op: "contains", value: "" }],
+        expectedIds: [idA, idB, idC],
+      },
+    ];
+
+    for (const testCase of cases) {
+      const rows = await db.all<Todo>(
+        makeQuery<Todo>("todos", { conditions: testCase.conditions }),
+      );
+      const actual = rows.map((row) => row.id).sort();
+      const expected = [...testCase.expectedIds].sort();
+      expect(actual, testCase.name).toEqual(expected);
+    }
+  });
+
+  it("supports orderBy + limit + offset", async () => {
+    const db = track(await createDb({ appId: "db-all-test", dbName: uniqueDbName("paginate") }));
+
+    db.insert(todos, {
+      title: "p1",
+      done: false,
+      priority: 1,
+      owner_id: undefined,
+      tags: ["x"],
+    });
+    db.insert(todos, {
+      title: "p2",
+      done: false,
+      priority: 2,
+      owner_id: undefined,
+      tags: ["x"],
+    });
+    db.insert(todos, {
+      title: "p3",
+      done: false,
+      priority: 3,
+      owner_id: undefined,
+      tags: ["x"],
+    });
+
+    const rows = await db.all<Todo>(
+      makeQuery<Todo>("todos", {
+        orderBy: [["priority", "desc"]],
+        offset: 1,
+        limit: 1,
+      }),
+    );
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].priority).toBe(2);
+    expect(rows[0].title).toBe("p2");
+  });
+
+  it("supports include relations", async () => {
+    const db = track(await createDb({ appId: "db-all-test", dbName: uniqueDbName("include") }));
+
+    const orgId = db.insert(orgs, { name: "Acme" });
+    const teamId = db.insert(teams, { name: "Core", org_id: orgId, parent_id: undefined });
+    const ownerId = db.insert(users, { name: "Owner", team_id: teamId });
+    db.insert(todos, {
+      title: "with-owner-1",
+      done: false,
+      priority: 1,
+      owner_id: ownerId,
+      tags: ["x"],
+    });
+    db.insert(todos, {
+      title: "with-owner-2",
+      done: true,
+      priority: 2,
+      owner_id: ownerId,
+      tags: ["y"],
+    });
+
+    const rows = await db.all<User>(
+      makeQuery<User>("users", {
+        conditions: [{ column: "id", op: "eq", value: ownerId }],
+        includes: { todosViaOwner: true },
+      }),
+    );
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      id: ownerId,
+      name: "Owner",
+    });
+    expect(rows[0].todosViaOwner).toBeUndefined();
+  });
+
+  it("supports multi-hop queries", async () => {
+    const db = track(await createDb({ appId: "db-all-test", dbName: uniqueDbName("hops") }));
+
+    const orgId = db.insert(orgs, { name: "Org A" });
+    const teamId = db.insert(teams, { name: "Team A", org_id: orgId, parent_id: undefined });
+    const userId = db.insert(users, { name: "User A", team_id: teamId });
+
+    const rows = await db.all<Org>(
+      makeQuery<Org>("users", {
+        conditions: [{ column: "id", op: "eq", value: userId }],
+        hops: ["team", "org"],
+      }),
+    );
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toEqual({ id: orgId, name: "Org A" });
+  });
+
+  it("supports gather queries", async () => {
+    const db = track(await createDb({ appId: "db-all-test", dbName: uniqueDbName("gather") }));
+
+    const rootId = db.insert(teams, { name: "root", org_id: undefined, parent_id: undefined });
+    const midId = db.insert(teams, { name: "mid", org_id: undefined, parent_id: rootId });
+    const leafId = db.insert(teams, { name: "leaf", org_id: undefined, parent_id: midId });
+
+    const rows = await db.all<Team>(
+      makeQuery<Team>("teams", {
+        conditions: [{ column: "id", op: "eq", value: leafId }],
+        gather: {
+          max_depth: 10,
+          step_table: "teams",
+          step_current_column: "id",
+          step_conditions: [],
+          step_hops: ["parent"],
+        },
+      }),
+    );
+
+    const ids = rows.map((row) => row.id).sort();
+    expect(ids).toEqual([leafId, midId, rootId].sort());
+  });
+});

--- a/packages/jazz-tools/tests/browser/db.all.test.ts
+++ b/packages/jazz-tools/tests/browser/db.all.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { createDb, type Db, type QueryBuilder, type TableProxy } from "../../src/runtime/db.js";
 import type { WasmSchema } from "../../src/drivers/types.js";
 
@@ -141,10 +141,95 @@ function makeQuery<T>(
 
 describe("db.all browser integration", () => {
   const dbs: Db[] = [];
+  let conditionsDb: Db;
+  const conditionCases: Array<{
+    name: string;
+    conditions: Array<{ column: string; op: string; value?: unknown }>;
+    expectedTitles: string[];
+  }> = [
+    {
+      name: "eq",
+      conditions: [{ column: "title", op: "eq", value: "alpha" }],
+      expectedTitles: ["alpha"],
+    },
+    {
+      name: "ne",
+      conditions: [{ column: "title", op: "ne", value: "alpha" }],
+      expectedTitles: ["beta", "gamma"],
+    },
+    {
+      name: "gt",
+      conditions: [{ column: "priority", op: "gt", value: 1 }],
+      expectedTitles: ["beta"],
+    },
+    {
+      name: "gte",
+      conditions: [{ column: "priority", op: "gte", value: 2 }],
+      expectedTitles: ["beta"],
+    },
+    {
+      name: "lt",
+      conditions: [{ column: "priority", op: "lt", value: 2 }],
+      expectedTitles: ["alpha"],
+    },
+    {
+      name: "lte",
+      conditions: [{ column: "priority", op: "lte", value: 1 }],
+      expectedTitles: ["alpha"],
+    },
+    {
+      name: "isNull",
+      conditions: [{ column: "priority", op: "isNull" }],
+      expectedTitles: ["gamma"],
+    },
+    {
+      name: "contains-array",
+      conditions: [{ column: "tags", op: "contains", value: "work" }],
+      expectedTitles: ["alpha", "gamma"],
+    },
+    {
+      name: "contains-text",
+      conditions: [{ column: "title", op: "contains", value: "alp" }],
+      expectedTitles: ["alpha"],
+    },
+    {
+      name: "contains-text-empty",
+      conditions: [{ column: "title", op: "contains", value: "" }],
+      expectedTitles: ["alpha", "beta", "gamma"],
+    },
+  ];
 
   function track(db: Db): Db {
     dbs.push(db);
     return db;
+  }
+
+  function seedTodosForConditions(db: Db): void {
+    const orgId = db.insert(orgs, { name: "Acme" });
+    const teamId = db.insert(teams, { name: "Core", org_id: orgId, parent_id: undefined });
+    const userId = db.insert(users, { name: "Alice", team_id: teamId });
+
+    db.insert(todos, {
+      title: "alpha",
+      done: false,
+      priority: 1,
+      owner_id: userId,
+      tags: ["work", "backend"],
+    });
+    db.insert(todos, {
+      title: "beta",
+      done: true,
+      priority: 2,
+      owner_id: userId,
+      tags: ["home"],
+    });
+    db.insert(todos, {
+      title: "gamma",
+      done: true,
+      priority: undefined,
+      owner_id: userId,
+      tags: ["work", "urgent"],
+    });
   }
 
   afterEach(async () => {
@@ -153,89 +238,25 @@ describe("db.all browser integration", () => {
     }
   });
 
-  it("supports all condition operators", async () => {
-    const db = track(await createDb({ appId: "db-all-test", dbName: uniqueDbName("ops") }));
+  beforeAll(async () => {
+    conditionsDb = await createDb({ appId: "db-all-test", dbName: uniqueDbName("ops") });
+    seedTodosForConditions(conditionsDb);
+  });
 
-    const orgId = db.insert(orgs, { name: "Acme" });
-    const teamId = db.insert(teams, { name: "Core", org_id: orgId, parent_id: undefined });
-    const userId = db.insert(users, { name: "Alice", team_id: teamId });
+  afterAll(async () => {
+    await conditionsDb.shutdown();
+  });
 
-    const idA = db.insert(todos, {
-      title: "alpha",
-      done: false,
-      priority: 1,
-      owner_id: userId,
-      tags: ["work", "backend"],
-    });
-    const idB = db.insert(todos, {
-      title: "beta",
-      done: true,
-      priority: 2,
-      owner_id: userId,
-      tags: ["home"],
-    });
-    const idC = db.insert(todos, {
-      title: "gamma",
-      done: true,
-      priority: undefined,
-      owner_id: userId,
-      tags: ["work", "urgent"],
-    });
-
-    const cases: Array<{
-      name: string;
-      conditions: Array<{ column: string; op: string; value?: unknown }>;
-      expectedIds: string[];
-    }> = [
-      {
-        name: "eq",
-        conditions: [{ column: "title", op: "eq", value: "alpha" }],
-        expectedIds: [idA],
-      },
-      {
-        name: "ne",
-        conditions: [{ column: "title", op: "ne", value: "alpha" }],
-        expectedIds: [idB, idC],
-      },
-      { name: "gt", conditions: [{ column: "priority", op: "gt", value: 1 }], expectedIds: [idB] },
-      {
-        name: "gte",
-        conditions: [{ column: "priority", op: "gte", value: 2 }],
-        expectedIds: [idB],
-      },
-      { name: "lt", conditions: [{ column: "priority", op: "lt", value: 2 }], expectedIds: [idA] },
-      {
-        name: "lte",
-        conditions: [{ column: "priority", op: "lte", value: 1 }],
-        expectedIds: [idA],
-      },
-      { name: "isNull", conditions: [{ column: "priority", op: "isNull" }], expectedIds: [idC] },
-      {
-        name: "contains-array",
-        conditions: [{ column: "tags", op: "contains", value: "work" }],
-        expectedIds: [idA, idC],
-      },
-      {
-        name: "contains-text",
-        conditions: [{ column: "title", op: "contains", value: "alp" }],
-        expectedIds: [idA],
-      },
-      {
-        name: "contains-text-empty",
-        conditions: [{ column: "title", op: "contains", value: "" }],
-        expectedIds: [idA, idB, idC],
-      },
-    ];
-
-    for (const testCase of cases) {
-      const rows = await db.all<Todo>(
+  for (const testCase of conditionCases) {
+    it(`supports condition operator ${testCase.name}`, async () => {
+      const rows = await conditionsDb.all<Todo>(
         makeQuery<Todo>("todos", { conditions: testCase.conditions }),
       );
-      const actual = rows.map((row) => row.id).sort();
-      const expected = [...testCase.expectedIds].sort();
-      expect(actual, testCase.name).toEqual(expected);
-    }
-  });
+      const actual = rows.map((row) => row.title).sort();
+      const expected = [...testCase.expectedTitles].sort();
+      expect(actual).toEqual(expected);
+    });
+  }
 
   it("supports orderBy + limit + offset", async () => {
     const db = track(await createDb({ appId: "db-all-test", dbName: uniqueDbName("paginate") }));

--- a/packages/jazz-tools/tests/browser/db.subscribeAll.test.ts
+++ b/packages/jazz-tools/tests/browser/db.subscribeAll.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { createDb, type Db, type QueryBuilder, type TableProxy } from "../../src/runtime/db.js";
 import type { SubscriptionDelta } from "../../src/runtime/subscription-manager.js";
 import type { WasmSchema } from "../../src/drivers/types.js";
@@ -156,6 +156,107 @@ async function waitForCondition(
 describe("db.subscribeAll browser integration", () => {
   const dbs: Db[] = [];
   const unsubscribes: Array<() => void> = [];
+  let conditionsDb: Db;
+  const conditionCases: Array<{
+    name: string;
+    query: QueryBuilder<Todo>;
+    insert: Omit<Todo, "id">;
+  }> = [
+    {
+      name: "eq",
+      query: makeQuery<Todo>("todos", {
+        conditions: [{ column: "title", op: "eq", value: "eq-hit" }],
+      }),
+      insert: { title: "eq-hit", done: false, priority: 1, owner_id: undefined, tags: ["x"] },
+    },
+    {
+      name: "ne",
+      query: makeQuery<Todo>("todos", {
+        conditions: [{ column: "title", op: "ne", value: "blocked" }],
+      }),
+      insert: { title: "ne-hit", done: false, priority: 2, owner_id: undefined, tags: ["x"] },
+    },
+    {
+      name: "gt",
+      query: makeQuery<Todo>("todos", {
+        conditions: [{ column: "priority", op: "gt", value: 10 }],
+      }),
+      insert: { title: "gt-hit", done: false, priority: 11, owner_id: undefined, tags: ["x"] },
+    },
+    {
+      name: "gte",
+      query: makeQuery<Todo>("todos", {
+        conditions: [{ column: "priority", op: "gte", value: 10 }],
+      }),
+      insert: { title: "gte-hit", done: false, priority: 10, owner_id: undefined, tags: ["x"] },
+    },
+    {
+      name: "lt",
+      query: makeQuery<Todo>("todos", {
+        conditions: [{ column: "priority", op: "lt", value: 0 }],
+      }),
+      insert: { title: "lt-hit", done: false, priority: -1, owner_id: undefined, tags: ["x"] },
+    },
+    {
+      name: "lte",
+      query: makeQuery<Todo>("todos", {
+        conditions: [{ column: "priority", op: "lte", value: 0 }],
+      }),
+      insert: { title: "lte-hit", done: false, priority: 0, owner_id: undefined, tags: ["x"] },
+    },
+    {
+      name: "isNull",
+      query: makeQuery<Todo>("todos", {
+        conditions: [{ column: "priority", op: "isNull" }],
+      }),
+      insert: {
+        title: "null-hit",
+        done: false,
+        priority: undefined,
+        owner_id: undefined,
+        tags: ["x"],
+      },
+    },
+    {
+      name: "contains-array",
+      query: makeQuery<Todo>("todos", {
+        conditions: [{ column: "tags", op: "contains", value: "needle" }],
+      }),
+      insert: {
+        title: "contains-array-hit",
+        done: false,
+        priority: 1,
+        owner_id: undefined,
+        tags: ["needle", "hay"],
+      },
+    },
+    {
+      name: "contains-text",
+      query: makeQuery<Todo>("todos", {
+        conditions: [{ column: "title", op: "contains", value: "needle" }],
+      }),
+      insert: {
+        title: "hay-needle-title",
+        done: false,
+        priority: 1,
+        owner_id: undefined,
+        tags: ["x"],
+      },
+    },
+    {
+      name: "contains-text-empty",
+      query: makeQuery<Todo>("todos", {
+        conditions: [{ column: "title", op: "contains", value: "" }],
+      }),
+      insert: {
+        title: "any-title",
+        done: false,
+        priority: 1,
+        owner_id: undefined,
+        tags: ["x"],
+      },
+    },
+  ];
 
   function track(db: Db): Db {
     dbs.push(db);
@@ -179,6 +280,17 @@ describe("db.subscribeAll browser integration", () => {
     for (const db of dbs.splice(0).reverse()) {
       await db.shutdown();
     }
+  });
+
+  beforeAll(async () => {
+    conditionsDb = await createDb({
+      appId: "db-subscribe-test",
+      dbName: uniqueDbName("filters"),
+    });
+  });
+
+  afterAll(async () => {
+    await conditionsDb.shutdown();
   });
 
   it("emits added, updated, removed, and all", async () => {
@@ -232,121 +344,16 @@ describe("db.subscribeAll browser integration", () => {
     unsubscribe();
   });
 
-  it("supports condition filters", async () => {
-    const db = track(
-      await createDb({ appId: "db-subscribe-test", dbName: uniqueDbName("filters") }),
-    );
-
-    const cases: Array<{
-      name: string;
-      query: QueryBuilder<Todo>;
-      insert: Omit<Todo, "id">;
-    }> = [
-      {
-        name: "eq",
-        query: makeQuery<Todo>("todos", {
-          conditions: [{ column: "title", op: "eq", value: "eq-hit" }],
-        }),
-        insert: { title: "eq-hit", done: false, priority: 1, owner_id: undefined, tags: ["x"] },
-      },
-      {
-        name: "ne",
-        query: makeQuery<Todo>("todos", {
-          conditions: [{ column: "title", op: "ne", value: "blocked" }],
-        }),
-        insert: { title: "ne-hit", done: false, priority: 2, owner_id: undefined, tags: ["x"] },
-      },
-      {
-        name: "gt",
-        query: makeQuery<Todo>("todos", {
-          conditions: [{ column: "priority", op: "gt", value: 10 }],
-        }),
-        insert: { title: "gt-hit", done: false, priority: 11, owner_id: undefined, tags: ["x"] },
-      },
-      {
-        name: "gte",
-        query: makeQuery<Todo>("todos", {
-          conditions: [{ column: "priority", op: "gte", value: 10 }],
-        }),
-        insert: { title: "gte-hit", done: false, priority: 10, owner_id: undefined, tags: ["x"] },
-      },
-      {
-        name: "lt",
-        query: makeQuery<Todo>("todos", {
-          conditions: [{ column: "priority", op: "lt", value: 0 }],
-        }),
-        insert: { title: "lt-hit", done: false, priority: -1, owner_id: undefined, tags: ["x"] },
-      },
-      {
-        name: "lte",
-        query: makeQuery<Todo>("todos", {
-          conditions: [{ column: "priority", op: "lte", value: 0 }],
-        }),
-        insert: { title: "lte-hit", done: false, priority: 0, owner_id: undefined, tags: ["x"] },
-      },
-      {
-        name: "isNull",
-        query: makeQuery<Todo>("todos", {
-          conditions: [{ column: "priority", op: "isNull" }],
-        }),
-        insert: {
-          title: "null-hit",
-          done: false,
-          priority: undefined,
-          owner_id: undefined,
-          tags: ["x"],
-        },
-      },
-      {
-        name: "contains-array",
-        query: makeQuery<Todo>("todos", {
-          conditions: [{ column: "tags", op: "contains", value: "needle" }],
-        }),
-        insert: {
-          title: "contains-array-hit",
-          done: false,
-          priority: 1,
-          owner_id: undefined,
-          tags: ["needle", "hay"],
-        },
-      },
-      {
-        name: "contains-text",
-        query: makeQuery<Todo>("todos", {
-          conditions: [{ column: "title", op: "contains", value: "needle" }],
-        }),
-        insert: {
-          title: "hay-needle-title",
-          done: false,
-          priority: 1,
-          owner_id: undefined,
-          tags: ["x"],
-        },
-      },
-      {
-        name: "contains-text-empty",
-        query: makeQuery<Todo>("todos", {
-          conditions: [{ column: "title", op: "contains", value: "" }],
-        }),
-        insert: {
-          title: "any-title",
-          done: false,
-          priority: 1,
-          owner_id: undefined,
-          tags: ["x"],
-        },
-      },
-    ];
-
-    for (const testCase of cases) {
+  for (const testCase of conditionCases) {
+    it(`supports condition filter ${testCase.name}`, async () => {
       const deltas: Array<SubscriptionDelta<Todo>> = [];
       const unsubscribe = trackUnsubscribe(
-        db.subscribeAll(testCase.query, (delta) => {
+        conditionsDb.subscribeAll(testCase.query, (delta) => {
           deltas.push(delta);
         }),
       );
 
-      const insertedId = db.insert(todos, testCase.insert);
+      const insertedId = conditionsDb.insert(todos, testCase.insert);
 
       await waitForCondition(
         () => deltas.some((delta) => delta.added.some((row) => row.id === insertedId)),
@@ -355,8 +362,8 @@ describe("db.subscribeAll browser integration", () => {
       );
 
       unsubscribe();
-    }
-  });
+    });
+  }
 
   it("supports orderBy + limit + offset", async () => {
     const db = track(await createDb({ appId: "db-subscribe-test", dbName: uniqueDbName("order") }));

--- a/packages/jazz-tools/tests/browser/db.subscribeAll.test.ts
+++ b/packages/jazz-tools/tests/browser/db.subscribeAll.test.ts
@@ -1,0 +1,527 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createDb, type Db, type QueryBuilder, type TableProxy } from "../../src/runtime/db.js";
+import type { SubscriptionDelta } from "../../src/runtime/subscription-manager.js";
+import type { WasmSchema } from "../../src/drivers/types.js";
+
+const schema: WasmSchema = {
+  tables: {
+    orgs: {
+      columns: [{ name: "name", column_type: { type: "Text" }, nullable: false }],
+    },
+    teams: {
+      columns: [
+        { name: "name", column_type: { type: "Text" }, nullable: false },
+        { name: "org_id", column_type: { type: "Uuid" }, nullable: true, references: "orgs" },
+        {
+          name: "parent_id",
+          column_type: { type: "Uuid" },
+          nullable: true,
+          references: "teams",
+        },
+      ],
+    },
+    users: {
+      columns: [
+        { name: "name", column_type: { type: "Text" }, nullable: false },
+        { name: "team_id", column_type: { type: "Uuid" }, nullable: true, references: "teams" },
+      ],
+    },
+    todos: {
+      columns: [
+        { name: "title", column_type: { type: "Text" }, nullable: false },
+        { name: "done", column_type: { type: "Boolean" }, nullable: false },
+        { name: "priority", column_type: { type: "Integer" }, nullable: true },
+        { name: "owner_id", column_type: { type: "Uuid" }, nullable: true, references: "users" },
+        {
+          name: "tags",
+          column_type: { type: "Array", element: { type: "Text" } },
+          nullable: false,
+        },
+      ],
+    },
+  },
+};
+
+interface Org {
+  id: string;
+  name: string;
+}
+
+interface Team {
+  id: string;
+  name: string;
+  org_id?: string;
+  parent_id?: string;
+}
+
+interface User {
+  id: string;
+  name: string;
+  team_id?: string;
+}
+
+interface Todo {
+  id: string;
+  title: string;
+  done: boolean;
+  priority?: number;
+  owner_id?: string;
+  tags: string[];
+}
+
+const orgs: TableProxy<Org, Omit<Org, "id">> = {
+  _table: "orgs",
+  _schema: schema,
+  _rowType: {} as Org,
+  _initType: {} as Omit<Org, "id">,
+};
+
+const teams: TableProxy<Team, Omit<Team, "id">> = {
+  _table: "teams",
+  _schema: schema,
+  _rowType: {} as Team,
+  _initType: {} as Omit<Team, "id">,
+};
+
+const users: TableProxy<User, Omit<User, "id">> = {
+  _table: "users",
+  _schema: schema,
+  _rowType: {} as User,
+  _initType: {} as Omit<User, "id">,
+};
+
+const todos: TableProxy<Todo, Omit<Todo, "id">> = {
+  _table: "todos",
+  _schema: schema,
+  _rowType: {} as Todo,
+  _initType: {} as Omit<Todo, "id">,
+};
+
+function uniqueDbName(label: string): string {
+  return `db-subscribe-all-${label}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function makeQuery<T>(
+  table: string,
+  body: {
+    conditions?: Array<{ column: string; op: string; value?: unknown }>;
+    includes?: Record<string, boolean | object>;
+    orderBy?: Array<[string, "asc" | "desc"]>;
+    limit?: number;
+    offset?: number;
+    hops?: string[];
+    gather?: {
+      max_depth: number;
+      step_table: string;
+      step_current_column: string;
+      step_conditions: Array<{ column: string; op: string; value: unknown }>;
+      step_hops: string[];
+    };
+  },
+): QueryBuilder<T> {
+  return {
+    _table: table,
+    _schema: schema,
+    _rowType: {} as T,
+    _build() {
+      return JSON.stringify({
+        table,
+        conditions: body.conditions ?? [],
+        includes: body.includes ?? {},
+        orderBy: body.orderBy ?? [],
+        limit: body.limit,
+        offset: body.offset,
+        hops: body.hops,
+        gather: body.gather,
+      });
+    },
+  };
+}
+
+async function waitForCondition(
+  check: () => boolean,
+  timeoutMs: number,
+  errorMessage: string,
+): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (check()) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error(errorMessage);
+}
+
+describe("db.subscribeAll browser integration", () => {
+  const dbs: Db[] = [];
+  const unsubscribes: Array<() => void> = [];
+
+  function track(db: Db): Db {
+    dbs.push(db);
+    return db;
+  }
+
+  function trackUnsubscribe(unsubscribe: () => void): () => void {
+    unsubscribes.push(unsubscribe);
+    return unsubscribe;
+  }
+
+  afterEach(async () => {
+    for (const unsubscribe of unsubscribes.splice(0)) {
+      try {
+        unsubscribe();
+      } catch {
+        // best effort
+      }
+    }
+
+    for (const db of dbs.splice(0).reverse()) {
+      await db.shutdown();
+    }
+  });
+
+  it("emits added, updated, removed, and all", async () => {
+    const db = track(await createDb({ appId: "db-subscribe-test", dbName: uniqueDbName("delta") }));
+
+    const deltas: Array<SubscriptionDelta<Todo>> = [];
+    const unsubscribe = trackUnsubscribe(
+      db.subscribeAll(
+        makeQuery<Todo>("todos", {
+          conditions: [{ column: "done", op: "eq", value: false }],
+        }),
+        (delta) => {
+          deltas.push(delta);
+        },
+      ),
+    );
+
+    const id = db.insert(todos, {
+      title: "watch-me",
+      done: false,
+      priority: 1,
+      owner_id: undefined,
+      tags: ["x"],
+    });
+
+    await waitForCondition(
+      () => deltas.some((delta) => delta.added.some((row) => row.id === id)),
+      4000,
+      "expected add delta",
+    );
+
+    db.update(todos, id, { title: "watch-me-updated" });
+
+    await waitForCondition(
+      () => deltas.some((delta) => delta.updated.some((row) => row.id === id)),
+      4000,
+      "expected update delta",
+    );
+
+    db.update(todos, id, { done: true });
+
+    await waitForCondition(
+      () => deltas.some((delta) => delta.removed.some((row) => row.id === id)),
+      4000,
+      "expected remove delta",
+    );
+
+    const latestAll = deltas[deltas.length - 1]?.all ?? [];
+    expect(latestAll.some((row) => row.id === id)).toBe(false);
+
+    unsubscribe();
+  });
+
+  it("supports condition filters", async () => {
+    const db = track(
+      await createDb({ appId: "db-subscribe-test", dbName: uniqueDbName("filters") }),
+    );
+
+    const cases: Array<{
+      name: string;
+      query: QueryBuilder<Todo>;
+      insert: Omit<Todo, "id">;
+    }> = [
+      {
+        name: "eq",
+        query: makeQuery<Todo>("todos", {
+          conditions: [{ column: "title", op: "eq", value: "eq-hit" }],
+        }),
+        insert: { title: "eq-hit", done: false, priority: 1, owner_id: undefined, tags: ["x"] },
+      },
+      {
+        name: "ne",
+        query: makeQuery<Todo>("todos", {
+          conditions: [{ column: "title", op: "ne", value: "blocked" }],
+        }),
+        insert: { title: "ne-hit", done: false, priority: 2, owner_id: undefined, tags: ["x"] },
+      },
+      {
+        name: "gt",
+        query: makeQuery<Todo>("todos", {
+          conditions: [{ column: "priority", op: "gt", value: 10 }],
+        }),
+        insert: { title: "gt-hit", done: false, priority: 11, owner_id: undefined, tags: ["x"] },
+      },
+      {
+        name: "gte",
+        query: makeQuery<Todo>("todos", {
+          conditions: [{ column: "priority", op: "gte", value: 10 }],
+        }),
+        insert: { title: "gte-hit", done: false, priority: 10, owner_id: undefined, tags: ["x"] },
+      },
+      {
+        name: "lt",
+        query: makeQuery<Todo>("todos", {
+          conditions: [{ column: "priority", op: "lt", value: 0 }],
+        }),
+        insert: { title: "lt-hit", done: false, priority: -1, owner_id: undefined, tags: ["x"] },
+      },
+      {
+        name: "lte",
+        query: makeQuery<Todo>("todos", {
+          conditions: [{ column: "priority", op: "lte", value: 0 }],
+        }),
+        insert: { title: "lte-hit", done: false, priority: 0, owner_id: undefined, tags: ["x"] },
+      },
+      {
+        name: "isNull",
+        query: makeQuery<Todo>("todos", {
+          conditions: [{ column: "priority", op: "isNull" }],
+        }),
+        insert: {
+          title: "null-hit",
+          done: false,
+          priority: undefined,
+          owner_id: undefined,
+          tags: ["x"],
+        },
+      },
+      {
+        name: "contains-array",
+        query: makeQuery<Todo>("todos", {
+          conditions: [{ column: "tags", op: "contains", value: "needle" }],
+        }),
+        insert: {
+          title: "contains-array-hit",
+          done: false,
+          priority: 1,
+          owner_id: undefined,
+          tags: ["needle", "hay"],
+        },
+      },
+      {
+        name: "contains-text",
+        query: makeQuery<Todo>("todos", {
+          conditions: [{ column: "title", op: "contains", value: "needle" }],
+        }),
+        insert: {
+          title: "hay-needle-title",
+          done: false,
+          priority: 1,
+          owner_id: undefined,
+          tags: ["x"],
+        },
+      },
+      {
+        name: "contains-text-empty",
+        query: makeQuery<Todo>("todos", {
+          conditions: [{ column: "title", op: "contains", value: "" }],
+        }),
+        insert: {
+          title: "any-title",
+          done: false,
+          priority: 1,
+          owner_id: undefined,
+          tags: ["x"],
+        },
+      },
+    ];
+
+    for (const testCase of cases) {
+      const deltas: Array<SubscriptionDelta<Todo>> = [];
+      const unsubscribe = trackUnsubscribe(
+        db.subscribeAll(testCase.query, (delta) => {
+          deltas.push(delta);
+        }),
+      );
+
+      const insertedId = db.insert(todos, testCase.insert);
+
+      await waitForCondition(
+        () => deltas.some((delta) => delta.added.some((row) => row.id === insertedId)),
+        4000,
+        `expected add delta for ${testCase.name}`,
+      );
+
+      unsubscribe();
+    }
+  });
+
+  it("supports orderBy + limit + offset", async () => {
+    const db = track(await createDb({ appId: "db-subscribe-test", dbName: uniqueDbName("order") }));
+
+    const deltas: Array<SubscriptionDelta<Todo>> = [];
+    const unsubscribe = trackUnsubscribe(
+      db.subscribeAll(
+        makeQuery<Todo>("todos", {
+          orderBy: [["priority", "desc"]],
+          offset: 1,
+          limit: 1,
+        }),
+        (delta) => deltas.push(delta),
+      ),
+    );
+
+    db.insert(todos, {
+      title: "p1",
+      done: false,
+      priority: 1,
+      owner_id: undefined,
+      tags: ["x"],
+    });
+    db.insert(todos, {
+      title: "p2",
+      done: false,
+      priority: 2,
+      owner_id: undefined,
+      tags: ["x"],
+    });
+    db.insert(todos, {
+      title: "p3",
+      done: false,
+      priority: 3,
+      owner_id: undefined,
+      tags: ["x"],
+    });
+
+    await waitForCondition(
+      () => deltas.some((delta) => delta.all.length === 1 && delta.all[0]?.title === "p2"),
+      4000,
+      "expected sorted/paginated result in subscription",
+    );
+
+    unsubscribe();
+  });
+
+  it("does not emit add for non-matching text contains", async () => {
+    const db = track(
+      await createDb({ appId: "db-subscribe-test", dbName: uniqueDbName("contains-text-miss") }),
+    );
+
+    const deltas: Array<SubscriptionDelta<Todo>> = [];
+    const unsubscribe = trackUnsubscribe(
+      db.subscribeAll(
+        makeQuery<Todo>("todos", {
+          conditions: [{ column: "title", op: "contains", value: "needle" }],
+        }),
+        (delta) => deltas.push(delta),
+      ),
+    );
+
+    const insertedId = db.insert(todos, {
+      title: "completely unrelated",
+      done: false,
+      priority: 1,
+      owner_id: undefined,
+      tags: ["x"],
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    expect(deltas.some((delta) => delta.added.some((row) => row.id === insertedId))).toBe(false);
+
+    unsubscribe();
+  });
+
+  it("supports include query execution path", async () => {
+    const db = track(
+      await createDb({ appId: "db-subscribe-test", dbName: uniqueDbName("include") }),
+    );
+
+    const deltas: Array<SubscriptionDelta<User>> = [];
+    const unsubscribe = trackUnsubscribe(
+      db.subscribeAll(
+        makeQuery<User>("users", {
+          includes: { todosViaOwner: true },
+        }),
+        (delta) => deltas.push(delta),
+      ),
+    );
+
+    const userId = db.insert(users, { name: "Owner", team_id: undefined });
+
+    await waitForCondition(
+      () => deltas.some((delta) => delta.added.some((row) => row.id === userId)),
+      4000,
+      "expected include query subscription delta",
+    );
+
+    unsubscribe();
+  });
+
+  it("supports hop queries", async () => {
+    const db = track(await createDb({ appId: "db-subscribe-test", dbName: uniqueDbName("hops") }));
+
+    const deltas: Array<SubscriptionDelta<Org>> = [];
+    const unsubscribe = trackUnsubscribe(
+      db.subscribeAll(
+        makeQuery<Org>("users", {
+          hops: ["team", "org"],
+        }),
+        (delta) => deltas.push(delta),
+      ),
+    );
+
+    const orgId = db.insert(orgs, { name: "Hop Org" });
+    const teamId = db.insert(teams, { name: "Hop Team", org_id: orgId, parent_id: undefined });
+    db.insert(users, { name: "Hop User", team_id: teamId });
+
+    await waitForCondition(
+      () =>
+        deltas.some((delta) => delta.all.some((row) => row.id === orgId && row.name === "Hop Org")),
+      4000,
+      "expected hop query subscription result",
+    );
+
+    unsubscribe();
+  });
+
+  it("supports gather queries", async () => {
+    const db = track(
+      await createDb({ appId: "db-subscribe-test", dbName: uniqueDbName("gather") }),
+    );
+
+    const deltas: Array<SubscriptionDelta<Team>> = [];
+    const unsubscribe = trackUnsubscribe(
+      db.subscribeAll(
+        makeQuery<Team>("teams", {
+          conditions: [{ column: "name", op: "eq", value: "leaf" }],
+          gather: {
+            max_depth: 10,
+            step_table: "teams",
+            step_current_column: "id",
+            step_conditions: [],
+            step_hops: ["parent"],
+          },
+        }),
+        (delta) => deltas.push(delta),
+      ),
+    );
+
+    const rootId = db.insert(teams, { name: "root", org_id: undefined, parent_id: undefined });
+    const midId = db.insert(teams, { name: "mid", org_id: undefined, parent_id: rootId });
+    const leafId = db.insert(teams, { name: "leaf", org_id: undefined, parent_id: midId });
+
+    await waitForCondition(
+      () => {
+        const latestAll = deltas[deltas.length - 1]?.all ?? [];
+        const ids = latestAll.map((row) => row.id);
+        return ids.includes(rootId) && ids.includes(midId) && ids.includes(leafId);
+      },
+      4000,
+      "expected gather query subscription result",
+    );
+
+    unsubscribe();
+  });
+});

--- a/packages/jazz-tools/tests/browser/react-core-provider.test.tsx
+++ b/packages/jazz-tools/tests/browser/react-core-provider.test.tsx
@@ -282,7 +282,7 @@ describe("react-core provider/hooks browser coverage", () => {
         { id: "a", title: "Alpha" },
         { id: "b", title: "Beta" },
       ],
-      added: [{ item: { id: "b", title: "Beta" }, index: 1 }],
+      added: [{ id: "b", title: "Beta" }],
       updated: [],
       removed: [],
     });
@@ -294,14 +294,7 @@ describe("react-core provider/hooks browser coverage", () => {
         { id: "a", title: "Alpha" },
       ],
       added: [],
-      updated: [
-        {
-          oldItem: { id: "b", title: "Beta" },
-          newItem: { id: "b", title: "Beta*" },
-          oldIndex: 1,
-          newIndex: 0,
-        },
-      ],
+      updated: [{ id: "b", title: "Beta*" }],
       removed: [],
     });
     await expectText("rows", "Beta*|Alpha");
@@ -310,7 +303,7 @@ describe("react-core provider/hooks browser coverage", () => {
       all: [{ id: "b", title: "Beta*" }],
       added: [],
       updated: [],
-      removed: [{ item: { id: "a", title: "Alpha" }, index: 1 }],
+      removed: [{ id: "a", title: "Alpha" }],
     });
     await expectText("rows", "Beta*");
   });

--- a/packages/jazz-tools/tests/browser/useAll.test.tsx
+++ b/packages/jazz-tools/tests/browser/useAll.test.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { userEvent } from "vitest/browser";
 import { createRoot, type Root } from "react-dom/client";
 import type { WasmSchema } from "../../src/drivers/types.js";
@@ -188,6 +188,7 @@ function UseAllProbe<T extends { id: string }>({
 
 describe("useAll browser integration", () => {
   const clients: JazzClient[] = [];
+  let conditionsClient: JazzClient;
   const conditionCases: Array<{
     name: string;
     query: QueryBuilder<Todo>;
@@ -303,6 +304,17 @@ describe("useAll browser integration", () => {
     return client;
   }
 
+  beforeAll(async () => {
+    conditionsClient = await createJazzClient({
+      appId: uniqueId("operators"),
+      dbName: uniqueId("operators"),
+    });
+  });
+
+  afterAll(async () => {
+    await conditionsClient.shutdown();
+  });
+
   afterEach(async () => {
     for (const client of clients.splice(0).reverse()) {
       await client.shutdown();
@@ -311,20 +323,13 @@ describe("useAll browser integration", () => {
 
   for (const testCase of conditionCases) {
     it(`supports condition operator ${testCase.name}`, async () => {
-      const client = track(
-        await createJazzClient({
-          appId: uniqueId(`operators-${testCase.name}`),
-          dbName: uniqueId(`operators-${testCase.name}`),
-        }),
-      );
-
       render(
-        <JazzProvider client={client} key={testCase.name}>
+        <JazzProvider client={conditionsClient} key={testCase.name}>
           <UseAllProbe query={testCase.query} pick={(row) => row.title} />
         </JazzProvider>,
       );
 
-      client.db.insert(todos, testCase.insert);
+      conditionsClient.db.insert(todos, testCase.insert);
 
       await waitForCondition(
         () => getText("rows").split("|").includes(testCase.pick),

--- a/packages/jazz-tools/tests/browser/useAll.test.tsx
+++ b/packages/jazz-tools/tests/browser/useAll.test.tsx
@@ -1,0 +1,584 @@
+import * as React from "react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createRoot, type Root } from "react-dom/client";
+import type { WasmSchema } from "../../src/drivers/types.js";
+import type { QueryBuilder, TableProxy } from "../../src/runtime/db.js";
+import { createJazzClient, type JazzClient } from "../../src/react/create-jazz-client.js";
+import { JazzProvider } from "../../src/react-core/provider.js";
+import { useAll } from "../../src/react-core/use-all.js";
+
+const schema: WasmSchema = {
+  tables: {
+    orgs: {
+      columns: [{ name: "name", column_type: { type: "Text" }, nullable: false }],
+    },
+    teams: {
+      columns: [
+        { name: "name", column_type: { type: "Text" }, nullable: false },
+        { name: "org_id", column_type: { type: "Uuid" }, nullable: true, references: "orgs" },
+        {
+          name: "parent_id",
+          column_type: { type: "Uuid" },
+          nullable: true,
+          references: "teams",
+        },
+      ],
+    },
+    users: {
+      columns: [
+        { name: "name", column_type: { type: "Text" }, nullable: false },
+        { name: "team_id", column_type: { type: "Uuid" }, nullable: true, references: "teams" },
+      ],
+    },
+    todos: {
+      columns: [
+        { name: "title", column_type: { type: "Text" }, nullable: false },
+        { name: "done", column_type: { type: "Boolean" }, nullable: false },
+        { name: "priority", column_type: { type: "Integer" }, nullable: true },
+        { name: "owner_id", column_type: { type: "Uuid" }, nullable: true, references: "users" },
+        {
+          name: "tags",
+          column_type: { type: "Array", element: { type: "Text" } },
+          nullable: false,
+        },
+      ],
+    },
+  },
+};
+
+type Org = { id: string; name: string };
+type Team = { id: string; name: string; org_id?: string; parent_id?: string };
+type User = { id: string; name: string; team_id?: string; todosViaOwner?: Todo[] };
+type Todo = {
+  id: string;
+  title: string;
+  done: boolean;
+  priority?: number;
+  owner_id?: string;
+  tags: string[];
+};
+
+const orgs: TableProxy<Org, Omit<Org, "id">> = {
+  _table: "orgs",
+  _schema: schema,
+  _rowType: {} as Org,
+  _initType: {} as Omit<Org, "id">,
+};
+
+const teams: TableProxy<Team, Omit<Team, "id">> = {
+  _table: "teams",
+  _schema: schema,
+  _rowType: {} as Team,
+  _initType: {} as Omit<Team, "id">,
+};
+
+const users: TableProxy<User, Omit<User, "id" | "todosViaOwner">> = {
+  _table: "users",
+  _schema: schema,
+  _rowType: {} as User,
+  _initType: {} as Omit<User, "id" | "todosViaOwner">,
+};
+
+const todos: TableProxy<Todo, Omit<Todo, "id">> = {
+  _table: "todos",
+  _schema: schema,
+  _rowType: {} as Todo,
+  _initType: {} as Omit<Todo, "id">,
+};
+
+function uniqueId(label: string): string {
+  return `use-all-${label}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function makeQuery<T>(
+  table: string,
+  body: {
+    conditions?: Array<{ column: string; op: string; value?: unknown }>;
+    includes?: Record<string, boolean | object>;
+    orderBy?: Array<[string, "asc" | "desc"]>;
+    limit?: number;
+    offset?: number;
+    hops?: string[];
+    gather?: {
+      max_depth: number;
+      step_table: string;
+      step_current_column: string;
+      step_conditions: Array<{ column: string; op: string; value: unknown }>;
+      step_hops: string[];
+    };
+  },
+): QueryBuilder<T> {
+  return {
+    _table: table,
+    _schema: schema,
+    _rowType: {} as T,
+    _build() {
+      return JSON.stringify({
+        table,
+        conditions: body.conditions ?? [],
+        includes: body.includes ?? {},
+        orderBy: body.orderBy ?? [],
+        limit: body.limit,
+        offset: body.offset,
+        hops: body.hops,
+        gather: body.gather,
+      });
+    },
+  };
+}
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  if (root) {
+    root.unmount();
+    root = null;
+  }
+  if (container) {
+    container.remove();
+    container = null;
+  }
+});
+
+function render(node: React.ReactNode): void {
+  if (!root) throw new Error("render called before root initialization");
+  root.render(node);
+}
+
+function getText(testId: string): string {
+  if (!container) return "";
+  const node = container.querySelector(`[data-testid="${testId}"]`);
+  return node?.textContent ?? "";
+}
+
+async function waitForCondition(
+  check: () => boolean,
+  timeoutMs: number,
+  errorMessage: string,
+): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (check()) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error(errorMessage);
+}
+
+function UseAllProbe<T extends { id: string }>({
+  query,
+  pick,
+}: {
+  query: QueryBuilder<T>;
+  pick: (row: T) => string;
+}) {
+  const rows = useAll(query);
+  const text = rows ? rows.map(pick).join("|") : "pending";
+  return <div data-testid="rows">{text}</div>;
+}
+
+describe("useAll browser integration", () => {
+  const clients: JazzClient[] = [];
+
+  function track(client: JazzClient): JazzClient {
+    clients.push(client);
+    return client;
+  }
+
+  afterEach(async () => {
+    for (const client of clients.splice(0).reverse()) {
+      await client.shutdown();
+    }
+  });
+
+  it("supports all condition operators", async () => {
+    const client = track(
+      await createJazzClient({
+        appId: uniqueId("operators"),
+        dbName: uniqueId("operators"),
+      }),
+    );
+
+    const cases: Array<{
+      name: string;
+      query: QueryBuilder<Todo>;
+      insert: Omit<Todo, "id">;
+      pick: string;
+    }> = [
+      {
+        name: "eq",
+        query: makeQuery<Todo>("todos", {
+          conditions: [{ column: "title", op: "eq", value: "eq-hit" }],
+        }),
+        insert: { title: "eq-hit", done: false, priority: 1, owner_id: undefined, tags: ["x"] },
+        pick: "eq-hit",
+      },
+      {
+        name: "ne",
+        query: makeQuery<Todo>("todos", {
+          conditions: [{ column: "title", op: "ne", value: "blocked" }],
+        }),
+        insert: { title: "ne-hit", done: false, priority: 2, owner_id: undefined, tags: ["x"] },
+        pick: "ne-hit",
+      },
+      {
+        name: "gt",
+        query: makeQuery<Todo>("todos", {
+          conditions: [{ column: "priority", op: "gt", value: 10 }],
+        }),
+        insert: { title: "gt-hit", done: false, priority: 11, owner_id: undefined, tags: ["x"] },
+        pick: "gt-hit",
+      },
+      {
+        name: "gte",
+        query: makeQuery<Todo>("todos", {
+          conditions: [{ column: "priority", op: "gte", value: 10 }],
+        }),
+        insert: { title: "gte-hit", done: false, priority: 10, owner_id: undefined, tags: ["x"] },
+        pick: "gte-hit",
+      },
+      {
+        name: "lt",
+        query: makeQuery<Todo>("todos", {
+          conditions: [{ column: "priority", op: "lt", value: 0 }],
+        }),
+        insert: { title: "lt-hit", done: false, priority: -1, owner_id: undefined, tags: ["x"] },
+        pick: "lt-hit",
+      },
+      {
+        name: "lte",
+        query: makeQuery<Todo>("todos", {
+          conditions: [{ column: "priority", op: "lte", value: 0 }],
+        }),
+        insert: { title: "lte-hit", done: false, priority: 0, owner_id: undefined, tags: ["x"] },
+        pick: "lte-hit",
+      },
+      {
+        name: "isNull",
+        query: makeQuery<Todo>("todos", { conditions: [{ column: "priority", op: "isNull" }] }),
+        insert: {
+          title: "null-hit",
+          done: false,
+          priority: undefined,
+          owner_id: undefined,
+          tags: ["x"],
+        },
+        pick: "null-hit",
+      },
+      {
+        name: "contains-array",
+        query: makeQuery<Todo>("todos", {
+          conditions: [{ column: "tags", op: "contains", value: "needle" }],
+        }),
+        insert: {
+          title: "contains-array-hit",
+          done: false,
+          priority: 1,
+          owner_id: undefined,
+          tags: ["needle", "hay"],
+        },
+        pick: "contains-array-hit",
+      },
+      {
+        name: "contains-text",
+        query: makeQuery<Todo>("todos", {
+          conditions: [{ column: "title", op: "contains", value: "needle" }],
+        }),
+        insert: {
+          title: "hay-needle-title",
+          done: false,
+          priority: 1,
+          owner_id: undefined,
+          tags: ["x"],
+        },
+        pick: "hay-needle-title",
+      },
+      {
+        name: "contains-text-empty",
+        query: makeQuery<Todo>("todos", {
+          conditions: [{ column: "title", op: "contains", value: "" }],
+        }),
+        insert: {
+          title: "any-title",
+          done: false,
+          priority: 1,
+          owner_id: undefined,
+          tags: ["x"],
+        },
+        pick: "any-title",
+      },
+    ];
+
+    for (const testCase of cases) {
+      render(
+        <JazzProvider client={client} key={testCase.name}>
+          <UseAllProbe query={testCase.query} pick={(row) => row.title} />
+        </JazzProvider>,
+      );
+
+      client.db.insert(todos, testCase.insert);
+
+      await waitForCondition(
+        () => getText("rows").split("|").includes(testCase.pick),
+        5000,
+        `expected useAll rows to include ${testCase.name}`,
+      );
+    }
+  });
+
+  it("supports orderBy + limit + offset", async () => {
+    const client = track(
+      await createJazzClient({
+        appId: uniqueId("order"),
+        dbName: uniqueId("order"),
+      }),
+    );
+
+    const query = makeQuery<Todo>("todos", {
+      orderBy: [["priority", "desc"]],
+      offset: 1,
+      limit: 1,
+    });
+
+    render(
+      <JazzProvider client={client}>
+        <UseAllProbe query={query} pick={(row) => row.title} />
+      </JazzProvider>,
+    );
+
+    client.db.insert(todos, {
+      title: "p1",
+      done: false,
+      priority: 1,
+      owner_id: undefined,
+      tags: ["x"],
+    });
+    client.db.insert(todos, {
+      title: "p2",
+      done: false,
+      priority: 2,
+      owner_id: undefined,
+      tags: ["x"],
+    });
+    client.db.insert(todos, {
+      title: "p3",
+      done: false,
+      priority: 3,
+      owner_id: undefined,
+      tags: ["x"],
+    });
+
+    await waitForCondition(() => getText("rows") === "p2", 5000, "expected p2 in paginated useAll");
+  });
+
+  it("does not include rows for non-matching text contains", async () => {
+    const client = track(
+      await createJazzClient({
+        appId: uniqueId("contains-text-miss"),
+        dbName: uniqueId("contains-text-miss"),
+      }),
+    );
+
+    render(
+      <JazzProvider client={client}>
+        <UseAllProbe
+          query={makeQuery<Todo>("todos", {
+            conditions: [{ column: "title", op: "contains", value: "needle" }],
+          })}
+          pick={(row) => row.title}
+        />
+      </JazzProvider>,
+    );
+
+    client.db.insert(todos, {
+      title: "completely unrelated",
+      done: false,
+      priority: 1,
+      owner_id: undefined,
+      tags: ["x"],
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    expect(getText("rows").includes("completely unrelated")).toBe(false);
+  });
+
+  it("supports include query execution path", async () => {
+    const client = track(
+      await createJazzClient({
+        appId: uniqueId("include"),
+        dbName: uniqueId("include"),
+      }),
+    );
+
+    const query = makeQuery<User>("users", {
+      includes: { todosViaOwner: true },
+    });
+
+    render(
+      <JazzProvider client={client}>
+        <UseAllProbe query={query} pick={(row) => row.name} />
+      </JazzProvider>,
+    );
+
+    const userId = client.db.insert(users, { name: "Owner", team_id: undefined });
+    client.db.insert(todos, {
+      title: "owned-todo",
+      done: false,
+      priority: 1,
+      owner_id: userId,
+      tags: ["x"],
+    });
+
+    await waitForCondition(
+      () => getText("rows").includes("Owner"),
+      5000,
+      "expected include useAll row",
+    );
+  });
+
+  it("supports hop queries", async () => {
+    const client = track(
+      await createJazzClient({
+        appId: uniqueId("hops"),
+        dbName: uniqueId("hops"),
+      }),
+    );
+
+    const query = makeQuery<Org>("users", {
+      hops: ["team", "org"],
+    });
+
+    render(
+      <JazzProvider client={client}>
+        <UseAllProbe query={query} pick={(row) => row.name} />
+      </JazzProvider>,
+    );
+
+    const orgId = client.db.insert(orgs, { name: "Hop Org" });
+    const teamId = client.db.insert(teams, {
+      name: "Hop Team",
+      org_id: orgId,
+      parent_id: undefined,
+    });
+    client.db.insert(users, { name: "Hop User", team_id: teamId });
+
+    await waitForCondition(
+      () => getText("rows").includes("Hop Org"),
+      5000,
+      "expected hop useAll row",
+    );
+  });
+
+  it("supports gather queries", async () => {
+    const client = track(
+      await createJazzClient({
+        appId: uniqueId("gather"),
+        dbName: uniqueId("gather"),
+      }),
+    );
+
+    const query = makeQuery<Team>("teams", {
+      conditions: [{ column: "name", op: "eq", value: "leaf" }],
+      gather: {
+        max_depth: 10,
+        step_table: "teams",
+        step_current_column: "id",
+        step_conditions: [],
+        step_hops: ["parent"],
+      },
+    });
+
+    render(
+      <JazzProvider client={client}>
+        <UseAllProbe query={query} pick={(row) => row.name} />
+      </JazzProvider>,
+    );
+
+    const rootId = client.db.insert(teams, {
+      name: "root",
+      org_id: undefined,
+      parent_id: undefined,
+    });
+    const midId = client.db.insert(teams, { name: "mid", org_id: undefined, parent_id: rootId });
+    client.db.insert(teams, { name: "leaf", org_id: undefined, parent_id: midId });
+
+    await waitForCondition(
+      () => {
+        const values = getText("rows").split("|");
+        return values.includes("root") && values.includes("mid") && values.includes("leaf");
+      },
+      5000,
+      "expected gather useAll rows",
+    );
+  });
+
+  it("reacts to query changes", async () => {
+    const client = track(
+      await createJazzClient({
+        appId: uniqueId("query-change"),
+        dbName: uniqueId("query-change"),
+      }),
+    );
+
+    client.db.insert(todos, {
+      title: "open-task",
+      done: false,
+      priority: 1,
+      owner_id: undefined,
+      tags: ["x"],
+    });
+    client.db.insert(todos, {
+      title: "done-task",
+      done: true,
+      priority: 2,
+      owner_id: undefined,
+      tags: ["x"],
+    });
+
+    function QuerySwitchProbe() {
+      const [showDone, setShowDone] = React.useState(false);
+      const query = makeQuery<Todo>("todos", {
+        conditions: [{ column: "done", op: "eq", value: showDone }],
+      });
+      const rows = useAll(query);
+      return (
+        <>
+          <button data-testid="toggle-query" onClick={() => setShowDone((value) => !value)}>
+            toggle
+          </button>
+          <div data-testid="rows">{rows ? rows.map((row) => row.title).join("|") : "pending"}</div>
+        </>
+      );
+    }
+
+    render(
+      <JazzProvider client={client}>
+        <QuerySwitchProbe />
+      </JazzProvider>,
+    );
+
+    await waitForCondition(
+      () => getText("rows").includes("open-task") && !getText("rows").includes("done-task"),
+      5000,
+      "expected initial query to show only open task",
+    );
+
+    container
+      ?.querySelector('[data-testid="toggle-query"]')
+      ?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+    await waitForCondition(
+      () => getText("rows").includes("done-task") && !getText("rows").includes("open-task"),
+      5000,
+      "expected updated query to show only done task",
+    );
+  });
+});

--- a/packages/jazz-tools/tests/browser/useAll.test.tsx
+++ b/packages/jazz-tools/tests/browser/useAll.test.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { userEvent } from "vitest/browser";
 import { createRoot, type Root } from "react-dom/client";
 import type { WasmSchema } from "../../src/drivers/types.js";
 import type { QueryBuilder, TableProxy } from "../../src/runtime/db.js";
@@ -187,6 +188,115 @@ function UseAllProbe<T extends { id: string }>({
 
 describe("useAll browser integration", () => {
   const clients: JazzClient[] = [];
+  const conditionCases: Array<{
+    name: string;
+    query: QueryBuilder<Todo>;
+    insert: Omit<Todo, "id">;
+    pick: string;
+  }> = [
+    {
+      name: "eq",
+      query: makeQuery<Todo>("todos", {
+        conditions: [{ column: "title", op: "eq", value: "eq-hit" }],
+      }),
+      insert: { title: "eq-hit", done: false, priority: 1, owner_id: undefined, tags: ["x"] },
+      pick: "eq-hit",
+    },
+    {
+      name: "ne",
+      query: makeQuery<Todo>("todos", {
+        conditions: [{ column: "title", op: "ne", value: "blocked" }],
+      }),
+      insert: { title: "ne-hit", done: false, priority: 2, owner_id: undefined, tags: ["x"] },
+      pick: "ne-hit",
+    },
+    {
+      name: "gt",
+      query: makeQuery<Todo>("todos", {
+        conditions: [{ column: "priority", op: "gt", value: 10 }],
+      }),
+      insert: { title: "gt-hit", done: false, priority: 11, owner_id: undefined, tags: ["x"] },
+      pick: "gt-hit",
+    },
+    {
+      name: "gte",
+      query: makeQuery<Todo>("todos", {
+        conditions: [{ column: "priority", op: "gte", value: 10 }],
+      }),
+      insert: { title: "gte-hit", done: false, priority: 10, owner_id: undefined, tags: ["x"] },
+      pick: "gte-hit",
+    },
+    {
+      name: "lt",
+      query: makeQuery<Todo>("todos", {
+        conditions: [{ column: "priority", op: "lt", value: 0 }],
+      }),
+      insert: { title: "lt-hit", done: false, priority: -1, owner_id: undefined, tags: ["x"] },
+      pick: "lt-hit",
+    },
+    {
+      name: "lte",
+      query: makeQuery<Todo>("todos", {
+        conditions: [{ column: "priority", op: "lte", value: 0 }],
+      }),
+      insert: { title: "lte-hit", done: false, priority: 0, owner_id: undefined, tags: ["x"] },
+      pick: "lte-hit",
+    },
+    {
+      name: "isNull",
+      query: makeQuery<Todo>("todos", { conditions: [{ column: "priority", op: "isNull" }] }),
+      insert: {
+        title: "null-hit",
+        done: false,
+        priority: undefined,
+        owner_id: undefined,
+        tags: ["x"],
+      },
+      pick: "null-hit",
+    },
+    {
+      name: "contains-array",
+      query: makeQuery<Todo>("todos", {
+        conditions: [{ column: "tags", op: "contains", value: "needle" }],
+      }),
+      insert: {
+        title: "contains-array-hit",
+        done: false,
+        priority: 1,
+        owner_id: undefined,
+        tags: ["needle", "hay"],
+      },
+      pick: "contains-array-hit",
+    },
+    {
+      name: "contains-text",
+      query: makeQuery<Todo>("todos", {
+        conditions: [{ column: "title", op: "contains", value: "needle" }],
+      }),
+      insert: {
+        title: "hay-needle-title",
+        done: false,
+        priority: 1,
+        owner_id: undefined,
+        tags: ["x"],
+      },
+      pick: "hay-needle-title",
+    },
+    {
+      name: "contains-text-empty",
+      query: makeQuery<Todo>("todos", {
+        conditions: [{ column: "title", op: "contains", value: "" }],
+      }),
+      insert: {
+        title: "any-title",
+        done: false,
+        priority: 1,
+        owner_id: undefined,
+        tags: ["x"],
+      },
+      pick: "any-title",
+    },
+  ];
 
   function track(client: JazzClient): JazzClient {
     clients.push(client);
@@ -199,125 +309,15 @@ describe("useAll browser integration", () => {
     }
   });
 
-  it("supports all condition operators", async () => {
-    const client = track(
-      await createJazzClient({
-        appId: uniqueId("operators"),
-        dbName: uniqueId("operators"),
-      }),
-    );
+  for (const testCase of conditionCases) {
+    it(`supports condition operator ${testCase.name}`, async () => {
+      const client = track(
+        await createJazzClient({
+          appId: uniqueId(`operators-${testCase.name}`),
+          dbName: uniqueId(`operators-${testCase.name}`),
+        }),
+      );
 
-    const cases: Array<{
-      name: string;
-      query: QueryBuilder<Todo>;
-      insert: Omit<Todo, "id">;
-      pick: string;
-    }> = [
-      {
-        name: "eq",
-        query: makeQuery<Todo>("todos", {
-          conditions: [{ column: "title", op: "eq", value: "eq-hit" }],
-        }),
-        insert: { title: "eq-hit", done: false, priority: 1, owner_id: undefined, tags: ["x"] },
-        pick: "eq-hit",
-      },
-      {
-        name: "ne",
-        query: makeQuery<Todo>("todos", {
-          conditions: [{ column: "title", op: "ne", value: "blocked" }],
-        }),
-        insert: { title: "ne-hit", done: false, priority: 2, owner_id: undefined, tags: ["x"] },
-        pick: "ne-hit",
-      },
-      {
-        name: "gt",
-        query: makeQuery<Todo>("todos", {
-          conditions: [{ column: "priority", op: "gt", value: 10 }],
-        }),
-        insert: { title: "gt-hit", done: false, priority: 11, owner_id: undefined, tags: ["x"] },
-        pick: "gt-hit",
-      },
-      {
-        name: "gte",
-        query: makeQuery<Todo>("todos", {
-          conditions: [{ column: "priority", op: "gte", value: 10 }],
-        }),
-        insert: { title: "gte-hit", done: false, priority: 10, owner_id: undefined, tags: ["x"] },
-        pick: "gte-hit",
-      },
-      {
-        name: "lt",
-        query: makeQuery<Todo>("todos", {
-          conditions: [{ column: "priority", op: "lt", value: 0 }],
-        }),
-        insert: { title: "lt-hit", done: false, priority: -1, owner_id: undefined, tags: ["x"] },
-        pick: "lt-hit",
-      },
-      {
-        name: "lte",
-        query: makeQuery<Todo>("todos", {
-          conditions: [{ column: "priority", op: "lte", value: 0 }],
-        }),
-        insert: { title: "lte-hit", done: false, priority: 0, owner_id: undefined, tags: ["x"] },
-        pick: "lte-hit",
-      },
-      {
-        name: "isNull",
-        query: makeQuery<Todo>("todos", { conditions: [{ column: "priority", op: "isNull" }] }),
-        insert: {
-          title: "null-hit",
-          done: false,
-          priority: undefined,
-          owner_id: undefined,
-          tags: ["x"],
-        },
-        pick: "null-hit",
-      },
-      {
-        name: "contains-array",
-        query: makeQuery<Todo>("todos", {
-          conditions: [{ column: "tags", op: "contains", value: "needle" }],
-        }),
-        insert: {
-          title: "contains-array-hit",
-          done: false,
-          priority: 1,
-          owner_id: undefined,
-          tags: ["needle", "hay"],
-        },
-        pick: "contains-array-hit",
-      },
-      {
-        name: "contains-text",
-        query: makeQuery<Todo>("todos", {
-          conditions: [{ column: "title", op: "contains", value: "needle" }],
-        }),
-        insert: {
-          title: "hay-needle-title",
-          done: false,
-          priority: 1,
-          owner_id: undefined,
-          tags: ["x"],
-        },
-        pick: "hay-needle-title",
-      },
-      {
-        name: "contains-text-empty",
-        query: makeQuery<Todo>("todos", {
-          conditions: [{ column: "title", op: "contains", value: "" }],
-        }),
-        insert: {
-          title: "any-title",
-          done: false,
-          priority: 1,
-          owner_id: undefined,
-          tags: ["x"],
-        },
-        pick: "any-title",
-      },
-    ];
-
-    for (const testCase of cases) {
       render(
         <JazzProvider client={client} key={testCase.name}>
           <UseAllProbe query={testCase.query} pick={(row) => row.title} />
@@ -331,8 +331,8 @@ describe("useAll browser integration", () => {
         5000,
         `expected useAll rows to include ${testCase.name}`,
       );
-    }
-  });
+    });
+  }
 
   it("supports orderBy + limit + offset", async () => {
     const client = track(
@@ -571,9 +571,9 @@ describe("useAll browser integration", () => {
       "expected initial query to show only open task",
     );
 
-    container
-      ?.querySelector('[data-testid="toggle-query"]')
-      ?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    const toggleQuery = container?.querySelector('[data-testid="toggle-query"]');
+    expect(toggleQuery).toBeTruthy();
+    await userEvent.click(toggleQuery as HTMLElement);
 
     await waitForCondition(
       () => getText("rows").includes("done-task") && !getText("rows").includes("open-task"),

--- a/packages/jazz-tools/tests/browser/useAllSuspense.test.tsx
+++ b/packages/jazz-tools/tests/browser/useAllSuspense.test.tsx
@@ -1,0 +1,614 @@
+import * as React from "react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createRoot, type Root } from "react-dom/client";
+import type { WasmSchema } from "../../src/drivers/types.js";
+import type { QueryBuilder, TableProxy } from "../../src/runtime/db.js";
+import { createJazzClient, type JazzClient } from "../../src/react/create-jazz-client.js";
+import { JazzProvider } from "../../src/react-core/provider.js";
+import { useAllSuspense } from "../../src/react-core/use-all.js";
+
+const schema: WasmSchema = {
+  tables: {
+    orgs: {
+      columns: [{ name: "name", column_type: { type: "Text" }, nullable: false }],
+    },
+    teams: {
+      columns: [
+        { name: "name", column_type: { type: "Text" }, nullable: false },
+        { name: "org_id", column_type: { type: "Uuid" }, nullable: true, references: "orgs" },
+        {
+          name: "parent_id",
+          column_type: { type: "Uuid" },
+          nullable: true,
+          references: "teams",
+        },
+      ],
+    },
+    users: {
+      columns: [
+        { name: "name", column_type: { type: "Text" }, nullable: false },
+        { name: "team_id", column_type: { type: "Uuid" }, nullable: true, references: "teams" },
+      ],
+    },
+    todos: {
+      columns: [
+        { name: "title", column_type: { type: "Text" }, nullable: false },
+        { name: "done", column_type: { type: "Boolean" }, nullable: false },
+        { name: "priority", column_type: { type: "Integer" }, nullable: true },
+        { name: "owner_id", column_type: { type: "Uuid" }, nullable: true, references: "users" },
+        {
+          name: "tags",
+          column_type: { type: "Array", element: { type: "Text" } },
+          nullable: false,
+        },
+      ],
+    },
+  },
+};
+
+type Org = { id: string; name: string };
+type Team = { id: string; name: string; org_id?: string; parent_id?: string };
+type User = { id: string; name: string; team_id?: string; todosViaOwner?: Todo[] };
+type Todo = {
+  id: string;
+  title: string;
+  done: boolean;
+  priority?: number;
+  owner_id?: string;
+  tags: string[];
+};
+
+const orgs: TableProxy<Org, Omit<Org, "id">> = {
+  _table: "orgs",
+  _schema: schema,
+  _rowType: {} as Org,
+  _initType: {} as Omit<Org, "id">,
+};
+
+const teams: TableProxy<Team, Omit<Team, "id">> = {
+  _table: "teams",
+  _schema: schema,
+  _rowType: {} as Team,
+  _initType: {} as Omit<Team, "id">,
+};
+
+const users: TableProxy<User, Omit<User, "id" | "todosViaOwner">> = {
+  _table: "users",
+  _schema: schema,
+  _rowType: {} as User,
+  _initType: {} as Omit<User, "id" | "todosViaOwner">,
+};
+
+const todos: TableProxy<Todo, Omit<Todo, "id">> = {
+  _table: "todos",
+  _schema: schema,
+  _rowType: {} as Todo,
+  _initType: {} as Omit<Todo, "id">,
+};
+
+function uniqueId(label: string): string {
+  return `use-all-suspense-${label}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function makeQuery<T>(
+  table: string,
+  body: {
+    conditions?: Array<{ column: string; op: string; value?: unknown }>;
+    includes?: Record<string, boolean | object>;
+    orderBy?: Array<[string, "asc" | "desc"]>;
+    limit?: number;
+    offset?: number;
+    hops?: string[];
+    gather?: {
+      max_depth: number;
+      step_table: string;
+      step_current_column: string;
+      step_conditions: Array<{ column: string; op: string; value: unknown }>;
+      step_hops: string[];
+    };
+  },
+): QueryBuilder<T> {
+  return {
+    _table: table,
+    _schema: schema,
+    _rowType: {} as T,
+    _build() {
+      return JSON.stringify({
+        table,
+        conditions: body.conditions ?? [],
+        includes: body.includes ?? {},
+        orderBy: body.orderBy ?? [],
+        limit: body.limit,
+        offset: body.offset,
+        hops: body.hops,
+        gather: body.gather,
+      });
+    },
+  };
+}
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  if (root) {
+    root.unmount();
+    root = null;
+  }
+  if (container) {
+    container.remove();
+    container = null;
+  }
+});
+
+function render(node: React.ReactNode): void {
+  if (!root) throw new Error("render called before root initialization");
+  root.render(node);
+}
+
+function renderSuspense(node: React.ReactNode): void {
+  render(
+    <React.Suspense fallback={<div data-testid="rows-fallback">pending</div>}>
+      {node}
+    </React.Suspense>,
+  );
+}
+
+function getText(testId: string): string {
+  if (!container) return "";
+  const node = container.querySelector(`[data-testid="${testId}"]`);
+  return node?.textContent ?? "";
+}
+
+function hasTestId(testId: string): boolean {
+  if (!container) return false;
+  return container.querySelector(`[data-testid="${testId}"]`) !== null;
+}
+
+async function waitForCondition(
+  check: () => boolean,
+  timeoutMs: number,
+  errorMessage: string,
+): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (check()) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error(errorMessage);
+}
+
+function UseAllProbe<T extends { id: string }>({
+  query,
+  pick,
+}: {
+  query: QueryBuilder<T>;
+  pick: (row: T) => string;
+}) {
+  const rows = useAllSuspense(query);
+  const text = rows.map(pick).join("|");
+  return <div data-testid="rows">{text}</div>;
+}
+
+describe("useAllSuspense browser integration", () => {
+  const clients: JazzClient[] = [];
+
+  function track(client: JazzClient): JazzClient {
+    clients.push(client);
+    return client;
+  }
+
+  afterEach(async () => {
+    for (const client of clients.splice(0).reverse()) {
+      await client.shutdown();
+    }
+  });
+
+  it("supports all condition operators", async () => {
+    const cases: Array<{
+      name: string;
+      query: QueryBuilder<Todo>;
+      insert: Omit<Todo, "id">;
+      pick: string;
+    }> = [
+      {
+        name: "eq",
+        query: makeQuery<Todo>("todos", {
+          conditions: [{ column: "title", op: "eq", value: "eq-hit" }],
+        }),
+        insert: { title: "eq-hit", done: false, priority: 1, owner_id: undefined, tags: ["x"] },
+        pick: "eq-hit",
+      },
+      {
+        name: "ne",
+        query: makeQuery<Todo>("todos", {
+          conditions: [{ column: "title", op: "ne", value: "blocked" }],
+        }),
+        insert: { title: "ne-hit", done: false, priority: 2, owner_id: undefined, tags: ["x"] },
+        pick: "ne-hit",
+      },
+      {
+        name: "gt",
+        query: makeQuery<Todo>("todos", {
+          conditions: [{ column: "priority", op: "gt", value: 10 }],
+        }),
+        insert: { title: "gt-hit", done: false, priority: 11, owner_id: undefined, tags: ["x"] },
+        pick: "gt-hit",
+      },
+      {
+        name: "gte",
+        query: makeQuery<Todo>("todos", {
+          conditions: [{ column: "priority", op: "gte", value: 10 }],
+        }),
+        insert: { title: "gte-hit", done: false, priority: 10, owner_id: undefined, tags: ["x"] },
+        pick: "gte-hit",
+      },
+      {
+        name: "lt",
+        query: makeQuery<Todo>("todos", {
+          conditions: [{ column: "priority", op: "lt", value: 0 }],
+        }),
+        insert: { title: "lt-hit", done: false, priority: -1, owner_id: undefined, tags: ["x"] },
+        pick: "lt-hit",
+      },
+      {
+        name: "lte",
+        query: makeQuery<Todo>("todos", {
+          conditions: [{ column: "priority", op: "lte", value: 0 }],
+        }),
+        insert: { title: "lte-hit", done: false, priority: 0, owner_id: undefined, tags: ["x"] },
+        pick: "lte-hit",
+      },
+      {
+        name: "isNull",
+        query: makeQuery<Todo>("todos", { conditions: [{ column: "priority", op: "isNull" }] }),
+        insert: {
+          title: "null-hit",
+          done: false,
+          priority: undefined,
+          owner_id: undefined,
+          tags: ["x"],
+        },
+        pick: "null-hit",
+      },
+      {
+        name: "contains-array",
+        query: makeQuery<Todo>("todos", {
+          conditions: [{ column: "tags", op: "contains", value: "needle" }],
+        }),
+        insert: {
+          title: "contains-array-hit",
+          done: false,
+          priority: 1,
+          owner_id: undefined,
+          tags: ["needle", "hay"],
+        },
+        pick: "contains-array-hit",
+      },
+      {
+        name: "contains-text",
+        query: makeQuery<Todo>("todos", {
+          conditions: [{ column: "title", op: "contains", value: "needle" }],
+        }),
+        insert: {
+          title: "hay-needle-title",
+          done: false,
+          priority: 1,
+          owner_id: undefined,
+          tags: ["x"],
+        },
+        pick: "hay-needle-title",
+      },
+      {
+        name: "contains-text-empty",
+        query: makeQuery<Todo>("todos", {
+          conditions: [{ column: "title", op: "contains", value: "" }],
+        }),
+        insert: {
+          title: "any-title",
+          done: false,
+          priority: 1,
+          owner_id: undefined,
+          tags: ["x"],
+        },
+        pick: "any-title",
+      },
+    ];
+
+    for (const testCase of cases) {
+      const client = track(
+        await createJazzClient({
+          appId: uniqueId(`operators-${testCase.name}`),
+          dbName: uniqueId(`operators-${testCase.name}`),
+        }),
+      );
+      const preloadBeforeRender =
+        testCase.name === "contains-text" || testCase.name === "contains-text-empty";
+      if (preloadBeforeRender) {
+        client.db.insert(todos, testCase.insert);
+      }
+
+      renderSuspense(
+        <JazzProvider client={client} key={testCase.name}>
+          <UseAllProbe query={testCase.query} pick={(row) => row.title} />
+        </JazzProvider>,
+      );
+
+      await waitForCondition(
+        () => hasTestId("rows"),
+        5000,
+        `expected suspense rows mount for ${testCase.name}`,
+      );
+
+      if (!preloadBeforeRender) {
+        client.db.insert(todos, testCase.insert);
+      }
+
+      await waitForCondition(
+        () => getText("rows").split("|").includes(testCase.pick),
+        5000,
+        `expected useAll rows to include ${testCase.name}`,
+      );
+    }
+  });
+
+  it("supports orderBy + limit + offset", async () => {
+    const client = track(
+      await createJazzClient({
+        appId: uniqueId("order"),
+        dbName: uniqueId("order"),
+      }),
+    );
+
+    const query = makeQuery<Todo>("todos", {
+      orderBy: [["priority", "desc"]],
+      offset: 1,
+      limit: 1,
+    });
+
+    renderSuspense(
+      <JazzProvider client={client}>
+        <UseAllProbe query={query} pick={(row) => row.title} />
+      </JazzProvider>,
+    );
+
+    client.db.insert(todos, {
+      title: "p1",
+      done: false,
+      priority: 1,
+      owner_id: undefined,
+      tags: ["x"],
+    });
+    client.db.insert(todos, {
+      title: "p2",
+      done: false,
+      priority: 2,
+      owner_id: undefined,
+      tags: ["x"],
+    });
+    client.db.insert(todos, {
+      title: "p3",
+      done: false,
+      priority: 3,
+      owner_id: undefined,
+      tags: ["x"],
+    });
+
+    await waitForCondition(
+      () => getText("rows") === "p2",
+      5000,
+      "expected p2 in paginated useAllSuspense",
+    );
+  });
+
+  it("does not include rows for non-matching text contains", async () => {
+    const client = track(
+      await createJazzClient({
+        appId: uniqueId("contains-text-miss"),
+        dbName: uniqueId("contains-text-miss"),
+      }),
+    );
+
+    renderSuspense(
+      <JazzProvider client={client}>
+        <UseAllProbe
+          query={makeQuery<Todo>("todos", {
+            conditions: [{ column: "title", op: "contains", value: "needle" }],
+          })}
+          pick={(row) => row.title}
+        />
+      </JazzProvider>,
+    );
+
+    client.db.insert(todos, {
+      title: "completely unrelated",
+      done: false,
+      priority: 1,
+      owner_id: undefined,
+      tags: ["x"],
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    expect(getText("rows").includes("completely unrelated")).toBe(false);
+  });
+
+  it("supports include query execution path", async () => {
+    const client = track(
+      await createJazzClient({
+        appId: uniqueId("include"),
+        dbName: uniqueId("include"),
+      }),
+    );
+
+    const query = makeQuery<User>("users", {
+      includes: { todosViaOwner: true },
+    });
+
+    renderSuspense(
+      <JazzProvider client={client}>
+        <UseAllProbe query={query} pick={(row) => row.name} />
+      </JazzProvider>,
+    );
+
+    const userId = client.db.insert(users, { name: "Owner", team_id: undefined });
+    client.db.insert(todos, {
+      title: "owned-todo",
+      done: false,
+      priority: 1,
+      owner_id: userId,
+      tags: ["x"],
+    });
+
+    await waitForCondition(
+      () => getText("rows").includes("Owner"),
+      5000,
+      "expected include useAllSuspense row",
+    );
+  });
+
+  it("supports hop queries", async () => {
+    const client = track(
+      await createJazzClient({
+        appId: uniqueId("hops"),
+        dbName: uniqueId("hops"),
+      }),
+    );
+
+    const query = makeQuery<Org>("users", {
+      hops: ["team", "org"],
+    });
+
+    renderSuspense(
+      <JazzProvider client={client}>
+        <UseAllProbe query={query} pick={(row) => row.name} />
+      </JazzProvider>,
+    );
+
+    const orgId = client.db.insert(orgs, { name: "Hop Org" });
+    const teamId = client.db.insert(teams, {
+      name: "Hop Team",
+      org_id: orgId,
+      parent_id: undefined,
+    });
+    client.db.insert(users, { name: "Hop User", team_id: teamId });
+
+    await waitForCondition(
+      () => getText("rows").includes("Hop Org"),
+      5000,
+      "expected hop useAllSuspense row",
+    );
+  });
+
+  it("supports gather queries", async () => {
+    const client = track(
+      await createJazzClient({
+        appId: uniqueId("gather"),
+        dbName: uniqueId("gather"),
+      }),
+    );
+
+    const query = makeQuery<Team>("teams", {
+      conditions: [{ column: "name", op: "eq", value: "leaf" }],
+      gather: {
+        max_depth: 10,
+        step_table: "teams",
+        step_current_column: "id",
+        step_conditions: [],
+        step_hops: ["parent"],
+      },
+    });
+
+    renderSuspense(
+      <JazzProvider client={client}>
+        <UseAllProbe query={query} pick={(row) => row.name} />
+      </JazzProvider>,
+    );
+
+    const rootId = client.db.insert(teams, {
+      name: "root",
+      org_id: undefined,
+      parent_id: undefined,
+    });
+    const midId = client.db.insert(teams, { name: "mid", org_id: undefined, parent_id: rootId });
+    client.db.insert(teams, { name: "leaf", org_id: undefined, parent_id: midId });
+
+    await waitForCondition(
+      () => {
+        const values = getText("rows").split("|");
+        return values.includes("root") && values.includes("mid") && values.includes("leaf");
+      },
+      5000,
+      "expected gather useAllSuspense rows",
+    );
+  });
+
+  it("reacts to query changes", async () => {
+    const client = track(
+      await createJazzClient({
+        appId: uniqueId("query-change"),
+        dbName: uniqueId("query-change"),
+      }),
+    );
+
+    client.db.insert(todos, {
+      title: "open-task",
+      done: false,
+      priority: 1,
+      owner_id: undefined,
+      tags: ["x"],
+    });
+    client.db.insert(todos, {
+      title: "done-task",
+      done: true,
+      priority: 2,
+      owner_id: undefined,
+      tags: ["x"],
+    });
+
+    function QuerySwitchProbe() {
+      const [showDone, setShowDone] = React.useState(false);
+      const query = makeQuery<Todo>("todos", {
+        conditions: [{ column: "done", op: "eq", value: showDone }],
+      });
+      const rows = useAllSuspense(query);
+      return (
+        <>
+          <button data-testid="toggle-query" onClick={() => setShowDone((value) => !value)}>
+            toggle
+          </button>
+          <div data-testid="rows">{rows.map((row) => row.title).join("|")}</div>
+        </>
+      );
+    }
+
+    renderSuspense(
+      <JazzProvider client={client}>
+        <QuerySwitchProbe />
+      </JazzProvider>,
+    );
+
+    await waitForCondition(
+      () => getText("rows").includes("open-task") && !getText("rows").includes("done-task"),
+      5000,
+      "expected initial query to show only open task",
+    );
+
+    container
+      ?.querySelector('[data-testid="toggle-query"]')
+      ?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+    await waitForCondition(
+      () => getText("rows").includes("done-task") && !getText("rows").includes("open-task"),
+      5000,
+      "expected updated query to show only done task",
+    );
+  });
+});

--- a/packages/jazz-tools/tests/browser/useAllSuspense.test.tsx
+++ b/packages/jazz-tools/tests/browser/useAllSuspense.test.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { userEvent } from "vitest/browser";
 import { createRoot, type Root } from "react-dom/client";
 import type { WasmSchema } from "../../src/drivers/types.js";
@@ -201,6 +201,7 @@ function UseAllProbe<T extends { id: string }>({
 
 describe("useAllSuspense browser integration", () => {
   const clients: JazzClient[] = [];
+  let conditionsClient: JazzClient;
   const conditionCases: Array<{
     name: string;
     query: QueryBuilder<Todo>;
@@ -316,6 +317,17 @@ describe("useAllSuspense browser integration", () => {
     return client;
   }
 
+  beforeAll(async () => {
+    conditionsClient = await createJazzClient({
+      appId: uniqueId("operators"),
+      dbName: uniqueId("operators"),
+    });
+  });
+
+  afterAll(async () => {
+    await conditionsClient.shutdown();
+  });
+
   afterEach(async () => {
     for (const client of clients.splice(0).reverse()) {
       await client.shutdown();
@@ -324,20 +336,14 @@ describe("useAllSuspense browser integration", () => {
 
   for (const testCase of conditionCases) {
     it(`supports condition operator ${testCase.name}`, async () => {
-      const client = track(
-        await createJazzClient({
-          appId: uniqueId(`operators-${testCase.name}`),
-          dbName: uniqueId(`operators-${testCase.name}`),
-        }),
-      );
       const preloadBeforeRender =
         testCase.name === "contains-text" || testCase.name === "contains-text-empty";
       if (preloadBeforeRender) {
-        client.db.insert(todos, testCase.insert);
+        conditionsClient.db.insert(todos, testCase.insert);
       }
 
       renderSuspense(
-        <JazzProvider client={client} key={testCase.name}>
+        <JazzProvider client={conditionsClient} key={testCase.name}>
           <UseAllProbe query={testCase.query} pick={(row) => row.title} />
         </JazzProvider>,
       );
@@ -349,7 +355,7 @@ describe("useAllSuspense browser integration", () => {
       );
 
       if (!preloadBeforeRender) {
-        client.db.insert(todos, testCase.insert);
+        conditionsClient.db.insert(todos, testCase.insert);
       }
 
       await waitForCondition(

--- a/packages/jazz-tools/tests/browser/useAllSuspense.test.tsx
+++ b/packages/jazz-tools/tests/browser/useAllSuspense.test.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { userEvent } from "vitest/browser";
 import { createRoot, type Root } from "react-dom/client";
 import type { WasmSchema } from "../../src/drivers/types.js";
 import type { QueryBuilder, TableProxy } from "../../src/runtime/db.js";
@@ -200,6 +201,115 @@ function UseAllProbe<T extends { id: string }>({
 
 describe("useAllSuspense browser integration", () => {
   const clients: JazzClient[] = [];
+  const conditionCases: Array<{
+    name: string;
+    query: QueryBuilder<Todo>;
+    insert: Omit<Todo, "id">;
+    pick: string;
+  }> = [
+    {
+      name: "eq",
+      query: makeQuery<Todo>("todos", {
+        conditions: [{ column: "title", op: "eq", value: "eq-hit" }],
+      }),
+      insert: { title: "eq-hit", done: false, priority: 1, owner_id: undefined, tags: ["x"] },
+      pick: "eq-hit",
+    },
+    {
+      name: "ne",
+      query: makeQuery<Todo>("todos", {
+        conditions: [{ column: "title", op: "ne", value: "blocked" }],
+      }),
+      insert: { title: "ne-hit", done: false, priority: 2, owner_id: undefined, tags: ["x"] },
+      pick: "ne-hit",
+    },
+    {
+      name: "gt",
+      query: makeQuery<Todo>("todos", {
+        conditions: [{ column: "priority", op: "gt", value: 10 }],
+      }),
+      insert: { title: "gt-hit", done: false, priority: 11, owner_id: undefined, tags: ["x"] },
+      pick: "gt-hit",
+    },
+    {
+      name: "gte",
+      query: makeQuery<Todo>("todos", {
+        conditions: [{ column: "priority", op: "gte", value: 10 }],
+      }),
+      insert: { title: "gte-hit", done: false, priority: 10, owner_id: undefined, tags: ["x"] },
+      pick: "gte-hit",
+    },
+    {
+      name: "lt",
+      query: makeQuery<Todo>("todos", {
+        conditions: [{ column: "priority", op: "lt", value: 0 }],
+      }),
+      insert: { title: "lt-hit", done: false, priority: -1, owner_id: undefined, tags: ["x"] },
+      pick: "lt-hit",
+    },
+    {
+      name: "lte",
+      query: makeQuery<Todo>("todos", {
+        conditions: [{ column: "priority", op: "lte", value: 0 }],
+      }),
+      insert: { title: "lte-hit", done: false, priority: 0, owner_id: undefined, tags: ["x"] },
+      pick: "lte-hit",
+    },
+    {
+      name: "isNull",
+      query: makeQuery<Todo>("todos", { conditions: [{ column: "priority", op: "isNull" }] }),
+      insert: {
+        title: "null-hit",
+        done: false,
+        priority: undefined,
+        owner_id: undefined,
+        tags: ["x"],
+      },
+      pick: "null-hit",
+    },
+    {
+      name: "contains-array",
+      query: makeQuery<Todo>("todos", {
+        conditions: [{ column: "tags", op: "contains", value: "needle" }],
+      }),
+      insert: {
+        title: "contains-array-hit",
+        done: false,
+        priority: 1,
+        owner_id: undefined,
+        tags: ["needle", "hay"],
+      },
+      pick: "contains-array-hit",
+    },
+    {
+      name: "contains-text",
+      query: makeQuery<Todo>("todos", {
+        conditions: [{ column: "title", op: "contains", value: "needle" }],
+      }),
+      insert: {
+        title: "hay-needle-title",
+        done: false,
+        priority: 1,
+        owner_id: undefined,
+        tags: ["x"],
+      },
+      pick: "hay-needle-title",
+    },
+    {
+      name: "contains-text-empty",
+      query: makeQuery<Todo>("todos", {
+        conditions: [{ column: "title", op: "contains", value: "" }],
+      }),
+      insert: {
+        title: "any-title",
+        done: false,
+        priority: 1,
+        owner_id: undefined,
+        tags: ["x"],
+      },
+      pick: "any-title",
+    },
+  ];
 
   function track(client: JazzClient): JazzClient {
     clients.push(client);
@@ -212,118 +322,8 @@ describe("useAllSuspense browser integration", () => {
     }
   });
 
-  it("supports all condition operators", async () => {
-    const cases: Array<{
-      name: string;
-      query: QueryBuilder<Todo>;
-      insert: Omit<Todo, "id">;
-      pick: string;
-    }> = [
-      {
-        name: "eq",
-        query: makeQuery<Todo>("todos", {
-          conditions: [{ column: "title", op: "eq", value: "eq-hit" }],
-        }),
-        insert: { title: "eq-hit", done: false, priority: 1, owner_id: undefined, tags: ["x"] },
-        pick: "eq-hit",
-      },
-      {
-        name: "ne",
-        query: makeQuery<Todo>("todos", {
-          conditions: [{ column: "title", op: "ne", value: "blocked" }],
-        }),
-        insert: { title: "ne-hit", done: false, priority: 2, owner_id: undefined, tags: ["x"] },
-        pick: "ne-hit",
-      },
-      {
-        name: "gt",
-        query: makeQuery<Todo>("todos", {
-          conditions: [{ column: "priority", op: "gt", value: 10 }],
-        }),
-        insert: { title: "gt-hit", done: false, priority: 11, owner_id: undefined, tags: ["x"] },
-        pick: "gt-hit",
-      },
-      {
-        name: "gte",
-        query: makeQuery<Todo>("todos", {
-          conditions: [{ column: "priority", op: "gte", value: 10 }],
-        }),
-        insert: { title: "gte-hit", done: false, priority: 10, owner_id: undefined, tags: ["x"] },
-        pick: "gte-hit",
-      },
-      {
-        name: "lt",
-        query: makeQuery<Todo>("todos", {
-          conditions: [{ column: "priority", op: "lt", value: 0 }],
-        }),
-        insert: { title: "lt-hit", done: false, priority: -1, owner_id: undefined, tags: ["x"] },
-        pick: "lt-hit",
-      },
-      {
-        name: "lte",
-        query: makeQuery<Todo>("todos", {
-          conditions: [{ column: "priority", op: "lte", value: 0 }],
-        }),
-        insert: { title: "lte-hit", done: false, priority: 0, owner_id: undefined, tags: ["x"] },
-        pick: "lte-hit",
-      },
-      {
-        name: "isNull",
-        query: makeQuery<Todo>("todos", { conditions: [{ column: "priority", op: "isNull" }] }),
-        insert: {
-          title: "null-hit",
-          done: false,
-          priority: undefined,
-          owner_id: undefined,
-          tags: ["x"],
-        },
-        pick: "null-hit",
-      },
-      {
-        name: "contains-array",
-        query: makeQuery<Todo>("todos", {
-          conditions: [{ column: "tags", op: "contains", value: "needle" }],
-        }),
-        insert: {
-          title: "contains-array-hit",
-          done: false,
-          priority: 1,
-          owner_id: undefined,
-          tags: ["needle", "hay"],
-        },
-        pick: "contains-array-hit",
-      },
-      {
-        name: "contains-text",
-        query: makeQuery<Todo>("todos", {
-          conditions: [{ column: "title", op: "contains", value: "needle" }],
-        }),
-        insert: {
-          title: "hay-needle-title",
-          done: false,
-          priority: 1,
-          owner_id: undefined,
-          tags: ["x"],
-        },
-        pick: "hay-needle-title",
-      },
-      {
-        name: "contains-text-empty",
-        query: makeQuery<Todo>("todos", {
-          conditions: [{ column: "title", op: "contains", value: "" }],
-        }),
-        insert: {
-          title: "any-title",
-          done: false,
-          priority: 1,
-          owner_id: undefined,
-          tags: ["x"],
-        },
-        pick: "any-title",
-      },
-    ];
-
-    for (const testCase of cases) {
+  for (const testCase of conditionCases) {
+    it(`supports condition operator ${testCase.name}`, async () => {
       const client = track(
         await createJazzClient({
           appId: uniqueId(`operators-${testCase.name}`),
@@ -357,8 +357,8 @@ describe("useAllSuspense browser integration", () => {
         5000,
         `expected useAll rows to include ${testCase.name}`,
       );
-    }
-  });
+    });
+  }
 
   it("supports orderBy + limit + offset", async () => {
     const client = track(
@@ -601,9 +601,9 @@ describe("useAllSuspense browser integration", () => {
       "expected initial query to show only open task",
     );
 
-    container
-      ?.querySelector('[data-testid="toggle-query"]')
-      ?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    const toggleQuery = container?.querySelector('[data-testid="toggle-query"]');
+    expect(toggleQuery).toBeTruthy();
+    await userEvent.click(toggleQuery as HTMLElement);
 
     await waitForCondition(
       () => getText("rows").includes("done-task") && !getText("rows").includes("open-task"),


### PR DESCRIPTION
- Updated Predicate::Contains to support substring matching for text columns.
- Added tests for filtering todos by title substring and handling empty substring matches.
- Improved the overall filtering logic in FilterNode to accommodate new text matching functionality.