### PR TITLE
perf(jazz-tools): reduce OPFS B-tree init overhead

### DIFF
--- a/crates/jazz-tools/src/storage/opfs_btree.rs
+++ b/crates/jazz-tools/src/storage/opfs_btree.rs
@@ -143,7 +143,6 @@ impl OpfsBTreeStorage {
         let storage = Self {
             tree: RefCell::new(tree),
         };
-        storage.log_key_stats();
         Ok(storage)
     }
 
@@ -165,22 +164,6 @@ impl OpfsBTreeStorage {
             .try_borrow_mut()
             .map_err(|_| StorageError::IoError("opfs-btree already borrowed".to_string()))?;
         f(&mut tree)
-    }
-
-    fn log_key_stats(&self) {
-        let count_prefix =
-            |pfx: &str| -> usize { self.tree_scan_keys(pfx).map(|v| v.len()).unwrap_or(0) };
-        let obj_count = count_prefix("obj:");
-        let idx_count = count_prefix("idx:");
-        let ack_count = count_prefix("ack:");
-        let catman_count = count_prefix("catman:");
-        tracing::info!(
-            obj_count,
-            idx_count,
-            ack_count,
-            catman_count,
-            "OpfsBTreeStorage opened"
-        );
     }
 
     fn tree_insert(&self, key: &str, value: &[u8]) -> Result<(), StorageError> {


### PR DESCRIPTION
## Summary
- remove the startup key-stats log path from `OpfsBTreeStorage::open_with_file`
- drop the now-unused `log_key_stats` helper
- keep initialization behavior identical aside from skipping the expensive stats scan/log

## Performance
- observed init time improvement: ~500ms -> ~30ms

## Validation
- `cargo check -p jazz-tools --quiet`

Before:
<img width="499" height="412" alt="Screenshot 2026-02-26 at 14 44 07" src="https://github.com/user-attachments/assets/2aef1be2-393b-46e0-bf5c-cf4726fd277c" />

After:
<img width="358" height="272" alt="Screenshot 2026-02-26 at 14 43 48" src="https://github.com/user-attachments/assets/ee34130d-cd5b-45ce-9ec8-7d55b76ad8e1" />
