### PR TITLE
Runtime scheduler hook for deferred subscribe binding

### DIFF
--- a/crates/jazz-napi/index.d.ts
+++ b/crates/jazz-napi/index.d.ts
@@ -33,6 +33,15 @@ export declare class NapiRuntime {
     optionsJson?: string | undefined | null,
   ): number;
   unsubscribe(handle: number): void;
+  /** Phase 1 of 2-phase subscribe: allocate a handle and store query params. */
+  createSubscription(
+    queryJson: string,
+    sessionJson?: string | undefined | null,
+    tier?: string | undefined | null,
+    optionsJson?: string | undefined | null,
+  ): number;
+  /** Phase 2 of 2-phase subscribe: compile, register, sync, attach callback, tick. */
+  executeSubscription(handle: number, onUpdate: (...args: any[]) => any): void;
   insertDurable(table: string, values: any, tier: string): Promise<string>;
   updateDurable(objectId: string, values: any, tier: string): Promise<void>;
   deleteDurable(objectId: string, tier: string): Promise<void>;

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -127,6 +127,90 @@ fn parse_query(json: &str) -> napi::Result<Query> {
     parse_query_json(json).map_err(napi::Error::from_reason)
 }
 
+fn parse_session_json(session_json: Option<String>) -> napi::Result<Option<Session>> {
+    if let Some(json) = session_json {
+        Ok(Some(serde_json::from_str::<Session>(&json).map_err(
+            |e| napi::Error::from_reason(format!("Invalid session JSON: {}", e)),
+        )?))
+    } else {
+        Ok(None)
+    }
+}
+
+fn parse_subscription_inputs(
+    query_json: &str,
+    session_json: Option<String>,
+    tier: Option<String>,
+    options_json: Option<String>,
+) -> napi::Result<(
+    Query,
+    Option<Session>,
+    ReadDurabilityOptions,
+    QueryPropagation,
+)> {
+    let query = parse_query(query_json)?;
+    let session = parse_session_json(session_json)?;
+    let (durability, propagation) = parse_read_durability_options(tier, options_json)?;
+    Ok((query, session, durability, propagation))
+}
+
+fn subscription_delta_to_json(delta: &SubscriptionDelta) -> serde_json::Value {
+    let row_to_json = |row: &jazz_tools::query_manager::types::Row,
+                       descriptor: &jazz_tools::query_manager::types::RowDescriptor|
+     -> serde_json::Value {
+        let values = decode_row(descriptor, &row.data)
+            .map(|vals| vals.into_iter().collect::<Vec<_>>())
+            .unwrap_or_default();
+        serde_json::json!({
+            "id": row.id.uuid().to_string(),
+            "values": values
+        })
+    };
+
+    let descriptor = &delta.descriptor;
+    let delta_obj = delta
+        .ordered_delta
+        .removed
+        .iter()
+        .map(|change| {
+            serde_json::json!({
+                "kind": 1,
+                "id": change.id.uuid().to_string(),
+                "index": change.index
+            })
+        })
+        .chain(delta.ordered_delta.updated.iter().map(|change| {
+            serde_json::json!({
+                "kind": 2,
+                "id": change.id.uuid().to_string(),
+                "index": change.new_index,
+                "row": change.row.as_ref().map(|row| row_to_json(row, descriptor))
+            })
+        }))
+        .chain(delta.ordered_delta.added.iter().map(|change| {
+            serde_json::json!({
+                "kind": 0,
+                "id": change.id.uuid().to_string(),
+                "index": change.index,
+                "row": row_to_json(&change.row, descriptor)
+            })
+        }))
+        .collect::<Vec<_>>();
+
+    serde_json::Value::Array(delta_obj)
+}
+
+fn make_subscription_callback(
+    tsfn: ThreadsafeFunction<serde_json::Value, ErrorStrategy::CalleeHandled>,
+) -> impl Fn(SubscriptionDelta) + Send + 'static {
+    move |delta: SubscriptionDelta| {
+        tsfn.call(
+            Ok(subscription_delta_to_json(&delta)),
+            ThreadsafeFunctionCallMode::NonBlocking,
+        );
+    }
+}
+
 // ============================================================================
 // NapiScheduler
 // ============================================================================
@@ -425,15 +509,7 @@ impl NapiRuntime {
         options_json: Option<String>,
     ) -> napi::Result<napi::JsObject> {
         let query = parse_query(&query_json)?;
-
-        let session =
-            if let Some(json) = session_json {
-                Some(serde_json::from_str::<Session>(&json).map_err(|e| {
-                    napi::Error::from_reason(format!("Invalid session JSON: {}", e))
-                })?)
-            } else {
-                None
-            };
+        let session = parse_session_json(session_json)?;
 
         let (durability, propagation) = parse_read_durability_options(tier, options_json)?;
 
@@ -488,18 +564,8 @@ impl NapiRuntime {
         tier: Option<String>,
         options_json: Option<String>,
     ) -> napi::Result<f64> {
-        let query = parse_query(&query_json)?;
-
-        let session =
-            if let Some(json) = session_json {
-                Some(serde_json::from_str::<Session>(&json).map_err(|e| {
-                    napi::Error::from_reason(format!("Invalid session JSON: {}", e))
-                })?)
-            } else {
-                None
-            };
-
-        let (durability, propagation) = parse_read_durability_options(tier, options_json)?;
+        let (query, session, durability, propagation) =
+            parse_subscription_inputs(&query_json, session_json, tier, options_json)?;
 
         // Create a ThreadsafeFunction for the JS callback.
         // The closure converts our serde_json::Value into a JsUnknown to pass to JS.
@@ -508,55 +574,7 @@ impl NapiRuntime {
                 let val = ctx.env.to_js_value(&ctx.value)?;
                 Ok(vec![val])
             })?;
-
-        let callback = move |delta: SubscriptionDelta| {
-            let row_to_json = |row: &jazz_tools::query_manager::types::Row,
-                               descriptor: &jazz_tools::query_manager::types::RowDescriptor|
-             -> serde_json::Value {
-                let values = decode_row(descriptor, &row.data)
-                    .map(|vals| vals.into_iter().collect::<Vec<_>>())
-                    .unwrap_or_default();
-                serde_json::json!({
-                    "id": row.id.uuid().to_string(),
-                    "values": values
-                })
-            };
-
-            let descriptor = &delta.descriptor;
-            let delta_obj = delta
-                .ordered_delta
-                .removed
-                .iter()
-                .map(|change| {
-                    serde_json::json!({
-                        "kind": 1,
-                        "id": change.id.uuid().to_string(),
-                        "index": change.index
-                    })
-                })
-                .chain(delta.ordered_delta.updated.iter().map(|change| {
-                    serde_json::json!({
-                        "kind": 2,
-                        "id": change.id.uuid().to_string(),
-                        "index": change.new_index,
-                        "row": change.row.as_ref().map(|row| row_to_json(row, descriptor))
-                    })
-                }))
-                .chain(delta.ordered_delta.added.iter().map(|change| {
-                    serde_json::json!({
-                        "kind": 0,
-                        "id": change.id.uuid().to_string(),
-                        "index": change.index,
-                        "row": row_to_json(&change.row, descriptor)
-                    })
-                }))
-                .collect::<Vec<_>>();
-
-            tsfn.call(
-                Ok(serde_json::Value::Array(delta_obj)),
-                ThreadsafeFunctionCallMode::NonBlocking,
-            );
-        };
+        let callback = make_subscription_callback(tsfn);
 
         let mut core = self
             .core
@@ -582,6 +600,55 @@ impl NapiRuntime {
             .lock()
             .map_err(|_| napi::Error::from_reason("lock"))?;
         core.unsubscribe(SubscriptionHandle(handle as u64));
+        Ok(())
+    }
+
+    /// Phase 1 of 2-phase subscribe: allocate a handle and store query params.
+    #[napi(js_name = "createSubscription")]
+    pub fn create_subscription(
+        &self,
+        query_json: String,
+        session_json: Option<String>,
+        tier: Option<String>,
+        options_json: Option<String>,
+    ) -> napi::Result<f64> {
+        let (query, session, durability, propagation) =
+            parse_subscription_inputs(&query_json, session_json, tier, options_json)?;
+
+        let mut core = self
+            .core
+            .lock()
+            .map_err(|_| napi::Error::from_reason("lock"))?;
+        let handle = core.create_subscription(query, session, durability, propagation);
+
+        Ok(handle.0 as f64)
+    }
+
+    /// Phase 2 of 2-phase subscribe: compile, register, sync, attach callback, tick.
+    #[napi(js_name = "executeSubscription")]
+    pub fn execute_subscription(
+        &self,
+        handle: f64,
+        #[napi(ts_arg_type = "(...args: any[]) => any")] on_update: napi::JsFunction,
+    ) -> napi::Result<()> {
+        let sub_handle = SubscriptionHandle(handle as u64);
+
+        let tsfn: ThreadsafeFunction<serde_json::Value, ErrorStrategy::CalleeHandled> =
+            on_update.create_threadsafe_function(0, |ctx| {
+                let val = ctx.env.to_js_value(&ctx.value)?;
+                Ok(vec![val])
+            })?;
+        let callback = make_subscription_callback(tsfn);
+
+        let mut core = self
+            .core
+            .lock()
+            .map_err(|_| napi::Error::from_reason("lock"))?;
+        core.execute_subscription(sub_handle, callback)
+            .map_err(|e| {
+                napi::Error::from_reason(format!("Execute subscription failed: {:?}", e))
+            })?;
+
         Ok(())
     }
 

--- a/crates/jazz-rn/rust/src/lib.rs
+++ b/crates/jazz-rn/rust/src/lib.rs
@@ -125,6 +125,24 @@ fn parse_tier(tier: &str) -> Result<DurabilityTier, JazzRnError> {
     }
 }
 
+fn default_read_durability_options(tier: Option<DurabilityTier>) -> ReadDurabilityOptions {
+    ReadDurabilityOptions {
+        tier,
+        local_updates: LocalUpdates::Immediate,
+    }
+}
+
+fn parse_subscription_inputs(
+    query_json: &str,
+    session_json: Option<String>,
+    tier: Option<String>,
+) -> Result<(Query, Option<Session>, ReadDurabilityOptions), JazzRnError> {
+    let query = parse_query(query_json)?;
+    let session = parse_session(session_json)?;
+    let tier = tier.as_deref().map(parse_tier).transpose()?;
+    Ok((query, session, default_read_durability_options(tier)))
+}
+
 fn build_rn_delta_json<F>(delta: &SubscriptionDelta, mut row_to_json: F) -> serde_json::Value
 where
     F: FnMut(&jazz_tools::query_manager::types::Row) -> serde_json::Value,
