### PR TITLE
Keep cloud server deployment PRs open

### DIFF
--- a/.github/workflows/deploy-cloud-server-image.yml
+++ b/.github/workflows/deploy-cloud-server-image.yml
@@ -117,5 +117,3 @@ jobs:
           else
             echo "Updated existing PR #${PR_NUMBER}"
           fi
-
-          gh pr merge --auto --squash "${BRANCH}"


### PR DESCRIPTION
## Summary
- stop auto-merging the deployment config PR created by the cloud server image deploy workflow
- leave the PR open so Pulumi can preview the config change before merge

## Testing
- git diff --check
- pulumi stack history --stack garden-computing/jazz-cloud2/dev --json