### PR TITLE
perf(query-manager): avoid spurious moved deltas on index shifts

### DIFF
--- a/crates/jazz-tools/src/query_manager/graph_nodes/limit_offset.rs
+++ b/crates/jazz-tools/src/query_manager/graph_nodes/limit_offset.rs
@@ -1,6 +1,9 @@
 use ahash::AHashSet;
 
-use crate::query_manager::types::{RowDescriptor, Tuple, TupleDelta, TupleDescriptor};
+use crate::query_manager::{
+    graph_nodes::tuple_delta::compute_tuple_delta,
+    types::{RowDescriptor, Tuple, TupleDelta, TupleDescriptor},
+};
 
 use super::RowNode;
 
@@ -59,56 +62,6 @@ impl LimitOffsetNode {
         self.current_tuples = self.windowed_tuples.iter().cloned().collect();
     }
 
-    /// Compute the delta between old and new tuple window.
-    fn compute_tuple_delta(&self, old_tuples: &[Tuple], new_tuples: &[Tuple]) -> TupleDelta {
-        let mut delta = TupleDelta::new();
-        let old_ids: std::collections::HashSet<Vec<crate::object::ObjectId>> =
-            old_tuples.iter().map(|t| t.ids()).collect();
-        let new_ids: std::collections::HashSet<Vec<crate::object::ObjectId>> =
-            new_tuples.iter().map(|t| t.ids()).collect();
-
-        // Find removed tuples (in old but not in new)
-        for old in old_tuples {
-            if !new_ids.contains(&old.ids()) {
-                delta.removed.push(old.clone());
-            }
-        }
-
-        // Find added tuples (in new but not in old)
-        for new in new_tuples {
-            if !old_ids.contains(&new.ids()) {
-                delta.added.push(new.clone());
-            }
-        }
-
-        // Find moved tuples (same IDs, different index)
-        let old_pos: std::collections::HashMap<Vec<crate::object::ObjectId>, usize> = old_tuples
-            .iter()
-            .enumerate()
-            .map(|(idx, t)| (t.ids(), idx))
-            .collect();
-        for (new_idx, new_tuple) in new_tuples.iter().enumerate() {
-            let ids = new_tuple.ids();
-            if let Some(old_idx) = old_pos.get(&ids)
-                && old_idx != &new_idx
-            {
-                delta.moved.push(new_tuple.clone());
-            }
-        }
-
-        // Find updated tuples (same IDs but different content)
-        for new in new_tuples {
-            if let Some(old) = old_tuples.iter().find(|t| *t == new) {
-                // Check if content changed (since == only compares IDs)
-                if has_tuple_content_changed(old, new) {
-                    delta.updated.push((old.clone(), new.clone()));
-                }
-            }
-        }
-
-        delta
-    }
-
     /// Rebuild state from a full ordered input (e.g. upstream SortNode output).
     pub fn process_with_ordered_input(&mut self, ordered_tuples: &[Tuple]) -> TupleDelta {
         let old_tuples = std::mem::take(&mut self.windowed_tuples);
@@ -116,23 +69,13 @@ impl LimitOffsetNode {
         self.all_tuples.extend_from_slice(ordered_tuples);
         self.recompute_tuple_window();
         self.dirty = false;
-        self.compute_tuple_delta(&old_tuples, &self.windowed_tuples)
+        compute_tuple_delta(&old_tuples, &self.windowed_tuples)
     }
 
     /// Ordered tuples currently visible after applying offset/limit.
     pub fn windowed_tuples(&self) -> &[Tuple] {
         &self.windowed_tuples
     }
-}
-
-/// Check if tuple content changed (for tuples with same IDs).
-fn has_tuple_content_changed(old: &Tuple, new: &Tuple) -> bool {
-    old.iter()
-        .zip(new.iter())
-        .any(|(o, n)| match (o.content(), n.content()) {
-            (Some(oc), Some(nc)) => oc != nc,
-            _ => false,
-        })
 }
 
 impl RowNode for LimitOffsetNode {
@@ -173,7 +116,7 @@ impl RowNode for LimitOffsetNode {
         self.dirty = false;
 
         // Return the delta for the window
-        self.compute_tuple_delta(&old_tuples, &self.windowed_tuples)
+        compute_tuple_delta(&old_tuples, &self.windowed_tuples)
     }
 
     fn current_tuples(&self) -> &AHashSet<Tuple> {
@@ -344,6 +287,7 @@ mod tests {
         assert!(contains_id(&result.removed, ids[0]));
         assert_eq!(result.added.len(), 1);
         assert!(contains_id(&result.added, ids[2])); // New tuple slides in
+        assert!(result.moved.is_empty());
 
         let windowed_ids = get_windowed_ids(&node);
         assert_eq!(windowed_ids.len(), 2);
@@ -368,5 +312,106 @@ mod tests {
         node.process(delta);
 
         assert!(node.windowed_tuples.is_empty());
+    }
+
+    #[test]
+    fn insertion_before_window_does_not_mark_window_as_moved() {
+        let mut node = make_limit_offset_node(Some(2), 1);
+        let ids: Vec<_> = (0..4).map(|_| ObjectId::new()).collect();
+        let tuples: Vec<_> = ids
+            .iter()
+            .enumerate()
+            .map(|(i, id)| make_tuple(*id, i as i32, &format!("Row{}", i)))
+            .collect();
+
+        node.process(TupleDelta {
+            added: tuples[..3].to_vec(),
+            removed: vec![],
+            moved: vec![],
+            updated: vec![],
+        });
+
+        let delta = node.process(TupleDelta {
+            added: vec![tuples[3].clone()],
+            removed: vec![],
+            moved: vec![tuples[0].clone()],
+            updated: vec![],
+        });
+
+        assert!(delta.moved.is_empty());
+    }
+
+    #[test]
+    fn ordered_input_insert_does_not_mark_existing_as_moved() {
+        let mut node = make_limit_offset_node(None, 0);
+        let ids: Vec<_> = (0..4).map(|_| ObjectId::new()).collect();
+        let base: Vec<_> = ids
+            .iter()
+            .take(3)
+            .enumerate()
+            .map(|(i, id)| make_tuple(*id, i as i32, &format!("Row{}", i)))
+            .collect();
+
+        node.process_with_ordered_input(&base);
+
+        let inserted = make_tuple(ids[3], 99, "Inserted");
+        let delta = node.process_with_ordered_input(&[
+            inserted.clone(),
+            base[0].clone(),
+            base[1].clone(),
+            base[2].clone(),
+        ]);
+
+        assert_eq!(delta.added.len(), 1);
+        assert!(delta.removed.is_empty());
+        assert!(delta.moved.is_empty());
+    }
+
+    #[test]
+    fn ordered_input_remove_does_not_mark_following_as_moved() {
+        let mut node = make_limit_offset_node(None, 0);
+        let ids: Vec<_> = (0..4).map(|_| ObjectId::new()).collect();
+        let tuples: Vec<_> = ids
+            .iter()
+            .enumerate()
+            .map(|(i, id)| make_tuple(*id, i as i32, &format!("Row{}", i)))
+            .collect();
+
+        node.process_with_ordered_input(&tuples);
+
+        let delta = node.process_with_ordered_input(&[
+            tuples[0].clone(),
+            tuples[2].clone(),
+            tuples[3].clone(),
+        ]);
+
+        assert_eq!(delta.removed.len(), 1);
+        assert_eq!(delta.removed[0].first_id(), tuples[1].first_id());
+        assert!(delta.added.is_empty());
+        assert!(delta.moved.is_empty());
+    }
+
+    #[test]
+    fn ordered_input_rotation_marks_only_reordered_tuple_as_moved() {
+        let mut node = make_limit_offset_node(None, 0);
+        let ids: Vec<_> = (0..3).map(|_| ObjectId::new()).collect();
+        let tuples: Vec<_> = ids
+            .iter()
+            .enumerate()
+            .map(|(i, id)| make_tuple(*id, i as i32, &format!("Row{}", i)))
+            .collect();
+
+        node.process_with_ordered_input(&tuples);
+
+        let delta = node.process_with_ordered_input(&[
+            tuples[1].clone(),
+            tuples[2].clone(),
+            tuples[0].clone(),
+        ]);
+
+        assert!(delta.added.is_empty());
+        assert!(delta.removed.is_empty());
+        assert_eq!(delta.moved.len(), 1);
+        assert_eq!(delta.moved[0].first_id(), tuples[0].first_id());
     }
 }

--- a/crates/jazz-tools/src/query_manager/graph_nodes/mod.rs
+++ b/crates/jazz-tools/src/query_manager/graph_nodes/mod.rs
@@ -13,6 +13,7 @@ pub mod recursive_relation;
 pub mod select_element;
 pub mod sort;
 pub mod subgraph;
+pub mod tuple_delta;
 pub mod union;
 
 use ahash::AHashSet;

--- a/crates/jazz-tools/src/query_manager/graph_nodes/output.rs
+++ b/crates/jazz-tools/src/query_manager/graph_nodes/output.rs
@@ -2,10 +2,10 @@ use ahash::AHashSet;
 
 use crate::query_manager::encoding::decode_row;
 use crate::query_manager::types::{
-    Row, RowDelta, RowDescriptor, Tuple, TupleDelta, TupleDescriptor, TupleElement, Value,
+    Row, RowDelta, RowDescriptor, Tuple, TupleDelta, TupleDescriptor, Value,
 };
 
-use super::RowNode;
+use super::{RowNode, tuple_delta::compute_tuple_delta};
 
 /// Output mode for query results.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -98,55 +98,9 @@ impl OutputNode {
         &self.ordered_tuples
     }
 
-    fn compute_tuple_delta(&self, old_tuples: &[Tuple], new_tuples: &[Tuple]) -> TupleDelta {
-        let mut delta = TupleDelta::new();
-        let old_ids: std::collections::HashSet<Vec<crate::object::ObjectId>> =
-            old_tuples.iter().map(|t| t.ids()).collect();
-        let new_ids: std::collections::HashSet<Vec<crate::object::ObjectId>> =
-            new_tuples.iter().map(|t| t.ids()).collect();
-
-        for old in old_tuples {
-            if !new_ids.contains(&old.ids()) {
-                delta.removed.push(old.clone());
-            }
-        }
-
-        for new in new_tuples {
-            if !old_ids.contains(&new.ids()) {
-                delta.added.push(new.clone());
-            }
-        }
-
-        let old_pos: std::collections::HashMap<Vec<crate::object::ObjectId>, usize> = old_tuples
-            .iter()
-            .enumerate()
-            .map(|(idx, t)| (t.ids(), idx))
-            .collect();
-        for (new_idx, new_tuple) in new_tuples.iter().enumerate() {
-            let ids = new_tuple.ids();
-            if let Some(old_idx) = old_pos.get(&ids)
-                && old_idx != &new_idx
-            {
-                delta.moved.push(tuple_as_id_only(new_tuple));
-            }
-        }
-
-        for old in old_tuples {
-            if let Some(new) = new_tuples
-                .iter()
-                .find(|candidate| candidate.ids() == old.ids())
-                && has_tuple_content_changed(old, new)
-            {
-                delta.updated.push((old.clone(), new.clone()));
-            }
-        }
-
-        delta
-    }
-
     /// Rebuild ordered output from a full ordered upstream input.
     pub fn process_with_ordered_input(&mut self, ordered_tuples: &[Tuple]) -> TupleDelta {
-        let delta = self.compute_tuple_delta(&self.ordered_tuples, ordered_tuples);
+        let delta = compute_tuple_delta(&self.ordered_tuples, ordered_tuples);
 
         self.ordered_tuples = ordered_tuples.to_vec();
         self.current_tuples = self.ordered_tuples.iter().cloned().collect();
@@ -191,24 +145,6 @@ impl OutputNode {
                 .collect(),
         }
     }
-}
-
-fn has_tuple_content_changed(old: &Tuple, new: &Tuple) -> bool {
-    old.iter()
-        .zip(new.iter())
-        .any(|(o, n)| match (o.content(), n.content()) {
-            (Some(oc), Some(nc)) => oc != nc,
-            _ => false,
-        })
-}
-
-fn tuple_as_id_only(tuple: &Tuple) -> Tuple {
-    Tuple::new(
-        tuple
-            .iter()
-            .map(|elem| TupleElement::Id(elem.id()))
-            .collect(),
-    )
 }
 
 /// Decoded delta with Values instead of binary.
