### PR TITLE
perf: encode main thread<>worker sync messages using postcard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,6 +199,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-polyfill"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
+dependencies = [
+ "critical-section",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -592,6 +601,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -707,6 +725,12 @@ dependencies = [
  "cast",
  "itertools 0.10.5",
 ]
+
+[[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-deque"
@@ -834,6 +858,18 @@ checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "encoding_rs"
@@ -1231,6 +1267,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1256,6 +1301,20 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
+]
+
+[[package]]
+name = "heapless"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
+dependencies = [
+ "atomic-polyfill",
+ "hash32",
+ "rustc_version",
+ "serde",
+ "spin",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -1758,6 +1817,7 @@ dependencies = [
  "opentelemetry-stdout",
  "opentelemetry_sdk",
  "opfs-btree",
+ "postcard",
  "rand 0.8.5",
  "reqwest",
  "serde",
@@ -2555,6 +2615,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "heapless",
+ "serde",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2962,6 +3035,15 @@ name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -203,7 +203,7 @@ impl NapiSyncSender {
 }
 
 impl SyncSender for NapiSyncSender {
-    fn send_sync_message(&self, message: OutboxEntry) {
+    fn send_sync_message(&self, message: OutboxEntry, _sender_tier: &'static str) {
         let cb = match self.callback.lock() {
             Ok(cb) => cb,
             Err(_) => return,

--- a/crates/jazz-nitro/src/lib.rs
+++ b/crates/jazz-nitro/src/lib.rs
@@ -289,7 +289,7 @@ impl NitroSyncSender {
 }
 
 impl SyncSender for NitroSyncSender {
-    fn send_sync_message(&self, message: OutboxEntry) {
+    fn send_sync_message(&self, message: OutboxEntry, _sender_tier: &'static str) {
         let Ok(json) = serde_json::to_string(&message) else {
             return;
         };

--- a/crates/jazz-rn/rust/src/lib.rs
+++ b/crates/jazz-rn/rust/src/lib.rs
@@ -263,7 +263,7 @@ impl RnSyncSender {
 }
 
 impl SyncSender for RnSyncSender {
-    fn send_sync_message(&self, message: OutboxEntry) {
+    fn send_sync_message(&self, message: OutboxEntry, _sender_tier: &'static str) {
         let Ok(json) = serde_json::to_string(&message) else {
             return;
         };

--- a/crates/jazz-tools/Cargo.toml
+++ b/crates/jazz-tools/Cargo.toml
@@ -57,6 +57,7 @@ rand = "0.8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_bytes = "0.11"
+postcard = { version = "1", features = ["alloc"] }
 jsonschema = { version = "0.42", default-features = false }
 internment = "0.8"
 smallvec = { version = "1.11", features = ["serde"] }

--- a/crates/jazz-tools/src/query_manager/query.rs
+++ b/crates/jazz-tools/src/query_manager/query.rs
@@ -1559,7 +1559,7 @@ mod tests {
     // ========================================================================
 
     #[test]
-    fn query_round_trip_serialization() {
+    fn query_round_trip_json_serialization() {
         let query = QueryBuilder::new("users")
             .filter_eq("org_id", Value::Integer(42))
             .filter_ge("score", Value::Integer(50))
@@ -1575,7 +1575,23 @@ mod tests {
     }
 
     #[test]
-    fn query_with_join_serialization() {
+    fn query_round_trip_binary_serialization() {
+        let query = QueryBuilder::new("users")
+            .filter_eq("org_id", Value::Integer(42))
+            .filter_ge("score", Value::Integer(50))
+            .branch("main")
+            .order_by_desc("score")
+            .limit(10)
+            .build();
+
+        let bytes = postcard::to_allocvec(&query).expect("serialize query postcard");
+        let decoded: Query = postcard::from_bytes(&bytes).expect("deserialize query postcard");
+
+        assert_eq!(query, decoded);
+    }
+
+    #[test]
+    fn query_with_join_json_serialization() {
         let query = QueryBuilder::new("users")
             .alias("u")
             .join("posts")
@@ -1591,7 +1607,23 @@ mod tests {
     }
 
     #[test]
-    fn query_with_array_subquery_serialization() {
+    fn query_with_join_binary_serialization() {
+        let query = QueryBuilder::new("users")
+            .alias("u")
+            .join("posts")
+            .alias("p")
+            .on("u.id", "p.author_id")
+            .branch("main")
+            .build();
+
+        let bytes = postcard::to_allocvec(&query).expect("serialize query postcard");
+        let decoded: Query = postcard::from_bytes(&bytes).expect("deserialize query postcard");
+
+        assert_eq!(query, decoded);
+    }
+
+    #[test]
+    fn query_with_array_subquery_json_serialization() {
         let query = QueryBuilder::new("orgs")
             .branch("main")
             .with_array("users", |b| b.from("users").correlate("id", "org_id"))
@@ -1604,7 +1636,20 @@ mod tests {
     }
 
     #[test]
-    fn query_with_recursive_serialization() {
+    fn query_with_array_subquery_binary_serialization() {
+        let query = QueryBuilder::new("orgs")
+            .branch("main")
+            .with_array("users", |b| b.from("users").correlate("id", "org_id"))
+            .build();
+
+        let bytes = postcard::to_allocvec(&query).expect("serialize query postcard");
+        let decoded: Query = postcard::from_bytes(&bytes).expect("deserialize query postcard");
+
+        assert_eq!(query, decoded);
+    }
+
+    #[test]
+    fn query_with_recursive_json_serialization() {
         let query = QueryBuilder::new("teams")
             .select(&["team_id"])
             .with_recursive(|r| {
@@ -1623,7 +1668,26 @@ mod tests {
     }
 
     #[test]
-    fn query_with_relation_ir_serialization() {
+    fn query_with_recursive_binary_serialization() {
+        let query = QueryBuilder::new("teams")
+            .select(&["team_id"])
+            .with_recursive(|r| {
+                r.from("team_edges")
+                    .correlate("child_team", "team_id")
+                    .select(&["parent_team"])
+                    .max_depth(10)
+            })
+            .branch("main")
+            .build();
+
+        let bytes = postcard::to_allocvec(&query).expect("serialize query postcard");
+        let decoded: Query = postcard::from_bytes(&bytes).expect("deserialize query postcard");
+
+        assert_eq!(query, decoded);
+    }
+
+    #[test]
+    fn query_with_relation_ir_json_serialization() {
         let mut query = QueryBuilder::new("users").branch("main").build();
         query.relation_ir = crate::query_manager::relation_ir::RelExpr::TableScan {
             table: TableName::new("users"),
@@ -1640,7 +1704,20 @@ mod tests {
     }
 
     #[test]
-    fn query_disjunction_serialization() {
+    fn query_with_relation_ir_postcard_serialization() {
+        let mut query = QueryBuilder::new("users").branch("main").build();
+        query.relation_ir = crate::query_manager::relation_ir::RelExpr::TableScan {
+            table: TableName::new("users"),
+        };
+
+        let bytes = postcard::to_allocvec(&query).expect("serialize query postcard");
+        let decoded: Query = postcard::from_bytes(&bytes).expect("deserialize query postcard");
+
+        assert_eq!(query, decoded);
+    }
+
+    #[test]
+    fn query_disjunction_json_serialization() {
         let query = QueryBuilder::new("users")
             .filter_eq("status", Value::Text("active".into()))
             .or()
@@ -1650,6 +1727,22 @@ mod tests {
 
         let json = serde_json::to_string(&query).expect("serialize");
         let decoded: Query = serde_json::from_str(&json).expect("deserialize");
+
+        assert_eq!(query, decoded);
+        assert_eq!(decoded.disjuncts.len(), 2);
+    }
+
+    #[test]
+    fn query_disjunction_binary_serialization() {
+        let query = QueryBuilder::new("users")
+            .filter_eq("status", Value::Text("active".into()))
+            .or()
+            .filter_eq("role", Value::Text("admin".into()))
+            .branch("main")
+            .build();
+
+        let bytes = postcard::to_allocvec(&query).expect("serialize query postcard");
+        let decoded: Query = postcard::from_bytes(&bytes).expect("deserialize query postcard");
 
         assert_eq!(query, decoded);
         assert_eq!(decoded.disjuncts.len(), 2);

--- a/crates/jazz-tools/src/query_manager/types/value.rs
+++ b/crates/jazz-tools/src/query_manager/types/value.rs
@@ -1,4 +1,4 @@
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::object::ObjectId;
 
@@ -10,8 +10,7 @@ use super::*;
 /// `PartialEq`/`Eq` are implemented manually because `f64` does not implement
 /// `Eq`. We use bitwise comparison (`f64::to_bits`) so that NaN == NaN and
 /// -0.0 != 0.0, which is the correct semantics for storage identity.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(tag = "type", content = "value")]
+#[derive(Debug, Clone)]
 pub enum Value {
     Integer(i32),
     BigInt(i64),
@@ -28,6 +27,137 @@ pub enum Value {
     /// The schema is external (from ColumnType::Row).
     Row(Vec<Value>),
     Null,
+}
+
+/// Use internally-tagged enum for JSON serialization.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", content = "value")]
+enum ValueHuman {
+    Integer(i32),
+    BigInt(i64),
+    Double(f64),
+    Boolean(bool),
+    Text(String),
+    Timestamp(u64),
+    Uuid(ObjectId),
+    Bytea(Vec<u8>),
+    Array(Vec<ValueHuman>),
+    Row(Vec<ValueHuman>),
+    Null,
+}
+
+/// Use externally-tagged enum for binary serialization (postcard does not support internally-tagged enums).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+enum ValueBinary {
+    Integer(i32),
+    BigInt(i64),
+    Double(f64),
+    Boolean(bool),
+    Text(String),
+    Timestamp(u64),
+    Uuid(ObjectId),
+    Bytea(Vec<u8>),
+    Array(Vec<ValueBinary>),
+    Row(Vec<ValueBinary>),
+    Null,
+}
+
+impl From<&Value> for ValueHuman {
+    fn from(value: &Value) -> Self {
+        match value {
+            Value::Integer(v) => ValueHuman::Integer(*v),
+            Value::BigInt(v) => ValueHuman::BigInt(*v),
+            Value::Double(v) => ValueHuman::Double(*v),
+            Value::Boolean(v) => ValueHuman::Boolean(*v),
+            Value::Text(v) => ValueHuman::Text(v.clone()),
+            Value::Timestamp(v) => ValueHuman::Timestamp(*v),
+            Value::Uuid(v) => ValueHuman::Uuid(*v),
+            Value::Bytea(v) => ValueHuman::Bytea(v.clone()),
+            Value::Array(v) => ValueHuman::Array(v.iter().map(ValueHuman::from).collect()),
+            Value::Row(v) => ValueHuman::Row(v.iter().map(ValueHuman::from).collect()),
+            Value::Null => ValueHuman::Null,
+        }
+    }
+}
+
+impl From<ValueHuman> for Value {
+    fn from(value: ValueHuman) -> Self {
+        match value {
+            ValueHuman::Integer(v) => Value::Integer(v),
+            ValueHuman::BigInt(v) => Value::BigInt(v),
+            ValueHuman::Double(v) => Value::Double(v),
+            ValueHuman::Boolean(v) => Value::Boolean(v),
+            ValueHuman::Text(v) => Value::Text(v),
+            ValueHuman::Timestamp(v) => Value::Timestamp(v),
+            ValueHuman::Uuid(v) => Value::Uuid(v),
+            ValueHuman::Bytea(v) => Value::Bytea(v),
+            ValueHuman::Array(v) => Value::Array(v.into_iter().map(Value::from).collect()),
+            ValueHuman::Row(v) => Value::Row(v.into_iter().map(Value::from).collect()),
+            ValueHuman::Null => Value::Null,
+        }
+    }
+}
+
+impl From<&Value> for ValueBinary {
+    fn from(value: &Value) -> Self {
+        match value {
+            Value::Integer(v) => ValueBinary::Integer(*v),
+            Value::BigInt(v) => ValueBinary::BigInt(*v),
+            Value::Double(v) => ValueBinary::Double(*v),
+            Value::Boolean(v) => ValueBinary::Boolean(*v),
+            Value::Text(v) => ValueBinary::Text(v.clone()),
+            Value::Timestamp(v) => ValueBinary::Timestamp(*v),
+            Value::Uuid(v) => ValueBinary::Uuid(*v),
+            Value::Bytea(v) => ValueBinary::Bytea(v.clone()),
+            Value::Array(v) => ValueBinary::Array(v.iter().map(ValueBinary::from).collect()),
+            Value::Row(v) => ValueBinary::Row(v.iter().map(ValueBinary::from).collect()),
+            Value::Null => ValueBinary::Null,
+        }
+    }
+}
+
+impl From<ValueBinary> for Value {
+    fn from(value: ValueBinary) -> Self {
+        match value {
+            ValueBinary::Integer(v) => Value::Integer(v),
+            ValueBinary::BigInt(v) => Value::BigInt(v),
+            ValueBinary::Double(v) => Value::Double(v),
+            ValueBinary::Boolean(v) => Value::Boolean(v),
+            ValueBinary::Text(v) => Value::Text(v),
+            ValueBinary::Timestamp(v) => Value::Timestamp(v),
+            ValueBinary::Uuid(v) => Value::Uuid(v),
+            ValueBinary::Bytea(v) => Value::Bytea(v),
+            ValueBinary::Array(v) => Value::Array(v.into_iter().map(Value::from).collect()),
+            ValueBinary::Row(v) => Value::Row(v.into_iter().map(Value::from).collect()),
+            ValueBinary::Null => Value::Null,
+        }
+    }
+}
+
+impl Serialize for Value {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        if serializer.is_human_readable() {
+            ValueHuman::from(self).serialize(serializer)
+        } else {
+            ValueBinary::from(self).serialize(serializer)
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for Value {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        if deserializer.is_human_readable() {
+            ValueHuman::deserialize(deserializer).map(Value::from)
+        } else {
+            ValueBinary::deserialize(deserializer).map(Value::from)
+        }
+    }
 }
 
 impl PartialEq for Value {

--- a/crates/jazz-tools/src/runtime_core.rs
+++ b/crates/jazz-tools/src/runtime_core.rs
@@ -58,7 +58,7 @@ pub trait Scheduler {
 /// No `Send` bound — WASM types are `!Send`. Send is enforced
 /// by the concrete wrapping type where needed.
 pub trait SyncSender {
-    fn send_sync_message(&self, message: OutboxEntry);
+    fn send_sync_message(&self, message: OutboxEntry, sender_tier: &'static str);
 }
 
 // ============================================================================
@@ -97,7 +97,7 @@ impl VecSyncSender {
 }
 
 impl SyncSender for VecSyncSender {
-    fn send_sync_message(&self, message: OutboxEntry) {
+    fn send_sync_message(&self, message: OutboxEntry, _sender_tier: &'static str) {
         self.messages.lock().unwrap().push(message);
     }
 }

--- a/crates/jazz-tools/src/runtime_core/ticks.rs
+++ b/crates/jazz-tools/src/runtime_core/ticks.rs
@@ -175,7 +175,7 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
             debug!(count = outbox.len(), "flushing outbox");
         }
         for msg in outbox {
-            self.sync_sender.send_sync_message(msg);
+            self.sync_sender.send_sync_message(msg, self.tier_label);
         }
 
         // 2. Process parked sync messages
@@ -193,7 +193,7 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
             debug!(count = outbox.len(), "flushing post-process outbox");
         }
         for msg in outbox {
-            self.sync_sender.send_sync_message(msg);
+            self.sync_sender.send_sync_message(msg, self.tier_label);
         }
 
         // Flush the storage durability barrier so writes survive a hard kill (tab close, crash).

--- a/crates/jazz-tools/src/runtime_tokio.rs
+++ b/crates/jazz-tools/src/runtime_tokio.rs
@@ -111,7 +111,7 @@ impl CallbackSyncSender {
 }
 
 impl SyncSender for CallbackSyncSender {
-    fn send_sync_message(&self, message: OutboxEntry) {
+    fn send_sync_message(&self, message: OutboxEntry, _sender_tier: &'static str) {
         (self.callback)(message);
     }
 }

--- a/crates/jazz-tools/src/sync_manager/types.rs
+++ b/crates/jazz-tools/src/sync_manager/types.rs
@@ -236,6 +236,7 @@ pub enum SyncPayload {
     QuerySubscription {
         query_id: QueryId,
         query: Box<Query>,
+        #[serde(with = "query_subscription_session_serde")]
         session: Option<Session>,
         #[serde(default)]
         propagation: QueryPropagation,
@@ -264,7 +265,82 @@ pub enum SyncPayload {
     Error(SyncError),
 }
 
+/// Sessions contain claims as a JSON object.
+/// postcard does not support the dynamic deserialization style it expects (deserialize_any)
+/// so we need a custom serializer/deserializer to serialize/deserialize the claims as a string.
+mod query_subscription_session_serde {
+    use super::Session;
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    struct SessionWire {
+        user_id: String,
+        claims_json: String,
+    }
+
+    pub fn serialize<S>(value: &Option<Session>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        if serializer.is_human_readable() {
+            return value.serialize(serializer);
+        }
+
+        let wire: Option<SessionWire> = value
+            .as_ref()
+            .map(|session| {
+                let claims_json =
+                    serde_json::to_string(&session.claims).map_err(serde::ser::Error::custom)?;
+                Ok(SessionWire {
+                    user_id: session.user_id.clone(),
+                    claims_json,
+                })
+            })
+            .transpose()?;
+
+        wire.serialize(serializer)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<Session>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        if deserializer.is_human_readable() {
+            return Option::<Session>::deserialize(deserializer);
+        }
+
+        let wire = Option::<SessionWire>::deserialize(deserializer)?;
+        wire.map(|session_wire| {
+            let claims = serde_json::from_str(&session_wire.claims_json)
+                .map_err(serde::de::Error::custom)?;
+            Ok(Session {
+                user_id: session_wire.user_id,
+                claims,
+            })
+        })
+        .transpose()
+    }
+}
+
 impl SyncPayload {
+    /// Encode this payload using postcard.
+    pub fn to_bytes(&self) -> Result<Vec<u8>, postcard::Error> {
+        postcard::to_allocvec(self)
+    }
+
+    /// Decode a payload from postcard bytes.
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, postcard::Error> {
+        postcard::from_bytes(bytes)
+    }
+
+    pub fn to_json(&self) -> Result<String, serde_json::Error> {
+        serde_json::to_string(self)
+    }
+
+    pub fn from_json(json: &str) -> Result<Self, serde_json::Error> {
+        serde_json::from_str(json)
+    }
+
     /// Check if this payload carries a catalogue object (schema or lens).
     pub fn is_catalogue(&self) -> bool {
         let metadata = match self {

--- a/crates/jazz-wasm/src/runtime.rs
+++ b/crates/jazz-wasm/src/runtime.rs
@@ -408,18 +408,7 @@ impl WasmRuntime {
     #[wasm_bindgen(js_name = onSyncMessageReceived)]
     pub fn on_sync_message_received(&self, payload: JsValue) -> Result<(), JsError> {
         let _span = debug_span!("wasm::onSyncMessageReceived", tier = self.tier_label).entered();
-        let payload = if let Some(json) = payload.as_string() {
-            SyncPayload::from_json(&json)
-                .map_err(|e| JsError::new(&format!("Invalid sync payload JSON: {e}")))?
-        } else if payload.is_instance_of::<Uint8Array>() {
-            let bytes = Uint8Array::new(&payload).to_vec();
-            SyncPayload::from_bytes(&bytes)
-                .map_err(|e| JsError::new(&format!("Invalid sync payload postcard: {e}")))?
-        } else {
-            return Err(JsError::new(
-                "Invalid sync payload type: expected Uint8Array or JSON string",
-            ));
-        };
+        let payload = self.parse_sync_payload(payload)?;
 
         let entry = InboxEntry {
             source: Source::Server(ServerId::new()),
@@ -439,7 +428,7 @@ impl WasmRuntime {
     pub fn on_sync_message_received_from_client(
         &self,
         client_id: &str,
-        payload: &[u8],
+        payload: JsValue,
     ) -> Result<(), JsError> {
         let _span = debug_span!(
             "wasm::onSyncMessageReceivedFromClient",
@@ -451,8 +440,7 @@ impl WasmRuntime {
             .map_err(|e| JsError::new(&format!("Invalid client ID: {}", e)))?;
         let cid = ClientId(uuid);
 
-        let payload = SyncPayload::from_bytes(payload)
-            .map_err(|e| JsError::new(&format!("Invalid sync payload postcard: {e}")))?;
+        let payload = self.parse_sync_payload(payload)?;
 
         let entry = InboxEntry {
             source: Source::Client(cid),
@@ -461,6 +449,21 @@ impl WasmRuntime {
 
         self.core.borrow_mut().park_sync_message(entry);
         Ok(())
+    }
+
+    fn parse_sync_payload(&self, payload: JsValue) -> Result<SyncPayload, JsError> {
+        if let Some(json) = payload.as_string() {
+            SyncPayload::from_json(&json)
+                .map_err(|e| JsError::new(&format!("Invalid sync payload JSON: {e}")))
+        } else if payload.is_instance_of::<Uint8Array>() {
+            let bytes = Uint8Array::new(&payload).to_vec();
+            SyncPayload::from_bytes(&bytes)
+                .map_err(|e| JsError::new(&format!("Invalid sync payload postcard: {e}")))
+        } else {
+            Err(JsError::new(
+                "Invalid sync payload type: expected Uint8Array or JSON string",
+            ))
+        }
     }
 
     /// Register a callback for outgoing sync messages.

--- a/crates/jazz-wasm/src/runtime.rs
+++ b/crates/jazz-wasm/src/runtime.rs
@@ -18,6 +18,7 @@ use std::rc::{Rc, Weak};
 use std::sync::Once;
 
 use js_sys::Function;
+use js_sys::Uint8Array;
 use serde::Serialize;
 #[cfg(target_arch = "wasm32")]
 use tracing::warn;
@@ -262,15 +263,27 @@ impl JsSyncSender {
 }
 
 impl SyncSender for JsSyncSender {
-    fn send_sync_message(&self, message: OutboxEntry) {
+    fn send_sync_message(&self, message: OutboxEntry, sender_tier: &'static str) {
         if let Some(ref callback) = *self.callback.borrow() {
             let is_catalogue = message.payload.is_catalogue();
-            if let Ok(payload_json) = serde_json::to_string(&message.payload) {
-                let (destination_kind, destination_id) = match message.destination {
-                    Destination::Server(server_id) => ("server", server_id.0.to_string()),
-                    Destination::Client(client_id) => ("client", client_id.0.to_string()),
-                };
-
+            let (destination_kind, destination_id) = match message.destination {
+                Destination::Server(server_id) => ("server", server_id.0.to_string()),
+                Destination::Client(client_id) => ("client", client_id.0.to_string()),
+            };
+            let use_binary_encoding = sender_tier == "client" || destination_kind == "client";
+            if use_binary_encoding {
+                if let Ok(payload_bytes) = message.payload.to_bytes() {
+                    let payload_js = Uint8Array::from(payload_bytes.as_slice());
+                    let _ = callback.call4(
+                        &JsValue::NULL,
+                        &JsValue::from_str(destination_kind),
+                        &JsValue::from_str(&destination_id),
+                        &payload_js.into(),
+                        &JsValue::from_bool(is_catalogue),
+                    );
+                }
+            } else {
+                let payload_json = message.payload.to_json().unwrap();
                 let _ = callback.call4(
                     &JsValue::NULL,
                     &JsValue::from_str(destination_kind),
@@ -390,12 +403,23 @@ impl WasmRuntime {
     /// Called by JS when a sync message arrives from the server.
     ///
     /// # Arguments
-    /// * `message_json` - JSON-encoded SyncPayload
+    /// * `payload` - Either postcard-encoded SyncPayload bytes (`Uint8Array`)
+    ///   or JSON-encoded SyncPayload (`string`)
     #[wasm_bindgen(js_name = onSyncMessageReceived)]
-    pub fn on_sync_message_received(&self, message_json: &str) -> Result<(), JsError> {
+    pub fn on_sync_message_received(&self, payload: JsValue) -> Result<(), JsError> {
         let _span = debug_span!("wasm::onSyncMessageReceived", tier = self.tier_label).entered();
-        let payload: SyncPayload = serde_json::from_str(message_json)
-            .map_err(|e| JsError::new(&format!("Invalid sync message: {}", e)))?;
+        let payload = if let Some(json) = payload.as_string() {
+            SyncPayload::from_json(&json)
+                .map_err(|e| JsError::new(&format!("Invalid sync payload JSON: {e}")))?
+        } else if payload.is_instance_of::<Uint8Array>() {
+            let bytes = Uint8Array::new(&payload).to_vec();
+            SyncPayload::from_bytes(&bytes)
+                .map_err(|e| JsError::new(&format!("Invalid sync payload postcard: {e}")))?
+        } else {
+            return Err(JsError::new(
+                "Invalid sync payload type: expected Uint8Array or JSON string",
+            ));
+        };
 
         let entry = InboxEntry {
             source: Source::Server(ServerId::new()),
@@ -410,12 +434,12 @@ impl WasmRuntime {
     ///
     /// # Arguments
     /// * `client_id` - UUID string of the sending client
-    /// * `message_json` - JSON-encoded SyncPayload
+    /// * `payload` - Postcard-encoded SyncPayload bytes
     #[wasm_bindgen(js_name = onSyncMessageReceivedFromClient)]
     pub fn on_sync_message_received_from_client(
         &self,
         client_id: &str,
-        message_json: &str,
+        payload: &[u8],
     ) -> Result<(), JsError> {
         let _span = debug_span!(
             "wasm::onSyncMessageReceivedFromClient",
@@ -427,8 +451,8 @@ impl WasmRuntime {
             .map_err(|e| JsError::new(&format!("Invalid client ID: {}", e)))?;
         let cid = ClientId(uuid);
 
-        let payload: SyncPayload = serde_json::from_str(message_json)
-            .map_err(|e| JsError::new(&format!("Invalid sync message: {}", e)))?;
+        let payload = SyncPayload::from_bytes(payload)
+            .map_err(|e| JsError::new(&format!("Invalid sync payload postcard: {e}")))?;
 
         let entry = InboxEntry {
             source: Source::Client(cid),

--- a/packages/jazz-tools/src/runtime/client.ts
+++ b/packages/jazz-tools/src/runtime/client.ts
@@ -63,7 +63,7 @@ export interface Runtime {
     options_json?: string | null,
   ): number;
   unsubscribe(handle: number): void;
-  onSyncMessageReceived(message_json: string): void;
+  onSyncMessageReceived(payload: Uint8Array | string): void;
   onSyncMessageToSend(callback: Function): void;
   addServer(): void;
   removeServer(): void;
@@ -72,7 +72,7 @@ export interface Runtime {
   getSchemaHash(): string;
   close?(): void | Promise<void>;
   setClientRole?(client_id: string, role: string): void;
-  onSyncMessageReceivedFromClient?(client_id: string, message_json: string): void;
+  onSyncMessageReceivedFromClient?(client_id: string, payload: Uint8Array | string): void;
 }
 
 /**
@@ -858,8 +858,8 @@ export class JazzClient {
       createSyncOutboxRouter({
         logPrefix: "[client] ",
         retryServerPayloads: true,
-        onServerPayload: (payloadJson, isCatalogue) =>
-          this.sendSyncMessage(payloadJson, isCatalogue),
+        onServerPayload: (payload, isCatalogue) =>
+          this.sendSyncMessage(payload as string, isCatalogue),
         onServerPayloadError: (error) => {
           const isExpectedAbort = isExpectedFetchAbortError(error);
           if (!isExpectedAbort) {

--- a/packages/jazz-tools/src/runtime/cloud-server.integration.test.ts
+++ b/packages/jazz-tools/src/runtime/cloud-server.integration.test.ts
@@ -374,6 +374,7 @@ async function connectClient(context: AppContext): Promise<JazzClient> {
     appId: context.appId,
     env: context.env,
     userBranch: context.userBranch,
+    tier: "worker",
   });
 
   return clientMod.JazzClient.connectWithRuntime(runtime, context);

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -235,7 +235,7 @@ interface FollowerSyncMessage {
   fromTabId: string;
   toLeaderTabId: string;
   term: number;
-  payload: string[];
+  payload: Uint8Array[];
 }
 
 interface LeaderSyncMessage {
@@ -243,7 +243,7 @@ interface LeaderSyncMessage {
   fromLeaderTabId: string;
   toTabId: string;
   term: number;
-  payload: string[];
+  payload: Uint8Array[];
 }
 
 interface FollowerCloseMessage {
@@ -261,8 +261,8 @@ function resolveBroadcastChannelCtor(): (new (name: string) => BroadcastChannelL
   return ctor as new (name: string) => BroadcastChannelLike;
 }
 
-function isStringArray(value: unknown): value is string[] {
-  return Array.isArray(value) && value.every((entry) => typeof entry === "string");
+function isBinaryPayloadArray(value: unknown): value is Uint8Array[] {
+  return Array.isArray(value) && value.every((entry) => entry instanceof Uint8Array);
 }
 
 function isTabSyncMessage(value: unknown): value is TabSyncMessage {
@@ -274,7 +274,7 @@ function isTabSyncMessage(value: unknown): value is TabSyncMessage {
       typeof message.fromTabId === "string" &&
       typeof message.toLeaderTabId === "string" &&
       typeof message.term === "number" &&
-      isStringArray(message.payload)
+      isBinaryPayloadArray(message.payload)
     );
   }
 
@@ -283,7 +283,7 @@ function isTabSyncMessage(value: unknown): value is TabSyncMessage {
       typeof message.fromLeaderTabId === "string" &&
       typeof message.toTabId === "string" &&
       typeof message.term === "number" &&
-      isStringArray(message.payload)
+      isBinaryPayloadArray(message.payload)
     );
   }
 

--- a/packages/jazz-tools/src/runtime/sync-transport.ts
+++ b/packages/jazz-tools/src/runtime/sync-transport.ts
@@ -54,7 +54,7 @@ export interface SyncStreamControllerOptions {
 export interface RuntimeSyncTarget {
   addServer(): void;
   removeServer(): void;
-  onSyncMessageReceived(messageJson: string): void;
+  onSyncMessageReceived(payload: string): void;
 }
 
 export interface RuntimeSyncStreamControllerOptions {
@@ -279,14 +279,14 @@ export function createRuntimeSyncStreamController(
     setClientId: options.setClientId,
     onConnected: () => options.getRuntime()?.addServer(),
     onDisconnected: () => options.getRuntime()?.removeServer(),
-    onSyncMessage: (json) => options.getRuntime()?.onSyncMessageReceived(json),
+    onSyncMessage: (payload) => options.getRuntime()?.onSyncMessageReceived(payload),
   });
 }
 
 export interface SyncOutboxRouterOptions {
   logPrefix?: string;
-  onServerPayload(payloadJson: string, isCatalogue: boolean): void | Promise<void>;
-  onClientPayload?(payloadJson: string): void;
+  onServerPayload(payload: Uint8Array | string, isCatalogue: boolean): void | Promise<void>;
+  onClientPayload?(payload: Uint8Array): void;
   onServerPayloadError?(error: unknown): void;
   retryServerPayloads?: boolean;
 }
@@ -301,7 +301,7 @@ export function createSyncOutboxRouter(
 ): (
   destinationKind: OutboxDestinationKind,
   destinationId: string,
-  payloadJson: string,
+  payload: Uint8Array | string,
   isCatalogue: boolean,
 ) => void {
   const logPrefix = options.logPrefix ?? "";
@@ -309,15 +309,15 @@ export function createSyncOutboxRouter(
   return (
     destinationKind: OutboxDestinationKind,
     _destinationId: string,
-    payloadJson: string,
+    payload: Uint8Array | string,
     isCatalogue: boolean,
   ) => {
     if (destinationKind === "client") {
-      options.onClientPayload?.(payloadJson);
+      options.onClientPayload?.(payload as Uint8Array);
       return;
     }
 
-    Promise.resolve(options.onServerPayload(payloadJson, isCatalogue)).catch((error) => {
+    Promise.resolve(options.onServerPayload(payload, isCatalogue)).catch((error) => {
       if (options.onServerPayloadError) {
         options.onServerPayloadError(error);
         return;

--- a/packages/jazz-tools/src/runtime/worker-bridge.race-harness.test.ts
+++ b/packages/jazz-tools/src/runtime/worker-bridge.race-harness.test.ts
@@ -14,9 +14,9 @@ type WorkerMessageHandler = (event: MessageEvent<WorkerToMainMessage>) => void;
 
 class FakeWorkerScript {
   private initialized = false;
-  private pendingSyncPayloads: string[] = [];
-  readonly receivedSyncPayloads: string[] = [];
-  readonly droppedSyncPayloads: string[] = [];
+  private pendingSyncPayloads: Uint8Array[] = [];
+  readonly receivedSyncPayloads: Uint8Array[] = [];
+  readonly droppedSyncPayloads: Uint8Array[] = [];
   initMessageCount = 0;
   shutdownMessageCount = 0;
 
@@ -107,7 +107,7 @@ class FakeWorkerScript {
     this.worker.emitToMain({ type: "error", message });
   }
 
-  emitSyncToMain(...payloads: string[]): void {
+  emitSyncToMain(...payloads: Uint8Array[]): void {
     this.worker.emitToMain({ type: "sync", payload: payloads });
   }
 }
@@ -148,13 +148,13 @@ class FakeWorker {
 
 function createRuntimeHarness() {
   let outboundHandler: ((...args: unknown[]) => void) | null = null;
-  const receivedFromWorker: string[] = [];
+  const receivedFromWorker: Uint8Array[] = [];
 
   const runtime = {
     onSyncMessageToSend(handler: (...args: unknown[]) => void) {
       outboundHandler = handler;
     },
-    onSyncMessageReceived(payload: string) {
+    onSyncMessageReceived(payload: Uint8Array) {
       receivedFromWorker.push(payload);
     },
     addServer() {},
@@ -168,7 +168,12 @@ function createRuntimeHarness() {
       if (!outboundHandler) {
         throw new Error("Runtime sync handler is not installed");
       }
-      outboundHandler("server", "server-1", JSON.stringify(payload), false);
+      outboundHandler(
+        "server",
+        "server-1",
+        new TextEncoder().encode(JSON.stringify(payload)),
+        false,
+      );
     },
   };
 }
@@ -184,6 +189,8 @@ function makeBridgeOptions(): WorkerBridgeOptions {
 }
 
 describe("WorkerBridge race harness", () => {
+  const enc = (value: unknown): Uint8Array => new TextEncoder().encode(JSON.stringify(value));
+
   it("WB-U01 queues outbound sync until init completes", async () => {
     const worker = new FakeWorker({ dropSyncBeforeInit: true });
     const { runtime, emitServerPayload } = createRuntimeHarness();
@@ -202,8 +209,8 @@ describe("WorkerBridge race harness", () => {
     expect(bridge.getWorkerClientId()).toBe("worker-client-1");
 
     expect(worker.script.receivedSyncPayloads).toEqual([
-      JSON.stringify({ kind: "sub", seq: 1 }),
-      JSON.stringify({ kind: "sub", seq: 2 }),
+      enc({ kind: "sub", seq: 1 }),
+      enc({ kind: "sub", seq: 2 }),
     ]);
   });
 
@@ -222,9 +229,9 @@ describe("WorkerBridge race harness", () => {
     await Promise.resolve();
 
     expect(worker.script.receivedSyncPayloads).toEqual([
-      JSON.stringify({ kind: "sub", seq: 1 }),
-      JSON.stringify({ kind: "sub", seq: 2 }),
-      JSON.stringify({ kind: "sub", seq: 3 }),
+      enc({ kind: "sub", seq: 1 }),
+      enc({ kind: "sub", seq: 2 }),
+      enc({ kind: "sub", seq: 3 }),
     ]);
   });
 
@@ -250,9 +257,9 @@ describe("WorkerBridge race harness", () => {
     const bridge = new WorkerBridge(worker as unknown as Worker, runtime);
 
     const initPromise = bridge.init(makeBridgeOptions());
-    worker.script.emitSyncToMain(JSON.stringify({ kind: "from-worker", seq: 1 }));
+    worker.script.emitSyncToMain(enc({ kind: "from-worker", seq: 1 }));
 
-    expect(receivedFromWorker).toEqual([JSON.stringify({ kind: "from-worker", seq: 1 })]);
+    expect(receivedFromWorker).toEqual([enc({ kind: "from-worker", seq: 1 })]);
 
     worker.script.completeInit("worker-client-3");
     await initPromise;
@@ -288,8 +295,8 @@ describe("WorkerBridge race harness", () => {
 
     expect((bridge as any).state.phase).toBe("failed");
     expect((bridge as any).state.pendingSyncPayloadsForWorker).toEqual([
-      JSON.stringify({ kind: "sub", seq: 1 }),
-      JSON.stringify({ kind: "sub", seq: 2 }),
+      enc({ kind: "sub", seq: 1 }),
+      enc({ kind: "sub", seq: 2 }),
     ]);
     expect(worker.script.receivedSyncPayloads).toEqual([]);
   });

--- a/packages/jazz-tools/src/runtime/worker-bridge.test.ts
+++ b/packages/jazz-tools/src/runtime/worker-bridge.test.ts
@@ -3,7 +3,6 @@ import { WorkerBridge, type PeerSyncBatch } from "./worker-bridge.js";
 import type { Runtime } from "./client.js";
 import type { WorkerToMainMessage } from "../worker/worker-protocol.js";
 import { OutboxDestinationKind } from "./sync-transport.js";
-import fa from "zod/v4/locales/fa.cjs";
 
 class MockWorker {
   onmessage: ((event: MessageEvent<WorkerToMainMessage>) => void) | null = null;
@@ -42,19 +41,19 @@ class MockWorker {
 type SendSyncPayloadCallback = (
   destinationKind: OutboxDestinationKind,
   destinationId: string,
-  payloadJson: string,
+  payload: Uint8Array,
   isCatalogue: boolean,
 ) => void;
 
 function createRuntimeMock(): {
   runtime: Runtime;
   emitSyncPayload: SendSyncPayloadCallback;
-  receivedFromWorker: string[];
+  receivedFromWorker: Uint8Array[];
   addServerCalls: { count: number };
   removeServerCalls: { count: number };
 } {
   let onSyncToSend: SendSyncPayloadCallback | null = null;
-  const receivedFromWorker: string[] = [];
+  const receivedFromWorker: Uint8Array[] = [];
   const addServerCalls = { count: 0 };
   const removeServerCalls = { count: 0 };
 
@@ -65,11 +64,8 @@ function createRuntimeMock(): {
     query: async () => [],
     subscribe: () => 1,
     unsubscribe: () => undefined,
-    insertDurable: async () => "id",
-    updateDurable: async () => undefined,
-    deleteDurable: async () => undefined,
-    onSyncMessageReceived: (messageJson: string) => {
-      receivedFromWorker.push(messageJson);
+    onSyncMessageReceived: (payload: Uint8Array) => {
+      receivedFromWorker.push(payload);
     },
     onSyncMessageToSend: (callback: SendSyncPayloadCallback) => {
       onSyncToSend = callback;
@@ -90,13 +86,13 @@ function createRuntimeMock(): {
     emitSyncPayload: (
       destinationKind: OutboxDestinationKind,
       destinationId: string,
-      payloadJson: string,
+      payload: Uint8Array,
       isCatalogue = false,
     ) => {
       if (!onSyncToSend) {
         throw new Error("onSyncMessageToSend callback not registered");
       }
-      onSyncToSend(destinationKind, destinationId, payloadJson, isCatalogue);
+      onSyncToSend(destinationKind, destinationId, payload, isCatalogue);
     },
     receivedFromWorker,
     addServerCalls,
@@ -105,6 +101,8 @@ function createRuntimeMock(): {
 }
 
 describe("WorkerBridge", () => {
+  const enc = (value: unknown): Uint8Array => new TextEncoder().encode(JSON.stringify(value));
+
   it("attaches runtime server and forwards worker sync payloads to runtime", () => {
     const worker = new MockWorker();
     const runtimeMock = createRuntimeMock();
@@ -115,10 +113,10 @@ describe("WorkerBridge", () => {
 
     worker.emitFromWorker({
       type: "sync",
-      payload: ["payload-a", "payload-b"],
+      payload: [enc({ id: 1 }), enc({ id: 2 })],
     });
 
-    expect(runtimeMock.receivedFromWorker).toEqual(["payload-a", "payload-b"]);
+    expect(runtimeMock.receivedFromWorker).toEqual([enc({ id: 1 }), enc({ id: 2 })]);
   });
 
   it("batches server-bound runtime payloads into one worker sync message", async () => {
@@ -126,13 +124,13 @@ describe("WorkerBridge", () => {
     const runtimeMock = createRuntimeMock();
     const bridge = new WorkerBridge(worker as unknown as Worker, runtimeMock.runtime);
 
-    runtimeMock.emitSyncPayload("server", "server-1", JSON.stringify({ id: 1 }), false);
-    runtimeMock.emitSyncPayload("server", "server-2", JSON.stringify({ id: 2 }), false);
-    runtimeMock.emitSyncPayload("client", "client-1", JSON.stringify({ ignored: true }), false);
+    runtimeMock.emitSyncPayload("server", "server-1", enc({ id: 1 }), false);
+    runtimeMock.emitSyncPayload("server", "server-2", enc({ id: 2 }), false);
+    runtimeMock.emitSyncPayload("client", "client-1", enc({ ignored: true }), false);
 
     // Outgoing payloads are buffered until init completes.
     let syncMessages = worker.posted.filter(
-      (entry): entry is { type: "sync"; payload: string[] } =>
+      (entry): entry is { type: "sync"; payload: Uint8Array[] } =>
         typeof entry === "object" && entry !== null && (entry as { type?: string }).type === "sync",
     );
     expect(syncMessages).toHaveLength(0);
@@ -149,14 +147,14 @@ describe("WorkerBridge", () => {
     await Promise.resolve();
 
     syncMessages = worker.posted.filter(
-      (entry): entry is { type: "sync"; payload: string[] } =>
+      (entry): entry is { type: "sync"; payload: Uint8Array[] } =>
         typeof entry === "object" && entry !== null && (entry as { type?: string }).type === "sync",
     );
 
     expect(syncMessages).toHaveLength(1);
     expect(syncMessages[0]).toEqual({
       type: "sync",
-      payload: [JSON.stringify({ id: 1 }), JSON.stringify({ id: 2 })],
+      payload: [enc({ id: 1 }), enc({ id: 2 })],
     });
   });
 
@@ -202,11 +200,11 @@ describe("WorkerBridge", () => {
     worker.emitFromWorker({ type: "shutdown-ok" });
     await shutdownPromise;
 
-    runtimeMock.emitSyncPayload("server", "server-1", JSON.stringify({ dropped: true }), false);
+    runtimeMock.emitSyncPayload("server", "server-1", enc({ dropped: true }), false);
     await Promise.resolve();
 
     const syncMessagesAfterShutdown = worker.posted.filter(
-      (entry): entry is { type: "sync"; payload: string[] } =>
+      (entry): entry is { type: "sync"; payload: Uint8Array[] } =>
         typeof entry === "object" && entry !== null && (entry as { type?: string }).type === "sync",
     );
     expect(syncMessagesAfterShutdown).toHaveLength(0);
@@ -223,12 +221,17 @@ describe("WorkerBridge", () => {
     });
 
     bridge.openPeer("peer-a");
-    bridge.sendPeerSync("peer-a", 9, ["payload-1", "payload-2"]);
+    bridge.sendPeerSync("peer-a", 9, [enc("payload-1"), enc("payload-2")]);
     bridge.closePeer("peer-a");
 
     expect(worker.posted).toEqual([
       { type: "peer-open", peerId: "peer-a" },
-      { type: "peer-sync", peerId: "peer-a", term: 9, payload: ["payload-1", "payload-2"] },
+      {
+        type: "peer-sync",
+        peerId: "peer-a",
+        term: 9,
+        payload: [enc("payload-1"), enc("payload-2")],
+      },
       { type: "peer-close", peerId: "peer-a" },
     ]);
 
@@ -236,14 +239,14 @@ describe("WorkerBridge", () => {
       type: "peer-sync",
       peerId: "peer-a",
       term: 9,
-      payload: ["from-worker"],
+      payload: [enc("from-worker")],
     });
 
     expect(peerBatches).toEqual([
       {
         peerId: "peer-a",
         term: 9,
-        payload: ["from-worker"],
+        payload: [enc("from-worker")],
       },
     ]);
   });
@@ -252,27 +255,27 @@ describe("WorkerBridge", () => {
     const worker = new MockWorker();
     const runtimeMock = createRuntimeMock();
     const bridge = new WorkerBridge(worker as unknown as Worker, runtimeMock.runtime);
-    const redirected: string[] = [];
+    const redirected: Uint8Array[] = [];
 
     bridge.setServerPayloadForwarder((payload) => {
       redirected.push(payload);
     });
-    runtimeMock.emitSyncPayload("server", "server-1", JSON.stringify({ routed: "peer" }), false);
+    runtimeMock.emitSyncPayload("server", "server-1", enc({ routed: "peer" }), false);
     await Promise.resolve();
 
     const workerSyncMessages = worker.posted.filter(
-      (entry): entry is { type: "sync"; payload: string[] } =>
+      (entry): entry is { type: "sync"; payload: Uint8Array[] } =>
         typeof entry === "object" && entry !== null && (entry as { type?: string }).type === "sync",
     );
     expect(workerSyncMessages).toHaveLength(0);
-    expect(redirected).toEqual([JSON.stringify({ routed: "peer" })]);
+    expect(redirected).toEqual([enc({ routed: "peer" })]);
 
     bridge.replayServerConnection();
     expect(runtimeMock.removeServerCalls.count).toBe(1);
     expect(runtimeMock.addServerCalls.count).toBe(2);
 
-    bridge.applyIncomingServerPayload("from-peer-leader");
-    expect(runtimeMock.receivedFromWorker).toEqual(["from-peer-leader"]);
+    bridge.applyIncomingServerPayload(enc("from-peer-leader"));
+    expect(runtimeMock.receivedFromWorker).toEqual([enc("from-peer-leader")]);
   });
 
   it("forwards lifecycle hints to worker", () => {

--- a/packages/jazz-tools/src/runtime/worker-bridge.test.ts
+++ b/packages/jazz-tools/src/runtime/worker-bridge.test.ts
@@ -64,6 +64,9 @@ function createRuntimeMock(): {
     query: async () => [],
     subscribe: () => 1,
     unsubscribe: () => undefined,
+    insertDurable: async () => "id",
+    updateDurable: async () => undefined,
+    deleteDurable: async () => undefined,
     onSyncMessageReceived: (payload: Uint8Array) => {
       receivedFromWorker.push(payload);
     },

--- a/packages/jazz-tools/src/runtime/worker-bridge.ts
+++ b/packages/jazz-tools/src/runtime/worker-bridge.ts
@@ -34,7 +34,7 @@ export interface WorkerBridgeOptions {
 export interface PeerSyncBatch {
   peerId: string;
   term: number;
-  payload: string[];
+  payload: Uint8Array[];
 }
 
 type BridgePhase = "idle" | "initializing" | "ready" | "failed" | "shutting-down" | "disposed";
@@ -49,10 +49,10 @@ interface WorkerBridgeState {
   phase: BridgePhase;
   workerClientId: string | null;
   initPromise: Promise<string> | null;
-  pendingSyncPayloadsForWorker: string[];
+  pendingSyncPayloadsForWorker: Uint8Array[];
   syncBatchFlushQueued: boolean;
   peerSyncListener: ((batch: PeerSyncBatch) => void) | null;
-  serverPayloadForwarder: ((payload: string) => void) | null;
+  serverPayloadForwarder: ((payload: Uint8Array) => void) | null;
 }
 
 const INIT_RESPONSE_TIMEOUT_MS = 12_000;
@@ -105,7 +105,7 @@ export class WorkerBridge {
       (
         destinationKind: OutboxDestinationKind,
         _destinationId: string,
-        payloadJson: string,
+        payload: Uint8Array,
         _isCatalogue: boolean,
       ) => {
         if (this.isDisposedLike()) return;
@@ -113,9 +113,9 @@ export class WorkerBridge {
         // Only forward server-bound messages (worker IS the server)
         if (destinationKind === "server") {
           if (this.state.serverPayloadForwarder) {
-            this.state.serverPayloadForwarder(payloadJson);
+            this.state.serverPayloadForwarder(payload);
           } else {
-            this.enqueueSyncMessageForWorker(payloadJson);
+            this.enqueueSyncMessageForWorker(payload);
           }
         }
       },
@@ -256,12 +256,12 @@ export class WorkerBridge {
     return this.state.workerClientId;
   }
 
-  setServerPayloadForwarder(forwarder: ((payload: string) => void) | null): void {
+  setServerPayloadForwarder(forwarder: ((payload: Uint8Array) => void) | null): void {
     if (this.isDisposedLike()) return;
     this.state.serverPayloadForwarder = forwarder;
   }
 
-  applyIncomingServerPayload(payload: string): void {
+  applyIncomingServerPayload(payload: Uint8Array): void {
     if (this.isDisposedLike()) return;
     this.runtime.onSyncMessageReceived(payload);
   }
@@ -281,15 +281,17 @@ export class WorkerBridge {
     this.worker.postMessage({ type: "peer-open", peerId });
   }
 
-  sendPeerSync(peerId: string, term: number, payload: string[]): void {
+  sendPeerSync(peerId: string, term: number, payload: Uint8Array[]): void {
     if (this.isDisposedLike()) return;
     if (payload.length === 0) return;
-    this.worker.postMessage({
-      type: "peer-sync",
+    const message = {
+      type: "peer-sync" as const,
       peerId,
       term,
       payload,
-    });
+    };
+    const transfer = collectPayloadTransferables(payload);
+    this.worker.postMessage(message, transfer);
   }
 
   closePeer(peerId: string): void {
@@ -297,7 +299,7 @@ export class WorkerBridge {
     this.worker.postMessage({ type: "peer-close", peerId });
   }
 
-  private enqueueSyncMessageForWorker(payload: string): void {
+  private enqueueSyncMessageForWorker(payload: Uint8Array): void {
     if (this.isDisposedLike()) return;
 
     this.state.pendingSyncPayloadsForWorker.push(payload);
@@ -323,10 +325,12 @@ export class WorkerBridge {
     const payloads = this.state.pendingSyncPayloadsForWorker;
     this.state.pendingSyncPayloadsForWorker = [];
 
-    this.worker.postMessage({
-      type: "sync",
+    const message = {
+      type: "sync" as const,
       payload: payloads,
-    });
+    };
+    const transfer = collectPayloadTransferables(payloads);
+    this.worker.postMessage(message, transfer);
   }
 
   private isDisposedLike(): boolean {
@@ -371,6 +375,10 @@ export class WorkerBridge {
     this.state.syncBatchFlushQueued = false;
     this.runtime.onSyncMessageToSend(() => undefined);
   }
+}
+
+function collectPayloadTransferables(payloads: Uint8Array[]): Transferable[] {
+  return payloads.map((payload) => payload.buffer);
 }
 
 /**

--- a/packages/jazz-tools/src/worker/jazz-worker.ts
+++ b/packages/jazz-tools/src/worker/jazz-worker.ts
@@ -21,7 +21,7 @@ import { normalizeRuntimeSchemaJson } from "../drivers/schema-wire.js";
 // Worker globals — minimal type for DedicatedWorkerGlobalScope
 // (Cannot use lib "WebWorker" as it conflicts with DOM types in the main tsconfig)
 declare const self: {
-  postMessage(msg: unknown): void;
+  postMessage(msg: unknown, transfer?: Transferable[]): void;
   onmessage: ((event: MessageEvent) => void) | null;
   close(): void;
   location?: { origin?: string };
@@ -43,9 +43,9 @@ let streamConnecting = false;
 let streamAttached = false;
 const streamConnectTimeoutMs = 10_000;
 let isShuttingDown = false;
-let pendingSyncMessages: string[] = []; // Buffer sync messages until init completes
-let pendingPeerSyncMessages: Array<{ peerId: string; term: number; payload: string[] }> = [];
-let pendingSyncPayloadsForMain: string[] = [];
+let pendingSyncMessages: Uint8Array[] = []; // Buffer sync messages until init completes
+let pendingPeerSyncMessages: Array<{ peerId: string; term: number; payload: Uint8Array[] }> = [];
+let pendingSyncPayloadsForMain: (Uint8Array | string)[] = [];
 let syncBatchFlushQueued = false;
 let initComplete = false;
 let bootstrapCatalogueForwarding = false;
@@ -91,7 +91,7 @@ async function runWithRootRelativeFetchSupport<T>(operation: () => Promise<T>): 
   }
 }
 
-function enqueueSyncMessageForMain(payload: string): void {
+function enqueueSyncMessageForMain(payload: Uint8Array | string): void {
   pendingSyncPayloadsForMain.push(payload);
   if (syncBatchFlushQueued) return;
 
@@ -106,7 +106,21 @@ function enqueueSyncMessageForMain(payload: string): void {
 }
 
 function post(msg: WorkerToMainMessage): void {
-  self.postMessage(msg);
+  const transfer =
+    msg.type === "sync" || msg.type === "peer-sync"
+      ? collectPayloadTransferables(msg.payload)
+      : undefined;
+  self.postMessage(msg, transfer);
+}
+
+function collectPayloadTransferables(payloads: (Uint8Array | string)[]): Transferable[] {
+  const transferables = [];
+  for (const payload of payloads) {
+    if (payload instanceof Uint8Array) {
+      transferables.push(payload.buffer);
+    }
+  }
+  return transferables;
 }
 
 // ============================================================================
@@ -188,14 +202,14 @@ async function handleInit(msg: InitMessage): Promise<void> {
       (
         destinationKind: OutboxDestinationKind,
         destinationId: string,
-        payloadJson: string,
+        payload: Uint8Array | string,
         isCatalogue: boolean,
       ) => {
         if (destinationKind === "client") {
           const destinationClientId = destinationId;
           if (destinationClientId === mainClientId) {
             // Local main-thread client-bound payload.
-            enqueueSyncMessageForMain(payloadJson);
+            enqueueSyncMessageForMain(payload);
             return;
           }
 
@@ -209,19 +223,19 @@ async function handleInit(msg: InitMessage): Promise<void> {
             type: "peer-sync",
             peerId,
             term,
-            payload: [payloadJson],
+            payload: [payload as Uint8Array],
           });
         } else if (destinationKind === "server") {
           if (bootstrapCatalogueForwarding) {
             if (isCatalogue) {
-              enqueueSyncMessageForMain(payloadJson);
+              enqueueSyncMessageForMain(payload);
             }
             return;
           }
 
           // Server-bound → HTTP POST to upstream
           if (activeServerUrl) {
-            void sendToServer(activeServerUrl, payloadJson, isCatalogue).catch((error) => {
+            void sendToServer(activeServerUrl, payload as string, isCatalogue).catch((error) => {
               if (!isExpectedFetchAbortError(error)) {
                 console.error("[worker] Sync POST error:", error);
               }
@@ -389,7 +403,7 @@ async function connectStream(): Promise<void> {
     await readBinaryFrames(
       reader,
       {
-        onSyncMessage: (json) => runtime?.onSyncMessageReceived(json),
+        onSyncMessage: (payload) => runtime?.onSyncMessageReceived(payload),
         onConnected: (clientId) => {
           console.log("[worker] Stream connected", { clientId });
           serverClientId = clientId;

--- a/packages/jazz-tools/src/worker/worker-protocol.ts
+++ b/packages/jazz-tools/src/worker/worker-protocol.ts
@@ -28,7 +28,7 @@ export interface InitMessage {
 /** Forward a sync payload from main thread to worker. */
 export interface SyncToWorkerMessage {
   type: "sync";
-  payload: string[]; // JSON-encoded SyncPayloads
+  payload: Uint8Array[];
 }
 
 export type WorkerLifecycleEvent =
@@ -56,7 +56,7 @@ export interface PeerSyncToWorkerMessage {
   type: "peer-sync";
   peerId: string;
   term: number;
-  payload: string[]; // JSON-encoded SyncPayloads
+  payload: Uint8Array[];
 }
 
 /**
@@ -134,7 +134,7 @@ export interface InitOkMessage {
 /** Forward a sync payload from worker to main thread. */
 export interface SyncToMainMessage {
   type: "sync";
-  payload: string[]; // JSON-encoded SyncPayloads
+  payload: (Uint8Array | string)[];
 }
 
 /** Forward sync payload(s) to a specific follower peer through leader main thread. */
@@ -142,7 +142,7 @@ export interface PeerSyncToMainMessage {
   type: "peer-sync";
   peerId: string;
   term: number;
-  payload: string[]; // JSON-encoded SyncPayloads
+  payload: Uint8Array[];
 }
 
 /** Worker encountered an error. */

--- a/specs/todo/b_launch/nitro_modules_bridge.md
+++ b/specs/todo/b_launch/nitro_modules_bridge.md
@@ -255,7 +255,7 @@ struct NitroSyncSender {
 }
 
 impl SyncSender for NitroSyncSender {
-    fn send_sync_message(&self, message: OutboxEntry) {
+    fn send_sync_message(&self, message: OutboxEntry, _sender_tier: &'static str) {
         let json = serde_json::to_string(&message).unwrap();
         self.callback.call(json);
     }


### PR DESCRIPTION
## Description

Replaces the existing JSON serialization for sync messages sent between the main thread and the worker thread with a faster binary encoding using [postcard](https://docs.rs/postcard/latest/postcard/).

## Discussion

None of the faster-than-JSON Rust<>Rust serialization libraries I found support schema evolution, so I decided to keep binary encoding scoped to main thread<>worker (& cross-tab communication). For communication across the network we continue to use JSON.

I tested multiple Rust crates:
- https://docs.rs/postcard/latest/postcard/
- https://docs.rs/bitcode/latest/bitcode/
- https://docs.rs/rkyv/latest/rkyv/

And found `postcard` to be the fastest in WASM. Keeping benchmarks here for future reference:
- [json-encoding.json.gz](https://github.com/user-attachments/files/25723029/1-json-encoding.json.gz)
- [postcard-encoding.json.gz](https://github.com/user-attachments/files/25723034/2-postcard-encoding.json.gz)
- [bitcode-encoding.json.gz](https://github.com/user-attachments/files/25723039/3-bitcode-encoding.json.gz)
- [rkyv-encoding.json.gz](https://github.com/user-attachments/files/25723041/4-rkyv-encoding.json.gz)

The code is in https://github.com/garden-co/jazz2/tree/perf/sync-payload-binary-encoding-pocs.

## Performance

Scenario: load 10k rows

### Main thread

#### Before

<img width="1728" height="671" alt="before-main-thread" src="https://github.com/user-attachments/assets/b47b4cc0-ef85-4118-a879-e84af29ea226" />

#### After

<img width="1728" height="671" alt="after-main-thread" src="https://github.com/user-attachments/assets/c8b9aea3-b322-459b-b923-2d5fa1980bd7" />

### Worker

#### Before

<img width="1728" height="671" alt="before-worker" src="https://github.com/user-attachments/assets/0ed83c2a-9e41-4dfa-8d65-ecd5d1ecf860" />

#### After

<img width="1728" height="671" alt="after-worker" src="https://github.com/user-attachments/assets/7661e5dd-803b-4c21-bff7-85f8a3486b4a" />