### PR TITLE
Spike Fjall storage backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1828,6 +1828,7 @@ dependencies = [
  "bytes",
  "clap",
  "criterion",
+ "fjall",
  "futures",
  "hex",
  "internment",

--- a/crates/jazz-tools/Cargo.toml
+++ b/crates/jazz-tools/Cargo.toml
@@ -17,6 +17,7 @@ required-features = ["cli"]
 
 [features]
 default = []
+fjall = ["dep:fjall"]
 surrealkv = ["dep:surrealkv", "dep:tokio"]
 runtime-tokio = ["dep:tokio"]
 transport = []
@@ -69,6 +70,7 @@ ahash = "0.8"
 sha2 = "0.10"
 
 tokio = { version = "1", features = ["full"], optional = true }
+fjall = { version = "3.0.2", optional = true }
 surrealkv = { version = "0.19", optional = true }
 
 axum = { version = "0.7", optional = true }
@@ -111,6 +113,10 @@ tokio = { version = "1", features = ["test-util", "full"] }
 [[bench]]
 name = "realistic_phase1"
 harness = false
+
+[[example]]
+name = "storage_backend_probe"
+required-features = ["fjall", "surrealkv"]
 
 [[example]]
 name = "realistic_bench"

--- a/crates/jazz-tools/examples/storage_backend_probe.rs
+++ b/crates/jazz-tools/examples/storage_backend_probe.rs
@@ -1,0 +1,305 @@
+use std::env;
+use std::time::Instant;
+
+use jazz_tools::object::ObjectId;
+use jazz_tools::query_manager::types::{ColumnType, Schema, SchemaBuilder, TableSchema, Value};
+use jazz_tools::runtime_core::{NoopScheduler, RuntimeCore, VecSyncSender};
+use jazz_tools::schema_manager::{AppId, SchemaManager};
+use jazz_tools::storage::{FjallStorage, Storage, SurrealKvStorage};
+use jazz_tools::sync_manager::SyncManager;
+use serde::Serialize;
+
+type ProbeRuntime<S> = RuntimeCore<S, NoopScheduler, VecSyncSender>;
+
+#[derive(Clone, Copy)]
+enum Backend {
+    SurrealKv,
+    Fjall,
+}
+
+impl Backend {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::SurrealKv => "surrealkv",
+            Self::Fjall => "fjall",
+        }
+    }
+
+    fn parse(raw: &str) -> Option<Self> {
+        match raw {
+            "surrealkv" => Some(Self::SurrealKv),
+            "fjall" => Some(Self::Fjall),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum Operation {
+    SeedFirstTaskCreate,
+    UpdateTaskStatus,
+}
+
+impl Operation {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::SeedFirstTaskCreate => "seed_first_task_create",
+            Self::UpdateTaskStatus => "update_task_status",
+        }
+    }
+
+    fn parse(raw: &str) -> Option<Self> {
+        match raw {
+            "seed_first_task_create" => Some(Self::SeedFirstTaskCreate),
+            "update_task_status" => Some(Self::UpdateTaskStatus),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct ProbeResult {
+    backend: &'static str,
+    operation: &'static str,
+    elapsed_ms: f64,
+}
+
+struct SeededBoard {
+    users: [ObjectId; 2],
+    project_id: ObjectId,
+    task_id: Option<ObjectId>,
+    next_timestamp: u64,
+}
+
+fn main() {
+    let mut backend = None;
+    let mut operation = None;
+    let mut args = env::args().skip(1);
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "--backend" => backend = args.next().and_then(|value| Backend::parse(&value)),
+            "--operation" => operation = args.next().and_then(|value| Operation::parse(&value)),
+            _ => {}
+        }
+    }
+
+    let backend = backend.unwrap_or_else(|| {
+        eprintln!("missing or invalid --backend (surrealkv|fjall)");
+        std::process::exit(2);
+    });
+    let operation = operation.unwrap_or_else(|| {
+        eprintln!("missing or invalid --operation (seed_first_task_create|update_task_status)");
+        std::process::exit(2);
+    });
+
+    let elapsed_ms = match backend {
+        Backend::SurrealKv => {
+            let tempdir = tempfile::tempdir().expect("create tempdir");
+            let storage =
+                SurrealKvStorage::open(tempdir.path().join("probe.surrealkv"), 64 * 1024 * 1024)
+                    .expect("open surrealkv");
+            run_with_storage(storage, operation)
+        }
+        Backend::Fjall => {
+            let tempdir = tempfile::tempdir().expect("create tempdir");
+            let storage = FjallStorage::open(tempdir.path().join("probe.fjall"), 64 * 1024 * 1024)
+                .expect("open fjall");
+            run_with_storage(storage, operation)
+        }
+    };
+
+    let result = ProbeResult {
+        backend: backend.as_str(),
+        operation: operation.as_str(),
+        elapsed_ms,
+    };
+    println!("{}", serde_json::to_string(&result).expect("encode json"));
+}
+
+fn run_with_storage<S: Storage>(storage: S, operation: Operation) -> f64 {
+    let mut runtime = create_runtime(storage);
+    let started = Instant::now();
+    match operation {
+        Operation::SeedFirstTaskCreate => {
+            let seeded = seed_board(&mut runtime, false);
+            insert_task(&mut runtime, &seeded);
+            runtime.flush_storage();
+        }
+        Operation::UpdateTaskStatus => {
+            let seeded = seed_board(&mut runtime, true);
+            let task_id = seeded.task_id.expect("task id");
+            runtime
+                .update(
+                    task_id,
+                    vec![
+                        ("status".to_string(), Value::Text("done".to_string())),
+                        ("priority".to_string(), Value::Integer(2)),
+                        ("assignee_id".to_string(), Value::Uuid(seeded.users[1])),
+                        (
+                            "updated_at".to_string(),
+                            Value::Timestamp(seeded.next_timestamp + 1),
+                        ),
+                    ],
+                    None,
+                )
+                .expect("update task");
+            runtime.flush_storage();
+        }
+    }
+    started.elapsed().as_secs_f64() * 1000.0
+}
+
+fn create_runtime<S: Storage>(storage: S) -> ProbeRuntime<S> {
+    let schema_manager = SchemaManager::new(
+        SyncManager::new(),
+        project_board_schema(),
+        AppId::from_name("storage-backend-probe"),
+        "dev",
+        "main",
+    )
+    .expect("create schema manager");
+    RuntimeCore::new(schema_manager, storage, NoopScheduler, VecSyncSender::new())
+}
+
+fn seed_board<S: Storage>(runtime: &mut ProbeRuntime<S>, include_task: bool) -> SeededBoard {
+    let mut next_timestamp = 1_770_000_000_000_000u64;
+    let mut bump_timestamp = || {
+        next_timestamp += 1;
+        next_timestamp
+    };
+
+    let (user_a, _) = runtime
+        .insert(
+            "users",
+            vec![
+                Value::Text("User A".to_string()),
+                Value::Text("a@bench.local".to_string()),
+            ],
+            None,
+        )
+        .expect("insert user a");
+    let (user_b, _) = runtime
+        .insert(
+            "users",
+            vec![
+                Value::Text("User B".to_string()),
+                Value::Text("b@bench.local".to_string()),
+            ],
+            None,
+        )
+        .expect("insert user b");
+
+    let (org_id, _) = runtime
+        .insert(
+            "organizations",
+            vec![
+                Value::Text("Org".to_string()),
+                Value::Timestamp(bump_timestamp()),
+            ],
+            None,
+        )
+        .expect("insert org");
+
+    for (user_id, role) in [(user_a, "owner"), (user_b, "editor")] {
+        runtime
+            .insert(
+                "memberships",
+                vec![
+                    Value::Uuid(org_id),
+                    Value::Uuid(user_id),
+                    Value::Text(role.to_string()),
+                ],
+                None,
+            )
+            .expect("insert membership");
+    }
+
+    let (project_id, _) = runtime
+        .insert(
+            "projects",
+            vec![
+                Value::Uuid(org_id),
+                Value::Text("Project".to_string()),
+                Value::Boolean(false),
+                Value::Timestamp(bump_timestamp()),
+            ],
+            None,
+        )
+        .expect("insert project");
+
+    let task_id = include_task.then(|| {
+        insert_task(
+            runtime,
+            &SeededBoard {
+                users: [user_a, user_b],
+                project_id,
+                task_id: None,
+                next_timestamp,
+            },
+        )
+    });
+
+    SeededBoard {
+        users: [user_a, user_b],
+        project_id,
+        task_id,
+        next_timestamp,
+    }
+}
+
+fn insert_task<S: Storage>(runtime: &mut ProbeRuntime<S>, seeded: &SeededBoard) -> ObjectId {
+    runtime
+        .insert(
+            "tasks",
+            vec![
+                Value::Uuid(seeded.project_id),
+                Value::Text("Task 0".to_string()),
+                Value::Text("todo".to_string()),
+                Value::Integer(1),
+                Value::Uuid(seeded.users[0]),
+                Value::Timestamp(seeded.next_timestamp + 1),
+                Value::Null,
+            ],
+            None,
+        )
+        .expect("insert task")
+        .0
+}
+
+fn project_board_schema() -> Schema {
+    SchemaBuilder::new()
+        .table(
+            TableSchema::builder("users")
+                .column("display_name", ColumnType::Text)
+                .column("email", ColumnType::Text),
+        )
+        .table(
+            TableSchema::builder("organizations")
+                .column("name", ColumnType::Text)
+                .column("created_at", ColumnType::Timestamp),
+        )
+        .table(
+            TableSchema::builder("memberships")
+                .fk_column("organization_id", "organizations")
+                .fk_column("user_id", "users")
+                .column("role", ColumnType::Text),
+        )
+        .table(
+            TableSchema::builder("projects")
+                .fk_column("organization_id", "organizations")
+                .column("name", ColumnType::Text)
+                .column("archived", ColumnType::Boolean)
+                .column("updated_at", ColumnType::Timestamp),
+        )
+        .table(
+            TableSchema::builder("tasks")
+                .fk_column("project_id", "projects")
+                .column("title", ColumnType::Text)
+                .column("status", ColumnType::Text)
+                .column("priority", ColumnType::Integer)
+                .fk_column("assignee_id", "users")
+                .column("updated_at", ColumnType::Timestamp)
+                .nullable_column("due_at", ColumnType::Timestamp),
+        )
+        .build()
+}

--- a/crates/jazz-tools/src/storage/fjall.rs
+++ b/crates/jazz-tools/src/storage/fjall.rs
@@ -1,0 +1,650 @@
+//! Fjall-backed Storage implementation.
+//!
+//! Uses one transactional Fjall database with a single keyspace and the same
+//! UTF-8 key encoding scheme as the other native backends.
+
+use std::cell::RefCell;
+use std::collections::{HashMap, HashSet};
+use std::ops::Bound;
+use std::path::Path;
+
+use fjall::{
+    KeyspaceCreateOptions, PersistMode, Readable, SingleWriterTxDatabase, SingleWriterTxKeyspace,
+    SingleWriterWriteTx, Snapshot,
+};
+
+use crate::commit::{Commit, CommitId};
+use crate::object::{BranchName, ObjectId};
+use crate::query_manager::types::Value;
+use crate::sync_manager::DurabilityTier;
+
+use super::{
+    CatalogueManifest, CatalogueManifestOp, LoadedBranch, Storage, StorageError,
+    storage_core::{
+        append_catalogue_manifest_op_core, append_catalogue_manifest_ops_core, append_commit_core,
+        create_object_core, delete_commit_core, index_insert_core, index_lookup_core,
+        index_range_core, index_remove_core, index_scan_all_core, load_branch_core,
+        load_catalogue_manifest_core, load_object_metadata_core, set_branch_tails_core,
+        store_ack_tier_core,
+    },
+};
+
+const KEYSPACE_NAME: &str = "jazz";
+
+pub struct FjallStorage {
+    db: SingleWriterTxDatabase,
+    keyspace: SingleWriterTxKeyspace,
+}
+
+impl FjallStorage {
+    pub fn open(path: impl AsRef<Path>, cache_size_bytes: usize) -> Result<Self, StorageError> {
+        let db = SingleWriterTxDatabase::builder(path.as_ref())
+            .cache_size(cache_size_bytes as u64)
+            .manual_journal_persist(true)
+            .open()
+            .map_err(|e| StorageError::IoError(format!("fjall open: {e}")))?;
+        let keyspace = db
+            .keyspace(KEYSPACE_NAME, KeyspaceCreateOptions::default)
+            .map_err(|e| StorageError::IoError(format!("fjall keyspace: {e}")))?;
+        Ok(Self { db, keyspace })
+    }
+
+    fn read_tx(&self) -> Snapshot {
+        self.db.read_tx()
+    }
+
+    fn write_tx(&self) -> SingleWriterWriteTx<'_> {
+        self.db.write_tx()
+    }
+
+    fn commit_tx(tx: SingleWriterWriteTx<'_>) -> Result<(), StorageError> {
+        tx.commit()
+            .map_err(|e| StorageError::IoError(format!("fjall commit: {e}")))
+    }
+
+    fn read_get(
+        txn: &impl Readable,
+        keyspace: &SingleWriterTxKeyspace,
+        key: &str,
+    ) -> Result<Option<Vec<u8>>, StorageError> {
+        txn.get(keyspace, key.as_bytes())
+            .map(|value| value.map(|value| value.to_vec()))
+            .map_err(|e| StorageError::IoError(format!("fjall get: {e}")))
+    }
+
+    fn scan_prefix(
+        txn: &impl Readable,
+        keyspace: &SingleWriterTxKeyspace,
+        prefix: &str,
+    ) -> Result<Vec<(String, Vec<u8>)>, StorageError> {
+        let mut out = Vec::new();
+        for item in txn.prefix(keyspace, prefix.as_bytes()) {
+            let (key, value) = item
+                .into_inner()
+                .map_err(|e| StorageError::IoError(format!("fjall prefix item: {e}")))?;
+            let key = String::from_utf8(key.to_vec())
+                .map_err(|e| StorageError::IoError(format!("fjall invalid key utf8: {e}")))?;
+            out.push((key, value.to_vec()));
+        }
+        Ok(out)
+    }
+
+    fn scan_prefix_keys(
+        txn: &impl Readable,
+        keyspace: &SingleWriterTxKeyspace,
+        prefix: &str,
+    ) -> Result<Vec<String>, StorageError> {
+        let mut out = Vec::new();
+        for item in txn.prefix(keyspace, prefix.as_bytes()) {
+            let key = item
+                .key()
+                .map_err(|e| StorageError::IoError(format!("fjall prefix key: {e}")))?;
+            let key = String::from_utf8(key.to_vec())
+                .map_err(|e| StorageError::IoError(format!("fjall invalid key utf8: {e}")))?;
+            out.push(key);
+        }
+        Ok(out)
+    }
+
+    fn scan_key_range(
+        txn: &impl Readable,
+        keyspace: &SingleWriterTxKeyspace,
+        start: &str,
+        end: &str,
+    ) -> Result<Vec<String>, StorageError> {
+        let mut out = Vec::new();
+        for item in txn.range(keyspace, start.as_bytes()..end.as_bytes()) {
+            let key = item
+                .key()
+                .map_err(|e| StorageError::IoError(format!("fjall range key: {e}")))?;
+            let key = String::from_utf8(key.to_vec())
+                .map_err(|e| StorageError::IoError(format!("fjall invalid key utf8: {e}")))?;
+            out.push(key);
+        }
+        Ok(out)
+    }
+
+    fn set_on_tx(
+        tx: &mut SingleWriterWriteTx<'_>,
+        keyspace: &SingleWriterTxKeyspace,
+        key: &str,
+        value: &[u8],
+    ) -> Result<(), StorageError> {
+        tx.insert(keyspace, key.as_bytes(), value);
+        Ok(())
+    }
+
+    fn delete_on_tx(
+        tx: &mut SingleWriterWriteTx<'_>,
+        keyspace: &SingleWriterTxKeyspace,
+        key: &str,
+    ) -> Result<(), StorageError> {
+        tx.remove(keyspace, key.as_bytes());
+        Ok(())
+    }
+
+    fn read_get_cell(
+        tx: &RefCell<SingleWriterWriteTx<'_>>,
+        keyspace: &SingleWriterTxKeyspace,
+        key: &str,
+    ) -> Result<Option<Vec<u8>>, StorageError> {
+        let tx = tx.borrow();
+        Self::read_get(&*tx, keyspace, key)
+    }
+
+    fn set_on_cell(
+        tx: &RefCell<SingleWriterWriteTx<'_>>,
+        keyspace: &SingleWriterTxKeyspace,
+        key: &str,
+        value: &[u8],
+    ) -> Result<(), StorageError> {
+        let mut tx = tx.borrow_mut();
+        Self::set_on_tx(&mut tx, keyspace, key, value)
+    }
+
+    fn delete_on_cell(
+        tx: &RefCell<SingleWriterWriteTx<'_>>,
+        keyspace: &SingleWriterTxKeyspace,
+        key: &str,
+    ) -> Result<(), StorageError> {
+        let mut tx = tx.borrow_mut();
+        Self::delete_on_tx(&mut tx, keyspace, key)
+    }
+}
+
+impl Storage for FjallStorage {
+    fn create_object(
+        &mut self,
+        id: ObjectId,
+        metadata: HashMap<String, String>,
+    ) -> Result<(), StorageError> {
+        let mut tx = self.write_tx();
+        create_object_core(id, metadata, |key, value| {
+            Self::set_on_tx(&mut tx, &self.keyspace, key, value)
+        })?;
+        Self::commit_tx(tx)
+    }
+
+    fn load_object_metadata(
+        &self,
+        id: ObjectId,
+    ) -> Result<Option<HashMap<String, String>>, StorageError> {
+        let tx = self.read_tx();
+        load_object_metadata_core(id, |key| Self::read_get(&tx, &self.keyspace, key))
+    }
+
+    fn load_branch(
+        &self,
+        object_id: ObjectId,
+        branch: &BranchName,
+    ) -> Result<Option<LoadedBranch>, StorageError> {
+        let tx = self.read_tx();
+        load_branch_core(
+            object_id,
+            branch,
+            |key| Self::read_get(&tx, &self.keyspace, key),
+            |prefix| Self::scan_prefix(&tx, &self.keyspace, prefix),
+        )
+    }
+
+    fn append_commit(
+        &mut self,
+        object_id: ObjectId,
+        branch: &BranchName,
+        commit: Commit,
+    ) -> Result<(), StorageError> {
+        let tx = RefCell::new(self.write_tx());
+        append_commit_core(
+            object_id,
+            branch,
+            commit,
+            |key| Self::read_get_cell(&tx, &self.keyspace, key),
+            |key, value| Self::set_on_cell(&tx, &self.keyspace, key, value),
+        )?;
+        Self::commit_tx(tx.into_inner())
+    }
+
+    fn delete_commit(
+        &mut self,
+        object_id: ObjectId,
+        branch: &BranchName,
+        commit_id: CommitId,
+    ) -> Result<(), StorageError> {
+        let tx = RefCell::new(self.write_tx());
+        delete_commit_core(
+            object_id,
+            branch,
+            commit_id,
+            |key| Self::read_get_cell(&tx, &self.keyspace, key),
+            |key, value| Self::set_on_cell(&tx, &self.keyspace, key, value),
+            |key| Self::delete_on_cell(&tx, &self.keyspace, key),
+        )?;
+        Self::commit_tx(tx.into_inner())
+    }
+
+    fn set_branch_tails(
+        &mut self,
+        object_id: ObjectId,
+        branch: &BranchName,
+        tails: Option<HashSet<CommitId>>,
+    ) -> Result<(), StorageError> {
+        let tx = RefCell::new(self.write_tx());
+        set_branch_tails_core(
+            object_id,
+            branch,
+            tails,
+            |key, value| Self::set_on_cell(&tx, &self.keyspace, key, value),
+            |key| Self::delete_on_cell(&tx, &self.keyspace, key),
+        )?;
+        Self::commit_tx(tx.into_inner())
+    }
+
+    fn store_ack_tier(
+        &mut self,
+        commit_id: CommitId,
+        tier: DurabilityTier,
+    ) -> Result<(), StorageError> {
+        let tx = RefCell::new(self.write_tx());
+        store_ack_tier_core(
+            commit_id,
+            tier,
+            |key| Self::read_get_cell(&tx, &self.keyspace, key),
+            |key, value| Self::set_on_cell(&tx, &self.keyspace, key, value),
+        )?;
+        Self::commit_tx(tx.into_inner())
+    }
+
+    fn append_catalogue_manifest_op(
+        &mut self,
+        app_id: ObjectId,
+        op: CatalogueManifestOp,
+    ) -> Result<(), StorageError> {
+        let tx = RefCell::new(self.write_tx());
+        append_catalogue_manifest_op_core(
+            app_id,
+            op,
+            |key| Self::read_get_cell(&tx, &self.keyspace, key),
+            |key, value| Self::set_on_cell(&tx, &self.keyspace, key, value),
+        )?;
+        Self::commit_tx(tx.into_inner())
+    }
+
+    fn append_catalogue_manifest_ops(
+        &mut self,
+        app_id: ObjectId,
+        ops: &[CatalogueManifestOp],
+    ) -> Result<(), StorageError> {
+        let tx = RefCell::new(self.write_tx());
+        append_catalogue_manifest_ops_core(
+            app_id,
+            ops,
+            |key| Self::read_get_cell(&tx, &self.keyspace, key),
+            |key, value| Self::set_on_cell(&tx, &self.keyspace, key, value),
+        )?;
+        Self::commit_tx(tx.into_inner())
+    }
+
+    fn load_catalogue_manifest(
+        &self,
+        app_id: ObjectId,
+    ) -> Result<Option<CatalogueManifest>, StorageError> {
+        let tx = self.read_tx();
+        load_catalogue_manifest_core(app_id, |prefix| {
+            Self::scan_prefix(&tx, &self.keyspace, prefix)
+        })
+    }
+
+    fn index_insert(
+        &mut self,
+        table: &str,
+        column: &str,
+        branch: &str,
+        value: &Value,
+        row_id: ObjectId,
+    ) -> Result<(), StorageError> {
+        let mut tx = self.write_tx();
+        index_insert_core(table, column, branch, value, row_id, |key, bytes| {
+            Self::set_on_tx(&mut tx, &self.keyspace, key, bytes)
+        })?;
+        Self::commit_tx(tx)
+    }
+
+    fn index_remove(
+        &mut self,
+        table: &str,
+        column: &str,
+        branch: &str,
+        value: &Value,
+        row_id: ObjectId,
+    ) -> Result<(), StorageError> {
+        let mut tx = self.write_tx();
+        index_remove_core(table, column, branch, value, row_id, |key| {
+            Self::delete_on_tx(&mut tx, &self.keyspace, key)
+        })?;
+        Self::commit_tx(tx)
+    }
+
+    fn index_lookup(
+        &self,
+        table: &str,
+        column: &str,
+        branch: &str,
+        value: &Value,
+    ) -> Vec<ObjectId> {
+        let tx = self.read_tx();
+        index_lookup_core(table, column, branch, value, |prefix| {
+            Self::scan_prefix_keys(&tx, &self.keyspace, prefix)
+        })
+    }
+
+    fn index_range(
+        &self,
+        table: &str,
+        column: &str,
+        branch: &str,
+        start: Bound<&Value>,
+        end: Bound<&Value>,
+    ) -> Vec<ObjectId> {
+        let tx = self.read_tx();
+        index_range_core(table, column, branch, start, end, |start_key, end_key| {
+            Self::scan_key_range(&tx, &self.keyspace, start_key, end_key)
+        })
+    }
+
+    fn index_scan_all(&self, table: &str, column: &str, branch: &str) -> Vec<ObjectId> {
+        let tx = self.read_tx();
+        index_scan_all_core(table, column, branch, |prefix| {
+            Self::scan_prefix_keys(&tx, &self.keyspace, prefix)
+        })
+    }
+
+    fn flush(&self) {
+        let _ = self.db.persist(PersistMode::SyncData);
+    }
+
+    fn flush_wal(&self) {
+        self.flush();
+    }
+
+    fn close(&self) -> Result<(), StorageError> {
+        self.db
+            .persist(PersistMode::SyncData)
+            .map_err(|e| StorageError::IoError(format!("fjall persist on close: {e}")))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use smallvec::smallvec;
+
+    fn make_commit(content: &[u8]) -> Commit {
+        Commit {
+            parents: smallvec![],
+            content: content.to_vec(),
+            timestamp: 12345,
+            author: ObjectId::new(),
+            metadata: None,
+            stored_state: Default::default(),
+            ack_state: Default::default(),
+        }
+    }
+
+    fn test_storage() -> (tempfile::TempDir, FjallStorage) {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("test.fjall");
+        let storage = FjallStorage::open(&db_path, 8 * 1024 * 1024).unwrap();
+        (temp_dir, storage)
+    }
+
+    #[test]
+    fn fjall_object_roundtrip() {
+        let (_temp_dir, mut storage) = test_storage();
+
+        let id = ObjectId::new();
+        let mut metadata = HashMap::new();
+        metadata.insert(
+            crate::metadata::MetadataKey::Table.to_string(),
+            "users".to_string(),
+        );
+        metadata.insert("app".to_string(), "test".to_string());
+
+        storage.create_object(id, metadata.clone()).unwrap();
+
+        let loaded = storage.load_object_metadata(id).unwrap();
+        assert_eq!(loaded, Some(metadata));
+
+        let other = ObjectId::new();
+        assert_eq!(storage.load_object_metadata(other).unwrap(), None);
+    }
+
+    #[test]
+    fn fjall_commit_roundtrip() {
+        let (_temp_dir, mut storage) = test_storage();
+
+        let id = ObjectId::new();
+        let branch = BranchName::new("main");
+        storage.create_object(id, HashMap::new()).unwrap();
+
+        assert_eq!(storage.load_branch(id, &branch).unwrap(), None);
+
+        let commit = make_commit(b"first");
+        let commit_id = commit.id();
+        storage.append_commit(id, &branch, commit).unwrap();
+
+        let loaded = storage.load_branch(id, &branch).unwrap().unwrap();
+        assert_eq!(loaded.commits.len(), 1);
+        assert!(loaded.tails.contains(&commit_id));
+        assert_eq!(loaded.commits[0].content, b"first");
+
+        let mut commit2 = make_commit(b"second");
+        commit2.parents = smallvec![commit_id];
+        let commit2_id = commit2.id();
+        storage.append_commit(id, &branch, commit2).unwrap();
+
+        let loaded = storage.load_branch(id, &branch).unwrap().unwrap();
+        assert_eq!(loaded.commits.len(), 2);
+        assert!(!loaded.tails.contains(&commit_id));
+        assert!(loaded.tails.contains(&commit2_id));
+
+        storage.delete_commit(id, &branch, commit_id).unwrap();
+        let loaded = storage.load_branch(id, &branch).unwrap().unwrap();
+        assert_eq!(loaded.commits.len(), 1);
+        assert_eq!(loaded.commits[0].content, b"second");
+    }
+
+    #[test]
+    fn fjall_index_ops() {
+        let (_temp_dir, mut storage) = test_storage();
+
+        let row1 = ObjectId::new();
+        let row2 = ObjectId::new();
+        let row3 = ObjectId::new();
+        let row4 = ObjectId::new();
+
+        storage
+            .index_insert("users", "age", "main", &Value::Integer(20), row1)
+            .unwrap();
+        storage
+            .index_insert("users", "age", "main", &Value::Integer(25), row2)
+            .unwrap();
+        storage
+            .index_insert("users", "age", "main", &Value::Integer(25), row3)
+            .unwrap();
+        storage
+            .index_insert("users", "age", "main", &Value::Integer(30), row4)
+            .unwrap();
+
+        let results = storage.index_lookup("users", "age", "main", &Value::Integer(25));
+        assert_eq!(results.len(), 2);
+        assert!(results.contains(&row2));
+        assert!(results.contains(&row3));
+
+        let results = storage.index_range(
+            "users",
+            "age",
+            "main",
+            Bound::Included(&Value::Integer(25)),
+            Bound::Excluded(&Value::Integer(30)),
+        );
+        assert_eq!(results.len(), 2);
+        assert!(results.contains(&row2));
+        assert!(results.contains(&row3));
+
+        let results = storage.index_range(
+            "users",
+            "age",
+            "main",
+            Bound::Unbounded,
+            Bound::Excluded(&Value::Integer(26)),
+        );
+        assert_eq!(results.len(), 3);
+        assert!(results.contains(&row1));
+        assert!(results.contains(&row2));
+        assert!(results.contains(&row3));
+
+        let results = storage.index_range(
+            "users",
+            "age",
+            "main",
+            Bound::Included(&Value::Integer(30)),
+            Bound::Unbounded,
+        );
+        assert_eq!(results.len(), 1);
+        assert!(results.contains(&row4));
+
+        let results = storage.index_scan_all("users", "age", "main");
+        assert_eq!(results.len(), 4);
+
+        storage
+            .index_remove("users", "age", "main", &Value::Integer(25), row2)
+            .unwrap();
+        let results = storage.index_lookup("users", "age", "main", &Value::Integer(25));
+        assert_eq!(results.len(), 1);
+        assert!(results.contains(&row3));
+    }
+
+    #[test]
+    fn fjall_persistence() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("persist.fjall");
+
+        let id = ObjectId::new();
+        let mut metadata = HashMap::new();
+        metadata.insert(
+            crate::metadata::MetadataKey::Table.to_string(),
+            "users".to_string(),
+        );
+
+        let commit_content = b"persistent data";
+        let branch = BranchName::new("main");
+
+        {
+            let mut storage = FjallStorage::open(&db_path, 8 * 1024 * 1024).unwrap();
+            storage.create_object(id, metadata.clone()).unwrap();
+
+            let commit = make_commit(commit_content);
+            storage.append_commit(id, &branch, commit).unwrap();
+
+            storage
+                .index_insert(
+                    "users",
+                    "name",
+                    "main",
+                    &Value::Text("Alice".to_string()),
+                    id,
+                )
+                .unwrap();
+            storage.flush();
+        }
+
+        {
+            let storage = FjallStorage::open(&db_path, 8 * 1024 * 1024).unwrap();
+
+            let loaded_meta = storage.load_object_metadata(id).unwrap();
+            assert_eq!(loaded_meta, Some(metadata));
+
+            let loaded_branch = storage.load_branch(id, &branch).unwrap().unwrap();
+            assert_eq!(loaded_branch.commits.len(), 1);
+            assert_eq!(loaded_branch.commits[0].content, commit_content);
+
+            let results =
+                storage.index_lookup("users", "name", "main", &Value::Text("Alice".to_string()));
+            assert_eq!(results.len(), 1);
+            assert!(results.contains(&id));
+        }
+    }
+
+    #[test]
+    fn fjall_catalogue_manifest_roundtrip() {
+        let (_temp_dir, mut storage) = test_storage();
+        let app_id = ObjectId::new();
+        let schema_object_id = ObjectId::new();
+        let lens_object_id = ObjectId::new();
+        let schema_hash = crate::query_manager::types::SchemaHash::from_bytes([0x11; 32]);
+        let source_hash = crate::query_manager::types::SchemaHash::from_bytes([0x22; 32]);
+        let target_hash = crate::query_manager::types::SchemaHash::from_bytes([0x33; 32]);
+
+        storage
+            .append_catalogue_manifest_op(
+                app_id,
+                crate::storage::CatalogueManifestOp::SchemaSeen {
+                    object_id: schema_object_id,
+                    schema_hash,
+                },
+            )
+            .unwrap();
+        storage
+            .append_catalogue_manifest_op(
+                app_id,
+                crate::storage::CatalogueManifestOp::LensSeen {
+                    object_id: lens_object_id,
+                    source_hash,
+                    target_hash,
+                },
+            )
+            .unwrap();
+        storage
+            .append_catalogue_manifest_op(
+                app_id,
+                crate::storage::CatalogueManifestOp::SchemaSeen {
+                    object_id: schema_object_id,
+                    schema_hash,
+                },
+            )
+            .unwrap();
+
+        let manifest = storage.load_catalogue_manifest(app_id).unwrap().unwrap();
+        assert_eq!(
+            manifest.schema_seen.get(&schema_object_id),
+            Some(&schema_hash)
+        );
+        assert_eq!(
+            manifest.lens_seen.get(&lens_object_id),
+            Some(&crate::storage::CatalogueLensSeen {
+                source_hash,
+                target_hash,
+            })
+        );
+    }
+}

