### PR TITLE
fix(jazz-tools): wait for initial server stream handshake

### DIFF
--- a/.changeset/edge-server-settled-query.md
+++ b/.changeset/edge-server-settled-query.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Wait for the initial server event stream handshake before returning from `JazzClient::connect`, preventing `EdgeServer` settled queries from racing the connection after server restart.

--- a/crates/jazz-tools/src/client.rs
+++ b/crates/jazz-tools/src/client.rs
@@ -19,7 +19,7 @@ use crate::sync_manager::{
 };
 use bytes::BytesMut;
 use futures::StreamExt;
-use tokio::sync::{RwLock, mpsc};
+use tokio::sync::{RwLock, mpsc, oneshot};
 
 use crate::transport::{AuthConfig, ServerConnection};
 use crate::{AppContext, JazzError, ObjectId, Result, SubscriptionHandle, SubscriptionStream};
@@ -191,12 +191,20 @@ impl JazzClient {
         > = Arc::new(RwLock::new(HashMap::new()));
 
         // Spawn binary stream listener if connected to server
+        let (initial_stream_ready_tx, initial_stream_ready_rx) = if server_connection.is_some() {
+            let (tx, rx) = oneshot::channel();
+            (Some(tx), Some(rx))
+        } else {
+            (None, None)
+        };
+
         let stream_listener_task = if let Some(ref conn) = server_connection {
             let conn_for_stream = conn.clone();
             let client_id_str = client_id.to_string();
             let runtime_for_stream = runtime.clone();
             let stream_headers = conn.build_stream_headers();
             let server_id_for_stream = server_id;
+            let mut initial_stream_ready_tx = initial_stream_ready_tx;
 
             Some(tokio::spawn(async move {
                 let http_client = reqwest::Client::new();
@@ -243,6 +251,14 @@ impl JazzClient {
 
                                             match serde_json::from_slice::<ServerEvent>(json) {
                                                 Ok(event) => {
+                                                    if matches!(
+                                                        event,
+                                                        ServerEvent::Connected { .. }
+                                                    ) && let Some(tx) =
+                                                        initial_stream_ready_tx.take()
+                                                    {
+                                                        let _ = tx.send(());
+                                                    }
                                                     if let Err(e) = handle_server_event(
                                                         event,
                                                         &runtime_for_stream,
@@ -286,6 +302,21 @@ impl JazzClient {
         } else {
             None
         };
+
+        if let Some(initial_stream_ready_rx) = initial_stream_ready_rx {
+            tokio::time::timeout(Duration::from_secs(10), initial_stream_ready_rx)
+                .await
+                .map_err(|_| {
+                    JazzError::Connection(
+                        "timed out waiting for server event stream to connect".to_string(),
+                    )
+                })?
+                .map_err(|_| {
+                    JazzError::Connection(
+                        "server event stream ended before sending Connected".to_string(),
+                    )
+                })?;
+        }
 
         Ok(Self {
             runtime,


### PR DESCRIPTION
## Summary
- wait for the initial `ServerEvent::Connected` event before returning from `JazzClient::connect`
- fail `connect` if the server event stream never comes up or exits before the handshake
- add a patch changeset for the `jazz-tools` client behavior fix

## Why
The existing `main` branch has a restart/query race in `jazz_tools_sender_side_objectupdated_delay_should_not_return_stale_settled_rows`. `JazzClient::connect` returned before the SSE stream had actually delivered its initial `Connected` frame, so a one-shot `EdgeServer` settled query could subscribe before the stream was ready and miss the initial settled row.

## Testing
- `cargo test -p jazz-cloud-server --test client_multi_integration -- --nocapture`
- `cargo test -p jazz-tools -- --nocapture`
- `cargo fmt --all --check`
