### PR TITLE
feat: split Db.update/delete into sync and durable APIs

### DIFF
--- a/.changeset/sync-update-delete-api.md
+++ b/.changeset/sync-update-delete-api.md
@@ -1,0 +1,9 @@
+---
+"jazz-tools": patch
+---
+
+Split the local-first update/delete APIs in `jazz-tools`.
+
+- `db.update(...)` and `db.delete(...)` now apply immediately and return `void`.
+- `db.updateDurable(...)` and `db.deleteDurable(...)` wait for the requested durability tier before resolving.
+- `db.deleteFrom(...)` has been renamed to `db.delete(...)`.

--- a/docs/content/docs/quickstarts/expo.mdx
+++ b/docs/content/docs/quickstarts/expo.mdx
@@ -105,7 +105,7 @@ Use `db.subscribeAll` (or `db.all`) with a durability tier when you need tier-ga
 
 ### Writing with a durability tier
 
-Use base mutation APIs with `{ tier }` when you need explicit write durability acknowledgement before proceeding:
+Use durable mutation APIs with `{ tier }` when you need explicit write durability acknowledgement before proceeding:
 
 <include cwd lang="ts">
   ../examples/docs/todo-client-localfirst-expo/src/docs-snippets.ts#writing-durability-expo

--- a/docs/content/docs/quickstarts/react.mdx
+++ b/docs/content/docs/quickstarts/react.mdx
@@ -108,7 +108,7 @@ Use `db.subscribeAll` (or `db.all`) with a durability tier when you need tier-ga
 
 ### Writing with a durability tier
 
-Use base mutation APIs with `{ tier }` to wait for specific durability tiers:
+Use durable mutation APIs with `{ tier }` to wait for specific durability tiers:
 
 <include cwd lang="ts">
   ../examples/docs/todo-client-localfirst-react/src/docs-snippets.ts#writing-durability-react

--- a/docs/content/docs/quickstarts/svelte.mdx
+++ b/docs/content/docs/quickstarts/svelte.mdx
@@ -108,7 +108,7 @@ Pass a tier as the second argument to `QuerySubscription` to gate initial delive
 
 ### Writing with a durability tier
 
-Use base mutation APIs with `{ tier }` when you need durability guarantees before continuing:
+Use durable mutation APIs with `{ tier }` when you need durability guarantees before continuing:
 
 <include cwd lang="ts">
   ../examples/docs/todo-client-localfirst-svelte/src/TodoList.svelte#writing-durability-svelte

--- a/docs/content/docs/quickstarts/vue.mdx
+++ b/docs/content/docs/quickstarts/vue.mdx
@@ -108,7 +108,7 @@ Use `db.subscribeAll` (or `db.all`) with a durability tier when you need tier-ga
 
 ### Writing with a durability tier
 
-Use base mutation APIs with `{ tier }` to wait for specific durability tiers:
+Use durable mutation APIs with `{ tier }` to wait for specific durability tiers:
 
 <include cwd lang="ts">
   ../examples/docs/todo-client-localfirst-vue/src/docs-snippets.ts#writing-durability-vue

--- a/docs/content/docs/writing-data.mdx
+++ b/docs/content/docs/writing-data.mdx
@@ -7,10 +7,11 @@ import DurabilityTiersTable from "../partials/quickstarts/durability-tiers-table
 
 ## Local-First Writes
 
-`insert`, `update`, and `deleteFrom` apply immediately in the local runtime.
+`insert`, `update`, and `delete` apply immediately in the local runtime.
 That keeps UI latency low because local state updates do not wait for any network hop.
 
-Mutation methods return promises that resolve when the requested durability tier is reached.
+`insertDurable`, `updateDurable`, and `deleteDurable` return promises that
+resolve when the requested durability tier is reached.
 
 ## Mutating from Framework Context
 
@@ -99,9 +100,12 @@ operation the system converges quickly.
 
 ### API Reference
 
-- `insert(table, data, options?)`
-- `update(table, id, data, options?)`
-- `deleteFrom(table, id, options?)`
+- `insert(table, data)`
+- `update(table, id, data)`
+- `delete(table, id)`
+- `insertDurable(table, data, { tier })`
+- `updateDurable(table, id, data, options?)`
+- `deleteDurable(table, id, options?)`
 - `options.tier`: `"worker" | "edge" | "global"`
 
 Defaults:

--- a/docs/content/docs/writing-data.mdx
+++ b/docs/content/docs/writing-data.mdx
@@ -175,10 +175,10 @@ other edge nodes will see it once their edge fetches the update from the global 
 
 ```ts
 // Remote clients will see this eventually — no timing guarantee on delivery
-await db.update(app.tasks, id, { done: true, completedBy: userId });
+db.update(app.tasks, id, { done: true, completedBy: userId });
 
 // Remote clients on this edge see this as soon as the promise resolves
-await db.update(app.tasks, id, { done: true, completedBy: userId }, { tier: "edge" });
+await db.updateDurable(app.tasks, id, { done: true, completedBy: userId }, { tier: "edge" });
 ```
 
 If remote clients are not reacting to a write promptly, check whether the tier is `"edge"` or

