### PR TITLE
Add Real (float) column type support

### DIFF
--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -44,7 +44,7 @@ use jazz_tools::sync_manager::{
 enum NapiValue {
     Integer(i32),
     BigInt(i64),
-    Real(f64),
+    Double(f64),
     Boolean(bool),
     Text(String),
     Timestamp(u64),
@@ -59,7 +59,7 @@ impl From<Value> for NapiValue {
         match v {
             Value::Integer(i) => NapiValue::Integer(i),
             Value::BigInt(i) => NapiValue::BigInt(i),
-            Value::Real(f) => NapiValue::Real(f),
+            Value::Double(f) => NapiValue::Double(f),
             Value::Boolean(b) => NapiValue::Boolean(b),
             Value::Text(s) => NapiValue::Text(s),
             Value::Timestamp(t) => NapiValue::Timestamp(t),
@@ -75,7 +75,7 @@ fn napi_value_to_groove(v: NapiValue) -> Result<Value, String> {
     Ok(match v {
         NapiValue::Integer(i) => Value::Integer(i),
         NapiValue::BigInt(i) => Value::BigInt(i),
-        NapiValue::Real(f) => Value::Real(f),
+        NapiValue::Double(f) => Value::Double(f),
         NapiValue::Boolean(b) => Value::Boolean(b),
         NapiValue::Text(s) => Value::Text(s),
         NapiValue::Timestamp(t) => Value::Timestamp(t),
@@ -430,8 +430,8 @@ fn groove_schema_to_js(schema: &Schema) -> JsSchema {
                 variants: None,
                 columns: None,
             },
-            ColumnType::Real => JsColumnType {
-                type_name: "Real".into(),
+            ColumnType::Double => JsColumnType {
+                type_name: "Double".into(),
                 element: None,
                 variants: None,
                 columns: None,

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -44,6 +44,7 @@ use jazz_tools::sync_manager::{
 enum NapiValue {
     Integer(i32),
     BigInt(i64),
+    Real(f64),
     Boolean(bool),
     Text(String),
     Timestamp(u64),
@@ -58,6 +59,7 @@ impl From<Value> for NapiValue {
         match v {
             Value::Integer(i) => NapiValue::Integer(i),
             Value::BigInt(i) => NapiValue::BigInt(i),
+            Value::Real(f) => NapiValue::Real(f),
             Value::Boolean(b) => NapiValue::Boolean(b),
             Value::Text(s) => NapiValue::Text(s),
             Value::Timestamp(t) => NapiValue::Timestamp(t),
@@ -73,6 +75,7 @@ fn napi_value_to_groove(v: NapiValue) -> Result<Value, String> {
     Ok(match v {
         NapiValue::Integer(i) => Value::Integer(i),
         NapiValue::BigInt(i) => Value::BigInt(i),
+        NapiValue::Real(f) => Value::Real(f),
         NapiValue::Boolean(b) => Value::Boolean(b),
         NapiValue::Text(s) => Value::Text(s),
         NapiValue::Timestamp(t) => Value::Timestamp(t),
@@ -423,6 +426,12 @@ fn groove_schema_to_js(schema: &Schema) -> JsSchema {
             },
             ColumnType::BigInt => JsColumnType {
                 type_name: "BigInt".into(),
+                element: None,
+                variants: None,
+                columns: None,
+            },
+            ColumnType::Real => JsColumnType {
+                type_name: "Real".into(),
                 element: None,
                 variants: None,
                 columns: None,

--- a/crates/jazz-rn/rust/src/lib.rs
+++ b/crates/jazz-rn/rust/src/lib.rs
@@ -98,6 +98,7 @@ where
 enum RnValue {
     Integer(i32),
     BigInt(i64),
+    Real(f64),
     Boolean(bool),
     Text(String),
     Timestamp(u64),
@@ -112,6 +113,7 @@ impl From<Value> for RnValue {
         match v {
             Value::Integer(i) => RnValue::Integer(i),
             Value::BigInt(i) => RnValue::BigInt(i),
+            Value::Real(f) => RnValue::Real(f),
             Value::Boolean(b) => RnValue::Boolean(b),
             Value::Text(s) => RnValue::Text(s),
             Value::Timestamp(t) => RnValue::Timestamp(t),
@@ -130,6 +132,7 @@ impl TryFrom<RnValue> for Value {
         Ok(match v {
             RnValue::Integer(i) => Value::Integer(i),
             RnValue::BigInt(i) => Value::BigInt(i),
+            RnValue::Real(f) => Value::Real(f),
             RnValue::Boolean(b) => Value::Boolean(b),
             RnValue::Text(s) => Value::Text(s),
             RnValue::Timestamp(t) => Value::Timestamp(t),
@@ -213,6 +216,7 @@ impl TryFrom<JsColumnType> for jazz_tools::query_manager::types::ColumnType {
         match ct.type_name.as_str() {
             "Integer" => Ok(ColumnType::Integer),
             "BigInt" => Ok(ColumnType::BigInt),
+            "Real" => Ok(ColumnType::Real),
             "Boolean" => Ok(ColumnType::Boolean),
             "Text" => Ok(ColumnType::Text),
             "Timestamp" => Ok(ColumnType::Timestamp),

--- a/crates/jazz-rn/rust/src/lib.rs
+++ b/crates/jazz-rn/rust/src/lib.rs
@@ -98,7 +98,7 @@ where
 enum RnValue {
     Integer(i32),
     BigInt(i64),
-    Real(f64),
+    Double(f64),
     Boolean(bool),
     Text(String),
     Timestamp(u64),
@@ -113,7 +113,7 @@ impl From<Value> for RnValue {
         match v {
             Value::Integer(i) => RnValue::Integer(i),
             Value::BigInt(i) => RnValue::BigInt(i),
-            Value::Real(f) => RnValue::Real(f),
+            Value::Double(f) => RnValue::Double(f),
             Value::Boolean(b) => RnValue::Boolean(b),
             Value::Text(s) => RnValue::Text(s),
             Value::Timestamp(t) => RnValue::Timestamp(t),
@@ -132,7 +132,7 @@ impl TryFrom<RnValue> for Value {
         Ok(match v {
             RnValue::Integer(i) => Value::Integer(i),
             RnValue::BigInt(i) => Value::BigInt(i),
-            RnValue::Real(f) => Value::Real(f),
+            RnValue::Double(f) => Value::Double(f),
             RnValue::Boolean(b) => Value::Boolean(b),
             RnValue::Text(s) => Value::Text(s),
             RnValue::Timestamp(t) => Value::Timestamp(t),
@@ -216,7 +216,7 @@ impl TryFrom<JsColumnType> for jazz_tools::query_manager::types::ColumnType {
         match ct.type_name.as_str() {
             "Integer" => Ok(ColumnType::Integer),
             "BigInt" => Ok(ColumnType::BigInt),
-            "Real" => Ok(ColumnType::Real),
+            "Double" => Ok(ColumnType::Double),
             "Boolean" => Ok(ColumnType::Boolean),
             "Text" => Ok(ColumnType::Text),
             "Timestamp" => Ok(ColumnType::Timestamp),

--- a/crates/jazz-tools/src/query_manager/encoding.rs
+++ b/crates/jazz-tools/src/query_manager/encoding.rs
@@ -132,7 +132,7 @@ fn value_matches_column_type(value: &Value, column_type: &ColumnType) -> bool {
     match column_type {
         ColumnType::Integer => matches!(value, Value::Integer(_)),
         ColumnType::BigInt => matches!(value, Value::BigInt(_)),
-        ColumnType::Real => matches!(value, Value::Real(_)),
+        ColumnType::Double => matches!(value, Value::Double(_)),
         ColumnType::Boolean => matches!(value, Value::Boolean(_)),
         ColumnType::Timestamp => matches!(value, Value::Timestamp(_)),
         ColumnType::Uuid => matches!(value, Value::Uuid(_)),
@@ -180,7 +180,7 @@ fn encode_fixed_value(buf: &mut Vec<u8>, col: &ColumnDescriptor, val: &Value) {
     match val {
         Value::Integer(n) => buf.extend_from_slice(&n.to_le_bytes()),
         Value::BigInt(n) => buf.extend_from_slice(&n.to_le_bytes()),
-        Value::Real(f) => buf.extend_from_slice(&f.to_le_bytes()),
+        Value::Double(f) => buf.extend_from_slice(&f.to_le_bytes()),
         Value::Boolean(b) => buf.push(if *b { 1 } else { 0 }),
         Value::Timestamp(t) => buf.extend_from_slice(&t.to_le_bytes()),
         Value::Uuid(id) => buf.extend_from_slice(id.uuid().as_bytes()),
@@ -274,14 +274,14 @@ pub fn decode_column(
             let n = i64::from_le_bytes(bytes[..8].try_into().unwrap());
             Ok(Value::BigInt(n))
         }
-        ColumnType::Real => {
+        ColumnType::Double => {
             if bytes.len() < 8 {
                 return Err(EncodingError::MalformedData {
-                    message: "real too short".into(),
+                    message: "double too short".into(),
                 });
             }
             let f = f64::from_le_bytes(bytes[..8].try_into().unwrap());
-            Ok(Value::Real(f))
+            Ok(Value::Double(f))
         }
         ColumnType::Boolean => {
             if bytes.is_empty() {
@@ -529,7 +529,7 @@ pub fn compare_column(
             let n2 = i64::from_le_bytes(bytes2[..8].try_into().unwrap());
             Ok(n1.cmp(&n2))
         }
-        ColumnType::Real => {
+        ColumnType::Double => {
             let f1 = f64::from_le_bytes(bytes1[..8].try_into().unwrap());
             let f2 = f64::from_le_bytes(bytes2[..8].try_into().unwrap());
             Ok(f1.total_cmp(&f2))
@@ -582,7 +582,7 @@ pub fn compare_column_to_value(
             let n2 = i64::from_le_bytes(value[..8].try_into().unwrap());
             Ok(n1.cmp(&n2))
         }
-        ColumnType::Real => {
+        ColumnType::Double => {
             let f1 = f64::from_le_bytes(bytes[..8].try_into().unwrap());
             let f2 = f64::from_le_bytes(value[..8].try_into().unwrap());
             Ok(f1.total_cmp(&f2))
@@ -637,7 +637,7 @@ pub fn encode_value(value: &Value) -> Vec<u8> {
     match value {
         Value::Integer(n) => n.to_le_bytes().to_vec(),
         Value::BigInt(n) => n.to_le_bytes().to_vec(),
-        Value::Real(f) => f.to_le_bytes().to_vec(),
+        Value::Double(f) => f.to_le_bytes().to_vec(),
         Value::Boolean(b) => vec![if *b { 1 } else { 0 }],
         Value::Timestamp(t) => t.to_le_bytes().to_vec(),
         Value::Uuid(id) => id.uuid().as_bytes().to_vec(),
@@ -850,13 +850,13 @@ fn decode_array_element(data: &[u8], element_type: &ColumnType) -> Result<Value,
                 data[..8].try_into().unwrap(),
             )))
         }
-        ColumnType::Real => {
+        ColumnType::Double => {
             if data.len() < 8 {
                 return Err(EncodingError::MalformedData {
-                    message: "real element too short".into(),
+                    message: "double element too short".into(),
                 });
             }
-            Ok(Value::Real(f64::from_le_bytes(
+            Ok(Value::Double(f64::from_le_bytes(
                 data[..8].try_into().unwrap(),
             )))
         }
@@ -1946,14 +1946,14 @@ mod tests {
     fn real_encode_decode_roundtrip() {
         let descriptor = RowDescriptor::new(vec![
             ColumnDescriptor::new("name", ColumnType::Text),
-            ColumnDescriptor::new("temperature", ColumnType::Real),
-            ColumnDescriptor::new("pressure", ColumnType::Real),
+            ColumnDescriptor::new("temperature", ColumnType::Double),
+            ColumnDescriptor::new("pressure", ColumnType::Double),
         ]);
 
         let values = vec![
             Value::Text("sensor-1".into()),
-            Value::Real(23.456),
-            Value::Real(-101.325),
+            Value::Double(23.456),
+            Value::Double(-101.325),
         ];
 
         let encoded = encode_row(&descriptor, &values).unwrap();
@@ -1965,7 +1965,7 @@ mod tests {
     #[test]
     fn real_encode_decode_special_values() {
         // Exercise: zero, negative zero, infinity, negative infinity, NaN, subnormal
-        let descriptor = RowDescriptor::new(vec![ColumnDescriptor::new("val", ColumnType::Real)]);
+        let descriptor = RowDescriptor::new(vec![ColumnDescriptor::new("val", ColumnType::Double)]);
 
         let cases: Vec<f64> = vec![
             0.0,
@@ -1981,12 +1981,12 @@ mod tests {
         ];
 
         for val in cases {
-            let values = vec![Value::Real(val)];
+            let values = vec![Value::Double(val)];
             let encoded = encode_row(&descriptor, &values).unwrap();
             let decoded = decode_row(&descriptor, &encoded).unwrap();
 
             match &decoded[0] {
-                Value::Real(decoded_val) => {
+                Value::Double(decoded_val) => {
                     // Bitwise comparison handles NaN and negative zero
                     assert_eq!(
                         val.to_bits(),
@@ -1994,7 +1994,7 @@ mod tests {
                         "round-trip failed for {val}"
                     );
                 }
-                other => panic!("expected Value::Real, got {other:?}"),
+                other => panic!("expected Value::Double, got {other:?}"),
             }
         }
     }
@@ -2002,11 +2002,11 @@ mod tests {
     #[test]
     fn real_nullable_encode_decode() {
         let descriptor = RowDescriptor::new(vec![
-            ColumnDescriptor::new("score", ColumnType::Real).nullable(),
+            ColumnDescriptor::new("score", ColumnType::Double).nullable(),
         ]);
 
         // With value
-        let values = vec![Value::Real(99.5)];
+        let values = vec![Value::Double(99.5)];
         let encoded = encode_row(&descriptor, &values).unwrap();
         let decoded = decode_row(&descriptor, &encoded).unwrap();
         assert_eq!(values, decoded);
@@ -2020,8 +2020,10 @@ mod tests {
 
     #[test]
     fn real_type_mismatch_rejected() {
-        let descriptor =
-            RowDescriptor::new(vec![ColumnDescriptor::new("temperature", ColumnType::Real)]);
+        let descriptor = RowDescriptor::new(vec![ColumnDescriptor::new(
+            "temperature",
+            ColumnType::Double,
+        )]);
 
         let err = encode_row(&descriptor, &[Value::Integer(42)]).unwrap_err();
         assert!(matches!(err, EncodingError::TypeMismatch { .. }));

--- a/crates/jazz-tools/src/query_manager/encoding.rs
+++ b/crates/jazz-tools/src/query_manager/encoding.rs
@@ -132,6 +132,7 @@ fn value_matches_column_type(value: &Value, column_type: &ColumnType) -> bool {
     match column_type {
         ColumnType::Integer => matches!(value, Value::Integer(_)),
         ColumnType::BigInt => matches!(value, Value::BigInt(_)),
+        ColumnType::Real => matches!(value, Value::Real(_)),
         ColumnType::Boolean => matches!(value, Value::Boolean(_)),
         ColumnType::Timestamp => matches!(value, Value::Timestamp(_)),
         ColumnType::Uuid => matches!(value, Value::Uuid(_)),
@@ -179,6 +180,7 @@ fn encode_fixed_value(buf: &mut Vec<u8>, col: &ColumnDescriptor, val: &Value) {
     match val {
         Value::Integer(n) => buf.extend_from_slice(&n.to_le_bytes()),
         Value::BigInt(n) => buf.extend_from_slice(&n.to_le_bytes()),
+        Value::Real(f) => buf.extend_from_slice(&f.to_le_bytes()),
         Value::Boolean(b) => buf.push(if *b { 1 } else { 0 }),
         Value::Timestamp(t) => buf.extend_from_slice(&t.to_le_bytes()),
         Value::Uuid(id) => buf.extend_from_slice(id.uuid().as_bytes()),
@@ -271,6 +273,15 @@ pub fn decode_column(
             }
             let n = i64::from_le_bytes(bytes[..8].try_into().unwrap());
             Ok(Value::BigInt(n))
+        }
+        ColumnType::Real => {
+            if bytes.len() < 8 {
+                return Err(EncodingError::MalformedData {
+                    message: "real too short".into(),
+                });
+            }
+            let f = f64::from_le_bytes(bytes[..8].try_into().unwrap());
+            Ok(Value::Real(f))
         }
         ColumnType::Boolean => {
             if bytes.is_empty() {
@@ -518,6 +529,11 @@ pub fn compare_column(
             let n2 = i64::from_le_bytes(bytes2[..8].try_into().unwrap());
             Ok(n1.cmp(&n2))
         }
+        ColumnType::Real => {
+            let f1 = f64::from_le_bytes(bytes1[..8].try_into().unwrap());
+            let f2 = f64::from_le_bytes(bytes2[..8].try_into().unwrap());
+            Ok(f1.total_cmp(&f2))
+        }
         ColumnType::Boolean => {
             let b1 = bytes1[0] != 0;
             let b2 = bytes2[0] != 0;
@@ -565,6 +581,11 @@ pub fn compare_column_to_value(
             let n1 = i64::from_le_bytes(bytes[..8].try_into().unwrap());
             let n2 = i64::from_le_bytes(value[..8].try_into().unwrap());
             Ok(n1.cmp(&n2))
+        }
+        ColumnType::Real => {
+            let f1 = f64::from_le_bytes(bytes[..8].try_into().unwrap());
+            let f2 = f64::from_le_bytes(value[..8].try_into().unwrap());
+            Ok(f1.total_cmp(&f2))
         }
         ColumnType::Boolean => {
             let b1 = bytes[0] != 0;
@@ -616,6 +637,7 @@ pub fn encode_value(value: &Value) -> Vec<u8> {
     match value {
         Value::Integer(n) => n.to_le_bytes().to_vec(),
         Value::BigInt(n) => n.to_le_bytes().to_vec(),
+        Value::Real(f) => f.to_le_bytes().to_vec(),
         Value::Boolean(b) => vec![if *b { 1 } else { 0 }],
         Value::Timestamp(t) => t.to_le_bytes().to_vec(),
         Value::Uuid(id) => id.uuid().as_bytes().to_vec(),
@@ -825,6 +847,16 @@ fn decode_array_element(data: &[u8], element_type: &ColumnType) -> Result<Value,
                 });
             }
             Ok(Value::BigInt(i64::from_le_bytes(
+                data[..8].try_into().unwrap(),
+            )))
+        }
+        ColumnType::Real => {
+            if data.len() < 8 {
+                return Err(EncodingError::MalformedData {
+                    message: "real element too short".into(),
+                });
+            }
+            Ok(Value::Real(f64::from_le_bytes(
                 data[..8].try_into().unwrap(),
             )))
         }
@@ -1933,9 +1965,7 @@ mod tests {
     #[test]
     fn real_encode_decode_special_values() {
         // Exercise: zero, negative zero, infinity, negative infinity, NaN, subnormal
-        let descriptor = RowDescriptor::new(vec![
-            ColumnDescriptor::new("val", ColumnType::Real),
-        ]);
+        let descriptor = RowDescriptor::new(vec![ColumnDescriptor::new("val", ColumnType::Real)]);
 
         let cases: Vec<f64> = vec![
             0.0,
@@ -1943,9 +1973,9 @@ mod tests {
             f64::INFINITY,
             f64::NEG_INFINITY,
             f64::NAN,
-            f64::MIN_POSITIVE,  // smallest normal
-            5e-324,             // smallest subnormal
-            -5e-324,            // negative subnormal
+            f64::MIN_POSITIVE, // smallest normal
+            5e-324,            // smallest subnormal
+            -5e-324,           // negative subnormal
             f64::MAX,
             f64::MIN,
         ];
@@ -1990,9 +2020,8 @@ mod tests {
 
     #[test]
     fn real_type_mismatch_rejected() {
-        let descriptor = RowDescriptor::new(vec![
-            ColumnDescriptor::new("temperature", ColumnType::Real),
-        ]);
+        let descriptor =
+            RowDescriptor::new(vec![ColumnDescriptor::new("temperature", ColumnType::Real)]);
 
         let err = encode_row(&descriptor, &[Value::Integer(42)]).unwrap_err();
         assert!(matches!(err, EncodingError::TypeMismatch { .. }));

--- a/crates/jazz-tools/src/query_manager/encoding.rs
+++ b/crates/jazz-tools/src/query_manager/encoding.rs
@@ -1909,4 +1909,92 @@ mod tests {
         let err = decode_row(&descriptor, &encoded).unwrap_err();
         assert!(matches!(err, EncodingError::MalformedData { .. }));
     }
+
+    #[test]
+    fn real_encode_decode_roundtrip() {
+        let descriptor = RowDescriptor::new(vec![
+            ColumnDescriptor::new("name", ColumnType::Text),
+            ColumnDescriptor::new("temperature", ColumnType::Real),
+            ColumnDescriptor::new("pressure", ColumnType::Real),
+        ]);
+
+        let values = vec![
+            Value::Text("sensor-1".into()),
+            Value::Real(23.456),
+            Value::Real(-101.325),
+        ];
+
+        let encoded = encode_row(&descriptor, &values).unwrap();
+        let decoded = decode_row(&descriptor, &encoded).unwrap();
+
+        assert_eq!(values, decoded);
+    }
+
+    #[test]
+    fn real_encode_decode_special_values() {
+        // Exercise: zero, negative zero, infinity, negative infinity, NaN, subnormal
+        let descriptor = RowDescriptor::new(vec![
+            ColumnDescriptor::new("val", ColumnType::Real),
+        ]);
+
+        let cases: Vec<f64> = vec![
+            0.0,
+            -0.0,
+            f64::INFINITY,
+            f64::NEG_INFINITY,
+            f64::NAN,
+            f64::MIN_POSITIVE,  // smallest normal
+            5e-324,             // smallest subnormal
+            -5e-324,            // negative subnormal
+            f64::MAX,
+            f64::MIN,
+        ];
+
+        for val in cases {
+            let values = vec![Value::Real(val)];
+            let encoded = encode_row(&descriptor, &values).unwrap();
+            let decoded = decode_row(&descriptor, &encoded).unwrap();
+
+            match &decoded[0] {
+                Value::Real(decoded_val) => {
+                    // Bitwise comparison handles NaN and negative zero
+                    assert_eq!(
+                        val.to_bits(),
+                        decoded_val.to_bits(),
+                        "round-trip failed for {val}"
+                    );
+                }
+                other => panic!("expected Value::Real, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn real_nullable_encode_decode() {
+        let descriptor = RowDescriptor::new(vec![
+            ColumnDescriptor::new("score", ColumnType::Real).nullable(),
+        ]);
+
+        // With value
+        let values = vec![Value::Real(99.5)];
+        let encoded = encode_row(&descriptor, &values).unwrap();
+        let decoded = decode_row(&descriptor, &encoded).unwrap();
+        assert_eq!(values, decoded);
+
+        // With null
+        let nulls = vec![Value::Null];
+        let encoded = encode_row(&descriptor, &nulls).unwrap();
+        let decoded = decode_row(&descriptor, &encoded).unwrap();
+        assert_eq!(nulls, decoded);
+    }
+
+    #[test]
+    fn real_type_mismatch_rejected() {
+        let descriptor = RowDescriptor::new(vec![
+            ColumnDescriptor::new("temperature", ColumnType::Real),
+        ]);
+
+        let err = encode_row(&descriptor, &[Value::Integer(42)]).unwrap_err();
+        assert!(matches!(err, EncodingError::TypeMismatch { .. }));
+    }
 }

--- a/crates/jazz-tools/src/query_manager/types/branch.rs
+++ b/crates/jazz-tools/src/query_manager/types/branch.rs
@@ -245,7 +245,7 @@ fn hash_value(hasher: &mut blake3::Hasher, value: &Value) {
             hasher.update(&[2]);
             hasher.update(&v.to_le_bytes());
         }
-        Value::Real(v) => {
+        Value::Double(v) => {
             hasher.update(&[10]);
             hasher.update(&v.to_le_bytes());
         }
@@ -352,7 +352,7 @@ fn hash_column_type(hasher: &mut blake3::Hasher, col_type: &ColumnType) {
         ColumnType::BigInt => {
             hasher.update(&[2]);
         }
-        ColumnType::Real => {
+        ColumnType::Double => {
             hasher.update(&[10]);
         }
         ColumnType::Boolean => {

--- a/crates/jazz-tools/src/query_manager/types/branch.rs
+++ b/crates/jazz-tools/src/query_manager/types/branch.rs
@@ -245,6 +245,10 @@ fn hash_value(hasher: &mut blake3::Hasher, value: &Value) {
             hasher.update(&[2]);
             hasher.update(&v.to_le_bytes());
         }
+        Value::Real(v) => {
+            hasher.update(&[10]);
+            hasher.update(&v.to_le_bytes());
+        }
         Value::Boolean(v) => {
             hasher.update(&[3, *v as u8]);
         }
@@ -347,6 +351,9 @@ fn hash_column_type(hasher: &mut blake3::Hasher, col_type: &ColumnType) {
         }
         ColumnType::BigInt => {
             hasher.update(&[2]);
+        }
+        ColumnType::Real => {
+            hasher.update(&[10]);
         }
         ColumnType::Boolean => {
             hasher.update(&[3]);

--- a/crates/jazz-tools/src/query_manager/types/schema.rs
+++ b/crates/jazz-tools/src/query_manager/types/schema.rs
@@ -86,7 +86,7 @@ pub enum ColumnType {
     /// 8-byte unsigned timestamp (microseconds since Unix epoch).
     Timestamp,
     /// 8-byte IEEE 754 double-precision float (f64).
-    Real,
+    Double,
     /// 16-byte UUID (ObjectId).
     Uuid,
     /// Homogeneous array of values.
@@ -102,7 +102,7 @@ impl ColumnType {
         match self {
             ColumnType::Integer => Some(4),
             ColumnType::BigInt => Some(8),
-            ColumnType::Real => Some(8),
+            ColumnType::Double => Some(8),
             ColumnType::Boolean => Some(1),
             ColumnType::Timestamp => Some(8),
             ColumnType::Uuid => Some(16),

--- a/crates/jazz-tools/src/query_manager/types/schema.rs
+++ b/crates/jazz-tools/src/query_manager/types/schema.rs
@@ -85,6 +85,8 @@ pub enum ColumnType {
     Enum(Vec<String>),
     /// 8-byte unsigned timestamp (microseconds since Unix epoch).
     Timestamp,
+    /// 8-byte IEEE 754 double-precision float (f64).
+    Real,
     /// 16-byte UUID (ObjectId).
     Uuid,
     /// Homogeneous array of values.
@@ -100,6 +102,7 @@ impl ColumnType {
         match self {
             ColumnType::Integer => Some(4),
             ColumnType::BigInt => Some(8),
+            ColumnType::Real => Some(8),
             ColumnType::Boolean => Some(1),
             ColumnType::Timestamp => Some(8),
             ColumnType::Uuid => Some(16),

--- a/crates/jazz-tools/src/query_manager/types/value.rs
+++ b/crates/jazz-tools/src/query_manager/types/value.rs
@@ -6,10 +6,16 @@ use super::*;
 
 /// Value type for API boundary (insert input, query output).
 /// Internally, rows are stored as binary.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+///
+/// `PartialEq`/`Eq` are implemented manually because `f64` does not implement
+/// `Eq`. We use bitwise comparison (`f64::to_bits`) so that NaN == NaN and
+/// -0.0 != 0.0, which is the correct semantics for storage identity.
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum Value {
     Integer(i32),
     BigInt(i64),
+    /// 8-byte IEEE 754 double-precision float.
+    Real(f64),
     Boolean(bool),
     Text(String),
     Timestamp(u64),
@@ -22,6 +28,26 @@ pub enum Value {
     Null,
 }
 
+impl PartialEq for Value {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Value::Integer(a), Value::Integer(b)) => a == b,
+            (Value::BigInt(a), Value::BigInt(b)) => a == b,
+            (Value::Real(a), Value::Real(b)) => a.to_bits() == b.to_bits(),
+            (Value::Boolean(a), Value::Boolean(b)) => a == b,
+            (Value::Text(a), Value::Text(b)) => a == b,
+            (Value::Timestamp(a), Value::Timestamp(b)) => a == b,
+            (Value::Uuid(a), Value::Uuid(b)) => a == b,
+            (Value::Array(a), Value::Array(b)) => a == b,
+            (Value::Row(a), Value::Row(b)) => a == b,
+            (Value::Null, Value::Null) => true,
+            _ => false,
+        }
+    }
+}
+
+impl Eq for Value {}
+
 impl Value {
     /// Returns the column type this value represents, or None for Null/Row.
     /// Row returns None because its schema is external.
@@ -29,6 +55,7 @@ impl Value {
         match self {
             Value::Integer(_) => Some(ColumnType::Integer),
             Value::BigInt(_) => Some(ColumnType::BigInt),
+            Value::Real(_) => Some(ColumnType::Real),
             Value::Boolean(_) => Some(ColumnType::Boolean),
             Value::Text(_) => Some(ColumnType::Text),
             Value::Timestamp(_) => Some(ColumnType::Timestamp),

--- a/crates/jazz-tools/src/query_manager/types/value.rs
+++ b/crates/jazz-tools/src/query_manager/types/value.rs
@@ -15,7 +15,7 @@ pub enum Value {
     Integer(i32),
     BigInt(i64),
     /// 8-byte IEEE 754 double-precision float.
-    Real(f64),
+    Double(f64),
     Boolean(bool),
     Text(String),
     Timestamp(u64),
@@ -33,7 +33,7 @@ impl PartialEq for Value {
         match (self, other) {
             (Value::Integer(a), Value::Integer(b)) => a == b,
             (Value::BigInt(a), Value::BigInt(b)) => a == b,
-            (Value::Real(a), Value::Real(b)) => a.to_bits() == b.to_bits(),
+            (Value::Double(a), Value::Double(b)) => a.to_bits() == b.to_bits(),
             (Value::Boolean(a), Value::Boolean(b)) => a == b,
             (Value::Text(a), Value::Text(b)) => a == b,
             (Value::Timestamp(a), Value::Timestamp(b)) => a == b,
@@ -55,7 +55,7 @@ impl Value {
         match self {
             Value::Integer(_) => Some(ColumnType::Integer),
             Value::BigInt(_) => Some(ColumnType::BigInt),
-            Value::Real(_) => Some(ColumnType::Real),
+            Value::Double(_) => Some(ColumnType::Double),
             Value::Boolean(_) => Some(ColumnType::Boolean),
             Value::Text(_) => Some(ColumnType::Text),
             Value::Timestamp(_) => Some(ColumnType::Timestamp),

--- a/crates/jazz-tools/src/schema_manager/auto_lens.rs
+++ b/crates/jazz-tools/src/schema_manager/auto_lens.rs
@@ -187,6 +187,7 @@ fn default_for_type(column_type: &ColumnType, nullable: bool) -> Value {
     match column_type {
         ColumnType::Integer => Value::Integer(0),
         ColumnType::BigInt => Value::BigInt(0),
+        ColumnType::Real => Value::Real(0.0),
         ColumnType::Boolean => Value::Boolean(false),
         ColumnType::Text => Value::Text(String::new()),
         ColumnType::Enum(variants) => variants

--- a/crates/jazz-tools/src/schema_manager/auto_lens.rs
+++ b/crates/jazz-tools/src/schema_manager/auto_lens.rs
@@ -187,7 +187,7 @@ fn default_for_type(column_type: &ColumnType, nullable: bool) -> Value {
     match column_type {
         ColumnType::Integer => Value::Integer(0),
         ColumnType::BigInt => Value::BigInt(0),
-        ColumnType::Real => Value::Real(0.0),
+        ColumnType::Double => Value::Double(0.0),
         ColumnType::Boolean => Value::Boolean(false),
         ColumnType::Text => Value::Text(String::new()),
         ColumnType::Enum(variants) => variants

--- a/crates/jazz-tools/src/schema_manager/diff.rs
+++ b/crates/jazz-tools/src/schema_manager/diff.rs
@@ -255,6 +255,7 @@ fn default_for_type(ct: &ColumnType) -> Value {
     match ct {
         ColumnType::Integer => Value::Integer(0),
         ColumnType::BigInt => Value::BigInt(0),
+        ColumnType::Real => Value::Real(0.0),
         ColumnType::Boolean => Value::Boolean(false),
         ColumnType::Text => Value::Text(String::new()),
         ColumnType::Enum(variants) => variants

--- a/crates/jazz-tools/src/schema_manager/diff.rs
+++ b/crates/jazz-tools/src/schema_manager/diff.rs
@@ -255,7 +255,7 @@ fn default_for_type(ct: &ColumnType) -> Value {
     match ct {
         ColumnType::Integer => Value::Integer(0),
         ColumnType::BigInt => Value::BigInt(0),
-        ColumnType::Real => Value::Real(0.0),
+        ColumnType::Double => Value::Double(0.0),
         ColumnType::Boolean => Value::Boolean(false),
         ColumnType::Text => Value::Text(String::new()),
         ColumnType::Enum(variants) => variants

--- a/crates/jazz-tools/src/schema_manager/encoding.rs
+++ b/crates/jazz-tools/src/schema_manager/encoding.rs
@@ -249,11 +249,13 @@ const TYPE_UUID: u8 = 6;
 const TYPE_ARRAY: u8 = 7;
 const TYPE_ROW: u8 = 8;
 const TYPE_ENUM: u8 = 9;
+const TYPE_REAL: u8 = 10;
 
 fn encode_column_type(buf: &mut Vec<u8>, col_type: &ColumnType) {
     match col_type {
         ColumnType::Integer => buf.push(TYPE_INTEGER),
         ColumnType::BigInt => buf.push(TYPE_BIGINT),
+        ColumnType::Real => buf.push(TYPE_REAL),
         ColumnType::Boolean => buf.push(TYPE_BOOLEAN),
         ColumnType::Text => buf.push(TYPE_TEXT),
         ColumnType::Timestamp => buf.push(TYPE_TIMESTAMP),
@@ -284,6 +286,7 @@ fn decode_column_type(
     match tag {
         TYPE_INTEGER => Ok(ColumnType::Integer),
         TYPE_BIGINT => Ok(ColumnType::BigInt),
+        TYPE_REAL => Ok(ColumnType::Real),
         TYPE_BOOLEAN => Ok(ColumnType::Boolean),
         TYPE_TEXT => Ok(ColumnType::Text),
         TYPE_TIMESTAMP => Ok(ColumnType::Timestamp),
@@ -868,6 +871,9 @@ const VALUE_TIMESTAMP: u8 = 5;
 const VALUE_UUID: u8 = 6;
 const VALUE_ARRAY: u8 = 7;
 const VALUE_ROW: u8 = 8;
+// 9 intentionally skipped: TYPE_ENUM is 9, and Values have no Enum tag
+// (enum values are stored as Text). Keeping Real at 10 aligns with TYPE_REAL.
+const VALUE_REAL: u8 = 10;
 
 fn encode_value(buf: &mut Vec<u8>, value: &Value) {
     match value {
@@ -879,6 +885,10 @@ fn encode_value(buf: &mut Vec<u8>, value: &Value) {
         Value::BigInt(n) => {
             buf.push(VALUE_BIGINT);
             buf.extend_from_slice(&n.to_le_bytes());
+        }
+        Value::Real(f) => {
+            buf.push(VALUE_REAL);
+            buf.extend_from_slice(&f.to_le_bytes());
         }
         Value::Boolean(b) => {
             buf.push(VALUE_BOOLEAN);
@@ -926,6 +936,10 @@ fn decode_value(data: &[u8], offset: &mut usize) -> Result<Value, CatalogueEncod
         VALUE_BIGINT => {
             let bytes = read_bytes(data, offset, 8)?;
             Ok(Value::BigInt(i64::from_le_bytes(bytes.try_into().unwrap())))
+        }
+        VALUE_REAL => {
+            let bytes = read_bytes(data, offset, 8)?;
+            Ok(Value::Real(f64::from_le_bytes(bytes.try_into().unwrap())))
         }
         VALUE_BOOLEAN => {
             let b = read_u8(data, offset)?;

--- a/crates/jazz-tools/src/schema_manager/encoding.rs
+++ b/crates/jazz-tools/src/schema_manager/encoding.rs
@@ -249,13 +249,13 @@ const TYPE_UUID: u8 = 6;
 const TYPE_ARRAY: u8 = 7;
 const TYPE_ROW: u8 = 8;
 const TYPE_ENUM: u8 = 9;
-const TYPE_REAL: u8 = 10;
+const TYPE_DOUBLE: u8 = 10;
 
 fn encode_column_type(buf: &mut Vec<u8>, col_type: &ColumnType) {
     match col_type {
         ColumnType::Integer => buf.push(TYPE_INTEGER),
         ColumnType::BigInt => buf.push(TYPE_BIGINT),
-        ColumnType::Real => buf.push(TYPE_REAL),
+        ColumnType::Double => buf.push(TYPE_DOUBLE),
         ColumnType::Boolean => buf.push(TYPE_BOOLEAN),
         ColumnType::Text => buf.push(TYPE_TEXT),
         ColumnType::Timestamp => buf.push(TYPE_TIMESTAMP),
@@ -286,7 +286,7 @@ fn decode_column_type(
     match tag {
         TYPE_INTEGER => Ok(ColumnType::Integer),
         TYPE_BIGINT => Ok(ColumnType::BigInt),
-        TYPE_REAL => Ok(ColumnType::Real),
+        TYPE_DOUBLE => Ok(ColumnType::Double),
         TYPE_BOOLEAN => Ok(ColumnType::Boolean),
         TYPE_TEXT => Ok(ColumnType::Text),
         TYPE_TIMESTAMP => Ok(ColumnType::Timestamp),
@@ -872,8 +872,8 @@ const VALUE_UUID: u8 = 6;
 const VALUE_ARRAY: u8 = 7;
 const VALUE_ROW: u8 = 8;
 // 9 intentionally skipped: TYPE_ENUM is 9, and Values have no Enum tag
-// (enum values are stored as Text). Keeping Real at 10 aligns with TYPE_REAL.
-const VALUE_REAL: u8 = 10;
+// (enum values are stored as Text). Keeping Double at 10 aligns with TYPE_DOUBLE.
+const VALUE_DOUBLE: u8 = 10;
 
 fn encode_value(buf: &mut Vec<u8>, value: &Value) {
     match value {
@@ -886,8 +886,8 @@ fn encode_value(buf: &mut Vec<u8>, value: &Value) {
             buf.push(VALUE_BIGINT);
             buf.extend_from_slice(&n.to_le_bytes());
         }
-        Value::Real(f) => {
-            buf.push(VALUE_REAL);
+        Value::Double(f) => {
+            buf.push(VALUE_DOUBLE);
             buf.extend_from_slice(&f.to_le_bytes());
         }
         Value::Boolean(b) => {
@@ -937,9 +937,9 @@ fn decode_value(data: &[u8], offset: &mut usize) -> Result<Value, CatalogueEncod
             let bytes = read_bytes(data, offset, 8)?;
             Ok(Value::BigInt(i64::from_le_bytes(bytes.try_into().unwrap())))
         }
-        VALUE_REAL => {
+        VALUE_DOUBLE => {
             let bytes = read_bytes(data, offset, 8)?;
-            Ok(Value::Real(f64::from_le_bytes(bytes.try_into().unwrap())))
+            Ok(Value::Double(f64::from_le_bytes(bytes.try_into().unwrap())))
         }
         VALUE_BOOLEAN => {
             let b = read_u8(data, offset)?;

--- a/crates/jazz-tools/src/schema_manager/files.rs
+++ b/crates/jazz-tools/src/schema_manager/files.rs
@@ -551,7 +551,7 @@ fn value_to_ts_literal(value: &Value) -> String {
         Value::Boolean(b) => b.to_string(),
         Value::Integer(i) => i.to_string(),
         Value::BigInt(i) => i.to_string(),
-        Value::Real(f) => {
+        Value::Double(f) => {
             assert!(
                 f.is_finite(),
                 "non-finite float in value_to_ts_literal: {f}"
@@ -1084,12 +1084,12 @@ mod tests {
     #[test]
     #[should_panic(expected = "non-finite float")]
     fn value_to_ts_literal_rejects_infinity() {
-        value_to_ts_literal(&crate::query_manager::types::Value::Real(f64::INFINITY));
+        value_to_ts_literal(&crate::query_manager::types::Value::Double(f64::INFINITY));
     }
 
     #[test]
     #[should_panic(expected = "non-finite float")]
     fn value_to_ts_literal_rejects_nan() {
-        value_to_ts_literal(&crate::query_manager::types::Value::Real(f64::NAN));
+        value_to_ts_literal(&crate::query_manager::types::Value::Double(f64::NAN));
     }
 }

--- a/crates/jazz-tools/src/schema_manager/files.rs
+++ b/crates/jazz-tools/src/schema_manager/files.rs
@@ -551,6 +551,13 @@ fn value_to_ts_literal(value: &Value) -> String {
         Value::Boolean(b) => b.to_string(),
         Value::Integer(i) => i.to_string(),
         Value::BigInt(i) => i.to_string(),
+        Value::Real(f) => {
+            assert!(
+                f.is_finite(),
+                "non-finite float in value_to_ts_literal: {f}"
+            );
+            format!("{f:?}")
+        }
         Value::Text(s) => format!("\"{}\"", s.replace('\\', "\\\\").replace('"', "\\\"")),
         Value::Timestamp(t) => t.to_string(),
         Value::Uuid(u) => format!("\"{}\"", u.uuid()),
@@ -1072,5 +1079,17 @@ mod tests {
         assert!(ts.contains(
             "status: col.drop().enum(\"done\", \"todo\", { backwardsDefault: \"todo\" }),"
         ));
+    }
+
+    #[test]
+    #[should_panic(expected = "non-finite float")]
+    fn value_to_ts_literal_rejects_infinity() {
+        value_to_ts_literal(&crate::query_manager::types::Value::Real(f64::INFINITY));
+    }
+
+    #[test]
+    #[should_panic(expected = "non-finite float")]
+    fn value_to_ts_literal_rejects_nan() {
+        value_to_ts_literal(&crate::query_manager::types::Value::Real(f64::NAN));
     }
 }

--- a/crates/jazz-tools/src/schema_manager/sql.rs
+++ b/crates/jazz-tools/src/schema_manager/sql.rs
@@ -451,7 +451,7 @@ impl Parser {
                 "TEXT" | "VARCHAR" | "CHAR" | "STRING" => ColumnType::Text,
                 "INTEGER" | "INT" | "SMALLINT" | "TINYINT" => ColumnType::Integer,
                 "BIGINT" => ColumnType::BigInt,
-                "REAL" | "FLOAT" | "DOUBLE" => ColumnType::Real,
+                "REAL" | "FLOAT" | "DOUBLE" => ColumnType::Double,
                 "BOOLEAN" | "BOOL" => ColumnType::Boolean,
                 "TIMESTAMP" => ColumnType::Timestamp,
                 "UUID" => ColumnType::Uuid,
@@ -683,7 +683,7 @@ impl Parser {
             Some(Token::Number(n)) => {
                 if n.contains('.') {
                     if let Ok(f) = n.parse::<f64>() {
-                        Ok(Value::Real(f))
+                        Ok(Value::Double(f))
                     } else {
                         Err(SqlParseError::InvalidDefaultValue(format!(
                             "Cannot parse float: {}",
@@ -1288,7 +1288,7 @@ pub(crate) fn column_type_to_sql(ct: &ColumnType) -> String {
     match ct {
         ColumnType::Integer => "INTEGER".to_string(),
         ColumnType::BigInt => "BIGINT".to_string(),
-        ColumnType::Real => "REAL".to_string(),
+        ColumnType::Double => "REAL".to_string(),
         ColumnType::Boolean => "BOOLEAN".to_string(),
         ColumnType::Text => "TEXT".to_string(),
         ColumnType::Enum(variants) => {
@@ -1312,7 +1312,7 @@ fn value_to_sql(val: &Value) -> String {
         Value::Boolean(b) => if *b { "TRUE" } else { "FALSE" }.to_string(),
         Value::Integer(i) => i.to_string(),
         Value::BigInt(i) => i.to_string(),
-        Value::Real(f) => {
+        Value::Double(f) => {
             assert!(f.is_finite(), "non-finite float in value_to_sql: {f}");
             format!("{f:?}")
         }
@@ -2014,12 +2014,12 @@ mod tests {
 
         let temp = &table.descriptor.columns[0];
         assert_eq!(temp.name.as_str(), "temperature");
-        assert_eq!(temp.column_type, ColumnType::Real);
+        assert_eq!(temp.column_type, ColumnType::Double);
         assert!(!temp.nullable);
 
         let humidity = &table.descriptor.columns[1];
         assert_eq!(humidity.name.as_str(), "humidity");
-        assert_eq!(humidity.column_type, ColumnType::Real);
+        assert_eq!(humidity.column_type, ColumnType::Double);
         assert!(humidity.nullable);
     }
 
@@ -2035,8 +2035,8 @@ mod tests {
         let schema = parse_schema(sql).unwrap();
         let table = schema.get(&TableName::new("sensors")).unwrap();
 
-        assert_eq!(table.descriptor.columns[0].column_type, ColumnType::Real);
-        assert_eq!(table.descriptor.columns[1].column_type, ColumnType::Real);
+        assert_eq!(table.descriptor.columns[0].column_type, ColumnType::Double);
+        assert_eq!(table.descriptor.columns[1].column_type, ColumnType::Double);
     }
 
     #[test]
@@ -2087,8 +2087,8 @@ mod tests {
             } => {
                 assert_eq!(table, "sensors");
                 assert_eq!(column, "calibration");
-                assert_eq!(*column_type, ColumnType::Real);
-                assert_eq!(*default, Value::Real(0.0));
+                assert_eq!(*column_type, ColumnType::Double);
+                assert_eq!(*default, Value::Double(0.0));
             }
             _ => panic!("Expected AddColumn"),
         }
@@ -2107,13 +2107,13 @@ mod tests {
     #[test]
     #[should_panic(expected = "non-finite float")]
     fn value_to_sql_rejects_infinity() {
-        value_to_sql(&Value::Real(f64::INFINITY));
+        value_to_sql(&Value::Double(f64::INFINITY));
     }
 
     #[test]
     #[should_panic(expected = "non-finite float")]
     fn value_to_sql_rejects_nan() {
-        value_to_sql(&Value::Real(f64::NAN));
+        value_to_sql(&Value::Double(f64::NAN));
     }
 
     #[test]
@@ -2129,7 +2129,7 @@ mod tests {
 
         assert_eq!(
             col.column_type,
-            ColumnType::Array(Box::new(ColumnType::Real))
+            ColumnType::Array(Box::new(ColumnType::Double))
         );
         assert!(!col.nullable);
     }

--- a/crates/jazz-tools/src/schema_manager/sql.rs
+++ b/crates/jazz-tools/src/schema_manager/sql.rs
@@ -451,6 +451,7 @@ impl Parser {
                 "TEXT" | "VARCHAR" | "CHAR" | "STRING" => ColumnType::Text,
                 "INTEGER" | "INT" | "SMALLINT" | "TINYINT" => ColumnType::Integer,
                 "BIGINT" => ColumnType::BigInt,
+                "REAL" | "FLOAT" | "DOUBLE" => ColumnType::Real,
                 "BOOLEAN" | "BOOL" => ColumnType::Boolean,
                 "TIMESTAMP" => ColumnType::Timestamp,
                 "UUID" => ColumnType::Uuid,
@@ -680,7 +681,16 @@ impl Parser {
             Some(Token::True) => Ok(Value::Boolean(true)),
             Some(Token::False) => Ok(Value::Boolean(false)),
             Some(Token::Number(n)) => {
-                if let Ok(i) = n.parse::<i32>() {
+                if n.contains('.') {
+                    if let Ok(f) = n.parse::<f64>() {
+                        Ok(Value::Real(f))
+                    } else {
+                        Err(SqlParseError::InvalidDefaultValue(format!(
+                            "Cannot parse float: {}",
+                            n
+                        )))
+                    }
+                } else if let Ok(i) = n.parse::<i32>() {
                     Ok(Value::Integer(i))
                 } else if let Ok(i) = n.parse::<i64>() {
                     Ok(Value::BigInt(i))
@@ -1278,6 +1288,7 @@ pub(crate) fn column_type_to_sql(ct: &ColumnType) -> String {
     match ct {
         ColumnType::Integer => "INTEGER".to_string(),
         ColumnType::BigInt => "BIGINT".to_string(),
+        ColumnType::Real => "REAL".to_string(),
         ColumnType::Boolean => "BOOLEAN".to_string(),
         ColumnType::Text => "TEXT".to_string(),
         ColumnType::Enum(variants) => {
@@ -1301,6 +1312,10 @@ fn value_to_sql(val: &Value) -> String {
         Value::Boolean(b) => if *b { "TRUE" } else { "FALSE" }.to_string(),
         Value::Integer(i) => i.to_string(),
         Value::BigInt(i) => i.to_string(),
+        Value::Real(f) => {
+            assert!(f.is_finite(), "non-finite float in value_to_sql: {f}");
+            format!("{f:?}")
+        }
         Value::Text(s) => format!("'{}'", s.replace('\'', "''")),
         Value::Timestamp(t) => t.to_string(),
         Value::Uuid(id) => format!("'{:?}'", id),
@@ -2077,6 +2092,28 @@ mod tests {
             }
             _ => panic!("Expected AddColumn"),
         }
+    }
+
+    #[test]
+    fn parse_non_finite_float_default_rejected() {
+        // The tokeniser treats inf/NaN as identifiers, not numbers, so these
+        // are rejected at parse time before reaching the value constructor.
+        for literal in &["inf", "-inf", "NaN"] {
+            let sql = format!("ALTER TABLE t ADD COLUMN x REAL DEFAULT {literal};");
+            assert!(parse_lens(&sql).is_err(), "should reject {literal}");
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "non-finite float")]
+    fn value_to_sql_rejects_infinity() {
+        value_to_sql(&Value::Real(f64::INFINITY));
+    }
+
+    #[test]
+    #[should_panic(expected = "non-finite float")]
+    fn value_to_sql_rejects_nan() {
+        value_to_sql(&Value::Real(f64::NAN));
     }
 
     #[test]

--- a/crates/jazz-tools/src/schema_manager/sql.rs
+++ b/crates/jazz-tools/src/schema_manager/sql.rs
@@ -1982,4 +1982,118 @@ mod tests {
         assert_eq!(owner.references, Some(TableName::new("users")));
         assert!(!owner.nullable);
     }
+
+    #[test]
+    fn parse_real_column_type() {
+        let sql = r#"
+            CREATE TABLE measurements (
+                temperature REAL NOT NULL,
+                humidity REAL
+            );
+        "#;
+
+        let schema = parse_schema(sql).unwrap();
+        let table = schema.get(&TableName::new("measurements")).unwrap();
+
+        assert_eq!(table.descriptor.columns.len(), 2);
+
+        let temp = &table.descriptor.columns[0];
+        assert_eq!(temp.name.as_str(), "temperature");
+        assert_eq!(temp.column_type, ColumnType::Real);
+        assert!(!temp.nullable);
+
+        let humidity = &table.descriptor.columns[1];
+        assert_eq!(humidity.name.as_str(), "humidity");
+        assert_eq!(humidity.column_type, ColumnType::Real);
+        assert!(humidity.nullable);
+    }
+
+    #[test]
+    fn parse_float_and_double_as_real_aliases() {
+        let sql = r#"
+            CREATE TABLE sensors (
+                pressure FLOAT NOT NULL,
+                altitude DOUBLE NOT NULL
+            );
+        "#;
+
+        let schema = parse_schema(sql).unwrap();
+        let table = schema.get(&TableName::new("sensors")).unwrap();
+
+        assert_eq!(table.descriptor.columns[0].column_type, ColumnType::Real);
+        assert_eq!(table.descriptor.columns[1].column_type, ColumnType::Real);
+    }
+
+    #[test]
+    fn sql_round_trip_with_real() {
+        let sql = r#"CREATE TABLE measurements (
+    temperature REAL NOT NULL,
+    humidity REAL
+);"#;
+
+        let schema = parse_schema(sql).unwrap();
+        let regenerated = schema_to_sql(&schema);
+        let reparsed = parse_schema(&regenerated).unwrap();
+
+        let orig = schema.get(&TableName::new("measurements")).unwrap();
+        let round = reparsed.get(&TableName::new("measurements")).unwrap();
+
+        assert_eq!(
+            orig.descriptor.columns.len(),
+            round.descriptor.columns.len()
+        );
+        assert_eq!(
+            orig.descriptor.columns[0].column_type,
+            round.descriptor.columns[0].column_type
+        );
+        assert_eq!(
+            orig.descriptor.columns[1].column_type,
+            round.descriptor.columns[1].column_type
+        );
+        assert_eq!(
+            orig.descriptor.columns[1].nullable,
+            round.descriptor.columns[1].nullable
+        );
+    }
+
+    #[test]
+    fn parse_lens_add_real_column_with_default() {
+        let sql = "ALTER TABLE sensors ADD COLUMN calibration REAL DEFAULT 0.0;";
+
+        let transform = parse_lens(sql).unwrap();
+        assert_eq!(transform.ops.len(), 1);
+
+        match &transform.ops[0] {
+            LensOp::AddColumn {
+                table,
+                column,
+                column_type,
+                default,
+            } => {
+                assert_eq!(table, "sensors");
+                assert_eq!(column, "calibration");
+                assert_eq!(*column_type, ColumnType::Real);
+                assert_eq!(*default, Value::Real(0.0));
+            }
+            _ => panic!("Expected AddColumn"),
+        }
+    }
+
+    #[test]
+    fn parse_real_array_column() {
+        let sql = "CREATE TABLE timeseries (samples REAL[] NOT NULL);";
+
+        let schema = parse_schema(sql).unwrap();
+        let col = &schema
+            .get(&TableName::new("timeseries"))
+            .unwrap()
+            .descriptor
+            .columns[0];
+
+        assert_eq!(
+            col.column_type,
+            ColumnType::Array(Box::new(ColumnType::Real))
+        );
+        assert!(!col.nullable);
+    }
 }

--- a/crates/jazz-tools/src/storage/key_codec.rs
+++ b/crates/jazz-tools/src/storage/key_codec.rs
@@ -79,14 +79,14 @@ pub(super) fn index_range_scan_bounds(
 
     // IEEE 754: -0.0 == 0.0 but they encode differently. Adjust bounds
     // so both zeros are treated as the same point.
-    let neg_zero = Value::Real(-0.0);
-    let pos_zero = Value::Real(0.0);
+    let neg_zero = Value::Double(-0.0);
+    let pos_zero = Value::Double(0.0);
 
     let start_key = match start {
-        Bound::Included(v) if super::is_real_zero(v) => {
+        Bound::Included(v) if super::is_double_zero(v) => {
             format!("{}{}", base_prefix, hex::encode(encode_value(&neg_zero)))
         }
-        Bound::Excluded(v) if super::is_real_zero(v) => {
+        Bound::Excluded(v) if super::is_double_zero(v) => {
             let encoded = hex::encode(encode_value(&pos_zero));
             let mut key = format!("{}{}:", base_prefix, encoded);
             increment_string(&mut key);
@@ -103,13 +103,13 @@ pub(super) fn index_range_scan_bounds(
     };
 
     let end_key = match end {
-        Bound::Included(v) if super::is_real_zero(v) => {
+        Bound::Included(v) if super::is_double_zero(v) => {
             let encoded = hex::encode(encode_value(&pos_zero));
             let mut key = format!("{}{}:", base_prefix, encoded);
             increment_string(&mut key);
             key
         }
-        Bound::Excluded(v) if super::is_real_zero(v) => {
+        Bound::Excluded(v) if super::is_double_zero(v) => {
             format!("{}{}", base_prefix, hex::encode(encode_value(&neg_zero)))
         }
         Bound::Included(v) => {

--- a/crates/jazz-tools/src/storage/key_codec.rs
+++ b/crates/jazz-tools/src/storage/key_codec.rs
@@ -77,7 +77,21 @@ pub(super) fn index_range_scan_bounds(
 ) -> Option<(String, String)> {
     let base_prefix = index_prefix(table, column, branch);
 
+    // IEEE 754: -0.0 == 0.0 but they encode differently. Adjust bounds
+    // so both zeros are treated as the same point.
+    let neg_zero = Value::Real(-0.0);
+    let pos_zero = Value::Real(0.0);
+
     let start_key = match start {
+        Bound::Included(v) if super::is_real_zero(v) => {
+            format!("{}{}", base_prefix, hex::encode(encode_value(&neg_zero)))
+        }
+        Bound::Excluded(v) if super::is_real_zero(v) => {
+            let encoded = hex::encode(encode_value(&pos_zero));
+            let mut key = format!("{}{}:", base_prefix, encoded);
+            increment_string(&mut key);
+            key
+        }
         Bound::Included(v) => format!("{}{}", base_prefix, hex::encode(encode_value(v))),
         Bound::Excluded(v) => {
             let encoded = hex::encode(encode_value(v));
@@ -89,6 +103,15 @@ pub(super) fn index_range_scan_bounds(
     };
 
     let end_key = match end {
+        Bound::Included(v) if super::is_real_zero(v) => {
+            let encoded = hex::encode(encode_value(&pos_zero));
+            let mut key = format!("{}{}:", base_prefix, encoded);
+            increment_string(&mut key);
+            key
+        }
+        Bound::Excluded(v) if super::is_real_zero(v) => {
+            format!("{}{}", base_prefix, hex::encode(encode_value(&neg_zero)))
+        }
         Bound::Included(v) => {
             let encoded = hex::encode(encode_value(v));
             let mut key = format!("{}{}:", base_prefix, encoded);

--- a/crates/jazz-tools/src/storage/mod.rs
+++ b/crates/jazz-tools/src/storage/mod.rs
@@ -761,4 +761,129 @@ mod tests {
         assert!(int_neg < int_zero);
         assert!(int_zero < int_pos);
     }
+
+    #[test]
+    fn real_encode_value_ordering() {
+        let neg_inf = encode_value(&Value::Real(f64::NEG_INFINITY));
+        let neg_big = encode_value(&Value::Real(-1000.0));
+        let neg_small = encode_value(&Value::Real(-0.001));
+        let neg_zero = encode_value(&Value::Real(-0.0));
+        let pos_zero = encode_value(&Value::Real(0.0));
+        let pos_small = encode_value(&Value::Real(0.001));
+        let pos_big = encode_value(&Value::Real(1000.0));
+        let pos_inf = encode_value(&Value::Real(f64::INFINITY));
+
+        assert!(neg_inf < neg_big);
+        assert!(neg_big < neg_small);
+        assert!(neg_small < neg_zero);
+        assert!(neg_zero < pos_zero);
+        assert!(pos_zero < pos_small);
+        assert!(pos_small < pos_big);
+        assert!(pos_big < pos_inf);
+    }
+
+    #[test]
+    fn real_cross_type_ordering() {
+        // Real should sort after all existing types (tag 0x09 > 0x08)
+        let row = encode_value(&Value::Row(vec![]));
+        let real = encode_value(&Value::Real(0.0));
+
+        assert!(row < real);
+    }
+
+    // ----------------------------------------------------------------
+    // Negative zero IEEE 754 semantics: -0.0 and 0.0 are equal per the
+    // standard, so index lookups and range queries must treat them as
+    // the same value even though they have distinct bit patterns.
+    // ----------------------------------------------------------------
+
+    #[test]
+    fn real_negative_zero_exact_lookup() {
+        // Store a value as -0.0, look it up with 0.0 (and vice versa).
+        let mut storage = MemoryStorage::new();
+
+        let row_neg = ObjectId::new();
+        let row_pos = ObjectId::new();
+
+        storage
+            .index_insert("prices", "amount", "main", &Value::Real(-0.0), row_neg)
+            .unwrap();
+        storage
+            .index_insert("prices", "amount", "main", &Value::Real(0.0), row_pos)
+            .unwrap();
+
+        // Looking up 0.0 should find both (IEEE 754: -0.0 == 0.0)
+        let results = storage.index_lookup("prices", "amount", "main", &Value::Real(0.0));
+        assert_eq!(results.len(), 2, "lookup 0.0 should match both zeros");
+        assert!(results.contains(&row_neg));
+        assert!(results.contains(&row_pos));
+
+        // Looking up -0.0 should also find both
+        let results = storage.index_lookup("prices", "amount", "main", &Value::Real(-0.0));
+        assert_eq!(results.len(), 2, "lookup -0.0 should match both zeros");
+        assert!(results.contains(&row_neg));
+        assert!(results.contains(&row_pos));
+    }
+
+    #[test]
+    fn real_negative_zero_range_gte() {
+        // WHERE amount >= 0.0 should include -0.0 (equal per IEEE 754)
+        let mut storage = MemoryStorage::new();
+
+        let row_neg_zero = ObjectId::new();
+        let row_pos_zero = ObjectId::new();
+        let row_negative = ObjectId::new();
+
+        storage
+            .index_insert("prices", "amount", "main", &Value::Real(-0.0), row_neg_zero)
+            .unwrap();
+        storage
+            .index_insert("prices", "amount", "main", &Value::Real(0.0), row_pos_zero)
+            .unwrap();
+        storage
+            .index_insert("prices", "amount", "main", &Value::Real(-1.0), row_negative)
+            .unwrap();
+
+        // >= 0.0 should include -0.0 and 0.0, but not -1.0
+        let results = storage.index_range(
+            "prices",
+            "amount",
+            "main",
+            Bound::Included(&Value::Real(0.0)),
+            Bound::Unbounded,
+        );
+        assert!(results.contains(&row_neg_zero), ">= 0.0 should include -0.0");
+        assert!(results.contains(&row_pos_zero), ">= 0.0 should include 0.0");
+        assert!(!results.contains(&row_negative), ">= 0.0 should exclude -1.0");
+    }
+
+    #[test]
+    fn real_negative_zero_range_lt() {
+        // WHERE amount < 0.0 should exclude -0.0 (equal per IEEE 754, not strictly less)
+        let mut storage = MemoryStorage::new();
+
+        let row_neg_zero = ObjectId::new();
+        let row_negative = ObjectId::new();
+
+        storage
+            .index_insert("prices", "amount", "main", &Value::Real(-0.0), row_neg_zero)
+            .unwrap();
+        storage
+            .index_insert("prices", "amount", "main", &Value::Real(-1.0), row_negative)
+            .unwrap();
+
+        // < 0.0 should exclude -0.0 but include -1.0
+        let results = storage.index_range(
+            "prices",
+            "amount",
+            "main",
+            Bound::Unbounded,
+            Bound::Excluded(&Value::Real(0.0)),
+        );
+        assert!(
+            !results.contains(&row_neg_zero),
+            "< 0.0 should exclude -0.0"
+        );
+        assert!(results.contains(&row_negative), "< 0.0 should include -1.0");
+    }
 }

--- a/crates/jazz-tools/src/storage/mod.rs
+++ b/crates/jazz-tools/src/storage/mod.rs
@@ -238,12 +238,12 @@ impl MemoryStorage {
 // Values must be encoded so lexicographic byte ordering equals semantic ordering.
 // This enables range queries via BTreeMap::range().
 
-/// Returns true if the value is Real(0.0) or Real(-0.0).
+/// Returns true if the value is Double(0.0) or Double(-0.0).
 ///
 /// IEEE 754 defines -0.0 == 0.0, but they have distinct bit patterns and
 /// therefore distinct index encodings. Query operations must check both.
-pub(crate) fn is_real_zero(value: &Value) -> bool {
-    matches!(value, Value::Real(f) if *f == 0.0)
+pub(crate) fn is_double_zero(value: &Value) -> bool {
+    matches!(value, Value::Double(f) if *f == 0.0)
 }
 
 /// Encode a Value into bytes that sort correctly for range queries.
@@ -270,7 +270,7 @@ pub(crate) fn encode_value(value: &Value) -> Vec<u8> {
             bytes
         }
 
-        Value::Real(f) => {
+        Value::Double(f) => {
             let mut bytes = vec![0x09];
             let bits = f.to_bits();
             // Flip for lexicographic ordering: if sign bit set, flip all bits;
@@ -496,9 +496,9 @@ impl Storage for MemoryStorage {
         };
 
         // IEEE 754: -0.0 == 0.0, so look up both encodings and merge.
-        if is_real_zero(value) {
+        if is_double_zero(value) {
             let mut result = HashSet::new();
-            for zero in &[Value::Real(0.0), Value::Real(-0.0)] {
+            for zero in &[Value::Double(0.0), Value::Double(-0.0)] {
                 if let Some(ids) = index.get(&encode_value(zero)) {
                     result.extend(ids.iter().copied());
                 }
@@ -534,22 +534,22 @@ impl Storage for MemoryStorage {
         //   End Included(zero)   → use +0.0 (widen to include the greater encoding)
         //   End Excluded(zero)   → use -0.0 (stop before both encodings)
         let start_bound = match start {
-            Bound::Included(v) if is_real_zero(v) => {
-                Bound::Included(encode_value(&Value::Real(-0.0)))
+            Bound::Included(v) if is_double_zero(v) => {
+                Bound::Included(encode_value(&Value::Double(-0.0)))
             }
-            Bound::Excluded(v) if is_real_zero(v) => {
-                Bound::Excluded(encode_value(&Value::Real(0.0)))
+            Bound::Excluded(v) if is_double_zero(v) => {
+                Bound::Excluded(encode_value(&Value::Double(0.0)))
             }
             Bound::Included(v) => Bound::Included(encode_value(v)),
             Bound::Excluded(v) => Bound::Excluded(encode_value(v)),
             Bound::Unbounded => Bound::Unbounded,
         };
         let end_bound = match end {
-            Bound::Included(v) if is_real_zero(v) => {
-                Bound::Included(encode_value(&Value::Real(0.0)))
+            Bound::Included(v) if is_double_zero(v) => {
+                Bound::Included(encode_value(&Value::Double(0.0)))
             }
-            Bound::Excluded(v) if is_real_zero(v) => {
-                Bound::Excluded(encode_value(&Value::Real(-0.0)))
+            Bound::Excluded(v) if is_double_zero(v) => {
+                Bound::Excluded(encode_value(&Value::Double(-0.0)))
             }
             Bound::Included(v) => Bound::Included(encode_value(v)),
             Bound::Excluded(v) => Bound::Excluded(encode_value(v)),
@@ -817,14 +817,14 @@ mod tests {
 
     #[test]
     fn real_encode_value_ordering() {
-        let neg_inf = encode_value(&Value::Real(f64::NEG_INFINITY));
-        let neg_big = encode_value(&Value::Real(-1000.0));
-        let neg_small = encode_value(&Value::Real(-0.001));
-        let neg_zero = encode_value(&Value::Real(-0.0));
-        let pos_zero = encode_value(&Value::Real(0.0));
-        let pos_small = encode_value(&Value::Real(0.001));
-        let pos_big = encode_value(&Value::Real(1000.0));
-        let pos_inf = encode_value(&Value::Real(f64::INFINITY));
+        let neg_inf = encode_value(&Value::Double(f64::NEG_INFINITY));
+        let neg_big = encode_value(&Value::Double(-1000.0));
+        let neg_small = encode_value(&Value::Double(-0.001));
+        let neg_zero = encode_value(&Value::Double(-0.0));
+        let pos_zero = encode_value(&Value::Double(0.0));
+        let pos_small = encode_value(&Value::Double(0.001));
+        let pos_big = encode_value(&Value::Double(1000.0));
+        let pos_inf = encode_value(&Value::Double(f64::INFINITY));
 
         assert!(neg_inf < neg_big);
         assert!(neg_big < neg_small);
@@ -837,11 +837,11 @@ mod tests {
 
     #[test]
     fn real_cross_type_ordering() {
-        // Real should sort after all existing types (tag 0x09 > 0x08)
+        // Double should sort after all existing types (tag 0x09 > 0x08)
         let row = encode_value(&Value::Row(vec![]));
-        let real = encode_value(&Value::Real(0.0));
+        let double = encode_value(&Value::Double(0.0));
 
-        assert!(row < real);
+        assert!(row < double);
     }
 
     // ----------------------------------------------------------------
@@ -859,20 +859,20 @@ mod tests {
         let row_pos = ObjectId::new();
 
         storage
-            .index_insert("prices", "amount", "main", &Value::Real(-0.0), row_neg)
+            .index_insert("prices", "amount", "main", &Value::Double(-0.0), row_neg)
             .unwrap();
         storage
-            .index_insert("prices", "amount", "main", &Value::Real(0.0), row_pos)
+            .index_insert("prices", "amount", "main", &Value::Double(0.0), row_pos)
             .unwrap();
 
         // Looking up 0.0 should find both (IEEE 754: -0.0 == 0.0)
-        let results = storage.index_lookup("prices", "amount", "main", &Value::Real(0.0));
+        let results = storage.index_lookup("prices", "amount", "main", &Value::Double(0.0));
         assert_eq!(results.len(), 2, "lookup 0.0 should match both zeros");
         assert!(results.contains(&row_neg));
         assert!(results.contains(&row_pos));
 
         // Looking up -0.0 should also find both
-        let results = storage.index_lookup("prices", "amount", "main", &Value::Real(-0.0));
+        let results = storage.index_lookup("prices", "amount", "main", &Value::Double(-0.0));
         assert_eq!(results.len(), 2, "lookup -0.0 should match both zeros");
         assert!(results.contains(&row_neg));
         assert!(results.contains(&row_pos));
@@ -888,13 +888,31 @@ mod tests {
         let row_negative = ObjectId::new();
 
         storage
-            .index_insert("prices", "amount", "main", &Value::Real(-0.0), row_neg_zero)
+            .index_insert(
+                "prices",
+                "amount",
+                "main",
+                &Value::Double(-0.0),
+                row_neg_zero,
+            )
             .unwrap();
         storage
-            .index_insert("prices", "amount", "main", &Value::Real(0.0), row_pos_zero)
+            .index_insert(
+                "prices",
+                "amount",
+                "main",
+                &Value::Double(0.0),
+                row_pos_zero,
+            )
             .unwrap();
         storage
-            .index_insert("prices", "amount", "main", &Value::Real(-1.0), row_negative)
+            .index_insert(
+                "prices",
+                "amount",
+                "main",
+                &Value::Double(-1.0),
+                row_negative,
+            )
             .unwrap();
 
         // >= 0.0 should include -0.0 and 0.0, but not -1.0
@@ -902,7 +920,7 @@ mod tests {
             "prices",
             "amount",
             "main",
-            Bound::Included(&Value::Real(0.0)),
+            Bound::Included(&Value::Double(0.0)),
             Bound::Unbounded,
         );
         assert!(
@@ -925,10 +943,22 @@ mod tests {
         let row_negative = ObjectId::new();
 
         storage
-            .index_insert("prices", "amount", "main", &Value::Real(-0.0), row_neg_zero)
+            .index_insert(
+                "prices",
+                "amount",
+                "main",
+                &Value::Double(-0.0),
+                row_neg_zero,
+            )
             .unwrap();
         storage
-            .index_insert("prices", "amount", "main", &Value::Real(-1.0), row_negative)
+            .index_insert(
+                "prices",
+                "amount",
+                "main",
+                &Value::Double(-1.0),
+                row_negative,
+            )
             .unwrap();
 
         // < 0.0 should exclude -0.0 but include -1.0
@@ -937,7 +967,7 @@ mod tests {
             "amount",
             "main",
             Bound::Unbounded,
-            Bound::Excluded(&Value::Real(0.0)),
+            Bound::Excluded(&Value::Double(0.0)),
         );
         assert!(
             !results.contains(&row_neg_zero),

--- a/crates/jazz-tools/src/storage/mod.rs
+++ b/crates/jazz-tools/src/storage/mod.rs
@@ -238,6 +238,14 @@ impl MemoryStorage {
 // Values must be encoded so lexicographic byte ordering equals semantic ordering.
 // This enables range queries via BTreeMap::range().
 
+/// Returns true if the value is Real(0.0) or Real(-0.0).
+///
+/// IEEE 754 defines -0.0 == 0.0, but they have distinct bit patterns and
+/// therefore distinct index encodings. Query operations must check both.
+pub(crate) fn is_real_zero(value: &Value) -> bool {
+    matches!(value, Value::Real(f) if *f == 0.0)
+}
+
 /// Encode a Value into bytes that sort correctly for range queries.
 pub(crate) fn encode_value(value: &Value) -> Vec<u8> {
     match value {
@@ -259,6 +267,20 @@ pub(crate) fn encode_value(value: &Value) -> Vec<u8> {
             // Flip sign bit so negative < positive, big-endian for correct ordering
             let mut bytes = vec![0x03];
             bytes.extend_from_slice(&(*n ^ i64::MIN).to_be_bytes());
+            bytes
+        }
+
+        Value::Real(f) => {
+            let mut bytes = vec![0x09];
+            let bits = f.to_bits();
+            // Flip for lexicographic ordering: if sign bit set, flip all bits;
+            // otherwise flip only the sign bit.
+            let ordered = if bits & (1u64 << 63) != 0 {
+                !bits
+            } else {
+                bits ^ (1u64 << 63)
+            };
+            bytes.extend_from_slice(&ordered.to_be_bytes());
             bytes
         }
 
@@ -472,6 +494,18 @@ impl Storage for MemoryStorage {
         let Some(index) = self.indices.get(&key) else {
             return Vec::new();
         };
+
+        // IEEE 754: -0.0 == 0.0, so look up both encodings and merge.
+        if is_real_zero(value) {
+            let mut result = HashSet::new();
+            for zero in &[Value::Real(0.0), Value::Real(-0.0)] {
+                if let Some(ids) = index.get(&encode_value(zero)) {
+                    result.extend(ids.iter().copied());
+                }
+            }
+            return result.into_iter().collect();
+        }
+
         let encoded = encode_value(value);
         index
             .get(&encoded)
@@ -492,12 +526,31 @@ impl Storage for MemoryStorage {
             return Vec::new();
         };
 
+        // IEEE 754: -0.0 == 0.0 but they have distinct encodings where
+        // encoded(-0.0) < encoded(+0.0). Adjust bounds so that both zeros
+        // are treated as the same point:
+        //   Start Included(zero) → use -0.0 (widen to include the lesser encoding)
+        //   Start Excluded(zero) → use +0.0 (skip past both encodings)
+        //   End Included(zero)   → use +0.0 (widen to include the greater encoding)
+        //   End Excluded(zero)   → use -0.0 (stop before both encodings)
         let start_bound = match start {
+            Bound::Included(v) if is_real_zero(v) => {
+                Bound::Included(encode_value(&Value::Real(-0.0)))
+            }
+            Bound::Excluded(v) if is_real_zero(v) => {
+                Bound::Excluded(encode_value(&Value::Real(0.0)))
+            }
             Bound::Included(v) => Bound::Included(encode_value(v)),
             Bound::Excluded(v) => Bound::Excluded(encode_value(v)),
             Bound::Unbounded => Bound::Unbounded,
         };
         let end_bound = match end {
+            Bound::Included(v) if is_real_zero(v) => {
+                Bound::Included(encode_value(&Value::Real(0.0)))
+            }
+            Bound::Excluded(v) if is_real_zero(v) => {
+                Bound::Excluded(encode_value(&Value::Real(-0.0)))
+            }
             Bound::Included(v) => Bound::Included(encode_value(v)),
             Bound::Excluded(v) => Bound::Excluded(encode_value(v)),
             Bound::Unbounded => Bound::Unbounded,
@@ -852,9 +905,15 @@ mod tests {
             Bound::Included(&Value::Real(0.0)),
             Bound::Unbounded,
         );
-        assert!(results.contains(&row_neg_zero), ">= 0.0 should include -0.0");
+        assert!(
+            results.contains(&row_neg_zero),
+            ">= 0.0 should include -0.0"
+        );
         assert!(results.contains(&row_pos_zero), ">= 0.0 should include 0.0");
-        assert!(!results.contains(&row_negative), ">= 0.0 should exclude -1.0");
+        assert!(
+            !results.contains(&row_negative),
+            ">= 0.0 should exclude -1.0"
+        );
     }
 
     #[test]

--- a/crates/jazz-tools/src/storage/storage_core.rs
+++ b/crates/jazz-tools/src/storage/storage_core.rs
@@ -202,6 +202,22 @@ pub(super) fn index_lookup_core(
     value: &Value,
     mut scan_prefix_keys: impl FnMut(&str) -> Result<Vec<String>, StorageError>,
 ) -> Vec<ObjectId> {
+    // IEEE 754: -0.0 == 0.0, so scan both prefixes and merge.
+    if super::is_real_zero(value) {
+        let mut result = HashSet::new();
+        for zero in &[Value::Real(0.0), Value::Real(-0.0)] {
+            let prefix = index_value_prefix(table, column, branch, zero);
+            if let Ok(keys) = scan_prefix_keys(&prefix) {
+                for key in &keys {
+                    if let Some(id) = parse_uuid_from_index_key(key) {
+                        result.insert(id);
+                    }
+                }
+            }
+        }
+        return result.into_iter().collect();
+    }
+
     let prefix = index_value_prefix(table, column, branch, value);
     scan_prefix_keys(&prefix)
         .map(|keys| {

--- a/crates/jazz-tools/src/storage/storage_core.rs
+++ b/crates/jazz-tools/src/storage/storage_core.rs
@@ -203,9 +203,9 @@ pub(super) fn index_lookup_core(
     mut scan_prefix_keys: impl FnMut(&str) -> Result<Vec<String>, StorageError>,
 ) -> Vec<ObjectId> {
     // IEEE 754: -0.0 == 0.0, so scan both prefixes and merge.
-    if super::is_real_zero(value) {
+    if super::is_double_zero(value) {
         let mut result = HashSet::new();
-        for zero in &[Value::Real(0.0), Value::Real(-0.0)] {
+        for zero in &[Value::Double(0.0), Value::Double(-0.0)] {
             let prefix = index_value_prefix(table, column, branch, zero);
             if let Ok(keys) = scan_prefix_keys(&prefix) {
                 for key in &keys {

--- a/crates/jazz-wasm/src/types.rs
+++ b/crates/jazz-wasm/src/types.rs
@@ -18,6 +18,7 @@ use tsify::Tsify;
 pub enum WasmValue {
     Integer(i32),
     BigInt(i64),
+    Real(f64),
     Boolean(bool),
     Text(String),
     Timestamp(u64),
@@ -33,6 +34,7 @@ impl From<jazz_tools::query_manager::types::Value> for WasmValue {
         match v {
             Value::Integer(i) => WasmValue::Integer(i),
             Value::BigInt(i) => WasmValue::BigInt(i),
+            Value::Real(f) => WasmValue::Real(f),
             Value::Boolean(b) => WasmValue::Boolean(b),
             Value::Text(s) => WasmValue::Text(s),
             Value::Timestamp(t) => WasmValue::Timestamp(t),
@@ -54,6 +56,7 @@ impl TryFrom<WasmValue> for jazz_tools::query_manager::types::Value {
         Ok(match v {
             WasmValue::Integer(i) => Value::Integer(i),
             WasmValue::BigInt(i) => Value::BigInt(i),
+            WasmValue::Real(f) => Value::Real(f),
             WasmValue::Boolean(b) => Value::Boolean(b),
             WasmValue::Text(s) => Value::Text(s),
             WasmValue::Timestamp(t) => Value::Timestamp(t),
@@ -107,6 +110,7 @@ pub struct WasmRowDelta {
 pub enum WasmColumnType {
     Integer,
     BigInt,
+    Real,
     Boolean,
     Text,
     Enum { variants: Vec<String> },
@@ -247,6 +251,7 @@ impl From<jazz_tools::query_manager::types::ColumnType> for WasmColumnType {
         match ct {
             ColumnType::Integer => WasmColumnType::Integer,
             ColumnType::BigInt => WasmColumnType::BigInt,
+            ColumnType::Real => WasmColumnType::Real,
             ColumnType::Boolean => WasmColumnType::Boolean,
             ColumnType::Text => WasmColumnType::Text,
             ColumnType::Enum(variants) => WasmColumnType::Enum { variants },
@@ -573,6 +578,7 @@ impl TryFrom<WasmSchema> for jazz_tools::query_manager::types::Schema {
             match wt {
                 WasmColumnType::Integer => ColumnType::Integer,
                 WasmColumnType::BigInt => ColumnType::BigInt,
+                WasmColumnType::Real => ColumnType::Real,
                 WasmColumnType::Boolean => ColumnType::Boolean,
                 WasmColumnType::Text => ColumnType::Text,
                 WasmColumnType::Enum { variants } => ColumnType::Enum(variants),

--- a/crates/jazz-wasm/src/types.rs
+++ b/crates/jazz-wasm/src/types.rs
@@ -18,7 +18,7 @@ use tsify::Tsify;
 pub enum WasmValue {
     Integer(i32),
     BigInt(i64),
-    Real(f64),
+    Double(f64),
     Boolean(bool),
     Text(String),
     Timestamp(u64),
@@ -34,7 +34,7 @@ impl From<jazz_tools::query_manager::types::Value> for WasmValue {
         match v {
             Value::Integer(i) => WasmValue::Integer(i),
             Value::BigInt(i) => WasmValue::BigInt(i),
-            Value::Real(f) => WasmValue::Real(f),
+            Value::Double(f) => WasmValue::Double(f),
             Value::Boolean(b) => WasmValue::Boolean(b),
             Value::Text(s) => WasmValue::Text(s),
             Value::Timestamp(t) => WasmValue::Timestamp(t),
@@ -56,7 +56,7 @@ impl TryFrom<WasmValue> for jazz_tools::query_manager::types::Value {
         Ok(match v {
             WasmValue::Integer(i) => Value::Integer(i),
             WasmValue::BigInt(i) => Value::BigInt(i),
-            WasmValue::Real(f) => Value::Real(f),
+            WasmValue::Double(f) => Value::Double(f),
             WasmValue::Boolean(b) => Value::Boolean(b),
             WasmValue::Text(s) => Value::Text(s),
             WasmValue::Timestamp(t) => Value::Timestamp(t),
@@ -110,7 +110,7 @@ pub struct WasmRowDelta {
 pub enum WasmColumnType {
     Integer,
     BigInt,
-    Real,
+    Double,
     Boolean,
     Text,
     Enum { variants: Vec<String> },
@@ -251,7 +251,7 @@ impl From<jazz_tools::query_manager::types::ColumnType> for WasmColumnType {
         match ct {
             ColumnType::Integer => WasmColumnType::Integer,
             ColumnType::BigInt => WasmColumnType::BigInt,
-            ColumnType::Real => WasmColumnType::Real,
+            ColumnType::Double => WasmColumnType::Double,
             ColumnType::Boolean => WasmColumnType::Boolean,
             ColumnType::Text => WasmColumnType::Text,
             ColumnType::Enum(variants) => WasmColumnType::Enum { variants },
@@ -578,7 +578,7 @@ impl TryFrom<WasmSchema> for jazz_tools::query_manager::types::Schema {
             match wt {
                 WasmColumnType::Integer => ColumnType::Integer,
                 WasmColumnType::BigInt => ColumnType::BigInt,
-                WasmColumnType::Real => ColumnType::Real,
+                WasmColumnType::Double => ColumnType::Double,
                 WasmColumnType::Boolean => ColumnType::Boolean,
                 WasmColumnType::Text => ColumnType::Text,
                 WasmColumnType::Enum { variants } => ColumnType::Enum(variants),

--- a/packages/jazz-tools/src/codegen/codegen.test.ts
+++ b/packages/jazz-tools/src/codegen/codegen.test.ts
@@ -46,14 +46,14 @@ describe("schemaToWasm", () => {
     });
   });
 
-  it("converts REAL to Integer (no Float in WASM)", () => {
+  it("converts REAL to Real", () => {
     table("items", { price: col.float() });
     const schema = getCollectedSchema();
     const wasm = schemaToWasm(schema);
 
     expect(wasm.tables.items.columns[0]).toEqual({
       name: "price",
-      column_type: { type: "Integer" },
+      column_type: { type: "Real" },
       nullable: false,
     });
   });

--- a/packages/jazz-tools/src/codegen/codegen.test.ts
+++ b/packages/jazz-tools/src/codegen/codegen.test.ts
@@ -46,14 +46,14 @@ describe("schemaToWasm", () => {
     });
   });
 
-  it("converts REAL to Real", () => {
+  it("converts REAL to Double", () => {
     table("items", { price: col.float() });
     const schema = getCollectedSchema();
     const wasm = schemaToWasm(schema);
 
     expect(wasm.tables.items.columns[0]).toEqual({
       name: "price",
-      column_type: { type: "Real" },
+      column_type: { type: "Double" },
       nullable: false,
     });
   });

--- a/packages/jazz-tools/src/codegen/query-builder-generator.ts
+++ b/packages/jazz-tools/src/codegen/query-builder-generator.ts
@@ -23,6 +23,7 @@ function columnTypeToTs(type: ColumnType): string {
       return "boolean";
     case "Integer":
     case "BigInt":
+    case "Real":
     case "Timestamp":
       return "number";
     case "Uuid":
@@ -54,6 +55,7 @@ function columnToWhereInputType(col: {
       return "boolean";
     case "Integer":
     case "BigInt":
+    case "Real":
       return "number | { eq?: number; ne?: number; gt?: number; gte?: number; lt?: number; lte?: number }";
     case "Timestamp":
       return "number | { eq?: number; gt?: number; gte?: number; lt?: number; lte?: number }";

--- a/packages/jazz-tools/src/codegen/query-builder-generator.ts
+++ b/packages/jazz-tools/src/codegen/query-builder-generator.ts
@@ -23,7 +23,7 @@ function columnTypeToTs(type: ColumnType): string {
       return "boolean";
     case "Integer":
     case "BigInt":
-    case "Real":
+    case "Double":
     case "Timestamp":
       return "number";
     case "Uuid":
@@ -55,7 +55,7 @@ function columnToWhereInputType(col: {
       return "boolean";
     case "Integer":
     case "BigInt":
-    case "Real":
+    case "Double":
       return "number | { eq?: number; ne?: number; gt?: number; gte?: number; lt?: number; lte?: number }";
     case "Timestamp":
       return "number | { eq?: number; gt?: number; gte?: number; lt?: number; lte?: number }";

--- a/packages/jazz-tools/src/codegen/schema-reader.ts
+++ b/packages/jazz-tools/src/codegen/schema-reader.ts
@@ -25,7 +25,7 @@ const map: Record<ScalarSqlType, ColumnType> = {
   TEXT: { type: "Text" },
   BOOLEAN: { type: "Boolean" },
   INTEGER: { type: "Integer" },
-  REAL: { type: "Real" },
+  REAL: { type: "Double" },
   UUID: { type: "Uuid" },
 };
 

--- a/packages/jazz-tools/src/codegen/schema-reader.ts
+++ b/packages/jazz-tools/src/codegen/schema-reader.ts
@@ -25,7 +25,7 @@ const map: Record<ScalarSqlType, ColumnType> = {
   TEXT: { type: "Text" },
   BOOLEAN: { type: "Boolean" },
   INTEGER: { type: "Integer" },
-  REAL: { type: "Integer" }, // REAL maps to Integer in WASM (no Float type)
+  REAL: { type: "Real" },
   UUID: { type: "Uuid" },
 };
 

--- a/packages/jazz-tools/src/codegen/type-generator.ts
+++ b/packages/jazz-tools/src/codegen/type-generator.ts
@@ -22,7 +22,7 @@ function wasmTypeToTs(colType: ColumnType): string {
       return "boolean";
     case "Integer":
     case "BigInt":
-    case "Real":
+    case "Double":
     case "Timestamp":
       return "number";
     case "Uuid":

--- a/packages/jazz-tools/src/codegen/type-generator.ts
+++ b/packages/jazz-tools/src/codegen/type-generator.ts
@@ -22,6 +22,7 @@ function wasmTypeToTs(colType: ColumnType): string {
       return "boolean";
     case "Integer":
     case "BigInt":
+    case "Real":
     case "Timestamp":
       return "number";
     case "Uuid":

--- a/packages/jazz-tools/src/runtime/row-transformer.ts
+++ b/packages/jazz-tools/src/runtime/row-transformer.ts
@@ -15,6 +15,7 @@ export type WasmValue =
   | { type: "Boolean"; value: boolean }
   | { type: "Integer"; value: number }
   | { type: "BigInt"; value: number }
+  | { type: "Real"; value: number }
   | { type: "Timestamp"; value: number }
   | { type: "Null" }
   | { type: "Array"; value: WasmValue[] }
@@ -118,6 +119,7 @@ export function unwrapValue(v: WasmValue): unknown {
       return v.value;
     case "Integer":
     case "BigInt":
+    case "Real":
     case "Timestamp":
       return v.value;
     case "Null":

--- a/packages/jazz-tools/src/runtime/row-transformer.ts
+++ b/packages/jazz-tools/src/runtime/row-transformer.ts
@@ -15,7 +15,7 @@ export type WasmValue =
   | { type: "Boolean"; value: boolean }
   | { type: "Integer"; value: number }
   | { type: "BigInt"; value: number }
-  | { type: "Real"; value: number }
+  | { type: "Double"; value: number }
   | { type: "Timestamp"; value: number }
   | { type: "Null" }
   | { type: "Array"; value: WasmValue[] }
@@ -119,7 +119,7 @@ export function unwrapValue(v: WasmValue): unknown {
       return v.value;
     case "Integer":
     case "BigInt":
-    case "Real":
+    case "Double":
     case "Timestamp":
       return v.value;
     case "Null":

--- a/packages/jazz-tools/src/runtime/value-converter.test.ts
+++ b/packages/jazz-tools/src/runtime/value-converter.test.ts
@@ -94,6 +94,13 @@ describe("toValue", () => {
     });
   });
 
+  it("converts Real values", () => {
+    const colType: ColumnType = { type: "Real" };
+    expect(toValue(23.456, colType)).toEqual({ type: "Real", value: 23.456 });
+    expect(toValue(-0.001, colType)).toEqual({ type: "Real", value: -0.001 });
+    expect(toValue(0, colType)).toEqual({ type: "Real", value: 0 });
+  });
+
   it("throws for unsupported column type", () => {
     const colType = { type: "Unknown" } as unknown as ColumnType;
     expect(() => toValue("test", colType)).toThrow("Unsupported column type");

--- a/packages/jazz-tools/src/runtime/value-converter.test.ts
+++ b/packages/jazz-tools/src/runtime/value-converter.test.ts
@@ -94,11 +94,11 @@ describe("toValue", () => {
     });
   });
 
-  it("converts Real values", () => {
-    const colType: ColumnType = { type: "Real" };
-    expect(toValue(23.456, colType)).toEqual({ type: "Real", value: 23.456 });
-    expect(toValue(-0.001, colType)).toEqual({ type: "Real", value: -0.001 });
-    expect(toValue(0, colType)).toEqual({ type: "Real", value: 0 });
+  it("converts Double values", () => {
+    const colType: ColumnType = { type: "Double" };
+    expect(toValue(23.456, colType)).toEqual({ type: "Double", value: 23.456 });
+    expect(toValue(-0.001, colType)).toEqual({ type: "Double", value: -0.001 });
+    expect(toValue(0, colType)).toEqual({ type: "Double", value: 0 });
   });
 
   it("throws for unsupported column type", () => {

--- a/packages/jazz-tools/src/runtime/value-converter.ts
+++ b/packages/jazz-tools/src/runtime/value-converter.ts
@@ -25,6 +25,8 @@ export function toValue(value: unknown, columnType: ColumnType): WasmValue {
       return { type: "Integer", value: Number(value) };
     case "BigInt":
       return { type: "BigInt", value: Number(value) };
+    case "Real":
+      return { type: "Real", value: Number(value) };
     case "Timestamp":
       return { type: "Timestamp", value: Number(value) };
     case "Uuid":

--- a/packages/jazz-tools/src/runtime/value-converter.ts
+++ b/packages/jazz-tools/src/runtime/value-converter.ts
@@ -25,8 +25,8 @@ export function toValue(value: unknown, columnType: ColumnType): WasmValue {
       return { type: "Integer", value: Number(value) };
     case "BigInt":
       return { type: "BigInt", value: Number(value) };
-    case "Real":
-      return { type: "Real", value: Number(value) };
+    case "Double":
+      return { type: "Double", value: Number(value) };
     case "Timestamp":
       return { type: "Timestamp", value: Number(value) };
     case "Uuid":

--- a/specs/todo/a_mvp/real_column_type.md
+++ b/specs/todo/a_mvp/real_column_type.md
@@ -1,0 +1,213 @@
+# Real (Float) Column Type
+
+## Overview
+
+The TypeScript DSL supports `col.float()` and emits `REAL` in SQL, but the Rust SQL parser rejects it with `UnsupportedType`. The WASM bridge also lacks a Real variant, so the codegen path currently maps REAL to Integer as a lossy workaround.
+
+This spec adds end-to-end support for floating-point columns.
+
+## Design decisions
+
+### One float type, always f64
+
+SQL distinguishes REAL (32-bit) from DOUBLE PRECISION (64-bit), but JavaScript `Number` is f64. Using f32 internally would silently lose precision on JS round-trips. Store and operate on f64 everywhere.
+
+### Accept multiple SQL keywords
+
+The parser should accept `REAL`, `FLOAT`, and `DOUBLE` as aliases, all mapping to the same `ColumnType::Real`. Emit `REAL` when serialising back to SQL.
+
+### No separate DECIMAL/NUMERIC type
+
+Those imply exact fixed-point arithmetic, which is a different feature. Out of scope.
+
+### Negative zero: faithful storage with IEEE 754 query semantics
+
+IEEE 754 defines `-0.0 == 0.0` (they compare equal). However, the two values have different bit patterns (`0x8000000000000000` vs `0x0000000000000000`), and the sign carries real-world meaning: a small negative value that underflows to `-0.0` *was* negative. As a database, our primary concern is persisting what the user gives us faithfully.
+
+Our index key encoding maps f64 bit patterns to bytes that sort lexicographically, which means `-0.0` and `0.0` naturally become distinct, adjacent index entries, with `-0.0` sorting immediately below `0.0`. This is correct for storage identity but deviates from IEEE 754 equality.
+
+We considered three options:
+
+1. **Normalise `-0.0` to `0.0` on insert.** IEEE 754 compliant for equality. Simple. But intentionally discards information the user gave us. A small negative value that underflowed is genuinely below zero, and we'd be erasing that provenance.
+
+2. **Store distinct bits, accept the deviation.** Faithful storage, simple implementation. But violates IEEE 754 equality, which could surprise users: `WHERE price = 0.0` would not match a stored `-0.0`.
+
+3. **Store distinct bits, match both on query.** Faithful storage and IEEE 754 compliant equality semantics. More complex, but gives us options in future (e.g. exposing raw bit patterns if a use case arises, while keeping standard behaviour as the default).
+
+We chose option 3. The complexity is contained to two index methods:
+
+**Exact lookup** (`index_lookup`): when the value is `Real(0.0)` or `Real(-0.0)`, query both encoded keys and merge the results.
+
+**Range queries** (`index_range`): when a bound involves a Real zero, adjust the bound to account for both representations. Specifically:
+
+- `>= 0.0` should include `-0.0` (they're equal per IEEE 754), but our encoding would miss it since `-0.0` sorts below. Fix: expand lower bound to `Included(-0.0)`.
+- `< 0.0` should exclude `-0.0` (not strictly less than an equal value), but our encoding would include it. Fix: tighten upper bound to `Excluded(-0.0)`.
+- `<= 0.0` already works: `-0.0` sorts below `0.0`, so it falls within the range naturally.
+- `> 0.0` already works: `-0.0` sorts below `0.0`, so it's excluded from "strictly greater" naturally.
+
+Implement this as a small helper (`fn ieee754_adjusted_bounds(...)` or similar) rather than spreading the logic across call sites.
+
+**Binary row encoding** is unaffected: it stores raw f64 bits faithfully, no special-casing.
+
+## Architecture / Components
+
+### 1. Rust core types
+
+Files:
+
+- `crates/jazz-tools/src/query_manager/types/schema.rs`
+- `crates/jazz-tools/src/query_manager/types/value.rs`
+
+Changes:
+
+- Add `ColumnType::Real` with doc comment `/// 8-byte IEEE 754 double-precision float (f64).`
+- Add `fixed_size` arm returning `Some(8)`.
+- Add `Value::Real(f64)` variant.
+- Add `Value::Real(_) => Some(ColumnType::Real)` in `column_type()`.
+
+Note: `ColumnType` derives `Eq`. `f64` is not `Eq`. `Value` currently derives `PartialEq` and `Eq` via the blanket derive. Options:
+
+- Implement `PartialEq`/`Eq` manually on `Value`, using `f64::to_bits()` for the Real arm (bitwise equality, NaN == NaN). This is the right semantics for storage identity comparison.
+- Or remove `Eq` from `Value` and fix any call sites. Likely more disruptive.
+
+Recommend the manual impl approach.
+
+### 2. Rust binary encoding
+
+File: `crates/jazz-tools/src/query_manager/encoding.rs`
+
+Changes:
+
+- Encode: `Value::Real(f) => buf.extend_from_slice(&f.to_le_bytes())` (8 bytes, little-endian, matching BigInt).
+- Decode: `ColumnType::Real => f64::from_le_bytes(bytes[..8].try_into()...)`.
+- Type validation: `ColumnType::Real` accepts `Value::Real(_)`.
+
+### 3. Rust index key encoding
+
+File: `crates/jazz-tools/src/storage/mod.rs` (`encode_value`)
+
+Add a `Value::Real(f)` arm with a new tag byte (e.g. `0x09`, after Row's `0x08`) and order-preserving encoding:
+
+```rust
+Value::Real(f) => {
+    let mut bytes = vec![0x09];
+    let bits = f.to_bits();
+    // Flip for lexicographic ordering: if sign bit set, flip all bits;
+    // otherwise flip only the sign bit.
+    let ordered = if bits & (1u64 << 63) != 0 {
+        !bits
+    } else {
+        bits ^ (1u64 << 63)
+    };
+    bytes.extend_from_slice(&ordered.to_be_bytes());
+    bytes
+}
+```
+
+This gives correct ordering: negative floats sort below positive, with magnitude ordering correct in both directions. NaN sorts to one end (acceptable for index purposes).
+
+### 4. Rust index query methods (negative zero handling)
+
+Files:
+
+- `crates/jazz-tools/src/storage/mod.rs` (MemoryStorage)
+- `crates/jazz-tools/src/storage/opfs_btree.rs` (OpfsBTreeStorage)
+- `crates/jazz-tools/src/storage/surrealkv.rs` (SurrealKvStorage)
+- Or, if index operations are shared via `storage_core`, the adjustment may live there.
+
+Add a helper for IEEE 754 negative zero adjustment:
+
+```rust
+/// Adjusts index bounds for IEEE 754 negative zero semantics.
+///
+/// -0.0 and 0.0 have distinct bit patterns (and thus distinct index keys)
+/// but are equal per IEEE 754. This helper expands/tightens bounds so that
+/// range queries treat both zeros as equal while the storage layer preserves
+/// the original bit patterns.
+fn ieee754_adjusted_bounds(
+    start: Bound<&Value>,
+    end: Bound<&Value>,
+) -> (Bound<Value>, Bound<Value>) { ... }
+```
+
+For `index_lookup`: when the value is `Real(0.0)` or `Real(-0.0)`, query both keys and merge results.
+
+### 5. Rust SQL parser and emitter
+
+File: `crates/jazz-tools/src/schema_manager/sql.rs`
+
+Changes:
+
+- `parse_column_type`: add `"REAL" | "FLOAT" | "DOUBLE" => ColumnType::Real` to the match.
+- `column_type_to_sql`: add `ColumnType::Real => "REAL".to_string()`.
+
+### 6. Rust schema manager encoding
+
+Files:
+
+- `crates/jazz-tools/src/schema_manager/encoding.rs`
+- `crates/jazz-tools/src/schema_manager/diff.rs`
+- `crates/jazz-tools/src/schema_manager/auto_lens.rs`
+
+Changes:
+
+- Add catalogue encoding tag for Real (follows the pattern of existing scalar types).
+- Diff and auto-lens should treat Real as a simple scalar, same as Integer/BigInt.
+
+### 7. WASM/NAPI bridge
+
+Files:
+
+- `crates/jazz-wasm/src/types.rs`
+- `crates/jazz-napi/src/lib.rs`
+
+Changes:
+
+- Add `WasmColumnType::Real` variant.
+- Add `WasmValue::Real(f64)` variant.
+- Add `From` impl arms in both directions (trivial).
+- tsify auto-generates the TypeScript discriminated union member `{ type: "Real" }` and `{ type: "Real", value: number }`.
+
+### 8. TypeScript codegen and runtime
+
+Files:
+
+- `packages/jazz-tools/src/codegen/schema-reader.ts`
+- `packages/jazz-tools/src/runtime/value-converter.ts`
+
+Changes:
+
+- `schema-reader.ts`: change `REAL: { type: "Integer" }` to `REAL: { type: "Real" }`.
+- `value-converter.ts`: add `case "Real": return { type: "Real", value: Number(value) }`.
+
+### 9. TypeScript DSL
+
+No changes needed. `col.float()` already emits `"REAL"` and the TS type mapping already maps REAL to `number`.
+
+## Testing strategy
+
+Tests live inline (`#[cfg(test)] mod tests`) in the files being changed, following existing convention.
+
+### Rust
+
+- `schema_manager/sql.rs`: parse/emit round-trip for `REAL`, `FLOAT`, `DOUBLE` keywords.
+- `query_manager/encoding.rs`: encode/decode round-trip for Real values including negative, zero, subnormal, infinity, NaN.
+- `storage/mod.rs`:
+  - `encode_value` ordering: negative < zero < positive for Real values; Real values sort after Row in cross-type ordering.
+  - Negative zero index lookup: store as `-0.0`, lookup with `0.0`, expect match (and vice versa).
+  - Negative zero range queries: verify `>= 0.0` includes `-0.0`; verify `< 0.0` excludes `-0.0`.
+
+### TypeScript
+
+- `sql-gen.test.ts`: already passes (no changes to SQL generation).
+- `codegen/codegen.test.ts`: update the "converts REAL to Integer" test to expect `{ type: "Real" }` instead.
+- `runtime/value-converter.test.ts`: add Real conversion case.
+
+### Integration
+
+The existing TS DSL to native build pipeline path should exercise the full round-trip once the Rust parser accepts REAL.
+
+## Other edge cases
+
+- **NaN**: stored and indexed like any other f64 bit pattern. NaN == NaN for storage identity (bitwise). NaN sorts to one end of index range scans, which is fine.
+- **Infinity**: valid f64 values, stored and sorted correctly by the encoding. No special handling needed.

--- a/specs/todo/a_mvp/real_column_type.md
+++ b/specs/todo/a_mvp/real_column_type.md
@@ -22,7 +22,7 @@ Those imply exact fixed-point arithmetic, which is a different feature. Out of s
 
 ### Negative zero: faithful storage with IEEE 754 query semantics
 
-IEEE 754 defines `-0.0 == 0.0` (they compare equal). However, the two values have different bit patterns (`0x8000000000000000` vs `0x0000000000000000`), and the sign carries real-world meaning: a small negative value that underflows to `-0.0` *was* negative. As a database, our primary concern is persisting what the user gives us faithfully.
+IEEE 754 defines `-0.0 == 0.0` (they compare equal). However, the two values have different bit patterns (`0x8000000000000000` vs `0x0000000000000000`), and the sign carries real-world meaning: a small negative value that underflows to `-0.0` _was_ negative. As a database, our primary concern is persisting what the user gives us faithfully.
 
 Our index key encoding maps f64 bit patterns to bytes that sort lexicographically, which means `-0.0` and `0.0` naturally become distinct, adjacent index entries, with `-0.0` sorting immediately below `0.0`. This is correct for storage identity but deviates from IEEE 754 equality.
 
@@ -207,7 +207,25 @@ Tests live inline (`#[cfg(test)] mod tests`) in the files being changed, followi
 
 The existing TS DSL to native build pipeline path should exercise the full round-trip once the Rust parser accepts REAL.
 
+## Known limitations
+
+### Negative zero may be lost crossing the WASM boundary (bidirectional)
+
+Negative zero can be silently converted to positive zero when crossing the WASM boundary in either direction: JS to Rust (inserts/updates) and Rust to JS (query results).
+
+This is caused by `serde_wasm_bindgen`'s `deserialize_any` implementation. When serde needs to buffer the `content` field of an adjacently tagged enum (`#[serde(tag = "type", content = "value")]`), it calls `deserialize_any` on the value. That implementation checks `Number.isSafeInteger()` to decide whether to store the value as an integer or a float. JavaScript's `Number.isSafeInteger(-0)` returns `true` (because `-0 === 0` in JS), so `-0.0` gets buffered as `Content::I64(0)`, which replays as `f64(0.0)`. The negative sign is lost.
+
+This means:
+
+- **JS to Rust (writes):** if a user inserts `-0.0` from JavaScript and buffering occurs, Rust receives `0.0` and persists it as such. The storage layer faithfully stores whatever it receives, but the value may already be wrong before it reaches storage.
+- **Rust to JS (reads):** if `-0.0` is stored correctly in Rust, it may appear as `0.0` when returned to JavaScript.
+
+The buffering only occurs when the `value` field precedes the `type` field in the JS object. When `type` comes first, serde reads the tag first and calls `deserialize_f64` directly, which preserves `-0.0`. Our `value-converter.ts` constructs objects with `type` first (`{ type: "Real", value: Number(value) }`), and Rust's serde serialisation follows struct field declaration order (also `type` first). So the common path through our own code should preserve `-0.0`, but this depends on JS object field ordering, which is not something we can strictly enforce.
+
+This is not easily fixable on our side; the behaviour is deep inside serde's Content buffering machinery and `serde_wasm_bindgen`'s `deserialize_any` implementation. However, because our storage layer, index encoding, and query methods all handle negative zero correctly, our implementation will begin faithfully persisting and returning `-0.0` end to end as soon as the upstream serialisation issue is resolved. No changes to our code will be needed.
+
 ## Other edge cases
 
-- **NaN**: stored and indexed like any other f64 bit pattern. NaN == NaN for storage identity (bitwise). NaN sorts to one end of index range scans, which is fine.
-- **Infinity**: valid f64 values, stored and sorted correctly by the encoding. No special handling needed.
+- **NaN and Infinity**: the binary encoding and index layer handle these correctly (NaN sorts to one end, infinities to their respective ends). However, non-finite values are rejected as column defaults because `format!("{f:?}")` produces `inf`/`NaN` which are not valid SQL or JavaScript literals. The SQL tokeniser naturally rejects these (they are identifiers, not numbers), and the `value_to_sql`/`value_to_ts_literal` functions assert finiteness as a safety net.
+
+- **Scientific notation**: SQL literals like `1e10` or `2.5e-3` are out of scope. The tokeniser only consumes digits and `.`, so scientific notation is not recognised. This could be added later if needed.


### PR DESCRIPTION
## Summary

- `col.float()` is permitted in the TypeScript DSL and emits `REAL` in SQL, but the Rust SQL parser rejected it with `UnsupportedType`. This came up while working on the chat app, where I wanted to use `col.float()` for stroke width on the canvas. Investigating the failure led to discovering that the WASM bridge had no Real type at all and was silently coercing floats to integers as a shortcut.
- This PR adds end-to-end support for Real (f64) columns: Rust core types, binary encoding, order-preserving index key encoding, SQL parser (accepts REAL/FLOAT/DOUBLE), schema manager, WASM and NAPI bridges, and TypeScript codegen/runtime.
- Implements IEEE 754 negative zero semantics in index queries: `-0.0` and `0.0` are stored as distinct bit patterns but treated as equal in lookups and range scans. Documents a known upstream limitation where `-0.0` may be lost crossing the WASM boundary due to serde buffering.

## Test plan

- [x] 14 new Rust tests covering SQL parsing, binary encoding round-trips, index key ordering, and negative zero query semantics
- [x] 2 updated TypeScript tests (codegen expects `{ type: "Real" }`, value-converter handles Real)
- [x] `cargo test -p jazz-tools --lib` passes (705 tests)
- [x] `cargo clippy` and `cargo fmt` clean
- [x] Relevant TypeScript tests pass (89 tests)