### PR TITLE
fix: ensure query subgraphs share parent branch/schema context

### DIFF
--- a/.changeset/fix-subgraph-context.md
+++ b/.changeset/fix-subgraph-context.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+fix: ensure query subgraphs share branch and schema context of parent graph

--- a/crates/jazz-tools/src/query_manager/graph.rs
+++ b/crates/jazz-tools/src/query_manager/graph.rs
@@ -257,12 +257,38 @@ impl QueryGraph {
 
     /// Compile a query into a graph (without policy filtering).
     pub fn compile(query: &Query, schema: &Schema) -> Option<Self> {
-        Self::try_compile_with_session(query, schema, None).ok()
+        let schema_context = Self::default_schema_context(schema);
+        let mut query_with_default_branch = query.clone();
+        if query_with_default_branch.branches.is_empty() {
+            query_with_default_branch.branches.push("main".to_string());
+        }
+        Self::try_compile_with_schema_context(
+            &query_with_default_branch,
+            schema,
+            None,
+            &schema_context,
+        )
+        .ok()
     }
 
     /// Compile a query into a graph with typed errors (without policy filtering).
     pub fn try_compile(query: &Query, schema: &Schema) -> Result<Self, QueryCompileError> {
-        Self::try_compile_with_session(query, schema, None)
+        let schema_context = Self::default_schema_context(schema);
+        let mut query_with_default_branch = query.clone();
+        if query_with_default_branch.branches.is_empty() {
+            query_with_default_branch.branches.push("main".to_string());
+        }
+        Self::try_compile_with_schema_context(
+            &query_with_default_branch,
+            schema,
+            None,
+            &schema_context,
+        )
+    }
+
+    /// Legacy compile sites default to querying `main` without schema fan-out.
+    fn default_schema_context(schema: &Schema) -> SchemaContext {
+        SchemaContext::with_defaults(schema.clone(), "main")
     }
 
     /// Compile relation IR directly into a graph.
@@ -288,6 +314,12 @@ impl QueryGraph {
         session: Option<Session>,
         features: RelationCompileFeatures,
     ) -> Option<Self> {
+        let default_branches = vec!["main".to_string()];
+        let branches: &[String] = if branches.is_empty() {
+            &default_branches
+        } else {
+            branches
+        };
         let plan = lower_relation_to_execution_plan(
             relation,
             branches,
@@ -296,7 +328,8 @@ impl QueryGraph {
             features.select_columns,
         )?;
         validate_execution_plan(&plan, schema).ok()?;
-        Self::compile_execution_plan_with_session(&plan, schema, session)
+        let schema_context = Self::default_schema_context(schema);
+        Self::compile_execution_plan_with_schema_context(&plan, schema, session, &schema_context)
     }
 
     /// Compile relation IR directly into a graph with schema context.
@@ -336,234 +369,24 @@ impl QueryGraph {
         Self::compile_execution_plan_with_schema_context(&plan, schema, session, schema_context)
     }
 
-    fn compile_execution_plan_with_session(
-        plan: &ExecutionQueryPlan,
-        schema: &Schema,
-        session: Option<Session>,
-    ) -> Option<Self> {
-        // Get branches (default to "main" if not specified)
-        let default_branches = vec!["main".to_string()];
-        let branches: &[String] = if plan.branches.is_empty() {
-            &default_branches
-        } else {
-            &plan.branches
-        };
-
-        if !plan.joins.is_empty() {
-            return Self::compile_join_plan(plan, schema, branches, session.clone());
-        }
-
-        let table_schema = schema.get(&plan.table)?;
-        let descriptor = table_schema.descriptor.clone();
-        let select_policy = table_schema.policies.select.using.clone();
-        let mut graph = QueryGraph::new(plan.table, descriptor.clone());
-
-        // Phase 1: Build IndexScan nodes (one per disjunct per branch)
-        // For multi-branch queries, we create scans for each branch and union them
-        let mut phase1_outputs: Vec<NodeId> = Vec::new();
-        let mut index_columns: Vec<String> = Vec::new();
-
-        for branch in branches {
-            for disjunct in &plan.disjuncts {
-                // Find best index condition for this disjunct
-                let (scan_column, scan_condition) =
-                    if let Some(cond) = disjunct.best_index_condition() {
-                        let column = cond.column().to_string();
-                        let scan_cond = condition_to_scan(cond);
-                        (column, scan_cond)
-                    } else {
-                        // No index condition, use "_id" for full scan
-                        ("_id".to_string(), ScanCondition::All)
-                    };
-
-                index_columns.push(scan_column.clone());
-                let scan_column_name = ColumnName::new(&scan_column);
-
-                let scan_node = IndexScanNode::new_with_branch(
-                    plan.table,
-                    scan_column_name,
-                    branch,
-                    scan_condition,
-                    descriptor.clone(),
-                );
-                let scan_id = graph.add_node(GraphNode::IndexScan(scan_node));
-                graph
-                    .index_scan_nodes
-                    .push((scan_id, plan.table, scan_column_name));
-                phase1_outputs.push(scan_id);
-            }
-
-            // If include_deleted is set, also scan _id_deleted index for this branch
-            if plan.include_deleted {
-                let deleted_column = ColumnName::new("_id_deleted");
-                let deleted_scan_node = IndexScanNode::new_with_branch(
-                    plan.table,
-                    deleted_column,
-                    branch,
-                    ScanCondition::All,
-                    descriptor.clone(),
-                );
-                let deleted_scan_id = graph.add_node(GraphNode::IndexScan(deleted_scan_node));
-                graph
-                    .index_scan_nodes
-                    .push((deleted_scan_id, plan.table, deleted_column));
-                phase1_outputs.push(deleted_scan_id);
-            }
-        }
-
-        // If multiple outputs, add Union node
-        let phase1_output = if phase1_outputs.len() > 1 {
-            let union_node = UnionNode::new();
-            let union_id = graph.add_node(GraphNode::Union(union_node));
-            for scan_id in &phase1_outputs {
-                graph.add_edge(union_id, *scan_id);
-            }
-            union_id
-        } else if !phase1_outputs.is_empty() {
-            phase1_outputs[0]
-        } else {
-            return None;
-        };
-
-        // Materialize node (boundary between Phase 1 and Phase 2)
-        let tuple_desc = TupleDescriptor::single("", descriptor.clone());
-        let materialize_node = MaterializeNode::new_all(tuple_desc);
-        let materialize_id = graph.add_node(GraphNode::Materialize(materialize_node));
-        graph.add_edge(materialize_id, phase1_output);
-
-        let mut phase2_input = materialize_id;
-        let mut current_descriptor = descriptor.clone();
-
-        // Policy filter node (if session provided and table has SELECT policy)
-        if let (Some(session), Some(policy)) = (&session, select_policy) {
-            let branch_for_policy = branches
-                .first()
-                .cloned()
-                .unwrap_or_else(|| "main".to_string());
-            let policy_node = PolicyFilterNode::new_with_branch(
-                current_descriptor.clone(),
-                policy,
-                session.clone(),
-                schema.clone(),
-                plan.table.as_str(),
-                branch_for_policy,
-            );
-            let inherits_tables: Vec<TableName> = policy_node
-                .inherits_tables()
-                .iter()
-                .map(TableName::new)
-                .collect();
-            let policy_id = graph.add_node(GraphNode::PolicyFilter(policy_node));
-            graph.add_edge(policy_id, phase2_input);
-            for inherits_table in inherits_tables {
-                graph.policy_filter_tables.push((policy_id, inherits_table));
-            }
-            phase2_input = policy_id;
-        }
-
-        // Array subqueries: insert ArraySubqueryNode for each array subquery
-        for subquery_spec in &plan.array_subqueries {
-            if let Some((node, new_descriptor)) =
-                graph.compile_array_subquery(subquery_spec, &current_descriptor, schema, branches)
-            {
-                let node_id = graph.add_node(GraphNode::ArraySubquery(node));
-                graph.add_edge(node_id, phase2_input);
-                graph
-                    .array_subquery_tables
-                    .push((node_id, subquery_spec.table));
-                phase2_input = node_id;
-                current_descriptor = new_descriptor;
-            }
-        }
-
-        // Phase 2: Filter node (only if there are remaining conditions not covered by index)
-        let predicate = build_remaining_predicate_from_disjuncts(
-            &plan.disjuncts,
-            &index_columns,
-            &current_descriptor,
-        );
-        if !matches!(predicate, Predicate::True) {
-            let filter_tuple_desc =
-                TupleDescriptor::single_with_materialization("", current_descriptor.clone(), true);
-            let filter_node = FilterNode::with_tuple_descriptor(filter_tuple_desc, predicate);
-            let filter_id = graph.add_node(GraphNode::Filter(filter_node));
-            graph.add_edge(filter_id, phase2_input);
-            phase2_input = filter_id;
-        }
-
-        // Sort node (default: id ASC when order_by is omitted)
-        let sort_keys = sort_keys_from_order_by(&plan.order_by, &current_descriptor);
-        if !sort_keys.is_empty() {
-            let sort_tuple_desc =
-                TupleDescriptor::single_with_materialization("", current_descriptor.clone(), true);
-            let sort_node = SortNode::with_tuple_descriptor(sort_tuple_desc, sort_keys);
-            let sort_id = graph.add_node(GraphNode::Sort(sort_node));
-            graph.add_edge(sort_id, phase2_input);
-            phase2_input = sort_id;
-        }
-
-        // LimitOffset node (if limit or offset specified)
-        if plan.limit.is_some() || plan.offset > 0 {
-            let limit_tuple_desc =
-                TupleDescriptor::single_with_materialization("", current_descriptor.clone(), true);
-            let limit_offset_node =
-                LimitOffsetNode::with_tuple_descriptor(limit_tuple_desc, plan.limit, plan.offset);
-            let limit_offset_id = graph.add_node(GraphNode::LimitOffset(limit_offset_node));
-            graph.add_edge(limit_offset_id, phase2_input);
-            phase2_input = limit_offset_id;
-        }
-
-        // Project node (if select_columns specified)
-        if let Some(columns) = &plan.select_columns {
-            let col_refs: Vec<&str> = columns.iter().map(|s| s.as_str()).collect();
-            let project_node = ProjectNode::new(current_descriptor.clone(), &col_refs);
-            current_descriptor = project_node.output_descriptor().clone();
-            let project_id = graph.add_node(GraphNode::Project(project_node));
-            graph.add_edge(project_id, phase2_input);
-            phase2_input = project_id;
-        }
-
-        // Recursive relation expansion (if configured).
-        if let Some(recursive_spec) = &plan.recursive
-            && let Some((node, new_descriptor, step_table)) = graph.compile_recursive_relation(
-                recursive_spec,
-                &current_descriptor,
-                schema,
-                branches,
-            )
-        {
-            let node_id = graph.add_node(GraphNode::RecursiveRelation(node));
-            graph.add_edge(node_id, phase2_input);
-            graph.recursive_relation_tables.push((node_id, step_table));
-            phase2_input = node_id;
-            current_descriptor = new_descriptor;
-        }
-
-        // Output node
-        graph.combined_descriptor = current_descriptor.clone();
-        let output_tuple_desc =
-            TupleDescriptor::single_with_materialization("", current_descriptor, true);
-        let output_node = OutputNode::with_tuple_descriptor(output_tuple_desc, OutputMode::Delta);
-        let output_id = graph.add_node(GraphNode::Output(output_node));
-        graph.add_edge(output_id, phase2_input);
-        graph.output_node = output_id;
-
-        Some(graph)
-    }
-
     fn compile_execution_plan_with_schema_context(
         plan: &ExecutionQueryPlan,
         schema: &Schema,
         session: Option<Session>,
         schema_context: &SchemaContext,
     ) -> Option<Self> {
-        // Build branch -> schema hash map for column translation
+        // Build branch -> schema hash map for column translation.
+        // Use full hashes from SchemaContext (do not re-parse branch strings, which only encode
+        // a shortened hash prefix).
         let mut branch_schema_map: HashMap<String, SchemaHash> = HashMap::new();
-        for branch_name in schema_context.all_branch_names() {
-            let branch_str = branch_name.as_str().to_string();
-            if let Some(composed) = ComposedBranchName::parse(&branch_name) {
-                branch_schema_map.insert(branch_str, composed.schema_hash);
-            }
+        for schema_hash in schema_context.all_live_hashes() {
+            let branch_name = ComposedBranchName::new(
+                &schema_context.env,
+                schema_hash,
+                &schema_context.user_branch,
+            )
+            .to_branch_name();
+            branch_schema_map.insert(branch_name.as_str().to_string(), schema_hash);
         }
 
         // Expand branches to include all live schema branches if not specified
@@ -578,7 +401,13 @@ impl QueryGraph {
         };
 
         if !plan.joins.is_empty() {
-            return Self::compile_join_plan(plan, schema, &branches, session.clone());
+            return Self::compile_join_plan(
+                plan,
+                schema,
+                &branches,
+                session.clone(),
+                schema_context,
+            );
         }
 
         let table_schema = schema.get(&plan.table)?;
@@ -715,9 +544,13 @@ impl QueryGraph {
 
         // Array subqueries: insert ArraySubqueryNode for each array subquery
         for subquery_spec in &plan.array_subqueries {
-            if let Some((node, new_descriptor)) =
-                graph.compile_array_subquery(subquery_spec, &current_descriptor, schema, &branches)
-            {
+            if let Some((node, new_descriptor)) = graph.compile_array_subquery(
+                subquery_spec,
+                &current_descriptor,
+                schema,
+                &branches,
+                schema_context,
+            ) {
                 let node_id = graph.add_node(GraphNode::ArraySubquery(node));
                 graph.add_edge(node_id, phase2_input);
                 graph
@@ -782,6 +615,7 @@ impl QueryGraph {
                 &current_descriptor,
                 schema,
                 &branches,
+                schema_context,
             )
         {
             let node_id = graph.add_node(GraphNode::RecursiveRelation(node));
@@ -801,56 +635,6 @@ impl QueryGraph {
         graph.output_node = output_id;
 
         Some(graph)
-    }
-
-    /// Compile a query into a graph with optional session-based policy filtering.
-    ///
-    /// When a session is provided and the table has a SELECT policy, a PolicyFilterNode
-    /// is inserted after materialization to filter rows based on the policy.
-    pub fn compile_with_session(
-        query: &Query,
-        schema: &Schema,
-        session: Option<Session>,
-    ) -> Option<Self> {
-        Self::try_compile_with_session(query, schema, session).ok()
-    }
-
-    /// Compile a query into a graph with optional session-based policy filtering.
-    ///
-    /// Returns a typed error instead of collapsing failures into `None`.
-    pub fn try_compile_with_session(
-        query: &Query,
-        schema: &Schema,
-        session: Option<Session>,
-    ) -> Result<Self, QueryCompileError> {
-        let default_branches = vec!["main".to_string()];
-        let branches: &[String] = if query.branches.is_empty() {
-            &default_branches
-        } else {
-            &query.branches
-        };
-        ensure_relation_tables_exist(&query.relation_ir, schema)?;
-
-        let plan = lower_relation_to_execution_plan(
-            &query.relation_ir,
-            branches,
-            query.include_deleted,
-            query.array_subqueries.clone(),
-            query.select_columns.clone(),
-        )
-        .ok_or_else(|| {
-            QueryCompileError::InvalidPlan(
-                "unsupported relation_ir shape for query graph compilation".to_string(),
-            )
-        })?;
-
-        validate_execution_plan(&plan, schema)?;
-
-        Self::compile_execution_plan_with_session(&plan, schema, session).ok_or_else(|| {
-            QueryCompileError::InvalidPlan(
-                "unsupported relation_ir shape for query graph compilation".to_string(),
-            )
-        })
     }
 
     /// Compile a query with schema context for multi-schema queries.
@@ -920,6 +704,7 @@ impl QueryGraph {
         outer_descriptor: &RowDescriptor,
         schema: &Schema,
         branches: &[String],
+        schema_context: &SchemaContext,
     ) -> Option<(ArraySubqueryNode, RowDescriptor)> {
         // Get inner table descriptor
         let inner_descriptor = schema.get(&spec.table)?.descriptor.clone();
@@ -1014,6 +799,7 @@ impl QueryGraph {
             spec.inner_column.clone(),
             spec.select_columns.clone().unwrap_or_default(),
             inner_output_descriptor,
+            schema_context.clone(),
         );
 
         // Create outer tuple descriptor
@@ -1079,6 +865,7 @@ impl QueryGraph {
         current_descriptor: &RowDescriptor,
         schema: &Schema,
         branches: &[String],
+        schema_context: &SchemaContext,
     ) -> Option<(RecursiveRelationNode, RowDescriptor, TableName)> {
         let step_table_schema = schema.get(&spec.table)?;
         let step_table_descriptor = step_table_schema.descriptor.clone();
@@ -1176,6 +963,7 @@ impl QueryGraph {
             spec.inner_column.clone(),
             spec.select_columns.clone().unwrap_or_default(),
             step_output_descriptor,
+            schema_context.clone(),
         );
 
         let input_descriptor =
@@ -1198,6 +986,7 @@ impl QueryGraph {
         schema: &Schema,
         branches: &[String],
         session: Option<Session>,
+        schema_context: &SchemaContext,
     ) -> Option<Self> {
         let base_table_schema = schema.get(&plan.table)?;
         let base_descriptor = base_table_schema.descriptor.clone();
@@ -1284,8 +1073,13 @@ impl QueryGraph {
         let mut left_descriptor = base_descriptor.clone();
 
         if let Some(recursive_spec) = &plan.recursive
-            && let Some((node, new_descriptor, step_table)) =
-                graph.compile_recursive_relation(recursive_spec, &left_descriptor, schema, branches)
+            && let Some((node, new_descriptor, step_table)) = graph.compile_recursive_relation(
+                recursive_spec,
+                &left_descriptor,
+                schema,
+                branches,
+                schema_context,
+            )
         {
             let node_id = graph.add_node(GraphNode::RecursiveRelation(node));
             graph.add_edge(node_id, left_id);

--- a/crates/jazz-tools/src/query_manager/graph_nodes/subgraph.rs
+++ b/crates/jazz-tools/src/query_manager/graph_nodes/subgraph.rs
@@ -7,6 +7,7 @@
 use crate::query_manager::graph::QueryGraph;
 use crate::query_manager::query::{Query, QueryBuilder};
 use crate::query_manager::types::{RowDescriptor, Schema, Value};
+use crate::schema_manager::SchemaContext;
 
 /// Template for creating subgraph instances.
 ///
@@ -24,6 +25,8 @@ pub struct SubgraphTemplate {
     select_columns: Vec<String>,
     /// Output descriptor for individual result rows.
     output_descriptor: RowDescriptor,
+    /// Schema context inherited from the parent graph compile.
+    schema_context: SchemaContext,
 }
 
 impl SubgraphTemplate {
@@ -39,12 +42,14 @@ impl SubgraphTemplate {
         inner_column: String,
         select_columns: Vec<String>,
         output_descriptor: RowDescriptor,
+        schema_context: SchemaContext,
     ) -> Self {
         Self {
             base_query,
             inner_column,
             select_columns,
             output_descriptor,
+            schema_context,
         }
     }
 
@@ -59,7 +64,11 @@ impl SubgraphTemplate {
     ) -> Option<SubgraphInstance> {
         // Build query with correlation filter
         let mut query_builder = QueryBuilder::new(self.base_query.table);
-        query_builder = query_builder.branches_owned(self.base_query.branches.clone());
+        if self.base_query.branches.is_empty() {
+            query_builder = query_builder.branch("main");
+        } else {
+            query_builder = query_builder.branches_owned(self.base_query.branches.clone());
+        }
         if self.base_query.include_deleted {
             query_builder = query_builder.include_deleted();
         }
@@ -149,7 +158,9 @@ impl SubgraphTemplate {
         }
 
         let query = query_builder.try_build().ok()?;
-        let graph = QueryGraph::try_compile(&query, schema).ok()?;
+        let graph =
+            QueryGraph::try_compile_with_schema_context(&query, schema, None, &self.schema_context)
+                .ok()?;
 
         Some(SubgraphInstance {
             graph,
@@ -304,6 +315,7 @@ impl SubgraphBuilder {
             self.inner_column,
             self.select_columns,
             output_descriptor,
+            SchemaContext::with_defaults(schema.clone(), "main"),
         ))
     }
 }
@@ -313,7 +325,11 @@ mod tests {
     use std::collections::HashMap;
 
     use super::*;
+    use crate::query_manager::graph::GraphNode;
+    use crate::query_manager::query::QueryBuilder;
     use crate::query_manager::types::{ColumnDescriptor, ColumnType, TableName};
+    use crate::query_manager::types::{ComposedBranchName, SchemaBuilder, SchemaHash, TableSchema};
+    use crate::schema_manager::{Lens, LensOp, LensTransform};
 
     fn test_schema() -> Schema {
         let mut schema = HashMap::new();
@@ -387,6 +403,84 @@ mod tests {
         assert_eq!(
             array,
             Value::Array(vec![Value::Integer(10), Value::Integer(20)])
+        );
+    }
+
+    #[test]
+    fn subgraph_template_inherits_parent_schema_and_branch_context() {
+        let v1 = SchemaBuilder::new()
+            .table(
+                TableSchema::builder("users")
+                    .column("id", ColumnType::Integer)
+                    .column("email", ColumnType::Text),
+            )
+            .build();
+        let v2 = SchemaBuilder::new()
+            .table(
+                TableSchema::builder("users")
+                    .column("id", ColumnType::Integer)
+                    .column("email_address", ColumnType::Text),
+            )
+            .build();
+
+        let v1_hash = SchemaHash::compute(&v1);
+        let v2_hash = SchemaHash::compute(&v2);
+
+        let mut transform = LensTransform::new();
+        transform.push(
+            LensOp::RenameColumn {
+                table: "users".to_string(),
+                old_name: "email".to_string(),
+                new_name: "email_address".to_string(),
+            },
+            false,
+        );
+        let lens = Lens::new(v1_hash, v2_hash, transform);
+
+        let mut schema_context = SchemaContext::new(v2.clone(), "dev", "main");
+        schema_context.add_live_schema(v1.clone(), lens);
+
+        let v1_branch = ComposedBranchName::new("dev", v1_hash, "main")
+            .to_branch_name()
+            .as_str()
+            .to_string();
+
+        let base_query = QueryBuilder::new("users")
+            .branches(&[v1_branch.as_str()])
+            .build();
+        let output_descriptor = v2.get(&TableName::new("users")).unwrap().descriptor.clone();
+        let template = SubgraphTemplate::new(
+            base_query,
+            "email_address".to_string(),
+            Vec::new(),
+            output_descriptor,
+            schema_context,
+        );
+
+        let instance = template
+            .instantiate(Value::Text("alice@example.com".to_string()), &v2)
+            .expect("subgraph should compile using inherited schema context");
+        assert_eq!(instance.graph.index_scan_nodes.len(), 1);
+
+        let (scan_id, _table, scan_column) = &instance.graph.index_scan_nodes[0];
+        assert_eq!(
+            scan_column.as_str(),
+            "email",
+            "index lookup should translate new column name to old-branch index column"
+        );
+
+        let scan_branch = instance
+            .graph
+            .nodes
+            .get(scan_id.0 as usize)
+            .and_then(|ctx| match &ctx.node {
+                GraphNode::IndexScan(scan) => Some(scan.branch.as_str()),
+                _ => None,
+            })
+            .expect("index scan node must exist");
+        assert_eq!(
+            scan_branch, v1_branch,
+            "subgraph should keep the parent branch list when instantiating"
         );
     }
 }

--- a/crates/jazz-tools/src/query_manager/policy_graph.rs
+++ b/crates/jazz-tools/src/query_manager/policy_graph.rs
@@ -8,6 +8,8 @@ use crate::object::ObjectId;
 
 use crate::storage::Storage;
 
+use crate::schema_manager::SchemaContext;
+
 use super::graph::{GraphNode, QueryGraph};
 use super::graph_nodes::NodeId;
 use super::graph_nodes::exists_output::ExistsOutputNode;
@@ -208,7 +210,14 @@ impl PolicyGraph {
         branch: &str,
     ) -> Option<Self> {
         let branches = vec![branch.to_string()];
-        let mut graph = QueryGraph::compile_relation_ir(rel, schema, &branches, None)?;
+        let schema_context = SchemaContext::with_defaults(schema.clone(), "main");
+        let mut graph = QueryGraph::compile_relation_ir_with_schema_context(
+            rel,
+            schema,
+            &branches,
+            None,
+            &schema_context,
+        )?;
         let output_descriptor = match graph
             .nodes
             .get(graph.output_node.0 as usize)


### PR DESCRIPTION
## Summary
- remove `with_session` query-graph compile paths and standardize on schema-context compilation
- ensure array and recursive subgraphs inherit the parent graph's `SchemaContext` and branch list during instantiation
- thread `SchemaContext` through subgraph template construction sites (including recursive in join plans)
- fix branch-to-schema-hash mapping in query-plan compilation to use full hashes from `SchemaContext`
- add a regression test proving subgraph instantiation keeps the parent branch and performs old-schema index-column translation
- add patch changeset: `fix: ensure query subgraphs share branch and schema context of parent graph`

## Validation
- `cargo fmt`
- `pnpm dlx oxfmt --ignore-path .oxfmtignore .`
- `pnpm dlx oxlint . --ignore-path .oxlintignore`
- `cargo clippy --workspace -- -D warnings`
- `cargo test -p jazz-tools --no-run`
- `cargo test -p jazz-tools subgraph_template_inherits_parent_schema_and_branch_context -- --nocapture`
- `cargo test -p jazz-tools end_to_end_column_rename_index_translation -- --nocapture`
- `cargo test -p jazz-tools query_manager::graph::tests:: -- --nocapture`
- `cargo test -p jazz-tools query_manager::policy_graph::tests:: -- --nocapture`

## Notes
- `oxlint` reports existing warnings in unrelated files (examples/packages); no new lint errors were introduced by this change