--- a/examples/docs/todo-client-localfirst-expo/src/TodoList.tsx
+++ b/examples/docs/todo-client-localfirst-expo/src/TodoList.tsx
@@ -37,19 +37,19 @@ export function TodoList() {
   // #endregion reading-reactive-hooks-expo
 
   // #region writing-use-db-expo
-  const addTodo = async () => {
+  const addTodo = () => {
     const trimmed = title.trim();
     if (!trimmed || !sessionUserId) return;
     db.insert(app.todos, { title: trimmed, done: false, owner_id: sessionUserId });
     setTitle("");
   };
 
-  const toggleTodo = async (todo: Todo) => {
-    await db.update(app.todos, todo.id, { done: !todo.done });
+  const toggleTodo = (todo: Todo) => {
+    db.update(app.todos, todo.id, { done: !todo.done });
   };
 
-  const removeTodo = async (id: string) => {
-    await db.deleteFrom(app.todos, id);
+  const removeTodo = (id: string) => {
+    db.delete(app.todos, id);
   };
   // #endregion writing-use-db-expo
 

--- a/examples/docs/todo-client-localfirst-expo/src/docs-snippets.ts
+++ b/examples/docs/todo-client-localfirst-expo/src/docs-snippets.ts
@@ -110,7 +110,7 @@ export async function writeWithDurabilityTier(db: Db, todoTitle: string) {
     { tier: "worker" },
   );
 
-  await db.update(app.todos, id, { done: true }, { tier: "worker" });
-  await db.deleteFrom(app.todos, id, { tier: "worker" });
+  await db.updateDurable(app.todos, id, { done: true }, { tier: "worker" });
+  await db.deleteDurable(app.todos, id, { tier: "worker" });
 }
 // #endregion writing-durability-expo

--- a/examples/docs/todo-client-localfirst-react/src/ConcurrentTodoList.tsx
+++ b/examples/docs/todo-client-localfirst-react/src/ConcurrentTodoList.tsx
@@ -119,7 +119,7 @@ function ConcurrentTodoResults({
               className="toggle"
             />
             <span>{todo.title}</span>
-            <button className="delete-btn" onClick={() => void db.deleteFrom(app.todos, todo.id)}>
+            <button className="delete-btn" onClick={() => db.delete(app.todos, todo.id)}>
               &times;
             </button>
           </li>

--- a/examples/docs/todo-client-localfirst-react/src/TodoList.tsx
+++ b/examples/docs/todo-client-localfirst-react/src/TodoList.tsx
@@ -16,26 +16,26 @@ export function TodoList() {
   // #endregion reading-filtering-react
 
   // #region writing-use-db-react
-  async function addTodo(todoTitle: string) {
+  function addTodo(todoTitle: string) {
     db.insert(app.todos, { title: todoTitle, done: false });
   }
 
-  async function toggleTodo(todo: { id: string; done: boolean }) {
-    await db.update(app.todos, todo.id, { done: !todo.done });
+  function toggleTodo(todo: { id: string; done: boolean }) {
+    db.update(app.todos, todo.id, { done: !todo.done });
   }
 
-  async function removeTodo(id: string) {
-    await db.deleteFrom(app.todos, id);
+  function removeTodo(id: string) {
+    db.delete(app.todos, id);
   }
   // #endregion writing-use-db-react
   // #endregion read-write-react
 
   const [title, setTitle] = useState("");
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (!title.trim()) return;
-    await addTodo(title.trim());
+    addTodo(title.trim());
     setTitle("");
   };
 

--- a/examples/docs/todo-client-localfirst-react/src/docs-snippets.ts
+++ b/examples/docs/todo-client-localfirst-react/src/docs-snippets.ts
@@ -103,7 +103,7 @@ export async function writeWithDurabilityTier(db: Db, todoTitle: string) {
     { title: todoTitle, done: false },
     { tier: "edge" },
   );
-  await db.update(app.todos, id, { done: true }, { tier: "edge" });
-  await db.deleteFrom(app.todos, id, { tier: "global" });
+  await db.updateDurable(app.todos, id, { done: true }, { tier: "edge" });
+  await db.deleteDurable(app.todos, id, { tier: "global" });
 }
 // #endregion writing-durability-react

--- a/examples/docs/todo-client-localfirst-svelte/src/TodoList.svelte
+++ b/examples/docs/todo-client-localfirst-svelte/src/TodoList.svelte
@@ -22,7 +22,7 @@
 
 	let title = $state('');
 
-	async function handleSubmit(e: SubmitEvent) {
+	function handleSubmit(e: SubmitEvent) {
 		e.preventDefault();
 		if (!title.trim()) return;
 		// #region writing-insert-svelte
@@ -32,20 +32,20 @@
 	}
 
 	// #region writing-mutations-svelte
-	async function toggleTodo(todo: { id: string; done: boolean }) {
-		await db.update(app.todos, todo.id, { done: !todo.done });
+	function toggleTodo(todo: { id: string; done: boolean }) {
+		db.update(app.todos, todo.id, { done: !todo.done });
 	}
 
-	async function removeTodo(id: string) {
-		await db.deleteFrom(app.todos, id);
+	function removeTodo(id: string) {
+		db.delete(app.todos, id);
 	}
 	// #endregion writing-mutations-svelte
 
 	// #region writing-durability-svelte
 	async function addImportantTodo(todoTitle: string) {
 		const { id } = await db.insertDurable(app.todos, { title: todoTitle, done: false }, { tier: 'edge' });
-		await db.update(app.todos, id, { done: true }, { tier: 'edge' });
-		await db.deleteFrom(app.todos, id, { tier: 'global' });
+		await db.updateDurable(app.todos, id, { done: true }, { tier: 'edge' });
+		await db.deleteDurable(app.todos, id, { tier: 'global' });
 	}
 	// #endregion writing-durability-svelte
 </script>

--- a/examples/docs/todo-client-localfirst-ts/src/docs-snippets.ts
+++ b/examples/docs/todo-client-localfirst-ts/src/docs-snippets.ts
@@ -77,8 +77,8 @@ export async function writeTodoCrud(db: Db, todoId: string) {
     owner_id: EXAMPLE_OWNER_ID,
     project: EXAMPLE_PROJECT_ID,
   });
-  await db.update(app.todos, todoId, { done: true });
-  await db.deleteFrom(app.todos, todoId);
+  db.update(app.todos, todoId, { done: true });
+  db.delete(app.todos, todoId);
 }
 // #endregion writing-crud-ts
 
@@ -95,7 +95,7 @@ export async function writeTodoWithDurabilityTiers(db: Db) {
     { tier: "edge" },
   );
 
-  await db.update(app.todos, id, { done: true }, { tier: "global" });
-  await db.deleteFrom(app.todos, id, { tier: "global" });
+  await db.updateDurable(app.todos, id, { done: true }, { tier: "global" });
+  await db.deleteDurable(app.todos, id, { tier: "global" });
 }
 // #endregion writing-durability-tier-ts

--- a/examples/docs/todo-client-localfirst-ts/src/main.ts
+++ b/examples/docs/todo-client-localfirst-ts/src/main.ts
@@ -140,7 +140,7 @@ export async function startApp(
       const checkbox = target as HTMLInputElement;
       db.update(app.todos, id, { done: checkbox.checked });
     } else if (target.classList.contains("delete-btn")) {
-      db.deleteFrom(app.todos, id);
+      db.delete(app.todos, id);
     }
   });
 

--- a/examples/docs/todo-client-localfirst-vue/src/TodoList.vue
+++ b/examples/docs/todo-client-localfirst-vue/src/TodoList.vue
@@ -13,36 +13,40 @@ const incompleteTodos = useAll(app.todos.where({ done: false }).orderBy("title",
 // #endregion reading-filtering-vue
 
 // #region writing-use-db-vue
-async function addTodo(todoTitle: string) {
-  await db.insert(app.todos, { title: todoTitle, done: false });
+function addTodo(todoTitle: string) {
+  db.insert(app.todos, { title: todoTitle, done: false });
 }
 
-async function toggleTodo(todo: { id: string; done: boolean }) {
-  await db.update(app.todos, todo.id, { done: !todo.done });
+function toggleTodo(todo: { id: string; done: boolean }) {
+  db.update(app.todos, todo.id, { done: !todo.done });
 }
 
-async function removeTodo(id: string) {
-  await db.deleteFrom(app.todos, id);
+function removeTodo(id: string) {
+  db.delete(app.todos, id);
 }
 // #endregion writing-use-db-vue
 
 // #region writing-durability-vue
 async function addImportantTodo(todoTitle: string) {
-  const id = await db.insert(app.todos, { title: todoTitle, done: false }, { tier: "edge" });
-  await db.update(app.todos, id, { done: true }, { tier: "edge" });
-  await db.deleteFrom(app.todos, id, { tier: "global" });
+  const { id } = await db.insertDurable(
+    app.todos,
+    { title: todoTitle, done: false },
+    { tier: "edge" },
+  );
+  await db.updateDurable(app.todos, id, { done: true }, { tier: "edge" });
+  await db.deleteDurable(app.todos, id, { tier: "global" });
 }
 // #endregion writing-durability-vue
 
 const title = ref("");
 
-async function handleSubmit(event: SubmitEvent) {
+function handleSubmit(event: SubmitEvent) {
   event.preventDefault();
   if (!title.value.trim()) {
     return;
   }
 
-  await addTodo(title.value.trim());
+  addTodo(title.value.trim());
   title.value = "";
 }
 </script>

--- a/examples/docs/todo-client-localfirst-vue/src/docs-snippets.ts
+++ b/examples/docs/todo-client-localfirst-vue/src/docs-snippets.ts
@@ -81,8 +81,12 @@ export function subscribeTodosAtEdge(db: Db, onCount: (count: number) => void) {
 
 // #region writing-durability-vue
 export async function writeWithDurabilityTier(db: Db, todoTitle: string) {
-  const id = await db.insert(app.todos, { title: todoTitle, done: false }, { tier: "edge" });
-  await db.update(app.todos, id, { done: true }, { tier: "edge" });
-  await db.deleteFrom(app.todos, id, { tier: "global" });
+  const { id } = await db.insertDurable(
+    app.todos,
+    { title: todoTitle, done: false },
+    { tier: "edge" },
+  );
+  await db.updateDurable(app.todos, id, { done: true }, { tier: "edge" });
+  await db.deleteDurable(app.todos, id, { tier: "global" });
 }
 // #endregion writing-durability-vue

--- a/examples/docs/todo-server-ts/src/main.ts
+++ b/examples/docs/todo-server-ts/src/main.ts
@@ -296,7 +296,7 @@ export async function createServer(dataPath?: string): Promise<TodoServer> {
         return;
       }
 
-      await client.update(id, updates);
+      await client.updateDurable(id, updates);
 
       // Fetch updated todo
       const rows = await client.query(schemaApp.todos.where({ id }));
@@ -322,7 +322,7 @@ export async function createServer(dataPath?: string): Promise<TodoServer> {
     try {
       const { id } = req.params;
 
-      await client.delete(id);
+      await client.deleteDurable(id);
       res.status(204).send();
 
       // Notify SSE connections

--- a/examples/todo-client-localfirst-expo/src/TodoList.tsx
+++ b/examples/todo-client-localfirst-expo/src/TodoList.tsx
@@ -49,7 +49,7 @@ export function TodoList() {
           <Text style={[styles.todoTitle, item.done && styles.todoDone]}>{item.title}</Text>
           {item.description ? <Text style={styles.todoDescription}>{item.description}</Text> : null}
         </View>
-        <Pressable onPress={() => db.deleteFrom(app.todos, item.id)} style={styles.deleteButton}>
+        <Pressable onPress={() => db.delete(app.todos, item.id)} style={styles.deleteButton}>
           <Text style={styles.deleteButtonText}>Delete</Text>
         </Pressable>
       </View>

--- a/examples/todo-client-localfirst-react/src/TodoList.tsx
+++ b/examples/todo-client-localfirst-react/src/TodoList.tsx
@@ -71,7 +71,7 @@ export function TodoList() {
             />
             <span>{todo.title}</span>
             {todo.description && <small>{todo.description}</small>}
-            <button className="delete-btn" onClick={() => db.deleteFrom(app.todos, todo.id)}>
+            <button className="delete-btn" onClick={() => db.delete(app.todos, todo.id)}>
               &times;
             </button>
           </li>

--- a/examples/todo-client-localfirst-svelte/src/TodoList.svelte
+++ b/examples/todo-client-localfirst-svelte/src/TodoList.svelte
@@ -40,7 +40,7 @@
 			{#if todo.description}
 				<small>{todo.description}</small>
 			{/if}
-			<button class="delete-btn" onclick={() => db.deleteFrom(app.todos, todo.id)}>
+			<button class="delete-btn" onclick={() => db.delete(app.todos, todo.id)}>
 				&times;
 			</button>
 		</li>

--- a/examples/todo-client-localfirst-ts/src/main.ts
+++ b/examples/todo-client-localfirst-ts/src/main.ts
@@ -170,7 +170,7 @@ export async function startApp(
       const checkbox = target as HTMLInputElement;
       db.update(app.todos, id, { done: checkbox.checked });
     } else if (target.classList.contains("delete-btn")) {
-      db.deleteFrom(app.todos, id);
+      db.delete(app.todos, id);
     }
   });
 

--- a/examples/todo-server-ts/src/main.ts
+++ b/examples/todo-server-ts/src/main.ts
@@ -294,7 +294,7 @@ export async function createServer(dataPath?: string): Promise<TodoServer> {
         return;
       }
 
-      await client.update(id, updates);
+      await client.updateDurable(id, updates);
 
       // Fetch updated todo
       const rows = await client.query(schemaApp.todos.where({ id }));
@@ -320,7 +320,7 @@ export async function createServer(dataPath?: string): Promise<TodoServer> {
     try {
       const { id } = req.params;
 
-      await client.delete(id);
+      await client.deleteDurable(id);
       res.status(204).send();
 
       // Notify SSE connections

--- a/examples/wequencer/README.md
+++ b/examples/wequencer/README.md
@@ -27,7 +27,7 @@ npm run build              # Schema codegen + production build
 
 ## How it works
 
-**State sync** is entirely handled by Jazz. Every beat, instrument change, BPM update, and participant rename is a synchronous local write (`db.insert`, `db.update`, `db.deleteFrom`). Jazz replicates the change to all connected peers in the background. The UI is driven by `QuerySubscription` reactive queries — no polling, no manual state management.
+**State sync** is entirely handled by Jazz. Every beat, instrument change, BPM update, and participant rename is a synchronous local write (`db.insert`, `db.update`, `db.delete`). Jazz replicates the change to all connected peers in the background. The UI is driven by `QuerySubscription` reactive queries — no polling, no manual state management.
 
 **Synchronized playback** is also scheduled through Jazz. All peers need to start their Tone.js transport at exactly the same moment. When a user hits play, a future timestamp (in server epoch time) is written to `jam.transport_start` via Jazz. All peers receive the update, convert it to their local clock using a measured offset, and schedule Tone.js to start at that instant. The offset is tracked by `ClockSync`, which connects to the Jazz WebSocket and computes a smoothed estimate of the difference between local `performance.now()` and server epoch time.
 

--- a/examples/wequencer/src/InstrumentManager.svelte
+++ b/examples/wequencer/src/InstrumentManager.svelte
@@ -31,7 +31,7 @@
 	}
 
 	function removeInstrument(id: string) {
-		db.deleteFrom(app.instruments, id);
+		db.delete(app.instruments, id);
 	}
 </script>
 

--- a/examples/wequencer/src/InstrumentRow.svelte
+++ b/examples/wequencer/src/InstrumentRow.svelte
@@ -30,7 +30,7 @@
   function toggleBeat(index: number) {
     const existing = beatAt(index);
     if (existing) {
-      db.deleteFrom(app.beats, existing.id);
+      db.delete(app.beats, existing.id);
     } else {
       db.insert(app.beats, {
         jam: jamId,

--- a/examples/wequencer/walkthrough/jazz-wequencer.html
+++ b/examples/wequencer/walkthrough/jazz-wequencer.html
@@ -3831,7 +3831,7 @@ img {
                 </tr>
                 <tr>
                   <td>
-                    <code>db.insert</code> / <code>db.update</code> / <code>db.deleteFrom</code>
+                    <code>db.insert</code> / <code>db.update</code> / <code>db.delete</code>
                   </td>
                   <td>Synchronous local writes — sync to edge happens in the background</td>
                 </tr>

--- a/examples/wequencer/walkthrough/jazz-wequencer.md
+++ b/examples/wequencer/walkthrough/jazz-wequencer.md
@@ -219,7 +219,7 @@ function toggleBeat(index: number) {
   const existing = beats.find((b) => b.beat_index === index);
 
   if (existing) {
-    db.deleteFrom(app.beats, existing.id); // remove
+    db.delete(app.beats, existing.id); // remove
   } else {
     db.insert(app.beats, {
       jam: jamId,
@@ -326,12 +326,12 @@ Because `QuerySubscription` watches `app.instruments`, every client's grid grows
 
 ## Jazz API surface — used in Wequencer
 
-| API                                         | Notes                                                                 |
-| ------------------------------------------- | --------------------------------------------------------------------- |
-| `createJazzClient`                          | Initialises WASM worker + OPFS database, begins syncing               |
-| `JazzSvelteProvider`                        | Provides `db` to every component — no prop drilling                   |
-| `getDb()`                                   | Db singleton — callable from any component in the tree                |
-| `getSession()`                              | Current user identity (`user_id`)                                     |
-| `new QuerySubscription(query)`              | **Svelte-specific** — reactive live query, re-renders on every change |
-| `db.insert` / `db.update` / `db.deleteFrom` | Synchronous local writes — sync to edge happens in the background     |
-| `db.all(query, { settledTier: 'edge' })`    | Async read that waits for edge server confirmation before resolving   |
+| API                                      | Notes                                                                 |
+| ---------------------------------------- | --------------------------------------------------------------------- |
+| `createJazzClient`                       | Initialises WASM worker + OPFS database, begins syncing               |
+| `JazzSvelteProvider`                     | Provides `db` to every component — no prop drilling                   |
+| `getDb()`                                | Db singleton — callable from any component in the tree                |
+| `getSession()`                           | Current user identity (`user_id`)                                     |
+| `new QuerySubscription(query)`           | **Svelte-specific** — reactive live query, re-renders on every change |
+| `db.insert` / `db.update` / `db.delete`  | Synchronous local writes — sync to edge happens in the background     |
+| `db.all(query, { settledTier: 'edge' })` | Async read that waits for edge server confirmation before resolving   |

--- a/packages/jazz-tools/bin/docs-index.txt
+++ b/packages/jazz-tools/bin/docs-index.txt
@@ -966,11 +966,11 @@ Use `db.subscribeAll` (or `db.all`) with a durability tier when you need tier-ga
 
 ### Writing with a durability tier
 
-Use base mutation APIs with `{ tier }` when you need explicit write durability acknowledgement before proceeding:
+Use durable mutation APIs with `{ tier }` when you need explicit write durability acknowledgement before proceeding:
 
 ```ts
 
-  const id = await db.insert(
+  const { id } = await db.insertDurable(
     app.todos,
     {
       title: todoTitle,
@@ -981,8 +981,8 @@ Use base mutation APIs with `{ tier }` when you need explicit write durability a
     { tier: "worker" },
   );
 
-  await db.update(app.todos, id, { done: true }, { tier: "worker" });
-  await db.delete(app.todos, id, { tier: "worker" });
+  await db.updateDurable(app.todos, id, { done: true }, { tier: "worker" });
+  await db.deleteDurable(app.todos, id, { tier: "worker" });
 }
 ```
 
@@ -1360,13 +1360,13 @@ Use `db.subscribeAll` (or `db.all`) with a durability tier when you need tier-ga
 
 ### Writing with a durability tier
 
-Use base mutation APIs with `{ tier }` to wait for specific durability tiers:
+Use durable mutation APIs with `{ tier }` to wait for specific durability tiers:
 
 ```ts
 
-  const id = await db.insert(app.todos, { title: todoTitle, done: false }, { tier: "edge" });
-  await db.update(app.todos, id, { done: true }, { tier: "edge" });
-  await db.delete(app.todos, id, { tier: "global" });
+  const { id } = await db.insertDurable(app.todos, { title: todoTitle, done: false }, { tier: "edge" });
+  await db.updateDurable(app.todos, id, { done: true }, { tier: "edge" });
+  await db.deleteDurable(app.todos, id, { tier: "global" });
 }
 ```
 
@@ -1751,9 +1751,9 @@ Deep dive: [Reading Data](/docs/reading-data).
 	}
 
 	async function addImportantTodo(todoTitle: string) {
-		const id = await db.insert(app.todos, { title: todoTitle, done: false }, { tier: 'edge' });
-		await db.update(app.todos, id, { done: true }, { tier: 'edge' });
-		await db.delete(app.todos, id, { tier: 'global' });
+		const { id } = await db.insertDurable(app.todos, { title: todoTitle, done: false }, { tier: 'edge' });
+		await db.updateDurable(app.todos, id, { done: true }, { tier: 'edge' });
+		await db.deleteDurable(app.todos, id, { tier: 'global' });
 	}
 
 </script>
@@ -1805,13 +1805,13 @@ Pass a tier as the second argument to `QuerySubscription` to gate initial delive
 
 ### Writing with a durability tier
 
-Use base mutation APIs with `{ tier }` when you need durability guarantees before continuing:
+Use durable mutation APIs with `{ tier }` when you need durability guarantees before continuing:
 
 ```ts
 	async function addImportantTodo(todoTitle: string) {
-		const id = await db.insert(app.todos, { title: todoTitle, done: false }, { tier: 'edge' });
-		await db.update(app.todos, id, { done: true }, { tier: 'edge' });
-		await db.delete(app.todos, id, { tier: 'global' });
+		const { id } = await db.insertDurable(app.todos, { title: todoTitle, done: false }, { tier: 'edge' });
+		await db.updateDurable(app.todos, id, { done: true }, { tier: 'edge' });
+		await db.deleteDurable(app.todos, id, { tier: 'global' });
 	}
 ```
 
@@ -2395,7 +2395,7 @@ async function toggleTodo(todo: { id: string; done: boolean }) {
 }
 
 async function removeTodo(id: string) {
-  await db.deleteFrom(app.todos, id);
+  db.delete(app.todos, id);
 }
 ```
 
@@ -2424,13 +2424,13 @@ Use `db.subscribeAll` (or `db.all`) with a durability tier when you need tier-ga
 
 ### Writing with a durability tier
 
-Use base mutation APIs with `{ tier }` to wait for specific durability tiers:
+Use durable mutation APIs with `{ tier }` to wait for specific durability tiers:
 
 ```ts
 
-  const id = await db.insert(app.todos, { title: todoTitle, done: false }, { tier: "edge" });
-  await db.update(app.todos, id, { done: true }, { tier: "edge" });
-  await db.deleteFrom(app.todos, id, { tier: "global" });
+  const { id } = await db.insertDurable(app.todos, { title: todoTitle, done: false }, { tier: "edge" });
+  await db.updateDurable(app.todos, id, { done: true }, { tier: "edge" });
+  await db.deleteDurable(app.todos, id, { tier: "global" });
 }
 ```
 
@@ -3364,7 +3364,7 @@ async function toggleTodo(todo: { id: string; done: boolean }) {
 }
 
 async function removeTodo(id: string) {
-  await db.deleteFrom(app.todos, id);
+  db.delete(app.todos, id);
 }
 ```
 
@@ -3487,7 +3487,7 @@ In practical terms:
 
     ```ts
 
-  const id = await db.insert(
+  const { id } = await db.insertDurable(
     app.todos,
     {
       title: "Write docs with durability tier",
@@ -3498,8 +3498,8 @@ In practical terms:
     { tier: "edge" },
   );
 
-  await db.update(app.todos, id, { done: true }, { tier: "global" });
-  await db.delete(app.todos, id, { tier: "global" });
+  await db.updateDurable(app.todos, id, { done: true }, { tier: "global" });
+  await db.deleteDurable(app.todos, id, { tier: "global" });
 }
 ```
 

--- a/packages/jazz-tools/bin/docs-index.txt
+++ b/packages/jazz-tools/bin/docs-index.txt
@@ -938,7 +938,7 @@ Deep dive: [Reading Data](/docs/reading-data).
   };
 
   const removeTodo = async (id: string) => {
-    await db.deleteFrom(app.todos, id);
+    await db.delete(app.todos, id);
   };
 ```
 
@@ -982,7 +982,7 @@ Use base mutation APIs with `{ tier }` when you need explicit write durability a
   );
 
   await db.update(app.todos, id, { done: true }, { tier: "worker" });
-  await db.deleteFrom(app.todos, id, { tier: "worker" });
+  await db.delete(app.todos, id, { tier: "worker" });
 }
 ```
 
@@ -1331,7 +1331,7 @@ Deep dive: [Reading Data](/docs/reading-data).
   }
 
   async function removeTodo(id: string) {
-    await db.deleteFrom(app.todos, id);
+    await db.delete(app.todos, id);
   }
 ```
 
@@ -1366,7 +1366,7 @@ Use base mutation APIs with `{ tier }` to wait for specific durability tiers:
 
   const id = await db.insert(app.todos, { title: todoTitle, done: false }, { tier: "edge" });
   await db.update(app.todos, id, { done: true }, { tier: "edge" });
-  await db.deleteFrom(app.todos, id, { tier: "global" });
+  await db.delete(app.todos, id, { tier: "global" });
 }
 ```
 
@@ -1747,13 +1747,13 @@ Deep dive: [Reading Data](/docs/reading-data).
 	}
 
 	async function removeTodo(id: string) {
-		await db.deleteFrom(app.todos, id);
+		await db.delete(app.todos, id);
 	}
 
 	async function addImportantTodo(todoTitle: string) {
 		const id = await db.insert(app.todos, { title: todoTitle, done: false }, { tier: 'edge' });
 		await db.update(app.todos, id, { done: true }, { tier: 'edge' });
-		await db.deleteFrom(app.todos, id, { tier: 'global' });
+		await db.delete(app.todos, id, { tier: 'global' });
 	}
 
 </script>
@@ -1811,7 +1811,7 @@ Use base mutation APIs with `{ tier }` when you need durability guarantees befor
 	async function addImportantTodo(todoTitle: string) {
 		const id = await db.insert(app.todos, { title: todoTitle, done: false }, { tier: 'edge' });
 		await db.update(app.todos, id, { done: true }, { tier: 'edge' });
-		await db.deleteFrom(app.todos, id, { tier: 'global' });
+		await db.delete(app.todos, id, { tier: 'global' });
 	}
 ```
 
@@ -3331,7 +3331,7 @@ DESCRIPTION:Insert, update, and delete APIs with local-first execution, framewor
 
 ## Local-First Writes
 
-`insert`, `update`, and `deleteFrom` apply immediately in the local runtime.
+`insert`, `update`, and `delete` apply immediately in the local runtime.
 That keeps UI latency low because local state updates do not wait for any network hop.
 
 Mutation methods return promises that resolve when the requested durability tier is reached.
@@ -3350,7 +3350,7 @@ Use the framework context binding to access the shared `Db` instance and execute
   }
 
   async function removeTodo(id: string) {
-    await db.deleteFrom(app.todos, id);
+    await db.delete(app.todos, id);
   }
 ```
 
@@ -3381,7 +3381,7 @@ async function removeTodo(id: string) {
   };
 
   const removeTodo = async (id: string) => {
-    await db.deleteFrom(app.todos, id);
+    await db.delete(app.todos, id);
   };
 ```
 
@@ -3398,7 +3398,7 @@ async function removeTodo(id: string) {
 	}
 
 	async function removeTodo(id: string) {
-		await db.deleteFrom(app.todos, id);
+		await db.delete(app.todos, id);
 	}
 ```
 
@@ -3413,7 +3413,7 @@ async function removeTodo(id: string) {
     project: EXAMPLE_PROJECT_ID,
   });
   await db.update(app.todos, todoId, { done: true });
-  await db.deleteFrom(app.todos, todoId);
+  await db.delete(app.todos, todoId);
 }
 ```
 
@@ -3461,7 +3461,7 @@ Notes:
 
 - `insert(table, data, options?)`
 - `update(table, id, data, options?)`
-- `deleteFrom(table, id, options?)`
+- `delete(table, id, options?)`
 - `options.tier`: `"worker" | "edge" | "global"`
 
 Durability tiers control when the returned promise resolves:
@@ -3499,7 +3499,7 @@ In practical terms:
   );
 
   await db.update(app.todos, id, { done: true }, { tier: "global" });
-  await db.deleteFrom(app.todos, id, { tier: "global" });
+  await db.delete(app.todos, id, { tier: "global" });
 }
 ```
 

--- a/packages/jazz-tools/src/runtime/client.mutations.test.ts
+++ b/packages/jazz-tools/src/runtime/client.mutations.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import { JazzClient, type Runtime } from "./client.js";
+import type { AppContext } from "./context.js";
+
+function makeClient() {
+  const updateCalls: Array<[string, Record<string, unknown>]> = [];
+  const updateDurableCalls: Array<[string, Record<string, unknown>, string]> = [];
+  const deleteCalls: string[] = [];
+  const deleteDurableCalls: Array<[string, string]> = [];
+
+  const runtime: Runtime = {
+    insert: () => ({ id: "00000000-0000-0000-0000-000000000001", values: [] }),
+    insertDurable: async () => ({ id: "00000000-0000-0000-0000-000000000001", values: [] }),
+    update: (objectId: string, updates: Record<string, unknown>) => {
+      updateCalls.push([objectId, updates]);
+    },
+    updateDurable: async (objectId: string, updates: Record<string, unknown>, tier: string) => {
+      updateDurableCalls.push([objectId, updates, tier]);
+    },
+    delete: (objectId: string) => {
+      deleteCalls.push(objectId);
+    },
+    deleteDurable: async (objectId: string, tier: string) => {
+      deleteDurableCalls.push([objectId, tier]);
+    },
+    query: async () => [],
+    subscribe: () => 0,
+    createSubscription: () => 0,
+    executeSubscription: () => {},
+    unsubscribe: () => {},
+    onSyncMessageReceived: () => {},
+    onSyncMessageToSend: () => {},
+    addServer: () => {},
+    removeServer: () => {},
+    addClient: () => "00000000-0000-0000-0000-000000000001",
+    getSchema: () => ({}),
+    getSchemaHash: () => "schema-hash",
+  };
+
+  const context: AppContext = {
+    appId: "test-app",
+    schema: {},
+    serverUrl: "http://localhost:1625",
+    backendSecret: "test-backend-secret",
+  };
+
+  const JazzClientCtor = JazzClient as unknown as {
+    new (
+      runtime: Runtime,
+      context: AppContext,
+      defaultDurabilityTier: "worker" | "edge" | "global",
+    ): JazzClient;
+  };
+
+  return {
+    client: new JazzClientCtor(runtime, context, "edge"),
+    updateCalls,
+    updateDurableCalls,
+    deleteCalls,
+    deleteDurableCalls,
+  };
+}
+
+describe("JazzClient mutation durability split", () => {
+  it("routes update/delete through the synchronous runtime methods", () => {
+    const { client, updateCalls, deleteCalls } = makeClient();
+    const updates = { done: { type: "Boolean" as const, value: true } };
+
+    expect(client.update("row-1", updates)).toBeUndefined();
+    expect(client.delete("row-1")).toBeUndefined();
+
+    expect(updateCalls).toEqual([["row-1", updates]]);
+    expect(deleteCalls).toEqual(["row-1"]);
+  });
+
+  it("routes updateDurable/deleteDurable through durability-aware runtime methods", async () => {
+    const { client, updateDurableCalls, deleteDurableCalls } = makeClient();
+    const updates = { done: { type: "Boolean" as const, value: true } };
+
+    const updatePending = client.updateDurable("row-1", updates);
+    const deletePending = client.deleteDurable("row-1", { tier: "global" });
+
+    expect(updatePending).toBeInstanceOf(Promise);
+    expect(deletePending).toBeInstanceOf(Promise);
+
+    await updatePending;
+    await deletePending;
+
+    expect(updateDurableCalls).toEqual([["row-1", updates, "edge"]]);
+    expect(deleteDurableCalls).toEqual([["row-1", "global"]]);
+  });
+});

--- a/packages/jazz-tools/src/runtime/client.ts
+++ b/packages/jazz-tools/src/runtime/client.ts
@@ -936,9 +936,16 @@ export class JazzClient {
   }
 
   /**
+   * Update a row by ID without waiting for durability.
+   */
+  update(objectId: string, updates: Record<string, Value>): void {
+    this.runtime.update(objectId, updates);
+  }
+
+  /**
    * Update a row by ID and wait for durability at the requested tier.
    */
-  async update(
+  async updateDurable(
     objectId: string,
     updates: Record<string, Value>,
     options?: WriteDurabilityOptions,
@@ -948,9 +955,16 @@ export class JazzClient {
   }
 
   /**
+   * Delete a row by ID without waiting for durability.
+   */
+  delete(objectId: string): void {
+    this.runtime.delete(objectId);
+  }
+
+  /**
    * Delete a row by ID and wait for durability at the requested tier.
    */
-  async delete(objectId: string, options?: WriteDurabilityOptions): Promise<void> {
+  async deleteDurable(objectId: string, options?: WriteDurabilityOptions): Promise<void> {
     const tier = this.resolveWriteTier(options);
     await this.runtime.deleteDurable(objectId, tier);
   }

--- a/packages/jazz-tools/src/runtime/cloud-server.integration.test.ts
+++ b/packages/jazz-tools/src/runtime/cloud-server.integration.test.ts
@@ -1286,7 +1286,11 @@ describe("cloud-server integration (Jazz TS)", () => {
       const createdRow = rowsAfterCreate.find((row) => row.id === rowId);
       expect(createdRow?.values[0]).toEqual({ type: "Text", value: "shared-item" });
 
-      await clientA.update(rowId, { done: { type: "Boolean", value: true } }, { tier: "edge" });
+      await clientA.updateDurable(
+        rowId,
+        { done: { type: "Boolean", value: true } },
+        { tier: "edge" },
+      );
       const rowsAfterUpdate = await waitForRows(clientB, queryAllTodos, (rows) => {
         const row = rows.find((r) => r.id === rowId);
         return Boolean(row && row.values[1]?.type === "Boolean" && row.values[1].value === true);
@@ -1294,7 +1298,7 @@ describe("cloud-server integration (Jazz TS)", () => {
       const updatedRow = rowsAfterUpdate.find((row) => row.id === rowId);
       expect(updatedRow?.values[1]).toEqual({ type: "Boolean", value: true });
 
-      await clientA.delete(rowId, { tier: "edge" });
+      await clientA.deleteDurable(rowId, { tier: "edge" });
       await waitForRows(clientB, queryAllTodos, (rows) => !rows.some((row) => row.id === rowId));
     } finally {
       if (clientA) await clientA.shutdown();

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -6,8 +6,8 @@
  *
  * Key design:
  * - createDb() is async (pre-loads WASM module)
- * - insert is sync (local-first immediate write, no durability wait)
- * - insertDurable/update/deleteFrom are async (durability-aware, return Promises)
+ * - insert/update/delete are sync (local-first immediate writes, no durability wait)
+ * - insertDurable/updateDurable/deleteDurable are async (durability-aware, return Promises)
  * - all/one are async (need storage I/O for queries)
  */
 
@@ -348,8 +348,8 @@ function isLeaderDebugEnabled(): boolean {
  *
  * // Mutations
  * const inserted = db.insert(app.todos, { title: "Buy milk", done: false });
- * await db.update(app.todos, inserted.id, { done: true });
- * await db.deleteFrom(app.todos, inserted.id);
+ * db.update(app.todos, inserted.id, { done: true });
+ * db.delete(app.todos, inserted.id);
  *
  * // Async queries (need storage I/O)
  * const todos = await db.all(app.todos.where({ done: false }));
@@ -1021,9 +1021,18 @@ export class Db {
   }
 
   /**
+   * Update an existing row without waiting for durability.
+   */
+  update<T, Init>(table: TableProxy<T, Init>, id: string, data: Partial<Init>): void {
+    const client = this.getClient(table._schema);
+    const updates = toUpdateRecord(data as Record<string, unknown>, table._schema, table._table);
+    client.update(id, updates);
+  }
+
+  /**
    * Update an existing row and wait for durability at the requested tier.
    */
-  async update<T, Init>(
+  async updateDurable<T, Init>(
     table: TableProxy<T, Init>,
     id: string,
     data: Partial<Init>,
@@ -1037,20 +1046,28 @@ export class Db {
     );
     await this.ensureBridgeReady();
     const updates = toUpdateRecord(data as Record<string, unknown>, inputSchema, table._table);
-    await client.update(id, updates, options);
+    await client.updateDurable(id, updates, options);
+  }
+
+  /**
+   * Delete a row without waiting for durability.
+   */
+  delete<T, Init>(table: TableProxy<T, Init>, id: string): void {
+    const client = this.getClient(table._schema);
+    client.delete(id);
   }
 
   /**
    * Delete a row and wait for durability at the requested tier.
    */
-  async deleteFrom<T, Init>(
+  async deleteDurable<T, Init>(
     table: TableProxy<T, Init>,
     id: string,
     options?: { tier?: DurabilityTier },
   ): Promise<void> {
     const client = this.getClient(table._schema);
     await this.ensureBridgeReady();
-    await client.delete(id, options);
+    await client.deleteDurable(id, options);
   }
 
   /**
@@ -1275,7 +1292,8 @@ function isBrowser(): boolean {
  * Create a new Db instance with the given configuration.
  *
  * This is an **async** factory function that pre-loads the WASM module.
- * After creation, mutations (insert/update/deleteFrom) are async and return Promises.
+ * After creation, local-first mutations (`insert`/`update`/`delete`) are synchronous.
+ * Use the `*Durable` variants when you need a Promise that resolves at a durability tier.
  *
  * In browser environments, automatically uses a dedicated worker for
  * OPFS persistence. In Node.js, uses in-memory storage.

--- a/packages/jazz-tools/src/runtime/value-converter.ts
+++ b/packages/jazz-tools/src/runtime/value-converter.ts
@@ -1,8 +1,8 @@
 /**
  * Convert JS values to WasmValue types for mutations.
  *
- * Used by Db.insert()/Db.insertDurable() and Db.update() to convert typed Init objects
- * into the Value[] format expected by JazzClient.
+ * Used by Db.insert()/Db.insertDurable() and Db.update()/Db.updateDurable()
+ * to convert typed Init objects into the Value[] format expected by JazzClient.
  */
 
 import type { WasmSchema, ColumnType, Value as WasmValue } from "../drivers/types.js";

--- a/packages/jazz-tools/tests/browser/db.subscribeAll.sort.test.ts
+++ b/packages/jazz-tools/tests/browser/db.subscribeAll.sort.test.ts
@@ -226,7 +226,7 @@ describe("db.subscribeAll sorting browser integration", () => {
           "expected initial sorted rows",
         );
 
-        await db.deleteFrom(todos, idB);
+        await db.delete(todos, idB);
 
         await waitForCondition(
           () => {
@@ -480,7 +480,7 @@ describe("db.subscribeAll sorting browser integration", () => {
         );
 
         await db.update(todos, idC, { rank: 0 });
-        await db.deleteFrom(todos, idA);
+        await db.delete(todos, idA);
         const { id: idD } = await db.insert(todos, { title: "D", rank: 2, done: false });
 
         await waitForCondition(
@@ -677,7 +677,7 @@ describe("db.subscribeAll sorting browser integration", () => {
         );
         expect(latestIds(snapshots)).toEqual([idB, idC]);
 
-        await db.deleteFrom(todos, idA);
+        await db.delete(todos, idA);
 
         await waitForCondition(
           () => {

--- a/packages/jazz-tools/tests/browser/realistic-bench.test.ts
+++ b/packages/jazz-tools/tests/browser/realistic-bench.test.ts
@@ -869,7 +869,7 @@ async function runB1(config: ProfileConfig): Promise<ScenarioResult> {
       reportLoopProgress("B1 updates", i, updateCount);
       const taskId = state.taskIds[rng.nextInt(state.taskIds.length)];
       const t0 = performance.now();
-      await db.update(tasksTable, taskId, {
+      db.update(tasksTable, taskId, {
         priority: 1 + rng.nextInt(4),
         status: ["todo", "in_progress", "review", "done"][rng.nextInt(4)],
         updated_at: nowMicros(),
@@ -881,7 +881,7 @@ async function runB1(config: ProfileConfig): Promise<ScenarioResult> {
       reportLoopProgress("B1 deletes", i, deleteCount);
       const id = insertedCommentIds[i];
       const t0 = performance.now();
-      await db.deleteFrom(commentsTable, id);
+      db.delete(commentsTable, id);
       (latencies.delete_sync ||= []).push(performance.now() - t0);
     }
 

--- a/packages/jazz-tools/tests/browser/worker-bridge.test.ts
+++ b/packages/jazz-tools/tests/browser/worker-bridge.test.ts
@@ -454,12 +454,35 @@ describe("Worker Bridge with OPFS", () => {
       }),
     );
 
-    const { id } = await db.insert(todos, { title: "Original", done: false });
-    await db.update(todos, id, { done: true });
+    const { id } = db.insert(todos, { title: "Original", done: false });
+    const result = db.update(todos, id, { done: true });
+    expect(result).toBeUndefined();
 
     const results = await db.all(allTodos);
     expect(results.length).toBe(1);
     expect(results[0].title).toBe("Original");
+    expect(results[0].done).toBe(true);
+  });
+
+  it("updates a row durably", async () => {
+    const db = track(
+      await createDb({
+        appId: "test-app",
+        driver: { type: "persistent", dbName: uniqueDbName("update-durable") },
+      }),
+    );
+
+    const { id } = await db.insertDurable(
+      todos,
+      { title: "Original", done: false },
+      { tier: "worker" },
+    );
+    const pending = db.updateDurable(todos, id, { done: true }, { tier: "worker" });
+    expect(pending).toBeInstanceOf(Promise);
+    await pending;
+
+    const results = await db.all(allTodos, { tier: "worker" });
+    expect(results.length).toBe(1);
     expect(results[0].done).toBe(true);
   });
 
@@ -471,11 +494,35 @@ describe("Worker Bridge with OPFS", () => {
       }),
     );
 
-    const { id } = await db.insert(todos, { title: "Ephemeral", done: false });
+    const { id } = db.insert(todos, { title: "Ephemeral", done: false });
     expect((await db.all(allTodos)).length).toBe(1);
 
-    await db.deleteFrom(todos, id);
+    const result = db.delete(todos, id);
+    expect(result).toBeUndefined();
     const results = await db.all(allTodos);
+    expect(results.length).toBe(0);
+  });
+
+  it("deletes a row durably", async () => {
+    const db = track(
+      await createDb({
+        appId: "test-app",
+        driver: { type: "persistent", dbName: uniqueDbName("delete-durable") },
+      }),
+    );
+
+    const { id } = await db.insertDurable(
+      todos,
+      { title: "Ephemeral", done: false },
+      { tier: "worker" },
+    );
+    expect((await db.all(allTodos, { tier: "worker" })).length).toBe(1);
+
+    const pending = db.deleteDurable(todos, id, { tier: "worker" });
+    expect(pending).toBeInstanceOf(Promise);
+    await pending;
+
+    const results = await db.all(allTodos, { tier: "worker" });
     expect(results.length).toBe(0);
   });
 

--- a/packages/jazz-tools/tests/ts-dsl/insert-api.test.ts
+++ b/packages/jazz-tools/tests/ts-dsl/insert-api.test.ts
@@ -6,7 +6,7 @@ function uniqueDbName(label: string): string {
   return `test-${label}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 }
 
-describe("TS Insert API", () => {
+describe("TS Write API", () => {
   let db: Db;
 
   beforeEach(async () => {
@@ -74,5 +74,81 @@ describe("TS Insert API", () => {
       tags: ["tag1", "tag2"],
       project: project.id,
     });
+  });
+
+  it("updates rows synchronously without returning a promise", async () => {
+    const project = db.insert(app.projects, { name: "Test Project" });
+    const todo = db.insert(app.todos, {
+      title: "Test Todo",
+      done: false,
+      tags: ["tag1", "tag2"],
+      project: project.id,
+    });
+
+    const result = db.update(app.todos, todo.id, { done: true });
+    expect(result).toBeUndefined();
+
+    const [updated] = await db.all(app.todos.where({ id: { eq: todo.id } }));
+    expect(updated.done).toBe(true);
+  });
+
+  it("can wait for updates to be persisted up to a specific durability tier", async () => {
+    const project = db.insert(app.projects, { name: "Test Project" });
+    const todo = db.insert(app.todos, {
+      title: "Test Todo",
+      done: false,
+      tags: ["tag1", "tag2"],
+      project: project.id,
+    });
+
+    const pending = db.updateDurable(app.todos, todo.id, { done: true }, { tier: "worker" });
+    expect(pending).toBeInstanceOf(Promise);
+
+    await pending;
+
+    const [updated] = await db.all(app.todos.where({ id: { eq: todo.id } }), { tier: "worker" });
+    expect(updated.done).toBe(true);
+  });
+
+  it("deletes rows synchronously without returning a promise", async () => {
+    const project = db.insert(app.projects, { name: "Test Project" });
+    const todo = db.insert(app.todos, {
+      title: "Test Todo",
+      done: false,
+      tags: ["tag1", "tag2"],
+      project: project.id,
+    });
+
+    const result = db.delete(app.todos, todo.id);
+    expect(result).toBeUndefined();
+
+    const rows = await db.all(app.todos.where({ id: { eq: todo.id } }));
+    expect(rows).toEqual([]);
+  });
+
+  it("can wait for deletes to be persisted up to a specific durability tier", async () => {
+    const project = await db.insertDurable(
+      app.projects,
+      { name: "Test Project" },
+      { tier: "worker" },
+    );
+    const todo = await db.insertDurable(
+      app.todos,
+      {
+        title: "Test Todo",
+        done: false,
+        tags: ["tag1", "tag2"],
+        project: project.id,
+      },
+      { tier: "worker" },
+    );
+
+    const pending = db.deleteDurable(app.todos, todo.id, { tier: "worker" });
+    expect(pending).toBeInstanceOf(Promise);
+
+    await pending;
+
+    const rows = await db.all(app.todos.where({ id: { eq: todo.id } }), { tier: "worker" });
+    expect(rows).toEqual([]);
   });
 });

--- a/specs/status-quo/browser_adapters.md
+++ b/specs/status-quo/browser_adapters.md
@@ -99,14 +99,14 @@ Current plain TypeScript usage pattern (see `examples/todo-client-localfirst-ts/
 1. Build a `DbConfig` (app/env/branch/auth/tier/server options + optional `driver` mode).
 2. Initialize with `Promise.all([createDb(config), resolveClientSession(config)])`.
 3. Read via `db.all(...)`/`db.one(...)` or `db.subscribeAll(...)`.
-4. Mutate via async local-first APIs (`insert`, `update`, `deleteFrom`) with optional `{ tier }` overrides.
+4. Mutate via local-first APIs (`insert`, `update`, `delete`) or durable variants (`insertDurable`, `updateDurable`, `deleteDurable`) when tiered acknowledgement matters.
 5. Tear down with `db.shutdown()`.
 
 ## Runtime Layers and Responsibilities
 
 1. `Db` (`runtime/db.ts`)
 
-- High-level typed API (`insert`, `update`, `deleteFrom`, `all`, `one`, `subscribeAll`).
+- High-level typed API (`insert`, `update`, `delete`, `insertDurable`, `updateDurable`, `deleteDurable`, `all`, `one`, `subscribeAll`).
 - Creates and memoizes `JazzClient` per schema key.
 - Creates worker + bridge in browser mode.
 - Waits for bridge init before durability-tiered mutations.
@@ -172,7 +172,7 @@ Payloads are JSON strings for sync messages (`payload: string`).
 
 ### 2. Mutation Path
 
-Durability mutation (`insert`, `update`, `deleteFrom` with optional `{ tier }`):
+Durability mutation (`insertDurable`, `updateDurable`, `deleteDurable`):
 
 1. `Db` waits for bridge init (`ensureBridgeReady()`).
 2. Call uses the main-thread `JazzClient` durable mutation API.

--- a/specs/status-quo/ts_client_codegen.md
+++ b/specs/status-quo/ts_client_codegen.md
@@ -126,13 +126,16 @@ In memory mode with `serverUrl`, default durability tier is `edge`.
 - `localUpdates?: "immediate" | "deferred"` (default: `immediate`)
 - `propagation?: "full" | "local-only"` (default `full`)
 
-### Mutations (Async Local-First)
+### Mutations (Local-First + Durable Variants)
 
-- `db.insert(table, data, options?)` — applies local write immediately and resolves with new ID at durability tier
-- `db.update(table, id, data, options?)` — applies local update immediately and resolves at durability tier
-- `db.deleteFrom(table, id, options?)` — applies local delete immediately and resolves at durability tier
+- `db.insert(table, data)` — applies a local write immediately and returns the inserted row
+- `db.update(table, id, data)` — applies a local update immediately and returns `void`
+- `db.delete(table, id)` — applies a local delete immediately and returns `void`
+- `db.insertDurable(table, data, { tier })` — applies a local write immediately and resolves with the inserted row at the requested durability tier
+- `db.updateDurable(table, id, data, options?)` — applies a local update immediately and resolves at the requested durability tier
+- `db.deleteDurable(table, id, options?)` — applies a local delete immediately and resolves at the requested durability tier
 
-`options` supports:
+Durable mutation options support:
 
 - `tier?: "worker" | "edge" | "global"`
 

--- a/specs/todo/a_mvp/durability_tier_api_unification.md
+++ b/specs/todo/a_mvp/durability_tier_api_unification.md
@@ -57,17 +57,26 @@ Default write behavior (`WriteOptions.tier` omitted):
 1. client: `"worker"`
 2. backend: `"edge"`
 
-### Method shape (no suffix variants)
+### Method shape (sync base + durable suffix variants)
 
-Tier options are accepted by base methods:
+Base mutation methods stay synchronous and local-first:
 
-1. `insert(..., options?: WriteOptions): Promise<...>`
-2. `update(..., options?: WriteOptions): Promise<void>`
-3. `deleteFrom(..., options?: WriteOptions): Promise<void>`
-4. `all(..., options?: ReadOptions): Promise<...>`
-5. `one(..., options?: ReadOptions): Promise<...>`
-6. `subscribeAll(..., options?: ReadOptions): () => void`
-7. Client-level `query/subscribe` equivalents take `ReadOptions`.
+1. `insert(...): Row`
+2. `update(...): void`
+3. `delete(...): void`
+
+Durable variants opt into acknowledgement promises:
+
+1. `insertDurable(..., options: WriteOptions): Promise<Row>`
+2. `updateDurable(..., options?: WriteOptions): Promise<void>`
+3. `deleteDurable(..., options?: WriteOptions): Promise<void>`
+
+Read methods continue to accept `ReadOptions`:
+
+1. `all(..., options?: ReadOptions): Promise<...>`
+2. `one(..., options?: ReadOptions): Promise<...>`
+3. `subscribeAll(..., options?: ReadOptions): () => void`
+4. Client-level `query/subscribe` equivalents take `ReadOptions`.
 
 Removed APIs:
 


### PR DESCRIPTION
## Summary
- restack the old `#237` update/delete durability split onto current `main`
- add a dedicated `jazz-tools` changeset for the user-facing API change
- update docs, examples, and browser benchmark call sites that were added after the original stack branch diverged

## Context
The original `#237` shows as merged because it landed on `feat/insert-sync`, but its commits never reached `main`.
This PR cherry-picks that API change onto current `main` and carries the minimum compatibility updates needed for the newer tree.

## API changes
- `db.update(...)` and `db.delete(...)` are now sync local-first writes
- `db.updateDurable(...)` and `db.deleteDurable(...)` are the async durability-aware variants
- `db.deleteFrom(...)` is renamed to `db.delete(...)`

## Validation
- `pnpm --filter jazz-tools exec vitest run --config vitest.config.ts ./src/runtime/client.mutations.test.ts ./tests/ts-dsl/insert-api.test.ts ./src/runtime/cloud-server.integration.test.ts`
- `pnpm --filter jazz-tools exec vitest run --config vitest.config.browser.ts ./tests/browser/worker-bridge.test.ts ./tests/browser/db.subscribeAll.sort.test.ts ./tests/browser/realistic-bench.test.ts`
