### PR TITLE
chore(changeset): add Svelte support release note

### DIFF
--- a/.changeset/svelte-support.md
+++ b/.changeset/svelte-support.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": minor
+---
+
+Added Svelte support.

--- a/.changeset/svelte-support.md
+++ b/.changeset/svelte-support.md
@@ -1,5 +1,5 @@
 ---
-"jazz-tools": minor
+"jazz-tools": patch
 ---
 
 Added Svelte support.


### PR DESCRIPTION
## Summary
- adds a changeset for the Svelte support work already merged in PR #145
- bumps `jazz-tools` with a `minor` changeset
- keeps this PR changeset-only (single file)

## Changes
- `.changeset/svelte-support.md`: "Added Svelte support."
