### PR TITLE
feat: implement enum column type end-to-end

### DIFF
--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -120,6 +120,8 @@ struct JsColumnType {
     #[serde(skip_serializing_if = "Option::is_none")]
     element: Option<Box<JsColumnType>>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    variants: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     columns: Option<Vec<JsColumnDescriptor>>,
 }
 
@@ -241,6 +243,10 @@ fn js_column_type_to_groove(ct: JsColumnType) -> jazz_tools::query_manager::type
         "BigInt" => ColumnType::BigInt,
         "Boolean" => ColumnType::Boolean,
         "Text" => ColumnType::Text,
+        "Enum" => {
+            let variants = ct.variants.expect("Enum type requires variants");
+            ColumnType::Enum(variants)
+        }
         "Timestamp" => ColumnType::Timestamp,
         "Uuid" => ColumnType::Uuid,
         "Array" => {
@@ -412,41 +418,55 @@ fn groove_schema_to_js(schema: &Schema) -> JsSchema {
             ColumnType::Integer => JsColumnType {
                 type_name: "Integer".into(),
                 element: None,
+                variants: None,
                 columns: None,
             },
             ColumnType::BigInt => JsColumnType {
                 type_name: "BigInt".into(),
                 element: None,
+                variants: None,
                 columns: None,
             },
             ColumnType::Boolean => JsColumnType {
                 type_name: "Boolean".into(),
                 element: None,
+                variants: None,
                 columns: None,
             },
             ColumnType::Text => JsColumnType {
                 type_name: "Text".into(),
                 element: None,
+                variants: None,
+                columns: None,
+            },
+            ColumnType::Enum(variants) => JsColumnType {
+                type_name: "Enum".into(),
+                element: None,
+                variants: Some(variants.clone()),
                 columns: None,
             },
             ColumnType::Timestamp => JsColumnType {
                 type_name: "Timestamp".into(),
                 element: None,
+                variants: None,
                 columns: None,
             },
             ColumnType::Uuid => JsColumnType {
                 type_name: "Uuid".into(),
                 element: None,
+                variants: None,
                 columns: None,
             },
             ColumnType::Array(elem) => JsColumnType {
                 type_name: "Array".into(),
                 element: Some(Box::new(ct_to_js(elem))),
+                variants: None,
                 columns: None,
             },
             ColumnType::Row(desc) => JsColumnType {
                 type_name: "Row".into(),
                 element: None,
+                variants: None,
                 columns: Some(
                     desc.columns
                         .iter()

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -1367,3 +1367,65 @@ pub fn parse_schema_fn(env: Env, json: String) -> napi::Result<napi::JsUnknown> 
     let _groove_schema = js_schema_to_groove(js_schema.clone());
     env.to_js_value(&js_schema)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use jazz_tools::query_manager::types::{ColumnType, SchemaBuilder, TableName, TableSchema};
+    use std::collections::HashMap;
+
+    #[test]
+    fn js_schema_to_groove_parses_enum_column_type() {
+        let js_schema = JsSchema {
+            tables: HashMap::from([(
+                "todos".to_string(),
+                JsTableSchema {
+                    columns: vec![JsColumnDescriptor {
+                        name: "status".to_string(),
+                        column_type: JsColumnType {
+                            type_name: "Enum".to_string(),
+                            element: None,
+                            variants: Some(vec!["done".to_string(), "todo".to_string()]),
+                            columns: None,
+                        },
+                        nullable: false,
+                        references: None,
+                    }],
+                    policies: None,
+                },
+            )]),
+        };
+
+        let schema = js_schema_to_groove(js_schema);
+        let status = schema
+            .get(&TableName::new("todos"))
+            .unwrap()
+            .descriptor
+            .column("status")
+            .unwrap();
+        assert_eq!(
+            status.column_type,
+            ColumnType::Enum(vec!["done".to_string(), "todo".to_string()])
+        );
+    }
+
+    #[test]
+    fn groove_schema_to_js_emits_enum_column_type() {
+        let schema = SchemaBuilder::new()
+            .table(TableSchema::builder("todos").column(
+                "status",
+                ColumnType::Enum(vec!["done".to_string(), "todo".to_string()]),
+            ))
+            .build();
+
+        let js_schema = groove_schema_to_js(&schema);
+        let status = &js_schema.tables["todos"].columns[0];
+        assert_eq!(status.column_type.type_name, "Enum");
+        assert_eq!(
+            status.column_type.variants,
+            Some(vec!["done".to_string(), "todo".to_string()])
+        );
+        assert!(status.column_type.element.is_none());
+        assert!(status.column_type.columns.is_none());
+    }
+}

--- a/crates/jazz-tools/src/query_manager/encoding.rs
+++ b/crates/jazz-tools/src/query_manager/encoding.rs
@@ -86,7 +86,7 @@ pub fn encode_row(descriptor: &RowDescriptor, values: &[Value]) -> Result<Vec<u8
 
     for (i, (col, val)) in descriptor.columns.iter().zip(values.iter()).enumerate() {
         // Validate type match
-        if !val.is_null() && val.column_type().is_some_and(|t| t != col.column_type) {
+        if !val.is_null() && !value_matches_column_type(val, &col.column_type) {
             return Err(EncodingError::TypeMismatch {
                 column: col.name.to_string(),
                 expected: col.column_type.clone(),
@@ -126,6 +126,40 @@ pub fn encode_row(descriptor: &RowDescriptor, values: &[Value]) -> Result<Vec<u8
     result.extend(var_data);
 
     Ok(result)
+}
+
+fn value_matches_column_type(value: &Value, column_type: &ColumnType) -> bool {
+    match column_type {
+        ColumnType::Integer => matches!(value, Value::Integer(_)),
+        ColumnType::BigInt => matches!(value, Value::BigInt(_)),
+        ColumnType::Boolean => matches!(value, Value::Boolean(_)),
+        ColumnType::Timestamp => matches!(value, Value::Timestamp(_)),
+        ColumnType::Uuid => matches!(value, Value::Uuid(_)),
+        ColumnType::Text => matches!(value, Value::Text(_)),
+        ColumnType::Enum(variants) => match value {
+            Value::Text(s) => variants.contains(s),
+            _ => false,
+        },
+        ColumnType::Array(element_type) => match value {
+            Value::Array(elements) => elements.iter().all(|element| {
+                !element.is_null() && value_matches_column_type(element, element_type)
+            }),
+            _ => false,
+        },
+        ColumnType::Row(row_descriptor) => match value {
+            Value::Row(values) if values.len() == row_descriptor.columns.len() => values
+                .iter()
+                .zip(row_descriptor.columns.iter())
+                .all(|(inner_value, inner_column)| {
+                    if inner_value.is_null() {
+                        inner_column.nullable
+                    } else {
+                        value_matches_column_type(inner_value, &inner_column.column_type)
+                    }
+                }),
+            _ => false,
+        },
+    }
 }
 
 /// Encode a fixed-size value to the buffer.
@@ -271,6 +305,17 @@ pub fn decode_column(
             let s = std::str::from_utf8(bytes).map_err(|e| EncodingError::MalformedData {
                 message: format!("invalid utf8: {e}"),
             })?;
+            Ok(Value::Text(s.to_string()))
+        }
+        ColumnType::Enum(variants) => {
+            let s = std::str::from_utf8(bytes).map_err(|e| EncodingError::MalformedData {
+                message: format!("invalid utf8: {e}"),
+            })?;
+            if !variants.iter().any(|variant| variant == s) {
+                return Err(EncodingError::MalformedData {
+                    message: format!("invalid enum variant: {s}"),
+                });
+            }
             Ok(Value::Text(s.to_string()))
         }
         ColumnType::Array(element_type) => {
@@ -487,7 +532,7 @@ pub fn compare_column(
             // Compare as bytes (UUIDs have natural byte ordering)
             Ok(bytes1.cmp(bytes2))
         }
-        ColumnType::Text | ColumnType::Array(_) | ColumnType::Row(_) => {
+        ColumnType::Text | ColumnType::Enum(_) | ColumnType::Array(_) | ColumnType::Row(_) => {
             // Lexicographic comparison of bytes
             Ok(bytes1.cmp(bytes2))
         }
@@ -531,9 +576,11 @@ pub fn compare_column_to_value(
             let t2 = u64::from_le_bytes(value[..8].try_into().unwrap());
             Ok(t1.cmp(&t2))
         }
-        ColumnType::Uuid | ColumnType::Text | ColumnType::Array(_) | ColumnType::Row(_) => {
-            Ok(bytes.cmp(value))
-        }
+        ColumnType::Uuid
+        | ColumnType::Text
+        | ColumnType::Enum(_)
+        | ColumnType::Array(_)
+        | ColumnType::Row(_) => Ok(bytes.cmp(value)),
     }
 }
 
@@ -815,6 +862,17 @@ fn decode_array_element(data: &[u8], element_type: &ColumnType) -> Result<Value,
             let s = std::str::from_utf8(data).map_err(|e| EncodingError::MalformedData {
                 message: format!("invalid utf8: {e}"),
             })?;
+            Ok(Value::Text(s.to_string()))
+        }
+        ColumnType::Enum(variants) => {
+            let s = std::str::from_utf8(data).map_err(|e| EncodingError::MalformedData {
+                message: format!("invalid utf8: {e}"),
+            })?;
+            if !variants.iter().any(|variant| variant == s) {
+                return Err(EncodingError::MalformedData {
+                    message: format!("invalid enum variant: {s}"),
+                });
+            }
             Ok(Value::Text(s.to_string()))
         }
         ColumnType::Array(inner_type) => {
@@ -1825,5 +1883,30 @@ mod tests {
 
         let decoded = decode_row(&dst_desc, &dst_encoded).unwrap();
         assert_eq!(decoded, src_values);
+    }
+
+    #[test]
+    fn encode_row_rejects_invalid_enum_variant() {
+        let descriptor = RowDescriptor::new(vec![ColumnDescriptor::new(
+            "status",
+            ColumnType::Enum(vec!["done".to_string(), "todo".to_string()]),
+        )]);
+
+        let err = encode_row(&descriptor, &[Value::Text("invalid".to_string())]).unwrap_err();
+        assert!(matches!(err, EncodingError::TypeMismatch { .. }));
+    }
+
+    #[test]
+    fn decode_row_rejects_invalid_enum_variant() {
+        let descriptor = RowDescriptor::new(vec![ColumnDescriptor::new(
+            "status",
+            ColumnType::Enum(vec!["done".to_string(), "todo".to_string()]),
+        )]);
+
+        let mut encoded = encode_row(&descriptor, &[Value::Text("todo".to_string())]).unwrap();
+        encoded.as_mut_slice().clone_from_slice(b"nope");
+
+        let err = decode_row(&descriptor, &encoded).unwrap_err();
+        assert!(matches!(err, EncodingError::MalformedData { .. }));
     }
 }

--- a/crates/jazz-tools/src/query_manager/types/branch.rs
+++ b/crates/jazz-tools/src/query_manager/types/branch.rs
@@ -354,6 +354,18 @@ fn hash_column_type(hasher: &mut blake3::Hasher, col_type: &ColumnType) {
         ColumnType::Text => {
             hasher.update(&[4]);
         }
+        ColumnType::Enum(variants) => {
+            hasher.update(&[9]);
+            // Enum variant ordering is normalized for hashing.
+            let mut normalized = variants.clone();
+            normalized.sort();
+            normalized.dedup();
+            hasher.update(&(normalized.len() as u64).to_le_bytes());
+            for variant in normalized {
+                hasher.update(variant.as_bytes());
+                hasher.update(&[0]);
+            }
+        }
         ColumnType::Timestamp => {
             hasher.update(&[5]);
         }

--- a/crates/jazz-tools/src/query_manager/types/schema.rs
+++ b/crates/jazz-tools/src/query_manager/types/schema.rs
@@ -81,6 +81,8 @@ pub enum ColumnType {
     Boolean,
     /// Variable-length UTF-8 text.
     Text,
+    /// Enumerated text constrained to a closed set of variants.
+    Enum(Vec<String>),
     /// 8-byte unsigned timestamp (microseconds since Unix epoch).
     Timestamp,
     /// 16-byte UUID (ObjectId).
@@ -102,6 +104,7 @@ impl ColumnType {
             ColumnType::Timestamp => Some(8),
             ColumnType::Uuid => Some(16),
             ColumnType::Text => None,
+            ColumnType::Enum(_) => None,
             ColumnType::Array(_) => None, // Arrays are variable-length
             ColumnType::Row(_) => None,   // Rows are variable-length
         }

--- a/crates/jazz-tools/src/query_manager/types/tests.rs
+++ b/crates/jazz-tools/src/query_manager/types/tests.rs
@@ -10,6 +10,7 @@ fn column_type_fixed_sizes() {
     assert_eq!(ColumnType::Timestamp.fixed_size(), Some(8));
     assert_eq!(ColumnType::Uuid.fixed_size(), Some(16));
     assert_eq!(ColumnType::Text.fixed_size(), None);
+    assert_eq!(ColumnType::Enum(vec!["a".to_string()]).fixed_size(), None);
 }
 
 #[test]
@@ -417,6 +418,35 @@ fn schema_hash_table_order_independent() {
     let hash1 = SchemaHash::compute(&schema1);
     let hash2 = SchemaHash::compute(&schema2);
     assert_eq!(hash1, hash2, "Table order should not affect hash");
+}
+
+#[test]
+fn schema_hash_enum_variant_order_independent() {
+    let schema1 = SchemaBuilder::new()
+        .table(TableSchema::builder("todos").column(
+            "status",
+            ColumnType::Enum(vec![
+                "done".to_string(),
+                "in_progress".to_string(),
+                "todo".to_string(),
+            ]),
+        ))
+        .build();
+
+    let schema2 = SchemaBuilder::new()
+        .table(TableSchema::builder("todos").column(
+            "status",
+            ColumnType::Enum(vec![
+                "todo".to_string(),
+                "done".to_string(),
+                "in_progress".to_string(),
+            ]),
+        ))
+        .build();
+
+    let hash1 = SchemaHash::compute(&schema1);
+    let hash2 = SchemaHash::compute(&schema2);
+    assert_eq!(hash1, hash2, "Enum variant order should not affect hash");
 }
 
 #[test]

--- a/crates/jazz-tools/src/schema_manager/auto_lens.rs
+++ b/crates/jazz-tools/src/schema_manager/auto_lens.rs
@@ -189,6 +189,11 @@ fn default_for_type(column_type: &ColumnType, nullable: bool) -> Value {
         ColumnType::BigInt => Value::BigInt(0),
         ColumnType::Boolean => Value::Boolean(false),
         ColumnType::Text => Value::Text(String::new()),
+        ColumnType::Enum(variants) => variants
+            .first()
+            .cloned()
+            .map(Value::Text)
+            .unwrap_or(Value::Null),
         ColumnType::Timestamp => Value::Timestamp(0),
         ColumnType::Uuid => Value::Null, // Can't generate a sensible default
         ColumnType::Array(_) => Value::Array(Vec::new()),

--- a/crates/jazz-tools/src/schema_manager/diff.rs
+++ b/crates/jazz-tools/src/schema_manager/diff.rs
@@ -257,6 +257,11 @@ fn default_for_type(ct: &ColumnType) -> Value {
         ColumnType::BigInt => Value::BigInt(0),
         ColumnType::Boolean => Value::Boolean(false),
         ColumnType::Text => Value::Text(String::new()),
+        ColumnType::Enum(variants) => variants
+            .first()
+            .cloned()
+            .map(Value::Text)
+            .unwrap_or(Value::Null),
         ColumnType::Timestamp => Value::Timestamp(0),
         ColumnType::Uuid => Value::Null, // Can't generate a sensible default
         ColumnType::Array(_) => Value::Array(vec![]),

--- a/crates/jazz-tools/src/schema_manager/encoding.rs
+++ b/crates/jazz-tools/src/schema_manager/encoding.rs
@@ -248,6 +248,7 @@ const TYPE_TIMESTAMP: u8 = 5;
 const TYPE_UUID: u8 = 6;
 const TYPE_ARRAY: u8 = 7;
 const TYPE_ROW: u8 = 8;
+const TYPE_ENUM: u8 = 9;
 
 fn encode_column_type(buf: &mut Vec<u8>, col_type: &ColumnType) {
     match col_type {
@@ -257,6 +258,13 @@ fn encode_column_type(buf: &mut Vec<u8>, col_type: &ColumnType) {
         ColumnType::Text => buf.push(TYPE_TEXT),
         ColumnType::Timestamp => buf.push(TYPE_TIMESTAMP),
         ColumnType::Uuid => buf.push(TYPE_UUID),
+        ColumnType::Enum(variants) => {
+            buf.push(TYPE_ENUM);
+            write_u32(buf, variants.len() as u32);
+            for variant in variants {
+                write_string(buf, variant);
+            }
+        }
         ColumnType::Array(elem) => {
             buf.push(TYPE_ARRAY);
             encode_column_type(buf, elem);
@@ -280,6 +288,14 @@ fn decode_column_type(
         TYPE_TEXT => Ok(ColumnType::Text),
         TYPE_TIMESTAMP => Ok(ColumnType::Timestamp),
         TYPE_UUID => Ok(ColumnType::Uuid),
+        TYPE_ENUM => {
+            let variant_count = read_u32(data, offset)? as usize;
+            let mut variants = Vec::with_capacity(variant_count);
+            for _ in 0..variant_count {
+                variants.push(read_string(data, offset, "enum_variant")?);
+            }
+            Ok(ColumnType::Enum(variants))
+        }
         TYPE_ARRAY => {
             let elem = decode_column_type(data, offset)?;
             Ok(ColumnType::Array(Box::new(elem)))
@@ -1088,6 +1104,34 @@ mod tests {
         let posts = decoded.get(&TableName::new("posts")).unwrap();
         let tags_col = posts.descriptor.column("tags").unwrap();
         assert!(matches!(tags_col.column_type, ColumnType::Array(_)));
+    }
+
+    #[test]
+    fn schema_roundtrip_with_enum() {
+        let schema = SchemaBuilder::new()
+            .table(TableSchema::builder("todos").column(
+                "status",
+                ColumnType::Enum(vec![
+                    "done".to_string(),
+                    "in_progress".to_string(),
+                    "todo".to_string(),
+                ]),
+            ))
+            .build();
+
+        let encoded = encode_schema(&schema);
+        let decoded = decode_schema(&encoded).unwrap();
+
+        let todos = decoded.get(&TableName::new("todos")).unwrap();
+        let status_col = todos.descriptor.column("status").unwrap();
+        assert_eq!(
+            status_col.column_type,
+            ColumnType::Enum(vec![
+                "done".to_string(),
+                "in_progress".to_string(),
+                "todo".to_string(),
+            ])
+        );
     }
 
     #[test]

--- a/crates/jazz-tools/src/schema_manager/files.rs
+++ b/crates/jazz-tools/src/schema_manager/files.rs
@@ -565,10 +565,23 @@ fn value_to_ts_literal(value: &Value) -> String {
     }
 }
 
+fn string_to_ts_literal(s: &str) -> String {
+    format!("\"{}\"", s.replace('\\', "\\\\").replace('"', "\\\""))
+}
+
+fn enum_variants_to_ts_args(variants: &[String]) -> String {
+    variants
+        .iter()
+        .map(|variant| string_to_ts_literal(variant))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
 /// Map ColumnType to col builder method name.
 fn sql_type_to_col_method(column_type: &ColumnType) -> &'static str {
     match column_type {
         ColumnType::Text => "string",
+        ColumnType::Enum(_) => "enum",
         ColumnType::Boolean => "boolean",
         ColumnType::Integer | ColumnType::BigInt => "int",
         ColumnType::Timestamp => "int", // Timestamps are stored as integers
@@ -620,18 +633,28 @@ fn lens_transform_to_ts(transform: &LensTransform) -> String {
                     } else {
                         ""
                     };
-                    if let ColumnType::Array(element_type) = column_type {
-                        let element_literal = column_type_to_sql(element_type);
-                        lines.push(format!(
-                            "  {}: col.add(){}.array({{ of: \"{}\", default: {} }}),{}",
-                            column, optional, element_literal, default_ts, draft_comment
-                        ));
-                    } else {
-                        let method = sql_type_to_col_method(column_type);
-                        lines.push(format!(
-                            "  {}: col.add(){}.{}({{ default: {} }}),{}",
-                            column, optional, method, default_ts, draft_comment
-                        ));
+                    match column_type {
+                        ColumnType::Array(element_type) => {
+                            let element_literal = column_type_to_sql(element_type);
+                            lines.push(format!(
+                                "  {}: col.add(){}.array({{ of: \"{}\", default: {} }}),{}",
+                                column, optional, element_literal, default_ts, draft_comment
+                            ));
+                        }
+                        ColumnType::Enum(variants) => {
+                            let variant_args = enum_variants_to_ts_args(variants);
+                            lines.push(format!(
+                                "  {}: col.add(){}.enum({}, {{ default: {} }}),{}",
+                                column, optional, variant_args, default_ts, draft_comment
+                            ));
+                        }
+                        _ => {
+                            let method = sql_type_to_col_method(column_type);
+                            lines.push(format!(
+                                "  {}: col.add(){}.{}({{ default: {} }}),{}",
+                                column, optional, method, default_ts, draft_comment
+                            ));
+                        }
                     }
                 }
                 LensOp::RemoveColumn {
@@ -641,18 +664,28 @@ fn lens_transform_to_ts(transform: &LensTransform) -> String {
                     ..
                 } => {
                     let default_ts = value_to_ts_literal(default);
-                    if let ColumnType::Array(element_type) = column_type {
-                        let element_literal = column_type_to_sql(element_type);
-                        lines.push(format!(
-                            "  {}: col.drop().array({{ of: \"{}\", backwardsDefault: {} }}),{}",
-                            column, element_literal, default_ts, draft_comment
-                        ));
-                    } else {
-                        let method = sql_type_to_col_method(column_type);
-                        lines.push(format!(
-                            "  {}: col.drop().{}({{ backwardsDefault: {} }}),{}",
-                            column, method, default_ts, draft_comment
-                        ));
+                    match column_type {
+                        ColumnType::Array(element_type) => {
+                            let element_literal = column_type_to_sql(element_type);
+                            lines.push(format!(
+                                "  {}: col.drop().array({{ of: \"{}\", backwardsDefault: {} }}),{}",
+                                column, element_literal, default_ts, draft_comment
+                            ));
+                        }
+                        ColumnType::Enum(variants) => {
+                            let variant_args = enum_variants_to_ts_args(variants);
+                            lines.push(format!(
+                                "  {}: col.drop().enum({}, {{ backwardsDefault: {} }}),{}",
+                                column, variant_args, default_ts, draft_comment
+                            ));
+                        }
+                        _ => {
+                            let method = sql_type_to_col_method(column_type);
+                            lines.push(format!(
+                                "  {}: col.drop().{}({{ backwardsDefault: {} }}),{}",
+                                column, method, default_ts, draft_comment
+                            ));
+                        }
                     }
                 }
                 LensOp::RenameColumn {
@@ -1015,5 +1048,29 @@ mod tests {
         let ts = lens_transform_to_ts(&transform);
         assert!(ts.contains("todos: col.add().array({ of: \"UUID\", default: [] }),"));
         assert!(ts.contains("todos: col.drop().array({ of: \"UUID\", backwardsDefault: [] }),"));
+    }
+
+    #[test]
+    fn lens_transform_to_ts_uses_enum_builder_for_enum_columns() {
+        let transform = LensTransform::with_ops(vec![
+            super::super::lens::LensOp::AddColumn {
+                table: "todos".to_string(),
+                column: "status".to_string(),
+                column_type: ColumnType::Enum(vec!["done".to_string(), "todo".to_string()]),
+                default: crate::query_manager::types::Value::Text("todo".to_string()),
+            },
+            super::super::lens::LensOp::RemoveColumn {
+                table: "todos".to_string(),
+                column: "status".to_string(),
+                column_type: ColumnType::Enum(vec!["done".to_string(), "todo".to_string()]),
+                default: crate::query_manager::types::Value::Text("todo".to_string()),
+            },
+        ]);
+
+        let ts = lens_transform_to_ts(&transform);
+        assert!(ts.contains("status: col.add().enum(\"done\", \"todo\", { default: \"todo\" }),"));
+        assert!(ts.contains(
+            "status: col.drop().enum(\"done\", \"todo\", { backwardsDefault: \"todo\" }),"
+        ));
     }
 }

--- a/crates/jazz-tools/src/schema_manager/sql.rs
+++ b/crates/jazz-tools/src/schema_manager/sql.rs
@@ -394,28 +394,69 @@ impl Parser {
 
     fn parse_column_type(&mut self) -> Result<ColumnType, SqlParseError> {
         let type_name = self.expect_ident()?;
+        let upper = type_name.to_uppercase();
 
-        // Skip optional size like VARCHAR(255)
-        if self.peek() == Some(&Token::LParen) {
-            self.advance();
-            // Skip until closing paren
-            while self.peek() != Some(&Token::RParen) {
-                if self.advance().is_none() {
-                    return Err(SqlParseError::UnexpectedEnd);
+        let mut col_type = if upper == "ENUM" {
+            self.expect(&Token::LParen)?;
+            let mut variants = Vec::new();
+            loop {
+                match self.advance() {
+                    Some(Token::StringLit(variant)) => variants.push(variant.clone()),
+                    Some(t) => {
+                        return Err(SqlParseError::Expected(format!(
+                            "enum variant string literal, got {:?}",
+                            t
+                        )));
+                    }
+                    None => return Err(SqlParseError::UnexpectedEnd),
+                }
+
+                match self.peek() {
+                    Some(Token::Comma) => {
+                        self.advance();
+                    }
+                    Some(Token::RParen) => {
+                        self.advance();
+                        break;
+                    }
+                    Some(t) => {
+                        return Err(SqlParseError::Expected(format!(
+                            ", or ) in ENUM type, got {:?}",
+                            t
+                        )));
+                    }
+                    None => return Err(SqlParseError::UnexpectedEnd),
                 }
             }
-            self.advance(); // consume RParen
-        }
+            if variants.is_empty() {
+                return Err(SqlParseError::SyntaxError(
+                    "ENUM type requires at least one variant".to_string(),
+                ));
+            }
+            ColumnType::Enum(variants)
+        } else {
+            // Skip optional size like VARCHAR(255)
+            if self.peek() == Some(&Token::LParen) {
+                self.advance();
+                // Skip until closing paren
+                while self.peek() != Some(&Token::RParen) {
+                    if self.advance().is_none() {
+                        return Err(SqlParseError::UnexpectedEnd);
+                    }
+                }
+                self.advance(); // consume RParen
+            }
 
-        let mut col_type = match type_name.to_uppercase().as_str() {
-            "TEXT" | "VARCHAR" | "CHAR" | "STRING" => Ok(ColumnType::Text),
-            "INTEGER" | "INT" | "SMALLINT" | "TINYINT" => Ok(ColumnType::Integer),
-            "BIGINT" => Ok(ColumnType::BigInt),
-            "BOOLEAN" | "BOOL" => Ok(ColumnType::Boolean),
-            "TIMESTAMP" => Ok(ColumnType::Timestamp),
-            "UUID" => Ok(ColumnType::Uuid),
-            _ => Err(SqlParseError::UnsupportedType(type_name)),
-        }?;
+            match upper.as_str() {
+                "TEXT" | "VARCHAR" | "CHAR" | "STRING" => ColumnType::Text,
+                "INTEGER" | "INT" | "SMALLINT" | "TINYINT" => ColumnType::Integer,
+                "BIGINT" => ColumnType::BigInt,
+                "BOOLEAN" | "BOOL" => ColumnType::Boolean,
+                "TIMESTAMP" => ColumnType::Timestamp,
+                "UUID" => ColumnType::Uuid,
+                _ => return Err(SqlParseError::UnsupportedType(type_name)),
+            }
+        };
 
         // Optional array suffixes: UUID[], TEXT[][], etc.
         while self.peek() == Some(&Token::LBracket) {
@@ -1239,6 +1280,14 @@ pub(crate) fn column_type_to_sql(ct: &ColumnType) -> String {
         ColumnType::BigInt => "BIGINT".to_string(),
         ColumnType::Boolean => "BOOLEAN".to_string(),
         ColumnType::Text => "TEXT".to_string(),
+        ColumnType::Enum(variants) => {
+            let variants = variants
+                .iter()
+                .map(|variant| format!("'{}'", variant.replace('\'', "''")))
+                .collect::<Vec<_>>()
+                .join(",");
+            format!("ENUM({variants})")
+        }
         ColumnType::Timestamp => "TIMESTAMP".to_string(),
         ColumnType::Uuid => "UUID".to_string(),
         ColumnType::Array(elem) => format!("{}[]", column_type_to_sql(elem)),
@@ -1626,6 +1675,27 @@ mod tests {
     }
 
     #[test]
+    fn parse_enum_column_type() {
+        let sql = "CREATE TABLE todos (status ENUM('todo','in_progress','done') NOT NULL);";
+        let schema = parse_schema(sql).unwrap();
+        let col = &schema
+            .get(&TableName::new("todos"))
+            .unwrap()
+            .descriptor
+            .columns[0];
+
+        assert_eq!(
+            col.column_type,
+            ColumnType::Enum(vec![
+                "todo".to_string(),
+                "in_progress".to_string(),
+                "done".to_string(),
+            ])
+        );
+        assert!(!col.nullable);
+    }
+
+    #[test]
     fn reject_non_create_in_schema() {
         let sql = "ALTER TABLE users ADD COLUMN age INTEGER;";
 
@@ -1662,6 +1732,29 @@ mod tests {
         match &transform.ops[0] {
             LensOp::AddColumn { default, .. } => {
                 assert_eq!(*default, Value::Integer(-42));
+            }
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn parse_lens_add_enum_column_with_default() {
+        let sql = "ALTER TABLE todos ADD COLUMN status ENUM('todo','done') DEFAULT 'todo';";
+        let transform = parse_lens(sql).unwrap();
+
+        match &transform.ops[0] {
+            LensOp::AddColumn {
+                column,
+                column_type,
+                default,
+                ..
+            } => {
+                assert_eq!(column, "status");
+                assert_eq!(
+                    *column_type,
+                    ColumnType::Enum(vec!["todo".to_string(), "done".to_string()])
+                );
+                assert_eq!(*default, Value::Text("todo".to_string()));
             }
             _ => panic!(),
         }
@@ -1819,6 +1912,27 @@ mod tests {
             ColumnType::Array(Box::new(ColumnType::Uuid))
         );
         assert_eq!(col.references, Some(TableName::new("file_parts")));
+        assert!(!col.nullable);
+    }
+
+    #[test]
+    fn sql_round_trip_with_enum() {
+        let sql = "CREATE TABLE todos (status ENUM('todo','done') NOT NULL);";
+        let schema = parse_schema(sql).unwrap();
+        let regenerated = schema_to_sql(&schema);
+
+        assert!(regenerated.contains("status ENUM('todo','done') NOT NULL"));
+
+        let reparsed = parse_schema(&regenerated).unwrap();
+        let col = &reparsed
+            .get(&TableName::new("todos"))
+            .unwrap()
+            .descriptor
+            .columns[0];
+        assert_eq!(
+            col.column_type,
+            ColumnType::Enum(vec!["todo".to_string(), "done".to_string()])
+        );
         assert!(!col.nullable);
     }
 

--- a/crates/jazz-wasm/src/types.rs
+++ b/crates/jazz-wasm/src/types.rs
@@ -109,6 +109,7 @@ pub enum WasmColumnType {
     BigInt,
     Boolean,
     Text,
+    Enum { variants: Vec<String> },
     Timestamp,
     Uuid,
     Array { element: Box<WasmColumnType> },
@@ -248,6 +249,7 @@ impl From<jazz_tools::query_manager::types::ColumnType> for WasmColumnType {
             ColumnType::BigInt => WasmColumnType::BigInt,
             ColumnType::Boolean => WasmColumnType::Boolean,
             ColumnType::Text => WasmColumnType::Text,
+            ColumnType::Enum(variants) => WasmColumnType::Enum { variants },
             ColumnType::Timestamp => WasmColumnType::Timestamp,
             ColumnType::Uuid => WasmColumnType::Uuid,
             ColumnType::Array(elem) => WasmColumnType::Array {
@@ -573,6 +575,7 @@ impl TryFrom<WasmSchema> for jazz_tools::query_manager::types::Schema {
                 WasmColumnType::BigInt => ColumnType::BigInt,
                 WasmColumnType::Boolean => ColumnType::Boolean,
                 WasmColumnType::Text => ColumnType::Text,
+                WasmColumnType::Enum { variants } => ColumnType::Enum(variants),
                 WasmColumnType::Timestamp => ColumnType::Timestamp,
                 WasmColumnType::Uuid => ColumnType::Uuid,
                 WasmColumnType::Array { element } => {

--- a/crates/jazz-wasm/src/types.rs
+++ b/crates/jazz-wasm/src/types.rs
@@ -626,3 +626,58 @@ impl TryFrom<WasmSchema> for jazz_tools::query_manager::types::Schema {
         Ok(schema)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use jazz_tools::query_manager::types::{
+        ColumnType, Schema, SchemaBuilder, TableName, TableSchema,
+    };
+    use serde_json::json;
+
+    #[test]
+    fn wasm_column_type_enum_json_roundtrip() {
+        let enum_type = WasmColumnType::Enum {
+            variants: vec!["done".to_string(), "todo".to_string()],
+        };
+        let value = serde_json::to_value(&enum_type).unwrap();
+        assert_eq!(
+            value,
+            json!({
+                "type": "Enum",
+                "variants": ["done", "todo"]
+            })
+        );
+
+        let decoded: WasmColumnType = serde_json::from_value(value).unwrap();
+        match decoded {
+            WasmColumnType::Enum { variants } => {
+                assert_eq!(variants, vec!["done".to_string(), "todo".to_string()]);
+            }
+            other => panic!("expected enum type, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn wasm_schema_enum_roundtrip() {
+        let schema = SchemaBuilder::new()
+            .table(TableSchema::builder("todos").column(
+                "status",
+                ColumnType::Enum(vec!["done".to_string(), "todo".to_string()]),
+            ))
+            .build();
+
+        let wasm_schema = WasmSchema::from(&schema);
+        let decoded = Schema::try_from(wasm_schema).unwrap();
+        let status = decoded
+            .get(&TableName::new("todos"))
+            .unwrap()
+            .descriptor
+            .column("status")
+            .unwrap();
+        assert_eq!(
+            status.column_type,
+            ColumnType::Enum(vec!["done".to_string(), "todo".to_string()])
+        );
+    }
+}

--- a/packages/jazz-tools/src/codegen/codegen.test.ts
+++ b/packages/jazz-tools/src/codegen/codegen.test.ts
@@ -136,6 +136,18 @@ describe("schemaToWasm", () => {
     });
   });
 
+  it("converts enum to Enum with normalized variants", () => {
+    table("tasks", { status: col.enum("in_progress", "todo", "done") });
+    const schema = getCollectedSchema();
+    const wasm = schemaToWasm(schema);
+
+    expect(wasm.tables.tasks.columns[0]).toEqual({
+      name: "status",
+      column_type: { type: "Enum", variants: ["done", "in_progress", "todo"] },
+      nullable: false,
+    });
+  });
+
   it("converts multiple tables", () => {
     table("users", { name: col.string() });
     table("todos", { title: col.string(), user_id: col.ref("users") });
@@ -331,6 +343,15 @@ describe("generateTypes", () => {
 
     expect(output).toContain("  tags: string[];");
     expect(output).toContain("  matrix: number[][];");
+  });
+
+  it("maps enum columns to string literal unions", () => {
+    table("tasks", { status: col.enum("in_progress", "todo", "done") });
+    const schema = getCollectedSchema();
+    const wasm = schemaToWasm(schema);
+    const output = generateTypes(wasm);
+
+    expect(output).toContain('  status: "done" | "in_progress" | "todo";');
   });
 
   it("exports wasmSchema constant", () => {
@@ -690,6 +711,17 @@ describe("generateWhereInputTypes", () => {
     const output = generateTypes(wasm);
 
     expect(output).toContain("tags?: string[] | { eq?: string[]; contains?: string };");
+  });
+
+  it("generates enum filters with eq/ne/in", () => {
+    table("tasks", { status: col.enum("in_progress", "todo", "done") });
+    const schema = getCollectedSchema();
+    const wasm = schemaToWasm(schema);
+    const output = generateTypes(wasm);
+
+    expect(output).toContain(
+      'status?: "done" | "in_progress" | "todo" | { eq?: "done" | "in_progress" | "todo"; ne?: "done" | "in_progress" | "todo"; in?: ("done" | "in_progress" | "todo")[] };',
+    );
   });
 });
 

--- a/packages/jazz-tools/src/codegen/query-builder-generator.ts
+++ b/packages/jazz-tools/src/codegen/query-builder-generator.ts
@@ -11,6 +11,10 @@ import type { WasmSchema, ColumnType } from "../drivers/types.js";
 import { tableNameToInterface } from "./type-generator.js";
 import type { Relation } from "./relation-analyzer.js";
 
+function arrayType(elementTs: string): string {
+  return elementTs.includes("|") ? `(${elementTs})[]` : `${elementTs}[]`;
+}
+
 function columnTypeToTs(type: ColumnType): string {
   switch (type.type) {
     case "Text":
@@ -23,8 +27,10 @@ function columnTypeToTs(type: ColumnType): string {
       return "number";
     case "Uuid":
       return "string";
+    case "Enum":
+      return type.variants.map((variant: string) => JSON.stringify(variant)).join(" | ");
     case "Array":
-      return `${columnTypeToTs(type.element)}[]`;
+      return arrayType(columnTypeToTs(type.element));
     default:
       return "unknown";
   }
@@ -59,9 +65,15 @@ function columnToWhereInputType(col: {
           : "string | { eq?: string; ne?: string }";
       }
       return "string | { eq?: string; ne?: string; in?: string[] }";
+    case "Enum": {
+      const variants = col.column_type.variants
+        .map((variant: string) => JSON.stringify(variant))
+        .join(" | ");
+      return `${variants} | { eq?: ${variants}; ne?: ${variants}; in?: (${variants})[] }`;
+    }
     case "Array": {
       const elementTs = columnTypeToTs(col.column_type.element);
-      const arrayTs = `${elementTs}[]`;
+      const arrayTs = arrayType(elementTs);
       return `${arrayTs} | { eq?: ${arrayTs}; contains?: ${elementTs} }`;
     }
     default:

--- a/packages/jazz-tools/src/codegen/schema-reader.ts
+++ b/packages/jazz-tools/src/codegen/schema-reader.ts
@@ -34,6 +34,9 @@ const map: Record<ScalarSqlType, ColumnType> = {
  */
 function sqlTypeToWasm(sqlType: SqlType): ColumnType {
   if (typeof sqlType !== "string") {
+    if (sqlType.kind === "ENUM") {
+      return { type: "Enum", variants: [...sqlType.variants] };
+    }
     return { type: "Array", element: sqlTypeToWasm(sqlType.element) };
   }
   return map[sqlType];

--- a/packages/jazz-tools/src/codegen/type-generator.ts
+++ b/packages/jazz-tools/src/codegen/type-generator.ts
@@ -26,12 +26,14 @@ function wasmTypeToTs(colType: ColumnType): string {
       return "number";
     case "Uuid":
       return "string";
+    case "Enum":
+      return colType.variants.map((variant: string) => JSON.stringify(variant)).join(" | ");
     case "Array":
       return `${wasmTypeToTs(colType.element)}[]`;
     case "Row":
       // Nested row - generate inline type
       const fields = colType.columns
-        .map((c) => {
+        .map((c: { name: string; nullable: boolean; column_type: ColumnType }) => {
           const opt = c.nullable ? "?" : "";
           return `${c.name}${opt}: ${wasmTypeToTs(c.column_type)}`;
         })

--- a/packages/jazz-tools/src/dsl.test.ts
+++ b/packages/jazz-tools/src/dsl.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { col } from "./dsl.js";
+
+describe("enum DSL invariants", () => {
+  it("rejects empty variant list", () => {
+    expect(() => (col.enum as (...args: unknown[]) => unknown)()).toThrow(
+      "Enum columns require at least one variant.",
+    );
+  });
+
+  it("rejects empty variant strings", () => {
+    expect(() => col.enum("todo", "")).toThrow("Enum variants cannot be empty strings.");
+  });
+
+  it("rejects duplicate variants", () => {
+    expect(() => col.enum("todo", "todo")).toThrow("Enum variants must be unique.");
+  });
+
+  it("rejects duplicate variants in add enum migration", () => {
+    expect(() => col.add().enum("todo", "todo", { default: "todo" })).toThrow(
+      "Enum variants must be unique.",
+    );
+  });
+
+  it("rejects empty variants in drop enum migration", () => {
+    expect(() => col.drop().enum("todo", "", { backwardsDefault: "todo" })).toThrow(
+      "Enum variants cannot be empty strings.",
+    );
+  });
+});

--- a/packages/jazz-tools/src/dsl.ts
+++ b/packages/jazz-tools/src/dsl.ts
@@ -5,6 +5,7 @@ import type {
   Schema,
   Table,
   SqlType,
+  EnumSqlType,
   Lens,
   LensOp,
   AddOp,
@@ -15,6 +16,22 @@ import type {
   ScalarSqlType,
   TSTypeFromSqlType,
 } from "./schema.js";
+
+function normalizeEnumVariants(variants: readonly string[]): string[] {
+  if (variants.length === 0) {
+    throw new Error("Enum columns require at least one variant.");
+  }
+  for (const variant of variants) {
+    if (variant.length === 0) {
+      throw new Error("Enum variants cannot be empty strings.");
+    }
+  }
+  const unique = new Set(variants);
+  if (unique.size !== variants.length) {
+    throw new Error("Enum variants must be unique.");
+  }
+  return [...unique].sort((a, b) => a.localeCompare(b));
+}
 
 // ============================================================================
 // Column Builder (for schema context)
@@ -31,6 +48,32 @@ class ScalarBuilder implements ColumnBuilder {
   private _nullable = false;
 
   constructor(public _sqlType: ScalarSqlType) {}
+
+  optional(): this {
+    this._nullable = true;
+    return this;
+  }
+
+  _build(name: string): Column {
+    return {
+      name,
+      sqlType: this._sqlType,
+      nullable: this._nullable,
+    };
+  }
+
+  get _references(): string | undefined {
+    return undefined;
+  }
+}
+
+class EnumBuilder implements ColumnBuilder {
+  private _nullable = false;
+  public _sqlType: EnumSqlType;
+
+  constructor(...variants: string[]) {
+    this._sqlType = { kind: "ENUM", variants: normalizeEnumVariants(variants) };
+  }
 
   optional(): this {
     this._nullable = true;
@@ -133,6 +176,18 @@ class AddBuilder<Optional extends boolean = false> {
     return { _type: "add", sqlType: "REAL", default: opts.default };
   }
 
+  enum<const Variants extends readonly [string, ...string[]]>(
+    ...args: [...variants: Variants, opts: { default: MaybeOptional<Variants[number], Optional> }]
+  ): AddOp {
+    const opts = args[args.length - 1] as { default: MaybeOptional<Variants[number], Optional> };
+    const variants = normalizeEnumVariants(args.slice(0, -1) as string[]);
+    return {
+      _type: "add",
+      sqlType: { kind: "ENUM", variants },
+      default: opts.default,
+    };
+  }
+
   array<T extends SqlType>(opts: {
     of: T;
     default: MaybeOptional<TSTypeFromSqlType<T>[], Optional>;
@@ -170,6 +225,18 @@ class DropBuilder {
     return { _type: "drop", sqlType: "REAL", backwardsDefault: opts.backwardsDefault };
   }
 
+  enum<const Variants extends readonly [string, ...string[]]>(
+    ...args: [...variants: Variants, opts: { backwardsDefault: Variants[number] }]
+  ): DropOp {
+    const opts = args[args.length - 1] as { backwardsDefault: Variants[number] };
+    const variants = normalizeEnumVariants(args.slice(0, -1) as string[]);
+    return {
+      _type: "drop",
+      sqlType: { kind: "ENUM", variants },
+      backwardsDefault: opts.backwardsDefault,
+    };
+  }
+
   array<T extends SqlType>(opts: { of: T; backwardsDefault: TSTypeFromSqlType<T>[] }): DropOp {
     return {
       _type: "drop",
@@ -189,6 +256,7 @@ export const col = {
   boolean: () => new ScalarBuilder("BOOLEAN"),
   int: () => new ScalarBuilder("INTEGER"),
   float: () => new ScalarBuilder("REAL"),
+  enum: (...variants: string[]) => new EnumBuilder(...variants),
   ref: (targetTable: string) => new RefBuilder(targetTable),
   array: (element: ColumnBuilder) => new ArrayBuilder(element),
 

--- a/packages/jazz-tools/src/runtime/query-adapter.test.ts
+++ b/packages/jazz-tools/src/runtime/query-adapter.test.ts
@@ -26,6 +26,11 @@ describe("translateQuery", () => {
           { name: "title", column_type: { type: "Text" }, nullable: false },
           { name: "done", column_type: { type: "Boolean" }, nullable: false },
           { name: "priority", column_type: { type: "Integer" }, nullable: true },
+          {
+            name: "status",
+            column_type: { type: "Enum", variants: ["done", "in_progress", "todo"] },
+            nullable: false,
+          },
           { name: "project", column_type: { type: "Uuid" }, nullable: true },
           {
             name: "tags",
@@ -101,6 +106,23 @@ describe("translateQuery", () => {
         left: { scope: "todos", column: "title" },
         op: "Eq",
         right: { type: "Literal", value: { Text: "Buy milk" } },
+      });
+    });
+
+    it("translates eq condition with enum value", () => {
+      const builderJson = JSON.stringify({
+        table: "todos",
+        conditions: [{ column: "status", op: "eq", value: "todo" }],
+        includes: {},
+        orderBy: [],
+      });
+
+      const result = parseTranslatedQuery(builderJson, basicSchema);
+      expect(expectFilterPredicate(result)).toEqual({
+        type: "Cmp",
+        left: { scope: "todos", column: "status" },
+        op: "Eq",
+        right: { type: "Literal", value: { Text: "todo" } },
       });
     });
 
@@ -404,6 +426,17 @@ describe("translateQuery", () => {
       });
 
       expect(() => translateQuery(builderJson, basicSchema)).toThrow("Unknown operator: unknown");
+    });
+
+    it("throws for invalid enum value", () => {
+      const builderJson = JSON.stringify({
+        table: "todos",
+        conditions: [{ column: "status", op: "eq", value: "invalid" }],
+        includes: {},
+        orderBy: [],
+      });
+
+      expect(() => translateQuery(builderJson, basicSchema)).toThrow("Invalid enum value");
     });
   });
 

--- a/packages/jazz-tools/src/runtime/query-adapter.ts
+++ b/packages/jazz-tools/src/runtime/query-adapter.ts
@@ -106,6 +106,11 @@ function toWasmValue(value: unknown, columnType: ColumnType): object {
     if (columnType?.type === "Uuid") {
       return { Uuid: value };
     }
+    if (columnType?.type === "Enum" && !columnType.variants.includes(value)) {
+      throw new Error(
+        `Invalid enum value "${value}". Expected one of: ${columnType.variants.join(", ")}`,
+      );
+    }
     return { Text: value };
   }
   throw new Error(`Unsupported value type: ${typeof value}`);

--- a/packages/jazz-tools/src/runtime/value-converter.test.ts
+++ b/packages/jazz-tools/src/runtime/value-converter.test.ts
@@ -54,6 +54,12 @@ describe("toValue", () => {
     expect(toValue(uuid, colType)).toEqual({ type: "Uuid", value: uuid });
   });
 
+  it("converts Enum values and validates variants", () => {
+    const colType = { type: "Enum", variants: ["done", "todo"] } as ColumnType;
+    expect(toValue("todo", colType)).toEqual({ type: "Text", value: "todo" });
+    expect(() => toValue("invalid", colType)).toThrow("Invalid enum value");
+  });
+
   it("converts Array values", () => {
     const colType: ColumnType = { type: "Array", element: { type: "Text" } };
     expect(toValue(["a", "b", "c"], colType)).toEqual({

--- a/packages/jazz-tools/src/runtime/value-converter.ts
+++ b/packages/jazz-tools/src/runtime/value-converter.ts
@@ -29,6 +29,15 @@ export function toValue(value: unknown, columnType: ColumnType): WasmValue {
       return { type: "Timestamp", value: Number(value) };
     case "Uuid":
       return { type: "Uuid", value: String(value) };
+    case "Enum": {
+      const enumValue = String(value);
+      if (!columnType.variants.includes(enumValue)) {
+        throw new Error(
+          `Invalid enum value "${enumValue}". Expected one of: ${columnType.variants.join(", ")}`,
+        );
+      }
+      return { type: "Text", value: enumValue };
+    }
     case "Array": {
       if (!Array.isArray(value)) {
         throw new Error(`Expected array for Array column type, got ${typeof value}`);

--- a/packages/jazz-tools/src/schema.ts
+++ b/packages/jazz-tools/src/schema.ts
@@ -2,15 +2,23 @@
 import type { RelExpr } from "./ir.js";
 
 export type ScalarSqlType = "TEXT" | "BOOLEAN" | "INTEGER" | "REAL" | "UUID";
+export interface EnumSqlType {
+  kind: "ENUM";
+  variants: string[];
+}
 export interface ArraySqlType {
   kind: "ARRAY";
   element: SqlType;
 }
-export type SqlType = ScalarSqlType | ArraySqlType;
+export type SqlType = ScalarSqlType | ArraySqlType | EnumSqlType;
 
 export function sqlTypeToString(sqlType: SqlType): string {
   if (typeof sqlType === "string") {
     return sqlType;
+  }
+  if (sqlType.kind === "ENUM") {
+    const variants = sqlType.variants.map((variant) => `'${variant.replace(/'/g, "''")}'`);
+    return `ENUM(${variants.join(",")})`;
   }
   return `${sqlTypeToString(sqlType.element)}[]`;
 }
@@ -31,7 +39,9 @@ export type TSTypeFromSqlType<T extends SqlType> = T extends ScalarSqlType
   ? TSTypeFromScalarSqlType<T>
   : T extends ArraySqlType
     ? TSTypeFromSqlType<T["element"]>[]
-    : never;
+    : T extends EnumSqlType
+      ? T["variants"][number]
+      : never;
 
 export interface Column {
   name: string;

--- a/packages/jazz-tools/src/sql-gen.test.ts
+++ b/packages/jazz-tools/src/sql-gen.test.ts
@@ -72,6 +72,19 @@ describe("schemaToSql", () => {
     expect(sql).toContain("real_null REAL");
   });
 
+  it("handles enum column types", () => {
+    resetCollectedState();
+    table("tasks", {
+      status: col.enum("in_progress", "todo", "done"),
+    });
+    const schema = getCollectedSchema();
+
+    const sql = schemaToSql(schema);
+
+    // Variants are normalized in DSL.
+    expect(sql).toContain("status ENUM('done','in_progress','todo') NOT NULL");
+  });
+
   it("handles array column types", () => {
     resetCollectedState();
     table("arrays", {
@@ -351,6 +364,34 @@ describe("lensToSql", () => {
 `);
     expect(lensToSql(lens, "bwd")).toBe(
       `ALTER TABLE projects ADD COLUMN todos UUID[] DEFAULT ARRAY[];
+`,
+    );
+  });
+
+  it("supports adding enum columns in lenses", () => {
+    resetCollectedState();
+    migrate("tasks", {
+      status: col.add().enum("todo", "done", { default: "todo" }),
+    });
+    const lens = getCollectedMigration()!;
+
+    expect(lensToSql(lens, "fwd")).toBe(
+      `ALTER TABLE tasks ADD COLUMN status ENUM('done','todo') DEFAULT 'todo';
+`,
+    );
+  });
+
+  it("supports dropping enum columns with backward re-add", () => {
+    resetCollectedState();
+    migrate("tasks", {
+      status: col.drop().enum("todo", "done", { backwardsDefault: "done" }),
+    });
+    const lens = getCollectedMigration()!;
+
+    expect(lensToSql(lens, "fwd")).toBe(`ALTER TABLE tasks DROP COLUMN status;
+`);
+    expect(lensToSql(lens, "bwd")).toBe(
+      `ALTER TABLE tasks ADD COLUMN status ENUM('done','todo') DEFAULT 'done';
 `,
     );
   });

--- a/specs/todo/a_mvp/enum_column_type_native_end_to_end_design.md
+++ b/specs/todo/a_mvp/enum_column_type_native_end_to_end_design.md
@@ -34,12 +34,12 @@ Changes:
 - Add enum sql type shape in TS schema model, e.g.:
   - `type EnumSqlType = { kind: "ENUM"; variants: string[] }`
   - include in `SqlType` union.
-- Add `col.enum(...variants)` in schema DSL and migration DSL (`col.add().enum(...)` / `col.drop().enum(...)` if we want parity with existing `add/drop` builders).
+- Add `col.enum(...variants)` in schema DSL and migration DSL (`col.add().enum(...)` / `col.drop().enum(...)`) with parity across schema and lens workflows.
 - Add validation in DSL:
   - at least one variant
   - unique variants
   - no empty-string variants
-- SQL generation path emits enum type syntax (see open question below).
+- SQL generation path emits enum type syntax: `ENUM('a','b',...)`.
 
 Core TS model sketch:
 
@@ -84,7 +84,7 @@ Files to touch:
 Changes:
 
 - Add `ColumnType::Enum(Vec<String>)`.
-- Preserve enum metadata in schema hash (variant list and order).
+- Preserve enum metadata in schema hash with normalized variant ordering (order-insensitive hash behavior).
 - Keep storage representation text-compatible (encode/decode as string bytes), but enforce type compatibility:
   - `Value::Text("draft")` is accepted for `ColumnType::Enum(["draft", ...])`.
   - reject text not present in variant list.
@@ -143,7 +143,7 @@ Proposed schema-level enum model:
 
 - schema type owns canonical list of variants.
 - value-level representation remains string (`Text`) for row payloads.
-- enum constraints are enforced by schema-aware validation layers (TS runtime and Rust encoding checks).
+- enum constraints are enforced by schema-aware validation layers in both TS runtime and native Rust runtime.
 
 This keeps wire/value formats stable while adding stricter type semantics.
 
@@ -179,28 +179,11 @@ This keeps wire/value formats stable while adding stricter type semantics.
 
 ## Missing Coverage Check
 
-Coverage appears complete for request scope (TS DSL to native runtime), but depends on one policy decision:
+Coverage appears complete for request scope (TS DSL to native runtime) with all policy questions resolved.
 
-- SQL representation of enum columns (custom `ENUM(...)` syntax vs text + check constraints).
+## Decisions
 
-## Ambiguities / Questions
-
-### SQL representation
-
-1. Should generated schema SQL use `ENUM('a','b')` as a first-class type syntax, or emit `TEXT` plus a `CHECK` constraint?
-   Impact: parser/emitter complexity and backward compatibility with existing SQL parser assumptions.
-
-### Migration API parity
-
-2. Do you want `col.add().enum(...)` and `col.drop().enum(...)` now, or only schema-time `col.enum(...)` in `table(...)` definitions?
-   Impact: whether migration-generation (`files.rs`) and lens SQL paths must support enum defaults immediately.
-
-### Variant ordering semantics
-
-3. Should variant order be semantically significant for schema hashes/diffs, or should variants be normalized/sorted?
-   Impact: whether reordering variants causes schema version bumps and migration generation.
-
-### Runtime enforcement location
-
-4. Should invalid enum values fail fast in TypeScript runtime only, native runtime only, or both?
-   Impact: consistency and error source clarity (client-side UX vs defense-in-depth).
+1. Use first-class `ENUM('a','b',...)` SQL syntax.
+2. Support `col.add().enum(...)` and `col.drop().enum(...)` now.
+3. Normalize variant ordering for schema hashing.
+4. Fail fast in both TypeScript and native runtime validation paths.


### PR DESCRIPTION
## Summary
- implement enum column type end-to-end from TS DSL through native layers (`col.enum("v1", "v2")`)
- support enum migrations for both `add` and `drop`
- normalize enum variant order for schema hashing
- enforce invariant failures in both TS/native validation paths
- add tests for TS DSL enum invariants and explicit WASM/NAPI enum bridge round-trips

## Validation
- `pnpm format:check`
- `pnpm lint`
- `pnpm build`
- `pnpm test`
