### PR TITLE
fix: allow query builders with select in generated include types

### DIFF
--- a/.changeset/late-jobs-show.md
+++ b/.changeset/late-jobs-show.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Improve type inference for `include` and `select` in TS queries

--- a/examples/docs/todo-client-localfirst-react/schema/app.ts
+++ b/examples/docs/todo-client-localfirst-react/schema/app.ts
@@ -48,15 +48,66 @@ export interface TodoWhereInput {
   project?: string | { eq?: string; ne?: string; isNull?: boolean };
 }
 
+type AnyProjectQueryBuilder<T = any> = { readonly _table: "projects" } & QueryBuilder<T>;
+type AnyTodoQueryBuilder<T = any> = { readonly _table: "todos" } & QueryBuilder<T>;
+
 export interface ProjectInclude {
-  todosViaProject?: true | TodoInclude | TodoQueryBuilder<any, any>;
+  todosViaProject?: true | TodoInclude | AnyTodoQueryBuilder<any>;
 }
 
 export interface TodoInclude {
-  parent?: true | TodoInclude | TodoQueryBuilder<any, any>;
-  todosViaParent?: true | TodoInclude | TodoQueryBuilder<any, any>;
-  project?: true | ProjectInclude | ProjectQueryBuilder<any, any>;
+  parent?: true | TodoInclude | AnyTodoQueryBuilder<any>;
+  todosViaParent?: true | TodoInclude | AnyTodoQueryBuilder<any>;
+  project?: true | ProjectInclude | AnyProjectQueryBuilder<any>;
 }
