### PR TITLE
perf: avoid decoding sync messages in JS

### DIFF
--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -135,8 +135,9 @@ impl Scheduler for NapiScheduler {
 // NapiSyncSender
 // ============================================================================
 
-/// Arguments for the sync message callback (destinationKind, destinationId, payloadJson)
-type SyncCallbackParams = (String, String, String);
+/// Arguments for the sync message callback
+/// (destinationKind, destinationId, payloadJson, isCatalogue)
+type SyncCallbackParams = (String, String, String, bool);
 
 pub struct NapiSyncSender {
     callback:
@@ -152,7 +153,7 @@ impl NapiSyncSender {
 
     fn set_callback(
         &self,
-        tsfn: ThreadsafeFunction<(String, String, String), ErrorStrategy::CalleeHandled>,
+        tsfn: ThreadsafeFunction<SyncCallbackParams, ErrorStrategy::CalleeHandled>,
     ) {
         if let Ok(mut cb) = self.callback.lock() {
             *cb = Some(tsfn);
@@ -174,13 +175,14 @@ impl SyncSender for NapiSyncSender {
             Ok(json) => json,
             Err(_) => return,
         };
+        let is_catalogue = message.payload.is_catalogue();
         let (destination_kind, destination_id) = match message.destination {
             Destination::Server(server_id) => ("server".to_string(), server_id.0.to_string()),
             Destination::Client(client_id) => ("client".to_string(), client_id.0.to_string()),
         };
 
         tsfn.call(
-            Ok((destination_kind, destination_id, payload_json)),
+            Ok((destination_kind, destination_id, payload_json, is_catalogue)),
             ThreadsafeFunctionCallMode::NonBlocking,
         );
     }
@@ -702,20 +704,22 @@ impl NapiRuntime {
         &self,
         #[napi(ts_arg_type = "(...args: any[]) => any")] callback: napi::JsFunction,
     ) -> napi::Result<()> {
-        let tsfn: ThreadsafeFunction<(String, String, String), ErrorStrategy::CalleeHandled> =
-            callback.create_threadsafe_function(
-                0,
-                |ctx: ThreadSafeCallContext<(String, String, String)>| {
-                    let destination_kind = ctx.env.create_string_from_std(ctx.value.0)?;
-                    let destination_id = ctx.env.create_string_from_std(ctx.value.1)?;
-                    let payload_json = ctx.env.create_string_from_std(ctx.value.2)?;
-                    Ok(vec![
-                        destination_kind.into_unknown(),
-                        destination_id.into_unknown(),
-                        payload_json.into_unknown(),
-                    ])
-                },
-            )?;
+        let tsfn: ThreadsafeFunction<SyncCallbackParams, ErrorStrategy::CalleeHandled> = callback
+            .create_threadsafe_function(
+            0,
+            |ctx: ThreadSafeCallContext<SyncCallbackParams>| {
+                let destination_kind = ctx.env.create_string_from_std(ctx.value.0)?;
+                let destination_id = ctx.env.create_string_from_std(ctx.value.1)?;
+                let payload_json = ctx.env.create_string_from_std(ctx.value.2)?;
+                let is_catalogue = ctx.env.get_boolean(ctx.value.3)?;
+                Ok(vec![
+                    destination_kind.into_unknown(),
+                    destination_id.into_unknown(),
+                    payload_json.into_unknown(),
+                    is_catalogue.into_unknown(),
+                ])
+            },
+        )?;
 
         let core = self
             .core

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -16,7 +16,9 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, Weak};
 
 use napi::Env;
-use napi::threadsafe_function::{ErrorStrategy, ThreadsafeFunction, ThreadsafeFunctionCallMode};
+use napi::threadsafe_function::{
+    ErrorStrategy, ThreadSafeCallContext, ThreadsafeFunction, ThreadsafeFunctionCallMode,
+};
 use napi_derive::napi;
 
 use jazz_tools::object::ObjectId;
@@ -32,7 +34,8 @@ use jazz_tools::schema_manager::{AppId, SchemaManager};
 use jazz_tools::storage::{Storage, SurrealKvStorage};
 use jazz_tools::sync_manager::QueryPropagation;
 use jazz_tools::sync_manager::{
-    ClientId, InboxEntry, OutboxEntry, PersistenceTier, ServerId, Source, SyncManager, SyncPayload,
+    ClientId, Destination, InboxEntry, OutboxEntry, PersistenceTier, ServerId, Source, SyncManager,
+    SyncPayload,
 };
 
 fn convert_values(values: Vec<Value>) -> Vec<Value> {
@@ -132,8 +135,12 @@ impl Scheduler for NapiScheduler {
 // NapiSyncSender
 // ============================================================================
 
+/// Arguments for the sync message callback (destinationKind, destinationId, payloadJson)
+type SyncCallbackParams = (String, String, String);
+
 pub struct NapiSyncSender {
-    callback: Arc<Mutex<Option<ThreadsafeFunction<String, ErrorStrategy::CalleeHandled>>>>,
+    callback:
+        Arc<Mutex<Option<ThreadsafeFunction<SyncCallbackParams, ErrorStrategy::CalleeHandled>>>>,
 }
 
 impl NapiSyncSender {
@@ -143,7 +150,10 @@ impl NapiSyncSender {
         }
     }
 
-    fn set_callback(&self, tsfn: ThreadsafeFunction<String, ErrorStrategy::CalleeHandled>) {
+    fn set_callback(
+        &self,
+        tsfn: ThreadsafeFunction<(String, String, String), ErrorStrategy::CalleeHandled>,
+    ) {
         if let Ok(mut cb) = self.callback.lock() {
             *cb = Some(tsfn);
         }
@@ -160,12 +170,19 @@ impl SyncSender for NapiSyncSender {
             Some(tsfn) => tsfn,
             None => return,
         };
-        let json = match serde_json::to_string(&message) {
+        let payload_json = match serde_json::to_string(&message.payload) {
             Ok(json) => json,
             Err(_) => return,
         };
+        let (destination_kind, destination_id) = match message.destination {
+            Destination::Server(server_id) => ("server".to_string(), server_id.0.to_string()),
+            Destination::Client(client_id) => ("client".to_string(), client_id.0.to_string()),
+        };
 
-        tsfn.call(Ok(json), ThreadsafeFunctionCallMode::NonBlocking);
+        tsfn.call(
+            Ok((destination_kind, destination_id, payload_json)),
+            ThreadsafeFunctionCallMode::NonBlocking,
+        );
     }
 }
 
@@ -685,11 +702,20 @@ impl NapiRuntime {
         &self,
         #[napi(ts_arg_type = "(...args: any[]) => any")] callback: napi::JsFunction,
     ) -> napi::Result<()> {
-        let tsfn: ThreadsafeFunction<String, ErrorStrategy::CalleeHandled> = callback
-            .create_threadsafe_function(0, |ctx| {
-                let val = ctx.env.create_string_from_std(ctx.value)?;
-                Ok(vec![val])
-            })?;
+        let tsfn: ThreadsafeFunction<(String, String, String), ErrorStrategy::CalleeHandled> =
+            callback.create_threadsafe_function(
+                0,
+                |ctx: ThreadSafeCallContext<(String, String, String)>| {
+                    let destination_kind = ctx.env.create_string_from_std(ctx.value.0)?;
+                    let destination_id = ctx.env.create_string_from_std(ctx.value.1)?;
+                    let payload_json = ctx.env.create_string_from_std(ctx.value.2)?;
+                    Ok(vec![
+                        destination_kind.into_unknown(),
+                        destination_id.into_unknown(),
+                        payload_json.into_unknown(),
+                    ])
+                },
+            )?;
 
         let core = self
             .core

--- a/crates/jazz-wasm/src/runtime.rs
+++ b/crates/jazz-wasm/src/runtime.rs
@@ -219,17 +219,19 @@ impl JsSyncSender {
 impl SyncSender for JsSyncSender {
     fn send_sync_message(&self, message: OutboxEntry) {
         if let Some(ref callback) = *self.callback.borrow() {
+            let is_catalogue = message.payload.is_catalogue();
             if let Ok(payload_json) = serde_json::to_string(&message.payload) {
                 let (destination_kind, destination_id) = match message.destination {
                     Destination::Server(server_id) => ("server", server_id.0.to_string()),
                     Destination::Client(client_id) => ("client", client_id.0.to_string()),
                 };
 
-                let _ = callback.call3(
+                let _ = callback.call4(
                     &JsValue::NULL,
                     &JsValue::from_str(destination_kind),
                     &JsValue::from_str(&destination_id),
                     &JsValue::from_str(&payload_json),
+                    &JsValue::from_bool(is_catalogue),
                 );
             }
         }

--- a/crates/jazz-wasm/src/runtime.rs
+++ b/crates/jazz-wasm/src/runtime.rs
@@ -53,7 +53,8 @@ use jazz_tools::storage::OpfsBTreeStorage;
 use jazz_tools::storage::{MemoryStorage, Storage};
 use jazz_tools::sync_manager::QueryPropagation;
 use jazz_tools::sync_manager::{
-    ClientId, InboxEntry, OutboxEntry, PersistenceTier, ServerId, Source, SyncManager, SyncPayload,
+    ClientId, Destination, InboxEntry, OutboxEntry, PersistenceTier, ServerId, Source, SyncManager,
+    SyncPayload,
 };
 
 use crate::query::parse_query;
@@ -218,9 +219,18 @@ impl JsSyncSender {
 impl SyncSender for JsSyncSender {
     fn send_sync_message(&self, message: OutboxEntry) {
         if let Some(ref callback) = *self.callback.borrow() {
-            if let Ok(json) = serde_json::to_string(&message) {
-                let js_value = JsValue::from_str(&json);
-                let _ = callback.call1(&JsValue::NULL, &js_value);
+            if let Ok(payload_json) = serde_json::to_string(&message.payload) {
+                let (destination_kind, destination_id) = match message.destination {
+                    Destination::Server(server_id) => ("server", server_id.0.to_string()),
+                    Destination::Client(client_id) => ("client", client_id.0.to_string()),
+                };
+
+                let _ = callback.call3(
+                    &JsValue::NULL,
+                    &JsValue::from_str(destination_kind),
+                    &JsValue::from_str(&destination_id),
+                    &JsValue::from_str(&payload_json),
+                );
             }
         }
     }

--- a/packages/jazz-tools/src/react-native/jazz-rn-runtime-adapter.test.ts
+++ b/packages/jazz-tools/src/react-native/jazz-rn-runtime-adapter.test.ts
@@ -74,8 +74,8 @@ describe("JazzRnRuntimeAdapter", () => {
 
     // Trigger callback captured by adapter wiring.
     const callbackObject = onSyncMessageToSend.mock.calls[0][0];
-    callbackObject.onSyncMessage("server", "server-1", "{}");
-    expect(syncHandler).toHaveBeenCalledWith("server", "server-1", "{}");
+    callbackObject.onSyncMessage("server", "server-1", "{}", false);
+    expect(syncHandler).toHaveBeenCalledWith("server", "server-1", "{}", false);
 
     const onUpdate = vi.fn();
     const handle = adapter.subscribe("{}", onUpdate, null, null);
@@ -104,7 +104,7 @@ describe("JazzRnRuntimeAdapter", () => {
     });
     const onSyncMessageToSend = binding.onSyncMessageToSend as ReturnType<typeof vi.fn>;
     const syncCallback = onSyncMessageToSend.mock.calls[0][0];
-    expect(() => syncCallback.onSyncMessage("server", "server-1", "{}")).not.toThrow();
+    expect(() => syncCallback.onSyncMessage("server", "server-1", "{}", false)).not.toThrow();
 
     const onUpdate = vi.fn(() => {
       throw new Error("sub boom");

--- a/packages/jazz-tools/src/react-native/jazz-rn-runtime-adapter.test.ts
+++ b/packages/jazz-tools/src/react-native/jazz-rn-runtime-adapter.test.ts
@@ -74,8 +74,8 @@ describe("JazzRnRuntimeAdapter", () => {
 
     // Trigger callback captured by adapter wiring.
     const callbackObject = onSyncMessageToSend.mock.calls[0][0];
-    callbackObject.onSyncMessage('{"destination":{},"payload":{}}');
-    expect(syncHandler).toHaveBeenCalledWith('{"destination":{},"payload":{}}');
+    callbackObject.onSyncMessage("server", "server-1", "{}");
+    expect(syncHandler).toHaveBeenCalledWith("server", "server-1", "{}");
 
     const onUpdate = vi.fn();
     const handle = adapter.subscribe("{}", onUpdate, null, null);
@@ -104,7 +104,7 @@ describe("JazzRnRuntimeAdapter", () => {
     });
     const onSyncMessageToSend = binding.onSyncMessageToSend as ReturnType<typeof vi.fn>;
     const syncCallback = onSyncMessageToSend.mock.calls[0][0];
-    expect(() => syncCallback.onSyncMessage("{}")).not.toThrow();
+    expect(() => syncCallback.onSyncMessage("server", "server-1", "{}")).not.toThrow();
 
     const onUpdate = vi.fn(() => {
       throw new Error("sub boom");

--- a/packages/jazz-tools/src/react-native/jazz-rn-runtime-adapter.ts
+++ b/packages/jazz-tools/src/react-native/jazz-rn-runtime-adapter.ts
@@ -27,6 +27,7 @@ export interface JazzRnRuntimeBinding {
             destinationKind: OutboxDestinationKind,
             destinationId: string,
             payloadJson: string,
+            isCatalogue: boolean,
           ): void;
         }
       | undefined,
@@ -218,9 +219,10 @@ export class JazzRnRuntimeAdapter implements Runtime {
         destinationKind: OutboxDestinationKind,
         destinationId: string,
         payloadJson: string,
+        isCatalogue: boolean,
       ) => {
         try {
-          callback(destinationKind, destinationId, payloadJson);
+          callback(destinationKind, destinationId, payloadJson, isCatalogue);
         } catch (error) {
           swallowCallbackError("sync message", error);
         }

--- a/packages/jazz-tools/src/react-native/jazz-rn-runtime-adapter.ts
+++ b/packages/jazz-tools/src/react-native/jazz-rn-runtime-adapter.ts
@@ -1,5 +1,6 @@
 import type { WasmSchema } from "../drivers/types.js";
 import type { Runtime } from "../runtime/client.js";
+import { OutboxDestinationKind } from "../runtime/sync-transport.js";
 
 export interface JazzRnRuntimeBinding {
   addClient(): string;
@@ -22,7 +23,11 @@ export interface JazzRnRuntimeBinding {
   onSyncMessageToSend(
     callback:
       | {
-          onSyncMessage(messageJson: string): void;
+          onSyncMessage(
+            destinationKind: OutboxDestinationKind,
+            destinationId: string,
+            payloadJson: string,
+          ): void;
         }
       | undefined,
   ): void;
@@ -209,9 +214,13 @@ export class JazzRnRuntimeAdapter implements Runtime {
 
   onSyncMessageToSend(callback: Function): void {
     this.binding.onSyncMessageToSend({
-      onSyncMessage: (messageJson: string) => {
+      onSyncMessage: (
+        destinationKind: OutboxDestinationKind,
+        destinationId: string,
+        payloadJson: string,
+      ) => {
         try {
-          callback(messageJson);
+          callback(destinationKind, destinationId, payloadJson);
         } catch (error) {
           swallowCallbackError("sync message", error);
         }

--- a/packages/jazz-tools/src/runtime/client.ts
+++ b/packages/jazz-tools/src/runtime/client.ts
@@ -782,7 +782,8 @@ export class JazzClient {
       createSyncOutboxRouter({
         logPrefix: "[client] ",
         retryServerPayloads: true,
-        onServerPayload: (payload) => this.sendSyncMessage(payload),
+        onServerPayload: (payloadJson, isCatalogue) =>
+          this.sendSyncMessage(payloadJson, isCatalogue),
         onServerPayloadError: (error) => {
           const isExpectedAbort = isExpectedFetchAbortError(error);
           if (!isExpectedAbort) {
@@ -797,18 +798,24 @@ export class JazzClient {
     this.streamController.start(serverUrl, serverPathPrefix);
   }
 
-  private async sendSyncMessage(payload: unknown): Promise<void> {
+  private async sendSyncMessage(payloadJson: string, isCatalogue: boolean): Promise<void> {
     const serverUrl = this.streamController.getServerUrl();
     if (!serverUrl) return;
 
-    await sendSyncPayload(serverUrl, payload, {
-      jwtToken: this.context.jwtToken,
-      localAuthMode: this.context.localAuthMode,
-      localAuthToken: this.context.localAuthToken,
-      adminSecret: this.context.adminSecret,
-      clientId: this.serverClientId,
-      pathPrefix: this.streamController.getPathPrefix(),
-    });
+    await sendSyncPayload(
+      serverUrl,
+      payloadJson,
+      isCatalogue,
+      {
+        jwtToken: this.context.jwtToken,
+        localAuthMode: this.context.localAuthMode,
+        localAuthToken: this.context.localAuthToken,
+        adminSecret: this.context.adminSecret,
+        clientId: this.serverClientId,
+        pathPrefix: this.streamController.getPathPrefix(),
+      },
+      "[client] ",
+    );
   }
 }
 

--- a/packages/jazz-tools/src/runtime/cloud-server.integration.test.ts
+++ b/packages/jazz-tools/src/runtime/cloud-server.integration.test.ts
@@ -1108,7 +1108,8 @@ describe("cloud-server integration (Jazz TS)", () => {
 
       await sendSyncPayload(
         server.baseUrl,
-        makeSyncPayload(),
+        JSON.stringify(makeSyncPayload()),
+        false,
         { jwtToken: signJwt("valid-user", JWT_SECRET), pathPrefix },
         "[valid] ",
       );
@@ -1116,7 +1117,8 @@ describe("cloud-server integration (Jazz TS)", () => {
       await expect(
         sendSyncPayload(
           server.baseUrl,
-          makeSyncPayload(),
+          JSON.stringify(makeSyncPayload()),
+          false,
           { jwtToken: signJwt("invalid-user", "wrong-secret"), pathPrefix },
           "[invalid] ",
         ),

--- a/packages/jazz-tools/src/runtime/sync-transport.test.ts
+++ b/packages/jazz-tools/src/runtime/sync-transport.test.ts
@@ -414,8 +414,8 @@ describe("sync-transport", () => {
       onClientPayload,
     });
 
-    router(JSON.stringify({ destination: { Server: "upstream-1" }, payload: { Ping: {} } }));
-    router(JSON.stringify({ destination: { Client: "client-1" }, payload: { Pong: {} } }));
+    router("server", "upstream-1", JSON.stringify({ Ping: {} }));
+    router("client", "client-1", JSON.stringify({ Pong: {} }));
 
     await vi.waitFor(() => expect(onServerPayload).toHaveBeenCalledWith({ Ping: {} }));
     expect(onClientPayload).toHaveBeenCalledWith(JSON.stringify({ Pong: {} }));
@@ -430,7 +430,7 @@ describe("sync-transport", () => {
       onServerPayloadError,
     });
 
-    router(JSON.stringify({ destination: { Server: "upstream-1" }, payload: { Ping: {} } }));
+    router("server", "upstream-1", JSON.stringify({ Ping: {} }));
 
     await vi.waitFor(() => expect(onServerPayloadError).toHaveBeenCalledWith(error));
   });

--- a/packages/jazz-tools/src/runtime/sync-transport.test.ts
+++ b/packages/jazz-tools/src/runtime/sync-transport.test.ts
@@ -67,8 +67,8 @@ describe("sync-transport", () => {
     const fetchMock = vi.fn().mockResolvedValue({ ok: true, statusText: "OK" });
     (globalThis as { fetch: typeof fetch }).fetch = fetchMock as unknown as typeof fetch;
 
-    await sendSyncPayload("http://localhost:3000", { Ping: {} }, {});
-    await sendSyncPayload("http://localhost:3000", { Pong: {} }, {});
+    await sendSyncPayload("http://localhost:3000", JSON.stringify({ Ping: {} }), false, {});
+    await sendSyncPayload("http://localhost:3000", JSON.stringify({ Pong: {} }), false, {});
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
 
@@ -87,11 +87,10 @@ describe("sync-transport", () => {
     (globalThis as { fetch: typeof fetch }).fetch = fetchMock as unknown as typeof fetch;
 
     const providedClientId = "11111111-2222-4333-8444-555555555555";
-    await sendSyncPayload(
-      "http://localhost:3000",
-      { Ping: {} },
-      { clientId: providedClientId, jwtToken: "token" },
-    );
+    await sendSyncPayload("http://localhost:3000", JSON.stringify({ Ping: {} }), false, {
+      clientId: providedClientId,
+      jwtToken: "token",
+    });
 
     const body = JSON.parse(fetchMock.mock.calls[0][1].body as string);
     expect(body.client_id).toBe(providedClientId);
@@ -103,29 +102,28 @@ describe("sync-transport", () => {
       .mockResolvedValue({ ok: false, status: 503, statusText: "Service Unavailable" });
     (globalThis as { fetch: typeof fetch }).fetch = fetchMock as unknown as typeof fetch;
 
-    await expect(sendSyncPayload("http://localhost:3000", { Ping: {} }, {})).rejects.toThrow(
-      "Sync POST failed: 503 Service Unavailable",
-    );
+    await expect(
+      sendSyncPayload("http://localhost:3000", JSON.stringify({ Ping: {} }), false, {}),
+    ).rejects.toThrow("Sync POST failed: 503 Service Unavailable");
   });
 
   it("throws when fetch rejects", async () => {
     const fetchMock = vi.fn().mockRejectedValue(new Error("network down"));
     (globalThis as { fetch: typeof fetch }).fetch = fetchMock as unknown as typeof fetch;
 
-    await expect(sendSyncPayload("http://localhost:3000", { Ping: {} }, {})).rejects.toThrow(
-      "Sync POST failed: network down",
-    );
+    await expect(
+      sendSyncPayload("http://localhost:3000", JSON.stringify({ Ping: {} }), false, {}),
+    ).rejects.toThrow("Sync POST failed: network down");
   });
 
   it("posts to path-prefixed sync route when provided", async () => {
     const fetchMock = vi.fn().mockResolvedValue({ ok: true, statusText: "OK" });
     (globalThis as { fetch: typeof fetch }).fetch = fetchMock as unknown as typeof fetch;
 
-    await sendSyncPayload(
-      "http://localhost:3000/",
-      { Ping: {} },
-      { jwtToken: "token", pathPrefix: "apps/app-123/" },
-    );
+    await sendSyncPayload("http://localhost:3000/", JSON.stringify({ Ping: {} }), false, {
+      jwtToken: "token",
+      pathPrefix: "apps/app-123/",
+    });
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(fetchMock.mock.calls[0][0]).toBe("http://localhost:3000/apps/app-123/sync");
@@ -137,7 +135,7 @@ describe("sync-transport", () => {
 
     await sendSyncPayload(
       "http://localhost:3000",
-      {
+      JSON.stringify({
         ObjectUpdated: {
           metadata: {
             metadata: {
@@ -145,7 +143,8 @@ describe("sync-transport", () => {
             },
           },
         },
-      },
+      }),
+      true,
       { jwtToken: "jwt-token" },
     );
 
@@ -158,7 +157,7 @@ describe("sync-transport", () => {
 
     await sendSyncPayload(
       "http://localhost:3000",
-      {
+      JSON.stringify({
         ObjectUpdated: {
           metadata: {
             metadata: {
@@ -166,7 +165,8 @@ describe("sync-transport", () => {
             },
           },
         },
-      },
+      }),
+      true,
       { adminSecret: "admin-secret", jwtToken: "jwt-token" },
     );
 
@@ -414,10 +414,12 @@ describe("sync-transport", () => {
       onClientPayload,
     });
 
-    router("server", "upstream-1", JSON.stringify({ Ping: {} }));
-    router("client", "client-1", JSON.stringify({ Pong: {} }));
+    router("server", "upstream-1", JSON.stringify({ Ping: {} }), false);
+    router("client", "client-1", JSON.stringify({ Pong: {} }), false);
 
-    await vi.waitFor(() => expect(onServerPayload).toHaveBeenCalledWith({ Ping: {} }));
+    await vi.waitFor(() =>
+      expect(onServerPayload).toHaveBeenCalledWith(JSON.stringify({ Ping: {} }), false),
+    );
     expect(onClientPayload).toHaveBeenCalledWith(JSON.stringify({ Pong: {} }));
   });
 
@@ -430,7 +432,7 @@ describe("sync-transport", () => {
       onServerPayloadError,
     });
 
-    router("server", "upstream-1", JSON.stringify({ Ping: {} }));
+    router("server", "upstream-1", JSON.stringify({ Ping: {} }), false);
 
     await vi.waitFor(() => expect(onServerPayloadError).toHaveBeenCalledWith(error));
   });

--- a/packages/jazz-tools/src/runtime/sync-transport.ts
+++ b/packages/jazz-tools/src/runtime/sync-transport.ts
@@ -290,44 +290,37 @@ export interface SyncOutboxRouterOptions {
   retryServerPayloads?: boolean;
 }
 
+export type OutboxDestinationKind = "server" | "client";
+
 /**
  * Create a shared runtime outbox router for server/client destinations.
  */
 export function createSyncOutboxRouter(
   options: SyncOutboxRouterOptions,
-): (envelope: string) => void {
+): (destinationKind: OutboxDestinationKind, destinationId: string, payloadJson: string) => void {
   const logPrefix = options.logPrefix ?? "";
 
-  return (envelope: string) => {
-    let parsed: { destination?: unknown; payload?: unknown };
+  return (destinationKind: OutboxDestinationKind, _destinationId: string, payloadJson: string) => {
+    if (destinationKind === "client") {
+      options.onClientPayload?.(payloadJson);
+      return;
+    }
+
+    let payload: unknown;
     try {
-      parsed = JSON.parse(envelope) as { destination?: unknown; payload?: unknown };
+      payload = JSON.parse(payloadJson);
     } catch (error) {
-      console.error(`${logPrefix}Sync envelope parse error:`, error);
+      console.error(`${logPrefix}Sync payload parse error:`, error);
       return;
     }
 
-    const destination = parsed.destination;
-    const payload = parsed.payload;
-    const isObjectDestination = destination !== null && typeof destination === "object";
-
-    if (isObjectDestination && "Client" in destination) {
-      const payloadJson = JSON.stringify(payload);
-      if (payloadJson !== undefined) {
-        options.onClientPayload?.(payloadJson);
+    Promise.resolve(options.onServerPayload(payload)).catch((error) => {
+      if (options.onServerPayloadError) {
+        options.onServerPayloadError(error);
+        return;
       }
-      return;
-    }
-
-    if (isObjectDestination && "Server" in destination) {
-      Promise.resolve(options.onServerPayload(payload)).catch((error) => {
-        if (options.onServerPayloadError) {
-          options.onServerPayloadError(error);
-          return;
-        }
-        console.error(`${logPrefix}Sync POST error:`, error);
-      });
-    }
+      console.error(`${logPrefix}Sync POST error:`, error);
+    });
   };
 }
 

--- a/packages/jazz-tools/src/runtime/sync-transport.ts
+++ b/packages/jazz-tools/src/runtime/sync-transport.ts
@@ -284,7 +284,7 @@ export function createRuntimeSyncStreamController(
 
 export interface SyncOutboxRouterOptions {
   logPrefix?: string;
-  onServerPayload(payload: unknown): void | Promise<void>;
+  onServerPayload(payloadJson: string, isCatalogue: boolean): void | Promise<void>;
   onClientPayload?(payloadJson: string): void;
   onServerPayloadError?(error: unknown): void;
   retryServerPayloads?: boolean;
@@ -297,24 +297,26 @@ export type OutboxDestinationKind = "server" | "client";
  */
 export function createSyncOutboxRouter(
   options: SyncOutboxRouterOptions,
-): (destinationKind: OutboxDestinationKind, destinationId: string, payloadJson: string) => void {
+): (
+  destinationKind: OutboxDestinationKind,
+  destinationId: string,
+  payloadJson: string,
+  isCatalogue: boolean,
+) => void {
   const logPrefix = options.logPrefix ?? "";
 
-  return (destinationKind: OutboxDestinationKind, _destinationId: string, payloadJson: string) => {
+  return (
+    destinationKind: OutboxDestinationKind,
+    _destinationId: string,
+    payloadJson: string,
+    isCatalogue: boolean,
+  ) => {
     if (destinationKind === "client") {
       options.onClientPayload?.(payloadJson);
       return;
     }
 
-    let payload: unknown;
-    try {
-      payload = JSON.parse(payloadJson);
-    } catch (error) {
-      console.error(`${logPrefix}Sync payload parse error:`, error);
-      return;
-    }
-
-    Promise.resolve(options.onServerPayload(payload)).catch((error) => {
+    Promise.resolve(options.onServerPayload(payloadJson, isCatalogue)).catch((error) => {
       if (options.onServerPayloadError) {
         options.onServerPayloadError(error);
         return;
@@ -417,19 +419,6 @@ export function applyUserAuthHeaders(headers: Record<string, string>, auth: Sync
 }
 
 /**
- * Check if a sync payload is for a catalogue object (schema or lens).
- * Catalogue payloads use admin-secret auth instead of JWT.
- */
-export function isCataloguePayload(payload: any): boolean {
-  const metadata = payload?.ObjectUpdated?.metadata?.metadata;
-  if (metadata) {
-    const t = metadata["type"];
-    return t === "catalogue_schema" || t === "catalogue_lens";
-  }
-  return false;
-}
-
-/**
  * POST a sync payload to the server.
  *
  * User auth headers are always applied first (JWT or local auth).
@@ -437,12 +426,12 @@ export function isCataloguePayload(payload: any): boolean {
  */
 export async function sendSyncPayload(
   serverUrl: string,
-  payload: any,
+  payloadJson: string,
+  isCatalogue: boolean,
   auth: SyncAuth,
   logPrefix = "",
 ): Promise<void> {
-  const cataloguePayload = isCataloguePayload(payload);
-  if (cataloguePayload && !auth.adminSecret) {
+  if (isCatalogue && !auth.adminSecret) {
     return;
   }
 
@@ -450,7 +439,7 @@ export async function sendSyncPayload(
     "Content-Type": "application/json",
   };
 
-  if (cataloguePayload) {
+  if (isCatalogue) {
     if (auth.adminSecret) {
       headers["X-Jazz-Admin-Secret"] = auth.adminSecret;
     }
@@ -458,10 +447,7 @@ export async function sendSyncPayload(
     applyUserAuthHeaders(headers, auth);
   }
 
-  const body = JSON.stringify({
-    payload,
-    client_id: auth.clientId ?? fallbackClientId,
-  });
+  const body = `{"payload":${payloadJson},"client_id":${JSON.stringify(auth.clientId ?? fallbackClientId)}}`;
 
   let response: Response;
   try {

--- a/packages/jazz-tools/src/runtime/worker-bridge.race-harness.test.ts
+++ b/packages/jazz-tools/src/runtime/worker-bridge.race-harness.test.ts
@@ -168,7 +168,7 @@ function createRuntimeHarness() {
       if (!outboundHandler) {
         throw new Error("Runtime sync handler is not installed");
       }
-      outboundHandler("server", "server-1", JSON.stringify(payload));
+      outboundHandler("server", "server-1", JSON.stringify(payload), false);
     },
   };
 }

--- a/packages/jazz-tools/src/runtime/worker-bridge.race-harness.test.ts
+++ b/packages/jazz-tools/src/runtime/worker-bridge.race-harness.test.ts
@@ -147,11 +147,11 @@ class FakeWorker {
 }
 
 function createRuntimeHarness() {
-  let outboundHandler: ((envelope: string) => void) | null = null;
+  let outboundHandler: ((...args: unknown[]) => void) | null = null;
   const receivedFromWorker: string[] = [];
 
   const runtime = {
-    onSyncMessageToSend(handler: (envelope: string) => void) {
+    onSyncMessageToSend(handler: (...args: unknown[]) => void) {
       outboundHandler = handler;
     },
     onSyncMessageReceived(payload: string) {
@@ -168,12 +168,7 @@ function createRuntimeHarness() {
       if (!outboundHandler) {
         throw new Error("Runtime sync handler is not installed");
       }
-      outboundHandler(
-        JSON.stringify({
-          destination: { Server: {} },
-          payload,
-        }),
-      );
+      outboundHandler("server", "server-1", JSON.stringify(payload));
     },
   };
 }

--- a/packages/jazz-tools/src/runtime/worker-bridge.test.ts
+++ b/packages/jazz-tools/src/runtime/worker-bridge.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { WorkerBridge, type PeerSyncBatch } from "./worker-bridge.js";
 import type { Runtime } from "./client.js";
 import type { WorkerToMainMessage } from "../worker/worker-protocol.js";
+import { OutboxDestinationKind } from "./sync-transport.js";
 
 class MockWorker {
   onmessage: ((event: MessageEvent<WorkerToMainMessage>) => void) | null = null;
@@ -37,14 +38,20 @@ class MockWorker {
   }
 }
 
+type SendSyncPayloadCallback = (
+  destinationKind: OutboxDestinationKind,
+  destinationId: string,
+  payload: unknown,
+) => void;
+
 function createRuntimeMock(): {
   runtime: Runtime;
-  emitSyncEnvelope: (envelope: unknown) => void;
+  emitSyncPayload: SendSyncPayloadCallback;
   receivedFromWorker: string[];
   addServerCalls: { count: number };
   removeServerCalls: { count: number };
 } {
-  let onSyncToSend: ((envelope: string) => void) | null = null;
+  let onSyncToSend: SendSyncPayloadCallback | null = null;
   const receivedFromWorker: string[] = [];
   const addServerCalls = { count: 0 };
   const removeServerCalls = { count: 0 };
@@ -62,8 +69,8 @@ function createRuntimeMock(): {
     onSyncMessageReceived: (messageJson: string) => {
       receivedFromWorker.push(messageJson);
     },
-    onSyncMessageToSend: (callback: Function) => {
-      onSyncToSend = callback as (envelope: string) => void;
+    onSyncMessageToSend: (callback: SendSyncPayloadCallback) => {
+      onSyncToSend = callback;
     },
     addServer: () => {
       addServerCalls.count += 1;
@@ -78,11 +85,15 @@ function createRuntimeMock(): {
 
   return {
     runtime,
-    emitSyncEnvelope: (envelope: unknown) => {
+    emitSyncPayload: (
+      destinationKind: OutboxDestinationKind,
+      destinationId: string,
+      payload: unknown,
+    ) => {
       if (!onSyncToSend) {
         throw new Error("onSyncMessageToSend callback not registered");
       }
-      onSyncToSend(JSON.stringify(envelope));
+      onSyncToSend(destinationKind, destinationId, JSON.stringify(payload));
     },
     receivedFromWorker,
     addServerCalls,
@@ -112,18 +123,9 @@ describe("WorkerBridge", () => {
     const runtimeMock = createRuntimeMock();
     const bridge = new WorkerBridge(worker as unknown as Worker, runtimeMock.runtime);
 
-    runtimeMock.emitSyncEnvelope({
-      destination: { Server: {} },
-      payload: { id: 1 },
-    });
-    runtimeMock.emitSyncEnvelope({
-      destination: { Server: {} },
-      payload: { id: 2 },
-    });
-    runtimeMock.emitSyncEnvelope({
-      destination: { Client: "peer" },
-      payload: { ignored: true },
-    });
+    runtimeMock.emitSyncPayload("server", "server-1", { id: 1 });
+    runtimeMock.emitSyncPayload("server", "server-2", { id: 2 });
+    runtimeMock.emitSyncPayload("client", "client-1", { ignored: true });
 
     // Outgoing payloads are buffered until init completes.
     let syncMessages = worker.posted.filter(
@@ -197,10 +199,7 @@ describe("WorkerBridge", () => {
     worker.emitFromWorker({ type: "shutdown-ok" });
     await shutdownPromise;
 
-    runtimeMock.emitSyncEnvelope({
-      destination: { Server: {} },
-      payload: { dropped: true },
-    });
+    runtimeMock.emitSyncPayload("server", "server-1", { dropped: true });
     await Promise.resolve();
 
     const syncMessagesAfterShutdown = worker.posted.filter(
@@ -255,10 +254,7 @@ describe("WorkerBridge", () => {
     bridge.setServerPayloadForwarder((payload) => {
       redirected.push(payload);
     });
-    runtimeMock.emitSyncEnvelope({
-      destination: { Server: {} },
-      payload: { routed: "peer" },
-    });
+    runtimeMock.emitSyncPayload("server", "server-1", { routed: "peer" });
     await Promise.resolve();
 
     const workerSyncMessages = worker.posted.filter(

--- a/packages/jazz-tools/src/runtime/worker-bridge.test.ts
+++ b/packages/jazz-tools/src/runtime/worker-bridge.test.ts
@@ -90,13 +90,13 @@ function createRuntimeMock(): {
     emitSyncPayload: (
       destinationKind: OutboxDestinationKind,
       destinationId: string,
-      payload: unknown,
+      payloadJson: string,
       isCatalogue = false,
     ) => {
       if (!onSyncToSend) {
         throw new Error("onSyncMessageToSend callback not registered");
       }
-      onSyncToSend(destinationKind, destinationId, JSON.stringify(payload), isCatalogue);
+      onSyncToSend(destinationKind, destinationId, payloadJson, isCatalogue);
     },
     receivedFromWorker,
     addServerCalls,

--- a/packages/jazz-tools/src/runtime/worker-bridge.test.ts
+++ b/packages/jazz-tools/src/runtime/worker-bridge.test.ts
@@ -3,6 +3,7 @@ import { WorkerBridge, type PeerSyncBatch } from "./worker-bridge.js";
 import type { Runtime } from "./client.js";
 import type { WorkerToMainMessage } from "../worker/worker-protocol.js";
 import { OutboxDestinationKind } from "./sync-transport.js";
+import fa from "zod/v4/locales/fa.cjs";
 
 class MockWorker {
   onmessage: ((event: MessageEvent<WorkerToMainMessage>) => void) | null = null;
@@ -41,7 +42,8 @@ class MockWorker {
 type SendSyncPayloadCallback = (
   destinationKind: OutboxDestinationKind,
   destinationId: string,
-  payload: unknown,
+  payloadJson: string,
+  isCatalogue: boolean,
 ) => void;
 
 function createRuntimeMock(): {
@@ -89,11 +91,12 @@ function createRuntimeMock(): {
       destinationKind: OutboxDestinationKind,
       destinationId: string,
       payload: unknown,
+      isCatalogue = false,
     ) => {
       if (!onSyncToSend) {
         throw new Error("onSyncMessageToSend callback not registered");
       }
-      onSyncToSend(destinationKind, destinationId, JSON.stringify(payload));
+      onSyncToSend(destinationKind, destinationId, JSON.stringify(payload), isCatalogue);
     },
     receivedFromWorker,
     addServerCalls,
@@ -123,9 +126,9 @@ describe("WorkerBridge", () => {
     const runtimeMock = createRuntimeMock();
     const bridge = new WorkerBridge(worker as unknown as Worker, runtimeMock.runtime);
 
-    runtimeMock.emitSyncPayload("server", "server-1", { id: 1 });
-    runtimeMock.emitSyncPayload("server", "server-2", { id: 2 });
-    runtimeMock.emitSyncPayload("client", "client-1", { ignored: true });
+    runtimeMock.emitSyncPayload("server", "server-1", JSON.stringify({ id: 1 }), false);
+    runtimeMock.emitSyncPayload("server", "server-2", JSON.stringify({ id: 2 }), false);
+    runtimeMock.emitSyncPayload("client", "client-1", JSON.stringify({ ignored: true }), false);
 
     // Outgoing payloads are buffered until init completes.
     let syncMessages = worker.posted.filter(
@@ -199,7 +202,7 @@ describe("WorkerBridge", () => {
     worker.emitFromWorker({ type: "shutdown-ok" });
     await shutdownPromise;
 
-    runtimeMock.emitSyncPayload("server", "server-1", { dropped: true });
+    runtimeMock.emitSyncPayload("server", "server-1", JSON.stringify({ dropped: true }), false);
     await Promise.resolve();
 
     const syncMessagesAfterShutdown = worker.posted.filter(
@@ -254,7 +257,7 @@ describe("WorkerBridge", () => {
     bridge.setServerPayloadForwarder((payload) => {
       redirected.push(payload);
     });
-    runtimeMock.emitSyncPayload("server", "server-1", { routed: "peer" });
+    runtimeMock.emitSyncPayload("server", "server-1", JSON.stringify({ routed: "peer" }), false);
     await Promise.resolve();
 
     const workerSyncMessages = worker.posted.filter(

--- a/packages/jazz-tools/src/runtime/worker-bridge.ts
+++ b/packages/jazz-tools/src/runtime/worker-bridge.ts
@@ -12,6 +12,7 @@ import type {
   WorkerLifecycleEvent,
   WorkerToMainMessage,
 } from "../worker/worker-protocol.js";
+import { OutboxDestinationKind } from "./sync-transport.js";
 
 /**
  * Options for initializing the worker bridge.
@@ -100,18 +101,20 @@ export class WorkerBridge {
     };
 
     // Wire main → worker: outgoing sync messages from runtime
-    this.runtime.onSyncMessageToSend((envelope: string) => {
-      if (this.isDisposedLike()) return;
-      const parsed = JSON.parse(envelope);
-      if (parsed.destination && "Server" in parsed.destination) {
-        const payload = JSON.stringify(parsed.payload);
-        if (this.state.serverPayloadForwarder) {
-          this.state.serverPayloadForwarder(payload);
-        } else {
-          this.enqueueSyncMessageForWorker(payload);
+    this.runtime.onSyncMessageToSend(
+      (destinationKind: OutboxDestinationKind, _destinationId: string, payloadJson: string) => {
+        if (this.isDisposedLike()) return;
+
+        // Only forward server-bound messages (worker IS the server)
+        if (destinationKind === "server") {
+          if (this.state.serverPayloadForwarder) {
+            this.state.serverPayloadForwarder(payloadJson);
+          } else {
+            this.enqueueSyncMessageForWorker(payloadJson);
+          }
         }
-      }
-    });
+      },
+    );
 
     // Register a server so the runtime sends sync messages to it
     this.runtime.addServer();

--- a/packages/jazz-tools/src/runtime/worker-bridge.ts
+++ b/packages/jazz-tools/src/runtime/worker-bridge.ts
@@ -102,7 +102,12 @@ export class WorkerBridge {
 
     // Wire main → worker: outgoing sync messages from runtime
     this.runtime.onSyncMessageToSend(
-      (destinationKind: OutboxDestinationKind, _destinationId: string, payloadJson: string) => {
+      (
+        destinationKind: OutboxDestinationKind,
+        _destinationId: string,
+        payloadJson: string,
+        _isCatalogue: boolean,
+      ) => {
         if (this.isDisposedLike()) return;
 
         // Only forward server-bound messages (worker IS the server)

--- a/packages/jazz-tools/src/worker/jazz-worker.ts
+++ b/packages/jazz-tools/src/worker/jazz-worker.ts
@@ -15,6 +15,7 @@ import {
   applyUserAuthHeaders,
   isCataloguePayload,
   isExpectedFetchAbortError,
+  OutboxDestinationKind,
 } from "../runtime/sync-transport.js";
 import { normalizeRuntimeSchemaJson } from "../drivers/schema-wire.js";
 
@@ -184,49 +185,57 @@ async function handleInit(msg: InitMessage): Promise<void> {
     runtime.setClientRole(mainClientId, "peer");
 
     // Set up outbox routing
-    runtime.onSyncMessageToSend((envelope: string) => {
-      const parsed = JSON.parse(envelope);
-
-      if (parsed.destination && "Client" in parsed.destination) {
-        const destinationClientId = parsed.destination.Client as string;
-        if (destinationClientId === mainClientId) {
-          // Local main-thread client-bound payload.
-          enqueueSyncMessageForMain(JSON.stringify(parsed.payload));
-          return;
-        }
-
-        // Follower peer client-bound payload.
-        const peerId = peerIdByRuntimeClient.get(destinationClientId);
-        if (!peerId) {
-          return;
-        }
-        const term = peerTermByPeerId.get(peerId) ?? 0;
-        post({
-          type: "peer-sync",
-          peerId,
-          term,
-          payload: [JSON.stringify(parsed.payload)],
-        });
-      } else if (parsed.destination && "Server" in parsed.destination) {
-        if (bootstrapCatalogueForwarding) {
-          if (isCataloguePayload(parsed.payload)) {
-            enqueueSyncMessageForMain(JSON.stringify(parsed.payload));
+    runtime.onSyncMessageToSend(
+      (destinationKind: OutboxDestinationKind, destinationId: string, payloadJson: string) => {
+        if (destinationKind === "client") {
+          const destinationClientId = destinationId;
+          if (destinationClientId === mainClientId) {
+            // Local main-thread client-bound payload.
+            enqueueSyncMessageForMain(payloadJson);
+            return;
           }
-          return;
-        }
 
-        // Server-bound → HTTP POST to upstream
-        if (activeServerUrl) {
-          void sendToServer(activeServerUrl, parsed.payload).catch((error) => {
-            if (!isExpectedFetchAbortError(error)) {
-              console.error("[worker] Sync POST error:", error);
-            }
-            detachServer();
-            scheduleReconnect();
+          // Follower peer client-bound payload.
+          const peerId = peerIdByRuntimeClient.get(destinationClientId);
+          if (!peerId) {
+            return;
+          }
+          const term = peerTermByPeerId.get(peerId) ?? 0;
+          post({
+            type: "peer-sync",
+            peerId,
+            term,
+            payload: [payloadJson],
           });
+        } else if (destinationKind === "server") {
+          let parsedPayload: unknown;
+          try {
+            parsedPayload = JSON.parse(payloadJson);
+          } catch (error) {
+            console.error("[worker] Sync payload parse error:", error);
+            return;
+          }
+
+          if (bootstrapCatalogueForwarding) {
+            if (isCataloguePayload(parsedPayload)) {
+              enqueueSyncMessageForMain(payloadJson);
+            }
+            return;
+          }
+
+          // Server-bound → HTTP POST to upstream
+          if (activeServerUrl) {
+            void sendToServer(activeServerUrl, parsedPayload).catch((error) => {
+              if (!isExpectedFetchAbortError(error)) {
+                console.error("[worker] Sync POST error:", error);
+              }
+              detachServer();
+              scheduleReconnect();
+            });
+          }
         }
-      }
-    });
+      },
+    );
 
     // Runtime is now fully ready to ingest client sync traffic.
     const bufferedSyncMessages = pendingSyncMessages;

--- a/packages/jazz-tools/src/worker/jazz-worker.ts
+++ b/packages/jazz-tools/src/worker/jazz-worker.ts
@@ -13,7 +13,6 @@ import {
   generateClientId,
   buildEventsUrl,
   applyUserAuthHeaders,
-  isCataloguePayload,
   isExpectedFetchAbortError,
   OutboxDestinationKind,
 } from "../runtime/sync-transport.js";
@@ -186,7 +185,12 @@ async function handleInit(msg: InitMessage): Promise<void> {
 
     // Set up outbox routing
     runtime.onSyncMessageToSend(
-      (destinationKind: OutboxDestinationKind, destinationId: string, payloadJson: string) => {
+      (
+        destinationKind: OutboxDestinationKind,
+        destinationId: string,
+        payloadJson: string,
+        isCatalogue: boolean,
+      ) => {
         if (destinationKind === "client") {
           const destinationClientId = destinationId;
           if (destinationClientId === mainClientId) {
@@ -208,16 +212,8 @@ async function handleInit(msg: InitMessage): Promise<void> {
             payload: [payloadJson],
           });
         } else if (destinationKind === "server") {
-          let parsedPayload: unknown;
-          try {
-            parsedPayload = JSON.parse(payloadJson);
-          } catch (error) {
-            console.error("[worker] Sync payload parse error:", error);
-            return;
-          }
-
           if (bootstrapCatalogueForwarding) {
-            if (isCataloguePayload(parsedPayload)) {
+            if (isCatalogue) {
               enqueueSyncMessageForMain(payloadJson);
             }
             return;
@@ -225,7 +221,7 @@ async function handleInit(msg: InitMessage): Promise<void> {
 
           // Server-bound → HTTP POST to upstream
           if (activeServerUrl) {
-            void sendToServer(activeServerUrl, parsedPayload).catch((error) => {
+            void sendToServer(activeServerUrl, payloadJson, isCatalogue).catch((error) => {
               if (!isExpectedFetchAbortError(error)) {
                 console.error("[worker] Sync POST error:", error);
               }
@@ -285,10 +281,15 @@ async function handleInit(msg: InitMessage): Promise<void> {
 // ============================================================================
 
 /** POST a sync payload to the upstream server. */
-async function sendToServer(serverUrl: string, payload: any): Promise<void> {
+async function sendToServer(
+  serverUrl: string,
+  payloadJson: string,
+  isCatalogue: boolean,
+): Promise<void> {
   await sendSyncPayload(
     serverUrl,
-    payload,
+    payloadJson,
+    isCatalogue,
     {
       jwtToken,
       localAuthMode,


### PR DESCRIPTION
## Description

Avoids deserializing JSON-encoded OutboxEntries and SyncPayloads on the JS side.

The performance gains are not significant, but this change sets the stage for using more efficient Rust<>Rust binary encodings.