### PR TITLE
fix(jazz-tools): bootstrap build from current.ts when sql is missing

### DIFF
--- a/.changeset/modern-cloths-tease.md
+++ b/.changeset/modern-cloths-tease.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+fix `jazz-tools build` bootstrap behavior by routing through the TypeScript schema CLI when `schema/current.ts` exists and `schema/current.sql` is missing

--- a/packages/jazz-tools/bin/jazz-tools.js
+++ b/packages/jazz-tools/bin/jazz-tools.js
@@ -2,7 +2,7 @@
 
 import { spawnSync } from "node:child_process";
 import { accessSync, chmodSync, constants, existsSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const BINARIES = {
@@ -42,6 +42,41 @@ function ensureExecutable(binaryPath, name) {
   }
 }
 
+function parseSchemaDir(args) {
+  let schemaDir = "./schema";
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "--schema-dir" && args[i + 1]) {
+      schemaDir = args[++i];
+      continue;
+    }
+
+    const prefix = "--schema-dir=";
+    if (arg.startsWith(prefix)) {
+      schemaDir = arg.slice(prefix.length);
+    }
+  }
+
+  return schemaDir;
+}
+
+function exitWithSpawnResult(result, name) {
+  if (result.error) {
+    fail(`Failed to execute ${name}: ${result.error.message}`);
+  }
+
+  if (typeof result.status === "number") {
+    process.exit(result.status);
+  }
+
+  if (result.signal) {
+    process.kill(process.pid, result.signal);
+  }
+
+  process.exit(1);
+}
+
 const key = `${process.platform}-${process.arch}`;
 const binaryName = BINARIES[key];
 const here = dirname(fileURLToPath(import.meta.url));
@@ -73,21 +108,31 @@ if (!binaryPath) {
 
 ensureExecutable(binaryPath, binaryName ?? localBinaryName);
 
-const result = spawnSync(binaryPath, process.argv.slice(2), {
-  stdio: "inherit",
-  env: process.env,
-});
+const args = process.argv.slice(2);
+const command = args[0];
 
-if (result.error) {
-  fail(`Failed to execute ${binaryName ?? binaryPath}: ${result.error.message}`);
+if (command === "build") {
+  const schemaDirArg = parseSchemaDir(args.slice(1));
+  const schemaDir = resolve(process.cwd(), schemaDirArg);
+  const currentSqlPath = join(schemaDir, "current.sql");
+  const currentTsPath = join(schemaDir, "current.ts");
+  const tsCliPath = join(here, "..", "dist", "cli.js");
+
+  if (!existsSync(currentSqlPath) && existsSync(currentTsPath) && existsSync(tsCliPath)) {
+    console.log(
+      `Detected ${schemaDirArg}/current.ts without current.sql. Running TypeScript schema build bootstrap.`,
+    );
+    const tsBuildResult = spawnSync(
+      process.execPath,
+      [tsCliPath, "build", "--schema-dir", schemaDirArg, "--jazz-bin", binaryPath],
+      {
+        stdio: "inherit",
+        env: process.env,
+      },
+    );
+    exitWithSpawnResult(tsBuildResult, "TypeScript schema build");
+  }
 }
 
-if (typeof result.status === "number") {
-  process.exit(result.status);
-}
-
-if (result.signal) {
-  process.kill(process.pid, result.signal);
-}
-
-process.exit(1);
+const result = spawnSync(binaryPath, args, { stdio: "inherit", env: process.env });
+exitWithSpawnResult(result, binaryName ?? binaryPath);


### PR DESCRIPTION
## Summary
- detect `build` invocations where `schema/current.ts` exists but `schema/current.sql` does not
- route those cases through the TypeScript schema CLI bootstrap to generate `current.sql` and continue the normal build
- keep existing native binary behavior unchanged for SQL-first workflows
- add a patch changeset for `jazz-tools`

## Testing
- node --check packages/jazz-tools/bin/jazz-tools.js
- manual smoke test with stubbed binary + TS CLI path to confirm bootstrap branch
