### PR TITLE
Make permission rule DSL side-effecty like schemas

### DIFF
--- a/docs/content/docs/permissions.mdx
+++ b/docs/content/docs/permissions.mdx
@@ -54,11 +54,11 @@ In TypeScript permissions, combine multiple conditions with array-based combinat
 import { definePermissions } from "jazz-tools/permissions";
 import { app } from "./app.js";
 
-export default definePermissions(app, ({ policy, allOf, anyOf, allowedTo, session }) => [
+export default definePermissions(app, ({ policy, allOf, anyOf, allowedTo, session }) => {
   policy.todos.allowRead.where(
     anyOf([{ owner_id: session.user_id }, allOf([{ done: false }, allowedTo.read("project")])]),
-  ),
-]);
+  );
+});
 ```
 
 `allOf([...])` compiles to logical `AND`, and `anyOf([...])` compiles to logical `OR`.
@@ -90,15 +90,15 @@ Use depth-bounded `INHERITS` when foreign keys can form recursive chains (for ex
     import { definePermissions } from "jazz-tools/permissions";
     import { app } from "./app.js";
 
-    export default definePermissions(app, ({ policy, allowedTo }) => [
+    export default definePermissions(app, ({ policy, allowedTo }) => {
       // Default recursive depth is 10.
-      policy.folders.allowRead.where(allowedTo.read("parentId")),
+      policy.folders.allowRead.where(allowedTo.read("parentId"));
 
       // Explicit override for recursive/self-referential chains.
       policy.folders.allowUpdate
         .whereOld(allowedTo.update("parentId", { maxDepth: 5 }))
-        .whereNew(allowedTo.update("parentId", { maxDepth: 5 })),
-    ]);
+        .whereNew(allowedTo.update("parentId", { maxDepth: 5 }));
+    });
     ```
 
     `maxDepth` must be a positive integer.
@@ -144,16 +144,14 @@ When simple `allowedTo.*(...)` is not expressive enough, build an explicit recur
         maxDepth: 10,
       });
 
