### PR TITLE
feat: add a lock system to speedup initial tab election

### DIFF
--- a/packages/jazz-tools/src/runtime/leader-lock.ts
+++ b/packages/jazz-tools/src/runtime/leader-lock.ts
@@ -1,0 +1,68 @@
+export interface LeaderLockLease {
+  release(): void;
+}
+
+export interface LeaderLockStrategy {
+  tryAcquire(lockName: string): Promise<LeaderLockLease | null>;
+}
+
+interface LockManagerLike {
+  request<T>(
+    name: string,
+    options: { mode?: "exclusive" | "shared"; ifAvailable?: boolean },
+    callback: (lock: unknown | null) => Promise<T> | T,
+  ): Promise<T>;
+}
+
+function resolveNavigatorLocks(): LockManagerLike | null {
+  const nav = (globalThis as { navigator?: { locks?: unknown } }).navigator;
+  if (!nav || !nav.locks) return null;
+  const locks = nav.locks as { request?: unknown };
+  if (typeof locks.request !== "function") return null;
+  return locks as unknown as LockManagerLike;
+}
+
+export function createNavigatorLocksLeaderLockStrategy(
+  lockManager: LockManagerLike | null = resolveNavigatorLocks(),
+): LeaderLockStrategy | null {
+  if (!lockManager) return null;
+
+  return {
+    async tryAcquire(lockName: string): Promise<LeaderLockLease | null> {
+      let resolveAcquired: ((lease: LeaderLockLease | null) => void) | null = null;
+      const acquiredPromise = new Promise<LeaderLockLease | null>((resolve) => {
+        resolveAcquired = resolve;
+      });
+
+      let releaseLock: (() => void) | null = null;
+      const heldUntilReleased = new Promise<void>((resolve) => {
+        releaseLock = () => resolve();
+      });
+
+      void lockManager
+        .request(lockName, { mode: "exclusive", ifAvailable: true }, async (lock) => {
+          if (!lock) {
+            resolveAcquired?.(null);
+            resolveAcquired = null;
+            return;
+          }
+
+          resolveAcquired?.({
+            release: () => {
+              if (!releaseLock) return;
+              releaseLock();
+              releaseLock = null;
+            },
+          });
+          resolveAcquired = null;
+          await heldUntilReleased;
+        })
+        .catch(() => {
+          resolveAcquired?.(null);
+          resolveAcquired = null;
+        });
+
+      return await acquiredPromise;
+    },
+  };
+}