@@ -444,5 +380,79 @@ mod tests {
         let deltas = node.take_tuple_deltas();
         assert_eq!(deltas.len(), 1);
         assert_eq!(deltas[0].added.len(), 1);
+    }
+
+    #[test]
+    fn ordered_input_insert_does_not_mark_existing_as_moved() {
+        let mut node = make_output_node(OutputMode::Delta);
+        let ids: Vec<_> = (0..4).map(|_| ObjectId::new()).collect();
+        let base: Vec<_> = ids
+            .iter()
+            .take(3)
+            .enumerate()
+            .map(|(i, id)| make_tuple(*id, i as i32, &format!("Row{}", i)))
+            .collect();
+
+        node.process_with_ordered_input(&base);
+
+        let inserted = make_tuple(ids[3], 99, "Inserted");
+        let delta = node.process_with_ordered_input(&[
+            inserted.clone(),
+            base[0].clone(),
+            base[1].clone(),
+            base[2].clone(),
+        ]);
+
+        assert_eq!(delta.added.len(), 1);
+        assert!(delta.removed.is_empty());
+        assert!(delta.moved.is_empty());
+    }
+
+    #[test]
+    fn ordered_input_remove_does_not_mark_following_as_moved() {
+        let mut node = make_output_node(OutputMode::Delta);
+        let ids: Vec<_> = (0..4).map(|_| ObjectId::new()).collect();
+        let tuples: Vec<_> = ids
+            .iter()
+            .enumerate()
+            .map(|(i, id)| make_tuple(*id, i as i32, &format!("Row{}", i)))
+            .collect();
+
+        node.process_with_ordered_input(&tuples);
+
+        let delta = node.process_with_ordered_input(&[
+            tuples[0].clone(),
+            tuples[2].clone(),
+            tuples[3].clone(),
+        ]);
+
+        assert_eq!(delta.removed.len(), 1);
+        assert_eq!(delta.removed[0].first_id(), tuples[1].first_id());
+        assert!(delta.added.is_empty());
+        assert!(delta.moved.is_empty());
+    }
+
+    #[test]
+    fn ordered_input_rotation_marks_only_reordered_tuple_as_moved() {
+        let mut node = make_output_node(OutputMode::Delta);
+        let ids: Vec<_> = (0..3).map(|_| ObjectId::new()).collect();
+        let tuples: Vec<_> = ids
+            .iter()
+            .enumerate()
+            .map(|(i, id)| make_tuple(*id, i as i32, &format!("Row{}", i)))
+            .collect();
+
+        node.process_with_ordered_input(&tuples);
+
+        let delta = node.process_with_ordered_input(&[
+            tuples[1].clone(),
+            tuples[2].clone(),
+            tuples[0].clone(),
+        ]);
+
+        assert!(delta.added.is_empty());
+        assert!(delta.removed.is_empty());
+        assert_eq!(delta.moved.len(), 1);
+        assert_eq!(delta.moved[0].first_id(), tuples[0].first_id());
     }
 }

