### PR TITLE
Add browser limit+offset windowing

### DIFF
--- a/crates/jazz-tools/src/query_manager/graph.rs
+++ b/crates/jazz-tools/src/query_manager/graph.rs
@@ -582,25 +582,26 @@ impl QueryGraph {
         // Sort node (default: id ASC when order_by is omitted)
         let sort_keys = sort_keys_from_order_by(&plan.order_by, &current_descriptor);
 
-        // Windowed index scan: when sorting by id ASC with limit, and no
-        // post-scan filtering, push offset+limit down to the index scan so
-        // storage only returns the needed key range.
+        // Windowed index scan: when sorting by id (ASC or DESC) with limit,
+        // and no post-scan filtering, push offset+limit down to the index scan
+        // so storage only returns the needed key range.
         let use_windowed_scan = plan.limit.is_some()
             && plan.recursive.is_none()
             && !plan.include_deleted
             && branches.len() == 1
             && phase1_outputs.len() == 1
             && phase2_input == materialize_id
-            && is_id_asc_only_sort(&sort_keys)
+            && is_id_only_sort(&sort_keys)
             && matches!(
                 graph.get_node(phase1_outputs[0]),
                 Some(GraphNode::IndexScan(n)) if matches!(n.condition, ScanCondition::All)
             );
 
         if use_windowed_scan {
+            let reverse = matches!(sort_keys[0].direction, SortDirection::Descending);
             let scan_id = phase1_outputs[0];
             if let Some(GraphNode::IndexScan(scan_node)) = graph.get_node_mut(scan_id) {
-                scan_node.set_window(plan.offset, plan.limit.unwrap());
+                scan_node.set_window(plan.offset, plan.limit.unwrap(), reverse);
             }
         }
 
@@ -2325,10 +2326,8 @@ fn sort_keys_from_order_by(
         .collect()
 }
 
-fn is_id_asc_only_sort(sort_keys: &[SortKey]) -> bool {
-    sort_keys.len() == 1
-        && matches!(sort_keys[0].target, SortTarget::RowId)
-        && matches!(sort_keys[0].direction, SortDirection::Ascending)
+fn is_id_only_sort(sort_keys: &[SortKey]) -> bool {
+    sort_keys.len() == 1 && matches!(sort_keys[0].target, SortTarget::RowId)
 }
 
 fn build_remaining_predicate_from_disjuncts(

--- a/crates/jazz-tools/src/query_manager/graph.rs
+++ b/crates/jazz-tools/src/query_manager/graph.rs
@@ -32,6 +32,7 @@ use super::graph_nodes::subgraph::SubgraphTemplate;
 use super::graph_nodes::union::UnionNode;
 use super::graph_nodes::{NodeId, RowNode, SourceContext, SourceNode, TransformNode};
 use super::index::ScanCondition;
+use super::policy::PolicyExpr;
 use super::query::{ArraySubquerySpec, Condition, Conjunction, Query, QueryBuilder};
 use super::relation_ir::RelExpr;
 use super::relation_ir_query_plan::{ExecutionQueryPlan, lower_relation_to_execution_plan};
@@ -515,8 +516,10 @@ impl QueryGraph {
         let mut phase2_input = materialize_id;
         let mut current_descriptor = descriptor.clone();
 
-        // Policy filter node (if session provided and table has SELECT policy)
-        if let (Some(session), Some(policy)) = (&session, select_policy) {
+        // Policy filter node (if session provided and table has a non-trivial SELECT policy)
+        if let (Some(session), Some(policy)) = (&session, select_policy)
+            && !matches!(policy, PolicyExpr::True)
+        {
             let branch_for_policy = branches
                 .first()
                 .cloned()
@@ -578,6 +581,29 @@ impl QueryGraph {
 
         // Sort node (default: id ASC when order_by is omitted)
         let sort_keys = sort_keys_from_order_by(&plan.order_by, &current_descriptor);
+
+        // Windowed index scan: when sorting by id ASC with limit, and no
+        // post-scan filtering, push offset+limit down to the index scan so
+        // storage only returns the needed key range.
+        let use_windowed_scan = plan.limit.is_some()
+            && plan.recursive.is_none()
+            && !plan.include_deleted
+            && branches.len() == 1
+            && phase1_outputs.len() == 1
+            && phase2_input == materialize_id
+            && is_id_asc_only_sort(&sort_keys)
+            && matches!(
+                graph.get_node(phase1_outputs[0]),
+                Some(GraphNode::IndexScan(n)) if matches!(n.condition, ScanCondition::All)
+            );
+
+        if use_windowed_scan {
+            let scan_id = phase1_outputs[0];
+            if let Some(GraphNode::IndexScan(scan_node)) = graph.get_node_mut(scan_id) {
+                scan_node.set_window(plan.offset, plan.limit.unwrap());
+            }
+        }
+
         if !sort_keys.is_empty() {
             let sort_tuple_desc =
                 TupleDescriptor::single_with_materialization("", current_descriptor.clone(), true);
@@ -587,8 +613,8 @@ impl QueryGraph {
             phase2_input = sort_id;
         }
 
-        // LimitOffset node (if limit or offset specified)
-        if plan.limit.is_some() || plan.offset > 0 {
+        // LimitOffset node (skip when windowed scan already handles pagination)
+        if !use_windowed_scan && (plan.limit.is_some() || plan.offset > 0) {
             let limit_tuple_desc =
                 TupleDescriptor::single_with_materialization("", current_descriptor.clone(), true);
             let limit_offset_node =
@@ -2297,6 +2323,12 @@ fn sort_keys_from_order_by(
             }
         })
         .collect()
+}
+
+fn is_id_asc_only_sort(sort_keys: &[SortKey]) -> bool {
+    sort_keys.len() == 1
+        && matches!(sort_keys[0].target, SortTarget::RowId)
+        && matches!(sort_keys[0].direction, SortDirection::Ascending)
 }
 
 fn build_remaining_predicate_from_disjuncts(

--- a/crates/jazz-tools/src/query_manager/graph_nodes/index_scan.rs
+++ b/crates/jazz-tools/src/query_manager/graph_nodes/index_scan.rs
@@ -23,8 +23,8 @@ pub struct IndexScanNode {
     /// Output tuple descriptor (single element, unmaterialized).
     output_descriptor: TupleDescriptor,
 
-    /// Optional (offset, limit) window for ordered index scans.
-    window: Option<(usize, usize)>,
+    /// Optional (offset, limit, reverse) window for ordered index scans.
+    window: Option<(usize, usize, bool)>,
 
     /// Current set of tuples (length-1) matching the condition.
     current_tuples: AHashSet<Tuple>,
@@ -73,16 +73,16 @@ impl IndexScanNode {
         &self.output_descriptor
     }
 
-    /// Set the window for ordered index scans (offset, limit).
-    pub fn set_window(&mut self, offset: usize, limit: usize) {
-        self.window = Some((offset, limit));
+    /// Set the window for ordered index scans (offset, limit, reverse).
+    pub fn set_window(&mut self, offset: usize, limit: usize, reverse: bool) {
+        self.window = Some((offset, limit, reverse));
     }
 }
 
 impl SourceNode for IndexScanNode {
     fn scan(&mut self, ctx: &SourceContext) -> TupleDelta {
         let new_ids: AHashSet<ObjectId> = match (&self.condition, self.window) {
-            (ScanCondition::All, Some((offset, limit))) => ctx
+            (ScanCondition::All, Some((offset, limit, reverse))) => ctx
                 .storage
                 .index_scan_ordered(
                     self.table.as_str(),
@@ -90,6 +90,7 @@ impl SourceNode for IndexScanNode {
                     &self.branch,
                     offset,
                     limit,
+                    reverse,
                 )
                 .into_iter()
                 .collect(),

--- a/crates/jazz-tools/src/query_manager/graph_nodes/index_scan.rs
+++ b/crates/jazz-tools/src/query_manager/graph_nodes/index_scan.rs
@@ -10,6 +10,9 @@ use super::{SourceContext, SourceNode};
 
 /// Source node that scans an index via Storage.
 /// Emits TupleDelta with length-1 tuples based on the scan condition.
+///
+/// When `window` is set and the condition is `All`, uses the ordered windowed
+/// scan to load only the needed range of keys from storage.
 #[derive(Debug)]
 pub struct IndexScanNode {
     pub table: TableName,
@@ -19,6 +22,9 @@ pub struct IndexScanNode {
 
     /// Output tuple descriptor (single element, unmaterialized).
     output_descriptor: TupleDescriptor,
+
+    /// Optional (offset, limit) window for ordered index scans.
+    window: Option<(usize, usize)>,
 
     /// Current set of tuples (length-1) matching the condition.
     current_tuples: AHashSet<Tuple>,
@@ -45,6 +51,7 @@ impl IndexScanNode {
             branch: branch.into(),
             condition,
             output_descriptor,
+            window: None,
             current_tuples: AHashSet::new(),
             last_scanned_ids: AHashSet::new(),
             dirty: true,
@@ -65,17 +72,33 @@ impl IndexScanNode {
     pub fn output_tuple_descriptor(&self) -> &TupleDescriptor {
         &self.output_descriptor
     }
+
+    /// Set the window for ordered index scans (offset, limit).
+    pub fn set_window(&mut self, offset: usize, limit: usize) {
+        self.window = Some((offset, limit));
+    }
 }
 
 impl SourceNode for IndexScanNode {
     fn scan(&mut self, ctx: &SourceContext) -> TupleDelta {
-        let new_ids: AHashSet<ObjectId> = match &self.condition {
-            ScanCondition::All => ctx
+        let new_ids: AHashSet<ObjectId> = match (&self.condition, self.window) {
+            (ScanCondition::All, Some((offset, limit))) => ctx
+                .storage
+                .index_scan_ordered(
+                    self.table.as_str(),
+                    self.column.as_str(),
+                    &self.branch,
+                    offset,
+                    limit,
+                )
+                .into_iter()
+                .collect(),
+            (ScanCondition::All, None) => ctx
                 .storage
                 .index_scan_all(self.table.as_str(), self.column.as_str(), &self.branch)
                 .into_iter()
                 .collect(),
-            ScanCondition::Eq(value) => ctx
+            (ScanCondition::Eq(value), _) => ctx
                 .storage
                 .index_lookup(
                     self.table.as_str(),
@@ -85,7 +108,7 @@ impl SourceNode for IndexScanNode {
                 )
                 .into_iter()
                 .collect(),
-            ScanCondition::Range { min, max } => {
+            (ScanCondition::Range { min, max }, _) => {
                 let start = min.as_ref();
                 let end = max.as_ref();
                 ctx.storage

--- a/crates/jazz-tools/src/query_manager/manager_tests.rs
+++ b/crates/jazz-tools/src/query_manager/manager_tests.rs
@@ -8317,3 +8317,230 @@ fn e2e_three_tier_untrusted_downstream_keeps_result_only_scope() {
         "Untrusted downstream should keep current result-only sync behavior"
     );
 }
+
+// ============================================================================
+// Windowed index scan tests
+// ============================================================================
+//
+// These test that limit+offset queries sorted by id (the default) load only
+// the needed range of keys from storage, producing correct results and
+// correct reactive deltas on insert/delete.
+
+#[test]
+fn windowed_scan_returns_correct_page() {
+    // Insert 6 rows, query with offset=2 limit=2 (default id ASC order).
+    // Expect the 3rd and 4th rows in id order.
+    let sync_manager = SyncManager::new();
+    let schema = test_schema();
+    let (mut qm, mut storage) = create_query_manager(sync_manager, schema);
+
+    let mut ids = Vec::new();
+    for i in 0..6 {
+        let h = qm
+            .insert(
+                &mut storage,
+                "users",
+                &[Value::Text(format!("User{i}")), Value::Integer(i)],
+            )
+            .unwrap();
+        ids.push(h.row_id);
+    }
+    ids.sort();
+
+    let query = qm.query("users").offset(2).limit(2).build();
+    let results = execute_query(&mut qm, &mut storage, query).unwrap();
+
+    assert_eq!(results.len(), 2);
+    let result_ids: Vec<_> = results.iter().map(|(id, _)| *id).collect();
+    assert_eq!(result_ids, &ids[2..4]);
+}
+
+#[test]
+fn windowed_scan_insert_before_window_shifts() {
+    // Start with rows [A, B, C, D] sorted by id, window offset=1 limit=2 → [B, C].
+    // Insert E whose id sorts before A → new order [E, A, B, C, D], window → [A, B].
+    //
+    //   before:  [A  B  C  D]
+    //                ^--^        window(1,2)
+    //   insert E (sorts first):
+    //   after:   [E  A  B  C  D]
+    //                ^--^        window(1,2) = [A, B]
+    let sync_manager = SyncManager::new();
+    let schema = test_schema();
+    let (mut qm, mut storage) = create_query_manager(sync_manager, schema);
+
+    // Create rows with controlled id ordering by generating many and picking sorted ones.
+    let mut handles = Vec::new();
+    for i in 0..4 {
+        let h = qm
+            .insert(
+                &mut storage,
+                "users",
+                &[Value::Text(format!("User{i}")), Value::Integer(i)],
+            )
+            .unwrap();
+        handles.push(h);
+    }
+    handles.sort_by_key(|h| h.row_id);
+
+    let query = qm.query("users").offset(1).limit(2).build();
+    let sub_id = qm.subscribe(query).unwrap();
+    qm.process(&mut storage);
+    let _ = qm.take_updates();
+
+    let initial = qm.get_subscription_results(sub_id);
+    assert_eq!(initial.len(), 2);
+    assert_eq!(initial[0].0, handles[1].row_id);
+    assert_eq!(initial[1].0, handles[2].row_id);
+
+    // Insert a row. Its UUID is random — we can't control where it sorts.
+    // Instead, verify the window is still correct after insert.
+    let new_h = qm
+        .insert(
+            &mut storage,
+            "users",
+            &[Value::Text("NewUser".into()), Value::Integer(99)],
+        )
+        .unwrap();
+    qm.process(&mut storage);
+
+    let mut all_ids: Vec<_> = handles.iter().map(|h| h.row_id).collect();
+    all_ids.push(new_h.row_id);
+    all_ids.sort();
+
+    let results = qm.get_subscription_results(sub_id);
+    assert_eq!(results.len(), 2);
+    let result_ids: Vec<_> = results.iter().map(|(id, _)| *id).collect();
+    assert_eq!(result_ids, &all_ids[1..3]);
+
+    qm.unsubscribe_with_sync(sub_id);
+}
+
+#[test]
+fn windowed_scan_delete_within_window_shifts() {
+    // Start with [A, B, C, D, E] sorted by id, window offset=1 limit=2 → [B, C].
+    // Delete B → [A, C, D, E], window → [C, D].
+    //
+    //   before:  [A  B  C  D  E]
+    //                ^--^          window(1,2)
+    //   delete B:
+    //   after:   [A  C  D  E]
+    //                ^--^          window(1,2) = [C, D]
+    let sync_manager = SyncManager::new();
+    let schema = test_schema();
+    let (mut qm, mut storage) = create_query_manager(sync_manager, schema);
+
+    let mut handles = Vec::new();
+    for i in 0..5 {
+        let h = qm
+            .insert(
+                &mut storage,
+                "users",
+                &[Value::Text(format!("User{i}")), Value::Integer(i)],
+            )
+            .unwrap();
+        handles.push(h);
+    }
+    handles.sort_by_key(|h| h.row_id);
+
+    let query = qm.query("users").offset(1).limit(2).build();
+    let sub_id = qm.subscribe(query).unwrap();
+    qm.process(&mut storage);
+    let _ = qm.take_updates();
+
+    let initial = qm.get_subscription_results(sub_id);
+    assert_eq!(initial.len(), 2);
+    assert_eq!(initial[0].0, handles[1].row_id);
+    assert_eq!(initial[1].0, handles[2].row_id);
+
+    // Delete the first row in the window (handles[1])
+    qm.delete(&mut storage, handles[1].row_id).unwrap();
+    qm.process(&mut storage);
+
+    let results = qm.get_subscription_results(sub_id);
+    assert_eq!(results.len(), 2);
+    assert_eq!(results[0].0, handles[2].row_id);
+    assert_eq!(results[1].0, handles[3].row_id);
+
+    qm.unsubscribe_with_sync(sub_id);
+}
+
+#[test]
+fn windowed_scan_delete_before_window_shifts() {
+    // Start with [A, B, C, D, E] sorted by id, window offset=2 limit=2 → [C, D].
+    // Delete A → [B, C, D, E], window → [D, E].
+    //
+    //   before:  [A  B  C  D  E]
+    //                   ^--^       window(2,2)
+    //   delete A:
+    //   after:   [B  C  D  E]
+    //                   ^--^       window(2,2) = [D, E]
+    let sync_manager = SyncManager::new();
+    let schema = test_schema();
+    let (mut qm, mut storage) = create_query_manager(sync_manager, schema);
+
+    let mut handles = Vec::new();
+    for i in 0..5 {
+        let h = qm
+            .insert(
+                &mut storage,
+                "users",
+                &[Value::Text(format!("User{i}")), Value::Integer(i)],
+            )
+            .unwrap();
+        handles.push(h);
+    }
+    handles.sort_by_key(|h| h.row_id);
+
+    let query = qm.query("users").offset(2).limit(2).build();
+    let sub_id = qm.subscribe(query).unwrap();
+    qm.process(&mut storage);
+    let _ = qm.take_updates();
+
+    let initial = qm.get_subscription_results(sub_id);
+    assert_eq!(initial.len(), 2);
+    assert_eq!(initial[0].0, handles[2].row_id);
+    assert_eq!(initial[1].0, handles[3].row_id);
+
+    // Delete the first row overall (before the window)
+    qm.delete(&mut storage, handles[0].row_id).unwrap();
+    qm.process(&mut storage);
+
+    let results = qm.get_subscription_results(sub_id);
+    assert_eq!(results.len(), 2);
+    assert_eq!(results[0].0, handles[3].row_id);
+    assert_eq!(results[1].0, handles[4].row_id);
+
+    qm.unsubscribe_with_sync(sub_id);
+}
+
+#[test]
+fn windowed_scan_with_filter_falls_back_to_full_scan() {
+    // When a WHERE filter is present, windowed scan is not eligible.
+    // Verify correct results with limit+offset+filter.
+    let sync_manager = SyncManager::new();
+    let schema = test_schema();
+    let (mut qm, mut storage) = create_query_manager(sync_manager, schema);
+
+    for i in 0..10 {
+        qm.insert(
+            &mut storage,
+            "users",
+            &[Value::Text(format!("User{i}")), Value::Integer(i * 10)],
+        )
+        .unwrap();
+    }
+
+    // Filter score >= 50, then limit 2 offset 1 in id order
+    let query = qm
+        .query("users")
+        .filter_ge("score", Value::Integer(50))
+        .offset(1)
+        .limit(2)
+        .build();
+    let results = execute_query(&mut qm, &mut storage, query).unwrap();
+
+    // Rows with score >= 50: scores 50,60,70,80,90 (5 rows).
+    // In id order, offset 1 limit 2 gives 2nd and 3rd of those 5.
+    assert_eq!(results.len(), 2);
+}

--- a/crates/jazz-tools/src/query_manager/manager_tests.rs
+++ b/crates/jazz-tools/src/query_manager/manager_tests.rs
@@ -8544,3 +8544,161 @@ fn windowed_scan_with_filter_falls_back_to_full_scan() {
     // In id order, offset 1 limit 2 gives 2nd and 3rd of those 5.
     assert_eq!(results.len(), 2);
 }
+
+#[test]
+fn windowed_scan_desc_returns_correct_page() {
+    // Insert 6 rows, query ORDER BY id DESC with offset=1 limit=2.
+    // Expect the 2nd and 3rd rows counting from the end of id order.
+    //
+    //   id order:  [A  B  C  D  E  F]
+    //   reversed:  [F  E  D  C  B  A]
+    //   offset=1:     [E  D  C  B  A]
+    //   limit=2:      [E  D]
+    let sync_manager = SyncManager::new();
+    let schema = test_schema();
+    let (mut qm, mut storage) = create_query_manager(sync_manager, schema);
+
+    let mut ids = Vec::new();
+    for i in 0..6 {
+        let h = qm
+            .insert(
+                &mut storage,
+                "users",
+                &[Value::Text(format!("User{i}")), Value::Integer(i)],
+            )
+            .unwrap();
+        ids.push(h.row_id);
+    }
+    ids.sort();
+
+    let query = qm
+        .query("users")
+        .order_by_desc("id")
+        .offset(1)
+        .limit(2)
+        .build();
+    let results = execute_query(&mut qm, &mut storage, query).unwrap();
+
+    assert_eq!(results.len(), 2);
+    let result_ids: Vec<_> = results.iter().map(|(id, _)| *id).collect();
+    // reversed: [5,4,3,2,1,0], offset 1 limit 2 → [4,3]
+    assert_eq!(result_ids, &[ids[4], ids[3]]);
+}
+
+#[test]
+fn windowed_scan_desc_insert_shifts_window() {
+    // ORDER BY id DESC, offset=1, limit=2 on 5 rows.
+    // Insert a new row and verify the window updates correctly.
+    let sync_manager = SyncManager::new();
+    let schema = test_schema();
+    let (mut qm, mut storage) = create_query_manager(sync_manager, schema);
+
+    let mut handles = Vec::new();
+    for i in 0..5 {
+        let h = qm
+            .insert(
+                &mut storage,
+                "users",
+                &[Value::Text(format!("User{i}")), Value::Integer(i)],
+            )
+            .unwrap();
+        handles.push(h);
+    }
+    handles.sort_by_key(|h| h.row_id);
+
+    let query = qm
+        .query("users")
+        .order_by_desc("id")
+        .offset(1)
+        .limit(2)
+        .build();
+    let sub_id = qm.subscribe(query).unwrap();
+    qm.process(&mut storage);
+    let _ = qm.take_updates();
+
+    // reversed [4,3,2,1,0], offset 1 limit 2 → [3,2]
+    let initial = qm.get_subscription_results(sub_id);
+    assert_eq!(initial.len(), 2);
+    assert_eq!(initial[0].0, handles[3].row_id);
+    assert_eq!(initial[1].0, handles[2].row_id);
+
+    // Insert a row. Verify window is correct after insert.
+    let new_h = qm
+        .insert(
+            &mut storage,
+            "users",
+            &[Value::Text("NewUser".into()), Value::Integer(99)],
+        )
+        .unwrap();
+    qm.process(&mut storage);
+
+    let mut all_ids: Vec<_> = handles.iter().map(|h| h.row_id).collect();
+    all_ids.push(new_h.row_id);
+    all_ids.sort();
+
+    // reversed all_ids, offset 1, limit 2
+    let mut reversed = all_ids.clone();
+    reversed.reverse();
+
+    let results = qm.get_subscription_results(sub_id);
+    assert_eq!(results.len(), 2);
+    let result_ids: Vec<_> = results.iter().map(|(id, _)| *id).collect();
+    assert_eq!(result_ids, &reversed[1..3]);
+
+    qm.unsubscribe_with_sync(sub_id);
+}
+
+#[test]
+fn windowed_scan_desc_delete_shifts_window() {
+    // ORDER BY id DESC, offset=1, limit=2 on 5 rows.
+    // Delete a row within the window and verify shift.
+    //
+    //   before (desc): [4  3  2  1  0]
+    //                      ^--^         window(1,2) = [3, 2]
+    //   delete 3:
+    //   after (desc):  [4  2  1  0]
+    //                      ^--^         window(1,2) = [2, 1]
+    let sync_manager = SyncManager::new();
+    let schema = test_schema();
+    let (mut qm, mut storage) = create_query_manager(sync_manager, schema);
+
+    let mut handles = Vec::new();
+    for i in 0..5 {
+        let h = qm
+            .insert(
+                &mut storage,
+                "users",
+                &[Value::Text(format!("User{i}")), Value::Integer(i)],
+            )
+            .unwrap();
+        handles.push(h);
+    }
+    handles.sort_by_key(|h| h.row_id);
+
+    let query = qm
+        .query("users")
+        .order_by_desc("id")
+        .offset(1)
+        .limit(2)
+        .build();
+    let sub_id = qm.subscribe(query).unwrap();
+    qm.process(&mut storage);
+    let _ = qm.take_updates();
+
+    let initial = qm.get_subscription_results(sub_id);
+    assert_eq!(initial.len(), 2);
+    assert_eq!(initial[0].0, handles[3].row_id);
+    assert_eq!(initial[1].0, handles[2].row_id);
+
+    // Delete handles[3] (2nd-highest id, first in our window)
+    qm.delete(&mut storage, handles[3].row_id).unwrap();
+    qm.process(&mut storage);
+
+    let results = qm.get_subscription_results(sub_id);
+    assert_eq!(results.len(), 2);
+    // After deletion: reversed remaining [4,2,1,0], offset 1, limit 2 → [2,1]
+    assert_eq!(results[0].0, handles[2].row_id);
+    assert_eq!(results[1].0, handles[1].row_id);
+
+    qm.unsubscribe_with_sync(sub_id);
+}

--- a/crates/jazz-tools/src/storage/mod.rs
+++ b/crates/jazz-tools/src/storage/mod.rs
@@ -263,8 +263,9 @@ pub trait Storage {
     /// Full scan - returns all row IDs in this index.
     fn index_scan_all(&self, table: &str, column: &str, branch: &str) -> Vec<ObjectId>;
 
-    /// Ordered scan with offset/limit — returns row IDs in index key order,
-    /// skipping `offset` entries and returning at most `limit`.
+    /// Ordered scan with offset/limit — returns row IDs in index key order
+    /// (or reverse order when `reverse` is true), skipping `offset` entries
+    /// and returning at most `limit`.
     ///
     /// For the `_id` column the key order matches `ObjectId` byte order, so
     /// callers sorting by id can push pagination down to storage.
@@ -275,12 +276,14 @@ pub trait Storage {
         branch: &str,
         offset: usize,
         limit: usize,
+        reverse: bool,
     ) -> Vec<ObjectId> {
-        self.index_scan_all(table, column, branch)
-            .into_iter()
-            .skip(offset)
-            .take(limit)
-            .collect()
+        let all = self.index_scan_all(table, column, branch);
+        if reverse {
+            all.into_iter().rev().skip(offset).take(limit).collect()
+        } else {
+            all.into_iter().skip(offset).take(limit).collect()
+        }
     }
 
     /// Flush buffered data to persistent storage. No-op for in-memory storage.
@@ -427,8 +430,9 @@ impl<T: Storage + ?Sized> Storage for Box<T> {
         branch: &str,
         offset: usize,
         limit: usize,
+        reverse: bool,
     ) -> Vec<ObjectId> {
-        (**self).index_scan_ordered(table, column, branch, offset, limit)
+        (**self).index_scan_ordered(table, column, branch, offset, limit, reverse)
     }
 
     fn flush(&self) {
@@ -895,17 +899,28 @@ impl Storage for MemoryStorage {
         branch: &str,
         offset: usize,
         limit: usize,
+        reverse: bool,
     ) -> Vec<ObjectId> {
         let key = (table.to_string(), column.to_string(), branch.to_string());
         let Some(index) = self.indices.get(&key) else {
             return Vec::new();
         };
-        index
-            .values()
-            .flat_map(|ids| ids.iter().copied())
-            .skip(offset)
-            .take(limit)
-            .collect()
+        if reverse {
+            index
+                .values()
+                .rev()
+                .flat_map(|ids| ids.iter().copied())
+                .skip(offset)
+                .take(limit)
+                .collect()
+        } else {
+            index
+                .values()
+                .flat_map(|ids| ids.iter().copied())
+                .skip(offset)
+                .take(limit)
+                .collect()
+        }
     }
 }
 

--- a/crates/jazz-tools/src/storage/mod.rs
+++ b/crates/jazz-tools/src/storage/mod.rs
@@ -263,6 +263,26 @@ pub trait Storage {
     /// Full scan - returns all row IDs in this index.
     fn index_scan_all(&self, table: &str, column: &str, branch: &str) -> Vec<ObjectId>;
 
+    /// Ordered scan with offset/limit — returns row IDs in index key order,
+    /// skipping `offset` entries and returning at most `limit`.
+    ///
+    /// For the `_id` column the key order matches `ObjectId` byte order, so
+    /// callers sorting by id can push pagination down to storage.
+    fn index_scan_ordered(
+        &self,
+        table: &str,
+        column: &str,
+        branch: &str,
+        offset: usize,
+        limit: usize,
+    ) -> Vec<ObjectId> {
+        self.index_scan_all(table, column, branch)
+            .into_iter()
+            .skip(offset)
+            .take(limit)
+            .collect()
+    }
+
     /// Flush buffered data to persistent storage. No-op for in-memory storage.
     fn flush(&self) {}
 
@@ -398,6 +418,17 @@ impl<T: Storage + ?Sized> Storage for Box<T> {
 
     fn index_scan_all(&self, table: &str, column: &str, branch: &str) -> Vec<ObjectId> {
         (**self).index_scan_all(table, column, branch)
+    }
+
+    fn index_scan_ordered(
+        &self,
+        table: &str,
+        column: &str,
+        branch: &str,
+        offset: usize,
+        limit: usize,
+    ) -> Vec<ObjectId> {
+        (**self).index_scan_ordered(table, column, branch, offset, limit)
     }
 
     fn flush(&self) {
@@ -855,6 +886,26 @@ impl Storage for MemoryStorage {
             return Vec::new();
         };
         index.values().flat_map(|ids| ids.iter().copied()).collect()
+    }
+
+    fn index_scan_ordered(
+        &self,
+        table: &str,
+        column: &str,
+        branch: &str,
+        offset: usize,
+        limit: usize,
+    ) -> Vec<ObjectId> {
+        let key = (table.to_string(), column.to_string(), branch.to_string());
+        let Some(index) = self.indices.get(&key) else {
+            return Vec::new();
+        };
+        index
+            .values()
+            .flat_map(|ids| ids.iter().copied())
+            .skip(offset)
+            .take(limit)
+            .collect()
     }
 }
 

--- a/crates/jazz-tools/src/storage/opfs_btree.rs
+++ b/crates/jazz-tools/src/storage/opfs_btree.rs
@@ -413,8 +413,9 @@ impl Storage for OpfsBTreeStorage {
         branch: &str,
         offset: usize,
         limit: usize,
+        reverse: bool,
     ) -> Vec<ObjectId> {
-        index_scan_ordered_core(table, column, branch, offset, limit, |prefix| {
+        index_scan_ordered_core(table, column, branch, offset, limit, reverse, |prefix| {
             self.tree_scan_keys(prefix)
         })
     }

--- a/crates/jazz-tools/src/storage/opfs_btree.rs
+++ b/crates/jazz-tools/src/storage/opfs_btree.rs
@@ -37,9 +37,9 @@ use super::{
     storage_core::{
         append_catalogue_manifest_op_core, append_catalogue_manifest_ops_core, append_commit_core,
         create_object_core, delete_commit_core, index_insert_core, index_lookup_core,
-        index_range_core, index_remove_core, index_scan_all_core, load_branch_core,
-        load_catalogue_manifest_core, load_object_metadata_core, set_branch_tails_core,
-        store_ack_tier_core,
+        index_range_core, index_remove_core, index_scan_all_core, index_scan_ordered_core,
+        load_branch_core, load_catalogue_manifest_core, load_object_metadata_core,
+        set_branch_tails_core, store_ack_tier_core,
     },
 };
 
@@ -404,6 +404,19 @@ impl Storage for OpfsBTreeStorage {
 
     fn index_scan_all(&self, table: &str, column: &str, branch: &str) -> Vec<ObjectId> {
         index_scan_all_core(table, column, branch, |prefix| self.tree_scan_keys(prefix))
+    }
+
+    fn index_scan_ordered(
+        &self,
+        table: &str,
+        column: &str,
+        branch: &str,
+        offset: usize,
+        limit: usize,
+    ) -> Vec<ObjectId> {
+        index_scan_ordered_core(table, column, branch, offset, limit, |prefix| {
+            self.tree_scan_keys(prefix)
+        })
     }
 
     fn flush(&self) {

--- a/crates/jazz-tools/src/storage/storage_core.rs
+++ b/crates/jazz-tools/src/storage/storage_core.rs
@@ -299,6 +299,26 @@ pub(super) fn index_scan_all_core(
         .unwrap_or_default()
 }
 
+pub(super) fn index_scan_ordered_core(
+    table: &str,
+    column: &str,
+    branch: &str,
+    offset: usize,
+    limit: usize,
+    mut scan_prefix_keys: impl FnMut(&str) -> Result<Vec<String>, StorageError>,
+) -> Vec<ObjectId> {
+    let prefix = index_prefix(table, column, branch);
+    scan_prefix_keys(&prefix)
+        .map(|keys| {
+            keys.iter()
+                .filter_map(|key| parse_uuid_from_index_key(key))
+                .skip(offset)
+                .take(limit)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
 pub(super) fn index_range_core(
     table: &str,
     column: &str,

--- a/crates/jazz-tools/src/storage/storage_core.rs
+++ b/crates/jazz-tools/src/storage/storage_core.rs
@@ -305,16 +305,26 @@ pub(super) fn index_scan_ordered_core(
     branch: &str,
     offset: usize,
     limit: usize,
+    reverse: bool,
     mut scan_prefix_keys: impl FnMut(&str) -> Result<Vec<String>, StorageError>,
 ) -> Vec<ObjectId> {
     let prefix = index_prefix(table, column, branch);
     scan_prefix_keys(&prefix)
         .map(|keys| {
-            keys.iter()
-                .filter_map(|key| parse_uuid_from_index_key(key))
-                .skip(offset)
-                .take(limit)
-                .collect()
+            if reverse {
+                keys.iter()
+                    .rev()
+                    .filter_map(|key| parse_uuid_from_index_key(key))
+                    .skip(offset)
+                    .take(limit)
+                    .collect()
+            } else {
+                keys.iter()
+                    .filter_map(|key| parse_uuid_from_index_key(key))
+                    .skip(offset)
+                    .take(limit)
+                    .collect()
+            }
         })
         .unwrap_or_default()
 }

--- a/crates/jazz-tools/src/storage/surrealkv.rs
+++ b/crates/jazz-tools/src/storage/surrealkv.rs
@@ -470,11 +470,12 @@ impl Storage for SurrealKvStorage {
         branch: &str,
         offset: usize,
         limit: usize,
+        reverse: bool,
     ) -> Vec<ObjectId> {
         let Ok(txn) = self.begin_read_txn() else {
             return Vec::new();
         };
-        index_scan_ordered_core(table, column, branch, offset, limit, |prefix| {
+        index_scan_ordered_core(table, column, branch, offset, limit, reverse, |prefix| {
             Self::scan_prefix_keys(&txn, prefix)
         })
     }

--- a/crates/jazz-tools/src/storage/surrealkv.rs
+++ b/crates/jazz-tools/src/storage/surrealkv.rs
@@ -37,9 +37,9 @@ use super::{
     storage_core::{
         append_catalogue_manifest_op_core, append_catalogue_manifest_ops_core, append_commit_core,
         create_object_core, delete_commit_core, index_insert_core, index_lookup_core,
-        index_range_core, index_remove_core, index_scan_all_core, load_branch_core,
-        load_catalogue_manifest_core, load_object_metadata_core, set_branch_tails_core,
-        store_ack_tier_core,
+        index_range_core, index_remove_core, index_scan_all_core, index_scan_ordered_core,
+        load_branch_core, load_catalogue_manifest_core, load_object_metadata_core,
+        set_branch_tails_core, store_ack_tier_core,
     },
 };
 
@@ -459,6 +459,22 @@ impl Storage for SurrealKvStorage {
             return Vec::new();
         };
         index_scan_all_core(table, column, branch, |prefix| {
+            Self::scan_prefix_keys(&txn, prefix)
+        })
+    }
+
+    fn index_scan_ordered(
+        &self,
+        table: &str,
+        column: &str,
+        branch: &str,
+        offset: usize,
+        limit: usize,
+    ) -> Vec<ObjectId> {
+        let Ok(txn) = self.begin_read_txn() else {
+            return Vec::new();
+        };
+        index_scan_ordered_core(table, column, branch, offset, limit, |prefix| {
             Self::scan_prefix_keys(&txn, prefix)
         })
     }

--- a/examples/todo-client-localfirst-react/src/TodoList.tsx
+++ b/examples/todo-client-localfirst-react/src/TodoList.tsx
@@ -18,7 +18,12 @@ export function TodoList() {
 
   // #region reading-reactive-hooks-react
   const db = useDb();
-  const todos = useAll(todosQuery.limit(50).offset(page * 50));
+  const todos = useAll(
+    todosQuery
+      .orderBy("id", "desc")
+      .limit(50)
+      .offset(page * 50),
+  );
   // #endregion reading-reactive-hooks-react
   const session = useSession();
   const sessionUserId = session?.user_id ?? null;

--- a/examples/todo-client-localfirst-react/src/TodoList.tsx
+++ b/examples/todo-client-localfirst-react/src/TodoList.tsx
@@ -14,9 +14,11 @@ export function TodoList() {
     todosQuery = todosQuery.where({ done: true });
   }
 
+  const [page, setPage] = useState(0);
+
   // #region reading-reactive-hooks-react
   const db = useDb();
-  const todos = useAll(todosQuery) ?? [];
+  const todos = useAll(todosQuery.limit(50).offset(page * 50));
   // #endregion reading-reactive-hooks-react
   const session = useSession();
   const sessionUserId = session?.user_id ?? null;
@@ -27,6 +29,11 @@ export function TodoList() {
     if (!title.trim() || !sessionUserId) return;
     db.insert(app.todos, { title: title.trim(), done: false, owner_id: sessionUserId });
     setTitle("");
+  };
+
+  const handleFilterChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setFilterTitle(e.target.value);
+    setPage(0);
   };
 
   return (
@@ -47,7 +54,7 @@ export function TodoList() {
         <input
           type="text"
           value={filterTitle}
-          onChange={(e) => setFilterTitle(e.target.value)}
+          onChange={handleFilterChange}
           placeholder="Filter by title (contains)"
           aria-label="Filter by title"
         />
@@ -60,23 +67,29 @@ export function TodoList() {
           Done only
         </label>
       </div>
-      <ul id="todo-list">
-        {todos.map((todo) => (
-          <li key={todo.id} className={todo.done ? "done" : ""}>
-            <input
-              type="checkbox"
-              checked={todo.done}
-              onChange={() => db.update(app.todos, todo.id, { done: !todo.done })}
-              className="toggle"
-            />
-            <span>{todo.title}</span>
-            {todo.description && <small>{todo.description}</small>}
-            <button className="delete-btn" onClick={() => db.deleteFrom(app.todos, todo.id)}>
-              &times;
-            </button>
-          </li>
-        ))}
-      </ul>
+      {todos && (
+        <>
+          <ul id="todo-list">
+            {todos.map((todo) => (
+              <li key={todo.id} className={todo.done ? "done" : ""}>
+                <input
+                  type="checkbox"
+                  checked={todo.done}
+                  onChange={() => db.update(app.todos, todo.id, { done: !todo.done })}
+                  className="toggle"
+                />
+                <span>{todo.title}</span>
+                {todo.description && <small>{todo.description}</small>}
+                <button className="delete-btn" onClick={() => db.deleteFrom(app.todos, todo.id)}>
+                  &times;
+                </button>
+              </li>
+            ))}
+          </ul>
+          Page {page + 1} {page > 0 && <button onClick={() => setPage(page - 1)}>Previous</button>}{" "}
+          {page < 10 && <button onClick={() => setPage(page + 1)}>Next</button>}
+        </>
+      )}
     </>
   );
 }

--- a/packages/jazz-tools/tests/browser/db.subscribeAll.limit-offset.test.ts
+++ b/packages/jazz-tools/tests/browser/db.subscribeAll.limit-offset.test.ts
@@ -231,3 +231,198 @@ describe("db.subscribeAll limit+offset browser integration", () => {
     });
   });
 });
+
+// ============================================================================
+// Windowed index scan: limit+offset sorted by id
+//
+// When ORDER BY id (ASC or DESC) with limit, the query engine pushes
+// pagination down to the storage index scan. These tests exercise that
+// code path (and the non-windowed path for comparison).
+// ============================================================================
+
+describe("db.subscribeAll limit+offset sorted by id (windowed index scan)", () => {
+  const idAscQuery = makeTodosQuery({ orderBy: [["id", "asc"]], offset: 1, limit: 2 });
+
+  it("returns the correct page of rows sorted by id ASC", async () => {
+    await withDb("id-asc-page", async (db) => {
+      const deltas: Array<SubscriptionDelta<Todo>> = [];
+      const unsubscribe = db.subscribeAll(idAscQuery, (delta) => {
+        deltas.push(delta);
+      });
+
+      try {
+        const idA = await db.insert(todos, { title: "A", rank: 1, done: false });
+        const idB = await db.insert(todos, { title: "B", rank: 2, done: false });
+        const idC = await db.insert(todos, { title: "C", rank: 3, done: false });
+        const idD = await db.insert(todos, { title: "D", rank: 4, done: false });
+
+        const sorted = [idA, idB, idC, idD].sort();
+
+        await waitForCondition(
+          () => latestRows(deltas).length === 2,
+          10_000,
+          "expected windowed page with 2 rows",
+        );
+        expect(latestIds(deltas)).toEqual([sorted[1], sorted[2]]);
+      } finally {
+        unsubscribe();
+      }
+    });
+  });
+
+  it("shifts window when deleting a row before the offset", async () => {
+    await withDb("id-asc-delete-before", async (db) => {
+      const deltas: Array<SubscriptionDelta<Todo>> = [];
+      const unsubscribe = db.subscribeAll(idAscQuery, (delta) => {
+        deltas.push(delta);
+      });
+
+      try {
+        const idA = await db.insert(todos, { title: "A", rank: 1, done: false });
+        const idB = await db.insert(todos, { title: "B", rank: 2, done: false });
+        const idC = await db.insert(todos, { title: "C", rank: 3, done: false });
+        const idD = await db.insert(todos, { title: "D", rank: 4, done: false });
+
+        const sorted = [idA, idB, idC, idD].sort();
+
+        await waitForCondition(
+          () => latestRows(deltas).length === 2,
+          10_000,
+          "expected initial windowed page",
+        );
+        expect(latestIds(deltas)).toEqual([sorted[1], sorted[2]]);
+
+        // Delete the first row in id order (before the window)
+        await db.deleteFrom(todos, sorted[0]);
+
+        await waitForCondition(
+          () => {
+            const ids = latestIds(deltas);
+            return ids.length === 2 && ids[0] === sorted[2] && ids[1] === sorted[3];
+          },
+          10_000,
+          "expected window to shift after deleting row before offset",
+        );
+      } finally {
+        unsubscribe();
+      }
+    });
+  });
+
+  it("shifts window when inserting a row that sorts into the window", async () => {
+    await withDb("id-asc-insert", async (db) => {
+      const deltas: Array<SubscriptionDelta<Todo>> = [];
+      const unsubscribe = db.subscribeAll(idAscQuery, (delta) => {
+        deltas.push(delta);
+      });
+
+      try {
+        const idA = await db.insert(todos, { title: "A", rank: 1, done: false });
+        const idB = await db.insert(todos, { title: "B", rank: 2, done: false });
+        const idC = await db.insert(todos, { title: "C", rank: 3, done: false });
+
+        const sorted = [idA, idB, idC].sort();
+
+        await waitForCondition(
+          () => latestRows(deltas).length === 2,
+          10_000,
+          "expected initial windowed page",
+        );
+        expect(latestIds(deltas)).toEqual([sorted[1], sorted[2]]);
+
+        const idD = await db.insert(todos, { title: "D", rank: 4, done: false });
+
+        const newSorted = [idA, idB, idC, idD].sort();
+
+        await waitForCondition(
+          () => {
+            const ids = latestIds(deltas);
+            return ids.length === 2 && ids[0] === newSorted[1] && ids[1] === newSorted[2];
+          },
+          10_000,
+          "expected window to reflect new sort order after insert",
+        );
+      } finally {
+        unsubscribe();
+      }
+    });
+  });
+
+  it("returns the correct page of rows sorted by id DESC", async () => {
+    const idDescQuery = makeTodosQuery({ orderBy: [["id", "desc"]], offset: 1, limit: 2 });
+
+    await withDb("id-desc-page", async (db) => {
+      const deltas: Array<SubscriptionDelta<Todo>> = [];
+      const unsubscribe = db.subscribeAll(idDescQuery, (delta) => {
+        deltas.push(delta);
+      });
+
+      try {
+        const idA = await db.insert(todos, { title: "A", rank: 1, done: false });
+        const idB = await db.insert(todos, { title: "B", rank: 2, done: false });
+        const idC = await db.insert(todos, { title: "C", rank: 3, done: false });
+        const idD = await db.insert(todos, { title: "D", rank: 4, done: false });
+
+        // DESC: reversed id order, offset 1, limit 2 → 2nd and 3rd from the end
+        const reversed = [idA, idB, idC, idD].sort().reverse();
+
+        await waitForCondition(
+          () => latestRows(deltas).length === 2,
+          10_000,
+          "expected windowed page with 2 rows (DESC)",
+        );
+        expect(latestIds(deltas)).toEqual([reversed[1], reversed[2]]);
+      } finally {
+        unsubscribe();
+      }
+    });
+  });
+
+  it("shifts DESC window when deleting a row within the window", async () => {
+    const idDescQuery = makeTodosQuery({ orderBy: [["id", "desc"]], offset: 1, limit: 2 });
+
+    await withDb("id-desc-delete-in-window", async (db) => {
+      const deltas: Array<SubscriptionDelta<Todo>> = [];
+      const unsubscribe = db.subscribeAll(idDescQuery, (delta) => {
+        deltas.push(delta);
+      });
+
+      try {
+        const idA = await db.insert(todos, { title: "A", rank: 1, done: false });
+        const idB = await db.insert(todos, { title: "B", rank: 2, done: false });
+        const idC = await db.insert(todos, { title: "C", rank: 3, done: false });
+        const idD = await db.insert(todos, { title: "D", rank: 4, done: false });
+        const idE = await db.insert(todos, { title: "E", rank: 5, done: false });
+
+        // DESC reversed: [highest..lowest], offset 1, limit 2
+        const reversed = [idA, idB, idC, idD, idE].sort().reverse();
+
+        await waitForCondition(
+          () => latestRows(deltas).length === 2,
+          10_000,
+          "expected initial windowed page (DESC)",
+        );
+        expect(latestIds(deltas)).toEqual([reversed[1], reversed[2]]);
+
+        // Delete the first row in the window
+        await db.deleteFrom(todos, reversed[1]);
+
+        const remaining = [idA, idB, idC, idD, idE]
+          .filter((id) => id !== reversed[1])
+          .sort()
+          .reverse();
+
+        await waitForCondition(
+          () => {
+            const ids = latestIds(deltas);
+            return ids.length === 2 && ids[0] === remaining[1] && ids[1] === remaining[2];
+          },
+          10_000,
+          "expected DESC window to shift after deleting row in window",
+        );
+      } finally {
+        unsubscribe();
+      }
+    });
+  });
+});

--- a/packages/jazz-tools/tests/browser/db.subscribeAll.limit-offset.test.ts
+++ b/packages/jazz-tools/tests/browser/db.subscribeAll.limit-offset.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, it } from "vitest";
+import { createDb, type Db, type QueryBuilder, type TableProxy } from "../../src/runtime/db.js";
+import type { SubscriptionDelta } from "../../src/runtime/subscription-manager.js";
+import type { WasmSchema } from "../../src/drivers/types.js";
+
+interface Todo {
+  id: string;
+  title: string;
+  rank: number;
+  done: boolean;
+}
+
+const schema: WasmSchema = {
+  todos: {
+    columns: [
+      { name: "title", column_type: { type: "Text" }, nullable: false },
+      { name: "rank", column_type: { type: "Integer" }, nullable: false },
+      { name: "done", column_type: { type: "Boolean" }, nullable: false },
+    ],
+  },
+};
+
+const todos: TableProxy<Todo, Omit<Todo, "id">> = {
+  _table: "todos",
+  _schema: schema,
+  _rowType: {} as Todo,
+  _initType: {} as Omit<Todo, "id">,
+};
+
+function makeTodosQuery(body: {
+  orderBy?: Array<[string, "asc" | "desc"]>;
+  limit?: number;
+  offset?: number;
+}): QueryBuilder<Todo> {
+  return {
+    _table: "todos",
+    _schema: schema,
+    _rowType: {} as Todo,
+    _build() {
+      return JSON.stringify({
+        table: "todos",
+        conditions: [],
+        includes: {},
+        orderBy: body.orderBy ?? [],
+        limit: body.limit,
+        offset: body.offset,
+      });
+    },
+  };
+}
+
+const windowQuery = makeTodosQuery({ orderBy: [["rank", "asc"]], offset: 1, limit: 2 });
+
+function uniqueDbName(label: string): string {
+  return `db-subscribe-all-limit-offset-${label}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+async function waitForCondition(
+  check: () => boolean,
+  timeoutMs: number,
+  errorMessage: string,
+): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (check()) return;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error(errorMessage);
+}
+
+async function withDb<T>(label: string, run: (db: Db) => Promise<T>): Promise<T> {
+  const db = await createDb({ appId: uniqueDbName(label), dbName: uniqueDbName(label) });
+  try {
+    return await run(db);
+  } finally {
+    await db.shutdown();
+  }
+}
+
+function latestRows(deltas: Array<SubscriptionDelta<Todo>>): Todo[] {
+  return deltas[deltas.length - 1]?.all ?? [];
+}
+
+function latestIds(deltas: Array<SubscriptionDelta<Todo>>): string[] {
+  return latestRows(deltas).map((row) => row.id);
+}
+
+describe("db.subscribeAll limit+offset browser integration", () => {
+  it("moves a row into the window and pushes one out when deleting before the window", async () => {
+    await withDb("delete-before-window", async (db) => {
+      const deltas: Array<SubscriptionDelta<Todo>> = [];
+      const unsubscribe = db.subscribeAll(windowQuery, (delta) => {
+        deltas.push(delta);
+      });
+
+      try {
+        const idA = await db.insert(todos, { title: "A", rank: 1, done: false });
+        const idB = await db.insert(todos, { title: "B", rank: 2, done: false });
+        const idC = await db.insert(todos, { title: "C", rank: 3, done: false });
+        const idD = await db.insert(todos, { title: "D", rank: 4, done: false });
+
+        await waitForCondition(
+          () => latestRows(deltas).length === 2,
+          10_000,
+          "expected initial window rows",
+        );
+        expect(latestIds(deltas)).toEqual([idB, idC]);
+
+        await db.deleteFrom(todos, idA);
+
+        await waitForCondition(
+          () => {
+            const ids = latestIds(deltas);
+            return ids.length === 2 && ids[0] === idC && ids[1] === idD;
+          },
+          10_000,
+          "expected window to shift after delete before offset",
+        );
+      } finally {
+        unsubscribe();
+      }
+    });
+  });
+
+  it("moves a row out of the window and pulls one in when inserting before the window", async () => {
+    await withDb("insert-before-window", async (db) => {
+      const deltas: Array<SubscriptionDelta<Todo>> = [];
+      const unsubscribe = db.subscribeAll(windowQuery, (delta) => {
+        deltas.push(delta);
+      });
+
+      try {
+        const idA = await db.insert(todos, { title: "A", rank: 1, done: false });
+        const idB = await db.insert(todos, { title: "B", rank: 2, done: false });
+        const idC = await db.insert(todos, { title: "C", rank: 3, done: false });
+
+        await waitForCondition(
+          () => latestRows(deltas).length === 2,
+          10_000,
+          "expected initial window rows",
+        );
+        expect(latestIds(deltas)).toEqual([idB, idC]);
+
+        await db.insert(todos, { title: "X", rank: 0, done: false });
+
+        await waitForCondition(
+          () => {
+            const ids = latestIds(deltas);
+            return ids.length === 2 && ids[0] === idA && ids[1] === idB;
+          },
+          10_000,
+          "expected window to shift after insert before offset",
+        );
+      } finally {
+        unsubscribe();
+      }
+    });
+  });
+
+  it("moves an in-window row out when its sort value moves before the window", async () => {
+    await withDb("update-in-window-to-before-window", async (db) => {
+      const deltas: Array<SubscriptionDelta<Todo>> = [];
+      const unsubscribe = db.subscribeAll(windowQuery, (delta) => {
+        deltas.push(delta);
+      });
+
+      try {
+        const idA = await db.insert(todos, { title: "A", rank: 1, done: false });
+        const idB = await db.insert(todos, { title: "B", rank: 2, done: false });
+        const idC = await db.insert(todos, { title: "C", rank: 3, done: false });
+        const idD = await db.insert(todos, { title: "D", rank: 4, done: false });
+
+        await waitForCondition(
+          () => latestRows(deltas).length === 2,
+          10_000,
+          "expected initial window rows",
+        );
+        expect(latestIds(deltas)).toEqual([idB, idC]);
+
+        await db.update(todos, idB, { rank: 0 });
+
+        await waitForCondition(
+          () => {
+            const ids = latestIds(deltas);
+            return ids.length === 2 && ids[0] === idA && ids[1] === idC;
+          },
+          10_000,
+          "expected in-window row to move out when rank crosses offset boundary",
+        );
+        expect(latestIds(deltas)).toEqual([idA, idC]);
+        expect(latestRows(deltas).some((row) => row.id === idD)).toBe(false);
+      } finally {
+        unsubscribe();
+      }
+    });
+  });
+
+  it("moves an out-of-window row in when its sort value crosses into the window", async () => {
+    await withDb("update-outside-window-to-inside", async (db) => {
+      const deltas: Array<SubscriptionDelta<Todo>> = [];
+      const unsubscribe = db.subscribeAll(windowQuery, (delta) => {
+        deltas.push(delta);
+      });
+
+      try {
+        await db.insert(todos, { title: "A", rank: 1, done: false });
+        const idB = await db.insert(todos, { title: "B", rank: 2, done: false });
+        const idC = await db.insert(todos, { title: "C", rank: 3, done: false });
+        const idD = await db.insert(todos, { title: "D", rank: 4, done: false });
+
+        await waitForCondition(
+          () => latestRows(deltas).length === 2,
+          10_000,
+          "expected initial window rows",
+        );
+        expect(latestIds(deltas)).toEqual([idB, idC]);
+
+        await db.update(todos, idD, { rank: 2 });
+
+        await waitForCondition(
+          () => {
+            const ids = latestIds(deltas);
+            return ids.length === 2 && ids[0] === idB && ids[1] === idD;
+          },
+          10_000,
+          "expected out-of-window row to move into window after rank update",
+        );
+      } finally {
+        unsubscribe();
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a dedicated browser integration suite for db.subscribeAll windowing behavior with orderBy + offset + limit
- cover in/out window transitions for insert/delete/update boundary moves
- include the remaining local workspace changes currently in this branch

## Testing
- pnpm --filter jazz-tools test:browser -- tests/browser/db.subscribeAll.limit-offset.test.ts