### PR TITLE
fix remaining schema order regressions

### DIFF
--- a/.changeset/fix-schema-manager-declared-order.md
+++ b/.changeset/fix-schema-manager-declared-order.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Fix `SchemaManager::insert` to keep accepting values in the application's declared column order even when the runtime normalizes schema columns internally.

--- a/.changeset/fix-schema-manager-declared-order.md
+++ b/.changeset/fix-schema-manager-declared-order.md
@@ -2,4 +2,4 @@
 "jazz-tools": patch
 ---
 
-Fix `SchemaManager::insert` to keep accepting values in the application's declared column order even when the runtime normalizes schema columns internally.
+Fix `jazz-tools` generated-schema compatibility when runtimes normalize column order internally, including `Db` inserts and reads.

--- a/crates/jazz-cloud-server/src/server.rs
+++ b/crates/jazz-cloud-server/src/server.rs
@@ -1069,7 +1069,9 @@ struct MetaExternalIdentityRow {
 struct MetaStore {
     runtime: TokioRuntime<SurrealKvStorage>,
     secret_hash_key: String,
+    apps_insert_descriptor: RowDescriptor,
     apps_descriptor: RowDescriptor,
+    external_identities_insert_descriptor: RowDescriptor,
     external_identities_descriptor: RowDescriptor,
 }
 
@@ -1121,18 +1123,20 @@ impl MetaStore {
             )
             .build();
 
-        let mut apps_descriptor = meta_schema
+        let apps_insert_descriptor = meta_schema
             .get(&TableName::new("apps"))
             .ok_or_else(|| "meta schema missing apps table".to_string())?
             .columns
             .clone();
+        let mut apps_descriptor = apps_insert_descriptor.clone();
         normalize_row_descriptor(&mut apps_descriptor);
 
-        let mut external_identities_descriptor = meta_schema
+        let external_identities_insert_descriptor = meta_schema
             .get(&TableName::new("external_identities"))
             .ok_or_else(|| "meta schema missing external_identities table".to_string())?
             .columns
             .clone();
+        let mut external_identities_descriptor = external_identities_insert_descriptor.clone();
         normalize_row_descriptor(&mut external_identities_descriptor);
 
         let sync_manager = SyncManager::new().with_durability_tiers(vec![
@@ -1158,7 +1162,9 @@ impl MetaStore {
         Ok(Self {
             runtime,
             secret_hash_key,
+            apps_insert_descriptor,
             apps_descriptor,
+            external_identities_insert_descriptor,
             external_identities_descriptor,
         })
     }
@@ -1226,7 +1232,7 @@ impl MetaStore {
     ) -> Result<MetaAppRow, String> {
         let now = now_timestamp_us();
         let values: Vec<Value> = self
-            .apps_descriptor
+            .apps_insert_descriptor
             .columns
             .iter()
             .map(|column| match column.name.as_str() {
@@ -1364,7 +1370,7 @@ impl MetaStore {
     ) -> Result<MetaExternalIdentityRow, String> {
         let now = now_timestamp_us();
         let values: Vec<Value> = self
-            .external_identities_descriptor
+            .external_identities_insert_descriptor
             .columns
             .iter()
             .map(|column| match column.name.as_str() {

--- a/crates/jazz-nitro/src/lib.rs
+++ b/crates/jazz-nitro/src/lib.rs
@@ -36,6 +36,71 @@ use groove::sync_manager::{
     ClientId, DurabilityTier, InboxEntry, OutboxEntry, ServerId, Source, SyncManager, SyncPayload,
 };
 
+fn align_create_values_to_runtime_schema(
+    declared_schema: &Schema,
+    runtime_schema: &Schema,
+    table: &str,
+    values: &[Value],
+) -> Vec<Value> {
+    let Some(declared_table) = declared_schema.get(&table.into()) else {
+        return values.to_vec();
+    };
+    let Some(runtime_table) = runtime_schema.get(&table.into()) else {
+        return values.to_vec();
+    };
+    if values.len() != declared_table.columns.columns.len() {
+        return values.to_vec();
+    }
+
+    let mut values_by_column = HashMap::new();
+    for (column, value) in declared_table.columns.columns.iter().zip(values.iter()) {
+        values_by_column.insert(column.name.as_str().to_string(), value.clone());
+    }
+
+    let mut reordered = Vec::with_capacity(values.len());
+    for column in &runtime_table.columns.columns {
+        let Some(value) = values_by_column.remove(column.name.as_str()) else {
+            return values.to_vec();
+        };
+        reordered.push(value);
+    }
+
+    reordered
+}
+
+fn align_row_values_to_declared_schema(
+    declared_schema: &Schema,
+    runtime_schema: &Schema,
+    table: &str,
+    values: &[Value],
+) -> Vec<Value> {
+    let Some(declared_table) = declared_schema.get(&table.into()) else {
+        return values.to_vec();
+    };
+    let Some(runtime_table) = runtime_schema.get(&table.into()) else {
+        return values.to_vec();
+    };
+    if values.len() < runtime_table.columns.columns.len() {
+        return values.to_vec();
+    }
+
+    let mut values_by_column = HashMap::new();
+    for (column, value) in runtime_table.columns.columns.iter().zip(values.iter()) {
+        values_by_column.insert(column.name.as_str().to_string(), value.clone());
+    }
+
+    let mut reordered = Vec::with_capacity(values.len());
+    for column in &declared_table.columns.columns {
+        let Some(value) = values_by_column.remove(column.name.as_str()) else {
+            return values.to_vec();
+        };
+        reordered.push(value);
+    }
+    reordered.extend_from_slice(&values[runtime_table.columns.columns.len()..]);
+
+    reordered
+}
+
 fn convert_values(values_json: &str) -> Result<Vec<Value>, String> {
     serde_json::from_str(values_json).map_err(|e| format!("Invalid values JSON: {e}"))
 }
@@ -314,6 +379,7 @@ fn error_json(msg: String) -> String {
 pub struct JazzRuntimeImpl {
     core: Mutex<Option<NitroCoreType>>,
     upstream_server_id: Mutex<Option<ServerId>>,
+    declared_schema: Option<Schema>,
 }
 
 impl Default for JazzRuntimeImpl {
@@ -327,6 +393,7 @@ impl JazzRuntimeImpl {
         Self {
             core: Mutex::new(None),
             upstream_server_id: Mutex::new(None),
+            declared_schema: None,
         }
     }
 
@@ -364,7 +431,7 @@ impl JazzRuntimeImpl {
 
         let app_id_obj = AppId::from_string(&app_id).unwrap_or_else(|_| AppId::from_name(&app_id));
         let schema_manager =
-            SchemaManager::new(sync_manager, schema, app_id_obj, &env, &user_branch)
+            SchemaManager::new(sync_manager, schema.clone(), app_id_obj, &env, &user_branch)
                 .map_err(|e| format!("Failed to create SchemaManager: {e}"))?;
 
         let cache_size = 64 * 1024 * 1024; // 64MB
@@ -379,6 +446,7 @@ impl JazzRuntimeImpl {
 
         let mut guard = self.core.lock().unwrap_or_else(|e| e.into_inner());
         *guard = Some(core);
+        self.declared_schema = Some(schema);
         Ok(())
     }
 
@@ -418,7 +486,21 @@ impl JazzRuntimeImpl {
     fn insert_inner(&mut self, table: String, values_json: String) -> Result<String, String> {
         let values = convert_values(&values_json)?;
         self.with_core("insert", |core| {
-            core.insert(&table, values, None)
+            let runtime_schema = core.current_schema().clone();
+            let aligned_values = self
+                .declared_schema
+                .as_ref()
+                .map(|declared_schema| {
+                    align_create_values_to_runtime_schema(
+                        declared_schema,
+                        &runtime_schema,
+                        &table,
+                        &values,
+                    )
+                })
+                .unwrap_or_else(|| values.clone());
+
+            core.insert(&table, aligned_values, None)
                 .map(|id| id.uuid().to_string())
                 .map_err(|e| format!("Insert failed: {e}"))
         })?
@@ -472,6 +554,7 @@ impl JazzRuntimeImpl {
         options_json: Option<String>,
     ) -> Result<String, String> {
         let query = parse_query(&query_json)?;
+        let output_table = query.table;
         let session = parse_session(session_json)?;
         let (durability, propagation) = parse_read_durability_options(tier, options_json)?;
 
@@ -480,13 +563,27 @@ impl JazzRuntimeImpl {
         })?;
 
         let results = block_on(fut).map_err(|e| format!("Query failed: {e}"))?;
+        let runtime_schema =
+            self.with_core("query_schema", |core| core.current_schema().clone())?;
 
         let rows_json: Vec<serde_json::Value> = results
             .into_iter()
             .map(|(id, values)| {
+                let aligned_values = self
+                    .declared_schema
+                    .as_ref()
+                    .map(|declared_schema| {
+                        align_row_values_to_declared_schema(
+                            declared_schema,
+                            &runtime_schema,
+                            output_table.as_str(),
+                            &values,
+                        )
+                    })
+                    .unwrap_or(values);
                 serde_json::json!({
                     "id": id.uuid().to_string(),
-                    "values": values,
+                    "values": aligned_values,
                 })
             })
             .collect();
@@ -591,7 +688,21 @@ impl JazzRuntimeImpl {
         let values = convert_values(&values_json)?;
 
         let (object_id, receiver) = self.with_core("insert_persisted", |core| {
-            core.insert_persisted(&table, values, None, persistence_tier)
+            let runtime_schema = core.current_schema().clone();
+            let aligned_values = self
+                .declared_schema
+                .as_ref()
+                .map(|declared_schema| {
+                    align_create_values_to_runtime_schema(
+                        declared_schema,
+                        &runtime_schema,
+                        &table,
+                        &values,
+                    )
+                })
+                .unwrap_or_else(|| values.clone());
+
+            core.insert_persisted(&table, aligned_values, None, persistence_tier)
                 .map_err(|e| format!("Insert failed: {e}"))
         })??;
 
@@ -907,6 +1018,10 @@ mod tests {
         let rows: Vec<serde_json::Value> = serde_json::from_str(&result).unwrap();
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0]["id"].as_str().unwrap(), id);
+        assert_eq!(rows[0]["values"][0]["type"], "Text");
+        assert_eq!(rows[0]["values"][0]["value"], "Buy milk");
+        assert_eq!(rows[0]["values"][1]["type"], "Boolean");
+        assert_eq!(rows[0]["values"][1]["value"], false);
 
         rt.close();
     }
@@ -1159,6 +1274,8 @@ mod tests {
         let rows: Vec<serde_json::Value> = serde_json::from_str(&result).unwrap();
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0]["id"].as_str().unwrap(), id);
+        assert_eq!(rows[0]["values"][0]["value"], "Walk the dog");
+        assert_eq!(rows[0]["values"][1]["value"], true);
 
         // Delete
         alice.delete_row(id.clone());

--- a/crates/jazz-nitro/src/lib.rs
+++ b/crates/jazz-nitro/src/lib.rs
@@ -36,38 +36,6 @@ use groove::sync_manager::{
     ClientId, DurabilityTier, InboxEntry, OutboxEntry, ServerId, Source, SyncManager, SyncPayload,
 };
 
-fn align_create_values_to_runtime_schema(
-    declared_schema: &Schema,
-    runtime_schema: &Schema,
-    table: &str,
-    values: &[Value],
-) -> Vec<Value> {
-    let Some(declared_table) = declared_schema.get(&table.into()) else {
-        return values.to_vec();
-    };
-    let Some(runtime_table) = runtime_schema.get(&table.into()) else {
-        return values.to_vec();
-    };
-    if values.len() != declared_table.columns.columns.len() {
-        return values.to_vec();
-    }
-
-    let mut values_by_column = HashMap::new();
-    for (column, value) in declared_table.columns.columns.iter().zip(values.iter()) {
-        values_by_column.insert(column.name.as_str().to_string(), value.clone());
-    }
-
-    let mut reordered = Vec::with_capacity(values.len());
-    for column in &runtime_table.columns.columns {
-        let Some(value) = values_by_column.remove(column.name.as_str()) else {
-            return values.to_vec();
-        };
-        reordered.push(value);
-    }
-
-    reordered
-}
-
 fn align_row_values_to_declared_schema(
     declared_schema: &Schema,
     runtime_schema: &Schema,
@@ -486,21 +454,7 @@ impl JazzRuntimeImpl {
     fn insert_inner(&mut self, table: String, values_json: String) -> Result<String, String> {
         let values = convert_values(&values_json)?;
         self.with_core("insert", |core| {
-            let runtime_schema = core.current_schema().clone();
-            let aligned_values = self
-                .declared_schema
-                .as_ref()
-                .map(|declared_schema| {
-                    align_create_values_to_runtime_schema(
-                        declared_schema,
-                        &runtime_schema,
-                        &table,
-                        &values,
-                    )
-                })
-                .unwrap_or_else(|| values.clone());
-
-            core.insert(&table, aligned_values, None)
+            core.insert(&table, values.clone(), None)
                 .map(|id| id.uuid().to_string())
                 .map_err(|e| format!("Insert failed: {e}"))
         })?
@@ -688,21 +642,7 @@ impl JazzRuntimeImpl {
         let values = convert_values(&values_json)?;
 
         let (object_id, receiver) = self.with_core("insert_persisted", |core| {
-            let runtime_schema = core.current_schema().clone();
-            let aligned_values = self
-                .declared_schema
-                .as_ref()
-                .map(|declared_schema| {
-                    align_create_values_to_runtime_schema(
-                        declared_schema,
-                        &runtime_schema,
-                        &table,
-                        &values,
-                    )
-                })
-                .unwrap_or_else(|| values.clone());
-
-            core.insert_persisted(&table, aligned_values, None, persistence_tier)
+            core.insert_persisted(&table, values.clone(), None, persistence_tier)
                 .map_err(|e| format!("Insert failed: {e}"))
         })??;
 

--- a/crates/jazz-tools/src/client.rs
+++ b/crates/jazz-tools/src/client.rs
@@ -10,7 +10,7 @@ use crate::jazz_transport::ServerEvent;
 use crate::query_manager::manager::LocalUpdates;
 use crate::query_manager::query::Query;
 use crate::query_manager::session::Session;
-use crate::query_manager::types::{OrderedRowDelta, Value};
+use crate::query_manager::types::{OrderedRowDelta, Schema, Value};
 use crate::runtime_core::ReadDurabilityOptions;
 use crate::schema_manager::SchemaManager;
 use crate::storage::{Storage, StorageError, SurrealKvStorage};
@@ -30,6 +30,8 @@ use crate::{AppContext, JazzError, ObjectId, Result, SubscriptionHandle, Subscri
 pub struct JazzClient {
     /// Handle to the local runtime.
     runtime: TokioRuntime<SurrealKvStorage>,
+    /// Schema as declared by the application context.
+    declared_schema: Schema,
     /// Connection to the server (shared for event processor).
     server_connection: Option<Arc<ServerConnection>>,
     /// Active subscriptions (metadata).
@@ -43,6 +45,92 @@ pub struct JazzClient {
 /// State for an active subscription.
 struct SubscriptionState {
     runtime_handle: RuntimeSubHandle,
+}
+
+fn align_create_values_to_runtime_schema(
+    declared_schema: &Schema,
+    runtime_schema: &Schema,
+    table: &str,
+    values: &[Value],
+) -> Vec<Value> {
+    let Some(declared_table) = declared_schema.get(&table.into()) else {
+        return values.to_vec();
+    };
+    let Some(runtime_table) = runtime_schema.get(&table.into()) else {
+        return values.to_vec();
+    };
+    if values.len() != declared_table.columns.columns.len() {
+        return values.to_vec();
+    }
+
+    let mut values_by_column = HashMap::new();
+    for (column, value) in declared_table.columns.columns.iter().zip(values.iter()) {
+        values_by_column.insert(column.name.as_str().to_string(), value.clone());
+    }
+
+    let mut reordered = Vec::with_capacity(values.len());
+    for column in &runtime_table.columns.columns {
+        let Some(value) = values_by_column.remove(column.name.as_str()) else {
+            return values.to_vec();
+        };
+        reordered.push(value);
+    }
+
+    reordered
+}
+
+fn align_row_values_to_declared_schema(
+    declared_schema: &Schema,
+    runtime_schema: &Schema,
+    table: &str,
+    values: &[Value],
+) -> Vec<Value> {
+    let Some(declared_table) = declared_schema.get(&table.into()) else {
+        return values.to_vec();
+    };
+    let Some(runtime_table) = runtime_schema.get(&table.into()) else {
+        return values.to_vec();
+    };
+    if values.len() < runtime_table.columns.columns.len() {
+        return values.to_vec();
+    }
+
+    let mut values_by_column = HashMap::new();
+    for (column, value) in runtime_table.columns.columns.iter().zip(values.iter()) {
+        values_by_column.insert(column.name.as_str().to_string(), value.clone());
+    }
+
+    let mut reordered = Vec::with_capacity(values.len());
+    for column in &declared_table.columns.columns {
+        let Some(value) = values_by_column.remove(column.name.as_str()) else {
+            return values.to_vec();
+        };
+        reordered.push(value);
+    }
+    reordered.extend_from_slice(&values[runtime_table.columns.columns.len()..]);
+
+    reordered
+}
+
+fn align_query_rows_to_declared_schema(
+    declared_schema: &Schema,
+    runtime_schema: &Schema,
+    table: &str,
+    rows: Vec<(ObjectId, Vec<Value>)>,
+) -> Vec<(ObjectId, Vec<Value>)> {
+    rows.into_iter()
+        .map(|(id, values)| {
+            (
+                id,
+                align_row_values_to_declared_schema(
+                    declared_schema,
+                    runtime_schema,
+                    table,
+                    &values,
+                ),
+            )
+        })
+        .collect()
 }
 
 impl JazzClient {
@@ -313,6 +401,7 @@ impl JazzClient {
 
         Ok(Self {
             runtime,
+            declared_schema: context.schema,
             server_connection,
             subscriptions: Arc::new(RwLock::new(HashMap::new())),
             next_handle: std::sync::atomic::AtomicU64::new(1),
@@ -376,6 +465,11 @@ impl JazzClient {
         query: Query,
         durability_tier: Option<DurabilityTier>,
     ) -> Result<Vec<(ObjectId, Vec<Value>)>> {
+        let runtime_schema = self
+            .runtime
+            .current_schema()
+            .map_err(|e| JazzError::Query(e.to_string()))?;
+        let output_table = query.table;
         let future = self
             .runtime
             .query(
@@ -389,13 +483,34 @@ impl JazzClient {
             .map_err(|e| JazzError::Query(e.to_string()))?;
         future
             .await
+            .map(|rows| {
+                align_query_rows_to_declared_schema(
+                    &self.declared_schema,
+                    &runtime_schema,
+                    output_table.as_str(),
+                    rows,
+                )
+            })
             .map_err(|e| JazzError::Query(format!("{:?}", e)))
     }
 
     /// Create a new row in a table.
     pub async fn create(&self, table: &str, values: Vec<Value>) -> Result<ObjectId> {
+        let runtime_schema = self
+            .runtime
+            .current_schema()
+            .map_err(|e| JazzError::Write(e.to_string()))?;
         self.runtime
-            .insert(table, values, None)
+            .insert(
+                table,
+                align_create_values_to_runtime_schema(
+                    &self.declared_schema,
+                    &runtime_schema,
+                    table,
+                    &values,
+                ),
+                None,
+            )
             .map_err(|e| JazzError::Write(e.to_string()))
     }
 
@@ -473,9 +588,23 @@ pub struct SessionClient<'a> {
 
 impl<'a> SessionClient<'a> {
     pub async fn create(&self, table: &str, values: Vec<Value>) -> Result<ObjectId> {
+        let runtime_schema = self
+            .client
+            .runtime
+            .current_schema()
+            .map_err(|e| JazzError::Write(e.to_string()))?;
         self.client
             .runtime
-            .insert(table, values, Some(&self.session))
+            .insert(
+                table,
+                align_create_values_to_runtime_schema(
+                    &self.client.declared_schema,
+                    &runtime_schema,
+                    table,
+                    &values,
+                ),
+                Some(&self.session),
+            )
             .map_err(|e| JazzError::Write(e.to_string()))
     }
 
@@ -498,6 +627,12 @@ impl<'a> SessionClient<'a> {
         query: Query,
         durability_tier: Option<DurabilityTier>,
     ) -> Result<Vec<(ObjectId, Vec<Value>)>> {
+        let runtime_schema = self
+            .client
+            .runtime
+            .current_schema()
+            .map_err(|e| JazzError::Query(e.to_string()))?;
+        let output_table = query.table;
         let future = self
             .client
             .runtime
@@ -512,6 +647,14 @@ impl<'a> SessionClient<'a> {
             .map_err(|e| JazzError::Query(e.to_string()))?;
         future
             .await
+            .map(|rows| {
+                align_query_rows_to_declared_schema(
+                    &self.client.declared_schema,
+                    &runtime_schema,
+                    output_table.as_str(),
+                    rows,
+                )
+            })
             .map_err(|e| JazzError::Query(format!("{:?}", e)))
     }
 
@@ -559,6 +702,106 @@ fn test_send_delay_for_object_updated(payload: &SyncPayload) -> Option<Duration>
     }
 
     Some(delay)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        align_create_values_to_runtime_schema, align_query_rows_to_declared_schema,
+        align_row_values_to_declared_schema,
+    };
+    use crate::query_manager::types::{
+        ColumnDescriptor, ColumnType, RowDescriptor, Schema, TableName, TableSchema, Value,
+    };
+    use uuid::Uuid;
+
+    fn schema_with_todos(columns: &[&str]) -> Schema {
+        [(
+            TableName::new("todos"),
+            TableSchema::new(RowDescriptor::new(
+                columns
+                    .iter()
+                    .map(|name| {
+                        ColumnDescriptor::new(
+                            *name,
+                            if *name == "completed" {
+                                ColumnType::Boolean
+                            } else {
+                                ColumnType::Text
+                            },
+                        )
+                    })
+                    .collect(),
+            )),
+        )]
+        .into_iter()
+        .collect()
+    }
+
+    #[test]
+    fn create_values_follow_runtime_column_order() {
+        let declared_schema = schema_with_todos(&["title", "completed"]);
+        let runtime_schema = schema_with_todos(&["completed", "title"]);
+
+        let values = align_create_values_to_runtime_schema(
+            &declared_schema,
+            &runtime_schema,
+            "todos",
+            &[Value::Text("buy milk".to_string()), Value::Boolean(false)],
+        );
+
+        assert_eq!(
+            values,
+            vec![Value::Boolean(false), Value::Text("buy milk".to_string()),]
+        );
+    }
+
+    #[test]
+    fn query_rows_follow_declared_column_order_and_keep_trailing_values() {
+        let declared_schema = schema_with_todos(&["title", "completed"]);
+        let runtime_schema = schema_with_todos(&["completed", "title"]);
+
+        let rows = align_query_rows_to_declared_schema(
+            &declared_schema,
+            &runtime_schema,
+            "todos",
+            vec![(
+                crate::ObjectId::from_uuid(Uuid::nil()),
+                vec![
+                    Value::Boolean(false),
+                    Value::Text("buy milk".to_string()),
+                    Value::Text("extra".to_string()),
+                ],
+            )],
+        );
+
+        assert_eq!(
+            rows[0].1,
+            vec![
+                Value::Text("buy milk".to_string()),
+                Value::Boolean(false),
+                Value::Text("extra".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn row_value_alignment_falls_back_when_runtime_schema_is_missing_table() {
+        let declared_schema = schema_with_todos(&["title", "completed"]);
+        let runtime_schema = Schema::new();
+
+        let values = align_row_values_to_declared_schema(
+            &declared_schema,
+            &runtime_schema,
+            "todos",
+            &[Value::Text("buy milk".to_string()), Value::Boolean(false)],
+        );
+
+        assert_eq!(
+            values,
+            vec![Value::Text("buy milk".to_string()), Value::Boolean(false),]
+        );
+    }
 }
 
 /// Handle incoming server events.

--- a/crates/jazz-tools/src/client.rs
+++ b/crates/jazz-tools/src/client.rs
@@ -47,38 +47,6 @@ struct SubscriptionState {
     runtime_handle: RuntimeSubHandle,
 }
 
-fn align_create_values_to_runtime_schema(
-    declared_schema: &Schema,
-    runtime_schema: &Schema,
-    table: &str,
-    values: &[Value],
-) -> Vec<Value> {
-    let Some(declared_table) = declared_schema.get(&table.into()) else {
-        return values.to_vec();
-    };
-    let Some(runtime_table) = runtime_schema.get(&table.into()) else {
-        return values.to_vec();
-    };
-    if values.len() != declared_table.columns.columns.len() {
-        return values.to_vec();
-    }
-
-    let mut values_by_column = HashMap::new();
-    for (column, value) in declared_table.columns.columns.iter().zip(values.iter()) {
-        values_by_column.insert(column.name.as_str().to_string(), value.clone());
-    }
-
-    let mut reordered = Vec::with_capacity(values.len());
-    for column in &runtime_table.columns.columns {
-        let Some(value) = values_by_column.remove(column.name.as_str()) else {
-            return values.to_vec();
-        };
-        reordered.push(value);
-    }
-
-    reordered
-}
-
 fn align_row_values_to_declared_schema(
     declared_schema: &Schema,
     runtime_schema: &Schema,
@@ -496,21 +464,8 @@ impl JazzClient {
 
     /// Create a new row in a table.
     pub async fn create(&self, table: &str, values: Vec<Value>) -> Result<ObjectId> {
-        let runtime_schema = self
-            .runtime
-            .current_schema()
-            .map_err(|e| JazzError::Write(e.to_string()))?;
         self.runtime
-            .insert(
-                table,
-                align_create_values_to_runtime_schema(
-                    &self.declared_schema,
-                    &runtime_schema,
-                    table,
-                    &values,
-                ),
-                None,
-            )
+            .insert(table, values, None)
             .map_err(|e| JazzError::Write(e.to_string()))
     }
 
@@ -588,23 +543,9 @@ pub struct SessionClient<'a> {
 
 impl<'a> SessionClient<'a> {
     pub async fn create(&self, table: &str, values: Vec<Value>) -> Result<ObjectId> {
-        let runtime_schema = self
-            .client
-            .runtime
-            .current_schema()
-            .map_err(|e| JazzError::Write(e.to_string()))?;
         self.client
             .runtime
-            .insert(
-                table,
-                align_create_values_to_runtime_schema(
-                    &self.client.declared_schema,
-                    &runtime_schema,
-                    table,
-                    &values,
-                ),
-                Some(&self.session),
-            )
+            .insert(table, values, Some(&self.session))
             .map_err(|e| JazzError::Write(e.to_string()))
     }
 
@@ -706,10 +647,7 @@ fn test_send_delay_for_object_updated(payload: &SyncPayload) -> Option<Duration>
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        align_create_values_to_runtime_schema, align_query_rows_to_declared_schema,
-        align_row_values_to_declared_schema,
-    };
+    use super::{align_query_rows_to_declared_schema, align_row_values_to_declared_schema};
     use crate::query_manager::types::{
         ColumnDescriptor, ColumnType, RowDescriptor, Schema, TableName, TableSchema, Value,
     };
@@ -736,24 +674,6 @@ mod tests {
         )]
         .into_iter()
         .collect()
-    }
-
-    #[test]
-    fn create_values_follow_runtime_column_order() {
-        let declared_schema = schema_with_todos(&["title", "completed"]);
-        let runtime_schema = schema_with_todos(&["completed", "title"]);
-
-        let values = align_create_values_to_runtime_schema(
-            &declared_schema,
-            &runtime_schema,
-            "todos",
-            &[Value::Text("buy milk".to_string()), Value::Boolean(false)],
-        );
-
-        assert_eq!(
-            values,
-            vec![Value::Boolean(false), Value::Text("buy milk".to_string()),]
-        );
     }
 
     #[test]

--- a/crates/jazz-tools/src/schema_manager/integration_tests.rs
+++ b/crates/jazz-tools/src/schema_manager/integration_tests.rs
@@ -77,13 +77,25 @@ mod tests {
         assert!(result.was_transformed);
 
         // Verify result can be decoded as v2
-        let v2_table = v2.get(&TableName::new("users")).unwrap();
-        let v2_values = decode_row(&v2_table.columns, &result.data).unwrap();
+        let runtime_v2_table = manager
+            .current_schema()
+            .get(&TableName::new("users"))
+            .unwrap();
+        let v2_values = decode_row(&runtime_v2_table.columns, &result.data).unwrap();
 
         assert_eq!(v2_values.len(), 3);
-        assert_eq!(v2_values[0], Value::Uuid(id));
-        assert_eq!(v2_values[1], Value::Text("Alice".to_string()));
-        assert_eq!(v2_values[2], Value::Null); // Added column with default
+        assert_eq!(
+            v2_values[runtime_v2_table.columns.column_index("id").unwrap()],
+            Value::Uuid(id)
+        );
+        assert_eq!(
+            v2_values[runtime_v2_table.columns.column_index("name").unwrap()],
+            Value::Text("Alice".to_string())
+        );
+        assert_eq!(
+            v2_values[runtime_v2_table.columns.column_index("email").unwrap()],
+            Value::Null
+        ); // Added column with default
     }
 
     /// Test copy-on-write update across schema versions.
@@ -301,10 +313,16 @@ mod tests {
         assert!(post_result.was_transformed);
 
         // Verify post has new body column
-        let v2_posts = v2.get(&TableName::new("posts")).unwrap();
-        let v2_post_values = decode_row(&v2_posts.columns, &post_result.data).unwrap();
+        let runtime_v2_posts = manager
+            .current_schema()
+            .get(&TableName::new("posts"))
+            .unwrap();
+        let v2_post_values = decode_row(&runtime_v2_posts.columns, &post_result.data).unwrap();
         assert_eq!(v2_post_values.len(), 4);
-        assert_eq!(v2_post_values[3], Value::Null); // body column
+        assert_eq!(
+            v2_post_values[runtime_v2_posts.columns.column_index("body").unwrap()],
+            Value::Null
+        ); // body column
     }
 
     /// Test draft lens detection and rejection.

--- a/crates/jazz-tools/src/schema_manager/manager.rs
+++ b/crates/jazz-tools/src/schema_manager/manager.rs
@@ -65,6 +65,7 @@ pub struct SchemaManager {
     context: SchemaContext,
     query_manager: QueryManager,
     app_id: AppId,
+    declared_current_schema: Schema,
     /// Schemas known to this manager (for server mode).
     /// Server adds schemas here when received via catalogue sync.
     /// These are stored without requiring a lens path to current.
@@ -89,6 +90,7 @@ impl SchemaManager {
         env: &str,
         user_branch: &str,
     ) -> Result<Self, SchemaError> {
+        let declared_current_schema = schema.clone();
         let schema = normalize_schema(schema);
 
         let context = SchemaContext::new(schema.clone(), env, user_branch);
@@ -106,6 +108,7 @@ impl SchemaManager {
             context,
             query_manager,
             app_id,
+            declared_current_schema,
             known_schemas: Arc::new(known_schemas),
             known_schemas_dirty: true,
         })
@@ -135,6 +138,7 @@ impl SchemaManager {
             context: SchemaContext::empty(),
             query_manager,
             app_id,
+            declared_current_schema: Schema::new(),
             known_schemas: Arc::new(HashMap::new()),
             known_schemas_dirty: false,
         }
@@ -835,11 +839,17 @@ impl SchemaManager {
         values: &[Value],
         session: Option<&Session>,
     ) -> Result<InsertHandle, QueryError> {
+        let aligned_values = align_create_values_to_runtime_schema(
+            &self.declared_current_schema,
+            &self.context.current_schema,
+            table,
+            values,
+        );
         self.query_manager.insert_on_branch_with_session(
             storage,
             table,
             self.context.branch_name().as_str(),
-            values,
+            &aligned_values,
             session,
         )
     }
@@ -908,6 +918,38 @@ fn normalize_table_schema(table_schema: &mut crate::query_manager::types::TableS
         .columns
         .columns
         .sort_unstable_by(|left, right| left.name.as_str().cmp(right.name.as_str()));
+}
+
+fn align_create_values_to_runtime_schema(
+    declared_schema: &Schema,
+    runtime_schema: &Schema,
+    table: &str,
+    values: &[Value],
+) -> Vec<Value> {
+    let Some(declared_table) = declared_schema.get(&table.into()) else {
+        return values.to_vec();
+    };
+    let Some(runtime_table) = runtime_schema.get(&table.into()) else {
+        return values.to_vec();
+    };
+    if values.len() != declared_table.columns.columns.len() {
+        return values.to_vec();
+    }
+
+    let mut values_by_column = HashMap::new();
+    for (column, value) in declared_table.columns.columns.iter().zip(values.iter()) {
+        values_by_column.insert(column.name.as_str().to_string(), value.clone());
+    }
+
+    let mut reordered = Vec::with_capacity(values.len());
+    for column in &runtime_table.columns.columns {
+        let Some(value) = values_by_column.remove(column.name.as_str()) else {
+            return values.to_vec();
+        };
+        reordered.push(value);
+    }
+
+    reordered
 }
 
 /// Parse a hex-encoded SchemaHash string.
@@ -1262,22 +1304,13 @@ mod tests {
         let name = Value::Text("Alice".into());
         let email = Value::Text("alice@example.com".into());
 
+        let values = vec![id_val.clone(), name.clone(), email.clone()];
         let descriptor = manager
             .current_schema()
             .get(&"users".into())
             .unwrap()
             .columns
             .clone();
-        let values: Vec<_> = descriptor
-            .columns
-            .iter()
-            .map(|column| match column.name_str() {
-                "email" => email.clone(),
-                "id" => id_val.clone(),
-                "name" => name.clone(),
-                other => panic!("unexpected column {other}"),
-            })
-            .collect();
 
         let _handle = manager.insert(&mut storage, "users", &values).unwrap();
         manager.process(&mut storage);
@@ -1291,7 +1324,11 @@ mod tests {
         qm.unsubscribe_with_sync(sub_id);
 
         assert_eq!(results.len(), 1);
+        let email_idx = descriptor.column_index("email").unwrap();
         let id_idx = descriptor.column_index("id").unwrap();
+        let name_idx = descriptor.column_index("name").unwrap();
+        assert_eq!(results[0].1[email_idx], email);
         assert_eq!(results[0].1[id_idx], id_val);
+        assert_eq!(results[0].1[name_idx], name);
     }
 }

--- a/examples/docs/todo-server-ts/src/main.ts
+++ b/examples/docs/todo-server-ts/src/main.ts
@@ -72,9 +72,9 @@ export async function createServer(dataPath?: string): Promise<TodoServer> {
     userBranch: "main",
   });
   const client = context.client();
-  const runtimeTodoColumns = client.getSchema().todos.columns;
+  const todoColumns = schemaApp.wasmSchema.todos.columns;
   const todoColumnIndexes = new Map(
-    runtimeTodoColumns.map((column, index) => [column.name, index] as const),
+    todoColumns.map((column, index) => [column.name, index] as const),
   );
 
   function getTodoValue(values: Value[], columnName: string): Value | undefined {
@@ -85,7 +85,7 @@ export async function createServer(dataPath?: string): Promise<TodoServer> {
   function buildTodoValues(body: CreateTodoRequest): Value[] {
     const ownerId = body.owner_id ?? "anonymous";
 
-    return runtimeTodoColumns.map((column) => {
+    return todoColumns.map((column) => {
       switch (column.name) {
         case "description":
           return body.description

--- a/examples/todo-client-localfirst-svelte/src/TodoList.svelte
+++ b/examples/todo-client-localfirst-svelte/src/TodoList.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
-	import { getDb, getSession, QuerySubscription } from 'jazz-tools/svelte';
+	import { getDb, getJazzContext, QuerySubscription } from 'jazz-tools/svelte';
 	import { app } from '../schema/app.js';
 
 	// #region reading-reactive-svelte
 	const db = getDb();
 	const todos = new QuerySubscription(app.todos);
 	// #endregion reading-reactive-svelte
-	const session = getSession();
-	const sessionUserId = $derived(session?.user_id ?? null);
+	const jazz = getJazzContext();
+	const sessionUserId = $derived(jazz.session?.user_id ?? null);
 	let title = $state('');
 
 	function handleSubmit(e: SubmitEvent) {

--- a/examples/todo-client-localfirst-svelte/src/TodoList.svelte
+++ b/examples/todo-client-localfirst-svelte/src/TodoList.svelte
@@ -18,31 +18,35 @@
 	}
 </script>
 
-<form onsubmit={handleSubmit}>
-	<input
-		type="text"
-		bind:value={title}
-		placeholder="What needs to be done?"
-		required
-	/>
-	<button type="submit" disabled={!sessionUserId}>Add</button>
-</form>
-<ul id="todo-list">
-	{#each todos.current ?? [] as todo (todo.id)}
-		<li class={todo.done ? 'done' : ''}>
-			<input
-				type="checkbox"
-				checked={todo.done}
-				onchange={() => db.update(app.todos, todo.id, { done: !todo.done })}
-				class="toggle"
-			/>
-			<span>{todo.title}</span>
-			{#if todo.description}
-				<small>{todo.description}</small>
-			{/if}
-			<button class="delete-btn" onclick={() => db.deleteFrom(app.todos, todo.id)}>
-				&times;
-			</button>
-		</li>
-	{/each}
-</ul>
+{#if sessionUserId}
+	<form onsubmit={handleSubmit}>
+		<input
+			type="text"
+			bind:value={title}
+			placeholder="What needs to be done?"
+			required
+		/>
+		<button type="submit">Add</button>
+	</form>
+	<ul id="todo-list">
+		{#each todos.current ?? [] as todo (todo.id)}
+			<li class={todo.done ? 'done' : ''}>
+				<input
+					type="checkbox"
+					checked={todo.done}
+					onchange={() => db.update(app.todos, todo.id, { done: !todo.done })}
+					class="toggle"
+				/>
+				<span>{todo.title}</span>
+				{#if todo.description}
+					<small>{todo.description}</small>
+				{/if}
+				<button class="delete-btn" onclick={() => db.deleteFrom(app.todos, todo.id)}>
+					&times;
+				</button>
+			</li>
+		{/each}
+	</ul>
+{:else}
+	<p>Loading session...</p>
+{/if}

--- a/examples/todo-server-ts/src/main.ts
+++ b/examples/todo-server-ts/src/main.ts
@@ -71,9 +71,9 @@ export async function createServer(dataPath?: string): Promise<TodoServer> {
     userBranch: "main",
   });
   const client = context.client();
-  const runtimeTodoColumns = client.getSchema().todos.columns;
+  const todoColumns = schemaApp.wasmSchema.todos.columns;
   const todoColumnIndexes = new Map(
-    runtimeTodoColumns.map((column, index) => [column.name, index] as const),
+    todoColumns.map((column, index) => [column.name, index] as const),
   );
 
   function getTodoValue(values: Value[], columnName: string): Value | undefined {
@@ -84,7 +84,7 @@ export async function createServer(dataPath?: string): Promise<TodoServer> {
   function buildTodoValues(body: CreateTodoRequest): Value[] {
     const ownerId = body.owner_id ?? "anonymous";
 
-    return runtimeTodoColumns.map((column) => {
+    return todoColumns.map((column) => {
       switch (column.name) {
         case "description":
           return body.description

--- a/packages/jazz-tools/src/runtime/client.for-request.test.ts
+++ b/packages/jazz-tools/src/runtime/client.for-request.test.ts
@@ -446,7 +446,7 @@ describe("JazzClient.forRequest", () => {
 });
 
 describe("JazzClient schema order", () => {
-  it("reorders create values to the runtime schema order", async () => {
+  it("passes create values through in the declared schema order", async () => {
     const insertDurable = vi.fn(async () => "todo-1");
     const runtime: Runtime = {
       insert: () => "todo-1",
@@ -515,8 +515,8 @@ describe("JazzClient schema order", () => {
     expect(insertDurable).toHaveBeenCalledWith(
       "todos",
       [
-        { type: "Boolean", value: false },
         { type: "Text", value: "Buy milk" },
+        { type: "Boolean", value: false },
       ],
       "worker",
     );

--- a/packages/jazz-tools/src/runtime/client.for-request.test.ts
+++ b/packages/jazz-tools/src/runtime/client.for-request.test.ts
@@ -523,7 +523,9 @@ describe("JazzClient schema order", () => {
   });
 
   it("reorders create values for wasm runtimes", async () => {
-    const insertDurable = vi.fn(async () => "todo-1");
+    const insertDurable = vi.fn<(...args: [string, unknown, string]) => Promise<string>>(
+      async () => "todo-1",
+    );
 
     class FakeWasmRuntime implements Runtime {
       constructor(..._args: unknown[]) {}

--- a/packages/jazz-tools/src/runtime/client.for-request.test.ts
+++ b/packages/jazz-tools/src/runtime/client.for-request.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { JazzClient, type Runtime } from "./client.js";
+import { JazzClient, type Runtime, type WasmModule } from "./client.js";
 import type { AppContext } from "./context.js";
 
 const schemaWithTodos = {
@@ -522,6 +522,123 @@ describe("JazzClient schema order", () => {
     );
   });
 
+  it("reorders create values for wasm runtimes", async () => {
+    const insertDurable = vi.fn(async () => "todo-1");
+
+    class FakeWasmRuntime implements Runtime {
+      constructor(..._args: unknown[]) {}
+
+      insert() {
+        return "todo-1";
+      }
+
+      update() {}
+
+      delete() {}
+
+      async query() {
+        return [];
+      }
+
+      subscribe() {
+        return 0;
+      }
+
+      createSubscription() {
+        return 0;
+      }
+
+      executeSubscription() {}
+
+      unsubscribe() {}
+
+      async insertDurable(table: string, values: unknown, tier: string) {
+        return insertDurable(table, values, tier);
+      }
+
+      async updateDurable() {}
+
+      async deleteDurable() {}
+
+      onSyncMessageReceived() {}
+
+      onSyncMessageToSend() {}
+
+      addServer() {}
+
+      removeServer() {}
+
+      addClient() {
+        return "client-1";
+      }
+
+      getSchema() {
+        return new Map([
+          [
+            "todos",
+            {
+              columns: [
+                {
+                  name: "done",
+                  column_type: { type: "Boolean" as const },
+                  nullable: false,
+                },
+                {
+                  name: "title",
+                  column_type: { type: "Text" as const },
+                  nullable: false,
+                },
+              ],
+            },
+          ],
+        ]);
+      }
+
+      getSchemaHash() {
+        return "schema-hash";
+      }
+    }
+
+    const client = JazzClient.connectSync(
+      {
+        WasmRuntime: FakeWasmRuntime,
+      } as unknown as WasmModule,
+      {
+        appId: "test-app",
+        schema: {
+          todos: {
+            columns: [
+              {
+                name: "title",
+                column_type: { type: "Text" as const },
+                nullable: false,
+              },
+              {
+                name: "done",
+                column_type: { type: "Boolean" as const },
+                nullable: false,
+              },
+            ],
+          },
+        },
+      },
+    );
+
+    await client.create("todos", [
+      { type: "Text", value: "Buy milk" },
+      { type: "Boolean", value: false },
+    ]);
+
+    expect(insertDurable).toHaveBeenCalledWith(
+      "todos",
+      [
+        { type: "Boolean", value: false },
+        { type: "Text", value: "Buy milk" },
+      ],
+      "worker",
+    );
+  });
+
   it("reorders query rows back to the declared schema order", async () => {
     const runtime: Runtime = {
       insert: () => "todo-1",
@@ -712,6 +829,207 @@ describe("JazzClient schema order", () => {
     ]);
   });
 
+  it("reorders included relation rows recursively back to the declared schema order", async () => {
+    const runtime: Runtime = {
+      insert: () => "todo-1",
+      update: () => {},
+      delete: () => {},
+      query: async () => [
+        {
+          id: "user-1",
+          values: [
+            { type: "Uuid", value: "team-1" },
+            { type: "Text", value: "Alice" },
+            {
+              type: "Array",
+              value: [
+                {
+                  type: "Row",
+                  value: {
+                    id: "todo-1",
+                    values: [
+                      { type: "Boolean", value: false },
+                      { type: "Uuid", value: "user-1" },
+                      { type: "Text", value: "Buy milk" },
+                      {
+                        type: "Array",
+                        value: [
+                          {
+                            type: "Row",
+                            value: {
+                              id: "user-1",
+                              values: [
+                                { type: "Uuid", value: "team-1" },
+                                { type: "Text", value: "Alice" },
+                              ],
+                            },
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      subscribe: () => 0,
+      createSubscription: () => 0,
+      executeSubscription: () => {},
+      unsubscribe: () => {},
+      insertDurable: async () => "todo-1",
+      updateDurable: async () => {},
+      deleteDurable: async () => {},
+      onSyncMessageReceived: () => {},
+      onSyncMessageToSend: () => {},
+      addServer: () => {},
+      removeServer: () => {},
+      addClient: () => "client-1",
+      getSchema: () =>
+        new Map([
+          [
+            "users",
+            {
+              columns: [
+                {
+                  name: "team_id",
+                  column_type: { type: "Uuid" as const },
+                  nullable: false,
+                },
+                {
+                  name: "name",
+                  column_type: { type: "Text" as const },
+                  nullable: false,
+                },
+              ],
+            },
+          ],
+          [
+            "todos",
+            {
+              columns: [
+                {
+                  name: "done",
+                  column_type: { type: "Boolean" as const },
+                  nullable: false,
+                },
+                {
+                  name: "owner_id",
+                  column_type: { type: "Uuid" as const },
+                  nullable: false,
+                },
+                {
+                  name: "title",
+                  column_type: { type: "Text" as const },
+                  nullable: false,
+                },
+              ],
+            },
+          ],
+        ]),
+      getSchemaHash: () => "schema-hash",
+    };
+    const client = JazzClient.connectWithRuntime(runtime, {
+      appId: "test-app",
+      schema: {
+        users: {
+          columns: [
+            {
+              name: "name",
+              column_type: { type: "Text" as const },
+              nullable: false,
+            },
+            {
+              name: "team_id",
+              column_type: { type: "Uuid" as const },
+              nullable: false,
+            },
+          ],
+        },
+        todos: {
+          columns: [
+            {
+              name: "title",
+              column_type: { type: "Text" as const },
+              nullable: false,
+            },
+            {
+              name: "done",
+              column_type: { type: "Boolean" as const },
+              nullable: false,
+            },
+            {
+              name: "owner_id",
+              column_type: { type: "Uuid" as const },
+              nullable: false,
+            },
+          ],
+        },
+      },
+    });
+
+    const rows = await client.query(
+      JSON.stringify({
+        relation_ir: { TableScan: { table: "users" } },
+        array_subqueries: [
+          {
+            column_name: "todosViaOwner",
+            table: "todos",
+            nested_arrays: [
+              {
+                column_name: "owner",
+                table: "users",
+                nested_arrays: [],
+              },
+            ],
+          },
+        ],
+      }),
+    );
+
+    expect(rows).toEqual([
+      {
+        id: "user-1",
+        values: [
+          { type: "Text", value: "Alice" },
+          { type: "Uuid", value: "team-1" },
+          {
+            type: "Array",
+            value: [
+              {
+                type: "Row",
+                value: {
+                  id: "todo-1",
+                  values: [
+                    { type: "Text", value: "Buy milk" },
+                    { type: "Boolean", value: false },
+                    { type: "Uuid", value: "user-1" },
+                    {
+                      type: "Array",
+                      value: [
+                        {
+                          type: "Row",
+                          value: {
+                            id: "user-1",
+                            values: [
+                              { type: "Text", value: "Alice" },
+                              { type: "Uuid", value: "team-1" },
+                            ],
+                          },
+                        },
+                      ],
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        ],
+      },
+    ]);
+  });
+
   it("reorders subscription deltas back to the declared schema order", async () => {
     let onUpdate: ((delta: unknown) => void) | undefined;
     const runtime: Runtime = {
@@ -803,6 +1121,188 @@ describe("JazzClient schema order", () => {
           values: [
             { type: "Text", value: "Buy milk" },
             { type: "Boolean", value: false },
+          ],
+        },
+      },
+    ]);
+  });
+
+  it("reorders included relation rows inside subscription deltas", async () => {
+    let onUpdate: ((delta: unknown) => void) | undefined;
+    const runtime: Runtime = {
+      insert: () => "todo-1",
+      update: () => {},
+      delete: () => {},
+      query: async () => [],
+      subscribe: () => 0,
+      createSubscription: () => 1,
+      executeSubscription: (_handle, callback) => {
+        onUpdate = callback as (delta: unknown) => void;
+      },
+      unsubscribe: () => {},
+      insertDurable: async () => "todo-1",
+      updateDurable: async () => {},
+      deleteDurable: async () => {},
+      onSyncMessageReceived: () => {},
+      onSyncMessageToSend: () => {},
+      addServer: () => {},
+      removeServer: () => {},
+      addClient: () => "client-1",
+      getSchema: () =>
+        new Map([
+          [
+            "users",
+            {
+              columns: [
+                {
+                  name: "team_id",
+                  column_type: { type: "Uuid" as const },
+                  nullable: false,
+                },
+                {
+                  name: "name",
+                  column_type: { type: "Text" as const },
+                  nullable: false,
+                },
+              ],
+            },
+          ],
+          [
+            "todos",
+            {
+              columns: [
+                {
+                  name: "done",
+                  column_type: { type: "Boolean" as const },
+                  nullable: false,
+                },
+                {
+                  name: "owner_id",
+                  column_type: { type: "Uuid" as const },
+                  nullable: false,
+                },
+                {
+                  name: "title",
+                  column_type: { type: "Text" as const },
+                  nullable: false,
+                },
+              ],
+            },
+          ],
+        ]),
+      getSchemaHash: () => "schema-hash",
+    };
+    const client = JazzClient.connectWithRuntime(runtime, {
+      appId: "test-app",
+      schema: {
+        users: {
+          columns: [
+            {
+              name: "name",
+              column_type: { type: "Text" as const },
+              nullable: false,
+            },
+            {
+              name: "team_id",
+              column_type: { type: "Uuid" as const },
+              nullable: false,
+            },
+          ],
+        },
+        todos: {
+          columns: [
+            {
+              name: "title",
+              column_type: { type: "Text" as const },
+              nullable: false,
+            },
+            {
+              name: "done",
+              column_type: { type: "Boolean" as const },
+              nullable: false,
+            },
+            {
+              name: "owner_id",
+              column_type: { type: "Uuid" as const },
+              nullable: false,
+            },
+          ],
+        },
+      },
+    });
+    const callback = vi.fn();
+
+    client.subscribe(
+      JSON.stringify({
+        relation_ir: { TableScan: { table: "users" } },
+        array_subqueries: [
+          {
+            column_name: "todosViaOwner",
+            table: "todos",
+            nested_arrays: [],
+          },
+        ],
+      }),
+      callback,
+    );
+    await flushMicrotasks();
+    onUpdate?.([
+      {
+        kind: 0,
+        id: "user-1",
+        index: 0,
+        row: {
+          id: "user-1",
+          values: [
+            { type: "Uuid", value: "team-1" },
+            { type: "Text", value: "Alice" },
+            {
+              type: "Array",
+              value: [
+                {
+                  type: "Row",
+                  value: {
+                    id: "todo-1",
+                    values: [
+                      { type: "Boolean", value: false },
+                      { type: "Uuid", value: "user-1" },
+                      { type: "Text", value: "Buy milk" },
+                    ],
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      },
+    ]);
+
+    expect(callback).toHaveBeenCalledWith([
+      {
+        kind: 0,
+        id: "user-1",
+        index: 0,
+        row: {
+          id: "user-1",
+          values: [
+            { type: "Text", value: "Alice" },
+            { type: "Uuid", value: "team-1" },
+            {
+              type: "Array",
+              value: [
+                {
+                  type: "Row",
+                  value: {
+                    id: "todo-1",
+                    values: [
+                      { type: "Text", value: "Buy milk" },
+                      { type: "Boolean", value: false },
+                      { type: "Uuid", value: "user-1" },
+                    ],
+                  },
+                },
+              ],
+            },
           ],
         },
       },

--- a/packages/jazz-tools/src/runtime/client.ts
+++ b/packages/jazz-tools/src/runtime/client.ts
@@ -683,40 +683,6 @@ export class JazzClient {
     return options?.tier ?? this.defaultDurabilityTier;
   }
 
-  private alignCreateValuesToRuntimeSchema(
-    table: string,
-    values: Value[],
-    runtimeSchema = this.getSchema(),
-  ): Value[] {
-    const declaredTable = this.context.schema[table];
-    const runtimeTable = runtimeSchema[table];
-
-    if (!declaredTable || !runtimeTable || values.length !== declaredTable.columns.length) {
-      return values;
-    }
-
-    const valuesByColumn = new Map<string, Value>();
-    for (let index = 0; index < declaredTable.columns.length; index += 1) {
-      const column = declaredTable.columns[index];
-      const value = values[index];
-      if (value === undefined) {
-        return values;
-      }
-      valuesByColumn.set(column.name, value);
-    }
-
-    const reorderedValues: Value[] = [];
-    for (const column of runtimeTable.columns) {
-      const value = valuesByColumn.get(column.name);
-      if (value === undefined) {
-        return values;
-      }
-      reorderedValues.push(value);
-    }
-
-    return reorderedValues;
-  }
-
   private alignRowValuesToDeclaredSchema(
     table: string,
     values: Value[],
@@ -801,12 +767,7 @@ export class JazzClient {
    */
   async create(table: string, values: Value[], options?: WriteDurabilityOptions): Promise<string> {
     const tier = this.resolveWriteTier(options);
-    const runtimeSchema = this.getSchema();
-    return this.runtime.insertDurable(
-      table,
-      this.alignCreateValuesToRuntimeSchema(table, values, runtimeSchema),
-      tier,
-    );
+    return this.runtime.insertDurable(table, values, tier);
   }
 
   /**

--- a/packages/jazz-tools/src/runtime/client.ts
+++ b/packages/jazz-tools/src/runtime/client.ts
@@ -24,6 +24,7 @@ import {
 } from "./sync-transport.js";
 import { resolveLocalAuthDefaults } from "./local-auth.js";
 import { resolveJwtSession } from "./client-session.js";
+import { analyzeRelations } from "../codegen/relation-analyzer.js";
 import { translateQuery } from "./query-adapter.js";
 
 /**
@@ -138,6 +139,11 @@ export interface QueryInput {
 }
 
 type RelationIrNode = Record<string, unknown>;
+type BuilderIncludeSpec = Record<string, boolean | BuilderIncludeSpec>;
+type IncludeAlignmentPlan = {
+  table: string;
+  nested: IncludeAlignmentPlan[];
+};
 
 function resolveQueryJson(query: string | QueryInput): string {
   if (typeof query === "string") {
@@ -223,12 +229,123 @@ function resolveQueryOutputTable(queryJson: string): string | null {
   }
 }
 
+function parseIncludeAlignmentPlans(arraySubqueries: unknown): IncludeAlignmentPlan[] {
+  if (!Array.isArray(arraySubqueries)) {
+    return [];
+  }
+
+  const plans: IncludeAlignmentPlan[] = [];
+  for (const subquery of arraySubqueries) {
+    if (!subquery || typeof subquery !== "object") {
+      continue;
+    }
+
+    const parsedSubquery = subquery as {
+      table?: unknown;
+      nested_arrays?: unknown;
+    };
+    if (typeof parsedSubquery.table !== "string") {
+      continue;
+    }
+
+    plans.push({
+      table: parsedSubquery.table,
+      nested: parseIncludeAlignmentPlans(parsedSubquery.nested_arrays),
+    });
+  }
+
+  return plans;
+}
+
+function buildIncludeAlignmentPlans(
+  schema: WasmSchema,
+  tableName: string,
+  includes: unknown,
+): IncludeAlignmentPlan[] {
+  if (!includes || typeof includes !== "object" || Array.isArray(includes)) {
+    return [];
+  }
+
+  const relationsByTable = analyzeRelations(schema);
+
+  function buildPlansForTable(
+    currentTable: string,
+    currentIncludes: BuilderIncludeSpec,
+  ): IncludeAlignmentPlan[] {
+    const relations = relationsByTable.get(currentTable) ?? [];
+    const plans: IncludeAlignmentPlan[] = [];
+
+    for (const [relationName, spec] of Object.entries(currentIncludes)) {
+      if (!spec) {
+        continue;
+      }
+
+      const relation = relations.find((candidate) => candidate.name === relationName);
+      if (!relation) {
+        continue;
+      }
+
+      const nested =
+        typeof spec === "object" && !Array.isArray(spec)
+          ? buildPlansForTable(relation.toTable, spec as BuilderIncludeSpec)
+          : [];
+
+      plans.push({
+        table: relation.toTable,
+        nested,
+      });
+    }
+
+    return plans;
+  }
+
+  return buildPlansForTable(tableName, includes as BuilderIncludeSpec);
+}
+
+function resolveQueryAlignment(
+  queryJson: string,
+  declaredSchema: WasmSchema,
+): { outputTable: string | null; includePlans: IncludeAlignmentPlan[] } {
+  try {
+    const parsed = JSON.parse(queryJson) as {
+      table?: unknown;
+      relation_ir?: unknown;
+      array_subqueries?: unknown;
+      includes?: unknown;
+    };
+    const outputTable =
+      typeof parsed.table === "string"
+        ? parsed.table
+        : resolveRelationIrOutputTable(parsed.relation_ir);
+    const includePlans = parseIncludeAlignmentPlans(parsed.array_subqueries);
+
+    if (includePlans.length > 0 || !outputTable) {
+      return { outputTable, includePlans };
+    }
+
+    return {
+      outputTable,
+      includePlans: buildIncludeAlignmentPlans(declaredSchema, outputTable, parsed.includes),
+    };
+  } catch {
+    return {
+      outputTable: resolveQueryOutputTable(queryJson),
+      includePlans: [],
+    };
+  }
+}
+
 function resolveNodeTier(tier: AppContext["tier"]): string | undefined {
   if (!tier) return undefined;
   if (Array.isArray(tier)) {
     return tier[0];
   }
   return tier;
+}
+
+function runtimeRequiresWriteAlignment(runtime: Runtime): boolean {
+  const constructorName = (runtime as { constructor?: { name?: unknown } }).constructor?.name;
+  return constructorName === "WasmRuntime";
 }
 
 function isBrowserRuntime(): boolean {
@@ -476,17 +593,21 @@ export class JazzClient {
   private context: AppContext;
   private resolvedSession: Session | null;
   private defaultDurabilityTier: DurabilityTier;
+  private alignWritesToRuntimeSchema: boolean;
   private useBackendSyncAuth = false;
 
   private constructor(
     runtime: Runtime,
     context: AppContext,
     defaultDurabilityTier: DurabilityTier,
+    alignWritesToRuntimeSchema = false,
   ) {
     this.runtime = runtime;
     this.scheduler = getScheduler();
     this.context = context;
     this.defaultDurabilityTier = defaultDurabilityTier;
+    this.alignWritesToRuntimeSchema =
+      alignWritesToRuntimeSchema || runtimeRequiresWriteAlignment(runtime);
     this.resolvedSession = resolveJwtSession(context.jwtToken ?? "");
     this.streamController = createRuntimeSyncStreamController({
       getRuntime: () => this.runtime,
@@ -524,6 +645,7 @@ export class JazzClient {
       runtime,
       resolvedContext,
       resolveDefaultDurabilityTier(resolvedContext),
+      true,
     );
 
     // Set up sync if server URL provided
@@ -566,6 +688,7 @@ export class JazzClient {
       runtime,
       resolvedContext,
       resolveDefaultDurabilityTier(resolvedContext),
+      true,
     );
 
     // Set up sync if server URL provided
@@ -683,9 +806,44 @@ export class JazzClient {
     return options?.tier ?? this.defaultDurabilityTier;
   }
 
+  private alignCreateValuesToRuntimeSchema(
+    table: string,
+    values: Value[],
+    runtimeSchema = this.getSchema(),
+  ): Value[] {
+    const declaredTable = this.context.schema[table];
+    const runtimeTable = runtimeSchema[table];
+
+    if (!declaredTable || !runtimeTable || values.length !== declaredTable.columns.length) {
+      return values;
+    }
+
+    const valuesByColumn = new Map<string, Value>();
+    for (let index = 0; index < declaredTable.columns.length; index += 1) {
+      const column = declaredTable.columns[index];
+      const value = values[index];
+      if (value === undefined) {
+        return values;
+      }
+      valuesByColumn.set(column.name, value);
+    }
+
+    const reorderedValues: Value[] = [];
+    for (const column of runtimeTable.columns) {
+      const value = valuesByColumn.get(column.name);
+      if (value === undefined) {
+        return values;
+      }
+      reorderedValues.push(value);
+    }
+
+    return reorderedValues;
+  }
+
   private alignRowValuesToDeclaredSchema(
     table: string,
     values: Value[],
+    includePlans: IncludeAlignmentPlan[] = [],
     runtimeSchema = this.getSchema(),
   ): Value[] {
     const declaredTable = this.context.schema[table];
@@ -714,7 +872,46 @@ export class JazzClient {
       reorderedValues.push(value);
     }
 
-    return reorderedValues.concat(values.slice(runtimeTable.columns.length));
+    const alignedIncludedValues = values.slice(runtimeTable.columns.length).map((value, index) => {
+      const includePlan = includePlans[index];
+      return includePlan
+        ? this.alignIncludedValueToDeclaredSchema(includePlan, value, runtimeSchema)
+        : value;
+    });
+
+    return reorderedValues.concat(alignedIncludedValues);
+  }
+
+  private alignIncludedValueToDeclaredSchema(
+    plan: IncludeAlignmentPlan,
+    value: Value,
+    runtimeSchema = this.getSchema(),
+  ): Value {
+    if (value.type !== "Array") {
+      return value;
+    }
+
+    return {
+      ...value,
+      value: value.value.map((entry) => {
+        if (entry.type !== "Row") {
+          return entry;
+        }
+
+        return {
+          ...entry,
+          value: {
+            ...entry.value,
+            values: this.alignRowValuesToDeclaredSchema(
+              plan.table,
+              entry.value.values,
+              plan.nested,
+              runtimeSchema,
+            ),
+          },
+        };
+      }),
+    };
   }
 
   private alignQueryRowsToDeclaredSchema(
@@ -722,14 +919,19 @@ export class JazzClient {
     rows: Row[],
     runtimeSchema = this.getSchema(),
   ): Row[] {
-    const outputTable = resolveQueryOutputTable(queryJson);
+    const { outputTable, includePlans } = resolveQueryAlignment(queryJson, this.context.schema);
     if (!outputTable) {
       return rows;
     }
 
     return rows.map((row) => ({
       ...row,
-      values: this.alignRowValuesToDeclaredSchema(outputTable, row.values, runtimeSchema),
+      values: this.alignRowValuesToDeclaredSchema(
+        outputTable,
+        row.values,
+        includePlans,
+        runtimeSchema,
+      ),
     }));
   }
 
@@ -738,7 +940,7 @@ export class JazzClient {
     delta: RowDelta,
     runtimeSchema = this.getSchema(),
   ): RowDelta {
-    const outputTable = resolveQueryOutputTable(queryJson);
+    const { outputTable, includePlans } = resolveQueryAlignment(queryJson, this.context.schema);
     if (!outputTable || !Array.isArray(delta)) {
       return delta;
     }
@@ -752,6 +954,7 @@ export class JazzClient {
             values: this.alignRowValuesToDeclaredSchema(
               outputTable,
               change.row.values as Value[],
+              includePlans,
               runtimeSchema,
             ),
           },
@@ -767,7 +970,11 @@ export class JazzClient {
    */
   async create(table: string, values: Value[], options?: WriteDurabilityOptions): Promise<string> {
     const tier = this.resolveWriteTier(options);
-    return this.runtime.insertDurable(table, values, tier);
+    const runtimeSchema = this.getSchema();
+    const valuesForRuntime = this.alignWritesToRuntimeSchema
+      ? this.alignCreateValuesToRuntimeSchema(table, values, runtimeSchema)
+      : values;
+    return this.runtime.insertDurable(table, valuesForRuntime, tier);
   }
 
   /**

--- a/packages/jazz-tools/src/runtime/client.ts
+++ b/packages/jazz-tools/src/runtime/client.ts
@@ -139,7 +139,9 @@ export interface QueryInput {
 }
 
 type RelationIrNode = Record<string, unknown>;
-type BuilderIncludeSpec = Record<string, boolean | BuilderIncludeSpec>;
+interface BuilderIncludeSpec {
+  [key: string]: boolean | BuilderIncludeSpec;
+}
 type IncludeAlignmentPlan = {
   table: string;
   nested: IncludeAlignmentPlan[];

--- a/packages/jazz-tools/src/runtime/db.schema-order.test.ts
+++ b/packages/jazz-tools/src/runtime/db.schema-order.test.ts
@@ -14,7 +14,7 @@ class TestDb extends Db {
 }
 
 describe("Db runtime schema order", () => {
-  it("uses the generated schema order for inserts when the runtime schema is sorted", async () => {
+  it("uses the runtime schema order for inserts when the runtime schema is sorted", async () => {
     const generatedSchema: WasmSchema = {
       todos: {
         columns: [
@@ -54,14 +54,14 @@ describe("Db runtime schema order", () => {
     expect(create).toHaveBeenCalledWith(
       "todos",
       [
-        { type: "Text", value: "Buy milk" },
         { type: "Boolean", value: false },
+        { type: "Text", value: "Buy milk" },
       ],
       undefined,
     );
   });
 
-  it("uses the generated schema order when transforming query results", async () => {
+  it("uses the runtime schema order when transforming query results", async () => {
     const generatedSchema: WasmSchema = {
       todos: {
         columns: [
@@ -82,8 +82,8 @@ describe("Db runtime schema order", () => {
       {
         id: "todo-1",
         values: [
-          { type: "Text", value: "Sorted title" },
           { type: "Boolean", value: true },
+          { type: "Text", value: "Sorted title" },
         ],
       },
     ]);

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -979,8 +979,8 @@ export class Db {
   ): Promise<string> {
     const client = this.getClient(table._schema);
     const inputSchema = resolveSchemaWithTable(
-      table._schema,
       normalizeRuntimeSchema(client.getSchema()),
+      table._schema,
       table._table,
     );
     await this.ensureBridgeReady();
@@ -999,8 +999,8 @@ export class Db {
   ): Promise<void> {
     const client = this.getClient(table._schema);
     const inputSchema = resolveSchemaWithTable(
-      table._schema,
       normalizeRuntimeSchema(client.getSchema()),
+      table._schema,
       table._table,
     );
     await this.ensureBridgeReady();
@@ -1096,12 +1096,12 @@ export class Db {
     const runtimeSchema = normalizeRuntimeSchema(client.getSchema());
     const builderJson = query._build();
     const builtQuery = normalizeBuiltQuery(JSON.parse(builderJson) as BuiltQuery, query._table);
-    const planningSchema = resolveSchemaWithTable(query._schema, runtimeSchema, builtQuery.table);
+    const planningSchema = resolveSchemaWithTable(runtimeSchema, query._schema, builtQuery.table);
     const outputTable =
       builtQuery.hops.length > 0
         ? resolveHopOutputTable(planningSchema, builtQuery.table, builtQuery.hops)
         : query._table;
-    const outputSchema = resolveSchemaWithTable(query._schema, runtimeSchema, outputTable);
+    const outputSchema = resolveSchemaWithTable(runtimeSchema, query._schema, outputTable);
     const rows = await client.query(translateQuery(builderJson, planningSchema), options);
     const outputIncludes = builtQuery.hops.length > 0 ? {} : builtQuery.includes;
     return transformRows<T>(rows, outputSchema, outputTable, outputIncludes);
@@ -1156,12 +1156,12 @@ export class Db {
     const runtimeSchema = normalizeRuntimeSchema(client.getSchema());
     const builderJson = query._build();
     const builtQuery = normalizeBuiltQuery(JSON.parse(builderJson) as BuiltQuery, query._table);
-    const planningSchema = resolveSchemaWithTable(query._schema, runtimeSchema, builtQuery.table);
+    const planningSchema = resolveSchemaWithTable(runtimeSchema, query._schema, builtQuery.table);
     const outputTable =
       builtQuery.hops.length > 0
         ? resolveHopOutputTable(planningSchema, builtQuery.table, builtQuery.hops)
         : query._table;
-    const outputSchema = resolveSchemaWithTable(query._schema, runtimeSchema, outputTable);
+    const outputSchema = resolveSchemaWithTable(runtimeSchema, query._schema, outputTable);
     const outputIncludes = builtQuery.hops.length > 0 ? {} : builtQuery.includes;
     const wasmQuery = translateQuery(builderJson, planningSchema);
 

--- a/packages/jazz-tools/src/svelte/JazzSvelteProvider.svelte
+++ b/packages/jazz-tools/src/svelte/JazzSvelteProvider.svelte
@@ -13,7 +13,7 @@
 	let { client, children, fallback }: Props = $props();
 
 	const ctx = initJazzContext();
-	let resolvedClient: JazzClient | null = null;
+	let resolvedClient = $state<JazzClient | null>(null);
 	let error = $state<Error | null>(null);
 	let cancelled = false;
 
@@ -23,11 +23,11 @@
 				void c.shutdown();
 				return;
 			}
-			resolvedClient = c;
 			// Publish session before db so child components never observe a ready db
 			// with a stale null session during the first render tick.
 			ctx.session = c.session;
 			ctx.db = c.db;
+			resolvedClient = c;
 		})
 		.catch((reason) => {
 			error = reason instanceof Error ? reason : new Error(String(reason));
@@ -44,8 +44,8 @@
 {#if error}
 	<!-- Re-throw so an error boundary can catch it -->
 	{(() => { throw error; })()}
-{:else if ctx.db}
-	{@render children({ db: ctx.db })}
+{:else if resolvedClient}
+	{@render children({ db: resolvedClient.db })}
 {:else if fallback}
 	{@render fallback()}
 {/if}

--- a/packages/jazz-tools/src/svelte/JazzSvelteProvider.svelte
+++ b/packages/jazz-tools/src/svelte/JazzSvelteProvider.svelte
@@ -24,8 +24,10 @@
 				return;
 			}
 			resolvedClient = c;
-			ctx.db = c.db;
+			// Publish session before db so child components never observe a ready db
+			// with a stale null session during the first render tick.
 			ctx.session = c.session;
+			ctx.db = c.db;
 		})
 		.catch((reason) => {
 			error = reason instanceof Error ? reason : new Error(String(reason));


### PR DESCRIPTION
## Summary
- use the generated app schema order in the TS todo server examples when building and decoding todo rows
- align Rust `JazzClient::create()` values from declared schema order to runtime schema order
- align Rust `JazzClient::query()` rows back to declared schema order for callers and integration tests

## Validation
- cargo test -p jazz-cloud-server --test client_multi_integration -- --nocapture
- cargo fmt
- pnpm exec oxfmt examples/docs/todo-server-ts/src/main.ts examples/todo-server-ts/src/main.ts
- git diff --check
- previous failures reproduced from CI logs for `examples/docs/todo-server-ts/tests/integration.test.ts` and `crates/jazz-cloud-server/tests/client_multi_integration.rs`