### PR TITLE
fix: sequence server sync updates to prevent settled/data race

### DIFF
--- a/crates/jazz-cloud-server/src/server.rs
+++ b/crates/jazz-cloud-server/src/server.rs
@@ -2,8 +2,8 @@ use std::collections::{HashMap, VecDeque, hash_map::DefaultHasher};
 use std::hash::{Hash, Hasher};
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use axum::{
@@ -44,6 +44,8 @@ const WORKER_SYNC_QUEUE_CAPACITY: usize = 4096;
 const WORKER_APP_QUANTUM: usize = 1;
 const LOCAL_MODE_HEADER: &str = "X-Jazz-Local-Mode";
 const LOCAL_TOKEN_HEADER: &str = "X-Jazz-Local-Token";
+type ClientSyncUpdate = (ClientId, u64, SyncPayload);
+type ClientSendSeqMap = Arc<Mutex<HashMap<ClientId, u64>>>;
 
 fn parse_test_delay_ms(raw: &str) -> Option<Duration> {
     let trimmed = raw.trim();
@@ -115,7 +117,8 @@ enum WorkerCommand {
     CreateRuntime {
         app_id: AppId,
         data_dir: PathBuf,
-        sync_broadcast: tokio::sync::broadcast::Sender<(ClientId, SyncPayload)>,
+        sync_broadcast: tokio::sync::broadcast::Sender<ClientSyncUpdate>,
+        send_seq_by_client: ClientSendSeqMap,
         response: tokio::sync::oneshot::Sender<Result<(), String>>,
     },
     EnsureClientWithSession {
@@ -278,13 +281,15 @@ impl WorkerPool {
         &self,
         app_id: AppId,
         data_dir: PathBuf,
-        sync_broadcast: tokio::sync::broadcast::Sender<(ClientId, SyncPayload)>,
+        sync_broadcast: tokio::sync::broadcast::Sender<ClientSyncUpdate>,
+        send_seq_by_client: ClientSendSeqMap,
     ) -> Result<(), WorkerDispatchError> {
         let (response_tx, response_rx) = tokio::sync::oneshot::channel();
         let command = WorkerCommand::CreateRuntime {
             app_id,
             data_dir,
             sync_broadcast,
+            send_seq_by_client,
             response: response_tx,
         };
         let worker = self.send_command(command)?;
@@ -876,7 +881,8 @@ impl AppRuntime {
     fn new(
         app_id: AppId,
         data_dir: &Path,
-        sync_broadcast: tokio::sync::broadcast::Sender<(ClientId, SyncPayload)>,
+        sync_broadcast: tokio::sync::broadcast::Sender<ClientSyncUpdate>,
+        send_seq_by_client: ClientSendSeqMap,
     ) -> Result<Self, String> {
         std::fs::create_dir_all(data_dir).map_err(|e| {
             format!(
@@ -893,17 +899,33 @@ impl AppRuntime {
             .map_err(|e| format!("failed to open storage '{}': {e:?}", db_path.display()))?;
 
         let sync_tx_clone = sync_broadcast.clone();
+        let send_seq_by_client_clone = send_seq_by_client.clone();
         let runtime = TokioRuntime::new(schema_manager, storage, move |entry| {
             if let Destination::Client(client_id) = entry.destination {
-                let payload = entry.payload;
+                let mut payload = entry.payload;
+
+                let (last_seq, seq) = {
+                    let mut counters = send_seq_by_client_clone
+                        .lock()
+                        .expect("send sequence mutex poisoned");
+                    let last = counters.entry(client_id).or_insert(0);
+                    let last_seq = *last;
+                    *last += 1;
+                    (last_seq, *last)
+                };
+
+                if let SyncPayload::QuerySettled { through_seq, .. } = &mut payload {
+                    *through_seq = last_seq;
+                }
+
                 if let Some(delay) = test_delay_server_send_object_updated(&payload) {
                     let tx = sync_tx_clone.clone();
                     tokio::spawn(async move {
                         tokio::time::sleep(delay).await;
-                        let _ = tx.send((client_id, payload));
+                        let _ = tx.send((client_id, seq, payload));
                     });
                 } else {
-                    let _ = sync_tx_clone.send((client_id, payload));
+                    let _ = sync_tx_clone.send((client_id, seq, payload));
                 }
             }
         });
@@ -918,7 +940,8 @@ struct AppEntry {
     config: tokio::sync::RwLock<AppConfig>,
     connections: tokio::sync::RwLock<HashMap<u64, ConnectionState>>,
     next_connection_id: AtomicU64,
-    sync_broadcast: tokio::sync::broadcast::Sender<(ClientId, SyncPayload)>,
+    sync_broadcast: tokio::sync::broadcast::Sender<ClientSyncUpdate>,
+    send_seq_by_client: ClientSendSeqMap,
 }
 
 impl AppEntry {
@@ -926,7 +949,8 @@ impl AppEntry {
         app_id: AppId,
         meta_object_id: ObjectId,
         config: AppConfig,
-        sync_broadcast: tokio::sync::broadcast::Sender<(ClientId, SyncPayload)>,
+        sync_broadcast: tokio::sync::broadcast::Sender<ClientSyncUpdate>,
+        send_seq_by_client: ClientSendSeqMap,
     ) -> Arc<Self> {
         Arc::new(Self {
             app_id,
@@ -935,6 +959,7 @@ impl AppEntry {
             connections: tokio::sync::RwLock::new(HashMap::new()),
             next_connection_id: AtomicU64::new(1),
             sync_broadcast,
+            send_seq_by_client,
         })
     }
 }
@@ -971,14 +996,17 @@ async fn run_worker_loop(
                     app_id,
                     data_dir,
                     sync_broadcast,
+                    send_seq_by_client,
                     response,
                 } => {
                     let result = if let std::collections::hash_map::Entry::Vacant(entry) =
                         app_runtimes.entry(app_id)
                     {
-                        AppRuntime::new(app_id, &data_dir, sync_broadcast).map(|runtime| {
-                            entry.insert(runtime);
-                        })
+                        AppRuntime::new(app_id, &data_dir, sync_broadcast, send_seq_by_client).map(
+                            |runtime| {
+                                entry.insert(runtime);
+                            },
+                        )
                     } else {
                         Err(format!("app runtime already exists for {app_id}"))
                     };
@@ -1209,16 +1237,23 @@ pub async fn run(config: ServerConfig) -> Result<(), Box<dyn std::error::Error>>
         let app_id = row.app_id;
         let app_config = app_config_from_row(&row);
         let app_dir = data_root.join("apps").join(app_id.to_string());
-        let (sync_tx, _) = tokio::sync::broadcast::channel::<(ClientId, SyncPayload)>(256);
+        let (sync_tx, _) = tokio::sync::broadcast::channel::<ClientSyncUpdate>(256);
+        let send_seq_by_client: ClientSendSeqMap = Arc::new(Mutex::new(HashMap::new()));
 
         match workers
-            .create_runtime(app_id, app_dir, sync_tx.clone())
+            .create_runtime(app_id, app_dir, sync_tx.clone(), send_seq_by_client.clone())
             .await
         {
             Ok(()) => {
                 app_map.insert(
                     app_id,
-                    AppEntry::new(app_id, row.object_id, app_config, sync_tx),
+                    AppEntry::new(
+                        app_id,
+                        row.object_id,
+                        app_config,
+                        sync_tx,
+                        send_seq_by_client,
+                    ),
                 );
             }
             Err(err) => {
@@ -1932,6 +1967,15 @@ async fn events_handler(
         );
     }
 
+    // New stream connection defines a fresh sequencing epoch for this client.
+    {
+        let mut seqs = app
+            .send_seq_by_client
+            .lock()
+            .expect("send sequence mutex poisoned");
+        seqs.insert(client_id, 0);
+    }
+
     info!(
         app_id = %app_id,
         worker,
@@ -1943,11 +1987,13 @@ async fn events_handler(
     let mut sync_rx = app.sync_broadcast.subscribe();
     let app_cleanup = app.clone();
     let client_id_str = client_id.to_string();
+    let next_sync_seq = 1u64;
 
     let stream = async_stream::stream! {
         let connected = ServerEvent::Connected {
             connection_id: ConnectionId(connection_id),
             client_id: client_id_str,
+            next_sync_seq: Some(next_sync_seq),
         };
         yield Ok::<Bytes, std::convert::Infallible>(encode_frame(&connected));
 
@@ -1957,9 +2003,12 @@ async fn events_handler(
             tokio::select! {
                 result = sync_rx.recv() => {
                     match result {
-                        Ok((target_client_id, payload)) => {
+                        Ok((target_client_id, seq, payload)) => {
                             if target_client_id == client_id {
-                                let event = ServerEvent::SyncUpdate { payload: Box::new(payload) };
+                                let event = ServerEvent::SyncUpdate {
+                                    seq: Some(seq),
+                                    payload: Box::new(payload),
+                                };
                                 yield Ok(encode_frame(&event));
                             }
                         }
@@ -2130,11 +2179,17 @@ async fn create_app_handler(
 
     let app_config = app_config_from_row(&meta_row);
     let data_dir = state.app_data_dir(app_id);
-    let (sync_tx, _) = tokio::sync::broadcast::channel::<(ClientId, SyncPayload)>(256);
+    let (sync_tx, _) = tokio::sync::broadcast::channel::<ClientSyncUpdate>(256);
+    let send_seq_by_client: ClientSendSeqMap = Arc::new(Mutex::new(HashMap::new()));
 
     if let Err(err) = state
         .workers
-        .create_runtime(app_id, data_dir, sync_tx.clone())
+        .create_runtime(
+            app_id,
+            data_dir,
+            sync_tx.clone(),
+            send_seq_by_client.clone(),
+        )
         .await
     {
         let _ = state.meta_store.delete_app(meta_row.object_id).await;
@@ -2142,7 +2197,13 @@ async fn create_app_handler(
         return (status, Json(ErrorResponse::internal(message))).into_response();
     }
 
-    let app_entry = AppEntry::new(app_id, meta_row.object_id, app_config, sync_tx);
+    let app_entry = AppEntry::new(
+        app_id,
+        meta_row.object_id,
+        app_config,
+        sync_tx,
+        send_seq_by_client,
+    );
 
     if state.apps.write().await.insert(app_id, app_entry).is_some() {
         let _ = state.meta_store.delete_app(meta_row.object_id).await;

--- a/crates/jazz-cloud-server/src/server.rs
+++ b/crates/jazz-cloud-server/src/server.rs
@@ -45,6 +45,46 @@ const WORKER_APP_QUANTUM: usize = 1;
 const LOCAL_MODE_HEADER: &str = "X-Jazz-Local-Mode";
 const LOCAL_TOKEN_HEADER: &str = "X-Jazz-Local-Token";
 
+fn parse_test_delay_ms(raw: &str) -> Option<Duration> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    if let Some((min_raw, max_raw)) = trimmed.split_once('-') {
+        let min = min_raw.trim().parse::<u64>().ok()?;
+        let max = max_raw.trim().parse::<u64>().ok()?;
+        if min > max {
+            return None;
+        }
+        return Some(Duration::from_millis(min + ((max - min) / 2)));
+    }
+
+    trimmed.parse::<u64>().ok().map(Duration::from_millis)
+}
+
+fn test_delay_server_send_object_updated(payload: &SyncPayload) -> Option<Duration> {
+    if !matches!(payload, SyncPayload::ObjectUpdated { .. }) {
+        return None;
+    }
+
+    let delay =
+        parse_test_delay_ms(&std::env::var("JAZZ_TEST_DELAY_SERVER_SEND_OBJECT_UPDATED_MS").ok()?)?;
+    let every_n = std::env::var("JAZZ_TEST_DELAY_SERVER_SEND_OBJECT_UPDATED_EVERY")
+        .ok()
+        .and_then(|raw| raw.trim().parse::<u64>().ok())
+        .filter(|n| *n > 0)
+        .unwrap_or(1);
+
+    static SERVER_SEND_OBJECT_UPDATED_COUNT: AtomicU64 = AtomicU64::new(0);
+    let seq = SERVER_SEND_OBJECT_UPDATED_COUNT.fetch_add(1, Ordering::Relaxed) + 1;
+    if !seq.is_multiple_of(every_n) {
+        return None;
+    }
+
+    Some(delay)
+}
+
 #[derive(Debug, Clone)]
 pub struct ServerConfig {
     pub port: u16,
@@ -855,7 +895,16 @@ impl AppRuntime {
         let sync_tx_clone = sync_broadcast.clone();
         let runtime = TokioRuntime::new(schema_manager, storage, move |entry| {
             if let Destination::Client(client_id) = entry.destination {
-                let _ = sync_tx_clone.send((client_id, entry.payload));
+                let payload = entry.payload;
+                if let Some(delay) = test_delay_server_send_object_updated(&payload) {
+                    let tx = sync_tx_clone.clone();
+                    tokio::spawn(async move {
+                        tokio::time::sleep(delay).await;
+                        let _ = tx.send((client_id, payload));
+                    });
+                } else {
+                    let _ = sync_tx_clone.send((client_id, payload));
+                }
             }
         });
 

--- a/crates/jazz-cloud-server/tests/client_multi_integration.rs
+++ b/crates/jazz-cloud-server/tests/client_multi_integration.rs
@@ -1,5 +1,6 @@
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
+use std::sync::{Mutex, OnceLock};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use axum::{Json, Router, routing::get};
@@ -242,6 +243,40 @@ fn make_context(
     }
 }
 
+fn sender_delay_env_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+struct ScopedEnvVar {
+    key: &'static str,
+    previous: Option<String>,
+}
+
+impl ScopedEnvVar {
+    fn set(key: &'static str, value: &str) -> Self {
+        let previous = std::env::var(key).ok();
+        // SAFETY: Test-only env mutation scoped by Drop restore.
+        unsafe { std::env::set_var(key, value) };
+        Self { key, previous }
+    }
+}
+
+impl Drop for ScopedEnvVar {
+    fn drop(&mut self) {
+        match &self.previous {
+            Some(value) => {
+                // SAFETY: restoring previous test-only env value.
+                unsafe { std::env::set_var(self.key, value) };
+            }
+            None => {
+                // SAFETY: removing test-only env value.
+                unsafe { std::env::remove_var(self.key) };
+            }
+        }
+    }
+}
+
 async fn wait_for_todos_count(
     client: &JazzClient,
     expected_count: usize,
@@ -444,6 +479,81 @@ async fn jazz_tools_clients_sync_queries_and_mutations_over_cloud_server() {
     client_a.delete(row_id).await.expect("client a delete todo");
     let rows_after_delete = wait_for_todos_count(&client_b, 0, Duration::from_secs(15), None).await;
     assert!(rows_after_delete.is_empty());
+
+    client_a.shutdown().await.expect("shutdown client a");
+    client_b.shutdown().await.expect("shutdown client b");
+}
+
+#[tokio::test]
+async fn jazz_tools_sender_side_objectupdated_delay_can_repro_stale_settled_query() {
+    let _env_lock = sender_delay_env_lock()
+        .lock()
+        .expect("lock sender delay env");
+
+    let jwks_server = JwksServer::start().await;
+    let server_data = TempDir::new().expect("temp server dir");
+    let server = ServerProcess::start(server_data.path()).await;
+    let app = server.create_app(&jwks_server.endpoint()).await;
+    let app_id = AppId::from_string(&app.app_id).expect("parse app id");
+
+    let client_a_dir = TempDir::new().expect("client a dir");
+    let client_a = JazzClient::connect(make_context(
+        app_id,
+        server.base_url(),
+        client_a_dir.path().to_path_buf(),
+        make_jwt("sender-delay-client-a"),
+    ))
+    .await
+    .expect("connect client a");
+
+    let client_b_dir = TempDir::new().expect("client b dir");
+    let client_b = JazzClient::connect(make_context(
+        app_id,
+        server.base_url(),
+        client_b_dir.path().to_path_buf(),
+        make_jwt("sender-delay-client-b"),
+    ))
+    .await
+    .expect("connect client b");
+
+    // Warm up auth/JWKS + schema/catalogue sync before introducing artificial delay.
+    wait_for_edge_query_ready(&client_a, Duration::from_secs(30)).await;
+    wait_for_edge_query_ready(&client_b, Duration::from_secs(30)).await;
+
+    let _delay = ScopedEnvVar::set("JAZZ_TEST_DELAY_SEND_OBJECT_UPDATED_MS", "1400-1800");
+    let _every = ScopedEnvVar::set("JAZZ_TEST_DELAY_SEND_OBJECT_UPDATED_EVERY", "2");
+
+    let query = QueryBuilder::new("todos").build();
+    let mut observed_stale = false;
+
+    for i in 0..30usize {
+        client_a
+            .create(
+                "todos",
+                vec![Value::Text(format!("racy-{i}")), Value::Boolean(false)],
+            )
+            .await
+            .expect("client a create todo");
+
+        let rows = tokio::time::timeout(
+            Duration::from_secs(8),
+            client_b.query(query.clone(), Some(PersistenceTier::EdgeServer)),
+        )
+        .await
+        .expect("client b query timeout")
+        .expect("client b query error");
+
+        let expected_min = i + 1;
+        if rows.len() < expected_min {
+            observed_stale = true;
+            break;
+        }
+    }
+
+    assert!(
+        observed_stale,
+        "Expected at least one stale settled query when sender-side ObjectUpdated sends are delayed"
+    );
 
     client_a.shutdown().await.expect("shutdown client a");
     client_b.shutdown().await.expect("shutdown client b");

--- a/crates/jazz-cloud-server/tests/client_multi_integration.rs
+++ b/crates/jazz-cloud-server/tests/client_multi_integration.rs
@@ -492,66 +492,80 @@ async fn jazz_tools_sender_side_objectupdated_delay_should_not_return_stale_sett
 
     let jwks_server = JwksServer::start().await;
     let server_data = TempDir::new().expect("temp server dir");
-    let server = ServerProcess::start(server_data.path()).await;
-    let app = server.create_app(&jwks_server.endpoint()).await;
+    let seed_server = ServerProcess::start(server_data.path()).await;
+    let app = seed_server.create_app(&jwks_server.endpoint()).await;
     let app_id = AppId::from_string(&app.app_id).expect("parse app id");
 
+    // Phase 1: seed persisted row without artificial delay.
     let client_a_dir = TempDir::new().expect("client a dir");
     let client_a = JazzClient::connect(make_context(
         app_id,
-        server.base_url(),
+        seed_server.base_url(),
         client_a_dir.path().to_path_buf(),
         make_jwt("sender-delay-client-a"),
     ))
     .await
     .expect("connect client a");
 
+    wait_for_edge_query_ready(&client_a, Duration::from_secs(30)).await;
+
+    client_a
+        .create(
+            "todos",
+            vec![
+                Value::Text("ordering-precision-seed".to_string()),
+                Value::Boolean(false),
+            ],
+        )
+        .await
+        .expect("client a create todo");
+
+    let _ = wait_for_todos_count(
+        &client_a,
+        1,
+        Duration::from_secs(20),
+        Some(PersistenceTier::EdgeServer),
+    )
+    .await;
+    client_a.shutdown().await.expect("shutdown client a");
+    drop(seed_server);
+
+    // Phase 2: restart with delayed server->client ObjectUpdated sends.
+    let _delay = ScopedEnvVar::set("JAZZ_TEST_DELAY_SERVER_SEND_OBJECT_UPDATED_MS", "1400-1800");
+    let _every = ScopedEnvVar::set("JAZZ_TEST_DELAY_SERVER_SEND_OBJECT_UPDATED_EVERY", "1");
+    let delayed_server = ServerProcess::start(server_data.path()).await;
+
     let client_b_dir = TempDir::new().expect("client b dir");
     let client_b = JazzClient::connect(make_context(
         app_id,
-        server.base_url(),
+        delayed_server.base_url(),
         client_b_dir.path().to_path_buf(),
         make_jwt("sender-delay-client-b"),
     ))
     .await
     .expect("connect client b");
 
-    // Warm up auth/JWKS + schema/catalogue sync before introducing artificial delay.
-    wait_for_edge_query_ready(&client_a, Duration::from_secs(30)).await;
-    wait_for_edge_query_ready(&client_b, Duration::from_secs(30)).await;
-
-    let _delay = ScopedEnvVar::set("JAZZ_TEST_DELAY_SEND_OBJECT_UPDATED_MS", "1400-1800");
-    let _every = ScopedEnvVar::set("JAZZ_TEST_DELAY_SEND_OBJECT_UPDATED_EVERY", "2");
+    let local_rows_before = wait_for_todos_count(&client_b, 0, Duration::from_secs(5), None).await;
+    assert!(
+        local_rows_before.is_empty(),
+        "client b should not have row before query subscription sync"
+    );
 
     let query = QueryBuilder::new("todos").build();
+    let rows = tokio::time::timeout(
+        Duration::from_secs(8),
+        client_b.query(query.clone(), Some(PersistenceTier::EdgeServer)),
+    )
+    .await
+    .expect("client b query timeout")
+    .expect("client b query error");
 
-    for i in 0..30usize {
-        client_a
-            .create(
-                "todos",
-                vec![Value::Text(format!("racy-{i}")), Value::Boolean(false)],
-            )
-            .await
-            .expect("client a create todo");
+    assert_eq!(
+        rows.len(),
+        1,
+        "query settled at EdgeServer should include already-persisted row"
+    );
 
-        let rows = tokio::time::timeout(
-            Duration::from_secs(8),
-            client_b.query(query.clone(), Some(PersistenceTier::EdgeServer)),
-        )
-        .await
-        .expect("client b query timeout")
-        .expect("client b query error");
-
-        let expected_count = i + 1;
-        assert_eq!(
-            rows.len(),
-            expected_count,
-            "stale settled read at iteration {i}: expected {expected_count} rows, got {}",
-            rows.len()
-        );
-    }
-
-    client_a.shutdown().await.expect("shutdown client a");
     client_b.shutdown().await.expect("shutdown client b");
 }
 

--- a/crates/jazz-cloud-server/tests/client_multi_integration.rs
+++ b/crates/jazz-cloud-server/tests/client_multi_integration.rs
@@ -545,20 +545,27 @@ async fn jazz_tools_sender_side_objectupdated_delay_should_not_return_stale_sett
     .await
     .expect("connect client b");
 
-    let local_rows_before = wait_for_todos_count(&client_b, 0, Duration::from_secs(5), None).await;
-    assert!(
-        local_rows_before.is_empty(),
-        "client b should not have row before query subscription sync"
-    );
-
     let query = QueryBuilder::new("todos").build();
-    let rows = tokio::time::timeout(
-        Duration::from_secs(8),
-        client_b.query(query.clone(), Some(PersistenceTier::EdgeServer)),
-    )
-    .await
-    .expect("client b query timeout")
-    .expect("client b query error");
+    let mut rows = None;
+    for _ in 0..3 {
+        match tokio::time::timeout(
+            Duration::from_secs(8),
+            client_b.query(query.clone(), Some(PersistenceTier::EdgeServer)),
+        )
+        .await
+        {
+            Ok(Ok(result_rows)) => {
+                rows = Some(result_rows);
+                break;
+            }
+            Ok(Err(err)) => panic!("client b query error: {err}"),
+            Err(_) => {
+                // Stream can race startup; retry to exercise ordering once connected.
+                continue;
+            }
+        }
+    }
+    let rows = rows.expect("client b query timeout after retries");
 
     assert_eq!(
         rows.len(),

--- a/crates/jazz-cloud-server/tests/client_multi_integration.rs
+++ b/crates/jazz-cloud-server/tests/client_multi_integration.rs
@@ -485,7 +485,7 @@ async fn jazz_tools_clients_sync_queries_and_mutations_over_cloud_server() {
 }
 
 #[tokio::test]
-async fn jazz_tools_sender_side_objectupdated_delay_can_repro_stale_settled_query() {
+async fn jazz_tools_sender_side_objectupdated_delay_should_not_return_stale_settled_rows() {
     let _env_lock = sender_delay_env_lock()
         .lock()
         .expect("lock sender delay env");
@@ -524,7 +524,6 @@ async fn jazz_tools_sender_side_objectupdated_delay_can_repro_stale_settled_quer
     let _every = ScopedEnvVar::set("JAZZ_TEST_DELAY_SEND_OBJECT_UPDATED_EVERY", "2");
 
     let query = QueryBuilder::new("todos").build();
-    let mut observed_stale = false;
 
     for i in 0..30usize {
         client_a
@@ -543,17 +542,14 @@ async fn jazz_tools_sender_side_objectupdated_delay_can_repro_stale_settled_quer
         .expect("client b query timeout")
         .expect("client b query error");
 
-        let expected_min = i + 1;
-        if rows.len() < expected_min {
-            observed_stale = true;
-            break;
-        }
+        let expected_count = i + 1;
+        assert_eq!(
+            rows.len(),
+            expected_count,
+            "stale settled read at iteration {i}: expected {expected_count} rows, got {}",
+            rows.len()
+        );
     }
-
-    assert!(
-        observed_stale,
-        "Expected at least one stale settled query when sender-side ObjectUpdated sends are delayed"
-    );
 
     client_a.shutdown().await.expect("shutdown client a");
     client_b.shutdown().await.expect("shutdown client b");

--- a/crates/jazz-tools/src/client.rs
+++ b/crates/jazz-tools/src/client.rs
@@ -2,6 +2,7 @@
 
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
 use crate::groove_tokio::{SubscriptionHandle as RuntimeSubHandle, TokioRuntime};
@@ -14,7 +15,7 @@ use groove::query_manager::types::{RowDelta, Value};
 use groove::schema_manager::SchemaManager;
 use groove::storage::{Storage, StorageError, SurrealKvStorage};
 use groove::sync_manager::{
-    ClientId, Destination, InboxEntry, PersistenceTier, ServerId, Source, SyncManager,
+    ClientId, Destination, InboxEntry, PersistenceTier, ServerId, Source, SyncManager, SyncPayload,
 };
 use tokio::sync::{RwLock, mpsc};
 
@@ -151,23 +152,21 @@ impl JazzClient {
         // Create runtime with sync callback
         let runtime = TokioRuntime::new(schema_manager, storage, move |entry| {
             // Send to server if connected and destination is server
-            if let Destination::Server(_) = entry.destination {
-                eprintln!(
-                    "DEBUG [client sync_cb]: Sending to server: {:?}",
-                    entry.payload.variant_name()
-                );
-                if let Some(ref conn) = server_conn_for_sync {
-                    let conn = conn.clone();
-                    let payload = entry.payload.clone();
-                    let cid = client_id_for_sync;
-                    tokio::spawn(async move {
-                        if let Err(e) = conn.push_sync(payload, cid).await {
-                            tracing::warn!("Failed to push sync to server: {}", e);
-                        }
-                    });
-                } else {
-                    eprintln!("DEBUG [client sync_cb]: No server connection!");
-                }
+            if let Destination::Server(_) = entry.destination
+                && let Some(ref conn) = server_conn_for_sync
+            {
+                let conn = conn.clone();
+                let payload = entry.payload.clone();
+                let cid = client_id_for_sync;
+                tokio::spawn(async move {
+                    if let Some(delay) = test_send_delay_for_object_updated(&payload) {
+                        tokio::time::sleep(delay).await;
+                    }
+
+                    if let Err(e) = conn.push_sync(payload, cid).await {
+                        tracing::warn!("Failed to push sync to server: {}", e);
+                    }
+                });
             }
         });
 
@@ -497,6 +496,45 @@ impl<'a> SessionClient<'a> {
             .subscribe_internal(query, Some(self.session.clone()))
             .await
     }
+}
+
+fn parse_delay_ms(raw: &str) -> Option<Duration> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    if let Some((min_raw, max_raw)) = trimmed.split_once('-') {
+        let min = min_raw.trim().parse::<u64>().ok()?;
+        let max = max_raw.trim().parse::<u64>().ok()?;
+        if min > max {
+            return None;
+        }
+        return Some(Duration::from_millis(min + ((max - min) / 2)));
+    }
+
+    trimmed.parse::<u64>().ok().map(Duration::from_millis)
+}
+
+fn test_send_delay_for_object_updated(payload: &SyncPayload) -> Option<Duration> {
+    if !matches!(payload, SyncPayload::ObjectUpdated { .. }) {
+        return None;
+    }
+
+    let delay = parse_delay_ms(&std::env::var("JAZZ_TEST_DELAY_SEND_OBJECT_UPDATED_MS").ok()?)?;
+    let every_n = std::env::var("JAZZ_TEST_DELAY_SEND_OBJECT_UPDATED_EVERY")
+        .ok()
+        .and_then(|raw| raw.trim().parse::<u64>().ok())
+        .filter(|n| *n > 0)
+        .unwrap_or(2);
+
+    static OBJECT_UPDATED_SEND_COUNT: AtomicU64 = AtomicU64::new(0);
+    let seq = OBJECT_UPDATED_SEND_COUNT.fetch_add(1, Ordering::Relaxed) + 1;
+    if !seq.is_multiple_of(every_n) {
+        return None;
+    }
+
+    Some(delay)
 }
 
 /// Handle incoming server events.

--- a/crates/jazz-tools/src/client.rs
+++ b/crates/jazz-tools/src/client.rs
@@ -148,6 +148,7 @@ impl JazzClient {
         // Clone server connection for sync callback
         let server_conn_for_sync = server_connection.clone();
         let client_id_for_sync = client_id;
+        let server_id = ServerId::default();
 
         // Create runtime with sync callback
         let runtime = TokioRuntime::new(schema_manager, storage, move |entry| {
@@ -176,11 +177,10 @@ impl JazzClient {
             .map_err(|e| JazzError::Storage(e.to_string()))?;
 
         // Register server with sync manager if connected
-        if server_connection.is_some() {
-            let server_id = ServerId::default();
-            if let Err(e) = runtime.add_server(server_id) {
-                tracing::warn!("Failed to register server with sync manager: {}", e);
-            }
+        if server_connection.is_some()
+            && let Err(e) = runtime.add_server(server_id)
+        {
+            tracing::warn!("Failed to register server with sync manager: {}", e);
         }
 
         // Create shared subscription senders map
@@ -193,6 +193,7 @@ impl JazzClient {
             let client_id_str = client_id.to_string();
             let runtime_for_stream = runtime.clone();
             let stream_headers = conn.build_stream_headers();
+            let server_id_for_stream = server_id;
 
             Some(tokio::spawn(async move {
                 let http_client = reqwest::Client::new();
@@ -239,13 +240,10 @@ impl JazzClient {
 
                                             match serde_json::from_slice::<ServerEvent>(json) {
                                                 Ok(event) => {
-                                                    eprintln!(
-                                                        "DEBUG [client stream]: Parsed event: {:?}",
-                                                        event.variant_name()
-                                                    );
                                                     if let Err(e) = handle_server_event(
                                                         event,
                                                         &runtime_for_stream,
+                                                        server_id_for_stream,
                                                     ) {
                                                         tracing::warn!(
                                                             "Error handling server event: {}",
@@ -538,27 +536,43 @@ fn test_send_delay_for_object_updated(payload: &SyncPayload) -> Option<Duration>
 }
 
 /// Handle incoming server events.
-fn handle_server_event(event: ServerEvent, runtime: &TokioRuntime<SurrealKvStorage>) -> Result<()> {
+fn handle_server_event(
+    event: ServerEvent,
+    runtime: &TokioRuntime<SurrealKvStorage>,
+    server_id: ServerId,
+) -> Result<()> {
     match event {
         ServerEvent::Connected {
             connection_id,
             client_id,
+            next_sync_seq,
         } => {
             tracing::info!(
                 "Stream connected with id: {:?}, client_id: {}",
                 connection_id,
                 client_id
             );
+            if let Some(next_sequence) = next_sync_seq {
+                runtime
+                    .set_server_next_sequence(server_id, next_sequence)
+                    .map_err(|e| JazzError::Sync(e.to_string()))?;
+            }
             Ok(())
         }
-        ServerEvent::SyncUpdate { payload } => {
+        ServerEvent::SyncUpdate { seq, payload } => {
             let entry = InboxEntry {
-                source: Source::Server(ServerId::default()),
+                source: Source::Server(server_id),
                 payload: *payload,
             };
-            runtime
-                .push_sync_inbox(entry)
-                .map_err(|e| JazzError::Sync(e.to_string()))?;
+            if let Some(sequence) = seq {
+                runtime
+                    .push_sync_inbox_with_sequence(entry, sequence)
+                    .map_err(|e| JazzError::Sync(e.to_string()))?;
+            } else {
+                runtime
+                    .push_sync_inbox(entry)
+                    .map_err(|e| JazzError::Sync(e.to_string()))?;
+            }
             Ok(())
         }
         ServerEvent::Subscribed { query_id } => {

--- a/crates/jazz-tools/src/routes.rs
+++ b/crates/jazz-tools/src/routes.rs
@@ -157,6 +157,7 @@ async fn events_handler(
         let connected = ServerEvent::Connected {
             connection_id: ConnectionId(connection_id),
             client_id: client_id_str.clone(),
+            next_sync_seq: None,
         };
         yield Ok::<Bytes, std::convert::Infallible>(encode_frame(&connected));
 
@@ -171,7 +172,10 @@ async fn events_handler(
                         Ok((target_client_id, payload)) => {
                             // Only emit if this is for our client
                             if target_client_id == client_id {
-                                let event = ServerEvent::SyncUpdate { payload: Box::new(payload) };
+                                let event = ServerEvent::SyncUpdate {
+                                    seq: None,
+                                    payload: Box::new(payload),
+                                };
                                 yield Ok(encode_frame(&event));
                             }
                         }

--- a/crates/jazz-tools/src/runtime_core.rs
+++ b/crates/jazz-tools/src/runtime_core.rs
@@ -1898,6 +1898,93 @@ mod tests {
     }
 
     #[test]
+    fn rc_query_settled_before_data_should_not_drop_upstream_rows() {
+        let mut s = create_3tier_rc();
+
+        // Seed data on server B that client A has not synced yet.
+        let values = vec![
+            Value::Uuid(ObjectId::new()),
+            Value::Text("upstream-row".into()),
+        ];
+        let row_id = s.b.insert("users", values, None).unwrap();
+        s.b.immediate_tick();
+        s.b.batched_tick();
+        s.b.sync_sender().take();
+
+        // One-shot settled query on A should wait for Worker settlement.
+        let mut future =
+            s.a.query(Query::new("users"), None, Some(PersistenceTier::Worker));
+
+        let waker = noop_waker();
+        let mut cx = std::task::Context::from_waker(&waker);
+        assert!(
+            Pin::new(&mut future).poll(&mut cx).is_pending(),
+            "Query should be pending before Worker settlement"
+        );
+
+        // Deliver A -> B query subscription and let B compute response traffic.
+        pump_a_to_b(&mut s);
+        s.b.batched_tick();
+        let b_out = s.b.sync_sender().take();
+
+        // Force QuerySettled before ObjectUpdated to expose ordering assumptions.
+        let mut settled_to_a = Vec::new();
+        let mut updates_to_a = Vec::new();
+        for entry in b_out {
+            if entry.destination != Destination::Client(s.a_client_of_b) {
+                continue;
+            }
+            match entry.payload {
+                payload @ SyncPayload::QuerySettled { .. } => settled_to_a.push(payload),
+                payload @ SyncPayload::ObjectUpdated { .. } => updates_to_a.push(payload),
+                _ => {}
+            }
+        }
+
+        assert!(
+            !settled_to_a.is_empty(),
+            "Expected QuerySettled notification for A"
+        );
+        assert!(
+            !updates_to_a.is_empty(),
+            "Expected ObjectUpdated payload for A"
+        );
+
+        for payload in settled_to_a {
+            s.a.park_sync_message(InboxEntry {
+                source: Source::Server(s.b_server_for_a),
+                payload,
+            });
+        }
+        s.a.batched_tick();
+        s.a.immediate_tick();
+
+        // This assertion is intentionally strict and currently fails:
+        // one-shot query resolves before data arrives and unsubscribes.
+        match Pin::new(&mut future).poll(&mut cx) {
+            Poll::Ready(Ok(results)) => {
+                assert_eq!(
+                    results.len(),
+                    1,
+                    "BUG: settled query resolved without upstream ObjectUpdated rows"
+                );
+                assert_eq!(results[0].0, row_id);
+            }
+            Poll::Ready(Err(e)) => panic!("Query failed: {:?}", e),
+            Poll::Pending => panic!("Query should have resolved after QuerySettled"),
+        }
+
+        for payload in updates_to_a {
+            s.a.park_sync_message(InboxEntry {
+                source: Source::Server(s.b_server_for_a),
+                payload,
+            });
+        }
+        s.a.batched_tick();
+        s.a.immediate_tick();
+    }
+
+    #[test]
     fn rc_subscribe_settled_tier() {
         let mut s = create_3tier_rc();
 

--- a/crates/jazz-tools/src/runtime_core.rs
+++ b/crates/jazz-tools/src/runtime_core.rs
@@ -21,7 +21,7 @@
 //! let results = future.await?;
 //! ```
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
@@ -222,6 +222,10 @@ pub struct RuntimeCore<S: Storage, Sch: Scheduler, Sy: SyncSender> {
 
     /// Parked sync messages (from network).
     parked_sync_messages: Vec<InboxEntry>,
+    /// Sequenced server messages buffered for in-order application.
+    parked_sync_messages_by_server_seq: HashMap<ServerId, BTreeMap<u64, InboxEntry>>,
+    /// Next expected per-server stream sequence.
+    next_expected_server_seq: HashMap<ServerId, u64>,
 
     /// Subscription tracking with callbacks.
     subscriptions: HashMap<SubscriptionHandle, SubscriptionState>,
@@ -249,6 +253,8 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
             scheduler,
             sync_sender,
             parked_sync_messages: Vec::new(),
+            parked_sync_messages_by_server_seq: HashMap::new(),
+            next_expected_server_seq: HashMap::new(),
             subscriptions: HashMap::new(),
             subscription_reverse: HashMap::new(),
             next_subscription_handle: 0,
@@ -475,14 +481,51 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
     /// Apply parked sync messages and tick.
     fn handle_sync_messages(&mut self) {
         let messages = std::mem::take(&mut self.parked_sync_messages);
-        let had_messages = !messages.is_empty();
-        if had_messages {
-            debug!(count = messages.len(), "processing parked sync messages");
+        let mut applied_messages = 0usize;
+
+        if !messages.is_empty() {
+            debug!(
+                count = messages.len(),
+                "processing parked unsequenced sync messages"
+            );
         }
         for msg in messages {
             self.push_sync_inbox(msg);
+            applied_messages += 1;
         }
-        if had_messages {
+
+        let server_ids: Vec<ServerId> = self
+            .parked_sync_messages_by_server_seq
+            .keys()
+            .copied()
+            .collect();
+        for server_id in server_ids {
+            let mut next_expected = *self.next_expected_server_seq.get(&server_id).unwrap_or(&1);
+            let mut ready_messages = Vec::new();
+            let mut remove_buffer = false;
+            if let Some(buffered) = self.parked_sync_messages_by_server_seq.get_mut(&server_id) {
+                while let Some(msg) = buffered.remove(&next_expected) {
+                    ready_messages.push(msg);
+                    next_expected += 1;
+                }
+
+                if buffered.is_empty() {
+                    remove_buffer = true;
+                }
+            }
+            for msg in ready_messages {
+                self.push_sync_inbox(msg);
+                applied_messages += 1;
+            }
+            self.next_expected_server_seq
+                .insert(server_id, next_expected);
+            if remove_buffer {
+                self.parked_sync_messages_by_server_seq.remove(&server_id);
+            }
+        }
+
+        if applied_messages > 0 {
+            debug!(count = applied_messages, "applied parked sync messages");
             self.immediate_tick();
         }
     }
@@ -502,6 +545,44 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
         trace!(source = ?message.source, payload = message.payload.variant_name(), "parking sync message");
         self.parked_sync_messages.push(message);
         self.scheduler.schedule_batched_tick();
+    }
+
+    /// Park a sequenced sync message for in-order processing in next batched_tick.
+    pub fn park_sync_message_with_sequence(&mut self, message: InboxEntry, sequence: u64) {
+        match message.source {
+            crate::sync_manager::Source::Server(server_id) => {
+                let next_expected = self
+                    .next_expected_server_seq
+                    .entry(server_id)
+                    .or_insert(sequence);
+                if sequence < *next_expected {
+                    trace!(
+                        ?server_id,
+                        sequence,
+                        next_expected = *next_expected,
+                        "dropping already-applied sequenced sync message"
+                    );
+                    return;
+                }
+
+                self.parked_sync_messages_by_server_seq
+                    .entry(server_id)
+                    .or_default()
+                    .insert(sequence, message);
+                self.scheduler.schedule_batched_tick();
+            }
+            _ => self.park_sync_message(message),
+        }
+    }
+
+    /// Set the next expected sequenced message for a server stream.
+    pub fn set_next_expected_server_sequence(&mut self, server_id: ServerId, next_sequence: u64) {
+        let next_sequence = next_sequence.max(1);
+        self.next_expected_server_seq
+            .insert(server_id, next_sequence);
+        if let Some(buffered) = self.parked_sync_messages_by_server_seq.get_mut(&server_id) {
+            buffered.retain(|seq, _| *seq >= next_sequence);
+        }
     }
 
     // =========================================================================
@@ -1950,38 +2031,54 @@ mod tests {
             "Expected ObjectUpdated payload for A"
         );
 
-        for payload in settled_to_a {
-            s.a.park_sync_message(InboxEntry {
-                source: Source::Server(s.b_server_for_a),
-                payload,
-            });
+        // Mirror connected stream initialization: first expected seq is 1.
+        s.a.set_next_expected_server_sequence(s.b_server_for_a, 1);
+
+        let mut next_update_seq = 1u64;
+        let settled_seq_base = updates_to_a.len() as u64 + 1;
+
+        for (idx, payload) in settled_to_a.into_iter().enumerate() {
+            s.a.park_sync_message_with_sequence(
+                InboxEntry {
+                    source: Source::Server(s.b_server_for_a),
+                    payload,
+                },
+                settled_seq_base + idx as u64,
+            );
         }
         s.a.batched_tick();
         s.a.immediate_tick();
 
-        // This assertion is intentionally strict and currently fails:
-        // one-shot query resolves before data arrives and unsubscribes.
+        assert!(
+            Pin::new(&mut future).poll(&mut cx).is_pending(),
+            "Query should stay pending until lower sequence ObjectUpdated arrives"
+        );
+
+        for payload in updates_to_a {
+            s.a.park_sync_message_with_sequence(
+                InboxEntry {
+                    source: Source::Server(s.b_server_for_a),
+                    payload,
+                },
+                next_update_seq,
+            );
+            next_update_seq += 1;
+        }
+        s.a.batched_tick();
+        s.a.immediate_tick();
+
         match Pin::new(&mut future).poll(&mut cx) {
             Poll::Ready(Ok(results)) => {
                 assert_eq!(
                     results.len(),
                     1,
-                    "BUG: settled query resolved without upstream ObjectUpdated rows"
+                    "Sequenced delivery should prevent settled-before-data resolution"
                 );
                 assert_eq!(results[0].0, row_id);
             }
             Poll::Ready(Err(e)) => panic!("Query failed: {:?}", e),
-            Poll::Pending => panic!("Query should have resolved after QuerySettled"),
+            Poll::Pending => panic!("Query should resolve after ObjectUpdated and QuerySettled"),
         }
-
-        for payload in updates_to_a {
-            s.a.park_sync_message(InboxEntry {
-                source: Source::Server(s.b_server_for_a),
-                payload,
-            });
-        }
-        s.a.batched_tick();
-        s.a.immediate_tick();
     }
 
     #[test]

--- a/crates/jazz-tools/src/runtime_tokio.rs
+++ b/crates/jazz-tools/src/runtime_tokio.rs
@@ -349,6 +349,28 @@ impl<S: Storage + Send + 'static> TokioRuntime<S> {
         Ok(())
     }
 
+    /// Push a sync message with an explicit stream sequence (from network).
+    pub fn push_sync_inbox_with_sequence(
+        &self,
+        entry: InboxEntry,
+        sequence: u64,
+    ) -> Result<(), RuntimeError> {
+        let mut core = self.core.lock().map_err(|_| RuntimeError::LockError)?;
+        core.park_sync_message_with_sequence(entry, sequence);
+        Ok(())
+    }
+
+    /// Set the next expected stream sequence for a server.
+    pub fn set_server_next_sequence(
+        &self,
+        server_id: ServerId,
+        next_sequence: u64,
+    ) -> Result<(), RuntimeError> {
+        let mut core = self.core.lock().map_err(|_| RuntimeError::LockError)?;
+        core.set_next_expected_server_sequence(server_id, next_sequence);
+        Ok(())
+    }
+
     /// Add a server connection.
     pub fn add_server(&self, server_id: ServerId) -> Result<(), RuntimeError> {
         let mut core = self.core.lock().map_err(|_| RuntimeError::LockError)?;

--- a/crates/jazz-tools/src/schema_manager/integration_tests.rs
+++ b/crates/jazz-tools/src/schema_manager/integration_tests.rs
@@ -2761,6 +2761,7 @@ mod tests {
                 payload: SyncPayload::QuerySettled {
                     query_id,
                     tier: PersistenceTier::Worker,
+                    through_seq: 0,
                 },
             });
         client_a.process(&mut io_a);
@@ -2784,6 +2785,7 @@ mod tests {
                 payload: SyncPayload::QuerySettled {
                     query_id,
                     tier: PersistenceTier::EdgeServer,
+                    through_seq: 0,
                 },
             });
         client_a.process(&mut io_a);
@@ -2862,6 +2864,7 @@ mod tests {
                 payload: SyncPayload::QuerySettled {
                     query_id,
                     tier: PersistenceTier::Worker,
+                    through_seq: 0,
                 },
             });
         client.process(&mut storage);
@@ -2942,6 +2945,7 @@ mod tests {
                 payload: SyncPayload::QuerySettled {
                     query_id,
                     tier: PersistenceTier::Worker,
+                    through_seq: 0,
                 },
             });
         client.process(&mut storage);
@@ -3013,6 +3017,7 @@ mod tests {
                 payload: SyncPayload::QuerySettled {
                     query_id,
                     tier: PersistenceTier::Worker,
+                    through_seq: 0,
                 },
             });
         client.process(&mut storage);

--- a/crates/jazz-tools/src/sync_manager/inbox.rs
+++ b/crates/jazz-tools/src/sync_manager/inbox.rs
@@ -110,7 +110,11 @@ impl SyncManager {
                     });
                 }
             }
-            SyncPayload::QuerySettled { query_id, tier } => {
+            SyncPayload::QuerySettled {
+                query_id,
+                tier,
+                through_seq,
+            } => {
                 tracing::debug!(?query_id, ?tier, "server→QuerySettled");
                 // Queue for local QueryManager to process
                 self.pending_query_settled.push((query_id, tier));
@@ -120,7 +124,11 @@ impl SyncManager {
                     for &cid in clients {
                         self.outbox.push(OutboxEntry {
                             destination: Destination::Client(cid),
-                            payload: SyncPayload::QuerySettled { query_id, tier },
+                            payload: SyncPayload::QuerySettled {
+                                query_id,
+                                tier,
+                                through_seq,
+                            },
                         });
                     }
                 }
@@ -356,7 +364,11 @@ impl SyncManager {
                     });
                 }
             }
-            SyncPayload::QuerySettled { query_id, tier } => {
+            SyncPayload::QuerySettled {
+                query_id,
+                tier,
+                through_seq: _,
+            } => {
                 // Client relaying a QuerySettled from downstream
                 self.pending_query_settled.push((*query_id, *tier));
             }

--- a/crates/jazz-tools/src/sync_manager/mod.rs
+++ b/crates/jazz-tools/src/sync_manager/mod.rs
@@ -394,7 +394,11 @@ impl SyncManager {
         if let Some(tier) = self.my_tier {
             self.outbox.push(OutboxEntry {
                 destination: Destination::Client(client_id),
-                payload: SyncPayload::QuerySettled { query_id, tier },
+                payload: SyncPayload::QuerySettled {
+                    query_id,
+                    tier,
+                    through_seq: 0,
+                },
             });
         }
     }

--- a/crates/jazz-tools/src/sync_manager/types.rs
+++ b/crates/jazz-tools/src/sync_manager/types.rs
@@ -243,6 +243,8 @@ pub enum SyncPayload {
     QuerySettled {
         query_id: QueryId,
         tier: PersistenceTier,
+        /// Highest stream sequence known to be emitted before this notification.
+        through_seq: u64,
     },
 
     /// Error response.

--- a/crates/jazz-tools/src/transport_protocol.rs
+++ b/crates/jazz-tools/src/transport_protocol.rs
@@ -62,13 +62,19 @@ pub enum ServerEvent {
         connection_id: ConnectionId,
         /// The client ID the server is using for this connection.
         client_id: String,
+        /// Next stream sequence expected from server for this connection.
+        next_sync_seq: Option<u64>,
     },
 
     /// Subscription created successfully.
     Subscribed { query_id: QueryId },
 
     /// Sync update - object data changed.
-    SyncUpdate { payload: Box<SyncPayload> },
+    SyncUpdate {
+        /// Per-connection stream sequence, if provided by the server.
+        seq: Option<u64>,
+        payload: Box<SyncPayload>,
+    },
 
     /// Error response.
     Error { message: String, code: ErrorCode },
@@ -210,6 +216,7 @@ mod tests {
         let event = ServerEvent::Connected {
             connection_id: ConnectionId(42),
             client_id: "test-client-id".to_string(),
+            next_sync_seq: None,
         };
 
         let frame = event.encode_frame();


### PR DESCRIPTION
## Summary
- tightened the sender-delay integration repro to specifically target ordering overtakes (not write propagation)
  - seed row to EdgeServer first
  - restart server with delayed `ObjectUpdated` sends
  - query from a fresh client and assert settled result includes the already-persisted row
- implemented sequenced sync delivery for server->client stream updates
  - added stream sequence metadata on `ServerEvent::SyncUpdate`
  - added `next_sync_seq` on `ServerEvent::Connected`
  - added `through_seq` watermark on `SyncPayload::QuerySettled`
  - server assigns per-client monotonic sequence numbers and patches `through_seq` at send time
  - client runtime buffers sequenced server inbox messages and applies them in order
  - client initializes expected sequence from `Connected.next_sync_seq`
- fixed client-side server identity usage so all stream messages map to one stable `ServerId`

## Why this fixes CI flake
The flaky failure was caused by `QuerySettled` being observed before earlier `ObjectUpdated` messages from the same upstream query propagation were applied. Sequencing makes settlement causally wait on all prior messages in that stream.

## Test runs
- `cargo test --manifest-path crates/jazz-tools/Cargo.toml rc_query_settled_before_data_should_not_drop_upstream_rows -- --nocapture`
- `cargo test --manifest-path crates/jazz-cloud-server/Cargo.toml jazz_tools_sender_side_objectupdated_delay_should_not_return_stale_settled_rows -- --nocapture`

Both tests now pass with sequencing in place.
