### PR TITLE
feat: make use-all work with concurrent rendering

### DIFF
--- a/docs/content/docs/reading-data.mdx
+++ b/docs/content/docs/reading-data.mdx
@@ -60,6 +60,16 @@ Use framework bindings immediately after subscription concepts:
   </Tab>
 </Tabs>
 
+### React Suspense and Transitions
+
+The docs React example app includes a Suspense-based list that keeps the previous result visible
+while a filter or page change resolves by moving the query behind a `Suspense` boundary and
+reading it with `useAllSuspense(query)`.
+
+<include cwd lang="tsx">
+  ../examples/docs/todo-client-localfirst-react/src/ConcurrentTodoList.tsx#reading-concurrent-rendering-react
+</include>
+
 ## Filters
 
 ### API Reference

--- a/examples/docs/todo-client-localfirst-react/src/ConcurrentTodoList.tsx
+++ b/examples/docs/todo-client-localfirst-react/src/ConcurrentTodoList.tsx
@@ -1,0 +1,136 @@
+import { Suspense, useDeferredValue, useState, useTransition } from "react";
+import { useAllSuspense, useDb } from "jazz-tools/react";
+import { app, type TodoQueryBuilder } from "../schema/app.js";
+
+// #region reading-concurrent-rendering-react
+export function ConcurrentTodoList() {
+  const db = useDb();
+  const [title, setTitle] = useState("");
+  const [filterTitle, setFilterTitle] = useState("");
+  const [showDoneOnly, setShowDoneOnly] = useState(false);
+  const [page, setPage] = useState(0);
+  const [isPending, startTransition] = useTransition();
+  const deferredFilterTitle = useDeferredValue(filterTitle);
+
+  let query = app.todos
+    .orderBy("id", "desc")
+    .limit(25)
+    .offset(page * 25);
+
+  if (deferredFilterTitle.trim()) {
+    query = query.where({ title: { contains: deferredFilterTitle.trim() } });
+  }
+  if (showDoneOnly) {
+    query = query.where({ done: true });
+  }
+
+  const isLoading = isPending || deferredFilterTitle !== filterTitle;
+
+  function updatePage(nextPage: number) {
+    startTransition(() => {
+      setPage(nextPage);
+    });
+  }
+
+  function handleFilterChange(e: React.ChangeEvent<HTMLInputElement>) {
+    setFilterTitle(e.target.value);
+    startTransition(() => {
+      setPage(0);
+    });
+  }
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const trimmedTitle = title.trim();
+
+    if (!trimmedTitle) {
+      return;
+    }
+
+    await db.insert(app.todos, { title: trimmedTitle, done: false });
+    setTitle("");
+  }
+
+  return (
+    <>
+      <form onSubmit={(e) => void handleSubmit(e)}>
+        <input
+          type="text"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="What needs to be done?"
+          required
+        />
+        <button type="submit">Add</button>
+      </form>
+
+      <div>
+        <input
+          type="text"
+          value={filterTitle}
+          onChange={handleFilterChange}
+          placeholder="Filter by title (contains)"
+          aria-label="Filter by title"
+        />
+        <label>
+          <input
+            type="checkbox"
+            checked={showDoneOnly}
+            onChange={(e) => setShowDoneOnly(e.target.checked)}
+          />
+          Done only
+        </label>
+      </div>
+
+      <Suspense fallback={<p>Loading todos...</p>}>
+        <div style={{ opacity: isLoading ? 0.5 : 1, transition: "opacity 0.2s" }}>
+          <ConcurrentTodoResults query={query} page={page} onPageChange={updatePage} />
+        </div>
+      </Suspense>
+    </>
+  );
+}
+// #endregion reading-concurrent-rendering-react
+
+function ConcurrentTodoResults({
+  query,
+  page,
+  onPageChange,
+}: {
+  query: TodoQueryBuilder;
+  page: number;
+  onPageChange: (nextPage: number) => void;
+}) {
+  const db = useDb();
+
+  // #region reading-reactive-hooks-suspense-react
+  const todos = useAllSuspense(query);
+  // #endregion reading-reactive-hooks-suspense-react
+
+  return (
+    <>
+      <ul id="concurrent-todo-list">
+        {todos.map((todo) => (
+          <li key={todo.id} className={todo.done ? "done" : ""}>
+            <input
+              type="checkbox"
+              checked={todo.done}
+              onChange={() => void db.update(app.todos, todo.id, { done: !todo.done })}
+              className="toggle"
+            />
+            <span>{todo.title}</span>
+            <button className="delete-btn" onClick={() => void db.deleteFrom(app.todos, todo.id)}>
+              &times;
+            </button>
+          </li>
+        ))}
+      </ul>
+
+      <div>
+        Page {page + 1}
+        {page > 0 ? <button onClick={() => onPageChange(page - 1)}>Previous</button> : null}
+        <button onClick={() => onPageChange(page + 1)}>Next</button>
+      </div>
+    </>
+  );
+}

