### PR TITLE
fix: repair cloud server image builds

### DIFF
--- a/crates/jazz-cloud-server/deploy/pulumi/Dockerfile
+++ b/crates/jazz-cloud-server/deploy/pulumi/Dockerfile
@@ -1,10 +1,11 @@
-FROM rust:1.88-bookworm AS builder
+FROM rust:1.93.1-bookworm AS builder
 
 WORKDIR /app
 
 COPY Cargo.toml Cargo.lock ./
 COPY crates ./crates
 COPY examples ./examples
+COPY patched-crates ./patched-crates
 
 RUN cargo build --release -p jazz-cloud-server
 

--- a/crates/jazz-cloud-server/deploy/pulumi/deploy-local.sh
+++ b/crates/jazz-cloud-server/deploy/pulumi/deploy-local.sh
@@ -228,25 +228,13 @@ if [[ "${SKIP_BUILD}" -eq 0 ]]; then
     "${REPO_ROOT}/Cargo.toml" \
     "${REPO_ROOT}/Cargo.lock" \
     "${REPO_ROOT}/crates" \
-    "${REPO_ROOT}/examples/todo-server-rs" \
+    "${REPO_ROOT}/examples" \
+    "${REPO_ROOT}/patched-crates" \
     "${TMP_CONTEXT}/"
-
-  cat > "${TMP_CONTEXT}/Dockerfile" <<'EOF'
-FROM rust:1.88-bookworm AS builder
-WORKDIR /app
-COPY . .
-RUN cargo build --release -p jazz-cloud-server
-
-FROM debian:bookworm-slim
-RUN apt-get update \
-  && apt-get install -y --no-install-recommends ca-certificates \
-  && rm -rf /var/lib/apt/lists/*
-COPY --from=builder /app/target/release/jazz-cloud-server /usr/local/bin/jazz-cloud-server
-ENTRYPOINT ["/usr/local/bin/jazz-cloud-server"]
-EOF
 
   docker buildx build \
     --platform linux/amd64 \
+    --file "${SCRIPT_DIR}/Dockerfile" \
     -t "${IMAGE_URI}" \
     --push \
     "${TMP_CONTEXT}"

--- a/crates/jazz-cloud-server/deploy/pulumi/push-cloud-server.sh
+++ b/crates/jazz-cloud-server/deploy/pulumi/push-cloud-server.sh
@@ -148,6 +148,7 @@ rsync -a \
   "${REPO_ROOT}/Cargo.lock" \
   "${REPO_ROOT}/crates" \
   "${REPO_ROOT}/examples" \
+  "${REPO_ROOT}/patched-crates" \
   "${TMP_CONTEXT}/"
 
 docker buildx build \


### PR DESCRIPTION
## Summary
- include `patched-crates/` in the cloud server Docker build context so the local `fjall` patch is available inside the image build
- align the cloud server builder image with the repo Rust toolchain (`1.93.1`) so current dependencies compile in CI
- make `deploy-local.sh` reuse the shared Dockerfile and sync the full `examples/` tree so local publish/deploy paths match CI

## Context
The `Publish Cloud Server Image` workflow failed on March 11, 2026 in job 66698876477 because Cargo could not read `/app/patched-crates/fjall-android-lock-workaround/Cargo.toml` during the Docker build. After fixing that missing path, the next container build failure was the stale `rust:1.88-bookworm` builder image, while the repo is pinned to Rust `1.93.1` and current dependencies require at least `1.91`.

Failing run: https://github.com/garden-co/jazz2/actions/runs/22974302229/job/66698876477

## Verification
- `docker buildx build --target builder --platform linux/amd64 --file crates/jazz-cloud-server/deploy/pulumi/Dockerfile --load -t jazz-cloud-server:test .`
- `docker buildx build --target builder --platform linux/amd64 --file crates/jazz-cloud-server/deploy/pulumi/Dockerfile --load -t jazz-cloud-server:temp-context-test <rsynced-temp-context>`
