### PR TITLE
fix(sync_manager): prefer server-established session over payload in QuerySubscription

### DIFF
--- a/.changeset/fix-query-subscription-session-fallback.md
+++ b/.changeset/fix-query-subscription-session-fallback.md
@@ -1,0 +1,7 @@
+---
+"jazz-tools": patch
+---
+
+Fix: sync server now falls back to the server-established session when a `QuerySubscription` payload omits one.
+
+Demo and anonymous auth clients sent `session: None` in subscription payloads, causing all their queries to return empty results after the payload-session change in #147. The server now prefers the session it validated from auth headers during the SSE handshake, falling back to the payload only for fully unauthenticated clients. Payload sessions that differ from the server-established session are ignored and a warning is logged.

--- a/crates/jazz-tools/src/sync_manager/inbox.rs
+++ b/crates/jazz-tools/src/sync_manager/inbox.rs
@@ -316,6 +316,22 @@ impl SyncManager {
                 session,
                 propagation,
             } => {
+                // Warn if the payload carries a session that differs from the one established
+                // during the SSE handshake — this would indicate a spoofing attempt.
+                if let (Some(payload_session), Some(client_session)) = (session, &client.session)
+                    && payload_session != client_session
+                {
+                    tracing::warn!(
+                        %client_id,
+                        "QuerySubscription payload session does not match client session; using client session"
+                    );
+                }
+                // Prefer the server-established session (set from validated auth headers
+                // during the SSE handshake) over whatever the client claims in the payload.
+                // Fall back to the payload only for anonymous/demo clients whose
+                // client.session is None.  Note: despite the name, client.session is
+                // server-owned state — not a value the client can supply directly.
+                let effective_session = client.session.clone().or_else(|| session.clone());
                 // Track origin for QuerySettled relay
                 self.query_origin
                     .entry(*query_id)
@@ -326,7 +342,7 @@ impl SyncManager {
                         client_id,
                         query_id: *query_id,
                         query: query.as_ref().clone(),
-                        session: session.clone(),
+                        session: effective_session,
                         propagation: *propagation,
                     });
             }

--- a/crates/jazz-tools/src/sync_manager/tests.rs
+++ b/crates/jazz-tools/src/sync_manager/tests.rs
@@ -2362,3 +2362,123 @@ fn ack_state_does_not_affect_commit_id_sync() {
 
     assert_eq!(commit1.id(), commit2.id());
 }
+
+// ========================================================================
+// QuerySubscription session fallback (inbox.rs fix)
+// ========================================================================
+
+/// Helper: push a QuerySubscription from a client and drain pending subs.
+fn push_query_subscription(
+    sm: &mut SyncManager,
+    client_id: ClientId,
+    payload_session: Option<Session>,
+) -> Vec<PendingQuerySubscription> {
+    use crate::query_manager::query::QueryBuilder;
+    let query = QueryBuilder::new("messages").branch("main").build();
+    sm.push_inbox(InboxEntry {
+        source: Source::Client(client_id),
+        payload: SyncPayload::QuerySubscription {
+            query_id: QueryId(1),
+            query: Box::new(query),
+            session: payload_session,
+            propagation: QueryPropagation::Full,
+        },
+    });
+    sm.process_inbox(&mut MemoryStorage::new());
+    sm.take_pending_query_subscriptions()
+}
+
+#[test]
+fn query_subscription_falls_back_to_client_session_when_payload_omits_it() {
+    // Demo/anonymous clients send session: None in the payload.
+    // The server established a session during the SSE handshake; that should be used.
+    //
+    //   client.session = Some("alice")   (server-established)
+    //   payload session = None           (client sent nothing)
+    //   → effective session = Some("alice")
+    let mut sm = SyncManager::new();
+    let client_id = ClientId::new();
+    sm.add_client(client_id);
+    sm.set_client_session(client_id, Session::new("alice"));
+
+    let pending = push_query_subscription(&mut sm, client_id, None);
+
+    assert_eq!(pending.len(), 1);
+    let session = pending[0]
+        .session
+        .as_ref()
+        .expect("should fall back to server-established session");
+    assert_eq!(session.user_id, "alice");
+}
+
+#[test]
+fn query_subscription_uses_client_session_when_payload_supplies_one() {
+    // Authenticated client sends a matching session in the payload.
+    // server session wins regardless (same value in the honest case).
+    //
+    //   client.session = Some("alice")
+    //   payload session = Some("alice")
+    //   → effective session = Some("alice")
+    let mut sm = SyncManager::new();
+    let client_id = ClientId::new();
+    sm.add_client(client_id);
+    sm.set_client_session(client_id, Session::new("alice"));
+
+    let pending = push_query_subscription(&mut sm, client_id, Some(Session::new("alice")));
+
+    assert_eq!(pending.len(), 1);
+    let session = pending[0]
+        .session
+        .as_ref()
+        .expect("session should be present");
+    assert_eq!(session.user_id, "alice");
+}
+
+#[test]
+fn query_subscription_ignores_spoofed_payload_session() {
+    // A client with an established server session sends a different session
+    // in the payload — the server-established one must win.
+    //
+    //   client.session = Some("alice")
+    //   payload session = Some("mallory")   ← spoofed
+    //   → effective session = Some("alice")
+    let mut sm = SyncManager::new();
+    let client_id = ClientId::new();
+    sm.add_client(client_id);
+    sm.set_client_session(client_id, Session::new("alice"));
+
+    let pending = push_query_subscription(&mut sm, client_id, Some(Session::new("mallory")));
+
+    assert_eq!(pending.len(), 1);
+    let session = pending[0]
+        .session
+        .as_ref()
+        .expect("session should be present");
+    assert_eq!(
+        session.user_id, "alice",
+        "spoofed payload session must be ignored"
+    );
+}
+
+#[test]
+fn query_subscription_demo_client_no_server_session_no_payload_session() {
+    // Fully anonymous/demo client: no server session, no payload session.
+    // Queries should proceed with session: None (the query layer handles
+    // the open-access policy for demo mode).
+    //
+    //   client.session = None
+    //   payload session = None
+    //   → effective session = None
+    let mut sm = SyncManager::new();
+    let client_id = ClientId::new();
+    sm.add_client(client_id);
+    // No set_client_session call — client is fully anonymous.
+
+    let pending = push_query_subscription(&mut sm, client_id, None);
+
+    assert_eq!(pending.len(), 1);
+    assert!(
+        pending[0].session.is_none(),
+        "anonymous client should produce session: None"
+    );
+}


### PR DESCRIPTION
## Summary

- Demo and anonymous clients send `session: None` in `QuerySubscription` payloads, causing all their queries to return empty results after PR #147 started using the payload session directly
- Fall back to `ClientState.session` (set from validated auth headers during the SSE handshake) when the payload omits a session
- Prefer `ClientState.session` unconditionally when both are present, preventing session spoofing via the payload

## Test plan

- [ ] `query_subscription_falls_back_to_client_session_when_payload_omits_it` — demo client with server-established session, payload `None` → uses server session
- [ ] `query_subscription_uses_client_session_when_payload_supplies_one` — authenticated client, both sides agree → correct session used
- [ ] `query_subscription_ignores_spoofed_payload_session` — payload carries a different session to `ClientState.session` → server session wins
- [ ] `query_subscription_demo_client_no_server_session_no_payload_session` — fully anonymous client, both `None` → `None` propagated