### PR TITLE
Add projection-aware select support to TS DSL

### DIFF
--- a/docs/content/docs/reading-data.mdx
+++ b/docs/content/docs/reading-data.mdx
@@ -211,7 +211,7 @@ Schema references used by the include examples:
 - **Availability:** generated TypeScript query builders.
 - **Behavior:** `select(...)` narrows the root row to `id` plus the columns you pick.
 - **With includes:** `include(...)` still works after `select(...)`.
-- **Projecting included rows:** pass a query builder inside `include(...)`, for example `include({ project: app.projects.select("name") })`.
+- **Selecting in included rows:** pass a query builder inside `include(...)`, for example `include({ project: app.projects.select("name") })`.
 
 <include cwd lang="ts">
   ../examples/docs/todo-client-localfirst-ts/src/docs-snippets.ts#reading-select-ts

--- a/docs/content/docs/reading-data.mdx
+++ b/docs/content/docs/reading-data.mdx
@@ -204,6 +204,19 @@ Schema references used by the include examples:
   </Tab>
 </Tabs>
 
+## Picking Columns via select
+
+### API Reference
+
+- **Availability:** generated TypeScript query builders.
+- **Behavior:** `select(...)` narrows the root row to `id` plus the columns you pick.
+- **With includes:** `include(...)` still works after `select(...)`.
+- **Projecting included rows:** pass a query builder inside `include(...)`, for example `include({ project: app.projects.select("name") })`.
+
+<include cwd lang="ts">
+  ../examples/docs/todo-client-localfirst-ts/src/docs-snippets.ts#reading-select-ts
+</include>
+
 ## Advanced: Recursive Queries
 
 Recursive queries compute bounded transitive closures from a seed row set.