--- a/crates/jazz-tools/src/storage/mod.rs
+++ b/crates/jazz-tools/src/storage/mod.rs
@@ -13,6 +13,10 @@ mod key_codec;
 mod opfs_btree;
 mod storage_core;
 pub use opfs_btree::OpfsBTreeStorage;
+#[cfg(all(feature = "fjall", not(target_arch = "wasm32")))]
+mod fjall;
+#[cfg(all(feature = "fjall", not(target_arch = "wasm32")))]
+pub use fjall::FjallStorage;
 #[cfg(all(feature = "surrealkv", not(target_arch = "wasm32")))]
 mod surrealkv;
 #[cfg(all(feature = "surrealkv", not(target_arch = "wasm32")))]


### PR DESCRIPTION
## Summary
- add a native-only `FjallStorage` backend behind a new `fjall` feature in `jazz-tools`
- add a focused `storage_backend_probe` example to compare the first task insert and task-status update paths across backends
- keep `JazzClient` and the main runtime wiring on SurrealKV for now so the spike stays small

## Validation
- `cargo test -p jazz-tools --features fjall --lib fjall_`
- `cargo run --release -p jazz-tools --features "fjall surrealkv" --example storage_backend_probe -- --backend fjall --operation seed_first_task_create`
- `cargo run --release -p jazz-tools --features "fjall surrealkv" --example storage_backend_probe -- --backend fjall --operation update_task_status`
- `gtimeout 20s cargo run --release -p jazz-tools --features "fjall surrealkv" --example storage_backend_probe -- --backend surrealkv --operation seed_first_task_create`
- `gtimeout 20s cargo run --release -p jazz-tools --features "fjall surrealkv" --example storage_backend_probe -- --backend surrealkv --operation update_task_status`

## Probe Results
- Fjall `seed_first_task_create`: `4.69ms`
- Fjall `update_task_status`: `8.27ms`
- SurrealKV `seed_first_task_create`: `33.48ms`
- SurrealKV `update_task_status`: `32.78ms`

## Notes
- this lower-level probe does not reproduce the hard SurrealKV hang we saw in the deeper diagnostic branch, so that still needs a higher-fidelity repro if we want to compare the exact failure mode
- the spike is intentionally native-only for now; browser/OPFS storage is unchanged