### PR TITLE
Overhaul durability tiers and migrate read/write APIs

### DIFF
--- a/.changeset/durability-tier-overhaul-summary.md
+++ b/.changeset/durability-tier-overhaul-summary.md
@@ -1,0 +1,10 @@
+---
+"jazz-tools": patch
+---
+
+Overhauled durability APIs to use a single `DurabilityTier` model across reads and writes.
+
+- Reads now take `{ tier, localUpdates }`, where `localUpdates` defaults to `"immediate"` so local writes are reflected right away even when waiting for a more remote durability tier.
+- Writes now use the base methods with optional `{ tier }` and environment-aware defaults (`"worker"` for clients, `"edge"` for backend contexts).
+- Renamed the top tier from `"core"` to `"global"` for clearer semantics.
+- Added multi-tier node identity support so single-node deployments (like CLI and cloud-server today) can acknowledge both `"edge"` and `"global"`.

--- a/crates/jazz-cloud-server/src/server.rs
+++ b/crates/jazz-cloud-server/src/server.rs
@@ -28,11 +28,12 @@ use jazz_tools::query_manager::session::Session;
 use jazz_tools::query_manager::types::{
     ColumnType, Schema, SchemaBuilder, SchemaHash, TableSchema, Value,
 };
+use jazz_tools::runtime_core::ReadDurabilityOptions;
 use jazz_tools::runtime_tokio::TokioRuntime;
 use jazz_tools::schema_manager::{AppId, SchemaManager, rehydrate_schema_manager_from_manifest};
 use jazz_tools::storage::SurrealKvStorage;
 use jazz_tools::sync_manager::{
-    ClientId, Destination, InboxEntry, PersistenceTier, Source, SyncManager, SyncPayload,
+    ClientId, Destination, DurabilityTier, InboxEntry, Source, SyncManager, SyncPayload,
 };
 use jsonwebtoken::jwk::{Jwk, JwkSet, KeyAlgorithm};
 use jsonwebtoken::{Algorithm, DecodingKey, Validation, decode, decode_header};
@@ -1057,7 +1058,10 @@ impl MetaStore {
             )
             .build();
 
-        let sync_manager = SyncManager::new().with_tier(PersistenceTier::EdgeServer);
+        let sync_manager = SyncManager::new().with_durability_tiers(vec![
+            DurabilityTier::EdgeServer,
+            DurabilityTier::GlobalServer,
+        ]);
         let schema_manager = SchemaManager::new(
             sync_manager,
             meta_schema,
@@ -1097,7 +1101,7 @@ impl MetaStore {
         let query = QueryBuilder::new("apps").build();
         let future = self
             .runtime
-            .query(query, None, None)
+            .query(query, None, ReadDurabilityOptions::default())
             .map_err(|e| format!("meta query error: {e}"))?;
 
         let rows = future
@@ -1115,7 +1119,7 @@ impl MetaStore {
             .build();
         let future = self
             .runtime
-            .query(query, None, None)
+            .query(query, None, ReadDurabilityOptions::default())
             .map_err(|e| format!("meta query error: {e}"))?;
         let mut rows = future
             .await
@@ -1253,7 +1257,7 @@ impl MetaStore {
 
         let future = self
             .runtime
-            .query(query, None, None)
+            .query(query, None, ReadDurabilityOptions::default())
             .map_err(|e| format!("external identity query error: {e}"))?;
         let mut rows = future
             .await
@@ -1486,7 +1490,10 @@ impl AppRuntime {
             )
         })?;
 
-        let sync_manager = SyncManager::new().with_tier(PersistenceTier::EdgeServer);
+        let sync_manager = SyncManager::new().with_durability_tiers(vec![
+            DurabilityTier::EdgeServer,
+            DurabilityTier::GlobalServer,
+        ]);
         let mut schema_manager = SchemaManager::new_server(sync_manager, app_id, "prod");
 
         let db_path = data_dir.join("jazz.surrealkv");

--- a/crates/jazz-cloud-server/tests/client_multi_integration.rs
+++ b/crates/jazz-cloud-server/tests/client_multi_integration.rs
@@ -8,7 +8,7 @@ use jazz_tools::object::BranchName;
 use jazz_tools::query_manager::types::{ComposedBranchName, SchemaHash};
 use jazz_tools::storage::{Storage, SurrealKvStorage};
 use jazz_tools::{
-    AppContext, AppId, ColumnType, JazzClient, PersistenceTier, QueryBuilder, SchemaBuilder,
+    AppContext, AppId, ColumnType, DurabilityTier, JazzClient, QueryBuilder, SchemaBuilder,
     TableSchema, Value,
 };
 use jsonwebtoken::{Algorithm, EncodingKey, Header, encode};
@@ -264,7 +264,7 @@ async fn wait_for_todos_count(
     client: &JazzClient,
     expected_count: usize,
     timeout: Duration,
-    settled_tier: Option<PersistenceTier>,
+    durability_tier: Option<DurabilityTier>,
 ) -> Vec<(jazz_tools::ObjectId, Vec<Value>)> {
     let query = QueryBuilder::new("todos").build();
     let deadline = tokio::time::Instant::now() + timeout;
@@ -273,7 +273,7 @@ async fn wait_for_todos_count(
     while tokio::time::Instant::now() < deadline {
         if let Ok(Ok(rows)) = tokio::time::timeout(
             Duration::from_secs(8),
-            client.query(query.clone(), settled_tier),
+            client.query(query.clone(), durability_tier),
         )
         .await
         {
@@ -298,7 +298,7 @@ async fn wait_for_edge_query_ready(client: &JazzClient, timeout: Duration) {
     while tokio::time::Instant::now() < deadline {
         if let Ok(Ok(_)) = tokio::time::timeout(
             Duration::from_secs(8),
-            client.query(query.clone(), Some(PersistenceTier::EdgeServer)),
+            client.query(query.clone(), Some(DurabilityTier::EdgeServer)),
         )
         .await
         {
@@ -523,7 +523,7 @@ async fn jazz_tools_sender_side_objectupdated_delay_should_not_return_stale_sett
         &client_a,
         1,
         Duration::from_secs(20),
-        Some(PersistenceTier::EdgeServer),
+        Some(DurabilityTier::EdgeServer),
     )
     .await;
     client_a.shutdown().await.expect("shutdown client a");
@@ -555,7 +555,7 @@ async fn jazz_tools_sender_side_objectupdated_delay_should_not_return_stale_sett
     for _ in 0..3 {
         match tokio::time::timeout(
             Duration::from_secs(8),
-            client_b.query(query.clone(), Some(PersistenceTier::EdgeServer)),
+            client_b.query(query.clone(), Some(DurabilityTier::EdgeServer)),
         )
         .await
         {
@@ -618,7 +618,7 @@ async fn jazz_tools_client_resyncs_after_server_restart_with_persisted_app_data(
             &writer,
             1,
             Duration::from_secs(10),
-            Some(PersistenceTier::EdgeServer),
+            Some(DurabilityTier::EdgeServer),
         )
         .await;
         writer.shutdown().await.expect("shutdown writer");
@@ -684,7 +684,7 @@ async fn jazz_tools_existing_client_keeps_working_after_server_restart_without_c
         &client,
         1,
         Duration::from_secs(20),
-        Some(PersistenceTier::EdgeServer),
+        Some(DurabilityTier::EdgeServer),
     )
     .await;
 
@@ -710,7 +710,7 @@ async fn jazz_tools_existing_client_keeps_working_after_server_restart_without_c
         &client,
         1,
         Duration::from_secs(12),
-        Some(PersistenceTier::EdgeServer),
+        Some(DurabilityTier::EdgeServer),
     )
     .await;
     assert_eq!(
@@ -734,7 +734,7 @@ async fn jazz_tools_existing_client_keeps_working_after_server_restart_without_c
         &client,
         2,
         Duration::from_secs(12),
-        Some(PersistenceTier::EdgeServer),
+        Some(DurabilityTier::EdgeServer),
     )
     .await;
     assert_eq!(

--- a/crates/jazz-napi/index.d.ts
+++ b/crates/jazz-napi/index.d.ts
@@ -22,20 +22,20 @@ export declare class NapiRuntime {
   query(
     queryJson: string,
     sessionJson?: string | undefined | null,
-    settledTier?: string | undefined | null,
+    tier?: string | undefined | null,
     optionsJson?: string | undefined | null,
   ): Promise<any>;
   subscribe(
     queryJson: string,
     onUpdate: (...args: any[]) => any,
     sessionJson?: string | undefined | null,
-    settledTier?: string | undefined | null,
+    tier?: string | undefined | null,
     optionsJson?: string | undefined | null,
   ): number;
   unsubscribe(handle: number): void;
-  insertWithAck(table: string, values: any, tier: string): Promise<string>;
-  updateWithAck(objectId: string, values: any, tier: string): Promise<void>;
-  deleteWithAck(objectId: string, tier: string): Promise<void>;
+  insertDurable(table: string, values: any, tier: string): Promise<string>;
+  updateDurable(objectId: string, values: any, tier: string): Promise<void>;
+  deleteDurable(objectId: string, tier: string): Promise<void>;
   onSyncMessageReceived(messageJson: string): void;
   /** Called by JS when a sync message arrives from a client (not a server). */
   onSyncMessageReceivedFromClient(clientId: string, messageJson: string): void;

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -23,18 +23,20 @@ use napi_derive::napi;
 
 use jazz_tools::object::ObjectId;
 use jazz_tools::query_manager::encoding::decode_row;
+use jazz_tools::query_manager::manager::LocalUpdates;
 use jazz_tools::query_manager::parse_query_json;
 use jazz_tools::query_manager::query::Query;
 use jazz_tools::query_manager::session::Session;
 use jazz_tools::query_manager::types::{Schema, SchemaHash, Value};
 use jazz_tools::runtime_core::{
-    RuntimeCore, Scheduler, SubscriptionDelta, SubscriptionHandle, SyncSender,
+    ReadDurabilityOptions, RuntimeCore, Scheduler, SubscriptionDelta, SubscriptionHandle,
+    SyncSender,
 };
 use jazz_tools::schema_manager::{AppId, SchemaManager};
 use jazz_tools::storage::{Storage, SurrealKvStorage};
 use jazz_tools::sync_manager::QueryPropagation;
 use jazz_tools::sync_manager::{
-    ClientId, Destination, InboxEntry, OutboxEntry, PersistenceTier, ServerId, Source, SyncManager,
+    ClientId, Destination, DurabilityTier, InboxEntry, OutboxEntry, ServerId, Source, SyncManager,
     SyncPayload,
 };
 
@@ -49,34 +51,73 @@ fn convert_updates(partial: HashMap<String, Value>) -> Vec<(String, Value)> {
 #[derive(Debug, Clone, serde::Deserialize, Default)]
 struct QueryExecutionOptionsWire {
     propagation: Option<String>,
+    local_updates: Option<String>,
 }
 
-fn parse_propagation(options_json: Option<String>) -> napi::Result<QueryPropagation> {
+fn parse_read_durability_options(
+    tier: Option<String>,
+    options_json: Option<String>,
+) -> napi::Result<(ReadDurabilityOptions, QueryPropagation)> {
+    let parsed_tier = tier.as_deref().map(parse_tier).transpose()?;
     let Some(raw) = options_json else {
-        return Ok(QueryPropagation::Full);
+        return Ok((
+            ReadDurabilityOptions {
+                tier: parsed_tier,
+                local_updates: LocalUpdates::Immediate,
+            },
+            QueryPropagation::Full,
+        ));
     };
 
     let options: QueryExecutionOptionsWire = serde_json::from_str(&raw)
         .map_err(|e| napi::Error::from_reason(format!("Invalid query options JSON: {}", e)))?;
 
-    match options.propagation.as_deref() {
+    let propagation = match options.propagation.as_deref() {
         None | Some("full") => Ok(QueryPropagation::Full),
         Some("local-only") => Ok(QueryPropagation::LocalOnly),
         Some(other) => Err(napi::Error::from_reason(format!(
             "Invalid propagation '{}'. Must be 'full' or 'local-only'.",
             other
         ))),
-    }
+    }?;
+
+    let local_updates = match options.local_updates.as_deref() {
+        None | Some("immediate") => Ok(LocalUpdates::Immediate),
+        Some("deferred") => Ok(LocalUpdates::Deferred),
+        Some(other) => Err(napi::Error::from_reason(format!(
+            "Invalid localUpdates '{}'. Must be 'immediate' or 'deferred'.",
+            other
+        ))),
+    }?;
+
+    Ok((
+        ReadDurabilityOptions {
+            tier: parsed_tier,
+            local_updates,
+        },
+        propagation,
+    ))
+}
+
+fn parse_node_durability_tiers(tier: Option<&str>) -> napi::Result<Vec<DurabilityTier>> {
+    let Some(raw) = tier else {
+        return Ok(Vec::new());
+    };
+    Ok(vec![parse_tier(raw)?])
+}
+
+fn parse_node_durability_tier(tier: Option<String>) -> napi::Result<Vec<DurabilityTier>> {
+    parse_node_durability_tiers(tier.as_deref())
 }
 
 // ============================================================================
-fn parse_tier(tier: &str) -> napi::Result<PersistenceTier> {
+fn parse_tier(tier: &str) -> napi::Result<DurabilityTier> {
     match tier {
-        "worker" => Ok(PersistenceTier::Worker),
-        "edge" => Ok(PersistenceTier::EdgeServer),
-        "core" => Ok(PersistenceTier::CoreServer),
+        "worker" => Ok(DurabilityTier::Worker),
+        "edge" => Ok(DurabilityTier::EdgeServer),
+        "global" => Ok(DurabilityTier::GlobalServer),
         _ => Err(napi::Error::from_reason(format!(
-            "Invalid tier '{}'. Must be 'worker', 'edge', or 'core'.",
+            "Invalid tier '{}'. Must be 'worker', 'edge', or 'global'.",
             tier
         ))),
     }
@@ -216,12 +257,12 @@ impl NapiRuntime {
             .map_err(|e| napi::Error::from_reason(format!("Invalid schema JSON: {}", e)))?;
 
         // Parse optional tier
-        let persistence_tier = tier.as_deref().map(parse_tier).transpose()?;
+        let node_tiers = parse_node_durability_tier(tier)?;
 
         // Create sync manager
         let mut sync_manager = SyncManager::new();
-        if let Some(t) = persistence_tier {
-            sync_manager = sync_manager.with_tier(t);
+        if !node_tiers.is_empty() {
+            sync_manager = sync_manager.with_durability_tiers(node_tiers);
         }
 
         // Create schema manager
@@ -380,7 +421,7 @@ impl NapiRuntime {
         env: Env,
         query_json: String,
         session_json: Option<String>,
-        settled_tier: Option<String>,
+        tier: Option<String>,
         options_json: Option<String>,
     ) -> napi::Result<napi::JsObject> {
         let query = parse_query(&query_json)?;
@@ -394,15 +435,14 @@ impl NapiRuntime {
                 None
             };
 
-        let tier = settled_tier.as_deref().map(parse_tier).transpose()?;
-        let propagation = parse_propagation(options_json)?;
+        let (durability, propagation) = parse_read_durability_options(tier, options_json)?;
 
         let future = {
             let mut core = self
                 .core
                 .lock()
                 .map_err(|_| napi::Error::from_reason("lock"))?;
-            core.query_with_propagation(query, session, tier, propagation)
+            core.query_with_propagation(query, session, durability, propagation)
         };
 
         // Create a deferred/promise pair
@@ -445,7 +485,7 @@ impl NapiRuntime {
         query_json: String,
         #[napi(ts_arg_type = "(...args: any[]) => any")] on_update: napi::JsFunction,
         session_json: Option<String>,
-        settled_tier: Option<String>,
+        tier: Option<String>,
         options_json: Option<String>,
     ) -> napi::Result<f64> {
         let query = parse_query(&query_json)?;
@@ -459,8 +499,7 @@ impl NapiRuntime {
                 None
             };
 
-        let tier = settled_tier.as_deref().map(parse_tier).transpose()?;
-        let propagation = parse_propagation(options_json)?;
+        let (durability, propagation) = parse_read_durability_options(tier, options_json)?;
 
         // Create a ThreadsafeFunction for the JS callback.
         // The closure converts our serde_json::Value into a JsUnknown to pass to JS.
@@ -524,11 +563,11 @@ impl NapiRuntime {
             .lock()
             .map_err(|_| napi::Error::from_reason("lock"))?;
         let handle = core
-            .subscribe_with_settled_tier_and_propagation(
+            .subscribe_with_durability_and_propagation(
                 query,
                 callback,
                 session,
-                tier,
+                durability,
                 propagation,
             )
             .map_err(|e| napi::Error::from_reason(format!("Subscribe failed: {:?}", e)))?;
@@ -550,8 +589,8 @@ impl NapiRuntime {
     // Persisted CRUD Operations
     // =========================================================================
 
-    #[napi(js_name = "insertWithAck", ts_return_type = "Promise<string>")]
-    pub fn insert_with_ack(
+    #[napi(js_name = "insertDurable", ts_return_type = "Promise<string>")]
+    pub fn insert_durable(
         &self,
         env: Env,
         table: String,
@@ -583,8 +622,8 @@ impl NapiRuntime {
         Ok(promise)
     }
 
-    #[napi(js_name = "updateWithAck", ts_return_type = "Promise<void>")]
-    pub fn update_with_ack(
+    #[napi(js_name = "updateDurable", ts_return_type = "Promise<void>")]
+    pub fn update_durable(
         &self,
         env: Env,
         object_id: String,
@@ -619,8 +658,8 @@ impl NapiRuntime {
         Ok(promise)
     }
 
-    #[napi(js_name = "deleteWithAck", ts_return_type = "Promise<void>")]
-    pub fn delete_with_ack(
+    #[napi(js_name = "deleteDurable", ts_return_type = "Promise<void>")]
+    pub fn delete_durable(
         &self,
         env: Env,
         object_id: String,

--- a/crates/jazz-nitro/jazz-nitro.nitro.ts
+++ b/crates/jazz-nitro/jazz-nitro.nitro.ts
@@ -42,7 +42,7 @@ export interface JazzRuntime extends HybridObject<{ ios: "rust"; android: "rust"
   query(
     queryJson: string,
     sessionJson: string | undefined,
-    settledTier: string | undefined,
+    tier: string | undefined,
   ): Promise<string>;
 
   // --- Subscriptions ---
@@ -52,7 +52,7 @@ export interface JazzRuntime extends HybridObject<{ ios: "rust"; android: "rust"
     queryJson: string,
     onUpdate: (deltaJson: string) => void,
     sessionJson: string | undefined,
-    settledTier: string | undefined,
+    tier: string | undefined,
   ): number;
 
   /** Unsubscribe by handle. */

--- a/crates/jazz-nitro/src/lib.rs
+++ b/crates/jazz-nitro/src/lib.rs
@@ -20,18 +20,20 @@ use futures::executor::block_on;
 
 use groove::object::ObjectId;
 use groove::query_manager::encoding::decode_row;
+use groove::query_manager::manager::LocalUpdates;
 use groove::query_manager::parse_query_json;
 use groove::query_manager::query::Query;
 use groove::query_manager::session::Session;
 use groove::query_manager::types::{Schema, SchemaHash, Value};
 use groove::runtime_core::{
-    RuntimeCore, Scheduler, SubscriptionDelta, SubscriptionHandle, SyncSender,
+    ReadDurabilityOptions, RuntimeCore, Scheduler, SubscriptionDelta, SubscriptionHandle,
+    SyncSender,
 };
 use groove::schema_manager::{AppId, SchemaManager};
 use groove::storage::SurrealKvStorage;
 use groove::sync_manager::QueryPropagation;
 use groove::sync_manager::{
-    ClientId, InboxEntry, OutboxEntry, PersistenceTier, ServerId, Source, SyncManager, SyncPayload,
+    ClientId, DurabilityTier, InboxEntry, OutboxEntry, ServerId, Source, SyncManager, SyncPayload,
 };
 
 fn convert_values(values_json: &str) -> Result<Vec<Value>, String> {
@@ -60,13 +62,13 @@ fn parse_session(session_json: Option<String>) -> Result<Option<Session>, String
     }
 }
 
-fn parse_tier(tier: &str) -> Result<PersistenceTier, String> {
+fn parse_tier(tier: &str) -> Result<DurabilityTier, String> {
     match tier {
-        "worker" => Ok(PersistenceTier::Worker),
-        "edge" => Ok(PersistenceTier::EdgeServer),
-        "core" => Ok(PersistenceTier::CoreServer),
+        "worker" => Ok(DurabilityTier::Worker),
+        "edge" => Ok(DurabilityTier::EdgeServer),
+        "global" => Ok(DurabilityTier::GlobalServer),
         _ => Err(format!(
-            "Invalid tier '{tier}'. Must be 'worker', 'edge', or 'core'."
+            "Invalid tier '{tier}'. Must be 'worker', 'edge', or 'global'."
         )),
     }
 }
@@ -74,23 +76,61 @@ fn parse_tier(tier: &str) -> Result<PersistenceTier, String> {
 #[derive(Debug, Clone, serde::Deserialize, Default)]
 struct QueryExecutionOptionsWire {
     propagation: Option<String>,
+    local_updates: Option<String>,
 }
 
-fn parse_propagation(options_json: Option<String>) -> Result<QueryPropagation, String> {
+fn parse_read_durability_options(
+    tier: Option<String>,
+    options_json: Option<String>,
+) -> Result<(ReadDurabilityOptions, QueryPropagation), String> {
+    let parsed_tier = tier.as_deref().map(parse_tier).transpose()?;
     let Some(raw) = options_json else {
-        return Ok(QueryPropagation::Full);
+        return Ok((
+            ReadDurabilityOptions {
+                tier: parsed_tier,
+                local_updates: LocalUpdates::Immediate,
+            },
+            QueryPropagation::Full,
+        ));
     };
 
     let options: QueryExecutionOptionsWire =
         serde_json::from_str(&raw).map_err(|e| format!("Invalid query options JSON: {e}"))?;
 
-    match options.propagation.as_deref() {
+    let propagation = match options.propagation.as_deref() {
         None | Some("full") => Ok(QueryPropagation::Full),
         Some("local-only") => Ok(QueryPropagation::LocalOnly),
         Some(other) => Err(format!(
             "Invalid propagation '{other}'. Must be 'full' or 'local-only'."
         )),
-    }
+    }?;
+
+    let local_updates = match options.local_updates.as_deref() {
+        None | Some("immediate") => Ok(LocalUpdates::Immediate),
+        Some("deferred") => Ok(LocalUpdates::Deferred),
+        Some(other) => Err(format!(
+            "Invalid localUpdates '{other}'. Must be 'immediate' or 'deferred'."
+        )),
+    }?;
+
+    Ok((
+        ReadDurabilityOptions {
+            tier: parsed_tier,
+            local_updates,
+        },
+        propagation,
+    ))
+}
+
+fn parse_node_durability_tiers(tier: Option<String>) -> Result<Vec<DurabilityTier>, String> {
+    let Some(raw) = tier else {
+        return Ok(Vec::new());
+    };
+    Ok(vec![parse_tier(&raw)?])
+}
+
+fn parse_node_durability_tier(tier: Option<String>) -> Result<Vec<DurabilityTier>, String> {
+    parse_node_durability_tiers(tier)
 }
 
 fn row_to_json(
@@ -315,11 +355,11 @@ impl JazzRuntimeImpl {
         let schema: Schema =
             serde_json::from_str(&schema_json).map_err(|e| format!("Invalid schema JSON: {e}"))?;
 
-        let persistence_tier = tier.as_deref().map(parse_tier).transpose()?;
+        let node_tiers = parse_node_durability_tier(tier)?;
 
         let mut sync_manager = SyncManager::new();
-        if let Some(t) = persistence_tier {
-            sync_manager = sync_manager.with_tier(t);
+        if !node_tiers.is_empty() {
+            sync_manager = sync_manager.with_durability_tiers(node_tiers);
         }
 
         let app_id_obj = AppId::from_string(&app_id).unwrap_or_else(|_| AppId::from_name(&app_id));
@@ -428,16 +468,15 @@ impl JazzRuntimeImpl {
         &mut self,
         query_json: String,
         session_json: Option<String>,
-        settled_tier: Option<String>,
+        tier: Option<String>,
         options_json: Option<String>,
     ) -> Result<String, String> {
         let query = parse_query(&query_json)?;
         let session = parse_session(session_json)?;
-        let tier = settled_tier.as_deref().map(parse_tier).transpose()?;
-        let propagation = parse_propagation(options_json)?;
+        let (durability, propagation) = parse_read_durability_options(tier, options_json)?;
 
         let fut = self.with_core("query", |core| {
-            core.query_with_propagation(query, session, tier, propagation)
+            core.query_with_propagation(query, session, durability, propagation)
         })?;
 
         let results = block_on(fut).map_err(|e| format!("Query failed: {e}"))?;
@@ -459,9 +498,9 @@ impl JazzRuntimeImpl {
         &mut self,
         query_json: String,
         session_json: Option<String>,
-        settled_tier: Option<String>,
+        tier: Option<String>,
     ) -> String {
-        self.query_inner(query_json, session_json, settled_tier, None)
+        self.query_inner(query_json, session_json, tier, None)
             .unwrap_or_else(error_json)
     }
 
@@ -472,13 +511,12 @@ impl JazzRuntimeImpl {
         query_json: String,
         on_update: Box<dyn Fn(String)>,
         session_json: Option<String>,
-        settled_tier: Option<String>,
+        tier: Option<String>,
         options_json: Option<String>,
     ) -> Result<f64, String> {
         let query = parse_query(&query_json)?;
         let session = parse_session(session_json)?;
-        let tier = settled_tier.as_deref().map(parse_tier).transpose()?;
-        let propagation = parse_propagation(options_json)?;
+        let (durability, propagation) = parse_read_durability_options(tier, options_json)?;
 
         // The generated Func_void_std__string wrapper implements Send + Sync,
         // so this transmute is safe — the underlying closure is already
@@ -493,7 +531,7 @@ impl JazzRuntimeImpl {
         >::new()));
 
         let handle = self.with_core("subscribe", |core| {
-            core.subscribe_with_settled_tier_and_propagation(
+            core.subscribe_with_durability_and_propagation(
                 query,
                 {
                     let rows_by_id = Arc::clone(&rows_by_id);
@@ -510,7 +548,7 @@ impl JazzRuntimeImpl {
                     }
                 },
                 session,
-                tier,
+                durability,
                 propagation,
             )
             .map_err(|e| format!("Subscribe failed: {e}"))
@@ -524,9 +562,9 @@ impl JazzRuntimeImpl {
         query_json: String,
         on_update: Box<dyn Fn(String)>,
         session_json: Option<String>,
-        settled_tier: Option<String>,
+        tier: Option<String>,
     ) -> f64 {
-        self.subscribe_inner(query_json, on_update, session_json, settled_tier, None)
+        self.subscribe_inner(query_json, on_update, session_json, tier, None)
             .unwrap_or_else(|e| {
                 log::error!("subscribe failed: {e}");
                 -1.0

--- a/crates/jazz-rn/rust/src/lib.rs
+++ b/crates/jazz-rn/rust/src/lib.rs
@@ -12,17 +12,20 @@ use futures::executor::block_on;
 
 use jazz_tools::object::ObjectId;
 use jazz_tools::query_manager::encoding::decode_row;
+use jazz_tools::query_manager::manager::LocalUpdates;
 use jazz_tools::query_manager::parse_query_json;
 use jazz_tools::query_manager::query::Query;
 use jazz_tools::query_manager::session::Session;
 use jazz_tools::query_manager::types::{Schema, SchemaHash, Value};
 use jazz_tools::runtime_core::{
-    RuntimeCore, Scheduler, SubscriptionDelta, SubscriptionHandle, SyncSender,
+    ReadDurabilityOptions, RuntimeCore, Scheduler, SubscriptionDelta, SubscriptionHandle,
+    SyncSender,
 };
 use jazz_tools::schema_manager::{AppId, SchemaManager};
 use jazz_tools::storage::SurrealKvStorage;
 use jazz_tools::sync_manager::{
-    ClientId, InboxEntry, OutboxEntry, PersistenceTier, ServerId, Source, SyncManager, SyncPayload,
+    ClientId, DurabilityTier, InboxEntry, OutboxEntry, QueryPropagation, ServerId, Source,
+    SyncManager, SyncPayload,
 };
 
 // ============================================================================
@@ -108,14 +111,14 @@ fn parse_session(session_json: Option<String>) -> Result<Option<Session>, JazzRn
     }
 }
 
-fn parse_tier(tier: &str) -> Result<PersistenceTier, JazzRnError> {
+fn parse_tier(tier: &str) -> Result<DurabilityTier, JazzRnError> {
     match tier {
-        "worker" => Ok(PersistenceTier::Worker),
-        "edge" => Ok(PersistenceTier::EdgeServer),
-        "core" => Ok(PersistenceTier::CoreServer),
+        "worker" => Ok(DurabilityTier::Worker),
+        "edge" => Ok(DurabilityTier::EdgeServer),
+        "global" => Ok(DurabilityTier::GlobalServer),
         _ => Err(JazzRnError::InvalidTier {
             message: format!(
-                "Invalid tier '{}'. Must be 'worker', 'edge', or 'core'.",
+                "Invalid tier '{}'. Must be 'worker', 'edge', or 'global'.",
                 tier
             ),
         }),
@@ -305,7 +308,7 @@ impl RnRuntime {
 
             let mut sync_manager = SyncManager::new();
             if let Some(t) = persistence_tier {
-                sync_manager = sync_manager.with_tier(t);
+                sync_manager = sync_manager.with_durability_tier(t);
             }
 
             let app_id_obj =
@@ -449,19 +452,27 @@ impl RnRuntime {
         &self,
         query_json: String,
         session_json: Option<String>,
-        settled_tier: Option<String>,
+        tier: Option<String>,
     ) -> Result<String, JazzRnError> {
         with_panic_boundary("query", || {
             let query = parse_query(&query_json)?;
             let session = parse_session(session_json)?;
-            let tier = settled_tier.as_deref().map(parse_tier).transpose()?;
+            let tier = tier.as_deref().map(parse_tier).transpose()?;
 
             // NOTE: query() triggers immediate_tick() internally.
             // We then block for the first callback result to be delivered.
             let mut core = self.core.lock().map_err(|_| JazzRnError::Internal {
                 message: "lock poisoned".into(),
             })?;
-            let fut = core.query(query, session, tier);
+            let fut = core.query_with_propagation(
+                query,
+                session,
+                ReadDurabilityOptions {
+                    tier,
+                    local_updates: LocalUpdates::Immediate,
+                },
+                QueryPropagation::Full,
+            );
             let results = block_on(fut).map_err(runtime_err)?;
 
             let rows_json: Vec<serde_json::Value> = results
@@ -487,19 +498,19 @@ impl RnRuntime {
         query_json: String,
         callback: Box<dyn SubscriptionCallback>,
         session_json: Option<String>,
-        settled_tier: Option<String>,
+        tier: Option<String>,
     ) -> Result<u64, JazzRnError> {
         with_panic_boundary("subscribe", || {
             let query = parse_query(&query_json)?;
             let session = parse_session(session_json)?;
-            let tier = settled_tier.as_deref().map(parse_tier).transpose()?;
+            let tier = tier.as_deref().map(parse_tier).transpose()?;
 
             let mut core = self.core.lock().map_err(|_| JazzRnError::Internal {
                 message: "lock poisoned".into(),
             })?;
 
             let handle = core
-                .subscribe_with_settled_tier(
+                .subscribe_with_durability_and_propagation(
                     query,
                     {
                         move |delta: SubscriptionDelta| {
@@ -526,7 +537,11 @@ impl RnRuntime {
                         }
                     },
                     session,
-                    tier,
+                    ReadDurabilityOptions {
+                        tier,
+                        local_updates: LocalUpdates::Immediate,
+                    },
+                    QueryPropagation::Full,
                 )
                 .map_err(runtime_err)?;
 

--- a/crates/jazz-tools/src/client.rs
+++ b/crates/jazz-tools/src/client.rs
@@ -7,13 +7,15 @@ use std::time::Duration;
 
 use crate::jazz_tokio::{SubscriptionHandle as RuntimeSubHandle, TokioRuntime};
 use crate::jazz_transport::ServerEvent;
+use crate::query_manager::manager::LocalUpdates;
 use crate::query_manager::query::Query;
 use crate::query_manager::session::Session;
 use crate::query_manager::types::{OrderedRowDelta, Value};
+use crate::runtime_core::ReadDurabilityOptions;
 use crate::schema_manager::SchemaManager;
 use crate::storage::{Storage, StorageError, SurrealKvStorage};
 use crate::sync_manager::{
-    ClientId, Destination, InboxEntry, PersistenceTier, ServerId, Source, SyncManager, SyncPayload,
+    ClientId, Destination, DurabilityTier, InboxEntry, ServerId, Source, SyncManager, SyncPayload,
 };
 use bytes::BytesMut;
 use futures::StreamExt;
@@ -353,17 +355,24 @@ impl JazzClient {
         Ok(SubscriptionStream::new(rx))
     }
 
-    /// One-shot query, optionally waiting for a settled tier.
+    /// One-shot query, optionally waiting for a durability tier.
     ///
     /// Returns the current results as `Vec<(ObjectId, Vec<Value>)>`.
     pub async fn query(
         &self,
         query: Query,
-        settled_tier: Option<PersistenceTier>,
+        durability_tier: Option<DurabilityTier>,
     ) -> Result<Vec<(ObjectId, Vec<Value>)>> {
         let future = self
             .runtime
-            .query(query, None, settled_tier)
+            .query(
+                query,
+                None,
+                ReadDurabilityOptions {
+                    tier: durability_tier,
+                    local_updates: LocalUpdates::Immediate,
+                },
+            )
             .map_err(|e| JazzError::Query(e.to_string()))?;
         future
             .await
@@ -478,12 +487,19 @@ impl<'a> SessionClient<'a> {
     pub async fn query(
         &self,
         query: Query,
-        settled_tier: Option<PersistenceTier>,
+        durability_tier: Option<DurabilityTier>,
     ) -> Result<Vec<(ObjectId, Vec<Value>)>> {
         let future = self
             .client
             .runtime
-            .query(query, Some(self.session.clone()), settled_tier)
+            .query(
+                query,
+                Some(self.session.clone()),
+                ReadDurabilityOptions {
+                    tier: durability_tier,
+                    local_updates: LocalUpdates::Immediate,
+                },
+            )
             .map_err(|e| JazzError::Query(e.to_string()))?;
         future
             .await

--- a/crates/jazz-tools/src/commands/server.rs
+++ b/crates/jazz-tools/src/commands/server.rs
@@ -8,10 +8,11 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use jazz_tools::query_manager::query::QueryBuilder;
 use jazz_tools::query_manager::types::{ColumnType, SchemaBuilder, TableSchema, Value};
+use jazz_tools::runtime_core::ReadDurabilityOptions;
 use jazz_tools::runtime_tokio::TokioRuntime;
 use jazz_tools::schema_manager::{AppId, SchemaManager, rehydrate_schema_manager_from_manifest};
 use jazz_tools::storage::SurrealKvStorage;
-use jazz_tools::sync_manager::{ClientId, Destination, PersistenceTier, SyncManager, SyncPayload};
+use jazz_tools::sync_manager::{ClientId, Destination, DurabilityTier, SyncManager, SyncPayload};
 use jsonwebtoken::jwk::JwkSet;
 use tokio::sync::{RwLock, broadcast};
 use tracing::info;
@@ -51,7 +52,8 @@ impl ExternalIdentityStore {
             )
             .build();
 
-        let sync_manager = SyncManager::new().with_tier(PersistenceTier::EdgeServer);
+        let sync_manager = SyncManager::new()
+            .with_durability_tiers([DurabilityTier::EdgeServer, DurabilityTier::GlobalServer]);
         let schema_manager = SchemaManager::new(
             sync_manager,
             schema,
@@ -80,7 +82,7 @@ impl ExternalIdentityStore {
 
         let future = self
             .runtime
-            .query(query, None, None)
+            .query(query, None, ReadDurabilityOptions::default())
             .map_err(|e| format!("external identity query error: {e}"))?;
         let rows = future
             .await
@@ -105,7 +107,7 @@ impl ExternalIdentityStore {
 
         let future = self
             .runtime
-            .query(query, None, None)
+            .query(query, None, ReadDurabilityOptions::default())
             .map_err(|e| format!("external identity query error: {e}"))?;
         let mut rows = future
             .await
@@ -223,7 +225,8 @@ pub async fn run(
     std::fs::create_dir_all(data_dir)?;
 
     // Create managers (server mode - no fixed current schema)
-    let sync_manager = SyncManager::new().with_tier(PersistenceTier::EdgeServer);
+    let sync_manager = SyncManager::new()
+        .with_durability_tiers([DurabilityTier::EdgeServer, DurabilityTier::GlobalServer]);
     let mut schema_manager = SchemaManager::new_server(sync_manager, app_id, "prod");
 
     // Create broadcast channel for SSE updates

--- a/crates/jazz-tools/src/commit.rs
+++ b/crates/jazz-tools/src/commit.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
 
 use crate::object::ObjectId;
-use crate::sync_manager::PersistenceTier;
+use crate::sync_manager::DurabilityTier;
 
 /// BLAKE3 hash identifying a commit.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -16,7 +16,7 @@ pub struct CommitId(pub [u8; 32]);
 /// Tracks which persistence tiers have confirmed storing this commit.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct CommitAckState {
-    pub confirmed_tiers: HashSet<PersistenceTier>,
+    pub confirmed_tiers: HashSet<DurabilityTier>,
 }
 
 /// Storage state of a commit (runtime only, not serialized).
@@ -172,10 +172,8 @@ mod tests {
         };
 
         let mut ack_state = CommitAckState::default();
-        ack_state.confirmed_tiers.insert(PersistenceTier::Worker);
-        ack_state
-            .confirmed_tiers
-            .insert(PersistenceTier::EdgeServer);
+        ack_state.confirmed_tiers.insert(DurabilityTier::Worker);
+        ack_state.confirmed_tiers.insert(DurabilityTier::EdgeServer);
 
         let commit2 = Commit {
             parents: smallvec![],

--- a/crates/jazz-tools/src/lib.rs
+++ b/crates/jazz-tools/src/lib.rs
@@ -51,7 +51,7 @@ pub use schema_manager::AppId;
 #[cfg(feature = "client")]
 pub use sync_manager::ClientId;
 #[cfg(feature = "client")]
-pub use sync_manager::PersistenceTier;
+pub use sync_manager::DurabilityTier;
 #[cfg(feature = "client")]
 pub use sync_manager::ServerId;
 

--- a/crates/jazz-tools/src/query_manager/manager.rs
+++ b/crates/jazz-tools/src/query_manager/manager.rs
@@ -8,7 +8,7 @@ use crate::object_manager::AllObjectUpdate;
 use crate::schema_manager::{LensTransformer, SchemaContext};
 use crate::storage::{CatalogueManifestOp, Storage};
 use crate::sync_manager::{
-    ClientId, PendingPermissionCheck, PendingUpdateId, PersistenceTier, QueryId, QueryPropagation,
+    ClientId, DurabilityTier, PendingPermissionCheck, PendingUpdateId, QueryId, QueryPropagation,
     SyncManager,
 };
 
@@ -178,14 +178,25 @@ pub(crate) struct QuerySubscription {
     /// Flag indicating this subscription has settled at least once.
     /// Used to ensure one-shot queries receive an initial callback (even if empty).
     pub(crate) settled_once: bool,
-    /// Required persistence tier before first delivery (None = immediate).
-    pub(crate) settled_tier: Option<PersistenceTier>,
+    /// Required durability tier before non-local delivery (None = immediate).
+    pub(crate) durability_tier: Option<DurabilityTier>,
+    /// How local writes behave while waiting for durability.
+    pub(crate) local_updates: LocalUpdates,
+    /// True when this subscription observed a local write since last delivery.
+    pub(crate) has_pending_local_updates: bool,
     /// Tiers that have confirmed settlement for this query.
-    pub(crate) achieved_tiers: HashSet<PersistenceTier>,
+    pub(crate) achieved_tiers: HashSet<DurabilityTier>,
     /// Current ordered IDs for ordered delta construction.
     pub(crate) current_ordered_ids: Vec<ObjectId>,
     /// Whether this subscription should be forwarded to upstream servers.
     pub(crate) propagation: QueryPropagation,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum LocalUpdates {
+    #[default]
+    Immediate,
+    Deferred,
 }
 
 /// Update for a query subscription.
@@ -761,12 +772,15 @@ impl QueryManager {
                 );
             }
 
-            let tier_satisfied = match &subscription.settled_tier {
-                None => true, // No tier requirement → immediate (current behavior)
+            let tier_satisfied = match &subscription.durability_tier {
+                None => true, // No durability requirement → immediate
                 Some(required) => subscription.achieved_tiers.iter().any(|t| t >= required),
             };
+            let allow_local_while_waiting = !tier_satisfied
+                && subscription.local_updates == LocalUpdates::Immediate
+                && subscription.has_pending_local_updates;
 
-            if !tier_satisfied {
+            if !tier_satisfied && !allow_local_while_waiting {
                 // Graph state updated by settle(), but don't deliver yet
                 tracing::trace!("tier not satisfied, holding delivery");
                 continue;
@@ -802,6 +816,7 @@ impl QueryManager {
                     ordered_delta: ordered.delta,
                     descriptor: subscription.graph.combined_descriptor.clone(),
                 });
+                subscription.has_pending_local_updates = false;
             } else if !delta.is_empty() {
                 let ordered_ids_after: Vec<ObjectId> = subscription
                     .graph
@@ -830,6 +845,7 @@ impl QueryManager {
                     ordered_delta: ordered.delta,
                     descriptor: subscription.graph.combined_descriptor.clone(),
                 });
+                subscription.has_pending_local_updates = false;
             }
         }
 
@@ -1157,14 +1173,15 @@ impl QueryManager {
         self.mark_subscriptions_dirty(&table);
         self.mark_row_updated_in_subscriptions(&table, update.object_id);
     }
-    /// Mark subscriptions dirty for a table.
-    /// Checks all tables involved in the subscription (including joined tables).
-    /// Also marks server-side subscriptions for downstream clients.
-    pub(super) fn mark_subscriptions_dirty(&mut self, table: &str) {
+    /// Mark subscriptions dirty for a table based on update origin.
+    fn mark_subscriptions_dirty_with_origin(&mut self, table: &str, local_update: bool) {
         // Mark local subscriptions dirty
         for subscription in self.subscriptions.values_mut() {
             if Self::subscription_involves_table(&subscription.graph, table) {
                 subscription.graph.mark_dirty_for_table(table);
+                if local_update {
+                    subscription.has_pending_local_updates = true;
+                }
             }
         }
 
@@ -1174,6 +1191,19 @@ impl QueryManager {
                 server_sub.graph.mark_dirty_for_table(table);
             }
         }
+    }
+
+    /// Mark subscriptions dirty from external updates (default behavior).
+    ///
+    /// Checks all tables involved in the subscription (including joined tables).
+    /// Also marks server-side subscriptions for downstream clients.
+    pub(super) fn mark_subscriptions_dirty(&mut self, table: &str) {
+        self.mark_subscriptions_dirty_with_origin(table, false);
+    }
+
+    /// Mark subscriptions dirty from local writes.
+    pub(super) fn mark_subscriptions_dirty_local(&mut self, table: &str) {
+        self.mark_subscriptions_dirty_with_origin(table, true);
     }
 
     /// Mark a row as updated in all subscriptions for a table.

--- a/crates/jazz-tools/src/query_manager/manager.rs
+++ b/crates/jazz-tools/src/query_manager/manager.rs
@@ -777,6 +777,7 @@ impl QueryManager {
                 Some(required) => subscription.achieved_tiers.iter().any(|t| t >= required),
             };
             let allow_local_while_waiting = !tier_satisfied
+                && subscription.settled_once
                 && subscription.local_updates == LocalUpdates::Immediate
                 && subscription.has_pending_local_updates;
 

--- a/crates/jazz-tools/src/query_manager/manager_tests.rs
+++ b/crates/jazz-tools/src/query_manager/manager_tests.rs
@@ -7033,10 +7033,10 @@ fn subscribe_with_sync_local_only_sends_to_connected_tier() {
 #[test]
 fn subscribe_with_sync_local_only_on_persistence_tier_does_not_send_upstream() {
     use crate::sync_manager::QueryPropagation;
-    use crate::sync_manager::{Destination, PersistenceTier, ServerId, SyncPayload};
+    use crate::sync_manager::{Destination, DurabilityTier, ServerId, SyncPayload};
     use uuid::Uuid;
 
-    let sync_manager = SyncManager::new().with_tier(PersistenceTier::Worker);
+    let sync_manager = SyncManager::new().with_durability_tier(DurabilityTier::Worker);
     let schema = test_schema();
     let (mut worker_qm, _storage) = create_query_manager(sync_manager, schema);
 

--- a/crates/jazz-tools/src/query_manager/subscriptions.rs
+++ b/crates/jazz-tools/src/query_manager/subscriptions.rs
@@ -6,14 +6,14 @@ use std::{
 use crate::object_manager::AllObjectUpdate;
 use crate::storage::Storage;
 use crate::sync_manager::QueryPropagation;
-use crate::sync_manager::{PersistenceTier, QueryId, ServerId};
+use crate::sync_manager::{DurabilityTier, QueryId, ServerId};
 
 #[cfg(test)]
 use super::encoding::decode_row;
 use super::graph_nodes::output::QuerySubscriptionId;
 use super::manager::{
-    CatalogueUpdate, QueryError, QueryManager, QuerySubscription, QuerySubscriptionFailure,
-    QueryUpdate,
+    CatalogueUpdate, LocalUpdates, QueryError, QueryManager, QuerySubscription,
+    QuerySubscriptionFailure, QueryUpdate,
 };
 use super::query::{Query, QueryBuilder};
 use super::session::Session;
@@ -25,7 +25,7 @@ use crate::object::ObjectId;
 
 impl QueryManager {
     fn should_send_local_subscription_upstream(&self, propagation: QueryPropagation) -> bool {
-        propagation == QueryPropagation::Full || !self.sync_manager.has_persistence_tier()
+        propagation == QueryPropagation::Full || !self.sync_manager.has_durability_identity()
     }
 
     /// Create a query builder for a table.
@@ -48,17 +48,34 @@ impl QueryManager {
     /// - Column name translation for old schema indices
     /// - Lens transforms for rows from old schema branches
     ///
-    /// `settled_tier`: If Some, holds first delivery until the specified tier confirms.
+    /// `durability_tier`: If Some, holds non-local delivery until the tier confirms.
     pub fn subscribe_with_session(
         &mut self,
         query: Query,
         session: Option<Session>,
-        settled_tier: Option<PersistenceTier>,
+        durability_tier: Option<DurabilityTier>,
+    ) -> Result<QuerySubscriptionId, QueryError> {
+        self.subscribe_with_session_with_local_updates(
+            query,
+            session,
+            durability_tier,
+            LocalUpdates::Immediate,
+        )
+    }
+
+    /// Subscribe with explicit local update behavior while waiting for durability.
+    pub fn subscribe_with_session_with_local_updates(
+        &mut self,
+        query: Query,
+        session: Option<Session>,
+        durability_tier: Option<DurabilityTier>,
+        local_updates: LocalUpdates,
     ) -> Result<QuerySubscriptionId, QueryError> {
         self.subscribe_with_session_and_propagation(
             query,
             session,
-            settled_tier,
+            durability_tier,
+            local_updates,
             QueryPropagation::Full,
         )
     }
@@ -67,11 +84,12 @@ impl QueryManager {
         &mut self,
         query: Query,
         session: Option<Session>,
-        settled_tier: Option<PersistenceTier>,
+        durability_tier: Option<DurabilityTier>,
+        local_updates: LocalUpdates,
         propagation: QueryPropagation,
     ) -> Result<QuerySubscriptionId, QueryError> {
         let _span =
-            tracing::debug_span!("QM::subscribe", table = %query.table, ?settled_tier).entered();
+            tracing::debug_span!("QM::subscribe", table = %query.table, ?durability_tier).entered();
         // Determine branches
         let branches: Vec<String> = if !query.branches.is_empty() {
             query.branches.clone()
@@ -94,6 +112,7 @@ impl QueryManager {
 
         let id = QuerySubscriptionId(self.next_subscription_id);
         self.next_subscription_id += 1;
+        let achieved_tiers = self.sync_manager.local_durability_tiers();
 
         tracing::debug!(
             sub_id = id.0,
@@ -110,8 +129,10 @@ impl QueryManager {
                 session,
                 needs_recompile: false,
                 settled_once: false,
-                settled_tier,
-                achieved_tiers: HashSet::new(),
+                durability_tier,
+                local_updates,
+                has_pending_local_updates: false,
+                achieved_tiers,
                 current_ordered_ids: Vec::new(),
                 propagation,
             },
@@ -166,7 +187,9 @@ impl QueryManager {
                 session,
                 needs_recompile: false,
                 settled_once: false,
-                settled_tier: None,
+                durability_tier: None,
+                local_updates: LocalUpdates::Immediate,
+                has_pending_local_updates: false,
                 achieved_tiers: HashSet::new(),
                 current_ordered_ids: Vec::new(),
                 propagation: QueryPropagation::Full,
@@ -191,12 +214,28 @@ impl QueryManager {
         &mut self,
         query: Query,
         session: Option<Session>,
-        settled_tier: Option<PersistenceTier>,
+        durability_tier: Option<DurabilityTier>,
     ) -> Result<QuerySubscriptionId, QueryError> {
-        self.subscribe_with_sync_and_propagation(
+        self.subscribe_with_sync_with_local_updates(
             query,
             session,
-            settled_tier,
+            durability_tier,
+            LocalUpdates::Immediate,
+        )
+    }
+
+    pub fn subscribe_with_sync_with_local_updates(
+        &mut self,
+        query: Query,
+        session: Option<Session>,
+        durability_tier: Option<DurabilityTier>,
+        local_updates: LocalUpdates,
+    ) -> Result<QuerySubscriptionId, QueryError> {
+        self.subscribe_with_sync_and_propagation_with_local_updates(
+            query,
+            session,
+            durability_tier,
+            local_updates,
             QueryPropagation::Full,
         )
     }
@@ -206,14 +245,32 @@ impl QueryManager {
         &mut self,
         query: Query,
         session: Option<Session>,
-        settled_tier: Option<PersistenceTier>,
+        durability_tier: Option<DurabilityTier>,
+        propagation: QueryPropagation,
+    ) -> Result<QuerySubscriptionId, QueryError> {
+        self.subscribe_with_sync_and_propagation_with_local_updates(
+            query,
+            session,
+            durability_tier,
+            LocalUpdates::Immediate,
+            propagation,
+        )
+    }
+
+    pub fn subscribe_with_sync_and_propagation_with_local_updates(
+        &mut self,
+        query: Query,
+        session: Option<Session>,
+        durability_tier: Option<DurabilityTier>,
+        local_updates: LocalUpdates,
         propagation: QueryPropagation,
     ) -> Result<QuerySubscriptionId, QueryError> {
         // Create local subscription
         let sub_id = self.subscribe_with_session_and_propagation(
             query.clone(),
             session.clone(),
-            settled_tier,
+            durability_tier,
+            local_updates,
             propagation,
         )?;
 

--- a/crates/jazz-tools/src/query_manager/writes.rs
+++ b/crates/jazz-tools/src/query_manager/writes.rs
@@ -120,7 +120,7 @@ impl QueryManager {
         tracing::trace!(%object_id, table, "index_insert complete");
 
         // Mark subscriptions dirty
-        self.mark_subscriptions_dirty(table);
+        self.mark_subscriptions_dirty_local(table);
         tracing::trace!(table, "mark_subscriptions_dirty");
 
         tracing::debug!(%object_id, ?row_commit_id, branch = self.current_branch(), "row created");
@@ -232,7 +232,7 @@ impl QueryManager {
         )?;
 
         // Mark subscriptions dirty
-        self.mark_subscriptions_dirty(table);
+        self.mark_subscriptions_dirty_local(table);
 
         Ok(InsertHandle {
             row_id: object_id,
@@ -939,7 +939,7 @@ impl QueryManager {
         tracing::trace!(%id, table = %table_name.0, "index_update complete");
 
         // Mark subscriptions dirty and notify about content update
-        self.mark_subscriptions_dirty(&table_name.0);
+        self.mark_subscriptions_dirty_local(&table_name.0);
         self.mark_row_updated_in_subscriptions(&table_name.0, id);
         tracing::trace!(table = %table_name.0, "mark_subscriptions_dirty");
 
@@ -1077,7 +1077,7 @@ impl QueryManager {
         tracing::trace!(%id, table = %table, "index_remove complete (soft delete)");
 
         // Mark subscriptions dirty and mark row as deleted
-        self.mark_subscriptions_dirty(&table);
+        self.mark_subscriptions_dirty_local(&table);
         self.mark_row_deleted_in_subscriptions(&table, id);
         tracing::trace!(table = %table, "mark_subscriptions_dirty (delete)");
 
@@ -1160,7 +1160,7 @@ impl QueryManager {
         )?;
 
         // Mark subscriptions dirty
-        self.mark_subscriptions_dirty(table);
+        self.mark_subscriptions_dirty_local(table);
         self.mark_row_deleted_in_subscriptions(table, id);
 
         Ok(DeleteHandle {
@@ -1255,7 +1255,7 @@ impl QueryManager {
         self.update_indices_for_undelete(storage, &table, id, &new_data, &descriptor)?;
 
         // Mark subscriptions dirty
-        self.mark_subscriptions_dirty(&table);
+        self.mark_subscriptions_dirty_local(&table);
 
         Ok(InsertHandle {
             row_id: id,
@@ -1347,7 +1347,7 @@ impl QueryManager {
         );
 
         // Mark subscriptions dirty and mark row as deleted
-        self.mark_subscriptions_dirty(&table);
+        self.mark_subscriptions_dirty_local(&table);
         self.mark_row_deleted_in_subscriptions(&table, id);
 
         Ok(DeleteHandle {

--- a/crates/jazz-tools/src/routes.rs
+++ b/crates/jazz-tools/src/routes.rs
@@ -651,7 +651,7 @@ mod tests {
     use groove::runtime_tokio::TokioRuntime;
     use groove::schema_manager::{AppId, SchemaManager};
     use groove::storage::SurrealKvStorage;
-    use groove::sync_manager::{ClientId, PersistenceTier, SyncManager, SyncPayload};
+    use groove::sync_manager::{ClientId, DurabilityTier, SyncManager, SyncPayload};
     use serde_json::Value;
     use tempfile::TempDir;
     use tokio::sync::{RwLock, broadcast};
@@ -667,7 +667,8 @@ mod tests {
         let storage =
             SurrealKvStorage::open(&db_path, 64 * 1024 * 1024).expect("open test storage");
 
-        let sync_manager = SyncManager::new().with_tier(PersistenceTier::EdgeServer);
+        let sync_manager = SyncManager::new()
+            .with_durability_tiers([DurabilityTier::EdgeServer, DurabilityTier::GlobalServer]);
         let schema_manager =
             SchemaManager::new_server(sync_manager, AppId::from_name("test-app"), "prod");
         let runtime = TokioRuntime::new(schema_manager, storage, |_entry| {});
@@ -756,7 +757,8 @@ mod tests {
             )
             .build();
         let schema_hash = SchemaHash::compute(&schema);
-        let sync_manager = SyncManager::new().with_tier(PersistenceTier::EdgeServer);
+        let sync_manager = SyncManager::new()
+            .with_durability_tiers([DurabilityTier::EdgeServer, DurabilityTier::GlobalServer]);
         let schema_manager = SchemaManager::new(
             sync_manager,
             schema,

--- a/crates/jazz-tools/src/runtime_core.rs
+++ b/crates/jazz-tools/src/runtime_core.rs
@@ -39,7 +39,7 @@ use crate::query_manager::session::Session;
 use crate::query_manager::types::{OrderedRowDelta, Schema, TableName, Value};
 use crate::schema_manager::SchemaManager;
 use crate::storage::Storage;
-use crate::sync_manager::{ClientId, InboxEntry, OutboxEntry, PersistenceTier, ServerId};
+use crate::sync_manager::{ClientId, DurabilityTier, InboxEntry, OutboxEntry, ServerId};
 
 // ============================================================================
 // Scheduler and SyncSender traits
@@ -108,6 +108,7 @@ pub struct SubscriptionHandle(pub u64);
 
 // Re-export QueryHandle from query_manager for convenience
 pub use crate::query_manager::manager::QueryHandle as QMQueryHandle;
+pub use subscriptions::ReadDurabilityOptions;
 
 /// Errors from runtime operations.
 #[derive(Debug, Clone)]
@@ -238,7 +239,7 @@ pub struct RuntimeCore<S: Storage, Sch: Scheduler, Sy: SyncSender> {
 
     /// Watchers for persistence acks: (commit_id, requested_tier) → senders.
     /// A tier >= requested tier satisfies the watcher (e.g., EdgeServer ack satisfies Worker).
-    ack_watchers: HashMap<CommitId, Vec<(PersistenceTier, oneshot::Sender<()>)>>,
+    ack_watchers: HashMap<CommitId, Vec<(DurabilityTier, oneshot::Sender<()>)>>,
 
     /// Label for tracing (e.g. "worker", "edge", "client").
     tier_label: &'static str,

--- a/crates/jazz-tools/src/runtime_core/subscriptions.rs
+++ b/crates/jazz-tools/src/runtime_core/subscriptions.rs
@@ -1,5 +1,21 @@
 use super::*;
+use crate::query_manager::manager::LocalUpdates;
 use crate::sync_manager::QueryPropagation;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ReadDurabilityOptions {
+    pub tier: Option<DurabilityTier>,
+    pub local_updates: LocalUpdates,
+}
+
+impl Default for ReadDurabilityOptions {
+    fn default() -> Self {
+        Self {
+            tier: None,
+            local_updates: LocalUpdates::Immediate,
+        }
+    }
+}
 
 impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
     // =========================================================================
@@ -17,11 +33,11 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
     where
         F: Fn(SubscriptionDelta) + Send + 'static,
     {
-        self.subscribe_impl(
+        self.subscribe_with_durability_and_propagation(
             query,
-            Box::new(callback),
+            callback,
             session,
-            None,
+            ReadDurabilityOptions::default(),
             QueryPropagation::Full,
         )
     }
@@ -37,99 +53,45 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
     where
         F: Fn(SubscriptionDelta) + 'static,
     {
-        self.subscribe_impl(
-            query,
-            Box::new(callback),
-            session,
-            None,
-            QueryPropagation::Full,
-        )
-    }
-
-    /// Subscribe with optional settled tier.
-    #[cfg(not(target_arch = "wasm32"))]
-    pub fn subscribe_with_settled_tier<F>(
-        &mut self,
-        query: Query,
-        callback: F,
-        session: Option<Session>,
-        settled_tier: Option<PersistenceTier>,
-    ) -> Result<SubscriptionHandle, RuntimeError>
-    where
-        F: Fn(SubscriptionDelta) + Send + 'static,
-    {
-        self.subscribe_with_settled_tier_and_propagation(
+        self.subscribe_with_durability_and_propagation(
             query,
             callback,
             session,
-            settled_tier,
+            ReadDurabilityOptions::default(),
             QueryPropagation::Full,
         )
     }
 
-    /// Subscribe with settled tier (WASM version - no Send required).
-    #[cfg(target_arch = "wasm32")]
-    pub fn subscribe_with_settled_tier<F>(
-        &mut self,
-        query: Query,
-        callback: F,
-        session: Option<Session>,
-        settled_tier: Option<PersistenceTier>,
-    ) -> Result<SubscriptionHandle, RuntimeError>
-    where
-        F: Fn(SubscriptionDelta) + 'static,
-    {
-        self.subscribe_with_settled_tier_and_propagation(
-            query,
-            callback,
-            session,
-            settled_tier,
-            QueryPropagation::Full,
-        )
-    }
-
-    /// Subscribe with settled tier and explicit propagation mode.
+    /// Subscribe with explicit durability and propagation options.
     #[cfg(not(target_arch = "wasm32"))]
-    pub fn subscribe_with_settled_tier_and_propagation<F>(
+    pub fn subscribe_with_durability_and_propagation<F>(
         &mut self,
         query: Query,
         callback: F,
         session: Option<Session>,
-        settled_tier: Option<PersistenceTier>,
+        durability: ReadDurabilityOptions,
         propagation: QueryPropagation,
     ) -> Result<SubscriptionHandle, RuntimeError>
     where
         F: Fn(SubscriptionDelta) + Send + 'static,
     {
-        self.subscribe_impl(
-            query,
-            Box::new(callback),
-            session,
-            settled_tier,
-            propagation,
-        )
+        self.subscribe_impl(query, Box::new(callback), session, durability, propagation)
     }
 
-    /// Subscribe with settled tier and explicit propagation mode (WASM version).
+    /// Subscribe with explicit durability and propagation options (WASM version).
     #[cfg(target_arch = "wasm32")]
-    pub fn subscribe_with_settled_tier_and_propagation<F>(
+    pub fn subscribe_with_durability_and_propagation<F>(
         &mut self,
         query: Query,
         callback: F,
         session: Option<Session>,
-        settled_tier: Option<PersistenceTier>,
+        durability: ReadDurabilityOptions,
         propagation: QueryPropagation,
     ) -> Result<SubscriptionHandle, RuntimeError>
     where
         F: Fn(SubscriptionDelta) + 'static,
     {
-        self.subscribe_impl(
-            query,
-            Box::new(callback),
-            session,
-            settled_tier,
-            propagation,
-        )
+        self.subscribe_impl(query, Box::new(callback), session, durability, propagation)
     }
 
     /// Internal subscribe implementation.
@@ -138,14 +100,26 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
         query: Query,
         callback: SubscriptionCallback,
         session: Option<Session>,
-        settled_tier: Option<PersistenceTier>,
+        durability: ReadDurabilityOptions,
         propagation: QueryPropagation,
     ) -> Result<SubscriptionHandle, RuntimeError> {
-        let _span = debug_span!("subscribe", table = query.table.as_str()).entered();
+        let _span = debug_span!(
+            "subscribe",
+            table = query.table.as_str(),
+            ?durability.tier,
+            local_updates = ?durability.local_updates
+        )
+        .entered();
         let query_sub_id = self
             .schema_manager
             .query_manager_mut()
-            .subscribe_with_sync_and_propagation(query, session, settled_tier, propagation)
+            .subscribe_with_sync_and_propagation_with_local_updates(
+                query,
+                session,
+                durability.tier,
+                durability.local_updates,
+                propagation,
+            )
             .map_err(|e| RuntimeError::QueryError(format!("{:?}", e)))?;
 
         let handle = SubscriptionHandle(self.next_subscription_handle);
@@ -195,31 +169,42 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
     // Queries
     // =========================================================================
 
-    /// Execute a one-shot query, optionally waiting for a settled tier.
-    pub fn query(
-        &mut self,
-        query: Query,
-        session: Option<Session>,
-        settled_tier: Option<PersistenceTier>,
-    ) -> QueryFuture {
-        self.query_with_propagation(query, session, settled_tier, QueryPropagation::Full)
+    /// Execute a one-shot query.
+    pub fn query(&mut self, query: Query, session: Option<Session>) -> QueryFuture {
+        self.query_with_propagation(
+            query,
+            session,
+            ReadDurabilityOptions::default(),
+            QueryPropagation::Full,
+        )
     }
 
     pub fn query_with_propagation(
         &mut self,
         query: Query,
         session: Option<Session>,
-        settled_tier: Option<PersistenceTier>,
+        durability: ReadDurabilityOptions,
         propagation: QueryPropagation,
     ) -> QueryFuture {
-        let _span = debug_span!("query", table = query.table.as_str(), ?settled_tier).entered();
+        let _span = debug_span!(
+            "query",
+            table = query.table.as_str(),
+            ?durability.tier,
+            local_updates = ?durability.local_updates
+        )
+        .entered();
         let (sender, receiver) = oneshot::channel();
 
         let sub_id = match self
             .schema_manager
             .query_manager_mut()
-            .subscribe_with_sync_and_propagation(query, session, settled_tier, propagation)
-        {
+            .subscribe_with_sync_and_propagation_with_local_updates(
+                query,
+                session,
+                durability.tier,
+                durability.local_updates,
+                propagation,
+            ) {
             Ok(id) => id,
             Err(e) => {
                 let _ = sender.send(Err(RuntimeError::QueryError(format!("{:?}", e))));

--- a/crates/jazz-tools/src/runtime_core/tests.rs
+++ b/crates/jazz-tools/src/runtime_core/tests.rs
@@ -203,7 +203,7 @@ fn test_park_sync_message() {
 // =========================================================================
 
 use crate::sync_manager::{
-    ClientId, ClientRole, Destination, InboxEntry, OutboxEntry, PersistenceTier, ServerId, Source,
+    ClientId, ClientRole, Destination, DurabilityTier, InboxEntry, OutboxEntry, ServerId, Source,
     SyncPayload,
 };
 
@@ -233,7 +233,7 @@ fn create_3tier_rc() -> ThreeTierRC {
     );
 
     // B = Worker server
-    let sm_b = SyncManager::new().with_tier(PersistenceTier::Worker);
+    let sm_b = SyncManager::new().with_durability_tier(DurabilityTier::Worker);
     let mgr_b = SchemaManager::new(sm_b, schema.clone(), app_id.clone(), "dev", "main").unwrap();
     let mut b = RuntimeCore::new(
         mgr_b,
@@ -243,7 +243,7 @@ fn create_3tier_rc() -> ThreeTierRC {
     );
 
     // C = EdgeServer
-    let sm_c = SyncManager::new().with_tier(PersistenceTier::EdgeServer);
+    let sm_c = SyncManager::new().with_durability_tier(DurabilityTier::EdgeServer);
     let mgr_c = SchemaManager::new(sm_c, schema, app_id, "dev", "main").unwrap();
     let mut c = RuntimeCore::new(
         mgr_c,
@@ -482,7 +482,7 @@ fn rc_replays_downstream_query_when_upstream_added_late() {
     );
 
     let mgr_b = SchemaManager::new(
-        SyncManager::new().with_tier(PersistenceTier::Worker),
+        SyncManager::new().with_durability_tier(DurabilityTier::Worker),
         schema.clone(),
         app_id.clone(),
         "dev",
@@ -497,7 +497,7 @@ fn rc_replays_downstream_query_when_upstream_added_late() {
     );
 
     let mgr_c = SchemaManager::new(
-        SyncManager::new().with_tier(PersistenceTier::EdgeServer),
+        SyncManager::new().with_durability_tier(DurabilityTier::EdgeServer),
         schema,
         app_id,
         "dev",
@@ -711,7 +711,7 @@ fn rc_insert_persisted_resolves_on_worker_ack() {
     let mut s = create_3tier_rc();
     let values = vec![Value::Uuid(ObjectId::new()), Value::Text("Alice".into())];
     let (id, mut receiver) =
-        s.a.insert_persisted("users", values, None, PersistenceTier::Worker)
+        s.a.insert_persisted("users", values, None, DurabilityTier::Worker)
             .unwrap();
     assert!(!id.0.is_nil());
 
@@ -735,7 +735,7 @@ fn rc_insert_persisted_holds_until_correct_tier() {
     let mut s = create_3tier_rc();
     let values = vec![Value::Uuid(ObjectId::new()), Value::Text("Alice".into())];
     let (_id, mut receiver) =
-        s.a.insert_persisted("users", values, None, PersistenceTier::EdgeServer)
+        s.a.insert_persisted("users", values, None, DurabilityTier::EdgeServer)
             .unwrap();
 
     pump_a_to_b(&mut s);
@@ -762,7 +762,7 @@ fn rc_insert_persisted_higher_tier_satisfies_lower() {
     let mut s = create_3tier_rc();
     let values = vec![Value::Uuid(ObjectId::new()), Value::Text("Alice".into())];
     let (_id, mut receiver) =
-        s.a.insert_persisted("users", values, None, PersistenceTier::Worker)
+        s.a.insert_persisted("users", values, None, DurabilityTier::Worker)
             .unwrap();
 
     pump_3tier(&mut s);
@@ -786,7 +786,7 @@ fn rc_update_persisted_resolves_on_ack() {
             id,
             vec![("name".into(), Value::Text("Bob".into()))],
             None,
-            PersistenceTier::Worker,
+            DurabilityTier::Worker,
         )
         .unwrap();
 
@@ -812,7 +812,7 @@ fn rc_delete_persisted_resolves_on_ack() {
     pump_a_to_b(&mut s);
 
     let mut receiver =
-        s.a.delete_persisted(id, None, PersistenceTier::Worker)
+        s.a.delete_persisted(id, None, DurabilityTier::Worker)
             .unwrap();
 
     pump_a_to_b(&mut s);
@@ -835,12 +835,12 @@ fn rc_multiple_persisted_inserts_independent() {
 
     let values1 = vec![Value::Uuid(ObjectId::new()), Value::Text("Alice".into())];
     let (_id1, mut receiver1) =
-        s.a.insert_persisted("users", values1, None, PersistenceTier::Worker)
+        s.a.insert_persisted("users", values1, None, DurabilityTier::Worker)
             .unwrap();
 
     let values2 = vec![Value::Uuid(ObjectId::new()), Value::Text("Bob".into())];
     let (_id2, mut receiver2) =
-        s.a.insert_persisted("users", values2, None, PersistenceTier::Worker)
+        s.a.insert_persisted("users", values2, None, DurabilityTier::Worker)
             .unwrap();
 
     pump_3tier(&mut s);
@@ -864,7 +864,7 @@ fn rc_query_no_settled_tier_immediate() {
     let values = vec![Value::Uuid(ObjectId::new()), Value::Text("Alice".into())];
     let id = s.a.insert("users", values, None).unwrap();
 
-    let mut future = s.a.query(Query::new("users"), None, None);
+    let mut future = s.a.query(Query::new("users"), None);
 
     let waker = noop_waker();
     let mut cx = std::task::Context::from_waker(&waker);
@@ -885,8 +885,15 @@ fn rc_query_settled_tier_holds() {
     let values = vec![Value::Uuid(ObjectId::new()), Value::Text("Alice".into())];
     let id = s.a.insert("users", values, None).unwrap();
 
-    let mut future =
-        s.a.query(Query::new("users"), None, Some(PersistenceTier::Worker));
+    let mut future = s.a.query_with_propagation(
+        Query::new("users"),
+        None,
+        ReadDurabilityOptions {
+            tier: Some(DurabilityTier::Worker),
+            local_updates: crate::query_manager::manager::LocalUpdates::Immediate,
+        },
+        crate::sync_manager::QueryPropagation::Full,
+    );
 
     let waker = noop_waker();
     let mut cx = std::task::Context::from_waker(&waker);
@@ -912,8 +919,15 @@ fn rc_query_settled_tier_holds() {
 fn rc_query_settled_tier_empty_resolves() {
     let mut s = create_3tier_rc();
 
-    let mut future =
-        s.a.query(Query::new("users"), None, Some(PersistenceTier::Worker));
+    let mut future = s.a.query_with_propagation(
+        Query::new("users"),
+        None,
+        ReadDurabilityOptions {
+            tier: Some(DurabilityTier::Worker),
+            local_updates: crate::query_manager::manager::LocalUpdates::Immediate,
+        },
+        crate::sync_manager::QueryPropagation::Full,
+    );
 
     let waker = noop_waker();
     let mut cx = std::task::Context::from_waker(&waker);
@@ -954,8 +968,15 @@ fn rc_query_settled_before_data_should_not_drop_upstream_rows() {
     s.b.sync_sender().take();
 
     // One-shot settled query on A should wait for Worker settlement.
-    let mut future =
-        s.a.query(Query::new("users"), None, Some(PersistenceTier::Worker));
+    let mut future = s.a.query_with_propagation(
+        Query::new("users"),
+        None,
+        ReadDurabilityOptions {
+            tier: Some(DurabilityTier::Worker),
+            local_updates: crate::query_manager::manager::LocalUpdates::Immediate,
+        },
+        crate::sync_manager::QueryPropagation::Full,
+    );
 
     let waker = noop_waker();
     let mut cx = std::task::Context::from_waker(&waker);
@@ -1050,7 +1071,7 @@ fn rc_subscribe_settled_tier() {
     let received_clone = received.clone();
 
     let _handle =
-        s.a.subscribe_with_settled_tier(
+        s.a.subscribe_with_durability_and_propagation(
             Query::new("users"),
             move |delta| {
                 let rows: Vec<(ObjectId, Vec<Value>)> = delta
@@ -1066,7 +1087,11 @@ fn rc_subscribe_settled_tier() {
                 received_clone.lock().unwrap().push(rows);
             },
             None,
-            Some(PersistenceTier::Worker),
+            ReadDurabilityOptions {
+                tier: Some(DurabilityTier::Worker),
+                local_updates: crate::query_manager::manager::LocalUpdates::Deferred,
+            },
+            crate::sync_manager::QueryPropagation::Full,
         )
         .unwrap();
 

--- a/crates/jazz-tools/src/runtime_core/tests.rs
+++ b/crates/jazz-tools/src/runtime_core/tests.rs
@@ -1117,6 +1117,59 @@ fn rc_subscribe_settled_tier() {
     assert_eq!(first_delivery[0].0, id);
 }
 
+#[test]
+fn rc_subscribe_remote_tier_immediate_local_updates() {
+    let mut s = create_3tier_rc();
+
+    let received = Arc::new(Mutex::new(Vec::<Vec<(ObjectId, Vec<Value>)>>::new()));
+    let received_clone = received.clone();
+
+    let _handle =
+        s.a.subscribe_with_durability_and_propagation(
+            Query::new("users"),
+            move |delta| {
+                let rows: Vec<(ObjectId, Vec<Value>)> = delta
+                    .ordered_delta
+                    .added
+                    .iter()
+                    .filter_map(|row| {
+                        decode_row(&delta.descriptor, &row.row.data)
+                            .ok()
+                            .map(|vals| (row.row.id, vals))
+                    })
+                    .collect();
+                received_clone.lock().unwrap().push(rows);
+            },
+            None,
+            ReadDurabilityOptions {
+                tier: Some(DurabilityTier::EdgeServer),
+                local_updates: crate::query_manager::manager::LocalUpdates::Immediate,
+            },
+            crate::sync_manager::QueryPropagation::Full,
+        )
+        .unwrap();
+
+    let values = vec![
+        Value::Uuid(ObjectId::new()),
+        Value::Text("local-first".into()),
+    ];
+    let id = s.a.insert("users", values, None).unwrap();
+    s.a.immediate_tick();
+
+    let calls = received.lock().unwrap();
+    assert!(
+        !calls.is_empty(),
+        "Immediate local updates should deliver before EdgeServer settlement"
+    );
+    let first_delivery = &calls[0];
+    assert_eq!(
+        first_delivery.len(),
+        1,
+        "Should include the local row immediately"
+    );
+    assert_eq!(first_delivery[0].0, id);
+}
+
 fn noop_waker() -> std::task::Waker {
     fn noop(_: *const ()) {}
     fn clone(_: *const ()) -> std::task::RawWaker {

--- a/crates/jazz-tools/src/runtime_core/tests.rs
+++ b/crates/jazz-tools/src/runtime_core/tests.rs
@@ -1149,25 +1149,68 @@ fn rc_subscribe_remote_tier_immediate_local_updates() {
         )
         .unwrap();
 
+    // Initial delivery should still wait for the requested remote tier.
     let values = vec![
         Value::Uuid(ObjectId::new()),
         Value::Text("local-first".into()),
     ];
-    let id = s.a.insert("users", values, None).unwrap();
+    let first_id = s.a.insert("users", values, None).unwrap();
     s.a.immediate_tick();
 
     let calls = received.lock().unwrap();
     assert!(
+        calls.is_empty(),
+        "Initial delivery should wait for EdgeServer settlement"
+    );
+    drop(calls);
+
+    // Worker settlement is not enough for an EdgeServer subscription.
+    pump_a_to_b(&mut s);
+    pump_b_to_a(&mut s);
+    assert!(
+        received.lock().unwrap().is_empty(),
+        "Worker tier should not unlock first delivery for EdgeServer reads"
+    );
+
+    // Reach EdgeServer settlement for the initial snapshot.
+    pump_b_to_c(&mut s);
+    pump_c_to_b_to_a(&mut s);
+
+    let calls = received.lock().unwrap();
+    assert!(
         !calls.is_empty(),
-        "Immediate local updates should deliver before EdgeServer settlement"
+        "First delivery should happen once EdgeServer settlement is reached"
     );
     let first_delivery = &calls[0];
     assert_eq!(
         first_delivery.len(),
         1,
-        "Should include the local row immediately"
+        "First snapshot should include one row"
     );
-    assert_eq!(first_delivery[0].0, id);
+    assert_eq!(first_delivery[0].0, first_id);
+    drop(calls);
+
+    // After initial delivery, local updates should callback immediately.
+    let second_values = vec![
+        Value::Uuid(ObjectId::new()),
+        Value::Text("local-second".into()),
+    ];
+    let second_id = s.a.insert("users", second_values, None).unwrap();
+    s.a.immediate_tick();
+
+    let calls = received.lock().unwrap();
+    assert_eq!(
+        calls.len(),
+        2,
+        "Second local write should trigger immediate callback"
+    );
+    let second_delivery = &calls[1];
+    assert_eq!(
+        second_delivery.len(),
+        1,
+        "Second callback should contain one added row"
+    );
+    assert_eq!(second_delivery[0].0, second_id);
 }
 
 fn noop_waker() -> std::task::Waker {

--- a/crates/jazz-tools/src/runtime_core/writes.rs
+++ b/crates/jazz-tools/src/runtime_core/writes.rs
@@ -68,7 +68,7 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
         table: &str,
         values: Vec<Value>,
         session: Option<&Session>,
-        tier: PersistenceTier,
+        tier: DurabilityTier,
     ) -> Result<(ObjectId, oneshot::Receiver<()>), RuntimeError> {
         let result = self
             .schema_manager
@@ -76,10 +76,19 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
             .map_err(|e| RuntimeError::WriteError(format!("{:?}", e)))?;
 
         let (sender, receiver) = oneshot::channel();
-        self.ack_watchers
-            .entry(result.row_commit_id)
-            .or_default()
-            .push((tier, sender));
+        if self
+            .schema_manager
+            .query_manager()
+            .sync_manager()
+            .has_local_durability_at_least(tier)
+        {
+            let _ = sender.send(());
+        } else {
+            self.ack_watchers
+                .entry(result.row_commit_id)
+                .or_default()
+                .push((tier, sender));
+        }
 
         self.immediate_tick();
         Ok((result.row_id, receiver))
@@ -92,7 +101,7 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
         object_id: ObjectId,
         values: Vec<(String, Value)>,
         session: Option<&Session>,
-        tier: PersistenceTier,
+        tier: DurabilityTier,
     ) -> Result<oneshot::Receiver<()>, RuntimeError> {
         let current_values = self.merge_row_update_values(object_id, values)?;
 
@@ -103,10 +112,19 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
             .map_err(|e| RuntimeError::WriteError(format!("{:?}", e)))?;
 
         let (sender, receiver) = oneshot::channel();
-        self.ack_watchers
-            .entry(commit_id)
-            .or_default()
-            .push((tier, sender));
+        if self
+            .schema_manager
+            .query_manager()
+            .sync_manager()
+            .has_local_durability_at_least(tier)
+        {
+            let _ = sender.send(());
+        } else {
+            self.ack_watchers
+                .entry(commit_id)
+                .or_default()
+                .push((tier, sender));
+        }
 
         self.immediate_tick();
         Ok(receiver)
@@ -149,7 +167,7 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
         &mut self,
         object_id: ObjectId,
         session: Option<&Session>,
-        tier: PersistenceTier,
+        tier: DurabilityTier,
     ) -> Result<oneshot::Receiver<()>, RuntimeError> {
         let handle = self
             .schema_manager
@@ -158,10 +176,19 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
             .map_err(|e| RuntimeError::WriteError(format!("{:?}", e)))?;
 
         let (sender, receiver) = oneshot::channel();
-        self.ack_watchers
-            .entry(handle.delete_commit_id)
-            .or_default()
-            .push((tier, sender));
+        if self
+            .schema_manager
+            .query_manager()
+            .sync_manager()
+            .has_local_durability_at_least(tier)
+        {
+            let _ = sender.send(());
+        } else {
+            self.ack_watchers
+                .entry(handle.delete_commit_id)
+                .or_default()
+                .push((tier, sender));
+        }
 
         self.immediate_tick();
         Ok(receiver)

--- a/crates/jazz-tools/src/runtime_tokio.rs
+++ b/crates/jazz-tools/src/runtime_tokio.rs
@@ -513,7 +513,9 @@ mod tests {
 
         // Query
         let query = Query::new("users");
-        let future = runtime.query(query, None, None).unwrap();
+        let future = runtime
+            .query(query, None, ReadDurabilityOptions::default())
+            .unwrap();
         let results = future.await.unwrap();
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].0, object_id);
@@ -539,7 +541,9 @@ mod tests {
 
         // Verify update
         let query = Query::new("users");
-        let future = runtime.query(query, None, None).unwrap();
+        let future = runtime
+            .query(query, None, ReadDurabilityOptions::default())
+            .unwrap();
         let results = future.await.unwrap();
         assert_eq!(results[0].1[1], Value::Text("Charlie".to_string()));
 
@@ -548,7 +552,9 @@ mod tests {
 
         // Verify deleted
         let query = Query::new("users");
-        let future = runtime.query(query, None, None).unwrap();
+        let future = runtime
+            .query(query, None, ReadDurabilityOptions::default())
+            .unwrap();
         let results = future.await.unwrap();
         assert_eq!(results.len(), 0);
     }

--- a/crates/jazz-tools/src/runtime_tokio.rs
+++ b/crates/jazz-tools/src/runtime_tokio.rs
@@ -21,12 +21,12 @@ use crate::query_manager::session::Session;
 use crate::query_manager::types::{Schema, SchemaHash, Value};
 pub use crate::runtime_core::SubscriptionHandle;
 use crate::runtime_core::{
-    QueryFuture, RuntimeCore, RuntimeError as CoreRuntimeError, Scheduler, SubscriptionDelta,
-    SyncSender,
+    QueryFuture, ReadDurabilityOptions, RuntimeCore, RuntimeError as CoreRuntimeError, Scheduler,
+    SubscriptionDelta, SyncSender,
 };
 use crate::schema_manager::{QuerySchemaContext, SchemaManager};
 use crate::storage::Storage;
-use crate::sync_manager::{ClientId, InboxEntry, OutboxEntry, PersistenceTier, ServerId};
+use crate::sync_manager::{ClientId, InboxEntry, OutboxEntry, QueryPropagation, ServerId};
 
 // ============================================================================
 // TokioScheduler
@@ -301,15 +301,15 @@ impl<S: Storage + Send + 'static> TokioRuntime<S> {
     // Queries
     // =========================================================================
 
-    /// Execute a one-shot query, optionally waiting for a settled tier.
+    /// Execute a one-shot query with durability options.
     pub fn query(
         &self,
         query: Query,
         session: Option<Session>,
-        settled_tier: Option<PersistenceTier>,
+        durability: ReadDurabilityOptions,
     ) -> Result<QueryFuture, RuntimeError> {
         let mut core = self.core.lock().map_err(|_| RuntimeError::LockError)?;
-        Ok(core.query(query, session, settled_tier))
+        Ok(core.query_with_propagation(query, session, durability, QueryPropagation::Full))
     }
 
     // =========================================================================

--- a/crates/jazz-tools/src/schema_manager/integration_tests.rs
+++ b/crates/jazz-tools/src/schema_manager/integration_tests.rs
@@ -8,6 +8,7 @@ mod tests {
     use crate::metadata::MetadataKey;
     use crate::object::ObjectId;
     use crate::query_manager::encoding::{decode_row, encode_row};
+    use crate::query_manager::manager::LocalUpdates;
     use crate::query_manager::types::{
         ColumnDescriptor, ColumnType, RowDescriptor, Schema, SchemaBuilder, SchemaHash, TableName,
         TableSchema, Value,
@@ -2050,7 +2051,7 @@ mod tests {
     // ========================================================================
 
     use crate::sync_manager::{
-        ClientId, ClientRole, Destination, InboxEntry, PersistenceTier, QueryId, ServerId, Source,
+        ClientId, ClientRole, Destination, DurabilityTier, InboxEntry, QueryId, ServerId, Source,
         SyncPayload,
     };
 
@@ -3001,7 +3002,7 @@ mod tests {
 
         // === Setup Server B (Worker tier) ===
         let mut server_b = SchemaManager::new(
-            SyncManager::new().with_tier(PersistenceTier::Worker),
+            SyncManager::new().with_durability_tier(DurabilityTier::Worker),
             schema.clone(),
             test_app_id(),
             "dev",
@@ -3035,7 +3036,7 @@ mod tests {
             .build();
         let sub_id = client_a
             .query_manager_mut()
-            .subscribe_with_sync(query, None, Some(PersistenceTier::Worker))
+            .subscribe_with_sync(query, None, Some(DurabilityTier::Worker))
             .unwrap();
         client_a.process(&mut io_a);
 
@@ -3145,7 +3146,12 @@ mod tests {
             .build();
         let sub_id = client_a
             .query_manager_mut()
-            .subscribe_with_sync(query, None, Some(PersistenceTier::EdgeServer))
+            .subscribe_with_sync_with_local_updates(
+                query,
+                None,
+                Some(DurabilityTier::EdgeServer),
+                LocalUpdates::Deferred,
+            )
             .unwrap();
         client_a.process(&mut io_a);
 
@@ -3176,7 +3182,7 @@ mod tests {
                 source: Source::Server(server_b_id),
                 payload: SyncPayload::QuerySettled {
                     query_id,
-                    tier: PersistenceTier::Worker,
+                    tier: DurabilityTier::Worker,
                     through_seq: 0,
                 },
             });
@@ -3200,7 +3206,7 @@ mod tests {
                 source: Source::Server(server_b_id),
                 payload: SyncPayload::QuerySettled {
                     query_id,
-                    tier: PersistenceTier::EdgeServer,
+                    tier: DurabilityTier::EdgeServer,
                     through_seq: 0,
                 },
             });
@@ -3246,7 +3252,12 @@ mod tests {
             .build();
         let sub_id = client
             .query_manager_mut()
-            .subscribe_with_sync(query, None, Some(PersistenceTier::Worker))
+            .subscribe_with_sync_with_local_updates(
+                query,
+                None,
+                Some(DurabilityTier::Worker),
+                LocalUpdates::Deferred,
+            )
             .unwrap();
         client.process(&mut storage);
 
@@ -3279,7 +3290,7 @@ mod tests {
                 source: Source::Server(server_id),
                 payload: SyncPayload::QuerySettled {
                     query_id,
-                    tier: PersistenceTier::Worker,
+                    tier: DurabilityTier::Worker,
                     through_seq: 0,
                 },
             });
@@ -3335,7 +3346,7 @@ mod tests {
             .build();
         let sub_id = client
             .query_manager_mut()
-            .subscribe_with_sync(query, None, Some(PersistenceTier::Worker))
+            .subscribe_with_sync(query, None, Some(DurabilityTier::Worker))
             .unwrap();
         client.process(&mut storage);
 
@@ -3360,7 +3371,7 @@ mod tests {
                 source: Source::Server(server_id),
                 payload: SyncPayload::QuerySettled {
                     query_id,
-                    tier: PersistenceTier::Worker,
+                    tier: DurabilityTier::Worker,
                     through_seq: 0,
                 },
             });
@@ -3407,7 +3418,7 @@ mod tests {
             .build();
         let sub_id = client
             .query_manager_mut()
-            .subscribe_with_sync(query, None, Some(PersistenceTier::Worker))
+            .subscribe_with_sync(query, None, Some(DurabilityTier::Worker))
             .unwrap();
         client.process(&mut storage);
 
@@ -3432,7 +3443,7 @@ mod tests {
                 source: Source::Server(server_id),
                 payload: SyncPayload::QuerySettled {
                     query_id,
-                    tier: PersistenceTier::Worker,
+                    tier: DurabilityTier::Worker,
                     through_seq: 0,
                 },
             });

--- a/crates/jazz-tools/src/storage/mod.rs
+++ b/crates/jazz-tools/src/storage/mod.rs
@@ -26,7 +26,7 @@ use serde::{Deserialize, Serialize};
 use crate::commit::{Commit, CommitId};
 use crate::object::{BranchName, ObjectId};
 use crate::query_manager::types::{SchemaHash, Value};
-use crate::sync_manager::PersistenceTier;
+use crate::sync_manager::DurabilityTier;
 
 // ============================================================================
 // Storage Types
@@ -184,7 +184,7 @@ pub trait Storage {
     fn store_ack_tier(
         &mut self,
         commit_id: CommitId,
-        tier: PersistenceTier,
+        tier: DurabilityTier,
     ) -> Result<(), StorageError>;
 
     // ================================================================
@@ -325,7 +325,7 @@ impl<T: Storage + ?Sized> Storage for Box<T> {
     fn store_ack_tier(
         &mut self,
         commit_id: CommitId,
-        tier: PersistenceTier,
+        tier: DurabilityTier,
     ) -> Result<(), StorageError> {
         (**self).store_ack_tier(commit_id, tier)
     }
@@ -435,7 +435,7 @@ pub struct MemoryStorage {
     indices: HashMap<IndexKey, IndexEntries>,
 
     /// Persistence ack tiers per commit.
-    ack_tiers: HashMap<CommitId, HashSet<PersistenceTier>>,
+    ack_tiers: HashMap<CommitId, HashSet<DurabilityTier>>,
     /// Append-only manifest ops keyed by app_id then op object_id.
     catalogue_manifest_ops: HashMap<ObjectId, HashMap<ObjectId, CatalogueManifestOp>>,
 }
@@ -674,7 +674,7 @@ impl Storage for MemoryStorage {
     fn store_ack_tier(
         &mut self,
         commit_id: CommitId,
-        tier: PersistenceTier,
+        tier: DurabilityTier,
     ) -> Result<(), StorageError> {
         self.ack_tiers.entry(commit_id).or_default().insert(tier);
         Ok(())

--- a/crates/jazz-tools/src/storage/opfs_btree.rs
+++ b/crates/jazz-tools/src/storage/opfs_btree.rs
@@ -9,7 +9,7 @@
 //! "obj:{uuid}:meta"                                       → JSON metadata
 //! "obj:{uuid}:br:{branch}:tips"                           → JSON HashSet<CommitId>
 //! "obj:{uuid}:br:{branch}:c:{commit_uuid}"                → JSON Commit
-//! "ack:{commit_hex}"                                      → JSON HashSet<PersistenceTier>
+//! "ack:{commit_hex}"                                      → JSON HashSet<DurabilityTier>
 //! "catman:{app_uuid}:op:{object_uuid}"                    → JSON CatalogueManifestOp
 //! "idx:{table}:{col}:{branch}:{hex_encoded_value}:{uuid}" → empty (existence is the signal)
 //! ```
@@ -29,7 +29,7 @@ use opfs_btree::{BTreeError, BTreeOptions, MemoryFile, OpfsBTree, SyncFile};
 use crate::commit::{Commit, CommitId};
 use crate::object::{BranchName, ObjectId};
 use crate::query_manager::types::Value;
-use crate::sync_manager::PersistenceTier;
+use crate::sync_manager::DurabilityTier;
 
 use super::{
     CatalogueManifest, CatalogueManifestOp, LoadedBranch, Storage, StorageError,
@@ -305,7 +305,7 @@ impl Storage for OpfsBTreeStorage {
     fn store_ack_tier(
         &mut self,
         commit_id: CommitId,
-        tier: PersistenceTier,
+        tier: DurabilityTier,
     ) -> Result<(), StorageError> {
         store_ack_tier_core(
             commit_id,
@@ -605,17 +605,17 @@ mod tests {
         let commit_id = CommitId([99u8; 32]);
 
         storage
-            .store_ack_tier(commit_id, PersistenceTier::Worker)
+            .store_ack_tier(commit_id, DurabilityTier::Worker)
             .unwrap();
         storage
-            .store_ack_tier(commit_id, PersistenceTier::EdgeServer)
+            .store_ack_tier(commit_id, DurabilityTier::EdgeServer)
             .unwrap();
 
         let key = super::super::key_codec::ack_key(commit_id);
         let data = storage.tree_read(&key).unwrap().unwrap();
-        let tiers: HashSet<PersistenceTier> = serde_json::from_slice(&data).unwrap();
-        assert!(tiers.contains(&PersistenceTier::Worker));
-        assert!(tiers.contains(&PersistenceTier::EdgeServer));
+        let tiers: HashSet<DurabilityTier> = serde_json::from_slice(&data).unwrap();
+        assert!(tiers.contains(&DurabilityTier::Worker));
+        assert!(tiers.contains(&DurabilityTier::EdgeServer));
     }
 
     #[test]

--- a/crates/jazz-tools/src/storage/storage_core.rs
+++ b/crates/jazz-tools/src/storage/storage_core.rs
@@ -5,7 +5,7 @@ use serde::{Serialize, de::DeserializeOwned};
 
 use crate::commit::{Commit, CommitId};
 use crate::object::{BranchName, ObjectId};
-use crate::sync_manager::PersistenceTier;
+use crate::sync_manager::DurabilityTier;
 
 use crate::query_manager::types::Value;
 
@@ -73,7 +73,7 @@ pub(super) fn load_branch_core(
 
         let ack_lookup_key = ack_key(commit.id());
         if let Some(ack_data) = get(&ack_lookup_key)? {
-            let tiers: HashSet<PersistenceTier> = decode_json(&ack_data, "ack")?;
+            let tiers: HashSet<DurabilityTier> = decode_json(&ack_data, "ack")?;
             commit.ack_state.confirmed_tiers = tiers;
         }
 
@@ -158,12 +158,12 @@ pub(super) fn set_branch_tails_core(
 
 pub(super) fn store_ack_tier_core(
     commit_id: CommitId,
-    tier: PersistenceTier,
+    tier: DurabilityTier,
     mut get: impl FnMut(&str) -> Result<Option<Vec<u8>>, StorageError>,
     mut set: impl FnMut(&str, &[u8]) -> Result<(), StorageError>,
 ) -> Result<(), StorageError> {
     let key = ack_key(commit_id);
-    let mut tiers: HashSet<PersistenceTier> = match get(&key)? {
+    let mut tiers: HashSet<DurabilityTier> = match get(&key)? {
         Some(data) => decode_json(&data, "ack")?,
         None => HashSet::new(),
     };

--- a/crates/jazz-tools/src/storage/surrealkv.rs
+++ b/crates/jazz-tools/src/storage/surrealkv.rs
@@ -9,7 +9,7 @@
 //! "obj:{uuid}:meta"                                       → JSON metadata
 //! "obj:{uuid}:br:{branch}:tips"                           → JSON HashSet<CommitId>
 //! "obj:{uuid}:br:{branch}:c:{commit_uuid}"                → JSON Commit
-//! "ack:{commit_hex}"                                      → JSON HashSet<PersistenceTier>
+//! "ack:{commit_hex}"                                      → JSON HashSet<DurabilityTier>
 //! "catman:{app_uuid}:op:{object_uuid}"                    → JSON CatalogueManifestOp
 //! "idx:{table}:{col}:{branch}:{hex_encoded_value}:{uuid}" → empty (existence is the signal)
 //! ```
@@ -29,7 +29,7 @@ use tokio::runtime::{Builder as TokioRuntimeBuilder, Runtime as TokioRuntime};
 use crate::commit::{Commit, CommitId};
 use crate::object::{BranchName, ObjectId};
 use crate::query_manager::types::Value;
-use crate::sync_manager::PersistenceTier;
+use crate::sync_manager::DurabilityTier;
 
 use super::{
     CatalogueManifest, CatalogueManifestOp, LoadedBranch, Storage, StorageError,
@@ -338,7 +338,7 @@ impl Storage for SurrealKvStorage {
     fn store_ack_tier(
         &mut self,
         commit_id: CommitId,
-        tier: PersistenceTier,
+        tier: DurabilityTier,
     ) -> Result<(), StorageError> {
         self.with_eventual_write(|txn| {
             store_ack_tier_core(

--- a/crates/jazz-tools/src/sync_manager/inbox.rs
+++ b/crates/jazz-tools/src/sync_manager/inbox.rs
@@ -38,19 +38,19 @@ impl SyncManager {
                 let persisted =
                     self.apply_object_updated(storage, object_id, metadata, branch_name, commits);
 
-                // Emit ack back to server if we have a tier
-                if let Some(tier) = self.my_tier
-                    && !persisted.is_empty()
-                {
-                    self.outbox.push(OutboxEntry {
-                        destination: Destination::Server(server_id),
-                        payload: SyncPayload::PersistenceAck {
-                            object_id,
-                            branch_name,
-                            confirmed_commits: persisted,
-                            tier,
-                        },
-                    });
+                // Emit ack back to server for each local durability identity.
+                if !persisted.is_empty() {
+                    for tier in self.my_tiers.iter().copied() {
+                        self.outbox.push(OutboxEntry {
+                            destination: Destination::Server(server_id),
+                            payload: SyncPayload::PersistenceAck {
+                                object_id,
+                                branch_name,
+                                confirmed_commits: persisted.clone(),
+                                tier,
+                            },
+                        });
+                    }
                 }
 
                 // Forward to clients whose scope includes this object/branch
@@ -405,19 +405,19 @@ impl SyncManager {
                 let persisted =
                     self.apply_object_updated(storage, object_id, metadata, branch_name, commits);
 
-                // Emit ack back to client if we have a tier
-                if let Some(tier) = self.my_tier
-                    && !persisted.is_empty()
-                {
-                    self.outbox.push(OutboxEntry {
-                        destination: Destination::Client(client_id),
-                        payload: SyncPayload::PersistenceAck {
-                            object_id,
-                            branch_name,
-                            confirmed_commits: persisted,
-                            tier,
-                        },
-                    });
+                // Emit ack back to client for each local durability identity.
+                if !persisted.is_empty() {
+                    for tier in self.my_tiers.iter().copied() {
+                        self.outbox.push(OutboxEntry {
+                            destination: Destination::Client(client_id),
+                            payload: SyncPayload::PersistenceAck {
+                                object_id,
+                                branch_name,
+                                confirmed_commits: persisted.clone(),
+                                tier,
+                            },
+                        });
+                    }
                 }
 
                 // Forward to servers

--- a/crates/jazz-tools/src/sync_manager/mod.rs
+++ b/crates/jazz-tools/src/sync_manager/mod.rs
@@ -47,18 +47,18 @@ pub struct SyncManager {
 
     pub(super) next_pending_id: u64,
 
-    /// This node's persistence tier (None = don't emit acks).
-    pub(super) my_tier: Option<PersistenceTier>,
+    /// This node's durability identities (empty = don't emit durability notifications).
+    pub(super) my_tiers: HashSet<DurabilityTier>,
     /// Tracks which clients are interested in acks for each commit.
     pub(super) commit_interest: HashMap<CommitId, HashSet<ClientId>>,
 
     /// Tracks which clients originated each query (for relaying QuerySettled).
     pub(super) query_origin: HashMap<QueryId, HashSet<ClientId>>,
     /// Pending QuerySettled notifications for QueryManager to process.
-    pub(super) pending_query_settled: Vec<(QueryId, PersistenceTier)>,
+    pub(super) pending_query_settled: Vec<(QueryId, DurabilityTier)>,
 
     /// Acks received during inbox processing, for RuntimeCore to consume.
-    pub(super) received_acks: Vec<(CommitId, PersistenceTier)>,
+    pub(super) received_acks: Vec<(CommitId, DurabilityTier)>,
 }
 
 impl std::fmt::Debug for SyncManager {
@@ -79,7 +79,7 @@ impl std::fmt::Debug for SyncManager {
                 &self.pending_query_unsubscriptions,
             )
             .field("next_pending_id", &self.next_pending_id)
-            .field("my_tier", &self.my_tier)
+            .field("my_tiers", &self.my_tiers)
             .field("commit_interest", &self.commit_interest)
             .field("query_origin", &self.query_origin)
             .field("pending_query_settled", &self.pending_query_settled)
@@ -111,7 +111,7 @@ impl SyncManager {
             pending_query_subscriptions: Vec::new(),
             pending_query_unsubscriptions: Vec::new(),
             next_pending_id: 0,
-            my_tier: None,
+            my_tiers: HashSet::new(),
             commit_interest: HashMap::new(),
             query_origin: HashMap::new(),
             pending_query_settled: Vec::new(),
@@ -119,16 +119,38 @@ impl SyncManager {
         }
     }
 
-    /// Set this node's persistence tier (enables ack emission).
-    pub fn with_tier(mut self, tier: PersistenceTier) -> Self {
-        self.my_tier = Some(tier);
+    /// Add a durability identity for this node (enables durability notifications).
+    pub fn with_durability_tier(mut self, tier: DurabilityTier) -> Self {
+        self.my_tiers.insert(tier);
         self
     }
 
-    /// True when this runtime instance represents a persistence tier node
-    /// (worker/edge/core) rather than a top-level client.
-    pub fn has_persistence_tier(&self) -> bool {
-        self.my_tier.is_some()
+    /// Add multiple durability identities for this node.
+    pub fn with_durability_tiers<I>(mut self, tiers: I) -> Self
+    where
+        I: IntoIterator<Item = DurabilityTier>,
+    {
+        self.my_tiers.extend(tiers);
+        self
+    }
+
+    /// True when this runtime instance represents a durability tier identity
+    /// (worker/edge/global) rather than a top-level client.
+    pub fn has_durability_identity(&self) -> bool {
+        !self.my_tiers.is_empty()
+    }
+
+    /// True when this node can satisfy acknowledgements for the requested tier
+    /// using one of its local durability identities.
+    pub fn has_local_durability_at_least(&self, requested_tier: DurabilityTier) -> bool {
+        self.my_tiers
+            .iter()
+            .any(|local_tier| *local_tier >= requested_tier)
+    }
+
+    /// Return this node's local durability identities.
+    pub fn local_durability_tiers(&self) -> HashSet<DurabilityTier> {
+        self.my_tiers.clone()
     }
 
     // ========================================================================
@@ -403,13 +425,13 @@ impl SyncManager {
     }
 
     /// Take pending QuerySettled notifications for QueryManager to process.
-    pub fn take_pending_query_settled(&mut self) -> Vec<(QueryId, PersistenceTier)> {
+    pub fn take_pending_query_settled(&mut self) -> Vec<(QueryId, DurabilityTier)> {
         std::mem::take(&mut self.pending_query_settled)
     }
 
     /// Take received persistence acks since last call.
     /// Used by RuntimeCore to resolve `_persisted` mutation receivers.
-    pub fn take_received_acks(&mut self) -> Vec<(CommitId, PersistenceTier)> {
+    pub fn take_received_acks(&mut self) -> Vec<(CommitId, DurabilityTier)> {
         std::mem::take(&mut self.received_acks)
     }
 
@@ -417,7 +439,7 @@ impl SyncManager {
     ///
     /// Called by QueryManager when a server subscription settles for the first time.
     pub fn emit_query_settled(&mut self, client_id: ClientId, query_id: QueryId) {
-        if let Some(tier) = self.my_tier {
+        for tier in self.my_tiers.iter().copied() {
             self.outbox.push(OutboxEntry {
                 destination: Destination::Client(client_id),
                 payload: SyncPayload::QuerySettled {

--- a/crates/jazz-tools/src/sync_manager/tests.rs
+++ b/crates/jazz-tools/src/sync_manager/tests.rs
@@ -1912,8 +1912,8 @@ fn setup_3tier() -> ThreeTierSetup {
     let c_server_for_b = ServerId::new();
 
     let a = SyncManager::new();
-    let mut b = SyncManager::new().with_tier(PersistenceTier::Worker);
-    let mut c = SyncManager::new().with_tier(PersistenceTier::EdgeServer);
+    let mut b = SyncManager::new().with_durability_tier(DurabilityTier::Worker);
+    let mut c = SyncManager::new().with_durability_tier(DurabilityTier::EdgeServer);
 
     // A connects to B as server
     b.add_client(a_client_of_b);
@@ -1990,7 +1990,7 @@ fn persistence_ack_direct() {
         a_commit
             .ack_state
             .confirmed_tiers
-            .contains(&PersistenceTier::Worker),
+            .contains(&DurabilityTier::Worker),
         "A should have received Worker ack from B"
     );
 }
@@ -2031,7 +2031,7 @@ fn persistence_ack_relay() {
         a_commit
             .ack_state
             .confirmed_tiers
-            .contains(&PersistenceTier::EdgeServer),
+            .contains(&DurabilityTier::EdgeServer),
         "A should have received EdgeServer ack relayed through B"
     );
 }
@@ -2070,14 +2070,14 @@ fn persistence_ack_both_tiers() {
         a_commit
             .ack_state
             .confirmed_tiers
-            .contains(&PersistenceTier::Worker),
+            .contains(&DurabilityTier::Worker),
         "Should have Worker ack from B"
     );
     assert!(
         a_commit
             .ack_state
             .confirmed_tiers
-            .contains(&PersistenceTier::EdgeServer),
+            .contains(&DurabilityTier::EdgeServer),
         "Should have EdgeServer ack from C"
     );
 }
@@ -2134,7 +2134,7 @@ fn persistence_ack_idempotent() {
         a_commit
             .ack_state
             .confirmed_tiers
-            .contains(&PersistenceTier::Worker)
+            .contains(&DurabilityTier::Worker)
     );
 }
 
@@ -2217,7 +2217,7 @@ fn persistence_ack_survives_reload() {
     io.append_commit(obj_id, &"main".into(), commit).unwrap();
 
     // Store ack tier
-    io.store_ack_tier(commit_id, PersistenceTier::EdgeServer)
+    io.store_ack_tier(commit_id, DurabilityTier::EdgeServer)
         .unwrap();
 
     // Load branch and verify ack_state is populated
@@ -2231,7 +2231,7 @@ fn persistence_ack_survives_reload() {
         loaded.commits[0]
             .ack_state
             .confirmed_tiers
-            .contains(&PersistenceTier::EdgeServer),
+            .contains(&DurabilityTier::EdgeServer),
         "Loaded commit should have EdgeServer ack"
     );
 }
@@ -2243,7 +2243,7 @@ fn ack_state_does_not_affect_commit_id_sync() {
     let mut ack_state = crate::commit::CommitAckState::default();
     ack_state
         .confirmed_tiers
-        .insert(PersistenceTier::CoreServer);
+        .insert(DurabilityTier::GlobalServer);
 
     let commit1 = make_test_commit(b"same-content", vec![]);
     let mut commit2 = make_test_commit(b"same-content", vec![]);

--- a/crates/jazz-tools/src/sync_manager/types.rs
+++ b/crates/jazz-tools/src/sync_manager/types.rs
@@ -19,12 +19,12 @@ pub struct PolicyError {
 // ID Types
 // ============================================================================
 
-/// Persistence tier — declaration order defines Ord (Worker < EdgeServer < CoreServer).
+/// Persistence tier — declaration order defines Ord (Worker < EdgeServer < GlobalServer).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, PartialOrd, Ord)]
-pub enum PersistenceTier {
+pub enum DurabilityTier {
     Worker,
     EdgeServer,
-    CoreServer,
+    GlobalServer,
 }
 
 /// Unique identifier for a server connection.
@@ -247,13 +247,13 @@ pub enum SyncPayload {
         object_id: ObjectId,
         branch_name: BranchName,
         confirmed_commits: HashSet<CommitId>,
-        tier: PersistenceTier,
+        tier: DurabilityTier,
     },
 
     /// Query settlement notification — a query has settled at a given persistence tier.
     QuerySettled {
         query_id: QueryId,
-        tier: PersistenceTier,
+        tier: DurabilityTier,
         /// Highest stream sequence known to be emitted before this notification.
         through_seq: u64,
     },

--- a/crates/jazz-tools/tests/client_restart_integration.rs
+++ b/crates/jazz-tools/tests/client_restart_integration.rs
@@ -8,7 +8,7 @@ use axum::{Json, Router, routing::get};
 use base64::Engine;
 use jazz_tools::storage::{Storage, SurrealKvStorage};
 use jazz_tools::{
-    AppContext, AppId, ColumnType, JazzClient, PersistenceTier, QueryBuilder, SchemaBuilder,
+    AppContext, AppId, ColumnType, DurabilityTier, JazzClient, QueryBuilder, SchemaBuilder,
     TableSchema, Value,
 };
 use jsonwebtoken::{Algorithm, EncodingKey, Header, encode};
@@ -212,7 +212,7 @@ async fn wait_for_todos_count(
     client: &JazzClient,
     expected_count: usize,
     timeout: Duration,
-    settled_tier: Option<PersistenceTier>,
+    durability_tier: Option<DurabilityTier>,
 ) -> Vec<(jazz_tools::ObjectId, Vec<Value>)> {
     let query = QueryBuilder::new("todos").build();
     let deadline = tokio::time::Instant::now() + timeout;
@@ -221,7 +221,7 @@ async fn wait_for_todos_count(
     while tokio::time::Instant::now() < deadline {
         if let Ok(Ok(rows)) = tokio::time::timeout(
             Duration::from_secs(8),
-            client.query(query.clone(), settled_tier),
+            client.query(query.clone(), durability_tier),
         )
         .await
         {
@@ -246,7 +246,7 @@ async fn wait_for_edge_query_ready(client: &JazzClient, timeout: Duration) {
     while tokio::time::Instant::now() < deadline {
         if let Ok(Ok(_)) = tokio::time::timeout(
             Duration::from_secs(8),
-            client.query(query.clone(), Some(PersistenceTier::EdgeServer)),
+            client.query(query.clone(), Some(DurabilityTier::EdgeServer)),
         )
         .await
         {
@@ -329,7 +329,7 @@ async fn jazz_tools_cli_existing_client_keeps_working_after_server_restart_witho
         &client,
         1,
         Duration::from_secs(20),
-        Some(PersistenceTier::EdgeServer),
+        Some(DurabilityTier::EdgeServer),
     )
     .await;
 
@@ -348,7 +348,7 @@ async fn jazz_tools_cli_existing_client_keeps_working_after_server_restart_witho
         &client,
         1,
         Duration::from_secs(25),
-        Some(PersistenceTier::EdgeServer),
+        Some(DurabilityTier::EdgeServer),
     )
     .await;
     assert_eq!(
@@ -372,7 +372,7 @@ async fn jazz_tools_cli_existing_client_keeps_working_after_server_restart_witho
         &client,
         2,
         Duration::from_secs(25),
-        Some(PersistenceTier::EdgeServer),
+        Some(DurabilityTier::EdgeServer),
     )
     .await;
     assert_eq!(

--- a/crates/jazz-wasm/src/runtime.rs
+++ b/crates/jazz-wasm/src/runtime.rs
@@ -38,11 +38,12 @@ fn init_tracing() {
 use jazz_tools::object::ObjectId;
 #[cfg(target_arch = "wasm32")]
 use jazz_tools::query_manager::encoding::decode_row;
+use jazz_tools::query_manager::manager::LocalUpdates;
 use jazz_tools::query_manager::session::Session;
 #[cfg(target_arch = "wasm32")]
 use jazz_tools::query_manager::types::{Row, RowDescriptor};
 use jazz_tools::query_manager::types::{Schema, SchemaHash, Value};
-use jazz_tools::runtime_core::{RuntimeCore, Scheduler, SyncSender};
+use jazz_tools::runtime_core::{ReadDurabilityOptions, RuntimeCore, Scheduler, SyncSender};
 #[cfg(target_arch = "wasm32")]
 use jazz_tools::runtime_core::{SubscriptionDelta, SubscriptionHandle};
 #[cfg(target_arch = "wasm32")]
@@ -53,7 +54,7 @@ use jazz_tools::storage::OpfsBTreeStorage;
 use jazz_tools::storage::{MemoryStorage, Storage};
 use jazz_tools::sync_manager::QueryPropagation;
 use jazz_tools::sync_manager::{
-    ClientId, Destination, InboxEntry, OutboxEntry, PersistenceTier, ServerId, Source, SyncManager,
+    ClientId, Destination, DurabilityTier, InboxEntry, OutboxEntry, ServerId, Source, SyncManager,
     SyncPayload,
 };
 
@@ -83,13 +84,13 @@ struct WasmLensEdgeDebug {
 }
 
 /// Parse a persistence tier string from JS.
-fn parse_tier(tier: &str) -> Result<PersistenceTier, JsError> {
+fn parse_tier(tier: &str) -> Result<DurabilityTier, JsError> {
     match tier {
-        "worker" => Ok(PersistenceTier::Worker),
-        "edge" => Ok(PersistenceTier::EdgeServer),
-        "core" => Ok(PersistenceTier::CoreServer),
+        "worker" => Ok(DurabilityTier::Worker),
+        "edge" => Ok(DurabilityTier::EdgeServer),
+        "global" => Ok(DurabilityTier::GlobalServer),
         _ => Err(JsError::new(&format!(
-            "Invalid tier '{}'. Must be 'worker', 'edge', or 'core'.",
+            "Invalid tier '{}'. Must be 'worker', 'edge', or 'global'.",
             tier
         ))),
     }
@@ -98,23 +99,67 @@ fn parse_tier(tier: &str) -> Result<PersistenceTier, JsError> {
 #[derive(Debug, serde::Deserialize, Default)]
 struct QueryExecutionOptionsWire {
     propagation: Option<String>,
+    local_updates: Option<String>,
 }
 
-fn parse_propagation(options_json: Option<String>) -> Result<QueryPropagation, JsError> {
+fn parse_read_durability_options(
+    tier: Option<String>,
+    options_json: Option<String>,
+) -> Result<(ReadDurabilityOptions, QueryPropagation), JsError> {
+    let parsed_tier = tier.as_deref().map(parse_tier).transpose()?;
     let Some(raw) = options_json else {
-        return Ok(QueryPropagation::Full);
+        return Ok((
+            ReadDurabilityOptions {
+                tier: parsed_tier,
+                local_updates: LocalUpdates::Immediate,
+            },
+            QueryPropagation::Full,
+        ));
     };
 
     let options: QueryExecutionOptionsWire = serde_json::from_str(&raw)
         .map_err(|e| JsError::new(&format!("Invalid query options JSON: {}", e)))?;
 
-    match options.propagation.as_deref() {
+    let propagation = match options.propagation.as_deref() {
         None | Some("full") => Ok(QueryPropagation::Full),
         Some("local-only") => Ok(QueryPropagation::LocalOnly),
         Some(other) => Err(JsError::new(&format!(
             "Invalid propagation '{}'. Must be 'full' or 'local-only'.",
             other
         ))),
+    }?;
+
+    let local_updates = match options.local_updates.as_deref() {
+        None | Some("immediate") => Ok(LocalUpdates::Immediate),
+        Some("deferred") => Ok(LocalUpdates::Deferred),
+        Some(other) => Err(JsError::new(&format!(
+            "Invalid localUpdates '{}'. Must be 'immediate' or 'deferred'.",
+            other
+        ))),
+    }?;
+
+    Ok((
+        ReadDurabilityOptions {
+            tier: parsed_tier,
+            local_updates,
+        },
+        propagation,
+    ))
+}
+
+fn parse_node_durability_tiers(tier: Option<&str>) -> Result<Vec<DurabilityTier>, JsError> {
+    let Some(raw) = tier else {
+        return Ok(Vec::new());
+    };
+    Ok(vec![parse_tier(raw)?])
+}
+
+fn tier_label_for_node_tier(tier: Option<&str>) -> &'static str {
+    match tier {
+        Some("worker") => "worker",
+        Some("edge") => "edge",
+        Some("global") => "global",
+        _ => "client",
     }
 }
 
@@ -266,7 +311,7 @@ impl WasmRuntime {
     /// * `app_id` - Application identifier
     /// * `env` - Environment (e.g., "dev", "prod")
     /// * `user_branch` - User's branch name (e.g., "main")
-    /// * `tier` - Optional persistence tier ("worker", "edge", "core").
+    /// * `tier` - Optional node durability tier ("worker", "edge", "global").
     ///            Set for server nodes to enable ack emission.
     #[wasm_bindgen(constructor)]
     pub fn new(
@@ -280,12 +325,7 @@ impl WasmRuntime {
         console_error_panic_hook::set_once();
         init_tracing();
 
-        let tier_label = match tier.as_deref() {
-            Some("worker") => "worker",
-            Some("edge") => "edge",
-            Some("core") => "core",
-            _ => "client",
-        };
+        let tier_label = tier_label_for_node_tier(tier.as_deref());
         let _span = info_span!(
             "WasmRuntime::new",
             tier = tier_label,
@@ -303,12 +343,12 @@ impl WasmRuntime {
         let schema: Schema = wasm_schema;
 
         // Parse optional tier
-        let persistence_tier = tier.as_deref().map(parse_tier).transpose()?;
+        let node_tiers = parse_node_durability_tiers(tier.as_deref())?;
 
         // Create sync manager
         let mut sync_manager = SyncManager::new();
-        if let Some(t) = persistence_tier {
-            sync_manager = sync_manager.with_tier(t);
+        if !node_tiers.is_empty() {
+            sync_manager = sync_manager.with_durability_tiers(node_tiers);
         }
 
         let app_id = AppId::from_string(app_id).unwrap_or_else(|_| AppId::from_name(app_id));
@@ -431,7 +471,7 @@ impl WasmRuntime {
 
     /// Execute a query and return results as a Promise.
     ///
-    /// Optional `settled_tier` holds delivery until the tier confirms.
+    /// Optional durability tier controls remote settlement behavior.
     #[wasm_bindgen]
     pub fn query(
         &self,
@@ -452,12 +492,11 @@ impl WasmRuntime {
             None
         };
 
-        let tier = settled_tier.as_deref().map(parse_tier).transpose()?;
-        let propagation = parse_propagation(options_json)?;
+        let (durability, propagation) = parse_read_durability_options(settled_tier, options_json)?;
 
         let future = {
             let mut core = self.core.borrow_mut();
-            core.query_with_propagation(query, session, tier, propagation)
+            core.query_with_propagation(query, session, durability, propagation)
         };
 
         let promise = wasm_bindgen_futures::future_to_promise(async move {
@@ -526,9 +565,9 @@ impl WasmRuntime {
 
     /// Insert a row and return a Promise that resolves when the tier acks.
     ///
-    /// `tier` must be one of: "worker", "edge", "core".
-    #[wasm_bindgen(js_name = insertWithAck)]
-    pub fn insert_with_ack(
+    /// `tier` must be one of: "worker", "edge", "global".
+    #[wasm_bindgen(js_name = insertDurable)]
+    pub fn insert_durable(
         &self,
         table: &str,
         values: JsValue,
@@ -555,8 +594,8 @@ impl WasmRuntime {
     }
 
     /// Update a row and return a Promise that resolves when the tier acks.
-    #[wasm_bindgen(js_name = updateWithAck)]
-    pub fn update_with_ack(
+    #[wasm_bindgen(js_name = updateDurable)]
+    pub fn update_durable(
         &self,
         object_id: &str,
         values: JsValue,
@@ -586,8 +625,8 @@ impl WasmRuntime {
     }
 
     /// Delete a row and return a Promise that resolves when the tier acks.
-    #[wasm_bindgen(js_name = deleteWithAck)]
-    pub fn delete_with_ack(&self, object_id: &str, tier: &str) -> Result<js_sys::Promise, JsError> {
+    #[wasm_bindgen(js_name = deleteDurable)]
+    pub fn delete_durable(&self, object_id: &str, tier: &str) -> Result<js_sys::Promise, JsError> {
         let persistence_tier = parse_tier(tier)?;
 
         let uuid = uuid::Uuid::parse_str(object_id)
@@ -618,7 +657,7 @@ impl WasmRuntime {
     /// - with upstream server: first callback waits for protocol QuerySettled convergence
     /// - without upstream server: first callback is local-immediate
     ///
-    /// Pass `settled_tier` to override this default.
+    /// Pass durability options to override this default.
     ///
     /// # Returns
     /// Subscription handle (f64) for later unsubscription.
@@ -644,8 +683,7 @@ impl WasmRuntime {
             None
         };
 
-        let tier = settled_tier.as_deref().map(parse_tier).transpose()?;
-        let propagation = parse_propagation(options_json)?;
+        let (durability, propagation) = parse_read_durability_options(settled_tier, options_json)?;
 
         let callback = move |delta: SubscriptionDelta| {
             let row_to_wasm = |row: &Row, descriptor: &RowDescriptor| -> SubscriptionRow {
@@ -699,11 +737,11 @@ impl WasmRuntime {
         let handle = self
             .core
             .borrow_mut()
-            .subscribe_with_settled_tier_and_propagation(
+            .subscribe_with_durability_and_propagation(
                 query,
                 callback,
                 session,
-                tier,
+                durability,
                 propagation,
             )
             .map_err(|e| JsError::new(&format!("Subscribe failed: {:?}", e)))?;
@@ -933,12 +971,7 @@ impl WasmRuntime {
         console_error_panic_hook::set_once();
         init_tracing();
 
-        let tier_label = match tier.as_deref() {
-            Some("worker") => "worker",
-            Some("edge") => "edge",
-            Some("core") => "core",
-            _ => "client",
-        };
+        let tier_label = tier_label_for_node_tier(tier.as_deref());
         let _span = info_span!(
             "WasmRuntime::openPersistent",
             tier = tier_label,
@@ -956,13 +989,13 @@ impl WasmRuntime {
 
         let schema: Schema = wasm_schema;
 
-        // Parse optional tier
-        let persistence_tier = tier.as_deref().map(parse_tier).transpose()?;
+        // Parse optional node durability tiers
+        let node_tiers = parse_node_durability_tiers(tier.as_deref())?;
 
         // Create sync manager
         let mut sync_manager = SyncManager::new();
-        if let Some(t) = persistence_tier {
-            sync_manager = sync_manager.with_tier(t);
+        if !node_tiers.is_empty() {
+            sync_manager = sync_manager.with_durability_tiers(node_tiers);
         }
 
         let app_id = AppId::from_string(app_id).unwrap_or_else(|_| AppId::from_name(app_id));

--- a/docs/content/docs/quickstarts/expo.mdx
+++ b/docs/content/docs/quickstarts/expo.mdx
@@ -5,7 +5,7 @@ description: Build a local-first Expo app with Jazz React Native bindings. Schem
 
 import AuthMethods from "../../partials/quickstarts/auth-methods.mdx";
 import FluentImmutableCallout from "../../partials/quickstarts/fluent-immutable-callout.mdx";
-import PersistenceTiersTable from "../../partials/quickstarts/persistence-tiers-table.mdx";
+import DurabilityTiersTable from "../../partials/quickstarts/durability-tiers-table.mdx";
 import RunCodegen from "../../partials/quickstarts/run-codegen.mdx";
 import ServerAuthConfig from "../../partials/quickstarts/server-auth-config.mdx";
 import QuickstartSchemaTypesSummary from "../../partials/quickstarts/schema-types-summary.mdx";
@@ -70,13 +70,13 @@ Query builders are fluent and immutable. Chain `.where()`, `.orderBy()`, `.limit
 
 <QuickstartWhereOperatorsSummary />
 
-By default `useAll` returns results immediately from the local replica. Use settled tiers when you need explicit confirmation boundaries.
+By default `useAll` returns results immediately from the local replica. Use durability options when you need explicit confirmation boundaries.
 
 Deep dive: [Reading Data](/docs/reading-data).
 
 ## Write data with `useDb`
 
-`useDb` returns the `Db` handle for mutations. Mutations are synchronous at the local runtime level and sync to the server in the background.
+`useDb` returns the `Db` handle for mutations. Mutations apply locally first and return promises that resolve at the selected durability tier.
 
 <include cwd lang="tsx" title="src/TodoList.tsx">
   ../examples/docs/todo-client-localfirst-expo/src/TodoList.tsx#writing-use-db-expo
@@ -86,32 +86,32 @@ Because writes hit the local runtime first, subscriptions update immediately wit
 
 Mutation API details: [Writing Data](/docs/writing-data).
 
-## Persistence tiers
+## Durability tiers
 
-<PersistenceTiersTable />
+<DurabilityTiersTable />
 
 <Callout title="Tier support">
   `worker` is the universal baseline. Higher-tier acknowledgements depend on deployment/runtime
   support, so pick the highest tier your app path guarantees.
 </Callout>
 
-### Reading with a settled tier
+### Reading with a durability tier
 
-Use `db.subscribeAll` (or `db.all`) with a settled tier when you need tier-gated delivery.
+Use `db.subscribeAll` (or `db.all`) with a durability tier when you need tier-gated delivery.
 
 <include cwd lang="ts">
   ../examples/docs/todo-client-localfirst-expo/src/docs-snippets.ts#reading-tier-expo
 </include>
 
-### Writing with an ack tier
+### Writing with a durability tier
 
-Use `*WithAck` APIs when you need explicit write acknowledgement before proceeding:
+Use base mutation APIs with `{ tier }` when you need explicit write durability acknowledgement before proceeding:
 
 <include cwd lang="ts">
-  ../examples/docs/todo-client-localfirst-expo/src/docs-snippets.ts#writing-ack-expo
+  ../examples/docs/todo-client-localfirst-expo/src/docs-snippets.ts#writing-durability-expo
 </include>
 
-Tier semantics in depth: [Reading Data](/docs/reading-data#read-settled-tiers) and [Writing Data](/docs/writing-data#write-ack-tiers).
+Tier semantics in depth: [Reading Data](/docs/reading-data#read-durability-options) and [Writing Data](/docs/writing-data#write-durability-tiers).
 
 ## Querying in depth
 

--- a/docs/content/docs/quickstarts/expo.mdx
+++ b/docs/content/docs/quickstarts/expo.mdx
@@ -82,7 +82,7 @@ Deep dive: [Reading Data](/docs/reading-data).
   ../examples/docs/todo-client-localfirst-expo/src/TodoList.tsx#writing-use-db-expo
 </include>
 
-Because writes hit the local runtime first, subscriptions update immediately with local-first UX.
+Because writes hit the local runtime first, subscriptions update immediately with local-first UX. For tier-gated reads, the first callback still waits for the requested tier.
 
 Mutation API details: [Writing Data](/docs/writing-data).
 

--- a/docs/content/docs/quickstarts/react.mdx
+++ b/docs/content/docs/quickstarts/react.mdx
@@ -84,7 +84,7 @@ Deep dive: [Reading Data](/docs/reading-data).
   ../examples/docs/todo-client-localfirst-react/src/TodoList.tsx#writing-use-db-react
 </include>
 
-Because writes hit the local runtime first, subscriptions update immediately with local-first UX.
+Because writes hit the local runtime first, subscriptions update immediately with local-first UX. For tier-gated reads, the first callback still waits for the requested tier.
 
 Mutation API details: [Writing Data](/docs/writing-data).
 

--- a/docs/content/docs/quickstarts/react.mdx
+++ b/docs/content/docs/quickstarts/react.mdx
@@ -5,7 +5,7 @@ description: Build a local-first React app with Jazz. Schema, provider, reactive
 
 import AuthMethods from "../../partials/quickstarts/auth-methods.mdx";
 import FluentImmutableCallout from "../../partials/quickstarts/fluent-immutable-callout.mdx";
-import PersistenceTiersTable from "../../partials/quickstarts/persistence-tiers-table.mdx";
+import DurabilityTiersTable from "../../partials/quickstarts/durability-tiers-table.mdx";
 import RunCodegen from "../../partials/quickstarts/run-codegen.mdx";
 import ServerAuthConfig from "../../partials/quickstarts/server-auth-config.mdx";
 import QuickstartSchemaTypesSummary from "../../partials/quickstarts/schema-types-summary.mdx";
@@ -72,13 +72,13 @@ Query builders are fluent and immutable. Chain `.where()`, `.orderBy()`, `.limit
 
 <QuickstartWhereOperatorsSummary />
 
-By default `useAll` returns results immediately from the local replica. Use settled tiers when you need explicit confirmation boundaries.
+By default `useAll` returns results immediately from the local replica. Use durability options when you need explicit confirmation boundaries.
 
 Deep dive: [Reading Data](/docs/reading-data).
 
 ## Write data with `useDb`
 
-`useDb` returns the `Db` handle for mutations. Mutations are synchronous at the local runtime level and sync to the server in the background.
+`useDb` returns the `Db` handle for mutations. Mutations apply locally first and return promises that resolve at the selected durability tier.
 
 <include cwd lang="tsx" title="src/TodoList.tsx">
   ../examples/docs/todo-client-localfirst-react/src/TodoList.tsx#writing-use-db-react
@@ -88,32 +88,33 @@ Because writes hit the local runtime first, subscriptions update immediately wit
 
 Mutation API details: [Writing Data](/docs/writing-data).
 
-## Persistence tiers
+## Durability tiers
 
-<PersistenceTiersTable />
+<DurabilityTiersTable />
 
 <Callout title="Which tier to use?">
   `worker` is the right default for most UI interactions. Use `edge` when you need to confirm data
-  has synced to the nearest server. Use `core` when you need globally consistent acknowledgement.
+  has synced to the nearest server. Use `global` when you need the broadest server-side durability
+  acknowledgement.
 </Callout>
 
-### Reading with a settled tier
+### Reading with a durability tier
 
-Use `db.subscribeAll` (or `db.all`) with a settled tier when you need tier-gated delivery.
+Use `db.subscribeAll` (or `db.all`) with a durability tier when you need tier-gated delivery.
 
 <include cwd lang="ts">
   ../examples/docs/todo-client-localfirst-react/src/docs-snippets.ts#reading-tier-react
 </include>
 
-### Writing with an ack tier
+### Writing with a durability tier
 
-Use `*WithAck` APIs to wait for specific durability tiers:
+Use base mutation APIs with `{ tier }` to wait for specific durability tiers:
 
 <include cwd lang="ts">
-  ../examples/docs/todo-client-localfirst-react/src/docs-snippets.ts#writing-ack-react
+  ../examples/docs/todo-client-localfirst-react/src/docs-snippets.ts#writing-durability-react
 </include>
 
-Tier semantics in depth: [Reading Data](/docs/reading-data#read-settled-tiers) and [Writing Data](/docs/writing-data#write-ack-tiers).
+Tier semantics in depth: [Reading Data](/docs/reading-data#read-durability-options) and [Writing Data](/docs/writing-data#write-durability-tiers).
 
 ## Querying in depth
 

--- a/docs/content/docs/quickstarts/svelte.mdx
+++ b/docs/content/docs/quickstarts/svelte.mdx
@@ -5,7 +5,7 @@ description: Build a local-first Svelte app with Jazz. Schema, provider, reactiv
 
 import AuthMethods from "../../partials/quickstarts/auth-methods.mdx";
 import FluentImmutableCallout from "../../partials/quickstarts/fluent-immutable-callout.mdx";
-import PersistenceTiersTable from "../../partials/quickstarts/persistence-tiers-table.mdx";
+import DurabilityTiersTable from "../../partials/quickstarts/durability-tiers-table.mdx";
 import RunCodegen from "../../partials/quickstarts/run-codegen.mdx";
 import ServerAuthConfig from "../../partials/quickstarts/server-auth-config.mdx";
 import QuickstartSchemaTypesSummary from "../../partials/quickstarts/schema-types-summary.mdx";
@@ -72,13 +72,13 @@ Query builders are fluent and immutable. Chain `.where()`, `.orderBy()`, `.limit
 
 <QuickstartWhereOperatorsSummary />
 
-By default `QuerySubscription` returns results immediately from the local replica. Use persistence tiers when you need explicit confirmation boundaries.
+By default `QuerySubscription` returns results immediately from the local replica. Use durability tiers when you need explicit confirmation boundaries.
 
 Deep dive: [Reading Data](/docs/reading-data).
 
 ## Write data with `getDb`
 
-`getDb` returns the `Db` handle for mutations. Mutations are synchronous at the local runtime level and sync to the server in the background.
+`getDb` returns the `Db` handle for mutations. Mutations apply locally first and return promises that resolve at the selected durability tier.
 
 <include cwd lang="svelte" title="src/TodoList.svelte">
   ../examples/docs/todo-client-localfirst-svelte/src/TodoList.svelte#read-write-svelte
@@ -88,13 +88,14 @@ Because writes hit the local runtime first, subscriptions update immediately wit
 
 Mutation API details: [Writing Data](/docs/writing-data).
 
-## Persistence tiers
+## Durability tiers
 
-<PersistenceTiersTable />
+<DurabilityTiersTable />
 
 <Callout title="Which tier to use?">
   `worker` is the right default for most UI interactions. Use `edge` when you need to confirm data
-  has synced to the nearest server. Use `core` when you need globally consistent acknowledgement.
+  has synced to the nearest server. Use `global` when you need the broadest server-side durability
+  acknowledgement.
 </Callout>
 
 ### Reading with a tier
@@ -105,15 +106,15 @@ Pass a tier as the second argument to `QuerySubscription` to gate initial delive
   ../examples/docs/todo-client-localfirst-svelte/src/TodoList.svelte#reading-tier-svelte
 </include>
 
-### Writing with a tier
+### Writing with a durability tier
 
-Use `*WithAck` variants when you need durability guarantees before continuing:
+Use base mutation APIs with `{ tier }` when you need durability guarantees before continuing:
 
 <include cwd lang="ts">
-  ../examples/docs/todo-client-localfirst-svelte/src/TodoList.svelte#writing-persisted-svelte
+  ../examples/docs/todo-client-localfirst-svelte/src/TodoList.svelte#writing-durability-svelte
 </include>
 
-Tier semantics in depth: [Reading Data](/docs/reading-data#read-settled-tiers) and [Writing Data](/docs/writing-data#write-ack-tiers).
+Tier semantics in depth: [Reading Data](/docs/reading-data#read-durability-options) and [Writing Data](/docs/writing-data#write-durability-tiers).
 
 ## Querying in depth
 

--- a/docs/content/docs/quickstarts/svelte.mdx
+++ b/docs/content/docs/quickstarts/svelte.mdx
@@ -84,7 +84,7 @@ Deep dive: [Reading Data](/docs/reading-data).
   ../examples/docs/todo-client-localfirst-svelte/src/TodoList.svelte#read-write-svelte
 </include>
 
-Because writes hit the local runtime first, subscriptions update immediately with local-first UX.
+Because writes hit the local runtime first, subscriptions update immediately with local-first UX. For tier-gated reads, the first callback still waits for the requested tier.
 
 Mutation API details: [Writing Data](/docs/writing-data).
 

--- a/docs/content/docs/reading-data.mdx
+++ b/docs/content/docs/reading-data.mdx
@@ -195,7 +195,7 @@ Defaults:
 
 - Browser/client default tier is `worker`.
 - Backend/server-connected default tier is `edge`.
-- `localUpdates: "immediate"` keeps local subscription updates synchronous while durability gating is active.
+- `localUpdates: "immediate"` keeps local subscription updates synchronous after the first tier-confirmed snapshot. The initial delivery remains tier-gated.
 
 Tradeoff summary:
 

--- a/docs/content/docs/reading-data.mdx
+++ b/docs/content/docs/reading-data.mdx
@@ -175,44 +175,49 @@ Recursive queries compute bounded transitive closures from a seed row set.
   ../examples/docs/todo-client-localfirst-ts/src/docs-snippets.ts#reading-recursive-ts
 </include>
 
-## Read Settled Tiers
+## Read Durability Options
 
 ### API Reference
 
-- `db.all(query, settledTier?)`
-- `db.one(query, settledTier?)`
-- `db.subscribeAll(query, callback, settledTier?)`
-- `settledTier`: `"worker" | "edge" | "core"`
+- `db.all(query, options?)`
+- `db.one(query, options?)`
+- `db.subscribeAll(query, callback, options?)`
+- `options.tier`: `"worker" | "edge" | "global"`
+- `options.localUpdates`: `"immediate" | "deferred"` (default: `"immediate"`)
 
-Settled tiers control when initial query delivery is considered confirmed:
+Durability tiers control when initial query delivery is considered confirmed:
 
 - `worker`: wait for worker/local storage acknowledgement.
 - `edge`: wait for edge server acknowledgement.
-- `core`: wait for core server acknowledgement.
+- `global`: wait for global server acknowledgement.
 
-Without a `settledTier`, reads are local-first and return immediately from local runtime state.
+Defaults:
+
+- Browser/client default tier is `worker`.
+- Backend/server-connected default tier is `edge`.
+- `localUpdates: "immediate"` keeps local subscription updates synchronous while durability gating is active.
 
 Tradeoff summary:
 
-- Lower settled tier: lower latency, narrower confirmation scope.
-- Higher settled tier: higher latency, broader confirmation scope.
+- Lower tier: lower latency, narrower confirmation scope.
+- Higher tier: higher latency, broader confirmation scope.
 
 <Tabs groupId="jazz-environment" items={["TypeScript", "Rust"]} persist>
   <Tab value="TypeScript">
     <include cwd lang="ts">
-      ../examples/docs/todo-client-localfirst-ts/src/docs-snippets.ts#reading-settled-tier-ts
+      ../examples/docs/todo-client-localfirst-ts/src/docs-snippets.ts#reading-durability-tier-ts
     </include>
   </Tab>
   <Tab value="Rust">
     <include cwd lang="rs">
-      ../examples/docs/todo-server-rs/src/docs_snippets.rs#reading-settled-tier-rust
+      ../examples/docs/todo-server-rs/src/docs_snippets.rs#reading-durability-tier-rust
     </include>
   </Tab>
 </Tabs>
 
-Read settled tiers pair naturally with write ack tiers:
+Read durability options pair naturally with write durability tiers:
 
-- Use write ack tiers to gate mutation durability checkpoints.
-- Use settled tiers to gate query/subscription delivery checkpoints.
+- Use write durability tiers to gate mutation durability checkpoints.
+- Use read durability options to gate query/subscription delivery checkpoints.
 
-See [Write Ack Tiers](/docs/writing-data#write-ack-tiers) for write-side semantics.
+See [Write Durability Tiers](/docs/writing-data#write-durability-tiers) for write-side semantics.

--- a/docs/content/docs/writing-data.mdx
+++ b/docs/content/docs/writing-data.mdx
@@ -1,15 +1,14 @@
 ---
 title: Writing Data
-description: Insert, update, and delete APIs with local-first execution, framework context hooks, and write acknowledgement tiers.
+description: Insert, update, and delete APIs with local-first execution, framework context hooks, and write durability tiers.
 ---
 
 ## Local-First Writes
 
 `insert`, `update`, and `deleteFrom` apply immediately in the local runtime.
-That keeps UI latency low because your app does not wait for any network hop.
+That keeps UI latency low because local state updates do not wait for any network hop.
 
-Use this mode when you want the fastest local response and can tolerate async sync
-to higher durability tiers.
+Mutation methods return promises that resolve when the requested durability tier is reached.
 
 ## Mutating from Framework Context
 
@@ -69,20 +68,25 @@ Notes:
 - Does not clear `localStorage` auth/synthetic-user data.
 - Reopens a clean worker runtime, so the same `db` instance remains usable.
 
-## Write Ack Tiers
+## Write Durability Tiers
 
 ### API Reference
 
-- `insertWithAck(table, data, tier)`
-- `updateWithAck(table, id, data, tier)`
-- `deleteFromWithAck(table, id, tier)`
-- `tier`: `"worker" | "edge" | "core"`
+- `insert(table, data, options?)`
+- `update(table, id, data, options?)`
+- `deleteFrom(table, id, options?)`
+- `options.tier`: `"worker" | "edge" | "global"`
 
-Ack tiers control when the returned promise resolves:
+Durability tiers control when the returned promise resolves:
 
 - `worker`: waits until the local worker/storage tier acknowledges the write.
 - `edge`: waits until the edge server acknowledges the write.
-- `core`: waits until the core server acknowledges the write.
+- `global`: waits until the global server acknowledges the write.
+
+Defaults:
+
+- Browser/client default tier is `worker`.
+- Backend/server-connected default tier is `edge`.
 
 Tradeoff summary:
 
@@ -91,33 +95,30 @@ Tradeoff summary:
 
 In practical terms:
 
-- Local-first writes (`insert`/`update`/`deleteFrom`) optimize for immediate UX.
-- Acked writes (`*WithAck`) optimize for explicit durability checkpoints.
+- Local-first updates remain immediate for UI/subscription state.
+- Mutation promises resolve at the selected durability checkpoint.
 
 <Tabs groupId="jazz-environment" items={["TypeScript", "Rust"]} persist>
   <Tab value="TypeScript">
     <include cwd lang="ts">
-      ../examples/docs/todo-client-localfirst-ts/src/docs-snippets.ts#writing-ack-tier-ts
+      ../examples/docs/todo-client-localfirst-ts/src/docs-snippets.ts#writing-durability-tier-ts
     </include>
   </Tab>
   <Tab value="Rust">
     <include cwd lang="rs">
-      ../examples/docs/todo-server-rs/src/docs_snippets.rs#writing-ack-tier-rust
+      ../examples/docs/todo-server-rs/src/docs_snippets.rs#writing-durability-tier-rust
     </include>
   </Tab>
 </Tabs>
 
-`insertPersisted` / `updatePersisted` / `deleteFromPersisted` are legacy aliases.
-Prefer the explicit `*WithAck` APIs in new code.
+## Combining Write Durability with Read Durability
 
-## Combining Write Acks with Settled Reads
+Write durability tiers and read durability options are complementary knobs:
 
-Write ack tiers and read settled tiers are complementary knobs:
+- Write tiers define when a mutation is considered durably acknowledged.
+- Read options define when query/subscription delivery is considered sufficiently confirmed.
 
-- Write acks define when a mutation is considered durably acknowledged.
-- Settled reads define when a query result is considered sufficiently confirmed.
-
-See [Read Settled Tiers](/docs/reading-data#read-settled-tiers) for read-side semantics.
+See [Read Durability Options](/docs/reading-data#read-durability-options) for read-side semantics.
 
 ## Backend Request Context Reminder
 

--- a/docs/content/partials/quickstarts/durability-tiers-table.mdx
+++ b/docs/content/partials/quickstarts/durability-tiers-table.mdx
@@ -1,0 +1,7 @@
+Jazz data propagates through tiers, from fastest local confirmation to broader durability.
+
+| Tier       | Where                 | When to use                                                       |
+| ---------- | --------------------- | ----------------------------------------------------------------- |
+| `"worker"` | Local runtime/storage | Default. Optimistic updates and local durability.                 |
+| `"edge"`   | Nearest sync server   | Confirm data has left the device. Useful for guarded transitions. |
+| `"global"` | Central server        | Globally durable acknowledgement at the broadest server boundary. |

--- a/docs/content/partials/quickstarts/persistence-tiers-table.mdx
+++ b/docs/content/partials/quickstarts/persistence-tiers-table.mdx
@@ -1,7 +1,0 @@
-Jazz data propagates through tiers, from fastest local confirmation to broader durability.
-
-| Tier       | Where                 | When to use                                                         |
-| ---------- | --------------------- | ------------------------------------------------------------------- |
-| `"worker"` | Local runtime/storage | Default. Optimistic updates and local durability.                   |
-| `"edge"`   | Nearest sync server   | Confirm data has left the device. Useful for guarded transitions.   |
-| `"core"`   | Central server        | Globally consistent state and strongest durability acknowledgement. |

--- a/examples/docs/todo-client-localfirst-expo/src/TodoList.tsx
+++ b/examples/docs/todo-client-localfirst-expo/src/TodoList.tsx
@@ -37,31 +37,31 @@ export function TodoList() {
   // #endregion reading-reactive-hooks-expo
 
   // #region writing-use-db-expo
-  const addTodo = () => {
+  const addTodo = async () => {
     const trimmed = title.trim();
     if (!trimmed || !sessionUserId) return;
-    db.insert(app.todos, { title: trimmed, done: false, owner_id: sessionUserId });
+    await db.insert(app.todos, { title: trimmed, done: false, owner_id: sessionUserId });
     setTitle("");
   };
 
-  const toggleTodo = (todo: Todo) => {
-    db.update(app.todos, todo.id, { done: !todo.done });
+  const toggleTodo = async (todo: Todo) => {
+    await db.update(app.todos, todo.id, { done: !todo.done });
   };
 
-  const removeTodo = (id: string) => {
-    db.deleteFrom(app.todos, id);
+  const removeTodo = async (id: string) => {
+    await db.deleteFrom(app.todos, id);
   };
   // #endregion writing-use-db-expo
 
   const renderItem: ListRenderItem<Todo> = ({ item }) => {
     return (
       <View style={styles.todoRow}>
-        <Switch value={item.done} onValueChange={() => toggleTodo(item)} />
+        <Switch value={item.done} onValueChange={() => void toggleTodo(item)} />
         <View style={styles.todoTextWrap}>
           <Text style={[styles.todoTitle, item.done && styles.todoDone]}>{item.title}</Text>
           {item.description ? <Text style={styles.todoDescription}>{item.description}</Text> : null}
         </View>
-        <Pressable onPress={() => removeTodo(item.id)} style={styles.deleteButton}>
+        <Pressable onPress={() => void removeTodo(item.id)} style={styles.deleteButton}>
           <Text style={styles.deleteButtonText}>Delete</Text>
         </Pressable>
       </View>
@@ -77,10 +77,10 @@ export function TodoList() {
           placeholder="What needs to be done?"
           style={styles.input}
           returnKeyType="done"
-          onSubmitEditing={addTodo}
+          onSubmitEditing={() => void addTodo()}
         />
         <Pressable
-          onPress={addTodo}
+          onPress={() => void addTodo()}
           style={[styles.addButton, !sessionUserId && styles.addButtonDisabled]}
           disabled={!sessionUserId}
         >

--- a/examples/docs/todo-client-localfirst-expo/src/docs-snippets.ts
+++ b/examples/docs/todo-client-localfirst-expo/src/docs-snippets.ts
@@ -91,14 +91,15 @@ export async function combinedQuery(db: Db) {
 // #region reading-tier-expo
 export function subscribeTodosAtEdge(db: Db, onCount: (count: number) => void) {
   return db.subscribeAll(app.todos.where({ done: false }), ({ all }) => onCount(all.length), {
-    settledTier: "edge",
+    tier: "edge",
+    localUpdates: "immediate",
   });
 }
 // #endregion reading-tier-expo
 
-// #region writing-ack-expo
-export async function writeWithAck(db: Db, todoTitle: string) {
-  const id = await db.insertWithAck(
+// #region writing-durability-expo
+export async function writeWithDurabilityTier(db: Db, todoTitle: string) {
+  const id = await db.insert(
     app.todos,
     {
       title: todoTitle,
@@ -106,10 +107,10 @@ export async function writeWithAck(db: Db, todoTitle: string) {
       owner_id: EXAMPLE_OWNER_ID,
       project: EXAMPLE_PROJECT_ID,
     },
-    "worker",
+    { tier: "worker" },
   );
 
-  await db.updateWithAck(app.todos, id, { done: true }, "worker");
-  await db.deleteFromWithAck(app.todos, id, "worker");
+  await db.update(app.todos, id, { done: true }, { tier: "worker" });
+  await db.deleteFrom(app.todos, id, { tier: "worker" });
 }
-// #endregion writing-ack-expo
+// #endregion writing-durability-expo

--- a/examples/docs/todo-client-localfirst-react/src/TodoList.tsx
+++ b/examples/docs/todo-client-localfirst-react/src/TodoList.tsx
@@ -10,7 +10,7 @@ export function TodoList() {
   // #endregion reading-reactive-hooks-react
 
   // #region reading-filtering-react
-  const incompleteTodos = useAll(
+  const _incompleteTodos = useAll(
     app.todos.where({ done: false }).orderBy("title", "asc").limit(50),
   );
   // #endregion reading-filtering-react

--- a/examples/docs/todo-client-localfirst-react/src/TodoList.tsx
+++ b/examples/docs/todo-client-localfirst-react/src/TodoList.tsx
@@ -16,26 +16,26 @@ export function TodoList() {
   // #endregion reading-filtering-react
 
   // #region writing-use-db-react
-  function addTodo(todoTitle: string) {
-    db.insert(app.todos, { title: todoTitle, done: false });
+  async function addTodo(todoTitle: string) {
+    await db.insert(app.todos, { title: todoTitle, done: false });
   }
 
-  function toggleTodo(todo: { id: string; done: boolean }) {
-    db.update(app.todos, todo.id, { done: !todo.done });
+  async function toggleTodo(todo: { id: string; done: boolean }) {
+    await db.update(app.todos, todo.id, { done: !todo.done });
   }
 
-  function removeTodo(id: string) {
-    db.deleteFrom(app.todos, id);
+  async function removeTodo(id: string) {
+    await db.deleteFrom(app.todos, id);
   }
   // #endregion writing-use-db-react
   // #endregion read-write-react
 
   const [title, setTitle] = useState("");
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!title.trim()) return;
-    addTodo(title.trim());
+    await addTodo(title.trim());
     setTitle("");
   };
 
@@ -57,12 +57,12 @@ export function TodoList() {
             <input
               type="checkbox"
               checked={todo.done}
-              onChange={() => toggleTodo(todo)}
+              onChange={() => void toggleTodo(todo)}
               className="toggle"
             />
             <span>{todo.title}</span>
             {todo.description && <small>{todo.description}</small>}
-            <button className="delete-btn" onClick={() => removeTodo(todo.id)}>
+            <button className="delete-btn" onClick={() => void removeTodo(todo.id)}>
               &times;
             </button>
           </li>

--- a/examples/docs/todo-client-localfirst-react/src/docs-snippets.ts
+++ b/examples/docs/todo-client-localfirst-react/src/docs-snippets.ts
@@ -90,15 +90,16 @@ export async function combinedQuery(db: Db) {
 // #region reading-tier-react
 export function subscribeTodosAtEdge(db: Db, onCount: (count: number) => void) {
   return db.subscribeAll(app.todos.where({ done: false }), ({ all }) => onCount(all.length), {
-    settledTier: "edge",
+    tier: "edge",
+    localUpdates: "immediate",
   });
 }
 // #endregion reading-tier-react
 
-// #region writing-ack-react
-export async function writeWithAck(db: Db, todoTitle: string) {
-  const id = await db.insertWithAck(app.todos, { title: todoTitle, done: false }, "edge");
-  await db.updateWithAck(app.todos, id, { done: true }, "edge");
-  await db.deleteFromWithAck(app.todos, id, "core");
+// #region writing-durability-react
+export async function writeWithDurabilityTier(db: Db, todoTitle: string) {
+  const id = await db.insert(app.todos, { title: todoTitle, done: false }, { tier: "edge" });
+  await db.update(app.todos, id, { done: true }, { tier: "edge" });
+  await db.deleteFrom(app.todos, id, { tier: "global" });
 }
-// #endregion writing-ack-react
+// #endregion writing-durability-react

--- a/examples/docs/todo-client-localfirst-svelte/src/TodoList.svelte
+++ b/examples/docs/todo-client-localfirst-svelte/src/TodoList.svelte
@@ -22,32 +22,32 @@
 
 	let title = $state('');
 
-	function handleSubmit(e: SubmitEvent) {
+	async function handleSubmit(e: SubmitEvent) {
 		e.preventDefault();
 		if (!title.trim()) return;
 		// #region writing-insert-svelte
-		db.insert(app.todos, { title: title.trim(), done: false });
+		await db.insert(app.todos, { title: title.trim(), done: false });
 		// #endregion writing-insert-svelte
 		title = '';
 	}
 
 	// #region writing-mutations-svelte
-	function toggleTodo(todo: { id: string; done: boolean }) {
-		db.update(app.todos, todo.id, { done: !todo.done });
+	async function toggleTodo(todo: { id: string; done: boolean }) {
+		await db.update(app.todos, todo.id, { done: !todo.done });
 	}
 
-	function removeTodo(id: string) {
-		db.deleteFrom(app.todos, id);
+	async function removeTodo(id: string) {
+		await db.deleteFrom(app.todos, id);
 	}
 	// #endregion writing-mutations-svelte
 
-	// #region writing-persisted-svelte
+	// #region writing-durability-svelte
 	async function addImportantTodo(todoTitle: string) {
-		const id = await db.insertWithAck(app.todos, { title: todoTitle, done: false }, 'edge');
-		await db.updateWithAck(app.todos, id, { done: true }, 'edge');
-		await db.deleteFromWithAck(app.todos, id, 'core');
+		const id = await db.insert(app.todos, { title: todoTitle, done: false }, { tier: 'edge' });
+		await db.update(app.todos, id, { done: true }, { tier: 'edge' });
+		await db.deleteFrom(app.todos, id, { tier: 'global' });
 	}
-	// #endregion writing-persisted-svelte
+	// #endregion writing-durability-svelte
 </script>
 
 <form onsubmit={handleSubmit}>

--- a/examples/docs/todo-client-localfirst-ts/src/docs-snippets.ts
+++ b/examples/docs/todo-client-localfirst-ts/src/docs-snippets.ts
@@ -16,11 +16,11 @@ export function subscribeTodos(db: Db, onCount: (count: number) => void) {
 }
 // #endregion reading-subscriptions-ts
 
-// #region reading-settled-tier-ts
-export async function readTodosSettledAtEdge(db: Db) {
-  return db.all(app.todos.where({ done: false }), { settledTier: "edge" });
+// #region reading-durability-tier-ts
+export async function readTodosAtEdgeDurability(db: Db) {
+  return db.all(app.todos.where({ done: false }), { tier: "edge", localUpdates: "immediate" });
 }
-// #endregion reading-settled-tier-ts
+// #endregion reading-durability-tier-ts
 
 // #region reading-filters-ts
 export async function readTodosWithFilters(db: Db) {
@@ -70,32 +70,32 @@ export function buildTodoLineageQuery() {
 // #endregion reading-recursive-ts
 
 // #region writing-crud-ts
-export function writeTodoCrud(db: Db, todoId: string) {
-  db.insert(app.todos, {
+export async function writeTodoCrud(db: Db, todoId: string) {
+  await db.insert(app.todos, {
     title: "Write docs",
     done: false,
     owner_id: EXAMPLE_OWNER_ID,
     project: EXAMPLE_PROJECT_ID,
   });
-  db.update(app.todos, todoId, { done: true });
-  db.deleteFrom(app.todos, todoId);
+  await db.update(app.todos, todoId, { done: true });
+  await db.deleteFrom(app.todos, todoId);
 }
 // #endregion writing-crud-ts
 
-// #region writing-ack-tier-ts
-export async function writeTodoWithAckTiers(db: Db) {
-  const id = await db.insertWithAck(
+// #region writing-durability-tier-ts
+export async function writeTodoWithDurabilityTiers(db: Db) {
+  const id = await db.insert(
     app.todos,
     {
-      title: "Write docs with ack",
+      title: "Write docs with durability tier",
       done: false,
       owner_id: EXAMPLE_OWNER_ID,
       project: EXAMPLE_PROJECT_ID,
     },
-    "edge",
+    { tier: "edge" },
   );
 
-  await db.updateWithAck(app.todos, id, { done: true }, "core");
-  await db.deleteFromWithAck(app.todos, id, "core");
+  await db.update(app.todos, id, { done: true }, { tier: "global" });
+  await db.deleteFrom(app.todos, id, { tier: "global" });
 }
-// #endregion writing-ack-tier-ts
+// #endregion writing-durability-tier-ts

--- a/examples/docs/todo-server-rs/src/docs_snippets.rs
+++ b/examples/docs/todo-server-rs/src/docs_snippets.rs
@@ -113,15 +113,15 @@ pub async fn subscribe_todos(
 }
 // #endregion reading-subscriptions-rust
 
-// #region reading-settled-tier-rust
-pub async fn read_todos_settled_edge(client: &JazzClient) -> jazz_tools::Result<usize> {
+// #region reading-durability-tier-rust
+pub async fn read_todos_at_edge_durability(client: &JazzClient) -> jazz_tools::Result<usize> {
     let query = QueryBuilder::new("todos").build();
     let rows = client
         .query(query, Some(DurabilityTier::EdgeServer))
         .await?;
     Ok(rows.len())
 }
-// #endregion reading-settled-tier-rust
+// #endregion reading-durability-tier-rust
 
 // #region reading-filters-rust
 pub async fn read_todos_with_filters(client: &JazzClient) -> jazz_tools::Result<usize> {
@@ -198,13 +198,15 @@ pub async fn write_todo_crud(client: &JazzClient, existing_id: ObjectId) -> jazz
 }
 // #endregion writing-crud-rust
 
-// #region writing-ack-tier-rust
-pub async fn write_todo_with_default_ack(client: &JazzClient) -> jazz_tools::Result<ObjectId> {
+// #region writing-durability-tier-rust
+pub async fn write_todo_with_default_durability(
+    client: &JazzClient,
+) -> jazz_tools::Result<ObjectId> {
     let id = client
         .create(
             "todos",
             vec![
-                Value::Text("Write docs with default ack behavior".to_string()),
+                Value::Text("Write docs with default durability behavior".to_string()),
                 Value::Boolean(false),
                 Value::Text(String::new()),
                 Value::Null,
@@ -213,8 +215,8 @@ pub async fn write_todo_with_default_ack(client: &JazzClient) -> jazz_tools::Res
         )
         .await?;
 
-    // Rust currently does not expose per-write ack tier arguments.
+    // Rust currently does not expose per-write durability tier arguments.
     // Writes apply locally first, then sync asynchronously to higher tiers.
     Ok(id)
 }
-// #endregion writing-ack-tier-rust
+// #endregion writing-durability-tier-rust

--- a/examples/docs/todo-server-rs/src/docs_snippets.rs
+++ b/examples/docs/todo-server-rs/src/docs_snippets.rs
@@ -5,7 +5,7 @@ use axum::http::{HeaderMap, StatusCode, header::AUTHORIZATION};
 use jazz_tools::query_manager::policy::{Operation, PolicyExpr};
 use jazz_tools::query_manager::types::TablePolicies;
 use jazz_tools::{
-    JazzClient, ObjectId, PersistenceTier, QueryBuilder, Session, SessionClient, Value,
+    DurabilityTier, JazzClient, ObjectId, QueryBuilder, Session, SessionClient, Value,
 };
 use serde_json::json;
 
@@ -117,7 +117,7 @@ pub async fn subscribe_todos(
 pub async fn read_todos_settled_edge(client: &JazzClient) -> jazz_tools::Result<usize> {
     let query = QueryBuilder::new("todos").build();
     let rows = client
-        .query(query, Some(PersistenceTier::EdgeServer))
+        .query(query, Some(DurabilityTier::EdgeServer))
         .await?;
     Ok(rows.len())
 }

--- a/examples/docs/todo-server-rs/tests/integration.rs
+++ b/examples/docs/todo-server-rs/tests/integration.rs
@@ -17,7 +17,7 @@ use futures_util::StreamExt as _;
 use futures_util::stream::Stream;
 use http_body_util::BodyExt;
 use jazz_tools::{
-    AppContext, AppId, ColumnType, JazzClient, PersistenceTier, SchemaBuilder, TableSchema,
+    AppContext, AppId, ColumnType, DurabilityTier, JazzClient, SchemaBuilder, TableSchema,
 };
 use serde::{Deserialize, Serialize};
 use tempfile::TempDir;
@@ -727,7 +727,7 @@ async fn jwks_handler(
 /// settled, not that we've received all server data. See specs/sync_manager.md
 /// Future Work section.
 ///
-/// NOTE: The core lazy schema activation is tested in jazz's
+/// NOTE: The global-server lazy schema activation is tested in jazz's
 /// `e2e_two_clients_server_schema_sync`. This integration test verifies
 /// end-to-end client-server sync with persistent client IDs.
 #[tokio::test]
@@ -801,12 +801,12 @@ async fn test_server_resync() {
         };
         let client = JazzClient::connect(context).await.unwrap();
 
-        // One-shot query with EdgeServer settled tier — waits for the server's
+        // One-shot query with EdgeServer durability tier — waits for the server's
         // QuerySettled response before resolving, ensuring synced data arrives.
         let query = QueryBuilder::new("todos").build();
         let results = tokio::time::timeout(
             Duration::from_secs(10),
-            client.query(query, Some(PersistenceTier::EdgeServer)),
+            client.query(query, Some(DurabilityTier::EdgeServer)),
         )
         .await
         .expect("Query with EdgeServer tier should resolve within 10s")

--- a/examples/docs/todo-server-ts/src/main.ts
+++ b/examples/docs/todo-server-ts/src/main.ts
@@ -65,11 +65,27 @@ function rowToTodo(id: string, values: Value[]): Todo | null {
   }
 
   return {
-    id,
+    id: normalizeTodoId(id),
     title: titleVal.value,
     done: doneVal.value,
     description: descVal?.type === "Text" && descVal.value ? descVal.value : undefined,
   };
+}
+
+function normalizeTodoId(id: string): string {
+  if (id.startsWith("uuid:")) {
+    return id.slice("uuid:".length);
+  }
+  if (id.startsWith("urn:uuid:")) {
+    return id.slice("urn:uuid:".length);
+  }
+  return id;
+}
+
+async function findTodoRowById(client: JazzClient, id: string) {
+  const normalizedId = normalizeTodoId(id);
+  const rows = await client.query(schemaApp.todos);
+  return rows.find((row) => normalizeTodoId(row.id) === normalizedId);
 }
 
 // ============================================================================
@@ -160,7 +176,7 @@ export async function createServer(dataPath?: string): Promise<TodoServer> {
         { type: "Text", value: ownerId },
       ];
 
-      const id = await client.create("todos", values);
+      const id = normalizeTodoId(await client.create("todos", values));
 
       const todo: Todo = {
         id,
@@ -221,10 +237,8 @@ export async function createServer(dataPath?: string): Promise<TodoServer> {
   // Get a single todo
   app.get("/todos/:id", async (req: Request, res: Response, next: NextFunction) => {
     try {
-      const { id } = req.params;
-
-      const rows = await client.query(schemaApp.todos.where({ id }));
-      const row = rows.find((r) => r.id === id);
+      const id = normalizeTodoId(req.params.id);
+      const row = await findTodoRowById(client, id);
 
       if (!row) {
         res.status(404).json({ error: "Todo not found" });
@@ -246,7 +260,7 @@ export async function createServer(dataPath?: string): Promise<TodoServer> {
   // Update a todo
   app.put("/todos/:id", async (req: Request, res: Response, next: NextFunction) => {
     try {
-      const { id } = req.params;
+      const id = normalizeTodoId(req.params.id);
       const body = req.body as UpdateTodoRequest;
 
       const updates: Record<string, Value> = {};
@@ -263,8 +277,7 @@ export async function createServer(dataPath?: string): Promise<TodoServer> {
 
       if (Object.keys(updates).length === 0) {
         // No updates, just return the current todo
-        const rows = await client.query(schemaApp.todos.where({ id }));
-        const row = rows.find((r) => r.id === id);
+        const row = await findTodoRowById(client, id);
 
         if (!row) {
           res.status(404).json({ error: "Todo not found" });
@@ -279,8 +292,7 @@ export async function createServer(dataPath?: string): Promise<TodoServer> {
       await client.update(id, updates);
 
       // Fetch updated todo
-      const rows = await client.query(schemaApp.todos.where({ id }));
-      const row = rows.find((r) => r.id === id);
+      const row = await findTodoRowById(client, id);
 
       if (!row) {
         res.status(404).json({ error: "Todo not found after update" });
@@ -300,7 +312,7 @@ export async function createServer(dataPath?: string): Promise<TodoServer> {
   // Delete a todo
   app.delete("/todos/:id", async (req: Request, res: Response, next: NextFunction) => {
     try {
-      const { id } = req.params;
+      const id = normalizeTodoId(req.params.id);
 
       await client.delete(id);
       res.status(204).send();

--- a/examples/docs/todo-server-ts/src/main.ts
+++ b/examples/docs/todo-server-ts/src/main.ts
@@ -65,27 +65,11 @@ function rowToTodo(id: string, values: Value[]): Todo | null {
   }
 
   return {
-    id: normalizeTodoId(id),
+    id,
     title: titleVal.value,
     done: doneVal.value,
     description: descVal?.type === "Text" && descVal.value ? descVal.value : undefined,
   };
-}
-
-function normalizeTodoId(id: string): string {
-  if (id.startsWith("uuid:")) {
-    return id.slice("uuid:".length);
-  }
-  if (id.startsWith("urn:uuid:")) {
-    return id.slice("urn:uuid:".length);
-  }
-  return id;
-}
-
-async function findTodoRowById(client: JazzClient, id: string) {
-  const normalizedId = normalizeTodoId(id);
-  const rows = await client.query(schemaApp.todos);
-  return rows.find((row) => normalizeTodoId(row.id) === normalizedId);
 }
 
 // ============================================================================
@@ -176,7 +160,7 @@ export async function createServer(dataPath?: string): Promise<TodoServer> {
         { type: "Text", value: ownerId },
       ];
 
-      const id = normalizeTodoId(await client.create("todos", values));
+      const id = await client.create("todos", values);
 
       const todo: Todo = {
         id,
@@ -237,8 +221,10 @@ export async function createServer(dataPath?: string): Promise<TodoServer> {
   // Get a single todo
   app.get("/todos/:id", async (req: Request, res: Response, next: NextFunction) => {
     try {
-      const id = normalizeTodoId(req.params.id);
-      const row = await findTodoRowById(client, id);
+      const { id } = req.params;
+
+      const rows = await client.query(schemaApp.todos.where({ id }));
+      const row = rows.find((r) => r.id === id);
 
       if (!row) {
         res.status(404).json({ error: "Todo not found" });
@@ -260,7 +246,7 @@ export async function createServer(dataPath?: string): Promise<TodoServer> {
   // Update a todo
   app.put("/todos/:id", async (req: Request, res: Response, next: NextFunction) => {
     try {
-      const id = normalizeTodoId(req.params.id);
+      const { id } = req.params;
       const body = req.body as UpdateTodoRequest;
 
       const updates: Record<string, Value> = {};
@@ -277,7 +263,8 @@ export async function createServer(dataPath?: string): Promise<TodoServer> {
 
       if (Object.keys(updates).length === 0) {
         // No updates, just return the current todo
-        const row = await findTodoRowById(client, id);
+        const rows = await client.query(schemaApp.todos.where({ id }));
+        const row = rows.find((r) => r.id === id);
 
         if (!row) {
           res.status(404).json({ error: "Todo not found" });
@@ -292,7 +279,8 @@ export async function createServer(dataPath?: string): Promise<TodoServer> {
       await client.update(id, updates);
 
       // Fetch updated todo
-      const row = await findTodoRowById(client, id);
+      const rows = await client.query(schemaApp.todos.where({ id }));
+      const row = rows.find((r) => r.id === id);
 
       if (!row) {
         res.status(404).json({ error: "Todo not found after update" });
@@ -312,7 +300,7 @@ export async function createServer(dataPath?: string): Promise<TodoServer> {
   // Delete a todo
   app.delete("/todos/:id", async (req: Request, res: Response, next: NextFunction) => {
     try {
-      const id = normalizeTodoId(req.params.id);
+      const { id } = req.params;
 
       await client.delete(id);
       res.status(204).send();

--- a/examples/todo-client-localfirst-react/src/TodoList.tsx
+++ b/examples/todo-client-localfirst-react/src/TodoList.tsx
@@ -16,7 +16,7 @@ export function TodoList() {
 
   // #region reading-reactive-hooks-react
   const db = useDb();
-  const todos = useAll(todosQuery);
+  const todos = useAll(todosQuery) ?? [];
   // #endregion reading-reactive-hooks-react
   const session = useSession();
   const sessionUserId = session?.user_id ?? null;

--- a/examples/todo-server-rs/tests/integration.rs
+++ b/examples/todo-server-rs/tests/integration.rs
@@ -17,7 +17,7 @@ use futures_util::StreamExt as _;
 use futures_util::stream::Stream;
 use http_body_util::BodyExt;
 use jazz_tools::{
-    AppContext, AppId, ColumnType, JazzClient, PersistenceTier, SchemaBuilder, TableSchema,
+    AppContext, AppId, ColumnType, DurabilityTier, JazzClient, SchemaBuilder, TableSchema,
 };
 use serde::{Deserialize, Serialize};
 use tempfile::TempDir;
@@ -806,7 +806,7 @@ async fn test_server_resync() {
         let query = QueryBuilder::new("todos").build();
         let results = tokio::time::timeout(
             Duration::from_secs(10),
-            client.query(query, Some(PersistenceTier::EdgeServer)),
+            client.query(query, Some(DurabilityTier::EdgeServer)),
         )
         .await
         .expect("Query with EdgeServer tier should resolve within 10s")

--- a/examples/todo-server-ts/src/main.ts
+++ b/examples/todo-server-ts/src/main.ts
@@ -65,11 +65,27 @@ function rowToTodo(id: string, values: Value[]): Todo | null {
   }
 
   return {
-    id,
+    id: normalizeTodoId(id),
     title: titleVal.value,
     done: doneVal.value,
     description: descVal?.type === "Text" && descVal.value ? descVal.value : undefined,
   };
+}
+
+function normalizeTodoId(id: string): string {
+  if (id.startsWith("uuid:")) {
+    return id.slice("uuid:".length);
+  }
+  if (id.startsWith("urn:uuid:")) {
+    return id.slice("urn:uuid:".length);
+  }
+  return id;
+}
+
+async function findTodoRowById(client: JazzClient, id: string) {
+  const normalizedId = normalizeTodoId(id);
+  const rows = await client.query(schemaApp.todos);
+  return rows.find((row) => normalizeTodoId(row.id) === normalizedId);
 }
 
 // ============================================================================
@@ -158,7 +174,7 @@ export async function createServer(dataPath?: string): Promise<TodoServer> {
         { type: "Text", value: ownerId },
       ];
 
-      const id = await client.create("todos", values);
+      const id = normalizeTodoId(await client.create("todos", values));
 
       const todo: Todo = {
         id,
@@ -219,10 +235,8 @@ export async function createServer(dataPath?: string): Promise<TodoServer> {
   // Get a single todo
   app.get("/todos/:id", async (req: Request, res: Response, next: NextFunction) => {
     try {
-      const { id } = req.params;
-
-      const rows = await client.query(schemaApp.todos.where({ id }));
-      const row = rows.find((r) => r.id === id);
+      const id = normalizeTodoId(req.params.id);
+      const row = await findTodoRowById(client, id);
 
       if (!row) {
         res.status(404).json({ error: "Todo not found" });
@@ -244,7 +258,7 @@ export async function createServer(dataPath?: string): Promise<TodoServer> {
   // Update a todo
   app.put("/todos/:id", async (req: Request, res: Response, next: NextFunction) => {
     try {
-      const { id } = req.params;
+      const id = normalizeTodoId(req.params.id);
       const body = req.body as UpdateTodoRequest;
 
       const updates: Record<string, Value> = {};
@@ -261,8 +275,7 @@ export async function createServer(dataPath?: string): Promise<TodoServer> {
 
       if (Object.keys(updates).length === 0) {
         // No updates, just return the current todo
-        const rows = await client.query(schemaApp.todos.where({ id }));
-        const row = rows.find((r) => r.id === id);
+        const row = await findTodoRowById(client, id);
 
         if (!row) {
           res.status(404).json({ error: "Todo not found" });
@@ -277,8 +290,7 @@ export async function createServer(dataPath?: string): Promise<TodoServer> {
       await client.update(id, updates);
 
       // Fetch updated todo
-      const rows = await client.query(schemaApp.todos.where({ id }));
-      const row = rows.find((r) => r.id === id);
+      const row = await findTodoRowById(client, id);
 
       if (!row) {
         res.status(404).json({ error: "Todo not found after update" });
@@ -298,7 +310,7 @@ export async function createServer(dataPath?: string): Promise<TodoServer> {
   // Delete a todo
   app.delete("/todos/:id", async (req: Request, res: Response, next: NextFunction) => {
     try {
-      const { id } = req.params;
+      const id = normalizeTodoId(req.params.id);
 
       await client.delete(id);
       res.status(204).send();

--- a/examples/todo-server-ts/src/main.ts
+++ b/examples/todo-server-ts/src/main.ts
@@ -65,27 +65,11 @@ function rowToTodo(id: string, values: Value[]): Todo | null {
   }
 
   return {
-    id: normalizeTodoId(id),
+    id,
     title: titleVal.value,
     done: doneVal.value,
     description: descVal?.type === "Text" && descVal.value ? descVal.value : undefined,
   };
-}
-
-function normalizeTodoId(id: string): string {
-  if (id.startsWith("uuid:")) {
-    return id.slice("uuid:".length);
-  }
-  if (id.startsWith("urn:uuid:")) {
-    return id.slice("urn:uuid:".length);
-  }
-  return id;
-}
-
-async function findTodoRowById(client: JazzClient, id: string) {
-  const normalizedId = normalizeTodoId(id);
-  const rows = await client.query(schemaApp.todos);
-  return rows.find((row) => normalizeTodoId(row.id) === normalizedId);
 }
 
 // ============================================================================
@@ -174,7 +158,7 @@ export async function createServer(dataPath?: string): Promise<TodoServer> {
         { type: "Text", value: ownerId },
       ];
 
-      const id = normalizeTodoId(await client.create("todos", values));
+      const id = await client.create("todos", values);
 
       const todo: Todo = {
         id,
@@ -235,8 +219,10 @@ export async function createServer(dataPath?: string): Promise<TodoServer> {
   // Get a single todo
   app.get("/todos/:id", async (req: Request, res: Response, next: NextFunction) => {
     try {
-      const id = normalizeTodoId(req.params.id);
-      const row = await findTodoRowById(client, id);
+      const { id } = req.params;
+
+      const rows = await client.query(schemaApp.todos.where({ id }));
+      const row = rows.find((r) => r.id === id);
 
       if (!row) {
         res.status(404).json({ error: "Todo not found" });
@@ -258,7 +244,7 @@ export async function createServer(dataPath?: string): Promise<TodoServer> {
   // Update a todo
   app.put("/todos/:id", async (req: Request, res: Response, next: NextFunction) => {
     try {
-      const id = normalizeTodoId(req.params.id);
+      const { id } = req.params;
       const body = req.body as UpdateTodoRequest;
 
       const updates: Record<string, Value> = {};
@@ -275,7 +261,8 @@ export async function createServer(dataPath?: string): Promise<TodoServer> {
 
       if (Object.keys(updates).length === 0) {
         // No updates, just return the current todo
-        const row = await findTodoRowById(client, id);
+        const rows = await client.query(schemaApp.todos.where({ id }));
+        const row = rows.find((r) => r.id === id);
 
         if (!row) {
           res.status(404).json({ error: "Todo not found" });
@@ -290,7 +277,8 @@ export async function createServer(dataPath?: string): Promise<TodoServer> {
       await client.update(id, updates);
 
       // Fetch updated todo
-      const row = await findTodoRowById(client, id);
+      const rows = await client.query(schemaApp.todos.where({ id }));
+      const row = rows.find((r) => r.id === id);
 
       if (!row) {
         res.status(404).json({ error: "Todo not found after update" });
@@ -310,7 +298,7 @@ export async function createServer(dataPath?: string): Promise<TodoServer> {
   // Delete a todo
   app.delete("/todos/:id", async (req: Request, res: Response, next: NextFunction) => {
     try {
-      const id = normalizeTodoId(req.params.id);
+      const { id } = req.params;
 
       await client.delete(id);
       res.status(204).send();

--- a/packages/jazz-tools/src/backend/create-jazz-context.test.ts
+++ b/packages/jazz-tools/src/backend/create-jazz-context.test.ts
@@ -108,7 +108,7 @@ describe("backend/create-jazz-context", () => {
       "dev",
       "main",
       "/tmp/jazz.db",
-      undefined,
+      "edge",
     );
   });
 

--- a/packages/jazz-tools/src/backend/create-jazz-context.ts
+++ b/packages/jazz-tools/src/backend/create-jazz-context.ts
@@ -23,8 +23,8 @@ export interface BackendContextConfig extends Omit<
   dataPath: string;
   /** Optional default schema source (typically generated `app` export). */
   app?: BackendSchemaSource;
-  /** Optional persistence tier for ack semantics. */
-  tier?: "worker" | "edge" | "core";
+  /** Optional node durability tier identity. */
+  tier?: "worker" | "edge" | "global";
 }
 
 interface ResolvedBackendContextConfig extends BackendContextConfig {
@@ -120,6 +120,7 @@ export class JazzContext {
       backendSecret: this.config.backendSecret,
       adminSecret: this.config.adminSecret,
       tier: this.config.tier,
+      defaultDurabilityTier: "edge",
     };
 
     this.clientInstance = JazzClient.connectWithRuntime(this.runtime, context);

--- a/packages/jazz-tools/src/backend/create-jazz-context.ts
+++ b/packages/jazz-tools/src/backend/create-jazz-context.ts
@@ -97,6 +97,7 @@ export class JazzContext {
   private createClient(schema: WasmSchema): JazzClient {
     const schemaJson = serializeRuntimeSchema(schema);
     this.initializedSchemaJson = schemaJson;
+    const nodeTier = this.config.tier ?? "edge";
 
     this.runtime = new NapiRuntime(
       schemaJson,
@@ -104,7 +105,7 @@ export class JazzContext {
       this.config.env ?? "dev",
       this.config.userBranch ?? "main",
       this.config.dataPath,
-      this.config.tier,
+      nodeTier,
     );
 
     const context: AppContext = {
@@ -119,7 +120,7 @@ export class JazzContext {
       localAuthToken: this.config.localAuthToken,
       backendSecret: this.config.backendSecret,
       adminSecret: this.config.adminSecret,
-      tier: this.config.tier,
+      tier: nodeTier,
       defaultDurabilityTier: "edge",
     };
 

--- a/packages/jazz-tools/src/dev-tools/dev-tools.ts
+++ b/packages/jazz-tools/src/dev-tools/dev-tools.ts
@@ -1,6 +1,6 @@
 import {
   JazzClient,
-  PersistenceTier,
+  DurabilityTier,
   QueryExecutionOptions,
   QueryInput,
   WasmSchema,
@@ -260,11 +260,11 @@ function hookRegistration(
 
         const queryPayload = isRecord(envelope.payload) ? envelope.payload : {};
         const query = queryPayload.query;
-        const settledTier = queryPayload.settledTier as PersistenceTier | undefined;
+        const tier = queryPayload.tier as DurabilityTier | undefined;
         const options = isRecord(queryPayload.options)
           ? (queryPayload.options as QueryExecutionOptions)
-          : settledTier
-            ? { settledTier }
+          : tier
+            ? { tier }
             : undefined;
 
         if (typeof query !== "string" && !isRecord(query)) {

--- a/packages/jazz-tools/src/dev-tools/extension-panel.ts
+++ b/packages/jazz-tools/src/dev-tools/extension-panel.ts
@@ -1,6 +1,6 @@
 import {
   JazzClient,
-  PersistenceTier,
+  DurabilityTier,
   QueryExecutionOptions,
   QueryInput,
   RequestLike,
@@ -438,15 +438,12 @@ class DevToolsJazzClient implements JazzClient {
   forRequest(request: RequestLike): SessionClient {
     throw new Error("Method not implemented.");
   }
-  create(table: string, values: Value[]): string {
-    throw new Error("Method not implemented.");
-  }
-  createWithAck(table: string, values: Value[], tier: PersistenceTier): Promise<string> {
+  create(table: string, values: Value[], options?: { tier?: DurabilityTier }): Promise<string> {
     throw new Error("Method not implemented.");
   }
   async query(query: string | QueryInput, options?: QueryExecutionOptions): Promise<Row[]> {
     await ensureDevtoolsAnnounced();
-    const payload = { query, options, settledTier: options?.settledTier };
+    const payload = { query, options, tier: options?.tier };
     const rows = await sendDevtoolsRequest<Row[]>(DEVTOOLS_COMMANDS.CLIENT_QUERY, payload);
     return rows;
   }
@@ -457,20 +454,14 @@ class DevToolsJazzClient implements JazzClient {
   ): Promise<Row[]> {
     throw new Error("Method not implemented.");
   }
-  update(objectId: string, updates: Record<string, Value>): void {
-    throw new Error("Method not implemented.");
-  }
-  updateWithAck(
+  update(
     objectId: string,
     updates: Record<string, Value>,
-    tier: PersistenceTier,
+    options?: { tier?: DurabilityTier },
   ): Promise<void> {
     throw new Error("Method not implemented.");
   }
-  delete(objectId: string): void {
-    throw new Error("Method not implemented.");
-  }
-  deleteWithAck(objectId: string, tier: PersistenceTier): Promise<void> {
+  delete(objectId: string, options?: { tier?: DurabilityTier }): Promise<void> {
     throw new Error("Method not implemented.");
   }
   subscribe(
@@ -488,7 +479,7 @@ class DevToolsJazzClient implements JazzClient {
         sendDevtoolsRequest(DEVTOOLS_COMMANDS.CLIENT_SUBSCRIBE, {
           query,
           options,
-          settledTier: options?.settledTier,
+          tier: options?.tier,
           subscriptionId: bridgeSubscriptionId,
         }),
       )

--- a/packages/jazz-tools/src/react-core/index.ts
+++ b/packages/jazz-tools/src/react-core/index.ts
@@ -3,7 +3,7 @@ export { JazzProvider, useDb, type JazzProviderProps } from "./provider.js";
 export { useAll, useAllSuspense } from "./use-all.js";
 
 export type {
-  PersistenceTier,
+  DurabilityTier,
   QueryBuilder,
   RowDelta,
   SubscriptionDelta,

--- a/packages/jazz-tools/src/react-native/create-jazz-rn-runtime.ts
+++ b/packages/jazz-tools/src/react-native/create-jazz-rn-runtime.ts
@@ -1,6 +1,6 @@
 import jazzRn from "jazz-rn";
 import type { WasmSchema } from "../drivers/types.js";
-import type { PersistenceTier } from "../runtime/client.js";
+import type { DurabilityTier } from "../runtime/client.js";
 import { JazzRnRuntimeAdapter } from "./jazz-rn-runtime-adapter.js";
 
 export interface CreateJazzRnRuntimeOptions {
@@ -8,7 +8,7 @@ export interface CreateJazzRnRuntimeOptions {
   appId: string;
   env?: string;
   userBranch?: string;
-  tier?: PersistenceTier;
+  tier?: DurabilityTier;
   dataPath?: string;
 }
 

--- a/packages/jazz-tools/src/react-native/db.test.ts
+++ b/packages/jazz-tools/src/react-native/db.test.ts
@@ -87,6 +87,7 @@ describe("react-native Db", () => {
       localAuthToken: config.localAuthToken,
       adminSecret: config.adminSecret,
       tier: config.tier,
+      defaultDurabilityTier: "worker",
     });
   });
 

--- a/packages/jazz-tools/src/react-native/db.ts
+++ b/packages/jazz-tools/src/react-native/db.ts
@@ -1,12 +1,12 @@
 import type { WasmSchema } from "../drivers/types.js";
-import { JazzClient, type PersistenceTier } from "../runtime/client.js";
+import { JazzClient, type DurabilityTier } from "../runtime/client.js";
 import { Db as RuntimeDb, type DbConfig as RuntimeDbConfig } from "../runtime/db.js";
 import { createJazzRnRuntime } from "./create-jazz-rn-runtime.js";
 import { analyzeRelations } from "../codegen/relation-analyzer.js";
 
 export interface DbConfig extends RuntimeDbConfig {
   dataPath?: string;
-  tier?: PersistenceTier;
+  tier?: DurabilityTier;
 }
 
 export class Db extends RuntimeDb {
@@ -42,6 +42,7 @@ export class Db extends RuntimeDb {
         localAuthToken: this.nativeConfig.localAuthToken,
         adminSecret: this.nativeConfig.adminSecret,
         tier: this.nativeConfig.tier,
+        defaultDurabilityTier: "worker",
       });
 
       this.nativeClients.set(key, client);

--- a/packages/jazz-tools/src/react-native/index.ts
+++ b/packages/jazz-tools/src/react-native/index.ts
@@ -24,7 +24,7 @@ export {
 } from "../synthetic-users.js";
 
 export type {
-  PersistenceTier,
+  DurabilityTier,
   QueryBuilder,
   RowDelta,
   SubscriptionDelta,

--- a/packages/jazz-tools/src/react-native/jazz-rn-runtime-adapter.test.ts
+++ b/packages/jazz-tools/src/react-native/jazz-rn-runtime-adapter.test.ts
@@ -151,18 +151,18 @@ describe("JazzRnRuntimeAdapter", () => {
     });
   });
 
-  it("supports worker-tier persisted mutations and rejects edge/core tiers", async () => {
+  it("supports worker-tier persisted mutations and rejects global tiers", async () => {
     const binding = createBinding();
     const adapter = new JazzRnRuntimeAdapter(binding, {});
 
-    await expect(adapter.insertWithAck("todos", [], "worker")).resolves.toBe("row-1");
+    await expect(adapter.insertDurable("todos", [], "worker")).resolves.toBe("row-1");
     expect(binding.flush).toHaveBeenCalledTimes(1);
 
-    await expect(adapter.updateWithAck("row-1", {}, "worker")).resolves.toBeUndefined();
-    await expect(adapter.deleteWithAck("row-1", "worker")).resolves.toBeUndefined();
+    await expect(adapter.updateDurable("row-1", {}, "worker")).resolves.toBeUndefined();
+    await expect(adapter.deleteDurable("row-1", "worker")).resolves.toBeUndefined();
     expect(binding.flush).toHaveBeenCalledTimes(3);
 
-    expect(() => adapter.insertWithAck("todos", [], "edge")).toThrow("supports only 'worker' tier");
+    expect(() => adapter.insertDurable("todos", [], "edge")).toThrow("supports only 'worker' tier");
   });
 
   it("swallows ObjectNotFound runtime errors for update/delete", () => {

--- a/packages/jazz-tools/src/react-native/jazz-rn-runtime-adapter.ts
+++ b/packages/jazz-tools/src/react-native/jazz-rn-runtime-adapter.ts
@@ -32,18 +32,14 @@ export interface JazzRnRuntimeBinding {
         }
       | undefined,
   ): void;
-  query(
-    queryJson: string,
-    sessionJson: string | undefined,
-    settledTier: string | undefined,
-  ): string;
+  query(queryJson: string, sessionJson: string | undefined, tier: string | undefined): string;
   removeServer(): void;
   setClientRole(clientId: string, role: string): void;
   subscribe(
     queryJson: string,
     callback: { onUpdate(deltaJson: string): void },
     sessionJson: string | undefined,
-    settledTier: string | undefined,
+    tier: string | undefined,
   ): bigint;
   unsubscribe(handle: bigint): void;
   update(objectId: string, valuesJson: string): void;
@@ -141,13 +137,9 @@ export class JazzRnRuntimeAdapter implements Runtime {
   async query(
     query_json: string,
     session_json?: string | null,
-    settled_tier?: string | null,
+    tier?: string | null,
   ): Promise<any> {
-    const rowsJson = this.binding.query(
-      query_json,
-      session_json ?? undefined,
-      settled_tier ?? undefined,
-    );
+    const rowsJson = this.binding.query(query_json, session_json ?? undefined, tier ?? undefined);
     return JSON.parse(rowsJson);
   }
 
@@ -155,7 +147,7 @@ export class JazzRnRuntimeAdapter implements Runtime {
     query_json: string,
     on_update: Function,
     session_json?: string | null,
-    settled_tier?: string | null,
+    tier?: string | null,
   ): number {
     const handle = this.binding.subscribe(
       query_json,
@@ -170,7 +162,7 @@ export class JazzRnRuntimeAdapter implements Runtime {
         },
       },
       session_json ?? undefined,
-      settled_tier ?? undefined,
+      tier ?? undefined,
     );
 
     const numericHandle = Number(handle);
@@ -187,21 +179,21 @@ export class JazzRnRuntimeAdapter implements Runtime {
     this.handleMap.delete(handle);
   }
 
-  insertWithAck(table: string, values: any, tier: string): Promise<string> {
+  insertDurable(table: string, values: any, tier: string): Promise<string> {
     assertWorkerTier(tier);
     const id = this.insert(table, values);
     this.binding.flush();
     return Promise.resolve(id);
   }
 
-  updateWithAck(object_id: string, values: any, tier: string): Promise<void> {
+  updateDurable(object_id: string, values: any, tier: string): Promise<void> {
     assertWorkerTier(tier);
     this.update(object_id, values);
     this.binding.flush();
     return Promise.resolve();
   }
 
-  deleteWithAck(object_id: string, tier: string): Promise<void> {
+  deleteDurable(object_id: string, tier: string): Promise<void> {
     assertWorkerTier(tier);
     this.delete(object_id);
     this.binding.flush();

--- a/packages/jazz-tools/src/react/create-jazz-client.integration.test.ts
+++ b/packages/jazz-tools/src/react/create-jazz-client.integration.test.ts
@@ -56,7 +56,7 @@ describe("react/create-jazz-client integration", () => {
     try {
       client = await createJazzClient({ appId: makeAppId("mutation-query") });
 
-      const id = client.db.insert(todosTable, { title: "buy milk", done: false });
+      const id = await client.db.insert(todosTable, { title: "buy milk", done: false });
       const rows = await client.db.all(allTodosQuery);
 
       expect(
@@ -93,7 +93,7 @@ describe("react/create-jazz-client integration", () => {
 
     try {
       client = await createJazzClient({ appId: makeAppId("shutdown") });
-      client.db.insert(todosTable, { title: "shutdown-check", done: false });
+      await client.db.insert(todosTable, { title: "shutdown-check", done: false });
       await client.db.all(allTodosQuery);
 
       await expect(client.shutdown()).resolves.toBeUndefined();

--- a/packages/jazz-tools/src/runtime/client.for-request.test.ts
+++ b/packages/jazz-tools/src/runtime/client.for-request.test.ts
@@ -39,13 +39,13 @@ function makeClient() {
     query: async (
       queryJson: string,
       sessionJson?: string | null,
-      settledTier?: string | null,
+      tier?: string | null,
       optionsJson?: string | null,
     ) => {
       queryCalls.push([
         queryJson,
         sessionJson ?? undefined,
-        settledTier ?? undefined,
+        tier ?? undefined,
         optionsJson ?? undefined,
       ]);
       return [];
@@ -54,22 +54,22 @@ function makeClient() {
       queryJson: string,
       onUpdate: Function,
       sessionJson?: string | null,
-      settledTier?: string | null,
+      tier?: string | null,
       optionsJson?: string | null,
     ) => {
       subscribeCalls.push([
         queryJson,
         sessionJson ?? undefined,
-        settledTier ?? undefined,
+        tier ?? undefined,
         optionsJson ?? undefined,
       ]);
       subscribeCallbacks.push(onUpdate);
       return 1;
     },
     unsubscribe: () => {},
-    insertWithAck: async () => "00000000-0000-0000-0000-000000000001",
-    updateWithAck: async () => {},
-    deleteWithAck: async () => {},
+    insertDurable: async () => "00000000-0000-0000-0000-000000000001",
+    updateDurable: async () => {},
+    deleteDurable: async () => {},
     onSyncMessageReceived: () => {},
     onSyncMessageToSend: () => {},
     addServer: () => {},
@@ -87,10 +87,14 @@ function makeClient() {
   };
 
   const JazzClientCtor = JazzClient as unknown as {
-    new (runtime: Runtime, context: AppContext): JazzClient;
+    new (
+      runtime: Runtime,
+      context: AppContext,
+      defaultDurabilityTier: "worker" | "edge" | "global",
+    ): JazzClient;
   };
   return {
-    client: new JazzClientCtor(runtime, context),
+    client: new JazzClientCtor(runtime, context, "edge"),
     queryCalls,
     subscribeCalls,
     subscribeCallbacks,

--- a/packages/jazz-tools/src/runtime/client.ts
+++ b/packages/jazz-tools/src/runtime/client.ts
@@ -43,25 +43,25 @@ export interface RequestLike {
  */
 export interface Runtime {
   insert(table: string, values: any): string;
+  insertDurable(table: string, values: any, tier: string): Promise<string>;
   update(object_id: string, values: any): void;
+  updateDurable(object_id: string, values: any, tier: string): Promise<void>;
   delete(object_id: string): void;
+  deleteDurable(object_id: string, tier: string): Promise<void>;
   query(
     query_json: string,
     session_json?: string | null,
-    settled_tier?: string | null,
+    tier?: string | null,
     options_json?: string | null,
   ): Promise<any>;
   subscribe(
     query_json: string,
     on_update: Function,
     session_json?: string | null,
-    settled_tier?: string | null,
+    tier?: string | null,
     options_json?: string | null,
   ): number;
   unsubscribe(handle: number): void;
-  insertWithAck(table: string, values: any, tier: string): Promise<string>;
-  updateWithAck(object_id: string, values: any, tier: string): Promise<void>;
-  deleteWithAck(object_id: string, tier: string): Promise<void>;
   onSyncMessageReceived(message_json: string): void;
   onSyncMessageToSend(callback: Function): void;
   addServer(): void;
@@ -79,13 +79,19 @@ export interface Runtime {
  *
  * - `worker`: Persisted in web worker / local storage
  * - `edge`: Persisted at edge server
- * - `core`: Persisted at core server
+ * - `global`: Persisted at global server
  */
-export type PersistenceTier = "worker" | "edge" | "core";
+export type DurabilityTier = "worker" | "edge" | "global";
+export type LocalUpdatesMode = "immediate" | "deferred";
 export type QueryPropagation = "full" | "local-only";
 export interface QueryExecutionOptions {
-  settledTier?: PersistenceTier;
+  tier?: DurabilityTier;
+  localUpdates?: LocalUpdatesMode;
   propagation?: QueryPropagation;
+}
+
+export interface WriteDurabilityOptions {
+  tier?: DurabilityTier;
 }
 
 /**
@@ -142,25 +148,46 @@ function resolveQueryJson(query: string | QueryInput): string {
   return translateQuery(builtQuery, schema);
 }
 
-function normalizeQueryExecutionOptions(options?: QueryExecutionOptions): QueryExecutionOptions {
-  if (!options) {
-    return { propagation: "full" };
+function resolveNodeTier(tier: AppContext["tier"]): string | undefined {
+  if (!tier) return undefined;
+  if (Array.isArray(tier)) {
+    return tier[0];
+  }
+  return tier;
+}
+
+function isBrowserRuntime(): boolean {
+  return typeof window !== "undefined" && typeof document !== "undefined";
+}
+
+function resolveDefaultDurabilityTier(context: AppContext): DurabilityTier {
+  if (context.defaultDurabilityTier) {
+    return context.defaultDurabilityTier;
   }
 
-  return {
-    settledTier: options.settledTier,
-    propagation: options.propagation ?? "full",
-  };
+  if (isBrowserRuntime()) {
+    return "worker";
+  }
+
+  // In non-browser environments, default to edge when connected to a server.
+  // For local/in-memory runtimes without a server, keep worker semantics.
+  return context.serverUrl ? "edge" : "worker";
 }
 
 function encodeQueryExecutionOptions(options: QueryExecutionOptions): string | undefined {
-  if ((options.propagation ?? "full") === "full") {
+  const payload: { propagation?: QueryPropagation; local_updates?: LocalUpdatesMode } = {};
+  if ((options.propagation ?? "full") !== "full") {
+    payload.propagation = options.propagation;
+  }
+  if ((options.localUpdates ?? "immediate") !== "immediate") {
+    payload.local_updates = options.localUpdates;
+  }
+
+  if (!payload.propagation && !payload.local_updates) {
     return undefined;
   }
 
-  return JSON.stringify({
-    propagation: options.propagation,
-  });
+  return JSON.stringify(payload);
 }
 
 function readHeader(request: RequestLike, name: string): string | undefined {
@@ -361,10 +388,16 @@ export class JazzClient {
   private subscriptions = new Map<number, SubscriptionCallback>();
   private context: AppContext;
   private resolvedSession: Session | null;
+  private defaultDurabilityTier: DurabilityTier;
 
-  private constructor(runtime: Runtime, context: AppContext) {
+  private constructor(
+    runtime: Runtime,
+    context: AppContext,
+    defaultDurabilityTier: DurabilityTier,
+  ) {
     this.runtime = runtime;
     this.context = context;
+    this.defaultDurabilityTier = defaultDurabilityTier;
     this.resolvedSession = resolveJwtSession(context.jwtToken ?? "");
     this.streamController = createRuntimeSyncStreamController({
       getRuntime: () => this.runtime,
@@ -399,10 +432,14 @@ export class JazzClient {
       resolvedContext.appId,
       resolvedContext.env ?? "dev",
       resolvedContext.userBranch ?? "main",
-      resolvedContext.tier,
+      resolveNodeTier(resolvedContext.tier),
     );
 
-    const client = new JazzClient(runtime, resolvedContext);
+    const client = new JazzClient(
+      runtime,
+      resolvedContext,
+      resolveDefaultDurabilityTier(resolvedContext),
+    );
 
     // Set up sync if server URL provided
     if (resolvedContext.serverUrl) {
@@ -432,10 +469,14 @@ export class JazzClient {
       resolvedContext.appId,
       resolvedContext.env ?? "dev",
       resolvedContext.userBranch ?? "main",
-      resolvedContext.tier,
+      resolveNodeTier(resolvedContext.tier),
     );
 
-    const client = new JazzClient(runtime, resolvedContext);
+    const client = new JazzClient(
+      runtime,
+      resolvedContext,
+      resolveDefaultDurabilityTier(resolvedContext),
+    );
 
     // Set up sync if server URL provided
     if (resolvedContext.serverUrl) {
@@ -456,7 +497,7 @@ export class JazzClient {
    * @returns Connected JazzClient instance
    */
   static connectWithRuntime(runtime: Runtime, context: AppContext): JazzClient {
-    const client = new JazzClient(runtime, context);
+    const client = new JazzClient(runtime, context, resolveDefaultDurabilityTier(context));
 
     // Set up sync if server URL provided
     if (context.serverUrl) {
@@ -507,34 +548,31 @@ export class JazzClient {
     return this.forSession(sessionFromRequest(request));
   }
 
-  /**
-   * Insert a new row into a table (sync, fire-and-forget).
-   *
-   * @param table Table name
-   * @param values Array of column values
-   * @returns The new row's ID (UUID string)
-   */
-  create(table: string, values: Value[]): string {
-    return this.runtime.insert(table, values);
+  private normalizeQueryExecutionOptions(options?: QueryExecutionOptions): QueryExecutionOptions {
+    return {
+      tier: options?.tier ?? this.defaultDurabilityTier,
+      localUpdates: options?.localUpdates ?? "immediate",
+      propagation: options?.propagation ?? "full",
+    };
+  }
+
+  private resolveWriteTier(options?: WriteDurabilityOptions): DurabilityTier {
+    return options?.tier ?? this.defaultDurabilityTier;
   }
 
   /**
-   * Insert a row and wait for acknowledgement at the specified tier.
-   *
-   * @param table Table name
-   * @param values Array of column values
-   * @param tier Acknowledgement tier to wait for
-   * @returns Promise resolving to the new row's ID when the tier acknowledges
+   * Insert a new row into a table and wait for durability at the requested tier.
    */
-  async createWithAck(table: string, values: Value[], tier: PersistenceTier): Promise<string> {
-    return this.runtime.insertWithAck(table, values, tier);
+  async create(table: string, values: Value[], options?: WriteDurabilityOptions): Promise<string> {
+    const tier = this.resolveWriteTier(options);
+    return this.runtime.insertDurable(table, values, tier);
   }
 
   /**
    * Execute a query and return all matching rows.
    *
    * @param query Query builder or JSON-encoded query specification
-   * @param settledTier Optional tier to hold delivery until confirmed
+   * @param options Optional read durability options
    * @returns Array of matching rows
    */
   async query(query: string | QueryInput, options?: QueryExecutionOptions): Promise<Row[]> {
@@ -542,7 +580,7 @@ export class JazzClient {
   }
 
   /**
-   * Internal query with optional session and settled tier.
+   * Internal query with optional session and read durability options.
    * @internal
    */
   async queryInternal(
@@ -550,54 +588,37 @@ export class JazzClient {
     session?: Session,
     options?: QueryExecutionOptions,
   ): Promise<Row[]> {
-    const normalizedOptions = normalizeQueryExecutionOptions(options);
+    const normalizedOptions = this.normalizeQueryExecutionOptions(options);
     const queryJson = resolveQueryJson(query);
     const sessionJson = session ? JSON.stringify(session) : undefined;
     const optionsJson = encodeQueryExecutionOptions(normalizedOptions);
     const results = await this.runtime.query(
       queryJson,
       sessionJson,
-      normalizedOptions.settledTier,
+      normalizedOptions.tier,
       optionsJson,
     );
     return results as Row[];
   }
 
   /**
-   * Update a row by ID (sync, fire-and-forget).
-   *
-   * @param objectId Row ID (UUID string)
-   * @param updates Object mapping column names to new values
+   * Update a row by ID and wait for durability at the requested tier.
    */
-  update(objectId: string, updates: Record<string, Value>): void {
-    this.runtime.update(objectId, updates);
-  }
-
-  /**
-   * Update a row and wait for acknowledgement at the specified tier.
-   */
-  async updateWithAck(
+  async update(
     objectId: string,
     updates: Record<string, Value>,
-    tier: PersistenceTier,
+    options?: WriteDurabilityOptions,
   ): Promise<void> {
-    await this.runtime.updateWithAck(objectId, updates, tier);
+    const tier = this.resolveWriteTier(options);
+    await this.runtime.updateDurable(objectId, updates, tier);
   }
 
   /**
-   * Delete a row by ID (sync, fire-and-forget).
-   *
-   * @param objectId Row ID (UUID string)
+   * Delete a row by ID and wait for durability at the requested tier.
    */
-  delete(objectId: string): void {
-    this.runtime.delete(objectId);
-  }
-
-  /**
-   * Delete a row and wait for acknowledgement at the specified tier.
-   */
-  async deleteWithAck(objectId: string, tier: PersistenceTier): Promise<void> {
-    await this.runtime.deleteWithAck(objectId, tier);
+  async delete(objectId: string, options?: WriteDurabilityOptions): Promise<void> {
+    const tier = this.resolveWriteTier(options);
+    await this.runtime.deleteDurable(objectId, tier);
   }
 
   /**
@@ -605,7 +626,7 @@ export class JazzClient {
    *
    * @param query Query builder or JSON-encoded query specification
    * @param callback Called with delta whenever results change
-   * @param settledTier Optional tier to hold initial delivery until confirmed
+   * @param options Optional read durability options
    * @returns Subscription ID for unsubscribing
    */
   subscribe(
@@ -617,7 +638,7 @@ export class JazzClient {
   }
 
   /**
-   * Internal subscribe with optional session and settled tier.
+   * Internal subscribe with optional session and read durability options.
    * @internal
    */
   subscribeInternal(
@@ -626,7 +647,7 @@ export class JazzClient {
     session?: Session,
     options?: QueryExecutionOptions,
   ): number {
-    const normalizedOptions = normalizeQueryExecutionOptions(options);
+    const normalizedOptions = this.normalizeQueryExecutionOptions(options);
     const sessionJson = session ? JSON.stringify(session) : undefined;
     const queryJson = resolveQueryJson(query);
     const optionsJson = encodeQueryExecutionOptions(normalizedOptions);
@@ -639,7 +660,7 @@ export class JazzClient {
         callback(delta);
       },
       sessionJson,
-      normalizedOptions.settledTier,
+      normalizedOptions.tier,
       optionsJson,
     );
     this.subscriptions.set(subId, callback);

--- a/packages/jazz-tools/src/runtime/cloud-server.integration.test.ts
+++ b/packages/jazz-tools/src/runtime/cloud-server.integration.test.ts
@@ -322,7 +322,7 @@ async function waitForRows(
   queryJson: string,
   predicate: (rows: Row[]) => boolean,
   timeoutMs = 20000,
-  settledTier: "edge" | undefined = "edge",
+  tier: "edge" | undefined = "edge",
 ): Promise<Row[]> {
   const deadline = Date.now() + timeoutMs;
   let lastRows: Row[] = [];
@@ -330,7 +330,7 @@ async function waitForRows(
 
   while (Date.now() < deadline) {
     try {
-      const rows = await client.query(queryJson, settledTier ? { settledTier } : undefined);
+      const rows = await client.query(queryJson, tier ? { tier } : undefined);
       if (predicate(rows)) return rows;
       lastRows = rows;
     } catch (error) {
@@ -344,6 +344,24 @@ async function waitForRows(
   throw new Error(
     `timed out waiting for predicate; lastRows=${JSON.stringify(lastRows)}, lastError=${lastErrorMessage}`,
   );
+}
+
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, label: string): Promise<T> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_, reject) => {
+        timeoutId = setTimeout(() => {
+          reject(new Error(`${label} after ${timeoutMs}ms`));
+        }, timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+  }
 }
 
 async function connectClient(context: AppContext): Promise<JazzClient> {
@@ -913,77 +931,77 @@ function buildProfileByIdQuery(schema: WasmSchema, id: string): string {
 }
 
 async function seedSocialGraph(client: JazzClient): Promise<SocialSeed> {
-  const aliceProfileId = await client.createWithAck(
+  const aliceProfileId = await client.create(
     "profiles",
     [
       { type: "Text", value: "alice" },
       { type: "Text", value: "alice" },
     ],
-    "edge",
+    { tier: "edge" },
   );
-  const bobProfileId = await client.createWithAck(
+  const bobProfileId = await client.create(
     "profiles",
     [
       { type: "Text", value: "bob" },
       { type: "Text", value: "bob" },
     ],
-    "edge",
+    { tier: "edge" },
   );
-  const carolProfileId = await client.createWithAck(
+  const carolProfileId = await client.create(
     "profiles",
     [
       { type: "Text", value: "carol" },
       { type: "Text", value: "carol" },
     ],
-    "edge",
+    { tier: "edge" },
   );
-  const eveProfileId = await client.createWithAck(
+  const eveProfileId = await client.create(
     "profiles",
     [
       { type: "Text", value: "eve" },
       { type: "Text", value: "eve" },
     ],
-    "edge",
+    { tier: "edge" },
   );
   const alicePrincipal = "alice";
   const bobPrincipal = "bob";
   const carolPrincipal = "carol";
   const evePrincipal = "eve";
 
-  const alicePersonId = await client.createWithAck(
+  const alicePersonId = await client.create(
     "people",
     [
       { type: "Uuid", value: aliceProfileId },
       { type: "Text", value: alicePrincipal },
     ],
-    "edge",
+    { tier: "edge" },
   );
-  const bobPersonId = await client.createWithAck(
+  const bobPersonId = await client.create(
     "people",
     [
       { type: "Uuid", value: bobProfileId },
       { type: "Text", value: bobPrincipal },
     ],
-    "edge",
+    { tier: "edge" },
   );
-  await client.createWithAck(
+  await client.create(
     "people",
     [
       { type: "Uuid", value: carolProfileId },
       { type: "Text", value: carolPrincipal },
     ],
-    "edge",
+    { tier: "edge" },
   );
-  const evePersonId = await client.createWithAck(
+  const evePersonId = await client.create(
     "people",
     [
       { type: "Uuid", value: eveProfileId },
       { type: "Text", value: evePrincipal },
     ],
-    "edge",
+    { tier: "edge" },
   );
 
-  await client.createWithAck(
+  await client.create(
     "friendships",
     [
       { type: "Uuid", value: alicePersonId },
@@ -991,9 +1009,9 @@ async function seedSocialGraph(client: JazzClient): Promise<SocialSeed> {
       { type: "Text", value: alicePrincipal },
       { type: "Text", value: bobPrincipal },
     ],
-    "edge",
+    { tier: "edge" },
   );
-  await client.createWithAck(
+  await client.create(
     "friendships",
     [
       { type: "Uuid", value: evePersonId },
@@ -1001,7 +1019,7 @@ async function seedSocialGraph(client: JazzClient): Promise<SocialSeed> {
       { type: "Text", value: evePrincipal },
       { type: "Text", value: alicePrincipal },
     ],
-    "edge",
+    { tier: "edge" },
   );
 
   return {
@@ -1033,27 +1051,41 @@ async function runSocialReadPermissionsScenario(style: SocialPolicyStyle): Promi
 
     const aliceSession = seeder.forSession({ user_id: seeded.alicePrincipal, claims: {} });
     const carolSession = seeder.forSession({ user_id: seeded.carolPrincipal, claims: {} });
-    await seeder.shutdown();
-    seeder = null;
 
-    const aliceProfiles = await aliceSession.query(queryAllProfiles);
+    const aliceProfiles = await withTimeout(
+      aliceSession.query(queryAllProfiles),
+      10000,
+      "alice session query(all profiles) timed out",
+    );
     const visibleIds = [...new Set(aliceProfiles.map((row) => row.id))].sort();
     expect(visibleIds).toEqual([seeded.bobProfileId, seeded.eveProfileId].sort());
 
-    const bobRows = await aliceSession.query(
-      buildProfileByIdQuery(socialSchema, seeded.bobProfileId),
+    const bobRows = await withTimeout(
+      aliceSession.query(buildProfileByIdQuery(socialSchema, seeded.bobProfileId)),
+      10000,
+      "alice session query(bob profile) timed out",
     );
     expect(bobRows).toHaveLength(1);
     expect(bobRows[0]?.values[0]).toEqual({ type: "Text", value: "bob" });
 
-    const carolRowsForAlice = await aliceSession.query(
-      buildProfileByIdQuery(socialSchema, seeded.carolProfileId),
+    const carolRowsForAlice = await withTimeout(
+      aliceSession.query(buildProfileByIdQuery(socialSchema, seeded.carolProfileId)),
+      10000,
+      "alice session query(carol profile) timed out",
     );
     expect(carolRowsForAlice).toEqual([]);
 
-    const carolFriendships = await carolSession.query(queryAllFriendships);
+    const carolFriendships = await withTimeout(
+      carolSession.query(queryAllFriendships),
+      10000,
+      "carol session query(friendships) timed out",
+    );
     expect(carolFriendships).toHaveLength(2);
-    const carolProfiles = await carolSession.query(queryAllProfiles);
+    const carolProfiles = await withTimeout(
+      carolSession.query(queryAllProfiles),
+      10000,
+      "carol session query(all profiles) timed out",
+    );
     expect(carolProfiles).toEqual([]);
   } finally {
     if (seeder) await seeder.shutdown();
@@ -1222,13 +1254,13 @@ describe("cloud-server integration (Jazz TS)", () => {
         makeContext(app.app_id, server.baseUrl, signJwt("b", JWT_SECRET)),
       );
 
-      const rowId = await clientA.createWithAck(
+      const rowId = await clientA.create(
         "todos",
         [
           { type: "Text", value: "shared-item" },
           { type: "Boolean", value: false },
         ],
-        "edge",
+        { tier: "edge" },
       );
 
       const rowsAfterCreate = await waitForRows(clientB, queryAllTodos, (rows) =>
@@ -1237,7 +1269,7 @@ describe("cloud-server integration (Jazz TS)", () => {
       const createdRow = rowsAfterCreate.find((row) => row.id === rowId);
       expect(createdRow?.values[0]).toEqual({ type: "Text", value: "shared-item" });
 
-      await clientA.updateWithAck(rowId, { done: { type: "Boolean", value: true } }, "edge");
+      await clientA.update(rowId, { done: { type: "Boolean", value: true } }, { tier: "edge" });
       const rowsAfterUpdate = await waitForRows(clientB, queryAllTodos, (rows) => {
         const row = rows.find((r) => r.id === rowId);
         return Boolean(row && row.values[1]?.type === "Boolean" && row.values[1].value === true);
@@ -1245,7 +1277,7 @@ describe("cloud-server integration (Jazz TS)", () => {
       const updatedRow = rowsAfterUpdate.find((row) => row.id === rowId);
       expect(updatedRow?.values[1]).toEqual({ type: "Boolean", value: true });
 
-      await clientA.deleteWithAck(rowId, "edge");
+      await clientA.delete(rowId, { tier: "edge" });
       await waitForRows(clientB, queryAllTodos, (rows) => !rows.some((row) => row.id === rowId));
     } finally {
       if (clientA) await clientA.shutdown();
@@ -1289,13 +1321,13 @@ describe("cloud-server integration (Jazz TS)", () => {
         writer = await connectClient(
           makeContext(app.app_id, server.baseUrl, signJwt("writer", JWT_SECRET)),
         );
-        await writer.createWithAck(
+        await writer.create(
           "todos",
           [
             { type: "Text", value: "persisted-item" },
             { type: "Boolean", value: false },
           ],
-          "edge",
+          { tier: "edge" },
         );
         await waitForRows(writer, queryAllTodos, (rows) => rows.length >= 1, 15000);
         return app.app_id;
@@ -1405,21 +1437,21 @@ describe("Policy bypass: subscription without session skips PolicyFilterNode", (
         makeContext(app.app_id, server.baseUrl, signJwt("seed-user", JWT_SECRET), schema),
       );
 
-      await seeder.createWithAck(
+      await seeder.create(
         "owned_items",
         [
           { type: "Text", value: "bob-item" },
           { type: "Text", value: "bob" },
         ],
-        "edge",
+        { tier: "edge" },
       );
-      await seeder.createWithAck(
+      await seeder.create(
         "owned_items",
         [
           { type: "Text", value: "carol-item" },
           { type: "Text", value: "carol" },
         ],
-        "edge",
+        { tier: "edge" },
       );
 
       await seeder.shutdown();
@@ -1429,17 +1461,17 @@ describe("Policy bypass: subscription without session skips PolicyFilterNode", (
       aliceClient = await connectClient(
         makeContext(app.app_id, server.baseUrl, signJwt("alice", JWT_SECRET), schema),
       );
-      await aliceClient.createWithAck(
+      await aliceClient.create(
         "owned_items",
         [
           { type: "Text", value: "alice-item" },
           { type: "Text", value: "alice" },
         ],
-        "edge",
+        { tier: "edge" },
       );
 
       // Establish sync by fetching data without session first.
-      await aliceClient.queryInternal(queryAllItems, undefined, { settledTier: "edge" });
+      await aliceClient.queryInternal(queryAllItems, undefined, { tier: "edge" });
 
       // query() should only return alice's row.
       const queryRows = await waitForRows(aliceClient, queryAllItems, (rows) => rows.length >= 1);
@@ -1506,13 +1538,13 @@ describe("Policy bypass: subscription without session skips PolicyFilterNode", (
       aliceClient = await connectClient(
         makeContext(app.app_id, server.baseUrl, signJwt("alice", JWT_SECRET), schema),
       );
-      await aliceClient.createWithAck(
+      await aliceClient.create(
         "owned_items",
         [
           { type: "Text", value: "alice-item" },
           { type: "Text", value: "alice" },
         ],
-        "edge",
+        { tier: "edge" },
       );
 
       // Bob connects and queries WITHOUT a session (explicitly undefined).
@@ -1520,7 +1552,7 @@ describe("Policy bypass: subscription without session skips PolicyFilterNode", (
       bobClient = await connectClient(
         makeContext(app.app_id, server.baseUrl, signJwt("bob", JWT_SECRET), schema),
       );
-      const rows = await bobClient.queryInternal(queryAllItems, undefined, { settledTier: "edge" });
+      const rows = await bobClient.queryInternal(queryAllItems, undefined, { tier: "edge" });
 
       // Server should fall back to Bob's connection-level session.
       // The hashed principal ID won't match Alice's ownerId, so zero rows.

--- a/packages/jazz-tools/src/runtime/context.ts
+++ b/packages/jazz-tools/src/runtime/context.ts
@@ -82,9 +82,14 @@ export interface AppContext {
   adminSecret?: string;
 
   /**
-   * Persistence tier for this node.
-   * Set for server nodes to enable ack emission.
+   * Durability tier identity for this node (or identities for multi-role nodes).
+   * Set for server nodes to enable durability notifications.
    * Clients typically leave this undefined.
    */
-  tier?: "worker" | "edge" | "core";
+  tier?: "worker" | "edge" | "global" | Array<"worker" | "edge" | "global">;
+
+  /**
+   * Default durability tier for reads and writes when no explicit tier is provided.
+   */
+  defaultDurabilityTier?: "worker" | "edge" | "global";
 }

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -17,7 +17,7 @@ import {
   JazzClient,
   loadWasmModule,
   type WasmModule,
-  type PersistenceTier,
+  type DurabilityTier,
   type QueryExecutionOptions,
   type QueryPropagation,
 } from "./client.js";
@@ -480,6 +480,7 @@ export class Db {
         localAuthMode: this.config.localAuthMode,
         localAuthToken: this.config.localAuthToken,
         adminSecret: this.config.adminSecret,
+        tier: this.worker ? undefined : "worker",
       });
 
       // In worker mode, set up the bridge for this client
@@ -917,159 +918,50 @@ export class Db {
   }
 
   /**
-   * Insert a new row into a table.
-   *
-   * This is a **synchronous** operation - the row is created immediately
-   * in the local WASM runtime. Sync to server happens asynchronously.
+   * Insert a new row into a table and wait for durability at the requested tier.
    *
    * @param table Table proxy from generated app module
    * @param data Init object with column values
-   * @returns The new row's ID (UUID string)
-   *
-   * @example
-   * ```typescript
-   * const id = db.insert(app.todos, { title: "Buy milk", done: false });
-   * ```
+   * @param options Optional durability tier override
+   * @returns Promise resolving to the new row's ID
    */
-  insert<T, Init>(table: TableProxy<T, Init>, data: Init): string {
-    const client = this.getClient(table._schema);
-    const values = toValueArray(data as Record<string, unknown>, table._schema, table._table);
-    return client.create(table._table, values);
-  }
-
-  /**
-   * Insert a new row and wait for acknowledgement at the specified tier.
-   *
-   * @param table Table proxy from generated app module
-   * @param data Init object with column values
-   * @param tier Acknowledgement tier to wait for
-   * @returns Promise resolving to the new row's ID when the tier acknowledges
-   *
-   * @example
-   * ```typescript
-   * const id = await db.insertWithAck(app.todos, { title: "Buy milk", done: false }, "edge");
-   * ```
-   */
-  async insertWithAck<T, Init>(
+  async insert<T, Init>(
     table: TableProxy<T, Init>,
     data: Init,
-    tier: PersistenceTier,
+    options?: { tier?: DurabilityTier },
   ): Promise<string> {
     const client = this.getClient(table._schema);
     await this.ensureBridgeReady();
     const values = toValueArray(data as Record<string, unknown>, table._schema, table._table);
-    return client.createWithAck(table._table, values, tier);
+    return client.create(table._table, values, options);
   }
 
   /**
-   * @deprecated Use insertWithAck().
+   * Update an existing row and wait for durability at the requested tier.
    */
-  async insertPersisted<T, Init>(
-    table: TableProxy<T, Init>,
-    data: Init,
-    tier: PersistenceTier,
-  ): Promise<string> {
-    return this.insertWithAck(table, data, tier);
-  }
-
-  /**
-   * Update an existing row.
-   *
-   * This is a **synchronous** operation - the row is updated immediately
-   * in the local WASM runtime. Sync to server happens asynchronously.
-   *
-   * @param table Table proxy from generated app module
-   * @param id Row ID to update
-   * @param data Partial object with fields to update
-   *
-   * @example
-   * ```typescript
-   * db.update(app.todos, id, { done: true });
-   * ```
-   */
-  update<T, Init>(table: TableProxy<T, Init>, id: string, data: Partial<Init>): void {
-    const client = this.getClient(table._schema);
-    const updates = toUpdateRecord(data as Record<string, unknown>, table._schema, table._table);
-    client.update(id, updates);
-  }
-
-  /**
-   * Update an existing row and wait for acknowledgement at the specified tier.
-   *
-   * @param table Table proxy from generated app module
-   * @param id Row ID to update
-   * @param data Partial object with fields to update
-   * @param tier Acknowledgement tier to wait for
-   */
-  async updateWithAck<T, Init>(
+  async update<T, Init>(
     table: TableProxy<T, Init>,
     id: string,
     data: Partial<Init>,
-    tier: PersistenceTier,
+    options?: { tier?: DurabilityTier },
   ): Promise<void> {
     const client = this.getClient(table._schema);
     await this.ensureBridgeReady();
     const updates = toUpdateRecord(data as Record<string, unknown>, table._schema, table._table);
-    await client.updateWithAck(id, updates, tier);
+    await client.update(id, updates, options);
   }
 
   /**
-   * @deprecated Use updateWithAck().
+   * Delete a row and wait for durability at the requested tier.
    */
-  async updatePersisted<T, Init>(
+  async deleteFrom<T, Init>(
     table: TableProxy<T, Init>,
     id: string,
-    data: Partial<Init>,
-    tier: PersistenceTier,
-  ): Promise<void> {
-    await this.updateWithAck(table, id, data, tier);
-  }
-
-  /**
-   * Delete a row.
-   *
-   * This is a **synchronous** operation - the row is deleted immediately
-   * in the local WASM runtime. Sync to server happens asynchronously.
-   *
-   * @param table Table proxy from generated app module
-   * @param id Row ID to delete
-   *
-   * @example
-   * ```typescript
-   * db.deleteFrom(app.todos, id);
-   * ```
-   */
-  deleteFrom<T, Init>(table: TableProxy<T, Init>, id: string): void {
-    const client = this.getClient(table._schema);
-    client.delete(id);
-  }
-
-  /**
-   * Delete a row and wait for acknowledgement at the specified tier.
-   *
-   * @param table Table proxy from generated app module
-   * @param id Row ID to delete
-   * @param tier Acknowledgement tier to wait for
-   */
-  async deleteFromWithAck<T, Init>(
-    table: TableProxy<T, Init>,
-    id: string,
-    tier: PersistenceTier,
+    options?: { tier?: DurabilityTier },
   ): Promise<void> {
     const client = this.getClient(table._schema);
     await this.ensureBridgeReady();
-    await client.deleteWithAck(id, tier);
-  }
-
-  /**
-   * @deprecated Use deleteFromWithAck().
-   */
-  async deleteFromPersisted<T, Init>(
-    table: TableProxy<T, Init>,
-    id: string,
-    tier: PersistenceTier,
-  ): Promise<void> {
-    await this.deleteFromWithAck(table, id, tier);
+    await client.delete(id, options);
   }
 
   /**
@@ -1155,7 +1047,7 @@ export class Db {
    * Execute a query and return the first matching row, or null.
    *
    * @param query QueryBuilder instance
-   * @param settledTier Optional tier to hold delivery until confirmed
+   * @param options Optional read durability options
    * @returns First matching typed object, or null if none found
    */
   async one<T>(query: QueryBuilder<T>, options?: QueryOptions): Promise<T | null> {

--- a/packages/jazz-tools/src/runtime/index.ts
+++ b/packages/jazz-tools/src/runtime/index.ts
@@ -2,9 +2,10 @@ export {
   JazzClient,
   type LinkExternalIdentityOptions,
   type LinkExternalIdentityResult,
+  type LocalUpdatesMode,
   SessionClient,
   loadWasmModule,
-  type PersistenceTier,
+  type DurabilityTier,
   type QueryExecutionOptions,
   type QueryInput,
   type QueryPropagation,
@@ -12,6 +13,7 @@ export {
   type Row,
   type Runtime,
   type SubscriptionCallback,
+  type WriteDurabilityOptions,
   type WasmModule,
 } from "./client.js";
 export type { AppContext, LocalAuthMode, Session } from "./context.js";

--- a/packages/jazz-tools/src/runtime/worker-bridge.test.ts
+++ b/packages/jazz-tools/src/runtime/worker-bridge.test.ts
@@ -65,9 +65,9 @@ function createRuntimeMock(): {
     query: async () => [],
     subscribe: () => 1,
     unsubscribe: () => undefined,
-    insertWithAck: async () => "id",
-    updateWithAck: async () => undefined,
-    deleteWithAck: async () => undefined,
+    insertDurable: async () => "id",
+    updateDurable: async () => undefined,
+    deleteDurable: async () => undefined,
     onSyncMessageReceived: (messageJson: string) => {
       receivedFromWorker.push(messageJson);
     },

--- a/packages/jazz-tools/src/subscriptions-orchestrator.integration.test.ts
+++ b/packages/jazz-tools/src/subscriptions-orchestrator.integration.test.ts
@@ -89,7 +89,7 @@ describe("SubscriptionsOrchestrator integration coverage", () => {
           observedSnapshots.push(delta.all);
         },
       });
-      const insertedId = db.insert(todosTable, { title: "first", done: false });
+      const insertedId = await db.insert(todosTable, { title: "first", done: false });
 
       await waitForCondition(
         () => observedSnapshots.some((snapshot) => snapshot.some((row) => row.id === insertedId)),
@@ -134,21 +134,21 @@ describe("SubscriptionsOrchestrator integration coverage", () => {
         },
       });
 
-      db.insert(todosTable, { title: "alpha", done: false });
+      await db.insert(todosTable, { title: "alpha", done: false });
       await waitForCondition(
         () => snapshots.some((rows) => rows.length === 1),
         5_000,
         "SO-I02 expected first snapshot",
       );
 
-      db.insert(todosTable, { title: "beta", done: false });
+      await db.insert(todosTable, { title: "beta", done: false });
       await waitForCondition(
         () => snapshots.some((rows) => rows.length === 2),
         5_000,
         "SO-I02 expected second snapshot",
       );
 
-      db.insert(todosTable, { title: "gamma", done: false });
+      await db.insert(todosTable, { title: "gamma", done: false });
       await waitForCondition(
         () => snapshots.some((rows) => rows.length === 3),
         5_000,
@@ -186,7 +186,7 @@ describe("SubscriptionsOrchestrator integration coverage", () => {
         },
       });
 
-      const insertedId = db.insert(todosTable, { title: "shared", done: false });
+      const insertedId = await db.insert(todosTable, { title: "shared", done: false });
       await waitForCondition(
         () => listenerA.length > 0 && listenerB.length > 0,
         5_000,
@@ -226,8 +226,8 @@ describe("SubscriptionsOrchestrator integration coverage", () => {
       });
 
       offA();
-      db.insert(todosTable, { title: "remaining-1", done: false });
-      db.insert(todosTable, { title: "remaining-2", done: true });
+      await db.insert(todosTable, { title: "remaining-1", done: false });
+      await db.insert(todosTable, { title: "remaining-2", done: true });
 
       await waitForCondition(
         () => listenerB.some((rows) => rows.length === 2),
@@ -257,7 +257,7 @@ describe("SubscriptionsOrchestrator integration coverage", () => {
         },
       });
 
-      db.insert(todosTable, { title: "before-shutdown", done: false });
+      await db.insert(todosTable, { title: "before-shutdown", done: false });
       await waitForCondition(
         () => events.length > 0,
         5_000,

--- a/packages/jazz-tools/src/subscriptions-orchestrator.ts
+++ b/packages/jazz-tools/src/subscriptions-orchestrator.ts
@@ -1,7 +1,7 @@
 import { SubscriptionManager, type SubscriptionDelta } from "./runtime/subscription-manager.js";
 import type { QueryBuilder, QueryOptions } from "./runtime/db.js";
 import type { Session } from "./runtime/context.js";
-import type { PersistenceTier } from "./runtime/client.js";
+import type { DurabilityTier } from "./runtime/client.js";
 
 type UseAllStatePending<T> = {
   status: "pending";
@@ -123,14 +123,14 @@ export function makeDeferred<T>(snapshot?: {
 
 interface QueryDefinition<T extends { id: string }> {
   query: QueryBuilder<T>;
-  tier?: PersistenceTier;
+  tier?: DurabilityTier;
   snapshot?: T[];
 }
 
 interface InternalCacheEntry<T extends { id: string }> {
   key: string;
   query: QueryBuilder<T>;
-  tier?: PersistenceTier;
+  tier?: DurabilityTier;
   state: UseAllState<T>;
   promise: TrackedPromise<T[]>;
   resolvefulfilled: (data: T[]) => void;
@@ -176,7 +176,7 @@ export class SubscriptionsOrchestrator {
 
   makeQueryKey<T extends { id: string }>(
     query: QueryBuilder<T>,
-    tier?: PersistenceTier,
+    tier?: DurabilityTier,
     snapshot?: T[],
   ): string {
     const key = `${this.config.appId}:${tier ?? "none"}:${query._build()}`;
@@ -293,7 +293,7 @@ export class SubscriptionsOrchestrator {
             this.scheduleCleanup(entry);
           }
         },
-        entry.tier ? { settledTier: entry.tier } : undefined,
+        entry.tier ? { tier: entry.tier } : undefined,
         this.session ?? undefined,
       );
     } catch (error) {

--- a/packages/jazz-tools/src/svelte/use-all.svelte.ts
+++ b/packages/jazz-tools/src/svelte/use-all.svelte.ts
@@ -1,6 +1,6 @@
 import { onDestroy } from "svelte";
 import type { QueryBuilder } from "../runtime/db.js";
-import type { PersistenceTier } from "../runtime/client.js";
+import type { DurabilityTier } from "../runtime/client.js";
 import { getJazzContext } from "./context.svelte.js";
 
 /**
@@ -30,7 +30,7 @@ export class QuerySubscription<T extends { id: string }> {
 
   #unsubscribe: (() => void) | null = null;
 
-  constructor(query: QueryBuilder<T>, tier?: PersistenceTier) {
+  constructor(query: QueryBuilder<T>, tier?: DurabilityTier) {
     const ctx = getJazzContext();
     this.current = tier ? undefined : [];
 
@@ -48,7 +48,7 @@ export class QuerySubscription<T extends { id: string }> {
             this.current = delta.all;
             this.loading = false;
           },
-          tier ? { settledTier: tier } : undefined,
+          tier ? { tier } : undefined,
         );
       } catch (e) {
         this.error = e instanceof Error ? e : new Error(String(e));

--- a/packages/jazz-tools/src/types/jazz-wasm.d.ts
+++ b/packages/jazz-tools/src/types/jazz-wasm.d.ts
@@ -1,0 +1,39 @@
+declare module "jazz-wasm" {
+  export default function init(input?: unknown): Promise<void>;
+  export function initSync(input?: unknown): void;
+
+  export class WasmRuntime {
+    constructor(schemaJson: string, appId: string, env: string, userBranch: string, tier?: string);
+
+    insert(table: string, values: unknown): string;
+    insertDurable(table: string, values: unknown, tier: string): Promise<string>;
+    update(objectId: string, values: unknown): void;
+    updateDurable(objectId: string, values: unknown, tier: string): Promise<void>;
+    delete(objectId: string): void;
+    deleteDurable(objectId: string, tier: string): Promise<void>;
+    query(
+      queryJson: string,
+      sessionJson?: string | null,
+      tier?: string | null,
+      optionsJson?: string | null,
+    ): Promise<unknown>;
+    subscribe(
+      queryJson: string,
+      onUpdate: Function,
+      sessionJson?: string | null,
+      tier?: string | null,
+      optionsJson?: string | null,
+    ): number;
+    unsubscribe(handle: number): void;
+    onSyncMessageReceived(messageJson: string): void;
+    onSyncMessageToSend(callback: Function): void;
+    addServer(): void;
+    removeServer(): void;
+    addClient(): string;
+    getSchema(): unknown;
+    getSchemaHash(): string;
+    close?(): void;
+    setClientRole?(clientId: string, role: string): void;
+    onSyncMessageReceivedFromClient?(clientId: string, messageJson: string): void;
+  }
+}

--- a/packages/jazz-tools/tests/browser/db.all.test.ts
+++ b/packages/jazz-tools/tests/browser/db.all.test.ts
@@ -248,12 +248,12 @@ describe("db.all browser integration", () => {
     return db;
   }
 
-  function seedTodosForConditions(db: Db): void {
-    const orgId = db.insert(orgs, { name: "Acme" });
-    const teamId = db.insert(teams, { name: "Core", org_id: orgId, parent_id: undefined });
-    const userId = db.insert(users, { name: "Alice", team_id: teamId });
+  async function seedTodosForConditions(db: Db): Promise<void> {
+    const orgId = await db.insert(orgs, { name: "Acme" });
+    const teamId = await db.insert(teams, { name: "Core", org_id: orgId, parent_id: undefined });
+    const userId = await db.insert(users, { name: "Alice", team_id: teamId });
 
-    db.insert(todos, {
+    await db.insert(todos, {
       title: "alpha",
       done: false,
       priority: 1,
@@ -261,7 +261,7 @@ describe("db.all browser integration", () => {
       tags: ["work", "backend"],
       payload: new Uint8Array([1, 2, 3]),
     });
-    db.insert(todos, {
+    await db.insert(todos, {
       title: "beta",
       done: true,
       priority: 2,
@@ -269,7 +269,7 @@ describe("db.all browser integration", () => {
       tags: ["home"],
       payload: new Uint8Array([4, 5, 6]),
     });
-    db.insert(todos, {
+    await db.insert(todos, {
       title: "gamma",
       done: true,
       priority: undefined,
@@ -287,7 +287,7 @@ describe("db.all browser integration", () => {
 
   beforeAll(async () => {
     conditionsDb = await createDb({ appId: "db-all-test", dbName: uniqueDbName("ops") });
-    seedTodosForConditions(conditionsDb);
+    await seedTodosForConditions(conditionsDb);
   });
 
   afterAll(async () => {
@@ -308,7 +308,7 @@ describe("db.all browser integration", () => {
   it("returns BYTEA columns as Uint8Array", async () => {
     const db = track(await createDb({ appId: "db-all-test", dbName: uniqueDbName("bytea") }));
 
-    const id = db.insert(todos, {
+    const id = await db.insert(todos, {
       title: "has-bytes",
       done: false,
       priority: 1,
@@ -331,21 +331,21 @@ describe("db.all browser integration", () => {
   it("supports orderBy + limit + offset", async () => {
     const db = track(await createDb({ appId: "db-all-test", dbName: uniqueDbName("paginate") }));
 
-    db.insert(todos, {
+    await db.insert(todos, {
       title: "p1",
       done: false,
       priority: 1,
       owner_id: undefined,
       tags: ["x"],
     });
-    db.insert(todos, {
+    await db.insert(todos, {
       title: "p2",
       done: false,
       priority: 2,
       owner_id: undefined,
       tags: ["x"],
     });
-    db.insert(todos, {
+    await db.insert(todos, {
       title: "p3",
       done: false,
       priority: 3,
@@ -369,17 +369,17 @@ describe("db.all browser integration", () => {
   it("supports include relations", async () => {
     const db = track(await createDb({ appId: "db-all-test", dbName: uniqueDbName("include") }));
 
-    const orgId = db.insert(orgs, { name: "Acme" });
-    const teamId = db.insert(teams, { name: "Core", org_id: orgId, parent_id: undefined });
-    const ownerId = db.insert(users, { name: "Owner", team_id: teamId });
-    db.insert(todos, {
+    const orgId = await db.insert(orgs, { name: "Acme" });
+    const teamId = await db.insert(teams, { name: "Core", org_id: orgId, parent_id: undefined });
+    const ownerId = await db.insert(users, { name: "Owner", team_id: teamId });
+    await db.insert(todos, {
       title: "with-owner-1",
       done: false,
       priority: 1,
       owner_id: ownerId,
       tags: ["x"],
     });
-    db.insert(todos, {
+    await db.insert(todos, {
       title: "with-owner-2",
       done: true,
       priority: 2,
@@ -411,9 +411,9 @@ describe("db.all browser integration", () => {
   it("supports multi-hop queries", async () => {
     const db = track(await createDb({ appId: "db-all-test", dbName: uniqueDbName("hops") }));
 
-    const orgId = db.insert(orgs, { name: "Org A" });
-    const teamId = db.insert(teams, { name: "Team A", org_id: orgId, parent_id: undefined });
-    const userId = db.insert(users, { name: "User A", team_id: teamId });
+    const orgId = await db.insert(orgs, { name: "Org A" });
+    const teamId = await db.insert(teams, { name: "Team A", org_id: orgId, parent_id: undefined });
+    const userId = await db.insert(users, { name: "User A", team_id: teamId });
 
     const rows = await db.all<Org>(
       makeQuery<Org>("users", {
@@ -429,13 +429,13 @@ describe("db.all browser integration", () => {
   it("supports one-off all queries across scalar and UUID[] foreign-key hops", async () => {
     const db = track(await createDb({ appId: "db-all-test", dbName: uniqueDbName("fk-hops") }));
 
-    const orgId = db.insert(orgs, { name: "FK Org" });
-    const teamId = db.insert(teams, { name: "FK Team", org_id: orgId, parent_id: undefined });
-    const userId = db.insert(users, { name: "FK User", team_id: teamId });
+    const orgId = await db.insert(orgs, { name: "FK Org" });
+    const teamId = await db.insert(teams, { name: "FK Team", org_id: orgId, parent_id: undefined });
+    const userId = await db.insert(users, { name: "FK User", team_id: teamId });
 
-    const partAId = db.insert(fileParts, { label: "A" });
-    const partBId = db.insert(fileParts, { label: "B" });
-    const fileId = db.insert(files, { name: "File 1", parts: [partBId, partAId] });
+    const partAId = await db.insert(fileParts, { label: "A" });
+    const partBId = await db.insert(fileParts, { label: "B" });
+    const fileId = await db.insert(files, { name: "File 1", parts: [partBId, partAId] });
 
     const teamRows = await db.all<Team>(
       makeQuery<Team>("users", {
@@ -459,9 +459,13 @@ describe("db.all browser integration", () => {
   it("supports gather queries", async () => {
     const db = track(await createDb({ appId: "db-all-test", dbName: uniqueDbName("gather") }));
 
-    const rootId = db.insert(teams, { name: "root", org_id: undefined, parent_id: undefined });
-    const midId = db.insert(teams, { name: "mid", org_id: undefined, parent_id: rootId });
-    const leafId = db.insert(teams, { name: "leaf", org_id: undefined, parent_id: midId });
+    const rootId = await db.insert(teams, {
+      name: "root",
+      org_id: undefined,
+      parent_id: undefined,
+    });
+    const midId = await db.insert(teams, { name: "mid", org_id: undefined, parent_id: rootId });
+    const leafId = await db.insert(teams, { name: "leaf", org_id: undefined, parent_id: midId });
 
     const rows = await db.all<Team>(
       makeQuery<Team>("teams", {

--- a/packages/jazz-tools/tests/browser/db.subscribeAll.sort.test.ts
+++ b/packages/jazz-tools/tests/browser/db.subscribeAll.sort.test.ts
@@ -98,10 +98,10 @@ describe("db.subscribeAll sorting browser integration", () => {
       });
 
       try {
-        const idA = db.insert(todos, { title: "A", rank: 10, done: false });
-        const idB = db.insert(todos, { title: "B", rank: 20, done: false });
-        const idC = db.insert(todos, { title: "C", rank: 30, done: false });
-        const idD = db.insert(todos, { title: "D", rank: 40, done: false });
+        const idA = await db.insert(todos, { title: "A", rank: 10, done: false });
+        const idB = await db.insert(todos, { title: "B", rank: 20, done: false });
+        const idC = await db.insert(todos, { title: "C", rank: 30, done: false });
+        const idD = await db.insert(todos, { title: "D", rank: 40, done: false });
 
         await waitForCondition(
           () => latestRows(deltas.map((delta) => delta.all)).length === 4,
@@ -110,7 +110,7 @@ describe("db.subscribeAll sorting browser integration", () => {
         );
         expect(latestIds(deltas.map((delta) => delta.all))).toEqual([idA, idB, idC, idD]);
 
-        db.update(todos, idD, { rank: 15 });
+        await db.update(todos, idD, { rank: 15 });
 
         await waitForCondition(
           () => {
@@ -140,9 +140,9 @@ describe("db.subscribeAll sorting browser integration", () => {
       });
 
       try {
-        const idA = db.insert(todos, { title: "A", rank: 1, done: false });
-        const idB = db.insert(todos, { title: "B", rank: 2, done: false });
-        const idC = db.insert(todos, { title: "C", rank: 3, done: false });
+        const idA = await db.insert(todos, { title: "A", rank: 1, done: false });
+        const idB = await db.insert(todos, { title: "B", rank: 2, done: false });
+        const idC = await db.insert(todos, { title: "C", rank: 3, done: false });
 
         await waitForCondition(
           () => deltas.some((delta) => delta.all.length === 3),
@@ -153,7 +153,7 @@ describe("db.subscribeAll sorting browser integration", () => {
         const before = deltas[deltas.length - 1].all.map((row) => row.id);
         expect(before).toEqual([idA, idB, idC]);
 
-        db.update(todos, idB, { title: "B-updated" });
+        await db.update(todos, idB, { title: "B-updated" });
 
         await waitForCondition(
           () => deltas.some((delta) => hasUpdateForId(delta, idB)),
@@ -177,9 +177,9 @@ describe("db.subscribeAll sorting browser integration", () => {
       });
 
       try {
-        const idA = db.insert(todos, { title: "A", rank: 1, done: false });
-        const idB = db.insert(todos, { title: "B", rank: 2, done: false });
-        const idC = db.insert(todos, { title: "C", rank: 3, done: false });
+        const idA = await db.insert(todos, { title: "A", rank: 1, done: false });
+        const idB = await db.insert(todos, { title: "B", rank: 2, done: false });
+        const idC = await db.insert(todos, { title: "C", rank: 3, done: false });
 
         await waitForCondition(
           () => snapshots.some((rows) => rows.length === 3),
@@ -187,7 +187,7 @@ describe("db.subscribeAll sorting browser integration", () => {
           "expected initial sorted rows",
         );
 
-        db.update(todos, idA, { rank: 10 });
+        await db.update(todos, idA, { rank: 10 });
 
         await waitForCondition(
           () => {
@@ -213,9 +213,9 @@ describe("db.subscribeAll sorting browser integration", () => {
       });
 
       try {
-        const idA = db.insert(todos, { title: "A", rank: 1, done: false });
-        const idB = db.insert(todos, { title: "B", rank: 2, done: false });
-        const idC = db.insert(todos, { title: "C", rank: 3, done: false });
+        const idA = await db.insert(todos, { title: "A", rank: 1, done: false });
+        const idB = await db.insert(todos, { title: "B", rank: 2, done: false });
+        const idC = await db.insert(todos, { title: "C", rank: 3, done: false });
 
         await waitForCondition(
           () => snapshots.some((rows) => rows.length === 3),
@@ -223,7 +223,7 @@ describe("db.subscribeAll sorting browser integration", () => {
           "expected initial sorted rows",
         );
 
-        db.deleteFrom(todos, idB);
+        await db.deleteFrom(todos, idB);
 
         await waitForCondition(
           () => {
@@ -249,9 +249,9 @@ describe("db.subscribeAll sorting browser integration", () => {
       });
 
       try {
-        const idA = db.insert(todos, { title: "A", rank: 10, done: false });
-        const idB = db.insert(todos, { title: "B", rank: 5, done: false });
-        const idC = db.insert(todos, { title: "C", rank: 1, done: false });
+        const idA = await db.insert(todos, { title: "A", rank: 10, done: false });
+        const idB = await db.insert(todos, { title: "B", rank: 5, done: false });
+        const idC = await db.insert(todos, { title: "C", rank: 1, done: false });
 
         await waitForCondition(
           () => latestRows(snapshots).length === 3,
@@ -262,7 +262,7 @@ describe("db.subscribeAll sorting browser integration", () => {
         const expectedById = [idA, idB, idC].toSorted((a, b) => a.localeCompare(b));
         expect(latestIds(snapshots)).toEqual(expectedById);
 
-        db.update(todos, idB, { title: "B-still" });
+        await db.update(todos, idB, { title: "B-still" });
 
         await waitForCondition(
           () => latestRows(snapshots).some((row) => row.id === idB && row.title === "B-still"),
@@ -288,9 +288,9 @@ describe("db.subscribeAll sorting browser integration", () => {
       );
 
       try {
-        const idA = db.insert(todos, { title: "A", rank: 1, done: false });
-        const idB = db.insert(todos, { title: "B", rank: 2, done: false });
-        const idC = db.insert(todos, { title: "C", rank: 3, done: false });
+        const idA = await db.insert(todos, { title: "A", rank: 1, done: false });
+        const idB = await db.insert(todos, { title: "B", rank: 2, done: false });
+        const idC = await db.insert(todos, { title: "C", rank: 3, done: false });
 
         await waitForCondition(
           () => latestRows(snapshots).length === 3,
@@ -299,7 +299,7 @@ describe("db.subscribeAll sorting browser integration", () => {
         );
         expect(latestIds(snapshots)).toEqual([idC, idB, idA]);
 
-        db.update(todos, idA, { rank: 10 });
+        await db.update(todos, idA, { rank: 10 });
 
         await waitForCondition(
           () => latestRows(snapshots)[0]?.id === idA,
@@ -322,9 +322,9 @@ describe("db.subscribeAll sorting browser integration", () => {
       });
 
       try {
-        const idA = db.insert(todos, { title: "A", rank: 1, done: false });
-        const idB = db.insert(todos, { title: "B", rank: 1, done: false });
-        const idC = db.insert(todos, { title: "C", rank: 1, done: false });
+        const idA = await db.insert(todos, { title: "A", rank: 1, done: false });
+        const idB = await db.insert(todos, { title: "B", rank: 1, done: false });
+        const idC = await db.insert(todos, { title: "C", rank: 1, done: false });
 
         await waitForCondition(
           () => latestRows(snapshots).length === 3,
@@ -356,9 +356,9 @@ describe("db.subscribeAll sorting browser integration", () => {
       );
 
       try {
-        const idA = db.insert(todos, { title: "A", rank: 1, done: false });
-        const idZ = db.insert(todos, { title: "Z", rank: 1, done: false });
-        const idM = db.insert(todos, { title: "M", rank: 2, done: false });
+        const idA = await db.insert(todos, { title: "A", rank: 1, done: false });
+        const idZ = await db.insert(todos, { title: "Z", rank: 1, done: false });
+        const idM = await db.insert(todos, { title: "M", rank: 2, done: false });
 
         await waitForCondition(
           () => latestRows(snapshots).length === 3,
@@ -367,7 +367,7 @@ describe("db.subscribeAll sorting browser integration", () => {
         );
         expect(latestIds(snapshots)).toEqual([idZ, idA, idM]);
 
-        db.update(todos, idM, { rank: 1 });
+        await db.update(todos, idM, { rank: 1 });
 
         await waitForCondition(
           () => latestRows(snapshots).length === 3 && latestRows(snapshots)[1]?.id === idM,
@@ -390,9 +390,9 @@ describe("db.subscribeAll sorting browser integration", () => {
       });
 
       try {
-        const idA = db.insert(todos, { title: "A", rank: 1, done: false });
-        const idB = db.insert(todos, { title: "B", rank: 2, done: false });
-        const idC = db.insert(todos, { title: "C", rank: 3, done: false });
+        const idA = await db.insert(todos, { title: "A", rank: 1, done: false });
+        const idB = await db.insert(todos, { title: "B", rank: 2, done: false });
+        const idC = await db.insert(todos, { title: "C", rank: 3, done: false });
 
         await waitForCondition(
           () => latestRows(snapshots).length === 3,
@@ -402,7 +402,7 @@ describe("db.subscribeAll sorting browser integration", () => {
         const before = latestIds(snapshots);
         expect(before).toEqual([idA, idB, idC]);
 
-        db.update(todos, idB, { rank: 2 });
+        await db.update(todos, idB, { rank: 2 });
 
         await waitForCondition(
           () => latestRows(snapshots).some((row) => row.id === idB && row.rank === 2),
@@ -428,10 +428,10 @@ describe("db.subscribeAll sorting browser integration", () => {
       );
 
       try {
-        const idA = db.insert(todos, { title: "A", rank: 1, done: false });
-        const idB = db.insert(todos, { title: "B", rank: 2, done: false });
-        const idC = db.insert(todos, { title: "C", rank: 3, done: false });
-        const idD = db.insert(todos, { title: "D", rank: 4, done: false });
+        const idA = await db.insert(todos, { title: "A", rank: 1, done: false });
+        const idB = await db.insert(todos, { title: "B", rank: 2, done: false });
+        const idC = await db.insert(todos, { title: "C", rank: 3, done: false });
+        const idD = await db.insert(todos, { title: "D", rank: 4, done: false });
 
         await waitForCondition(
           () => latestRows(snapshots).length === 2,
@@ -440,7 +440,7 @@ describe("db.subscribeAll sorting browser integration", () => {
         );
         expect(latestIds(snapshots)).toEqual([idB, idC]);
 
-        db.update(todos, idD, { rank: 0 });
+        await db.update(todos, idD, { rank: 0 });
 
         await waitForCondition(
           () => {
@@ -466,9 +466,9 @@ describe("db.subscribeAll sorting browser integration", () => {
       });
 
       try {
-        const idA = db.insert(todos, { title: "A", rank: 1, done: false });
-        const idB = db.insert(todos, { title: "B", rank: 2, done: false });
-        const idC = db.insert(todos, { title: "C", rank: 3, done: false });
+        const idA = await db.insert(todos, { title: "A", rank: 1, done: false });
+        const idB = await db.insert(todos, { title: "B", rank: 2, done: false });
+        const idC = await db.insert(todos, { title: "C", rank: 3, done: false });
 
         await waitForCondition(
           () => latestRows(snapshots).length === 3,
@@ -476,9 +476,9 @@ describe("db.subscribeAll sorting browser integration", () => {
           "expected initial rows",
         );
 
-        db.update(todos, idC, { rank: 0 });
-        db.deleteFrom(todos, idA);
-        const idD = db.insert(todos, { title: "D", rank: 2, done: false });
+        await db.update(todos, idC, { rank: 0 });
+        await db.deleteFrom(todos, idA);
+        const idD = await db.insert(todos, { title: "D", rank: 2, done: false });
 
         await waitForCondition(
           () => {
@@ -505,8 +505,8 @@ describe("db.subscribeAll sorting browser integration", () => {
       });
 
       try {
-        const idB = db.insert(todos, { title: "B", rank: 20, done: false });
-        const idD = db.insert(todos, { title: "D", rank: 40, done: false });
+        const idB = await db.insert(todos, { title: "B", rank: 20, done: false });
+        const idD = await db.insert(todos, { title: "D", rank: 40, done: false });
 
         await waitForCondition(
           () => latestRows(snapshots).length === 2,
@@ -515,14 +515,14 @@ describe("db.subscribeAll sorting browser integration", () => {
         );
         expect(latestIds(snapshots)).toEqual([idB, idD]);
 
-        const idA = db.insert(todos, { title: "A", rank: 10, done: false });
+        const idA = await db.insert(todos, { title: "A", rank: 10, done: false });
         await waitForCondition(
           () => latestRows(snapshots)[0]?.id === idA,
           10_000,
           "expected top insert to appear first",
         );
 
-        const idC = db.insert(todos, { title: "C", rank: 30, done: false });
+        const idC = await db.insert(todos, { title: "C", rank: 30, done: false });
         await waitForCondition(
           () => {
             const ids = latestIds(snapshots);
@@ -532,7 +532,7 @@ describe("db.subscribeAll sorting browser integration", () => {
           "expected middle insert to appear in middle",
         );
 
-        const idE = db.insert(todos, { title: "E", rank: 50, done: false });
+        const idE = await db.insert(todos, { title: "E", rank: 50, done: false });
         await waitForCondition(
           () => latestRows(snapshots)[4]?.id === idE,
           10_000,
@@ -551,9 +551,9 @@ describe("db.subscribeAll sorting browser integration", () => {
     const dbName = uniqueDbName("restart");
 
     const db1 = await createDb({ appId, dbName });
-    const idA = db1.insert(todos, { title: "A", rank: 3, done: false });
-    const idB = db1.insert(todos, { title: "B", rank: 1, done: false });
-    const idC = db1.insert(todos, { title: "C", rank: 2, done: false });
+    const idA = await db1.insert(todos, { title: "A", rank: 3, done: false });
+    const idB = await db1.insert(todos, { title: "B", rank: 1, done: false });
+    const idC = await db1.insert(todos, { title: "C", rank: 2, done: false });
     await db1.shutdown();
 
     const db2 = await createDb({ appId, dbName });
@@ -584,9 +584,9 @@ describe("db.subscribeAll sorting browser integration", () => {
       });
 
       try {
-        const idNull = db.insert(todos, { title: "N", rank: undefined, done: false });
-        const idOne = db.insert(todos, { title: "A", rank: 1, done: false });
-        const idTwo = db.insert(todos, { title: "B", rank: 2, done: false });
+        const idNull = await db.insert(todos, { title: "N", rank: undefined, done: false });
+        const idOne = await db.insert(todos, { title: "A", rank: 1, done: false });
+        const idTwo = await db.insert(todos, { title: "B", rank: 2, done: false });
 
         await waitForCondition(
           () => latestRows(snapshots).length === 3,
@@ -597,7 +597,7 @@ describe("db.subscribeAll sorting browser integration", () => {
         const initial = latestIds(snapshots);
         expect(initial).toEqual(expect.arrayContaining([idNull, idOne, idTwo]));
 
-        db.update(todos, idNull, { title: "N-updated" });
+        await db.update(todos, idNull, { title: "N-updated" });
 
         await waitForCondition(
           () => latestRows(snapshots).some((row) => row.id === idNull && row.title === "N-updated"),
@@ -623,9 +623,9 @@ describe("db.subscribeAll sorting browser integration", () => {
       );
 
       try {
-        const idA = db.insert(todos, { title: "A", rank: 3, done: false });
-        const idB = db.insert(todos, { title: "B", rank: 2, done: false });
-        const idC = db.insert(todos, { title: "C", rank: 1, done: false });
+        const idA = await db.insert(todos, { title: "A", rank: 3, done: false });
+        const idB = await db.insert(todos, { title: "B", rank: 2, done: false });
+        const idC = await db.insert(todos, { title: "C", rank: 1, done: false });
 
         await waitForCondition(
           () => latestRows(snapshots).length === 3,
@@ -636,7 +636,7 @@ describe("db.subscribeAll sorting browser integration", () => {
         const expected = [idA, idB, idC].toSorted((a, b) => b.localeCompare(a));
         expect(latestIds(snapshots)).toEqual(expected);
 
-        db.update(todos, idB, { title: "B-updated" });
+        await db.update(todos, idB, { title: "B-updated" });
 
         await waitForCondition(
           () => latestRows(snapshots).some((row) => row.id === idB && row.title === "B-updated"),
@@ -662,10 +662,10 @@ describe("db.subscribeAll sorting browser integration", () => {
       );
 
       try {
-        const idA = db.insert(todos, { title: "A", rank: 1, done: false });
-        const idB = db.insert(todos, { title: "B", rank: 2, done: false });
-        const idC = db.insert(todos, { title: "C", rank: 3, done: false });
-        const idD = db.insert(todos, { title: "D", rank: 4, done: false });
+        const idA = await db.insert(todos, { title: "A", rank: 1, done: false });
+        const idB = await db.insert(todos, { title: "B", rank: 2, done: false });
+        const idC = await db.insert(todos, { title: "C", rank: 3, done: false });
+        const idD = await db.insert(todos, { title: "D", rank: 4, done: false });
 
         await waitForCondition(
           () => latestRows(snapshots).length === 2,
@@ -674,7 +674,7 @@ describe("db.subscribeAll sorting browser integration", () => {
         );
         expect(latestIds(snapshots)).toEqual([idB, idC]);
 
-        db.deleteFrom(todos, idA);
+        await db.deleteFrom(todos, idA);
 
         await waitForCondition(
           () => {
@@ -708,9 +708,9 @@ describe("db.subscribeAll sorting browser integration", () => {
       );
 
       try {
-        const idA = db.insert(todos, { title: "A", rank: 1, done: false });
-        const idB = db.insert(todos, { title: "B", rank: 1, done: false });
-        const idC = db.insert(todos, { title: "C", rank: 2, done: false });
+        const idA = await db.insert(todos, { title: "A", rank: 1, done: false });
+        const idB = await db.insert(todos, { title: "B", rank: 1, done: false });
+        const idC = await db.insert(todos, { title: "C", rank: 2, done: false });
 
         await waitForCondition(
           () => latestRows(snapshots).length === 3,
@@ -721,7 +721,7 @@ describe("db.subscribeAll sorting browser integration", () => {
         const expectedTieOrder = [idA, idB].toSorted((a, b) => b.localeCompare(a));
         expect(latestIds(snapshots)).toEqual([...expectedTieOrder, idC]);
 
-        db.update(todos, idC, { rank: 1 });
+        await db.update(todos, idC, { rank: 1 });
 
         await waitForCondition(
           () =>

--- a/packages/jazz-tools/tests/browser/db.subscribeAll.test.ts
+++ b/packages/jazz-tools/tests/browser/db.subscribeAll.test.ts
@@ -365,7 +365,7 @@ describe("db.subscribeAll browser integration", () => {
       ),
     );
 
-    const id = db.insert(todos, {
+    const id = await db.insert(todos, {
       title: "watch-me",
       done: false,
       priority: 1,
@@ -379,7 +379,7 @@ describe("db.subscribeAll browser integration", () => {
       "expected add delta",
     );
 
-    db.update(todos, id, { title: "watch-me-updated" });
+    await db.update(todos, id, { title: "watch-me-updated" });
 
     await waitForCondition(
       () => deltas.some((delta) => hasChangeForId(delta, 2, id)),
@@ -387,7 +387,7 @@ describe("db.subscribeAll browser integration", () => {
       "expected update delta",
     );
 
-    db.update(todos, id, { done: true });
+    await db.update(todos, id, { done: true });
 
     await waitForCondition(
       () => deltas.some((delta) => hasChangeForId(delta, 1, id)),
@@ -410,7 +410,7 @@ describe("db.subscribeAll browser integration", () => {
         }),
       );
 
-      const insertedId = conditionsDb.insert(todos, testCase.insert);
+      const insertedId = await conditionsDb.insert(todos, testCase.insert);
 
       await waitForCondition(
         () => deltas.some((delta) => hasChangeForId(delta, 0, insertedId)),
@@ -435,7 +435,7 @@ describe("db.subscribeAll browser integration", () => {
       ),
     );
 
-    const id = db.insert(todos, {
+    const id = await db.insert(todos, {
       title: "bytes-hit",
       done: false,
       priority: 1,
@@ -472,21 +472,21 @@ describe("db.subscribeAll browser integration", () => {
       ),
     );
 
-    db.insert(todos, {
+    await db.insert(todos, {
       title: "p1",
       done: false,
       priority: 1,
       owner_id: undefined,
       tags: ["x"],
     });
-    db.insert(todos, {
+    await db.insert(todos, {
       title: "p2",
       done: false,
       priority: 2,
       owner_id: undefined,
       tags: ["x"],
     });
-    db.insert(todos, {
+    await db.insert(todos, {
       title: "p3",
       done: false,
       priority: 3,
@@ -518,7 +518,7 @@ describe("db.subscribeAll browser integration", () => {
       ),
     );
 
-    const insertedId = db.insert(todos, {
+    const insertedId = await db.insert(todos, {
       title: "completely unrelated",
       done: false,
       priority: 1,
@@ -547,7 +547,7 @@ describe("db.subscribeAll browser integration", () => {
       ),
     );
 
-    const userId = db.insert(users, { name: "Owner", team_id: undefined });
+    const userId = await db.insert(users, { name: "Owner", team_id: undefined });
 
     await waitForCondition(
       () => deltas.some((delta) => hasChangeForId(delta, 0, userId)),
@@ -571,9 +571,13 @@ describe("db.subscribeAll browser integration", () => {
       ),
     );
 
-    const orgId = db.insert(orgs, { name: "Hop Org" });
-    const teamId = db.insert(teams, { name: "Hop Team", org_id: orgId, parent_id: undefined });
-    db.insert(users, { name: "Hop User", team_id: teamId });
+    const orgId = await db.insert(orgs, { name: "Hop Org" });
+    const teamId = await db.insert(teams, {
+      name: "Hop Team",
+      org_id: orgId,
+      parent_id: undefined,
+    });
+    await db.insert(users, { name: "Hop User", team_id: teamId });
 
     await waitForCondition(
       () =>
@@ -590,11 +594,19 @@ describe("db.subscribeAll browser integration", () => {
       await createDb({ appId: "db-subscribe-test", dbName: uniqueDbName("scalar-fk-update") }),
     );
 
-    const orgAId = db.insert(orgs, { name: "Org A" });
-    const orgBId = db.insert(orgs, { name: "Org B" });
-    const teamAId = db.insert(teams, { name: "Team A", org_id: orgAId, parent_id: undefined });
-    const teamBId = db.insert(teams, { name: "Team B", org_id: orgBId, parent_id: undefined });
-    const userId = db.insert(users, { name: "Mover", team_id: teamAId });
+    const orgAId = await db.insert(orgs, { name: "Org A" });
+    const orgBId = await db.insert(orgs, { name: "Org B" });
+    const teamAId = await db.insert(teams, {
+      name: "Team A",
+      org_id: orgAId,
+      parent_id: undefined,
+    });
+    const teamBId = await db.insert(teams, {
+      name: "Team B",
+      org_id: orgBId,
+      parent_id: undefined,
+    });
+    const userId = await db.insert(users, { name: "Mover", team_id: teamAId });
 
     const deltas: Array<SubscriptionDelta<Team>> = [];
     const unsubscribe = trackUnsubscribe(
@@ -616,7 +628,7 @@ describe("db.subscribeAll browser integration", () => {
       "expected initial team hop result",
     );
 
-    db.update(users, userId, { team_id: teamBId });
+    await db.update(users, userId, { team_id: teamBId });
 
     await waitForCondition(
       () => {
@@ -638,9 +650,9 @@ describe("db.subscribeAll browser integration", () => {
       await createDb({ appId: "db-subscribe-test", dbName: uniqueDbName("array-fk-update") }),
     );
 
-    const partAId = db.insert(fileParts, { label: "A" });
-    const partBId = db.insert(fileParts, { label: "B" });
-    const fileId = db.insert(files, { name: "File", parts: [partAId] });
+    const partAId = await db.insert(fileParts, { label: "A" });
+    const partBId = await db.insert(fileParts, { label: "B" });
+    const fileId = await db.insert(files, { name: "File", parts: [partAId] });
 
     const deltas: Array<SubscriptionDelta<FilePart>> = [];
     const unsubscribe = trackUnsubscribe(
@@ -662,7 +674,7 @@ describe("db.subscribeAll browser integration", () => {
       "expected initial UUID[] hop result",
     );
 
-    db.update(files, fileId, { parts: [partBId] });
+    await db.update(files, fileId, { parts: [partBId] });
 
     await waitForCondition(
       () => {
@@ -701,9 +713,13 @@ describe("db.subscribeAll browser integration", () => {
       ),
     );
 
-    const rootId = db.insert(teams, { name: "root", org_id: undefined, parent_id: undefined });
-    const midId = db.insert(teams, { name: "mid", org_id: undefined, parent_id: rootId });
-    const leafId = db.insert(teams, { name: "leaf", org_id: undefined, parent_id: midId });
+    const rootId = await db.insert(teams, {
+      name: "root",
+      org_id: undefined,
+      parent_id: undefined,
+    });
+    const midId = await db.insert(teams, { name: "mid", org_id: undefined, parent_id: rootId });
+    const leafId = await db.insert(teams, { name: "leaf", org_id: undefined, parent_id: midId });
 
     await waitForCondition(
       () => {

--- a/packages/jazz-tools/tests/browser/useAll.test.tsx
+++ b/packages/jazz-tools/tests/browser/useAll.test.tsx
@@ -327,7 +327,7 @@ describe("useAll browser integration", () => {
         </JazzProvider>,
       );
 
-      conditionsClient.db.insert(todos, testCase.insert);
+      await conditionsClient.db.insert(todos, testCase.insert);
 
       await waitForCondition(
         () => getText("rows").split("|").includes(testCase.pick),
@@ -357,21 +357,21 @@ describe("useAll browser integration", () => {
       </JazzProvider>,
     );
 
-    client.db.insert(todos, {
+    await client.db.insert(todos, {
       title: "p1",
       done: false,
       priority: 1,
       owner_id: undefined,
       tags: ["x"],
     });
-    client.db.insert(todos, {
+    await client.db.insert(todos, {
       title: "p2",
       done: false,
       priority: 2,
       owner_id: undefined,
       tags: ["x"],
     });
-    client.db.insert(todos, {
+    await client.db.insert(todos, {
       title: "p3",
       done: false,
       priority: 3,
@@ -401,7 +401,7 @@ describe("useAll browser integration", () => {
       </JazzProvider>,
     );
 
-    client.db.insert(todos, {
+    await client.db.insert(todos, {
       title: "completely unrelated",
       done: false,
       priority: 1,
@@ -431,8 +431,8 @@ describe("useAll browser integration", () => {
       </JazzProvider>,
     );
 
-    const userId = client.db.insert(users, { name: "Owner", team_id: undefined });
-    client.db.insert(todos, {
+    const userId = await client.db.insert(users, { name: "Owner", team_id: undefined });
+    await client.db.insert(todos, {
       title: "owned-todo",
       done: false,
       priority: 1,
@@ -465,13 +465,13 @@ describe("useAll browser integration", () => {
       </JazzProvider>,
     );
 
-    const orgId = client.db.insert(orgs, { name: "Hop Org" });
-    const teamId = client.db.insert(teams, {
+    const orgId = await client.db.insert(orgs, { name: "Hop Org" });
+    const teamId = await client.db.insert(teams, {
       name: "Hop Team",
       org_id: orgId,
       parent_id: undefined,
     });
-    client.db.insert(users, { name: "Hop User", team_id: teamId });
+    await client.db.insert(users, { name: "Hop User", team_id: teamId });
 
     await waitForCondition(
       () => getText("rows").includes("Hop Org"),
@@ -505,13 +505,17 @@ describe("useAll browser integration", () => {
       </JazzProvider>,
     );
 
-    const rootId = client.db.insert(teams, {
+    const rootId = await client.db.insert(teams, {
       name: "root",
       org_id: undefined,
       parent_id: undefined,
     });
-    const midId = client.db.insert(teams, { name: "mid", org_id: undefined, parent_id: rootId });
-    client.db.insert(teams, { name: "leaf", org_id: undefined, parent_id: midId });
+    const midId = await client.db.insert(teams, {
+      name: "mid",
+      org_id: undefined,
+      parent_id: rootId,
+    });
+    await client.db.insert(teams, { name: "leaf", org_id: undefined, parent_id: midId });
 
     await waitForCondition(
       () => {
@@ -531,14 +535,14 @@ describe("useAll browser integration", () => {
       }),
     );
 
-    client.db.insert(todos, {
+    await client.db.insert(todos, {
       title: "open-task",
       done: false,
       priority: 1,
       owner_id: undefined,
       tags: ["x"],
     });
-    client.db.insert(todos, {
+    await client.db.insert(todos, {
       title: "done-task",
       done: true,
       priority: 2,

--- a/packages/jazz-tools/tests/browser/useAllSuspense.test.tsx
+++ b/packages/jazz-tools/tests/browser/useAllSuspense.test.tsx
@@ -337,7 +337,7 @@ describe("useAllSuspense browser integration", () => {
       const preloadBeforeRender =
         testCase.name === "contains-text" || testCase.name === "contains-text-empty";
       if (preloadBeforeRender) {
-        conditionsClient.db.insert(todos, testCase.insert);
+        await conditionsClient.db.insert(todos, testCase.insert);
       }
 
       renderSuspense(
@@ -353,7 +353,7 @@ describe("useAllSuspense browser integration", () => {
       );
 
       if (!preloadBeforeRender) {
-        conditionsClient.db.insert(todos, testCase.insert);
+        await conditionsClient.db.insert(todos, testCase.insert);
       }
 
       await waitForCondition(
@@ -384,21 +384,21 @@ describe("useAllSuspense browser integration", () => {
       </JazzProvider>,
     );
 
-    client.db.insert(todos, {
+    await client.db.insert(todos, {
       title: "p1",
       done: false,
       priority: 1,
       owner_id: undefined,
       tags: ["x"],
     });
-    client.db.insert(todos, {
+    await client.db.insert(todos, {
       title: "p2",
       done: false,
       priority: 2,
       owner_id: undefined,
       tags: ["x"],
     });
-    client.db.insert(todos, {
+    await client.db.insert(todos, {
       title: "p3",
       done: false,
       priority: 3,
@@ -432,7 +432,7 @@ describe("useAllSuspense browser integration", () => {
       </JazzProvider>,
     );
 
-    client.db.insert(todos, {
+    await client.db.insert(todos, {
       title: "completely unrelated",
       done: false,
       priority: 1,
@@ -462,8 +462,8 @@ describe("useAllSuspense browser integration", () => {
       </JazzProvider>,
     );
 
-    const userId = client.db.insert(users, { name: "Owner", team_id: undefined });
-    client.db.insert(todos, {
+    const userId = await client.db.insert(users, { name: "Owner", team_id: undefined });
+    await client.db.insert(todos, {
       title: "owned-todo",
       done: false,
       priority: 1,
@@ -496,13 +496,13 @@ describe("useAllSuspense browser integration", () => {
       </JazzProvider>,
     );
 
-    const orgId = client.db.insert(orgs, { name: "Hop Org" });
-    const teamId = client.db.insert(teams, {
+    const orgId = await client.db.insert(orgs, { name: "Hop Org" });
+    const teamId = await client.db.insert(teams, {
       name: "Hop Team",
       org_id: orgId,
       parent_id: undefined,
     });
-    client.db.insert(users, { name: "Hop User", team_id: teamId });
+    await client.db.insert(users, { name: "Hop User", team_id: teamId });
 
     await waitForCondition(
       () => getText("rows").includes("Hop Org"),
@@ -536,13 +536,17 @@ describe("useAllSuspense browser integration", () => {
       </JazzProvider>,
     );
 
-    const rootId = client.db.insert(teams, {
+    const rootId = await client.db.insert(teams, {
       name: "root",
       org_id: undefined,
       parent_id: undefined,
     });
-    const midId = client.db.insert(teams, { name: "mid", org_id: undefined, parent_id: rootId });
-    client.db.insert(teams, { name: "leaf", org_id: undefined, parent_id: midId });
+    const midId = await client.db.insert(teams, {
+      name: "mid",
+      org_id: undefined,
+      parent_id: rootId,
+    });
+    await client.db.insert(teams, { name: "leaf", org_id: undefined, parent_id: midId });
 
     await waitForCondition(
       () => {
@@ -562,14 +566,14 @@ describe("useAllSuspense browser integration", () => {
       }),
     );
 
-    client.db.insert(todos, {
+    await client.db.insert(todos, {
       title: "open-task",
       done: false,
       priority: 1,
       owner_id: undefined,
       tags: ["x"],
     });
-    client.db.insert(todos, {
+    await client.db.insert(todos, {
       title: "done-task",
       done: true,
       priority: 2,

--- a/packages/jazz-tools/tests/browser/worker-bridge.test.ts
+++ b/packages/jazz-tools/tests/browser/worker-bridge.test.ts
@@ -317,7 +317,7 @@ describe("Worker Bridge with OPFS", () => {
     const db = track(await createDb({ appId: "test-app", dbName: uniqueDbName("insert-query") }));
 
     // Insert (sync — runs on main-thread in-memory runtime)
-    const id = db.insert(todos, { title: "Buy milk", done: false });
+    const id = await db.insert(todos, { title: "Buy milk", done: false });
     expect(id).toBeTruthy();
     expect(typeof id).toBe("string");
 
@@ -332,9 +332,9 @@ describe("Worker Bridge with OPFS", () => {
   it("inserts multiple rows and queries all", async () => {
     const db = track(await createDb({ appId: "test-app", dbName: uniqueDbName("multi-insert") }));
 
-    db.insert(todos, { title: "Task A", done: false });
-    db.insert(todos, { title: "Task B", done: true });
-    db.insert(todos, { title: "Task C", done: false });
+    await db.insert(todos, { title: "Task A", done: false });
+    await db.insert(todos, { title: "Task B", done: true });
+    await db.insert(todos, { title: "Task C", done: false });
 
     const results = await db.all(allTodos);
     expect(results.length).toBe(3);
@@ -350,8 +350,8 @@ describe("Worker Bridge with OPFS", () => {
   it("updates a row", async () => {
     const db = track(await createDb({ appId: "test-app", dbName: uniqueDbName("update") }));
 
-    const id = db.insert(todos, { title: "Original", done: false });
-    db.update(todos, id, { done: true });
+    const id = await db.insert(todos, { title: "Original", done: false });
+    await db.update(todos, id, { done: true });
 
     const results = await db.all(allTodos);
     expect(results.length).toBe(1);
@@ -362,10 +362,10 @@ describe("Worker Bridge with OPFS", () => {
   it("deletes a row", async () => {
     const db = track(await createDb({ appId: "test-app", dbName: uniqueDbName("delete") }));
 
-    const id = db.insert(todos, { title: "Ephemeral", done: false });
+    const id = await db.insert(todos, { title: "Ephemeral", done: false });
     expect((await db.all(allTodos)).length).toBe(1);
 
-    db.deleteFrom(todos, id);
+    await db.deleteFrom(todos, id);
     const results = await db.all(allTodos);
     expect(results.length).toBe(0);
   });
@@ -378,7 +378,7 @@ describe("Worker Bridge with OPFS", () => {
     const dbName = uniqueDbName("persistence");
 
     const db1 = await createDb({ appId: "test-app", dbName });
-    db1.insert(todos, { title: "Survive reload", done: true });
+    await db1.insert(todos, { title: "Survive reload", done: true });
     const before = await db1.all(allTodos);
     expect(before.length).toBe(1);
     await db1.shutdown();
@@ -387,7 +387,7 @@ describe("Worker Bridge with OPFS", () => {
     // Using "worker" settled tier makes the query wait for the worker's
     // QuerySettled response, ensuring OPFS data arrives before resolving.
     const db2 = track(await createDb({ appId: "test-app", dbName }));
-    const after = await db2.all(allTodos, { settledTier: "worker" });
+    const after = await db2.all(allTodos, { tier: "worker" });
     expect(after.length).toBe(1);
     expect(after[0].title).toBe("Survive reload");
     expect(after[0].done).toBe(true);
@@ -398,9 +398,9 @@ describe("Worker Bridge with OPFS", () => {
 
     const db1 = track(await createDb({ appId: "test-app", dbName }));
 
-    // insertWithAck ensures data is in OPFS WAL before we crash
-    await db1.insertWithAck(todos, { title: "Crash-proof", done: false }, "worker");
-    await db1.insertWithAck(todos, { title: "Also survives", done: true }, "worker");
+    // insert({ tier: "worker" }) ensures data is in OPFS WAL before we crash
+    await db1.insert(todos, { title: "Crash-proof", done: false }, { tier: "worker" });
+    await db1.insert(todos, { title: "Also survives", done: true }, { tier: "worker" });
 
     // Simulate crash: release OPFS handles WITHOUT flushing snapshot.
     // WAL has the data, but snapshot is stale. Recovery must replay WAL.
@@ -418,7 +418,7 @@ describe("Worker Bridge with OPFS", () => {
 
     // New Db with same dbName — worker must recover from OPFS WAL
     const db2 = track(await createDb({ appId: "test-app", dbName }));
-    const after = await db2.all(allTodos, { settledTier: "worker" });
+    const after = await db2.all(allTodos, { tier: "worker" });
     expect(after.length).toBe(2);
 
     const titles = after.map((r) => r.title).sort();
@@ -428,18 +428,18 @@ describe("Worker Bridge with OPFS", () => {
   it("deletes OPFS storage for the current namespace and keeps the same Db usable", async () => {
     const db = track(await createDb({ appId: "test-app", dbName: uniqueDbName("delete-storage") }));
 
-    await db.insertWithAck(todos, { title: "Should be deleted", done: false }, "worker");
-    const before = await db.all(allTodos, { settledTier: "worker" });
+    await db.insert(todos, { title: "Should be deleted", done: false }, { tier: "worker" });
+    const before = await db.all(allTodos, { tier: "worker" });
     expect(before.length).toBe(1);
     expect(before[0].title).toBe("Should be deleted");
 
     await db.deleteClientStorage();
 
-    const afterDelete = await db.all(allTodos, { settledTier: "worker" });
+    const afterDelete = await db.all(allTodos, { tier: "worker" });
     expect(afterDelete).toEqual([]);
 
-    const id = db.insert(todos, { title: "Fresh after delete", done: true });
-    const afterReinsert = await db.all(allTodos, { settledTier: "worker" });
+    const id = await db.insert(todos, { title: "Fresh after delete", done: true });
+    const afterReinsert = await db.all(allTodos, { tier: "worker" });
     expect(afterReinsert).toHaveLength(1);
     expect(afterReinsert[0].id).toBe(id);
     expect(afterReinsert[0].title).toBe("Fresh after delete");
@@ -451,7 +451,7 @@ describe("Worker Bridge with OPFS", () => {
     const seeded = track(await createDb({ appId: "test-app", dbName }));
 
     // Initialize worker/main runtimes with schema v2 from client context.
-    await seeded.all(allCatalogueTodos, { settledTier: "worker" });
+    await seeded.all(allCatalogueTodos, { tier: "worker" });
 
     // Seed historical v1 schema + auto lens v1->v2 directly into worker OPFS.
     await seedWorkerLiveSchema(seeded, catalogueSchemaV1);
@@ -469,7 +469,7 @@ describe("Worker Bridge with OPFS", () => {
     untrack(seeded);
 
     const offline = track(await createDb({ appId: "test-app", dbName }));
-    await offline.all(allCatalogueTodos, { settledTier: "worker" });
+    await offline.all(allCatalogueTodos, { tier: "worker" });
 
     await waitForCondition(
       async () => {
@@ -482,7 +482,7 @@ describe("Worker Bridge with OPFS", () => {
 
     await waitForCondition(
       async () => {
-        await offline.all(allCatalogueTodos, { settledTier: "worker" });
+        await offline.all(allCatalogueTodos, { tier: "worker" });
         const mainState = getMainDebugSchemaState(offline, catalogueSchemaV2);
         return hasRestoredCatalogueState(mainState);
       },
@@ -492,14 +492,14 @@ describe("Worker Bridge with OPFS", () => {
   }, 90_000);
 
   // -------------------------------------------------------------------------
-  // 5. Acknowledged insert resolves at worker tier
+  // 5. Durable insert resolves at worker tier
   // -------------------------------------------------------------------------
 
-  it("insertWithAck resolves when worker acks", async () => {
+  it("insert resolves when worker acks", async () => {
     const db = track(await createDb({ appId: "test-app", dbName: uniqueDbName("with-ack") }));
 
-    // insertWithAck("worker") should resolve once the worker's OPFS has it
-    const id = await db.insertWithAck(todos, { title: "Durable", done: false }, "worker");
+    // insert("worker") should resolve once the worker's OPFS has it
+    const id = await db.insert(todos, { title: "Durable", done: false }, { tier: "worker" });
     expect(id).toBeTruthy();
     expect(typeof id).toBe("string");
 
@@ -524,7 +524,7 @@ describe("Worker Bridge with OPFS", () => {
       }),
     );
 
-    db.insert(todos, { title: "Observed", done: false });
+    await db.insert(todos, { title: "Observed", done: false });
 
     // Wait for subscription to fire
     await waitForCondition(
@@ -545,16 +545,16 @@ describe("Worker Bridge with OPFS", () => {
 
     const received: Todo[][] = [];
 
-    const projectId = db.insert(projects, { name: "Observed Project" });
+    const projectId = await db.insert(projects, { name: "Observed Project" });
     const unsub = trackSubscription(
       db.subscribeAll(todosByProject(projectId), (delta) => {
         received.push([...delta.all]);
       }),
     );
 
-    db.insert(todos, { title: "Observed", done: false, project: projectId });
-    const anotherProjectId = db.insert(projects, { name: "Ignored Project" });
-    db.insert(todos, { title: "Not observed", done: false, project: anotherProjectId });
+    await db.insert(todos, { title: "Observed", done: false, project: projectId });
+    const anotherProjectId = await db.insert(projects, { name: "Ignored Project" });
+    await db.insert(todos, { title: "Not observed", done: false, project: anotherProjectId });
 
     // Wait for subscription to fire
     await waitForCondition(
@@ -573,7 +573,7 @@ describe("Worker Bridge with OPFS", () => {
   it("forwards page lifecycle hints from main thread to worker bridge", async () => {
     const db = track(await createDb({ appId: "test-app", dbName: uniqueDbName("lifecycle") }));
 
-    db.insert(todos, { title: "Prime bridge", done: false });
+    await db.insert(todos, { title: "Prime bridge", done: false });
     await (db as any).ensureBridgeReady();
 
     const bridge = (db as any).workerBridge;
@@ -604,9 +604,9 @@ describe("Worker Bridge with OPFS", () => {
 
     const title = `sync-a-to-b-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     await withTimeout(
-      dbA.insertWithAck(todos, { title, done: false }, "worker"),
+      await dbA.insert(todos, { title, done: false }, { tier: "worker" }),
       10000,
-      "A insertWithAck(worker) did not resolve",
+      "A insert(worker) did not resolve",
     );
 
     const rowsOnB = await waitForTodos(
@@ -625,9 +625,9 @@ describe("Worker Bridge with OPFS", () => {
 
     const title = `sync-b-to-a-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     await withTimeout(
-      dbB.insertWithAck(todos, { title, done: true }, "worker"),
+      await dbB.insert(todos, { title, done: true }, { tier: "worker" }),
       10000,
-      "B insertWithAck(worker) did not resolve",
+      "B insert(worker) did not resolve",
     );
 
     const rowsOnA = await waitForTodos(
@@ -654,7 +654,7 @@ describe("Worker Bridge with OPFS", () => {
       ),
     );
 
-    await dbA.insertWithAck(todos, { title: "local-only-local-1", done: true }, "worker");
+    await dbA.insert(todos, { title: "local-only-local-1", done: true }, { tier: "worker" });
 
     // Wait for initial local-only snapshot.
     await waitForCondition(
@@ -710,9 +710,9 @@ describe("Worker Bridge with OPFS", () => {
 
     const remoteTitle = `remote-for-local-only-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     await withTimeout(
-      dbA.insertWithAck(todos, { title: remoteTitle, done: false }, "worker"),
+      await dbA.insert(todos, { title: remoteTitle, done: false }, { tier: "worker" }),
       10000,
-      "A insertWithAck(worker) did not resolve",
+      "A insert(worker) did not resolve",
     );
 
     // Give sync enough time; local-only must still not see remote data.
@@ -721,7 +721,7 @@ describe("Worker Bridge with OPFS", () => {
     expect(latestAfterRemote.some((row) => row.title === remoteTitle)).toBe(false);
 
     const localTitle = `local-only-local-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-    dbB.insert(todos, { title: localTitle, done: true });
+    await dbB.insert(todos, { title: localTitle, done: true });
 
     await waitForCondition(
       async () => {
@@ -759,7 +759,7 @@ describe("Worker Bridge with OPFS", () => {
       },
     );
 
-    follower.insert(todos, { title: "Routed via leader", done: false });
+    await follower.insert(todos, { title: "Routed via leader", done: false });
 
     await waitForCondition(
       async () => receivedByLeader.includes("Routed via leader"),
@@ -769,8 +769,8 @@ describe("Worker Bridge with OPFS", () => {
 
     await waitForCondition(
       async () => {
-        const leaderRows = await leader.all(allTodos, { settledTier: "worker" });
-        const followerRows = await follower.all(allTodos, { settledTier: "worker" });
+        const leaderRows = await leader.all(allTodos, { tier: "worker" });
+        const followerRows = await follower.all(allTodos, { tier: "worker" });
         const leaderHas = leaderRows.some((row) => row.title === "Routed via leader");
         const followerHas = followerRows.some((row) => row.title === "Routed via leader");
         return leaderHas && followerHas;
@@ -797,10 +797,10 @@ describe("Worker Bridge with OPFS", () => {
       "Follower should be promoted to leader after shutdown",
     );
 
-    const id = follower.insert(todos, { title: "Post-failover", done: true });
+    const id = await follower.insert(todos, { title: "Post-failover", done: true });
     await waitForCondition(
       async () => {
-        const rows = await follower.all(allTodos, { settledTier: "worker" });
+        const rows = await follower.all(allTodos, { tier: "worker" });
         return rows.some((row) => row.id === id && row.title === "Post-failover");
       },
       8000,
@@ -826,14 +826,19 @@ describe("Worker Bridge with OPFS", () => {
     const reopened = track(await createDb({ appId: "test-app", dbName }));
     const currentLeader = await waitForSingleLeader([survivor, reopened]);
     const currentFollower = currentLeader === survivor ? reopened : survivor;
+    await currentLeader.all(allTodos, { tier: "worker" });
 
     const marker = `reopen-${Date.now()}`;
-    currentFollower.insert(todos, { title: marker, done: false });
+    await withTimeout(
+      currentFollower.insert(todos, { title: marker, done: false }),
+      10000,
+      "Follower insert during reopen re-election did not resolve",
+    );
 
     await waitForCondition(
       async () => {
-        const leaderRows = await currentLeader.all(allTodos, { settledTier: "worker" });
-        const followerRows = await currentFollower.all(allTodos, { settledTier: "worker" });
+        const leaderRows = await currentLeader.all(allTodos, { tier: "worker" });
+        const followerRows = await currentFollower.all(allTodos, { tier: "worker" });
         const leaderHas = leaderRows.some((row) => row.title === marker);
         const followerHas = followerRows.some((row) => row.title === marker);
         return leaderHas && followerHas;
@@ -903,7 +908,7 @@ async function waitForTodos(
   predicate: (rows: Todo[]) => boolean,
   label: string,
   timeoutMs = 15000,
-  settledTier: "worker" | "edge" | undefined = undefined,
+  tier: "worker" | "edge" | undefined = undefined,
 ): Promise<Todo[]> {
   const deadline = Date.now() + timeoutMs;
   let lastRows: Todo[] = [];
@@ -911,7 +916,7 @@ async function waitForTodos(
 
   while (Date.now() < deadline) {
     try {
-      const rows = await db.all(allTodos, { settledTier });
+      const rows = await db.all(allTodos, { tier });
       if (predicate(rows)) {
         return rows;
       }
@@ -929,7 +934,7 @@ async function waitForTodos(
   const lastErrorMessage =
     lastError instanceof Error ? lastError.message : lastError ? String(lastError) : "none";
   throw new Error(
-    `${label}: timed out after ${timeoutMs}ms (tier=${settledTier ?? "default"}); ` +
+    `${label}: timed out after ${timeoutMs}ms (tier=${tier ?? "default"}); ` +
       `lastRowsCount=${lastRows.length}; lastRows=${rowPreview}; lastError=${lastErrorMessage}`,
   );
 }

--- a/packages/jazz-tools/tests/ts-dsl/query-api.test.ts
+++ b/packages/jazz-tools/tests/ts-dsl/query-api.test.ts
@@ -29,7 +29,7 @@ describe("TS Query API", () => {
   it("queries by id", async () => {
     const db = track(await createDb({ appId: "test-app", dbName: uniqueDbName("query-by-id") }));
 
-    const id = db.insert(app.projects, { name: "Project A" });
+    const id = await db.insert(app.projects, { name: "Project A" });
 
     const results = await db.all(app.projects.where({ id: { eq: id } }));
     expect(results.length).toBe(1);
@@ -46,8 +46,8 @@ describe("TS Query API", () => {
       }),
     );
 
-    const projectId = db.insert(app.projects, { name: "Announcements" });
-    const todoId = db.insert(app.todos, {
+    const projectId = await db.insert(app.projects, { name: "Announcements" });
+    const todoId = await db.insert(app.todos, {
       title: "Hello world",
       done: false,
       tags: ["general"],
@@ -73,8 +73,8 @@ describe("TS Query API", () => {
       }),
     );
 
-    const projectId = db.insert(app.projects, { name: "Announcements" });
-    const todoId = db.insert(app.todos, {
+    const projectId = await db.insert(app.projects, { name: "Announcements" });
+    const todoId = await db.insert(app.todos, {
       title: "Write tests",
       done: false,
       tags: ["dev"],
@@ -100,20 +100,20 @@ describe("TS Query API", () => {
           dbName: uniqueDbName("query-by-array-column-equality"),
         }),
       );
-      const projectId = db.insert(app.projects, { name: "Project A" });
-      const id1 = db.insert(app.todos, {
+      const projectId = await db.insert(app.projects, { name: "Project A" });
+      const id1 = await db.insert(app.todos, {
         title: "Todo 1",
         done: false,
         tags: ["tag1"],
         project: projectId,
       });
-      const _id2 = db.insert(app.todos, {
+      const _id2 = await db.insert(app.todos, {
         title: "Todo 2",
         done: false,
         tags: ["tag2"],
         project: projectId,
       });
-      const _id3 = db.insert(app.todos, {
+      const _id3 = await db.insert(app.todos, {
         title: "Todo 3",
         done: false,
         tags: ["tag1", "tag2"],
@@ -132,20 +132,20 @@ describe("TS Query API", () => {
           dbName: uniqueDbName("query-by-array-column-contains"),
         }),
       );
-      const projectId = db.insert(app.projects, { name: "Project A" });
-      const id1 = db.insert(app.todos, {
+      const projectId = await db.insert(app.projects, { name: "Project A" });
+      const id1 = await db.insert(app.todos, {
         title: "Todo 1",
         done: false,
         tags: ["tag1"],
         project: projectId,
       });
-      const _id2 = db.insert(app.todos, {
+      const _id2 = await db.insert(app.todos, {
         title: "Todo 2",
         done: false,
         tags: ["tag2"],
         project: projectId,
       });
-      const id3 = db.insert(app.todos, {
+      const id3 = await db.insert(app.todos, {
         title: "Todo 3",
         done: false,
         tags: ["tag1", "tag2"],

--- a/specs/status-quo/browser_adapters.md
+++ b/specs/status-quo/browser_adapters.md
@@ -72,7 +72,7 @@ Current behavior:
 1. `JazzProvider` (`react/provider.tsx`) resolves local-auth defaults, then runs `Promise.all([createDb(config), resolveClientSession(config)])` on mount.
 2. Provider context stores `{ db, session }`; `useDb()` and `useSession()` read from this context and throw outside provider boundaries.
 3. On unmount, provider calls `db.shutdown()` for clean worker/runtime teardown.
-4. `useAll(query, tier?)` (`react/use-all.ts`) wraps `db.subscribeAll(...)`; without a tier it starts with `[]`, and with a tier it starts as `undefined` until settlement.
+4. `useAll(query)` (`react/use-all.ts`) wraps `db.subscribeAll(...)` and streams reactive updates.
 5. `useLinkExternalIdentity` (`react/use-link-external-identity.ts`) bridges local synthetic identity to external JWT identity and can fall back to active synthetic profile state.
 
 ### TypeScript Adapter (`jazz-tools` / `jazz-tools/backend`)
@@ -90,7 +90,7 @@ Current plain TypeScript usage pattern (see `examples/todo-client-localfirst-ts/
 1. Build a `DbConfig` (app/env/branch/auth/tier/server options).
 2. Initialize with `Promise.all([createDb(config), resolveClientSession(config)])`.
 3. Read via `db.all(...)`/`db.one(...)` or `db.subscribeAll(...)`.
-4. Mutate via sync local-first APIs (`insert`, `update`, `deleteFrom`) and optional ack-tier APIs (`insertWithAck`, `updateWithAck`, `deleteFromWithAck`).
+4. Mutate via async local-first APIs (`insert`, `update`, `deleteFrom`) with optional `{ tier }` overrides.
 5. Tear down with `db.shutdown()`.
 
 ## Runtime Layers and Responsibilities
@@ -100,7 +100,7 @@ Current plain TypeScript usage pattern (see `examples/todo-client-localfirst-ts/
 - High-level typed API (`insert`, `update`, `deleteFrom`, `all`, `one`, `subscribeAll`).
 - Creates and memoizes `JazzClient` per schema key.
 - Creates worker + bridge in browser mode.
-- Waits for bridge init before ack-tier mutations.
+- Waits for bridge init before durability-tiered mutations.
 
 2. `JazzClient` (`runtime/client.ts`)
 
@@ -163,19 +163,14 @@ Payloads are JSON strings for sync messages (`payload: string`).
 
 ### 2. Mutation Path
 
-No-ack mutation (`insert`, `update`, `deleteFrom`):
-
-1. Call hits main-thread `JazzClient` runtime synchronously.
-2. Main runtime emits server-destination sync envelope.
-3. `WorkerBridge` forwards envelope payload as `sync` message to worker.
-4. Worker ingests message as peer-client sync input.
-5. Worker runtime may emit upstream server sync and/or client sync updates.
-
-Ack mutation (`insertWithAck`, `updateWithAck`, `deleteFromWithAck`):
+Durability mutation (`insert`, `update`, `deleteFrom` with optional `{ tier }`):
 
 1. `Db` waits for bridge init (`ensureBridgeReady()`).
-2. Uses runtime persisted mutation API with requested tier (`worker`, `edge`, `core`).
-3. Promise resolves when tier ack arrives through runtime sync protocol.
+2. Call uses the main-thread `JazzClient` durable mutation API.
+3. Local runtime applies the write immediately and emits server-destination sync envelope.
+4. `WorkerBridge` forwards envelope payload as `sync` message to worker.
+5. Worker ingests message as peer-client sync input and may emit upstream server sync and/or client sync updates.
+6. Promise resolves when the requested durability tier (`worker`, `edge`, `global`) is acknowledged.
 
 ### 3. Query Path
 

--- a/specs/status-quo/life_of_a_subscription.md
+++ b/specs/status-quo/life_of_a_subscription.md
@@ -223,6 +223,7 @@ Delivery semantics after settle:
 - if required durability tier is not achieved, graph state updates but delivery is held
 - first delivery is a full snapshot via `current_result_as_delta()`
 - later deliveries are incremental deltas
+- with `localUpdates/immediate`, only post-first-settlement local writes bypass tier waiting; initial snapshot remains tier-gated
 
 > [`query_manager/manager.rs:640`](../../crates/jazz-tools/src/query_manager/manager.rs#L640)
 > [`query_manager/manager.rs:651`](../../crates/jazz-tools/src/query_manager/manager.rs#L651)

--- a/specs/status-quo/life_of_a_subscription.md
+++ b/specs/status-quo/life_of_a_subscription.md
@@ -120,7 +120,7 @@ Call chain:
 
 1. `Db.subscribeAll()` -> `client.subscribe(...)`
 2. `JazzClient.subscribeInternal(...)` -> `runtime.subscribe(...)`
-3. Rust `RuntimeCore::subscribe_with_settled_tier(...)`
+3. Rust `RuntimeCore::subscribe_with_durability_and_propagation(...)`
 4. first `process()` pass compiles and settles; callback then remains registered for incremental updates
 
 > [`runtime/db.ts:582`](../../packages/jazz-tools/src/runtime/db.ts#L582)
@@ -220,7 +220,7 @@ Main-thread `row_loader` behavior during settle:
 
 Delivery semantics after settle:
 
-- if required settled tier is not achieved, graph state updates but delivery is held
+- if required durability tier is not achieved, graph state updates but delivery is held
 - first delivery is a full snapshot via `current_result_as_delta()`
 - later deliveries are incremental deltas
 
@@ -344,10 +344,10 @@ For `db.subscribeAll(...)`, callback remains active and receives later deltas.
 
 Both are implemented on top of the same reactive machinery:
 
-- one-shot query is "subscribe once, resolve on first settled snapshot, then unsubscribe"
+- one-shot query is "subscribe once, resolve on first durability-qualified snapshot, then unsubscribe"
 - live query is "subscribe and keep subscription state"
 
-That shared path is why both participate in the same tier-settlement, lens-transform, and sync-forwarding behavior.
+That shared path is why both participate in the same durability-tier gating, lens-transform, and sync-forwarding behavior.
 
 > [`src/runtime_core.rs:632`](../../crates/jazz-tools/src/runtime_core.rs#L632)
 > [`src/runtime_core.rs:656`](../../crates/jazz-tools/src/runtime_core.rs#L656)

--- a/specs/status-quo/query_sync_integration.md
+++ b/specs/status-quo/query_sync_integration.md
@@ -95,6 +95,7 @@ End-to-end path:
 5. Receiver stores `(query_id, tier)` in `pending_query_settled`.
 6. In local `QueryManager::process()`, pending `QuerySettled` is consumed before local subscription settle/delivery.
 7. Delivery gate checks `achieved_tiers >= durability_tier`; if satisfied, first delivery is full snapshot, else delivery is held.
+8. With `local_updates = Immediate`, local write deltas can bypass tier waiting only after that first delivery (`settled_once = true`). Initial delivery never bypasses tier gating.
 
 > [`query_manager/subscriptions.rs:160`](../../crates/jazz-tools/src/query_manager/subscriptions.rs#L160)
 > [`query_manager/server_queries.rs:23`](../../crates/jazz-tools/src/query_manager/server_queries.rs#L23)
@@ -112,6 +113,7 @@ Why this ordering matters:
 - `ObjectUpdated` may arrive in the same batch as `QuerySettled`.
 - Because `QuerySettled` is applied before local delivery checks, first delivery can unblock in the same tick once both data and tier condition are true.
 - If tier is not satisfied, query state still settles locally; only delivery is deferred.
+- `local_updates = Immediate` changes post-initial behavior only: later local writes can still notify immediately while waiting on higher-tier confirmation.
 
 ## PersistenceAck Integration (Detailed)
 

--- a/specs/status-quo/query_sync_integration.md
+++ b/specs/status-quo/query_sync_integration.md
@@ -57,7 +57,7 @@ All relevant types (Query, Condition, Value, etc.) implement Serialize/Deseriali
 
 ## Client subscribe_with_sync()
 
-`subscribe_with_sync_and_propagation(query, session, settled_tier, propagation)`:
+`subscribe_with_sync_and_propagation(query, session, durability_tier, propagation)`:
 
 1. Creates local subscription via `subscribe_with_session()`
 2. Sends `QuerySubscription` to connected servers based on propagation mode
@@ -68,7 +68,7 @@ Also: `unsubscribe_with_sync()` for cleanup.
 Propagation behavior:
 
 - `full` (default): forward subscription and unsubscription upstream; replay on reconnect.
-- `local-only`: do not forward past the local persistence boundary. In browser main->worker topology this still reaches worker (OPFS tier), but worker will not forward to edge/core.
+- `local-only`: do not forward past the local durability boundary. In browser main->worker topology this still reaches worker (OPFS tier), but worker will not forward to edge/global.
 
 > [`query_manager/subscriptions.rs:26`](../../crates/jazz-tools/src/query_manager/subscriptions.rs#L26)
 > [`query_manager/subscriptions.rs:205`](../../crates/jazz-tools/src/query_manager/subscriptions.rs#L205)
@@ -88,13 +88,13 @@ Server forwards received `QuerySubscription` to upstream servers only when `prop
 
 End-to-end path:
 
-1. Local `subscribe_with_sync_and_propagation(query, session, settled_tier, propagation)` creates a local subscription and conditionally forwards `QuerySubscription` upstream.
+1. Local `subscribe_with_sync_and_propagation(query, session, durability_tier, propagation)` creates a local subscription and conditionally forwards `QuerySubscription` upstream.
 2. Upstream/server `QueryManager` compiles + settles a server-side graph and computes scope.
 3. On first server-side settle, it emits exactly one `QuerySettled { query_id, tier }`.
 4. Any intermediate sync node relays that payload to original downstream clients via `query_origin`.
 5. Receiver stores `(query_id, tier)` in `pending_query_settled`.
 6. In local `QueryManager::process()`, pending `QuerySettled` is consumed before local subscription settle/delivery.
-7. Delivery gate checks `achieved_tiers >= settled_tier`; if satisfied, first delivery is full snapshot, else delivery is held.
+7. Delivery gate checks `achieved_tiers >= durability_tier`; if satisfied, first delivery is full snapshot, else delivery is held.
 
 > [`query_manager/subscriptions.rs:160`](../../crates/jazz-tools/src/query_manager/subscriptions.rs#L160)
 > [`query_manager/server_queries.rs:23`](../../crates/jazz-tools/src/query_manager/server_queries.rs#L23)
@@ -119,7 +119,7 @@ Why this ordering matters:
 
 End-to-end path:
 
-1. Persisted write API (`insert_persisted`, `update_persisted`, `delete_persisted`) registers an ack watcher keyed by commit ID and requested tier.
+1. Durable write APIs register an ack watcher keyed by commit ID and requested tier.
 2. Commit is synced upstream via `ObjectUpdated`.
 3. Receiver with `my_tier` set applies the commit and emits `PersistenceAck` for newly persisted commit IDs.
 4. Ack receiver stores tier to storage and in-memory commit ack state, then queues it for runtime.

--- a/specs/status-quo/sync_manager.md
+++ b/specs/status-quo/sync_manager.md
@@ -178,6 +178,7 @@ One-hop flow (browser main thread -> worker):
 5. On first settle only, worker emits `QuerySettled { query_id, tier: Worker }`.
 6. Main receives that payload, queues it in `pending_query_settled`, then `QueryManager::process()` moves it into `subscription.achieved_tiers`.
 7. First delivery is held until `achieved_tiers` satisfies `durability_tier`; then the first callback is a full snapshot.
+8. If local updates are configured as immediate, only later local write-driven updates bypass tier waiting. Initial delivery remains tier-gated.
 
 > [`sync_manager/inbox.rs:279`](../../crates/jazz-tools/src/sync_manager/inbox.rs#L279)
 > [`sync_manager/inbox.rs:285`](../../crates/jazz-tools/src/sync_manager/inbox.rs#L285)

--- a/specs/status-quo/sync_manager.md
+++ b/specs/status-quo/sync_manager.md
@@ -1,6 +1,6 @@
 # Sync Manager — Status Quo
 
-The Sync Manager coordinates data flow between nodes in the multi-tier topology (browser ↔ edge server ↔ core server). Its job is to ensure each node has the data it needs — no more, no less.
+The Sync Manager coordinates data flow between nodes in the multi-tier topology (browser ↔ edge server ↔ global server). Its job is to ensure each node has the data it needs — no more, no less.
 
 The fundamental asymmetry: **upward** (to servers), we push everything — the server is trusted and needs all data for query evaluation. **Downward** (to clients), we push only what matches the client's active queries — clients are untrusted and shouldn't see data they haven't asked for.
 
@@ -48,10 +48,10 @@ The effective scope is computed dynamically via `is_in_scope()` rather than stor
 
 > `crates/groove/src/sync_manager.rs:133-144`
 
-### PersistenceTier
+### DurabilityTier
 
 ```
-Worker | EdgeServer | CoreServer
+Worker | EdgeServer | GlobalServer
 ```
 
 Used in PersistenceAck and QuerySettled for tier-aware durability.
@@ -75,7 +75,7 @@ Used in PersistenceAck and QuerySettled for tier-aware durability.
 
 Note: the spec originally called these `QueryRegistration`/`QueryUnregistration` — renamed to `QuerySubscription`/`QueryUnsubscription` in implementation.
 
-`QuerySubscription` now carries `propagation` (`full` default, `local-only` optional). `local-only` prevents forwarding beyond the local persistence tier.
+`QuerySubscription` now carries `propagation` (`full` default, `local-only` optional). `local-only` prevents forwarding beyond the local durability tier.
 
 > [`sync_manager/types.rs:83`](../../crates/jazz-tools/src/sync_manager/types.rs#L83)
 > [`sync_manager/types.rs:235`](../../crates/jazz-tools/src/sync_manager/types.rs#L235)
@@ -165,7 +165,7 @@ A key boundary: the SyncManager never touches query graphs or SQL. When a client
 
 ## QuerySettled and PersistenceAck
 
-### QuerySettled: read-settlement signal
+### QuerySettled: read-durability signal
 
 `QuerySettled` is a tier-tagged signal that says: "this query has settled here at tier `T`."
 
@@ -177,7 +177,7 @@ One-hop flow (browser main thread -> worker):
 4. If `propagation=full`, worker forwards upstream; if `local-only`, worker stops propagation at worker tier.
 5. On first settle only, worker emits `QuerySettled { query_id, tier: Worker }`.
 6. Main receives that payload, queues it in `pending_query_settled`, then `QueryManager::process()` moves it into `subscription.achieved_tiers`.
-7. First delivery is held until `achieved_tiers` satisfies `settled_tier`; then the first callback is a full snapshot.
+7. First delivery is held until `achieved_tiers` satisfies `durability_tier`; then the first callback is a full snapshot.
 
 > [`sync_manager/inbox.rs:279`](../../crates/jazz-tools/src/sync_manager/inbox.rs#L279)
 > [`sync_manager/inbox.rs:285`](../../crates/jazz-tools/src/sync_manager/inbox.rs#L285)
@@ -189,7 +189,7 @@ One-hop flow (browser main thread -> worker):
 > [`query_manager/manager.rs:640`](../../crates/jazz-tools/src/query_manager/manager.rs#L640)
 > [`query_manager/manager.rs:651`](../../crates/jazz-tools/src/query_manager/manager.rs#L651)
 
-Key consequence: this is what makes `settled_tier` meaningful. Query state can settle and accumulate while delivery is gated, then unblock exactly when the required tier confirmation arrives.
+Key consequence: this is what makes `durability_tier` meaningful. Query state can settle and accumulate while delivery is gated, then unblock exactly when the required tier confirmation arrives.
 
 ### PersistenceAck: write-durability signal
 
@@ -201,7 +201,7 @@ One-hop flow (browser main thread -> worker):
 2. Worker applies commits; for newly persisted commit IDs and if `my_tier` is set, worker emits `PersistenceAck` back to the sender.
 3. Main receives `PersistenceAck`, stores tier state in storage, updates in-memory `commit.ack_state.confirmed_tiers`, and queues `(commit_id, tier)` for runtime consumers.
 4. `RuntimeCore` drains received acks and resolves ack watchers whose requested tier is `<= acked_tier`.
-5. `insert_persisted` / `update_persisted` / `delete_persisted` receivers resolve at this step.
+5. Durable write watchers resolve at this step.
 
 > [`sync_manager/inbox.rs:391`](../../crates/jazz-tools/src/sync_manager/inbox.rs#L391)
 > [`sync_manager/inbox.rs:395`](../../crates/jazz-tools/src/sync_manager/inbox.rs#L395)
@@ -216,7 +216,7 @@ Key consequence: delivery and durability are decoupled on purpose.
 
 - `QuerySettled` gates first query result delivery semantics.
 - `PersistenceAck` gates persisted-write completion semantics.
-- Both use the same ordered tier lattice (`Worker < EdgeServer < CoreServer`), but they answer different questions.
+- Both use the same ordered tier lattice (`Worker < EdgeServer < GlobalServer`), but they answer different questions.
 
 > [`sync_manager/types.rs:22`](../../crates/jazz-tools/src/sync_manager/types.rs#L22)
 

--- a/specs/status-quo/ts_client_codegen.md
+++ b/specs/status-quo/ts_client_codegen.md
@@ -15,16 +15,16 @@ schema/current.ts ──► node ./packages/jazz-tools/dist/cli.js build ──�
 
 ## Design Decisions
 
-| Decision           | Choice                 | Rationale                                       |
-| ------------------ | ---------------------- | ----------------------------------------------- |
-| Schema source      | WasmSchema JSON        | Types already resolved, consistent with runtime |
-| Relations          | `col.ref('table')`     | All refs are UUIDs, simple syntax               |
-| Relation naming    | Strip `_id` suffix     | `parent_id` → `.include({ parent })`            |
-| Reverse relations  | `tableViaColumn`       | `blockersViaBlocking` — auto-derived            |
-| Output             | Single `schema/app.ts` | Simple imports, easy to understand              |
-| Subscription shape | Full state + delta     | `{ all, added, updated, removed }`              |
-| DB interface       | Generic + schema       | `createDb(config)`, `db.all(query)`             |
-| Mutations          | Sync (WASM pre-loaded) | `createDb()` is async, mutations are sync       |
+| Decision           | Choice                 | Rationale                                                      |
+| ------------------ | ---------------------- | -------------------------------------------------------------- |
+| Schema source      | WasmSchema JSON        | Types already resolved, consistent with runtime                |
+| Relations          | `col.ref('table')`     | All refs are UUIDs, simple syntax                              |
+| Relation naming    | Strip `_id` suffix     | `parent_id` → `.include({ parent })`                           |
+| Reverse relations  | `tableViaColumn`       | `blockersViaBlocking` — auto-derived                           |
+| Output             | Single `schema/app.ts` | Simple imports, easy to understand                             |
+| Subscription shape | Full state + delta     | `{ all, added, updated, removed }`                             |
+| DB interface       | Generic + schema       | `createDb(config)`, `db.all(query)`                            |
+| Mutations          | Async local-first      | local state updates immediately; promises are durability-gated |
 
 ## Part 1: Schema DSL Extension
 
@@ -103,7 +103,7 @@ Generates fluent, immutable query builders per table:
 
 ### Db Class
 
-`createDb(config)` is the main entry point for application code. It's async because it pre-loads the WASM module, but once initialized, all mutations are synchronous (local-first: writes don't wait for the network). The Db lazily creates and memoizes `JazzClient` instances per schema hash, so multiple schemas can coexist in one app.
+`createDb(config)` is the main entry point for application code. It's async because it pre-loads the WASM module. Once initialized, mutations apply local-first immediately and return promises that resolve at the configured durability tier. The Db lazily creates and memoizes `JazzClient` instances per schema hash, so multiple schemas can coexist in one app.
 
 > `packages/jazz-tools/src/runtime/db.ts:93-450` (Db class)
 > `packages/jazz-tools/src/runtime/db.ts:479-484` (createDb factory)
@@ -115,16 +115,19 @@ Generates fluent, immutable query builders per table:
 
 `options` supports:
 
-- `settledTier?: "worker" | "edge" | "core"`
+- `tier?: "worker" | "edge" | "global"`
+- `localUpdates?: "immediate" | "deferred"` (default: `immediate`)
 - `propagation?: "full" | "local-only"` (default `full`)
 
-### Mutations (Synchronous)
+### Mutations (Async Local-First)
 
-- `db.insert(table, data)` — sync, returns ID immediately
-- `db.update(table, id, data)` — sync partial update
-- `db.deleteFrom(table, id)` — sync deletion
+- `db.insert(table, data, options?)` — applies local write immediately and resolves with new ID at durability tier
+- `db.update(table, id, data, options?)` — applies local update immediately and resolves at durability tier
+- `db.deleteFrom(table, id, options?)` — applies local delete immediately and resolves at durability tier
 
-Also: `insertPersisted()`, `updatePersisted()`, `deleteFromPersisted()` — async variants that wait for durability ack.
+`options` supports:
+
+- `tier?: "worker" | "edge" | "global"`
 
 ### Subscriptions
 
@@ -162,9 +165,10 @@ The TS runtime intentionally treats upstream attachment as replay boundary for s
 
 - `JazzProvider` — async `createDb(config)` on mount, provides `Db` through context, calls `db.shutdown()` on unmount
 - `useDb()` — context hook returning `Db` (throws outside provider)
-- `useAll(query, tier?)` — `useSyncExternalStore` wrapper over `db.subscribeAll(...)`
+- `useAll(query)` — `useSyncExternalStore` wrapper over `db.subscribeAll(...)`
+- `useAllSuspense(query)` — suspense-enabled query hook
 
-`useAll(query)` (no tier) returns `T[]` immediately from the synchronous initial subscription callback path. `useAll(query, tier)` returns `T[] | undefined` until the requested tier settles.
+`useAll(query)` returns `T[] | undefined` and resolves as subscription data arrives. Durability-tier gating is configured through `db.subscribeAll(..., options)` when needed.
 
 > `packages/jazz-tools/package.json` (`./react` export)
 > `packages/jazz-tools/src/react/provider.tsx`

--- a/specs/status-quo/ts_client_codegen.md
+++ b/specs/status-quo/ts_client_codegen.md
@@ -131,7 +131,7 @@ Generates fluent, immutable query builders per table:
 
 ### Subscriptions
 
-`db.subscribeAll(query, callback, options?)` — the local-first alternative to polling. The callback fires whenever the query's results change (local writes, sync updates). It receives `{ all, added, updated, removed }` — the full result set plus a delta.
+`db.subscribeAll(query, callback, options?)` — the local-first alternative to polling. The callback fires whenever the query's results change (local writes, sync updates). It receives `{ all, added, updated, removed }` — the full result set plus a delta. With tier-gated reads, initial delivery still waits for the requested tier; `localUpdates: "immediate"` affects only subsequent local-write updates.
 
 The SubscriptionManager preserves object identity for unchanged items: if a new todo is added, existing todo objects in the array keep the same JavaScript reference. This makes React's `useMemo`/referential equality checks work naturally.
 

--- a/specs/todo/a_mvp/durability_tier_api_unification.md
+++ b/specs/todo/a_mvp/durability_tier_api_unification.md
@@ -1,0 +1,133 @@
+# Durability Tier API Unification (Breaking, MVP)
+
+## Status
+
+Proposed and approved for immediate implementation.
+
+## Goals
+
+1. Replace durability terminology with a single, intuitive model.
+2. Remove split read/write tier naming from public APIs.
+3. Make base CRUD/query APIs tier-aware (no suffixed tier methods).
+4. Preserve local-first UX while supporting tier-gated reads.
+5. Support nodes that represent multiple durability identities.
+
+## Non-Goals
+
+1. Consistency/merge/transaction semantics (handled separately).
+2. Backward compatibility shims or aliases.
+
+## Terminology
+
+`DurabilityTier` replaces all prior tier naming:
+
+1. `worker`
+2. `edge`
+3. `global` (renamed from `core`)
+
+Ordering: `worker < edge < global`.
+
+## Public API (TypeScript)
+
+### Types
+
+```ts
+export type DurabilityTier = "worker" | "edge" | "global";
+
+export type ReadOptions = {
+  tier?: DurabilityTier;
+  localUpdates?: "immediate" | "deferred";
+  propagation?: "full" | "local-only";
+};
+
+export type WriteOptions = {
+  tier?: DurabilityTier;
+};
+```
+
+Default read behavior:
+
+1. `localUpdates` defaults to `"immediate"`.
+2. Read `tier` default is environment-specific:
+   1. client: `"worker"`
+   2. backend: `"edge"`
+
+Default write behavior (`WriteOptions.tier` omitted):
+
+1. client: `"worker"`
+2. backend: `"edge"`
+
+### Method shape (no suffix variants)
+
+Tier options are accepted by base methods:
+
+1. `insert(..., options?: WriteOptions): Promise<...>`
+2. `update(..., options?: WriteOptions): Promise<void>`
+3. `deleteFrom(..., options?: WriteOptions): Promise<void>`
+4. `all(..., options?: ReadOptions): Promise<...>`
+5. `one(..., options?: ReadOptions): Promise<...>`
+6. `subscribeAll(..., options?: ReadOptions): () => void`
+7. Client-level `query/subscribe` equivalents take `ReadOptions`.
+
+Removed APIs:
+
+1. `*WithAck`
+2. `*Persisted`
+3. `settledTier` option naming
+4. any read/write-suffixed tier-specific variant names
+5. `PersistenceTier`
+
+## Read semantics
+
+`ReadOptions.tier` gates durability confirmation for initial read/subscription settlement.
+
+`localUpdates` controls delivery of updates caused by local writes while durability gating is active:
+
+1. `"immediate"` (default): local write-driven subscription updates deliver synchronously.
+2. `"deferred"`: preserve strict tier gating for delivery.
+
+## Runtime semantics
+
+## Multi-tier identities
+
+A node may advertise multiple durability identities (not a single optional tier).
+
+Examples:
+
+1. `jazz-tools` CLI server: `["edge", "global"]`
+2. current cloud-server deployment: `["edge", "global"]`
+
+Behavior:
+
+1. Nodes emit `PersistenceAck` for every identity they represent.
+2. Nodes emit `QuerySettled` for every identity they represent.
+3. Emission order is deterministic and ascending by durability rank (`edge` then `global` for dual-identity servers).
+
+## Implementation plan (required changes)
+
+1. Replace core tier type/string parsing across Rust/TS bindings:
+   1. `core` -> `global`
+   2. `PersistenceTier` -> `DurabilityTier`
+2. Change runtime/sync manager configuration from single tier to multi-identity set.
+3. Update ack/settlement emission to emit for each identity.
+4. Replace read option names and behavior wiring:
+   1. `settledTier` -> `tier`
+   2. add `localUpdates`
+5. Replace base mutation APIs to accept `WriteOptions` and apply defaults by environment.
+6. Remove legacy suffixed APIs and all usage across packages/examples/docs/tests.
+7. Update docs language:
+   1. “write ack tier” / “read settled tier” -> durability tier semantics
+   2. `core` -> `global`
+
+## Tests and docs updates
+
+All affected tests and docs must be updated in the same change:
+
+1. runtime core durability/settlement tests
+2. wasm/napi/nitro tier parse and API tests
+3. browser worker-bridge and subscription behavior tests
+4. backend context defaults tests
+5. quickstarts and API docs pages
+6. examples snippets
+
+No compatibility layer is allowed.

--- a/specs/todo/a_mvp/durability_tier_api_unification.md
+++ b/specs/todo/a_mvp/durability_tier_api_unification.md
@@ -83,8 +83,8 @@ Removed APIs:
 
 `localUpdates` controls delivery of updates caused by local writes while durability gating is active:
 
-1. `"immediate"` (default): local write-driven subscription updates deliver synchronously.
-2. `"deferred"`: preserve strict tier gating for delivery.
+1. `"immediate"` (default): the initial delivery still waits for `ReadOptions.tier`; after that first settled snapshot, local write-driven subscription updates deliver synchronously.
+2. `"deferred"`: preserve strict tier gating for both initial and subsequent deliveries.
 
 ## Runtime semantics
 


### PR DESCRIPTION
## Summary
- introduce `DurabilityTier` (`worker | edge | global`) and hard-migrate from old write-ack/read-settled naming
- remove suffixed read/write tier methods and make base APIs tier-aware
- update read API to `{ tier, localUpdates }` with `localUpdates: "immediate"` default
- set defaults by environment/use-case:
  - browser/client default write/read tier: `worker`
  - backend/server-connected default write/read tier: `edge`
- rename `core` tier to `global`
- support multi-tier node identities and configure single-node server paths (cloud-server/jazz-tools server) to emit both `edge` and `global` acks
- add spec: `specs/todo/a_mvp/durability_tier_api_unification.md`

## Validation
- `pnpm format`
- `pnpm lint`
- `pnpm -C packages/jazz-tools build`
- `pnpm -C packages/jazz-tools exec vitest run --config vitest.config.browser.ts tests/browser/db.all.test.ts tests/browser/db.subscribeAll.test.ts tests/browser/db.subscribeAll.sort.test.ts tests/browser/worker-bridge.test.ts tests/browser/useAll.test.tsx tests/browser/useAllSuspense.test.tsx`
- `pnpm -C packages/jazz-tools exec vitest run --config vitest.config.ts src/runtime/client.for-request.test.ts src/subscriptions-orchestrator.integration.test.ts src/react/create-jazz-client.integration.test.ts src/runtime/worker-bridge.test.ts src/react-native/jazz-rn-runtime-adapter.test.ts tests/ts-dsl/query-api.test.ts`
- `pnpm -C packages/jazz-tools exec vitest run --config vitest.config.ts src/runtime/cloud-server.integration.test.ts`

## Notes
- no compatibility shims were kept (hard migration)
- write/read durability defaults and local update behavior now match the agreed API direction
