### PR TITLE
codegen: fix nested include optional-selector never[] collapse

### DIFF
--- a/.changeset/tidy-points-guess.md
+++ b/.changeset/tidy-points-guess.md
@@ -4,4 +4,4 @@
 
 Tighten generated query helper and include types for stronger inference and stricter contracts.
 
-This preserves include-aware returned row types by keeping `QueryBuilder<...WithIncludes<I>>` / `_rowType` aligned with selected includes, narrows generated `*Include` relation flags to `true` (instead of `boolean`), tightens `gather(...)` step callback typing, and removes unnecessary `unknown` casts in generated include helpers.
+This preserves include-aware returned row types by keeping `QueryBuilder<...WithIncludes<I>>` / `_rowType` aligned with selected includes, narrows generated `*Include` relation flags to `true` (instead of `boolean`), tightens `gather(...)` step callback typing, avoids optional-include selector collapse to `never` in nested array includes, and removes unnecessary `unknown` casts in generated include helpers.

--- a/examples/docs/todo-client-localfirst-expo/schema/app.ts
+++ b/examples/docs/todo-client-localfirst-expo/schema/app.ts
@@ -72,37 +72,45 @@ export interface TodoRelations {
 }
 
 export type ProjectWithIncludes<I extends ProjectInclude = {}> = Project & {
-  todosViaProject?: I["todosViaProject"] extends true
-    ? Todo[]
-    : I["todosViaProject"] extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
-      ? TodoWithIncludes<QueryInclude>[]
-      : I["todosViaProject"] extends TodoInclude
-        ? TodoWithIncludes<I["todosViaProject"]>[]
-        : never;
+  todosViaProject?: NonNullable<I["todosViaProject"]> extends infer RelationInclude
+    ? RelationInclude extends true
+      ? Todo[]
+      : RelationInclude extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
+        ? TodoWithIncludes<QueryInclude>[]
+        : RelationInclude extends TodoInclude
+          ? TodoWithIncludes<RelationInclude>[]
+          : never
+    : never;
 };
 
 export type TodoWithIncludes<I extends TodoInclude = {}> = Todo & {
-  parent?: I["parent"] extends true
-    ? Todo
-    : I["parent"] extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
-      ? TodoWithIncludes<QueryInclude>
-      : I["parent"] extends TodoInclude
-        ? TodoWithIncludes<I["parent"]>
-        : never;
-  todosViaParent?: I["todosViaParent"] extends true
-    ? Todo[]
-    : I["todosViaParent"] extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
-      ? TodoWithIncludes<QueryInclude>[]
-      : I["todosViaParent"] extends TodoInclude
-        ? TodoWithIncludes<I["todosViaParent"]>[]
-        : never;
-  project?: I["project"] extends true
-    ? Project
-    : I["project"] extends ProjectQueryBuilder<infer QueryInclude extends ProjectInclude>
-      ? ProjectWithIncludes<QueryInclude>
-      : I["project"] extends ProjectInclude
-        ? ProjectWithIncludes<I["project"]>
-        : never;
+  parent?: NonNullable<I["parent"]> extends infer RelationInclude
+    ? RelationInclude extends true
+      ? Todo
+      : RelationInclude extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
+        ? TodoWithIncludes<QueryInclude>
+        : RelationInclude extends TodoInclude
+          ? TodoWithIncludes<RelationInclude>
+          : never
+    : never;
+  todosViaParent?: NonNullable<I["todosViaParent"]> extends infer RelationInclude
+    ? RelationInclude extends true
+      ? Todo[]
+      : RelationInclude extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
+        ? TodoWithIncludes<QueryInclude>[]
+        : RelationInclude extends TodoInclude
+          ? TodoWithIncludes<RelationInclude>[]
+          : never
+    : never;
+  project?: NonNullable<I["project"]> extends infer RelationInclude
+    ? RelationInclude extends true
+      ? Project
+      : RelationInclude extends ProjectQueryBuilder<infer QueryInclude extends ProjectInclude>
+        ? ProjectWithIncludes<QueryInclude>
+        : RelationInclude extends ProjectInclude
+          ? ProjectWithIncludes<RelationInclude>
+          : never
+    : never;
 };
 
 export const wasmSchema: WasmSchema = {

--- a/examples/docs/todo-client-localfirst-react/schema/app.ts
+++ b/examples/docs/todo-client-localfirst-react/schema/app.ts
@@ -69,37 +69,45 @@ export interface TodoRelations {
 }
 
 export type ProjectWithIncludes<I extends ProjectInclude = {}> = Project & {
-  todosViaProject?: I["todosViaProject"] extends true
-    ? Todo[]
-    : I["todosViaProject"] extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
-      ? TodoWithIncludes<QueryInclude>[]
-      : I["todosViaProject"] extends TodoInclude
-        ? TodoWithIncludes<I["todosViaProject"]>[]
-        : never;
+  todosViaProject?: NonNullable<I["todosViaProject"]> extends infer RelationInclude
+    ? RelationInclude extends true
+      ? Todo[]
+      : RelationInclude extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
+        ? TodoWithIncludes<QueryInclude>[]
+        : RelationInclude extends TodoInclude
+          ? TodoWithIncludes<RelationInclude>[]
+          : never
+    : never;
 };
 
 export type TodoWithIncludes<I extends TodoInclude = {}> = Todo & {
-  parent?: I["parent"] extends true
-    ? Todo
-    : I["parent"] extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
-      ? TodoWithIncludes<QueryInclude>
-      : I["parent"] extends TodoInclude
-        ? TodoWithIncludes<I["parent"]>
-        : never;
-  todosViaParent?: I["todosViaParent"] extends true
-    ? Todo[]
-    : I["todosViaParent"] extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
-      ? TodoWithIncludes<QueryInclude>[]
-      : I["todosViaParent"] extends TodoInclude
-        ? TodoWithIncludes<I["todosViaParent"]>[]
-        : never;
-  project?: I["project"] extends true
-    ? Project
-    : I["project"] extends ProjectQueryBuilder<infer QueryInclude extends ProjectInclude>
-      ? ProjectWithIncludes<QueryInclude>
-      : I["project"] extends ProjectInclude
-        ? ProjectWithIncludes<I["project"]>
-        : never;
+  parent?: NonNullable<I["parent"]> extends infer RelationInclude
+    ? RelationInclude extends true
+      ? Todo
+      : RelationInclude extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
+        ? TodoWithIncludes<QueryInclude>
+        : RelationInclude extends TodoInclude
+          ? TodoWithIncludes<RelationInclude>
+          : never
+    : never;
+  todosViaParent?: NonNullable<I["todosViaParent"]> extends infer RelationInclude
+    ? RelationInclude extends true
+      ? Todo[]
+      : RelationInclude extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
+        ? TodoWithIncludes<QueryInclude>[]
+        : RelationInclude extends TodoInclude
+          ? TodoWithIncludes<RelationInclude>[]
+          : never
+    : never;
+  project?: NonNullable<I["project"]> extends infer RelationInclude
+    ? RelationInclude extends true
+      ? Project
+      : RelationInclude extends ProjectQueryBuilder<infer QueryInclude extends ProjectInclude>
+        ? ProjectWithIncludes<QueryInclude>
+        : RelationInclude extends ProjectInclude
+          ? ProjectWithIncludes<RelationInclude>
+          : never
+    : never;
 };
 
 export const wasmSchema: WasmSchema = {

--- a/examples/docs/todo-client-localfirst-svelte/schema/app.ts
+++ b/examples/docs/todo-client-localfirst-svelte/schema/app.ts
@@ -69,37 +69,45 @@ export interface TodoRelations {
 }
 
 export type ProjectWithIncludes<I extends ProjectInclude = {}> = Project & {
-  todosViaProject?: I["todosViaProject"] extends true
-    ? Todo[]
-    : I["todosViaProject"] extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
-      ? TodoWithIncludes<QueryInclude>[]
-      : I["todosViaProject"] extends TodoInclude
-        ? TodoWithIncludes<I["todosViaProject"]>[]
-        : never;
+  todosViaProject?: NonNullable<I["todosViaProject"]> extends infer RelationInclude
+    ? RelationInclude extends true
+      ? Todo[]
+      : RelationInclude extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
+        ? TodoWithIncludes<QueryInclude>[]
+        : RelationInclude extends TodoInclude
+          ? TodoWithIncludes<RelationInclude>[]
+          : never
+    : never;
 };
 
 export type TodoWithIncludes<I extends TodoInclude = {}> = Todo & {
-  parent?: I["parent"] extends true
-    ? Todo
-    : I["parent"] extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
-      ? TodoWithIncludes<QueryInclude>
-      : I["parent"] extends TodoInclude
-        ? TodoWithIncludes<I["parent"]>
-        : never;
-  todosViaParent?: I["todosViaParent"] extends true
-    ? Todo[]
-    : I["todosViaParent"] extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
-      ? TodoWithIncludes<QueryInclude>[]
-      : I["todosViaParent"] extends TodoInclude
-        ? TodoWithIncludes<I["todosViaParent"]>[]
-        : never;
-  project?: I["project"] extends true
-    ? Project
-    : I["project"] extends ProjectQueryBuilder<infer QueryInclude extends ProjectInclude>
-      ? ProjectWithIncludes<QueryInclude>
-      : I["project"] extends ProjectInclude
-        ? ProjectWithIncludes<I["project"]>
-        : never;
+  parent?: NonNullable<I["parent"]> extends infer RelationInclude
+    ? RelationInclude extends true
+      ? Todo
+      : RelationInclude extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
+        ? TodoWithIncludes<QueryInclude>
+        : RelationInclude extends TodoInclude
+          ? TodoWithIncludes<RelationInclude>
+          : never
+    : never;
+  todosViaParent?: NonNullable<I["todosViaParent"]> extends infer RelationInclude
+    ? RelationInclude extends true
+      ? Todo[]
+      : RelationInclude extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
+        ? TodoWithIncludes<QueryInclude>[]
+        : RelationInclude extends TodoInclude
+          ? TodoWithIncludes<RelationInclude>[]
+          : never
+    : never;
+  project?: NonNullable<I["project"]> extends infer RelationInclude
+    ? RelationInclude extends true
+      ? Project
+      : RelationInclude extends ProjectQueryBuilder<infer QueryInclude extends ProjectInclude>
+        ? ProjectWithIncludes<QueryInclude>
+        : RelationInclude extends ProjectInclude
+          ? ProjectWithIncludes<RelationInclude>
+          : never
+    : never;
 };
 
 export const wasmSchema: WasmSchema = {

--- a/examples/docs/todo-client-localfirst-ts/schema/app.ts
+++ b/examples/docs/todo-client-localfirst-ts/schema/app.ts
@@ -69,37 +69,45 @@ export interface TodoRelations {
 }
 
 export type ProjectWithIncludes<I extends ProjectInclude = {}> = Project & {
-  todosViaProject?: I["todosViaProject"] extends true
-    ? Todo[]
-    : I["todosViaProject"] extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
-      ? TodoWithIncludes<QueryInclude>[]
-      : I["todosViaProject"] extends TodoInclude
-        ? TodoWithIncludes<I["todosViaProject"]>[]
-        : never;
+  todosViaProject?: NonNullable<I["todosViaProject"]> extends infer RelationInclude
+    ? RelationInclude extends true
+      ? Todo[]
+      : RelationInclude extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
+        ? TodoWithIncludes<QueryInclude>[]
+        : RelationInclude extends TodoInclude
+          ? TodoWithIncludes<RelationInclude>[]
+          : never
+    : never;
 };
 
 export type TodoWithIncludes<I extends TodoInclude = {}> = Todo & {
-  parent?: I["parent"] extends true
-    ? Todo
-    : I["parent"] extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
-      ? TodoWithIncludes<QueryInclude>
-      : I["parent"] extends TodoInclude
-        ? TodoWithIncludes<I["parent"]>
-        : never;
-  todosViaParent?: I["todosViaParent"] extends true
-    ? Todo[]
-    : I["todosViaParent"] extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
-      ? TodoWithIncludes<QueryInclude>[]
-      : I["todosViaParent"] extends TodoInclude
-        ? TodoWithIncludes<I["todosViaParent"]>[]
-        : never;
-  project?: I["project"] extends true
-    ? Project
-    : I["project"] extends ProjectQueryBuilder<infer QueryInclude extends ProjectInclude>
-      ? ProjectWithIncludes<QueryInclude>
-      : I["project"] extends ProjectInclude
-        ? ProjectWithIncludes<I["project"]>
-        : never;
+  parent?: NonNullable<I["parent"]> extends infer RelationInclude
+    ? RelationInclude extends true
+      ? Todo
+      : RelationInclude extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
+        ? TodoWithIncludes<QueryInclude>
+        : RelationInclude extends TodoInclude
+          ? TodoWithIncludes<RelationInclude>
+          : never
+    : never;
+  todosViaParent?: NonNullable<I["todosViaParent"]> extends infer RelationInclude
+    ? RelationInclude extends true
+      ? Todo[]
+      : RelationInclude extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
+        ? TodoWithIncludes<QueryInclude>[]
+        : RelationInclude extends TodoInclude
+          ? TodoWithIncludes<RelationInclude>[]
+          : never
+    : never;
+  project?: NonNullable<I["project"]> extends infer RelationInclude
+    ? RelationInclude extends true
+      ? Project
+      : RelationInclude extends ProjectQueryBuilder<infer QueryInclude extends ProjectInclude>
+        ? ProjectWithIncludes<QueryInclude>
+        : RelationInclude extends ProjectInclude
+          ? ProjectWithIncludes<RelationInclude>
+          : never
+    : never;
 };
 
 export const wasmSchema: WasmSchema = {

--- a/examples/docs/todo-server-ts/schema/app.ts
+++ b/examples/docs/todo-server-ts/schema/app.ts
@@ -72,37 +72,45 @@ export interface TodoRelations {
 }
 
 export type ProjectWithIncludes<I extends ProjectInclude = {}> = Project & {
-  todosViaProject?: I["todosViaProject"] extends true
-    ? Todo[]
-    : I["todosViaProject"] extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
-      ? TodoWithIncludes<QueryInclude>[]
-      : I["todosViaProject"] extends TodoInclude
-        ? TodoWithIncludes<I["todosViaProject"]>[]
-        : never;
+  todosViaProject?: NonNullable<I["todosViaProject"]> extends infer RelationInclude
+    ? RelationInclude extends true
+      ? Todo[]
+      : RelationInclude extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
+        ? TodoWithIncludes<QueryInclude>[]
+        : RelationInclude extends TodoInclude
+          ? TodoWithIncludes<RelationInclude>[]
+          : never
+    : never;
 };
 
 export type TodoWithIncludes<I extends TodoInclude = {}> = Todo & {
-  parent?: I["parent"] extends true
-    ? Todo
-    : I["parent"] extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
-      ? TodoWithIncludes<QueryInclude>
-      : I["parent"] extends TodoInclude
-        ? TodoWithIncludes<I["parent"]>
-        : never;
-  todosViaParent?: I["todosViaParent"] extends true
-    ? Todo[]
-    : I["todosViaParent"] extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
-      ? TodoWithIncludes<QueryInclude>[]
-      : I["todosViaParent"] extends TodoInclude
-        ? TodoWithIncludes<I["todosViaParent"]>[]
-        : never;
-  project?: I["project"] extends true
-    ? Project
-    : I["project"] extends ProjectQueryBuilder<infer QueryInclude extends ProjectInclude>
-      ? ProjectWithIncludes<QueryInclude>
-      : I["project"] extends ProjectInclude
-        ? ProjectWithIncludes<I["project"]>
-        : never;
+  parent?: NonNullable<I["parent"]> extends infer RelationInclude
+    ? RelationInclude extends true
+      ? Todo
+      : RelationInclude extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
+        ? TodoWithIncludes<QueryInclude>
+        : RelationInclude extends TodoInclude
+          ? TodoWithIncludes<RelationInclude>
+          : never
+    : never;
+  todosViaParent?: NonNullable<I["todosViaParent"]> extends infer RelationInclude
+    ? RelationInclude extends true
+      ? Todo[]
+      : RelationInclude extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
+        ? TodoWithIncludes<QueryInclude>[]
+        : RelationInclude extends TodoInclude
+          ? TodoWithIncludes<RelationInclude>[]
+          : never
+    : never;
+  project?: NonNullable<I["project"]> extends infer RelationInclude
+    ? RelationInclude extends true
+      ? Project
+      : RelationInclude extends ProjectQueryBuilder<infer QueryInclude extends ProjectInclude>
+        ? ProjectWithIncludes<QueryInclude>
+        : RelationInclude extends ProjectInclude
+          ? ProjectWithIncludes<RelationInclude>
+          : never
+    : never;
 };
 
 export const wasmSchema: WasmSchema = {

--- a/examples/todo-client-localfirst-expo/schema/app.ts
+++ b/examples/todo-client-localfirst-expo/schema/app.ts
@@ -72,37 +72,45 @@ export interface TodoRelations {
 }
 
 export type ProjectWithIncludes<I extends ProjectInclude = {}> = Project & {
-  todosViaProject?: I["todosViaProject"] extends true
-    ? Todo[]
-    : I["todosViaProject"] extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
-      ? TodoWithIncludes<QueryInclude>[]
-      : I["todosViaProject"] extends TodoInclude
-        ? TodoWithIncludes<I["todosViaProject"]>[]
-        : never;
+  todosViaProject?: NonNullable<I["todosViaProject"]> extends infer RelationInclude
+    ? RelationInclude extends true
+      ? Todo[]
+      : RelationInclude extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
+        ? TodoWithIncludes<QueryInclude>[]
+        : RelationInclude extends TodoInclude
+          ? TodoWithIncludes<RelationInclude>[]
+          : never
+    : never;
 };
 
 export type TodoWithIncludes<I extends TodoInclude = {}> = Todo & {
-  parent?: I["parent"] extends true
-    ? Todo
-    : I["parent"] extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
-      ? TodoWithIncludes<QueryInclude>
-      : I["parent"] extends TodoInclude
-        ? TodoWithIncludes<I["parent"]>
-        : never;
-  todosViaParent?: I["todosViaParent"] extends true
-    ? Todo[]
-    : I["todosViaParent"] extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
-      ? TodoWithIncludes<QueryInclude>[]
-      : I["todosViaParent"] extends TodoInclude
-        ? TodoWithIncludes<I["todosViaParent"]>[]
-        : never;
-  project?: I["project"] extends true
-    ? Project
-    : I["project"] extends ProjectQueryBuilder<infer QueryInclude extends ProjectInclude>
-      ? ProjectWithIncludes<QueryInclude>
-      : I["project"] extends ProjectInclude
-        ? ProjectWithIncludes<I["project"]>
-        : never;
+  parent?: NonNullable<I["parent"]> extends infer RelationInclude
+    ? RelationInclude extends true
+      ? Todo
+      : RelationInclude extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
+        ? TodoWithIncludes<QueryInclude>
+        : RelationInclude extends TodoInclude
+          ? TodoWithIncludes<RelationInclude>
+          : never
+    : never;
+  todosViaParent?: NonNullable<I["todosViaParent"]> extends infer RelationInclude
+    ? RelationInclude extends true
+      ? Todo[]
+      : RelationInclude extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
+        ? TodoWithIncludes<QueryInclude>[]
+        : RelationInclude extends TodoInclude
+          ? TodoWithIncludes<RelationInclude>[]
+          : never
+    : never;
+  project?: NonNullable<I["project"]> extends infer RelationInclude
+    ? RelationInclude extends true
+      ? Project
+      : RelationInclude extends ProjectQueryBuilder<infer QueryInclude extends ProjectInclude>
+        ? ProjectWithIncludes<QueryInclude>
+        : RelationInclude extends ProjectInclude
+          ? ProjectWithIncludes<RelationInclude>
+          : never
+    : never;
 };
 
 export const wasmSchema: WasmSchema = {

--- a/examples/todo-client-localfirst-react/schema/app.ts
+++ b/examples/todo-client-localfirst-react/schema/app.ts
@@ -72,37 +72,45 @@ export interface TodoRelations {
 }
 
 export type ProjectWithIncludes<I extends ProjectInclude = {}> = Project & {
-  todosViaProject?: I["todosViaProject"] extends true
-    ? Todo[]
-    : I["todosViaProject"] extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
-      ? TodoWithIncludes<QueryInclude>[]
-      : I["todosViaProject"] extends TodoInclude
-        ? TodoWithIncludes<I["todosViaProject"]>[]
-        : never;
+  todosViaProject?: NonNullable<I["todosViaProject"]> extends infer RelationInclude
+    ? RelationInclude extends true
+      ? Todo[]
+      : RelationInclude extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
+        ? TodoWithIncludes<QueryInclude>[]
+        : RelationInclude extends TodoInclude
+          ? TodoWithIncludes<RelationInclude>[]
+          : never
+    : never;
 };
 
 export type TodoWithIncludes<I extends TodoInclude = {}> = Todo & {
-  parent?: I["parent"] extends true
-    ? Todo
-    : I["parent"] extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
-      ? TodoWithIncludes<QueryInclude>
-      : I["parent"] extends TodoInclude
-        ? TodoWithIncludes<I["parent"]>
-        : never;
-  todosViaParent?: I["todosViaParent"] extends true
-    ? Todo[]
-    : I["todosViaParent"] extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
-      ? TodoWithIncludes<QueryInclude>[]
-      : I["todosViaParent"] extends TodoInclude
-        ? TodoWithIncludes<I["todosViaParent"]>[]
-        : never;
-  project?: I["project"] extends true
-    ? Project
-    : I["project"] extends ProjectQueryBuilder<infer QueryInclude extends ProjectInclude>
-      ? ProjectWithIncludes<QueryInclude>
-      : I["project"] extends ProjectInclude
-        ? ProjectWithIncludes<I["project"]>
-        : never;
+  parent?: NonNullable<I["parent"]> extends infer RelationInclude
+    ? RelationInclude extends true
+      ? Todo
+      : RelationInclude extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
+        ? TodoWithIncludes<QueryInclude>
+        : RelationInclude extends TodoInclude
+          ? TodoWithIncludes<RelationInclude>
+          : never
+    : never;
+  todosViaParent?: NonNullable<I["todosViaParent"]> extends infer RelationInclude
+    ? RelationInclude extends true
+      ? Todo[]
+      : RelationInclude extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
+        ? TodoWithIncludes<QueryInclude>[]
+        : RelationInclude extends TodoInclude
+          ? TodoWithIncludes<RelationInclude>[]
+          : never
+    : never;
+  project?: NonNullable<I["project"]> extends infer RelationInclude
+    ? RelationInclude extends true
+      ? Project
+      : RelationInclude extends ProjectQueryBuilder<infer QueryInclude extends ProjectInclude>
+        ? ProjectWithIncludes<QueryInclude>
+        : RelationInclude extends ProjectInclude
+          ? ProjectWithIncludes<RelationInclude>
+          : never
+    : never;
 };
 
 export const wasmSchema: WasmSchema = {

--- a/examples/todo-client-localfirst-svelte/schema/app.ts
+++ b/examples/todo-client-localfirst-svelte/schema/app.ts
@@ -72,37 +72,45 @@ export interface TodoRelations {
 }
 
 export type ProjectWithIncludes<I extends ProjectInclude = {}> = Project & {
-  todosViaProject?: I["todosViaProject"] extends true
-    ? Todo[]
-    : I["todosViaProject"] extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
-      ? TodoWithIncludes<QueryInclude>[]
-      : I["todosViaProject"] extends TodoInclude
-        ? TodoWithIncludes<I["todosViaProject"]>[]
-        : never;
+  todosViaProject?: NonNullable<I["todosViaProject"]> extends infer RelationInclude
+    ? RelationInclude extends true
+      ? Todo[]
+      : RelationInclude extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
+        ? TodoWithIncludes<QueryInclude>[]
+        : RelationInclude extends TodoInclude
+          ? TodoWithIncludes<RelationInclude>[]
+          : never
+    : never;
 };
 
 export type TodoWithIncludes<I extends TodoInclude = {}> = Todo & {
-  parent?: I["parent"] extends true
-    ? Todo
-    : I["parent"] extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
-      ? TodoWithIncludes<QueryInclude>
-      : I["parent"] extends TodoInclude
-        ? TodoWithIncludes<I["parent"]>
-        : never;
-  todosViaParent?: I["todosViaParent"] extends true
-    ? Todo[]
-    : I["todosViaParent"] extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
-      ? TodoWithIncludes<QueryInclude>[]
-      : I["todosViaParent"] extends TodoInclude
-        ? TodoWithIncludes<I["todosViaParent"]>[]
-        : never;
-  project?: I["project"] extends true
-    ? Project
-    : I["project"] extends ProjectQueryBuilder<infer QueryInclude extends ProjectInclude>
-      ? ProjectWithIncludes<QueryInclude>
-      : I["project"] extends ProjectInclude
-        ? ProjectWithIncludes<I["project"]>
-        : never;
+  parent?: NonNullable<I["parent"]> extends infer RelationInclude
+    ? RelationInclude extends true
+      ? Todo
+      : RelationInclude extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
+        ? TodoWithIncludes<QueryInclude>
+        : RelationInclude extends TodoInclude
+          ? TodoWithIncludes<RelationInclude>
+          : never
+    : never;
+  todosViaParent?: NonNullable<I["todosViaParent"]> extends infer RelationInclude
+    ? RelationInclude extends true
+      ? Todo[]
+      : RelationInclude extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
+        ? TodoWithIncludes<QueryInclude>[]
+        : RelationInclude extends TodoInclude
+          ? TodoWithIncludes<RelationInclude>[]
+          : never
+    : never;
+  project?: NonNullable<I["project"]> extends infer RelationInclude
+    ? RelationInclude extends true
+      ? Project
+      : RelationInclude extends ProjectQueryBuilder<infer QueryInclude extends ProjectInclude>
+        ? ProjectWithIncludes<QueryInclude>
+        : RelationInclude extends ProjectInclude
+          ? ProjectWithIncludes<RelationInclude>
+          : never
+    : never;
 };
 
 export const wasmSchema: WasmSchema = {

--- a/examples/todo-client-localfirst-ts/schema/app.ts
+++ b/examples/todo-client-localfirst-ts/schema/app.ts
@@ -72,37 +72,45 @@ export interface TodoRelations {
 }
 
 export type ProjectWithIncludes<I extends ProjectInclude = {}> = Project & {
-  todosViaProject?: I["todosViaProject"] extends true
-    ? Todo[]
-    : I["todosViaProject"] extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
-      ? TodoWithIncludes<QueryInclude>[]
-      : I["todosViaProject"] extends TodoInclude
-        ? TodoWithIncludes<I["todosViaProject"]>[]
-        : never;
+  todosViaProject?: NonNullable<I["todosViaProject"]> extends infer RelationInclude
+    ? RelationInclude extends true
+      ? Todo[]
+      : RelationInclude extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
+        ? TodoWithIncludes<QueryInclude>[]
+        : RelationInclude extends TodoInclude
+          ? TodoWithIncludes<RelationInclude>[]
+          : never
+    : never;
 };
 
 export type TodoWithIncludes<I extends TodoInclude = {}> = Todo & {
-  parent?: I["parent"] extends true
-    ? Todo
-    : I["parent"] extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
-      ? TodoWithIncludes<QueryInclude>
-      : I["parent"] extends TodoInclude
-        ? TodoWithIncludes<I["parent"]>
-        : never;
-  todosViaParent?: I["todosViaParent"] extends true
-    ? Todo[]
-    : I["todosViaParent"] extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
-      ? TodoWithIncludes<QueryInclude>[]
-      : I["todosViaParent"] extends TodoInclude
-        ? TodoWithIncludes<I["todosViaParent"]>[]
-        : never;
-  project?: I["project"] extends true
-    ? Project
-    : I["project"] extends ProjectQueryBuilder<infer QueryInclude extends ProjectInclude>
-      ? ProjectWithIncludes<QueryInclude>
-      : I["project"] extends ProjectInclude
-        ? ProjectWithIncludes<I["project"]>
-        : never;
+  parent?: NonNullable<I["parent"]> extends infer RelationInclude
+    ? RelationInclude extends true
+      ? Todo
+      : RelationInclude extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
+        ? TodoWithIncludes<QueryInclude>
+        : RelationInclude extends TodoInclude
+          ? TodoWithIncludes<RelationInclude>
+          : never
+    : never;
+  todosViaParent?: NonNullable<I["todosViaParent"]> extends infer RelationInclude
+    ? RelationInclude extends true
+      ? Todo[]
+      : RelationInclude extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
+        ? TodoWithIncludes<QueryInclude>[]
+        : RelationInclude extends TodoInclude
+          ? TodoWithIncludes<RelationInclude>[]
+          : never
+    : never;
+  project?: NonNullable<I["project"]> extends infer RelationInclude
+    ? RelationInclude extends true
+      ? Project
+      : RelationInclude extends ProjectQueryBuilder<infer QueryInclude extends ProjectInclude>
+        ? ProjectWithIncludes<QueryInclude>
+        : RelationInclude extends ProjectInclude
+          ? ProjectWithIncludes<RelationInclude>
+          : never
+    : never;
 };
 
 export const wasmSchema: WasmSchema = {

--- a/examples/todo-server-ts/schema/app.ts
+++ b/examples/todo-server-ts/schema/app.ts
@@ -72,37 +72,45 @@ export interface TodoRelations {
 }
 
 export type ProjectWithIncludes<I extends ProjectInclude = {}> = Project & {
-  todosViaProject?: I["todosViaProject"] extends true
-    ? Todo[]
-    : I["todosViaProject"] extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
-      ? TodoWithIncludes<QueryInclude>[]
-      : I["todosViaProject"] extends TodoInclude
-        ? TodoWithIncludes<I["todosViaProject"]>[]
-        : never;
+  todosViaProject?: NonNullable<I["todosViaProject"]> extends infer RelationInclude
+    ? RelationInclude extends true
+      ? Todo[]
+      : RelationInclude extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
+        ? TodoWithIncludes<QueryInclude>[]
+        : RelationInclude extends TodoInclude
+          ? TodoWithIncludes<RelationInclude>[]
+          : never
+    : never;
 };
 
 export type TodoWithIncludes<I extends TodoInclude = {}> = Todo & {
-  parent?: I["parent"] extends true
-    ? Todo
-    : I["parent"] extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
-      ? TodoWithIncludes<QueryInclude>
-      : I["parent"] extends TodoInclude
-        ? TodoWithIncludes<I["parent"]>
-        : never;
-  todosViaParent?: I["todosViaParent"] extends true
-    ? Todo[]
-    : I["todosViaParent"] extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
-      ? TodoWithIncludes<QueryInclude>[]
-      : I["todosViaParent"] extends TodoInclude
-        ? TodoWithIncludes<I["todosViaParent"]>[]
-        : never;
-  project?: I["project"] extends true
-    ? Project
-    : I["project"] extends ProjectQueryBuilder<infer QueryInclude extends ProjectInclude>
-      ? ProjectWithIncludes<QueryInclude>
-      : I["project"] extends ProjectInclude
-        ? ProjectWithIncludes<I["project"]>
-        : never;
+  parent?: NonNullable<I["parent"]> extends infer RelationInclude
+    ? RelationInclude extends true
+      ? Todo
+      : RelationInclude extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
+        ? TodoWithIncludes<QueryInclude>
+        : RelationInclude extends TodoInclude
+          ? TodoWithIncludes<RelationInclude>
+          : never
+    : never;
+  todosViaParent?: NonNullable<I["todosViaParent"]> extends infer RelationInclude
+    ? RelationInclude extends true
+      ? Todo[]
+      : RelationInclude extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
+        ? TodoWithIncludes<QueryInclude>[]
+        : RelationInclude extends TodoInclude
+          ? TodoWithIncludes<RelationInclude>[]
+          : never
+    : never;
+  project?: NonNullable<I["project"]> extends infer RelationInclude
+    ? RelationInclude extends true
+      ? Project
+      : RelationInclude extends ProjectQueryBuilder<infer QueryInclude extends ProjectInclude>
+        ? ProjectWithIncludes<QueryInclude>
+        : RelationInclude extends ProjectInclude
+          ? ProjectWithIncludes<RelationInclude>
+          : never
+    : never;
 };
 
 export const wasmSchema: WasmSchema = {

--- a/packages/jazz-tools/src/codegen/codegen.test.ts
+++ b/packages/jazz-tools/src/codegen/codegen.test.ts
@@ -806,24 +806,52 @@ describe("generateTypes with relations", () => {
 
     expect(output).toContain("export type TodoWithIncludes<I extends TodoInclude = {}>");
     expect(output).toContain("export type UserWithIncludes<I extends UserInclude = {}>");
-    expect(output).toContain('owner?: I["owner"] extends true');
+    expect(output).toContain('owner?: NonNullable<I["owner"]> extends infer RelationInclude');
+    expect(output).toContain("? RelationInclude extends true");
     expect(output).toContain("? User");
     expect(output).toContain(
-      ': I["owner"] extends UserQueryBuilder<infer QueryInclude extends UserInclude>',
+      ": RelationInclude extends UserQueryBuilder<infer QueryInclude extends UserInclude>",
     );
     expect(output).toContain("? UserWithIncludes<QueryInclude>");
-    expect(output).toContain(': I["owner"] extends UserInclude');
-    expect(output).toContain('? UserWithIncludes<I["owner"]>');
-    expect(output).toContain('todosViaOwner?: I["todosViaOwner"] extends true');
+    expect(output).toContain(": RelationInclude extends UserInclude");
+    expect(output).toContain("? UserWithIncludes<RelationInclude>");
+    expect(output).toContain(
+      'todosViaOwner?: NonNullable<I["todosViaOwner"]> extends infer RelationInclude',
+    );
     expect(output).toContain("? Todo[]");
     expect(output).toContain(
-      ': I["todosViaOwner"] extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>',
+      ": RelationInclude extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>",
     );
     expect(output).toContain("? TodoWithIncludes<QueryInclude>[]");
-    expect(output).toContain(': I["todosViaOwner"] extends TodoInclude');
-    expect(output).toContain('? TodoWithIncludes<I["todosViaOwner"]>[]');
+    expect(output).toContain(": RelationInclude extends TodoInclude");
+    expect(output).toContain("? TodoWithIncludes<RelationInclude>[]");
     expect(output).not.toContain("WithIncludesFor<");
     expect(output).not.toContain("WithIncludesArray<");
+  });
+
+  it("avoids collapsing nested array includes to never when selectors are optional", () => {
+    table("teams", { legacy_id: col.string() });
+    table("resources", { kind: col.enum("branding") });
+    table("resource_access_edges", {
+      resource: col.ref("resources"),
+      team: col.ref("teams"),
+      grant_role: col.enum("viewer", "editor", "manager"),
+    });
+    table("brandings", {
+      resource: col.ref("resources"),
+      name: col.string(),
+    });
+    const schema = getCollectedSchema();
+    const wasm = schemaToWasm(schema);
+    const output = generateTypes(wasm);
+
+    expect(output).toContain(
+      'resource_access_edgesViaResource?: NonNullable<I["resource_access_edgesViaResource"]> extends infer RelationInclude',
+    );
+    expect(output).toContain("? ResourceAccessEdgeWithIncludes<RelationInclude>[]");
+    expect(output).not.toContain(
+      'resource_access_edgesViaResource?: I["resource_access_edgesViaResource"] extends true',
+    );
   });
 
   it("generates Include types for self-referential tables", () => {

--- a/packages/jazz-tools/src/codegen/type-generator.ts
+++ b/packages/jazz-tools/src/codegen/type-generator.ts
@@ -205,13 +205,15 @@ function generateRelationsTypes(relations: Map<string, Relation[]>): string[] {
  *
  * Example output:
  *   export type TodoWithIncludes<I extends TodoInclude = {}> = Todo & {
- *     project?: I["project"] extends true
- *       ? Project
- *       : I["project"] extends ProjectQueryBuilder<infer QueryInclude extends ProjectInclude>
- *         ? ProjectWithIncludes<QueryInclude>
- *         : I["project"] extends ProjectInclude
- *           ? ProjectWithIncludes<I["project"]>
- *           : never;
+ *     project?: NonNullable<I["project"]> extends infer RelationInclude
+ *       ? RelationInclude extends true
+ *         ? Project
+ *         : RelationInclude extends ProjectQueryBuilder<infer QueryInclude extends ProjectInclude>
+ *           ? ProjectWithIncludes<QueryInclude>
+ *           : RelationInclude extends ProjectInclude
+ *             ? ProjectWithIncludes<RelationInclude>
+ *             : never
+ *       : never;
  *   };
  */
 function generateWithIncludesTypes(relations: Map<string, Relation[]>): string[] {
@@ -231,24 +233,26 @@ function generateWithIncludesTypes(relations: Map<string, Relation[]>): string[]
       const targetInclude = targetInterface + "Include";
       const targetQueryBuilder = targetInterface + "QueryBuilder";
       const targetWithIncludes = targetInterface + "WithIncludes";
-      const includeSelector = `I["${rel.name}"]`;
+      const includeSelector = `NonNullable<I["${rel.name}"]>`;
       const trueType = rel.isArray ? `${targetInterface}[]` : targetInterface;
       const queryBuilderType = rel.isArray
         ? `${targetWithIncludes}<QueryInclude>[]`
         : `${targetWithIncludes}<QueryInclude>`;
       const nestedIncludeType = rel.isArray
-        ? `${targetWithIncludes}<${includeSelector}>[]`
-        : `${targetWithIncludes}<${includeSelector}>`;
+        ? `${targetWithIncludes}<RelationInclude>[]`
+        : `${targetWithIncludes}<RelationInclude>`;
 
-      lines.push(`  ${rel.name}?: ${includeSelector} extends true`);
-      lines.push(`    ? ${trueType}`);
+      lines.push(`  ${rel.name}?: ${includeSelector} extends infer RelationInclude`);
+      lines.push(`    ? RelationInclude extends true`);
+      lines.push(`      ? ${trueType}`);
       lines.push(
-        `    : ${includeSelector} extends ${targetQueryBuilder}<infer QueryInclude extends ${targetInclude}>`,
+        `      : RelationInclude extends ${targetQueryBuilder}<infer QueryInclude extends ${targetInclude}>`,
       );
-      lines.push(`      ? ${queryBuilderType}`);
-      lines.push(`      : ${includeSelector} extends ${targetInclude}`);
-      lines.push(`        ? ${nestedIncludeType}`);
-      lines.push(`        : never;`);
+      lines.push(`        ? ${queryBuilderType}`);
+      lines.push(`        : RelationInclude extends ${targetInclude}`);
+      lines.push(`          ? ${nestedIncludeType}`);
+      lines.push(`          : never`);
+      lines.push(`    : never;`);
     }
     lines.push(`};`);
     lines.push(``);

--- a/packages/jazz-tools/tests/ts-dsl/fixtures/basic/app.ts
+++ b/packages/jazz-tools/tests/ts-dsl/fixtures/basic/app.ts
@@ -62,23 +62,27 @@ export interface TodoRelations {
 }
 
 export type ProjectWithIncludes<I extends ProjectInclude = {}> = Project & {
-  todosViaProject?: I["todosViaProject"] extends true
-    ? Todo[]
-    : I["todosViaProject"] extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
-      ? TodoWithIncludes<QueryInclude>[]
-      : I["todosViaProject"] extends TodoInclude
-        ? TodoWithIncludes<I["todosViaProject"]>[]
-        : never;
+  todosViaProject?: NonNullable<I["todosViaProject"]> extends infer RelationInclude
+    ? RelationInclude extends true
+      ? Todo[]
+      : RelationInclude extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
+        ? TodoWithIncludes<QueryInclude>[]
+        : RelationInclude extends TodoInclude
+          ? TodoWithIncludes<RelationInclude>[]
+          : never
+    : never;
 };
 
 export type TodoWithIncludes<I extends TodoInclude = {}> = Todo & {
-  project?: I["project"] extends true
-    ? Project
-    : I["project"] extends ProjectQueryBuilder<infer QueryInclude extends ProjectInclude>
-      ? ProjectWithIncludes<QueryInclude>
-      : I["project"] extends ProjectInclude
-        ? ProjectWithIncludes<I["project"]>
-        : never;
+  project?: NonNullable<I["project"]> extends infer RelationInclude
+    ? RelationInclude extends true
+      ? Project
+      : RelationInclude extends ProjectQueryBuilder<infer QueryInclude extends ProjectInclude>
+        ? ProjectWithIncludes<QueryInclude>
+        : RelationInclude extends ProjectInclude
+          ? ProjectWithIncludes<RelationInclude>
+          : never
+    : never;
 };
 
 export const wasmSchema: WasmSchema = {


### PR DESCRIPTION
## Summary
- fix nested include typing where optional include selectors could collapse array relation results to `never[]`
- update generated `WithIncludes` relation branches to narrow on `NonNullable<I["..."]> extends infer RelationInclude`
- regenerate examples/docs/fixtures to reflect the updated generated typing
- update the existing changeset (`.changeset/tidy-points-guess.md`) to mention this nested include fix

## Repro (before)
A nested include like:

```ts
type BrandingWithResourceAccess = BrandingWithIncludes<{
  resource: {
    resource_access_edgesViaResource: {
      team: true;
    };
  };
}>;

const edges = branding.resource?.resource_access_edgesViaResource ?? [];
```

could resolve `edges` to `never[]`.

## Validation
- added codegen regression coverage for this case in `packages/jazz-tools/src/codegen/codegen.test.ts`
- verified local type-level repro assertion that nested edges are not `never[]`
- ran:
  - `pnpm build`
  - `pnpm test`
