### PR TITLE
codegen: fix relation include overrides for foreign-key columns

### DIFF
--- a/.changeset/clever-taxes-wait.md
+++ b/.changeset/clever-taxes-wait.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Generate include result types by overriding foreign-key scalar fields only when the relation key is actually included, while preserving nested include inference

--- a/packages/jazz-tools/src/codegen/codegen.test.ts
+++ b/packages/jazz-tools/src/codegen/codegen.test.ts
@@ -806,27 +806,24 @@ describe("generateTypes with relations", () => {
 
     expect(output).toContain("export type TodoWithIncludes<I extends TodoInclude = {}>");
     expect(output).toContain("export type UserWithIncludes<I extends UserInclude = {}>");
-    expect(output).toContain("type TodoIncludedRelations<I extends TodoInclude = {}> =");
+    expect(output).toContain(
+      "type TodoIncludedRelations<I extends TodoInclude = {}, B extends object = Todo> =",
+    );
     expect(output).toContain('("owner" extends keyof I');
     expect(output).toContain('(NonNullable<I["owner"]> extends infer RelationInclude');
-    expect(output).toContain("? { owner?: User }");
+    expect(output).toContain('? [I] extends [{ [P in "owner"]-?: unknown }]');
+    expect(output).toContain('("owner" extends keyof B');
+    expect(output).toContain(": { owner?: (");
     expect(output).toContain(
       ': RelationInclude extends UserQueryBuilder<infer QueryInclude extends UserInclude, infer QuerySelect extends keyof User | "*">',
     );
-    expect(output).toContain("? { owner?: UserSelectedWithIncludes<QueryInclude, QuerySelect> }");
-    expect(output).toContain(": RelationInclude extends UserInclude");
-    expect(output).toContain("? { owner?: UserWithIncludes<RelationInclude> }");
     expect(output).toContain('("todosViaOwner" extends keyof I');
     expect(output).toContain('(NonNullable<I["todosViaOwner"]> extends infer RelationInclude');
-    expect(output).toContain("? { todosViaOwner?: Todo[] }");
+    expect(output).toContain('? [I] extends [{ [P in "todosViaOwner"]-?: unknown }]');
+    expect(output).toContain('("todosViaOwner" extends keyof B');
     expect(output).toContain(
       ': RelationInclude extends TodoQueryBuilder<infer QueryInclude extends TodoInclude, infer QuerySelect extends keyof Todo | "*">',
     );
-    expect(output).toContain(
-      "? { todosViaOwner?: TodoSelectedWithIncludes<QueryInclude, QuerySelect>[] }",
-    );
-    expect(output).toContain(": RelationInclude extends TodoInclude");
-    expect(output).toContain("? { todosViaOwner?: TodoWithIncludes<RelationInclude>[] }");
     expect(output).not.toContain("WithIncludesFor<");
     expect(output).not.toContain("WithIncludesArray<");
   });
@@ -844,7 +841,21 @@ describe("generateTypes with relations", () => {
       'export type TodoSelectedWithIncludes<I extends TodoInclude = {}, S extends keyof Todo | "*" = keyof Todo>',
     );
     expect(output).toContain(
-      "Omit<TodoSelected<S>, Extract<keyof I, keyof TodoRelations>> & TodoIncludedRelations<I>",
+      "Omit<TodoSelected<S>, Extract<keyof I, keyof TodoRelations>> & TodoIncludedRelations<I, TodoSelected<S>>",
+    );
+  });
+
+  it("preserves scalar FK unions for widened optional overlapping includes", () => {
+    table("users", { name: col.string() });
+    table("todos", { owner: col.ref("users"), title: col.string() });
+    const schema = getCollectedSchema();
+    const wasm = schemaToWasm(schema);
+    const output = generateTypes(wasm);
+
+    expect(output).toContain('{ [P in keyof Pick<B, "owner">]: Pick<B, "owner">[P] | (');
+    expect(output).toContain("? User");
+    expect(output).toContain(
+      'export type TodoSelectedWithIncludes<I extends TodoInclude = {}, S extends keyof Todo | "*" = keyof Todo> = Omit<TodoSelected<S>, Extract<keyof I, keyof TodoRelations>> & TodoIncludedRelations<I, TodoSelected<S>>;',
     );
   });
 