--- a/examples/docs/todo-client-localfirst-react/schema/app.ts
+++ b/examples/docs/todo-client-localfirst-react/schema/app.ts
@@ -72,8 +72,11 @@ export type ProjectWithIncludes<I extends ProjectInclude = {}> = Project & {
   todosViaProject?: NonNullable<I["todosViaProject"]> extends infer RelationInclude
     ? RelationInclude extends true
       ? Todo[]
-      : RelationInclude extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
-        ? TodoWithIncludes<QueryInclude>[]
+      : RelationInclude extends TodoQueryBuilder<
+            infer QueryInclude extends TodoInclude,
+            infer QuerySelect extends keyof Todo
+          >
+        ? TodoSelectedWithIncludes<QueryInclude, QuerySelect>[]
         : RelationInclude extends TodoInclude
           ? TodoWithIncludes<RelationInclude>[]
           : never
@@ -84,8 +87,11 @@ export type TodoWithIncludes<I extends TodoInclude = {}> = Todo & {
   parent?: NonNullable<I["parent"]> extends infer RelationInclude
     ? RelationInclude extends true
       ? Todo
-      : RelationInclude extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
-        ? TodoWithIncludes<QueryInclude>
+      : RelationInclude extends TodoQueryBuilder<
+            infer QueryInclude extends TodoInclude,
+            infer QuerySelect extends keyof Todo
+          >
+        ? TodoSelectedWithIncludes<QueryInclude, QuerySelect>
         : RelationInclude extends TodoInclude
           ? TodoWithIncludes<RelationInclude>
           : never
@@ -93,8 +99,11 @@ export type TodoWithIncludes<I extends TodoInclude = {}> = Todo & {
   todosViaParent?: NonNullable<I["todosViaParent"]> extends infer RelationInclude
     ? RelationInclude extends true
       ? Todo[]
-      : RelationInclude extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
-        ? TodoWithIncludes<QueryInclude>[]
+      : RelationInclude extends TodoQueryBuilder<
+            infer QueryInclude extends TodoInclude,
+            infer QuerySelect extends keyof Todo
+          >
+        ? TodoSelectedWithIncludes<QueryInclude, QuerySelect>[]
         : RelationInclude extends TodoInclude
           ? TodoWithIncludes<RelationInclude>[]
           : never
@@ -102,13 +111,36 @@ export type TodoWithIncludes<I extends TodoInclude = {}> = Todo & {
   project?: NonNullable<I["project"]> extends infer RelationInclude
     ? RelationInclude extends true
       ? Project
-      : RelationInclude extends ProjectQueryBuilder<infer QueryInclude extends ProjectInclude>
-        ? ProjectWithIncludes<QueryInclude>
+      : RelationInclude extends ProjectQueryBuilder<
+            infer QueryInclude extends ProjectInclude,
+            infer QuerySelect extends keyof Project
+          >
+        ? ProjectSelectedWithIncludes<QueryInclude, QuerySelect>
         : RelationInclude extends ProjectInclude
           ? ProjectWithIncludes<RelationInclude>
           : never
     : never;
 };
+
+export type ProjectSelected<S extends keyof Project = keyof Project> = Pick<
+  Project,
+  Extract<S | "id", keyof Project>
+>;
+
+export type ProjectSelectedWithIncludes<
+  I extends ProjectInclude = {},
+  S extends keyof Project = keyof Project,
+> = ProjectSelected<S> & Omit<ProjectWithIncludes<I>, keyof Project>;
+
+export type TodoSelected<S extends keyof Todo = keyof Todo> = Pick<
+  Todo,
+  Extract<S | "id", keyof Todo>
+>;
+
+export type TodoSelectedWithIncludes<
+  I extends TodoInclude = {},
+  S extends keyof Todo = keyof Todo,
+> = TodoSelected<S> & Omit<TodoWithIncludes<I>, keyof Todo>;
 
 export const wasmSchema: WasmSchema = {
   projects: {
@@ -217,15 +249,17 @@ export const wasmSchema: WasmSchema = {
   },
 };
 
-export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements QueryBuilder<
-  ProjectWithIncludes<I>
-> {
+export class ProjectQueryBuilder<
+  I extends ProjectInclude = {},
+  S extends keyof Project = keyof Project,
+> implements QueryBuilder<ProjectSelectedWithIncludes<I, S>> {
   readonly _table = "projects";
   readonly _schema: WasmSchema = wasmSchema;
-  declare readonly _rowType: ProjectWithIncludes<I>;
+  declare readonly _rowType: ProjectSelectedWithIncludes<I, S>;
   declare readonly _initType: ProjectInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<ProjectInclude> = {};
+  private _selectColumns?: string[];
   private _orderBys: Array<[string, "asc" | "desc"]> = [];
   private _limitVal?: number;
   private _offsetVal?: number;
@@ -238,7 +272,7 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
     step_hops: string[];
   };
 
-  where(conditions: ProjectWhereInput): ProjectQueryBuilder<I> {
+  where(conditions: ProjectWhereInput): ProjectQueryBuilder<I, S> {
     const clone = this._clone();
     for (const [key, value] of Object.entries(conditions)) {
       if (value === undefined) continue;
@@ -255,31 +289,37 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
     return clone;
   }
 
-  include<NewI extends ProjectInclude>(relations: NewI): ProjectQueryBuilder<I & NewI> {
-    const clone = this._clone<I & NewI>();
+  select<NewS extends keyof Project>(...columns: [NewS, ...NewS[]]): ProjectQueryBuilder<I, NewS> {
+    const clone = this._clone<I, NewS>();
+    clone._selectColumns = [...columns] as string[];
+    return clone;
+  }
+
+  include<NewI extends ProjectInclude>(relations: NewI): ProjectQueryBuilder<I & NewI, S> {
+    const clone = this._clone<I & NewI, S>();
     clone._includes = { ...this._includes, ...relations };
     return clone;
   }
 
-  orderBy(column: keyof Project, direction: "asc" | "desc" = "asc"): ProjectQueryBuilder<I> {
+  orderBy(column: keyof Project, direction: "asc" | "desc" = "asc"): ProjectQueryBuilder<I, S> {
     const clone = this._clone();
     clone._orderBys.push([column as string, direction]);
     return clone;
   }
 
-  limit(n: number): ProjectQueryBuilder<I> {
+  limit(n: number): ProjectQueryBuilder<I, S> {
     const clone = this._clone();
     clone._limitVal = n;
     return clone;
   }
 
-  offset(n: number): ProjectQueryBuilder<I> {
+  offset(n: number): ProjectQueryBuilder<I, S> {
     const clone = this._clone();
     clone._offsetVal = n;
     return clone;
   }
 
-  hopTo(relation: "todosViaProject"): ProjectQueryBuilder<I> {
+  hopTo(relation: "todosViaProject"): ProjectQueryBuilder<I, S> {
     const clone = this._clone();
     clone._hops.push(relation);
     return clone;
@@ -289,7 +329,7 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
     start: ProjectWhereInput;
     step: (ctx: { current: string }) => QueryBuilder<unknown>;
     maxDepth?: number;
-  }): ProjectQueryBuilder<I> {
+  }): ProjectQueryBuilder<I, S> {
     if (options.start === undefined) {
       throw new Error("gather(...) requires start where conditions.");
     }
@@ -371,6 +411,7 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
       table: this._table,
       conditions: this._conditions,
       includes: this._includes,
+      select: this._selectColumns,
       orderBy: this._orderBys,
       limit: this._limitVal,
       offset: this._offsetVal,
@@ -379,10 +420,14 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
     });
   }
 
-  private _clone<CloneI extends ProjectInclude = I>(): ProjectQueryBuilder<CloneI> {
-    const clone = new ProjectQueryBuilder<CloneI>();
+  private _clone<
+    CloneI extends ProjectInclude = I,
+    CloneS extends keyof Project = S,
+  >(): ProjectQueryBuilder<CloneI, CloneS> {
+    const clone = new ProjectQueryBuilder<CloneI, CloneS>();
     clone._conditions = [...this._conditions];
     clone._includes = { ...this._includes };
+    clone._selectColumns = this._selectColumns ? [...this._selectColumns] : undefined;
     clone._orderBys = [...this._orderBys];
     clone._limitVal = this._limitVal;
     clone._offsetVal = this._offsetVal;
@@ -398,15 +443,17 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
   }
 }
 
-export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilder<
-  TodoWithIncludes<I>
-> {
+export class TodoQueryBuilder<
+  I extends TodoInclude = {},
+  S extends keyof Todo = keyof Todo,
+> implements QueryBuilder<TodoSelectedWithIncludes<I, S>> {
   readonly _table = "todos";
   readonly _schema: WasmSchema = wasmSchema;
-  declare readonly _rowType: TodoWithIncludes<I>;
+  declare readonly _rowType: TodoSelectedWithIncludes<I, S>;
   declare readonly _initType: TodoInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<TodoInclude> = {};
+  private _selectColumns?: string[];
   private _orderBys: Array<[string, "asc" | "desc"]> = [];
   private _limitVal?: number;
   private _offsetVal?: number;
@@ -419,7 +466,7 @@ export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilde
     step_hops: string[];
   };
 
-  where(conditions: TodoWhereInput): TodoQueryBuilder<I> {
+  where(conditions: TodoWhereInput): TodoQueryBuilder<I, S> {
     const clone = this._clone();
     for (const [key, value] of Object.entries(conditions)) {
       if (value === undefined) continue;
@@ -436,31 +483,37 @@ export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilde
     return clone;
   }
 
-  include<NewI extends TodoInclude>(relations: NewI): TodoQueryBuilder<I & NewI> {
-    const clone = this._clone<I & NewI>();
+  select<NewS extends keyof Todo>(...columns: [NewS, ...NewS[]]): TodoQueryBuilder<I, NewS> {
+    const clone = this._clone<I, NewS>();
+    clone._selectColumns = [...columns] as string[];
+    return clone;
+  }
+
+  include<NewI extends TodoInclude>(relations: NewI): TodoQueryBuilder<I & NewI, S> {
+    const clone = this._clone<I & NewI, S>();
     clone._includes = { ...this._includes, ...relations };
     return clone;
   }
 
-  orderBy(column: keyof Todo, direction: "asc" | "desc" = "asc"): TodoQueryBuilder<I> {
+  orderBy(column: keyof Todo, direction: "asc" | "desc" = "asc"): TodoQueryBuilder<I, S> {
     const clone = this._clone();
     clone._orderBys.push([column as string, direction]);
     return clone;
   }
 
-  limit(n: number): TodoQueryBuilder<I> {
+  limit(n: number): TodoQueryBuilder<I, S> {
     const clone = this._clone();
     clone._limitVal = n;
     return clone;
   }
 
-  offset(n: number): TodoQueryBuilder<I> {
+  offset(n: number): TodoQueryBuilder<I, S> {
     const clone = this._clone();
     clone._offsetVal = n;
     return clone;
   }
 
-  hopTo(relation: "parent" | "todosViaParent" | "project"): TodoQueryBuilder<I> {
+  hopTo(relation: "parent" | "todosViaParent" | "project"): TodoQueryBuilder<I, S> {
     const clone = this._clone();
     clone._hops.push(relation);
     return clone;
@@ -470,7 +523,7 @@ export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilde
     start: TodoWhereInput;
     step: (ctx: { current: string }) => QueryBuilder<unknown>;
     maxDepth?: number;
-  }): TodoQueryBuilder<I> {
+  }): TodoQueryBuilder<I, S> {
     if (options.start === undefined) {
       throw new Error("gather(...) requires start where conditions.");
     }
@@ -552,6 +605,7 @@ export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilde
       table: this._table,
       conditions: this._conditions,
       includes: this._includes,
+      select: this._selectColumns,
       orderBy: this._orderBys,
       limit: this._limitVal,
       offset: this._offsetVal,
@@ -560,10 +614,14 @@ export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilde
     });
   }
 
-  private _clone<CloneI extends TodoInclude = I>(): TodoQueryBuilder<CloneI> {
-    const clone = new TodoQueryBuilder<CloneI>();
+  private _clone<CloneI extends TodoInclude = I, CloneS extends keyof Todo = S>(): TodoQueryBuilder<
+    CloneI,
+    CloneS
+  > {
+    const clone = new TodoQueryBuilder<CloneI, CloneS>();
     clone._conditions = [...this._conditions];
     clone._includes = { ...this._includes };
+    clone._selectColumns = this._selectColumns ? [...this._selectColumns] : undefined;
     clone._orderBys = [...this._orderBys];
     clone._limitVal = this._limitVal;
     clone._offsetVal = this._offsetVal;

--- a/examples/docs/todo-client-localfirst-svelte/schema/app.ts
+++ b/examples/docs/todo-client-localfirst-svelte/schema/app.ts
@@ -72,8 +72,11 @@ export type ProjectWithIncludes<I extends ProjectInclude = {}> = Project & {
   todosViaProject?: NonNullable<I["todosViaProject"]> extends infer RelationInclude
     ? RelationInclude extends true
       ? Todo[]
-      : RelationInclude extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
-        ? TodoWithIncludes<QueryInclude>[]
+      : RelationInclude extends TodoQueryBuilder<
+            infer QueryInclude extends TodoInclude,
+            infer QuerySelect extends keyof Todo
+          >
+        ? TodoSelectedWithIncludes<QueryInclude, QuerySelect>[]
         : RelationInclude extends TodoInclude
           ? TodoWithIncludes<RelationInclude>[]
           : never
@@ -84,8 +87,11 @@ export type TodoWithIncludes<I extends TodoInclude = {}> = Todo & {
   parent?: NonNullable<I["parent"]> extends infer RelationInclude
     ? RelationInclude extends true
       ? Todo
-      : RelationInclude extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
-        ? TodoWithIncludes<QueryInclude>
+      : RelationInclude extends TodoQueryBuilder<
+            infer QueryInclude extends TodoInclude,
+            infer QuerySelect extends keyof Todo
+          >
+        ? TodoSelectedWithIncludes<QueryInclude, QuerySelect>
         : RelationInclude extends TodoInclude
           ? TodoWithIncludes<RelationInclude>
           : never
@@ -93,8 +99,11 @@ export type TodoWithIncludes<I extends TodoInclude = {}> = Todo & {
   todosViaParent?: NonNullable<I["todosViaParent"]> extends infer RelationInclude
     ? RelationInclude extends true
       ? Todo[]
-      : RelationInclude extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
-        ? TodoWithIncludes<QueryInclude>[]
+      : RelationInclude extends TodoQueryBuilder<
+            infer QueryInclude extends TodoInclude,
+            infer QuerySelect extends keyof Todo
+          >
+        ? TodoSelectedWithIncludes<QueryInclude, QuerySelect>[]
         : RelationInclude extends TodoInclude
           ? TodoWithIncludes<RelationInclude>[]
           : never
@@ -102,13 +111,36 @@ export type TodoWithIncludes<I extends TodoInclude = {}> = Todo & {
   project?: NonNullable<I["project"]> extends infer RelationInclude
     ? RelationInclude extends true
       ? Project
-      : RelationInclude extends ProjectQueryBuilder<infer QueryInclude extends ProjectInclude>
-        ? ProjectWithIncludes<QueryInclude>
+      : RelationInclude extends ProjectQueryBuilder<
+            infer QueryInclude extends ProjectInclude,
+            infer QuerySelect extends keyof Project
+          >
+        ? ProjectSelectedWithIncludes<QueryInclude, QuerySelect>
         : RelationInclude extends ProjectInclude
           ? ProjectWithIncludes<RelationInclude>
           : never
     : never;
 };
+
+export type ProjectSelected<S extends keyof Project = keyof Project> = Pick<
+  Project,
+  Extract<S | "id", keyof Project>
+>;
+
+export type ProjectSelectedWithIncludes<
+  I extends ProjectInclude = {},
+  S extends keyof Project = keyof Project,
+> = ProjectSelected<S> & Omit<ProjectWithIncludes<I>, keyof Project>;
+
+export type TodoSelected<S extends keyof Todo = keyof Todo> = Pick<
+  Todo,
+  Extract<S | "id", keyof Todo>
+>;
+
+export type TodoSelectedWithIncludes<
+  I extends TodoInclude = {},
+  S extends keyof Todo = keyof Todo,
+> = TodoSelected<S> & Omit<TodoWithIncludes<I>, keyof Todo>;
 
 export const wasmSchema: WasmSchema = {
   projects: {
@@ -217,15 +249,17 @@ export const wasmSchema: WasmSchema = {
   },
 };
 
-export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements QueryBuilder<
-  ProjectWithIncludes<I>
-> {
+export class ProjectQueryBuilder<
+  I extends ProjectInclude = {},
+  S extends keyof Project = keyof Project,
+> implements QueryBuilder<ProjectSelectedWithIncludes<I, S>> {
   readonly _table = "projects";
   readonly _schema: WasmSchema = wasmSchema;
-  declare readonly _rowType: ProjectWithIncludes<I>;
+  declare readonly _rowType: ProjectSelectedWithIncludes<I, S>;
   declare readonly _initType: ProjectInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<ProjectInclude> = {};
+  private _selectColumns?: string[];
   private _orderBys: Array<[string, "asc" | "desc"]> = [];
   private _limitVal?: number;
   private _offsetVal?: number;
@@ -238,7 +272,7 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
     step_hops: string[];
   };
 
-  where(conditions: ProjectWhereInput): ProjectQueryBuilder<I> {
+  where(conditions: ProjectWhereInput): ProjectQueryBuilder<I, S> {
     const clone = this._clone();
     for (const [key, value] of Object.entries(conditions)) {
       if (value === undefined) continue;
@@ -255,31 +289,37 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
     return clone;
   }
 
-  include<NewI extends ProjectInclude>(relations: NewI): ProjectQueryBuilder<I & NewI> {
-    const clone = this._clone<I & NewI>();
+  select<NewS extends keyof Project>(...columns: [NewS, ...NewS[]]): ProjectQueryBuilder<I, NewS> {
+    const clone = this._clone<I, NewS>();
+    clone._selectColumns = [...columns] as string[];
+    return clone;
+  }
+
+  include<NewI extends ProjectInclude>(relations: NewI): ProjectQueryBuilder<I & NewI, S> {
+    const clone = this._clone<I & NewI, S>();
     clone._includes = { ...this._includes, ...relations };
     return clone;
   }
 
-  orderBy(column: keyof Project, direction: "asc" | "desc" = "asc"): ProjectQueryBuilder<I> {
+  orderBy(column: keyof Project, direction: "asc" | "desc" = "asc"): ProjectQueryBuilder<I, S> {
     const clone = this._clone();
     clone._orderBys.push([column as string, direction]);
     return clone;
   }
 
-  limit(n: number): ProjectQueryBuilder<I> {
+  limit(n: number): ProjectQueryBuilder<I, S> {
     const clone = this._clone();
     clone._limitVal = n;
     return clone;
   }
 
-  offset(n: number): ProjectQueryBuilder<I> {
+  offset(n: number): ProjectQueryBuilder<I, S> {
     const clone = this._clone();
     clone._offsetVal = n;
     return clone;
   }
 
-  hopTo(relation: "todosViaProject"): ProjectQueryBuilder<I> {
+  hopTo(relation: "todosViaProject"): ProjectQueryBuilder<I, S> {
     const clone = this._clone();
     clone._hops.push(relation);
     return clone;
@@ -289,7 +329,7 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
     start: ProjectWhereInput;
     step: (ctx: { current: string }) => QueryBuilder<unknown>;
     maxDepth?: number;
-  }): ProjectQueryBuilder<I> {
+  }): ProjectQueryBuilder<I, S> {
     if (options.start === undefined) {
       throw new Error("gather(...) requires start where conditions.");
     }
@@ -371,6 +411,7 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
       table: this._table,
       conditions: this._conditions,
       includes: this._includes,
+      select: this._selectColumns,
       orderBy: this._orderBys,
       limit: this._limitVal,
       offset: this._offsetVal,
@@ -379,10 +420,14 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
     });
   }
 
-  private _clone<CloneI extends ProjectInclude = I>(): ProjectQueryBuilder<CloneI> {
-    const clone = new ProjectQueryBuilder<CloneI>();
+  private _clone<
+    CloneI extends ProjectInclude = I,
+    CloneS extends keyof Project = S,
+  >(): ProjectQueryBuilder<CloneI, CloneS> {
+    const clone = new ProjectQueryBuilder<CloneI, CloneS>();
     clone._conditions = [...this._conditions];
     clone._includes = { ...this._includes };
+    clone._selectColumns = this._selectColumns ? [...this._selectColumns] : undefined;
     clone._orderBys = [...this._orderBys];
     clone._limitVal = this._limitVal;
     clone._offsetVal = this._offsetVal;
@@ -398,15 +443,17 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
   }
 }
 
-export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilder<
-  TodoWithIncludes<I>
-> {
+export class TodoQueryBuilder<
+  I extends TodoInclude = {},
+  S extends keyof Todo = keyof Todo,
+> implements QueryBuilder<TodoSelectedWithIncludes<I, S>> {
   readonly _table = "todos";
   readonly _schema: WasmSchema = wasmSchema;
-  declare readonly _rowType: TodoWithIncludes<I>;
+  declare readonly _rowType: TodoSelectedWithIncludes<I, S>;
   declare readonly _initType: TodoInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<TodoInclude> = {};
+  private _selectColumns?: string[];
   private _orderBys: Array<[string, "asc" | "desc"]> = [];
   private _limitVal?: number;
   private _offsetVal?: number;
@@ -419,7 +466,7 @@ export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilde
     step_hops: string[];
   };
 
-  where(conditions: TodoWhereInput): TodoQueryBuilder<I> {
+  where(conditions: TodoWhereInput): TodoQueryBuilder<I, S> {
     const clone = this._clone();
     for (const [key, value] of Object.entries(conditions)) {
       if (value === undefined) continue;
@@ -436,31 +483,37 @@ export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilde
     return clone;
   }
 
-  include<NewI extends TodoInclude>(relations: NewI): TodoQueryBuilder<I & NewI> {
-    const clone = this._clone<I & NewI>();
+  select<NewS extends keyof Todo>(...columns: [NewS, ...NewS[]]): TodoQueryBuilder<I, NewS> {
+    const clone = this._clone<I, NewS>();
+    clone._selectColumns = [...columns] as string[];
+    return clone;
+  }
+
+  include<NewI extends TodoInclude>(relations: NewI): TodoQueryBuilder<I & NewI, S> {
+    const clone = this._clone<I & NewI, S>();
     clone._includes = { ...this._includes, ...relations };
     return clone;
   }
 
-  orderBy(column: keyof Todo, direction: "asc" | "desc" = "asc"): TodoQueryBuilder<I> {
+  orderBy(column: keyof Todo, direction: "asc" | "desc" = "asc"): TodoQueryBuilder<I, S> {
     const clone = this._clone();
     clone._orderBys.push([column as string, direction]);
     return clone;
   }
 
-  limit(n: number): TodoQueryBuilder<I> {
+  limit(n: number): TodoQueryBuilder<I, S> {
     const clone = this._clone();
     clone._limitVal = n;
     return clone;
   }
 
-  offset(n: number): TodoQueryBuilder<I> {
+  offset(n: number): TodoQueryBuilder<I, S> {
     const clone = this._clone();
     clone._offsetVal = n;
     return clone;
   }
 
-  hopTo(relation: "parent" | "todosViaParent" | "project"): TodoQueryBuilder<I> {
+  hopTo(relation: "parent" | "todosViaParent" | "project"): TodoQueryBuilder<I, S> {
     const clone = this._clone();
     clone._hops.push(relation);
     return clone;
@@ -470,7 +523,7 @@ export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilde
     start: TodoWhereInput;
     step: (ctx: { current: string }) => QueryBuilder<unknown>;
     maxDepth?: number;
-  }): TodoQueryBuilder<I> {
+  }): TodoQueryBuilder<I, S> {
     if (options.start === undefined) {
       throw new Error("gather(...) requires start where conditions.");
     }
@@ -552,6 +605,7 @@ export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilde
       table: this._table,
       conditions: this._conditions,
       includes: this._includes,
+      select: this._selectColumns,
       orderBy: this._orderBys,
       limit: this._limitVal,
       offset: this._offsetVal,
@@ -560,10 +614,14 @@ export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilde
     });
   }
 
-  private _clone<CloneI extends TodoInclude = I>(): TodoQueryBuilder<CloneI> {
-    const clone = new TodoQueryBuilder<CloneI>();
+  private _clone<CloneI extends TodoInclude = I, CloneS extends keyof Todo = S>(): TodoQueryBuilder<
+    CloneI,
+    CloneS
+  > {
+    const clone = new TodoQueryBuilder<CloneI, CloneS>();
     clone._conditions = [...this._conditions];
     clone._includes = { ...this._includes };
+    clone._selectColumns = this._selectColumns ? [...this._selectColumns] : undefined;
     clone._orderBys = [...this._orderBys];
     clone._limitVal = this._limitVal;
     clone._offsetVal = this._offsetVal;

--- a/examples/docs/todo-client-localfirst-ts/schema/app.ts
+++ b/examples/docs/todo-client-localfirst-ts/schema/app.ts
@@ -72,8 +72,11 @@ export type ProjectWithIncludes<I extends ProjectInclude = {}> = Project & {
   todosViaProject?: NonNullable<I["todosViaProject"]> extends infer RelationInclude
     ? RelationInclude extends true
       ? Todo[]
-      : RelationInclude extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
-        ? TodoWithIncludes<QueryInclude>[]
+      : RelationInclude extends TodoQueryBuilder<
+            infer QueryInclude extends TodoInclude,
+            infer QuerySelect extends keyof Todo
+          >
+        ? TodoSelectedWithIncludes<QueryInclude, QuerySelect>[]
         : RelationInclude extends TodoInclude
           ? TodoWithIncludes<RelationInclude>[]
           : never
@@ -84,8 +87,11 @@ export type TodoWithIncludes<I extends TodoInclude = {}> = Todo & {
   parent?: NonNullable<I["parent"]> extends infer RelationInclude
     ? RelationInclude extends true
       ? Todo
-      : RelationInclude extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
-        ? TodoWithIncludes<QueryInclude>
+      : RelationInclude extends TodoQueryBuilder<
+            infer QueryInclude extends TodoInclude,
+            infer QuerySelect extends keyof Todo
+          >
+        ? TodoSelectedWithIncludes<QueryInclude, QuerySelect>
         : RelationInclude extends TodoInclude
           ? TodoWithIncludes<RelationInclude>
           : never
@@ -93,8 +99,11 @@ export type TodoWithIncludes<I extends TodoInclude = {}> = Todo & {
   todosViaParent?: NonNullable<I["todosViaParent"]> extends infer RelationInclude
     ? RelationInclude extends true
       ? Todo[]
-      : RelationInclude extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
-        ? TodoWithIncludes<QueryInclude>[]
+      : RelationInclude extends TodoQueryBuilder<
+            infer QueryInclude extends TodoInclude,
+            infer QuerySelect extends keyof Todo
+          >
+        ? TodoSelectedWithIncludes<QueryInclude, QuerySelect>[]
         : RelationInclude extends TodoInclude
           ? TodoWithIncludes<RelationInclude>[]
           : never
@@ -102,13 +111,36 @@ export type TodoWithIncludes<I extends TodoInclude = {}> = Todo & {
   project?: NonNullable<I["project"]> extends infer RelationInclude
     ? RelationInclude extends true
       ? Project
-      : RelationInclude extends ProjectQueryBuilder<infer QueryInclude extends ProjectInclude>
-        ? ProjectWithIncludes<QueryInclude>
+      : RelationInclude extends ProjectQueryBuilder<
+            infer QueryInclude extends ProjectInclude,
+            infer QuerySelect extends keyof Project
+          >
+        ? ProjectSelectedWithIncludes<QueryInclude, QuerySelect>
         : RelationInclude extends ProjectInclude
           ? ProjectWithIncludes<RelationInclude>
           : never
     : never;
 };
+
+export type ProjectSelected<S extends keyof Project = keyof Project> = Pick<
+  Project,
+  Extract<S | "id", keyof Project>
+>;
+
+export type ProjectSelectedWithIncludes<
+  I extends ProjectInclude = {},
+  S extends keyof Project = keyof Project,
+> = ProjectSelected<S> & Omit<ProjectWithIncludes<I>, keyof Project>;
+
+export type TodoSelected<S extends keyof Todo = keyof Todo> = Pick<
+  Todo,
+  Extract<S | "id", keyof Todo>
+>;
+
+export type TodoSelectedWithIncludes<
+  I extends TodoInclude = {},
+  S extends keyof Todo = keyof Todo,
+> = TodoSelected<S> & Omit<TodoWithIncludes<I>, keyof Todo>;
 
 export const wasmSchema: WasmSchema = {
   projects: {
@@ -190,15 +222,17 @@ export const wasmSchema: WasmSchema = {
   },
 };
 
-export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements QueryBuilder<
-  ProjectWithIncludes<I>
-> {
+export class ProjectQueryBuilder<
+  I extends ProjectInclude = {},
+  S extends keyof Project = keyof Project,
+> implements QueryBuilder<ProjectSelectedWithIncludes<I, S>> {
   readonly _table = "projects";
   readonly _schema: WasmSchema = wasmSchema;
-  declare readonly _rowType: ProjectWithIncludes<I>;
+  declare readonly _rowType: ProjectSelectedWithIncludes<I, S>;
   declare readonly _initType: ProjectInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<ProjectInclude> = {};
+  private _selectColumns?: string[];
   private _orderBys: Array<[string, "asc" | "desc"]> = [];
   private _limitVal?: number;
   private _offsetVal?: number;
@@ -211,7 +245,7 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
     step_hops: string[];
   };
 
-  where(conditions: ProjectWhereInput): ProjectQueryBuilder<I> {
+  where(conditions: ProjectWhereInput): ProjectQueryBuilder<I, S> {
     const clone = this._clone();
     for (const [key, value] of Object.entries(conditions)) {
       if (value === undefined) continue;
@@ -228,31 +262,37 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
     return clone;
   }
 
-  include<NewI extends ProjectInclude>(relations: NewI): ProjectQueryBuilder<I & NewI> {
-    const clone = this._clone<I & NewI>();
+  select<NewS extends keyof Project>(...columns: [NewS, ...NewS[]]): ProjectQueryBuilder<I, NewS> {
+    const clone = this._clone<I, NewS>();
+    clone._selectColumns = [...columns] as string[];
+    return clone;
+  }
+
+  include<NewI extends ProjectInclude>(relations: NewI): ProjectQueryBuilder<I & NewI, S> {
+    const clone = this._clone<I & NewI, S>();
     clone._includes = { ...this._includes, ...relations };
     return clone;
   }
 
-  orderBy(column: keyof Project, direction: "asc" | "desc" = "asc"): ProjectQueryBuilder<I> {
+  orderBy(column: keyof Project, direction: "asc" | "desc" = "asc"): ProjectQueryBuilder<I, S> {
     const clone = this._clone();
     clone._orderBys.push([column as string, direction]);
     return clone;
   }
 
-  limit(n: number): ProjectQueryBuilder<I> {
+  limit(n: number): ProjectQueryBuilder<I, S> {
     const clone = this._clone();
     clone._limitVal = n;
     return clone;
   }
 
-  offset(n: number): ProjectQueryBuilder<I> {
+  offset(n: number): ProjectQueryBuilder<I, S> {
     const clone = this._clone();
     clone._offsetVal = n;
     return clone;
   }
 
-  hopTo(relation: "todosViaProject"): ProjectQueryBuilder<I> {
+  hopTo(relation: "todosViaProject"): ProjectQueryBuilder<I, S> {
     const clone = this._clone();
     clone._hops.push(relation);
     return clone;
@@ -262,7 +302,7 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
     start: ProjectWhereInput;
     step: (ctx: { current: string }) => QueryBuilder<unknown>;
     maxDepth?: number;
-  }): ProjectQueryBuilder<I> {
+  }): ProjectQueryBuilder<I, S> {
     if (options.start === undefined) {
       throw new Error("gather(...) requires start where conditions.");
     }
@@ -344,6 +384,7 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
       table: this._table,
       conditions: this._conditions,
       includes: this._includes,
+      select: this._selectColumns,
       orderBy: this._orderBys,
       limit: this._limitVal,
       offset: this._offsetVal,
@@ -352,10 +393,14 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
     });
   }
 
-  private _clone<CloneI extends ProjectInclude = I>(): ProjectQueryBuilder<CloneI> {
-    const clone = new ProjectQueryBuilder<CloneI>();
+  private _clone<
+    CloneI extends ProjectInclude = I,
+    CloneS extends keyof Project = S,
+  >(): ProjectQueryBuilder<CloneI, CloneS> {
+    const clone = new ProjectQueryBuilder<CloneI, CloneS>();
     clone._conditions = [...this._conditions];
     clone._includes = { ...this._includes };
+    clone._selectColumns = this._selectColumns ? [...this._selectColumns] : undefined;
     clone._orderBys = [...this._orderBys];
     clone._limitVal = this._limitVal;
     clone._offsetVal = this._offsetVal;
@@ -371,15 +416,17 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
   }
 }
 
-export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilder<
-  TodoWithIncludes<I>
-> {
+export class TodoQueryBuilder<
+  I extends TodoInclude = {},
+  S extends keyof Todo = keyof Todo,
+> implements QueryBuilder<TodoSelectedWithIncludes<I, S>> {
   readonly _table = "todos";
   readonly _schema: WasmSchema = wasmSchema;
-  declare readonly _rowType: TodoWithIncludes<I>;
+  declare readonly _rowType: TodoSelectedWithIncludes<I, S>;
   declare readonly _initType: TodoInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<TodoInclude> = {};
+  private _selectColumns?: string[];
   private _orderBys: Array<[string, "asc" | "desc"]> = [];
   private _limitVal?: number;
   private _offsetVal?: number;
@@ -392,7 +439,7 @@ export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilde
     step_hops: string[];
   };
 
-  where(conditions: TodoWhereInput): TodoQueryBuilder<I> {
+  where(conditions: TodoWhereInput): TodoQueryBuilder<I, S> {
     const clone = this._clone();
     for (const [key, value] of Object.entries(conditions)) {
       if (value === undefined) continue;
@@ -409,31 +456,37 @@ export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilde
     return clone;
   }
 
-  include<NewI extends TodoInclude>(relations: NewI): TodoQueryBuilder<I & NewI> {
-    const clone = this._clone<I & NewI>();
+  select<NewS extends keyof Todo>(...columns: [NewS, ...NewS[]]): TodoQueryBuilder<I, NewS> {
+    const clone = this._clone<I, NewS>();
+    clone._selectColumns = [...columns] as string[];
+    return clone;
+  }
+
+  include<NewI extends TodoInclude>(relations: NewI): TodoQueryBuilder<I & NewI, S> {
+    const clone = this._clone<I & NewI, S>();
     clone._includes = { ...this._includes, ...relations };
     return clone;
   }
 
-  orderBy(column: keyof Todo, direction: "asc" | "desc" = "asc"): TodoQueryBuilder<I> {
+  orderBy(column: keyof Todo, direction: "asc" | "desc" = "asc"): TodoQueryBuilder<I, S> {
     const clone = this._clone();
     clone._orderBys.push([column as string, direction]);
     return clone;
   }
 
-  limit(n: number): TodoQueryBuilder<I> {
+  limit(n: number): TodoQueryBuilder<I, S> {
     const clone = this._clone();
     clone._limitVal = n;
     return clone;
   }
 
-  offset(n: number): TodoQueryBuilder<I> {
+  offset(n: number): TodoQueryBuilder<I, S> {
     const clone = this._clone();
     clone._offsetVal = n;
     return clone;
   }
 
-  hopTo(relation: "parent" | "todosViaParent" | "project"): TodoQueryBuilder<I> {
+  hopTo(relation: "parent" | "todosViaParent" | "project"): TodoQueryBuilder<I, S> {
     const clone = this._clone();
     clone._hops.push(relation);
     return clone;
@@ -443,7 +496,7 @@ export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilde
     start: TodoWhereInput;
     step: (ctx: { current: string }) => QueryBuilder<unknown>;
     maxDepth?: number;
-  }): TodoQueryBuilder<I> {
+  }): TodoQueryBuilder<I, S> {
     if (options.start === undefined) {
       throw new Error("gather(...) requires start where conditions.");
     }
@@ -525,6 +578,7 @@ export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilde
       table: this._table,
       conditions: this._conditions,
       includes: this._includes,
+      select: this._selectColumns,
       orderBy: this._orderBys,
       limit: this._limitVal,
       offset: this._offsetVal,
@@ -533,10 +587,14 @@ export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilde
     });
   }
 
-  private _clone<CloneI extends TodoInclude = I>(): TodoQueryBuilder<CloneI> {
-    const clone = new TodoQueryBuilder<CloneI>();
+  private _clone<CloneI extends TodoInclude = I, CloneS extends keyof Todo = S>(): TodoQueryBuilder<
+    CloneI,
+    CloneS
+  > {
+    const clone = new TodoQueryBuilder<CloneI, CloneS>();
     clone._conditions = [...this._conditions];
     clone._includes = { ...this._includes };
+    clone._selectColumns = this._selectColumns ? [...this._selectColumns] : undefined;
     clone._orderBys = [...this._orderBys];
     clone._limitVal = this._limitVal;
     clone._offsetVal = this._offsetVal;

--- a/examples/docs/todo-client-localfirst-ts/src/docs-snippets.ts
+++ b/examples/docs/todo-client-localfirst-ts/src/docs-snippets.ts
@@ -60,7 +60,7 @@ export async function readTodosWithIncludes(db: Db) {
 // #endregion reading-includes-ts
 
 // #region reading-select-ts
-export async function readTodoTitlesWithProjectedProject(db: Db) {
+export async function readTodoTitlesWithSelectedProject(db: Db) {
   return db.all(
     app.todos
       .select("title")

--- a/examples/docs/todo-client-localfirst-ts/src/docs-snippets.ts
+++ b/examples/docs/todo-client-localfirst-ts/src/docs-snippets.ts
@@ -59,6 +59,17 @@ export async function readTodosWithIncludes(db: Db) {
 }
 // #endregion reading-includes-ts
 
+// #region reading-select-ts
+export async function readTodoTitlesWithProjectedProject(db: Db) {
+  return db.all(
+    app.todos
+      .select("title")
+      .where({ done: false })
+      .include({ project: app.projects.select("name") }),
+  );
+}
+// #endregion reading-select-ts
+
 // #region reading-recursive-ts
 export function buildTodoLineageQuery() {
   return app.todos.gather({

--- a/examples/docs/todo-client-localfirst-vue/schema/app.ts
+++ b/examples/docs/todo-client-localfirst-vue/schema/app.ts
@@ -72,8 +72,11 @@ export type ProjectWithIncludes<I extends ProjectInclude = {}> = Project & {
   todosViaProject?: NonNullable<I["todosViaProject"]> extends infer RelationInclude
     ? RelationInclude extends true
       ? Todo[]
-      : RelationInclude extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
-        ? TodoWithIncludes<QueryInclude>[]
+      : RelationInclude extends TodoQueryBuilder<
+            infer QueryInclude extends TodoInclude,
+            infer QuerySelect extends keyof Todo
+          >
+        ? TodoSelectedWithIncludes<QueryInclude, QuerySelect>[]
         : RelationInclude extends TodoInclude
           ? TodoWithIncludes<RelationInclude>[]
           : never
@@ -84,8 +87,11 @@ export type TodoWithIncludes<I extends TodoInclude = {}> = Todo & {
   parent?: NonNullable<I["parent"]> extends infer RelationInclude
     ? RelationInclude extends true
       ? Todo
-      : RelationInclude extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
-        ? TodoWithIncludes<QueryInclude>
+      : RelationInclude extends TodoQueryBuilder<
+            infer QueryInclude extends TodoInclude,
+            infer QuerySelect extends keyof Todo
+          >
+        ? TodoSelectedWithIncludes<QueryInclude, QuerySelect>
         : RelationInclude extends TodoInclude
           ? TodoWithIncludes<RelationInclude>
           : never
@@ -93,8 +99,11 @@ export type TodoWithIncludes<I extends TodoInclude = {}> = Todo & {
   todosViaParent?: NonNullable<I["todosViaParent"]> extends infer RelationInclude
     ? RelationInclude extends true
       ? Todo[]
-      : RelationInclude extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
-        ? TodoWithIncludes<QueryInclude>[]
+      : RelationInclude extends TodoQueryBuilder<
+            infer QueryInclude extends TodoInclude,
+            infer QuerySelect extends keyof Todo
+          >
+        ? TodoSelectedWithIncludes<QueryInclude, QuerySelect>[]
         : RelationInclude extends TodoInclude
           ? TodoWithIncludes<RelationInclude>[]
           : never
@@ -102,13 +111,36 @@ export type TodoWithIncludes<I extends TodoInclude = {}> = Todo & {
   project?: NonNullable<I["project"]> extends infer RelationInclude
     ? RelationInclude extends true
       ? Project
-      : RelationInclude extends ProjectQueryBuilder<infer QueryInclude extends ProjectInclude>
-        ? ProjectWithIncludes<QueryInclude>
+      : RelationInclude extends ProjectQueryBuilder<
+            infer QueryInclude extends ProjectInclude,
+            infer QuerySelect extends keyof Project
+          >
+        ? ProjectSelectedWithIncludes<QueryInclude, QuerySelect>
         : RelationInclude extends ProjectInclude
           ? ProjectWithIncludes<RelationInclude>
           : never
     : never;
 };
+
+export type ProjectSelected<S extends keyof Project = keyof Project> = Pick<
+  Project,
+  Extract<S | "id", keyof Project>
+>;
+
+export type ProjectSelectedWithIncludes<
+  I extends ProjectInclude = {},
+  S extends keyof Project = keyof Project,
+> = ProjectSelected<S> & Omit<ProjectWithIncludes<I>, keyof Project>;
+
+export type TodoSelected<S extends keyof Todo = keyof Todo> = Pick<
+  Todo,
+  Extract<S | "id", keyof Todo>
+>;
+
+export type TodoSelectedWithIncludes<
+  I extends TodoInclude = {},
+  S extends keyof Todo = keyof Todo,
+> = TodoSelected<S> & Omit<TodoWithIncludes<I>, keyof Todo>;
 
 export const wasmSchema: WasmSchema = {
   projects: {
@@ -217,15 +249,17 @@ export const wasmSchema: WasmSchema = {
   },
 };
 
-export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements QueryBuilder<
-  ProjectWithIncludes<I>
-> {
+export class ProjectQueryBuilder<
+  I extends ProjectInclude = {},
+  S extends keyof Project = keyof Project,
+> implements QueryBuilder<ProjectSelectedWithIncludes<I, S>> {
   readonly _table = "projects";
   readonly _schema: WasmSchema = wasmSchema;
-  declare readonly _rowType: ProjectWithIncludes<I>;
+  declare readonly _rowType: ProjectSelectedWithIncludes<I, S>;
   declare readonly _initType: ProjectInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<ProjectInclude> = {};
+  private _selectColumns?: string[];
   private _orderBys: Array<[string, "asc" | "desc"]> = [];
   private _limitVal?: number;
   private _offsetVal?: number;
@@ -238,7 +272,7 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
     step_hops: string[];
   };
 
-  where(conditions: ProjectWhereInput): ProjectQueryBuilder<I> {
+  where(conditions: ProjectWhereInput): ProjectQueryBuilder<I, S> {
     const clone = this._clone();
     for (const [key, value] of Object.entries(conditions)) {
       if (value === undefined) continue;
@@ -255,31 +289,37 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
     return clone;
   }
 
-  include<NewI extends ProjectInclude>(relations: NewI): ProjectQueryBuilder<I & NewI> {
-    const clone = this._clone<I & NewI>();
+  select<NewS extends keyof Project>(...columns: [NewS, ...NewS[]]): ProjectQueryBuilder<I, NewS> {
+    const clone = this._clone<I, NewS>();
+    clone._selectColumns = [...columns] as string[];
+    return clone;
+  }
+
+  include<NewI extends ProjectInclude>(relations: NewI): ProjectQueryBuilder<I & NewI, S> {
+    const clone = this._clone<I & NewI, S>();
     clone._includes = { ...this._includes, ...relations };
     return clone;
   }
 
-  orderBy(column: keyof Project, direction: "asc" | "desc" = "asc"): ProjectQueryBuilder<I> {
+  orderBy(column: keyof Project, direction: "asc" | "desc" = "asc"): ProjectQueryBuilder<I, S> {
     const clone = this._clone();
     clone._orderBys.push([column as string, direction]);
     return clone;
   }
 
-  limit(n: number): ProjectQueryBuilder<I> {
+  limit(n: number): ProjectQueryBuilder<I, S> {
     const clone = this._clone();
     clone._limitVal = n;
     return clone;
   }
 
-  offset(n: number): ProjectQueryBuilder<I> {
+  offset(n: number): ProjectQueryBuilder<I, S> {
     const clone = this._clone();
     clone._offsetVal = n;
     return clone;
   }
 
-  hopTo(relation: "todosViaProject"): ProjectQueryBuilder<I> {
+  hopTo(relation: "todosViaProject"): ProjectQueryBuilder<I, S> {
     const clone = this._clone();
     clone._hops.push(relation);
     return clone;
@@ -289,7 +329,7 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
     start: ProjectWhereInput;
     step: (ctx: { current: string }) => QueryBuilder<unknown>;
     maxDepth?: number;
-  }): ProjectQueryBuilder<I> {
+  }): ProjectQueryBuilder<I, S> {
     if (options.start === undefined) {
       throw new Error("gather(...) requires start where conditions.");
     }
@@ -371,6 +411,7 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
       table: this._table,
       conditions: this._conditions,
       includes: this._includes,
+      select: this._selectColumns,
       orderBy: this._orderBys,
       limit: this._limitVal,
       offset: this._offsetVal,
@@ -379,10 +420,14 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
     });
   }
 
-  private _clone<CloneI extends ProjectInclude = I>(): ProjectQueryBuilder<CloneI> {
-    const clone = new ProjectQueryBuilder<CloneI>();
+  private _clone<
+    CloneI extends ProjectInclude = I,
+    CloneS extends keyof Project = S,
+  >(): ProjectQueryBuilder<CloneI, CloneS> {
+    const clone = new ProjectQueryBuilder<CloneI, CloneS>();
     clone._conditions = [...this._conditions];
     clone._includes = { ...this._includes };
+    clone._selectColumns = this._selectColumns ? [...this._selectColumns] : undefined;
     clone._orderBys = [...this._orderBys];
     clone._limitVal = this._limitVal;
     clone._offsetVal = this._offsetVal;
@@ -398,15 +443,17 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
   }
 }
 
-export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilder<
-  TodoWithIncludes<I>
-> {
+export class TodoQueryBuilder<
+  I extends TodoInclude = {},
+  S extends keyof Todo = keyof Todo,
+> implements QueryBuilder<TodoSelectedWithIncludes<I, S>> {
   readonly _table = "todos";
   readonly _schema: WasmSchema = wasmSchema;
-  declare readonly _rowType: TodoWithIncludes<I>;
+  declare readonly _rowType: TodoSelectedWithIncludes<I, S>;
   declare readonly _initType: TodoInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<TodoInclude> = {};
+  private _selectColumns?: string[];
   private _orderBys: Array<[string, "asc" | "desc"]> = [];
   private _limitVal?: number;
   private _offsetVal?: number;
@@ -419,7 +466,7 @@ export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilde
     step_hops: string[];
   };
 
-  where(conditions: TodoWhereInput): TodoQueryBuilder<I> {
+  where(conditions: TodoWhereInput): TodoQueryBuilder<I, S> {
     const clone = this._clone();
     for (const [key, value] of Object.entries(conditions)) {
       if (value === undefined) continue;
@@ -436,31 +483,37 @@ export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilde
     return clone;
   }
 
-  include<NewI extends TodoInclude>(relations: NewI): TodoQueryBuilder<I & NewI> {
-    const clone = this._clone<I & NewI>();
+  select<NewS extends keyof Todo>(...columns: [NewS, ...NewS[]]): TodoQueryBuilder<I, NewS> {
+    const clone = this._clone<I, NewS>();
+    clone._selectColumns = [...columns] as string[];
+    return clone;
+  }
+
+  include<NewI extends TodoInclude>(relations: NewI): TodoQueryBuilder<I & NewI, S> {
+    const clone = this._clone<I & NewI, S>();
     clone._includes = { ...this._includes, ...relations };
     return clone;
   }
 
-  orderBy(column: keyof Todo, direction: "asc" | "desc" = "asc"): TodoQueryBuilder<I> {
+  orderBy(column: keyof Todo, direction: "asc" | "desc" = "asc"): TodoQueryBuilder<I, S> {
     const clone = this._clone();
     clone._orderBys.push([column as string, direction]);
     return clone;
   }
 
-  limit(n: number): TodoQueryBuilder<I> {
+  limit(n: number): TodoQueryBuilder<I, S> {
     const clone = this._clone();
     clone._limitVal = n;
     return clone;
   }
 
-  offset(n: number): TodoQueryBuilder<I> {
+  offset(n: number): TodoQueryBuilder<I, S> {
     const clone = this._clone();
     clone._offsetVal = n;
     return clone;
   }
 
-  hopTo(relation: "parent" | "todosViaParent" | "project"): TodoQueryBuilder<I> {
+  hopTo(relation: "parent" | "todosViaParent" | "project"): TodoQueryBuilder<I, S> {
     const clone = this._clone();
     clone._hops.push(relation);
     return clone;
@@ -470,7 +523,7 @@ export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilde
     start: TodoWhereInput;
     step: (ctx: { current: string }) => QueryBuilder<unknown>;
     maxDepth?: number;
-  }): TodoQueryBuilder<I> {
+  }): TodoQueryBuilder<I, S> {
     if (options.start === undefined) {
       throw new Error("gather(...) requires start where conditions.");
     }
@@ -552,6 +605,7 @@ export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilde
       table: this._table,
       conditions: this._conditions,
       includes: this._includes,
+      select: this._selectColumns,
       orderBy: this._orderBys,
       limit: this._limitVal,
       offset: this._offsetVal,
@@ -560,10 +614,14 @@ export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilde
     });
   }
 
-  private _clone<CloneI extends TodoInclude = I>(): TodoQueryBuilder<CloneI> {
-    const clone = new TodoQueryBuilder<CloneI>();
+  private _clone<CloneI extends TodoInclude = I, CloneS extends keyof Todo = S>(): TodoQueryBuilder<
+    CloneI,
+    CloneS
+  > {
+    const clone = new TodoQueryBuilder<CloneI, CloneS>();
     clone._conditions = [...this._conditions];
     clone._includes = { ...this._includes };
+    clone._selectColumns = this._selectColumns ? [...this._selectColumns] : undefined;
     clone._orderBys = [...this._orderBys];
     clone._limitVal = this._limitVal;
     clone._offsetVal = this._offsetVal;

--- a/examples/todo-client-localfirst-react/schema/app.ts
+++ b/examples/todo-client-localfirst-react/schema/app.ts
@@ -75,8 +75,11 @@ export type ProjectWithIncludes<I extends ProjectInclude = {}> = Project & {
   todosViaProject?: NonNullable<I["todosViaProject"]> extends infer RelationInclude
     ? RelationInclude extends true
       ? Todo[]
-      : RelationInclude extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
-        ? TodoWithIncludes<QueryInclude>[]
+      : RelationInclude extends TodoQueryBuilder<
+            infer QueryInclude extends TodoInclude,
+            infer QuerySelect extends keyof Todo
+          >
+        ? TodoSelectedWithIncludes<QueryInclude, QuerySelect>[]
         : RelationInclude extends TodoInclude
           ? TodoWithIncludes<RelationInclude>[]
           : never
@@ -87,8 +90,11 @@ export type TodoWithIncludes<I extends TodoInclude = {}> = Todo & {
   parent?: NonNullable<I["parent"]> extends infer RelationInclude
     ? RelationInclude extends true
       ? Todo
-      : RelationInclude extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
-        ? TodoWithIncludes<QueryInclude>
+      : RelationInclude extends TodoQueryBuilder<
+            infer QueryInclude extends TodoInclude,
+            infer QuerySelect extends keyof Todo
+          >
+        ? TodoSelectedWithIncludes<QueryInclude, QuerySelect>
         : RelationInclude extends TodoInclude
           ? TodoWithIncludes<RelationInclude>
           : never
@@ -96,8 +102,11 @@ export type TodoWithIncludes<I extends TodoInclude = {}> = Todo & {
   todosViaParent?: NonNullable<I["todosViaParent"]> extends infer RelationInclude
     ? RelationInclude extends true
       ? Todo[]
-      : RelationInclude extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
-        ? TodoWithIncludes<QueryInclude>[]
+      : RelationInclude extends TodoQueryBuilder<
+            infer QueryInclude extends TodoInclude,
+            infer QuerySelect extends keyof Todo
+          >
+        ? TodoSelectedWithIncludes<QueryInclude, QuerySelect>[]
         : RelationInclude extends TodoInclude
           ? TodoWithIncludes<RelationInclude>[]
           : never
@@ -105,13 +114,36 @@ export type TodoWithIncludes<I extends TodoInclude = {}> = Todo & {
   project?: NonNullable<I["project"]> extends infer RelationInclude
     ? RelationInclude extends true
       ? Project
-      : RelationInclude extends ProjectQueryBuilder<infer QueryInclude extends ProjectInclude>
-        ? ProjectWithIncludes<QueryInclude>
+      : RelationInclude extends ProjectQueryBuilder<
+            infer QueryInclude extends ProjectInclude,
+            infer QuerySelect extends keyof Project
+          >
+        ? ProjectSelectedWithIncludes<QueryInclude, QuerySelect>
         : RelationInclude extends ProjectInclude
           ? ProjectWithIncludes<RelationInclude>
           : never
     : never;
 };
+
+export type ProjectSelected<S extends keyof Project = keyof Project> = Pick<
+  Project,
+  Extract<S | "id", keyof Project>
+>;
+
+export type ProjectSelectedWithIncludes<
+  I extends ProjectInclude = {},
+  S extends keyof Project = keyof Project,
+> = ProjectSelected<S> & Omit<ProjectWithIncludes<I>, keyof Project>;
+
+export type TodoSelected<S extends keyof Todo = keyof Todo> = Pick<
+  Todo,
+  Extract<S | "id", keyof Todo>
+>;
+
+export type TodoSelectedWithIncludes<
+  I extends TodoInclude = {},
+  S extends keyof Todo = keyof Todo,
+> = TodoSelected<S> & Omit<TodoWithIncludes<I>, keyof Todo>;
 
 export const wasmSchema: WasmSchema = {
   projects: {
@@ -224,15 +256,17 @@ export const wasmSchema: WasmSchema = {
   },
 };
 
-export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements QueryBuilder<
-  ProjectWithIncludes<I>
-> {
+export class ProjectQueryBuilder<
+  I extends ProjectInclude = {},
+  S extends keyof Project = keyof Project,
+> implements QueryBuilder<ProjectSelectedWithIncludes<I, S>> {
   readonly _table = "projects";
   readonly _schema: WasmSchema = wasmSchema;
-  declare readonly _rowType: ProjectWithIncludes<I>;
+  declare readonly _rowType: ProjectSelectedWithIncludes<I, S>;
   declare readonly _initType: ProjectInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<ProjectInclude> = {};
+  private _selectColumns?: string[];
   private _orderBys: Array<[string, "asc" | "desc"]> = [];
   private _limitVal?: number;
   private _offsetVal?: number;
@@ -245,7 +279,7 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
     step_hops: string[];
   };
 
-  where(conditions: ProjectWhereInput): ProjectQueryBuilder<I> {
+  where(conditions: ProjectWhereInput): ProjectQueryBuilder<I, S> {
     const clone = this._clone();
     for (const [key, value] of Object.entries(conditions)) {
       if (value === undefined) continue;
@@ -262,31 +296,37 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
     return clone;
   }
 
-  include<NewI extends ProjectInclude>(relations: NewI): ProjectQueryBuilder<I & NewI> {
-    const clone = this._clone<I & NewI>();
+  select<NewS extends keyof Project>(...columns: [NewS, ...NewS[]]): ProjectQueryBuilder<I, NewS> {
+    const clone = this._clone<I, NewS>();
+    clone._selectColumns = [...columns] as string[];
+    return clone;
+  }
+
+  include<NewI extends ProjectInclude>(relations: NewI): ProjectQueryBuilder<I & NewI, S> {
+    const clone = this._clone<I & NewI, S>();
     clone._includes = { ...this._includes, ...relations };
     return clone;
   }
 
-  orderBy(column: keyof Project, direction: "asc" | "desc" = "asc"): ProjectQueryBuilder<I> {
+  orderBy(column: keyof Project, direction: "asc" | "desc" = "asc"): ProjectQueryBuilder<I, S> {
     const clone = this._clone();
     clone._orderBys.push([column as string, direction]);
     return clone;
   }
 
-  limit(n: number): ProjectQueryBuilder<I> {
+  limit(n: number): ProjectQueryBuilder<I, S> {
     const clone = this._clone();
     clone._limitVal = n;
     return clone;
   }
 
-  offset(n: number): ProjectQueryBuilder<I> {
+  offset(n: number): ProjectQueryBuilder<I, S> {
     const clone = this._clone();
     clone._offsetVal = n;
     return clone;
   }
 
-  hopTo(relation: "todosViaProject"): ProjectQueryBuilder<I> {
+  hopTo(relation: "todosViaProject"): ProjectQueryBuilder<I, S> {
     const clone = this._clone();
     clone._hops.push(relation);
     return clone;
@@ -296,7 +336,7 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
     start: ProjectWhereInput;
     step: (ctx: { current: string }) => QueryBuilder<unknown>;
     maxDepth?: number;
-  }): ProjectQueryBuilder<I> {
+  }): ProjectQueryBuilder<I, S> {
     if (options.start === undefined) {
       throw new Error("gather(...) requires start where conditions.");
     }
@@ -378,6 +418,7 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
       table: this._table,
       conditions: this._conditions,
       includes: this._includes,
+      select: this._selectColumns,
       orderBy: this._orderBys,
       limit: this._limitVal,
       offset: this._offsetVal,
@@ -386,10 +427,14 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
     });
   }
 
-  private _clone<CloneI extends ProjectInclude = I>(): ProjectQueryBuilder<CloneI> {
-    const clone = new ProjectQueryBuilder<CloneI>();
+  private _clone<
+    CloneI extends ProjectInclude = I,
+    CloneS extends keyof Project = S,
+  >(): ProjectQueryBuilder<CloneI, CloneS> {
+    const clone = new ProjectQueryBuilder<CloneI, CloneS>();
     clone._conditions = [...this._conditions];
     clone._includes = { ...this._includes };
+    clone._selectColumns = this._selectColumns ? [...this._selectColumns] : undefined;
     clone._orderBys = [...this._orderBys];
     clone._limitVal = this._limitVal;
     clone._offsetVal = this._offsetVal;
@@ -405,15 +450,17 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
   }
 }
 
-export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilder<
-  TodoWithIncludes<I>
-> {
+export class TodoQueryBuilder<
+  I extends TodoInclude = {},
+  S extends keyof Todo = keyof Todo,
+> implements QueryBuilder<TodoSelectedWithIncludes<I, S>> {
   readonly _table = "todos";
   readonly _schema: WasmSchema = wasmSchema;
-  declare readonly _rowType: TodoWithIncludes<I>;
+  declare readonly _rowType: TodoSelectedWithIncludes<I, S>;
   declare readonly _initType: TodoInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<TodoInclude> = {};
+  private _selectColumns?: string[];
   private _orderBys: Array<[string, "asc" | "desc"]> = [];
   private _limitVal?: number;
   private _offsetVal?: number;
@@ -426,7 +473,7 @@ export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilde
     step_hops: string[];
   };
 
-  where(conditions: TodoWhereInput): TodoQueryBuilder<I> {
+  where(conditions: TodoWhereInput): TodoQueryBuilder<I, S> {
     const clone = this._clone();
     for (const [key, value] of Object.entries(conditions)) {
       if (value === undefined) continue;
@@ -443,31 +490,37 @@ export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilde
     return clone;
   }
 
-  include<NewI extends TodoInclude>(relations: NewI): TodoQueryBuilder<I & NewI> {
-    const clone = this._clone<I & NewI>();
+  select<NewS extends keyof Todo>(...columns: [NewS, ...NewS[]]): TodoQueryBuilder<I, NewS> {
+    const clone = this._clone<I, NewS>();
+    clone._selectColumns = [...columns] as string[];
+    return clone;
+  }
+
+  include<NewI extends TodoInclude>(relations: NewI): TodoQueryBuilder<I & NewI, S> {
+    const clone = this._clone<I & NewI, S>();
     clone._includes = { ...this._includes, ...relations };
     return clone;
   }
 
-  orderBy(column: keyof Todo, direction: "asc" | "desc" = "asc"): TodoQueryBuilder<I> {
+  orderBy(column: keyof Todo, direction: "asc" | "desc" = "asc"): TodoQueryBuilder<I, S> {
     const clone = this._clone();
     clone._orderBys.push([column as string, direction]);
     return clone;
   }
 
-  limit(n: number): TodoQueryBuilder<I> {
+  limit(n: number): TodoQueryBuilder<I, S> {
     const clone = this._clone();
     clone._limitVal = n;
     return clone;
   }
 
-  offset(n: number): TodoQueryBuilder<I> {
+  offset(n: number): TodoQueryBuilder<I, S> {
     const clone = this._clone();
     clone._offsetVal = n;
     return clone;
   }
 
-  hopTo(relation: "parent" | "todosViaParent" | "project"): TodoQueryBuilder<I> {
+  hopTo(relation: "parent" | "todosViaParent" | "project"): TodoQueryBuilder<I, S> {
     const clone = this._clone();
     clone._hops.push(relation);
     return clone;
@@ -477,7 +530,7 @@ export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilde
     start: TodoWhereInput;
     step: (ctx: { current: string }) => QueryBuilder<unknown>;
     maxDepth?: number;
-  }): TodoQueryBuilder<I> {
+  }): TodoQueryBuilder<I, S> {
     if (options.start === undefined) {
       throw new Error("gather(...) requires start where conditions.");
     }
@@ -559,6 +612,7 @@ export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilde
       table: this._table,
       conditions: this._conditions,
       includes: this._includes,
+      select: this._selectColumns,
       orderBy: this._orderBys,
       limit: this._limitVal,
       offset: this._offsetVal,
@@ -567,10 +621,14 @@ export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilde
     });
   }
 
-  private _clone<CloneI extends TodoInclude = I>(): TodoQueryBuilder<CloneI> {
-    const clone = new TodoQueryBuilder<CloneI>();
+  private _clone<CloneI extends TodoInclude = I, CloneS extends keyof Todo = S>(): TodoQueryBuilder<
+    CloneI,
+    CloneS
+  > {
+    const clone = new TodoQueryBuilder<CloneI, CloneS>();
     clone._conditions = [...this._conditions];
     clone._includes = { ...this._includes };
+    clone._selectColumns = this._selectColumns ? [...this._selectColumns] : undefined;
     clone._orderBys = [...this._orderBys];
     clone._limitVal = this._limitVal;
     clone._offsetVal = this._offsetVal;

--- a/examples/todo-client-localfirst-svelte/schema/app.ts
+++ b/examples/todo-client-localfirst-svelte/schema/app.ts
@@ -75,8 +75,11 @@ export type ProjectWithIncludes<I extends ProjectInclude = {}> = Project & {
   todosViaProject?: NonNullable<I["todosViaProject"]> extends infer RelationInclude
     ? RelationInclude extends true
       ? Todo[]
-      : RelationInclude extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
-        ? TodoWithIncludes<QueryInclude>[]
+      : RelationInclude extends TodoQueryBuilder<
+            infer QueryInclude extends TodoInclude,
+            infer QuerySelect extends keyof Todo
+          >
+        ? TodoSelectedWithIncludes<QueryInclude, QuerySelect>[]
         : RelationInclude extends TodoInclude
           ? TodoWithIncludes<RelationInclude>[]
           : never
@@ -87,8 +90,11 @@ export type TodoWithIncludes<I extends TodoInclude = {}> = Todo & {
   parent?: NonNullable<I["parent"]> extends infer RelationInclude
     ? RelationInclude extends true
       ? Todo
-      : RelationInclude extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
-        ? TodoWithIncludes<QueryInclude>
+      : RelationInclude extends TodoQueryBuilder<
+            infer QueryInclude extends TodoInclude,
+            infer QuerySelect extends keyof Todo
+          >
+        ? TodoSelectedWithIncludes<QueryInclude, QuerySelect>
         : RelationInclude extends TodoInclude
           ? TodoWithIncludes<RelationInclude>
           : never
@@ -96,8 +102,11 @@ export type TodoWithIncludes<I extends TodoInclude = {}> = Todo & {
   todosViaParent?: NonNullable<I["todosViaParent"]> extends infer RelationInclude
     ? RelationInclude extends true
       ? Todo[]
-      : RelationInclude extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
-        ? TodoWithIncludes<QueryInclude>[]
+      : RelationInclude extends TodoQueryBuilder<
+            infer QueryInclude extends TodoInclude,
+            infer QuerySelect extends keyof Todo
+          >
+        ? TodoSelectedWithIncludes<QueryInclude, QuerySelect>[]
         : RelationInclude extends TodoInclude
           ? TodoWithIncludes<RelationInclude>[]
           : never
@@ -105,13 +114,36 @@ export type TodoWithIncludes<I extends TodoInclude = {}> = Todo & {
   project?: NonNullable<I["project"]> extends infer RelationInclude
     ? RelationInclude extends true
       ? Project
-      : RelationInclude extends ProjectQueryBuilder<infer QueryInclude extends ProjectInclude>
-        ? ProjectWithIncludes<QueryInclude>
+      : RelationInclude extends ProjectQueryBuilder<
+            infer QueryInclude extends ProjectInclude,
+            infer QuerySelect extends keyof Project
+          >
+        ? ProjectSelectedWithIncludes<QueryInclude, QuerySelect>
         : RelationInclude extends ProjectInclude
           ? ProjectWithIncludes<RelationInclude>
           : never
     : never;
 };
+
+export type ProjectSelected<S extends keyof Project = keyof Project> = Pick<
+  Project,
+  Extract<S | "id", keyof Project>
+>;
+
+export type ProjectSelectedWithIncludes<
+  I extends ProjectInclude = {},
+  S extends keyof Project = keyof Project,
+> = ProjectSelected<S> & Omit<ProjectWithIncludes<I>, keyof Project>;
+
+export type TodoSelected<S extends keyof Todo = keyof Todo> = Pick<
+  Todo,
+  Extract<S | "id", keyof Todo>
+>;
+
+export type TodoSelectedWithIncludes<
+  I extends TodoInclude = {},
+  S extends keyof Todo = keyof Todo,
+> = TodoSelected<S> & Omit<TodoWithIncludes<I>, keyof Todo>;
 
 export const wasmSchema: WasmSchema = {
   projects: {
@@ -224,15 +256,17 @@ export const wasmSchema: WasmSchema = {
   },
 };
 
-export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements QueryBuilder<
-  ProjectWithIncludes<I>
-> {
+export class ProjectQueryBuilder<
+  I extends ProjectInclude = {},
+  S extends keyof Project = keyof Project,
+> implements QueryBuilder<ProjectSelectedWithIncludes<I, S>> {
   readonly _table = "projects";
   readonly _schema: WasmSchema = wasmSchema;
-  declare readonly _rowType: ProjectWithIncludes<I>;
+  declare readonly _rowType: ProjectSelectedWithIncludes<I, S>;
   declare readonly _initType: ProjectInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<ProjectInclude> = {};
+  private _selectColumns?: string[];
   private _orderBys: Array<[string, "asc" | "desc"]> = [];
   private _limitVal?: number;
   private _offsetVal?: number;
@@ -245,7 +279,7 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
     step_hops: string[];
   };
 
-  where(conditions: ProjectWhereInput): ProjectQueryBuilder<I> {
+  where(conditions: ProjectWhereInput): ProjectQueryBuilder<I, S> {
     const clone = this._clone();
     for (const [key, value] of Object.entries(conditions)) {
       if (value === undefined) continue;
@@ -262,31 +296,37 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
     return clone;
   }
 
-  include<NewI extends ProjectInclude>(relations: NewI): ProjectQueryBuilder<I & NewI> {
-    const clone = this._clone<I & NewI>();
+  select<NewS extends keyof Project>(...columns: [NewS, ...NewS[]]): ProjectQueryBuilder<I, NewS> {
+    const clone = this._clone<I, NewS>();
+    clone._selectColumns = [...columns] as string[];
+    return clone;
+  }
+
+  include<NewI extends ProjectInclude>(relations: NewI): ProjectQueryBuilder<I & NewI, S> {
+    const clone = this._clone<I & NewI, S>();
     clone._includes = { ...this._includes, ...relations };
     return clone;
   }
 
-  orderBy(column: keyof Project, direction: "asc" | "desc" = "asc"): ProjectQueryBuilder<I> {
+  orderBy(column: keyof Project, direction: "asc" | "desc" = "asc"): ProjectQueryBuilder<I, S> {
     const clone = this._clone();
     clone._orderBys.push([column as string, direction]);
     return clone;
   }
 
-  limit(n: number): ProjectQueryBuilder<I> {
+  limit(n: number): ProjectQueryBuilder<I, S> {
     const clone = this._clone();
     clone._limitVal = n;
     return clone;
   }
 
-  offset(n: number): ProjectQueryBuilder<I> {
+  offset(n: number): ProjectQueryBuilder<I, S> {
     const clone = this._clone();
     clone._offsetVal = n;
     return clone;
   }
 
-  hopTo(relation: "todosViaProject"): ProjectQueryBuilder<I> {
+  hopTo(relation: "todosViaProject"): ProjectQueryBuilder<I, S> {
     const clone = this._clone();
     clone._hops.push(relation);
     return clone;
@@ -296,7 +336,7 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
     start: ProjectWhereInput;
     step: (ctx: { current: string }) => QueryBuilder<unknown>;
     maxDepth?: number;
-  }): ProjectQueryBuilder<I> {
+  }): ProjectQueryBuilder<I, S> {
     if (options.start === undefined) {
       throw new Error("gather(...) requires start where conditions.");
     }
@@ -378,6 +418,7 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
       table: this._table,
       conditions: this._conditions,
       includes: this._includes,
+      select: this._selectColumns,
       orderBy: this._orderBys,
       limit: this._limitVal,
       offset: this._offsetVal,
@@ -386,10 +427,14 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
     });
   }
 
-  private _clone<CloneI extends ProjectInclude = I>(): ProjectQueryBuilder<CloneI> {
-    const clone = new ProjectQueryBuilder<CloneI>();
+  private _clone<
+    CloneI extends ProjectInclude = I,
+    CloneS extends keyof Project = S,
+  >(): ProjectQueryBuilder<CloneI, CloneS> {
+    const clone = new ProjectQueryBuilder<CloneI, CloneS>();
     clone._conditions = [...this._conditions];
     clone._includes = { ...this._includes };
+    clone._selectColumns = this._selectColumns ? [...this._selectColumns] : undefined;
     clone._orderBys = [...this._orderBys];
     clone._limitVal = this._limitVal;
     clone._offsetVal = this._offsetVal;
@@ -405,15 +450,17 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
   }
 }
 
-export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilder<
-  TodoWithIncludes<I>
-> {
+export class TodoQueryBuilder<
+  I extends TodoInclude = {},
+  S extends keyof Todo = keyof Todo,
+> implements QueryBuilder<TodoSelectedWithIncludes<I, S>> {
   readonly _table = "todos";
   readonly _schema: WasmSchema = wasmSchema;
-  declare readonly _rowType: TodoWithIncludes<I>;
+  declare readonly _rowType: TodoSelectedWithIncludes<I, S>;
   declare readonly _initType: TodoInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<TodoInclude> = {};
+  private _selectColumns?: string[];
   private _orderBys: Array<[string, "asc" | "desc"]> = [];
   private _limitVal?: number;
   private _offsetVal?: number;
@@ -426,7 +473,7 @@ export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilde
     step_hops: string[];
   };
 
-  where(conditions: TodoWhereInput): TodoQueryBuilder<I> {
+  where(conditions: TodoWhereInput): TodoQueryBuilder<I, S> {
     const clone = this._clone();
     for (const [key, value] of Object.entries(conditions)) {
       if (value === undefined) continue;
@@ -443,31 +490,37 @@ export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilde
     return clone;
   }
 
-  include<NewI extends TodoInclude>(relations: NewI): TodoQueryBuilder<I & NewI> {
-    const clone = this._clone<I & NewI>();
+  select<NewS extends keyof Todo>(...columns: [NewS, ...NewS[]]): TodoQueryBuilder<I, NewS> {
+    const clone = this._clone<I, NewS>();
+    clone._selectColumns = [...columns] as string[];
+    return clone;
+  }
+
+  include<NewI extends TodoInclude>(relations: NewI): TodoQueryBuilder<I & NewI, S> {
+    const clone = this._clone<I & NewI, S>();
     clone._includes = { ...this._includes, ...relations };
     return clone;
   }
 
-  orderBy(column: keyof Todo, direction: "asc" | "desc" = "asc"): TodoQueryBuilder<I> {
+  orderBy(column: keyof Todo, direction: "asc" | "desc" = "asc"): TodoQueryBuilder<I, S> {
     const clone = this._clone();
     clone._orderBys.push([column as string, direction]);
     return clone;
   }
 
-  limit(n: number): TodoQueryBuilder<I> {
+  limit(n: number): TodoQueryBuilder<I, S> {
     const clone = this._clone();
     clone._limitVal = n;
     return clone;
   }
 
-  offset(n: number): TodoQueryBuilder<I> {
+  offset(n: number): TodoQueryBuilder<I, S> {
     const clone = this._clone();
     clone._offsetVal = n;
     return clone;
   }
 
-  hopTo(relation: "parent" | "todosViaParent" | "project"): TodoQueryBuilder<I> {
+  hopTo(relation: "parent" | "todosViaParent" | "project"): TodoQueryBuilder<I, S> {
     const clone = this._clone();
     clone._hops.push(relation);
     return clone;
@@ -477,7 +530,7 @@ export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilde
     start: TodoWhereInput;
     step: (ctx: { current: string }) => QueryBuilder<unknown>;
     maxDepth?: number;
-  }): TodoQueryBuilder<I> {
+  }): TodoQueryBuilder<I, S> {
     if (options.start === undefined) {
       throw new Error("gather(...) requires start where conditions.");
     }
@@ -559,6 +612,7 @@ export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilde
       table: this._table,
       conditions: this._conditions,
       includes: this._includes,
+      select: this._selectColumns,
       orderBy: this._orderBys,
       limit: this._limitVal,
       offset: this._offsetVal,
@@ -567,10 +621,14 @@ export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilde
     });
   }
 
-  private _clone<CloneI extends TodoInclude = I>(): TodoQueryBuilder<CloneI> {
-    const clone = new TodoQueryBuilder<CloneI>();
+  private _clone<CloneI extends TodoInclude = I, CloneS extends keyof Todo = S>(): TodoQueryBuilder<
+    CloneI,
+    CloneS
+  > {
+    const clone = new TodoQueryBuilder<CloneI, CloneS>();
     clone._conditions = [...this._conditions];
     clone._includes = { ...this._includes };
+    clone._selectColumns = this._selectColumns ? [...this._selectColumns] : undefined;
     clone._orderBys = [...this._orderBys];
     clone._limitVal = this._limitVal;
     clone._offsetVal = this._offsetVal;

--- a/examples/todo-client-localfirst-ts/schema/app.ts
+++ b/examples/todo-client-localfirst-ts/schema/app.ts
@@ -75,8 +75,11 @@ export type ProjectWithIncludes<I extends ProjectInclude = {}> = Project & {
   todosViaProject?: NonNullable<I["todosViaProject"]> extends infer RelationInclude
     ? RelationInclude extends true
       ? Todo[]
-      : RelationInclude extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
-        ? TodoWithIncludes<QueryInclude>[]
+      : RelationInclude extends TodoQueryBuilder<
+            infer QueryInclude extends TodoInclude,
+            infer QuerySelect extends keyof Todo
+          >
+        ? TodoSelectedWithIncludes<QueryInclude, QuerySelect>[]
         : RelationInclude extends TodoInclude
           ? TodoWithIncludes<RelationInclude>[]
           : never
@@ -87,8 +90,11 @@ export type TodoWithIncludes<I extends TodoInclude = {}> = Todo & {
   parent?: NonNullable<I["parent"]> extends infer RelationInclude
     ? RelationInclude extends true
       ? Todo
-      : RelationInclude extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
-        ? TodoWithIncludes<QueryInclude>
+      : RelationInclude extends TodoQueryBuilder<
+            infer QueryInclude extends TodoInclude,
+            infer QuerySelect extends keyof Todo
+          >
+        ? TodoSelectedWithIncludes<QueryInclude, QuerySelect>
         : RelationInclude extends TodoInclude
           ? TodoWithIncludes<RelationInclude>
           : never
@@ -96,8 +102,11 @@ export type TodoWithIncludes<I extends TodoInclude = {}> = Todo & {
   todosViaParent?: NonNullable<I["todosViaParent"]> extends infer RelationInclude
     ? RelationInclude extends true
       ? Todo[]
-      : RelationInclude extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
-        ? TodoWithIncludes<QueryInclude>[]
+      : RelationInclude extends TodoQueryBuilder<
+            infer QueryInclude extends TodoInclude,
+            infer QuerySelect extends keyof Todo
+          >
+        ? TodoSelectedWithIncludes<QueryInclude, QuerySelect>[]
         : RelationInclude extends TodoInclude
           ? TodoWithIncludes<RelationInclude>[]
           : never
@@ -105,13 +114,36 @@ export type TodoWithIncludes<I extends TodoInclude = {}> = Todo & {
   project?: NonNullable<I["project"]> extends infer RelationInclude
     ? RelationInclude extends true
       ? Project
-      : RelationInclude extends ProjectQueryBuilder<infer QueryInclude extends ProjectInclude>
-        ? ProjectWithIncludes<QueryInclude>
+      : RelationInclude extends ProjectQueryBuilder<
+            infer QueryInclude extends ProjectInclude,
+            infer QuerySelect extends keyof Project
+          >
+        ? ProjectSelectedWithIncludes<QueryInclude, QuerySelect>
         : RelationInclude extends ProjectInclude
           ? ProjectWithIncludes<RelationInclude>
           : never
     : never;
 };
+
+export type ProjectSelected<S extends keyof Project = keyof Project> = Pick<
+  Project,
+  Extract<S | "id", keyof Project>
+>;
+
+export type ProjectSelectedWithIncludes<
+  I extends ProjectInclude = {},
+  S extends keyof Project = keyof Project,
+> = ProjectSelected<S> & Omit<ProjectWithIncludes<I>, keyof Project>;
+
+export type TodoSelected<S extends keyof Todo = keyof Todo> = Pick<
+  Todo,
+  Extract<S | "id", keyof Todo>
+>;
+
+export type TodoSelectedWithIncludes<
+  I extends TodoInclude = {},
+  S extends keyof Todo = keyof Todo,
+> = TodoSelected<S> & Omit<TodoWithIncludes<I>, keyof Todo>;
 
 export const wasmSchema: WasmSchema = {
   projects: {
@@ -224,15 +256,17 @@ export const wasmSchema: WasmSchema = {
   },
 };
 
-export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements QueryBuilder<
-  ProjectWithIncludes<I>
-> {
+export class ProjectQueryBuilder<
+  I extends ProjectInclude = {},
+  S extends keyof Project = keyof Project,
+> implements QueryBuilder<ProjectSelectedWithIncludes<I, S>> {
   readonly _table = "projects";
   readonly _schema: WasmSchema = wasmSchema;
-  declare readonly _rowType: ProjectWithIncludes<I>;
+  declare readonly _rowType: ProjectSelectedWithIncludes<I, S>;
   declare readonly _initType: ProjectInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<ProjectInclude> = {};
+  private _selectColumns?: string[];
   private _orderBys: Array<[string, "asc" | "desc"]> = [];
   private _limitVal?: number;
   private _offsetVal?: number;
@@ -245,7 +279,7 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
     step_hops: string[];
   };
 
-  where(conditions: ProjectWhereInput): ProjectQueryBuilder<I> {
+  where(conditions: ProjectWhereInput): ProjectQueryBuilder<I, S> {
     const clone = this._clone();
     for (const [key, value] of Object.entries(conditions)) {
       if (value === undefined) continue;
@@ -262,31 +296,37 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
     return clone;
   }
 
-  include<NewI extends ProjectInclude>(relations: NewI): ProjectQueryBuilder<I & NewI> {
-    const clone = this._clone<I & NewI>();
+  select<NewS extends keyof Project>(...columns: [NewS, ...NewS[]]): ProjectQueryBuilder<I, NewS> {
+    const clone = this._clone<I, NewS>();
+    clone._selectColumns = [...columns] as string[];
+    return clone;
+  }
+
+  include<NewI extends ProjectInclude>(relations: NewI): ProjectQueryBuilder<I & NewI, S> {
+    const clone = this._clone<I & NewI, S>();
     clone._includes = { ...this._includes, ...relations };
     return clone;
   }
 
-  orderBy(column: keyof Project, direction: "asc" | "desc" = "asc"): ProjectQueryBuilder<I> {
+  orderBy(column: keyof Project, direction: "asc" | "desc" = "asc"): ProjectQueryBuilder<I, S> {
     const clone = this._clone();
     clone._orderBys.push([column as string, direction]);
     return clone;
   }
 
-  limit(n: number): ProjectQueryBuilder<I> {
+  limit(n: number): ProjectQueryBuilder<I, S> {
     const clone = this._clone();
     clone._limitVal = n;
     return clone;
   }
 
-  offset(n: number): ProjectQueryBuilder<I> {
+  offset(n: number): ProjectQueryBuilder<I, S> {
     const clone = this._clone();
     clone._offsetVal = n;
     return clone;
   }
 
-  hopTo(relation: "todosViaProject"): ProjectQueryBuilder<I> {
+  hopTo(relation: "todosViaProject"): ProjectQueryBuilder<I, S> {
     const clone = this._clone();
     clone._hops.push(relation);
     return clone;
@@ -296,7 +336,7 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
     start: ProjectWhereInput;
     step: (ctx: { current: string }) => QueryBuilder<unknown>;
     maxDepth?: number;
-  }): ProjectQueryBuilder<I> {
+  }): ProjectQueryBuilder<I, S> {
     if (options.start === undefined) {
       throw new Error("gather(...) requires start where conditions.");
     }
@@ -378,6 +418,7 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
       table: this._table,
       conditions: this._conditions,
       includes: this._includes,
+      select: this._selectColumns,
       orderBy: this._orderBys,
       limit: this._limitVal,
       offset: this._offsetVal,
@@ -386,10 +427,14 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
     });
   }
 
-  private _clone<CloneI extends ProjectInclude = I>(): ProjectQueryBuilder<CloneI> {
-    const clone = new ProjectQueryBuilder<CloneI>();
+  private _clone<
+    CloneI extends ProjectInclude = I,
+    CloneS extends keyof Project = S,
+  >(): ProjectQueryBuilder<CloneI, CloneS> {
+    const clone = new ProjectQueryBuilder<CloneI, CloneS>();
     clone._conditions = [...this._conditions];
     clone._includes = { ...this._includes };
+    clone._selectColumns = this._selectColumns ? [...this._selectColumns] : undefined;
     clone._orderBys = [...this._orderBys];
     clone._limitVal = this._limitVal;
     clone._offsetVal = this._offsetVal;
@@ -405,15 +450,17 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
   }
 }
 
-export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilder<
-  TodoWithIncludes<I>
-> {
+export class TodoQueryBuilder<
+  I extends TodoInclude = {},
+  S extends keyof Todo = keyof Todo,
+> implements QueryBuilder<TodoSelectedWithIncludes<I, S>> {
   readonly _table = "todos";
   readonly _schema: WasmSchema = wasmSchema;
-  declare readonly _rowType: TodoWithIncludes<I>;
+  declare readonly _rowType: TodoSelectedWithIncludes<I, S>;
   declare readonly _initType: TodoInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<TodoInclude> = {};
+  private _selectColumns?: string[];
   private _orderBys: Array<[string, "asc" | "desc"]> = [];
   private _limitVal?: number;
   private _offsetVal?: number;
@@ -426,7 +473,7 @@ export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilde
     step_hops: string[];
   };
 
-  where(conditions: TodoWhereInput): TodoQueryBuilder<I> {
+  where(conditions: TodoWhereInput): TodoQueryBuilder<I, S> {
     const clone = this._clone();
     for (const [key, value] of Object.entries(conditions)) {
       if (value === undefined) continue;
@@ -443,31 +490,37 @@ export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilde
     return clone;
   }
 
-  include<NewI extends TodoInclude>(relations: NewI): TodoQueryBuilder<I & NewI> {
-    const clone = this._clone<I & NewI>();
+  select<NewS extends keyof Todo>(...columns: [NewS, ...NewS[]]): TodoQueryBuilder<I, NewS> {
+    const clone = this._clone<I, NewS>();
+    clone._selectColumns = [...columns] as string[];
+    return clone;
+  }
+
+  include<NewI extends TodoInclude>(relations: NewI): TodoQueryBuilder<I & NewI, S> {
+    const clone = this._clone<I & NewI, S>();
     clone._includes = { ...this._includes, ...relations };
     return clone;
   }
 
-  orderBy(column: keyof Todo, direction: "asc" | "desc" = "asc"): TodoQueryBuilder<I> {
+  orderBy(column: keyof Todo, direction: "asc" | "desc" = "asc"): TodoQueryBuilder<I, S> {
     const clone = this._clone();
     clone._orderBys.push([column as string, direction]);
     return clone;
   }
 
-  limit(n: number): TodoQueryBuilder<I> {
+  limit(n: number): TodoQueryBuilder<I, S> {
     const clone = this._clone();
     clone._limitVal = n;
     return clone;
   }
 
-  offset(n: number): TodoQueryBuilder<I> {
+  offset(n: number): TodoQueryBuilder<I, S> {
     const clone = this._clone();
     clone._offsetVal = n;
     return clone;
   }
 
-  hopTo(relation: "parent" | "todosViaParent" | "project"): TodoQueryBuilder<I> {
+  hopTo(relation: "parent" | "todosViaParent" | "project"): TodoQueryBuilder<I, S> {
     const clone = this._clone();
     clone._hops.push(relation);
     return clone;
@@ -477,7 +530,7 @@ export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilde
     start: TodoWhereInput;
     step: (ctx: { current: string }) => QueryBuilder<unknown>;
     maxDepth?: number;
-  }): TodoQueryBuilder<I> {
+  }): TodoQueryBuilder<I, S> {
     if (options.start === undefined) {
       throw new Error("gather(...) requires start where conditions.");
     }
@@ -559,6 +612,7 @@ export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilde
       table: this._table,
       conditions: this._conditions,
       includes: this._includes,
+      select: this._selectColumns,
       orderBy: this._orderBys,
       limit: this._limitVal,
       offset: this._offsetVal,
@@ -567,10 +621,14 @@ export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilde
     });
   }
 
-  private _clone<CloneI extends TodoInclude = I>(): TodoQueryBuilder<CloneI> {
-    const clone = new TodoQueryBuilder<CloneI>();
+  private _clone<CloneI extends TodoInclude = I, CloneS extends keyof Todo = S>(): TodoQueryBuilder<
+    CloneI,
+    CloneS
+  > {
+    const clone = new TodoQueryBuilder<CloneI, CloneS>();
     clone._conditions = [...this._conditions];
     clone._includes = { ...this._includes };
+    clone._selectColumns = this._selectColumns ? [...this._selectColumns] : undefined;
     clone._orderBys = [...this._orderBys];
     clone._limitVal = this._limitVal;
     clone._offsetVal = this._offsetVal;

--- a/examples/wequencer/schema/app.ts
+++ b/examples/wequencer/schema/app.ts
@@ -158,8 +158,11 @@ export type InstrumentWithIncludes<I extends InstrumentInclude = {}> = Instrumen
   beatsViaInstrument?: NonNullable<I["beatsViaInstrument"]> extends infer RelationInclude
     ? RelationInclude extends true
       ? Beat[]
-      : RelationInclude extends BeatQueryBuilder<infer QueryInclude extends BeatInclude>
-        ? BeatWithIncludes<QueryInclude>[]
+      : RelationInclude extends BeatQueryBuilder<
+            infer QueryInclude extends BeatInclude,
+            infer QuerySelect extends keyof Beat
+          >
+        ? BeatSelectedWithIncludes<QueryInclude, QuerySelect>[]
         : RelationInclude extends BeatInclude
           ? BeatWithIncludes<RelationInclude>[]
           : never
@@ -170,8 +173,11 @@ export type JamWithIncludes<I extends JamInclude = {}> = Jam & {
   beatsViaJam?: NonNullable<I["beatsViaJam"]> extends infer RelationInclude
     ? RelationInclude extends true
       ? Beat[]
-      : RelationInclude extends BeatQueryBuilder<infer QueryInclude extends BeatInclude>
-        ? BeatWithIncludes<QueryInclude>[]
+      : RelationInclude extends BeatQueryBuilder<
+            infer QueryInclude extends BeatInclude,
+            infer QuerySelect extends keyof Beat
+          >
+        ? BeatSelectedWithIncludes<QueryInclude, QuerySelect>[]
         : RelationInclude extends BeatInclude
           ? BeatWithIncludes<RelationInclude>[]
           : never
@@ -180,9 +186,10 @@ export type JamWithIncludes<I extends JamInclude = {}> = Jam & {
     ? RelationInclude extends true
       ? Participant[]
       : RelationInclude extends ParticipantQueryBuilder<
-            infer QueryInclude extends ParticipantInclude
+            infer QueryInclude extends ParticipantInclude,
+            infer QuerySelect extends keyof Participant
           >
-        ? ParticipantWithIncludes<QueryInclude>[]
+        ? ParticipantSelectedWithIncludes<QueryInclude, QuerySelect>[]
         : RelationInclude extends ParticipantInclude
           ? ParticipantWithIncludes<RelationInclude>[]
           : never
@@ -193,8 +200,11 @@ export type BeatWithIncludes<I extends BeatInclude = {}> = Beat & {
   jam?: NonNullable<I["jam"]> extends infer RelationInclude
     ? RelationInclude extends true
       ? Jam
-      : RelationInclude extends JamQueryBuilder<infer QueryInclude extends JamInclude>
-        ? JamWithIncludes<QueryInclude>
+      : RelationInclude extends JamQueryBuilder<
+            infer QueryInclude extends JamInclude,
+            infer QuerySelect extends keyof Jam
+          >
+        ? JamSelectedWithIncludes<QueryInclude, QuerySelect>
         : RelationInclude extends JamInclude
           ? JamWithIncludes<RelationInclude>
           : never
@@ -202,8 +212,11 @@ export type BeatWithIncludes<I extends BeatInclude = {}> = Beat & {
   instrument?: NonNullable<I["instrument"]> extends infer RelationInclude
     ? RelationInclude extends true
       ? Instrument
-      : RelationInclude extends InstrumentQueryBuilder<infer QueryInclude extends InstrumentInclude>
-        ? InstrumentWithIncludes<QueryInclude>
+      : RelationInclude extends InstrumentQueryBuilder<
+            infer QueryInclude extends InstrumentInclude,
+            infer QuerySelect extends keyof Instrument
+          >
+        ? InstrumentSelectedWithIncludes<QueryInclude, QuerySelect>
         : RelationInclude extends InstrumentInclude
           ? InstrumentWithIncludes<RelationInclude>
           : never
@@ -214,13 +227,53 @@ export type ParticipantWithIncludes<I extends ParticipantInclude = {}> = Partici
   jam?: NonNullable<I["jam"]> extends infer RelationInclude
     ? RelationInclude extends true
       ? Jam
-      : RelationInclude extends JamQueryBuilder<infer QueryInclude extends JamInclude>
-        ? JamWithIncludes<QueryInclude>
+      : RelationInclude extends JamQueryBuilder<
+            infer QueryInclude extends JamInclude,
+            infer QuerySelect extends keyof Jam
+          >
+        ? JamSelectedWithIncludes<QueryInclude, QuerySelect>
         : RelationInclude extends JamInclude
           ? JamWithIncludes<RelationInclude>
           : never
     : never;
 };
+
+export type InstrumentSelected<S extends keyof Instrument = keyof Instrument> = Pick<
+  Instrument,
+  Extract<S | "id", keyof Instrument>
+>;
+
+export type InstrumentSelectedWithIncludes<
+  I extends InstrumentInclude = {},
+  S extends keyof Instrument = keyof Instrument,
+> = InstrumentSelected<S> & Omit<InstrumentWithIncludes<I>, keyof Instrument>;
+
+export type JamSelected<S extends keyof Jam = keyof Jam> = Pick<Jam, Extract<S | "id", keyof Jam>>;
+
+export type JamSelectedWithIncludes<
+  I extends JamInclude = {},
+  S extends keyof Jam = keyof Jam,
+> = JamSelected<S> & Omit<JamWithIncludes<I>, keyof Jam>;
+
+export type BeatSelected<S extends keyof Beat = keyof Beat> = Pick<
+  Beat,
+  Extract<S | "id", keyof Beat>
+>;
+
+export type BeatSelectedWithIncludes<
+  I extends BeatInclude = {},
+  S extends keyof Beat = keyof Beat,
+> = BeatSelected<S> & Omit<BeatWithIncludes<I>, keyof Beat>;
+
+export type ParticipantSelected<S extends keyof Participant = keyof Participant> = Pick<
+  Participant,
+  Extract<S | "id", keyof Participant>
+>;
+
+export type ParticipantSelectedWithIncludes<
+  I extends ParticipantInclude = {},
+  S extends keyof Participant = keyof Participant,
+> = ParticipantSelected<S> & Omit<ParticipantWithIncludes<I>, keyof Participant>;
 
 export const wasmSchema: WasmSchema = {
   instruments: {
@@ -342,15 +395,17 @@ export const wasmSchema: WasmSchema = {
   },
 };
 
-export class InstrumentQueryBuilder<I extends InstrumentInclude = {}> implements QueryBuilder<
-  InstrumentWithIncludes<I>
-> {
+export class InstrumentQueryBuilder<
+  I extends InstrumentInclude = {},
+  S extends keyof Instrument = keyof Instrument,
+> implements QueryBuilder<InstrumentSelectedWithIncludes<I, S>> {
   readonly _table = "instruments";
   readonly _schema: WasmSchema = wasmSchema;
-  declare readonly _rowType: InstrumentWithIncludes<I>;
+  declare readonly _rowType: InstrumentSelectedWithIncludes<I, S>;
   declare readonly _initType: InstrumentInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<InstrumentInclude> = {};
+  private _selectColumns?: string[];
   private _orderBys: Array<[string, "asc" | "desc"]> = [];
   private _limitVal?: number;
   private _offsetVal?: number;
@@ -363,7 +418,7 @@ export class InstrumentQueryBuilder<I extends InstrumentInclude = {}> implements
     step_hops: string[];
   };
 
-  where(conditions: InstrumentWhereInput): InstrumentQueryBuilder<I> {
+  where(conditions: InstrumentWhereInput): InstrumentQueryBuilder<I, S> {
     const clone = this._clone();
     for (const [key, value] of Object.entries(conditions)) {
       if (value === undefined) continue;
@@ -380,31 +435,42 @@ export class InstrumentQueryBuilder<I extends InstrumentInclude = {}> implements
     return clone;
   }
 
-  include<NewI extends InstrumentInclude>(relations: NewI): InstrumentQueryBuilder<I & NewI> {
-    const clone = this._clone<I & NewI>();
+  select<NewS extends keyof Instrument>(
+    ...columns: [NewS, ...NewS[]]
+  ): InstrumentQueryBuilder<I, NewS> {
+    const clone = this._clone<I, NewS>();
+    clone._selectColumns = [...columns] as string[];
+    return clone;
+  }
+
+  include<NewI extends InstrumentInclude>(relations: NewI): InstrumentQueryBuilder<I & NewI, S> {
+    const clone = this._clone<I & NewI, S>();
     clone._includes = { ...this._includes, ...relations };
     return clone;
   }
 
-  orderBy(column: keyof Instrument, direction: "asc" | "desc" = "asc"): InstrumentQueryBuilder<I> {
+  orderBy(
+    column: keyof Instrument,
+    direction: "asc" | "desc" = "asc",
+  ): InstrumentQueryBuilder<I, S> {
     const clone = this._clone();
     clone._orderBys.push([column as string, direction]);
     return clone;
   }
 
-  limit(n: number): InstrumentQueryBuilder<I> {
+  limit(n: number): InstrumentQueryBuilder<I, S> {
     const clone = this._clone();
     clone._limitVal = n;
     return clone;
   }
 
-  offset(n: number): InstrumentQueryBuilder<I> {
+  offset(n: number): InstrumentQueryBuilder<I, S> {
     const clone = this._clone();
     clone._offsetVal = n;
     return clone;
   }
 
-  hopTo(relation: "beatsViaInstrument"): InstrumentQueryBuilder<I> {
+  hopTo(relation: "beatsViaInstrument"): InstrumentQueryBuilder<I, S> {
     const clone = this._clone();
     clone._hops.push(relation);
     return clone;
@@ -414,7 +480,7 @@ export class InstrumentQueryBuilder<I extends InstrumentInclude = {}> implements
     start: InstrumentWhereInput;
     step: (ctx: { current: string }) => QueryBuilder<unknown>;
     maxDepth?: number;
-  }): InstrumentQueryBuilder<I> {
+  }): InstrumentQueryBuilder<I, S> {
     if (options.start === undefined) {
       throw new Error("gather(...) requires start where conditions.");
     }
@@ -496,6 +562,7 @@ export class InstrumentQueryBuilder<I extends InstrumentInclude = {}> implements
       table: this._table,
       conditions: this._conditions,
       includes: this._includes,
+      select: this._selectColumns,
       orderBy: this._orderBys,
       limit: this._limitVal,
       offset: this._offsetVal,
@@ -504,10 +571,14 @@ export class InstrumentQueryBuilder<I extends InstrumentInclude = {}> implements
     });
   }
 
-  private _clone<CloneI extends InstrumentInclude = I>(): InstrumentQueryBuilder<CloneI> {
-    const clone = new InstrumentQueryBuilder<CloneI>();
+  private _clone<
+    CloneI extends InstrumentInclude = I,
+    CloneS extends keyof Instrument = S,
+  >(): InstrumentQueryBuilder<CloneI, CloneS> {
+    const clone = new InstrumentQueryBuilder<CloneI, CloneS>();
     clone._conditions = [...this._conditions];
     clone._includes = { ...this._includes };
+    clone._selectColumns = this._selectColumns ? [...this._selectColumns] : undefined;
     clone._orderBys = [...this._orderBys];
     clone._limitVal = this._limitVal;
     clone._offsetVal = this._offsetVal;
@@ -523,15 +594,17 @@ export class InstrumentQueryBuilder<I extends InstrumentInclude = {}> implements
   }
 }
 
-export class JamQueryBuilder<I extends JamInclude = {}> implements QueryBuilder<
-  JamWithIncludes<I>
-> {
+export class JamQueryBuilder<
+  I extends JamInclude = {},
+  S extends keyof Jam = keyof Jam,
+> implements QueryBuilder<JamSelectedWithIncludes<I, S>> {
   readonly _table = "jams";
   readonly _schema: WasmSchema = wasmSchema;
-  declare readonly _rowType: JamWithIncludes<I>;
+  declare readonly _rowType: JamSelectedWithIncludes<I, S>;
   declare readonly _initType: JamInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<JamInclude> = {};
+  private _selectColumns?: string[];
   private _orderBys: Array<[string, "asc" | "desc"]> = [];
   private _limitVal?: number;
   private _offsetVal?: number;
@@ -544,7 +617,7 @@ export class JamQueryBuilder<I extends JamInclude = {}> implements QueryBuilder<
     step_hops: string[];
   };
 
-  where(conditions: JamWhereInput): JamQueryBuilder<I> {
+  where(conditions: JamWhereInput): JamQueryBuilder<I, S> {
     const clone = this._clone();
     for (const [key, value] of Object.entries(conditions)) {
       if (value === undefined) continue;
@@ -561,31 +634,37 @@ export class JamQueryBuilder<I extends JamInclude = {}> implements QueryBuilder<
     return clone;
   }
 
-  include<NewI extends JamInclude>(relations: NewI): JamQueryBuilder<I & NewI> {
-    const clone = this._clone<I & NewI>();
+  select<NewS extends keyof Jam>(...columns: [NewS, ...NewS[]]): JamQueryBuilder<I, NewS> {
+    const clone = this._clone<I, NewS>();
+    clone._selectColumns = [...columns] as string[];
+    return clone;
+  }
+
+  include<NewI extends JamInclude>(relations: NewI): JamQueryBuilder<I & NewI, S> {
+    const clone = this._clone<I & NewI, S>();
     clone._includes = { ...this._includes, ...relations };
     return clone;
   }
 
-  orderBy(column: keyof Jam, direction: "asc" | "desc" = "asc"): JamQueryBuilder<I> {
+  orderBy(column: keyof Jam, direction: "asc" | "desc" = "asc"): JamQueryBuilder<I, S> {
     const clone = this._clone();
     clone._orderBys.push([column as string, direction]);
     return clone;
   }
 
-  limit(n: number): JamQueryBuilder<I> {
+  limit(n: number): JamQueryBuilder<I, S> {
     const clone = this._clone();
     clone._limitVal = n;
     return clone;
   }
 
-  offset(n: number): JamQueryBuilder<I> {
+  offset(n: number): JamQueryBuilder<I, S> {
     const clone = this._clone();
     clone._offsetVal = n;
     return clone;
   }
 
-  hopTo(relation: "beatsViaJam" | "participantsViaJam"): JamQueryBuilder<I> {
+  hopTo(relation: "beatsViaJam" | "participantsViaJam"): JamQueryBuilder<I, S> {
     const clone = this._clone();
     clone._hops.push(relation);
     return clone;
@@ -595,7 +674,7 @@ export class JamQueryBuilder<I extends JamInclude = {}> implements QueryBuilder<
     start: JamWhereInput;
     step: (ctx: { current: string }) => QueryBuilder<unknown>;
     maxDepth?: number;
-  }): JamQueryBuilder<I> {
+  }): JamQueryBuilder<I, S> {
     if (options.start === undefined) {
       throw new Error("gather(...) requires start where conditions.");
     }
@@ -677,6 +756,7 @@ export class JamQueryBuilder<I extends JamInclude = {}> implements QueryBuilder<
       table: this._table,
       conditions: this._conditions,
       includes: this._includes,
+      select: this._selectColumns,
       orderBy: this._orderBys,
       limit: this._limitVal,
       offset: this._offsetVal,
@@ -685,10 +765,14 @@ export class JamQueryBuilder<I extends JamInclude = {}> implements QueryBuilder<
     });
   }
 
-  private _clone<CloneI extends JamInclude = I>(): JamQueryBuilder<CloneI> {
-    const clone = new JamQueryBuilder<CloneI>();
+  private _clone<CloneI extends JamInclude = I, CloneS extends keyof Jam = S>(): JamQueryBuilder<
+    CloneI,
+    CloneS
+  > {
+    const clone = new JamQueryBuilder<CloneI, CloneS>();
     clone._conditions = [...this._conditions];
     clone._includes = { ...this._includes };
+    clone._selectColumns = this._selectColumns ? [...this._selectColumns] : undefined;
     clone._orderBys = [...this._orderBys];
     clone._limitVal = this._limitVal;
     clone._offsetVal = this._offsetVal;
@@ -704,15 +788,17 @@ export class JamQueryBuilder<I extends JamInclude = {}> implements QueryBuilder<
   }
 }
 
-export class BeatQueryBuilder<I extends BeatInclude = {}> implements QueryBuilder<
-  BeatWithIncludes<I>
-> {
+export class BeatQueryBuilder<
+  I extends BeatInclude = {},
+  S extends keyof Beat = keyof Beat,
+> implements QueryBuilder<BeatSelectedWithIncludes<I, S>> {
   readonly _table = "beats";
   readonly _schema: WasmSchema = wasmSchema;
-  declare readonly _rowType: BeatWithIncludes<I>;
+  declare readonly _rowType: BeatSelectedWithIncludes<I, S>;
   declare readonly _initType: BeatInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<BeatInclude> = {};
+  private _selectColumns?: string[];
   private _orderBys: Array<[string, "asc" | "desc"]> = [];
   private _limitVal?: number;
   private _offsetVal?: number;
@@ -725,7 +811,7 @@ export class BeatQueryBuilder<I extends BeatInclude = {}> implements QueryBuilde
     step_hops: string[];
   };
 
-  where(conditions: BeatWhereInput): BeatQueryBuilder<I> {
+  where(conditions: BeatWhereInput): BeatQueryBuilder<I, S> {
     const clone = this._clone();
     for (const [key, value] of Object.entries(conditions)) {
       if (value === undefined) continue;
@@ -742,31 +828,37 @@ export class BeatQueryBuilder<I extends BeatInclude = {}> implements QueryBuilde
     return clone;
   }
 
-  include<NewI extends BeatInclude>(relations: NewI): BeatQueryBuilder<I & NewI> {
-    const clone = this._clone<I & NewI>();
+  select<NewS extends keyof Beat>(...columns: [NewS, ...NewS[]]): BeatQueryBuilder<I, NewS> {
+    const clone = this._clone<I, NewS>();
+    clone._selectColumns = [...columns] as string[];
+    return clone;
+  }
+
+  include<NewI extends BeatInclude>(relations: NewI): BeatQueryBuilder<I & NewI, S> {
+    const clone = this._clone<I & NewI, S>();
     clone._includes = { ...this._includes, ...relations };
     return clone;
   }
 
-  orderBy(column: keyof Beat, direction: "asc" | "desc" = "asc"): BeatQueryBuilder<I> {
+  orderBy(column: keyof Beat, direction: "asc" | "desc" = "asc"): BeatQueryBuilder<I, S> {
     const clone = this._clone();
     clone._orderBys.push([column as string, direction]);
     return clone;
   }
 
-  limit(n: number): BeatQueryBuilder<I> {
+  limit(n: number): BeatQueryBuilder<I, S> {
     const clone = this._clone();
     clone._limitVal = n;
     return clone;
   }
 
-  offset(n: number): BeatQueryBuilder<I> {
+  offset(n: number): BeatQueryBuilder<I, S> {
     const clone = this._clone();
     clone._offsetVal = n;
     return clone;
   }
 
-  hopTo(relation: "jam" | "instrument"): BeatQueryBuilder<I> {
+  hopTo(relation: "jam" | "instrument"): BeatQueryBuilder<I, S> {
     const clone = this._clone();
     clone._hops.push(relation);
     return clone;
@@ -776,7 +868,7 @@ export class BeatQueryBuilder<I extends BeatInclude = {}> implements QueryBuilde
     start: BeatWhereInput;
     step: (ctx: { current: string }) => QueryBuilder<unknown>;
     maxDepth?: number;
-  }): BeatQueryBuilder<I> {
+  }): BeatQueryBuilder<I, S> {
     if (options.start === undefined) {
       throw new Error("gather(...) requires start where conditions.");
     }
@@ -858,6 +950,7 @@ export class BeatQueryBuilder<I extends BeatInclude = {}> implements QueryBuilde
       table: this._table,
       conditions: this._conditions,
       includes: this._includes,
+      select: this._selectColumns,
       orderBy: this._orderBys,
       limit: this._limitVal,
       offset: this._offsetVal,
@@ -866,10 +959,14 @@ export class BeatQueryBuilder<I extends BeatInclude = {}> implements QueryBuilde
     });
   }
 
-  private _clone<CloneI extends BeatInclude = I>(): BeatQueryBuilder<CloneI> {
-    const clone = new BeatQueryBuilder<CloneI>();
+  private _clone<CloneI extends BeatInclude = I, CloneS extends keyof Beat = S>(): BeatQueryBuilder<
+    CloneI,
+    CloneS
+  > {
+    const clone = new BeatQueryBuilder<CloneI, CloneS>();
     clone._conditions = [...this._conditions];
     clone._includes = { ...this._includes };
+    clone._selectColumns = this._selectColumns ? [...this._selectColumns] : undefined;
     clone._orderBys = [...this._orderBys];
     clone._limitVal = this._limitVal;
     clone._offsetVal = this._offsetVal;
@@ -885,15 +982,17 @@ export class BeatQueryBuilder<I extends BeatInclude = {}> implements QueryBuilde
   }
 }
 
-export class ParticipantQueryBuilder<I extends ParticipantInclude = {}> implements QueryBuilder<
-  ParticipantWithIncludes<I>
-> {
+export class ParticipantQueryBuilder<
+  I extends ParticipantInclude = {},
+  S extends keyof Participant = keyof Participant,
+> implements QueryBuilder<ParticipantSelectedWithIncludes<I, S>> {
   readonly _table = "participants";
   readonly _schema: WasmSchema = wasmSchema;
-  declare readonly _rowType: ParticipantWithIncludes<I>;
+  declare readonly _rowType: ParticipantSelectedWithIncludes<I, S>;
   declare readonly _initType: ParticipantInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<ParticipantInclude> = {};
+  private _selectColumns?: string[];
   private _orderBys: Array<[string, "asc" | "desc"]> = [];
   private _limitVal?: number;
   private _offsetVal?: number;
@@ -906,7 +1005,7 @@ export class ParticipantQueryBuilder<I extends ParticipantInclude = {}> implemen
     step_hops: string[];
   };
 
-  where(conditions: ParticipantWhereInput): ParticipantQueryBuilder<I> {
+  where(conditions: ParticipantWhereInput): ParticipantQueryBuilder<I, S> {
     const clone = this._clone();
     for (const [key, value] of Object.entries(conditions)) {
       if (value === undefined) continue;
@@ -923,8 +1022,16 @@ export class ParticipantQueryBuilder<I extends ParticipantInclude = {}> implemen
     return clone;
   }
 
-  include<NewI extends ParticipantInclude>(relations: NewI): ParticipantQueryBuilder<I & NewI> {
-    const clone = this._clone<I & NewI>();
+  select<NewS extends keyof Participant>(
+    ...columns: [NewS, ...NewS[]]
+  ): ParticipantQueryBuilder<I, NewS> {
+    const clone = this._clone<I, NewS>();
+    clone._selectColumns = [...columns] as string[];
+    return clone;
+  }
+
+  include<NewI extends ParticipantInclude>(relations: NewI): ParticipantQueryBuilder<I & NewI, S> {
+    const clone = this._clone<I & NewI, S>();
     clone._includes = { ...this._includes, ...relations };
     return clone;
   }
@@ -932,25 +1039,25 @@ export class ParticipantQueryBuilder<I extends ParticipantInclude = {}> implemen
   orderBy(
     column: keyof Participant,
     direction: "asc" | "desc" = "asc",
-  ): ParticipantQueryBuilder<I> {
+  ): ParticipantQueryBuilder<I, S> {
     const clone = this._clone();
     clone._orderBys.push([column as string, direction]);
     return clone;
   }
 
-  limit(n: number): ParticipantQueryBuilder<I> {
+  limit(n: number): ParticipantQueryBuilder<I, S> {
     const clone = this._clone();
     clone._limitVal = n;
     return clone;
   }
 
-  offset(n: number): ParticipantQueryBuilder<I> {
+  offset(n: number): ParticipantQueryBuilder<I, S> {
     const clone = this._clone();
     clone._offsetVal = n;
     return clone;
   }
 
-  hopTo(relation: "jam"): ParticipantQueryBuilder<I> {
+  hopTo(relation: "jam"): ParticipantQueryBuilder<I, S> {
     const clone = this._clone();
     clone._hops.push(relation);
     return clone;
@@ -960,7 +1067,7 @@ export class ParticipantQueryBuilder<I extends ParticipantInclude = {}> implemen
     start: ParticipantWhereInput;
     step: (ctx: { current: string }) => QueryBuilder<unknown>;
     maxDepth?: number;
-  }): ParticipantQueryBuilder<I> {
+  }): ParticipantQueryBuilder<I, S> {
     if (options.start === undefined) {
       throw new Error("gather(...) requires start where conditions.");
     }
@@ -1042,6 +1149,7 @@ export class ParticipantQueryBuilder<I extends ParticipantInclude = {}> implemen
       table: this._table,
       conditions: this._conditions,
       includes: this._includes,
+      select: this._selectColumns,
       orderBy: this._orderBys,
       limit: this._limitVal,
       offset: this._offsetVal,
@@ -1050,10 +1158,14 @@ export class ParticipantQueryBuilder<I extends ParticipantInclude = {}> implemen
     });
   }
 
-  private _clone<CloneI extends ParticipantInclude = I>(): ParticipantQueryBuilder<CloneI> {
-    const clone = new ParticipantQueryBuilder<CloneI>();
+  private _clone<
+    CloneI extends ParticipantInclude = I,
+    CloneS extends keyof Participant = S,
+  >(): ParticipantQueryBuilder<CloneI, CloneS> {
+    const clone = new ParticipantQueryBuilder<CloneI, CloneS>();
     clone._conditions = [...this._conditions];
     clone._includes = { ...this._includes };
+    clone._selectColumns = this._selectColumns ? [...this._selectColumns] : undefined;
     clone._orderBys = [...this._orderBys];
     clone._limitVal = this._limitVal;
     clone._offsetVal = this._offsetVal;

--- a/packages/jazz-tools/src/codegen/codegen.test.ts
+++ b/packages/jazz-tools/src/codegen/codegen.test.ts
@@ -810,7 +810,7 @@ describe("generateTypes with relations", () => {
     expect(output).toContain("? RelationInclude extends true");
     expect(output).toContain("? User");
     expect(output).toContain(
-      ": RelationInclude extends UserQueryBuilder<infer QueryInclude extends UserInclude, infer QuerySelect extends keyof User>",
+      ': RelationInclude extends UserQueryBuilder<infer QueryInclude extends UserInclude, infer QuerySelect extends keyof User | "*">',
     );
     expect(output).toContain("? UserSelectedWithIncludes<QueryInclude, QuerySelect>");
     expect(output).toContain(": RelationInclude extends UserInclude");
@@ -820,7 +820,7 @@ describe("generateTypes with relations", () => {
     );
     expect(output).toContain("? Todo[]");
     expect(output).toContain(
-      ": RelationInclude extends TodoQueryBuilder<infer QueryInclude extends TodoInclude, infer QuerySelect extends keyof Todo>",
+      ': RelationInclude extends TodoQueryBuilder<infer QueryInclude extends TodoInclude, infer QuerySelect extends keyof Todo | "*">',
     );
     expect(output).toContain("? TodoSelectedWithIncludes<QueryInclude, QuerySelect>[]");
     expect(output).toContain(": RelationInclude extends TodoInclude");
@@ -836,10 +836,10 @@ describe("generateTypes with relations", () => {
     const wasm = schemaToWasm(schema);
     const output = generateTypes(wasm);
 
-    expect(output).toContain("export type TodoSelected<S extends keyof Todo = keyof Todo>");
-    expect(output).toContain('Pick<Todo, Extract<S | "id", keyof Todo>>');
+    expect(output).toContain('export type TodoSelected<S extends keyof Todo | "*" = keyof Todo>');
+    expect(output).toContain('"*" extends S ? Todo : Pick<Todo, Extract<S | "id", keyof Todo>>');
     expect(output).toContain(
-      "export type TodoSelectedWithIncludes<I extends TodoInclude = {}, S extends keyof Todo = keyof Todo>",
+      'export type TodoSelectedWithIncludes<I extends TodoInclude = {}, S extends keyof Todo | "*" = keyof Todo>',
     );
     expect(output).toContain("TodoSelected<S> & Omit<TodoWithIncludes<I>, keyof Todo>");
   });
@@ -993,13 +993,13 @@ describe("generateQueryBuilderClasses", () => {
     const output = generateTypes(wasm);
 
     expect(output).toContain(
-      "export class TodoQueryBuilder<I extends Record<string, never> = {}, S extends keyof Todo = keyof Todo> implements QueryBuilder<TodoSelected<S>> {",
+      'export class TodoQueryBuilder<I extends Record<string, never> = {}, S extends keyof Todo | "*" = keyof Todo> implements QueryBuilder<TodoSelected<S>> {',
     );
     expect(output).toContain("declare readonly _rowType: TodoSelected<S>;");
     expect(output).toContain("declare readonly _initType: TodoInit;");
     expect(output).toContain("where(conditions: TodoWhereInput)");
     expect(output).toContain(
-      "select<NewS extends keyof Todo>(...columns: [NewS, ...NewS[]]): TodoQueryBuilder<I, NewS>",
+      'select<NewS extends keyof Todo | "*">(...columns: [NewS, ...NewS[]]): TodoQueryBuilder<I, NewS>',
     );
     expect(output).toContain("orderBy(column: keyof Todo");
     expect(output).toContain("limit(n: number)");
@@ -1016,7 +1016,7 @@ describe("generateQueryBuilderClasses", () => {
     const output = generateTypes(wasm);
 
     expect(output).toContain(
-      "export class TodoQueryBuilder<I extends TodoInclude = {}, S extends keyof Todo = keyof Todo> implements QueryBuilder<TodoSelectedWithIncludes<I, S>> {",
+      'export class TodoQueryBuilder<I extends TodoInclude = {}, S extends keyof Todo | "*" = keyof Todo> implements QueryBuilder<TodoSelectedWithIncludes<I, S>> {',
     );
     expect(output).toContain("declare readonly _rowType: TodoSelectedWithIncludes<I, S>;");
   });
@@ -1096,7 +1096,7 @@ describe("generateQueryBuilderClasses", () => {
     const output = generateTypes(wasm);
 
     expect(output).toContain(
-      "private _clone<CloneI extends Record<string, never> = I, CloneS extends keyof Todo = S>(): TodoQueryBuilder<CloneI, CloneS> {",
+      'private _clone<CloneI extends Record<string, never> = I, CloneS extends keyof Todo | "*" = S>(): TodoQueryBuilder<CloneI, CloneS> {',
     );
     expect(output).toContain("const clone = new TodoQueryBuilder<CloneI, CloneS>();");
     expect(output).toContain("clone._conditions = [...this._conditions];");

--- a/packages/jazz-tools/src/codegen/codegen.test.ts
+++ b/packages/jazz-tools/src/codegen/codegen.test.ts
@@ -810,9 +810,9 @@ describe("generateTypes with relations", () => {
     expect(output).toContain("? RelationInclude extends true");
     expect(output).toContain("? User");
     expect(output).toContain(
-      ": RelationInclude extends UserQueryBuilder<infer QueryInclude extends UserInclude>",
+      ": RelationInclude extends UserQueryBuilder<infer QueryInclude extends UserInclude, infer QuerySelect extends keyof User>",
     );
-    expect(output).toContain("? UserWithIncludes<QueryInclude>");
+    expect(output).toContain("? UserSelectedWithIncludes<QueryInclude, QuerySelect>");
     expect(output).toContain(": RelationInclude extends UserInclude");
     expect(output).toContain("? UserWithIncludes<RelationInclude>");
     expect(output).toContain(
@@ -820,13 +820,28 @@ describe("generateTypes with relations", () => {
     );
     expect(output).toContain("? Todo[]");
     expect(output).toContain(
-      ": RelationInclude extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>",
+      ": RelationInclude extends TodoQueryBuilder<infer QueryInclude extends TodoInclude, infer QuerySelect extends keyof Todo>",
     );
-    expect(output).toContain("? TodoWithIncludes<QueryInclude>[]");
+    expect(output).toContain("? TodoSelectedWithIncludes<QueryInclude, QuerySelect>[]");
     expect(output).toContain(": RelationInclude extends TodoInclude");
     expect(output).toContain("? TodoWithIncludes<RelationInclude>[]");
     expect(output).not.toContain("WithIncludesFor<");
     expect(output).not.toContain("WithIncludesArray<");
+  });
+
+  it("generates selection helper types", () => {
+    table("users", { name: col.string() });
+    table("todos", { owner_id: col.ref("users"), title: col.string() });
+    const schema = getCollectedSchema();
+    const wasm = schemaToWasm(schema);
+    const output = generateTypes(wasm);
+
+    expect(output).toContain("export type TodoSelected<S extends keyof Todo = keyof Todo>");
+    expect(output).toContain('Pick<Todo, Extract<S | "id", keyof Todo>>');
+    expect(output).toContain(
+      "export type TodoSelectedWithIncludes<I extends TodoInclude = {}, S extends keyof Todo = keyof Todo>",
+    );
+    expect(output).toContain("TodoSelected<S> & Omit<TodoWithIncludes<I>, keyof Todo>");
   });
 
   it("avoids collapsing nested array includes to never when selectors are optional", () => {
@@ -978,11 +993,14 @@ describe("generateQueryBuilderClasses", () => {
     const output = generateTypes(wasm);
 
     expect(output).toContain(
-      "export class TodoQueryBuilder<I extends Record<string, never> = {}> implements QueryBuilder<Todo> {",
+      "export class TodoQueryBuilder<I extends Record<string, never> = {}, S extends keyof Todo = keyof Todo> implements QueryBuilder<TodoSelected<S>> {",
     );
-    expect(output).toContain("declare readonly _rowType: Todo;");
+    expect(output).toContain("declare readonly _rowType: TodoSelected<S>;");
     expect(output).toContain("declare readonly _initType: TodoInit;");
     expect(output).toContain("where(conditions: TodoWhereInput)");
+    expect(output).toContain(
+      "select<NewS extends keyof Todo>(...columns: [NewS, ...NewS[]]): TodoQueryBuilder<I, NewS>",
+    );
     expect(output).toContain("orderBy(column: keyof Todo");
     expect(output).toContain("limit(n: number)");
     expect(output).toContain("offset(n: number)");
@@ -998,9 +1016,9 @@ describe("generateQueryBuilderClasses", () => {
     const output = generateTypes(wasm);
 
     expect(output).toContain(
-      "export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilder<TodoWithIncludes<I>> {",
+      "export class TodoQueryBuilder<I extends TodoInclude = {}, S extends keyof Todo = keyof Todo> implements QueryBuilder<TodoSelectedWithIncludes<I, S>> {",
     );
-    expect(output).toContain("declare readonly _rowType: TodoWithIncludes<I>;");
+    expect(output).toContain("declare readonly _rowType: TodoSelectedWithIncludes<I, S>;");
   });
 
   it("generates include method for tables with relations", () => {
@@ -1011,7 +1029,7 @@ describe("generateQueryBuilderClasses", () => {
     const output = generateTypes(wasm);
 
     expect(output).toContain("include<NewI extends TodoInclude>(relations: NewI)");
-    expect(output).toContain("const clone = this._clone<I & NewI>();");
+    expect(output).toContain("const clone = this._clone<I & NewI, S>();");
     expect(output).not.toContain("as unknown as TodoQueryBuilder<I & NewI>");
   });
 
@@ -1061,11 +1079,14 @@ describe("generateQueryBuilderClasses", () => {
     expect(output).toContain("table: this._table,");
     expect(output).toContain("conditions: this._conditions,");
     expect(output).toContain("includes: this._includes,");
+    expect(output).toContain("select: this._selectColumns,");
     expect(output).toContain("orderBy: this._orderBys,");
     expect(output).toContain("limit: this._limitVal,");
     expect(output).toContain("offset: this._offsetVal,");
     expect(output).toContain("hops: this._hops,");
     expect(output).toContain("gather: this._gatherVal,");
+    expect(output).toContain("toJSON(): unknown {");
+    expect(output).toContain("return JSON.parse(this._build());");
   });
 
   it("generates private _clone method for immutability", () => {
@@ -1075,10 +1096,13 @@ describe("generateQueryBuilderClasses", () => {
     const output = generateTypes(wasm);
 
     expect(output).toContain(
-      "private _clone<CloneI extends Record<string, never> = I>(): TodoQueryBuilder<CloneI> {",
+      "private _clone<CloneI extends Record<string, never> = I, CloneS extends keyof Todo = S>(): TodoQueryBuilder<CloneI, CloneS> {",
     );
-    expect(output).toContain("const clone = new TodoQueryBuilder<CloneI>();");
+    expect(output).toContain("const clone = new TodoQueryBuilder<CloneI, CloneS>();");
     expect(output).toContain("clone._conditions = [...this._conditions];");
+    expect(output).toContain(
+      "clone._selectColumns = this._selectColumns ? [...this._selectColumns] : undefined;",
+    );
     expect(output).toContain("clone._hops = [...this._hops];");
     expect(output).toContain("clone._gatherVal = this._gatherVal");
   });

--- a/packages/jazz-tools/src/codegen/query-builder-generator.ts
+++ b/packages/jazz-tools/src/codegen/query-builder-generator.ts
@@ -145,10 +145,12 @@ function generateQueryBuilderClass(
 
   // Determine Include type - use the interface if it exists, otherwise empty object
   const includeConstraint = hasRelations ? `${interfaceName}Include` : "Record<string, never>";
-  const rowType = hasRelations ? `${interfaceName}WithIncludes<I>` : interfaceName;
+  const rowType = hasRelations
+    ? `${interfaceName}SelectedWithIncludes<I, S>`
+    : `${interfaceName}Selected<S>`;
 
   lines.push(
-    `export class ${interfaceName}QueryBuilder<I extends ${includeConstraint} = {}> implements QueryBuilder<${rowType}> {`,
+    `export class ${interfaceName}QueryBuilder<I extends ${includeConstraint} = {}, S extends keyof ${interfaceName} = keyof ${interfaceName}> implements QueryBuilder<${rowType}> {`,
   );
   lines.push(`  readonly _table = "${tableName}";`);
   lines.push(`  readonly _schema: WasmSchema = wasmSchema;`);
@@ -157,6 +159,7 @@ function generateQueryBuilderClass(
   lines.push(`  declare readonly _initType: ${interfaceName}Init;`);
   lines.push(`  private _conditions: Array<{ column: string; op: string; value: unknown }> = [];`);
   lines.push(`  private _includes: Partial<${includeConstraint}> = {};`);
+  lines.push(`  private _selectColumns?: string[];`);
   lines.push(`  private _orderBys: Array<[string, "asc" | "desc"]> = [];`);
   lines.push(`  private _limitVal?: number;`);
   lines.push(`  private _offsetVal?: number;`);
@@ -171,7 +174,7 @@ function generateQueryBuilderClass(
   lines.push(``);
 
   // where() method
-  lines.push(`  where(conditions: ${whereInputInterface}): ${interfaceName}QueryBuilder<I> {`);
+  lines.push(`  where(conditions: ${whereInputInterface}): ${interfaceName}QueryBuilder<I, S> {`);
   lines.push(`    const clone = this._clone();`);
   lines.push(`    for (const [key, value] of Object.entries(conditions)) {`);
   lines.push(`      if (value === undefined) continue;`);
@@ -189,13 +192,23 @@ function generateQueryBuilderClass(
   lines.push(`  }`);
   lines.push(``);
 
+  // select() method
+  lines.push(
+    `  select<NewS extends keyof ${interfaceName}>(...columns: [NewS, ...NewS[]]): ${interfaceName}QueryBuilder<I, NewS> {`,
+  );
+  lines.push(`    const clone = this._clone<I, NewS>();`);
+  lines.push(`    clone._selectColumns = [...columns] as string[];`);
+  lines.push(`    return clone;`);
+  lines.push(`  }`);
+  lines.push(``);
+
   // include() method - only if table has relations
   if (hasRelations) {
     const includeInterface = interfaceName + "Include";
     lines.push(
-      `  include<NewI extends ${includeInterface}>(relations: NewI): ${interfaceName}QueryBuilder<I & NewI> {`,
+      `  include<NewI extends ${includeInterface}>(relations: NewI): ${interfaceName}QueryBuilder<I & NewI, S> {`,
     );
-    lines.push(`    const clone = this._clone<I & NewI>();`);
+    lines.push(`    const clone = this._clone<I & NewI, S>();`);
     lines.push(`    clone._includes = { ...this._includes, ...relations };`);
     lines.push(`    return clone;`);
     lines.push(`  }`);
@@ -204,7 +217,7 @@ function generateQueryBuilderClass(
 
   // orderBy() method
   lines.push(
-    `  orderBy(column: keyof ${interfaceName}, direction: "asc" | "desc" = "asc"): ${interfaceName}QueryBuilder<I> {`,
+    `  orderBy(column: keyof ${interfaceName}, direction: "asc" | "desc" = "asc"): ${interfaceName}QueryBuilder<I, S> {`,
   );
   lines.push(`    const clone = this._clone();`);
   lines.push(`    clone._orderBys.push([column as string, direction]);`);
@@ -213,7 +226,7 @@ function generateQueryBuilderClass(
   lines.push(``);
 
   // limit() method
-  lines.push(`  limit(n: number): ${interfaceName}QueryBuilder<I> {`);
+  lines.push(`  limit(n: number): ${interfaceName}QueryBuilder<I, S> {`);
   lines.push(`    const clone = this._clone();`);
   lines.push(`    clone._limitVal = n;`);
   lines.push(`    return clone;`);
@@ -221,7 +234,7 @@ function generateQueryBuilderClass(
   lines.push(``);
 
   // offset() method
-  lines.push(`  offset(n: number): ${interfaceName}QueryBuilder<I> {`);
+  lines.push(`  offset(n: number): ${interfaceName}QueryBuilder<I, S> {`);
   lines.push(`    const clone = this._clone();`);
   lines.push(`    clone._offsetVal = n;`);
   lines.push(`    return clone;`);
@@ -230,7 +243,7 @@ function generateQueryBuilderClass(
 
   if (hasRelations) {
     const relationUnion = tableRels.map((rel) => `"${rel.name}"`).join(" | ");
-    lines.push(`  hopTo(relation: ${relationUnion}): ${interfaceName}QueryBuilder<I> {`);
+    lines.push(`  hopTo(relation: ${relationUnion}): ${interfaceName}QueryBuilder<I, S> {`);
     lines.push(`    const clone = this._clone();`);
     lines.push(`    clone._hops.push(relation);`);
     lines.push(`    return clone;`);
@@ -243,7 +256,7 @@ function generateQueryBuilderClass(
   lines.push(`    start: ${whereInputInterface};`);
   lines.push(`    step: (ctx: { current: string }) => QueryBuilder<unknown>;`);
   lines.push(`    maxDepth?: number;`);
-  lines.push(`  }): ${interfaceName}QueryBuilder<I> {`);
+  lines.push(`  }): ${interfaceName}QueryBuilder<I, S> {`);
   lines.push(`    if (options.start === undefined) {`);
   lines.push(`      throw new Error("gather(...) requires start where conditions.");`);
   lines.push(`    }`);
@@ -329,6 +342,7 @@ function generateQueryBuilderClass(
   lines.push(`      table: this._table,`);
   lines.push(`      conditions: this._conditions,`);
   lines.push(`      includes: this._includes,`);
+  lines.push(`      select: this._selectColumns,`);
   lines.push(`      orderBy: this._orderBys,`);
   lines.push(`      limit: this._limitVal,`);
   lines.push(`      offset: this._offsetVal,`);
@@ -337,14 +351,21 @@ function generateQueryBuilderClass(
   lines.push(`    });`);
   lines.push(`  }`);
   lines.push(``);
+  lines.push(`  toJSON(): unknown {`);
+  lines.push(`    return JSON.parse(this._build());`);
+  lines.push(`  }`);
+  lines.push(``);
 
   // _clone() method
   lines.push(
-    `  private _clone<CloneI extends ${includeConstraint} = I>(): ${interfaceName}QueryBuilder<CloneI> {`,
+    `  private _clone<CloneI extends ${includeConstraint} = I, CloneS extends keyof ${interfaceName} = S>(): ${interfaceName}QueryBuilder<CloneI, CloneS> {`,
   );
-  lines.push(`    const clone = new ${interfaceName}QueryBuilder<CloneI>();`);
+  lines.push(`    const clone = new ${interfaceName}QueryBuilder<CloneI, CloneS>();`);
   lines.push(`    clone._conditions = [...this._conditions];`);
   lines.push(`    clone._includes = { ...this._includes };`);
+  lines.push(
+    `    clone._selectColumns = this._selectColumns ? [...this._selectColumns] : undefined;`,
+  );
   lines.push(`    clone._orderBys = [...this._orderBys];`);
   lines.push(`    clone._limitVal = this._limitVal;`);
   lines.push(`    clone._offsetVal = this._offsetVal;`);

--- a/packages/jazz-tools/src/codegen/query-builder-generator.ts
+++ b/packages/jazz-tools/src/codegen/query-builder-generator.ts
@@ -150,7 +150,7 @@ function generateQueryBuilderClass(
     : `${interfaceName}Selected<S>`;
 
   lines.push(
-    `export class ${interfaceName}QueryBuilder<I extends ${includeConstraint} = {}, S extends keyof ${interfaceName} = keyof ${interfaceName}> implements QueryBuilder<${rowType}> {`,
+    `export class ${interfaceName}QueryBuilder<I extends ${includeConstraint} = {}, S extends keyof ${interfaceName} | "*" = keyof ${interfaceName}> implements QueryBuilder<${rowType}> {`,
   );
   lines.push(`  readonly _table = "${tableName}";`);
   lines.push(`  readonly _schema: WasmSchema = wasmSchema;`);
@@ -194,7 +194,7 @@ function generateQueryBuilderClass(
 
   // select() method
   lines.push(
-    `  select<NewS extends keyof ${interfaceName}>(...columns: [NewS, ...NewS[]]): ${interfaceName}QueryBuilder<I, NewS> {`,
+    `  select<NewS extends keyof ${interfaceName} | "*">(...columns: [NewS, ...NewS[]]): ${interfaceName}QueryBuilder<I, NewS> {`,
   );
   lines.push(`    const clone = this._clone<I, NewS>();`);
   lines.push(`    clone._selectColumns = [...columns] as string[];`);
@@ -358,7 +358,7 @@ function generateQueryBuilderClass(
 
   // _clone() method
   lines.push(
-    `  private _clone<CloneI extends ${includeConstraint} = I, CloneS extends keyof ${interfaceName} = S>(): ${interfaceName}QueryBuilder<CloneI, CloneS> {`,
+    `  private _clone<CloneI extends ${includeConstraint} = I, CloneS extends keyof ${interfaceName} | "*" = S>(): ${interfaceName}QueryBuilder<CloneI, CloneS> {`,
   );
   lines.push(`    const clone = new ${interfaceName}QueryBuilder<CloneI, CloneS>();`);
   lines.push(`    clone._conditions = [...this._conditions];`);

--- a/packages/jazz-tools/src/codegen/type-generator.ts
+++ b/packages/jazz-tools/src/codegen/type-generator.ts
@@ -246,7 +246,7 @@ function generateWithIncludesTypes(relations: Map<string, Relation[]>): string[]
       lines.push(`    ? RelationInclude extends true`);
       lines.push(`      ? ${trueType}`);
       lines.push(
-        `      : RelationInclude extends ${targetQueryBuilder}<infer QueryInclude extends ${targetInclude}, infer QuerySelect extends keyof ${targetInterface}>`,
+        `      : RelationInclude extends ${targetQueryBuilder}<infer QueryInclude extends ${targetInclude}, infer QuerySelect extends keyof ${targetInterface} | "*">`,
       );
       lines.push(`        ? ${queryBuilderSelectedType}`);
       lines.push(`        : RelationInclude extends ${targetInclude}`);
@@ -271,13 +271,13 @@ function generateSelectionTypes(schema: WasmSchema, relations: Map<string, Relat
     const hasRelations = (relations.get(tableName) ?? []).length > 0;
 
     lines.push(
-      `export type ${baseInterface}Selected<S extends keyof ${baseInterface} = keyof ${baseInterface}> = Pick<${baseInterface}, Extract<S | "id", keyof ${baseInterface}>>;`,
+      `export type ${baseInterface}Selected<S extends keyof ${baseInterface} | "*" = keyof ${baseInterface}> = "*" extends S ? ${baseInterface} : Pick<${baseInterface}, Extract<S | "id", keyof ${baseInterface}>>;`,
     );
     lines.push("");
 
     if (hasRelations) {
       lines.push(
-        `export type ${baseInterface}SelectedWithIncludes<I extends ${includeInterface} = {}, S extends keyof ${baseInterface} = keyof ${baseInterface}> = ${baseInterface}Selected<S> & Omit<${withIncludesType}<I>, keyof ${baseInterface}>;`,
+        `export type ${baseInterface}SelectedWithIncludes<I extends ${includeInterface} = {}, S extends keyof ${baseInterface} | "*" = keyof ${baseInterface}> = ${baseInterface}Selected<S> & Omit<${withIncludesType}<I>, keyof ${baseInterface}>;`,
       );
       lines.push("");
     }

--- a/packages/jazz-tools/src/codegen/type-generator.ts
+++ b/packages/jazz-tools/src/codegen/type-generator.ts
@@ -235,9 +235,9 @@ function generateWithIncludesTypes(relations: Map<string, Relation[]>): string[]
       const targetWithIncludes = targetInterface + "WithIncludes";
       const includeSelector = `NonNullable<I["${rel.name}"]>`;
       const trueType = rel.isArray ? `${targetInterface}[]` : targetInterface;
-      const queryBuilderType = rel.isArray
-        ? `${targetWithIncludes}<QueryInclude>[]`
-        : `${targetWithIncludes}<QueryInclude>`;
+      const queryBuilderSelectedType = rel.isArray
+        ? `${targetInterface}SelectedWithIncludes<QueryInclude, QuerySelect>[]`
+        : `${targetInterface}SelectedWithIncludes<QueryInclude, QuerySelect>`;
       const nestedIncludeType = rel.isArray
         ? `${targetWithIncludes}<RelationInclude>[]`
         : `${targetWithIncludes}<RelationInclude>`;
@@ -246,9 +246,9 @@ function generateWithIncludesTypes(relations: Map<string, Relation[]>): string[]
       lines.push(`    ? RelationInclude extends true`);
       lines.push(`      ? ${trueType}`);
       lines.push(
-        `      : RelationInclude extends ${targetQueryBuilder}<infer QueryInclude extends ${targetInclude}>`,
+        `      : RelationInclude extends ${targetQueryBuilder}<infer QueryInclude extends ${targetInclude}, infer QuerySelect extends keyof ${targetInterface}>`,
       );
-      lines.push(`        ? ${queryBuilderType}`);
+      lines.push(`        ? ${queryBuilderSelectedType}`);
       lines.push(`        : RelationInclude extends ${targetInclude}`);
       lines.push(`          ? ${nestedIncludeType}`);
       lines.push(`          : never`);
@@ -256,6 +256,31 @@ function generateWithIncludesTypes(relations: Map<string, Relation[]>): string[]
     }
     lines.push(`};`);
     lines.push(``);
+  }
+
+  return lines;
+}
+
+function generateSelectionTypes(schema: WasmSchema, relations: Map<string, Relation[]>): string[] {
+  const lines: string[] = [];
+
+  for (const tableName of Object.keys(schema)) {
+    const baseInterface = tableNameToInterface(tableName);
+    const includeInterface = baseInterface + "Include";
+    const withIncludesType = baseInterface + "WithIncludes";
+    const hasRelations = (relations.get(tableName) ?? []).length > 0;
+
+    lines.push(
+      `export type ${baseInterface}Selected<S extends keyof ${baseInterface} = keyof ${baseInterface}> = Pick<${baseInterface}, Extract<S | "id", keyof ${baseInterface}>>;`,
+    );
+    lines.push("");
+
+    if (hasRelations) {
+      lines.push(
+        `export type ${baseInterface}SelectedWithIncludes<I extends ${includeInterface} = {}, S extends keyof ${baseInterface} = keyof ${baseInterface}> = ${baseInterface}Selected<S> & Omit<${withIncludesType}<I>, keyof ${baseInterface}>;`,
+      );
+      lines.push("");
+    }
   }
 
   return lines;
@@ -271,9 +296,10 @@ function generateWithIncludesTypes(relations: Map<string, Relation[]>): string[]
  * 4. Include types for relation loading (e.g., TodoInclude)
  * 5. Relations types mapping relation names to types (e.g., TodoRelations)
  * 6. WithIncludes types for type-safe results (e.g., TodoWithIncludes)
- * 7. QueryBuilder classes (e.g., TodoQueryBuilder)
- * 8. Exported wasmSchema constant
- * 9. App export with table proxies
+ * 7. Selection helper types for type-safe projections (e.g., TodoSelected)
+ * 8. QueryBuilder classes (e.g., TodoQueryBuilder)
+ * 9. Exported wasmSchema constant
+ * 10. App export with table proxies
  */
 export function generateTypes(schema: WasmSchema): string {
   const jsonSchemaBindings = collectJsonSchemaBindings(schema);
@@ -346,6 +372,9 @@ export function generateTypes(schema: WasmSchema): string {
 
   // WithIncludes types (type-safe results based on include spec)
   lines.push(...generateWithIncludesTypes(relations));
+
+  // Selection helper types (type-safe results based on select columns)
+  lines.push(...generateSelectionTypes(schema, relations));
 
   // Export WasmSchema JSON
   lines.push(`export const wasmSchema: WasmSchema = ${JSON.stringify(schema, null, 2)};`);

--- a/packages/jazz-tools/src/runtime/client.ts
+++ b/packages/jazz-tools/src/runtime/client.ts
@@ -140,6 +140,7 @@ export interface QueryInput {
 type RelationIrNode = Record<string, unknown>;
 type ArraySubqueryPlan = {
   table: string;
+  selectColumns: string[];
   nested: ArraySubqueryPlan[];
 };
 
@@ -239,6 +240,7 @@ function parseArraySubqueryPlans(value: unknown): ArraySubqueryPlan[] {
     }
     const plan = entry as {
       table?: unknown;
+      select_columns?: unknown;
       nested_arrays?: unknown;
     };
     if (typeof plan.table !== "string") {
@@ -246,6 +248,9 @@ function parseArraySubqueryPlans(value: unknown): ArraySubqueryPlan[] {
     }
     plans.push({
       table: plan.table,
+      selectColumns: Array.isArray(plan.select_columns)
+        ? plan.select_columns.filter((column): column is string => typeof column === "string")
+        : [],
       nested: parseArraySubqueryPlans(plan.nested_arrays),
     });
   }
@@ -256,12 +261,14 @@ function parseArraySubqueryPlans(value: unknown): ArraySubqueryPlan[] {
 function resolveQueryAlignmentPlan(queryJson: string): {
   outputTable: string | null;
   arraySubqueries: ArraySubqueryPlan[];
+  selectColumns: string[];
 } {
   try {
     const parsed = JSON.parse(queryJson) as {
       table?: unknown;
       relation_ir?: unknown;
       array_subqueries?: unknown;
+      select_columns?: unknown;
     };
     return {
       outputTable:
@@ -269,11 +276,15 @@ function resolveQueryAlignmentPlan(queryJson: string): {
           ? parsed.table
           : resolveRelationIrOutputTable(parsed.relation_ir),
       arraySubqueries: parseArraySubqueryPlans(parsed.array_subqueries),
+      selectColumns: Array.isArray(parsed.select_columns)
+        ? parsed.select_columns.filter((column): column is string => typeof column === "string")
+        : [],
     };
   } catch {
     return {
       outputTable: null,
       arraySubqueries: [],
+      selectColumns: [],
     };
   }
 }
@@ -761,11 +772,45 @@ export class JazzClient {
     values: Value[],
     runtimeSchema = this.getSchema(),
     arraySubqueries: ArraySubqueryPlan[] = [],
+    selectColumns: string[] = [],
   ): Value[] {
     const declaredTable = this.context.schema[table];
     const runtimeTable = runtimeSchema[table];
 
-    if (!declaredTable || !runtimeTable || values.length < runtimeTable.columns.length) {
+    if (!declaredTable || !runtimeTable) {
+      return values;
+    }
+
+    const projectedBaseColumnCount =
+      selectColumns.length > 0
+        ? selectColumns.filter((columnName) =>
+            declaredTable.columns.some((column) => column.name === columnName),
+          ).length
+        : 0;
+
+    if (projectedBaseColumnCount > 0) {
+      if (values.length < projectedBaseColumnCount) {
+        return values;
+      }
+
+      const projectedValues = values.slice(0, projectedBaseColumnCount);
+      const trailingValues = values.slice(projectedBaseColumnCount);
+      if (arraySubqueries.length === 0) {
+        return projectedValues.concat(trailingValues);
+      }
+
+      const alignedTrailingValues = trailingValues.map((value, index) => {
+        const plan = arraySubqueries[index];
+        if (!plan) {
+          return value;
+        }
+        return this.alignIncludedValueToDeclaredSchema(value, plan, runtimeSchema);
+      });
+
+      return projectedValues.concat(alignedTrailingValues);
+    }
+
+    if (values.length < runtimeTable.columns.length) {
       return values;
     }
 
@@ -829,6 +874,7 @@ export class JazzClient {
               entry.value.values,
               runtimeSchema,
               plan.nested,
+              plan.selectColumns,
             ),
           },
         };
@@ -841,7 +887,7 @@ export class JazzClient {
     rows: Row[],
     runtimeSchema = this.getSchema(),
   ): Row[] {
-    const { outputTable, arraySubqueries } = resolveQueryAlignmentPlan(queryJson);
+    const { outputTable, arraySubqueries, selectColumns } = resolveQueryAlignmentPlan(queryJson);
     if (!outputTable) {
       return rows;
     }
@@ -853,6 +899,7 @@ export class JazzClient {
         row.values,
         runtimeSchema,
         arraySubqueries,
+        selectColumns,
       ),
     }));
   }
@@ -862,7 +909,7 @@ export class JazzClient {
     delta: RowDelta,
     runtimeSchema = this.getSchema(),
   ): RowDelta {
-    const { outputTable, arraySubqueries } = resolveQueryAlignmentPlan(queryJson);
+    const { outputTable, arraySubqueries, selectColumns } = resolveQueryAlignmentPlan(queryJson);
     if (!outputTable || !Array.isArray(delta)) {
       return delta;
     }
@@ -878,6 +925,7 @@ export class JazzClient {
               change.row.values as Value[],
               runtimeSchema,
               arraySubqueries,
+              selectColumns,
             ),
           },
         };

--- a/packages/jazz-tools/src/runtime/client.ts
+++ b/packages/jazz-tools/src/runtime/client.ts
@@ -216,18 +216,6 @@ function resolveRelationIrOutputTable(node: unknown): string | null {
   return null;
 }
 
-function resolveQueryOutputTable(queryJson: string): string | null {
-  try {
-    const parsed = JSON.parse(queryJson) as { table?: unknown; relation_ir?: unknown };
-    if (typeof parsed.table === "string") {
-      return parsed.table;
-    }
-    return resolveRelationIrOutputTable(parsed.relation_ir);
-  } catch {
-    return null;
-  }
-}
-
 function parseArraySubqueryPlans(value: unknown): ArraySubqueryPlan[] {
   if (!Array.isArray(value)) {
     return [];

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -24,13 +24,14 @@ import {
 } from "./client.js";
 import { WorkerBridge, type PeerSyncBatch, type WorkerBridgeOptions } from "./worker-bridge.js";
 import { translateQuery } from "./query-adapter.js";
-import { transformRow, transformRows, type IncludeSpec } from "./row-transformer.js";
+import { transformRow, transformRows } from "./row-transformer.js";
 import { toValueArray, toUpdateRecord } from "./value-converter.js";
 import { SubscriptionManager, type SubscriptionDelta } from "./subscription-manager.js";
 import { resolveLocalAuthDefaults } from "./local-auth.js";
 import { analyzeRelations } from "../codegen/relation-analyzer.js";
 import { TabLeaderElection, type LeaderRole, type LeaderSnapshot } from "./tab-leader-election.js";
 import type { WorkerLifecycleEvent } from "../worker/worker-protocol.js";
+import { normalizeBuiltQuery } from "./query-builder-shape.js";
 
 type WasmLogLevel = "error" | "warn" | "info" | "debug" | "trace";
 const DEFAULT_WASM_LOG_LEVEL: WasmLogLevel = "warn";
@@ -103,103 +104,6 @@ export interface QueryBuilder<T> {
 
 export interface QueryOptions extends QueryExecutionOptions {
   propagation?: QueryPropagation;
-}
-
-interface BuiltQuery {
-  table?: string;
-  conditions?: Array<{ column: string; op: string; value: unknown }>;
-  includes?: IncludeSpec;
-  orderBy?: Array<[string, "asc" | "desc"]>;
-  limit?: number;
-  offset?: number;
-  hops?: string[];
-  gather?: {
-    max_depth: number;
-    step_table: string;
-    step_current_column: string;
-    step_conditions: Array<{ column: string; op: string; value: unknown }>;
-    step_hops: string[];
-  };
-}
-
-type NormalizedBuiltQuery = {
-  table: string;
-  conditions: Array<{ column: string; op: string; value: unknown }>;
-  includes: IncludeSpec;
-  orderBy: Array<[string, "asc" | "desc"]>;
-  limit?: number;
-  offset?: number;
-  hops: string[];
-  gather?:
-    | {
-        max_depth: number;
-        step_table: string;
-        step_current_column: string;
-        step_conditions: Array<{ column: string; op: string; value: unknown }>;
-        step_hops: string[];
-      }
-    | undefined;
-};
-
-function isPlainObject(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function normalizeBuiltQuery(raw: BuiltQuery, fallbackTable: string): NormalizedBuiltQuery {
-  const table = typeof raw.table === "string" ? raw.table : fallbackTable;
-  const conditions = Array.isArray(raw.conditions)
-    ? raw.conditions.filter(
-        (condition): condition is { column: string; op: string; value: unknown } =>
-          isPlainObject(condition) &&
-          typeof condition.column === "string" &&
-          typeof condition.op === "string",
-      )
-    : [];
-  const includes = isPlainObject(raw.includes) ? (raw.includes as IncludeSpec) : {};
-  const orderBy = Array.isArray(raw.orderBy)
-    ? raw.orderBy.filter(
-        (entry): entry is [string, "asc" | "desc"] =>
-          Array.isArray(entry) &&
-          entry.length === 2 &&
-          typeof entry[0] === "string" &&
-          (entry[1] === "asc" || entry[1] === "desc"),
-      )
-    : [];
-  const hops = Array.isArray(raw.hops)
-    ? raw.hops.filter((hop): hop is string => typeof hop === "string")
-    : [];
-  const gather =
-    isPlainObject(raw.gather) &&
-    Number.isInteger(raw.gather.max_depth) &&
-    raw.gather.max_depth > 0 &&
-    typeof raw.gather.step_table === "string" &&
-    typeof raw.gather.step_current_column === "string" &&
-    Array.isArray(raw.gather.step_conditions) &&
-    Array.isArray(raw.gather.step_hops)
-      ? {
-          max_depth: raw.gather.max_depth,
-          step_table: raw.gather.step_table,
-          step_current_column: raw.gather.step_current_column,
-          step_conditions: raw.gather.step_conditions.filter(
-            (condition): condition is { column: string; op: string; value: unknown } =>
-              isPlainObject(condition) &&
-              typeof condition.column === "string" &&
-              typeof condition.op === "string",
-          ),
-          step_hops: raw.gather.step_hops.filter((hop): hop is string => typeof hop === "string"),
-        }
-      : undefined;
-
-  return {
-    table,
-    conditions,
-    includes,
-    orderBy,
-    limit: typeof raw.limit === "number" ? raw.limit : undefined,
-    offset: typeof raw.offset === "number" ? raw.offset : undefined,
-    hops,
-    gather,
-  };
 }
 
 function resolveHopOutputTable(
@@ -1144,7 +1048,7 @@ export class Db {
     const client = this.getClient(query._schema);
     const runtimeSchema = normalizeRuntimeSchema(client.getSchema());
     const builderJson = query._build();
-    const builtQuery = normalizeBuiltQuery(JSON.parse(builderJson) as BuiltQuery, query._table);
+    const builtQuery = normalizeBuiltQuery(JSON.parse(builderJson), query._table);
     const planningSchema = resolveSchemaWithTable(query._schema, runtimeSchema, builtQuery.table);
     const outputTable =
       builtQuery.hops.length > 0
@@ -1153,7 +1057,7 @@ export class Db {
     const outputSchema = resolveSchemaWithTable(query._schema, runtimeSchema, outputTable);
     const rows = await client.query(translateQuery(builderJson, planningSchema), options);
     const outputIncludes = builtQuery.hops.length > 0 ? {} : builtQuery.includes;
-    return transformRows<T>(rows, outputSchema, outputTable, outputIncludes);
+    return transformRows<T>(rows, outputSchema, outputTable, outputIncludes, builtQuery.select);
   }
 
   /**
@@ -1204,7 +1108,7 @@ export class Db {
     const client = this.getClient(query._schema);
     const runtimeSchema = normalizeRuntimeSchema(client.getSchema());
     const builderJson = query._build();
-    const builtQuery = normalizeBuiltQuery(JSON.parse(builderJson) as BuiltQuery, query._table);
+    const builtQuery = normalizeBuiltQuery(JSON.parse(builderJson), query._table);
     const planningSchema = resolveSchemaWithTable(query._schema, runtimeSchema, builtQuery.table);
     const outputTable =
       builtQuery.hops.length > 0
@@ -1215,7 +1119,13 @@ export class Db {
     const wasmQuery = translateQuery(builderJson, planningSchema);
 
     const transform = (row: WasmRow): T => {
-      return transformRows<T>([row], outputSchema, outputTable, outputIncludes)[0];
+      return transformRows<T>(
+        [row],
+        outputSchema,
+        outputTable,
+        outputIncludes,
+        builtQuery.select,
+      )[0];
     };
 
     const subId = client.subscribeInternal(

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -83,10 +83,6 @@ function resolveStorageDriver(driver?: StorageDriver): StorageDriver {
   return driver ?? { type: "persistent" };
 }
 
-function isMemoryDriver(driver?: StorageDriver): boolean {
-  return resolveStorageDriver(driver).type === "memory";
-}
-
 /**
  * Interface that QueryBuilder classes implement.
  * Generated builders expose these internal properties for Db to use.

--- a/packages/jazz-tools/src/runtime/query-adapter.test.ts
+++ b/packages/jazz-tools/src/runtime/query-adapter.test.ts
@@ -106,6 +106,21 @@ describe("translateQuery", () => {
       expect(result.select_columns).toEqual(["title", "done"]);
       expect(result.relation_ir).toEqual({ type: "TableScan", table: "todos" });
     });
+
+    it('treats select(["*"]) as selecting all columns', () => {
+      const builderJson = JSON.stringify({
+        table: "todos",
+        conditions: [],
+        includes: {},
+        select: ["*"],
+        orderBy: [],
+      });
+
+      const result = parseTranslatedQuery(builderJson, basicSchema);
+
+      expect(result.select_columns).toBeUndefined();
+      expect(result.relation_ir).toEqual({ type: "TableScan", table: "todos" });
+    });
   });
 
   describe("condition translation", () => {

--- a/packages/jazz-tools/src/runtime/query-adapter.test.ts
+++ b/packages/jazz-tools/src/runtime/query-adapter.test.ts
@@ -91,6 +91,21 @@ describe("translateQuery", () => {
       }
       expect(result.relation_ir.input.offset).toBe(5);
     });
+
+    it("pushes select columns into the runtime query payload", () => {
+      const builderJson = JSON.stringify({
+        table: "todos",
+        conditions: [],
+        includes: {},
+        select: ["title", "done"],
+        orderBy: [],
+      });
+
+      const result = parseTranslatedQuery(builderJson, basicSchema);
+
+      expect(result.select_columns).toEqual(["title", "done"]);
+      expect(result.relation_ir).toEqual({ type: "TableScan", table: "todos" });
+    });
   });
 
   describe("condition translation", () => {
@@ -665,6 +680,34 @@ describe("translateQuery", () => {
       ]);
     });
 
+    it("hides top-level include column names when projecting selected columns", () => {
+      const builderJson = JSON.stringify({
+        table: "todos",
+        conditions: [],
+        includes: { owner: true },
+        select: ["title"],
+        orderBy: [],
+      });
+
+      const result = parseTranslatedQuery(builderJson, schemaWithRelations);
+
+      expect(result.select_columns).toEqual(["title", "__jazz_include_owner"]);
+      expect(result.array_subqueries).toEqual([
+        {
+          column_name: "__jazz_include_owner",
+          table: "users",
+          inner_column: "id",
+          outer_column: "todos.owner_id",
+          filters: [],
+          joins: [],
+          select_columns: null,
+          order_by: [],
+          limit: null,
+          nested_arrays: [],
+        },
+      ]);
+    });
+
     it("translates reverse relation include", () => {
       const builderJson = JSON.stringify({
         table: "users",
@@ -849,6 +892,94 @@ describe("translateQuery", () => {
               filters: [],
               joins: [],
               select_columns: null,
+              order_by: [],
+              limit: null,
+              nested_arrays: [],
+            },
+          ],
+        },
+      ]);
+    });
+
+    it("translates include builders with projected nested columns", () => {
+      const nestedSchema: WasmSchema = {
+        comments: {
+          columns: [
+            { name: "text", column_type: { type: "Text" }, nullable: false },
+            {
+              name: "todo_id",
+              column_type: { type: "Uuid" },
+              nullable: false,
+              references: "todos",
+            },
+          ],
+        },
+        todos: {
+          columns: [
+            { name: "title", column_type: { type: "Text" }, nullable: false },
+            {
+              name: "owner_id",
+              column_type: { type: "Uuid" },
+              nullable: false,
+              references: "users",
+            },
+          ],
+        },
+        users: {
+          columns: [
+            { name: "name", column_type: { type: "Text" }, nullable: false },
+            { name: "email", column_type: { type: "Text" }, nullable: false },
+          ],
+        },
+      };
+
+      const builderJson = JSON.stringify({
+        table: "comments",
+        conditions: [],
+        includes: {
+          todo: {
+            table: "todos",
+            conditions: [],
+            includes: {
+              owner: {
+                table: "users",
+                conditions: [],
+                includes: {},
+                select: ["name"],
+                orderBy: [],
+                hops: [],
+              },
+            },
+            select: ["title"],
+            orderBy: [],
+            hops: [],
+          },
+        },
+        orderBy: [],
+      });
+
+      const result = parseTranslatedQuery(builderJson, nestedSchema);
+
+      expect(result.array_subqueries).toEqual([
+        {
+          column_name: "todo",
+          table: "todos",
+          inner_column: "id",
+          outer_column: "comments.todo_id",
+          filters: [],
+          joins: [],
+          select_columns: ["title", "__jazz_include_owner"],
+          order_by: [],
+          limit: null,
+          nested_arrays: [
+            {
+              column_name: "__jazz_include_owner",
+              table: "users",
+              inner_column: "id",
+              outer_column: "todos.owner_id",
+              filters: [],
+              joins: [],
+              select_columns: ["name"],
               order_by: [],
               limit: null,
               nested_arrays: [],

--- a/packages/jazz-tools/src/runtime/query-adapter.ts
+++ b/packages/jazz-tools/src/runtime/query-adapter.ts
@@ -11,6 +11,13 @@
 import type { ColumnType, WasmSchema } from "../drivers/types.js";
 import { toJsonText } from "./json-text.js";
 import { analyzeRelations, type Relation } from "../codegen/relation-analyzer.js";
+import {
+  normalizeBuiltQuery,
+  type BuiltCondition,
+  type BuiltGather,
+  type NormalizedIncludeEntry,
+  type NormalizedIncludeSpec,
+} from "./query-builder-shape.js";
 import type {
   RelColumnRef,
   RelExpr,
@@ -18,26 +25,6 @@ import type {
   RelPredicateExpr,
   RelProjectColumn,
 } from "../ir.js";
-
-/**
- * Structure produced by QueryBuilder._build()
- */
-interface BuilderOutput {
-  table: string;
-  conditions: Array<{ column: string; op: string; value: unknown }>;
-  includes: Record<string, boolean | object>;
-  orderBy: Array<[string, "asc" | "desc"]>;
-  limit?: number;
-  offset?: number;
-  hops?: string[];
-  gather?: {
-    max_depth: number;
-    step_table: string;
-    step_current_column: string;
-    step_conditions: Array<{ column: string; op: string; value: unknown }>;
-    step_hops: string[];
-  };
-}
 
 function relColumn(column: string, scope?: string): RelColumnRef {
   return scope ? { scope, column } : { column };
@@ -181,58 +168,145 @@ function toWasmValue(value: unknown, columnType: ColumnType): object {
  * @param relations Map from table name to relations on that table
  * @returns Array of array_subquery objects
  */
+function hiddenIncludeColumnName(relationName: string): string {
+  return `__jazz_include_${relationName}`;
+}
+
+function validateIncludeBuilderSpec(
+  relation: Relation,
+  spec: NormalizedIncludeEntry,
+  relationName: string,
+): void {
+  if (spec.table && spec.table !== relation.toTable) {
+    throw new Error(
+      `Include builder for relation "${relationName}" must target table "${relation.toTable}", got "${spec.table}".`,
+    );
+  }
+  if (typeof spec.offset === "number" && spec.offset !== 0) {
+    throw new Error(`Include builder for relation "${relationName}" does not support offset().`);
+  }
+  if (spec.hops.length > 0) {
+    throw new Error(`Include builder for relation "${relationName}" does not support hopTo(...).`);
+  }
+  if (spec.gather) {
+    throw new Error(`Include builder for relation "${relationName}" does not support gather(...).`);
+  }
+}
+
+function conditionToArraySubqueryFilter(
+  cond: BuiltCondition,
+  schema: WasmSchema,
+  table: string,
+): object {
+  const column = stripQualifier(cond.column);
+  const columnType = getColumnType(schema, table, column);
+  if (!columnType) {
+    throw new Error(`Unknown column "${column}" in table "${table}"`);
+  }
+
+  if (columnType.type === "Bytea" && ["gt", "gte", "lt", "lte"].includes(cond.op)) {
+    throw new Error(`BYTEA column "${column}" only supports eq/ne operators.`);
+  }
+  if (columnType.type === "Bytea" && cond.op === "contains") {
+    throw new Error(`BYTEA column "${column}" does not support contains filters.`);
+  }
+  if (columnType.type === "Json" && ["gt", "gte", "lt", "lte", "contains"].includes(cond.op)) {
+    throw new Error(`JSON column "${column}" only supports eq/ne/in/isNull operators.`);
+  }
+
+  const valueTypeForCondition =
+    cond.op === "contains" && columnType.type === "Array" ? columnType.element : columnType;
+  const literalValue = toWasmValue(cond.value, valueTypeForCondition);
+
+  switch (cond.op) {
+    case "eq":
+      return { Eq: { column, value: literalValue } };
+    case "ne":
+      return { Ne: { column, value: literalValue } };
+    case "gt":
+      return { Gt: { column, value: literalValue } };
+    case "gte":
+      return { Ge: { column, value: literalValue } };
+    case "lt":
+      return { Lt: { column, value: literalValue } };
+    case "lte":
+      return { Le: { column, value: literalValue } };
+    case "isNull":
+      return { IsNull: { column } };
+    case "contains":
+      return { Contains: { column, value: literalValue } };
+    default:
+      throw new Error(
+        `Include builder for table "${table}" does not support "${cond.op}" filters.`,
+      );
+  }
+}
+
 function toArraySubqueries(
-  includes: Record<string, boolean | object>,
+  includes: NormalizedIncludeSpec,
   tableName: string,
   relations: Map<string, Relation[]>,
+  schema: WasmSchema,
+  options?: { hideCurrentLevelColumnNames?: boolean },
 ): object[] {
   const tableRels = relations.get(tableName) || [];
   const subqueries: object[] = [];
+  const hideCurrentLevelColumnNames = options?.hideCurrentLevelColumnNames === true;
 
   for (const [relName, spec] of Object.entries(includes)) {
-    if (!spec) continue;
-
     const rel = tableRels.find((r) => r.name === relName);
     if (!rel) {
       throw new Error(`Unknown relation "${relName}" on table "${tableName}"`);
     }
+    validateIncludeBuilderSpec(rel, spec, relName);
+
+    const includeProjectionColumns =
+      spec.select.length > 0
+        ? Object.keys(spec.includes).map((relationName) => hiddenIncludeColumnName(relationName))
+        : [];
+    const filters = spec.conditions.map((condition) =>
+      conditionToArraySubqueryFilter(condition, schema, rel.toTable),
+    );
+    const orderBy = spec.orderBy.map(([column, direction]) => [
+      stripQualifier(column),
+      direction === "desc" ? "Descending" : "Ascending",
+    ]);
+    const nestedArrays = toArraySubqueries(spec.includes, rel.toTable, relations, schema, {
+      hideCurrentLevelColumnNames: spec.select.length > 0,
+    });
+    const selectColumns =
+      spec.select.length > 0 ? [...spec.select, ...includeProjectionColumns] : null;
 
     // Build the subquery based on relation type
     if (rel.type === "forward") {
       // Forward relation: todos.owner_id -> users.id
       // We join from the FK column to the target table's id
       subqueries.push({
-        column_name: relName,
+        column_name: hideCurrentLevelColumnNames ? hiddenIncludeColumnName(relName) : relName,
         table: rel.toTable,
         inner_column: "id",
         outer_column: `${tableName}.${rel.fromColumn}`,
-        filters: [],
+        filters,
         joins: [],
-        select_columns: null,
-        order_by: [],
-        limit: null,
-        nested_arrays:
-          typeof spec === "object"
-            ? toArraySubqueries(spec as Record<string, boolean | object>, rel.toTable, relations)
-            : [],
+        select_columns: selectColumns,
+        order_by: orderBy,
+        limit: spec.limit ?? null,
+        nested_arrays: nestedArrays,
       });
     } else {
       // Reverse relation: users -> todos via todos.owner_id
       // We join from the target table's FK column to our id
       subqueries.push({
-        column_name: relName,
+        column_name: hideCurrentLevelColumnNames ? hiddenIncludeColumnName(relName) : relName,
         table: rel.toTable,
         inner_column: rel.toColumn,
         outer_column: `${tableName}.id`,
-        filters: [],
+        filters,
         joins: [],
-        select_columns: null,
-        order_by: [],
-        limit: null,
-        nested_arrays:
-          typeof spec === "object"
-            ? toArraySubqueries(spec as Record<string, boolean | object>, rel.toTable, relations)
-            : [],
+        select_columns: selectColumns,
+        order_by: orderBy,
+        limit: spec.limit ?? null,
+        nested_arrays: nestedArrays,
       });
     }
   }
@@ -421,7 +495,7 @@ function lowerHopsToRelExpr(
 }
 
 function gatherToRelExpr(
-  gather: NonNullable<BuilderOutput["gather"]>,
+  gather: BuiltGather,
   seedTable: string,
   seedExpr: RelExpr,
   relations: Map<string, Relation[]>,
@@ -516,23 +590,21 @@ function gatherToRelExpr(
  * - gather => Gather with step Join + Project
  */
 export function translateBuilderToRelationIr(builderJson: string, schema: WasmSchema): RelExpr {
-  const builder: BuilderOutput = JSON.parse(builderJson);
+  const builder = normalizeBuiltQuery(JSON.parse(builderJson), "");
   const relations = analyzeRelations(schema);
-  const hops = Array.isArray(builder.hops)
-    ? builder.hops.filter((hop): hop is string => typeof hop === "string")
-    : [];
+  const hops = builder.hops;
 
-  if (builder.gather && Object.keys(builder.includes ?? {}).length > 0) {
+  if (builder.gather && Object.keys(builder.includes).length > 0) {
     throw new Error("gather(...) does not yet support include(...).");
   }
-  if (hops.length > 0 && Object.keys(builder.includes ?? {}).length > 0) {
+  if (hops.length > 0 && Object.keys(builder.includes).length > 0) {
     throw new Error("hopTo(...) does not yet support include(...).");
   }
 
   let relation: RelExpr = { TableScan: { table: builder.table } };
   relation = applyFilter(
     relation,
-    conditionsToRelPredicate(builder.conditions ?? [], schema, builder.table, builder.table),
+    conditionsToRelPredicate(builder.conditions, schema, builder.table, builder.table),
   );
 
   if (builder.gather) {
@@ -589,13 +661,23 @@ export function translateBuilderToRelationIr(builderJson: string, schema: WasmSc
  * @returns JSON string for WASM runtime query()
  */
 export function translateQuery(builderJson: string, schema: WasmSchema): string {
-  const builder: BuilderOutput = JSON.parse(builderJson);
+  const builder = normalizeBuiltQuery(JSON.parse(builderJson), "");
   const relations = analyzeRelations(schema);
   const relation = translateBuilderToRelationIr(builderJson, schema);
+  const selectColumns = builder.select;
+  const includeProjectionColumns =
+    selectColumns.length > 0
+      ? Object.keys(builder.includes).map((relationName) => hiddenIncludeColumnName(relationName))
+      : [];
   const query = {
     table: builder.table,
-    array_subqueries: toArraySubqueries(builder.includes ?? {}, builder.table, relations),
+    array_subqueries: toArraySubqueries(builder.includes, builder.table, relations, schema, {
+      hideCurrentLevelColumnNames: selectColumns.length > 0,
+    }),
     relation_ir: relation,
+    ...(selectColumns.length > 0
+      ? { select_columns: [...selectColumns, ...includeProjectionColumns] }
+      : {}),
   };
 
   return JSON.stringify(query);

--- a/packages/jazz-tools/src/runtime/query-builder-shape.ts
+++ b/packages/jazz-tools/src/runtime/query-builder-shape.ts
@@ -1,0 +1,212 @@
+export interface BuiltCondition {
+  column: string;
+  op: string;
+  value: unknown;
+}
+
+export interface BuiltGather {
+  max_depth: number;
+  step_table: string;
+  step_current_column: string;
+  step_conditions: BuiltCondition[];
+  step_hops: string[];
+}
+
+export interface NormalizedIncludeEntry {
+  table?: string;
+  conditions: BuiltCondition[];
+  includes: NormalizedIncludeSpec;
+  select: string[];
+  orderBy: Array<[string, "asc" | "desc"]>;
+  limit?: number;
+  offset?: number;
+  hops: string[];
+  gather?: BuiltGather;
+}
+
+export interface NormalizedIncludeSpec {
+  [relationName: string]: NormalizedIncludeEntry;
+}
+
+export interface NormalizedBuiltQuery {
+  table: string;
+  conditions: BuiltCondition[];
+  includes: NormalizedIncludeSpec;
+  select: string[];
+  orderBy: Array<[string, "asc" | "desc"]>;
+  limit?: number;
+  offset?: number;
+  hops: string[];
+  gather?: BuiltGather;
+}
+
+type BuiltQueryShape = {
+  table?: unknown;
+  conditions?: unknown;
+  includes?: unknown;
+  select?: unknown;
+  orderBy?: unknown;
+  limit?: unknown;
+  offset?: unknown;
+  hops?: unknown;
+  gather?: unknown;
+};
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeConditions(value: unknown): BuiltCondition[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.filter(
+    (condition): condition is BuiltCondition =>
+      isPlainObject(condition) &&
+      typeof condition.column === "string" &&
+      typeof condition.op === "string",
+  );
+}
+
+function normalizeOrderBy(value: unknown): Array<[string, "asc" | "desc"]> {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.filter(
+    (entry): entry is [string, "asc" | "desc"] =>
+      Array.isArray(entry) &&
+      entry.length === 2 &&
+      typeof entry[0] === "string" &&
+      (entry[1] === "asc" || entry[1] === "desc"),
+  );
+}
+
+function normalizeGather(value: unknown): BuiltGather | undefined {
+  const maxDepth =
+    isPlainObject(value) && typeof value.max_depth === "number" ? value.max_depth : NaN;
+  if (
+    !isPlainObject(value) ||
+    !Number.isInteger(maxDepth) ||
+    maxDepth <= 0 ||
+    typeof value.step_table !== "string" ||
+    typeof value.step_current_column !== "string"
+  ) {
+    return undefined;
+  }
+
+  return {
+    max_depth: maxDepth,
+    step_table: value.step_table,
+    step_current_column: value.step_current_column,
+    step_conditions: normalizeConditions(value.step_conditions),
+    step_hops: Array.isArray(value.step_hops)
+      ? value.step_hops.filter((hop): hop is string => typeof hop === "string")
+      : [],
+  };
+}
+
+function createEmptyIncludeEntry(): NormalizedIncludeEntry {
+  return {
+    conditions: [],
+    includes: {},
+    select: [],
+    orderBy: [],
+    hops: [],
+  };
+}
+
+function isBuiltQueryShape(value: Record<string, unknown>): value is BuiltQueryShape {
+  return "table" in value && "conditions" in value && "includes" in value && "orderBy" in value;
+}
+
+function isNormalizedIncludeEntryShape(value: Record<string, unknown>): boolean {
+  return "conditions" in value && "includes" in value && "select" in value && "orderBy" in value;
+}
+
+function normalizeIncludeEntry(raw: unknown): NormalizedIncludeEntry | null {
+  if (raw === true) {
+    return createEmptyIncludeEntry();
+  }
+
+  if (!isPlainObject(raw)) {
+    return null;
+  }
+
+  if (isBuiltQueryShape(raw)) {
+    const normalized = normalizeBuiltQuery(raw, "");
+    return {
+      table: normalized.table || undefined,
+      conditions: normalized.conditions,
+      includes: normalized.includes,
+      select: normalized.select,
+      orderBy: normalized.orderBy,
+      limit: normalized.limit,
+      offset: normalized.offset,
+      hops: normalized.hops,
+      gather: normalized.gather,
+    };
+  }
+
+  if (isNormalizedIncludeEntryShape(raw)) {
+    return {
+      table: typeof raw.table === "string" ? raw.table : undefined,
+      conditions: normalizeConditions(raw.conditions),
+      includes: normalizeIncludeEntries(raw.includes),
+      select: Array.isArray(raw.select)
+        ? raw.select.filter((column): column is string => typeof column === "string")
+        : [],
+      orderBy: normalizeOrderBy(raw.orderBy),
+      limit: typeof raw.limit === "number" ? raw.limit : undefined,
+      offset: typeof raw.offset === "number" ? raw.offset : undefined,
+      hops: Array.isArray(raw.hops)
+        ? raw.hops.filter((hop): hop is string => typeof hop === "string")
+        : [],
+      gather: normalizeGather(raw.gather),
+    };
+  }
+
+  const entry = createEmptyIncludeEntry();
+  entry.includes = normalizeIncludeEntries(raw);
+  return entry;
+}
+
+export function normalizeIncludeEntries(raw: unknown): NormalizedIncludeSpec {
+  if (!isPlainObject(raw)) {
+    return {};
+  }
+
+  const includes: NormalizedIncludeSpec = {};
+  for (const [relationName, spec] of Object.entries(raw)) {
+    if (!spec) {
+      continue;
+    }
+    const normalized = normalizeIncludeEntry(spec);
+    if (normalized) {
+      includes[relationName] = normalized;
+    }
+  }
+
+  return includes;
+}
+
+export function normalizeBuiltQuery(raw: unknown, fallbackTable: string): NormalizedBuiltQuery {
+  const value = isPlainObject(raw) ? raw : {};
+
+  return {
+    table: typeof value.table === "string" && value.table.length > 0 ? value.table : fallbackTable,
+    conditions: normalizeConditions(value.conditions),
+    includes: normalizeIncludeEntries(value.includes),
+    select: Array.isArray(value.select)
+      ? value.select.filter((column): column is string => typeof column === "string")
+      : [],
+    orderBy: normalizeOrderBy(value.orderBy),
+    limit: typeof value.limit === "number" ? value.limit : undefined,
+    offset: typeof value.offset === "number" ? value.offset : undefined,
+    hops: Array.isArray(value.hops)
+      ? value.hops.filter((hop): hop is string => typeof hop === "string")
+      : [],
+    gather: normalizeGather(value.gather),
+  };
+}

--- a/packages/jazz-tools/src/runtime/query-builder-shape.ts
+++ b/packages/jazz-tools/src/runtime/query-builder-shape.ts
@@ -83,6 +83,15 @@ function normalizeOrderBy(value: unknown): Array<[string, "asc" | "desc"]> {
   );
 }
 
+function normalizeSelect(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  const select = value.filter((column): column is string => typeof column === "string");
+  return select.includes("*") ? [] : select;
+}
+
 function normalizeGather(value: unknown): BuiltGather | undefined {
   const maxDepth =
     isPlainObject(value) && typeof value.max_depth === "number" ? value.max_depth : NaN;
@@ -154,9 +163,7 @@ function normalizeIncludeEntry(raw: unknown): NormalizedIncludeEntry | null {
       table: typeof raw.table === "string" ? raw.table : undefined,
       conditions: normalizeConditions(raw.conditions),
       includes: normalizeIncludeEntries(raw.includes),
-      select: Array.isArray(raw.select)
-        ? raw.select.filter((column): column is string => typeof column === "string")
-        : [],
+      select: normalizeSelect(raw.select),
       orderBy: normalizeOrderBy(raw.orderBy),
       limit: typeof raw.limit === "number" ? raw.limit : undefined,
       offset: typeof raw.offset === "number" ? raw.offset : undefined,
@@ -198,9 +205,7 @@ export function normalizeBuiltQuery(raw: unknown, fallbackTable: string): Normal
     table: typeof value.table === "string" && value.table.length > 0 ? value.table : fallbackTable,
     conditions: normalizeConditions(value.conditions),
     includes: normalizeIncludeEntries(value.includes),
-    select: Array.isArray(value.select)
-      ? value.select.filter((column): column is string => typeof column === "string")
-      : [],
+    select: normalizeSelect(value.select),
     orderBy: normalizeOrderBy(value.orderBy),
     limit: typeof value.limit === "number" ? value.limit : undefined,
     offset: typeof value.offset === "number" ? value.offset : undefined,

--- a/packages/jazz-tools/src/runtime/row-transformer.test.ts
+++ b/packages/jazz-tools/src/runtime/row-transformer.test.ts
@@ -311,6 +311,25 @@ describe("transformRows", () => {
     });
   });
 
+  it("applies root select projections while preserving id", () => {
+    const rows: WasmRow[] = [
+      {
+        id: "uuid-1",
+        values: [
+          { type: "Text", value: "Buy milk" },
+          { type: "Boolean", value: false },
+          { type: "Integer", value: 5 },
+        ],
+      },
+    ];
+
+    const result = transformRows<{ id: string; title: string }>(rows, schema, "todos", {}, [
+      "title",
+    ]);
+
+    expect(result).toEqual([{ id: "uuid-1", title: "Buy milk" }]);
+  });
+
   it("maps forward include arrays to relation names with id", () => {
     const rows: WasmRow[] = [
       {
@@ -345,6 +364,89 @@ describe("transformRows", () => {
           id: "user-1",
           name: "Alice",
           manager_id: undefined,
+        },
+      },
+    ]);
+  });
+
+  it("keeps included relations when applying root select projections", () => {
+    const rows: WasmRow[] = [
+      {
+        id: "todo-1",
+        values: [
+          { type: "Text", value: "Buy milk" },
+          {
+            type: "Array",
+            value: [
+              {
+                type: "Row",
+                value: {
+                  id: "user-1",
+                  values: [{ type: "Text", value: "Alice" }, { type: "Null" }],
+                },
+              },
+            ],
+          },
+        ],
+      },
+    ];
+
+    const result = transformRows(rows, relationSchema, "todos", { owner: true }, ["title"]);
+
+    expect(result).toEqual([
+      {
+        id: "todo-1",
+        title: "Buy milk",
+        owner: {
+          id: "user-1",
+          name: "Alice",
+          manager_id: undefined,
+        },
+      },
+    ]);
+  });
+
+  it("applies nested include projections to related rows", () => {
+    const rows: WasmRow[] = [
+      {
+        id: "todo-1",
+        values: [
+          { type: "Text", value: "Buy milk" },
+          { type: "Uuid", value: "user-1" },
+          {
+            type: "Array",
+            value: [
+              {
+                type: "Row",
+                value: {
+                  id: "user-1",
+                  values: [{ type: "Text", value: "Alice" }],
+                },
+              },
+            ],
+          },
+        ],
+      },
+    ];
+
+    const result = transformRows(rows, relationSchema, "todos", {
+      owner: {
+        conditions: [],
+        includes: {},
+        select: ["name"],
+        orderBy: [],
+        hops: [],
+      },
+    });
+
+    expect(result).toEqual([
+      {
+        id: "todo-1",
+        title: "Buy milk",
+        owner_id: "user-1",
+        owner: {
+          id: "user-1",
+          name: "Alice",
         },
       },
     ]);

--- a/packages/jazz-tools/src/runtime/row-transformer.ts
+++ b/packages/jazz-tools/src/runtime/row-transformer.ts
@@ -5,17 +5,47 @@
 import type { Value as WasmValue, WasmRow, WasmSchema } from "../drivers/types.js";
 import type { ColumnType } from "../drivers/types.js";
 import { analyzeRelations, type Relation } from "../codegen/relation-analyzer.js";
+import { normalizeIncludeEntries, type NormalizedIncludeSpec } from "./query-builder-shape.js";
 
 export type { WasmValue };
 
 export interface IncludeSpec {
-  [relationName: string]: boolean | IncludeSpec;
+  [relationName: string]: unknown;
 }
 
 type IncludePlan = {
   relation: Relation;
   nested: IncludePlan[];
+  projection?: readonly string[];
 };
+
+function resolveBaseColumns(
+  tableName: string,
+  schema: WasmSchema,
+  projection?: readonly string[],
+): Array<{ name: string; columnType: ColumnType }> {
+  const table = schema[tableName];
+  if (!table) {
+    throw new Error(`Unknown table "${tableName}" in schema`);
+  }
+
+  if (!projection || projection.length === 0) {
+    return table.columns.map((column) => ({
+      name: column.name,
+      columnType: column.column_type,
+    }));
+  }
+
+  return projection
+    .filter(
+      (columnName): columnName is string => typeof columnName === "string" && columnName !== "id",
+    )
+    .map((columnName) => {
+      const column = table.columns.find((candidate) => candidate.name === columnName);
+      return column ? { name: column.name, columnType: column.column_type } : null;
+    })
+    .filter((column): column is { name: string; columnType: ColumnType } => column !== null);
+}
 
 function toByteArray(value: unknown): Uint8Array {
   if (value instanceof Uint8Array) {
@@ -41,26 +71,25 @@ function toByteArray(value: unknown): Uint8Array {
 
 function buildIncludePlans(
   tableName: string,
-  includes: IncludeSpec,
+  includes: NormalizedIncludeSpec,
   relationsByTable: Map<string, Relation[]>,
 ): IncludePlan[] {
   const relations = relationsByTable.get(tableName) || [];
   const plans: IncludePlan[] = [];
 
   for (const [relationName, spec] of Object.entries(includes)) {
-    if (!spec) continue;
-
     const relation = relations.find((candidate) => candidate.name === relationName);
     if (!relation) {
       throw new Error(`Unknown relation "${relationName}" on table "${tableName}"`);
     }
 
-    const nested =
-      typeof spec === "object"
-        ? buildIncludePlans(relation.toTable, spec as IncludeSpec, relationsByTable)
-        : [];
+    const nested = buildIncludePlans(relation.toTable, spec.includes, relationsByTable);
 
-    plans.push({ relation, nested });
+    plans.push({
+      relation,
+      nested,
+      projection: spec.select.length > 0 ? spec.select : undefined,
+    });
   }
 
   return plans;
@@ -78,7 +107,14 @@ function transformIncludedValue(value: WasmValue, plan: IncludePlan, schema: Was
     // Row id is carried in the struct's `id` field
     const rowId = entry.value.id;
     const columnValues = entry.value.values;
-    return transformRowValues(columnValues, schema, plan.relation.toTable, plan.nested, rowId);
+    return transformRowValues(
+      columnValues,
+      schema,
+      plan.relation.toTable,
+      plan.nested,
+      rowId,
+      plan.projection,
+    );
   });
 
   return plan.relation.isArray ? rows : rows[0];
@@ -90,6 +126,7 @@ function transformRowValues(
   tableName: string,
   includePlans: IncludePlan[],
   rowId?: string,
+  projection?: readonly string[],
 ): Record<string, unknown> {
   const table = schema[tableName];
   if (!table) {
@@ -101,16 +138,18 @@ function transformRowValues(
     obj.id = rowId;
   }
 
-  for (let i = 0; i < table.columns.length; i++) {
-    const col = table.columns[i];
+  const baseColumns = resolveBaseColumns(tableName, schema, projection);
+
+  for (let i = 0; i < baseColumns.length; i++) {
+    const col = baseColumns[i];
     const value = values[i];
     if (value !== undefined) {
-      obj[col.name] = unwrapValue(value, col.column_type);
+      obj[col.name] = unwrapValue(value, col.columnType);
     }
   }
 
   for (let i = 0; i < includePlans.length; i++) {
-    const value = values[table.columns.length + i];
+    const value = values[baseColumns.length + i];
     if (value === undefined) continue;
     const plan = includePlans[i];
     obj[plan.relation.name] = transformIncludedValue(value, plan, schema);
@@ -175,6 +214,7 @@ export function transformRows<T>(
   schema: WasmSchema,
   tableName: string,
   includes: IncludeSpec = {},
+  projection?: readonly string[],
 ): T[] {
   if (!schema[tableName]) {
     throw new Error(`Unknown table "${tableName}" in schema`);
@@ -183,7 +223,7 @@ export function transformRows<T>(
   const includePlans =
     Object.keys(includes).length === 0
       ? []
-      : buildIncludePlans(tableName, includes, analyzeRelations(schema));
+      : buildIncludePlans(tableName, normalizeIncludeEntries(includes), analyzeRelations(schema));
 
   return rows.map((row) => {
     return transformRowValues(
@@ -192,6 +232,7 @@ export function transformRows<T>(
       tableName,
       includePlans,
       row.id,
+      projection,
     ) as T;
   });
 }
@@ -201,6 +242,7 @@ export function transformRow<T>(
   schema: WasmSchema,
   tableName: string,
   includes: IncludeSpec = {},
+  projection?: readonly string[],
 ): T {
-  return transformRows<T>([row], schema, tableName, includes)[0];
+  return transformRows<T>([row], schema, tableName, includes, projection)[0];
 }

--- a/packages/jazz-tools/tests/ts-dsl/fixtures/basic/app.ts
+++ b/packages/jazz-tools/tests/ts-dsl/fixtures/basic/app.ts
@@ -65,8 +65,11 @@ export type ProjectWithIncludes<I extends ProjectInclude = {}> = Project & {
   todosViaProject?: NonNullable<I["todosViaProject"]> extends infer RelationInclude
     ? RelationInclude extends true
       ? Todo[]
-      : RelationInclude extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
-        ? TodoWithIncludes<QueryInclude>[]
+      : RelationInclude extends TodoQueryBuilder<
+            infer QueryInclude extends TodoInclude,
+            infer QuerySelect extends keyof Todo
+          >
+        ? TodoSelectedWithIncludes<QueryInclude, QuerySelect>[]
         : RelationInclude extends TodoInclude
           ? TodoWithIncludes<RelationInclude>[]
           : never
@@ -77,13 +80,36 @@ export type TodoWithIncludes<I extends TodoInclude = {}> = Todo & {
   project?: NonNullable<I["project"]> extends infer RelationInclude
     ? RelationInclude extends true
       ? Project
-      : RelationInclude extends ProjectQueryBuilder<infer QueryInclude extends ProjectInclude>
-        ? ProjectWithIncludes<QueryInclude>
+      : RelationInclude extends ProjectQueryBuilder<
+            infer QueryInclude extends ProjectInclude,
+            infer QuerySelect extends keyof Project
+          >
+        ? ProjectSelectedWithIncludes<QueryInclude, QuerySelect>
         : RelationInclude extends ProjectInclude
           ? ProjectWithIncludes<RelationInclude>
           : never
     : never;
 };
+
+export type ProjectSelected<S extends keyof Project = keyof Project> = Pick<
+  Project,
+  Extract<S | "id", keyof Project>
+>;
+
+export type ProjectSelectedWithIncludes<
+  I extends ProjectInclude = {},
+  S extends keyof Project = keyof Project,
+> = ProjectSelected<S> & Omit<ProjectWithIncludes<I>, keyof Project>;
+
+export type TodoSelected<S extends keyof Todo = keyof Todo> = Pick<
+  Todo,
+  Extract<S | "id", keyof Todo>
+>;
+
+export type TodoSelectedWithIncludes<
+  I extends TodoInclude = {},
+  S extends keyof Todo = keyof Todo,
+> = TodoSelected<S> & Omit<TodoWithIncludes<I>, keyof Todo>;
 
 export const wasmSchema: WasmSchema = {
   projects: {
@@ -135,15 +161,17 @@ export const wasmSchema: WasmSchema = {
   },
 };
 
-export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements QueryBuilder<
-  ProjectWithIncludes<I>
-> {
+export class ProjectQueryBuilder<
+  I extends ProjectInclude = {},
+  S extends keyof Project = keyof Project,
+> implements QueryBuilder<ProjectSelectedWithIncludes<I, S>> {
   readonly _table = "projects";
   readonly _schema: WasmSchema = wasmSchema;
-  declare readonly _rowType: ProjectWithIncludes<I>;
+  declare readonly _rowType: ProjectSelectedWithIncludes<I, S>;
   declare readonly _initType: ProjectInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<ProjectInclude> = {};
+  private _selectColumns?: string[];
   private _orderBys: Array<[string, "asc" | "desc"]> = [];
   private _limitVal?: number;
   private _offsetVal?: number;
@@ -156,7 +184,7 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
     step_hops: string[];
   };
 
-  where(conditions: ProjectWhereInput): ProjectQueryBuilder<I> {
+  where(conditions: ProjectWhereInput): ProjectQueryBuilder<I, S> {
     const clone = this._clone();
     for (const [key, value] of Object.entries(conditions)) {
       if (value === undefined) continue;
@@ -173,31 +201,37 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
     return clone;
   }
 
-  include<NewI extends ProjectInclude>(relations: NewI): ProjectQueryBuilder<I & NewI> {
-    const clone = this._clone<I & NewI>();
+  select<NewS extends keyof Project>(...columns: [NewS, ...NewS[]]): ProjectQueryBuilder<I, NewS> {
+    const clone = this._clone<I, NewS>();
+    clone._selectColumns = [...columns] as string[];
+    return clone;
+  }
+
+  include<NewI extends ProjectInclude>(relations: NewI): ProjectQueryBuilder<I & NewI, S> {
+    const clone = this._clone<I & NewI, S>();
     clone._includes = { ...this._includes, ...relations };
     return clone;
   }
 
-  orderBy(column: keyof Project, direction: "asc" | "desc" = "asc"): ProjectQueryBuilder<I> {
+  orderBy(column: keyof Project, direction: "asc" | "desc" = "asc"): ProjectQueryBuilder<I, S> {
     const clone = this._clone();
     clone._orderBys.push([column as string, direction]);
     return clone;
   }
 
-  limit(n: number): ProjectQueryBuilder<I> {
+  limit(n: number): ProjectQueryBuilder<I, S> {
     const clone = this._clone();
     clone._limitVal = n;
     return clone;
   }
 
-  offset(n: number): ProjectQueryBuilder<I> {
+  offset(n: number): ProjectQueryBuilder<I, S> {
     const clone = this._clone();
     clone._offsetVal = n;
     return clone;
   }
 
-  hopTo(relation: "todosViaProject"): ProjectQueryBuilder<I> {
+  hopTo(relation: "todosViaProject"): ProjectQueryBuilder<I, S> {
     const clone = this._clone();
     clone._hops.push(relation);
     return clone;
@@ -207,7 +241,7 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
     start: ProjectWhereInput;
     step: (ctx: { current: string }) => QueryBuilder<unknown>;
     maxDepth?: number;
-  }): ProjectQueryBuilder<I> {
+  }): ProjectQueryBuilder<I, S> {
     if (options.start === undefined) {
       throw new Error("gather(...) requires start where conditions.");
     }
@@ -289,6 +323,7 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
       table: this._table,
       conditions: this._conditions,
       includes: this._includes,
+      select: this._selectColumns,
       orderBy: this._orderBys,
       limit: this._limitVal,
       offset: this._offsetVal,
@@ -297,10 +332,18 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
     });
   }
 
-  private _clone<CloneI extends ProjectInclude = I>(): ProjectQueryBuilder<CloneI> {
-    const clone = new ProjectQueryBuilder<CloneI>();
+  toJSON(): unknown {
+    return JSON.parse(this._build());
+  }
+
+  private _clone<
+    CloneI extends ProjectInclude = I,
+    CloneS extends keyof Project = S,
+  >(): ProjectQueryBuilder<CloneI, CloneS> {
+    const clone = new ProjectQueryBuilder<CloneI, CloneS>();
     clone._conditions = [...this._conditions];
     clone._includes = { ...this._includes };
+    clone._selectColumns = this._selectColumns ? [...this._selectColumns] : undefined;
     clone._orderBys = [...this._orderBys];
     clone._limitVal = this._limitVal;
     clone._offsetVal = this._offsetVal;
@@ -316,15 +359,17 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
   }
 }
 
-export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilder<
-  TodoWithIncludes<I>
-> {
+export class TodoQueryBuilder<
+  I extends TodoInclude = {},
+  S extends keyof Todo = keyof Todo,
+> implements QueryBuilder<TodoSelectedWithIncludes<I, S>> {
   readonly _table = "todos";
   readonly _schema: WasmSchema = wasmSchema;
-  declare readonly _rowType: TodoWithIncludes<I>;
+  declare readonly _rowType: TodoSelectedWithIncludes<I, S>;
   declare readonly _initType: TodoInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<TodoInclude> = {};
+  private _selectColumns?: string[];
   private _orderBys: Array<[string, "asc" | "desc"]> = [];
   private _limitVal?: number;
   private _offsetVal?: number;
@@ -337,7 +382,7 @@ export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilde
     step_hops: string[];
   };
 
-  where(conditions: TodoWhereInput): TodoQueryBuilder<I> {
+  where(conditions: TodoWhereInput): TodoQueryBuilder<I, S> {
     const clone = this._clone();
     for (const [key, value] of Object.entries(conditions)) {
       if (value === undefined) continue;
@@ -354,31 +399,37 @@ export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilde
     return clone;
   }
 
-  include<NewI extends TodoInclude>(relations: NewI): TodoQueryBuilder<I & NewI> {
-    const clone = this._clone<I & NewI>();
+  select<NewS extends keyof Todo>(...columns: [NewS, ...NewS[]]): TodoQueryBuilder<I, NewS> {
+    const clone = this._clone<I, NewS>();
+    clone._selectColumns = [...columns] as string[];
+    return clone;
+  }
+
+  include<NewI extends TodoInclude>(relations: NewI): TodoQueryBuilder<I & NewI, S> {
+    const clone = this._clone<I & NewI, S>();
     clone._includes = { ...this._includes, ...relations };
     return clone;
   }
 
-  orderBy(column: keyof Todo, direction: "asc" | "desc" = "asc"): TodoQueryBuilder<I> {
+  orderBy(column: keyof Todo, direction: "asc" | "desc" = "asc"): TodoQueryBuilder<I, S> {
     const clone = this._clone();
     clone._orderBys.push([column as string, direction]);
     return clone;
   }
 
-  limit(n: number): TodoQueryBuilder<I> {
+  limit(n: number): TodoQueryBuilder<I, S> {
     const clone = this._clone();
     clone._limitVal = n;
     return clone;
   }
 
-  offset(n: number): TodoQueryBuilder<I> {
+  offset(n: number): TodoQueryBuilder<I, S> {
     const clone = this._clone();
     clone._offsetVal = n;
     return clone;
   }
 
-  hopTo(relation: "project"): TodoQueryBuilder<I> {
+  hopTo(relation: "project"): TodoQueryBuilder<I, S> {
     const clone = this._clone();
     clone._hops.push(relation);
     return clone;
@@ -388,7 +439,7 @@ export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilde
     start: TodoWhereInput;
     step: (ctx: { current: string }) => QueryBuilder<unknown>;
     maxDepth?: number;
-  }): TodoQueryBuilder<I> {
+  }): TodoQueryBuilder<I, S> {
     if (options.start === undefined) {
       throw new Error("gather(...) requires start where conditions.");
     }
@@ -470,6 +521,7 @@ export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilde
       table: this._table,
       conditions: this._conditions,
       includes: this._includes,
+      select: this._selectColumns,
       orderBy: this._orderBys,
       limit: this._limitVal,
       offset: this._offsetVal,
@@ -478,10 +530,18 @@ export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilde
     });
   }
 
-  private _clone<CloneI extends TodoInclude = I>(): TodoQueryBuilder<CloneI> {
-    const clone = new TodoQueryBuilder<CloneI>();
+  toJSON(): unknown {
+    return JSON.parse(this._build());
+  }
+
+  private _clone<CloneI extends TodoInclude = I, CloneS extends keyof Todo = S>(): TodoQueryBuilder<
+    CloneI,
+    CloneS
+  > {
+    const clone = new TodoQueryBuilder<CloneI, CloneS>();
     clone._conditions = [...this._conditions];
     clone._includes = { ...this._includes };
+    clone._selectColumns = this._selectColumns ? [...this._selectColumns] : undefined;
     clone._orderBys = [...this._orderBys];
     clone._limitVal = this._limitVal;
     clone._offsetVal = this._offsetVal;

--- a/packages/jazz-tools/tests/ts-dsl/fixtures/basic/app.ts
+++ b/packages/jazz-tools/tests/ts-dsl/fixtures/basic/app.ts
@@ -67,7 +67,7 @@ export type ProjectWithIncludes<I extends ProjectInclude = {}> = Project & {
       ? Todo[]
       : RelationInclude extends TodoQueryBuilder<
             infer QueryInclude extends TodoInclude,
-            infer QuerySelect extends keyof Todo
+            infer QuerySelect extends keyof Todo | "*"
           >
         ? TodoSelectedWithIncludes<QueryInclude, QuerySelect>[]
         : RelationInclude extends TodoInclude
@@ -82,7 +82,7 @@ export type TodoWithIncludes<I extends TodoInclude = {}> = Todo & {
       ? Project
       : RelationInclude extends ProjectQueryBuilder<
             infer QueryInclude extends ProjectInclude,
-            infer QuerySelect extends keyof Project
+            infer QuerySelect extends keyof Project | "*"
           >
         ? ProjectSelectedWithIncludes<QueryInclude, QuerySelect>
         : RelationInclude extends ProjectInclude
@@ -91,24 +91,22 @@ export type TodoWithIncludes<I extends TodoInclude = {}> = Todo & {
     : never;
 };
 
-export type ProjectSelected<S extends keyof Project = keyof Project> = Pick<
-  Project,
-  Extract<S | "id", keyof Project>
->;
+export type ProjectSelected<S extends keyof Project | "*" = keyof Project> = "*" extends S
+  ? Project
+  : Pick<Project, Extract<S | "id", keyof Project>>;
 
 export type ProjectSelectedWithIncludes<
   I extends ProjectInclude = {},
-  S extends keyof Project = keyof Project,
+  S extends keyof Project | "*" = keyof Project,
 > = ProjectSelected<S> & Omit<ProjectWithIncludes<I>, keyof Project>;
 
-export type TodoSelected<S extends keyof Todo = keyof Todo> = Pick<
-  Todo,
-  Extract<S | "id", keyof Todo>
->;
+export type TodoSelected<S extends keyof Todo | "*" = keyof Todo> = "*" extends S
+  ? Todo
+  : Pick<Todo, Extract<S | "id", keyof Todo>>;
 
 export type TodoSelectedWithIncludes<
   I extends TodoInclude = {},
-  S extends keyof Todo = keyof Todo,
+  S extends keyof Todo | "*" = keyof Todo,
 > = TodoSelected<S> & Omit<TodoWithIncludes<I>, keyof Todo>;
 
 export const wasmSchema: WasmSchema = {
@@ -163,7 +161,7 @@ export const wasmSchema: WasmSchema = {
 
 export class ProjectQueryBuilder<
   I extends ProjectInclude = {},
-  S extends keyof Project = keyof Project,
+  S extends keyof Project | "*" = keyof Project,
 > implements QueryBuilder<ProjectSelectedWithIncludes<I, S>> {
   readonly _table = "projects";
   readonly _schema: WasmSchema = wasmSchema;
@@ -201,7 +199,9 @@ export class ProjectQueryBuilder<
     return clone;
   }
 
-  select<NewS extends keyof Project>(...columns: [NewS, ...NewS[]]): ProjectQueryBuilder<I, NewS> {
+  select<NewS extends keyof Project | "*">(
+    ...columns: [NewS, ...NewS[]]
+  ): ProjectQueryBuilder<I, NewS> {
     const clone = this._clone<I, NewS>();
     clone._selectColumns = [...columns] as string[];
     return clone;
@@ -338,7 +338,7 @@ export class ProjectQueryBuilder<
 
   private _clone<
     CloneI extends ProjectInclude = I,
-    CloneS extends keyof Project = S,
+    CloneS extends keyof Project | "*" = S,
   >(): ProjectQueryBuilder<CloneI, CloneS> {
     const clone = new ProjectQueryBuilder<CloneI, CloneS>();
     clone._conditions = [...this._conditions];
@@ -361,7 +361,7 @@ export class ProjectQueryBuilder<
 
 export class TodoQueryBuilder<
   I extends TodoInclude = {},
-  S extends keyof Todo = keyof Todo,
+  S extends keyof Todo | "*" = keyof Todo,
 > implements QueryBuilder<TodoSelectedWithIncludes<I, S>> {
   readonly _table = "todos";
   readonly _schema: WasmSchema = wasmSchema;
@@ -399,7 +399,7 @@ export class TodoQueryBuilder<
     return clone;
   }
 
-  select<NewS extends keyof Todo>(...columns: [NewS, ...NewS[]]): TodoQueryBuilder<I, NewS> {
+  select<NewS extends keyof Todo | "*">(...columns: [NewS, ...NewS[]]): TodoQueryBuilder<I, NewS> {
     const clone = this._clone<I, NewS>();
     clone._selectColumns = [...columns] as string[];
     return clone;
@@ -534,10 +534,10 @@ export class TodoQueryBuilder<
     return JSON.parse(this._build());
   }
 
-  private _clone<CloneI extends TodoInclude = I, CloneS extends keyof Todo = S>(): TodoQueryBuilder<
-    CloneI,
-    CloneS
-  > {
+  private _clone<
+    CloneI extends TodoInclude = I,
+    CloneS extends keyof Todo | "*" = S,
+  >(): TodoQueryBuilder<CloneI, CloneS> {
     const clone = new TodoQueryBuilder<CloneI, CloneS>();
     clone._conditions = [...this._conditions];
     clone._includes = { ...this._includes };

--- a/packages/jazz-tools/tests/ts-dsl/generated-app.test.ts
+++ b/packages/jazz-tools/tests/ts-dsl/generated-app.test.ts
@@ -13,6 +13,17 @@ describe("generated TS DSL fixture", () => {
     });
   });
 
+  it('serializes select("*") metadata on generated query builders', () => {
+    expect(JSON.parse(app.todos.select("*")._build())).toEqual({
+      table: "todos",
+      conditions: [],
+      includes: {},
+      select: ["*"],
+      orderBy: [],
+      hops: [],
+    });
+  });
+
   it("serializes nested include builders as query objects", () => {
     expect(
       JSON.parse(app.projects.include({ todosViaProject: app.todos.select("title") })._build()),

--- a/packages/jazz-tools/tests/ts-dsl/generated-app.test.ts
+++ b/packages/jazz-tools/tests/ts-dsl/generated-app.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { app } from "./fixtures/basic/app";
+
+describe("generated TS DSL fixture", () => {
+  it("serializes select metadata on generated query builders", () => {
+    expect(JSON.parse(app.todos.select("title").include({ project: true })._build())).toEqual({
+      table: "todos",
+      conditions: [],
+      includes: { project: true },
+      select: ["title"],
+      orderBy: [],
+      hops: [],
+    });
+  });
+
+  it("serializes nested include builders as query objects", () => {
+    expect(
+      JSON.parse(app.projects.include({ todosViaProject: app.todos.select("title") })._build()),
+    ).toEqual({
+      table: "projects",
+      conditions: [],
+      includes: {
+        todosViaProject: {
+          table: "todos",
+          conditions: [],
+          includes: {},
+          select: ["title"],
+          orderBy: [],
+          hops: [],
+        },
+      },
+      orderBy: [],
+      hops: [],
+    });
+  });
+});

--- a/packages/jazz-tools/tests/ts-dsl/query-api.test.ts
+++ b/packages/jazz-tools/tests/ts-dsl/query-api.test.ts
@@ -97,6 +97,150 @@ describe("TS Query API", () => {
     expect(todo.project?.name).toBe("Announcements");
   });
 
+  it("select narrows root columns while preserving id and includes", async () => {
+    const db = track(
+      await createDb({
+        appId: "test-app",
+        driver: { type: "persistent", dbName: uniqueDbName("select-root-columns") },
+      }),
+    );
+
+    const { id: projectId } = await db.insert(app.projects, { name: "Announcements" });
+    const { id: todoId } = await db.insert(app.todos, {
+      title: "Write tests",
+      done: false,
+      tags: ["dev"],
+      project: projectId,
+    });
+
+    const results = await db.all(
+      app.todos
+        .select("title")
+        .where({ id: { eq: todoId } })
+        .include({ project: true }),
+    );
+
+    expect(results).toEqual([
+      {
+        id: todoId,
+        title: "Write tests",
+        project: {
+          id: projectId,
+          name: "Announcements",
+        },
+      },
+    ]);
+    expect("done" in results[0]).toBe(false);
+    expect("tags" in results[0]).toBe(false);
+  });
+
+  it("include builders can project nested relation columns", async () => {
+    const db = track(
+      await createDb({
+        appId: "test-app",
+        driver: { type: "persistent", dbName: uniqueDbName("select-nested-columns") },
+      }),
+    );
+
+    const { id: projectId } = await db.insert(app.projects, { name: "Announcements" });
+    const { id: todoId } = await db.insert(app.todos, {
+      title: "Write tests",
+      done: false,
+      tags: ["dev"],
+      project: projectId,
+    });
+
+    const results = await db.all(
+      app.projects
+        .where({ id: { eq: projectId } })
+        .include({ todosViaProject: app.todos.select("title") }),
+    );
+
+    expect(results).toEqual([
+      {
+        id: projectId,
+        name: "Announcements",
+        todosViaProject: [
+          {
+            id: todoId,
+            title: "Write tests",
+          },
+        ],
+      },
+    ]);
+    expect("done" in results[0].todosViaProject![0]).toBe(false);
+    expect("tags" in results[0].todosViaProject![0]).toBe(false);
+    expect("project" in results[0].todosViaProject![0]).toBe(false);
+  });
+
+  it("subscribeAll preserves projected root columns with includes", async () => {
+    const db = track(
+      await createDb({
+        appId: "test-app",
+        driver: { type: "persistent", dbName: uniqueDbName("subscribe-select-root-columns") },
+      }),
+    );
+
+    const { id: projectId } = await db.insert(app.projects, { name: "Announcements" });
+
+    type SubscribedTodo = {
+      id: string;
+      title: string;
+      project: {
+        id: string;
+        name: string;
+      };
+    };
+
+    let unsubscribe = () => {};
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    const deltaPromise = new Promise<{ all: SubscribedTodo[] }>((resolve, reject) => {
+      timeout = setTimeout(() => {
+        unsubscribe();
+        reject(new Error("Timed out waiting for subscribeAll projection update"));
+      }, 10_000);
+
+      unsubscribe = db.subscribeAll(
+        app.todos.select("title").include({ project: true }),
+        (delta) => {
+          if (delta.all.length !== 1) {
+            return;
+          }
+
+          resolve(delta as { all: SubscribedTodo[] });
+        },
+      );
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const { id: todoId } = await db.insert(app.todos, {
+      title: "Watch subscription",
+      done: false,
+      tags: ["dev"],
+      project: projectId,
+    });
+
+    const delta = await deltaPromise;
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+    unsubscribe();
+
+    expect(delta.all).toEqual([
+      {
+        id: todoId,
+        title: "Watch subscription",
+        project: {
+          id: projectId,
+          name: "Announcements",
+        },
+      },
+    ]);
+    expect("done" in delta.all[0]).toBe(false);
+    expect("tags" in delta.all[0]).toBe(false);
+  });
+
   describe("query by array column", () => {
     it("using eq", async () => {
       const db = track(

--- a/packages/jazz-tools/tests/ts-dsl/query-api.test.ts
+++ b/packages/jazz-tools/tests/ts-dsl/query-api.test.ts
@@ -134,6 +134,35 @@ describe("TS Query API", () => {
     expect("tags" in results[0]).toBe(false);
   });
 
+  it('select("*") resets to all root columns', async () => {
+    const db = track(
+      await createDb({
+        appId: "test-app",
+        driver: { type: "persistent", dbName: uniqueDbName("select-all-columns") },
+      }),
+    );
+
+    const { id: projectId } = await db.insert(app.projects, { name: "Announcements" });
+    const { id: todoId } = await db.insert(app.todos, {
+      title: "Write tests",
+      done: false,
+      tags: ["dev"],
+      project: projectId,
+    });
+
+    const results = await db.all(app.todos.select("*").where({ id: { eq: todoId } }));
+
+    expect(results).toEqual([
+      {
+        id: todoId,
+        title: "Write tests",
+        done: false,
+        tags: ["dev"],
+        project: projectId,
+      },
+    ]);
+  });
+
   it("include builders can project nested relation columns", async () => {
     const db = track(
       await createDb({


### PR DESCRIPTION
## Summary
- add `.select()` to the generated TS query DSL with selection-aware result types
- push selected columns down into the runtime query payload, including include projections
- support nested include builders that serialize/query with projected columns and add coverage for `subscribeAll`

## Checks
- `pnpm run format:check`
- `pnpm run lint`
- `pnpm exec tsc -p tsconfig.json` (in `packages/jazz-tools`)
- `pnpm exec vitest run --config vitest.config.ts src/runtime/query-adapter.test.ts src/runtime/row-transformer.test.ts src/codegen/codegen.test.ts tests/ts-dsl/generated-app.test.ts tests/ts-dsl/query-api.test.ts` (in `packages/jazz-tools`)
- `pnpm exec vitest run --config vitest.config.ts src/runtime/db.schema-order.test.ts tests/ts-dsl/insert-api.test.ts` (in `packages/jazz-tools`)

## Notes
- repo-wide `lint` exits cleanly but still reports existing oxlint warnings outside this change set
- left unrelated local change in `crates/jazz-napi/index.d.ts` out of the branch history