### PR TITLE
jazz-tools: harden runtime sync outbox callback contract

### DIFF
--- a/.changeset/blue-pets-reflect.md
+++ b/.changeset/blue-pets-reflect.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Harden runtime sync outbox handling across WASM/RN and NAPI callback contracts by typing both callback shapes, routing both through a shared normalizer, and adding conformance tests that assert identical `/sync` behavior.

--- a/packages/jazz-tools/src/runtime/client.ts
+++ b/packages/jazz-tools/src/runtime/client.ts
@@ -20,6 +20,7 @@ import {
   type SyncStreamController,
   type SyncAuth,
   type LinkExternalResponse,
+  type RuntimeSyncOutboxCallback,
 } from "./sync-transport.js";
 import { resolveLocalAuthDefaults } from "./local-auth.js";
 import { resolveJwtSession } from "./client-session.js";
@@ -64,7 +65,7 @@ export interface Runtime {
   ): number;
   unsubscribe(handle: number): void;
   onSyncMessageReceived(message_json: string): void;
-  onSyncMessageToSend(callback: Function): void;
+  onSyncMessageToSend(callback: RuntimeSyncOutboxCallback): void;
   addServer(): void;
   removeServer(): void;
   addClient(): string;

--- a/packages/jazz-tools/src/runtime/sync-transport.test.ts
+++ b/packages/jazz-tools/src/runtime/sync-transport.test.ts
@@ -11,11 +11,45 @@ import {
   readBinaryFrames,
   sendSyncPayload,
   SyncStreamController,
+  type RuntimeSyncOutboxCallback,
 } from "./sync-transport.js";
 
 describe("sync-transport", () => {
   const originalFetch = globalThis.fetch;
   const textEncoder = new TextEncoder();
+  const outboxInvokers: Array<
+    [
+      name: string,
+      invoke: (
+        router: RuntimeSyncOutboxCallback,
+        destinationKind: "server" | "client",
+        destinationId: string,
+        payloadJson: string,
+        isCatalogue: boolean,
+      ) => void,
+    ]
+  > = [
+    [
+      "wasm/rn",
+      (
+        router: RuntimeSyncOutboxCallback,
+        destinationKind: "server" | "client",
+        destinationId: string,
+        payloadJson: string,
+        isCatalogue: boolean,
+      ) => router(destinationKind, destinationId, payloadJson, isCatalogue),
+    ],
+    [
+      "napi-callee-handled",
+      (
+        router: RuntimeSyncOutboxCallback,
+        destinationKind: "server" | "client",
+        destinationId: string,
+        payloadJson: string,
+        isCatalogue: boolean,
+      ) => router(null, destinationKind, destinationId, payloadJson, isCatalogue),
+    ],
+  ];
 
   function encodeFrames(events: unknown[]): Uint8Array {
     const chunks: Uint8Array[] = events.map((event) => {
@@ -450,22 +484,54 @@ describe("sync-transport", () => {
     controller.stop();
   });
 
-  it("sync outbox router routes server and client destinations", async () => {
-    const onServerPayload = vi.fn().mockResolvedValue(undefined);
-    const onClientPayload = vi.fn();
-    const router = createSyncOutboxRouter({
-      onServerPayload,
-      onClientPayload,
-    });
+  it.each(outboxInvokers)(
+    "sync outbox router routes server and client destinations (%s)",
+    async (_name, invoke) => {
+      const onServerPayload = vi.fn().mockResolvedValue(undefined);
+      const onClientPayload = vi.fn();
+      const router = createSyncOutboxRouter({
+        onServerPayload,
+        onClientPayload,
+      });
 
-    router("server", "upstream-1", JSON.stringify({ Ping: {} }), false);
-    router("client", "client-1", JSON.stringify({ Pong: {} }), false);
+      invoke(router, "server", "upstream-1", JSON.stringify({ Ping: {} }), false);
+      invoke(router, "client", "client-1", JSON.stringify({ Pong: {} }), false);
 
-    await vi.waitFor(() =>
-      expect(onServerPayload).toHaveBeenCalledWith(JSON.stringify({ Ping: {} }), false),
-    );
-    expect(onClientPayload).toHaveBeenCalledWith(JSON.stringify({ Pong: {} }));
-  });
+      await vi.waitFor(() =>
+        expect(onServerPayload).toHaveBeenCalledWith(JSON.stringify({ Ping: {} }), false),
+      );
+      expect(onClientPayload).toHaveBeenCalledWith(JSON.stringify({ Pong: {} }));
+    },
+  );
+
+  it.each(outboxInvokers)(
+    "sync outbox router posts server payloads via sendSyncPayload (%s)",
+    async (_name, invoke) => {
+      const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200, statusText: "OK" });
+      (globalThis as { fetch: typeof fetch }).fetch = fetchMock as unknown as typeof fetch;
+
+      const router = createSyncOutboxRouter({
+        onServerPayload: (payloadJson, isCatalogue) =>
+          sendSyncPayload("http://localhost:3000", payloadJson, isCatalogue, {
+            backendSecret: "backend-secret",
+          }),
+      });
+
+      const payloadJson = JSON.stringify({ QuerySubscription: { id: "q-1" } });
+      invoke(router, "server", "upstream-1", payloadJson, false);
+
+      await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+      const requestBody = JSON.parse(fetchMock.mock.calls[0][1].body as string) as {
+        payload: unknown;
+      };
+      expect(requestBody.payload).toEqual(JSON.parse(payloadJson));
+      expect(fetchMock.mock.calls[0][0]).toBe("http://localhost:3000/sync");
+      expect(fetchMock.mock.calls[0][1].headers).toMatchObject({
+        "X-Jazz-Backend-Secret": "backend-secret",
+      });
+    },
+  );
 
   it("sync outbox router surfaces server-send failures", async () => {
     const error = new Error("network down");

--- a/packages/jazz-tools/src/runtime/sync-transport.ts
+++ b/packages/jazz-tools/src/runtime/sync-transport.ts
@@ -292,26 +292,72 @@ export interface SyncOutboxRouterOptions {
 }
 
 export type OutboxDestinationKind = "server" | "client";
+export type RuntimeSyncOutboxCallbackArgs =
+  | [
+      destinationKind: OutboxDestinationKind,
+      destinationId: string,
+      payloadJson: string,
+      isCatalogue: boolean,
+    ]
+  | [
+      err: unknown,
+      destinationKind: OutboxDestinationKind,
+      destinationId: string,
+      payloadJson: string,
+      isCatalogue: boolean,
+    ];
+export type RuntimeSyncOutboxCallback = (...args: RuntimeSyncOutboxCallbackArgs) => void;
+
+function isOutboxDestinationKind(value: unknown): value is OutboxDestinationKind {
+  return value === "server" || value === "client";
+}
+
+function normalizeOutboxCallbackArgs(args: unknown[]): {
+  destinationKind: OutboxDestinationKind;
+  payloadJson: string;
+  isCatalogue: boolean;
+} | null {
+  // WASM/RN-style callback: (destinationKind, destinationId, payloadJson, isCatalogue)
+  if (isOutboxDestinationKind(args[0])) {
+    const payloadJson = args[2];
+    if (typeof payloadJson !== "string") return null;
+    return {
+      destinationKind: args[0],
+      payloadJson,
+      isCatalogue: Boolean(args[3]),
+    };
+  }
+
+  // NAPI callee-handled callback: (err, destinationKind, destinationId, payloadJson, isCatalogue)
+  if (isOutboxDestinationKind(args[1])) {
+    const payloadJson = args[3];
+    if (typeof payloadJson !== "string") return null;
+    return {
+      destinationKind: args[1],
+      payloadJson,
+      isCatalogue: Boolean(args[4]),
+    };
+  }
+
+  return null;
+}
 
 /**
  * Create a shared runtime outbox router for server/client destinations.
  */
 export function createSyncOutboxRouter(
   options: SyncOutboxRouterOptions,
-): (
-  destinationKind: OutboxDestinationKind,
-  destinationId: string,
-  payloadJson: string,
-  isCatalogue: boolean,
-) => void {
+): RuntimeSyncOutboxCallback {
   const logPrefix = options.logPrefix ?? "";
 
-  return (
-    destinationKind: OutboxDestinationKind,
-    _destinationId: string,
-    payloadJson: string,
-    isCatalogue: boolean,
-  ) => {
+  return (...args: RuntimeSyncOutboxCallbackArgs) => {
+    const normalized = normalizeOutboxCallbackArgs(args);
+    if (!normalized) {
+      console.error(`${logPrefix}Invalid sync outbox callback arguments`, args);
+      return;
+    }
+
+    const { destinationKind, payloadJson, isCatalogue } = normalized;
     if (destinationKind === "client") {
       options.onClientPayload?.(payloadJson);
       return;

--- a/packages/jazz-tools/src/runtime/worker-bridge.ts
+++ b/packages/jazz-tools/src/runtime/worker-bridge.ts
@@ -12,7 +12,7 @@ import type {
   WorkerLifecycleEvent,
   WorkerToMainMessage,
 } from "../worker/worker-protocol.js";
-import { OutboxDestinationKind } from "./sync-transport.js";
+import { createSyncOutboxRouter } from "./sync-transport.js";
 
 /**
  * Options for initializing the worker bridge.
@@ -102,23 +102,17 @@ export class WorkerBridge {
 
     // Wire main → worker: outgoing sync messages from runtime
     this.runtime.onSyncMessageToSend(
-      (
-        destinationKind: OutboxDestinationKind,
-        _destinationId: string,
-        payloadJson: string,
-        _isCatalogue: boolean,
-      ) => {
-        if (this.isDisposedLike()) return;
+      createSyncOutboxRouter({
+        onServerPayload: (payloadJson) => {
+          if (this.isDisposedLike()) return;
 
-        // Only forward server-bound messages (worker IS the server)
-        if (destinationKind === "server") {
           if (this.state.serverPayloadForwarder) {
             this.state.serverPayloadForwarder(payloadJson);
           } else {
             this.enqueueSyncMessageForWorker(payloadJson);
           }
-        }
-      },
+        },
+      }),
     );
 
     // Register a server so the runtime sends sync messages to it

--- a/packages/jazz-tools/src/types/jazz-wasm.d.ts
+++ b/packages/jazz-tools/src/types/jazz-wasm.d.ts
@@ -1,4 +1,20 @@
 declare module "jazz-wasm" {
+  type SyncOutboxCallbackArgs =
+    | [
+        destinationKind: "server" | "client",
+        destinationId: string,
+        payloadJson: string,
+        isCatalogue: boolean,
+      ]
+    | [
+        err: unknown,
+        destinationKind: "server" | "client",
+        destinationId: string,
+        payloadJson: string,
+        isCatalogue: boolean,
+      ];
+  type SyncOutboxCallback = (...args: SyncOutboxCallbackArgs) => void;
+
   export default function init(input?: unknown): Promise<void>;
   export function initSync(input?: unknown): void;
 
@@ -26,7 +42,7 @@ declare module "jazz-wasm" {
     ): number;
     unsubscribe(handle: number): void;
     onSyncMessageReceived(messageJson: string): void;
-    onSyncMessageToSend(callback: Function): void;
+    onSyncMessageToSend(callback: SyncOutboxCallback): void;
     addServer(): void;
     removeServer(): void;
     addClient(): string;


### PR DESCRIPTION
## Summary
- type runtime sync outbox callbacks explicitly instead of using `Function`, including both WASM/RN and NAPI callback shapes
- normalize and route both callback shapes through the shared outbox router, and use that router in `WorkerBridge` as well
- add cross-runtime conformance tests that validate identical routing and `/sync` POST behavior for both callback signatures
- add a changeset for `jazz-tools`

## Testing
- pnpm vitest run --config vitest.config.ts src/runtime/sync-transport.test.ts src/runtime/worker-bridge.test.ts src/runtime/worker-bridge.race-harness.test.ts src/runtime/client.for-request.test.ts src/backend/create-jazz-context.test.ts
- pnpm build
