### PR TITLE
Support direct query-builder usage in backend clients

### DIFF
--- a/.changeset/tall-bees-grow.md
+++ b/.changeset/tall-bees-grow.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Allow backend `JazzClient` and `SessionClient` query/subscribe calls to consume generated query builders directly. Query-builder payloads with `_schema` are now translated automatically to runtime query JSON (`relation_ir`), so backend code can call `context.forRequest(...).query(app.todos.where(...))` without manual `translateQuery(...)`.

--- a/crates/jazz-napi/index.d.ts
+++ b/crates/jazz-napi/index.d.ts
@@ -23,12 +23,14 @@ export declare class NapiRuntime {
     queryJson: string,
     sessionJson?: string | undefined | null,
     settledTier?: string | undefined | null,
+    optionsJson?: string | undefined | null,
   ): Promise<any>;
   subscribe(
     queryJson: string,
     onUpdate: (...args: any[]) => any,
     sessionJson?: string | undefined | null,
     settledTier?: string | undefined | null,
+    optionsJson?: string | undefined | null,
   ): number;
   unsubscribe(handle: number): void;
   insertWithAck(table: string, values: any, tier: string): Promise<string>;

--- a/examples/docs/todo-server-ts/src/main.ts
+++ b/examples/docs/todo-server-ts/src/main.ts
@@ -10,8 +10,8 @@ import type { Server } from "node:http";
 import { tmpdir } from "node:os";
 import { mkdtempSync } from "node:fs";
 import { join } from "node:path";
-import { createJazzContext, translateQuery, type JazzClient, type Value } from "jazz-tools/backend";
-import { app as schemaApp, wasmSchema as schema } from "../schema/app.js";
+import { createJazzContext, type JazzClient, type Value } from "jazz-tools/backend";
+import { app as schemaApp } from "../schema/app.js";
 
 // ============================================================================
 // Types
@@ -72,18 +72,6 @@ function rowToTodo(id: string, values: Value[]): Todo | null {
   };
 }
 
-function buildQuery(table: string) {
-  return translateQuery(
-    JSON.stringify({
-      table,
-      conditions: [],
-      includes: {},
-      orderBy: [],
-    }),
-    schema,
-  );
-}
-
 // ============================================================================
 // Server Factory
 // ============================================================================
