### PR TITLE
feat: replace in-memory OPFS-btree with pure in-memory storage in WASM

### DIFF
--- a/crates/jazz-tools/src/storage/mod.rs
+++ b/crates/jazz-tools/src/storage/mod.rs
@@ -181,6 +181,122 @@ pub trait Storage {
     fn flush_wal(&self) {}
 }
 
+// Box<Storage> is used to allow for dynamic dispatch of the Storage trait.
+impl<T: Storage + ?Sized> Storage for Box<T> {
+    fn create_object(
+        &mut self,
+        id: ObjectId,
+        metadata: HashMap<String, String>,
+    ) -> Result<(), StorageError> {
+        (**self).create_object(id, metadata)
+    }
+
+    fn load_object_metadata(
+        &self,
+        id: ObjectId,
+    ) -> Result<Option<HashMap<String, String>>, StorageError> {
+        (**self).load_object_metadata(id)
+    }
+
+    fn load_branch(
+        &self,
+        object_id: ObjectId,
+        branch: &BranchName,
+    ) -> Result<Option<LoadedBranch>, StorageError> {
+        (**self).load_branch(object_id, branch)
+    }
+
+    fn append_commit(
+        &mut self,
+        object_id: ObjectId,
+        branch: &BranchName,
+        commit: Commit,
+    ) -> Result<(), StorageError> {
+        (**self).append_commit(object_id, branch, commit)
+    }
+
+    fn delete_commit(
+        &mut self,
+        object_id: ObjectId,
+        branch: &BranchName,
+        commit_id: CommitId,
+    ) -> Result<(), StorageError> {
+        (**self).delete_commit(object_id, branch, commit_id)
+    }
+
+    fn set_branch_tails(
+        &mut self,
+        object_id: ObjectId,
+        branch: &BranchName,
+        tails: Option<HashSet<CommitId>>,
+    ) -> Result<(), StorageError> {
+        (**self).set_branch_tails(object_id, branch, tails)
+    }
+
+    fn store_ack_tier(
+        &mut self,
+        commit_id: CommitId,
+        tier: PersistenceTier,
+    ) -> Result<(), StorageError> {
+        (**self).store_ack_tier(commit_id, tier)
+    }
+
+    fn index_insert(
+        &mut self,
+        table: &str,
+        column: &str,
+        branch: &str,
+        value: &Value,
+        row_id: ObjectId,
+    ) -> Result<(), StorageError> {
+        (**self).index_insert(table, column, branch, value, row_id)
+    }
+
+    fn index_remove(
+        &mut self,
+        table: &str,
+        column: &str,
+        branch: &str,
+        value: &Value,
+        row_id: ObjectId,
+    ) -> Result<(), StorageError> {
+        (**self).index_remove(table, column, branch, value, row_id)
+    }
+
+    fn index_lookup(
+        &self,
+        table: &str,
+        column: &str,
+        branch: &str,
+        value: &Value,
+    ) -> Vec<ObjectId> {
+        (**self).index_lookup(table, column, branch, value)
+    }
+
+    fn index_range(
+        &self,
+        table: &str,
+        column: &str,
+        branch: &str,
+        start: Bound<&Value>,
+        end: Bound<&Value>,
+    ) -> Vec<ObjectId> {
+        (**self).index_range(table, column, branch, start, end)
+    }
+
+    fn index_scan_all(&self, table: &str, column: &str, branch: &str) -> Vec<ObjectId> {
+        (**self).index_scan_all(table, column, branch)
+    }
+
+    fn flush(&self) {
+        (**self).flush();
+    }
+
+    fn flush_wal(&self) {
+        (**self).flush_wal();
+    }
+}
+
 // ============================================================================
 // MemoryStorage - In-memory implementation for testing and main thread
 // ============================================================================

--- a/crates/jazz-wasm/src/runtime.rs
+++ b/crates/jazz-wasm/src/runtime.rs
@@ -7,7 +7,7 @@
 //!
 //! # Architecture
 //!
-//! - `OpfsBTreeStorage` provides synchronous storage (from jazz_tools::storage)
+//! - `MemoryStorage`/`OpfsBTreeStorage` provide synchronous storage (from jazz_tools::storage)
 //! - `WasmScheduler` implements `Scheduler` using `spawn_local` (debounced)
 //! - `JsSyncSender` implements `SyncSender` bridging to a JS callback
 //! - `WasmRuntime` wraps `Rc<RefCell<RuntimeCore<...>>>`