@@ -869,8 +880,9 @@ describe("generateTypes with relations", () => {
       '(NonNullable<I["resource_access_edgesViaResource"]> extends infer RelationInclude',
     );
     expect(output).toContain(
-      "? { resource_access_edgesViaResource?: ResourceAccessEdgeWithIncludes<RelationInclude>[] }",
+      '? [I] extends [{ [P in "resource_access_edgesViaResource"]-?: unknown }]',
     );
+    expect(output).toContain("? ResourceAccessEdgeWithIncludes<RelationInclude>[]");
     expect(output).not.toContain(
       'resource_access_edgesViaResource?: I["resource_access_edgesViaResource"] extends true',
     );

--- a/packages/jazz-tools/src/codegen/codegen.test.ts
+++ b/packages/jazz-tools/src/codegen/codegen.test.ts
@@ -806,25 +806,27 @@ describe("generateTypes with relations", () => {
 
     expect(output).toContain("export type TodoWithIncludes<I extends TodoInclude = {}>");
     expect(output).toContain("export type UserWithIncludes<I extends UserInclude = {}>");
-    expect(output).toContain('owner?: NonNullable<I["owner"]> extends infer RelationInclude');
-    expect(output).toContain("? RelationInclude extends true");
-    expect(output).toContain("? User");
+    expect(output).toContain("type TodoIncludedRelations<I extends TodoInclude = {}> =");
+    expect(output).toContain('("owner" extends keyof I');
+    expect(output).toContain('(NonNullable<I["owner"]> extends infer RelationInclude');
+    expect(output).toContain("? { owner?: User }");
     expect(output).toContain(
       ': RelationInclude extends UserQueryBuilder<infer QueryInclude extends UserInclude, infer QuerySelect extends keyof User | "*">',
     );
-    expect(output).toContain("? UserSelectedWithIncludes<QueryInclude, QuerySelect>");
+    expect(output).toContain("? { owner?: UserSelectedWithIncludes<QueryInclude, QuerySelect> }");
     expect(output).toContain(": RelationInclude extends UserInclude");
-    expect(output).toContain("? UserWithIncludes<RelationInclude>");
-    expect(output).toContain(
-      'todosViaOwner?: NonNullable<I["todosViaOwner"]> extends infer RelationInclude',
-    );
-    expect(output).toContain("? Todo[]");
+    expect(output).toContain("? { owner?: UserWithIncludes<RelationInclude> }");
+    expect(output).toContain('("todosViaOwner" extends keyof I');
+    expect(output).toContain('(NonNullable<I["todosViaOwner"]> extends infer RelationInclude');
+    expect(output).toContain("? { todosViaOwner?: Todo[] }");
     expect(output).toContain(
       ': RelationInclude extends TodoQueryBuilder<infer QueryInclude extends TodoInclude, infer QuerySelect extends keyof Todo | "*">',
     );
-    expect(output).toContain("? TodoSelectedWithIncludes<QueryInclude, QuerySelect>[]");
+    expect(output).toContain(
+      "? { todosViaOwner?: TodoSelectedWithIncludes<QueryInclude, QuerySelect>[] }",
+    );
     expect(output).toContain(": RelationInclude extends TodoInclude");
-    expect(output).toContain("? TodoWithIncludes<RelationInclude>[]");
+    expect(output).toContain("? { todosViaOwner?: TodoWithIncludes<RelationInclude>[] }");
     expect(output).not.toContain("WithIncludesFor<");
     expect(output).not.toContain("WithIncludesArray<");
   });
@@ -841,7 +843,9 @@ describe("generateTypes with relations", () => {
     expect(output).toContain(
       'export type TodoSelectedWithIncludes<I extends TodoInclude = {}, S extends keyof Todo | "*" = keyof Todo>',
     );
-    expect(output).toContain("TodoSelected<S> & Omit<TodoWithIncludes<I>, keyof Todo>");
+    expect(output).toContain(
+      "Omit<TodoSelected<S>, Extract<keyof I, keyof TodoRelations>> & TodoIncludedRelations<I>",
+    );
   });
 
   it("avoids collapsing nested array includes to never when selectors are optional", () => {
@@ -860,10 +864,13 @@ describe("generateTypes with relations", () => {
     const wasm = schemaToWasm(schema);
     const output = generateTypes(wasm);
 
+    expect(output).toContain('("resource_access_edgesViaResource" extends keyof I');
     expect(output).toContain(
-      'resource_access_edgesViaResource?: NonNullable<I["resource_access_edgesViaResource"]> extends infer RelationInclude',
+      '(NonNullable<I["resource_access_edgesViaResource"]> extends infer RelationInclude',
     );
-    expect(output).toContain("? ResourceAccessEdgeWithIncludes<RelationInclude>[]");
+    expect(output).toContain(
+      "? { resource_access_edgesViaResource?: ResourceAccessEdgeWithIncludes<RelationInclude>[] }",
+    );
     expect(output).not.toContain(
       'resource_access_edgesViaResource?: I["resource_access_edgesViaResource"] extends true',
     );

--- a/packages/jazz-tools/src/codegen/type-generator.ts
+++ b/packages/jazz-tools/src/codegen/type-generator.ts
@@ -204,22 +204,20 @@ function generateRelationsTypes(relations: Map<string, Relation[]>): string[] {
  * Generate WithIncludes types for type-safe include results.
  *
  * Example output:
- *   type TodoIncludedRelations<I extends TodoInclude = {}> =
+ *   type TodoIncludedRelations<I extends TodoInclude = {}, B extends object = Todo> =
  *     ("project" extends keyof I
  *       ? (NonNullable<I["project"]> extends infer RelationInclude
- *           ? RelationInclude extends true
+ *           ? [I] extends [{ [P in "project"]-?: unknown }]
  *             ? { project?: Project }
- *             : RelationInclude extends ProjectQueryBuilder<infer QueryInclude extends ProjectInclude>
- *               ? { project?: ProjectWithIncludes<QueryInclude> }
- *               : RelationInclude extends ProjectInclude
- *                 ? { project?: ProjectWithIncludes<RelationInclude> }
- *                 : {}
+ *             : ("project" extends keyof B
+ *                 ? { [P in keyof Pick<B, "project">]: Pick<B, "project">[P] | Project }
+ *                 : { project?: Project })
  *           : {})
  *       : {}) &
  *     {};
  *
  *   export type TodoWithIncludes<I extends TodoInclude = {}> =
- *     Omit<Todo, Extract<keyof I, keyof TodoRelations>> & TodoIncludedRelations<I>;
+ *     Omit<Todo, Extract<keyof I, keyof TodoRelations>> & TodoIncludedRelations<I, Todo>;
  */
 function generateWithIncludesTypes(relations: Map<string, Relation[]>): string[] {
   const lines: string[] = [];
@@ -232,12 +230,15 @@ function generateWithIncludesTypes(relations: Map<string, Relation[]>): string[]
     const relationsInterface = baseInterface + "Relations";
     const includedRelationsType = baseInterface + "IncludedRelations";
 
-    lines.push(`type ${includedRelationsType}<I extends ${includeInterface} = {}> =`);
+    lines.push(
+      `type ${includedRelationsType}<I extends ${includeInterface} = {}, B extends object = ${baseInterface}> =`,
+    );
     for (const rel of rels) {
       const targetInterface = tableNameToInterface(rel.toTable);
       const targetInclude = targetInterface + "Include";
       const targetQueryBuilder = targetInterface + "QueryBuilder";
       const targetWithIncludes = targetInterface + "WithIncludes";
+      const relationKey = `"${rel.name}"`;
       const trueType = rel.isArray ? `${targetInterface}[]` : targetInterface;
       const queryBuilderSelectedType = rel.isArray
         ? `${targetInterface}SelectedWithIncludes<QueryInclude, QuerySelect>[]`
@@ -246,24 +247,53 @@ function generateWithIncludesTypes(relations: Map<string, Relation[]>): string[]
         ? `${targetWithIncludes}<RelationInclude>[]`
         : `${targetWithIncludes}<RelationInclude>`;
 
-      lines.push(`  ("${rel.name}" extends keyof I`);
-      lines.push(`    ? (NonNullable<I["${rel.name}"]> extends infer RelationInclude`);
-      lines.push(`        ? RelationInclude extends true`);
-      lines.push(`          ? { ${rel.name}?: ${trueType} }`);
+      lines.push(`  (${relationKey} extends keyof I`);
+      lines.push(`    ? (NonNullable<I[${relationKey}]> extends infer RelationInclude`);
+      lines.push(`        ? [I] extends [{ [P in ${relationKey}]-?: unknown }]`);
+      lines.push(`          ? { ${rel.name}?: (`);
+      lines.push(`              RelationInclude extends true`);
+      lines.push(`                ? ${trueType}`);
       lines.push(
-        `          : RelationInclude extends ${targetQueryBuilder}<infer QueryInclude extends ${targetInclude}, infer QuerySelect extends keyof ${targetInterface} | "*">`,
+        `                : RelationInclude extends ${targetQueryBuilder}<infer QueryInclude extends ${targetInclude}, infer QuerySelect extends keyof ${targetInterface} | "*">`,
       );
-      lines.push(`            ? { ${rel.name}?: ${queryBuilderSelectedType} }`);
-      lines.push(`            : RelationInclude extends ${targetInclude}`);
-      lines.push(`              ? { ${rel.name}?: ${nestedIncludeType} }`);
-      lines.push(`              : {}`);
+      lines.push(`                  ? ${queryBuilderSelectedType}`);
+      lines.push(`                  : RelationInclude extends ${targetInclude}`);
+      lines.push(`                    ? ${nestedIncludeType}`);
+      lines.push(`                    : never`);
+      lines.push(`            ) }`);
+      lines.push(`          : (${relationKey} extends keyof B`);
+      lines.push(
+        `              ? { [P in keyof Pick<B, ${relationKey}>]: Pick<B, ${relationKey}>[P] | (`,
+      );
+      lines.push(`                  RelationInclude extends true`);
+      lines.push(`                    ? ${trueType}`);
+      lines.push(
+        `                    : RelationInclude extends ${targetQueryBuilder}<infer QueryInclude extends ${targetInclude}, infer QuerySelect extends keyof ${targetInterface} | "*">`,
+      );
+      lines.push(`                      ? ${queryBuilderSelectedType}`);
+      lines.push(`                      : RelationInclude extends ${targetInclude}`);
+      lines.push(`                        ? ${nestedIncludeType}`);
+      lines.push(`                        : never`);
+      lines.push(`                ) }`);
+      lines.push(`              : { ${rel.name}?: (`);
+      lines.push(`                  RelationInclude extends true`);
+      lines.push(`                    ? ${trueType}`);
+      lines.push(
+        `                    : RelationInclude extends ${targetQueryBuilder}<infer QueryInclude extends ${targetInclude}, infer QuerySelect extends keyof ${targetInterface} | "*">`,
+      );
+      lines.push(`                      ? ${queryBuilderSelectedType}`);
+      lines.push(`                      : RelationInclude extends ${targetInclude}`);
+      lines.push(`                        ? ${nestedIncludeType}`);
+      lines.push(`                        : never`);
+      lines.push(`                ) }`);
+      lines.push(`            )`);
       lines.push(`        : {})`);
       lines.push(`    : {}) &`);
     }
     lines.push(`  {};`);
     lines.push(``);
     lines.push(
-      `export type ${baseInterface}WithIncludes<I extends ${includeInterface} = {}> = Omit<${baseInterface}, Extract<keyof I, keyof ${relationsInterface}>> & ${includedRelationsType}<I>;`,
+      `export type ${baseInterface}WithIncludes<I extends ${includeInterface} = {}> = Omit<${baseInterface}, Extract<keyof I, keyof ${relationsInterface}>> & ${includedRelationsType}<I, ${baseInterface}>;`,
     );
     lines.push(``);
   }
@@ -286,7 +316,7 @@ function generateSelectionTypes(schema: WasmSchema, relations: Map<string, Relat
 
     if (hasRelations) {
       lines.push(
-        `export type ${baseInterface}SelectedWithIncludes<I extends ${includeInterface} = {}, S extends keyof ${baseInterface} | "*" = keyof ${baseInterface}> = Omit<${baseInterface}Selected<S>, Extract<keyof I, keyof ${baseInterface}Relations>> & ${baseInterface}IncludedRelations<I>;`,
+        `export type ${baseInterface}SelectedWithIncludes<I extends ${includeInterface} = {}, S extends keyof ${baseInterface} | "*" = keyof ${baseInterface}> = Omit<${baseInterface}Selected<S>, Extract<keyof I, keyof ${baseInterface}Relations>> & ${baseInterface}IncludedRelations<I, ${baseInterface}Selected<S>>;`,
       );
       lines.push("");
     }

--- a/packages/jazz-tools/src/codegen/type-generator.ts
+++ b/packages/jazz-tools/src/codegen/type-generator.ts
@@ -204,17 +204,22 @@ function generateRelationsTypes(relations: Map<string, Relation[]>): string[] {
  * Generate WithIncludes types for type-safe include results.
  *
  * Example output:
- *   export type TodoWithIncludes<I extends TodoInclude = {}> = Todo & {
- *     project?: NonNullable<I["project"]> extends infer RelationInclude
- *       ? RelationInclude extends true
- *         ? Project
- *         : RelationInclude extends ProjectQueryBuilder<infer QueryInclude extends ProjectInclude>
- *           ? ProjectWithIncludes<QueryInclude>
- *           : RelationInclude extends ProjectInclude
- *             ? ProjectWithIncludes<RelationInclude>
- *             : never
- *       : never;
- *   };
+ *   type TodoIncludedRelations<I extends TodoInclude = {}> =
+ *     ("project" extends keyof I
+ *       ? (NonNullable<I["project"]> extends infer RelationInclude
+ *           ? RelationInclude extends true
+ *             ? { project?: Project }
+ *             : RelationInclude extends ProjectQueryBuilder<infer QueryInclude extends ProjectInclude>
+ *               ? { project?: ProjectWithIncludes<QueryInclude> }
+ *               : RelationInclude extends ProjectInclude
+ *                 ? { project?: ProjectWithIncludes<RelationInclude> }
+ *                 : {}
+ *           : {})
+ *       : {}) &
+ *     {};
+ *
+ *   export type TodoWithIncludes<I extends TodoInclude = {}> =
+ *     Omit<Todo, Extract<keyof I, keyof TodoRelations>> & TodoIncludedRelations<I>;
  */
 function generateWithIncludesTypes(relations: Map<string, Relation[]>): string[] {
   const lines: string[] = [];
@@ -224,16 +229,15 @@ function generateWithIncludesTypes(relations: Map<string, Relation[]>): string[]
 
     const baseInterface = tableNameToInterface(tableName);
     const includeInterface = baseInterface + "Include";
+    const relationsInterface = baseInterface + "Relations";
+    const includedRelationsType = baseInterface + "IncludedRelations";
 
-    lines.push(
-      `export type ${baseInterface}WithIncludes<I extends ${includeInterface} = {}> = ${baseInterface} & {`,
-    );
+    lines.push(`type ${includedRelationsType}<I extends ${includeInterface} = {}> =`);
     for (const rel of rels) {
       const targetInterface = tableNameToInterface(rel.toTable);
       const targetInclude = targetInterface + "Include";
       const targetQueryBuilder = targetInterface + "QueryBuilder";
       const targetWithIncludes = targetInterface + "WithIncludes";
-      const includeSelector = `NonNullable<I["${rel.name}"]>`;
       const trueType = rel.isArray ? `${targetInterface}[]` : targetInterface;
       const queryBuilderSelectedType = rel.isArray
         ? `${targetInterface}SelectedWithIncludes<QueryInclude, QuerySelect>[]`
@@ -242,19 +246,25 @@ function generateWithIncludesTypes(relations: Map<string, Relation[]>): string[]
         ? `${targetWithIncludes}<RelationInclude>[]`
         : `${targetWithIncludes}<RelationInclude>`;
 
-      lines.push(`  ${rel.name}?: ${includeSelector} extends infer RelationInclude`);
-      lines.push(`    ? RelationInclude extends true`);
-      lines.push(`      ? ${trueType}`);
+      lines.push(`  ("${rel.name}" extends keyof I`);
+      lines.push(`    ? (NonNullable<I["${rel.name}"]> extends infer RelationInclude`);
+      lines.push(`        ? RelationInclude extends true`);
+      lines.push(`          ? { ${rel.name}?: ${trueType} }`);
       lines.push(
-        `      : RelationInclude extends ${targetQueryBuilder}<infer QueryInclude extends ${targetInclude}, infer QuerySelect extends keyof ${targetInterface} | "*">`,
+        `          : RelationInclude extends ${targetQueryBuilder}<infer QueryInclude extends ${targetInclude}, infer QuerySelect extends keyof ${targetInterface} | "*">`,
       );
-      lines.push(`        ? ${queryBuilderSelectedType}`);
-      lines.push(`        : RelationInclude extends ${targetInclude}`);
-      lines.push(`          ? ${nestedIncludeType}`);
-      lines.push(`          : never`);
-      lines.push(`    : never;`);
+      lines.push(`            ? { ${rel.name}?: ${queryBuilderSelectedType} }`);
+      lines.push(`            : RelationInclude extends ${targetInclude}`);
+      lines.push(`              ? { ${rel.name}?: ${nestedIncludeType} }`);
+      lines.push(`              : {}`);
+      lines.push(`        : {})`);
+      lines.push(`    : {}) &`);
     }
-    lines.push(`};`);
+    lines.push(`  {};`);
+    lines.push(``);
+    lines.push(
+      `export type ${baseInterface}WithIncludes<I extends ${includeInterface} = {}> = Omit<${baseInterface}, Extract<keyof I, keyof ${relationsInterface}>> & ${includedRelationsType}<I>;`,
+    );
     lines.push(``);
   }
 
@@ -267,7 +277,6 @@ function generateSelectionTypes(schema: WasmSchema, relations: Map<string, Relat
   for (const tableName of Object.keys(schema)) {
     const baseInterface = tableNameToInterface(tableName);
     const includeInterface = baseInterface + "Include";
-    const withIncludesType = baseInterface + "WithIncludes";
     const hasRelations = (relations.get(tableName) ?? []).length > 0;
 
     lines.push(
@@ -277,7 +286,7 @@ function generateSelectionTypes(schema: WasmSchema, relations: Map<string, Relat
 
     if (hasRelations) {
       lines.push(
-        `export type ${baseInterface}SelectedWithIncludes<I extends ${includeInterface} = {}, S extends keyof ${baseInterface} | "*" = keyof ${baseInterface}> = ${baseInterface}Selected<S> & Omit<${withIncludesType}<I>, keyof ${baseInterface}>;`,
+        `export type ${baseInterface}SelectedWithIncludes<I extends ${includeInterface} = {}, S extends keyof ${baseInterface} | "*" = keyof ${baseInterface}> = Omit<${baseInterface}Selected<S>, Extract<keyof I, keyof ${baseInterface}Relations>> & ${baseInterface}IncludedRelations<I>;`,
       );
       lines.push("");
     }

--- a/packages/jazz-tools/tests/codegen/fixtures/include-collisions/negative-typecheck.ts
+++ b/packages/jazz-tools/tests/codegen/fixtures/include-collisions/negative-typecheck.ts
@@ -1,0 +1,7 @@
+import { app, type TodoInclude } from "./app.ts";
+
+const forwarded: TodoInclude = {};
+const maybeForwarded = app.todos.include(forwarded).orderBy("id", "asc");
+declare const row: typeof maybeForwarded._rowType;
+
+row.owner?.id;

--- a/packages/jazz-tools/tests/codegen/fixtures/include-collisions/negative-typecheck.ts
+++ b/packages/jazz-tools/tests/codegen/fixtures/include-collisions/negative-typecheck.ts
@@ -1,7 +1,9 @@
 import { app, type TodoInclude } from "./app.ts";
 
+declare function read<T>(_value: T): void;
+
 const forwarded: TodoInclude = {};
 const maybeForwarded = app.todos.include(forwarded).orderBy("id", "asc");
 declare const row: typeof maybeForwarded._rowType;
 
-row.owner?.id;
+read(row.owner?.id);

--- a/packages/jazz-tools/tests/codegen/fixtures/include-collisions/schema.ts
+++ b/packages/jazz-tools/tests/codegen/fixtures/include-collisions/schema.ts
@@ -1,0 +1,11 @@
+import { col, table } from "../../../../src/dsl.js";
+
+export function buildSchema() {
+  table("users", { name: col.string() });
+  table("projects", { name: col.string() });
+  table("todos", {
+    owner: col.ref("users"),
+    project_id: col.ref("projects"),
+    title: col.string(),
+  });
+}

--- a/packages/jazz-tools/tests/codegen/fixtures/include-collisions/typecheck.ts
+++ b/packages/jazz-tools/tests/codegen/fixtures/include-collisions/typecheck.ts
@@ -1,0 +1,34 @@
+import { app, type TodoInclude } from "./app.ts";
+
+const noInclude = app.todos.orderBy("id", "asc");
+declare const noIncludeRow: typeof noInclude._rowType;
+
+// @ts-expect-error overlapping FK stays scalar without include()
+noIncludeRow.owner?.id;
+// @ts-expect-error non-overlapping relation key is absent without include()
+noIncludeRow.project?.id;
+
+const withOwner = app.todos.include({ owner: true }).orderBy("id", "asc");
+declare const withOwnerRow: typeof withOwner._rowType;
+withOwnerRow.owner?.id;
+
+const withProject = app.todos.include({ project: true }).orderBy("id", "asc");
+declare const withProjectRow: typeof withProject._rowType;
+withProjectRow.project?.id;
+
+const forwarded: TodoInclude = {};
+const maybeForwarded = app.todos.include(forwarded).orderBy("id", "asc");
+declare const maybeForwardedRow: typeof maybeForwarded._rowType;
+// @ts-expect-error widened include must preserve scalar possibility for overlapping FKs
+maybeForwardedRow.owner?.id;
+maybeForwardedRow.project?.id;
+
+const conditional = Math.random() > 0.5 ? { owner: true as const } : {};
+const maybeConditional = app.todos.include(conditional).orderBy("id", "asc");
+declare const maybeConditionalRow: typeof maybeConditional._rowType;
+// @ts-expect-error union include must preserve scalar possibility for overlapping FKs
+maybeConditionalRow.owner?.id;
+
+if (typeof maybeForwardedRow.owner !== "string" && maybeForwardedRow.owner) {
+  maybeForwardedRow.owner.id;
+}

--- a/packages/jazz-tools/tests/codegen/fixtures/include-collisions/typecheck.ts
+++ b/packages/jazz-tools/tests/codegen/fixtures/include-collisions/typecheck.ts
@@ -1,34 +1,36 @@
 import { app, type TodoInclude } from "./app.ts";
 
+declare function read<T>(_value: T): void;
+
 const noInclude = app.todos.orderBy("id", "asc");
 declare const noIncludeRow: typeof noInclude._rowType;
 
 // @ts-expect-error overlapping FK stays scalar without include()
-noIncludeRow.owner?.id;
+read(noIncludeRow.owner?.id);
 // @ts-expect-error non-overlapping relation key is absent without include()
-noIncludeRow.project?.id;
+read(noIncludeRow.project?.id);
 
 const withOwner = app.todos.include({ owner: true }).orderBy("id", "asc");
 declare const withOwnerRow: typeof withOwner._rowType;
-withOwnerRow.owner?.id;
+read(withOwnerRow.owner?.id);
 
 const withProject = app.todos.include({ project: true }).orderBy("id", "asc");
 declare const withProjectRow: typeof withProject._rowType;
-withProjectRow.project?.id;
+read(withProjectRow.project?.id);
 
 const forwarded: TodoInclude = {};
 const maybeForwarded = app.todos.include(forwarded).orderBy("id", "asc");
 declare const maybeForwardedRow: typeof maybeForwarded._rowType;
 // @ts-expect-error widened include must preserve scalar possibility for overlapping FKs
-maybeForwardedRow.owner?.id;
-maybeForwardedRow.project?.id;
+read(maybeForwardedRow.owner?.id);
+read(maybeForwardedRow.project?.id);
 
 const conditional = Math.random() > 0.5 ? { owner: true as const } : {};
 const maybeConditional = app.todos.include(conditional).orderBy("id", "asc");
 declare const maybeConditionalRow: typeof maybeConditional._rowType;
 // @ts-expect-error union include must preserve scalar possibility for overlapping FKs
-maybeConditionalRow.owner?.id;
+read(maybeConditionalRow.owner?.id);
 
 if (typeof maybeForwardedRow.owner !== "string" && maybeForwardedRow.owner) {
-  maybeForwardedRow.owner.id;
+  read(maybeForwardedRow.owner.id);
 }

--- a/packages/jazz-tools/tests/codegen/fixtures/nested-reverse-array/schema.ts
+++ b/packages/jazz-tools/tests/codegen/fixtures/nested-reverse-array/schema.ts
@@ -1,0 +1,15 @@
+import { col, table } from "../../../../src/dsl.js";
+
+export function buildSchema() {
+  table("teams", { legacy_id: col.string() });
+  table("resources", { kind: col.enum("branding") });
+  table("resource_access_edges", {
+    resource: col.ref("resources"),
+    team: col.ref("teams"),
+    grant_role: col.enum("viewer", "editor", "manager"),
+  });
+  table("brandings", {
+    resource: col.ref("resources"),
+    name: col.string(),
+  });
+}

--- a/packages/jazz-tools/tests/codegen/fixtures/nested-reverse-array/typecheck.ts
+++ b/packages/jazz-tools/tests/codegen/fixtures/nested-reverse-array/typecheck.ts
@@ -1,0 +1,8 @@
+import { app } from "./app.ts";
+
+const nested = app.resources.include({
+  resource_access_edgesViaResource: { team: true },
+});
+
+declare const row: typeof nested._rowType;
+row.resource_access_edgesViaResource?.[0].team?.id;

--- a/packages/jazz-tools/tests/codegen/fixtures/nested-reverse-array/typecheck.ts
+++ b/packages/jazz-tools/tests/codegen/fixtures/nested-reverse-array/typecheck.ts
@@ -1,8 +1,10 @@
 import { app } from "./app.ts";
 
+declare function read<T>(_value: T): void;
+
 const nested = app.resources.include({
   resource_access_edgesViaResource: { team: true },
 });
 
 declare const row: typeof nested._rowType;
-row.resource_access_edgesViaResource?.[0].team?.id;
+read(row.resource_access_edgesViaResource?.[0].team?.id);

--- a/packages/jazz-tools/tests/codegen/typecheck-generated.test.ts
+++ b/packages/jazz-tools/tests/codegen/typecheck-generated.test.ts
@@ -1,0 +1,123 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, relative, resolve, sep } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import ts from "typescript";
+import { describe, expect, it } from "vitest";
+import { getCollectedSchema, resetCollectedState } from "../../src/dsl.js";
+import { schemaToWasm } from "../../src/codegen/schema-reader.js";
+import { generateTypes } from "../../src/codegen/type-generator.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PACKAGE_ROOT = resolve(HERE, "../..");
+const DRIVERS_TYPES_PATH = resolve(PACKAGE_ROOT, "src/drivers/types.ts");
+const RUNTIME_DB_PATH = resolve(PACKAGE_ROOT, "src/runtime/db.ts");
+const TYPECHECK_FIXTURES_DIR = resolve(HERE, "fixtures");
+
+function toModuleSpecifier(fromDir: string, toFile: string): string {
+  const rel = relative(fromDir, toFile).split(sep).join("/");
+  return rel.startsWith(".") ? rel : `./${rel}`;
+}
+
+function createGeneratedAppSource(tempDir: string, buildSchema: () => void): string {
+  resetCollectedState();
+
+  try {
+    buildSchema();
+
+    return generateTypes(schemaToWasm(getCollectedSchema())).replace(
+      'import type { WasmSchema, QueryBuilder } from "jazz-tools";',
+      [
+        `import type { WasmSchema } from "${toModuleSpecifier(tempDir, DRIVERS_TYPES_PATH)}";`,
+        `import type { QueryBuilder } from "${toModuleSpecifier(tempDir, RUNTIME_DB_PATH)}";`,
+      ].join("\n"),
+    );
+  } finally {
+    resetCollectedState();
+  }
+}
+
+function compileTypecheckFixture({
+  buildSchema,
+  typecheckSource,
+}: {
+  buildSchema: () => void;
+  typecheckSource: string;
+}): readonly ts.Diagnostic[] {
+  const tempDir = mkdtempSync(join(tmpdir(), "jazz-tools-codegen-typecheck-"));
+  const appPath = join(tempDir, "app.ts");
+  const typecheckPath = join(tempDir, "typecheck.ts");
+
+  try {
+    writeFileSync(appPath, createGeneratedAppSource(tempDir, buildSchema));
+    writeFileSync(typecheckPath, typecheckSource);
+
+    const compilerOptions: ts.CompilerOptions = {
+      noEmit: true,
+      strict: true,
+      target: ts.ScriptTarget.ES2022,
+      module: ts.ModuleKind.ESNext,
+      moduleResolution: ts.ModuleResolutionKind.Bundler,
+      allowImportingTsExtensions: true,
+      skipLibCheck: true,
+    };
+
+    const program = ts.createProgram([typecheckPath], compilerOptions);
+    return ts.getPreEmitDiagnostics(program);
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+async function compileTypecheckFixtureDir(
+  fixtureName: string,
+  typecheckFileName = "typecheck.ts",
+): Promise<readonly ts.Diagnostic[]> {
+  const fixtureDir = resolve(TYPECHECK_FIXTURES_DIR, fixtureName);
+  const schemaModule = (await import(pathToFileURL(join(fixtureDir, "schema.ts")).href)) as {
+    buildSchema: () => void;
+  };
+
+  return compileTypecheckFixture({
+    buildSchema: schemaModule.buildSchema,
+    typecheckSource: readFileSync(join(fixtureDir, typecheckFileName), "utf8"),
+  });
+}
+
+function formatDiagnostics(diagnostics: readonly ts.Diagnostic[]): string {
+  const host: ts.FormatDiagnosticsHost = {
+    getCanonicalFileName: (fileName) => fileName,
+    getCurrentDirectory: () => process.cwd(),
+    getNewLine: () => "\n",
+  };
+
+  return ts.formatDiagnosticsWithColorAndContext([...diagnostics], host);
+}
+
+function diagnosticCodes(diagnostics: readonly ts.Diagnostic[]): number[] {
+  return diagnostics.map((diagnostic) => diagnostic.code).sort((a, b) => a - b);
+}
+
+describe("generated codegen typechecking", () => {
+  it("typechecks include collisions, widened includes, and non-overlapping relations", async () => {
+    const diagnostics = await compileTypecheckFixtureDir("include-collisions");
+
+    expect(diagnostics, formatDiagnostics(diagnostics)).toHaveLength(0);
+  });
+
+  it("typechecks nested include selectors for reverse array relations", async () => {
+    const diagnostics = await compileTypecheckFixtureDir("nested-reverse-array");
+
+    expect(diagnostics, formatDiagnostics(diagnostics)).toHaveLength(0);
+  });
+
+  it("reports compile errors for unsafe access on maybe-included overlapping relations", async () => {
+    const diagnostics = await compileTypecheckFixtureDir(
+      "include-collisions",
+      "negative-typecheck.ts",
+    );
+
+    expect(diagnostics.length, formatDiagnostics(diagnostics)).toBeGreaterThan(0);
+    expect(diagnosticCodes(diagnostics)).toContain(2339);
+  });
+});

--- a/packages/jazz-tools/vitest.config.ts
+++ b/packages/jazz-tools/vitest.config.ts
@@ -40,7 +40,7 @@ export default defineConfig({
     environment: "node",
     // Use forks pool to avoid Vite's module resolution issues with node: builtins
     pool: "forks",
-    include: ["src/**/*.test.ts", "tests/ts-dsl/**/*.test.ts"],
+    include: ["src/**/*.test.ts", "tests/ts-dsl/**/*.test.ts", "tests/codegen/**/*.test.ts"],
     exclude: ["tests/browser/**", "node_modules/**"],
     server: {
       deps: {


### PR DESCRIPTION
# Summary

Fix generated include result types so relation includes override same-named foreign-key scalar fields only when that relation is actually included.

# Problem

Generated types were incorrect:
```ts
const rows = useAll(app.items.include({ owner: true }));
rows?.[0].owner.id; // error: owner was still typed as string
```

# Root Cause

The generated type combined base fields and included relations in a way that dropped relation overrides for overlapping keys like owner, and it still evaluated I["owner"] even when no include key was present.

# Fix

Generate included relations separately, guard them with key presence, and then replace overlapping base keys only for relations that were actually included.