### PR TITLE
fix(release): remove unsupported napi create-npm-dirs flag

### DIFF
--- a/.github/workflows/publish-jazz-tools-alpha.yml
+++ b/.github/workflows/publish-jazz-tools-alpha.yml
@@ -358,7 +358,7 @@ jobs:
       - name: Stage jazz-napi platform package artifacts
         run: |
           cd crates/jazz-napi
-          pnpm exec napi create-npm-dirs -t .
+          pnpm exec napi create-npm-dirs
           pnpm exec napi artifacts -d artifacts --dist npm
           node -e 'const fs=require("fs");for(const entry of fs.readdirSync("npm",{withFileTypes:true})){if(!entry.isDirectory())continue;const path=`npm/${entry.name}/package.json`;const p=JSON.parse(fs.readFileSync(path,"utf8"));p.name=`@garden-co/${p.name}`;fs.writeFileSync(path,`${JSON.stringify(p,null,2)}\n`);}'
 


### PR DESCRIPTION
## Summary
- remove the unsupported `-t .` flag from `pnpm exec napi create-npm-dirs`
- fix the shared alpha publish workflow used by both preview and real release runs

## Why
The release preview failed in the `Publish npm alpha` job because `@napi-rs/cli` v3 rejects `-t` for `create-npm-dirs`:
- https://github.com/garden-co/jazz2/actions/runs/22742052814/job/65958765228

## Validation
- verified locally that `pnpm exec napi create-npm-dirs --dry-run` succeeds from `crates/jazz-napi`
- `git diff --check`