@@ -178,6 +196,33 @@ where
         .collect::<Vec<_>>();
 
     serde_json::Value::Array(changes)
+}
+
+fn subscription_delta_to_json(delta: &SubscriptionDelta) -> serde_json::Value {
+    let descriptor = &delta.descriptor;
+    let row_to_json = |row: &jazz_tools::query_manager::types::Row| -> serde_json::Value {
+        let values = decode_row(descriptor, &row.data)
+            .map(|vals| vals.into_iter().collect::<Vec<_>>())
+            .unwrap_or_default();
+        serde_json::json!({
+            "id": row.id.uuid().to_string(),
+            "values": values,
+        })
+    };
+    build_rn_delta_json(delta, row_to_json)
+}
+
+fn make_subscription_callback(
+    callback: Box<dyn SubscriptionCallback>,
+) -> impl Fn(SubscriptionDelta) + Send + 'static {
+    move |delta: SubscriptionDelta| {
+        let payload = subscription_delta_to_json(&delta);
+        if let Ok(json) = serde_json::to_string(&payload) {
+            let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                callback.on_update(json);
+            }));
+        }
+    }
 }
 
 // ============================================================================
@@ -501,9 +546,9 @@ impl RnRuntime {
         tier: Option<String>,
     ) -> Result<u64, JazzRnError> {
         with_panic_boundary("subscribe", || {
-            let query = parse_query(&query_json)?;
-            let session = parse_session(session_json)?;
-            let tier = tier.as_deref().map(parse_tier).transpose()?;
+            let (query, session, durability) =
+                parse_subscription_inputs(&query_json, session_json, tier)?;
+            let callback = make_subscription_callback(callback);
 
             let mut core = self.core.lock().map_err(|_| JazzRnError::Internal {
                 message: "lock poisoned".into(),
@@ -512,35 +557,9 @@ impl RnRuntime {
             let handle = core
                 .subscribe_with_durability_and_propagation(
                     query,
-                    {
-                        move |delta: SubscriptionDelta| {
-                            let descriptor = &delta.descriptor;
-                            let row_to_json =
-                                |row: &jazz_tools::query_manager::types::Row| -> serde_json::Value {
-                                    let values = decode_row(descriptor, &row.data)
-                                        .map(|vals| vals.into_iter().collect::<Vec<_>>())
-                                        .unwrap_or_default();
-                                    serde_json::json!({
-                                        "id": row.id.uuid().to_string(),
-                                        "values": values,
-                                    })
-                                };
-
-                            let payload = build_rn_delta_json(&delta, row_to_json);
-
-                            if let Ok(json) = serde_json::to_string(&payload) {
-                                let _ =
-                                    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                                        callback.on_update(json);
-                                    }));
-                            }
-                        }
-                    },
+                    callback,
                     session,
-                    ReadDurabilityOptions {
-                        tier,
-                        local_updates: LocalUpdates::Immediate,
-                    },
+                    durability,
                     QueryPropagation::Full,
                 )
                 .map_err(runtime_err)?;
@@ -555,6 +574,47 @@ impl RnRuntime {
                 message: "lock poisoned".into(),
             })?;
             core.unsubscribe(SubscriptionHandle(handle));
+            Ok(())
+        })
+    }
+
+    /// Phase 1 of 2-phase subscribe: allocate a handle and store query params.
+    pub fn create_subscription(
+        &self,
+        query_json: String,
+        session_json: Option<String>,
+        tier: Option<String>,
+    ) -> Result<u64, JazzRnError> {
+        with_panic_boundary("create_subscription", || {
+            let (query, session, durability) =
+                parse_subscription_inputs(&query_json, session_json, tier)?;
+
+            let mut core = self.core.lock().map_err(|_| JazzRnError::Internal {
+                message: "lock poisoned".into(),
+            })?;
+
+            let handle =
+                core.create_subscription(query, session, durability, QueryPropagation::Full);
+
+            Ok(handle.0)
+        })
+    }
+
+    /// Phase 2 of 2-phase subscribe: compile, register, sync, attach callback, tick.
+    pub fn execute_subscription(
+        &self,
+        handle: u64,
+        callback: Box<dyn SubscriptionCallback>,
+    ) -> Result<(), JazzRnError> {
+        with_panic_boundary("execute_subscription", || {
+            let mut core = self.core.lock().map_err(|_| JazzRnError::Internal {
+                message: "lock poisoned".into(),
+            })?;
+            let callback = make_subscription_callback(callback);
+
+            core.execute_subscription(SubscriptionHandle(handle), callback)
+                .map_err(runtime_err)?;
+
             Ok(())
         })
     }

--- a/crates/jazz-rn/src/generated/jazz_rn-ffi.ts
+++ b/crates/jazz-rn/src/generated/jazz_rn-ffi.ts
@@ -113,6 +113,19 @@ interface NativeModuleInterface {
     role: Uint8Array,
     uniffi_out_err: UniffiRustCallStatus
   ): void;
+  ubrn_uniffi_jazz_rn_fn_method_rnruntime_create_subscription(
+    ptr: bigint,
+    queryJson: Uint8Array,
+    sessionJson: Uint8Array,
+    settledTier: Uint8Array,
+    uniffi_out_err: UniffiRustCallStatus
+  ): bigint;
+  ubrn_uniffi_jazz_rn_fn_method_rnruntime_execute_subscription(
+    ptr: bigint,
+    handle: bigint,
+    callback: bigint,
+    uniffi_out_err: UniffiRustCallStatus
+  ): void;
   ubrn_uniffi_jazz_rn_fn_method_rnruntime_subscribe(
     ptr: bigint,
     queryJson: Uint8Array,

--- a/crates/jazz-rn/src/generated/jazz_rn.ts
+++ b/crates/jazz-rn/src/generated/jazz_rn.ts
@@ -683,6 +683,15 @@ export interface RnRuntimeInterface {
   ) /*throws*/ : string;
   removeServer() /*throws*/ : void;
   setClientRole(clientId: string, role: string) /*throws*/ : void;
+  createSubscription(
+    queryJson: string,
+    sessionJson: string | undefined,
+    settledTier: string | undefined
+  ) /*throws*/ : /*u64*/ bigint;
+  executeSubscription(
+    handle: /*u64*/ bigint,
+    callback: SubscriptionCallback
+  ) /*throws*/ : void;
   subscribe(
     queryJson: string,
     callback: SubscriptionCallback,
@@ -997,6 +1006,50 @@ export class RnRuntime
           uniffiTypeRnRuntimeObjectFactory.clonePointer(this),
           FfiConverterString.lower(clientId),
           FfiConverterString.lower(role),
+          callStatus
+        );
+      },
+      /*liftString:*/ FfiConverterString.lift
+    );
+  }
+
+  public createSubscription(
+    queryJson: string,
+    sessionJson: string | undefined,
+    settledTier: string | undefined
+  ): /*u64*/ bigint /*throws*/ {
+    return FfiConverterUInt64.lift(
+      uniffiCaller.rustCallWithError(
+        /*liftError:*/ FfiConverterTypeJazzRnError.lift.bind(
+          FfiConverterTypeJazzRnError
+        ),
+        /*caller:*/ (callStatus) => {
+          return nativeModule().ubrn_uniffi_jazz_rn_fn_method_rnruntime_create_subscription(
+            uniffiTypeRnRuntimeObjectFactory.clonePointer(this),
+            FfiConverterString.lower(queryJson),
+            FfiConverterOptionalString.lower(sessionJson),
+            FfiConverterOptionalString.lower(settledTier),
+            callStatus
+          );
+        },
+        /*liftString:*/ FfiConverterString.lift
+      )
+    );
+  }
+
+  public executeSubscription(
+    handle: /*u64*/ bigint,
+    callback: SubscriptionCallback
+  ): void /*throws*/ {
+    uniffiCaller.rustCallWithError(
+      /*liftError:*/ FfiConverterTypeJazzRnError.lift.bind(
+        FfiConverterTypeJazzRnError
+      ),
+      /*caller:*/ (callStatus) => {
+        nativeModule().ubrn_uniffi_jazz_rn_fn_method_rnruntime_execute_subscription(
+          uniffiTypeRnRuntimeObjectFactory.clonePointer(this),
+          FfiConverterUInt64.lower(handle),
+          FfiConverterTypeSubscriptionCallback.lower(callback),
           callStatus
         );
       },

--- a/crates/jazz-tools/src/runtime_core.rs
+++ b/crates/jazz-tools/src/runtime_core.rs
@@ -233,6 +233,8 @@ pub struct RuntimeCore<S: Storage, Sch: Scheduler, Sy: SyncSender> {
     /// Reverse map for routing updates.
     subscription_reverse: HashMap<QuerySubscriptionId, SubscriptionHandle>,
     next_subscription_handle: u64,
+    /// Created-but-not-yet-executed subscriptions (2-phase subscribe).
+    pending_subscriptions: HashMap<SubscriptionHandle, subscriptions::PendingSubscription>,
 
     /// Pending one-shot queries (query() calls waiting for first callback).
     pending_one_shot_queries: HashMap<SubscriptionHandle, PendingOneShotQuery>,
@@ -259,6 +261,7 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
             subscriptions: HashMap::new(),
             subscription_reverse: HashMap::new(),
             next_subscription_handle: 0,
+            pending_subscriptions: HashMap::new(),
             pending_one_shot_queries: HashMap::new(),
             ack_watchers: HashMap::new(),
             tier_label: "unknown",

--- a/crates/jazz-tools/src/runtime_core/subscriptions.rs
+++ b/crates/jazz-tools/src/runtime_core/subscriptions.rs
@@ -17,7 +17,57 @@ impl Default for ReadDurabilityOptions {
     }
 }
 
+/// Subscription created but not yet executed (2-phase subscribe).
+pub(super) struct PendingSubscription {
+    pub query: Query,
+    pub session: Option<Session>,
+    pub durability: ReadDurabilityOptions,
+    pub propagation: QueryPropagation,
+}
+
 impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
+    fn allocate_subscription_handle(&mut self) -> SubscriptionHandle {
+        let handle = SubscriptionHandle(self.next_subscription_handle);
+        self.next_subscription_handle += 1;
+        handle
+    }
+
+    fn subscribe_query(
+        &mut self,
+        query: Query,
+        session: Option<Session>,
+        durability: ReadDurabilityOptions,
+        propagation: QueryPropagation,
+    ) -> Result<QuerySubscriptionId, RuntimeError> {
+        self.schema_manager
+            .query_manager_mut()
+            .subscribe_with_sync_and_propagation_with_local_updates(
+                query,
+                session,
+                durability.tier,
+                durability.local_updates,
+                propagation,
+            )
+            .map_err(|e| RuntimeError::QueryError(format!("{:?}", e)))
+    }
+
+    fn activate_subscription(
+        &mut self,
+        handle: SubscriptionHandle,
+        query_sub_id: QuerySubscriptionId,
+        callback: SubscriptionCallback,
+    ) {
+        self.subscriptions.insert(
+            handle,
+            SubscriptionState {
+                query_sub_id,
+                callback,
+            },
+        );
+        self.subscription_reverse.insert(query_sub_id, handle);
+        self.immediate_tick();
+    }
+
     // =========================================================================
     // Subscriptions
     // =========================================================================
@@ -110,37 +160,115 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
             local_updates = ?durability.local_updates
         )
         .entered();
-        let query_sub_id = self
-            .schema_manager
-            .query_manager_mut()
-            .subscribe_with_sync_and_propagation_with_local_updates(
-                query,
-                session,
-                durability.tier,
-                durability.local_updates,
-                propagation,
-            )
-            .map_err(|e| RuntimeError::QueryError(format!("{:?}", e)))?;
-
-        let handle = SubscriptionHandle(self.next_subscription_handle);
-        self.next_subscription_handle += 1;
+        let query_sub_id = self.subscribe_query(query, session, durability, propagation)?;
+        let handle = self.allocate_subscription_handle();
         debug!(handle = handle.0, sub_id = query_sub_id.0, "subscribed");
-
-        self.subscriptions.insert(
-            handle,
-            SubscriptionState {
-                query_sub_id,
-                callback,
-            },
-        );
-        self.subscription_reverse.insert(query_sub_id, handle);
-
-        self.immediate_tick();
+        self.activate_subscription(handle, query_sub_id, callback);
         Ok(handle)
     }
 
