### PR TITLE
fix(changeset): correct invalid frontmatter syntax

### DIFF
--- a/.changeset/fair-forks-bake.md
+++ b/.changeset/fair-forks-bake.md
@@ -1,3 +1,5 @@
-## "jazz-tools": patch
+---
+"jazz-tools": patch
+---
 
 Add Expo support.


### PR DESCRIPTION
## Summary
- fix malformed changeset frontmatter in `.changeset/fair-forks-bake.md`
- replace `## "jazz-tools": patch` with valid changeset YAML frontmatter fenced by `---`

## Why
The `Changesets Release PR` workflow failed to parse this file with:
`could not parse changeset - invalid frontmatter: ## "jazz-tools": patch`

## Validation
- `pnpm changeset status` now succeeds locally and shows expected patch bumps.