--- a/packages/jazz-tools/src/runtime/tab-leader-election.test.ts
+++ b/packages/jazz-tools/src/runtime/tab-leader-election.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TabLeaderElection } from "./tab-leader-election.js";
+import type { LeaderLockStrategy } from "./leader-lock.js";
 
 class MockBroadcastChannel {
   static channels = new Map<string, Set<MockBroadcastChannel>>();
@@ -68,6 +69,31 @@ class MockBroadcastChannel {
 describe("TabLeaderElection", () => {
   const originalBroadcastChannel = (globalThis as { BroadcastChannel?: unknown }).BroadcastChannel;
   const elections: TabLeaderElection[] = [];
+  const lockOwners = new Map<string, string>();
+
+  function createLockStrategyForTab(
+    tabId: string,
+    canAcquire: () => boolean = () => true,
+  ): LeaderLockStrategy {
+    return {
+      async tryAcquire(lockName: string) {
+        if (!canAcquire()) return null;
+        const owner = lockOwners.get(lockName);
+        if (owner && owner !== tabId) return null;
+        lockOwners.set(lockName, tabId);
+        let released = false;
+        return {
+          release: () => {
+            if (released) return;
+            released = true;
+            if (lockOwners.get(lockName) === tabId) {
+              lockOwners.delete(lockName);
+            }
+          },
+        };
+      },
+    };
+  }
 
   function createElection(
     tabId: string,
@@ -78,8 +104,8 @@ describe("TabLeaderElection", () => {
       dbName: "test-db",
       heartbeatMs: 100,
       leaseMs: 280,
-      initialElectionDelayMs: 120,
       tabId,
+      lockStrategy: createLockStrategyForTab(tabId),
       ...options,
     });
     elections.push(election);
@@ -108,6 +134,7 @@ describe("TabLeaderElection", () => {
       election.stop();
     }
     MockBroadcastChannel.reset();
+    lockOwners.clear();
     (globalThis as { BroadcastChannel?: unknown }).BroadcastChannel = originalBroadcastChannel;
     vi.useRealTimers();
   });
@@ -172,7 +199,7 @@ describe("TabLeaderElection", () => {
     expect(nextState.term).toBeGreaterThan(0);
   });
 
-  it("uses a deterministic tie-breaker when claims happen in the same term", async () => {
+  it("converges to a single leader when two tabs start together", async () => {
     const a = createElection("tab-a");
     const z = createElection("tab-z");
 
@@ -182,8 +209,7 @@ describe("TabLeaderElection", () => {
 
     const stateA = a.snapshot();
     const stateZ = z.snapshot();
-    expect(stateA.leaderTabId).toBe("tab-z");
-    expect(stateZ.leaderTabId).toBe("tab-z");
+    expect(stateA.leaderTabId).toBe(stateZ.leaderTabId);
     expect(stateA.term).toBe(stateZ.term);
     expect([stateA.role, stateZ.role].sort()).toEqual(["follower", "leader"]);
   });
@@ -241,7 +267,7 @@ describe("TabLeaderElection", () => {
 
   it("waitForInitialLeader rejects if stopped before a leader is chosen", async () => {
     const election = createElection("tab-a", {
-      initialElectionDelayMs: 500,
+      lockStrategy: createLockStrategyForTab("tab-a", () => false),
     });
     election.start();
     const leaderPromise = election.waitForInitialLeader(2000);
@@ -263,5 +289,49 @@ describe("TabLeaderElection", () => {
     expect(state.role).toBe("leader");
     expect(state.leaderTabId).toBe("tab-a");
     expect(state.term).toBeGreaterThan(0);
+  });
+
+  it("uses take-then-ask-forgiveness startup: probe first, discover on failure", async () => {
+    const leader = createElection("tab-a", {
+      lockStrategy: createLockStrategyForTab("tab-a", () => true),
+    });
+    leader.start();
+    await advance(140);
+    expect(leader.snapshot().role).toBe("leader");
+
+    const follower = createElection("tab-b", {
+      lockStrategy: createLockStrategyForTab("tab-b", () => false),
+    });
+    follower.start();
+    await advance(220);
+
+    const state = follower.snapshot();
+    expect(state.role).toBe("follower");
+    expect(state.leaderTabId).toBe("tab-a");
+    expect(state.term).toBe(leader.snapshot().term);
+  });
+
+  it("re-probes on leader loss and promotes when lock probe succeeds", async () => {
+    const first = createElection("tab-a", {
+      lockStrategy: createLockStrategyForTab("tab-a", () => true),
+    });
+    let secondCanLead = false;
+    const second = createElection("tab-b", {
+      lockStrategy: createLockStrategyForTab("tab-b", () => secondCanLead),
+    });
+
+    first.start();
+    second.start();
+    await advance(260);
+    expect(first.snapshot().role).toBe("leader");
+    expect(second.snapshot().role).toBe("follower");
+
+    first.stop();
+    secondCanLead = true;
+    await advance(360);
+
+    const nextState = second.snapshot();
+    expect(nextState.role).toBe("leader");
+    expect(nextState.leaderTabId).toBe("tab-b");
   });
 });

--- a/packages/jazz-tools/src/runtime/tab-leader-election.ts
+++ b/packages/jazz-tools/src/runtime/tab-leader-election.ts
@@ -1,3 +1,9 @@
+import {
+  createNavigatorLocksLeaderLockStrategy,
+  type LeaderLockLease,
+  type LeaderLockStrategy,
+} from "./leader-lock.js";
+
 /**
  * Cross-tab leader election for browser tabs using BroadcastChannel.
  *
@@ -5,24 +11,25 @@
  *
  *   start
  *     |
- *     +--> request current leader
- *     +--> arm initial-election timeout
- *     |
- *     +--> receive heartbeat/claim --------> follower (lease deadline armed)
- *     |                                         |
- *     |                                         +--> lease deadline expires
- *     |                                               without heartbeat
- *     |                                               |
- *     +-----------------------------------------------+--> promote self to leader
- *                                                           |
- *                                                           +--> emit claim + heartbeat
- *                                                           +--> send periodic heartbeats
+ *     +--> requestCurrentLeader() ------------------------------+
+ *     |                                                        |
+ *     +--> tryAcquireLeadershipLock()                         |
+ *            |                                                |
+ *            +--> acquired -> leader                          |
+ *            |       |                                        |
+ *            |       +--> claim + heartbeat                   |
+ *            |       +--> keep lock lease until step-down     |
+ *            |                                                |
+ *            +--> not acquired -> follower                    |
+ *                    |                                        |
+ *                    +--> wait for heartbeat/claim -----------+
+ *                    |
+ *                    +--> lease timeout -> tryAcquireLeadershipLock() again
  *
  * Election model:
- * - Each tab has a stable random tab ID.
- * - Leaders send periodic heartbeats with term + leader ID.
- * - Followers start an election when the lease deadline expires.
- * - Higher term always wins; same-term ties are broken by tab ID.
+ * - Lock ownership determines who may become leader.
+ * - Leader messages still use term + leader ID fencing.
+ * - Followers discover leader over BroadcastChannel and re-probe on timeout.
  */
 
 export type LeaderRole = "leader" | "follower";
@@ -39,9 +46,9 @@ export interface TabLeaderElectionOptions {
   dbName: string;
   heartbeatMs?: number;
   leaseMs?: number;
-  initialElectionDelayMs?: number;
   tabId?: string;
   now?: () => number;
+  lockStrategy?: LeaderLockStrategy;
 }
 
 interface LeaderHeartbeatMessage {
@@ -52,7 +59,7 @@ interface LeaderHeartbeatMessage {
 }
 
 interface LeaderRequestMessage {
-  type: "leader-request";
+  type: "who-is-leader";
   requesterTabId: string;
 }
 
@@ -77,10 +84,8 @@ interface BroadcastChannelLike {
 function randomTabId(): string {
   const cryptoObj = (globalThis as { crypto?: Crypto }).crypto;
   if (cryptoObj && typeof cryptoObj.randomUUID === "function") {
-    // Prefer UUID when available to minimize collision risk across tabs/processes.
     return cryptoObj.randomUUID();
   }
-  // Fallback for environments lacking randomUUID (still sufficient for local tie-breaks).
   return `tab-${Math.random().toString(36).slice(2, 12)}`;
 }
 
@@ -99,7 +104,7 @@ function isMessage(value: unknown): value is LeaderElectionMessage {
       typeof msg.sentAtMs === "number"
     );
   }
-  if (msg.type === "leader-request") {
+  if (msg.type === "who-is-leader") {
     return typeof msg.requesterTabId === "string";
   }
   if (msg.type === "leader-claim") {
@@ -122,9 +127,10 @@ export class TabLeaderElection {
   private readonly tabId: string;
   private readonly heartbeatMs: number;
   private readonly leaseMs: number;
-  private readonly initialElectionDelayMs: number;
   private readonly now: () => number;
   private readonly channelName: string;
+  private readonly lockName: string;
+  private readonly lockStrategy: LeaderLockStrategy | null;
 
   private started = false;
   private channel: BroadcastChannelLike | null = null;
@@ -135,12 +141,13 @@ export class TabLeaderElection {
 
   private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
   private leaseDeadlineTimer: ReturnType<typeof setTimeout> | null = null;
-  private initialElectionTimer: ReturnType<typeof setTimeout> | null = null;
+  private probeInFlight = false;
+  private leadershipLockLease: LeaderLockLease | null = null;
 
   private readonly listeners = new Set<LeaderChangeListener>();
   private readyResolve: ((snapshot: LeaderSnapshot) => void) | null = null;
   private readyReject: ((reason?: unknown) => void) | null = null;
-  private readyPromise: Promise<LeaderSnapshot>;
+  private readonly readyPromise: Promise<LeaderSnapshot>;
   private readySettled = false;
 
   private readonly onMessage = (event: MessageEvent): void => {
@@ -151,12 +158,10 @@ export class TabLeaderElection {
     this.tabId = options.tabId ?? randomTabId();
     this.heartbeatMs = Math.max(100, options.heartbeatMs ?? 1000);
     this.leaseMs = Math.max(this.heartbeatMs * 2, options.leaseMs ?? 5000);
-    this.initialElectionDelayMs = Math.max(
-      this.heartbeatMs,
-      options.initialElectionDelayMs ?? this.heartbeatMs,
-    );
     this.now = options.now ?? (() => Date.now());
     this.channelName = `jazz-leader:${options.appId}:${options.dbName}`;
+    this.lockName = `jazz-leader-lock:${options.appId}:${options.dbName}`;
+    this.lockStrategy = options.lockStrategy ?? createNavigatorLocksLeaderLockStrategy();
 
     this.readyPromise = new Promise<LeaderSnapshot>((resolve, reject) => {
       this.readyResolve = resolve;
@@ -169,41 +174,27 @@ export class TabLeaderElection {
     this.started = true;
 
     const ChannelCtor = resolveBroadcastChannelCtor();
-    if (!ChannelCtor) {
-      this.promoteToLeader(this.term + 1);
-      return;
+    if (ChannelCtor) {
+      this.channel = new ChannelCtor(this.channelName);
+      this.channel.addEventListener("message", this.onMessage);
+      this.requestCurrentLeader();
     }
 
-    this.channel = new ChannelCtor(this.channelName);
-    this.channel.addEventListener("message", this.onMessage);
-
-    this.postMessage({
-      type: "leader-request",
-      requesterTabId: this.tabId,
-    });
-
-    // Startup liveness guard:
-    // if request/heartbeat messages are dropped or delayed, this tab must not wait forever.
-    this.initialElectionTimer = setTimeout(() => {
-      if (!this.leaderTabId) {
-        this.promoteToLeader(this.term + 1);
-      }
-    }, this.initialElectionDelayMs);
+    void this.tryTakeLeadership({ requestLeaderOnFailure: false });
+    this.scheduleLeaseDeadlineCheck();
   }
 
   stop(): void {
     if (!this.started) return;
     this.started = false;
 
-    if (this.initialElectionTimer) {
-      clearTimeout(this.initialElectionTimer);
-      this.initialElectionTimer = null;
-    }
     if (this.heartbeatTimer) {
       clearInterval(this.heartbeatTimer);
       this.heartbeatTimer = null;
     }
     this.clearLeaseDeadlineTimer();
+    this.releaseLeadershipLock();
+
     if (this.channel) {
       this.channel.removeEventListener("message", this.onMessage);
       this.channel.close();
@@ -255,7 +246,7 @@ export class TabLeaderElection {
     if (!isMessage(raw)) return;
 
     switch (raw.type) {
-      case "leader-request":
+      case "who-is-leader":
         if (this.role === "leader") {
           this.sendHeartbeat();
         }
@@ -328,6 +319,9 @@ export class TabLeaderElection {
       this.ensureHeartbeatTimer();
       this.clearLeaseDeadlineTimer();
     } else {
+      if (prevRole === "leader") {
+        this.releaseLeadershipLock();
+      }
       this.clearHeartbeatTimer();
       this.scheduleLeaseDeadlineCheck();
     }
@@ -359,10 +353,9 @@ export class TabLeaderElection {
       return;
     }
 
-    const referenceTime =
-      this.lastLeaderSeenAtMs > 0 ? this.lastLeaderSeenAtMs : this.now() - this.heartbeatMs;
-    const deadlineMs = referenceTime + this.leaseMs;
-    const delayMs = Math.max(0, deadlineMs - this.now());
+    const delayMs = this.leaderTabId
+      ? Math.max(0, this.lastLeaderSeenAtMs + this.leaseMs - this.now())
+      : this.heartbeatMs;
 
     this.clearLeaseDeadlineTimer();
     this.leaseDeadlineTimer = setTimeout(() => {
@@ -379,14 +372,15 @@ export class TabLeaderElection {
 
   private onLeaseDeadline(): void {
     if (!this.started || this.role === "leader") return;
+
     if (!this.leaderTabId) {
-      this.promoteToLeader(this.term + 1);
+      void this.tryTakeLeadership({ requestLeaderOnFailure: true });
       return;
     }
 
     const elapsed = this.now() - this.lastLeaderSeenAtMs;
     if (elapsed >= this.leaseMs) {
-      this.promoteToLeader(this.term + 1);
+      void this.tryTakeLeadership({ requestLeaderOnFailure: true });
       return;
     }
 
@@ -405,6 +399,52 @@ export class TabLeaderElection {
 
   private postMessage(message: LeaderElectionMessage): void {
     this.channel?.postMessage(message);
+  }
+
+  private requestCurrentLeader(): void {
+    this.postMessage({
+      type: "who-is-leader",
+      requesterTabId: this.tabId,
+    });
+  }
+
+  private async tryTakeLeadership(options: { requestLeaderOnFailure: boolean }): Promise<void> {
+    if (!this.started || this.isLeader()) return;
+    if (this.probeInFlight) return;
+
+    this.probeInFlight = true;
+    try {
+      const acquired = await this.tryAcquireLeadershipLock();
+      if (!this.started || this.isLeader()) return;
+
+      if (acquired) {
+        this.promoteToLeader(this.term + 1);
+        return;
+      }
+
+      if (options.requestLeaderOnFailure) {
+        this.requestCurrentLeader();
+      }
+      this.scheduleLeaseDeadlineCheck();
+    } finally {
+      this.probeInFlight = false;
+    }
+  }
+
+  private async tryAcquireLeadershipLock(): Promise<boolean> {
+    if (this.leadershipLockLease) return true;
+    if (!this.lockStrategy) return false;
+
+    const lease = await this.lockStrategy.tryAcquire(this.lockName);
+    if (!lease) return false;
+    this.leadershipLockLease = lease;
+    return true;
+  }
+
+  private releaseLeadershipLock(): void {
+    const lease = this.leadershipLockLease;
+    this.leadershipLockLease = null;
+    lease?.release();
   }
 
   private emitChange(): void {

--- a/packages/jazz-tools/tests/browser/leader-lock.test.ts
+++ b/packages/jazz-tools/tests/browser/leader-lock.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { createNavigatorLocksLeaderLockStrategy } from "../../src/runtime/leader-lock.js";
+
+function uniqueLockName(prefix: string): string {
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+async function waitForLease(
+  tryAcquire: () => Promise<{ release(): void } | null>,
+  timeoutMs: number,
+) {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    const lease = await tryAcquire();
+    if (lease) return lease;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  return null;
+}
+
+describe("leader-lock browser integration", () => {
+  it("acquires an exclusive lease and blocks concurrent acquisition until release", async () => {
+    const strategyA = createNavigatorLocksLeaderLockStrategy();
+    const strategyB = createNavigatorLocksLeaderLockStrategy();
+    expect(strategyA).not.toBeNull();
+    expect(strategyB).not.toBeNull();
+
+    const lockName = uniqueLockName("leader-lock");
+    const leaseA = await strategyA!.tryAcquire(lockName);
+    expect(leaseA).not.toBeNull();
+
+    const leaseWhileHeld = await strategyB!.tryAcquire(lockName);
+    expect(leaseWhileHeld).toBeNull();
+
+    leaseA!.release();
+
+    const leaseAfterRelease = await waitForLease(() => strategyB!.tryAcquire(lockName), 1000);
+    expect(leaseAfterRelease).not.toBeNull();
+    leaseAfterRelease!.release();
+  });
+});

--- a/packages/jazz-tools/tests/browser/tab-leader-election.test.ts
+++ b/packages/jazz-tools/tests/browser/tab-leader-election.test.ts
@@ -1,0 +1,253 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { TabLeaderElection } from "../../src/runtime/tab-leader-election.js";
+import type { LeaderLockStrategy } from "../../src/runtime/leader-lock.js";
+
+function uniqueName(prefix: string): string {
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+async function waitForCondition(
+  predicate: () => boolean | Promise<boolean>,
+  timeoutMs: number,
+  message: string,
+): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (await predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error(message);
+}
+
+describe("tab-leader-election browser integration", () => {
+  const elections: TabLeaderElection[] = [];
+
+  function createElection(
+    appId: string,
+    dbName: string,
+    tabId: string,
+    options: Partial<ConstructorParameters<typeof TabLeaderElection>[0]> = {},
+  ): TabLeaderElection {
+    const election = new TabLeaderElection({
+      appId,
+      dbName,
+      tabId,
+      heartbeatMs: 100,
+      leaseMs: 280,
+      ...options,
+    });
+    elections.push(election);
+    return election;
+  }
+
+  afterEach(() => {
+    for (const election of elections.splice(0)) {
+      election.stop();
+    }
+  });
+
+  it("elects itself as leader when no competing tab holds the lock", async () => {
+    const appId = uniqueName("app");
+    const dbName = uniqueName("db");
+    const election = createElection(appId, dbName, "tab-a");
+    election.start();
+
+    await waitForCondition(
+      () => election.snapshot().role === "leader",
+      2000,
+      "expected single tab to become leader",
+    );
+
+    const state = election.snapshot();
+    expect(state.role).toBe("leader");
+    expect(state.leaderTabId).toBe("tab-a");
+  });
+
+  it("follows an existing leader when lock is already held", async () => {
+    const appId = uniqueName("app");
+    const dbName = uniqueName("db");
+    const leader = createElection(appId, dbName, "tab-a");
+    leader.start();
+    await waitForCondition(() => leader.snapshot().role === "leader", 2000, "leader not elected");
+
+    const follower = createElection(appId, dbName, "tab-b");
+    follower.start();
+
+    await waitForCondition(
+      () => {
+        const state = follower.snapshot();
+        return state.role === "follower" && state.leaderTabId === "tab-a";
+      },
+      2500,
+      "follower did not attach to current leader",
+    );
+  });
+
+  it("fails over to the remaining tab after leader stops", async () => {
+    const appId = uniqueName("app");
+    const dbName = uniqueName("db");
+    const a = createElection(appId, dbName, "tab-a");
+    const b = createElection(appId, dbName, "tab-b");
+    a.start();
+    b.start();
+
+    await waitForCondition(
+      () => {
+        const roleA = a.snapshot().role;
+        const roleB = b.snapshot().role;
+        return (
+          (roleA === "leader" && roleB === "follower") ||
+          (roleA === "follower" && roleB === "leader")
+        );
+      },
+      3000,
+      "pair did not converge to leader/follower",
+    );
+
+    const leader = a.snapshot().role === "leader" ? a : b;
+    const follower = leader === a ? b : a;
+    leader.stop();
+
+    await waitForCondition(
+      () => {
+        const state = follower.snapshot();
+        return state.role === "leader" && state.leaderTabId === state.tabId;
+      },
+      3000,
+      "follower did not take over after leader stop",
+    );
+  });
+
+  it("converges to exactly one leader when two tabs start together", async () => {
+    const appId = uniqueName("app");
+    const dbName = uniqueName("db");
+    const a = createElection(appId, dbName, "tab-a");
+    const b = createElection(appId, dbName, "tab-b");
+    a.start();
+    b.start();
+
+    await waitForCondition(
+      () => {
+        const roleA = a.snapshot().role;
+        const roleB = b.snapshot().role;
+        return (
+          (roleA === "leader" && roleB === "follower") ||
+          (roleA === "follower" && roleB === "leader")
+        );
+      },
+      3000,
+      "did not converge to single leader",
+    );
+
+    const stateA = a.snapshot();
+    const stateB = b.snapshot();
+    expect(stateA.leaderTabId).toBe(stateB.leaderTabId);
+    expect([stateA.role, stateB.role].sort()).toEqual(["follower", "leader"]);
+  });
+
+  it("ignores stale-term heartbeats", async () => {
+    const appId = uniqueName("app");
+    const dbName = uniqueName("db");
+    const election = createElection(appId, dbName, "tab-a");
+    election.start();
+    await waitForCondition(() => election.snapshot().role === "leader", 2000, "leader not elected");
+
+    const before = election.snapshot();
+    (election as any).handleIncomingMessage({
+      type: "leader-heartbeat",
+      leaderTabId: "tab-stale",
+      term: Math.max(0, before.term - 1),
+      sentAtMs: Date.now(),
+    });
+    const after = election.snapshot();
+    expect(after).toEqual(before);
+  });
+
+  it("adopts a higher-term heartbeat and steps down", async () => {
+    const appId = uniqueName("app");
+    const dbName = uniqueName("db");
+    const election = createElection(appId, dbName, "tab-a");
+    election.start();
+    await waitForCondition(() => election.snapshot().role === "leader", 2000, "leader not elected");
+
+    const before = election.snapshot();
+    (election as any).handleIncomingMessage({
+      type: "leader-heartbeat",
+      leaderTabId: "tab-new",
+      term: before.term + 5,
+      sentAtMs: Date.now(),
+    });
+
+    const after = election.snapshot();
+    expect(after.role).toBe("follower");
+    expect(after.leaderTabId).toBe("tab-new");
+    expect(after.term).toBe(before.term + 5);
+  });
+
+  it("waitForInitialLeader rejects if stopped before any leader is chosen", async () => {
+    const appId = uniqueName("app");
+    const dbName = uniqueName("db");
+    const neverAcquire: LeaderLockStrategy = {
+      async tryAcquire() {
+        return null;
+      },
+    };
+
+    const originalBroadcastChannel = (globalThis as { BroadcastChannel?: unknown })
+      .BroadcastChannel;
+    delete (globalThis as { BroadcastChannel?: unknown }).BroadcastChannel;
+    try {
+      const election = createElection(appId, dbName, "tab-a", { lockStrategy: neverAcquire });
+      election.start();
+      const promise = election.waitForInitialLeader(1000);
+      election.stop();
+      await expect(promise).rejects.toThrow(
+        "Leader election stopped before initial leader was chosen",
+      );
+    } finally {
+      (globalThis as { BroadcastChannel?: unknown }).BroadcastChannel = originalBroadcastChannel;
+    }
+  });
+
+  it("does not fail over while leader lock is still held even without heartbeat/discovery messages", async () => {
+    const appId = uniqueName("app");
+    const dbName = uniqueName("db");
+    const originalBroadcastChannel = (globalThis as { BroadcastChannel?: unknown })
+      .BroadcastChannel;
+    delete (globalThis as { BroadcastChannel?: unknown }).BroadcastChannel;
+    try {
+      const a = createElection(appId, dbName, "tab-a");
+      const b = createElection(appId, dbName, "tab-b");
+      a.start();
+      b.start();
+
+      await waitForCondition(
+        () => {
+          const roleA = a.snapshot().role;
+          const roleB = b.snapshot().role;
+          return (
+            (roleA === "leader" && roleB === "follower") ||
+            (roleA === "follower" && roleB === "leader")
+          );
+        },
+        3000,
+        "pair did not converge to leader/follower with lock-only coordination",
+      );
+
+      const leader = a.snapshot().role === "leader" ? a : b;
+      const follower = leader === a ? b : a;
+
+      await new Promise((resolve) => setTimeout(resolve, 900));
+      expect(follower.snapshot().role).toBe("follower");
+
+      leader.stop();
+      await waitForCondition(
+        () => follower.snapshot().role === "leader",
+        3000,
+        "follower did not take over after leader released lock",
+      );
+    } finally {
+      (globalThis as { BroadcastChannel?: unknown }).BroadcastChannel = originalBroadcastChannel;
+    }
+  });
+});


### PR DESCRIPTION
Currently the first tab waits for 1s before declaring themselves the leader and start the app.

Changing the init phase to rely on a lock system that would remove the initial wait.