### PR TITLE
perf: parallelize alpha preview and release builds

### DIFF
--- a/.github/workflows/preview-jazz-tools-alpha-release.yml
+++ b/.github/workflows/preview-jazz-tools-alpha-release.yml
@@ -11,6 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
+  actions: read
   contents: read
   id-token: write
   pull-requests: read

--- a/.github/workflows/preview-jazz-tools-alpha-release.yml
+++ b/.github/workflows/preview-jazz-tools-alpha-release.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   mark-preview-pending:
     name: Mark release preview pending
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     if: startsWith(github.ref, 'refs/heads/changeset-release/')
     steps:
       - name: Set pending commit status
@@ -45,7 +45,7 @@ jobs:
 
   mark-preview-final:
     name: Mark release preview result
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     if: always() && startsWith(github.ref, 'refs/heads/changeset-release/')
     needs: [mark-preview-pending, preview]
     steps:

--- a/.github/workflows/publish-jazz-tools-alpha.yml
+++ b/.github/workflows/publish-jazz-tools-alpha.yml
@@ -31,7 +31,7 @@ on:
 jobs:
   release-push-gate:
     name: Gate release push trigger
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: read
       pull-requests: read
@@ -40,42 +40,74 @@ jobs:
       reason: ${{ steps.gate.outputs.reason }}
     steps:
       - id: gate
+        uses: actions/github-script@v8
         env:
           EVENT_NAME: ${{ github.event_name }}
           REF: ${{ github.ref }}
-          REPOSITORY: ${{ github.repository }}
           SHA: ${{ github.sha }}
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          if [ "${EVENT_NAME}" != "push" ]; then
-            echo "should_run=true" >> "${GITHUB_OUTPUT}"
-            echo "reason=non-push invocation (${EVENT_NAME})" >> "${GITHUB_OUTPUT}"
-            exit 0
-          fi
+        with:
+          script: |
+            const eventName = process.env.EVENT_NAME;
+            const ref = process.env.REF;
+            const sha = process.env.SHA;
+            let shouldRun = "false";
+            let reason = "";
 
-          if [ "${REF}" != "refs/heads/main" ]; then
-            echo "should_run=false" >> "${GITHUB_OUTPUT}"
-            echo "reason=push is not on main (${REF})" >> "${GITHUB_OUTPUT}"
-            exit 0
-          fi
+            if (eventName !== "push") {
+              shouldRun = "true";
+              reason = `non-push invocation (${eventName})`;
+            } else if (ref !== "refs/heads/main") {
+              shouldRun = "false";
+              reason = `push is not on main (${ref})`;
+            } else {
+              let matchSource = "commit pull association";
+              const associatedPulls = await github.request(
+                "GET /repos/{owner}/{repo}/commits/{commit_sha}/pulls",
+                {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  commit_sha: sha,
+                },
+              );
 
-          MATCH_SOURCE="commit pull association"
-          PR_NUMBER=$(gh api "repos/${REPOSITORY}/commits/${SHA}/pulls" --jq '.[] | select(.merged_at != null and .base.ref == "main" and (.head.ref | startswith("changeset-release/"))) | .number' 2>/dev/null | head -n 1 || true)
+              let releasePr = associatedPulls.data.find(
+                (pr) =>
+                  pr.merged_at !== null &&
+                  pr.base.ref === "main" &&
+                  pr.head.ref.startsWith("changeset-release/"),
+              );
 
-          # The commit->pull association endpoint can lag right after merge.
-          # Fallback to scanning recent merged PRs by merge_commit_sha.
-          if [ -z "${PR_NUMBER}" ]; then
-            MATCH_SOURCE="recent merged PR scan by merge_commit_sha"
-            PR_NUMBER=$(gh api "repos/${REPOSITORY}/pulls?state=closed&base=main&sort=updated&direction=desc&per_page=100" --jq ".[] | select(.merged_at != null and .merge_commit_sha == \"${SHA}\" and (.head.ref | startswith(\"changeset-release/\"))) | .number" 2>/dev/null | head -n 1 || true)
-          fi
+              if (!releasePr) {
+                matchSource = "recent merged PR scan by merge_commit_sha";
+                const mergedPulls = await github.paginate(github.rest.pulls.list, {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  state: "closed",
+                  base: "main",
+                  sort: "updated",
+                  direction: "desc",
+                  per_page: 100,
+                });
 
-          if [ -n "${PR_NUMBER}" ]; then
-            echo "should_run=true" >> "${GITHUB_OUTPUT}"
-            echo "reason=merged changeset release PR #${PR_NUMBER} (${MATCH_SOURCE})" >> "${GITHUB_OUTPUT}"
-          else
-            echo "should_run=false" >> "${GITHUB_OUTPUT}"
-            echo "reason=main push is not from a merged changeset-release/* PR" >> "${GITHUB_OUTPUT}"
-          fi
+                releasePr = mergedPulls.find(
+                  (pr) =>
+                    pr.merged_at !== null &&
+                    pr.merge_commit_sha === sha &&
+                    pr.head.ref.startsWith("changeset-release/"),
+                );
+              }
+
+              if (releasePr) {
+                shouldRun = "true";
+                reason = `merged changeset release PR #${releasePr.number} (${matchSource})`;
+              } else {
+                shouldRun = "false";
+                reason = "main push is not from a merged changeset-release/* PR";
+              }
+            }
+
+            core.setOutput("should_run", shouldRun);
+            core.setOutput("reason", reason);
 
       - name: Show gate decision
         run: |
@@ -84,9 +116,13 @@ jobs:
 
   build-linux:
     name: Build Linux (${{ matrix.arch }})
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: [release-push-gate]
     if: needs.release-push-gate.outputs.should_run == 'true'
+    env:
+      RUSTC_WRAPPER: sccache
+      SCCACHE_DIR: /home/runner/.cache/sccache
+      SCCACHE_CACHE_SIZE: 8G
     strategy:
       fail-fast: false
       matrix:
