### PR TITLE
feat: update doesn't revalidate all columns, but just the updated ones

### DIFF
--- a/crates/jazz-tools/src/query_manager/writes.rs
+++ b/crates/jazz-tools/src/query_manager/writes.rs
@@ -250,10 +250,57 @@ impl QueryManager {
         values: &[Value],
         branch: &str,
     ) -> Result<(), QueryError> {
+        self.validate_foreign_keys_for_values_inner(
+            storage, table_name, descriptor, values, branch, None,
+        )
+    }
+
+    /// Validate FK constraints, optionally limited to only the specified columns.
+    ///
+    /// When `changed_columns` is `Some`, only FK columns whose name is in the
+    /// set are validated. This is used by partial updates (RuntimeCore::update)
+    /// so that unchanged FK columns are not re-checked
+    fn validate_foreign_keys_for_changed_columns(
+        &self,
+        storage: &dyn Storage,
+        table_name: &TableName,
+        descriptor: &RowDescriptor,
+        values: &[Value],
+        branch: &str,
+        changed_columns: &[String],
+    ) -> Result<(), QueryError> {
+        self.validate_foreign_keys_for_values_inner(
+            storage,
+            table_name,
+            descriptor,
+            values,
+            branch,
+            Some(changed_columns),
+        )
+    }
+
+    fn validate_foreign_keys_for_values_inner(
+        &self,
+        storage: &dyn Storage,
+        table_name: &TableName,
+        descriptor: &RowDescriptor,
+        values: &[Value],
+        branch: &str,
+        changed_columns: Option<&[String]>,
+    ) -> Result<(), QueryError> {
         for (column, value) in descriptor.columns.iter().zip(values.iter()) {
             let Some(referenced_table) = column.references else {
                 continue;
             };
+
+            // When doing a partial update, skip FK validation for columns
+            // that were not changed — the old value was already validated
+            // at insert time.
+            if let Some(changed) = changed_columns
+                && !changed.iter().any(|c| c == column.name.as_str())
+            {
+                continue;
+            }
 
             match (&column.column_type, value) {
                 (ColumnType::Uuid, Value::Uuid(target_id)) => {
@@ -808,6 +855,32 @@ impl QueryManager {
         values: &[Value],
         session: Option<&Session>,
     ) -> Result<CommitId, QueryError> {
+        self.update_with_session_inner(storage, id, values, session, None)
+    }
+
+    /// Update a row, validating FK constraints only for the specified columns.
+    ///
+    /// Used by `RuntimeCore::update` for partial updates: when only `done` is
+    /// changed, there is no need to re-validate the `project` FK
+    pub fn update_with_session_partial<H: Storage>(
+        &mut self,
+        storage: &mut H,
+        id: ObjectId,
+        values: &[Value],
+        session: Option<&Session>,
+        changed_columns: &[String],
+    ) -> Result<CommitId, QueryError> {
+        self.update_with_session_inner(storage, id, values, session, Some(changed_columns))
+    }
+
+    fn update_with_session_inner<H: Storage>(
+        &mut self,
+        storage: &mut H,
+        id: ObjectId,
+        values: &[Value],
+        session: Option<&Session>,
+        changed_columns: Option<&[String]>,
+    ) -> Result<CommitId, QueryError> {
         let _span = tracing::debug_span!("QM::update", %id).entered();
         // Ensure object is loaded from storage (cold-start: may only exist on disk)
         let branch = self.current_branch();
@@ -849,13 +922,29 @@ impl QueryManager {
             });
         }
 
-        self.validate_foreign_keys_for_values(
-            storage,
-            &table_name,
-            &descriptor,
-            values,
-            &self.current_branch(),
-        )?;
+        // For partial updates, only validate FK constraints on columns that
+        // were actually changed. Unchanged FK values were already validated
+        // at insert time and don't need re-checking — this avoids false
+        // violations after cold start when referenced rows may not yet be
+        // indexed.
+        if let Some(changed) = changed_columns {
+            self.validate_foreign_keys_for_changed_columns(
+                storage,
+                &table_name,
+                &descriptor,
+                values,
+                &self.current_branch(),
+                changed,
+            )?;
+        } else {
+            self.validate_foreign_keys_for_values(
+                storage,
+                &table_name,
+                &descriptor,
+                values,
+                &self.current_branch(),
+            )?;
+        }
         self.validate_json_for_values(&descriptor, values)?;
 
         // Encode new data (used by WITH CHECK and commit write).

--- a/crates/jazz-tools/src/runtime_core/tests.rs
+++ b/crates/jazz-tools/src/runtime_core/tests.rs
@@ -1321,3 +1321,173 @@ fn test_persist_schema_then_add_server_sends_catalogue() {
             .join(", ")
     );
 }
+
+// =========================================================================
+// Foreign Key + Partial Update Tests
+// =========================================================================
+
+/// Schema that mirrors the stress-test app: projects + todos with FK.
+fn fk_stress_schema() -> Schema {
+    SchemaBuilder::new()
+        .table(
+            TableSchema::builder("projects")
+                .column("name", ColumnType::Text)
+                .column("owner_id", ColumnType::Text),
+        )
+        .table(
+            TableSchema::builder("todos")
+                .column("title", ColumnType::Text)
+                .column("done", ColumnType::Boolean)
+                .nullable_column("description", ColumnType::Text)
+                .column("owner_id", ColumnType::Text)
+                .nullable_fk_column("project", "projects"),
+        )
+        .build()
+}
+
+fn create_fk_runtime() -> TestCore {
+    let schema = fk_stress_schema();
+    let app_id = AppId::from_name("fk-test");
+    let sync_manager = SyncManager::new();
+    let schema_manager = SchemaManager::new(sync_manager, schema, app_id, "dev", "main").unwrap();
+    let mut core = RuntimeCore::new(
+        schema_manager,
+        MemoryStorage::new(),
+        NoopScheduler,
+        VecSyncSender::new(),
+    );
+    core.immediate_tick();
+    core
+}
+
+/// Reproduce the stress-test bug: after page reload, sync is query-scoped —
+/// only objects matching active queries arrive in MemoryStorage. If the app
+/// subscribes to `todos.limit(50)` but not all projects, a todo's `project`
+/// FK can reference a project that's never loaded.
+///
+/// We simulate this by inserting both rows, then removing the project from
+/// the `_id` index (as if query-scoped sync never brought it in).
+///
+/// ```text
+///   MemoryStorage (after query-scoped sync)
+///   ┌────────────────────────────────────────┐
+///   │ projects._id index:  []     ← empty!   │
+///   │ todos._id index:     [todo_1]           │
+///   │                                         │
+///   │ todo_1.project = project_42  → not in   │
+///   │                               index     │
+///   └────────────────────────────────────────┘
+///
+///   User toggles todo_1.done → partial update
+///   → FK re-check on `project` → NOT FOUND → 💥
+/// ```
+#[test]
+fn rc_partial_update_with_unloaded_fk_reference() {
+    let mut core = create_fk_runtime();
+
+    // Insert a project (FK validation passes at insert time)
+    let (project_id, _) = core
+        .insert(
+            "projects",
+            vec![Value::Text("Acme".into()), Value::Text("alice".into())],
+            None,
+        )
+        .unwrap();
+
+    // Insert a todo referencing that project
+    let (todo_id, _) = core
+        .insert(
+            "todos",
+            vec![
+                Value::Text("Buy milk".into()),
+                Value::Boolean(true),        // done
+                Value::Null,                 // description (nullable)
+                Value::Text("alice".into()), // owner_id
+                Value::Uuid(project_id),     // project FK
+            ],
+            None,
+        )
+        .unwrap();
+
+    core.immediate_tick();
+
+    // Simulate query-scoped sync: remove the project from the _id index.
+    // This is what happens after page reload when the app only subscribes
+    // to `todos` but not `projects` — the project never arrives.
+    //
+    // The branch name is a composed name (e.g. "dev-<hash>-main"), not just "main".
+    let branch = core.schema_manager().branch_name();
+    core.storage
+        .index_remove(
+            "projects",
+            "_id",
+            branch.as_str(),
+            &Value::Uuid(project_id),
+            project_id,
+        )
+        .unwrap();
+
+    // Partial update: only change `done`.
+    // Without the fix, this fails with UuidForeignKeyViolation on `project`
+    // because the project is not in the _id index.
+    core.update(
+        todo_id,
+        vec![("done".to_string(), Value::Boolean(false))],
+        None,
+    )
+    .expect(
+        "partial update of non-FK column must succeed even when referenced project is not loaded",
+    );
+}
+
+/// Verify that when a FK column is explicitly changed in a partial update,
+/// it IS still validated (only unchanged FK columns are skipped).
+#[test]
+fn rc_partial_update_validates_changed_fk_column() {
+    let mut core = create_fk_runtime();
+
+    // Insert a project
+    let (project_id, _) = core
+        .insert(
+            "projects",
+            vec![Value::Text("Acme".into()), Value::Text("alice".into())],
+            None,
+        )
+        .unwrap();
+
+    // Insert a todo referencing that project
+    let (todo_id, _) = core
+        .insert(
+            "todos",
+            vec![
+                Value::Text("Buy milk".into()),
+                Value::Boolean(true),
+                Value::Null,
+                Value::Text("alice".into()),
+                Value::Uuid(project_id),
+            ],
+            None,
+        )
+        .unwrap();
+
+    core.immediate_tick();
+
+    // Partial update: change the `project` FK to a non-existent project.
+    // This MUST fail because we're changing the FK column.
+    let bogus_project = ObjectId::new();
+    let result = core.update(
+        todo_id,
+        vec![("project".to_string(), Value::Uuid(bogus_project))],
+        None,
+    );
+
+    assert!(
+        result.is_err(),
+        "changing FK to non-existent project must fail"
+    );
+    let err_msg = format!("{:?}", result.err().unwrap());
+    assert!(
+        err_msg.contains("UuidForeignKeyViolation"),
+        "error should be UuidForeignKeyViolation, got: {err_msg}"
+    );
+}

--- a/crates/jazz-tools/src/runtime_core/writes.rs
+++ b/crates/jazz-tools/src/runtime_core/writes.rs
@@ -32,11 +32,18 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
         session: Option<&Session>,
     ) -> Result<(), RuntimeError> {
         let _span = debug_span!("update", %object_id).entered();
+        let changed_columns: Vec<String> = values.iter().map(|(name, _)| name.clone()).collect();
         let current_values = self.merge_row_update_values(object_id, values)?;
 
         self.schema_manager
             .query_manager_mut()
-            .update_with_session(&mut self.storage, object_id, &current_values, session)
+            .update_with_session_partial(
+                &mut self.storage,
+                object_id,
+                &current_values,
+                session,
+                &changed_columns,
+            )
             .map_err(|e| RuntimeError::WriteError(format!("{:?}", e)))?;
 
         self.immediate_tick();
@@ -108,12 +115,19 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
         session: Option<&Session>,
         tier: DurabilityTier,
     ) -> Result<oneshot::Receiver<()>, RuntimeError> {
+        let changed_columns: Vec<String> = values.iter().map(|(name, _)| name.clone()).collect();
         let current_values = self.merge_row_update_values(object_id, values)?;
 
         let commit_id = self
             .schema_manager
             .query_manager_mut()
-            .update_with_session(&mut self.storage, object_id, &current_values, session)
+            .update_with_session_partial(
+                &mut self.storage,
+                object_id,
+                &current_values,
+                session,
+                &changed_columns,
+            )
             .map_err(|e| RuntimeError::WriteError(format!("{:?}", e)))?;
 
         let (sender, receiver) = oneshot::channel();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -211,6 +211,49 @@ importers:
         specifier: catalog:default
         version: 5.9.3
 
+  examples/dev-stress-test-react:
+    dependencies:
+      jazz-tools:
+        specifier: workspace:*
+        version: link:../../packages/jazz-tools
+      react:
+        specifier: 19.2.4
+        version: 19.2.4
+      react-dom:
+        specifier: 19.2.4
+        version: 19.2.4(react@19.2.4)
+    devDependencies:
+      '@types/react':
+        specifier: ^19.0.0
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.0.0
+        version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: ^4.0.0
+        version: 4.7.0(vite@6.4.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/browser':
+        specifier: catalog:default
+        version: 4.0.18(vite@6.4.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18)
+      '@vitest/browser-playwright':
+        specifier: catalog:default
+        version: 4.0.18(playwright@1.58.2)(vite@6.4.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18)
+      typescript:
+        specifier: catalog:default
+        version: 5.9.3
+      vite:
+        specifier: ^6.0.0
+        version: 6.4.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vite-plugin-top-level-await:
+        specifier: ^1.6.0
+        version: 1.6.0(rollup@4.59.0)(vite@6.4.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      vite-plugin-wasm:
+        specifier: ^3.5.0
+        version: 3.5.0(vite@6.4.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      vitest:
+        specifier: catalog:default
+        version: 4.0.18(@types/node@25.3.3)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+
   examples/docs/todo-client-localfirst-expo:
     dependencies:
       expo:
@@ -14366,30 +14409,6 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.18(vite@6.4.1(@types/node@20.19.35)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
-    dependencies:
-      '@vitest/spy': 4.0.18
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 6.4.1(@types/node@20.19.35)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
-
-  '@vitest/mocker@4.0.18(vite@6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
-    dependencies:
-      '@vitest/spy': 4.0.18
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
-
-  '@vitest/mocker@4.0.18(vite@6.4.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
-    dependencies:
-      '@vitest/spy': 4.0.18
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 6.4.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
-
   '@vitest/mocker@4.0.18(vite@6.4.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 4.0.18
@@ -14405,7 +14424,6 @@ snapshots:
       magic-string: 0.30.21
     optionalDependencies:
       vite: 7.3.1(@types/node@20.19.35)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
-    optional: true
 
   '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
@@ -14422,7 +14440,14 @@ snapshots:
       magic-string: 0.30.21
     optionalDependencies:
       vite: 7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
-    optional: true
+
+  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
+    dependencies:
+      '@vitest/spy': 4.0.18
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/pretty-format@4.0.18':
     dependencies:
@@ -20728,57 +20753,6 @@ snapshots:
     dependencies:
       vite: 7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
-  vite@6.4.1(@types/node@20.19.35)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
-    dependencies:
-      esbuild: 0.25.12
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-      postcss: 8.5.6
-      rollup: 4.59.0
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      '@types/node': 20.19.35
-      fsevents: 2.3.3
-      jiti: 2.6.1
-      lightningcss: 1.31.1
-      terser: 5.46.0
-      tsx: 4.21.0
-      yaml: 2.8.2
-
-  vite@6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
-    dependencies:
-      esbuild: 0.25.12
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-      postcss: 8.5.6
-      rollup: 4.59.0
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      '@types/node': 22.19.13
-      fsevents: 2.3.3
-      jiti: 2.6.1
-      lightningcss: 1.31.1
-      terser: 5.46.0
-      tsx: 4.21.0
-      yaml: 2.8.2
-
-  vite@6.4.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
-    dependencies:
-      esbuild: 0.25.12
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-      postcss: 8.5.6
-      rollup: 4.59.0
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      '@types/node': 24.11.0
-      fsevents: 2.3.3
-      jiti: 2.6.1
-      lightningcss: 1.31.1
-      terser: 5.46.0
-      tsx: 4.21.0
-      yaml: 2.8.2
-
   vite@6.4.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       esbuild: 0.25.12
@@ -20812,7 +20786,6 @@ snapshots:
       terser: 5.46.0
       tsx: 4.21.0
       yaml: 2.8.2
-    optional: true
 
   vite@7.3.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
@@ -20864,7 +20837,6 @@ snapshots:
       terser: 5.46.0
       tsx: 4.21.0
       yaml: 2.8.2
-    optional: true
 
   vitefu@1.1.2(vite@6.4.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
     optionalDependencies:
@@ -20877,7 +20849,7 @@ snapshots:
   vitest@4.0.18(@types/node@20.19.35)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@6.4.1(@types/node@20.19.35)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@20.19.35)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18
@@ -20894,7 +20866,7 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 6.4.1(@types/node@20.19.35)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@20.19.35)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.19.35
@@ -20917,7 +20889,7 @@ snapshots:
   vitest@4.0.18(@types/node@22.19.13)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18
@@ -20934,7 +20906,7 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.13
@@ -20957,7 +20929,7 @@ snapshots:
   vitest@4.0.18(@types/node@24.11.0)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@6.4.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18
@@ -20974,7 +20946,7 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 6.4.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.11.0
@@ -20997,7 +20969,7 @@ snapshots:
   vitest@4.0.18(@types/node@25.3.3)(@vitest/browser-playwright@4.0.18)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@6.4.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18
@@ -21014,7 +20986,7 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 6.4.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.3.3


### PR DESCRIPTION
The sync system is query-driven. Only objects that match an active query's result set get synced to the client. Here's what the DataPage of the stress test subscribes to:
```js
// Query 1: 50 todos
app.todos.where({ done: true }).orderBy(...).limit(50)

// Query 2: 20 projects  
app.projects.limit(20)
```
With 15,000 todos and 2,000 projects, there is a high probability that the 50 todos retrieved by our query won't have their corresponding projects in memory.
Consequently, marking a todo as 'done' will trigger a UuidForeignKeyViolation error. Because the update process validates all columns - including associations - the operation fails if the corresponding project entity has not been loaded into memory.

The fix I did is to avoid revalidating all the columns during updates. 

