### PR TITLE
Show release preview status on release PRs

### DIFF
--- a/.github/workflows/preview-jazz-tools-alpha-release.yml
+++ b/.github/workflows/preview-jazz-tools-alpha-release.yml
@@ -13,11 +13,69 @@ concurrency:
 permissions:
   contents: read
   id-token: write
+  statuses: write
 
 jobs:
+  mark-preview-pending:
+    name: Mark release preview pending
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/heads/changeset-release/')
+    steps:
+      - name: Set pending commit status
+        uses: actions/github-script@v8
+        with:
+          script: |
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: context.sha,
+              state: "pending",
+              context: "Release preview (alpha)",
+              description: "Release preview is running.",
+              target_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+            });
+
   preview:
     name: Release preview build
     uses: ./.github/workflows/publish-jazz-tools-alpha.yml
     with:
       mode: dry-run
     secrets: inherit
+
+  mark-preview-final:
+    name: Mark release preview result
+    runs-on: ubuntu-latest
+    if: always() && startsWith(github.ref, 'refs/heads/changeset-release/')
+    needs: [mark-preview-pending, preview]
+    steps:
+      - name: Set final commit status
+        uses: actions/github-script@v8
+        env:
+          PREVIEW_RESULT: ${{ needs.preview.result }}
+        with:
+          script: |
+            const result = process.env.PREVIEW_RESULT || "failure";
+            const stateByResult = {
+              success: "success",
+              failure: "failure",
+              cancelled: "error",
+              skipped: "error",
+            };
+            const state = stateByResult[result] || "error";
+            const descriptionByResult = {
+              success: "Release preview passed.",
+              failure: "Release preview failed.",
+              cancelled: "Release preview was cancelled.",
+              skipped: "Release preview was skipped.",
+            };
+            const description = descriptionByResult[result] || `Release preview ended with result: ${result}.`;
+
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: context.sha,
+              state,
+              context: "Release preview (alpha)",
+              description,
+              target_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+            });


### PR DESCRIPTION
## Summary
- add `statuses: write` permission to the preview workflow
- set a pending `Release preview (alpha)` commit status at workflow start for `changeset-release/*` refs
- set final success/failure/error status when preview finishes

## Why
- `workflow_dispatch` preview runs can execute correctly but not appear in the PR checks rollup
- publishing an explicit commit status guarantees a visible red/green check on the release PR commit
