### PR TITLE
fix runtime schema order compatibility

### DIFF
--- a/.changeset/fix-runtime-schema-order-compat.md
+++ b/.changeset/fix-runtime-schema-order-compat.md
@@ -1,0 +1,7 @@
+---
+"jazz-tools": patch
+---
+
+Fix runtime schema-order compatibility after sorted table columns.
+
+`Db` mutations and query transforms now tolerate runtime schemas returned as `Map`s, and low-level `JazzClient` create/query/subscribe APIs preserve the declared schema column order expected by generated bindings and app code.

--- a/crates/jazz-cloud-server/src/server.rs
+++ b/crates/jazz-cloud-server/src/server.rs
@@ -26,7 +26,7 @@ use jazz_tools::object::ObjectId;
 use jazz_tools::query_manager::query::QueryBuilder;
 use jazz_tools::query_manager::session::Session;
 use jazz_tools::query_manager::types::{
-    ColumnType, Schema, SchemaBuilder, SchemaHash, TableSchema, Value,
+    ColumnType, RowDescriptor, Schema, SchemaBuilder, SchemaHash, TableName, TableSchema, Value,
 };
 use jazz_tools::runtime_core::ReadDurabilityOptions;
 use jazz_tools::runtime_tokio::TokioRuntime;
@@ -1069,6 +1069,24 @@ struct MetaExternalIdentityRow {
 struct MetaStore {
     runtime: TokioRuntime<SurrealKvStorage>,
     secret_hash_key: String,
+    apps_descriptor: RowDescriptor,
+    external_identities_descriptor: RowDescriptor,
+}
+
+fn normalize_row_descriptor(descriptor: &mut RowDescriptor) {
+    descriptor
+        .columns
+        .sort_unstable_by(|left, right| left.name.as_str().cmp(right.name.as_str()));
+}
+
+fn descriptor_value<'a>(
+    descriptor: &RowDescriptor,
+    values: &'a [Value],
+    column: &str,
+) -> Option<&'a Value> {
+    descriptor
+        .column_index(column)
+        .and_then(|index| values.get(index))
 }
 
 impl MetaStore {
@@ -1103,6 +1121,20 @@ impl MetaStore {
             )
             .build();
 
+        let mut apps_descriptor = meta_schema
+            .get(&TableName::new("apps"))
+            .ok_or_else(|| "meta schema missing apps table".to_string())?
+            .columns
+            .clone();
+        normalize_row_descriptor(&mut apps_descriptor);
+
+        let mut external_identities_descriptor = meta_schema
+            .get(&TableName::new("external_identities"))
+            .ok_or_else(|| "meta schema missing external_identities table".to_string())?
+            .columns
+            .clone();
+        normalize_row_descriptor(&mut external_identities_descriptor);
+
         let sync_manager = SyncManager::new().with_durability_tiers(vec![
             DurabilityTier::EdgeServer,
             DurabilityTier::GlobalServer,
@@ -1126,6 +1158,8 @@ impl MetaStore {
         Ok(Self {
             runtime,
             secret_hash_key,
+            apps_descriptor,
+            external_identities_descriptor,
         })
     }
 
@@ -1154,7 +1188,7 @@ impl MetaStore {
             .map_err(|e| format!("meta query await error: {e}"))?;
 
         rows.into_iter()
-            .map(|(object_id, values)| Self::decode_row(object_id, &values))
+            .map(|(object_id, values)| self.decode_row(object_id, &values))
             .collect()
     }
 
@@ -1171,7 +1205,7 @@ impl MetaStore {
             .map_err(|e| format!("meta query await error: {e}"))?;
 
         if let Some((object_id, values)) = rows.pop() {
-            Ok(Some(Self::decode_row(object_id, &values)?))
+            Ok(Some(self.decode_row(object_id, &values)?))
         } else {
             Ok(None)
         }
@@ -1191,22 +1225,28 @@ impl MetaStore {
         admin_secret: Option<String>,
     ) -> Result<MetaAppRow, String> {
         let now = now_timestamp_us();
-        let values = vec![
-            Value::Uuid(app_id.as_object_id()),
-            Value::Text(app_name.clone()),
-            Value::Text(jwks_endpoint.clone()),
-            Value::Boolean(allow_anonymous),
-            Value::Boolean(allow_demo),
-            Value::Text(backend_secret_hash.clone()),
-            Value::Text(admin_secret_hash.clone()),
-            Value::Text(status.as_str().to_string()),
-            Value::Timestamp(now),
-            Value::Timestamp(now),
-            match &admin_secret {
-                Some(value) => Value::Text(value.clone()),
-                None => Value::Null,
-            },
-        ];
+        let values: Vec<Value> = self
+            .apps_descriptor
+            .columns
+            .iter()
+            .map(|column| match column.name.as_str() {
+                "admin_secret" => match &admin_secret {
+                    Some(value) => Value::Text(value.clone()),
+                    None => Value::Null,
+                },
+                "admin_secret_hash" => Value::Text(admin_secret_hash.clone()),
+                "allow_anonymous" => Value::Boolean(allow_anonymous),
+                "allow_demo" => Value::Boolean(allow_demo),
+                "app_id" => Value::Uuid(app_id.as_object_id()),
+                "app_name" => Value::Text(app_name.clone()),
+                "backend_secret_hash" => Value::Text(backend_secret_hash.clone()),
+                "created_at" => Value::Timestamp(now),
+                "jwks_endpoint" => Value::Text(jwks_endpoint.clone()),
+                "status" => Value::Text(status.as_str().to_string()),
+                "updated_at" => Value::Timestamp(now),
+                other => panic!("unexpected meta apps column {other}"),
+            })
+            .collect();
 
         let object_id = self
             .runtime
@@ -1309,9 +1349,7 @@ impl MetaStore {
             .map_err(|e| format!("external identity query await error: {e}"))?;
 
         if let Some((object_id, values)) = rows.pop() {
-            Ok(Some(Self::decode_external_identity_row(
-                object_id, &values,
-            )?))
+            Ok(Some(self.decode_external_identity_row(object_id, &values)?))
         } else {
             Ok(None)
         }
@@ -1325,14 +1363,20 @@ impl MetaStore {
         principal_id: &str,
     ) -> Result<MetaExternalIdentityRow, String> {
         let now = now_timestamp_us();
-        let values = vec![
-            Value::Uuid(app_id.as_object_id()),
-            Value::Text(issuer.to_string()),
-            Value::Text(subject.to_string()),
-            Value::Text(principal_id.to_string()),
-            Value::Timestamp(now),
-            Value::Timestamp(now),
-        ];
+        let values: Vec<Value> = self
+            .external_identities_descriptor
+            .columns
+            .iter()
+            .map(|column| match column.name.as_str() {
+                "app_id" => Value::Uuid(app_id.as_object_id()),
+                "created_at" => Value::Timestamp(now),
+                "issuer" => Value::Text(issuer.to_string()),
+                "principal_id" => Value::Text(principal_id.to_string()),
+                "subject" => Value::Text(subject.to_string()),
+                "updated_at" => Value::Timestamp(now),
+                other => panic!("unexpected external identity column {other}"),
+            })
+            .collect();
 
         let object_id = self
             .runtime
@@ -1349,121 +1393,119 @@ impl MetaStore {
         })
     }
 
-    fn decode_row(object_id: ObjectId, values: &[Value]) -> Result<MetaAppRow, String> {
-        if values.len() < 8 {
-            return Err(format!(
-                "meta row has invalid column count: expected at least 8, got {}",
-                values.len()
-            ));
-        }
-
-        let app_obj_id = match &values[0] {
-            Value::Uuid(id) => *id,
-            other => {
+    fn decode_row(&self, object_id: ObjectId, values: &[Value]) -> Result<MetaAppRow, String> {
+        let app_obj_id = match descriptor_value(&self.apps_descriptor, values, "app_id") {
+            Some(Value::Uuid(id)) => *id,
+            Some(other) => {
                 return Err(format!(
                     "meta row field app_id expected uuid, got {other:?}"
                 ));
             }
+            None => return Err("meta row missing app_id".to_string()),
         };
 
-        let app_name = match &values[1] {
-            Value::Text(s) => s.clone(),
-            other => {
+        let app_name = match descriptor_value(&self.apps_descriptor, values, "app_name") {
+            Some(Value::Text(s)) => s.clone(),
+            Some(other) => {
                 return Err(format!(
                     "meta row field app_name expected text, got {other:?}"
                 ));
             }
+            None => return Err("meta row missing app_name".to_string()),
         };
 
-        let jwks_endpoint = match &values[2] {
-            Value::Text(s) => s.clone(),
-            other => {
+        let jwks_endpoint = match descriptor_value(&self.apps_descriptor, values, "jwks_endpoint") {
+            Some(Value::Text(s)) => s.clone(),
+            Some(other) => {
                 return Err(format!(
                     "meta row field jwks_endpoint expected text, got {other:?}"
                 ));
             }
+            None => return Err("meta row missing jwks_endpoint".to_string()),
         };
-        let (allow_anonymous, allow_demo, idx_shift) = if values.len() >= 10 {
-            let allow_anonymous = match &values[3] {
-                Value::Boolean(v) => *v,
-                other => {
+
+        let allow_anonymous =
+            match descriptor_value(&self.apps_descriptor, values, "allow_anonymous") {
+                Some(Value::Boolean(v)) => *v,
+                Some(other) => {
                     return Err(format!(
                         "meta row field allow_anonymous expected boolean, got {other:?}"
                     ));
                 }
+                None => true,
             };
-            let allow_demo = match &values[4] {
-                Value::Boolean(v) => *v,
-                other => {
+
+        let allow_demo = match descriptor_value(&self.apps_descriptor, values, "allow_demo") {
+            Some(Value::Boolean(v)) => *v,
+            Some(other) => {
+                return Err(format!(
+                    "meta row field allow_demo expected boolean, got {other:?}"
+                ));
+            }
+            None => true,
+        };
+
+        let backend_secret_hash =
+            match descriptor_value(&self.apps_descriptor, values, "backend_secret_hash") {
+                Some(Value::Text(s)) => s.clone(),
+                Some(other) => {
                     return Err(format!(
-                        "meta row field allow_demo expected boolean, got {other:?}"
+                        "meta row field backend_secret_hash expected text, got {other:?}"
                     ));
                 }
+                None => return Err("meta row missing backend_secret_hash".to_string()),
             };
-            (allow_anonymous, allow_demo, 2)
-        } else {
-            // Backward-compat for older rows before auth mode flags existed.
-            (true, true, 0)
-        };
 
-        let backend_secret_hash = match &values[3 + idx_shift] {
-            Value::Text(s) => s.clone(),
-            other => {
-                return Err(format!(
-                    "meta row field backend_secret_hash expected text, got {other:?}"
-                ));
-            }
-        };
+        let admin_secret_hash =
+            match descriptor_value(&self.apps_descriptor, values, "admin_secret_hash") {
+                Some(Value::Text(s)) => s.clone(),
+                Some(other) => {
+                    return Err(format!(
+                        "meta row field admin_secret_hash expected text, got {other:?}"
+                    ));
+                }
+                None => return Err("meta row missing admin_secret_hash".to_string()),
+            };
 
-        let admin_secret_hash = match &values[4 + idx_shift] {
-            Value::Text(s) => s.clone(),
-            other => {
-                return Err(format!(
-                    "meta row field admin_secret_hash expected text, got {other:?}"
-                ));
-            }
-        };
-
-        let status = match &values[5 + idx_shift] {
-            Value::Text(s) => AppStatus::from_str(s)
+        let status = match descriptor_value(&self.apps_descriptor, values, "status") {
+            Some(Value::Text(s)) => AppStatus::from_str(s)
                 .ok_or_else(|| format!("meta row has invalid status value: {s}"))?,
-            other => {
+            Some(other) => {
                 return Err(format!(
                     "meta row field status expected text, got {other:?}"
                 ));
             }
+            None => return Err("meta row missing status".to_string()),
         };
 
-        let created_at = match &values[6 + idx_shift] {
-            Value::Timestamp(ts) => *ts,
-            other => {
+        let created_at = match descriptor_value(&self.apps_descriptor, values, "created_at") {
+            Some(Value::Timestamp(ts)) => *ts,
+            Some(other) => {
                 return Err(format!(
                     "meta row field created_at expected timestamp, got {other:?}"
                 ));
             }
+            None => return Err("meta row missing created_at".to_string()),
         };
 
-        let updated_at = match &values[7 + idx_shift] {
-            Value::Timestamp(ts) => *ts,
-            other => {
+        let updated_at = match descriptor_value(&self.apps_descriptor, values, "updated_at") {
+            Some(Value::Timestamp(ts)) => *ts,
+            Some(other) => {
                 return Err(format!(
                     "meta row field updated_at expected timestamp, got {other:?}"
                 ));
             }
+            None => return Err("meta row missing updated_at".to_string()),
         };
 
-        let admin_secret = if values.len() > 8 + idx_shift {
-            match &values[8 + idx_shift] {
-                Value::Text(value) => Some(value.clone()),
-                Value::Null => None,
-                other => {
-                    return Err(format!(
-                        "meta row field admin_secret expected text|null, got {other:?}"
-                    ));
-                }
+        let admin_secret = match descriptor_value(&self.apps_descriptor, values, "admin_secret") {
+            Some(Value::Text(value)) => Some(value.clone()),
+            Some(Value::Null) | None => None,
+            Some(other) => {
+                return Err(format!(
+                    "meta row field admin_secret expected text|null, got {other:?}"
+                ));
             }
-        } else {
-            None
         };
 
         Ok(MetaAppRow {
@@ -1483,24 +1525,20 @@ impl MetaStore {
     }
 
     fn decode_external_identity_row(
+        &self,
         _object_id: ObjectId,
         values: &[Value],
     ) -> Result<MetaExternalIdentityRow, String> {
-        if values.len() < 6 {
-            return Err(format!(
-                "external identity row has invalid column count: expected at least 6, got {}",
-                values.len()
-            ));
-        }
-
-        let principal_id = match &values[3] {
-            Value::Text(s) => s.clone(),
-            other => {
-                return Err(format!(
-                    "external identity field principal_id expected text, got {other:?}"
-                ));
-            }
-        };
+        let principal_id =
+            match descriptor_value(&self.external_identities_descriptor, values, "principal_id") {
+                Some(Value::Text(s)) => s.clone(),
+                Some(other) => {
+                    return Err(format!(
+                        "external identity field principal_id expected text, got {other:?}"
+                    ));
+                }
+                None => return Err("external identity row missing principal_id".to_string()),
+            };
 
         Ok(MetaExternalIdentityRow { principal_id })
     }

--- a/packages/jazz-tools/src/drivers/schema-wire.ts
+++ b/packages/jazz-tools/src/drivers/schema-wire.ts
@@ -8,6 +8,16 @@ export function isWasmSchema(value: unknown): value is WasmSchema {
   return isRecord(value);
 }
 
+export function normalizeRuntimeSchema(schema: unknown): WasmSchema {
+  if (schema instanceof Map) {
+    return Object.fromEntries(schema.entries()) as WasmSchema;
+  }
+  if (!isWasmSchema(schema)) {
+    throw new Error("Invalid runtime schema value.");
+  }
+  return schema;
+}
+
 export function serializeRuntimeSchema(schema: WasmSchema): string {
   return JSON.stringify(schema);
 }

--- a/packages/jazz-tools/src/runtime/client.for-request.test.ts
+++ b/packages/jazz-tools/src/runtime/client.for-request.test.ts
@@ -444,3 +444,368 @@ describe("JazzClient.forRequest", () => {
     expect(() => client.unsubscribe(123_456)).not.toThrow();
   });
 });
+
+describe("JazzClient schema order", () => {
+  it("reorders create values to the runtime schema order", async () => {
+    const insertDurable = vi.fn(async () => "todo-1");
+    const runtime: Runtime = {
+      insert: () => "todo-1",
+      update: () => {},
+      delete: () => {},
+      query: async () => [],
+      subscribe: () => 0,
+      createSubscription: () => 0,
+      executeSubscription: () => {},
+      unsubscribe: () => {},
+      insertDurable,
+      updateDurable: async () => {},
+      deleteDurable: async () => {},
+      onSyncMessageReceived: () => {},
+      onSyncMessageToSend: () => {},
+      addServer: () => {},
+      removeServer: () => {},
+      addClient: () => "client-1",
+      getSchema: () =>
+        new Map([
+          [
+            "todos",
+            {
+              columns: [
+                {
+                  name: "done",
+                  column_type: { type: "Boolean" as const },
+                  nullable: false,
+                },
+                {
+                  name: "title",
+                  column_type: { type: "Text" as const },
+                  nullable: false,
+                },
+              ],
+            },
+          ],
+        ]),
+      getSchemaHash: () => "schema-hash",
+    };
+    const client = JazzClient.connectWithRuntime(runtime, {
+      appId: "test-app",
+      schema: {
+        todos: {
+          columns: [
+            {
+              name: "title",
+              column_type: { type: "Text" as const },
+              nullable: false,
+            },
+            {
+              name: "done",
+              column_type: { type: "Boolean" as const },
+              nullable: false,
+            },
+          ],
+        },
+      },
+    });
+
+    await client.create("todos", [
+      { type: "Text", value: "Buy milk" },
+      { type: "Boolean", value: false },
+    ]);
+
+    expect(insertDurable).toHaveBeenCalledWith(
+      "todos",
+      [
+        { type: "Boolean", value: false },
+        { type: "Text", value: "Buy milk" },
+      ],
+      "worker",
+    );
+  });
+
+  it("reorders query rows back to the declared schema order", async () => {
+    const runtime: Runtime = {
+      insert: () => "todo-1",
+      update: () => {},
+      delete: () => {},
+      query: async () => [
+        {
+          id: "todo-1",
+          values: [
+            { type: "Boolean", value: false },
+            { type: "Text", value: "Buy milk" },
+          ],
+        },
+      ],
+      subscribe: () => 0,
+      createSubscription: () => 0,
+      executeSubscription: () => {},
+      unsubscribe: () => {},
+      insertDurable: async () => "todo-1",
+      updateDurable: async () => {},
+      deleteDurable: async () => {},
+      onSyncMessageReceived: () => {},
+      onSyncMessageToSend: () => {},
+      addServer: () => {},
+      removeServer: () => {},
+      addClient: () => "client-1",
+      getSchema: () =>
+        new Map([
+          [
+            "todos",
+            {
+              columns: [
+                {
+                  name: "done",
+                  column_type: { type: "Boolean" as const },
+                  nullable: false,
+                },
+                {
+                  name: "title",
+                  column_type: { type: "Text" as const },
+                  nullable: false,
+                },
+              ],
+            },
+          ],
+        ]),
+      getSchemaHash: () => "schema-hash",
+    };
+    const client = JazzClient.connectWithRuntime(runtime, {
+      appId: "test-app",
+      schema: {
+        todos: {
+          columns: [
+            {
+              name: "title",
+              column_type: { type: "Text" as const },
+              nullable: false,
+            },
+            {
+              name: "done",
+              column_type: { type: "Boolean" as const },
+              nullable: false,
+            },
+          ],
+        },
+      },
+    });
+
+    const rows = await client.query(
+      JSON.stringify({ relation_ir: { TableScan: { table: "todos" } } }),
+    );
+
+    expect(rows).toEqual([
+      {
+        id: "todo-1",
+        values: [
+          { type: "Text", value: "Buy milk" },
+          { type: "Boolean", value: false },
+        ],
+      },
+    ]);
+  });
+
+  it("reorders query row columns while preserving included relation values", async () => {
+    const runtime: Runtime = {
+      insert: () => "todo-1",
+      update: () => {},
+      delete: () => {},
+      query: async () => [
+        {
+          id: "todo-1",
+          values: [
+            { type: "Boolean", value: false },
+            { type: "Text", value: "Buy milk" },
+            {
+              type: "Array",
+              value: [
+                {
+                  type: "Row",
+                  value: {
+                    id: "project-1",
+                    values: [{ type: "Text", value: "Inbox" }],
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      subscribe: () => 0,
+      createSubscription: () => 0,
+      executeSubscription: () => {},
+      unsubscribe: () => {},
+      insertDurable: async () => "todo-1",
+      updateDurable: async () => {},
+      deleteDurable: async () => {},
+      onSyncMessageReceived: () => {},
+      onSyncMessageToSend: () => {},
+      addServer: () => {},
+      removeServer: () => {},
+      addClient: () => "client-1",
+      getSchema: () =>
+        new Map([
+          [
+            "todos",
+            {
+              columns: [
+                {
+                  name: "done",
+                  column_type: { type: "Boolean" as const },
+                  nullable: false,
+                },
+                {
+                  name: "title",
+                  column_type: { type: "Text" as const },
+                  nullable: false,
+                },
+              ],
+            },
+          ],
+        ]),
+      getSchemaHash: () => "schema-hash",
+    };
+    const client = JazzClient.connectWithRuntime(runtime, {
+      appId: "test-app",
+      schema: {
+        todos: {
+          columns: [
+            {
+              name: "title",
+              column_type: { type: "Text" as const },
+              nullable: false,
+            },
+            {
+              name: "done",
+              column_type: { type: "Boolean" as const },
+              nullable: false,
+            },
+          ],
+        },
+      },
+    });
+
+    const rows = await client.query(
+      JSON.stringify({ relation_ir: { TableScan: { table: "todos" } } }),
+    );
+
+    expect(rows).toEqual([
+      {
+        id: "todo-1",
+        values: [
+          { type: "Text", value: "Buy milk" },
+          { type: "Boolean", value: false },
+          {
+            type: "Array",
+            value: [
+              {
+                type: "Row",
+                value: {
+                  id: "project-1",
+                  values: [{ type: "Text", value: "Inbox" }],
+                },
+              },
+            ],
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("reorders subscription deltas back to the declared schema order", async () => {
+    let onUpdate: ((delta: unknown) => void) | undefined;
+    const runtime: Runtime = {
+      insert: () => "todo-1",
+      update: () => {},
+      delete: () => {},
+      query: async () => [],
+      subscribe: () => 0,
+      createSubscription: () => 1,
+      executeSubscription: (_handle, callback) => {
+        onUpdate = callback as (delta: unknown) => void;
+      },
+      unsubscribe: () => {},
+      insertDurable: async () => "todo-1",
+      updateDurable: async () => {},
+      deleteDurable: async () => {},
+      onSyncMessageReceived: () => {},
+      onSyncMessageToSend: () => {},
+      addServer: () => {},
+      removeServer: () => {},
+      addClient: () => "client-1",
+      getSchema: () =>
+        new Map([
+          [
+            "todos",
+            {
+              columns: [
+                {
+                  name: "done",
+                  column_type: { type: "Boolean" as const },
+                  nullable: false,
+                },
+                {
+                  name: "title",
+                  column_type: { type: "Text" as const },
+                  nullable: false,
+                },
+              ],
+            },
+          ],
+        ]),
+      getSchemaHash: () => "schema-hash",
+    };
+    const client = JazzClient.connectWithRuntime(runtime, {
+      appId: "test-app",
+      schema: {
+        todos: {
+          columns: [
+            {
+              name: "title",
+              column_type: { type: "Text" as const },
+              nullable: false,
+            },
+            {
+              name: "done",
+              column_type: { type: "Boolean" as const },
+              nullable: false,
+            },
+          ],
+        },
+      },
+    });
+    const callback = vi.fn();
+
+    client.subscribe(JSON.stringify({ relation_ir: { TableScan: { table: "todos" } } }), callback);
+    await flushMicrotasks();
+    onUpdate?.([
+      {
+        kind: 0,
+        id: "todo-1",
+        index: 0,
+        row: {
+          id: "todo-1",
+          values: [
+            { type: "Boolean", value: false },
+            { type: "Text", value: "Buy milk" },
+          ],
+        },
+      },
+    ]);
+
+    expect(callback).toHaveBeenCalledWith([
+      {
+        kind: 0,
+        id: "todo-1",
+        index: 0,
+        row: {
+          id: "todo-1",
+          values: [
+            { type: "Text", value: "Buy milk" },
+            { type: "Boolean", value: false },
+          ],
+        },
+      },
+    ]);
+  });
+});

--- a/packages/jazz-tools/src/runtime/client.ts
+++ b/packages/jazz-tools/src/runtime/client.ts
@@ -7,7 +7,7 @@
 
 import type { AppContext, Session } from "./context.js";
 import type { Value, RowDelta, WasmSchema } from "../drivers/types.js";
-import { serializeRuntimeSchema } from "../drivers/schema-wire.js";
+import { normalizeRuntimeSchema, serializeRuntimeSchema } from "../drivers/schema-wire.js";
 import {
   sendSyncPayload,
   generateClientId,
@@ -137,6 +137,8 @@ export interface QueryInput {
   _schema?: WasmSchema;
 }
 
+type RelationIrNode = Record<string, unknown>;
+
 function resolveQueryJson(query: string | QueryInput): string {
   if (typeof query === "string") {
     return query;
@@ -159,6 +161,66 @@ function resolveQueryJson(query: string | QueryInput): string {
   }
 
   return translateQuery(builtQuery, schema);
+}
+
+function resolveRelationIrOutputTable(node: unknown): string | null {
+  if (!node || typeof node !== "object") {
+    return null;
+  }
+
+  const relation = node as RelationIrNode;
+
+  if ("TableScan" in relation) {
+    const tableScan = relation.TableScan as { table?: unknown } | undefined;
+    return typeof tableScan?.table === "string" ? tableScan.table : null;
+  }
+
+  if ("Filter" in relation) {
+    return resolveRelationIrOutputTable(
+      (relation.Filter as { input?: unknown } | undefined)?.input,
+    );
+  }
+
+  if ("OrderBy" in relation) {
+    return resolveRelationIrOutputTable(
+      (relation.OrderBy as { input?: unknown } | undefined)?.input,
+    );
+  }
+
+  if ("Limit" in relation) {
+    return resolveRelationIrOutputTable((relation.Limit as { input?: unknown } | undefined)?.input);
+  }
+
+  if ("Offset" in relation) {
+    return resolveRelationIrOutputTable(
+      (relation.Offset as { input?: unknown } | undefined)?.input,
+    );
+  }
+
+  if ("Project" in relation) {
+    return resolveRelationIrOutputTable(
+      (relation.Project as { input?: unknown } | undefined)?.input,
+    );
+  }
+
+  if ("Gather" in relation) {
+    const gather = relation.Gather as { seed?: unknown } | undefined;
+    return resolveRelationIrOutputTable(gather?.seed);
+  }
+
+  return null;
+}
+
+function resolveQueryOutputTable(queryJson: string): string | null {
+  try {
+    const parsed = JSON.parse(queryJson) as { table?: unknown; relation_ir?: unknown };
+    if (typeof parsed.table === "string") {
+      return parsed.table;
+    }
+    return resolveRelationIrOutputTable(parsed.relation_ir);
+  } catch {
+    return null;
+  }
 }
 
 function resolveNodeTier(tier: AppContext["tier"]): string | undefined {
@@ -621,12 +683,130 @@ export class JazzClient {
     return options?.tier ?? this.defaultDurabilityTier;
   }
 
+  private alignCreateValuesToRuntimeSchema(
+    table: string,
+    values: Value[],
+    runtimeSchema = this.getSchema(),
+  ): Value[] {
+    const declaredTable = this.context.schema[table];
+    const runtimeTable = runtimeSchema[table];
+
+    if (!declaredTable || !runtimeTable || values.length !== declaredTable.columns.length) {
+      return values;
+    }
+
+    const valuesByColumn = new Map<string, Value>();
+    for (let index = 0; index < declaredTable.columns.length; index += 1) {
+      const column = declaredTable.columns[index];
+      const value = values[index];
+      if (value === undefined) {
+        return values;
+      }
+      valuesByColumn.set(column.name, value);
+    }
+
+    const reorderedValues: Value[] = [];
+    for (const column of runtimeTable.columns) {
+      const value = valuesByColumn.get(column.name);
+      if (value === undefined) {
+        return values;
+      }
+      reorderedValues.push(value);
+    }
+
+    return reorderedValues;
+  }
+
+  private alignRowValuesToDeclaredSchema(
+    table: string,
+    values: Value[],
+    runtimeSchema = this.getSchema(),
+  ): Value[] {
+    const declaredTable = this.context.schema[table];
+    const runtimeTable = runtimeSchema[table];
+
+    if (!declaredTable || !runtimeTable || values.length < runtimeTable.columns.length) {
+      return values;
+    }
+
+    const valuesByColumn = new Map<string, Value>();
+    for (let index = 0; index < runtimeTable.columns.length; index += 1) {
+      const column = runtimeTable.columns[index];
+      const value = values[index];
+      if (value === undefined) {
+        return values;
+      }
+      valuesByColumn.set(column.name, value);
+    }
+
+    const reorderedValues: Value[] = [];
+    for (const column of declaredTable.columns) {
+      const value = valuesByColumn.get(column.name);
+      if (value === undefined) {
+        return values;
+      }
+      reorderedValues.push(value);
+    }
+
+    return reorderedValues.concat(values.slice(runtimeTable.columns.length));
+  }
+
+  private alignQueryRowsToDeclaredSchema(
+    queryJson: string,
+    rows: Row[],
+    runtimeSchema = this.getSchema(),
+  ): Row[] {
+    const outputTable = resolveQueryOutputTable(queryJson);
+    if (!outputTable) {
+      return rows;
+    }
+
+    return rows.map((row) => ({
+      ...row,
+      values: this.alignRowValuesToDeclaredSchema(outputTable, row.values, runtimeSchema),
+    }));
+  }
+
+  private alignSubscriptionDeltaToDeclaredSchema(
+    queryJson: string,
+    delta: RowDelta,
+    runtimeSchema = this.getSchema(),
+  ): RowDelta {
+    const outputTable = resolveQueryOutputTable(queryJson);
+    if (!outputTable || !Array.isArray(delta)) {
+      return delta;
+    }
+
+    return delta.map((change) => {
+      if ((change.kind === 0 || change.kind === 2) && change.row) {
+        return {
+          ...change,
+          row: {
+            ...change.row,
+            values: this.alignRowValuesToDeclaredSchema(
+              outputTable,
+              change.row.values as Value[],
+              runtimeSchema,
+            ),
+          },
+        };
+      }
+
+      return change;
+    });
+  }
+
   /**
    * Insert a new row into a table and wait for durability at the requested tier.
    */
   async create(table: string, values: Value[], options?: WriteDurabilityOptions): Promise<string> {
     const tier = this.resolveWriteTier(options);
-    return this.runtime.insertDurable(table, values, tier);
+    const runtimeSchema = this.getSchema();
+    return this.runtime.insertDurable(
+      table,
+      this.alignCreateValuesToRuntimeSchema(table, values, runtimeSchema),
+      tier,
+    );
   }
 
   /**
@@ -653,13 +833,14 @@ export class JazzClient {
     const queryJson = resolveQueryJson(query);
     const sessionJson = session ? JSON.stringify(session) : undefined;
     const optionsJson = encodeQueryExecutionOptions(normalizedOptions);
+    const runtimeSchema = this.getSchema();
     const results = await this.runtime.query(
       queryJson,
       sessionJson,
       normalizedOptions.tier,
       optionsJson,
     );
-    return results as Row[];
+    return this.alignQueryRowsToDeclaredSchema(queryJson, results as Row[], runtimeSchema);
   }
 
   /**
@@ -718,6 +899,7 @@ export class JazzClient {
     const sessionJson = session ? JSON.stringify(session) : undefined;
     const queryJson = resolveQueryJson(query);
     const optionsJson = encodeQueryExecutionOptions(normalizedOptions);
+    const runtimeSchema = this.getSchema();
 
     const handle = this.runtime.createSubscription(
       queryJson,
@@ -730,7 +912,7 @@ export class JazzClient {
       this.runtime.executeSubscription(handle, (deltaJsonOrObject: RowDelta | string) => {
         const delta: RowDelta =
           typeof deltaJsonOrObject === "string" ? JSON.parse(deltaJsonOrObject) : deltaJsonOrObject;
-        callback(delta);
+        callback(this.alignSubscriptionDeltaToDeclaredSchema(queryJson, delta, runtimeSchema));
       });
     });
 
@@ -750,7 +932,7 @@ export class JazzClient {
    * Get the current schema.
    */
   getSchema(): WasmSchema {
-    return this.runtime.getSchema() as WasmSchema;
+    return normalizeRuntimeSchema(this.runtime.getSchema());
   }
 
   /**

--- a/packages/jazz-tools/src/runtime/db.schema-order.test.ts
+++ b/packages/jazz-tools/src/runtime/db.schema-order.test.ts
@@ -14,7 +14,7 @@ class TestDb extends Db {
 }
 
 describe("Db runtime schema order", () => {
-  it("uses the runtime schema order for inserts", async () => {
+  it("uses the generated schema order for inserts when the runtime schema is sorted", async () => {
     const generatedSchema: WasmSchema = {
       todos: {
         columns: [
@@ -35,7 +35,7 @@ describe("Db runtime schema order", () => {
       async () => "todo-1",
     );
     const client = {
-      getSchema: () => runtimeSchema,
+      getSchema: () => new Map(Object.entries(runtimeSchema)),
       create,
     } as unknown as JazzClient;
     const db = new TestDb(client);
@@ -54,14 +54,14 @@ describe("Db runtime schema order", () => {
     expect(create).toHaveBeenCalledWith(
       "todos",
       [
-        { type: "Boolean", value: false },
         { type: "Text", value: "Buy milk" },
+        { type: "Boolean", value: false },
       ],
       undefined,
     );
   });
 
-  it("uses the runtime schema order when transforming query results", async () => {
+  it("uses the generated schema order when transforming query results", async () => {
     const generatedSchema: WasmSchema = {
       todos: {
         columns: [
@@ -82,13 +82,13 @@ describe("Db runtime schema order", () => {
       {
         id: "todo-1",
         values: [
-          { type: "Boolean", value: true },
           { type: "Text", value: "Sorted title" },
+          { type: "Boolean", value: true },
         ],
       },
     ]);
     const client = {
-      getSchema: () => runtimeSchema,
+      getSchema: () => new Map(Object.entries(runtimeSchema)),
       query,
     } as unknown as JazzClient;
     const db = new TestDb(client);
@@ -111,6 +111,92 @@ describe("Db runtime schema order", () => {
       {
         id: "todo-1",
         title: "Sorted title",
+        done: true,
+      },
+    ]);
+  });
+
+  it("falls back to the generated schema when the runtime schema is missing a table", async () => {
+    const generatedSchema: WasmSchema = {
+      todos: {
+        columns: [
+          { name: "title", column_type: { type: "Text" }, nullable: false },
+          { name: "done", column_type: { type: "Boolean" }, nullable: false },
+        ],
+      },
+    };
+    const create = vi.fn<(...args: [string, Value[], { tier?: string }?]) => Promise<string>>(
+      async () => "todo-1",
+    );
+    const client = {
+      getSchema: () => new Map(),
+      create,
+    } as unknown as JazzClient;
+    const db = new TestDb(client);
+    const table = {
+      _table: "todos",
+      _schema: generatedSchema,
+      _rowType: {} as { id: string; title: string; done: boolean },
+      _initType: {} as { title: string; done: boolean },
+    } satisfies TableProxy<
+      { id: string; title: string; done: boolean },
+      { title: string; done: boolean }
+    >;
+
+    await db.insert(table, { title: "Buy milk", done: false });
+
+    expect(create).toHaveBeenCalledWith(
+      "todos",
+      [
+        { type: "Text", value: "Buy milk" },
+        { type: "Boolean", value: false },
+      ],
+      undefined,
+    );
+  });
+
+  it("falls back to the generated schema for query results when the runtime schema is missing a table", async () => {
+    const generatedSchema: WasmSchema = {
+      todos: {
+        columns: [
+          { name: "title", column_type: { type: "Text" }, nullable: false },
+          { name: "done", column_type: { type: "Boolean" }, nullable: false },
+        ],
+      },
+    };
+    const query = vi.fn<(...args: [string, object?]) => Promise<WasmRow[]>>(async () => [
+      {
+        id: "todo-1",
+        values: [
+          { type: "Text", value: "Generated title" },
+          { type: "Boolean", value: true },
+        ],
+      },
+    ]);
+    const client = {
+      getSchema: () => new Map(),
+      query,
+    } as unknown as JazzClient;
+    const db = new TestDb(client);
+    const builder = {
+      _table: "todos",
+      _schema: generatedSchema,
+      _rowType: {} as { id: string; title: string; done: boolean },
+      _build: () =>
+        JSON.stringify({
+          table: "todos",
+          conditions: [],
+          includes: {},
+          orderBy: [],
+        }),
+    } satisfies QueryBuilder<{ id: string; title: string; done: boolean }>;
+
+    const rows = await db.all(builder);
+
+    expect(rows).toEqual([
+      {
+        id: "todo-1",
+        title: "Generated title",
         done: true,
       },
     ]);

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -11,7 +11,7 @@
  */
 
 import type { WasmSchema, WasmRow, StorageDriver } from "../drivers/types.js";
-import { serializeRuntimeSchema } from "../drivers/schema-wire.js";
+import { normalizeRuntimeSchema, serializeRuntimeSchema } from "../drivers/schema-wire.js";
 import type { Session } from "./context.js";
 import {
   JazzClient,
@@ -209,6 +209,14 @@ function resolveHopOutputTable(
     currentTable = relation.toTable;
   }
   return currentTable;
+}
+
+function resolveSchemaWithTable(
+  preferredSchema: WasmSchema,
+  fallbackSchema: WasmSchema,
+  tableName: string,
+): WasmSchema {
+  return preferredSchema[tableName] ? preferredSchema : fallbackSchema;
 }
 
 /**
@@ -970,9 +978,13 @@ export class Db {
     options?: { tier?: DurabilityTier },
   ): Promise<string> {
     const client = this.getClient(table._schema);
-    const runtimeSchema = client.getSchema();
+    const inputSchema = resolveSchemaWithTable(
+      table._schema,
+      normalizeRuntimeSchema(client.getSchema()),
+      table._table,
+    );
     await this.ensureBridgeReady();
-    const values = toValueArray(data as Record<string, unknown>, runtimeSchema, table._table);
+    const values = toValueArray(data as Record<string, unknown>, inputSchema, table._table);
     return client.create(table._table, values, options);
   }
 
@@ -986,9 +998,13 @@ export class Db {
     options?: { tier?: DurabilityTier },
   ): Promise<void> {
     const client = this.getClient(table._schema);
-    const runtimeSchema = client.getSchema();
+    const inputSchema = resolveSchemaWithTable(
+      table._schema,
+      normalizeRuntimeSchema(client.getSchema()),
+      table._table,
+    );
     await this.ensureBridgeReady();
-    const updates = toUpdateRecord(data as Record<string, unknown>, runtimeSchema, table._table);
+    const updates = toUpdateRecord(data as Record<string, unknown>, inputSchema, table._table);
     await client.update(id, updates, options);
   }
 
@@ -1077,16 +1093,18 @@ export class Db {
    */
   async all<T>(query: QueryBuilder<T>, options?: QueryOptions): Promise<T[]> {
     const client = this.getClient(query._schema);
-    const runtimeSchema = client.getSchema();
+    const runtimeSchema = normalizeRuntimeSchema(client.getSchema());
     const builderJson = query._build();
     const builtQuery = normalizeBuiltQuery(JSON.parse(builderJson) as BuiltQuery, query._table);
-    const rows = await client.query(translateQuery(builderJson, runtimeSchema), options);
+    const planningSchema = resolveSchemaWithTable(query._schema, runtimeSchema, builtQuery.table);
     const outputTable =
       builtQuery.hops.length > 0
-        ? resolveHopOutputTable(runtimeSchema, builtQuery.table, builtQuery.hops)
+        ? resolveHopOutputTable(planningSchema, builtQuery.table, builtQuery.hops)
         : query._table;
+    const outputSchema = resolveSchemaWithTable(query._schema, runtimeSchema, outputTable);
+    const rows = await client.query(translateQuery(builderJson, planningSchema), options);
     const outputIncludes = builtQuery.hops.length > 0 ? {} : builtQuery.includes;
-    return transformRows<T>(rows, runtimeSchema, outputTable, outputIncludes);
+    return transformRows<T>(rows, outputSchema, outputTable, outputIncludes);
   }
 
   /**
@@ -1135,18 +1153,20 @@ export class Db {
   ): () => void {
     const manager = new SubscriptionManager<T>();
     const client = this.getClient(query._schema);
-    const runtimeSchema = client.getSchema();
+    const runtimeSchema = normalizeRuntimeSchema(client.getSchema());
     const builderJson = query._build();
     const builtQuery = normalizeBuiltQuery(JSON.parse(builderJson) as BuiltQuery, query._table);
+    const planningSchema = resolveSchemaWithTable(query._schema, runtimeSchema, builtQuery.table);
     const outputTable =
       builtQuery.hops.length > 0
-        ? resolveHopOutputTable(runtimeSchema, builtQuery.table, builtQuery.hops)
+        ? resolveHopOutputTable(planningSchema, builtQuery.table, builtQuery.hops)
         : query._table;
+    const outputSchema = resolveSchemaWithTable(query._schema, runtimeSchema, outputTable);
     const outputIncludes = builtQuery.hops.length > 0 ? {} : builtQuery.includes;
-    const wasmQuery = translateQuery(builderJson, runtimeSchema);
+    const wasmQuery = translateQuery(builderJson, planningSchema);
 
     const transform = (row: WasmRow): T => {
-      return transformRows<T>([row], runtimeSchema, outputTable, outputIncludes)[0];
+      return transformRows<T>([row], outputSchema, outputTable, outputIncludes)[0];
     };
 
     const subId = client.subscribeInternal(


### PR DESCRIPTION
## Summary
- normalize runtime schemas returned as `Map`s before using them in the TS runtime
- keep `JazzClient` create/query/subscribe values aligned to the declared schema order while preserving include payloads
- make cloud-server meta row encoding/decoding use descriptor lookups so sorted schema columns do not break app creation

## Validation
- pnpm --filter jazz-tools exec vitest run --config vitest.config.ts src/runtime/db.schema-order.test.ts src/react/create-jazz-client.integration.test.ts src/vue/create-jazz-client.integration.test.ts src/subscriptions-orchestrator.integration.test.ts tests/ts-dsl/query-api.test.ts src/runtime/client.for-request.test.ts
- pnpm --filter jazz-tools exec vitest run --config vitest.config.ts src/runtime/client.for-request.test.ts src/runtime/cloud-server.integration.test.ts
- pnpm format:check
- cargo build -p jazz-cloud-server