### PR TITLE
fix(jazz-tools): correct cold-start tip computation in get_or_load

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -18,10 +18,5 @@
     "todo-client-localfirst-svelte-docs": "0.1.0",
     "todo-client-localfirst-svelte": "0.1.0"
   },
-  "changesets": [
-    "bright-oranges-march",
-    "fair-forks-bake",
-    "green-humans-divide",
-    "svelte-support"
-  ]
+  "changesets": ["bright-oranges-march", "fair-forks-bake", "green-humans-divide", "svelte-support"]
 }

--- a/crates/jazz-rn/package.json
+++ b/crates/jazz-rn/package.json
@@ -48,8 +48,8 @@
     "./package.json": "./package.json"
   },
   "publishConfig": {
-    "registry": "https://registry.npmjs.org/",
     "access": "public",
+    "registry": "https://registry.npmjs.org/",
     "tag": "alpha"
   },
   "scripts": {

--- a/crates/jazz-tools/src/object_manager/mod.rs
+++ b/crates/jazz-tools/src/object_manager/mod.rs
@@ -209,11 +209,24 @@ impl ObjectManager {
             let bn = BranchName::new(branch_name);
             if let Ok(Some(loaded)) = storage.load_branch(id, &bn) {
                 let mut commits = HashMap::new();
+                // Compute tips correctly: a tip is a commit not referenced
+                // as a parent by any other commit in the branch.
+                let mut all_ids: HashSet<CommitId> = HashSet::new();
+                let mut parent_ids: HashSet<CommitId> = HashSet::new();
+                for commit in &loaded.commits {
+                    all_ids.insert(commit.id());
+                    for parent in &commit.parents {
+                        parent_ids.insert(*parent);
+                    }
+                }
                 let mut tips: SmolSet<[CommitId; 2]> = SmolSet::new();
+                for cid in &all_ids {
+                    if !parent_ids.contains(cid) {
+                        tips.insert(*cid);
+                    }
+                }
                 for commit in loaded.commits {
-                    let cid = commit.id();
-                    tips.insert(cid);
-                    commits.insert(cid, commit);
+                    commits.insert(commit.id(), commit);
                 }
                 object.branches.insert(
                     bn,

--- a/crates/jazz-tools/src/object_manager/tests.rs
+++ b/crates/jazz-tools/src/object_manager/tests.rs
@@ -957,6 +957,53 @@ fn frontier_with_extended_divergence() {
 }
 
 #[test]
+fn get_or_load_computes_correct_tips_for_multi_commit_branch() {
+    // Simulates cold-start: session 1 creates A→B, session 2 loads from
+    // storage and must compute tips correctly (only B, not both A and B).
+    //
+    //   session 1: A → B       (2 commits, B is only tip)
+    //   session 2: get_or_load → add_commit C with parent B
+    let mut io = MemoryStorage::new();
+    let author = ObjectId::new();
+
+    // --- Session 1: create object with two commits ---
+    let object_id = {
+        let mut mgr = ObjectManager::new();
+        let oid = mgr.create(&mut io, None);
+        let a = mgr
+            .add_commit(&mut io, oid, "main", vec![], b"A".to_vec(), author, None)
+            .unwrap();
+        mgr.add_commit(&mut io, oid, "main", vec![a], b"B".to_vec(), author, None)
+            .unwrap();
+        oid
+    };
+
+    // --- Session 2: new ObjectManager, load from storage ---
+    let mut mgr2 = ObjectManager::new();
+    let loaded = mgr2.get_or_load(object_id, &io, &["main".to_string()]);
+    assert!(loaded.is_some(), "object should load from storage");
+
+    // Verify only one tip (B), not two
+    let tips = mgr2.get_tip_ids(object_id, "main".to_string()).unwrap();
+    assert_eq!(tips.len(), 1, "should have exactly 1 tip after loading A→B");
+
+    // Adding a new commit should succeed — this failed before the fix
+    // because both A and B were tips, and add_commit rejected A as
+    // ParentNotFound during the tails check.
+    let tip = *tips.iter().next().unwrap();
+    mgr2.add_commit(
+        &mut io,
+        object_id,
+        "main",
+        vec![tip],
+        b"C".to_vec(),
+        author,
+        None,
+    )
+    .expect("add_commit after cold-start load should succeed");
+}
+
+#[test]
 fn frontier_with_three_way_divergence() {
     let mut io = MemoryStorage::new();
     let mut manager = ObjectManager::new();

--- a/crates/jazz-tools/src/query_manager/writes.rs
+++ b/crates/jazz-tools/src/query_manager/writes.rs
@@ -790,6 +790,12 @@ impl QueryManager {
         session: Option<&Session>,
     ) -> Result<CommitId, QueryError> {
         let _span = tracing::debug_span!("QM::update", %id).entered();
+        // Ensure object is loaded from storage (cold-start: may only exist on disk)
+        let branch = self.current_branch();
+        self.sync_manager
+            .object_manager
+            .get_or_load(id, storage, &[branch]);
+
         // Get table name from object metadata
         let table = self
             .sync_manager
@@ -956,6 +962,12 @@ impl QueryManager {
         session: Option<&Session>,
     ) -> Result<DeleteHandle, QueryError> {
         let _span = tracing::debug_span!("QM::delete", %id).entered();
+        // Ensure object is loaded from storage (cold-start: may only exist on disk)
+        let branch = self.current_branch();
+        self.sync_manager
+            .object_manager
+            .get_or_load(id, storage, &[branch]);
+
         // Check for hard delete first
         if self.is_hard_deleted(id) {
             return Err(QueryError::RowHardDeleted(id));


### PR DESCRIPTION
## Summary
- **ObjectManager.get_or_load** naively treated every loaded commit as a tip. With 2+ commits (A→B), both A and B became tips, causing `add_commit` to reject new writes with `ParentNotFound`. Fix computes tips correctly by excluding commits referenced as parents.
- Adds `get_or_load` calls at the start of `update_with_session` and `delete_with_session` so cold-started objects are loaded from storage before the first mutation.
- Adds regression test `get_or_load_computes_correct_tips_for_multi_commit_branch` in object_manager tests.

## Test plan
- [x] New test creates 2 commits (A→B), drops the ObjectManager, reloads via `get_or_load`, and verifies a third commit can be added
- [x] All 766 jazz-tools tests pass