### PR TITLE
feat: refactor worker managers in state machines and add a retry for nomodificationallowederror

### DIFF
--- a/packages/jazz-tools/src/runtime/worker-bridge.race-harness.test.ts
+++ b/packages/jazz-tools/src/runtime/worker-bridge.race-harness.test.ts
@@ -291,9 +291,30 @@ describe("WorkerBridge race harness", () => {
     worker.script.failInit("boom");
     await expect(initPromise).rejects.toThrow("Worker init failed: boom");
 
-    expect((bridge as any).initState).toBe("failed");
-    expect((bridge as any).pendingSyncPayloadsForWorker).toEqual([]);
+    expect((bridge as any).state.phase).toBe("failed");
+    expect((bridge as any).state.pendingSyncPayloadsForWorker).toEqual([]);
     expect(worker.script.receivedSyncPayloads).toEqual([]);
+  });
+
+  it("WB-U09 init times out after the bridge timeout window", async () => {
+    vi.useFakeTimers();
+    try {
+      const worker = new FakeWorker({ initAckMode: "manual" });
+      const { runtime } = createRuntimeHarness();
+      const bridge = new WorkerBridge(worker as unknown as Worker, runtime);
+
+      const initErrorPromise = bridge.init(makeBridgeOptions()).then(
+        () => new Error("Expected init to timeout"),
+        (error: unknown) => (error instanceof Error ? error : new Error(String(error))),
+      );
+      await vi.advanceTimersByTimeAsync(12_001);
+
+      const initError = await initErrorPromise;
+      expect(initError.message).toContain("Worker init timeout");
+      expect((bridge as any).state.phase).toBe("failed");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("WB-U07 handles synchronous shutdown-ok acknowledgements", async () => {

--- a/packages/jazz-tools/src/runtime/worker-bridge.ts
+++ b/packages/jazz-tools/src/runtime/worker-bridge.ts
@@ -36,6 +36,27 @@ export interface PeerSyncBatch {
   payload: string[];
 }
 
+type BridgePhase = "idle" | "initializing" | "ready" | "failed" | "shutting-down" | "disposed";
+type BridgeEvent =
+  | { type: "INIT_CALLED" }
+  | { type: "INIT_OK"; clientId: string }
+  | { type: "INIT_FAILED" }
+  | { type: "SHUTDOWN_CALLED" }
+  | { type: "SHUTDOWN_FINISHED" };
+
+interface WorkerBridgeState {
+  phase: BridgePhase;
+  workerClientId: string | null;
+  initPromise: Promise<string> | null;
+  pendingSyncPayloadsForWorker: string[];
+  syncBatchFlushQueued: boolean;
+  peerSyncListener: ((batch: PeerSyncBatch) => void) | null;
+  serverPayloadForwarder: ((payload: string) => void) | null;
+}
+
+const INIT_RESPONSE_TIMEOUT_MS = 12_000;
+const SHUTDOWN_ACK_TIMEOUT_MS = 5_000;
+
 /**
  * Bridge between main-thread runtime and dedicated worker.
  *
@@ -47,29 +68,30 @@ export interface PeerSyncBatch {
 export class WorkerBridge {
   private worker: Worker;
   private runtime: Runtime;
-  private workerClientId: string | null = null;
-  private initState: "idle" | "pending" | "ready" | "failed" = "idle";
-  private initPromise: Promise<string> | null = null;
-  private pendingSyncPayloadsForWorker: string[] = [];
-  private syncBatchFlushQueued = false;
-  private disposed = false;
-  private peerSyncListener: ((batch: PeerSyncBatch) => void) | null = null;
-  private serverPayloadForwarder: ((payload: string) => void) | null = null;
+  private state: WorkerBridgeState;
 
   constructor(worker: Worker, runtime: Runtime) {
     this.worker = worker;
     this.runtime = runtime;
+    this.state = {
+      phase: "idle",
+      workerClientId: null,
+      initPromise: null,
+      pendingSyncPayloadsForWorker: [],
+      syncBatchFlushQueued: false,
+      peerSyncListener: null,
+      serverPayloadForwarder: null,
+    };
 
     // Wire worker → main: incoming sync messages from worker
     this.worker.onmessage = (event: MessageEvent<WorkerToMainMessage>) => {
       const msg = event.data;
       if (msg.type === "sync") {
-        // Worker sends payload-only (it's the "server" for main thread)
         for (const payload of msg.payload) {
           this.runtime.onSyncMessageReceived(payload);
         }
       } else if (msg.type === "peer-sync") {
-        this.peerSyncListener?.({
+        this.state.peerSyncListener?.({
           peerId: msg.peerId,
           term: msg.term,
           payload: msg.payload,
@@ -79,13 +101,12 @@ export class WorkerBridge {
 
     // Wire main → worker: outgoing sync messages from runtime
     this.runtime.onSyncMessageToSend((envelope: string) => {
-      if (this.disposed) return;
+      if (this.isDisposedLike()) return;
       const parsed = JSON.parse(envelope);
-      // Only forward server-bound messages (worker IS the server)
       if (parsed.destination && "Server" in parsed.destination) {
         const payload = JSON.stringify(parsed.payload);
-        if (this.serverPayloadForwarder) {
-          this.serverPayloadForwarder(payload);
+        if (this.state.serverPayloadForwarder) {
+          this.state.serverPayloadForwarder(payload);
         } else {
           this.enqueueSyncMessageForWorker(payload);
         }
@@ -102,11 +123,17 @@ export class WorkerBridge {
    * Waits for the worker to respond with init-ok.
    */
   init(options: WorkerBridgeOptions): Promise<string> {
-    if (this.initPromise) {
-      return this.initPromise;
+    if (this.state.initPromise) {
+      return this.state.initPromise;
     }
 
-    this.initState = "pending";
+    if (this.isDisposedLike()) {
+      const disposedError = Promise.reject(new Error("WorkerBridge has been disposed"));
+      this.state.initPromise = disposedError;
+      return disposedError;
+    }
+
+    this.transition({ type: "INIT_CALLED" });
 
     const initMsg: InitMessage = {
       type: "init",
@@ -127,18 +154,29 @@ export class WorkerBridge {
     const responsePromise = waitForMessage<WorkerToMainMessage>(
       this.worker,
       (msg) => msg.type === "init-ok" || msg.type === "error",
+      INIT_RESPONSE_TIMEOUT_MS,
+      "Worker init timeout",
     );
+
     this.worker.postMessage(initMsg);
 
-    this.initPromise = responsePromise
+    const initPromise = responsePromise
       .then((response) => {
+        if (this.isDisposedLike()) {
+          throw new Error("WorkerBridge has been disposed");
+        }
+
         if (response.type === "error") {
+          this.transition({ type: "INIT_FAILED" });
           throw new Error(`Worker init failed: ${response.message}`);
         }
 
         if (response.type === "init-ok") {
-          this.workerClientId = response.clientId;
-          this.initState = "ready";
+          if (this.state.phase !== "initializing") {
+            // Ignore late init-ok after a terminal transition.
+            throw new Error("Worker init response arrived after bridge left initializing state");
+          }
+          this.transition({ type: "INIT_OK", clientId: response.clientId });
           this.flushPendingSyncToWorker();
           return response.clientId;
         }
@@ -146,12 +184,14 @@ export class WorkerBridge {
         throw new Error("Unexpected worker response");
       })
       .catch((error) => {
-        this.initState = "failed";
-        this.pendingSyncPayloadsForWorker = [];
+        if (this.state.phase !== "disposed") {
+          this.transition({ type: "INIT_FAILED" });
+        }
         throw error;
       });
 
-    return this.initPromise;
+    this.state.initPromise = initPromise;
+    return initPromise;
   }
 
   /**
@@ -162,11 +202,12 @@ export class WorkerBridge {
     localAuthMode?: "anonymous" | "demo";
     localAuthToken?: string;
   }): void {
+    if (this.isDisposedLike()) return;
     this.worker.postMessage({ type: "update-auth", ...auth });
   }
 
   sendLifecycleHint(event: WorkerLifecycleEvent): void {
-    if (this.disposed) return;
+    if (this.isDisposedLike()) return;
     this.worker.postMessage({
       type: "lifecycle-hint",
       event,
@@ -180,64 +221,60 @@ export class WorkerBridge {
    * @param worker The Worker instance (needed for listening to shutdown-ok)
    */
   async shutdown(worker: Worker): Promise<void> {
-    if (this.disposed) return;
-    this.disposed = true;
+    if (this.isDisposedLike()) return;
 
-    // Detach upstream edge so the next bridge attach performs a clean replay.
-    this.runtime.removeServer();
+    this.transition({ type: "SHUTDOWN_CALLED" });
 
     const shutdownAckPromise = waitForMessage<WorkerToMainMessage>(
       worker,
       (msg) => msg.type === "shutdown-ok",
-      5000,
+      SHUTDOWN_ACK_TIMEOUT_MS,
+      "Worker shutdown timeout",
     );
     this.worker.postMessage({ type: "shutdown" });
     try {
       await shutdownAckPromise;
+      this.transition({ type: "SHUTDOWN_FINISHED" });
     } catch {
+      this.transition({ type: "SHUTDOWN_FINISHED" });
       // Timeout — worker may have already closed
     }
-
-    // Drop any buffered payloads and stop forwarding from stale callbacks.
-    this.pendingSyncPayloadsForWorker = [];
-    this.serverPayloadForwarder = null;
-    this.runtime.onSyncMessageToSend(() => undefined);
   }
 
   /**
    * Get the client ID the worker assigned to the main thread.
    */
   getWorkerClientId(): string | null {
-    return this.workerClientId;
+    return this.state.workerClientId;
   }
 
   setServerPayloadForwarder(forwarder: ((payload: string) => void) | null): void {
-    if (this.disposed) return;
-    this.serverPayloadForwarder = forwarder;
+    if (this.isDisposedLike()) return;
+    this.state.serverPayloadForwarder = forwarder;
   }
 
   applyIncomingServerPayload(payload: string): void {
-    if (this.disposed) return;
+    if (this.isDisposedLike()) return;
     this.runtime.onSyncMessageReceived(payload);
   }
 
   replayServerConnection(): void {
-    if (this.disposed) return;
+    if (this.isDisposedLike()) return;
     this.runtime.removeServer();
     this.runtime.addServer();
   }
 
   onPeerSync(listener: (batch: PeerSyncBatch) => void): void {
-    this.peerSyncListener = listener;
+    this.state.peerSyncListener = listener;
   }
 
   openPeer(peerId: string): void {
-    if (this.disposed) return;
+    if (this.isDisposedLike()) return;
     this.worker.postMessage({ type: "peer-open", peerId });
   }
 
   sendPeerSync(peerId: string, term: number, payload: string[]): void {
-    if (this.disposed) return;
+    if (this.isDisposedLike()) return;
     if (payload.length === 0) return;
     this.worker.postMessage({
       type: "peer-sync",
@@ -248,39 +285,84 @@ export class WorkerBridge {
   }
 
   closePeer(peerId: string): void {
-    if (this.disposed) return;
+    if (this.isDisposedLike()) return;
     this.worker.postMessage({ type: "peer-close", peerId });
   }
 
   private enqueueSyncMessageForWorker(payload: string): void {
-    if (this.disposed) return;
-    this.pendingSyncPayloadsForWorker.push(payload);
-    if (this.syncBatchFlushQueued) return;
+    if (this.isDisposedLike()) return;
 
-    this.syncBatchFlushQueued = true;
+    this.state.pendingSyncPayloadsForWorker.push(payload);
+    if (this.state.syncBatchFlushQueued) return;
+
+    this.state.syncBatchFlushQueued = true;
     queueMicrotask(() => {
-      if (this.disposed) {
-        this.syncBatchFlushQueued = false;
-        this.pendingSyncPayloadsForWorker = [];
+      if (this.isDisposedLike()) {
+        this.state.syncBatchFlushQueued = false;
+        this.state.pendingSyncPayloadsForWorker = [];
         return;
       }
-      this.syncBatchFlushQueued = false;
+      this.state.syncBatchFlushQueued = false;
       this.flushPendingSyncToWorker();
     });
   }
 
   private flushPendingSyncToWorker(): void {
-    if (this.initState !== "ready" || this.pendingSyncPayloadsForWorker.length === 0) {
+    if (this.state.phase !== "ready" || this.state.pendingSyncPayloadsForWorker.length === 0) {
       return;
     }
 
-    const payloads = this.pendingSyncPayloadsForWorker;
-    this.pendingSyncPayloadsForWorker = [];
+    const payloads = this.state.pendingSyncPayloadsForWorker;
+    this.state.pendingSyncPayloadsForWorker = [];
 
     this.worker.postMessage({
       type: "sync",
       payload: payloads,
     });
+  }
+
+  private isDisposedLike(): boolean {
+    return this.state.phase === "disposed" || this.state.phase === "shutting-down";
+  }
+
+  private transition(event: BridgeEvent): void {
+    switch (event.type) {
+      case "INIT_CALLED":
+        if (this.state.phase === "idle" || this.state.phase === "failed") {
+          this.state.phase = "initializing";
+        }
+        return;
+      case "INIT_OK":
+        if (this.state.phase !== "initializing") return;
+        this.state.workerClientId = event.clientId;
+        this.state.phase = "ready";
+        return;
+      case "INIT_FAILED":
+        if (this.state.phase !== "initializing") return;
+        this.state.phase = "failed";
+        this.state.pendingSyncPayloadsForWorker = [];
+        this.state.syncBatchFlushQueued = false;
+        return;
+      case "SHUTDOWN_CALLED":
+        if (this.state.phase === "disposed" || this.state.phase === "shutting-down") return;
+        this.state.phase = "shutting-down";
+        // Detach upstream edge so the next bridge attach performs a clean replay.
+        this.runtime.removeServer();
+        return;
+      case "SHUTDOWN_FINISHED":
+        if (this.state.phase === "disposed") return;
+        this.state.phase = "disposed";
+        this.disposeInternals();
+        return;
+    }
+  }
+
+  private disposeInternals(): void {
+    this.state.pendingSyncPayloadsForWorker = [];
+    this.state.serverPayloadForwarder = null;
+    this.state.peerSyncListener = null;
+    this.state.syncBatchFlushQueued = false;
+    this.runtime.onSyncMessageToSend(() => undefined);
   }
 }
 
@@ -290,12 +372,13 @@ export class WorkerBridge {
 function waitForMessage<T>(
   worker: Worker,
   predicate: (msg: T) => boolean,
-  timeoutMs = 10000,
+  timeoutMs: number,
+  timeoutMessage: string,
 ): Promise<T> {
   return new Promise((resolve, reject) => {
     const timeout = setTimeout(() => {
       cleanup();
-      reject(new Error("Worker message timeout"));
+      reject(new Error(timeoutMessage));
     }, timeoutMs);
 
     const handler = (event: MessageEvent<T>) => {

--- a/packages/jazz-tools/src/worker/init-retry.test.ts
+++ b/packages/jazz-tools/src/worker/init-retry.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+import {
+  openPersistentWithRetry,
+  OpfsInitRetryCancelled,
+  OpfsInitRetryFailure,
+  isRetryableOpfsInitError,
+} from "./init-retry.js";
+
+describe("openPersistentWithRetry", () => {
+  it("retries retryable OPFS errors and eventually succeeds", async () => {
+    let calls = 0;
+    const result = await openPersistentWithRetry({
+      open: async () => {
+        calls += 1;
+        if (calls < 3) {
+          throw new Error("NoModificationAllowedError: createSyncAccessHandle conflict");
+        }
+        return "ok";
+      },
+      policy: {
+        totalTimeoutMs: 2_000,
+        baseDelayMs: 1,
+        maxDelayMs: 2,
+        jitterMs: 0,
+      },
+      now: (() => {
+        let t = 0;
+        return () => t;
+      })(),
+      sleep: async () => undefined,
+      random: () => 0,
+    });
+
+    expect(result.value).toBe("ok");
+    expect(result.attempts).toBe(3);
+  });
+
+  it("fails with timeout metadata when retryable errors exceed budget", async () => {
+    let calls = 0;
+    let nowMs = 0;
+
+    try {
+      await openPersistentWithRetry({
+        open: async () => {
+          calls += 1;
+          throw new Error("NoModificationAllowedError: createSyncAccessHandle conflict");
+        },
+        policy: {
+          totalTimeoutMs: 10,
+          baseDelayMs: 5,
+          maxDelayMs: 5,
+          jitterMs: 0,
+        },
+        now: () => nowMs,
+        sleep: async (ms) => {
+          nowMs += ms;
+        },
+        random: () => 0,
+      });
+    } catch (error) {
+      expect(error).toBeInstanceOf(OpfsInitRetryFailure);
+      const typed = error as OpfsInitRetryFailure;
+      expect(typed.timedOut).toBe(true);
+      expect(typed.retryable).toBe(true);
+      expect(typed.attempts).toBeGreaterThan(0);
+    }
+    expect(calls).toBeGreaterThan(1);
+  });
+
+  it("fails immediately on non-retryable init error", async () => {
+    await expect(
+      openPersistentWithRetry({
+        open: async () => {
+          throw new Error("SyntaxError: broken schema");
+        },
+        policy: {
+          totalTimeoutMs: 100,
+          baseDelayMs: 10,
+          maxDelayMs: 10,
+          jitterMs: 0,
+        },
+        sleep: async () => undefined,
+      }),
+    ).rejects.toMatchObject({
+      name: "OpfsInitRetryFailure",
+      retryable: false,
+      timedOut: false,
+      attempts: 1,
+    });
+  });
+
+  it("cancels retries when cancellation signal is raised", async () => {
+    let cancelled = false;
+
+    await expect(
+      openPersistentWithRetry({
+        open: async () => {
+          cancelled = true;
+          throw new Error("NoModificationAllowedError: createSyncAccessHandle conflict");
+        },
+        isCancelled: () => cancelled,
+        policy: {
+          totalTimeoutMs: 100,
+          baseDelayMs: 10,
+          maxDelayMs: 10,
+          jitterMs: 0,
+        },
+        sleep: async () => undefined,
+      }),
+    ).rejects.toBeInstanceOf(OpfsInitRetryCancelled);
+  });
+});
+
+describe("isRetryableOpfsInitError", () => {
+  it("matches known OPFS contention signatures", () => {
+    expect(isRetryableOpfsInitError("NoModificationAllowedError: file locked")).toBe(true);
+    expect(
+      isRetryableOpfsInitError(
+        "Failed to execute createSyncAccessHandle: Access Handles cannot be created if there is another open Access Handle",
+      ),
+    ).toBe(true);
+    expect(isRetryableOpfsInitError("TypeError: invalid schema JSON")).toBe(false);
+  });
+});

--- a/packages/jazz-tools/src/worker/init-retry.ts
+++ b/packages/jazz-tools/src/worker/init-retry.ts
@@ -1,0 +1,178 @@
+export interface NormalizedWorkerInitError {
+  name: string;
+  message: string;
+}
+
+export interface OpfsInitRetryPolicy {
+  totalTimeoutMs: number;
+  baseDelayMs: number;
+  maxDelayMs: number;
+  jitterMs: number;
+}
+
+export const DEFAULT_OPFS_INIT_RETRY_POLICY: OpfsInitRetryPolicy = {
+  totalTimeoutMs: 10_000,
+  baseDelayMs: 120,
+  maxDelayMs: 1_200,
+  jitterMs: 120,
+};
+
+export class OpfsInitRetryFailure extends Error {
+  readonly attempts: number;
+  readonly elapsedMs: number;
+  readonly retryable: boolean;
+  readonly timedOut: boolean;
+  readonly causeError: NormalizedWorkerInitError;
+
+  constructor(args: {
+    attempts: number;
+    elapsedMs: number;
+    retryable: boolean;
+    timedOut: boolean;
+    causeError: NormalizedWorkerInitError;
+  }) {
+    const reason = args.timedOut ? "retry timeout" : "non-retryable";
+    super(
+      `OPFS init ${reason} after ${args.attempts} attempt(s) in ${args.elapsedMs}ms: ${args.causeError.name}: ${args.causeError.message}`,
+    );
+    this.name = "OpfsInitRetryFailure";
+    this.attempts = args.attempts;
+    this.elapsedMs = args.elapsedMs;
+    this.retryable = args.retryable;
+    this.timedOut = args.timedOut;
+    this.causeError = args.causeError;
+  }
+}
+
+export class OpfsInitRetryCancelled extends Error {
+  constructor() {
+    super("OPFS init retry cancelled");
+    this.name = "OpfsInitRetryCancelled";
+  }
+}
+
+export interface OpenPersistentWithRetryOptions<T> {
+  open: () => Promise<T>;
+  policy?: OpfsInitRetryPolicy;
+  isRetryable?: (error: unknown) => boolean;
+  isCancelled?: () => boolean;
+  now?: () => number;
+  random?: () => number;
+  sleep?: (ms: number) => Promise<void>;
+}
+
+export interface OpenPersistentWithRetryResult<T> {
+  value: T;
+  attempts: number;
+  elapsedMs: number;
+}
+
+export function normalizeUnknownWorkerInitError(error: unknown): NormalizedWorkerInitError {
+  if (error instanceof Error) {
+    return {
+      name: error.name || "Error",
+      message: error.message || String(error),
+    };
+  }
+  if (typeof error === "string") {
+    return {
+      name: "Error",
+      message: error,
+    };
+  }
+  return {
+    name: "UnknownError",
+    message: String(error),
+  };
+}
+
+export function isRetryableOpfsInitError(error: unknown): boolean {
+  const normalized = normalizeUnknownWorkerInitError(error);
+  const haystack = `${normalized.name} ${normalized.message}`.toLowerCase();
+
+  if (haystack.includes("nomodificationallowederror")) {
+    return true;
+  }
+
+  const mentionsSyncHandle = haystack.includes("createsyncaccesshandle");
+  const mentionsOpenHandleConflict =
+    haystack.includes("another open access handle") ||
+    haystack.includes("another open access-handle") ||
+    (haystack.includes("access handle") && haystack.includes("another open"));
+
+  return mentionsSyncHandle && mentionsOpenHandleConflict;
+}
+
+export function computeRetryDelayMs(
+  attempt: number,
+  policy: OpfsInitRetryPolicy,
+  random: () => number = Math.random,
+): number {
+  const exponent = Math.max(0, attempt - 1);
+  const expDelay = Math.min(policy.maxDelayMs, policy.baseDelayMs * 2 ** exponent);
+  const jitter = Math.floor(random() * (policy.jitterMs + 1));
+  return expDelay + jitter;
+}
+
+export async function openPersistentWithRetry<T>(
+  options: OpenPersistentWithRetryOptions<T>,
+): Promise<OpenPersistentWithRetryResult<T>> {
+  const policy = options.policy ?? DEFAULT_OPFS_INIT_RETRY_POLICY;
+  const isRetryable = options.isRetryable ?? isRetryableOpfsInitError;
+  const isCancelled = options.isCancelled ?? (() => false);
+  const now = options.now ?? (() => Date.now());
+  const random = options.random ?? (() => Math.random());
+  const sleep =
+    options.sleep ?? ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+
+  const startedAt = now();
+  const deadline = startedAt + policy.totalTimeoutMs;
+  let attempts = 0;
+
+  while (true) {
+    if (isCancelled()) {
+      throw new OpfsInitRetryCancelled();
+    }
+
+    attempts += 1;
+
+    try {
+      const value = await options.open();
+      return {
+        value,
+        attempts,
+        elapsedMs: Math.max(0, now() - startedAt),
+      };
+    } catch (error) {
+      if (isCancelled()) {
+        throw new OpfsInitRetryCancelled();
+      }
+
+      const retryable = isRetryable(error);
+      const elapsedMs = Math.max(0, now() - startedAt);
+      if (!retryable) {
+        throw new OpfsInitRetryFailure({
+          attempts,
+          elapsedMs,
+          retryable: false,
+          timedOut: false,
+          causeError: normalizeUnknownWorkerInitError(error),
+        });
+      }
+
+      const remainingMs = deadline - now();
+      if (remainingMs <= 0) {
+        throw new OpfsInitRetryFailure({
+          attempts,
+          elapsedMs,
+          retryable: true,
+          timedOut: true,
+          causeError: normalizeUnknownWorkerInitError(error),
+        });
+      }
+
+      const delayMs = Math.min(remainingMs, computeRetryDelayMs(attempts, policy, random));
+      await sleep(delayMs);
+    }
+  }
+}

--- a/packages/jazz-tools/src/worker/jazz-worker.ts
+++ b/packages/jazz-tools/src/worker/jazz-worker.ts
@@ -15,6 +15,12 @@ import {
   applyUserAuthHeaders,
   isCataloguePayload,
 } from "../runtime/sync-transport.js";
+import {
+  openPersistentWithRetry,
+  isRetryableOpfsInitError,
+  OpfsInitRetryCancelled,
+  OpfsInitRetryFailure,
+} from "./init-retry.js";
 
 // Worker globals — minimal type for DedicatedWorkerGlobalScope
 // (Cannot use lib "WebWorker" as it conflicts with DOM types in the main tsconfig)
@@ -24,517 +30,658 @@ declare const self: {
   close(): void;
 };
 
-let runtime: any = null; // WasmRuntime instance
-let mainClientId: string | null = null;
-let jwtToken: string | undefined;
-let localAuthMode: "anonymous" | "demo" | undefined;
-let localAuthToken: string | undefined;
-let adminSecret: string | undefined;
-let streamAbortController: AbortController | null = null;
-let serverClientId: string = generateClientId();
-let activeServerUrl: string | null = null;
-let activeServerPathPrefix: string | undefined;
-let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
-let reconnectAttempt = 0;
-let streamConnecting = false;
-let streamAttached = false;
-let isShuttingDown = false;
-let pendingSyncMessages: string[] = []; // Buffer sync messages until init completes
-let pendingPeerSyncMessages: Array<{ peerId: string; term: number; payload: string[] }> = [];
-let pendingSyncPayloadsForMain: string[] = [];
-let syncBatchFlushQueued = false;
-let initComplete = false;
-let bootstrapCatalogueForwarding = false;
-let peerRuntimeClientByPeerId = new Map<string, string>();
-let peerIdByRuntimeClient = new Map<string, string>();
-let peerTermByPeerId = new Map<string, number>();
+type WorkerPhase =
+  | "booting"
+  | "ready-for-init"
+  | "initializing"
+  | "running"
+  | "shutting-down"
+  | "closed";
 
-function enqueueSyncMessageForMain(payload: string): void {
-  pendingSyncPayloadsForMain.push(payload);
-  if (syncBatchFlushQueued) return;
+type WorkerEvent =
+  | { type: "WASM_LOADED" }
+  | { type: "WASM_LOAD_FAILED" }
+  | { type: "INIT_REQUESTED" }
+  | { type: "INIT_SUCCEEDED" }
+  | { type: "INIT_FAILED" }
+  | { type: "SHUTDOWN_REQUESTED" }
+  | { type: "SHUTDOWN_COMPLETED" };
 
-  syncBatchFlushQueued = true;
-  queueMicrotask(() => {
-    syncBatchFlushQueued = false;
-    const payloads = pendingSyncPayloadsForMain;
-    pendingSyncPayloadsForMain = [];
-    if (payloads.length === 0) return;
-    post({ type: "sync", payload: payloads });
-  });
+interface WorkerState {
+  phase: WorkerPhase;
+  runtime: any | null;
+  mainClientId: string | null;
+  jwtToken: string | undefined;
+  localAuthMode: "anonymous" | "demo" | undefined;
+  localAuthToken: string | undefined;
+  adminSecret: string | undefined;
+  streamAbortController: AbortController | null;
+  serverClientId: string;
+  activeServerUrl: string | null;
+  activeServerPathPrefix: string | undefined;
+  reconnectTimer: ReturnType<typeof setTimeout> | null;
+  reconnectAttempt: number;
+  streamConnecting: boolean;
+  streamAttached: boolean;
+  pendingSyncMessages: string[];
+  pendingPeerSyncMessages: Array<{ peerId: string; term: number; payload: string[] }>;
+  pendingSyncPayloadsForMain: string[];
+  syncBatchFlushQueued: boolean;
+  initComplete: boolean;
+  bootstrapCatalogueForwarding: boolean;
+  peerRuntimeClientByPeerId: Map<string, string>;
+  peerIdByRuntimeClient: Map<string, string>;
+  peerTermByPeerId: Map<string, number>;
+  initSessionId: number;
 }
 
-function post(msg: WorkerToMainMessage): void {
-  self.postMessage(msg);
+interface FreeableRuntime {
+  free: () => void;
 }
 
-// ============================================================================
-// Startup: Load WASM
-// ============================================================================
-
-async function startup(): Promise<void> {
-  try {
-    const wasmModule: any = await import("jazz-wasm");
-    // With vite-plugin-wasm, init happens at import time and default is not a function.
-    // Without it, default is the init function that must be called.
-    if (typeof wasmModule.default === "function") {
-      await wasmModule.default();
-    }
-    post({ type: "ready" });
-  } catch (e: any) {
-    post({ type: "error", message: `WASM load failed: ${e.message}` });
-  }
-}
-
-// ============================================================================
-// Init: Open persistent runtime, register main thread as client
-// ============================================================================
-
-async function handleInit(msg: InitMessage): Promise<void> {
-  try {
-    const wasmModule: any = await import("jazz-wasm");
-    initComplete = false;
-    isShuttingDown = false;
-    activeServerUrl = msg.serverUrl ?? null;
-    activeServerPathPrefix = msg.serverPathPrefix;
-    reconnectAttempt = 0;
-    streamAttached = false;
-    streamConnecting = false;
-    serverClientId = generateClientId();
-    peerRuntimeClientByPeerId.clear();
-    peerIdByRuntimeClient.clear();
-    peerTermByPeerId.clear();
-    if (reconnectTimer) {
-      clearTimeout(reconnectTimer);
-      reconnectTimer = null;
-    }
-    if (streamAbortController) {
-      streamAbortController.abort();
-      streamAbortController = null;
-    }
-
-    // Open persistent OPFS-backed runtime with Worker tier
-    runtime = await wasmModule.WasmRuntime.openPersistent(
-      msg.schemaJson,
-      msg.appId,
-      msg.env,
-      msg.userBranch,
-      msg.dbName,
-      "worker",
-    );
-
-    // Store auth
-    jwtToken = msg.jwtToken;
-    localAuthMode = msg.localAuthMode;
-    localAuthToken = msg.localAuthToken;
-    adminSecret = msg.adminSecret;
-
-    // Register main thread as a Peer client
-    mainClientId = runtime.addClient();
-    runtime.setClientRole(mainClientId, "peer");
-
-    // Set up outbox routing
-    runtime.onSyncMessageToSend((envelope: string) => {
-      const parsed = JSON.parse(envelope);
-
-      if (parsed.destination && "Client" in parsed.destination) {
-        const destinationClientId = parsed.destination.Client as string;
-        if (destinationClientId === mainClientId) {
-          // Local main-thread client-bound payload.
-          enqueueSyncMessageForMain(JSON.stringify(parsed.payload));
-          return;
-        }
-
-        // Follower peer client-bound payload.
-        const peerId = peerIdByRuntimeClient.get(destinationClientId);
-        if (!peerId) {
-          return;
-        }
-        const term = peerTermByPeerId.get(peerId) ?? 0;
-        post({
-          type: "peer-sync",
-          peerId,
-          term,
-          payload: [JSON.stringify(parsed.payload)],
-        });
-      } else if (parsed.destination && "Server" in parsed.destination) {
-        if (bootstrapCatalogueForwarding) {
-          if (isCataloguePayload(parsed.payload)) {
-            enqueueSyncMessageForMain(JSON.stringify(parsed.payload));
-          }
-          return;
-        }
-
-        // Server-bound → HTTP POST to upstream
-        if (activeServerUrl) {
-          void sendToServer(activeServerUrl, parsed.payload).catch((error) => {
-            console.error("[worker] Sync POST error:", error);
-            detachServer();
-            scheduleReconnect();
-          });
-        }
-      }
-    });
-
-    // Runtime is now fully ready to ingest client sync traffic.
-    const bufferedSyncMessages = pendingSyncMessages;
-    pendingSyncMessages = [];
-    initComplete = true;
-
-    // Drain sync messages that arrived before init completed.
-    for (const payload of bufferedSyncMessages) {
-      runtime.onSyncMessageReceivedFromClient(mainClientId!, payload);
-    }
-
-    const bufferedPeerSyncMessages = pendingPeerSyncMessages;
-    pendingPeerSyncMessages = [];
-    for (const buffered of bufferedPeerSyncMessages) {
-      const peerClientId = ensurePeerClient(buffered.peerId);
-      if (!peerClientId) continue;
-      peerTermByPeerId.set(buffered.peerId, buffered.term);
-      for (const payload of buffered.payload) {
-        runtime.onSyncMessageReceivedFromClient(peerClientId, payload);
-      }
-    }
-
-    // Bootstrap catalogue-only sync from worker to main runtime.
-    // This sends persisted schema/lens objects (including rehydrated ones)
-    // without syncing user data rows.
-    bootstrapCatalogueForwarding = true;
-    try {
-      runtime.addServer();
-      runtime.removeServer();
-    } finally {
-      bootstrapCatalogueForwarding = false;
-    }
-
-    post({ type: "init-ok", clientId: mainClientId! });
-
-    // Connect upstream in background (do not block init).
-    if (activeServerUrl) {
-      void connectStream();
-    }
-  } catch (e: any) {
-    post({ type: "error", message: `Init failed: ${e.message}` });
-  }
-}
-
-// ============================================================================
-// Upstream server communication
-// ============================================================================
-
-/** POST a sync payload to the upstream server. */
-async function sendToServer(serverUrl: string, payload: any): Promise<void> {
-  await sendSyncPayload(
-    serverUrl,
-    payload,
-    {
-      jwtToken,
-      localAuthMode,
-      localAuthToken,
-      adminSecret,
-      clientId: serverClientId,
-      pathPrefix: activeServerPathPrefix,
-    },
-    "[worker] ",
+function isFreeableRuntime(value: unknown): value is FreeableRuntime {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as { free?: unknown }).free === "function"
   );
 }
 
-function attachServer(): void {
-  if (!runtime) return;
-  // Re-attach every time the stream reconnects so query subscriptions replay.
-  if (streamAttached) {
-    runtime.removeServer();
-  }
-  runtime.addServer();
-  streamAttached = true;
-  reconnectAttempt = 0;
-}
-
-function detachServer(): void {
-  if (!runtime || !streamAttached) return;
-  runtime.removeServer();
-  streamAttached = false;
-}
-
-function scheduleReconnect(): void {
-  if (isShuttingDown || !activeServerUrl) return;
-  if (reconnectTimer) return;
-
-  const baseMs = 300;
-  const maxMs = 10_000;
-  const jitterMs = Math.floor(Math.random() * 200);
-  const delayMs = Math.min(maxMs, baseMs * 2 ** reconnectAttempt) + jitterMs;
-  reconnectAttempt += 1;
-
-  reconnectTimer = setTimeout(() => {
-    reconnectTimer = null;
-    void connectStream();
-  }, delayMs);
-}
-
-/** Connect to the server's binary streaming endpoint. */
-async function connectStream(): Promise<void> {
-  if (streamConnecting || !activeServerUrl || isShuttingDown) return;
-  streamConnecting = true;
-
-  const headers: Record<string, string> = {
-    Accept: "application/octet-stream",
+class JazzWorkerRuntime {
+  private state: WorkerState = {
+    phase: "booting",
+    runtime: null,
+    mainClientId: null,
+    jwtToken: undefined,
+    localAuthMode: undefined,
+    localAuthToken: undefined,
+    adminSecret: undefined,
+    streamAbortController: null,
+    serverClientId: generateClientId(),
+    activeServerUrl: null,
+    activeServerPathPrefix: undefined,
+    reconnectTimer: null,
+    reconnectAttempt: 0,
+    streamConnecting: false,
+    streamAttached: false,
+    pendingSyncMessages: [],
+    pendingPeerSyncMessages: [],
+    pendingSyncPayloadsForMain: [],
+    syncBatchFlushQueued: false,
+    initComplete: false,
+    bootstrapCatalogueForwarding: false,
+    peerRuntimeClientByPeerId: new Map<string, string>(),
+    peerIdByRuntimeClient: new Map<string, string>(),
+    peerTermByPeerId: new Map<string, number>(),
+    initSessionId: 0,
   };
-  applyUserAuthHeaders(headers, { jwtToken, localAuthMode, localAuthToken });
 
-  streamAbortController = new AbortController();
-
-  try {
-    const eventsUrl = buildEventsUrl(activeServerUrl, serverClientId, activeServerPathPrefix);
-
-    const response = await fetch(eventsUrl, {
-      headers,
-      signal: streamAbortController.signal,
-    });
-
-    if (!response.ok) {
-      console.error(`[worker] Stream connect failed: ${response.status}`);
-      detachServer();
-      streamConnecting = false;
-      scheduleReconnect();
-      return;
+  transition(event: WorkerEvent): void {
+    switch (event.type) {
+      case "WASM_LOADED":
+      case "WASM_LOAD_FAILED":
+        if (this.state.phase === "booting") {
+          this.state.phase = "ready-for-init";
+        }
+        return;
+      case "INIT_REQUESTED":
+        if (this.state.phase === "ready-for-init" || this.state.phase === "running") {
+          this.state.phase = "initializing";
+        }
+        return;
+      case "INIT_SUCCEEDED":
+        if (this.state.phase === "initializing") {
+          this.state.phase = "running";
+        }
+        return;
+      case "INIT_FAILED":
+        if (this.state.phase === "initializing") {
+          this.state.phase = "ready-for-init";
+        }
+        return;
+      case "SHUTDOWN_REQUESTED":
+        if (this.state.phase !== "closed") {
+          this.state.phase = "shutting-down";
+          this.state.initSessionId += 1;
+        }
+        return;
+      case "SHUTDOWN_COMPLETED":
+        this.state.phase = "closed";
+        return;
     }
+  }
 
-    const reader = response.body!.getReader();
-    let connected = false;
-    await readBinaryFrames(
-      reader,
-      {
-        onSyncMessage: (json) => runtime?.onSyncMessageReceived(json),
-        onConnected: (clientId) => {
-          serverClientId = clientId;
-          if (!connected) {
-            connected = true;
-            attachServer();
+  async startup(): Promise<void> {
+    try {
+      const wasmModule: any = await import("jazz-wasm");
+      if (typeof wasmModule.default === "function") {
+        await wasmModule.default();
+      }
+      this.transition({ type: "WASM_LOADED" });
+      this.post({ type: "ready" });
+    } catch (e: any) {
+      this.transition({ type: "WASM_LOAD_FAILED" });
+      this.post({ type: "error", message: `WASM load failed: ${e.message}` });
+    }
+  }
+
+  async onMessage(event: MessageEvent<MainToWorkerMessage>): Promise<void> {
+    const msg = event.data;
+
+    switch (msg.type) {
+      case "init":
+        await this.handleInit(msg);
+        break;
+
+      case "sync": {
+        const payloads = msg.payload;
+        if (this.state.runtime && this.state.mainClientId && this.state.initComplete) {
+          for (const payload of payloads) {
+            this.state.runtime.onSyncMessageReceivedFromClient(this.state.mainClientId, payload);
           }
-        },
+        } else {
+          this.state.pendingSyncMessages.push(...payloads);
+        }
+        break;
+      }
+
+      case "peer-open":
+        if (this.state.runtime && this.state.initComplete) {
+          this.ensurePeerClient(msg.peerId);
+        }
+        break;
+
+      case "peer-sync": {
+        if (!this.state.runtime || !this.state.mainClientId || !this.state.initComplete) {
+          this.state.pendingPeerSyncMessages.push({
+            peerId: msg.peerId,
+            term: msg.term,
+            payload: msg.payload,
+          });
+          break;
+        }
+
+        const peerClientId = this.ensurePeerClient(msg.peerId);
+        if (!peerClientId) break;
+        this.state.peerTermByPeerId.set(msg.peerId, msg.term);
+        for (const payload of msg.payload) {
+          this.state.runtime.onSyncMessageReceivedFromClient(peerClientId, payload);
+        }
+        break;
+      }
+
+      case "peer-close":
+        this.closePeer(msg.peerId);
+        break;
+
+      case "lifecycle-hint":
+        if (
+          msg.event === "visibility-hidden" ||
+          msg.event === "pagehide" ||
+          msg.event === "freeze"
+        ) {
+          this.flushWalBestEffort();
+        } else if (msg.event === "visibility-visible" || msg.event === "resume") {
+          this.nudgeReconnectAfterResume();
+        }
+        break;
+
+      case "update-auth":
+        this.state.jwtToken = msg.jwtToken;
+        this.state.localAuthMode = msg.localAuthMode;
+        this.state.localAuthToken = msg.localAuthToken;
+        if (this.state.streamAbortController) {
+          this.state.streamAbortController.abort();
+          this.state.streamAbortController = null;
+        }
+        this.detachServer();
+        if (this.state.activeServerUrl && !this.isShuttingDownLike()) {
+          this.scheduleReconnect();
+        }
+        break;
+
+      case "shutdown":
+        this.completeShutdown("flush");
+        break;
+
+      case "simulate-crash":
+        this.completeShutdown("flushWal");
+        break;
+
+      case "debug-schema-state":
+        if (!this.state.runtime || !this.state.initComplete) {
+          this.post({
+            type: "error",
+            message: "debug-schema-state requested before worker init complete",
+          });
+          break;
+        }
+        try {
+          const statePayload = this.state.runtime.__debugSchemaState();
+          this.post({ type: "debug-schema-state-ok", state: statePayload });
+        } catch (error: any) {
+          this.post({
+            type: "error",
+            message: `debug-schema-state failed: ${error?.message ?? error}`,
+          });
+        }
+        break;
+
+      case "debug-seed-live-schema":
+        if (!this.state.runtime || !this.state.initComplete) {
+          this.post({
+            type: "error",
+            message: "debug-seed-live-schema requested before worker init complete",
+          });
+          break;
+        }
+        try {
+          const runtimeAny = this.state.runtime as Record<string, unknown>;
+          const seedMethod =
+            runtimeAny.__debugSeedLiveSchema ??
+            runtimeAny.debugSeedLiveSchema ??
+            runtimeAny.debug_seed_live_schema;
+          if (typeof seedMethod !== "function") {
+            throw new Error("worker runtime does not expose a debug seed method");
+          }
+          (seedMethod as (schemaJson: string) => void).call(this.state.runtime, msg.schemaJson);
+          this.post({ type: "debug-seed-live-schema-ok" });
+        } catch (error: any) {
+          this.post({
+            type: "error",
+            message: `debug-seed-live-schema failed: ${error?.message ?? error}`,
+          });
+        }
+        break;
+    }
+  }
+
+  private post(msg: WorkerToMainMessage): void {
+    self.postMessage(msg);
+  }
+
+  private isShuttingDownLike(): boolean {
+    return this.state.phase === "shutting-down" || this.state.phase === "closed";
+  }
+
+  private resetBeforeInit(msg: InitMessage): void {
+    this.state.initComplete = false;
+    this.state.activeServerUrl = msg.serverUrl ?? null;
+    this.state.activeServerPathPrefix = msg.serverPathPrefix;
+    this.state.reconnectAttempt = 0;
+    this.state.streamAttached = false;
+    this.state.streamConnecting = false;
+    this.state.serverClientId = generateClientId();
+    this.state.peerRuntimeClientByPeerId.clear();
+    this.state.peerIdByRuntimeClient.clear();
+    this.state.peerTermByPeerId.clear();
+    this.state.mainClientId = null;
+    this.state.bootstrapCatalogueForwarding = false;
+
+    if (this.state.reconnectTimer) {
+      clearTimeout(this.state.reconnectTimer);
+      this.state.reconnectTimer = null;
+    }
+    if (this.state.streamAbortController) {
+      this.state.streamAbortController.abort();
+      this.state.streamAbortController = null;
+    }
+  }
+
+  private resetPeerState(): void {
+    this.state.peerRuntimeClientByPeerId.clear();
+    this.state.peerIdByRuntimeClient.clear();
+    this.state.peerTermByPeerId.clear();
+    this.state.pendingPeerSyncMessages = [];
+  }
+
+  private disposeRuntime(clean: "flush" | "flushWal"): void {
+    if (!this.state.runtime) return;
+    this.detachServer();
+    if (clean === "flush") {
+      this.state.runtime.flush();
+    } else {
+      this.state.runtime.flushWal();
+    }
+    this.state.runtime.free();
+    this.state.runtime = null;
+    this.state.mainClientId = null;
+  }
+
+  private teardownConnectionState(): void {
+    this.state.activeServerUrl = null;
+    this.state.activeServerPathPrefix = undefined;
+    if (this.state.reconnectTimer) {
+      clearTimeout(this.state.reconnectTimer);
+      this.state.reconnectTimer = null;
+    }
+    if (this.state.streamAbortController) {
+      this.state.streamAbortController.abort();
+      this.state.streamAbortController = null;
+    }
+    this.state.streamAttached = false;
+    this.state.streamConnecting = false;
+    this.state.reconnectAttempt = 0;
+  }
+
+  private completeShutdown(clean: "flush" | "flushWal"): void {
+    this.transition({ type: "SHUTDOWN_REQUESTED" });
+    this.state.initComplete = false;
+    this.teardownConnectionState();
+    this.disposeRuntime(clean);
+    this.resetPeerState();
+    this.post({ type: "shutdown-ok" });
+    this.transition({ type: "SHUTDOWN_COMPLETED" });
+    self.close();
+  }
+
+  private enqueueSyncMessageForMain(payload: string): void {
+    this.state.pendingSyncPayloadsForMain.push(payload);
+    if (this.state.syncBatchFlushQueued) return;
+
+    this.state.syncBatchFlushQueued = true;
+    queueMicrotask(() => {
+      this.state.syncBatchFlushQueued = false;
+      const payloads = this.state.pendingSyncPayloadsForMain;
+      this.state.pendingSyncPayloadsForMain = [];
+      if (payloads.length === 0) return;
+      this.post({ type: "sync", payload: payloads });
+    });
+  }
+
+  private ensurePeerClient(peerId: string): string | null {
+    if (!this.state.runtime) return null;
+    const existing = this.state.peerRuntimeClientByPeerId.get(peerId);
+    if (existing) return existing;
+
+    const clientId = this.state.runtime.addClient();
+    this.state.runtime.setClientRole(clientId, "peer");
+    this.state.peerRuntimeClientByPeerId.set(peerId, clientId);
+    this.state.peerIdByRuntimeClient.set(clientId, peerId);
+    return clientId;
+  }
+
+  private closePeer(peerId: string): void {
+    const runtimeClientId = this.state.peerRuntimeClientByPeerId.get(peerId);
+    if (!runtimeClientId) return;
+    this.state.peerRuntimeClientByPeerId.delete(peerId);
+    this.state.peerIdByRuntimeClient.delete(runtimeClientId);
+    this.state.peerTermByPeerId.delete(peerId);
+  }
+
+  private async sendToServer(serverUrl: string, payload: any): Promise<void> {
+    await sendSyncPayload(
+      serverUrl,
+      payload,
+      {
+        jwtToken: this.state.jwtToken,
+        localAuthMode: this.state.localAuthMode,
+        localAuthToken: this.state.localAuthToken,
+        adminSecret: this.state.adminSecret,
+        clientId: this.state.serverClientId,
+        pathPrefix: this.state.activeServerPathPrefix,
       },
       "[worker] ",
     );
-  } catch (e: any) {
-    if (e?.name === "AbortError") return;
-    console.error("[worker] Stream connect error:", e);
-  } finally {
-    streamConnecting = false;
   }
 
-  if (streamAbortController && !streamAbortController.signal.aborted) {
-    detachServer();
-    scheduleReconnect();
+  private attachServer(): void {
+    if (!this.state.runtime) return;
+    if (this.state.streamAttached) {
+      this.state.runtime.removeServer();
+    }
+    this.state.runtime.addServer();
+    this.state.streamAttached = true;
+    this.state.reconnectAttempt = 0;
   }
-}
 
-function ensurePeerClient(peerId: string): string | null {
-  if (!runtime) return null;
-  const existing = peerRuntimeClientByPeerId.get(peerId);
-  if (existing) return existing;
-
-  const clientId = runtime.addClient();
-  runtime.setClientRole(clientId, "peer");
-  peerRuntimeClientByPeerId.set(peerId, clientId);
-  peerIdByRuntimeClient.set(clientId, peerId);
-  return clientId;
-}
-
-function closePeer(peerId: string): void {
-  const runtimeClientId = peerRuntimeClientByPeerId.get(peerId);
-  if (!runtimeClientId) return;
-  peerRuntimeClientByPeerId.delete(peerId);
-  peerIdByRuntimeClient.delete(runtimeClientId);
-  peerTermByPeerId.delete(peerId);
-}
-
-function flushWalBestEffort(): void {
-  if (!runtime || !initComplete) return;
-  try {
-    runtime.flushWal();
-  } catch (error) {
-    console.warn("[worker] flushWal on lifecycle hint failed:", error);
+  private detachServer(): void {
+    if (!this.state.runtime || !this.state.streamAttached) return;
+    this.state.runtime.removeServer();
+    this.state.streamAttached = false;
   }
-}
 
-function nudgeReconnectAfterResume(): void {
-  if (!activeServerUrl || isShuttingDown) return;
-  if (streamAttached || streamConnecting) return;
-  if (reconnectTimer) return;
-  reconnectAttempt = 0;
-  scheduleReconnect();
-}
+  private scheduleReconnect(): void {
+    if (this.isShuttingDownLike() || !this.state.activeServerUrl) return;
+    if (this.state.reconnectTimer) return;
 
-// ============================================================================
-// Message handler
-// ============================================================================
+    const baseMs = 300;
+    const maxMs = 10_000;
+    const jitterMs = Math.floor(Math.random() * 200);
+    const delayMs = Math.min(maxMs, baseMs * 2 ** this.state.reconnectAttempt) + jitterMs;
+    this.state.reconnectAttempt += 1;
 
-self.onmessage = async (event: MessageEvent<MainToWorkerMessage>) => {
-  const msg = event.data;
+    this.state.reconnectTimer = setTimeout(() => {
+      this.state.reconnectTimer = null;
+      void this.connectStream();
+    }, delayMs);
+  }
 
-  switch (msg.type) {
-    case "init":
-      await handleInit(msg);
-      break;
+  private async connectStream(): Promise<void> {
+    if (this.state.streamConnecting || !this.state.activeServerUrl || this.isShuttingDownLike())
+      return;
+    this.state.streamConnecting = true;
 
-    case "sync": {
-      const payloads = msg.payload;
-      if (runtime && mainClientId && initComplete) {
-        for (const payload of payloads) {
-          runtime.onSyncMessageReceivedFromClient(mainClientId, payload);
+    const headers: Record<string, string> = {
+      Accept: "application/octet-stream",
+    };
+    applyUserAuthHeaders(headers, {
+      jwtToken: this.state.jwtToken,
+      localAuthMode: this.state.localAuthMode,
+      localAuthToken: this.state.localAuthToken,
+    });
+
+    this.state.streamAbortController = new AbortController();
+
+    try {
+      const eventsUrl = buildEventsUrl(
+        this.state.activeServerUrl,
+        this.state.serverClientId,
+        this.state.activeServerPathPrefix,
+      );
+
+      const response = await fetch(eventsUrl, {
+        headers,
+        signal: this.state.streamAbortController.signal,
+      });
+
+      if (!response.ok) {
+        console.error(`[worker] Stream connect failed: ${response.status}`);
+        this.detachServer();
+        this.state.streamConnecting = false;
+        this.scheduleReconnect();
+        return;
+      }
+
+      const reader = response.body!.getReader();
+      let connected = false;
+      await readBinaryFrames(
+        reader,
+        {
+          onSyncMessage: (json) => this.state.runtime?.onSyncMessageReceived(json),
+          onConnected: (clientId) => {
+            this.state.serverClientId = clientId;
+            if (!connected) {
+              connected = true;
+              this.attachServer();
+            }
+          },
+        },
+        "[worker] ",
+      );
+    } catch (e: any) {
+      if (e?.name === "AbortError") return;
+      console.error("[worker] Stream connect error:", e);
+    } finally {
+      this.state.streamConnecting = false;
+    }
+
+    if (this.state.streamAbortController && !this.state.streamAbortController.signal.aborted) {
+      this.detachServer();
+      this.scheduleReconnect();
+    }
+  }
+
+  private flushWalBestEffort(): void {
+    if (!this.state.runtime || !this.state.initComplete) return;
+    try {
+      this.state.runtime.flushWal();
+    } catch (error) {
+      console.warn("[worker] flushWal on lifecycle hint failed:", error);
+    }
+  }
+
+  private nudgeReconnectAfterResume(): void {
+    if (!this.state.activeServerUrl || this.isShuttingDownLike()) return;
+    if (this.state.streamAttached || this.state.streamConnecting) return;
+    if (this.state.reconnectTimer) return;
+    this.state.reconnectAttempt = 0;
+    this.scheduleReconnect();
+  }
+
+  private async handleInit(msg: InitMessage): Promise<void> {
+    this.transition({ type: "INIT_REQUESTED" });
+    const thisInitSessionId = ++this.state.initSessionId;
+
+    try {
+      const wasmModule: any = await import("jazz-wasm");
+      this.resetBeforeInit(msg);
+
+      const initResult = await openPersistentWithRetry({
+        open: () =>
+          wasmModule.WasmRuntime.openPersistent(
+            msg.schemaJson,
+            msg.appId,
+            msg.env,
+            msg.userBranch,
+            msg.dbName,
+            "worker",
+          ),
+        isRetryable: isRetryableOpfsInitError,
+        isCancelled: () =>
+          this.state.initSessionId !== thisInitSessionId || this.isShuttingDownLike(),
+      });
+
+      if (this.state.initSessionId !== thisInitSessionId || this.isShuttingDownLike()) {
+        if (isFreeableRuntime(initResult?.value)) {
+          try {
+            initResult.value.free();
+          } catch {
+            // Best effort if cancellation raced after open succeeded.
+          }
         }
-      } else {
-        pendingSyncMessages.push(...payloads);
-      }
-      break;
-    }
-
-    case "peer-open":
-      if (runtime && initComplete) {
-        ensurePeerClient(msg.peerId);
-      }
-      break;
-
-    case "peer-sync": {
-      if (!runtime || !mainClientId || !initComplete) {
-        pendingPeerSyncMessages.push({
-          peerId: msg.peerId,
-          term: msg.term,
-          payload: msg.payload,
-        });
-        break;
+        return;
       }
 
-      const peerClientId = ensurePeerClient(msg.peerId);
-      if (!peerClientId) break;
-      peerTermByPeerId.set(msg.peerId, msg.term);
-      for (const payload of msg.payload) {
-        runtime.onSyncMessageReceivedFromClient(peerClientId, payload);
-      }
-      break;
-    }
+      this.state.runtime = initResult.value;
 
-    case "peer-close":
-      closePeer(msg.peerId);
-      break;
+      this.state.jwtToken = msg.jwtToken;
+      this.state.localAuthMode = msg.localAuthMode;
+      this.state.localAuthToken = msg.localAuthToken;
+      this.state.adminSecret = msg.adminSecret;
 
-    case "lifecycle-hint":
-      if (msg.event === "visibility-hidden" || msg.event === "pagehide" || msg.event === "freeze") {
-        flushWalBestEffort();
-      } else if (msg.event === "visibility-visible" || msg.event === "resume") {
-        nudgeReconnectAfterResume();
-      }
-      break;
+      this.state.mainClientId = this.state.runtime.addClient();
+      this.state.runtime.setClientRole(this.state.mainClientId, "peer");
 
-    case "update-auth":
-      jwtToken = msg.jwtToken;
-      localAuthMode = msg.localAuthMode;
-      localAuthToken = msg.localAuthToken;
-      // Reconnect stream to bind the new token.
-      if (streamAbortController) {
-        streamAbortController.abort();
-        streamAbortController = null;
-      }
-      detachServer();
-      if (activeServerUrl && !isShuttingDown) {
-        scheduleReconnect();
-      }
-      break;
+      this.state.runtime.onSyncMessageToSend((envelope: string) => {
+        const parsed = JSON.parse(envelope);
 
-    case "shutdown":
-      isShuttingDown = true;
-      initComplete = false;
-      activeServerUrl = null;
-      activeServerPathPrefix = undefined;
-      if (reconnectTimer) {
-        clearTimeout(reconnectTimer);
-        reconnectTimer = null;
-      }
-      if (streamAbortController) {
-        streamAbortController.abort();
-        streamAbortController = null;
-      }
-      if (runtime) {
-        detachServer();
-        runtime.flush();
-        runtime.free(); // Triggers Rust Drop → closes OPFS exclusive handles
-        runtime = null;
-      }
-      peerRuntimeClientByPeerId.clear();
-      peerIdByRuntimeClient.clear();
-      peerTermByPeerId.clear();
-      pendingPeerSyncMessages = [];
-      post({ type: "shutdown-ok" });
-      self.close();
-      break;
+        if (parsed.destination && "Client" in parsed.destination) {
+          const destinationClientId = parsed.destination.Client as string;
+          if (destinationClientId === this.state.mainClientId) {
+            this.enqueueSyncMessageForMain(JSON.stringify(parsed.payload));
+            return;
+          }
 
-    case "simulate-crash":
-      // Flush WAL buffer to OPFS but do NOT write snapshot.
-      // This simulates a crash where writes reached the WAL but no
-      // clean checkpoint happened. Recovery must replay the WAL.
-      isShuttingDown = true;
-      initComplete = false;
-      activeServerUrl = null;
-      activeServerPathPrefix = undefined;
-      if (reconnectTimer) {
-        clearTimeout(reconnectTimer);
-        reconnectTimer = null;
-      }
-      if (streamAbortController) {
-        streamAbortController.abort();
-        streamAbortController = null;
-      }
-      if (runtime) {
-        detachServer();
-        runtime.flushWal(); // WAL buffer → OPFS, but no snapshot
-        runtime.free(); // Drop → releases OPFS exclusive handles
-        runtime = null;
-      }
-      peerRuntimeClientByPeerId.clear();
-      peerIdByRuntimeClient.clear();
-      peerTermByPeerId.clear();
-      pendingPeerSyncMessages = [];
-      post({ type: "shutdown-ok" });
-      self.close();
-      break;
+          const peerId = this.state.peerIdByRuntimeClient.get(destinationClientId);
+          if (!peerId) {
+            return;
+          }
+          const term = this.state.peerTermByPeerId.get(peerId) ?? 0;
+          this.post({
+            type: "peer-sync",
+            peerId,
+            term,
+            payload: [JSON.stringify(parsed.payload)],
+          });
+        } else if (parsed.destination && "Server" in parsed.destination) {
+          if (this.state.bootstrapCatalogueForwarding) {
+            if (isCataloguePayload(parsed.payload)) {
+              this.enqueueSyncMessageForMain(JSON.stringify(parsed.payload));
+            }
+            return;
+          }
 
-    case "debug-schema-state":
-      if (!runtime || !initComplete) {
-        post({
-          type: "error",
-          message: "debug-schema-state requested before worker init complete",
-        });
-        break;
+          if (this.state.activeServerUrl) {
+            void this.sendToServer(this.state.activeServerUrl, parsed.payload).catch((error) => {
+              console.error("[worker] Sync POST error:", error);
+              this.detachServer();
+              this.scheduleReconnect();
+            });
+          }
+        }
+      });
+
+      const bufferedSyncMessages = this.state.pendingSyncMessages;
+      this.state.pendingSyncMessages = [];
+      this.state.initComplete = true;
+
+      for (const payload of bufferedSyncMessages) {
+        this.state.runtime.onSyncMessageReceivedFromClient(this.state.mainClientId!, payload);
       }
+
+      const bufferedPeerSyncMessages = this.state.pendingPeerSyncMessages;
+      this.state.pendingPeerSyncMessages = [];
+      for (const buffered of bufferedPeerSyncMessages) {
+        const peerClientId = this.ensurePeerClient(buffered.peerId);
+        if (!peerClientId) continue;
+        this.state.peerTermByPeerId.set(buffered.peerId, buffered.term);
+        for (const payload of buffered.payload) {
+          this.state.runtime.onSyncMessageReceivedFromClient(peerClientId, payload);
+        }
+      }
+
+      this.state.bootstrapCatalogueForwarding = true;
       try {
-        const state = runtime.__debugSchemaState();
-        post({ type: "debug-schema-state-ok", state });
-      } catch (error: any) {
-        post({ type: "error", message: `debug-schema-state failed: ${error?.message ?? error}` });
+        this.state.runtime.addServer();
+        this.state.runtime.removeServer();
+      } finally {
+        this.state.bootstrapCatalogueForwarding = false;
       }
-      break;
 
-    case "debug-seed-live-schema":
-      if (!runtime || !initComplete) {
-        post({
-          type: "error",
-          message: "debug-seed-live-schema requested before worker init complete",
-        });
-        break;
+      this.transition({ type: "INIT_SUCCEEDED" });
+      this.post({ type: "init-ok", clientId: this.state.mainClientId! });
+
+      if (this.state.activeServerUrl) {
+        void this.connectStream();
       }
-      try {
-        runtime.__debugSeedLiveSchema(msg.schemaJson);
-        post({ type: "debug-seed-live-schema-ok" });
-      } catch (error: any) {
-        post({
-          type: "error",
-          message: `debug-seed-live-schema failed: ${error?.message ?? error}`,
-        });
+    } catch (e: unknown) {
+      if (e instanceof OpfsInitRetryCancelled) {
+        return;
       }
-      break;
+
+      if (this.state.initSessionId !== thisInitSessionId || this.isShuttingDownLike()) {
+        return;
+      }
+
+      this.transition({ type: "INIT_FAILED" });
+
+      if (e instanceof OpfsInitRetryFailure) {
+        this.post({
+          type: "error",
+          message: `Init failed: ${e.message}`,
+        });
+        return;
+      }
+
+      const message = e instanceof Error ? e.message : String(e);
+      this.post({ type: "error", message: `Init failed: ${message}` });
+    }
   }
-};
+}
 
-// Start loading WASM immediately
-startup();
+const runtime = new JazzWorkerRuntime();
+self.onmessage = (event: MessageEvent) => {
+  void runtime.onMessage(event as MessageEvent<MainToWorkerMessage>);
+};
+void runtime.startup();

--- a/packages/jazz-tools/tests/browser/worker-bridge.test.ts
+++ b/packages/jazz-tools/tests/browser/worker-bridge.test.ts
@@ -10,6 +10,7 @@
 import { describe, it, expect, afterEach } from "vitest";
 import { createDb, Db, type QueryBuilder, type TableProxy } from "../../src/runtime/db.js";
 import type { WasmSchema } from "../../src/drivers/types.js";
+import type { InitMessage, WorkerToMainMessage } from "../../src/worker/worker-protocol.js";
 import { TEST_PORT, ADMIN_SECRET, APP_ID } from "./test-constants.js";
 
 interface DebugLensEdgeState {
@@ -431,6 +432,68 @@ describe("Worker Bridge with OPFS", () => {
     expect(titles).toEqual(["Also survives", "Crash-proof"]);
   });
 
+  it("retries OPFS init contention and succeeds when lock is released in time", async () => {
+    const dbName = uniqueDbName("opfs-retry-success");
+    const workerA = await spawnRawJazzWorker();
+    const workerB = await spawnRawJazzWorker();
+
+    try {
+      const initA = await initRawWorker(workerA, dbName, 5_000);
+      expect(initA.type).toBe("init-ok");
+
+      const initBPromise = initRawWorker(workerB, dbName, 16_000);
+
+      await sleep(1_000);
+      workerA.postMessage({ type: "shutdown" });
+      await waitForWorkerMessageType(workerA, "shutdown-ok", 5_000, "raw shutdown");
+      workerA.terminate();
+
+      const initB = await initBPromise;
+      expect(initB.type).toBe("init-ok");
+    } finally {
+      try {
+        workerB.postMessage({ type: "shutdown" });
+        await waitForWorkerMessageType(workerB, "shutdown-ok", 5_000, "raw shutdown");
+      } catch {
+        // Best effort
+      }
+      workerB.terminate();
+    }
+  }, 35_000);
+
+  it("fails init deterministically after OPFS contention timeout budget", async () => {
+    const dbName = uniqueDbName("opfs-retry-timeout");
+    const workerA = await spawnRawJazzWorker();
+    const workerB = await spawnRawJazzWorker();
+
+    try {
+      const initA = await initRawWorker(workerA, dbName, 5_000);
+      expect(initA.type).toBe("init-ok");
+
+      const initB = await initRawWorker(workerB, dbName, 18_000);
+      expect(initB.type).toBe("error");
+      if (initB.type === "error") {
+        expect(initB.message).toContain("retry timeout");
+        expect(initB.message).toContain("attempt");
+      }
+    } finally {
+      try {
+        workerA.postMessage({ type: "shutdown" });
+        await waitForWorkerMessageType(workerA, "shutdown-ok", 5_000, "raw shutdown");
+      } catch {
+        // Best effort
+      }
+      try {
+        workerB.postMessage({ type: "shutdown" });
+        await waitForWorkerMessageType(workerB, "shutdown-ok", 5_000, "raw shutdown");
+      } catch {
+        // Best effort
+      }
+      workerA.terminate();
+      workerB.terminate();
+    }
+  }, 40_000);
+
   it("rehydrates worker catalogue schemas/lenses and restores them on main thread", async () => {
     const dbName = uniqueDbName("catalogue-schema-lens-rehydrate");
     const seeded = track(await createDb({ appId: "test-app", dbName }));
@@ -780,6 +843,58 @@ async function waitForWorkerMessageType(
     };
 
     worker.addEventListener("message", handler);
+  });
+}
+
+async function spawnRawJazzWorker(): Promise<Worker> {
+  const worker = new Worker(new URL("../../src/worker/jazz-worker.js", import.meta.url), {
+    type: "module",
+  });
+  await waitForWorkerMessageType(worker, "ready", 15_000, "raw worker ready");
+  return worker;
+}
+
+async function initRawWorker(
+  worker: Worker,
+  dbName: string,
+  timeoutMs: number,
+): Promise<{ type: "init-ok"; clientId: string } | { type: "error"; message: string }> {
+  const initMessage: InitMessage = {
+    type: "init",
+    schemaJson: JSON.stringify(schema),
+    appId: "test-app",
+    env: "dev",
+    userBranch: "main",
+    dbName,
+    clientId: "",
+  };
+
+  return await new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      cleanup();
+      reject(new Error(`raw init: no init response within ${timeoutMs}ms`));
+    }, timeoutMs);
+
+    const handler = (event: MessageEvent) => {
+      const data = event.data as WorkerToMainMessage;
+      if (data.type === "init-ok") {
+        cleanup();
+        resolve({ type: "init-ok", clientId: data.clientId });
+        return;
+      }
+      if (data.type === "error") {
+        cleanup();
+        resolve({ type: "error", message: data.message });
+      }
+    };
+
+    const cleanup = () => {
+      clearTimeout(timeout);
+      worker.removeEventListener("message", handler);
+    };
+
+    worker.addEventListener("message", handler);
+    worker.postMessage(initMessage);
   });
 }
 


### PR DESCRIPTION
On a reload I've got the following error 
<img width="557" height="325" alt="Screenshot 2026-02-26 at 10 15 29" src="https://github.com/user-attachments/assets/367c0f6c-0ad4-48ae-86bb-818533c975c3" />

So I've added a wrapper around openPersistent to retry on that error, which might happen if the previous session was busy during reload. (isolated in the init-retry module)

I've also refactored worker-bridge and jazz-worker to be state machines.

The feature set should be the same as before, the only difference is the retry on init.