--- a/examples/todo-client-localfirst-react/src/TodoList.tsx
+++ b/examples/todo-client-localfirst-react/src/TodoList.tsx
@@ -11,17 +11,17 @@ export function TodoList() {
 
   const deferredFilterTitle = useDeferredValue(filterTitle);
 
-  let todosQuery = app.todos;
+  let todosQuery = app.todos
+    .orderBy("id", "desc")
+    .limit(50)
+    .offset(page * 50);
+
   if (deferredFilterTitle) {
     todosQuery = todosQuery.where({ title: { contains: deferredFilterTitle.trim() } });
   }
   if (showDoneOnly) {
     todosQuery = todosQuery.where({ done: true });
   }
-  const query = todosQuery
-    .orderBy("id", "desc")
-    .limit(50)
-    .offset(page * 50);
 
   const db = useDb();
   const session = useSession();
@@ -80,9 +80,9 @@ export function TodoList() {
           Done only
         </label>
       </div>
-      <Suspense fallback={<p>Loading todos…</p>}>
+      <Suspense fallback={null}>
         <div style={{ opacity: isLoading ? 0.5 : 1, transition: "opacity 0.2s" }}>
-          <TodoResults query={query} page={page} setPage={handlePageChange} />
+          <TodoResults query={todosQuery} page={page} setPage={handlePageChange} />
         </div>
       </Suspense>
     </>

--- a/examples/todo-client-localfirst-react/src/TodoList.tsx
+++ b/examples/todo-client-localfirst-react/src/TodoList.tsx
@@ -1,29 +1,23 @@
-import { Suspense, useDeferredValue, useState, useTransition } from "react";
-import { useDb, useAllSuspense, useSession } from "jazz-tools/react";
-import { app, type TodoQueryBuilder } from "../schema/app.js";
+import { useState } from "react";
+import { useDb, useAll, useSession } from "jazz-tools/react";
+import { app } from "../schema/app.js";
 
 export function TodoList() {
   const [filterTitle, setFilterTitle] = useState("");
   const [showDoneOnly, setShowDoneOnly] = useState(false);
-  const [page, setPage] = useState(0);
-
-  const [isPending, startTransition] = useTransition();
-
-  const deferredFilterTitle = useDeferredValue(filterTitle);
-
-  let todosQuery = app.todos
-    .orderBy("id", "desc")
-    .limit(50)
-    .offset(page * 50);
-
-  if (deferredFilterTitle) {
-    todosQuery = todosQuery.where({ title: { contains: deferredFilterTitle.trim() } });
+  const trimmedFilterTitle = filterTitle.trim();
+  let todosQuery = app.todos;
+  if (trimmedFilterTitle) {
+    todosQuery = todosQuery.where({ title: { contains: trimmedFilterTitle } });
   }
   if (showDoneOnly) {
     todosQuery = todosQuery.where({ done: true });
   }
 
   const db = useDb();
+  // #region reading-reactive-hooks-react
+  const todos = useAll(todosQuery) ?? [];
+  // #endregion reading-reactive-hooks-react
   const session = useSession();
   const sessionUserId = session?.user_id ?? null;
   const [title, setTitle] = useState("");
@@ -31,23 +25,9 @@ export function TodoList() {
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (!title.trim() || !sessionUserId) return;
-
     db.insert(app.todos, { title: title.trim(), done: false, owner_id: sessionUserId });
     setTitle("");
   };
-
-  const handlePageChange = (p: number) => {
-    startTransition(() => {
-      setPage(p);
-    });
-  };
-
-  const handleFilterChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setFilterTitle(e.target.value);
-    setPage(0);
-  };
-
-  const isLoading = isPending || deferredFilterTitle !== filterTitle;
 
   return (
     <>
@@ -67,7 +47,7 @@ export function TodoList() {
         <input
           type="text"
           value={filterTitle}
-          onChange={handleFilterChange}
+          onChange={(e) => setFilterTitle(e.target.value)}
           placeholder="Filter by title (contains)"
           aria-label="Filter by title"
         />
@@ -80,32 +60,6 @@ export function TodoList() {
           Done only
         </label>
       </div>
-      <Suspense fallback={null}>
-        <div style={{ opacity: isLoading ? 0.5 : 1, transition: "opacity 0.2s" }}>
-          <TodoResults query={todosQuery} page={page} setPage={handlePageChange} />
-        </div>
-      </Suspense>
-    </>
-  );
-}
-
-function TodoResults({
-  query,
-  page,
-  setPage,
-}: {
-  query: TodoQueryBuilder;
-  page: number;
-  setPage: (p: number) => void;
-}) {
-  const db = useDb();
-
-  // #region reading-reactive-hooks-react
-  const todos = useAllSuspense(query);
-  // #endregion reading-reactive-hooks-react
-
-  return (
-    <>
       <ul id="todo-list">
         {todos.map((todo) => (
           <li key={todo.id} className={todo.done ? "done" : ""}>
@@ -123,8 +77,6 @@ function TodoResults({
           </li>
         ))}
       </ul>
-      Page {page + 1} {page > 0 && <button onClick={() => setPage(page - 1)}>Previous</button>}{" "}
-      <button onClick={() => setPage(page + 1)}>Next</button>
     </>
   );
 }

--- a/examples/todo-client-localfirst-react/src/TodoList.tsx
+++ b/examples/todo-client-localfirst-react/src/TodoList.tsx
@@ -1,23 +1,29 @@
-import { useState } from "react";
-import { useDb, useAll, useSession } from "jazz-tools/react";
-import { app } from "../schema/app.js";
+import { Suspense, useDeferredValue, useState, useTransition } from "react";
+import { useDb, useAllSuspense, useSession } from "jazz-tools/react";
+import { app, type TodoQueryBuilder } from "../schema/app.js";
 
 export function TodoList() {
   const [filterTitle, setFilterTitle] = useState("");
   const [showDoneOnly, setShowDoneOnly] = useState(false);
-  const trimmedFilterTitle = filterTitle.trim();
+  const [page, setPage] = useState(0);
+
+  const [isPending, startTransition] = useTransition();
+
+  const deferredFilterTitle = useDeferredValue(filterTitle);
+
   let todosQuery = app.todos;
-  if (trimmedFilterTitle) {
-    todosQuery = todosQuery.where({ title: { contains: trimmedFilterTitle } });
+  if (deferredFilterTitle) {
+    todosQuery = todosQuery.where({ title: { contains: deferredFilterTitle.trim() } });
   }
   if (showDoneOnly) {
     todosQuery = todosQuery.where({ done: true });
   }
+  const query = todosQuery
+    .orderBy("id", "desc")
+    .limit(50)
+    .offset(page * 50);
 
-  // #region reading-reactive-hooks-react
   const db = useDb();
-  const todos = useAll(todosQuery) ?? [];
-  // #endregion reading-reactive-hooks-react
   const session = useSession();
   const sessionUserId = session?.user_id ?? null;
   const [title, setTitle] = useState("");
@@ -25,9 +31,23 @@ export function TodoList() {
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (!title.trim() || !sessionUserId) return;
+
     db.insert(app.todos, { title: title.trim(), done: false, owner_id: sessionUserId });
     setTitle("");
   };
+
+  const handlePageChange = (p: number) => {
+    startTransition(() => {
+      setPage(p);
+    });
+  };
+
+  const handleFilterChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setFilterTitle(e.target.value);
+    setPage(0);
+  };
+
+  const isLoading = isPending || deferredFilterTitle !== filterTitle;
 
   return (
     <>
@@ -47,7 +67,7 @@ export function TodoList() {
         <input
           type="text"
           value={filterTitle}
-          onChange={(e) => setFilterTitle(e.target.value)}
+          onChange={handleFilterChange}
           placeholder="Filter by title (contains)"
           aria-label="Filter by title"
         />
@@ -60,6 +80,32 @@ export function TodoList() {
           Done only
         </label>
       </div>
+      <Suspense fallback={<p>Loading todos…</p>}>
+        <div style={{ opacity: isLoading ? 0.5 : 1, transition: "opacity 0.2s" }}>
+          <TodoResults query={query} page={page} setPage={handlePageChange} />
+        </div>
+      </Suspense>
+    </>
+  );
+}
+
+function TodoResults({
+  query,
+  page,
+  setPage,
+}: {
+  query: TodoQueryBuilder;
+  page: number;
+  setPage: (p: number) => void;
+}) {
+  const db = useDb();
+
+  // #region reading-reactive-hooks-react
+  const todos = useAllSuspense(query);
+  // #endregion reading-reactive-hooks-react
+
+  return (
+    <>
       <ul id="todo-list">
         {todos.map((todo) => (
           <li key={todo.id} className={todo.done ? "done" : ""}>
@@ -77,6 +123,8 @@ export function TodoList() {
           </li>
         ))}
       </ul>
+      Page {page + 1} {page > 0 && <button onClick={() => setPage(page - 1)}>Previous</button>}{" "}
+      <button onClick={() => setPage(page + 1)}>Next</button>
     </>
   );
 }

--- a/packages/jazz-tools/src/react-core/use-all.ts
+++ b/packages/jazz-tools/src/react-core/use-all.ts
@@ -1,33 +1,7 @@
 import * as React from "react";
 import { type Usable, use } from "react";
 import type { QueryBuilder } from "../runtime/db.js";
-import type { SubscriptionDelta } from "../runtime/subscription-manager.js";
-import type { TrackedPromise, UseAllState } from "../subscriptions-orchestrator.js";
 import { useJazzClient } from "./provider.js";
-
-type UseAllAction<T extends { id: string }> =
-  | { type: "entry_pending"; promise: TrackedPromise<T[]> }
-  | { type: "entry_fulfilled"; data: T[] }
-  | { type: "entry_delta"; delta: SubscriptionDelta<T> }
-  | { type: "entry_error"; error: unknown };
-
-function reducer<T extends { id: string }>(
-  prev: UseAllState<T>,
-  action: UseAllAction<T>,
-): UseAllState<T> {
-  switch (action.type) {
-    case "entry_pending":
-      return { status: "pending", data: undefined, promise: action.promise, error: null };
-    case "entry_fulfilled":
-      return { status: "fulfilled", data: action.data, error: null };
-    case "entry_delta":
-      return { status: "fulfilled", data: action.delta.all, error: null };
-    case "entry_error":
-      return { status: "rejected", data: undefined, error: action.error };
-    default:
-      return prev;
-  }
-}
 
 function useAllBase<T extends { id: string }>(
   query: QueryBuilder<T>,
@@ -37,26 +11,18 @@ function useAllBase<T extends { id: string }>(
 
   const key = manager.makeQueryKey(query);
   const entry = manager.getCacheEntry<T>(key);
-  const [state, dispatch] = React.useReducer(reducer<T>, entry.state);
+  const dispatch = React.useReducer((_, action) => action, entry.state)[1];
 
   React.useLayoutEffect(() => {
-    if (entry.state.status === "pending") {
-      dispatch({ type: "entry_pending", promise: entry.state.promise });
-    } else if (entry.state.status === "fulfilled") {
-      dispatch({ type: "entry_fulfilled", data: entry.state.data });
-    } else if (entry.state.status === "rejected") {
-      dispatch({ type: "entry_error", error: entry.state.error });
-    }
-
     const unsubscribe = entry.subscribe({
-      onfulfilled: (data: T[]) => {
-        dispatch({ type: "entry_fulfilled", data });
+      onfulfilled: () => {
+        dispatch(entry.state);
       },
-      onDelta: (delta: SubscriptionDelta<T>) => {
-        dispatch({ type: "entry_delta", delta });
+      onDelta: () => {
+        dispatch(entry.state);
       },
-      onError: (error: unknown) => {
-        dispatch({ type: "entry_error", error });
+      onError: () => {
+        dispatch(entry.state);
       },
     });
 
@@ -64,6 +30,8 @@ function useAllBase<T extends { id: string }>(
       unsubscribe();
     };
   }, [entry]);
+
+  const state = entry.state;
 
   if (suspense) {
     if (state.status === "pending") {

--- a/packages/jazz-tools/src/subscriptions-orchestrator.ts
+++ b/packages/jazz-tools/src/subscriptions-orchestrator.ts
@@ -243,6 +243,10 @@ export class SubscriptionsOrchestrator {
           callbacks.onError?.(entry.state.error);
         }
 
+        if (entry.state.status === "fulfilled") {
+          callbacks.onfulfilled?.(entry.state.data);
+        }
+
         return () => {
           if (!entry.listeners.delete(callbacks)) {
             return;

--- a/packages/jazz-tools/tests/browser/useAllSuspense.test.tsx
+++ b/packages/jazz-tools/tests/browser/useAllSuspense.test.tsx
@@ -384,6 +384,12 @@ describe("useAllSuspense browser integration", () => {
       </JazzProvider>,
     );
 
+    await waitForCondition(
+      () => hasTestId("rows"),
+      5000,
+      "expected suspense rows mount for orderBy + limit + offset",
+    );
+
     await client.db.insert(todos, {
       title: "p1",
       done: false,
@@ -496,6 +502,12 @@ describe("useAllSuspense browser integration", () => {
       </JazzProvider>,
     );
 
+    await waitForCondition(
+      () => hasTestId("rows"),
+      5000,
+      "expected suspense rows mount for hop query",
+    );
+
     const orgId = await client.db.insert(orgs, { name: "Hop Org" });
     const teamId = await client.db.insert(teams, {
       name: "Hop Team",
@@ -534,6 +546,12 @@ describe("useAllSuspense browser integration", () => {
       <JazzProvider client={client}>
         <UseAllProbe query={query} pick={(row) => row.name} />
       </JazzProvider>,
+    );
+
+    await waitForCondition(
+      () => hasTestId("rows"),
+      5000,
+      "expected suspense rows mount for gather query",
     );
 
     const rootId = await client.db.insert(teams, {


### PR DESCRIPTION
Fixes use-all to enable concurrent rendering on React

Enables nice patterns on loading with suspense, and [ViewTransition stuff](https://react.dev/reference/react/ViewTransition#animating-enter-exit-with-activity)

https://github.com/user-attachments/assets/482f6fa1-1e96-4f6c-a7ec-e3feeae4a0aa