-    /// Unsubscribe from a query.
+    // =========================================================================
+    // Two-phase subscribe: create + execute
+    // =========================================================================
+
+    /// Phase 1: allocate a handle and store query params. No compilation, no
+    /// sync, no tick — just bookkeeping.
+    pub fn create_subscription(
+        &mut self,
+        query: Query,
+        session: Option<Session>,
+        durability: ReadDurabilityOptions,
+        propagation: QueryPropagation,
+    ) -> SubscriptionHandle {
+        let handle = self.allocate_subscription_handle();
+        debug!(
+            handle = handle.0,
+            table = query.table.as_str(),
+            "subscription created (pending)"
+        );
+        self.pending_subscriptions.insert(
+            handle,
+            PendingSubscription {
+                query,
+                session,
+                durability,
+                propagation,
+            },
+        );
+        handle
+    }
+
+    /// Phase 2: compile graph, register with QueryManager, sync to servers,
+    /// attach callback, and run `immediate_tick` to deliver the first delta.
+    ///
+    /// No-ops silently if the handle was already unsubscribed between create
+    /// and execute.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn execute_subscription<F>(
+        &mut self,
+        handle: SubscriptionHandle,
+        callback: F,
+    ) -> Result<(), RuntimeError>
+    where
+        F: Fn(SubscriptionDelta) + Send + 'static,
+    {
+        self.execute_subscription_impl(handle, Box::new(callback))
+    }
+
+    /// Phase 2 (WASM version — no Send required).
+    #[cfg(target_arch = "wasm32")]
+    pub fn execute_subscription<F>(
+        &mut self,
+        handle: SubscriptionHandle,
+        callback: F,
+    ) -> Result<(), RuntimeError>
+    where
+        F: Fn(SubscriptionDelta) + 'static,
+    {
+        self.execute_subscription_impl(handle, Box::new(callback))
+    }
+
+    fn execute_subscription_impl(
+        &mut self,
+        handle: SubscriptionHandle,
+        callback: SubscriptionCallback,
+    ) -> Result<(), RuntimeError> {
+        let Some(pending) = self.pending_subscriptions.remove(&handle) else {
+            return Ok(());
+        };
+
+        let _span = debug_span!(
+            "execute_subscription",
+            handle = handle.0,
+            table = pending.query.table.as_str(),
+            ?pending.durability.tier,
+            local_updates = ?pending.durability.local_updates
+        )
+        .entered();
+
+        let query_sub_id = self.subscribe_query(
+            pending.query,
+            pending.session,
+            pending.durability,
+            pending.propagation,
+        )?;
+
+        debug!(
+            handle = handle.0,
+            sub_id = query_sub_id.0,
+            "subscription executed"
+        );
+        self.activate_subscription(handle, query_sub_id, callback);
+        Ok(())
+    }
+
+    /// Unsubscribe from a query. Works for both pending (created but not
+    /// executed) and active subscriptions.
     pub fn unsubscribe(&mut self, handle: SubscriptionHandle) {
+        if self.pending_subscriptions.remove(&handle).is_some() {
+            debug!(handle = handle.0, "unsubscribed pending subscription");
+            return;
+        }
         if let Some(state) = self.subscriptions.remove(&handle) {
             self.subscription_reverse.remove(&state.query_sub_id);
             self.schema_manager

--- a/crates/jazz-wasm/src/runtime.rs
+++ b/crates/jazz-wasm/src/runtime.rs
@@ -40,6 +40,8 @@ use jazz_tools::object::ObjectId;
 #[cfg(target_arch = "wasm32")]
 use jazz_tools::query_manager::encoding::decode_row;
 use jazz_tools::query_manager::manager::LocalUpdates;
+#[cfg(target_arch = "wasm32")]
+use jazz_tools::query_manager::query::Query;
 use jazz_tools::query_manager::session::Session;
 #[cfg(target_arch = "wasm32")]
 use jazz_tools::query_manager::types::{Row, RowDescriptor};
@@ -146,6 +148,86 @@ fn parse_read_durability_options(
         },
         propagation,
     ))