@@ -105,6 +141,20 @@ jobs:
         with:
           toolchain: 1.93.1
           targets: x86_64-unknown-linux-musl,aarch64-unknown-linux-musl
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: sccache
+
+      - name: Mount sccache sticky disk
+        uses: useblacksmith/stickydisk@v1
+        with:
+          key: release-cli-sccache-${{ github.repository_id }}-${{ matrix.target }}-v1
+          path: /home/runner/.cache/sccache
 
       - uses: goto-bus-stop/setup-zig@v2
         with:
@@ -151,6 +201,10 @@ jobs:
           toolchain: 1.93.1
           targets: aarch64-apple-darwin,x86_64-apple-darwin
 
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+
       - name: Build CLI binary
         run: cargo build -p jazz-tools --bin jazz-tools --features cli --release --target ${{ matrix.target }}
 
@@ -178,6 +232,10 @@ jobs:
           toolchain: 1.93.1
           targets: x86_64-pc-windows-msvc
 
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+
       - name: Build CLI binary
         run: cargo build -p jazz-tools --bin jazz-tools --features cli --release --target x86_64-pc-windows-msvc
 
@@ -192,6 +250,65 @@ jobs:
           name: jazz-tools-windows-x64
           path: dist/jazz-tools-windows-x64.exe
 
+  build-wasm:
+    name: Build jazz-wasm
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    needs: [release-push-gate]
+    if: needs.release-push-gate.outputs.should_run == 'true'
+    env:
+      RUSTC_WRAPPER: sccache
+      SCCACHE_DIR: /home/runner/.cache/sccache
+      SCCACHE_CACHE_SIZE: 8G
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - run: corepack enable
+      - run: pnpm install --frozen-lockfile
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.93.1
+          targets: wasm32-unknown-unknown
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-pack
+
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: sccache
+
+      - name: Mount sccache sticky disk
+        uses: useblacksmith/stickydisk@v1
+        with:
+          key: release-wasm-sccache-${{ github.repository_id }}-v1
+          path: /home/runner/.cache/sccache
+
+      - name: Build jazz-wasm npm package
+        run: pnpm --filter jazz-wasm build
+
+      - name: Verify built jazz-wasm publish artifacts
+        run: |
+          test -f crates/jazz-wasm/pkg/jazz_wasm_bg.wasm
+          test -f crates/jazz-wasm/pkg/jazz_wasm.js
+          test -f crates/jazz-wasm/pkg/jazz_wasm.d.ts
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: jazz-wasm-pkg
+          path: crates/jazz-wasm/pkg
+          if-no-files-found: error
+
   build-napi:
     name: Build jazz-napi (${{ matrix.platform }})
     runs-on: ${{ matrix.os }}
@@ -201,18 +318,22 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
+          - os: blacksmith-4vcpu-ubuntu-2404
             target: x86_64-unknown-linux-gnu
             platform: linux-x64-gnu
+            use_sccache: true
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             platform: win32-x64-msvc
+            use_sccache: false
           - os: macos-14
             target: x86_64-apple-darwin
             platform: darwin-x64
+            use_sccache: false
           - os: macos-14
             target: aarch64-apple-darwin
             platform: darwin-arm64
+            use_sccache: false
 
     steps:
       - uses: actions/checkout@v6
@@ -220,6 +341,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
+          cache: pnpm
 
       - run: corepack enable
       - run: pnpm install --frozen-lockfile
@@ -229,7 +351,32 @@ jobs:
           toolchain: 1.93.1
           targets: ${{ matrix.target }}
 
-      - name: Build jazz-napi binding
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+
+      - if: ${{ matrix.use_sccache }}
+        uses: taiki-e/install-action@v2
+        with:
+          tool: sccache
+
+      - if: ${{ matrix.use_sccache }}
+        name: Mount sccache sticky disk
+        uses: useblacksmith/stickydisk@v1
+        with:
+          key: release-napi-sccache-${{ github.repository_id }}-${{ matrix.platform }}-v1
+          path: /home/runner/.cache/sccache
+
+      - name: Build jazz-napi binding (Linux)
+        if: ${{ matrix.use_sccache }}
+        env:
+          RUSTC_WRAPPER: sccache
+          SCCACHE_DIR: /home/runner/.cache/sccache
+          SCCACHE_CACHE_SIZE: 8G
+        run: pnpm --filter jazz-napi exec napi build --platform --release --target ${{ matrix.target }}
+
+      - name: Build jazz-napi binding (macOS/Windows)
+        if: ${{ !matrix.use_sccache }}
         run: pnpm --filter jazz-napi exec napi build --platform --release --target ${{ matrix.target }}
 
       - uses: actions/upload-artifact@v4
@@ -238,11 +385,13 @@ jobs:
           path: crates/jazz-napi/jazz-napi.${{ matrix.platform }}.node
           if-no-files-found: error
 
-  build-rn-native:
-    name: Build jazz-rn native payload
+  build-rn-ios:
+    name: Build jazz-rn iOS payload
     runs-on: macos-14
     needs: [release-push-gate]
     if: needs.release-push-gate.outputs.should_run == 'true'
+    env:
+      HOMEBREW_NO_AUTO_UPDATE: 1
 
     steps:
       - uses: actions/checkout@v6
@@ -250,39 +399,112 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
+          cache: pnpm
 
       - run: corepack enable
       - run: pnpm install --frozen-lockfile
 
-      - name: Install/build React Native native prerequisites
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.93.1
+          targets: aarch64-apple-ios,aarch64-apple-ios-sim,x86_64-apple-ios
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+
+      - name: Install/build React Native iOS prerequisites
+        env:
+          JAZZ_RN_PLATFORM: ios
         run: pnpm run ensure:rust-toolchain
 
-      - name: Build jazz-rn iOS and Android native payloads
-        run: pnpm --filter jazz-rn build:rn
+      - name: Build jazz-rn iOS native payload
+        run: pnpm --filter jazz-rn build:rn:ios
 
-      - name: Verify built jazz-rn native payloads
+      - name: Verify built jazz-rn iOS native payload
         run: |
           test -d crates/jazz-rn/JazzRnFramework.xcframework
           test -f crates/jazz-rn/JazzRnFramework.xcframework/Info.plist