-      return [
-        policy.todos.allowRead.where((todo) =>
-          policy.exists(
-            reachableTeams.hopTo("resource_access_edgesViaTeam").where({
-              "resource_access_edges.resource": todo.id,
-              grant_role: "viewer",
-            }),
-          ),
+      policy.todos.allowRead.where((todo) =>
+        policy.exists(
+          reachableTeams.hopTo("resource_access_edgesViaTeam").where({
+            "resource_access_edges.resource": todo.id,
+            grant_role: "viewer",
+          }),
         ),
-      ];
+      );
     });
     ```
 

--- a/examples/docs/todo-client-localfirst-react/schema/permissions.ts
+++ b/examples/docs/todo-client-localfirst-react/schema/permissions.ts
@@ -1,9 +1,9 @@
 import { definePermissions } from "jazz-tools/permissions";
 import { app } from "./app.js";
 
-export default definePermissions(app, ({ policy }) => [
-  policy.todos.allowRead.where({}),
-  policy.todos.allowInsert.where({}),
-  policy.todos.allowUpdate.where({}),
-  policy.todos.allowDelete.where({}),
-]);
+export default definePermissions(app, ({ policy }) => {
+  policy.todos.allowRead.where({});
+  policy.todos.allowInsert.where({});
+  policy.todos.allowUpdate.where({});
+  policy.todos.allowDelete.where({});
+});

--- a/examples/docs/todo-client-localfirst-ts/schema/permissions.ts
+++ b/examples/docs/todo-client-localfirst-ts/schema/permissions.ts
@@ -1,9 +1,9 @@
 import { definePermissions } from "jazz-tools/permissions";
 import { app } from "./app.js";
 
-export default definePermissions(app, ({ policy }) => [
-  policy.todos.allowRead.where({}),
-  policy.todos.allowInsert.where({}),
-  policy.todos.allowUpdate.where({}),
-  policy.todos.allowDelete.where({}),
-]);
+export default definePermissions(app, ({ policy }) => {
+  policy.todos.allowRead.where({});
+  policy.todos.allowInsert.where({});
+  policy.todos.allowUpdate.where({});
+  policy.todos.allowDelete.where({});
+});

--- a/examples/docs/todo-server-ts/schema/permissions.ts
+++ b/examples/docs/todo-server-ts/schema/permissions.ts
@@ -1,9 +1,9 @@
 import { definePermissions } from "jazz-tools/permissions";
 import { app } from "./app.js";
 
-export default definePermissions(app, ({ policy, session }) => [
-  policy.todos.allowRead.where({ owner_id: session.user_id }),
-  policy.todos.allowInsert.where({ owner_id: session.user_id }),
-  policy.todos.allowUpdate.where({ owner_id: session.user_id }),
-  policy.todos.allowDelete.where({ owner_id: session.user_id }),
-]);
+export default definePermissions(app, ({ policy, session }) => {
+  policy.todos.allowRead.where({ owner_id: session.user_id });
+  policy.todos.allowInsert.where({ owner_id: session.user_id });
+  policy.todos.allowUpdate.where({ owner_id: session.user_id });
+  policy.todos.allowDelete.where({ owner_id: session.user_id });
+});

--- a/examples/docs/todo-server-ts/src/permissions-snippets.ts
+++ b/examples/docs/todo-server-ts/src/permissions-snippets.ts
@@ -23,21 +23,21 @@ table("todoShares", {
 // #endregion permissions-schema-ts
 
 // #region permissions-simple-ts
-definePermissions(app, ({ policy, allOf, session }) => [
-  policy.todos.allowRead.where({ owner_id: session.user_id }),
-  policy.todos.allowInsert.where({ owner_id: session.user_id }),
+definePermissions(app, ({ policy, allOf, session }) => {
+  policy.todos.allowRead.where({ owner_id: session.user_id });
+  policy.todos.allowInsert.where({ owner_id: session.user_id });
   policy.todos.allowUpdate
     .whereOld(allOf([{ owner_id: session.user_id }, { done: false }]))
-    .whereNew({ owner_id: session.user_id }),
-  policy.todos.allowDelete.where({ owner_id: session.user_id }),
-]);
+    .whereNew({ owner_id: session.user_id });
+  policy.todos.allowDelete.where({ owner_id: session.user_id });
+});
 // #endregion permissions-simple-ts
 
 // #region permissions-allowed-to-ts
-definePermissions(app, ({ policy, anyOf, allOf, allowedTo }) => [
-  policy.todos.allowRead.where(anyOf([{ done: false }, allowedTo.read("project")])),
+definePermissions(app, ({ policy, anyOf, allOf, allowedTo }) => {
+  policy.todos.allowRead.where(anyOf([{ done: false }, allowedTo.read("project")]));
   policy.todos.allowUpdate
     .whereOld(allOf([allowedTo.update("project"), { done: false }]))
-    .whereNew(allowedTo.update("project")),
-]);
+    .whereNew(allowedTo.update("project"));
+});
 // #endregion permissions-allowed-to-ts

--- a/examples/todo-client-localfirst-react/schema/permissions.ts
+++ b/examples/todo-client-localfirst-react/schema/permissions.ts
@@ -1,11 +1,11 @@
 import { definePermissions } from "jazz-tools/permissions";
 import { app } from "./app.js";
 
-export default definePermissions(app, ({ policy, session }) => [
-  policy.todos.allowRead.where({}),
-  policy.todos.allowInsert.where({ owner_id: session.user_id }),
+export default definePermissions(app, ({ policy, session }) => {
+  policy.todos.allowRead.where({});
+  policy.todos.allowInsert.where({ owner_id: session.user_id });
   policy.todos.allowUpdate
     .whereOld({ owner_id: session.user_id })
-    .whereNew({ owner_id: session.user_id }),
-  policy.todos.allowDelete.where({ owner_id: session.user_id }),
-]);
+    .whereNew({ owner_id: session.user_id });
+  policy.todos.allowDelete.where({ owner_id: session.user_id });
+});

--- a/examples/todo-client-localfirst-ts/schema/permissions.ts
+++ b/examples/todo-client-localfirst-ts/schema/permissions.ts
@@ -1,11 +1,11 @@
 import { definePermissions } from "jazz-tools/permissions";
 import { app } from "./app.js";
 
-export default definePermissions(app, ({ policy, session }) => [
-  policy.todos.allowRead.where({}),
-  policy.todos.allowInsert.where({ owner_id: session.user_id }),
+export default definePermissions(app, ({ policy, session }) => {
+  policy.todos.allowRead.where({});
+  policy.todos.allowInsert.where({ owner_id: session.user_id });
   policy.todos.allowUpdate
     .whereOld({ owner_id: session.user_id })
-    .whereNew({ owner_id: session.user_id }),
-  policy.todos.allowDelete.where({ owner_id: session.user_id }),
-]);
+    .whereNew({ owner_id: session.user_id });
+  policy.todos.allowDelete.where({ owner_id: session.user_id });
+});

--- a/examples/todo-server-ts/schema/permissions.ts
+++ b/examples/todo-server-ts/schema/permissions.ts
@@ -1,9 +1,9 @@
 import { definePermissions } from "jazz-tools/permissions";
 import { app } from "./app.js";
 
-export default definePermissions(app, ({ policy, session }) => [
-  policy.todos.allowRead.where({ owner_id: session.user_id }),
-  policy.todos.allowInsert.where({ owner_id: session.user_id }),
-  policy.todos.allowUpdate.where({ owner_id: session.user_id }),
-  policy.todos.allowDelete.where({ owner_id: session.user_id }),
-]);
+export default definePermissions(app, ({ policy, session }) => {
+  policy.todos.allowRead.where({ owner_id: session.user_id });
+  policy.todos.allowInsert.where({ owner_id: session.user_id });
+  policy.todos.allowUpdate.where({ owner_id: session.user_id });
+  policy.todos.allowDelete.where({ owner_id: session.user_id });
+});

--- a/packages/jazz-tools/src/permissions/index.ts
+++ b/packages/jazz-tools/src/permissions/index.ts
@@ -461,25 +461,32 @@ type PermissionWhereInput<T> =
 class UpdateRuleBuilder<WhereInput, Row> {
   private oldCondition?: Condition;
   private newCondition?: Condition;
+  private isRegistered = false;
 
-  constructor(private readonly table: string) {}
+  constructor(
+    private readonly table: string,
+    private readonly registerRule?: (ruleLike: RuleLike) => void,
+  ) {}
 
   where(
     input: Condition | PermissionWhereInput<WhereInput> | ((row: RowContext<Row>) => unknown),
   ): Rule {
     const condition = resolveWhereInput(input);
-    return {
+    const rule: Rule = {
       table: this.table,
       action: "update",
       using: condition,
       withCheck: condition,
     };
+    this.registerRule?.(rule);
+    return rule;
   }
 
   whereOld(
     input: Condition | PermissionWhereInput<WhereInput> | ((row: RowContext<Row>) => unknown),
   ): this {
     this.oldCondition = resolveWhereInput(input);
+    this.registerBuilder();
     return this;
   }
 
@@ -487,7 +494,16 @@ class UpdateRuleBuilder<WhereInput, Row> {
     input: Condition | PermissionWhereInput<WhereInput> | ((row: RowContext<Row>) => unknown),
   ): this {
     this.newCondition = resolveWhereInput(input);
+    this.registerBuilder();
     return this;
+  }
+
+  private registerBuilder(): void {
+    if (this.isRegistered) {
+      return;
+    }
+    this.isRegistered = true;
+    this.registerRule?.(this as unknown as RuleLike);
   }
 
   toRule(): Rule {
@@ -505,20 +521,28 @@ class UpdateRuleBuilder<WhereInput, Row> {
 
 export function definePermissions<TApp extends AppLike>(
   app: TApp,
-  factory: (ctx: PolicyContext<TApp>) => RuleLike[] | RuleLike,
+  factory: (ctx: PolicyContext<TApp>) => void,
 ): CompiledPermissions {
   const fkReferencesByTable = collectFkReferencesByTable(app);
   const relationsByTable = collectRelationsByTable(app);
   const tableNames = Object.keys(app).filter((key) => key !== "wasmSchema");
+  const rules: RuleLike[] = [];
+  const seenRules = new Set<RuleLike>();
+  const collectRule = (ruleLike: RuleLike): void => {
+    if (seenRules.has(ruleLike)) {
+      return;
+    }
+    seenRules.add(ruleLike);
+    rules.push(ruleLike);
+  };
   const ctx = {
-    policy: buildPolicyContext(tableNames, relationsByTable),
+    policy: buildPolicyContext(tableNames, relationsByTable, collectRule),
     anyOf,
     allOf,
     allowedTo: createAllowedToContext(),
     session: createSessionContext(),
   } as unknown as PolicyContext<TApp>;
-  const output = factory(ctx);
-  const rules = Array.isArray(output) ? output : [output];
+  factory(ctx);
   return compileRules(rules, fkReferencesByTable);
 }
 
@@ -570,10 +594,11 @@ function collectRelationsByTable(app: AppLike): Map<string, Relation[]> {
 function buildPolicyContext(
   tableNames: string[],
   relationsByTable: Map<string, Relation[]>,
+  collectRule: (ruleLike: RuleLike) => void,
 ): Record<string, unknown> {
   const context: Record<string, unknown> = {};
   for (const table of tableNames) {
-    context[table] = buildTablePolicyBuilder(table, relationsByTable);
+    context[table] = buildTablePolicyBuilder(table, relationsByTable, collectRule);
   }
   context.exists = (relation: PermissionRelation): ExistsRelationCondition => ({
     __jazzPermissionKind: "exists-relation",
@@ -585,17 +610,24 @@ function buildPolicyContext(
 function buildTablePolicyBuilder(
   table: string,
   relationsByTable: Map<string, Relation[]>,
+  collectRule: (ruleLike: RuleLike) => void,
 ): Record<string, unknown> {
+  const registerRule = (rule: Rule): Rule => {
+    collectRule(rule);
+    return rule;
+  };
   const read: ActionBuilder<unknown, unknown> = {
-    where: (input) => ({ table, action: "read", using: resolveWhereInput(input) }),
+    where: (input) => registerRule({ table, action: "read", using: resolveWhereInput(input) }),
   };
   const insert: ActionBuilder<unknown, unknown> = {
-    where: (input) => ({ table, action: "insert", withCheck: resolveWhereInput(input) }),
+    where: (input) =>
+      registerRule({ table, action: "insert", withCheck: resolveWhereInput(input) }),
   };
   const del: ActionBuilder<unknown, unknown> = {
-    where: (input) => ({ table, action: "delete", using: resolveWhereInput(input) }),
+    where: (input) => registerRule({ table, action: "delete", using: resolveWhereInput(input) }),
   };
-  const updateFactory = (): UpdateRuleBuilder<unknown, unknown> => new UpdateRuleBuilder(table);
+  const updateFactory = (): UpdateRuleBuilder<unknown, unknown> =>
+    new UpdateRuleBuilder(table, collectRule);
   const exists: ExistsBuilder<unknown> = {
     where: (input) => ({
       __jazzPermissionKind: "exists",

--- a/packages/jazz-tools/src/runtime/cloud-server.integration.test.ts
+++ b/packages/jazz-tools/src/runtime/cloud-server.integration.test.ts
@@ -743,66 +743,62 @@ function buildSocialSchema(style: SocialPolicyStyle): WasmSchema {
       const sessionPersonId = session.user_id;
 
       if (style === "split") {
-        return [
-          policy.people.allowRead.where((person) =>
-            anyOf([
-              policy.exists(
-                policy.friendships.where({
-                  personAPrincipal: sessionPersonId,
-                  personBPrincipal: person.principalId,
-                }),
-              ),
-              policy.exists(
-                policy.friendships.where({
-                  personBPrincipal: sessionPersonId,
-                  personAPrincipal: person.principalId,
-                }),
-              ),
-            ]),
-          ),
-          policy.profiles.allowRead.where(allowedTo.readReferencing(policy.people, "profileId")),
-        ];
+        policy.people.allowRead.where((person) =>
+          anyOf([
+            policy.exists(
+              policy.friendships.where({
+                personAPrincipal: sessionPersonId,
+                personBPrincipal: person.principalId,
+              }),
+            ),
+            policy.exists(
+              policy.friendships.where({
+                personBPrincipal: sessionPersonId,
+                personAPrincipal: person.principalId,
+              }),
+            ),
+          ]),
+        );
+        policy.profiles.allowRead.where(allowedTo.readReferencing(policy.people, "profileId"));
+        return;
       }
 
       if (style === "join") {
-        return [
-          policy.profiles.allowRead.where((profile) =>
-            anyOf([
-              policy.exists(
-                policy.people
-                  .where({ principalId: profile.principalId })
-                  .join(policy.friendships, { left: "id", right: "personAId" })
-                  .where({ personBPrincipal: sessionPersonId }),
-              ),
-              policy.exists(
-                policy.people
-                  .where({ principalId: profile.principalId })
-                  .join(policy.friendships, { left: "id", right: "personBId" })
-                  .where({ personAPrincipal: sessionPersonId }),
-              ),
-            ]),
-          ),
-        ];
-      }
-
-      return [
         policy.profiles.allowRead.where((profile) =>
           anyOf([
             policy.exists(
               policy.people
                 .where({ principalId: profile.principalId })
-                .hopTo("friendshipsViaPersonAId")
+                .join(policy.friendships, { left: "id", right: "personAId" })
                 .where({ personBPrincipal: sessionPersonId }),
             ),
             policy.exists(
               policy.people
                 .where({ principalId: profile.principalId })
-                .hopTo("friendshipsViaPersonBId")
+                .join(policy.friendships, { left: "id", right: "personBId" })
                 .where({ personAPrincipal: sessionPersonId }),
             ),
           ]),
-        ),
-      ];
+        );
+        return;
+      }
+
+      policy.profiles.allowRead.where((profile) =>
+        anyOf([
+          policy.exists(
+            policy.people
+              .where({ principalId: profile.principalId })
+              .hopTo("friendshipsViaPersonAId")
+              .where({ personBPrincipal: sessionPersonId }),
+          ),
+          policy.exists(
+            policy.people
+              .where({ principalId: profile.principalId })
+              .hopTo("friendshipsViaPersonBId")
+              .where({ personAPrincipal: sessionPersonId }),
+          ),
+        ]),
+      );
     }),
   );
 


### PR DESCRIPTION
## Summary
- remove explicit return-value collection from `definePermissions`
- make rule collection exclusively side-effect-driven via permission clause invocation
- keep rule dedupe and register update builders/rules as clauses are called

## Validation
- `pnpm -C packages/jazz-tools test src/permissions/index.test.ts src/permissions/type-inference.test.ts`
- `pnpm -C . exec oxfmt packages/jazz-tools/src/permissions/index.ts`
- `pnpm -C . exec oxlint packages/jazz-tools/src/permissions/index.ts`
