### PR TITLE
Add sync ingestion test for QueryManager catalogues

### DIFF
--- a/crates/jazz-tools/src/query_manager/manager_tests.rs
+++ b/crates/jazz-tools/src/query_manager/manager_tests.rs
@@ -623,12 +623,13 @@ fn subscription_updates_after_insert_and_process() {
     let sub_id = qm.subscribe(query).unwrap();
 
     // Insert a row
-    qm.insert(
-        &mut storage,
-        "users",
-        &[Value::Text("Alice".into()), Value::Integer(100)],
-    )
-    .unwrap();
+    let handle = qm
+        .insert(
+            &mut storage,
+            "users",
+            &[Value::Text("Alice".into()), Value::Integer(100)],
+        )
+        .unwrap();
 
     // Process - should settle subscriptions
     qm.process(&mut storage);
@@ -638,6 +639,10 @@ fn subscription_updates_after_insert_and_process() {
     assert_eq!(updates.len(), 1);
     assert_eq!(updates[0].subscription_id, sub_id);
     assert_eq!(updates[0].delta.added.len(), 1);
+    assert_eq!(
+        updates[0].delta.added[0].id, handle.row_id,
+        "Delta should identify the inserted row"
+    );
 }
 
 #[test]
@@ -1614,11 +1619,13 @@ fn update_fails_filter_emits_removal() {
     qm.process(&mut storage);
     let updates = qm.take_updates();
     assert_eq!(updates.len(), 1);
+    assert_eq!(updates[0].subscription_id, sub_id);
     assert_eq!(
         updates[0].delta.added.len(),
         1,
         "Row should be added initially"
     );
+    assert_eq!(updates[0].delta.added[0].id, handle.row_id);
 
     // Update score to 30 (fails filter)
     qm.update(
@@ -1638,6 +1645,7 @@ fn update_fails_filter_emits_removal() {
         1,
         "Row should be removed when it fails filter"
     );
+    assert_eq!(updates[0].delta.removed[0].id, handle.row_id);
 }
 
 #[test]
@@ -1741,6 +1749,8 @@ fn update_still_passes_filter_emits_update() {
         1,
         "Row should be updated when it still passes filter"
     );
+    assert_eq!(updates[0].delta.updated[0].0.id, handle.row_id);
+    assert_eq!(updates[0].delta.updated[0].1.id, handle.row_id);
 }
 
 #[test]
@@ -2789,12 +2799,13 @@ fn include_deleted_query_does_not_return_hard_deleted_rows() {
             &[Value::Text("Alice".into()), Value::Integer(100)],
         )
         .unwrap();
-    qm.insert(
-        &mut storage,
-        "users",
-        &[Value::Text("Bob".into()), Value::Integer(50)],
-    )
-    .unwrap();
+    let bob_handle = qm
+        .insert(
+            &mut storage,
+            "users",
+            &[Value::Text("Bob".into()), Value::Integer(50)],
+        )
+        .unwrap();
 
     // Hard delete Alice
     qm.hard_delete(&mut storage, handle1.row_id).unwrap();
@@ -2803,6 +2814,7 @@ fn include_deleted_query_does_not_return_hard_deleted_rows() {
     let query = qm.query("users").include_deleted().build();
     let results = execute_query(&mut qm, &mut storage, query).unwrap();
     assert_eq!(results.len(), 1);
+    assert_eq!(results[0].0, bob_handle.row_id);
     assert_eq!(results[0].1[0], Value::Text("Bob".into()));
 }
 
@@ -2833,7 +2845,9 @@ fn soft_delete_emits_removal_delta() {
     qm.process(&mut storage);
     let updates = qm.take_updates();
     assert_eq!(updates.len(), 1);
+    assert_eq!(updates[0].subscription_id, sub_id);
     assert_eq!(updates[0].delta.added.len(), 1); // Alice added
+    assert_eq!(updates[0].delta.added[0].id, handle.row_id);
 
     // Delete Alice
     qm.delete(&mut storage, handle.row_id).unwrap();
@@ -2845,6 +2859,8 @@ fn soft_delete_emits_removal_delta() {
     assert_eq!(updates[0].subscription_id, sub_id);
     assert_eq!(updates[0].delta.removed.len(), 1);
     assert_eq!(updates[0].delta.removed[0].id, handle.row_id);
+    assert!(updates[0].delta.added.is_empty());
+    assert!(updates[0].delta.updated.is_empty());
 }
 
 #[test]
@@ -2870,7 +2886,9 @@ fn hard_delete_emits_removal_delta() {
     qm.process(&mut storage);
     let updates = qm.take_updates();
     assert_eq!(updates.len(), 1);
+    assert_eq!(updates[0].subscription_id, sub_id);
     assert_eq!(updates[0].delta.added.len(), 1); // Alice added
+    assert_eq!(updates[0].delta.added[0].id, handle.row_id);
 
     // Hard delete Alice
     qm.hard_delete(&mut storage, handle.row_id).unwrap();
@@ -2882,6 +2900,8 @@ fn hard_delete_emits_removal_delta() {
     assert_eq!(updates[0].subscription_id, sub_id);
     assert_eq!(updates[0].delta.removed.len(), 1);
     assert_eq!(updates[0].delta.removed[0].id, handle.row_id);
+    assert!(updates[0].delta.added.is_empty());
+    assert!(updates[0].delta.updated.is_empty());
 }
 
 #[test]
@@ -2916,7 +2936,9 @@ fn delete_row_not_in_subscription_no_delta() {
     qm.process(&mut storage);
     let updates = qm.take_updates();
     assert_eq!(updates.len(), 1);
+    assert_eq!(updates[0].subscription_id, sub_id);
     assert_eq!(updates[0].delta.added.len(), 1); // Only Alice
+    assert_eq!(updates[0].delta.added[0].id, alice_handle.row_id);
 
     // Delete Alice (who IS in subscription) - should emit removal delta
     qm.delete(&mut storage, alice_handle.row_id).unwrap();
@@ -2927,6 +2949,9 @@ fn delete_row_not_in_subscription_no_delta() {
     assert_eq!(updates.len(), 1);
     assert_eq!(updates[0].subscription_id, sub_id);
     assert_eq!(updates[0].delta.removed.len(), 1);
+    assert_eq!(updates[0].delta.removed[0].id, alice_handle.row_id);
+    assert!(updates[0].delta.added.is_empty());
+    assert!(updates[0].delta.updated.is_empty());
 }
 
 // ========================================================================
@@ -3136,10 +3161,17 @@ fn join_subscription_fails_for_invalid_join_column() {
         .build();
     let result = qm.subscribe(query);
 
-    assert!(
-        matches!(result, Err(QueryError::QueryCompilationError(_))),
-        "Join queries with invalid join columns should fail during subscription compilation"
-    );
+    match result {
+        Err(QueryError::QueryCompilationError(msg)) => {
+            assert_eq!(
+                msg,
+                "invalid relation plan: unsupported relation_ir shape for schema-context query compilation"
+            );
+        }
+        other => panic!(
+            "Join queries with invalid join columns should fail with QueryCompilationError, got {other:?}"
+        ),
+    }
 }
 
 #[test]
@@ -3157,10 +3189,17 @@ fn join_subscription_fails_for_circular_join_chain() {
         .build();
     let result = qm.subscribe(query);
 
-    assert!(
-        matches!(result, Err(QueryError::QueryCompilationError(_))),
-        "Circular/self join chains are not supported and should fail compilation"
-    );
+    match result {
+        Err(QueryError::QueryCompilationError(msg)) => {
+            assert_eq!(
+                msg,
+                "invalid relation plan: unsupported relation_ir shape for schema-context query compilation"
+            );
+        }
+        other => panic!(
+            "Circular/self join chains should fail with QueryCompilationError, got {other:?}"
+        ),
+    }
 }
 
 #[test]

--- a/crates/jazz-tools/src/query_manager/manager_tests.rs
+++ b/crates/jazz-tools/src/query_manager/manager_tests.rs
@@ -470,7 +470,12 @@ fn table_not_found_error() {
     let (mut qm, mut storage) = create_query_manager(sync_manager, schema);
 
     let result = qm.insert(&mut storage, "nonexistent", &[Value::Text("test".into())]);
-    assert!(matches!(result, Err(QueryError::TableNotFound(_))));
+    match result {
+        Err(QueryError::TableNotFound(table)) => {
+            assert_eq!(table, TableName::new("nonexistent"));
+        }
+        other => panic!("Expected TableNotFound(nonexistent), got {other:?}"),
+    }
 }
 
 #[test]
@@ -480,10 +485,13 @@ fn column_count_mismatch_error() {
     let (mut qm, mut storage) = create_query_manager(sync_manager, schema);
 
     let result = qm.insert(&mut storage, "users", &[Value::Text("Alice".into())]);
-    assert!(matches!(
-        result,
-        Err(QueryError::ColumnCountMismatch { .. })
-    ));
+    match result {
+        Err(QueryError::ColumnCountMismatch { expected, actual }) => {
+            assert_eq!(expected, 2, "users table has two columns in test_schema()");
+            assert_eq!(actual, 1, "insert call provided one value");
+        }
+        other => panic!("Expected ColumnCountMismatch, got {other:?}"),
+    }
 }
 
 #[test]

--- a/crates/jazz-tools/src/query_manager/manager_tests.rs
+++ b/crates/jazz-tools/src/query_manager/manager_tests.rs
@@ -2664,7 +2664,10 @@ fn undelete_hard_deleted_row_fails() {
         handle.row_id,
         &[Value::Text("Alice".into()), Value::Integer(100)],
     );
-    assert!(matches!(result, Err(QueryError::RowHardDeleted(_))));
+    match result {
+        Err(QueryError::RowHardDeleted(row_id)) => assert_eq!(row_id, handle.row_id),
+        other => panic!("Expected RowHardDeleted for hard-deleted row, got {other:?}"),
+    }
 }
 
 // ========================================================================
@@ -2715,7 +2718,10 @@ fn truncate_nondeleted_row_fails() {
 
     // Try to truncate a non-deleted row - should fail
     let result = qm.truncate(&mut storage, handle.row_id);
-    assert!(matches!(result, Err(QueryError::RowNotDeleted(_))));
+    match result {
+        Err(QueryError::RowNotDeleted(row_id)) => assert_eq!(row_id, handle.row_id),
+        other => panic!("Expected RowNotDeleted for non-deleted row, got {other:?}"),
+    }
 }
 
 // ========================================================================

--- a/crates/jazz-tools/src/query_manager/manager_tests.rs
+++ b/crates/jazz-tools/src/query_manager/manager_tests.rs
@@ -2249,7 +2249,10 @@ fn delete_already_deleted_row_fails() {
 
     // Try to delete again - should fail
     let result = qm.delete(&mut storage, handle.row_id);
-    assert!(matches!(result, Err(QueryError::RowAlreadyDeleted(_))));
+    match result {
+        Err(QueryError::RowAlreadyDeleted(row_id)) => assert_eq!(row_id, handle.row_id),
+        other => panic!("Expected RowAlreadyDeleted for deleted row, got {other:?}"),
+    }
 }
 
 #[test]
@@ -2523,7 +2526,10 @@ fn undelete_nondeleted_row_fails() {
         handle.row_id,
         &[Value::Text("Alice".into()), Value::Integer(100)],
     );
-    assert!(matches!(result, Err(QueryError::RowNotDeleted(_))));
+    match result {
+        Err(QueryError::RowNotDeleted(row_id)) => assert_eq!(row_id, handle.row_id),
+        other => panic!("Expected RowNotDeleted for non-deleted row, got {other:?}"),
+    }
 }
 
 // ========================================================================

--- a/crates/jazz-tools/src/schema_manager/integration_tests.rs
+++ b/crates/jazz-tools/src/schema_manager/integration_tests.rs
@@ -429,6 +429,34 @@ mod tests {
             .unwrap();
     }
 
+    /// Ingest a remote catalogue object on the `main` branch through sync path.
+    fn ingest_remote_catalogue_object(
+        qm: &mut QueryManager,
+        storage: &mut MemoryStorage,
+        object_id: ObjectId,
+        metadata: HashMap<String, String>,
+        content: Vec<u8>,
+        timestamp: u64,
+    ) {
+        qm.sync_manager_mut()
+            .object_manager
+            .receive_object(storage, object_id, metadata);
+
+        let commit = Commit {
+            parents: Default::default(),
+            content,
+            timestamp,
+            author: object_id,
+            metadata: None,
+            stored_state: StoredState::Stored,
+            ack_state: Default::default(),
+        };
+        qm.sync_manager_mut()
+            .object_manager
+            .receive_commit(storage, object_id, "main", commit)
+            .unwrap();
+    }
+
     /// Test QueryManager with schema context initialization.
     #[test]
     fn query_manager_with_schema_context() {
@@ -1281,13 +1309,98 @@ mod tests {
 
         let mut qm = QueryManager::new(SyncManager::new());
         qm.set_current_schema(v1.clone(), "dev", "main");
+        let mut storage = MemoryStorage::new();
 
         // Initially no pending catalogue updates
         assert!(qm.take_pending_catalogue_updates().is_empty());
 
-        // Simulate a catalogue object being received via sync
-        // For this to work, we'd need to inject via the object manager and process
-        // This is more of a unit test showing the API exists
+        // Inject two real catalogue schema objects via sync path.
+        let v2 = SchemaBuilder::new()
+            .table(
+                TableSchema::builder("users")
+                    .column("id", ColumnType::Uuid)
+                    .column("name", ColumnType::Text)
+                    .nullable_column("email", ColumnType::Text),
+            )
+            .build();
+        let v2_hash = SchemaHash::compute(&v2);
+        let object_id_v2 = v2_hash.to_object_id();
+        let encoded_schema_v2 = encode_schema(&v2);
+
+        let v3 = SchemaBuilder::new()
+            .table(
+                TableSchema::builder("users")
+                    .column("id", ColumnType::Uuid)
+                    .column("name", ColumnType::Text)
+                    .nullable_column("email", ColumnType::Text)
+                    .nullable_column("role", ColumnType::Text),
+            )
+            .build();
+        let v3_hash = SchemaHash::compute(&v3);
+        let object_id_v3 = v3_hash.to_object_id();
+        let encoded_schema_v3 = encode_schema(&v3);
+
+        let mut metadata_v2 = HashMap::new();
+        metadata_v2.insert(
+            MetadataKey::Type.to_string(),
+            ObjectType::CatalogueSchema.to_string(),
+        );
+        metadata_v2.insert(
+            MetadataKey::AppId.to_string(),
+            test_app_id().uuid().to_string(),
+        );
+        metadata_v2.insert(MetadataKey::SchemaHash.to_string(), v2_hash.to_string());
+
+        let mut metadata_v3 = HashMap::new();
+        metadata_v3.insert(
+            MetadataKey::Type.to_string(),
+            ObjectType::CatalogueSchema.to_string(),
+        );
+        metadata_v3.insert(
+            MetadataKey::AppId.to_string(),
+            test_app_id().uuid().to_string(),
+        );
+        metadata_v3.insert(MetadataKey::SchemaHash.to_string(), v3_hash.to_string());
+
+        ingest_remote_catalogue_object(
+            &mut qm,
+            &mut storage,
+            object_id_v2,
+            metadata_v2,
+            encoded_schema_v2.clone(),
+            1,
+        );
+        ingest_remote_catalogue_object(
+            &mut qm,
+            &mut storage,
+            object_id_v3,
+            metadata_v3,
+            encoded_schema_v3.clone(),
+            2,
+        );
+
+        qm.process(&mut storage);
+
+        let pending = qm.take_pending_catalogue_updates();
+        assert_eq!(pending.len(), 2, "two catalogue objects should be queued");
+        assert_eq!(pending[0].object_id, object_id_v2);
+        assert_eq!(pending[1].object_id, object_id_v3);
+
+        for update in &pending {
+            assert_eq!(
+                update.metadata.get(MetadataKey::Type.as_str()),
+                Some(&ObjectType::CatalogueSchema.to_string())
+            );
+            assert_eq!(
+                update.metadata.get(MetadataKey::AppId.as_str()),
+                Some(&test_app_id().uuid().to_string())
+            );
+        }
+        assert_eq!(pending[0].content, encoded_schema_v2);
+        assert_eq!(pending[1].content, encoded_schema_v3);
+
+        // Queue should be drained after take().
+        assert!(qm.take_pending_catalogue_updates().is_empty());
     }
 
     /// E2E test: Full catalogue sync flow with data query.

--- a/crates/jazz-tools/src/sync_manager/tests.rs
+++ b/crates/jazz-tools/src/sync_manager/tests.rs
@@ -1066,11 +1066,22 @@ fn reject_permission_check_sends_error() {
     let outbox = sm.take_outbox();
     assert_eq!(outbox.len(), 1);
 
-    match &outbox[0].payload {
-        SyncPayload::Error(SyncError::PermissionDenied { reason, .. }) => {
+    match &outbox[0] {
+        OutboxEntry {
+            destination: Destination::Client(id),
+            payload:
+                SyncPayload::Error(SyncError::PermissionDenied {
+                    object_id,
+                    branch_name,
+                    reason,
+                }),
+        } => {
+            assert_eq!(*id, client_id);
+            assert_eq!(*object_id, obj_id);
+            assert_eq!(branch_name.as_str(), "main");
             assert_eq!(reason, "access denied by policy");
         }
-        _ => panic!("Expected PermissionDenied error"),
+        _ => panic!("Expected PermissionDenied error for source client"),
     }
 
     // Commit should NOT be applied
@@ -1109,6 +1120,7 @@ fn server_update_forwarded_to_matching_clients() {
         stored_state: crate::commit::StoredState::Stored,
         ack_state: Default::default(),
     };
+    let commit_id = commit.id();
 
     sm.push_inbox(InboxEntry {
         source: Source::Server(server_id),
@@ -1132,10 +1144,19 @@ fn server_update_forwarded_to_matching_clients() {
     match &outbox[0] {
         OutboxEntry {
             destination: Destination::Client(id),
-            payload: SyncPayload::ObjectUpdated { object_id, .. },
+            payload:
+                SyncPayload::ObjectUpdated {
+                    object_id,
+                    branch_name,
+                    commits,
+                    ..
+                },
         } => {
             assert_eq!(*id, client_id);
             assert_eq!(*object_id, obj_id);
+            assert_eq!(branch_name.as_str(), "main");
+            assert_eq!(commits.len(), 1);
+            assert_eq!(commits[0].id(), commit_id);
         }
         _ => panic!("Expected ObjectUpdated to client"),
     }
@@ -1195,6 +1216,7 @@ fn client_update_forwarded_to_server_and_other_clients() {
         stored_state: crate::commit::StoredState::Stored,
         ack_state: Default::default(),
     };
+    let commit_id = commit.id();
 
     sm.push_inbox(InboxEntry {
         source: Source::Client(client1),
@@ -1217,6 +1239,44 @@ fn client_update_forwarded_to_server_and_other_clients() {
     assert!(destinations.contains(&Destination::Server(server_id)));
     assert!(destinations.contains(&Destination::Client(client2)));
     assert!(!destinations.contains(&Destination::Client(client1)));
+
+    let server_update = outbox
+        .iter()
+        .find(|e| matches!(e.destination, Destination::Server(id) if id == server_id))
+        .expect("expected forwarded update to server");
+    match &server_update.payload {
+        SyncPayload::ObjectUpdated {
+            object_id,
+            branch_name,
+            commits,
+            ..
+        } => {
+            assert_eq!(*object_id, obj_id);
+            assert_eq!(branch_name.as_str(), "main");
+            assert_eq!(commits.len(), 1);
+            assert_eq!(commits[0].id(), commit_id);
+        }
+        other => panic!("Expected ObjectUpdated payload to server, got {:?}", other),
+    }
+
+    let client_update = outbox
+        .iter()
+        .find(|e| matches!(e.destination, Destination::Client(id) if id == client2))
+        .expect("expected forwarded update to matching client");
+    match &client_update.payload {
+        SyncPayload::ObjectUpdated {
+            object_id,
+            branch_name,
+            commits,
+            ..
+        } => {
+            assert_eq!(*object_id, obj_id);
+            assert_eq!(branch_name.as_str(), "main");
+            assert_eq!(commits.len(), 1);
+            assert_eq!(commits[0].id(), commit_id);
+        }
+        other => panic!("Expected ObjectUpdated payload to client2, got {:?}", other),
+    }
 }
 
 #[test]
@@ -1255,8 +1315,22 @@ fn metadata_sent_only_once_per_destination() {
 
     // First message should have metadata
     assert_eq!(outbox.len(), 1);
-    match &outbox[0].payload {
-        SyncPayload::ObjectUpdated { metadata, .. } => {
+    match &outbox[0] {
+        OutboxEntry {
+            destination: Destination::Server(id),
+            payload:
+                SyncPayload::ObjectUpdated {
+                    object_id,
+                    branch_name,
+                    commits,
+                    metadata,
+                },
+        } => {
+            assert_eq!(*id, server_id);
+            assert_eq!(*object_id, obj_id);
+            assert_eq!(branch_name.as_str(), "main");
+            assert_eq!(commits.len(), 1);
+            assert_eq!(commits[0].id(), c1);
             let metadata = metadata
                 .as_ref()
                 .expect("Existing object sync should include metadata on first send");
@@ -1267,7 +1341,7 @@ fn metadata_sent_only_once_per_destination() {
                 "Expected key=value metadata to be included in first sync"
             );
         }
-        _ => panic!("Expected ObjectUpdated"),
+        _ => panic!("Expected ObjectUpdated to server with first-send metadata"),
     }
 
     // Add another commit (as child of c1)
@@ -1286,11 +1360,25 @@ fn metadata_sent_only_once_per_destination() {
     let outbox = sm.take_outbox();
 
     // Second message should NOT have metadata
-    match &outbox[0].payload {
-        SyncPayload::ObjectUpdated { metadata, .. } => {
+    assert_eq!(outbox.len(), 1);
+    match &outbox[0] {
+        OutboxEntry {
+            destination: Destination::Server(id),
+            payload:
+                SyncPayload::ObjectUpdated {
+                    object_id,
+                    branch_name,
+                    commits,
+                    metadata,
+                },
+        } => {
+            assert_eq!(*id, server_id);
+            assert_eq!(*object_id, obj_id);
+            assert_eq!(branch_name.as_str(), "main");
+            assert_eq!(commits.len(), 1);
             assert!(metadata.is_none());
         }
-        _ => panic!("Expected ObjectUpdated"),
+        _ => panic!("Expected ObjectUpdated to server without metadata on repeat send"),
     }
 }
 
@@ -1684,12 +1772,17 @@ fn send_query_subscription_includes_session() {
     let outbox = sm.take_outbox();
     assert_eq!(outbox.len(), 1);
 
-    match &outbox[0].payload {
-        SyncPayload::QuerySubscription {
-            query_id,
-            query: sent_query,
-            session: sent_session,
+    match &outbox[0] {
+        OutboxEntry {
+            destination: Destination::Server(id),
+            payload:
+                SyncPayload::QuerySubscription {
+                    query_id,
+                    query: sent_query,
+                    session: sent_session,
+                },
         } => {
+            assert_eq!(*id, server_id);
             assert_eq!(*query_id, QueryId(1));
             assert_eq!(sent_query.table, query.table);
             let sent_session = sent_session
@@ -1697,7 +1790,7 @@ fn send_query_subscription_includes_session() {
                 .expect("QuerySubscription payload should include session");
             assert_eq!(sent_session.user_id, "alice");
         }
-        _ => panic!("Expected QuerySubscription"),
+        _ => panic!("Expected QuerySubscription to connected server"),
     }
 }
 

--- a/crates/jazz-tools/src/sync_manager/tests.rs
+++ b/crates/jazz-tools/src/sync_manager/tests.rs
@@ -1253,8 +1253,18 @@ fn client_update_forwarded_to_server_and_other_clients() {
         } => {
             assert_eq!(*object_id, obj_id);
             assert_eq!(branch_name.as_str(), "main");
-            assert_eq!(commits.len(), 1);
-            assert_eq!(commits[0].id(), commit_id);
+            assert!(
+                commits.iter().any(|c| c.id() == commit_id),
+                "server payload must include the client's new commit"
+            );
+            let parent_pos = commits.iter().position(|c| c.id() == c1);
+            let child_pos = commits.iter().position(|c| c.id() == commit_id);
+            if let (Some(parent_pos), Some(child_pos)) = (parent_pos, child_pos) {
+                assert!(
+                    parent_pos < child_pos,
+                    "if parent commit is forwarded, it must come before child"
+                );
+            }
         }
         other => panic!("Expected ObjectUpdated payload to server, got {:?}", other),
     }
@@ -1272,8 +1282,10 @@ fn client_update_forwarded_to_server_and_other_clients() {
         } => {
             assert_eq!(*object_id, obj_id);
             assert_eq!(branch_name.as_str(), "main");
-            assert_eq!(commits.len(), 1);
-            assert_eq!(commits[0].id(), commit_id);
+            assert!(
+                commits.iter().any(|c| c.id() == commit_id),
+                "client payload must include the forwarded commit"
+            );
         }
         other => panic!("Expected ObjectUpdated payload to client2, got {:?}", other),
     }

--- a/crates/jazz-tools/src/sync_manager/tests.rs
+++ b/crates/jazz-tools/src/sync_manager/tests.rs
@@ -760,15 +760,23 @@ fn user_without_session_rejected() {
     let outbox = sm.take_outbox();
     assert_eq!(outbox.len(), 1);
 
-    match &outbox[0].payload {
-        SyncPayload::Error(SyncError::SessionRequired {
-            object_id,
-            branch_name,
-        }) => {
+    match &outbox[0] {
+        OutboxEntry {
+            destination: Destination::Client(id),
+            payload:
+                SyncPayload::Error(SyncError::SessionRequired {
+                    object_id,
+                    branch_name,
+                }),
+        } => {
+            assert_eq!(*id, client_id);
             assert_eq!(*object_id, obj_id);
             assert_eq!(branch_name.as_str(), "main");
         }
-        other => panic!("Expected SessionRequired error, got {:?}", other),
+        other => panic!(
+            "Expected SessionRequired error to source client, got {:?}",
+            other
+        ),
     }
 
     // Object should not exist
@@ -821,15 +829,23 @@ fn user_catalogue_write_rejected() {
     let outbox = sm.take_outbox();
     assert_eq!(outbox.len(), 1);
 
-    match &outbox[0].payload {
-        SyncPayload::Error(SyncError::CatalogueWriteDenied {
-            object_id,
-            branch_name,
-        }) => {
+    match &outbox[0] {
+        OutboxEntry {
+            destination: Destination::Client(id),
+            payload:
+                SyncPayload::Error(SyncError::CatalogueWriteDenied {
+                    object_id,
+                    branch_name,
+                }),
+        } => {
+            assert_eq!(*id, client_id);
             assert_eq!(*object_id, obj_id);
             assert_eq!(branch_name.as_str(), "main");
         }
-        other => panic!("Expected CatalogueWriteDenied error, got {:?}", other),
+        other => panic!(
+            "Expected CatalogueWriteDenied error to source client, got {:?}",
+            other
+        ),
     }
 
     // Object should not exist

--- a/crates/jazz-tools/src/sync_manager/tests.rs
+++ b/crates/jazz-tools/src/sync_manager/tests.rs
@@ -45,13 +45,18 @@ fn add_server_receives_existing_objects() {
     let outbox = sm.take_outbox();
     assert_eq!(outbox.len(), 1);
 
-    match &outbox[0].payload {
-        SyncPayload::ObjectUpdated {
-            object_id,
-            metadata,
-            branch_name,
-            commits,
+    match &outbox[0] {
+        OutboxEntry {
+            destination: Destination::Server(id),
+            payload:
+                SyncPayload::ObjectUpdated {
+                    object_id,
+                    metadata,
+                    branch_name,
+                    commits,
+                },
         } => {
+            assert_eq!(*id, server_id);
             assert_eq!(*object_id, obj_id);
             let metadata = metadata
                 .as_ref()
@@ -64,7 +69,7 @@ fn add_server_receives_existing_objects() {
             assert_eq!(branch_name.as_str(), "main");
             assert_eq!(commits.len(), 1);
         }
-        _ => panic!("Expected ObjectUpdated"),
+        _ => panic!("Expected ObjectUpdated to the newly added server"),
     }
 }
 
@@ -202,15 +207,27 @@ fn commits_sent_in_causal_order() {
     let outbox = sm.take_outbox();
     assert_eq!(outbox.len(), 1);
 
-    match &outbox[0].payload {
-        SyncPayload::ObjectUpdated { commits, .. } => {
+    match &outbox[0] {
+        OutboxEntry {
+            destination: Destination::Server(id),
+            payload:
+                SyncPayload::ObjectUpdated {
+                    object_id,
+                    branch_name,
+                    commits,
+                    ..
+                },
+        } => {
+            assert_eq!(*id, server_id);
+            assert_eq!(*object_id, obj_id);
+            assert_eq!(branch_name.as_str(), "main");
             assert_eq!(commits.len(), 3);
             // Parents should come before children
             assert_eq!(commits[0].id(), c1);
             assert_eq!(commits[1].id(), c2);
             assert_eq!(commits[2].id(), c3);
         }
-        _ => panic!("Expected ObjectUpdated"),
+        _ => panic!("Expected ObjectUpdated with causal commit ordering"),
     }
 }
 
@@ -250,10 +267,18 @@ fn client_with_query_receives_matching_objects() {
     match &outbox[0] {
         OutboxEntry {
             destination: Destination::Client(id),
-            payload: SyncPayload::ObjectUpdated { object_id, .. },
+            payload:
+                SyncPayload::ObjectUpdated {
+                    object_id,
+                    branch_name,
+                    commits,
+                    ..
+                },
         } => {
             assert_eq!(*id, client_id);
             assert_eq!(*object_id, obj_id);
+            assert_eq!(branch_name.as_str(), "main");
+            assert_eq!(commits.len(), 1);
         }
         _ => panic!("Expected ObjectUpdated to client"),
     }

--- a/crates/jazz-tools/src/sync_manager/tests.rs
+++ b/crates/jazz-tools/src/sync_manager/tests.rs
@@ -321,11 +321,23 @@ fn local_commit_in_scope_syncs_to_client() {
     let outbox = sm.take_outbox();
     assert_eq!(outbox.len(), 1);
 
-    match &outbox[0].payload {
-        SyncPayload::ObjectUpdated { commits, .. } => {
+    match &outbox[0] {
+        OutboxEntry {
+            destination: Destination::Client(id),
+            payload:
+                SyncPayload::ObjectUpdated {
+                    object_id,
+                    branch_name,
+                    commits,
+                    ..
+                },
+        } => {
+            assert_eq!(*id, client_id);
+            assert_eq!(*object_id, obj_id);
+            assert_eq!(branch_name.as_str(), "main");
             assert!(commits.iter().any(|c| c.id() == commit_id));
         }
-        _ => panic!("Expected ObjectUpdated"),
+        _ => panic!("Expected ObjectUpdated to matching client scope"),
     }
 }
 
@@ -397,11 +409,23 @@ fn query_update_adds_scope_triggers_initial_sync() {
     let outbox = sm.take_outbox();
     assert_eq!(outbox.len(), 1); // Only obj2 (newly visible)
 
-    match &outbox[0].payload {
-        SyncPayload::ObjectUpdated { object_id, .. } => {
+    match &outbox[0] {
+        OutboxEntry {
+            destination: Destination::Client(id),
+            payload:
+                SyncPayload::ObjectUpdated {
+                    object_id,
+                    branch_name,
+                    commits,
+                    ..
+                },
+        } => {
+            assert_eq!(*id, client_id);
             assert_eq!(*object_id, obj2);
+            assert_eq!(branch_name.as_str(), "main");
+            assert_eq!(commits.len(), 1);
         }
-        _ => panic!("Expected ObjectUpdated"),
+        _ => panic!("Expected ObjectUpdated for newly visible object"),
     }
 }
 

--- a/specs/todo/a_mvp/weak_tests.md
+++ b/specs/todo/a_mvp/weak_tests.md
@@ -10,13 +10,7 @@ This file replaces the old test-quality subsection from `general_cleanup.md` and
 
 ## Remaining Weak Assertions
 
-## 3. Test Stub / Non-Behavioral Case (high priority)
-
-- `crates/groove/src/schema_manager/integration_tests.rs:query_manager_queues_catalogue_updates`
-  - Current: asserts only initial empty queue and then stops.
-  - Needed: inject a real catalogue payload via sync path and assert pending catalogue update enqueue/dequeue behavior.
-
-## 4. Broader Sweep (medium priority)
+## 4. Broader Sweep (medium priority) - Partially done but needs more work
 
 - Continue reducing `len()`-only checks in older tests (especially early `sync_manager/tests.rs` and older `manager_tests.rs` cases) where object identity/content can be asserted cheaply.
 - Avoid broad `matches!` patterns that do not validate key payload fields.


### PR DESCRIPTION
## Summary
- add helper to ingest remote catalogue objects via the sync path in integration tests
- extend the schema context test to inject two real schema versions, process them, and assert pending queue contents match
- reduce `len()`-only checks in older tests and general tests hardening

## Testing
- Not run (not requested)