-          test -f crates/jazz-rn/android/src/main/jniLibs/arm64-v8a/libjazz_rn.a
-          test -f crates/jazz-rn/android/src/main/jniLibs/x86_64/libjazz_rn.a
 
-      - name: Stage jazz-rn native payload artifact
+      - name: Stage jazz-rn iOS payload artifact
         run: |
-          mkdir -p dist/rn-native
-          cp -R crates/jazz-rn/JazzRnFramework.xcframework dist/rn-native/
-          cp -R crates/jazz-rn/android/src/main/jniLibs dist/rn-native/
+          mkdir -p dist/rn-ios
+          cp -R crates/jazz-rn/JazzRnFramework.xcframework dist/rn-ios/
 
       - uses: actions/upload-artifact@v4
         with:
-          name: jazz-rn-native-payload
-          path: dist/rn-native
+          name: jazz-rn-ios-payload
+          path: dist/rn-ios
+          if-no-files-found: error
+
+  build-rn-android:
+    name: Build jazz-rn Android payload
+    runs-on: macos-14
+    needs: [release-push-gate]
+    if: needs.release-push-gate.outputs.should_run == 'true'
+    env:
+      HOMEBREW_NO_AUTO_UPDATE: 1
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - run: corepack enable
+      - run: pnpm install --frozen-lockfile
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.93.1
+          targets: aarch64-linux-android,armv7-linux-androideabi,i686-linux-android,x86_64-linux-android
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-ndk
+
+      - name: Install/build React Native Android prerequisites
+        env:
+          JAZZ_RN_PLATFORM: android
+        run: pnpm run ensure:rust-toolchain
+
+      - name: Build jazz-rn Android native payload
+        run: pnpm --filter jazz-rn build:rn:android
+
+      - name: Verify built jazz-rn Android native payload
+        run: |
+          test -f crates/jazz-rn/android/src/main/jniLibs/arm64-v8a/libjazz_rn.a
+          test -f crates/jazz-rn/android/src/main/jniLibs/x86_64/libjazz_rn.a
+
+      - name: Stage jazz-rn Android payload artifact
+        run: |
+          mkdir -p dist/rn-android
+          cp -R crates/jazz-rn/android/src/main/jniLibs dist/rn-android/
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: jazz-rn-android-payload
+          path: dist/rn-android
           if-no-files-found: error
 
   publish-npm:
     name: Publish npm alpha
-    runs-on: ubuntu-latest
-    needs: [release-push-gate, build-linux, build-macos, build-windows, build-napi, build-rn-native]
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    needs:
+      - release-push-gate
+      - build-linux
+      - build-macos
+      - build-windows
+      - build-wasm
+      - build-napi
+      - build-rn-ios
+      - build-rn-android
     if: needs.release-push-gate.outputs.should_run == 'true'
     permissions:
       contents: read
@@ -297,24 +519,22 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
+          cache: pnpm
           registry-url: https://registry.npmjs.org
 
       - run: corepack enable
       - run: pnpm install --frozen-lockfile
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/download-artifact@v4
         with:
-          toolchain: 1.93.1
-          targets: wasm32-unknown-unknown
-
-      - uses: taiki-e/install-action@v2
-        with:
-          tool: wasm-pack
+          pattern: jazz-tools-*
+          path: dist
+          merge-multiple: true
 
       - uses: actions/download-artifact@v4
         with:
-          path: dist
-          merge-multiple: true
+          name: jazz-wasm-pkg
+          path: crates/jazz-wasm/pkg
 
       - uses: actions/download-artifact@v4
         with:
@@ -324,16 +544,21 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          name: jazz-rn-native-payload
-          path: dist/rn-native
+          name: jazz-rn-ios-payload
+          path: dist/rn-ios
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: jazz-rn-android-payload
+          path: dist/rn-android
 
       - name: Stage jazz-rn native payload into npm package sources
         run: |
           rm -rf crates/jazz-rn/JazzRnFramework.xcframework
           rm -rf crates/jazz-rn/android/src/main/jniLibs
           mkdir -p crates/jazz-rn/android/src/main
-          cp -R dist/rn-native/JazzRnFramework.xcframework crates/jazz-rn/
-          cp -R dist/rn-native/jniLibs crates/jazz-rn/android/src/main/
+          cp -R dist/rn-ios/JazzRnFramework.xcframework crates/jazz-rn/
+          cp -R dist/rn-android/jniLibs crates/jazz-rn/android/src/main/
 
       - name: Show release mode
         run: |
@@ -345,9 +570,6 @@ jobs:
               ;;
           esac
           echo "Release mode: ${RELEASE_MODE}"
-
-      - name: Build jazz-wasm npm package
-        run: pnpm --filter jazz-wasm build
 
       - name: Verify jazz-wasm publish artifacts
         run: |

--- a/.github/workflows/publish-jazz-tools-alpha.yml
+++ b/.github/workflows/publish-jazz-tools-alpha.yml
@@ -251,11 +251,17 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.14.0
+          run_install: false
+
       - uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
 
-      - run: corepack enable
       - run: pnpm install --frozen-lockfile
 
       - uses: dtolnay/rust-toolchain@stable
@@ -325,11 +331,17 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.14.0
+          run_install: false
+
       - uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
 
-      - run: corepack enable
       - run: pnpm install --frozen-lockfile
 
       - uses: dtolnay/rust-toolchain@stable
@@ -382,11 +394,17 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.14.0
+          run_install: false
+
       - uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
 
-      - run: corepack enable
       - run: pnpm install --frozen-lockfile
 
       - uses: dtolnay/rust-toolchain@stable
@@ -443,11 +461,17 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.14.0
+          run_install: false
+
       - uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
 
-      - run: corepack enable
       - run: pnpm install --frozen-lockfile
 
       - uses: dtolnay/rust-toolchain@stable
@@ -508,12 +532,18 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.14.0
+          run_install: false
+
       - uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
           registry-url: https://registry.npmjs.org
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
 
-      - run: corepack enable
       - run: pnpm install --frozen-lockfile
 
       - uses: actions/download-artifact@v4

--- a/.github/workflows/publish-jazz-tools-alpha.yml
+++ b/.github/workflows/publish-jazz-tools-alpha.yml
@@ -38,6 +38,9 @@ jobs:
     outputs:
       should_run: ${{ steps.gate.outputs.should_run }}
       reason: ${{ steps.gate.outputs.reason }}
