### PR TITLE
Introspection for active queries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1852,6 +1852,7 @@ dependencies = [
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
+ "tower",
  "tower-http 0.5.2",
  "tracing",
  "tracing-opentelemetry",

--- a/crates/jazz-tools/Cargo.toml
+++ b/crates/jazz-tools/Cargo.toml
@@ -107,6 +107,7 @@ serde_json = "1"
 serde = { version = "1", features = ["derive"] }
 futures = "0.3"
 tokio = { version = "1", features = ["test-util", "full"] }
+tower = { version = "0.5", features = ["util"] }
 
 [[bench]]
 name = "realistic_phase1"

--- a/crates/jazz-tools/src/query_manager/manager.rs
+++ b/crates/jazz-tools/src/query_manager/manager.rs
@@ -1,6 +1,9 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+
 use crate::commit::CommitId;
 use crate::metadata::{MetadataKey, ObjectType};
 use crate::object::{BranchName, ObjectId};
@@ -201,6 +204,17 @@ pub enum LocalUpdates {
     Deferred,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ServerSubscriptionTelemetryGroup {
+    #[serde(rename = "groupKey")]
+    pub group_key: String,
+    pub count: usize,
+    pub table: String,
+    pub query: String,
+    pub branches: Vec<String>,
+    pub propagation: QueryPropagation,
+}
+
 /// Update for a query subscription.
 #[derive(Debug, Clone)]
 pub struct QueryUpdate {
@@ -321,6 +335,31 @@ pub struct QueryManager {
 }
 
 impl QueryManager {
+    pub fn server_subscription_telemetry(&self) -> Vec<ServerSubscriptionTelemetryGroup> {
+        let mut groups: HashMap<String, ServerSubscriptionTelemetryGroup> = HashMap::new();
+
+        for subscription in self.server_subscriptions.values() {
+            let query = serde_json::to_string(&subscription.query)
+                .unwrap_or_else(|_| "{\"error\":\"query serialization failed\"}".to_string());
+            let propagation = propagation_label(subscription.propagation);
+            let group_key = subscription_group_key(&query, &subscription.branches, propagation);
+
+            groups
+                .entry(group_key.clone())
+                .and_modify(|group| group.count += 1)
+                .or_insert_with(|| ServerSubscriptionTelemetryGroup {
+                    group_key,
+                    count: 1,
+                    table: subscription.query.table.as_str().to_string(),
+                    query,
+                    branches: subscription.branches.clone(),
+                    propagation: subscription.propagation,
+                });
+        }
+
+        groups.into_values().collect()
+    }
+
     /// Create a new QueryManager with empty schema context.
     ///
     /// Call `set_current_schema()` to initialize the current schema before queries.
@@ -1318,4 +1357,24 @@ impl QueryManager {
         let total = indices + subscriptions + policy_checks;
         (indices, subscriptions, policy_checks, total)
     }
+}
+
+fn propagation_label(propagation: QueryPropagation) -> &'static str {
+    match propagation {
+        QueryPropagation::Full => "full",
+        QueryPropagation::LocalOnly => "local-only",
+    }
+}
+
+fn subscription_group_key(query: &str, branches: &[String], propagation: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(query.as_bytes());
+    hasher.update([0]);
+    hasher.update(propagation.as_bytes());
+    hasher.update([0]);
+    for branch in branches {
+        hasher.update(branch.as_bytes());
+        hasher.update([0]);
+    }
+    hex::encode(hasher.finalize())
 }

--- a/crates/jazz-tools/src/query_manager/manager_tests.rs
+++ b/crates/jazz-tools/src/query_manager/manager_tests.rs
@@ -7393,6 +7393,101 @@ fn server_pushes_new_matches() {
 }
 
 #[test]
+fn server_subscription_telemetry_tracks_grouping_and_unsubscribe_lifecycle() {
+    use crate::sync_manager::{
+        ClientId, InboxEntry, QueryId, QueryPropagation, Source, SyncPayload,
+    };
+
+    let sync_manager = SyncManager::new();
+    let schema = test_schema();
+    let (mut server_qm, mut storage) = create_query_manager(sync_manager, schema);
+
+    let repeated_query = server_qm.query("users").build();
+    let repeated_query_json = serde_json::to_string(&repeated_query).unwrap();
+    let filtered_query = server_qm
+        .query("users")
+        .filter_eq("name", Value::Text("Alice".into()))
+        .build();
+
+    let client_a = ClientId::new();
+    let client_b = ClientId::new();
+    let client_c = ClientId::new();
+    for client_id in [client_a, client_b, client_c] {
+        server_qm.sync_manager_mut().add_client(client_id);
+    }
+
+    for (client_id, query_id, query, propagation) in [
+        (
+            client_a,
+            QueryId(1),
+            repeated_query.clone(),
+            QueryPropagation::Full,
+        ),
+        (
+            client_b,
+            QueryId(2),
+            repeated_query.clone(),
+            QueryPropagation::Full,
+        ),
+        (
+            client_c,
+            QueryId(3),
+            repeated_query.clone(),
+            QueryPropagation::LocalOnly,
+        ),
+        (
+            client_c,
+            QueryId(4),
+            filtered_query.clone(),
+            QueryPropagation::Full,
+        ),
+    ] {
+        server_qm.sync_manager_mut().push_inbox(InboxEntry {
+            source: Source::Client(client_id),
+            payload: SyncPayload::QuerySubscription {
+                query_id,
+                query: Box::new(query),
+                session: None,
+                propagation,
+            },
+        });
+    }
+
+    server_qm.process(&mut storage);
+
+    let telemetry = server_qm.server_subscription_telemetry();
+    assert_eq!(telemetry.len(), 3);
+    assert!(telemetry.iter().any(|group| {
+        group.count == 2 && group.propagation == QueryPropagation::Full && group.table == "users"
+    }));
+    assert!(
+        telemetry
+            .iter()
+            .any(|group| { group.count == 1 && group.propagation == QueryPropagation::LocalOnly })
+    );
+    assert!(
+        telemetry
+            .iter()
+            .any(|group| { group.count == 1 && group.query.contains("\"name\"") })
+    );
+
+    server_qm.sync_manager_mut().push_inbox(InboxEntry {
+        source: Source::Client(client_b),
+        payload: SyncPayload::QueryUnsubscription {
+            query_id: QueryId(2),
+        },
+    });
+    server_qm.process(&mut storage);
+
+    let telemetry_after_unsubscribe = server_qm.server_subscription_telemetry();
+    assert!(telemetry_after_unsubscribe.iter().any(|group| {
+        group.count == 1
+            && group.propagation == QueryPropagation::Full
+            && group.query == repeated_query_json
+    }));
+}
+
+#[test]
 fn server_does_not_push_non_matching() {
     use crate::sync_manager::{ClientId, Destination, InboxEntry, QueryId, Source, SyncPayload};
     use uuid::Uuid;

--- a/crates/jazz-tools/src/routes.rs
+++ b/crates/jazz-tools/src/routes.rs
@@ -1,7 +1,7 @@
 //! HTTP routes for the Jazz server.
 
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use axum::{
     Router,
@@ -25,6 +25,7 @@ use crate::middleware::auth::{
     validate_backend_secret, validate_jwt_identity,
 };
 use jazz_tools::query_manager::types::SchemaHash;
+use jazz_tools::schema_manager::AppId;
 
 /// Create the router with all routes.
 pub fn create_router(state: Arc<ServerState>) -> Router {
@@ -32,6 +33,10 @@ pub fn create_router(state: Arc<ServerState>) -> Router {
         .route("/sync", post(sync_handler))
         .route("/schema/:hash", get(schema_handler))
         .route("/schemas", get(schema_hashes_handler))
+        .route(
+            "/admin/introspection/subscriptions",
+            get(admin_subscription_introspection_handler),
+        )
         // Link a local anonymous/demo principal to an external identity.
         .route("/auth/link-external", post(link_external_handler))
         // Health check
@@ -55,6 +60,20 @@ struct EventsParams {
 #[derive(Debug, Serialize)]
 struct SchemaHashesResponse {
     hashes: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AdminSubscriptionIntrospectionParams {
+    #[serde(rename = "appId")]
+    app_id: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct AdminSubscriptionIntrospectionResponse {
+    app_id: String,
+    generated_at: u64,
+    queries: Vec<jazz_tools::query_manager::manager::ServerSubscriptionTelemetryGroup>,
 }
 
 #[derive(Debug, Serialize)]
@@ -470,6 +489,71 @@ async fn schema_hashes_handler(
     }
 }
 
+async fn admin_subscription_introspection_handler(
+    State(state): State<Arc<ServerState>>,
+    headers: HeaderMap,
+    Query(params): Query<AdminSubscriptionIntrospectionParams>,
+) -> impl IntoResponse {
+    let admin_secret = headers
+        .get("X-Jazz-Admin-Secret")
+        .and_then(|v| v.to_str().ok());
+
+    match validate_admin_secret(admin_secret, &state.auth_config) {
+        Ok(()) => {}
+        Err((status, msg)) => {
+            return (status, Json(ErrorResponse::unauthorized(msg))).into_response();
+        }
+    }
+
+    let Some(app_id_text) = params.app_id.as_deref() else {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse::bad_request(
+                "appId query parameter is required",
+            )),
+        )
+            .into_response();
+    };
+
+    let requested_app_id = match parse_app_id_param(app_id_text) {
+        Ok(app_id) => app_id,
+        Err(message) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse::bad_request(message)),
+            )
+                .into_response();
+        }
+    };
+
+    if requested_app_id != state.app_id {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse::not_found(format!(
+                "app not found: {}",
+                app_id_text.trim()
+            ))),
+        )
+            .into_response();
+    }
+
+    match state.runtime.server_subscription_telemetry() {
+        Ok(queries) => Json(AdminSubscriptionIntrospectionResponse {
+            app_id: state.app_id.to_string(),
+            generated_at: unix_timestamp_millis(),
+            queries,
+        })
+        .into_response(),
+        Err(err) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse::internal(format!(
+                "failed to read subscription telemetry: {err}"
+            ))),
+        )
+            .into_response(),
+    }
+}
+
 fn parse_schema_hash_param(hash_text: &str) -> Result<SchemaHash, String> {
     let decoded_hash_bytes = hex::decode(hash_text)
         .map_err(|_| "invalid schema hash: expected hex string".to_string())?;
@@ -480,6 +564,34 @@ fn parse_schema_hash_param(hash_text: &str) -> Result<SchemaHash, String> {
     let mut hash_bytes = [0u8; 32];
     hash_bytes.copy_from_slice(&decoded_hash_bytes);
     Ok(SchemaHash::from_bytes(hash_bytes))
+}
+
+fn parse_app_id_param(app_id_text: &str) -> Result<AppId, String> {
+    let trimmed = app_id_text.trim();
+    if trimmed.is_empty() {
+        return Err("invalid appId: expected UUID or app identifier".to_string());
+    }
+
+    if let Ok(app_id) = AppId::from_string(trimmed) {
+        return Ok(app_id);
+    }
+
+    if trimmed
+        .chars()
+        .all(|char| char.is_ascii_alphanumeric() || matches!(char, '-' | '_' | '.'))
+    {
+        return Ok(AppId::from_name(trimmed));
+    }
+
+    Err("invalid appId: expected UUID or app identifier".to_string())
+}
+
+fn unix_timestamp_millis() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+        .min(u128::from(u64::MAX)) as u64
 }
 
 async fn link_external_handler(
@@ -683,11 +795,17 @@ mod tests {
 
     use axum::body;
     use axum::routing::get;
-    use groove::query_manager::types::{ColumnType, SchemaBuilder, TableSchema};
-    use groove::runtime_tokio::TokioRuntime;
-    use groove::schema_manager::{AppId, SchemaManager};
-    use groove::storage::SurrealKvStorage;
-    use groove::sync_manager::{ClientId, DurabilityTier, SyncManager, SyncPayload};
+    use jazz_tools::query_manager::query::QueryBuilder;
+    use jazz_tools::query_manager::types::{
+        ColumnType, SchemaBuilder, TableSchema, Value as QueryValue,
+    };
+    use jazz_tools::runtime_tokio::TokioRuntime;
+    use jazz_tools::schema_manager::{AppId, SchemaManager};
+    use jazz_tools::storage::SurrealKvStorage;
+    use jazz_tools::sync_manager::{
+        ClientId, DurabilityTier, InboxEntry, QueryId, QueryPropagation, Source, SyncManager,
+        SyncPayload,
+    };
     use serde_json::Value;
     use tempfile::TempDir;
     use tokio::sync::{RwLock, broadcast};
@@ -695,6 +813,66 @@ mod tests {
 
     use crate::commands::server::{ExternalIdentityStore, ServerState};
     use crate::middleware::AuthConfig;
+
+    fn test_auth_config() -> AuthConfig {
+        AuthConfig {
+            backend_secret: None,
+            admin_secret: Some("admin-secret".to_string()),
+            allow_anonymous: true,
+            allow_demo: true,
+            jwks_url: None,
+            jwks_set: None,
+        }
+    }
+
+    fn make_state_with_schema(
+        schema: jazz_tools::query_manager::types::Schema,
+    ) -> (TempDir, Arc<ServerState>) {
+        let data_dir = TempDir::new().expect("temp dir");
+        let db_path = data_dir.path().join("groove.surrealkv");
+        let storage =
+            SurrealKvStorage::open(&db_path, 64 * 1024 * 1024).expect("open test storage");
+
+        let sync_manager = SyncManager::new()
+            .with_durability_tiers([DurabilityTier::EdgeServer, DurabilityTier::GlobalServer]);
+        let schema_manager = SchemaManager::new(
+            sync_manager,
+            schema,
+            AppId::from_name("test-app"),
+            "prod",
+            "main",
+        )
+        .expect("schema manager");
+        let runtime = TokioRuntime::new(schema_manager, storage, |_entry| {});
+
+        let (sync_tx, _) = broadcast::channel::<(ClientId, SyncPayload)>(16);
+
+        let state = Arc::new(ServerState {
+            runtime,
+            app_id: AppId::from_name("test-app"),
+            connections: RwLock::new(HashMap::new()),
+            next_connection_id: std::sync::atomic::AtomicU64::new(1),
+            sync_broadcast: sync_tx,
+            auth_config: test_auth_config(),
+            external_identity_store: Arc::new(
+                ExternalIdentityStore::new(data_dir.path().to_str().unwrap()).unwrap(),
+            ),
+            external_identities: RwLock::new(HashMap::new()),
+        });
+
+        (data_dir, state)
+    }
+
+    fn make_test_router(state: Arc<ServerState>) -> axum::Router {
+        axum::Router::new()
+            .route("/schema/:hash", get(schema_handler))
+            .route("/schemas", get(schema_hashes_handler))
+            .route(
+                "/admin/introspection/subscriptions",
+                get(admin_subscription_introspection_handler),
+            )
+            .with_state(state)
+    }
 
     #[tokio::test]
     async fn schema_handler_requires_admin_secret() {
@@ -780,11 +958,6 @@ mod tests {
 
     #[tokio::test]
     async fn schema_handlers_return_hashes_and_requested_schema() {
-        let data_dir = TempDir::new().expect("temp dir");
-        let db_path = data_dir.path().join("groove.surrealkv");
-        let storage =
-            SurrealKvStorage::open(&db_path, 64 * 1024 * 1024).expect("open test storage");
-
         let schema = SchemaBuilder::new()
             .table(
                 TableSchema::builder("users")
@@ -793,46 +966,9 @@ mod tests {
             )
             .build();
         let schema_hash = SchemaHash::compute(&schema);
-        let sync_manager = SyncManager::new()
-            .with_durability_tiers([DurabilityTier::EdgeServer, DurabilityTier::GlobalServer]);
-        let schema_manager = SchemaManager::new(
-            sync_manager,
-            schema,
-            AppId::from_name("test-app"),
-            "prod",
-            "main",
-        )
-        .expect("schema manager");
-        let runtime = TokioRuntime::new(schema_manager, storage, |_entry| {});
+        let (_data_dir, state) = make_state_with_schema(schema);
 
-        let auth_config = AuthConfig {
-            backend_secret: None,
-            admin_secret: Some("admin-secret".to_string()),
-            allow_anonymous: true,
-            allow_demo: true,
-            jwks_url: None,
-            jwks_set: None,
-        };
-
-        let (sync_tx, _) = broadcast::channel::<(ClientId, SyncPayload)>(16);
-
-        let state = Arc::new(ServerState {
-            runtime,
-            app_id: AppId::from_name("test-app"),
-            connections: RwLock::new(HashMap::new()),
-            next_connection_id: std::sync::atomic::AtomicU64::new(1),
-            sync_broadcast: sync_tx,
-            auth_config,
-            external_identity_store: Arc::new(
-                ExternalIdentityStore::new(data_dir.path().to_str().unwrap()).unwrap(),
-            ),
-            external_identities: RwLock::new(HashMap::new()),
-        });
-
-        let app = axum::Router::new()
-            .route("/schema/:hash", get(schema_handler))
-            .route("/schemas", get(schema_hashes_handler))
-            .with_state(state);
+        let app = make_test_router(state);
 
         let hashes_response = app
             .clone()
@@ -880,5 +1016,170 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(bad_hash_response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn admin_subscription_introspection_requires_admin_secret_and_valid_app_id() {
+        let schema = SchemaBuilder::new()
+            .table(
+                TableSchema::builder("users")
+                    .column("id", ColumnType::Uuid)
+                    .column("name", ColumnType::Text),
+            )
+            .build();
+        let (_data_dir, state) = make_state_with_schema(schema);
+        let app = make_test_router(state.clone());
+
+        let without_secret = app
+            .clone()
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri("/admin/introspection/subscriptions?appId=test-app")
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(without_secret.status(), StatusCode::UNAUTHORIZED);
+
+        let wrong_secret = app
+            .clone()
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri("/admin/introspection/subscriptions?appId=test-app")
+                    .header("X-Jazz-Admin-Secret", "wrong-secret")
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(wrong_secret.status(), StatusCode::UNAUTHORIZED);
+
+        let missing_app_id = app
+            .clone()
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri("/admin/introspection/subscriptions")
+                    .header("X-Jazz-Admin-Secret", "admin-secret")
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(missing_app_id.status(), StatusCode::BAD_REQUEST);
+
+        let invalid_app_id = app
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri("/admin/introspection/subscriptions?appId=bad/id")
+                    .header("X-Jazz-Admin-Secret", "admin-secret")
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(invalid_app_id.status(), StatusCode::BAD_REQUEST);
+
+        let mismatched_app_id = make_test_router(state)
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri("/admin/introspection/subscriptions?appId=other-app")
+                    .header("X-Jazz-Admin-Secret", "admin-secret")
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(mismatched_app_id.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn admin_subscription_introspection_groups_active_server_subscriptions() {
+        let schema = SchemaBuilder::new()
+            .table(
+                TableSchema::builder("users")
+                    .column("id", ColumnType::Uuid)
+                    .column("name", ColumnType::Text),
+            )
+            .build();
+        let (_data_dir, state) = make_state_with_schema(schema);
+
+        let repeated_query = QueryBuilder::new("users").build();
+        let filtered_query = QueryBuilder::new("users")
+            .filter_eq("name", QueryValue::Text("Alice".to_string()))
+            .build();
+
+        for (index, query, propagation) in [
+            (1_u64, repeated_query.clone(), QueryPropagation::Full),
+            (2_u64, repeated_query.clone(), QueryPropagation::Full),
+            (3_u64, repeated_query.clone(), QueryPropagation::LocalOnly),
+            (4_u64, filtered_query, QueryPropagation::Full),
+        ] {
+            let client_id = ClientId::new();
+            state.runtime.add_client(client_id, None).unwrap();
+            state
+                .runtime
+                .push_sync_inbox(InboxEntry {
+                    source: Source::Client(client_id),
+                    payload: SyncPayload::QuerySubscription {
+                        query_id: QueryId(index),
+                        query: Box::new(query),
+                        session: None,
+                        propagation,
+                    },
+                })
+                .unwrap();
+        }
+        state.runtime.flush().await.unwrap();
+
+        let response = make_test_router(state.clone())
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri("/admin/introspection/subscriptions?appId=test-app")
+                    .header("X-Jazz-Admin-Secret", "admin-secret")
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("telemetry body");
+        let json: Value = serde_json::from_slice(&body).expect("telemetry json");
+
+        let expected_app_id = state.app_id.to_string();
+        assert_eq!(json["appId"].as_str(), Some(expected_app_id.as_str()));
+        assert!(json["generatedAt"].as_u64().is_some());
+
+        let groups = json["queries"].as_array().expect("queries array");
+        assert_eq!(groups.len(), 3);
+
+        let repeated_full = groups.iter().find(|group| {
+            group["count"].as_u64() == Some(2) && group["propagation"].as_str() == Some("full")
+        });
+        let repeated_full = repeated_full.expect("expected grouped full subscriptions");
+        assert_eq!(repeated_full["table"].as_str(), Some("users"));
+        assert_eq!(
+            repeated_full["branches"]
+                .as_array()
+                .map(|branches| branches.len())
+                .unwrap_or_default(),
+            1
+        );
+        assert!(repeated_full["groupKey"].as_str().is_some());
+
+        assert!(groups.iter().any(|group| {
+            group["count"].as_u64() == Some(1)
+                && group["propagation"].as_str() == Some("local-only")
+        }));
+        assert!(groups.iter().any(|group| {
+            group["count"].as_u64() == Some(1)
+                && group["query"]
+                    .as_str()
+                    .map(|query| query.contains("\"name\""))
+                    .unwrap_or(false)
+        }));
     }
 }

--- a/crates/jazz-tools/src/runtime_tokio.rs
+++ b/crates/jazz-tools/src/runtime_tokio.rs
@@ -453,6 +453,18 @@ impl<S: Storage + Send + 'static> TokioRuntime<S> {
         Ok(core.schema_manager().get_known_schema(schema_hash).cloned())
     }
 
+    /// Return grouped telemetry for active downstream server subscriptions.
+    pub fn server_subscription_telemetry(
+        &self,
+    ) -> Result<Vec<crate::query_manager::manager::ServerSubscriptionTelemetryGroup>, RuntimeError>
+    {
+        let core = self.core.lock().map_err(|_| RuntimeError::LockError)?;
+        Ok(core
+            .schema_manager()
+            .query_manager()
+            .server_subscription_telemetry())
+    }
+
     /// Access the underlying storage (for flushing, etc).
     ///
     /// The callback receives `&S` while holding the core lock.

--- a/examples/todo-client-localfirst-react/src/App.tsx
+++ b/examples/todo-client-localfirst-react/src/App.tsx
@@ -26,6 +26,7 @@ function defaultConfig(
     appId,
     env: "dev",
     userBranch: "main",
+    devMode: true,
     localAuthMode: active.localAuthMode,
     localAuthToken: active.localAuthToken,
     ...overrides,

--- a/packages/inspector/src/App.tsx
+++ b/packages/inspector/src/App.tsx
@@ -183,7 +183,7 @@ export default function App() {
     );
   }
 
-  if (!client || !wasmSchema) {
+  if (!client || !wasmSchema || !storedConfig) {
     return (
       <main className={styles.statePage}>
         <section className={styles.stateCard}>
@@ -202,6 +202,12 @@ export default function App() {
           selectedSchemaHash={storedConfig?.schemaHash ?? null}
           onSelectSchema={handleHeaderSchemaSelect}
           isSwitchingSchema={isSwitchingSchema}
+          connection={{
+            serverUrl: storedConfig.serverUrl,
+            appId: storedConfig.appId,
+            adminSecret: storedConfig.adminSecret,
+            serverPathPrefix: storedConfig.serverPathPrefix,
+          }}
         >
           <BrowserRouter>
             <InspectorRoutes />

--- a/packages/inspector/src/components/data-explorer/TableDataGrid.test.tsx
+++ b/packages/inspector/src/components/data-explorer/TableDataGrid.test.tsx
@@ -95,7 +95,10 @@ describe("TableDataGrid", () => {
     expect(mockSubscribeAll).toHaveBeenCalledWith(
       expect.any(Object),
       expect.any(Function),
-      expect.objectContaining({ propagation: "local-only" }),
+      expect.objectContaining({
+        propagation: "local-only",
+        visibility: "hidden_from_live_query_list",
+      }),
     );
   });
 });

--- a/packages/inspector/src/components/data-explorer/TableDataGrid.tsx
+++ b/packages/inspector/src/components/data-explorer/TableDataGrid.tsx
@@ -73,7 +73,10 @@ export function TableDataGrid() {
       (delta) => {
         setRows(delta.all);
       },
-      { propagation: queryPropagation },
+      {
+        propagation: queryPropagation,
+        visibility: "hidden_from_live_query_list",
+      },
     );
 
     return () => {

--- a/packages/inspector/src/components/inspector-layout/index.test.tsx
+++ b/packages/inspector/src/components/inspector-layout/index.test.tsx
@@ -4,14 +4,21 @@ import { MemoryRouter } from "react-router";
 import { InspectorLayout } from "./index";
 
 const mockUseStandaloneContext = vi.fn();
+const mockUseDevtoolsContext = vi.fn();
 
 vi.mock("../../contexts/standalone-context.js", () => ({
   useStandaloneContext: () => mockUseStandaloneContext(),
 }));
 
+vi.mock("../../contexts/devtools-context.js", () => ({
+  useDevtoolsContext: () => mockUseDevtoolsContext(),
+}));
+
 describe("InspectorLayout", () => {
   beforeEach(() => {
     mockUseStandaloneContext.mockReset();
+    mockUseDevtoolsContext.mockReset();
+    mockUseDevtoolsContext.mockReturnValue({ runtime: "extension" });
   });
 
   afterEach(() => {
@@ -40,6 +47,7 @@ describe("InspectorLayout", () => {
     expect(screen.getByRole("combobox")).not.toBeNull();
     expect(screen.getByRole("option", { name: "hash-a" })).not.toBeNull();
     expect(screen.getByRole("option", { name: "hash-b" })).not.toBeNull();
+    expect(screen.getByRole("link", { name: "Live Query" })).not.toBeNull();
   });
 
   it("calls schema selection handler when dropdown value changes", () => {
@@ -109,5 +117,18 @@ describe("InspectorLayout", () => {
 
     expect(screen.queryByRole("button", { name: "Reset connection" })).toBeNull();
     expect(screen.queryByRole("combobox")).toBeNull();
+  });
+
+  it("hides the live query tab in standalone mode", () => {
+    mockUseStandaloneContext.mockReturnValue(null);
+    mockUseDevtoolsContext.mockReturnValue({ runtime: "standalone" });
+
+    render(
+      <MemoryRouter initialEntries={["/data-explorer"]}>
+        <InspectorLayout />
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByRole("link", { name: "Live Query" })).toBeNull();
   });
 });

--- a/packages/inspector/src/components/inspector-layout/index.test.tsx
+++ b/packages/inspector/src/components/inspector-layout/index.test.tsx
@@ -118,17 +118,4 @@ describe("InspectorLayout", () => {
     expect(screen.queryByRole("button", { name: "Reset connection" })).toBeNull();
     expect(screen.queryByRole("combobox")).toBeNull();
   });
-
-  it("hides the live query tab in standalone mode", () => {
-    mockUseStandaloneContext.mockReturnValue(null);
-    mockUseDevtoolsContext.mockReturnValue({ runtime: "standalone" });
-
-    render(
-      <MemoryRouter initialEntries={["/data-explorer"]}>
-        <InspectorLayout />
-      </MemoryRouter>,
-    );
-
-    expect(screen.queryByRole("link", { name: "Live Query" })).toBeNull();
-  });
 });

--- a/packages/inspector/src/components/inspector-layout/index.tsx
+++ b/packages/inspector/src/components/inspector-layout/index.tsx
@@ -1,9 +1,11 @@
 import { NavLink, Outlet } from "react-router";
 import { useStandaloneContext } from "../../contexts/standalone-context.js";
+import { useDevtoolsContext } from "../../contexts/devtools-context.js";
 import styles from "./index.module.css";
 
 export function InspectorLayout() {
   const standaloneContext = useStandaloneContext();
+  const { runtime } = useDevtoolsContext();
 
   return (
     <main className={styles.root}>
@@ -17,14 +19,16 @@ export function InspectorLayout() {
           >
             Data Explorer
           </NavLink>
-          <NavLink
-            to="/live-query"
-            className={({ isActive }) =>
-              `${styles.tabLink} ${isActive ? styles.tabLinkActive : ""}`
-            }
-          >
-            Live Query
-          </NavLink>
+          {runtime === "extension" ? (
+            <NavLink
+              to="/live-query"
+              className={({ isActive }) =>
+                `${styles.tabLink} ${isActive ? styles.tabLinkActive : ""}`
+              }
+            >
+              Live Query
+            </NavLink>
+          ) : null}
         </nav>
         {standaloneContext ? (
           <div className={styles.topBarActions}>

--- a/packages/inspector/src/components/inspector-layout/index.tsx
+++ b/packages/inspector/src/components/inspector-layout/index.tsx
@@ -1,11 +1,9 @@
 import { NavLink, Outlet } from "react-router";
 import { useStandaloneContext } from "../../contexts/standalone-context.js";
-import { useDevtoolsContext } from "../../contexts/devtools-context.js";
 import styles from "./index.module.css";
 
 export function InspectorLayout() {
   const standaloneContext = useStandaloneContext();
-  const { runtime } = useDevtoolsContext();
 
   return (
     <main className={styles.root}>
@@ -19,16 +17,14 @@ export function InspectorLayout() {
           >
             Data Explorer
           </NavLink>
-          {runtime === "extension" ? (
-            <NavLink
-              to="/live-query"
-              className={({ isActive }) =>
-                `${styles.tabLink} ${isActive ? styles.tabLinkActive : ""}`
-              }
-            >
-              Live Query
-            </NavLink>
-          ) : null}
+          <NavLink
+            to="/live-query"
+            className={({ isActive }) =>
+              `${styles.tabLink} ${isActive ? styles.tabLinkActive : ""}`
+            }
+          >
+            Live Query
+          </NavLink>
         </nav>
         {standaloneContext ? (
           <div className={styles.topBarActions}>

--- a/packages/inspector/src/contexts/standalone-context.tsx
+++ b/packages/inspector/src/contexts/standalone-context.tsx
@@ -1,11 +1,19 @@
 import { createContext, useContext, type PropsWithChildren } from "react";
 
+export interface StandaloneConnectionConfig {
+  serverUrl: string;
+  appId: string;
+  adminSecret: string;
+  serverPathPrefix?: string;
+}
+
 interface StandaloneContextValue {
   onReset: () => void;
   schemaHashes: string[];
   selectedSchemaHash: string | null;
   onSelectSchema: (schemaHash: string) => void;
   isSwitchingSchema: boolean;
+  connection: StandaloneConnectionConfig;
 }
 
 const StandaloneContext = createContext<StandaloneContextValue | null>(null);
@@ -17,10 +25,18 @@ export function StandaloneProvider({
   selectedSchemaHash,
   onSelectSchema,
   isSwitchingSchema,
+  connection,
 }: PropsWithChildren<StandaloneContextValue>) {
   return (
     <StandaloneContext.Provider
-      value={{ onReset, schemaHashes, selectedSchemaHash, onSelectSchema, isSwitchingSchema }}
+      value={{
+        onReset,
+        schemaHashes,
+        selectedSchemaHash,
+        onSelectSchema,
+        isSwitchingSchema,
+        connection,
+      }}
     >
       {children}
     </StandaloneContext.Provider>

--- a/packages/inspector/src/pages/live-query/LiveQueryFilters.test.tsx
+++ b/packages/inspector/src/pages/live-query/LiveQueryFilters.test.tsx
@@ -1,0 +1,54 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { LiveQueryFilters } from "./LiveQueryFilters";
+
+describe("LiveQueryFilters", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders schema-driven table options and tier options", () => {
+    render(
+      <LiveQueryFilters
+        availableTables={["projects", "todos"]}
+        selectedTable=""
+        selectedTier=""
+        onTableChange={vi.fn()}
+        onTierChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("option", { name: "All tables" })).not.toBeNull();
+    expect(screen.getByRole("option", { name: "projects" })).not.toBeNull();
+    expect(screen.getByRole("option", { name: "todos" })).not.toBeNull();
+    expect(screen.getByRole("option", { name: "All tiers" })).not.toBeNull();
+    expect(screen.getByRole("option", { name: "worker" })).not.toBeNull();
+    expect(screen.getByRole("option", { name: "edge" })).not.toBeNull();
+    expect(screen.getByRole("option", { name: "global" })).not.toBeNull();
+  });
+
+  it("calls change handlers when filters change", () => {
+    const onTableChange = vi.fn();
+    const onTierChange = vi.fn();
+
+    render(
+      <LiveQueryFilters
+        availableTables={["todos"]}
+        selectedTable=""
+        selectedTier=""
+        onTableChange={onTableChange}
+        onTierChange={onTierChange}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Filter by table"), {
+      target: { value: "todos" },
+    });
+    fireEvent.change(screen.getByLabelText("Filter by tier"), {
+      target: { value: "edge" },
+    });
+
+    expect(onTableChange).toHaveBeenCalledWith("todos");
+    expect(onTierChange).toHaveBeenCalledWith("edge");
+  });
+});

--- a/packages/inspector/src/pages/live-query/LiveQueryFilters.tsx
+++ b/packages/inspector/src/pages/live-query/LiveQueryFilters.tsx
@@ -6,6 +6,7 @@ interface LiveQueryFiltersProps {
   selectedTier: string;
   onTableChange: (value: string) => void;
   onTierChange: (value: string) => void;
+  showTierFilter?: boolean;
 }
 
 const TIER_OPTIONS = [
@@ -21,6 +22,7 @@ export function LiveQueryFilters({
   selectedTier,
   onTableChange,
   onTierChange,
+  showTierFilter = true,
 }: LiveQueryFiltersProps) {
   return (
     <form className={styles.filters} onSubmit={(event) => event.preventDefault()}>
@@ -40,21 +42,23 @@ export function LiveQueryFilters({
           ))}
         </select>
       </label>
-      <label className={styles.filterField}>
-        Tier
-        <select
-          aria-label="Filter by tier"
-          className={styles.filterSelect}
-          value={selectedTier}
-          onChange={(event) => onTierChange(event.target.value)}
-        >
-          {TIER_OPTIONS.map((tier) => (
-            <option key={tier.value || "all"} value={tier.value}>
-              {tier.label}
-            </option>
-          ))}
-        </select>
-      </label>
+      {showTierFilter ? (
+        <label className={styles.filterField}>
+          Tier
+          <select
+            aria-label="Filter by tier"
+            className={styles.filterSelect}
+            value={selectedTier}
+            onChange={(event) => onTierChange(event.target.value)}
+          >
+            {TIER_OPTIONS.map((tier) => (
+              <option key={tier.value || "all"} value={tier.value}>
+                {tier.label}
+              </option>
+            ))}
+          </select>
+        </label>
+      ) : null}
     </form>
   );
 }

--- a/packages/inspector/src/pages/live-query/LiveQueryFilters.tsx
+++ b/packages/inspector/src/pages/live-query/LiveQueryFilters.tsx
@@ -1,0 +1,60 @@
+import styles from "./index.module.css";
+
+interface LiveQueryFiltersProps {
+  availableTables: string[];
+  selectedTable: string;
+  selectedTier: string;
+  onTableChange: (value: string) => void;
+  onTierChange: (value: string) => void;
+}
+
+const TIER_OPTIONS = [
+  { value: "", label: "All tiers" },
+  { value: "worker", label: "worker" },
+  { value: "edge", label: "edge" },
+  { value: "global", label: "global" },
+] as const;
+
+export function LiveQueryFilters({
+  availableTables,
+  selectedTable,
+  selectedTier,
+  onTableChange,
+  onTierChange,
+}: LiveQueryFiltersProps) {
+  return (
+    <form className={styles.filters} onSubmit={(event) => event.preventDefault()}>
+      <label className={styles.filterField}>
+        Table
+        <select
+          aria-label="Filter by table"
+          className={styles.filterSelect}
+          value={selectedTable}
+          onChange={(event) => onTableChange(event.target.value)}
+        >
+          <option value="">All tables</option>
+          {availableTables.map((table) => (
+            <option key={table} value={table}>
+              {table}
+            </option>
+          ))}
+        </select>
+      </label>
+      <label className={styles.filterField}>
+        Tier
+        <select
+          aria-label="Filter by tier"
+          className={styles.filterSelect}
+          value={selectedTier}
+          onChange={(event) => onTierChange(event.target.value)}
+        >
+          {TIER_OPTIONS.map((tier) => (
+            <option key={tier.value || "all"} value={tier.value}>
+              {tier.label}
+            </option>
+          ))}
+        </select>
+      </label>
+    </form>
+  );
+}

--- a/packages/inspector/src/pages/live-query/index.module.css
+++ b/packages/inspector/src/pages/live-query/index.module.css
@@ -1,15 +1,23 @@
 .container {
   height: 100%;
-  border: 1px solid #2a3341;
-  border-radius: 8px;
-  background: #151a24;
+  border: 1px solid #273344;
+  border-radius: 10px;
+  background:
+    radial-gradient(circle at top right, rgba(76, 99, 143, 0.2), transparent 28%),
+    linear-gradient(180deg, #141b25 0%, #0f141c 100%);
   padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  overflow: hidden;
 }
 
 .header {
   display: flex;
-  flex-direction: column;
-  gap: 8px;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: flex-start;
+  flex-wrap: wrap;
 }
 
 .title {
@@ -22,4 +30,123 @@
   margin: 0;
   color: #95a2b5;
   font-size: 14px;
+}
+
+.emptyState {
+  border: 1px dashed #36465d;
+  border-radius: 8px;
+  padding: 24px;
+  background: rgba(21, 27, 36, 0.8);
+}
+
+.emptyTitle {
+  margin: 0 0 8px;
+  color: #eef3fb;
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.emptyText {
+  margin: 0;
+  color: #9ca8b9;
+  font-size: 14px;
+}
+
+.tableShell {
+  min-height: 0;
+  overflow: auto;
+  border: 1px solid #2c394b;
+  border-radius: 8px;
+  background: rgba(17, 23, 31, 0.84);
+}
+
+.table {
+  width: 100%;
+  min-width: 960px;
+  border-collapse: collapse;
+}
+
+.table th,
+.table td {
+  padding: 12px 14px;
+  border-bottom: 1px solid #253141;
+  text-align: left;
+  vertical-align: top;
+}
+
+.table th {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  background: #18212d;
+  color: #9ca8b9;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.sortableHeader {
+  cursor: pointer;
+}
+
+.sortableHeader:hover {
+  color: #dde6f3;
+}
+
+.table td {
+  color: #dbe1ea;
+  font-size: 13px;
+}
+
+.codeBlock {
+  margin: 0;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  font-size: 12px;
+  line-height: 1.5;
+  color: #b8d2ff;
+}
+
+.stackDetails {
+  min-width: 280px;
+}
+
+.stackSummary {
+  cursor: pointer;
+  color: #ffd48a;
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.stackSummary:hover {
+  color: #ffe2ad;
+}
+
+.stackDetails[open] .stackSummary {
+  margin-bottom: 8px;
+}
+
+.filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.filterField {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  color: #9ca8b9;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.filterSelect {
+  min-width: 160px;
+  border: 1px solid #36465d;
+  background: #202937;
+  color: #d6dde7;
+  border-radius: 6px;
+  padding: 8px 10px;
+  font-size: 13px;
 }

--- a/packages/inspector/src/pages/live-query/index.module.css
+++ b/packages/inspector/src/pages/live-query/index.module.css
@@ -32,6 +32,12 @@
   font-size: 14px;
 }
 
+.statusText {
+  margin: 6px 0 0;
+  color: #7f91a8;
+  font-size: 12px;
+}
+
 .emptyState {
   border: 1px dashed #36465d;
   border-radius: 8px;

--- a/packages/inspector/src/pages/live-query/index.test.tsx
+++ b/packages/inspector/src/pages/live-query/index.test.tsx
@@ -48,6 +48,7 @@ describe("LiveQuery", () => {
         id: "sub-1",
         table: "todos",
         tier: "worker",
+        propagation: "full",
         branches: ["main"],
         createdAt: "2026-03-10T10:00:00.000Z",
         query: '{"table":"todos"}',
@@ -59,6 +60,7 @@ describe("LiveQuery", () => {
     render(<LiveQuery />);
 
     expect(screen.getByRole("cell", { name: "todos" })).not.toBeNull();
+    expect(screen.getByRole("cell", { name: "full" })).not.toBeNull();
     expect(screen.getByText('{"table":"todos"}')).not.toBeNull();
     const summary = screen.getByText(/TodoList\.tsx:34:17/, { selector: "summary" });
     expect(summary).not.toBeNull();
@@ -74,6 +76,7 @@ describe("LiveQuery", () => {
         id: "sub-1",
         table: "todos",
         tier: "worker",
+        propagation: "full",
         branches: ["main"],
         createdAt: "2026-03-10T10:00:00.000Z",
         query: '{"table":"todos"}',
@@ -83,6 +86,7 @@ describe("LiveQuery", () => {
         id: "sub-2",
         table: "projects",
         tier: "edge",
+        propagation: "local-only",
         branches: ["main"],
         createdAt: "2026-03-10T11:00:00.000Z",
         query: '{"table":"projects"}',
@@ -112,6 +116,7 @@ describe("LiveQuery", () => {
         id: "sub-1",
         table: "todos",
         tier: "global",
+        propagation: "full",
         branches: ["main"],
         createdAt: "2026-03-10T10:00:00.000Z",
         query: '{"table":"todos"}',
@@ -121,6 +126,7 @@ describe("LiveQuery", () => {
         id: "sub-2",
         table: "projects",
         tier: "edge",
+        propagation: "local-only",
         branches: ["main"],
         createdAt: "2026-03-10T11:00:00.000Z",
         query: '{"table":"projects"}',
@@ -130,6 +136,7 @@ describe("LiveQuery", () => {
         id: "sub-3",
         table: "users",
         tier: "worker",
+        propagation: "full",
         branches: ["main"],
         createdAt: "2026-03-10T11:00:00.000Z",
         query: '{"table":"users"}',

--- a/packages/inspector/src/pages/live-query/index.test.tsx
+++ b/packages/inspector/src/pages/live-query/index.test.tsx
@@ -1,0 +1,160 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { LiveQuery } from "./index";
+
+const mockGetActiveQuerySubscriptions = vi.fn();
+const mockOnActiveQuerySubscriptionsChange = vi.fn();
+const mockUseDevtoolsContext = vi.fn();
+
+vi.mock("jazz-tools", () => ({
+  getActiveQuerySubscriptions: () => mockGetActiveQuerySubscriptions(),
+  onActiveQuerySubscriptionsChange: (listener: (subscriptions: unknown[]) => void) =>
+    mockOnActiveQuerySubscriptionsChange(listener),
+}));
+
+vi.mock("../../contexts/devtools-context.js", () => ({
+  useDevtoolsContext: () => mockUseDevtoolsContext(),
+}));
+
+describe("LiveQuery", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  beforeEach(() => {
+    mockGetActiveQuerySubscriptions.mockReset();
+    mockOnActiveQuerySubscriptionsChange.mockReset();
+    mockUseDevtoolsContext.mockReset();
+    mockUseDevtoolsContext.mockReturnValue({
+      runtime: "extension",
+      wasmSchema: {
+        projects: { columns: [] },
+        todos: { columns: [] },
+      },
+    });
+    mockGetActiveQuerySubscriptions.mockReturnValue([]);
+    mockOnActiveQuerySubscriptionsChange.mockImplementation(() => vi.fn());
+  });
+
+  it("renders an empty state when there are no active subscriptions", () => {
+    render(<LiveQuery />);
+
+    expect(screen.getByText("No active subscriptions")).not.toBeNull();
+  });
+
+  it("renders traced subscriptions from the extension bridge", () => {
+    mockGetActiveQuerySubscriptions.mockReturnValue([
+      {
+        id: "sub-1",
+        table: "todos",
+        tier: "worker",
+        branches: ["main"],
+        createdAt: "2026-03-10T10:00:00.000Z",
+        query: '{"table":"todos"}',
+        stack:
+          "Error\n    at useAll (http://localhost:5173/@fs/.../use-all.js:37:12)\n    at TodoList (http://localhost:5173/src/TodoList.tsx:34:17)\n    at renderWithHooks (http://localhost:5173/node_modules/.vite/deps/react-dom_client.js:5652:24)",
+      },
+    ]);
+
+    render(<LiveQuery />);
+
+    expect(screen.getByRole("cell", { name: "todos" })).not.toBeNull();
+    expect(screen.getByText('{"table":"todos"}')).not.toBeNull();
+    const summary = screen.getByText(/TodoList\.tsx:34:17/, { selector: "summary" });
+    expect(summary).not.toBeNull();
+
+    fireEvent.click(summary);
+
+    expect(screen.getByText(/at useAll/)).not.toBeNull();
+  });
+
+  it("filters rows by table and tier", () => {
+    mockGetActiveQuerySubscriptions.mockReturnValue([
+      {
+        id: "sub-1",
+        table: "todos",
+        tier: "worker",
+        branches: ["main"],
+        createdAt: "2026-03-10T10:00:00.000Z",
+        query: '{"table":"todos"}',
+        stack: "Error\n    at TodoList (http://localhost:5173/src/TodoList.tsx:34:17)",
+      },
+      {
+        id: "sub-2",
+        table: "projects",
+        tier: "edge",
+        branches: ["main"],
+        createdAt: "2026-03-10T11:00:00.000Z",
+        query: '{"table":"projects"}',
+        stack: "Error\n    at ProjectList (http://localhost:5173/src/ProjectList.tsx:10:8)",
+      },
+    ]);
+
+    render(<LiveQuery />);
+
+    fireEvent.change(screen.getByLabelText("Filter by table"), {
+      target: { value: "projects" },
+    });
+
+    expect(screen.queryByRole("cell", { name: "todos" })).toBeNull();
+    expect(screen.getByRole("cell", { name: "projects" })).not.toBeNull();
+
+    fireEvent.change(screen.getByLabelText("Filter by tier"), {
+      target: { value: "worker" },
+    });
+
+    expect(screen.getByText("No active subscriptions")).not.toBeNull();
+  });
+
+  it("sorts by started date and tier, and allows toggling started order", () => {
+    mockGetActiveQuerySubscriptions.mockReturnValue([
+      {
+        id: "sub-1",
+        table: "todos",
+        tier: "global",
+        branches: ["main"],
+        createdAt: "2026-03-10T10:00:00.000Z",
+        query: '{"table":"todos"}',
+        stack: "Error\n    at TodoList (http://localhost:5173/src/TodoList.tsx:34:17)",
+      },
+      {
+        id: "sub-2",
+        table: "projects",
+        tier: "edge",
+        branches: ["main"],
+        createdAt: "2026-03-10T11:00:00.000Z",
+        query: '{"table":"projects"}',
+        stack: "Error\n    at ProjectList (http://localhost:5173/src/ProjectList.tsx:10:8)",
+      },
+      {
+        id: "sub-3",
+        table: "users",
+        tier: "worker",
+        branches: ["main"],
+        createdAt: "2026-03-10T11:00:00.000Z",
+        query: '{"table":"users"}',
+        stack: "Error\n    at UserList (http://localhost:5173/src/UserList.tsx:10:8)",
+      },
+    ]);
+    mockUseDevtoolsContext.mockReturnValue({
+      runtime: "extension",
+      wasmSchema: {
+        projects: { columns: [] },
+        todos: { columns: [] },
+        users: { columns: [] },
+      },
+    });
+
+    render(<LiveQuery />);
+
+    const rows = screen.getAllByRole("row");
+    expect(rows[1]?.textContent).toContain("users");
+    expect(rows[2]?.textContent).toContain("projects");
+    expect(rows[3]?.textContent).toContain("todos");
+
+    fireEvent.click(screen.getByRole("columnheader", { name: /Started/ }));
+
+    const reSortedRows = screen.getAllByRole("row");
+    expect(reSortedRows[1]?.textContent).toContain("todos");
+  });
+});

--- a/packages/inspector/src/pages/live-query/index.test.tsx
+++ b/packages/inspector/src/pages/live-query/index.test.tsx
@@ -1,12 +1,15 @@
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { LiveQuery } from "./index";
 
+const mockFetchServerSubscriptions = vi.fn();
 const mockGetActiveQuerySubscriptions = vi.fn();
 const mockOnActiveQuerySubscriptionsChange = vi.fn();
 const mockUseDevtoolsContext = vi.fn();
+const mockUseStandaloneContext = vi.fn();
 
 vi.mock("jazz-tools", () => ({
+  fetchServerSubscriptions: (...args: unknown[]) => mockFetchServerSubscriptions(...args),
   getActiveQuerySubscriptions: () => mockGetActiveQuerySubscriptions(),
   onActiveQuerySubscriptionsChange: (listener: (subscriptions: unknown[]) => void) =>
     mockOnActiveQuerySubscriptionsChange(listener),
@@ -16,15 +19,21 @@ vi.mock("../../contexts/devtools-context.js", () => ({
   useDevtoolsContext: () => mockUseDevtoolsContext(),
 }));
 
+vi.mock("../../contexts/standalone-context.js", () => ({
+  useStandaloneContext: () => mockUseStandaloneContext(),
+}));
+
 describe("LiveQuery", () => {
   afterEach(() => {
     cleanup();
   });
 
   beforeEach(() => {
+    mockFetchServerSubscriptions.mockReset();
     mockGetActiveQuerySubscriptions.mockReset();
     mockOnActiveQuerySubscriptionsChange.mockReset();
     mockUseDevtoolsContext.mockReset();
+    mockUseStandaloneContext.mockReset();
     mockUseDevtoolsContext.mockReturnValue({
       runtime: "extension",
       wasmSchema: {
@@ -32,11 +41,23 @@ describe("LiveQuery", () => {
         todos: { columns: [] },
       },
     });
+    mockUseStandaloneContext.mockReturnValue({
+      connection: {
+        serverUrl: "http://localhost:1625",
+        appId: "test-app",
+        adminSecret: "admin-secret",
+      },
+    });
     mockGetActiveQuerySubscriptions.mockReturnValue([]);
     mockOnActiveQuerySubscriptionsChange.mockImplementation(() => vi.fn());
+    mockFetchServerSubscriptions.mockResolvedValue({
+      appId: "test-app",
+      generatedAt: 1741600800000,
+      queries: [],
+    });
   });
 
-  it("renders an empty state when there are no active subscriptions", () => {
+  it("renders an empty state when there are no active extension subscriptions", () => {
     render(<LiveQuery />);
 
     expect(screen.getByText("No active subscriptions")).not.toBeNull();
@@ -70,7 +91,7 @@ describe("LiveQuery", () => {
     expect(screen.getByText(/at useAll/)).not.toBeNull();
   });
 
-  it("filters rows by table and tier", () => {
+  it("filters extension rows by table and tier", () => {
     mockGetActiveQuerySubscriptions.mockReturnValue([
       {
         id: "sub-1",
@@ -110,7 +131,7 @@ describe("LiveQuery", () => {
     expect(screen.getByText("No active subscriptions")).not.toBeNull();
   });
 
-  it("sorts by started date and tier, and allows toggling started order", () => {
+  it("sorts extension rows by started date and tier, and allows toggling started order", () => {
     mockGetActiveQuerySubscriptions.mockReturnValue([
       {
         id: "sub-1",
@@ -163,5 +184,40 @@ describe("LiveQuery", () => {
 
     const reSortedRows = screen.getAllByRole("row");
     expect(reSortedRows[1]?.textContent).toContain("todos");
+  });
+
+  it("fetches and renders grouped standalone server telemetry", async () => {
+    mockUseDevtoolsContext.mockReturnValue({
+      runtime: "standalone",
+      wasmSchema: {},
+    });
+    mockFetchServerSubscriptions.mockResolvedValue({
+      appId: "test-app",
+      generatedAt: 1741600800000,
+      queries: [
+        {
+          groupKey: "group-1",
+          count: 2,
+          table: "todos",
+          propagation: "full",
+          branches: ["main"],
+          query: '{"table":"todos"}',
+        },
+      ],
+    });
+
+    render(<LiveQuery />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("cell", { name: "todos" })).not.toBeNull();
+    });
+
+    expect(mockFetchServerSubscriptions).toHaveBeenCalledWith("http://localhost:1625", {
+      adminSecret: "admin-secret",
+      appId: "test-app",
+      pathPrefix: undefined,
+    });
+    expect(screen.getByRole("cell", { name: "2" })).not.toBeNull();
+    expect(screen.queryByLabelText("Filter by tier")).toBeNull();
   });
 });

--- a/packages/inspector/src/pages/live-query/index.tsx
+++ b/packages/inspector/src/pages/live-query/index.tsx
@@ -1,4 +1,14 @@
 import {
+  fetchServerSubscriptions,
+  getActiveQuerySubscriptions,
+  onActiveQuerySubscriptionsChange,
+} from "jazz-tools";
+import type {
+  ActiveQuerySubscriptionTrace,
+  DurabilityTier,
+  IntrospectionSubscriptionGroup,
+} from "jazz-tools";
+import {
   flexRender,
   getCoreRowModel,
   getSortedRowModel,
@@ -6,12 +16,13 @@ import {
   type SortingState,
   useReactTable,
 } from "@tanstack/react-table";
-import { getActiveQuerySubscriptions, onActiveQuerySubscriptionsChange } from "jazz-tools";
-import type { ActiveQuerySubscriptionTrace, DurabilityTier } from "jazz-tools";
 import { useEffect, useMemo, useState } from "react";
 import { useDevtoolsContext } from "../../contexts/devtools-context.js";
+import { useStandaloneContext } from "../../contexts/standalone-context.js";
 import { LiveQueryFilters } from "./LiveQueryFilters.js";
 import styles from "./index.module.css";
+
+const SERVER_SUBSCRIPTIONS_POLL_MS = 20_000;
 
 function getUserStackSummary(stack: string | undefined): string {
   if (!stack) {
@@ -23,7 +34,7 @@ function getUserStackSummary(stack: string | undefined): string {
   return firstUserFrame?.trim() ?? lines[0]?.trim() ?? "n/a";
 }
 
-function formatStartedAt(value: string): string {
+function formatTime(value: string | number): string {
   return new Date(value).toLocaleTimeString();
 }
 
@@ -56,7 +67,74 @@ function useActiveSubscriptions(runtime: "standalone" | "extension") {
   return subscriptions;
 }
 
-export function LiveQuery() {
+function useServerSubscriptionTelemetry(runtime: "standalone" | "extension") {
+  const standaloneContext = useStandaloneContext();
+  const [queries, setQueries] = useState<IntrospectionSubscriptionGroup[]>([]);
+  const [generatedAt, setGeneratedAt] = useState<number | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(runtime === "standalone");
+
+  useEffect(() => {
+    if (runtime !== "standalone" || !standaloneContext) {
+      setQueries([]);
+      setGeneratedAt(null);
+      setError(null);
+      setIsLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+
+    const load = async (showLoader: boolean) => {
+      if (showLoader) {
+        setIsLoading(true);
+      }
+
+      try {
+        const response = await fetchServerSubscriptions(standaloneContext.connection.serverUrl, {
+          adminSecret: standaloneContext.connection.adminSecret,
+          appId: standaloneContext.connection.appId,
+          pathPrefix: standaloneContext.connection.serverPathPrefix,
+        });
+        if (cancelled) {
+          return;
+        }
+        setQueries(response.queries);
+        setGeneratedAt(response.generatedAt);
+        setError(null);
+      } catch (err) {
+        if (cancelled) {
+          return;
+        }
+        setError(err instanceof Error ? err.message : String(err));
+      } finally {
+        if (!cancelled && showLoader) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    load(true);
+    const intervalId = window.setInterval(() => {
+      load(false);
+    }, SERVER_SUBSCRIPTIONS_POLL_MS);
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(intervalId);
+    };
+  }, [
+    runtime,
+    standaloneContext?.connection.adminSecret,
+    standaloneContext?.connection.appId,
+    standaloneContext?.connection.serverPathPrefix,
+    standaloneContext?.connection.serverUrl,
+  ]);
+
+  return { queries, generatedAt, error, isLoading };
+}
+
+function ExtensionLiveQuery() {
   const { runtime, wasmSchema } = useDevtoolsContext();
   const subscriptions = useActiveSubscriptions(runtime);
   const [selectedTable, setSelectedTable] = useState("");
@@ -108,7 +186,7 @@ export function LiveQuery() {
         accessorKey: "createdAt",
         header: "Started",
         sortingFn: "datetime",
-        cell: ({ row }) => formatStartedAt(row.original.createdAt),
+        cell: ({ row }) => formatTime(row.original.createdAt),
       },
       {
         accessorKey: "query",
@@ -141,10 +219,6 @@ export function LiveQuery() {
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
   });
-
-  if (runtime !== "extension") {
-    return null;
-  }
 
   return (
     <section className={styles.container}>
@@ -212,4 +286,98 @@ export function LiveQuery() {
       )}
     </section>
   );
+}
+
+function StandaloneLiveQuery() {
+  const { queries, generatedAt, error, isLoading } = useServerSubscriptionTelemetry("standalone");
+  const [selectedTable, setSelectedTable] = useState("");
+
+  const availableTables = useMemo(() => {
+    return [...new Set(queries.map((query) => query.table))].sort();
+  }, [queries]);
+  const filteredQueries = useMemo(() => {
+    return queries.filter((query) => !selectedTable || query.table === selectedTable);
+  }, [queries, selectedTable]);
+
+  return (
+    <section className={styles.container}>
+      <header className={styles.header}>
+        <div>
+          <h1 className={styles.title}>Live Query</h1>
+          <p className={styles.subtitle}>
+            Grouped active server-managed subscriptions for the connected Jazz server.
+          </p>
+          <p className={styles.statusText}>
+            {generatedAt
+              ? `Polled every 20s. Last refresh ${formatTime(generatedAt)}.`
+              : "Polled every 20s."}
+          </p>
+        </div>
+        <LiveQueryFilters
+          availableTables={availableTables}
+          selectedTable={selectedTable}
+          selectedTier=""
+          onTableChange={setSelectedTable}
+          onTierChange={() => undefined}
+          showTierFilter={false}
+        />
+      </header>
+      {error && queries.length === 0 ? (
+        <section className={styles.emptyState}>
+          <p className={styles.emptyTitle}>Unable to load subscription telemetry</p>
+          <p className={styles.emptyText}>{error}</p>
+        </section>
+      ) : isLoading && queries.length === 0 ? (
+        <section className={styles.emptyState}>
+          <p className={styles.emptyTitle}>Loading subscriptions</p>
+          <p className={styles.emptyText}>Fetching active server subscriptions.</p>
+        </section>
+      ) : filteredQueries.length === 0 ? (
+        <section className={styles.emptyState}>
+          <p className={styles.emptyTitle}>No active subscriptions</p>
+          <p className={styles.emptyText}>
+            The connected server is not currently tracking any downstream query subscriptions.
+          </p>
+        </section>
+      ) : (
+        <div className={styles.tableShell}>
+          <table className={styles.table}>
+            <thead>
+              <tr>
+                <th>Count</th>
+                <th>Table</th>
+                <th>Propagation</th>
+                <th>Branches</th>
+                <th>Query</th>
+              </tr>
+            </thead>
+            <tbody>
+              {filteredQueries.map((query) => (
+                <tr key={query.groupKey}>
+                  <td>{query.count}</td>
+                  <td>{query.table}</td>
+                  <td>{query.propagation}</td>
+                  <td>{query.branches.join(", ")}</td>
+                  <td>
+                    <pre className={styles.codeBlock}>{query.query}</pre>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+      {error && queries.length > 0 ? <p className={styles.statusText}>{error}</p> : null}
+    </section>
+  );
+}
+
+export function LiveQuery() {
+  const { runtime } = useDevtoolsContext();
+
+  if (runtime === "standalone") {
+    return <StandaloneLiveQuery />;
+  }
+
+  return <ExtensionLiveQuery />;
 }

--- a/packages/inspector/src/pages/live-query/index.tsx
+++ b/packages/inspector/src/pages/live-query/index.tsx
@@ -1,12 +1,210 @@
+import {
+  flexRender,
+  getCoreRowModel,
+  getSortedRowModel,
+  type ColumnDef,
+  type SortingState,
+  useReactTable,
+} from "@tanstack/react-table";
+import { getActiveQuerySubscriptions, onActiveQuerySubscriptionsChange } from "jazz-tools";
+import type { ActiveQuerySubscriptionTrace, DurabilityTier } from "jazz-tools";
+import { useEffect, useMemo, useState } from "react";
+import { useDevtoolsContext } from "../../contexts/devtools-context.js";
+import { LiveQueryFilters } from "./LiveQueryFilters.js";
 import styles from "./index.module.css";
 
+function getUserStackSummary(stack: string | undefined): string {
+  if (!stack) {
+    return "n/a";
+  }
+
+  const lines = stack.split("\n").slice(1);
+  const firstUserFrame = lines.find((line) => line.includes("/src/"));
+  return firstUserFrame?.trim() ?? lines[0]?.trim() ?? "n/a";
+}
+
+function formatStartedAt(value: string): string {
+  return new Date(value).toLocaleTimeString();
+}
+
+function tierRank(tier: DurabilityTier): number {
+  switch (tier) {
+    case "worker":
+      return 0;
+    case "edge":
+      return 1;
+    case "global":
+      return 2;
+  }
+}
+
+function useActiveSubscriptions(runtime: "standalone" | "extension") {
+  const [subscriptions, setSubscriptions] = useState(() => getActiveQuerySubscriptions());
+
+  useEffect(() => {
+    if (runtime !== "extension") {
+      setSubscriptions([]);
+      return;
+    }
+
+    setSubscriptions(getActiveQuerySubscriptions());
+    return onActiveQuerySubscriptionsChange((nextSubscriptions) => {
+      setSubscriptions([...nextSubscriptions]);
+    });
+  }, [runtime]);
+
+  return subscriptions;
+}
+
 export function LiveQuery() {
+  const { runtime, wasmSchema } = useDevtoolsContext();
+  const subscriptions = useActiveSubscriptions(runtime);
+  const [selectedTable, setSelectedTable] = useState("");
+  const [selectedTier, setSelectedTier] = useState("");
+  const [sorting, setSorting] = useState<SortingState>([
+    { id: "createdAt", desc: true },
+    { id: "tier", desc: false },
+  ]);
+
+  const availableTables = useMemo(() => Object.keys(wasmSchema ?? {}).sort(), [wasmSchema]);
+  const filteredSubscriptions = useMemo(() => {
+    return subscriptions.filter((subscription) => {
+      if (selectedTable && subscription.table !== selectedTable) {
+        return false;
+      }
+      if (selectedTier && subscription.tier !== selectedTier) {
+        return false;
+      }
+      return true;
+    });
+  }, [selectedTable, selectedTier, subscriptions]);
+
+  const columns = useMemo<ColumnDef<ActiveQuerySubscriptionTrace>[]>(
+    () => [
+      {
+        accessorKey: "table",
+        header: "Table",
+        cell: (info) => info.getValue<string>(),
+      },
+      {
+        accessorKey: "tier",
+        header: "Tier",
+        sortingFn: (left, right, columnId) =>
+          tierRank(left.getValue<DurabilityTier>(columnId)) -
+          tierRank(right.getValue<DurabilityTier>(columnId)),
+        cell: (info) => info.getValue<string>(),
+      },
+      {
+        id: "branches",
+        header: "Branches",
+        cell: ({ row }) => row.original.branches.join(", "),
+      },
+      {
+        accessorKey: "createdAt",
+        header: "Started",
+        sortingFn: "datetime",
+        cell: ({ row }) => formatStartedAt(row.original.createdAt),
+      },
+      {
+        accessorKey: "query",
+        header: "Query",
+        enableSorting: false,
+        cell: ({ row }) => <pre className={styles.codeBlock}>{row.original.query}</pre>,
+      },
+      {
+        id: "stack",
+        header: "Stack",
+        enableSorting: false,
+        cell: ({ row }) => (
+          <details className={styles.stackDetails}>
+            <summary className={styles.stackSummary}>
+              {getUserStackSummary(row.original.stack)}
+            </summary>
+            <pre className={styles.codeBlock}>{row.original.stack ?? "n/a"}</pre>
+          </details>
+        ),
+      },
+    ],
+    [],
+  );
+
+  const table = useReactTable({
+    data: filteredSubscriptions,
+    columns,
+    state: { sorting },
+    onSortingChange: setSorting,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+  });
+
+  if (runtime !== "extension") {
+    return null;
+  }
+
   return (
     <section className={styles.container}>
       <header className={styles.header}>
-        <h1 className={styles.title}>Live Query</h1>
-        <p className={styles.subtitle}>Coming soon.</p>
+        <div>
+          <h1 className={styles.title}>Live Query</h1>
+          <p className={styles.subtitle}>
+            Active `Db.subscribeAll(...)` subscriptions captured from the inspected page runtime.
+          </p>
+        </div>
+        <LiveQueryFilters
+          availableTables={availableTables}
+          selectedTable={selectedTable}
+          selectedTier={selectedTier}
+          onTableChange={setSelectedTable}
+          onTierChange={setSelectedTier}
+        />
       </header>
+      {filteredSubscriptions.length === 0 ? (
+        <section className={styles.emptyState}>
+          <p className={styles.emptyTitle}>No active subscriptions</p>
+          <p className={styles.emptyText}>
+            Open a page with `devMode: true` and create a live query to see it here.
+          </p>
+        </section>
+      ) : (
+        <div className={styles.tableShell}>
+          <table className={styles.table}>
+            <thead>
+              {table.getHeaderGroups().map((headerGroup) => (
+                <tr key={headerGroup.id}>
+                  {headerGroup.headers.map((header) => {
+                    const sortDirection = header.column.getIsSorted();
+                    const canSort = header.column.getCanSort();
+
+                    return (
+                      <th
+                        key={header.id}
+                        className={canSort ? styles.sortableHeader : undefined}
+                        onClick={canSort ? header.column.getToggleSortingHandler() : undefined}
+                      >
+                        {header.isPlaceholder
+                          ? null
+                          : flexRender(header.column.columnDef.header, header.getContext())}
+                        {sortDirection === "asc" ? " ↑" : sortDirection === "desc" ? " ↓" : ""}
+                      </th>
+                    );
+                  })}
+                </tr>
+              ))}
+            </thead>
+            <tbody>
+              {table.getRowModel().rows.map((row) => (
+                <tr key={row.id}>
+                  {row.getVisibleCells().map((cell) => (
+                    <td key={cell.id}>
+                      {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
     </section>
   );
 }

--- a/packages/inspector/src/pages/live-query/index.tsx
+++ b/packages/inspector/src/pages/live-query/index.tsx
@@ -95,6 +95,11 @@ export function LiveQuery() {
         cell: (info) => info.getValue<string>(),
       },
       {
+        accessorKey: "propagation",
+        header: "Propagation",
+        cell: (info) => info.getValue<string>(),
+      },
+      {
         id: "branches",
         header: "Branches",
         cell: ({ row }) => row.original.branches.join(", "),

--- a/packages/inspector/src/routes.test.tsx
+++ b/packages/inspector/src/routes.test.tsx
@@ -1,0 +1,71 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter, Outlet } from "react-router";
+import { InspectorRoutes } from "./routes";
+
+const mockUseDevtoolsContext = vi.fn();
+
+vi.mock("./contexts/devtools-context.js", () => ({
+  useDevtoolsContext: () => mockUseDevtoolsContext(),
+}));
+
+vi.mock("./components/inspector-layout", () => ({
+  InspectorLayout: () => (
+    <div>
+      layout
+      <Outlet />
+    </div>
+  ),
+}));
+
+vi.mock("./pages/data-explorer", () => ({
+  DataExplorer: () => <div>data explorer</div>,
+}));
+
+vi.mock("./components/data-explorer/TableDataGrid", () => ({
+  TableDataGrid: () => <div>table grid</div>,
+}));
+
+vi.mock("./components/data-explorer/TableSchemaSql", () => ({
+  TableSchemaSql: () => <div>schema sql</div>,
+}));
+
+vi.mock("./pages/live-query", () => ({
+  LiveQuery: () => <div>live query page</div>,
+}));
+
+describe("InspectorRoutes", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  beforeEach(() => {
+    mockUseDevtoolsContext.mockReset();
+  });
+
+  it("exposes the live query route in extension mode", () => {
+    mockUseDevtoolsContext.mockReturnValue({ runtime: "extension" });
+
+    render(
+      <MemoryRouter initialEntries={["/live-query"]}>
+        <InspectorRoutes />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("live query page")).not.toBeNull();
+  });
+
+  it("does not resolve the live query route in standalone mode", () => {
+    mockUseDevtoolsContext.mockReturnValue({ runtime: "standalone" });
+    const errorSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    render(
+      <MemoryRouter initialEntries={["/live-query"]}>
+        <InspectorRoutes />
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByText("live query page")).toBeNull();
+    errorSpy.mockRestore();
+  });
+});

--- a/packages/inspector/src/routes.test.tsx
+++ b/packages/inspector/src/routes.test.tsx
@@ -54,18 +54,4 @@ describe("InspectorRoutes", () => {
 
     expect(screen.getByText("live query page")).not.toBeNull();
   });
-
-  it("does not resolve the live query route in standalone mode", () => {
-    mockUseDevtoolsContext.mockReturnValue({ runtime: "standalone" });
-    const errorSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
-
-    render(
-      <MemoryRouter initialEntries={["/live-query"]}>
-        <InspectorRoutes />
-      </MemoryRouter>,
-    );
-
-    expect(screen.queryByText("live query page")).toBeNull();
-    errorSpy.mockRestore();
-  });
 });

--- a/packages/inspector/src/routes.tsx
+++ b/packages/inspector/src/routes.tsx
@@ -4,11 +4,8 @@ import { TableDataGrid } from "./components/data-explorer/TableDataGrid";
 import { TableSchemaSql } from "./components/data-explorer/TableSchemaSql";
 import { InspectorLayout } from "./components/inspector-layout";
 import { LiveQuery } from "./pages/live-query";
-import { useDevtoolsContext } from "./contexts/devtools-context";
 
 export function InspectorRoutes() {
-  const { runtime } = useDevtoolsContext();
-
   return (
     <Routes>
       <Route path="/" element={<InspectorLayout />}>
@@ -17,7 +14,7 @@ export function InspectorRoutes() {
           <Route path=":table/data" element={<TableDataGrid />} />
           <Route path=":table/schema" element={<TableSchemaSql />} />
         </Route>
-        {runtime === "extension" ? <Route path="live-query" element={<LiveQuery />} /> : null}
+        <Route path="live-query" element={<LiveQuery />} />
       </Route>
     </Routes>
   );

--- a/packages/inspector/src/routes.tsx
+++ b/packages/inspector/src/routes.tsx
@@ -4,8 +4,11 @@ import { TableDataGrid } from "./components/data-explorer/TableDataGrid";
 import { TableSchemaSql } from "./components/data-explorer/TableSchemaSql";
 import { InspectorLayout } from "./components/inspector-layout";
 import { LiveQuery } from "./pages/live-query";
+import { useDevtoolsContext } from "./contexts/devtools-context";
 
 export function InspectorRoutes() {
+  const { runtime } = useDevtoolsContext();
+
   return (
     <Routes>
       <Route path="/" element={<InspectorLayout />}>
@@ -14,7 +17,7 @@ export function InspectorRoutes() {
           <Route path=":table/data" element={<TableDataGrid />} />
           <Route path=":table/schema" element={<TableSchemaSql />} />
         </Route>
-        <Route path="live-query" element={<LiveQuery />} />
+        {runtime === "extension" ? <Route path="live-query" element={<LiveQuery />} /> : null}
       </Route>
     </Routes>
   );

--- a/packages/jazz-tools/src/dev-tools/dev-tools.test.ts
+++ b/packages/jazz-tools/src/dev-tools/dev-tools.test.ts
@@ -93,6 +93,27 @@ function waitForEvent(
 }
 
 describe("attachDevTools active query subscription bridge", () => {
+  it("enables db devMode when attaching", async () => {
+    const fakeWindow = new FakeWindow();
+    (globalThis as { window?: unknown }).window = fakeWindow as unknown;
+
+    const fakeDb = {
+      config: {
+        appId: "devtools-test",
+      },
+      setDevMode: vi.fn(function (this: { config: { devMode?: boolean } }, enabled: boolean) {
+        this.config.devMode = enabled;
+      }),
+      clients: new Map([["default", {}]]),
+      getActiveQuerySubscriptions: vi.fn(() => []),
+      onActiveQuerySubscriptionsChange: vi.fn(() => () => {}),
+    };
+
+    await attachDevTools({ db: fakeDb as any }, {} as any);
+
+    expect(fakeDb.setDevMode).toHaveBeenCalledWith(true);
+  });
+
   it("returns snapshots and pushes updates", async () => {
     const fakeWindow = new FakeWindow();
     (globalThis as { window?: unknown }).window = fakeWindow as unknown;
@@ -126,6 +147,7 @@ describe("attachDevTools active query subscription bridge", () => {
         appId: "devtools-test",
         devMode: true,
       },
+      setDevMode: vi.fn(),
       clients: new Map([["default", {}]]),
       getActiveQuerySubscriptions: vi.fn(() => currentSubscriptions),
       onActiveQuerySubscriptionsChange: vi.fn(

--- a/packages/jazz-tools/src/dev-tools/dev-tools.test.ts
+++ b/packages/jazz-tools/src/dev-tools/dev-tools.test.ts
@@ -104,6 +104,7 @@ describe("attachDevTools active query subscription bridge", () => {
         table: "todos",
         branches: ["main"],
         tier: "worker",
+        propagation: "full",
         createdAt: "2026-03-10T10:00:00.000Z",
         stack: "Error\n  at demo",
       },

--- a/packages/jazz-tools/src/dev-tools/dev-tools.test.ts
+++ b/packages/jazz-tools/src/dev-tools/dev-tools.test.ts
@@ -1,0 +1,179 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { attachDevTools } from "./dev-tools.js";
+import {
+  DEVTOOLS_BRIDGE_CHANNEL,
+  DEVTOOLS_COMMANDS,
+  DEVTOOLS_EVENTS,
+  type DevtoolsEventEnvelope,
+  type DevtoolsResponseEnvelope,
+} from "./protocol.js";
+import type { ActiveQuerySubscriptionTrace } from "../runtime/db.js";
+
+type MessageListener = (event: { source: FakeWindow; data: unknown }) => void;
+
+class FakeWindow {
+  private readonly listeners = new Set<MessageListener>();
+
+  addEventListener(type: string, listener: MessageListener): void {
+    if (type === "message") {
+      this.listeners.add(listener);
+    }
+  }
+
+  removeEventListener(type: string, listener: MessageListener): void {
+    if (type === "message") {
+      this.listeners.delete(listener);
+    }
+  }
+
+  postMessage(data: unknown): void {
+    for (const listener of Array.from(this.listeners)) {
+      listener({ source: this, data });
+    }
+  }
+}
+
+const originalWindow = (globalThis as { window?: unknown }).window;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  if (originalWindow === undefined) {
+    delete (globalThis as { window?: unknown }).window;
+  } else {
+    (globalThis as { window?: unknown }).window = originalWindow;
+  }
+});
+
+function waitForResponse(
+  fakeWindow: FakeWindow,
+  requestId: string,
+): Promise<DevtoolsResponseEnvelope> {
+  return new Promise((resolve) => {
+    const listener: MessageListener = (event) => {
+      const message = event.data as Partial<DevtoolsResponseEnvelope>;
+      if (
+        message.channel !== DEVTOOLS_BRIDGE_CHANNEL ||
+        message.kind !== "response" ||
+        message.requestId !== requestId
+      ) {
+        return;
+      }
+      fakeWindow.removeEventListener("message", listener);
+      resolve(message as DevtoolsResponseEnvelope);
+    };
+    fakeWindow.addEventListener("message", listener);
+  });
+}
+
+function waitForEvent(
+  fakeWindow: FakeWindow,
+  eventName: string,
+): Promise<
+  DevtoolsEventEnvelope<typeof DEVTOOLS_EVENTS.CLIENT_ACTIVE_QUERY_SUBSCRIPTIONS_CHANGED>
+> {
+  return new Promise((resolve) => {
+    const listener: MessageListener = (event) => {
+      const message = event.data as Partial<DevtoolsEventEnvelope>;
+      if (
+        message.channel !== DEVTOOLS_BRIDGE_CHANNEL ||
+        message.kind !== "event" ||
+        message.event !== eventName
+      ) {
+        return;
+      }
+      fakeWindow.removeEventListener("message", listener);
+      resolve(
+        message as DevtoolsEventEnvelope<
+          typeof DEVTOOLS_EVENTS.CLIENT_ACTIVE_QUERY_SUBSCRIPTIONS_CHANGED
+        >,
+      );
+    };
+    fakeWindow.addEventListener("message", listener);
+  });
+}
+
+describe("attachDevTools active query subscription bridge", () => {
+  it("returns snapshots and pushes updates", async () => {
+    const fakeWindow = new FakeWindow();
+    (globalThis as { window?: unknown }).window = fakeWindow as unknown;
+
+    const initialSubscriptions: ActiveQuerySubscriptionTrace[] = [
+      {
+        id: "sub-1",
+        query: '{"table":"todos"}',
+        table: "todos",
+        branches: ["main"],
+        tier: "worker",
+        createdAt: "2026-03-10T10:00:00.000Z",
+        stack: "Error\n  at demo",
+      },
+    ];
+    const nextSubscriptions: ActiveQuerySubscriptionTrace[] = [
+      {
+        ...initialSubscriptions[0],
+        id: "sub-2",
+      },
+    ];
+
+    let currentSubscriptions = initialSubscriptions;
+    let notifySubscriptionsChange:
+      | ((subscriptions: readonly ActiveQuerySubscriptionTrace[]) => void)
+      | null = null;
+
+    const fakeDb = {
+      config: {
+        appId: "devtools-test",
+        devMode: true,
+      },
+      clients: new Map([["default", {}]]),
+      getActiveQuerySubscriptions: vi.fn(() => currentSubscriptions),
+      onActiveQuerySubscriptionsChange: vi.fn(
+        (listener: (subscriptions: readonly ActiveQuerySubscriptionTrace[]) => void) => {
+          notifySubscriptionsChange = listener;
+          listener(currentSubscriptions);
+          return () => {
+            notifySubscriptionsChange = null;
+          };
+        },
+      ),
+    };
+
+    await attachDevTools({ db: fakeDb as any }, {} as any);
+
+    const announceRequestId = "announce-1";
+    const announceResponsePromise = waitForResponse(fakeWindow, announceRequestId);
+    fakeWindow.postMessage({
+      channel: DEVTOOLS_BRIDGE_CHANNEL,
+      kind: "request",
+      requestId: announceRequestId,
+      command: DEVTOOLS_COMMANDS.ANNOUNCE,
+      payload: {},
+    });
+
+    expect((await announceResponsePromise).ok).toBe(true);
+
+    const listRequestId = "list-1";
+    const listResponsePromise = waitForResponse(fakeWindow, listRequestId);
+    fakeWindow.postMessage({
+      channel: DEVTOOLS_BRIDGE_CHANNEL,
+      kind: "request",
+      requestId: listRequestId,
+      command: DEVTOOLS_COMMANDS.CLIENT_LIST_ACTIVE_QUERY_SUBSCRIPTIONS,
+      payload: {},
+    });
+
+    expect((await listResponsePromise).payload).toEqual(initialSubscriptions);
+
+    const eventPromise = waitForEvent(
+      fakeWindow,
+      DEVTOOLS_EVENTS.CLIENT_ACTIVE_QUERY_SUBSCRIPTIONS_CHANGED,
+    );
+    currentSubscriptions = nextSubscriptions;
+    if (notifySubscriptionsChange) {
+      // @ts-expect-error
+      notifySubscriptionsChange(nextSubscriptions);
+    }
+
+    expect((await eventPromise).payload.subscriptions).toEqual(nextSubscriptions);
+  });
+});

--- a/packages/jazz-tools/src/dev-tools/dev-tools.ts
+++ b/packages/jazz-tools/src/dev-tools/dev-tools.ts
@@ -1,4 +1,5 @@
 import {
+  ActiveQuerySubscriptionTrace,
   JazzClient,
   DurabilityTier,
   QueryExecutionOptions,
@@ -26,6 +27,7 @@ type RuntimeBridgeState = {
   connected: boolean;
   listeners: Set<DevToolsStateListener>;
   activeSubscriptions: Map<string, { client: JazzClient; runtimeSubscriptionId: number }>;
+  activeQuerySubscriptionsUnsubscribe: (() => void) | null;
 };
 
 export interface DevToolsAttachment {
@@ -74,6 +76,52 @@ function clearRuntimeBridgeSubscriptions(db: Db): void {
     }
   }
   state.activeSubscriptions.clear();
+}
+
+function emitActiveQuerySubscriptionsChanged(
+  subscriptions: readonly ActiveQuerySubscriptionTrace[],
+): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  window.postMessage(
+    {
+      channel: DEVTOOLS_BRIDGE_CHANNEL,
+      kind: "event",
+      event: DEVTOOLS_EVENTS.CLIENT_ACTIVE_QUERY_SUBSCRIPTIONS_CHANGED,
+      payload: {
+        subscriptions: subscriptions.map((subscription) => ({
+          ...subscription,
+          branches: [...subscription.branches],
+        })),
+      },
+    },
+    "*",
+  );
+}
+
+function ensureActiveQuerySubscriptionBridge(db: Db): void {
+  const state = runtimeBridgeStateByDb.get(db);
+  if (!state || state.activeQuerySubscriptionsUnsubscribe) {
+    return;
+  }
+
+  state.activeQuerySubscriptionsUnsubscribe = db.onActiveQuerySubscriptionsChange(
+    (subscriptions) => {
+      emitActiveQuerySubscriptionsChanged(subscriptions);
+    },
+  );
+}
+
+function clearActiveQuerySubscriptionBridge(db: Db): void {
+  const state = runtimeBridgeStateByDb.get(db);
+  if (!state?.activeQuerySubscriptionsUnsubscribe) {
+    return;
+  }
+
+  state.activeQuerySubscriptionsUnsubscribe();
+  state.activeQuerySubscriptionsUnsubscribe = null;
 }
 
 function getFirstDbClient(db: Db): JazzClient | null {
@@ -148,6 +196,7 @@ function hookRegistration(
       connected: false,
       listeners: new Set(),
       activeSubscriptions: new Map(),
+      activeQuerySubscriptionsUnsubscribe: null,
     };
     runtimeBridgeStateByDb.set(db, state);
   } else {
@@ -175,6 +224,7 @@ function hookRegistration(
         }
         if (eventEnvelope.event === DEVTOOLS_EVENTS.DISCONNECTED) {
           clearRuntimeBridgeSubscriptions(db);
+          clearActiveQuerySubscriptionBridge(db);
           setRuntimeBridgeConnected(db, false);
         }
         return;
@@ -229,7 +279,17 @@ function hookRegistration(
           } else {
             respond({ ok: true, payload: { ready: false } });
           }
+          ensureActiveQuerySubscriptionBridge(db);
           setRuntimeBridgeConnected(db, true);
+          return;
+        }
+
+        if (envelope.command === DEVTOOLS_COMMANDS.CLIENT_LIST_ACTIVE_QUERY_SUBSCRIPTIONS) {
+          ensureActiveQuerySubscriptionBridge(db);
+          respond({
+            ok: true,
+            payload: db.getActiveQuerySubscriptions(),
+          });
           return;
         }
 

--- a/packages/jazz-tools/src/dev-tools/dev-tools.ts
+++ b/packages/jazz-tools/src/dev-tools/dev-tools.ts
@@ -445,6 +445,7 @@ export async function attachDevTools(
 ): Promise<DevToolsAttachment> {
   const resolved = await Promise.resolve(clientOrDb as Promise<{ db: Db }> | { db: Db } | Db);
   const db = resolveDb(resolved as Db | { db: Db });
+  db.setDevMode(true);
   const dbConfig = resolveBridgeDbConfig(db);
   return hookRegistration(db, { wasmSchema, dbConfig: dbConfig ?? undefined });
 }

--- a/packages/jazz-tools/src/dev-tools/extension-panel.ts
+++ b/packages/jazz-tools/src/dev-tools/extension-panel.ts
@@ -1,4 +1,5 @@
 import {
+  ActiveQuerySubscriptionTrace,
   JazzClient,
   DurabilityTier,
   QueryExecutionOptions,
@@ -43,9 +44,13 @@ type PendingRequest = {
 };
 
 type DevToolsPortListener = () => void;
+type ActiveQuerySubscriptionsListener = (
+  subscriptions: readonly ActiveQuerySubscriptionTrace[],
+) => void;
 
 const devtoolsPortDisconnectListeners = new Set<DevToolsPortListener>();
 const devtoolsPortConnectListeners = new Set<DevToolsPortListener>();
+const activeQuerySubscriptionsListeners = new Set<ActiveQuerySubscriptionsListener>();
 
 let devtoolsPort: any | null = null;
 let announcedBootstrap: DevToolsBootstrap | null = null;
@@ -54,6 +59,16 @@ const pendingRequests = new Map<string, PendingRequest>();
 const pendingSubscriptionCallbacks = new Map<string, SubscriptionCallback>();
 const pendingSubscriptionBridgeIds = new Map<number, string>();
 let nextSubscriptionHandle = 1;
+let activeQuerySubscriptions: ActiveQuerySubscriptionTrace[] = [];
+
+function cloneActiveQuerySubscriptions(
+  subscriptions: readonly ActiveQuerySubscriptionTrace[],
+): ActiveQuerySubscriptionTrace[] {
+  return subscriptions.map((subscription) => ({
+    ...subscription,
+    branches: [...subscription.branches],
+  }));
+}
 
 function randomId(): string {
   if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
@@ -77,6 +92,13 @@ function notifyDevtoolsPortConnected(): void {
 function notifyDevtoolsPortDisconnected(): void {
   for (const listener of devtoolsPortDisconnectListeners) {
     listener();
+  }
+}
+
+function notifyActiveQuerySubscriptionsChanged(): void {
+  const snapshot = cloneActiveQuerySubscriptions(activeQuerySubscriptions);
+  for (const listener of activeQuerySubscriptionsListeners) {
+    listener(snapshot);
   }
 }
 
@@ -253,6 +275,22 @@ async function ensureDevtoolsPort(): Promise<any> {
       return;
     }
 
+    if (
+      eventEnvelope.channel === DEVTOOLS_BRIDGE_CHANNEL &&
+      eventEnvelope.kind === "event" &&
+      eventEnvelope.event === DEVTOOLS_EVENTS.CLIENT_ACTIVE_QUERY_SUBSCRIPTIONS_CHANGED
+    ) {
+      const payload = eventEnvelope.payload as
+        | DevtoolsEventPayloadByEvent[typeof DEVTOOLS_EVENTS.CLIENT_ACTIVE_QUERY_SUBSCRIPTIONS_CHANGED]
+        | undefined;
+      if (!payload || !Array.isArray(payload.subscriptions)) {
+        return;
+      }
+      activeQuerySubscriptions = cloneActiveQuerySubscriptions(payload.subscriptions);
+      notifyActiveQuerySubscriptionsChanged();
+      return;
+    }
+
     const responseEnvelope = message as Partial<DevtoolsResponseEnvelope>;
     if (
       responseEnvelope.channel !== DEVTOOLS_BRIDGE_CHANNEL ||
@@ -291,9 +329,11 @@ async function ensureDevtoolsPort(): Promise<any> {
     pendingSubscriptionCallbacks.clear();
     pendingSubscriptionBridgeIds.clear();
     nextSubscriptionHandle = 1;
+    activeQuerySubscriptions = [];
     devtoolsPort = null;
     announcedBootstrap = null;
     announcePromise = null;
+    notifyActiveQuerySubscriptionsChanged();
     notifyDevtoolsPortDisconnected();
   };
 
@@ -365,6 +405,10 @@ async function ensureDevtoolsAnnounced(): Promise<DevToolsBootstrap> {
           wasmSchema: result.wasmSchema as WasmSchema,
           dbConfig: sanitizeDbConfigForBridge(result.dbConfig as DbConfig)!,
         };
+        activeQuerySubscriptions = cloneActiveQuerySubscriptions(
+          await sendDevtoolsRequest(DEVTOOLS_COMMANDS.CLIENT_LIST_ACTIVE_QUERY_SUBSCRIPTIONS, {}),
+        );
+        notifyActiveQuerySubscriptionsChanged();
         return announcedBootstrap;
       } catch {
         await wait(ANNOUNCE_POLL_INTERVAL_MS);
@@ -406,6 +450,20 @@ export function onDevToolsPortConnect(listener: DevToolsPortListener): () => voi
   devtoolsPortConnectListeners.add(listener);
   return () => {
     devtoolsPortConnectListeners.delete(listener);
+  };
+}
+
+export function getActiveQuerySubscriptions(): ActiveQuerySubscriptionTrace[] {
+  return cloneActiveQuerySubscriptions(activeQuerySubscriptions);
+}
+
+export function onActiveQuerySubscriptionsChange(
+  listener: ActiveQuerySubscriptionsListener,
+): () => void {
+  activeQuerySubscriptionsListeners.add(listener);
+  listener(getActiveQuerySubscriptions());
+  return () => {
+    activeQuerySubscriptionsListeners.delete(listener);
   };
 }
 

--- a/packages/jazz-tools/src/dev-tools/index.ts
+++ b/packages/jazz-tools/src/dev-tools/index.ts
@@ -1,9 +1,11 @@
 export { attachDevTools, type DevToolsAttachment } from "./dev-tools.js";
 export {
   createDbFromInspectedPage,
+  getActiveQuerySubscriptions,
   getRegisteredDbConfig,
   getRegisteredWasmSchema,
   waitForDevToolsBootstrap,
+  onActiveQuerySubscriptionsChange,
   onDevToolsPortConnect,
   onDevToolsPortDisconnect,
 } from "./extension-panel.js";

--- a/packages/jazz-tools/src/dev-tools/protocol.ts
+++ b/packages/jazz-tools/src/dev-tools/protocol.ts
@@ -1,4 +1,10 @@
-import type { DurabilityTier, QueryExecutionOptions, QueryInput, WasmSchema } from "../index.js";
+import type {
+  ActiveQuerySubscriptionTrace,
+  DurabilityTier,
+  QueryExecutionOptions,
+  QueryInput,
+  WasmSchema,
+} from "../index.js";
 import type { DbConfig } from "../runtime/db.js";
 
 export const DEVTOOLS_BRIDGE_CHANNEL = "jazz-devtools-v1" as const;
@@ -10,12 +16,14 @@ export const DEVTOOLS_COMMANDS = {
   CLIENT_QUERY: "client.query",
   CLIENT_SUBSCRIBE: "client.subscribe",
   CLIENT_UNSUBSCRIBE: "client.unsubscribe",
+  CLIENT_LIST_ACTIVE_QUERY_SUBSCRIPTIONS: "client.listActiveQuerySubscriptions",
 } as const;
 
 export const DEVTOOLS_EVENTS = {
   CONNECTED: "devtools.connected",
   DISCONNECTED: "devtools.disconnected",
   CLIENT_SUBSCRIPTION_DELTA: "client.subscription.delta",
+  CLIENT_ACTIVE_QUERY_SUBSCRIPTIONS_CHANGED: "client.activeQuerySubscriptions.changed",
 } as const;
 
 export type DevtoolsBridgeCommand = (typeof DEVTOOLS_COMMANDS)[keyof typeof DEVTOOLS_COMMANDS];
@@ -52,12 +60,17 @@ export type DevtoolsClientUnsubscribeRequestPayload = {
 };
 export type DevtoolsClientUnsubscribeResponsePayload = { unsubscribed: true };
 
+export type DevtoolsClientListActiveQuerySubscriptionsRequestPayload = Record<string, never>;
+export type DevtoolsClientListActiveQuerySubscriptionsResponsePayload =
+  ActiveQuerySubscriptionTrace[];
+
 export interface DevtoolsRequestPayloadByCommand {
   [DEVTOOLS_COMMANDS.BRIDGE_HANDSHAKE]: DevtoolsBridgeHandshakeRequestPayload;
   [DEVTOOLS_COMMANDS.ANNOUNCE]: DevtoolsAnnounceRequestPayload;
   [DEVTOOLS_COMMANDS.CLIENT_QUERY]: DevtoolsClientQueryRequestPayload;
   [DEVTOOLS_COMMANDS.CLIENT_SUBSCRIBE]: DevtoolsClientSubscribeRequestPayload;
   [DEVTOOLS_COMMANDS.CLIENT_UNSUBSCRIBE]: DevtoolsClientUnsubscribeRequestPayload;
+  [DEVTOOLS_COMMANDS.CLIENT_LIST_ACTIVE_QUERY_SUBSCRIPTIONS]: DevtoolsClientListActiveQuerySubscriptionsRequestPayload;
 }
 
 export interface DevtoolsResponsePayloadByCommand {
@@ -66,6 +79,7 @@ export interface DevtoolsResponsePayloadByCommand {
   [DEVTOOLS_COMMANDS.CLIENT_QUERY]: DevtoolsClientQueryResponsePayload;
   [DEVTOOLS_COMMANDS.CLIENT_SUBSCRIBE]: DevtoolsClientSubscribeResponsePayload;
   [DEVTOOLS_COMMANDS.CLIENT_UNSUBSCRIBE]: DevtoolsClientUnsubscribeResponsePayload;
+  [DEVTOOLS_COMMANDS.CLIENT_LIST_ACTIVE_QUERY_SUBSCRIPTIONS]: DevtoolsClientListActiveQuerySubscriptionsResponsePayload;
 }
 
 export type DevtoolsRequestEnvelope =
@@ -103,6 +117,13 @@ export type DevtoolsRequestEnvelope =
       requestId: string;
       command: (typeof DEVTOOLS_COMMANDS)["CLIENT_UNSUBSCRIBE"];
       payload: DevtoolsClientUnsubscribeRequestPayload;
+    }
+  | {
+      channel: typeof DEVTOOLS_BRIDGE_CHANNEL;
+      kind: "request";
+      requestId: string;
+      command: (typeof DEVTOOLS_COMMANDS)["CLIENT_LIST_ACTIVE_QUERY_SUBSCRIPTIONS"];
+      payload: DevtoolsClientListActiveQuerySubscriptionsRequestPayload;
     };
 
 export type DevtoolsResponseEnvelope<
@@ -121,10 +142,15 @@ export type DevtoolsSubscriptionDeltaEventPayload = {
   delta: unknown;
 };
 
+export type DevtoolsActiveQuerySubscriptionsChangedEventPayload = {
+  subscriptions: ActiveQuerySubscriptionTrace[];
+};
+
 export interface DevtoolsEventPayloadByEvent {
   [DEVTOOLS_EVENTS.CONNECTED]: undefined;
   [DEVTOOLS_EVENTS.DISCONNECTED]: undefined;
   [DEVTOOLS_EVENTS.CLIENT_SUBSCRIPTION_DELTA]: DevtoolsSubscriptionDeltaEventPayload;
+  [DEVTOOLS_EVENTS.CLIENT_ACTIVE_QUERY_SUBSCRIPTIONS_CHANGED]: DevtoolsActiveQuerySubscriptionsChangedEventPayload;
 }
 
 export type DevtoolsEventEnvelope<TEvent extends DevtoolsBridgeEvent = DevtoolsBridgeEvent> = {
@@ -159,6 +185,7 @@ export function sanitizeDbConfigForBridge(dbConfig: DbConfig | null): DbConfig |
     serverPathPrefix: dbConfig.serverPathPrefix,
     env: dbConfig.env,
     userBranch: dbConfig.userBranch,
+    devMode: dbConfig.devMode,
     jwtToken: dbConfig.jwtToken,
     localAuthMode: dbConfig.localAuthMode,
     localAuthToken: dbConfig.localAuthToken,

--- a/packages/jazz-tools/src/runtime/client.ts
+++ b/packages/jazz-tools/src/runtime/client.ts
@@ -93,10 +93,19 @@ export interface Runtime {
 export type DurabilityTier = "worker" | "edge" | "global";
 export type LocalUpdatesMode = "immediate" | "deferred";
 export type QueryPropagation = "full" | "local-only";
+export type QueryVisibility = "public" | "hidden_from_live_query_list";
 export interface QueryExecutionOptions {
   tier?: DurabilityTier;
   localUpdates?: LocalUpdatesMode;
   propagation?: QueryPropagation;
+  visibility?: QueryVisibility;
+}
+
+export interface ResolvedQueryExecutionOptions {
+  tier: DurabilityTier;
+  localUpdates: LocalUpdatesMode;
+  propagation: QueryPropagation;
+  visibility: QueryVisibility;
 }
 
 export interface WriteDurabilityOptions {
@@ -135,6 +144,39 @@ export interface QueryInput {
   _build(): string;
   /** Optional schema metadata available on generated QueryBuilder objects. */
   _schema?: WasmSchema;
+}
+
+type QueryExecutionDefaultsContext = {
+  serverUrl?: string;
+  defaultDurabilityTier?: DurabilityTier;
+};
+
+export function resolveDefaultDurabilityTier(
+  context: QueryExecutionDefaultsContext,
+): DurabilityTier {
+  if (context.defaultDurabilityTier) {
+    return context.defaultDurabilityTier;
+  }
+
+  if (isBrowserRuntime()) {
+    return "worker";
+  }
+
+  // In non-browser environments, default to edge when connected to a server.
+  // For local/in-memory runtimes without a server, keep worker semantics.
+  return context.serverUrl ? "edge" : "worker";
+}
+
+export function resolveEffectiveQueryExecutionOptions(
+  context: QueryExecutionDefaultsContext,
+  options?: QueryExecutionOptions,
+): ResolvedQueryExecutionOptions {
+  return {
+    tier: options?.tier ?? resolveDefaultDurabilityTier(context),
+    localUpdates: options?.localUpdates ?? "immediate",
+    propagation: options?.propagation ?? "full",
+    visibility: options?.visibility ?? "public",
+  };
 }
 
 type RelationIrNode = Record<string, unknown>;
@@ -299,20 +341,6 @@ function getScheduler(): (task: () => void) => void {
   }
 
   return queueMicrotask;
-}
-
-function resolveDefaultDurabilityTier(context: AppContext): DurabilityTier {
-  if (context.defaultDurabilityTier) {
-    return context.defaultDurabilityTier;
-  }
-
-  if (isBrowserRuntime()) {
-    return "worker";
-  }
-
-  // In non-browser environments, default to edge when connected to a server.
-  // For local/in-memory runtimes without a server, keep worker semantics.
-  return context.serverUrl ? "edge" : "worker";
 }
 
 function encodeQueryExecutionOptions(options: QueryExecutionOptions): string | undefined {
@@ -744,11 +772,10 @@ export class JazzClient {
   }
 
   private normalizeQueryExecutionOptions(options?: QueryExecutionOptions): QueryExecutionOptions {
-    return {
-      tier: options?.tier ?? this.defaultDurabilityTier,
-      localUpdates: options?.localUpdates ?? "immediate",
-      propagation: options?.propagation ?? "full",
-    };
+    return resolveEffectiveQueryExecutionOptions(
+      { ...this.context, defaultDurabilityTier: this.defaultDurabilityTier },
+      options,
+    );
   }
 
   private resolveWriteTier(options?: WriteDurabilityOptions): DurabilityTier {

--- a/packages/jazz-tools/src/runtime/db.dev-mode.test.ts
+++ b/packages/jazz-tools/src/runtime/db.dev-mode.test.ts
@@ -68,6 +68,7 @@ describe("Db devMode active query tracing", () => {
     expect(trace?.table).toBe("todos");
     expect(trace?.branches).toEqual(["feature-branch"]);
     expect(trace?.tier).toBe("worker");
+    expect(trace?.propagation).toBe("full");
     expect(trace?.query).toContain('"table":"todos"');
     expect(trace?.stack).toContain("Error");
     expect(observed.at(-1)).toHaveLength(1);
@@ -94,9 +95,13 @@ describe("Db devMode active query tracing", () => {
 
   it("records explicit tier overrides", async () => {
     const db = await makeDb(true);
-    const unsubscribe = db.subscribeAll(makeQuery(), () => undefined, { tier: "edge" });
+    const unsubscribe = db.subscribeAll(makeQuery(), () => undefined, {
+      tier: "edge",
+      propagation: "local-only",
+    });
 
     expect(db.getActiveQuerySubscriptions()[0]?.tier).toBe("edge");
+    expect(db.getActiveQuerySubscriptions()[0]?.propagation).toBe("local-only");
 
     unsubscribe();
   });

--- a/packages/jazz-tools/src/runtime/db.dev-mode.test.ts
+++ b/packages/jazz-tools/src/runtime/db.dev-mode.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createDb, type Db, type QueryBuilder } from "./db.js";
+import type { WasmSchema } from "../drivers/types.js";
+
+const schema: WasmSchema = {
+  todos: {
+    columns: [{ name: "title", column_type: { type: "Text" }, nullable: false }],
+  },
+};
+
+function makeQuery(): QueryBuilder<{ id: string; title: string }> {
+  return {
+    _table: "todos",
+    _schema: schema,
+    _rowType: {} as { id: string; title: string },
+    _build() {
+      return JSON.stringify({
+        table: "todos",
+        conditions: [],
+        includes: {},
+        orderBy: [],
+      });
+    },
+  };
+}
+
+const dbs: Db[] = [];
+
+afterEach(async () => {
+  while (dbs.length > 0) {
+    const db = dbs.pop();
+    if (db) {
+      await db.shutdown();
+    }
+  }
+});
+
+async function makeDb(devMode?: boolean, userBranch?: string): Promise<Db> {
+  const db = await createDb({
+    appId: `dev-mode-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    devMode,
+    userBranch,
+  });
+  dbs.push(db);
+  return db;
+}
+
+describe("Db devMode active query tracing", () => {
+  it("does not expose traces when devMode is disabled", async () => {
+    const db = await makeDb(false);
+    const unsubscribe = db.subscribeAll(makeQuery(), () => undefined);
+
+    expect(db.getActiveQuerySubscriptions()).toEqual([]);
+
+    unsubscribe();
+  });
+
+  it("tracks visible subscriptions with default metadata and cleanup", async () => {
+    const db = await makeDb(true, "feature-branch");
+    const observed: Array<ReturnType<Db["getActiveQuerySubscriptions"]>> = [];
+    const stop = db.onActiveQuerySubscriptionsChange((traces) => {
+      observed.push(traces.map((trace) => ({ ...trace })));
+    });
+
+    const unsubscribe = db.subscribeAll(makeQuery(), () => undefined);
+    const [trace] = db.getActiveQuerySubscriptions();
+
+    expect(trace?.table).toBe("todos");
+    expect(trace?.branches).toEqual(["feature-branch"]);
+    expect(trace?.tier).toBe("worker");
+    expect(trace?.query).toContain('"table":"todos"');
+    expect(trace?.stack).toContain("Error");
+    expect(observed.at(-1)).toHaveLength(1);
+
+    unsubscribe();
+
+    expect(db.getActiveQuerySubscriptions()).toEqual([]);
+    expect(observed.at(-1)).toEqual([]);
+
+    stop();
+  });
+
+  it("filters hidden subscriptions out of the inspector list", async () => {
+    const db = await makeDb(true);
+
+    const unsubscribe = db.subscribeAll(makeQuery(), () => undefined, {
+      visibility: "hidden_from_live_query_list",
+    });
+
+    expect(db.getActiveQuerySubscriptions()).toEqual([]);
+
+    unsubscribe();
+  });
+
+  it("records explicit tier overrides", async () => {
+    const db = await makeDb(true);
+    const unsubscribe = db.subscribeAll(makeQuery(), () => undefined, { tier: "edge" });
+
+    expect(db.getActiveQuerySubscriptions()[0]?.tier).toBe("edge");
+
+    unsubscribe();
+  });
+
+  it("clears traces on shutdown", async () => {
+    const db = await makeDb(true);
+    const observed: Array<ReturnType<Db["getActiveQuerySubscriptions"]>> = [];
+    const stop = db.onActiveQuerySubscriptionsChange((traces) => {
+      observed.push(traces.map((trace) => ({ ...trace })));
+    });
+
+    db.subscribeAll(makeQuery(), () => undefined);
+    await db.shutdown();
+    dbs.splice(dbs.indexOf(db), 1);
+
+    expect(db.getActiveQuerySubscriptions()).toEqual([]);
+    expect(observed.at(-1)).toEqual([]);
+
+    stop();
+  });
+});

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -21,6 +21,8 @@ import {
   type DurabilityTier,
   type QueryExecutionOptions,
   type QueryPropagation,
+  type QueryVisibility,
+  resolveEffectiveQueryExecutionOptions,
 } from "./client.js";
 import { WorkerBridge, type PeerSyncBatch, type WorkerBridgeOptions } from "./worker-bridge.js";
 import { translateQuery } from "./query-adapter.js";
@@ -77,6 +79,8 @@ export interface DbConfig {
   dbName?: string;
   /** Optional WASM tracing level for benchmark/debug scenarios (default: "warn"). */
   logLevel?: WasmLogLevel;
+  /** Enable runtime tracing for DevTools-only diagnostics. */
+  devMode?: boolean;
 }
 
 function resolveStorageDriver(driver?: StorageDriver): StorageDriver {
@@ -100,6 +104,68 @@ export interface QueryBuilder<T> {
 
 export interface QueryOptions extends QueryExecutionOptions {
   propagation?: QueryPropagation;
+}
+
+export interface ActiveQuerySubscriptionTrace {
+  id: string;
+  query: string;
+  table: string;
+  branches: string[];
+  tier: DurabilityTier;
+  createdAt: string;
+  stack?: string;
+}
+
+type ActiveQuerySubscriptionTraceListener = (
+  traces: readonly ActiveQuerySubscriptionTrace[],
+) => void;
+
+type StoredActiveQuerySubscriptionTrace = ActiveQuerySubscriptionTrace & {
+  visibility: QueryVisibility;
+};
+
+type RuntimeQueryTracePayload = {
+  table: string;
+  branches: string[];
+};
+
+function trimSubscriptionTraceStack(stack: string | undefined): string | undefined {
+  if (!stack) {
+    return stack;
+  }
+
+  const lines = stack.split("\n");
+  if (lines.length <= 1) {
+    return stack;
+  }
+
+  const isInternalFrame = (line: string): boolean => {
+    return (
+      line.includes("Db.registerActiveQuerySubscriptionTrace") ||
+      line.includes("Db.subscribeAll") ||
+      line.includes("SubscriptionsOrchestrator.ensureEntryForKey") ||
+      line.includes("SubscriptionsOrchestrator.getCacheEntry") ||
+      line.includes("/node_modules/") ||
+      line.includes("react-dom") ||
+      line.includes("react_stack_bottom_frame")
+    );
+  };
+
+  const firstOriginIndex = lines.findIndex((line, index) => index > 0 && !isInternalFrame(line));
+  if (firstOriginIndex <= 0) {
+    return stack;
+  }
+
+  return [lines[0], ...lines.slice(firstOriginIndex)].join("\n");
+}
+
+function cloneActiveQuerySubscriptionTrace(
+  trace: ActiveQuerySubscriptionTrace,
+): ActiveQuerySubscriptionTrace {
+  return {
+    ...trace,
+    branches: [...trace.branches],
+  };
 }
 
 function resolveHopOutputTable(
@@ -283,6 +349,13 @@ export class Db {
   private workerReconfigure: Promise<void> = Promise.resolve();
   private isShuttingDown = false;
   private lifecycleHooksAttached = false;
+  private readonly activeQuerySubscriptionTraces = new Map<
+    string,
+    StoredActiveQuerySubscriptionTrace
+  >();
+  private readonly activeQuerySubscriptionTraceListeners =
+    new Set<ActiveQuerySubscriptionTraceListener>();
+  private nextActiveQuerySubscriptionTraceId = 1;
   private readonly onSyncChannelMessage = (event: MessageEvent): void => {
     this.handleSyncChannelMessage(event.data);
   };
@@ -879,6 +952,20 @@ export class Db {
     return structuredClone(this.config);
   }
 
+  getActiveQuerySubscriptions(): ActiveQuerySubscriptionTrace[] {
+    return Array.from(this.activeQuerySubscriptionTraces.values())
+      .filter((trace) => trace.visibility === "public")
+      .map(({ visibility: _visibility, ...trace }) => cloneActiveQuerySubscriptionTrace(trace));
+  }
+
+  onActiveQuerySubscriptionsChange(listener: ActiveQuerySubscriptionTraceListener): () => void {
+    this.activeQuerySubscriptionTraceListeners.add(listener);
+    listener(this.getActiveQuerySubscriptions());
+    return () => {
+      this.activeQuerySubscriptionTraceListeners.delete(listener);
+    };
+  }
+
   /**
    * Insert a new row into a table without waiting for durability.
    *
@@ -1133,9 +1220,11 @@ export class Db {
       session,
       options,
     );
+    const traceId = this.registerActiveQuerySubscriptionTrace(wasmQuery, builtQuery.table, options);
 
     // Return unsubscribe function
     return () => {
+      this.unregisterActiveQuerySubscriptionTrace(traceId);
       client.unsubscribe(subId);
       manager.clear();
     };
@@ -1147,6 +1236,7 @@ export class Db {
    */
   async shutdown(): Promise<void> {
     this.isShuttingDown = true;
+    this.clearActiveQuerySubscriptionTraces();
     this.logLeaderDebug("shutdown");
     this.sendFollowerClose(this.activeRemoteLeaderTabId, this.currentLeaderTerm);
     this.activeRemoteLeaderTabId = null;
@@ -1183,6 +1273,86 @@ export class Db {
     if (this.worker) {
       this.worker.terminate();
       this.worker = null;
+    }
+  }
+
+  private notifyActiveQuerySubscriptionTraceListeners(): void {
+    if (this.activeQuerySubscriptionTraceListeners.size === 0) {
+      return;
+    }
+
+    const snapshot = this.getActiveQuerySubscriptions();
+    for (const listener of this.activeQuerySubscriptionTraceListeners) {
+      listener(snapshot);
+    }
+  }
+
+  private registerActiveQuerySubscriptionTrace(
+    queryJson: string,
+    fallbackTable: string,
+    options?: QueryOptions,
+  ): string | null {
+    if (this.config.devMode === false) {
+      return null;
+    }
+
+    const resolvedOptions = resolveEffectiveQueryExecutionOptions(this.config, options);
+    const payload = this.parseRuntimeQueryTracePayload(queryJson, fallbackTable);
+    const traceId = `sub-${this.nextActiveQuerySubscriptionTraceId++}`;
+
+    this.activeQuerySubscriptionTraces.set(traceId, {
+      id: traceId,
+      query: queryJson,
+      table: payload.table,
+      branches: payload.branches,
+      tier: resolvedOptions.tier,
+      createdAt: new Date().toISOString(),
+      stack: trimSubscriptionTraceStack(new Error().stack),
+      visibility: resolvedOptions.visibility ?? "public",
+    });
+    this.notifyActiveQuerySubscriptionTraceListeners();
+
+    return traceId;
+  }
+
+  private unregisterActiveQuerySubscriptionTrace(traceId: string | null): void {
+    if (!traceId) {
+      return;
+    }
+    if (!this.activeQuerySubscriptionTraces.delete(traceId)) {
+      return;
+    }
+    this.notifyActiveQuerySubscriptionTraceListeners();
+  }
+
+  private clearActiveQuerySubscriptionTraces(): void {
+    if (this.activeQuerySubscriptionTraces.size === 0) {
+      return;
+    }
+    this.activeQuerySubscriptionTraces.clear();
+    this.notifyActiveQuerySubscriptionTraceListeners();
+  }
+
+  private parseRuntimeQueryTracePayload(
+    queryJson: string,
+    fallbackTable: string,
+  ): RuntimeQueryTracePayload {
+    try {
+      const parsed = JSON.parse(queryJson) as { table?: unknown; branches?: unknown };
+      const table = typeof parsed.table === "string" ? parsed.table : fallbackTable;
+      const branches = Array.isArray(parsed.branches)
+        ? parsed.branches.filter((branch): branch is string => typeof branch === "string")
+        : [];
+
+      return {
+        table,
+        branches: branches.length > 0 ? branches : [this.config.userBranch ?? "main"],
+      };
+    } catch {
+      return {
+        table: fallbackTable,
+        branches: [this.config.userBranch ?? "main"],
+      };
     }
   }
 }

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -112,6 +112,7 @@ export interface ActiveQuerySubscriptionTrace {
   table: string;
   branches: string[];
   tier: DurabilityTier;
+  propagation: QueryPropagation;
   createdAt: string;
   stack?: string;
 }
@@ -1306,6 +1307,7 @@ export class Db {
       table: payload.table,
       branches: payload.branches,
       tier: resolvedOptions.tier,
+      propagation: resolvedOptions.propagation,
       createdAt: new Date().toISOString(),
       stack: trimSubscriptionTraceStack(new Error().stack),
       visibility: resolvedOptions.visibility ?? "public",

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -953,6 +953,10 @@ export class Db {
     return structuredClone(this.config);
   }
 
+  setDevMode(enabled: boolean): void {
+    this.config.devMode = enabled;
+  }
+
   getActiveQuerySubscriptions(): ActiveQuerySubscriptionTrace[] {
     return Array.from(this.activeQuerySubscriptionTraces.values())
       .filter((trace) => trace.visibility === "public")

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -1297,7 +1297,7 @@ export class Db {
     fallbackTable: string,
     options?: QueryOptions,
   ): string | null {
-    if (this.config.devMode === false) {
+    if (!this.config.devMode) {
       return null;
     }
 

--- a/packages/jazz-tools/src/runtime/index.ts
+++ b/packages/jazz-tools/src/runtime/index.ts
@@ -9,6 +9,7 @@ export {
   type QueryExecutionOptions,
   type QueryInput,
   type QueryPropagation,
+  type QueryVisibility,
   type RequestLike,
   type Row,
   type Runtime,
@@ -21,6 +22,7 @@ export { linkExternalIdentity, type LinkExternalResponse } from "./sync-transpor
 export {
   createDb,
   Db,
+  type ActiveQuerySubscriptionTrace,
   type DbConfig,
   type QueryBuilder,
   type QueryOptions,

--- a/packages/jazz-tools/src/runtime/index.ts
+++ b/packages/jazz-tools/src/runtime/index.ts
@@ -35,6 +35,12 @@ export {
   fetchStoredWasmSchema,
   type FetchStoredWasmSchemaOptions,
 } from "./schema-fetch.js";
+export {
+  fetchServerSubscriptions,
+  type FetchServerSubscriptionsOptions,
+  type IntrospectionSubscriptionGroup,
+  type IntrospectionSubscriptionResponse,
+} from "./introspection-fetch.js";
 export { resolveLocalAuthDefaults } from "./local-auth.js";
 export { translateQuery } from "./query-adapter.js";
 export { transformRows, unwrapValue, type WasmValue } from "./row-transformer.js";

--- a/packages/jazz-tools/src/runtime/introspection-fetch.ts
+++ b/packages/jazz-tools/src/runtime/introspection-fetch.ts
@@ -1,0 +1,55 @@
+import type { QueryPropagation } from "./client.js";
+import { buildEndpointUrl } from "./sync-transport.js";
+
+export interface IntrospectionSubscriptionGroup {
+  groupKey: string;
+  count: number;
+  table: string;
+  query: string;
+  branches: string[];
+  propagation: QueryPropagation;
+}
+
+export interface IntrospectionSubscriptionResponse {
+  appId: string;
+  generatedAt: number;
+  queries: IntrospectionSubscriptionGroup[];
+}
+
+export interface FetchServerSubscriptionsOptions {
+  adminSecret: string;
+  appId: string;
+  pathPrefix?: string;
+}
+
+export async function fetchServerSubscriptions(
+  serverUrl: string,
+  options: FetchServerSubscriptionsOptions,
+): Promise<IntrospectionSubscriptionResponse> {
+  const subscriptionsUrl = new URL(
+    buildEndpointUrl(serverUrl, "/admin/introspection/subscriptions", options.pathPrefix),
+  );
+  subscriptionsUrl.searchParams.set("appId", options.appId);
+
+  const response = await fetch(subscriptionsUrl.toString(), {
+    method: "GET",
+    headers: {
+      "X-Jazz-Admin-Secret": options.adminSecret,
+    },
+  });
+
+  if (!response.ok) {
+    const bodyText = await response.text().catch(() => "");
+    const detail = bodyText ? ` - ${bodyText}` : "";
+    throw new Error(
+      `Server subscriptions fetch failed: ${response.status} ${response.statusText}${detail}`,
+    );
+  }
+
+  const payload = (await response.json()) as Partial<IntrospectionSubscriptionResponse>;
+  return {
+    appId: typeof payload.appId === "string" ? payload.appId : "",
+    generatedAt: typeof payload.generatedAt === "number" ? payload.generatedAt : 0,
+    queries: Array.isArray(payload.queries) ? payload.queries : [],
+  };
+}

--- a/packages/jazz-tools/src/runtime/schema-fetch.test.ts
+++ b/packages/jazz-tools/src/runtime/schema-fetch.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { fetchSchemaHashes, fetchStoredWasmSchema } from "./schema-fetch.js";
+import { fetchServerSubscriptions } from "./introspection-fetch.js";
 
 describe("schema-fetch", () => {
   const originalFetch = globalThis.fetch;
@@ -99,6 +100,67 @@ describe("schema-fetch", () => {
 
     expect(fetchMock.mock.calls[0][0]).toBe(
       "http://localhost:1625/schema/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    );
+  });
+
+  it("fetches grouped server subscriptions with admin secret and app id", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: async () => ({
+        appId: "app-123",
+        generatedAt: 1741600800000,
+        queries: [
+          {
+            groupKey: "group-1",
+            count: 2,
+            table: "todos",
+            query: '{"table":"todos"}',
+            branches: ["main"],
+            propagation: "full",
+          },
+        ],
+      }),
+    });
+    (globalThis as { fetch: typeof fetch }).fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await fetchServerSubscriptions("http://localhost:1625/", {
+      adminSecret: "admin-secret",
+      appId: "test-app",
+      pathPrefix: "/apps/app-123",
+    });
+
+    expect(result.appId).toBe("app-123");
+    expect(result.queries).toHaveLength(1);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      "http://localhost:1625/apps/app-123/admin/introspection/subscriptions?appId=test-app",
+    );
+    expect(fetchMock.mock.calls[0][1]).toMatchObject({
+      method: "GET",
+      headers: {
+        "X-Jazz-Admin-Secret": "admin-secret",
+      },
+    });
+  });
+
+  it("throws a descriptive error when server subscription fetch fails", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      statusText: "Unauthorized",
+      text: async () => '{"error":"bad secret"}',
+    });
+    (globalThis as { fetch: typeof fetch }).fetch = fetchMock as unknown as typeof fetch;
+
+    await expect(
+      fetchServerSubscriptions("http://localhost:1625", {
+        adminSecret: "wrong-secret",
+        appId: "test-app",
+      }),
+    ).rejects.toThrow(
+      'Server subscriptions fetch failed: 401 Unauthorized - {"error":"bad secret"}',
     );
   });
 });


### PR DESCRIPTION
## Summary

This adds the first live-query introspection slice from the database viewer/editor MVP, split into two separate features:

- **In-app active subscriptions**: the DevTools / in-app inspector can now show the client runtime’s currently active query subscriptions, including table, branches, tier, propagation mode, and trace metadata for debugging.
- **Server subscriptions**: the standalone inspector can now poll a new admin introspection endpoint and display grouped active server-managed subscriptions for a given app.

## Notes

Server subscription introspection currently reflects the existing `server_subscriptions` lifecycle on the server. Those subscriptions are **not cleaned up on client disconnect yet**, so they can remain visible longer than they should. That is a known limitation and is expected to be fixed as part of [query_subscription_disconnect_cleanup.md](https://github.com/garden-co/jazz2/tree/feat/introspection-active-queries/specs/todo/a_mvp/query_subscription_disconnect_cleanup.md).
