### PR TITLE
feat: make query optional in `useAll`

### DIFF
--- a/.changeset/silent-flowers-live.md
+++ b/.changeset/silent-flowers-live.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Make query optional in `useAll` to support conditionally running queries when inputs are missing

--- a/docs/content/docs/reading-data.mdx
+++ b/docs/content/docs/reading-data.mdx
@@ -87,6 +87,18 @@ useEffect(() => {
 }, [rows]);
 ```
 
+### Running queries conditionally
+
+There are some cases where you want to defer running a query. This could happen if the query depends on an input the user hasn't provided yet,
+or on the output of a previous query. In these cases, you can pass `undefined` to `useAll` to defer the query until the condition is met.
+
+```ts
+const [filter, setFilter] = useState<string | null>(null);
+const rows = useAll(filter ? app.todos.where({ title: { contains: filter } }) : undefined);
+```
+
+When an undefined query is passed to `useAll`, it will return `undefined` until the query is provided.
+
 ### React Suspense and Transitions
 
 The docs React example app includes a Suspense-based list that keeps the previous result visible

--- a/packages/jazz-tools/src/react-core/use-all.ts
+++ b/packages/jazz-tools/src/react-core/use-all.ts
@@ -3,17 +3,28 @@ import { type Usable, use } from "react";
 import type { QueryBuilder } from "../runtime/db.js";
 import { useJazzClient } from "./provider.js";
 
-function useAllBase<T extends { id: string }>(
-  query: QueryBuilder<T>,
-  suspense: boolean,
-): T[] | undefined {
-  const { manager } = useJazzClient();
+type UseAllOptions = {
+  suspense?: boolean;
+};
 
-  const key = manager.makeQueryKey(query);
-  const entry = manager.getCacheEntry<T>(key);
-  const dispatch = React.useReducer((_, action) => action, entry.state)[1];
+const SUSPEND_FOREVER: Promise<never> = new Promise(() => {});
+
+function useAllBase<T extends { id: string }>(
+  query?: QueryBuilder<T>,
+  options?: UseAllOptions,
+): T[] | undefined {
+  const { suspense = false } = options ?? {};
+  const { manager } = useJazzClient();
+  const entry = React.useMemo(() => {
+    if (!query) return null;
+    const key = manager.makeQueryKey(query);
+    return manager.getCacheEntry<T>(key);
+  }, [manager, query]);
+  const dispatch = React.useReducer((_, action) => action, entry?.state)[1];
 
   React.useLayoutEffect(() => {
+    if (!entry) return;
+
     const unsubscribe = entry.subscribe({
       onfulfilled: () => {
         dispatch(entry.state);
@@ -31,6 +42,13 @@ function useAllBase<T extends { id: string }>(
     };
   }, [entry]);
 
+  if (!entry) {
+    if (suspense) {
+      return use(SUSPEND_FOREVER as unknown as Usable<T[]>);
+    }
+    return undefined;
+  }
+
   const state = entry.state;
 
   if (suspense) {
@@ -46,10 +64,10 @@ function useAllBase<T extends { id: string }>(
   return state.status === "fulfilled" ? state.data : undefined;
 }
 
-export function useAll<T extends { id: string }>(query: QueryBuilder<T>): T[] | undefined {
-  return useAllBase(query, false);
+export function useAll<T extends { id: string }>(query?: QueryBuilder<T>): T[] | undefined {
+  return useAllBase(query, { suspense: false });
 }
 
-export function useAllSuspense<T extends { id: string }>(query: QueryBuilder<T>): T[] {
-  return useAllBase(query, true) as T[];
+export function useAllSuspense<T extends { id: string }>(query?: QueryBuilder<T>): T[] {
+  return useAllBase(query, { suspense: true }) as T[];
 }

--- a/packages/jazz-tools/tests/browser/useAll.test.tsx
+++ b/packages/jazz-tools/tests/browser/useAll.test.tsx
@@ -176,7 +176,7 @@ function UseAllProbe<T extends { id: string }>({
   query,
   pick,
 }: {
-  query: QueryBuilder<T>;
+  query?: QueryBuilder<T>;
   pick: (row: T) => string;
 }) {
   const rows = useAll(query);
@@ -586,6 +586,58 @@ describe("useAll browser integration", () => {
       () => getText("rows").includes("done-task") && !getText("rows").includes("open-task"),
       5000,
       "expected updated query to show only done task",
+    );
+  });
+
+  it("returns undefined when query is missing and a result when the query is provided later", async () => {
+    const client = track(
+      await createJazzClient({
+        appId: uniqueId("missing-query"),
+        driver: { type: "persistent", dbName: uniqueId("missing-query") },
+      }),
+    );
+
+    await client.db.insert(todos, {
+      title: "late-query-task",
+      done: false,
+      priority: 1,
+      owner_id: undefined,
+      tags: ["x"],
+    });
+
+    function MissingThenSetQueryProbe() {
+      const [useQuery, setUseQuery] = React.useState(false);
+      const query = useQuery ? makeQuery<Todo>("todos", {}) : undefined;
+      return (
+        <>
+          <button data-testid="set-query" onClick={() => setUseQuery(true)}>
+            set-query
+          </button>
+          <UseAllProbe query={query} pick={(row) => row.title} />
+        </>
+      );
+    }
+
+    render(
+      <JazzProvider client={client}>
+        <MissingThenSetQueryProbe />
+      </JazzProvider>,
+    );
+
+    await waitForCondition(
+      () => getText("rows") === "pending",
+      5000,
+      "expected pending text when query is missing",
+    );
+
+    const setQueryButton = container?.querySelector('[data-testid="set-query"]');
+    expect(setQueryButton).toBeTruthy();
+    await userEvent.click(setQueryButton as HTMLElement);
+
+    await waitForCondition(
+      () => getText("rows").includes("late-query-task"),
+      5000,
+      "expected rows to load after query is provided",
     );
   });
 });

--- a/packages/jazz-tools/tests/browser/useAllSuspense.test.tsx
+++ b/packages/jazz-tools/tests/browser/useAllSuspense.test.tsx
@@ -189,7 +189,7 @@ function UseAllProbe<T extends { id: string }>({
   query,
   pick,
 }: {
-  query: QueryBuilder<T>;
+  query?: QueryBuilder<T>;
   pick: (row: T) => string;
 }) {
   const rows = useAllSuspense(query);
@@ -635,6 +635,61 @@ describe("useAllSuspense browser integration", () => {
       () => getText("rows").includes("done-task") && !getText("rows").includes("open-task"),
       5000,
       "expected updated query to show only done task",
+    );
+  });
+
+  it("stays suspended when query is missing and resumes once query is provided", async () => {
+    const client = track(
+      await createJazzClient({
+        appId: uniqueId("missing-query"),
+        driver: { type: "persistent", dbName: uniqueId("missing-query") },
+      }),
+    );
+
+    await client.db.insert(todos, {
+      title: "late-query-task",
+      done: false,
+      priority: 1,
+      owner_id: undefined,
+      tags: ["x"],
+    });
+
+    function MissingThenSetSuspenseQueryProbe() {
+      const [useQuery, setUseQuery] = React.useState(false);
+      const query = useQuery ? makeQuery<Todo>("todos", {}) : undefined;
+
+      return (
+        <>
+          <button data-testid="set-query" onClick={() => setUseQuery(true)}>
+            set-query
+          </button>
+          <React.Suspense fallback={<div data-testid="rows-fallback">pending</div>}>
+            <UseAllProbe query={query} pick={(row: Todo) => row.title} />
+          </React.Suspense>
+        </>
+      );
+    }
+
+    render(
+      <JazzProvider client={client}>
+        <MissingThenSetSuspenseQueryProbe />
+      </JazzProvider>,
+    );
+
+    await waitForCondition(
+      () => hasTestId("rows-fallback") && !hasTestId("rows"),
+      5000,
+      "expected suspense fallback while query is missing",
+    );
+
+    const setQueryButton = container?.querySelector('[data-testid="set-query"]');
+    expect(setQueryButton).toBeTruthy();
+    await userEvent.click(setQueryButton as HTMLElement);
+
+    await waitForCondition(
+      () => hasTestId("rows") && getText("rows").includes("late-query-task"),
+      5000,
+      "expected suspense hook to resolve after query is provided",
     );
   });
 });


### PR DESCRIPTION
## Description

React's Rules of hooks make it inconvenient to run queries when some of their inputs aren't yet available (either because of a missing user input, or a previous query not having completed). 

```typescript
const db = useDb();
const session = useSession();
const userId = session?.user_id ?? null;
// Fails because `userId` can be null
const users = useAll(app.users.where({ user_id: { eq: userId } }));
```

This PR makes the query provided to `useAll` optional, to enable the following pattern:

```typescript
const users = useAll(userId ? app.users.where({ user_id: { eq: userId } }) : undefined);
```

When a query is not provided, `useAll` will return `undefined` (and `useAllSuspense` will suspend).

## Discussion

I took a look at how TanStack Query solves this issue. I found their model for [disabling/pausing queries](https://tanstack.com/query/v5/docs/framework/react/guides/disabling-queries#typesafe-disabling-of-queries-using-skiptoken) excessively complex (as it introduces a new "paused" state to the query lifecycle which I don't think we need), and it also doesn't solve typing properly (see https://tkdodo.eu/blog/react-query-and-type-script#type-safety-with-the-enabled-option). Our solution is closer to their newer approach of avoiding to provide a query with [skipToken](https://tanstack.com/query/v5/docs/framework/react/guides/disabling-queries#typesafe-disabling-of-queries-using-skiptoken). 