### PR TITLE
Fix preview permissions for reusable publish workflow gate

### DIFF
--- a/.github/workflows/preview-jazz-tools-alpha-release.yml
+++ b/.github/workflows/preview-jazz-tools-alpha-release.yml
@@ -13,6 +13,7 @@ concurrency:
 permissions:
   contents: read
   id-token: write
+  pull-requests: read
   statuses: write
 
 jobs:


### PR DESCRIPTION
## Summary
- add `pull-requests: read` to `preview-jazz-tools-alpha-release.yml` permissions

## Why
- `publish-jazz-tools-alpha.yml` now has a `release-push-gate` job that requests `pull-requests: read`
- when preview calls that reusable workflow, the caller must allow that permission or workflow validation fails
