### PR TITLE
Add alpha release preview workflow and RN native payload checks

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -13,7 +13,10 @@
     "todo-client-localfirst-react": "0.1.0",
     "todo-client-localfirst-ts": "0.1.0",
     "todo-server-ts": "0.1.0",
-    "jazz-tools": "2.0.0-alpha.6"
+    "jazz-tools": "2.0.0-alpha.6",
+    "jazz-nitro": "0.1.0",
+    "todo-client-localfirst-svelte-docs": "0.1.0",
+    "todo-client-localfirst-svelte": "0.1.0"
   },
-  "changesets": []
+  "changesets": ["bright-oranges-march", "fair-forks-bake", "green-humans-divide", "svelte-support"]
 }

--- a/.github/workflows/preview-jazz-tools-alpha-release.yml
+++ b/.github/workflows/preview-jazz-tools-alpha-release.yml
@@ -26,6 +26,7 @@ concurrency:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   preview:

--- a/.github/workflows/preview-jazz-tools-alpha-release.yml
+++ b/.github/workflows/preview-jazz-tools-alpha-release.yml
@@ -1,0 +1,36 @@
+name: Preview jazz-tools alpha release
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+    paths:
+      - packages/jazz-tools/package.json
+      - crates/jazz-wasm/package.json
+      - crates/jazz-napi/package.json
+      - crates/jazz-rn/package.json
+      - packages/jazz-tools/CHANGELOG.md
+      - crates/jazz-wasm/CHANGELOG.md
+      - crates/jazz-napi/CHANGELOG.md
+      - crates/jazz-rn/CHANGELOG.md
+  workflow_dispatch:
+
+concurrency:
+  group: preview-jazz-tools-alpha-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  preview:
+    if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false && (github.event.pull_request.title == 'Version Packages (alpha)' || startsWith(github.event.pull_request.head.ref, 'changeset-release/')))
+    uses: ./.github/workflows/publish-jazz-tools-alpha.yml
+    with:
+      mode: dry-run
+    secrets: inherit

--- a/.github/workflows/publish-jazz-tools-alpha.yml
+++ b/.github/workflows/publish-jazz-tools-alpha.yml
@@ -13,8 +13,23 @@ on:
       - crates/jazz-wasm/CHANGELOG.md
       - crates/jazz-napi/CHANGELOG.md
       - crates/jazz-rn/CHANGELOG.md
+  workflow_call:
+    inputs:
+      mode:
+        description: "Execution mode: publish (real release) or dry-run (build + verify only)."
+        required: false
+        type: string
+        default: publish
   workflow_dispatch:
     inputs:
+      mode:
+        description: "Execution mode."
+        required: true
+        type: choice
+        default: publish
+        options:
+          - publish
+          - dry-run
       version:
         description: "Optional exact manual version override (for example 2.0.0-alpha.6)."
         required: false
@@ -178,6 +193,7 @@ jobs:
       id-token: write
     env:
       NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      RELEASE_MODE: ${{ github.event_name == 'workflow_call' && inputs.mode || github.event_name == 'workflow_dispatch' && github.event.inputs.mode || 'publish' }}
 
     steps:
       - uses: actions/checkout@v6
@@ -209,6 +225,9 @@ jobs:
           pattern: jazz-napi-binding-*
           path: crates/jazz-napi/artifacts
           merge-multiple: true
+
+      - name: Show release mode
+        run: 'echo "Release mode: ${RELEASE_MODE}"'
 
       - name: Build jazz-wasm npm package
         run: pnpm --filter jazz-wasm build
@@ -312,9 +331,31 @@ jobs:
           TMP_DIR=$(mktemp -d)
           npm_config_ignore_scripts=true pnpm --filter jazz-rn pack --pack-destination "${TMP_DIR}"
           TARBALL=$(ls "${TMP_DIR}"/jazz-rn-*.tgz | head -n 1)
