### PR TITLE
fix: reevaluate_all corrupts base columns on second subscription fire

### DIFF
--- a/.changeset/pr-185-include-join-column-shift.md
+++ b/.changeset/pr-185-include-join-column-shift.md
@@ -2,4 +2,4 @@
 "jazz-tools": patch
 ---
 
-fix: prevent reevaluate_all from corrupting base columns on repeated subscriptions
+Fixed array subquery incremental updates so parent row fields stay correct. Previously, when related rows changed after subscribing, update payloads could return corrupted parent values (for example, garbled `id` or `name`).

--- a/.changeset/pr-185-include-join-column-shift.md
+++ b/.changeset/pr-185-include-join-column-shift.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+fix: prevent reevaluate_all from corrupting base columns on repeated subscriptions

--- a/crates/jazz-tools/src/query_manager/graph_nodes/array_subquery.rs
+++ b/crates/jazz-tools/src/query_manager/graph_nodes/array_subquery.rs
@@ -330,6 +330,33 @@ impl ArraySubqueryNode {
         }]))
     }
 
+    /// Update the array column in an existing output tuple.
+    ///
+    /// `build_output_tuple` expects an *outer* tuple encoded with the base
+    /// descriptor.  Tuples stored in `current_tuples` are already encoded with
+    /// `self.output_descriptor` (base + array column).  Decoding those with
+    /// the base descriptor misreads the variable-length offset table and
+    /// corrupts the base column values.  This method decodes with the full
+    /// combined descriptor and replaces only the last (array) column.
+    fn update_output_tuple_array(&self, output_tuple: &Tuple, new_array: &Value) -> Option<Tuple> {
+        let element = output_tuple.get(0)?;
+        let outer_id = element.id();
+        let outer_content = element.content()?;
+        let commit_id = element.commit_id()?;
+
+        let mut values = decode_row(&self.output_descriptor, outer_content).ok()?;
+        let last_idx = values.len().checked_sub(1)?;
+        values[last_idx] = new_array.clone();
+
+        let output_content = encode_row(&self.output_descriptor, &values).ok()?;
+
+        Some(Tuple::new(vec![TupleElement::Row {
+            id: outer_id,
+            content: output_content,
+            commit_id,
+        }]))
+    }
+
     /// Re-evaluate all instances when inner data changes.
     /// Returns deltas for any arrays that changed.
     pub fn reevaluate_all<F>(&mut self, io: &dyn Storage, row_loader: &mut F) -> TupleDelta
