### PR TITLE
feat: sort schema's columns

### DIFF
--- a/.changeset/calm-pumas-arrive.md
+++ b/.changeset/calm-pumas-arrive.md
@@ -1,0 +1,7 @@
+---
+"jazz-tools": patch
+---
+
+Normalize schema manager table columns before hashing sorting by name.
+
+This makes logically equivalent schemas produce the same schema hash even when their column declarations are ordered differently.

--- a/crates/jazz-tools/src/schema_manager/manager.rs
+++ b/crates/jazz-tools/src/schema_manager/manager.rs
@@ -89,6 +89,8 @@ impl SchemaManager {
         env: &str,
         user_branch: &str,
     ) -> Result<Self, SchemaError> {
+        let schema = normalize_schema(schema);
+
         let context = SchemaContext::new(schema.clone(), env, user_branch);
         let current_hash = SchemaHash::compute(&schema);
 
@@ -894,6 +896,20 @@ impl SchemaManager {
     }
 }
 
+fn normalize_schema(mut schema: Schema) -> Schema {
+    for table_schema in schema.values_mut() {
+        normalize_table_schema(table_schema);
+    }
+    schema
+}
+
+fn normalize_table_schema(table_schema: &mut crate::query_manager::types::TableSchema) {
+    table_schema
+        .columns
+        .columns
+        .sort_unstable_by(|left, right| left.name.as_str().cmp(right.name.as_str()));
+}
+
 /// Parse a hex-encoded SchemaHash string.
 fn parse_schema_hash(hex_str: &str) -> Result<SchemaHash, SchemaError> {
     let bytes = hex::decode(hex_str)
@@ -945,6 +961,58 @@ mod tests {
         assert_eq!(manager.env(), "dev");
         assert_eq!(manager.user_branch(), "main");
         assert_eq!(manager.app_id(), test_app_id());
+    }
+
+    #[test]
+    fn schema_manager_new_normalizes_table_columns_by_name() {
+        let schema = SchemaBuilder::new()
+            .table(
+                TableSchema::builder("users")
+                    .column("name", ColumnType::Text)
+                    .column("id", ColumnType::Uuid)
+                    .nullable_column("email", ColumnType::Text),
+            )
+            .build();
+
+        let manager =
+            SchemaManager::new(SyncManager::new(), schema, test_app_id(), "dev", "main").unwrap();
+
+        let descriptor = manager.current_schema().get(&"users".into()).unwrap();
+        let column_names: Vec<_> = descriptor
+            .columns
+            .columns
+            .iter()
+            .map(|column| column.name_str())
+            .collect();
+
+        assert_eq!(column_names, vec!["email", "id", "name"]);
+    }
+
+    #[test]
+    fn schema_manager_new_hashes_equivalent_column_orderings_identically() {
+        let schema_a = SchemaBuilder::new()
+            .table(
+                TableSchema::builder("users")
+                    .column("name", ColumnType::Text)
+                    .column("id", ColumnType::Uuid)
+                    .nullable_column("email", ColumnType::Text),
+            )
+            .build();
+        let schema_b = SchemaBuilder::new()
+            .table(
+                TableSchema::builder("users")
+                    .nullable_column("email", ColumnType::Text)
+                    .column("id", ColumnType::Uuid)
+                    .column("name", ColumnType::Text),
+            )
+            .build();
+
+        let manager_a =
+            SchemaManager::new(SyncManager::new(), schema_a, test_app_id(), "dev", "main").unwrap();
+        let manager_b =
+            SchemaManager::new(SyncManager::new(), schema_b, test_app_id(), "dev", "main").unwrap();
+
+        assert_eq!(manager_a.current_hash(), manager_b.current_hash());
     }
 
     #[test]
@@ -1194,9 +1262,24 @@ mod tests {
         let name = Value::Text("Alice".into());
         let email = Value::Text("alice@example.com".into());
 
-        let _handle = manager
-            .insert(&mut storage, "users", &[id_val.clone(), name, email])
-            .unwrap();
+        let descriptor = manager
+            .current_schema()
+            .get(&"users".into())
+            .unwrap()
+            .columns
+            .clone();
+        let values: Vec<_> = descriptor
+            .columns
+            .iter()
+            .map(|column| match column.name_str() {
+                "email" => email.clone(),
+                "id" => id_val.clone(),
+                "name" => name.clone(),
+                other => panic!("unexpected column {other}"),
+            })
+            .collect();
+
+        let _handle = manager.insert(&mut storage, "users", &values).unwrap();
         manager.process(&mut storage);
 
         // Query via subscribe/process/unsubscribe pattern
@@ -1208,6 +1291,7 @@ mod tests {
         qm.unsubscribe_with_sync(sub_id);
 
         assert_eq!(results.len(), 1);
-        assert_eq!(results[0].1[0], id_val);
+        let id_idx = descriptor.column_index("id").unwrap();
+        assert_eq!(results[0].1[id_idx], id_val);
     }
 }

--- a/examples/docs/todo-server-ts/src/main.ts
+++ b/examples/docs/todo-server-ts/src/main.ts
@@ -53,29 +53,6 @@ export interface RunningServer extends TodoServer {
 // Helpers
 // ============================================================================
 
-function rowToTodo(id: string, values: Value[]): Todo | null {
-  if (values.length < 2) return null;
-
-  const titleVal = values[0];
-  const doneVal = values[1];
-  const descVal = values[2];
-
-  if (titleVal.type !== "Text" || doneVal.type !== "Boolean") {
-    return null;
-  }
-
-  return {
-    id,
-    title: titleVal.value,
-    done: doneVal.value,
-    description: descVal?.type === "Text" && descVal.value ? descVal.value : undefined,
-  };
-}
-
-// ============================================================================
-// Server Factory
-// ============================================================================
-
 /**
  * Create a todo server.
  *
@@ -95,6 +72,58 @@ export async function createServer(dataPath?: string): Promise<TodoServer> {
     userBranch: "main",
   });
   const client = context.client();
+  const runtimeTodoColumns = client.getSchema().todos.columns;
+  const todoColumnIndexes = new Map(
+    runtimeTodoColumns.map((column, index) => [column.name, index] as const),
+  );
+
+  function getTodoValue(values: Value[], columnName: string): Value | undefined {
+    const index = todoColumnIndexes.get(columnName);
+    return index === undefined ? undefined : values[index];
+  }
+
+  function buildTodoValues(body: CreateTodoRequest): Value[] {
+    const ownerId = body.owner_id ?? "anonymous";
+
+    return runtimeTodoColumns.map((column) => {
+      switch (column.name) {
+        case "description":
+          return body.description
+            ? ({ type: "Text", value: body.description } as const)
+            : ({ type: "Null" } as const);
+        case "done":
+          return { type: "Boolean", value: false } as const;
+        case "owner_id":
+          return { type: "Text", value: ownerId } as const;
+        case "parent":
+        case "project":
+          return { type: "Null" } as const;
+        case "title":
+          return { type: "Text", value: body.title } as const;
+        default:
+          throw new Error(`Unsupported todo column: ${column.name}`);
+      }
+    });
+  }
+
+  function rowToTodo(id: string, values: Value[]): Todo | null {
+    if (values.length < 2) return null;
+
+    const titleVal = getTodoValue(values, "title");
+    const doneVal = getTodoValue(values, "done");
+    const descVal = getTodoValue(values, "description");
+
+    if (titleVal?.type !== "Text" || doneVal?.type !== "Boolean") {
+      return null;
+    }
+
+    return {
+      id,
+      title: titleVal.value,
+      done: doneVal.value,
+      description: descVal?.type === "Text" && descVal.value ? descVal.value : undefined,
+    };
+  }
   // #endregion context-setup-ts-backend
 
   // Create Express app
@@ -150,15 +179,7 @@ export async function createServer(dataPath?: string): Promise<TodoServer> {
         return;
       }
 
-      const ownerId = body.owner_id ?? "anonymous";
-      const values: Value[] = [
-        { type: "Text", value: body.title },
-        { type: "Boolean", value: false },
-        { type: "Text", value: body.description ?? "" },
-        { type: "Null" },
-        { type: "Null" },
-        { type: "Text", value: ownerId },
-      ];
+      const values = buildTodoValues(body);
 
       const id = await client.create("todos", values);
 

--- a/examples/todo-server-ts/src/main.ts
+++ b/examples/todo-server-ts/src/main.ts
@@ -53,29 +53,6 @@ export interface RunningServer extends TodoServer {
 // Helpers
 // ============================================================================
 
-function rowToTodo(id: string, values: Value[]): Todo | null {
-  if (values.length < 2) return null;
-
-  const titleVal = values[0];
-  const doneVal = values[1];
-  const descVal = values[2];
-
-  if (titleVal.type !== "Text" || doneVal.type !== "Boolean") {
-    return null;
-  }
-
-  return {
-    id,
-    title: titleVal.value,
-    done: doneVal.value,
-    description: descVal?.type === "Text" && descVal.value ? descVal.value : undefined,
-  };
-}
-
-// ============================================================================
-// Server Factory
-// ============================================================================
-
 /**
  * Create a todo server.
  *
@@ -94,6 +71,58 @@ export async function createServer(dataPath?: string): Promise<TodoServer> {
     userBranch: "main",
   });
   const client = context.client();
+  const runtimeTodoColumns = client.getSchema().todos.columns;
+  const todoColumnIndexes = new Map(
+    runtimeTodoColumns.map((column, index) => [column.name, index] as const),
+  );
+
+  function getTodoValue(values: Value[], columnName: string): Value | undefined {
+    const index = todoColumnIndexes.get(columnName);
+    return index === undefined ? undefined : values[index];
+  }
+
+  function buildTodoValues(body: CreateTodoRequest): Value[] {
+    const ownerId = body.owner_id ?? "anonymous";
+
+    return runtimeTodoColumns.map((column) => {
+      switch (column.name) {
+        case "description":
+          return body.description
+            ? ({ type: "Text", value: body.description } as const)
+            : ({ type: "Null" } as const);
+        case "done":
+          return { type: "Boolean", value: false } as const;
+        case "owner_id":
+          return { type: "Text", value: ownerId } as const;
+        case "parent":
+        case "project":
+          return { type: "Null" } as const;
+        case "title":
+          return { type: "Text", value: body.title } as const;
+        default:
+          throw new Error(`Unsupported todo column: ${column.name}`);
+      }
+    });
+  }
+
+  function rowToTodo(id: string, values: Value[]): Todo | null {
+    if (values.length < 2) return null;
+
+    const titleVal = getTodoValue(values, "title");
+    const doneVal = getTodoValue(values, "done");
+    const descVal = getTodoValue(values, "description");
+
+    if (titleVal?.type !== "Text" || doneVal?.type !== "Boolean") {
+      return null;
+    }
+
+    return {
+      id,
+      title: titleVal.value,
+      done: doneVal.value,
+      description: descVal?.type === "Text" && descVal.value ? descVal.value : undefined,
+    };
+  }
 
   // Create Express app
   const app = express();
@@ -148,15 +177,7 @@ export async function createServer(dataPath?: string): Promise<TodoServer> {
         return;
       }
 
-      const ownerId = body.owner_id ?? "anonymous";
-      const values: Value[] = [
-        { type: "Text", value: body.title },
-        { type: "Boolean", value: false },
-        { type: "Text", value: body.description ?? "" },
-        { type: "Null" },
-        { type: "Null" },
-        { type: "Text", value: ownerId },
-      ];
+      const values = buildTodoValues(body);
 
       const id = await client.create("todos", values);
 

--- a/packages/jazz-tools/src/runtime/db.schema-order.test.ts
+++ b/packages/jazz-tools/src/runtime/db.schema-order.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it, vi } from "vitest";
+import { Db, type QueryBuilder, type TableProxy } from "./db.js";
+import type { Value, WasmRow, WasmSchema } from "../drivers/types.js";
+import type { JazzClient } from "./client.js";
+
+class TestDb extends Db {
+  constructor(private readonly testClient: JazzClient) {
+    super({ appId: "schema-order-test" }, null);
+  }
+
+  protected override getClient(_schema: WasmSchema): JazzClient {
+    return this.testClient;
+  }
+}
+
+describe("Db runtime schema order", () => {
+  it("uses the runtime schema order for inserts", async () => {
+    const generatedSchema: WasmSchema = {
+      todos: {
+        columns: [
+          { name: "title", column_type: { type: "Text" }, nullable: false },
+          { name: "done", column_type: { type: "Boolean" }, nullable: false },
+        ],
+      },
+    };
+    const runtimeSchema: WasmSchema = {
+      todos: {
+        columns: [
+          { name: "done", column_type: { type: "Boolean" }, nullable: false },
+          { name: "title", column_type: { type: "Text" }, nullable: false },
+        ],
+      },
+    };
+    const create = vi.fn<(...args: [string, Value[], { tier?: string }?]) => Promise<string>>(
+      async () => "todo-1",
+    );
+    const client = {
+      getSchema: () => runtimeSchema,
+      create,
+    } as unknown as JazzClient;
+    const db = new TestDb(client);
+    const table = {
+      _table: "todos",
+      _schema: generatedSchema,
+      _rowType: {} as { id: string; title: string; done: boolean },
+      _initType: {} as { title: string; done: boolean },
+    } satisfies TableProxy<{ id: string; title: string; done: boolean }, { title: string; done: boolean }>;
+
+    await db.insert(table, { title: "Buy milk", done: false });
+
+    expect(create).toHaveBeenCalledWith("todos", [
+      { type: "Boolean", value: false },
+      { type: "Text", value: "Buy milk" },
+    ], undefined);
+  });
+
+  it("uses the runtime schema order when transforming query results", async () => {
+    const generatedSchema: WasmSchema = {
+      todos: {
+        columns: [
+          { name: "title", column_type: { type: "Text" }, nullable: false },
+          { name: "done", column_type: { type: "Boolean" }, nullable: false },
+        ],
+      },
+    };
+    const runtimeSchema: WasmSchema = {
+      todos: {
+        columns: [
+          { name: "done", column_type: { type: "Boolean" }, nullable: false },
+          { name: "title", column_type: { type: "Text" }, nullable: false },
+        ],
+      },
+    };
+    const query = vi.fn<(...args: [string, object?]) => Promise<WasmRow[]>>(async () => [
+      {
+        id: "todo-1",
+        values: [
+          { type: "Boolean", value: true },
+          { type: "Text", value: "Sorted title" },
+        ],
+      },
+    ]);
+    const client = {
+      getSchema: () => runtimeSchema,
+      query,
+    } as unknown as JazzClient;
+    const db = new TestDb(client);
+    const builder = {
+      _table: "todos",
+      _schema: generatedSchema,
+      _rowType: {} as { id: string; title: string; done: boolean },
+      _build: () =>
+        JSON.stringify({
+          table: "todos",
+          conditions: [],
+          includes: {},
+          orderBy: [],
+        }),
+    } satisfies QueryBuilder<{ id: string; title: string; done: boolean }>;
+
+    const rows = await db.all(builder);
+
+    expect(rows).toEqual([
+      {
+        id: "todo-1",
+        title: "Sorted title",
+        done: true,
+      },
+    ]);
+  });
+});

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -965,8 +965,9 @@ export class Db {
     options?: { tier?: DurabilityTier },
   ): Promise<string> {
     const client = this.getClient(table._schema);
+    const runtimeSchema = client.getSchema();
     await this.ensureBridgeReady();
-    const values = toValueArray(data as Record<string, unknown>, table._schema, table._table);
+    const values = toValueArray(data as Record<string, unknown>, runtimeSchema, table._table);
     return client.create(table._table, values, options);
   }
 
@@ -980,8 +981,9 @@ export class Db {
     options?: { tier?: DurabilityTier },
   ): Promise<void> {
     const client = this.getClient(table._schema);
+    const runtimeSchema = client.getSchema();
     await this.ensureBridgeReady();
-    const updates = toUpdateRecord(data as Record<string, unknown>, table._schema, table._table);
+    const updates = toUpdateRecord(data as Record<string, unknown>, runtimeSchema, table._table);
     await client.update(id, updates, options);
   }
 
@@ -1070,15 +1072,16 @@ export class Db {
    */
   async all<T>(query: QueryBuilder<T>, options?: QueryOptions): Promise<T[]> {
     const client = this.getClient(query._schema);
+    const runtimeSchema = client.getSchema();
     const builderJson = query._build();
     const builtQuery = normalizeBuiltQuery(JSON.parse(builderJson) as BuiltQuery, query._table);
-    const rows = await client.query(translateQuery(builderJson, query._schema), options);
+    const rows = await client.query(translateQuery(builderJson, runtimeSchema), options);
     const outputTable =
       builtQuery.hops.length > 0
-        ? resolveHopOutputTable(query._schema, builtQuery.table, builtQuery.hops)
+        ? resolveHopOutputTable(runtimeSchema, builtQuery.table, builtQuery.hops)
         : query._table;
     const outputIncludes = builtQuery.hops.length > 0 ? {} : builtQuery.includes;
-    return transformRows<T>(rows, query._schema, outputTable, outputIncludes);
+    return transformRows<T>(rows, runtimeSchema, outputTable, outputIncludes);
   }
 
   /**
@@ -1127,17 +1130,18 @@ export class Db {
   ): () => void {
     const manager = new SubscriptionManager<T>();
     const client = this.getClient(query._schema);
+    const runtimeSchema = client.getSchema();
     const builderJson = query._build();
     const builtQuery = normalizeBuiltQuery(JSON.parse(builderJson) as BuiltQuery, query._table);
     const outputTable =
       builtQuery.hops.length > 0
-        ? resolveHopOutputTable(query._schema, builtQuery.table, builtQuery.hops)
+        ? resolveHopOutputTable(runtimeSchema, builtQuery.table, builtQuery.hops)
         : query._table;
     const outputIncludes = builtQuery.hops.length > 0 ? {} : builtQuery.includes;
-    const wasmQuery = translateQuery(builderJson, query._schema);
+    const wasmQuery = translateQuery(builderJson, runtimeSchema);
 
     const transform = (row: WasmRow): T => {
-      return transformRows<T>([row], query._schema, outputTable, outputIncludes)[0];
+      return transformRows<T>([row], runtimeSchema, outputTable, outputIncludes)[0];
     };
 
     const subId = client.subscribeInternal(


### PR DESCRIPTION
Normalize schema manager table columns before hashing, sorting by name.

For now, this replaces #197 