+      release_pr_number: ${{ steps.gate.outputs.release_pr_number }}
+      release_pr_head_ref: ${{ steps.gate.outputs.release_pr_head_ref }}
+      release_pr_head_sha: ${{ steps.gate.outputs.release_pr_head_sha }}
     steps:
       - id: gate
         uses: actions/github-script@v8
@@ -52,6 +55,9 @@ jobs:
             const sha = process.env.SHA;
             let shouldRun = "false";
             let reason = "";
+            let releasePrNumber = "";
+            let releasePrHeadRef = "";
+            let releasePrHeadSha = "";
 
             if (eventName !== "push") {
               shouldRun = "true";
@@ -100,6 +106,9 @@ jobs:
               if (releasePr) {
                 shouldRun = "true";
                 reason = `merged changeset release PR #${releasePr.number} (${matchSource})`;
+                releasePrNumber = String(releasePr.number);
+                releasePrHeadRef = releasePr.head.ref;
+                releasePrHeadSha = releasePr.head.sha;
               } else {
                 shouldRun = "false";
                 reason = "main push is not from a merged changeset-release/* PR";
@@ -108,17 +117,171 @@ jobs:
 
             core.setOutput("should_run", shouldRun);
             core.setOutput("reason", reason);
+            core.setOutput("release_pr_number", releasePrNumber);
+            core.setOutput("release_pr_head_ref", releasePrHeadRef);
+            core.setOutput("release_pr_head_sha", releasePrHeadSha);
 
       - name: Show gate decision
         run: |
           echo "should_run=${{ steps.gate.outputs.should_run }}"
           echo "reason=${{ steps.gate.outputs.reason }}"
+          echo "release_pr_number=${{ steps.gate.outputs.release_pr_number }}"
+          echo "release_pr_head_ref=${{ steps.gate.outputs.release_pr_head_ref }}"
+          echo "release_pr_head_sha=${{ steps.gate.outputs.release_pr_head_sha }}"
+
+  resolve-preview-artifacts:
+    name: Resolve preview artifact source
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    needs: [release-push-gate]
+    if: needs.release-push-gate.outputs.should_run == 'true'
+    permissions:
+      actions: read
+      contents: read
+    outputs:
+      use_preview_artifacts: ${{ steps.resolve.outputs.use_preview_artifacts }}
+      preview_run_id: ${{ steps.resolve.outputs.preview_run_id }}
+      reason: ${{ steps.resolve.outputs.reason }}
+    steps:
+      - id: resolve
+        uses: actions/github-script@v8
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF: ${{ github.ref }}
+          SHA: ${{ github.sha }}
+          RELEASE_MODE: ${{ inputs.mode || github.event.inputs.mode || 'publish' }}
+          RELEASE_PR_NUMBER: ${{ needs.release-push-gate.outputs.release_pr_number }}
+          RELEASE_PR_HEAD_REF: ${{ needs.release-push-gate.outputs.release_pr_head_ref }}
+          RELEASE_PR_HEAD_SHA: ${{ needs.release-push-gate.outputs.release_pr_head_sha }}
+        with:
+          script: |
+            const eventName = process.env.EVENT_NAME;
+            const ref = process.env.REF;
+            const sha = process.env.SHA;
+            const releaseMode = process.env.RELEASE_MODE;
+            const releasePrNumber = process.env.RELEASE_PR_NUMBER;
+            const releasePrHeadRef = process.env.RELEASE_PR_HEAD_REF;
+            const releasePrHeadSha = process.env.RELEASE_PR_HEAD_SHA;
+            let usePreviewArtifacts = "false";
+            let previewRunId = "";
+            let reason = "";
+
+            if (releaseMode !== "publish") {
+              reason = `preview artifact reuse disabled for mode=${releaseMode}`;
+            } else if (eventName !== "push" || ref !== "refs/heads/main") {
+              reason = `preview artifact reuse disabled for ${eventName} on ${ref}`;
+            } else if (!releasePrNumber || !releasePrHeadRef || !releasePrHeadSha) {
+              reason = "release PR metadata unavailable for artifact reuse";
+            } else {
+              const owner = context.repo.owner;
+              const repo = context.repo.repo;
+              const [mergeCommit, previewCommit] = await Promise.all([
+                github.rest.git.getCommit({
+                  owner,
+                  repo,
+                  commit_sha: sha,
+                }),
+                github.rest.git.getCommit({
+                  owner,
+                  repo,
+                  commit_sha: releasePrHeadSha,
+                }),
+              ]);
+
+              const mergeTree = mergeCommit.data.tree.sha;
+              const previewTree = previewCommit.data.tree.sha;
+
+              if (mergeTree !== previewTree) {
+                reason = `main merge tree ${mergeTree} differs from release PR head tree ${previewTree}`;
+              } else {
+                const runs = await github.paginate(
+                  github.rest.actions.listWorkflowRuns,
+                  {
+                    owner,
+                    repo,
+                    workflow_id: "preview-jazz-tools-alpha-release.yml",
+                    branch: releasePrHeadRef,
+                    per_page: 100,
+                  },
+                  (response) => response.data.workflow_runs,
+                );
+
+                const previewRun = runs
+                  .filter(
+                    (run) =>
+                      run.head_sha === releasePrHeadSha &&
+                      run.status === "completed" &&
+                      run.conclusion === "success",
+                  )
+                  .sort(
+                    (a, b) =>
+                      new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
+                  )[0];
+
+                if (!previewRun) {
+                  reason = `no successful preview run found for ${releasePrHeadRef}@${releasePrHeadSha}`;
+                } else {
+                  const artifacts = await github.paginate(
+                    github.rest.actions.listWorkflowRunArtifacts,
+                    {
+                      owner,
+                      repo,
+                      run_id: previewRun.id,
+                      per_page: 100,
+                    },
+                    (response) => response.data.artifacts,
+                  );
+
+                  const requiredArtifacts = [
+                    "jazz-tools-darwin-arm64",
+                    "jazz-tools-darwin-x64",
+                    "jazz-tools-linux-arm64",
+                    "jazz-tools-linux-x64",
+                    "jazz-tools-windows-x64",
+                    "jazz-wasm-pkg",
+                    "jazz-napi-binding-darwin-arm64",
+                    "jazz-napi-binding-darwin-x64",
+                    "jazz-napi-binding-linux-x64-gnu",
+                    "jazz-napi-binding-win32-x64-msvc",
+                    "jazz-rn-ios-payload",
+                    "jazz-rn-android-payload-arm64-v8a",
+                    "jazz-rn-android-payload-armeabi-v7a",
+                    "jazz-rn-android-payload-x86",
+                    "jazz-rn-android-payload-x86_64",
+                  ];
+
+                  const availableArtifacts = new Set(
+                    artifacts.filter((artifact) => !artifact.expired).map((artifact) => artifact.name),
+                  );
+                  const missingArtifacts = requiredArtifacts.filter(
+                    (artifactName) => !availableArtifacts.has(artifactName),
+                  );
+
+                  if (missingArtifacts.length > 0) {
+                    reason = `preview run ${previewRun.id} is missing artifacts: ${missingArtifacts.join(", ")}`;
+                  } else {
+                    usePreviewArtifacts = "true";
+                    previewRunId = String(previewRun.id);
+                    reason = `reusing preview artifacts from run ${previewRun.id} for PR #${releasePrNumber}`;
+                  }
+                }
+              }
+            }
+
+            core.setOutput("use_preview_artifacts", usePreviewArtifacts);
+            core.setOutput("preview_run_id", previewRunId);
+            core.setOutput("reason", reason);
+
+      - name: Show artifact reuse decision
+        run: |
+          echo "use_preview_artifacts=${{ steps.resolve.outputs.use_preview_artifacts }}"
+          echo "preview_run_id=${{ steps.resolve.outputs.preview_run_id }}"
+          echo "reason=${{ steps.resolve.outputs.reason }}"
 
   build-linux:
     name: Build CLI Linux (${{ matrix.arch }})
     runs-on: ubuntu-24.04
-    needs: [release-push-gate]
-    if: needs.release-push-gate.outputs.should_run == 'true'
+    needs: [release-push-gate, resolve-preview-artifacts]
+    if: needs.release-push-gate.outputs.should_run == 'true' && needs.resolve-preview-artifacts.outputs.use_preview_artifacts != 'true'
     env:
       CARGO_ZIGBUILD_CACHE_DIR: /tmp/cargo-zigbuild-cache
     strategy:
@@ -168,8 +331,8 @@ jobs:
   build-macos:
     name: Build CLI macOS (${{ matrix.arch }})
     runs-on: macos-14
-    needs: [release-push-gate]
-    if: needs.release-push-gate.outputs.should_run == 'true'
+    needs: [release-push-gate, resolve-preview-artifacts]
+    if: needs.release-push-gate.outputs.should_run == 'true' && needs.resolve-preview-artifacts.outputs.use_preview_artifacts != 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -209,8 +372,8 @@ jobs:
   build-windows:
     name: Build CLI Windows (x64)
     runs-on: windows-latest
-    needs: [release-push-gate]
-    if: needs.release-push-gate.outputs.should_run == 'true'
+    needs: [release-push-gate, resolve-preview-artifacts]
+    if: needs.release-push-gate.outputs.should_run == 'true' && needs.resolve-preview-artifacts.outputs.use_preview_artifacts != 'true'
 
     steps:
       - uses: actions/checkout@v6
@@ -241,8 +404,8 @@ jobs:
   build-wasm:
     name: Build jazz-wasm
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    needs: [release-push-gate]
-    if: needs.release-push-gate.outputs.should_run == 'true'
+    needs: [release-push-gate, resolve-preview-artifacts]
+    if: needs.release-push-gate.outputs.should_run == 'true' && needs.resolve-preview-artifacts.outputs.use_preview_artifacts != 'true'
     env:
       RUSTC_WRAPPER: sccache
       SCCACHE_DIR: /home/runner/.cache/sccache
@@ -305,8 +468,8 @@ jobs:
   build-napi:
     name: Build jazz-napi (${{ matrix.platform }})
     runs-on: ${{ matrix.os }}
-    needs: [release-push-gate]
-    if: needs.release-push-gate.outputs.should_run == 'true'
+    needs: [release-push-gate, resolve-preview-artifacts]
+    if: needs.release-push-gate.outputs.should_run == 'true' && needs.resolve-preview-artifacts.outputs.use_preview_artifacts != 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -386,8 +549,8 @@ jobs:
   build-rn-ios:
     name: Build jazz-rn iOS payload
     runs-on: macos-14
-    needs: [release-push-gate]
-    if: needs.release-push-gate.outputs.should_run == 'true'
+    needs: [release-push-gate, resolve-preview-artifacts]
+    if: needs.release-push-gate.outputs.should_run == 'true' && needs.resolve-preview-artifacts.outputs.use_preview_artifacts != 'true'
     env:
       HOMEBREW_NO_AUTO_UPDATE: 1
 
@@ -443,8 +606,8 @@ jobs:
   build-rn-android:
     name: Build jazz-rn Android payload (${{ matrix.abi }})
     runs-on: ubuntu-24.04
-    needs: [release-push-gate]
-    if: needs.release-push-gate.outputs.should_run == 'true'
+    needs: [release-push-gate, resolve-preview-artifacts]
+    if: needs.release-push-gate.outputs.should_run == 'true' && needs.resolve-preview-artifacts.outputs.use_preview_artifacts != 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -514,6 +677,7 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     needs:
       - release-push-gate
+      - resolve-preview-artifacts
       - build-linux
       - build-macos
       - build-windows
@@ -521,8 +685,23 @@ jobs:
       - build-napi
       - build-rn-ios
       - build-rn-android
-    if: needs.release-push-gate.outputs.should_run == 'true'
+    if: >-
+      always() &&
+      needs.release-push-gate.outputs.should_run == 'true' &&
+      (
+        needs.resolve-preview-artifacts.outputs.use_preview_artifacts == 'true' ||
+        (
+          needs.build-linux.result == 'success' &&
+          needs.build-macos.result == 'success' &&
+          needs.build-windows.result == 'success' &&
+          needs.build-wasm.result == 'success' &&
+          needs.build-napi.result == 'success' &&
+          needs.build-rn-ios.result == 'success' &&
+          needs.build-rn-android.result == 'success'
+        )
+      )
     permissions:
+      actions: read
       contents: read
       id-token: write
     env:
@@ -546,30 +725,92 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - uses: actions/download-artifact@v4
+      - name: Show artifact source
+        run: |
+          if [ "${{ needs.resolve-preview-artifacts.outputs.use_preview_artifacts }}" = "true" ]; then
+            echo "Artifact source: preview run ${{ needs.resolve-preview-artifacts.outputs.preview_run_id }}"
+          else
+            echo "Artifact source: current workflow run"
+          fi
+          echo "Artifact decision reason: ${{ needs.resolve-preview-artifacts.outputs.reason }}"
+
+      - uses: actions/download-artifact@v5
+        if: needs.resolve-preview-artifacts.outputs.use_preview_artifacts != 'true'
         with:
           pattern: jazz-tools-*
           path: dist
           merge-multiple: true
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
+        if: needs.resolve-preview-artifacts.outputs.use_preview_artifacts != 'true'
         with:
           name: jazz-wasm-pkg
           path: crates/jazz-wasm/pkg
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
+        if: needs.resolve-preview-artifacts.outputs.use_preview_artifacts != 'true'
         with:
           pattern: jazz-napi-binding-*
           path: crates/jazz-napi/artifacts
           merge-multiple: true
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
+        if: needs.resolve-preview-artifacts.outputs.use_preview_artifacts != 'true'
         with:
           name: jazz-rn-ios-payload
           path: dist/rn-ios
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
+        if: needs.resolve-preview-artifacts.outputs.use_preview_artifacts != 'true'
         with:
+          pattern: jazz-rn-android-payload-*
+          path: dist/rn-android
+          merge-multiple: true
+
+      - uses: actions/download-artifact@v5
+        if: needs.resolve-preview-artifacts.outputs.use_preview_artifacts == 'true'
+        with:
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ needs.resolve-preview-artifacts.outputs.preview_run_id }}
+          pattern: jazz-tools-*
+          path: dist
+          merge-multiple: true
+
+      - uses: actions/download-artifact@v5
+        if: needs.resolve-preview-artifacts.outputs.use_preview_artifacts == 'true'
+        with:
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ needs.resolve-preview-artifacts.outputs.preview_run_id }}
+          name: jazz-wasm-pkg
+          path: crates/jazz-wasm/pkg
+
+      - uses: actions/download-artifact@v5
+        if: needs.resolve-preview-artifacts.outputs.use_preview_artifacts == 'true'
+        with:
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ needs.resolve-preview-artifacts.outputs.preview_run_id }}
+          pattern: jazz-napi-binding-*
+          path: crates/jazz-napi/artifacts
+          merge-multiple: true
+
+      - uses: actions/download-artifact@v5
+        if: needs.resolve-preview-artifacts.outputs.use_preview_artifacts == 'true'
+        with:
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ needs.resolve-preview-artifacts.outputs.preview_run_id }}
+          name: jazz-rn-ios-payload
+          path: dist/rn-ios
+
+      - uses: actions/download-artifact@v5
+        if: needs.resolve-preview-artifacts.outputs.use_preview_artifacts == 'true'
+        with:
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ needs.resolve-preview-artifacts.outputs.preview_run_id }}
           pattern: jazz-rn-android-payload-*
           path: dist/rn-android
           merge-multiple: true

