### PR TITLE
feat: split (sync) Db.insert and (async) Db.insertDurable APIs

### DIFF
--- a/.changeset/sync-insert-api.md
+++ b/.changeset/sync-insert-api.md
@@ -1,0 +1,8 @@
+---
+"jazz-tools": patch
+---
+
+Split the local-first insert APIs in `jazz-tools`.
+
+- `db.insert(...)` now applies the write immediately and returns the inserted row synchronously.
+- `db.insertDurable(...)` waits for the requested durability tier before resolving.

--- a/examples/docs/todo-client-localfirst-expo/src/TodoList.tsx
+++ b/examples/docs/todo-client-localfirst-expo/src/TodoList.tsx
@@ -40,7 +40,7 @@ export function TodoList() {
   const addTodo = async () => {
     const trimmed = title.trim();
     if (!trimmed || !sessionUserId) return;
-    await db.insert(app.todos, { title: trimmed, done: false, owner_id: sessionUserId });
+    db.insert(app.todos, { title: trimmed, done: false, owner_id: sessionUserId });
     setTitle("");
   };
 

--- a/examples/docs/todo-client-localfirst-expo/src/docs-snippets.ts
+++ b/examples/docs/todo-client-localfirst-expo/src/docs-snippets.ts
@@ -99,7 +99,7 @@ export function subscribeTodosAtEdge(db: Db, onCount: (count: number) => void) {
 
 // #region writing-durability-expo
 export async function writeWithDurabilityTier(db: Db, todoTitle: string) {
-  const { id } = await db.insert(
+  const { id } = await db.insertDurable(
     app.todos,
     {
       title: todoTitle,

--- a/examples/docs/todo-client-localfirst-react/src/TodoList.tsx
+++ b/examples/docs/todo-client-localfirst-react/src/TodoList.tsx
@@ -17,7 +17,7 @@ export function TodoList() {
 
   // #region writing-use-db-react
   async function addTodo(todoTitle: string) {
-    await db.insert(app.todos, { title: todoTitle, done: false });
+    db.insert(app.todos, { title: todoTitle, done: false });
   }
 
   async function toggleTodo(todo: { id: string; done: boolean }) {

--- a/examples/docs/todo-client-localfirst-react/src/docs-snippets.ts
+++ b/examples/docs/todo-client-localfirst-react/src/docs-snippets.ts
@@ -98,7 +98,11 @@ export function subscribeTodosAtEdge(db: Db, onCount: (count: number) => void) {
 
 // #region writing-durability-react
 export async function writeWithDurabilityTier(db: Db, todoTitle: string) {
-  const { id } = await db.insert(app.todos, { title: todoTitle, done: false }, { tier: "edge" });
+  const { id } = await db.insertDurable(
+    app.todos,
+    { title: todoTitle, done: false },
+    { tier: "edge" },
+  );
   await db.update(app.todos, id, { done: true }, { tier: "edge" });
   await db.deleteFrom(app.todos, id, { tier: "global" });
 }

--- a/examples/docs/todo-client-localfirst-svelte/src/TodoList.svelte
+++ b/examples/docs/todo-client-localfirst-svelte/src/TodoList.svelte
@@ -26,7 +26,7 @@
 		e.preventDefault();
 		if (!title.trim()) return;
 		// #region writing-insert-svelte
-		await db.insert(app.todos, { title: title.trim(), done: false });
+		db.insert(app.todos, { title: title.trim(), done: false });
 		// #endregion writing-insert-svelte
 		title = '';
 	}
@@ -43,7 +43,7 @@
 
 	// #region writing-durability-svelte
 	async function addImportantTodo(todoTitle: string) {
-		const { id } = await db.insert(app.todos, { title: todoTitle, done: false }, { tier: 'edge' });
+		const { id } = await db.insertDurable(app.todos, { title: todoTitle, done: false }, { tier: 'edge' });
 		await db.update(app.todos, id, { done: true }, { tier: 'edge' });
 		await db.deleteFrom(app.todos, id, { tier: 'global' });
 	}

--- a/examples/docs/todo-client-localfirst-ts/src/docs-snippets.ts
+++ b/examples/docs/todo-client-localfirst-ts/src/docs-snippets.ts
@@ -71,7 +71,7 @@ export function buildTodoLineageQuery() {
 
 // #region writing-crud-ts
 export async function writeTodoCrud(db: Db, todoId: string) {
-  await db.insert(app.todos, {
+  db.insert(app.todos, {
     title: "Write docs",
     done: false,
     owner_id: EXAMPLE_OWNER_ID,

--- a/examples/docs/todo-client-localfirst-ts/src/docs-snippets.ts
+++ b/examples/docs/todo-client-localfirst-ts/src/docs-snippets.ts
@@ -84,7 +84,7 @@ export async function writeTodoCrud(db: Db, todoId: string) {
 
 // #region writing-durability-tier-ts
 export async function writeTodoWithDurabilityTiers(db: Db) {
-  const { id } = await db.insert(
+  const { id } = await db.insertDurable(
     app.todos,
     {
       title: "Write docs with durability tier",

--- a/packages/jazz-tools/src/dev-tools/extension-panel.ts
+++ b/packages/jazz-tools/src/dev-tools/extension-panel.ts
@@ -446,7 +446,7 @@ class DevToolsJazzClient implements JazzClient {
   forRequest(request: RequestLike): SessionClient {
     throw new Error("Method not implemented.");
   }
-  create(table: string, values: Value[], options?: { tier?: DurabilityTier }): Promise<Row> {
+  createDurable(table: string, values: Value[], options?: { tier?: DurabilityTier }): Promise<Row> {
     throw new Error("Method not implemented.");
   }
   async query(query: string | QueryInput, options?: QueryExecutionOptions): Promise<Row[]> {

--- a/packages/jazz-tools/src/runtime/client.for-request.test.ts
+++ b/packages/jazz-tools/src/runtime/client.for-request.test.ts
@@ -452,9 +452,10 @@ describe("JazzClient.forRequest", () => {
 
 describe("JazzClient schema order", () => {
   it("passes create values through in the declared schema order", async () => {
+    const insert = vi.fn(() => mockRow());
     const insertDurable = vi.fn(async () => mockRow());
     const runtime: Runtime = {
-      insert: () => mockRow(),
+      insert,
       update: () => {},
       delete: () => {},
       query: async () => [],
@@ -517,14 +518,11 @@ describe("JazzClient schema order", () => {
       { type: "Boolean", value: false },
     ]);
 
-    expect(insertDurable).toHaveBeenCalledWith(
-      "todos",
-      [
-        { type: "Text", value: "Buy milk" },
-        { type: "Boolean", value: false },
-      ],
-      "worker",
-    );
+    expect(insert).toHaveBeenCalledWith("todos", [
+      { type: "Text", value: "Buy milk" },
+      { type: "Boolean", value: false },
+    ]);
+    expect(insertDurable).not.toHaveBeenCalled();
   });
 
   it("uses the local auth session for direct queries and subscriptions", async () => {

--- a/packages/jazz-tools/src/runtime/client.ts
+++ b/packages/jazz-tools/src/runtime/client.ts
@@ -878,7 +878,11 @@ export class JazzClient {
    * Insert a new row into a table without waiting for durability.
    */
   create(table: string, values: Value[]): Row {
-    return this.runtime.insert(table, values);
+    const row = this.runtime.insert(table, values);
+    return {
+      ...row,
+      values: this.alignRowValuesToDeclaredSchema(table, row.values as Value[], this.getSchema()),
+    };
   }
 
   /**

--- a/packages/jazz-tools/src/runtime/client.ts
+++ b/packages/jazz-tools/src/runtime/client.ts
@@ -875,9 +875,20 @@ export class JazzClient {
   }
 
   /**
+   * Insert a new row into a table without waiting for durability.
+   */
+  create(table: string, values: Value[]): Row {
+    return this.runtime.insert(table, values);
+  }
+
+  /**
    * Insert a new row into a table and wait for durability at the requested tier.
    */
-  async create(table: string, values: Value[], options?: WriteDurabilityOptions): Promise<Row> {
+  async createDurable(
+    table: string,
+    values: Value[],
+    options?: WriteDurabilityOptions,
+  ): Promise<Row> {
     const tier = this.resolveWriteTier(options);
     const row = await this.runtime.insertDurable(table, values, tier);
     return {

--- a/packages/jazz-tools/src/runtime/cloud-server.integration.test.ts
+++ b/packages/jazz-tools/src/runtime/cloud-server.integration.test.ts
@@ -933,7 +933,7 @@ function buildProfileByIdQuery(schema: WasmSchema, id: string): string {
 
 async function seedSocialGraph(client: JazzClient): Promise<SocialSeed> {
   const aliceProfileId = (
-    await client.create(
+    await client.createDurable(
       "profiles",
       [
         { type: "Text", value: "alice" },
@@ -943,7 +943,7 @@ async function seedSocialGraph(client: JazzClient): Promise<SocialSeed> {
     )
   ).id;
   const bobProfileId = (
-    await client.create(
+    await client.createDurable(
       "profiles",
       [
         { type: "Text", value: "bob" },
@@ -953,7 +953,7 @@ async function seedSocialGraph(client: JazzClient): Promise<SocialSeed> {
     )
   ).id;
   const carolProfileId = (
-    await client.create(
+    await client.createDurable(
       "profiles",
       [
         { type: "Text", value: "carol" },
@@ -963,7 +963,7 @@ async function seedSocialGraph(client: JazzClient): Promise<SocialSeed> {
     )
   ).id;
   const eveProfileId = (
-    await client.create(
+    await client.createDurable(
       "profiles",
       [
         { type: "Text", value: "eve" },
@@ -978,7 +978,7 @@ async function seedSocialGraph(client: JazzClient): Promise<SocialSeed> {
   const evePrincipal = "eve";
 
   const alicePersonId = (
-    await client.create(
+    await client.createDurable(
       "people",
       [
         { type: "Uuid", value: aliceProfileId },
@@ -988,7 +988,7 @@ async function seedSocialGraph(client: JazzClient): Promise<SocialSeed> {
     )
   ).id;
   const bobPersonId = (
-    await client.create(
+    await client.createDurable(
       "people",
       [
         { type: "Uuid", value: bobProfileId },
@@ -997,7 +997,7 @@ async function seedSocialGraph(client: JazzClient): Promise<SocialSeed> {
       { tier: "edge" },
     )
   ).id;
-  await client.create(
+  await client.createDurable(
     "people",
     [
       { type: "Uuid", value: carolProfileId },
@@ -1006,7 +1006,7 @@ async function seedSocialGraph(client: JazzClient): Promise<SocialSeed> {
     { tier: "edge" },
   );
   const evePersonId = (
-    await client.create(
+    await client.createDurable(
       "people",
       [
         { type: "Uuid", value: eveProfileId },
@@ -1016,7 +1016,7 @@ async function seedSocialGraph(client: JazzClient): Promise<SocialSeed> {
     )
   ).id;
 
-  await client.create(
+  await client.createDurable(
     "friendships",
     [
       { type: "Uuid", value: alicePersonId },
@@ -1026,7 +1026,7 @@ async function seedSocialGraph(client: JazzClient): Promise<SocialSeed> {
     ],
     { tier: "edge" },
   );
-  await client.create(
+  await client.createDurable(
     "friendships",
     [
       { type: "Uuid", value: evePersonId },
@@ -1270,7 +1270,7 @@ describe("cloud-server integration (Jazz TS)", () => {
       );
 
       const rowId = (
-        await clientA.create(
+        await clientA.createDurable(
           "todos",
           [
             { type: "Text", value: "shared-item" },
@@ -1338,7 +1338,7 @@ describe("cloud-server integration (Jazz TS)", () => {
         writer = await connectClient(
           makeContext(app.app_id, server.baseUrl, signJwt("writer", JWT_SECRET)),
         );
-        await writer.create(
+        await writer.createDurable(
           "todos",
           [
             { type: "Text", value: "persisted-item" },
@@ -1454,7 +1454,7 @@ describe("Policy bypass: subscription without session skips PolicyFilterNode", (
         makeContext(app.app_id, server.baseUrl, signJwt("seed-user", JWT_SECRET), schema),
       );
 
-      await seeder.create(
+      await seeder.createDurable(
         "owned_items",
         [
           { type: "Text", value: "bob-item" },
@@ -1462,7 +1462,7 @@ describe("Policy bypass: subscription without session skips PolicyFilterNode", (
         ],
         { tier: "edge" },
       );
-      await seeder.create(
+      await seeder.createDurable(
         "owned_items",
         [
           { type: "Text", value: "carol-item" },
@@ -1478,7 +1478,7 @@ describe("Policy bypass: subscription without session skips PolicyFilterNode", (
       aliceClient = await connectClient(
         makeContext(app.app_id, server.baseUrl, signJwt("alice", JWT_SECRET), schema),
       );
-      await aliceClient.create(
+      await aliceClient.createDurable(
         "owned_items",
         [
           { type: "Text", value: "alice-item" },
@@ -1555,7 +1555,7 @@ describe("Policy bypass: subscription without session skips PolicyFilterNode", (
       aliceClient = await connectClient(
         makeContext(app.app_id, server.baseUrl, signJwt("alice", JWT_SECRET), schema),
       );
-      await aliceClient.create(
+      await aliceClient.createDurable(
         "owned_items",
         [
           { type: "Text", value: "alice-item" },

--- a/packages/jazz-tools/src/runtime/db.schema-order.test.ts
+++ b/packages/jazz-tools/src/runtime/db.schema-order.test.ts
@@ -31,15 +31,13 @@ describe("Db runtime schema order", () => {
         ],
       },
     };
-    const create = vi.fn<(...args: [string, Value[], { tier?: string }?]) => Promise<Row>>(
-      async () => ({
-        id: "todo-1",
-        values: [
-          { type: "Text", value: "Buy milk" },
-          { type: "Boolean", value: false },
-        ],
-      }),
-    );
+    const create = vi.fn<(...args: [string, Value[]]) => Row>(() => ({
+      id: "todo-1",
+      values: [
+        { type: "Text", value: "Buy milk" },
+        { type: "Boolean", value: false },
+      ],
+    }));
     const client = {
       getSchema: () => new Map(Object.entries(runtimeSchema)),
       create,
@@ -55,16 +53,12 @@ describe("Db runtime schema order", () => {
       { title: string; done: boolean }
     >;
 
-    const row = await db.insert(table, { title: "Buy milk", done: false });
+    const row = db.insert(table, { title: "Buy milk", done: false });
 
-    expect(create).toHaveBeenCalledWith(
-      "todos",
-      [
-        { type: "Text", value: "Buy milk" },
-        { type: "Boolean", value: false },
-      ],
-      undefined,
-    );
+    expect(create).toHaveBeenCalledWith("todos", [
+      { type: "Text", value: "Buy milk" },
+      { type: "Boolean", value: false },
+    ]);
     expect(row).toEqual({
       id: "todo-1",
       title: "Buy milk",
@@ -136,15 +130,13 @@ describe("Db runtime schema order", () => {
         ],
       },
     };
-    const create = vi.fn<(...args: [string, Value[], { tier?: string }?]) => Promise<Row>>(
-      async () => ({
-        id: "todo-1",
-        values: [
-          { type: "Text", value: "Buy milk" },
-          { type: "Boolean", value: false },
-        ],
-      }),
-    );
+    const create = vi.fn<(...args: [string, Value[]]) => Row>(() => ({
+      id: "todo-1",
+      values: [
+        { type: "Text", value: "Buy milk" },
+        { type: "Boolean", value: false },
+      ],
+    }));
     const client = {
       getSchema: () => new Map(),
       create,
@@ -160,16 +152,12 @@ describe("Db runtime schema order", () => {
       { title: string; done: boolean }
     >;
 
-    const row = await db.insert(table, { title: "Buy milk", done: false });
+    const row = db.insert(table, { title: "Buy milk", done: false });
 
-    expect(create).toHaveBeenCalledWith(
-      "todos",
-      [
-        { type: "Text", value: "Buy milk" },
-        { type: "Boolean", value: false },
-      ],
-      undefined,
-    );
+    expect(create).toHaveBeenCalledWith("todos", [
+      { type: "Text", value: "Buy milk" },
+      { type: "Boolean", value: false },
+    ]);
     expect(row).toEqual({
       id: "todo-1",
       title: "Buy milk",

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -6,7 +6,8 @@
  *
  * Key design:
  * - createDb() is async (pre-loads WASM module)
- * - insert/update/deleteFrom are async (await WASM bridge readiness, return Promises)
+ * - insert is sync (local-first immediate write, no durability wait)
+ * - insertDurable/update/deleteFrom are async (durability-aware, return Promises)
  * - all/one are async (need storage I/O for queries)
  */
 
@@ -345,8 +346,8 @@ function isLeaderDebugEnabled(): boolean {
  * ```typescript
  * const db = await createDb({ appId: "my-app", driver });
  *
- * // Async mutations
- * const inserted = await db.insert(app.todos, { title: "Buy milk", done: false });
+ * // Mutations
+ * const inserted = db.insert(app.todos, { title: "Buy milk", done: false });
  * await db.update(app.todos, inserted.id, { done: true });
  * await db.deleteFrom(app.todos, inserted.id);
  *
@@ -979,17 +980,33 @@ export class Db {
   }
 
   /**
+   * Insert a new row into a table without waiting for durability.
+   *
+   * @param table Table proxy from generated app module
+   * @param data Init object with column values
+   * @returns Inserted row
+   */
+  insert<T, Init>(table: TableProxy<T, Init>, data: Init): T {
+    const client = this.getClient(table._schema);
+    // Don't wait for bridge to be ready in worker mode. Inserts will be propagated once the bridge is ready.
+    // If the bridge fails to initialize, the insert will be lost on restart.
+    const values = toValueArray(data as Record<string, unknown>, table._schema, table._table);
+    const row = client.create(table._table, values);
+    return transformRow(row, table._schema, table._table);
+  }
+
+  /**
    * Insert a new row into a table and wait for durability at the requested tier.
    *
    * @param table Table proxy from generated app module
    * @param data Init object with column values
-   * @param options Optional durability tier override
+   * @param options Durability tier
    * @returns Promise resolving to the inserted row
    */
-  async insert<T, Init>(
+  async insertDurable<T, Init>(
     table: TableProxy<T, Init>,
     data: Init,
-    options?: { tier?: DurabilityTier },
+    options: { tier: DurabilityTier },
   ): Promise<T> {
     const client = this.getClient(table._schema);
     const inputSchema = resolveSchemaWithTable(
@@ -999,7 +1016,7 @@ export class Db {
     );
     await this.ensureBridgeReady();
     const values = toValueArray(data as Record<string, unknown>, inputSchema, table._table);
-    const row = await client.create(table._table, values, options);
+    const row = await client.createDurable(table._table, values, options);
     return transformRow(row, table._schema, table._table);
   }
 

--- a/packages/jazz-tools/src/runtime/value-converter.ts
+++ b/packages/jazz-tools/src/runtime/value-converter.ts
@@ -1,7 +1,7 @@
 /**
  * Convert JS values to WasmValue types for mutations.
  *
- * Used by Db.insert() and Db.update() to convert typed Init objects
+ * Used by Db.insert()/Db.insertDurable() and Db.update() to convert typed Init objects
  * into the Value[] format expected by JazzClient.
  */
 

--- a/packages/jazz-tools/tests/browser/worker-bridge.test.ts
+++ b/packages/jazz-tools/tests/browser/worker-bridge.test.ts
@@ -358,6 +358,90 @@ describe("Worker Bridge with OPFS", () => {
     expect(titles).toEqual(["Task A", "Task B", "Task C"]);
   });
 
+  it("sync insert before bridge init is persisted after init completes", async () => {
+    const dbName = uniqueDbName("sync-insert-before-bridge-ready");
+    const db1 = track(
+      await createDb({
+        appId: "test-app",
+        driver: { type: "persistent", dbName },
+      }),
+    );
+
+    // First I/O operation, bridge hasn't been initialized yet.
+    const { id } = db1.insert(todos, { title: "Test", done: false });
+
+    await waitForCondition(
+      async () => {
+        const row = await db1.one(allTodos, { tier: "worker" });
+        return row?.id === id;
+      },
+      8_000,
+      "sync insert should be forwarded to worker after bridge init",
+    );
+
+    await db1.shutdown();
+    untrack(db1);
+
+    const db2 = track(
+      await createDb({
+        appId: "test-app",
+        driver: { type: "persistent", dbName },
+      }),
+    );
+
+    const persistedRow = await db2.one(allTodos, { tier: "worker" });
+    expect(persistedRow?.id).toBe(id);
+  });
+
+  it("sync insert is not persisted if bridge fails to init", async () => {
+    const dbName = uniqueDbName("sync-insert-bridge-init-failure");
+    const db1 = track(
+      await createDb({
+        appId: "test-app",
+        driver: { type: "persistent", dbName },
+      }),
+    );
+
+    // @ts-expect-error - worker is private
+    const worker = db1.worker as Worker;
+    const originalPostMessage = worker.postMessage.bind(worker);
+    worker.postMessage = ((message: unknown, transfer?: Transferable[]) => {
+      const typed = message as { type?: string } | undefined;
+      if (typed?.type === "init") {
+        queueMicrotask(() => {
+          worker.dispatchEvent(
+            new MessageEvent("message", {
+              data: { type: "error", message: "forced bridge init failure for test" },
+            }),
+          );
+        });
+        return;
+      }
+      return originalPostMessage(message, { transfer });
+    }) as Worker["postMessage"];
+
+    const { id } = db1.insert(todos, { title: "Test", done: false });
+    expect(id).toBeDefined();
+
+    worker.postMessage = originalPostMessage;
+    // Shutdown fails to ensure bridge is ready, but steps down as leader before that
+    await expect(db1.shutdown()).rejects.toThrow(
+      "Worker init failed: forced bridge init failure for test",
+    );
+
+    untrack(db1);
+
+    const db2 = track(
+      await createDb({
+        appId: "test-app",
+        driver: { type: "persistent", dbName },
+      }),
+    );
+
+    const persistedRows = await db2.all(allTodos, { tier: "worker" });
+    expect(persistedRows.length).toEqual(0);
+  });
+
   // -------------------------------------------------------------------------
   // 3. Update + delete through worker bridge
   // -------------------------------------------------------------------------
@@ -428,8 +512,8 @@ describe("Worker Bridge with OPFS", () => {
     );
 
     // insert({ tier: "worker" }) ensures data is in OPFS WAL before we crash
-    await db1.insert(todos, { title: "Crash-proof", done: false }, { tier: "worker" });
-    await db1.insert(todos, { title: "Also survives", done: true }, { tier: "worker" });
+    await db1.insertDurable(todos, { title: "Crash-proof", done: false }, { tier: "worker" });
+    await db1.insertDurable(todos, { title: "Also survives", done: true }, { tier: "worker" });
 
     // Simulate crash: release OPFS handles WITHOUT flushing snapshot.
     // WAL has the data, but snapshot is stale. Recovery must replay WAL.
@@ -464,7 +548,7 @@ describe("Worker Bridge with OPFS", () => {
       }),
     );
 
-    await db.insert(todos, { title: "Should be deleted", done: false }, { tier: "worker" });
+    await db.insertDurable(todos, { title: "Should be deleted", done: false }, { tier: "worker" });
     const before = await db.all(allTodos, { tier: "worker" });
     expect(before.length).toBe(1);
     expect(before[0].title).toBe("Should be deleted");
@@ -544,7 +628,11 @@ describe("Worker Bridge with OPFS", () => {
     );
 
     // insert("worker") should resolve once the worker's OPFS has it
-    const { id } = await db.insert(todos, { title: "Durable", done: false }, { tier: "worker" });
+    const { id } = await db.insertDurable(
+      todos,
+      { title: "Durable", done: false },
+      { tier: "worker" },
+    );
     expect(id).toBeTruthy();
     expect(typeof id).toBe("string");
 
@@ -664,7 +752,7 @@ describe("Worker Bridge with OPFS", () => {
 
     const title = `sync-a-to-b-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     await withTimeout(
-      dbA.insert(todos, { title, done: false }, { tier: "worker" }),
+      dbA.insertDurable(todos, { title, done: false }, { tier: "worker" }),
       10000,
       "A insert(worker) did not resolve",
     );
@@ -685,7 +773,7 @@ describe("Worker Bridge with OPFS", () => {
 
     const title = `sync-b-to-a-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     await withTimeout(
-      dbB.insert(todos, { title, done: true }, { tier: "worker" }),
+      dbB.insertDurable(todos, { title, done: true }, { tier: "worker" }),
       10000,
       "B insert(worker) did not resolve",
     );
@@ -716,7 +804,7 @@ describe("Worker Bridge with OPFS", () => {
       ),
     );
 
-    await dbA.insert(todos, { title: "local-only-local-1", done: true }, { tier: "worker" });
+    await dbA.insertDurable(todos, { title: "local-only-local-1", done: true }, { tier: "worker" });
 
     // Wait for initial local-only snapshot.
     await waitForCondition(
@@ -774,7 +862,7 @@ describe("Worker Bridge with OPFS", () => {
 
     const remoteTitle = `remote-for-local-only-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     await withTimeout(
-      dbA.insert(todos, { title: remoteTitle, done: false }, { tier: "worker" }),
+      dbA.insertDurable(todos, { title: remoteTitle, done: false }, { tier: "worker" }),
       10000,
       "A insert(worker) did not resolve",
     );
@@ -908,7 +996,7 @@ describe("Worker Bridge with OPFS", () => {
 
     const marker = `reopen-${Date.now()}`;
     await withTimeout(
-      currentFollower.insert(todos, { title: marker, done: false }),
+      currentFollower.insertDurable(todos, { title: marker, done: false }, { tier: "worker" }),
       10000,
       "Follower insert during reopen re-election did not resolve",
     );

--- a/packages/jazz-tools/tests/ts-dsl/insert-api.test.ts
+++ b/packages/jazz-tools/tests/ts-dsl/insert-api.test.ts
@@ -1,5 +1,5 @@
 import { createDb, type Db } from "../../src/runtime/db.js";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { app } from "./fixtures/basic/app";
 
 function uniqueDbName(label: string): string {
@@ -7,45 +7,65 @@ function uniqueDbName(label: string): string {
 }
 
 describe("TS Insert API", () => {
-  const dbs: Db[] = [];
+  let db: Db;
 
-  function track(db: Db): Db {
-    dbs.push(db);
-    return db;
-  }
+  beforeEach(async () => {
+    db = await createDb({
+      appId: "test-app",
+      driver: { type: "persistent", dbName: uniqueDbName("insert-row-shape") },
+    });
+  });
 
   afterEach(async () => {
-    for (const db of dbs) {
-      try {
-        await db.shutdown();
-      } catch {
-        // Best effort
-      }
-    }
-    dbs.length = 0;
+    await db.shutdown();
   });
 
   it("returns the inserted row", async () => {
-    const db = track(
-      await createDb({
-        appId: "test-app",
-        driver: { type: "persistent", dbName: uniqueDbName("insert-row-shape") },
-      }),
-    );
-
-    const project = await db.insert(app.projects, { name: "Test Project" });
+    const project = db.insert(app.projects, { name: "Test Project" });
 
     expect(project).toEqual({
       id: expect.any(String),
       name: "Test Project",
     });
 
-    const todo = await db.insert(app.todos, {
+    const todo = db.insert(app.todos, {
       title: "Test Todo",
       done: true,
       tags: ["tag1", "tag2"],
       project: project.id,
     });
+
+    expect(todo).toEqual({
+      id: expect.any(String),
+      title: "Test Todo",
+      done: true,
+      tags: ["tag1", "tag2"],
+      project: project.id,
+    });
+  });
+
+  it("can wait for row to be persisted up to a specific durability tier", async () => {
+    const project = await db.insertDurable(
+      app.projects,
+      { name: "Test Project" },
+      { tier: "worker" },
+    );
+
+    expect(project).toEqual({
+      id: expect.any(String),
+      name: "Test Project",
+    });
+
+    const todo = await db.insertDurable(
+      app.todos,
+      {
+        title: "Test Todo",
+        done: true,
+        tags: ["tag1", "tag2"],
+        project: project.id,
+      },
+      { tier: "worker" },
+    );
 
     expect(todo).toEqual({
       id: expect.any(String),


### PR DESCRIPTION
## Description

The current `Db.insert` method always returns a Promise, even when no durability tier is provided and insertion happens synchronously. This PR splits this method into two, to make a cleaner distinction between:
- the synchronous `insert` method, that receives no durability tier, immediately returns the inserted row and persists it asynchronously
- the async `insertDurable` method, that always receives a durability tier and waits until the row is persisted up to the given durability tier