### PR TITLE
fix(svelte): avoid stale session on first provider render

### DIFF
--- a/.changeset/svelte-provider-session-order.md
+++ b/.changeset/svelte-provider-session-order.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Fix the Svelte provider so child components only render after both the `db` and `session` context are ready.

--- a/packages/jazz-tools/src/svelte/JazzSvelteProvider.svelte
+++ b/packages/jazz-tools/src/svelte/JazzSvelteProvider.svelte
@@ -13,23 +13,36 @@
 	let { client, children, fallback }: Props = $props();
 
 	const ctx = initJazzContext();
-	let resolvedClient: JazzClient | null = null;
+	let resolvedClient = $state<JazzClient | null>(null);
 	let error = $state<Error | null>(null);
 	let cancelled = false;
 
-	Promise.resolve(client)
-		.then((c) => {
-			if (cancelled) {
-				void c.shutdown();
-				return;
-			}
-			resolvedClient = c;
-			ctx.db = c.db;
-			ctx.session = c.session;
-		})
-		.catch((reason) => {
-			error = reason instanceof Error ? reason : new Error(String(reason));
-		});
+	$effect(() => {
+		let active = true;
+
+		Promise.resolve(client)
+			.then((c) => {
+				if (cancelled || !active) {
+					void c.shutdown();
+					return;
+				}
+				// Publish session before db so child components never observe a ready db
+				// with a stale null session during the first render tick.
+				ctx.session = c.session;
+				ctx.db = c.db;
+				resolvedClient = c;
+			})
+			.catch((reason) => {
+				if (!active) {
+					return;
+				}
+				error = reason instanceof Error ? reason : new Error(String(reason));
+			});
+
+		return () => {
+			active = false;
+		};
+	});
 
 	onDestroy(() => {
 		cancelled = true;
@@ -42,8 +55,8 @@
 {#if error}
 	<!-- Re-throw so an error boundary can catch it -->
 	{(() => { throw error; })()}
-{:else if ctx.db}
-	{@render children({ db: ctx.db })}
+{:else if resolvedClient}
+	{@render children({ db: resolvedClient.db })}
 {:else if fallback}
 	{@render fallback()}
 {/if}

--- a/packages/jazz-tools/tests/browser/fixtures/ProviderSessionConsumer.svelte
+++ b/packages/jazz-tools/tests/browser/fixtures/ProviderSessionConsumer.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+	import type { Db } from '../../../src/runtime/db.js';
+	import { getSession } from '../../../src/svelte/context.svelte.js';
+
+	let { db }: { db: Db } = $props();
+
+	// Mirror the example pattern that captures the initial session value.
+	const session = getSession();
+	const sessionUserId = $derived(session?.user_id ?? 'missing');
+</script>
+
+<div data-testid="db-ready">{db ? 'yes' : 'no'}</div>
+<div data-testid="session-user">{sessionUserId}</div>

--- a/packages/jazz-tools/tests/browser/fixtures/ProviderSessionProbe.svelte
+++ b/packages/jazz-tools/tests/browser/fixtures/ProviderSessionProbe.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+	import JazzSvelteProvider from '../../../src/svelte/JazzSvelteProvider.svelte';
+	import type { JazzClient } from '../../../src/svelte/create-jazz-client.js';
+	import ProviderSessionConsumer from './ProviderSessionConsumer.svelte';
+
+	let { client }: { client: JazzClient | Promise<JazzClient> } = $props();
+</script>
+
+<JazzSvelteProvider {client}>
+	{#snippet children({ db })}
+		<ProviderSessionConsumer {db} />
+	{/snippet}
+</JazzSvelteProvider>

--- a/packages/jazz-tools/tests/browser/svelte-provider.session.test.ts
+++ b/packages/jazz-tools/tests/browser/svelte-provider.session.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { mount, unmount, type Component } from "svelte";
+
+async function waitFor(check: () => boolean, timeoutMs: number, message: string): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (check()) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error(`Timeout: ${message}`);
+}
+
+const mounts: Array<{ instance: Record<string, never>; container: HTMLDivElement }> = [];
+
+afterEach(() => {
+  for (const { instance, container } of mounts) {
+    unmount(instance);
+    container.remove();
+  }
+  mounts.length = 0;
+});
+
+describe("JazzSvelteProvider session readiness", () => {
+  it("does not render children with a stale null session", async () => {
+    const el = document.createElement("div");
+    document.body.appendChild(el);
+
+    const fakeClient = {
+      db: { shutdown: async () => {} },
+      session: { user_id: "user-1", claims: {} },
+      shutdown: async () => {},
+    };
+
+    const { default: ProviderSessionProbe } =
+      await import("./fixtures/ProviderSessionProbe.svelte");
+    const instance = mount(ProviderSessionProbe as Component, {
+      target: el,
+      props: {
+        client: Promise.resolve(fakeClient as never),
+      },
+    });
+    mounts.push({ instance, container: el });
+
+    await waitFor(
+      () => el.querySelector('[data-testid="session-user"]') !== null,
+      2000,
+      "provider child should render",
+    );
+
+    expect(el.querySelector('[data-testid="db-ready"]')?.textContent).toBe("yes");
+    expect(el.querySelector('[data-testid="session-user"]')?.textContent).toBe("user-1");
+  });
+});

--- a/packages/jazz-tools/vitest.config.browser.ts
+++ b/packages/jazz-tools/vitest.config.browser.ts
@@ -3,9 +3,10 @@ import wasm from "vite-plugin-wasm";
 import topLevelAwait from "vite-plugin-top-level-await";
 import { resolve } from "node:path";
 import { playwright } from "@vitest/browser-playwright";
+import { svelte } from "@sveltejs/vite-plugin-svelte";
 
 export default defineConfig({
-  plugins: [wasm(), topLevelAwait()],
+  plugins: [wasm(), topLevelAwait(), svelte({ hot: false })],
   server: {
     fs: {
       allow: [resolve(__dirname, "../..")],


### PR DESCRIPTION
## Summary
- make `JazzSvelteProvider` resolve its client in a reactive effect instead of capturing the initial prop value
- publish `session` before `db` and only render children after the resolved client is ready
- add a browser regression test that mirrors the Svelte todo example's `getSession()` capture pattern

## Context
This is the only clean forward-portable slice I found from [`#243`](https://github.com/garden-co/jazz2/pull/243).
The rest of that branch has already landed on `main` through newer schema-order fixes or is based on older pre-merge API shapes.

## Validation
- `pnpm --filter jazz-tools exec vitest run --config vitest.config.ts ./src/svelte/context.test.ts ./src/svelte/create-jazz-client.test.ts ./src/svelte/use-all.test.ts ./src/svelte/use-link-external-identity.test.ts`
- `pnpm --filter jazz-tools exec vitest run --config vitest.config.browser.ts ./tests/browser/svelte-provider.session.test.ts ./tests/browser/useAll.test.tsx`
- `pnpm format:check`

## Note
`pnpm --filter jazz-tools build` is not reliable in this borrowed-worktree setup because the shared workspace link for `jazz-rn` types is incomplete; I left full build verification to CI.