--- a/.github/workflows/publish-jazz-tools-alpha.yml
+++ b/.github/workflows/publish-jazz-tools-alpha.yml
@@ -115,7 +115,7 @@ jobs:
           echo "reason=${{ steps.gate.outputs.reason }}"
 
   build-linux:
-    name: Build Linux (${{ matrix.arch }})
+    name: Build CLI Linux (${{ matrix.arch }})
     runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: [release-push-gate]
     if: needs.release-push-gate.outputs.should_run == 'true'
@@ -123,6 +123,7 @@ jobs:
       RUSTC_WRAPPER: sccache
       SCCACHE_DIR: /home/runner/.cache/sccache
       SCCACHE_CACHE_SIZE: 8G
+      CARGO_ZIGBUILD_CACHE_DIR: /tmp/cargo-zigbuild-cache
     strategy:
       fail-fast: false
       matrix:
@@ -178,7 +179,7 @@ jobs:
           path: dist/${{ matrix.output }}
 
   build-macos:
-    name: Build macOS (${{ matrix.arch }})
+    name: Build CLI macOS (${{ matrix.arch }})
     runs-on: macos-14
     needs: [release-push-gate]
     if: needs.release-push-gate.outputs.should_run == 'true'
@@ -219,7 +220,7 @@ jobs:
           path: dist/${{ matrix.output }}
 
   build-windows:
