### PR TITLE
feat: split Db.update/delete into sync and durable APIs

### DIFF
--- a/.changeset/quick-coins-smoke.md
+++ b/.changeset/quick-coins-smoke.md
@@ -5,4 +5,9 @@
 "jazz-rn": patch
 ---
 
-Modify inserts to return the inserted row instead of just the id
+Refine the local-first write APIs across the stacked insert/update/delete follow-up work.
+
+- Insert operations now return the full inserted row instead of just its id.
+- In `jazz-tools`, base `Db` write methods are now synchronous local-first APIs: `db.insert(...)`, `db.update(...)`, and `db.delete(...)`.
+- When durability-tier acknowledgement matters, use the explicit async variants: `db.insertDurable(...)`, `db.updateDurable(...)`, and `db.deleteDurable(...)`.
+- `db.deleteFrom(...)` / `db.deleteFromDurable(...)` have been renamed to `db.delete(...)` / `db.deleteDurable(...)`.

--- a/docs/content/docs/writing-data.mdx
+++ b/docs/content/docs/writing-data.mdx
@@ -5,10 +5,11 @@ description: Insert, update, and delete APIs with local-first execution, framewo
 
 ## Local-First Writes
 
-`insert`, `update`, and `deleteFrom` apply immediately in the local runtime.
+`insert`, `update`, and `delete` apply immediately in the local runtime.
 That keeps UI latency low because local state updates do not wait for any network hop.
 
-Mutation methods return promises that resolve when the requested durability tier is reached.
+`insertDurable`, `updateDurable`, and `deleteDurable` return promises that
+resolve when the requested durability tier is reached.
 
 ## Mutating from Framework Context
 
@@ -72,9 +73,12 @@ Notes:
 
 ### API Reference
 
-- `insert(table, data, options?)`
-- `update(table, id, data, options?)`
-- `deleteFrom(table, id, options?)`
+- `insert(table, data)`
+- `update(table, id, data)`
+- `delete(table, id)`
+- `insertDurable(table, data, { tier })`
+- `updateDurable(table, id, data, options?)`
+- `deleteDurable(table, id, options?)`
 - `options.tier`: `"worker" | "edge" | "global"`
 
 Durability tiers control when the returned promise resolves:
@@ -96,7 +100,7 @@ Tradeoff summary:
 In practical terms:
 
 - Local-first updates remain immediate for UI/subscription state.
-- Mutation promises resolve at the selected durability checkpoint.
+- Durable mutation promises resolve at the selected durability checkpoint.
 
 <Tabs groupId="jazz-environment" items={["TypeScript", "Rust"]} persist>
   <Tab value="TypeScript">

