### PR TITLE
opfs-btree: cache page header validation for cached pages

### DIFF
--- a/crates/opfs-btree/src/db.rs
+++ b/crates/opfs-btree/src/db.rs
@@ -265,8 +265,6 @@ impl<F: SyncFile> OpfsBTree<F> {
         let root_page_raw = self.pages.get(&root_page_id).ok_or_else(|| {
             BTreeError::Corrupt(format!("root page {} missing after delete", root_page_id))
         })?;
-        // Safe: tree pages are checksum-validated when read from disk, and this
-        // buffer is already resident in the in-memory page cache.
         let root_page = decode_page(root_page_raw, self.options.page_size)?;
 
         if let Page::Leaf { entries, .. } = &root_page
@@ -450,7 +448,6 @@ impl<F: SyncFile> OpfsBTree<F> {
                 let page_raw = self.pages.get(&page_id).cloned().ok_or_else(|| {
                     BTreeError::Corrupt(format!("page {} missing during insert", page_id))
                 })?;
-                // Safe: page bytes came from the validated cache entry for this page_id.
                 let page = decode_page(&page_raw, self.options.page_size)?;
                 let Page::Leaf { mut entries, next } = page else {
                     return Err(BTreeError::Corrupt(format!(
@@ -517,7 +514,6 @@ impl<F: SyncFile> OpfsBTree<F> {
                 let page_raw = self.pages.get(&page_id).cloned().ok_or_else(|| {
                     BTreeError::Corrupt(format!("page {} missing during insert", page_id))
                 })?;
-                // Safe: page bytes came from the validated cache entry for this page_id.
                 let page = decode_page(&page_raw, self.options.page_size)?;
                 let Page::Internal {
                     mut keys,
@@ -629,7 +625,6 @@ impl<F: SyncFile> OpfsBTree<F> {
                 let page_raw = self.pages.get(&page_id).cloned().ok_or_else(|| {
                     BTreeError::Corrupt(format!("page {} missing during delete", page_id))
                 })?;
-                // Safe: page bytes came from the validated cache entry for this page_id.
                 let page = decode_page(&page_raw, self.options.page_size)?;
                 let Page::Internal { keys, children } = page else {
                     return Err(BTreeError::Corrupt(format!(

--- a/crates/opfs-btree/src/db.rs
+++ b/crates/opfs-btree/src/db.rs
@@ -5,9 +5,9 @@ use crate::BTreeError;
 use crate::file::SyncFile;
 use crate::page::{
     OverflowRef, Page, PageId, PageKind, RawLeafDeleteResult, RawLeafUpsertResult, ValueCell,
-    ValueCellRef, decode_page, encode_page, freelist_ids_per_page, page_fits, raw_freelist_page,
-    raw_internal_child_for_key, raw_leaf_delete_in_place, raw_leaf_find_value, raw_leaf_scan,
-    raw_leaf_upsert_in_place, raw_page_kind, validate_page,
+    ValueCellRef, decode_page_unchecked, encode_page, freelist_ids_per_page, page_fits,
+    raw_freelist_page, raw_internal_child_for_key, raw_leaf_delete_in_place, raw_leaf_find_value,
+    raw_leaf_scan, raw_leaf_upsert_in_place, raw_page_kind, validate_page,
 };
 use crate::superblock::{Superblock, SuperblockSlot};
 
@@ -265,7 +265,9 @@ impl<F: SyncFile> OpfsBTree<F> {
         let root_page_raw = self.pages.get(&root_page_id).ok_or_else(|| {
             BTreeError::Corrupt(format!("root page {} missing after delete", root_page_id))
         })?;
-        let root_page = decode_page(root_page_raw, self.options.page_size)?;
+        // Safe: tree pages are checksum-validated when read from disk, and this
+        // buffer is already resident in the in-memory page cache.
+        let root_page = decode_page_unchecked(root_page_raw, self.options.page_size)?;
 
         if let Page::Leaf { entries, .. } = &root_page
             && entries.is_empty()
@@ -448,7 +450,8 @@ impl<F: SyncFile> OpfsBTree<F> {
                 let page_raw = self.pages.get(&page_id).cloned().ok_or_else(|| {
                     BTreeError::Corrupt(format!("page {} missing during insert", page_id))
                 })?;
-                let page = decode_page(&page_raw, self.options.page_size)?;
+                // Safe: page bytes came from the validated cache entry for this page_id.
+                let page = decode_page_unchecked(&page_raw, self.options.page_size)?;
                 let Page::Leaf { mut entries, next } = page else {
                     return Err(BTreeError::Corrupt(format!(
                         "expected leaf page {}, found non-leaf during split fallback",
@@ -514,7 +517,8 @@ impl<F: SyncFile> OpfsBTree<F> {
                 let page_raw = self.pages.get(&page_id).cloned().ok_or_else(|| {
                     BTreeError::Corrupt(format!("page {} missing during insert", page_id))
                 })?;
-                let page = decode_page(&page_raw, self.options.page_size)?;
+                // Safe: page bytes came from the validated cache entry for this page_id.
+                let page = decode_page_unchecked(&page_raw, self.options.page_size)?;
                 let Page::Internal {
                     mut keys,
                     mut children,
@@ -625,7 +629,8 @@ impl<F: SyncFile> OpfsBTree<F> {
                 let page_raw = self.pages.get(&page_id).cloned().ok_or_else(|| {
                     BTreeError::Corrupt(format!("page {} missing during delete", page_id))
                 })?;
-                let page = decode_page(&page_raw, self.options.page_size)?;
+                // Safe: page bytes came from the validated cache entry for this page_id.
+                let page = decode_page_unchecked(&page_raw, self.options.page_size)?;
                 let Page::Internal { keys, children } = page else {
                     return Err(BTreeError::Corrupt(format!(
                         "expected internal page {}, found non-internal during delete",

--- a/crates/opfs-btree/src/db.rs
+++ b/crates/opfs-btree/src/db.rs
@@ -5,9 +5,9 @@ use crate::BTreeError;
 use crate::file::SyncFile;
 use crate::page::{
     OverflowRef, Page, PageId, PageKind, RawLeafDeleteResult, RawLeafUpsertResult, ValueCell,
-    ValueCellRef, decode_page_unchecked, encode_page, freelist_ids_per_page, page_fits,
-    raw_freelist_page, raw_internal_child_for_key, raw_leaf_delete_in_place, raw_leaf_find_value,
-    raw_leaf_scan, raw_leaf_upsert_in_place, raw_page_kind, validate_page,
+    ValueCellRef, decode_page, encode_page, freelist_ids_per_page, page_fits, raw_freelist_page,
+    raw_internal_child_for_key, raw_leaf_delete_in_place, raw_leaf_find_value, raw_leaf_scan,
+    raw_leaf_upsert_in_place, raw_page_kind, validate_page,
 };
 use crate::superblock::{Superblock, SuperblockSlot};
 
@@ -267,7 +267,7 @@ impl<F: SyncFile> OpfsBTree<F> {
         })?;
         // Safe: tree pages are checksum-validated when read from disk, and this
         // buffer is already resident in the in-memory page cache.
-        let root_page = decode_page_unchecked(root_page_raw, self.options.page_size)?;
+        let root_page = decode_page(root_page_raw, self.options.page_size)?;
 
         if let Page::Leaf { entries, .. } = &root_page
             && entries.is_empty()
@@ -451,7 +451,7 @@ impl<F: SyncFile> OpfsBTree<F> {
                     BTreeError::Corrupt(format!("page {} missing during insert", page_id))
                 })?;
                 // Safe: page bytes came from the validated cache entry for this page_id.
-                let page = decode_page_unchecked(&page_raw, self.options.page_size)?;
+                let page = decode_page(&page_raw, self.options.page_size)?;
                 let Page::Leaf { mut entries, next } = page else {
                     return Err(BTreeError::Corrupt(format!(
                         "expected leaf page {}, found non-leaf during split fallback",
@@ -518,7 +518,7 @@ impl<F: SyncFile> OpfsBTree<F> {
                     BTreeError::Corrupt(format!("page {} missing during insert", page_id))
                 })?;
                 // Safe: page bytes came from the validated cache entry for this page_id.
-                let page = decode_page_unchecked(&page_raw, self.options.page_size)?;
+                let page = decode_page(&page_raw, self.options.page_size)?;
                 let Page::Internal {
                     mut keys,
                     mut children,
@@ -630,7 +630,7 @@ impl<F: SyncFile> OpfsBTree<F> {
                     BTreeError::Corrupt(format!("page {} missing during delete", page_id))
                 })?;
                 // Safe: page bytes came from the validated cache entry for this page_id.
-                let page = decode_page_unchecked(&page_raw, self.options.page_size)?;
+                let page = decode_page(&page_raw, self.options.page_size)?;
                 let Page::Internal { keys, children } = page else {
                     return Err(BTreeError::Corrupt(format!(
                         "expected internal page {}, found non-internal during delete",

--- a/crates/opfs-btree/src/page.rs
+++ b/crates/opfs-btree/src/page.rs
@@ -131,11 +131,6 @@ pub(crate) fn encode_page(page: &Page, page_size: usize) -> Result<Vec<u8>, BTre
     Ok(raw)
 }
 
-#[cfg_attr(not(test), allow(dead_code))]
-pub(crate) fn decode_page(raw: &[u8], expected_page_size: usize) -> Result<Page, BTreeError> {
-    decode_page_with_checksum(raw, expected_page_size, true)
-}
-
 pub(crate) fn decode_page_unchecked(
     raw: &[u8],
     expected_page_size: usize,
@@ -1465,7 +1460,7 @@ mod tests {
         };
 
         let encoded = encode_page(&page, 4096).expect("encode leaf page");
-        let decoded = decode_page(&encoded, 4096).expect("decode leaf page");
+        let decoded = decode_page_with_checksum(&encoded, 4096, true).expect("decode leaf page");
         assert_eq!(decoded, page);
     }
 
@@ -1479,7 +1474,7 @@ mod tests {
         let mut encoded = encode_page(&page, 4096).expect("encode overflow page");
         encoded[100] ^= 0xFF;
 
-        let err = decode_page(&encoded, 4096).expect_err("must fail checksum");
+        let err = decode_page_with_checksum(&encoded, 4096, true).expect_err("must fail checksum");
         assert!(matches!(err, BTreeError::Corrupt(_)));
     }
 
@@ -1490,7 +1485,7 @@ mod tests {
         let (decoded_chunk, next) = raw_overflow_chunk(&raw, 4096).expect("raw overflow");
         assert_eq!(decoded_chunk, chunk.as_slice());
         assert_eq!(next, Some(42));
-        let decoded_page = decode_page(&raw, 4096).expect("decode");
+        let decoded_page = decode_page_with_checksum(&raw, 4096, true).expect("decode");
         assert_eq!(
             decoded_page,
             Page::Overflow {
@@ -1533,7 +1528,7 @@ mod tests {
             }
         );
 
-        let decoded = decode_page(&raw, 4096).expect("decode");
+        let decoded = decode_page_with_checksum(&raw, 4096, true).expect("decode");
         assert_eq!(
             decoded,
             Page::Leaf {

--- a/crates/opfs-btree/src/page.rs
+++ b/crates/opfs-btree/src/page.rs
@@ -131,19 +131,8 @@ pub(crate) fn encode_page(page: &Page, page_size: usize) -> Result<Vec<u8>, BTre
     Ok(raw)
 }
 
-pub(crate) fn decode_page_unchecked(
-    raw: &[u8],
-    expected_page_size: usize,
-) -> Result<Page, BTreeError> {
-    decode_page_with_checksum(raw, expected_page_size, false)
-}
-
-fn decode_page_with_checksum(
-    raw: &[u8],
-    expected_page_size: usize,
-    verify_checksum: bool,
-) -> Result<Page, BTreeError> {
-    let header = parse_header(raw, expected_page_size, verify_checksum)?;
+pub(crate) fn decode_page(raw: &[u8], expected_page_size: usize) -> Result<Page, BTreeError> {
+    let header = parse_header(raw, expected_page_size, false)?;
     let payload = header.payload;
 
     match header.kind {
@@ -1460,7 +1449,7 @@ mod tests {
         };
 
         let encoded = encode_page(&page, 4096).expect("encode leaf page");
-        let decoded = decode_page_with_checksum(&encoded, 4096, true).expect("decode leaf page");
+        let decoded = decode_page(&encoded, 4096).expect("decode leaf page");
         assert_eq!(decoded, page);
     }
 
@@ -1474,7 +1463,7 @@ mod tests {
         let mut encoded = encode_page(&page, 4096).expect("encode overflow page");
         encoded[100] ^= 0xFF;
 
-        let err = decode_page_with_checksum(&encoded, 4096, true).expect_err("must fail checksum");
+        let err = validate_page(&encoded, 4096).expect_err("must fail checksum");
         assert!(matches!(err, BTreeError::Corrupt(_)));
     }
 
@@ -1485,7 +1474,7 @@ mod tests {
         let (decoded_chunk, next) = raw_overflow_chunk(&raw, 4096).expect("raw overflow");
         assert_eq!(decoded_chunk, chunk.as_slice());
         assert_eq!(next, Some(42));
-        let decoded_page = decode_page_with_checksum(&raw, 4096, true).expect("decode");
+        let decoded_page = decode_page(&raw, 4096).expect("decode");
         assert_eq!(
             decoded_page,
             Page::Overflow {
@@ -1528,7 +1517,7 @@ mod tests {
             }
         );
 
-        let decoded = decode_page_with_checksum(&raw, 4096, true).expect("decode");
+        let decoded = decode_page(&raw, 4096).expect("decode");
         assert_eq!(
             decoded,
             Page::Leaf {

--- a/crates/opfs-btree/src/page.rs
+++ b/crates/opfs-btree/src/page.rs
@@ -131,8 +131,24 @@ pub(crate) fn encode_page(page: &Page, page_size: usize) -> Result<Vec<u8>, BTre
     Ok(raw)
 }
 
+#[cfg_attr(not(test), allow(dead_code))]
 pub(crate) fn decode_page(raw: &[u8], expected_page_size: usize) -> Result<Page, BTreeError> {
-    let header = parse_header(raw, expected_page_size, true)?;
+    decode_page_with_checksum(raw, expected_page_size, true)
+}
+
+pub(crate) fn decode_page_unchecked(
+    raw: &[u8],
+    expected_page_size: usize,
+) -> Result<Page, BTreeError> {
+    decode_page_with_checksum(raw, expected_page_size, false)
+}
+
+fn decode_page_with_checksum(
+    raw: &[u8],
+    expected_page_size: usize,
+    verify_checksum: bool,
+) -> Result<Page, BTreeError> {
+    let header = parse_header(raw, expected_page_size, verify_checksum)?;
     let payload = header.payload;
 
     match header.kind {


### PR DESCRIPTION
To me it looks like decode_page is always called on in-memory pages that should have already been validated when loaded from storage.

If this optimization is safe, it helps on getting another ~15% improvement on load

Before:
<img width="519" height="143" alt="Screenshot 2026-03-02 at 19 27 18" src="https://github.com/user-attachments/assets/bc12c406-ff8a-437b-a91d-1b0428e5df24" />

After:
<img width="425" height="120" alt="Screenshot 2026-03-02 at 19 26 59" src="https://github.com/user-attachments/assets/b60648c6-c38f-4bec-8654-caec8661c4c9" />