### PR TITLE
Add permission introspection magic columns spec

### DIFF
--- a/specs/todo/a_mvp/magic_columns_permission_introspection.md
+++ b/specs/todo/a_mvp/magic_columns_permission_introspection.md
@@ -1,0 +1,123 @@
+# Magic Columns for Permission Introspection
+
+Permission introspection columns expose whether the current session could act on a row using the same policy machinery as real mutations.
+
+## Initial Columns
+
+- `_canEdit`
+- `_canDelete`
+
+These are virtual/magic columns, not user-declared schema columns.
+
+## Semantics
+
+### Session Context
+
+The columns are evaluated in the context of the current session, exactly like session-aware mutation checks.
+
+If no session is present, the value should be `NULL` rather than `true` or `false`.
+
+### `_canEdit`
+
+`_canEdit` answers:
+
+> Does this session pass the row's `UPDATE USING` policy for the current row?
+
+This is intentionally narrower than "could some update succeed?" and does **not** attempt to predict `WITH CHECK` because no candidate new row exists at read time.
+
+If the table has no `UPDATE USING` policy, `_canEdit` is `true`.
+
+### `_canDelete`
+
+`_canDelete` answers:
+
+> Does this session pass the row's effective delete policy?
+
+This should use the same policy resolution as real deletes:
+
+- explicit `DELETE USING`, if present
+- otherwise the existing fallback to `UPDATE USING`
+
+If the table has no delete/update-using policy, `_canDelete` is `true`.
+
+## Query Surface
+
+### Explicit Opt-In
+
+These columns are excluded from `SELECT *`.
+
+Examples:
+
+- `SELECT * FROM todos` returns only normal columns
+- `SELECT *, _canEdit, _canDelete FROM todos` opts into the magic columns
+- `SELECT t._canEdit FROM todos AS t` is allowed
+
+This follows the "hidden/system column" model used by several SQL systems and keeps default reads cheap.
+
+### Joined Queries
+
+Magic columns must work in joined queries.
+
+They should bind to a specific row source, for example:
+
+- `SELECT u.name, p.title, u._canEdit, p._canDelete ...`
+
+This requires projection metadata to preserve source scope/table identity rather than flattening everything down to unqualified column strings too early.
+
+### Filters
+
+Magic columns should be usable in `WHERE`, but only as non-indexed filters.
+
+Examples:
+
+- `WHERE _canDelete = true`
+- `WHERE p._canEdit = true`
+
+If a query references a magic column in filtering, the planner should compute the relevant magic columns before the filter stage. If a magic column is only projected, it can be computed later.
+
+## Reuse of Mutation Policy Logic
+
+The implementation should reuse the same permission evaluation path as real mutations rather than creating a second policy engine.
+
+At a high level:
+
+1. Resolve the relevant operation and policy:
+   - `_canEdit` -> `Operation::Update`, using only `UPDATE USING`
+   - `_canDelete` -> `Operation::Delete`, using the effective delete policy
+2. Evaluate the simple predicate parts directly from row bytes
+3. Reuse the existing complex-clause handling for:
+   - `INHERITS`
+   - `EXISTS`
+   - `EXISTS REL`
+   - `INHERITS REFERENCING`
+4. Reuse the same dependency tracking so values re-evaluate when referenced policy rows change
+
+This keeps introspection aligned with real authorization behavior.
+
+## Output Shape
+
+Once explicitly requested, magic columns should appear in graph output descriptors like ordinary nullable boolean columns.
+
+That means downstream nodes can treat them as normal columns for:
+
+- projection
+- filtering
+- output encoding
+
+But they should remain hidden from schema/catalog metadata and wildcard expansion.
+
+## Required Groundwork
+
+Two planner refactors are the intended first implementation steps:
+
+1. Make projection metadata precise
+   - preserve source scope/table identity
+   - preserve aliases
+   - support projecting columns from joined inputs without collapsing to `Vec<String>`
+
+2. Make condition/filter metadata precise
+   - preserve source scope/table identity in conditions
+   - resolve filters against joined tuple descriptors correctly
+   - allow future non-indexed filters over computed/magic columns
+
+These refactors should land before the actual `_canEdit` / `_canDelete` computation node.


### PR DESCRIPTION
## Summary
- add an implementation spec for  and 
- lock the semantics we converged on for session handling, joined-query support, and filter support
- document the two planner refactors needed before implementing the computed columns

## Testing
- not run (docs only)