-    name: Build Windows (x64)
+    name: Build CLI Windows (x64)
     runs-on: windows-latest
     needs: [release-push-gate]
     if: needs.release-push-gate.outputs.should_run == 'true'
@@ -266,7 +267,6 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
-          cache: pnpm
 
       - run: corepack enable
       - run: pnpm install --frozen-lockfile
@@ -341,7 +341,6 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
-          cache: pnpm
 
       - run: corepack enable
       - run: pnpm install --frozen-lockfile
@@ -399,7 +398,6 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
-          cache: pnpm
 
       - run: corepack enable
       - run: pnpm install --frozen-lockfile
@@ -451,7 +449,6 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
-          cache: pnpm
 
       - run: corepack enable
       - run: pnpm install --frozen-lockfile
@@ -519,7 +516,6 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
-          cache: pnpm
           registry-url: https://registry.npmjs.org
 
       - run: corepack enable

--- a/.github/workflows/publish-jazz-tools-alpha.yml
+++ b/.github/workflows/publish-jazz-tools-alpha.yml
@@ -116,13 +116,10 @@ jobs:
 
   build-linux:
     name: Build CLI Linux (${{ matrix.arch }})
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     needs: [release-push-gate]
     if: needs.release-push-gate.outputs.should_run == 'true'
     env:
