### PR TITLE
fix: stabilize useAllSuspense in concurrent rendering

### DIFF
--- a/packages/jazz-tools/src/react-core/use-all.ts
+++ b/packages/jazz-tools/src/react-core/use-all.ts
@@ -1,33 +1,7 @@
 import * as React from "react";
-import { type Usable, use } from "react";
+import { type Usable, use, useSyncExternalStore } from "react";
 import type { QueryBuilder } from "../runtime/db.js";
-import type { SubscriptionDelta } from "../runtime/subscription-manager.js";
-import type { TrackedPromise, UseAllState } from "../subscriptions-orchestrator.js";
 import { useJazzClient } from "./provider.js";
-
-type UseAllAction<T extends { id: string }> =
-  | { type: "entry_pending"; promise: TrackedPromise<T[]> }
-  | { type: "entry_fulfilled"; data: T[] }
-  | { type: "entry_delta"; delta: SubscriptionDelta<T> }
-  | { type: "entry_error"; error: unknown };
-
-function reducer<T extends { id: string }>(
-  prev: UseAllState<T>,
-  action: UseAllAction<T>,
-): UseAllState<T> {
-  switch (action.type) {
-    case "entry_pending":
-      return { status: "pending", data: undefined, promise: action.promise, error: null };
-    case "entry_fulfilled":
-      return { status: "fulfilled", data: action.data, error: null };
-    case "entry_delta":
-      return { status: "fulfilled", data: action.delta.all, error: null };
-    case "entry_error":
-      return { status: "rejected", data: undefined, error: action.error };
-    default:
-      return prev;
-  }
-}
 
 function useAllBase<T extends { id: string }>(
   query: QueryBuilder<T>,
@@ -37,33 +11,26 @@ function useAllBase<T extends { id: string }>(
 
   const key = manager.makeQueryKey(query);
   const entry = manager.getCacheEntry<T>(key);
-  const [state, dispatch] = React.useReducer(reducer<T>, entry.state);
-
-  React.useLayoutEffect(() => {
-    if (entry.state.status === "pending") {
-      dispatch({ type: "entry_pending", promise: entry.state.promise });
-    } else if (entry.state.status === "fulfilled") {
-      dispatch({ type: "entry_fulfilled", data: entry.state.data });
-    } else if (entry.state.status === "rejected") {
-      dispatch({ type: "entry_error", error: entry.state.error });
-    }
-
-    const unsubscribe = entry.subscribe({
-      onfulfilled: (data: T[]) => {
-        dispatch({ type: "entry_fulfilled", data });
-      },
-      onDelta: (delta: SubscriptionDelta<T>) => {
-        dispatch({ type: "entry_delta", delta });
-      },
-      onError: (error: unknown) => {
-        dispatch({ type: "entry_error", error });
-      },
-    });
-
-    return () => {
-      unsubscribe();
-    };
-  }, [entry]);
+  const subscribe = React.useCallback(
+    (onStoreChange: () => void) =>
+      entry.subscribe({
+        onfulfilled: () => {
+          onStoreChange();
+        },
+        onDelta: () => {
+          onStoreChange();
+        },
+        onError: () => {
+          onStoreChange();
+        },
+      }),
+    [entry],
+  );
+  const state = useSyncExternalStore(
+    subscribe,
+    () => entry.state,
+    () => entry.state,
+  );
 
   if (suspense) {
     if (state.status === "pending") {


### PR DESCRIPTION
## Summary
- replace reducer/effect bridge in `useAll` hooks with `useSyncExternalStore`
- read query cache state directly from orchestrator entries for React-consistent external store behavior
- preserve suspense semantics for pending/rejected states

## Why
This removes a race window in suspense rendering where complex query subscriptions (`orderBy`/`limit`/`offset`, hops, gather) could observe stale empty state in browser CI.

## Testing
- CI
