### PR TITLE
feat(sql): parse EXISTS in policy expressions; fix outer-row id binding

### DIFF
--- a/.changeset/exists-policy-expressions.md
+++ b/.changeset/exists-policy-expressions.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Add support for `EXISTS (SELECT FROM <table> WHERE <expr>)` in SQL policy expressions.

--- a/.changeset/fix-outer-row-id-in-exists-policies.md
+++ b/.changeset/fix-outer-row-id-in-exists-policies.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Fix `@session.__jazz_outer_row.id` not resolving inside EXISTS subquery policies. Previously the outer row's UUID was silently treated as an unresolvable column, causing all EXISTS policy checks to evaluate to false on the server.

--- a/crates/jazz-tools/src/query_manager/graph_nodes/policy_filter.rs
+++ b/crates/jazz-tools/src/query_manager/graph_nodes/policy_filter.rs
@@ -610,10 +610,11 @@ impl PolicyFilterNode {
             return false;
         }
 
-        let bound_condition = match bind_outer_row_refs(condition, &row.data, descriptor) {
-            Some(expr) => expr,
-            None => return false,
-        };
+        let bound_condition =
+            match bind_outer_row_refs(condition, &row.data, descriptor, Some(row.id)) {
+                Some(expr) => expr,
+                None => return false,
+            };
 
         let table_name = TableName::new(table);
         let mut graph = match PolicyGraph::for_exists(

--- a/crates/jazz-tools/src/query_manager/policy.rs
+++ b/crates/jazz-tools/src/query_manager/policy.rs
@@ -831,13 +831,39 @@ fn resolve_policy_value(value: &PolicyValue, session: &Session) -> Option<Value>
     }
 }
 
+/// Resolve an outer-row column reference to a literal `Value`.
+///
+/// Tries the named column first; if the descriptor has no column called `"id"`,
+/// falls back to the row's `ObjectId` (UUID), which is stored separately from the
+/// content bytes. Returns `None` on any failure.
+fn resolve_outer_col(
+    outer_col: &str,
+    outer_content: &[u8],
+    outer_descriptor: &RowDescriptor,
+    outer_row_id: Option<ObjectId>,
+) -> Option<Value> {
+    if let Some(col_index) = outer_descriptor.column_index(outer_col) {
+        decode_column(outer_descriptor, outer_content, col_index).ok()
+    } else if outer_col == "id" {
+        // `@session.__jazz_outer_row.id` refers to the row's ObjectId (UUID),
+        // which is not a content column.
+        Some(Value::Uuid(outer_row_id?))
+    } else {
+        None
+    }
+}
+
 /// Bind outer-row references encoded as `@session.__jazz_outer_row.<column>` to literals.