--- a/crates/jazz-tools/src/query_manager/graph_nodes/tuple_delta.rs
+++ b/crates/jazz-tools/src/query_manager/graph_nodes/tuple_delta.rs
@@ -1,0 +1,145 @@
+use std::collections::HashMap;
+
+use crate::query_manager::types::{Tuple, TupleDelta, TupleElement};
+
+pub(crate) fn compute_tuple_delta(old_tuples: &[Tuple], new_tuples: &[Tuple]) -> TupleDelta {
+    let mut delta = TupleDelta::new();
+    let old_ids: Vec<_> = old_tuples.iter().map(|t| t.ids()).collect();
+    let new_ids: Vec<_> = new_tuples.iter().map(|t| t.ids()).collect();
+    let old_pos_by_ids: HashMap<_, _> = old_ids
+        .iter()
+        .enumerate()
+        .map(|(idx, ids)| (ids.clone(), idx))
+        .collect();
+    let new_pos_by_ids: HashMap<_, _> = new_ids
+        .iter()
+        .enumerate()
+        .map(|(idx, ids)| (ids.clone(), idx))
+        .collect();
+
+    for (old, ids) in old_tuples.iter().zip(old_ids.iter()) {
+        if !new_pos_by_ids.contains_key(ids) {
+            delta.removed.push(old.clone());
+        }
+    }
+
+    for (new, ids) in new_tuples.iter().zip(new_ids.iter()) {
+        if !old_pos_by_ids.contains_key(ids) {
+            delta.added.push(new.clone());
+        }
+    }
+
+    let new_to_old_idx_mapping: Vec<_> = new_ids
+        .iter()
+        .enumerate()
+        .filter_map(|(new_idx, ids)| {
+            old_pos_by_ids
+                .get(ids)
+                .copied()
+                .map(|old_idx| (new_idx, old_idx))
+        })
+        .collect();
+    let old_idx_sequence: Vec<_> = new_to_old_idx_mapping
+        .iter()
+        .map(|(_, old_idx)| *old_idx)
+        .collect();
+    let lis_positions = lis_positions(&old_idx_sequence);
+    let mut keep = vec![false; old_idx_sequence.len()];
+    for pos in lis_positions {
+        keep[pos] = true;
+    }
+    for (i, (new_idx, _)) in new_to_old_idx_mapping.iter().enumerate() {
+        if !keep[i] {
+            delta.moved.push(tuple_as_id_only(&new_tuples[*new_idx]));
+        }
+    }
+
+    for (old, ids) in old_tuples.iter().zip(old_ids.iter()) {
+        if let Some(new_idx) = new_pos_by_ids.get(ids)
+            && has_tuple_content_changed(old, &new_tuples[*new_idx])
+        {
+            delta
+                .updated
+                .push((old.clone(), new_tuples[*new_idx].clone()));
+        }
+    }
+
+    delta
+}
+
+/// Returns the positions of the Longest Increasing Subsequence in the input sequence.
+/// This is the fastest way to find the positions of the moved tuples, in O(n log n) time.
+/// How it works:
+/// 1. Keep only IDs present in both old and new lists.
+/// 2. Replace each ID in new order with its position in the old order.
+/// 3. You get a number sequence.
+///   - If relative order is unchanged, sequence is increasing.
+///   - Reorders create decreases.
+/// 4. Find the Longest Increasing Subsequence (LIS) in that sequence.
+///    - LIS elements are the largest set you can keep "as is" without moving.
+/// 5. Mark IDs not in LIS as moved (in new order).
+///
+/// Example:
+/// old: [A, B, C, D]
+/// new: [B, C, A, D]
+/// old positions: A=0,B=1,C=2,D=3
+/// new mapped to old positions: [1,2,0,3]
+/// LIS is [1,2,3] => IDs [B,C,D] stay
+/// non-LIS is A => only A is moved
+/// Result: [B, C, D] are not moved, A is moved.
+fn lis_positions(sequence: &[usize]) -> Vec<usize> {
+    if sequence.is_empty() {
+        return Vec::new();
+    }
+
+    let mut tails_values: Vec<usize> = Vec::new();
+    let mut tails_indices: Vec<usize> = Vec::new();
+    let mut predecessors: Vec<Option<usize>> = vec![None; sequence.len()];
+
+    for (idx, &value) in sequence.iter().enumerate() {
+        let pos = match tails_values.binary_search(&value) {
+            Ok(pos) => pos,
+            Err(pos) => pos,
+        };
+
+        if pos > 0 {
+            predecessors[idx] = Some(tails_indices[pos - 1]);
+        }
+
+        if pos == tails_values.len() {
+            tails_values.push(value);
+            tails_indices.push(idx);
+        } else {
+            tails_values[pos] = value;
+            tails_indices[pos] = idx;
+        }
+    }
+
+    let mut lis = Vec::new();
+    let mut current = tails_indices.last().copied();
+    while let Some(idx) = current {
+        lis.push(idx);
+        current = predecessors[idx];
+    }
+    lis.reverse();
+    lis
+}
+
+fn tuple_as_id_only(tuple: &Tuple) -> Tuple {
+    Tuple::new(
+        tuple
+            .iter()
+            .map(|elem| TupleElement::Id(elem.id()))
+            .collect(),
+    )
+}
+
+/// Check if tuple content changed (for tuples with same IDs).
+fn has_tuple_content_changed(old: &Tuple, new: &Tuple) -> bool {
+    old.iter()
+        .zip(new.iter())
+        .any(|(o, n)| match (o.content(), n.content()) {
+            (Some(oc), Some(nc)) => oc != nc,
+            _ => false,
+        })
+}


