### PR TITLE
feat: retry queue

### DIFF
--- a/packages/jazz-tools/src/runtime/client.ts
+++ b/packages/jazz-tools/src/runtime/client.ts
@@ -730,6 +730,7 @@ export class JazzClient {
     this.runtime.onSyncMessageToSend(
       createSyncOutboxRouter({
         logPrefix: "[client] ",
+        retryServerPayloads: true,
         onServerPayload: (payload) => this.sendSyncMessage(payload),
         onServerPayloadError: (error) => {
           console.error("Sync POST error:", error);

--- a/packages/jazz-tools/src/runtime/sync-transport.test.ts
+++ b/packages/jazz-tools/src/runtime/sync-transport.test.ts
@@ -7,6 +7,7 @@ import {
   generateClientId,
   linkExternalIdentity,
   normalizePathPrefix,
+  readBinaryFrames,
   sendSyncPayload,
   SyncStreamController,
 } from "./sync-transport.js";
@@ -361,5 +362,34 @@ describe("sync-transport", () => {
     router(JSON.stringify({ destination: { Server: "upstream-1" }, payload: { Ping: {} } }));
 
     await vi.waitFor(() => expect(onServerPayloadError).toHaveBeenCalledWith(error));
+  });
+
+  it("sync outbox router retries failed server payloads in-order when enabled", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, "random").mockReturnValue(0);
+
+    const onServerPayload = vi
+      .fn<(...args: [unknown]) => Promise<void>>()
+      .mockRejectedValueOnce(new Error("network down"))
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(undefined);
+    const onServerPayloadError = vi.fn();
+    const router = createSyncOutboxRouter({
+      onServerPayload,
+      onServerPayloadError,
+      retryServerPayloads: true,
+    });
+
+    router(JSON.stringify({ destination: { Server: "upstream-1" }, payload: { seq: 1 } }));
+    router(JSON.stringify({ destination: { Server: "upstream-1" }, payload: { seq: 2 } }));
+
+    await vi.waitFor(() => expect(onServerPayload).toHaveBeenCalledTimes(1));
+    expect(onServerPayload.mock.calls[0][0]).toEqual({ seq: 1 });
+    expect(onServerPayloadError).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(300);
+    await vi.waitFor(() => expect(onServerPayload).toHaveBeenCalledTimes(3));
+    expect(onServerPayload.mock.calls[1][0]).toEqual({ seq: 1 });
+    expect(onServerPayload.mock.calls[2][0]).toEqual({ seq: 2 });
   });
 });

--- a/packages/jazz-tools/src/runtime/sync-transport.test.ts
+++ b/packages/jazz-tools/src/runtime/sync-transport.test.ts
@@ -102,18 +102,21 @@ describe("sync-transport", () => {
       .mockResolvedValue({ ok: false, status: 503, statusText: "Service Unavailable" });
     (globalThis as { fetch: typeof fetch }).fetch = fetchMock as unknown as typeof fetch;
 
-    await expect(sendSyncPayload("http://localhost:3000", { Ping: {} }, {})).rejects.toThrow(
-      "Sync POST failed: 503 Service Unavailable",
-    );
+    await expect(sendSyncPayload("http://localhost:3000", { Ping: {} }, {})).rejects.toMatchObject({
+      message: "Sync POST failed: 503 Service Unavailable",
+      status: 503,
+      retryable: false,
+    });
   });
 
   it("throws when fetch rejects", async () => {
     const fetchMock = vi.fn().mockRejectedValue(new Error("network down"));
     (globalThis as { fetch: typeof fetch }).fetch = fetchMock as unknown as typeof fetch;
 
-    await expect(sendSyncPayload("http://localhost:3000", { Ping: {} }, {})).rejects.toThrow(
-      "Sync POST failed: network down",
-    );
+    await expect(sendSyncPayload("http://localhost:3000", { Ping: {} }, {})).rejects.toMatchObject({
+      message: "Sync POST failed: network down",
+      retryable: true,
+    });
   });
 
   it("posts to path-prefixed sync route when provided", async () => {
@@ -391,5 +394,35 @@ describe("sync-transport", () => {
     await vi.waitFor(() => expect(onServerPayload).toHaveBeenCalledTimes(3));
     expect(onServerPayload.mock.calls[1][0]).toEqual({ seq: 1 });
     expect(onServerPayload.mock.calls[2][0]).toEqual({ seq: 2 });
+  });
+
+  it("sync outbox router drops non-offline server payload errors and keeps draining", async () => {
+    vi.useFakeTimers();
+
+    const terminalError = Object.assign(new Error("Sync POST failed: 503 Service Unavailable"), {
+      status: 503,
+      retryable: false,
+    });
+    const onServerPayload = vi
+      .fn<(...args: [unknown]) => Promise<void>>()
+      .mockRejectedValueOnce(terminalError)
+      .mockResolvedValueOnce(undefined);
+    const onServerPayloadError = vi.fn();
+    const router = createSyncOutboxRouter({
+      onServerPayload,
+      onServerPayloadError,
+      retryServerPayloads: true,
+    });
+
+    router(JSON.stringify({ destination: { Server: "upstream-1" }, payload: { seq: 1 } }));
+    router(JSON.stringify({ destination: { Server: "upstream-1" }, payload: { seq: 2 } }));
+
+    await vi.waitFor(() => expect(onServerPayload).toHaveBeenCalledTimes(2));
+    expect(onServerPayload.mock.calls[0][0]).toEqual({ seq: 1 });
+    expect(onServerPayload.mock.calls[1][0]).toEqual({ seq: 2 });
+    expect(onServerPayloadError).toHaveBeenCalledWith(terminalError);
+
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(onServerPayload).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/jazz-tools/src/runtime/sync-transport.test.ts
+++ b/packages/jazz-tools/src/runtime/sync-transport.test.ts
@@ -396,6 +396,51 @@ describe("sync-transport", () => {
     expect(onServerPayload.mock.calls[2][0]).toEqual({ seq: 2 });
   });
 
+  it("sync outbox router drops newest payloads when pending count limit is reached", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, "random").mockReturnValue(0);
+
+    const onServerPayload = vi
+      .fn<(...args: [unknown]) => Promise<void>>()
+      .mockRejectedValueOnce(new Error("network down"))
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(undefined);
+    const onServerPayloadError = vi.fn();
+    const router = createSyncOutboxRouter({
+      onServerPayload,
+      onServerPayloadError,
+      retryServerPayloads: true,
+      maxPendingServerPayloads: 2,
+    });
+
+    router(JSON.stringify({ destination: { Server: "upstream-1" }, payload: { seq: 1 } }));
+    router(JSON.stringify({ destination: { Server: "upstream-1" }, payload: { seq: 2 } }));
+    router(JSON.stringify({ destination: { Server: "upstream-1" }, payload: { seq: 3 } }));
+
+    await vi.waitFor(() => expect(onServerPayload).toHaveBeenCalledTimes(1));
+    await vi.waitFor(() =>
+      expect(onServerPayloadError).toHaveBeenCalledWith(
+        expect.objectContaining({ code: "SYNC_SERVER_PAYLOAD_QUEUE_OVERFLOW" }),
+      ),
+    );
+
+    const overflowError = onServerPayloadError.mock.calls
+      .map((call) => call[0] as Record<string, unknown>)
+      .find((error) => error.code === "SYNC_SERVER_PAYLOAD_QUEUE_OVERFLOW");
+    expect(overflowError).toMatchObject({
+      code: "SYNC_SERVER_PAYLOAD_QUEUE_OVERFLOW",
+      retryable: false,
+      queueLength: 2,
+      maxPendingServerPayloads: 2,
+    });
+
+    await vi.advanceTimersByTimeAsync(300);
+    await vi.waitFor(() => expect(onServerPayload).toHaveBeenCalledTimes(3));
+    expect(onServerPayload.mock.calls[0][0]).toEqual({ seq: 1 });
+    expect(onServerPayload.mock.calls[1][0]).toEqual({ seq: 1 });
+    expect(onServerPayload.mock.calls[2][0]).toEqual({ seq: 2 });
+  });
+
   it("sync outbox router drops non-offline server payload errors and keeps draining", async () => {
     vi.useFakeTimers();
 

--- a/packages/jazz-tools/src/runtime/sync-transport.ts
+++ b/packages/jazz-tools/src/runtime/sync-transport.ts
@@ -252,11 +252,21 @@ export interface SyncOutboxRouterOptions {
   onClientPayload?(payloadJson: string): void;
   onServerPayloadError?(error: unknown): void;
   retryServerPayloads?: boolean;
+  maxPendingServerPayloads?: number;
 }
 
 type SyncPostErrorDetails = {
   retryable?: unknown;
 };
+
+type SyncQueueOverflowError = Error & {
+  code: "SYNC_SERVER_PAYLOAD_QUEUE_OVERFLOW";
+  retryable: false;
+  queueLength: number;
+  maxPendingServerPayloads: number;
+};
+
+const defaultMaxPendingServerPayloads = 2_000;
 
 const offlineErrorPatterns = [
   /network/i,
@@ -297,6 +307,28 @@ function isRetryableSyncPostError(error: unknown): boolean {
   return isOfflineTransportError(error);
 }
 
+function normalizePositiveIntegerLimit(value: number | undefined, fallback: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 1) {
+    return fallback;
+  }
+  return Math.floor(value);
+}
+
+function createQueueOverflowError(details: {
+  queueLength: number;
+  maxPendingServerPayloads: number;
+  logPrefix: string;
+}): SyncQueueOverflowError {
+  const error = new Error(
+    `${details.logPrefix}Sync server payload queue overflow`,
+  ) as SyncQueueOverflowError;
+  error.code = "SYNC_SERVER_PAYLOAD_QUEUE_OVERFLOW";
+  error.retryable = false;
+  error.queueLength = details.queueLength;
+  error.maxPendingServerPayloads = details.maxPendingServerPayloads;
+  return error;
+}
+
 /**
  * Create a shared runtime outbox router for server/client destinations.
  */
@@ -305,6 +337,10 @@ export function createSyncOutboxRouter(
 ): (envelope: string) => void {
   const logPrefix = options.logPrefix ?? "";
   const retryServerPayloads = options.retryServerPayloads ?? false;
+  const maxPendingServerPayloads = normalizePositiveIntegerLimit(
+    options.maxPendingServerPayloads,
+    defaultMaxPendingServerPayloads,
+  );
   const pendingServerPayloads: unknown[] = [];
   let serverFlushQueued = false;
   let serverFlushInFlight = false;
@@ -388,6 +424,17 @@ export function createSyncOutboxRouter(
     }
 
     if (isObjectDestination && "Server" in destination) {
+      if (pendingServerPayloads.length >= maxPendingServerPayloads) {
+        handleServerPayloadError(
+          createQueueOverflowError({
+            queueLength: pendingServerPayloads.length,
+            maxPendingServerPayloads,
+            logPrefix,
+          }),
+        );
+        return;
+      }
+
       pendingServerPayloads.push(payload);
       scheduleServerFlush();
     }

--- a/packages/jazz-tools/src/runtime/sync-transport.ts
+++ b/packages/jazz-tools/src/runtime/sync-transport.ts
@@ -254,6 +254,49 @@ export interface SyncOutboxRouterOptions {
   retryServerPayloads?: boolean;
 }
 
+type SyncPostErrorDetails = {
+  retryable?: unknown;
+};
+
+const offlineErrorPatterns = [
+  /network/i,
+  /offline/i,
+  /failed to fetch/i,
+  /fetch failed/i,
+  /load failed/i,
+  /econnrefused/i,
+  /econnreset/i,
+  /ehostunreach/i,
+  /enetunreach/i,
+  /enotfound/i,
+  /eai_again/i,
+  /etimedout/i,
+  /timed out/i,
+];
+
+function isOfflineTransportError(error: unknown): boolean {
+  const navigatorRef = (globalThis as { navigator?: { onLine?: boolean } }).navigator;
+  if (navigatorRef?.onLine === false) {
+    return true;
+  }
+
+  const message = error instanceof Error ? error.message : String(error);
+  return offlineErrorPatterns.some((pattern) => pattern.test(message));
+}
+
+function isRetryableSyncPostError(error: unknown): boolean {
+  if (!error || typeof error !== "object") {
+    return isOfflineTransportError(error);
+  }
+
+  const details = error as SyncPostErrorDetails;
+  if (typeof details.retryable === "boolean") {
+    return details.retryable;
+  }
+
+  return isOfflineTransportError(error);
+}
+
 /**
  * Create a shared runtime outbox router for server/client destinations.
  */
@@ -305,8 +348,9 @@ export function createSyncOutboxRouter(
         retryAttempt = 0;
       } catch (error) {
         handleServerPayloadError(error);
-        if (!retryServerPayloads) {
+        if (!retryServerPayloads || !isRetryableSyncPostError(error)) {
           pendingServerPayloads.shift();
+          retryAttempt = 0;
           continue;
         }
         const baseMs = 300;
@@ -475,12 +519,24 @@ export async function sendSyncPayload(
     });
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
-    throw new Error(`${logPrefix}Sync POST failed: ${msg}`);
+    const error = new Error(`${logPrefix}Sync POST failed: ${msg}`) as Error & {
+      retryable: boolean;
+    };
+    error.retryable = isOfflineTransportError(e);
+    throw error;
   }
 
   if (!response.ok) {
     const statusText = response.statusText ? ` ${response.statusText}` : "";
-    throw new Error(`${logPrefix}Sync POST failed: ${response.status}${statusText}`);
+    const error = new Error(
+      `${logPrefix}Sync POST failed: ${response.status}${statusText}`,
+    ) as Error & {
+      status: number;
+      retryable: boolean;
+    };
+    error.status = response.status;
+    error.retryable = false;
+    throw error;
   }
 }
 

--- a/packages/jazz-tools/src/runtime/sync-transport.ts
+++ b/packages/jazz-tools/src/runtime/sync-transport.ts
@@ -251,6 +251,7 @@ export interface SyncOutboxRouterOptions {
   onServerPayload(payload: unknown): void | Promise<void>;
   onClientPayload?(payloadJson: string): void;
   onServerPayloadError?(error: unknown): void;
+  retryServerPayloads?: boolean;
 }
 
 /**
@@ -260,6 +261,66 @@ export function createSyncOutboxRouter(
   options: SyncOutboxRouterOptions,
 ): (envelope: string) => void {
   const logPrefix = options.logPrefix ?? "";
+  const retryServerPayloads = options.retryServerPayloads ?? false;
+  const pendingServerPayloads: unknown[] = [];
+  let serverFlushQueued = false;
+  let serverFlushInFlight = false;
+  let serverRetryTimer: ReturnType<typeof setTimeout> | null = null;
+  let retryAttempt = 0;
+
+  const scheduleServerFlush = (): void => {
+    if (serverFlushQueued || serverFlushInFlight || serverRetryTimer) return;
+    serverFlushQueued = true;
+    queueMicrotask(() => {
+      serverFlushQueued = false;
+      void flushServerPayloads();
+    });
+  };
+
+  const scheduleServerRetry = (delayMs: number): void => {
+    if (serverRetryTimer) return;
+    serverRetryTimer = setTimeout(() => {
+      serverRetryTimer = null;
+      void flushServerPayloads();
+    }, delayMs);
+  };
+
+  const handleServerPayloadError = (error: unknown): void => {
+    if (options.onServerPayloadError) {
+      options.onServerPayloadError(error);
+      return;
+    }
+    console.error(`${logPrefix}Sync POST error:`, error);
+  };
+
+  const flushServerPayloads = async (): Promise<void> => {
+    if (serverFlushInFlight) return;
+    serverFlushInFlight = true;
+
+    while (pendingServerPayloads.length > 0) {
+      const payload = pendingServerPayloads[0];
+      try {
+        await options.onServerPayload(payload);
+        pendingServerPayloads.shift();
+        retryAttempt = 0;
+      } catch (error) {
+        handleServerPayloadError(error);
+        if (!retryServerPayloads) {
+          pendingServerPayloads.shift();
+          continue;
+        }
+        const baseMs = 300;
+        const maxMs = 10_000;
+        const jitterMs = Math.floor(Math.random() * 200);
+        const delayMs = Math.min(maxMs, baseMs * 2 ** retryAttempt) + jitterMs;
+        retryAttempt += 1;
+        scheduleServerRetry(delayMs);
+        break;
+      }
+    }
+
+    serverFlushInFlight = false;
+  };
 
   return (envelope: string) => {
     let parsed: { destination?: unknown; payload?: unknown };
@@ -283,13 +344,8 @@ export function createSyncOutboxRouter(
     }
 
     if (isObjectDestination && "Server" in destination) {
-      Promise.resolve(options.onServerPayload(payload)).catch((error) => {
-        if (options.onServerPayloadError) {
-          options.onServerPayloadError(error);
-          return;
-        }
-        console.error(`${logPrefix}Sync POST error:`, error);
-      });
+      pendingServerPayloads.push(payload);
+      scheduleServerFlush();
     }
   };
 }


### PR DESCRIPTION
We keep the client-side server payload retry queue because reconnect alone does not close the delivery gap. RuntimeCore drains its outbox and hands messages to JS before the HTTP /sync POST is confirmed; if that POST fails at that moment, the payload would be lost without JS-level retry. Reconnect restores the stream and re-attaches server state, but that is a heavier recovery path and not a direct replacement for immediate payload delivery guarantees. The retry queue gives ordered, eventual resend with exponential backoff for transient outages.
