### PR TITLE
feat: return inserted row on `db.insert`

### DIFF
--- a/.changeset/quick-coins-smoke.md
+++ b/.changeset/quick-coins-smoke.md
@@ -1,0 +1,8 @@
+---
+"jazz-tools": patch
+"jazz-napi": patch
+"jazz-wasm": patch
+"jazz-rn": patch
+---
+
+Modify inserts to return the inserted row instead of just the id

--- a/crates/jazz-cloud-server/src/server.rs
+++ b/crates/jazz-cloud-server/src/server.rs
@@ -1254,7 +1254,7 @@ impl MetaStore {
             })
             .collect();
 
-        let object_id = self
+        let (object_id, _row_values) = self
             .runtime
             .insert("apps", values, None)
             .map_err(|e| format!("failed to insert meta app record: {e}"))?;

--- a/crates/jazz-cloud-server/tests/client_multi_integration.rs
+++ b/crates/jazz-cloud-server/tests/client_multi_integration.rs
@@ -438,7 +438,7 @@ async fn jazz_tools_clients_sync_queries_and_mutations_over_cloud_server() {
     // Ensure query path is fully ready before asserting cross-client sync.
     wait_for_edge_query_ready(&client_b, Duration::from_secs(30)).await;
 
-    let row_id = client_a
+    let (row_id, _row_values) = client_a
         .create(
             "todos",
             vec![
@@ -788,7 +788,7 @@ async fn jazz_tools_where_subscription_drops_row_when_remote_client_updates_it_o
     wait_for_edge_query_ready(&client_b, Duration::from_secs(30)).await;
 
     // Insert via client-a so it's visible in its own subscription immediately.
-    let row_id = client_a
+    let (row_id, _row_values) = client_a
         .create(
             "todos",
             vec![Value::Text("buy milk".to_string()), Value::Boolean(false)],

--- a/crates/jazz-napi/index.d.ts
+++ b/crates/jazz-napi/index.d.ts
@@ -18,7 +18,7 @@ export declare class NapiRuntime {
     userBranch: string,
     tier?: string | undefined | null,
   ): NapiRuntime;
-  insert(table: string, values: any): string;
+  insert(table: string, values: any): any;
   update(objectId: string, values: any): void;
   delete(objectId: string): void;
   query(
@@ -44,7 +44,7 @@ export declare class NapiRuntime {
   ): number;
   /** Phase 2 of 2-phase subscribe: compile, register, sync, attach callback, tick. */
   executeSubscription(handle: number, onUpdate: (...args: any[]) => any): void;
-  insertDurable(table: string, values: any, tier: string): Promise<string>;
+  insertDurable(table: string, values: any, tier: string): Promise<any>;
   updateDurable(objectId: string, values: any, tier: string): Promise<void>;
   deleteDurable(objectId: string, tier: string): Promise<void>;
   onSyncMessageReceived(messageJson: string): void;

--- a/crates/jazz-napi/index.js
+++ b/crates/jazz-napi/index.js
@@ -80,12 +80,12 @@ function requireNative() {
         const binding = require("jazz-napi-android-arm64");
         const bindingPackageVersion = require("jazz-napi-android-arm64/package.json").version;
         if (
-          bindingPackageVersion !== "2.0.0-alpha.13" &&
+          bindingPackageVersion !== "2.0.0-alpha.14" &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 2.0.0-alpha.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+            `Native binding package version mismatch, expected 2.0.0-alpha.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
           );
         }
         return binding;
@@ -102,12 +102,12 @@ function requireNative() {
         const binding = require("jazz-napi-android-arm-eabi");
         const bindingPackageVersion = require("jazz-napi-android-arm-eabi/package.json").version;
         if (
-          bindingPackageVersion !== "2.0.0-alpha.13" &&
+          bindingPackageVersion !== "2.0.0-alpha.14" &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 2.0.0-alpha.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+            `Native binding package version mismatch, expected 2.0.0-alpha.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
           );
         }
         return binding;
@@ -132,12 +132,12 @@ function requireNative() {
           const binding = require("jazz-napi-win32-x64-gnu");
           const bindingPackageVersion = require("jazz-napi-win32-x64-gnu/package.json").version;
           if (
-            bindingPackageVersion !== "2.0.0-alpha.13" &&
+            bindingPackageVersion !== "2.0.0-alpha.14" &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 2.0.0-alpha.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+              `Native binding package version mismatch, expected 2.0.0-alpha.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
             );
           }
           return binding;
@@ -154,12 +154,12 @@ function requireNative() {
           const binding = require("jazz-napi-win32-x64-msvc");
           const bindingPackageVersion = require("jazz-napi-win32-x64-msvc/package.json").version;
           if (
-            bindingPackageVersion !== "2.0.0-alpha.13" &&
+            bindingPackageVersion !== "2.0.0-alpha.14" &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 2.0.0-alpha.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+              `Native binding package version mismatch, expected 2.0.0-alpha.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
             );
           }
           return binding;
@@ -177,12 +177,12 @@ function requireNative() {
         const binding = require("jazz-napi-win32-ia32-msvc");
         const bindingPackageVersion = require("jazz-napi-win32-ia32-msvc/package.json").version;
         if (
-          bindingPackageVersion !== "2.0.0-alpha.13" &&
+          bindingPackageVersion !== "2.0.0-alpha.14" &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 2.0.0-alpha.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+            `Native binding package version mismatch, expected 2.0.0-alpha.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
           );
         }
         return binding;
@@ -199,12 +199,12 @@ function requireNative() {
         const binding = require("jazz-napi-win32-arm64-msvc");
         const bindingPackageVersion = require("jazz-napi-win32-arm64-msvc/package.json").version;
         if (
-          bindingPackageVersion !== "2.0.0-alpha.13" &&
+          bindingPackageVersion !== "2.0.0-alpha.14" &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 2.0.0-alpha.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+            `Native binding package version mismatch, expected 2.0.0-alpha.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
           );
         }
         return binding;
@@ -224,12 +224,12 @@ function requireNative() {
       const binding = require("jazz-napi-darwin-universal");
       const bindingPackageVersion = require("jazz-napi-darwin-universal/package.json").version;
       if (
-        bindingPackageVersion !== "2.0.0-alpha.13" &&
+        bindingPackageVersion !== "2.0.0-alpha.14" &&
         process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
         process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
       ) {
         throw new Error(
-          `Native binding package version mismatch, expected 2.0.0-alpha.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+          `Native binding package version mismatch, expected 2.0.0-alpha.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
         );
       }
       return binding;
@@ -246,12 +246,12 @@ function requireNative() {
         const binding = require("jazz-napi-darwin-x64");
         const bindingPackageVersion = require("jazz-napi-darwin-x64/package.json").version;
         if (
-          bindingPackageVersion !== "2.0.0-alpha.13" &&
+          bindingPackageVersion !== "2.0.0-alpha.14" &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 2.0.0-alpha.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+            `Native binding package version mismatch, expected 2.0.0-alpha.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
           );
         }
         return binding;
@@ -268,12 +268,12 @@ function requireNative() {
         const binding = require("jazz-napi-darwin-arm64");
         const bindingPackageVersion = require("jazz-napi-darwin-arm64/package.json").version;
         if (
-          bindingPackageVersion !== "2.0.0-alpha.13" &&
+          bindingPackageVersion !== "2.0.0-alpha.14" &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 2.0.0-alpha.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+            `Native binding package version mismatch, expected 2.0.0-alpha.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
           );
         }
         return binding;
@@ -294,12 +294,12 @@ function requireNative() {
         const binding = require("jazz-napi-freebsd-x64");
         const bindingPackageVersion = require("jazz-napi-freebsd-x64/package.json").version;
         if (
-          bindingPackageVersion !== "2.0.0-alpha.13" &&
+          bindingPackageVersion !== "2.0.0-alpha.14" &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 2.0.0-alpha.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+            `Native binding package version mismatch, expected 2.0.0-alpha.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
           );
         }
         return binding;
@@ -316,12 +316,12 @@ function requireNative() {
         const binding = require("jazz-napi-freebsd-arm64");
         const bindingPackageVersion = require("jazz-napi-freebsd-arm64/package.json").version;
         if (
-          bindingPackageVersion !== "2.0.0-alpha.13" &&
+          bindingPackageVersion !== "2.0.0-alpha.14" &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 2.0.0-alpha.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+            `Native binding package version mismatch, expected 2.0.0-alpha.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
           );
         }
         return binding;
@@ -343,12 +343,12 @@ function requireNative() {
           const binding = require("jazz-napi-linux-x64-musl");
           const bindingPackageVersion = require("jazz-napi-linux-x64-musl/package.json").version;
           if (
-            bindingPackageVersion !== "2.0.0-alpha.13" &&
+            bindingPackageVersion !== "2.0.0-alpha.14" &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 2.0.0-alpha.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+              `Native binding package version mismatch, expected 2.0.0-alpha.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
             );
           }
           return binding;
@@ -365,12 +365,12 @@ function requireNative() {
           const binding = require("jazz-napi-linux-x64-gnu");
           const bindingPackageVersion = require("jazz-napi-linux-x64-gnu/package.json").version;
           if (
-            bindingPackageVersion !== "2.0.0-alpha.13" &&
+            bindingPackageVersion !== "2.0.0-alpha.14" &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 2.0.0-alpha.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+              `Native binding package version mismatch, expected 2.0.0-alpha.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
             );
           }
           return binding;
@@ -389,12 +389,12 @@ function requireNative() {
           const binding = require("jazz-napi-linux-arm64-musl");
           const bindingPackageVersion = require("jazz-napi-linux-arm64-musl/package.json").version;
           if (
-            bindingPackageVersion !== "2.0.0-alpha.13" &&
+            bindingPackageVersion !== "2.0.0-alpha.14" &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 2.0.0-alpha.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+              `Native binding package version mismatch, expected 2.0.0-alpha.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
             );
           }
           return binding;
@@ -411,12 +411,12 @@ function requireNative() {
           const binding = require("jazz-napi-linux-arm64-gnu");
           const bindingPackageVersion = require("jazz-napi-linux-arm64-gnu/package.json").version;
           if (
-            bindingPackageVersion !== "2.0.0-alpha.13" &&
+            bindingPackageVersion !== "2.0.0-alpha.14" &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 2.0.0-alpha.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+              `Native binding package version mismatch, expected 2.0.0-alpha.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
             );
           }
           return binding;
@@ -436,12 +436,12 @@ function requireNative() {
           const bindingPackageVersion =
             require("jazz-napi-linux-arm-musleabihf/package.json").version;
           if (
-            bindingPackageVersion !== "2.0.0-alpha.13" &&
+            bindingPackageVersion !== "2.0.0-alpha.14" &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 2.0.0-alpha.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+              `Native binding package version mismatch, expected 2.0.0-alpha.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
             );
           }
           return binding;
@@ -459,12 +459,12 @@ function requireNative() {
           const bindingPackageVersion =
             require("jazz-napi-linux-arm-gnueabihf/package.json").version;
           if (
-            bindingPackageVersion !== "2.0.0-alpha.13" &&
+            bindingPackageVersion !== "2.0.0-alpha.14" &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 2.0.0-alpha.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+              `Native binding package version mismatch, expected 2.0.0-alpha.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
             );
           }
           return binding;
@@ -484,12 +484,12 @@ function requireNative() {
           const bindingPackageVersion =
             require("jazz-napi-linux-loong64-musl/package.json").version;
           if (
-            bindingPackageVersion !== "2.0.0-alpha.13" &&
+            bindingPackageVersion !== "2.0.0-alpha.14" &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 2.0.0-alpha.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+              `Native binding package version mismatch, expected 2.0.0-alpha.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
             );
           }
           return binding;
@@ -506,12 +506,12 @@ function requireNative() {
           const binding = require("jazz-napi-linux-loong64-gnu");
           const bindingPackageVersion = require("jazz-napi-linux-loong64-gnu/package.json").version;
           if (
-            bindingPackageVersion !== "2.0.0-alpha.13" &&
+            bindingPackageVersion !== "2.0.0-alpha.14" &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 2.0.0-alpha.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+              `Native binding package version mismatch, expected 2.0.0-alpha.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
             );
           }
           return binding;
@@ -531,12 +531,12 @@ function requireNative() {
           const bindingPackageVersion =
             require("jazz-napi-linux-riscv64-musl/package.json").version;
           if (
-            bindingPackageVersion !== "2.0.0-alpha.13" &&
+            bindingPackageVersion !== "2.0.0-alpha.14" &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 2.0.0-alpha.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+              `Native binding package version mismatch, expected 2.0.0-alpha.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
             );
           }
           return binding;
@@ -553,12 +553,12 @@ function requireNative() {
           const binding = require("jazz-napi-linux-riscv64-gnu");
           const bindingPackageVersion = require("jazz-napi-linux-riscv64-gnu/package.json").version;
           if (
-            bindingPackageVersion !== "2.0.0-alpha.13" &&
+            bindingPackageVersion !== "2.0.0-alpha.14" &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 2.0.0-alpha.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+              `Native binding package version mismatch, expected 2.0.0-alpha.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
             );
           }
           return binding;
@@ -576,12 +576,12 @@ function requireNative() {
         const binding = require("jazz-napi-linux-ppc64-gnu");
         const bindingPackageVersion = require("jazz-napi-linux-ppc64-gnu/package.json").version;
         if (
-          bindingPackageVersion !== "2.0.0-alpha.13" &&
+          bindingPackageVersion !== "2.0.0-alpha.14" &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 2.0.0-alpha.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+            `Native binding package version mismatch, expected 2.0.0-alpha.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
           );
         }
         return binding;
@@ -598,12 +598,12 @@ function requireNative() {
         const binding = require("jazz-napi-linux-s390x-gnu");
         const bindingPackageVersion = require("jazz-napi-linux-s390x-gnu/package.json").version;
         if (
-          bindingPackageVersion !== "2.0.0-alpha.13" &&
+          bindingPackageVersion !== "2.0.0-alpha.14" &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 2.0.0-alpha.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+            `Native binding package version mismatch, expected 2.0.0-alpha.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
           );
         }
         return binding;
@@ -624,12 +624,12 @@ function requireNative() {
         const binding = require("jazz-napi-openharmony-arm64");
         const bindingPackageVersion = require("jazz-napi-openharmony-arm64/package.json").version;
         if (
-          bindingPackageVersion !== "2.0.0-alpha.13" &&
+          bindingPackageVersion !== "2.0.0-alpha.14" &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 2.0.0-alpha.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+            `Native binding package version mismatch, expected 2.0.0-alpha.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
           );
         }
         return binding;
@@ -646,12 +646,12 @@ function requireNative() {
         const binding = require("jazz-napi-openharmony-x64");
         const bindingPackageVersion = require("jazz-napi-openharmony-x64/package.json").version;
         if (
-          bindingPackageVersion !== "2.0.0-alpha.13" &&
+          bindingPackageVersion !== "2.0.0-alpha.14" &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 2.0.0-alpha.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+            `Native binding package version mismatch, expected 2.0.0-alpha.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
           );
         }
         return binding;
@@ -668,12 +668,12 @@ function requireNative() {
         const binding = require("jazz-napi-openharmony-arm");
         const bindingPackageVersion = require("jazz-napi-openharmony-arm/package.json").version;
         if (
-          bindingPackageVersion !== "2.0.0-alpha.13" &&
+          bindingPackageVersion !== "2.0.0-alpha.14" &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 2.0.0-alpha.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+            `Native binding package version mismatch, expected 2.0.0-alpha.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
           );
         }
         return binding;

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -92,6 +92,19 @@ fn align_values_to_declared_schema(
         .unwrap_or(values)
 }
 
+fn align_row_values_to_declared_schema(
+    declared_schema: &Schema,
+    runtime_schema: &Schema,
+    table: &TableName,
+    values: Vec<Value>,
+) -> Vec<Value> {
+    let Some(runtime_table) = runtime_schema.get(table) else {
+        return values;
+    };
+
+    align_values_to_declared_schema(declared_schema, table, &runtime_table.columns, values)
+}
+
 fn align_query_rows_to_declared_schema(
     declared_schema: &Schema,
     runtime_schema: &Schema,
@@ -573,6 +586,12 @@ impl NapiRuntime {
         let (object_id, row_values) = core
             .insert(&table, groove_values, None)
             .map_err(|e| napi::Error::from_reason(format!("Insert failed: {:?}", e)))?;
+        let row_values = align_row_values_to_declared_schema(
+            &self.declared_schema,
+            core.current_schema(),
+            &TableName::new(table.clone()),
+            row_values,
+        );
 
         Ok(serde_json::json!({
             "id": object_id.uuid().to_string(),
@@ -819,8 +838,16 @@ impl NapiRuntime {
                 .core
                 .lock()
                 .map_err(|_| napi::Error::from_reason("lock"))?;
-            core.insert_persisted(&table, groove_values, None, persistence_tier)
-                .map_err(|e| napi::Error::from_reason(format!("Insert failed: {:?}", e)))?
+            let ((object_id, row_values), receiver) = core
+                .insert_persisted(&table, groove_values, None, persistence_tier)
+                .map_err(|e| napi::Error::from_reason(format!("Insert failed: {:?}", e)))?;
+            let row_values = align_row_values_to_declared_schema(
+                &self.declared_schema,
+                core.current_schema(),
+                &TableName::new(table.clone()),
+                row_values,
+            );
+            ((object_id, row_values), receiver)
         };
 
         let _ = receiver.await;

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -561,7 +561,7 @@ impl NapiRuntime {
         &self,
         table: String,
         #[napi(ts_arg_type = "any")] values: serde_json::Value,
-    ) -> napi::Result<String> {
+    ) -> napi::Result<serde_json::Value> {
         let js_values: Vec<Value> = serde_json::from_value(values)
             .map_err(|e| napi::Error::from_reason(format!("Invalid values: {}", e)))?;
         let groove_values = convert_values(js_values);
@@ -570,11 +570,14 @@ impl NapiRuntime {
             .core
             .lock()
             .map_err(|_| napi::Error::from_reason("lock"))?;
-        let result = core
+        let (object_id, row_values) = core
             .insert(&table, groove_values, None)
             .map_err(|e| napi::Error::from_reason(format!("Insert failed: {:?}", e)))?;
 
-        Ok(result.uuid().to_string())
+        Ok(serde_json::json!({
+            "id": object_id.uuid().to_string(),
+            "values": row_values,
+        }))
     }
 
     #[napi]
@@ -798,20 +801,20 @@ impl NapiRuntime {
     // Persisted CRUD Operations
     // =========================================================================
 
-    #[napi(js_name = "insertDurable", ts_return_type = "Promise<string>")]
+    #[napi(js_name = "insertDurable", ts_return_type = "Promise<any>")]
     pub async fn insert_durable(
         &self,
         table: String,
         #[napi(ts_arg_type = "any")] values: serde_json::Value,
         tier: String,
-    ) -> napi::Result<String> {
+    ) -> napi::Result<serde_json::Value> {
         let persistence_tier = parse_tier(&tier)?;
 
         let js_values: Vec<Value> = serde_json::from_value(values)
             .map_err(|e| napi::Error::from_reason(format!("Invalid values: {}", e)))?;
         let groove_values = convert_values(js_values);
 
-        let (object_id, receiver) = {
+        let ((object_id, row_values), receiver) = {
             let mut core = self
                 .core
                 .lock()
@@ -821,7 +824,10 @@ impl NapiRuntime {
         };
 
         let _ = receiver.await;
-        Ok(object_id.uuid().to_string())
+        Ok(serde_json::json!({
+            "id": object_id.uuid().to_string(),
+            "values": row_values,
+        }))
     }
 
     #[napi(js_name = "updateDurable", ts_return_type = "Promise<void>")]

--- a/crates/jazz-nitro/src/lib.rs
+++ b/crates/jazz-nitro/src/lib.rs
@@ -474,10 +474,25 @@ impl JazzRuntimeImpl {
 
     fn insert_inner(&mut self, table: String, values_json: String) -> Result<String, String> {
         let values = convert_values(&values_json)?;
+        let declared_schema = self
+            .declared_schema
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone();
         self.with_core("insert", |core| {
             core.insert(&table, values, None)
                 .map_err(|e| format!("Insert failed: {e}"))
                 .and_then(|(id, values)| {
+                    let values = if let Some(schema) = declared_schema.as_ref() {
+                        align_row_values_to_declared_schema(
+                            schema,
+                            core.current_schema(),
+                            &TableName::new(table.clone()),
+                            values,
+                        )
+                    } else {
+                        values
+                    };
                     serde_json::to_string(&serde_json::json!({
                         "id": id.uuid().to_string(),
                         "values": values,
@@ -683,11 +698,29 @@ impl JazzRuntimeImpl {
     ) -> Result<String, String> {
         let persistence_tier = parse_tier(&tier)?;
         let values = convert_values(&values_json)?;
+        let declared_schema = self
+            .declared_schema
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone();
 
         let ((object_id, row_values), receiver) =
             self.with_core("insert_persisted", |core| {
                 core.insert_persisted(&table, values, None, persistence_tier)
                     .map_err(|e| format!("Insert failed: {e}"))
+                    .map(|((object_id, row_values), receiver)| {
+                        let row_values = if let Some(schema) = declared_schema.as_ref() {
+                            align_row_values_to_declared_schema(
+                                schema,
+                                core.current_schema(),
+                                &TableName::new(table.clone()),
+                                row_values,
+                            )
+                        } else {
+                            row_values
+                        };
+                        ((object_id, row_values), receiver)
+                    })
             })??;
 
         let _ = block_on(receiver);

--- a/crates/jazz-nitro/src/lib.rs
+++ b/crates/jazz-nitro/src/lib.rs
@@ -476,8 +476,14 @@ impl JazzRuntimeImpl {
         let values = convert_values(&values_json)?;
         self.with_core("insert", |core| {
             core.insert(&table, values, None)
-                .map(|id| id.uuid().to_string())
                 .map_err(|e| format!("Insert failed: {e}"))
+                .and_then(|(id, values)| {
+                    serde_json::to_string(&serde_json::json!({
+                        "id": id.uuid().to_string(),
+                        "values": values,
+                    }))
+                    .map_err(|e| format!("Insert serialization failed: {e}"))
+                })
         })?
     }
 
@@ -678,13 +684,18 @@ impl JazzRuntimeImpl {
         let persistence_tier = parse_tier(&tier)?;
         let values = convert_values(&values_json)?;
 
-        let (object_id, receiver) = self.with_core("insert_persisted", |core| {
-            core.insert_persisted(&table, values, None, persistence_tier)
-                .map_err(|e| format!("Insert failed: {e}"))
-        })??;
+        let ((object_id, row_values), receiver) =
+            self.with_core("insert_persisted", |core| {
+                core.insert_persisted(&table, values, None, persistence_tier)
+                    .map_err(|e| format!("Insert failed: {e}"))
+            })??;
 
         let _ = block_on(receiver);
-        Ok(object_id.uuid().to_string())
+        serde_json::to_string(&serde_json::json!({
+            "id": object_id.uuid().to_string(),
+            "values": row_values,
+        }))
+        .map_err(|e| format!("Insert serialization failed: {e}"))
     }
 
     pub fn insert_persisted(&mut self, table: String, values_json: String, tier: String) -> String {
@@ -987,8 +998,18 @@ mod tests {
         ])
         .to_string();
 
-        let id = rt.insert("todos".into(), values_json);
+        let insert_result: serde_json::Value =
+            serde_json::from_str(&rt.insert("todos".into(), values_json)).unwrap();
+        let id = insert_result["id"].as_str().unwrap().to_string();
         assert!(!id.is_empty());
+        assert_eq!(
+            insert_result["values"][0],
+            serde_json::json!({ "type": "Text", "value": "Buy milk" })
+        );
+        assert_eq!(
+            insert_result["values"][1],
+            serde_json::json!({ "type": "Boolean", "value": false })
+        );
 
         let query_json = serde_json::json!({ "table": "todos", "relation_ir": { "TableScan": { "table": "todos" } } }).to_string();
         let result = rt.query(query_json, None, None);
@@ -1230,10 +1251,20 @@ mod tests {
             { "type": "Boolean", "value": false }
         ])
         .to_string();
-        let id = alice.insert("todos".into(), values);
+        let insert_result: serde_json::Value =
+            serde_json::from_str(&alice.insert("todos".into(), values)).unwrap();
+        let id = insert_result["id"].as_str().unwrap().to_string();
         assert!(
             uuid::Uuid::parse_str(&id).is_ok(),
             "Insert should return valid UUID"
+        );
+        assert_eq!(
+            insert_result["values"][0],
+            serde_json::json!({ "type": "Text", "value": "Walk the dog" })
+        );
+        assert_eq!(
+            insert_result["values"][1],
+            serde_json::json!({ "type": "Boolean", "value": false })
         );
 
         // Update: mark done

--- a/crates/jazz-rn/rust/src/lib.rs
+++ b/crates/jazz-rn/rust/src/lib.rs
@@ -16,7 +16,7 @@ use jazz_tools::query_manager::manager::LocalUpdates;
 use jazz_tools::query_manager::parse_query_json;
 use jazz_tools::query_manager::query::Query;
 use jazz_tools::query_manager::session::Session;
-use jazz_tools::query_manager::types::{Schema, SchemaHash, Value};
+use jazz_tools::query_manager::types::{RowDescriptor, Schema, SchemaHash, TableName, Value};
 use jazz_tools::runtime_core::{
     ReadDurabilityOptions, RuntimeCore, Scheduler, SubscriptionDelta, SubscriptionHandle,
     SyncSender,
@@ -98,6 +98,47 @@ fn convert_values(values_json: &str) -> Result<Vec<Value>, JazzRnError> {
 fn convert_updates(values_json: &str) -> Result<Vec<(String, Value)>, JazzRnError> {
     let partial: HashMap<String, Value> = serde_json::from_str(values_json).map_err(json_err)?;
     Ok(partial.into_iter().collect())
+}
+
+fn reorder_values_by_column_name(
+    source_descriptor: &RowDescriptor,
+    target_descriptor: &RowDescriptor,
+    values: &[Value],
+) -> Option<Vec<Value>> {
+    if values.len() != source_descriptor.columns.len()
+        || source_descriptor.columns.len() != target_descriptor.columns.len()
+    {
+        return None;
+    }
+
+    let mut values_by_column = HashMap::with_capacity(values.len());
+    for (column, value) in source_descriptor.columns.iter().zip(values.iter()) {
+        values_by_column.insert(column.name, value.clone());
+    }
+
+    let mut reordered_values = Vec::with_capacity(values.len());
+    for column in &target_descriptor.columns {
+        reordered_values.push(values_by_column.remove(&column.name)?);
+    }
+
+    Some(reordered_values)
+}
+
+fn align_row_values_to_declared_schema(
+    declared_schema: &Schema,
+    runtime_schema: &Schema,
+    table: &TableName,
+    values: Vec<Value>,
+) -> Vec<Value> {
+    let Some(declared_table) = declared_schema.get(table) else {
+        return values;
+    };
+    let Some(runtime_table) = runtime_schema.get(table) else {
+        return values;
+    };
+
+    reorder_values_by_column_name(&runtime_table.columns, &declared_table.columns, &values)
+        .unwrap_or(values)
 }
 
 fn parse_query(query_json: &str) -> Result<Query, JazzRnError> {
@@ -333,6 +374,7 @@ type RnCoreType = RuntimeCore<SurrealKvStorage, RnScheduler, RnSyncSender>;
 pub struct RnRuntime {
     core: Mutex<RnCoreType>,
     upstream_server_id: Mutex<Option<ServerId>>,
+    declared_schema: Schema,
 }
 
 #[uniffi::export]
@@ -348,6 +390,7 @@ impl RnRuntime {
     ) -> Result<Arc<Self>, JazzRnError> {
         with_panic_boundary("new", || {
             let schema: Schema = serde_json::from_str(&schema_json).map_err(json_err)?;
+            let declared_schema = schema.clone();
 
             let persistence_tier = tier.as_deref().map(parse_tier).transpose()?;
 
@@ -398,6 +441,7 @@ impl RnRuntime {
             Ok(Arc::new(Self {
                 core: Mutex::new(core),
                 upstream_server_id: Mutex::new(None),
+                declared_schema,
             }))
         })
     }
@@ -453,6 +497,12 @@ impl RnRuntime {
                 message: "lock poisoned".into(),
             })?;
             let (id, row_values) = core.insert(&table, values, None).map_err(runtime_err)?;
+            let row_values = align_row_values_to_declared_schema(
+                &self.declared_schema,
+                core.current_schema(),
+                &TableName::new(table.clone()),
+                row_values,
+            );
             serde_json::to_string(&serde_json::json!({
                 "id": id.uuid().to_string(),
                 "values": row_values,

--- a/crates/jazz-rn/rust/src/lib.rs
+++ b/crates/jazz-rn/rust/src/lib.rs
@@ -452,8 +452,14 @@ impl RnRuntime {
             let mut core = self.core.lock().map_err(|_| JazzRnError::Internal {
                 message: "lock poisoned".into(),
             })?;
-            let id = core.insert(&table, values, None).map_err(runtime_err)?;
-            Ok(id.uuid().to_string())
+            let (id, row_values) = core.insert(&table, values, None).map_err(runtime_err)?;
+            serde_json::to_string(&serde_json::json!({
+                "id": id.uuid().to_string(),
+                "values": row_values,
+            }))
+            .map_err(|e| JazzRnError::Internal {
+                message: format!("insert serialization failed: {e}"),
+            })
         })
     }
 

--- a/crates/jazz-tools/src/client.rs
+++ b/crates/jazz-tools/src/client.rs
@@ -400,9 +400,20 @@ impl JazzClient {
 
     /// Create a new row in a table.
     pub async fn create(&self, table: &str, values: Vec<Value>) -> Result<(ObjectId, Vec<Value>)> {
-        self.runtime
+        let (object_id, row_values) = self
+            .runtime
             .insert(table, values, None)
-            .map_err(|e| JazzError::Write(e.to_string()))
+            .map_err(|e| JazzError::Write(e.to_string()))?;
+        let row_values = match self.runtime.current_schema() {
+            Ok(schema) => align_row_values_to_declared_schema(
+                &self.declared_schema,
+                &schema,
+                &TableName::new(table),
+                row_values,
+            ),
+            Err(_) => row_values,
+        };
+        Ok((object_id, row_values))
     }
 
     /// Update a row.
@@ -508,10 +519,21 @@ pub struct SessionClient<'a> {
 
 impl<'a> SessionClient<'a> {
     pub async fn create(&self, table: &str, values: Vec<Value>) -> Result<(ObjectId, Vec<Value>)> {
-        self.client
+        let (object_id, row_values) = self
+            .client
             .runtime
             .insert(table, values, Some(&self.session))
-            .map_err(|e| JazzError::Write(e.to_string()))
+            .map_err(|e| JazzError::Write(e.to_string()))?;
+        let row_values = match self.client.runtime.current_schema() {
+            Ok(schema) => align_row_values_to_declared_schema(
+                &self.client.declared_schema,
+                &schema,
+                &TableName::new(table),
+                row_values,
+            ),
+            Err(_) => row_values,
+        };
+        Ok((object_id, row_values))
     }
 
     pub async fn update(&self, object_id: ObjectId, updates: Vec<(String, Value)>) -> Result<()> {

--- a/crates/jazz-tools/src/client.rs
+++ b/crates/jazz-tools/src/client.rs
@@ -399,7 +399,7 @@ impl JazzClient {
     }
 
     /// Create a new row in a table.
-    pub async fn create(&self, table: &str, values: Vec<Value>) -> Result<ObjectId> {
+    pub async fn create(&self, table: &str, values: Vec<Value>) -> Result<(ObjectId, Vec<Value>)> {
         self.runtime
             .insert(table, values, None)
             .map_err(|e| JazzError::Write(e.to_string()))
@@ -507,7 +507,7 @@ pub struct SessionClient<'a> {
 }
 
 impl<'a> SessionClient<'a> {
-    pub async fn create(&self, table: &str, values: Vec<Value>) -> Result<ObjectId> {
+    pub async fn create(&self, table: &str, values: Vec<Value>) -> Result<(ObjectId, Vec<Value>)> {
         self.client
             .runtime
             .insert(table, values, Some(&self.session))

--- a/crates/jazz-tools/src/query_manager/manager.rs
+++ b/crates/jazz-tools/src/query_manager/manager.rs
@@ -125,16 +125,18 @@ impl std::error::Error for QueryError {}
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct QueryHandle(pub u64);
 
-/// Handle for tracking insert completion.
+/// Result of an insert, including durability metadata and row values.
 ///
 /// Poll via `is_complete()` to check if the row is persisted.
 /// Poll via `is_indexed()` to check if the row is indexed.
 #[derive(Debug, Clone)]
-pub struct InsertHandle {
+pub struct InsertResult {
     /// The row's ObjectId.
     pub row_id: ObjectId,
     /// CommitId of the row data.
     pub row_commit_id: CommitId,
+    /// Inserted row values in table column order.
+    pub row_values: Vec<Value>,
 }
 
 /// Handle for tracking delete completion.
@@ -146,7 +148,7 @@ pub struct DeleteHandle {
     pub delete_commit_id: CommitId,
 }
 
-impl InsertHandle {
+impl InsertResult {
     /// Check if the row data is durable (persisted to storage).
     ///
     /// Must call `QueryManager::process()` between checks to drive storage operations.

--- a/crates/jazz-tools/src/query_manager/writes.rs
+++ b/crates/jazz-tools/src/query_manager/writes.rs
@@ -6,7 +6,7 @@ use crate::object::{BranchName, ObjectId};
 use crate::storage::Storage;
 
 use super::encoding::{decode_column, decode_row, encode_row};
-use super::manager::{DeleteHandle, InsertHandle, QueryError, QueryManager};
+use super::manager::{DeleteHandle, InsertResult, QueryError, QueryManager};
 use super::policy::{ComplexClause, Operation, evaluate_simple_parts};
 use super::session::Session;
 use super::types::{ColumnType, LoadedRow, RowDescriptor, TableName, Value};
@@ -14,14 +14,14 @@ use super::types::{ColumnType, LoadedRow, RowDescriptor, TableName, Value};
 impl QueryManager {
     /// Insert a new row into a table.
     ///
-    /// Returns an `InsertHandle` that can be polled to check durability.
+    /// Returns an `InsertResult` that can be polled to check durability.
     /// Index updates happen immediately (creating sentinels if needed).
     pub fn insert<H: Storage>(
         &mut self,
         storage: &mut H,
         table: &str,
         values: &[Value],
-    ) -> Result<InsertHandle, QueryError> {
+    ) -> Result<InsertResult, QueryError> {
         self.insert_with_session(storage, table, values, None)
     }
 
@@ -36,7 +36,7 @@ impl QueryManager {
         table: &str,
         values: &[Value],
         session: Option<&Session>,
-    ) -> Result<InsertHandle, QueryError> {
+    ) -> Result<InsertResult, QueryError> {
         let _span = tracing::debug_span!("QM::insert", table).entered();
         let table_name = TableName::new(table);
         let table_schema = self
@@ -124,9 +124,10 @@ impl QueryManager {
         tracing::trace!(table, "mark_subscriptions_dirty");
 
         tracing::debug!(%object_id, ?row_commit_id, branch = self.current_branch(), "row created");
-        Ok(InsertHandle {
+        Ok(InsertResult {
             row_id: object_id,
             row_commit_id,
+            row_values: values.to_vec(),
         })
     }
 
@@ -139,7 +140,7 @@ impl QueryManager {
         table: &str,
         branch: &str,
         values: &[Value],
-    ) -> Result<InsertHandle, QueryError> {
+    ) -> Result<InsertResult, QueryError> {
         self.insert_on_branch_with_session(storage, table, branch, values, None)
     }
 
@@ -151,7 +152,7 @@ impl QueryManager {
         branch: &str,
         values: &[Value],
         session: Option<&Session>,
-    ) -> Result<InsertHandle, QueryError> {
+    ) -> Result<InsertResult, QueryError> {
         let table_name = TableName::new(table);
         let table_schema = self
             .schema
@@ -234,9 +235,10 @@ impl QueryManager {
         // Mark subscriptions dirty
         self.mark_subscriptions_dirty_local(table);
 
-        Ok(InsertHandle {
+        Ok(InsertResult {
             row_id: object_id,
             row_commit_id,
+            row_values: values.to_vec(),
         })
     }
 
@@ -1187,7 +1189,7 @@ impl QueryManager {
         storage: &mut H,
         id: ObjectId,
         values: &[Value],
-    ) -> Result<InsertHandle, QueryError> {
+    ) -> Result<InsertResult, QueryError> {
         // Check for hard delete first
         if self.is_hard_deleted(id) {
             return Err(QueryError::RowHardDeleted(id));
@@ -1266,9 +1268,10 @@ impl QueryManager {
         // Mark subscriptions dirty
         self.mark_subscriptions_dirty_local(&table);
 
-        Ok(InsertHandle {
+        Ok(InsertResult {
             row_id: id,
             row_commit_id,
+            row_values: values.to_vec(),
         })
     }
 
@@ -1526,7 +1529,7 @@ impl QueryManager {
     /// Check if a commit has been stored to disk.
     ///
     /// With sync storage, commits are stored immediately.
-    /// Used by `InsertHandle::is_complete()` to check durability.
+    /// Used by `InsertResult::is_complete()` to check durability.
     pub fn is_commit_stored(&self, object_id: ObjectId, commit_id: &CommitId) -> bool {
         if let Some(obj) = self.sync_manager.object_manager.get(object_id) {
             // Check all branches for the commit

--- a/crates/jazz-tools/src/runtime_core.rs
+++ b/crates/jazz-tools/src/runtime_core.rs
@@ -138,6 +138,8 @@ impl From<QueryError> for RuntimeError {
 
 /// Type alias for query results.
 pub type QueryResult = Result<Vec<(ObjectId, Vec<Value>)>, RuntimeError>;
+/// Type alias for inserted row payloads.
+pub type InsertedRow = (ObjectId, Vec<Value>);
 
 /// Future that resolves to query results.
 ///

--- a/crates/jazz-tools/src/runtime_core/tests.rs
+++ b/crates/jazz-tools/src/runtime_core/tests.rs
@@ -65,8 +65,9 @@ fn test_runtime_core_insert_query() {
         Value::Uuid(ObjectId::new()),
         Value::Text("Alice".to_string()),
     ];
-    let object_id = core.insert("users", values.clone(), None).unwrap();
+    let (object_id, row_values) = core.insert("users", values.clone(), None).unwrap();
     assert!(!object_id.0.is_nil());
+    assert_eq!(row_values, values);
 
     core.immediate_tick();
     core.batched_tick();
@@ -75,6 +76,7 @@ fn test_runtime_core_insert_query() {
     let results = execute_query(&mut core, query);
     assert_eq!(results.len(), 1);
     assert_eq!(results[0].0, object_id);
+    assert_eq!(results[0].1, row_values);
 }
 
 #[test]
@@ -154,7 +156,7 @@ fn test_runtime_core_update_delete() {
 
     let id = ObjectId::new();
     let values = vec![Value::Uuid(id), Value::Text("Charlie".to_string())];
-    let object_id = core.insert("users", values, None).unwrap();
+    let (object_id, _row_values) = core.insert("users", values, None).unwrap();
     core.immediate_tick();
     core.batched_tick();
 
@@ -651,20 +653,22 @@ fn rc_does_not_replay_unsubscribed_queries_on_upstream_reconnect() {
 fn rc_insert_returns_immediately() {
     let mut s = create_3tier_rc();
     let values = vec![Value::Uuid(ObjectId::new()), Value::Text("Alice".into())];
-    let id = s.a.insert("users", values, None).unwrap();
+    let (id, row_values) = s.a.insert("users", values.clone(), None).unwrap();
     assert!(!id.0.is_nil());
+    assert_eq!(row_values, values);
 
     let query = Query::new("users");
     let results = execute_query(&mut s.a, query);
     assert_eq!(results.len(), 1);
     assert_eq!(results[0].0, id);
+    assert_eq!(results[0].1, row_values);
 }
 
 #[test]
 fn rc_insert_data_syncs_to_server() {
     let mut s = create_3tier_rc();
     let values = vec![Value::Uuid(ObjectId::new()), Value::Text("Alice".into())];
-    let id = s.a.insert("users", values, None).unwrap();
+    let (id, _row_values) = s.a.insert("users", values, None).unwrap();
 
     pump_a_to_b(&mut s);
 
@@ -678,7 +682,7 @@ fn rc_insert_data_syncs_to_server() {
 fn rc_update_sync() {
     let mut s = create_3tier_rc();
     let values = vec![Value::Uuid(ObjectId::new()), Value::Text("Alice".into())];
-    let id = s.a.insert("users", values, None).unwrap();
+    let (id, _row_values) = s.a.insert("users", values, None).unwrap();
     pump_a_to_b(&mut s);
 
     s.a.update(id, vec![("name".into(), Value::Text("Bob".into()))], None)
@@ -695,7 +699,7 @@ fn rc_update_sync() {
 fn rc_delete_sync() {
     let mut s = create_3tier_rc();
     let values = vec![Value::Uuid(ObjectId::new()), Value::Text("Alice".into())];
-    let id = s.a.insert("users", values, None).unwrap();
+    let (id, _row_values) = s.a.insert("users", values, None).unwrap();
     pump_a_to_b(&mut s);
 
     s.a.delete(id, None).unwrap();
@@ -710,10 +714,11 @@ fn rc_delete_sync() {
 fn rc_insert_persisted_resolves_on_worker_ack() {
     let mut s = create_3tier_rc();
     let values = vec![Value::Uuid(ObjectId::new()), Value::Text("Alice".into())];
-    let (id, mut receiver) =
-        s.a.insert_persisted("users", values, None, DurabilityTier::Worker)
+    let ((id, row_values), mut receiver) =
+        s.a.insert_persisted("users", values.clone(), None, DurabilityTier::Worker)
             .unwrap();
     assert!(!id.0.is_nil());
+    assert_eq!(row_values, values);
 
     assert!(
         receiver.try_recv().is_err() || receiver.try_recv() == Ok(None),
@@ -778,7 +783,7 @@ fn rc_insert_persisted_higher_tier_satisfies_lower() {
 fn rc_update_persisted_resolves_on_ack() {
     let mut s = create_3tier_rc();
     let values = vec![Value::Uuid(ObjectId::new()), Value::Text("Alice".into())];
-    let id = s.a.insert("users", values, None).unwrap();
+    let (id, _row_values) = s.a.insert("users", values, None).unwrap();
     pump_a_to_b(&mut s);
 
     let mut receiver =
@@ -808,7 +813,7 @@ fn rc_update_persisted_resolves_on_ack() {
 fn rc_delete_persisted_resolves_on_ack() {
     let mut s = create_3tier_rc();
     let values = vec![Value::Uuid(ObjectId::new()), Value::Text("Alice".into())];
-    let id = s.a.insert("users", values, None).unwrap();
+    let (id, _row_values) = s.a.insert("users", values, None).unwrap();
     pump_a_to_b(&mut s);
 
     let mut receiver =
@@ -862,7 +867,7 @@ fn rc_query_no_settled_tier_immediate() {
     let mut s = create_3tier_rc();
 
     let values = vec![Value::Uuid(ObjectId::new()), Value::Text("Alice".into())];
-    let id = s.a.insert("users", values, None).unwrap();
+    let (id, _row_values) = s.a.insert("users", values, None).unwrap();
 
     let mut future = s.a.query(Query::new("users"), None);
 
@@ -883,7 +888,7 @@ fn rc_query_settled_tier_holds() {
     let mut s = create_3tier_rc();
 
     let values = vec![Value::Uuid(ObjectId::new()), Value::Text("Alice".into())];
-    let id = s.a.insert("users", values, None).unwrap();
+    let (id, _row_values) = s.a.insert("users", values, None).unwrap();
 
     let mut future = s.a.query_with_propagation(
         Query::new("users"),
@@ -962,7 +967,7 @@ fn rc_query_settled_before_data_should_not_drop_upstream_rows() {
         Value::Uuid(ObjectId::new()),
         Value::Text("upstream-row".into()),
     ];
-    let row_id = s.b.insert("users", values, None).unwrap();
+    let (row_id, _row_values) = s.b.insert("users", values, None).unwrap();
     s.b.immediate_tick();
     s.b.batched_tick();
     s.b.sync_sender().take();
@@ -1096,7 +1101,7 @@ fn rc_subscribe_settled_tier() {
         .unwrap();
 
     let values = vec![Value::Uuid(ObjectId::new()), Value::Text("Alice".into())];
-    let id = s.a.insert("users", values, None).unwrap();
+    let (id, _row_values) = s.a.insert("users", values, None).unwrap();
     s.a.immediate_tick();
 
     assert!(
@@ -1154,7 +1159,7 @@ fn rc_subscribe_remote_tier_immediate_local_updates() {
         Value::Uuid(ObjectId::new()),
         Value::Text("local-first".into()),
     ];
-    let first_id = s.a.insert("users", values, None).unwrap();
+    let (first_id, _row_values) = s.a.insert("users", values, None).unwrap();
     s.a.immediate_tick();
 
     let calls = received.lock().unwrap();
@@ -1195,7 +1200,7 @@ fn rc_subscribe_remote_tier_immediate_local_updates() {
         Value::Uuid(ObjectId::new()),
         Value::Text("local-second".into()),
     ];
-    let second_id = s.a.insert("users", second_values, None).unwrap();
+    let (second_id, _row_values) = s.a.insert("users", second_values, None).unwrap();
     s.a.immediate_tick();
 
     let calls = received.lock().unwrap();

--- a/crates/jazz-tools/src/runtime_core/writes.rs
+++ b/crates/jazz-tools/src/runtime_core/writes.rs
@@ -11,15 +11,17 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
         table: &str,
         values: Vec<Value>,
         session: Option<&Session>,
-    ) -> Result<ObjectId, RuntimeError> {
+    ) -> Result<InsertedRow, RuntimeError> {
         let _span = debug_span!("insert", table).entered();
         let result = self
             .schema_manager
             .insert_with_session(&mut self.storage, table, &values, session)
             .map_err(|e| RuntimeError::WriteError(format!("{:?}", e)))?;
-        debug!(object_id = %result.row_id, "inserted");
+        let row_id = result.row_id;
+        let row_values = result.row_values;
+        debug!(object_id = %row_id, "inserted");
         self.immediate_tick();
-        Ok(result.row_id)
+        Ok((row_id, row_values))
     }
 
     /// Update a row (partial update by column name).
@@ -69,11 +71,14 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
         values: Vec<Value>,
         session: Option<&Session>,
         tier: DurabilityTier,
-    ) -> Result<(ObjectId, oneshot::Receiver<()>), RuntimeError> {
+    ) -> Result<(InsertedRow, oneshot::Receiver<()>), RuntimeError> {
         let result = self
             .schema_manager
             .insert_with_session(&mut self.storage, table, &values, session)
             .map_err(|e| RuntimeError::WriteError(format!("{:?}", e)))?;
+        let row_id = result.row_id;
+        let row_commit_id = result.row_commit_id;
+        let row_values = result.row_values;
 
         let (sender, receiver) = oneshot::channel();
         if self
@@ -85,13 +90,13 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
             let _ = sender.send(());
         } else {
             self.ack_watchers
-                .entry(result.row_commit_id)
+                .entry(row_commit_id)
                 .or_default()
                 .push((tier, sender));
         }
 
         self.immediate_tick();
-        Ok((result.row_id, receiver))
+        Ok(((row_id, row_values), receiver))
     }
 
     /// Update a row and return a receiver that resolves when the requested

--- a/crates/jazz-tools/src/runtime_tokio.rs
+++ b/crates/jazz-tools/src/runtime_tokio.rs
@@ -221,7 +221,7 @@ impl<S: Storage + Send + 'static> TokioRuntime<S> {
         table: &str,
         values: Vec<Value>,
         session: Option<&Session>,
-    ) -> Result<ObjectId, RuntimeError> {
+    ) -> Result<(ObjectId, Vec<Value>), RuntimeError> {
         let mut core = self.core.lock().map_err(|_| RuntimeError::LockError)?;
         let result = core.insert(table, values, session)?;
         Ok(result)
@@ -515,8 +515,9 @@ mod tests {
             Value::Uuid(ObjectId::new()),
             Value::Text("Alice".to_string()),
         ];
-        let object_id = runtime.insert("users", values, None).unwrap();
+        let (object_id, row_values) = runtime.insert("users", values.clone(), None).unwrap();
         assert!(!object_id.0.is_nil());
+        assert_eq!(row_values, values);
 
         // Query
         let query = Query::new("users");
@@ -540,7 +541,7 @@ mod tests {
 
         // Insert
         let values = vec![Value::Uuid(ObjectId::new()), Value::Text("Bob".to_string())];
-        let object_id = runtime.insert("users", values, None).unwrap();
+        let (object_id, _row_values) = runtime.insert("users", values, None).unwrap();
 
         // Update
         let updates = vec![("name".to_string(), Value::Text("Charlie".to_string()))];
@@ -596,7 +597,7 @@ mod tests {
 
         // Insert a row - this should trigger the subscription callback
         let values = vec![Value::Uuid(ObjectId::new()), Value::Text("Eve".to_string())];
-        let _object_id = runtime.insert("users", values, None).unwrap();
+        let (_object_id, _row_values) = runtime.insert("users", values, None).unwrap();
 
         // Verify callback was invoked
         let updates_vec = updates.lock().unwrap();

--- a/crates/jazz-tools/src/schema_manager/manager.rs
+++ b/crates/jazz-tools/src/schema_manager/manager.rs
@@ -10,7 +10,7 @@
 use std::{collections::HashMap, sync::Arc};
 
 use crate::object::{BranchName, ObjectId};
-use crate::query_manager::manager::{DeleteHandle, InsertHandle, QueryError, QueryManager};
+use crate::query_manager::manager::{DeleteHandle, InsertResult, QueryError, QueryManager};
 use crate::query_manager::query::{Query, QueryBuilder};
 use crate::query_manager::session::Session;
 use crate::query_manager::types::{
@@ -843,7 +843,7 @@ impl SchemaManager {
         storage: &mut H,
         table: &str,
         values: &[Value],
-    ) -> Result<InsertHandle, QueryError> {
+    ) -> Result<InsertResult, QueryError> {
         let _span =
             tracing::debug_span!("SM::insert", table, schema_hash = %self.context.current_hash)
                 .entered();
@@ -857,7 +857,7 @@ impl SchemaManager {
         table: &str,
         values: &[Value],
         session: Option<&Session>,
-    ) -> Result<InsertHandle, QueryError> {
+    ) -> Result<InsertResult, QueryError> {
         let aligned_values = self.align_insert_values_to_runtime_schema(table, values);
         self.query_manager.insert_on_branch_with_session(
             storage,

--- a/crates/jazz-wasm/src/runtime.rs
+++ b/crates/jazz-wasm/src/runtime.rs
@@ -586,21 +586,26 @@ impl WasmRuntime {
     /// Insert a row into a table.
     ///
     /// # Returns
-    /// The new row's ObjectId as a UUID string.
+    /// The inserted row as `{ id, values }`.
     #[wasm_bindgen]
-    pub fn insert(&self, table: &str, values: JsValue) -> Result<String, JsError> {
+    pub fn insert(&self, table: &str, values: JsValue) -> Result<JsValue, JsError> {
         let _span = debug_span!("wasm::insert", tier = self.tier_label, table).entered();
         let wasm_values: Vec<Value> = serde_wasm_bindgen::from_value(values)?;
         let groove_values: Vec<Value> = wasm_values;
 
         let mut core = self.core.borrow_mut();
-        let result = core
+        let (object_id, row_values) = core
             .insert(table, groove_values, None)
             .map_err(|e| JsError::new(&format!("Insert failed: {:?}", e)))?;
 
-        let object_id = result.uuid().to_string();
-        tracing::debug!(object_id = %object_id, "inserted");
-        Ok(object_id)
+        let row = SubscriptionRow {
+            id: object_id.uuid().to_string(),
+            values: row_values,
+        };
+        tracing::debug!(object_id = %row.id, "inserted");
+        let serializer = serde_wasm_bindgen::Serializer::new().serialize_maps_as_objects(true);
+        row.serialize(&serializer)
+            .map_err(|e| JsError::new(&format!("Serialization failed: {:?}", e)))
     }
 
     /// Execute a query and return results as a Promise.
@@ -735,16 +740,21 @@ impl WasmRuntime {
         let wasm_values: Vec<Value> = serde_wasm_bindgen::from_value(values)?;
         let groove_values: Vec<Value> = wasm_values;
 
-        let (object_id, receiver) = {
+        let ((object_id, row_values), receiver) = {
             let mut core = self.core.borrow_mut();
             core.insert_persisted(table, groove_values, None, persistence_tier)
                 .map_err(|e| JsError::new(&format!("Insert failed: {:?}", e)))?
         };
 
-        let id_str = object_id.uuid().to_string();
+        let row = SubscriptionRow {
+            id: object_id.uuid().to_string(),
+            values: row_values,
+        };
         let promise = wasm_bindgen_futures::future_to_promise(async move {
             let _ = receiver.await;
-            Ok(JsValue::from_str(&id_str))
+            let serializer = serde_wasm_bindgen::Serializer::new().serialize_maps_as_objects(true);
+            row.serialize(&serializer)
+                .map_err(|e| JsValue::from_str(&format!("Serialization failed: {:?}", e)))
         });
 
         Ok(promise)

--- a/examples/docs/todo-client-localfirst-expo/src/docs-snippets.ts
+++ b/examples/docs/todo-client-localfirst-expo/src/docs-snippets.ts
@@ -99,7 +99,7 @@ export function subscribeTodosAtEdge(db: Db, onCount: (count: number) => void) {
 
 // #region writing-durability-expo
 export async function writeWithDurabilityTier(db: Db, todoTitle: string) {
-  const id = await db.insert(
+  const { id } = await db.insert(
     app.todos,
     {
       title: todoTitle,

--- a/examples/docs/todo-client-localfirst-react/src/docs-snippets.ts
+++ b/examples/docs/todo-client-localfirst-react/src/docs-snippets.ts
@@ -98,7 +98,7 @@ export function subscribeTodosAtEdge(db: Db, onCount: (count: number) => void) {
 
 // #region writing-durability-react
 export async function writeWithDurabilityTier(db: Db, todoTitle: string) {
-  const id = await db.insert(app.todos, { title: todoTitle, done: false }, { tier: "edge" });
+  const { id } = await db.insert(app.todos, { title: todoTitle, done: false }, { tier: "edge" });
   await db.update(app.todos, id, { done: true }, { tier: "edge" });
   await db.deleteFrom(app.todos, id, { tier: "global" });
 }

--- a/examples/docs/todo-client-localfirst-svelte/src/TodoList.svelte
+++ b/examples/docs/todo-client-localfirst-svelte/src/TodoList.svelte
@@ -43,7 +43,7 @@
 
 	// #region writing-durability-svelte
 	async function addImportantTodo(todoTitle: string) {
-		const id = await db.insert(app.todos, { title: todoTitle, done: false }, { tier: 'edge' });
+		const { id } = await db.insert(app.todos, { title: todoTitle, done: false }, { tier: 'edge' });
 		await db.update(app.todos, id, { done: true }, { tier: 'edge' });
 		await db.deleteFrom(app.todos, id, { tier: 'global' });
 	}

--- a/examples/docs/todo-client-localfirst-ts/src/docs-snippets.ts
+++ b/examples/docs/todo-client-localfirst-ts/src/docs-snippets.ts
@@ -84,7 +84,7 @@ export async function writeTodoCrud(db: Db, todoId: string) {
 
 // #region writing-durability-tier-ts
 export async function writeTodoWithDurabilityTiers(db: Db) {
-  const id = await db.insert(
+  const { id } = await db.insert(
     app.todos,
     {
       title: "Write docs with durability tier",

--- a/examples/docs/todo-server-rs/src/docs_snippets.rs
+++ b/examples/docs/todo-server-rs/src/docs_snippets.rs
@@ -186,7 +186,7 @@ pub async fn write_todo_crud(client: &JazzClient, existing_id: ObjectId) -> jazz
         Value::Null,
     ];
 
-    let _new_id = client.create("todos", values).await?;
+    let _new_row = client.create("todos", values).await?;
     client
         .update(
             existing_id,
@@ -202,7 +202,7 @@ pub async fn write_todo_crud(client: &JazzClient, existing_id: ObjectId) -> jazz
 pub async fn write_todo_with_default_durability(
     client: &JazzClient,
 ) -> jazz_tools::Result<ObjectId> {
-    let id = client
+    let (id, _row_values) = client
         .create(
             "todos",
             vec![

--- a/examples/docs/todo-server-rs/src/routes.rs
+++ b/examples/docs/todo-server-rs/src/routes.rs
@@ -131,17 +131,8 @@ async fn create_todo(
     ];
 
     match state.client.create("todos", values).await {
-        Ok(row_id) => {
-            let todo = Todo {
-                id: *row_id.uuid(),
-                title: request.title,
-                done: false,
-                description: if description.is_empty() {
-                    None
-                } else {
-                    Some(description)
-                },
-            };
+        Ok((row_id, row_values)) => {
+            let todo = row_to_todo(row_id, &row_values);
 
             // Broadcast to SSE connections
             broadcast_todos(&state).await;

--- a/examples/docs/todo-server-rs/tests/integration.rs
+++ b/examples/docs/todo-server-rs/tests/integration.rs
@@ -212,17 +212,8 @@ async fn create_todo(
         Value::Null,
     ];
     match state.client.create("todos", values).await {
-        Ok(row_id) => {
-            let todo = Todo {
-                id: *row_id.uuid(),
-                title: request.title,
-                done: false,
-                description: if description.is_empty() {
-                    None
-                } else {
-                    Some(description)
-                },
-            };
+        Ok((row_id, row_values)) => {
+            let todo = row_to_todo(row_id, &row_values);
             broadcast_todos(&state).await;
             (StatusCode::CREATED, Json(todo)).into_response()
         }
@@ -469,7 +460,7 @@ async fn test_local_persistence() {
             Value::Null,
             Value::Null,
         ];
-        let row_id = client.create("todos", values).await.unwrap();
+        let (row_id, _row_values) = client.create("todos", values).await.unwrap();
 
         // Verify it exists
         let query = QueryBuilder::new("todos").build();
@@ -766,7 +757,7 @@ async fn test_server_resync() {
             Value::Null,
             Value::Null,
         ];
-        let _row_id = client.create("todos", values).await.unwrap();
+        let (_row_id, _row_values) = client.create("todos", values).await.unwrap();
 
         // Verify it exists locally
         let query = QueryBuilder::new("todos").build();

--- a/examples/docs/todo-server-ts/src/main.ts
+++ b/examples/docs/todo-server-ts/src/main.ts
@@ -181,14 +181,13 @@ export async function createServer(dataPath?: string): Promise<TodoServer> {
 
       const values = buildTodoValues(body);
 
-      const id = await client.create("todos", values);
+      const row = await client.create("todos", values);
+      const todo = rowToTodo(row.id, row.values);
 
-      const todo: Todo = {
-        id,
-        title: body.title,
-        done: false,
-        description: body.description,
-      };
+      if (!todo) {
+        res.status(500).json({ error: "Failed to create todo" });
+        return;
+      }
 
       res.status(201).json(todo);
 

--- a/examples/todo-server-rs/src/routes.rs
+++ b/examples/todo-server-rs/src/routes.rs
@@ -131,17 +131,8 @@ async fn create_todo(
     ];
 
     match state.client.create("todos", values).await {
-        Ok(row_id) => {
-            let todo = Todo {
-                id: *row_id.uuid(),
-                title: request.title,
-                done: false,
-                description: if description.is_empty() {
-                    None
-                } else {
-                    Some(description)
-                },
-            };
+        Ok((row_id, row_values)) => {
+            let todo = row_to_todo(row_id, &row_values);
 
             // Broadcast to SSE connections
             broadcast_todos(&state).await;

--- a/examples/todo-server-rs/tests/integration.rs
+++ b/examples/todo-server-rs/tests/integration.rs
@@ -212,17 +212,8 @@ async fn create_todo(
         Value::Null,
     ];
     match state.client.create("todos", values).await {
-        Ok(row_id) => {
-            let todo = Todo {
-                id: *row_id.uuid(),
-                title: request.title,
-                done: false,
-                description: if description.is_empty() {
-                    None
-                } else {
-                    Some(description)
-                },
-            };
+        Ok((row_id, row_values)) => {
+            let todo = row_to_todo(row_id, &row_values);
             broadcast_todos(&state).await;
             (StatusCode::CREATED, Json(todo)).into_response()
         }
@@ -469,7 +460,7 @@ async fn test_local_persistence() {
             Value::Null,
             Value::Null,
         ];
-        let row_id = client.create("todos", values).await.unwrap();
+        let (row_id, _row_values) = client.create("todos", values).await.unwrap();
 
         // Verify it exists
         let query = QueryBuilder::new("todos").build();
@@ -766,7 +757,7 @@ async fn test_server_resync() {
             Value::Null,
             Value::Null,
         ];
-        let _row_id = client.create("todos", values).await.unwrap();
+        let (_row_id, _row_values) = client.create("todos", values).await.unwrap();
 
         // Verify it exists locally
         let query = QueryBuilder::new("todos").build();

--- a/examples/todo-server-ts/src/main.ts
+++ b/examples/todo-server-ts/src/main.ts
@@ -179,14 +179,13 @@ export async function createServer(dataPath?: string): Promise<TodoServer> {
 
       const values = buildTodoValues(body);
 
-      const id = await client.create("todos", values);
+      const row = await client.create("todos", values);
+      const todo = rowToTodo(row.id, row.values);
 
-      const todo: Todo = {
-        id,
-        title: body.title,
-        done: false,
-        description: body.description,
-      };
+      if (!todo) {
+        res.status(500).json({ error: "Failed to create todo" });
+        return;
+      }
 
       res.status(201).json(todo);
 

--- a/packages/jazz-tools/src/dev-tools/extension-panel.ts
+++ b/packages/jazz-tools/src/dev-tools/extension-panel.ts
@@ -446,7 +446,7 @@ class DevToolsJazzClient implements JazzClient {
   forRequest(request: RequestLike): SessionClient {
     throw new Error("Method not implemented.");
   }
-  create(table: string, values: Value[], options?: { tier?: DurabilityTier }): Promise<string> {
+  create(table: string, values: Value[], options?: { tier?: DurabilityTier }): Promise<Row> {
     throw new Error("Method not implemented.");
   }
   async query(query: string | QueryInput, options?: QueryExecutionOptions): Promise<Row[]> {

--- a/packages/jazz-tools/src/react-native/jazz-rn-runtime-adapter.test.ts
+++ b/packages/jazz-tools/src/react-native/jazz-rn-runtime-adapter.test.ts
@@ -12,7 +12,7 @@ function createBinding(overrides: Partial<JazzRnRuntimeBinding> = {}): JazzRnRun
     executeSubscription: vi.fn(),
     flush: vi.fn(),
     getSchemaHash: vi.fn(() => "schema-hash"),
-    insert: vi.fn((_table, _valuesJson) => "row-1"),
+    insert: vi.fn((_table, _valuesJson) => JSON.stringify({ id: "row-1", values: [] })),
     onBatchedTickNeeded: vi.fn(),
     onSyncMessageReceived: vi.fn(),
     onSyncMessageReceivedFromClient: vi.fn(),
@@ -46,8 +46,8 @@ describe("JazzRnRuntimeAdapter", () => {
     const binding = createBinding();
     const adapter = new JazzRnRuntimeAdapter(binding, {});
 
-    const id = adapter.insert("todos", [{ type: "Text", value: "milk" }]);
-    expect(id).toBe("row-1");
+    const row = adapter.insert("todos", [{ type: "Text", value: "milk" }]);
+    expect(row).toEqual({ id: "row-1", values: [] });
     expect(binding.insert).toHaveBeenCalledWith(
       "todos",
       JSON.stringify([{ type: "Text", value: "milk" }]),
@@ -185,7 +185,10 @@ describe("JazzRnRuntimeAdapter", () => {
     const binding = createBinding();
     const adapter = new JazzRnRuntimeAdapter(binding, {});
 
-    await expect(adapter.insertDurable("todos", [], "worker")).resolves.toBe("row-1");
+    await expect(adapter.insertDurable("todos", [], "worker")).resolves.toEqual({
+      id: "row-1",
+      values: [],
+    });
     expect(binding.flush).toHaveBeenCalledTimes(1);
 
     await expect(adapter.updateDurable("row-1", {}, "worker")).resolves.toBeUndefined();

--- a/packages/jazz-tools/src/react-native/jazz-rn-runtime-adapter.ts
+++ b/packages/jazz-tools/src/react-native/jazz-rn-runtime-adapter.ts
@@ -1,5 +1,5 @@
 import type { WasmSchema } from "../drivers/types.js";
-import type { Runtime } from "../runtime/client.js";
+import type { Row, Runtime } from "../runtime/client.js";
 import { OutboxDestinationKind } from "../runtime/sync-transport.js";
 
 export interface JazzRnRuntimeBinding {
@@ -118,8 +118,9 @@ export class JazzRnRuntimeAdapter implements Runtime {
     });
   }
 
-  insert(table: string, values: any): string {
-    return this.binding.insert(table, JSON.stringify(values));
+  insert(table: string, values: any): Row {
+    const rowJson = this.binding.insert(table, JSON.stringify(values));
+    return JSON.parse(rowJson) as Row;
   }
 
   update(object_id: string, values: any): void {
@@ -218,11 +219,11 @@ export class JazzRnRuntimeAdapter implements Runtime {
     this.handleMap.delete(handle);
   }
 
-  insertDurable(table: string, values: any, tier: string): Promise<string> {
+  insertDurable(table: string, values: any, tier: string): Promise<Row> {
     assertWorkerTier(tier);
-    const id = this.insert(table, values);
+    const row = this.insert(table, values);
     this.binding.flush();
-    return Promise.resolve(id);
+    return Promise.resolve(row);
   }
 
   updateDurable(object_id: string, values: any, tier: string): Promise<void> {

--- a/packages/jazz-tools/src/react/create-jazz-client.integration.test.ts
+++ b/packages/jazz-tools/src/react/create-jazz-client.integration.test.ts
@@ -56,11 +56,13 @@ describe("react/create-jazz-client integration", () => {
     try {
       client = await createJazzClient({ appId: makeAppId("mutation-query") });
 
-      const id = await client.db.insert(todosTable, { title: "buy milk", done: false });
+      const inserted = await client.db.insert(todosTable, { title: "buy milk", done: false });
       const rows = await client.db.all(allTodosQuery);
 
       expect(
-        rows.some((row) => row.id === id && row.title === "buy milk" && row.done === false),
+        rows.some(
+          (row) => row.id === inserted.id && row.title === "buy milk" && row.done === false,
+        ),
       ).toBe(true);
     } finally {
       if (client) {

--- a/packages/jazz-tools/src/runtime/client.for-request.test.ts
+++ b/packages/jazz-tools/src/runtime/client.for-request.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { JazzClient, type Runtime } from "./client.js";
+import { JazzClient, type Row, type Runtime } from "./client.js";
 import type { AppContext } from "./context.js";
 import { deriveLocalPrincipalId } from "./client-session.js";
 
@@ -27,6 +27,10 @@ function makeJwt(payload: Record<string, unknown>): string {
 
 async function flushMicrotasks(): Promise<void> {
   await Promise.resolve();
+}
+
+function mockRow(id = "todo-1"): Row {
+  return { id, values: [] };
 }
 
 function makeClient() {
@@ -448,9 +452,9 @@ describe("JazzClient.forRequest", () => {
 
 describe("JazzClient schema order", () => {
   it("passes create values through in the declared schema order", async () => {
-    const insertDurable = vi.fn(async () => "todo-1");
+    const insertDurable = vi.fn(async () => mockRow());
     const runtime: Runtime = {
-      insert: () => "todo-1",
+      insert: () => mockRow(),
       update: () => {},
       delete: () => {},
       query: async () => [],
@@ -527,7 +531,7 @@ describe("JazzClient schema order", () => {
     const query = vi.fn(async () => []);
     const createSubscription = vi.fn(() => 0);
     const runtime: Runtime = {
-      insert: () => "todo-1",
+      insert: () => mockRow(),
       update: () => {},
       delete: () => {},
       query,
@@ -535,7 +539,7 @@ describe("JazzClient schema order", () => {
       createSubscription,
       executeSubscription: () => {},
       unsubscribe: () => {},
-      insertDurable: async () => "todo-1",
+      insertDurable: async () => mockRow(),
       updateDurable: async () => {},
       deleteDurable: async () => {},
       onSyncMessageReceived: () => {},
@@ -599,7 +603,7 @@ describe("JazzClient schema order", () => {
 
   it("reorders query rows back to the declared schema order", async () => {
     const runtime: Runtime = {
-      insert: () => "todo-1",
+      insert: () => mockRow(),
       update: () => {},
       delete: () => {},
       query: async () => [
@@ -615,7 +619,7 @@ describe("JazzClient schema order", () => {
       createSubscription: () => 0,
       executeSubscription: () => {},
       unsubscribe: () => {},
-      insertDurable: async () => "todo-1",
+      insertDurable: async () => mockRow(),
       updateDurable: async () => {},
       deleteDurable: async () => {},
       onSyncMessageReceived: () => {},
@@ -682,7 +686,7 @@ describe("JazzClient schema order", () => {
 
   it("reorders query row columns while preserving included relation values", async () => {
     const runtime: Runtime = {
-      insert: () => "todo-1",
+      insert: () => mockRow(),
       update: () => {},
       delete: () => {},
       query: async () => [
@@ -710,7 +714,7 @@ describe("JazzClient schema order", () => {
       createSubscription: () => 0,
       executeSubscription: () => {},
       unsubscribe: () => {},
-      insertDurable: async () => "todo-1",
+      insertDurable: async () => mockRow(),
       updateDurable: async () => {},
       deleteDurable: async () => {},
       onSyncMessageReceived: () => {},
@@ -789,7 +793,7 @@ describe("JazzClient schema order", () => {
 
   it("reorders included relation row values to the declared schema order", async () => {
     const runtime: Runtime = {
-      insert: () => "todo-1",
+      insert: () => mockRow(),
       update: () => {},
       delete: () => {},
       query: async () => [
@@ -820,7 +824,7 @@ describe("JazzClient schema order", () => {
       createSubscription: () => 0,
       executeSubscription: () => {},
       unsubscribe: () => {},
-      insertDurable: async () => "todo-1",
+      insertDurable: async () => mockRow(),
       updateDurable: async () => {},
       deleteDurable: async () => {},
       onSyncMessageReceived: () => {},
@@ -937,7 +941,7 @@ describe("JazzClient schema order", () => {
   it("reorders subscription deltas back to the declared schema order", async () => {
     let onUpdate: ((delta: unknown) => void) | undefined;
     const runtime: Runtime = {
-      insert: () => "todo-1",
+      insert: () => mockRow(),
       update: () => {},
       delete: () => {},
       query: async () => [],
@@ -947,7 +951,7 @@ describe("JazzClient schema order", () => {
         onUpdate = callback as (delta: unknown) => void;
       },
       unsubscribe: () => {},
-      insertDurable: async () => "todo-1",
+      insertDurable: async () => mockRow(),
       updateDurable: async () => {},
       deleteDurable: async () => {},
       onSyncMessageReceived: () => {},

--- a/packages/jazz-tools/src/runtime/client.for-request.test.ts
+++ b/packages/jazz-tools/src/runtime/client.for-request.test.ts
@@ -40,7 +40,7 @@ function makeClient() {
   let nextHandle = 0;
 
   const runtime: Runtime = {
-    insert: () => "00000000-0000-0000-0000-000000000001",
+    insert: () => ({ id: "00000000-0000-0000-0000-000000000001", values: [] }),
     update: () => {},
     delete: () => {},
     query: async (
@@ -78,7 +78,7 @@ function makeClient() {
     unsubscribe: (handle: number) => {
       unsubscribeCalls.push(handle);
     },
-    insertDurable: async () => "00000000-0000-0000-0000-000000000001",
+    insertDurable: async () => ({ id: "00000000-0000-0000-0000-000000000001", values: [] }),
     updateDurable: async () => {},
     deleteDurable: async () => {},
     onSyncMessageReceived: () => {},
@@ -116,7 +116,7 @@ function makeClient() {
 function makeClientWithContext(context: AppContext): JazzClient {
   let nextHandle = 0;
   const runtime: Runtime = {
-    insert: () => "00000000-0000-0000-0000-000000000001",
+    insert: () => ({ id: "00000000-0000-0000-0000-000000000001", values: [] }),
     update: () => {},
     delete: () => {},
     query: async () => [],
@@ -124,7 +124,7 @@ function makeClientWithContext(context: AppContext): JazzClient {
     createSubscription: () => nextHandle++,
     executeSubscription: () => {},
     unsubscribe: () => {},
-    insertDurable: async () => "00000000-0000-0000-0000-000000000001",
+    insertDurable: async () => ({ id: "00000000-0000-0000-0000-000000000001", values: [] }),
     updateDurable: async () => {},
     deleteDurable: async () => {},
     onSyncMessageReceived: () => {},

--- a/packages/jazz-tools/src/runtime/client.ts
+++ b/packages/jazz-tools/src/runtime/client.ts
@@ -44,8 +44,8 @@ export interface RequestLike {
  * satisfy this interface, allowing `JazzClient` to work with either backend.
  */
 export interface Runtime {
-  insert(table: string, values: any): string;
-  insertDurable(table: string, values: any, tier: string): Promise<string>;
+  insert(table: string, values: any): Row;
+  insertDurable(table: string, values: any, tier: string): Promise<Row>;
   update(object_id: string, values: any): void;
   updateDurable(object_id: string, values: any, tier: string): Promise<void>;
   delete(object_id: string): void;
@@ -877,7 +877,7 @@ export class JazzClient {
   /**
    * Insert a new row into a table and wait for durability at the requested tier.
    */
-  async create(table: string, values: Value[], options?: WriteDurabilityOptions): Promise<string> {
+  async create(table: string, values: Value[], options?: WriteDurabilityOptions): Promise<Row> {
     const tier = this.resolveWriteTier(options);
     return this.runtime.insertDurable(table, values, tier);
   }

--- a/packages/jazz-tools/src/runtime/client.ts
+++ b/packages/jazz-tools/src/runtime/client.ts
@@ -879,7 +879,11 @@ export class JazzClient {
    */
   async create(table: string, values: Value[], options?: WriteDurabilityOptions): Promise<Row> {
     const tier = this.resolveWriteTier(options);
-    return this.runtime.insertDurable(table, values, tier);
+    const row = await this.runtime.insertDurable(table, values, tier);
+    return {
+      ...row,
+      values: this.alignRowValuesToDeclaredSchema(table, row.values as Value[], this.getSchema()),
+    };
   }
 
   /**

--- a/packages/jazz-tools/src/runtime/cloud-server.integration.test.ts
+++ b/packages/jazz-tools/src/runtime/cloud-server.integration.test.ts
@@ -932,59 +932,71 @@ function buildProfileByIdQuery(schema: WasmSchema, id: string): string {
 }
 
 async function seedSocialGraph(client: JazzClient): Promise<SocialSeed> {
-  const aliceProfileId = await client.create(
-    "profiles",
-    [
-      { type: "Text", value: "alice" },
-      { type: "Text", value: "alice" },
-    ],
-    { tier: "edge" },
-  );
-  const bobProfileId = await client.create(
-    "profiles",
-    [
-      { type: "Text", value: "bob" },
-      { type: "Text", value: "bob" },
-    ],
-    { tier: "edge" },
-  );
-  const carolProfileId = await client.create(
-    "profiles",
-    [
-      { type: "Text", value: "carol" },
-      { type: "Text", value: "carol" },
-    ],
-    { tier: "edge" },
-  );
-  const eveProfileId = await client.create(
-    "profiles",
-    [
-      { type: "Text", value: "eve" },
-      { type: "Text", value: "eve" },
-    ],
-    { tier: "edge" },
-  );
+  const aliceProfileId = (
+    await client.create(
+      "profiles",
+      [
+        { type: "Text", value: "alice" },
+        { type: "Text", value: "alice" },
+      ],
+      { tier: "edge" },
+    )
+  ).id;
+  const bobProfileId = (
+    await client.create(
+      "profiles",
+      [
+        { type: "Text", value: "bob" },
+        { type: "Text", value: "bob" },
+      ],
+      { tier: "edge" },
+    )
+  ).id;
+  const carolProfileId = (
+    await client.create(
+      "profiles",
+      [
+        { type: "Text", value: "carol" },
+        { type: "Text", value: "carol" },
+      ],
+      { tier: "edge" },
+    )
+  ).id;
+  const eveProfileId = (
+    await client.create(
+      "profiles",
+      [
+        { type: "Text", value: "eve" },
+        { type: "Text", value: "eve" },
+      ],
+      { tier: "edge" },
+    )
+  ).id;
   const alicePrincipal = "alice";
   const bobPrincipal = "bob";
   const carolPrincipal = "carol";
   const evePrincipal = "eve";
 
-  const alicePersonId = await client.create(
-    "people",
-    [
-      { type: "Uuid", value: aliceProfileId },
-      { type: "Text", value: alicePrincipal },
-    ],
-    { tier: "edge" },
-  );
-  const bobPersonId = await client.create(
-    "people",
-    [
-      { type: "Uuid", value: bobProfileId },
-      { type: "Text", value: bobPrincipal },
-    ],
-    { tier: "edge" },
-  );
+  const alicePersonId = (
+    await client.create(
+      "people",
+      [
+        { type: "Uuid", value: aliceProfileId },
+        { type: "Text", value: alicePrincipal },
+      ],
+      { tier: "edge" },
+    )
+  ).id;
+  const bobPersonId = (
+    await client.create(
+      "people",
+      [
+        { type: "Uuid", value: bobProfileId },
+        { type: "Text", value: bobPrincipal },
+      ],
+      { tier: "edge" },
+    )
+  ).id;
   await client.create(
     "people",
     [
@@ -993,14 +1005,16 @@ async function seedSocialGraph(client: JazzClient): Promise<SocialSeed> {
     ],
     { tier: "edge" },
   );
-  const evePersonId = await client.create(
-    "people",
-    [
-      { type: "Uuid", value: eveProfileId },
-      { type: "Text", value: evePrincipal },
-    ],
-    { tier: "edge" },
-  );
+  const evePersonId = (
+    await client.create(
+      "people",
+      [
+        { type: "Uuid", value: eveProfileId },
+        { type: "Text", value: evePrincipal },
+      ],
+      { tier: "edge" },
+    )
+  ).id;
 
   await client.create(
     "friendships",
@@ -1255,14 +1269,16 @@ describe("cloud-server integration (Jazz TS)", () => {
         makeContext(app.app_id, server.baseUrl, signJwt("b", JWT_SECRET)),
       );
 
-      const rowId = await clientA.create(
-        "todos",
-        [
-          { type: "Text", value: "shared-item" },
-          { type: "Boolean", value: false },
-        ],
-        { tier: "edge" },
-      );
+      const rowId = (
+        await clientA.create(
+          "todos",
+          [
+            { type: "Text", value: "shared-item" },
+            { type: "Boolean", value: false },
+          ],
+          { tier: "edge" },
+        )
+      ).id;
 
       const rowsAfterCreate = await waitForRows(clientB, queryAllTodos, (rows) =>
         rows.some((row) => row.id === rowId),

--- a/packages/jazz-tools/src/runtime/db.schema-order.test.ts
+++ b/packages/jazz-tools/src/runtime/db.schema-order.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { Db, type QueryBuilder, type TableProxy } from "./db.js";
 import type { Value, WasmRow, WasmSchema } from "../drivers/types.js";
-import type { JazzClient } from "./client.js";
+import type { JazzClient, Row } from "./client.js";
 
 class TestDb extends Db {
   constructor(private readonly testClient: JazzClient) {
@@ -31,8 +31,14 @@ describe("Db runtime schema order", () => {
         ],
       },
     };
-    const create = vi.fn<(...args: [string, Value[], { tier?: string }?]) => Promise<string>>(
-      async () => "todo-1",
+    const create = vi.fn<(...args: [string, Value[], { tier?: string }?]) => Promise<Row>>(
+      async () => ({
+        id: "todo-1",
+        values: [
+          { type: "Text", value: "Buy milk" },
+          { type: "Boolean", value: false },
+        ],
+      }),
     );
     const client = {
       getSchema: () => new Map(Object.entries(runtimeSchema)),
@@ -49,7 +55,7 @@ describe("Db runtime schema order", () => {
       { title: string; done: boolean }
     >;
 
-    await db.insert(table, { title: "Buy milk", done: false });
+    const row = await db.insert(table, { title: "Buy milk", done: false });
 
     expect(create).toHaveBeenCalledWith(
       "todos",
@@ -59,6 +65,11 @@ describe("Db runtime schema order", () => {
       ],
       undefined,
     );
+    expect(row).toEqual({
+      id: "todo-1",
+      title: "Buy milk",
+      done: false,
+    });
   });
 
   it("uses the generated schema order when transforming query results", async () => {
@@ -125,8 +136,14 @@ describe("Db runtime schema order", () => {
         ],
       },
     };
-    const create = vi.fn<(...args: [string, Value[], { tier?: string }?]) => Promise<string>>(
-      async () => "todo-1",
+    const create = vi.fn<(...args: [string, Value[], { tier?: string }?]) => Promise<Row>>(
+      async () => ({
+        id: "todo-1",
+        values: [
+          { type: "Text", value: "Buy milk" },
+          { type: "Boolean", value: false },
+        ],
+      }),
     );
     const client = {
       getSchema: () => new Map(),
@@ -143,7 +160,7 @@ describe("Db runtime schema order", () => {
       { title: string; done: boolean }
     >;
 
-    await db.insert(table, { title: "Buy milk", done: false });
+    const row = await db.insert(table, { title: "Buy milk", done: false });
 
     expect(create).toHaveBeenCalledWith(
       "todos",
@@ -153,6 +170,11 @@ describe("Db runtime schema order", () => {
       ],
       undefined,
     );
+    expect(row).toEqual({
+      id: "todo-1",
+      title: "Buy milk",
+      done: false,
+    });
   });
 
   it("falls back to the generated schema for query results when the runtime schema is missing a table", async () => {

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -23,7 +23,7 @@ import {
 } from "./client.js";
 import { WorkerBridge, type PeerSyncBatch, type WorkerBridgeOptions } from "./worker-bridge.js";
 import { translateQuery } from "./query-adapter.js";
-import { transformRows, type IncludeSpec } from "./row-transformer.js";
+import { transformRow, transformRows, type IncludeSpec } from "./row-transformer.js";
 import { toValueArray, toUpdateRecord } from "./value-converter.js";
 import { SubscriptionManager, type SubscriptionDelta } from "./subscription-manager.js";
 import { resolveLocalAuthDefaults } from "./local-auth.js";
@@ -346,13 +346,13 @@ function isLeaderDebugEnabled(): boolean {
  * const db = await createDb({ appId: "my-app", driver });
  *
  * // Async mutations
- * const id = await db.insert(app.todos, { title: "Buy milk", done: false });
- * await db.update(app.todos, id, { done: true });
- * await db.deleteFrom(app.todos, id);
+ * const inserted = await db.insert(app.todos, { title: "Buy milk", done: false });
+ * await db.update(app.todos, inserted.id, { done: true });
+ * await db.deleteFrom(app.todos, inserted.id);
  *
  * // Async queries (need storage I/O)
  * const todos = await db.all(app.todos.where({ done: false }));
- * const todo = await db.one(app.todos.where({ id }));
+ * const todo = await db.one(app.todos.where({ id: inserted.id }));
  *
  * // Subscriptions
  * const unsubscribe = db.subscribeAll(app.todos, (delta) => {
@@ -984,13 +984,13 @@ export class Db {
    * @param table Table proxy from generated app module
    * @param data Init object with column values
    * @param options Optional durability tier override
-   * @returns Promise resolving to the new row's ID
+   * @returns Promise resolving to the inserted row
    */
   async insert<T, Init>(
     table: TableProxy<T, Init>,
     data: Init,
     options?: { tier?: DurabilityTier },
-  ): Promise<string> {
+  ): Promise<T> {
     const client = this.getClient(table._schema);
     const inputSchema = resolveSchemaWithTable(
       table._schema,
@@ -999,7 +999,8 @@ export class Db {
     );
     await this.ensureBridgeReady();
     const values = toValueArray(data as Record<string, unknown>, inputSchema, table._table);
-    return client.create(table._table, values, options);
+    const row = await client.create(table._table, values, options);
+    return transformRow(row, table._schema, table._table);
   }
 
   /**

--- a/packages/jazz-tools/src/runtime/row-transformer.ts
+++ b/packages/jazz-tools/src/runtime/row-transformer.ts
@@ -195,3 +195,12 @@ export function transformRows<T>(
     ) as T;
   });
 }
+
+export function transformRow<T>(
+  row: WasmRow,
+  schema: WasmSchema,
+  tableName: string,
+  includes: IncludeSpec = {},
+): T {
+  return transformRows<T>([row], schema, tableName, includes)[0];
+}

--- a/packages/jazz-tools/src/runtime/worker-bridge.test.ts
+++ b/packages/jazz-tools/src/runtime/worker-bridge.test.ts
@@ -58,13 +58,13 @@ function createRuntimeMock(): {
   const removeServerCalls = { count: 0 };
 
   const runtime: Runtime = {
-    insert: () => "id",
+    insert: () => ({ id: "id", values: [] }),
     update: () => undefined,
     delete: () => undefined,
     query: async () => [],
     subscribe: () => 1,
     unsubscribe: () => undefined,
-    insertDurable: async () => "id",
+    insertDurable: async () => ({ id: "id", values: [] }),
     updateDurable: async () => undefined,
     deleteDurable: async () => undefined,
     createSubscription: () => 1,

--- a/packages/jazz-tools/src/subscriptions-orchestrator.integration.test.ts
+++ b/packages/jazz-tools/src/subscriptions-orchestrator.integration.test.ts
@@ -89,16 +89,16 @@ describe("SubscriptionsOrchestrator integration coverage", () => {
           observedSnapshots.push(delta.all);
         },
       });
-      const insertedId = await db.insert(todosTable, { title: "first", done: false });
+      const inserted = await db.insert(todosTable, { title: "first", done: false });
 
       await waitForCondition(
-        () => observedSnapshots.some((snapshot) => snapshot.some((row) => row.id === insertedId)),
+        () => observedSnapshots.some((snapshot) => snapshot.some((row) => row.id === inserted.id)),
         5_000,
         "SO-I01 expected snapshot to include inserted row",
       );
 
       const latest = observedSnapshots[observedSnapshots.length - 1];
-      expect(latest.some((row) => row.id === insertedId)).toBe(true);
+      expect(latest.some((row) => row.id === inserted.id)).toBe(true);
       expect(latest.some((row) => row.title === "first")).toBe(true);
       expect(entry.status).toBe("fulfilled");
 
@@ -186,7 +186,7 @@ describe("SubscriptionsOrchestrator integration coverage", () => {
         },
       });
 
-      const insertedId = await db.insert(todosTable, { title: "shared", done: false });
+      const { id: insertedId } = await db.insert(todosTable, { title: "shared", done: false });
       await waitForCondition(
         () => listenerA.length > 0 && listenerB.length > 0,
         5_000,

--- a/packages/jazz-tools/src/types/jazz-wasm.d.ts
+++ b/packages/jazz-tools/src/types/jazz-wasm.d.ts
@@ -29,8 +29,12 @@ declare module "jazz-wasm" {
     );
     schedule?: (task: () => void) => void;
 
-    insert(table: string, values: unknown): string;
-    insertDurable(table: string, values: unknown, tier: string): Promise<string>;
+    insert(table: string, values: unknown): { id: string; values: any[] };
+    insertDurable(
+      table: string,
+      values: unknown,
+      tier: string,
+    ): Promise<{ id: string; values: any[] }>;
     update(objectId: string, values: unknown): void;
     updateDurable(objectId: string, values: unknown, tier: string): Promise<void>;
     delete(objectId: string): void;

--- a/packages/jazz-tools/src/vue/create-jazz-client.integration.test.ts
+++ b/packages/jazz-tools/src/vue/create-jazz-client.integration.test.ts
@@ -56,11 +56,13 @@ describe("vue/create-jazz-client integration", () => {
     try {
       client = await createJazzClient({ appId: makeAppId("mutation-query") });
 
-      const id = await client.db.insert(todosTable, { title: "buy milk", done: false });
+      const inserted = await client.db.insert(todosTable, { title: "buy milk", done: false });
       const rows = await client.db.all(allTodosQuery);
 
       expect(
-        rows.some((row) => row.id === id && row.title === "buy milk" && row.done === false),
+        rows.some(
+          (row) => row.id === inserted.id && row.title === "buy milk" && row.done === false,
+        ),
       ).toBe(true);
     } finally {
       if (client) {

--- a/packages/jazz-tools/tests/browser/db.all.test.ts
+++ b/packages/jazz-tools/tests/browser/db.all.test.ts
@@ -249,9 +249,13 @@ describe("db.all browser integration", () => {
   }
 
   async function seedTodosForConditions(db: Db): Promise<void> {
-    const orgId = await db.insert(orgs, { name: "Acme" });
-    const teamId = await db.insert(teams, { name: "Core", org_id: orgId, parent_id: undefined });
-    const userId = await db.insert(users, { name: "Alice", team_id: teamId });
+    const { id: orgId } = await db.insert(orgs, { name: "Acme" });
+    const { id: teamId } = await db.insert(teams, {
+      name: "Core",
+      org_id: orgId,
+      parent_id: undefined,
+    });
+    const { id: userId } = await db.insert(users, { name: "Alice", team_id: teamId });
 
     await db.insert(todos, {
       title: "alpha",
@@ -316,7 +320,7 @@ describe("db.all browser integration", () => {
       }),
     );
 
-    const id = await db.insert(todos, {
+    const { id } = await db.insert(todos, {
       title: "has-bytes",
       done: false,
       priority: 1,
@@ -387,9 +391,13 @@ describe("db.all browser integration", () => {
       }),
     );
 
-    const orgId = await db.insert(orgs, { name: "Acme" });
-    const teamId = await db.insert(teams, { name: "Core", org_id: orgId, parent_id: undefined });
-    const ownerId = await db.insert(users, { name: "Owner", team_id: teamId });
+    const { id: orgId } = await db.insert(orgs, { name: "Acme" });
+    const { id: teamId } = await db.insert(teams, {
+      name: "Core",
+      org_id: orgId,
+      parent_id: undefined,
+    });
+    const { id: ownerId } = await db.insert(users, { name: "Owner", team_id: teamId });
     await db.insert(todos, {
       title: "with-owner-1",
       done: false,
@@ -434,9 +442,13 @@ describe("db.all browser integration", () => {
       }),
     );
 
-    const orgId = await db.insert(orgs, { name: "Org A" });
-    const teamId = await db.insert(teams, { name: "Team A", org_id: orgId, parent_id: undefined });
-    const userId = await db.insert(users, { name: "User A", team_id: teamId });
+    const { id: orgId } = await db.insert(orgs, { name: "Org A" });
+    const { id: teamId } = await db.insert(teams, {
+      name: "Team A",
+      org_id: orgId,
+      parent_id: undefined,
+    });
+    const { id: userId } = await db.insert(users, { name: "User A", team_id: teamId });
 
     const rows = await db.all<Org>(
       makeQuery<Org>("users", {
@@ -457,13 +469,17 @@ describe("db.all browser integration", () => {
       }),
     );
 
-    const orgId = await db.insert(orgs, { name: "FK Org" });
-    const teamId = await db.insert(teams, { name: "FK Team", org_id: orgId, parent_id: undefined });
-    const userId = await db.insert(users, { name: "FK User", team_id: teamId });
+    const { id: orgId } = await db.insert(orgs, { name: "FK Org" });
+    const { id: teamId } = await db.insert(teams, {
+      name: "FK Team",
+      org_id: orgId,
+      parent_id: undefined,
+    });
+    const { id: userId } = await db.insert(users, { name: "FK User", team_id: teamId });
 
-    const partAId = await db.insert(fileParts, { label: "A" });
-    const partBId = await db.insert(fileParts, { label: "B" });
-    const fileId = await db.insert(files, { name: "File 1", parts: [partBId, partAId] });
+    const { id: partAId } = await db.insert(fileParts, { label: "A" });
+    const { id: partBId } = await db.insert(fileParts, { label: "B" });
+    const { id: fileId } = await db.insert(files, { name: "File 1", parts: [partBId, partAId] });
 
     const teamRows = await db.all<Team>(
       makeQuery<Team>("users", {
@@ -492,13 +508,21 @@ describe("db.all browser integration", () => {
       }),
     );
 
-    const rootId = await db.insert(teams, {
+    const { id: rootId } = await db.insert(teams, {
       name: "root",
       org_id: undefined,
       parent_id: undefined,
     });
-    const midId = await db.insert(teams, { name: "mid", org_id: undefined, parent_id: rootId });
-    const leafId = await db.insert(teams, { name: "leaf", org_id: undefined, parent_id: midId });
+    const { id: midId } = await db.insert(teams, {
+      name: "mid",
+      org_id: undefined,
+      parent_id: rootId,
+    });
+    const { id: leafId } = await db.insert(teams, {
+      name: "leaf",
+      org_id: undefined,
+      parent_id: midId,
+    });
 
     const rows = await db.all<Team>(
       makeQuery<Team>("teams", {

--- a/packages/jazz-tools/tests/browser/db.subscribeAll.sort.test.ts
+++ b/packages/jazz-tools/tests/browser/db.subscribeAll.sort.test.ts
@@ -101,10 +101,10 @@ describe("db.subscribeAll sorting browser integration", () => {
       });
 
       try {
-        const idA = await db.insert(todos, { title: "A", rank: 10, done: false });
-        const idB = await db.insert(todos, { title: "B", rank: 20, done: false });
-        const idC = await db.insert(todos, { title: "C", rank: 30, done: false });
-        const idD = await db.insert(todos, { title: "D", rank: 40, done: false });
+        const { id: idA } = await db.insert(todos, { title: "A", rank: 10, done: false });
+        const { id: idB } = await db.insert(todos, { title: "B", rank: 20, done: false });
+        const { id: idC } = await db.insert(todos, { title: "C", rank: 30, done: false });
+        const { id: idD } = await db.insert(todos, { title: "D", rank: 40, done: false });
 
         await waitForCondition(
           () => latestRows(deltas.map((delta) => delta.all)).length === 4,
@@ -143,9 +143,9 @@ describe("db.subscribeAll sorting browser integration", () => {
       });
 
       try {
-        const idA = await db.insert(todos, { title: "A", rank: 1, done: false });
-        const idB = await db.insert(todos, { title: "B", rank: 2, done: false });
-        const idC = await db.insert(todos, { title: "C", rank: 3, done: false });
+        const { id: idA } = await db.insert(todos, { title: "A", rank: 1, done: false });
+        const { id: idB } = await db.insert(todos, { title: "B", rank: 2, done: false });
+        const { id: idC } = await db.insert(todos, { title: "C", rank: 3, done: false });
 
         await waitForCondition(
           () => deltas.some((delta) => delta.all.length === 3),
@@ -180,9 +180,9 @@ describe("db.subscribeAll sorting browser integration", () => {
       });
 
       try {
-        const idA = await db.insert(todos, { title: "A", rank: 1, done: false });
-        const idB = await db.insert(todos, { title: "B", rank: 2, done: false });
-        const idC = await db.insert(todos, { title: "C", rank: 3, done: false });
+        const { id: idA } = await db.insert(todos, { title: "A", rank: 1, done: false });
+        const { id: idB } = await db.insert(todos, { title: "B", rank: 2, done: false });
+        const { id: idC } = await db.insert(todos, { title: "C", rank: 3, done: false });
 
         await waitForCondition(
           () => snapshots.some((rows) => rows.length === 3),
@@ -216,9 +216,9 @@ describe("db.subscribeAll sorting browser integration", () => {
       });
 
       try {
-        const idA = await db.insert(todos, { title: "A", rank: 1, done: false });
-        const idB = await db.insert(todos, { title: "B", rank: 2, done: false });
-        const idC = await db.insert(todos, { title: "C", rank: 3, done: false });
+        const { id: idA } = await db.insert(todos, { title: "A", rank: 1, done: false });
+        const { id: idB } = await db.insert(todos, { title: "B", rank: 2, done: false });
+        const { id: idC } = await db.insert(todos, { title: "C", rank: 3, done: false });
 
         await waitForCondition(
           () => snapshots.some((rows) => rows.length === 3),
@@ -252,9 +252,9 @@ describe("db.subscribeAll sorting browser integration", () => {
       });
 
       try {
-        const idA = await db.insert(todos, { title: "A", rank: 10, done: false });
-        const idB = await db.insert(todos, { title: "B", rank: 5, done: false });
-        const idC = await db.insert(todos, { title: "C", rank: 1, done: false });
+        const { id: idA } = await db.insert(todos, { title: "A", rank: 10, done: false });
+        const { id: idB } = await db.insert(todos, { title: "B", rank: 5, done: false });
+        const { id: idC } = await db.insert(todos, { title: "C", rank: 1, done: false });
 
         await waitForCondition(
           () => latestRows(snapshots).length === 3,
@@ -291,9 +291,9 @@ describe("db.subscribeAll sorting browser integration", () => {
       );
 
       try {
-        const idA = await db.insert(todos, { title: "A", rank: 1, done: false });
-        const idB = await db.insert(todos, { title: "B", rank: 2, done: false });
-        const idC = await db.insert(todos, { title: "C", rank: 3, done: false });
+        const { id: idA } = await db.insert(todos, { title: "A", rank: 1, done: false });
+        const { id: idB } = await db.insert(todos, { title: "B", rank: 2, done: false });
+        const { id: idC } = await db.insert(todos, { title: "C", rank: 3, done: false });
 
         await waitForCondition(
           () => latestRows(snapshots).length === 3,
@@ -325,9 +325,9 @@ describe("db.subscribeAll sorting browser integration", () => {
       });
 
       try {
-        const idA = await db.insert(todos, { title: "A", rank: 1, done: false });
-        const idB = await db.insert(todos, { title: "B", rank: 1, done: false });
-        const idC = await db.insert(todos, { title: "C", rank: 1, done: false });
+        const { id: idA } = await db.insert(todos, { title: "A", rank: 1, done: false });
+        const { id: idB } = await db.insert(todos, { title: "B", rank: 1, done: false });
+        const { id: idC } = await db.insert(todos, { title: "C", rank: 1, done: false });
 
         await waitForCondition(
           () => latestRows(snapshots).length === 3,
@@ -359,9 +359,9 @@ describe("db.subscribeAll sorting browser integration", () => {
       );
 
       try {
-        const idA = await db.insert(todos, { title: "A", rank: 1, done: false });
-        const idZ = await db.insert(todos, { title: "Z", rank: 1, done: false });
-        const idM = await db.insert(todos, { title: "M", rank: 2, done: false });
+        const { id: idA } = await db.insert(todos, { title: "A", rank: 1, done: false });
+        const { id: idZ } = await db.insert(todos, { title: "Z", rank: 1, done: false });
+        const { id: idM } = await db.insert(todos, { title: "M", rank: 2, done: false });
 
         await waitForCondition(
           () => latestRows(snapshots).length === 3,
@@ -393,9 +393,9 @@ describe("db.subscribeAll sorting browser integration", () => {
       });
 
       try {
-        const idA = await db.insert(todos, { title: "A", rank: 1, done: false });
-        const idB = await db.insert(todos, { title: "B", rank: 2, done: false });
-        const idC = await db.insert(todos, { title: "C", rank: 3, done: false });
+        const { id: idA } = await db.insert(todos, { title: "A", rank: 1, done: false });
+        const { id: idB } = await db.insert(todos, { title: "B", rank: 2, done: false });
+        const { id: idC } = await db.insert(todos, { title: "C", rank: 3, done: false });
 
         await waitForCondition(
           () => latestRows(snapshots).length === 3,
@@ -431,10 +431,10 @@ describe("db.subscribeAll sorting browser integration", () => {
       );
 
       try {
-        const idA = await db.insert(todos, { title: "A", rank: 1, done: false });
-        const idB = await db.insert(todos, { title: "B", rank: 2, done: false });
-        const idC = await db.insert(todos, { title: "C", rank: 3, done: false });
-        const idD = await db.insert(todos, { title: "D", rank: 4, done: false });
+        const { id: idA } = await db.insert(todos, { title: "A", rank: 1, done: false });
+        const { id: idB } = await db.insert(todos, { title: "B", rank: 2, done: false });
+        const { id: idC } = await db.insert(todos, { title: "C", rank: 3, done: false });
+        const { id: idD } = await db.insert(todos, { title: "D", rank: 4, done: false });
 
         await waitForCondition(
           () => latestRows(snapshots).length === 2,
@@ -469,9 +469,9 @@ describe("db.subscribeAll sorting browser integration", () => {
       });
 
       try {
-        const idA = await db.insert(todos, { title: "A", rank: 1, done: false });
-        const idB = await db.insert(todos, { title: "B", rank: 2, done: false });
-        const idC = await db.insert(todos, { title: "C", rank: 3, done: false });
+        const { id: idA } = await db.insert(todos, { title: "A", rank: 1, done: false });
+        const { id: idB } = await db.insert(todos, { title: "B", rank: 2, done: false });
+        const { id: idC } = await db.insert(todos, { title: "C", rank: 3, done: false });
 
         await waitForCondition(
           () => latestRows(snapshots).length === 3,
@@ -481,7 +481,7 @@ describe("db.subscribeAll sorting browser integration", () => {
 
         await db.update(todos, idC, { rank: 0 });
         await db.deleteFrom(todos, idA);
-        const idD = await db.insert(todos, { title: "D", rank: 2, done: false });
+        const { id: idD } = await db.insert(todos, { title: "D", rank: 2, done: false });
 
         await waitForCondition(
           () => {
@@ -508,8 +508,8 @@ describe("db.subscribeAll sorting browser integration", () => {
       });
 
       try {
-        const idB = await db.insert(todos, { title: "B", rank: 20, done: false });
-        const idD = await db.insert(todos, { title: "D", rank: 40, done: false });
+        const { id: idB } = await db.insert(todos, { title: "B", rank: 20, done: false });
+        const { id: idD } = await db.insert(todos, { title: "D", rank: 40, done: false });
 
         await waitForCondition(
           () => latestRows(snapshots).length === 2,
@@ -518,14 +518,14 @@ describe("db.subscribeAll sorting browser integration", () => {
         );
         expect(latestIds(snapshots)).toEqual([idB, idD]);
 
-        const idA = await db.insert(todos, { title: "A", rank: 10, done: false });
+        const { id: idA } = await db.insert(todos, { title: "A", rank: 10, done: false });
         await waitForCondition(
           () => latestRows(snapshots)[0]?.id === idA,
           10_000,
           "expected top insert to appear first",
         );
 
-        const idC = await db.insert(todos, { title: "C", rank: 30, done: false });
+        const { id: idC } = await db.insert(todos, { title: "C", rank: 30, done: false });
         await waitForCondition(
           () => {
             const ids = latestIds(snapshots);
@@ -535,7 +535,7 @@ describe("db.subscribeAll sorting browser integration", () => {
           "expected middle insert to appear in middle",
         );
 
-        const idE = await db.insert(todos, { title: "E", rank: 50, done: false });
+        const { id: idE } = await db.insert(todos, { title: "E", rank: 50, done: false });
         await waitForCondition(
           () => latestRows(snapshots)[4]?.id === idE,
           10_000,
@@ -554,9 +554,9 @@ describe("db.subscribeAll sorting browser integration", () => {
     const dbName = uniqueDbName("restart");
 
     const db1 = await createDb({ appId, driver: { type: "persistent", dbName } });
-    const idA = await db1.insert(todos, { title: "A", rank: 3, done: false });
-    const idB = await db1.insert(todos, { title: "B", rank: 1, done: false });
-    const idC = await db1.insert(todos, { title: "C", rank: 2, done: false });
+    const { id: idA } = await db1.insert(todos, { title: "A", rank: 3, done: false });
+    const { id: idB } = await db1.insert(todos, { title: "B", rank: 1, done: false });
+    const { id: idC } = await db1.insert(todos, { title: "C", rank: 2, done: false });
     await db1.shutdown();
 
     const db2 = await createDb({ appId, driver: { type: "persistent", dbName } });
@@ -587,9 +587,9 @@ describe("db.subscribeAll sorting browser integration", () => {
       });
 
       try {
-        const idNull = await db.insert(todos, { title: "N", rank: undefined, done: false });
-        const idOne = await db.insert(todos, { title: "A", rank: 1, done: false });
-        const idTwo = await db.insert(todos, { title: "B", rank: 2, done: false });
+        const { id: idNull } = await db.insert(todos, { title: "N", rank: undefined, done: false });
+        const { id: idOne } = await db.insert(todos, { title: "A", rank: 1, done: false });
+        const { id: idTwo } = await db.insert(todos, { title: "B", rank: 2, done: false });
 
         await waitForCondition(
           () => latestRows(snapshots).length === 3,
@@ -626,9 +626,9 @@ describe("db.subscribeAll sorting browser integration", () => {
       );
 
       try {
-        const idA = await db.insert(todos, { title: "A", rank: 3, done: false });
-        const idB = await db.insert(todos, { title: "B", rank: 2, done: false });
-        const idC = await db.insert(todos, { title: "C", rank: 1, done: false });
+        const { id: idA } = await db.insert(todos, { title: "A", rank: 3, done: false });
+        const { id: idB } = await db.insert(todos, { title: "B", rank: 2, done: false });
+        const { id: idC } = await db.insert(todos, { title: "C", rank: 1, done: false });
 
         await waitForCondition(
           () => latestRows(snapshots).length === 3,
@@ -665,10 +665,10 @@ describe("db.subscribeAll sorting browser integration", () => {
       );
 
       try {
-        const idA = await db.insert(todos, { title: "A", rank: 1, done: false });
-        const idB = await db.insert(todos, { title: "B", rank: 2, done: false });
-        const idC = await db.insert(todos, { title: "C", rank: 3, done: false });
-        const idD = await db.insert(todos, { title: "D", rank: 4, done: false });
+        const { id: idA } = await db.insert(todos, { title: "A", rank: 1, done: false });
+        const { id: idB } = await db.insert(todos, { title: "B", rank: 2, done: false });
+        const { id: idC } = await db.insert(todos, { title: "C", rank: 3, done: false });
+        const { id: idD } = await db.insert(todos, { title: "D", rank: 4, done: false });
 
         await waitForCondition(
           () => latestRows(snapshots).length === 2,
@@ -711,9 +711,9 @@ describe("db.subscribeAll sorting browser integration", () => {
       );
 
       try {
-        const idA = await db.insert(todos, { title: "A", rank: 1, done: false });
-        const idB = await db.insert(todos, { title: "B", rank: 1, done: false });
-        const idC = await db.insert(todos, { title: "C", rank: 2, done: false });
+        const { id: idA } = await db.insert(todos, { title: "A", rank: 1, done: false });
+        const { id: idB } = await db.insert(todos, { title: "B", rank: 1, done: false });
+        const { id: idC } = await db.insert(todos, { title: "C", rank: 2, done: false });
 
         await waitForCondition(
           () => latestRows(snapshots).length === 3,

--- a/packages/jazz-tools/tests/browser/db.subscribeAll.test.ts
+++ b/packages/jazz-tools/tests/browser/db.subscribeAll.test.ts
@@ -370,7 +370,7 @@ describe("db.subscribeAll browser integration", () => {
       ),
     );
 
-    const id = await db.insert(todos, {
+    const { id } = await db.insert(todos, {
       title: "watch-me",
       done: false,
       priority: 1,
@@ -415,7 +415,7 @@ describe("db.subscribeAll browser integration", () => {
         }),
       );
 
-      const insertedId = await conditionsDb.insert(todos, testCase.insert);
+      const { id: insertedId } = await conditionsDb.insert(todos, testCase.insert);
 
       await waitForCondition(
         () => deltas.some((delta) => hasChangeForId(delta, 0, insertedId)),
@@ -445,7 +445,7 @@ describe("db.subscribeAll browser integration", () => {
       ),
     );
 
-    const id = await db.insert(todos, {
+    const { id } = await db.insert(todos, {
       title: "bytes-hit",
       done: false,
       priority: 1,
@@ -536,7 +536,7 @@ describe("db.subscribeAll browser integration", () => {
       ),
     );
 
-    const insertedId = await db.insert(todos, {
+    const { id: insertedId } = await db.insert(todos, {
       title: "completely unrelated",
       done: false,
       priority: 1,
@@ -568,7 +568,7 @@ describe("db.subscribeAll browser integration", () => {
       ),
     );
 
-    const userId = await db.insert(users, { name: "Owner", team_id: undefined });
+    const { id: userId } = await db.insert(users, { name: "Owner", team_id: undefined });
 
     await waitForCondition(
       () => deltas.some((delta) => hasChangeForId(delta, 0, userId)),
@@ -597,13 +597,13 @@ describe("db.subscribeAll browser integration", () => {
       ),
     );
 
-    const orgId = await db.insert(orgs, { name: "Hop Org" });
-    const teamId = await db.insert(teams, {
+    const { id: orgId } = await db.insert(orgs, { name: "Hop Org" });
+    const { id: teamId } = await db.insert(teams, {
       name: "Hop Team",
       org_id: orgId,
       parent_id: undefined,
     });
-    await db.insert(users, { name: "Hop User", team_id: teamId });
+    const { id: userId } = await db.insert(users, { name: "Hop User", team_id: teamId });
 
     await waitForCondition(
       () =>
@@ -623,19 +623,19 @@ describe("db.subscribeAll browser integration", () => {
       }),
     );
 
-    const orgAId = await db.insert(orgs, { name: "Org A" });
-    const orgBId = await db.insert(orgs, { name: "Org B" });
-    const teamAId = await db.insert(teams, {
+    const { id: orgAId } = await db.insert(orgs, { name: "Org A" });
+    const { id: orgBId } = await db.insert(orgs, { name: "Org B" });
+    const { id: teamAId } = await db.insert(teams, {
       name: "Team A",
       org_id: orgAId,
       parent_id: undefined,
     });
-    const teamBId = await db.insert(teams, {
+    const { id: teamBId } = await db.insert(teams, {
       name: "Team B",
       org_id: orgBId,
       parent_id: undefined,
     });
-    const userId = await db.insert(users, { name: "Mover", team_id: teamAId });
+    const { id: userId } = await db.insert(users, { name: "Mover", team_id: teamAId });
 
     const deltas: Array<SubscriptionDelta<Team>> = [];
     const unsubscribe = trackUnsubscribe(
@@ -682,9 +682,9 @@ describe("db.subscribeAll browser integration", () => {
       }),
     );
 
-    const partAId = await db.insert(fileParts, { label: "A" });
-    const partBId = await db.insert(fileParts, { label: "B" });
-    const fileId = await db.insert(files, { name: "File", parts: [partAId] });
+    const { id: partAId } = await db.insert(fileParts, { label: "A" });
+    const { id: partBId } = await db.insert(fileParts, { label: "B" });
+    const { id: fileId } = await db.insert(files, { name: "File", parts: [partAId, partBId] });
 
     const deltas: Array<SubscriptionDelta<FilePart>> = [];
     const unsubscribe = trackUnsubscribe(
@@ -748,13 +748,21 @@ describe("db.subscribeAll browser integration", () => {
       ),
     );
 
-    const rootId = await db.insert(teams, {
+    const { id: rootId } = await db.insert(teams, {
       name: "root",
       org_id: undefined,
       parent_id: undefined,
     });
-    const midId = await db.insert(teams, { name: "mid", org_id: undefined, parent_id: rootId });
-    const leafId = await db.insert(teams, { name: "leaf", org_id: undefined, parent_id: midId });
+    const { id: midId } = await db.insert(teams, {
+      name: "mid",
+      org_id: undefined,
+      parent_id: rootId,
+    });
+    const { id: leafId } = await db.insert(teams, {
+      name: "leaf",
+      org_id: undefined,
+      parent_id: midId,
+    });
 
     await waitForCondition(
       () => {

--- a/packages/jazz-tools/tests/browser/db.subscribeAll.test.ts
+++ b/packages/jazz-tools/tests/browser/db.subscribeAll.test.ts
@@ -684,7 +684,7 @@ describe("db.subscribeAll browser integration", () => {
 
     const { id: partAId } = await db.insert(fileParts, { label: "A" });
     const { id: partBId } = await db.insert(fileParts, { label: "B" });
-    const { id: fileId } = await db.insert(files, { name: "File", parts: [partAId, partBId] });
+    const { id: fileId } = await db.insert(files, { name: "File", parts: [partAId] });
 
     const deltas: Array<SubscriptionDelta<FilePart>> = [];
     const unsubscribe = trackUnsubscribe(

--- a/packages/jazz-tools/tests/browser/realistic-bench.test.ts
+++ b/packages/jazz-tools/tests/browser/realistic-bench.test.ts
@@ -438,7 +438,7 @@ async function seedDataset(db: Db, config: ProfileConfig): Promise<SeedState> {
   const ts = nowMicros();
   for (let i = 0; i < config.users; i += 1) {
     reportLoopProgress("seed users", i, config.users);
-    const id = await db.insert(usersTable, {
+    const { id } = await db.insert(usersTable, {
       display_name: `User ${i}`,
       email: `user${i}@bench.test`,
     });
@@ -447,7 +447,7 @@ async function seedDataset(db: Db, config: ProfileConfig): Promise<SeedState> {
 
   for (let i = 0; i < config.organizations; i += 1) {
     reportLoopProgress("seed organizations", i, config.organizations);
-    const id = await db.insert(organizationsTable, {
+    const { id } = await db.insert(organizationsTable, {
       name: `Org ${i}`,
       created_at: ts + i,
     });
@@ -465,7 +465,7 @@ async function seedDataset(db: Db, config: ProfileConfig): Promise<SeedState> {
 
   for (let i = 0; i < config.projects; i += 1) {
     reportLoopProgress("seed projects", i, config.projects);
-    const id = await db.insert(projectsTable, {
+    const { id } = await db.insert(projectsTable, {
       organization_id: organizations[i % organizations.length],
       name: `Project ${i}`,
       archived: false,
@@ -479,7 +479,7 @@ async function seedDataset(db: Db, config: ProfileConfig): Promise<SeedState> {
     reportLoopProgress("seed tasks", i, config.tasks);
     const projectIdx = i % projects.length;
     const assigneeIdx = i % users.length;
-    const id = await db.insert(tasksTable, {
+    const { id } = await db.insert(tasksTable, {
       project_id: projects[projectIdx],
       title: `Task ${i}`,
       status: statuses[i % statuses.length],
@@ -855,7 +855,7 @@ async function runB1(config: ProfileConfig): Promise<ScenarioResult> {
       reportLoopProgress("B1 inserts", i, insertCount);
       const taskIdx = rng.nextInt(state.taskIds.length);
       const t0 = performance.now();
-      const id = await db.insert(commentsTable, {
+      const { id } = await db.insert(commentsTable, {
         task_id: state.taskIds[taskIdx],
         author_id: state.users[rng.nextInt(state.users.length)],
         body: `b1_insert_comment_${i}`,
@@ -1443,7 +1443,7 @@ async function seedPermissionDataset(
   const allowedFolders: string[] = [];
   const deniedFolders: string[] = [];
   const ts = nowMicros();
-  const allowedRootId = await db.insert(
+  const { id: allowedRootId } = await db.insert(
     folderTable,
     {
       parent_id: null,
@@ -1453,7 +1453,7 @@ async function seedPermissionDataset(
     },
     durabilityOptions(tier),
   );
-  const deniedRootId = await db.insert(
+  const { id: deniedRootId } = await db.insert(
     folderTable,
     {
       parent_id: null,
@@ -1472,7 +1472,7 @@ async function seedPermissionDataset(
     const parent = allowedChain
       ? allowedFolders[allowedFolders.length - 1]
       : deniedFolders[deniedFolders.length - 1];
-    const id = await db.insert(
+    const { id } = await db.insert(
       folderTable,
       {
         parent_id: parent,
@@ -1507,7 +1507,7 @@ async function seedPermissionDataset(
         ? owners.allowedOwnerId
         : owners.intermediateOwnerId
       : owners.deniedOwnerId;
-    const id = await db.insert(
+    const { id } = await db.insert(
       documentTable,
       {
         folder_id: folderId,

--- a/packages/jazz-tools/tests/browser/useAll.test.tsx
+++ b/packages/jazz-tools/tests/browser/useAll.test.tsx
@@ -431,7 +431,7 @@ describe("useAll browser integration", () => {
       </JazzProvider>,
     );
 
-    const userId = await client.db.insert(users, { name: "Owner", team_id: undefined });
+    const { id: userId } = await client.db.insert(users, { name: "Owner", team_id: undefined });
     await client.db.insert(todos, {
       title: "owned-todo",
       done: false,
@@ -465,8 +465,8 @@ describe("useAll browser integration", () => {
       </JazzProvider>,
     );
 
-    const orgId = await client.db.insert(orgs, { name: "Hop Org" });
-    const teamId = await client.db.insert(teams, {
+    const { id: orgId } = await client.db.insert(orgs, { name: "Hop Org" });
+    const { id: teamId } = await client.db.insert(teams, {
       name: "Hop Team",
       org_id: orgId,
       parent_id: undefined,
@@ -505,12 +505,12 @@ describe("useAll browser integration", () => {
       </JazzProvider>,
     );
 
-    const rootId = await client.db.insert(teams, {
+    const { id: rootId } = await client.db.insert(teams, {
       name: "root",
       org_id: undefined,
       parent_id: undefined,
     });
-    const midId = await client.db.insert(teams, {
+    const { id: midId } = await client.db.insert(teams, {
       name: "mid",
       org_id: undefined,
       parent_id: rootId,

--- a/packages/jazz-tools/tests/browser/useAllSuspense.test.tsx
+++ b/packages/jazz-tools/tests/browser/useAllSuspense.test.tsx
@@ -468,7 +468,7 @@ describe("useAllSuspense browser integration", () => {
       </JazzProvider>,
     );
 
-    const userId = await client.db.insert(users, { name: "Owner", team_id: undefined });
+    const { id: userId } = await client.db.insert(users, { name: "Owner", team_id: undefined });
     await client.db.insert(todos, {
       title: "owned-todo",
       done: false,
@@ -508,8 +508,8 @@ describe("useAllSuspense browser integration", () => {
       "expected suspense rows mount for hop query",
     );
 
-    const orgId = await client.db.insert(orgs, { name: "Hop Org" });
-    const teamId = await client.db.insert(teams, {
+    const { id: orgId } = await client.db.insert(orgs, { name: "Hop Org" });
+    const { id: teamId } = await client.db.insert(teams, {
       name: "Hop Team",
       org_id: orgId,
       parent_id: undefined,
@@ -554,12 +554,12 @@ describe("useAllSuspense browser integration", () => {
       "expected suspense rows mount for gather query",
     );
 
-    const rootId = await client.db.insert(teams, {
+    const { id: rootId } = await client.db.insert(teams, {
       name: "root",
       org_id: undefined,
       parent_id: undefined,
     });
-    const midId = await client.db.insert(teams, {
+    const { id: midId } = await client.db.insert(teams, {
       name: "mid",
       org_id: undefined,
       parent_id: rootId,

--- a/packages/jazz-tools/tests/browser/worker-bridge.test.ts
+++ b/packages/jazz-tools/tests/browser/worker-bridge.test.ts
@@ -370,7 +370,7 @@ describe("Worker Bridge with OPFS", () => {
       }),
     );
 
-    const id = await db.insert(todos, { title: "Original", done: false });
+    const { id } = await db.insert(todos, { title: "Original", done: false });
     await db.update(todos, id, { done: true });
 
     const results = await db.all(allTodos);
@@ -387,7 +387,7 @@ describe("Worker Bridge with OPFS", () => {
       }),
     );
 
-    const id = await db.insert(todos, { title: "Ephemeral", done: false });
+    const { id } = await db.insert(todos, { title: "Ephemeral", done: false });
     expect((await db.all(allTodos)).length).toBe(1);
 
     await db.deleteFrom(todos, id);
@@ -600,7 +600,7 @@ describe("Worker Bridge with OPFS", () => {
 
     const received: Todo[][] = [];
 
-    const projectId = await db.insert(projects, { name: "Observed Project" });
+    const { id: projectId } = await db.insert(projects, { name: "Observed Project" });
     const unsub = trackSubscription(
       db.subscribeAll(todosByProject(projectId), (delta) => {
         received.push([...delta.all]);
@@ -608,7 +608,7 @@ describe("Worker Bridge with OPFS", () => {
     );
 
     await db.insert(todos, { title: "Observed", done: false, project: projectId });
-    const anotherProjectId = await db.insert(projects, { name: "Ignored Project" });
+    const { id: anotherProjectId } = await db.insert(projects, { name: "Ignored Project" });
     await db.insert(todos, { title: "Not observed", done: false, project: anotherProjectId });
 
     // Wait for subscription to fire
@@ -664,7 +664,7 @@ describe("Worker Bridge with OPFS", () => {
 
     const title = `sync-a-to-b-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     await withTimeout(
-      await dbA.insert(todos, { title, done: false }, { tier: "worker" }),
+      dbA.insert(todos, { title, done: false }, { tier: "worker" }),
       10000,
       "A insert(worker) did not resolve",
     );
@@ -685,7 +685,7 @@ describe("Worker Bridge with OPFS", () => {
 
     const title = `sync-b-to-a-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     await withTimeout(
-      await dbB.insert(todos, { title, done: true }, { tier: "worker" }),
+      dbB.insert(todos, { title, done: true }, { tier: "worker" }),
       10000,
       "B insert(worker) did not resolve",
     );
@@ -774,7 +774,7 @@ describe("Worker Bridge with OPFS", () => {
 
     const remoteTitle = `remote-for-local-only-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     await withTimeout(
-      await dbA.insert(todos, { title: remoteTitle, done: false }, { tier: "worker" }),
+      dbA.insert(todos, { title: remoteTitle, done: false }, { tier: "worker" }),
       10000,
       "A insert(worker) did not resolve",
     );
@@ -869,7 +869,7 @@ describe("Worker Bridge with OPFS", () => {
       "Follower should be promoted to leader after shutdown",
     );
 
-    const id = await follower.insert(todos, { title: "Post-failover", done: true });
+    const { id } = await follower.insert(todos, { title: "Post-failover", done: true });
     await waitForCondition(
       async () => {
         const rows = await follower.all(allTodos, { tier: "worker" });

--- a/packages/jazz-tools/tests/browser/worker-bridge.test.ts
+++ b/packages/jazz-tools/tests/browser/worker-bridge.test.ts
@@ -327,7 +327,7 @@ describe("Worker Bridge with OPFS", () => {
     );
 
     // Insert (sync — runs on main-thread in-memory runtime)
-    const id = await db.insert(todos, { title: "Buy milk", done: false });
+    const { id } = await db.insert(todos, { title: "Buy milk", done: false });
     expect(id).toBeTruthy();
     expect(typeof id).toBe("string");
 
@@ -474,7 +474,7 @@ describe("Worker Bridge with OPFS", () => {
     const afterDelete = await db.all(allTodos, { tier: "worker" });
     expect(afterDelete).toEqual([]);
 
-    const id = await db.insert(todos, { title: "Fresh after delete", done: true });
+    const { id } = await db.insert(todos, { title: "Fresh after delete", done: true });
     const afterReinsert = await db.all(allTodos, { tier: "worker" });
     expect(afterReinsert).toHaveLength(1);
     expect(afterReinsert[0].id).toBe(id);
@@ -544,7 +544,7 @@ describe("Worker Bridge with OPFS", () => {
     );
 
     // insert("worker") should resolve once the worker's OPFS has it
-    const id = await db.insert(todos, { title: "Durable", done: false }, { tier: "worker" });
+    const { id } = await db.insert(todos, { title: "Durable", done: false }, { tier: "worker" });
     expect(id).toBeTruthy();
     expect(typeof id).toBe("string");
 

--- a/packages/jazz-tools/tests/ts-dsl/insert-api.test.ts
+++ b/packages/jazz-tools/tests/ts-dsl/insert-api.test.ts
@@ -1,0 +1,58 @@
+import { createDb, type Db } from "../../src/runtime/db.js";
+import { afterEach, describe, expect, it } from "vitest";
+import { app } from "./fixtures/basic/app";
+
+function uniqueDbName(label: string): string {
+  return `test-${label}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+describe("TS Insert API", () => {
+  const dbs: Db[] = [];
+
+  function track(db: Db): Db {
+    dbs.push(db);
+    return db;
+  }
+
+  afterEach(async () => {
+    for (const db of dbs) {
+      try {
+        await db.shutdown();
+      } catch {
+        // Best effort
+      }
+    }
+    dbs.length = 0;
+  });
+
+  it("returns the inserted row", async () => {
+    const db = track(
+      await createDb({
+        appId: "test-app",
+        driver: { type: "persistent", dbName: uniqueDbName("insert-row-shape") },
+      }),
+    );
+
+    const project = await db.insert(app.projects, { name: "Test Project" });
+
+    expect(project).toEqual({
+      id: expect.any(String),
+      name: "Test Project",
+    });
+
+    const todo = await db.insert(app.todos, {
+      title: "Test Todo",
+      done: true,
+      tags: ["tag1", "tag2"],
+      project: project.id,
+    });
+
+    expect(todo).toEqual({
+      id: expect.any(String),
+      title: "Test Todo",
+      done: true,
+      tags: ["tag1", "tag2"],
+      project: project.id,
+    });
+  });
+});

--- a/packages/jazz-tools/tests/ts-dsl/query-api.test.ts
+++ b/packages/jazz-tools/tests/ts-dsl/query-api.test.ts
@@ -34,7 +34,7 @@ describe("TS Query API", () => {
       }),
     );
 
-    const id = await db.insert(app.projects, { name: "Project A" });
+    const { id } = await db.insert(app.projects, { name: "Project A" });
 
     const results = await db.all(app.projects.where({ id: { eq: id } }));
     expect(results.length).toBe(1);
@@ -51,8 +51,8 @@ describe("TS Query API", () => {
       }),
     );
 
-    const projectId = await db.insert(app.projects, { name: "Announcements" });
-    const todoId = await db.insert(app.todos, {
+    const { id: projectId } = await db.insert(app.projects, { name: "Announcements" });
+    const { id: todoId } = await db.insert(app.todos, {
       title: "Hello world",
       done: false,
       tags: ["general"],
@@ -78,8 +78,8 @@ describe("TS Query API", () => {
       }),
     );
 
-    const projectId = await db.insert(app.projects, { name: "Announcements" });
-    const todoId = await db.insert(app.todos, {
+    const { id: projectId } = await db.insert(app.projects, { name: "Announcements" });
+    const { id: todoId } = await db.insert(app.todos, {
       title: "Write tests",
       done: false,
       tags: ["dev"],
@@ -105,20 +105,20 @@ describe("TS Query API", () => {
           driver: { type: "persistent", dbName: uniqueDbName("query-by-array-column-equality") },
         }),
       );
-      const projectId = await db.insert(app.projects, { name: "Project A" });
-      const id1 = await db.insert(app.todos, {
+      const { id: projectId } = await db.insert(app.projects, { name: "Project A" });
+      const { id: id1 } = await db.insert(app.todos, {
         title: "Todo 1",
         done: false,
         tags: ["tag1"],
         project: projectId,
       });
-      const _id2 = await db.insert(app.todos, {
+      await db.insert(app.todos, {
         title: "Todo 2",
         done: false,
         tags: ["tag2"],
         project: projectId,
       });
-      const _id3 = await db.insert(app.todos, {
+      await db.insert(app.todos, {
         title: "Todo 3",
         done: false,
         tags: ["tag1", "tag2"],
@@ -137,20 +137,20 @@ describe("TS Query API", () => {
           driver: { type: "persistent", dbName: uniqueDbName("query-by-array-column-contains") },
         }),
       );
-      const projectId = await db.insert(app.projects, { name: "Project A" });
-      const id1 = await db.insert(app.todos, {
+      const { id: projectId } = await db.insert(app.projects, { name: "Project A" });
+      const { id: id1 } = await db.insert(app.todos, {
         title: "Todo 1",
         done: false,
         tags: ["tag1"],
         project: projectId,
       });
-      const _id2 = await db.insert(app.todos, {
+      await db.insert(app.todos, {
         title: "Todo 2",
         done: false,
         tags: ["tag2"],
         project: projectId,
       });
-      const id3 = await db.insert(app.todos, {
+      const { id: id3 } = await db.insert(app.todos, {
         title: "Todo 3",
         done: false,
         tags: ["tag1", "tag2"],


### PR DESCRIPTION
## Description

Modify inserts to return the inserted row instead of just the id. The inserted values are returned from the insert query itself (i.e. there's no separate read query).