### PR TITLE
chore(changeset): patch release note for Next.js wasm fix

### DIFF
--- a/.changeset/quick-days-jam.md
+++ b/.changeset/quick-days-jam.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Fix WebAssembly fetch behavior in Next.js runtimes.


### PR DESCRIPTION
## Summary
- add a patch changeset for `jazz-tools` covering the Next.js wasm fetch fix from #170
- this should cause changesets automation to open a new `changeset-release/*` PR after merge

## Included changeset
- `.changeset/quick-days-jam.md`

## Validation
- `pnpm format`