--- a/examples/docs/todo-client-localfirst-expo/src/TodoList.tsx
+++ b/examples/docs/todo-client-localfirst-expo/src/TodoList.tsx
@@ -37,19 +37,19 @@ export function TodoList() {
   // #endregion reading-reactive-hooks-expo
 
   // #region writing-use-db-expo
-  const addTodo = async () => {
+  const addTodo = () => {
     const trimmed = title.trim();
     if (!trimmed || !sessionUserId) return;
     db.insert(app.todos, { title: trimmed, done: false, owner_id: sessionUserId });
     setTitle("");
   };
 
-  const toggleTodo = async (todo: Todo) => {
-    await db.update(app.todos, todo.id, { done: !todo.done });
+  const toggleTodo = (todo: Todo) => {
+    db.update(app.todos, todo.id, { done: !todo.done });
   };
 
-  const removeTodo = async (id: string) => {
-    await db.deleteFrom(app.todos, id);
+  const removeTodo = (id: string) => {
+    db.delete(app.todos, id);
   };
   // #endregion writing-use-db-expo
 

--- a/examples/docs/todo-client-localfirst-expo/src/docs-snippets.ts
+++ b/examples/docs/todo-client-localfirst-expo/src/docs-snippets.ts
@@ -110,7 +110,7 @@ export async function writeWithDurabilityTier(db: Db, todoTitle: string) {
     { tier: "worker" },
   );
 
-  await db.update(app.todos, id, { done: true }, { tier: "worker" });
-  await db.deleteFrom(app.todos, id, { tier: "worker" });
+  await db.updateDurable(app.todos, id, { done: true }, { tier: "worker" });
+  await db.deleteDurable(app.todos, id, { tier: "worker" });
 }
 // #endregion writing-durability-expo

--- a/examples/docs/todo-client-localfirst-react/src/TodoList.tsx
+++ b/examples/docs/todo-client-localfirst-react/src/TodoList.tsx
@@ -16,26 +16,26 @@ export function TodoList() {
   // #endregion reading-filtering-react
 
   // #region writing-use-db-react
-  async function addTodo(todoTitle: string) {
+  function addTodo(todoTitle: string) {
     db.insert(app.todos, { title: todoTitle, done: false });
   }
 
-  async function toggleTodo(todo: { id: string; done: boolean }) {
-    await db.update(app.todos, todo.id, { done: !todo.done });
+  function toggleTodo(todo: { id: string; done: boolean }) {
+    db.update(app.todos, todo.id, { done: !todo.done });
   }
 
-  async function removeTodo(id: string) {
-    await db.deleteFrom(app.todos, id);
+  function removeTodo(id: string) {
+    db.delete(app.todos, id);
   }
   // #endregion writing-use-db-react
   // #endregion read-write-react
 
   const [title, setTitle] = useState("");
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (!title.trim()) return;
-    await addTodo(title.trim());
+    addTodo(title.trim());
     setTitle("");
   };
 

--- a/examples/docs/todo-client-localfirst-react/src/docs-snippets.ts
+++ b/examples/docs/todo-client-localfirst-react/src/docs-snippets.ts
@@ -103,7 +103,7 @@ export async function writeWithDurabilityTier(db: Db, todoTitle: string) {
     { title: todoTitle, done: false },
     { tier: "edge" },
   );
-  await db.update(app.todos, id, { done: true }, { tier: "edge" });
-  await db.deleteFrom(app.todos, id, { tier: "global" });
+  await db.updateDurable(app.todos, id, { done: true }, { tier: "edge" });
+  await db.deleteDurable(app.todos, id, { tier: "global" });
 }
 // #endregion writing-durability-react

--- a/examples/docs/todo-client-localfirst-svelte/src/TodoList.svelte
+++ b/examples/docs/todo-client-localfirst-svelte/src/TodoList.svelte
@@ -22,7 +22,7 @@
 
 	let title = $state('');
 
-	async function handleSubmit(e: SubmitEvent) {
+	function handleSubmit(e: SubmitEvent) {
 		e.preventDefault();
 		if (!title.trim()) return;
 		// #region writing-insert-svelte
@@ -32,20 +32,20 @@
 	}
 
 	// #region writing-mutations-svelte
-	async function toggleTodo(todo: { id: string; done: boolean }) {
-		await db.update(app.todos, todo.id, { done: !todo.done });
+	function toggleTodo(todo: { id: string; done: boolean }) {
+		db.update(app.todos, todo.id, { done: !todo.done });
 	}
 
-	async function removeTodo(id: string) {
-		await db.deleteFrom(app.todos, id);
+	function removeTodo(id: string) {
+		db.delete(app.todos, id);
 	}
 	// #endregion writing-mutations-svelte
 
 	// #region writing-durability-svelte
 	async function addImportantTodo(todoTitle: string) {
 		const { id } = await db.insertDurable(app.todos, { title: todoTitle, done: false }, { tier: 'edge' });
-		await db.update(app.todos, id, { done: true }, { tier: 'edge' });
-		await db.deleteFrom(app.todos, id, { tier: 'global' });
+		await db.updateDurable(app.todos, id, { done: true }, { tier: 'edge' });
+		await db.deleteDurable(app.todos, id, { tier: 'global' });
 	}
 	// #endregion writing-durability-svelte
 </script>

--- a/examples/docs/todo-client-localfirst-ts/src/docs-snippets.ts
+++ b/examples/docs/todo-client-localfirst-ts/src/docs-snippets.ts
@@ -77,8 +77,8 @@ export async function writeTodoCrud(db: Db, todoId: string) {
     owner_id: EXAMPLE_OWNER_ID,
     project: EXAMPLE_PROJECT_ID,
   });
-  await db.update(app.todos, todoId, { done: true });
-  await db.deleteFrom(app.todos, todoId);
+  db.update(app.todos, todoId, { done: true });
+  db.delete(app.todos, todoId);
 }
 // #endregion writing-crud-ts
 
@@ -95,7 +95,7 @@ export async function writeTodoWithDurabilityTiers(db: Db) {
     { tier: "edge" },
   );
 
-  await db.update(app.todos, id, { done: true }, { tier: "global" });
-  await db.deleteFrom(app.todos, id, { tier: "global" });
+  await db.updateDurable(app.todos, id, { done: true }, { tier: "global" });
+  await db.deleteDurable(app.todos, id, { tier: "global" });
 }
 // #endregion writing-durability-tier-ts

--- a/examples/docs/todo-client-localfirst-ts/src/main.ts
+++ b/examples/docs/todo-client-localfirst-ts/src/main.ts
@@ -140,7 +140,7 @@ export async function startApp(
       const checkbox = target as HTMLInputElement;
       db.update(app.todos, id, { done: checkbox.checked });
     } else if (target.classList.contains("delete-btn")) {
-      db.deleteFrom(app.todos, id);
+      db.delete(app.todos, id);
     }
   });
 

--- a/examples/docs/todo-server-ts/src/main.ts
+++ b/examples/docs/todo-server-ts/src/main.ts
@@ -275,7 +275,7 @@ export async function createServer(dataPath?: string): Promise<TodoServer> {
         return;
       }
 
-      await client.update(id, updates);
+      await client.updateDurable(id, updates);
 
       // Fetch updated todo
       const rows = await client.query(schemaApp.todos.where({ id }));
@@ -301,7 +301,7 @@ export async function createServer(dataPath?: string): Promise<TodoServer> {
     try {
       const { id } = req.params;
 
-      await client.delete(id);
+      await client.deleteDurable(id);
       res.status(204).send();
 
       // Notify SSE connections

--- a/examples/todo-client-localfirst-expo/src/TodoList.tsx
+++ b/examples/todo-client-localfirst-expo/src/TodoList.tsx
@@ -49,7 +49,7 @@ export function TodoList() {
           <Text style={[styles.todoTitle, item.done && styles.todoDone]}>{item.title}</Text>
           {item.description ? <Text style={styles.todoDescription}>{item.description}</Text> : null}
         </View>
-        <Pressable onPress={() => db.deleteFrom(app.todos, item.id)} style={styles.deleteButton}>
+        <Pressable onPress={() => db.delete(app.todos, item.id)} style={styles.deleteButton}>
           <Text style={styles.deleteButtonText}>Delete</Text>
         </Pressable>
       </View>

--- a/examples/todo-client-localfirst-react/src/TodoList.tsx
+++ b/examples/todo-client-localfirst-react/src/TodoList.tsx
@@ -71,7 +71,7 @@ export function TodoList() {
             />
             <span>{todo.title}</span>
             {todo.description && <small>{todo.description}</small>}
-            <button className="delete-btn" onClick={() => db.deleteFrom(app.todos, todo.id)}>
+            <button className="delete-btn" onClick={() => db.delete(app.todos, todo.id)}>
               &times;
             </button>
           </li>

--- a/examples/todo-client-localfirst-svelte/src/TodoList.svelte
+++ b/examples/todo-client-localfirst-svelte/src/TodoList.svelte
@@ -40,7 +40,7 @@
 			{#if todo.description}
 				<small>{todo.description}</small>
 			{/if}
-			<button class="delete-btn" onclick={() => db.deleteFrom(app.todos, todo.id)}>
+			<button class="delete-btn" onclick={() => db.delete(app.todos, todo.id)}>
 				&times;
 			</button>
 		</li>

--- a/examples/todo-client-localfirst-ts/src/main.ts
+++ b/examples/todo-client-localfirst-ts/src/main.ts
@@ -170,7 +170,7 @@ export async function startApp(
       const checkbox = target as HTMLInputElement;
       db.update(app.todos, id, { done: checkbox.checked });
     } else if (target.classList.contains("delete-btn")) {
-      db.deleteFrom(app.todos, id);
+      db.delete(app.todos, id);
     }
   });
 

--- a/examples/todo-server-ts/src/main.ts
+++ b/examples/todo-server-ts/src/main.ts
@@ -273,7 +273,7 @@ export async function createServer(dataPath?: string): Promise<TodoServer> {
         return;
       }
 
-      await client.update(id, updates);
+      await client.updateDurable(id, updates);
 
       // Fetch updated todo
       const rows = await client.query(schemaApp.todos.where({ id }));
@@ -299,7 +299,7 @@ export async function createServer(dataPath?: string): Promise<TodoServer> {
     try {
       const { id } = req.params;
 
-      await client.delete(id);
+      await client.deleteDurable(id);
       res.status(204).send();
 
       // Notify SSE connections

--- a/examples/wequencer/README.md
+++ b/examples/wequencer/README.md
@@ -27,7 +27,7 @@ npm run build              # Schema codegen + production build
 
 ## How it works
 
-**State sync** is entirely handled by Jazz. Every beat, instrument change, BPM update, and participant rename is a synchronous local write (`db.insert`, `db.update`, `db.deleteFrom`). Jazz replicates the change to all connected peers in the background. The UI is driven by `QuerySubscription` reactive queries — no polling, no manual state management.
+**State sync** is entirely handled by Jazz. Every beat, instrument change, BPM update, and participant rename is a synchronous local write (`db.insert`, `db.update`, `db.delete`). Jazz replicates the change to all connected peers in the background. The UI is driven by `QuerySubscription` reactive queries — no polling, no manual state management.
 
 **Synchronized playback** is also scheduled through Jazz. All peers need to start their Tone.js transport at exactly the same moment. When a user hits play, a future timestamp (in server epoch time) is written to `jam.transport_start` via Jazz. All peers receive the update, convert it to their local clock using a measured offset, and schedule Tone.js to start at that instant. The offset is tracked by `ClockSync`, which connects to the Jazz WebSocket and computes a smoothed estimate of the difference between local `performance.now()` and server epoch time.
 

--- a/examples/wequencer/src/InstrumentManager.svelte
+++ b/examples/wequencer/src/InstrumentManager.svelte
@@ -31,7 +31,7 @@
 	}
 
 	function removeInstrument(id: string) {
-		db.deleteFrom(app.instruments, id);
+		db.delete(app.instruments, id);
 	}
 </script>
 

--- a/examples/wequencer/src/InstrumentRow.svelte
+++ b/examples/wequencer/src/InstrumentRow.svelte
@@ -30,7 +30,7 @@
   function toggleBeat(index: number) {
     const existing = beatAt(index);
     if (existing) {
-      db.deleteFrom(app.beats, existing.id);
+      db.delete(app.beats, existing.id);
     } else {
       db.insert(app.beats, {
         jam: jamId,

--- a/examples/wequencer/walkthrough/jazz-wequencer.md
+++ b/examples/wequencer/walkthrough/jazz-wequencer.md
@@ -219,7 +219,7 @@ function toggleBeat(index: number) {
   const existing = beats.find((b) => b.beat_index === index);
 
   if (existing) {
-    db.deleteFrom(app.beats, existing.id); // remove
+    db.delete(app.beats, existing.id); // remove
   } else {
     db.insert(app.beats, {
       jam: jamId,
@@ -326,12 +326,12 @@ Because `QuerySubscription` watches `app.instruments`, every client's grid grows
 
 ## Jazz API surface — used in Wequencer
 
-| API                                         | Notes                                                                 |
-| ------------------------------------------- | --------------------------------------------------------------------- |
-| `createJazzClient`                          | Initialises WASM worker + OPFS database, begins syncing               |
-| `JazzSvelteProvider`                        | Provides `db` to every component — no prop drilling                   |
-| `getDb()`                                   | Db singleton — callable from any component in the tree                |
-| `getSession()`                              | Current user identity (`user_id`)                                     |
-| `new QuerySubscription(query)`              | **Svelte-specific** — reactive live query, re-renders on every change |
-| `db.insert` / `db.update` / `db.deleteFrom` | Synchronous local writes — sync to edge happens in the background     |
-| `db.all(query, { settledTier: 'edge' })`    | Async read that waits for edge server confirmation before resolving   |
+| API                                      | Notes                                                                 |
+| ---------------------------------------- | --------------------------------------------------------------------- |
+| `createJazzClient`                       | Initialises WASM worker + OPFS database, begins syncing               |
+| `JazzSvelteProvider`                     | Provides `db` to every component — no prop drilling                   |
+| `getDb()`                                | Db singleton — callable from any component in the tree                |
+| `getSession()`                           | Current user identity (`user_id`)                                     |
+| `new QuerySubscription(query)`           | **Svelte-specific** — reactive live query, re-renders on every change |
+| `db.insert` / `db.update` / `db.delete`  | Synchronous local writes — sync to edge happens in the background     |
+| `db.all(query, { settledTier: 'edge' })` | Async read that waits for edge server confirmation before resolving   |

--- a/packages/jazz-tools/bin/docs-index.txt
+++ b/packages/jazz-tools/bin/docs-index.txt
@@ -735,7 +735,7 @@ Deep dive: [Reading Data](/docs/reading-data).
   };
 
   const removeTodo = async (id: string) => {
-    await db.deleteFrom(app.todos, id);
+    await db.delete(app.todos, id);
   };
 ```
 
@@ -779,7 +779,7 @@ Use base mutation APIs with `{ tier }` when you need explicit write durability a
   );
 
   await db.update(app.todos, id, { done: true }, { tier: "worker" });
-  await db.deleteFrom(app.todos, id, { tier: "worker" });
+  await db.delete(app.todos, id, { tier: "worker" });
 }
 ```
 
@@ -1128,7 +1128,7 @@ Deep dive: [Reading Data](/docs/reading-data).
   }
 
   async function removeTodo(id: string) {
-    await db.deleteFrom(app.todos, id);
+    await db.delete(app.todos, id);
   }
 ```
 
@@ -1163,7 +1163,7 @@ Use base mutation APIs with `{ tier }` to wait for specific durability tiers:
 
   const id = await db.insert(app.todos, { title: todoTitle, done: false }, { tier: "edge" });
   await db.update(app.todos, id, { done: true }, { tier: "edge" });
-  await db.deleteFrom(app.todos, id, { tier: "global" });
+  await db.delete(app.todos, id, { tier: "global" });
 }
 ```
 
@@ -1544,13 +1544,13 @@ Deep dive: [Reading Data](/docs/reading-data).
 	}
 
 	async function removeTodo(id: string) {
-		await db.deleteFrom(app.todos, id);
+		await db.delete(app.todos, id);
 	}
 
 	async function addImportantTodo(todoTitle: string) {
 		const id = await db.insert(app.todos, { title: todoTitle, done: false }, { tier: 'edge' });
 		await db.update(app.todos, id, { done: true }, { tier: 'edge' });
-		await db.deleteFrom(app.todos, id, { tier: 'global' });
+		await db.delete(app.todos, id, { tier: 'global' });
 	}
 
 </script>
@@ -1608,7 +1608,7 @@ Use base mutation APIs with `{ tier }` when you need durability guarantees befor
 	async function addImportantTodo(todoTitle: string) {
 		const id = await db.insert(app.todos, { title: todoTitle, done: false }, { tier: 'edge' });
 		await db.update(app.todos, id, { done: true }, { tier: 'edge' });
-		await db.deleteFrom(app.todos, id, { tier: 'global' });
+		await db.delete(app.todos, id, { tier: 'global' });
 	}
 ```
 
@@ -2689,7 +2689,7 @@ DESCRIPTION:Insert, update, and delete APIs with local-first execution, framewor
 
 ## Local-First Writes
 
-`insert`, `update`, and `deleteFrom` apply immediately in the local runtime.
+`insert`, `update`, and `delete` apply immediately in the local runtime.
 That keeps UI latency low because local state updates do not wait for any network hop.
 
 Mutation methods return promises that resolve when the requested durability tier is reached.
@@ -2708,7 +2708,7 @@ Use the framework context binding to access the shared `Db` instance and execute
   }
 
   async function removeTodo(id: string) {
-    await db.deleteFrom(app.todos, id);
+    await db.delete(app.todos, id);
   }
 ```
 
@@ -2725,7 +2725,7 @@ Use the framework context binding to access the shared `Db` instance and execute
   };
 
   const removeTodo = async (id: string) => {
-    await db.deleteFrom(app.todos, id);
+    await db.delete(app.todos, id);
   };
 ```
 
@@ -2742,7 +2742,7 @@ Use the framework context binding to access the shared `Db` instance and execute
 	}
 
 	async function removeTodo(id: string) {
-		await db.deleteFrom(app.todos, id);
+		await db.delete(app.todos, id);
 	}
 ```
 
@@ -2757,7 +2757,7 @@ Use the framework context binding to access the shared `Db` instance and execute
     project: EXAMPLE_PROJECT_ID,
   });
   await db.update(app.todos, todoId, { done: true });
-  await db.deleteFrom(app.todos, todoId);
+  await db.delete(app.todos, todoId);
 }
 ```
 
@@ -2805,7 +2805,7 @@ Notes:
 
 - `insert(table, data, options?)`
 - `update(table, id, data, options?)`
-- `deleteFrom(table, id, options?)`
+- `delete(table, id, options?)`
 - `options.tier`: `"worker" | "edge" | "global"`
 
 Durability tiers control when the returned promise resolves:
@@ -2843,7 +2843,7 @@ In practical terms:
   );
 
   await db.update(app.todos, id, { done: true }, { tier: "global" });
-  await db.deleteFrom(app.todos, id, { tier: "global" });
+  await db.delete(app.todos, id, { tier: "global" });
 }
 ```
 

--- a/packages/jazz-tools/src/runtime/client.mutations.test.ts
+++ b/packages/jazz-tools/src/runtime/client.mutations.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import { JazzClient, type Runtime } from "./client.js";
+import type { AppContext } from "./context.js";
+
+function makeClient() {
+  const updateCalls: Array<[string, Record<string, unknown>]> = [];
+  const updateDurableCalls: Array<[string, Record<string, unknown>, string]> = [];
+  const deleteCalls: string[] = [];
+  const deleteDurableCalls: Array<[string, string]> = [];
+
+  const runtime: Runtime = {
+    insert: () => ({ id: "00000000-0000-0000-0000-000000000001", values: [] }),
+    insertDurable: async () => ({ id: "00000000-0000-0000-0000-000000000001", values: [] }),
+    update: (objectId: string, updates: Record<string, unknown>) => {
+      updateCalls.push([objectId, updates]);
+    },
+    updateDurable: async (objectId: string, updates: Record<string, unknown>, tier: string) => {
+      updateDurableCalls.push([objectId, updates, tier]);
+    },
+    delete: (objectId: string) => {
+      deleteCalls.push(objectId);
+    },
+    deleteDurable: async (objectId: string, tier: string) => {
+      deleteDurableCalls.push([objectId, tier]);
+    },
+    query: async () => [],
+    subscribe: () => 0,
+    createSubscription: () => 0,
+    executeSubscription: () => {},
+    unsubscribe: () => {},
+    onSyncMessageReceived: () => {},
+    onSyncMessageToSend: () => {},
+    addServer: () => {},
+    removeServer: () => {},
+    addClient: () => "00000000-0000-0000-0000-000000000001",
+    getSchema: () => ({}),
+    getSchemaHash: () => "schema-hash",
+  };
+
+  const context: AppContext = {
+    appId: "test-app",
+    schema: {},
+    serverUrl: "http://localhost:1625",
+    backendSecret: "test-backend-secret",
+  };
+
+  const JazzClientCtor = JazzClient as unknown as {
+    new (
+      runtime: Runtime,
+      context: AppContext,
+      defaultDurabilityTier: "worker" | "edge" | "global",
+    ): JazzClient;
+  };
+
+  return {
+    client: new JazzClientCtor(runtime, context, "edge"),
+    updateCalls,
+    updateDurableCalls,
+    deleteCalls,
+    deleteDurableCalls,
+  };
+}
+
+describe("JazzClient mutation durability split", () => {
+  it("routes update/delete through the synchronous runtime methods", () => {
+    const { client, updateCalls, deleteCalls } = makeClient();
+    const updates = { done: { type: "Boolean" as const, value: true } };
+
+    expect(client.update("row-1", updates)).toBeUndefined();
+    expect(client.delete("row-1")).toBeUndefined();
+
+    expect(updateCalls).toEqual([["row-1", updates]]);
+    expect(deleteCalls).toEqual(["row-1"]);
+  });
+
+  it("routes updateDurable/deleteDurable through durability-aware runtime methods", async () => {
+    const { client, updateDurableCalls, deleteDurableCalls } = makeClient();
+    const updates = { done: { type: "Boolean" as const, value: true } };
+
+    const updatePending = client.updateDurable("row-1", updates);
+    const deletePending = client.deleteDurable("row-1", { tier: "global" });
+
+    expect(updatePending).toBeInstanceOf(Promise);
+    expect(deletePending).toBeInstanceOf(Promise);
+
+    await updatePending;
+    await deletePending;
+
+    expect(updateDurableCalls).toEqual([["row-1", updates, "edge"]]);
+    expect(deleteDurableCalls).toEqual([["row-1", "global"]]);
+  });
+});

--- a/packages/jazz-tools/src/runtime/client.ts
+++ b/packages/jazz-tools/src/runtime/client.ts
@@ -674,9 +674,16 @@ export class JazzClient {
   }
 
   /**
+   * Update a row by ID without waiting for durability.
+   */
+  update(objectId: string, updates: Record<string, Value>): void {
+    this.runtime.update(objectId, updates);
+  }
+
+  /**
    * Update a row by ID and wait for durability at the requested tier.
    */
-  async update(
+  async updateDurable(
     objectId: string,
     updates: Record<string, Value>,
     options?: WriteDurabilityOptions,
@@ -686,9 +693,16 @@ export class JazzClient {
   }
 
   /**
+   * Delete a row by ID without waiting for durability.
+   */
+  delete(objectId: string): void {
+    this.runtime.delete(objectId);
+  }
+
+  /**
    * Delete a row by ID and wait for durability at the requested tier.
    */
-  async delete(objectId: string, options?: WriteDurabilityOptions): Promise<void> {
+  async deleteDurable(objectId: string, options?: WriteDurabilityOptions): Promise<void> {
     const tier = this.resolveWriteTier(options);
     await this.runtime.deleteDurable(objectId, tier);
   }

--- a/packages/jazz-tools/src/runtime/cloud-server.integration.test.ts
+++ b/packages/jazz-tools/src/runtime/cloud-server.integration.test.ts
@@ -1286,7 +1286,11 @@ describe("cloud-server integration (Jazz TS)", () => {
       const createdRow = rowsAfterCreate.find((row) => row.id === rowId);
       expect(createdRow?.values[0]).toEqual({ type: "Text", value: "shared-item" });
 
-      await clientA.update(rowId, { done: { type: "Boolean", value: true } }, { tier: "edge" });
+      await clientA.updateDurable(
+        rowId,
+        { done: { type: "Boolean", value: true } },
+        { tier: "edge" },
+      );
       const rowsAfterUpdate = await waitForRows(clientB, queryAllTodos, (rows) => {
         const row = rows.find((r) => r.id === rowId);
         return Boolean(row && row.values[1]?.type === "Boolean" && row.values[1].value === true);
@@ -1294,7 +1298,7 @@ describe("cloud-server integration (Jazz TS)", () => {
       const updatedRow = rowsAfterUpdate.find((row) => row.id === rowId);
       expect(updatedRow?.values[1]).toEqual({ type: "Boolean", value: true });
 
-      await clientA.delete(rowId, { tier: "edge" });
+      await clientA.deleteDurable(rowId, { tier: "edge" });
       await waitForRows(clientB, queryAllTodos, (rows) => !rows.some((row) => row.id === rowId));
     } finally {
       if (clientA) await clientA.shutdown();

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -6,8 +6,8 @@
  *
  * Key design:
  * - createDb() is async (pre-loads WASM module)
- * - insert is sync (local-first immediate write, no durability wait)
- * - insertDurable/update/deleteFrom are async (durability-aware, return Promises)
+ * - insert/update/delete are sync (local-first immediate writes, no durability wait)
+ * - insertDurable/updateDurable/deleteDurable are async (durability-aware, return Promises)
  * - all/one are async (need storage I/O for queries)
  */
 
@@ -329,8 +329,8 @@ function isLeaderDebugEnabled(): boolean {
  *
  * // Mutations
  * const inserted = db.insert(app.todos, { title: "Buy milk", done: false });
- * await db.update(app.todos, inserted.id, { done: true });
- * await db.deleteFrom(app.todos, inserted.id);
+ * db.update(app.todos, inserted.id, { done: true });
+ * db.delete(app.todos, inserted.id);
  *
  * // Async queries (need storage I/O)
  * const todos = await db.all(app.todos.where({ done: false }));
@@ -989,9 +989,18 @@ export class Db {
   }
 
   /**
+   * Update an existing row without waiting for durability.
+   */
+  update<T, Init>(table: TableProxy<T, Init>, id: string, data: Partial<Init>): void {
+    const client = this.getClient(table._schema);
+    const updates = toUpdateRecord(data as Record<string, unknown>, table._schema, table._table);
+    client.update(id, updates);
+  }
+
+  /**
    * Update an existing row and wait for durability at the requested tier.
    */
-  async update<T, Init>(
+  async updateDurable<T, Init>(
     table: TableProxy<T, Init>,
     id: string,
     data: Partial<Init>,
@@ -1000,20 +1009,28 @@ export class Db {
     const client = this.getClient(table._schema);
     await this.ensureBridgeReady();
     const updates = toUpdateRecord(data as Record<string, unknown>, table._schema, table._table);
-    await client.update(id, updates, options);
+    await client.updateDurable(id, updates, options);
+  }
+
+  /**
+   * Delete a row without waiting for durability.
+   */
+  delete<T, Init>(table: TableProxy<T, Init>, id: string): void {
+    const client = this.getClient(table._schema);
+    client.delete(id);
   }
 
   /**
    * Delete a row and wait for durability at the requested tier.
    */
-  async deleteFrom<T, Init>(
+  async deleteDurable<T, Init>(
     table: TableProxy<T, Init>,
     id: string,
     options?: { tier?: DurabilityTier },
   ): Promise<void> {
     const client = this.getClient(table._schema);
     await this.ensureBridgeReady();
-    await client.delete(id, options);
+    await client.deleteDurable(id, options);
   }
 
   /**
@@ -1232,7 +1249,8 @@ function isBrowser(): boolean {
  * Create a new Db instance with the given configuration.
  *
  * This is an **async** factory function that pre-loads the WASM module.
- * After creation, mutations (insert/update/deleteFrom) are async and return Promises.
+ * After creation, local-first mutations (`insert`/`update`/`delete`) are synchronous.
+ * Use the `*Durable` variants when you need a Promise that resolves at a durability tier.
  *
  * In browser environments, automatically uses a dedicated worker for
  * OPFS persistence. In Node.js, uses in-memory storage.

--- a/packages/jazz-tools/src/runtime/value-converter.ts
+++ b/packages/jazz-tools/src/runtime/value-converter.ts
@@ -1,8 +1,8 @@
 /**
  * Convert JS values to WasmValue types for mutations.
  *
- * Used by Db.insert()/Db.insertDurable() and Db.update() to convert typed Init objects
- * into the Value[] format expected by JazzClient.
+ * Used by Db.insert()/Db.insertDurable() and Db.update()/Db.updateDurable()
+ * to convert typed Init objects into the Value[] format expected by JazzClient.
  */
 
 import type { WasmSchema, ColumnType, Value as WasmValue } from "../drivers/types.js";

--- a/packages/jazz-tools/tests/browser/db.subscribeAll.sort.test.ts
+++ b/packages/jazz-tools/tests/browser/db.subscribeAll.sort.test.ts
@@ -226,7 +226,7 @@ describe("db.subscribeAll sorting browser integration", () => {
           "expected initial sorted rows",
         );
 
-        await db.deleteFrom(todos, idB);
+        await db.delete(todos, idB);
 
         await waitForCondition(
           () => {
@@ -480,7 +480,7 @@ describe("db.subscribeAll sorting browser integration", () => {
         );
 
         await db.update(todos, idC, { rank: 0 });
-        await db.deleteFrom(todos, idA);
+        await db.delete(todos, idA);
         const { id: idD } = await db.insert(todos, { title: "D", rank: 2, done: false });
 
         await waitForCondition(
@@ -677,7 +677,7 @@ describe("db.subscribeAll sorting browser integration", () => {
         );
         expect(latestIds(snapshots)).toEqual([idB, idC]);
 
-        await db.deleteFrom(todos, idA);
+        await db.delete(todos, idA);
 
         await waitForCondition(
           () => {

--- a/packages/jazz-tools/tests/browser/worker-bridge.test.ts
+++ b/packages/jazz-tools/tests/browser/worker-bridge.test.ts
@@ -454,12 +454,35 @@ describe("Worker Bridge with OPFS", () => {
       }),
     );
 
-    const { id } = await db.insert(todos, { title: "Original", done: false });
-    await db.update(todos, id, { done: true });
+    const { id } = db.insert(todos, { title: "Original", done: false });
+    const result = db.update(todos, id, { done: true });
+    expect(result).toBeUndefined();
 
     const results = await db.all(allTodos);
     expect(results.length).toBe(1);
     expect(results[0].title).toBe("Original");
+    expect(results[0].done).toBe(true);
+  });
+
+  it("updates a row durably", async () => {
+    const db = track(
+      await createDb({
+        appId: "test-app",
+        driver: { type: "persistent", dbName: uniqueDbName("update-durable") },
+      }),
+    );
+
+    const { id } = await db.insertDurable(
+      todos,
+      { title: "Original", done: false },
+      { tier: "worker" },
+    );
+    const pending = db.updateDurable(todos, id, { done: true }, { tier: "worker" });
+    expect(pending).toBeInstanceOf(Promise);
+    await pending;
+
+    const results = await db.all(allTodos, { tier: "worker" });
+    expect(results.length).toBe(1);
     expect(results[0].done).toBe(true);
   });
 
@@ -471,11 +494,35 @@ describe("Worker Bridge with OPFS", () => {
       }),
     );
 
-    const { id } = await db.insert(todos, { title: "Ephemeral", done: false });
+    const { id } = db.insert(todos, { title: "Ephemeral", done: false });
     expect((await db.all(allTodos)).length).toBe(1);
 
-    await db.deleteFrom(todos, id);
+    const result = db.delete(todos, id);
+    expect(result).toBeUndefined();
     const results = await db.all(allTodos);
+    expect(results.length).toBe(0);
+  });
+
+  it("deletes a row durably", async () => {
+    const db = track(
+      await createDb({
+        appId: "test-app",
+        driver: { type: "persistent", dbName: uniqueDbName("delete-durable") },
+      }),
+    );
+
+    const { id } = await db.insertDurable(
+      todos,
+      { title: "Ephemeral", done: false },
+      { tier: "worker" },
+    );
+    expect((await db.all(allTodos, { tier: "worker" })).length).toBe(1);
+
+    const pending = db.deleteDurable(todos, id, { tier: "worker" });
+    expect(pending).toBeInstanceOf(Promise);
+    await pending;
+
+    const results = await db.all(allTodos, { tier: "worker" });
     expect(results.length).toBe(0);
   });
 

--- a/packages/jazz-tools/tests/ts-dsl/insert-api.test.ts
+++ b/packages/jazz-tools/tests/ts-dsl/insert-api.test.ts
@@ -6,7 +6,7 @@ function uniqueDbName(label: string): string {
   return `test-${label}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 }
 
-describe("TS Insert API", () => {
+describe("TS Write API", () => {
   let db: Db;
 
   beforeEach(async () => {
@@ -74,5 +74,81 @@ describe("TS Insert API", () => {
       tags: ["tag1", "tag2"],
       project: project.id,
     });
+  });
+
+  it("updates rows synchronously without returning a promise", async () => {
+    const project = db.insert(app.projects, { name: "Test Project" });
+    const todo = db.insert(app.todos, {
+      title: "Test Todo",
+      done: false,
+      tags: ["tag1", "tag2"],
+      project: project.id,
+    });
+
+    const result = db.update(app.todos, todo.id, { done: true });
+    expect(result).toBeUndefined();
+
+    const [updated] = await db.all(app.todos.where({ id: { eq: todo.id } }));
+    expect(updated.done).toBe(true);
+  });
+
+  it("can wait for updates to be persisted up to a specific durability tier", async () => {
+    const project = db.insert(app.projects, { name: "Test Project" });
+    const todo = db.insert(app.todos, {
+      title: "Test Todo",
+      done: false,
+      tags: ["tag1", "tag2"],
+      project: project.id,
+    });
+
+    const pending = db.updateDurable(app.todos, todo.id, { done: true }, { tier: "worker" });
+    expect(pending).toBeInstanceOf(Promise);
+
+    await pending;
+
+    const [updated] = await db.all(app.todos.where({ id: { eq: todo.id } }), { tier: "worker" });
+    expect(updated.done).toBe(true);
+  });
+
+  it("deletes rows synchronously without returning a promise", async () => {
+    const project = db.insert(app.projects, { name: "Test Project" });
+    const todo = db.insert(app.todos, {
+      title: "Test Todo",
+      done: false,
+      tags: ["tag1", "tag2"],
+      project: project.id,
+    });
+
+    const result = db.delete(app.todos, todo.id);
+    expect(result).toBeUndefined();
+
+    const rows = await db.all(app.todos.where({ id: { eq: todo.id } }));
+    expect(rows).toEqual([]);
+  });
+
+  it("can wait for deletes to be persisted up to a specific durability tier", async () => {
+    const project = await db.insertDurable(
+      app.projects,
+      { name: "Test Project" },
+      { tier: "worker" },
+    );
+    const todo = await db.insertDurable(
+      app.todos,
+      {
+        title: "Test Todo",
+        done: false,
+        tags: ["tag1", "tag2"],
+        project: project.id,
+      },
+      { tier: "worker" },
+    );
+
+    const pending = db.deleteDurable(app.todos, todo.id, { tier: "worker" });
+    expect(pending).toBeInstanceOf(Promise);
+
+    await pending;
+
+    const rows = await db.all(app.todos.where({ id: { eq: todo.id } }), { tier: "worker" });
+    expect(rows).toEqual([]);
   });
 });

--- a/specs/status-quo/browser_adapters.md
+++ b/specs/status-quo/browser_adapters.md
@@ -99,14 +99,14 @@ Current plain TypeScript usage pattern (see `examples/todo-client-localfirst-ts/
 1. Build a `DbConfig` (app/env/branch/auth/tier/server options + optional `driver` mode).
 2. Initialize with `Promise.all([createDb(config), resolveClientSession(config)])`.
 3. Read via `db.all(...)`/`db.one(...)` or `db.subscribeAll(...)`.
-4. Mutate via async local-first APIs (`insert`, `update`, `deleteFrom`) with optional `{ tier }` overrides.
+4. Mutate via local-first APIs (`insert`, `update`, `delete`) or durable variants (`insertDurable`, `updateDurable`, `deleteDurable`) when tiered acknowledgement matters.
 5. Tear down with `db.shutdown()`.
 
 ## Runtime Layers and Responsibilities
 
 1. `Db` (`runtime/db.ts`)
 
-- High-level typed API (`insert`, `update`, `deleteFrom`, `all`, `one`, `subscribeAll`).
+- High-level typed API (`insert`, `update`, `delete`, `insertDurable`, `updateDurable`, `deleteDurable`, `all`, `one`, `subscribeAll`).
 - Creates and memoizes `JazzClient` per schema key.
 - Creates worker + bridge in browser mode.
 - Waits for bridge init before durability-tiered mutations.
@@ -172,7 +172,7 @@ Payloads are JSON strings for sync messages (`payload: string`).
 
 ### 2. Mutation Path
 
-Durability mutation (`insert`, `update`, `deleteFrom` with optional `{ tier }`):
+Durability mutation (`insertDurable`, `updateDurable`, `deleteDurable`):
 
 1. `Db` waits for bridge init (`ensureBridgeReady()`).
 2. Call uses the main-thread `JazzClient` durable mutation API.

--- a/specs/status-quo/ts_client_codegen.md
+++ b/specs/status-quo/ts_client_codegen.md
@@ -126,13 +126,16 @@ In memory mode with `serverUrl`, default durability tier is `edge`.
 - `localUpdates?: "immediate" | "deferred"` (default: `immediate`)
 - `propagation?: "full" | "local-only"` (default `full`)
 
-### Mutations (Async Local-First)
+### Mutations (Local-First + Durable Variants)
 
-- `db.insert(table, data, options?)` — applies local write immediately and resolves with new ID at durability tier
-- `db.update(table, id, data, options?)` — applies local update immediately and resolves at durability tier
-- `db.deleteFrom(table, id, options?)` — applies local delete immediately and resolves at durability tier
+- `db.insert(table, data)` — applies a local write immediately and returns the inserted row
+- `db.update(table, id, data)` — applies a local update immediately and returns `void`
+- `db.delete(table, id)` — applies a local delete immediately and returns `void`
+- `db.insertDurable(table, data, { tier })` — applies a local write immediately and resolves with the inserted row at the requested durability tier
+- `db.updateDurable(table, id, data, options?)` — applies a local update immediately and resolves at the requested durability tier
+- `db.deleteDurable(table, id, options?)` — applies a local delete immediately and resolves at the requested durability tier
 
-`options` supports:
+Durable mutation options support:
 
 - `tier?: "worker" | "edge" | "global"`
 

--- a/specs/todo/a_mvp/durability_tier_api_unification.md
+++ b/specs/todo/a_mvp/durability_tier_api_unification.md
@@ -57,17 +57,26 @@ Default write behavior (`WriteOptions.tier` omitted):
 1. client: `"worker"`
 2. backend: `"edge"`
 
-### Method shape (no suffix variants)
+### Method shape (sync base + durable suffix variants)
 
-Tier options are accepted by base methods:
+Base mutation methods stay synchronous and local-first:
 
-1. `insert(..., options?: WriteOptions): Promise<...>`
-2. `update(..., options?: WriteOptions): Promise<void>`
-3. `deleteFrom(..., options?: WriteOptions): Promise<void>`
-4. `all(..., options?: ReadOptions): Promise<...>`
-5. `one(..., options?: ReadOptions): Promise<...>`
-6. `subscribeAll(..., options?: ReadOptions): () => void`
-7. Client-level `query/subscribe` equivalents take `ReadOptions`.
+1. `insert(...): Row`
+2. `update(...): void`
+3. `delete(...): void`
+
+Durable variants opt into acknowledgement promises:
+
+1. `insertDurable(..., options: WriteOptions): Promise<Row>`
+2. `updateDurable(..., options?: WriteOptions): Promise<void>`
+3. `deleteDurable(..., options?: WriteOptions): Promise<void>`
+
+Read methods continue to accept `ReadOptions`:
+
+1. `all(..., options?: ReadOptions): Promise<...>`
+2. `one(..., options?: ReadOptions): Promise<...>`
+3. `subscribeAll(..., options?: ReadOptions): () => void`
+4. Client-level `query/subscribe` equivalents take `ReadOptions`.
 
 Removed APIs:
 


### PR DESCRIPTION
## Summary
- make `Db.update` and `Db.delete` synchronous local-first writes
- add `Db.updateDurable` and `Db.deleteDurable` for tier-gated acknowledgement
- rename `deleteFrom*` to `delete*` across tests, docs, examples, and specs

## Verification
- `pnpm -C packages/jazz-tools exec tsc -p tsconfig.json --noEmit`
- `pnpm -C packages/jazz-tools exec vitest run src/runtime/client.mutations.test.ts tests/ts-dsl/insert-api.test.ts`
- `pnpm -C packages/jazz-tools exec vitest run --config vitest.config.browser.ts ./tests/browser/worker-bridge.test.ts -t "updates a row|updates a row durably|deletes a row|deletes a row durably"`