### PR TITLE
fix(sql): quote rust-emitted identifiers in frozen schema/lens SQL

### DIFF
--- a/.changeset/edge-server-settled-query.md
+++ b/.changeset/edge-server-settled-query.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Wait for the initial server event stream handshake before returning from `JazzClient::connect`, preventing `EdgeServer` settled queries from racing the connection after server restart.

--- a/.changeset/rust-frozen-sql-quoting.md
+++ b/.changeset/rust-frozen-sql-quoting.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Quote keyword and non-bare identifiers when emitting frozen schema and lens SQL from Rust so round-tripping generated SQL continues to parse.

--- a/crates/jazz-tools/src/client.rs
+++ b/crates/jazz-tools/src/client.rs
@@ -19,7 +19,7 @@ use crate::sync_manager::{
 };
 use bytes::BytesMut;
 use futures::StreamExt;
-use tokio::sync::{RwLock, mpsc};
+use tokio::sync::{RwLock, mpsc, oneshot};
 
 use crate::transport::{AuthConfig, ServerConnection};
 use crate::{AppContext, JazzError, ObjectId, Result, SubscriptionHandle, SubscriptionStream};
@@ -191,12 +191,20 @@ impl JazzClient {
         > = Arc::new(RwLock::new(HashMap::new()));
 
         // Spawn binary stream listener if connected to server
+        let (initial_stream_ready_tx, initial_stream_ready_rx) = if server_connection.is_some() {
+            let (tx, rx) = oneshot::channel();
+            (Some(tx), Some(rx))
+        } else {
+            (None, None)
+        };
+
         let stream_listener_task = if let Some(ref conn) = server_connection {
             let conn_for_stream = conn.clone();
             let client_id_str = client_id.to_string();
             let runtime_for_stream = runtime.clone();
             let stream_headers = conn.build_stream_headers();
             let server_id_for_stream = server_id;
+            let mut initial_stream_ready_tx = initial_stream_ready_tx;
 
             Some(tokio::spawn(async move {
                 let http_client = reqwest::Client::new();
@@ -243,6 +251,14 @@ impl JazzClient {
 
                                             match serde_json::from_slice::<ServerEvent>(json) {
                                                 Ok(event) => {
+                                                    if matches!(
+                                                        event,
+                                                        ServerEvent::Connected { .. }
+                                                    ) && let Some(tx) =
+                                                        initial_stream_ready_tx.take()
+                                                    {
+                                                        let _ = tx.send(());
+                                                    }
                                                     if let Err(e) = handle_server_event(
                                                         event,
                                                         &runtime_for_stream,
@@ -286,6 +302,21 @@ impl JazzClient {
         } else {
             None
         };
+
+        if let Some(initial_stream_ready_rx) = initial_stream_ready_rx {
+            tokio::time::timeout(Duration::from_secs(10), initial_stream_ready_rx)
+                .await
+                .map_err(|_| {
+                    JazzError::Connection(
+                        "timed out waiting for server event stream to connect".to_string(),
+                    )
+                })?
+                .map_err(|_| {
+                    JazzError::Connection(
+                        "server event stream ended before sending Connected".to_string(),
+                    )
+                })?;
+        }
 
         Ok(Self {
             runtime,

--- a/crates/jazz-tools/src/schema_manager/sql.rs
+++ b/crates/jazz-tools/src/schema_manager/sql.rs
@@ -1248,6 +1248,74 @@ pub fn schema_to_sql(schema: &Schema) -> String {
     blocks.join("\n\n")
 }
 
+fn is_bare_identifier(identifier: &str) -> bool {
+    let mut chars = identifier.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+
+    if !(first.is_alphabetic() || first == '_') {
+        return false;
+    }
+
+    chars.all(|c| c.is_alphanumeric() || c == '_')
+}
+
+fn is_reserved_keyword(identifier: &str) -> bool {
+    matches!(
+        identifier.to_ascii_uppercase().as_str(),
+        "CREATE"
+            | "TABLE"
+            | "POLICY"
+            | "ON"
+            | "FOR"
+            | "USING"
+            | "WITH"
+            | "CHECK"
+            | "SESSION"
+            | "INHERITS"
+            | "INHERIT"
+            | "VIA"
+            | "REFERENCING"
+            | "SELECT"
+            | "INSERT"
+            | "UPDATE"
+            | "DELETE"
+            | "AND"
+            | "OR"
+            | "IN"
+            | "CONTAINS"
+            | "IS"
+            | "ALTER"
+            | "ADD"
+            | "DROP"
+            | "COLUMN"
+            | "RENAME"
+            | "TO"
+            | "NOT"
+            | "NULL"
+            | "DEFAULT"
+            | "TRUE"
+            | "FALSE"
+            | "REFERENCES"
+    )
+}
+
+fn quote_identifier(identifier: &str) -> String {
+    if is_bare_identifier(identifier) && !is_reserved_keyword(identifier) {
+        return identifier.to_string();
+    }
+
+    format!("\"{}\"", identifier.replace('"', "\"\""))
+}
+
+fn session_path_to_sql(path: &[String]) -> String {
+    path.iter()
+        .map(|segment| quote_identifier(segment))
+        .collect::<Vec<_>>()
+        .join(".")
+}
+
 fn table_schema_to_sql(table_name: &str, schema: &TableSchema) -> String {
     let mut columns = Vec::new();
 
@@ -1256,7 +1324,11 @@ fn table_schema_to_sql(table_name: &str, schema: &TableSchema) -> String {
         columns.push(format!("    {}", col_sql));
     }
 
-    format!("CREATE TABLE {} (\n{}\n);", table_name, columns.join(",\n"))
+    format!(
+        "CREATE TABLE {} (\n{}\n);",
+        quote_identifier(table_name),
+        columns.join(",\n")
+    )
 }
 
 fn table_policies_to_sql(table_name: &str, policies: &TablePolicies) -> Vec<String> {
@@ -1274,11 +1346,11 @@ fn table_policies_to_sql(table_name: &str, policies: &TablePolicies) -> Vec<Stri
         if clauses.is_empty() {
             continue;
         }
+        let policy_name = quote_identifier(&format!("{}_{}_policy", table_name, name));
         statements.push(format!(
-            "CREATE POLICY {}_{}_policy ON {} FOR {} {};",
-            table_name,
-            name,
-            table_name,
+            "CREATE POLICY {} ON {} FOR {} {};",
+            policy_name,
+            quote_identifier(table_name),
             sql_op,
             clauses.join(" ")
         ));
@@ -1303,23 +1375,31 @@ fn policy_expr_to_sql(expr: &PolicyExpr) -> String {
         PolicyExpr::Cmp { column, op, value } => {
             format!(
                 "{} {} {}",
-                column,
+                quote_identifier(column),
                 cmp_op_to_sql(op),
                 policy_value_to_sql(value)
             )
         }
-        PolicyExpr::IsNull { column } => format!("{} IS NULL", column),
-        PolicyExpr::IsNotNull { column } => format!("{} IS NOT NULL", column),
+        PolicyExpr::IsNull { column } => format!("{} IS NULL", quote_identifier(column)),
+        PolicyExpr::IsNotNull { column } => format!("{} IS NOT NULL", quote_identifier(column)),
         PolicyExpr::Contains { column, value } => {
-            format!("{} CONTAINS {}", column, policy_value_to_sql(value))
+            format!(
+                "{} CONTAINS {}",
+                quote_identifier(column),
+                policy_value_to_sql(value)
+            )
         }
         PolicyExpr::In {
             column,
             session_path,
-        } => format!("{} IN @session.{}", column, session_path.join(".")),
+        } => format!(
+            "{} IN @session.{}",
+            quote_identifier(column),
+            session_path_to_sql(session_path)
+        ),
         PolicyExpr::InList { column, values } => format!(
             "{} IN ({})",
-            column,
+            quote_identifier(column),
             values
                 .iter()
                 .map(policy_value_to_sql)
@@ -1329,7 +1409,7 @@ fn policy_expr_to_sql(expr: &PolicyExpr) -> String {
         PolicyExpr::Exists { table, condition } => {
             format!(
                 "EXISTS (SELECT FROM {} WHERE {})",
-                table,
+                quote_identifier(table),
                 policy_expr_to_sql(condition)
             )
         }
@@ -1342,13 +1422,13 @@ fn policy_expr_to_sql(expr: &PolicyExpr) -> String {
             Some(depth) => format!(
                 "INHERITS {} VIA {} MAX DEPTH {}",
                 operation_to_sql(*operation),
-                via_column,
+                quote_identifier(via_column),
                 depth
             ),
             None => format!(
                 "INHERITS {} VIA {}",
                 operation_to_sql(*operation),
-                via_column
+                quote_identifier(via_column)
             ),
         },
         PolicyExpr::InheritsReferencing {
@@ -1359,16 +1439,16 @@ fn policy_expr_to_sql(expr: &PolicyExpr) -> String {
         } => match max_depth {
             Some(depth) => format!(
                 "INHERITS {} REFERENCING {} VIA {} MAX DEPTH {}",
-                operation.to_string().to_uppercase(),
-                source_table,
-                via_column,
+                operation_to_sql(*operation),
+                quote_identifier(source_table),
+                quote_identifier(via_column),
                 depth
             ),
             None => format!(
                 "INHERITS {} REFERENCING {} VIA {}",
-                operation.to_string().to_uppercase(),
-                source_table,
-                via_column
+                operation_to_sql(*operation),
+                quote_identifier(source_table),
+                quote_identifier(via_column)
             ),
         },
         PolicyExpr::And(exprs) => exprs
@@ -1390,7 +1470,7 @@ fn policy_expr_to_sql(expr: &PolicyExpr) -> String {
 fn policy_value_to_sql(value: &PolicyValue) -> String {
     match value {
         PolicyValue::Literal(value) => value_to_sql(value),
-        PolicyValue::SessionRef(path) => format!("@session.{}", path.join(".")),
+        PolicyValue::SessionRef(path) => format!("@session.{}", session_path_to_sql(path)),
     }
 }
 
@@ -1417,14 +1497,14 @@ fn operation_to_sql(operation: Operation) -> &'static str {
 fn column_descriptor_to_sql(col: &ColumnDescriptor) -> String {
     let type_str = column_type_to_sql(&col.column_type);
     let ref_str = match &col.references {
-        Some(table) => format!(" REFERENCES {}", table.as_str()),
+        Some(table) => format!(" REFERENCES {}", quote_identifier(table.as_str())),
         None => String::new(),
     };
     let nullable_str = if col.nullable { "" } else { " NOT NULL" };
 
     format!(
         "{} {}{}{}",
-        col.name.as_str(),
+        quote_identifier(col.name.as_str()),
         type_str,
         ref_str,
         nullable_str
@@ -1461,11 +1541,18 @@ fn lens_op_to_sql(op: &LensOp) -> String {
             let default_str = value_to_sql(default);
             format!(
                 "ALTER TABLE {} ADD COLUMN {} {} DEFAULT {};",
-                table, column, type_str, default_str
+                quote_identifier(table),
+                quote_identifier(column),
+                type_str,
+                default_str
             )
         }
         LensOp::RemoveColumn { table, column, .. } => {
-            format!("ALTER TABLE {} DROP COLUMN {};", table, column)
+            format!(
+                "ALTER TABLE {} DROP COLUMN {};",
+                quote_identifier(table),
+                quote_identifier(column)
+            )
         }
         LensOp::RenameColumn {
             table,
@@ -1474,12 +1561,14 @@ fn lens_op_to_sql(op: &LensOp) -> String {
         } => {
             format!(
                 "ALTER TABLE {} RENAME COLUMN {} TO {};",
-                table, old_name, new_name
+                quote_identifier(table),
+                quote_identifier(old_name),
+                quote_identifier(new_name)
             )
         }
         LensOp::AddTable { table, schema } => table_schema_to_sql(table, schema),
         LensOp::RemoveTable { table, .. } => {
-            format!("DROP TABLE {};", table)
+            format!("DROP TABLE {};", quote_identifier(table))
         }
     }
 }
@@ -1902,6 +1991,25 @@ mod tests {
     }
 
     #[test]
+    fn schema_to_sql_roundtrip_with_quoted_keyword_identifier() {
+        let sql = r#"CREATE TABLE data_entry_entries (
+    "table" TEXT NOT NULL
+);"#;
+
+        let schema = parse_schema(sql).unwrap();
+        let regenerated = schema_to_sql(&schema);
+        assert!(regenerated.contains("\"table\" TEXT NOT NULL"));
+
+        let reparsed = parse_schema(&regenerated).unwrap();
+        let column = &reparsed
+            .get(&TableName::new("data_entry_entries"))
+            .unwrap()
+            .columns
+            .columns[0];
+        assert_eq!(column.name.as_str(), "table");
+    }
+
+    #[test]
     fn lens_to_sql_add_column() {
         let transform = LensTransform::with_ops(vec![LensOp::AddColumn {
             table: "users".to_string(),
@@ -1912,6 +2020,37 @@ mod tests {
 
         let sql = lens_to_sql(&transform);
         assert!(sql.contains("ALTER TABLE users ADD COLUMN age INTEGER DEFAULT 0;"));
+    }
+
+    #[test]
+    fn lens_to_sql_roundtrip_with_quoted_keyword_identifier() {
+        let transform = LensTransform::with_ops(vec![LensOp::AddColumn {
+            table: "data_entry_entries".to_string(),
+            column: "table".to_string(),
+            column_type: ColumnType::Text,
+            default: Value::Null,
+        }]);
+
+        let sql = lens_to_sql(&transform);
+        assert!(
+            sql.contains("ALTER TABLE data_entry_entries ADD COLUMN \"table\" TEXT DEFAULT NULL;")
+        );
+
+        let reparsed = parse_lens(&sql).unwrap();
+        match &reparsed.ops[0] {
+            LensOp::AddColumn {
+                table,
+                column,
+                column_type,
+                default,
+            } => {
+                assert_eq!(table, "data_entry_entries");
+                assert_eq!(column, "table");
+                assert_eq!(*column_type, ColumnType::Text);
+                assert_eq!(*default, Value::Null);
+            }
+            _ => panic!("Expected AddColumn"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- quote identifiers in Rust schema/lens SQL emission paths when names are reserved keywords or not bare identifiers
- apply identifier quoting consistently across table/column names, references, policies, session paths, and lens operations
- add round-trip regressions for schema and lens SQL with a keyword column name ("table")

## Validation
- cargo test -p jazz-tools schema_to_sql_roundtrip_with_quoted_keyword_identifier -- --nocapture
- cargo test -p jazz-tools lens_to_sql_roundtrip_with_quoted_keyword_identifier -- --nocapture
- cargo test -p jazz-tools schema_manager::sql::tests -- --nocapture