### PR TITLE
Fix benchmark PR comment github-script core redeclaration

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -580,7 +580,6 @@ jobs:
           REPORT_PATH: bench-out/pr-report.md
         with:
           script: |
-            const core = require("@actions/core");
             const fs = require("fs");
             const marker = "<!-- realistic-bench-report -->";
             const body = `${marker}\n${fs.readFileSync(process.env.REPORT_PATH, "utf8")}`;


### PR DESCRIPTION
## Summary
- remove the local `core` require from the benchmark PR comment `actions/github-script@v7` step
- keep using the injected `core` object provided by `github-script`
- fix the SyntaxError that breaks the benchmark workflow on pull requests

## Verification
- `git diff --check`
- local AsyncFunction parse check for the patched github-script body