### PR TITLE
Fix cloud server deployment dispatch payload

### DIFF
--- a/.github/workflows/publish-cloud-server-image.yml
+++ b/.github/workflows/publish-cloud-server-image.yml
@@ -97,9 +97,14 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
+          payload=$(jq -n \
+            --arg stack "${{ github.event.inputs.stack }}" \
+            --arg image_tag "${{ steps.meta.outputs.tag }}" \
+            '{event_type: "cloud-server-image-updated", client_payload: {stack: $stack, image_tag: $image_tag}}')
+
           gh api repos/${{ github.repository }}/dispatches \
-            -f event_type=cloud-server-image-updated \
-            -f client_payload="{\"stack\":\"${{ github.event.inputs.stack }}\",\"image_tag\":\"${{ steps.meta.outputs.tag }}\"}"
+            --method POST \
+            --input - <<<"$payload"
 
       - name: Summary
         run: |


### PR DESCRIPTION
## Summary
- send the repository dispatch body as JSON instead of form-encoding client_payload as a string
- keep the publish-image workflow handing off the target stack and image tag to the deploy workflow

## Testing
- git diff --check