### PR TITLE
Add NAPI sync regression coverage

### DIFF
--- a/.changeset/napi-backend-sync-regression.md
+++ b/.changeset/napi-backend-sync-regression.md
@@ -1,0 +1,7 @@
+---
+"jazz-tools": patch
+---
+
+Fix backend N-API sync regression where outbound messages were dropped before they reached the server.
+
+`createJazzContext(...).asBackend()` now accepts the real nested N-API sync callback shape used by published alpha builds, so backend query subscriptions and other upstream sync traffic can leave the local runtime again.

--- a/packages/jazz-tools/src/runtime/client.for-request.test.ts
+++ b/packages/jazz-tools/src/runtime/client.for-request.test.ts
@@ -364,6 +364,33 @@ describe("JazzClient.forRequest", () => {
     });
   });
 
+  it("forwards NAPI error-first delta payloads to subscription callbacks", async () => {
+    const { client, executeSubscriptionCalls } = makeClient();
+    const callback = vi.fn();
+    client.subscribe('{"table":"todos"}', callback);
+    await flushMicrotasks();
+
+    const onUpdate = executeSubscriptionCalls[0][1];
+    onUpdate(null, [
+      {
+        kind: 0,
+        id: "row-a",
+        index: 0,
+        row: { id: "row-a", values: [] },
+      },
+    ]);
+
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(callback).toHaveBeenCalledWith([
+      {
+        kind: 0,
+        id: "row-a",
+        index: 0,
+        row: { id: "row-a", values: [] },
+      },
+    ]);
+  });
+
   it("forwards partial structured deltas without throwing", async () => {
     const { client, executeSubscriptionCalls } = makeClient();
     const callback = vi.fn();

--- a/packages/jazz-tools/src/runtime/client.ts
+++ b/packages/jazz-tools/src/runtime/client.ts
@@ -240,6 +240,19 @@ function readHeader(request: RequestLike, name: string): string | undefined {
   return raw;
 }
 
+function normalizeSubscriptionCallbackArgs(args: unknown[]): RowDelta | string | undefined {
+  if (args.length === 1) {
+    return args[0] as RowDelta | string;
+  }
+
+  if (args.length === 2 && args[0] == null) {
+    return args[1] as RowDelta | string | undefined;
+  }
+
+  console.error("Invalid subscription callback arguments", args);
+  return undefined;
+}
+
 function decodeBase64Url(value: string): string {
   const base64 = value.replace(/-/g, "+").replace(/_/g, "/");
   const padded = base64 + "=".repeat((4 - (base64.length % 4)) % 4);
@@ -727,7 +740,12 @@ export class JazzClient {
     );
 
     this.scheduler(() => {
-      this.runtime.executeSubscription(handle, (deltaJsonOrObject: RowDelta | string) => {
+      this.runtime.executeSubscription(handle, (...args: unknown[]) => {
+        const deltaJsonOrObject = normalizeSubscriptionCallbackArgs(args);
+        if (deltaJsonOrObject === undefined) {
+          return;
+        }
+
         const delta: RowDelta =
           typeof deltaJsonOrObject === "string" ? JSON.parse(deltaJsonOrObject) : deltaJsonOrObject;
         callback(delta);

--- a/packages/jazz-tools/src/runtime/napi.integration.test.ts
+++ b/packages/jazz-tools/src/runtime/napi.integration.test.ts
@@ -17,7 +17,6 @@ import type { QueryBuilder } from "./db.js";
 import { translateQuery } from "./query-adapter.js";
 import { pushSchemaCatalogue, startLocalJazzServer } from "../testing/local-jazz-server.js";
 import { createNapiRuntime, loadNapiModule } from "./testing/napi-runtime-test-utils.js";
-import { wasmSchema as TODO_SERVER_WASM_SCHEMA } from "../../../../examples/todo-server-ts/schema/app.ts";
 
 type Todo = {
   id: string;
@@ -58,6 +57,87 @@ const TEST_SCHEMA: WasmSchema = {
       { name: "title", column_type: { type: "Text" }, nullable: false },
       { name: "done", column_type: { type: "Boolean" }, nullable: false },
     ],
+  },
+};
+
+const TODO_SERVER_WASM_SCHEMA: WasmSchema = {
+  projects: {
+    columns: [{ name: "name", column_type: { type: "Text" }, nullable: false }],
+  },
+  todos: {
+    columns: [
+      { name: "title", column_type: { type: "Text" }, nullable: false },
+      { name: "done", column_type: { type: "Boolean" }, nullable: false },
+      { name: "description", column_type: { type: "Text" }, nullable: true },
+      {
+        name: "parent",
+        column_type: { type: "Uuid" },
+        nullable: true,
+        references: "todos",
+      },
+      {
+        name: "project",
+        column_type: { type: "Uuid" },
+        nullable: true,
+        references: "projects",
+      },
+      { name: "owner_id", column_type: { type: "Text" }, nullable: false },
+    ],
+    policies: {
+      select: {
+        using: {
+          type: "Cmp",
+          column: "owner_id",
+          op: "Eq",
+          value: {
+            type: "SessionRef",
+            path: ["user_id"],
+          },
+        },
+      },
+      insert: {
+        with_check: {
+          type: "Cmp",
+          column: "owner_id",
+          op: "Eq",
+          value: {
+            type: "SessionRef",
+            path: ["user_id"],
+          },
+        },
+      },
+      update: {
+        using: {
+          type: "Cmp",
+          column: "owner_id",
+          op: "Eq",
+          value: {
+            type: "SessionRef",
+            path: ["user_id"],
+          },
+        },
+        with_check: {
+          type: "Cmp",
+          column: "owner_id",
+          op: "Eq",
+          value: {
+            type: "SessionRef",
+            path: ["user_id"],
+          },
+        },
+      },
+      delete: {
+        using: {
+          type: "Cmp",
+          column: "owner_id",
+          op: "Eq",
+          value: {
+            type: "SessionRef",
+            path: ["user_id"],
+          },
+        },
+      },
+    },
   },
 };
 
@@ -496,7 +576,7 @@ describe("NAPI integration", () => {
       { timeout: 15_000 },
     );
 
-    const objectId = runtime.insert("todos", [
+    const insertedRow = runtime.insert("todos", [
       { type: "Text", value: "client-synced-item" },
       { type: "Boolean", value: false },
     ]);
@@ -517,7 +597,7 @@ describe("NAPI integration", () => {
     );
 
     expect(rawCalls.every((call) => isNestedOutboxCall(call))).toBe(true);
-    expect(objectId).toEqual(expect.any(String));
+    expect(insertedRow.id).toEqual(expect.any(String));
   }, 20_000);
 
   it("posts backend query subscriptions upstream via createJazzContext(...).asBackend()", async () => {
@@ -908,7 +988,7 @@ describe("NAPI integration", () => {
       const aliceWriter = aliceContext.client();
 
       await withTimeout(
-        bobWriter.create(
+        bobWriter.createDurable(
           "todos",
           [
             { type: "Text", value: "bob-item" },
@@ -924,7 +1004,7 @@ describe("NAPI integration", () => {
         "bob writer create timed out",
       );
       await withTimeout(
-        carolWriter.create(
+        carolWriter.createDurable(
           "todos",
           [
             { type: "Text", value: "carol-item" },
@@ -940,7 +1020,7 @@ describe("NAPI integration", () => {
         "carol writer create timed out",
       );
       await withTimeout(
-        aliceWriter.create(
+        aliceWriter.createDurable(
           "todos",
           [
             { type: "Text", value: "alice-item" },
@@ -1080,7 +1160,7 @@ describe("NAPI integration", () => {
 
       await waitForRows(reader, (rows) => rows.length === 0);
 
-      const rowId = await writer.create(
+      const createdRow = await writer.createDurable(
         "todos",
         [
           { type: "Text", value: "napi-shared-item" },
@@ -1088,15 +1168,20 @@ describe("NAPI integration", () => {
         ],
         { tier: "edge" },
       );
+      const rowId = createdRow.id;
 
       const rowsAfterCreate = await waitForRows(reader, (rows) =>
         rows.some((row) => row.id === rowId),
       );
-      const createdRow = rowsAfterCreate.find((row) => row.id === rowId);
-      expect(createdRow?.values[0]).toEqual({ type: "Text", value: "napi-shared-item" });
-      expect(createdRow?.values[1]).toEqual({ type: "Boolean", value: false });
+      const replicatedRow = rowsAfterCreate.find((row) => row.id === rowId);
+      expect(replicatedRow?.values[0]).toEqual({ type: "Text", value: "napi-shared-item" });
+      expect(replicatedRow?.values[1]).toEqual({ type: "Boolean", value: false });
 
-      await writer.update(rowId, { done: { type: "Boolean", value: true } }, { tier: "edge" });
+      await writer.updateDurable(
+        rowId,
+        { done: { type: "Boolean", value: true } },
+        { tier: "edge" },
+      );
 
       const rowsAfterUpdate = await waitForRows(reader, (rows) => {
         const row = rows.find((entry) => entry.id === rowId);
@@ -1105,7 +1190,7 @@ describe("NAPI integration", () => {
       const updatedRow = rowsAfterUpdate.find((row) => row.id === rowId);
       expect(updatedRow?.values[1]).toEqual({ type: "Boolean", value: true });
 
-      await writer.delete(rowId, { tier: "edge" });
+      await writer.deleteDurable(rowId, { tier: "edge" });
       await waitForRows(reader, (rows) => !rows.some((row) => row.id === rowId));
     } finally {
       if (writerContext) {
@@ -1142,7 +1227,7 @@ describe("NAPI integration", () => {
       });
 
       const writer = writerContext.client();
-      const rowId = await writer.create(
+      const createdRow = await writer.createDurable(
         "todos",
         [
           { type: "Text", value: "persisted-local-item" },
@@ -1150,6 +1235,7 @@ describe("NAPI integration", () => {
         ],
         { tier: "worker" },
       );
+      const rowId = createdRow.id;
 
       await waitForRows(writer, (rows) => rows.some((row) => row.id === rowId), 10_000, {
         tier: "worker",

--- a/packages/jazz-tools/src/runtime/napi.integration.test.ts
+++ b/packages/jazz-tools/src/runtime/napi.integration.test.ts
@@ -1,0 +1,414 @@
+import { randomUUID } from "node:crypto";
+import {
+  createServer as createHttpServer,
+  type IncomingMessage,
+  type Server as HttpServer,
+  type ServerResponse,
+} from "node:http";
+import { createServer as createNetServer } from "node:net";
+import { fileURLToPath } from "node:url";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import type { WasmSchema } from "../drivers/types.js";
+import type { JazzClient, Row } from "./client.js";
+import type { QueryBuilder } from "./db.js";
+import { translateQuery } from "./query-adapter.js";
+import { pushSchemaCatalogue, startLocalJazzServer } from "../testing/local-jazz-server.js";
+import { createNapiRuntime, loadNapiModule } from "./testing/napi-runtime-test-utils.js";
+
+type Todo = {
+  id: string;
+  title: string;
+  done: boolean;
+};
+
+type SyncRequestBody = {
+  client_id: string;
+  payload: unknown;
+};
+
+type SyncCaptureServerHandle = {
+  baseUrl: string;
+  syncRequests: Array<{
+    headers: IncomingMessage["headers"];
+    body: SyncRequestBody;
+  }>;
+  stop(): Promise<void>;
+};
+
+const TEST_SCHEMA: WasmSchema = {
+  todos: {
+    columns: [
+      { name: "title", column_type: { type: "Text" }, nullable: false },
+      { name: "done", column_type: { type: "Boolean" }, nullable: false },
+    ],
+  },
+};
+
+const allTodosQuery: QueryBuilder<Todo> = {
+  _table: "todos",
+  _schema: TEST_SCHEMA,
+  _rowType: undefined as unknown as Todo,
+  _build() {
+    return JSON.stringify({
+      table: "todos",
+      conditions: [],
+      includes: {},
+      orderBy: [],
+      offset: 0,
+    });
+  },
+};
+
+const BASIC_SCHEMA_DIR = fileURLToPath(new URL("../testing/fixtures/basic", import.meta.url));
+
+beforeAll(async () => {
+  await loadNapiModule();
+});
+
+function encodeFrames(events: unknown[]): Uint8Array {
+  const encoder = new TextEncoder();
+  const chunks = events.map((event) => {
+    const payload = encoder.encode(JSON.stringify(event));
+    const frame = new Uint8Array(4 + payload.length);
+    new DataView(frame.buffer).setUint32(0, payload.length, false);
+    frame.set(payload, 4);
+    return frame;
+  });
+
+  const totalLength = chunks.reduce((sum, chunk) => sum + chunk.length, 0);
+  const out = new Uint8Array(totalLength);
+  let offset = 0;
+  for (const chunk of chunks) {
+    out.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return out;
+}
+
+async function readRequestBody(request: IncomingMessage): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of request) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+async function getAvailablePort(): Promise<number> {
+  return await new Promise<number>((resolve, reject) => {
+    const server = createNetServer();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        server.close((error) => {
+          if (error) reject(error);
+          else reject(new Error("failed to allocate an available port"));
+        });
+        return;
+      }
+
+      server.close((error) => {
+        if (error) reject(error);
+        else resolve(address.port);
+      });
+    });
+  });
+}
+
+async function listen(server: HttpServer): Promise<number> {
+  return await new Promise<number>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        reject(new Error("failed to determine listening address"));
+        return;
+      }
+      resolve(address.port);
+    });
+  });
+}
+
+async function startSyncCaptureServer(): Promise<SyncCaptureServerHandle> {
+  const syncRequests: SyncCaptureServerHandle["syncRequests"] = [];
+  const openStreams = new Set<ServerResponse>();
+  const server = createHttpServer(async (request, response) => {
+    const url = new URL(request.url ?? "/", "http://127.0.0.1");
+
+    if (request.method === "GET" && url.pathname === "/events") {
+      openStreams.add(response);
+      response.once("close", () => {
+        openStreams.delete(response);
+      });
+      response.writeHead(200, { "Content-Type": "application/octet-stream" });
+      response.write(encodeFrames([{ type: "Connected", client_id: "server-client-1" }]));
+      return;
+    }
+
+    if (request.method === "POST" && url.pathname === "/sync") {
+      const rawBody = await readRequestBody(request);
+      syncRequests.push({
+        headers: request.headers,
+        body: JSON.parse(rawBody) as SyncRequestBody,
+      });
+      response.writeHead(200, { "Content-Type": "application/json" });
+      response.end("{}");
+      return;
+    }
+
+    if (request.method === "GET" && url.pathname === "/health") {
+      response.writeHead(200, { "Content-Type": "application/json" });
+      response.end(JSON.stringify({ status: "ok" }));
+      return;
+    }
+
+    response.writeHead(404);
+    response.end("not found");
+  });
+
+  const port = await listen(server);
+
+  return {
+    baseUrl: `http://127.0.0.1:${port}`,
+    syncRequests,
+    async stop() {
+      for (const stream of openStreams) {
+        stream.destroy();
+      }
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) reject(error);
+          else resolve();
+        });
+      });
+    },
+  };
+}
+
+async function waitForRows(
+  client: JazzClient,
+  predicate: (rows: Row[]) => boolean,
+  timeoutMs = 20_000,
+): Promise<Row[]> {
+  const deadline = Date.now() + timeoutMs;
+  let lastRows: Row[] = [];
+  let lastError: unknown = undefined;
+
+  while (Date.now() < deadline) {
+    try {
+      const rows = await client.query(allTodosQuery, { tier: "edge" });
+      if (predicate(rows)) return rows;
+      lastRows = rows;
+    } catch (error) {
+      lastError = error;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 150));
+  }
+
+  const lastErrorMessage =
+    lastError instanceof Error ? lastError.message : lastError ? String(lastError) : "none";
+  throw new Error(
+    `timed out waiting for rows; lastRows=${JSON.stringify(lastRows)}, lastError=${lastErrorMessage}`,
+  );
+}
+
+function isNestedOutboxCall(call: unknown[]): call is [null, [string, string, string, boolean]] {
+  return (
+    call[0] === null &&
+    Array.isArray(call[1]) &&
+    typeof call[1][0] === "string" &&
+    typeof call[1][1] === "string" &&
+    typeof call[1][2] === "string" &&
+    typeof call[1][3] === "boolean"
+  );
+}
+
+function isQuerySubscriptionPayload(payloadJson: string): boolean {
+  try {
+    const payload = JSON.parse(payloadJson) as Record<string, unknown>;
+    return "QuerySubscription" in payload;
+  } catch {
+    return false;
+  }
+}
+
+async function settleAsyncSyncWork(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 50));
+}
+
+describe("NAPI integration", () => {
+  it("emits the real nested onSyncMessageToSend callback shape from the compiled addon", async () => {
+    const runtime = await createNapiRuntime(TEST_SCHEMA, {
+      appId: `napi-contract-${randomUUID()}`,
+      tier: "worker",
+    });
+    const queryJson = translateQuery(allTodosQuery._build(), TEST_SCHEMA);
+    const rawCalls: unknown[][] = [];
+
+    runtime.addServer();
+    runtime.onSyncMessageToSend((...args: unknown[]) => {
+      rawCalls.push(args);
+    });
+
+    const handle = runtime.subscribe(queryJson, () => undefined, undefined, "edge", undefined);
+
+    await vi.waitFor(
+      () => {
+        expect(
+          rawCalls.some(
+            (call) => isNestedOutboxCall(call) && isQuerySubscriptionPayload(call[1][2]),
+          ),
+        ).toBe(true);
+      },
+      { timeout: 15_000 },
+    );
+
+    runtime.unsubscribe(handle);
+
+    expect(rawCalls.every((call) => isNestedOutboxCall(call))).toBe(true);
+
+    const querySubscriptionCall = rawCalls.find(
+      (call) => isNestedOutboxCall(call) && isQuerySubscriptionPayload(call[1][2]),
+    );
+
+    expect(querySubscriptionCall).toBeDefined();
+    expect(querySubscriptionCall?.[1]).toEqual([
+      "server",
+      expect.any(String),
+      expect.any(String),
+      false,
+    ]);
+  }, 20_000);
+
+  it("posts backend query subscriptions upstream via createJazzContext(...).asBackend()", async () => {
+    const captureServer = await startSyncCaptureServer();
+    let context: {
+      asBackend(): JazzClient;
+      shutdown(): Promise<void>;
+    } | null = null;
+
+    try {
+      const { createJazzContext } = await import("../backend/create-jazz-context.js");
+      context = createJazzContext({
+        appId: `napi-backend-sync-${randomUUID()}`,
+        app: { wasmSchema: TEST_SCHEMA },
+        driver: { type: "memory" },
+        serverUrl: captureServer.baseUrl,
+        backendSecret: "napi-backend-secret",
+      });
+
+      const client = context.asBackend();
+      const subscriptionId = client.subscribe(allTodosQuery, () => undefined, { tier: "edge" });
+
+      await vi.waitFor(() => expect(captureServer.syncRequests).toHaveLength(1), {
+        timeout: 15_000,
+      });
+
+      client.unsubscribe(subscriptionId);
+
+      const request = captureServer.syncRequests[0];
+      expect(request.headers["x-jazz-backend-secret"]).toBe("napi-backend-secret");
+      expect(request.headers.authorization).toBeUndefined();
+      expect(request.headers["x-jazz-local-mode"]).toBeUndefined();
+      expect(request.headers["x-jazz-local-token"]).toBeUndefined();
+      expect(request.body.client_id).toBe("server-client-1");
+      expect(request.body.payload).toHaveProperty("QuerySubscription");
+    } finally {
+      if (context) {
+        await context.shutdown();
+      }
+      await settleAsyncSyncWork();
+      await captureServer.stop();
+    }
+  }, 20_000);
+
+  it("syncs edge create/update/delete flows between real backend NAPI contexts", async () => {
+    const port = await getAvailablePort();
+    const appId = randomUUID();
+    const backendSecret = "napi-e2e-backend-secret";
+    const adminSecret = "napi-e2e-admin-secret";
+    const server = await startLocalJazzServer({
+      appId,
+      port,
+      backendSecret,
+      adminSecret,
+    });
+    let writerContext: {
+      asBackend(): JazzClient;
+      shutdown(): Promise<void>;
+    } | null = null;
+    let readerContext: {
+      asBackend(): JazzClient;
+      shutdown(): Promise<void>;
+    } | null = null;
+
+    try {
+      const { createJazzContext } = await import("../backend/create-jazz-context.js");
+
+      await pushSchemaCatalogue({
+        serverUrl: server.url,
+        appId,
+        adminSecret,
+        schemaDir: BASIC_SCHEMA_DIR,
+      });
+
+      writerContext = createJazzContext({
+        appId,
+        app: { wasmSchema: TEST_SCHEMA },
+        driver: { type: "memory" },
+        serverUrl: server.url,
+        backendSecret,
+      });
+      readerContext = createJazzContext({
+        appId,
+        app: { wasmSchema: TEST_SCHEMA },
+        driver: { type: "memory" },
+        serverUrl: server.url,
+        backendSecret,
+      });
+
+      const writer = writerContext.asBackend();
+      const reader = readerContext.asBackend();
+
+      await waitForRows(reader, (rows) => rows.length === 0);
+
+      const rowId = await writer.create(
+        "todos",
+        [
+          { type: "Text", value: "napi-shared-item" },
+          { type: "Boolean", value: false },
+        ],
+        { tier: "edge" },
+      );
+
+      const rowsAfterCreate = await waitForRows(reader, (rows) =>
+        rows.some((row) => row.id === rowId),
+      );
+      const createdRow = rowsAfterCreate.find((row) => row.id === rowId);
+      expect(createdRow?.values[0]).toEqual({ type: "Text", value: "napi-shared-item" });
+      expect(createdRow?.values[1]).toEqual({ type: "Boolean", value: false });
+
+      await writer.update(rowId, { done: { type: "Boolean", value: true } }, { tier: "edge" });
+
+      const rowsAfterUpdate = await waitForRows(reader, (rows) => {
+        const row = rows.find((entry) => entry.id === rowId);
+        return Boolean(row?.values[1]?.type === "Boolean" && row.values[1].value === true);
+      });
+      const updatedRow = rowsAfterUpdate.find((row) => row.id === rowId);
+      expect(updatedRow?.values[1]).toEqual({ type: "Boolean", value: true });
+
+      await writer.delete(rowId, { tier: "edge" });
+      await waitForRows(reader, (rows) => !rows.some((row) => row.id === rowId));
+    } finally {
+      if (writerContext) {
+        await writerContext.shutdown();
+      }
+      if (readerContext) {
+        await readerContext.shutdown();
+      }
+      await settleAsyncSyncWork();
+      await server.stop();
+    }
+  }, 60_000);
+});

--- a/packages/jazz-tools/src/runtime/napi.integration.test.ts
+++ b/packages/jazz-tools/src/runtime/napi.integration.test.ts
@@ -29,6 +29,13 @@ type SyncRequestBody = {
   payload: unknown;
 };
 
+type ObjectMutationRequest = {
+  method: string;
+  pathname: string;
+  headers: IncomingMessage["headers"];
+  body: Record<string, unknown>;
+};
+
 type SyncCaptureServerHandle = {
   baseUrl: string;
   eventClientIds: string[];
@@ -36,6 +43,7 @@ type SyncCaptureServerHandle = {
     headers: IncomingMessage["headers"];
     body: SyncRequestBody;
   }>;
+  objectRequests: ObjectMutationRequest[];
   closeLatestStream(): void;
   stop(): Promise<void>;
 };
@@ -136,6 +144,7 @@ async function listen(server: HttpServer): Promise<number> {
 
 async function startSyncCaptureServer(): Promise<SyncCaptureServerHandle> {
   const syncRequests: SyncCaptureServerHandle["syncRequests"] = [];
+  const objectRequests: SyncCaptureServerHandle["objectRequests"] = [];
   const eventClientIds: string[] = [];
   const openStreams = new Set<ServerResponse>();
   const server = createHttpServer(async (request, response) => {
@@ -164,6 +173,29 @@ async function startSyncCaptureServer(): Promise<SyncCaptureServerHandle> {
       return;
     }
 
+    if (
+      (request.method === "POST" || request.method === "PUT") &&
+      (url.pathname === "/sync/object" || url.pathname === "/sync/object/delete")
+    ) {
+      const rawBody = await readRequestBody(request);
+      objectRequests.push({
+        method: request.method,
+        pathname: url.pathname,
+        headers: request.headers,
+        body: JSON.parse(rawBody) as Record<string, unknown>,
+      });
+
+      response.writeHead(200, { "Content-Type": "application/json" });
+      response.end(
+        JSON.stringify(
+          request.method === "POST" && url.pathname === "/sync/object"
+            ? { object_id: `captured-object-${objectRequests.length}` }
+            : {},
+        ),
+      );
+      return;
+    }
+
     if (request.method === "GET" && url.pathname === "/health") {
       response.writeHead(200, { "Content-Type": "application/json" });
       response.end(JSON.stringify({ status: "ok" }));
@@ -180,6 +212,7 @@ async function startSyncCaptureServer(): Promise<SyncCaptureServerHandle> {
     baseUrl: `http://127.0.0.1:${port}`,
     eventClientIds,
     syncRequests,
+    objectRequests,
     closeLatestStream() {
       const latest = Array.from(openStreams).at(-1);
       latest?.destroy();
@@ -247,6 +280,15 @@ function isQuerySubscriptionPayload(payloadJson: string): boolean {
   }
 }
 
+function hasPayloadKind(payloadJson: string, payloadKind: string): boolean {
+  try {
+    const payload = JSON.parse(payloadJson) as Record<string, unknown>;
+    return payloadKind in payload;
+  } catch {
+    return false;
+  }
+}
+
 function isQuerySubscriptionRequest(request: { body: SyncRequestBody }): boolean {
   return (
     typeof request.body.payload === "object" &&
@@ -257,6 +299,34 @@ function isQuerySubscriptionRequest(request: { body: SyncRequestBody }): boolean
 
 async function settleAsyncSyncWork(): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, 50));
+}
+
+function decodeSessionHeader(headerValue: string | string[] | undefined): Record<string, unknown> {
+  const encoded = Array.isArray(headerValue) ? headerValue[0] : headerValue;
+  if (!encoded) {
+    throw new Error("expected X-Jazz-Session header to be present");
+  }
+  return JSON.parse(Buffer.from(encoded, "base64").toString("utf8")) as Record<string, unknown>;
+}
+
+function toBase64Url(value: unknown): string {
+  const encoded = Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+  return encoded.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+}
+
+function makeJwt(payload: Record<string, unknown>): string {
+  return `${toBase64Url({ alg: "HS256", typ: "JWT" })}.${toBase64Url(payload)}.signature`;
+}
+
+function buildClientQuerySubscriptionPayload(queryJson: string, queryId = 1): string {
+  return JSON.stringify({
+    QuerySubscription: {
+      query_id: queryId,
+      query: JSON.parse(queryJson) as Record<string, unknown>,
+      session: null,
+      propagation: "full",
+    },
+  });
 }
 
 async function createTempDir(prefix: string): Promise<string> {
@@ -305,6 +375,64 @@ describe("NAPI integration", () => {
       expect.any(String),
       false,
     ]);
+  }, 20_000);
+
+  it("routes client-originated subscriptions back through the real nested client callback shape", async () => {
+    const runtime = await createNapiRuntime(TEST_SCHEMA, {
+      appId: `napi-client-contract-${randomUUID()}`,
+      tier: "edge",
+    });
+    const queryJson = translateQuery(allTodosQuery._build(), TEST_SCHEMA);
+    const rawCalls: unknown[][] = [];
+
+    runtime.onSyncMessageToSend((...args: unknown[]) => {
+      rawCalls.push(args);
+    });
+
+    const clientId = runtime.addClient();
+    runtime.setClientRole?.(clientId, "peer");
+    runtime.onSyncMessageReceivedFromClient?.(
+      clientId,
+      buildClientQuerySubscriptionPayload(queryJson),
+    );
+
+    await vi.waitFor(
+      () => {
+        expect(
+          rawCalls.some(
+            (call) =>
+              isNestedOutboxCall(call) &&
+              call[1][0] === "client" &&
+              call[1][1] === clientId &&
+              hasPayloadKind(call[1][2], "QuerySettled"),
+          ),
+        ).toBe(true);
+      },
+      { timeout: 15_000 },
+    );
+
+    const objectId = runtime.insert("todos", [
+      { type: "Text", value: "client-synced-item" },
+      { type: "Boolean", value: false },
+    ]);
+
+    await vi.waitFor(
+      () => {
+        expect(
+          rawCalls.some(
+            (call) =>
+              isNestedOutboxCall(call) &&
+              call[1][0] === "client" &&
+              call[1][1] === clientId &&
+              hasPayloadKind(call[1][2], "ObjectUpdated"),
+          ),
+        ).toBe(true);
+      },
+      { timeout: 15_000 },
+    );
+
+    expect(rawCalls.every((call) => isNestedOutboxCall(call))).toBe(true);
+    expect(objectId).toEqual(expect.any(String));
   }, 20_000);
 
   it("posts backend query subscriptions upstream via createJazzContext(...).asBackend()", async () => {
@@ -410,6 +538,175 @@ describe("NAPI integration", () => {
       await captureServer.stop();
     }
   }, 25_000);
+
+  it("sends backend impersonation headers for createJazzContext(...).forSession() mutations", async () => {
+    const captureServer = await startSyncCaptureServer();
+    let context: {
+      forSession(session: { user_id: string; claims: Record<string, unknown> }): {
+        create(table: string, values: Array<Record<string, unknown>>): Promise<string>;
+        update(objectId: string, updates: Record<string, unknown>): Promise<void>;
+        delete(objectId: string): Promise<void>;
+      };
+      shutdown(): Promise<void>;
+    } | null = null;
+
+    try {
+      const { createJazzContext } = await import("../backend/create-jazz-context.js");
+      context = createJazzContext({
+        appId: `napi-session-headers-${randomUUID()}`,
+        app: { wasmSchema: TEST_SCHEMA },
+        driver: { type: "memory" },
+        serverUrl: captureServer.baseUrl,
+        backendSecret: "napi-session-secret",
+      });
+
+      const session = {
+        user_id: "session-user",
+        claims: { role: "editor", team: "alpha" },
+      };
+      const scopedClient = context.forSession(session);
+      const createdObjectId = await scopedClient.create("todos", [
+        { type: "Text", value: "session-created-item" },
+        { type: "Boolean", value: false },
+      ]);
+
+      await scopedClient.update(createdObjectId, {
+        done: { type: "Boolean", value: true },
+      });
+      await scopedClient.delete(createdObjectId);
+
+      await vi.waitFor(() => expect(captureServer.objectRequests).toHaveLength(3), {
+        timeout: 15_000,
+      });
+
+      for (const request of captureServer.objectRequests) {
+        expect(request.headers["x-jazz-backend-secret"]).toBe("napi-session-secret");
+        expect(decodeSessionHeader(request.headers["x-jazz-session"])).toEqual(session);
+        expect(request.headers.authorization).toBeUndefined();
+        expect(request.headers["x-jazz-local-mode"]).toBeUndefined();
+        expect(request.headers["x-jazz-local-token"]).toBeUndefined();
+      }
+
+      expect(captureServer.objectRequests[0]).toMatchObject({
+        method: "POST",
+        pathname: "/sync/object",
+        body: {
+          table: "todos",
+          values: [
+            { type: "Text", value: "session-created-item" },
+            { type: "Boolean", value: false },
+          ],
+          schema_context: {
+            env: "dev",
+            user_branch: "main",
+            schema_hash: expect.any(String),
+          },
+        },
+      });
+      expect(captureServer.objectRequests[1]).toMatchObject({
+        method: "PUT",
+        pathname: "/sync/object",
+        body: {
+          object_id: createdObjectId,
+          updates: [["done", { type: "Boolean", value: true }]],
+          schema_context: {
+            env: "dev",
+            user_branch: "main",
+            schema_hash: expect.any(String),
+          },
+        },
+      });
+      expect(captureServer.objectRequests[2]).toMatchObject({
+        method: "POST",
+        pathname: "/sync/object/delete",
+        body: {
+          object_id: createdObjectId,
+          schema_context: {
+            env: "dev",
+            user_branch: "main",
+            schema_hash: expect.any(String),
+          },
+        },
+      });
+    } finally {
+      if (context) {
+        await context.shutdown();
+      }
+      await settleAsyncSyncWork();
+      await captureServer.stop();
+    }
+  }, 20_000);
+
+  it("extracts JWT request auth and still sends backend impersonation headers for createJazzContext(...).forRequest()", async () => {
+    const captureServer = await startSyncCaptureServer();
+    let context: {
+      forRequest(request: { headers: Record<string, string> }): {
+        create(table: string, values: Array<Record<string, unknown>>): Promise<string>;
+      };
+      shutdown(): Promise<void>;
+    } | null = null;
+
+    try {
+      const { createJazzContext } = await import("../backend/create-jazz-context.js");
+      context = createJazzContext({
+        appId: `napi-request-headers-${randomUUID()}`,
+        app: { wasmSchema: TEST_SCHEMA },
+        driver: { type: "memory" },
+        serverUrl: captureServer.baseUrl,
+        backendSecret: "napi-request-secret",
+      });
+
+      const jwt = makeJwt({
+        sub: "request-user",
+        claims: { role: "reviewer", tenant: "beta" },
+      });
+      const scopedClient = context.forRequest({
+        headers: {
+          authorization: `Bearer ${jwt}`,
+        },
+      });
+
+      const createdObjectId = await scopedClient.create("todos", [
+        { type: "Text", value: "request-created-item" },
+        { type: "Boolean", value: false },
+      ]);
+
+      await vi.waitFor(() => expect(captureServer.objectRequests).toHaveLength(1), {
+        timeout: 15_000,
+      });
+
+      expect(createdObjectId).toBe("captured-object-1");
+      expect(captureServer.objectRequests[0]).toMatchObject({
+        method: "POST",
+        pathname: "/sync/object",
+        body: {
+          table: "todos",
+          values: [
+            { type: "Text", value: "request-created-item" },
+            { type: "Boolean", value: false },
+          ],
+        },
+      });
+      expect(captureServer.objectRequests[0]?.headers["x-jazz-backend-secret"]).toBe(
+        "napi-request-secret",
+      );
+      expect(
+        decodeSessionHeader(captureServer.objectRequests[0]?.headers["x-jazz-session"]),
+      ).toEqual({
+        user_id: "request-user",
+        claims: { role: "reviewer", tenant: "beta" },
+      });
+      expect(captureServer.objectRequests[0]?.headers.authorization).toBeUndefined();
+      expect(captureServer.objectRequests[0]?.headers["x-jazz-local-mode"]).toBeUndefined();
+      expect(captureServer.objectRequests[0]?.headers["x-jazz-local-token"]).toBeUndefined();
+    } finally {
+      if (context) {
+        await context.shutdown();
+      }
+      await settleAsyncSyncWork();
+      await captureServer.stop();
+    }
+  }, 20_000);
 
   it("syncs edge create/update/delete flows between real backend NAPI contexts", async () => {
     const port = await getAvailablePort();

--- a/packages/jazz-tools/src/runtime/napi.integration.test.ts
+++ b/packages/jazz-tools/src/runtime/napi.integration.test.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import { createHmac, randomUUID } from "node:crypto";
 import { mkdtemp, rm } from "node:fs/promises";
 import {
   createServer as createHttpServer,
@@ -17,6 +17,7 @@ import type { QueryBuilder } from "./db.js";
 import { translateQuery } from "./query-adapter.js";
 import { pushSchemaCatalogue, startLocalJazzServer } from "../testing/local-jazz-server.js";
 import { createNapiRuntime, loadNapiModule } from "./testing/napi-runtime-test-utils.js";
+import { wasmSchema as TODO_SERVER_WASM_SCHEMA } from "../../../../examples/todo-server-ts/schema/app.ts";
 
 type Todo = {
   id: string;
@@ -48,6 +49,9 @@ type SyncCaptureServerHandle = {
   stop(): Promise<void>;
 };
 
+const JWT_KID = "napi-test-kid";
+const JWT_SECRET = "napi-test-secret";
+
 const TEST_SCHEMA: WasmSchema = {
   todos: {
     columns: [
@@ -73,6 +77,9 @@ const allTodosQuery: QueryBuilder<Todo> = {
 };
 
 const BASIC_SCHEMA_DIR = fileURLToPath(new URL("../testing/fixtures/basic", import.meta.url));
+const TODO_SERVER_SCHEMA_DIR = fileURLToPath(
+  new URL("../../../../examples/todo-server-ts/schema", import.meta.url),
+);
 
 beforeAll(async () => {
   await loadNapiModule();
@@ -260,6 +267,78 @@ async function waitForRows(
   );
 }
 
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, label: string): Promise<T> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_, reject) => {
+        timeoutId = setTimeout(() => {
+          reject(new Error(`${label} after ${timeoutMs}ms`));
+        }, timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+  }
+}
+
+function base64Url(input: Buffer | string): string {
+  const encoded = (input instanceof Buffer ? input : Buffer.from(input)).toString("base64");
+  return encoded.replace(/=/g, "").replace(/\+/g, "-").replace(/\//g, "_");
+}
+
+class JwksServer {
+  private readonly server: HttpServer;
+  readonly url: string;
+
+  private constructor(server: HttpServer, url: string) {
+    this.server = server;
+    this.url = url;
+  }
+
+  static async start(secret: string): Promise<JwksServer> {
+    const server = createHttpServer((request, response) => {
+      if (request.url !== "/jwks") {
+        response.statusCode = 404;
+        response.end("not found");
+        return;
+      }
+
+      response.statusCode = 200;
+      response.setHeader("Content-Type", "application/json");
+      response.end(
+        JSON.stringify({
+          keys: [
+            {
+              kty: "oct",
+              kid: JWT_KID,
+              alg: "HS256",
+              k: base64Url(secret),
+            },
+          ],
+        }),
+      );
+    });
+
+    const port = await getAvailablePort();
+    await new Promise<void>((resolve, reject) => {
+      server.listen(port, "127.0.0.1", (error?: unknown) => {
+        if (error) reject(error);
+        else resolve();
+      });
+    });
+
+    return new JwksServer(server, `http://127.0.0.1:${port}/jwks`);
+  }
+
+  async stop(): Promise<void> {
+    await new Promise<void>((resolve) => this.server.close(() => resolve()));
+  }
+}
+
 function isNestedOutboxCall(call: unknown[]): call is [null, [string, string, string, boolean]] {
   return (
     call[0] === null &&
@@ -310,12 +389,18 @@ function decodeSessionHeader(headerValue: string | string[] | undefined): Record
 }
 
 function toBase64Url(value: unknown): string {
-  const encoded = Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-  return encoded.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+  return base64Url(Buffer.from(JSON.stringify(value), "utf8"));
 }
 
 function makeJwt(payload: Record<string, unknown>): string {
   return `${toBase64Url({ alg: "HS256", typ: "JWT" })}.${toBase64Url(payload)}.signature`;
+}
+
+function signJwt(payload: Record<string, unknown>, secret: string): string {
+  const header = { alg: "HS256", typ: "JWT", kid: JWT_KID };
+  const signedPart = `${toBase64Url(header)}.${toBase64Url(payload)}`;
+  const signature = createHmac("sha256", secret).update(signedPart).digest();
+  return `${signedPart}.${base64Url(signature)}`;
 }
 
 function buildClientQuerySubscriptionPayload(queryJson: string, queryId = 1): string {
@@ -707,6 +792,243 @@ describe("NAPI integration", () => {
       await captureServer.stop();
     }
   }, 20_000);
+
+  it("filters session-scoped query reads over backend-authenticated sync", async () => {
+    const port = await getAvailablePort();
+    const appId = randomUUID();
+    const backendSecret = "napi-query-backend-secret";
+    const adminSecret = "napi-query-admin-secret";
+    const queryAllTodos = translateQuery(
+      JSON.stringify({
+        table: "todos",
+        conditions: [],
+        includes: {},
+        orderBy: [],
+        offset: 0,
+      }),
+      TODO_SERVER_WASM_SCHEMA,
+    );
+    const rowTitles = (rows: Row[]): string[] =>
+      rows
+        .map((row) => {
+          const title = row.values[0];
+          if (title?.type !== "Text") {
+            throw new Error(`expected text title at column 0, got ${JSON.stringify(title)}`);
+          }
+          return title.value;
+        })
+        .sort();
+
+    const jwks = await JwksServer.start(JWT_SECRET);
+    const server = await startLocalJazzServer({
+      appId,
+      port,
+      jwksUrl: jwks.url,
+      backendSecret,
+      adminSecret,
+    });
+    let bobContext: {
+      client(): JazzClient;
+      shutdown(): Promise<void>;
+    } | null = null;
+    let carolContext: {
+      client(): JazzClient;
+      shutdown(): Promise<void>;
+    } | null = null;
+    let aliceContext: {
+      client(): JazzClient;
+      shutdown(): Promise<void>;
+    } | null = null;
+    let readerContext: {
+      asBackend(): JazzClient;
+      forSession(session: { user_id: string; claims: Record<string, unknown> }): {
+        query(query: string, options?: { tier?: "worker" | "edge" | "global" }): Promise<Row[]>;
+      };
+      forRequest(request: { headers: Record<string, string> }): {
+        query(query: string, options?: { tier?: "worker" | "edge" | "global" }): Promise<Row[]>;
+      };
+      shutdown(): Promise<void>;
+    } | null = null;
+
+    try {
+      const { createJazzContext } = await import("../backend/create-jazz-context.js");
+
+      await pushSchemaCatalogue({
+        serverUrl: server.url,
+        appId,
+        adminSecret,
+        schemaDir: TODO_SERVER_SCHEMA_DIR,
+        env: "test",
+        userBranch: "main",
+      });
+
+      bobContext = createJazzContext({
+        appId,
+        app: { wasmSchema: TODO_SERVER_WASM_SCHEMA },
+        driver: { type: "memory" },
+        serverUrl: server.url,
+        jwtToken: signJwt({ sub: "bob", claims: {} }, JWT_SECRET),
+        env: "test",
+        userBranch: "main",
+        tier: "worker",
+      });
+      carolContext = createJazzContext({
+        appId,
+        app: { wasmSchema: TODO_SERVER_WASM_SCHEMA },
+        driver: { type: "memory" },
+        serverUrl: server.url,
+        jwtToken: signJwt({ sub: "carol", claims: {} }, JWT_SECRET),
+        env: "test",
+        userBranch: "main",
+        tier: "worker",
+      });
+      aliceContext = createJazzContext({
+        appId,
+        app: { wasmSchema: TODO_SERVER_WASM_SCHEMA },
+        driver: { type: "memory" },
+        serverUrl: server.url,
+        jwtToken: signJwt({ sub: "alice", claims: {} }, JWT_SECRET),
+        env: "test",
+        userBranch: "main",
+        tier: "worker",
+      });
+      readerContext = createJazzContext({
+        appId,
+        app: { wasmSchema: TODO_SERVER_WASM_SCHEMA },
+        driver: { type: "memory" },
+        serverUrl: server.url,
+        backendSecret,
+        env: "test",
+        userBranch: "main",
+        tier: "worker",
+      });
+
+      const bobWriter = bobContext.client();
+      const carolWriter = carolContext.client();
+      const aliceWriter = aliceContext.client();
+
+      await withTimeout(
+        bobWriter.create(
+          "todos",
+          [
+            { type: "Text", value: "bob-item" },
+            { type: "Boolean", value: false },
+            { type: "Text", value: "" },
+            { type: "Null" },
+            { type: "Null" },
+            { type: "Text", value: "bob" },
+          ],
+          { tier: "edge" },
+        ),
+        10_000,
+        "bob writer create timed out",
+      );
+      await withTimeout(
+        carolWriter.create(
+          "todos",
+          [
+            { type: "Text", value: "carol-item" },
+            { type: "Boolean", value: false },
+            { type: "Text", value: "" },
+            { type: "Null" },
+            { type: "Null" },
+            { type: "Text", value: "carol" },
+          ],
+          { tier: "edge" },
+        ),
+        10_000,
+        "carol writer create timed out",
+      );
+      await withTimeout(
+        aliceWriter.create(
+          "todos",
+          [
+            { type: "Text", value: "alice-item" },
+            { type: "Boolean", value: false },
+            { type: "Text", value: "" },
+            { type: "Null" },
+            { type: "Null" },
+            { type: "Text", value: "alice" },
+          ],
+          { tier: "edge" },
+        ),
+        10_000,
+        "alice writer create timed out",
+      );
+
+      const readerBackend = readerContext.asBackend();
+      const aliceSessionClient = readerContext.forSession({
+        user_id: "alice",
+        claims: {},
+      });
+      const aliceRequestClient = readerContext.forRequest({
+        headers: {
+          authorization: `Bearer ${makeJwt({ sub: "alice" })}`,
+        },
+      });
+
+      await vi.waitFor(
+        async () => {
+          expect(
+            rowTitles(
+              await withTimeout(
+                readerBackend.queryInternal(queryAllTodos, undefined, { tier: "edge" }),
+                10_000,
+                "backend reader query timed out",
+              ),
+            ),
+          ).toEqual(["alice-item", "bob-item", "carol-item"]);
+        },
+        { timeout: 20_000 },
+      );
+
+      await vi.waitFor(
+        async () => {
+          expect(
+            rowTitles(
+              await withTimeout(
+                aliceSessionClient.query(queryAllTodos, { tier: "edge" }),
+                10_000,
+                "alice session query timed out",
+              ),
+            ),
+          ).toEqual(["alice-item"]);
+        },
+        { timeout: 20_000 },
+      );
+
+      await vi.waitFor(
+        async () => {
+          expect(
+            rowTitles(
+              await withTimeout(
+                aliceRequestClient.query(queryAllTodos, { tier: "edge" }),
+                10_000,
+                "alice request query timed out",
+              ),
+            ),
+          ).toEqual(["alice-item"]);
+        },
+        { timeout: 20_000 },
+      );
+    } finally {
+      if (bobContext) {
+        await bobContext.shutdown();
+      }
+      if (carolContext) {
+        await carolContext.shutdown();
+      }
+      if (aliceContext) {
+        await aliceContext.shutdown();
+      }
+      if (readerContext) {
+        await readerContext.shutdown();
+      }
+      await settleAsyncSyncWork();
+      await server.stop();
+      await jwks.stop();
+    }
+  }, 60_000);
 
   it("syncs edge create/update/delete flows between real backend NAPI contexts", async () => {
     const port = await getAvailablePort();

--- a/packages/jazz-tools/src/runtime/napi.integration.test.ts
+++ b/packages/jazz-tools/src/runtime/napi.integration.test.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { mkdtemp, rm } from "node:fs/promises";
 import {
   createServer as createHttpServer,
   type IncomingMessage,
@@ -6,6 +7,8 @@ import {
   type ServerResponse,
 } from "node:http";
 import { createServer as createNetServer } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 import type { WasmSchema } from "../drivers/types.js";
@@ -28,10 +31,12 @@ type SyncRequestBody = {
 
 type SyncCaptureServerHandle = {
   baseUrl: string;
+  eventClientIds: string[];
   syncRequests: Array<{
     headers: IncomingMessage["headers"];
     body: SyncRequestBody;
   }>;
+  closeLatestStream(): void;
   stop(): Promise<void>;
 };
 
@@ -131,17 +136,20 @@ async function listen(server: HttpServer): Promise<number> {
 
 async function startSyncCaptureServer(): Promise<SyncCaptureServerHandle> {
   const syncRequests: SyncCaptureServerHandle["syncRequests"] = [];
+  const eventClientIds: string[] = [];
   const openStreams = new Set<ServerResponse>();
   const server = createHttpServer(async (request, response) => {
     const url = new URL(request.url ?? "/", "http://127.0.0.1");
 
     if (request.method === "GET" && url.pathname === "/events") {
+      const clientId = `server-client-${eventClientIds.length + 1}`;
+      eventClientIds.push(clientId);
       openStreams.add(response);
       response.once("close", () => {
         openStreams.delete(response);
       });
       response.writeHead(200, { "Content-Type": "application/octet-stream" });
-      response.write(encodeFrames([{ type: "Connected", client_id: "server-client-1" }]));
+      response.write(encodeFrames([{ type: "Connected", client_id: clientId }]));
       return;
     }
 
@@ -170,7 +178,12 @@ async function startSyncCaptureServer(): Promise<SyncCaptureServerHandle> {
 
   return {
     baseUrl: `http://127.0.0.1:${port}`,
+    eventClientIds,
     syncRequests,
+    closeLatestStream() {
+      const latest = Array.from(openStreams).at(-1);
+      latest?.destroy();
+    },
     async stop() {
       for (const stream of openStreams) {
         stream.destroy();
@@ -189,6 +202,7 @@ async function waitForRows(
   client: JazzClient,
   predicate: (rows: Row[]) => boolean,
   timeoutMs = 20_000,
+  queryOptions: { tier?: "worker" | "edge" | "global" } = { tier: "edge" },
 ): Promise<Row[]> {
   const deadline = Date.now() + timeoutMs;
   let lastRows: Row[] = [];
@@ -196,7 +210,7 @@ async function waitForRows(
 
   while (Date.now() < deadline) {
     try {
-      const rows = await client.query(allTodosQuery, { tier: "edge" });
+      const rows = await client.query(allTodosQuery, queryOptions);
       if (predicate(rows)) return rows;
       lastRows = rows;
     } catch (error) {
@@ -233,8 +247,20 @@ function isQuerySubscriptionPayload(payloadJson: string): boolean {
   }
 }
 
+function isQuerySubscriptionRequest(request: { body: SyncRequestBody }): boolean {
+  return (
+    typeof request.body.payload === "object" &&
+    request.body.payload !== null &&
+    "QuerySubscription" in (request.body.payload as Record<string, unknown>)
+  );
+}
+
 async function settleAsyncSyncWork(): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, 50));
+}
+
+async function createTempDir(prefix: string): Promise<string> {
+  return await mkdtemp(join(tmpdir(), prefix));
 }
 
 describe("NAPI integration", () => {
@@ -301,13 +327,19 @@ describe("NAPI integration", () => {
       const client = context.asBackend();
       const subscriptionId = client.subscribe(allTodosQuery, () => undefined, { tier: "edge" });
 
-      await vi.waitFor(() => expect(captureServer.syncRequests).toHaveLength(1), {
-        timeout: 15_000,
-      });
+      await vi.waitFor(
+        () => expect(captureServer.syncRequests.filter(isQuerySubscriptionRequest)).toHaveLength(1),
+        {
+          timeout: 15_000,
+        },
+      );
 
       client.unsubscribe(subscriptionId);
 
-      const request = captureServer.syncRequests[0];
+      const request = captureServer.syncRequests.find(isQuerySubscriptionRequest);
+      if (!request) {
+        throw new Error("expected a QuerySubscription sync request");
+      }
       expect(request.headers["x-jazz-backend-secret"]).toBe("napi-backend-secret");
       expect(request.headers.authorization).toBeUndefined();
       expect(request.headers["x-jazz-local-mode"]).toBeUndefined();
@@ -322,6 +354,62 @@ describe("NAPI integration", () => {
       await captureServer.stop();
     }
   }, 20_000);
+
+  it("replays active backend query subscriptions after the events stream reconnects", async () => {
+    const captureServer = await startSyncCaptureServer();
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    let context: {
+      asBackend(): JazzClient;
+      shutdown(): Promise<void>;
+    } | null = null;
+
+    try {
+      const { createJazzContext } = await import("../backend/create-jazz-context.js");
+      context = createJazzContext({
+        appId: `napi-backend-reconnect-${randomUUID()}`,
+        app: { wasmSchema: TEST_SCHEMA },
+        driver: { type: "memory" },
+        serverUrl: captureServer.baseUrl,
+        backendSecret: "napi-backend-secret",
+      });
+
+      const client = context.asBackend();
+      const subscriptionId = client.subscribe(allTodosQuery, () => undefined, { tier: "edge" });
+
+      await vi.waitFor(
+        () => expect(captureServer.syncRequests.filter(isQuerySubscriptionRequest)).toHaveLength(1),
+        {
+          timeout: 15_000,
+        },
+      );
+      expect(captureServer.eventClientIds).toEqual(["server-client-1"]);
+
+      captureServer.closeLatestStream();
+
+      await vi.waitFor(() => expect(captureServer.eventClientIds).toHaveLength(2), {
+        timeout: 15_000,
+      });
+      await vi.waitFor(
+        () => expect(captureServer.syncRequests.filter(isQuerySubscriptionRequest)).toHaveLength(2),
+        {
+          timeout: 15_000,
+        },
+      );
+
+      client.unsubscribe(subscriptionId);
+
+      const querySubscriptions = captureServer.syncRequests.filter(isQuerySubscriptionRequest);
+      expect(querySubscriptions[1]?.body.client_id).toBe("server-client-2");
+      expect(querySubscriptions[1]?.headers["x-jazz-backend-secret"]).toBe("napi-backend-secret");
+    } finally {
+      consoleError.mockRestore();
+      if (context) {
+        await context.shutdown();
+      }
+      await settleAsyncSyncWork();
+      await captureServer.stop();
+    }
+  }, 25_000);
 
   it("syncs edge create/update/delete flows between real backend NAPI contexts", async () => {
     const port = await getAvailablePort();
@@ -411,4 +499,72 @@ describe("NAPI integration", () => {
       await server.stop();
     }
   }, 60_000);
+
+  it("reopens persistent backend runtimes cleanly and retains local data", async () => {
+    const dataRoot = await createTempDir("jazz-napi-persistent-");
+    const dataPath = join(dataRoot, "runtime.skv");
+    const appId = randomUUID();
+    let writerContext: {
+      client(): JazzClient;
+      shutdown(): Promise<void>;
+    } | null = null;
+    let reopenedContext: {
+      client(): JazzClient;
+      shutdown(): Promise<void>;
+    } | null = null;
+
+    try {
+      const { createJazzContext } = await import("../backend/create-jazz-context.js");
+
+      writerContext = createJazzContext({
+        appId,
+        app: { wasmSchema: TEST_SCHEMA },
+        driver: { type: "persistent", dataPath },
+      });
+
+      const writer = writerContext.client();
+      const rowId = await writer.create(
+        "todos",
+        [
+          { type: "Text", value: "persisted-local-item" },
+          { type: "Boolean", value: false },
+        ],
+        { tier: "worker" },
+      );
+
+      await waitForRows(writer, (rows) => rows.some((row) => row.id === rowId), 10_000, {
+        tier: "worker",
+      });
+
+      await writerContext.shutdown();
+      writerContext = null;
+      await settleAsyncSyncWork();
+
+      reopenedContext = createJazzContext({
+        appId,
+        app: { wasmSchema: TEST_SCHEMA },
+        driver: { type: "persistent", dataPath },
+      });
+
+      const reopened = reopenedContext.client();
+      const reopenedRows = await waitForRows(
+        reopened,
+        (rows) => rows.some((row) => row.id === rowId),
+        10_000,
+        { tier: "worker" },
+      );
+
+      const reopenedRow = reopenedRows.find((row) => row.id === rowId);
+      expect(reopenedRow?.values[0]).toEqual({ type: "Text", value: "persisted-local-item" });
+      expect(reopenedRow?.values[1]).toEqual({ type: "Boolean", value: false });
+    } finally {
+      if (writerContext) {
+        await writerContext.shutdown();
+      }
+      if (reopenedContext) {
+        await reopenedContext.shutdown();
+      }
+      await rm(dataRoot, { recursive: true, force: true });
+    }
+  }, 30_000);
 });

--- a/packages/jazz-tools/src/runtime/sync-transport.test.ts
+++ b/packages/jazz-tools/src/runtime/sync-transport.test.ts
@@ -49,6 +49,16 @@ describe("sync-transport", () => {
         isCatalogue: boolean,
       ) => router(null, destinationKind, destinationId, payloadJson, isCatalogue),
     ],
+    [
+      "napi-nested",
+      (
+        router: RuntimeSyncOutboxCallback,
+        destinationKind: "server" | "client",
+        destinationId: string,
+        payloadJson: string,
+        isCatalogue: boolean,
+      ) => router(null, [destinationKind, destinationId, payloadJson, isCatalogue]),
+    ],
   ];
 
   function encodeFrames(events: unknown[]): Uint8Array {
@@ -503,6 +513,19 @@ describe("sync-transport", () => {
       expect(onClientPayload).toHaveBeenCalledWith(JSON.stringify({ Pong: {} }));
     },
   );
+
+  it("sync outbox router accepts the real nested NAPI callback shape", async () => {
+    const onServerPayload = vi.fn().mockResolvedValue(undefined);
+    const router = createSyncOutboxRouter({
+      onServerPayload,
+    });
+
+    router(null, ["server", "upstream-1", JSON.stringify({ Ping: {} }), false]);
+
+    await vi.waitFor(() =>
+      expect(onServerPayload).toHaveBeenCalledWith(JSON.stringify({ Ping: {} }), false),
+    );
+  });
 
   it.each(outboxInvokers)(
     "sync outbox router posts server payloads via sendSyncPayload (%s)",

--- a/packages/jazz-tools/src/runtime/sync-transport.ts
+++ b/packages/jazz-tools/src/runtime/sync-transport.ts
@@ -305,6 +305,15 @@ export type RuntimeSyncOutboxCallbackArgs =
       destinationId: string,
       payload: Uint8Array | string,
       isCatalogue: boolean,
+    ]
+  | [
+      err: unknown,
+      message: [
+        destinationKind: OutboxDestinationKind,
+        destinationId: string,
+        payload: Uint8Array | string,
+        isCatalogue: boolean,
+      ],
     ];
 export type RuntimeSyncOutboxCallback = (...args: RuntimeSyncOutboxCallbackArgs) => void;
 
@@ -340,6 +349,17 @@ function normalizeOutboxCallbackArgs(args: unknown[]): {
       destinationKind: args[1],
       payload: payload,
       isCatalogue: Boolean(args[4]),
+    };
+  }
+
+  // Real NAPI callback: (err, [destinationKind, destinationId, payloadJson, isCatalogue])
+  if (Array.isArray(args[1]) && isOutboxDestinationKind(args[1][0])) {
+    const payload = args[1][2];
+    if (!isOutboxPayload(payload)) return null;
+    return {
+      destinationKind: args[1][0],
+      payload,
+      isCatalogue: Boolean(args[1][3]),
     };
   }
 

--- a/packages/jazz-tools/src/runtime/testing/napi-runtime-test-utils.ts
+++ b/packages/jazz-tools/src/runtime/testing/napi-runtime-test-utils.ts
@@ -1,0 +1,71 @@
+import { createRequire } from "node:module";
+import { onTestFinished } from "vitest";
+import type { WasmSchema } from "../../drivers/types.js";
+import { serializeRuntimeSchema } from "../../drivers/schema-wire.js";
+import type { Runtime } from "../client.js";
+
+type NapiModule = typeof import("jazz-napi");
+export type TestNapiRuntime = Runtime & { close?: () => void };
+
+const require = createRequire(import.meta.url);
+
+let napiModulePromise: Promise<NapiModule> | null = null;
+
+function formatNapiLoadError(error: unknown): Error {
+  const message = error instanceof Error ? error.message : String(error);
+  return new Error(
+    `jazz-napi build artifacts not found or failed to load. Run \`pnpm --filter jazz-napi build:debug\` first.\n\nOriginal error: ${message}`,
+  );
+}
+
+export function hasJazzNapiBuild(): boolean {
+  try {
+    require("jazz-napi");
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function loadNapiModule(): Promise<NapiModule> {
+  if (!napiModulePromise) {
+    napiModulePromise = Promise.resolve().then(() => {
+      try {
+        return require("jazz-napi") as NapiModule;
+      } catch (error) {
+        throw formatNapiLoadError(error);
+      }
+    });
+  }
+
+  return napiModulePromise;
+}
+
+export async function createNapiRuntime(
+  schema: WasmSchema,
+  opts?: {
+    appId?: string;
+    env?: string;
+    userBranch?: string;
+    tier?: string;
+  },
+): Promise<TestNapiRuntime> {
+  const { NapiRuntime } = await loadNapiModule();
+  const runtime = NapiRuntime.inMemory(
+    serializeRuntimeSchema(schema),
+    opts?.appId ?? "test-app",
+    opts?.env ?? "test",
+    opts?.userBranch ?? "main",
+    opts?.tier,
+  );
+
+  onTestFinished(() => {
+    try {
+      runtime.close();
+    } catch {
+      // Best effort cleanup for native runtimes during test shutdown.
+    }
+  });
+
+  return runtime as unknown as TestNapiRuntime;
+}


### PR DESCRIPTION
## Summary
- accept the real nested NAPI sync outbox callback shape in the shared JS router
- add regression coverage for the nested callback contract in sync transport tests
- add a small real-addon NAPI integration suite covering callback shape, backend sync POST auth, and backend edge CRUD/query flow

## Verification
- pnpm exec oxfmt packages/jazz-tools/src/runtime/sync-transport.ts packages/jazz-tools/src/runtime/sync-transport.test.ts packages/jazz-tools/src/runtime/napi.integration.test.ts packages/jazz-tools/src/runtime/testing/napi-runtime-test-utils.ts
- pnpm lint
- pnpm --filter jazz-napi build:debug
- pnpm --filter jazz-wasm build
- cargo build -p jazz-tools --bin jazz-tools --features cli
- pnpm --filter jazz-tools exec vitest run --config vitest.config.ts src/runtime/sync-transport.test.ts src/runtime/napi.integration.test.ts