+}
+
+#[cfg(target_arch = "wasm32")]
+fn parse_subscription_inputs(
+    query_json: &str,
+    session_json: Option<String>,
+    settled_tier: Option<String>,
+    options_json: Option<String>,
+) -> Result<
+    (
+        Query,
+        Option<Session>,
+        ReadDurabilityOptions,
+        QueryPropagation,
+    ),
+    JsError,
+> {
+    let query = parse_query(query_json).map_err(|e| JsError::new(&e))?;
+    let session = if let Some(json) = session_json {
+        Some(
+            serde_json::from_str::<Session>(&json)
+                .map_err(|e| JsError::new(&format!("Invalid session JSON: {}", e)))?,
+        )
+    } else {
+        None
+    };
+    let (durability, propagation) = parse_read_durability_options(settled_tier, options_json)?;
+    Ok((query, session, durability, propagation))
+}
+
+#[cfg(target_arch = "wasm32")]
+fn make_subscription_callback(on_update: Function) -> impl Fn(SubscriptionDelta) + 'static {
+    move |delta: SubscriptionDelta| {
+        let row_to_wasm = |row: &Row, descriptor: &RowDescriptor| -> SubscriptionRow {
+            let values = decode_row(descriptor, &row.data)
+                .map(|vals| vals.into_iter().map(Value::from).collect::<Vec<_>>())
+                .unwrap_or_default();
+            SubscriptionRow {
+                id: row.id.uuid().to_string(),
+                values,
+            }
+        };
+
+        let descriptor = &delta.descriptor;
+        let wasm_delta = SubscriptionRowDelta(
+            delta
+                .ordered_delta
+                .removed
+                .iter()
+                .map(|change| {
+                    SubscriptionRowChange::Removed(SubscriptionRowRemoved {
+                        kind: 1,
+                        id: change.id.uuid().to_string(),
+                        index: change.index,
+                    })
+                })
+                .chain(delta.ordered_delta.updated.iter().map(|change| {
+                    SubscriptionRowChange::Updated(SubscriptionRowUpdated {
+                        kind: 2,
+                        id: change.id.uuid().to_string(),
+                        index: change.new_index,
+                        row: change.row.as_ref().map(|row| row_to_wasm(row, descriptor)),
+                    })
+                }))
+                .chain(delta.ordered_delta.added.iter().map(|change| {
+                    SubscriptionRowChange::Added(SubscriptionRowAdded {
+                        kind: 0,
+                        id: change.id.uuid().to_string(),
+                        index: change.index,
+                        row: row_to_wasm(&change.row, descriptor),
+                    })
+                }))
+                .collect::<Vec<_>>(),
+        );
+
+        let serializer = serde_wasm_bindgen::Serializer::new().serialize_maps_as_objects(true);
+        if let Ok(delta_value) = wasm_delta.serialize(&serializer) {
+            let _ = on_update.call1(&JsValue::NULL, &delta_value);
+        }
+    }
 }
 
 fn parse_node_durability_tiers(tier: Option<&str>) -> Result<Vec<DurabilityTier>, JsError> {
@@ -699,67 +781,9 @@ impl WasmRuntime {
         options_json: Option<String>,
     ) -> Result<f64, JsError> {
         let _span = debug_span!("wasm::subscribe", tier = self.tier_label).entered();
-        let query = parse_query(query_json).map_err(|e| JsError::new(&e))?;
-
-        let session = if let Some(json) = session_json {
-            Some(
-                serde_json::from_str::<Session>(&json)
-                    .map_err(|e| JsError::new(&format!("Invalid session JSON: {}", e)))?,
-            )
-        } else {
-            None
-        };
-
-        let (durability, propagation) = parse_read_durability_options(settled_tier, options_json)?;
-
-        let callback = move |delta: SubscriptionDelta| {
-            let row_to_wasm = |row: &Row, descriptor: &RowDescriptor| -> SubscriptionRow {
-                let values = decode_row(descriptor, &row.data)
-                    .map(|vals| vals.into_iter().map(Value::from).collect::<Vec<_>>())
-                    .unwrap_or_default();
-                SubscriptionRow {
-                    id: row.id.uuid().to_string(),
-                    values,
-                }
-            };
-
-            let descriptor = &delta.descriptor;
-            let wasm_delta = SubscriptionRowDelta(
-                delta
-                    .ordered_delta
-                    .removed
-                    .iter()
-                    .map(|change| {
-                        SubscriptionRowChange::Removed(SubscriptionRowRemoved {
-                            kind: 1,
-                            id: change.id.uuid().to_string(),
-                            index: change.index,
-                        })
-                    })
-                    .chain(delta.ordered_delta.updated.iter().map(|change| {
-                        SubscriptionRowChange::Updated(SubscriptionRowUpdated {
-                            kind: 2,
-                            id: change.id.uuid().to_string(),
-                            index: change.new_index,
-                            row: change.row.as_ref().map(|row| row_to_wasm(row, descriptor)),
-                        })
-                    }))
-                    .chain(delta.ordered_delta.added.iter().map(|change| {
-                        SubscriptionRowChange::Added(SubscriptionRowAdded {
-                            kind: 0,
-                            id: change.id.uuid().to_string(),
-                            index: change.index,
-                            row: row_to_wasm(&change.row, descriptor),
-                        })
-                    }))
-                    .collect::<Vec<_>>(),
-            );
-
-            let serializer = serde_wasm_bindgen::Serializer::new().serialize_maps_as_objects(true);
-            if let Ok(delta_value) = wasm_delta.serialize(&serializer) {
-                let _ = on_update.call1(&JsValue::NULL, &delta_value);
-            }
-        };
+        let (query, session, durability, propagation) =
+            parse_subscription_inputs(query_json, session_json, settled_tier, options_json)?;
+        let callback = make_subscription_callback(on_update);
 
         let handle = self
             .core
@@ -787,6 +811,54 @@ impl WasmRuntime {
         self.core
             .borrow_mut()
             .unsubscribe(SubscriptionHandle(sub_id));
+    }
+
+    /// Phase 1 of 2-phase subscribe: allocate a handle and store query params.
+    /// No compilation, no sync, no tick — just bookkeeping.
+    #[cfg(target_arch = "wasm32")]
+    #[wasm_bindgen(js_name = createSubscription)]
+    pub fn create_subscription(
+        &self,
+        query_json: &str,
+        session_json: Option<String>,
+        settled_tier: Option<String>,
+        options_json: Option<String>,
+    ) -> Result<f64, JsError> {
+        let _span = debug_span!("wasm::createSubscription", tier = self.tier_label).entered();
+        let (query, session, durability, propagation) =
+            parse_subscription_inputs(query_json, session_json, settled_tier, options_json)?;
+
+        let handle =
+            self.core
+                .borrow_mut()
+                .create_subscription(query, session, durability, propagation);
+
+        tracing::debug!(handle = handle.0, "subscription created (pending)");
+        Ok(handle.0 as f64)
+    }
+
+    /// Phase 2 of 2-phase subscribe: compile graph, register subscription,
+    /// sync to servers, attach callback, and deliver the first delta.
+    ///
+    /// No-ops silently if the handle was already unsubscribed.
+    #[cfg(target_arch = "wasm32")]
+    #[wasm_bindgen(js_name = executeSubscription)]
+    pub fn execute_subscription(&self, handle: f64, on_update: Function) -> Result<(), JsError> {
+        let sub_handle = SubscriptionHandle(handle as u64);
+        let _span = debug_span!(
+            "wasm::executeSubscription",
+            handle = sub_handle.0,
+            tier = self.tier_label
+        )
+        .entered();
+        let callback = make_subscription_callback(on_update);
+
+        self.core
+            .borrow_mut()
+            .execute_subscription(sub_handle, callback)
+            .map_err(|e| JsError::new(&format!("Execute subscription failed: {:?}", e)))?;
+
+        Ok(())
     }
 
     // =========================================================================

--- a/packages/jazz-tools/src/react-native/jazz-rn-runtime-adapter.test.ts
+++ b/packages/jazz-tools/src/react-native/jazz-rn-runtime-adapter.test.ts
@@ -7,7 +7,9 @@ function createBinding(overrides: Partial<JazzRnRuntimeBinding> = {}): JazzRnRun
     addServer: vi.fn(),
     batchedTick: vi.fn(),
     close: vi.fn(),
+    createSubscription: vi.fn(() => 9n),
     delete_: vi.fn(),
+    executeSubscription: vi.fn(),
     flush: vi.fn(),
     getSchemaHash: vi.fn(() => "schema-hash"),
     insert: vi.fn((_table, _valuesJson) => "row-1"),
@@ -93,6 +95,34 @@ describe("JazzRnRuntimeAdapter", () => {
 
     adapter.unsubscribe(handle);
     expect(binding.unsubscribe).toHaveBeenCalledWith(7n);
+  });
+
+  it("bridges 2-phase createSubscription + executeSubscription with handle conversion", () => {
+    const binding = createBinding();
+    const adapter = new JazzRnRuntimeAdapter(binding, {});
+
+    const handle = adapter.createSubscription("{}", null, null);
+    expect(handle).toBe(9);
+    expect(binding.createSubscription).toHaveBeenCalledWith("{}", undefined, undefined);
+
+    const onUpdate = vi.fn();
+    adapter.executeSubscription(handle, onUpdate);
+
+    const executeMock = binding.executeSubscription as ReturnType<typeof vi.fn>;
+    expect(executeMock).toHaveBeenCalledTimes(1);
+    expect(executeMock.mock.calls[0][0]).toBe(9n);
+
+    const callbackObject = executeMock.mock.calls[0][1];
+    callbackObject.onUpdate('{"added":[],"removed":[],"updated":[],"pending":false}');
+    expect(onUpdate).toHaveBeenCalledWith({
+      added: [],
+      removed: [],
+      updated: [],
+      pending: false,
+    });
+
+    adapter.unsubscribe(handle);
+    expect(binding.unsubscribe).toHaveBeenCalledWith(9n);
   });
 
   it("swallows exceptions thrown by JS callbacks crossing the native boundary", () => {

--- a/packages/jazz-tools/src/react-native/jazz-rn-runtime-adapter.ts
+++ b/packages/jazz-tools/src/react-native/jazz-rn-runtime-adapter.ts
@@ -35,6 +35,12 @@ export interface JazzRnRuntimeBinding {
   query(queryJson: string, sessionJson: string | undefined, tier: string | undefined): string;
   removeServer(): void;
   setClientRole(clientId: string, role: string): void;
+  createSubscription(
+    queryJson: string,
+    sessionJson: string | undefined,
+    tier: string | undefined,
+  ): bigint;
+  executeSubscription(handle: bigint, callback: { onUpdate(deltaJson: string): void }): void;
   subscribe(
     queryJson: string,
     callback: { onUpdate(deltaJson: string): void },
@@ -141,6 +147,39 @@ export class JazzRnRuntimeAdapter implements Runtime {
   ): Promise<any> {
     const rowsJson = this.binding.query(query_json, session_json ?? undefined, tier ?? undefined);
     return JSON.parse(rowsJson);
+  }
+
+  createSubscription(
+    query_json: string,
+    session_json?: string | null,
+    tier?: string | null,
+  ): number {
+    const handle = this.binding.createSubscription(
+      query_json,
+      session_json ?? undefined,
+      tier ?? undefined,
+    );
+
+    const numericHandle = Number(handle);
+    if (!Number.isSafeInteger(numericHandle)) {
+      throw new Error(`Subscription handle ${handle.toString()} is outside safe integer range`);
+    }
+    this.handleMap.set(numericHandle, handle);
+    return numericHandle;
+  }
+
+  executeSubscription(handle: number, on_update: Function): void {
+    const nativeHandle = this.handleMap.get(handle) ?? BigInt(handle);
+    this.binding.executeSubscription(nativeHandle, {
+      onUpdate: (deltaJson: string) => {
+        try {
+          const parsed = JSON.parse(deltaJson) as unknown;
+          on_update(parsed);
+        } catch (error) {
+          swallowCallbackError("subscription", error);
+        }
+      },
+    });
   }
 
   subscribe(

--- a/packages/jazz-tools/src/runtime/client.for-request.test.ts
+++ b/packages/jazz-tools/src/runtime/client.for-request.test.ts
@@ -30,6 +30,7 @@ function makeClient() {
   const subscribeCalls: Array<
     [string, string | undefined, string | undefined, string | undefined]
   > = [];
+  const unsubscribeCalls: number[] = [];
   const subscribeCallbacks: Array<Function> = [];
 
   const runtime: Runtime = {
@@ -66,7 +67,9 @@ function makeClient() {
       subscribeCallbacks.push(onUpdate);
       return 1;
     },
-    unsubscribe: () => {},
+    unsubscribe: (handle: number) => {
+      unsubscribeCalls.push(handle);
+    },
     insertDurable: async () => "00000000-0000-0000-0000-000000000001",
     updateDurable: async () => {},
     deleteDurable: async () => {},
@@ -97,8 +100,13 @@ function makeClient() {
     client: new JazzClientCtor(runtime, context, "edge"),
     queryCalls,
     subscribeCalls,
+    unsubscribeCalls,
     subscribeCallbacks,
   };
+}
+
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve();
 }
 
 function makeClientWithContext(context: AppContext): JazzClient {
@@ -270,7 +278,7 @@ describe("JazzClient.forRequest", () => {
     expect(parsed).toHaveProperty("relation_ir");
   });
 
-  it("accepts query builders for subscribe calls", () => {
+  it("accepts query builders for subscribe calls", async () => {
     const { client, subscribeCalls } = makeClient();
 
     const builder = {
@@ -282,10 +290,12 @@ describe("JazzClient.forRequest", () => {
     const subId = client.subscribe(builder, () => {});
 
     expect(subId).toBe(1);
+    expect(subscribeCalls).toHaveLength(0);
+    await flushMicrotasks();
     expect(subscribeCalls[0][0]).toBe(builder._build());
   });
 
-  it("translates schema-aware query builders for subscribe calls", () => {
+  it("translates schema-aware query builders for subscribe calls", async () => {
     const { client, subscribeCalls } = makeClient();
 
     const builder = {
@@ -303,15 +313,18 @@ describe("JazzClient.forRequest", () => {
     const subId = client.subscribe(builder, () => {});
 
     expect(subId).toBe(1);
+    expect(subscribeCalls).toHaveLength(0);
+    await flushMicrotasks();
     const parsed = JSON.parse(subscribeCalls[0][0]) as Record<string, unknown>;
     expect(parsed.table).toBe("todos");
     expect(parsed).toHaveProperty("relation_ir");
   });
 
-  it("forwards structured RN delta payloads to subscription callbacks", () => {
+  it("forwards structured RN delta payloads to subscription callbacks", async () => {
     const { client, subscribeCallbacks } = makeClient();
     const callback = vi.fn();
     client.subscribe('{"table":"todos"}', callback);
+    await flushMicrotasks();
 
     subscribeCallbacks[0](
       JSON.stringify({
@@ -345,10 +358,11 @@ describe("JazzClient.forRequest", () => {
     });
   });
 
-  it("forwards partial structured deltas without throwing", () => {
+  it("forwards partial structured deltas without throwing", async () => {
     const { client, subscribeCallbacks } = makeClient();
     const callback = vi.fn();
     client.subscribe('{"table":"todos"}', callback);
+    await flushMicrotasks();
 
     expect(() =>
       subscribeCallbacks[0](
@@ -369,9 +383,219 @@ describe("JazzClient.forRequest", () => {
     expect(queryCalls[0][3]).toBe(JSON.stringify({ propagation: "local-only" }));
   });
 
-  it("passes query propagation options to runtime subscribe", () => {
+  it("passes query propagation options to runtime subscribe", async () => {
     const { client, subscribeCalls } = makeClient();
     client.subscribe('{"table":"todos"}', () => {}, { propagation: "local-only" });
+    await flushMicrotasks();
     expect(subscribeCalls[0][3]).toBe(JSON.stringify({ propagation: "local-only" }));
+  });
+
+  it("returns provisional subscription handle synchronously", () => {
+    const { client, subscribeCalls } = makeClient();
+    const subId = client.subscribe('{"table":"todos"}', () => {});
+    expect(subId).toBe(1);
+    expect(subscribeCalls).toHaveLength(0);
+  });
+
+  it("defers runtime subscribe to a microtask", async () => {
+    const { client, subscribeCalls } = makeClient();
+    client.subscribe('{"table":"todos"}', () => {});
+    expect(subscribeCalls).toHaveLength(0);
+    await flushMicrotasks();
+    expect(subscribeCalls).toHaveLength(1);
+  });
+
+  it("cancel-before-bind: unsubscribe before microtask prevents runtime subscribe", async () => {
+    const { client, subscribeCalls, unsubscribeCalls } = makeClient();
+    const subId = client.subscribe('{"table":"todos"}', () => {});
+    client.unsubscribe(subId);
+    await flushMicrotasks();
+    expect(subscribeCalls).toHaveLength(0);
+    expect(unsubscribeCalls).toHaveLength(0);
+  });
+
+  it("unsubscribe after bind unsubscribes runtime handle", async () => {
+    const { client, unsubscribeCalls } = makeClient();
+    const subId = client.subscribe('{"table":"todos"}', () => {});
+    await flushMicrotasks();
+    client.unsubscribe(subId);
+    expect(unsubscribeCalls).toEqual([1]);
+  });
+
+  it("unsubscribe unknown handle is a no-op", () => {
+    const { client } = makeClient();
+    expect(() => client.unsubscribe(123_456)).not.toThrow();
+  });
+
+  it("subscribe bind failure cleans up subscription state", async () => {
+    const runtime: Runtime = {
+      insert: () => "00000000-0000-0000-0000-000000000001",
+      update: () => {},
+      delete: () => {},
+      query: async () => [],
+      subscribe: () => {
+        throw new Error("subscribe failed");
+      },
+      unsubscribe: () => {},
+      insertDurable: async () => "00000000-0000-0000-0000-000000000001",
+      updateDurable: async () => {},
+      deleteDurable: async () => {},
+      onSyncMessageReceived: () => {},
+      onSyncMessageToSend: () => {},
+      addServer: () => {},
+      removeServer: () => {},
+      addClient: () => "00000000-0000-0000-0000-000000000001",
+      getSchema: () => ({}),
+      getSchemaHash: () => "schema-hash",
+    };
+    const context: AppContext = {
+      appId: "test-app",
+      schema: {},
+      serverUrl: "http://localhost:1625",
+      backendSecret: "test-backend-secret",
+    };
+    const JazzClientCtor = JazzClient as unknown as {
+      new (
+        runtime: Runtime,
+        context: AppContext,
+        defaultDurabilityTier: "worker" | "edge" | "global",
+      ): JazzClient;
+    };
+    const client = new JazzClientCtor(runtime, context, "edge");
+
+    const subId = client.subscribe('{"table":"todos"}', () => {});
+    await flushMicrotasks();
+
+    // Should not throw after failed bind; state must already be cleaned up.
+    expect(() => client.unsubscribe(subId)).not.toThrow();
+  });
+
+  it("uses runtime-provided scheduler when available", () => {
+    const scheduleCalls: Array<() => void> = [];
+    const subscribeCalls: string[] = [];
+    const runtime: Runtime = {
+      schedule: (task) => {
+        scheduleCalls.push(task);
+      },
+      insert: () => "00000000-0000-0000-0000-000000000001",
+      update: () => {},
+      delete: () => {},
+      query: async () => [],
+      subscribe: (queryJson: string) => {
+        subscribeCalls.push(queryJson);
+        return 1;
+      },
+      unsubscribe: () => {},
+      insertDurable: async () => "00000000-0000-0000-0000-000000000001",
+      updateDurable: async () => {},
+      deleteDurable: async () => {},
+      onSyncMessageReceived: () => {},
+      onSyncMessageToSend: () => {},
+      addServer: () => {},
+      removeServer: () => {},
+      addClient: () => "00000000-0000-0000-0000-000000000001",
+      getSchema: () => ({}),
+      getSchemaHash: () => "schema-hash",
+    };
+    const context: AppContext = {
+      appId: "test-app",
+      schema: {},
+      serverUrl: "http://localhost:1625",
+      backendSecret: "test-backend-secret",
+    };
+    const JazzClientCtor = JazzClient as unknown as {
+      new (
+        runtime: Runtime,
+        context: AppContext,
+        defaultDurabilityTier: "worker" | "edge" | "global",
+      ): JazzClient;
+    };
+    const client = new JazzClientCtor(runtime, context, "edge");
+
+    client.subscribe('{"table":"todos"}', () => {});
+    expect(scheduleCalls).toHaveLength(1);
+    expect(subscribeCalls).toHaveLength(0);
+
+    scheduleCalls[0]();
+    expect(subscribeCalls).toEqual(['{"table":"todos"}']);
+  });
+
+  it("browser default scheduler uses postTask with user-visible priority", () => {
+    const priorWindow = (globalThis as { window?: unknown }).window;
+    const priorDocument = (globalThis as { document?: unknown }).document;
+    const priorScheduler = (globalThis as { scheduler?: unknown }).scheduler;
+
+    const postTask = vi.fn((task: () => void) => {
+      task();
+      return Promise.resolve();
+    });
+
+    Object.defineProperty(globalThis, "window", { value: {}, configurable: true });
+    Object.defineProperty(globalThis, "document", { value: {}, configurable: true });
+    Object.defineProperty(globalThis, "scheduler", { value: { postTask }, configurable: true });
+
+    try {
+      const subscribeCalls: string[] = [];
+      const runtime: Runtime = {
+        insert: () => "00000000-0000-0000-0000-000000000001",
+        update: () => {},
+        delete: () => {},
+        query: async () => [],
+        subscribe: (queryJson: string) => {
+          subscribeCalls.push(queryJson);
+          return 1;
+        },
+        unsubscribe: () => {},
+        insertDurable: async () => "00000000-0000-0000-0000-000000000001",
+        updateDurable: async () => {},
+        deleteDurable: async () => {},
+        onSyncMessageReceived: () => {},
+        onSyncMessageToSend: () => {},
+        addServer: () => {},
+        removeServer: () => {},
+        addClient: () => "00000000-0000-0000-0000-000000000001",
+        getSchema: () => ({}),
+        getSchemaHash: () => "schema-hash",
+      };
+      const context: AppContext = {
+        appId: "test-app",
+        schema: {},
+        serverUrl: "http://localhost:1625",
+        backendSecret: "test-backend-secret",
+      };
+      const JazzClientCtor = JazzClient as unknown as {
+        new (
+          runtime: Runtime,
+          context: AppContext,
+          defaultDurabilityTier: "worker" | "edge" | "global",
+        ): JazzClient;
+      };
+      const client = new JazzClientCtor(runtime, context, "edge");
+
+      client.subscribe('{"table":"todos"}', () => {});
+
+      expect(postTask).toHaveBeenCalledTimes(1);
+      expect(postTask).toHaveBeenCalledWith(expect.any(Function), { priority: "user-visible" });
+      expect(subscribeCalls).toEqual(['{"table":"todos"}']);
+    } finally {
+      if (priorWindow === undefined) {
+        delete (globalThis as { window?: unknown }).window;
+      } else {
+        Object.defineProperty(globalThis, "window", { value: priorWindow, configurable: true });
+      }
+      if (priorDocument === undefined) {
+        delete (globalThis as { document?: unknown }).document;
+      } else {
+        Object.defineProperty(globalThis, "document", { value: priorDocument, configurable: true });
+      }
+      if (priorScheduler === undefined) {
+        delete (globalThis as { scheduler?: unknown }).scheduler;
+      } else {
+        Object.defineProperty(globalThis, "scheduler", {
+          value: priorScheduler,
+          configurable: true,
+        });
+      }
+    }
   });
 });

--- a/packages/jazz-tools/src/runtime/client.for-request.test.ts
+++ b/packages/jazz-tools/src/runtime/client.for-request.test.ts
@@ -24,14 +24,19 @@ function makeJwt(payload: Record<string, unknown>): string {
   return `${toBase64Url(header)}.${toBase64Url(payload)}.signature`;
 }
 
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve();
+}
+
 function makeClient() {
   const queryCalls: Array<[string, string | undefined, string | undefined, string | undefined]> =
     [];
-  const subscribeCalls: Array<
+  const createSubscriptionCalls: Array<
     [string, string | undefined, string | undefined, string | undefined]
   > = [];
+  const executeSubscriptionCalls: Array<[number, Function]> = [];
   const unsubscribeCalls: number[] = [];
-  const subscribeCallbacks: Array<Function> = [];
+  let nextHandle = 0;
 
   const runtime: Runtime = {
     insert: () => "00000000-0000-0000-0000-000000000001",
@@ -51,21 +56,23 @@ function makeClient() {
       ]);
       return [];
     },
-    subscribe: (
+    subscribe: () => nextHandle++,
+    createSubscription: (
       queryJson: string,
-      onUpdate: Function,
       sessionJson?: string | null,
       tier?: string | null,
       optionsJson?: string | null,
     ) => {
-      subscribeCalls.push([
+      createSubscriptionCalls.push([
         queryJson,
         sessionJson ?? undefined,
         tier ?? undefined,
         optionsJson ?? undefined,
       ]);
-      subscribeCallbacks.push(onUpdate);
-      return 1;
+      return nextHandle++;
+    },
+    executeSubscription: (handle: number, onUpdate: Function) => {
+      executeSubscriptionCalls.push([handle, onUpdate]);
     },
     unsubscribe: (handle: number) => {
       unsubscribeCalls.push(handle);
@@ -99,23 +106,22 @@ function makeClient() {
   return {
     client: new JazzClientCtor(runtime, context, "edge"),
     queryCalls,
-    subscribeCalls,
+    createSubscriptionCalls,
+    executeSubscriptionCalls,
     unsubscribeCalls,
-    subscribeCallbacks,
   };
 }
 
-async function flushMicrotasks(): Promise<void> {
-  await Promise.resolve();
-}
-
 function makeClientWithContext(context: AppContext): JazzClient {
+  let nextHandle = 0;
   const runtime: Runtime = {
     insert: () => "00000000-0000-0000-0000-000000000001",
     update: () => {},
     delete: () => {},
     query: async () => [],
-    subscribe: () => 1,
+    subscribe: () => nextHandle++,
+    createSubscription: () => nextHandle++,
+    executeSubscription: () => {},
     unsubscribe: () => {},
     insertDurable: async () => "00000000-0000-0000-0000-000000000001",
     updateDurable: async () => {},
@@ -279,7 +285,7 @@ describe("JazzClient.forRequest", () => {
   });
 
   it("accepts query builders for subscribe calls", async () => {
-    const { client, subscribeCalls } = makeClient();
+    const { client, createSubscriptionCalls, executeSubscriptionCalls } = makeClient();
 
     const builder = {
       _build() {
@@ -287,16 +293,17 @@ describe("JazzClient.forRequest", () => {
       },
     };
 
-    const subId = client.subscribe(builder, () => {});
+    client.subscribe(builder, () => {});
 
-    expect(subId).toBe(1);
-    expect(subscribeCalls).toHaveLength(0);
+    expect(createSubscriptionCalls).toHaveLength(1);
+    expect(createSubscriptionCalls[0][0]).toBe(builder._build());
+    expect(executeSubscriptionCalls).toHaveLength(0);
     await flushMicrotasks();
-    expect(subscribeCalls[0][0]).toBe(builder._build());
+    expect(executeSubscriptionCalls).toHaveLength(1);
   });
 
   it("translates schema-aware query builders for subscribe calls", async () => {
-    const { client, subscribeCalls } = makeClient();
+    const { client, createSubscriptionCalls } = makeClient();
 
     const builder = {
       _schema: schemaWithTodos,
@@ -310,23 +317,22 @@ describe("JazzClient.forRequest", () => {
       },
     };
 
-    const subId = client.subscribe(builder, () => {});
+    client.subscribe(builder, () => {});
 
-    expect(subId).toBe(1);
-    expect(subscribeCalls).toHaveLength(0);
-    await flushMicrotasks();
-    const parsed = JSON.parse(subscribeCalls[0][0]) as Record<string, unknown>;
+    expect(createSubscriptionCalls).toHaveLength(1);
+    const parsed = JSON.parse(createSubscriptionCalls[0][0]) as Record<string, unknown>;
     expect(parsed.table).toBe("todos");
     expect(parsed).toHaveProperty("relation_ir");
   });
 
   it("forwards structured RN delta payloads to subscription callbacks", async () => {
-    const { client, subscribeCallbacks } = makeClient();
+    const { client, executeSubscriptionCalls } = makeClient();
     const callback = vi.fn();
     client.subscribe('{"table":"todos"}', callback);
     await flushMicrotasks();
 
-    subscribeCallbacks[0](
+    const onUpdate = executeSubscriptionCalls[0][1];
+    onUpdate(
       JSON.stringify({
         added: [{ row: { id: "row-a", values: [] }, index: 0 }],
         removed: [{ row: { id: "row-r", values: [] }, index: 1 }],
@@ -359,13 +365,14 @@ describe("JazzClient.forRequest", () => {
   });
 
   it("forwards partial structured deltas without throwing", async () => {
-    const { client, subscribeCallbacks } = makeClient();
+    const { client, executeSubscriptionCalls } = makeClient();
     const callback = vi.fn();
     client.subscribe('{"table":"todos"}', callback);
     await flushMicrotasks();
 
+    const onUpdate = executeSubscriptionCalls[0][1];
     expect(() =>
-      subscribeCallbacks[0](
+      onUpdate(
         JSON.stringify({
           pending: true,
         }),
@@ -383,219 +390,57 @@ describe("JazzClient.forRequest", () => {
     expect(queryCalls[0][3]).toBe(JSON.stringify({ propagation: "local-only" }));
   });
 
-  it("passes query propagation options to runtime subscribe", async () => {
-    const { client, subscribeCalls } = makeClient();
+  it("passes query propagation options to runtime createSubscription", () => {
+    const { client, createSubscriptionCalls } = makeClient();
     client.subscribe('{"table":"todos"}', () => {}, { propagation: "local-only" });
-    await flushMicrotasks();
-    expect(subscribeCalls[0][3]).toBe(JSON.stringify({ propagation: "local-only" }));
+    expect(createSubscriptionCalls[0][3]).toBe(JSON.stringify({ propagation: "local-only" }));
   });
 
-  it("returns provisional subscription handle synchronously", () => {
-    const { client, subscribeCalls } = makeClient();
-    const subId = client.subscribe('{"table":"todos"}', () => {});
-    expect(subId).toBe(1);
-    expect(subscribeCalls).toHaveLength(0);
-  });
+  // =========================================================================
+  // 2-phase subscribe lifecycle
+  // =========================================================================
 
-  it("defers runtime subscribe to a microtask", async () => {
-    const { client, subscribeCalls } = makeClient();
+  it("createSubscription is called synchronously, executeSubscription is deferred", async () => {
+    const { client, createSubscriptionCalls, executeSubscriptionCalls } = makeClient();
     client.subscribe('{"table":"todos"}', () => {});
-    expect(subscribeCalls).toHaveLength(0);
+
+    expect(createSubscriptionCalls).toHaveLength(1);
+    expect(executeSubscriptionCalls).toHaveLength(0);
+
     await flushMicrotasks();
-    expect(subscribeCalls).toHaveLength(1);
+    expect(executeSubscriptionCalls).toHaveLength(1);
   });
 
-  it("cancel-before-bind: unsubscribe before microtask prevents runtime subscribe", async () => {
-    const { client, subscribeCalls, unsubscribeCalls } = makeClient();
+  it("returns the handle from runtime.createSubscription", () => {
+    const { client } = makeClient();
+    const subId = client.subscribe('{"table":"todos"}', () => {});
+    expect(subId).toBe(0);
+    const subId2 = client.subscribe('{"table":"todos"}', () => {});
+    expect(subId2).toBe(1);
+  });
+
+  it("unsubscribe before execute calls runtime.unsubscribe with the handle", async () => {
+    const { client, executeSubscriptionCalls, unsubscribeCalls } = makeClient();
     const subId = client.subscribe('{"table":"todos"}', () => {});
     client.unsubscribe(subId);
+
+    expect(unsubscribeCalls).toEqual([0]);
+
     await flushMicrotasks();
-    expect(subscribeCalls).toHaveLength(0);
-    expect(unsubscribeCalls).toHaveLength(0);
+    // executeSubscription still fires (the runtime no-ops since handle was already unsubscribed)
+    expect(executeSubscriptionCalls).toHaveLength(1);
   });
 
-  it("unsubscribe after bind unsubscribes runtime handle", async () => {
+  it("unsubscribe after execute calls runtime.unsubscribe", async () => {
     const { client, unsubscribeCalls } = makeClient();
     const subId = client.subscribe('{"table":"todos"}', () => {});
     await flushMicrotasks();
     client.unsubscribe(subId);
-    expect(unsubscribeCalls).toEqual([1]);
+    expect(unsubscribeCalls).toEqual([0]);
   });
 
   it("unsubscribe unknown handle is a no-op", () => {
     const { client } = makeClient();
     expect(() => client.unsubscribe(123_456)).not.toThrow();
-  });
-
-  it("subscribe bind failure cleans up subscription state", async () => {
-    const runtime: Runtime = {
-      insert: () => "00000000-0000-0000-0000-000000000001",
-      update: () => {},
-      delete: () => {},
-      query: async () => [],
-      subscribe: () => {
-        throw new Error("subscribe failed");
-      },
-      unsubscribe: () => {},
-      insertDurable: async () => "00000000-0000-0000-0000-000000000001",
-      updateDurable: async () => {},
-      deleteDurable: async () => {},
-      onSyncMessageReceived: () => {},
-      onSyncMessageToSend: () => {},
-      addServer: () => {},
-      removeServer: () => {},
-      addClient: () => "00000000-0000-0000-0000-000000000001",
-      getSchema: () => ({}),
-      getSchemaHash: () => "schema-hash",
-    };
-    const context: AppContext = {
-      appId: "test-app",
-      schema: {},
-      serverUrl: "http://localhost:1625",
-      backendSecret: "test-backend-secret",
-    };
-    const JazzClientCtor = JazzClient as unknown as {
-      new (
-        runtime: Runtime,
-        context: AppContext,
-        defaultDurabilityTier: "worker" | "edge" | "global",
-      ): JazzClient;
-    };
-    const client = new JazzClientCtor(runtime, context, "edge");
-
-    const subId = client.subscribe('{"table":"todos"}', () => {});
-    await flushMicrotasks();
-
-    // Should not throw after failed bind; state must already be cleaned up.
-    expect(() => client.unsubscribe(subId)).not.toThrow();
-  });
-
-  it("uses runtime-provided scheduler when available", () => {
-    const scheduleCalls: Array<() => void> = [];
-    const subscribeCalls: string[] = [];
-    const runtime: Runtime = {
-      schedule: (task) => {
-        scheduleCalls.push(task);
-      },
-      insert: () => "00000000-0000-0000-0000-000000000001",
-      update: () => {},
-      delete: () => {},
-      query: async () => [],
-      subscribe: (queryJson: string) => {
-        subscribeCalls.push(queryJson);
-        return 1;
-      },
-      unsubscribe: () => {},
-      insertDurable: async () => "00000000-0000-0000-0000-000000000001",
-      updateDurable: async () => {},
-      deleteDurable: async () => {},
-      onSyncMessageReceived: () => {},
-      onSyncMessageToSend: () => {},
-      addServer: () => {},
-      removeServer: () => {},
-      addClient: () => "00000000-0000-0000-0000-000000000001",
-      getSchema: () => ({}),
-      getSchemaHash: () => "schema-hash",
-    };
-    const context: AppContext = {
-      appId: "test-app",
-      schema: {},
-      serverUrl: "http://localhost:1625",
-      backendSecret: "test-backend-secret",
-    };
-    const JazzClientCtor = JazzClient as unknown as {
-      new (
-        runtime: Runtime,
-        context: AppContext,
-        defaultDurabilityTier: "worker" | "edge" | "global",
-      ): JazzClient;
-    };
-    const client = new JazzClientCtor(runtime, context, "edge");
-
-    client.subscribe('{"table":"todos"}', () => {});
-    expect(scheduleCalls).toHaveLength(1);
-    expect(subscribeCalls).toHaveLength(0);
-
-    scheduleCalls[0]();
-    expect(subscribeCalls).toEqual(['{"table":"todos"}']);
-  });
-
-  it("browser default scheduler uses postTask with user-visible priority", () => {
-    const priorWindow = (globalThis as { window?: unknown }).window;
-    const priorDocument = (globalThis as { document?: unknown }).document;
-    const priorScheduler = (globalThis as { scheduler?: unknown }).scheduler;
-
-    const postTask = vi.fn((task: () => void) => {
-      task();
-      return Promise.resolve();
-    });
-
-    Object.defineProperty(globalThis, "window", { value: {}, configurable: true });
-    Object.defineProperty(globalThis, "document", { value: {}, configurable: true });
-    Object.defineProperty(globalThis, "scheduler", { value: { postTask }, configurable: true });
-
-    try {
-      const subscribeCalls: string[] = [];
-      const runtime: Runtime = {
-        insert: () => "00000000-0000-0000-0000-000000000001",
-        update: () => {},
-        delete: () => {},
-        query: async () => [],
-        subscribe: (queryJson: string) => {
-          subscribeCalls.push(queryJson);
-          return 1;
-        },
-        unsubscribe: () => {},
-        insertDurable: async () => "00000000-0000-0000-0000-000000000001",
-        updateDurable: async () => {},
-        deleteDurable: async () => {},
-        onSyncMessageReceived: () => {},
-        onSyncMessageToSend: () => {},
-        addServer: () => {},
-        removeServer: () => {},
-        addClient: () => "00000000-0000-0000-0000-000000000001",
-        getSchema: () => ({}),
-        getSchemaHash: () => "schema-hash",
-      };
-      const context: AppContext = {
-        appId: "test-app",
-        schema: {},
-        serverUrl: "http://localhost:1625",
-        backendSecret: "test-backend-secret",
-      };
-      const JazzClientCtor = JazzClient as unknown as {
-        new (
-          runtime: Runtime,
-          context: AppContext,
-          defaultDurabilityTier: "worker" | "edge" | "global",
-        ): JazzClient;
-      };
-      const client = new JazzClientCtor(runtime, context, "edge");
-
-      client.subscribe('{"table":"todos"}', () => {});
-
-      expect(postTask).toHaveBeenCalledTimes(1);
-      expect(postTask).toHaveBeenCalledWith(expect.any(Function), { priority: "user-visible" });
-      expect(subscribeCalls).toEqual(['{"table":"todos"}']);
-    } finally {
-      if (priorWindow === undefined) {
-        delete (globalThis as { window?: unknown }).window;
-      } else {
-        Object.defineProperty(globalThis, "window", { value: priorWindow, configurable: true });
-      }
-      if (priorDocument === undefined) {
-        delete (globalThis as { document?: unknown }).document;
-      } else {
-        Object.defineProperty(globalThis, "document", { value: priorDocument, configurable: true });
-      }
-      if (priorScheduler === undefined) {
-        delete (globalThis as { scheduler?: unknown }).scheduler;
-      } else {
-        Object.defineProperty(globalThis, "scheduler", {
-          value: priorScheduler,
-          configurable: true,
-        });
-      }
-    }
   });
 });

--- a/packages/jazz-tools/src/runtime/client.ts
+++ b/packages/jazz-tools/src/runtime/client.ts
@@ -44,6 +44,7 @@ export interface RequestLike {
  * satisfy this interface, allowing `JazzClient` to work with either backend.
  */
 export interface Runtime {
+  schedule?: (task: () => void) => void;
   insert(table: string, values: any): string;
   insertDurable(table: string, values: any, tier: string): Promise<string>;
   update(object_id: string, values: any): void;
@@ -117,6 +118,22 @@ export interface LinkExternalIdentityOptions {
 
 export type LinkExternalIdentityResult = LinkExternalResponse;
 
+type PendingSubscriptionState = {
+  queryJson: string;
+  sessionJson?: string;
+  tier?: string;
+  optionsJson?: string;
+  callback: SubscriptionCallback;
+  canceled: boolean;
+};
+
+type BrowserScheduler = {
+  postTask?: (
+    task: () => void,
+    options?: { priority?: "user-blocking" | "user-visible" | "background" },
+  ) => Promise<unknown>;
+};
+
 /**
  * QueryBuilder-compatible input accepted by query and subscribe APIs.
  */
@@ -160,6 +177,18 @@ function resolveNodeTier(tier: AppContext["tier"]): string | undefined {
 
 function isBrowserRuntime(): boolean {
   return typeof window !== "undefined" && typeof document !== "undefined";
+}
+
+function defaultRuntimeScheduler(): (task: () => void) => void {
+  if ("scheduler" in globalThis) {
+    return (task: () => void) => {
+      // See: https://developer.mozilla.org/en-US/docs/Web/API/Scheduler/postTask
+      // @ts-ignore Scheduler is not yet provided by the dom library
+      void globalThis.scheduler.postTask(task, { priority: "user-visible" });
+    };
+  }
+
+  return queueMicrotask;
 }
 
 function resolveDefaultDurabilityTier(context: AppContext): DurabilityTier {
@@ -388,6 +417,10 @@ export class JazzClient {
   private streamController: SyncStreamController;
   private serverClientId: string = generateClientId();
   private subscriptions = new Map<number, SubscriptionCallback>();
+  private pendingSubscriptions = new Map<number, PendingSubscriptionState>();
+  private boundSubscriptions = new Map<number, number>();
+  private nextProvisionalSubscriptionId = 1;
+  private isShuttingDown = false;
   private context: AppContext;
   private resolvedSession: Session | null;
   private defaultDurabilityTier: DurabilityTier;
@@ -399,6 +432,7 @@ export class JazzClient {
     defaultDurabilityTier: DurabilityTier,
   ) {
     this.runtime = runtime;
+    this.runtime.schedule ??= defaultRuntimeScheduler();
     this.context = context;
     this.defaultDurabilityTier = defaultDurabilityTier;
     this.resolvedSession = resolveJwtSession(context.jwtToken ?? "");
@@ -683,20 +717,61 @@ export class JazzClient {
     const sessionJson = session ? JSON.stringify(session) : undefined;
     const queryJson = resolveQueryJson(query);
     const optionsJson = encodeQueryExecutionOptions(normalizedOptions);
-    const subId = this.runtime.subscribe(
+    const provisionalId = this.nextProvisionalSubscriptionId++;
+
+    this.subscriptions.set(provisionalId, callback);
+    this.pendingSubscriptions.set(provisionalId, {
       queryJson,
-      (deltaJsonOrObject: RowDelta | string) => {
-        // WASM runtime passes delta as JSON string, need to parse it
-        const delta: RowDelta =
-          typeof deltaJsonOrObject === "string" ? JSON.parse(deltaJsonOrObject) : deltaJsonOrObject;
-        callback(delta);
-      },
       sessionJson,
-      normalizedOptions.tier,
+      tier: normalizedOptions.tier,
       optionsJson,
-    );
-    this.subscriptions.set(subId, callback);
-    return subId;
+      callback,
+      canceled: false,
+    });
+
+    const schedule = this.runtime.schedule ?? ((task: () => void) => queueMicrotask(task));
+    schedule(() => {
+      this.bindPendingSubscription(provisionalId);
+    });
+
+    return provisionalId;
+  }
+
+  private bindPendingSubscription(provisionalId: number): void {
+    if (this.isShuttingDown) {
+      this.pendingSubscriptions.delete(provisionalId);
+      this.subscriptions.delete(provisionalId);
+      return;
+    }
+
+    const pending = this.pendingSubscriptions.get(provisionalId);
+    if (!pending || pending.canceled) {
+      this.pendingSubscriptions.delete(provisionalId);
+      this.subscriptions.delete(provisionalId);
+      return;
+    }
+
+    try {
+      const runtimeSubId = this.runtime.subscribe(
+        pending.queryJson,
+        (deltaJsonOrObject: RowDelta | string) => {
+          // WASM runtime passes delta as JSON string, need to parse it
+          const delta: RowDelta =
+            typeof deltaJsonOrObject === "string"
+              ? JSON.parse(deltaJsonOrObject)
+              : deltaJsonOrObject;
+          pending.callback(delta);
+        },
+        pending.sessionJson,
+        pending.tier,
+        pending.optionsJson,
+      );
+      this.boundSubscriptions.set(provisionalId, runtimeSubId);
+    } catch {
+      this.subscriptions.delete(provisionalId);
+    } finally {
+      this.pendingSubscriptions.delete(provisionalId);
+    }
   }
 
   /**
@@ -705,8 +780,28 @@ export class JazzClient {
    * @param subscriptionId ID returned from subscribe()
    */
   unsubscribe(subscriptionId: number): void {
-    this.runtime.unsubscribe(subscriptionId);
+    const pending = this.pendingSubscriptions.get(subscriptionId);
+    if (pending) {
+      pending.canceled = true;
+      this.pendingSubscriptions.delete(subscriptionId);
+      this.subscriptions.delete(subscriptionId);
+      return;
+    }
+
+    const runtimeSubId = this.boundSubscriptions.get(subscriptionId);
+    if (runtimeSubId === undefined) {
+      return;
+    }
+
+    this.boundSubscriptions.delete(subscriptionId);
     this.subscriptions.delete(subscriptionId);
+    this.runtime.unsubscribe(runtimeSubId);
+  }
+
+  private clearSubscriptionState(): void {
+    this.pendingSubscriptions.clear();
+    this.boundSubscriptions.clear();
+    this.subscriptions.clear();
   }
 
   /**
@@ -841,6 +936,8 @@ export class JazzClient {
    * Shutdown the client and release resources.
    */
   async shutdown(): Promise<void> {
+    this.isShuttingDown = true;
+    this.clearSubscriptionState();
     this.streamController.stop();
 
     // Close driver if it supports it

--- a/packages/jazz-tools/src/runtime/client.ts
+++ b/packages/jazz-tools/src/runtime/client.ts
@@ -44,7 +44,6 @@ export interface RequestLike {
  * satisfy this interface, allowing `JazzClient` to work with either backend.
  */
 export interface Runtime {
-  schedule?: (task: () => void) => void;
   insert(table: string, values: any): string;
   insertDurable(table: string, values: any, tier: string): Promise<string>;
   update(object_id: string, values: any): void;
@@ -64,6 +63,13 @@ export interface Runtime {
     tier?: string | null,
     options_json?: string | null,
   ): number;
+  createSubscription(
+    query_json: string,
+    session_json?: string | null,
+    tier?: string | null,
+    options_json?: string | null,
+  ): number;
+  executeSubscription(handle: number, on_update: Function): void;
   unsubscribe(handle: number): void;
   onSyncMessageReceived(payload: Uint8Array | string): void;
   onSyncMessageToSend(callback: RuntimeSyncOutboxCallback): void;
@@ -118,22 +124,6 @@ export interface LinkExternalIdentityOptions {
 
 export type LinkExternalIdentityResult = LinkExternalResponse;
 
-type PendingSubscriptionState = {
-  queryJson: string;
-  sessionJson?: string;
-  tier?: string;
-  optionsJson?: string;
-  callback: SubscriptionCallback;
-  canceled: boolean;
-};
-
-type BrowserScheduler = {
-  postTask?: (
-    task: () => void,
-    options?: { priority?: "user-blocking" | "user-visible" | "background" },
-  ) => Promise<unknown>;
-};
-
 /**
  * QueryBuilder-compatible input accepted by query and subscribe APIs.
  */
@@ -179,7 +169,7 @@ function isBrowserRuntime(): boolean {
   return typeof window !== "undefined" && typeof document !== "undefined";
 }
 
-function defaultRuntimeScheduler(): (task: () => void) => void {
+function getScheduler(): (task: () => void) => void {
   if ("scheduler" in globalThis) {
     return (task: () => void) => {
       // See: https://developer.mozilla.org/en-US/docs/Web/API/Scheduler/postTask
@@ -416,11 +406,7 @@ export class JazzClient {
   private runtime: Runtime;
   private streamController: SyncStreamController;
   private serverClientId: string = generateClientId();
-  private subscriptions = new Map<number, SubscriptionCallback>();
-  private pendingSubscriptions = new Map<number, PendingSubscriptionState>();
-  private boundSubscriptions = new Map<number, number>();
-  private nextProvisionalSubscriptionId = 1;
-  private isShuttingDown = false;
+  private scheduler: (task: () => void) => void;
   private context: AppContext;
   private resolvedSession: Session | null;
   private defaultDurabilityTier: DurabilityTier;
@@ -432,7 +418,7 @@ export class JazzClient {
     defaultDurabilityTier: DurabilityTier,
   ) {
     this.runtime = runtime;
-    this.runtime.schedule ??= defaultRuntimeScheduler();
+    this.scheduler = getScheduler();
     this.context = context;
     this.defaultDurabilityTier = defaultDurabilityTier;
     this.resolvedSession = resolveJwtSession(context.jwtToken ?? "");
@@ -705,6 +691,12 @@ export class JazzClient {
 
   /**
    * Internal subscribe with optional session and read durability options.
+   *
+   * Uses the runtime's 2-phase subscribe API: `createSubscription` allocates
+   * a handle synchronously (zero work), then `executeSubscription` is deferred
+   * via the scheduler so compilation + first tick run outside the caller's
+   * synchronous stack (e.g. outside a React render).
+   *
    * @internal
    */
   subscribeInternal(
@@ -717,61 +709,23 @@ export class JazzClient {
     const sessionJson = session ? JSON.stringify(session) : undefined;
     const queryJson = resolveQueryJson(query);
     const optionsJson = encodeQueryExecutionOptions(normalizedOptions);
-    const provisionalId = this.nextProvisionalSubscriptionId++;
 
-    this.subscriptions.set(provisionalId, callback);
-    this.pendingSubscriptions.set(provisionalId, {
+    const handle = this.runtime.createSubscription(
       queryJson,
       sessionJson,
-      tier: normalizedOptions.tier,
+      normalizedOptions.tier,
       optionsJson,
-      callback,
-      canceled: false,
+    );
+
+    this.scheduler(() => {
+      this.runtime.executeSubscription(handle, (deltaJsonOrObject: RowDelta | string) => {
+        const delta: RowDelta =
+          typeof deltaJsonOrObject === "string" ? JSON.parse(deltaJsonOrObject) : deltaJsonOrObject;
+        callback(delta);
+      });
     });
 
-    const schedule = this.runtime.schedule ?? ((task: () => void) => queueMicrotask(task));
-    schedule(() => {
-      this.bindPendingSubscription(provisionalId);
-    });
-
-    return provisionalId;
-  }
-
-  private bindPendingSubscription(provisionalId: number): void {
-    if (this.isShuttingDown) {
-      this.pendingSubscriptions.delete(provisionalId);
-      this.subscriptions.delete(provisionalId);
-      return;
-    }
-
-    const pending = this.pendingSubscriptions.get(provisionalId);
-    if (!pending || pending.canceled) {
-      this.pendingSubscriptions.delete(provisionalId);
-      this.subscriptions.delete(provisionalId);
-      return;
-    }
-
-    try {
-      const runtimeSubId = this.runtime.subscribe(
-        pending.queryJson,
-        (deltaJsonOrObject: RowDelta | string) => {
-          // WASM runtime passes delta as JSON string, need to parse it
-          const delta: RowDelta =
-            typeof deltaJsonOrObject === "string"
-              ? JSON.parse(deltaJsonOrObject)
-              : deltaJsonOrObject;
-          pending.callback(delta);
-        },
-        pending.sessionJson,
-        pending.tier,
-        pending.optionsJson,
-      );
-      this.boundSubscriptions.set(provisionalId, runtimeSubId);
-    } catch {
-      this.subscriptions.delete(provisionalId);
-    } finally {
-      this.pendingSubscriptions.delete(provisionalId);
-    }
+    return handle;
   }
 
   /**
@@ -780,28 +734,7 @@ export class JazzClient {
    * @param subscriptionId ID returned from subscribe()
    */
   unsubscribe(subscriptionId: number): void {
-    const pending = this.pendingSubscriptions.get(subscriptionId);
-    if (pending) {
-      pending.canceled = true;
-      this.pendingSubscriptions.delete(subscriptionId);
-      this.subscriptions.delete(subscriptionId);
-      return;
-    }
-
-    const runtimeSubId = this.boundSubscriptions.get(subscriptionId);
-    if (runtimeSubId === undefined) {
-      return;
-    }
-
-    this.boundSubscriptions.delete(subscriptionId);
-    this.subscriptions.delete(subscriptionId);
-    this.runtime.unsubscribe(runtimeSubId);
-  }
-
-  private clearSubscriptionState(): void {
-    this.pendingSubscriptions.clear();
-    this.boundSubscriptions.clear();
-    this.subscriptions.clear();
+    this.runtime.unsubscribe(subscriptionId);
   }
 
   /**
@@ -936,8 +869,6 @@ export class JazzClient {
    * Shutdown the client and release resources.
    */
   async shutdown(): Promise<void> {
-    this.isShuttingDown = true;
-    this.clearSubscriptionState();
     this.streamController.stop();
 
     // Close driver if it supports it

--- a/packages/jazz-tools/src/runtime/worker-bridge.test.ts
+++ b/packages/jazz-tools/src/runtime/worker-bridge.test.ts
@@ -67,8 +67,12 @@ function createRuntimeMock(): {
     insertDurable: async () => "id",
     updateDurable: async () => undefined,
     deleteDurable: async () => undefined,
-    onSyncMessageReceived: (payload: Uint8Array) => {
-      receivedFromWorker.push(payload);
+    createSubscription: () => 1,
+    executeSubscription: () => undefined,
+    onSyncMessageReceived: (payload: Uint8Array | string) => {
+      receivedFromWorker.push(
+        typeof payload === "string" ? new TextEncoder().encode(payload) : payload,
+      );
     },
     onSyncMessageToSend: (callback: SendSyncPayloadCallback) => {
       onSyncToSend = callback;

--- a/packages/jazz-tools/src/types/jazz-wasm.d.ts
+++ b/packages/jazz-tools/src/types/jazz-wasm.d.ts
@@ -20,6 +20,7 @@ declare module "jazz-wasm" {
 
   export class WasmRuntime {
     constructor(schemaJson: string, appId: string, env: string, userBranch: string, tier?: string);
+    schedule?: (task: () => void) => void;
 
     insert(table: string, values: unknown): string;
     insertDurable(table: string, values: unknown, tier: string): Promise<string>;

--- a/packages/jazz-tools/src/types/jazz-wasm.d.ts
+++ b/packages/jazz-tools/src/types/jazz-wasm.d.ts
@@ -34,6 +34,13 @@ declare module "jazz-wasm" {
       tier?: string | null,
       optionsJson?: string | null,
     ): Promise<unknown>;
+    createSubscription(
+      queryJson: string,
+      sessionJson?: string | null,
+      tier?: string | null,
+      optionsJson?: string | null,
+    ): number;
+    executeSubscription(handle: number, onUpdate: Function): void;
     subscribe(
       queryJson: string,
       onUpdate: Function,


### PR DESCRIPTION
I've started working on testing the UX of a "filter" input and noticed that sometimes the input becomes laggy due to the main thread building the subscription object

<img width="644" height="534" alt="Screenshot 2026-03-03 at 15 54 59" src="https://github.com/user-attachments/assets/d0d32530-14e3-4bda-8c6e-287c679c5e9f" />

Since there is no good reason for blocking the main thread I've wrapped the subscribe in the [Scheduler API](https://developer.mozilla.org/en-US/docs/Web/API/Scheduler/postTask) to make the subscription fire without blocking the user interactions.

<img width="737" height="645" alt="Screenshot 2026-03-03 at 16 01 27" src="https://github.com/user-attachments/assets/f7a6112b-862e-4492-aaae-8e486c4e3658" />

Currently the priority is set to `user-visible`, we could also make it lower and go for `background`:

> [user-visible](https://developer.mozilla.org/en-US/docs/Web/API/Prioritized_Task_Scheduling_API#user-visible)
Tasks that are visible to the user but not necessarily blocking user actions. This might include rendering non-essential parts of the page, such as non-essential images or animations.

> This is the default priority for scheduler.postTask() and scheduler.yield().

> [background](https://developer.mozilla.org/en-US/docs/Web/API/Prioritized_Task_Scheduling_API#background)
Tasks that are not time-critical. This might include log processing or initializing third party libraries that aren't required for rendering.

For this kind of task is probably best suited to go with `background`, but it feels more risky.
With the background the task is scheduled after React non-critical rendering parts, and we probably want to the subscription start as early as possible without interrupting the user interaction.

<img width="899" height="547" alt="Screenshot 2026-03-03 at 16 14 18" src="https://github.com/user-attachments/assets/6f447cda-5a49-4b2a-be72-7ae614bb6470" />