-      RUSTC_WRAPPER: sccache
-      SCCACHE_DIR: /home/runner/.cache/sccache
-      SCCACHE_CACHE_SIZE: 8G
       CARGO_ZIGBUILD_CACHE_DIR: /tmp/cargo-zigbuild-cache
     strategy:
       fail-fast: false
@@ -146,16 +143,6 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
-
-      - uses: taiki-e/install-action@v2
-        with:
-          tool: sccache
-
-      - name: Mount sccache sticky disk
-        uses: useblacksmith/stickydisk@v1
-        with:
-          key: release-cli-sccache-${{ github.repository_id }}-${{ matrix.target }}-v1
-          path: /home/runner/.cache/sccache
 
       - uses: goto-bus-stop/setup-zig@v2
         with:
@@ -436,12 +423,22 @@ jobs:
           if-no-files-found: error
 
   build-rn-android:
-    name: Build jazz-rn Android payload
-    runs-on: macos-14
+    name: Build jazz-rn Android payload (${{ matrix.abi }})
+    runs-on: ubuntu-24.04
     needs: [release-push-gate]
     if: needs.release-push-gate.outputs.should_run == 'true'
-    env:
-      HOMEBREW_NO_AUTO_UPDATE: 1
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: aarch64-linux-android
+            abi: arm64-v8a
+          - target: armv7-linux-androideabi
+            abi: armeabi-v7a
+          - target: i686-linux-android
+            abi: x86
+          - target: x86_64-linux-android
+            abi: x86_64
 
     steps:
       - uses: actions/checkout@v6
@@ -456,7 +453,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: 1.93.1
-          targets: aarch64-linux-android,armv7-linux-androideabi,i686-linux-android,x86_64-linux-android
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -469,24 +465,23 @@ jobs:
       - name: Install/build React Native Android prerequisites
         env:
           JAZZ_RN_PLATFORM: android
+          JAZZ_RN_ANDROID_TARGETS: ${{ matrix.target }}
         run: pnpm run ensure:rust-toolchain
 
       - name: Build jazz-rn Android native payload
-        run: pnpm --filter jazz-rn build:rn:android
+        run: pnpm --filter jazz-rn exec ubrn build android --targets ${{ matrix.target }} --and-generate --release
 
       - name: Verify built jazz-rn Android native payload
-        run: |
-          test -f crates/jazz-rn/android/src/main/jniLibs/arm64-v8a/libjazz_rn.a
-          test -f crates/jazz-rn/android/src/main/jniLibs/x86_64/libjazz_rn.a
+        run: test -f crates/jazz-rn/android/src/main/jniLibs/${{ matrix.abi }}/libjazz_rn.a
 
       - name: Stage jazz-rn Android payload artifact
         run: |
-          mkdir -p dist/rn-android
-          cp -R crates/jazz-rn/android/src/main/jniLibs dist/rn-android/
+          mkdir -p dist/rn-android/jniLibs
+          cp -R crates/jazz-rn/android/src/main/jniLibs/${{ matrix.abi }} dist/rn-android/jniLibs/
 
       - uses: actions/upload-artifact@v4
         with:
-          name: jazz-rn-android-payload
+          name: jazz-rn-android-payload-${{ matrix.abi }}
           path: dist/rn-android
           if-no-files-found: error
 
@@ -545,8 +540,9 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          name: jazz-rn-android-payload
+          pattern: jazz-rn-android-payload-*
           path: dist/rn-android
+          merge-multiple: true
 
       - name: Stage jazz-rn native payload into npm package sources
         run: |
@@ -726,8 +722,8 @@ jobs:
             exit 1
           }
 
