### PR TITLE
fix(codegen): generate DROP COLUMN for all tables in multi-table migration

### DIFF
--- a/.changeset/pr-187-codegen-multicol-drop.md
+++ b/.changeset/pr-187-codegen-multicol-drop.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+fix(codegen): generate DROP COLUMN statements for all affected tables in multi-table migrations

--- a/packages/jazz-tools/src/cli.test.ts
+++ b/packages/jazz-tools/src/cli.test.ts
@@ -109,6 +109,63 @@ export default {
 `;
 }
 
+function schemaWithMessagesAndCanvases(): string {
+  return `
+import { table, col } from ${JSON.stringify(dslPath)};
+
+table("messages", {
+  content: col.string(),
+  isPublic: col.boolean(),
+});
+
+table("canvases", {
+  name: col.string(),
+  isPublic: col.boolean(),
+});
+`;
+}
+
+function migrationDropIsPublicFromBothTables(): string {
+  return `
+import { migrate, col } from ${JSON.stringify(dslPath)};
+
+migrate("messages", {
+  isPublic: col.drop().boolean({ backwardsDefault: false }),
+});
+
+migrate("canvases", {
+  isPublic: col.drop().boolean({ backwardsDefault: false }),
+});
+`;
+}
+
+describe("cli build migration SQL generation", () => {
+  it("generates DROP COLUMN for every table when migrate() is called on multiple tables", async () => {
+    const { schemaDir, jazzBin } = await createWorkspace();
+    await writeFile(join(schemaDir, "current.ts"), schemaWithMessagesAndCanvases());
+    await writeFile(
+      join(schemaDir, "migration_v1_v2_aaaaaaaaaaaa_bbbbbbbbbbbb.ts"),
+      migrationDropIsPublicFromBothTables(),
+    );
+
+    await build({ schemaDir, jazzBin });
+
+    const fwdSql = await readFile(
+      join(schemaDir, "migration_v1_v2_fwd_aaaaaaaaaaaa_bbbbbbbbbbbb.sql"),
+      "utf8",
+    );
+    const bwdSql = await readFile(
+      join(schemaDir, "migration_v1_v2_bwd_aaaaaaaaaaaa_bbbbbbbbbbbb.sql"),
+      "utf8",
+    );
+
+    expect(fwdSql).toContain("ALTER TABLE messages DROP COLUMN isPublic;");
+    expect(fwdSql).toContain("ALTER TABLE canvases DROP COLUMN isPublic;");
+    expect(bwdSql).toContain("ALTER TABLE messages ADD COLUMN isPublic BOOLEAN DEFAULT FALSE;");
+    expect(bwdSql).toContain("ALTER TABLE canvases ADD COLUMN isPublic BOOLEAN DEFAULT FALSE;");
+  });
+});
+
 describe("cli build permissions generation", () => {
   it("loads permissions.ts, merges policies, and creates permissions.test.ts stub", async () => {
     const { schemaDir, jazzBin } = await createWorkspace();

--- a/packages/jazz-tools/src/cli.ts
+++ b/packages/jazz-tools/src/cli.ts
@@ -7,8 +7,8 @@ import { access, readdir, writeFile } from "fs/promises";
 import { join, basename, dirname } from "path";
 import { pathToFileURL } from "url";
 import { register } from "tsx/esm/api";
-import { schemaToSql, lensToSql } from "./sql-gen.js";
-import { getCollectedSchema, getCollectedMigration, resetCollectedState } from "./dsl.js";
+import { schemaToSql, lensesToSql } from "./sql-gen.js";
+import { getCollectedSchema, getCollectedMigrations, resetCollectedState } from "./dsl.js";
 import { generateClient } from "./codegen/index.js";
 import type { Lens, Schema, TablePolicies, OperationPolicy } from "./schema.js";
 
@@ -52,12 +52,12 @@ async function loadSchema(filePath: string): Promise<Schema> {
   return getCollectedSchema();
 }
 
-async function loadMigrationModule(filePath: string): Promise<Lens | null> {
+async function loadMigrationModule(filePath: string): Promise<Lens[]> {
   resetCollectedState();
   // Add cache-busting query param since Node.js caches dynamic imports
   const url = pathToFileURL(filePath).href + `?v=${++importCounter}`;
   await import(url);
-  return getCollectedMigration();
+  return getCollectedMigrations();
 }
 
 async function generateSqlForSchemaFile(tsFile: string, schema: Schema): Promise<void> {
@@ -104,15 +104,15 @@ function migrationSqlFilename(tsFile: string, direction: "fwd" | "bwd"): string 
 }
 
 async function generateSqlForMigrationFile(tsFile: string): Promise<void> {
-  const lens = await loadMigrationModule(tsFile);
+  const lenses = await loadMigrationModule(tsFile);
 
-  if (!lens) {
+  if (lenses.length === 0) {
     console.error(`No migration found in ${basename(tsFile)}`);
     return;
   }
 
-  const fwdSql = lensToSql(lens, "fwd");
-  const bwdSql = lensToSql(lens, "bwd");
+  const fwdSql = lensesToSql(lenses, "fwd");
+  const bwdSql = lensesToSql(lenses, "bwd");
 
   const fwdFile = migrationSqlFilename(tsFile, "fwd");
   const bwdFile = migrationSqlFilename(tsFile, "bwd");

--- a/packages/jazz-tools/src/dsl.ts
+++ b/packages/jazz-tools/src/dsl.ts
@@ -447,6 +447,34 @@ export function getCollectedMigration(): Lens | null {
   return { table: migration.table, operations };
 }
 
+export function getCollectedMigrations(): Lens[] {
+  const migrations = [...collectedMigrations];
+  collectedMigrations = [];
+  return migrations.map((migration) => {
+    const operations: LensOp[] = migration.operations.map(({ column, op }) => {
+      switch (op._type) {
+        case "add":
+          return {
+            type: "introduce" as const,
+            column,
+            sqlType: op.sqlType,
+            value: op.default,
+          };
+        case "drop":
+          return {
+            type: "drop" as const,
+            column,
+            sqlType: op.sqlType,
+            value: op.backwardsDefault,
+          };
+        case "rename":
+          return { type: "rename" as const, column, value: op.oldName };
+      }
+    });
+    return { table: migration.table, operations };
+  });
+}
+
 export function resetCollectedState(): void {
   collectedTables = [];
   collectedMigrations = [];

--- a/packages/jazz-tools/src/sql-gen.ts
+++ b/packages/jazz-tools/src/sql-gen.ts
@@ -194,3 +194,8 @@ export function lensToSql(lens: Lens, direction: "fwd" | "bwd"): string {
   const converter = direction === "fwd" ? lensOpToForwardSql : lensOpToBackwardSql;
   return lens.operations.map((op) => converter(lens.table, op)).join("\n") + "\n";
 }
+
+export function lensesToSql(lenses: Lens[], direction: "fwd" | "bwd"): string {
+  const ordered = direction === "bwd" ? [...lenses].reverse() : lenses;
+  return ordered.map((lens) => lensToSql(lens, direction)).join("");
+}

--- a/specs/status-quo/schema_files.md
+++ b/specs/status-quo/schema_files.md
@@ -90,6 +90,8 @@ migrate("todos", {
 });
 ```
 
+A stub may call `migrate()` multiple times when a schema change affects more than one table. Each call is collected and all tables are included in the generated SQL.
+
 Uses side-effect collection (no export needed).
 
 > `packages/jazz-tools/src/dsl.ts` (DSL implementation)


### PR DESCRIPTION
## Summary

Fixes a bug where calling `migrate()` on multiple tables in a single migration stub only generated SQL for the first table. The second and subsequent tables were silently dropped.

- `dsl.ts`: add `getCollectedMigrations()` (plural) — the old `getCollectedMigration()` only returned `collectedMigrations[0]`
- `sql-gen.ts`: add `lensesToSql()` — maps all lenses to SQL, reversing order for the backward migration
- `cli.ts`: update `loadMigrationModule` and `generateSqlForMigrationFile` to use the new plural functions
- `specs/status-quo/schema_files.md`: document that a migration stub may call `migrate()` multiple times

## Test plan

- [ ] New CLI integration test (`cli.test.ts`) covers the exact failure: a stub with two `migrate()` calls produces `ALTER TABLE … DROP COLUMN` for both tables in both fwd and bwd SQL
- [ ] `pnpm --filter jazz-tools test` passes (437 tests)
- [ ] `pnpm test` (full suite, 11 packages) passes