### PR TITLE
feat: spin standalone inspector with server command

### DIFF
--- a/.changeset/inspector-cli-packaging.md
+++ b/.changeset/inspector-cli-packaging.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Add first-class inspector CLI support in `jazz-tools` and package the standalone inspector build in npm artifacts. Introduces `jazz-tools inspector` (default port `8625`) and `jazz-tools server --inspector` for serving the UI on the server port at `/_inspector`.

--- a/.github/workflows/publish-jazz-tools-alpha.yml
+++ b/.github/workflows/publish-jazz-tools-alpha.yml
@@ -857,6 +857,9 @@ jobs:
       - name: Build jazz-tools TypeScript package
         run: pnpm --filter jazz-tools build
 
+      - name: Build inspector standalone web bundle
+        run: pnpm --filter inspector build:standalone
+
       - name: Verify jazz-tools publish artifacts
         run: |
           test -f packages/jazz-tools/dist/index.js
@@ -864,6 +867,14 @@ jobs:
           test -f packages/jazz-tools/dist/backend/index.js
           test -f packages/jazz-tools/dist/react/index.js
           test -f packages/jazz-tools/dist/permissions/index.js
+
+      - name: Stage inspector bundle into npm package
+        run: |
+          rm -rf packages/jazz-tools/dist/inspector
+          mkdir -p packages/jazz-tools/dist
+          cp -R packages/inspector/dist packages/jazz-tools/dist/inspector
+          test -f packages/jazz-tools/dist/inspector/index.html
+          test -d packages/jazz-tools/dist/inspector/assets
 
       - name: Stage binaries into npm package
         run: |
@@ -972,6 +983,10 @@ jobs:
           node "${EXTRACT_DIR}/package/bin/jazz-tools.js" --help >/dev/null
           test -x "${EXTRACT_DIR}/package/bin/native/${HOST_LINUX_BIN}" || {
             echo "Packed native binary ${HOST_LINUX_BIN} is not executable after runtime bootstrap."
+            exit 1
+          }
+          test -f "${EXTRACT_DIR}/package/dist/inspector/index.html" || {
+            echo "Missing packed inspector index.html"
             exit 1
           }
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1359,6 +1359,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range-header"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9171a2ea8a68358193d15dd5d70c1c10a2afc3e7e4c5bc92bc9f025cebd7359c"
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2050,6 +2056,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "minicov"
@@ -3828,10 +3844,18 @@ checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
 dependencies = [
  "bitflags 2.11.0",
  "bytes",
+ "futures-util",
  "http",
  "http-body",
  "http-body-util",
+ "http-range-header",
+ "httpdate",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -3988,6 +4012,12 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-general-category"

--- a/crates/jazz-tools/Cargo.toml
+++ b/crates/jazz-tools/Cargo.toml
@@ -75,7 +75,7 @@ axum = { version = "0.7", optional = true }
 bytes = { version = "1", optional = true }
 clap = { version = "4", features = ["derive", "env"], optional = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = true }
-tower-http = { version = "0.5", features = ["cors", "trace"], optional = true }
+tower-http = { version = "0.5", features = ["cors", "trace", "fs"], optional = true }
 async-stream = { version = "0.3", optional = true }
 jsonwebtoken = { version = "9", optional = true }
 base64 = { version = "0.22", optional = true }

--- a/crates/jazz-tools/src/commands/server.rs
+++ b/crates/jazz-tools/src/commands/server.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashMap;
 use std::net::SocketAddr;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -214,12 +214,19 @@ pub async fn run(
     port: u16,
     data_dir: &str,
     mut auth_config: AuthConfig,
+    inspector_assets_dir: Option<String>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     // Parse app ID
     let app_id = AppId::from_string(app_id_str)?;
 
     info!("Starting Jazz server for app: {}", app_id);
     info!("Data directory: {}", data_dir);
+
+    let inspector_assets_dir = resolve_inspector_assets_dir(inspector_assets_dir)?;
+    if let Some(path) = &inspector_assets_dir {
+        info!("Inspector enabled at /_inspector");
+        info!("Inspector assets directory: {}", path.display());
+    }
 
     // Create data directory if it doesn't exist
     std::fs::create_dir_all(data_dir)?;
@@ -304,7 +311,7 @@ pub async fn run(
     });
 
     // Build router
-    let app = routes::create_router(state);
+    let app = routes::create_router(state, inspector_assets_dir);
 
     // Start server
     let addr = SocketAddr::from(([0, 0, 0, 0], port));
@@ -321,4 +328,57 @@ fn now_timestamp_us() -> u64 {
         Ok(duration) => duration.as_micros().min(u128::from(u64::MAX)) as u64,
         Err(_) => 0,
     }
+}
+
+pub fn resolve_inspector_assets_dir(
+    inspector_assets_dir: Option<String>,
+) -> Result<Option<PathBuf>, Box<dyn std::error::Error>> {
+    let inspector_assets_dir: Option<PathBuf> = match inspector_assets_dir {
+        Some(dir) => {
+            let path = PathBuf::from(dir);
+            if !path.exists() {
+                return Err(format!(
+                    "Inspector assets directory does not exist: {}",
+                    path.display()
+                )
+                .into());
+            }
+            let index_path = path.join("index.html");
+            if !index_path.exists() {
+                return Err(format!(
+                    "Inspector assets missing index.html: {}",
+                    index_path.display()
+                )
+                .into());
+            }
+            Some(path)
+        }
+        None => None,
+    };
+    Ok(inspector_assets_dir)
+}
+
+/// Run only the standalone inspector UI static server.
+pub async fn run_inspector(
+    port: u16,
+    host: &str,
+    inspector_assets_dir: Option<String>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let inspector_assets_dir = resolve_inspector_assets_dir(inspector_assets_dir)?
+        .ok_or("Inspector assets directory is required to run inspector")?;
+
+    info!("Starting standalone inspector");
+    info!(
+        "Inspector assets directory: {}",
+        inspector_assets_dir.display()
+    );
+
+    let app = routes::create_inspector_router(inspector_assets_dir);
+
+    let bind_addr = format!("{host}:{port}");
+    let listener = tokio::net::TcpListener::bind(&bind_addr).await?;
+    info!("Inspector listening on http://{}", bind_addr);
+    info!("Inspector URL: http://{}/_inspector/", bind_addr);
+    axum::serve(listener, app).await?;
+    Ok(())
 }

