### PR TITLE
feat: localOnly query propagation for devTool extension

### DIFF
--- a/packages/inspector/src/App.tsx
+++ b/packages/inspector/src/App.tsx
@@ -158,7 +158,7 @@ export default function App() {
 
   return (
     <JazzProvider client={client}>
-      <DevtoolsProvider wasmSchema={wasmSchema}>
+      <DevtoolsProvider wasmSchema={wasmSchema} runtime="standalone">
         <ConfigResetProvider onReset={handleReset}>
           <BrowserRouter>
             <InspectorRoutes />

--- a/packages/inspector/src/components/data-explorer/TableDataGrid.test.tsx
+++ b/packages/inspector/src/components/data-explorer/TableDataGrid.test.tsx
@@ -2,7 +2,7 @@ import { cleanup, fireEvent, render, screen, within } from "@testing-library/rea
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TableDataGrid } from "./TableDataGrid";
 
-const mockUseAll = vi.fn();
+const mockSubscribeAll = vi.fn();
 let currentRows: Array<Record<string, unknown>>;
 
 const mockWasmSchema = {
@@ -16,7 +16,9 @@ const mockWasmSchema = {
 };
 
 vi.mock("jazz-tools/react", () => ({
-  useAll: (...args: unknown[]) => mockUseAll(...args),
+  useDb: () => ({
+    subscribeAll: (...args: unknown[]) => mockSubscribeAll(...args),
+  }),
 }));
 
 vi.mock("jazz-tools", () => ({
@@ -29,7 +31,11 @@ vi.mock("jazz-tools", () => ({
 }));
 
 vi.mock("../../contexts/devtools-context.js", () => ({
-  useDevtoolsContext: () => ({ wasmSchema: mockWasmSchema }),
+  useDevtoolsContext: () => ({
+    wasmSchema: mockWasmSchema,
+    runtime: "extension",
+    queryPropagation: "local-only",
+  }),
 }));
 
 vi.mock("react-router", async () => {
@@ -51,7 +57,10 @@ describe("TableDataGrid", () => {
       { id: "row-1", title: "alpha", done: true, meta: null },
     ];
 
-    mockUseAll.mockImplementation(() => currentRows);
+    mockSubscribeAll.mockImplementation((_, callback) => {
+      callback({ all: currentRows, delta: [] });
+      return vi.fn();
+    });
   });
 
   it("renders schema-derived columns and reactive rows", () => {
@@ -79,5 +88,15 @@ describe("TableDataGrid", () => {
     const firstDataRowCells = within(firstDataRow).getAllByRole("cell");
 
     expect(firstDataRowCells[1]?.textContent).toBe("alpha");
+  });
+
+  it("subscribes with local-only propagation in extension mode", () => {
+    render(<TableDataGrid />);
+
+    expect(mockSubscribeAll).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.any(Function),
+      expect.objectContaining({ propagation: "local-only" }),
+    );
   });
 });

--- a/packages/inspector/src/components/data-explorer/TableDataGrid.tsx
+++ b/packages/inspector/src/components/data-explorer/TableDataGrid.tsx
@@ -7,7 +7,7 @@ import {
   useReactTable,
 } from "@tanstack/react-table";
 import { allRowsInTableQuery, type DynamicTableRow } from "jazz-tools";
-import { useAll } from "jazz-tools/react";
+import { useDb } from "jazz-tools/react";
 import { useEffect, useMemo, useState } from "react";
 import { Navigate, useParams } from "react-router";
 import { useDevtoolsContext } from "../../contexts/devtools-context.js";
@@ -30,17 +30,31 @@ export function TableDataGrid() {
     return <Navigate to="/data-explorer" replace />;
   }
 
-  const schema = useDevtoolsContext().wasmSchema;
+  const { wasmSchema: schema, queryPropagation } = useDevtoolsContext();
+  const db = useDb();
   const queryBuilder = useMemo(
     () => allRowsInTableQuery<DynamicTableRow>(table, schema),
     [table, schema],
   );
-  const rows = useAll(queryBuilder) ?? [];
+  const [rows, setRows] = useState<DynamicTableRow[]>([]);
   const [sorting, setSorting] = useState<SortingState>([]);
   const [pageSize, setPageSize] = useState<number>(PAGE_SIZE_OPTIONS[0]);
   const [pageIndex, setPageIndex] = useState(0);
-
   const schemaColumns = schema[table]?.columns ?? [];
+
+  useEffect(() => {
+    const unsubscribe = db.subscribeAll(
+      queryBuilder,
+      (delta) => {
+        setRows(delta.all);
+      },
+      { propagation: queryPropagation },
+    );
+
+    return () => {
+      unsubscribe();
+    };
+  }, [db, queryBuilder, queryPropagation]);
 
   const columnDefs = useMemo<ColumnDef<DynamicTableRow>[]>(
     () => [

--- a/packages/inspector/src/contexts/devtools-context.tsx
+++ b/packages/inspector/src/contexts/devtools-context.tsx
@@ -1,8 +1,13 @@
-import type { WasmSchema } from "jazz-tools";
-import { createContext, useContext, type PropsWithChildren } from "react";
+import type { WasmSchema, QueryPropagation } from "jazz-tools";
+import { createContext, useContext, useState, type PropsWithChildren } from "react";
+
+export type InspectorRuntime = "standalone" | "extension";
 
 interface DevtoolsContextValue {
   wasmSchema: WasmSchema;
+  runtime: InspectorRuntime;
+  queryPropagation: QueryPropagation;
+  setQueryPropagation: (value: QueryPropagation) => void;
 }
 
 export const DevtoolsContext = createContext<DevtoolsContextValue | null>(null);
@@ -10,8 +15,34 @@ export const DevtoolsContext = createContext<DevtoolsContextValue | null>(null);
 export function DevtoolsProvider({
   children,
   wasmSchema,
-}: PropsWithChildren<{ wasmSchema: WasmSchema }>) {
-  return <DevtoolsContext.Provider value={{ wasmSchema }}>{children}</DevtoolsContext.Provider>;
+  runtime,
+  queryPropagation,
+}: PropsWithChildren<{
+  wasmSchema: WasmSchema;
+  runtime: InspectorRuntime;
+  queryPropagation?: QueryPropagation;
+}>) {
+  const [extensionQueryPropagation, setExtensionQueryPropagation] = useState<QueryPropagation>(
+    queryPropagation ?? "local-only",
+  );
+  const resolvedPropagation = runtime === "standalone" ? "full" : extensionQueryPropagation;
+  const setQueryPropagation = (value: QueryPropagation) => {
+    if (runtime === "standalone") return;
+    setExtensionQueryPropagation(value);
+  };
+
+  return (
+    <DevtoolsContext.Provider
+      value={{
+        wasmSchema,
+        runtime,
+        queryPropagation: resolvedPropagation,
+        setQueryPropagation,
+      }}
+    >
+      {children}
+    </DevtoolsContext.Provider>
+  );
 }
 
 export function useDevtoolsContext(): DevtoolsContextValue {

--- a/packages/inspector/src/devtools-main.tsx
+++ b/packages/inspector/src/devtools-main.tsx
@@ -26,7 +26,7 @@ function App() {
 
   return (
     <JazzProvider client={client}>
-      <DevtoolsProvider wasmSchema={wasmSchema}>
+      <DevtoolsProvider wasmSchema={wasmSchema} runtime="extension">
         <MemoryRouter>
           <InspectorRoutes />
         </MemoryRouter>

--- a/packages/inspector/src/pages/data-explorer/index.module.css
+++ b/packages/inspector/src/pages/data-explorer/index.module.css
@@ -15,11 +15,32 @@
 }
 
 .sidebarTitle {
-  margin: 0 0 10px;
+  margin: 0;
   font-size: 13px;
   text-transform: uppercase;
   letter-spacing: 0.05em;
   color: #8c9ab0;
+}
+
+.sidebarHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin: 0 0 10px;
+}
+
+.propagationSwitch {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  color: #9aa6ba;
+}
+
+.propagationLabel {
+  text-transform: none;
+  letter-spacing: normal;
 }
 
 .tableList {

--- a/packages/inspector/src/pages/data-explorer/index.tsx
+++ b/packages/inspector/src/pages/data-explorer/index.tsx
@@ -4,7 +4,12 @@ import { useDevtoolsContext } from "../../contexts/devtools-context.js";
 import styles from "./index.module.css";
 
 export function DataExplorer() {
-  const schema = useDevtoolsContext().wasmSchema;
+  const {
+    wasmSchema: schema,
+    runtime,
+    queryPropagation,
+    setQueryPropagation,
+  } = useDevtoolsContext();
   const { table } = useParams();
 
   const tableNames = useMemo(() => Object.keys(schema ?? {}).sort(), [schema]);
@@ -12,7 +17,22 @@ export function DataExplorer() {
   return (
     <div className={styles.layout}>
       <aside className={styles.sidebar}>
-        <h2 className={styles.sidebarTitle}>Tables</h2>
+        <div className={styles.sidebarHeader}>
+          <h2 className={styles.sidebarTitle}>Tables</h2>
+          {runtime === "extension" ? (
+            <label className={styles.propagationSwitch}>
+              <span className={styles.propagationLabel}>Local-only</span>
+              <input
+                type="checkbox"
+                checked={queryPropagation === "local-only"}
+                onChange={(event) => {
+                  setQueryPropagation(event.target.checked ? "local-only" : "full");
+                }}
+                aria-label="Toggle query propagation between local-only and full"
+              />
+            </label>
+          ) : null}
+        </div>
         <ul className={styles.tableList}>
           {tableNames.map((tableName) => (
             <li key={tableName}>


### PR DESCRIPTION
This PR adds runtime-aware query propagation controls to the inspector.

- Introduces runtime info (standalone vs extension) in the devtools context.
- Enforces full propagation in standalone mode.
- Adds an extension-only switch in Data Explorer (next to Tables) to toggle propagation between:
  - localOnly (local-only in runtime options)
  - network (full in runtime options)
- Wires table data subscriptions to use the selected propagation mode.