### PR TITLE
fix: rebuild jazz-wasm when rust crate deps change

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -17,6 +17,10 @@
     "jazz-napi#build": {
       "outputs": ["jazz-napi.node", "index.d.ts"]
     },
+    "jazz-wasm#build": {
+      "dependsOn": ["@jazz/rust#build:crates"],
+      "outputs": ["pkg/**"]
+    },
     "build:crates": {
       "dependsOn": ["^build:crates"],
       "outputs": ["../target/debug/jazz*"]


### PR DESCRIPTION
Fix stale `jazz-wasm` artifacts when only Rust dependency crates change (e.g. `crates/jazz-tools` or `crates/opfs-btree`).

Before this change, edits in Rust crates used by `jazz-wasm` were not reflected at runtime unless a file inside `crates/jazz-wasm` was also modified.