### PR TITLE
Fix cold offset query sync scope

### DIFF
--- a/crates/jazz-tools/src/query_manager/graph.rs
+++ b/crates/jazz-tools/src/query_manager/graph.rs
@@ -100,6 +100,8 @@ pub struct QueryGraph {
     dirty_bitmap: BitVec,
     /// The output node ID.
     pub output_node: NodeId,
+    /// The pagination node, when the query applies limit/offset.
+    pagination_node: Option<NodeId>,
     /// Table this query operates on.
     pub table: TableName,
     /// Index scan nodes for this query (for marking dirty on updates).
@@ -129,6 +131,7 @@ impl QueryGraph {
             nodes: Vec::new(),
             dirty_bitmap: BitVec::new(),
             output_node: NodeId(0),
+            pagination_node: None,
             table,
             index_scan_nodes: Vec::new(),
             array_subquery_tables: Vec::new(),
@@ -235,6 +238,57 @@ impl QueryGraph {
             })
             .unwrap_or_default();
 
+        self.object_ids_with_branches(&output_ids)
+    }
+
+    /// Returns ObjectIds that must be synced for the client to reproduce the
+    /// current query result locally.
+    pub fn sync_scope_object_ids(&self) -> HashSet<(ObjectId, BranchName)> {
+        let sync_ids: AHashSet<ObjectId> = self
+            .pagination_node
+            .and_then(|node_id| self.get_node(node_id))
+            .and_then(|node| {
+                if let GraphNode::LimitOffset(limit_offset) = node {
+                    Some(
+                        limit_offset
+                            .sync_input_tuples()
+                            .iter()
+                            .flat_map(|tuple| tuple.ids())
+                            .collect(),
+                    )
+                } else {
+                    None
+                }
+            })
+            .unwrap_or_else(|| {
+                self.get_node(self.output_node)
+                    .and_then(|node| {
+                        if let GraphNode::Output(output) = node {
+                            Some(
+                                output
+                                    .current_tuples()
+                                    .iter()
+                                    .flat_map(|tuple| tuple.ids())
+                                    .collect(),
+                            )
+                        } else {
+                            None
+                        }
+                    })
+                    .unwrap_or_default()
+            });
+
+        self.object_ids_with_branches(&sync_ids)
+    }
+
+    fn object_ids_with_branches(
+        &self,
+        scoped_ids: &AHashSet<ObjectId>,
+    ) -> HashSet<(ObjectId, BranchName)> {
+        if scoped_ids.is_empty() {
+            return HashSet::new();
+        }
+
         // For each IndexScanNode, find which of its ObjectIds are in the output
         // and pair them with the scan's branch
         let mut result = HashSet::new();
@@ -244,7 +298,7 @@ impl QueryGraph {
                 let branch = BranchName::new(&scan.branch);
                 for tuple in scan.current_tuples() {
                     for id in tuple.ids() {
-                        if output_ids.contains(&id) {
+                        if scoped_ids.contains(&id) {
                             result.insert((id, branch));
                         }
                     }
@@ -595,6 +649,7 @@ impl QueryGraph {
                 LimitOffsetNode::with_tuple_descriptor(limit_tuple_desc, plan.limit, plan.offset);
             let limit_offset_id = graph.add_node(GraphNode::LimitOffset(limit_offset_node));
             graph.add_edge(limit_offset_id, phase2_input);
+            graph.pagination_node = Some(limit_offset_id);
             phase2_input = limit_offset_id;
         }
 
@@ -1274,6 +1329,7 @@ impl QueryGraph {
             );
             let limit_offset_id = graph.add_node(GraphNode::LimitOffset(limit_offset_node));
             graph.add_edge(limit_offset_id, phase2_input);
+            graph.pagination_node = Some(limit_offset_id);
             phase2_input = limit_offset_id;
         }
 

--- a/crates/jazz-tools/src/query_manager/graph_nodes/limit_offset.rs
+++ b/crates/jazz-tools/src/query_manager/graph_nodes/limit_offset.rs
@@ -76,6 +76,19 @@ impl LimitOffsetNode {
     pub fn windowed_tuples(&self) -> &[Tuple] {
         &self.windowed_tuples
     }
+
+    /// Tuples that must be present locally to reproduce this paginated window.
+    ///
+    /// For offset-based pagination, the client must have the ordered prefix up to
+    /// `offset + limit` so it can reapply the same windowing logic locally.
+    /// When no limit is present, that means the full ordered input.
+    pub fn sync_input_tuples(&self) -> &[Tuple] {
+        let end = match self.limit {
+            Some(limit) => self.offset.saturating_add(limit).min(self.all_tuples.len()),
+            None => self.all_tuples.len(),
+        };
+        &self.all_tuples[..end]
+    }
 }
 
 impl RowNode for LimitOffsetNode {

--- a/crates/jazz-tools/src/query_manager/manager_tests.rs
+++ b/crates/jazz-tools/src/query_manager/manager_tests.rs
@@ -7748,6 +7748,66 @@ fn e2e_client_receives_server_data_via_subscription() {
     assert!(!names.contains(&"Bob"), "Should NOT contain Bob");
 }
 
+/// E2E: Client can cold-load a paginated remote query with a non-zero offset.
+#[test]
+fn e2e_client_receives_paginated_server_data_on_cold_offset_subscription() {
+    use crate::sync_manager::{ClientId, ServerId};
+    use uuid::Uuid;
+
+    let schema = test_schema();
+
+    let server_sync = SyncManager::new();
+    let (mut server, mut server_io) = create_query_manager(server_sync, schema.clone());
+
+    for (name, score) in [("A", 1), ("B", 2), ("C", 3), ("D", 4)] {
+        server
+            .insert(
+                &mut server_io,
+                "users",
+                &[Value::Text(name.into()), Value::Integer(score)],
+            )
+            .unwrap();
+    }
+    server.process(&mut server_io);
+
+    let client_sync = SyncManager::new();
+    let (mut client, mut client_io) = create_query_manager(client_sync, schema);
+
+    let server_id = ServerId(Uuid::new_v7(uuid::Timestamp::now(uuid::NoContext)));
+    let client_id = ClientId(Uuid::new_v7(uuid::Timestamp::now(uuid::NoContext)));
+
+    client.sync_manager_mut().add_server(server_id);
+    server.sync_manager_mut().add_client(client_id);
+    let _ = client.sync_manager_mut().take_outbox();
+
+    let query = client
+        .query("users")
+        .order_by("score")
+        .offset(2)
+        .limit(1)
+        .build();
+
+    let sub_id = client.subscribe_with_sync(query, None, None).unwrap();
+
+    pump_messages(
+        &mut client,
+        &mut server,
+        &mut client_io,
+        &mut server_io,
+        client_id,
+        server_id,
+    );
+
+    let results = client.get_subscription_results(sub_id);
+    assert_eq!(
+        results.len(),
+        1,
+        "Cold paginated subscription should materialize the requested page"
+    );
+    assert_eq!(results[0].1[0], Value::Text("C".into()));
+    assert_eq!(results[0].1[1], Value::Integer(3));
+}
+
 /// E2E: Client receives new matching rows as server inserts them.
 #[test]
 fn e2e_client_receives_new_matching_row() {

--- a/crates/jazz-tools/src/query_manager/server_queries.rs
+++ b/crates/jazz-tools/src/query_manager/server_queries.rs
@@ -201,8 +201,9 @@ impl QueryManager {
 
             let _delta = graph.settle(storage_ref, row_loader);
 
-            // Query result-set scope is always synced.
-            let result_scope = graph.contributing_object_ids();
+            // Sync the rows needed for the client to reproduce the current result
+            // locally, including any ordered prefix required by pagination.
+            let result_scope = graph.sync_scope_object_ids();
             // Trusted clients (Peer/Admin) also need policy context rows.
             let scope = if sync_policy_context_rows {
                 Self::scope_with_policy_context_rows_from_object_manager(
@@ -360,7 +361,7 @@ impl QueryManager {
                 }
 
                 // Check if scope changed
-                let result_scope = sub.graph.contributing_object_ids();
+                let result_scope = sub.graph.sync_scope_object_ids();
                 if trusted_clients.contains(client_id) {
                     Self::scope_with_policy_context_rows_from_object_manager(
                         &result_scope,


### PR DESCRIPTION
## Summary
- sync the ordered prefix required to replay paginated queries locally instead of syncing only the current server-side window
- track the pagination node in the query graph so downstream sync scope can include `offset + limit` rows when needed
- add a regression test for a cold remote subscription with a non-zero offset

## Repro
- with a large dataset, a direct cold load at `offset=500` returned no rows
- navigating from page 1 to page 10 in the same session worked because earlier rows had already been cached locally

## Testing
- cargo test -p jazz-tools e2e_client_ -- --nocapture
- cargo test -p jazz-tools offset_limited_subscription_shifts_window_when_deleting_row_before_window -- --nocapture