### PR TITLE
Fix preview release mode and add required release-preview gate

### DIFF
--- a/.github/workflows/preview-jazz-tools-alpha-release.yml
+++ b/.github/workflows/preview-jazz-tools-alpha-release.yml
@@ -30,7 +30,6 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           PR_DRAFT: ${{ github.event.pull_request.draft }}
-          PR_TITLE: ${{ github.event.pull_request.title }}
           PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
           if [ "${EVENT_NAME}" != "pull_request" ]; then
@@ -43,7 +42,7 @@ jobs:
             exit 0
           fi
 
-          if [ "${PR_TITLE}" = "Version Packages (alpha)" ] || [[ "${PR_HEAD_REF}" == changeset-release/* ]]; then
+          if [[ "${PR_HEAD_REF}" == changeset-release/* ]]; then
             echo "is_release_pr=true" >> "${GITHUB_OUTPUT}"
           else
             echo "is_release_pr=false" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/preview-jazz-tools-alpha-release.yml
+++ b/.github/workflows/preview-jazz-tools-alpha-release.yml
@@ -9,15 +9,6 @@ on:
       - synchronize
       - reopened
       - ready_for_review
-    paths:
-      - packages/jazz-tools/package.json
-      - crates/jazz-wasm/package.json
-      - crates/jazz-napi/package.json
-      - crates/jazz-rn/package.json
-      - packages/jazz-tools/CHANGELOG.md
-      - crates/jazz-wasm/CHANGELOG.md
-      - crates/jazz-napi/CHANGELOG.md
-      - crates/jazz-rn/CHANGELOG.md
   workflow_dispatch:
 
 concurrency:
@@ -29,9 +20,67 @@ permissions:
   id-token: write
 
 jobs:
+  classify-pr:
+    name: Classify release PR
+    runs-on: ubuntu-latest
+    outputs:
+      is_release_pr: ${{ steps.classify.outputs.is_release_pr }}
+    steps:
+      - id: classify
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_DRAFT: ${{ github.event.pull_request.draft }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          if [ "${EVENT_NAME}" != "pull_request" ]; then
+            echo "is_release_pr=true" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          if [ "${PR_DRAFT}" = "true" ]; then
+            echo "is_release_pr=false" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          if [ "${PR_TITLE}" = "Version Packages (alpha)" ] || [[ "${PR_HEAD_REF}" == changeset-release/* ]]; then
+            echo "is_release_pr=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "is_release_pr=false" >> "${GITHUB_OUTPUT}"
+          fi
+
   preview:
-    if: github.event_name != 'pull_request' || (github.event.pull_request.draft == false && (github.event.pull_request.title == 'Version Packages (alpha)' || startsWith(github.event.pull_request.head.ref, 'changeset-release/')))
+    name: Release preview build
+    needs: classify-pr
+    if: needs.classify-pr.outputs.is_release_pr == 'true'
     uses: ./.github/workflows/publish-jazz-tools-alpha.yml
     with:
       mode: dry-run
     secrets: inherit
+
+  release-preview-required:
+    name: Release preview required
+    runs-on: ubuntu-latest
+    needs: [classify-pr, preview]
+    if: always()
+    steps:
+      - name: Enforce preview result for release PRs
+        env:
+          IS_RELEASE_PR: ${{ needs.classify-pr.outputs.is_release_pr }}
+          PREVIEW_RESULT: ${{ needs.preview.result }}
+        run: |
+          echo "is_release_pr=${IS_RELEASE_PR}"
+          echo "preview_result=${PREVIEW_RESULT}"
+
+          if [ "${IS_RELEASE_PR}" != "true" ]; then
+            echo "Not a release PR; skipping heavy preview requirement."
+            exit 0
+          fi
+
+          if [ "${PREVIEW_RESULT}" = "success" ]; then
+            echo "Release preview passed."
+            exit 0
+          fi
+
+          echo "Release preview failed (result=${PREVIEW_RESULT})."
+          exit 1

--- a/.github/workflows/preview-jazz-tools-alpha-release.yml
+++ b/.github/workflows/preview-jazz-tools-alpha-release.yml
@@ -1,18 +1,13 @@
 name: Preview jazz-tools alpha release
 
 on:
-  pull_request:
+  push:
     branches:
-      - main
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
+      - changeset-release/*
   workflow_dispatch:
 
 concurrency:
-  group: preview-jazz-tools-alpha-${{ github.event.pull_request.number || github.ref }}
+  group: preview-jazz-tools-alpha-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -20,66 +15,9 @@ permissions:
   id-token: write
 
 jobs:
-  classify-pr:
-    name: Classify release PR
-    runs-on: ubuntu-latest
-    outputs:
-      is_release_pr: ${{ steps.classify.outputs.is_release_pr }}
-    steps:
-      - id: classify
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          PR_DRAFT: ${{ github.event.pull_request.draft }}
-          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
-        run: |
-          if [ "${EVENT_NAME}" != "pull_request" ]; then
-            echo "is_release_pr=true" >> "${GITHUB_OUTPUT}"
-            exit 0
-          fi
-
-          if [ "${PR_DRAFT}" = "true" ]; then
-            echo "is_release_pr=false" >> "${GITHUB_OUTPUT}"
-            exit 0
-          fi
-
-          if [[ "${PR_HEAD_REF}" == changeset-release/* ]]; then
-            echo "is_release_pr=true" >> "${GITHUB_OUTPUT}"
-          else
-            echo "is_release_pr=false" >> "${GITHUB_OUTPUT}"
-          fi
-
   preview:
     name: Release preview build
-    needs: classify-pr
-    if: needs.classify-pr.outputs.is_release_pr == 'true'
     uses: ./.github/workflows/publish-jazz-tools-alpha.yml
     with:
       mode: dry-run
     secrets: inherit
-
-  release-preview-required:
-    name: Release preview required
-    runs-on: ubuntu-latest
-    needs: [classify-pr, preview]
-    if: always()
-    steps:
-      - name: Enforce preview result for release PRs
-        env:
-          IS_RELEASE_PR: ${{ needs.classify-pr.outputs.is_release_pr }}
-          PREVIEW_RESULT: ${{ needs.preview.result }}
-        run: |
-          echo "is_release_pr=${IS_RELEASE_PR}"
-          echo "preview_result=${PREVIEW_RESULT}"
-
-          if [ "${IS_RELEASE_PR}" != "true" ]; then
-            echo "Not a release PR; skipping heavy preview requirement."
-            exit 0
-          fi
-
-          if [ "${PREVIEW_RESULT}" = "success" ]; then
-            echo "Release preview passed."
-            exit 0
-          fi
-
-          echo "Release preview failed (result=${PREVIEW_RESULT})."
-          exit 1

--- a/.github/workflows/publish-jazz-tools-alpha.yml
+++ b/.github/workflows/publish-jazz-tools-alpha.yml
@@ -327,7 +327,21 @@ jobs:
         run: |
           mkdir -p packages/jazz-tools/bin/native
           cp dist/jazz-tools-* packages/jazz-tools/bin/native/
-          chmod +x packages/jazz-tools/bin/native/jazz-tools-darwin-* packages/jazz-tools/bin/native/jazz-tools-linux-* || true
+          for bin in \
+            jazz-tools-darwin-arm64 \
+            jazz-tools-darwin-x64 \
+            jazz-tools-linux-arm64 \
+            jazz-tools-linux-x64 \
+            jazz-tools-windows-x64.exe; do
+            FILE="packages/jazz-tools/bin/native/${bin}"
+            test -f "${FILE}" || { echo "Missing staged native binary ${bin}"; exit 1; }
+          done
+          chmod 755 \
+            packages/jazz-tools/bin/native/jazz-tools-darwin-arm64 \
+            packages/jazz-tools/bin/native/jazz-tools-darwin-x64 \
+            packages/jazz-tools/bin/native/jazz-tools-linux-arm64 \
+            packages/jazz-tools/bin/native/jazz-tools-linux-x64
+          ls -l packages/jazz-tools/bin/native
 
       - name: Resolve lock-stepped npm package versions
         run: |
@@ -388,7 +402,7 @@ jobs:
           TARBALL=$(ls "${TMP_DIR}"/jazz-tools-*.tgz | head -n 1)
           tar -xOf "${TARBALL}" package/package.json | node -e 'let s="";process.stdin.on("data",(d)=>s+=d);process.stdin.on("end",()=>{const p=JSON.parse(s);for(const field of ["dependencies","optionalDependencies","peerDependencies"]){for(const [name,version] of Object.entries(p[field]||{})){if(typeof version==="string"&&version.startsWith("workspace:")){throw new Error(`${field}.${name} uses workspace protocol (${version}) in packed manifest`);}}}console.log(`Packed manifest OK for ${p.name}@${p.version}`);});'
 
-      - name: Verify packed jazz-tools native binaries are executable
+      - name: Verify packed jazz-tools native binaries and runtime bootstrap
         run: |
           TMP_DIR=$(mktemp -d)
           EXTRACT_DIR=$(mktemp -d)
@@ -402,8 +416,22 @@ jobs:
             jazz-tools-linux-x64; do
             FILE="${EXTRACT_DIR}/package/bin/native/${bin}"
             test -f "${FILE}" || { echo "Missing packed native binary ${bin}"; exit 1; }
-            test -x "${FILE}" || { echo "Packed native binary ${bin} is not executable"; exit 1; }
           done
+
+          case "$(uname -m)" in
+            x86_64) HOST_LINUX_BIN="jazz-tools-linux-x64" ;;
+            aarch64|arm64) HOST_LINUX_BIN="jazz-tools-linux-arm64" ;;
+            *)
+              echo "Unsupported linux runner architecture: $(uname -m)"
+              exit 1
+              ;;
+          esac
+
+          node "${EXTRACT_DIR}/package/bin/jazz-tools.js" --version >/dev/null
+          test -x "${EXTRACT_DIR}/package/bin/native/${HOST_LINUX_BIN}" || {
+            echo "Packed native binary ${HOST_LINUX_BIN} is not executable after runtime bootstrap."
+            exit 1
+          }
 
       - name: Verify packed jazz-rn manifest
         run: |

--- a/.github/workflows/publish-jazz-tools-alpha.yml
+++ b/.github/workflows/publish-jazz-tools-alpha.yml
@@ -427,7 +427,7 @@ jobs:
               ;;
           esac
 
-          node "${EXTRACT_DIR}/package/bin/jazz-tools.js" --version >/dev/null
+          node "${EXTRACT_DIR}/package/bin/jazz-tools.js" --help >/dev/null
           test -x "${EXTRACT_DIR}/package/bin/native/${HOST_LINUX_BIN}" || {
             echo "Packed native binary ${HOST_LINUX_BIN} is not executable after runtime bootstrap."
             exit 1

--- a/.github/workflows/publish-jazz-tools-alpha.yml
+++ b/.github/workflows/publish-jazz-tools-alpha.yml
@@ -193,7 +193,7 @@ jobs:
       id-token: write
     env:
       NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      RELEASE_MODE: ${{ github.event_name == 'workflow_call' && inputs.mode || github.event_name == 'workflow_dispatch' && github.event.inputs.mode || 'publish' }}
+      RELEASE_MODE: ${{ inputs.mode || github.event.inputs.mode || 'publish' }}
 
     steps:
       - uses: actions/checkout@v6
@@ -227,7 +227,15 @@ jobs:
           merge-multiple: true
 
       - name: Show release mode
-        run: 'echo "Release mode: ${RELEASE_MODE}"'
+        run: |
+          case "${RELEASE_MODE}" in
+            publish|dry-run) ;;
+            *)
+              echo "Unsupported RELEASE_MODE='${RELEASE_MODE}'"
+              exit 1
+              ;;
+          esac
+          echo "Release mode: ${RELEASE_MODE}"
 
       - name: Build jazz-wasm npm package
         run: pnpm --filter jazz-wasm build
@@ -271,7 +279,9 @@ jobs:
 
       - name: Resolve lock-stepped npm package versions
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          if [ "${RELEASE_MODE}" = "dry-run" ]; then
+            VERSION=$(node -p 'JSON.parse(require("fs").readFileSync("packages/jazz-tools/package.json","utf8")).version')
+          elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             VERSION="${{ github.event.inputs.version || '' }}"
             if [ -n "${VERSION}" ]; then
               npm --prefix packages/jazz-tools version "${VERSION}" --no-git-tag-version

--- a/.github/workflows/publish-jazz-tools-alpha.yml
+++ b/.github/workflows/publish-jazz-tools-alpha.yml
@@ -184,10 +184,49 @@ jobs:
           path: crates/jazz-napi/jazz-napi.${{ matrix.platform }}.node
           if-no-files-found: error
 
+  build-rn-native:
+    name: Build jazz-rn native payload
+    runs-on: macos-14
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+
+      - run: corepack enable
+      - run: pnpm install --frozen-lockfile
+
+      - name: Install/build React Native native prerequisites
+        run: pnpm run ensure:rust-toolchain
+
+      - name: Build jazz-rn iOS and Android native payloads
+        run: pnpm --filter jazz-rn build:rn
+
+      - name: Verify built jazz-rn native payloads
+        run: |
+          test -d crates/jazz-rn/JazzRnFramework.xcframework
+          test -f crates/jazz-rn/JazzRnFramework.xcframework/Info.plist
+          test -f crates/jazz-rn/android/src/main/jniLibs/arm64-v8a/libjazz_rn.a
+          test -f crates/jazz-rn/android/src/main/jniLibs/x86_64/libjazz_rn.a
+
+      - name: Stage jazz-rn native payload artifact
+        run: |
+          mkdir -p dist/rn-native
+          cp -R crates/jazz-rn/JazzRnFramework.xcframework dist/rn-native/
+          cp -R crates/jazz-rn/android/src/main/jniLibs dist/rn-native/
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: jazz-rn-native-payload
+          path: dist/rn-native
+          if-no-files-found: error
+
   publish-npm:
     name: Publish npm alpha
     runs-on: ubuntu-latest
-    needs: [build-linux, build-macos, build-windows, build-napi]
+    needs: [build-linux, build-macos, build-windows, build-napi, build-rn-native]
     permissions:
       contents: read
       id-token: write
@@ -225,6 +264,19 @@ jobs:
           pattern: jazz-napi-binding-*
           path: crates/jazz-napi/artifacts
           merge-multiple: true
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: jazz-rn-native-payload
+          path: dist/rn-native
+
+      - name: Stage jazz-rn native payload into npm package sources
+        run: |
+          rm -rf crates/jazz-rn/JazzRnFramework.xcframework
+          rm -rf crates/jazz-rn/android/src/main/jniLibs
+          mkdir -p crates/jazz-rn/android/src/main
+          cp -R dist/rn-native/JazzRnFramework.xcframework crates/jazz-rn/
+          cp -R dist/rn-native/jniLibs crates/jazz-rn/android/src/main/
 
       - name: Show release mode
         run: |
@@ -335,6 +387,23 @@ jobs:
           pnpm --filter jazz-tools pack --pack-destination "${TMP_DIR}"
           TARBALL=$(ls "${TMP_DIR}"/jazz-tools-*.tgz | head -n 1)
           tar -xOf "${TARBALL}" package/package.json | node -e 'let s="";process.stdin.on("data",(d)=>s+=d);process.stdin.on("end",()=>{const p=JSON.parse(s);for(const field of ["dependencies","optionalDependencies","peerDependencies"]){for(const [name,version] of Object.entries(p[field]||{})){if(typeof version==="string"&&version.startsWith("workspace:")){throw new Error(`${field}.${name} uses workspace protocol (${version}) in packed manifest`);}}}console.log(`Packed manifest OK for ${p.name}@${p.version}`);});'
+
+      - name: Verify packed jazz-tools native binaries are executable
+        run: |
+          TMP_DIR=$(mktemp -d)
+          EXTRACT_DIR=$(mktemp -d)
+          pnpm --filter jazz-tools pack --pack-destination "${TMP_DIR}"
+          TARBALL=$(ls "${TMP_DIR}"/jazz-tools-*.tgz | head -n 1)
+          tar -xzf "${TARBALL}" -C "${EXTRACT_DIR}"
+          for bin in \
+            jazz-tools-darwin-arm64 \
+            jazz-tools-darwin-x64 \
+            jazz-tools-linux-arm64 \
+            jazz-tools-linux-x64; do
+            FILE="${EXTRACT_DIR}/package/bin/native/${bin}"
+            test -f "${FILE}" || { echo "Missing packed native binary ${bin}"; exit 1; }
+            test -x "${FILE}" || { echo "Packed native binary ${bin} is not executable"; exit 1; }
+          done
 
       - name: Verify packed jazz-rn manifest
         run: |

--- a/packages/jazz-tools/bin/jazz-tools.js
+++ b/packages/jazz-tools/bin/jazz-tools.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { spawnSync } from "node:child_process";
-import { existsSync } from "node:fs";
+import { accessSync, chmodSync, constants, existsSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -16,6 +16,30 @@ const BINARIES = {
 function fail(message) {
   console.error(message);
   process.exit(1);
+}
+
+function ensureExecutable(binaryPath, name) {
+  if (process.platform === "win32") {
+    return;
+  }
+
+  try {
+    accessSync(binaryPath, constants.X_OK);
+    return;
+  } catch {}
+
+  try {
+    chmodSync(binaryPath, 0o755);
+  } catch (error) {
+    const details = error instanceof Error ? error.message : String(error);
+    fail(`Bundled binary ${name} is not executable and chmod failed: ${details}`);
+  }
+
+  try {
+    accessSync(binaryPath, constants.X_OK);
+  } catch {
+    fail(`Bundled binary ${name} is not executable after chmod.`);
+  }
 }
 
 const key = `${process.platform}-${process.arch}`;
@@ -47,13 +71,15 @@ if (!binaryPath) {
   fail(lines.join("\n"));
 }
 
+ensureExecutable(binaryPath, binaryName ?? localBinaryName);
+
 const result = spawnSync(binaryPath, process.argv.slice(2), {
   stdio: "inherit",
   env: process.env,
 });
 
 if (result.error) {
-  fail(`Failed to execute ${binaryName}: ${result.error.message}`);
+  fail(`Failed to execute ${binaryName ?? binaryPath}: ${result.error.message}`);
 }
 
 if (typeof result.status === "number") {


### PR DESCRIPTION
## Summary
- fix reusable alpha publish workflow mode resolution so preview calls reliably run in `dry-run`
- prevent preview runs from executing `changeset version` in the lock-step version step
- add a `Release preview required` gate job in the preview workflow
  - for release PRs (`Version Packages (alpha)` or `changeset-release/*`), gate fails unless full preview succeeds
  - for non-release PRs, gate passes immediately
- build and stage `jazz-rn` native payloads during release/preview (`JazzRnFramework.xcframework` + Android `jniLibs`) before pack/publish checks
- add a packed-tarball guard to ensure shipped CLI binaries are executable on macOS/Linux

## Why
- preview runs for release PRs were incorrectly entering publish/versioning code paths and failing with `npm error Version not changed`
- RN payload checks were failing because native payloads were never built/staged in CI
- previous published CLI binaries had missing execute bits; we now enforce this in CI before publish

## Validation
- YAML parse checks passed
- `pnpm format:check` passed
- workflow run in progress on this branch for end-to-end verification