@@ -44,7 +44,9 @@ use jazz_tools::runtime_core::{RuntimeCore, Scheduler, SyncSender};
 #[cfg(target_arch = "wasm32")]
 use jazz_tools::runtime_core::{SubscriptionDelta, SubscriptionHandle};
 use jazz_tools::schema_manager::{AppId, SchemaManager};
+#[cfg(target_arch = "wasm32")]
 use jazz_tools::storage::OpfsBTreeStorage;
+use jazz_tools::storage::{MemoryStorage, Storage};
 use jazz_tools::sync_manager::{
     ClientId, InboxEntry, OutboxEntry, PersistenceTier, ServerId, Source, SyncManager, SyncPayload,
 };
@@ -70,7 +72,7 @@ fn parse_tier(tier: &str) -> Result<PersistenceTier, JsError> {
 // ============================================================================
 
 /// Concrete RuntimeCore type for WASM.
-type WasmCoreType = RuntimeCore<OpfsBTreeStorage, WasmScheduler, JsSyncSender>;
+type WasmCoreType = RuntimeCore<Box<dyn Storage>, WasmScheduler, JsSyncSender>;
 
 // ============================================================================
 // WasmScheduler
@@ -159,7 +161,7 @@ impl SyncSender for JsSyncSender {
 
 /// Main runtime for JavaScript applications.
 ///
-/// Wraps `Rc<RefCell<RuntimeCore<OpfsBTreeStorage, WasmScheduler, JsSyncSender>>>`.
+/// Wraps `Rc<RefCell<WasmCoreType>>`.
 /// All methods borrow the core, call RuntimeCore, and return.
 /// Async scheduling happens via WasmScheduler.schedule_batched_tick().
 #[wasm_bindgen]
@@ -174,7 +176,7 @@ pub struct WasmRuntime {
 impl WasmRuntime {
     /// Create a new WasmRuntime.
     ///
-    /// Storage is synchronous (in-memory via OpfsBTreeStorage).
+    /// Storage is synchronous (in-memory via MemoryStorage).
     ///
     /// # Arguments
     /// * `schema_json` - JSON-encoded schema definition
@@ -239,9 +241,7 @@ impl WasmRuntime {
         .map_err(|e| JsError::new(&format!("Failed to create SchemaManager: {:?}", e)))?;
 
         // Create components
-        const DEFAULT_CACHE_SIZE: usize = 32 * 1024 * 1024; // 32MB
-        let storage = OpfsBTreeStorage::memory(DEFAULT_CACHE_SIZE)
-            .map_err(|e| JsError::new(&format!("Storage init: {:?}", e)))?;
+        let storage: Box<dyn Storage> = Box::new(MemoryStorage::new());
         let scheduler = WasmScheduler::new();
         let sync_sender = JsSyncSender::new();
 
@@ -820,9 +820,11 @@ impl WasmRuntime {
         .map_err(|e| JsError::new(&format!("Failed to create SchemaManager: {:?}", e)))?;
 
         const DEFAULT_CACHE_SIZE: usize = 32 * 1024 * 1024;
-        let storage = OpfsBTreeStorage::open_opfs(db_name, DEFAULT_CACHE_SIZE)
-            .await
-            .map_err(|e| JsError::new(&format!("Storage: {:?}", e)))?;
+        let storage: Box<dyn Storage> = Box::new(
+            OpfsBTreeStorage::open_opfs(db_name, DEFAULT_CACHE_SIZE)
+                .await
+                .map_err(|e| JsError::new(&format!("Storage: {:?}", e)))?,
+        );
 
         let scheduler = WasmScheduler::new();
         let sync_sender = JsSyncSender::new();


### PR DESCRIPTION
## Description

While profiling, we found we're spending lots of time running crc32 checksums in the in-memory OPFS-btree storage in the main thread:

<img width="1728" height="542" alt="before" src="https://github.com/user-attachments/assets/f262c4b4-b303-438e-a5ca-598ec76fd631" />

Decided to replace the in-memory OPFS-btree storage with a more light-weight, pure in-memory storage, which speeds up main-thread "storage" by ~4x:

<img width="1728" height="542" alt="after" src="https://github.com/user-attachments/assets/c2aabd04-430d-4ef7-afde-31ce15a1e948" />

## Discussion

Went with boxed dynamic references to storages to support runtime polymorphism for different storage implementations in the WASM runtime. I found this approach way less verbose than generating an enum wrapper over both types of storage and doing pattern matching, and checked performance is not noticeably affected. Still, I'm relatively new to Rust, so we can change this if you think there's a better way to do this.