### PR TITLE
fix(release): use npm-dir with napi version

### DIFF
--- a/.github/workflows/publish-jazz-tools-alpha.yml
+++ b/.github/workflows/publish-jazz-tools-alpha.yml
@@ -427,7 +427,7 @@ jobs:
       - name: Sync jazz-napi platform package versions and optional deps
         run: |
           cd crates/jazz-napi
-          pnpm exec napi version -p npm
+          pnpm exec napi version --npm-dir npm
           node -e 'const fs=require("fs");const rootPath="package.json";const pkg=JSON.parse(fs.readFileSync(rootPath,"utf8"));const deps=[];for(const entry of fs.readdirSync("npm",{withFileTypes:true})){if(!entry.isDirectory())continue;const child=JSON.parse(fs.readFileSync(`npm/${entry.name}/package.json`,"utf8"));deps.push([child.name,pkg.version]);}deps.sort((a,b)=>a[0].localeCompare(b[0]));pkg.optionalDependencies=Object.fromEntries(deps);fs.writeFileSync(rootPath,`${JSON.stringify(pkg,null,2)}\n`);'
 
       - name: Guard alpha-only lock-stepped publish versions


### PR DESCRIPTION
## Summary
- replace the unsupported `-p npm` flag with `--npm-dir npm` for `pnpm exec napi version`
- keep the alpha publish workflow aligned with `@napi-rs/cli` v3 for the remaining version-sync step

## Why
The latest preview run got past the earlier `create-npm-dirs` and `artifacts` fixes, then failed in the next  v3-incompatible command:
- https://github.com/garden-co/jazz2/actions/runs/22747083115/job/65974447697

## Validation
- verified locally that `pnpm exec napi version --npm-dir npm` updates the generated per-platform package versions
- `git diff --check`