### PR TITLE
chore: ignore formats in benchmark's json

### DIFF
--- a/.oxfmtignore
+++ b/.oxfmtignore
@@ -7,3 +7,4 @@ examples/*/schema/app.ts
 examples/docs/*/schema/app.ts
 crates/jazz-napi/index.d.ts
 crates/jazz-napi/index.js
+benchmarks/**/*.json

--- a/.oxfmtignore
+++ b/.oxfmtignore
@@ -8,3 +8,4 @@ examples/docs/*/schema/app.ts
 crates/jazz-napi/index.d.ts
 crates/jazz-napi/index.js
 benchmarks/**/*.json
+benchmarks/**/*.html

--- a/.oxlintignore
+++ b/.oxlintignore
@@ -4,3 +4,4 @@ examples/docs/*/schema/app.ts
 crates/jazz-napi/index.d.ts
 crates/jazz-napi/index.js
 benchmarks/**/*.json
+benchmarks/**/*.html

--- a/.oxlintignore
+++ b/.oxlintignore
@@ -3,3 +3,4 @@ examples/*/schema/app.ts
 examples/docs/*/schema/app.ts
 crates/jazz-napi/index.d.ts
 crates/jazz-napi/index.js
+benchmarks/**/*.json


### PR DESCRIPTION
Like #282, but better