--- a/crates/jazz-tools/src/main.rs
+++ b/crates/jazz-tools/src/main.rs
@@ -4,7 +4,8 @@
 //!
 //! ```text
 //! jazz-tools create app [--name <NAME>]    # Returns AppId (random or deterministic from name)
-//! jazz-tools server <APP_ID> [--port 1625] [--data-dir ./data] [--in-memory]
+//! jazz-tools server <APP_ID> [--port 1625] [--data-dir ./data] [--in-memory] [--inspector]
+//! jazz-tools inspector [--port 8625] [--host 127.0.0.1]
 //! ```
 
 mod commands;
@@ -121,6 +122,32 @@ enum Commands {
         /// Secret for admin operations (schema/policy sync)
         #[arg(long, env = "JAZZ_ADMIN_SECRET")]
         admin_secret: Option<String>,
+
+        /// Serve the standalone inspector UI at /_inspector.
+        #[arg(long)]
+        inspector: bool,
+
+        /// Path to built inspector assets directory.
+        ///
+        /// Intended for the npm launcher to pass staged assets.
+        #[arg(long, env = "JAZZ_INSPECTOR_ASSETS_DIR", hide = true)]
+        inspector_assets_dir: Option<String>,
+    },
+    /// Run standalone inspector UI without starting sync server
+    Inspector {
+        /// Port to listen on
+        #[arg(short, long, default_value = "8625")]
+        port: u16,
+
+        /// Host/interface to bind
+        #[arg(long, default_value = "127.0.0.1")]
+        host: String,
+
+        /// Path to built inspector assets directory.
+        ///
+        /// Intended for the npm launcher to pass staged assets.
+        #[arg(long, env = "JAZZ_INSPECTOR_ASSETS_DIR", hide = true)]
+        inspector_assets_dir: Option<String>,
     },
 }
 
