### PR TITLE
Implement UUID array foreign key semantics

### DIFF
--- a/crates/jazz-tools/src/query_manager/graph.rs
+++ b/crates/jazz-tools/src/query_manager/graph.rs
@@ -914,7 +914,11 @@ impl QueryGraph {
             .split('.')
             .next_back()
             .unwrap_or(&spec.outer_column);
-        let outer_correlation_col = outer_descriptor.column_index(outer_col_name)?;
+        let outer_correlation_col = match outer_descriptor.column_index(outer_col_name) {
+            Some(index) => Some(index),
+            None if outer_col_name == "id" || outer_col_name == "_id" => None,
+            None => return None,
+        };
 
         // Build base query for subgraph, inheriting branches from outer query.
         let mut base_builder = QueryBuilder::new(spec.table);

--- a/crates/jazz-tools/src/query_manager/graph.rs
+++ b/crates/jazz-tools/src/query_manager/graph.rs
@@ -13,7 +13,7 @@ use crate::schema_manager::{SchemaContext, translate_column_for_index};
 use crate::storage::Storage;
 
 use super::graph_nodes::alias::AliasNode;
-use super::graph_nodes::array_subquery::ArraySubqueryNode;
+use super::graph_nodes::array_subquery::{ArraySubqueryNode, Correlate};
 use super::graph_nodes::exists_output::ExistsOutputNode;
 use super::graph_nodes::filter::{FilterNode, Predicate};
 use super::graph_nodes::index_scan::IndexScanNode;
@@ -914,9 +914,9 @@ impl QueryGraph {
             .split('.')
             .next_back()
             .unwrap_or(&spec.outer_column);
-        let outer_correlation_col = match outer_descriptor.column_index(outer_col_name) {
-            Some(index) => Some(index),
-            None if outer_col_name == "id" || outer_col_name == "_id" => None,
+        let outer_correlation = match outer_descriptor.column_index(outer_col_name) {
+            Some(index) => Correlate::Col(index),
+            None if outer_col_name == "id" || outer_col_name == "_id" => Correlate::Id,
             None => return None,
         };
 
@@ -1007,7 +1007,7 @@ impl QueryGraph {
         let node = ArraySubqueryNode::new(
             outer_tuple_descriptor,
             subgraph_template,
-            outer_correlation_col,
+            outer_correlation,
             spec.column_name.clone(),
             schema.clone(),
         );

--- a/crates/jazz-tools/src/query_manager/graph_nodes/array_subquery.rs
+++ b/crates/jazz-tools/src/query_manager/graph_nodes/array_subquery.rs
@@ -56,7 +56,8 @@ pub struct ArraySubqueryNode {
     schema: Schema,
 
     /// Column index in outer row that provides correlation value.
-    outer_correlation_col: usize,
+    /// `None` means correlate on the outer tuple's object id.
+    outer_correlation_col: Option<usize>,
 
     /// Per-outer-row state: outer_id → (correlation_value, array_result).
     /// We store the array result directly rather than SubgraphInstances
@@ -77,13 +78,14 @@ impl ArraySubqueryNode {
     /// # Arguments
     /// * `outer_descriptor` - Descriptor for incoming outer tuples
     /// * `subgraph_template` - Template for creating inner subgraph instances
-    /// * `outer_correlation_col` - Column index in outer row to use as correlation value
+    /// * `outer_correlation_col` - Column index in outer row to use as correlation value.
+    ///   Use `None` to correlate on the outer tuple's object id.
     /// * `array_column_name` - Name for the output array column
     /// * `schema` - Schema for compiling subgraphs
     pub fn new(
         outer_descriptor: TupleDescriptor,
         subgraph_template: SubgraphTemplate,
-        outer_correlation_col: usize,
+        outer_correlation_col: Option<usize>,
         array_column_name: String,
         schema: Schema,
     ) -> Self {
@@ -229,11 +231,15 @@ impl ArraySubqueryNode {
 
     /// Extract correlation value from an outer tuple.
     fn extract_correlation_value(&self, tuple: &Tuple) -> Option<Value> {
+        if self.outer_correlation_col.is_none() {
+            return tuple.first_id().map(Value::Uuid);
+        }
+
         let element = tuple.get(0)?;
         let content = element.content()?;
         let outer_row_desc = self.outer_descriptor.combined_descriptor();
         let values = decode_row(&outer_row_desc, content).ok()?;
-        values.get(self.outer_correlation_col).cloned()
+        values.get(self.outer_correlation_col?).cloned()
     }
 
     /// Evaluate the subgraph for a given correlation value.
@@ -244,31 +250,48 @@ impl ArraySubqueryNode {
         io: &dyn Storage,
         row_loader: &mut dyn FnMut(ObjectId) -> Option<(Vec<u8>, CommitId)>,
     ) -> Value {
-        // Create subgraph instance
+        // UUID[] FK forward includes correlate an array of ids to scalar inner ids.
+        // Evaluate each element independently so output preserves source order/duplicates.
+        if let Value::Array(elements) = correlation_value {
+            let mut materialized = Vec::new();
+            for element in elements {
+                let Value::Array(mut nested) =
+                    self.evaluate_subgraph_for_single(element, io, row_loader)
+                else {
+                    continue;
+                };
+                materialized.append(&mut nested);
+            }
+            return Value::Array(materialized);
+        }
+
+        self.evaluate_subgraph_for_single(correlation_value, io, row_loader)
+    }
+
+    fn evaluate_subgraph_for_single(
+        &self,
+        correlation_value: &Value,
+        io: &dyn Storage,
+        row_loader: &mut dyn FnMut(ObjectId) -> Option<(Vec<u8>, CommitId)>,
+    ) -> Value {
         let instance = self
             .subgraph_template
             .instantiate(correlation_value.clone(), &self.schema);
-
         let mut instance = match instance {
             Some(i) => i,
             None => return Value::Array(vec![]),
         };
 
-        // Settle the subgraph
         let row_delta = instance.graph.settle(io, row_loader);
-
-        // Convert result rows to array of Row values
         let array_elements: Vec<Value> = row_delta
             .added
             .iter()
             .filter_map(|row| {
-                // Decode row to values and wrap as a Row (heterogeneous tuple)
                 let output_desc = self.subgraph_template.output_descriptor();
                 let values = decode_row(output_desc, &row.data).ok()?;
                 Some(Value::Row(values))
             })
             .collect();
-
         Value::Array(array_elements)
     }
 
@@ -452,8 +475,13 @@ mod tests {
             .build(&schema)
             .unwrap();
 
-        let node =
-            ArraySubqueryNode::new(outer_descriptor, template, 0, "posts".to_string(), schema);
+        let node = ArraySubqueryNode::new(
+            outer_descriptor,
+            template,
+            Some(0),
+            "posts".to_string(),
+            schema,
+        );
 
         // Output should have: id, name, posts (array)
         assert_eq!(node.output_descriptor().columns.len(), 3);
@@ -484,7 +512,7 @@ mod tests {
         let node = ArraySubqueryNode::new(
             outer_descriptor,
             template,
-            0,
+            Some(0),
             "posts".to_string(),
             schema.clone(),
         );
@@ -501,5 +529,46 @@ mod tests {
 
         let correlation = node.extract_correlation_value(&user_tuple);
         assert_eq!(correlation, Some(Value::Integer(42)));
+    }
+
+    #[test]
+    fn array_subquery_extracts_object_id_correlation_value() {
+        let schema = test_schema();
+
+        let outer_descriptor = TupleDescriptor::single_with_materialization(
+            "users",
+            schema
+                .get(&TableName::new("users"))
+                .unwrap()
+                .descriptor
+                .clone(),
+            true,
+        );
+
+        let template = SubgraphBuilder::new("posts")
+            .correlate("author_id")
+            .build(&schema)
+            .unwrap();
+
+        let node = ArraySubqueryNode::new(
+            outer_descriptor,
+            template,
+            None,
+            "posts".to_string(),
+            schema.clone(),
+        );
+
+        let row_id = ObjectId::new();
+        let user_values = vec![Value::Integer(42), Value::Text("Alice".into())];
+        let user_row_desc = &schema.get(&TableName::new("users")).unwrap().descriptor;
+        let user_data = encode_row(user_row_desc, &user_values).unwrap();
+        let user_tuple = Tuple::new(vec![TupleElement::Row {
+            id: row_id,
+            content: user_data,
+            commit_id: CommitId([0; 32]),
+        }]);
+
+        let correlation = node.extract_correlation_value(&user_tuple);
+        assert_eq!(correlation, Some(Value::Uuid(row_id)));
     }
 }

--- a/crates/jazz-tools/src/query_manager/graph_nodes/array_subquery.rs
+++ b/crates/jazz-tools/src/query_manager/graph_nodes/array_subquery.rs
@@ -41,6 +41,14 @@ use super::subgraph::SubgraphTemplate;
 /// - Memory overhead per instance
 /// - Update cost distribution (how many instances need re-settling on inner change?)
 /// - Common subgraph patterns that could benefit from memoization
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Correlate {
+    /// Correlate using a column value from the outer row.
+    Col(usize),
+    /// Correlate using the outer tuple's object id.
+    Id,
+}
+
 #[derive(Debug)]
 pub struct ArraySubqueryNode {
     /// Descriptor for outer tuples.
@@ -55,9 +63,8 @@ pub struct ArraySubqueryNode {
     /// Schema for compiling subgraphs.
     schema: Schema,
 
-    /// Column index in outer row that provides correlation value.
-    /// `None` means correlate on the outer tuple's object id.
-    outer_correlation_col: Option<usize>,
+    /// Source of the correlation value from the outer tuple.
+    outer_correlation: Correlate,
 
     /// Per-outer-row state: outer_id → (correlation_value, array_result).
     /// We store the array result directly rather than SubgraphInstances
@@ -78,14 +85,13 @@ impl ArraySubqueryNode {
     /// # Arguments
     /// * `outer_descriptor` - Descriptor for incoming outer tuples
     /// * `subgraph_template` - Template for creating inner subgraph instances
-    /// * `outer_correlation_col` - Column index in outer row to use as correlation value.
-    ///   Use `None` to correlate on the outer tuple's object id.
+    /// * `outer_correlation` - Source for correlation value from outer tuple.
     /// * `array_column_name` - Name for the output array column
     /// * `schema` - Schema for compiling subgraphs
     pub fn new(
         outer_descriptor: TupleDescriptor,
         subgraph_template: SubgraphTemplate,
-        outer_correlation_col: Option<usize>,
+        outer_correlation: Correlate,
         array_column_name: String,
         schema: Schema,
     ) -> Self {
@@ -115,7 +121,7 @@ impl ArraySubqueryNode {
             output_tuple_descriptor,
             subgraph_template,
             schema,
-            outer_correlation_col,
+            outer_correlation,
             instances: AHashMap::new(),
             current_tuples: AHashSet::new(),
             dirty: true,
@@ -231,15 +237,16 @@ impl ArraySubqueryNode {
 
     /// Extract correlation value from an outer tuple.
     fn extract_correlation_value(&self, tuple: &Tuple) -> Option<Value> {
-        if self.outer_correlation_col.is_none() {
-            return tuple.first_id().map(Value::Uuid);
+        match self.outer_correlation {
+            Correlate::Id => tuple.first_id().map(Value::Uuid),
+            Correlate::Col(col_idx) => {
+                let element = tuple.get(0)?;
+                let content = element.content()?;
+                let outer_row_desc = self.outer_descriptor.combined_descriptor();
+                let values = decode_row(&outer_row_desc, content).ok()?;
+                values.get(col_idx).cloned()
+            }
         }
-
-        let element = tuple.get(0)?;
-        let content = element.content()?;
-        let outer_row_desc = self.outer_descriptor.combined_descriptor();
-        let values = decode_row(&outer_row_desc, content).ok()?;
-        values.get(self.outer_correlation_col?).cloned()
     }
 
     /// Evaluate the subgraph for a given correlation value.
@@ -478,7 +485,7 @@ mod tests {
         let node = ArraySubqueryNode::new(
             outer_descriptor,
             template,
-            Some(0),
+            Correlate::Col(0),
             "posts".to_string(),
             schema,
         );
@@ -512,7 +519,7 @@ mod tests {
         let node = ArraySubqueryNode::new(
             outer_descriptor,
             template,
-            Some(0),
+            Correlate::Col(0),
             "posts".to_string(),
             schema.clone(),
         );
@@ -553,7 +560,7 @@ mod tests {
         let node = ArraySubqueryNode::new(
             outer_descriptor,
             template,
-            None,
+            Correlate::Id,
             "posts".to_string(),
             schema.clone(),
         );

--- a/crates/jazz-tools/src/query_manager/graph_nodes/join.rs
+++ b/crates/jazz-tools/src/query_manager/graph_nodes/join.rs
@@ -1,8 +1,10 @@
 use ahash::{AHashMap, AHashSet};
 
 use crate::object::ObjectId;
-use crate::query_manager::encoding::column_bytes;
-use crate::query_manager::types::{RowDescriptor, Tuple, TupleDelta, TupleDescriptor};
+use crate::query_manager::encoding::{column_bytes, decode_column, encode_value};
+use crate::query_manager::types::{
+    ColumnType, RowDescriptor, Tuple, TupleDelta, TupleDescriptor, Value,
+};
 
 /// Join node for equi-joins.
 ///
@@ -86,6 +88,7 @@ enum JoinKeySpec {
         element_index: usize,
         row_descriptor: RowDescriptor,
         local_col_index: usize,
+        match_array_elements: bool,
     },
 }
 
@@ -168,33 +171,59 @@ impl JoinNode {
         &self.output_descriptor
     }
 
-    /// Extract join key from a left tuple.
-    fn extract_left_key(&self, tuple: &Tuple) -> Option<Vec<u8>> {
-        self.extract_key(tuple, &self.left_key_spec)
+    /// Extract join keys from a left tuple.
+    fn extract_left_keys(&self, tuple: &Tuple) -> Vec<Vec<u8>> {
+        self.extract_keys(tuple, &self.left_key_spec)
     }
 
-    /// Extract join key from a right tuple.
-    fn extract_right_key(&self, tuple: &Tuple) -> Option<Vec<u8>> {
-        self.extract_key(tuple, &self.right_key_spec)
+    /// Extract join keys from a right tuple.
+    fn extract_right_keys(&self, tuple: &Tuple) -> Vec<Vec<u8>> {
+        self.extract_keys(tuple, &self.right_key_spec)
     }
 
-    fn extract_key(&self, tuple: &Tuple, spec: &JoinKeySpec) -> Option<Vec<u8>> {
+    fn extract_keys(&self, tuple: &Tuple, spec: &JoinKeySpec) -> Vec<Vec<u8>> {
         match spec {
             JoinKeySpec::TupleId { element_index } => {
-                let id = tuple.get(*element_index)?.id();
-                Some(id.uuid().as_bytes().to_vec())
+                let Some(id) = tuple.get(*element_index).map(|element| element.id()) else {
+                    return Vec::new();
+                };
+                vec![id.uuid().as_bytes().to_vec()]
             }
             JoinKeySpec::Column {
                 element_index,
                 row_descriptor,
                 local_col_index,
+                match_array_elements,
             } => {
-                let element = tuple.get(*element_index)?;
-                let content = element.content()?;
-                column_bytes(row_descriptor, content, *local_col_index)
-                    .ok()
-                    .flatten()
-                    .map(|b| b.to_vec())
+                let Some(element) = tuple.get(*element_index) else {
+                    return Vec::new();
+                };
+                let Some(content) = element.content() else {
+                    return Vec::new();
+                };
+                if !match_array_elements {
+                    return column_bytes(row_descriptor, content, *local_col_index)
+                        .ok()
+                        .flatten()
+                        .map(|bytes| vec![bytes.to_vec()])
+                        .unwrap_or_default();
+                }
+
+                let Ok(Value::Array(values)) =
+                    decode_column(row_descriptor, content, *local_col_index)
+                else {
+                    return Vec::new();
+                };
+
+                let mut out = Vec::new();
+                let mut seen = AHashSet::new();
+                for value in values {
+                    let encoded = encode_value(&value);
+                    if seen.insert(encoded.clone()) {
+                        out.push(encoded);
+                    }
+                }
+                out
             }
         }
     }
@@ -226,10 +255,15 @@ impl JoinNode {
 
         let element = tuple_descriptor.element(element_index)?;
         if let Some(local_col_index) = element.descriptor.column_index(&column_ref.column) {
+            let match_array_elements = matches!(
+                element.descriptor.columns[local_col_index].column_type,
+                ColumnType::Array(_)
+            );
             return Some(JoinKeySpec::Column {
                 element_index,
                 row_descriptor: element.descriptor.clone(),
                 local_col_index,
+                match_array_elements,
             });
         }
 
@@ -257,10 +291,15 @@ impl JoinNode {
 
         if matches.len() == 1 {
             let (element_index, local_col_index, row_descriptor) = matches[0].clone();
+            let match_array_elements = matches!(
+                row_descriptor.columns[local_col_index].column_type,
+                ColumnType::Array(_)
+            );
             return Some(JoinKeySpec::Column {
                 element_index,
                 row_descriptor,
                 local_col_index,
+                match_array_elements,
             });
         }
 
@@ -283,32 +322,36 @@ impl JoinNode {
     fn add_left_tuple(&mut self, tuple: Tuple) -> Vec<Tuple> {
         let mut new_outputs = Vec::new();
 
-        if let Some(key) = self.extract_left_key(&tuple) {
-            // Add to left index
+        let keys = self.extract_left_keys(&tuple);
+        for key in &keys {
             self.left_by_key
                 .entry(key.clone())
                 .or_default()
                 .insert(tuple.clone());
+        }
 
-            // Find matching right tuples
-            if let Some(right_matches) = self.right_by_key.get(&key) {
-                for right_tuple in right_matches {
-                    let combined = self.combine_tuples(&tuple, right_tuple);
-
-                    // Track provenance
-                    self.left_to_output
-                        .entry(tuple.ids())
-                        .or_default()
-                        .insert(combined.clone());
-                    self.right_to_output
-                        .entry(right_tuple.ids())
-                        .or_default()
-                        .insert(combined.clone());
-
-                    self.current_tuples.insert(combined.clone());
-                    new_outputs.push(combined);
-                }
+        let mut right_matches = AHashSet::new();
+        for key in &keys {
+            if let Some(matches_for_key) = self.right_by_key.get(key) {
+                right_matches.extend(matches_for_key.iter().cloned());
             }
+        }
+
+        for right_tuple in right_matches {
+            let combined = self.combine_tuples(&tuple, &right_tuple);
+
+            // Track provenance
+            self.left_to_output
+                .entry(tuple.ids())
+                .or_default()
+                .insert(combined.clone());
+            self.right_to_output
+                .entry(right_tuple.ids())
+                .or_default()
+                .insert(combined.clone());
+
+            self.current_tuples.insert(combined.clone());
+            new_outputs.push(combined);
         }
 
         self.left_tuples.insert(tuple);
@@ -319,8 +362,7 @@ impl JoinNode {
     fn remove_left_tuple(&mut self, tuple: &Tuple) -> Vec<Tuple> {
         let mut removed_outputs = Vec::new();
 
-        if let Some(key) = self.extract_left_key(tuple) {
-            // Remove from left index
+        for key in self.extract_left_keys(tuple) {
             if let Some(set) = self.left_by_key.get_mut(&key) {
                 set.remove(tuple);
                 if set.is_empty() {
@@ -356,32 +398,36 @@ impl JoinNode {
     fn add_right_tuple(&mut self, tuple: Tuple) -> Vec<Tuple> {
         let mut new_outputs = Vec::new();
 
-        if let Some(key) = self.extract_right_key(&tuple) {
-            // Add to right index
+        let keys = self.extract_right_keys(&tuple);
+        for key in &keys {
             self.right_by_key
                 .entry(key.clone())
                 .or_default()
                 .insert(tuple.clone());
+        }
 
-            // Find matching left tuples
-            if let Some(left_matches) = self.left_by_key.get(&key) {
-                for left_tuple in left_matches {
-                    let combined = self.combine_tuples(left_tuple, &tuple);
-
-                    // Track provenance
-                    self.left_to_output
-                        .entry(left_tuple.ids())
-                        .or_default()
-                        .insert(combined.clone());
-                    self.right_to_output
-                        .entry(tuple.ids())
-                        .or_default()
-                        .insert(combined.clone());
-
-                    self.current_tuples.insert(combined.clone());
-                    new_outputs.push(combined);
-                }
+        let mut left_matches = AHashSet::new();
+        for key in &keys {
+            if let Some(matches_for_key) = self.left_by_key.get(key) {
+                left_matches.extend(matches_for_key.iter().cloned());
             }
+        }
+
+        for left_tuple in left_matches {
+            let combined = self.combine_tuples(&left_tuple, &tuple);
+
+            // Track provenance
+            self.left_to_output
+                .entry(left_tuple.ids())
+                .or_default()
+                .insert(combined.clone());
+            self.right_to_output
+                .entry(tuple.ids())
+                .or_default()
+                .insert(combined.clone());
+
+            self.current_tuples.insert(combined.clone());
+            new_outputs.push(combined);
         }
 
         self.right_tuples.insert(tuple);
@@ -392,8 +438,7 @@ impl JoinNode {
     fn remove_right_tuple(&mut self, tuple: &Tuple) -> Vec<Tuple> {
         let mut removed_outputs = Vec::new();
 
-        if let Some(key) = self.extract_right_key(tuple) {
-            // Remove from right index
+        for key in self.extract_right_keys(tuple) {
             if let Some(set) = self.right_by_key.get_mut(&key) {
                 set.remove(tuple);
                 if set.is_empty() {
@@ -542,6 +587,17 @@ mod tests {
         ])
     }
 
+    fn files_descriptor() -> RowDescriptor {
+        RowDescriptor::new(vec![ColumnDescriptor::new(
+            "parts",
+            ColumnType::Array(Box::new(ColumnType::Uuid)),
+        )])
+    }
+
+    fn file_parts_descriptor() -> RowDescriptor {
+        RowDescriptor::new(vec![ColumnDescriptor::new("name", ColumnType::Text)])
+    }
+
     fn make_user_tuple(id: ObjectId, user_id: i32, name: &str) -> Tuple {
         let descriptor = users_descriptor();
         let data = encode_row(
@@ -596,6 +652,111 @@ mod tests {
             content: data,
             commit_id: CommitId([0; 32]),
         }])
+    }
+
+    fn make_file_tuple(id: ObjectId, parts: Vec<ObjectId>) -> Tuple {
+        let descriptor = files_descriptor();
+        let data = encode_row(
+            &descriptor,
+            &[Value::Array(parts.into_iter().map(Value::Uuid).collect())],
+        )
+        .unwrap();
+        Tuple::new(vec![TupleElement::Row {
+            id,
+            content: data,
+            commit_id: CommitId([0; 32]),
+        }])
+    }
+
+    fn make_file_part_tuple(id: ObjectId, name: &str) -> Tuple {
+        let descriptor = file_parts_descriptor();
+        let data = encode_row(&descriptor, &[Value::Text(name.into())]).unwrap();
+        Tuple::new(vec![TupleElement::Row {
+            id,
+            content: data,
+            commit_id: CommitId([0; 32]),
+        }])
+    }
+
+    #[test]
+    fn join_matches_array_membership_for_forward_fk_hops() {
+        let mut node = JoinNode::from_row_descriptors(
+            "files",
+            files_descriptor(),
+            "file_parts",
+            file_parts_descriptor(),
+            "parts",
+            "id",
+        )
+        .expect("array-fk forward join should compile");
+
+        let file_id = ObjectId::new();
+        let part_a = ObjectId::new();
+        let part_b = ObjectId::new();
+
+        let file = make_file_tuple(file_id, vec![part_a, part_b, part_a]);
+        let row_a = make_file_part_tuple(part_a, "A");
+        let row_b = make_file_part_tuple(part_b, "B");
+
+        node.process_left(TupleDelta {
+            added: vec![file],
+            removed: vec![],
+            updated: vec![],
+        });
+        let delta = node.process_right(TupleDelta {
+            added: vec![row_a, row_b],
+            removed: vec![],
+            updated: vec![],
+        });
+
+        assert_eq!(
+            delta.added.len(),
+            2,
+            "membership join should match both part ids"
+        );
+        assert_eq!(
+            node.current_tuples().len(),
+            2,
+            "join outputs are row-set semantics (deduped by tuple identity)"
+        );
+    }
+
+    #[test]
+    fn join_matches_array_membership_for_reverse_fk_hops() {
+        let mut node = JoinNode::from_row_descriptors(
+            "file_parts",
+            file_parts_descriptor(),
+            "files",
+            files_descriptor(),
+            "id",
+            "parts",
+        )
+        .expect("array-fk reverse join should compile");
+
+        let file_id = ObjectId::new();
+        let part_a = ObjectId::new();
+        let part_b = ObjectId::new();
+
+        let file = make_file_tuple(file_id, vec![part_a, part_b]);
+        let row_a = make_file_part_tuple(part_a, "A");
+        let row_b = make_file_part_tuple(part_b, "B");
+
+        node.process_right(TupleDelta {
+            added: vec![file],
+            removed: vec![],
+            updated: vec![],
+        });
+        let delta = node.process_left(TupleDelta {
+            added: vec![row_a, row_b],
+            removed: vec![],
+            updated: vec![],
+        });
+
+        assert_eq!(
+            delta.added.len(),
+            2,
+            "reverse membership join should match file rows containing each part id"
+        );
     }
 
     #[test]

--- a/crates/jazz-tools/src/query_manager/graph_nodes/join.rs
+++ b/crates/jazz-tools/src/query_manager/graph_nodes/join.rs
@@ -697,13 +697,11 @@ mod tests {
 
         node.process_left(TupleDelta {
             added: vec![file],
-            removed: vec![],
-            updated: vec![],
+            ..Default::default()
         });
         let delta = node.process_right(TupleDelta {
             added: vec![row_a, row_b],
-            removed: vec![],
-            updated: vec![],
+            ..Default::default()
         });
 
         assert_eq!(
@@ -740,13 +738,11 @@ mod tests {
 
         node.process_right(TupleDelta {
             added: vec![file],
-            removed: vec![],
-            updated: vec![],
+            ..Default::default()
         });
         let delta = node.process_left(TupleDelta {
             added: vec![row_a, row_b],
-            removed: vec![],
-            updated: vec![],
+            ..Default::default()
         });
 
         assert_eq!(

--- a/crates/jazz-tools/src/query_manager/graph_nodes/join.rs
+++ b/crates/jazz-tools/src/query_manager/graph_nodes/join.rs
@@ -181,6 +181,18 @@ impl JoinNode {
         self.extract_keys(tuple, &self.right_key_spec)
     }
 
+    fn encode_unique_values(values: &[Value]) -> Vec<Vec<u8>> {
+        let mut out = Vec::with_capacity(values.len());
+        let mut seen = AHashSet::new();
+        for value in values {
+            let encoded = encode_value(value);
+            if seen.insert(encoded.clone()) {
+                out.push(encoded);
+            }
+        }
+        out
+    }
+
     fn extract_keys(&self, tuple: &Tuple, spec: &JoinKeySpec) -> Vec<Vec<u8>> {
         match spec {
             JoinKeySpec::TupleId { element_index } => {
@@ -214,16 +226,7 @@ impl JoinNode {
                 else {
                     return Vec::new();
                 };
-
-                let mut out = Vec::new();
-                let mut seen = AHashSet::new();
-                for value in values {
-                    let encoded = encode_value(&value);
-                    if seen.insert(encoded.clone()) {
-                        out.push(encoded);
-                    }
-                }
-                out
+                Self::encode_unique_values(&values)
             }
         }
     }
@@ -323,15 +326,12 @@ impl JoinNode {
         let mut new_outputs = Vec::new();
 
         let keys = self.extract_left_keys(&tuple);
+        let mut right_matches = AHashSet::new();
         for key in &keys {
             self.left_by_key
                 .entry(key.clone())
                 .or_default()
                 .insert(tuple.clone());
-        }
-
-        let mut right_matches = AHashSet::new();
-        for key in &keys {
             if let Some(matches_for_key) = self.right_by_key.get(key) {
                 right_matches.extend(matches_for_key.iter().cloned());
             }
@@ -399,15 +399,12 @@ impl JoinNode {
         let mut new_outputs = Vec::new();
 
         let keys = self.extract_right_keys(&tuple);
+        let mut left_matches = AHashSet::new();
         for key in &keys {
             self.right_by_key
                 .entry(key.clone())
                 .or_default()
                 .insert(tuple.clone());
-        }
-
-        let mut left_matches = AHashSet::new();
-        for key in &keys {
             if let Some(matches_for_key) = self.left_by_key.get(key) {
                 left_matches.extend(matches_for_key.iter().cloned());
             }

--- a/crates/jazz-tools/src/query_manager/indices.rs
+++ b/crates/jazz-tools/src/query_manager/indices.rs
@@ -3,9 +3,58 @@ use crate::storage::Storage;
 
 use super::encoding::decode_column;
 use super::manager::{QueryError, QueryManager};
-use super::types::{RowDescriptor, Value};
+use super::types::{ColumnDescriptor, ColumnType, RowDescriptor, Value};
 
 impl QueryManager {
+    fn expand_index_values(column: &ColumnDescriptor, value: &Value) -> Vec<Value> {
+        let mut values = vec![value.clone()];
+        if column.references.is_some()
+            && matches!(
+                &column.column_type,
+                ColumnType::Array(element_type) if matches!(element_type.as_ref(), ColumnType::Uuid)
+            )
+            && let Value::Array(elements) = value
+        {
+            values.extend(
+                elements
+                    .iter()
+                    .filter(|element| matches!(element, Value::Uuid(_)))
+                    .cloned(),
+            );
+        }
+        values
+    }
+
+    fn insert_column_index_values(
+        storage: &mut dyn Storage,
+        table: &str,
+        column: &ColumnDescriptor,
+        branch: &str,
+        value: &Value,
+        object_id: ObjectId,
+    ) -> Result<(), QueryError> {
+        for index_value in Self::expand_index_values(column, value) {
+            storage
+                .index_insert(table, column.name.as_str(), branch, &index_value, object_id)
+                .map_err(|e| QueryError::IndexError(format!("{:?}", e)))?;
+        }
+        Ok(())
+    }
+
+    fn remove_column_index_values(
+        storage: &mut dyn Storage,
+        table: &str,
+        column: &ColumnDescriptor,
+        branch: &str,
+        value: &Value,
+        object_id: ObjectId,
+    ) {
+        for index_value in Self::expand_index_values(column, value) {
+            let _ =
+                storage.index_remove(table, column.name.as_str(), branch, &index_value, object_id);
+        }
+    }
+
     /// Update indices when a row is inserted on a specific branch.
     pub(super) fn update_indices_for_insert_on_branch(
         storage: &mut dyn Storage,
@@ -25,9 +74,7 @@ impl QueryManager {
             if let Ok(value) = decode_column(descriptor, data, col_idx)
                 && value != Value::Null
             {
-                storage
-                    .index_insert(table, col.name.as_str(), branch, &value, object_id)
-                    .map_err(|e| QueryError::IndexError(format!("{:?}", e)))?;
+                Self::insert_column_index_values(storage, table, col, branch, &value, object_id)?;
             }
         }
 
@@ -71,15 +118,17 @@ impl QueryManager {
             if let Ok(old_value) = decode_column(descriptor, old_data, col_idx)
                 && old_value != Value::Null
             {
-                let _ =
-                    storage.index_remove(table, col.name.as_str(), branch, &old_value, object_id);
+                Self::remove_column_index_values(
+                    storage, table, col, branch, &old_value, object_id,
+                );
             }
             // Add new value
             if let Ok(new_value) = decode_column(descriptor, new_data, col_idx)
                 && new_value != Value::Null
             {
-                let _ =
-                    storage.index_insert(table, col.name.as_str(), branch, &new_value, object_id);
+                let _ = Self::insert_column_index_values(
+                    storage, table, col, branch, &new_value, object_id,
+                );
             }
         }
 
@@ -124,7 +173,7 @@ impl QueryManager {
             if let Ok(value) = decode_column(descriptor, old_data, col_idx)
                 && value != Value::Null
             {
-                let _ = storage.index_remove(table, col.name.as_str(), branch, &value, object_id);
+                Self::remove_column_index_values(storage, table, col, branch, &value, object_id);
             }
         }
 
@@ -179,8 +228,9 @@ impl QueryManager {
                 if let Ok(value) = decode_column(descriptor, data, col_idx)
                     && value != Value::Null
                 {
-                    let _ =
-                        storage.index_remove(table, col.name.as_str(), branch, &value, object_id);
+                    Self::remove_column_index_values(
+                        storage, table, col, branch, &value, object_id,
+                    );
                 }
             }
         }
@@ -244,7 +294,9 @@ impl QueryManager {
             if let Ok(value) = decode_column(descriptor, new_data, col_idx)
                 && value != Value::Null
             {
-                let _ = storage.index_insert(table, col.name.as_str(), branch, &value, object_id);
+                let _ = Self::insert_column_index_values(
+                    storage, table, col, branch, &value, object_id,
+                );
             }
         }
 

--- a/crates/jazz-tools/src/query_manager/manager.rs
+++ b/crates/jazz-tools/src/query_manager/manager.rs
@@ -44,6 +44,13 @@ pub enum QueryError {
         table: TableName,
         operation: Operation,
     },
+    /// UUID[] reference points at a missing row.
+    UuidArrayForeignKeyViolation {
+        table: TableName,
+        column: String,
+        referenced_table: TableName,
+        missing_id: ObjectId,
+    },
     /// Unknown schema hash - client should sync schema first.
     UnknownSchema(SchemaHash),
 }
@@ -68,6 +75,16 @@ impl std::fmt::Display for QueryError {
             QueryError::PolicyDenied { table, operation } => {
                 write!(f, "policy denied {} on table {}", operation, table)
             }
+            QueryError::UuidArrayForeignKeyViolation {
+                table,
+                column,
+                referenced_table,
+                missing_id,
+            } => write!(
+                f,
+                "uuid[] foreign key violation on {}.{}: missing referenced row {} in table {}",
+                table, column, missing_id, referenced_table
+            ),
             QueryError::UnknownSchema(hash) => {
                 write!(
                     f,

--- a/crates/jazz-tools/src/query_manager/manager.rs
+++ b/crates/jazz-tools/src/query_manager/manager.rs
@@ -44,6 +44,13 @@ pub enum QueryError {
         table: TableName,
         operation: Operation,
     },
+    /// UUID reference points at a missing row.
+    UuidForeignKeyViolation {
+        table: TableName,
+        column: String,
+        referenced_table: TableName,
+        missing_id: ObjectId,
+    },
     /// UUID[] reference points at a missing row.
     UuidArrayForeignKeyViolation {
         table: TableName,
@@ -75,6 +82,16 @@ impl std::fmt::Display for QueryError {
             QueryError::PolicyDenied { table, operation } => {
                 write!(f, "policy denied {} on table {}", operation, table)
             }
+            QueryError::UuidForeignKeyViolation {
+                table,
+                column,
+                referenced_table,
+                missing_id,
+            } => write!(
+                f,
+                "uuid foreign key violation on {}.{}: missing referenced row {} in table {}",
+                table, column, missing_id, referenced_table
+            ),
             QueryError::UuidArrayForeignKeyViolation {
                 table,
                 column,

--- a/crates/jazz-tools/src/query_manager/manager_tests.rs
+++ b/crates/jazz-tools/src/query_manager/manager_tests.rs
@@ -3567,6 +3567,23 @@ fn file_storage_schema() -> Schema {
     schema
 }
 
+fn scalar_fk_schema() -> Schema {
+    let mut schema = Schema::new();
+    schema.insert(
+        TableName::new("users"),
+        RowDescriptor::new(vec![ColumnDescriptor::new("name", ColumnType::Text)]).into(),
+    );
+    schema.insert(
+        TableName::new("posts"),
+        RowDescriptor::new(vec![
+            ColumnDescriptor::new("title", ColumnType::Text),
+            ColumnDescriptor::new("author_id", ColumnType::Uuid).references("users"),
+        ])
+        .into(),
+    );
+    schema
+}
+
 fn files_with_parts_descriptor() -> RowDescriptor {
     let part_descriptor =
         RowDescriptor::new(vec![ColumnDescriptor::new("label", ColumnType::Text)]);
@@ -3577,6 +3594,58 @@ fn files_with_parts_descriptor() -> RowDescriptor {
             ColumnType::Array(Box::new(ColumnType::Row(Box::new(part_descriptor)))),
         ),
     ])
+}
+
+#[test]
+fn scalar_uuid_fk_insert_and_update_validation() {
+    let sync_manager = SyncManager::new();
+    let schema = scalar_fk_schema();
+    let (mut qm, mut storage) = create_query_manager(sync_manager, schema);
+
+    let missing_author = ObjectId::new();
+    let insert_missing = qm.insert(
+        &mut storage,
+        "posts",
+        &[Value::Text("missing".into()), Value::Uuid(missing_author)],
+    );
+    assert!(
+        matches!(
+            insert_missing,
+            Err(QueryError::UuidForeignKeyViolation { ref column, .. }) if column == "author_id"
+        ),
+        "insert with missing UUID reference should fail: {insert_missing:?}"
+    );
+
+    let author = qm
+        .insert(&mut storage, "users", &[Value::Text("Alice".into())])
+        .unwrap();
+    let post = qm
+        .insert(
+            &mut storage,
+            "posts",
+            &[Value::Text("ok".into()), Value::Uuid(author.row_id)],
+        )
+        .unwrap();
+
+    qm.update(
+        &mut storage,
+        post.row_id,
+        &[Value::Text("still-ok".into()), Value::Uuid(author.row_id)],
+    )
+    .unwrap();
+
+    let update_missing = qm.update(
+        &mut storage,
+        post.row_id,
+        &[Value::Text("broken".into()), Value::Uuid(ObjectId::new())],
+    );
+    assert!(
+        matches!(
+            update_missing,
+            Err(QueryError::UuidForeignKeyViolation { .. })
+        ),
+        "update with missing UUID reference should fail: {update_missing:?}"
+    );
 }
 
 #[test]
@@ -3779,6 +3848,139 @@ fn uuid_array_fk_reverse_membership_and_index_updates_on_edit() {
         "removed array members should be removed from membership index"
     );
     assert!(ids_for_b_after.contains(&file.row_id));
+}
+
+#[test]
+fn server_permission_checks_reject_missing_scalar_fk_writes() {
+    use crate::commit::{Commit, StoredState};
+    use crate::sync_manager::{
+        ClientId, ClientRole, InboxEntry, ObjectMetadata, Source, SyncError, SyncPayload,
+    };
+
+    let sync_manager = SyncManager::new();
+    let schema = scalar_fk_schema();
+    let (mut qm, mut storage) = create_query_manager(sync_manager, schema);
+    let branch = get_branch(&qm);
+
+    let client_id = ClientId::new();
+    qm.sync_manager_mut().add_client(client_id);
+    qm.sync_manager_mut()
+        .set_client_role(client_id, ClientRole::User);
+    qm.sync_manager_mut()
+        .set_client_session(client_id, PolicySession::new("alice"));
+
+    let post_descriptor = RowDescriptor::new(vec![
+        ColumnDescriptor::new("title", ColumnType::Text),
+        ColumnDescriptor::new("author_id", ColumnType::Uuid),
+    ]);
+
+    let missing_author = ObjectId::new();
+    let inserted_post_id = ObjectId::new();
+    let insert_metadata =
+        std::collections::HashMap::from([(MetadataKey::Table.to_string(), "posts".to_string())]);
+    qm.sync_manager_mut().object_manager.receive_object(
+        &mut storage,
+        inserted_post_id,
+        insert_metadata.clone(),
+    );
+    let insert_payload = SyncPayload::ObjectUpdated {
+        object_id: inserted_post_id,
+        metadata: Some(ObjectMetadata {
+            id: inserted_post_id,
+            metadata: insert_metadata,
+        }),
+        branch_name: branch.clone().into(),
+        commits: vec![Commit {
+            parents: smallvec![],
+            content: encode_row(
+                &post_descriptor,
+                &[
+                    Value::Text("from-client".into()),
+                    Value::Uuid(missing_author),
+                ],
+            )
+            .unwrap(),
+            timestamp: 1000,
+            author: inserted_post_id,
+            metadata: None,
+            stored_state: StoredState::Stored,
+            ack_state: Default::default(),
+        }],
+    };
+
+    qm.sync_manager_mut().push_inbox(InboxEntry {
+        source: Source::Client(client_id),
+        payload: insert_payload,
+    });
+    qm.process(&mut storage);
+
+    let outbox = qm.sync_manager_mut().take_outbox();
+    let insert_rejection = outbox.iter().find_map(|entry| match &entry.payload {
+        SyncPayload::Error(SyncError::PermissionDenied { reason, .. }) => Some(reason.as_str()),
+        _ => None,
+    });
+    assert!(
+        matches!(insert_rejection, Some(reason) if reason.contains("uuid foreign key violation")),
+        "insert should be rejected for missing scalar FK: {outbox:?}"
+    );
+
+    let author = qm
+        .insert(&mut storage, "users", &[Value::Text("Author".into())])
+        .unwrap();
+    let post = qm
+        .insert(
+            &mut storage,
+            "posts",
+            &[Value::Text("seed".into()), Value::Uuid(author.row_id)],
+        )
+        .unwrap();
+    let seed_row = qm.get_row(post.row_id).expect("seed post should exist");
+    assert_eq!(seed_row.1[1], Value::Uuid(author.row_id));
+
+    let update_payload = SyncPayload::ObjectUpdated {
+        object_id: post.row_id,
+        metadata: None,
+        branch_name: branch.clone().into(),
+        commits: vec![Commit {
+            parents: smallvec![post.row_commit_id],
+            content: encode_row(
+                &post_descriptor,
+                &[
+                    Value::Text("update-attempt".into()),
+                    Value::Uuid(ObjectId::new()),
+                ],
+            )
+            .unwrap(),
+            timestamp: 2000,
+            author: post.row_id,
+            metadata: None,
+            stored_state: StoredState::Stored,
+            ack_state: Default::default(),
+        }],
+    };
+
+    qm.sync_manager_mut().push_inbox(InboxEntry {
+        source: Source::Client(client_id),
+        payload: update_payload,
+    });
+    qm.process(&mut storage);
+
+    let outbox = qm.sync_manager_mut().take_outbox();
+    let update_rejection = outbox.iter().find_map(|entry| match &entry.payload {
+        SyncPayload::Error(SyncError::PermissionDenied { reason, .. }) => Some(reason.as_str()),
+        _ => None,
+    });
+    assert!(
+        matches!(update_rejection, Some(reason) if reason.contains("uuid foreign key violation")),
+        "update should be rejected for missing scalar FK: {outbox:?}"
+    );
+
+    let post_after = qm.get_row(post.row_id).expect("post should still exist");
+    assert_eq!(
+        post_after.1[1],
+        Value::Uuid(author.row_id),
+        "rejected update must not overwrite existing scalar FK value"
+    );
 }
 
 fn users_posts_schema() -> Schema {

--- a/crates/jazz-tools/src/query_manager/manager_tests.rs
+++ b/crates/jazz-tools/src/query_manager/manager_tests.rs
@@ -14,7 +14,7 @@ use crate::query_manager::types::{
     ColumnDescriptor, ColumnType, PolicyExpr, RowDescriptor, Schema, TableName, TablePolicies,
     TableSchema, Value,
 };
-use crate::storage::MemoryStorage;
+use crate::storage::{MemoryStorage, Storage};
 use crate::sync_manager::SyncManager;
 
 fn test_schema() -> Schema {
@@ -3549,6 +3549,237 @@ fn deleting_parent_row_does_not_cascade_to_joined_rows() {
 // ========================================================================
 // Array subquery (correlated subquery) tests
 // ========================================================================
+
+fn file_storage_schema() -> Schema {
+    let mut schema = Schema::new();
+    schema.insert(
+        TableName::new("file_parts"),
+        RowDescriptor::new(vec![ColumnDescriptor::new("label", ColumnType::Text)]).into(),
+    );
+    schema.insert(
+        TableName::new("files"),
+        RowDescriptor::new(vec![
+            ColumnDescriptor::new("parts", ColumnType::Array(Box::new(ColumnType::Uuid)))
+                .references("file_parts"),
+        ])
+        .into(),
+    );
+    schema
+}
+
+fn files_with_parts_descriptor() -> RowDescriptor {
+    let part_descriptor =
+        RowDescriptor::new(vec![ColumnDescriptor::new("label", ColumnType::Text)]);
+    RowDescriptor::new(vec![
+        ColumnDescriptor::new("parts", ColumnType::Array(Box::new(ColumnType::Uuid))),
+        ColumnDescriptor::new(
+            "part_rows",
+            ColumnType::Array(Box::new(ColumnType::Row(Box::new(part_descriptor)))),
+        ),
+    ])
+}
+
+#[test]
+fn uuid_array_fk_insert_and_update_validation() {
+    let sync_manager = SyncManager::new();
+    let schema = file_storage_schema();
+    let (mut qm, mut storage) = create_query_manager(sync_manager, schema);
+
+    let missing = ObjectId::new();
+    let insert_missing = qm.insert(
+        &mut storage,
+        "files",
+        &[Value::Array(vec![Value::Uuid(missing)])],
+    );
+    assert!(
+        matches!(
+            insert_missing,
+            Err(QueryError::UuidArrayForeignKeyViolation { ref column, .. }) if column == "parts"
+        ),
+        "insert with missing UUID[] reference should fail: {insert_missing:?}"
+    );
+
+    let part = qm
+        .insert(&mut storage, "file_parts", &[Value::Text("A".into())])
+        .unwrap();
+    let file = qm
+        .insert(
+            &mut storage,
+            "files",
+            &[Value::Array(vec![
+                Value::Uuid(part.row_id),
+                Value::Uuid(part.row_id),
+            ])],
+        )
+        .unwrap();
+    qm.update(
+        &mut storage,
+        file.row_id,
+        &[Value::Array(vec![Value::Uuid(part.row_id)])],
+    )
+    .unwrap();
+
+    let update_missing = qm.update(
+        &mut storage,
+        file.row_id,
+        &[Value::Array(vec![Value::Uuid(ObjectId::new())])],
+    );
+    assert!(
+        matches!(
+            update_missing,
+            Err(QueryError::UuidArrayForeignKeyViolation { .. })
+        ),
+        "update with missing UUID[] reference should fail: {update_missing:?}"
+    );
+}
+
+#[test]
+fn uuid_array_fk_forward_materialization_preserves_order_and_duplicates() {
+    let sync_manager = SyncManager::new();
+    let schema = file_storage_schema();
+    let (mut qm, mut storage) = create_query_manager(sync_manager, schema);
+
+    let part_a = qm
+        .insert(&mut storage, "file_parts", &[Value::Text("A".into())])
+        .unwrap();
+    let part_b = qm
+        .insert(&mut storage, "file_parts", &[Value::Text("B".into())])
+        .unwrap();
+
+    qm.insert(
+        &mut storage,
+        "files",
+        &[Value::Array(vec![
+            Value::Uuid(part_b.row_id),
+            Value::Uuid(part_a.row_id),
+            Value::Uuid(part_b.row_id),
+        ])],
+    )
+    .unwrap();
+
+    let query = qm
+        .query("files")
+        .with_array("part_rows", |sub| {
+            sub.from("file_parts").correlate("id", "files.parts")
+        })
+        .build();
+    let sub_id = qm.subscribe(query).unwrap();
+    qm.process(&mut storage);
+
+    let update = qm
+        .take_updates()
+        .into_iter()
+        .find(|u| u.subscription_id == sub_id)
+        .expect("files subscription should produce one update");
+    let row_values =
+        decode_row(&files_with_parts_descriptor(), &update.delta.added[0].data).unwrap();
+    let part_rows = row_values[1]
+        .as_array()
+        .expect("part_rows should be an array");
+    let labels: Vec<String> = part_rows
+        .iter()
+        .map(|row| {
+            let values = row.as_row().expect("part row");
+            match &values[0] {
+                Value::Text(label) => label.clone(),
+                other => panic!("expected text label, got {other:?}"),
+            }
+        })
+        .collect();
+    assert_eq!(labels, vec!["B", "A", "B"]);
+}
+
+#[test]
+fn uuid_array_fk_reverse_membership_and_index_updates_on_edit() {
+    let sync_manager = SyncManager::new();
+    let schema = file_storage_schema();
+    let (mut qm, mut storage) = create_query_manager(sync_manager, schema);
+    let branch = get_branch(&qm);
+
+    let part_a = qm
+        .insert(&mut storage, "file_parts", &[Value::Text("A".into())])
+        .unwrap();
+    let part_b = qm
+        .insert(&mut storage, "file_parts", &[Value::Text("B".into())])
+        .unwrap();
+    let file = qm
+        .insert(
+            &mut storage,
+            "files",
+            &[Value::Array(vec![
+                Value::Uuid(part_a.row_id),
+                Value::Uuid(part_b.row_id),
+                Value::Uuid(part_b.row_id),
+            ])],
+        )
+        .unwrap();
+
+    let query = qm
+        .query("file_parts")
+        .with_array("files", |sub| {
+            sub.from("files").correlate("parts", "file_parts.id")
+        })
+        .build();
+    let before = execute_query(&mut qm, &mut storage, query.clone()).unwrap();
+    let before_counts: std::collections::HashMap<String, usize> = before
+        .iter()
+        .map(|(_, values)| {
+            let label = match &values[0] {
+                Value::Text(label) => label.clone(),
+                other => panic!("expected label text, got {other:?}"),
+            };
+            let count = values[1]
+                .as_array()
+                .expect("files include should be array")
+                .len();
+            (label, count)
+        })
+        .collect();
+    assert_eq!(before_counts.get("A"), Some(&1));
+    assert_eq!(before_counts.get("B"), Some(&1));
+
+    let ids_for_a_before =
+        storage.index_lookup("files", "parts", &branch, &Value::Uuid(part_a.row_id));
+    let ids_for_b_before =
+        storage.index_lookup("files", "parts", &branch, &Value::Uuid(part_b.row_id));
+    assert!(ids_for_a_before.contains(&file.row_id));
+    assert!(ids_for_b_before.contains(&file.row_id));
+
+    qm.update(
+        &mut storage,
+        file.row_id,
+        &[Value::Array(vec![Value::Uuid(part_b.row_id)])],
+    )
+    .unwrap();
+
+    let after = execute_query(&mut qm, &mut storage, query).unwrap();
+    let after_counts: std::collections::HashMap<String, usize> = after
+        .iter()
+        .map(|(_, values)| {
+            let label = match &values[0] {
+                Value::Text(label) => label.clone(),
+                other => panic!("expected label text, got {other:?}"),
+            };
+            let count = values[1]
+                .as_array()
+                .expect("files include should be array")
+                .len();
+            (label, count)
+        })
+        .collect();
+    assert_eq!(after_counts.get("A"), Some(&0));
+    assert_eq!(after_counts.get("B"), Some(&1));
+
+    let ids_for_a_after =
+        storage.index_lookup("files", "parts", &branch, &Value::Uuid(part_a.row_id));
+    let ids_for_b_after =
+        storage.index_lookup("files", "parts", &branch, &Value::Uuid(part_b.row_id));
+    assert!(
+        !ids_for_a_after.contains(&file.row_id),
+        "removed array members should be removed from membership index"
+    );
+    assert!(ids_for_b_after.contains(&file.row_id));
+}
 
 fn users_posts_schema() -> Schema {
     let mut schema = Schema::new();

--- a/crates/jazz-tools/src/query_manager/server_queries.rs
+++ b/crates/jazz-tools/src/query_manager/server_queries.rs
@@ -419,7 +419,7 @@ impl QueryManager {
 
         if check.operation == Operation::Insert
             && let Some(new_content) = check.new_content.as_ref()
-            && let Err(err) = self.validate_uuid_array_foreign_keys_for_content(
+            && let Err(err) = self.validate_foreign_keys_for_content(
                 storage,
                 &table_name,
                 &table_schema.descriptor,
@@ -542,7 +542,7 @@ impl QueryManager {
         branch: &str,
     ) {
         if let Some(new_content) = check.new_content.as_ref()
-            && let Err(err) = self.validate_uuid_array_foreign_keys_for_content(
+            && let Err(err) = self.validate_foreign_keys_for_content(
                 storage,
                 &table_name,
                 &table_schema.descriptor,

--- a/crates/jazz-tools/src/query_manager/server_queries.rs
+++ b/crates/jazz-tools/src/query_manager/server_queries.rs
@@ -5,7 +5,7 @@ use crate::commit::CommitId;
 use crate::metadata::MetadataKey;
 use crate::object::{BranchName, ObjectId};
 use crate::storage::Storage;
-use crate::sync_manager::{ClientId, ClientRole, PendingPermissionCheck, QueryId};
+use crate::sync_manager::{ClientId, ClientRole, PendingPermissionCheck, QueryId, SyncPayload};
 
 use super::manager::{PolicyCheckState, QueryManager, ServerQuerySubscription};
 use super::policy::{ComplexClause, Operation, evaluate_simple_parts};
@@ -391,6 +391,12 @@ impl QueryManager {
         storage: &mut H,
         check: PendingPermissionCheck,
     ) {
+        let branch = match &check.payload {
+            SyncPayload::ObjectUpdated { branch_name, .. }
+            | SyncPayload::ObjectTruncated { branch_name, .. } => branch_name.as_str().to_string(),
+            _ => self.current_branch(),
+        };
+
         // Get table name from metadata
         let table_name = match check.metadata.get(MetadataKey::Table.as_str()) {
             Some(t) => TableName::new(t),
@@ -411,9 +417,24 @@ impl QueryManager {
             }
         };
 
+        if check.operation == Operation::Insert
+            && let Some(new_content) = check.new_content.as_ref()
+            && let Err(err) = self.validate_uuid_array_foreign_keys_for_content(
+                storage,
+                &table_name,
+                &table_schema.descriptor,
+                new_content,
+                &branch,
+            )
+        {
+            self.sync_manager
+                .reject_permission_check(check, err.to_string());
+            return;
+        }
+
         // Handle UPDATE specially - needs both USING and WITH CHECK
         if check.operation == Operation::Update {
-            self.evaluate_update_permission(storage, check, table_name, table_schema);
+            self.evaluate_update_permission(storage, check, table_name, table_schema, &branch);
             return;
         }
 
@@ -518,7 +539,22 @@ impl QueryManager {
         check: PendingPermissionCheck,
         table_name: TableName,
         table_schema: TableSchema,
+        branch: &str,
     ) {
+        if let Some(new_content) = check.new_content.as_ref()
+            && let Err(err) = self.validate_uuid_array_foreign_keys_for_content(
+                storage,
+                &table_name,
+                &table_schema.descriptor,
+                new_content,
+                branch,
+            )
+        {
+            self.sync_manager
+                .reject_permission_check(check, err.to_string());
+            return;
+        }
+
         let using_policy = table_schema.policies.update.using.as_ref();
         let check_policy = table_schema.policies.update.with_check.as_ref();
 

--- a/crates/jazz-tools/src/query_manager/writes.rs
+++ b/crates/jazz-tools/src/query_manager/writes.rs
@@ -53,7 +53,7 @@ impl QueryManager {
             });
         }
 
-        self.validate_uuid_array_foreign_keys_for_values(
+        self.validate_foreign_keys_for_values(
             storage,
             &table_name,
             &descriptor,
@@ -165,13 +165,7 @@ impl QueryManager {
             });
         }
 
-        self.validate_uuid_array_foreign_keys_for_values(
-            storage,
-            &table_name,
-            &descriptor,
-            values,
-            branch,
-        )?;
+        self.validate_foreign_keys_for_values(storage, &table_name, &descriptor, values, branch)?;
 
         // Encode to binary
         let data = encode_row(&descriptor, values)
@@ -242,7 +236,7 @@ impl QueryManager {
         })
     }
 
-    fn validate_uuid_array_foreign_keys_for_values(
+    fn validate_foreign_keys_for_values(
         &self,
         storage: &dyn Storage,
         table_name: &TableName,
@@ -254,40 +248,54 @@ impl QueryManager {
             let Some(referenced_table) = column.references else {
                 continue;
             };
-            let ColumnType::Array(element_type) = &column.column_type else {
-                continue;
-            };
-            if !matches!(element_type.as_ref(), ColumnType::Uuid) {
-                continue;
-            }
-            let Value::Array(elements) = value else {
-                continue;
-            };
 
-            for element in elements {
-                let Value::Uuid(target_id) = element else {
-                    continue;
-                };
-                if self.row_is_indexed_on_branch(
-                    storage,
-                    referenced_table.as_str(),
-                    branch,
-                    *target_id,
-                ) {
-                    continue;
+            match (&column.column_type, value) {
+                (ColumnType::Uuid, Value::Uuid(target_id)) => {
+                    if self.row_is_indexed_on_branch(
+                        storage,
+                        referenced_table.as_str(),
+                        branch,
+                        *target_id,
+                    ) {
+                        continue;
+                    }
+                    return Err(QueryError::UuidForeignKeyViolation {
+                        table: *table_name,
+                        column: column.name.as_str().to_string(),
+                        referenced_table,
+                        missing_id: *target_id,
+                    });
                 }
-                return Err(QueryError::UuidArrayForeignKeyViolation {
-                    table: *table_name,
-                    column: column.name.as_str().to_string(),
-                    referenced_table,
-                    missing_id: *target_id,
-                });
+                (ColumnType::Array(element_type), Value::Array(elements))
+                    if matches!(element_type.as_ref(), ColumnType::Uuid) =>
+                {
+                    for element in elements {
+                        let Value::Uuid(target_id) = element else {
+                            continue;
+                        };
+                        if self.row_is_indexed_on_branch(
+                            storage,
+                            referenced_table.as_str(),
+                            branch,
+                            *target_id,
+                        ) {
+                            continue;
+                        }
+                        return Err(QueryError::UuidArrayForeignKeyViolation {
+                            table: *table_name,
+                            column: column.name.as_str().to_string(),
+                            referenced_table,
+                            missing_id: *target_id,
+                        });
+                    }
+                }
+                _ => {}
             }
         }
         Ok(())
     }
 
-    pub(super) fn validate_uuid_array_foreign_keys_for_content(
+    pub(super) fn validate_foreign_keys_for_content(
         &self,
         storage: &dyn Storage,
         table_name: &TableName,
@@ -297,9 +305,7 @@ impl QueryManager {
     ) -> Result<(), QueryError> {
         let values = decode_row(descriptor, content)
             .map_err(|e| QueryError::EncodingError(e.to_string()))?;
-        self.validate_uuid_array_foreign_keys_for_values(
-            storage, table_name, descriptor, &values, branch,
-        )
+        self.validate_foreign_keys_for_values(storage, table_name, descriptor, &values, branch)
     }
 
     /// Evaluate a policy expression against encoded row content using full policy context.
@@ -418,7 +424,7 @@ impl QueryManager {
             });
         }
 
-        self.validate_uuid_array_foreign_keys_for_values(
+        self.validate_foreign_keys_for_values(
             storage,
             &table_name,
             &descriptor,
@@ -766,7 +772,7 @@ impl QueryManager {
             });
         }
 
-        self.validate_uuid_array_foreign_keys_for_values(
+        self.validate_foreign_keys_for_values(
             storage,
             &table_name,
             &descriptor,

--- a/crates/jazz-tools/src/query_manager/writes.rs
+++ b/crates/jazz-tools/src/query_manager/writes.rs
@@ -9,7 +9,7 @@ use super::encoding::{decode_row, encode_row};
 use super::manager::{DeleteHandle, InsertHandle, QueryError, QueryManager};
 use super::policy::{Operation, evaluate_simple_parts};
 use super::session::Session;
-use super::types::{RowDescriptor, TableName, Value};
+use super::types::{ColumnType, RowDescriptor, TableName, Value};
 
 impl QueryManager {
     /// Insert a new row into a table.
@@ -52,6 +52,14 @@ impl QueryManager {
                 actual: values.len(),
             });
         }
+
+        self.validate_uuid_array_foreign_keys_for_values(
+            storage,
+            &table_name,
+            &descriptor,
+            values,
+            &self.current_branch(),
+        )?;
 
         // Encode to binary
         let data = encode_row(&descriptor, values)
@@ -157,6 +165,14 @@ impl QueryManager {
             });
         }
 
+        self.validate_uuid_array_foreign_keys_for_values(
+            storage,
+            &table_name,
+            &descriptor,
+            values,
+            branch,
+        )?;
+
         // Encode to binary
         let data = encode_row(&descriptor, values)
             .map_err(|e| QueryError::EncodingError(e.to_string()))?;
@@ -224,6 +240,66 @@ impl QueryManager {
             row_id: object_id,
             row_commit_id,
         })
+    }
+
+    fn validate_uuid_array_foreign_keys_for_values(
+        &self,
+        storage: &dyn Storage,
+        table_name: &TableName,
+        descriptor: &RowDescriptor,
+        values: &[Value],
+        branch: &str,
+    ) -> Result<(), QueryError> {
+        for (column, value) in descriptor.columns.iter().zip(values.iter()) {
+            let Some(referenced_table) = column.references else {
+                continue;
+            };
+            let ColumnType::Array(element_type) = &column.column_type else {
+                continue;
+            };
+            if !matches!(element_type.as_ref(), ColumnType::Uuid) {
+                continue;
+            }
+            let Value::Array(elements) = value else {
+                continue;
+            };
+
+            for element in elements {
+                let Value::Uuid(target_id) = element else {
+                    continue;
+                };
+                if self.row_is_indexed_on_branch(
+                    storage,
+                    referenced_table.as_str(),
+                    branch,
+                    *target_id,
+                ) {
+                    continue;
+                }
+                return Err(QueryError::UuidArrayForeignKeyViolation {
+                    table: *table_name,
+                    column: column.name.as_str().to_string(),
+                    referenced_table,
+                    missing_id: *target_id,
+                });
+            }
+        }
+        Ok(())
+    }
+
+    pub(super) fn validate_uuid_array_foreign_keys_for_content(
+        &self,
+        storage: &dyn Storage,
+        table_name: &TableName,
+        descriptor: &RowDescriptor,
+        content: &[u8],
+        branch: &str,
+    ) -> Result<(), QueryError> {
+        let values = decode_row(descriptor, content)
+            .map_err(|e| QueryError::EncodingError(e.to_string()))?;
+        self.validate_uuid_array_foreign_keys_for_values(
+            storage, table_name, descriptor, &values, branch,
+        )
     }
 
     /// Evaluate a policy expression against encoded row content using full policy context.
@@ -341,6 +417,14 @@ impl QueryManager {
                 actual: values.len(),
             });
         }
+
+        self.validate_uuid_array_foreign_keys_for_values(
+            storage,
+            &table_name,
+            &descriptor,
+            values,
+            &self.current_branch(),
+        )?;
 
         // Encode new data (used by WITH CHECK and commit write).
         let new_data = encode_row(&descriptor, values)
@@ -681,6 +765,14 @@ impl QueryManager {
                 actual: values.len(),
             });
         }
+
+        self.validate_uuid_array_foreign_keys_for_values(
+            storage,
+            &table_name,
+            &descriptor,
+            values,
+            &self.current_branch(),
+        )?;
 
         // Encode new row data
         let new_data = encode_row(&descriptor, values)

--- a/crates/jazz-tools/src/schema_manager/sql.rs
+++ b/crates/jazz-tools/src/schema_manager/sql.rs
@@ -936,6 +936,37 @@ impl Parser {
 // Public API
 // ============================================================================
 
+fn is_valid_reference_column_type(column_type: &ColumnType) -> bool {
+    match column_type {
+        ColumnType::Uuid => true,
+        ColumnType::Array(element_type) => matches!(element_type.as_ref(), ColumnType::Uuid),
+        _ => false,
+    }
+}
+
+fn validate_schema_references(schema: &Schema) -> Result<(), SqlParseError> {
+    for (table_name, table_schema) in schema {
+        for column in &table_schema.descriptor.columns {
+            let Some(referenced_table) = column.references else {
+                continue;
+            };
+
+            if !is_valid_reference_column_type(&column.column_type) {
+                return Err(SqlParseError::SyntaxError(format!(
+                    "column '{}.{}' declares REFERENCES but has type {:?}; only UUID and UUID[] support REFERENCES",
+                    table_name.as_str(),
+                    column.name.as_str(),
+                    column.column_type
+                )));
+            }
+
+            let _ = referenced_table;
+        }
+    }
+
+    Ok(())
+}
+
 /// Parse a schema SQL file into a Schema.
 pub fn parse_schema(sql: &str) -> Result<Schema, SqlParseError> {
     let tokens = Tokenizer::new(sql).tokenize()?;
@@ -997,6 +1028,8 @@ pub fn parse_schema(sql: &str) -> Result<Schema, SqlParseError> {
             None => break,
         }
     }
+
+    validate_schema_references(&schema)?;
 
     Ok(schema)
 }
@@ -1660,6 +1693,32 @@ mod tests {
         );
         assert_eq!(col.references, Some(TableName::new("file_parts")));
         assert!(!col.nullable);
+    }
+
+    #[test]
+    fn reject_non_uuid_array_references() {
+        let sql = "CREATE TABLE files (parts TEXT[] REFERENCES file_parts NOT NULL);";
+        let error = parse_schema(sql).unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("only UUID and UUID[] support REFERENCES"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn reject_non_uuid_scalar_references() {
+        let sql = "CREATE TABLE files (part TEXT REFERENCES file_parts NOT NULL);";
+        let error = parse_schema(sql).unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("only UUID and UUID[] support REFERENCES"),
+            "unexpected error: {error}"
+        );
     }
 
     #[test]

--- a/examples/docs/todo-client-localfirst-ts/src/main.ts
+++ b/examples/docs/todo-client-localfirst-ts/src/main.ts
@@ -86,13 +86,11 @@ export async function startApp(
   form.appendChild(btn);
   container.appendChild(form);
 
-  const selectedProjectId = "00000000-0000-0000-0000-000000000000";
-
   const list = document.createElement("ul");
   list.id = "todo-list";
   container.appendChild(list);
-  // Subscribe to the project & all its todos
-  const query = app.todos.where({ project: selectedProjectId });
+  // Subscribe to all todos.
+  const query = app.todos;
   db.subscribeAll(query, ({ all: todos }) => {
     const ordered = orderTodosWithDepth(todos);
     parentSelect.innerHTML = "";
@@ -126,7 +124,6 @@ export async function startApp(
     db.insert(app.todos, {
       title: input.value,
       done: false,
-      project: selectedProjectId,
       ...(selectedParentId ? { parent: selectedParentId } : {}),
     });
     input.value = "";

--- a/examples/todo-client-localfirst-ts/src/main.ts
+++ b/examples/todo-client-localfirst-ts/src/main.ts
@@ -115,13 +115,11 @@ export async function startApp(
   form.appendChild(btn);
   container.appendChild(form);
 
-  const selectedProjectId = "00000000-0000-0000-0000-000000000000";
-
   const list = document.createElement("ul");
   list.id = "todo-list";
   container.appendChild(list);
-  // Subscribe to the project & all its todos
-  const query = app.todos.where({ project: selectedProjectId });
+  // Subscribe to all todos.
+  const query = app.todos;
   db.subscribeAll(query, ({ all: todos }) => {
     const ordered = orderTodosWithDepth(todos);
     parentSelect.innerHTML = "";
@@ -156,7 +154,6 @@ export async function startApp(
       title: input.value,
       done: false,
       owner_id: sessionUserId,
-      project: selectedProjectId,
       ...(selectedParentId ? { parent: selectedParentId } : {}),
     });
     input.value = "";

--- a/packages/jazz-tools/src/codegen/codegen.test.ts
+++ b/packages/jazz-tools/src/codegen/codegen.test.ts
@@ -486,6 +486,36 @@ describe("analyzeRelations", () => {
     );
   });
 
+  it("marks forward UUID[] references as array relations", () => {
+    const schema: WasmSchema = {
+      tables: {
+        files: {
+          columns: [
+            {
+              name: "parts",
+              column_type: { type: "Array", element: { type: "Uuid" } },
+              nullable: false,
+              references: "file_parts",
+            },
+          ],
+        },
+        file_parts: { columns: [] },
+      },
+    };
+
+    const relations = analyzeRelations(schema);
+    const fileRels = relations.get("files")!;
+
+    expect(fileRels).toContainEqual(
+      expect.objectContaining({
+        name: "parts",
+        type: "forward",
+        toTable: "file_parts",
+        isArray: true,
+      }),
+    );
+  });
+
   it("handles self-referential relations", () => {
     const schema: WasmSchema = {
       tables: {
@@ -570,6 +600,28 @@ describe("analyzeRelations", () => {
 
     expect(() => analyzeRelations(schema)).toThrow(
       'Table "todos" references unknown table "users" via column "owner_id"',
+    );
+  });
+
+  it("throws for non-UUID references", () => {
+    const schema: WasmSchema = {
+      tables: {
+        files: {
+          columns: [
+            {
+              name: "parts",
+              column_type: { type: "Array", element: { type: "Text" } },
+              nullable: false,
+              references: "file_parts",
+            },
+          ],
+        },
+        file_parts: { columns: [] },
+      },
+    };
+
+    expect(() => analyzeRelations(schema)).toThrow(
+      'Column "files.parts" uses references but is not UUID or UUID[]',
     );
   });
 });

--- a/packages/jazz-tools/src/codegen/relation-analyzer.ts
+++ b/packages/jazz-tools/src/codegen/relation-analyzer.ts
@@ -56,6 +56,17 @@ export function analyzeRelations(schema: WasmSchema): Map<string, Relation[]> {
   for (const [tableName, table] of Object.entries(schema.tables)) {
     for (const col of table.columns) {
       if (col.references) {
+        const isUuidRef =
+          col.column_type.type === "Uuid" ||
+          (col.column_type.type === "Array" && col.column_type.element.type === "Uuid");
+        if (!isUuidRef) {
+          throw new Error(
+            `Column "${tableName}.${col.name}" uses references but is not UUID or UUID[]`,
+          );
+        }
+        const isForwardArray =
+          col.column_type.type === "Array" && col.column_type.element.type === "Uuid";
+
         // Forward relation: parent_id -> parent
         const forwardName = col.name.replace(/_id$/, "");
         const forwardRelation: Relation = {
@@ -65,7 +76,7 @@ export function analyzeRelations(schema: WasmSchema): Map<string, Relation[]> {
           toTable: col.references,
           fromColumn: col.name,
           toColumn: "id",
-          isArray: false,
+          isArray: isForwardArray,
           nullable: col.nullable,
         };
         relations.get(tableName)!.push(forwardRelation);

--- a/packages/jazz-tools/src/runtime/query-adapter.test.ts
+++ b/packages/jazz-tools/src/runtime/query-adapter.test.ts
@@ -563,6 +563,78 @@ describe("translateQuery", () => {
       ]);
     });
 
+    it("translates UUID[] forward and reverse includes using membership columns", () => {
+      const arrayFkSchema: WasmSchema = {
+        tables: {
+          files: {
+            columns: [
+              {
+                name: "parts",
+                column_type: { type: "Array", element: { type: "Uuid" } },
+                nullable: false,
+                references: "file_parts",
+              },
+            ],
+          },
+          file_parts: {
+            columns: [{ name: "name", column_type: { type: "Text" }, nullable: false }],
+          },
+        },
+      };
+
+      const forward = JSON.parse(
+        translateQuery(
+          JSON.stringify({
+            table: "files",
+            conditions: [],
+            includes: { parts: true },
+            orderBy: [],
+          }),
+          arrayFkSchema,
+        ),
+      );
+      expect(forward.array_subqueries).toEqual([
+        {
+          column_name: "parts",
+          table: "file_parts",
+          inner_column: "id",
+          outer_column: "files.parts",
+          filters: [],
+          joins: [],
+          select_columns: null,
+          order_by: [],
+          limit: null,
+          nested_arrays: [],
+        },
+      ]);
+
+      const reverse = JSON.parse(
+        translateQuery(
+          JSON.stringify({
+            table: "file_parts",
+            conditions: [],
+            includes: { filesViaParts: true },
+            orderBy: [],
+          }),
+          arrayFkSchema,
+        ),
+      );
+      expect(reverse.array_subqueries).toEqual([
+        {
+          column_name: "filesViaParts",
+          table: "files",
+          inner_column: "parts",
+          outer_column: "file_parts.id",
+          filters: [],
+          joins: [],
+          select_columns: null,
+          order_by: [],
+          limit: null,
+          nested_arrays: [],
+        },
+      ]);
+    });
+
     it("skips false includes", () => {
       const builderJson = JSON.stringify({
         table: "todos",

--- a/packages/jazz-tools/tests/browser/db.all.test.ts
+++ b/packages/jazz-tools/tests/browser/db.all.test.ts
@@ -38,6 +38,20 @@ const schema: WasmSchema = {
         },
       ],
     },
+    file_parts: {
+      columns: [{ name: "label", column_type: { type: "Text" }, nullable: false }],
+    },
+    files: {
+      columns: [
+        { name: "name", column_type: { type: "Text" }, nullable: false },
+        {
+          name: "parts",
+          column_type: { type: "Array", element: { type: "Uuid" } },
+          nullable: false,
+          references: "file_parts",
+        },
+      ],
+    },
   },
 };
 
@@ -70,6 +84,17 @@ interface Todo {
   owner?: User;
 }
 
+interface FilePart {
+  id: string;
+  label: string;
+}
+
+interface File {
+  id: string;
+  name: string;
+  parts: string[];
+}
+
 const orgs: TableProxy<Org, Omit<Org, "id">> = {
   _table: "orgs",
   _schema: schema,
@@ -96,6 +121,20 @@ const todos: TableProxy<Todo, Omit<Todo, "id" | "owner">> = {
   _schema: schema,
   _rowType: {} as Todo,
   _initType: {} as Omit<Todo, "id" | "owner">,
+};
+
+const fileParts: TableProxy<FilePart, Omit<FilePart, "id">> = {
+  _table: "file_parts",
+  _schema: schema,
+  _rowType: {} as FilePart,
+  _initType: {} as Omit<FilePart, "id">,
+};
+
+const files: TableProxy<File, Omit<File, "id">> = {
+  _table: "files",
+  _schema: schema,
+  _rowType: {} as File,
+  _initType: {} as Omit<File, "id">,
 };
 
 function uniqueDbName(label: string): string {
@@ -329,7 +368,13 @@ describe("db.all browser integration", () => {
       id: ownerId,
       name: "Owner",
     });
-    expect(rows[0].todosViaOwner).toBeUndefined();
+    expect(rows[0].todosViaOwner).toHaveLength(2);
+    expect(rows[0].todosViaOwner).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ title: "with-owner-1", owner_id: ownerId }),
+        expect.objectContaining({ title: "with-owner-2", owner_id: ownerId }),
+      ]),
+    );
   });
 
   it("supports multi-hop queries", async () => {
@@ -348,6 +393,36 @@ describe("db.all browser integration", () => {
 
     expect(rows).toHaveLength(1);
     expect(rows[0]).toEqual({ id: orgId, name: "Org A" });
+  });
+
+  it("supports one-off all queries across scalar and UUID[] foreign-key hops", async () => {
+    const db = track(await createDb({ appId: "db-all-test", dbName: uniqueDbName("fk-hops") }));
+
+    const orgId = db.insert(orgs, { name: "FK Org" });
+    const teamId = db.insert(teams, { name: "FK Team", org_id: orgId, parent_id: undefined });
+    const userId = db.insert(users, { name: "FK User", team_id: teamId });
+
+    const partAId = db.insert(fileParts, { label: "A" });
+    const partBId = db.insert(fileParts, { label: "B" });
+    const fileId = db.insert(files, { name: "File 1", parts: [partBId, partAId] });
+
+    const teamRows = await db.all<Team>(
+      makeQuery<Team>("users", {
+        conditions: [{ column: "id", op: "eq", value: userId }],
+        hops: ["team"],
+      }),
+    );
+    expect(teamRows).toHaveLength(1);
+    expect(teamRows[0]).toMatchObject({ id: teamId, name: "FK Team" });
+
+    const partRows = await db.all<FilePart>(
+      makeQuery<FilePart>("files", {
+        conditions: [{ column: "id", op: "eq", value: fileId }],
+        hops: ["parts"],
+      }),
+    );
+    expect(partRows).toHaveLength(2);
+    expect(partRows.map((row) => row.label).sort()).toEqual(["A", "B"]);
   });
 
   it("supports gather queries", async () => {

--- a/packages/jazz-tools/tests/browser/db.subscribeAll.test.ts
+++ b/packages/jazz-tools/tests/browser/db.subscribeAll.test.ts
@@ -39,6 +39,20 @@ const schema: WasmSchema = {
         },
       ],
     },
+    file_parts: {
+      columns: [{ name: "label", column_type: { type: "Text" }, nullable: false }],
+    },
+    files: {
+      columns: [
+        { name: "name", column_type: { type: "Text" }, nullable: false },
+        {
+          name: "parts",
+          column_type: { type: "Array", element: { type: "Uuid" } },
+          nullable: false,
+          references: "file_parts",
+        },
+      ],
+    },
   },
 };
 
@@ -69,6 +83,17 @@ interface Todo {
   tags: string[];
 }
 
+interface FilePart {
+  id: string;
+  label: string;
+}
+
+interface File {
+  id: string;
+  name: string;
+  parts: string[];
+}
+
 const orgs: TableProxy<Org, Omit<Org, "id">> = {
   _table: "orgs",
   _schema: schema,
@@ -95,6 +120,20 @@ const todos: TableProxy<Todo, Omit<Todo, "id">> = {
   _schema: schema,
   _rowType: {} as Todo,
   _initType: {} as Omit<Todo, "id">,
+};
+
+const fileParts: TableProxy<FilePart, Omit<FilePart, "id">> = {
+  _table: "file_parts",
+  _schema: schema,
+  _rowType: {} as FilePart,
+  _initType: {} as Omit<FilePart, "id">,
+};
+
+const files: TableProxy<File, Omit<File, "id">> = {
+  _table: "files",
+  _schema: schema,
+  _rowType: {} as File,
+  _initType: {} as Omit<File, "id">,
 };
 
 function uniqueDbName(label: string): string {
@@ -489,6 +528,100 @@ describe("db.subscribeAll browser integration", () => {
       4000,
       "expected hop query subscription result",
     );
+
+    unsubscribe();
+  });
+
+  it("reacts to scalar FK updates in hop subscriptions", async () => {
+    const db = track(
+      await createDb({ appId: "db-subscribe-test", dbName: uniqueDbName("scalar-fk-update") }),
+    );
+
+    const orgAId = db.insert(orgs, { name: "Org A" });
+    const orgBId = db.insert(orgs, { name: "Org B" });
+    const teamAId = db.insert(teams, { name: "Team A", org_id: orgAId, parent_id: undefined });
+    const teamBId = db.insert(teams, { name: "Team B", org_id: orgBId, parent_id: undefined });
+    const userId = db.insert(users, { name: "Mover", team_id: teamAId });
+
+    const deltas: Array<SubscriptionDelta<Team>> = [];
+    const unsubscribe = trackUnsubscribe(
+      db.subscribeAll(
+        makeQuery<Team>("users", {
+          conditions: [{ column: "id", op: "eq", value: userId }],
+          hops: ["team"],
+        }),
+        (delta) => deltas.push(delta),
+      ),
+    );
+
+    await waitForCondition(
+      () => {
+        const latestAll = deltas[deltas.length - 1]?.all ?? [];
+        return latestAll.length === 1 && latestAll[0]?.id === teamAId;
+      },
+      4000,
+      "expected initial team hop result",
+    );
+
+    db.update(users, userId, { team_id: teamBId });
+
+    await waitForCondition(
+      () => {
+        const latestAll = deltas[deltas.length - 1]?.all ?? [];
+        return latestAll.length === 1 && latestAll[0]?.id === teamBId;
+      },
+      4000,
+      "expected hop result to move after scalar FK update",
+    );
+
+    expect(deltas.some((delta) => delta.removed.some((row) => row.id === teamAId))).toBe(true);
+    expect(deltas.some((delta) => delta.added.some((row) => row.id === teamBId))).toBe(true);
+
+    unsubscribe();
+  });
+
+  it("reacts to UUID[] FK updates in hop subscriptions", async () => {
+    const db = track(
+      await createDb({ appId: "db-subscribe-test", dbName: uniqueDbName("array-fk-update") }),
+    );
+
+    const partAId = db.insert(fileParts, { label: "A" });
+    const partBId = db.insert(fileParts, { label: "B" });
+    const fileId = db.insert(files, { name: "File", parts: [partAId] });
+
+    const deltas: Array<SubscriptionDelta<FilePart>> = [];
+    const unsubscribe = trackUnsubscribe(
+      db.subscribeAll(
+        makeQuery<FilePart>("files", {
+          conditions: [{ column: "id", op: "eq", value: fileId }],
+          hops: ["parts"],
+        }),
+        (delta) => deltas.push(delta),
+      ),
+    );
+
+    await waitForCondition(
+      () => {
+        const latestAll = deltas[deltas.length - 1]?.all ?? [];
+        return latestAll.length === 1 && latestAll[0]?.id === partAId;
+      },
+      4000,
+      "expected initial UUID[] hop result",
+    );
+
+    db.update(files, fileId, { parts: [partBId] });
+
+    await waitForCondition(
+      () => {
+        const latestAll = deltas[deltas.length - 1]?.all ?? [];
+        return latestAll.length === 1 && latestAll[0]?.id === partBId;
+      },
+      4000,
+      "expected hop result to move after UUID[] FK update",
+    );
+
+    expect(deltas.some((delta) => delta.removed.some((row) => row.id === partAId))).toBe(true);
+    expect(deltas.some((delta) => delta.added.some((row) => row.id === partBId))).toBe(true);
 
     unsubscribe();
   });

--- a/packages/jazz-tools/tests/browser/db.subscribeAll.test.ts
+++ b/packages/jazz-tools/tests/browser/db.subscribeAll.test.ts
@@ -574,12 +574,8 @@ describe("db.subscribeAll browser integration", () => {
       "expected hop result to move after scalar FK update",
     );
 
-    expect(deltas.some((delta) => (delta.removed ?? []).some((row) => row.id === teamAId))).toBe(
-      true,
-    );
-    expect(deltas.some((delta) => (delta.added ?? []).some((row) => row.id === teamBId))).toBe(
-      true,
-    );
+    expect(deltas.some((delta) => delta.all.some((row) => row.id === teamAId))).toBe(true);
+    expect(deltas.some((delta) => delta.all.some((row) => row.id === teamBId))).toBe(true);
 
     unsubscribe();
   });
@@ -624,12 +620,8 @@ describe("db.subscribeAll browser integration", () => {
       "expected hop result to move after UUID[] FK update",
     );
 
-    expect(deltas.some((delta) => (delta.removed ?? []).some((row) => row.id === partAId))).toBe(
-      true,
-    );
-    expect(deltas.some((delta) => (delta.added ?? []).some((row) => row.id === partBId))).toBe(
-      true,
-    );
+    expect(deltas.some((delta) => delta.all.some((row) => row.id === partAId))).toBe(true);
+    expect(deltas.some((delta) => delta.all.some((row) => row.id === partBId))).toBe(true);
 
     unsubscribe();
   });

--- a/packages/jazz-tools/tests/browser/db.subscribeAll.test.ts
+++ b/packages/jazz-tools/tests/browser/db.subscribeAll.test.ts
@@ -574,8 +574,12 @@ describe("db.subscribeAll browser integration", () => {
       "expected hop result to move after scalar FK update",
     );
 
-    expect(deltas.some((delta) => delta.removed.some((row) => row.id === teamAId))).toBe(true);
-    expect(deltas.some((delta) => delta.added.some((row) => row.id === teamBId))).toBe(true);
+    expect(deltas.some((delta) => (delta.removed ?? []).some((row) => row.id === teamAId))).toBe(
+      true,
+    );
+    expect(deltas.some((delta) => (delta.added ?? []).some((row) => row.id === teamBId))).toBe(
+      true,
+    );
 
     unsubscribe();
   });
@@ -620,8 +624,12 @@ describe("db.subscribeAll browser integration", () => {
       "expected hop result to move after UUID[] FK update",
     );
 
-    expect(deltas.some((delta) => delta.removed.some((row) => row.id === partAId))).toBe(true);
-    expect(deltas.some((delta) => delta.added.some((row) => row.id === partBId))).toBe(true);
+    expect(deltas.some((delta) => (delta.removed ?? []).some((row) => row.id === partAId))).toBe(
+      true,
+    );
+    expect(deltas.some((delta) => (delta.added ?? []).some((row) => row.id === partBId))).toBe(
+      true,
+    );
 
     unsubscribe();
   });

--- a/packages/jazz-tools/tests/browser/worker-bridge.test.ts
+++ b/packages/jazz-tools/tests/browser/worker-bridge.test.ts
@@ -51,11 +51,27 @@ interface TodoInit {
   tags?: string[];
 }
 
+interface Project {
+  id: string;
+  name: string;
+}
+
+interface ProjectInit {
+  name: string;
+}
+
 const todos: TableProxy<Todo, TodoInit> = {
   _table: "todos",
   _schema: schema,
   _rowType: {} as Todo,
   _initType: {} as TodoInit,
+};
+
+const projects: TableProxy<Project, ProjectInit> = {
+  _table: "projects",
+  _schema: schema,
+  _rowType: {} as Project,
+  _initType: {} as ProjectInit,
 };
 
 /** QueryBuilder that selects all todos. */
@@ -411,7 +427,7 @@ describe("Worker Bridge with OPFS", () => {
 
     const received: Todo[][] = [];
 
-    const projectId = "00000000-0000-0000-0000-000000000123";
+    const projectId = db.insert(projects, { name: "Observed Project" });
     const unsub = trackSubscription(
       db.subscribeAll(todosByProject(projectId), (delta) => {
         received.push([...delta.all]);
@@ -419,7 +435,7 @@ describe("Worker Bridge with OPFS", () => {
     );
 
     db.insert(todos, { title: "Observed", done: false, project: projectId });
-    const anotherProjectId = "00000000-0000-0000-0000-000000000456";
+    const anotherProjectId = db.insert(projects, { name: "Ignored Project" });
     db.insert(todos, { title: "Not observed", done: false, project: anotherProjectId });
 
     // Wait for subscription to fire


### PR DESCRIPTION
## Summary
- implement UUID array foreign-key semantics across query planning/execution paths
- update SQL/schema handling and codegen relation analysis for UUID array FK support
- add/expand query manager and runtime tests covering UUID array FK behavior

## Validation
- pnpm turbo run build:crates --filter=@jazz/rust
- pnpm turbo run build --filter=jazz-wasm
- pnpm turbo run build --filter=!jazz-rn --filter=!jazz-wasm --filter=!todo-client-localfirst-expo --only
- pnpm turbo run test --filter=!jazz-rn --filter=!todo-client-localfirst-expo --only