+          LISTING=$(mktemp)
+          tar -tf "${TARBALL}" > "${LISTING}"
+
+          # Ensure iOS payload is present for CocoaPods (Expo/RN iOS consumers).
+          grep -q '^package/JazzRnFramework.xcframework/' "${LISTING}" || {
+            echo "Missing JazzRnFramework.xcframework in packed jazz-rn tarball."
+            exit 1
+          }
+          grep -q '^package/JazzRnFramework.xcframework/Info.plist$' "${LISTING}" || {
+            echo "Missing JazzRnFramework.xcframework/Info.plist in packed jazz-rn tarball."
+            exit 1
+          }
+
+          # Ensure key Android native slices are present for Expo/RN Android consumers.
+          for abi in arm64-v8a x86_64; do
+            grep -q "^package/android/src/main/jniLibs/${abi}/libjazz_rn\\.a$" "${LISTING}" || {
+              echo "Missing Android native library for ABI ${abi} in packed jazz-rn tarball."
+              exit 1
+            }
+          done
+
           tar -xOf "${TARBALL}" package/package.json | node -e 'let s="";process.stdin.on("data",(d)=>s+=d);process.stdin.on("end",()=>{const p=JSON.parse(s);for(const field of ["dependencies","optionalDependencies","peerDependencies"]){for(const [name,version] of Object.entries(p[field]||{})){if(typeof version==="string"&&version.startsWith("workspace:")){throw new Error(`${field}.${name} uses workspace protocol (${version}) in packed manifest`);}}}if(!(p.publishConfig&&p.publishConfig.tag==="alpha")){throw new Error(`Expected publishConfig.tag=alpha for ${p.name}, got ${(p.publishConfig||{}).tag}`);}console.log(`Packed manifest OK for ${p.name}@${p.version}`);});'
 
       - name: Publish jazz-wasm (alpha tag)
+        if: env.RELEASE_MODE == 'publish'
         run: |
           WASM_VERSION=$(node -p 'JSON.parse(require("fs").readFileSync("crates/jazz-wasm/package.json","utf8")).version')
           if npm view "jazz-wasm@${WASM_VERSION}" version >/dev/null 2>&1; then
@@ -324,6 +365,7 @@ jobs:
           fi
 
       - name: Publish jazz-napi (alpha tag)
+        if: env.RELEASE_MODE == 'publish'
         run: |
           NAPI_VERSION=$(node -p 'JSON.parse(require("fs").readFileSync("crates/jazz-napi/package.json","utf8")).version')
           for pkg_dir in crates/jazz-napi/npm/*; do
@@ -342,6 +384,7 @@ jobs:
           fi
 
       - name: Publish jazz-rn (alpha tag)
+        if: env.RELEASE_MODE == 'publish'
         run: |
           RN_VERSION=$(node -p 'JSON.parse(require("fs").readFileSync("crates/jazz-rn/package.json","utf8")).version')
           if npm view "jazz-rn@${RN_VERSION}" version >/dev/null 2>&1; then
@@ -351,6 +394,7 @@ jobs:
           fi
 
       - name: Publish jazz-tools (alpha tag)
+        if: env.RELEASE_MODE == 'publish'
         run: |
           TOOLS_VERSION=$(node -p 'JSON.parse(require("fs").readFileSync("packages/jazz-tools/package.json","utf8")).version')
           if npm view "jazz-tools@${TOOLS_VERSION}" version >/dev/null 2>&1; then

--- a/crates/jazz-rn/package.json
+++ b/crates/jazz-rn/package.json
@@ -48,8 +48,8 @@
     "./package.json": "./package.json"
   },
   "publishConfig": {
-    "registry": "https://registry.npmjs.org/",
     "access": "public",
+    "registry": "https://registry.npmjs.org/",
     "tag": "alpha"
   },
   "scripts": {


### PR DESCRIPTION
## Summary
- add a PR-triggered preview workflow for Changesets release PRs that runs the existing alpha release pipeline in `dry-run` mode
- make `.github/workflows/publish-jazz-tools-alpha.yml` reusable via `workflow_call` and add a `mode` input (`publish` / `dry-run`)
- gate `jazz-rn` release quality by verifying packed tarballs include iOS XCFramework payload and key Android ABI static libraries (`arm64-v8a`, `x86_64`)

## Why
- gives an early signal on release PRs before merge
- avoids publishing if RN/Expo native payloads are missing from the npm tarball

## Validation
- YAML parse check for both workflow files
- local `jazz-rn` pack inspection confirms the new guard would currently fail when native payloads are absent