+
+export type ProjectIncludedRelations<I extends ProjectInclude = {}> = {
+  [K in keyof I]-?: K extends "todosViaProject"
+    ? NonNullable<I["todosViaProject"]> extends infer RelationInclude
+      ? RelationInclude extends true
+        ? Todo[]
+        : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
+          ? QueryRow[]
+          : RelationInclude extends TodoInclude
+            ? TodoWithIncludes<RelationInclude>[]
+            : never
+      : never
+    : never;
+};
+
+export type TodoIncludedRelations<I extends TodoInclude = {}> = {
+  [K in keyof I]-?: K extends "parent"
+    ? NonNullable<I["parent"]> extends infer RelationInclude
+      ? RelationInclude extends true
+        ? Todo
+        : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
+          ? QueryRow
+          : RelationInclude extends TodoInclude
+            ? TodoWithIncludes<RelationInclude>
+            : never
+      : never
+    : K extends "todosViaParent"
+      ? NonNullable<I["todosViaParent"]> extends infer RelationInclude
+        ? RelationInclude extends true
+          ? Todo[]
+          : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
+            ? QueryRow[]
+            : RelationInclude extends TodoInclude
+              ? TodoWithIncludes<RelationInclude>[]
+              : never
+        : never
+      : K extends "project"
+        ? NonNullable<I["project"]> extends infer RelationInclude
+          ? RelationInclude extends true
+            ? Project
+            : RelationInclude extends AnyProjectQueryBuilder<infer QueryRow>
+              ? QueryRow
+              : RelationInclude extends ProjectInclude
+                ? ProjectWithIncludes<RelationInclude>
+                : never
+          : never
+        : never;
+};
 
 export interface ProjectRelations {
   todosViaProject: Todo[];
@@ -70,60 +121,15 @@ export interface TodoRelations {
 
 export type ProjectWithIncludes<I extends ProjectInclude = {}> = Omit<
   Project,
-  keyof ProjectInclude
-> & {
-  todosViaProject?: NonNullable<I["todosViaProject"]> extends infer RelationInclude
-    ? RelationInclude extends true
-      ? Todo[]
-      : RelationInclude extends TodoQueryBuilder<
-            infer QueryInclude extends TodoInclude,
-            infer QuerySelect extends keyof Todo | "*"
-          >
-        ? TodoSelectedWithIncludes<QueryInclude, QuerySelect>[]
-        : RelationInclude extends TodoInclude
-          ? TodoWithIncludes<RelationInclude>[]
-          : never
-    : never;
-};
+  Extract<keyof I, keyof Project>
+> &
+  ProjectIncludedRelations<I>;
 
-export type TodoWithIncludes<I extends TodoInclude = {}> = Omit<Todo, keyof TodoInclude> & {
-  parent?: NonNullable<I["parent"]> extends infer RelationInclude
-    ? RelationInclude extends true
-      ? Todo
-      : RelationInclude extends TodoQueryBuilder<
-            infer QueryInclude extends TodoInclude,
-            infer QuerySelect extends keyof Todo | "*"
-          >
-        ? TodoSelectedWithIncludes<QueryInclude, QuerySelect>
-        : RelationInclude extends TodoInclude
-          ? TodoWithIncludes<RelationInclude>
-          : never
-    : never;
-  todosViaParent?: NonNullable<I["todosViaParent"]> extends infer RelationInclude
-    ? RelationInclude extends true
-      ? Todo[]
-      : RelationInclude extends TodoQueryBuilder<
-            infer QueryInclude extends TodoInclude,
-            infer QuerySelect extends keyof Todo | "*"
-          >
-        ? TodoSelectedWithIncludes<QueryInclude, QuerySelect>[]
-        : RelationInclude extends TodoInclude
-          ? TodoWithIncludes<RelationInclude>[]
-          : never
-    : never;
-  project?: NonNullable<I["project"]> extends infer RelationInclude
-    ? RelationInclude extends true
-      ? Project
-      : RelationInclude extends ProjectQueryBuilder<
-            infer QueryInclude extends ProjectInclude,
-            infer QuerySelect extends keyof Project | "*"
-          >
-        ? ProjectSelectedWithIncludes<QueryInclude, QuerySelect>
-        : RelationInclude extends ProjectInclude
-          ? ProjectWithIncludes<RelationInclude>
-          : never
-    : never;
-};
+export type TodoWithIncludes<I extends TodoInclude = {}> = Omit<
+  Todo,
+  Extract<keyof I, keyof Todo>
+> &
+  TodoIncludedRelations<I>;
 
 export type ProjectSelected<S extends keyof Project | "*" = keyof Project> = "*" extends S
   ? Project
@@ -132,8 +138,8 @@ export type ProjectSelected<S extends keyof Project | "*" = keyof Project> = "*"
 export type ProjectSelectedWithIncludes<
   I extends ProjectInclude = {},
   S extends keyof Project | "*" = keyof Project,
-> = Omit<ProjectSelected<S>, keyof ProjectInclude> &
-  Omit<ProjectWithIncludes<I>, keyof Omit<Project, keyof ProjectInclude>>;
+> = Omit<ProjectSelected<S>, Extract<keyof I, keyof ProjectSelected<S>>> &
+  ProjectIncludedRelations<I>;
 
 export type TodoSelected<S extends keyof Todo | "*" = keyof Todo> = "*" extends S
   ? Todo
@@ -142,8 +148,7 @@ export type TodoSelected<S extends keyof Todo | "*" = keyof Todo> = "*" extends 
 export type TodoSelectedWithIncludes<
   I extends TodoInclude = {},
   S extends keyof Todo | "*" = keyof Todo,
-> = Omit<TodoSelected<S>, keyof TodoInclude> &
-  Omit<TodoWithIncludes<I>, keyof Omit<Todo, keyof TodoInclude>>;
+> = Omit<TodoSelected<S>, Extract<keyof I, keyof TodoSelected<S>>> & TodoIncludedRelations<I>;
 
 export const wasmSchema: WasmSchema = {
   projects: {

--- a/examples/docs/todo-client-localfirst-react/schema/app.ts
+++ b/examples/docs/todo-client-localfirst-react/schema/app.ts
@@ -49,13 +49,13 @@ export interface TodoWhereInput {
 }
 
 export interface ProjectInclude {
-  todosViaProject?: true | TodoInclude | TodoQueryBuilder;
+  todosViaProject?: true | TodoInclude | TodoQueryBuilder<any, any>;
 }
 
 export interface TodoInclude {
-  parent?: true | TodoInclude | TodoQueryBuilder;
-  todosViaParent?: true | TodoInclude | TodoQueryBuilder;
-  project?: true | ProjectInclude | ProjectQueryBuilder;
+  parent?: true | TodoInclude | TodoQueryBuilder<any, any>;
+  todosViaParent?: true | TodoInclude | TodoQueryBuilder<any, any>;
+  project?: true | ProjectInclude | ProjectQueryBuilder<any, any>;
 }
 
 export interface ProjectRelations {

--- a/examples/docs/todo-client-localfirst-react/schema/app.ts
+++ b/examples/docs/todo-client-localfirst-react/schema/app.ts
@@ -68,7 +68,10 @@ export interface TodoRelations {
   project: Project;
 }
 
-export type ProjectWithIncludes<I extends ProjectInclude = {}> = Project & {
+export type ProjectWithIncludes<I extends ProjectInclude = {}> = Omit<
+  Project,
+  keyof ProjectInclude
+> & {
   todosViaProject?: NonNullable<I["todosViaProject"]> extends infer RelationInclude
     ? RelationInclude extends true
       ? Todo[]
@@ -83,7 +86,7 @@ export type ProjectWithIncludes<I extends ProjectInclude = {}> = Project & {
     : never;
 };
 
-export type TodoWithIncludes<I extends TodoInclude = {}> = Todo & {
+export type TodoWithIncludes<I extends TodoInclude = {}> = Omit<Todo, keyof TodoInclude> & {
   parent?: NonNullable<I["parent"]> extends infer RelationInclude
     ? RelationInclude extends true
       ? Todo
@@ -129,7 +132,8 @@ export type ProjectSelected<S extends keyof Project | "*" = keyof Project> = "*"
 export type ProjectSelectedWithIncludes<
   I extends ProjectInclude = {},
   S extends keyof Project | "*" = keyof Project,
-> = ProjectSelected<S> & Omit<ProjectWithIncludes<I>, keyof Project>;
+> = Omit<ProjectSelected<S>, keyof ProjectInclude> &
+  Omit<ProjectWithIncludes<I>, keyof Omit<Project, keyof ProjectInclude>>;
 
 export type TodoSelected<S extends keyof Todo | "*" = keyof Todo> = "*" extends S
   ? Todo
@@ -138,7 +142,8 @@ export type TodoSelected<S extends keyof Todo | "*" = keyof Todo> = "*" extends 
 export type TodoSelectedWithIncludes<
   I extends TodoInclude = {},
   S extends keyof Todo | "*" = keyof Todo,
-> = TodoSelected<S> & Omit<TodoWithIncludes<I>, keyof Todo>;
+> = Omit<TodoSelected<S>, keyof TodoInclude> &
+  Omit<TodoWithIncludes<I>, keyof Omit<Todo, keyof TodoInclude>>;
 
 export const wasmSchema: WasmSchema = {
   projects: {

--- a/examples/docs/todo-client-localfirst-react/schema/app.ts
+++ b/examples/docs/todo-client-localfirst-react/schema/app.ts
@@ -79,11 +79,11 @@ export type TodoIncludedRelations<I extends TodoInclude = {}> = {
   [K in keyof I]-?: K extends "parent"
     ? NonNullable<I["parent"]> extends infer RelationInclude
       ? RelationInclude extends true
-        ? Todo
+        ? Todo | undefined
         : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
-          ? QueryRow
+          ? QueryRow | undefined
           : RelationInclude extends TodoInclude
-            ? TodoWithIncludes<RelationInclude>
+            ? TodoWithIncludes<RelationInclude> | undefined
             : never
       : never
     : K extends "todosViaParent"
@@ -99,11 +99,11 @@ export type TodoIncludedRelations<I extends TodoInclude = {}> = {
       : K extends "project"
         ? NonNullable<I["project"]> extends infer RelationInclude
           ? RelationInclude extends true
-            ? Project
+            ? Project | undefined
             : RelationInclude extends AnyProjectQueryBuilder<infer QueryRow>
-              ? QueryRow
+              ? QueryRow | undefined
               : RelationInclude extends ProjectInclude
-                ? ProjectWithIncludes<RelationInclude>
+                ? ProjectWithIncludes<RelationInclude> | undefined
                 : never
           : never
         : never;

--- a/examples/docs/todo-client-localfirst-svelte/schema/app.ts
+++ b/examples/docs/todo-client-localfirst-svelte/schema/app.ts
@@ -48,15 +48,66 @@ export interface TodoWhereInput {
   project?: string | { eq?: string; ne?: string; isNull?: boolean };
 }
 
+type AnyProjectQueryBuilder<T = any> = { readonly _table: "projects" } & QueryBuilder<T>;
+type AnyTodoQueryBuilder<T = any> = { readonly _table: "todos" } & QueryBuilder<T>;
+
 export interface ProjectInclude {
-  todosViaProject?: true | TodoInclude | TodoQueryBuilder<any, any>;
+  todosViaProject?: true | TodoInclude | AnyTodoQueryBuilder<any>;
 }
 
 export interface TodoInclude {
-  parent?: true | TodoInclude | TodoQueryBuilder<any, any>;
-  todosViaParent?: true | TodoInclude | TodoQueryBuilder<any, any>;
-  project?: true | ProjectInclude | ProjectQueryBuilder<any, any>;
+  parent?: true | TodoInclude | AnyTodoQueryBuilder<any>;
+  todosViaParent?: true | TodoInclude | AnyTodoQueryBuilder<any>;
+  project?: true | ProjectInclude | AnyProjectQueryBuilder<any>;
 }
+
+export type ProjectIncludedRelations<I extends ProjectInclude = {}> = {
+  [K in keyof I]-?: K extends "todosViaProject"
+    ? NonNullable<I["todosViaProject"]> extends infer RelationInclude
+      ? RelationInclude extends true
+        ? Todo[]
+        : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
+          ? QueryRow[]
+          : RelationInclude extends TodoInclude
+            ? TodoWithIncludes<RelationInclude>[]
+            : never
+      : never
+    : never;
+};
+
+export type TodoIncludedRelations<I extends TodoInclude = {}> = {
+  [K in keyof I]-?: K extends "parent"
+    ? NonNullable<I["parent"]> extends infer RelationInclude
+      ? RelationInclude extends true
+        ? Todo
+        : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
+          ? QueryRow
+          : RelationInclude extends TodoInclude
+            ? TodoWithIncludes<RelationInclude>
+            : never
+      : never
+    : K extends "todosViaParent"
+      ? NonNullable<I["todosViaParent"]> extends infer RelationInclude
+        ? RelationInclude extends true
+          ? Todo[]
+          : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
+            ? QueryRow[]
+            : RelationInclude extends TodoInclude
+              ? TodoWithIncludes<RelationInclude>[]
+              : never
+        : never
+      : K extends "project"
+        ? NonNullable<I["project"]> extends infer RelationInclude
+          ? RelationInclude extends true
+            ? Project
+            : RelationInclude extends AnyProjectQueryBuilder<infer QueryRow>
+              ? QueryRow
+              : RelationInclude extends ProjectInclude
+                ? ProjectWithIncludes<RelationInclude>
+                : never
+          : never
+        : never;
+};
 
 export interface ProjectRelations {
   todosViaProject: Todo[];
@@ -70,60 +121,15 @@ export interface TodoRelations {
 
 export type ProjectWithIncludes<I extends ProjectInclude = {}> = Omit<
   Project,
-  keyof ProjectInclude
-> & {
-  todosViaProject?: NonNullable<I["todosViaProject"]> extends infer RelationInclude
-    ? RelationInclude extends true
-      ? Todo[]
-      : RelationInclude extends TodoQueryBuilder<
-            infer QueryInclude extends TodoInclude,
-            infer QuerySelect extends keyof Todo | "*"
-          >
-        ? TodoSelectedWithIncludes<QueryInclude, QuerySelect>[]
-        : RelationInclude extends TodoInclude
-          ? TodoWithIncludes<RelationInclude>[]
-          : never
-    : never;
-};
+  Extract<keyof I, keyof Project>
+> &
+  ProjectIncludedRelations<I>;
 
-export type TodoWithIncludes<I extends TodoInclude = {}> = Omit<Todo, keyof TodoInclude> & {
-  parent?: NonNullable<I["parent"]> extends infer RelationInclude
-    ? RelationInclude extends true
-      ? Todo
-      : RelationInclude extends TodoQueryBuilder<
-            infer QueryInclude extends TodoInclude,
-            infer QuerySelect extends keyof Todo | "*"
-          >
-        ? TodoSelectedWithIncludes<QueryInclude, QuerySelect>
-        : RelationInclude extends TodoInclude
-          ? TodoWithIncludes<RelationInclude>
-          : never
-    : never;
-  todosViaParent?: NonNullable<I["todosViaParent"]> extends infer RelationInclude
-    ? RelationInclude extends true
-      ? Todo[]
-      : RelationInclude extends TodoQueryBuilder<
-            infer QueryInclude extends TodoInclude,
-            infer QuerySelect extends keyof Todo | "*"
-          >
-        ? TodoSelectedWithIncludes<QueryInclude, QuerySelect>[]
-        : RelationInclude extends TodoInclude
-          ? TodoWithIncludes<RelationInclude>[]
-          : never
-    : never;
-  project?: NonNullable<I["project"]> extends infer RelationInclude
-    ? RelationInclude extends true
-      ? Project
-      : RelationInclude extends ProjectQueryBuilder<
-            infer QueryInclude extends ProjectInclude,
-            infer QuerySelect extends keyof Project | "*"
-          >
-        ? ProjectSelectedWithIncludes<QueryInclude, QuerySelect>
-        : RelationInclude extends ProjectInclude
-          ? ProjectWithIncludes<RelationInclude>
-          : never
-    : never;
-};
+export type TodoWithIncludes<I extends TodoInclude = {}> = Omit<
+  Todo,
+  Extract<keyof I, keyof Todo>
+> &
+  TodoIncludedRelations<I>;
 
 export type ProjectSelected<S extends keyof Project | "*" = keyof Project> = "*" extends S
   ? Project
@@ -132,8 +138,8 @@ export type ProjectSelected<S extends keyof Project | "*" = keyof Project> = "*"
 export type ProjectSelectedWithIncludes<
   I extends ProjectInclude = {},
   S extends keyof Project | "*" = keyof Project,
-> = Omit<ProjectSelected<S>, keyof ProjectInclude> &
-  Omit<ProjectWithIncludes<I>, keyof Omit<Project, keyof ProjectInclude>>;
+> = Omit<ProjectSelected<S>, Extract<keyof I, keyof ProjectSelected<S>>> &
+  ProjectIncludedRelations<I>;
 
 export type TodoSelected<S extends keyof Todo | "*" = keyof Todo> = "*" extends S
   ? Todo
@@ -142,8 +148,7 @@ export type TodoSelected<S extends keyof Todo | "*" = keyof Todo> = "*" extends 
 export type TodoSelectedWithIncludes<
   I extends TodoInclude = {},
   S extends keyof Todo | "*" = keyof Todo,
-> = Omit<TodoSelected<S>, keyof TodoInclude> &
-  Omit<TodoWithIncludes<I>, keyof Omit<Todo, keyof TodoInclude>>;
+> = Omit<TodoSelected<S>, Extract<keyof I, keyof TodoSelected<S>>> & TodoIncludedRelations<I>;
 
 export const wasmSchema: WasmSchema = {
   projects: {

--- a/examples/docs/todo-client-localfirst-svelte/schema/app.ts
+++ b/examples/docs/todo-client-localfirst-svelte/schema/app.ts
@@ -49,13 +49,13 @@ export interface TodoWhereInput {
 }
 
 export interface ProjectInclude {
-  todosViaProject?: true | TodoInclude | TodoQueryBuilder;
+  todosViaProject?: true | TodoInclude | TodoQueryBuilder<any, any>;
 }
 
 export interface TodoInclude {
-  parent?: true | TodoInclude | TodoQueryBuilder;
-  todosViaParent?: true | TodoInclude | TodoQueryBuilder;
-  project?: true | ProjectInclude | ProjectQueryBuilder;
+  parent?: true | TodoInclude | TodoQueryBuilder<any, any>;
+  todosViaParent?: true | TodoInclude | TodoQueryBuilder<any, any>;
+  project?: true | ProjectInclude | ProjectQueryBuilder<any, any>;
 }
 
 export interface ProjectRelations {

--- a/examples/docs/todo-client-localfirst-svelte/schema/app.ts
+++ b/examples/docs/todo-client-localfirst-svelte/schema/app.ts
@@ -68,7 +68,10 @@ export interface TodoRelations {
   project: Project;
 }
 
-export type ProjectWithIncludes<I extends ProjectInclude = {}> = Project & {
+export type ProjectWithIncludes<I extends ProjectInclude = {}> = Omit<
+  Project,
+  keyof ProjectInclude
+> & {
   todosViaProject?: NonNullable<I["todosViaProject"]> extends infer RelationInclude
     ? RelationInclude extends true
       ? Todo[]
@@ -83,7 +86,7 @@ export type ProjectWithIncludes<I extends ProjectInclude = {}> = Project & {
     : never;
 };
 
-export type TodoWithIncludes<I extends TodoInclude = {}> = Todo & {
+export type TodoWithIncludes<I extends TodoInclude = {}> = Omit<Todo, keyof TodoInclude> & {
   parent?: NonNullable<I["parent"]> extends infer RelationInclude
     ? RelationInclude extends true
       ? Todo
@@ -129,7 +132,8 @@ export type ProjectSelected<S extends keyof Project | "*" = keyof Project> = "*"
 export type ProjectSelectedWithIncludes<
   I extends ProjectInclude = {},
   S extends keyof Project | "*" = keyof Project,
-> = ProjectSelected<S> & Omit<ProjectWithIncludes<I>, keyof Project>;
+> = Omit<ProjectSelected<S>, keyof ProjectInclude> &
+  Omit<ProjectWithIncludes<I>, keyof Omit<Project, keyof ProjectInclude>>;
 
 export type TodoSelected<S extends keyof Todo | "*" = keyof Todo> = "*" extends S
   ? Todo
@@ -138,7 +142,8 @@ export type TodoSelected<S extends keyof Todo | "*" = keyof Todo> = "*" extends 
 export type TodoSelectedWithIncludes<
   I extends TodoInclude = {},
   S extends keyof Todo | "*" = keyof Todo,
-> = TodoSelected<S> & Omit<TodoWithIncludes<I>, keyof Todo>;
+> = Omit<TodoSelected<S>, keyof TodoInclude> &
+  Omit<TodoWithIncludes<I>, keyof Omit<Todo, keyof TodoInclude>>;
 
 export const wasmSchema: WasmSchema = {
   projects: {

--- a/examples/docs/todo-client-localfirst-svelte/schema/app.ts
+++ b/examples/docs/todo-client-localfirst-svelte/schema/app.ts
@@ -79,11 +79,11 @@ export type TodoIncludedRelations<I extends TodoInclude = {}> = {
   [K in keyof I]-?: K extends "parent"
     ? NonNullable<I["parent"]> extends infer RelationInclude
       ? RelationInclude extends true
-        ? Todo
+        ? Todo | undefined
         : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
-          ? QueryRow
+          ? QueryRow | undefined
           : RelationInclude extends TodoInclude
-            ? TodoWithIncludes<RelationInclude>
+            ? TodoWithIncludes<RelationInclude> | undefined
             : never
       : never
     : K extends "todosViaParent"
@@ -99,11 +99,11 @@ export type TodoIncludedRelations<I extends TodoInclude = {}> = {
       : K extends "project"
         ? NonNullable<I["project"]> extends infer RelationInclude
           ? RelationInclude extends true
-            ? Project
+            ? Project | undefined
             : RelationInclude extends AnyProjectQueryBuilder<infer QueryRow>
-              ? QueryRow
+              ? QueryRow | undefined
               : RelationInclude extends ProjectInclude
-                ? ProjectWithIncludes<RelationInclude>
+                ? ProjectWithIncludes<RelationInclude> | undefined
                 : never
           : never
         : never;

--- a/examples/docs/todo-client-localfirst-ts/schema/app.ts
+++ b/examples/docs/todo-client-localfirst-ts/schema/app.ts
@@ -48,15 +48,66 @@ export interface TodoWhereInput {
   project?: string | { eq?: string; ne?: string; isNull?: boolean };
 }
 
+type AnyProjectQueryBuilder<T = any> = { readonly _table: "projects" } & QueryBuilder<T>;
+type AnyTodoQueryBuilder<T = any> = { readonly _table: "todos" } & QueryBuilder<T>;
+
 export interface ProjectInclude {
-  todosViaProject?: true | TodoInclude | TodoQueryBuilder<any, any>;
+  todosViaProject?: true | TodoInclude | AnyTodoQueryBuilder<any>;
 }
 
 export interface TodoInclude {
-  parent?: true | TodoInclude | TodoQueryBuilder<any, any>;
-  todosViaParent?: true | TodoInclude | TodoQueryBuilder<any, any>;
-  project?: true | ProjectInclude | ProjectQueryBuilder<any, any>;
+  parent?: true | TodoInclude | AnyTodoQueryBuilder<any>;
+  todosViaParent?: true | TodoInclude | AnyTodoQueryBuilder<any>;
+  project?: true | ProjectInclude | AnyProjectQueryBuilder<any>;
 }
+
+export type ProjectIncludedRelations<I extends ProjectInclude = {}> = {
+  [K in keyof I]-?: K extends "todosViaProject"
+    ? NonNullable<I["todosViaProject"]> extends infer RelationInclude
+      ? RelationInclude extends true
+        ? Todo[]
+        : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
+          ? QueryRow[]
+          : RelationInclude extends TodoInclude
+            ? TodoWithIncludes<RelationInclude>[]
+            : never
+      : never
+    : never;
+};
+
+export type TodoIncludedRelations<I extends TodoInclude = {}> = {
+  [K in keyof I]-?: K extends "parent"
+    ? NonNullable<I["parent"]> extends infer RelationInclude
+      ? RelationInclude extends true
+        ? Todo
+        : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
+          ? QueryRow
+          : RelationInclude extends TodoInclude
+            ? TodoWithIncludes<RelationInclude>
+            : never
+      : never
+    : K extends "todosViaParent"
+      ? NonNullable<I["todosViaParent"]> extends infer RelationInclude
+        ? RelationInclude extends true
+          ? Todo[]
+          : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
+            ? QueryRow[]
+            : RelationInclude extends TodoInclude
+              ? TodoWithIncludes<RelationInclude>[]
+              : never
+        : never
+      : K extends "project"
+        ? NonNullable<I["project"]> extends infer RelationInclude
+          ? RelationInclude extends true
+            ? Project
+            : RelationInclude extends AnyProjectQueryBuilder<infer QueryRow>
+              ? QueryRow
+              : RelationInclude extends ProjectInclude
+                ? ProjectWithIncludes<RelationInclude>
+                : never
+          : never
+        : never;
+};
 
 export interface ProjectRelations {
   todosViaProject: Todo[];
@@ -70,60 +121,15 @@ export interface TodoRelations {
 
 export type ProjectWithIncludes<I extends ProjectInclude = {}> = Omit<
   Project,
-  keyof ProjectInclude
-> & {
-  todosViaProject?: NonNullable<I["todosViaProject"]> extends infer RelationInclude
-    ? RelationInclude extends true
-      ? Todo[]
-      : RelationInclude extends TodoQueryBuilder<
-            infer QueryInclude extends TodoInclude,
-            infer QuerySelect extends keyof Todo | "*"
-          >
-        ? TodoSelectedWithIncludes<QueryInclude, QuerySelect>[]
-        : RelationInclude extends TodoInclude
-          ? TodoWithIncludes<RelationInclude>[]
-          : never
-    : never;
-};
+  Extract<keyof I, keyof Project>
+> &
+  ProjectIncludedRelations<I>;
 
-export type TodoWithIncludes<I extends TodoInclude = {}> = Omit<Todo, keyof TodoInclude> & {
-  parent?: NonNullable<I["parent"]> extends infer RelationInclude
-    ? RelationInclude extends true
-      ? Todo
-      : RelationInclude extends TodoQueryBuilder<
-            infer QueryInclude extends TodoInclude,
-            infer QuerySelect extends keyof Todo | "*"
-          >
-        ? TodoSelectedWithIncludes<QueryInclude, QuerySelect>
-        : RelationInclude extends TodoInclude
-          ? TodoWithIncludes<RelationInclude>
-          : never
-    : never;
-  todosViaParent?: NonNullable<I["todosViaParent"]> extends infer RelationInclude
-    ? RelationInclude extends true
-      ? Todo[]
-      : RelationInclude extends TodoQueryBuilder<
-            infer QueryInclude extends TodoInclude,
-            infer QuerySelect extends keyof Todo | "*"
-          >
-        ? TodoSelectedWithIncludes<QueryInclude, QuerySelect>[]
-        : RelationInclude extends TodoInclude
-          ? TodoWithIncludes<RelationInclude>[]
-          : never
-    : never;
-  project?: NonNullable<I["project"]> extends infer RelationInclude
-    ? RelationInclude extends true
-      ? Project
-      : RelationInclude extends ProjectQueryBuilder<
-            infer QueryInclude extends ProjectInclude,
-            infer QuerySelect extends keyof Project | "*"
-          >
-        ? ProjectSelectedWithIncludes<QueryInclude, QuerySelect>
-        : RelationInclude extends ProjectInclude
-          ? ProjectWithIncludes<RelationInclude>
-          : never
-    : never;
-};
+export type TodoWithIncludes<I extends TodoInclude = {}> = Omit<
+  Todo,
+  Extract<keyof I, keyof Todo>
+> &
+  TodoIncludedRelations<I>;
 
 export type ProjectSelected<S extends keyof Project | "*" = keyof Project> = "*" extends S
   ? Project
@@ -132,8 +138,8 @@ export type ProjectSelected<S extends keyof Project | "*" = keyof Project> = "*"
 export type ProjectSelectedWithIncludes<
   I extends ProjectInclude = {},
   S extends keyof Project | "*" = keyof Project,
-> = Omit<ProjectSelected<S>, keyof ProjectInclude> &
-  Omit<ProjectWithIncludes<I>, keyof Omit<Project, keyof ProjectInclude>>;
+> = Omit<ProjectSelected<S>, Extract<keyof I, keyof ProjectSelected<S>>> &
+  ProjectIncludedRelations<I>;
 
 export type TodoSelected<S extends keyof Todo | "*" = keyof Todo> = "*" extends S
   ? Todo
@@ -142,8 +148,7 @@ export type TodoSelected<S extends keyof Todo | "*" = keyof Todo> = "*" extends 
 export type TodoSelectedWithIncludes<
   I extends TodoInclude = {},
   S extends keyof Todo | "*" = keyof Todo,
-> = Omit<TodoSelected<S>, keyof TodoInclude> &
-  Omit<TodoWithIncludes<I>, keyof Omit<Todo, keyof TodoInclude>>;
+> = Omit<TodoSelected<S>, Extract<keyof I, keyof TodoSelected<S>>> & TodoIncludedRelations<I>;
 
 export const wasmSchema: WasmSchema = {
   projects: {

--- a/examples/docs/todo-client-localfirst-ts/schema/app.ts
+++ b/examples/docs/todo-client-localfirst-ts/schema/app.ts
@@ -49,13 +49,13 @@ export interface TodoWhereInput {
 }
 
 export interface ProjectInclude {
-  todosViaProject?: true | TodoInclude | TodoQueryBuilder;
+  todosViaProject?: true | TodoInclude | TodoQueryBuilder<any, any>;
 }
 
 export interface TodoInclude {
-  parent?: true | TodoInclude | TodoQueryBuilder;
-  todosViaParent?: true | TodoInclude | TodoQueryBuilder;
-  project?: true | ProjectInclude | ProjectQueryBuilder;
+  parent?: true | TodoInclude | TodoQueryBuilder<any, any>;
+  todosViaParent?: true | TodoInclude | TodoQueryBuilder<any, any>;
+  project?: true | ProjectInclude | ProjectQueryBuilder<any, any>;
 }
 
 export interface ProjectRelations {

--- a/examples/docs/todo-client-localfirst-ts/schema/app.ts
+++ b/examples/docs/todo-client-localfirst-ts/schema/app.ts
@@ -68,7 +68,10 @@ export interface TodoRelations {
   project: Project;
 }
 
-export type ProjectWithIncludes<I extends ProjectInclude = {}> = Project & {
+export type ProjectWithIncludes<I extends ProjectInclude = {}> = Omit<
+  Project,
+  keyof ProjectInclude
+> & {
   todosViaProject?: NonNullable<I["todosViaProject"]> extends infer RelationInclude
     ? RelationInclude extends true
       ? Todo[]
@@ -83,7 +86,7 @@ export type ProjectWithIncludes<I extends ProjectInclude = {}> = Project & {
     : never;
 };
 
-export type TodoWithIncludes<I extends TodoInclude = {}> = Todo & {
+export type TodoWithIncludes<I extends TodoInclude = {}> = Omit<Todo, keyof TodoInclude> & {
   parent?: NonNullable<I["parent"]> extends infer RelationInclude
     ? RelationInclude extends true
       ? Todo
@@ -129,7 +132,8 @@ export type ProjectSelected<S extends keyof Project | "*" = keyof Project> = "*"
 export type ProjectSelectedWithIncludes<
   I extends ProjectInclude = {},
   S extends keyof Project | "*" = keyof Project,
-> = ProjectSelected<S> & Omit<ProjectWithIncludes<I>, keyof Project>;
+> = Omit<ProjectSelected<S>, keyof ProjectInclude> &
+  Omit<ProjectWithIncludes<I>, keyof Omit<Project, keyof ProjectInclude>>;
 
 export type TodoSelected<S extends keyof Todo | "*" = keyof Todo> = "*" extends S
   ? Todo
@@ -138,7 +142,8 @@ export type TodoSelected<S extends keyof Todo | "*" = keyof Todo> = "*" extends 
 export type TodoSelectedWithIncludes<
   I extends TodoInclude = {},
   S extends keyof Todo | "*" = keyof Todo,
-> = TodoSelected<S> & Omit<TodoWithIncludes<I>, keyof Todo>;
+> = Omit<TodoSelected<S>, keyof TodoInclude> &
+  Omit<TodoWithIncludes<I>, keyof Omit<Todo, keyof TodoInclude>>;
 
 export const wasmSchema: WasmSchema = {
   projects: {

--- a/examples/docs/todo-client-localfirst-ts/schema/app.ts
+++ b/examples/docs/todo-client-localfirst-ts/schema/app.ts
@@ -79,11 +79,11 @@ export type TodoIncludedRelations<I extends TodoInclude = {}> = {
   [K in keyof I]-?: K extends "parent"
     ? NonNullable<I["parent"]> extends infer RelationInclude
       ? RelationInclude extends true
-        ? Todo
+        ? Todo | undefined
         : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
-          ? QueryRow
+          ? QueryRow | undefined
           : RelationInclude extends TodoInclude
-            ? TodoWithIncludes<RelationInclude>
+            ? TodoWithIncludes<RelationInclude> | undefined
             : never
       : never
     : K extends "todosViaParent"
@@ -99,11 +99,11 @@ export type TodoIncludedRelations<I extends TodoInclude = {}> = {
       : K extends "project"
         ? NonNullable<I["project"]> extends infer RelationInclude
           ? RelationInclude extends true
-            ? Project
+            ? Project | undefined
             : RelationInclude extends AnyProjectQueryBuilder<infer QueryRow>
-              ? QueryRow
+              ? QueryRow | undefined
               : RelationInclude extends ProjectInclude
-                ? ProjectWithIncludes<RelationInclude>
+                ? ProjectWithIncludes<RelationInclude> | undefined
                 : never
           : never
         : never;

--- a/examples/docs/todo-client-localfirst-vue/schema/app.ts
+++ b/examples/docs/todo-client-localfirst-vue/schema/app.ts
@@ -48,15 +48,66 @@ export interface TodoWhereInput {
   project?: string | { eq?: string; ne?: string; isNull?: boolean };
 }
 
+type AnyProjectQueryBuilder<T = any> = { readonly _table: "projects" } & QueryBuilder<T>;
+type AnyTodoQueryBuilder<T = any> = { readonly _table: "todos" } & QueryBuilder<T>;
+
 export interface ProjectInclude {
-  todosViaProject?: true | TodoInclude | TodoQueryBuilder<any, any>;
+  todosViaProject?: true | TodoInclude | AnyTodoQueryBuilder<any>;
 }
 
 export interface TodoInclude {
-  parent?: true | TodoInclude | TodoQueryBuilder<any, any>;
-  todosViaParent?: true | TodoInclude | TodoQueryBuilder<any, any>;
-  project?: true | ProjectInclude | ProjectQueryBuilder<any, any>;
+  parent?: true | TodoInclude | AnyTodoQueryBuilder<any>;
+  todosViaParent?: true | TodoInclude | AnyTodoQueryBuilder<any>;
+  project?: true | ProjectInclude | AnyProjectQueryBuilder<any>;
 }
+
+export type ProjectIncludedRelations<I extends ProjectInclude = {}> = {
+  [K in keyof I]-?: K extends "todosViaProject"
+    ? NonNullable<I["todosViaProject"]> extends infer RelationInclude
+      ? RelationInclude extends true
+        ? Todo[]
+        : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
+          ? QueryRow[]
+          : RelationInclude extends TodoInclude
+            ? TodoWithIncludes<RelationInclude>[]
+            : never
+      : never
+    : never;
+};
+
+export type TodoIncludedRelations<I extends TodoInclude = {}> = {
+  [K in keyof I]-?: K extends "parent"
+    ? NonNullable<I["parent"]> extends infer RelationInclude
+      ? RelationInclude extends true
+        ? Todo
+        : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
+          ? QueryRow
+          : RelationInclude extends TodoInclude
+            ? TodoWithIncludes<RelationInclude>
+            : never
+      : never
+    : K extends "todosViaParent"
+      ? NonNullable<I["todosViaParent"]> extends infer RelationInclude
+        ? RelationInclude extends true
+          ? Todo[]
+          : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
+            ? QueryRow[]
+            : RelationInclude extends TodoInclude
+              ? TodoWithIncludes<RelationInclude>[]
+              : never
+        : never
+      : K extends "project"
+        ? NonNullable<I["project"]> extends infer RelationInclude
+          ? RelationInclude extends true
+            ? Project
+            : RelationInclude extends AnyProjectQueryBuilder<infer QueryRow>
+              ? QueryRow
+              : RelationInclude extends ProjectInclude
+                ? ProjectWithIncludes<RelationInclude>
+                : never
+          : never
+        : never;
+};
 
 export interface ProjectRelations {
   todosViaProject: Todo[];
@@ -70,60 +121,15 @@ export interface TodoRelations {
 
 export type ProjectWithIncludes<I extends ProjectInclude = {}> = Omit<
   Project,
-  keyof ProjectInclude
-> & {
-  todosViaProject?: NonNullable<I["todosViaProject"]> extends infer RelationInclude
-    ? RelationInclude extends true
-      ? Todo[]
-      : RelationInclude extends TodoQueryBuilder<
-            infer QueryInclude extends TodoInclude,
-            infer QuerySelect extends keyof Todo | "*"
-          >
-        ? TodoSelectedWithIncludes<QueryInclude, QuerySelect>[]
-        : RelationInclude extends TodoInclude
-          ? TodoWithIncludes<RelationInclude>[]
-          : never
-    : never;
-};
+  Extract<keyof I, keyof Project>
+> &
+  ProjectIncludedRelations<I>;
 
-export type TodoWithIncludes<I extends TodoInclude = {}> = Omit<Todo, keyof TodoInclude> & {
-  parent?: NonNullable<I["parent"]> extends infer RelationInclude
-    ? RelationInclude extends true
-      ? Todo
-      : RelationInclude extends TodoQueryBuilder<
-            infer QueryInclude extends TodoInclude,
-            infer QuerySelect extends keyof Todo | "*"
-          >
-        ? TodoSelectedWithIncludes<QueryInclude, QuerySelect>
-        : RelationInclude extends TodoInclude
-          ? TodoWithIncludes<RelationInclude>
-          : never
-    : never;
-  todosViaParent?: NonNullable<I["todosViaParent"]> extends infer RelationInclude
-    ? RelationInclude extends true
-      ? Todo[]
-      : RelationInclude extends TodoQueryBuilder<
-            infer QueryInclude extends TodoInclude,
-            infer QuerySelect extends keyof Todo | "*"
-          >
-        ? TodoSelectedWithIncludes<QueryInclude, QuerySelect>[]
-        : RelationInclude extends TodoInclude
-          ? TodoWithIncludes<RelationInclude>[]
-          : never
-    : never;
-  project?: NonNullable<I["project"]> extends infer RelationInclude
-    ? RelationInclude extends true
-      ? Project
-      : RelationInclude extends ProjectQueryBuilder<
-            infer QueryInclude extends ProjectInclude,
-            infer QuerySelect extends keyof Project | "*"
-          >
-        ? ProjectSelectedWithIncludes<QueryInclude, QuerySelect>
-        : RelationInclude extends ProjectInclude
-          ? ProjectWithIncludes<RelationInclude>
-          : never
-    : never;
-};
+export type TodoWithIncludes<I extends TodoInclude = {}> = Omit<
+  Todo,
+  Extract<keyof I, keyof Todo>
+> &
+  TodoIncludedRelations<I>;
 
 export type ProjectSelected<S extends keyof Project | "*" = keyof Project> = "*" extends S
   ? Project
@@ -132,8 +138,8 @@ export type ProjectSelected<S extends keyof Project | "*" = keyof Project> = "*"
 export type ProjectSelectedWithIncludes<
   I extends ProjectInclude = {},
   S extends keyof Project | "*" = keyof Project,
-> = Omit<ProjectSelected<S>, keyof ProjectInclude> &
-  Omit<ProjectWithIncludes<I>, keyof Omit<Project, keyof ProjectInclude>>;
+> = Omit<ProjectSelected<S>, Extract<keyof I, keyof ProjectSelected<S>>> &
+  ProjectIncludedRelations<I>;
 
 export type TodoSelected<S extends keyof Todo | "*" = keyof Todo> = "*" extends S
   ? Todo
@@ -142,8 +148,7 @@ export type TodoSelected<S extends keyof Todo | "*" = keyof Todo> = "*" extends 
 export type TodoSelectedWithIncludes<
   I extends TodoInclude = {},
   S extends keyof Todo | "*" = keyof Todo,
-> = Omit<TodoSelected<S>, keyof TodoInclude> &
-  Omit<TodoWithIncludes<I>, keyof Omit<Todo, keyof TodoInclude>>;
+> = Omit<TodoSelected<S>, Extract<keyof I, keyof TodoSelected<S>>> & TodoIncludedRelations<I>;
 
 export const wasmSchema: WasmSchema = {
   projects: {

--- a/examples/docs/todo-client-localfirst-vue/schema/app.ts
+++ b/examples/docs/todo-client-localfirst-vue/schema/app.ts
@@ -49,13 +49,13 @@ export interface TodoWhereInput {
 }
 
 export interface ProjectInclude {
-  todosViaProject?: true | TodoInclude | TodoQueryBuilder;
+  todosViaProject?: true | TodoInclude | TodoQueryBuilder<any, any>;
 }
 
 export interface TodoInclude {
-  parent?: true | TodoInclude | TodoQueryBuilder;
-  todosViaParent?: true | TodoInclude | TodoQueryBuilder;
-  project?: true | ProjectInclude | ProjectQueryBuilder;
+  parent?: true | TodoInclude | TodoQueryBuilder<any, any>;
+  todosViaParent?: true | TodoInclude | TodoQueryBuilder<any, any>;
+  project?: true | ProjectInclude | ProjectQueryBuilder<any, any>;
 }
 
 export interface ProjectRelations {

--- a/examples/docs/todo-client-localfirst-vue/schema/app.ts
+++ b/examples/docs/todo-client-localfirst-vue/schema/app.ts
@@ -68,7 +68,10 @@ export interface TodoRelations {
   project: Project;
 }
 
-export type ProjectWithIncludes<I extends ProjectInclude = {}> = Project & {
+export type ProjectWithIncludes<I extends ProjectInclude = {}> = Omit<
+  Project,
+  keyof ProjectInclude
+> & {
   todosViaProject?: NonNullable<I["todosViaProject"]> extends infer RelationInclude
     ? RelationInclude extends true
       ? Todo[]
@@ -83,7 +86,7 @@ export type ProjectWithIncludes<I extends ProjectInclude = {}> = Project & {
     : never;
 };
 
-export type TodoWithIncludes<I extends TodoInclude = {}> = Todo & {
+export type TodoWithIncludes<I extends TodoInclude = {}> = Omit<Todo, keyof TodoInclude> & {
   parent?: NonNullable<I["parent"]> extends infer RelationInclude
     ? RelationInclude extends true
       ? Todo
@@ -129,7 +132,8 @@ export type ProjectSelected<S extends keyof Project | "*" = keyof Project> = "*"
 export type ProjectSelectedWithIncludes<
   I extends ProjectInclude = {},
   S extends keyof Project | "*" = keyof Project,
-> = ProjectSelected<S> & Omit<ProjectWithIncludes<I>, keyof Project>;
+> = Omit<ProjectSelected<S>, keyof ProjectInclude> &
+  Omit<ProjectWithIncludes<I>, keyof Omit<Project, keyof ProjectInclude>>;
 
 export type TodoSelected<S extends keyof Todo | "*" = keyof Todo> = "*" extends S
   ? Todo
@@ -138,7 +142,8 @@ export type TodoSelected<S extends keyof Todo | "*" = keyof Todo> = "*" extends 
 export type TodoSelectedWithIncludes<
   I extends TodoInclude = {},
   S extends keyof Todo | "*" = keyof Todo,
-> = TodoSelected<S> & Omit<TodoWithIncludes<I>, keyof Todo>;
+> = Omit<TodoSelected<S>, keyof TodoInclude> &
+  Omit<TodoWithIncludes<I>, keyof Omit<Todo, keyof TodoInclude>>;
 
 export const wasmSchema: WasmSchema = {
   projects: {

--- a/examples/docs/todo-client-localfirst-vue/schema/app.ts
+++ b/examples/docs/todo-client-localfirst-vue/schema/app.ts
@@ -79,11 +79,11 @@ export type TodoIncludedRelations<I extends TodoInclude = {}> = {
   [K in keyof I]-?: K extends "parent"
     ? NonNullable<I["parent"]> extends infer RelationInclude
       ? RelationInclude extends true
-        ? Todo
+        ? Todo | undefined
         : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
-          ? QueryRow
+          ? QueryRow | undefined
           : RelationInclude extends TodoInclude
-            ? TodoWithIncludes<RelationInclude>
+            ? TodoWithIncludes<RelationInclude> | undefined
             : never
       : never
     : K extends "todosViaParent"
@@ -99,11 +99,11 @@ export type TodoIncludedRelations<I extends TodoInclude = {}> = {
       : K extends "project"
         ? NonNullable<I["project"]> extends infer RelationInclude
           ? RelationInclude extends true
-            ? Project
+            ? Project | undefined
             : RelationInclude extends AnyProjectQueryBuilder<infer QueryRow>
-              ? QueryRow
+              ? QueryRow | undefined
               : RelationInclude extends ProjectInclude
-                ? ProjectWithIncludes<RelationInclude>
+                ? ProjectWithIncludes<RelationInclude> | undefined
                 : never
           : never
         : never;

--- a/examples/todo-client-localfirst-react/schema/app.ts
+++ b/examples/todo-client-localfirst-react/schema/app.ts
@@ -51,15 +51,66 @@ export interface TodoWhereInput {
   project?: string | { eq?: string; ne?: string; isNull?: boolean };
 }
 
+type AnyProjectQueryBuilder<T = any> = { readonly _table: "projects" } & QueryBuilder<T>;
+type AnyTodoQueryBuilder<T = any> = { readonly _table: "todos" } & QueryBuilder<T>;
+
 export interface ProjectInclude {
-  todosViaProject?: true | TodoInclude | TodoQueryBuilder<any, any>;
+  todosViaProject?: true | TodoInclude | AnyTodoQueryBuilder<any>;
 }
 
 export interface TodoInclude {
-  parent?: true | TodoInclude | TodoQueryBuilder<any, any>;
-  todosViaParent?: true | TodoInclude | TodoQueryBuilder<any, any>;
-  project?: true | ProjectInclude | ProjectQueryBuilder<any, any>;
+  parent?: true | TodoInclude | AnyTodoQueryBuilder<any>;
+  todosViaParent?: true | TodoInclude | AnyTodoQueryBuilder<any>;
+  project?: true | ProjectInclude | AnyProjectQueryBuilder<any>;
 }
+
+export type ProjectIncludedRelations<I extends ProjectInclude = {}> = {
+  [K in keyof I]-?: K extends "todosViaProject"
+    ? NonNullable<I["todosViaProject"]> extends infer RelationInclude
+      ? RelationInclude extends true
+        ? Todo[]
+        : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
+          ? QueryRow[]
+          : RelationInclude extends TodoInclude
+            ? TodoWithIncludes<RelationInclude>[]
+            : never
+      : never
+    : never;
+};
+
+export type TodoIncludedRelations<I extends TodoInclude = {}> = {
+  [K in keyof I]-?: K extends "parent"
+    ? NonNullable<I["parent"]> extends infer RelationInclude
+      ? RelationInclude extends true
+        ? Todo
+        : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
+          ? QueryRow
+          : RelationInclude extends TodoInclude
+            ? TodoWithIncludes<RelationInclude>
+            : never
+      : never
+    : K extends "todosViaParent"
+      ? NonNullable<I["todosViaParent"]> extends infer RelationInclude
+        ? RelationInclude extends true
+          ? Todo[]
+          : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
+            ? QueryRow[]
+            : RelationInclude extends TodoInclude
+              ? TodoWithIncludes<RelationInclude>[]
+              : never
+        : never
+      : K extends "project"
+        ? NonNullable<I["project"]> extends infer RelationInclude
+          ? RelationInclude extends true
+            ? Project
+            : RelationInclude extends AnyProjectQueryBuilder<infer QueryRow>
+              ? QueryRow
+              : RelationInclude extends ProjectInclude
+                ? ProjectWithIncludes<RelationInclude>
+                : never
+          : never
+        : never;
+};
 
 export interface ProjectRelations {
   todosViaProject: Todo[];
@@ -73,60 +124,15 @@ export interface TodoRelations {
 
 export type ProjectWithIncludes<I extends ProjectInclude = {}> = Omit<
   Project,
-  keyof ProjectInclude
-> & {
-  todosViaProject?: NonNullable<I["todosViaProject"]> extends infer RelationInclude
-    ? RelationInclude extends true
-      ? Todo[]
-      : RelationInclude extends TodoQueryBuilder<
-            infer QueryInclude extends TodoInclude,
-            infer QuerySelect extends keyof Todo | "*"
-          >
-        ? TodoSelectedWithIncludes<QueryInclude, QuerySelect>[]
-        : RelationInclude extends TodoInclude
-          ? TodoWithIncludes<RelationInclude>[]
-          : never
-    : never;
-};
+  Extract<keyof I, keyof Project>
+> &
+  ProjectIncludedRelations<I>;
 
-export type TodoWithIncludes<I extends TodoInclude = {}> = Omit<Todo, keyof TodoInclude> & {
-  parent?: NonNullable<I["parent"]> extends infer RelationInclude
-    ? RelationInclude extends true
-      ? Todo
-      : RelationInclude extends TodoQueryBuilder<
-            infer QueryInclude extends TodoInclude,
-            infer QuerySelect extends keyof Todo | "*"
-          >
-        ? TodoSelectedWithIncludes<QueryInclude, QuerySelect>
-        : RelationInclude extends TodoInclude
-          ? TodoWithIncludes<RelationInclude>
-          : never
-    : never;
-  todosViaParent?: NonNullable<I["todosViaParent"]> extends infer RelationInclude
-    ? RelationInclude extends true
-      ? Todo[]
-      : RelationInclude extends TodoQueryBuilder<
-            infer QueryInclude extends TodoInclude,
-            infer QuerySelect extends keyof Todo | "*"
-          >
-        ? TodoSelectedWithIncludes<QueryInclude, QuerySelect>[]
-        : RelationInclude extends TodoInclude
-          ? TodoWithIncludes<RelationInclude>[]
-          : never
-    : never;
-  project?: NonNullable<I["project"]> extends infer RelationInclude
-    ? RelationInclude extends true
-      ? Project
-      : RelationInclude extends ProjectQueryBuilder<
-            infer QueryInclude extends ProjectInclude,
-            infer QuerySelect extends keyof Project | "*"
-          >
-        ? ProjectSelectedWithIncludes<QueryInclude, QuerySelect>
-        : RelationInclude extends ProjectInclude
-          ? ProjectWithIncludes<RelationInclude>
-          : never
-    : never;
-};
+export type TodoWithIncludes<I extends TodoInclude = {}> = Omit<
+  Todo,
+  Extract<keyof I, keyof Todo>
+> &
+  TodoIncludedRelations<I>;
 
 export type ProjectSelected<S extends keyof Project | "*" = keyof Project> = "*" extends S
   ? Project
@@ -135,8 +141,8 @@ export type ProjectSelected<S extends keyof Project | "*" = keyof Project> = "*"
 export type ProjectSelectedWithIncludes<
   I extends ProjectInclude = {},
   S extends keyof Project | "*" = keyof Project,
-> = Omit<ProjectSelected<S>, keyof ProjectInclude> &
-  Omit<ProjectWithIncludes<I>, keyof Omit<Project, keyof ProjectInclude>>;
+> = Omit<ProjectSelected<S>, Extract<keyof I, keyof ProjectSelected<S>>> &
+  ProjectIncludedRelations<I>;
 
 export type TodoSelected<S extends keyof Todo | "*" = keyof Todo> = "*" extends S
   ? Todo
@@ -145,8 +151,7 @@ export type TodoSelected<S extends keyof Todo | "*" = keyof Todo> = "*" extends 
 export type TodoSelectedWithIncludes<
   I extends TodoInclude = {},
   S extends keyof Todo | "*" = keyof Todo,
-> = Omit<TodoSelected<S>, keyof TodoInclude> &
-  Omit<TodoWithIncludes<I>, keyof Omit<Todo, keyof TodoInclude>>;
+> = Omit<TodoSelected<S>, Extract<keyof I, keyof TodoSelected<S>>> & TodoIncludedRelations<I>;
 
 export const wasmSchema: WasmSchema = {
   projects: {

--- a/examples/todo-client-localfirst-react/schema/app.ts
+++ b/examples/todo-client-localfirst-react/schema/app.ts
@@ -52,13 +52,13 @@ export interface TodoWhereInput {
 }
 
 export interface ProjectInclude {
-  todosViaProject?: true | TodoInclude | TodoQueryBuilder;
+  todosViaProject?: true | TodoInclude | TodoQueryBuilder<any, any>;
 }
 
 export interface TodoInclude {
-  parent?: true | TodoInclude | TodoQueryBuilder;
-  todosViaParent?: true | TodoInclude | TodoQueryBuilder;
-  project?: true | ProjectInclude | ProjectQueryBuilder;
+  parent?: true | TodoInclude | TodoQueryBuilder<any, any>;
+  todosViaParent?: true | TodoInclude | TodoQueryBuilder<any, any>;
+  project?: true | ProjectInclude | ProjectQueryBuilder<any, any>;
 }
 
 export interface ProjectRelations {

--- a/examples/todo-client-localfirst-react/schema/app.ts
+++ b/examples/todo-client-localfirst-react/schema/app.ts
@@ -82,11 +82,11 @@ export type TodoIncludedRelations<I extends TodoInclude = {}> = {
   [K in keyof I]-?: K extends "parent"
     ? NonNullable<I["parent"]> extends infer RelationInclude
       ? RelationInclude extends true
-        ? Todo
+        ? Todo | undefined
         : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
-          ? QueryRow
+          ? QueryRow | undefined
           : RelationInclude extends TodoInclude
-            ? TodoWithIncludes<RelationInclude>
+            ? TodoWithIncludes<RelationInclude> | undefined
             : never
       : never
     : K extends "todosViaParent"
@@ -102,11 +102,11 @@ export type TodoIncludedRelations<I extends TodoInclude = {}> = {
       : K extends "project"
         ? NonNullable<I["project"]> extends infer RelationInclude
           ? RelationInclude extends true
-            ? Project
+            ? Project | undefined
             : RelationInclude extends AnyProjectQueryBuilder<infer QueryRow>
-              ? QueryRow
+              ? QueryRow | undefined
               : RelationInclude extends ProjectInclude
-                ? ProjectWithIncludes<RelationInclude>
+                ? ProjectWithIncludes<RelationInclude> | undefined
                 : never
           : never
         : never;

--- a/examples/todo-client-localfirst-react/schema/app.ts
+++ b/examples/todo-client-localfirst-react/schema/app.ts
@@ -71,7 +71,10 @@ export interface TodoRelations {
   project: Project;
 }
 
-export type ProjectWithIncludes<I extends ProjectInclude = {}> = Project & {
+export type ProjectWithIncludes<I extends ProjectInclude = {}> = Omit<
+  Project,
+  keyof ProjectInclude
+> & {
   todosViaProject?: NonNullable<I["todosViaProject"]> extends infer RelationInclude
     ? RelationInclude extends true
       ? Todo[]
@@ -86,7 +89,7 @@ export type ProjectWithIncludes<I extends ProjectInclude = {}> = Project & {
     : never;
 };
 
-export type TodoWithIncludes<I extends TodoInclude = {}> = Todo & {
+export type TodoWithIncludes<I extends TodoInclude = {}> = Omit<Todo, keyof TodoInclude> & {
   parent?: NonNullable<I["parent"]> extends infer RelationInclude
     ? RelationInclude extends true
       ? Todo
@@ -132,7 +135,8 @@ export type ProjectSelected<S extends keyof Project | "*" = keyof Project> = "*"
 export type ProjectSelectedWithIncludes<
   I extends ProjectInclude = {},
   S extends keyof Project | "*" = keyof Project,
-> = ProjectSelected<S> & Omit<ProjectWithIncludes<I>, keyof Project>;
+> = Omit<ProjectSelected<S>, keyof ProjectInclude> &
+  Omit<ProjectWithIncludes<I>, keyof Omit<Project, keyof ProjectInclude>>;
 
 export type TodoSelected<S extends keyof Todo | "*" = keyof Todo> = "*" extends S
   ? Todo
@@ -141,7 +145,8 @@ export type TodoSelected<S extends keyof Todo | "*" = keyof Todo> = "*" extends 
 export type TodoSelectedWithIncludes<
   I extends TodoInclude = {},
   S extends keyof Todo | "*" = keyof Todo,
-> = TodoSelected<S> & Omit<TodoWithIncludes<I>, keyof Todo>;
+> = Omit<TodoSelected<S>, keyof TodoInclude> &
+  Omit<TodoWithIncludes<I>, keyof Omit<Todo, keyof TodoInclude>>;
 
 export const wasmSchema: WasmSchema = {
   projects: {

--- a/examples/todo-client-localfirst-svelte/schema/app.ts
+++ b/examples/todo-client-localfirst-svelte/schema/app.ts
@@ -51,15 +51,66 @@ export interface TodoWhereInput {
   project?: string | { eq?: string; ne?: string; isNull?: boolean };
 }
 
+type AnyProjectQueryBuilder<T = any> = { readonly _table: "projects" } & QueryBuilder<T>;
+type AnyTodoQueryBuilder<T = any> = { readonly _table: "todos" } & QueryBuilder<T>;
+
 export interface ProjectInclude {
-  todosViaProject?: true | TodoInclude | TodoQueryBuilder<any, any>;
+  todosViaProject?: true | TodoInclude | AnyTodoQueryBuilder<any>;
 }
 
 export interface TodoInclude {
-  parent?: true | TodoInclude | TodoQueryBuilder<any, any>;
-  todosViaParent?: true | TodoInclude | TodoQueryBuilder<any, any>;
-  project?: true | ProjectInclude | ProjectQueryBuilder<any, any>;
+  parent?: true | TodoInclude | AnyTodoQueryBuilder<any>;
+  todosViaParent?: true | TodoInclude | AnyTodoQueryBuilder<any>;
+  project?: true | ProjectInclude | AnyProjectQueryBuilder<any>;
 }
+
+export type ProjectIncludedRelations<I extends ProjectInclude = {}> = {
+  [K in keyof I]-?: K extends "todosViaProject"
+    ? NonNullable<I["todosViaProject"]> extends infer RelationInclude
+      ? RelationInclude extends true
+        ? Todo[]
+        : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
+          ? QueryRow[]
+          : RelationInclude extends TodoInclude
+            ? TodoWithIncludes<RelationInclude>[]
+            : never
+      : never
+    : never;
+};
+
+export type TodoIncludedRelations<I extends TodoInclude = {}> = {
+  [K in keyof I]-?: K extends "parent"
+    ? NonNullable<I["parent"]> extends infer RelationInclude
+      ? RelationInclude extends true
+        ? Todo
+        : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
+          ? QueryRow
+          : RelationInclude extends TodoInclude
+            ? TodoWithIncludes<RelationInclude>
+            : never
+      : never
+    : K extends "todosViaParent"
+      ? NonNullable<I["todosViaParent"]> extends infer RelationInclude
+        ? RelationInclude extends true
+          ? Todo[]
+          : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
+            ? QueryRow[]
+            : RelationInclude extends TodoInclude
+              ? TodoWithIncludes<RelationInclude>[]
+              : never
+        : never
+      : K extends "project"
+        ? NonNullable<I["project"]> extends infer RelationInclude
+          ? RelationInclude extends true
+            ? Project
+            : RelationInclude extends AnyProjectQueryBuilder<infer QueryRow>
+              ? QueryRow
+              : RelationInclude extends ProjectInclude
+                ? ProjectWithIncludes<RelationInclude>
+                : never
+          : never
+        : never;
+};
 
 export interface ProjectRelations {
   todosViaProject: Todo[];
@@ -73,60 +124,15 @@ export interface TodoRelations {
 
 export type ProjectWithIncludes<I extends ProjectInclude = {}> = Omit<
   Project,
-  keyof ProjectInclude
-> & {
-  todosViaProject?: NonNullable<I["todosViaProject"]> extends infer RelationInclude
-    ? RelationInclude extends true
-      ? Todo[]
-      : RelationInclude extends TodoQueryBuilder<
-            infer QueryInclude extends TodoInclude,
-            infer QuerySelect extends keyof Todo | "*"
-          >
-        ? TodoSelectedWithIncludes<QueryInclude, QuerySelect>[]
-        : RelationInclude extends TodoInclude
-          ? TodoWithIncludes<RelationInclude>[]
-          : never
-    : never;
-};
+  Extract<keyof I, keyof Project>
+> &
+  ProjectIncludedRelations<I>;
 
-export type TodoWithIncludes<I extends TodoInclude = {}> = Omit<Todo, keyof TodoInclude> & {
-  parent?: NonNullable<I["parent"]> extends infer RelationInclude
-    ? RelationInclude extends true
-      ? Todo
-      : RelationInclude extends TodoQueryBuilder<
-            infer QueryInclude extends TodoInclude,
-            infer QuerySelect extends keyof Todo | "*"
-          >
-        ? TodoSelectedWithIncludes<QueryInclude, QuerySelect>
-        : RelationInclude extends TodoInclude
-          ? TodoWithIncludes<RelationInclude>
-          : never
-    : never;
-  todosViaParent?: NonNullable<I["todosViaParent"]> extends infer RelationInclude
-    ? RelationInclude extends true
-      ? Todo[]
-      : RelationInclude extends TodoQueryBuilder<
-            infer QueryInclude extends TodoInclude,
-            infer QuerySelect extends keyof Todo | "*"
-          >
-        ? TodoSelectedWithIncludes<QueryInclude, QuerySelect>[]
-        : RelationInclude extends TodoInclude
-          ? TodoWithIncludes<RelationInclude>[]
-          : never
-    : never;
-  project?: NonNullable<I["project"]> extends infer RelationInclude
-    ? RelationInclude extends true
-      ? Project
-      : RelationInclude extends ProjectQueryBuilder<
-            infer QueryInclude extends ProjectInclude,
-            infer QuerySelect extends keyof Project | "*"
-          >
-        ? ProjectSelectedWithIncludes<QueryInclude, QuerySelect>
-        : RelationInclude extends ProjectInclude
-          ? ProjectWithIncludes<RelationInclude>
-          : never
-    : never;
-};
+export type TodoWithIncludes<I extends TodoInclude = {}> = Omit<
+  Todo,
+  Extract<keyof I, keyof Todo>
+> &
+  TodoIncludedRelations<I>;
 
 export type ProjectSelected<S extends keyof Project | "*" = keyof Project> = "*" extends S
   ? Project
@@ -135,8 +141,8 @@ export type ProjectSelected<S extends keyof Project | "*" = keyof Project> = "*"
 export type ProjectSelectedWithIncludes<
   I extends ProjectInclude = {},
   S extends keyof Project | "*" = keyof Project,
-> = Omit<ProjectSelected<S>, keyof ProjectInclude> &
-  Omit<ProjectWithIncludes<I>, keyof Omit<Project, keyof ProjectInclude>>;
+> = Omit<ProjectSelected<S>, Extract<keyof I, keyof ProjectSelected<S>>> &
+  ProjectIncludedRelations<I>;
 
 export type TodoSelected<S extends keyof Todo | "*" = keyof Todo> = "*" extends S
   ? Todo
@@ -145,8 +151,7 @@ export type TodoSelected<S extends keyof Todo | "*" = keyof Todo> = "*" extends 
 export type TodoSelectedWithIncludes<
   I extends TodoInclude = {},
   S extends keyof Todo | "*" = keyof Todo,
-> = Omit<TodoSelected<S>, keyof TodoInclude> &
-  Omit<TodoWithIncludes<I>, keyof Omit<Todo, keyof TodoInclude>>;
+> = Omit<TodoSelected<S>, Extract<keyof I, keyof TodoSelected<S>>> & TodoIncludedRelations<I>;
 
 export const wasmSchema: WasmSchema = {
   projects: {

--- a/examples/todo-client-localfirst-svelte/schema/app.ts
+++ b/examples/todo-client-localfirst-svelte/schema/app.ts
@@ -52,13 +52,13 @@ export interface TodoWhereInput {
 }
 
 export interface ProjectInclude {
-  todosViaProject?: true | TodoInclude | TodoQueryBuilder;
+  todosViaProject?: true | TodoInclude | TodoQueryBuilder<any, any>;
 }
 
 export interface TodoInclude {
-  parent?: true | TodoInclude | TodoQueryBuilder;
-  todosViaParent?: true | TodoInclude | TodoQueryBuilder;
-  project?: true | ProjectInclude | ProjectQueryBuilder;
+  parent?: true | TodoInclude | TodoQueryBuilder<any, any>;
+  todosViaParent?: true | TodoInclude | TodoQueryBuilder<any, any>;
+  project?: true | ProjectInclude | ProjectQueryBuilder<any, any>;
 }
 
 export interface ProjectRelations {

--- a/examples/todo-client-localfirst-svelte/schema/app.ts
+++ b/examples/todo-client-localfirst-svelte/schema/app.ts
@@ -82,11 +82,11 @@ export type TodoIncludedRelations<I extends TodoInclude = {}> = {
   [K in keyof I]-?: K extends "parent"
     ? NonNullable<I["parent"]> extends infer RelationInclude
       ? RelationInclude extends true
-        ? Todo
+        ? Todo | undefined
         : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
-          ? QueryRow
+          ? QueryRow | undefined
           : RelationInclude extends TodoInclude
-            ? TodoWithIncludes<RelationInclude>
+            ? TodoWithIncludes<RelationInclude> | undefined
             : never
       : never
     : K extends "todosViaParent"
@@ -102,11 +102,11 @@ export type TodoIncludedRelations<I extends TodoInclude = {}> = {
       : K extends "project"
         ? NonNullable<I["project"]> extends infer RelationInclude
           ? RelationInclude extends true
-            ? Project
+            ? Project | undefined
             : RelationInclude extends AnyProjectQueryBuilder<infer QueryRow>
-              ? QueryRow
+              ? QueryRow | undefined
               : RelationInclude extends ProjectInclude
-                ? ProjectWithIncludes<RelationInclude>
+                ? ProjectWithIncludes<RelationInclude> | undefined
                 : never
           : never
         : never;

--- a/examples/todo-client-localfirst-svelte/schema/app.ts
+++ b/examples/todo-client-localfirst-svelte/schema/app.ts
@@ -71,7 +71,10 @@ export interface TodoRelations {
   project: Project;
 }
 
-export type ProjectWithIncludes<I extends ProjectInclude = {}> = Project & {
+export type ProjectWithIncludes<I extends ProjectInclude = {}> = Omit<
+  Project,
+  keyof ProjectInclude
+> & {
   todosViaProject?: NonNullable<I["todosViaProject"]> extends infer RelationInclude
     ? RelationInclude extends true
       ? Todo[]
@@ -86,7 +89,7 @@ export type ProjectWithIncludes<I extends ProjectInclude = {}> = Project & {
     : never;
 };
 
-export type TodoWithIncludes<I extends TodoInclude = {}> = Todo & {
+export type TodoWithIncludes<I extends TodoInclude = {}> = Omit<Todo, keyof TodoInclude> & {
   parent?: NonNullable<I["parent"]> extends infer RelationInclude
     ? RelationInclude extends true
       ? Todo
@@ -132,7 +135,8 @@ export type ProjectSelected<S extends keyof Project | "*" = keyof Project> = "*"
 export type ProjectSelectedWithIncludes<
   I extends ProjectInclude = {},
   S extends keyof Project | "*" = keyof Project,
-> = ProjectSelected<S> & Omit<ProjectWithIncludes<I>, keyof Project>;
+> = Omit<ProjectSelected<S>, keyof ProjectInclude> &
+  Omit<ProjectWithIncludes<I>, keyof Omit<Project, keyof ProjectInclude>>;
 
 export type TodoSelected<S extends keyof Todo | "*" = keyof Todo> = "*" extends S
   ? Todo
@@ -141,7 +145,8 @@ export type TodoSelected<S extends keyof Todo | "*" = keyof Todo> = "*" extends 
 export type TodoSelectedWithIncludes<
   I extends TodoInclude = {},
   S extends keyof Todo | "*" = keyof Todo,
-> = TodoSelected<S> & Omit<TodoWithIncludes<I>, keyof Todo>;
+> = Omit<TodoSelected<S>, keyof TodoInclude> &
+  Omit<TodoWithIncludes<I>, keyof Omit<Todo, keyof TodoInclude>>;
 
 export const wasmSchema: WasmSchema = {
   projects: {

--- a/examples/todo-client-localfirst-ts/schema/app.ts
+++ b/examples/todo-client-localfirst-ts/schema/app.ts
@@ -51,15 +51,66 @@ export interface TodoWhereInput {
   project?: string | { eq?: string; ne?: string; isNull?: boolean };
 }
 
+type AnyProjectQueryBuilder<T = any> = { readonly _table: "projects" } & QueryBuilder<T>;
+type AnyTodoQueryBuilder<T = any> = { readonly _table: "todos" } & QueryBuilder<T>;
+
 export interface ProjectInclude {
-  todosViaProject?: true | TodoInclude | TodoQueryBuilder<any, any>;
+  todosViaProject?: true | TodoInclude | AnyTodoQueryBuilder<any>;
 }
 
 export interface TodoInclude {
-  parent?: true | TodoInclude | TodoQueryBuilder<any, any>;
-  todosViaParent?: true | TodoInclude | TodoQueryBuilder<any, any>;
-  project?: true | ProjectInclude | ProjectQueryBuilder<any, any>;
+  parent?: true | TodoInclude | AnyTodoQueryBuilder<any>;
+  todosViaParent?: true | TodoInclude | AnyTodoQueryBuilder<any>;
+  project?: true | ProjectInclude | AnyProjectQueryBuilder<any>;
 }
+
+export type ProjectIncludedRelations<I extends ProjectInclude = {}> = {
+  [K in keyof I]-?: K extends "todosViaProject"
+    ? NonNullable<I["todosViaProject"]> extends infer RelationInclude
+      ? RelationInclude extends true
+        ? Todo[]
+        : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
+          ? QueryRow[]
+          : RelationInclude extends TodoInclude
+            ? TodoWithIncludes<RelationInclude>[]
+            : never
+      : never
+    : never;
+};
+
+export type TodoIncludedRelations<I extends TodoInclude = {}> = {
+  [K in keyof I]-?: K extends "parent"
+    ? NonNullable<I["parent"]> extends infer RelationInclude
+      ? RelationInclude extends true
+        ? Todo
+        : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
+          ? QueryRow
+          : RelationInclude extends TodoInclude
+            ? TodoWithIncludes<RelationInclude>
+            : never
+      : never
+    : K extends "todosViaParent"
+      ? NonNullable<I["todosViaParent"]> extends infer RelationInclude
+        ? RelationInclude extends true
+          ? Todo[]
+          : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
+            ? QueryRow[]
+            : RelationInclude extends TodoInclude
+              ? TodoWithIncludes<RelationInclude>[]
+              : never
+        : never
+      : K extends "project"
+        ? NonNullable<I["project"]> extends infer RelationInclude
+          ? RelationInclude extends true
+            ? Project
+            : RelationInclude extends AnyProjectQueryBuilder<infer QueryRow>
+              ? QueryRow
+              : RelationInclude extends ProjectInclude
+                ? ProjectWithIncludes<RelationInclude>
+                : never
+          : never
+        : never;
+};
 
 export interface ProjectRelations {
   todosViaProject: Todo[];
@@ -73,60 +124,15 @@ export interface TodoRelations {
 
 export type ProjectWithIncludes<I extends ProjectInclude = {}> = Omit<
   Project,
-  keyof ProjectInclude
-> & {
-  todosViaProject?: NonNullable<I["todosViaProject"]> extends infer RelationInclude
-    ? RelationInclude extends true
-      ? Todo[]
-      : RelationInclude extends TodoQueryBuilder<
-            infer QueryInclude extends TodoInclude,
-            infer QuerySelect extends keyof Todo | "*"
-          >
-        ? TodoSelectedWithIncludes<QueryInclude, QuerySelect>[]
-        : RelationInclude extends TodoInclude
-          ? TodoWithIncludes<RelationInclude>[]
-          : never
-    : never;
-};
+  Extract<keyof I, keyof Project>
+> &
+  ProjectIncludedRelations<I>;
 
-export type TodoWithIncludes<I extends TodoInclude = {}> = Omit<Todo, keyof TodoInclude> & {
-  parent?: NonNullable<I["parent"]> extends infer RelationInclude
-    ? RelationInclude extends true
-      ? Todo
-      : RelationInclude extends TodoQueryBuilder<
-            infer QueryInclude extends TodoInclude,
-            infer QuerySelect extends keyof Todo | "*"
-          >
-        ? TodoSelectedWithIncludes<QueryInclude, QuerySelect>
-        : RelationInclude extends TodoInclude
-          ? TodoWithIncludes<RelationInclude>
-          : never
-    : never;
-  todosViaParent?: NonNullable<I["todosViaParent"]> extends infer RelationInclude
-    ? RelationInclude extends true
-      ? Todo[]
-      : RelationInclude extends TodoQueryBuilder<
-            infer QueryInclude extends TodoInclude,
-            infer QuerySelect extends keyof Todo | "*"
-          >
-        ? TodoSelectedWithIncludes<QueryInclude, QuerySelect>[]
-        : RelationInclude extends TodoInclude
-          ? TodoWithIncludes<RelationInclude>[]
-          : never
-    : never;
-  project?: NonNullable<I["project"]> extends infer RelationInclude
-    ? RelationInclude extends true
-      ? Project
-      : RelationInclude extends ProjectQueryBuilder<
-            infer QueryInclude extends ProjectInclude,
-            infer QuerySelect extends keyof Project | "*"
-          >
-        ? ProjectSelectedWithIncludes<QueryInclude, QuerySelect>
-        : RelationInclude extends ProjectInclude
-          ? ProjectWithIncludes<RelationInclude>
-          : never
-    : never;
-};
+export type TodoWithIncludes<I extends TodoInclude = {}> = Omit<
+  Todo,
+  Extract<keyof I, keyof Todo>
+> &
+  TodoIncludedRelations<I>;
 
 export type ProjectSelected<S extends keyof Project | "*" = keyof Project> = "*" extends S
   ? Project
@@ -135,8 +141,8 @@ export type ProjectSelected<S extends keyof Project | "*" = keyof Project> = "*"
 export type ProjectSelectedWithIncludes<
   I extends ProjectInclude = {},
   S extends keyof Project | "*" = keyof Project,
-> = Omit<ProjectSelected<S>, keyof ProjectInclude> &
-  Omit<ProjectWithIncludes<I>, keyof Omit<Project, keyof ProjectInclude>>;
+> = Omit<ProjectSelected<S>, Extract<keyof I, keyof ProjectSelected<S>>> &
+  ProjectIncludedRelations<I>;
 
 export type TodoSelected<S extends keyof Todo | "*" = keyof Todo> = "*" extends S
   ? Todo
@@ -145,8 +151,7 @@ export type TodoSelected<S extends keyof Todo | "*" = keyof Todo> = "*" extends 
 export type TodoSelectedWithIncludes<
   I extends TodoInclude = {},
   S extends keyof Todo | "*" = keyof Todo,
-> = Omit<TodoSelected<S>, keyof TodoInclude> &
-  Omit<TodoWithIncludes<I>, keyof Omit<Todo, keyof TodoInclude>>;
+> = Omit<TodoSelected<S>, Extract<keyof I, keyof TodoSelected<S>>> & TodoIncludedRelations<I>;
 
 export const wasmSchema: WasmSchema = {
   projects: {

--- a/examples/todo-client-localfirst-ts/schema/app.ts
+++ b/examples/todo-client-localfirst-ts/schema/app.ts
@@ -52,13 +52,13 @@ export interface TodoWhereInput {
 }
 
 export interface ProjectInclude {
-  todosViaProject?: true | TodoInclude | TodoQueryBuilder;
+  todosViaProject?: true | TodoInclude | TodoQueryBuilder<any, any>;
 }
 
 export interface TodoInclude {
-  parent?: true | TodoInclude | TodoQueryBuilder;
-  todosViaParent?: true | TodoInclude | TodoQueryBuilder;
-  project?: true | ProjectInclude | ProjectQueryBuilder;
+  parent?: true | TodoInclude | TodoQueryBuilder<any, any>;
+  todosViaParent?: true | TodoInclude | TodoQueryBuilder<any, any>;
+  project?: true | ProjectInclude | ProjectQueryBuilder<any, any>;
 }
 
 export interface ProjectRelations {

--- a/examples/todo-client-localfirst-ts/schema/app.ts
+++ b/examples/todo-client-localfirst-ts/schema/app.ts
@@ -82,11 +82,11 @@ export type TodoIncludedRelations<I extends TodoInclude = {}> = {
   [K in keyof I]-?: K extends "parent"
     ? NonNullable<I["parent"]> extends infer RelationInclude
       ? RelationInclude extends true
-        ? Todo
+        ? Todo | undefined
         : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
-          ? QueryRow
+          ? QueryRow | undefined
           : RelationInclude extends TodoInclude
-            ? TodoWithIncludes<RelationInclude>
+            ? TodoWithIncludes<RelationInclude> | undefined
             : never
       : never
     : K extends "todosViaParent"
@@ -102,11 +102,11 @@ export type TodoIncludedRelations<I extends TodoInclude = {}> = {
       : K extends "project"
         ? NonNullable<I["project"]> extends infer RelationInclude
           ? RelationInclude extends true
-            ? Project
+            ? Project | undefined
             : RelationInclude extends AnyProjectQueryBuilder<infer QueryRow>
-              ? QueryRow
+              ? QueryRow | undefined
               : RelationInclude extends ProjectInclude
-                ? ProjectWithIncludes<RelationInclude>
+                ? ProjectWithIncludes<RelationInclude> | undefined
                 : never
           : never
         : never;

--- a/examples/todo-client-localfirst-ts/schema/app.ts
+++ b/examples/todo-client-localfirst-ts/schema/app.ts
@@ -71,7 +71,10 @@ export interface TodoRelations {
   project: Project;
 }
 
-export type ProjectWithIncludes<I extends ProjectInclude = {}> = Project & {
+export type ProjectWithIncludes<I extends ProjectInclude = {}> = Omit<
+  Project,
+  keyof ProjectInclude
+> & {
   todosViaProject?: NonNullable<I["todosViaProject"]> extends infer RelationInclude
     ? RelationInclude extends true
       ? Todo[]
@@ -86,7 +89,7 @@ export type ProjectWithIncludes<I extends ProjectInclude = {}> = Project & {
     : never;
 };
 
-export type TodoWithIncludes<I extends TodoInclude = {}> = Todo & {
+export type TodoWithIncludes<I extends TodoInclude = {}> = Omit<Todo, keyof TodoInclude> & {
   parent?: NonNullable<I["parent"]> extends infer RelationInclude
     ? RelationInclude extends true
       ? Todo
@@ -132,7 +135,8 @@ export type ProjectSelected<S extends keyof Project | "*" = keyof Project> = "*"
 export type ProjectSelectedWithIncludes<
   I extends ProjectInclude = {},
   S extends keyof Project | "*" = keyof Project,
-> = ProjectSelected<S> & Omit<ProjectWithIncludes<I>, keyof Project>;
+> = Omit<ProjectSelected<S>, keyof ProjectInclude> &
+  Omit<ProjectWithIncludes<I>, keyof Omit<Project, keyof ProjectInclude>>;
 
 export type TodoSelected<S extends keyof Todo | "*" = keyof Todo> = "*" extends S
   ? Todo
@@ -141,7 +145,8 @@ export type TodoSelected<S extends keyof Todo | "*" = keyof Todo> = "*" extends 
 export type TodoSelectedWithIncludes<
   I extends TodoInclude = {},
   S extends keyof Todo | "*" = keyof Todo,
-> = TodoSelected<S> & Omit<TodoWithIncludes<I>, keyof Todo>;
+> = Omit<TodoSelected<S>, keyof TodoInclude> &
+  Omit<TodoWithIncludes<I>, keyof Omit<Todo, keyof TodoInclude>>;
 
 export const wasmSchema: WasmSchema = {
   projects: {

--- a/examples/wequencer/schema/app.ts
+++ b/examples/wequencer/schema/app.ts
@@ -154,7 +154,10 @@ export interface ParticipantRelations {
   jam: Jam;
 }
 
-export type InstrumentWithIncludes<I extends InstrumentInclude = {}> = Instrument & {
+export type InstrumentWithIncludes<I extends InstrumentInclude = {}> = Omit<
+  Instrument,
+  keyof InstrumentInclude
+> & {
   beatsViaInstrument?: NonNullable<I["beatsViaInstrument"]> extends infer RelationInclude
     ? RelationInclude extends true
       ? Beat[]
@@ -169,7 +172,7 @@ export type InstrumentWithIncludes<I extends InstrumentInclude = {}> = Instrumen
     : never;
 };
 
-export type JamWithIncludes<I extends JamInclude = {}> = Jam & {
+export type JamWithIncludes<I extends JamInclude = {}> = Omit<Jam, keyof JamInclude> & {
   beatsViaJam?: NonNullable<I["beatsViaJam"]> extends infer RelationInclude
     ? RelationInclude extends true
       ? Beat[]
@@ -196,7 +199,7 @@ export type JamWithIncludes<I extends JamInclude = {}> = Jam & {
     : never;
 };
 
-export type BeatWithIncludes<I extends BeatInclude = {}> = Beat & {
+export type BeatWithIncludes<I extends BeatInclude = {}> = Omit<Beat, keyof BeatInclude> & {
   jam?: NonNullable<I["jam"]> extends infer RelationInclude
     ? RelationInclude extends true
       ? Jam
@@ -223,7 +226,10 @@ export type BeatWithIncludes<I extends BeatInclude = {}> = Beat & {
     : never;
 };
 
-export type ParticipantWithIncludes<I extends ParticipantInclude = {}> = Participant & {
+export type ParticipantWithIncludes<I extends ParticipantInclude = {}> = Omit<
+  Participant,
+  keyof ParticipantInclude
+> & {
   jam?: NonNullable<I["jam"]> extends infer RelationInclude
     ? RelationInclude extends true
       ? Jam
@@ -245,7 +251,8 @@ export type InstrumentSelected<S extends keyof Instrument | "*" = keyof Instrume
 export type InstrumentSelectedWithIncludes<
   I extends InstrumentInclude = {},
   S extends keyof Instrument | "*" = keyof Instrument,
-> = InstrumentSelected<S> & Omit<InstrumentWithIncludes<I>, keyof Instrument>;
+> = Omit<InstrumentSelected<S>, keyof InstrumentInclude> &
+  Omit<InstrumentWithIncludes<I>, keyof Omit<Instrument, keyof InstrumentInclude>>;
 
 export type JamSelected<S extends keyof Jam | "*" = keyof Jam> = "*" extends S
   ? Jam
@@ -254,7 +261,8 @@ export type JamSelected<S extends keyof Jam | "*" = keyof Jam> = "*" extends S
 export type JamSelectedWithIncludes<
   I extends JamInclude = {},
   S extends keyof Jam | "*" = keyof Jam,
-> = JamSelected<S> & Omit<JamWithIncludes<I>, keyof Jam>;
+> = Omit<JamSelected<S>, keyof JamInclude> &
+  Omit<JamWithIncludes<I>, keyof Omit<Jam, keyof JamInclude>>;
 
 export type BeatSelected<S extends keyof Beat | "*" = keyof Beat> = "*" extends S
   ? Beat
@@ -263,7 +271,8 @@ export type BeatSelected<S extends keyof Beat | "*" = keyof Beat> = "*" extends 
 export type BeatSelectedWithIncludes<
   I extends BeatInclude = {},
   S extends keyof Beat | "*" = keyof Beat,
-> = BeatSelected<S> & Omit<BeatWithIncludes<I>, keyof Beat>;
+> = Omit<BeatSelected<S>, keyof BeatInclude> &
+  Omit<BeatWithIncludes<I>, keyof Omit<Beat, keyof BeatInclude>>;
 
 export type ParticipantSelected<S extends keyof Participant | "*" = keyof Participant> =
   "*" extends S ? Participant : Pick<Participant, Extract<S | "id", keyof Participant>>;
@@ -271,7 +280,8 @@ export type ParticipantSelected<S extends keyof Participant | "*" = keyof Partic
 export type ParticipantSelectedWithIncludes<
   I extends ParticipantInclude = {},
   S extends keyof Participant | "*" = keyof Participant,
-> = ParticipantSelected<S> & Omit<ParticipantWithIncludes<I>, keyof Participant>;
+> = Omit<ParticipantSelected<S>, keyof ParticipantInclude> &
+  Omit<ParticipantWithIncludes<I>, keyof Omit<Participant, keyof ParticipantInclude>>;
 
 export const wasmSchema: WasmSchema = {
   instruments: {

--- a/examples/wequencer/schema/app.ts
+++ b/examples/wequencer/schema/app.ts
@@ -118,23 +118,104 @@ export interface ParticipantWhereInput {
   display_name?: string | { eq?: string; ne?: string; contains?: string };
 }
 
+type AnyInstrumentQueryBuilder<T = any> = { readonly _table: "instruments" } & QueryBuilder<T>;
+type AnyJamQueryBuilder<T = any> = { readonly _table: "jams" } & QueryBuilder<T>;
+type AnyBeatQueryBuilder<T = any> = { readonly _table: "beats" } & QueryBuilder<T>;
+type AnyParticipantQueryBuilder<T = any> = { readonly _table: "participants" } & QueryBuilder<T>;
+
 export interface InstrumentInclude {
-  beatsViaInstrument?: true | BeatInclude | BeatQueryBuilder<any, any>;
+  beatsViaInstrument?: true | BeatInclude | AnyBeatQueryBuilder<any>;
 }
 
 export interface JamInclude {
-  beatsViaJam?: true | BeatInclude | BeatQueryBuilder<any, any>;
-  participantsViaJam?: true | ParticipantInclude | ParticipantQueryBuilder<any, any>;
+  beatsViaJam?: true | BeatInclude | AnyBeatQueryBuilder<any>;
+  participantsViaJam?: true | ParticipantInclude | AnyParticipantQueryBuilder<any>;
 }
 
 export interface BeatInclude {
-  jam?: true | JamInclude | JamQueryBuilder<any, any>;
-  instrument?: true | InstrumentInclude | InstrumentQueryBuilder<any, any>;
+  jam?: true | JamInclude | AnyJamQueryBuilder<any>;
+  instrument?: true | InstrumentInclude | AnyInstrumentQueryBuilder<any>;
 }
 
 export interface ParticipantInclude {
-  jam?: true | JamInclude | JamQueryBuilder<any, any>;
+  jam?: true | JamInclude | AnyJamQueryBuilder<any>;
 }
+
+export type InstrumentIncludedRelations<I extends InstrumentInclude = {}> = {
+  [K in keyof I]-?: K extends "beatsViaInstrument"
+    ? NonNullable<I["beatsViaInstrument"]> extends infer RelationInclude
+      ? RelationInclude extends true
+        ? Beat[]
+        : RelationInclude extends AnyBeatQueryBuilder<infer QueryRow>
+          ? QueryRow[]
+          : RelationInclude extends BeatInclude
+            ? BeatWithIncludes<RelationInclude>[]
+            : never
+      : never
+    : never;
+};
+
+export type JamIncludedRelations<I extends JamInclude = {}> = {
+  [K in keyof I]-?: K extends "beatsViaJam"
+    ? NonNullable<I["beatsViaJam"]> extends infer RelationInclude
+      ? RelationInclude extends true
+        ? Beat[]
+        : RelationInclude extends AnyBeatQueryBuilder<infer QueryRow>
+          ? QueryRow[]
+          : RelationInclude extends BeatInclude
+            ? BeatWithIncludes<RelationInclude>[]
+            : never
+      : never
+    : K extends "participantsViaJam"
+      ? NonNullable<I["participantsViaJam"]> extends infer RelationInclude
+        ? RelationInclude extends true
+          ? Participant[]
+          : RelationInclude extends AnyParticipantQueryBuilder<infer QueryRow>
+            ? QueryRow[]
+            : RelationInclude extends ParticipantInclude
+              ? ParticipantWithIncludes<RelationInclude>[]
+              : never
+        : never
+      : never;
+};
+
+export type BeatIncludedRelations<I extends BeatInclude = {}> = {
+  [K in keyof I]-?: K extends "jam"
+    ? NonNullable<I["jam"]> extends infer RelationInclude
+      ? RelationInclude extends true
+        ? Jam
+        : RelationInclude extends AnyJamQueryBuilder<infer QueryRow>
+          ? QueryRow
+          : RelationInclude extends JamInclude
+            ? JamWithIncludes<RelationInclude>
+            : never
+      : never
+    : K extends "instrument"
+      ? NonNullable<I["instrument"]> extends infer RelationInclude
+        ? RelationInclude extends true
+          ? Instrument
+          : RelationInclude extends AnyInstrumentQueryBuilder<infer QueryRow>
+            ? QueryRow
+            : RelationInclude extends InstrumentInclude
+              ? InstrumentWithIncludes<RelationInclude>
+              : never
+        : never
+      : never;
+};
+
+export type ParticipantIncludedRelations<I extends ParticipantInclude = {}> = {
+  [K in keyof I]-?: K extends "jam"
+    ? NonNullable<I["jam"]> extends infer RelationInclude
+      ? RelationInclude extends true
+        ? Jam
+        : RelationInclude extends AnyJamQueryBuilder<infer QueryRow>
+          ? QueryRow
+          : RelationInclude extends JamInclude
+            ? JamWithIncludes<RelationInclude>
+            : never
+      : never
+    : never;
+};
 
 export interface InstrumentRelations {
   beatsViaInstrument: Beat[];
@@ -156,93 +237,24 @@ export interface ParticipantRelations {
 
 export type InstrumentWithIncludes<I extends InstrumentInclude = {}> = Omit<
   Instrument,
-  keyof InstrumentInclude
-> & {
-  beatsViaInstrument?: NonNullable<I["beatsViaInstrument"]> extends infer RelationInclude
-    ? RelationInclude extends true
-      ? Beat[]
-      : RelationInclude extends BeatQueryBuilder<
-            infer QueryInclude extends BeatInclude,
-            infer QuerySelect extends keyof Beat | "*"
-          >
-        ? BeatSelectedWithIncludes<QueryInclude, QuerySelect>[]
-        : RelationInclude extends BeatInclude
-          ? BeatWithIncludes<RelationInclude>[]
-          : never
-    : never;
-};
+  Extract<keyof I, keyof Instrument>
+> &
+  InstrumentIncludedRelations<I>;
 
-export type JamWithIncludes<I extends JamInclude = {}> = Omit<Jam, keyof JamInclude> & {
-  beatsViaJam?: NonNullable<I["beatsViaJam"]> extends infer RelationInclude
-    ? RelationInclude extends true
-      ? Beat[]
-      : RelationInclude extends BeatQueryBuilder<
-            infer QueryInclude extends BeatInclude,
-            infer QuerySelect extends keyof Beat | "*"
-          >
-        ? BeatSelectedWithIncludes<QueryInclude, QuerySelect>[]
-        : RelationInclude extends BeatInclude
-          ? BeatWithIncludes<RelationInclude>[]
-          : never
-    : never;
-  participantsViaJam?: NonNullable<I["participantsViaJam"]> extends infer RelationInclude
-    ? RelationInclude extends true
-      ? Participant[]
-      : RelationInclude extends ParticipantQueryBuilder<
-            infer QueryInclude extends ParticipantInclude,
-            infer QuerySelect extends keyof Participant | "*"
-          >
-        ? ParticipantSelectedWithIncludes<QueryInclude, QuerySelect>[]
-        : RelationInclude extends ParticipantInclude
-          ? ParticipantWithIncludes<RelationInclude>[]
-          : never
-    : never;
-};
+export type JamWithIncludes<I extends JamInclude = {}> = Omit<Jam, Extract<keyof I, keyof Jam>> &
+  JamIncludedRelations<I>;
 
-export type BeatWithIncludes<I extends BeatInclude = {}> = Omit<Beat, keyof BeatInclude> & {
-  jam?: NonNullable<I["jam"]> extends infer RelationInclude
-    ? RelationInclude extends true
-      ? Jam
-      : RelationInclude extends JamQueryBuilder<
-            infer QueryInclude extends JamInclude,
-            infer QuerySelect extends keyof Jam | "*"
-          >
-        ? JamSelectedWithIncludes<QueryInclude, QuerySelect>
-        : RelationInclude extends JamInclude
-          ? JamWithIncludes<RelationInclude>
-          : never
-    : never;
-  instrument?: NonNullable<I["instrument"]> extends infer RelationInclude
-    ? RelationInclude extends true
-      ? Instrument
-      : RelationInclude extends InstrumentQueryBuilder<
-            infer QueryInclude extends InstrumentInclude,
-            infer QuerySelect extends keyof Instrument | "*"
-          >
-        ? InstrumentSelectedWithIncludes<QueryInclude, QuerySelect>
-        : RelationInclude extends InstrumentInclude
-          ? InstrumentWithIncludes<RelationInclude>
-          : never
-    : never;
-};
+export type BeatWithIncludes<I extends BeatInclude = {}> = Omit<
+  Beat,
+  Extract<keyof I, keyof Beat>
+> &
+  BeatIncludedRelations<I>;
 
 export type ParticipantWithIncludes<I extends ParticipantInclude = {}> = Omit<
   Participant,
-  keyof ParticipantInclude
-> & {
-  jam?: NonNullable<I["jam"]> extends infer RelationInclude
-    ? RelationInclude extends true
-      ? Jam
-      : RelationInclude extends JamQueryBuilder<
-            infer QueryInclude extends JamInclude,
-            infer QuerySelect extends keyof Jam | "*"
-          >
-        ? JamSelectedWithIncludes<QueryInclude, QuerySelect>
-        : RelationInclude extends JamInclude
-          ? JamWithIncludes<RelationInclude>
-          : never
-    : never;
-};
+  Extract<keyof I, keyof Participant>
+> &
+  ParticipantIncludedRelations<I>;
 
 export type InstrumentSelected<S extends keyof Instrument | "*" = keyof Instrument> = "*" extends S
   ? Instrument
@@ -251,8 +263,8 @@ export type InstrumentSelected<S extends keyof Instrument | "*" = keyof Instrume
 export type InstrumentSelectedWithIncludes<
   I extends InstrumentInclude = {},
   S extends keyof Instrument | "*" = keyof Instrument,
-> = Omit<InstrumentSelected<S>, keyof InstrumentInclude> &
-  Omit<InstrumentWithIncludes<I>, keyof Omit<Instrument, keyof InstrumentInclude>>;
+> = Omit<InstrumentSelected<S>, Extract<keyof I, keyof InstrumentSelected<S>>> &
+  InstrumentIncludedRelations<I>;
 
 export type JamSelected<S extends keyof Jam | "*" = keyof Jam> = "*" extends S
   ? Jam
@@ -261,8 +273,7 @@ export type JamSelected<S extends keyof Jam | "*" = keyof Jam> = "*" extends S
 export type JamSelectedWithIncludes<
   I extends JamInclude = {},
   S extends keyof Jam | "*" = keyof Jam,
-> = Omit<JamSelected<S>, keyof JamInclude> &
-  Omit<JamWithIncludes<I>, keyof Omit<Jam, keyof JamInclude>>;
+> = Omit<JamSelected<S>, Extract<keyof I, keyof JamSelected<S>>> & JamIncludedRelations<I>;
 
 export type BeatSelected<S extends keyof Beat | "*" = keyof Beat> = "*" extends S
   ? Beat
@@ -271,8 +282,7 @@ export type BeatSelected<S extends keyof Beat | "*" = keyof Beat> = "*" extends 
 export type BeatSelectedWithIncludes<
   I extends BeatInclude = {},
   S extends keyof Beat | "*" = keyof Beat,
-> = Omit<BeatSelected<S>, keyof BeatInclude> &
-  Omit<BeatWithIncludes<I>, keyof Omit<Beat, keyof BeatInclude>>;
+> = Omit<BeatSelected<S>, Extract<keyof I, keyof BeatSelected<S>>> & BeatIncludedRelations<I>;
 
 export type ParticipantSelected<S extends keyof Participant | "*" = keyof Participant> =
   "*" extends S ? Participant : Pick<Participant, Extract<S | "id", keyof Participant>>;
@@ -280,8 +290,8 @@ export type ParticipantSelected<S extends keyof Participant | "*" = keyof Partic
 export type ParticipantSelectedWithIncludes<
   I extends ParticipantInclude = {},
   S extends keyof Participant | "*" = keyof Participant,
-> = Omit<ParticipantSelected<S>, keyof ParticipantInclude> &
-  Omit<ParticipantWithIncludes<I>, keyof Omit<Participant, keyof ParticipantInclude>>;
+> = Omit<ParticipantSelected<S>, Extract<keyof I, keyof ParticipantSelected<S>>> &
+  ParticipantIncludedRelations<I>;
 
 export const wasmSchema: WasmSchema = {
   instruments: {

--- a/examples/wequencer/schema/app.ts
+++ b/examples/wequencer/schema/app.ts
@@ -119,21 +119,21 @@ export interface ParticipantWhereInput {
 }
 
 export interface InstrumentInclude {
-  beatsViaInstrument?: true | BeatInclude | BeatQueryBuilder;
+  beatsViaInstrument?: true | BeatInclude | BeatQueryBuilder<any, any>;
 }
 
 export interface JamInclude {
-  beatsViaJam?: true | BeatInclude | BeatQueryBuilder;
-  participantsViaJam?: true | ParticipantInclude | ParticipantQueryBuilder;
+  beatsViaJam?: true | BeatInclude | BeatQueryBuilder<any, any>;
+  participantsViaJam?: true | ParticipantInclude | ParticipantQueryBuilder<any, any>;
 }
 
 export interface BeatInclude {
-  jam?: true | JamInclude | JamQueryBuilder;
-  instrument?: true | InstrumentInclude | InstrumentQueryBuilder;
+  jam?: true | JamInclude | JamQueryBuilder<any, any>;
+  instrument?: true | InstrumentInclude | InstrumentQueryBuilder<any, any>;
 }
 
 export interface ParticipantInclude {
-  jam?: true | JamInclude | JamQueryBuilder;
+  jam?: true | JamInclude | JamQueryBuilder<any, any>;
 }
 
 export interface InstrumentRelations {

--- a/packages/jazz-tools/package.json
+++ b/packages/jazz-tools/package.json
@@ -60,11 +60,10 @@
     "tag": "alpha"
   },
   "scripts": {
-    "build": "pnpm typecheck:tests && tsc && cp src/worker/jazz-worker.ts dist/worker/jazz-worker.ts && pnpm build:svelte",
+    "build": "tsc && cp src/worker/jazz-worker.ts dist/worker/jazz-worker.ts && pnpm build:test && pnpm build:svelte",
     "build:svelte": "svelte-package -i src/svelte -o dist/svelte --tsconfig tsconfig.svelte.json && node scripts/cleanup-generated-src-types.mjs",
     "test": "vitest run --config vitest.config.ts",
-    "test:build": "node dist/cli.js build --schema-dir tests/ts-dsl/fixtures/basic",
-    "typecheck:tests": "tsc --project tsconfig.tests.json",
+    "build:test": "node dist/cli.js build --schema-dir tests/ts-dsl/fixtures/basic && tsc --project tsconfig.tests.json",
     "test:browser": "vitest run --config vitest.config.browser.ts",
     "bench:realistic:browser": "vitest run --config vitest.config.browser.ts tests/browser/realistic-bench.test.ts",
     "stage:local": "node scripts/stage-local-binary.mjs",

--- a/packages/jazz-tools/package.json
+++ b/packages/jazz-tools/package.json
@@ -60,10 +60,11 @@
     "tag": "alpha"
   },
   "scripts": {
-    "build": "tsc && cp src/worker/jazz-worker.ts dist/worker/jazz-worker.ts && pnpm build:svelte",
+    "build": "pnpm typecheck:tests && tsc && cp src/worker/jazz-worker.ts dist/worker/jazz-worker.ts && pnpm build:svelte",
     "build:svelte": "svelte-package -i src/svelte -o dist/svelte --tsconfig tsconfig.svelte.json && node scripts/cleanup-generated-src-types.mjs",
     "test": "vitest run --config vitest.config.ts",
     "test:build": "node dist/cli.js build --schema-dir tests/ts-dsl/fixtures/basic",
+    "typecheck:tests": "tsc --project tsconfig.tests.json",
     "test:browser": "vitest run --config vitest.config.browser.ts",
     "bench:realistic:browser": "vitest run --config vitest.config.browser.ts tests/browser/realistic-bench.test.ts",
     "stage:local": "node scripts/stage-local-binary.mjs",

--- a/packages/jazz-tools/src/codegen/codegen.test.ts
+++ b/packages/jazz-tools/src/codegen/codegen.test.ts
@@ -770,9 +770,12 @@ describe("generateTypes with relations", () => {
     const wasm = schemaToWasm(schema);
     const output = generateTypes(wasm);
 
+    expect(output).toContain(
+      'type AnyUserQueryBuilder<T = any> = { readonly _table: "users" } & QueryBuilder<T>;',
+    );
     expect(output).toContain("export interface TodoInclude {");
     // Include types now include QueryBuilder union and only allow `true` for flags
-    expect(output).toContain("owner?: true | UserInclude | UserQueryBuilder<any, any>;");
+    expect(output).toContain("owner?: true | UserInclude | AnyUserQueryBuilder<any>;");
   });
 
   it("generates Relations types", () => {
@@ -816,18 +819,14 @@ describe("generateTypes with relations", () => {
     expect(output).toContain('NonNullable<I["owner"]> extends infer RelationInclude');
     expect(output).toContain("? RelationInclude extends true");
     expect(output).toContain("? User");
-    expect(output).toContain(
-      ': RelationInclude extends UserQueryBuilder<infer QueryInclude extends UserInclude, infer QuerySelect extends keyof User | "*">',
-    );
+    expect(output).toContain(": RelationInclude extends AnyUserQueryBuilder<infer QueryRow>");
     expect(output).toContain("? QueryRow");
     expect(output).toContain(": RelationInclude extends UserInclude");
     expect(output).toContain("? UserWithIncludes<RelationInclude>");
     expect(output).toContain('K extends "todosViaOwner"');
     expect(output).toContain("? Todo[]");
-    expect(output).toContain(
-      ': RelationInclude extends TodoQueryBuilder<infer QueryInclude extends TodoInclude, infer QuerySelect extends keyof Todo | "*">',
-    );
-    expect(output).toContain("? QueryRow[]");
+    expect(output).toContain(": RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>");
+    expect(output).toContain('? Omit<QueryRow, "id">[]');
     expect(output).toContain(": RelationInclude extends TodoInclude");
     expect(output).toContain("? TodoWithIncludes<RelationInclude>[]");
     expect(output).not.toContain("WithIncludesFor<");
@@ -885,8 +884,8 @@ describe("generateTypes with relations", () => {
 
     expect(output).toContain("export interface TodoInclude {");
     // Include types now include QueryBuilder union and only allow `true` for flags
-    expect(output).toContain("parent?: true | TodoInclude | TodoQueryBuilder<any, any>;");
-    expect(output).toContain("todosViaParent?: true | TodoInclude | TodoQueryBuilder<any, any>;");
+    expect(output).toContain("parent?: true | TodoInclude | AnyTodoQueryBuilder<any>;");
+    expect(output).toContain("todosViaParent?: true | TodoInclude | AnyTodoQueryBuilder<any>;");
   });
 
   it("does not generate relation types for tables without relations", () => {
@@ -1069,7 +1068,7 @@ describe("generateQueryBuilderClasses", () => {
     const wasm = schemaToWasm(schema);
     const output = generateTypes(wasm);
 
-    expect(output).toContain("owner?: true | UserInclude | UserQueryBuilder<any, any>;");
+    expect(output).toContain("owner?: true | UserInclude | AnyUserQueryBuilder<any>;");
   });
 
   it("QueryBuilder._build() returns valid JSON structure", () => {
@@ -1173,7 +1172,7 @@ describe("QueryBuilder self-referential relations", () => {
     const wasm = schemaToWasm(schema);
     const output = generateTypes(wasm);
 
-    expect(output).toContain("parent?: true | TodoInclude | TodoQueryBuilder<any, any>;");
-    expect(output).toContain("todosViaParent?: true | TodoInclude | TodoQueryBuilder<any, any>;");
+    expect(output).toContain("parent?: true | TodoInclude | AnyTodoQueryBuilder<any>;");
+    expect(output).toContain("todosViaParent?: true | TodoInclude | AnyTodoQueryBuilder<any>;");
   });
 });

--- a/packages/jazz-tools/src/codegen/codegen.test.ts
+++ b/packages/jazz-tools/src/codegen/codegen.test.ts
@@ -833,6 +833,30 @@ describe("generateTypes with relations", () => {
     expect(output).not.toContain("WithIncludesArray<");
   });
 
+  it("preserves undefined for nullable forward includes", () => {
+    table("users", { name: col.string() });
+    table("todos", { owner_id: col.ref("users").optional() });
+    const schema = getCollectedSchema();
+    const wasm = schemaToWasm(schema);
+    const output = generateTypes(wasm);
+
+    expect(output).toContain("? User | undefined");
+    expect(output).toContain("? QueryRow | undefined");
+    expect(output).toContain("? UserWithIncludes<RelationInclude> | undefined");
+  });
+
+  it("preserves undefined for nullable forward array includes", () => {
+    table("users", { name: col.string() });
+    table("groups", { member_ids: col.array(col.ref("users")).optional() });
+    const schema = getCollectedSchema();
+    const wasm = schemaToWasm(schema);
+    const output = generateTypes(wasm);
+
+    expect(output).toContain("? User[] | undefined");
+    expect(output).toContain("? QueryRow[] | undefined");
+    expect(output).toContain("? UserWithIncludes<RelationInclude>[] | undefined");
+  });
+
   it("generates selection helper types", () => {
     table("users", { name: col.string() });
     table("todos", { owner_id: col.ref("users"), title: col.string() });

--- a/packages/jazz-tools/src/codegen/codegen.test.ts
+++ b/packages/jazz-tools/src/codegen/codegen.test.ts
@@ -804,29 +804,30 @@ describe("generateTypes with relations", () => {
     const wasm = schemaToWasm(schema);
     const output = generateTypes(wasm);
 
+    expect(output).toContain("export type TodoIncludedRelations<I extends TodoInclude = {}> = {");
     expect(output).toContain(
-      "export type TodoWithIncludes<I extends TodoInclude = {}> = Omit<Todo, keyof TodoInclude> & {",
+      "export type TodoWithIncludes<I extends TodoInclude = {}> = Omit<Todo, Extract<keyof I, keyof Todo>> & TodoIncludedRelations<I>;",
     );
     expect(output).toContain(
-      "export type UserWithIncludes<I extends UserInclude = {}> = Omit<User, keyof UserInclude> & {",
+      "export type UserWithIncludes<I extends UserInclude = {}> = Omit<User, Extract<keyof I, keyof User>> & UserIncludedRelations<I>;",
     );
-    expect(output).toContain('owner?: NonNullable<I["owner"]> extends infer RelationInclude');
+    expect(output).toContain("[K in keyof I]-?:");
+    expect(output).toContain('K extends "owner"');
+    expect(output).toContain('NonNullable<I["owner"]> extends infer RelationInclude');
     expect(output).toContain("? RelationInclude extends true");
     expect(output).toContain("? User");
     expect(output).toContain(
       ': RelationInclude extends UserQueryBuilder<infer QueryInclude extends UserInclude, infer QuerySelect extends keyof User | "*">',
     );
-    expect(output).toContain("? UserSelectedWithIncludes<QueryInclude, QuerySelect>");
+    expect(output).toContain("? QueryRow");
     expect(output).toContain(": RelationInclude extends UserInclude");
     expect(output).toContain("? UserWithIncludes<RelationInclude>");
-    expect(output).toContain(
-      'todosViaOwner?: NonNullable<I["todosViaOwner"]> extends infer RelationInclude',
-    );
+    expect(output).toContain('K extends "todosViaOwner"');
     expect(output).toContain("? Todo[]");
     expect(output).toContain(
       ': RelationInclude extends TodoQueryBuilder<infer QueryInclude extends TodoInclude, infer QuerySelect extends keyof Todo | "*">',
     );
-    expect(output).toContain("? TodoSelectedWithIncludes<QueryInclude, QuerySelect>[]");
+    expect(output).toContain("? QueryRow[]");
     expect(output).toContain(": RelationInclude extends TodoInclude");
     expect(output).toContain("? TodoWithIncludes<RelationInclude>[]");
     expect(output).not.toContain("WithIncludesFor<");
@@ -846,7 +847,7 @@ describe("generateTypes with relations", () => {
       'export type TodoSelectedWithIncludes<I extends TodoInclude = {}, S extends keyof Todo | "*" = keyof Todo>',
     );
     expect(output).toContain(
-      "Omit<TodoSelected<S>, keyof TodoInclude> & Omit<TodoWithIncludes<I>, keyof Omit<Todo, keyof TodoInclude>>",
+      "Omit<TodoSelected<S>, Extract<keyof I, keyof TodoSelected<S>>> & TodoIncludedRelations<I>",
     );
   });
 
@@ -866,9 +867,7 @@ describe("generateTypes with relations", () => {
     const wasm = schemaToWasm(schema);
     const output = generateTypes(wasm);
 
-    expect(output).toContain(
-      'resource_access_edgesViaResource?: NonNullable<I["resource_access_edgesViaResource"]> extends infer RelationInclude',
-    );
+    expect(output).toContain('K extends "resource_access_edgesViaResource"');
     expect(output).toContain("? ResourceAccessEdgeWithIncludes<RelationInclude>[]");
     expect(output).not.toContain(
       'resource_access_edgesViaResource?: I["resource_access_edgesViaResource"] extends true',

--- a/packages/jazz-tools/src/codegen/codegen.test.ts
+++ b/packages/jazz-tools/src/codegen/codegen.test.ts
@@ -826,7 +826,7 @@ describe("generateTypes with relations", () => {
     expect(output).toContain('K extends "todosViaOwner"');
     expect(output).toContain("? Todo[]");
     expect(output).toContain(": RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>");
-    expect(output).toContain('? Omit<QueryRow, "id">[]');
+    expect(output).toContain("? QueryRow[]");
     expect(output).toContain(": RelationInclude extends TodoInclude");
     expect(output).toContain("? TodoWithIncludes<RelationInclude>[]");
     expect(output).not.toContain("WithIncludesFor<");

--- a/packages/jazz-tools/src/codegen/codegen.test.ts
+++ b/packages/jazz-tools/src/codegen/codegen.test.ts
@@ -772,7 +772,7 @@ describe("generateTypes with relations", () => {
 
     expect(output).toContain("export interface TodoInclude {");
     // Include types now include QueryBuilder union and only allow `true` for flags
-    expect(output).toContain("owner?: true | UserInclude | UserQueryBuilder;");
+    expect(output).toContain("owner?: true | UserInclude | UserQueryBuilder<any, any>;");
   });
 
   it("generates Relations types", () => {
@@ -880,8 +880,8 @@ describe("generateTypes with relations", () => {
 
     expect(output).toContain("export interface TodoInclude {");
     // Include types now include QueryBuilder union and only allow `true` for flags
-    expect(output).toContain("parent?: true | TodoInclude | TodoQueryBuilder;");
-    expect(output).toContain("todosViaParent?: true | TodoInclude | TodoQueryBuilder;");
+    expect(output).toContain("parent?: true | TodoInclude | TodoQueryBuilder<any, any>;");
+    expect(output).toContain("todosViaParent?: true | TodoInclude | TodoQueryBuilder<any, any>;");
   });
 
   it("does not generate relation types for tables without relations", () => {
@@ -1064,7 +1064,7 @@ describe("generateQueryBuilderClasses", () => {
     const wasm = schemaToWasm(schema);
     const output = generateTypes(wasm);
 
-    expect(output).toContain("owner?: true | UserInclude | UserQueryBuilder;");
+    expect(output).toContain("owner?: true | UserInclude | UserQueryBuilder<any, any>;");
   });
 
   it("QueryBuilder._build() returns valid JSON structure", () => {
@@ -1168,7 +1168,7 @@ describe("QueryBuilder self-referential relations", () => {
     const wasm = schemaToWasm(schema);
     const output = generateTypes(wasm);
 
-    expect(output).toContain("parent?: true | TodoInclude | TodoQueryBuilder;");
-    expect(output).toContain("todosViaParent?: true | TodoInclude | TodoQueryBuilder;");
+    expect(output).toContain("parent?: true | TodoInclude | TodoQueryBuilder<any, any>;");
+    expect(output).toContain("todosViaParent?: true | TodoInclude | TodoQueryBuilder<any, any>;");
   });
 });

--- a/packages/jazz-tools/src/codegen/codegen.test.ts
+++ b/packages/jazz-tools/src/codegen/codegen.test.ts
@@ -804,8 +804,12 @@ describe("generateTypes with relations", () => {
     const wasm = schemaToWasm(schema);
     const output = generateTypes(wasm);
 
-    expect(output).toContain("export type TodoWithIncludes<I extends TodoInclude = {}>");
-    expect(output).toContain("export type UserWithIncludes<I extends UserInclude = {}>");
+    expect(output).toContain(
+      "export type TodoWithIncludes<I extends TodoInclude = {}> = Omit<Todo, keyof TodoInclude> & {",
+    );
+    expect(output).toContain(
+      "export type UserWithIncludes<I extends UserInclude = {}> = Omit<User, keyof UserInclude> & {",
+    );
     expect(output).toContain('owner?: NonNullable<I["owner"]> extends infer RelationInclude');
     expect(output).toContain("? RelationInclude extends true");
     expect(output).toContain("? User");
@@ -841,7 +845,9 @@ describe("generateTypes with relations", () => {
     expect(output).toContain(
       'export type TodoSelectedWithIncludes<I extends TodoInclude = {}, S extends keyof Todo | "*" = keyof Todo>',
     );
-    expect(output).toContain("TodoSelected<S> & Omit<TodoWithIncludes<I>, keyof Todo>");
+    expect(output).toContain(
+      "Omit<TodoSelected<S>, keyof TodoInclude> & Omit<TodoWithIncludes<I>, keyof Omit<Todo, keyof TodoInclude>>",
+    );
   });
 
   it("avoids collapsing nested array includes to never when selectors are optional", () => {

--- a/packages/jazz-tools/src/codegen/type-generator.ts
+++ b/packages/jazz-tools/src/codegen/type-generator.ts
@@ -200,23 +200,7 @@ function generateRelationsTypes(relations: Map<string, Relation[]>): string[] {
   return lines;
 }
 
-/**
- * Generate WithIncludes types for type-safe include results.
- *
- * Example output:
- *   export type TodoWithIncludes<I extends TodoInclude = {}> = Omit<Todo, keyof TodoInclude> & {
- *     project?: NonNullable<I["project"]> extends infer RelationInclude
- *       ? RelationInclude extends true
- *         ? Project
- *         : RelationInclude extends ProjectQueryBuilder<infer QueryInclude extends ProjectInclude>
- *           ? ProjectWithIncludes<QueryInclude>
- *           : RelationInclude extends ProjectInclude
- *             ? ProjectWithIncludes<RelationInclude>
- *             : never
- *       : never;
- *   };
- */
-function generateWithIncludesTypes(relations: Map<string, Relation[]>): string[] {
+function generateIncludedRelationsTypes(relations: Map<string, Relation[]>): string[] {
   const lines: string[] = [];
 
   for (const [tableName, rels] of relations) {
@@ -226,35 +210,59 @@ function generateWithIncludesTypes(relations: Map<string, Relation[]>): string[]
     const includeInterface = baseInterface + "Include";
 
     lines.push(
-      `export type ${baseInterface}WithIncludes<I extends ${includeInterface} = {}> = Omit<${baseInterface}, keyof ${includeInterface}> & {`,
+      `export type ${baseInterface}IncludedRelations<I extends ${includeInterface} = {}> = {`,
     );
-    for (const rel of rels) {
+    lines.push(`  [K in keyof I]-?:`);
+
+    rels.forEach((rel, index) => {
       const targetInterface = tableNameToInterface(rel.toTable);
       const targetInclude = targetInterface + "Include";
-      const targetQueryBuilder = targetInterface + "QueryBuilder";
       const targetWithIncludes = targetInterface + "WithIncludes";
-      const includeSelector = `NonNullable<I["${rel.name}"]>`;
       const trueType = rel.isArray ? `${targetInterface}[]` : targetInterface;
-      const queryBuilderSelectedType = rel.isArray
-        ? `${targetInterface}SelectedWithIncludes<QueryInclude, QuerySelect>[]`
-        : `${targetInterface}SelectedWithIncludes<QueryInclude, QuerySelect>`;
+      const queryBuilderSelectedType = rel.isArray ? `QueryRow[]` : `QueryRow`;
       const nestedIncludeType = rel.isArray
         ? `${targetWithIncludes}<RelationInclude>[]`
         : `${targetWithIncludes}<RelationInclude>`;
+      const prefix = index === 0 ? "    " : "    : ";
 
-      lines.push(`  ${rel.name}?: ${includeSelector} extends infer RelationInclude`);
-      lines.push(`    ? RelationInclude extends true`);
-      lines.push(`      ? ${trueType}`);
+      lines.push(`${prefix}K extends "${rel.name}"`);
+      lines.push(`      ? NonNullable<I["${rel.name}"]> extends infer RelationInclude`);
+      lines.push(`        ? RelationInclude extends true`);
+      lines.push(`          ? ${trueType}`);
       lines.push(
-        `      : RelationInclude extends ${targetQueryBuilder}<infer QueryInclude extends ${targetInclude}, infer QuerySelect extends keyof ${targetInterface} | "*">`,
+        `          : RelationInclude extends ({ readonly _table: "${rel.toTable}" } & QueryBuilder<infer QueryRow>)`,
       );
-      lines.push(`        ? ${queryBuilderSelectedType}`);
-      lines.push(`        : RelationInclude extends ${targetInclude}`);
-      lines.push(`          ? ${nestedIncludeType}`);
-      lines.push(`          : never`);
-      lines.push(`    : never;`);
-    }
+      lines.push(`            ? ${queryBuilderSelectedType}`);
+      lines.push(`            : RelationInclude extends ${targetInclude}`);
+      lines.push(`              ? ${nestedIncludeType}`);
+      lines.push(`              : never`);
+      lines.push(`        : never`);
+    });
+
+    lines.push(`    : never;`);
     lines.push(`};`);
+    lines.push(``);
+  }
+
+  return lines;
+}
+
+/**
+ * Generate WithIncludes types for type-safe include results.
+ */
+function generateWithIncludesTypes(relations: Map<string, Relation[]>): string[] {
+  const lines: string[] = [];
+
+  for (const [tableName, rels] of relations) {
+    if (rels.length === 0) continue;
+
+    const baseInterface = tableNameToInterface(tableName);
+    const includeInterface = baseInterface + "Include";
+    const includedRelationsType = baseInterface + "IncludedRelations";
+
+    lines.push(
+      `export type ${baseInterface}WithIncludes<I extends ${includeInterface} = {}> = Omit<${baseInterface}, Extract<keyof I, keyof ${baseInterface}>> & ${includedRelationsType}<I>;`,
+    );
     lines.push(``);
   }
 
@@ -267,7 +275,7 @@ function generateSelectionTypes(schema: WasmSchema, relations: Map<string, Relat
   for (const tableName of Object.keys(schema)) {
     const baseInterface = tableNameToInterface(tableName);
     const includeInterface = baseInterface + "Include";
-    const withIncludesType = baseInterface + "WithIncludes";
+    const includedRelationsType = baseInterface + "IncludedRelations";
     const hasRelations = (relations.get(tableName) ?? []).length > 0;
 
     lines.push(
@@ -277,7 +285,7 @@ function generateSelectionTypes(schema: WasmSchema, relations: Map<string, Relat
 
     if (hasRelations) {
       lines.push(
-        `export type ${baseInterface}SelectedWithIncludes<I extends ${includeInterface} = {}, S extends keyof ${baseInterface} | "*" = keyof ${baseInterface}> = Omit<${baseInterface}Selected<S>, keyof ${includeInterface}> & Omit<${withIncludesType}<I>, keyof Omit<${baseInterface}, keyof ${includeInterface}>>;`,
+        `export type ${baseInterface}SelectedWithIncludes<I extends ${includeInterface} = {}, S extends keyof ${baseInterface} | "*" = keyof ${baseInterface}> = Omit<${baseInterface}Selected<S>, Extract<keyof I, keyof ${baseInterface}Selected<S>>> & ${includedRelationsType}<I>;`,
       );
       lines.push("");
     }
@@ -366,6 +374,9 @@ export function generateTypes(schema: WasmSchema): string {
 
   // Include types (for specifying which relations to load)
   lines.push(...generateIncludeTypes(relations));
+
+  // Helper types for explicitly included relations only
+  lines.push(...generateIncludedRelationsTypes(relations));
 
   // Relations types (mapping relation names to their result types)
   lines.push(...generateRelationsTypes(relations));

--- a/packages/jazz-tools/src/codegen/type-generator.ts
+++ b/packages/jazz-tools/src/codegen/type-generator.ts
@@ -157,6 +157,16 @@ function generateAnyQueryBuilderAliases(schema: WasmSchema): string[] {
   return lines;
 }
 
+function maybeUndefined(type: string, nullable: boolean): string {
+  return nullable ? `${type} | undefined` : type;
+}
+
+function relationResultType(baseType: string, rel: Relation): string {
+  return rel.isArray
+    ? maybeUndefined(`${baseType}[]`, rel.nullable)
+    : maybeUndefined(baseType, rel.nullable);
+}
+
 /**
  * Generate Include types for nested relation loading.
  *
@@ -235,11 +245,9 @@ function generateIncludedRelationsTypes(relations: Map<string, Relation[]>): str
       const targetInterface = tableNameToInterface(rel.toTable);
       const targetInclude = targetInterface + "Include";
       const targetWithIncludes = targetInterface + "WithIncludes";
-      const trueType = rel.isArray ? `${targetInterface}[]` : targetInterface;
-      const queryBuilderSelectedType = rel.isArray ? `QueryRow[]` : `QueryRow`;
-      const nestedIncludeType = rel.isArray
-        ? `${targetWithIncludes}<RelationInclude>[]`
-        : `${targetWithIncludes}<RelationInclude>`;
+      const trueType = relationResultType(targetInterface, rel);
+      const queryBuilderSelectedType = relationResultType(`QueryRow`, rel);
+      const nestedIncludeType = relationResultType(`${targetWithIncludes}<RelationInclude>`, rel);
       const prefix = index === 0 ? "    " : "    : ";
 
       lines.push(`${prefix}K extends "${rel.name}"`);

--- a/packages/jazz-tools/src/codegen/type-generator.ts
+++ b/packages/jazz-tools/src/codegen/type-generator.ts
@@ -140,13 +140,30 @@ export function tableNameToInterface(name: string): string {
   return parts.map((word) => word.charAt(0).toUpperCase() + word.slice(1)).join("");
 }
 
+function generateAnyQueryBuilderAliases(schema: WasmSchema): string[] {
+  const lines: string[] = [];
+
+  for (const tableName of Object.keys(schema)) {
+    const baseInterface = tableNameToInterface(tableName);
+    lines.push(
+      `type Any${baseInterface}QueryBuilder<T = any> = { readonly _table: "${tableName}" } & QueryBuilder<T>;`,
+    );
+  }
+
+  if (lines.length > 0) {
+    lines.push("");
+  }
+
+  return lines;
+}
+
 /**
  * Generate Include types for nested relation loading.
  *
  * Example output:
  *   export interface TodoInclude {
- *     parent?: true | TodoInclude | TodoQueryBuilder<any, any>;
- *     owner?: true | UserInclude | UserQueryBuilder<any, any>;
+ *     parent?: true | TodoInclude | AnyTodoQueryBuilder<any>;
+ *     owner?: true | UserInclude | AnyUserQueryBuilder<any>;
  *   }
  */
 function generateIncludeTypes(relations: Map<string, Relation[]>): string[] {
@@ -160,9 +177,9 @@ function generateIncludeTypes(relations: Map<string, Relation[]>): string[] {
     for (const rel of rels) {
       const targetInterface = tableNameToInterface(rel.toTable);
       const targetInclude = targetInterface + "Include";
-      const targetQueryBuilder = targetInterface + "QueryBuilder";
-      // Accept any valid specialization of the relation query builder.
-      lines.push(`  ${rel.name}?: true | ${targetInclude} | ${targetQueryBuilder}<any, any>;`);
+      lines.push(
+        `  ${rel.name}?: true | ${targetInclude} | Any${targetInterface}QueryBuilder<any>;`,
+      );
     }
     lines.push(`}`);
     lines.push(``);
@@ -230,7 +247,7 @@ function generateIncludedRelationsTypes(relations: Map<string, Relation[]>): str
       lines.push(`        ? RelationInclude extends true`);
       lines.push(`          ? ${trueType}`);
       lines.push(
-        `          : RelationInclude extends ({ readonly _table: "${rel.toTable}" } & QueryBuilder<infer QueryRow>)`,
+        `          : RelationInclude extends Any${targetInterface}QueryBuilder<infer QueryRow>`,
       );
       lines.push(`            ? ${queryBuilderSelectedType}`);
       lines.push(`            : RelationInclude extends ${targetInclude}`);
@@ -368,6 +385,9 @@ export function generateTypes(schema: WasmSchema): string {
       wasmTypeToTs(columnType, jsonTypeBySchemaKey),
     ),
   );
+
+  // Helper aliases for any query builder specializations
+  lines.push(...generateAnyQueryBuilderAliases(schema));
 
   // Analyze relations and generate relation types
   const relations = analyzeRelations(schema);

--- a/packages/jazz-tools/src/codegen/type-generator.ts
+++ b/packages/jazz-tools/src/codegen/type-generator.ts
@@ -204,7 +204,7 @@ function generateRelationsTypes(relations: Map<string, Relation[]>): string[] {
  * Generate WithIncludes types for type-safe include results.
  *
  * Example output:
- *   export type TodoWithIncludes<I extends TodoInclude = {}> = Todo & {
+ *   export type TodoWithIncludes<I extends TodoInclude = {}> = Omit<Todo, keyof TodoInclude> & {
  *     project?: NonNullable<I["project"]> extends infer RelationInclude
  *       ? RelationInclude extends true
  *         ? Project
@@ -226,7 +226,7 @@ function generateWithIncludesTypes(relations: Map<string, Relation[]>): string[]
     const includeInterface = baseInterface + "Include";
 
     lines.push(
-      `export type ${baseInterface}WithIncludes<I extends ${includeInterface} = {}> = ${baseInterface} & {`,
+      `export type ${baseInterface}WithIncludes<I extends ${includeInterface} = {}> = Omit<${baseInterface}, keyof ${includeInterface}> & {`,
     );
     for (const rel of rels) {
       const targetInterface = tableNameToInterface(rel.toTable);
@@ -277,7 +277,7 @@ function generateSelectionTypes(schema: WasmSchema, relations: Map<string, Relat
 
     if (hasRelations) {
       lines.push(
-        `export type ${baseInterface}SelectedWithIncludes<I extends ${includeInterface} = {}, S extends keyof ${baseInterface} | "*" = keyof ${baseInterface}> = ${baseInterface}Selected<S> & Omit<${withIncludesType}<I>, keyof ${baseInterface}>;`,
+        `export type ${baseInterface}SelectedWithIncludes<I extends ${includeInterface} = {}, S extends keyof ${baseInterface} | "*" = keyof ${baseInterface}> = Omit<${baseInterface}Selected<S>, keyof ${includeInterface}> & Omit<${withIncludesType}<I>, keyof Omit<${baseInterface}, keyof ${includeInterface}>>;`,
       );
       lines.push("");
     }

--- a/packages/jazz-tools/src/codegen/type-generator.ts
+++ b/packages/jazz-tools/src/codegen/type-generator.ts
@@ -145,8 +145,8 @@ export function tableNameToInterface(name: string): string {
  *
  * Example output:
  *   export interface TodoInclude {
- *     parent?: true | TodoInclude | TodoQueryBuilder;
- *     owner?: true | UserInclude | UserQueryBuilder;
+ *     parent?: true | TodoInclude | TodoQueryBuilder<any, any>;
+ *     owner?: true | UserInclude | UserQueryBuilder<any, any>;
  *   }
  */
 function generateIncludeTypes(relations: Map<string, Relation[]>): string[] {
@@ -161,8 +161,8 @@ function generateIncludeTypes(relations: Map<string, Relation[]>): string[] {
       const targetInterface = tableNameToInterface(rel.toTable);
       const targetInclude = targetInterface + "Include";
       const targetQueryBuilder = targetInterface + "QueryBuilder";
-      // Add QueryBuilder to union for type-safe filtered includes
-      lines.push(`  ${rel.name}?: true | ${targetInclude} | ${targetQueryBuilder};`);
+      // Accept any valid specialization of the relation query builder.
+      lines.push(`  ${rel.name}?: true | ${targetInclude} | ${targetQueryBuilder}<any, any>;`);
     }
     lines.push(`}`);
     lines.push(``);

--- a/packages/jazz-tools/tests/ts-dsl/fixtures/basic/app.ts
+++ b/packages/jazz-tools/tests/ts-dsl/fixtures/basic/app.ts
@@ -61,7 +61,10 @@ export interface TodoRelations {
   project: Project;
 }
 
-export type ProjectWithIncludes<I extends ProjectInclude = {}> = Project & {
+export type ProjectWithIncludes<I extends ProjectInclude = {}> = Omit<
+  Project,
+  keyof ProjectInclude
+> & {
   todosViaProject?: NonNullable<I["todosViaProject"]> extends infer RelationInclude
     ? RelationInclude extends true
       ? Todo[]
@@ -76,7 +79,7 @@ export type ProjectWithIncludes<I extends ProjectInclude = {}> = Project & {
     : never;
 };
 
-export type TodoWithIncludes<I extends TodoInclude = {}> = Todo & {
+export type TodoWithIncludes<I extends TodoInclude = {}> = Omit<Todo, keyof TodoInclude> & {
   project?: NonNullable<I["project"]> extends infer RelationInclude
     ? RelationInclude extends true
       ? Project
@@ -98,7 +101,8 @@ export type ProjectSelected<S extends keyof Project | "*" = keyof Project> = "*"
 export type ProjectSelectedWithIncludes<
   I extends ProjectInclude = {},
   S extends keyof Project | "*" = keyof Project,
-> = ProjectSelected<S> & Omit<ProjectWithIncludes<I>, keyof Project>;
+> = Omit<ProjectSelected<S>, keyof ProjectInclude> &
+  Omit<ProjectWithIncludes<I>, keyof Omit<Project, keyof ProjectInclude>>;
 
 export type TodoSelected<S extends keyof Todo | "*" = keyof Todo> = "*" extends S
   ? Todo
@@ -107,7 +111,8 @@ export type TodoSelected<S extends keyof Todo | "*" = keyof Todo> = "*" extends 
 export type TodoSelectedWithIncludes<
   I extends TodoInclude = {},
   S extends keyof Todo | "*" = keyof Todo,
-> = TodoSelected<S> & Omit<TodoWithIncludes<I>, keyof Todo>;
+> = Omit<TodoSelected<S>, keyof TodoInclude> &
+  Omit<TodoWithIncludes<I>, keyof Omit<Todo, keyof TodoInclude>>;
 
 export const wasmSchema: WasmSchema = {
   projects: {

--- a/packages/jazz-tools/tests/ts-dsl/fixtures/basic/app.ts
+++ b/packages/jazz-tools/tests/ts-dsl/fixtures/basic/app.ts
@@ -46,11 +46,11 @@ export interface TodoWhereInput {
 }
 
 export interface ProjectInclude {
-  todosViaProject?: true | TodoInclude | TodoQueryBuilder;
+  todosViaProject?: true | TodoInclude | TodoQueryBuilder<any, any>;
 }
 
 export interface TodoInclude {
-  project?: true | ProjectInclude | ProjectQueryBuilder;
+  project?: true | ProjectInclude | ProjectQueryBuilder<any, any>;
 }
 
 export interface ProjectRelations {

--- a/packages/jazz-tools/tests/ts-dsl/fixtures/basic/app.ts
+++ b/packages/jazz-tools/tests/ts-dsl/fixtures/basic/app.ts
@@ -24,7 +24,7 @@ export interface Todo {
   done: boolean;
   tags: string[];
   project: string;
-  owner: string;
+  owner?: string;
 }
 
 export interface UserInit {
@@ -40,7 +40,7 @@ export interface TodoInit {
   done: boolean;
   tags: string[];
   project: string;
-  owner: string;
+  owner?: string;
 }
 
 export interface UserWhereInput {
@@ -59,7 +59,7 @@ export interface TodoWhereInput {
   done?: boolean;
   tags?: string[] | { eq?: string[]; contains?: string };
   project?: string | { eq?: string; ne?: string };
-  owner?: string | { eq?: string; ne?: string };
+  owner?: string | { eq?: string; ne?: string; isNull?: boolean };
 }
 
 type AnyUserQueryBuilder<T = any> = { readonly _table: "users" } & QueryBuilder<T>;
@@ -121,11 +121,11 @@ export type TodoIncludedRelations<I extends TodoInclude = {}> = {
     : K extends "owner"
       ? NonNullable<I["owner"]> extends infer RelationInclude
         ? RelationInclude extends true
-          ? User
+          ? User | undefined
           : RelationInclude extends AnyUserQueryBuilder<infer QueryRow>
-            ? QueryRow
+            ? QueryRow | undefined
             : RelationInclude extends UserInclude
-              ? UserWithIncludes<RelationInclude>
+              ? UserWithIncludes<RelationInclude> | undefined
               : never
         : never
       : never;
@@ -252,7 +252,7 @@ export const wasmSchema: WasmSchema = {
         column_type: {
           type: "Uuid",
         },
-        nullable: false,
+        nullable: true,
         references: "users",
       },
     ],

--- a/packages/jazz-tools/tests/ts-dsl/fixtures/basic/app.ts
+++ b/packages/jazz-tools/tests/ts-dsl/fixtures/basic/app.ts
@@ -8,6 +8,11 @@ export type JsonValue =
   | { [key: string]: JsonValue }
   | JsonValue[];
 
+export interface User {
+  id: string;
+  name: string;
+}
+
 export interface Project {
   id: string;
   name: string;
@@ -19,6 +24,11 @@ export interface Todo {
   done: boolean;
   tags: string[];
   project: string;
+  owner: string;
+}
+
+export interface UserInit {
+  name: string;
 }
 
 export interface ProjectInit {
@@ -30,6 +40,12 @@ export interface TodoInit {
   done: boolean;
   tags: string[];
   project: string;
+  owner: string;
+}
+
+export interface UserWhereInput {
+  id?: string | { eq?: string; ne?: string; in?: string[] };
+  name?: string | { eq?: string; ne?: string; contains?: string };
 }
 
 export interface ProjectWhereInput {
@@ -43,6 +59,11 @@ export interface TodoWhereInput {
   done?: boolean;
   tags?: string[] | { eq?: string[]; contains?: string };
   project?: string | { eq?: string; ne?: string };
+  owner?: string | { eq?: string; ne?: string };
+}
+
+export interface UserInclude {
+  todosViaOwner?: true | TodoInclude | TodoQueryBuilder<any, any>;
 }
 
 export interface ProjectInclude {
@@ -51,6 +72,11 @@ export interface ProjectInclude {
 
 export interface TodoInclude {
   project?: true | ProjectInclude | ProjectQueryBuilder<any, any>;
+  owner?: true | UserInclude | UserQueryBuilder<any, any>;
+}
+
+export interface UserRelations {
+  todosViaOwner: Todo[];
 }
 
 export interface ProjectRelations {
@@ -59,7 +85,23 @@ export interface ProjectRelations {
 
 export interface TodoRelations {
   project: Project;
+  owner: User;
 }
+
+export type UserWithIncludes<I extends UserInclude = {}> = Omit<User, keyof UserInclude> & {
+  todosViaOwner?: NonNullable<I["todosViaOwner"]> extends infer RelationInclude
+    ? RelationInclude extends true
+      ? Todo[]
+      : RelationInclude extends TodoQueryBuilder<
+            infer QueryInclude extends TodoInclude,
+            infer QuerySelect extends keyof Todo | "*"
+          >
+        ? TodoSelectedWithIncludes<QueryInclude, QuerySelect>[]
+        : RelationInclude extends TodoInclude
+          ? TodoWithIncludes<RelationInclude>[]
+          : never
+    : never;
+};
 
 export type ProjectWithIncludes<I extends ProjectInclude = {}> = Omit<
   Project,
@@ -92,7 +134,29 @@ export type TodoWithIncludes<I extends TodoInclude = {}> = Omit<Todo, keyof Todo
           ? ProjectWithIncludes<RelationInclude>
           : never
     : never;
+  owner?: NonNullable<I["owner"]> extends infer RelationInclude
+    ? RelationInclude extends true
+      ? User
+      : RelationInclude extends UserQueryBuilder<
+            infer QueryInclude extends UserInclude,
+            infer QuerySelect extends keyof User | "*"
+          >
+        ? UserSelectedWithIncludes<QueryInclude, QuerySelect>
+        : RelationInclude extends UserInclude
+          ? UserWithIncludes<RelationInclude>
+          : never
+    : never;
 };
+
+export type UserSelected<S extends keyof User | "*" = keyof User> = "*" extends S
+  ? User
+  : Pick<User, Extract<S | "id", keyof User>>;
+
+export type UserSelectedWithIncludes<
+  I extends UserInclude = {},
+  S extends keyof User | "*" = keyof User,
+> = Omit<UserSelected<S>, keyof UserInclude> &
+  Omit<UserWithIncludes<I>, keyof Omit<User, keyof UserInclude>>;
 
 export type ProjectSelected<S extends keyof Project | "*" = keyof Project> = "*" extends S
   ? Project
@@ -115,6 +179,17 @@ export type TodoSelectedWithIncludes<
   Omit<TodoWithIncludes<I>, keyof Omit<Todo, keyof TodoInclude>>;
 
 export const wasmSchema: WasmSchema = {
+  users: {
+    columns: [
+      {
+        name: "name",
+        column_type: {
+          type: "Text",
+        },
+        nullable: false,
+      },
+    ],
+  },
   projects: {
     columns: [
       {
@@ -160,9 +235,215 @@ export const wasmSchema: WasmSchema = {
         nullable: false,
         references: "projects",
       },
+      {
+        name: "owner",
+        column_type: {
+          type: "Uuid",
+        },
+        nullable: false,
+        references: "users",
+      },
     ],
   },
 };
+
+export class UserQueryBuilder<
+  I extends UserInclude = {},
+  S extends keyof User | "*" = keyof User,
+> implements QueryBuilder<UserSelectedWithIncludes<I, S>> {
+  readonly _table = "users";
+  readonly _schema: WasmSchema = wasmSchema;
+  declare readonly _rowType: UserSelectedWithIncludes<I, S>;
+  declare readonly _initType: UserInit;
+  private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
+  private _includes: Partial<UserInclude> = {};
+  private _selectColumns?: string[];
+  private _orderBys: Array<[string, "asc" | "desc"]> = [];
+  private _limitVal?: number;
+  private _offsetVal?: number;
+  private _hops: string[] = [];
+  private _gatherVal?: {
+    max_depth: number;
+    step_table: string;
+    step_current_column: string;
+    step_conditions: Array<{ column: string; op: string; value: unknown }>;
+    step_hops: string[];
+  };
+
+  where(conditions: UserWhereInput): UserQueryBuilder<I, S> {
+    const clone = this._clone();
+    for (const [key, value] of Object.entries(conditions)) {
+      if (value === undefined) continue;
+      if (typeof value === "object" && value !== null && !Array.isArray(value)) {
+        for (const [op, opValue] of Object.entries(value)) {
+          if (opValue !== undefined) {
+            clone._conditions.push({ column: key, op, value: opValue });
+          }
+        }
+      } else {
+        clone._conditions.push({ column: key, op: "eq", value });
+      }
+    }
+    return clone;
+  }
+
+  select<NewS extends keyof User | "*">(...columns: [NewS, ...NewS[]]): UserQueryBuilder<I, NewS> {
+    const clone = this._clone<I, NewS>();
+    clone._selectColumns = [...columns] as string[];
+    return clone;
+  }
+
+  include<NewI extends UserInclude>(relations: NewI): UserQueryBuilder<I & NewI, S> {
+    const clone = this._clone<I & NewI, S>();
+    clone._includes = { ...this._includes, ...relations };
+    return clone;
+  }
+
+  orderBy(column: keyof User, direction: "asc" | "desc" = "asc"): UserQueryBuilder<I, S> {
+    const clone = this._clone();
+    clone._orderBys.push([column as string, direction]);
+    return clone;
+  }
+
+  limit(n: number): UserQueryBuilder<I, S> {
+    const clone = this._clone();
+    clone._limitVal = n;
+    return clone;
+  }
+
+  offset(n: number): UserQueryBuilder<I, S> {
+    const clone = this._clone();
+    clone._offsetVal = n;
+    return clone;
+  }
+
+  hopTo(relation: "todosViaOwner"): UserQueryBuilder<I, S> {
+    const clone = this._clone();
+    clone._hops.push(relation);
+    return clone;
+  }
+
+  gather(options: {
+    start: UserWhereInput;
+    step: (ctx: { current: string }) => QueryBuilder<unknown>;
+    maxDepth?: number;
+  }): UserQueryBuilder<I, S> {
+    if (options.start === undefined) {
+      throw new Error("gather(...) requires start where conditions.");
+    }
+    if (typeof options.step !== "function") {
+      throw new Error("gather(...) requires step callback.");
+    }
+
+    const maxDepth = options.maxDepth ?? 10;
+    if (!Number.isInteger(maxDepth) || maxDepth <= 0) {
+      throw new Error("gather(...) maxDepth must be a positive integer.");
+    }
+    if (Object.keys(this._includes).length > 0) {
+      throw new Error("gather(...) does not support include(...) in MVP.");
+    }
+    if (this._hops.length > 0) {
+      throw new Error("gather(...) must be called before hopTo(...).");
+    }
+
+    const currentToken = "__jazz_gather_current__";
+    const stepOutput = options.step({ current: currentToken });
+    if (
+      !stepOutput ||
+      typeof stepOutput !== "object" ||
+      typeof (stepOutput as { _build?: unknown })._build !== "function"
+    ) {
+      throw new Error("gather(...) step must return a query expression built from app.<table>.");
+    }
+
+    const stepBuilt = JSON.parse(stepOutput._build()) as {
+      table?: unknown;
+      conditions?: Array<{ column: string; op: string; value: unknown }>;
+      hops?: unknown;
+    };
+
+    if (typeof stepBuilt.table !== "string" || !stepBuilt.table) {
+      throw new Error("gather(...) step query is missing table metadata.");
+    }
+    if (!Array.isArray(stepBuilt.conditions)) {
+      throw new Error("gather(...) step query is missing condition metadata.");
+    }
+
+    const stepHops = Array.isArray(stepBuilt.hops)
+      ? stepBuilt.hops.filter((hop): hop is string => typeof hop === "string")
+      : [];
+    if (stepHops.length !== 1) {
+      throw new Error("gather(...) step must include exactly one hopTo(...).");
+    }
+
+    const currentConditions = stepBuilt.conditions.filter(
+      (condition) => condition.op === "eq" && condition.value === currentToken,
+    );
+    if (currentConditions.length !== 1) {
+      throw new Error(
+        "gather(...) step must include exactly one where condition bound to current.",
+      );
+    }
+
+    const currentCondition = currentConditions[0];
+    const stepConditions = stepBuilt.conditions.filter(
+      (condition) => !(condition.op === "eq" && condition.value === currentToken),
+    );
+
+    const withStart = this.where(options.start);
+    const clone = withStart._clone();
+    clone._hops = [];
+    clone._gatherVal = {
+      max_depth: maxDepth,
+      step_table: stepBuilt.table,
+      step_current_column: currentCondition.column,
+      step_conditions: stepConditions,
+      step_hops: stepHops,
+    };
+
+    return clone;
+  }
+
+  _build(): string {
+    return JSON.stringify({
+      table: this._table,
+      conditions: this._conditions,
+      includes: this._includes,
+      select: this._selectColumns,
+      orderBy: this._orderBys,
+      limit: this._limitVal,
+      offset: this._offsetVal,
+      hops: this._hops,
+      gather: this._gatherVal,
+    });
+  }
+
+  toJSON(): unknown {
+    return JSON.parse(this._build());
+  }
+
+  private _clone<
+    CloneI extends UserInclude = I,
+    CloneS extends keyof User | "*" = S,
+  >(): UserQueryBuilder<CloneI, CloneS> {
+    const clone = new UserQueryBuilder<CloneI, CloneS>();
+    clone._conditions = [...this._conditions];
+    clone._includes = { ...this._includes };
+    clone._selectColumns = this._selectColumns ? [...this._selectColumns] : undefined;
+    clone._orderBys = [...this._orderBys];
+    clone._limitVal = this._limitVal;
+    clone._offsetVal = this._offsetVal;
+    clone._hops = [...this._hops];
+    clone._gatherVal = this._gatherVal
+      ? {
+          ...this._gatherVal,
+          step_conditions: this._gatherVal.step_conditions.map((condition) => ({ ...condition })),
+          step_hops: [...this._gatherVal.step_hops],
+        }
+      : undefined;
+    return clone;
+  }
+}
 
 export class ProjectQueryBuilder<
   I extends ProjectInclude = {},
@@ -434,7 +715,7 @@ export class TodoQueryBuilder<
     return clone;
   }
 
-  hopTo(relation: "project"): TodoQueryBuilder<I, S> {
+  hopTo(relation: "project" | "owner"): TodoQueryBuilder<I, S> {
     const clone = this._clone();
     clone._hops.push(relation);
     return clone;
@@ -563,12 +844,14 @@ export class TodoQueryBuilder<
 }
 
 export interface GeneratedApp {
+  users: UserQueryBuilder;
   projects: ProjectQueryBuilder;
   todos: TodoQueryBuilder;
   wasmSchema: WasmSchema;
 }
 
 export const app: GeneratedApp = {
+  users: new UserQueryBuilder(),
   projects: new ProjectQueryBuilder(),
   todos: new TodoQueryBuilder(),
   wasmSchema,

--- a/packages/jazz-tools/tests/ts-dsl/fixtures/basic/app.ts
+++ b/packages/jazz-tools/tests/ts-dsl/fixtures/basic/app.ts
@@ -62,17 +62,21 @@ export interface TodoWhereInput {
   owner?: string | { eq?: string; ne?: string };
 }
 
+type AnyUserQueryBuilder<T = any> = { readonly _table: "users" } & QueryBuilder<T>;
+type AnyProjectQueryBuilder<T = any> = { readonly _table: "projects" } & QueryBuilder<T>;
+type AnyTodoQueryBuilder<T = any> = { readonly _table: "todos" } & QueryBuilder<T>;
+
 export interface UserInclude {
-  todosViaOwner?: true | TodoInclude | TodoQueryBuilder<any, any>;
+  todosViaOwner?: true | TodoInclude | AnyTodoQueryBuilder<any>;
 }
 
 export interface ProjectInclude {
-  todosViaProject?: true | TodoInclude | TodoQueryBuilder<any, any>;
+  todosViaProject?: true | TodoInclude | AnyTodoQueryBuilder<any>;
 }
 
 export interface TodoInclude {
-  project?: true | ProjectInclude | ProjectQueryBuilder<any, any>;
-  owner?: true | UserInclude | UserQueryBuilder<any, any>;
+  project?: true | ProjectInclude | AnyProjectQueryBuilder<any>;
+  owner?: true | UserInclude | AnyUserQueryBuilder<any>;
 }
 
 export type UserIncludedRelations<I extends UserInclude = {}> = {
@@ -80,7 +84,7 @@ export type UserIncludedRelations<I extends UserInclude = {}> = {
     ? NonNullable<I["todosViaOwner"]> extends infer RelationInclude
       ? RelationInclude extends true
         ? Todo[]
-        : RelationInclude extends { readonly _table: "todos" } & QueryBuilder<infer QueryRow>
+        : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
           ? QueryRow[]
           : RelationInclude extends TodoInclude
             ? TodoWithIncludes<RelationInclude>[]
@@ -94,7 +98,7 @@ export type ProjectIncludedRelations<I extends ProjectInclude = {}> = {
     ? NonNullable<I["todosViaProject"]> extends infer RelationInclude
       ? RelationInclude extends true
         ? Todo[]
-        : RelationInclude extends { readonly _table: "todos" } & QueryBuilder<infer QueryRow>
+        : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
           ? QueryRow[]
           : RelationInclude extends TodoInclude
             ? TodoWithIncludes<RelationInclude>[]
@@ -108,7 +112,7 @@ export type TodoIncludedRelations<I extends TodoInclude = {}> = {
     ? NonNullable<I["project"]> extends infer RelationInclude
       ? RelationInclude extends true
         ? Project
-        : RelationInclude extends { readonly _table: "projects" } & QueryBuilder<infer QueryRow>
+        : RelationInclude extends AnyProjectQueryBuilder<infer QueryRow>
           ? QueryRow
           : RelationInclude extends ProjectInclude
             ? ProjectWithIncludes<RelationInclude>
@@ -118,7 +122,7 @@ export type TodoIncludedRelations<I extends TodoInclude = {}> = {
       ? NonNullable<I["owner"]> extends infer RelationInclude
         ? RelationInclude extends true
           ? User
-          : RelationInclude extends { readonly _table: "users" } & QueryBuilder<infer QueryRow>
+          : RelationInclude extends AnyUserQueryBuilder<infer QueryRow>
             ? QueryRow
             : RelationInclude extends UserInclude
               ? UserWithIncludes<RelationInclude>

--- a/packages/jazz-tools/tests/ts-dsl/fixtures/basic/app.ts
+++ b/packages/jazz-tools/tests/ts-dsl/fixtures/basic/app.ts
@@ -75,6 +75,58 @@ export interface TodoInclude {
   owner?: true | UserInclude | UserQueryBuilder<any, any>;
 }
 
+export type UserIncludedRelations<I extends UserInclude = {}> = {
+  [K in keyof I]-?: K extends "todosViaOwner"
+    ? NonNullable<I["todosViaOwner"]> extends infer RelationInclude
+      ? RelationInclude extends true
+        ? Todo[]
+        : RelationInclude extends { readonly _table: "todos" } & QueryBuilder<infer QueryRow>
+          ? QueryRow[]
+          : RelationInclude extends TodoInclude
+            ? TodoWithIncludes<RelationInclude>[]
+            : never
+      : never
+    : never;
+};
+
+export type ProjectIncludedRelations<I extends ProjectInclude = {}> = {
+  [K in keyof I]-?: K extends "todosViaProject"
+    ? NonNullable<I["todosViaProject"]> extends infer RelationInclude
+      ? RelationInclude extends true
+        ? Todo[]
+        : RelationInclude extends { readonly _table: "todos" } & QueryBuilder<infer QueryRow>
+          ? QueryRow[]
+          : RelationInclude extends TodoInclude
+            ? TodoWithIncludes<RelationInclude>[]
+            : never
+      : never
+    : never;
+};
+
+export type TodoIncludedRelations<I extends TodoInclude = {}> = {
+  [K in keyof I]-?: K extends "project"
+    ? NonNullable<I["project"]> extends infer RelationInclude
+      ? RelationInclude extends true
+        ? Project
+        : RelationInclude extends { readonly _table: "projects" } & QueryBuilder<infer QueryRow>
+          ? QueryRow
+          : RelationInclude extends ProjectInclude
+            ? ProjectWithIncludes<RelationInclude>
+            : never
+      : never
+    : K extends "owner"
+      ? NonNullable<I["owner"]> extends infer RelationInclude
+        ? RelationInclude extends true
+          ? User
+          : RelationInclude extends { readonly _table: "users" } & QueryBuilder<infer QueryRow>
+            ? QueryRow
+            : RelationInclude extends UserInclude
+              ? UserWithIncludes<RelationInclude>
+              : never
+        : never
+      : never;
+};
+
 export interface UserRelations {
   todosViaOwner: Todo[];
 }
@@ -88,65 +140,23 @@ export interface TodoRelations {
   owner: User;
 }
 
-export type UserWithIncludes<I extends UserInclude = {}> = Omit<User, keyof UserInclude> & {
-  todosViaOwner?: NonNullable<I["todosViaOwner"]> extends infer RelationInclude
-    ? RelationInclude extends true
-      ? Todo[]
-      : RelationInclude extends TodoQueryBuilder<
-            infer QueryInclude extends TodoInclude,
-            infer QuerySelect extends keyof Todo | "*"
-          >
-        ? TodoSelectedWithIncludes<QueryInclude, QuerySelect>[]
-        : RelationInclude extends TodoInclude
-          ? TodoWithIncludes<RelationInclude>[]
-          : never
-    : never;
-};
+export type UserWithIncludes<I extends UserInclude = {}> = Omit<
+  User,
+  Extract<keyof I, keyof User>
+> &
+  UserIncludedRelations<I>;
 
 export type ProjectWithIncludes<I extends ProjectInclude = {}> = Omit<
   Project,
-  keyof ProjectInclude
-> & {
-  todosViaProject?: NonNullable<I["todosViaProject"]> extends infer RelationInclude
-    ? RelationInclude extends true
-      ? Todo[]
-      : RelationInclude extends TodoQueryBuilder<
-            infer QueryInclude extends TodoInclude,
-            infer QuerySelect extends keyof Todo | "*"
-          >
-        ? TodoSelectedWithIncludes<QueryInclude, QuerySelect>[]
-        : RelationInclude extends TodoInclude
-          ? TodoWithIncludes<RelationInclude>[]
-          : never
-    : never;
-};
+  Extract<keyof I, keyof Project>
+> &
+  ProjectIncludedRelations<I>;
 
-export type TodoWithIncludes<I extends TodoInclude = {}> = Omit<Todo, keyof TodoInclude> & {
-  project?: NonNullable<I["project"]> extends infer RelationInclude
-    ? RelationInclude extends true
-      ? Project
-      : RelationInclude extends ProjectQueryBuilder<
-            infer QueryInclude extends ProjectInclude,
-            infer QuerySelect extends keyof Project | "*"
-          >
-        ? ProjectSelectedWithIncludes<QueryInclude, QuerySelect>
-        : RelationInclude extends ProjectInclude
-          ? ProjectWithIncludes<RelationInclude>
-          : never
-    : never;
-  owner?: NonNullable<I["owner"]> extends infer RelationInclude
-    ? RelationInclude extends true
-      ? User
-      : RelationInclude extends UserQueryBuilder<
-            infer QueryInclude extends UserInclude,
-            infer QuerySelect extends keyof User | "*"
-          >
-        ? UserSelectedWithIncludes<QueryInclude, QuerySelect>
-        : RelationInclude extends UserInclude
-          ? UserWithIncludes<RelationInclude>
-          : never
-    : never;
-};
+export type TodoWithIncludes<I extends TodoInclude = {}> = Omit<
+  Todo,
+  Extract<keyof I, keyof Todo>
+> &
+  TodoIncludedRelations<I>;
 
 export type UserSelected<S extends keyof User | "*" = keyof User> = "*" extends S
   ? User
@@ -155,8 +165,7 @@ export type UserSelected<S extends keyof User | "*" = keyof User> = "*" extends 
 export type UserSelectedWithIncludes<
   I extends UserInclude = {},
   S extends keyof User | "*" = keyof User,
-> = Omit<UserSelected<S>, keyof UserInclude> &
-  Omit<UserWithIncludes<I>, keyof Omit<User, keyof UserInclude>>;
+> = Omit<UserSelected<S>, Extract<keyof I, keyof UserSelected<S>>> & UserIncludedRelations<I>;
 
 export type ProjectSelected<S extends keyof Project | "*" = keyof Project> = "*" extends S
   ? Project
@@ -165,8 +174,8 @@ export type ProjectSelected<S extends keyof Project | "*" = keyof Project> = "*"
 export type ProjectSelectedWithIncludes<
   I extends ProjectInclude = {},
   S extends keyof Project | "*" = keyof Project,
-> = Omit<ProjectSelected<S>, keyof ProjectInclude> &
-  Omit<ProjectWithIncludes<I>, keyof Omit<Project, keyof ProjectInclude>>;
+> = Omit<ProjectSelected<S>, Extract<keyof I, keyof ProjectSelected<S>>> &
+  ProjectIncludedRelations<I>;
 
 export type TodoSelected<S extends keyof Todo | "*" = keyof Todo> = "*" extends S
   ? Todo
@@ -175,8 +184,7 @@ export type TodoSelected<S extends keyof Todo | "*" = keyof Todo> = "*" extends 
 export type TodoSelectedWithIncludes<
   I extends TodoInclude = {},
   S extends keyof Todo | "*" = keyof Todo,
-> = Omit<TodoSelected<S>, keyof TodoInclude> &
-  Omit<TodoWithIncludes<I>, keyof Omit<Todo, keyof TodoInclude>>;
+> = Omit<TodoSelected<S>, Extract<keyof I, keyof TodoSelected<S>>> & TodoIncludedRelations<I>;
 
 export const wasmSchema: WasmSchema = {
   users: {

--- a/packages/jazz-tools/tests/ts-dsl/fixtures/basic/current.sql
+++ b/packages/jazz-tools/tests/ts-dsl/fixtures/basic/current.sql
@@ -11,5 +11,5 @@ CREATE TABLE todos (
     done BOOLEAN NOT NULL,
     tags TEXT[] NOT NULL,
     project UUID REFERENCES projects NOT NULL,
-    owner UUID REFERENCES users NOT NULL
+    owner UUID REFERENCES users
 );

--- a/packages/jazz-tools/tests/ts-dsl/fixtures/basic/current.ts
+++ b/packages/jazz-tools/tests/ts-dsl/fixtures/basic/current.ts
@@ -1,5 +1,9 @@
 import { table, col } from "jazz-tools";
 
+table("users", {
+  name: col.string(),
+});
+
 table("projects", {
   name: col.string(),
 });
@@ -9,4 +13,5 @@ table("todos", {
   done: col.boolean(),
   tags: col.array(col.string()),
   project: col.ref("projects"),
+  owner: col.ref("users"),
 });

--- a/packages/jazz-tools/tests/ts-dsl/fixtures/basic/current.ts
+++ b/packages/jazz-tools/tests/ts-dsl/fixtures/basic/current.ts
@@ -13,5 +13,5 @@ table("todos", {
   done: col.boolean(),
   tags: col.array(col.string()),
   project: col.ref("projects"),
-  owner: col.ref("users"),
+  owner: col.ref("users").optional(),
 });

--- a/packages/jazz-tools/tests/ts-dsl/fixtures/basic/schema_v1_444407d1436c.sql
+++ b/packages/jazz-tools/tests/ts-dsl/fixtures/basic/schema_v1_444407d1436c.sql
@@ -1,7 +1,3 @@
-CREATE TABLE users (
-    name TEXT NOT NULL
-);
-
 CREATE TABLE projects (
     name TEXT NOT NULL
 );
@@ -12,4 +8,8 @@ CREATE TABLE todos (
     tags TEXT[] NOT NULL,
     project UUID REFERENCES projects NOT NULL,
     owner UUID REFERENCES users NOT NULL
+);
+
+CREATE TABLE users (
+    name TEXT NOT NULL
 );

--- a/packages/jazz-tools/tests/ts-dsl/fixtures/basic/schema_v1_54ba2c0b9384.sql
+++ b/packages/jazz-tools/tests/ts-dsl/fixtures/basic/schema_v1_54ba2c0b9384.sql
@@ -7,7 +7,7 @@ CREATE TABLE todos (
     done BOOLEAN NOT NULL,
     tags TEXT[] NOT NULL,
     project UUID REFERENCES projects NOT NULL,
-    owner UUID REFERENCES users NOT NULL
+    owner UUID REFERENCES users
 );
 
 CREATE TABLE users (

--- a/packages/jazz-tools/tests/ts-dsl/insert-api.test.ts
+++ b/packages/jazz-tools/tests/ts-dsl/insert-api.test.ts
@@ -6,6 +6,10 @@ function uniqueDbName(label: string): string {
   return `test-${label}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 }
 
+function insertOwner(db: Db, name = "Test User") {
+  return db.insert(app.users, { name });
+}
+
 describe("TS Write API", () => {
   let db: Db;
 
@@ -22,6 +26,7 @@ describe("TS Write API", () => {
 
   it("returns the inserted row", async () => {
     const project = db.insert(app.projects, { name: "Test Project" });
+    const owner = insertOwner(db);
 
     expect(project).toEqual({
       id: expect.any(String),
@@ -33,6 +38,7 @@ describe("TS Write API", () => {
       done: true,
       tags: ["tag1", "tag2"],
       project: project.id,
+      owner: owner.id,
     });
 
     expect(todo).toEqual({
@@ -41,6 +47,7 @@ describe("TS Write API", () => {
       done: true,
       tags: ["tag1", "tag2"],
       project: project.id,
+      owner: owner.id,
     });
   });
 
@@ -55,6 +62,7 @@ describe("TS Write API", () => {
       id: expect.any(String),
       name: "Test Project",
     });
+    const owner = insertOwner(db);
 
     const todo = await db.insertDurable(
       app.todos,
@@ -63,6 +71,7 @@ describe("TS Write API", () => {
         done: true,
         tags: ["tag1", "tag2"],
         project: project.id,
+        owner: owner.id,
       },
       { tier: "worker" },
     );
@@ -73,16 +82,19 @@ describe("TS Write API", () => {
       done: true,
       tags: ["tag1", "tag2"],
       project: project.id,
+      owner: owner.id,
     });
   });
 
   it("updates rows synchronously without returning a promise", async () => {
     const project = db.insert(app.projects, { name: "Test Project" });
+    const owner = insertOwner(db);
     const todo = db.insert(app.todos, {
       title: "Test Todo",
       done: false,
       tags: ["tag1", "tag2"],
       project: project.id,
+      owner: owner.id,
     });
 
     const result = db.update(app.todos, todo.id, { done: true });
@@ -94,11 +106,13 @@ describe("TS Write API", () => {
 
   it("can wait for updates to be persisted up to a specific durability tier", async () => {
     const project = db.insert(app.projects, { name: "Test Project" });
+    const owner = insertOwner(db);
     const todo = db.insert(app.todos, {
       title: "Test Todo",
       done: false,
       tags: ["tag1", "tag2"],
       project: project.id,
+      owner: owner.id,
     });
 
     const pending = db.updateDurable(app.todos, todo.id, { done: true }, { tier: "worker" });
@@ -112,11 +126,13 @@ describe("TS Write API", () => {
 
   it("deletes rows synchronously without returning a promise", async () => {
     const project = db.insert(app.projects, { name: "Test Project" });
+    const owner = insertOwner(db);
     const todo = db.insert(app.todos, {
       title: "Test Todo",
       done: false,
       tags: ["tag1", "tag2"],
       project: project.id,
+      owner: owner.id,
     });
 
     const result = db.delete(app.todos, todo.id);
@@ -132,6 +148,7 @@ describe("TS Write API", () => {
       { name: "Test Project" },
       { tier: "worker" },
     );
+    const owner = insertOwner(db);
     const todo = await db.insertDurable(
       app.todos,
       {
@@ -139,6 +156,7 @@ describe("TS Write API", () => {
         done: false,
         tags: ["tag1", "tag2"],
         project: project.id,
+        owner: owner.id,
       },
       { tier: "worker" },
     );

--- a/packages/jazz-tools/tests/ts-dsl/query-api.test.ts
+++ b/packages/jazz-tools/tests/ts-dsl/query-api.test.ts
@@ -6,6 +6,14 @@ function uniqueDbName(label: string): string {
   return `test-${label}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 }
 
+function insertOwner(db: Db, name = "Test User") {
+  return db.insert(app.users, { name });
+}
+
+function insertProject(db: Db, name = "Test Project") {
+  return db.insert(app.projects, { name });
+}
+
 describe("TS Query API", () => {
   const dbs: Db[] = [];
 
@@ -34,7 +42,7 @@ describe("TS Query API", () => {
       }),
     );
 
-    const { id } = await db.insert(app.projects, { name: "Project A" });
+    const { id } = insertProject(db, "Project A");
 
     const results = await db.all(app.projects.where({ id: { eq: id } }));
     expect(results.length).toBe(1);
@@ -51,12 +59,14 @@ describe("TS Query API", () => {
       }),
     );
 
-    const { id: projectId } = await db.insert(app.projects, { name: "Announcements" });
-    const { id: todoId } = await db.insert(app.todos, {
+    const { id: projectId } = insertProject(db);
+    const { id: ownerId } = insertOwner(db);
+    const { id: todoId } = db.insert(app.todos, {
       title: "Hello world",
       done: false,
       tags: ["general"],
       project: projectId,
+      owner: ownerId,
     });
 
     const baseline = await db.all(app.todos.where({ id: { eq: todoId } }));
@@ -78,12 +88,14 @@ describe("TS Query API", () => {
       }),
     );
 
-    const { id: projectId } = await db.insert(app.projects, { name: "Announcements" });
-    const { id: todoId } = await db.insert(app.todos, {
+    const { id: projectId } = insertProject(db, "Announcements");
+    const { id: ownerId } = insertOwner(db);
+    const { id: todoId } = db.insert(app.todos, {
       title: "Write tests",
       done: false,
       tags: ["dev"],
       project: projectId,
+      owner: ownerId,
     });
 
     const results = await db.all(
@@ -93,6 +105,7 @@ describe("TS Query API", () => {
     expect(results.length).toBe(1);
     const todo = results[0];
     expect(todo.title).toBe("Write tests");
+    expect(todo.owner).toBe(ownerId);
     expect(todo.project).toBeDefined();
     expect(todo.project?.name).toBe("Announcements");
   });
@@ -105,12 +118,14 @@ describe("TS Query API", () => {
       }),
     );
 
-    const { id: projectId } = await db.insert(app.projects, { name: "Announcements" });
-    const { id: todoId } = await db.insert(app.todos, {
+    const { id: projectId } = insertProject(db, "Announcements");
+    const { id: ownerId } = insertOwner(db);
+    const { id: todoId } = db.insert(app.todos, {
       title: "Write tests",
       done: false,
       tags: ["dev"],
       project: projectId,
+      owner: ownerId,
     });
 
     const results = await db.all(
@@ -142,12 +157,14 @@ describe("TS Query API", () => {
       }),
     );
 
-    const { id: projectId } = await db.insert(app.projects, { name: "Announcements" });
-    const { id: todoId } = await db.insert(app.todos, {
+    const { id: projectId } = insertProject(db);
+    const { id: ownerId } = insertOwner(db);
+    const { id: todoId } = db.insert(app.todos, {
       title: "Write tests",
       done: false,
       tags: ["dev"],
       project: projectId,
+      owner: ownerId,
     });
 
     const results = await db.all(app.todos.select("*").where({ id: { eq: todoId } }));
@@ -159,6 +176,7 @@ describe("TS Query API", () => {
         done: false,
         tags: ["dev"],
         project: projectId,
+        owner: ownerId,
       },
     ]);
   });
@@ -171,12 +189,14 @@ describe("TS Query API", () => {
       }),
     );
 
-    const { id: projectId } = await db.insert(app.projects, { name: "Announcements" });
-    const { id: todoId } = await db.insert(app.todos, {
+    const { id: projectId } = insertProject(db, "Announcements");
+    const { id: ownerId } = insertOwner(db);
+    const { id: todoId } = db.insert(app.todos, {
       title: "Write tests",
       done: false,
       tags: ["dev"],
       project: projectId,
+      owner: ownerId,
     });
 
     const results = await db.all(
@@ -210,7 +230,8 @@ describe("TS Query API", () => {
       }),
     );
 
-    const { id: projectId } = await db.insert(app.projects, { name: "Announcements" });
+    const { id: projectId } = insertProject(db, "Announcements");
+    const { id: ownerId } = insertOwner(db);
 
     type SubscribedTodo = {
       id: string;
@@ -243,11 +264,12 @@ describe("TS Query API", () => {
 
     await new Promise((resolve) => setTimeout(resolve, 0));
 
-    const { id: todoId } = await db.insert(app.todos, {
+    const { id: todoId } = db.insert(app.todos, {
       title: "Watch subscription",
       done: false,
       tags: ["dev"],
       project: projectId,
+      owner: ownerId,
     });
 
     const delta = await deltaPromise;
@@ -278,24 +300,28 @@ describe("TS Query API", () => {
           driver: { type: "persistent", dbName: uniqueDbName("query-by-array-column-equality") },
         }),
       );
-      const { id: projectId } = await db.insert(app.projects, { name: "Project A" });
-      const { id: id1 } = await db.insert(app.todos, {
+      const { id: projectId } = insertProject(db);
+      const { id: ownerId } = insertOwner(db);
+      const { id: id1 } = db.insert(app.todos, {
         title: "Todo 1",
         done: false,
         tags: ["tag1"],
         project: projectId,
+        owner: ownerId,
       });
-      await db.insert(app.todos, {
+      db.insert(app.todos, {
         title: "Todo 2",
         done: false,
         tags: ["tag2"],
         project: projectId,
+        owner: ownerId,
       });
-      await db.insert(app.todos, {
+      db.insert(app.todos, {
         title: "Todo 3",
         done: false,
         tags: ["tag1", "tag2"],
         project: projectId,
+        owner: ownerId,
       });
 
       const todosWithTags = await db.all(app.todos.where({ tags: { eq: ["tag1"] } }));
@@ -310,24 +336,28 @@ describe("TS Query API", () => {
           driver: { type: "persistent", dbName: uniqueDbName("query-by-array-column-contains") },
         }),
       );
-      const { id: projectId } = await db.insert(app.projects, { name: "Project A" });
-      const { id: id1 } = await db.insert(app.todos, {
+      const { id: projectId } = insertProject(db);
+      const { id: ownerId } = insertOwner(db);
+      const { id: id1 } = db.insert(app.todos, {
         title: "Todo 1",
         done: false,
         tags: ["tag1"],
         project: projectId,
+        owner: ownerId,
       });
-      await db.insert(app.todos, {
+      db.insert(app.todos, {
         title: "Todo 2",
         done: false,
         tags: ["tag2"],
         project: projectId,
+        owner: ownerId,
       });
-      const { id: id3 } = await db.insert(app.todos, {
+      const { id: id3 } = db.insert(app.todos, {
         title: "Todo 3",
         done: false,
         tags: ["tag1", "tag2"],
         project: projectId,
+        owner: ownerId,
       });
 
       const todosWithTags = await db.all(app.todos.where({ tags: { contains: "tag1" } }));

--- a/packages/jazz-tools/tests/ts-dsl/query-api.test.ts
+++ b/packages/jazz-tools/tests/ts-dsl/query-api.test.ts
@@ -1,6 +1,6 @@
 import { createDb, type Db } from "../../src/runtime/db.js";
-import { afterEach, describe, it, expect } from "vitest";
-import { app } from "./fixtures/basic/app";
+import { afterEach, describe, it, expect, assert, expectTypeOf } from "vitest";
+import { app, Project } from "./fixtures/basic/app";
 
 function uniqueDbName(label: string): string {
   return `test-${label}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
@@ -147,6 +147,38 @@ describe("TS Query API", () => {
     ]);
     expect("done" in results[0]).toBe(false);
     expect("tags" in results[0]).toBe(false);
+  });
+
+  it("included columns are returned even if they are not part of the top-level select", async () => {
+    const db = track(
+      await createDb({
+        appId: "test-app",
+        driver: { type: "persistent", dbName: uniqueDbName("select-root-columns") },
+      }),
+    );
+
+    const { id: projectId } = insertProject(db, "Announcements");
+    const { id: ownerId } = insertOwner(db);
+    const { id: todoId } = db.insert(app.todos, {
+      title: "Write tests",
+      done: false,
+      tags: ["dev"],
+      project: projectId,
+      owner: ownerId,
+    });
+
+    const result = await db.one(
+      app.todos
+        .select("owner")
+        .where({ id: { eq: todoId } })
+        .include({ project: true }),
+    );
+
+    assert(result, "Result is not defined");
+    expectTypeOf(result.owner).toEqualTypeOf<string>();
+    expect(result.owner).toBe(ownerId);
+    expectTypeOf(result.project).toEqualTypeOf<Project>();
+    expect(result.project.name).toBe("Announcements");
   });
 
   it('select("*") resets to all root columns', async () => {

--- a/packages/jazz-tools/tests/ts-dsl/query-api.test.ts
+++ b/packages/jazz-tools/tests/ts-dsl/query-api.test.ts
@@ -1,6 +1,6 @@
 import { createDb, type Db } from "../../src/runtime/db.js";
 import { afterEach, describe, it, expect, assert, expectTypeOf } from "vitest";
-import { app, Project } from "./fixtures/basic/app";
+import { app, Project, Todo } from "./fixtures/basic/app";
 
 function uniqueDbName(label: string): string {
   return `test-${label}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
@@ -47,6 +47,7 @@ describe("TS Query API", () => {
     const results = await db.all(app.projects.where({ id: { eq: id } }));
     expect(results.length).toBe(1);
 
+    expectTypeOf(results[0]).branded.toEqualTypeOf<Project>();
     expect(results[0].id).toBe(id);
     expect(results[0].name).toBe("Project A");
   });
@@ -105,9 +106,10 @@ describe("TS Query API", () => {
     expect(results.length).toBe(1);
     const todo = results[0];
     expect(todo.title).toBe("Write tests");
+    expectTypeOf(todo.owner).toEqualTypeOf<string>();
     expect(todo.owner).toBe(ownerId);
-    expect(todo.project).toBeDefined();
-    expect(todo.project?.name).toBe("Announcements");
+    expectTypeOf(todo.project).toEqualTypeOf<Project>();
+    expect(todo.project.name).toBe("Announcements");
   });
 
   it("select narrows root columns while preserving id and includes", async () => {
@@ -128,28 +130,30 @@ describe("TS Query API", () => {
       owner: ownerId,
     });
 
-    const results = await db.all(
+    const result = await db.one(
       app.todos
         .select("title")
         .where({ id: { eq: todoId } })
         .include({ project: true }),
     );
 
-    expect(results).toEqual([
-      {
-        id: todoId,
-        title: "Write tests",
-        project: {
-          id: projectId,
-          name: "Announcements",
-        },
+    assert(result, "Result is not defined");
+    expectTypeOf(result.id).toEqualTypeOf<string>();
+    expectTypeOf(result.title).toEqualTypeOf<string>();
+    expectTypeOf(result.project).toEqualTypeOf<Project>();
+    expect(result).toEqual({
+      id: todoId,
+      title: "Write tests",
+      project: {
+        id: projectId,
+        name: "Announcements",
       },
-    ]);
-    expect("done" in results[0]).toBe(false);
-    expect("tags" in results[0]).toBe(false);
+    });
+    expect("done" in result).toBe(false);
+    expect("tags" in result).toBe(false);
   });
 
-  it("included columns are returned even if they are not part of the top-level select", async () => {
+  it("include only resolves the provided columns, not all references", async () => {
     const db = track(
       await createDb({
         appId: "test-app",
@@ -199,18 +203,18 @@ describe("TS Query API", () => {
       owner: ownerId,
     });
 
-    const results = await db.all(app.todos.select("*").where({ id: { eq: todoId } }));
+    const result = await db.one(app.todos.select("*").where({ id: { eq: todoId } }));
 
-    expect(results).toEqual([
-      {
-        id: todoId,
-        title: "Write tests",
-        done: false,
-        tags: ["dev"],
-        project: projectId,
-        owner: ownerId,
-      },
-    ]);
+    assert(result, "Result is not defined");
+    expectTypeOf(result).branded.toEqualTypeOf<Todo>();
+    expect(result).toEqual({
+      id: todoId,
+      title: "Write tests",
+      done: false,
+      tags: ["dev"],
+      project: projectId,
+      owner: ownerId,
+    });
   });
 
   it("include builders can project nested relation columns", async () => {
@@ -231,27 +235,28 @@ describe("TS Query API", () => {
       owner: ownerId,
     });
 
-    const results = await db.all(
+    const result = await db.one(
       app.projects
         .where({ id: { eq: projectId } })
         .include({ todosViaProject: app.todos.select("title") }),
     );
 
-    expect(results).toEqual([
-      {
-        id: projectId,
-        name: "Announcements",
-        todosViaProject: [
-          {
-            id: todoId,
-            title: "Write tests",
-          },
-        ],
-      },
-    ]);
-    expect("done" in results[0].todosViaProject![0]).toBe(false);
-    expect("tags" in results[0].todosViaProject![0]).toBe(false);
-    expect("project" in results[0].todosViaProject![0]).toBe(false);
+    assert(result, "Result is not defined");
+    expect(result).toEqual({
+      id: projectId,
+      name: "Announcements",
+      todosViaProject: [
+        {
+          id: todoId,
+          title: "Write tests",
+        },
+      ],
+    });
+    expectTypeOf(result.name).toEqualTypeOf<string>();
+    expectTypeOf(result.todosViaProject).branded.toEqualTypeOf<{ id: string; title: string }[]>();
+    expect("done" in result.todosViaProject[0]).toBe(false);
+    expect("tags" in result.todosViaProject[0]).toBe(false);
+    expect("project" in result.todosViaProject[0]).toBe(false);
   });
 
   it("subscribeAll preserves projected root columns with includes", async () => {

--- a/packages/jazz-tools/tests/ts-dsl/query-api.test.ts
+++ b/packages/jazz-tools/tests/ts-dsl/query-api.test.ts
@@ -1,6 +1,6 @@
 import { createDb, type Db } from "../../src/runtime/db.js";
 import { afterEach, describe, it, expect, assert, expectTypeOf } from "vitest";
-import { app, Project, Todo } from "./fixtures/basic/app";
+import { app, Project, Todo, User } from "./fixtures/basic/app";
 
 function uniqueDbName(label: string): string {
   return `test-${label}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
@@ -106,7 +106,7 @@ describe("TS Query API", () => {
     expect(results.length).toBe(1);
     const todo = results[0];
     expect(todo.title).toBe("Write tests");
-    expectTypeOf(todo.owner).toEqualTypeOf<string>();
+    expectTypeOf(todo.owner).toEqualTypeOf<string | undefined>();
     expect(todo.owner).toBe(ownerId);
     expectTypeOf(todo.project).toEqualTypeOf<Project>();
     expect(todo.project.name).toBe("Announcements");
@@ -179,10 +179,34 @@ describe("TS Query API", () => {
     );
 
     assert(result, "Result is not defined");
-    expectTypeOf(result.owner).toEqualTypeOf<string>();
+    expectTypeOf(result.owner).toEqualTypeOf<string | undefined>();
     expect(result.owner).toBe(ownerId);
     expectTypeOf(result.project).toEqualTypeOf<Project>();
     expect(result.project.name).toBe("Announcements");
+  });
+
+  it("include returns 'undefined' for null foreign key columns", async () => {
+    const db = track(
+      await createDb({
+        appId: "test-app",
+        driver: { type: "persistent", dbName: uniqueDbName("select-root-columns") },
+      }),
+    );
+
+    const { id: projectId } = insertProject(db, "Announcements");
+    const { id: todoId } = db.insert(app.todos, {
+      title: "Write tests",
+      done: false,
+      tags: ["dev"],
+      project: projectId,
+      owner: undefined,
+    });
+
+    const result = await db.one(app.todos.where({ id: { eq: todoId } }).include({ owner: true }));
+
+    assert(result, "Result is not defined");
+    expectTypeOf(result.owner).toEqualTypeOf<User | undefined>();
+    expect(result.owner).toBeUndefined();
   });
 
   it('select("*") resets to all root columns', async () => {

--- a/packages/jazz-tools/tsconfig.tests.json
+++ b/packages/jazz-tools/tsconfig.tests.json
@@ -1,0 +1,19 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "declaration": false,
+    "declarationMap": false,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "noEmit": true,
+    "rootDir": ".",
+    "sourceMap": false,
+    "paths": {
+      "jazz-tools": ["./src/index.ts"],
+      "jazz-tools/*": ["./src/*"]
+    }
+  },
+  "include": ["src/**/*", "tests/ts-dsl/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Description

The TS generator had two separate typing problems:
1. select query builders used inside `include` were not typechecking
2. when including referenced rows, the type of the referenced row was colliding with the type of the FK (string). This is the same issue that was fixed by https://github.com/garden-co/jazz2/pull/262, but this PR introduces a simpler solution.

The first issue occurred because the query builder type for `include` was too narrow. E.g.:

```ts
project?: true | ProjectInclude | ProjectQueryBuilder;
```

That bare `ProjectQueryBuilder` means using the default generic parameters, so it effectively only accepted the full-row builder shape. But `select("title")` produces a specialized builder like `TodoQueryBuilder<{}, "title">`, which is still valid and should be allowed. The fix was to generate a more generic type for these query builders (that still prevents invalid selections).

-------

Both of these type regressions where not caught by ts-dsl tests because we were not running the type checker for these tests when building the app. Now we do. I also added type tests in the `query-api` integration tests.