+///
+/// `outer_row_id` must be supplied when the policy may reference
+/// `@session.__jazz_outer_row.id` (the row's UUID primary key).
 ///
 /// Returns `None` if a referenced outer column cannot be resolved.
 pub fn bind_outer_row_refs(
     expr: &PolicyExpr,
     outer_content: &[u8],
     outer_descriptor: &RowDescriptor,
+    outer_row_id: Option<ObjectId>,
 ) -> Option<PolicyExpr> {
     match expr {
         PolicyExpr::Cmp { column, op, value } => {
@@ -845,9 +871,12 @@ pub fn bind_outer_row_refs(
                 PolicyValue::Literal(v) => PolicyValue::Literal(v.clone()),
                 PolicyValue::SessionRef(path) => {
                     if let Some(outer_col) = outer_row_ref_column(path) {
-                        let col_index = outer_descriptor.column_index(outer_col)?;
-                        let resolved =
-                            decode_column(outer_descriptor, outer_content, col_index).ok()?;
+                        let resolved = resolve_outer_col(
+                            outer_col,
+                            outer_content,
+                            outer_descriptor,
+                            outer_row_id,
+                        )?;
                         PolicyValue::Literal(resolved)
                     } else {
                         PolicyValue::SessionRef(path.clone())
@@ -872,9 +901,12 @@ pub fn bind_outer_row_refs(
                 PolicyValue::Literal(v) => PolicyValue::Literal(v.clone()),
                 PolicyValue::SessionRef(path) => {
                     if let Some(outer_col) = outer_row_ref_column(path) {
-                        let col_index = outer_descriptor.column_index(outer_col)?;
-                        let resolved =
-                            decode_column(outer_descriptor, outer_content, col_index).ok()?;
+                        let resolved = resolve_outer_col(
+                            outer_col,
+                            outer_content,
+                            outer_descriptor,
+                            outer_row_id,
+                        )?;
                         PolicyValue::Literal(resolved)
                     } else {
                         PolicyValue::SessionRef(path.clone())
@@ -905,9 +937,12 @@ pub fn bind_outer_row_refs(
                     PolicyValue::Literal(v) => Some(PolicyValue::Literal(v.clone())),
                     PolicyValue::SessionRef(path) => {
                         if let Some(outer_col) = outer_row_ref_column(path) {
-                            let col_index = outer_descriptor.column_index(outer_col)?;
-                            let resolved =
-                                decode_column(outer_descriptor, outer_content, col_index).ok()?;
+                            let resolved = resolve_outer_col(
+                                outer_col,
+                                outer_content,
+                                outer_descriptor,
+                                outer_row_id,
+                            )?;
                             Some(PolicyValue::Literal(resolved))
                         } else {
                             Some(PolicyValue::SessionRef(path.clone()))
@@ -950,19 +985,24 @@ pub fn bind_outer_row_refs(
         PolicyExpr::And(exprs) => Some(PolicyExpr::And(
             exprs
                 .iter()
-                .map(|expr| bind_outer_row_refs(expr, outer_content, outer_descriptor))
+                .map(|expr| {
+                    bind_outer_row_refs(expr, outer_content, outer_descriptor, outer_row_id)
+                })
                 .collect::<Option<Vec<_>>>()?,
         )),
         PolicyExpr::Or(exprs) => Some(PolicyExpr::Or(
             exprs
                 .iter()
-                .map(|expr| bind_outer_row_refs(expr, outer_content, outer_descriptor))
+                .map(|expr| {
+                    bind_outer_row_refs(expr, outer_content, outer_descriptor, outer_row_id)
+                })
                 .collect::<Option<Vec<_>>>()?,
         )),
         PolicyExpr::Not(expr) => Some(PolicyExpr::Not(Box::new(bind_outer_row_refs(
             expr,
             outer_content,
             outer_descriptor,
+            outer_row_id,
         )?))),
         PolicyExpr::True => Some(PolicyExpr::True),
         PolicyExpr::False => Some(PolicyExpr::False),
@@ -1612,7 +1652,7 @@ fn evaluate_simple_recursive(
         }),
 
         PolicyExpr::Exists { table, condition } => {
-            let bound = match bind_outer_row_refs(condition, content, descriptor) {
+            let bound = match bind_outer_row_refs(condition, content, descriptor, None) {
                 Some(expr) => expr,
                 None => return SimpleEvalResult::fail(),
             };
@@ -1775,6 +1815,49 @@ mod tests {
 
         let result = evaluate_simple_parts(&expr, &content, &descriptor, &session);
         assert!(!result.passed);
+    }
+
+    #[test]
+    fn test_bind_outer_row_refs_id_resolves_to_object_id_when_not_a_column() {
+        // Regression test: `@session.__jazz_outer_row.id` must resolve to the row's
+        // ObjectId (UUID) even when "id" is not a named column in the descriptor.
+        // This is the common case — e.g. `EXISTS (SELECT FROM chatMembers WHERE chat =
+        // @session.__jazz_outer_row.id AND userId = @session.user_id)`.
+        use crate::object::ObjectId;
+
+        let descriptor =
+            RowDescriptor::new(vec![ColumnDescriptor::new("owner_id", ColumnType::Text)]);
+        let content = encode_row(&descriptor, &[Value::Text("user-1".into())]).unwrap();
+
+        let row_id = ObjectId::from_uuid(uuid::Uuid::from_u128(
+            0xdead_beef_cafe_0000_0000_0000_0000_0001,
+        ));
+
+        let expr = PolicyExpr::Cmp {
+            column: "chat".into(),
+            op: CmpOp::Eq,
+            value: PolicyValue::SessionRef(vec![OUTER_ROW_SESSION_PREFIX.into(), "id".into()]),
+        };
+
+        // Without a row_id: "id" is not a column, so binding must fail.
+        assert!(
+            bind_outer_row_refs(&expr, &content, &descriptor, None).is_none(),
+            "should fail when id is not a column and no row_id is provided"
+        );
+
+        // With a row_id: should resolve to the UUID literal.
+        let bound = bind_outer_row_refs(&expr, &content, &descriptor, Some(row_id));
+        assert!(
+            matches!(
+                &bound,
+                Some(PolicyExpr::Cmp {
+                    value: PolicyValue::Literal(Value::Uuid(id)),
+                    ..
+                }) if *id == row_id
+            ),
+            "expected @session.__jazz_outer_row.id to resolve to Value::Uuid(row_id), got {:?}",
+            bound
+        );
     }
 
     #[test]

--- a/crates/jazz-tools/src/schema_manager/sql.rs
+++ b/crates/jazz-tools/src/schema_manager/sql.rs
@@ -2592,4 +2592,66 @@ mod tests {
         );
         assert!(!col.nullable);
     }
+
+    #[test]
+    fn parse_policy_exists_subquery() {
+        // EXISTS (SELECT FROM <table> WHERE <condition>) in a USING clause
+        let sql = r#"
+            CREATE TABLE messages (
+                id UUID NOT NULL,
+                room_id UUID NOT NULL
+            );
+            CREATE POLICY messages_select_policy ON messages FOR SELECT
+                USING (EXISTS (SELECT FROM members WHERE member_id = session.user_id));
+        "#;
+
+        let schema = parse_schema(sql).unwrap();
+        let table = schema.get(&TableName::new("messages")).unwrap();
+        let using = table.policies.select.using.as_ref().unwrap();
+
+        assert!(
+            matches!(
+                using,
+                PolicyExpr::Exists { table, .. } if table == "members"
+            ),
+            "expected PolicyExpr::Exists, got {:?}",
+            using
+        );
+    }
+
+    #[test]
+    fn policy_exists_round_trip() {
+        // policy_expr_to_sql(parse(EXISTS expr)) should reproduce the original SQL
+        let sql = r#"
+            CREATE TABLE messages (
+                id UUID NOT NULL,
+                room_id UUID NOT NULL
+            );
+            CREATE POLICY messages_select_policy ON messages FOR SELECT
+                USING (EXISTS (SELECT FROM members WHERE member_id = session.user_id));
+        "#;
+
+        let schema = parse_schema(sql).unwrap();
+        let regenerated = schema_to_sql(&schema);
+        let reparsed = parse_schema(&regenerated).unwrap();
+
+        let original_using = schema
+            .get(&TableName::new("messages"))
+            .unwrap()
+            .policies
+            .select
+            .using
+            .as_ref()
+            .unwrap();
+        let reparsed_using = reparsed
+            .get(&TableName::new("messages"))
+            .unwrap()
+            .policies
+            .select
+            .using
+            .as_ref()
+            .unwrap();
+
+        assert_eq!(original_using, reparsed_using);
+    }
 }

--- a/crates/jazz-tools/src/schema_manager/sql.rs
+++ b/crates/jazz-tools/src/schema_manager/sql.rs
@@ -105,6 +105,9 @@ enum Token {
     True,
     False,
     References,
+    Exists,
+    From,
+    Where,
     // Punctuation
     LParen,
     RParen,
@@ -331,6 +334,9 @@ impl<'a> Tokenizer<'a> {
                     "TRUE" => Token::True,
                     "FALSE" => Token::False,
                     "REFERENCES" => Token::References,
+                    "EXISTS" => Token::Exists,
+                    "FROM" => Token::From,
+                    "WHERE" => Token::Where,
                     _ => Token::Ident(ident),
                 }
             }
@@ -640,6 +646,20 @@ impl Parser {
                         max_depth: None,
                     })
                 }
+            }
+            Some(Token::Exists) => {
+                self.advance();
+                self.expect(&Token::LParen)?;
+                self.expect(&Token::Select)?;
+                self.expect(&Token::From)?;
+                let table = self.expect_ident()?;
+                self.expect(&Token::Where)?;
+                let condition = self.parse_policy_expr()?;
+                self.expect(&Token::RParen)?;
+                Ok(PolicyExpr::Exists {
+                    table,
+                    condition: Box::new(condition),
+                })
             }
             Some(Token::Ident(_)) => {
                 let column = self.expect_ident()?;
@@ -2593,19 +2613,19 @@ mod tests {
         assert!(!col.nullable);
     }
 
+    const EXISTS_POLICY_SQL: &str = r#"
+        CREATE TABLE messages (
+            id UUID NOT NULL,
+            room_id UUID NOT NULL
+        );
+        CREATE POLICY messages_select_policy ON messages FOR SELECT
+            USING (EXISTS (SELECT FROM members WHERE member_id = @session.user_id));
+    "#;
+
     #[test]
     fn parse_policy_exists_subquery() {
         // EXISTS (SELECT FROM <table> WHERE <condition>) in a USING clause
-        let sql = r#"
-            CREATE TABLE messages (
-                id UUID NOT NULL,
-                room_id UUID NOT NULL
-            );
-            CREATE POLICY messages_select_policy ON messages FOR SELECT
-                USING (EXISTS (SELECT FROM members WHERE member_id = session.user_id));
-        "#;
-
-        let schema = parse_schema(sql).unwrap();
+        let schema = parse_schema(EXISTS_POLICY_SQL).unwrap();
         let table = schema.get(&TableName::new("messages")).unwrap();
         let using = table.policies.select.using.as_ref().unwrap();
 
@@ -2622,14 +2642,7 @@ mod tests {
     #[test]
     fn policy_exists_round_trip() {
         // policy_expr_to_sql(parse(EXISTS expr)) should reproduce the original SQL
-        let sql = r#"
-            CREATE TABLE messages (
-                id UUID NOT NULL,
-                room_id UUID NOT NULL
-            );
-            CREATE POLICY messages_select_policy ON messages FOR SELECT
-                USING (EXISTS (SELECT FROM members WHERE member_id = session.user_id));
-        "#;
+        let sql = EXISTS_POLICY_SQL;
 
         let schema = parse_schema(sql).unwrap();
         let regenerated = schema_to_sql(&schema);


### PR DESCRIPTION
## Summary

- Adds `EXISTS (SELECT FROM <table> WHERE <expr>)` support to the SQL policy expression parser (`parse_policy_primary` in `schema_manager/sql.rs`), producing `PolicyExpr::Exists`. The `query_manager` and `policy_expr_to_sql` already had the `Exists` variant; the gap was purely in the parser.
- Fixes `@session.__jazz_outer_row.id` not resolving inside EXISTS subquery policies. `bind_outer_row_refs` only looked up named columns via the `RowDescriptor`; since `id` is the row's `ObjectId` stored outside the content bytes, `column_index("id")` always returned `None` and the EXISTS check silently evaluated to `false`. Private chats were therefore invisible to members after the server subscription fired. Fix: add `resolve_outer_col` helper that falls back to `Value::Uuid(outer_row_id)` when the column is `"id"` and no descriptor entry exists.

## Relation to PR #215

PR #215 (`fix: id in array subqueries`) adds `id: Option<ObjectId>` to `Value::Row { id, values }` so that row IDs are accessible in the `ArraySubqueryNode` path. That PR does not touch `bind_outer_row_refs`, so the fix here is complementary — both are needed for `@session.__jazz_outer_row.id` to work in all contexts.

## Test plan

- [ ] `cargo test -p jazz-tools` — 788 tests pass
- [ ] `parse_policy_exists_subquery` and `policy_exists_round_trip` — SQL round-trip for EXISTS policies
- [ ] `test_bind_outer_row_refs_id_resolves_to_object_id_when_not_a_column` — regression test for the outer-row id binding fix
- [ ] Browser tests: `invite.test.tsx` and `send-permission.test.tsx` (private chat visibility)