### PR TITLE
feat: persist original json_schema 

### DIFF
--- a/crates/jazz-cloud-server/src/server.rs
+++ b/crates/jazz-cloud-server/src/server.rs
@@ -11,7 +11,7 @@ use axum::{
     extract::{Path as AxumPath, Query, State},
     http::{
         HeaderMap, HeaderValue, StatusCode,
-        header::{AUTHORIZATION, WWW_AUTHENTICATE},
+        header::{AUTHORIZATION, CONTENT_TYPE, WWW_AUTHENTICATE},
     },
     response::{Html, IntoResponse, Json},
     routing::{get, patch, post},
@@ -25,9 +25,7 @@ use jazz_tools::jazz_transport::{
 use jazz_tools::object::ObjectId;
 use jazz_tools::query_manager::query::QueryBuilder;
 use jazz_tools::query_manager::session::Session;
-use jazz_tools::query_manager::types::{
-    ColumnType, Schema, SchemaBuilder, SchemaHash, TableSchema, Value,
-};
+use jazz_tools::query_manager::types::{ColumnType, SchemaBuilder, SchemaHash, TableSchema, Value};
 use jazz_tools::runtime_core::ReadDurabilityOptions;
 use jazz_tools::runtime_tokio::TokioRuntime;
 use jazz_tools::schema_manager::{AppId, SchemaManager, rehydrate_schema_manager_from_manifest};
@@ -676,7 +674,7 @@ enum WorkerCommand {
     GetCatalogueSchema {
         app_id: AppId,
         schema_hash: SchemaHash,
-        response: tokio::sync::oneshot::Sender<Result<Option<Schema>, String>>,
+        response: tokio::sync::oneshot::Sender<Result<Option<String>, String>>,
     },
     GetSchemaHashes {
         app_id: AppId,
@@ -931,7 +929,7 @@ impl WorkerPool {
         &self,
         app_id: AppId,
         schema_hash: SchemaHash,
-    ) -> Result<Option<Schema>, WorkerDispatchError> {
+    ) -> Result<Option<String>, WorkerDispatchError> {
         let (response_tx, response_rx) = tokio::sync::oneshot::channel();
         let command = WorkerCommand::GetCatalogueSchema {
             app_id,
@@ -1822,7 +1820,7 @@ async fn run_worker_loop(
                         .and_then(|runtime| {
                             let maybe_schema = runtime
                                 .runtime
-                                .known_schema(&schema_hash)
+                                .known_schema_json(&schema_hash)
                                 .map_err(|err| err.to_string())?;
                             Ok(maybe_schema.as_ref().cloned())
                         });
@@ -3314,7 +3312,9 @@ async fn schema_catalogue_handler(
         .get_catalogue_schema(app_id, schema_hash)
         .await
     {
-        Ok(Some(schema)) => Json(schema).into_response(),
+        Ok(Some(schema_json)) => {
+            ([(CONTENT_TYPE, "application/json")], schema_json).into_response()
+        }
         Ok(None) => (
             StatusCode::NOT_FOUND,
             Json(ErrorResponse::not_found("schema catalogue not found")),

--- a/crates/jazz-cloud-server/tests/client_multi_integration.rs
+++ b/crates/jazz-cloud-server/tests/client_multi_integration.rs
@@ -528,6 +528,14 @@ async fn jazz_tools_sender_side_objectupdated_delay_should_not_return_stale_sett
     .await;
     client_a.shutdown().await.expect("shutdown client a");
     drop(seed_server);
+    wait_for_todos_count_on_disk(app_id, server_data.path(), 1, Duration::from_secs(20)).await;
+    wait_for_catalogue_manifest_schema_count_on_disk(
+        app_id,
+        server_data.path(),
+        1,
+        Duration::from_secs(20),
+    )
+    .await;
 
     // Phase 2: restart with delayed server->client ObjectUpdated sends.
     let delayed_server = ServerProcess::start_with_options(
@@ -550,27 +558,13 @@ async fn jazz_tools_sender_side_objectupdated_delay_should_not_return_stale_sett
     .await
     .expect("connect client b");
 
-    let query = QueryBuilder::new("todos").build();
-    let mut rows = None;
-    for _ in 0..3 {
-        match tokio::time::timeout(
-            Duration::from_secs(8),
-            client_b.query(query.clone(), Some(DurabilityTier::EdgeServer)),
-        )
-        .await
-        {
-            Ok(Ok(result_rows)) => {
-                rows = Some(result_rows);
-                break;
-            }
-            Ok(Err(err)) => panic!("client b query error: {err}"),
-            Err(_) => {
-                // Stream can race startup; retry to exercise ordering once connected.
-                continue;
-            }
-        }
-    }
-    let rows = rows.expect("client b query timeout after retries");
+    let rows = wait_for_todos_count(
+        &client_b,
+        1,
+        Duration::from_secs(20),
+        Some(DurabilityTier::EdgeServer),
+    )
+    .await;
 
     assert_eq!(
         rows.len(),

--- a/crates/jazz-cloud-server/tests/server_integration.rs
+++ b/crates/jazz-cloud-server/tests/server_integration.rs
@@ -736,6 +736,11 @@ async fn schema_catalogue_sync_and_retrieval_round_trip() {
         MetadataKey::SchemaHash.as_str().to_string(),
         hex::encode(schema_hash.as_bytes()),
     );
+    let pushed_schema_json = r#"{"users":{"columns":{"name":{"Text":null},"id":{"Uuid":null}}}}"#;
+    metadata.insert(
+        MetadataKey::SchemaJson.as_str().to_string(),
+        pushed_schema_json.to_string(),
+    );
 
     let sync_payload = json!({
         "client_id": Uuid::new_v4().to_string(),
@@ -790,8 +795,6 @@ async fn schema_catalogue_sync_and_retrieval_round_trip() {
         .get_schema_by_hash(&created.app_id, "admin-secret", &expected_hash)
         .await;
     assert_eq!(schema_response.status(), StatusCode::OK);
-
-    let schema_json: Value = schema_response.json().await.expect("schema json");
-    let expected_schema_json = serde_json::to_value(schema.clone()).expect("expected schema json");
-    assert_eq!(schema_json, expected_schema_json);
+    let schema_body = schema_response.text().await.expect("schema body");
+    assert_eq!(schema_body, pushed_schema_json);
 }

--- a/crates/jazz-tools/src/metadata.rs
+++ b/crates/jazz-tools/src/metadata.rs
@@ -17,6 +17,8 @@ pub enum MetadataKey {
     AppId,
     /// Schema content hash on catalogue schema objects.
     SchemaHash,
+    /// Original schema JSON string on catalogue schema objects.
+    SchemaJson,
     /// Source schema hash on catalogue lens objects.
     SourceHash,
     /// Target schema hash on catalogue lens objects.
@@ -33,6 +35,7 @@ impl MetadataKey {
             Self::Delete => "delete",
             Self::AppId => "app_id",
             Self::SchemaHash => "schema_hash",
+            Self::SchemaJson => "schema_json",
             Self::SourceHash => "source_hash",
             Self::TargetHash => "target_hash",
             Self::NoSync => "nosync",

--- a/crates/jazz-tools/src/routes.rs
+++ b/crates/jazz-tools/src/routes.rs
@@ -6,7 +6,10 @@ use std::time::Duration;
 use axum::{
     Router,
     extract::{Path, Query, State},
-    http::{HeaderMap, StatusCode, header::AUTHORIZATION},
+    http::{
+        HeaderMap, StatusCode,
+        header::{AUTHORIZATION, CONTENT_TYPE},
+    },
     response::{IntoResponse, Json},
     routing::{get, post},
 };
@@ -408,14 +411,13 @@ async fn schema_handler(
         }
     };
 
-    match state.runtime.known_schema(&schema_hash) {
-        Ok(Some(schema)) => {
+    match state.runtime.known_schema_json(&schema_hash) {
+        Ok(Some(schema_json)) => {
             tracing::info!(
                 requested_hash = %schema_hash.short(),
                 "schema request: returning requested hash"
             );
-            let body = schema.clone();
-            Json(body).into_response()
+            ([(CONTENT_TYPE, "application/json")], schema_json).into_response()
         }
         Ok(None) => (
             StatusCode::NOT_FOUND,
@@ -682,13 +684,13 @@ mod tests {
     use std::collections::HashMap;
 
     use axum::body;
-    use axum::routing::get;
+    use axum::routing::{get, post};
     use groove::query_manager::types::{ColumnType, SchemaBuilder, TableSchema};
     use groove::runtime_tokio::TokioRuntime;
-    use groove::schema_manager::{AppId, SchemaManager};
+    use groove::schema_manager::{AppId, SchemaManager, encode_schema};
     use groove::storage::SurrealKvStorage;
     use groove::sync_manager::{ClientId, DurabilityTier, SyncManager, SyncPayload};
-    use serde_json::Value;
+    use serde_json::{Value, json};
     use tempfile::TempDir;
     use tokio::sync::{RwLock, broadcast};
     use tower::util::ServiceExt;
@@ -880,5 +882,120 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(bad_hash_response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn schema_handler_returns_verbatim_pushed_schema_json() {
+        let data_dir = TempDir::new().expect("temp dir");
+        let db_path = data_dir.path().join("groove.surrealkv");
+        let storage =
+            SurrealKvStorage::open(&db_path, 64 * 1024 * 1024).expect("open test storage");
+
+        let sync_manager = SyncManager::new()
+            .with_durability_tiers([DurabilityTier::EdgeServer, DurabilityTier::GlobalServer]);
+        let schema_manager =
+            SchemaManager::new_server(sync_manager, AppId::from_name("test-app"), "prod");
+        let runtime = TokioRuntime::new(schema_manager, storage, |_entry| {});
+
+        let auth_config = AuthConfig {
+            backend_secret: None,
+            admin_secret: Some("admin-secret".to_string()),
+            allow_anonymous: true,
+            allow_demo: true,
+            jwks_url: None,
+            jwks_set: None,
+        };
+
+        let (sync_tx, _) = broadcast::channel::<(ClientId, SyncPayload)>(16);
+
+        let state = Arc::new(ServerState {
+            runtime,
+            app_id: AppId::from_name("test-app"),
+            connections: RwLock::new(HashMap::new()),
+            next_connection_id: std::sync::atomic::AtomicU64::new(1),
+            sync_broadcast: sync_tx,
+            auth_config,
+            external_identity_store: Arc::new(
+                ExternalIdentityStore::new(data_dir.path().to_str().unwrap()).unwrap(),
+            ),
+            external_identities: RwLock::new(HashMap::new()),
+        });
+
+        let app = axum::Router::new()
+            .route("/sync", post(sync_handler))
+            .route("/schema/:hash", get(schema_handler))
+            .route("/schemas", get(schema_hashes_handler))
+            .with_state(state);
+
+        let schema = SchemaBuilder::new()
+            .table(
+                TableSchema::builder("users")
+                    .column("id", ColumnType::Uuid)
+                    .column("name", ColumnType::Text),
+            )
+            .build();
+        let schema_hash = SchemaHash::compute(&schema);
+        let object_id = schema_hash.to_object_id().to_string();
+        let schema_json = r#"{"users":{"columns":{"name":{"Text":null},"id":{"Uuid":null}}}}"#;
+        let encoded_schema = encode_schema(&schema);
+
+        let sync_payload = json!({
+            "client_id": "01234567-89ab-cdef-0123-456789abcdef",
+            "payload": {
+                "ObjectUpdated": {
+                    "object_id": object_id,
+                    "metadata": {
+                        "id": object_id,
+                        "metadata": {
+                            "type": "catalogue_schema",
+                            "app_id": AppId::from_name("test-app").to_string(),
+                            "schema_hash": schema_hash.to_string(),
+                            "schema_json": schema_json,
+                        }
+                    },
+                    "branch_name": "main",
+                    "commits": [
+                        {
+                            "parents": [],
+                            "content": encoded_schema,
+                            "timestamp": 1,
+                            "author": "fedcba98-7654-3210-fedc-ba9876543210",
+                            "metadata": null
+                        }
+                    ]
+                }
+            }
+        });
+
+        let sync_response = app
+            .clone()
+            .oneshot(
+                axum::http::Request::builder()
+                    .method("POST")
+                    .uri("/sync")
+                    .header("content-type", "application/json")
+                    .header("X-Jazz-Admin-Secret", "admin-secret")
+                    .body(axum::body::Body::from(sync_payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(sync_response.status(), StatusCode::OK);
+
+        let schema_response = app
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri(format!("/schema/{}", schema_hash))
+                    .header("X-Jazz-Admin-Secret", "admin-secret")
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(schema_response.status(), StatusCode::OK);
+        let body = body::to_bytes(schema_response.into_body(), usize::MAX)
+            .await
+            .expect("schema body");
+        assert_eq!(std::str::from_utf8(&body).unwrap(), schema_json);
     }
 }

--- a/crates/jazz-tools/src/runtime_tokio.rs
+++ b/crates/jazz-tools/src/runtime_tokio.rs
@@ -453,6 +453,18 @@ impl<S: Storage + Send + 'static> TokioRuntime<S> {
         Ok(core.schema_manager().get_known_schema(schema_hash).cloned())
     }
 
+    /// Get persisted original schema JSON by hash from catalogue state.
+    pub fn known_schema_json(
+        &self,
+        schema_hash: &SchemaHash,
+    ) -> Result<Option<String>, RuntimeError> {
+        let core = self.core.lock().map_err(|_| RuntimeError::LockError)?;
+        Ok(core
+            .schema_manager()
+            .get_known_schema_json(schema_hash)
+            .map(str::to_string))
+    }
+
     /// Access the underlying storage (for flushing, etc).
     ///
     /// The callback receives `&S` while holding the core lock.

--- a/crates/jazz-tools/src/schema_manager/context.rs
+++ b/crates/jazz-tools/src/schema_manager/context.rs
@@ -65,6 +65,8 @@ pub enum SchemaError {
     },
     /// Schema not found in context.
     SchemaNotFound(SchemaHash),
+    /// Catalogue schema metadata missing `schema_json`.
+    MissingSchemaJson,
     /// Lens not found.
     LensNotFound {
         source: SchemaHash,
@@ -93,6 +95,9 @@ impl std::fmt::Display for SchemaError {
             }
             SchemaError::SchemaNotFound(hash) => {
                 write!(f, "Schema not found: {}", hash.short())
+            }
+            SchemaError::MissingSchemaJson => {
+                write!(f, "Catalogue schema metadata missing schema_json")
             }
             SchemaError::LensNotFound { source, target } => {
                 write!(

--- a/crates/jazz-tools/src/schema_manager/integration_tests.rs
+++ b/crates/jazz-tools/src/schema_manager/integration_tests.rs
@@ -1203,6 +1203,10 @@ mod tests {
             test_app_id().uuid().to_string(),
         );
         metadata.insert(MetadataKey::SchemaHash.to_string(), v2_hash.to_string());
+        metadata.insert(
+            MetadataKey::SchemaJson.to_string(),
+            serde_json::to_string(&v2).unwrap(),
+        );
 
         // Process the catalogue update
         manager_b
@@ -1255,6 +1259,10 @@ mod tests {
             test_app_id().uuid().to_string(),
         );
         schema_metadata.insert(MetadataKey::SchemaHash.to_string(), v2_hash.to_string());
+        schema_metadata.insert(
+            MetadataKey::SchemaJson.to_string(),
+            serde_json::to_string(&v2).unwrap(),
+        );
 
         manager_b
             .process_catalogue_update(v2_object_id, &schema_metadata, &v2_encoded)
@@ -1351,6 +1359,10 @@ mod tests {
             test_app_id().uuid().to_string(),
         );
         metadata_v2.insert(MetadataKey::SchemaHash.to_string(), v2_hash.to_string());
+        metadata_v2.insert(
+            MetadataKey::SchemaJson.to_string(),
+            serde_json::to_string(&v2).unwrap(),
+        );
 
         let mut metadata_v3 = HashMap::new();
         metadata_v3.insert(
@@ -1362,6 +1374,10 @@ mod tests {
             test_app_id().uuid().to_string(),
         );
         metadata_v3.insert(MetadataKey::SchemaHash.to_string(), v3_hash.to_string());
+        metadata_v3.insert(
+            MetadataKey::SchemaJson.to_string(),
+            serde_json::to_string(&v3).unwrap(),
+        );
 
         ingest_remote_catalogue_object(
             &mut qm,
@@ -1467,6 +1483,10 @@ mod tests {
                 AppId::from_name("other-app").uuid().to_string(),
             );
             metadata.insert(MetadataKey::SchemaHash.to_string(), hash.to_string());
+            metadata.insert(
+                MetadataKey::SchemaJson.to_string(),
+                serde_json::to_string(&schema).unwrap(),
+            );
 
             manager
                 .process_catalogue_update(hash.to_object_id(), &metadata, &encode_schema(&schema))
@@ -1568,12 +1588,26 @@ mod tests {
             test_app_id().uuid().to_string(),
         );
         metadata.insert(MetadataKey::SchemaHash.to_string(), v1_hash.to_string());
+        metadata.insert(
+            MetadataKey::SchemaJson.to_string(),
+            serde_json::to_string(&v1).unwrap(),
+        );
 
         manager
             .process_catalogue_update(v1_hash.to_object_id(), &metadata, &encode_schema(&v1))
             .unwrap();
+        let mut metadata_overwrite = metadata.clone();
+        let overwritten_json = " {\"users\":{\"columns\":{\"name\":{\"Text\":null},\"id\":{\"Uuid\":null},\"birthday\":{\"Timestamp\":null}}}} ";
+        metadata_overwrite.insert(
+            MetadataKey::SchemaJson.to_string(),
+            overwritten_json.to_string(),
+        );
         manager
-            .process_catalogue_update(v1_hash.to_object_id(), &metadata, &encode_schema(&v1))
+            .process_catalogue_update(
+                v1_hash.to_object_id(),
+                &metadata_overwrite,
+                &encode_schema(&v1),
+            )
             .unwrap();
 
         let after = (
@@ -1583,6 +1617,10 @@ mod tests {
             manager.is_schema_known(&v1_hash),
         );
         assert_eq!(after, before, "same-schema pushes should be idempotent");
+        assert_eq!(
+            manager.get_known_schema_json(&v1_hash),
+            Some(overwritten_json)
+        );
     }
 
     /// Malformed schema payload should fail decode path deterministically.
@@ -1616,6 +1654,7 @@ mod tests {
             test_app_id().uuid().to_string(),
         );
         metadata.insert(MetadataKey::SchemaHash.to_string(), target_hash.to_string());
+        metadata.insert(MetadataKey::SchemaJson.to_string(), "{}".to_string());
 
         let err = manager
             .process_catalogue_update(ObjectId::new(), &metadata, b"\xFF")
@@ -1955,6 +1994,10 @@ mod tests {
             test_app_id().uuid().to_string(),
         );
         v2_metadata.insert(MetadataKey::SchemaHash.to_string(), v2_hash.to_string());
+        v2_metadata.insert(
+            MetadataKey::SchemaJson.to_string(),
+            serde_json::to_string(&v2).unwrap(),
+        );
 
         client
             .process_catalogue_update(v2_hash.to_object_id(), &v2_metadata, &v2_encoded)
@@ -1975,6 +2018,10 @@ mod tests {
             test_app_id().uuid().to_string(),
         );
         v3_metadata.insert(MetadataKey::SchemaHash.to_string(), v3_hash.to_string());
+        v3_metadata.insert(
+            MetadataKey::SchemaJson.to_string(),
+            serde_json::to_string(&v3).unwrap(),
+        );
 
         client
             .process_catalogue_update(v3_hash.to_object_id(), &v3_metadata, &v3_encoded)
@@ -2839,6 +2886,10 @@ mod tests {
             test_app_id().uuid().to_string(),
         );
         schema_metadata.insert(MetadataKey::SchemaHash.to_string(), v2_hash.to_string());
+        schema_metadata.insert(
+            MetadataKey::SchemaJson.to_string(),
+            serde_json::to_string(&v2).unwrap(),
+        );
 
         client
             .process_catalogue_update(v2_hash.to_object_id(), &schema_metadata, &v2_encoded)

--- a/crates/jazz-tools/src/schema_manager/manager.rs
+++ b/crates/jazz-tools/src/schema_manager/manager.rs
@@ -23,6 +23,12 @@ use super::encoding::{decode_lens_transform, decode_schema, encode_lens_transfor
 use super::lens::Lens;
 use super::types::AppId;
 
+#[derive(Debug, Clone)]
+struct KnownSchema {
+    schema: Schema,
+    original_json: String,
+}
+
 /// SchemaManager coordinates schema evolution with query execution.
 ///
 /// It manages:
@@ -68,8 +74,7 @@ pub struct SchemaManager {
     /// Schemas known to this manager (for server mode).
     /// Server adds schemas here when received via catalogue sync.
     /// These are stored without requiring a lens path to current.
-    known_schemas: Arc<HashMap<SchemaHash, Schema>>,
-    known_schema_json: HashMap<SchemaHash, String>,
+    known_schemas: Arc<HashMap<SchemaHash, KnownSchema>>,
     known_schemas_dirty: bool,
 }
 
@@ -99,12 +104,13 @@ impl SchemaManager {
 
         // Initialize known_schemas with current schema
         let mut known_schemas = HashMap::new();
-        known_schemas.insert(current_hash, schema);
-        let mut known_schema_json = HashMap::new();
-        known_schema_json.insert(
+        known_schemas.insert(
             current_hash,
-            serde_json::to_string(&context.current_schema)
-                .expect("serializing current schema should not fail"),
+            KnownSchema {
+                schema,
+                original_json: serde_json::to_string(&context.current_schema)
+                    .expect("serializing current schema should not fail"),
+            },
         );
 
         Ok(Self {
@@ -112,7 +118,6 @@ impl SchemaManager {
             query_manager,
             app_id,
             known_schemas: Arc::new(known_schemas),
-            known_schema_json,
             known_schemas_dirty: true,
         })
     }
@@ -142,7 +147,6 @@ impl SchemaManager {
             query_manager,
             app_id,
             known_schemas: Arc::new(HashMap::new()),
-            known_schema_json: HashMap::new(),
             known_schemas_dirty: false,
         }
     }
@@ -168,7 +172,14 @@ impl SchemaManager {
             return;
         }
 
-        Arc::make_mut(&mut self.known_schemas).insert(hash, schema.clone());
+        Arc::make_mut(&mut self.known_schemas).insert(
+            hash,
+            KnownSchema {
+                original_json: serde_json::to_string(&schema)
+                    .expect("serializing schema should not fail"),
+                schema: schema.clone(),
+            },
+        );
         self.known_schemas_dirty = true;
 
         // If we have a current schema context, also try the lens-path activation
@@ -180,12 +191,14 @@ impl SchemaManager {
 
     /// Get a known schema by hash.
     pub fn get_known_schema(&self, hash: &SchemaHash) -> Option<&Schema> {
-        self.known_schemas.get(hash)
+        self.known_schemas.get(hash).map(|known| &known.schema)
     }
 
     /// Get original schema JSON for a known schema hash.
     pub fn get_known_schema_json(&self, hash: &SchemaHash) -> Option<&str> {
-        self.known_schema_json.get(hash).map(String::as_str)
+        self.known_schemas
+            .get(hash)
+            .map(|known| known.original_json.as_str())
     }
 
     /// Check if a schema is known (either current, live, or in known_schemas).
@@ -516,11 +529,11 @@ impl SchemaManager {
         let historical_schemas: Vec<Schema> = self
             .known_schemas
             .iter()
-            .filter_map(|(hash, schema)| {
+            .filter_map(|(hash, known)| {
                 if *hash == current_hash {
                     None
                 } else {
-                    Some(schema.clone())
+                    Some(known.schema.clone())
                 }
             })
             .collect();
@@ -637,12 +650,20 @@ impl SchemaManager {
 
         // Always store/overwrite original JSON for this hash so API retrieval
         // reflects the latest pushed schema_json for that hash.
-        self.known_schema_json.insert(hash, schema_json);
-
-        // Always add to known_schemas (server or client)
-        // This allows server-mode query execution even without lens paths
-        if !self.known_schemas.contains_key(&hash) {
-            Arc::make_mut(&mut self.known_schemas).insert(hash, schema.clone());
+        // Always add/update known_schemas (server or client). This allows
+        // server-mode query execution even without lens paths.
+        let entry = Arc::make_mut(&mut self.known_schemas)
+            .entry(hash)
+            .or_insert_with(|| {
+                self.known_schemas_dirty = true;
+                KnownSchema {
+                    schema: schema.clone(),
+                    original_json: schema_json.clone(),
+                }
+            });
+        entry.original_json = schema_json;
+        if entry.schema != schema {
+            entry.schema = schema.clone();
             self.known_schemas_dirty = true;
         }
 
@@ -789,6 +810,7 @@ impl SchemaManager {
             .known_schemas
             .get(&ctx.schema_hash)
             .ok_or(QueryError::UnknownSchema(ctx.schema_hash))?
+            .schema
             .clone();
 
         // Build a SchemaContext with target as current
@@ -801,10 +823,10 @@ impl SchemaManager {
         }
 
         // Add other known schemas as potential live schemas
-        for (hash, schema) in self.known_schemas.iter() {
+        for (hash, known) in self.known_schemas.iter() {
             if *hash != ctx.schema_hash {
                 // Add to pending - will activate if lens path exists to target
-                temp_context.add_pending_schema(schema.clone());
+                temp_context.add_pending_schema(known.schema.clone());
             }
         }
 
@@ -821,9 +843,9 @@ impl SchemaManager {
         for branch_name in temp_context.all_branch_names() {
             let branch_str = branch_name.as_str();
             if let Some(composed) = ComposedBranchName::parse(&branch_name)
-                && let Some(schema) = self.known_schemas.get(&composed.schema_hash)
+                && let Some(known) = self.known_schemas.get(&composed.schema_hash)
             {
-                for (table_name, table_schema) in schema {
+                for (table_name, table_schema) in &known.schema {
                     self.query_manager.ensure_indices_for_branch(
                         table_name.as_str(),
                         branch_str,
@@ -911,8 +933,13 @@ impl SchemaManager {
         // Sync known schemas to QueryManager for server-mode lazy activation
         // This enables QueryManager to activate branches when rows arrive
         if self.known_schemas_dirty {
-            self.query_manager
-                .set_known_schemas(Arc::clone(&self.known_schemas));
+            let schemas = Arc::new(
+                self.known_schemas
+                    .iter()
+                    .map(|(hash, known)| (*hash, known.schema.clone()))
+                    .collect(),
+            );
+            self.query_manager.set_known_schemas(schemas);
             self.known_schemas_dirty = false;
         }
 

--- a/crates/jazz-tools/src/schema_manager/manager.rs
+++ b/crates/jazz-tools/src/schema_manager/manager.rs
@@ -69,6 +69,7 @@ pub struct SchemaManager {
     /// Server adds schemas here when received via catalogue sync.
     /// These are stored without requiring a lens path to current.
     known_schemas: Arc<HashMap<SchemaHash, Schema>>,
+    known_schema_json: HashMap<SchemaHash, String>,
     known_schemas_dirty: bool,
 }
 
@@ -99,12 +100,19 @@ impl SchemaManager {
         // Initialize known_schemas with current schema
         let mut known_schemas = HashMap::new();
         known_schemas.insert(current_hash, schema);
+        let mut known_schema_json = HashMap::new();
+        known_schema_json.insert(
+            current_hash,
+            serde_json::to_string(&context.current_schema)
+                .expect("serializing current schema should not fail"),
+        );
 
         Ok(Self {
             context,
             query_manager,
             app_id,
             known_schemas: Arc::new(known_schemas),
+            known_schema_json,
             known_schemas_dirty: true,
         })
     }
@@ -134,6 +142,7 @@ impl SchemaManager {
             query_manager,
             app_id,
             known_schemas: Arc::new(HashMap::new()),
+            known_schema_json: HashMap::new(),
             known_schemas_dirty: false,
         }
     }
@@ -172,6 +181,11 @@ impl SchemaManager {
     /// Get a known schema by hash.
     pub fn get_known_schema(&self, hash: &SchemaHash) -> Option<&Schema> {
         self.known_schemas.get(hash)
+    }
+
+    /// Get original schema JSON for a known schema hash.
+    pub fn get_known_schema_json(&self, hash: &SchemaHash) -> Option<&str> {
+        self.known_schema_json.get(hash).map(String::as_str)
     }
 
     /// Check if a schema is known (either current, live, or in known_schemas).
@@ -446,7 +460,7 @@ impl SchemaManager {
         let object_id = schema_hash.to_object_id();
         let content = encode_schema(&self.context.current_schema);
 
-        let metadata = self.schema_metadata(&schema_hash);
+        let metadata = self.schema_metadata(&schema_hash, &self.context.current_schema);
         self.query_manager
             .sync_manager_mut()
             .create_object_with_content(storage, object_id, metadata, content);
@@ -466,7 +480,7 @@ impl SchemaManager {
         let object_id = schema_hash.to_object_id();
         let content = encode_schema(schema);
 
-        let metadata = self.schema_metadata(&schema_hash);
+        let metadata = self.schema_metadata(&schema_hash, schema);
         self.query_manager
             .sync_manager_mut()
             .create_object_with_content(storage, object_id, metadata, content);
@@ -522,7 +536,11 @@ impl SchemaManager {
     }
 
     /// Build metadata for a schema catalogue object.
-    fn schema_metadata(&self, schema_hash: &SchemaHash) -> HashMap<String, String> {
+    fn schema_metadata(
+        &self,
+        schema_hash: &SchemaHash,
+        schema: &Schema,
+    ) -> HashMap<String, String> {
         let mut metadata = HashMap::new();
         metadata.insert(
             crate::metadata::MetadataKey::Type.to_string(),
@@ -535,6 +553,10 @@ impl SchemaManager {
         metadata.insert(
             crate::metadata::MetadataKey::SchemaHash.to_string(),
             schema_hash.to_string(),
+        );
+        metadata.insert(
+            crate::metadata::MetadataKey::SchemaJson.to_string(),
+            serde_json::to_string(schema).expect("serializing schema should not fail"),
         );
         metadata
     }
@@ -608,6 +630,14 @@ impl SchemaManager {
             .map_err(|_| SchemaError::SchemaNotFound(SchemaHash::from_bytes([0; 32])))?;
 
         let hash = SchemaHash::compute(&schema);
+        let schema_json = metadata
+            .get(crate::metadata::MetadataKey::SchemaJson.as_str())
+            .ok_or(SchemaError::MissingSchemaJson)?
+            .clone();
+
+        // Always store/overwrite original JSON for this hash so API retrieval
+        // reflects the latest pushed schema_json for that hash.
+        self.known_schema_json.insert(hash, schema_json);
 
         // Always add to known_schemas (server or client)
         // This allows server-mode query execution even without lens paths

--- a/crates/jazz-tools/src/schema_manager/rehydrate.rs
+++ b/crates/jazz-tools/src/schema_manager/rehydrate.rs
@@ -1,8 +1,5 @@
-use std::collections::HashMap;
-
 use tracing::{info, warn};
 
-use crate::metadata::{MetadataKey, ObjectType};
 use crate::object::{BranchName, ObjectId};
 use crate::storage::{CatalogueManifest, Storage};
 
@@ -25,33 +22,6 @@ fn latest_catalogue_content<S: Storage + ?Sized>(
             .map(|commit| commit.content)
             .filter(|content| !content.is_empty())
     }))
-}
-
-fn schema_metadata_for_rehydrate(app_id: AppId, schema_hash: &str) -> HashMap<String, String> {
-    let mut metadata = HashMap::new();
-    metadata.insert(
-        MetadataKey::Type.to_string(),
-        ObjectType::CatalogueSchema.to_string(),
-    );
-    metadata.insert(MetadataKey::AppId.to_string(), app_id.uuid().to_string());
-    metadata.insert(MetadataKey::SchemaHash.to_string(), schema_hash.to_string());
-    metadata
-}
-
-fn lens_metadata_for_rehydrate(
-    app_id: AppId,
-    source_hash: &str,
-    target_hash: &str,
-) -> HashMap<String, String> {
-    let mut metadata = HashMap::new();
-    metadata.insert(
-        MetadataKey::Type.to_string(),
-        ObjectType::CatalogueLens.to_string(),
-    );
-    metadata.insert(MetadataKey::AppId.to_string(), app_id.uuid().to_string());
-    metadata.insert(MetadataKey::SourceHash.to_string(), source_hash.to_string());
-    metadata.insert(MetadataKey::TargetHash.to_string(), target_hash.to_string());
-    metadata
 }
 
 /// Rehydrate server schema state from persisted catalogue manifest operations.
@@ -81,7 +51,7 @@ pub fn rehydrate_schema_manager_from_manifest<S: Storage + ?Sized>(
     let mut schema_count = 0usize;
     let mut lens_count = 0usize;
 
-    for (object_id, schema_hash) in schema_seen {
+    for (object_id, _schema_hash) in schema_seen {
         let Some(content) = latest_catalogue_content(storage, object_id)? else {
             warn!(
                 app_id = %app_id,
@@ -91,7 +61,17 @@ pub fn rehydrate_schema_manager_from_manifest<S: Storage + ?Sized>(
             continue;
         };
 
-        let metadata = schema_metadata_for_rehydrate(app_id, &schema_hash.to_string());
+        let Some(metadata) = storage.load_object_metadata(object_id).map_err(|err| {
+            format!("failed to load metadata for schema object {object_id}: {err:?}")
+        })?
+        else {
+            warn!(
+                app_id = %app_id,
+                object_id = %object_id,
+                "catalogue schema in manifest missing object metadata"
+            );
+            continue;
+        };
         if let Err(error) = schema_manager.process_catalogue_update(object_id, &metadata, &content)
         {
             warn!(
@@ -105,7 +85,7 @@ pub fn rehydrate_schema_manager_from_manifest<S: Storage + ?Sized>(
         }
     }
 
-    for (object_id, lens) in lens_seen {
+    for (object_id, _lens) in lens_seen {
         let Some(content) = latest_catalogue_content(storage, object_id)? else {
             warn!(
                 app_id = %app_id,
@@ -115,11 +95,17 @@ pub fn rehydrate_schema_manager_from_manifest<S: Storage + ?Sized>(
             continue;
         };
 
-        let metadata = lens_metadata_for_rehydrate(
-            app_id,
-            &lens.source_hash.to_string(),
-            &lens.target_hash.to_string(),
-        );
+        let Some(metadata) = storage.load_object_metadata(object_id).map_err(|err| {
+            format!("failed to load metadata for lens object {object_id}: {err:?}")
+        })?
+        else {
+            warn!(
+                app_id = %app_id,
+                object_id = %object_id,
+                "catalogue lens in manifest missing object metadata"
+            );
+            continue;
+        };
         if let Err(error) = schema_manager.process_catalogue_update(object_id, &metadata, &content)
         {
             warn!(

--- a/crates/jazz-tools/tests/auth_test.rs
+++ b/crates/jazz-tools/tests/auth_test.rs
@@ -442,6 +442,12 @@ mod integration_tests {
             MetadataKey::SchemaHash.as_str().to_string(),
             hex::encode(schema_hash.as_bytes()),
         );
+        let pushed_schema_json =
+            r#"{"users":{"columns":{"name":{"Text":null},"id":{"Uuid":null}}}}"#;
+        metadata.insert(
+            MetadataKey::SchemaJson.as_str().to_string(),
+            pushed_schema_json.to_string(),
+        );
 
         let sync_payload = json!({
             "client_id": Uuid::new_v4().to_string(),
@@ -496,8 +502,7 @@ mod integration_tests {
             .await
             .unwrap();
         assert_eq!(schema_response.status(), StatusCode::OK);
-        let schema_json: Value = schema_response.json().await.unwrap();
-        let expected_schema_json = serde_json::to_value(schema.clone()).unwrap();
-        assert_eq!(schema_json, expected_schema_json);
+        let schema_body = schema_response.text().await.unwrap();
+        assert_eq!(schema_body, pushed_schema_json);
     }
 }


### PR DESCRIPTION
## Summary
This PR makes schema catalogue reads return the exact JSON originally pushed by clients, instead of reconstructing JSON from decoded `Schema` objects. This is because we want to have exactly the same JSON hash and structure of the original wasm schema. A single change, such as a different field order in the JSON, leads to a different hash. 

## What changed
- Persisted original pushed schema JSON (`metadata.schema_json`) alongside encoded schema bytes for catalogue schema objects.
- Made `schema_json` required for newly ingested `catalogue_schema` updates.
- Added overwrite behavior for repeated pushes of the same schema hash:
  - If a known hash is pushed again, stored `original_json` is replaced with the latest `schema_json`.

## Implementation notes
- Refactored schema manager storage to a single `KnownSchema` structure containing:
  - decoded `Schema` (runtime/query usage)
  - `original_json` (API serving)
- Rehydrate path now uses persisted object metadata so `schema_json` is available after restart.

## Tests
- Cloud integration test: push catalogue schema with `schema_json`, fetch `/apps/:app_id/schema/:hash`, assert raw body equals pushed string.
- Single-tenant integration test: same raw-body equality assertion for `/schema/:hash`.
- Overwrite behavior test: re-pushing an existing hash updates returned `original_json`.
- Existing schema hash-list behavior remains validated.