@@ -118,7 +106,7 @@ export async function createServer(dataPath?: string): Promise<TodoServer> {
 
   // Helper to broadcast current todos to all SSE connections
   async function broadcastTodos() {
-    const rows = await client.query(buildQuery("todos"));
+    const rows = await client.query(schemaApp.todos);
     const todos = rows
       .map((row) => rowToTodo(row.id, row.values))
       .filter((t): t is Todo => t !== null);
@@ -141,7 +129,7 @@ export async function createServer(dataPath?: string): Promise<TodoServer> {
   // List all todos
   app.get("/todos", async (_req: Request, res: Response, next: NextFunction) => {
     try {
-      const rows = await client.query(buildQuery("todos"));
+      const rows = await client.query(schemaApp.todos);
       const todos = rows
         .map((row) => rowToTodo(row.id, row.values))
         .filter((t): t is Todo => t !== null);
@@ -193,7 +181,7 @@ export async function createServer(dataPath?: string): Promise<TodoServer> {
   // List todos as a specific session user (for policy verification/testing)
   app.get("/todos/as/:userId", async (req: Request, res: Response, next: NextFunction) => {
     try {
-      const rows = await client.queryInternal(buildQuery("todos"), {
+      const rows = await client.queryInternal(schemaApp.todos, {
         user_id: req.params.userId,
         claims: {},
       });
@@ -218,7 +206,7 @@ export async function createServer(dataPath?: string): Promise<TodoServer> {
     sseConnections.add(res);
 
     // Send initial state
-    const rows = await client.query(buildQuery("todos"));
+    const rows = await client.query(schemaApp.todos);
     const todos = rows
       .map((row) => rowToTodo(row.id, row.values))
       .filter((t): t is Todo => t !== null);
@@ -235,7 +223,7 @@ export async function createServer(dataPath?: string): Promise<TodoServer> {
     try {
       const { id } = req.params;
 
-      const rows = await client.query(buildQuery("todos"));
+      const rows = await client.query(schemaApp.todos.where({ id }));
       const row = rows.find((r) => r.id === id);
 
       if (!row) {
@@ -275,7 +263,7 @@ export async function createServer(dataPath?: string): Promise<TodoServer> {
 
       if (Object.keys(updates).length === 0) {
         // No updates, just return the current todo
-        const rows = await client.query(buildQuery("todos"));
+        const rows = await client.query(schemaApp.todos.where({ id }));
         const row = rows.find((r) => r.id === id);
 
         if (!row) {
@@ -291,7 +279,7 @@ export async function createServer(dataPath?: string): Promise<TodoServer> {
       await client.update(id, updates);
 
       // Fetch updated todo
-      const rows = await client.query(buildQuery("todos"));
+      const rows = await client.query(schemaApp.todos.where({ id }));
       const row = rows.find((r) => r.id === id);
 
       if (!row) {

--- a/examples/todo-server-ts/src/main.ts
+++ b/examples/todo-server-ts/src/main.ts
@@ -10,8 +10,8 @@ import type { Server } from "node:http";
 import { tmpdir } from "node:os";
 import { mkdtempSync } from "node:fs";
 import { join } from "node:path";
-import { createJazzContext, translateQuery, type JazzClient, type Value } from "jazz-tools/backend";
-import { app as schemaApp, wasmSchema as schema } from "../schema/app.js";
+import { createJazzContext, type JazzClient, type Value } from "jazz-tools/backend";
+import { app as schemaApp } from "../schema/app.js";
 
 // ============================================================================
 // Types
@@ -72,18 +72,6 @@ function rowToTodo(id: string, values: Value[]): Todo | null {
   };
 }
 
-function buildQuery(table: string) {
-  return translateQuery(
-    JSON.stringify({
-      table,
-      conditions: [],
-      includes: {},
-      orderBy: [],
-    }),
-    schema,
-  );
-}
-
 // ============================================================================
 // Server Factory
 // ============================================================================
@@ -116,7 +104,7 @@ export async function createServer(dataPath?: string): Promise<TodoServer> {
 
   // Helper to broadcast current todos to all SSE connections
   async function broadcastTodos() {
-    const rows = await client.query(buildQuery("todos"));
+    const rows = await client.query(schemaApp.todos);
     const todos = rows
       .map((row) => rowToTodo(row.id, row.values))
       .filter((t): t is Todo => t !== null);
@@ -139,7 +127,7 @@ export async function createServer(dataPath?: string): Promise<TodoServer> {
   // List all todos
   app.get("/todos", async (_req: Request, res: Response, next: NextFunction) => {
     try {
-      const rows = await client.query(buildQuery("todos"));
+      const rows = await client.query(schemaApp.todos);
       const todos = rows
         .map((row) => rowToTodo(row.id, row.values))
         .filter((t): t is Todo => t !== null);
@@ -191,7 +179,7 @@ export async function createServer(dataPath?: string): Promise<TodoServer> {
   // List todos as a specific session user (for policy verification/testing)
   app.get("/todos/as/:userId", async (req: Request, res: Response, next: NextFunction) => {
     try {
-      const rows = await client.queryInternal(buildQuery("todos"), {
+      const rows = await client.queryInternal(schemaApp.todos, {
         user_id: req.params.userId,
         claims: {},
       });
@@ -216,7 +204,7 @@ export async function createServer(dataPath?: string): Promise<TodoServer> {
     sseConnections.add(res);
 
     // Send initial state
-    const rows = await client.query(buildQuery("todos"));
+    const rows = await client.query(schemaApp.todos);
     const todos = rows
       .map((row) => rowToTodo(row.id, row.values))
       .filter((t): t is Todo => t !== null);
@@ -233,7 +221,7 @@ export async function createServer(dataPath?: string): Promise<TodoServer> {
     try {
       const { id } = req.params;
 
-      const rows = await client.query(buildQuery("todos"));
+      const rows = await client.query(schemaApp.todos.where({ id }));
       const row = rows.find((r) => r.id === id);
 
       if (!row) {
@@ -273,7 +261,7 @@ export async function createServer(dataPath?: string): Promise<TodoServer> {
 
       if (Object.keys(updates).length === 0) {
         // No updates, just return the current todo
-        const rows = await client.query(buildQuery("todos"));
+        const rows = await client.query(schemaApp.todos.where({ id }));
         const row = rows.find((r) => r.id === id);
 
         if (!row) {
@@ -289,7 +277,7 @@ export async function createServer(dataPath?: string): Promise<TodoServer> {
       await client.update(id, updates);
 
       // Fetch updated todo
-      const rows = await client.query(buildQuery("todos"));
+      const rows = await client.query(schemaApp.todos.where({ id }));
       const row = rows.find((r) => r.id === id);
 
       if (!row) {

--- a/examples/todo-server-ts/src/request-context.ts
+++ b/examples/todo-server-ts/src/request-context.ts
@@ -1,6 +1,6 @@
 import type { Request } from "express";
-import { translateQuery, type JazzContext, type Session } from "jazz-tools/backend";
-import { app as schemaApp, wasmSchema as schema } from "../schema/app.js";
+import { type JazzContext, type Session } from "jazz-tools/backend";
+import { app as schemaApp } from "../schema/app.js";
 
 type RequesterIdentity = {
   userId: string;
@@ -10,30 +10,6 @@ type RequesterIdentity = {
 function verifyJwtAndExtractIdentity(_jwt: string): RequesterIdentity {
   // Replace with your auth provider's JWT verification logic.
   return { userId: "replace-with-verified-sub", claims: {} };
-}
-
-function buildQuery(table: string): string {
-  return translateQuery(
-    JSON.stringify({
-      table,
-      conditions: [],
-      includes: {},
-      orderBy: [],
-    }),
-    schema,
-  );
-}
-
-function buildFolderScopedQuery(folderId: string): string {
-  return translateQuery(
-    JSON.stringify({
-      table: "todos",
-      conditions: [{ column: "folder_id", op: "eq", value: folderId }],
-      includes: {},
-      orderBy: [],
-    }),
-    schema,
-  );
 }
 
 export function sessionFromRequest(req: Request): Session {
@@ -49,13 +25,13 @@ export function sessionFromRequest(req: Request): Session {
 
 export async function listTodosForRequester(req: Request, context: JazzContext) {
   const userClient = context.forSession(sessionFromRequest(req), schemaApp);
-  const rows = await userClient.query(buildQuery("todos"));
+  const rows = await userClient.query(schemaApp.todos);
   return rows;
 }
 
 export async function listTodosWithSimplePolicy(req: Request, context: JazzContext) {
   const userClient = context.forSession(sessionFromRequest(req), schemaApp);
-  return userClient.query(buildQuery("todos"));
+  return userClient.query(schemaApp.todos);
 }
 
 export async function listTodosWithInheritedPolicy(
@@ -64,5 +40,5 @@ export async function listTodosWithInheritedPolicy(
   folderId: string,
 ) {
   const userClient = context.forSession(sessionFromRequest(req), schemaApp);
-  return userClient.query(buildFolderScopedQuery(folderId));
+  return userClient.query(schemaApp.todos.where({ project: folderId }));
 }

--- a/packages/jazz-tools/src/runtime/client.for-request.test.ts
+++ b/packages/jazz-tools/src/runtime/client.for-request.test.ts
@@ -2,6 +2,18 @@ import { describe, expect, it, vi } from "vitest";
 import { JazzClient, type Runtime } from "./client.js";
 import type { AppContext } from "./context.js";
 
+const schemaWithTodos = {
+  todos: {
+    columns: [
+      {
+        name: "done",
+        column_type: { type: "Boolean" as const },
+        nullable: false,
+      },
+    ],
+  },
+} as AppContext["schema"];
+
 function toBase64Url(value: unknown): string {
   const encoded = Buffer.from(JSON.stringify(value), "utf8").toString("base64");
   return encoded.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
@@ -172,6 +184,35 @@ describe("JazzClient.forRequest", () => {
     expect(queryCalls[0][0]).toBe(builder._build());
   });
 
+  it("translates schema-aware query builders for session-scoped query calls", async () => {
+    const { client, queryCalls } = makeClient();
+    const token = makeJwt({ sub: "user-901" });
+
+    const scopedClient = client.forRequest({
+      headers: {
+        authorization: `Bearer ${token}`,
+      },
+    });
+
+    const builder = {
+      _schema: schemaWithTodos,
+      _build() {
+        return JSON.stringify({
+          table: "todos",
+          conditions: [{ column: "done", op: "eq", value: true }],
+          includes: {},
+          orderBy: [],
+        });
+      },
+    };
+
+    await scopedClient.query(builder);
+
+    const parsed = JSON.parse(queryCalls[0][0]) as Record<string, unknown>;
+    expect(parsed.table).toBe("todos");
+    expect(parsed).toHaveProperty("relation_ir");
+  });
+
   it("accepts query builders for subscribe calls", () => {
     const { client, subscribeCalls } = makeClient();
 
@@ -185,6 +226,29 @@ describe("JazzClient.forRequest", () => {
 
     expect(subId).toBe(1);
     expect(subscribeCalls[0][0]).toBe(builder._build());
+  });
+
+  it("translates schema-aware query builders for subscribe calls", () => {
+    const { client, subscribeCalls } = makeClient();
+
+    const builder = {
+      _schema: schemaWithTodos,
+      _build() {
+        return JSON.stringify({
+          table: "todos",
+          conditions: [],
+          includes: {},
+          orderBy: [],
+        });
+      },
+    };
+
+    const subId = client.subscribe(builder, () => {});
+
+    expect(subId).toBe(1);
+    const parsed = JSON.parse(subscribeCalls[0][0]) as Record<string, unknown>;
+    expect(parsed.table).toBe("todos");
+    expect(parsed).toHaveProperty("relation_ir");
   });
 
   it("forwards structured RN delta payloads to subscription callbacks", () => {

--- a/packages/jazz-tools/src/runtime/client.ts
+++ b/packages/jazz-tools/src/runtime/client.ts
@@ -22,6 +22,7 @@ import {
 } from "./sync-transport.js";
 import { resolveLocalAuthDefaults } from "./local-auth.js";
 import { resolveJwtSession } from "./client-session.js";
+import { translateQuery } from "./query-adapter.js";
 
 /**
  * Minimal request shape supported by `JazzClient.forRequest()`.
@@ -113,10 +114,32 @@ export type LinkExternalIdentityResult = LinkExternalResponse;
  */
 export interface QueryInput {
   _build(): string;
+  /** Optional schema metadata available on generated QueryBuilder objects. */
+  _schema?: WasmSchema;
 }
 
 function resolveQueryJson(query: string | QueryInput): string {
-  return typeof query === "string" ? query : query._build();
+  if (typeof query === "string") {
+    return query;
+  }
+
+  const builtQuery = query._build();
+  const schema = query._schema;
+  if (!schema || typeof schema !== "object" || Array.isArray(schema)) {
+    return builtQuery;
+  }
+
+  // Query payloads already in runtime form include relation_ir and should pass through unchanged.
+  try {
+    const parsed = JSON.parse(builtQuery) as Record<string, unknown>;
+    if (parsed && typeof parsed === "object" && "relation_ir" in parsed) {
+      return builtQuery;
+    }
+  } catch {
+    return builtQuery;
+  }
+
+  return translateQuery(builtQuery, schema);
 }
 
 function normalizeQueryExecutionOptions(options?: QueryExecutionOptions): QueryExecutionOptions {
@@ -313,7 +336,7 @@ export class SessionClient {
    * Query as this session's user.
    */
   async query(query: string | QueryInput, options?: QueryExecutionOptions): Promise<Row[]> {
-    return this.client.queryInternal(resolveQueryJson(query), this.session, options);
+    return this.client.queryInternal(query, this.session, options);
   }
 
   /**
@@ -515,7 +538,7 @@ export class JazzClient {
    * @returns Array of matching rows
    */
   async query(query: string | QueryInput, options?: QueryExecutionOptions): Promise<Row[]> {
-    return this.queryInternal(resolveQueryJson(query), this.resolvedSession ?? undefined, options);
+    return this.queryInternal(query, this.resolvedSession ?? undefined, options);
   }
 
   /**
@@ -523,11 +546,12 @@ export class JazzClient {
    * @internal
    */
   async queryInternal(
-    queryJson: string,
+    query: string | QueryInput,
     session?: Session,
     options?: QueryExecutionOptions,
   ): Promise<Row[]> {
     const normalizedOptions = normalizeQueryExecutionOptions(options);
+    const queryJson = resolveQueryJson(query);
     const sessionJson = session ? JSON.stringify(session) : undefined;
     const optionsJson = encodeQueryExecutionOptions(normalizedOptions);
     const results = await this.runtime.query(


### PR DESCRIPTION
## Summary
- allow JazzClient and SessionClient query/subscribe paths to accept generated query builders directly when _schema is available
- auto-translate builder JSON to runtime query JSON (relation_ir) in runtime/client.ts, with passthrough for already-translated payloads
- update TypeScript backend example servers to use direct builder queries instead of manual translateQuery calls
- add runtime tests covering schema-aware builder translation for query and subscribe

## Validation
- pnpm build
- pnpm --filter jazz-tools exec vitest run src/runtime/client.for-request.test.ts src/backend/create-jazz-context.test.ts --config vitest.config.ts
- pnpm --filter todo-server-ts test
- pnpm --filter todo-server-ts-docs test
