### PR TITLE
chore: add missing Fjall storage changeset

### DIFF
--- a/.changeset/fjall-native-storage.md
+++ b/.changeset/fjall-native-storage.md
@@ -1,0 +1,9 @@
+---
+"jazz-tools": patch
+"jazz-napi": patch
+"jazz-rn": patch
+---
+
+Switch the native persistent storage engine from SurrealKV to Fjall for the CLI, NAPI bindings, and React Native bindings.
+
+Native local data now lives in Fjall-backed stores and uses `.fjall` database paths by default.


### PR DESCRIPTION
## Summary
- add a patch changeset for the SurrealKV to Fjall native storage switch
- cover the CLI, NAPI bindings, and React Native bindings explicitly
- note the default move to `.fjall` database paths

## Testing
- not run (changeset only)