@@ -185,6 +212,8 @@ async fn main() {
             allow_demo,
             backend_secret,
             admin_secret,
+            inspector,
+            inspector_assets_dir,
         } => {
             let data_dir = if in_memory {
                 let tmp =
@@ -215,8 +244,29 @@ async fn main() {
                 backend_secret,
                 admin_secret,
             };
-            if let Err(e) = commands::server::run(&app_id, port, &data_dir, auth_config).await {
+            if let Err(e) = commands::server::run(
+                &app_id,
+                port,
+                &data_dir,
+                auth_config,
+                inspector.then_some(inspector_assets_dir).flatten(),
+            )
+            .await
+            {
                 eprintln!("Server error: {}", e);
+                shutdown_tracing();
+                std::process::exit(1);
+            }
+            shutdown_tracing();
+        }
+        Commands::Inspector {
+            port,
+            host,
+            inspector_assets_dir,
+        } => {
+            if let Err(e) = commands::server::run_inspector(port, &host, inspector_assets_dir).await
+            {
+                eprintln!("Inspector error: {}", e);
                 shutdown_tracing();
                 std::process::exit(1);
             }

--- a/crates/jazz-tools/src/routes.rs
+++ b/crates/jazz-tools/src/routes.rs
@@ -1,5 +1,6 @@
 //! HTTP routes for the Jazz server.
 
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -7,7 +8,7 @@ use axum::{
     Router,
     extract::{Path, Query, State},
     http::{HeaderMap, StatusCode, header::AUTHORIZATION},
-    response::{IntoResponse, Json},
+    response::{IntoResponse, Json, Redirect},
     routing::{get, post},
 };
 use bytes::Bytes;
@@ -17,6 +18,7 @@ use jazz_tools::jazz_transport::{
 use jazz_tools::sync_manager::ClientId;
 use serde::{Deserialize, Serialize};
 use tower_http::cors::CorsLayer;
+use tower_http::services::{ServeDir, ServeFile};
 use tower_http::trace::TraceLayer;
 
 use crate::commands::server::{ConnectionState, ServerState};
@@ -27,8 +29,26 @@ use crate::middleware::auth::{
 use jazz_tools::query_manager::types::SchemaHash;
 use jazz_tools::schema_manager::AppId;
 
+fn mount_inspector_routes<S>(router: Router<S>, inspector_assets_dir: Option<PathBuf>) -> Router<S>
+where
+    S: Clone + Send + Sync + 'static,
+{
+    if let Some(assets_dir) = inspector_assets_dir {
+        let index = assets_dir.join("index.html");
+        let inspector_service = ServeDir::new(assets_dir)
+            .append_index_html_on_directories(true)
+            .fallback(ServeFile::new(index));
+        router
+            .route("/", get(inspector_redirect_handler))
+            .route("/_inspector", get(inspector_redirect_handler))
+            .nest_service("/_inspector/", inspector_service)
+    } else {
+        router
+    }
+}
+
 /// Create the router with all routes.
-pub fn create_router(state: Arc<ServerState>) -> Router {
+pub fn create_router(state: Arc<ServerState>, inspector_assets_dir: Option<PathBuf>) -> Router {
     let traced_routes = Router::new()
         .route("/sync", post(sync_handler))
         .route("/schema/:hash", get(schema_handler))
@@ -43,11 +63,28 @@ pub fn create_router(state: Arc<ServerState>) -> Router {
         .route("/health", get(health_handler))
         .layer(TraceLayer::new_for_http());
 
-    Router::new()
+    let mut router = Router::new()
         .route("/events", get(events_handler))
         .merge(traced_routes)
-        .layer(CorsLayer::permissive())
-        .with_state(state)
+        .layer(CorsLayer::permissive());
+
+    router = mount_inspector_routes(router, inspector_assets_dir);
+
+    router.with_state(state)
+}
+
+/// Create a router for running only the standalone inspector UI.
+pub fn create_inspector_router(inspector_assets_dir: PathBuf) -> Router {
+    mount_inspector_routes(
+        Router::new()
+            .layer(CorsLayer::permissive())
+            .layer(TraceLayer::new_for_http()),
+        Some(inspector_assets_dir),
+    )
+}
+
+async fn inspector_redirect_handler() -> impl IntoResponse {
+    Redirect::temporary("/_inspector/")
 }
 
 /// Query parameters for events endpoint.

--- a/packages/inspector/package.json
+++ b/packages/inspector/package.json
@@ -5,8 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && pnpm run build:web && pnpm run build:extension",
-    "build:web": "vite build --mode web",
+    "build:standalone": "vite build --mode standalone",
     "build:extension": "vite build --mode extension",
     "preview": "vite preview",
     "test": "vitest run --config vitest.config.ts",

--- a/packages/inspector/src/App.tsx
+++ b/packages/inspector/src/App.tsx
@@ -209,7 +209,7 @@ export default function App() {
             serverPathPrefix: storedConfig.serverPathPrefix,
           }}
         >
-          <BrowserRouter>
+          <BrowserRouter basename={import.meta.env.BASE_URL}>
             <InspectorRoutes />
           </BrowserRouter>
         </StandaloneProvider>

--- a/packages/inspector/vite.config.ts
+++ b/packages/inspector/vite.config.ts
@@ -4,10 +4,11 @@ import react from "@vitejs/plugin-react-swc";
 
 export default defineConfig(({ mode }) => {
   const isExtensionBuild = mode === "extension";
+  const isStandaloneBuild = mode === "standalone";
 
   return {
     plugins: [react()],
-    base: isExtensionBuild ? "./" : "/",
+    base: isExtensionBuild ? "./" : isStandaloneBuild ? "/_inspector/" : "/",
     publicDir: isExtensionBuild ? "chrome-extension" : "public",
     worker: {
       format: "es",

--- a/packages/jazz-tools/README.md
+++ b/packages/jazz-tools/README.md
@@ -8,6 +8,18 @@ CLI package for Jazz 2.
 npx jazz-tools@alpha server
 ```
 
+Run with bundled standalone inspector:
+
+```bash
+npx jazz-tools@alpha server <APP_ID> --inspector
+```
+
+Run inspector as a standalone process (without running the sync server):
+
+```bash
+npx jazz-tools@alpha inspector --port 8625
+```
+
 To use a specific prerelease:
 
 ```bash


### PR DESCRIPTION
## Summary
- Add inspector serving support to `jazz-tools` with two modes:
  - `jazz-tools inspector` to run the standalone inspector process (default port `8625`)
  - `jazz-tools server --inspector` to mount inspector on the same server at `/_inspector`
- Package inspector web assets into the `jazz-tools` npm artifact so inspector works out of the box.


## CLI changes
- Add `inspector` Rust subcommand with:
  - `--port` (default `8625`)
  - `--host` (default `127.0.0.1`)
- Add `server --inspector` option