### PR TITLE
fix(release): use npm-dir with napi artifacts

### DIFF
--- a/.github/workflows/publish-jazz-tools-alpha.yml
+++ b/.github/workflows/publish-jazz-tools-alpha.yml
@@ -359,7 +359,7 @@ jobs:
         run: |
           cd crates/jazz-napi
           pnpm exec napi create-npm-dirs
-          pnpm exec napi artifacts -d artifacts --dist npm
+          pnpm exec napi artifacts -d artifacts --npm-dir npm
           node -e 'const fs=require("fs");for(const entry of fs.readdirSync("npm",{withFileTypes:true})){if(!entry.isDirectory())continue;const path=`npm/${entry.name}/package.json`;const p=JSON.parse(fs.readFileSync(path,"utf8"));p.name=`@garden-co/${p.name}`;fs.writeFileSync(path,`${JSON.stringify(p,null,2)}\n`);}'
 
       - name: Verify staged jazz-napi platform artifacts


### PR DESCRIPTION
## Summary
- replace the unsupported `--dist npm` flag with `--npm-dir npm` for `pnpm exec napi artifacts`
- keep the alpha publish workflow aligned with `@napi-rs/cli` v3 semantics

## Why
After PR #225 fixed `create-npm-dirs`, the next preview run failed in the same step because `napi artifacts` also changed its accepted flags in v3:
- https://github.com/garden-co/jazz2/actions/runs/22743646365/job/65963958656

## Validation
- verified locally that `pnpm exec napi artifacts -d artifacts --npm-dir npm` stages platform binaries into generated npm package folders
- `git diff --check`