### PR TITLE
Rewrite query sync scope provenance

### DIFF
--- a/.changeset/clean-hills-wave.md
+++ b/.changeset/clean-hills-wave.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+fix query sync provenance for paginated, nested subquery, and recursive subscriptions

--- a/crates/jazz-tools/src/query_manager/graph.rs
+++ b/crates/jazz-tools/src/query_manager/graph.rs
@@ -6,7 +6,6 @@ use std::ops::Bound;
 use bitvec::prelude::*;
 use smallvec::SmallVec;
 
-use crate::commit::CommitId;
 use crate::object::{BranchName, ObjectId};
 use crate::schema_manager::{SchemaContext, translate_column_for_index};
 
@@ -37,8 +36,8 @@ use super::relation_ir::RelExpr;
 use super::relation_ir_query_plan::{ExecutionQueryPlan, lower_relation_to_execution_plan};
 use super::session::Session;
 use super::types::{
-    ColumnDescriptor, ColumnName, ColumnType, ComposedBranchName, Row, RowDelta, RowDescriptor,
-    Schema, SchemaHash, TableName, Tuple, TupleDelta, TupleDescriptor,
+    ColumnDescriptor, ColumnName, ColumnType, ComposedBranchName, LoadedRow, Row, RowDelta,
+    RowDescriptor, Schema, SchemaHash, TableName, Tuple, TupleDelta, TupleDescriptor,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -100,6 +99,8 @@ pub struct QueryGraph {
     dirty_bitmap: BitVec,
     /// The output node ID.
     pub output_node: NodeId,
+    /// The pagination node, when the query applies limit/offset.
+    pagination_node: Option<NodeId>,
     /// Table this query operates on.
     pub table: TableName,
     /// Index scan nodes for this query (for marking dirty on updates).
@@ -129,6 +130,7 @@ impl QueryGraph {
             nodes: Vec::new(),
             dirty_bitmap: BitVec::new(),
             output_node: NodeId(0),
+            pagination_node: None,
             table,
             index_scan_nodes: Vec::new(),
             array_subquery_tables: Vec::new(),
@@ -217,42 +219,26 @@ impl QueryGraph {
     /// After calling `settle()`, this method returns the (ObjectId, BranchName) pairs
     /// for all rows currently in the query result.
     pub fn contributing_object_ids(&self) -> HashSet<(ObjectId, BranchName)> {
-        // Get all ObjectIds in the final output
-        let output_ids: AHashSet<ObjectId> = self
-            .get_node(self.output_node)
-            .and_then(|node| {
-                if let GraphNode::Output(output) = node {
-                    Some(
-                        output
-                            .current_tuples()
-                            .iter()
-                            .flat_map(|t| t.ids())
-                            .collect(),
-                    )
-                } else {
-                    None
-                }
-            })
-            .unwrap_or_default();
+        self.scope_from_tuples(&self.current_output_tuples())
+    }
 
-        // For each IndexScanNode, find which of its ObjectIds are in the output
-        // and pair them with the scan's branch
-        let mut result = HashSet::new();
-
-        for (node_id, _table, _column) in &self.index_scan_nodes {
-            if let Some(GraphNode::IndexScan(scan)) = self.get_node(*node_id) {
-                let branch = BranchName::new(&scan.branch);
-                for tuple in scan.current_tuples() {
-                    for id in tuple.ids() {
-                        if output_ids.contains(&id) {
-                            result.insert((id, branch));
-                        }
-                    }
-                }
-            }
+    /// Returns ObjectIds that must be synced for the client to reproduce the
+    /// current query result locally.
+    pub fn sync_scope_object_ids(&self) -> HashSet<(ObjectId, BranchName)> {
+        if let Some(node_id) = self.pagination_node
+            && let Some(GraphNode::LimitOffset(limit_offset)) = self.get_node(node_id)
+        {
+            return self.scope_from_tuples(limit_offset.sync_input_tuples());
         }
 
-        result
+        self.contributing_object_ids()
+    }
+
+    fn scope_from_tuples(&self, tuples: &[Tuple]) -> HashSet<(ObjectId, BranchName)> {
+        tuples
+            .iter()
+            .flat_map(|tuple| tuple.provenance().iter().copied())
+            .collect()
     }
 
     /// Compile a query into a graph (without policy filtering).
@@ -595,6 +581,7 @@ impl QueryGraph {
                 LimitOffsetNode::with_tuple_descriptor(limit_tuple_desc, plan.limit, plan.offset);
             let limit_offset_id = graph.add_node(GraphNode::LimitOffset(limit_offset_node));
             graph.add_edge(limit_offset_id, phase2_input);
+            graph.pagination_node = Some(limit_offset_id);
             phase2_input = limit_offset_id;
         }
 
@@ -1276,6 +1263,7 @@ impl QueryGraph {
             );
             let limit_offset_id = graph.add_node(GraphNode::LimitOffset(limit_offset_node));
             graph.add_edge(limit_offset_id, phase2_input);
+            graph.pagination_node = Some(limit_offset_id);
             phase2_input = limit_offset_id;
         }
 
@@ -1545,7 +1533,7 @@ impl QueryGraph {
     /// Uses tuple-based processing internally, converts to RowDelta for output.
     pub fn settle<F>(&mut self, storage: &dyn Storage, mut row_loader: F) -> RowDelta
     where
-        F: FnMut(ObjectId) -> Option<(Vec<u8>, CommitId)>,
+        F: FnMut(ObjectId) -> Option<LoadedRow>,
     {
         let order = self.topo_sort_dirty();
         if !order.is_empty() {
@@ -1965,25 +1953,45 @@ impl QueryGraph {
 
     /// Get current result from output node.
     pub fn current_result(&self) -> Vec<Row> {
+        self.current_output_rows_with_provenance()
+            .into_iter()
+            .map(|(row, _)| row)
+            .collect()
+    }
+
+    /// Get the current output tuples in output order.
+    pub fn current_output_tuples(&self) -> Vec<Tuple> {
         match self.get_node(self.output_node) {
-            Some(GraphNode::Output(node)) => node.current_rows(),
+            Some(GraphNode::Output(node)) => node.ordered_tuples().to_vec(),
             _ => vec![],
         }
+    }
+
+    pub(crate) fn current_output_rows_with_provenance(
+        &self,
+    ) -> Vec<(Row, crate::query_manager::types::TupleProvenance)> {
+        self.current_output_tuples()
+            .into_iter()
+            .filter_map(|tuple| {
+                let row = if tuple.len() == 1 {
+                    tuple.to_single_row()
+                } else {
+                    tuple
+                        .flatten_with_descriptors(
+                            &self.table_descriptors,
+                            &self.combined_descriptor,
+                        )
+                        .and_then(|flattened| flattened.to_single_row())
+                }?;
+                Some((row, tuple.provenance().clone()))
+            })
+            .collect()
     }
 
     /// Returns all current output rows as a RowDelta with everything in `added`.
     /// Used for first delivery after tier-gated settlement.
     pub fn current_result_as_delta(&self) -> RowDelta {
-        let output_tuples: Vec<Tuple> = self
-            .get_node(self.output_node)
-            .and_then(|node| {
-                if let GraphNode::Output(output) = node {
-                    Some(output.ordered_tuples().to_vec())
-                } else {
-                    None
-                }
-            })
-            .unwrap_or_default();
+        let output_tuples = self.current_output_tuples();
 
         if output_tuples.is_empty() {
             return RowDelta::default();

--- a/crates/jazz-tools/src/query_manager/graph_nodes/array_subquery.rs
+++ b/crates/jazz-tools/src/query_manager/graph_nodes/array_subquery.rs
@@ -7,12 +7,11 @@
 
 use ahash::{AHashMap, AHashSet};
 
-use crate::commit::CommitId;
 use crate::object::ObjectId;
 use crate::query_manager::encoding::{decode_row, encode_row};
 use crate::query_manager::types::{
-    ColumnDescriptor, ColumnType, RowDescriptor, Schema, Tuple, TupleDelta, TupleDescriptor,
-    TupleElement, Value,
+    ColumnDescriptor, ColumnType, LoadedRow, RowDescriptor, Schema, Tuple, TupleDelta,
+    TupleDescriptor, TupleElement, TupleProvenance, Value,
 };
 
 use crate::storage::Storage;
@@ -66,10 +65,8 @@ pub struct ArraySubqueryNode {
     /// Source of the correlation value from the outer tuple.
     outer_correlation: Correlate,
 
-    /// Per-outer-row state: outer_id → (correlation_value, array_result).
-    /// We store the array result directly rather than SubgraphInstances
-    /// since we evaluate synchronously during process().
-    instances: AHashMap<ObjectId, (Value, Value)>,
+    /// Per-outer-row state: outer_id → latest outer tuple + evaluated array.
+    instances: AHashMap<ObjectId, ArrayInstanceState>,
 
     /// Current output tuples.
     current_tuples: AHashSet<Tuple>,
@@ -77,6 +74,14 @@ pub struct ArraySubqueryNode {
     dirty: bool,
     /// True if the inner table changed (need to reevaluate all instances).
     inner_dirty: bool,
+}
+
+#[derive(Debug, Clone)]
+struct ArrayInstanceState {
+    outer_tuple: Tuple,
+    correlation_value: Value,
+    array_result: Value,
+    provenance: TupleProvenance,
 }
 
 impl ArraySubqueryNode {
@@ -152,15 +157,25 @@ impl ArraySubqueryNode {
         mut row_loader: F,
     ) -> TupleDelta
     where
-        F: FnMut(ObjectId) -> Option<(Vec<u8>, CommitId)>,
+        F: FnMut(ObjectId) -> Option<LoadedRow>,
     {
         let mut result = TupleDelta::new();
 
         // Process removed tuples
         for tuple in input.removed {
             if let Some(outer_id) = tuple.first_id() {
-                self.instances.remove(&outer_id);
-                if let Some(old_output) = self.build_output_tuple(&tuple, &Value::Array(vec![])) {
+                let state = self.instances.remove(&outer_id);
+                let old_array = state
+                    .as_ref()
+                    .map(|state| state.array_result.clone())
+                    .unwrap_or_else(|| Value::Array(vec![]));
+                let old_provenance = state
+                    .as_ref()
+                    .map(|state| state.provenance.clone())
+                    .unwrap_or_default();
+                if let Some(old_output) =
+                    self.build_output_tuple(&tuple, &old_array, &old_provenance)
+                {
                     self.current_tuples.remove(&old_output);
                     result.removed.push(old_output);
                 }
@@ -173,15 +188,24 @@ impl ArraySubqueryNode {
                 // Get correlation value from outer tuple
                 if let Some(correlation_value) = self.extract_correlation_value(&tuple) {
                     // Evaluate subgraph for this correlation value
-                    let array_result =
+                    let (array_result, provenance) =
                         self.evaluate_subgraph(&correlation_value, io, &mut row_loader);
 
                     // Store instance state
-                    self.instances
-                        .insert(outer_id, (correlation_value, array_result.clone()));
+                    self.instances.insert(
+                        outer_id,
+                        ArrayInstanceState {
+                            outer_tuple: tuple.clone(),
+                            correlation_value,
+                            array_result: array_result.clone(),
+                            provenance: provenance.clone(),
+                        },
+                    );
 
                     // Build output tuple with array column
-                    if let Some(output_tuple) = self.build_output_tuple(&tuple, &array_result) {
+                    if let Some(output_tuple) =
+                        self.build_output_tuple(&tuple, &array_result, &provenance)
+                    {
                         self.current_tuples.insert(output_tuple.clone());
                         result.added.push(output_tuple);
                     }
@@ -191,48 +215,61 @@ impl ArraySubqueryNode {
 
         // Process updated tuples
         for (old_tuple, new_tuple) in input.updated {
-            if let Some(outer_id) = new_tuple.first_id() {
-                let old_correlation = self.extract_correlation_value(&old_tuple);
-                let new_correlation = self.extract_correlation_value(&new_tuple);
+            let old_outer_id = old_tuple.first_id();
+            let new_outer_id = new_tuple.first_id();
+            let old_state = old_outer_id.and_then(|outer_id| self.instances.remove(&outer_id));
 
-                // Check if correlation value changed
-                let needs_reevaluate = old_correlation != new_correlation;
+            let old_array = old_state
+                .as_ref()
+                .map(|state| state.array_result.clone())
+                .unwrap_or_else(|| Value::Array(vec![]));
+            let old_provenance = old_state
+                .as_ref()
+                .map(|state| state.provenance.clone())
+                .unwrap_or_default();
 
-                let array_result = if needs_reevaluate {
-                    if let Some(ref new_corr) = new_correlation {
-                        self.evaluate_subgraph(new_corr, io, &mut row_loader)
-                    } else {
-                        Value::Array(vec![])
-                    }
-                } else {
-                    // Correlation unchanged, keep existing array
-                    self.instances
-                        .get(&outer_id)
-                        .map(|(_, arr)| arr.clone())
-                        .unwrap_or(Value::Array(vec![]))
-                };
+            let old_correlation = old_state
+                .as_ref()
+                .map(|state| state.correlation_value.clone())
+                .or_else(|| self.extract_correlation_value(&old_tuple));
+            let new_correlation = self.extract_correlation_value(&new_tuple);
 
-                // Update instance
-                if let Some(ref new_corr) = new_correlation {
-                    self.instances
-                        .insert(outer_id, (new_corr.clone(), array_result.clone()));
-                }
+            let (new_array, new_provenance) = if old_correlation == new_correlation {
+                (
+                    old_state
+                        .as_ref()
+                        .map(|state| state.array_result.clone())
+                        .unwrap_or_else(|| Value::Array(vec![])),
+                    old_state
+                        .as_ref()
+                        .map(|state| state.provenance.clone())
+                        .unwrap_or_default(),
+                )
+            } else if let Some(ref new_corr) = new_correlation {
+                self.evaluate_subgraph(new_corr, io, &mut row_loader)
+            } else {
+                (Value::Array(vec![]), TupleProvenance::default())
+            };
 
-                // Build old and new output tuples
-                let old_array = self
-                    .instances
-                    .get(&outer_id)
-                    .map(|(_, arr)| arr.clone())
-                    .unwrap_or(Value::Array(vec![]));
+            if let (Some(outer_id), Some(correlation_value)) = (new_outer_id, new_correlation) {
+                self.instances.insert(
+                    outer_id,
+                    ArrayInstanceState {
+                        outer_tuple: new_tuple.clone(),
+                        correlation_value,
+                        array_result: new_array.clone(),
+                        provenance: new_provenance.clone(),
+                    },
+                );
+            }
 
-                if let (Some(old_output), Some(new_output)) = (
-                    self.build_output_tuple(&old_tuple, &old_array),
-                    self.build_output_tuple(&new_tuple, &array_result),
-                ) {
-                    self.current_tuples.remove(&old_output);
-                    self.current_tuples.insert(new_output.clone());
-                    result.updated.push((old_output, new_output));
-                }
+            if let (Some(old_output), Some(new_output)) = (
+                self.build_output_tuple(&old_tuple, &old_array, &old_provenance),
+                self.build_output_tuple(&new_tuple, &new_array, &new_provenance),
+            ) {
+                self.current_tuples.remove(&old_output);
+                self.current_tuples.insert(new_output.clone());
+                result.updated.push((old_output, new_output));
             }
         }
 
@@ -260,21 +297,23 @@ impl ArraySubqueryNode {
         &self,
         correlation_value: &Value,
         io: &dyn Storage,
-        row_loader: &mut dyn FnMut(ObjectId) -> Option<(Vec<u8>, CommitId)>,
-    ) -> Value {
+        row_loader: &mut dyn FnMut(ObjectId) -> Option<LoadedRow>,
+    ) -> (Value, TupleProvenance) {
         // UUID[] FK forward includes correlate an array of ids to scalar inner ids.
         // Evaluate each element independently so output preserves source order/duplicates.
         if let Value::Array(elements) = correlation_value {
             let mut materialized = Vec::new();
+            let mut provenance = TupleProvenance::default();
             for element in elements {
-                let Value::Array(mut nested) =
-                    self.evaluate_subgraph_for_single(element, io, row_loader)
-                else {
+                let (nested_value, nested_provenance) =
+                    self.evaluate_subgraph_for_single(element, io, row_loader);
+                let Value::Array(mut nested) = nested_value else {
                     continue;
                 };
                 materialized.append(&mut nested);
+                provenance.extend(nested_provenance);
             }
-            return Value::Array(materialized);
+            return (Value::Array(materialized), provenance);
         }
 
         self.evaluate_subgraph_for_single(correlation_value, io, row_loader)
@@ -284,34 +323,42 @@ impl ArraySubqueryNode {
         &self,
         correlation_value: &Value,
         io: &dyn Storage,
-        row_loader: &mut dyn FnMut(ObjectId) -> Option<(Vec<u8>, CommitId)>,
-    ) -> Value {
+        row_loader: &mut dyn FnMut(ObjectId) -> Option<LoadedRow>,
+    ) -> (Value, TupleProvenance) {
         let instance = self
             .subgraph_template
             .instantiate(correlation_value.clone(), &self.schema);
         let mut instance = match instance {
             Some(i) => i,
-            None => return Value::Array(vec![]),
+            None => return (Value::Array(vec![]), TupleProvenance::default()),
         };
 
-        let row_delta = instance.graph.settle(io, row_loader);
-        let array_elements: Vec<Value> = row_delta
-            .added
+        let _row_delta = instance.graph.settle(io, row_loader);
+        let mut provenance = TupleProvenance::default();
+        let array_elements: Vec<Value> = instance
+            .graph
+            .current_output_rows_with_provenance()
             .iter()
-            .filter_map(|row| {
+            .filter_map(|(row, row_provenance)| {
                 let output_desc = self.subgraph_template.output_descriptor();
                 let values = decode_row(output_desc, &row.data).ok()?;
+                provenance.extend(row_provenance.iter().copied());
                 Some(Value::Row {
                     id: Some(row.id),
                     values,
                 })
             })
             .collect();
-        Value::Array(array_elements)
+        (Value::Array(array_elements), provenance)
     }
 
     /// Build output tuple from outer tuple + array result.
-    fn build_output_tuple(&self, outer_tuple: &Tuple, array_result: &Value) -> Option<Tuple> {
+    fn build_output_tuple(
+        &self,
+        outer_tuple: &Tuple,
+        array_result: &Value,
+        inner_provenance: &TupleProvenance,
+    ) -> Option<Tuple> {
         let element = outer_tuple.get(0)?;
         let outer_id = element.id();
         let outer_content = element.content()?;
@@ -327,88 +374,65 @@ impl ArraySubqueryNode {
         // Encode output
         let output_content = encode_row(&self.output_descriptor, &values).ok()?;
 
-        Some(Tuple::new(vec![TupleElement::Row {
-            id: outer_id,
-            content: output_content,
-            commit_id,
-        }]))
-    }
+        let mut provenance = outer_tuple.provenance().clone();
+        provenance.extend(inner_provenance.iter().copied());
 
-    /// Update the array column in an existing output tuple.
-    ///
-    /// `build_output_tuple` expects an *outer* tuple encoded with the base
-    /// descriptor.  Tuples stored in `current_tuples` are already encoded with
-    /// `self.output_descriptor` (base + array column).  Decoding those with
-    /// the base descriptor misreads the variable-length offset table and
-    /// corrupts the base column values.  This method decodes with the full
-    /// combined descriptor and replaces only the last (array) column.
-    fn update_output_tuple_array(&self, output_tuple: &Tuple, new_array: &Value) -> Option<Tuple> {
-        let element = output_tuple.get(0)?;
-        let outer_id = element.id();
-        let outer_content = element.content()?;
-        let commit_id = element.commit_id()?;
-
-        let mut values = decode_row(&self.output_descriptor, outer_content).ok()?;
-        let last_idx = values.len().checked_sub(1)?;
-        values[last_idx] = new_array.clone();
-
-        let output_content = encode_row(&self.output_descriptor, &values).ok()?;
-
-        Some(Tuple::new(vec![TupleElement::Row {
-            id: outer_id,
-            content: output_content,
-            commit_id,
-        }]))
+        Some(Tuple::new_with_provenance(
+            vec![TupleElement::Row {
+                id: outer_id,
+                content: output_content,
+                commit_id,
+            }],
+            provenance,
+        ))
     }
 
     /// Re-evaluate all instances when inner data changes.
     /// Returns deltas for any arrays that changed.
     pub fn reevaluate_all<F>(&mut self, io: &dyn Storage, row_loader: &mut F) -> TupleDelta
     where
-        F: FnMut(ObjectId) -> Option<(Vec<u8>, CommitId)>,
+        F: FnMut(ObjectId) -> Option<LoadedRow>,
     {
         let mut result = TupleDelta::new();
 
         // Clear inner_dirty flag
         self.inner_dirty = false;
 
-        // Collect outer IDs and their data to avoid borrow issues
-        let instances_snapshot: Vec<(ObjectId, Value, Value)> = self
+        // Collect state snapshots to avoid borrow issues during re-evaluation.
+        let instances_snapshot: Vec<(ObjectId, ArrayInstanceState)> = self
             .instances
             .iter()
-            .map(|(id, (corr, arr))| (*id, corr.clone(), arr.clone()))
+            .map(|(id, state)| (*id, state.clone()))
             .collect();
 
-        for (outer_id, correlation_value, old_array) in instances_snapshot {
+        for (outer_id, old_state) in instances_snapshot {
             // Re-evaluate subgraph
-            let new_array = self.evaluate_subgraph(&correlation_value, io, row_loader);
+            let (new_array, new_provenance) =
+                self.evaluate_subgraph(&old_state.correlation_value, io, row_loader);
 
-            // Check if array changed
-            if old_array != new_array {
-                // Find the current tuple with this outer_id
-                let old_tuple = self
-                    .current_tuples
-                    .iter()
-                    .find(|t| t.first_id() == Some(outer_id))
-                    .cloned();
+            if (old_state.array_result != new_array || old_state.provenance != new_provenance)
+                && let (Some(old_tuple), Some(new_tuple)) = (
+                    self.build_output_tuple(
+                        &old_state.outer_tuple,
+                        &old_state.array_result,
+                        &old_state.provenance,
+                    ),
+                    self.build_output_tuple(&old_state.outer_tuple, &new_array, &new_provenance),
+                )
+            {
+                result.updated.push((old_tuple.clone(), new_tuple.clone()));
 
-                if let Some(old_tuple) = old_tuple {
-                    // Build new tuple with updated array.  Use
-                    // update_output_tuple_array (not build_output_tuple) because
-                    // old_tuple is already an output tuple encoded with the
-                    // combined descriptor.
-                    if let Some(new_tuple) = self.update_output_tuple_array(&old_tuple, &new_array)
-                    {
-                        // Emit update: (old_tuple, new_tuple)
-                        result.updated.push((old_tuple.clone(), new_tuple.clone()));
-
-                        // Update internal state
-                        self.current_tuples.remove(&old_tuple);
-                        self.current_tuples.insert(new_tuple);
-                        self.instances
-                            .insert(outer_id, (correlation_value, new_array));
-                    }
-                }
+                self.current_tuples.remove(&old_tuple);
+                self.current_tuples.insert(new_tuple);
+                self.instances.insert(
+                    outer_id,
+                    ArrayInstanceState {
+                        outer_tuple: old_state.outer_tuple.clone(),
+                        correlation_value: old_state.correlation_value.clone(),
+                        array_result: new_array,
+                        provenance: new_provenance,
+                    },
+                );
             }
         }
 
@@ -436,7 +460,9 @@ impl RowNode for ArraySubqueryNode {
             if let Some(outer_id) = tuple.first_id() {
                 self.instances.remove(&outer_id);
             }
-            if let Some(output) = self.build_output_tuple(&tuple, &Value::Array(vec![])) {
+            if let Some(output) =
+                self.build_output_tuple(&tuple, &Value::Array(vec![]), &TupleProvenance::default())
+            {
                 self.current_tuples.remove(&output);
                 result.removed.push(output);
             }
@@ -447,10 +473,19 @@ impl RowNode for ArraySubqueryNode {
                 (tuple.first_id(), self.extract_correlation_value(&tuple))
             {
                 // Without context, we can't evaluate - store empty array
-                self.instances
-                    .insert(outer_id, (correlation_value, Value::Array(vec![])));
+                self.instances.insert(
+                    outer_id,
+                    ArrayInstanceState {
+                        outer_tuple: tuple.clone(),
+                        correlation_value,
+                        array_result: Value::Array(vec![]),
+                        provenance: TupleProvenance::default(),
+                    },
+                );
             }
-            if let Some(output) = self.build_output_tuple(&tuple, &Value::Array(vec![])) {
+            if let Some(output) =
+                self.build_output_tuple(&tuple, &Value::Array(vec![]), &TupleProvenance::default())
+            {
                 self.current_tuples.insert(output.clone());
                 result.added.push(output);
             }
@@ -476,6 +511,7 @@ impl RowNode for ArraySubqueryNode {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::commit::CommitId;
     use crate::query_manager::graph_nodes::subgraph::SubgraphBuilder;
     use crate::query_manager::types::TableName;
 

--- a/crates/jazz-tools/src/query_manager/graph_nodes/index_scan.rs
+++ b/crates/jazz-tools/src/query_manager/graph_nodes/index_scan.rs
@@ -1,6 +1,6 @@
 use ahash::AHashSet;
 
-use crate::object::ObjectId;
+use crate::object::{BranchName, ObjectId};
 use crate::query_manager::index::ScanCondition;
 use crate::query_manager::types::{
     ColumnName, RowDescriptor, TableName, Tuple, TupleDelta, TupleDescriptor,
@@ -122,16 +122,23 @@ impl SourceNode for IndexScanNode {
         );
 
         self.last_scanned_ids = new_ids;
+        let branch = BranchName::new(&self.branch);
         self.current_tuples = self
             .last_scanned_ids
             .iter()
-            .map(|&id| Tuple::from_id(id))
+            .map(|&id| Tuple::from_scoped_id(id, branch))
             .collect();
         self.dirty = false;
 
         TupleDelta {
-            added: added.into_iter().map(Tuple::from_id).collect(),
-            removed: removed.into_iter().map(Tuple::from_id).collect(),
+            added: added
+                .into_iter()
+                .map(|id| Tuple::from_scoped_id(id, branch))
+                .collect(),
+            removed: removed
+                .into_iter()
+                .map(|id| Tuple::from_scoped_id(id, branch))
+                .collect(),
             moved: vec![],
             updated: vec![],
         }

--- a/crates/jazz-tools/src/query_manager/graph_nodes/join.rs
+++ b/crates/jazz-tools/src/query_manager/graph_nodes/join.rs
@@ -318,7 +318,9 @@ impl JoinNode {
         let mut elements = Vec::with_capacity(left.len() + right.len());
         elements.extend(left.iter().cloned());
         elements.extend(right.iter().cloned());
-        Tuple::new(elements)
+        let mut combined = Tuple::new(elements).with_provenance(left.provenance().clone());
+        combined.merge_provenance(right.provenance());
+        combined
     }
 
     /// Add a left tuple and compute new output tuples.

--- a/crates/jazz-tools/src/query_manager/graph_nodes/limit_offset.rs
+++ b/crates/jazz-tools/src/query_manager/graph_nodes/limit_offset.rs
@@ -56,9 +56,18 @@ impl LimitOffsetNode {
             Some(limit) => (start + limit).min(self.all_tuples.len()),
             None => self.all_tuples.len(),
         };
+        let sync_scope = self.sync_scope_provenance();
         self.windowed_tuples.clear();
         self.windowed_tuples
-            .extend_from_slice(&self.all_tuples[start..end]);
+            .extend(
+                self.all_tuples[start..end]
+                    .iter()
+                    .cloned()
+                    .map(|mut tuple| {
+                        tuple.merge_provenance(&sync_scope);
+                        tuple
+                    }),
+            );
         self.current_tuples = self.windowed_tuples.iter().cloned().collect();
     }
 
@@ -75,6 +84,26 @@ impl LimitOffsetNode {
     /// Ordered tuples currently visible after applying offset/limit.
     pub fn windowed_tuples(&self) -> &[Tuple] {
         &self.windowed_tuples
+    }
+
+    /// Tuples that must be present locally to reproduce this paginated window.
+    ///
+    /// For offset-based pagination, the client must have the ordered prefix up to
+    /// `offset + limit` so it can reapply the same windowing logic locally.
+    /// When no limit is present, that means the full ordered input.
+    pub fn sync_input_tuples(&self) -> &[Tuple] {
+        let end = match self.limit {
+            Some(limit) => self.offset.saturating_add(limit).min(self.all_tuples.len()),
+            None => self.all_tuples.len(),
+        };
+        &self.all_tuples[..end]
+    }
+
+    fn sync_scope_provenance(&self) -> crate::query_manager::types::TupleProvenance {
+        self.sync_input_tuples()
+            .iter()
+            .flat_map(|tuple| tuple.provenance().iter().copied())
+            .collect()
     }
 }
 

--- a/crates/jazz-tools/src/query_manager/graph_nodes/materialize.rs
+++ b/crates/jazz-tools/src/query_manager/graph_nodes/materialize.rs
@@ -1,10 +1,9 @@
 use ahash::{AHashMap, AHashSet};
 use std::collections::HashSet;
 
-use crate::commit::CommitId;
 use crate::object::ObjectId;
 use crate::query_manager::types::{
-    Row, RowDescriptor, Tuple, TupleDelta, TupleDescriptor, TupleElement,
+    LoadedRow, Row, RowDescriptor, Tuple, TupleDelta, TupleDescriptor, TupleElement,
 };
 
 /// Materializes rows from IDs/tuples.
@@ -36,7 +35,7 @@ pub struct MaterializeNode {
 }
 
 /// Function type for loading row data from storage.
-pub type RowLoader = Box<dyn FnMut(ObjectId) -> Option<(Vec<u8>, CommitId)>>;
+pub type RowLoader = Box<dyn FnMut(ObjectId) -> Option<LoadedRow>>;
 
 impl MaterializeNode {
     /// Create a new materialize node with TupleDescriptor and selective element materialization.
@@ -115,7 +114,7 @@ impl MaterializeNode {
     /// If loader returns None for any element in a tuple, that tuple is silently dropped.
     pub fn materialize_tuples<F>(&mut self, delta: TupleDelta, mut loader: F) -> TupleDelta
     where
-        F: FnMut(ObjectId) -> Option<(Vec<u8>, CommitId)>,
+        F: FnMut(ObjectId) -> Option<LoadedRow>,
     {
         let mut result = TupleDelta::new();
 
@@ -180,9 +179,14 @@ impl MaterializeNode {
     /// Returns None if any element that should be materialized can't be loaded.
     fn materialize_tuple<F>(&mut self, tuple: &Tuple, loader: &mut F) -> Option<Tuple>
     where
-        F: FnMut(ObjectId) -> Option<(Vec<u8>, CommitId)>,
+        F: FnMut(ObjectId) -> Option<LoadedRow>,
     {
         let mut materialized_elements = Vec::with_capacity(tuple.len());
+        let mut materialized_provenance = if tuple.len() == 1 {
+            AHashSet::new()
+        } else {
+            tuple.provenance().clone()
+        };
 
         for (elem_idx, elem) in tuple.iter().enumerate() {
             // Only materialize if this element is in our list
@@ -194,13 +198,18 @@ impl MaterializeNode {
             match elem {
                 TupleElement::Id(id) => {
                     // Try to load the row data
-                    if let Some((data, commit_id)) = loader(*id) {
-                        let row = Row::new(*id, data.clone(), commit_id);
+                    if let Some(loaded) = loader(*id) {
+                        let row = Row::new(*id, loaded.data.clone(), loaded.commit_id);
                         self.rows.insert(*id, row);
+                        if tuple.len() == 1 {
+                            materialized_provenance = loaded.provenance.clone();
+                        } else {
+                            materialized_provenance.extend(loaded.provenance.iter().copied());
+                        }
                         materialized_elements.push(TupleElement::Row {
                             id: *id,
-                            content: data,
-                            commit_id,
+                            content: loaded.data,
+                            commit_id: loaded.commit_id,
                         });
                     } else {
                         // Row unavailable - drop the entire tuple
@@ -220,7 +229,10 @@ impl MaterializeNode {
             }
         }
 
-        Some(Tuple::new(materialized_elements))
+        Some(Tuple::new_with_provenance(
+            materialized_elements,
+            materialized_provenance,
+        ))
     }
 
     /// Check for deleted IDs and return removal deltas (tuple version).
@@ -252,7 +264,7 @@ impl MaterializeNode {
     /// Check for updated IDs and return update deltas (tuple version).
     pub fn check_updated_tuples<F>(&mut self, mut loader: F) -> TupleDelta
     where
-        F: FnMut(ObjectId) -> Option<(Vec<u8>, CommitId)>,
+        F: FnMut(ObjectId) -> Option<LoadedRow>,
     {
         let mut result = TupleDelta::new();
         let ids_to_check: Vec<_> = self.updated_ids.drain().collect();
@@ -285,8 +297,13 @@ impl MaterializeNode {
     /// Re-materialize a tuple, reloading row data for materialized elements.
     fn rematerialize_tuple<F>(&mut self, tuple: &Tuple, loader: &mut F) -> Tuple
     where
-        F: FnMut(ObjectId) -> Option<(Vec<u8>, CommitId)>,
+        F: FnMut(ObjectId) -> Option<LoadedRow>,
     {
+        let mut rematerialized_provenance = if tuple.len() == 1 {
+            AHashSet::new()
+        } else {
+            tuple.provenance().clone()
+        };
         let elements: Vec<TupleElement> = tuple
             .iter()
             .enumerate()
@@ -297,13 +314,18 @@ impl MaterializeNode {
                 }
 
                 let id = elem.id();
-                if let Some((data, commit_id)) = loader(id) {
-                    let row = Row::new(id, data.clone(), commit_id);
+                if let Some(loaded) = loader(id) {
+                    let row = Row::new(id, loaded.data.clone(), loaded.commit_id);
                     self.rows.insert(id, row);
+                    if tuple.len() == 1 {
+                        rematerialized_provenance = loaded.provenance.clone();
+                    } else {
+                        rematerialized_provenance.extend(loaded.provenance.iter().copied());
+                    }
                     TupleElement::Row {
                         id,
-                        content: data,
-                        commit_id,
+                        content: loaded.data,
+                        commit_id: loaded.commit_id,
                     }
                 } else {
                     // Couldn't load - keep as-is
@@ -312,7 +334,7 @@ impl MaterializeNode {
             })
             .collect();
 
-        Tuple::new(elements)
+        Tuple::new_with_provenance(elements, rematerialized_provenance)
     }
 
     /// Get current tuples.
@@ -345,6 +367,7 @@ fn has_content_changed(old: &Tuple, new: &Tuple) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::commit::CommitId;
     use crate::query_manager::types::{ColumnDescriptor, ColumnType};
 
     fn test_descriptor() -> RowDescriptor {
@@ -356,6 +379,10 @@ mod tests {
 
     fn make_commit_id(n: u8) -> CommitId {
         CommitId([n; 32])
+    }
+
+    fn make_loaded_row(data: Vec<u8>, commit_id: CommitId) -> LoadedRow {
+        LoadedRow::new(data, commit_id, Default::default())
     }
 
     fn make_tuple_delta_add(ids: &[ObjectId]) -> TupleDelta {
@@ -395,11 +422,11 @@ mod tests {
 
         let delta = make_tuple_delta_add(&[id1, id2]);
 
-        let loader = |id: ObjectId| -> Option<(Vec<u8>, CommitId)> {
+        let loader = |id: ObjectId| -> Option<LoadedRow> {
             if id == id1 {
-                Some((data1.clone(), commit1))
+                Some(make_loaded_row(data1.clone(), commit1))
             } else if id == id2 {
-                Some((data2.clone(), commit2))
+                Some(make_loaded_row(data2.clone(), commit2))
             } else {
                 None
             }
@@ -423,7 +450,7 @@ mod tests {
         // First add
         let add_delta = make_tuple_delta_add(&[id1]);
         let loader =
-            |_: ObjectId| -> Option<(Vec<u8>, CommitId)> { Some((data1.clone(), commit1)) };
+            |_: ObjectId| -> Option<LoadedRow> { Some(make_loaded_row(data1.clone(), commit1)) };
         let added = node.materialize_tuples(add_delta, loader);
         assert_eq!(added.added.len(), 1);
 
@@ -449,13 +476,14 @@ mod tests {
 
         // Add the row
         let add_delta = make_tuple_delta_add(&[id1]);
-        node.materialize_tuples(add_delta, |_| Some((data1.clone(), commit1)));
+        node.materialize_tuples(add_delta, |_| Some(make_loaded_row(data1.clone(), commit1)));
 
         // Mark for update check
         node.mark_updated(id1);
 
         // Check for update with new data
-        let update_delta = node.check_updated_tuples(|_| Some((data2.clone(), commit2)));
+        let update_delta =
+            node.check_updated_tuples(|_| Some(make_loaded_row(data2.clone(), commit2)));
 
         assert_eq!(update_delta.updated.len(), 1);
     }
@@ -470,13 +498,14 @@ mod tests {
 
         // Add the row
         let add_delta = make_tuple_delta_add(&[id1]);
-        node.materialize_tuples(add_delta, |_| Some((data1.clone(), commit1)));
+        node.materialize_tuples(add_delta, |_| Some(make_loaded_row(data1.clone(), commit1)));
 
         // Mark for update check
         node.mark_updated(id1);
 
         // Check for update with same data - should not emit update
-        let update_delta = node.check_updated_tuples(|_| Some((data1.clone(), commit1)));
+        let update_delta =
+            node.check_updated_tuples(|_| Some(make_loaded_row(data1.clone(), commit1)));
 
         assert!(update_delta.updated.is_empty());
     }
@@ -493,9 +522,9 @@ mod tests {
         let delta = make_tuple_delta_add(&[id1, id2]);
 
         // Loader only returns data for id1, not id2
-        let loader = |id: ObjectId| -> Option<(Vec<u8>, CommitId)> {
+        let loader = |id: ObjectId| -> Option<LoadedRow> {
             if id == id1 {
-                Some((data1.clone(), commit1))
+                Some(make_loaded_row(data1.clone(), commit1))
             } else {
                 None // id2 is unavailable (hard-deleted)
             }
@@ -522,7 +551,7 @@ mod tests {
 
         let delta = make_tuple_delta_add(&[id1]);
         let loader =
-            |_: ObjectId| -> Option<(Vec<u8>, CommitId)> { Some((data1.clone(), commit1)) };
+            |_: ObjectId| -> Option<LoadedRow> { Some(make_loaded_row(data1.clone(), commit1)) };
 
         let result = node.materialize_tuples(delta, loader);
 

--- a/crates/jazz-tools/src/query_manager/graph_nodes/policy_filter.rs
+++ b/crates/jazz-tools/src/query_manager/graph_nodes/policy_filter.rs
@@ -6,7 +6,6 @@
 use ahash::AHashSet;
 use std::collections::HashSet;
 
-use crate::commit::CommitId;
 use crate::object::ObjectId;
 use crate::query_manager::encoding::{column_is_null, decode_column};
 use crate::query_manager::policy::{
@@ -16,7 +15,8 @@ use crate::query_manager::policy::{
 use crate::query_manager::policy_graph::PolicyGraph;
 use crate::query_manager::session::Session;
 use crate::query_manager::types::{
-    ColumnType, Row, RowDescriptor, Schema, TableName, Tuple, TupleDelta, TupleElement, Value,
+    ColumnType, LoadedRow, Row, RowDescriptor, Schema, TableName, Tuple, TupleDelta, TupleElement,
+    Value,
 };
 
 use crate::storage::Storage;
@@ -131,7 +131,7 @@ impl PolicyFilterNode {
         mut row_loader: F,
     ) -> TupleDelta
     where
-        F: FnMut(ObjectId) -> Option<(Vec<u8>, CommitId)>,
+        F: FnMut(ObjectId) -> Option<LoadedRow>,
     {
         let mut result = TupleDelta::default();
 
@@ -211,7 +211,7 @@ impl PolicyFilterNode {
     /// Re-evaluate all current tuples when INHERITS-referenced tables change.
     fn reevaluate_all_with_context<F>(&mut self, io: &dyn Storage, row_loader: &mut F) -> TupleDelta
     where
-        F: FnMut(ObjectId) -> Option<(Vec<u8>, CommitId)>,
+        F: FnMut(ObjectId) -> Option<LoadedRow>,
     {
         let mut result = TupleDelta::default();
         let all_tuples: Vec<_> = self.input_tuples.iter().cloned().collect();
@@ -244,7 +244,7 @@ impl PolicyFilterNode {
         &self,
         row: &Row,
         io: &dyn Storage,
-        row_loader: &mut dyn FnMut(ObjectId) -> Option<(Vec<u8>, CommitId)>,
+        row_loader: &mut dyn FnMut(ObjectId) -> Option<LoadedRow>,
     ) -> bool {
         let mut visited_referencing = HashSet::new();
         self.evaluate_row_access_with_referencing(
@@ -271,7 +271,7 @@ impl PolicyFilterNode {
         table_name: &str,
         local_policy_override: Option<&PolicyExpr>,
         io: &dyn Storage,
-        row_loader: &mut dyn FnMut(ObjectId) -> Option<(Vec<u8>, CommitId)>,
+        row_loader: &mut dyn FnMut(ObjectId) -> Option<LoadedRow>,
         depth: usize,
         visited_referencing: &mut HashSet<(TableName, ObjectId, Operation)>,
     ) -> bool {
@@ -332,7 +332,7 @@ impl PolicyFilterNode {
         row: &Row,
         target_table_name: &str,
         io: &dyn Storage,
-        row_loader: &mut dyn FnMut(ObjectId) -> Option<(Vec<u8>, CommitId)>,
+        row_loader: &mut dyn FnMut(ObjectId) -> Option<LoadedRow>,
         depth: usize,
         visited_referencing: &mut HashSet<(TableName, ObjectId, Operation)>,
     ) -> bool {
@@ -371,16 +371,20 @@ impl PolicyFilterNode {
         };
 
         for source_row_id in candidate_ids {
-            let Some((source_content, source_commit_id)) = row_loader(source_row_id) else {
+            let Some(source_row) = row_loader(source_row_id) else {
                 continue;
             };
 
-            if !referencing_edge_matches_target(source_descriptor, &source_content, col_idx, row.id)
-            {
+            if !referencing_edge_matches_target(
+                source_descriptor,
+                &source_row.data,
+                col_idx,
+                row.id,
+            ) {
                 continue;
             }
 
-            let source_row = Row::new(source_row_id, source_content, source_commit_id);
+            let source_row = Row::new(source_row_id, source_row.data, source_row.commit_id);
             if self.evaluate_row_access_with_referencing(
                 operation,
                 &source_row,
@@ -409,7 +413,7 @@ impl PolicyFilterNode {
         descriptor: &RowDescriptor,
         table_name: &str,
         io: &dyn Storage,
-        row_loader: &mut dyn FnMut(ObjectId) -> Option<(Vec<u8>, CommitId)>,
+        row_loader: &mut dyn FnMut(ObjectId) -> Option<LoadedRow>,
         depth: usize,
         visited: &mut HashSet<ObjectId>,
         visited_referencing: &mut HashSet<(TableName, ObjectId, Operation)>,
@@ -512,7 +516,7 @@ impl PolicyFilterNode {
         descriptor: &RowDescriptor,
         _table_name: &str,
         io: &dyn Storage,
-        row_loader: &mut dyn FnMut(ObjectId) -> Option<(Vec<u8>, CommitId)>,
+        row_loader: &mut dyn FnMut(ObjectId) -> Option<LoadedRow>,
         depth: usize,
         visited: &mut HashSet<ObjectId>,
         visited_referencing: &mut HashSet<(TableName, ObjectId, Operation)>,
@@ -554,7 +558,7 @@ impl PolicyFilterNode {
         }
         visited.insert(parent_id);
 
-        let (parent_content, parent_commit_id) = match row_loader(parent_id) {
+        let parent_row = match row_loader(parent_id) {
             Some(content) => content,
             None => return false,
         };
@@ -580,7 +584,7 @@ impl PolicyFilterNode {
             None => return true,
         };
 
-        let parent_row = Row::new(parent_id, parent_content, parent_commit_id);
+        let parent_row = Row::new(parent_id, parent_row.data, parent_row.commit_id);
         self.evaluate_expr_with_context(
             parent_policy,
             &parent_row,
@@ -603,7 +607,7 @@ impl PolicyFilterNode {
         row: &Row,
         descriptor: &RowDescriptor,
         io: &dyn Storage,
-        row_loader: &mut dyn FnMut(ObjectId) -> Option<(Vec<u8>, CommitId)>,
+        row_loader: &mut dyn FnMut(ObjectId) -> Option<LoadedRow>,
         depth: usize,
     ) -> bool {
         if depth >= crate::query_manager::policy::RECURSIVE_POLICY_MAX_DEPTH_HARD_CAP {
@@ -645,7 +649,7 @@ impl PolicyFilterNode {
         row: &Row,
         descriptor: &RowDescriptor,
         io: &dyn Storage,
-        row_loader: &mut dyn FnMut(ObjectId) -> Option<(Vec<u8>, CommitId)>,
+        row_loader: &mut dyn FnMut(ObjectId) -> Option<LoadedRow>,
         depth: usize,
     ) -> bool {
         if depth >= crate::query_manager::policy::RECURSIVE_POLICY_MAX_DEPTH_HARD_CAP {

--- a/crates/jazz-tools/src/query_manager/graph_nodes/project.rs
+++ b/crates/jazz-tools/src/query_manager/graph_nodes/project.rs
@@ -153,7 +153,7 @@ impl ProjectNode {
             }
         }
 
-        Some(Tuple::new(projected_elements))
+        Some(Tuple::new(projected_elements).with_provenance(tuple.provenance().clone()))
     }
 }
 

--- a/crates/jazz-tools/src/query_manager/graph_nodes/recursive_relation.rs
+++ b/crates/jazz-tools/src/query_manager/graph_nodes/recursive_relation.rs
@@ -12,7 +12,8 @@ use crate::commit::CommitId;
 use crate::object::ObjectId;
 use crate::query_manager::encoding::{decode_row, encode_row};
 use crate::query_manager::types::{
-    Row, RowDescriptor, Schema, TableName, Tuple, TupleDelta, TupleDescriptor, TupleElement, Value,
+    LoadedRow, Row, RowDescriptor, Schema, TableName, Tuple, TupleDelta, TupleDescriptor,
+    TupleElement, TupleProvenance, Value,
 };
 use crate::storage::Storage;
 
@@ -107,7 +108,7 @@ impl RecursiveRelationNode {
         mut row_loader: F,
     ) -> TupleDelta
     where
-        F: FnMut(ObjectId) -> Option<(Vec<u8>, CommitId)>,
+        F: FnMut(ObjectId) -> Option<LoadedRow>,
     {
         self.apply_seed_delta(input);
 
@@ -156,7 +157,7 @@ impl RecursiveRelationNode {
     fn recompute(
         &self,
         io: &dyn Storage,
-        row_loader: &mut dyn FnMut(ObjectId) -> Option<(Vec<u8>, CommitId)>,
+        row_loader: &mut dyn FnMut(ObjectId) -> Option<LoadedRow>,
     ) -> AHashSet<Tuple> {
         if self.hop.is_some() {
             return self.recompute_with_hop(io, row_loader);
@@ -165,14 +166,18 @@ impl RecursiveRelationNode {
             return self.recompute_with_object_id(io, row_loader);
         }
 
-        let mut seen_contents = AHashSet::<Vec<u8>>::new();
-        let mut frontier_contents = Vec::<Vec<u8>>::new();
+        let mut seen_contents = AHashMap::<Vec<u8>, TupleProvenance>::new();
+        let mut frontier_contents = Vec::<(Vec<u8>, TupleProvenance)>::new();
 
         for tuple in self.seed_tuples.values() {
-            if let Some(content) = self.normalize_seed_tuple(tuple)
-                && seen_contents.insert(content.clone())
-            {
-                frontier_contents.push(content);
+            if let Some(content) = self.normalize_seed_tuple(tuple) {
+                let provenance = tuple.provenance().clone();
+                let entry = seen_contents.entry(content.clone()).or_default();
+                let previous_len = entry.len();
+                entry.extend(provenance.iter().copied());
+                if previous_len == 0 || entry.len() > previous_len {
+                    frontier_contents.push((content, entry.clone()));
+                }
             }
         }
 
@@ -181,17 +186,23 @@ impl RecursiveRelationNode {
                 break;
             }
 
-            let mut next_frontier = Vec::<Vec<u8>>::new();
+            let mut next_frontier = Vec::<(Vec<u8>, TupleProvenance)>::new();
 
-            for content in frontier_contents {
+            for (content, frontier_provenance) in frontier_contents {
                 let corr = match self.extract_correlation_from_content(None, &content) {
                     Some(v) => v,
                     None => continue,
                 };
 
-                for step_content in self.evaluate_step(&corr, io, row_loader) {
-                    if seen_contents.insert(step_content.clone()) {
-                        next_frontier.push(step_content);
+                for (step_content, step_provenance) in self.evaluate_step(&corr, io, row_loader) {
+                    let mut combined_provenance = frontier_provenance.clone();
+                    combined_provenance.extend(step_provenance.iter().copied());
+
+                    let entry = seen_contents.entry(step_content.clone()).or_default();
+                    let previous_len = entry.len();
+                    entry.extend(combined_provenance.iter().copied());
+                    if previous_len == 0 || entry.len() > previous_len {
+                        next_frontier.push((step_content, entry.clone()));
                     }
                 }
             }
@@ -201,24 +212,44 @@ impl RecursiveRelationNode {
 
         seen_contents
             .into_iter()
-            .map(tuple_from_normalized_content)
+            .map(|(content, provenance)| tuple_from_normalized_content(content, provenance))
             .collect()
     }
 
     fn recompute_with_object_id(
         &self,
         io: &dyn Storage,
-        row_loader: &mut dyn FnMut(ObjectId) -> Option<(Vec<u8>, CommitId)>,
+        row_loader: &mut dyn FnMut(ObjectId) -> Option<LoadedRow>,
     ) -> AHashSet<Tuple> {
-        let mut seen_rows = AHashMap::<ObjectId, (Vec<u8>, CommitId)>::new();
-        let mut frontier = Vec::<ObjectId>::new();
+        let mut seen_rows = AHashMap::<ObjectId, (Vec<u8>, CommitId, TupleProvenance)>::new();
+        let mut frontier = Vec::<(ObjectId, Vec<u8>, TupleProvenance)>::new();
 
         for tuple in self.seed_tuples.values() {
             if let Some((id, content, commit_id)) = self.normalize_seed_tuple_with_id(tuple) {
-                let is_new = !seen_rows.contains_key(&id);
-                seen_rows.insert(id, (content, commit_id));
-                if is_new {
-                    frontier.push(id);
+                let provenance = tuple.provenance().clone();
+                let enqueue = match seen_rows.get_mut(&id) {
+                    Some((existing_content, existing_commit_id, existing_provenance)) => {
+                        let previous_len = existing_provenance.len();
+                        existing_provenance.extend(provenance.iter().copied());
+                        let changed =
+                            *existing_content != content || *existing_commit_id != commit_id;
+                        if changed {
+                            *existing_content = content.clone();
+                            *existing_commit_id = commit_id;
+                        }
+                        changed || existing_provenance.len() > previous_len
+                    }
+                    None => {
+                        seen_rows.insert(id, (content.clone(), commit_id, provenance.clone()));
+                        true
+                    }
+                };
+                if enqueue {
+                    let frontier_provenance = seen_rows
+                        .get(&id)
+                        .map(|(_, _, provenance)| provenance.clone())
+                        .unwrap_or(provenance);
+                    frontier.push((id, content, frontier_provenance));
                 }
             }
         }
@@ -230,27 +261,51 @@ impl RecursiveRelationNode {
                 break;
             }
 
-            let mut next_frontier = Vec::<ObjectId>::new();
+            let mut next_frontier = Vec::<(ObjectId, Vec<u8>, TupleProvenance)>::new();
 
-            for row_id in frontier {
+            for (row_id, _content, frontier_provenance) in frontier {
                 let corr = Value::Uuid(row_id);
 
-                for step_row in self.evaluate_step_rows(&corr, io, row_loader) {
+                for (step_row, step_provenance) in self.evaluate_step_rows(&corr, io, row_loader) {
                     let Some((next_id, next_content, next_commit_id)) =
                         self.normalize_step_row(&step_desc, &step_row)
                     else {
                         continue;
                     };
 
-                    match seen_rows.get(&next_id) {
-                        Some((existing_content, _)) if *existing_content == next_content => {}
-                        Some(_) => {
-                            seen_rows.insert(next_id, (next_content, next_commit_id));
+                    let mut combined_provenance = frontier_provenance.clone();
+                    combined_provenance.extend(step_provenance.iter().copied());
+
+                    let enqueue = match seen_rows.get_mut(&next_id) {
+                        Some((existing_content, existing_commit_id, existing_provenance)) => {
+                            let previous_len = existing_provenance.len();
+                            existing_provenance.extend(combined_provenance.iter().copied());
+                            let changed = *existing_content != next_content
+                                || *existing_commit_id != next_commit_id;
+                            if changed {
+                                *existing_content = next_content.clone();
+                                *existing_commit_id = next_commit_id;
+                            }
+                            changed || existing_provenance.len() > previous_len
                         }
                         None => {
-                            seen_rows.insert(next_id, (next_content, next_commit_id));
-                            next_frontier.push(next_id);
+                            seen_rows.insert(
+                                next_id,
+                                (
+                                    next_content.clone(),
+                                    next_commit_id,
+                                    combined_provenance.clone(),
+                                ),
+                            );
+                            true
                         }
+                    };
+                    if enqueue {
+                        let frontier_provenance = seen_rows
+                            .get(&next_id)
+                            .map(|(_, _, provenance)| provenance.clone())
+                            .unwrap_or(combined_provenance);
+                        next_frontier.push((next_id, next_content, frontier_provenance));
                     }
                 }
             }
@@ -260,12 +315,15 @@ impl RecursiveRelationNode {
 
         seen_rows
             .into_iter()
-            .map(|(id, (content, commit_id))| {
-                Tuple::new(vec![TupleElement::Row {
-                    id,
-                    content,
-                    commit_id,
-                }])
+            .map(|(id, (content, commit_id, provenance))| {
+                Tuple::new_with_provenance(
+                    vec![TupleElement::Row {
+                        id,
+                        content,
+                        commit_id,
+                    }],
+                    provenance,
+                )
             })
             .collect()
     }
@@ -273,21 +331,42 @@ impl RecursiveRelationNode {
     fn recompute_with_hop(
         &self,
         io: &dyn Storage,
-        row_loader: &mut dyn FnMut(ObjectId) -> Option<(Vec<u8>, CommitId)>,
+        row_loader: &mut dyn FnMut(ObjectId) -> Option<LoadedRow>,
     ) -> AHashSet<Tuple> {
         let Some(hop) = &self.hop else {
             return AHashSet::new();
         };
 
-        let mut seen_rows = AHashMap::<ObjectId, (Vec<u8>, CommitId)>::new();
-        let mut frontier = Vec::<(ObjectId, Vec<u8>)>::new();
+        let mut seen_rows = AHashMap::<ObjectId, (Vec<u8>, CommitId, TupleProvenance)>::new();
+        let mut frontier = Vec::<(ObjectId, Vec<u8>, TupleProvenance)>::new();
 
         for tuple in self.seed_tuples.values() {
-            if let Some((id, content, commit_id)) = self.normalize_seed_tuple_with_id(tuple)
-                && !seen_rows.contains_key(&id)
-            {
-                seen_rows.insert(id, (content.clone(), commit_id));
-                frontier.push((id, content));
+            if let Some((id, content, commit_id)) = self.normalize_seed_tuple_with_id(tuple) {
+                let provenance = tuple.provenance().clone();
+                let enqueue = match seen_rows.get_mut(&id) {
+                    Some((existing_content, existing_commit_id, existing_provenance)) => {
+                        let previous_len = existing_provenance.len();
+                        existing_provenance.extend(provenance.iter().copied());
+                        let changed =
+                            *existing_content != content || *existing_commit_id != commit_id;
+                        if changed {
+                            *existing_content = content.clone();
+                            *existing_commit_id = commit_id;
+                        }
+                        changed || existing_provenance.len() > previous_len
+                    }
+                    None => {
+                        seen_rows.insert(id, (content.clone(), commit_id, provenance.clone()));
+                        true
+                    }
+                };
+                if enqueue {
+                    let frontier_provenance = seen_rows
+                        .get(&id)
+                        .map(|(_, _, provenance)| provenance.clone())
+                        .unwrap_or(provenance);
+                    frontier.push((id, content, frontier_provenance));
+                }
             }
         }
 
@@ -296,15 +375,15 @@ impl RecursiveRelationNode {
                 break;
             }
 
-            let mut next_frontier = Vec::<(ObjectId, Vec<u8>)>::new();
+            let mut next_frontier = Vec::<(ObjectId, Vec<u8>, TupleProvenance)>::new();
 
-            for (row_id, content) in frontier {
+            for (row_id, content, frontier_provenance) in frontier {
                 let corr = match self.extract_correlation_from_content(Some(row_id), &content) {
                     Some(v) => v,
                     None => continue,
                 };
 
-                for step_row in self.evaluate_step_rows(&corr, io, row_loader) {
+                for (step_row, step_provenance) in self.evaluate_step_rows(&corr, io, row_loader) {
                     let step_values =
                         match decode_row(self.step_template.output_descriptor(), &step_row.data) {
                             Ok(values) => values,
@@ -314,17 +393,47 @@ impl RecursiveRelationNode {
                     else {
                         continue;
                     };
-                    if seen_rows.contains_key(target_id) {
-                        continue;
-                    }
-                    let Some((target_content, target_commit_id)) = row_loader(*target_id) else {
+                    let Some(target_row) = row_loader(*target_id) else {
                         continue;
                     };
-                    if decode_row(&self.output_descriptor, &target_content).is_err() {
+                    if decode_row(&self.output_descriptor, &target_row.data).is_err() {
                         continue;
                     }
-                    seen_rows.insert(*target_id, (target_content.clone(), target_commit_id));
-                    next_frontier.push((*target_id, target_content));
+                    let mut combined_provenance = frontier_provenance.clone();
+                    combined_provenance.extend(step_provenance.iter().copied());
+                    combined_provenance.extend(target_row.provenance.iter().copied());
+
+                    let enqueue = match seen_rows.get_mut(target_id) {
+                        Some((existing_content, existing_commit_id, existing_provenance)) => {
+                            let previous_len = existing_provenance.len();
+                            existing_provenance.extend(combined_provenance.iter().copied());
+                            let changed = *existing_content != target_row.data
+                                || *existing_commit_id != target_row.commit_id;
+                            if changed {
+                                *existing_content = target_row.data.clone();
+                                *existing_commit_id = target_row.commit_id;
+                            }
+                            changed || existing_provenance.len() > previous_len
+                        }
+                        None => {
+                            seen_rows.insert(
+                                *target_id,
+                                (
+                                    target_row.data.clone(),
+                                    target_row.commit_id,
+                                    combined_provenance.clone(),
+                                ),
+                            );
+                            true
+                        }
+                    };
+                    if enqueue {
+                        let frontier_provenance = seen_rows
+                            .get(target_id)
+                            .map(|(_, _, provenance)| provenance.clone())
+                            .unwrap_or(combined_provenance);
+                        next_frontier.push((*target_id, target_row.data, frontier_provenance));
+                    }
                 }
             }
 
@@ -333,12 +442,15 @@ impl RecursiveRelationNode {
 
         seen_rows
             .into_iter()
-            .map(|(id, (content, commit_id))| {
-                Tuple::new(vec![TupleElement::Row {
-                    id,
-                    content,
-                    commit_id,
-                }])
+            .map(|(id, (content, commit_id, provenance))| {
+                Tuple::new_with_provenance(
+                    vec![TupleElement::Row {
+                        id,
+                        content,
+                        commit_id,
+                    }],
+                    provenance,
+                )
             })
             .collect()
     }
@@ -380,19 +492,20 @@ impl RecursiveRelationNode {
         &self,
         correlation_value: &Value,
         io: &dyn Storage,
-        row_loader: &mut dyn FnMut(ObjectId) -> Option<(Vec<u8>, CommitId)>,
-    ) -> Vec<Vec<u8>> {
+        row_loader: &mut dyn FnMut(ObjectId) -> Option<LoadedRow>,
+    ) -> Vec<(Vec<u8>, TupleProvenance)> {
         let step_desc = self.step_template.output_descriptor().clone();
-        let step_delta = self.evaluate_step_rows(correlation_value, io, row_loader);
-
-        step_delta
+        self.evaluate_step_rows(correlation_value, io, row_loader)
             .into_iter()
-            .filter_map(|row| {
+            .filter_map(|(row, provenance)| {
                 let values = decode_row(&step_desc, &row.data).ok()?;
                 if values.len() != self.output_descriptor.columns.len() {
                     return None;
                 }
-                encode_row(&self.output_descriptor, &values).ok()
+                Some((
+                    encode_row(&self.output_descriptor, &values).ok()?,
+                    provenance,
+                ))
             })
             .collect()
     }
@@ -401,8 +514,8 @@ impl RecursiveRelationNode {
         &self,
         correlation_value: &Value,
         io: &dyn Storage,
-        row_loader: &mut dyn FnMut(ObjectId) -> Option<(Vec<u8>, CommitId)>,
-    ) -> Vec<crate::query_manager::types::Row> {
+        row_loader: &mut dyn FnMut(ObjectId) -> Option<LoadedRow>,
+    ) -> Vec<(crate::query_manager::types::Row, TupleProvenance)> {
         let mut instance = match self
             .step_template
             .instantiate(correlation_value.clone(), &self.schema)
@@ -410,14 +523,15 @@ impl RecursiveRelationNode {
             Some(instance) => instance,
             None => return Vec::new(),
         };
-        instance.graph.settle(io, row_loader).added
+        let _delta = instance.graph.settle(io, row_loader);
+        instance.graph.current_output_rows_with_provenance()
     }
 
     fn normalize_step_row(
         &self,
         step_descriptor: &RowDescriptor,
         step_row: &Row,
-    ) -> Option<(ObjectId, Vec<u8>, CommitId)> {
+    ) -> Option<(ObjectId, Vec<u8>, crate::commit::CommitId)> {
         let values = decode_row(step_descriptor, &step_row.data).ok()?;
         if values.len() != self.output_descriptor.columns.len() {
             return None;
@@ -452,16 +566,19 @@ impl RowNode for RecursiveRelationNode {
     }
 }
 
-fn tuple_from_normalized_content(content: Vec<u8>) -> Tuple {
+fn tuple_from_normalized_content(content: Vec<u8>, provenance: TupleProvenance) -> Tuple {
     // Stable synthetic id by row content for deterministic dedupe.
     let uuid = Uuid::new_v5(&Uuid::NAMESPACE_OID, &content);
     let id = ObjectId::from_uuid(uuid);
     let commit_id = CommitId([0; 32]);
-    Tuple::new(vec![TupleElement::Row {
-        id,
-        content,
-        commit_id,
-    }])
+    Tuple::new_with_provenance(
+        vec![TupleElement::Row {
+            id,
+            content,
+            commit_id,
+        }],
+        provenance,
+    )
 }
 
 fn diff_sets(old_set: &AHashSet<Tuple>, new_set: &AHashSet<Tuple>) -> TupleDelta {
@@ -484,7 +601,7 @@ fn diff_sets(old_set: &AHashSet<Tuple>, new_set: &AHashSet<Tuple>) -> TupleDelta
 
         let old_content = old_tuple.get(0).and_then(|e| e.content());
         let new_content = new_tuple.get(0).and_then(|e| e.content());
-        if old_content != new_content {
+        if old_content != new_content || old_tuple.provenance() != new_tuple.provenance() {
             delta
                 .updated
                 .push(((*old_tuple).clone(), (*new_tuple).clone()));

--- a/crates/jazz-tools/src/query_manager/graph_nodes/select_element.rs
+++ b/crates/jazz-tools/src/query_manager/graph_nodes/select_element.rs
@@ -45,7 +45,7 @@ impl SelectElementNode {
 
     fn select_tuple(&self, tuple: &Tuple) -> Option<Tuple> {
         let element = tuple.get(self.element_index)?.clone();
-        Some(Tuple::new(vec![element]))
+        Some(Tuple::new(vec![element]).with_provenance(tuple.provenance().clone()))
     }
 
     fn tuple_content_changed(old_tuple: &Tuple, new_tuple: &Tuple) -> bool {

--- a/crates/jazz-tools/src/query_manager/graph_nodes/tuple_delta.rs
+++ b/crates/jazz-tools/src/query_manager/graph_nodes/tuple_delta.rs
@@ -132,14 +132,28 @@ fn tuple_as_id_only(tuple: &Tuple) -> Tuple {
             .map(|elem| TupleElement::Id(elem.id()))
             .collect(),
     )
+    .with_provenance(tuple.provenance().clone())
 }
 
-/// Check if tuple content changed (for tuples with same IDs).
+/// Check if tuple content or provenance changed (for tuples with same IDs).
 fn has_tuple_content_changed(old: &Tuple, new: &Tuple) -> bool {
-    old.iter()
-        .zip(new.iter())
-        .any(|(o, n)| match (o.content(), n.content()) {
-            (Some(oc), Some(nc)) => oc != nc,
-            _ => false,
-        })
+    if old.provenance() != new.provenance() {
+        return true;
+    }
+
+    old.iter().zip(new.iter()).any(|(o, n)| match (o, n) {
+        (
+            TupleElement::Row {
+                content: old_content,
+                commit_id: old_commit,
+                ..
+            },
+            TupleElement::Row {
+                content: new_content,
+                commit_id: new_commit,
+                ..
+            },
+        ) => old_content != new_content || old_commit != new_commit,
+        _ => false,
+    })
 }

--- a/crates/jazz-tools/src/query_manager/graph_nodes/union.rs
+++ b/crates/jazz-tools/src/query_manager/graph_nodes/union.rs
@@ -1,4 +1,4 @@
-use ahash::AHashSet;
+use ahash::{AHashMap, AHashSet};
 
 use crate::query_manager::types::{Tuple, TupleDelta, TupleDescriptor};
 
@@ -50,11 +50,17 @@ impl TransformNode for UnionNode {
     /// Compute the union of multiple input tuple sets.
     /// For union: a tuple is present if it's in ANY input.
     fn process(&mut self, inputs: &[&AHashSet<Tuple>]) -> TupleDelta {
-        // Compute new union of tuples
-        let mut new_tuples = AHashSet::new();
+        // Compute new union of tuples, merging provenance for equal tuple IDs.
+        let mut merged_by_ids = AHashMap::<Vec<_>, Tuple>::new();
         for tuples in inputs {
-            new_tuples.extend(tuples.iter().cloned());
+            for tuple in tuples.iter() {
+                merged_by_ids
+                    .entry(tuple.ids())
+                    .and_modify(|existing| existing.merge_provenance_from(tuple))
+                    .or_insert_with(|| tuple.clone());
+            }
         }
+        let new_tuples: AHashSet<Tuple> = merged_by_ids.values().cloned().collect();
 
         // Compute delta
         let added: Vec<Tuple> = new_tuples
@@ -66,6 +72,16 @@ impl TransformNode for UnionNode {
             .difference(&new_tuples)
             .cloned()
             .collect();
+        let updated: Vec<(Tuple, Tuple)> = self
+            .current_tuples
+            .iter()
+            .filter_map(|old_tuple| {
+                new_tuples.get(old_tuple).and_then(|new_tuple| {
+                    (old_tuple.provenance() != new_tuple.provenance())
+                        .then(|| (old_tuple.clone(), new_tuple.clone()))
+                })
+            })
+            .collect();
 
         // Update state
         self.current_tuples = new_tuples;
@@ -75,7 +91,7 @@ impl TransformNode for UnionNode {
             added,
             removed,
             moved: vec![],
-            updated: vec![],
+            updated,
         }
     }
 

--- a/crates/jazz-tools/src/query_manager/manager.rs
+++ b/crates/jazz-tools/src/query_manager/manager.rs
@@ -19,8 +19,8 @@ use super::policy_graph::PolicyGraph;
 use super::query::Query;
 use super::session::Session;
 use super::types::{
-    ComposedBranchName, OrderedRowDelta, RowDelta, RowDescriptor, Schema, SchemaHash, TableName,
-    TableSchema, Value, build_ordered_delta_with_post_ids,
+    ComposedBranchName, LoadedRow, OrderedRowDelta, RowDelta, RowDescriptor, Schema, SchemaHash,
+    TableName, TableSchema, Value, build_ordered_delta_with_post_ids,
 };
 
 /// Error types for QueryManager operations.
@@ -690,7 +690,7 @@ impl QueryManager {
             // For single-branch subscriptions, reads from that branch
             // For multi-branch subscriptions, uses LWW across branches
             // When schema context is present, applies lens transform for old schema branches
-            let row_loader = |id: ObjectId| -> Option<(Vec<u8>, CommitId)> {
+            let row_loader = |id: ObjectId| -> Option<LoadedRow> {
                 let obj = om.get_or_load(id, storage_ref, branches);
                 if obj.is_none() {
                     tracing::trace!(%id, "row_loader: object not found");
@@ -741,7 +741,13 @@ impl QueryManager {
                     let transformer = LensTransformer::new(schema_context, &table);
                     match transformer.transform(&content, commit_id, source_hash) {
                         Ok(result) => {
-                            return Some((result.data, commit_id));
+                            return Some(LoadedRow::new(
+                                result.data,
+                                commit_id,
+                                [(id, BranchName::new(&source_branch))]
+                                    .into_iter()
+                                    .collect(),
+                            ));
                         }
                         Err(err) => {
                             tracing::warn!(
@@ -759,7 +765,13 @@ impl QueryManager {
                     }
                 }
 
-                Some((content, commit_id))
+                Some(LoadedRow::new(
+                    content,
+                    commit_id,
+                    [(id, BranchName::new(&source_branch))]
+                        .into_iter()
+                        .collect(),
+                ))
             };
 
             let delta = subscription.graph.settle(storage_ref, row_loader);

--- a/crates/jazz-tools/src/query_manager/manager_tests.rs
+++ b/crates/jazz-tools/src/query_manager/manager_tests.rs
@@ -6568,6 +6568,235 @@ fn contributing_ids_update_reactively() {
     );
 }
 
+#[test]
+fn contributing_ids_for_limit_offset_include_ordered_prefix() {
+    let sync_manager = SyncManager::new();
+    let schema = test_schema();
+    let (mut qm, mut storage) = create_query_manager(sync_manager, schema);
+
+    let handle_a = qm
+        .insert(
+            &mut storage,
+            "users",
+            &[Value::Text("A".into()), Value::Integer(1)],
+        )
+        .unwrap();
+    let handle_b = qm
+        .insert(
+            &mut storage,
+            "users",
+            &[Value::Text("B".into()), Value::Integer(2)],
+        )
+        .unwrap();
+    let handle_c = qm
+        .insert(
+            &mut storage,
+            "users",
+            &[Value::Text("C".into()), Value::Integer(3)],
+        )
+        .unwrap();
+    let _handle_d = qm
+        .insert(
+            &mut storage,
+            "users",
+            &[Value::Text("D".into()), Value::Integer(4)],
+        )
+        .unwrap();
+
+    let query = qm
+        .query("users")
+        .order_by("score")
+        .offset(2)
+        .limit(1)
+        .build();
+    let sub_id = qm.subscribe(query).unwrap();
+
+    qm.process(&mut storage);
+
+    let branch = crate::object::BranchName::new(&get_branch(&qm));
+    let contributing = qm.get_subscription_contributing_ids(sub_id);
+
+    assert_eq!(
+        contributing.len(),
+        3,
+        "Paginated queries need the ordered prefix through offset + limit"
+    );
+    assert!(contributing.contains(&(handle_a.row_id, branch.clone())));
+    assert!(contributing.contains(&(handle_b.row_id, branch.clone())));
+    assert!(contributing.contains(&(handle_c.row_id, branch)));
+}
+
+#[test]
+fn contributing_ids_for_offset_only_include_full_input() {
+    let sync_manager = SyncManager::new();
+    let schema = test_schema();
+    let (mut qm, mut storage) = create_query_manager(sync_manager, schema);
+
+    let handles = [
+        qm.insert(
+            &mut storage,
+            "users",
+            &[Value::Text("A".into()), Value::Integer(1)],
+        )
+        .unwrap(),
+        qm.insert(
+            &mut storage,
+            "users",
+            &[Value::Text("B".into()), Value::Integer(2)],
+        )
+        .unwrap(),
+        qm.insert(
+            &mut storage,
+            "users",
+            &[Value::Text("C".into()), Value::Integer(3)],
+        )
+        .unwrap(),
+        qm.insert(
+            &mut storage,
+            "users",
+            &[Value::Text("D".into()), Value::Integer(4)],
+        )
+        .unwrap(),
+    ];
+
+    let query = qm.query("users").order_by("score").offset(2).build();
+    let sub_id = qm.subscribe(query).unwrap();
+
+    qm.process(&mut storage);
+
+    let branch = crate::object::BranchName::new(&get_branch(&qm));
+    let contributing = qm.get_subscription_contributing_ids(sub_id);
+
+    assert_eq!(
+        contributing.len(),
+        handles.len(),
+        "Offset without limit still needs the full ordered input to replay locally"
+    );
+    for handle in handles {
+        assert!(contributing.contains(&(handle.row_id, branch.clone())));
+    }
+}
+
+#[test]
+fn contributing_ids_for_array_subquery_include_inner_rows() {
+    let sync_manager = SyncManager::new();
+    let schema = users_posts_schema();
+    let (mut qm, mut storage) = create_query_manager(sync_manager, schema);
+
+    let user = qm
+        .insert(
+            &mut storage,
+            "users",
+            &[Value::Integer(1), Value::Text("Alice".into())],
+        )
+        .unwrap();
+    let post1 = qm
+        .insert(
+            &mut storage,
+            "posts",
+            &[
+                Value::Integer(100),
+                Value::Text("Post 1".into()),
+                Value::Integer(1),
+            ],
+        )
+        .unwrap();
+    let post2 = qm
+        .insert(
+            &mut storage,
+            "posts",
+            &[
+                Value::Integer(101),
+                Value::Text("Post 2".into()),
+                Value::Integer(1),
+            ],
+        )
+        .unwrap();
+
+    let query = qm
+        .query("users")
+        .with_array("posts", |sub| {
+            sub.from("posts").correlate("author_id", "users.id")
+        })
+        .build();
+    let sub_id = qm.subscribe(query).unwrap();
+
+    qm.process(&mut storage);
+
+    let branch = crate::object::BranchName::new(&get_branch(&qm));
+    let contributing = qm.get_subscription_contributing_ids(sub_id);
+
+    assert_eq!(
+        contributing.len(),
+        3,
+        "Array subquery outputs depend on both outer and inner rows"
+    );
+    assert!(contributing.contains(&(user.row_id, branch.clone())));
+    assert!(contributing.contains(&(post1.row_id, branch.clone())));
+    assert!(contributing.contains(&(post2.row_id, branch)));
+}
+
+#[test]
+fn contributing_ids_for_recursive_hop_include_recursive_dependencies() {
+    let sync_manager = SyncManager::new();
+    let schema = recursive_hop_team_schema();
+    let (mut qm, mut storage) = create_query_manager(sync_manager, schema);
+
+    let team1 = qm
+        .insert(&mut storage, "teams", &[Value::Text("team-1".into())])
+        .unwrap();
+    let team2 = qm
+        .insert(&mut storage, "teams", &[Value::Text("team-2".into())])
+        .unwrap();
+    let team3 = qm
+        .insert(&mut storage, "teams", &[Value::Text("team-3".into())])
+        .unwrap();
+
+    let edge1 = qm
+        .insert(
+            &mut storage,
+            "team_edges",
+            &[Value::Uuid(team1.row_id), Value::Uuid(team2.row_id)],
+        )
+        .unwrap();
+    let edge2 = qm
+        .insert(
+            &mut storage,
+            "team_edges",
+            &[Value::Uuid(team2.row_id), Value::Uuid(team3.row_id)],
+        )
+        .unwrap();
+
+    let query = qm
+        .query("teams")
+        .filter_eq("name", Value::Text("team-1".into()))
+        .with_recursive(|r| {
+            r.from("team_edges")
+                .correlate("child_team", "_id")
+                .select(&["parent_team"])
+                .hop("teams", "parent_team")
+                .max_depth(10)
+        })
+        .build();
+    let sub_id = qm.subscribe(query).unwrap();
+
+    qm.process(&mut storage);
+
+    let branch = crate::object::BranchName::new(&get_branch(&qm));
+    let contributing = qm.get_subscription_contributing_ids(sub_id);
+
+    assert_eq!(
+        contributing.len(),
+        5,
+        "Recursive hop outputs depend on both discovered rows and traversal edges"
+    );
+    assert!(contributing.contains(&(team1.row_id, branch.clone())));
+    assert!(contributing.contains(&(team2.row_id, branch.clone())));
+    assert!(contributing.contains(&(team3.row_id, branch.clone())));
+    assert!(contributing.contains(&(edge1.row_id, branch.clone())));
+    assert!(contributing.contains(&(edge2.row_id, branch)));
+}
+
 // ============================================================================
 // Server-Side Query Subscription Tests
 // ============================================================================
@@ -7767,6 +7996,287 @@ fn e2e_client_receives_server_data_via_subscription() {
     assert!(names.contains(&"Alice"), "Should contain Alice");
     assert!(names.contains(&"Charlie"), "Should contain Charlie");
     assert!(!names.contains(&"Bob"), "Should NOT contain Bob");
+}
+
+/// E2E: Client can cold-load a paginated remote query with a non-zero offset.
+#[test]
+fn e2e_client_receives_paginated_server_data_on_cold_offset_subscription() {
+    use crate::sync_manager::{ClientId, ServerId};
+    use uuid::Uuid;
+
+    let schema = test_schema();
+
+    let server_sync = SyncManager::new();
+    let (mut server, mut server_io) = create_query_manager(server_sync, schema.clone());
+
+    for (name, score) in [("A", 1), ("B", 2), ("C", 3), ("D", 4)] {
+        server
+            .insert(
+                &mut server_io,
+                "users",
+                &[Value::Text(name.into()), Value::Integer(score)],
+            )
+            .unwrap();
+    }
+    server.process(&mut server_io);
+
+    let client_sync = SyncManager::new();
+    let (mut client, mut client_io) = create_query_manager(client_sync, schema);
+
+    let server_id = ServerId(Uuid::new_v7(uuid::Timestamp::now(uuid::NoContext)));
+    let client_id = ClientId(Uuid::new_v7(uuid::Timestamp::now(uuid::NoContext)));
+
+    client.sync_manager_mut().add_server(server_id);
+    server.sync_manager_mut().add_client(client_id);
+    let _ = client.sync_manager_mut().take_outbox();
+
+    let query = client
+        .query("users")
+        .order_by("score")
+        .offset(2)
+        .limit(1)
+        .build();
+
+    let sub_id = client.subscribe_with_sync(query, None, None).unwrap();
+
+    pump_messages(
+        &mut client,
+        &mut server,
+        &mut client_io,
+        &mut server_io,
+        client_id,
+        server_id,
+    );
+
+    let results = client.get_subscription_results(sub_id);
+    assert_eq!(
+        results.len(),
+        1,
+        "Cold paginated subscription should materialize the requested page"
+    );
+    assert_eq!(results[0].1[0], Value::Text("C".into()));
+    assert_eq!(results[0].1[1], Value::Integer(3));
+}
+
+#[test]
+fn e2e_client_receives_paginated_server_data_on_cold_offset_only_subscription() {
+    use crate::sync_manager::{ClientId, ServerId};
+    use uuid::Uuid;
+
+    let schema = test_schema();
+
+    let server_sync = SyncManager::new();
+    let (mut server, mut server_io) = create_query_manager(server_sync, schema.clone());
+
+    for (name, score) in [("A", 1), ("B", 2), ("C", 3), ("D", 4)] {
+        server
+            .insert(
+                &mut server_io,
+                "users",
+                &[Value::Text(name.into()), Value::Integer(score)],
+            )
+            .unwrap();
+    }
+    server.process(&mut server_io);
+
+    let client_sync = SyncManager::new();
+    let (mut client, mut client_io) = create_query_manager(client_sync, schema);
+
+    let server_id = ServerId(Uuid::new_v7(uuid::Timestamp::now(uuid::NoContext)));
+    let client_id = ClientId(Uuid::new_v7(uuid::Timestamp::now(uuid::NoContext)));
+
+    client.sync_manager_mut().add_server(server_id);
+    server.sync_manager_mut().add_client(client_id);
+    let _ = client.sync_manager_mut().take_outbox();
+
+    let query = client.query("users").order_by("score").offset(2).build();
+
+    let sub_id = client.subscribe_with_sync(query, None, None).unwrap();
+
+    pump_messages(
+        &mut client,
+        &mut server,
+        &mut client_io,
+        &mut server_io,
+        client_id,
+        server_id,
+    );
+
+    let results = client.get_subscription_results(sub_id);
+    assert_eq!(
+        results.len(),
+        2,
+        "Offset-only query should keep trailing rows"
+    );
+    assert_eq!(results[0].1[0], Value::Text("C".into()));
+    assert_eq!(results[1].1[0], Value::Text("D".into()));
+}
+
+#[test]
+fn e2e_client_receives_array_subquery_server_data_via_subscription() {
+    use crate::sync_manager::{ClientId, ServerId};
+    use uuid::Uuid;
+
+    let schema = users_posts_schema();
+
+    let server_sync = SyncManager::new();
+    let (mut server, mut server_io) = create_query_manager(server_sync, schema.clone());
+
+    server
+        .insert(
+            &mut server_io,
+            "users",
+            &[Value::Integer(1), Value::Text("Alice".into())],
+        )
+        .unwrap();
+    server
+        .insert(
+            &mut server_io,
+            "posts",
+            &[
+                Value::Integer(100),
+                Value::Text("Post 1".into()),
+                Value::Integer(1),
+            ],
+        )
+        .unwrap();
+    server
+        .insert(
+            &mut server_io,
+            "posts",
+            &[
+                Value::Integer(101),
+                Value::Text("Post 2".into()),
+                Value::Integer(1),
+            ],
+        )
+        .unwrap();
+    server.process(&mut server_io);
+
+    let client_sync = SyncManager::new();
+    let (mut client, mut client_io) = create_query_manager(client_sync, schema);
+
+    let server_id = ServerId(Uuid::new_v7(uuid::Timestamp::now(uuid::NoContext)));
+    let client_id = ClientId(Uuid::new_v7(uuid::Timestamp::now(uuid::NoContext)));
+
+    client.sync_manager_mut().add_server(server_id);
+    server.sync_manager_mut().add_client(client_id);
+    let _ = client.sync_manager_mut().take_outbox();
+
+    let query = client
+        .query("users")
+        .with_array("posts", |sub| {
+            sub.from("posts").correlate("author_id", "users.id")
+        })
+        .build();
+
+    let sub_id = client.subscribe_with_sync(query, None, None).unwrap();
+
+    pump_messages(
+        &mut client,
+        &mut server,
+        &mut client_io,
+        &mut server_io,
+        client_id,
+        server_id,
+    );
+
+    let results = client.get_subscription_results(sub_id);
+    assert_eq!(results.len(), 1, "Client should receive the user row");
+    assert_eq!(results[0].1[0], Value::Integer(1));
+    assert_eq!(results[0].1[1], Value::Text("Alice".into()));
+
+    let posts = results[0].1[2].as_array().expect("posts array");
+    assert_eq!(
+        posts.len(),
+        2,
+        "Client should receive inner rows needed for the array"
+    );
+}
+
+#[test]
+fn e2e_client_receives_recursive_hop_server_data_via_subscription() {
+    use crate::sync_manager::{ClientId, ServerId};
+    use uuid::Uuid;
+
+    let schema = recursive_hop_team_schema();
+
+    let server_sync = SyncManager::new();
+    let (mut server, mut server_io) = create_query_manager(server_sync, schema.clone());
+
+    let team1 = server
+        .insert(&mut server_io, "teams", &[Value::Text("team-1".into())])
+        .unwrap();
+    let team2 = server
+        .insert(&mut server_io, "teams", &[Value::Text("team-2".into())])
+        .unwrap();
+    let team3 = server
+        .insert(&mut server_io, "teams", &[Value::Text("team-3".into())])
+        .unwrap();
+    server
+        .insert(
+            &mut server_io,
+            "team_edges",
+            &[Value::Uuid(team1.row_id), Value::Uuid(team2.row_id)],
+        )
+        .unwrap();
+    server
+        .insert(
+            &mut server_io,
+            "team_edges",
+            &[Value::Uuid(team2.row_id), Value::Uuid(team3.row_id)],
+        )
+        .unwrap();
+    server.process(&mut server_io);
+
+    let client_sync = SyncManager::new();
+    let (mut client, mut client_io) = create_query_manager(client_sync, schema);
+
+    let server_id = ServerId(Uuid::new_v7(uuid::Timestamp::now(uuid::NoContext)));
+    let client_id = ClientId(Uuid::new_v7(uuid::Timestamp::now(uuid::NoContext)));
+
+    client.sync_manager_mut().add_server(server_id);
+    server.sync_manager_mut().add_client(client_id);
+    let _ = client.sync_manager_mut().take_outbox();
+
+    let query = client
+        .query("teams")
+        .filter_eq("name", Value::Text("team-1".into()))
+        .with_recursive(|r| {
+            r.from("team_edges")
+                .correlate("child_team", "_id")
+                .select(&["parent_team"])
+                .hop("teams", "parent_team")
+                .max_depth(10)
+        })
+        .build();
+
+    let sub_id = client.subscribe_with_sync(query, None, None).unwrap();
+
+    pump_messages(
+        &mut client,
+        &mut server,
+        &mut client_io,
+        &mut server_io,
+        client_id,
+        server_id,
+    );
+
+    let mut names: Vec<String> = client
+        .get_subscription_results(sub_id)
+        .into_iter()
+        .filter_map(|(_, values)| match values.first() {
+            Some(Value::Text(name)) => Some(name.clone()),
+            _ => None,
+        })
+        .collect();
+    names.sort();
+
+    assert_eq!(
+        names,
+        vec!["team-1", "team-2", "team-3"],
+        "Client should receive recursive dependencies needed to replay the closure"
+    );
 }
 
 /// E2E: Client receives new matching rows as server inserts them.

--- a/crates/jazz-tools/src/query_manager/policy_graph.rs
+++ b/crates/jazz-tools/src/query_manager/policy_graph.rs
@@ -3,7 +3,6 @@
 //! Creates minimal query graphs to evaluate policy conditions like USING and INHERITS.
 //! These graphs are throwaway - created, settled until complete, then discarded.
 
-use crate::commit::CommitId;
 use crate::object::ObjectId;
 
 use crate::storage::Storage;
@@ -20,7 +19,7 @@ use super::index::ScanCondition;
 use super::policy::PolicyExpr;
 use super::session::Session;
 use super::types::ColumnName;
-use super::types::{Schema, TableName, TupleDescriptor, Value};
+use super::types::{LoadedRow, Schema, TableName, TupleDescriptor, Value};
 
 /// A one-shot graph for evaluating a policy condition.
 ///
@@ -247,7 +246,7 @@ impl PolicyGraph {
     pub fn settle(
         &mut self,
         io: &dyn Storage,
-        row_loader: &mut dyn FnMut(ObjectId) -> Option<(Vec<u8>, CommitId)>,
+        row_loader: &mut dyn FnMut(ObjectId) -> Option<LoadedRow>,
     ) -> bool {
         let _delta = self.graph.settle(io, row_loader);
         true
@@ -389,7 +388,7 @@ mod tests {
         let storage = crate::storage::MemoryStorage::new();
 
         // Row loader returns None for all IDs (no data)
-        let mut row_loader = |_id: ObjectId| -> Option<(Vec<u8>, CommitId)> { None };
+        let mut row_loader = |_id: ObjectId| -> Option<LoadedRow> { None };
 
         // Settle the graph
         pg.settle(&storage, &mut row_loader);

--- a/crates/jazz-tools/src/query_manager/server_queries.rs
+++ b/crates/jazz-tools/src/query_manager/server_queries.rs
@@ -11,7 +11,9 @@ use super::manager::{PolicyCheckState, QueryManager, ServerQuerySubscription};
 use super::policy::{ComplexClause, Operation, evaluate_simple_parts};
 use super::policy_graph::PolicyGraph;
 use super::session::Session;
-use super::types::{ComposedBranchName, RowDescriptor, Schema, TableName, TableSchema, Value};
+use super::types::{
+    ComposedBranchName, LoadedRow, RowDescriptor, Schema, TableName, TableSchema, Value,
+};
 
 impl QueryManager {
     fn should_sync_policy_context_rows(&self, client_id: ClientId) -> bool {
@@ -167,11 +169,12 @@ impl QueryManager {
             };
 
             // Simple row loader for server-side graphs (no schema transform needed)
-            let row_loader = |id: ObjectId| -> Option<(Vec<u8>, CommitId)> {
+            let row_loader = |id: ObjectId| -> Option<LoadedRow> {
                 let obj = om.get_or_load(id, storage_ref, &branches)?;
-                let mut best: Option<(u64, Vec<u8>, CommitId)> = None;
+                let mut best: Option<(u64, Vec<u8>, CommitId, BranchName)> = None;
                 for branch_name in &branches {
-                    if let Some(branch) = obj.branches.get(&BranchName::new(branch_name)) {
+                    let branch_name = BranchName::new(branch_name);
+                    if let Some(branch) = obj.branches.get(&branch_name) {
                         for &tip_id in &branch.tips {
                             if let Some(commit) = branch.commits.get(&tip_id) {
                                 match &best {
@@ -180,13 +183,15 @@ impl QueryManager {
                                             commit.timestamp,
                                             commit.content.clone(),
                                             tip_id,
+                                            branch_name,
                                         ));
                                     }
-                                    Some((best_ts, _, _)) if commit.timestamp > *best_ts => {
+                                    Some((best_ts, _, _, _)) if commit.timestamp > *best_ts => {
                                         best = Some((
                                             commit.timestamp,
                                             commit.content.clone(),
                                             tip_id,
+                                            branch_name,
                                         ));
                                     }
                                     _ => {}
@@ -195,14 +200,22 @@ impl QueryManager {
                         }
                     }
                 }
-                best.filter(|(_, content, _)| !content.is_empty())
-                    .map(|(_, content, commit_id)| (content, commit_id))
+                best.filter(|(_, content, _, _)| !content.is_empty()).map(
+                    |(_, content, commit_id, branch_name)| {
+                        LoadedRow::new(
+                            content,
+                            commit_id,
+                            [(id, branch_name)].into_iter().collect(),
+                        )
+                    },
+                )
             };
 
             let _delta = graph.settle(storage_ref, row_loader);
 
-            // Query result-set scope is always synced.
-            let result_scope = graph.contributing_object_ids();
+            // Sync the rows needed for the client to reproduce the current result
+            // locally, including any ordered prefix required by pagination.
+            let result_scope = graph.sync_scope_object_ids();
             // Trusted clients (Peer/Admin) also need policy context rows.
             let scope = if sync_policy_context_rows {
                 Self::scope_with_policy_context_rows_from_object_manager(
@@ -317,11 +330,12 @@ impl QueryManager {
             let branches = &sub.branches;
 
             // Row loader for this subscription
-            let row_loader = |id: ObjectId| -> Option<(Vec<u8>, CommitId)> {
+            let row_loader = |id: ObjectId| -> Option<LoadedRow> {
                 let obj = om.get_or_load(id, storage, branches)?;
-                let mut best: Option<(u64, Vec<u8>, CommitId)> = None;
+                let mut best: Option<(u64, Vec<u8>, CommitId, BranchName)> = None;
                 for branch_name in branches {
-                    if let Some(branch) = obj.branches.get(&BranchName::new(branch_name)) {
+                    let branch_name = BranchName::new(branch_name);
+                    if let Some(branch) = obj.branches.get(&branch_name) {
                         for &tip_id in &branch.tips {
                             if let Some(commit) = branch.commits.get(&tip_id) {
                                 match &best {
@@ -330,13 +344,15 @@ impl QueryManager {
                                             commit.timestamp,
                                             commit.content.clone(),
                                             tip_id,
+                                            branch_name,
                                         ));
                                     }
-                                    Some((best_ts, _, _)) if commit.timestamp > *best_ts => {
+                                    Some((best_ts, _, _, _)) if commit.timestamp > *best_ts => {
                                         best = Some((
                                             commit.timestamp,
                                             commit.content.clone(),
                                             tip_id,
+                                            branch_name,
                                         ));
                                     }
                                     _ => {}
@@ -345,8 +361,15 @@ impl QueryManager {
                         }
                     }
                 }
-                best.filter(|(_, content, _)| !content.is_empty())
-                    .map(|(_, content, commit_id)| (content, commit_id))
+                best.filter(|(_, content, _, _)| !content.is_empty()).map(
+                    |(_, content, commit_id, branch_name)| {
+                        LoadedRow::new(
+                            content,
+                            commit_id,
+                            [(id, branch_name)].into_iter().collect(),
+                        )
+                    },
+                )
             };
 
             let new_scope = {
@@ -360,7 +383,7 @@ impl QueryManager {
                 }
 
                 // Check if scope changed
-                let result_scope = sub.graph.contributing_object_ids();
+                let result_scope = sub.graph.sync_scope_object_ids();
                 if trusted_clients.contains(client_id) {
                     Self::scope_with_policy_context_rows_from_object_manager(
                         &result_scope,
@@ -922,7 +945,7 @@ impl QueryManager {
 
         // Settle each active policy check
         for (pending_id, state) in &mut self.active_policy_checks {
-            let mut row_loader = |id: ObjectId| -> Option<(Vec<u8>, CommitId)> {
+            let mut row_loader = |id: ObjectId| -> Option<LoadedRow> {
                 let obj = om.get_or_load(id, storage_ref, &branches)?;
                 let branch = obj.branches.get(&BranchName::new(&current_branch))?;
                 let tip_id = branch.tips.iter().next()?;
@@ -930,7 +953,13 @@ impl QueryManager {
                 if commit.content.is_empty() {
                     return None;
                 }
-                Some((commit.content.clone(), *tip_id))
+                Some(LoadedRow::new(
+                    commit.content.clone(),
+                    *tip_id,
+                    [(id, BranchName::new(&current_branch))]
+                        .into_iter()
+                        .collect(),
+                ))
             };
 
             // Settle all graphs

--- a/crates/jazz-tools/src/query_manager/types/tuple.rs
+++ b/crates/jazz-tools/src/query_manager/types/tuple.rs
@@ -1,7 +1,9 @@
 use std::hash::{Hash, Hasher};
 
+use ahash::AHashSet;
+
 use crate::commit::CommitId;
-use crate::object::ObjectId;
+use crate::object::{BranchName, ObjectId};
 
 use super::encoding::{decode_row, encode_row};
 use super::*;
@@ -79,22 +81,55 @@ impl TupleElement {
 /// A tuple of elements with identity based on IDs only.
 /// Length corresponds to number of tables in query (1 for single-table, 2 for join, etc.)
 #[derive(Clone, Debug)]
-pub struct Tuple(pub Vec<TupleElement>);
+pub struct Tuple(pub Vec<TupleElement>, pub TupleProvenance);
+
+pub type ScopedObject = (ObjectId, BranchName);
+pub type TupleProvenance = AHashSet<ScopedObject>;
+
+#[derive(Clone, Debug)]
+pub struct LoadedRow {
+    pub data: Vec<u8>,
+    pub commit_id: CommitId,
+    pub provenance: TupleProvenance,
+}
+
+impl LoadedRow {
+    pub fn new(data: Vec<u8>, commit_id: CommitId, provenance: TupleProvenance) -> Self {
+        Self {
+            data,
+            commit_id,
+            provenance,
+        }
+    }
+}
 
 impl Tuple {
     /// Create a new tuple from elements.
     pub fn new(elements: Vec<TupleElement>) -> Self {
-        Self(elements)
+        Self(elements, TupleProvenance::new())
+    }
+
+    /// Create a tuple with explicit contributing-object provenance.
+    pub fn new_with_provenance(elements: Vec<TupleElement>, provenance: TupleProvenance) -> Self {
+        Self(elements, provenance)
     }
 
     /// Create a single-element tuple from an ObjectId.
     pub fn from_id(id: ObjectId) -> Self {
-        Self(vec![TupleElement::Id(id)])
+        Self::new(vec![TupleElement::Id(id)])
+    }
+
+    /// Create a single-element tuple from an ObjectId scoped to a branch.
+    pub fn from_scoped_id(id: ObjectId, branch: BranchName) -> Self {
+        Self::new_with_provenance(
+            vec![TupleElement::Id(id)],
+            [(id, branch)].into_iter().collect(),
+        )
     }
 
     /// Create a single-element tuple from a Row.
     pub fn from_row(row: &Row) -> Self {
-        Self(vec![TupleElement::from_row(row)])
+        Self::new(vec![TupleElement::from_row(row)])
     }
 
     /// Get all IDs in the tuple.
@@ -178,11 +213,14 @@ impl Tuple {
         let first_id = self.first_id()?;
         let commit_id = first_commit_id.unwrap_or(CommitId([0; 32]));
 
-        Some(Tuple::new(vec![TupleElement::Row {
-            id: first_id,
-            content: combined_content,
-            commit_id,
-        }]))
+        Some(
+            Tuple::new(vec![TupleElement::Row {
+                id: first_id,
+                content: combined_content,
+                commit_id,
+            }])
+            .with_provenance(self.provenance().clone()),
+        )
     }
 
     /// Iterate over elements.
@@ -193,6 +231,27 @@ impl Tuple {
     /// Iterate mutably over elements.
     pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut TupleElement> {
         self.0.iter_mut()
+    }
+
+    /// Get the contributing-object provenance for this tuple.
+    pub fn provenance(&self) -> &TupleProvenance {
+        &self.1
+    }
+
+    /// Replace the contributing-object provenance for this tuple.
+    pub fn with_provenance(mut self, provenance: TupleProvenance) -> Self {
+        self.1 = provenance;
+        self
+    }
+
+    /// Merge another tuple's provenance into this tuple.
+    pub fn merge_provenance_from(&mut self, other: &Tuple) {
+        self.1.extend(other.1.iter().copied());
+    }
+
+    /// Merge an explicit provenance set into this tuple.
+    pub fn merge_provenance(&mut self, provenance: &TupleProvenance) {
+        self.1.extend(provenance.iter().copied());
     }
 }
 
@@ -273,23 +332,24 @@ impl TupleDelta {
                 }
             })
             .collect();
-        let updated: Option<Vec<(Row, Row)>> = self
-            .updated
-            .iter()
-            .map(|(old, new)| {
-                if old.len() == 1 && new.len() == 1 {
-                    Some((old.to_single_row()?, new.to_single_row()?))
-                } else {
-                    None
-                }
-            })
-            .collect();
+
+        let mut updated = Vec::with_capacity(self.updated.len());
+        for (old, new) in &self.updated {
+            if old.len() != 1 || new.len() != 1 {
+                return None;
+            }
+            let old_row = old.to_single_row()?;
+            let new_row = new.to_single_row()?;
+            if old_row != new_row {
+                updated.push((old_row, new_row));
+            }
+        }
 
         Some(RowDelta {
             added: added?,
             removed: removed?,
             moved: self.moved.iter().filter_map(|t| t.first_id()).collect(),
-            updated: updated?,
+            updated,
         })
     }
 
@@ -332,31 +392,30 @@ impl TupleDelta {
                 }
             })
             .collect();
-        let updated: Option<Vec<(Row, Row)>> = self
-            .updated
-            .iter()
-            .map(|(old, new)| {
-                let old_row = if old.len() == 1 {
-                    old.to_single_row()
-                } else {
-                    old.flatten_with_descriptors(descriptors, combined_descriptor)?
-                        .to_single_row()
-                }?;
-                let new_row = if new.len() == 1 {
-                    new.to_single_row()
-                } else {
-                    new.flatten_with_descriptors(descriptors, combined_descriptor)?
-                        .to_single_row()
-                }?;
-                Some((old_row, new_row))
-            })
-            .collect();
+        let mut updated = Vec::with_capacity(self.updated.len());
+        for (old, new) in &self.updated {
+            let old_row = if old.len() == 1 {
+                old.to_single_row()
+            } else {
+                old.flatten_with_descriptors(descriptors, combined_descriptor)?
+                    .to_single_row()
+            }?;
+            let new_row = if new.len() == 1 {
+                new.to_single_row()
+            } else {
+                new.flatten_with_descriptors(descriptors, combined_descriptor)?
+                    .to_single_row()
+            }?;
+            if old_row != new_row {
+                updated.push((old_row, new_row));
+            }
+        }
 
         Some(RowDelta {
             added: added?,
             removed: removed?,
             moved: self.moved.iter().filter_map(|t| t.first_id()).collect(),
-            updated: updated?,
+            updated,
         })
     }
 

--- a/crates/jazz-tools/src/query_manager/writes.rs
+++ b/crates/jazz-tools/src/query_manager/writes.rs
@@ -9,7 +9,7 @@ use super::encoding::{decode_column, decode_row, encode_row};
 use super::manager::{DeleteHandle, InsertHandle, QueryError, QueryManager};
 use super::policy::{ComplexClause, Operation, evaluate_simple_parts};
 use super::session::Session;
-use super::types::{ColumnType, RowDescriptor, TableName, Value};
+use super::types::{ColumnType, LoadedRow, RowDescriptor, TableName, Value};
 
 impl QueryManager {
     /// Insert a new row into a table.
@@ -533,7 +533,7 @@ impl QueryManager {
         let branches = vec![branch.to_string()];
         let storage_ref: &dyn Storage = storage;
         let om = &mut self.sync_manager.object_manager;
-        let mut row_loader = |id: ObjectId| -> Option<(Vec<u8>, CommitId)> {
+        let mut row_loader = |id: ObjectId| -> Option<LoadedRow> {
             let obj = om.get_or_load(id, storage_ref, &branches)?;
             let branch_state = obj.branches.get(&BranchName::new(branch))?;
             let tip_id = branch_state.tips.iter().next()?;
@@ -541,7 +541,11 @@ impl QueryManager {
             if commit.content.is_empty() {
                 return None;
             }
-            Some((commit.content.clone(), *tip_id))
+            Some(LoadedRow::new(
+                commit.content.clone(),
+                *tip_id,
+                [(id, BranchName::new(branch))].into_iter().collect(),
+            ))
         };
 
         for graph in &mut graphs {


### PR DESCRIPTION
## Summary
- add failing coverage for paginated sync scope, array subquery dependencies, recursive hop dependencies, and the downstream cold-subscription failures they cause
- rewrite contributing-object provenance to travel with tuples and loaded rows through the query graph, including joins, projections, selected elements, nested array subqueries, and recursive relations
- preserve the trusted downstream server vs untrusted downstream client distinction by syncing result provenance for everyone and layering policy-context rows only for trusted downstreams

## Testing
- cargo check -p jazz-tools
- cargo test -p jazz-tools query_manager::manager_tests -- --nocapture
- cargo test -p jazz-tools query_manager::graph_nodes::materialize -- --nocapture
- cargo test -p jazz-tools query_manager::graph_nodes::array_subquery -- --nocapture
- cargo test -p jazz-tools query_manager::graph_nodes::recursive_relation -- --nocapture
- cargo test -p jazz-tools query_manager::graph_nodes::select_element -- --nocapture
- cargo test -p jazz-tools query_manager::graph_nodes::join -- --nocapture
- cargo test -p jazz-tools query_manager::graph_nodes::project -- --nocapture
- cargo test -p jazz-tools query_manager::graph_nodes::limit_offset -- --nocapture
