### PR TITLE
perf(opfs-tree): switch to FxHashMap and optimize page cache eviction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2423,6 +2423,7 @@ dependencies = [
  "fjall",
  "js-sys",
  "rocksdb",
+ "rustc-hash",
  "serde",
  "serde-wasm-bindgen 0.6.5",
  "surrealkv 0.20.2",

--- a/crates/opfs-btree/Cargo.toml
+++ b/crates/opfs-btree/Cargo.toml
@@ -14,6 +14,7 @@ compare-native = ["dep:bf-tree", "dep:rocksdb", "dep:fjall", "dep:surrealkv", "d
 
 [dependencies]
 crc32fast = "1"
+rustc-hash = "2"
 thiserror = "2"
 tracing = "0.1"
 serde = { version = "1", features = ["derive"] }

--- a/crates/opfs-btree/src/db.rs
+++ b/crates/opfs-btree/src/db.rs
@@ -1,4 +1,5 @@
 use rustc_hash::{FxHashMap, FxHashSet};
+use std::collections::BinaryHeap;
 
 use crate::BTreeError;
 use crate::file::SyncFile;
@@ -1470,50 +1471,56 @@ impl<F: SyncFile> OpfsBTree<F> {
         }
 
         let root_page_id = self.root_page_id;
-        let mut candidates: Vec<(u8, u64, PageId)> = self
-            .pages
-            .iter()
-            .filter_map(|(page_id, page)| {
-                if Some(*page_id) == protected_page
-                    || Some(*page_id) == root_page_id
-                    || self.dirty_pages.contains(page_id)
-                {
-                    return None;
-                }
-                let priority = match raw_page_kind(page, self.options.page_size) {
-                    Ok(kind) => {
-                        if self.options.pin_internal_pages && kind == PageKind::Internal {
-                            return None;
-                        }
-                        eviction_priority(kind)
-                    }
-                    Err(_) => 0, // blob/raw pages are always evictable when clean
-                };
-
-                Some((
-                    priority,
-                    *self.page_access_epoch.get(page_id).unwrap_or(&0),
-                    *page_id,
-                ))
-            })
-            .collect();
-
-        let target = self
-            .pages
-            .len()
-            .saturating_sub(max_cached_pages)
-            .min(candidates.len());
+        let target = self.pages.len().saturating_sub(max_cached_pages);
         if target == 0 {
             return;
         }
 
-        let split_at = target - 1;
-        let _ = candidates.select_nth_unstable(split_at);
-        let victims = &mut candidates[..target];
+        // One pass top-k selection:
+        // Keep only the k worst eviction candidates in a bounded max heap.
+        // Candidate ordering is (priority, access_epoch, page_id), where smaller
+        // values are better eviction victims.
+        let mut victims: BinaryHeap<(u8, u64, PageId)> = BinaryHeap::with_capacity(target);
+        for (page_id, page) in &self.pages {
+            if Some(*page_id) == protected_page
+                || Some(*page_id) == root_page_id
+                || self.dirty_pages.contains(page_id)
+            {
+                continue;
+            }
 
-        for (_, _, page_id) in victims.iter() {
-            self.pages.remove(page_id);
-            self.page_access_epoch.remove(page_id);
+            let priority = match raw_page_kind(page, self.options.page_size) {
+                Ok(kind) => {
+                    if self.options.pin_internal_pages && kind == PageKind::Internal {
+                        continue;
+                    }
+                    eviction_priority(kind)
+                }
+                Err(_) => 0, // blob/raw pages are always evictable when clean
+            };
+
+            let candidate = (
+                priority,
+                *self.page_access_epoch.get(page_id).unwrap_or(&0),
+                *page_id,
+            );
+
+            if victims.len() < target {
+                victims.push(candidate);
+                continue;
+            }
+
+            if let Some(worst_kept) = victims.peek()
+                && candidate < *worst_kept
+            {
+                let _ = victims.pop();
+                victims.push(candidate);
+            }
+        }
+
+        for (_, _, page_id) in victims {
+            self.pages.remove(&page_id);
+            self.page_access_epoch.remove(&page_id);
         }
     }
 

--- a/crates/opfs-btree/src/db.rs
+++ b/crates/opfs-btree/src/db.rs
@@ -1,4 +1,5 @@
-use std::collections::{HashMap, HashSet};
+use rustc_hash::FxHashMap;
+use std::collections::HashSet;
 
 use crate::BTreeError;
 use crate::file::SyncFile;
@@ -18,6 +19,8 @@ const OVERFLOW_REUSE_MIN_BYTES: usize = 128 * 1024;
 const OVERFLOW_DIRECT_READ_MIN_BYTES: usize = 128 * 1024;
 const BOOTSTRAP_GENERATION: u64 = 1;
 const ALLOC_NEAR_WINDOW: u64 = 32;
+
+type OpfsMap<K, V> = FxHashMap<K, V>;
 
 #[derive(Debug, Clone, Copy)]
 pub struct BTreeOptions {
@@ -89,9 +92,9 @@ pub struct OpfsBTree<F: SyncFile> {
     active: Superblock,
     root_page_id: Option<PageId>,
     total_pages: u64,
-    pages: HashMap<PageId, Vec<u8>>,
+    pages: OpfsMap<PageId, Vec<u8>>,
     blob_pages: HashSet<PageId>,
-    page_access_epoch: HashMap<PageId, u64>,
+    page_access_epoch: OpfsMap<PageId, u64>,
     access_epoch: u64,
     dirty_pages: HashSet<PageId>,
     free_pages: Vec<PageId>,
@@ -135,9 +138,9 @@ impl<F: SyncFile> OpfsBTree<F> {
             active,
             root_page_id: None,
             total_pages: 2,
-            pages: HashMap::new(),
+            pages: OpfsMap::default(),
             blob_pages: HashSet::new(),
-            page_access_epoch: HashMap::new(),
+            page_access_epoch: OpfsMap::default(),
             access_epoch: 0,
             dirty_pages: HashSet::new(),
             free_pages: Vec::new(),
@@ -1101,8 +1104,12 @@ impl<F: SyncFile> OpfsBTree<F> {
             };
             self.pages.insert(current_page_id, page_raw.to_vec());
             self.touch_page(current_page_id);
-            self.evict_pages_if_needed(Some(page_id));
+            self.evict_pages_if_needed_with_allowance(
+                Some(page_id),
+                self.options.read_coalesce_pages,
+            );
         }
+        self.evict_pages_if_needed(Some(page_id));
 
         Ok(())
     }
@@ -1450,8 +1457,17 @@ impl<F: SyncFile> OpfsBTree<F> {
     }
 
     fn evict_pages_if_needed(&mut self, protected_page: Option<PageId>) {
+        self.evict_pages_if_needed_with_allowance(protected_page, 0);
+    }
+
+    fn evict_pages_if_needed_with_allowance(
+        &mut self,
+        protected_page: Option<PageId>,
+        over_budget_allowance: usize,
+    ) {
         let max_cached_pages = self.max_cached_pages();
-        if self.pages.len() <= max_cached_pages {
+        let trigger = max_cached_pages.saturating_add(over_budget_allowance);
+        if self.pages.len() <= trigger {
             return;
         }
 
@@ -1483,16 +1499,23 @@ impl<F: SyncFile> OpfsBTree<F> {
                 ))
             })
             .collect();
-        candidates.sort_unstable();
 
-        let mut target = self.pages.len().saturating_sub(max_cached_pages);
-        for (_, _, page_id) in candidates {
-            if target == 0 {
-                break;
-            }
-            self.pages.remove(&page_id);
-            self.page_access_epoch.remove(&page_id);
-            target -= 1;
+        let target = self
+            .pages
+            .len()
+            .saturating_sub(max_cached_pages)
+            .min(candidates.len());
+        if target == 0 {
+            return;
+        }
+
+        let split_at = target - 1;
+        let _ = candidates.select_nth_unstable(split_at);
+        let victims = &mut candidates[..target];
+
+        for (_, _, page_id) in victims.iter() {
+            self.pages.remove(page_id);
+            self.page_access_epoch.remove(page_id);
         }
     }
 
@@ -2169,6 +2192,67 @@ mod tests {
         );
         let range = tree.range(b"k01000", b"k01010", 32).expect("range");
         assert_eq!(range.len(), 10);
+    }
+
+    #[test]
+    fn cache_eviction_allowance_defers_until_threshold() {
+        let file = MemoryFile::new();
+        let mut tree = OpfsBTree::open(file, tiny_cache_options()).expect("open tree");
+        let max_cached = tree.max_cached_pages();
+        let allowance = 4usize;
+        let keep_len = max_cached + allowance;
+        let page_size = tree.options.page_size;
+
+        for idx in 0..keep_len {
+            let page_id = 10_000 + idx as u64;
+            tree.pages.insert(page_id, vec![0u8; page_size]);
+            tree.touch_page(page_id);
+        }
+
+        tree.evict_pages_if_needed_with_allowance(None, allowance);
+        assert_eq!(
+            tree.pages.len(),
+            keep_len,
+            "eviction should not run while within allowance"
+        );
+
+        let overflow_page_id = 10_000 + keep_len as u64;
+        tree.pages.insert(overflow_page_id, vec![0u8; page_size]);
+        tree.touch_page(overflow_page_id);
+
+        tree.evict_pages_if_needed_with_allowance(None, allowance);
+        assert!(
+            tree.pages.len() <= max_cached,
+            "eviction should reduce cache back to strict budget"
+        );
+    }
+
+    #[test]
+    fn cache_eviction_keeps_budget_for_coalesced_reads() {
+        let file = MemoryFile::new();
+        let mut options = tiny_cache_options();
+        options.read_coalesce_pages = 8;
+        let mut tree = OpfsBTree::open(file, options).expect("open tree");
+
+        for i in 0..8_000u32 {
+            let key = format!("k{:05}", i);
+            let value = format!("value-{}", i);
+            tree.put(key.as_bytes(), value.as_bytes()).expect("put");
+        }
+        tree.checkpoint().expect("checkpoint");
+
+        let max_cached = tree.max_cached_pages();
+        let root = tree.root_page_id.expect("root exists");
+
+        for page_id in 2..tree.total_pages {
+            tree.ensure_page_loaded(page_id).expect("load page");
+            assert!(
+                tree.pages.len() <= max_cached,
+                "cache exceeded budget after loading page {}",
+                page_id
+            );
+            assert!(tree.pages.contains_key(&root));
+        }
     }
 
     #[test]

--- a/crates/opfs-btree/src/db.rs
+++ b/crates/opfs-btree/src/db.rs
@@ -1,5 +1,4 @@
-use rustc_hash::FxHashMap;
-use std::collections::HashSet;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::BTreeError;
 use crate::file::SyncFile;
@@ -21,6 +20,7 @@ const BOOTSTRAP_GENERATION: u64 = 1;
 const ALLOC_NEAR_WINDOW: u64 = 32;
 
 type OpfsMap<K, V> = FxHashMap<K, V>;
+type OpfsSet<T> = FxHashSet<T>;
 
 #[derive(Debug, Clone, Copy)]
 pub struct BTreeOptions {
@@ -93,12 +93,12 @@ pub struct OpfsBTree<F: SyncFile> {
     root_page_id: Option<PageId>,
     total_pages: u64,
     pages: OpfsMap<PageId, Vec<u8>>,
-    blob_pages: HashSet<PageId>,
+    blob_pages: OpfsSet<PageId>,
     page_access_epoch: OpfsMap<PageId, u64>,
     access_epoch: u64,
-    dirty_pages: HashSet<PageId>,
+    dirty_pages: OpfsSet<PageId>,
     free_pages: Vec<PageId>,
-    free_set: HashSet<PageId>,
+    free_set: OpfsSet<PageId>,
     freelist_meta_pages: Vec<PageId>,
 }
 
@@ -139,12 +139,12 @@ impl<F: SyncFile> OpfsBTree<F> {
             root_page_id: None,
             total_pages: 2,
             pages: OpfsMap::default(),
-            blob_pages: HashSet::new(),
+            blob_pages: OpfsSet::default(),
             page_access_epoch: OpfsMap::default(),
             access_epoch: 0,
-            dirty_pages: HashSet::new(),
+            dirty_pages: OpfsSet::default(),
             free_pages: Vec::new(),
-            free_set: HashSet::new(),
+            free_set: OpfsSet::default(),
             freelist_meta_pages: Vec::new(),
         };
 
@@ -290,7 +290,7 @@ impl<F: SyncFile> OpfsBTree<F> {
 
         let mut out = Vec::new();
         let mut current = self.find_leaf_page_id(start)?;
-        let mut visited = HashSet::new();
+        let mut visited = OpfsSet::default();
 
         while let Some(page_id) = current {
             if !visited.insert(page_id) {
@@ -1021,7 +1021,7 @@ impl<F: SyncFile> OpfsBTree<F> {
 
     fn load_freelist_from_disk(&mut self, head_page_id: PageId) -> Result<(), BTreeError> {
         let mut current = head_page_id;
-        let mut seen = HashSet::new();
+        let mut seen = OpfsSet::default();
 
         while current != 0 {
             if !seen.insert(current) {
@@ -1324,7 +1324,7 @@ impl<F: SyncFile> OpfsBTree<F> {
     }
 
     fn sanitize_free_pages(&mut self) {
-        let live_page_ids: HashSet<PageId> = self.pages.keys().copied().collect();
+        let live_page_ids: OpfsSet<PageId> = self.pages.keys().copied().collect();
         self.free_set.retain(|page_id| {
             *page_id >= 2 && *page_id < self.total_pages && !live_page_ids.contains(page_id)
         });

--- a/crates/opfs-btree/src/db.rs
+++ b/crates/opfs-btree/src/db.rs
@@ -1085,6 +1085,7 @@ impl<F: SyncFile> OpfsBTree<F> {
 
         let mut raw = vec![0u8; run_bytes];
         self.file.read_exact_at(offset, &mut raw)?;
+        let allowance = self.max_cached_pages() / 4;
 
         for i in 0..run_pages {
             let current_page_id = page_id + i as u64;
@@ -1104,10 +1105,7 @@ impl<F: SyncFile> OpfsBTree<F> {
             };
             self.pages.insert(current_page_id, page_raw.to_vec());
             self.touch_page(current_page_id);
-            self.evict_pages_if_needed_with_allowance(
-                Some(page_id),
-                self.options.read_coalesce_pages,
-            );
+            self.evict_pages_if_needed_with_allowance(Some(page_id), allowance);
         }
         self.evict_pages_if_needed(Some(page_id));
 

--- a/crates/opfs-btree/src/db.rs
+++ b/crates/opfs-btree/src/db.rs
@@ -1471,7 +1471,8 @@ impl<F: SyncFile> OpfsBTree<F> {
         }
 
         let root_page_id = self.root_page_id;
-        let target = self.pages.len().saturating_sub(max_cached_pages);
+        let steady_cached_pages = max_cached_pages.saturating_sub(max_cached_pages / 4).max(1);
+        let target = self.pages.len().saturating_sub(steady_cached_pages);
         if target == 0 {
             return;
         }
@@ -2204,6 +2205,7 @@ mod tests {
         let file = MemoryFile::new();
         let mut tree = OpfsBTree::open(file, tiny_cache_options()).expect("open tree");
         let max_cached = tree.max_cached_pages();
+        let steady_cached = max_cached.saturating_sub(max_cached / 4).max(1);
         let allowance = 4usize;
         let keep_len = max_cached + allowance;
         let page_size = tree.options.page_size;
@@ -2227,8 +2229,8 @@ mod tests {
 
         tree.evict_pages_if_needed_with_allowance(None, allowance);
         assert!(
-            tree.pages.len() <= max_cached,
-            "eviction should reduce cache back to strict budget"
+            tree.pages.len() <= steady_cached,
+            "eviction should reduce cache to steady-state budget"
         );
     }
 


### PR DESCRIPTION
Optimizations:
- Switch to [FxHashMap](https://github.com/rust-lang/rustc-hash)
- use top-k instead of full sorting to select the victims to deallocate.
- trigger the eviction during navigation using an allowance, which means we don't start evicting pages immediately after reaching max if we are in the middle of a navigation
- kill victims until we are under the 75% of the max page, to reduce the frequence of which the eviction occurs

Testing on 15k rows reduces the loading times from 2s to 650ms

Before
<img width="825" height="877" alt="Screenshot 2026-02-27 at 13 03 53" src="https://github.com/user-attachments/assets/31203623-5224-4ce7-b49b-e36542600640" />

After
<img width="814" height="799" alt="Screenshot 2026-02-27 at 14 51 53" src="https://github.com/user-attachments/assets/9062202a-d18b-4320-b764-ab027a873ba2" />




Question: is it ok to use the fast hash everywhere?