### PR TITLE
Optimize opfs-btree parse_header hot path

### DIFF
--- a/crates/opfs-btree/src/page.rs
+++ b/crates/opfs-btree/src/page.rs
@@ -871,14 +871,11 @@ fn parse_header<'a>(
     }
 
     let kind = decode_kind(raw[4])?;
-    let next_page_id = nonzero(u64::from_le_bytes(
-        raw[8..16].try_into().expect("next page id header slice"),
-    ));
-    let item_count = u32::from_le_bytes(raw[16..20].try_into().expect("item count header slice"));
+    let next_page_id = nonzero(read_le_u64(raw, 8));
+    let item_count = read_le_u32(raw, 16);
 
     if verify_checksum {
-        let expected_checksum =
-            u32::from_le_bytes(raw[20..24].try_into().expect("checksum header slice"));
+        let expected_checksum = read_le_u32(raw, 20);
         let actual_checksum = page_checksum(raw);
         if expected_checksum != actual_checksum {
             return Err(BTreeError::Corrupt(format!(
@@ -1346,6 +1343,30 @@ fn page_checksum(raw: &[u8]) -> u32 {
     hasher.update(&raw[..20]);
     hasher.update(&raw[24..]);
     hasher.finalize()
+}
+
+#[inline]
+fn read_le_u32(raw: &[u8], offset: usize) -> u32 {
+    u32::from_le_bytes([
+        raw[offset],
+        raw[offset + 1],
+        raw[offset + 2],
+        raw[offset + 3],
+    ])
+}
+
+#[inline]
+fn read_le_u64(raw: &[u8], offset: usize) -> u64 {
+    u64::from_le_bytes([
+        raw[offset],
+        raw[offset + 1],
+        raw[offset + 2],
+        raw[offset + 3],
+        raw[offset + 4],
+        raw[offset + 5],
+        raw[offset + 6],
+        raw[offset + 7],
+    ])
 }
 
 fn nonzero(value: u64) -> Option<u64> {


### PR DESCRIPTION
## Summary
- replace `parse_header` slice-to-array conversions with direct fixed-offset little-endian readers
- keep checksum, magic, and page-size validation behavior unchanged
- add small inline helpers for u32/u64 header field decoding

## Validation
- cargo test -p opfs-btree --lib page -- --nocapture

limit 100 on 30k rows

Before:
<img width="706" height="996" alt="Screenshot 2026-03-02 at 19 12 20" src="https://github.com/user-attachments/assets/5c5ea3ff-90bb-4637-b8a0-e3965ac24230" />

After:
<img width="710" height="923" alt="Screenshot 2026-03-02 at 19 10 24" src="https://github.com/user-attachments/assets/5669341d-b854-46ee-ace2-f503c0b08550" />