@@ -362,8 +389,12 @@ impl ArraySubqueryNode {
                     .cloned();
 
                 if let Some(old_tuple) = old_tuple {
-                    // Build new tuple with updated array
-                    if let Some(new_tuple) = self.build_output_tuple(&old_tuple, &new_array) {
+                    // Build new tuple with updated array.  Use
+                    // update_output_tuple_array (not build_output_tuple) because
+                    // old_tuple is already an output tuple encoded with the
+                    // combined descriptor.
+                    if let Some(new_tuple) = self.update_output_tuple_array(&old_tuple, &new_array)
+                    {
                         // Emit update: (old_tuple, new_tuple)
                         result.updated.push((old_tuple.clone(), new_tuple.clone()));
 

--- a/crates/jazz-tools/src/query_manager/manager_tests.rs
+++ b/crates/jazz-tools/src/query_manager/manager_tests.rs
@@ -4847,6 +4847,128 @@ fn array_subquery_delta_on_inner_insert() {
 }
 
 #[test]
+fn array_subquery_reevaluate_all_does_not_corrupt_base_columns() {
+    // When the inner table changes after subscription, reevaluate_all re-builds
+    // the output tuple from the stored current_tuple.  Those stored tuples are
+    // encoded with the *combined* descriptor (base cols + array col), but
+    // build_output_tuple was decoding them with the *base* descriptor only,
+    // causing the variable-length offset table to be misread and garbling
+    // base column values on every subsequent fire.
+    //
+    // ASCII flow:
+    //
+    //   insert Alice (no posts)
+    //   subscribe → [Alice, []] Added   ← outer tuple encoded with base desc (correct)
+    //   insert Post → reevaluate_all    ← old_tuple now encoded with combined desc
+    //                → [???, [Post]] Updated  ← name garbled before fix
+
+    let sync_manager = SyncManager::new();
+    let schema = users_posts_schema();
+    let (mut qm, mut storage) = create_query_manager(sync_manager, schema);
+
+    // Insert Alice with NO posts — ensures the stored current_tuple after the
+    // first fire carries an empty-array combined encoding.
+    qm.insert(
+        &mut storage,
+        "users",
+        &[Value::Integer(1), Value::Text("Alice".into())],
+    )
+    .unwrap();
+
+    let query = qm
+        .query("users")
+        .with_array("posts", |sub| {
+            sub.from("posts").correlate("author_id", "users.id")
+        })
+        .build();
+
+    let sub_id = qm.subscribe(query).unwrap();
+    qm.process(&mut storage);
+
+    // Consume and verify the initial Added delta.
+    let initial_updates = qm.take_updates();
+    let initial_delta = initial_updates
+        .iter()
+        .find(|u| u.subscription_id == sub_id)
+        .map(|u| &u.delta)
+        .expect("Should have initial update");
+    assert_eq!(initial_delta.added.len(), 1, "Initial: 1 user row Added");
+
+    let output_descriptor = users_with_posts_descriptor();
+    let initial_values =
+        decode_row(&output_descriptor, &initial_delta.added[0].data).expect("decode initial row");
+    assert_eq!(
+        initial_values[0],
+        Value::Integer(1),
+        "Initial: id must be 1"
+    );
+    assert_eq!(
+        initial_values[1],
+        Value::Text("Alice".into()),
+        "Initial: name must be Alice"
+    );
+    assert_eq!(
+        initial_values[2].as_array().expect("posts array").len(),
+        0,
+        "Initial: posts must be empty"
+    );
+
+    // Now insert a post — this triggers reevaluate_all on the ArraySubqueryNode.
+    // The old_tuple in current_tuples is the combined-descriptor-encoded row
+    // from the initial fire.  Before the fix, build_output_tuple decodes it
+    // with the base descriptor, corrupting the variable-length name field.
+    qm.insert(
+        &mut storage,
+        "posts",
+        &[
+            Value::Integer(100),
+            Value::Text("First Post".into()),
+            Value::Integer(1), // author_id = Alice
+        ],
+    )
+    .unwrap();
+    qm.process(&mut storage);
+
+    let second_updates = qm.take_updates();
+    let second_delta = second_updates
+        .iter()
+        .find(|u| u.subscription_id == sub_id)
+        .map(|u| &u.delta)
+        .expect("Should have delta after post insert");
+
+    assert!(
+        !second_delta.updated.is_empty() || !second_delta.added.is_empty(),
+        "Expected an Updated or Added row after inner insert"
+    );
+
+    let new_row_data = if !second_delta.updated.is_empty() {
+        &second_delta.updated[0].1.data
+    } else {
+        &second_delta.added[0].data
+    };
+
+    let new_values = decode_row(&output_descriptor, new_row_data).expect("decode updated row");
+
+    // These are the assertions that expose the bug: before the fix, the
+    // variable-length offset table mismatch causes id and name to be garbled.
+    assert_eq!(
+        new_values[0],
+        Value::Integer(1),
+        "After inner insert: id must not be corrupted"
+    );
+    assert_eq!(
+        new_values[1],
+        Value::Text("Alice".into()),
+        "After inner insert: name must not be corrupted"
+    );
+    assert_eq!(
+        new_values[2].as_array().expect("posts array").len(),
+        1,
+        "After inner insert: posts array must contain 1 post"
+    );
+}
+
+#[test]
 fn array_subquery_delta_on_outer_insert() {
     // Test: after subscription, inserting a new user should emit a delta
     // with the new user row (with their posts array).


### PR DESCRIPTION
## Summary

When `.include()` is used, `ArraySubqueryNode::reevaluate_all` is called whenever the inner table changes. It passes the stored **output tuple** (encoded with the combined descriptor: base columns + array column) to `build_output_tuple`, which decodes it using only the **base descriptor**. The variable-length offset table in the stored bytes encodes positions for all columns including the array, so reading it with a shorter descriptor shifts the offset boundary and corrupts variable-length base columns (e.g. `name` becoming `"\u{5}\0\0\0Alice\0\0\0\0"` instead of `"Alice"`).

The first subscription fire is unaffected because it receives the original outer tuple encoded with the base descriptor. Only the second and subsequent fires — triggered by inner-table changes — are corrupted.

**Fix:** add `update_output_tuple_array`, which decodes the stored output tuple using `self.output_descriptor` (the full combined descriptor), replaces only the last value (the array), and re-encodes. `reevaluate_all` now calls this instead of `build_output_tuple`.

**Relation to #107:** same class of bug (wrong descriptor used to decode row data), different location and trigger. #107 fixed a stale `combined_descriptor` at graph compilation time (corrupting the first fire). This fixes the re-evaluation path (corrupting subsequent fires).

## Test plan

- [x] New Rust test `array_subquery_reevaluate_all_does_not_corrupt_base_columns` — fails before fix, passes after
- [x] All 23 `array_subquery_*` Rust tests pass
- [x] Full test suite: ~1370 individual tests passing