### PR TITLE
fix(svelte-e2e): reliable server setup and port isolation

### DIFF
--- a/examples/todo-client-localfirst-svelte/tests/browser/global-setup.ts
+++ b/examples/todo-client-localfirst-svelte/tests/browser/global-setup.ts
@@ -1,108 +1,38 @@
-/**
- * Global setup for browser tests — spawns a real jazz-tools server.
- */
-
-import { spawn, type ChildProcess } from "node:child_process";
-import { mkdtempSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { TEST_PORT, JWT_SECRET, ADMIN_SECRET, APP_ID } from "./test-constants.js";
+import {
+  type LocalJazzServerHandle,
+  startLocalJazzServer,
+  pushSchemaCatalogue,
+} from "jazz-tools/testing";
+import { TEST_PORT, ADMIN_SECRET, APP_ID } from "./test-constants.js";
 
-export { TEST_PORT, JWT_SECRET, ADMIN_SECRET, APP_ID };
+export { TEST_PORT, ADMIN_SECRET, APP_ID };
 
-const HEALTH_POLL_INTERVAL_MS = 100;
-const HEALTH_TIMEOUT_MS = 30_000;
-
-let serverProcess: ChildProcess | null = null;
-let dataDir: string | null = null;
-
-async function isHealthy(port: number): Promise<boolean> {
-  const url = `http://127.0.0.1:${port}/health`;
-  try {
-    const resp = await fetch(url);
-    return resp.ok;
-  } catch {
-    return false;
-  }
-}
-
-async function waitForHealth(port: number, timeoutMs = HEALTH_TIMEOUT_MS): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-
-  while (Date.now() < deadline) {
-    if (await isHealthy(port)) {
-      return;
-    }
-    await new Promise((r) => setTimeout(r, HEALTH_POLL_INTERVAL_MS));
-  }
-
-  throw new Error(
-    `Server failed to become ready on port ${port} within ${Math.ceil(timeoutMs / 1000)} seconds`,
-  );
-}
+let server: Promise<LocalJazzServerHandle> | null = null;
 
 export async function setup(): Promise<void> {
-  // Vitest may invoke global setup more than once; reuse an existing healthy server.
-  if (await isHealthy(TEST_PORT)) {
+  if (server) {
+    await server;
     return;
   }
 
-  dataDir = mkdtempSync(join(tmpdir(), "jazz-tools-react-test-"));
-
-  const jazzBinary = join(import.meta.dirname ?? __dirname, "../../../../target/debug/jazz-tools");
-
-  serverProcess = spawn(
-    jazzBinary,
-    ["server", APP_ID, "--port", TEST_PORT.toString(), "--data-dir", dataDir],
-    {
-      env: {
-        ...process.env,
-        JAZZ_ADMIN_SECRET: ADMIN_SECRET,
-      },
-      stdio: ["ignore", "pipe", "pipe"],
-    },
-  );
-
-  serverProcess.stdout?.on("data", (data: Buffer) => {
-    process.stdout.write(`[jazz-server] ${data}`);
-  });
-  serverProcess.stderr?.on("data", (data: Buffer) => {
-    process.stderr.write(`[jazz-server] ${data}`);
+  server = startLocalJazzServer({
+    appId: APP_ID,
+    port: TEST_PORT,
+    adminSecret: ADMIN_SECRET,
+    healthTimeoutMs: 5000,
   });
 
-  try {
-    await waitForHealth(TEST_PORT);
-  } catch (error) {
-    // Another concurrent setup may have won the race to bind this port.
-    if (await isHealthy(TEST_PORT)) {
-      return;
-    }
-    throw error;
-  }
+  const serverHandle = await server;
+
+  await pushSchemaCatalogue({
+    serverUrl: serverHandle.url,
+    appId: APP_ID,
+    adminSecret: ADMIN_SECRET,
+    schemaDir: join(import.meta.dirname ?? __dirname, "../../schema"),
+  });
 }
 
 export async function teardown(): Promise<void> {
-  if (serverProcess) {
-    try {
-      serverProcess.kill("SIGTERM");
-    } catch {
-      // Process may already be gone.
-    }
-
-    await new Promise<void>((resolve) => {
-      serverProcess?.on("exit", () => resolve());
-      setTimeout(resolve, 2000);
-    });
-
-    serverProcess = null;
-  }
-
-  if (dataDir) {
-    try {
-      rmSync(dataDir, { recursive: true, force: true });
-    } catch {
-      // Best effort cleanup
-    }
-    dataDir = null;
-  }
+  await (await server)?.stop();
 }

--- a/examples/todo-client-localfirst-svelte/tests/browser/test-constants.ts
+++ b/examples/todo-client-localfirst-svelte/tests/browser/test-constants.ts
@@ -1,5 +1,5 @@
 /** Shared constants for browser tests — no Node.js imports. */
-export const TEST_PORT = 19877;
-export const JWT_SECRET = "test-jwt-secret-for-react-browser-tests";
-export const ADMIN_SECRET = "test-admin-secret-for-react-browser-tests";
-export const APP_ID = "00000000-0000-0000-0000-000000000002";
+export const TEST_PORT = 19879;
+export const JWT_SECRET = "test-jwt-secret-for-svelte-browser-tests";
+export const ADMIN_SECRET = "test-admin-secret-for-svelte-browser-tests";
+export const APP_ID = "00000000-0000-0000-0000-000000000004";

--- a/examples/todo-client-localfirst-svelte/tests/browser/todo-app.test.ts
+++ b/examples/todo-client-localfirst-svelte/tests/browser/todo-app.test.ts
@@ -260,6 +260,7 @@ describe("Svelte Todo App E2E", () => {
   // 7. Server sync between two app instances
   // -------------------------------------------------------------------------
 
+  // Longer timeout: sync can take up to 20s under full-suite load.
   it("syncs a todo between two app instances through the server", async () => {
     const serverUrl = `http://127.0.0.1:${TEST_PORT}`;
 
@@ -281,9 +282,8 @@ describe("Svelte Todo App E2E", () => {
       adminSecret: ADMIN_SECRET,
     });
 
-    // Under heavily loaded CI, give both instances extra time to establish
-    // their event streams before sending the first mutation.
-    await new Promise((r) => setTimeout(r, 2000));
+    // Let both app instances finish server/event-stream setup before mutating.
+    await new Promise((r) => setTimeout(r, 750));
 
     // Add a todo in app 1 via the form
     const input1 = el1.querySelector<HTMLInputElement>("input[type='text']")!;
@@ -302,10 +302,10 @@ describe("Svelte Todo App E2E", () => {
     // Wait for it to appear in app 2 via server sync
     await waitFor(
       () => el2.querySelectorAll("#todo-list li").length === 1,
-      45000,
+      25000,
       "Todo should sync to app 2 through the server",
     );
 
     expect(el2.querySelector("#todo-list li span")!.textContent).toBe("Synced todo");
-  });
+  }, 60000);
 });


### PR DESCRIPTION
## Summary

- Replace the hand-rolled binary spawn in `global-setup.ts` with `startLocalJazzServer` + `pushSchemaCatalogue` from `jazz-tools/testing`, matching the pattern used by the React example
- Give the Svelte tests their own unique port (19879), `APP_ID`, and `ADMIN_SECRET` — previously they shared port 19877 with React (harmless), but moving to 19878 conflicted with the TS example under concurrent turbo execution, causing 401 errors during schema push
- Reduce startup delay before first mutation (2000 → 750 ms) and `waitFor` timeout for the sync test (45 s → 25 s), and add a 60 s per-test timeout so the sync test has headroom without bumping into vitest's default limit

## Test plan

- [ ] `pnpm --filter todo-client-localfirst-svelte test` passes (7/7)
- [ ] `pnpm test` (full suite, all 11 packages) passes with no port conflicts