### PR TITLE
style: format runtime schema order regression test

### DIFF
--- a/packages/jazz-tools/src/runtime/db.schema-order.test.ts
+++ b/packages/jazz-tools/src/runtime/db.schema-order.test.ts
@@ -44,14 +44,21 @@ describe("Db runtime schema order", () => {
       _schema: generatedSchema,
       _rowType: {} as { id: string; title: string; done: boolean },
       _initType: {} as { title: string; done: boolean },
-    } satisfies TableProxy<{ id: string; title: string; done: boolean }, { title: string; done: boolean }>;
+    } satisfies TableProxy<
+      { id: string; title: string; done: boolean },
+      { title: string; done: boolean }
+    >;
 
     await db.insert(table, { title: "Buy milk", done: false });
 
-    expect(create).toHaveBeenCalledWith("todos", [
-      { type: "Boolean", value: false },
-      { type: "Text", value: "Buy milk" },
-    ], undefined);
+    expect(create).toHaveBeenCalledWith(
+      "todos",
+      [
+        { type: "Boolean", value: false },
+        { type: "Text", value: "Buy milk" },
+      ],
+      undefined,
+    );
   });
 
   it("uses the runtime schema order when transforming query results", async () => {


### PR DESCRIPTION
## Summary
- format the runtime schema order regression test added in #233
- restore 
> @ format:check /private/tmp/jazz2-post233-fix
> oxfmt --check --ignore-path .oxfmtignore . && cargo fmt --check

 ELIFECYCLE  Command failed.
 WARN   Local package.json exists, but node_modules missing, did you mean to install? on main