### PR DESCRIPTION
## Motivation

This PR fixes spurious moved events in query result deltas by changing move detection from absolute index comparison to relative-order comparison among shared tuples.

Previously, adding/removing a tuple could shift indices and incorrectly mark many unaffected tuples as moved. Now, tuples are only marked as moved when their order changes relative to each other.

## Validation

Tested inserting an element after loading 10k rows.

### Before

[before.json.gz](https://github.com/user-attachments/files/25604382/before.json.gz)

Main thread:
<img width="1728" height="650" alt="before-main-thread" src="https://github.com/user-attachments/assets/f7e135b5-6a78-459d-b5dd-4b355c5d0b5e" />

Worker: 
<img width="1728" height="547" alt="before-worker" src="https://github.com/user-attachments/assets/c2f8a40a-e19e-40fc-a8d8-f8bfb5908b34" />

### After

[after.json.gz](https://github.com/user-attachments/files/25604389/after.json.gz)

Main thread:

<img width="1728" height="651" alt="after-main-thread" src="https://github.com/user-attachments/assets/64d53a68-a7a8-4500-88ea-1d9b4a029221" />

Worker:

<img width="1728" height="547" alt="after-worker" src="https://github.com/user-attachments/assets/c950ab71-c45f-4200-9262-f5d0879d309d" />