-          # Ensure key Android native slices are present for Expo/RN Android consumers.
-          for abi in arm64-v8a x86_64; do
+          # Ensure Android native slices are present for Expo/RN Android consumers.
+          for abi in arm64-v8a armeabi-v7a x86 x86_64; do
             grep -q "^package/android/src/main/jniLibs/${abi}/libjazz_rn\\.a$" "${LISTING}" || {
               echo "Missing Android native library for ABI ${abi} in packed jazz-rn tarball."
               exit 1

--- a/scripts/install-jazz-rn-deps.sh
+++ b/scripts/install-jazz-rn-deps.sh
@@ -7,6 +7,7 @@ export RUSTUP_HOME="${RUSTUP_HOME:-$HOME/.rustup}"
 export PATH="$CARGO_HOME/bin:$PATH"
 JAZZ_SKIP_RN_DEPS="${JAZZ_SKIP_RN_DEPS:-0}"
 JAZZ_RN_PLATFORM="${JAZZ_RN_PLATFORM:-all}"
+JAZZ_RN_ANDROID_TARGETS="${JAZZ_RN_ANDROID_TARGETS:-aarch64-linux-android armv7-linux-androideabi i686-linux-android x86_64-linux-android}"
 RUST_TOOLCHAIN="${JAZZ_RUST_TOOLCHAIN:-1.93.1}"
 
 is_truthy() {
@@ -67,12 +68,11 @@ if is_truthy "$JAZZ_SKIP_RN_DEPS"; then
 fi
 
 if [[ "$JAZZ_RN_PLATFORM" == "all" || "$JAZZ_RN_PLATFORM" == "android" ]]; then
-  rustup target add \
-    aarch64-linux-android \
-    armv7-linux-androideabi \
-    i686-linux-android \
-    x86_64-linux-android \
-    --toolchain "$RUST_TOOLCHAIN"
+  # Split Android CI jobs can scope bootstrap to a single target to avoid
+  # reinstalling every ABI's toolchain on each runner.
+  # shellcheck disable=SC2206
+  android_targets=($JAZZ_RN_ANDROID_TARGETS)
+  rustup target add "${android_targets[@]}" --toolchain "$RUST_TOOLCHAIN"
 fi
 
 if [[ "$JAZZ_RN_PLATFORM" == "all" || "$JAZZ_RN_PLATFORM" == "android" ]]; then

--- a/scripts/install-jazz-rn-deps.sh
+++ b/scripts/install-jazz-rn-deps.sh
@@ -6,6 +6,7 @@ export CARGO_HOME="${CARGO_HOME:-$HOME/.cargo}"
 export RUSTUP_HOME="${RUSTUP_HOME:-$HOME/.rustup}"
 export PATH="$CARGO_HOME/bin:$PATH"
 JAZZ_SKIP_RN_DEPS="${JAZZ_SKIP_RN_DEPS:-0}"
+JAZZ_RN_PLATFORM="${JAZZ_RN_PLATFORM:-all}"
 RUST_TOOLCHAIN="${JAZZ_RUST_TOOLCHAIN:-1.93.1}"
 
 is_truthy() {
@@ -26,6 +27,15 @@ ensure_wrapper_command_exists() {
   fi
 }
 
+install_brew_formula_if_missing() {
+  local command_name="$1"
+  local formula="$2"
+
+  if ! command -v "$command_name" >/dev/null 2>&1; then
+    brew install "$formula"
+  fi
+}
+
 if [[ -n "${RUSTC_WRAPPER:-}" ]]; then
   ensure_wrapper_command_exists "RUSTC_WRAPPER" "$RUSTC_WRAPPER"
 fi
@@ -42,21 +52,33 @@ rustup toolchain install "$RUST_TOOLCHAIN"
 rustup default "$RUST_TOOLCHAIN"
 rustup target add wasm32-unknown-unknown --toolchain "$RUST_TOOLCHAIN"
 
+case "$JAZZ_RN_PLATFORM" in
+  all | ios | android) ;;
+  *)
+    echo "Unsupported JAZZ_RN_PLATFORM: ${JAZZ_RN_PLATFORM}" >&2
+    exit 1
+    ;;
+esac
+
 if is_truthy "$JAZZ_SKIP_RN_DEPS"; then
   echo "Skipping React Native dependency bootstrap (JAZZ_SKIP_RN_DEPS=$JAZZ_SKIP_RN_DEPS)."
   echo "Jazz prerequisites installed."
   exit 0
 fi
 
-rustup target add \
-  aarch64-linux-android \
-  armv7-linux-androideabi \
-  i686-linux-android \
-  x86_64-linux-android \
-  --toolchain "$RUST_TOOLCHAIN"
+if [[ "$JAZZ_RN_PLATFORM" == "all" || "$JAZZ_RN_PLATFORM" == "android" ]]; then
+  rustup target add \
+    aarch64-linux-android \
+    armv7-linux-androideabi \
+    i686-linux-android \
+    x86_64-linux-android \
+    --toolchain "$RUST_TOOLCHAIN"
+fi
 
-if ! command -v cargo-ndk >/dev/null 2>&1; then
-  cargo install cargo-ndk --locked
+if [[ "$JAZZ_RN_PLATFORM" == "all" || "$JAZZ_RN_PLATFORM" == "android" ]]; then
+  if ! command -v cargo-ndk >/dev/null 2>&1; then
+    cargo install cargo-ndk --locked
+  fi
 fi
 
 case "$(uname -s)" in
@@ -66,7 +88,12 @@ case "$(uname -s)" in
       exit 1
     fi
 
-    brew install cmake ninja clang-format
+    install_brew_formula_if_missing cmake cmake
+    install_brew_formula_if_missing ninja ninja
+
+    if [[ "$JAZZ_RN_PLATFORM" == "all" ]]; then
+      install_brew_formula_if_missing clang-format clang-format
+    fi
 
     if ! xcode-select -p >/dev/null 2>&1; then
       xcode-select --install || true
@@ -74,16 +101,31 @@ case "$(uname -s)" in
       exit 1
     fi
 
-    rustup target add aarch64-apple-ios aarch64-apple-ios-sim x86_64-apple-ios --toolchain "$RUST_TOOLCHAIN"
+    if [[ "$JAZZ_RN_PLATFORM" == "all" || "$JAZZ_RN_PLATFORM" == "ios" ]]; then
+      rustup target add aarch64-apple-ios aarch64-apple-ios-sim x86_64-apple-ios --toolchain "$RUST_TOOLCHAIN"
+    fi
     ;;
   Linux)
+    if [[ "$JAZZ_RN_PLATFORM" == "ios" ]]; then
+      echo "iOS prerequisites require macOS." >&2
+      exit 1
+    fi
+
     if command -v apt-get >/dev/null 2>&1; then
       if command -v sudo >/dev/null 2>&1; then
         sudo apt-get update
-        sudo apt-get install -y cmake ninja-build clang-format
+        if [[ "$JAZZ_RN_PLATFORM" == "all" ]]; then
+          sudo apt-get install -y cmake ninja-build clang-format
+        else
+          sudo apt-get install -y cmake ninja-build
+        fi
       else
         apt-get update
-        apt-get install -y cmake ninja-build clang-format
+        if [[ "$JAZZ_RN_PLATFORM" == "all" ]]; then
+          apt-get install -y cmake ninja-build clang-format
+        else
+          apt-get install -y cmake ninja-build
+        fi
       fi
     else
       echo "Install cmake, ninja and clang-format with your package manager, then re-run this script." >&2


### PR DESCRIPTION
## Summary
- move Linux release and preview jobs onto Blacksmith and add release-path Rust/pnpm caching
- split the React Native payload build into parallel iOS and Android jobs
- build `jazz-wasm` in its own job and download it as an artifact in the final publish step
- make the RN dependency bootstrap platform-aware so each job installs only the targets and tools it actually needs

## Why
- the RN macOS job was the critical path because iOS and Android native builds ran serially in one job
- the final publish job still spent extra time building `jazz-wasm` after every other artifact had already completed
- Linux and Windows release jobs were doing cold Rust builds with little reuse across runs

## Validation
- `bash -n scripts/install-jazz-rn-deps.sh`
- `ruby -e 'require "yaml"; [".github/workflows/publish-jazz-tools-alpha.yml", ".github/workflows/preview-jazz-tools-alpha-release.yml"].each { |f| YAML.load_file(f) }'`
- `git diff --check`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest ...` (only reported the expected custom Blacksmith runner-label warnings)
