### PR TITLE
Add mutation outcome protocol plumbing

### DIFF
--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -33,8 +33,8 @@ use jazz_tools::query_manager::query::Query;
 use jazz_tools::query_manager::session::Session;
 use jazz_tools::query_manager::types::{Schema, SchemaHash, TableName, Value};
 use jazz_tools::runtime_core::{
-    ReadDurabilityOptions, RuntimeCore, Scheduler, SubscriptionDelta, SubscriptionHandle,
-    SyncSender,
+    PersistedMutationError, ReadDurabilityOptions, RuntimeCore, Scheduler, SubscriptionDelta,
+    SubscriptionHandle, SyncSender,
 };
 use jazz_tools::schema_manager::{AppId, SchemaManager};
 use jazz_tools::storage::{FjallStorage, MemoryStorage, Storage};
@@ -43,6 +43,23 @@ use jazz_tools::sync_manager::{
     ClientId, DurabilityTier, InboxEntry, MutationId, ObjectOutcomeEvent, ObjectOutcomeState,
     OutboxEntry, ServerId, Source, SyncManager, SyncPayload,
 };
+
+const PERSISTED_MUTATION_ERROR_CAUSE_PREFIX: &str = "__jazzPersistedMutationError__:";
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct JsonPersistedMutationErrorPayload {
+    mutation_id: String,
+    root_mutation_id: String,
+    object_id: String,
+    branch_name: String,
+    operation: String,
+    commit_ids: Vec<String>,
+    previous_commit_ids: Vec<String>,
+    code: String,
+    reason: String,
+    rejected_at_micros: u64,
+}
 
 fn convert_values(values: Vec<Value>) -> Vec<Value> {
     values
@@ -146,6 +163,56 @@ fn object_outcome_event_to_json(event: ObjectOutcomeEvent) -> serde_json::Value 
         "objectId": event.object_id.uuid().to_string(),
         "outcome": event.outcome.map(object_outcome_state_to_json),
     })
+}
+
+fn encode_commit_id_hex(bytes: [u8; 32]) -> String {
+    bytes.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+fn persisted_mutation_error_payload(
+    error: PersistedMutationError,
+) -> JsonPersistedMutationErrorPayload {
+    let rejection = error.rejection;
+    JsonPersistedMutationErrorPayload {
+        mutation_id: error.mutation_id.to_string(),
+        root_mutation_id: error.root_mutation_id.to_string(),
+        object_id: rejection.object_id.uuid().to_string(),
+        branch_name: rejection.branch_name.to_string(),
+        operation: serde_json::to_string(&rejection.operation)
+            .unwrap_or_else(|_| "\"update\"".to_string())
+            .trim_matches('"')
+            .to_string(),
+        commit_ids: rejection
+            .commit_ids
+            .into_iter()
+            .map(|commit_id| encode_commit_id_hex(commit_id.0))
+            .collect(),
+        previous_commit_ids: rejection
+            .previous_commit_ids
+            .into_iter()
+            .map(|commit_id| encode_commit_id_hex(commit_id.0))
+            .collect(),
+        code: serde_json::to_string(&rejection.code)
+            .unwrap_or_else(|_| "\"permission_denied\"".to_string())
+            .trim_matches('"')
+            .to_string(),
+        reason: rejection.reason,
+        rejected_at_micros: rejection.rejected_at_micros,
+    }
+}
+
+fn persisted_mutation_error_to_napi(error: PersistedMutationError) -> napi::Error {
+    let payload = persisted_mutation_error_payload(error);
+    let mut js_error = napi::Error::from_reason(format!(
+        "mutation {} rejected: {}",
+        payload.mutation_id, payload.reason
+    ));
+    let cause_payload = serde_json::to_string(&payload).unwrap_or_else(|_| "{}".to_string());
+    js_error.set_cause(napi::Error::from_reason(format!(
+        "{}{}",
+        PERSISTED_MUTATION_ERROR_CAUSE_PREFIX, cause_payload
+    )));
+    js_error
 }
 
 fn parse_query(json: &str) -> napi::Result<Query> {
@@ -729,7 +796,7 @@ impl NapiRuntime {
         receiver
             .await
             .map_err(|_| napi::Error::from_reason("Insert durable waiter cancelled"))?
-            .map_err(|err| napi::Error::from_reason(err.to_string()))?;
+            .map_err(persisted_mutation_error_to_napi)?;
         Ok(serde_json::json!({
             "id": object_id.uuid().to_string(),
             "values": row_values,
@@ -765,7 +832,7 @@ impl NapiRuntime {
         receiver
             .await
             .map_err(|_| napi::Error::from_reason("Update durable waiter cancelled"))?
-            .map_err(|err| napi::Error::from_reason(err.to_string()))?;
+            .map_err(persisted_mutation_error_to_napi)?;
         Ok(())
     }
 
@@ -789,7 +856,7 @@ impl NapiRuntime {
         receiver
             .await
             .map_err(|_| napi::Error::from_reason("Delete durable waiter cancelled"))?
-            .map_err(|err| napi::Error::from_reason(err.to_string()))?;
+            .map_err(persisted_mutation_error_to_napi)?;
         Ok(())
     }
 

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -689,7 +689,10 @@ impl NapiRuntime {
             ((object_id, row_values), receiver)
         };
 
-        let _ = receiver.await;
+        receiver
+            .await
+            .map_err(|_| napi::Error::from_reason("Insert durable waiter cancelled"))?
+            .map_err(|err| napi::Error::from_reason(err.to_string()))?;
         Ok(serde_json::json!({
             "id": object_id.uuid().to_string(),
             "values": row_values,
@@ -722,7 +725,10 @@ impl NapiRuntime {
                 .map_err(|e| napi::Error::from_reason(format!("Update failed: {:?}", e)))?
         };
 
-        let _ = receiver.await;
+        receiver
+            .await
+            .map_err(|_| napi::Error::from_reason("Update durable waiter cancelled"))?
+            .map_err(|err| napi::Error::from_reason(err.to_string()))?;
         Ok(())
     }
 
@@ -743,7 +749,10 @@ impl NapiRuntime {
                 .map_err(|e| napi::Error::from_reason(format!("Delete failed: {:?}", e)))?
         };
 
-        let _ = receiver.await;
+        receiver
+            .await
+            .map_err(|_| napi::Error::from_reason("Delete durable waiter cancelled"))?
+            .map_err(|err| napi::Error::from_reason(err.to_string()))?;
         Ok(())
     }
 

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -40,7 +40,8 @@ use jazz_tools::schema_manager::{AppId, SchemaManager};
 use jazz_tools::storage::{FjallStorage, MemoryStorage, Storage};
 use jazz_tools::sync_manager::QueryPropagation;
 use jazz_tools::sync_manager::{
-    ClientId, DurabilityTier, InboxEntry, OutboxEntry, ServerId, Source, SyncManager, SyncPayload,
+    ClientId, DurabilityTier, InboxEntry, MutationId, ObjectOutcomeEvent, ObjectOutcomeState,
+    OutboxEntry, ServerId, Source, SyncManager, SyncPayload,
 };
 
 fn convert_values(values: Vec<Value>) -> Vec<Value> {
@@ -109,6 +110,42 @@ fn open_fjall_storage_with_retry(data_path: &str, cache_size: usize) -> napi::Re
 // ============================================================================
 fn parse_tier(tier: &str) -> napi::Result<DurabilityTier> {
     parse_binding_tier(tier).map_err(napi::Error::from_reason)
+}
+
+fn parse_mutation_id(mutation_id: &str) -> napi::Result<MutationId> {
+    uuid::Uuid::parse_str(mutation_id)
+        .map(MutationId)
+        .map_err(|e| napi::Error::from_reason(format!("Invalid MutationId: {}", e)))
+}
+
+fn object_outcome_state_to_json(outcome: ObjectOutcomeState) -> serde_json::Value {
+    match outcome {
+        ObjectOutcomeState::Pending { mutation_id } => serde_json::json!({
+            "type": "pending",
+            "mutationId": mutation_id.to_string(),
+        }),
+        ObjectOutcomeState::Accepted { mutation_id } => serde_json::json!({
+            "type": "accepted",
+            "mutationId": mutation_id.to_string(),
+        }),
+        ObjectOutcomeState::Errored {
+            mutation_id,
+            code,
+            reason,
+        } => serde_json::json!({
+            "type": "errored",
+            "mutationId": mutation_id.to_string(),
+            "code": code,
+            "reason": reason,
+        }),
+    }
+}
+
+fn object_outcome_event_to_json(event: ObjectOutcomeEvent) -> serde_json::Value {
+    serde_json::json!({
+        "objectId": event.object_id.uuid().to_string(),
+        "outcome": event.outcome.map(object_outcome_state_to_json),
+    })
 }
 
 fn parse_query(json: &str) -> napi::Result<Query> {
@@ -817,6 +854,59 @@ impl NapiRuntime {
             .lock()
             .map_err(|_| napi::Error::from_reason("lock"))?;
         core.sync_sender().set_callback(callback);
+        Ok(())
+    }
+
+    #[napi(js_name = "setMutationJournalEnabled")]
+    pub fn set_mutation_journal_enabled(&self, enabled: bool) -> napi::Result<()> {
+        let mut core = self
+            .core
+            .lock()
+            .map_err(|_| napi::Error::from_reason("lock"))?;
+        core.set_mutation_journal_enabled(enabled);
+        Ok(())
+    }
+
+    #[napi(js_name = "listObjectOutcomes", ts_return_type = "any")]
+    pub fn list_object_outcomes(&self) -> napi::Result<serde_json::Value> {
+        let core = self
+            .core
+            .lock()
+            .map_err(|_| napi::Error::from_reason("lock"))?;
+        let outcomes = core
+            .list_object_outcomes()
+            .map_err(|e| napi::Error::from_reason(format!("List object outcomes failed: {:?}", e)))?
+            .into_iter()
+            .map(object_outcome_event_to_json)
+            .collect::<Vec<_>>();
+        Ok(serde_json::Value::Array(outcomes))
+    }
+
+    #[napi(js_name = "takeObjectOutcomeEvents", ts_return_type = "any")]
+    pub fn take_object_outcome_events(&self) -> napi::Result<serde_json::Value> {
+        let mut core = self
+            .core
+            .lock()
+            .map_err(|_| napi::Error::from_reason("lock"))?;
+        let events = core
+            .take_object_outcome_events()
+            .into_iter()
+            .map(object_outcome_event_to_json)
+            .collect::<Vec<_>>();
+        Ok(serde_json::Value::Array(events))
+    }
+
+    #[napi(js_name = "acknowledgeMutationOutcome")]
+    pub fn acknowledge_mutation_outcome(&self, mutation_id: String) -> napi::Result<()> {
+        let mutation_id = parse_mutation_id(&mutation_id)?;
+        let mut core = self
+            .core
+            .lock()
+            .map_err(|_| napi::Error::from_reason("lock"))?;
+        core.acknowledge_mutation_outcome(mutation_id)
+            .map_err(|e| {
+                napi::Error::from_reason(format!("Acknowledge mutation outcome failed: {:?}", e))
+            })?;
         Ok(())
     }
 

--- a/crates/jazz-tools/src/object.rs
+++ b/crates/jazz-tools/src/object.rs
@@ -135,6 +135,8 @@ pub struct Branch {
     pub commits: HashMap<CommitId, Commit>,
     /// Current tips (unmerged heads). Inline storage for ≤2 tips.
     pub tips: SmolSet<[CommitId; 2]>,
+    /// Local-only commits retained after rollback but excluded from the active frontier.
+    pub inactive_commits: SmolSet<[CommitId; 2]>,
     /// Truncation boundary. None = full history from roots.
     /// Some(tails) = history only includes tails and their descendants.
     pub tails: Option<SmolSet<[CommitId; 2]>>,

--- a/crates/jazz-tools/src/object_manager/mod.rs
+++ b/crates/jazz-tools/src/object_manager/mod.rs
@@ -214,9 +214,16 @@ impl ObjectManager {
                 let mut all_ids: HashSet<CommitId> = HashSet::new();
                 let mut parent_ids: HashSet<CommitId> = HashSet::new();
                 for commit in &loaded.commits {
-                    all_ids.insert(commit.id());
+                    let commit_id = commit.id();
+                    if loaded.inactive_commits.contains(&commit_id) {
+                        continue;
+                    }
+
+                    all_ids.insert(commit_id);
                     for parent in &commit.parents {
-                        parent_ids.insert(*parent);
+                        if !loaded.inactive_commits.contains(parent) {
+                            parent_ids.insert(*parent);
+                        }
                     }
                 }
                 let mut tips: SmolSet<[CommitId; 2]> = SmolSet::new();
@@ -233,6 +240,7 @@ impl ObjectManager {
                     Branch {
                         commits,
                         tips,
+                        inactive_commits: loaded.inactive_commits.into_iter().collect(),
                         tails: if loaded.tails.is_empty() {
                             None
                         } else {
@@ -786,6 +794,166 @@ impl ObjectManager {
         }
     }
 
+    /// Mark a commit chain as inactive while retaining the underlying commits for later inspection.
+    ///
+    /// The active frontier is recomputed without the inactive chain and subscribers are notified.
+    pub fn deactivate_commit_chain<H: Storage>(
+        &mut self,
+        io: &mut H,
+        object_id: ObjectId,
+        branch_name: impl Into<BranchName>,
+        root_commit_ids: HashSet<CommitId>,
+    ) -> Result<Vec<CommitId>, Error> {
+        let branch_name = branch_name.into();
+
+        let (previous_commit_ids, old_content, deactivated_commits, current_commit_ids, inactive) = {
+            let object = self
+                .get(object_id)
+                .ok_or(Error::ObjectNotFound(object_id))?;
+            let branch = object
+                .branches
+                .get(&branch_name)
+                .ok_or(Error::BranchNotFound(branch_name))?;
+
+            let previous_commit_ids = Self::tips_by_timestamp(&branch.commits, &branch.tips);
+            let old_content = previous_commit_ids
+                .last()
+                .and_then(|tip_id| branch.commits.get(tip_id))
+                .map(|commit| commit.content.clone());
+            let deactivated_commits =
+                Self::find_descendants_inclusive(&branch.commits, &root_commit_ids);
+
+            if deactivated_commits.is_empty() {
+                return Ok(Vec::new());
+            }
+
+            let mut inactive: SmolSet<[CommitId; 2]> = branch.inactive_commits.clone();
+            for commit_id in &deactivated_commits {
+                inactive.insert(*commit_id);
+            }
+
+            let mut updated_branch = branch.clone();
+            updated_branch.inactive_commits = inactive.clone();
+            updated_branch.tips = Self::recompute_active_tips(&updated_branch);
+
+            (
+                previous_commit_ids,
+                old_content,
+                deactivated_commits,
+                Self::tips_by_timestamp(&updated_branch.commits, &updated_branch.tips),
+                inactive,
+            )
+        };
+
+        let object = self
+            .get_mut(object_id)
+            .expect("object existence already validated");
+        let branch = object.branches.get_mut(&branch_name).unwrap();
+        branch.inactive_commits = inactive;
+        branch.tips = current_commit_ids.iter().copied().collect();
+
+        Self::persist_branch_frontier(io, object_id, &branch_name, branch)?;
+        let inactive_to_store: HashSet<_> = branch.inactive_commits.iter().copied().collect();
+        io.set_branch_inactive_commits(
+            object_id,
+            &branch_name,
+            (!inactive_to_store.is_empty()).then_some(inactive_to_store),
+        )
+        .map_err(Error::StorageError)?;
+
+        self.notify_subscribers_of_commit(object_id, branch_name);
+        self.notify_all_object_subscribers(
+            object_id,
+            branch_name,
+            false,
+            previous_commit_ids,
+            old_content,
+        );
+
+        Ok(deactivated_commits.into_iter().collect())
+    }
+
+    /// Physically delete previously inactivated commits from a branch.
+    pub fn prune_inactive_commits<H: Storage>(
+        &mut self,
+        io: &mut H,
+        object_id: ObjectId,
+        branch_name: impl Into<BranchName>,
+        commit_ids: &HashSet<CommitId>,
+    ) -> Result<usize, Error> {
+        let branch_name = branch_name.into();
+
+        let Some(object) = self.get(object_id) else {
+            return Ok(0);
+        };
+        let Some(branch) = object.branches.get(&branch_name) else {
+            return Ok(0);
+        };
+
+        let commits_to_delete: HashSet<_> = commit_ids
+            .iter()
+            .copied()
+            .filter(|commit_id| branch.inactive_commits.contains(commit_id))
+            .collect();
+
+        if commits_to_delete.is_empty() {
+            return Ok(0);
+        }
+
+        for commit_id in &commits_to_delete {
+            io.delete_commit(object_id, &branch_name, *commit_id)
+                .map_err(Error::StorageError)?;
+        }
+
+        let (active_tips, inactive_to_store) = {
+            let object = self
+                .get_mut(object_id)
+                .expect("object existence already validated");
+            let branch = object.branches.get_mut(&branch_name).unwrap();
+
+            for commit_id in &commits_to_delete {
+                branch.commits.remove(commit_id);
+                branch.inactive_commits.remove(commit_id);
+            }
+            branch.tips = Self::recompute_active_tips(branch);
+            (
+                branch.tips.iter().copied().collect::<HashSet<_>>(),
+                branch
+                    .inactive_commits
+                    .iter()
+                    .copied()
+                    .collect::<HashSet<_>>(),
+            )
+        };
+
+        let should_remove_branch = active_tips.is_empty() && inactive_to_store.is_empty();
+
+        if should_remove_branch {
+            if let Some(object) = self.get_mut(object_id) {
+                object.branches.remove(&branch_name);
+            }
+            io.set_branch_tails(object_id, &branch_name, None)
+                .map_err(Error::StorageError)?;
+            io.set_branch_inactive_commits(object_id, &branch_name, None)
+                .map_err(Error::StorageError)?;
+        } else {
+            io.set_branch_tails(
+                object_id,
+                &branch_name,
+                (!active_tips.is_empty()).then_some(active_tips),
+            )
+            .map_err(Error::StorageError)?;
+            io.set_branch_inactive_commits(
+                object_id,
+                &branch_name,
+                (!inactive_to_store.is_empty()).then_some(inactive_to_store),
+            )
+            .map_err(Error::StorageError)?;
+        }
+
+        Ok(commits_to_delete.len())
+    }
+
     /// Truncate a branch by removing commits topologically earlier than the specified tails.
     ///
     /// All tips must be descendants of (or equal to) some tail. Commits before the tails
@@ -860,6 +1028,7 @@ impl ObjectManager {
         // Remove deleted commits from memory
         for commit_id in &commits_to_delete {
             branch.commits.remove(commit_id);
+            branch.inactive_commits.remove(commit_id);
         }
 
         TruncateResult::Success {
@@ -937,6 +1106,72 @@ impl ObjectManager {
         }
 
         ancestors
+    }
+
+    fn recompute_active_tips(branch: &Branch) -> SmolSet<[CommitId; 2]> {
+        let mut all_ids = HashSet::new();
+        let mut parent_ids = HashSet::new();
+
+        for (commit_id, commit) in &branch.commits {
+            if branch.inactive_commits.contains(commit_id) {
+                continue;
+            }
+
+            all_ids.insert(*commit_id);
+            for parent in &commit.parents {
+                if branch.commits.contains_key(parent) && !branch.inactive_commits.contains(parent)
+                {
+                    parent_ids.insert(*parent);
+                }
+            }
+        }
+
+        all_ids
+            .into_iter()
+            .filter(|commit_id| !parent_ids.contains(commit_id))
+            .collect()
+    }
+
+    fn find_descendants_inclusive(
+        commits: &HashMap<CommitId, Commit>,
+        starting_points: &HashSet<CommitId>,
+    ) -> HashSet<CommitId> {
+        let mut descendants = starting_points
+            .iter()
+            .copied()
+            .filter(|commit_id| commits.contains_key(commit_id))
+            .collect::<HashSet<_>>();
+        let mut changed = true;
+
+        while changed {
+            changed = false;
+            for (commit_id, commit) in commits {
+                if descendants.contains(commit_id) {
+                    continue;
+                }
+                if commit
+                    .parents
+                    .iter()
+                    .any(|parent| descendants.contains(parent))
+                {
+                    descendants.insert(*commit_id);
+                    changed = true;
+                }
+            }
+        }
+
+        descendants
+    }
+
+    fn persist_branch_frontier<H: Storage>(
+        io: &mut H,
+        object_id: ObjectId,
+        branch_name: &BranchName,
+        branch: &Branch,
+    ) -> Result<(), Error> {
+        let tips: HashSet<_> = branch.tips.iter().copied().collect();
+        io.set_branch_tails(object_id, branch_name, (!tips.is_empty()).then_some(tips))
+            .map_err(Error::StorageError)
     }
 
     // ========================================================================

--- a/crates/jazz-tools/src/query_manager/manager.rs
+++ b/crates/jazz-tools/src/query_manager/manager.rs
@@ -1105,6 +1105,36 @@ impl QueryManager {
             return;
         }
 
+        // Rollback can remove a branch frontier entirely (e.g. rejected inserts).
+        // In that case, remove any indexed visibility for the previous state.
+        if update.commit_ids.is_empty() {
+            let old_data = if has_prior_history {
+                Some(update.old_content.as_deref().unwrap_or_else(|| {
+                    panic!(
+                        "missing old_content for empty-frontier update: object_id={}, table={}, branch={}, prev_tips={}, commit_ids={}",
+                        update.object_id,
+                        table,
+                        branch,
+                        update.previous_commit_ids.len(),
+                        update.commit_ids.len(),
+                    )
+                }))
+            } else {
+                update.old_content.as_deref()
+            };
+            let _ = Self::update_indices_for_hard_delete_on_branch(
+                storage,
+                &table,
+                branch,
+                update.object_id,
+                old_data,
+                &descriptor,
+            );
+            self.mark_subscriptions_dirty(&table);
+            self.mark_row_deleted_in_subscriptions(&table, update.object_id);
+            return;
+        }
+
         // Check if incoming update is a hard delete
         if self.is_incoming_hard_delete(update.object_id) {
             let old_data = if has_prior_history {

--- a/crates/jazz-tools/src/query_manager/manager_tests.rs
+++ b/crates/jazz-tools/src/query_manager/manager_tests.rs
@@ -4647,7 +4647,8 @@ fn uuid_array_fk_reverse_membership_and_index_updates_on_edit() {
 fn server_permission_checks_reject_missing_scalar_fk_writes() {
     use crate::commit::{Commit, StoredState};
     use crate::sync_manager::{
-        ClientId, ClientRole, InboxEntry, ObjectMetadata, Source, SyncError, SyncPayload,
+        ClientId, ClientRole, InboxEntry, MutationOutcome, MutationRejectCode, MutationRejection,
+        ObjectMetadata, Source, SyncPayload,
     };
 
     let sync_manager = SyncManager::new();
@@ -4709,7 +4710,11 @@ fn server_permission_checks_reject_missing_scalar_fk_writes() {
 
     let outbox = qm.sync_manager_mut().take_outbox();
     let insert_rejection = outbox.iter().find_map(|entry| match &entry.payload {
-        SyncPayload::Error(SyncError::PermissionDenied { reason, .. }) => Some(reason.as_str()),
+        SyncPayload::MutationOutcome(MutationOutcome::Rejected(MutationRejection {
+            reason,
+            code: MutationRejectCode::PermissionDenied,
+            ..
+        })) => Some(reason.as_str()),
         _ => None,
     });
     assert!(
@@ -4760,7 +4765,11 @@ fn server_permission_checks_reject_missing_scalar_fk_writes() {
 
     let outbox = qm.sync_manager_mut().take_outbox();
     let update_rejection = outbox.iter().find_map(|entry| match &entry.payload {
-        SyncPayload::Error(SyncError::PermissionDenied { reason, .. }) => Some(reason.as_str()),
+        SyncPayload::MutationOutcome(MutationOutcome::Rejected(MutationRejection {
+            reason,
+            code: MutationRejectCode::PermissionDenied,
+            ..
+        })) => Some(reason.as_str()),
         _ => None,
     });
     assert!(

--- a/crates/jazz-tools/src/query_manager/rebac_tests.rs
+++ b/crates/jazz-tools/src/query_manager/rebac_tests.rs
@@ -11,8 +11,8 @@ use crate::metadata::MetadataKey;
 use crate::object::ObjectId;
 use crate::storage::MemoryStorage;
 use crate::sync_manager::{
-    ClientId, Destination, InboxEntry, ObjectMetadata, QueryId, Source, SyncError, SyncManager,
-    SyncPayload,
+    ClientId, Destination, InboxEntry, MutationOutcome, MutationRejectCode, MutationRejection,
+    ObjectMetadata, QueryId, Source, SyncManager, SyncPayload,
 };
 
 use crate::query_manager::encoding::{decode_row, encode_row};
@@ -298,8 +298,13 @@ fn run_recursive_folder_update(max_depth: Option<usize>) -> (bool, bool) {
     let denied = outbox.iter().any(|entry| {
         matches!(
             (&entry.destination, &entry.payload),
-            (Destination::Client(id), SyncPayload::Error(SyncError::PermissionDenied { .. }))
-                if *id == client_id
+            (
+                Destination::Client(id),
+                SyncPayload::MutationOutcome(MutationOutcome::Rejected(MutationRejection {
+                    code: MutationRejectCode::PermissionDenied,
+                    ..
+                }))
+            ) if *id == client_id
         )
     });
 
@@ -447,7 +452,11 @@ fn rebac_insert_denied_by_simple_policy() {
         .expect("Should receive error response");
 
     match &error.payload {
-        SyncPayload::Error(SyncError::PermissionDenied { reason, .. }) => {
+        SyncPayload::MutationOutcome(MutationOutcome::Rejected(MutationRejection {
+            reason,
+            code: MutationRejectCode::PermissionDenied,
+            ..
+        })) => {
             assert!(
                 reason.contains("denied by policy"),
                 "Error should mention policy denial: {reason}"
@@ -825,7 +834,10 @@ fn rebac_exists_clause_denies_non_matching_insert() {
     );
 
     match &error.unwrap().payload {
-        SyncPayload::Error(SyncError::PermissionDenied { .. }) => {
+        SyncPayload::MutationOutcome(MutationOutcome::Rejected(MutationRejection {
+            code: MutationRejectCode::PermissionDenied,
+            ..
+        })) => {
             // Expected
         }
         other => panic!("Expected PermissionDenied error, got {:?}", other),
@@ -975,7 +987,10 @@ fn rebac_update_denied_by_using_policy() {
     );
 
     match &error.unwrap().payload {
-        SyncPayload::Error(SyncError::PermissionDenied { .. }) => {
+        SyncPayload::MutationOutcome(MutationOutcome::Rejected(MutationRejection {
+            code: MutationRejectCode::PermissionDenied,
+            ..
+        })) => {
             // Expected
         }
         other => panic!("Expected PermissionDenied error, got {:?}", other),
@@ -1511,7 +1526,10 @@ fn rebac_update_denied_by_using_exists_policy() {
         "Bob's update should be denied by EXISTS in USING policy"
     );
     match &bob_error.unwrap().payload {
-        SyncPayload::Error(SyncError::PermissionDenied { .. }) => {
+        SyncPayload::MutationOutcome(MutationOutcome::Rejected(MutationRejection {
+            code: MutationRejectCode::PermissionDenied,
+            ..
+        })) => {
             // Expected
         }
         other => panic!("Expected PermissionDenied error for Bob, got {:?}", other),
@@ -1580,7 +1598,13 @@ fn rebac_update_denied_by_using_exists_policy() {
     let alice_error = outbox.iter().find(|e| {
         matches!(
             (&e.destination, &e.payload),
-            (Destination::Client(id), SyncPayload::Error(SyncError::PermissionDenied { .. })) if *id == alice_client
+            (
+                Destination::Client(id),
+                SyncPayload::MutationOutcome(MutationOutcome::Rejected(MutationRejection {
+                    code: MutationRejectCode::PermissionDenied,
+                    ..
+                }))
+            ) if *id == alice_client
         )
     });
 

--- a/crates/jazz-tools/src/runtime_core.rs
+++ b/crates/jazz-tools/src/runtime_core.rs
@@ -518,6 +518,11 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
             }))
     }
 
+    /// List the current object-level outcome overlays for all tracked objects.
+    pub fn list_object_outcomes(&self) -> Result<Vec<ObjectOutcomeEvent>, RuntimeError> {
+        self.list_object_outcomes_inner()
+    }
+
     /// Acknowledge a surfaced mutation outcome and prune any retained dead commit chain.
     pub fn acknowledge_mutation_outcome(
         &mut self,

--- a/crates/jazz-tools/src/runtime_core.rs
+++ b/crates/jazz-tools/src/runtime_core.rs
@@ -41,8 +41,8 @@ use crate::schema_manager::SchemaManager;
 use crate::storage::Storage;
 use crate::sync_manager::{
     ClientId, DurabilityTier, InboxEntry, MutationEvent, MutationId, MutationOutcome,
-    MutationOutcomeFilter, MutationOutcomeState, MutationRecord, ObjectOutcomeState, OutboxEntry,
-    ServerId,
+    MutationOutcomeFilter, MutationOutcomeState, MutationRecord, MutationRejection,
+    ObjectOutcomeEvent, ObjectOutcomeState, OutboxEntry, ServerId,
 };
 
 // ============================================================================
@@ -144,6 +144,28 @@ impl From<QueryError> for RuntimeError {
 pub type QueryResult = Result<Vec<(ObjectId, Vec<Value>)>, RuntimeError>;
 /// Type alias for inserted row payloads.
 pub type InsertedRow = (ObjectId, Vec<Value>);
+/// Error returned by a persisted mutation waiter when the mutation is rejected.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PersistedMutationError {
+    pub mutation_id: MutationId,
+    pub root_mutation_id: MutationId,
+    pub rejection: MutationRejection,
+}
+
+impl std::fmt::Display for PersistedMutationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "mutation {} rejected: {}",
+            self.mutation_id, self.rejection.reason
+        )
+    }
+}
+
+impl std::error::Error for PersistedMutationError {}
+
+pub type PersistedMutationResult = Result<(), PersistedMutationError>;
+pub type PersistedMutationReceiver = oneshot::Receiver<PersistedMutationResult>;
 
 /// Future that resolves to query results.
 ///
@@ -216,6 +238,11 @@ struct PendingOneShotQuery {
     sender: Option<QuerySender>,
 }
 
+struct PersistedMutationWatcher {
+    tier: DurabilityTier,
+    sender: oneshot::Sender<PersistedMutationResult>,
+}
+
 /// Unified runtime core for both native and WASM platforms.
 ///
 /// Generic over `Storage` for data persistence, `Scheduler` for tick scheduling,
@@ -245,14 +272,16 @@ pub struct RuntimeCore<S: Storage, Sch: Scheduler, Sy: SyncSender> {
     /// Pending one-shot queries (query() calls waiting for first callback).
     pending_one_shot_queries: HashMap<SubscriptionHandle, PendingOneShotQuery>,
 
-    /// Watchers for persistence acks: (commit_id, requested_tier) → senders.
-    /// A tier >= requested tier satisfies the watcher (e.g., EdgeServer ack satisfies Worker).
-    ack_watchers: HashMap<CommitId, Vec<(DurabilityTier, oneshot::Sender<()>)>>,
+    /// Watchers for durable mutation outcomes keyed by local mutation id.
+    /// A tier >= requested tier resolves with `Ok(())`; a rejection resolves with `Err(...)`.
+    ack_watchers: HashMap<MutationId, Vec<PersistedMutationWatcher>>,
 
     /// Shared raw mutation outcomes received from sync.
     mutation_outcomes: Vec<MutationOutcome>,
     /// Higher-level mutation events derived from the local journal.
     mutation_events: Vec<MutationEvent>,
+    /// Derived object-level outcome changes for bindings to invalidate visible rows.
+    object_outcome_events: Vec<ObjectOutcomeEvent>,
     /// In-memory reverse index for fast commit-to-mutation correlation.
     commit_to_mutation: HashMap<CommitId, MutationId>,
     /// Whether this runtime owns the local mutation journal.
@@ -281,6 +310,7 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
             ack_watchers: HashMap::new(),
             mutation_outcomes: Vec::new(),
             mutation_events: Vec::new(),
+            object_outcome_events: Vec::new(),
             commit_to_mutation: HashMap::new(),
             mutation_journal_enabled: true,
             tier_label: "unknown",
@@ -388,6 +418,11 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
     /// Take higher-level mutation events derived from the local mutation journal.
     pub fn take_mutation_events(&mut self) -> Vec<MutationEvent> {
         std::mem::take(&mut self.mutation_events)
+    }
+
+    /// Take derived object-outcome change events since the last call.
+    pub fn take_object_outcome_events(&mut self) -> Vec<ObjectOutcomeEvent> {
+        std::mem::take(&mut self.object_outcome_events)
     }
 
     /// Load one mutation record by mutation id.

--- a/crates/jazz-tools/src/runtime_core.rs
+++ b/crates/jazz-tools/src/runtime_core.rs
@@ -40,7 +40,8 @@ use crate::query_manager::types::{OrderedRowDelta, Schema, TableName, Value};
 use crate::schema_manager::SchemaManager;
 use crate::storage::Storage;
 use crate::sync_manager::{
-    ClientId, DurabilityTier, InboxEntry, MutationOutcome, OutboxEntry, ServerId,
+    ClientId, DurabilityTier, InboxEntry, MutationEvent, MutationId, MutationOutcome,
+    MutationOutcomeFilter, MutationRecord, OutboxEntry, ServerId,
 };
 
 // ============================================================================
@@ -247,6 +248,15 @@ pub struct RuntimeCore<S: Storage, Sch: Scheduler, Sy: SyncSender> {
     /// A tier >= requested tier satisfies the watcher (e.g., EdgeServer ack satisfies Worker).
     ack_watchers: HashMap<CommitId, Vec<(DurabilityTier, oneshot::Sender<()>)>>,
 
+    /// Shared raw mutation outcomes received from sync.
+    mutation_outcomes: Vec<MutationOutcome>,
+    /// Higher-level mutation events derived from the local journal.
+    mutation_events: Vec<MutationEvent>,
+    /// In-memory reverse index for fast commit-to-mutation correlation.
+    commit_to_mutation: HashMap<CommitId, MutationId>,
+    /// Whether this runtime owns the local mutation journal.
+    mutation_journal_enabled: bool,
+
     /// Label for tracing (e.g. "worker", "edge", "client").
     tier_label: &'static str,
 }
@@ -268,6 +278,10 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
             pending_subscriptions: HashMap::new(),
             pending_one_shot_queries: HashMap::new(),
             ack_watchers: HashMap::new(),
+            mutation_outcomes: Vec::new(),
+            mutation_events: Vec::new(),
+            commit_to_mutation: HashMap::new(),
+            mutation_journal_enabled: true,
             tier_label: "unknown",
         }
     }
@@ -275,6 +289,16 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
     /// Set the tier label used in tracing spans.
     pub fn set_tier_label(&mut self, label: &'static str) {
         self.tier_label = label;
+    }
+
+    /// Enable or disable local mutation journal ownership for this runtime.
+    pub fn set_mutation_journal_enabled(&mut self, enabled: bool) {
+        self.mutation_journal_enabled = enabled;
+    }
+
+    /// Whether this runtime owns local mutation journal persistence.
+    pub fn mutation_journal_enabled(&self) -> bool {
+        self.mutation_journal_enabled
     }
 
     /// Get mutable reference to the Storage.
@@ -357,13 +381,50 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
 
     /// Take mutation outcomes received since the last call.
     pub fn take_mutation_outcomes(&mut self) -> Vec<MutationOutcome> {
-        self.schema_manager
-            .query_manager_mut()
-            .sync_manager_mut()
-            .take_received_mutation_outcomes()
+        std::mem::take(&mut self.mutation_outcomes)
+    }
+
+    /// Take higher-level mutation events derived from the local mutation journal.
+    pub fn take_mutation_events(&mut self) -> Vec<MutationEvent> {
+        std::mem::take(&mut self.mutation_events)
+    }
+
+    /// Load one mutation record by mutation id.
+    pub fn get_mutation_record(
+        &self,
+        mutation_id: MutationId,
+    ) -> Result<Option<MutationRecord>, RuntimeError> {
+        self.storage
+            .load_mutation_record(mutation_id)
+            .map_err(|err| RuntimeError::WriteError(format!("{:?}", err)))
+    }
+
+    /// Load one mutation record by commit id.
+    pub fn get_mutation_record_by_commit(
+        &self,
+        commit_id: CommitId,
+    ) -> Result<Option<MutationRecord>, RuntimeError> {
+        self.storage
+            .load_mutation_record_by_commit(commit_id)
+            .map_err(|err| RuntimeError::WriteError(format!("{:?}", err)))
+    }
+
+    /// List pending mutation journal records.
+    pub fn list_pending_mutations(&self) -> Result<Vec<MutationRecord>, RuntimeError> {
+        self.storage
+            .list_mutation_records_by_outcome(MutationOutcomeFilter::Pending)
+            .map_err(|err| RuntimeError::WriteError(format!("{:?}", err)))
+    }
+
+    /// List rejected mutation journal records.
+    pub fn list_rejected_mutations(&self) -> Result<Vec<MutationRecord>, RuntimeError> {
+        self.storage
+            .list_mutation_records_by_outcome(MutationOutcomeFilter::Rejected)
+            .map_err(|err| RuntimeError::WriteError(format!("{:?}", err)))
     }
 }
 
+mod mutations;
 mod subscriptions;
 mod sync;
 mod ticks;

--- a/crates/jazz-tools/src/runtime_core.rs
+++ b/crates/jazz-tools/src/runtime_core.rs
@@ -41,7 +41,8 @@ use crate::schema_manager::SchemaManager;
 use crate::storage::Storage;
 use crate::sync_manager::{
     ClientId, DurabilityTier, InboxEntry, MutationEvent, MutationId, MutationOutcome,
-    MutationOutcomeFilter, MutationRecord, OutboxEntry, ServerId,
+    MutationOutcomeFilter, MutationOutcomeState, MutationRecord, ObjectOutcomeState, OutboxEntry,
+    ServerId,
 };
 
 // ============================================================================
@@ -421,6 +422,73 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
         self.storage
             .list_mutation_records_by_outcome(MutationOutcomeFilter::Rejected)
             .map_err(|err| RuntimeError::WriteError(format!("{:?}", err)))
+    }
+
+    /// List mutation journal records associated with one object.
+    pub fn list_mutations_for_object(
+        &self,
+        object_id: ObjectId,
+    ) -> Result<Vec<MutationRecord>, RuntimeError> {
+        self.storage
+            .list_mutation_records_for_object(object_id)
+            .map_err(|err| RuntimeError::WriteError(format!("{:?}", err)))
+    }
+
+    /// Derive the current object-level outcome overlay from the mutation journal.
+    pub fn get_object_outcome(
+        &self,
+        object_id: ObjectId,
+    ) -> Result<Option<ObjectOutcomeState>, RuntimeError> {
+        let records = self
+            .storage
+            .list_mutation_records_for_object(object_id)
+            .map_err(|err| RuntimeError::WriteError(format!("{:?}", err)))?;
+
+        let rejected = records
+            .iter()
+            .filter_map(|record| match &record.outcome {
+                MutationOutcomeState::Rejected(rejection) => Some((
+                    rejection.rejected_at_micros,
+                    ObjectOutcomeState::Errored {
+                        mutation_id: record.id,
+                        code: rejection.code,
+                        reason: rejection.reason.clone(),
+                    },
+                )),
+                _ => None,
+            })
+            .max_by_key(|(timestamp, _)| *timestamp)
+            .map(|(_, outcome)| outcome);
+        if rejected.is_some() {
+            return Ok(rejected);
+        }
+
+        let pending = records
+            .iter()
+            .filter(|record| matches!(record.outcome, MutationOutcomeState::Pending))
+            .max_by_key(|record| record.recorded_at_micros)
+            .map(|record| ObjectOutcomeState::Pending {
+                mutation_id: record.id,
+            });
+        if pending.is_some() {
+            return Ok(pending);
+        }
+
+        Ok(records
+            .iter()
+            .filter(|record| matches!(record.outcome, MutationOutcomeState::Accepted))
+            .max_by_key(|record| record.recorded_at_micros)
+            .map(|record| ObjectOutcomeState::Accepted {
+                mutation_id: record.id,
+            }))
+    }
+
+    /// Acknowledge a surfaced mutation outcome and prune any retained dead commit chain.
+    pub fn acknowledge_mutation_outcome(
+        &mut self,
+        mutation_id: MutationId,
+    ) -> Result<(), RuntimeError> {
+        self.acknowledge_mutation_outcome_inner(mutation_id)
     }
 }
 

--- a/crates/jazz-tools/src/runtime_core.rs
+++ b/crates/jazz-tools/src/runtime_core.rs
@@ -39,7 +39,9 @@ use crate::query_manager::session::Session;
 use crate::query_manager::types::{OrderedRowDelta, Schema, TableName, Value};
 use crate::schema_manager::SchemaManager;
 use crate::storage::Storage;
-use crate::sync_manager::{ClientId, DurabilityTier, InboxEntry, OutboxEntry, ServerId};
+use crate::sync_manager::{
+    ClientId, DurabilityTier, InboxEntry, MutationOutcome, OutboxEntry, ServerId,
+};
 
 // ============================================================================
 // Scheduler and SyncSender traits
@@ -351,6 +353,14 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
     /// Get access to the underlying SchemaManager.
     pub fn schema_manager(&self) -> &SchemaManager {
         &self.schema_manager
+    }
+
+    /// Take mutation outcomes received since the last call.
+    pub fn take_mutation_outcomes(&mut self) -> Vec<MutationOutcome> {
+        self.schema_manager
+            .query_manager_mut()
+            .sync_manager_mut()
+            .take_received_mutation_outcomes()
     }
 }
 

--- a/crates/jazz-tools/src/runtime_core/mutations.rs
+++ b/crates/jazz-tools/src/runtime_core/mutations.rs
@@ -95,44 +95,46 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
             }
         }
 
-        for mutation_id in mutation_ids {
-            let Some(mut record) = self
-                .storage
-                .load_mutation_record(mutation_id)
-                .map_err(|err| RuntimeError::WriteError(format!("{:?}", err)))?
-            else {
-                continue;
-            };
-
-            match &outcome {
-                MutationOutcome::Accepted(_) => {
-                    if matches!(record.outcome, MutationOutcomeState::Accepted) {
-                        continue;
-                    }
-                    record.outcome = MutationOutcomeState::Accepted;
-                    self.storage
-                        .put_mutation_record(record)
-                        .map_err(|err| RuntimeError::WriteError(format!("{:?}", err)))?;
-                    self.mutation_events
-                        .push(MutationEvent::Accepted { mutation_id });
+        match outcome {
+            MutationOutcome::Accepted(_) => {
+                for mutation_id in mutation_ids {
+                    self.mark_mutation_accepted(mutation_id)?;
                 }
-                MutationOutcome::Rejected(rejection) => {
-                    if matches_rejection(&record.outcome, rejection) {
-                        continue;
-                    }
-                    record.outcome = MutationOutcomeState::Rejected(rejection.clone());
-                    self.storage
-                        .put_mutation_record(record)
-                        .map_err(|err| RuntimeError::WriteError(format!("{:?}", err)))?;
-                    self.mutation_events.push(MutationEvent::Rejected {
-                        mutation_id,
-                        rejection: rejection.clone(),
-                    });
+            }
+            MutationOutcome::Rejected(rejection) => {
+                for mutation_id in mutation_ids {
+                    self.apply_rejection_to_mutation_chain(mutation_id, rejection.clone())?;
                 }
             }
         }
 
         Ok(())
+    }
+
+    pub(crate) fn acknowledge_mutation_outcome_inner(
+        &mut self,
+        mutation_id: MutationId,
+    ) -> Result<(), RuntimeError> {
+        if !self.mutation_journal_enabled {
+            return Ok(());
+        }
+
+        let Some(record) = self
+            .storage
+            .load_mutation_record(mutation_id)
+            .map_err(|err| RuntimeError::WriteError(format!("{:?}", err)))?
+        else {
+            return Ok(());
+        };
+
+        match &record.outcome {
+            MutationOutcomeState::Pending => Ok(()),
+            MutationOutcomeState::Accepted => self.delete_mutation_record(record),
+            MutationOutcomeState::Rejected(_) => self.acknowledge_rejection_group(record.id),
+            MutationOutcomeState::SupersededByRejection { root_mutation_id } => {
+                self.acknowledge_rejection_group(*root_mutation_id)
+            }
+        }
     }
 
     fn load_mutation_record_for_commit(
@@ -158,6 +160,188 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
         }
 
         Ok(record)
+    }
+
+    fn load_mutation_records_for_object(
+        &mut self,
+        object_id: ObjectId,
+    ) -> Result<Vec<MutationRecord>, RuntimeError> {
+        let records = self
+            .storage
+            .list_mutation_records_for_object(object_id)
+            .map_err(|err| RuntimeError::WriteError(format!("{:?}", err)))?;
+
+        for record in &records {
+            for &commit_id in &record.commit_ids {
+                self.commit_to_mutation.insert(commit_id, record.id);
+            }
+        }
+
+        Ok(records)
+    }
+
+    fn mark_mutation_accepted(&mut self, mutation_id: MutationId) -> Result<(), RuntimeError> {
+        let Some(mut record) = self
+            .storage
+            .load_mutation_record(mutation_id)
+            .map_err(|err| RuntimeError::WriteError(format!("{:?}", err)))?
+        else {
+            return Ok(());
+        };
+
+        if matches!(record.outcome, MutationOutcomeState::Accepted) {
+            return Ok(());
+        }
+
+        record.outcome = MutationOutcomeState::Accepted;
+        self.storage
+            .put_mutation_record(record)
+            .map_err(|err| RuntimeError::WriteError(format!("{:?}", err)))?;
+        self.mutation_events
+            .push(MutationEvent::Accepted { mutation_id });
+        Ok(())
+    }
+
+    fn apply_rejection_to_mutation_chain(
+        &mut self,
+        root_mutation_id: MutationId,
+        rejection: MutationRejection,
+    ) -> Result<(), RuntimeError> {
+        let Some(root_record) = self
+            .storage
+            .load_mutation_record(root_mutation_id)
+            .map_err(|err| RuntimeError::WriteError(format!("{:?}", err)))?
+        else {
+            return Ok(());
+        };
+
+        let deactivated_commit_ids = {
+            let root_commit_ids: HashSet<_> = root_record.commit_ids.iter().copied().collect();
+            self.schema_manager
+                .query_manager_mut()
+                .sync_manager_mut()
+                .object_manager
+                .deactivate_commit_chain(
+                    &mut self.storage,
+                    root_record.object_id,
+                    root_record.branch_name,
+                    root_commit_ids,
+                )
+                .map_err(|err| RuntimeError::WriteError(format!("{:?}", err)))?
+        };
+
+        let related_records = self.load_mutation_records_for_object(root_record.object_id)?;
+        let mut deactivated_commit_ids: HashSet<_> = deactivated_commit_ids.into_iter().collect();
+        if deactivated_commit_ids.is_empty() {
+            deactivated_commit_ids.extend(root_record.commit_ids.iter().copied());
+        }
+
+        for mut record in related_records.into_iter().filter(|record| {
+            record.branch_name == root_record.branch_name
+                && record
+                    .commit_ids
+                    .iter()
+                    .any(|commit_id| deactivated_commit_ids.contains(commit_id))
+        }) {
+            if record.id == root_mutation_id {
+                if matches_rejection(&record.outcome, &rejection) {
+                    continue;
+                }
+                record.outcome = MutationOutcomeState::Rejected(rejection.clone());
+                self.storage
+                    .put_mutation_record(record)
+                    .map_err(|err| RuntimeError::WriteError(format!("{:?}", err)))?;
+                self.mutation_events.push(MutationEvent::Rejected {
+                    mutation_id: root_mutation_id,
+                    rejection: rejection.clone(),
+                });
+            } else {
+                if matches!(
+                    record.outcome,
+                    MutationOutcomeState::SupersededByRejection {
+                        root_mutation_id: existing_root
+                    } if existing_root == root_mutation_id
+                ) {
+                    continue;
+                }
+                let mutation_id = record.id;
+                record.outcome = MutationOutcomeState::SupersededByRejection { root_mutation_id };
+                self.storage
+                    .put_mutation_record(record)
+                    .map_err(|err| RuntimeError::WriteError(format!("{:?}", err)))?;
+                self.mutation_events
+                    .push(MutationEvent::SupersededByRejection {
+                        mutation_id,
+                        root_mutation_id,
+                    });
+            }
+        }
+
+        Ok(())
+    }
+
+    fn acknowledge_rejection_group(
+        &mut self,
+        root_mutation_id: MutationId,
+    ) -> Result<(), RuntimeError> {
+        let Some(root_record) = self
+            .storage
+            .load_mutation_record(root_mutation_id)
+            .map_err(|err| RuntimeError::WriteError(format!("{:?}", err)))?
+        else {
+            return Ok(());
+        };
+
+        let records = self.load_mutation_records_for_object(root_record.object_id)?;
+        let records_to_ack: Vec<_> = records
+            .into_iter()
+            .filter(|record| {
+                record.branch_name == root_record.branch_name
+                    && (record.id == root_mutation_id
+                        || matches!(
+                            record.outcome,
+                            MutationOutcomeState::SupersededByRejection {
+                                root_mutation_id: existing_root
+                            } if existing_root == root_mutation_id
+                        ))
+            })
+            .collect();
+
+        let commit_ids_to_prune: HashSet<_> = records_to_ack
+            .iter()
+            .flat_map(|record| record.commit_ids.iter().copied())
+            .collect();
+
+        self.schema_manager
+            .query_manager_mut()
+            .sync_manager_mut()
+            .object_manager
+            .prune_inactive_commits(
+                &mut self.storage,
+                root_record.object_id,
+                root_record.branch_name,
+                &commit_ids_to_prune,
+            )
+            .map_err(|err| RuntimeError::WriteError(format!("{:?}", err)))?;
+
+        for record in records_to_ack {
+            self.delete_mutation_record(record)?;
+        }
+
+        Ok(())
+    }
+
+    fn delete_mutation_record(&mut self, record: MutationRecord) -> Result<(), RuntimeError> {
+        self.storage
+            .delete_mutation_record(record.id)
+            .map_err(|err| RuntimeError::WriteError(format!("{:?}", err)))?;
+        for commit_id in record.commit_ids {
+            self.commit_to_mutation.remove(&commit_id);
+        }
+        self.mutation_events.push(MutationEvent::Acknowledged {
+            mutation_id: record.id,
+        });
+        Ok(())
     }
 }
 

--- a/crates/jazz-tools/src/runtime_core/mutations.rs
+++ b/crates/jazz-tools/src/runtime_core/mutations.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use super::*;
 use crate::object::BranchName;
@@ -179,6 +179,76 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
         }
 
         Ok(record)
+    }
+
+    pub(crate) fn list_object_outcomes_inner(
+        &self,
+    ) -> Result<Vec<ObjectOutcomeEvent>, RuntimeError> {
+        let mut by_object: HashMap<ObjectId, (u8, u64, ObjectOutcomeState)> = HashMap::new();
+
+        for record in self
+            .storage
+            .list_mutation_records_by_outcome(MutationOutcomeFilter::Accepted)
+            .map_err(|err| RuntimeError::WriteError(format!("{:?}", err)))?
+        {
+            let candidate = (
+                0,
+                record.recorded_at_micros,
+                ObjectOutcomeState::Accepted {
+                    mutation_id: record.id,
+                },
+            );
+            upsert_object_outcome_candidate(&mut by_object, record.object_id, candidate);
+        }
+
+        for record in self
+            .storage
+            .list_mutation_records_by_outcome(MutationOutcomeFilter::Pending)
+            .map_err(|err| RuntimeError::WriteError(format!("{:?}", err)))?
+        {
+            let candidate = (
+                1,
+                record.recorded_at_micros,
+                ObjectOutcomeState::Pending {
+                    mutation_id: record.id,
+                },
+            );
+            upsert_object_outcome_candidate(&mut by_object, record.object_id, candidate);
+        }
+
+        for record in self
+            .storage
+            .list_mutation_records_by_outcome(MutationOutcomeFilter::Rejected)
+            .map_err(|err| RuntimeError::WriteError(format!("{:?}", err)))?
+        {
+            let Some(rejection) = (match &record.outcome {
+                MutationOutcomeState::Rejected(rejection) => Some(rejection),
+                _ => None,
+            }) else {
+                continue;
+            };
+
+            let candidate = (
+                2,
+                rejection.rejected_at_micros,
+                ObjectOutcomeState::Errored {
+                    mutation_id: record.id,
+                    code: rejection.code,
+                    reason: rejection.reason.clone(),
+                },
+            );
+            upsert_object_outcome_candidate(&mut by_object, record.object_id, candidate);
+        }
+
+        let mut outcomes = by_object
+            .into_iter()
+            .map(|(object_id, (_, _, outcome))| ObjectOutcomeEvent {
+                object_id,
+                outcome: Some(outcome),
+            })
+            .collect::<Vec<_>>();
+        outcomes.sort_by_key(|event| *event.object_id.uuid());
+        Ok(outcomes)
     }
 
     fn load_mutation_records_for_object(
@@ -479,4 +549,19 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
 
 fn matches_rejection(outcome: &MutationOutcomeState, rejection: &MutationRejection) -> bool {
     matches!(outcome, MutationOutcomeState::Rejected(existing) if existing == rejection)
+}
+
+fn upsert_object_outcome_candidate(
+    by_object: &mut HashMap<ObjectId, (u8, u64, ObjectOutcomeState)>,
+    object_id: ObjectId,
+    candidate: (u8, u64, ObjectOutcomeState),
+) {
+    match by_object.get(&object_id) {
+        Some((existing_priority, existing_timestamp, _))
+            if *existing_priority > candidate.0
+                || (*existing_priority == candidate.0 && *existing_timestamp >= candidate.1) => {}
+        _ => {
+            by_object.insert(object_id, candidate);
+        }
+    }
 }

--- a/crates/jazz-tools/src/runtime_core/mutations.rs
+++ b/crates/jazz-tools/src/runtime_core/mutations.rs
@@ -6,6 +6,8 @@ use crate::sync_manager::{
     MutationOperation, MutationOutcomeState, MutationRejection, current_timestamp_micros,
 };
 
+pub(crate) const MAX_RETAINED_UNACKNOWLEDGED_REJECTIONS: usize = 10_000;
+
 impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
     pub(crate) fn record_local_mutation(
         &mut self,
@@ -20,6 +22,7 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
             return Ok(None);
         }
 
+        let previous_object_outcome = self.get_object_outcome(object_id)?;
         let mutation_id = MutationId::new();
         let record = MutationRecord {
             id: mutation_id,
@@ -43,6 +46,7 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
         }
         self.mutation_events
             .push(MutationEvent::Recorded { mutation_id });
+        self.enqueue_object_outcome_event_if_changed(object_id, previous_object_outcome)?;
 
         Ok(Some(mutation_id))
     }
@@ -78,6 +82,19 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
         Ok(())
     }
 
+    pub(crate) fn register_persisted_mutation_waiter(
+        &mut self,
+        mutation_id: MutationId,
+        tier: DurabilityTier,
+    ) -> PersistedMutationReceiver {
+        let (sender, receiver) = oneshot::channel();
+        self.ack_watchers
+            .entry(mutation_id)
+            .or_default()
+            .push(PersistedMutationWatcher { tier, sender });
+        receiver
+    }
+
     pub(crate) fn handle_received_mutation_outcome(
         &mut self,
         outcome: MutationOutcome,
@@ -108,6 +125,8 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
             }
         }
 
+        self.enforce_rejected_mutation_retention_cap(MAX_RETAINED_UNACKNOWLEDGED_REJECTIONS)?;
+
         Ok(())
     }
 
@@ -129,15 +148,15 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
 
         match &record.outcome {
             MutationOutcomeState::Pending => Ok(()),
-            MutationOutcomeState::Accepted => self.delete_mutation_record(record),
-            MutationOutcomeState::Rejected(_) => self.acknowledge_rejection_group(record.id),
+            MutationOutcomeState::Accepted => self.delete_mutation_record(record, true),
+            MutationOutcomeState::Rejected(_) => self.prune_rejection_group(record.id, true),
             MutationOutcomeState::SupersededByRejection { root_mutation_id } => {
-                self.acknowledge_rejection_group(*root_mutation_id)
+                self.prune_rejection_group(*root_mutation_id, true)
             }
         }
     }
 
-    fn load_mutation_record_for_commit(
+    pub(crate) fn load_mutation_record_for_commit(
         &mut self,
         commit_id: CommitId,
     ) -> Result<Option<MutationRecord>, RuntimeError> {
@@ -193,12 +212,17 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
             return Ok(());
         }
 
+        let previous_object_outcome = self.get_object_outcome(record.object_id)?;
+        let object_id = record.object_id;
         record.outcome = MutationOutcomeState::Accepted;
+        let highest_acked_tier = record.highest_acked_tier;
         self.storage
             .put_mutation_record(record)
             .map_err(|err| RuntimeError::WriteError(format!("{:?}", err)))?;
         self.mutation_events
             .push(MutationEvent::Accepted { mutation_id });
+        self.resolve_persisted_waiters(mutation_id, highest_acked_tier);
+        self.enqueue_object_outcome_event_if_changed(object_id, previous_object_outcome)?;
         Ok(())
     }
 
@@ -214,6 +238,7 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
         else {
             return Ok(());
         };
+        let previous_object_outcome = self.get_object_outcome(root_record.object_id)?;
 
         let deactivated_commit_ids = {
             let root_commit_ids: HashSet<_> = root_record.commit_ids.iter().copied().collect();
@@ -255,6 +280,14 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
                     mutation_id: root_mutation_id,
                     rejection: rejection.clone(),
                 });
+                self.reject_persisted_waiters(
+                    root_mutation_id,
+                    PersistedMutationError {
+                        mutation_id: root_mutation_id,
+                        root_mutation_id,
+                        rejection: rejection.clone(),
+                    },
+                );
             } else {
                 if matches!(
                     record.outcome,
@@ -274,15 +307,29 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
                         mutation_id,
                         root_mutation_id,
                     });
+                self.reject_persisted_waiters(
+                    mutation_id,
+                    PersistedMutationError {
+                        mutation_id,
+                        root_mutation_id,
+                        rejection: rejection.clone(),
+                    },
+                );
             }
         }
+
+        self.enqueue_object_outcome_event_if_changed(
+            root_record.object_id,
+            previous_object_outcome,
+        )?;
 
         Ok(())
     }
 
-    fn acknowledge_rejection_group(
+    fn prune_rejection_group(
         &mut self,
         root_mutation_id: MutationId,
+        emit_ack_events: bool,
     ) -> Result<(), RuntimeError> {
         let Some(root_record) = self
             .storage
@@ -325,22 +372,107 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
             .map_err(|err| RuntimeError::WriteError(format!("{:?}", err)))?;
 
         for record in records_to_ack {
-            self.delete_mutation_record(record)?;
+            self.delete_mutation_record(record, emit_ack_events)?;
         }
 
         Ok(())
     }
 
-    fn delete_mutation_record(&mut self, record: MutationRecord) -> Result<(), RuntimeError> {
+    fn delete_mutation_record(
+        &mut self,
+        record: MutationRecord,
+        emit_ack_event: bool,
+    ) -> Result<(), RuntimeError> {
+        let previous_object_outcome = self.get_object_outcome(record.object_id)?;
+        let object_id = record.object_id;
         self.storage
             .delete_mutation_record(record.id)
             .map_err(|err| RuntimeError::WriteError(format!("{:?}", err)))?;
+        self.ack_watchers.remove(&record.id);
         for commit_id in record.commit_ids {
             self.commit_to_mutation.remove(&commit_id);
         }
-        self.mutation_events.push(MutationEvent::Acknowledged {
-            mutation_id: record.id,
+        if emit_ack_event {
+            self.mutation_events.push(MutationEvent::Acknowledged {
+                mutation_id: record.id,
+            });
+        }
+        self.enqueue_object_outcome_event_if_changed(object_id, previous_object_outcome)?;
+        Ok(())
+    }
+
+    pub(crate) fn resolve_persisted_waiters(
+        &mut self,
+        mutation_id: MutationId,
+        highest_acked_tier: Option<DurabilityTier>,
+    ) {
+        let Some(highest_acked_tier) = highest_acked_tier else {
+            return;
+        };
+        let Some(watchers) = self.ack_watchers.remove(&mutation_id) else {
+            return;
+        };
+
+        let mut remaining = Vec::new();
+        for watcher in watchers {
+            if highest_acked_tier >= watcher.tier {
+                let _ = watcher.sender.send(Ok(()));
+            } else {
+                remaining.push(watcher);
+            }
+        }
+
+        if !remaining.is_empty() {
+            self.ack_watchers.insert(mutation_id, remaining);
+        }
+    }
+
+    fn reject_persisted_waiters(&mut self, mutation_id: MutationId, error: PersistedMutationError) {
+        if let Some(watchers) = self.ack_watchers.remove(&mutation_id) {
+            for watcher in watchers {
+                let _ = watcher.sender.send(Err(error.clone()));
+            }
+        }
+    }
+
+    pub(crate) fn enforce_rejected_mutation_retention_cap(
+        &mut self,
+        limit: usize,
+    ) -> Result<(), RuntimeError> {
+        let mut rejected_roots = self
+            .storage
+            .list_mutation_records_by_outcome(MutationOutcomeFilter::Rejected)
+            .map_err(|err| RuntimeError::WriteError(format!("{:?}", err)))?;
+
+        if rejected_roots.len() <= limit {
+            return Ok(());
+        }
+
+        rejected_roots.sort_by_key(|record| match &record.outcome {
+            MutationOutcomeState::Rejected(rejection) => rejection.rejected_at_micros,
+            _ => u64::MAX,
         });
+
+        let overflow = rejected_roots.len() - limit;
+        for record in rejected_roots.into_iter().take(overflow) {
+            self.prune_rejection_group(record.id, false)?;
+        }
+
+        Ok(())
+    }
+
+    fn enqueue_object_outcome_event_if_changed(
+        &mut self,
+        object_id: ObjectId,
+        previous: Option<ObjectOutcomeState>,
+    ) -> Result<(), RuntimeError> {
+        let current = self.get_object_outcome(object_id)?;
+        if current != previous {
+            self.object_outcome_events.push(ObjectOutcomeEvent {
+                object_id,
+                outcome: current,
+            });
+        }
         Ok(())
     }
 }

--- a/crates/jazz-tools/src/runtime_core/mutations.rs
+++ b/crates/jazz-tools/src/runtime_core/mutations.rs
@@ -1,0 +1,166 @@
+use std::collections::HashSet;
+
+use super::*;
+use crate::object::BranchName;
+use crate::sync_manager::{
+    MutationOperation, MutationOutcomeState, MutationRejection, current_timestamp_micros,
+};
+
+impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
+    pub(crate) fn record_local_mutation(
+        &mut self,
+        object_id: ObjectId,
+        branch_name: BranchName,
+        table: Option<String>,
+        operation: MutationOperation,
+        commit_ids: Vec<CommitId>,
+        previous_commit_ids: Vec<CommitId>,
+    ) -> Result<Option<MutationId>, RuntimeError> {
+        if !self.mutation_journal_enabled || commit_ids.is_empty() {
+            return Ok(None);
+        }
+
+        let mutation_id = MutationId::new();
+        let record = MutationRecord {
+            id: mutation_id,
+            object_id,
+            branch_name,
+            table,
+            operation,
+            commit_ids: commit_ids.clone(),
+            previous_commit_ids,
+            recorded_at_micros: current_timestamp_micros(),
+            highest_acked_tier: None,
+            outcome: MutationOutcomeState::Pending,
+        };
+
+        self.storage
+            .put_mutation_record(record)
+            .map_err(|err| RuntimeError::WriteError(format!("{:?}", err)))?;
+
+        for commit_id in commit_ids {
+            self.commit_to_mutation.insert(commit_id, mutation_id);
+        }
+        self.mutation_events
+            .push(MutationEvent::Recorded { mutation_id });
+
+        Ok(Some(mutation_id))
+    }
+
+    pub(crate) fn advance_mutation_ack(
+        &mut self,
+        commit_id: CommitId,
+        tier: DurabilityTier,
+    ) -> Result<(), RuntimeError> {
+        if !self.mutation_journal_enabled {
+            return Ok(());
+        }
+
+        let Some(mut record) = self.load_mutation_record_for_commit(commit_id)? else {
+            return Ok(());
+        };
+
+        if record
+            .highest_acked_tier
+            .is_some_and(|existing| existing >= tier)
+        {
+            return Ok(());
+        }
+
+        let mutation_id = record.id;
+        record.highest_acked_tier = Some(tier);
+        self.storage
+            .put_mutation_record(record)
+            .map_err(|err| RuntimeError::WriteError(format!("{:?}", err)))?;
+        self.mutation_events
+            .push(MutationEvent::AckAdvanced { mutation_id, tier });
+
+        Ok(())
+    }
+
+    pub(crate) fn handle_received_mutation_outcome(
+        &mut self,
+        outcome: MutationOutcome,
+    ) -> Result<(), RuntimeError> {
+        self.mutation_outcomes.push(outcome.clone());
+
+        if !self.mutation_journal_enabled {
+            return Ok(());
+        }
+
+        let mut mutation_ids = HashSet::new();
+        for &commit_id in outcome.commit_ids() {
+            if let Some(record) = self.load_mutation_record_for_commit(commit_id)? {
+                mutation_ids.insert(record.id);
+            }
+        }
+
+        for mutation_id in mutation_ids {
+            let Some(mut record) = self
+                .storage
+                .load_mutation_record(mutation_id)
+                .map_err(|err| RuntimeError::WriteError(format!("{:?}", err)))?
+            else {
+                continue;
+            };
+
+            match &outcome {
+                MutationOutcome::Accepted(_) => {
+                    if matches!(record.outcome, MutationOutcomeState::Accepted) {
+                        continue;
+                    }
+                    record.outcome = MutationOutcomeState::Accepted;
+                    self.storage
+                        .put_mutation_record(record)
+                        .map_err(|err| RuntimeError::WriteError(format!("{:?}", err)))?;
+                    self.mutation_events
+                        .push(MutationEvent::Accepted { mutation_id });
+                }
+                MutationOutcome::Rejected(rejection) => {
+                    if matches_rejection(&record.outcome, rejection) {
+                        continue;
+                    }
+                    record.outcome = MutationOutcomeState::Rejected(rejection.clone());
+                    self.storage
+                        .put_mutation_record(record)
+                        .map_err(|err| RuntimeError::WriteError(format!("{:?}", err)))?;
+                    self.mutation_events.push(MutationEvent::Rejected {
+                        mutation_id,
+                        rejection: rejection.clone(),
+                    });
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn load_mutation_record_for_commit(
+        &mut self,
+        commit_id: CommitId,
+    ) -> Result<Option<MutationRecord>, RuntimeError> {
+        if let Some(mutation_id) = self.commit_to_mutation.get(&commit_id).copied() {
+            return self
+                .storage
+                .load_mutation_record(mutation_id)
+                .map_err(|err| RuntimeError::WriteError(format!("{:?}", err)));
+        }
+
+        let record = self
+            .storage
+            .load_mutation_record_by_commit(commit_id)
+            .map_err(|err| RuntimeError::WriteError(format!("{:?}", err)))?;
+
+        if let Some(record) = &record {
+            for &mapped_commit_id in &record.commit_ids {
+                self.commit_to_mutation.insert(mapped_commit_id, record.id);
+            }
+        }
+
+        Ok(record)
+    }
+}
+
+fn matches_rejection(outcome: &MutationOutcomeState, rejection: &MutationRejection) -> bool {
+    matches!(outcome, MutationOutcomeState::Rejected(existing) if existing == rejection)
+}

--- a/crates/jazz-tools/src/runtime_core/tests.rs
+++ b/crates/jazz-tools/src/runtime_core/tests.rs
@@ -55,6 +55,15 @@ fn reject_mutation(
     record: &MutationRecord,
     reason: &str,
 ) -> MutationRejection {
+    reject_mutation_at(core, record, reason, 456)
+}
+
+fn reject_mutation_at(
+    core: &mut TestCore,
+    record: &MutationRecord,
+    reason: &str,
+    rejected_at_micros: u64,
+) -> MutationRejection {
     let rejection = MutationRejection {
         object_id: record.object_id,
         branch_name: record.branch_name,
@@ -63,7 +72,7 @@ fn reject_mutation(
         previous_commit_ids: record.previous_commit_ids.clone(),
         code: MutationRejectCode::PermissionDenied,
         reason: reason.to_string(),
-        rejected_at_micros: 456,
+        rejected_at_micros,
     };
 
     core.park_sync_message(InboxEntry {
@@ -73,6 +82,36 @@ fn reject_mutation(
     core.batched_tick();
 
     rejection
+}
+
+fn expect_persisted_pending(receiver: &mut PersistedMutationReceiver, message: &str) {
+    match receiver.try_recv() {
+        Ok(None) => {}
+        Ok(Some(Ok(()))) => panic!("{message}: receiver resolved successfully"),
+        Ok(Some(Err(err))) => panic!("{message}: {err}"),
+        Err(_) => panic!("{message}: receiver cancelled"),
+    }
+}
+
+fn expect_persisted_ok(receiver: &mut PersistedMutationReceiver, message: &str) {
+    match receiver.try_recv() {
+        Ok(Some(Ok(()))) => {}
+        Ok(Some(Err(err))) => panic!("{message}: {err}"),
+        Ok(None) => panic!("{message}: receiver still pending"),
+        Err(_) => panic!("{message}: receiver cancelled"),
+    }
+}
+
+fn expect_persisted_err(
+    receiver: &mut PersistedMutationReceiver,
+    message: &str,
+) -> PersistedMutationError {
+    match receiver.try_recv() {
+        Ok(Some(Err(err))) => err,
+        Ok(Some(Ok(()))) => panic!("{message}: receiver resolved successfully"),
+        Ok(None) => panic!("{message}: receiver still pending"),
+        Err(_) => panic!("{message}: receiver cancelled"),
+    }
 }
 
 #[test]
@@ -278,6 +317,13 @@ fn runtime_core_records_local_mutations_and_events() {
         core.get_object_outcome(object_id).unwrap(),
         Some(crate::sync_manager::ObjectOutcomeState::Pending { mutation_id })
     );
+    assert_eq!(
+        core.take_object_outcome_events(),
+        vec![crate::sync_manager::ObjectOutcomeEvent {
+            object_id,
+            outcome: Some(crate::sync_manager::ObjectOutcomeState::Pending { mutation_id }),
+        }]
+    );
 }
 
 #[test]
@@ -373,6 +419,13 @@ fn runtime_core_rejected_insert_rolls_back_dependent_chain_and_acknowledges() {
             reason: "policy denied write".into(),
         })
     );
+    assert!(core.take_object_outcome_events().iter().any(|event| matches!(
+        event,
+        crate::sync_manager::ObjectOutcomeEvent {
+            object_id: event_object_id,
+            outcome: Some(crate::sync_manager::ObjectOutcomeState::Errored { mutation_id, .. }),
+        } if *event_object_id == object_id && *mutation_id == insert_mutation_id
+    )));
 
     let update_record = core
         .get_mutation_record(update_mutation_id)
@@ -417,6 +470,17 @@ fn runtime_core_rejected_insert_rolls_back_dependent_chain_and_acknowledges() {
             .is_none()
     );
     assert!(core.get_object_outcome(object_id).unwrap().is_none());
+    assert!(
+        core.take_object_outcome_events()
+            .iter()
+            .any(|event| matches!(
+                event,
+                crate::sync_manager::ObjectOutcomeEvent {
+                    object_id: event_object_id,
+                    outcome: None,
+                } if *event_object_id == object_id
+            ))
+    );
     assert!(execute_query(&mut core, Query::new("users")).is_empty());
 
     let object = core
@@ -510,6 +574,74 @@ fn runtime_core_rejected_update_restores_previous_row_state() {
     let results = execute_query(&mut core, Query::new("users"));
     assert_eq!(results.len(), 1);
     assert_eq!(results[0].1[1], Value::Text("Alice".into()));
+}
+
+#[test]
+fn runtime_core_retention_cap_prunes_oldest_rejections_without_ack_event() {
+    let mut core = create_test_runtime();
+
+    let (first_id, _) = core
+        .insert(
+            "users",
+            vec![Value::Uuid(ObjectId::new()), Value::Text("First".into())],
+            None,
+        )
+        .unwrap();
+    let first_mutation_id = match core.take_mutation_events().as_slice() {
+        [MutationEvent::Recorded { mutation_id }] => *mutation_id,
+        other => panic!("unexpected mutation events after first insert: {other:?}"),
+    };
+    let first_record = core
+        .get_mutation_record(first_mutation_id)
+        .unwrap()
+        .expect("first mutation should exist");
+    reject_mutation_at(&mut core, &first_record, "first rejection", 1);
+    core.take_mutation_events();
+
+    let (second_id, _) = core
+        .insert(
+            "users",
+            vec![Value::Uuid(ObjectId::new()), Value::Text("Second".into())],
+            None,
+        )
+        .unwrap();
+    let second_mutation_id = match core.take_mutation_events().as_slice() {
+        [MutationEvent::Recorded { mutation_id }] => *mutation_id,
+        other => panic!("unexpected mutation events after second insert: {other:?}"),
+    };
+    let second_record = core
+        .get_mutation_record(second_mutation_id)
+        .unwrap()
+        .expect("second mutation should exist");
+    reject_mutation_at(&mut core, &second_record, "second rejection", 2);
+    core.take_mutation_events();
+
+    core.enforce_rejected_mutation_retention_cap(1).unwrap();
+
+    assert!(
+        core.get_mutation_record(first_mutation_id)
+            .unwrap()
+            .is_none()
+    );
+    assert!(
+        core.get_mutation_record(second_mutation_id)
+            .unwrap()
+            .is_some()
+    );
+    assert!(core.get_object_outcome(first_id).unwrap().is_none());
+    assert!(matches!(
+        core.get_object_outcome(second_id).unwrap(),
+        Some(crate::sync_manager::ObjectOutcomeState::Errored {
+            mutation_id,
+            ..
+        }) if mutation_id == second_mutation_id
+    ));
+    assert!(
+        core.take_mutation_events()
+            .iter()
+            .all(|event| !matches!(event, MutationEvent::Acknowledged { .. })),
+        "forced retention compaction should not emit acknowledgement events"
+    );
 }
 
 // =========================================================================
@@ -1033,19 +1165,12 @@ fn rc_insert_persisted_resolves_on_worker_ack() {
     assert!(!id.0.is_nil());
     assert_eq!(row_values, values);
 
-    assert!(
-        receiver.try_recv().is_err() || receiver.try_recv() == Ok(None),
-        "Receiver should not be resolved before ack"
-    );
+    expect_persisted_pending(&mut receiver, "receiver should not resolve before ack");
 
     pump_a_to_b(&mut s);
     pump_b_to_a(&mut s);
 
-    match receiver.try_recv() {
-        Ok(Some(())) => {}
-        Ok(None) => panic!("Receiver should be resolved after Worker ack"),
-        Err(_) => panic!("Receiver was cancelled"),
-    }
+    expect_persisted_ok(&mut receiver, "receiver should resolve after Worker ack");
 }
 
 #[test]
@@ -1088,20 +1213,18 @@ fn rc_insert_persisted_holds_until_correct_tier() {
     pump_a_to_b(&mut s);
     pump_b_to_a(&mut s);
 
-    assert_eq!(
-        receiver.try_recv(),
-        Ok(None),
-        "Worker ack should not satisfy EdgeServer request"
+    expect_persisted_pending(
+        &mut receiver,
+        "Worker ack should not satisfy EdgeServer request",
     );
 
     pump_b_to_c(&mut s);
     pump_c_to_b_to_a(&mut s);
 
-    match receiver.try_recv() {
-        Ok(Some(())) => {}
-        Ok(None) => panic!("Receiver should be resolved after EdgeServer ack"),
-        Err(_) => panic!("Receiver was cancelled"),
-    }
+    expect_persisted_ok(
+        &mut receiver,
+        "receiver should resolve after EdgeServer ack",
+    );
 }
 
 #[test]
@@ -1114,11 +1237,10 @@ fn rc_insert_persisted_higher_tier_satisfies_lower() {
 
     pump_3tier(&mut s);
 
-    match receiver.try_recv() {
-        Ok(Some(())) => {}
-        Ok(None) => panic!("EdgeServer ack should satisfy Worker request"),
-        Err(_) => panic!("Receiver was cancelled"),
-    }
+    expect_persisted_ok(
+        &mut receiver,
+        "EdgeServer ack should satisfy Worker request",
+    );
 }
 
 #[test]
@@ -1140,11 +1262,10 @@ fn rc_update_persisted_resolves_on_ack() {
     pump_a_to_b(&mut s);
     pump_b_to_a(&mut s);
 
-    match receiver.try_recv() {
-        Ok(Some(())) => {}
-        Ok(None) => panic!("Update receiver should be resolved after Worker ack"),
-        Err(_) => panic!("Receiver was cancelled"),
-    }
+    expect_persisted_ok(
+        &mut receiver,
+        "Update receiver should be resolved after Worker ack",
+    );
 
     let query = Query::new("users");
     let results = execute_query(&mut s.b, query);
@@ -1165,15 +1286,75 @@ fn rc_delete_persisted_resolves_on_ack() {
     pump_a_to_b(&mut s);
     pump_b_to_a(&mut s);
 
-    match receiver.try_recv() {
-        Ok(Some(())) => {}
-        Ok(None) => panic!("Delete receiver should be resolved after Worker ack"),
-        Err(_) => panic!("Receiver was cancelled"),
-    }
+    expect_persisted_ok(
+        &mut receiver,
+        "Delete receiver should be resolved after Worker ack",
+    );
 
     let query = Query::new("users");
     let results = execute_query(&mut s.b, query);
     assert_eq!(results.len(), 0);
+}
+
+#[test]
+fn rc_insert_persisted_rejects_on_mutation_outcome() {
+    let mut s = create_3tier_rc();
+    let values = vec![Value::Uuid(ObjectId::new()), Value::Text("Alice".into())];
+    let ((_id, _row_values), mut receiver) =
+        s.a.insert_persisted("users", values, None, DurabilityTier::Worker)
+            .unwrap();
+    let mutation_id = match s.a.take_mutation_events().as_slice() {
+        [MutationEvent::Recorded { mutation_id }] => *mutation_id,
+        other => panic!("unexpected mutation events: {other:?}"),
+    };
+    let record =
+        s.a.get_mutation_record(mutation_id)
+            .unwrap()
+            .expect("mutation record should exist");
+    let rejection = reject_mutation(&mut s.a, &record, "policy denied write");
+
+    let error = expect_persisted_err(&mut receiver, "insert durable receiver should reject");
+    assert_eq!(error.mutation_id, mutation_id);
+    assert_eq!(error.root_mutation_id, mutation_id);
+    assert_eq!(error.rejection, rejection);
+}
+
+#[test]
+fn rc_persisted_waiter_rejects_when_mutation_is_superseded() {
+    let mut s = create_3tier_rc();
+    let values = vec![Value::Uuid(ObjectId::new()), Value::Text("Alice".into())];
+    let (id, _row_values) = s.a.insert("users", values, None).unwrap();
+    let insert_mutation_id = match s.a.take_mutation_events().as_slice() {
+        [MutationEvent::Recorded { mutation_id }] => *mutation_id,
+        other => panic!("unexpected mutation events after insert: {other:?}"),
+    };
+
+    let mut receiver =
+        s.a.update_persisted(
+            id,
+            vec![("name".into(), Value::Text("Bob".into()))],
+            None,
+            DurabilityTier::Worker,
+        )
+        .unwrap();
+    let update_mutation_id = match s.a.take_mutation_events().as_slice() {
+        [MutationEvent::Recorded { mutation_id }] => *mutation_id,
+        other => panic!("unexpected mutation events after update: {other:?}"),
+    };
+    let insert_record =
+        s.a.get_mutation_record(insert_mutation_id)
+            .unwrap()
+            .expect("insert mutation record should exist");
+    let rejection = reject_mutation(&mut s.a, &insert_record, "policy denied write");
+
+    let error = expect_persisted_err(
+        &mut receiver,
+        "superseded durable receiver should reject with root rejection",
+    );
+    assert_eq!(error.mutation_id, update_mutation_id);
+    assert_eq!(error.root_mutation_id, insert_mutation_id);
+    assert_eq!(error.rejection, rejection);
+    assert!(execute_query(&mut s.a, Query::new("users")).is_empty());
 }
 
 #[test]
@@ -1192,16 +1373,8 @@ fn rc_multiple_persisted_inserts_independent() {
 
     pump_3tier(&mut s);
 
-    match receiver1.try_recv() {
-        Ok(Some(())) => {}
-        Ok(None) => panic!("receiver1 should be resolved"),
-        Err(_) => panic!("receiver1 cancelled"),
-    }
-    match receiver2.try_recv() {
-        Ok(Some(())) => {}
-        Ok(None) => panic!("receiver2 should be resolved"),
-        Err(_) => panic!("receiver2 cancelled"),
-    }
+    expect_persisted_ok(&mut receiver1, "receiver1 should be resolved");
+    expect_persisted_ok(&mut receiver2, "receiver2 should be resolved");
 }
 
 #[test]

--- a/crates/jazz-tools/src/runtime_core/tests.rs
+++ b/crates/jazz-tools/src/runtime_core/tests.rs
@@ -227,14 +227,99 @@ fn runtime_core_drains_received_mutation_outcomes() {
     assert!(core.take_mutation_outcomes().is_empty());
 }
 
+#[test]
+fn runtime_core_records_local_mutations_and_events() {
+    let mut core = create_test_runtime();
+    let values = vec![Value::Uuid(ObjectId::new()), Value::Text("Alice".into())];
+    let (object_id, _row_values) = core.insert("users", values, None).unwrap();
+
+    let events = core.take_mutation_events();
+    let mutation_id = match events.as_slice() {
+        [MutationEvent::Recorded { mutation_id }] => *mutation_id,
+        other => panic!("unexpected mutation events: {other:?}"),
+    };
+
+    let record = core
+        .get_mutation_record(mutation_id)
+        .unwrap()
+        .expect("mutation record should exist");
+    assert_eq!(record.object_id, object_id);
+    assert_eq!(record.table.as_deref(), Some("users"));
+    assert_eq!(record.operation, MutationOperation::Insert);
+    assert!(matches!(record.outcome, MutationOutcomeState::Pending));
+    assert_eq!(record.commit_ids.len(), 1);
+    assert!(record.previous_commit_ids.is_empty());
+}
+
+#[test]
+fn runtime_core_can_disable_mutation_journal() {
+    let mut core = create_test_runtime();
+    core.set_mutation_journal_enabled(false);
+
+    let values = vec![Value::Uuid(ObjectId::new()), Value::Text("Alice".into())];
+    let _ = core.insert("users", values, None).unwrap();
+
+    assert!(core.take_mutation_events().is_empty());
+    assert!(core.list_pending_mutations().unwrap().is_empty());
+}
+
+#[test]
+fn runtime_core_updates_mutation_records_from_rejections() {
+    use crate::object::BranchName;
+
+    let mut core = create_test_runtime();
+    let values = vec![Value::Uuid(ObjectId::new()), Value::Text("Alice".into())];
+    let (object_id, _row_values) = core.insert("users", values, None).unwrap();
+    let mutation_id = match core.take_mutation_events().as_slice() {
+        [MutationEvent::Recorded { mutation_id }] => *mutation_id,
+        other => panic!("unexpected mutation events: {other:?}"),
+    };
+
+    let record = core
+        .get_mutation_record(mutation_id)
+        .unwrap()
+        .expect("mutation record should exist");
+    let rejection = MutationRejection {
+        object_id,
+        branch_name: BranchName::new("main"),
+        operation: MutationOperation::Insert,
+        commit_ids: record.commit_ids.clone(),
+        previous_commit_ids: record.previous_commit_ids.clone(),
+        code: MutationRejectCode::PermissionDenied,
+        reason: "policy denied write".into(),
+        rejected_at_micros: 456,
+    };
+
+    core.park_sync_message(InboxEntry {
+        source: Source::Server(ServerId::new()),
+        payload: SyncPayload::MutationOutcome(MutationOutcome::Rejected(rejection.clone())),
+    });
+    core.batched_tick();
+
+    let events = core.take_mutation_events();
+    assert!(events.iter().any(|event| matches!(
+        event,
+        MutationEvent::Rejected {
+            mutation_id: event_mutation_id,
+            rejection: event_rejection,
+        } if *event_mutation_id == mutation_id && event_rejection == &rejection
+    )));
+
+    let record = core
+        .get_mutation_record(mutation_id)
+        .unwrap()
+        .expect("mutation record should exist");
+    assert_eq!(record.outcome, MutationOutcomeState::Rejected(rejection));
+}
+
 // =========================================================================
 // Durability API Tests (3-tier: A ↔ B[Worker] ↔ C[EdgeServer])
 // =========================================================================
 
 use crate::sync_manager::{
-    ClientId, ClientRole, Destination, DurabilityTier, InboxEntry, MutationOperation,
-    MutationOutcome, MutationRejectCode, MutationRejection, OutboxEntry, ServerId, Source,
-    SyncPayload,
+    ClientId, ClientRole, Destination, DurabilityTier, InboxEntry, MutationEvent,
+    MutationOperation, MutationOutcome, MutationOutcomeState, MutationRejectCode,
+    MutationRejection, OutboxEntry, ServerId, Source, SyncPayload,
 };
 
 /// Three-tier RuntimeCore setup for durability tests.
@@ -761,6 +846,35 @@ fn rc_insert_persisted_resolves_on_worker_ack() {
         Ok(None) => panic!("Receiver should be resolved after Worker ack"),
         Err(_) => panic!("Receiver was cancelled"),
     }
+}
+
+#[test]
+fn rc_worker_ack_advances_mutation_record() {
+    let mut s = create_3tier_rc();
+    let values = vec![Value::Uuid(ObjectId::new()), Value::Text("Alice".into())];
+    let ((_id, _row_values), _receiver) =
+        s.a.insert_persisted("users", values, None, DurabilityTier::Worker)
+            .unwrap();
+    let mutation_id = match s.a.take_mutation_events().as_slice() {
+        [MutationEvent::Recorded { mutation_id }] => *mutation_id,
+        other => panic!("unexpected mutation events: {other:?}"),
+    };
+
+    pump_a_to_b(&mut s);
+    pump_b_to_a(&mut s);
+
+    let record =
+        s.a.get_mutation_record(mutation_id)
+            .unwrap()
+            .expect("mutation record should exist");
+    assert_eq!(record.highest_acked_tier, Some(DurabilityTier::Worker));
+    assert!(s.a.take_mutation_events().iter().any(|event| matches!(
+        event,
+        MutationEvent::AckAdvanced {
+            mutation_id: event_mutation_id,
+            tier: DurabilityTier::Worker,
+        } if *event_mutation_id == mutation_id
+    )));
 }
 
 #[test]

--- a/crates/jazz-tools/src/runtime_core/tests.rs
+++ b/crates/jazz-tools/src/runtime_core/tests.rs
@@ -50,6 +50,31 @@ fn execute_query(core: &mut TestCore, query: Query) -> Vec<(ObjectId, Vec<Value>
     results
 }
 
+fn reject_mutation(
+    core: &mut TestCore,
+    record: &MutationRecord,
+    reason: &str,
+) -> MutationRejection {
+    let rejection = MutationRejection {
+        object_id: record.object_id,
+        branch_name: record.branch_name,
+        operation: record.operation,
+        commit_ids: record.commit_ids.clone(),
+        previous_commit_ids: record.previous_commit_ids.clone(),
+        code: MutationRejectCode::PermissionDenied,
+        reason: reason.to_string(),
+        rejected_at_micros: 456,
+    };
+
+    core.park_sync_message(InboxEntry {
+        source: Source::Server(ServerId::new()),
+        payload: SyncPayload::MutationOutcome(MutationOutcome::Rejected(rejection.clone())),
+    });
+    core.batched_tick();
+
+    rejection
+}
+
 #[test]
 fn test_runtime_core_new() {
     let core = create_test_runtime();
@@ -249,6 +274,10 @@ fn runtime_core_records_local_mutations_and_events() {
     assert!(matches!(record.outcome, MutationOutcomeState::Pending));
     assert_eq!(record.commit_ids.len(), 1);
     assert!(record.previous_commit_ids.is_empty());
+    assert_eq!(
+        core.get_object_outcome(object_id).unwrap(),
+        Some(crate::sync_manager::ObjectOutcomeState::Pending { mutation_id })
+    );
 }
 
 #[test]
@@ -265,11 +294,9 @@ fn runtime_core_can_disable_mutation_journal() {
 
 #[test]
 fn runtime_core_updates_mutation_records_from_rejections() {
-    use crate::object::BranchName;
-
     let mut core = create_test_runtime();
     let values = vec![Value::Uuid(ObjectId::new()), Value::Text("Alice".into())];
-    let (object_id, _row_values) = core.insert("users", values, None).unwrap();
+    let (_object_id, _row_values) = core.insert("users", values, None).unwrap();
     let mutation_id = match core.take_mutation_events().as_slice() {
         [MutationEvent::Recorded { mutation_id }] => *mutation_id,
         other => panic!("unexpected mutation events: {other:?}"),
@@ -279,22 +306,7 @@ fn runtime_core_updates_mutation_records_from_rejections() {
         .get_mutation_record(mutation_id)
         .unwrap()
         .expect("mutation record should exist");
-    let rejection = MutationRejection {
-        object_id,
-        branch_name: BranchName::new("main"),
-        operation: MutationOperation::Insert,
-        commit_ids: record.commit_ids.clone(),
-        previous_commit_ids: record.previous_commit_ids.clone(),
-        code: MutationRejectCode::PermissionDenied,
-        reason: "policy denied write".into(),
-        rejected_at_micros: 456,
-    };
-
-    core.park_sync_message(InboxEntry {
-        source: Source::Server(ServerId::new()),
-        payload: SyncPayload::MutationOutcome(MutationOutcome::Rejected(rejection.clone())),
-    });
-    core.batched_tick();
+    let rejection = reject_mutation(&mut core, &record, "policy denied write");
 
     let events = core.take_mutation_events();
     assert!(events.iter().any(|event| matches!(
@@ -310,6 +322,194 @@ fn runtime_core_updates_mutation_records_from_rejections() {
         .unwrap()
         .expect("mutation record should exist");
     assert_eq!(record.outcome, MutationOutcomeState::Rejected(rejection));
+}
+
+#[test]
+fn runtime_core_rejected_insert_rolls_back_dependent_chain_and_acknowledges() {
+    let mut core = create_test_runtime();
+    let row_id = ObjectId::new();
+    let values = vec![Value::Uuid(row_id), Value::Text("Alice".into())];
+    let (object_id, _) = core.insert("users", values, None).unwrap();
+    let insert_mutation_id = match core.take_mutation_events().as_slice() {
+        [MutationEvent::Recorded { mutation_id }] => *mutation_id,
+        other => panic!("unexpected mutation events after insert: {other:?}"),
+    };
+
+    core.update(
+        object_id,
+        vec![("name".to_string(), Value::Text("Bob".into()))],
+        None,
+    )
+    .unwrap();
+    let update_mutation_id = match core.take_mutation_events().as_slice() {
+        [MutationEvent::Recorded { mutation_id }] => *mutation_id,
+        other => panic!("unexpected mutation events after update: {other:?}"),
+    };
+
+    let results = execute_query(&mut core, Query::new("users"));
+    assert_eq!(results[0].1[1], Value::Text("Bob".into()));
+
+    let insert_record = core
+        .get_mutation_record(insert_mutation_id)
+        .unwrap()
+        .expect("insert mutation should exist");
+    let rejection = reject_mutation(&mut core, &insert_record, "policy denied write");
+
+    assert!(execute_query(&mut core, Query::new("users")).is_empty());
+
+    let insert_record = core
+        .get_mutation_record(insert_mutation_id)
+        .unwrap()
+        .expect("insert mutation should still exist");
+    assert_eq!(
+        insert_record.outcome,
+        MutationOutcomeState::Rejected(rejection)
+    );
+    assert_eq!(
+        core.get_object_outcome(object_id).unwrap(),
+        Some(crate::sync_manager::ObjectOutcomeState::Errored {
+            mutation_id: insert_mutation_id,
+            code: MutationRejectCode::PermissionDenied,
+            reason: "policy denied write".into(),
+        })
+    );
+
+    let update_record = core
+        .get_mutation_record(update_mutation_id)
+        .unwrap()
+        .expect("dependent update mutation should still exist");
+    assert_eq!(
+        update_record.outcome,
+        MutationOutcomeState::SupersededByRejection {
+            root_mutation_id: insert_mutation_id,
+        }
+    );
+
+    let events = core.take_mutation_events();
+    assert!(events.iter().any(|event| matches!(
+        event,
+        MutationEvent::Rejected { mutation_id, .. } if *mutation_id == insert_mutation_id
+    )));
+    assert!(events.iter().any(|event| matches!(
+        event,
+        MutationEvent::SupersededByRejection {
+            mutation_id,
+            root_mutation_id,
+        } if *mutation_id == update_mutation_id && *root_mutation_id == insert_mutation_id
+    )));
+
+    core.acknowledge_mutation_outcome(update_mutation_id)
+        .unwrap();
+
+    assert!(
+        core.list_mutations_for_object(object_id)
+            .unwrap()
+            .is_empty()
+    );
+    assert!(
+        core.get_mutation_record(insert_mutation_id)
+            .unwrap()
+            .is_none()
+    );
+    assert!(
+        core.get_mutation_record(update_mutation_id)
+            .unwrap()
+            .is_none()
+    );
+    assert!(core.get_object_outcome(object_id).unwrap().is_none());
+    assert!(execute_query(&mut core, Query::new("users")).is_empty());
+
+    let object = core
+        .schema_manager()
+        .query_manager()
+        .sync_manager()
+        .object_manager
+        .get(object_id)
+        .expect("row object metadata should remain");
+    assert!(
+        object
+            .branches
+            .get(&crate::object::BranchName::new("main"))
+            .is_none(),
+        "rejected insert branch should be pruned after acknowledgement"
+    );
+}
+
+#[test]
+fn runtime_core_rejected_update_restores_previous_row_state() {
+    let mut core = create_test_runtime();
+    let row_id = ObjectId::new();
+    let values = vec![Value::Uuid(row_id), Value::Text("Alice".into())];
+    let (object_id, _) = core.insert("users", values, None).unwrap();
+    let insert_mutation_id = match core.take_mutation_events().as_slice() {
+        [MutationEvent::Recorded { mutation_id }] => *mutation_id,
+        other => panic!("unexpected mutation events after insert: {other:?}"),
+    };
+
+    core.update(
+        object_id,
+        vec![("name".to_string(), Value::Text("Bob".into()))],
+        None,
+    )
+    .unwrap();
+    let update_mutation_id = match core.take_mutation_events().as_slice() {
+        [MutationEvent::Recorded { mutation_id }] => *mutation_id,
+        other => panic!("unexpected mutation events after update: {other:?}"),
+    };
+
+    let update_record = core
+        .get_mutation_record(update_mutation_id)
+        .unwrap()
+        .expect("update mutation should exist");
+    let rejection = reject_mutation(&mut core, &update_record, "policy denied update");
+
+    let results = execute_query(&mut core, Query::new("users"));
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].1[1], Value::Text("Alice".into()));
+
+    let update_record = core
+        .get_mutation_record(update_mutation_id)
+        .unwrap()
+        .expect("update mutation should remain until acknowledgement");
+    assert_eq!(
+        update_record.outcome,
+        MutationOutcomeState::Rejected(rejection)
+    );
+    assert_eq!(
+        core.get_object_outcome(object_id).unwrap(),
+        Some(crate::sync_manager::ObjectOutcomeState::Errored {
+            mutation_id: update_mutation_id,
+            code: MutationRejectCode::PermissionDenied,
+            reason: "policy denied update".into(),
+        })
+    );
+
+    let insert_record = core
+        .get_mutation_record(insert_mutation_id)
+        .unwrap()
+        .expect("insert mutation should be unaffected");
+    assert!(matches!(
+        insert_record.outcome,
+        MutationOutcomeState::Pending
+    ));
+
+    core.acknowledge_mutation_outcome(update_mutation_id)
+        .unwrap();
+
+    assert!(
+        core.get_mutation_record(update_mutation_id)
+            .unwrap()
+            .is_none()
+    );
+    assert_eq!(
+        core.get_object_outcome(object_id).unwrap(),
+        Some(crate::sync_manager::ObjectOutcomeState::Pending {
+            mutation_id: insert_mutation_id,
+        })
+    );
+    let results = execute_query(&mut core, Query::new("users"));
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].1[1], Value::Text("Alice".into()));
 }
 
 // =========================================================================

--- a/crates/jazz-tools/src/runtime_core/tests.rs
+++ b/crates/jazz-tools/src/runtime_core/tests.rs
@@ -200,12 +200,40 @@ fn test_park_sync_message() {
     assert_eq!(core.parked_sync_messages.len(), 1);
 }
 
+#[test]
+fn runtime_core_drains_received_mutation_outcomes() {
+    use crate::object::BranchName;
+
+    let mut core = create_test_runtime();
+    let outcome = MutationOutcome::Rejected(MutationRejection {
+        object_id: ObjectId::new(),
+        branch_name: BranchName::new("main"),
+        operation: MutationOperation::Update,
+        commit_ids: vec![CommitId([1; 32])],
+        previous_commit_ids: vec![CommitId([0; 32])],
+        code: MutationRejectCode::PermissionDenied,
+        reason: "policy denied write".into(),
+        rejected_at_micros: 123,
+    });
+
+    core.park_sync_message(InboxEntry {
+        source: Source::Server(ServerId::new()),
+        payload: SyncPayload::MutationOutcome(outcome.clone()),
+    });
+
+    core.batched_tick();
+
+    assert_eq!(core.take_mutation_outcomes(), vec![outcome]);
+    assert!(core.take_mutation_outcomes().is_empty());
+}
+
 // =========================================================================
 // Durability API Tests (3-tier: A ↔ B[Worker] ↔ C[EdgeServer])
 // =========================================================================
 
 use crate::sync_manager::{
-    ClientId, ClientRole, Destination, DurabilityTier, InboxEntry, OutboxEntry, ServerId, Source,
+    ClientId, ClientRole, Destination, DurabilityTier, InboxEntry, MutationOperation,
+    MutationOutcome, MutationRejectCode, MutationRejection, OutboxEntry, ServerId, Source,
     SyncPayload,
 };
 

--- a/crates/jazz-tools/src/runtime_core/ticks.rs
+++ b/crates/jazz-tools/src/runtime_core/ticks.rs
@@ -124,6 +124,9 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
             .sync_manager_mut()
             .take_received_acks();
         for (commit_id, acked_tier) in received_acks {
+            if let Err(error) = self.advance_mutation_ack(commit_id, acked_tier) {
+                tracing::warn!(?commit_id, ?acked_tier, error = %error, "failed to advance mutation ack");
+            }
             if let Some(watchers) = self.ack_watchers.remove(&commit_id) {
                 let mut remaining = Vec::new();
                 for (requested_tier, sender) in watchers {
@@ -142,6 +145,18 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
                 if !remaining.is_empty() {
                     self.ack_watchers.insert(commit_id, remaining);
                 }
+            }
+        }
+
+        // 3c. Process received mutation outcomes.
+        let received_mutation_outcomes = self
+            .schema_manager
+            .query_manager_mut()
+            .sync_manager_mut()
+            .take_received_mutation_outcomes();
+        for outcome in received_mutation_outcomes {
+            if let Err(error) = self.handle_received_mutation_outcome(outcome) {
+                tracing::warn!(error = %error, "failed to process mutation outcome");
             }
         }
 

--- a/crates/jazz-tools/src/runtime_core/ticks.rs
+++ b/crates/jazz-tools/src/runtime_core/ticks.rs
@@ -22,7 +22,57 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
         //    was just processed and made the schema available).
         self.schema_manager.process(&mut self.storage);
 
-        // 3. Collect subscription updates
+        // 3. Process received persistence acks — resolve matching watchers
+        let received_acks = self
+            .schema_manager
+            .query_manager_mut()
+            .sync_manager_mut()
+            .take_received_acks();
+        for (commit_id, acked_tier) in received_acks {
+            if let Err(error) = self.advance_mutation_ack(commit_id, acked_tier) {
+                tracing::warn!(?commit_id, ?acked_tier, error = %error, "failed to advance mutation ack");
+            }
+            if let Some(watchers) = self.ack_watchers.remove(&commit_id) {
+                let mut remaining = Vec::new();
+                for (requested_tier, sender) in watchers {
+                    if acked_tier >= requested_tier {
+                        tracing::debug!(
+                            ?commit_id,
+                            ?acked_tier,
+                            ?requested_tier,
+                            "ack watcher resolved"
+                        );
+                        let _ = sender.send(());
+                    } else {
+                        remaining.push((requested_tier, sender));
+                    }
+                }
+                if !remaining.is_empty() {
+                    self.ack_watchers.insert(commit_id, remaining);
+                }
+            }
+        }
+
+        // 4. Process received mutation outcomes.
+        let received_mutation_outcomes = self
+            .schema_manager
+            .query_manager_mut()
+            .sync_manager_mut()
+            .take_received_mutation_outcomes();
+        let had_mutation_outcomes = !received_mutation_outcomes.is_empty();
+        for outcome in received_mutation_outcomes {
+            if let Err(error) = self.handle_received_mutation_outcome(outcome) {
+                tracing::warn!(error = %error, "failed to process mutation outcome");
+            }
+        }
+
+        if had_mutation_outcomes {
+            self.schema_manager.process(&mut self.storage);
+            self.schema_manager.process(&mut self.storage);
+        }
+
+        // 5. Collect subscription updates after mutation outcomes have had a chance
+        // to roll back local state and invalidate queries.
         let subscription_updates = self.schema_manager.query_manager_mut().take_updates();
         let subscription_failures = self
             .schema_manager
@@ -34,14 +84,11 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
         let mut failed_one_shots: Vec<SubscriptionHandle> = Vec::new();
         let mut callbacks_fired: u64 = 0;
 
-        // 3. Call subscription callbacks AND handle one-shot queries
+        // 6. Call subscription callbacks AND handle one-shot queries.
         for update in &subscription_updates {
             if let Some(&handle) = self.subscription_reverse.get(&update.subscription_id) {
-                // Check if this is a one-shot query
                 if let Some(pending) = self.pending_one_shot_queries.get_mut(&handle) {
-                    // First callback = graph settled, fulfill the future
                     if let Some(sender) = pending.sender.take() {
-                        // Decode rows using the query's output descriptor
                         let results: Vec<(ObjectId, Vec<Value>)> = update
                             .ordered_delta
                             .added
@@ -54,10 +101,8 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
                             .collect();
                         let _ = sender.send(Ok(results));
                     }
-                    // Mark for cleanup (unsubscribe happens after loop)
                     completed_one_shots.push(handle);
                 } else if let Some(state) = self.subscriptions.get(&handle) {
-                    // Regular subscription - call callback
                     let delta = SubscriptionDelta {
                         handle,
                         ordered_delta: update.ordered_delta.clone(),
@@ -98,10 +143,8 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
             }
         }
 
-        // 2b. Cleanup completed one-shot queries
         for handle in completed_one_shots {
             if let Some(pending) = self.pending_one_shot_queries.remove(&handle) {
-                // Unsubscribe from the underlying subscription
                 self.schema_manager
                     .query_manager_mut()
                     .unsubscribe_with_sync(pending.subscription_id);
@@ -109,58 +152,13 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
             }
         }
 
-        // 2c. Cleanup failed one-shot queries.
-        // The underlying subscriptions were already removed by QueryManager.
         for handle in failed_one_shots {
             if let Some(pending) = self.pending_one_shot_queries.remove(&handle) {
                 self.subscription_reverse.remove(&pending.subscription_id);
             }
         }
 
-        // 3b. Process received persistence acks — resolve matching watchers
-        let received_acks = self
-            .schema_manager
-            .query_manager_mut()
-            .sync_manager_mut()
-            .take_received_acks();
-        for (commit_id, acked_tier) in received_acks {
-            if let Err(error) = self.advance_mutation_ack(commit_id, acked_tier) {
-                tracing::warn!(?commit_id, ?acked_tier, error = %error, "failed to advance mutation ack");
-            }
-            if let Some(watchers) = self.ack_watchers.remove(&commit_id) {
-                let mut remaining = Vec::new();
-                for (requested_tier, sender) in watchers {
-                    if acked_tier >= requested_tier {
-                        tracing::debug!(
-                            ?commit_id,
-                            ?acked_tier,
-                            ?requested_tier,
-                            "ack watcher resolved"
-                        );
-                        let _ = sender.send(());
-                    } else {
-                        remaining.push((requested_tier, sender));
-                    }
-                }
-                if !remaining.is_empty() {
-                    self.ack_watchers.insert(commit_id, remaining);
-                }
-            }
-        }
-
-        // 3c. Process received mutation outcomes.
-        let received_mutation_outcomes = self
-            .schema_manager
-            .query_manager_mut()
-            .sync_manager_mut()
-            .take_received_mutation_outcomes();
-        for outcome in received_mutation_outcomes {
-            if let Err(error) = self.handle_received_mutation_outcome(outcome) {
-                tracing::warn!(error = %error, "failed to process mutation outcome");
-            }
-        }
-
-        // 4. Schedule batched_tick if outbound messages exist
+        // 7. Schedule batched_tick if outbound messages exist
         if self.has_outbound() {
             self.scheduler.schedule_batched_tick();
         }

--- a/crates/jazz-tools/src/runtime_core/ticks.rs
+++ b/crates/jazz-tools/src/runtime_core/ticks.rs
@@ -32,24 +32,14 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
             if let Err(error) = self.advance_mutation_ack(commit_id, acked_tier) {
                 tracing::warn!(?commit_id, ?acked_tier, error = %error, "failed to advance mutation ack");
             }
-            if let Some(watchers) = self.ack_watchers.remove(&commit_id) {
-                let mut remaining = Vec::new();
-                for (requested_tier, sender) in watchers {
-                    if acked_tier >= requested_tier {
-                        tracing::debug!(
-                            ?commit_id,
-                            ?acked_tier,
-                            ?requested_tier,
-                            "ack watcher resolved"
-                        );
-                        let _ = sender.send(());
-                    } else {
-                        remaining.push((requested_tier, sender));
-                    }
-                }
-                if !remaining.is_empty() {
-                    self.ack_watchers.insert(commit_id, remaining);
-                }
+            if let Ok(Some(record)) = self.load_mutation_record_for_commit(commit_id) {
+                tracing::debug!(
+                    ?commit_id,
+                    mutation_id = %record.id,
+                    ?acked_tier,
+                    "ack advanced mutation watcher state"
+                );
+                self.resolve_persisted_waiters(record.id, record.highest_acked_tier);
             }
         }
 

--- a/crates/jazz-tools/src/runtime_core/writes.rs
+++ b/crates/jazz-tools/src/runtime_core/writes.rs
@@ -105,7 +105,7 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
         values: Vec<Value>,
         session: Option<&Session>,
         tier: DurabilityTier,
-    ) -> Result<(InsertedRow, oneshot::Receiver<()>), RuntimeError> {
+    ) -> Result<(InsertedRow, PersistedMutationReceiver), RuntimeError> {
         let branch_name = self.schema_manager.branch_name();
         let result = self
             .schema_manager
@@ -114,29 +114,29 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
         let row_id = result.row_id;
         let row_commit_id = result.row_commit_id;
         let row_values = result.row_values;
-        self.record_local_mutation(
-            row_id,
-            branch_name,
-            Some(table.to_string()),
-            MutationOperation::Insert,
-            vec![row_commit_id],
-            Vec::new(),
-        )?;
+        let mutation_id = self
+            .record_local_mutation(
+                row_id,
+                branch_name,
+                Some(table.to_string()),
+                MutationOperation::Insert,
+                vec![row_commit_id],
+                Vec::new(),
+            )?
+            .ok_or_else(|| RuntimeError::WriteError("mutation journal disabled".to_string()))?;
 
-        let (sender, receiver) = oneshot::channel();
-        if self
+        let receiver = if self
             .schema_manager
             .query_manager()
             .sync_manager()
             .has_local_durability_at_least(tier)
         {
-            let _ = sender.send(());
+            let (sender, receiver) = oneshot::channel();
+            let _ = sender.send(Ok(()));
+            receiver
         } else {
-            self.ack_watchers
-                .entry(row_commit_id)
-                .or_default()
-                .push((tier, sender));
-        }
+            self.register_persisted_mutation_waiter(mutation_id, tier)
+        };
 
         self.immediate_tick();
         Ok(((row_id, row_values), receiver))
@@ -150,7 +150,7 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
         values: Vec<(String, Value)>,
         session: Option<&Session>,
         tier: DurabilityTier,
-    ) -> Result<oneshot::Receiver<()>, RuntimeError> {
+    ) -> Result<PersistedMutationReceiver, RuntimeError> {
         let current_values = self.merge_row_update_values(object_id, values)?;
         let (table, branch_name, previous_commit_ids) =
             self.capture_existing_mutation_context(object_id)?;
@@ -160,29 +160,29 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
             .query_manager_mut()
             .update_with_session(&mut self.storage, object_id, &current_values, session)
             .map_err(|e| RuntimeError::WriteError(format!("{:?}", e)))?;
-        self.record_local_mutation(
-            object_id,
-            branch_name,
-            Some(table),
-            MutationOperation::Update,
-            vec![commit_id],
-            previous_commit_ids,
-        )?;
+        let mutation_id = self
+            .record_local_mutation(
+                object_id,
+                branch_name,
+                Some(table),
+                MutationOperation::Update,
+                vec![commit_id],
+                previous_commit_ids,
+            )?
+            .ok_or_else(|| RuntimeError::WriteError("mutation journal disabled".to_string()))?;
 
-        let (sender, receiver) = oneshot::channel();
-        if self
+        let receiver = if self
             .schema_manager
             .query_manager()
             .sync_manager()
             .has_local_durability_at_least(tier)
         {
-            let _ = sender.send(());
+            let (sender, receiver) = oneshot::channel();
+            let _ = sender.send(Ok(()));
+            receiver
         } else {
-            self.ack_watchers
-                .entry(commit_id)
-                .or_default()
-                .push((tier, sender));
-        }
+            self.register_persisted_mutation_waiter(mutation_id, tier)
+        };
 
         self.immediate_tick();
         Ok(receiver)
@@ -249,7 +249,7 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
         object_id: ObjectId,
         session: Option<&Session>,
         tier: DurabilityTier,
-    ) -> Result<oneshot::Receiver<()>, RuntimeError> {
+    ) -> Result<PersistedMutationReceiver, RuntimeError> {
         let (table, branch_name, previous_commit_ids) =
             self.capture_existing_mutation_context(object_id)?;
         let handle = self
@@ -257,29 +257,29 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
             .query_manager_mut()
             .delete_with_session(&mut self.storage, object_id, session)
             .map_err(|e| RuntimeError::WriteError(format!("{:?}", e)))?;
-        self.record_local_mutation(
-            object_id,
-            branch_name,
-            Some(table),
-            MutationOperation::Delete,
-            vec![handle.delete_commit_id],
-            previous_commit_ids,
-        )?;
+        let mutation_id = self
+            .record_local_mutation(
+                object_id,
+                branch_name,
+                Some(table),
+                MutationOperation::Delete,
+                vec![handle.delete_commit_id],
+                previous_commit_ids,
+            )?
+            .ok_or_else(|| RuntimeError::WriteError("mutation journal disabled".to_string()))?;
 
-        let (sender, receiver) = oneshot::channel();
-        if self
+        let receiver = if self
             .schema_manager
             .query_manager()
             .sync_manager()
             .has_local_durability_at_least(tier)
         {
-            let _ = sender.send(());
+            let (sender, receiver) = oneshot::channel();
+            let _ = sender.send(Ok(()));
+            receiver
         } else {
-            self.ack_watchers
-                .entry(handle.delete_commit_id)
-                .or_default()
-                .push((tier, sender));
-        }
+            self.register_persisted_mutation_waiter(mutation_id, tier)
+        };
 
         self.immediate_tick();
         Ok(receiver)

--- a/crates/jazz-tools/src/runtime_core/writes.rs
+++ b/crates/jazz-tools/src/runtime_core/writes.rs
@@ -1,4 +1,6 @@
 use super::*;
+use crate::object::BranchName;
+use crate::sync_manager::MutationOperation;
 
 impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
     // =========================================================================
@@ -13,12 +15,22 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
         session: Option<&Session>,
     ) -> Result<InsertedRow, RuntimeError> {
         let _span = debug_span!("insert", table).entered();
+        let branch_name = self.schema_manager.branch_name();
         let result = self
             .schema_manager
             .insert_with_session(&mut self.storage, table, &values, session)
             .map_err(|e| RuntimeError::WriteError(format!("{:?}", e)))?;
         let row_id = result.row_id;
+        let row_commit_id = result.row_commit_id;
         let row_values = result.row_values;
+        self.record_local_mutation(
+            row_id,
+            branch_name,
+            Some(table.to_string()),
+            MutationOperation::Insert,
+            vec![row_commit_id],
+            Vec::new(),
+        )?;
         debug!(object_id = %row_id, "inserted");
         self.immediate_tick();
         Ok((row_id, row_values))
@@ -33,11 +45,22 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
     ) -> Result<(), RuntimeError> {
         let _span = debug_span!("update", %object_id).entered();
         let current_values = self.merge_row_update_values(object_id, values)?;
+        let (table, branch_name, previous_commit_ids) =
+            self.capture_existing_mutation_context(object_id)?;
 
-        self.schema_manager
+        let commit_id = self
+            .schema_manager
             .query_manager_mut()
             .update_with_session(&mut self.storage, object_id, &current_values, session)
             .map_err(|e| RuntimeError::WriteError(format!("{:?}", e)))?;
+        self.record_local_mutation(
+            object_id,
+            branch_name,
+            Some(table),
+            MutationOperation::Update,
+            vec![commit_id],
+            previous_commit_ids,
+        )?;
 
         self.immediate_tick();
         Ok(())
@@ -50,10 +73,21 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
         session: Option<&Session>,
     ) -> Result<(), RuntimeError> {
         let _span = debug_span!("delete", %object_id).entered();
-        self.schema_manager
+        let (table, branch_name, previous_commit_ids) =
+            self.capture_existing_mutation_context(object_id)?;
+        let handle = self
+            .schema_manager
             .query_manager_mut()
             .delete_with_session(&mut self.storage, object_id, session)
             .map_err(|e| RuntimeError::WriteError(format!("{:?}", e)))?;
+        self.record_local_mutation(
+            object_id,
+            branch_name,
+            Some(table),
+            MutationOperation::Delete,
+            vec![handle.delete_commit_id],
+            previous_commit_ids,
+        )?;
         debug!("deleted");
         self.immediate_tick();
         Ok(())
@@ -72,6 +106,7 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
         session: Option<&Session>,
         tier: DurabilityTier,
     ) -> Result<(InsertedRow, oneshot::Receiver<()>), RuntimeError> {
+        let branch_name = self.schema_manager.branch_name();
         let result = self
             .schema_manager
             .insert_with_session(&mut self.storage, table, &values, session)
@@ -79,6 +114,14 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
         let row_id = result.row_id;
         let row_commit_id = result.row_commit_id;
         let row_values = result.row_values;
+        self.record_local_mutation(
+            row_id,
+            branch_name,
+            Some(table.to_string()),
+            MutationOperation::Insert,
+            vec![row_commit_id],
+            Vec::new(),
+        )?;
 
         let (sender, receiver) = oneshot::channel();
         if self
@@ -109,12 +152,22 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
         tier: DurabilityTier,
     ) -> Result<oneshot::Receiver<()>, RuntimeError> {
         let current_values = self.merge_row_update_values(object_id, values)?;
+        let (table, branch_name, previous_commit_ids) =
+            self.capture_existing_mutation_context(object_id)?;
 
         let commit_id = self
             .schema_manager
             .query_manager_mut()
             .update_with_session(&mut self.storage, object_id, &current_values, session)
             .map_err(|e| RuntimeError::WriteError(format!("{:?}", e)))?;
+        self.record_local_mutation(
+            object_id,
+            branch_name,
+            Some(table),
+            MutationOperation::Update,
+            vec![commit_id],
+            previous_commit_ids,
+        )?;
 
         let (sender, receiver) = oneshot::channel();
         if self
@@ -166,6 +219,29 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
         Ok(current_values)
     }
 
+    fn capture_existing_mutation_context(
+        &mut self,
+        object_id: ObjectId,
+    ) -> Result<(String, BranchName, Vec<CommitId>), RuntimeError> {
+        let branch_name = self.schema_manager.branch_name();
+        let table = self
+            .schema_manager
+            .query_manager_mut()
+            .get_row(object_id)
+            .map(|(table, _)| table)
+            .ok_or(RuntimeError::NotFound)?;
+        let previous_commit_ids = self
+            .schema_manager
+            .query_manager()
+            .sync_manager()
+            .object_manager
+            .get_tip_ids(object_id, branch_name)
+            .map(|tips| tips.iter().copied().collect())
+            .unwrap_or_default();
+
+        Ok((table, branch_name, previous_commit_ids))
+    }
+
     /// Delete a row and return a receiver that resolves when the requested
     /// persistence tier (or higher) acknowledges.
     pub fn delete_persisted(
@@ -174,11 +250,21 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
         session: Option<&Session>,
         tier: DurabilityTier,
     ) -> Result<oneshot::Receiver<()>, RuntimeError> {
+        let (table, branch_name, previous_commit_ids) =
+            self.capture_existing_mutation_context(object_id)?;
         let handle = self
             .schema_manager
             .query_manager_mut()
             .delete_with_session(&mut self.storage, object_id, session)
             .map_err(|e| RuntimeError::WriteError(format!("{:?}", e)))?;
+        self.record_local_mutation(
+            object_id,
+            branch_name,
+            Some(table),
+            MutationOperation::Delete,
+            vec![handle.delete_commit_id],
+            previous_commit_ids,
+        )?;
 
         let (sender, receiver) = oneshot::channel();
         if self

--- a/crates/jazz-tools/src/runtime_tokio.rs
+++ b/crates/jazz-tools/src/runtime_tokio.rs
@@ -27,7 +27,8 @@ use crate::runtime_core::{
 use crate::schema_manager::{QuerySchemaContext, SchemaManager};
 use crate::storage::Storage;
 use crate::sync_manager::{
-    ClientId, InboxEntry, MutationOutcome, OutboxEntry, QueryPropagation, ServerId,
+    ClientId, InboxEntry, MutationEvent, MutationId, MutationOutcome, MutationRecord, OutboxEntry,
+    QueryPropagation, ServerId,
 };
 
 // ============================================================================
@@ -366,6 +367,28 @@ impl<S: Storage + Send + 'static> TokioRuntime<S> {
     pub fn take_mutation_outcomes(&self) -> Result<Vec<MutationOutcome>, RuntimeError> {
         let mut core = self.core.lock().map_err(|_| RuntimeError::LockError)?;
         Ok(core.take_mutation_outcomes())
+    }
+
+    /// Take mutation journal events received since the last call.
+    pub fn take_mutation_events(&self) -> Result<Vec<MutationEvent>, RuntimeError> {
+        let mut core = self.core.lock().map_err(|_| RuntimeError::LockError)?;
+        Ok(core.take_mutation_events())
+    }
+
+    /// Enable or disable local mutation journal ownership for this runtime.
+    pub fn set_mutation_journal_enabled(&self, enabled: bool) -> Result<(), RuntimeError> {
+        let mut core = self.core.lock().map_err(|_| RuntimeError::LockError)?;
+        core.set_mutation_journal_enabled(enabled);
+        Ok(())
+    }
+
+    /// Load one mutation record by mutation id.
+    pub fn get_mutation_record(
+        &self,
+        mutation_id: MutationId,
+    ) -> Result<Option<MutationRecord>, RuntimeError> {
+        let core = self.core.lock().map_err(|_| RuntimeError::LockError)?;
+        core.get_mutation_record(mutation_id).map_err(Into::into)
     }
 
     /// Set the next expected stream sequence for a server.

--- a/crates/jazz-tools/src/runtime_tokio.rs
+++ b/crates/jazz-tools/src/runtime_tokio.rs
@@ -26,7 +26,9 @@ use crate::runtime_core::{
 };
 use crate::schema_manager::{QuerySchemaContext, SchemaManager};
 use crate::storage::Storage;
-use crate::sync_manager::{ClientId, InboxEntry, OutboxEntry, QueryPropagation, ServerId};
+use crate::sync_manager::{
+    ClientId, InboxEntry, MutationOutcome, OutboxEntry, QueryPropagation, ServerId,
+};
 
 // ============================================================================
 // TokioScheduler
@@ -358,6 +360,12 @@ impl<S: Storage + Send + 'static> TokioRuntime<S> {
         let mut core = self.core.lock().map_err(|_| RuntimeError::LockError)?;
         core.park_sync_message_with_sequence(entry, sequence);
         Ok(())
+    }
+
+    /// Take mutation outcomes received since the last call.
+    pub fn take_mutation_outcomes(&self) -> Result<Vec<MutationOutcome>, RuntimeError> {
+        let mut core = self.core.lock().map_err(|_| RuntimeError::LockError)?;
+        Ok(core.take_mutation_outcomes())
     }
 
     /// Set the next expected stream sequence for a server.

--- a/crates/jazz-tools/src/runtime_tokio.rs
+++ b/crates/jazz-tools/src/runtime_tokio.rs
@@ -28,7 +28,7 @@ use crate::schema_manager::{QuerySchemaContext, SchemaManager};
 use crate::storage::Storage;
 use crate::sync_manager::{
     ClientId, InboxEntry, MutationEvent, MutationId, MutationOutcome, MutationRecord,
-    ObjectOutcomeState, OutboxEntry, QueryPropagation, ServerId,
+    ObjectOutcomeEvent, ObjectOutcomeState, OutboxEntry, QueryPropagation, ServerId,
 };
 
 // ============================================================================
@@ -373,6 +373,12 @@ impl<S: Storage + Send + 'static> TokioRuntime<S> {
     pub fn take_mutation_events(&self) -> Result<Vec<MutationEvent>, RuntimeError> {
         let mut core = self.core.lock().map_err(|_| RuntimeError::LockError)?;
         Ok(core.take_mutation_events())
+    }
+
+    /// Take derived object-outcome change events since the last call.
+    pub fn take_object_outcome_events(&self) -> Result<Vec<ObjectOutcomeEvent>, RuntimeError> {
+        let mut core = self.core.lock().map_err(|_| RuntimeError::LockError)?;
+        Ok(core.take_object_outcome_events())
     }
 
     /// Enable or disable local mutation journal ownership for this runtime.

--- a/crates/jazz-tools/src/runtime_tokio.rs
+++ b/crates/jazz-tools/src/runtime_tokio.rs
@@ -416,6 +416,12 @@ impl<S: Storage + Send + 'static> TokioRuntime<S> {
         core.get_object_outcome(object_id).map_err(Into::into)
     }
 
+    /// List the current object-level outcome overlays for all tracked objects.
+    pub fn list_object_outcomes(&self) -> Result<Vec<ObjectOutcomeEvent>, RuntimeError> {
+        let core = self.core.lock().map_err(|_| RuntimeError::LockError)?;
+        core.list_object_outcomes().map_err(Into::into)
+    }
+
     /// Acknowledge a surfaced mutation outcome and prune any retained dead commit chain.
     pub fn acknowledge_mutation_outcome(
         &self,

--- a/crates/jazz-tools/src/runtime_tokio.rs
+++ b/crates/jazz-tools/src/runtime_tokio.rs
@@ -27,8 +27,8 @@ use crate::runtime_core::{
 use crate::schema_manager::{QuerySchemaContext, SchemaManager};
 use crate::storage::Storage;
 use crate::sync_manager::{
-    ClientId, InboxEntry, MutationEvent, MutationId, MutationOutcome, MutationRecord, OutboxEntry,
-    QueryPropagation, ServerId,
+    ClientId, InboxEntry, MutationEvent, MutationId, MutationOutcome, MutationRecord,
+    ObjectOutcomeState, OutboxEntry, QueryPropagation, ServerId,
 };
 
 // ============================================================================
@@ -389,6 +389,35 @@ impl<S: Storage + Send + 'static> TokioRuntime<S> {
     ) -> Result<Option<MutationRecord>, RuntimeError> {
         let core = self.core.lock().map_err(|_| RuntimeError::LockError)?;
         core.get_mutation_record(mutation_id).map_err(Into::into)
+    }
+
+    /// List mutation journal records associated with one object.
+    pub fn list_mutations_for_object(
+        &self,
+        object_id: ObjectId,
+    ) -> Result<Vec<MutationRecord>, RuntimeError> {
+        let core = self.core.lock().map_err(|_| RuntimeError::LockError)?;
+        core.list_mutations_for_object(object_id)
+            .map_err(Into::into)
+    }
+
+    /// Derive the current object-level outcome overlay from the mutation journal.
+    pub fn get_object_outcome(
+        &self,
+        object_id: ObjectId,
+    ) -> Result<Option<ObjectOutcomeState>, RuntimeError> {
+        let core = self.core.lock().map_err(|_| RuntimeError::LockError)?;
+        core.get_object_outcome(object_id).map_err(Into::into)
+    }
+
+    /// Acknowledge a surfaced mutation outcome and prune any retained dead commit chain.
+    pub fn acknowledge_mutation_outcome(
+        &self,
+        mutation_id: MutationId,
+    ) -> Result<(), RuntimeError> {
+        let mut core = self.core.lock().map_err(|_| RuntimeError::LockError)?;
+        core.acknowledge_mutation_outcome(mutation_id)
+            .map_err(Into::into)
     }
 
     /// Set the next expected stream sequence for a server.

--- a/crates/jazz-tools/src/storage/fjall.rs
+++ b/crates/jazz-tools/src/storage/fjall.rs
@@ -16,16 +16,17 @@ use fjall::{
 use crate::commit::{Commit, CommitId};
 use crate::object::{BranchName, ObjectId};
 use crate::query_manager::types::Value;
-use crate::sync_manager::DurabilityTier;
+use crate::sync_manager::{DurabilityTier, MutationId, MutationOutcomeFilter, MutationRecord};
 
 use super::{
     CatalogueManifest, CatalogueManifestOp, LoadedBranch, Storage, StorageError,
     storage_core::{
         append_catalogue_manifest_op_core, append_catalogue_manifest_ops_core, append_commit_core,
-        create_object_core, delete_commit_core, index_insert_core, index_lookup_core,
-        index_range_core, index_remove_core, index_scan_all_core, load_branch_core,
-        load_catalogue_manifest_core, load_object_metadata_core, set_branch_tails_core,
-        store_ack_tier_core,
+        create_object_core, delete_commit_core, delete_mutation_record_core, index_insert_core,
+        index_lookup_core, index_range_core, index_remove_core, index_scan_all_core,
+        list_mutation_records_by_outcome_core, load_branch_core, load_catalogue_manifest_core,
+        load_mutation_record_by_commit_core, load_mutation_record_core, load_object_metadata_core,
+        put_mutation_record_core, set_branch_tails_core, store_ack_tier_core,
     },
 };
 
@@ -294,6 +295,65 @@ impl Storage for FjallStorage {
                 |key, value| Self::set_on_cell(&tx, &inner.keyspace, key, value),
             )?;
             Self::commit_tx(tx.into_inner())
+        })
+    }
+
+    fn put_mutation_record(&mut self, record: MutationRecord) -> Result<(), StorageError> {
+        self.with_inner(|inner| {
+            let tx = RefCell::new(inner.db.write_tx());
+            put_mutation_record_core(
+                record,
+                |key| Self::read_get_cell(&tx, &inner.keyspace, key),
+                |key, value| Self::set_on_cell(&tx, &inner.keyspace, key, value),
+                |key| Self::delete_on_cell(&tx, &inner.keyspace, key),
+            )?;
+            Self::commit_tx(tx.into_inner())
+        })
+    }
+
+    fn load_mutation_record(
+        &self,
+        mutation_id: MutationId,
+    ) -> Result<Option<MutationRecord>, StorageError> {
+        self.with_inner(|inner| {
+            let tx = inner.db.read_tx();
+            load_mutation_record_core(mutation_id, |key| Self::read_get(&tx, &inner.keyspace, key))
+        })
+    }
+
+    fn load_mutation_record_by_commit(
+        &self,
+        commit_id: CommitId,
+    ) -> Result<Option<MutationRecord>, StorageError> {
+        self.with_inner(|inner| {
+            let tx = inner.db.read_tx();
+            load_mutation_record_by_commit_core(commit_id, |key| {
+                Self::read_get(&tx, &inner.keyspace, key)
+            })
+        })
+    }
+
+    fn delete_mutation_record(&mut self, mutation_id: MutationId) -> Result<(), StorageError> {
+        self.with_inner(|inner| {
+            let tx = RefCell::new(inner.db.write_tx());
+            delete_mutation_record_core(
+                mutation_id,
+                |key| Self::read_get_cell(&tx, &inner.keyspace, key),
+                |key| Self::delete_on_cell(&tx, &inner.keyspace, key),
+            )?;
+            Self::commit_tx(tx.into_inner())
+        })
+    }
+
+    fn list_mutation_records_by_outcome(
+        &self,
+        outcome: MutationOutcomeFilter,
+    ) -> Result<Vec<MutationRecord>, StorageError> {
+        self.with_inner(|inner| {
+            let tx = inner.db.read_tx();
+            list_mutation_records_by_outcome_core(outcome, |prefix| {
+                Self::scan_prefix(&tx, &inner.keyspace, prefix)
+            })
         })
     }
 

--- a/crates/jazz-tools/src/storage/fjall.rs
+++ b/crates/jazz-tools/src/storage/fjall.rs
@@ -24,9 +24,10 @@ use super::{
         append_catalogue_manifest_op_core, append_catalogue_manifest_ops_core, append_commit_core,
         create_object_core, delete_commit_core, delete_mutation_record_core, index_insert_core,
         index_lookup_core, index_range_core, index_remove_core, index_scan_all_core,
-        list_mutation_records_by_outcome_core, load_branch_core, load_catalogue_manifest_core,
-        load_mutation_record_by_commit_core, load_mutation_record_core, load_object_metadata_core,
-        put_mutation_record_core, set_branch_tails_core, store_ack_tier_core,
+        list_mutation_records_by_outcome_core, list_mutation_records_for_object_core,
+        load_branch_core, load_catalogue_manifest_core, load_mutation_record_by_commit_core,
+        load_mutation_record_core, load_object_metadata_core, put_mutation_record_core,
+        set_branch_inactive_commits_core, set_branch_tails_core, store_ack_tier_core,
     },
 };
 
@@ -281,6 +282,25 @@ impl Storage for FjallStorage {
         })
     }
 
+    fn set_branch_inactive_commits(
+        &mut self,
+        object_id: ObjectId,
+        branch: &BranchName,
+        inactive_commits: Option<HashSet<CommitId>>,
+    ) -> Result<(), StorageError> {
+        self.with_inner(|inner| {
+            let tx = RefCell::new(inner.db.write_tx());
+            set_branch_inactive_commits_core(
+                object_id,
+                branch,
+                inactive_commits,
+                |key, value| Self::set_on_cell(&tx, &inner.keyspace, key, value),
+                |key| Self::delete_on_cell(&tx, &inner.keyspace, key),
+            )?;
+            Self::commit_tx(tx.into_inner())
+        })
+    }
+
     fn store_ack_tier(
         &mut self,
         commit_id: CommitId,
@@ -352,6 +372,18 @@ impl Storage for FjallStorage {
         self.with_inner(|inner| {
             let tx = inner.db.read_tx();
             list_mutation_records_by_outcome_core(outcome, |prefix| {
+                Self::scan_prefix(&tx, &inner.keyspace, prefix)
+            })
+        })
+    }
+
+    fn list_mutation_records_for_object(
+        &self,
+        object_id: ObjectId,
+    ) -> Result<Vec<MutationRecord>, StorageError> {
+        self.with_inner(|inner| {
+            let tx = inner.db.read_tx();
+            list_mutation_records_for_object_core(object_id, |prefix| {
                 Self::scan_prefix(&tx, &inner.keyspace, prefix)
             })
         })

--- a/crates/jazz-tools/src/storage/key_codec.rs
+++ b/crates/jazz-tools/src/storage/key_codec.rs
@@ -3,6 +3,7 @@ use std::ops::Bound;
 use crate::commit::CommitId;
 use crate::object::{BranchName, ObjectId};
 use crate::query_manager::types::Value;
+use crate::sync_manager::MutationId;
 
 use super::encode_value;
 
@@ -34,6 +35,18 @@ pub(super) fn commit_prefix(object_id: ObjectId, branch: &BranchName) -> String 
 
 pub(super) fn ack_key(commit_id: CommitId) -> String {
     format!("ack:{}", hex::encode(commit_id.0))
+}
+
+pub(super) fn mutation_record_key(mutation_id: MutationId) -> String {
+    format!("mut:{}", hex::encode(mutation_id.0.as_bytes()))
+}
+
+pub(super) fn mutation_record_prefix() -> &'static str {
+    "mut:"
+}
+
+pub(super) fn mutation_commit_index_key(commit_id: CommitId) -> String {
+    format!("mutc:{}", hex::encode(commit_id.0))
 }
 
 pub(super) fn catalogue_manifest_op_key(app_id: ObjectId, object_id: ObjectId) -> String {

--- a/crates/jazz-tools/src/storage/key_codec.rs
+++ b/crates/jazz-tools/src/storage/key_codec.rs
@@ -20,6 +20,10 @@ pub(super) fn branch_tips_key(object_id: ObjectId, branch: &BranchName) -> Strin
     format!("obj:{}:br:{}:tips", format_uuid(object_id), branch)
 }
 
+pub(super) fn branch_inactive_commits_key(object_id: ObjectId, branch: &BranchName) -> String {
+    format!("obj:{}:br:{}:inactive", format_uuid(object_id), branch)
+}
+
 pub(super) fn commit_key(object_id: ObjectId, branch: &BranchName, commit_id: CommitId) -> String {
     format!(
         "obj:{}:br:{}:c:{}",

--- a/crates/jazz-tools/src/storage/mod.rs
+++ b/crates/jazz-tools/src/storage/mod.rs
@@ -26,7 +26,7 @@ use serde::{Deserialize, Serialize};
 use crate::commit::{Commit, CommitId};
 use crate::object::{BranchName, ObjectId};
 use crate::query_manager::types::{SchemaHash, Value};
-use crate::sync_manager::DurabilityTier;
+use crate::sync_manager::{DurabilityTier, MutationId, MutationOutcomeFilter, MutationRecord};
 
 // ============================================================================
 // Storage Types
@@ -188,6 +188,34 @@ pub trait Storage {
     ) -> Result<(), StorageError>;
 
     // ================================================================
+    // Mutation journal storage
+    // ================================================================
+
+    /// Insert or replace a mutation journal record.
+    fn put_mutation_record(&mut self, record: MutationRecord) -> Result<(), StorageError>;
+
+    /// Load one mutation record by mutation id.
+    fn load_mutation_record(
+        &self,
+        mutation_id: MutationId,
+    ) -> Result<Option<MutationRecord>, StorageError>;
+
+    /// Load one mutation record by one of its commit ids.
+    fn load_mutation_record_by_commit(
+        &self,
+        commit_id: CommitId,
+    ) -> Result<Option<MutationRecord>, StorageError>;
+
+    /// Delete one mutation record and its commit indexes.
+    fn delete_mutation_record(&mut self, mutation_id: MutationId) -> Result<(), StorageError>;
+
+    /// List mutation records matching one outcome state.
+    fn list_mutation_records_by_outcome(
+        &self,
+        outcome: MutationOutcomeFilter,
+    ) -> Result<Vec<MutationRecord>, StorageError>;
+
+    // ================================================================
     // Catalogue manifest storage
     // ================================================================
 
@@ -335,6 +363,35 @@ impl<T: Storage + ?Sized> Storage for Box<T> {
         (**self).store_ack_tier(commit_id, tier)
     }
 
+    fn put_mutation_record(&mut self, record: MutationRecord) -> Result<(), StorageError> {
+        (**self).put_mutation_record(record)
+    }
+
+    fn load_mutation_record(
+        &self,
+        mutation_id: MutationId,
+    ) -> Result<Option<MutationRecord>, StorageError> {
+        (**self).load_mutation_record(mutation_id)
+    }
+
+    fn load_mutation_record_by_commit(
+        &self,
+        commit_id: CommitId,
+    ) -> Result<Option<MutationRecord>, StorageError> {
+        (**self).load_mutation_record_by_commit(commit_id)
+    }
+
+    fn delete_mutation_record(&mut self, mutation_id: MutationId) -> Result<(), StorageError> {
+        (**self).delete_mutation_record(mutation_id)
+    }
+
+    fn list_mutation_records_by_outcome(
+        &self,
+        outcome: MutationOutcomeFilter,
+    ) -> Result<Vec<MutationRecord>, StorageError> {
+        (**self).list_mutation_records_by_outcome(outcome)
+    }
+
     fn append_catalogue_manifest_op(
         &mut self,
         app_id: ObjectId,
@@ -445,6 +502,10 @@ pub struct MemoryStorage {
 
     /// Persistence ack tiers per commit.
     ack_tiers: HashMap<CommitId, HashSet<DurabilityTier>>,
+    /// Mutation journal entries keyed by mutation id.
+    mutation_records: HashMap<MutationId, MutationRecord>,
+    /// Commit-to-mutation reverse index for mutation outcomes and ack updates.
+    mutation_records_by_commit: HashMap<CommitId, MutationId>,
     /// Append-only manifest ops keyed by app_id then op object_id.
     catalogue_manifest_ops: HashMap<ObjectId, HashMap<ObjectId, CatalogueManifestOp>>,
 }
@@ -687,6 +748,60 @@ impl Storage for MemoryStorage {
     ) -> Result<(), StorageError> {
         self.ack_tiers.entry(commit_id).or_default().insert(tier);
         Ok(())
+    }
+
+    fn put_mutation_record(&mut self, record: MutationRecord) -> Result<(), StorageError> {
+        if let Some(existing) = self.mutation_records.insert(record.id, record.clone()) {
+            for commit_id in existing.commit_ids {
+                self.mutation_records_by_commit.remove(&commit_id);
+            }
+        }
+
+        for &commit_id in &record.commit_ids {
+            self.mutation_records_by_commit.insert(commit_id, record.id);
+        }
+
+        Ok(())
+    }
+
+    fn load_mutation_record(
+        &self,
+        mutation_id: MutationId,
+    ) -> Result<Option<MutationRecord>, StorageError> {
+        Ok(self.mutation_records.get(&mutation_id).cloned())
+    }
+
+    fn load_mutation_record_by_commit(
+        &self,
+        commit_id: CommitId,
+    ) -> Result<Option<MutationRecord>, StorageError> {
+        let Some(mutation_id) = self.mutation_records_by_commit.get(&commit_id) else {
+            return Ok(None);
+        };
+
+        Ok(self.mutation_records.get(mutation_id).cloned())
+    }
+
+    fn delete_mutation_record(&mut self, mutation_id: MutationId) -> Result<(), StorageError> {
+        if let Some(record) = self.mutation_records.remove(&mutation_id) {
+            for commit_id in record.commit_ids {
+                self.mutation_records_by_commit.remove(&commit_id);
+            }
+        }
+
+        Ok(())
+    }
+
+    fn list_mutation_records_by_outcome(
+        &self,
+        outcome: MutationOutcomeFilter,
+    ) -> Result<Vec<MutationRecord>, StorageError> {
+        Ok(self
+            .mutation_records
+            .values()
+            .filter(|record| record.matches_filter(outcome))
+            .cloned()
+            .collect())
     }
 
     fn append_catalogue_manifest_op(
@@ -1354,5 +1469,55 @@ mod tests {
             },
         );
         assert!(matches!(conflict, Err(StorageError::IoError(_))));
+    }
+
+    #[test]
+    fn memory_storage_mutation_record_lifecycle() {
+        use crate::sync_manager::{
+            MutationId, MutationOperation, MutationOutcomeFilter, MutationOutcomeState,
+            MutationRecord,
+        };
+
+        let mut storage = MemoryStorage::new();
+        let record = MutationRecord {
+            id: MutationId::new(),
+            object_id: ObjectId::new(),
+            branch_name: BranchName::new("main"),
+            table: Some("users".into()),
+            operation: MutationOperation::Insert,
+            commit_ids: vec![CommitId([1; 32])],
+            previous_commit_ids: Vec::new(),
+            recorded_at_micros: 123,
+            highest_acked_tier: None,
+            outcome: MutationOutcomeState::Pending,
+        };
+
+        storage.put_mutation_record(record.clone()).unwrap();
+
+        assert_eq!(
+            storage.load_mutation_record(record.id).unwrap(),
+            Some(record.clone())
+        );
+        assert_eq!(
+            storage
+                .load_mutation_record_by_commit(record.commit_ids[0])
+                .unwrap(),
+            Some(record.clone())
+        );
+        assert_eq!(
+            storage
+                .list_mutation_records_by_outcome(MutationOutcomeFilter::Pending)
+                .unwrap(),
+            vec![record.clone()]
+        );
+
+        storage.delete_mutation_record(record.id).unwrap();
+        assert_eq!(storage.load_mutation_record(record.id).unwrap(), None);
+        assert_eq!(
+            storage
+                .load_mutation_record_by_commit(record.commit_ids[0])
+                .unwrap(),
+            None
+        );
     }
 }

--- a/crates/jazz-tools/src/storage/mod.rs
+++ b/crates/jazz-tools/src/storage/mod.rs
@@ -47,6 +47,7 @@ pub enum StorageError {
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct LoadedBranch {
     pub commits: Vec<Commit>,
+    pub inactive_commits: HashSet<CommitId>,
     pub tails: HashSet<CommitId>,
 }
 
@@ -176,6 +177,14 @@ pub trait Storage {
         tails: Option<HashSet<CommitId>>,
     ) -> Result<(), StorageError>;
 
+    /// Record which commits on a branch are retained locally but excluded from the active frontier.
+    fn set_branch_inactive_commits(
+        &mut self,
+        object_id: ObjectId,
+        branch: &BranchName,
+        inactive_commits: Option<HashSet<CommitId>>,
+    ) -> Result<(), StorageError>;
+
     // ================================================================
     // Persistence ack storage
     // ================================================================
@@ -213,6 +222,12 @@ pub trait Storage {
     fn list_mutation_records_by_outcome(
         &self,
         outcome: MutationOutcomeFilter,
+    ) -> Result<Vec<MutationRecord>, StorageError>;
+
+    /// List all mutation records recorded for one object.
+    fn list_mutation_records_for_object(
+        &self,
+        object_id: ObjectId,
     ) -> Result<Vec<MutationRecord>, StorageError>;
 
     // ================================================================
@@ -355,6 +370,15 @@ impl<T: Storage + ?Sized> Storage for Box<T> {
         (**self).set_branch_tails(object_id, branch, tails)
     }
 
+    fn set_branch_inactive_commits(
+        &mut self,
+        object_id: ObjectId,
+        branch: &BranchName,
+        inactive_commits: Option<HashSet<CommitId>>,
+    ) -> Result<(), StorageError> {
+        (**self).set_branch_inactive_commits(object_id, branch, inactive_commits)
+    }
+
     fn store_ack_tier(
         &mut self,
         commit_id: CommitId,
@@ -390,6 +414,13 @@ impl<T: Storage + ?Sized> Storage for Box<T> {
         outcome: MutationOutcomeFilter,
     ) -> Result<Vec<MutationRecord>, StorageError> {
         (**self).list_mutation_records_by_outcome(outcome)
+    }
+
+    fn list_mutation_records_for_object(
+        &self,
+        object_id: ObjectId,
+    ) -> Result<Vec<MutationRecord>, StorageError> {
+        (**self).list_mutation_records_for_object(object_id)
     }
 
     fn append_catalogue_manifest_op(
@@ -521,6 +552,7 @@ struct ObjectData {
 #[derive(Debug, Clone, Default)]
 struct BranchData {
     commits: Vec<Commit>,
+    inactive_commits: HashSet<CommitId>,
     tails: HashSet<CommitId>,
 }
 
@@ -677,6 +709,7 @@ impl Storage for MemoryStorage {
         }
         Ok(Some(LoadedBranch {
             commits,
+            inactive_commits: branch_data.inactive_commits.clone(),
             tails: branch_data.tails.clone(),
         }))
     }
@@ -716,6 +749,7 @@ impl Storage for MemoryStorage {
             .and_then(|obj| obj.branches.get_mut(branch))
         {
             branch_data.commits.retain(|c| c.id() != commit_id);
+            branch_data.inactive_commits.remove(&commit_id);
             branch_data.tails.remove(&commit_id);
         }
         Ok(())
@@ -733,6 +767,22 @@ impl Storage for MemoryStorage {
             .and_then(|obj| obj.branches.get_mut(branch))
         {
             branch_data.tails = tails.unwrap_or_default();
+        }
+        Ok(())
+    }
+
+    fn set_branch_inactive_commits(
+        &mut self,
+        object_id: ObjectId,
+        branch: &BranchName,
+        inactive_commits: Option<HashSet<CommitId>>,
+    ) -> Result<(), StorageError> {
+        if let Some(branch_data) = self
+            .objects
+            .get_mut(&object_id)
+            .and_then(|obj| obj.branches.get_mut(branch))
+        {
+            branch_data.inactive_commits = inactive_commits.unwrap_or_default();
         }
         Ok(())
     }
@@ -800,6 +850,18 @@ impl Storage for MemoryStorage {
             .mutation_records
             .values()
             .filter(|record| record.matches_filter(outcome))
+            .cloned()
+            .collect())
+    }
+
+    fn list_mutation_records_for_object(
+        &self,
+        object_id: ObjectId,
+    ) -> Result<Vec<MutationRecord>, StorageError> {
+        Ok(self
+            .mutation_records
+            .values()
+            .filter(|record| record.object_id == object_id)
             .cloned()
             .collect())
     }

--- a/crates/jazz-tools/src/storage/opfs_btree.rs
+++ b/crates/jazz-tools/src/storage/opfs_btree.rs
@@ -29,17 +29,18 @@ use opfs_btree::{BTreeError, BTreeOptions, MemoryFile, OpfsBTree, SyncFile};
 use crate::commit::{Commit, CommitId};
 use crate::object::{BranchName, ObjectId};
 use crate::query_manager::types::Value;
-use crate::sync_manager::DurabilityTier;
+use crate::sync_manager::{DurabilityTier, MutationId, MutationOutcomeFilter, MutationRecord};
 
 use super::{
     CatalogueManifest, CatalogueManifestOp, LoadedBranch, Storage, StorageError,
     key_codec::increment_bytes,
     storage_core::{
         append_catalogue_manifest_op_core, append_catalogue_manifest_ops_core, append_commit_core,
-        create_object_core, delete_commit_core, index_insert_core, index_lookup_core,
-        index_range_core, index_remove_core, index_scan_all_core, load_branch_core,
-        load_catalogue_manifest_core, load_object_metadata_core, set_branch_tails_core,
-        store_ack_tier_core,
+        create_object_core, delete_commit_core, delete_mutation_record_core, index_insert_core,
+        index_lookup_core, index_range_core, index_remove_core, index_scan_all_core,
+        list_mutation_records_by_outcome_core, load_branch_core, load_catalogue_manifest_core,
+        load_mutation_record_by_commit_core, load_mutation_record_core, load_object_metadata_core,
+        put_mutation_record_core, set_branch_tails_core, store_ack_tier_core,
     },
 };
 
@@ -313,6 +314,44 @@ impl Storage for OpfsBTreeStorage {
             |key| self.tree_read(key),
             |key, value| self.tree_insert(key, value),
         )
+    }
+
+    fn put_mutation_record(&mut self, record: MutationRecord) -> Result<(), StorageError> {
+        put_mutation_record_core(
+            record,
+            |key| self.tree_read(key),
+            |key, value| self.tree_insert(key, value),
+            |key| self.tree_delete(key),
+        )
+    }
+
+    fn load_mutation_record(
+        &self,
+        mutation_id: MutationId,
+    ) -> Result<Option<MutationRecord>, StorageError> {
+        load_mutation_record_core(mutation_id, |key| self.tree_read(key))
+    }
+
+    fn load_mutation_record_by_commit(
+        &self,
+        commit_id: CommitId,
+    ) -> Result<Option<MutationRecord>, StorageError> {
+        load_mutation_record_by_commit_core(commit_id, |key| self.tree_read(key))
+    }
+
+    fn delete_mutation_record(&mut self, mutation_id: MutationId) -> Result<(), StorageError> {
+        delete_mutation_record_core(
+            mutation_id,
+            |key| self.tree_read(key),
+            |key| self.tree_delete(key),
+        )
+    }
+
+    fn list_mutation_records_by_outcome(
+        &self,
+        outcome: MutationOutcomeFilter,
+    ) -> Result<Vec<MutationRecord>, StorageError> {
+        list_mutation_records_by_outcome_core(outcome, |prefix| self.tree_scan_prefix(prefix))
     }
 
     fn append_catalogue_manifest_op(

--- a/crates/jazz-tools/src/storage/opfs_btree.rs
+++ b/crates/jazz-tools/src/storage/opfs_btree.rs
@@ -38,9 +38,10 @@ use super::{
         append_catalogue_manifest_op_core, append_catalogue_manifest_ops_core, append_commit_core,
         create_object_core, delete_commit_core, delete_mutation_record_core, index_insert_core,
         index_lookup_core, index_range_core, index_remove_core, index_scan_all_core,
-        list_mutation_records_by_outcome_core, load_branch_core, load_catalogue_manifest_core,
-        load_mutation_record_by_commit_core, load_mutation_record_core, load_object_metadata_core,
-        put_mutation_record_core, set_branch_tails_core, store_ack_tier_core,
+        list_mutation_records_by_outcome_core, list_mutation_records_for_object_core,
+        load_branch_core, load_catalogue_manifest_core, load_mutation_record_by_commit_core,
+        load_mutation_record_core, load_object_metadata_core, put_mutation_record_core,
+        set_branch_inactive_commits_core, set_branch_tails_core, store_ack_tier_core,
     },
 };
 
@@ -303,6 +304,21 @@ impl Storage for OpfsBTreeStorage {
         )
     }
 
+    fn set_branch_inactive_commits(
+        &mut self,
+        object_id: ObjectId,
+        branch: &BranchName,
+        inactive_commits: Option<HashSet<CommitId>>,
+    ) -> Result<(), StorageError> {
+        set_branch_inactive_commits_core(
+            object_id,
+            branch,
+            inactive_commits,
+            |key, value| self.tree_insert(key, value),
+            |key| self.tree_delete(key),
+        )
+    }
+
     fn store_ack_tier(
         &mut self,
         commit_id: CommitId,
@@ -352,6 +368,13 @@ impl Storage for OpfsBTreeStorage {
         outcome: MutationOutcomeFilter,
     ) -> Result<Vec<MutationRecord>, StorageError> {
         list_mutation_records_by_outcome_core(outcome, |prefix| self.tree_scan_prefix(prefix))
+    }
+
+    fn list_mutation_records_for_object(
+        &self,
+        object_id: ObjectId,
+    ) -> Result<Vec<MutationRecord>, StorageError> {
+        list_mutation_records_for_object_core(object_id, |prefix| self.tree_scan_prefix(prefix))
     }
 
     fn append_catalogue_manifest_op(

--- a/crates/jazz-tools/src/storage/storage_core.rs
+++ b/crates/jazz-tools/src/storage/storage_core.rs
@@ -10,10 +10,10 @@ use crate::sync_manager::{DurabilityTier, MutationId, MutationOutcomeFilter, Mut
 use crate::query_manager::types::Value;
 
 use super::key_codec::{
-    ack_key, branch_tips_key, catalogue_manifest_op_key, catalogue_manifest_op_prefix, commit_key,
-    commit_prefix, index_entry_key, index_prefix, index_range_scan_bounds, index_value_prefix,
-    mutation_commit_index_key, mutation_record_key, mutation_record_prefix, obj_meta_key,
-    parse_uuid_from_index_key,
+    ack_key, branch_inactive_commits_key, branch_tips_key, catalogue_manifest_op_key,
+    catalogue_manifest_op_prefix, commit_key, commit_prefix, index_entry_key, index_prefix,
+    index_range_scan_bounds, index_value_prefix, mutation_commit_index_key, mutation_record_key,
+    mutation_record_prefix, obj_meta_key, parse_uuid_from_index_key,
 };
 use super::{CatalogueManifest, CatalogueManifestOp, LoadedBranch, StorageError};
 
@@ -87,7 +87,17 @@ pub(super) fn load_branch_core(
         None => HashSet::new(),
     };
 
-    Ok(Some(LoadedBranch { commits, tails }))
+    let inactive_key = branch_inactive_commits_key(object_id, branch);
+    let inactive_commits = match get(&inactive_key)? {
+        Some(data) => decode_json(&data, "inactive commits")?,
+        None => HashSet::new(),
+    };
+
+    Ok(Some(LoadedBranch {
+        commits,
+        inactive_commits,
+        tails,
+    }))
 }
 
 pub(super) fn append_commit_core(
@@ -137,6 +147,19 @@ pub(super) fn delete_commit_core(
         set(&tips_key, &tips_json)?;
     }
 
+    let inactive_key = branch_inactive_commits_key(object_id, branch);
+    if let Some(data) = get(&inactive_key)? {
+        let mut inactive: HashSet<CommitId> = decode_json(&data, "inactive commits")?;
+        if inactive.remove(&commit_id) {
+            if inactive.is_empty() {
+                delete(&inactive_key)?;
+            } else {
+                let inactive_json = encode_json(&inactive, "inactive commits")?;
+                set(&inactive_key, &inactive_json)?;
+            }
+        }
+    }
+
     Ok(())
 }
 
@@ -154,6 +177,23 @@ pub(super) fn set_branch_tails_core(
             set(&tips_key, &json)
         }
         None => delete(&tips_key),
+    }
+}
+
+pub(super) fn set_branch_inactive_commits_core(
+    object_id: ObjectId,
+    branch: &BranchName,
+    inactive_commits: Option<HashSet<CommitId>>,
+    mut set: impl FnMut(&str, &[u8]) -> Result<(), StorageError>,
+    mut delete: impl FnMut(&str) -> Result<(), StorageError>,
+) -> Result<(), StorageError> {
+    let inactive_key = branch_inactive_commits_key(object_id, branch);
+    match inactive_commits {
+        Some(commits) if !commits.is_empty() => {
+            let json = encode_json(&commits, "inactive commits")?;
+            set(&inactive_key, &json)
+        }
+        _ => delete(&inactive_key),
     }
 }
 
@@ -250,6 +290,23 @@ pub(super) fn list_mutation_records_by_outcome_core(
     for (_key, data) in entries {
         let record: MutationRecord = decode_json(&data, "mutation record")?;
         if record.matches_filter(outcome) {
+            records.push(record);
+        }
+    }
+
+    Ok(records)
+}
+
+pub(super) fn list_mutation_records_for_object_core(
+    object_id: ObjectId,
+    mut scan_prefix: impl FnMut(&str) -> Result<Vec<(String, Vec<u8>)>, StorageError>,
+) -> Result<Vec<MutationRecord>, StorageError> {
+    let entries = scan_prefix(mutation_record_prefix())?;
+    let mut records = Vec::new();
+
+    for (_key, data) in entries {
+        let record: MutationRecord = decode_json(&data, "mutation record")?;
+        if record.object_id == object_id {
             records.push(record);
         }
     }

--- a/crates/jazz-tools/src/storage/storage_core.rs
+++ b/crates/jazz-tools/src/storage/storage_core.rs
@@ -5,14 +5,15 @@ use serde::{Serialize, de::DeserializeOwned};
 
 use crate::commit::{Commit, CommitId};
 use crate::object::{BranchName, ObjectId};
-use crate::sync_manager::DurabilityTier;
+use crate::sync_manager::{DurabilityTier, MutationId, MutationOutcomeFilter, MutationRecord};
 
 use crate::query_manager::types::Value;
 
 use super::key_codec::{
     ack_key, branch_tips_key, catalogue_manifest_op_key, catalogue_manifest_op_prefix, commit_key,
     commit_prefix, index_entry_key, index_prefix, index_range_scan_bounds, index_value_prefix,
-    obj_meta_key, parse_uuid_from_index_key,
+    mutation_commit_index_key, mutation_record_key, mutation_record_prefix, obj_meta_key,
+    parse_uuid_from_index_key,
 };
 use super::{CatalogueManifest, CatalogueManifestOp, LoadedBranch, StorageError};
 
@@ -170,6 +171,90 @@ pub(super) fn store_ack_tier_core(
     tiers.insert(tier);
     let json = encode_json(&tiers, "ack")?;
     set(&key, &json)
+}
+
+pub(super) fn put_mutation_record_core(
+    record: MutationRecord,
+    mut get: impl FnMut(&str) -> Result<Option<Vec<u8>>, StorageError>,
+    mut set: impl FnMut(&str, &[u8]) -> Result<(), StorageError>,
+    mut delete: impl FnMut(&str) -> Result<(), StorageError>,
+) -> Result<(), StorageError> {
+    let record_key = mutation_record_key(record.id);
+
+    if let Some(existing) = get(&record_key)? {
+        let existing_record: MutationRecord = decode_json(&existing, "mutation record")?;
+        for commit_id in existing_record.commit_ids {
+            if !record.commit_ids.contains(&commit_id) {
+                delete(&mutation_commit_index_key(commit_id))?;
+            }
+        }
+    }
+
+    let record_json = encode_json(&record, "mutation record")?;
+    set(&record_key, &record_json)?;
+
+    let mutation_id_json = encode_json(&record.id, "mutation id")?;
+    for &commit_id in &record.commit_ids {
+        let key = mutation_commit_index_key(commit_id);
+        set(&key, &mutation_id_json)?;
+    }
+
+    Ok(())
+}
+
+pub(super) fn load_mutation_record_core(
+    mutation_id: MutationId,
+    mut get: impl FnMut(&str) -> Result<Option<Vec<u8>>, StorageError>,
+) -> Result<Option<MutationRecord>, StorageError> {
+    let key = mutation_record_key(mutation_id);
+    match get(&key)? {
+        Some(data) => Ok(Some(decode_json(&data, "mutation record")?)),
+        None => Ok(None),
+    }
+}
+
+pub(super) fn load_mutation_record_by_commit_core(
+    commit_id: CommitId,
+    mut get: impl FnMut(&str) -> Result<Option<Vec<u8>>, StorageError>,
+) -> Result<Option<MutationRecord>, StorageError> {
+    let commit_key = mutation_commit_index_key(commit_id);
+    let Some(mutation_id_bytes) = get(&commit_key)? else {
+        return Ok(None);
+    };
+    let mutation_id: MutationId = decode_json(&mutation_id_bytes, "mutation id")?;
+    load_mutation_record_core(mutation_id, get)
+}
+
+pub(super) fn delete_mutation_record_core(
+    mutation_id: MutationId,
+    mut get: impl FnMut(&str) -> Result<Option<Vec<u8>>, StorageError>,
+    mut delete: impl FnMut(&str) -> Result<(), StorageError>,
+) -> Result<(), StorageError> {
+    if let Some(record) = load_mutation_record_core(mutation_id, &mut get)? {
+        for commit_id in record.commit_ids {
+            delete(&mutation_commit_index_key(commit_id))?;
+        }
+        delete(&mutation_record_key(mutation_id))?;
+    }
+
+    Ok(())
+}
+
+pub(super) fn list_mutation_records_by_outcome_core(
+    outcome: MutationOutcomeFilter,
+    mut scan_prefix: impl FnMut(&str) -> Result<Vec<(String, Vec<u8>)>, StorageError>,
+) -> Result<Vec<MutationRecord>, StorageError> {
+    let entries = scan_prefix(mutation_record_prefix())?;
+    let mut records = Vec::new();
+
+    for (_key, data) in entries {
+        let record: MutationRecord = decode_json(&data, "mutation record")?;
+        if record.matches_filter(outcome) {
+            records.push(record);
+        }
+    }
+
+    Ok(records)
 }
 
 pub(super) fn append_catalogue_manifest_op_core(

--- a/crates/jazz-tools/src/sync_manager/inbox.rs
+++ b/crates/jazz-tools/src/sync_manager/inbox.rs
@@ -133,6 +133,14 @@ impl SyncManager {
                     }
                 }
             }
+            SyncPayload::MutationOutcome(outcome) => {
+                tracing::debug!(
+                    commits = outcome.commit_ids().len(),
+                    "server→MutationOutcome"
+                );
+                self.received_mutation_outcomes.push(outcome.clone());
+                self.relay_mutation_outcome_to_interested_clients(&outcome, None);
+            }
             SyncPayload::Error(err) => {
                 // Log or handle server error
                 eprintln!("Error from server {:?}: {:?}", server_id, err);
@@ -172,13 +180,15 @@ impl SyncManager {
                     }
                     ClientRole::Backend => {
                         if payload.is_catalogue() {
-                            self.outbox.push(OutboxEntry {
-                                destination: Destination::Client(client_id),
-                                payload: SyncPayload::Error(SyncError::CatalogueWriteDenied {
-                                    object_id,
-                                    branch_name,
-                                }),
-                            });
+                            self.emit_mutation_rejected_from_payload(
+                                client_id,
+                                &payload,
+                                MutationRejectCode::CatalogueWriteDenied,
+                                format!(
+                                    "catalogue write denied for object {} on branch {}",
+                                    object_id, branch_name
+                                ),
+                            );
                             return;
                         }
                         self.apply_payload_from_client(storage, client_id, payload, false);
@@ -186,24 +196,28 @@ impl SyncManager {
                     ClientRole::User => {
                         // User requires session
                         let Some(session) = &client.session else {
-                            self.outbox.push(OutboxEntry {
-                                destination: Destination::Client(client_id),
-                                payload: SyncPayload::Error(SyncError::SessionRequired {
-                                    object_id,
-                                    branch_name,
-                                }),
-                            });
+                            self.emit_mutation_rejected_from_payload(
+                                client_id,
+                                &payload,
+                                MutationRejectCode::SessionRequired,
+                                format!(
+                                    "session required for object {} on branch {}",
+                                    object_id, branch_name
+                                ),
+                            );
                             return;
                         };
                         // User cannot write catalogue objects
                         if payload.is_catalogue() {
-                            self.outbox.push(OutboxEntry {
-                                destination: Destination::Client(client_id),
-                                payload: SyncPayload::Error(SyncError::CatalogueWriteDenied {
-                                    object_id,
-                                    branch_name,
-                                }),
-                            });
+                            self.emit_mutation_rejected_from_payload(
+                                client_id,
+                                &payload,
+                                MutationRejectCode::CatalogueWriteDenied,
+                                format!(
+                                    "catalogue write denied for object {} on branch {}",
+                                    object_id, branch_name
+                                ),
+                            );
                             return;
                         }
                         // Row data — queue for ReBAC permission check
@@ -256,26 +270,30 @@ impl SyncManager {
                     }
                     ClientRole::Backend => {
                         if payload.is_catalogue() {
-                            self.outbox.push(OutboxEntry {
-                                destination: Destination::Client(client_id),
-                                payload: SyncPayload::Error(SyncError::CatalogueWriteDenied {
-                                    object_id,
-                                    branch_name,
-                                }),
-                            });
+                            self.emit_mutation_rejected_from_payload(
+                                client_id,
+                                &payload,
+                                MutationRejectCode::CatalogueWriteDenied,
+                                format!(
+                                    "catalogue write denied for object {} on branch {}",
+                                    object_id, branch_name
+                                ),
+                            );
                             return;
                         }
                         self.apply_payload_from_client(storage, client_id, payload, false);
                     }
                     ClientRole::User => {
                         let Some(session) = &client.session else {
-                            self.outbox.push(OutboxEntry {
-                                destination: Destination::Client(client_id),
-                                payload: SyncPayload::Error(SyncError::SessionRequired {
-                                    object_id,
-                                    branch_name,
-                                }),
-                            });
+                            self.emit_mutation_rejected_from_payload(
+                                client_id,
+                                &payload,
+                                MutationRejectCode::SessionRequired,
+                                format!(
+                                    "session required for object {} on branch {}",
+                                    object_id, branch_name
+                                ),
+                            );
                             return;
                         };
                         let (metadata, old_content) = self
@@ -415,6 +433,10 @@ impl SyncManager {
             } => {
                 // Client relaying a QuerySettled from downstream
                 self.pending_query_settled.push((*query_id, *tier));
+            }
+            SyncPayload::MutationOutcome(outcome) => {
+                self.received_mutation_outcomes.push(outcome.clone());
+                self.relay_mutation_outcome_to_interested_clients(outcome, Some(client_id));
             }
             // Clients shouldn't send these
             SyncPayload::Error(_) => {}

--- a/crates/jazz-tools/src/sync_manager/mod.rs
+++ b/crates/jazz-tools/src/sync_manager/mod.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
-use crate::commit::CommitId;
+use crate::commit::{Commit, CommitId};
 use crate::object::{BranchName, ObjectId};
 use crate::object_manager::ObjectManager;
 use crate::query_manager::query::Query;
@@ -59,6 +59,8 @@ pub struct SyncManager {
 
     /// Acks received during inbox processing, for RuntimeCore to consume.
     pub(super) received_acks: Vec<(CommitId, DurabilityTier)>,
+    /// Mutation outcomes received during inbox processing, for RuntimeCore to consume.
+    pub(super) received_mutation_outcomes: Vec<MutationOutcome>,
 }
 
 impl std::fmt::Debug for SyncManager {
@@ -84,6 +86,10 @@ impl std::fmt::Debug for SyncManager {
             .field("query_origin", &self.query_origin)
             .field("pending_query_settled", &self.pending_query_settled)
             .field("received_acks", &self.received_acks)
+            .field(
+                "received_mutation_outcomes",
+                &self.received_mutation_outcomes,
+            )
             .finish()
     }
 }
@@ -116,6 +122,7 @@ impl SyncManager {
             query_origin: HashMap::new(),
             pending_query_settled: Vec::new(),
             received_acks: Vec::new(),
+            received_mutation_outcomes: Vec::new(),
         }
     }
 
@@ -435,6 +442,11 @@ impl SyncManager {
         std::mem::take(&mut self.received_acks)
     }
 
+    /// Take received mutation outcomes since last call.
+    pub fn take_received_mutation_outcomes(&mut self) -> Vec<MutationOutcome> {
+        std::mem::take(&mut self.received_mutation_outcomes)
+    }
+
     /// Emit a QuerySettled notification to a client.
     ///
     /// Called by QueryManager when a server subscription settles for the first time.
@@ -465,5 +477,107 @@ impl SyncManager {
                 reason: reason.into(),
             }),
         });
+    }
+
+    pub(crate) fn mutation_previous_commit_ids(
+        &self,
+        object_id: ObjectId,
+        branch_name: &BranchName,
+    ) -> Vec<CommitId> {
+        self.object_manager
+            .get_tip_ids(object_id, branch_name.as_str())
+            .map(|tips| tips.iter().copied().collect())
+            .unwrap_or_default()
+    }
+
+    pub(crate) fn emit_mutation_rejected_from_payload(
+        &mut self,
+        client_id: ClientId,
+        payload: &SyncPayload,
+        code: MutationRejectCode,
+        reason: impl Into<String>,
+    ) {
+        let Some(rejection) = self.build_mutation_rejection_from_payload(payload, code, reason)
+        else {
+            return;
+        };
+
+        self.outbox.push(OutboxEntry {
+            destination: Destination::Client(client_id),
+            payload: SyncPayload::MutationOutcome(MutationOutcome::Rejected(rejection)),
+        });
+    }
+
+    pub(crate) fn relay_mutation_outcome_to_interested_clients(
+        &mut self,
+        outcome: &MutationOutcome,
+        exclude_client_id: Option<ClientId>,
+    ) {
+        let mut interested = HashSet::new();
+        for &commit_id in outcome.commit_ids() {
+            if let Some(clients) = self.commit_interest.get(&commit_id) {
+                interested.extend(clients);
+            }
+        }
+
+        if let Some(client_id) = exclude_client_id {
+            interested.remove(&client_id);
+        }
+
+        for client_id in interested {
+            self.outbox.push(OutboxEntry {
+                destination: Destination::Client(client_id),
+                payload: SyncPayload::MutationOutcome(outcome.clone()),
+            });
+        }
+    }
+
+    fn build_mutation_rejection_from_payload(
+        &self,
+        payload: &SyncPayload,
+        code: MutationRejectCode,
+        reason: impl Into<String>,
+    ) -> Option<MutationRejection> {
+        match payload {
+            SyncPayload::ObjectUpdated {
+                object_id,
+                branch_name,
+                commits,
+                ..
+            } => {
+                let previous_commit_ids =
+                    self.mutation_previous_commit_ids(*object_id, branch_name);
+                let operation = if previous_commit_ids.is_empty() {
+                    MutationOperation::Insert
+                } else {
+                    MutationOperation::Update
+                };
+                Some(MutationRejection {
+                    object_id: *object_id,
+                    branch_name: *branch_name,
+                    operation,
+                    commit_ids: commits.iter().map(Commit::id).collect(),
+                    previous_commit_ids,
+                    code,
+                    reason: reason.into(),
+                    rejected_at_micros: current_timestamp_micros(),
+                })
+            }
+            SyncPayload::ObjectTruncated {
+                object_id,
+                branch_name,
+                tails,
+            } => Some(MutationRejection {
+                object_id: *object_id,
+                branch_name: *branch_name,
+                operation: MutationOperation::Delete,
+                commit_ids: tails.iter().copied().collect(),
+                previous_commit_ids: self.mutation_previous_commit_ids(*object_id, branch_name),
+                code,
+                reason: reason.into(),
+                rejected_at_micros: current_timestamp_micros(),
+            }),
+            _ => None,
+        }
     }
 }

--- a/crates/jazz-tools/src/sync_manager/permissions.rs
+++ b/crates/jazz-tools/src/sync_manager/permissions.rs
@@ -29,28 +29,22 @@ impl SyncManager {
     /// This takes the full PendingPermissionCheck since it was already taken
     /// from the queue by take_pending_permission_checks().
     pub fn reject_permission_check(&mut self, check: PendingPermissionCheck, reason: String) {
-        // Extract object_id and branch_name from payload
-        let (object_id, branch_name) = match &check.payload {
-            SyncPayload::ObjectUpdated {
-                object_id,
-                branch_name,
-                ..
-            } => (*object_id, *branch_name),
-            SyncPayload::ObjectTruncated {
-                object_id,
-                branch_name,
-                ..
-            } => (*object_id, *branch_name),
-            _ => return,
+        let Some(operation) = MutationOperation::from_write_operation(check.operation) else {
+            return;
         };
+        let payload = &check.payload;
+        let Some(mut rejection) = self.build_mutation_rejection_from_payload(
+            payload,
+            MutationRejectCode::PermissionDenied,
+            reason,
+        ) else {
+            return;
+        };
+        rejection.operation = operation;
 
         self.outbox.push(OutboxEntry {
             destination: Destination::Client(check.client_id),
-            payload: SyncPayload::Error(SyncError::PermissionDenied {
-                object_id,
-                branch_name,
-                reason,
-            }),
+            payload: SyncPayload::MutationOutcome(MutationOutcome::Rejected(rejection)),
         });
     }
 

--- a/crates/jazz-tools/src/sync_manager/tests.rs
+++ b/crates/jazz-tools/src/sync_manager/tests.rs
@@ -15,6 +15,79 @@ fn can_create_sync_manager() {
     assert!(sm.clients.is_empty());
 }
 
+#[test]
+fn mutation_outcome_payload_roundtrips_json_and_postcard() {
+    let payload = SyncPayload::MutationOutcome(MutationOutcome::Rejected(MutationRejection {
+        object_id: ObjectId::new(),
+        branch_name: "main".into(),
+        operation: MutationOperation::Update,
+        commit_ids: vec![CommitId([1; 32]), CommitId([2; 32])],
+        previous_commit_ids: vec![CommitId([0; 32])],
+        code: MutationRejectCode::PermissionDenied,
+        reason: "denied by policy".into(),
+        rejected_at_micros: 123,
+    }));
+
+    let json = payload.to_json().expect("json encode should succeed");
+    assert_eq!(
+        SyncPayload::from_json(&json).expect("json decode should succeed"),
+        payload
+    );
+
+    let bytes = payload.to_bytes().expect("postcard encode should succeed");
+    assert_eq!(
+        SyncPayload::from_bytes(&bytes).expect("postcard decode should succeed"),
+        payload
+    );
+}
+
+#[test]
+fn server_mutation_outcome_is_queued_and_relayed_to_interested_clients() {
+    let mut sm = SyncManager::new();
+    let mut io = MemoryStorage::new();
+    let server_id = ServerId::new();
+    let client_id = ClientId::new();
+    let commit_id = CommitId([9; 32]);
+
+    sm.add_server(server_id);
+    sm.add_client(client_id);
+    sm.commit_interest
+        .insert(commit_id, std::collections::HashSet::from([client_id]));
+    sm.take_outbox();
+
+    let outcome = MutationOutcome::Rejected(MutationRejection {
+        object_id: ObjectId::new(),
+        branch_name: "main".into(),
+        operation: MutationOperation::Update,
+        commit_ids: vec![commit_id],
+        previous_commit_ids: vec![CommitId([1; 32])],
+        code: MutationRejectCode::PermissionDenied,
+        reason: "denied".into(),
+        rejected_at_micros: 123,
+    });
+
+    sm.push_inbox(InboxEntry {
+        source: Source::Server(server_id),
+        payload: SyncPayload::MutationOutcome(outcome.clone()),
+    });
+    sm.process_inbox(&mut io);
+
+    assert_eq!(sm.take_received_mutation_outcomes(), vec![outcome.clone()]);
+
+    let outbox = sm.take_outbox();
+    assert_eq!(outbox.len(), 1);
+    assert!(matches!(
+        &outbox[0],
+        OutboxEntry {
+            destination: Destination::Client(id),
+            payload: SyncPayload::MutationOutcome(MutationOutcome::Rejected(MutationRejection {
+                code: MutationRejectCode::PermissionDenied,
+                ..
+            })),
+        } if *id == client_id
+    ));
+}
+
 // ========================================================================
 // Phase 2: Server Sync Tests
 // ========================================================================
@@ -768,7 +841,13 @@ fn backend_catalogue_writes_are_denied() {
             entry,
             OutboxEntry {
                 destination: Destination::Client(id),
-                payload: SyncPayload::Error(SyncError::CatalogueWriteDenied { object_id, .. }),
+                payload: SyncPayload::MutationOutcome(MutationOutcome::Rejected(
+                    MutationRejection {
+                        object_id,
+                        code: MutationRejectCode::CatalogueWriteDenied,
+                        ..
+                    }
+                )),
             } if *id == client_id && *object_id == obj_id
         )
     }));
@@ -875,10 +954,12 @@ fn user_without_session_rejected() {
         OutboxEntry {
             destination: Destination::Client(id),
             payload:
-                SyncPayload::Error(SyncError::SessionRequired {
+                SyncPayload::MutationOutcome(MutationOutcome::Rejected(MutationRejection {
                     object_id,
                     branch_name,
-                }),
+                    code: MutationRejectCode::SessionRequired,
+                    ..
+                })),
         } => {
             assert_eq!(*id, client_id);
             assert_eq!(*object_id, obj_id);
@@ -944,10 +1025,12 @@ fn user_catalogue_write_rejected() {
         OutboxEntry {
             destination: Destination::Client(id),
             payload:
-                SyncPayload::Error(SyncError::CatalogueWriteDenied {
+                SyncPayload::MutationOutcome(MutationOutcome::Rejected(MutationRejection {
                     object_id,
                     branch_name,
-                }),
+                    code: MutationRejectCode::CatalogueWriteDenied,
+                    ..
+                })),
         } => {
             assert_eq!(*id, client_id);
             assert_eq!(*object_id, obj_id);
@@ -1181,11 +1264,13 @@ fn reject_permission_check_sends_error() {
         OutboxEntry {
             destination: Destination::Client(id),
             payload:
-                SyncPayload::Error(SyncError::PermissionDenied {
+                SyncPayload::MutationOutcome(MutationOutcome::Rejected(MutationRejection {
                     object_id,
                     branch_name,
                     reason,
-                }),
+                    code: MutationRejectCode::PermissionDenied,
+                    ..
+                })),
         } => {
             assert_eq!(*id, client_id);
             assert_eq!(*object_id, obj_id);

--- a/crates/jazz-tools/src/sync_manager/types.rs
+++ b/crates/jazz-tools/src/sync_manager/types.rs
@@ -2,6 +2,7 @@ use std::collections::{HashMap, HashSet};
 
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
+use web_time::{SystemTime, UNIX_EPOCH};
 
 use crate::commit::{Commit, CommitId};
 use crate::object::{BranchName, ObjectId};
@@ -80,6 +81,28 @@ impl std::fmt::Display for ClientId {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct QueryId(pub u64);
 
+/// Unique identifier for a locally recorded mutation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct MutationId(pub Uuid);
+
+impl MutationId {
+    pub fn new() -> Self {
+        Self(Uuid::now_v7())
+    }
+}
+
+impl Default for MutationId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl std::fmt::Display for MutationId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub enum QueryPropagation {
     #[default]
@@ -100,6 +123,13 @@ pub(super) type BranchSyncData = (
     BranchName,
     HashSet<CommitId>,
 );
+
+pub(crate) fn current_timestamp_micros() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_micros() as u64)
+        .unwrap_or(0)
+}
 
 // ============================================================================
 // Client Roles
@@ -178,6 +208,70 @@ impl ClientState {
 // ============================================================================
 // Errors
 // ============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MutationOperation {
+    Insert,
+    Update,
+    Delete,
+}
+
+impl MutationOperation {
+    pub fn from_write_operation(operation: Operation) -> Option<Self> {
+        match operation {
+            Operation::Insert => Some(Self::Insert),
+            Operation::Update => Some(Self::Update),
+            Operation::Delete => Some(Self::Delete),
+            Operation::Select => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MutationRejectCode {
+    PermissionDenied,
+    SessionRequired,
+    CatalogueWriteDenied,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MutationAcceptance {
+    pub object_id: ObjectId,
+    pub branch_name: BranchName,
+    pub operation: MutationOperation,
+    pub commit_ids: Vec<CommitId>,
+    pub previous_commit_ids: Vec<CommitId>,
+    pub accepted_at_micros: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MutationRejection {
+    pub object_id: ObjectId,
+    pub branch_name: BranchName,
+    pub operation: MutationOperation,
+    pub commit_ids: Vec<CommitId>,
+    pub previous_commit_ids: Vec<CommitId>,
+    pub code: MutationRejectCode,
+    pub reason: String,
+    pub rejected_at_micros: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum MutationOutcome {
+    Accepted(MutationAcceptance),
+    Rejected(MutationRejection),
+}
+
+impl MutationOutcome {
+    pub fn commit_ids(&self) -> &[CommitId] {
+        match self {
+            Self::Accepted(acceptance) => &acceptance.commit_ids,
+            Self::Rejected(rejection) => &rejection.commit_ids,
+        }
+    }
+}
 
 /// Strongly typed errors for sync operations.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -260,6 +354,9 @@ pub enum SyncPayload {
         /// Highest stream sequence known to be emitted before this notification.
         through_seq: u64,
     },
+
+    /// Terminal outcome for a client-originated mutation.
+    MutationOutcome(MutationOutcome),
 
     /// Error response.
     Error(SyncError),
@@ -372,6 +469,7 @@ impl SyncPayload {
             SyncPayload::QueryUnsubscription { .. } => "QueryUnsubscription",
             SyncPayload::PersistenceAck { .. } => "PersistenceAck",
             SyncPayload::QuerySettled { .. } => "QuerySettled",
+            SyncPayload::MutationOutcome(_) => "MutationOutcome",
             SyncPayload::Error(_) => "Error",
         }
     }

--- a/crates/jazz-tools/src/sync_manager/types.rs
+++ b/crates/jazz-tools/src/sync_manager/types.rs
@@ -296,6 +296,12 @@ pub enum ObjectOutcomeState {
     },
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ObjectOutcomeEvent {
+    pub object_id: ObjectId,
+    pub outcome: Option<ObjectOutcomeState>,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum MutationOutcomeFilter {

--- a/crates/jazz-tools/src/sync_manager/types.rs
+++ b/crates/jazz-tools/src/sync_manager/types.rs
@@ -273,6 +273,83 @@ impl MutationOutcome {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum MutationOutcomeState {
+    Pending,
+    Accepted,
+    Rejected(MutationRejection),
+    SupersededByRejection { root_mutation_id: MutationId },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MutationOutcomeFilter {
+    Pending,
+    Accepted,
+    Rejected,
+    SupersededByRejection,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MutationRecord {
+    pub id: MutationId,
+    pub object_id: ObjectId,
+    pub branch_name: BranchName,
+    pub table: Option<String>,
+    pub operation: MutationOperation,
+    pub commit_ids: Vec<CommitId>,
+    pub previous_commit_ids: Vec<CommitId>,
+    pub recorded_at_micros: u64,
+    pub highest_acked_tier: Option<DurabilityTier>,
+    pub outcome: MutationOutcomeState,
+}
+
+impl MutationRecord {
+    pub fn matches_filter(&self, filter: MutationOutcomeFilter) -> bool {
+        matches!(
+            (&self.outcome, filter),
+            (
+                MutationOutcomeState::Pending,
+                MutationOutcomeFilter::Pending
+            ) | (
+                MutationOutcomeState::Accepted,
+                MutationOutcomeFilter::Accepted
+            ) | (
+                MutationOutcomeState::Rejected(_),
+                MutationOutcomeFilter::Rejected
+            ) | (
+                MutationOutcomeState::SupersededByRejection { .. },
+                MutationOutcomeFilter::SupersededByRejection
+            )
+        )
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MutationEvent {
+    Recorded {
+        mutation_id: MutationId,
+    },
+    AckAdvanced {
+        mutation_id: MutationId,
+        tier: DurabilityTier,
+    },
+    Accepted {
+        mutation_id: MutationId,
+    },
+    Rejected {
+        mutation_id: MutationId,
+        rejection: MutationRejection,
+    },
+    SupersededByRejection {
+        mutation_id: MutationId,
+        root_mutation_id: MutationId,
+    },
+    Acknowledged {
+        mutation_id: MutationId,
+    },
+}
+
 /// Strongly typed errors for sync operations.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum SyncError {

--- a/crates/jazz-tools/src/sync_manager/types.rs
+++ b/crates/jazz-tools/src/sync_manager/types.rs
@@ -281,6 +281,21 @@ pub enum MutationOutcomeState {
     SupersededByRejection { root_mutation_id: MutationId },
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ObjectOutcomeState {
+    Pending {
+        mutation_id: MutationId,
+    },
+    Accepted {
+        mutation_id: MutationId,
+    },
+    Errored {
+        mutation_id: MutationId,
+        code: MutationRejectCode,
+        reason: String,
+    },
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum MutationOutcomeFilter {

--- a/crates/jazz-wasm/src/runtime.rs
+++ b/crates/jazz-wasm/src/runtime.rs
@@ -579,6 +579,12 @@ impl WasmRuntime {
         self.core.borrow().sync_sender().set_callback(callback);
     }
 
+    /// Enable or disable local mutation journal ownership for this runtime.
+    #[wasm_bindgen(js_name = setMutationJournalEnabled)]
+    pub fn set_mutation_journal_enabled(&self, enabled: bool) {
+        self.core.borrow_mut().set_mutation_journal_enabled(enabled);
+    }
+
     // =========================================================================
     // CRUD Operations
     // =========================================================================

--- a/crates/jazz-wasm/src/runtime.rs
+++ b/crates/jazz-wasm/src/runtime.rs
@@ -76,8 +76,8 @@ use jazz_tools::storage::OpfsBTreeStorage;
 use jazz_tools::storage::{MemoryStorage, Storage};
 use jazz_tools::sync_manager::QueryPropagation;
 use jazz_tools::sync_manager::{
-    ClientId, Destination, DurabilityTier, InboxEntry, OutboxEntry, ServerId, Source, SyncManager,
-    SyncPayload,
+    ClientId, Destination, DurabilityTier, InboxEntry, MutationId, ObjectOutcomeEvent,
+    ObjectOutcomeState, OutboxEntry, ServerId, Source, SyncManager, SyncPayload,
 };
 
 use crate::query::parse_query;
@@ -87,6 +87,7 @@ use crate::types::{
     SubscriptionRowAdded, SubscriptionRowChange, SubscriptionRowDelta, SubscriptionRowRemoved,
     SubscriptionRowUpdated,
 };
+use crate::types::{WasmObjectOutcomeEvent, WasmObjectOutcomeState};
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -115,6 +116,39 @@ fn parse_tier(tier: &str) -> Result<DurabilityTier, JsError> {
             "Invalid tier '{}'. Must be 'worker', 'edge', or 'global'.",
             tier
         ))),
+    }
+}
+
+fn parse_mutation_id(mutation_id: &str) -> Result<MutationId, JsError> {
+    uuid::Uuid::parse_str(mutation_id)
+        .map(MutationId)
+        .map_err(|e| JsError::new(&format!("Invalid MutationId: {}", e)))
+}
+
+fn object_outcome_state_to_wasm(outcome: ObjectOutcomeState) -> WasmObjectOutcomeState {
+    match outcome {
+        ObjectOutcomeState::Pending { mutation_id } => WasmObjectOutcomeState::Pending {
+            mutation_id: mutation_id.to_string(),
+        },
+        ObjectOutcomeState::Accepted { mutation_id } => WasmObjectOutcomeState::Accepted {
+            mutation_id: mutation_id.to_string(),
+        },
+        ObjectOutcomeState::Errored {
+            mutation_id,
+            code,
+            reason,
+        } => WasmObjectOutcomeState::Errored {
+            mutation_id: mutation_id.to_string(),
+            code,
+            reason,
+        },
+    }
+}
+
+fn object_outcome_event_to_wasm(event: ObjectOutcomeEvent) -> WasmObjectOutcomeEvent {
+    WasmObjectOutcomeEvent {
+        object_id: event.object_id.uuid().to_string(),
+        outcome: event.outcome.map(object_outcome_state_to_wasm),
     }
 }
 
@@ -583,6 +617,49 @@ impl WasmRuntime {
     #[wasm_bindgen(js_name = setMutationJournalEnabled)]
     pub fn set_mutation_journal_enabled(&self, enabled: bool) {
         self.core.borrow_mut().set_mutation_journal_enabled(enabled);
+    }
+
+    /// List the current object-outcome overlays for all tracked objects.
+    #[wasm_bindgen(js_name = listObjectOutcomes)]
+    pub fn list_object_outcomes(&self) -> Result<JsValue, JsError> {
+        let outcomes = self
+            .core
+            .borrow()
+            .list_object_outcomes()
+            .map_err(|e| JsError::new(&format!("List object outcomes failed: {:?}", e)))?
+            .into_iter()
+            .map(object_outcome_event_to_wasm)
+            .collect::<Vec<_>>();
+        let serializer = serde_wasm_bindgen::Serializer::new().serialize_maps_as_objects(true);
+        outcomes
+            .serialize(&serializer)
+            .map_err(|e| JsError::new(&format!("Serialization failed: {:?}", e)))
+    }
+
+    /// Take object-outcome change events received since the last call.
+    #[wasm_bindgen(js_name = takeObjectOutcomeEvents)]
+    pub fn take_object_outcome_events(&self) -> Result<JsValue, JsError> {
+        let events = self
+            .core
+            .borrow_mut()
+            .take_object_outcome_events()
+            .into_iter()
+            .map(object_outcome_event_to_wasm)
+            .collect::<Vec<_>>();
+        let serializer = serde_wasm_bindgen::Serializer::new().serialize_maps_as_objects(true);
+        events
+            .serialize(&serializer)
+            .map_err(|e| JsError::new(&format!("Serialization failed: {:?}", e)))
+    }
+
+    /// Acknowledge a surfaced mutation outcome and prune the retained dead commits.
+    #[wasm_bindgen(js_name = acknowledgeMutationOutcome)]
+    pub fn acknowledge_mutation_outcome(&self, mutation_id: &str) -> Result<(), JsError> {
+        let mutation_id = parse_mutation_id(mutation_id)?;
+        self.core
+            .borrow_mut()
+            .acknowledge_mutation_outcome(mutation_id)
+            .map_err(|e| JsError::new(&format!("Acknowledge mutation outcome failed: {:?}", e)))
     }
 
     // =========================================================================

--- a/crates/jazz-wasm/src/runtime.rs
+++ b/crates/jazz-wasm/src/runtime.rs
@@ -65,7 +65,9 @@ use jazz_tools::query_manager::session::Session;
 #[cfg(target_arch = "wasm32")]
 use jazz_tools::query_manager::types::{Row, RowDescriptor};
 use jazz_tools::query_manager::types::{Schema, SchemaHash, Value};
-use jazz_tools::runtime_core::{ReadDurabilityOptions, RuntimeCore, Scheduler, SyncSender};
+use jazz_tools::runtime_core::{
+    PersistedMutationError, ReadDurabilityOptions, RuntimeCore, Scheduler, SyncSender,
+};
 #[cfg(target_arch = "wasm32")]
 use jazz_tools::runtime_core::{SubscriptionDelta, SubscriptionHandle};
 #[cfg(target_arch = "wasm32")]
@@ -88,6 +90,23 @@ use crate::types::{
     SubscriptionRowUpdated,
 };
 use crate::types::{WasmObjectOutcomeEvent, WasmObjectOutcomeState};
+
+const PERSISTED_MUTATION_ERROR_CAUSE_PREFIX: &str = "__jazzPersistedMutationError__:";
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct WasmPersistedMutationErrorPayload {
+    mutation_id: String,
+    root_mutation_id: String,
+    object_id: String,
+    branch_name: String,
+    operation: String,
+    commit_ids: Vec<String>,
+    previous_commit_ids: Vec<String>,
+    code: String,
+    reason: String,
+    rejected_at_micros: u64,
+}
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -150,6 +169,76 @@ fn object_outcome_event_to_wasm(event: ObjectOutcomeEvent) -> WasmObjectOutcomeE
         object_id: event.object_id.uuid().to_string(),
         outcome: event.outcome.map(object_outcome_state_to_wasm),
     }
+}
+
+fn encode_commit_id_hex(bytes: [u8; 32]) -> String {
+    bytes.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+fn persisted_mutation_error_payload(
+    error: PersistedMutationError,
+) -> WasmPersistedMutationErrorPayload {
+    let rejection = error.rejection;
+    WasmPersistedMutationErrorPayload {
+        mutation_id: error.mutation_id.to_string(),
+        root_mutation_id: error.root_mutation_id.to_string(),
+        object_id: rejection.object_id.uuid().to_string(),
+        branch_name: rejection.branch_name.to_string(),
+        operation: serde_json::to_string(&rejection.operation)
+            .unwrap_or_else(|_| "\"update\"".to_string())
+            .trim_matches('"')
+            .to_string(),
+        commit_ids: rejection
+            .commit_ids
+            .into_iter()
+            .map(|commit_id| encode_commit_id_hex(commit_id.0))
+            .collect(),
+        previous_commit_ids: rejection
+            .previous_commit_ids
+            .into_iter()
+            .map(|commit_id| encode_commit_id_hex(commit_id.0))
+            .collect(),
+        code: serde_json::to_string(&rejection.code)
+            .unwrap_or_else(|_| "\"permission_denied\"".to_string())
+            .trim_matches('"')
+            .to_string(),
+        reason: rejection.reason,
+        rejected_at_micros: rejection.rejected_at_micros,
+    }
+}
+
+fn persisted_mutation_error_to_js_value(error: PersistedMutationError) -> JsValue {
+    let payload = persisted_mutation_error_payload(error);
+    let js_error = js_sys::Error::new(&format!(
+        "mutation {} rejected: {}",
+        payload.mutation_id, payload.reason
+    ));
+    let _ = js_sys::Reflect::set(
+        js_error.as_ref(),
+        &JsValue::from_str("name"),
+        &JsValue::from_str("PersistedMutationError"),
+    );
+
+    if let Ok(payload_value) = serde_wasm_bindgen::to_value(&payload) {
+        let _ = js_sys::Reflect::set(
+            js_error.as_ref(),
+            &JsValue::from_str("jazzPersistedMutationError"),
+            &payload_value,
+        );
+    }
+
+    let cause_payload = serde_json::to_string(&payload).unwrap_or_else(|_| "{}".to_string());
+    let cause = js_sys::Error::new(&format!(
+        "{}{}",
+        PERSISTED_MUTATION_ERROR_CAUSE_PREFIX, cause_payload
+    ));
+    let _ = js_sys::Reflect::set(
+        js_error.as_ref(),
+        &JsValue::from_str("cause"),
+        cause.as_ref(),
+    );
+
+    js_error.into()
 }
 
 fn parse_session_json(session_json: Option<String>) -> Result<Option<Session>, JsError> {
@@ -837,7 +926,7 @@ impl WasmRuntime {
             receiver
                 .await
                 .map_err(|_| JsValue::from_str("Insert durable waiter cancelled"))?
-                .map_err(|err| JsValue::from_str(&err.to_string()))?;
+                .map_err(persisted_mutation_error_to_js_value)?;
             let serializer = serde_wasm_bindgen::Serializer::new().serialize_maps_as_objects(true);
             row.serialize(&serializer)
                 .map_err(|e| JsValue::from_str(&format!("Serialization failed: {:?}", e)))
@@ -873,7 +962,7 @@ impl WasmRuntime {
             receiver
                 .await
                 .map_err(|_| JsValue::from_str("Update durable waiter cancelled"))?
-                .map_err(|err| JsValue::from_str(&err.to_string()))?;
+                .map_err(persisted_mutation_error_to_js_value)?;
             Ok(JsValue::undefined())
         });
 
@@ -899,7 +988,7 @@ impl WasmRuntime {
             receiver
                 .await
                 .map_err(|_| JsValue::from_str("Delete durable waiter cancelled"))?
-                .map_err(|err| JsValue::from_str(&err.to_string()))?;
+                .map_err(persisted_mutation_error_to_js_value)?;
             Ok(JsValue::undefined())
         });
 

--- a/crates/jazz-wasm/src/runtime.rs
+++ b/crates/jazz-wasm/src/runtime.rs
@@ -757,7 +757,10 @@ impl WasmRuntime {
             values: row_values,
         };
         let promise = wasm_bindgen_futures::future_to_promise(async move {
-            let _ = receiver.await;
+            receiver
+                .await
+                .map_err(|_| JsValue::from_str("Insert durable waiter cancelled"))?
+                .map_err(|err| JsValue::from_str(&err.to_string()))?;
             let serializer = serde_wasm_bindgen::Serializer::new().serialize_maps_as_objects(true);
             row.serialize(&serializer)
                 .map_err(|e| JsValue::from_str(&format!("Serialization failed: {:?}", e)))
@@ -790,7 +793,10 @@ impl WasmRuntime {
         };
 
         let promise = wasm_bindgen_futures::future_to_promise(async move {
-            let _ = receiver.await;
+            receiver
+                .await
+                .map_err(|_| JsValue::from_str("Update durable waiter cancelled"))?
+                .map_err(|err| JsValue::from_str(&err.to_string()))?;
             Ok(JsValue::undefined())
         });
 
@@ -813,7 +819,10 @@ impl WasmRuntime {
         };
 
         let promise = wasm_bindgen_futures::future_to_promise(async move {
-            let _ = receiver.await;
+            receiver
+                .await
+                .map_err(|_| JsValue::from_str("Delete durable waiter cancelled"))?
+                .map_err(|err| JsValue::from_str(&err.to_string()))?;
             Ok(JsValue::undefined())
         });
 

--- a/crates/jazz-wasm/src/types.rs
+++ b/crates/jazz-wasm/src/types.rs
@@ -1,12 +1,38 @@
 //! Shared boundary types used at the WASM boundary.
 
+use serde::Serialize;
+
 pub use jazz_tools::query_manager::policy::{
     CmpOp, Operation as PolicyOperation, PolicyExpr, PolicyValue,
 };
 pub use jazz_tools::query_manager::types::{
     ColumnDescriptor, ColumnType, OperationPolicy, Schema, TablePolicies, TableSchema, Value,
 };
+use jazz_tools::sync_manager::MutationRejectCode;
 pub use jazz_tools::wire_types::{
     SubscriptionRow, SubscriptionRowAdded, SubscriptionRowChange, SubscriptionRowDelta,
     SubscriptionRowRemoved, SubscriptionRowUpdated,
 };
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum WasmObjectOutcomeState {
+    Pending {
+        mutation_id: String,
+    },
+    Accepted {
+        mutation_id: String,
+    },
+    Errored {
+        mutation_id: String,
+        code: MutationRejectCode,
+        reason: String,
+    },
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WasmObjectOutcomeEvent {
+    pub object_id: String,
+    pub outcome: Option<WasmObjectOutcomeState>,
+}

--- a/docs/content/docs/reading-data.mdx
+++ b/docs/content/docs/reading-data.mdx
@@ -246,6 +246,22 @@ Permission introspection columns are computed for the current session and are om
   ../examples/docs/todo-client-localfirst-ts/src/docs-snippets.ts#reading-magic-columns-ts
 </include>
 
+### Mutation Outcome Overlays
+
+Visible rows may also carry a transient `$outcome` overlay when the local-first client is still
+tracking a mutation outcome for that object.
+
+- `pending`: the local mutation has been created but not yet accepted or rejected by the authority
+- `accepted`: the authority accepted the mutation and the client has not compacted the transient outcome yet
+- `errored`: the authority rejected the mutation; includes rejection details plus `acknowledge()`
+
+`$outcome` is attached automatically to returned rows. It is not queryable through
+`where(...)`, `orderBy(...)`, or `select(...)`.
+
+<include cwd lang="ts">
+  ../examples/docs/todo-client-localfirst-ts/src/docs-snippets.ts#reading-outcome-overlays-ts
+</include>
+
 ## Advanced: Recursive Queries
 
 Recursive queries compute bounded transitive closures from a seed row set.

--- a/docs/content/docs/writing-data.mdx
+++ b/docs/content/docs/writing-data.mdx
@@ -13,6 +13,26 @@ That keeps UI latency low because local state updates do not wait for any networ
 `insertDurable`, `updateDurable`, and `deleteDurable` return promises that
 resolve when the requested durability tier is reached.
 
+## Delayed Mutation Rejections
+
+Because Jazz is local-first, a write can be rejected long after the original mutation was created.
+The common case is a permission rejection that arrives after offline work is replayed.
+
+`insertDurable`, `updateDurable`, and `deleteDurable` also reject their promise if the authority
+later rejects the mutation.
+
+Recommended app pattern:
+
+- For visible rows, render the row-level `$outcome` overlay documented in [Reading Data](/docs/reading-data#mutation-outcome-overlays).
+- For invisible rows, subscribe to the global object-outcome stream and surface toasts, inbox items, or badges.
+
+When an outcome is rejected, call `acknowledge()` after the user has seen or handled it. That clears
+the surfaced issue and lets the persistence-owning client prune the rejected local commit chain.
+
+<include cwd lang="ts">
+  ../examples/docs/todo-client-localfirst-ts/src/docs-snippets.ts#writing-outcome-events-ts
+</include>
+
 ## Mutating from Framework Context
 
 Use the framework context binding to access the shared `Db` instance and execute mutations.

--- a/examples/docs/todo-client-localfirst-ts/schema/app.ts
+++ b/examples/docs/todo-client-localfirst-ts/schema/app.ts
@@ -1,5 +1,5 @@
 // AUTO-GENERATED FILE - DO NOT EDIT
-import type { WasmSchema, QueryBuilder } from "jazz-tools";
+import type { WasmSchema, QueryBuilder, ObjectOutcomeState } from "jazz-tools";
 export type JsonValue = string | number | boolean | null | { [key: string]: JsonValue } | JsonValue[];
 
 export type PermissionIntrospectionColumn = "$canRead" | "$canEdit" | "$canDelete";
@@ -9,12 +9,18 @@ export interface PermissionIntrospectionColumns {
   $canDelete: boolean | null;
 }
 
-export interface Project {
+export type MutationOutcomeState = ObjectOutcomeState;
+export interface MutationOutcomeColumns {
+  $outcome?: MutationOutcomeState;
+}
+export type VisibleRowColumns<T> = Exclude<keyof T, keyof MutationOutcomeColumns>;
+
+export interface Project extends MutationOutcomeColumns {
   id: string;
   name: string;
 }
 
-export interface Todo {
+export interface Todo extends MutationOutcomeColumns {
   id: string;
   title: string;
   done: boolean;
@@ -132,19 +138,19 @@ export type ProjectWithIncludes<I extends ProjectInclude = {}> = Omit<Project, E
 
 export type TodoWithIncludes<I extends TodoInclude = {}> = Omit<Todo, Extract<keyof I, keyof Todo>> & TodoIncludedRelations<I>;
 
-export type ProjectSelectableColumn = keyof Project | PermissionIntrospectionColumn | "*";
-export type ProjectOrderableColumn = keyof Project | PermissionIntrospectionColumn;
+export type ProjectSelectableColumn = VisibleRowColumns<Project> | PermissionIntrospectionColumn | "*";
+export type ProjectOrderableColumn = VisibleRowColumns<Project> | PermissionIntrospectionColumn;
 
-export type ProjectSelected<S extends ProjectSelectableColumn = keyof Project> = "*" extends S ? Project : Pick<Project, Extract<S | "id", keyof Project>> & Pick<PermissionIntrospectionColumns, Extract<S, PermissionIntrospectionColumn>>;
+export type ProjectSelected<S extends ProjectSelectableColumn = VisibleRowColumns<Project>> = "*" extends S ? Project : Pick<Project, Extract<S | "id", keyof Project>> & Pick<PermissionIntrospectionColumns, Extract<S, PermissionIntrospectionColumn>> & MutationOutcomeColumns;
 
-export type ProjectSelectedWithIncludes<I extends ProjectInclude = {}, S extends ProjectSelectableColumn = keyof Project> = Omit<ProjectSelected<S>, Extract<keyof I, keyof ProjectSelected<S>>> & ProjectIncludedRelations<I>;
+export type ProjectSelectedWithIncludes<I extends ProjectInclude = {}, S extends ProjectSelectableColumn = VisibleRowColumns<Project>> = Omit<ProjectSelected<S>, Extract<keyof I, keyof ProjectSelected<S>>> & ProjectIncludedRelations<I>;
 
-export type TodoSelectableColumn = keyof Todo | PermissionIntrospectionColumn | "*";
-export type TodoOrderableColumn = keyof Todo | PermissionIntrospectionColumn;
+export type TodoSelectableColumn = VisibleRowColumns<Todo> | PermissionIntrospectionColumn | "*";
+export type TodoOrderableColumn = VisibleRowColumns<Todo> | PermissionIntrospectionColumn;
 
-export type TodoSelected<S extends TodoSelectableColumn = keyof Todo> = "*" extends S ? Todo : Pick<Todo, Extract<S | "id", keyof Todo>> & Pick<PermissionIntrospectionColumns, Extract<S, PermissionIntrospectionColumn>>;
+export type TodoSelected<S extends TodoSelectableColumn = VisibleRowColumns<Todo>> = "*" extends S ? Todo : Pick<Todo, Extract<S | "id", keyof Todo>> & Pick<PermissionIntrospectionColumns, Extract<S, PermissionIntrospectionColumn>> & MutationOutcomeColumns;
 
-export type TodoSelectedWithIncludes<I extends TodoInclude = {}, S extends TodoSelectableColumn = keyof Todo> = Omit<TodoSelected<S>, Extract<keyof I, keyof TodoSelected<S>>> & TodoIncludedRelations<I>;
+export type TodoSelectedWithIncludes<I extends TodoInclude = {}, S extends TodoSelectableColumn = VisibleRowColumns<Todo>> = Omit<TodoSelected<S>, Extract<keyof I, keyof TodoSelected<S>>> & TodoIncludedRelations<I>;
 
 export const wasmSchema: WasmSchema = {
   "projects": {
@@ -226,7 +232,7 @@ export const wasmSchema: WasmSchema = {
   }
 };
 
-export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends ProjectSelectableColumn = keyof Project> implements QueryBuilder<ProjectSelectedWithIncludes<I, S>> {
+export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends ProjectSelectableColumn = VisibleRowColumns<Project>> implements QueryBuilder<ProjectSelectedWithIncludes<I, S>> {
   readonly _table = "projects";
   readonly _schema: WasmSchema = wasmSchema;
   declare readonly _rowType: ProjectSelectedWithIncludes<I, S>;
@@ -414,7 +420,7 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
   }
 }
 
-export class TodoQueryBuilder<I extends TodoInclude = {}, S extends TodoSelectableColumn = keyof Todo> implements QueryBuilder<TodoSelectedWithIncludes<I, S>> {
+export class TodoQueryBuilder<I extends TodoInclude = {}, S extends TodoSelectableColumn = VisibleRowColumns<Todo>> implements QueryBuilder<TodoSelectedWithIncludes<I, S>> {
   readonly _table = "todos";
   readonly _schema: WasmSchema = wasmSchema;
   declare readonly _rowType: TodoSelectedWithIncludes<I, S>;

--- a/examples/docs/todo-client-localfirst-ts/src/docs-snippets.ts
+++ b/examples/docs/todo-client-localfirst-ts/src/docs-snippets.ts
@@ -2,7 +2,6 @@ import type { Db } from "jazz-tools";
 import { app } from "../schema/app.js";
 
 const EXAMPLE_PROJECT_ID = "00000000-0000-0000-0000-000000000000";
-const EXAMPLE_OWNER_ID = "local:example-owner";
 
 // #region reading-oneshot-ts
 export async function readTodosOneshot(db: Db) {
@@ -86,6 +85,47 @@ export async function readDeletableTodos(db: Db) {
 }
 // #endregion reading-magic-columns-ts
 
+// #region reading-outcome-overlays-ts
+type VisibleTodo = Awaited<ReturnType<typeof readTodosOneshot>>[number];
+
+export function subscribeTodosWithOutcomeStatus(
+  db: Db,
+  onRows: (
+    rows: Array<{
+      id: string;
+      title: string;
+      status: "idle" | "saving" | "synced" | "error";
+      message?: string;
+    }>,
+  ) => void,
+) {
+  return db.subscribeAll(app.todos.orderBy("title", "asc"), ({ all }) => {
+    onRows(
+      all.map((todo) => ({
+        id: todo.id,
+        title: todo.title,
+        status:
+          todo.$outcome?.type === "pending"
+            ? "saving"
+            : todo.$outcome?.type === "accepted"
+              ? "synced"
+              : todo.$outcome?.type === "errored"
+                ? "error"
+                : "idle",
+        message: todo.$outcome?.type === "errored" ? todo.$outcome.reason : undefined,
+      })),
+    );
+  });
+}
+
+export async function acknowledgeVisibleTodoOutcome(todo: VisibleTodo) {
+  if (todo.$outcome?.type !== "errored") {
+    return;
+  }
+  await todo.$outcome.acknowledge();
+}
+// #endregion reading-outcome-overlays-ts
+
 // #region reading-recursive-ts
 export function buildTodoLineageQuery() {
   return app.todos.gather({
@@ -101,7 +141,6 @@ export async function writeTodoCrud(db: Db, todoId: string) {
   db.insert(app.todos, {
     title: "Write docs",
     done: false,
-    owner_id: EXAMPLE_OWNER_ID,
     project: EXAMPLE_PROJECT_ID,
   });
   db.update(app.todos, todoId, { done: true });
@@ -116,7 +155,6 @@ export async function writeTodoWithDurabilityTiers(db: Db) {
     {
       title: "Write docs with durability tier",
       done: false,
-      owner_id: EXAMPLE_OWNER_ID,
       project: EXAMPLE_PROJECT_ID,
     },
     { tier: "edge" },
@@ -126,3 +164,29 @@ export async function writeTodoWithDurabilityTiers(db: Db) {
   await db.deleteDurable(app.todos, id, { tier: "global" });
 }
 // #endregion writing-durability-tier-ts
+
+// #region writing-outcome-events-ts
+export function subscribeMutationOutcomeToasts(
+  db: Db,
+  showToast: (toast: {
+    objectId: string;
+    message: string;
+    acknowledge: () => Promise<void>;
+  }) => void,
+) {
+  return db.onObjectOutcomeEvents((events) => {
+    for (const event of events) {
+      const outcome = event.outcome;
+      if (!outcome || outcome.type !== "errored") {
+        continue;
+      }
+
+      showToast({
+        objectId: event.objectId,
+        message: outcome.reason,
+        acknowledge: () => outcome.acknowledge(),
+      });
+    }
+  });
+}
+// #endregion writing-outcome-events-ts

--- a/packages/jazz-tools/src/codegen/codegen.test.ts
+++ b/packages/jazz-tools/src/codegen/codegen.test.ts
@@ -337,9 +337,12 @@ describe("generateTypes", () => {
     const wasm = schemaToWasm(schema);
     const output = generateTypes(wasm);
 
-    expect(output).toContain("export interface Todo {");
+    expect(output).toContain("export type MutationOutcomeState = ObjectOutcomeState;");
+    expect(output).toContain("export interface MutationOutcomeColumns {");
+    expect(output).toContain("export interface Todo extends MutationOutcomeColumns {");
     expect(output).toContain("  id: string;");
     expect(output).toContain("  title: string;");
+    expect(output).toContain("  $outcome?: MutationOutcomeState;");
   });
 
   it("generates init interface without id field", () => {
@@ -375,7 +378,7 @@ describe("generateTypes", () => {
     const wasm = schemaToWasm(schema);
     const output = generateTypes(wasm);
 
-    expect(output).toContain("export interface UserProfile {");
+    expect(output).toContain("export interface UserProfile extends MutationOutcomeColumns {");
     expect(output).toContain("export interface UserProfileInit {");
   });
 
@@ -385,7 +388,7 @@ describe("generateTypes", () => {
     const wasm = schemaToWasm(schema);
     const output = generateTypes(wasm);
 
-    expect(output).toContain("export interface Category {");
+    expect(output).toContain("export interface Category extends MutationOutcomeColumns {");
     expect(output).toContain("export interface CategoryInit {");
   });
 
@@ -405,7 +408,7 @@ describe("generateTypes", () => {
     const wasm = schemaToWasm(schema);
     const output = generateTypes(wasm);
 
-    expect(output).toContain(`export interface ${expected} {`);
+    expect(output).toContain(`export interface ${expected} extends MutationOutcomeColumns {`);
     expect(output).toContain(`export interface ${expected}Init {`);
   });
 
@@ -492,7 +495,7 @@ describe("generateTypes", () => {
     const output = generateTypes(wasm);
 
     expect(output).toContain(
-      'import type { WasmSchema, QueryBuilder, JsonSchemaToTs } from "jazz-tools";',
+      'import type { WasmSchema, QueryBuilder, ObjectOutcomeState, JsonSchemaToTs } from "jazz-tools";',
     );
     expect(output).toContain("const __jsonSchema1 =");
     expect(output).toContain("type __JsonType1 = JsonSchemaToTs<typeof __jsonSchema1>;");
@@ -517,7 +520,9 @@ describe("generateTypes", () => {
     const wasm = schemaToWasm(schema);
     const output = generateTypes(wasm);
 
-    expect(output).toContain('import type { WasmSchema, QueryBuilder } from "jazz-tools";');
+    expect(output).toContain(
+      'import type { WasmSchema, QueryBuilder, ObjectOutcomeState } from "jazz-tools";',
+    );
   });
 
   it("includes auto-generated header comment", () => {
@@ -546,10 +551,12 @@ describe("generateClient", () => {
 
     // Header
     expect(output).toContain("// AUTO-GENERATED FILE - DO NOT EDIT");
-    expect(output).toContain('import type { WasmSchema, QueryBuilder } from "jazz-tools";');
+    expect(output).toContain(
+      'import type { WasmSchema, QueryBuilder, ObjectOutcomeState } from "jazz-tools";',
+    );
 
     // Base interface
-    expect(output).toContain("export interface Todo {");
+    expect(output).toContain("export interface Todo extends MutationOutcomeColumns {");
     expect(output).toContain("  id: string;");
     expect(output).toContain("  title: string;");
     expect(output).toContain("  done: boolean;");
@@ -865,23 +872,23 @@ describe("generateTypes with relations", () => {
     const output = generateTypes(wasm);
 
     expect(output).toContain(
-      'export type TodoSelectableColumn = keyof Todo | PermissionIntrospectionColumn | "*"',
+      'export type TodoSelectableColumn = VisibleRowColumns<Todo> | PermissionIntrospectionColumn | "*"',
     );
     expect(output).toContain(
-      "export type TodoOrderableColumn = keyof Todo | PermissionIntrospectionColumn",
+      "export type TodoOrderableColumn = VisibleRowColumns<Todo> | PermissionIntrospectionColumn",
     );
     expect(output).toContain("export interface PermissionIntrospectionColumns {");
     expect(output).toContain("  $canRead: boolean | null;");
     expect(output).toContain("  $canEdit: boolean | null;");
     expect(output).toContain("  $canDelete: boolean | null;");
     expect(output).toContain(
-      "export type TodoSelected<S extends TodoSelectableColumn = keyof Todo>",
+      "export type TodoSelected<S extends TodoSelectableColumn = VisibleRowColumns<Todo>>",
     );
     expect(output).toContain(
-      '"*" extends S ? Todo : Pick<Todo, Extract<S | "id", keyof Todo>> & Pick<PermissionIntrospectionColumns, Extract<S, PermissionIntrospectionColumn>>',
+      '"*" extends S ? Todo : Pick<Todo, Extract<S | "id", keyof Todo>> & Pick<PermissionIntrospectionColumns, Extract<S, PermissionIntrospectionColumn>> & MutationOutcomeColumns',
     );
     expect(output).toContain(
-      "export type TodoSelectedWithIncludes<I extends TodoInclude = {}, S extends TodoSelectableColumn = keyof Todo>",
+      "export type TodoSelectedWithIncludes<I extends TodoInclude = {}, S extends TodoSelectableColumn = VisibleRowColumns<Todo>>",
     );
     expect(output).toContain(
       "Omit<TodoSelected<S>, Extract<keyof I, keyof TodoSelected<S>>> & TodoIncludedRelations<I>",
@@ -933,7 +940,7 @@ describe("generateTypes with relations", () => {
     const output = generateTypes(wasm);
 
     // Should still have base and init types
-    expect(output).toContain("export interface Item {");
+    expect(output).toContain("export interface Item extends MutationOutcomeColumns {");
     expect(output).toContain("export interface ItemInit {");
 
     // Should NOT have Include/Relations/WithIncludes since no relations
@@ -1035,7 +1042,7 @@ describe("generateQueryBuilderClasses", () => {
     const output = generateTypes(wasm);
 
     expect(output).toContain(
-      "export class TodoQueryBuilder<I extends Record<string, never> = {}, S extends TodoSelectableColumn = keyof Todo> implements QueryBuilder<TodoSelected<S>> {",
+      "export class TodoQueryBuilder<I extends Record<string, never> = {}, S extends TodoSelectableColumn = VisibleRowColumns<Todo>> implements QueryBuilder<TodoSelected<S>> {",
     );
     expect(output).toContain("declare readonly _rowType: TodoSelected<S>;");
     expect(output).toContain("declare readonly _initType: TodoInit;");
@@ -1058,7 +1065,7 @@ describe("generateQueryBuilderClasses", () => {
     const output = generateTypes(wasm);
 
     expect(output).toContain(
-      "export class TodoQueryBuilder<I extends TodoInclude = {}, S extends TodoSelectableColumn = keyof Todo> implements QueryBuilder<TodoSelectedWithIncludes<I, S>> {",
+      "export class TodoQueryBuilder<I extends TodoInclude = {}, S extends TodoSelectableColumn = VisibleRowColumns<Todo>> implements QueryBuilder<TodoSelectedWithIncludes<I, S>> {",
     );
     expect(output).toContain("declare readonly _rowType: TodoSelectedWithIncludes<I, S>;");
   });

--- a/packages/jazz-tools/src/codegen/query-builder-generator.ts
+++ b/packages/jazz-tools/src/codegen/query-builder-generator.ts
@@ -154,9 +154,10 @@ function generateQueryBuilderClass(
   const rowType = hasRelations
     ? `${interfaceName}SelectedWithIncludes<I, S>`
     : `${interfaceName}Selected<S>`;
+  const defaultSelectableColumns = `VisibleRowColumns<${interfaceName}>`;
 
   lines.push(
-    `export class ${interfaceName}QueryBuilder<I extends ${includeConstraint} = {}, S extends ${selectableColumnType} = keyof ${interfaceName}> implements QueryBuilder<${rowType}> {`,
+    `export class ${interfaceName}QueryBuilder<I extends ${includeConstraint} = {}, S extends ${selectableColumnType} = ${defaultSelectableColumns}> implements QueryBuilder<${rowType}> {`,
   );
   lines.push(`  readonly _table = "${tableName}";`);
   lines.push(`  readonly _schema: WasmSchema = wasmSchema;`);

--- a/packages/jazz-tools/src/codegen/type-generator.ts
+++ b/packages/jazz-tools/src/codegen/type-generator.ts
@@ -293,6 +293,17 @@ function generateMagicColumnTypes(): string[] {
   return lines;
 }
 
+function generateMutationOutcomeTypes(): string[] {
+  return [
+    "export type MutationOutcomeState = ObjectOutcomeState;",
+    "export interface MutationOutcomeColumns {",
+    "  $outcome?: MutationOutcomeState;",
+    "}",
+    "export type VisibleRowColumns<T> = Exclude<keyof T, keyof MutationOutcomeColumns>;",
+    "",
+  ];
+}
+
 /**
  * Generate WithIncludes types for type-safe include results.
  */
@@ -327,21 +338,21 @@ function generateSelectionTypes(schema: WasmSchema, relations: Map<string, Relat
     const hasRelations = (relations.get(tableName) ?? []).length > 0;
 
     lines.push(
-      `export type ${selectableColumnType} = keyof ${baseInterface} | PermissionIntrospectionColumn | "*";`,
+      `export type ${selectableColumnType} = VisibleRowColumns<${baseInterface}> | PermissionIntrospectionColumn | "*";`,
     );
     lines.push(
-      `export type ${orderableColumnType} = keyof ${baseInterface} | PermissionIntrospectionColumn;`,
+      `export type ${orderableColumnType} = VisibleRowColumns<${baseInterface}> | PermissionIntrospectionColumn;`,
     );
     lines.push("");
 
     lines.push(
-      `export type ${baseInterface}Selected<S extends ${selectableColumnType} = keyof ${baseInterface}> = "*" extends S ? ${baseInterface} : Pick<${baseInterface}, Extract<S | "id", keyof ${baseInterface}>> & Pick<PermissionIntrospectionColumns, Extract<S, PermissionIntrospectionColumn>>;`,
+      `export type ${baseInterface}Selected<S extends ${selectableColumnType} = VisibleRowColumns<${baseInterface}>> = "*" extends S ? ${baseInterface} : Pick<${baseInterface}, Extract<S | "id", keyof ${baseInterface}>> & Pick<PermissionIntrospectionColumns, Extract<S, PermissionIntrospectionColumn>> & MutationOutcomeColumns;`,
     );
     lines.push("");
 
     if (hasRelations) {
       lines.push(
-        `export type ${baseInterface}SelectedWithIncludes<I extends ${includeInterface} = {}, S extends ${selectableColumnType} = keyof ${baseInterface}> = Omit<${baseInterface}Selected<S>, Extract<keyof I, keyof ${baseInterface}Selected<S>>> & ${includedRelationsType}<I>;`,
+        `export type ${baseInterface}SelectedWithIncludes<I extends ${includeInterface} = {}, S extends ${selectableColumnType} = VisibleRowColumns<${baseInterface}>> = Omit<${baseInterface}Selected<S>, Extract<keyof I, keyof ${baseInterface}Selected<S>>> & ${includedRelationsType}<I>;`,
       );
       lines.push("");
     }
@@ -371,7 +382,7 @@ export function generateTypes(schema: WasmSchema): string {
     jsonSchemaBindings.map((binding) => [binding.key, binding.typeName]),
   );
 
-  const importNames = ["WasmSchema", "QueryBuilder"];
+  const importNames = ["WasmSchema", "QueryBuilder", "ObjectOutcomeState"];
   if (jsonSchemaBindings.length > 0) {
     importNames.push("JsonSchemaToTs");
   }
@@ -394,11 +405,12 @@ export function generateTypes(schema: WasmSchema): string {
   }
 
   lines.push(...generateMagicColumnTypes());
+  lines.push(...generateMutationOutcomeTypes());
 
   // Base types (with id)
   for (const [tableName, table] of Object.entries(schema)) {
     const interfaceName = tableNameToInterface(tableName);
-    lines.push(`export interface ${interfaceName} {`);
+    lines.push(`export interface ${interfaceName} extends MutationOutcomeColumns {`);
     lines.push("  id: string;");
     for (const col of table.columns) {
       const opt = col.nullable ? "?" : "";

--- a/packages/jazz-tools/src/runtime/client.mutations.test.ts
+++ b/packages/jazz-tools/src/runtime/client.mutations.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { JazzClient, type Runtime } from "./client.js";
+import { JazzClient, PersistedMutationError, type Runtime } from "./client.js";
 import type { AppContext } from "./context.js";
+import { ObjectOutcomeMirror } from "./object-outcomes.js";
+
+const PERSISTED_MUTATION_ERROR_CAUSE_PREFIX = "__jazzPersistedMutationError__:";
 
 function makeClient() {
   const updateCalls: Array<[string, Record<string, unknown>]> = [];
@@ -88,5 +91,89 @@ describe("JazzClient mutation durability split", () => {
 
     expect(updateDurableCalls).toEqual([["row-1", updates, "edge"]]);
     expect(deleteDurableCalls).toEqual([["row-1", "global"]]);
+  });
+
+  it("wraps structured durable mutation rejections with acknowledge()", async () => {
+    const { client } = makeClient();
+    const acknowledgeCalls: string[] = [];
+    client.setObjectOutcomeSource(
+      new ObjectOutcomeMirror(async (mutationId) => {
+        acknowledgeCalls.push(mutationId);
+      }),
+    );
+
+    const runtime = (client as unknown as { runtime: Runtime }).runtime;
+    runtime.updateDurable = async () => {
+      const error = new Error("mutation rejected");
+      Object.assign(error, {
+        name: "PersistedMutationError",
+        jazzPersistedMutationError: {
+          mutationId: "mutation-2",
+          rootMutationId: "mutation-1",
+          objectId: "row-1",
+          branchName: "main",
+          operation: "update",
+          commitIds: ["commit-1"],
+          previousCommitIds: ["commit-0"],
+          code: "permission_denied",
+          reason: "blocked",
+          rejectedAtMicros: 123,
+        },
+      });
+      throw error;
+    };
+
+    const rejection = await client
+      .updateDurable("row-1", { done: { type: "Boolean", value: true } })
+      .catch((error) => error);
+
+    expect(rejection).toBeInstanceOf(PersistedMutationError);
+    expect(rejection).toMatchObject({
+      mutationId: "mutation-2",
+      rootMutationId: "mutation-1",
+      objectId: "row-1",
+      branchName: "main",
+      operation: "update",
+      code: "permission_denied",
+      reason: "blocked",
+      rejectedAtMicros: 123,
+    });
+
+    await rejection.acknowledge();
+    expect(acknowledgeCalls).toEqual(["mutation-2"]);
+  });
+
+  it("parses napi-style durable mutation rejection causes", async () => {
+    const { client } = makeClient();
+    const runtime = (client as unknown as { runtime: Runtime }).runtime;
+    runtime.deleteDurable = async () => {
+      const error = new Error("mutation mutation-3 rejected: blocked");
+      (error as { cause?: unknown }).cause = new Error(
+        `${PERSISTED_MUTATION_ERROR_CAUSE_PREFIX}${JSON.stringify({
+          mutationId: "mutation-3",
+          rootMutationId: "mutation-1",
+          objectId: "row-1",
+          branchName: "main",
+          operation: "delete",
+          commitIds: ["commit-3"],
+          previousCommitIds: ["commit-2"],
+          code: "permission_denied",
+          reason: "blocked",
+          rejectedAtMicros: 456,
+        })}`,
+      );
+      throw error;
+    };
+
+    const rejection = await client.deleteDurable("row-1").catch((error) => error);
+
+    expect(rejection).toBeInstanceOf(PersistedMutationError);
+    expect(rejection).toMatchObject({
+      mutationId: "mutation-3",
+      rootMutationId: "mutation-1",
+      operation: "delete",
+      code: "permission_denied",
+      reason: "blocked",
+    });
   });
 });

--- a/packages/jazz-tools/src/runtime/client.object-outcomes.test.ts
+++ b/packages/jazz-tools/src/runtime/client.object-outcomes.test.ts
@@ -92,6 +92,10 @@ describe("JazzClient object outcomes", () => {
     const { client, emitSubscriptionDelta } = makeClient();
     const mirror = new ObjectOutcomeMirror();
     client.setObjectOutcomeSource(mirror);
+    const observedEvents: unknown[] = [];
+    client.onObjectOutcomeEvents((events) => {
+      observedEvents.push(...events);
+    });
 
     const seen: Row[][] = [];
     client.subscribeInternal('{"table":"todos"}', (delta) => {
@@ -147,5 +151,19 @@ describe("JazzClient object outcomes", () => {
     if (seen[1][0]?.$outcome?.type === "errored") {
       expect(typeof seen[1][0].$outcome.acknowledge).toBe("function");
     }
+
+    expect(observedEvents).toHaveLength(1);
+    expect(observedEvents[0]).toMatchObject({
+      objectId: "row-1",
+      outcome: {
+        type: "errored",
+        mutationId: "mutation-1",
+        code: "permission_denied",
+        reason: "blocked",
+      },
+    });
+    const firstEvent = observedEvents[0] as { outcome?: { type?: string; acknowledge?: unknown } };
+    expect(firstEvent.outcome?.type).toBe("errored");
+    expect(typeof firstEvent.outcome?.acknowledge).toBe("function");
   });
 });

--- a/packages/jazz-tools/src/runtime/client.object-outcomes.test.ts
+++ b/packages/jazz-tools/src/runtime/client.object-outcomes.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it, vi } from "vitest";
+import { JazzClient, type Row, type Runtime } from "./client.js";
+import type { AppContext } from "./context.js";
+import { ObjectOutcomeMirror } from "./object-outcomes.js";
+
+vi.mock("jazz-wasm", () => ({
+  default: async () => {},
+  initSync: () => {},
+  WasmRuntime: class {},
+}));
+
+function makeClient() {
+  let subscriptionCallback: ((delta: unknown) => void) | null = null;
+
+  const runtime: Runtime = {
+    insert: () => ({ id: "row-1", values: [] }),
+    insertDurable: async () => ({ id: "row-1", values: [] }),
+    update: () => {},
+    updateDurable: async () => {},
+    delete: () => {},
+    deleteDurable: async () => {},
+    query: async () => [{ id: "row-1", values: [] }],
+    subscribe: () => 1,
+    createSubscription: () => 1,
+    executeSubscription: (_handle: number, onUpdate: Function) => {
+      subscriptionCallback = onUpdate as (delta: unknown) => void;
+    },
+    unsubscribe: () => {},
+    onSyncMessageReceived: () => {},
+    onSyncMessageToSend: () => {},
+    addServer: () => {},
+    removeServer: () => {},
+    addClient: () => "client-id",
+    getSchema: () => ({}),
+    getSchemaHash: () => "schema-hash",
+  };
+
+  const context: AppContext = {
+    appId: "test-app",
+    schema: {},
+  };
+
+  const JazzClientCtor = JazzClient as unknown as {
+    new (
+      runtime: Runtime,
+      context: AppContext,
+      defaultDurabilityTier: "worker" | "edge" | "global",
+    ): JazzClient;
+  };
+
+  return {
+    client: new JazzClientCtor(runtime, context, "worker"),
+    emitSubscriptionDelta(delta: unknown) {
+      if (!subscriptionCallback) {
+        throw new Error("subscription callback not registered");
+      }
+      subscriptionCallback(delta);
+    },
+  };
+}
+
+describe("JazzClient object outcomes", () => {
+  it("enriches queried rows with the current object outcome", async () => {
+    const { client } = makeClient();
+    const mirror = new ObjectOutcomeMirror();
+    mirror.replaceSnapshot([
+      {
+        objectId: "row-1",
+        outcome: {
+          type: "pending",
+          mutationId: "mutation-1",
+        },
+      },
+    ]);
+    client.setObjectOutcomeSource(mirror);
+
+    const rows = await client.queryInternal('{"table":"todos"}');
+
+    expect(rows).toEqual([
+      {
+        id: "row-1",
+        values: [],
+        $outcome: {
+          type: "pending",
+          mutationId: "mutation-1",
+        },
+      },
+    ] satisfies Row[]);
+  });
+
+  it("emits subscription updates when only the object outcome changes", async () => {
+    const { client, emitSubscriptionDelta } = makeClient();
+    const mirror = new ObjectOutcomeMirror();
+    client.setObjectOutcomeSource(mirror);
+
+    const seen: Row[][] = [];
+    client.subscribeInternal('{"table":"todos"}', (delta) => {
+      seen.push(
+        delta.flatMap((change) => (change.kind === 1 || !change.row ? [] : [change.row as Row])),
+      );
+    });
+
+    await Promise.resolve();
+
+    emitSubscriptionDelta([
+      {
+        kind: 0,
+        id: "row-1",
+        index: 0,
+        row: {
+          id: "row-1",
+          values: [],
+        },
+      },
+    ]);
+
+    mirror.applyEvents([
+      {
+        objectId: "row-1",
+        outcome: {
+          type: "errored",
+          mutationId: "mutation-1",
+          code: "permission_denied",
+          reason: "blocked",
+        },
+      },
+    ]);
+
+    expect(seen).toHaveLength(2);
+    expect(seen[0]).toEqual([
+      {
+        id: "row-1",
+        values: [],
+      },
+    ]);
+    expect(seen[1][0]).toMatchObject({
+      id: "row-1",
+      values: [],
+      $outcome: {
+        type: "errored",
+        mutationId: "mutation-1",
+        code: "permission_denied",
+        reason: "blocked",
+      },
+    });
+    expect(seen[1][0]?.$outcome?.type).toBe("errored");
+    if (seen[1][0]?.$outcome?.type === "errored") {
+      expect(typeof seen[1][0].$outcome.acknowledge).toBe("function");
+    }
+  });
+});

--- a/packages/jazz-tools/src/runtime/client.ts
+++ b/packages/jazz-tools/src/runtime/client.ts
@@ -25,6 +25,13 @@ import {
 import { resolveLocalAuthDefaults } from "./local-auth.js";
 import { resolveClientSessionSync } from "./client-session.js";
 import { translateQuery } from "./query-adapter.js";
+import {
+  type ObjectOutcomeSource,
+  type ObjectOutcomeState,
+  type RuntimeObjectOutcomeBindings,
+  type RuntimeObjectOutcomeEvent,
+  RuntimeObjectOutcomeSource,
+} from "./object-outcomes.js";
 
 /**
  * Minimal request shape supported by `JazzClient.forRequest()`.
@@ -43,7 +50,7 @@ export interface RequestLike {
  * Both `WasmRuntime` (from jazz-wasm) and `NapiRuntime` (from jazz-napi)
  * satisfy this interface, allowing `JazzClient` to work with either backend.
  */
-export interface Runtime {
+export interface Runtime extends RuntimeObjectOutcomeBindings {
   insert(table: string, values: any): Row;
   insertDurable(table: string, values: any, tier: string): Promise<Row>;
   update(object_id: string, values: any): void;
@@ -118,12 +125,19 @@ export interface WriteDurabilityOptions {
 export interface Row {
   id: string;
   values: Value[];
+  $outcome?: ObjectOutcomeState;
 }
 
 /**
  * Subscription callback type.
  */
 export type SubscriptionCallback = (delta: RowDelta) => void;
+
+type OutcomeAwareSubscriptionState = {
+  callback: SubscriptionCallback;
+  rowsById: Map<string, Row>;
+  orderedIds: string[];
+};
 
 export interface LinkExternalIdentityOptions {
   jwtToken?: string;
@@ -572,6 +586,10 @@ export class JazzClient {
   private resolvedSession: Session | null;
   private defaultDurabilityTier: DurabilityTier;
   private useBackendSyncAuth = false;
+  private objectOutcomeSource: ObjectOutcomeSource | null = null;
+  private runtimeObjectOutcomeSource: RuntimeObjectOutcomeSource | null = null;
+  private objectOutcomeUnsubscribe: (() => void) | null = null;
+  private readonly outcomeSubscriptions = new Map<number, OutcomeAwareSubscriptionState>();
 
   private constructor(
     runtime: Runtime,
@@ -595,7 +613,11 @@ export class JazzClient {
       setClientId: (clientId) => {
         this.serverClientId = clientId;
       },
+      onSyncMessageReceived: () => {
+        this.drainRuntimeObjectOutcomeSource();
+      },
     });
+    this.installRuntimeObjectOutcomeSource(runtime);
   }
 
   /**
@@ -698,6 +720,45 @@ export class JazzClient {
   }
 
   /**
+   * Install an object-outcome source for row enrichment and late-rejection invalidation.
+   * @internal
+   */
+  setObjectOutcomeSource(source: ObjectOutcomeSource | null): void {
+    this.objectOutcomeUnsubscribe?.();
+    this.objectOutcomeUnsubscribe = null;
+    this.objectOutcomeSource = source;
+
+    if (!source) {
+      return;
+    }
+
+    this.objectOutcomeUnsubscribe = source.subscribeObjectOutcomeEvents((events) => {
+      this.handleObjectOutcomeEvents(events);
+    });
+  }
+
+  /**
+   * Read the current object outcome for one row id.
+   */
+  getObjectOutcome(objectId: string): ObjectOutcomeState | null {
+    return this.objectOutcomeSource?.getObjectOutcome(objectId) ?? null;
+  }
+
+  /**
+   * Subscribe to object outcome changes for invisible-data notifications.
+   */
+  onObjectOutcomeEvents(listener: (events: RuntimeObjectOutcomeEvent[]) => void): () => void {
+    return this.objectOutcomeSource?.subscribeObjectOutcomeEvents(listener) ?? (() => {});
+  }
+
+  /**
+   * Acknowledge a surfaced mutation outcome.
+   */
+  acknowledgeMutationOutcome(mutationId: string): Promise<void> {
+    return this.objectOutcomeSource?.acknowledgeMutationOutcome(mutationId) ?? Promise.resolve();
+  }
+
+  /**
    * Create a session-scoped client for backend operations.
    *
    * This allows backend applications to perform operations as a specific user.
@@ -754,6 +815,24 @@ export class JazzClient {
     this.useBackendSyncAuth = true;
     this.streamController.updateAuth();
     return this;
+  }
+
+  private installRuntimeObjectOutcomeSource(runtime: Runtime): void {
+    if (
+      !runtime.listObjectOutcomes &&
+      !runtime.takeObjectOutcomeEvents &&
+      !runtime.acknowledgeMutationOutcome
+    ) {
+      this.setObjectOutcomeSource(null);
+      return;
+    }
+
+    this.runtimeObjectOutcomeSource = new RuntimeObjectOutcomeSource(runtime);
+    this.setObjectOutcomeSource(this.runtimeObjectOutcomeSource);
+  }
+
+  private drainRuntimeObjectOutcomeSource(): void {
+    this.runtimeObjectOutcomeSource?.drain();
   }
 
   private getSyncAuth(): SyncAuth {
@@ -950,13 +1029,115 @@ export class JazzClient {
     });
   }
 
+  private withObjectOutcome(row: Row): Row {
+    const outcome = this.objectOutcomeSource?.getObjectOutcome(row.id) ?? null;
+    if (!outcome) {
+      if (!("$outcome" in row)) {
+        return row;
+      }
+      const { $outcome: _ignored, ...rest } = row;
+      return rest;
+    }
+
+    if (objectOutcomeEquals(row.$outcome ?? null, outcome)) {
+      return row;
+    }
+
+    return {
+      ...row,
+      $outcome: outcome,
+    };
+  }
+
+  private enrichRows(rows: Row[]): Row[] {
+    return rows.map((row) => this.withObjectOutcome(row));
+  }
+
+  private enrichRowDelta(delta: RowDelta): RowDelta {
+    return delta.map((change) => {
+      if ((change.kind === 0 || change.kind === 2) && change.row) {
+        return {
+          ...change,
+          row: this.withObjectOutcome(change.row),
+        };
+      }
+
+      return change;
+    });
+  }
+
+  private applyOutcomeAwareDelta(state: OutcomeAwareSubscriptionState, delta: RowDelta): void {
+    const sortedDelta = [...delta].sort((left, right) => left.index - right.index);
+
+    for (const change of sortedDelta) {
+      switch (change.kind) {
+        case 0:
+          state.rowsById.set(change.id, change.row);
+          insertIdAt(state.orderedIds, change.id, change.index);
+          break;
+        case 1:
+          state.rowsById.delete(change.id);
+          removeId(state.orderedIds, change.id);
+          break;
+        case 2:
+          removeId(state.orderedIds, change.id);
+          insertIdAt(state.orderedIds, change.id, change.index);
+          if (change.row) {
+            state.rowsById.set(change.id, change.row);
+          }
+          break;
+      }
+    }
+  }
+
+  private handleObjectOutcomeEvents(events: RuntimeObjectOutcomeEvent[]): void {
+    if (events.length === 0 || this.outcomeSubscriptions.size === 0) {
+      return;
+    }
+
+    const changedIds = new Set(events.map((event) => event.objectId));
+    for (const state of this.outcomeSubscriptions.values()) {
+      const delta: RowDelta = [];
+
+      for (const objectId of changedIds) {
+        const currentRow = state.rowsById.get(objectId);
+        if (!currentRow) {
+          continue;
+        }
+
+        const index = state.orderedIds.indexOf(objectId);
+        if (index === -1) {
+          continue;
+        }
+
+        const nextRow = this.withObjectOutcome(currentRow);
+        if (rowsHaveSameOutcome(currentRow, nextRow)) {
+          continue;
+        }
+
+        state.rowsById.set(objectId, nextRow);
+        delta.push({
+          kind: 2,
+          id: objectId,
+          index,
+          row: nextRow,
+        });
+      }
+
+      if (delta.length > 0) {
+        state.callback(delta);
+      }
+    }
+  }
+
   /**
    * Insert a new row into a table without waiting for durability.
    */
   create(table: string, values: Value[]): Row {
     const row = this.runtime.insert(table, values);
+    this.drainRuntimeObjectOutcomeSource();
     return {
-      ...row,
+      ...this.withObjectOutcome(row),
       values: this.alignRowValuesToDeclaredSchema(table, row.values as Value[], this.getSchema()),
     };
   }
@@ -971,8 +1152,9 @@ export class JazzClient {
   ): Promise<Row> {
     const tier = this.resolveWriteTier(options);
     const row = await this.runtime.insertDurable(table, values, tier);
+    this.drainRuntimeObjectOutcomeSource();
     return {
-      ...row,
+      ...this.withObjectOutcome(row),
       values: this.alignRowValuesToDeclaredSchema(table, row.values as Value[], this.getSchema()),
     };
   }
@@ -1008,7 +1190,9 @@ export class JazzClient {
       normalizedOptions.tier,
       optionsJson,
     );
-    return this.alignQueryRowsToDeclaredSchema(queryJson, results as Row[], runtimeSchema);
+    return this.enrichRows(
+      this.alignQueryRowsToDeclaredSchema(queryJson, results as Row[], runtimeSchema),
+    );
   }
 
   /**
@@ -1016,6 +1200,7 @@ export class JazzClient {
    */
   update(objectId: string, updates: Record<string, Value>): void {
     this.runtime.update(objectId, updates);
+    this.drainRuntimeObjectOutcomeSource();
   }
 
   /**
@@ -1028,6 +1213,7 @@ export class JazzClient {
   ): Promise<void> {
     const tier = this.resolveWriteTier(options);
     await this.runtime.updateDurable(objectId, updates, tier);
+    this.drainRuntimeObjectOutcomeSource();
   }
 
   /**
@@ -1035,6 +1221,7 @@ export class JazzClient {
    */
   delete(objectId: string): void {
     this.runtime.delete(objectId);
+    this.drainRuntimeObjectOutcomeSource();
   }
 
   /**
@@ -1043,6 +1230,7 @@ export class JazzClient {
   async deleteDurable(objectId: string, options?: WriteDurabilityOptions): Promise<void> {
     const tier = this.resolveWriteTier(options);
     await this.runtime.deleteDurable(objectId, tier);
+    this.drainRuntimeObjectOutcomeSource();
   }
 
   /**
@@ -1082,6 +1270,11 @@ export class JazzClient {
     const queryJson = resolveQueryJson(query);
     const optionsJson = encodeQueryExecutionOptions(normalizedOptions);
     const runtimeSchema = this.getSchema();
+    const outcomeState: OutcomeAwareSubscriptionState = {
+      callback,
+      rowsById: new Map(),
+      orderedIds: [],
+    };
 
     const handle = this.runtime.createSubscription(
       queryJson,
@@ -1089,6 +1282,7 @@ export class JazzClient {
       normalizedOptions.tier,
       optionsJson,
     );
+    this.outcomeSubscriptions.set(handle, outcomeState);
 
     this.scheduler(() => {
       this.runtime.executeSubscription(handle, (...args: unknown[]) => {
@@ -1099,7 +1293,14 @@ export class JazzClient {
 
         const delta: RowDelta =
           typeof deltaJsonOrObject === "string" ? JSON.parse(deltaJsonOrObject) : deltaJsonOrObject;
-        callback(this.alignSubscriptionDeltaToDeclaredSchema(queryJson, delta, runtimeSchema));
+        const alignedDelta = this.alignSubscriptionDeltaToDeclaredSchema(
+          queryJson,
+          delta,
+          runtimeSchema,
+        );
+        const enrichedDelta = this.enrichRowDelta(alignedDelta);
+        this.applyOutcomeAwareDelta(outcomeState, enrichedDelta);
+        callback(enrichedDelta);
       });
     });
 
@@ -1112,6 +1313,7 @@ export class JazzClient {
    * @param subscriptionId ID returned from subscribe()
    */
   unsubscribe(subscriptionId: number): void {
+    this.outcomeSubscriptions.delete(subscriptionId);
     this.runtime.unsubscribe(subscriptionId);
   }
 
@@ -1248,6 +1450,12 @@ export class JazzClient {
    */
   async shutdown(): Promise<void> {
     this.streamController.stop();
+    this.objectOutcomeUnsubscribe?.();
+    this.objectOutcomeUnsubscribe = null;
+    this.outcomeSubscriptions.clear();
+    this.runtimeObjectOutcomeSource?.dispose();
+    this.runtimeObjectOutcomeSource = null;
+    this.objectOutcomeSource = null;
 
     // Close runtime if it supports explicit shutdown (e.g., NapiRuntime).
     if (this.runtime.close) {
@@ -1292,6 +1500,41 @@ export class JazzClient {
       "[client] ",
     );
   }
+}
+
+function removeId(ids: string[], id: string): void {
+  const index = ids.indexOf(id);
+  if (index !== -1) {
+    ids.splice(index, 1);
+  }
+}
+
+function insertIdAt(ids: string[], id: string, index: number): void {
+  const clamped = Math.max(0, Math.min(index, ids.length));
+  ids.splice(clamped, 0, id);
+}
+
+function rowsHaveSameOutcome(left: Row, right: Row): boolean {
+  return objectOutcomeEquals(left.$outcome ?? null, right.$outcome ?? null);
+}
+
+function objectOutcomeEquals(
+  left: ObjectOutcomeState | null,
+  right: ObjectOutcomeState | null,
+): boolean {
+  if (left === right) {
+    return true;
+  }
+  if (!left || !right) {
+    return false;
+  }
+  if (left.type !== right.type || left.mutationId !== right.mutationId) {
+    return false;
+  }
+  if (left.type !== "errored" || right.type !== "errored") {
+    return true;
+  }
+  return left.code === right.code && left.reason === right.reason;
 }
 
 /**

--- a/packages/jazz-tools/src/runtime/client.ts
+++ b/packages/jazz-tools/src/runtime/client.ts
@@ -32,6 +32,12 @@ import {
   type RuntimeObjectOutcomeBindings,
   RuntimeObjectOutcomeSource,
 } from "./object-outcomes.js";
+import {
+  PersistedMutationError,
+  normalizePersistedMutationError,
+  type MutationOperation,
+  type PersistedMutationErrorData,
+} from "./persisted-mutation-error.js";
 
 /**
  * Minimal request shape supported by `JazzClient.forRequest()`.
@@ -118,6 +124,8 @@ export interface ResolvedQueryExecutionOptions {
 export interface WriteDurabilityOptions {
   tier?: DurabilityTier;
 }
+
+export { PersistedMutationError, type MutationOperation, type PersistedMutationErrorData };
 
 /**
  * Query row result.
@@ -1140,6 +1148,14 @@ export class JazzClient {
     }
   }
 
+  private wrapPersistedMutationError(error: unknown): unknown {
+    return (
+      normalizePersistedMutationError(error, (mutationId) =>
+        this.acknowledgeMutationOutcome(mutationId),
+      ) ?? error
+    );
+  }
+
   /**
    * Insert a new row into a table without waiting for durability.
    */
@@ -1161,12 +1177,17 @@ export class JazzClient {
     options?: WriteDurabilityOptions,
   ): Promise<Row> {
     const tier = this.resolveWriteTier(options);
-    const row = await this.runtime.insertDurable(table, values, tier);
-    this.drainRuntimeObjectOutcomeSource();
-    return {
-      ...this.withObjectOutcome(row),
-      values: this.alignRowValuesToDeclaredSchema(table, row.values as Value[], this.getSchema()),
-    };
+    try {
+      const row = await this.runtime.insertDurable(table, values, tier);
+      this.drainRuntimeObjectOutcomeSource();
+      return {
+        ...this.withObjectOutcome(row),
+        values: this.alignRowValuesToDeclaredSchema(table, row.values as Value[], this.getSchema()),
+      };
+    } catch (error) {
+      this.drainRuntimeObjectOutcomeSource();
+      throw this.wrapPersistedMutationError(error);
+    }
   }
 
   /**
@@ -1222,8 +1243,13 @@ export class JazzClient {
     options?: WriteDurabilityOptions,
   ): Promise<void> {
     const tier = this.resolveWriteTier(options);
-    await this.runtime.updateDurable(objectId, updates, tier);
-    this.drainRuntimeObjectOutcomeSource();
+    try {
+      await this.runtime.updateDurable(objectId, updates, tier);
+      this.drainRuntimeObjectOutcomeSource();
+    } catch (error) {
+      this.drainRuntimeObjectOutcomeSource();
+      throw this.wrapPersistedMutationError(error);
+    }
   }
 
   /**
@@ -1239,8 +1265,13 @@ export class JazzClient {
    */
   async deleteDurable(objectId: string, options?: WriteDurabilityOptions): Promise<void> {
     const tier = this.resolveWriteTier(options);
-    await this.runtime.deleteDurable(objectId, tier);
-    this.drainRuntimeObjectOutcomeSource();
+    try {
+      await this.runtime.deleteDurable(objectId, tier);
+      this.drainRuntimeObjectOutcomeSource();
+    } catch (error) {
+      this.drainRuntimeObjectOutcomeSource();
+      throw this.wrapPersistedMutationError(error);
+    }
   }
 
   /**

--- a/packages/jazz-tools/src/runtime/client.ts
+++ b/packages/jazz-tools/src/runtime/client.ts
@@ -26,10 +26,10 @@ import { resolveLocalAuthDefaults } from "./local-auth.js";
 import { resolveClientSessionSync } from "./client-session.js";
 import { translateQuery } from "./query-adapter.js";
 import {
+  type ObjectOutcomeEvent,
   type ObjectOutcomeSource,
   type ObjectOutcomeState,
   type RuntimeObjectOutcomeBindings,
-  type RuntimeObjectOutcomeEvent,
   RuntimeObjectOutcomeSource,
 } from "./object-outcomes.js";
 
@@ -125,6 +125,12 @@ export interface WriteDurabilityOptions {
 export interface Row {
   id: string;
   values: Value[];
+  /**
+   * Mutation outcome overlay for this row, if there is still unacknowledged local state to surface.
+   *
+   * `$outcome` is attached automatically to visible rows. It is not selected, filtered, or ordered
+   * through the query builder.
+   */
   $outcome?: ObjectOutcomeState;
 }
 
@@ -739,6 +745,8 @@ export class JazzClient {
 
   /**
    * Read the current object outcome for one row id.
+   *
+   * Rejected outcomes include `acknowledge()` so apps can clear surfaced errors after handling them.
    */
   getObjectOutcome(objectId: string): ObjectOutcomeState | null {
     return this.objectOutcomeSource?.getObjectOutcome(objectId) ?? null;
@@ -746,8 +754,10 @@ export class JazzClient {
 
   /**
    * Subscribe to object outcome changes for invisible-data notifications.
+   *
+   * This is the app-facing stream for delayed rejections that no longer have a visible row in a query.
    */
-  onObjectOutcomeEvents(listener: (events: RuntimeObjectOutcomeEvent[]) => void): () => void {
+  onObjectOutcomeEvents(listener: (events: ObjectOutcomeEvent[]) => void): () => void {
     return this.objectOutcomeSource?.subscribeObjectOutcomeEvents(listener) ?? (() => {});
   }
 
@@ -1090,7 +1100,7 @@ export class JazzClient {
     }
   }
 
-  private handleObjectOutcomeEvents(events: RuntimeObjectOutcomeEvent[]): void {
+  private handleObjectOutcomeEvents(events: ObjectOutcomeEvent[]): void {
     if (events.length === 0 || this.outcomeSubscriptions.size === 0) {
       return;
     }

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -24,6 +24,7 @@ import {
   type QueryVisibility,
   resolveEffectiveQueryExecutionOptions,
 } from "./client.js";
+import type { RuntimeObjectOutcomeEvent } from "./object-outcomes.js";
 import { WorkerBridge, type PeerSyncBatch, type WorkerBridgeOptions } from "./worker-bridge.js";
 import { translateQuery } from "./query-adapter.js";
 import { transformRow, transformRows } from "./row-transformer.js";
@@ -356,6 +357,10 @@ export class Db {
   >();
   private readonly activeQuerySubscriptionTraceListeners =
     new Set<ActiveQuerySubscriptionTraceListener>();
+  private readonly objectOutcomeListeners = new Set<
+    (events: RuntimeObjectOutcomeEvent[]) => void
+  >();
+  private readonly clientObjectOutcomeUnsubscribes = new Map<string, () => void>();
   private nextActiveQuerySubscriptionTraceId = 1;
   private readonly onSyncChannelMessage = (event: MessageEvent): void => {
     this.handleSyncChannelMessage(event.data);
@@ -510,6 +515,7 @@ export class Db {
       }
 
       this.clients.set(key, client);
+      this.attachClientObjectOutcomeForwarder(key, client);
     }
 
     return this.clients.get(key)!;
@@ -532,6 +538,7 @@ export class Db {
     }
 
     const bridge = new WorkerBridge(this.worker, client.getRuntime());
+    client.setObjectOutcomeSource(bridge);
     this.leaderPeerIds.clear();
     bridge.onPeerSync((batch) => {
       this.handleWorkerPeerSync(batch);
@@ -539,6 +546,19 @@ export class Db {
     this.applyBridgeRoutingForCurrentLeader(bridge, false);
     this.workerBridge = bridge;
     this.bridgeReady = bridge.init(this.buildWorkerBridgeOptions(schemaJson)).then(() => undefined);
+  }
+
+  private attachClientObjectOutcomeForwarder(key: string, client: JazzClient): void {
+    if (this.clientObjectOutcomeUnsubscribes.has(key)) {
+      return;
+    }
+
+    const unsubscribe = client.onObjectOutcomeEvents((events) => {
+      for (const listener of this.objectOutcomeListeners) {
+        listener(events);
+      }
+    });
+    this.clientObjectOutcomeUnsubscribes.set(key, unsubscribe);
   }
 
   private buildWorkerBridgeOptions(schemaJson: string): WorkerBridgeOptions {
@@ -971,6 +991,13 @@ export class Db {
     };
   }
 
+  onObjectOutcomeEvents(listener: (events: RuntimeObjectOutcomeEvent[]) => void): () => void {
+    this.objectOutcomeListeners.add(listener);
+    return () => {
+      this.objectOutcomeListeners.delete(listener);
+    };
+  }
+
   /**
    * Insert a new row into a table without waiting for durability.
    *
@@ -1242,6 +1269,11 @@ export class Db {
   async shutdown(): Promise<void> {
     this.isShuttingDown = true;
     this.clearActiveQuerySubscriptionTraces();
+    for (const unsubscribe of this.clientObjectOutcomeUnsubscribes.values()) {
+      unsubscribe();
+    }
+    this.clientObjectOutcomeUnsubscribes.clear();
+    this.objectOutcomeListeners.clear();
     this.logLeaderDebug("shutdown");
     this.sendFollowerClose(this.activeRemoteLeaderTabId, this.currentLeaderTerm);
     this.activeRemoteLeaderTabId = null;

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -24,7 +24,7 @@ import {
   type QueryVisibility,
   resolveEffectiveQueryExecutionOptions,
 } from "./client.js";
-import type { RuntimeObjectOutcomeEvent } from "./object-outcomes.js";
+import type { ObjectOutcomeEvent } from "./object-outcomes.js";
 import { WorkerBridge, type PeerSyncBatch, type WorkerBridgeOptions } from "./worker-bridge.js";
 import { translateQuery } from "./query-adapter.js";
 import { transformRow, transformRows } from "./row-transformer.js";
@@ -357,9 +357,7 @@ export class Db {
   >();
   private readonly activeQuerySubscriptionTraceListeners =
     new Set<ActiveQuerySubscriptionTraceListener>();
-  private readonly objectOutcomeListeners = new Set<
-    (events: RuntimeObjectOutcomeEvent[]) => void
-  >();
+  private readonly objectOutcomeListeners = new Set<(events: ObjectOutcomeEvent[]) => void>();
   private readonly clientObjectOutcomeUnsubscribes = new Map<string, () => void>();
   private nextActiveQuerySubscriptionTraceId = 1;
   private readonly onSyncChannelMessage = (event: MessageEvent): void => {
@@ -991,7 +989,13 @@ export class Db {
     };
   }
 
-  onObjectOutcomeEvents(listener: (events: RuntimeObjectOutcomeEvent[]) => void): () => void {
+  /**
+   * Subscribe to global mutation outcome changes, including rows that are no longer visible in queries.
+   *
+   * Use this for toasts, issue inboxes, or badges. Rejected outcomes include `acknowledge()`, which clears
+   * the surfaced issue and lets the persistence owner prune the rejected local commits.
+   */
+  onObjectOutcomeEvents(listener: (events: ObjectOutcomeEvent[]) => void): () => void {
     this.objectOutcomeListeners.add(listener);
     return () => {
       this.objectOutcomeListeners.delete(listener);

--- a/packages/jazz-tools/src/runtime/index.ts
+++ b/packages/jazz-tools/src/runtime/index.ts
@@ -53,6 +53,7 @@ export {
 } from "./subscription-manager.js";
 export type {
   MutationRejectCode,
+  ObjectOutcomeEvent,
   ObjectOutcomeState,
   RuntimeObjectOutcomeEvent,
 } from "./object-outcomes.js";

--- a/packages/jazz-tools/src/runtime/index.ts
+++ b/packages/jazz-tools/src/runtime/index.ts
@@ -51,4 +51,9 @@ export {
   type RowDelta,
   type SubscriptionDelta,
 } from "./subscription-manager.js";
+export type {
+  MutationRejectCode,
+  ObjectOutcomeState,
+  RuntimeObjectOutcomeEvent,
+} from "./object-outcomes.js";
 export { WorkerBridge, type WorkerBridgeOptions } from "./worker-bridge.js";

--- a/packages/jazz-tools/src/runtime/index.ts
+++ b/packages/jazz-tools/src/runtime/index.ts
@@ -3,6 +3,9 @@ export {
   type LinkExternalIdentityOptions,
   type LinkExternalIdentityResult,
   type LocalUpdatesMode,
+  type MutationOperation,
+  PersistedMutationError,
+  type PersistedMutationErrorData,
   SessionClient,
   loadWasmModule,
   type DurabilityTier,
@@ -57,4 +60,5 @@ export type {
   ObjectOutcomeState,
   RuntimeObjectOutcomeEvent,
 } from "./object-outcomes.js";
+export { isPersistedMutationError } from "./persisted-mutation-error.js";
 export { WorkerBridge, type WorkerBridgeOptions } from "./worker-bridge.js";

--- a/packages/jazz-tools/src/runtime/object-outcomes.ts
+++ b/packages/jazz-tools/src/runtime/object-outcomes.ts
@@ -13,6 +13,20 @@ export interface RuntimeObjectOutcomeEvent {
   outcome: RuntimeObjectOutcomeState | null;
 }
 
+/**
+ * App-facing object outcome event enriched with acknowledge() for rejected outcomes.
+ */
+export interface ObjectOutcomeEvent {
+  objectId: string;
+  outcome: ObjectOutcomeState | null;
+}
+
+/**
+ * Current mutation outcome overlay for one visible object.
+ *
+ * This is attached to returned rows as `$outcome` and is also used by the
+ * global object-outcome event stream.
+ */
 export type ObjectOutcomeState =
   | { type: "pending"; mutationId: string }
   | { type: "accepted"; mutationId: string }
@@ -26,7 +40,7 @@ export type ObjectOutcomeState =
 
 export interface ObjectOutcomeSource {
   getObjectOutcome(objectId: string): ObjectOutcomeState | null;
-  subscribeObjectOutcomeEvents(listener: (events: RuntimeObjectOutcomeEvent[]) => void): () => void;
+  subscribeObjectOutcomeEvents(listener: (events: ObjectOutcomeEvent[]) => void): () => void;
   acknowledgeMutationOutcome(mutationId: string): Promise<void>;
 }
 
@@ -37,7 +51,7 @@ export interface RuntimeObjectOutcomeBindings {
   setMutationJournalEnabled?(enabled: boolean): void;
 }
 
-type OutcomeListener = (events: RuntimeObjectOutcomeEvent[]) => void;
+type OutcomeListener = (events: ObjectOutcomeEvent[]) => void;
 
 export class ObjectOutcomeMirror implements ObjectOutcomeSource {
   private readonly cache = new Map<string, RuntimeObjectOutcomeState>();
@@ -56,13 +70,13 @@ export class ObjectOutcomeMirror implements ObjectOutcomeSource {
     }
 
     const changedIds = new Set<string>([...this.cache.keys(), ...next.keys()]);
-    const changes: RuntimeObjectOutcomeEvent[] = [];
+    const changedObjectIds: string[] = [];
 
     for (const objectId of changedIds) {
       const previous = this.cache.get(objectId) ?? null;
       const current = next.get(objectId) ?? null;
       if (!runtimeObjectOutcomeEquals(previous, current)) {
-        changes.push({ objectId, outcome: current });
+        changedObjectIds.push(objectId);
       }
     }
 
@@ -71,11 +85,11 @@ export class ObjectOutcomeMirror implements ObjectOutcomeSource {
       this.cache.set(objectId, outcome);
     }
 
-    this.emit(changes);
+    this.emit(changedObjectIds);
   }
 
   applyEvents(events: RuntimeObjectOutcomeEvent[]): void {
-    const changes: RuntimeObjectOutcomeEvent[] = [];
+    const changedObjectIds: string[] = [];
 
     for (const event of events) {
       const previous = this.cache.get(event.objectId) ?? null;
@@ -89,10 +103,10 @@ export class ObjectOutcomeMirror implements ObjectOutcomeSource {
         this.cache.delete(event.objectId);
       }
 
-      changes.push(event);
+      changedObjectIds.push(event.objectId);
     }
 
-    this.emit(changes);
+    this.emit(changedObjectIds);
   }
 
   getObjectOutcome(objectId: string): ObjectOutcomeState | null {
@@ -127,10 +141,15 @@ export class ObjectOutcomeMirror implements ObjectOutcomeSource {
     this.cache.clear();
   }
 
-  private emit(events: RuntimeObjectOutcomeEvent[]): void {
-    if (events.length === 0) {
+  private emit(objectIds: string[]): void {
+    if (objectIds.length === 0) {
       return;
     }
+
+    const events = objectIds.map((objectId) => ({
+      objectId,
+      outcome: this.getObjectOutcome(objectId),
+    }));
 
     for (const listener of this.listeners) {
       listener(events);

--- a/packages/jazz-tools/src/runtime/object-outcomes.ts
+++ b/packages/jazz-tools/src/runtime/object-outcomes.ts
@@ -1,0 +1,176 @@
+export type MutationRejectCode =
+  | "permission_denied"
+  | "session_required"
+  | "catalogue_write_denied";
+
+export type RuntimeObjectOutcomeState =
+  | { type: "pending"; mutationId: string }
+  | { type: "accepted"; mutationId: string }
+  | { type: "errored"; mutationId: string; code: MutationRejectCode; reason: string };
+
+export interface RuntimeObjectOutcomeEvent {
+  objectId: string;
+  outcome: RuntimeObjectOutcomeState | null;
+}
+
+export type ObjectOutcomeState =
+  | { type: "pending"; mutationId: string }
+  | { type: "accepted"; mutationId: string }
+  | {
+      type: "errored";
+      mutationId: string;
+      code: MutationRejectCode;
+      reason: string;
+      acknowledge: () => Promise<void>;
+    };
+
+export interface ObjectOutcomeSource {
+  getObjectOutcome(objectId: string): ObjectOutcomeState | null;
+  subscribeObjectOutcomeEvents(listener: (events: RuntimeObjectOutcomeEvent[]) => void): () => void;
+  acknowledgeMutationOutcome(mutationId: string): Promise<void>;
+}
+
+export interface RuntimeObjectOutcomeBindings {
+  listObjectOutcomes?(): RuntimeObjectOutcomeEvent[];
+  takeObjectOutcomeEvents?(): RuntimeObjectOutcomeEvent[];
+  acknowledgeMutationOutcome?(mutationId: string): void | Promise<void>;
+  setMutationJournalEnabled?(enabled: boolean): void;
+}
+
+type OutcomeListener = (events: RuntimeObjectOutcomeEvent[]) => void;
+
+export class ObjectOutcomeMirror implements ObjectOutcomeSource {
+  private readonly cache = new Map<string, RuntimeObjectOutcomeState>();
+  private readonly listeners = new Set<OutcomeListener>();
+
+  constructor(
+    private readonly acknowledgeImpl: (mutationId: string) => Promise<void> | void = async () => {},
+  ) {}
+
+  replaceSnapshot(snapshot: RuntimeObjectOutcomeEvent[]): void {
+    const next = new Map<string, RuntimeObjectOutcomeState>();
+    for (const event of snapshot) {
+      if (event.outcome) {
+        next.set(event.objectId, event.outcome);
+      }
+    }
+
+    const changedIds = new Set<string>([...this.cache.keys(), ...next.keys()]);
+    const changes: RuntimeObjectOutcomeEvent[] = [];
+
+    for (const objectId of changedIds) {
+      const previous = this.cache.get(objectId) ?? null;
+      const current = next.get(objectId) ?? null;
+      if (!runtimeObjectOutcomeEquals(previous, current)) {
+        changes.push({ objectId, outcome: current });
+      }
+    }
+
+    this.cache.clear();
+    for (const [objectId, outcome] of next) {
+      this.cache.set(objectId, outcome);
+    }
+
+    this.emit(changes);
+  }
+
+  applyEvents(events: RuntimeObjectOutcomeEvent[]): void {
+    const changes: RuntimeObjectOutcomeEvent[] = [];
+
+    for (const event of events) {
+      const previous = this.cache.get(event.objectId) ?? null;
+      if (runtimeObjectOutcomeEquals(previous, event.outcome)) {
+        continue;
+      }
+
+      if (event.outcome) {
+        this.cache.set(event.objectId, event.outcome);
+      } else {
+        this.cache.delete(event.objectId);
+      }
+
+      changes.push(event);
+    }
+
+    this.emit(changes);
+  }
+
+  getObjectOutcome(objectId: string): ObjectOutcomeState | null {
+    const outcome = this.cache.get(objectId);
+    if (!outcome) {
+      return null;
+    }
+
+    if (outcome.type === "errored") {
+      return {
+        ...outcome,
+        acknowledge: () => Promise.resolve(this.acknowledgeImpl(outcome.mutationId)),
+      };
+    }
+
+    return outcome;
+  }
+
+  subscribeObjectOutcomeEvents(listener: OutcomeListener): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  async acknowledgeMutationOutcome(mutationId: string): Promise<void> {
+    await this.acknowledgeImpl(mutationId);
+  }
+
+  dispose(): void {
+    this.listeners.clear();
+    this.cache.clear();
+  }
+
+  private emit(events: RuntimeObjectOutcomeEvent[]): void {
+    if (events.length === 0) {
+      return;
+    }
+
+    for (const listener of this.listeners) {
+      listener(events);
+    }
+  }
+}
+
+export class RuntimeObjectOutcomeSource extends ObjectOutcomeMirror {
+  constructor(private readonly runtime: RuntimeObjectOutcomeBindings) {
+    super(async (mutationId) => {
+      if (!runtime.acknowledgeMutationOutcome) {
+        return;
+      }
+      await runtime.acknowledgeMutationOutcome(mutationId);
+      this.drain();
+    });
+
+    this.replaceSnapshot(runtime.listObjectOutcomes?.() ?? []);
+  }
+
+  drain(): void {
+    this.applyEvents(this.runtime.takeObjectOutcomeEvents?.() ?? []);
+  }
+}
+
+function runtimeObjectOutcomeEquals(
+  left: RuntimeObjectOutcomeState | null,
+  right: RuntimeObjectOutcomeState | null,
+): boolean {
+  if (left === right) {
+    return true;
+  }
+  if (!left || !right) {
+    return false;
+  }
+  if (left.type !== right.type || left.mutationId !== right.mutationId) {
+    return false;
+  }
+  if (left.type !== "errored" || right.type !== "errored") {
+    return true;
+  }
+  return left.code === right.code && left.reason === right.reason;
+}

--- a/packages/jazz-tools/src/runtime/persisted-mutation-error.ts
+++ b/packages/jazz-tools/src/runtime/persisted-mutation-error.ts
@@ -1,0 +1,184 @@
+import type { MutationRejectCode } from "./object-outcomes.js";
+
+const PERSISTED_MUTATION_ERROR_CAUSE_PREFIX = "__jazzPersistedMutationError__:";
+
+export type MutationOperation = "insert" | "update" | "delete";
+
+export interface PersistedMutationErrorData {
+  mutationId: string;
+  rootMutationId: string;
+  objectId: string;
+  branchName: string;
+  operation: MutationOperation;
+  commitIds: string[];
+  previousCommitIds: string[];
+  code: MutationRejectCode;
+  reason: string;
+  rejectedAtMicros: number;
+}
+
+export class PersistedMutationError extends Error implements PersistedMutationErrorData {
+  readonly mutationId: string;
+  readonly rootMutationId: string;
+  readonly objectId: string;
+  readonly branchName: string;
+  readonly operation: MutationOperation;
+  readonly commitIds: string[];
+  readonly previousCommitIds: string[];
+  readonly code: MutationRejectCode;
+  readonly reason: string;
+  readonly rejectedAtMicros: number;
+  readonly acknowledge: () => Promise<void>;
+
+  constructor(
+    data: PersistedMutationErrorData,
+    acknowledgeImpl: (mutationId: string) => Promise<void> | void = async () => {},
+    cause?: unknown,
+  ) {
+    super(`mutation ${data.mutationId} rejected: ${data.reason}`);
+    this.name = "PersistedMutationError";
+    this.mutationId = data.mutationId;
+    this.rootMutationId = data.rootMutationId;
+    this.objectId = data.objectId;
+    this.branchName = data.branchName;
+    this.operation = data.operation;
+    this.commitIds = [...data.commitIds];
+    this.previousCommitIds = [...data.previousCommitIds];
+    this.code = data.code;
+    this.reason = data.reason;
+    this.rejectedAtMicros = data.rejectedAtMicros;
+    this.acknowledge = () => Promise.resolve(acknowledgeImpl(this.mutationId));
+
+    if (cause !== undefined) {
+      (this as { cause?: unknown }).cause = cause;
+    }
+  }
+}
+
+export function isPersistedMutationError(error: unknown): error is PersistedMutationError {
+  return error instanceof PersistedMutationError;
+}
+
+export function normalizePersistedMutationError(
+  error: unknown,
+  acknowledgeImpl: (mutationId: string) => Promise<void> | void = async () => {},
+): PersistedMutationError | null {
+  if (error instanceof PersistedMutationError) {
+    return error;
+  }
+
+  const payload =
+    parsePersistedMutationErrorData(error) ??
+    parsePersistedMutationErrorData(asRecord(error)?.jazzPersistedMutationError) ??
+    parsePersistedMutationErrorData(asRecord(error)?.cause) ??
+    parsePersistedMutationErrorDataFromMessage(asRecord(error)?.message) ??
+    parsePersistedMutationErrorDataFromMessage(asRecord(asRecord(error)?.cause)?.message);
+
+  if (!payload) {
+    return null;
+  }
+
+  return new PersistedMutationError(payload, acknowledgeImpl, error);
+}
+
+function parsePersistedMutationErrorData(value: unknown): PersistedMutationErrorData | null {
+  const record = asRecord(value);
+  if (!record) {
+    return null;
+  }
+
+  const mutationId = asString(record.mutationId);
+  const rootMutationId = asString(record.rootMutationId);
+  const objectId = asString(record.objectId);
+  const branchName = asString(record.branchName);
+  const operation = asMutationOperation(record.operation);
+  const code = asMutationRejectCode(record.code);
+  const reason = asString(record.reason);
+  const rejectedAtMicros = asNumber(record.rejectedAtMicros);
+  const commitIds = asStringArray(record.commitIds);
+  const previousCommitIds = asStringArray(record.previousCommitIds);
+
+  if (
+    !mutationId ||
+    !rootMutationId ||
+    !objectId ||
+    !branchName ||
+    !operation ||
+    !code ||
+    !reason ||
+    rejectedAtMicros === null ||
+    !commitIds ||
+    !previousCommitIds
+  ) {
+    return null;
+  }
+
+  return {
+    mutationId,
+    rootMutationId,
+    objectId,
+    branchName,
+    operation,
+    commitIds,
+    previousCommitIds,
+    code,
+    reason,
+    rejectedAtMicros,
+  };
+}
+
+function parsePersistedMutationErrorDataFromMessage(
+  message: unknown,
+): PersistedMutationErrorData | null {
+  if (typeof message !== "string" || !message.startsWith(PERSISTED_MUTATION_ERROR_CAUSE_PREFIX)) {
+    return null;
+  }
+
+  try {
+    return parsePersistedMutationErrorData(
+      JSON.parse(message.slice(PERSISTED_MUTATION_ERROR_CAUSE_PREFIX.length)),
+    );
+  } catch {
+    return null;
+  }
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : null;
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
+}
+
+function asNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function asStringArray(value: unknown): string[] | null {
+  return Array.isArray(value) && value.every((entry) => typeof entry === "string")
+    ? [...value]
+    : null;
+}
+
+function asMutationRejectCode(value: unknown): MutationRejectCode | null {
+  switch (value) {
+    case "permission_denied":
+    case "session_required":
+    case "catalogue_write_denied":
+      return value;
+    default:
+      return null;
+  }
+}
+
+function asMutationOperation(value: unknown): MutationOperation | null {
+  switch (value) {
+    case "insert":
+    case "update":
+    case "delete":
+      return value;
+    default:
+      return null;
+  }
+}

--- a/packages/jazz-tools/src/runtime/row-transformer.test.ts
+++ b/packages/jazz-tools/src/runtime/row-transformer.test.ts
@@ -5,6 +5,7 @@
 import { describe, it, expect } from "vitest";
 import { unwrapValue, transformRows, type WasmValue } from "./row-transformer.js";
 import type { WasmSchema, WasmRow } from "../drivers/types.js";
+import type { ObjectOutcomeState } from "./object-outcomes.js";
 
 describe("unwrapValue", () => {
   it("unwraps Text to string", () => {
@@ -235,6 +236,41 @@ describe("transformRows", () => {
   it("handles empty rows array", () => {
     const result = transformRows([], schema, "todos");
     expect(result).toEqual([]);
+  });
+
+  it("preserves object outcomes on transformed rows", () => {
+    const rows: Array<WasmRow & { $outcome?: ObjectOutcomeState }> = [
+      {
+        id: "uuid-1",
+        values: [
+          { type: "Text", value: "Buy milk" },
+          { type: "Boolean", value: false },
+          { type: "Integer", value: 5 },
+        ],
+        $outcome: {
+          type: "errored",
+          mutationId: "mutation-1",
+          code: "permission_denied",
+          reason: "blocked",
+          acknowledge: async () => {},
+        },
+      },
+    ];
+
+    const result = transformRows(rows, schema, "todos") as Array<{
+      id: string;
+      title: string;
+      done: boolean;
+      priority: number;
+      $outcome?: ObjectOutcomeState;
+    }>;
+
+    expect(result[0]?.$outcome).toMatchObject({
+      type: "errored",
+      mutationId: "mutation-1",
+      code: "permission_denied",
+      reason: "blocked",
+    });
   });
 
   it("transforms timestamp values to Date objects", () => {

--- a/packages/jazz-tools/src/runtime/row-transformer.ts
+++ b/packages/jazz-tools/src/runtime/row-transformer.ts
@@ -6,6 +6,7 @@ import type { Value as WasmValue, WasmRow, WasmSchema } from "../drivers/types.j
 import type { ColumnType } from "../drivers/types.js";
 import { analyzeRelations, type Relation } from "../codegen/relation-analyzer.js";
 import { magicColumnType } from "../magic-columns.js";
+import type { ObjectOutcomeState } from "./object-outcomes.js";
 import { normalizeIncludeEntries, type NormalizedIncludeSpec } from "./query-builder-shape.js";
 
 export type { WasmValue };
@@ -13,6 +14,10 @@ export type { WasmValue };
 export interface IncludeSpec {
   [relationName: string]: unknown;
 }
+
+type OutcomeAwareWasmRow = WasmRow & {
+  $outcome?: ObjectOutcomeState;
+};
 
 type IncludePlan = {
   relation: Relation;
@@ -215,7 +220,7 @@ export function unwrapValue(v: WasmValue, columnType?: ColumnType): unknown {
  * @returns Array of typed objects with named properties
  */
 export function transformRows<T>(
-  rows: WasmRow[],
+  rows: OutcomeAwareWasmRow[],
   schema: WasmSchema,
   tableName: string,
   includes: IncludeSpec = {},
@@ -231,19 +236,23 @@ export function transformRows<T>(
       : buildIncludePlans(tableName, normalizeIncludeEntries(includes), analyzeRelations(schema));
 
   return rows.map((row) => {
-    return transformRowValues(
+    const transformed = transformRowValues(
       row.values as WasmValue[],
       schema,
       tableName,
       includePlans,
       row.id,
       projection,
-    ) as T;
+    ) as T & { $outcome?: ObjectOutcomeState };
+    if (row.$outcome !== undefined) {
+      transformed.$outcome = row.$outcome;
+    }
+    return transformed as T;
   });
 }
 
 export function transformRow<T>(
-  row: WasmRow,
+  row: OutcomeAwareWasmRow,
   schema: WasmSchema,
   tableName: string,
   includes: IncludeSpec = {},

--- a/packages/jazz-tools/src/runtime/sync-transport.ts
+++ b/packages/jazz-tools/src/runtime/sync-transport.ts
@@ -63,6 +63,7 @@ export interface RuntimeSyncStreamControllerOptions {
   getAuth(): Pick<SyncAuth, "jwtToken" | "localAuthMode" | "localAuthToken" | "backendSecret">;
   getClientId(): string;
   setClientId(clientId: string): void;
+  onSyncMessageReceived?(): void;
 }
 
 function errorMessage(error: unknown): string {
@@ -279,7 +280,11 @@ export function createRuntimeSyncStreamController(
     setClientId: options.setClientId,
     onConnected: () => options.getRuntime()?.addServer(),
     onDisconnected: () => options.getRuntime()?.removeServer(),
-    onSyncMessage: (payload) => options.getRuntime()?.onSyncMessageReceived(payload),
+    onSyncMessage: (payload) => {
+      const runtime = options.getRuntime();
+      runtime?.onSyncMessageReceived(payload);
+      options.onSyncMessageReceived?.();
+    },
   });
 }
 

--- a/packages/jazz-tools/src/runtime/worker-bridge.race-harness.test.ts
+++ b/packages/jazz-tools/src/runtime/worker-bridge.race-harness.test.ts
@@ -46,6 +46,7 @@ class FakeWorkerScript {
         this.shutdownMessageCount += 1;
         this.handleShutdown();
         return;
+      case "acknowledge-mutation-outcome":
       case "update-auth":
       case "simulate-crash":
         return;
@@ -94,7 +95,7 @@ class FakeWorkerScript {
     if (this.initialized) return;
     this.initialized = true;
 
-    this.worker.emitToMain({ type: "init-ok", clientId });
+    this.worker.emitToMain({ type: "init-ok", clientId, objectOutcomes: [] });
 
     const pending = this.pendingSyncPayloads;
     this.pendingSyncPayloads = [];

--- a/packages/jazz-tools/src/runtime/worker-bridge.test.ts
+++ b/packages/jazz-tools/src/runtime/worker-bridge.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { WorkerBridge, type PeerSyncBatch } from "./worker-bridge.js";
 import type { Runtime } from "./client.js";
 import type { WorkerToMainMessage } from "../worker/worker-protocol.js";
-import type { RuntimeObjectOutcomeEvent } from "./object-outcomes.js";
+import type { ObjectOutcomeEvent } from "./object-outcomes.js";
 import { OutboxDestinationKind } from "./sync-transport.js";
 
 class MockWorker {
@@ -211,7 +211,7 @@ describe("WorkerBridge", () => {
     const worker = new MockWorker();
     const runtimeMock = createRuntimeMock();
     const bridge = new WorkerBridge(worker as unknown as Worker, runtimeMock.runtime);
-    const observed: RuntimeObjectOutcomeEvent[][] = [];
+    const observed: ObjectOutcomeEvent[][] = [];
 
     bridge.subscribeObjectOutcomeEvents((events) => {
       observed.push(events);
@@ -268,6 +268,20 @@ describe("WorkerBridge", () => {
     });
     expect(current?.type).toBe("errored");
     expect(observed).toHaveLength(2);
+    expect(observed[1]?.[0]).toMatchObject({
+      objectId: "row-1",
+      outcome: {
+        type: "errored",
+        mutationId: "mutation-1",
+        code: "permission_denied",
+        reason: "blocked",
+      },
+    });
+    const observedOutcome = observed[1]?.[0]?.outcome;
+    expect(observedOutcome?.type).toBe("errored");
+    if (observedOutcome?.type === "errored") {
+      expect(typeof observedOutcome.acknowledge).toBe("function");
+    }
 
     if (!current || current.type !== "errored") {
       throw new Error("expected errored object outcome");

--- a/packages/jazz-tools/src/runtime/worker-bridge.test.ts
+++ b/packages/jazz-tools/src/runtime/worker-bridge.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { WorkerBridge, type PeerSyncBatch } from "./worker-bridge.js";
 import type { Runtime } from "./client.js";
 import type { WorkerToMainMessage } from "../worker/worker-protocol.js";
+import type { RuntimeObjectOutcomeEvent } from "./object-outcomes.js";
 import { OutboxDestinationKind } from "./sync-transport.js";
 
 class MockWorker {
@@ -51,11 +52,13 @@ function createRuntimeMock(): {
   receivedFromWorker: Uint8Array[];
   addServerCalls: { count: number };
   removeServerCalls: { count: number };
+  mutationJournalEnabledCalls: boolean[];
 } {
   let onSyncToSend: SendSyncPayloadCallback | null = null;
   const receivedFromWorker: Uint8Array[] = [];
   const addServerCalls = { count: 0 };
   const removeServerCalls = { count: 0 };
+  const mutationJournalEnabledCalls: boolean[] = [];
 
   const runtime: Runtime = {
     insert: () => ({ id: "id", values: [] }),
@@ -83,6 +86,9 @@ function createRuntimeMock(): {
     removeServer: () => {
       removeServerCalls.count += 1;
     },
+    setMutationJournalEnabled: (enabled: boolean) => {
+      mutationJournalEnabledCalls.push(enabled);
+    },
     addClient: () => "client-id",
     getSchema: () => ({}),
     getSchemaHash: () => "schema-hash",
@@ -104,6 +110,7 @@ function createRuntimeMock(): {
     receivedFromWorker,
     addServerCalls,
     removeServerCalls,
+    mutationJournalEnabledCalls,
   };
 }
 
@@ -117,6 +124,7 @@ describe("WorkerBridge", () => {
     new WorkerBridge(worker as unknown as Worker, runtimeMock.runtime);
 
     expect(runtimeMock.addServerCalls.count).toBe(1);
+    expect(runtimeMock.mutationJournalEnabledCalls).toEqual([false]);
 
     worker.emitFromWorker({
       type: "sync",
@@ -149,7 +157,11 @@ describe("WorkerBridge", () => {
       userBranch: "main",
       dbName: "db-1",
     });
-    worker.emitFromWorker({ type: "init-ok", clientId: "worker-client-123" });
+    worker.emitFromWorker({
+      type: "init-ok",
+      clientId: "worker-client-123",
+      objectOutcomes: [],
+    });
     await initPromise;
     await Promise.resolve();
 
@@ -188,10 +200,91 @@ describe("WorkerBridge", () => {
     worker.emitFromWorker({
       type: "init-ok",
       clientId: "worker-client-123",
+      objectOutcomes: [],
     });
 
     await expect(initPromise).resolves.toBe("worker-client-123");
     expect(bridge.getWorkerClientId()).toBe("worker-client-123");
+  });
+
+  it("mirrors worker-owned object outcomes and acknowledges through the worker", async () => {
+    const worker = new MockWorker();
+    const runtimeMock = createRuntimeMock();
+    const bridge = new WorkerBridge(worker as unknown as Worker, runtimeMock.runtime);
+    const observed: RuntimeObjectOutcomeEvent[][] = [];
+
+    bridge.subscribeObjectOutcomeEvents((events) => {
+      observed.push(events);
+    });
+
+    const initPromise = bridge.init({
+      schemaJson: '{"tables":[]}',
+      appId: "app-1",
+      env: "dev",
+      userBranch: "main",
+      dbName: "db-1",
+    });
+    worker.emitFromWorker({
+      type: "init-ok",
+      clientId: "worker-client-123",
+      objectOutcomes: [
+        {
+          objectId: "row-1",
+          outcome: {
+            type: "pending",
+            mutationId: "mutation-1",
+          },
+        },
+      ],
+    });
+    await initPromise;
+
+    expect(bridge.getObjectOutcome("row-1")).toMatchObject({
+      type: "pending",
+      mutationId: "mutation-1",
+    });
+
+    worker.emitFromWorker({
+      type: "object-outcome-events",
+      events: [
+        {
+          objectId: "row-1",
+          outcome: {
+            type: "errored",
+            mutationId: "mutation-1",
+            code: "permission_denied",
+            reason: "blocked",
+          },
+        },
+      ],
+    });
+
+    const current = bridge.getObjectOutcome("row-1");
+    expect(current).toMatchObject({
+      type: "errored",
+      mutationId: "mutation-1",
+      code: "permission_denied",
+      reason: "blocked",
+    });
+    expect(current?.type).toBe("errored");
+    expect(observed).toHaveLength(2);
+
+    if (!current || current.type !== "errored") {
+      throw new Error("expected errored object outcome");
+    }
+
+    expect(typeof current.acknowledge).toBe("function");
+    const acknowledgePromise = current.acknowledge();
+    expect(worker.posted).toContainEqual({
+      type: "acknowledge-mutation-outcome",
+      mutationId: "mutation-1",
+    });
+
+    worker.emitFromWorker({
+      type: "acknowledge-mutation-outcome-ok",
+      mutationId: "mutation-1",
+    });
+    await acknowledgePromise;
   });
 
   it("detaches runtime server on shutdown and stops forwarding after disposal", async () => {

--- a/packages/jazz-tools/src/runtime/worker-bridge.ts
+++ b/packages/jazz-tools/src/runtime/worker-bridge.ts
@@ -7,6 +7,11 @@
  */
 
 import type { Runtime } from "./client.js";
+import {
+  ObjectOutcomeMirror,
+  type ObjectOutcomeSource,
+  type RuntimeObjectOutcomeEvent,
+} from "./object-outcomes.js";
 import type {
   InitMessage,
   WorkerLifecycleEvent,
@@ -58,6 +63,7 @@ interface WorkerBridgeState {
 
 const INIT_RESPONSE_TIMEOUT_MS = 12_000;
 const SHUTDOWN_ACK_TIMEOUT_MS = 5_000;
+const ACK_RESPONSE_TIMEOUT_MS = 5_000;
 
 /**
  * Bridge between main-thread runtime and dedicated worker.
@@ -67,10 +73,13 @@ const SHUTDOWN_ACK_TIMEOUT_MS = 5_000;
  * - Forwards incoming sync messages from the worker to the main runtime
  * - The worker is treated as the main thread's "server" for sync purposes
  */
-export class WorkerBridge {
+export class WorkerBridge implements ObjectOutcomeSource {
   private worker: Worker;
   private runtime: Runtime;
   private state: WorkerBridgeState;
+  private readonly objectOutcomes = new ObjectOutcomeMirror((mutationId) =>
+    this.requestMutationOutcomeAcknowledgement(mutationId),
+  );
 
   constructor(worker: Worker, runtime: Runtime) {
     this.worker = worker;
@@ -84,6 +93,7 @@ export class WorkerBridge {
       peerSyncListener: null,
       serverPayloadForwarder: null,
     };
+    this.runtime.setMutationJournalEnabled?.(false);
 
     // Wire worker → main: incoming sync messages from worker
     this.worker.onmessage = (event: MessageEvent<WorkerToMainMessage>) => {
@@ -98,6 +108,10 @@ export class WorkerBridge {
           term: msg.term,
           payload: msg.payload,
         });
+      } else if (msg.type === "init-ok") {
+        this.objectOutcomes.replaceSnapshot(msg.objectOutcomes);
+      } else if (msg.type === "object-outcome-events") {
+        this.objectOutcomes.applyEvents(msg.events);
       }
     };
 
@@ -180,6 +194,7 @@ export class WorkerBridge {
             // Ignore late init-ok after a terminal transition.
             throw new Error("Worker init response arrived after bridge left initializing state");
           }
+          this.objectOutcomes.replaceSnapshot(response.objectOutcomes);
           this.transition({ type: "INIT_OK", clientId: response.clientId });
           this.flushPendingSyncToWorker();
           return response.clientId;
@@ -252,6 +267,20 @@ export class WorkerBridge {
     return this.state.workerClientId;
   }
 
+  getObjectOutcome(objectId: string) {
+    return this.objectOutcomes.getObjectOutcome(objectId);
+  }
+
+  subscribeObjectOutcomeEvents(
+    listener: (events: RuntimeObjectOutcomeEvent[]) => void,
+  ): () => void {
+    return this.objectOutcomes.subscribeObjectOutcomeEvents(listener);
+  }
+
+  acknowledgeMutationOutcome(mutationId: string): Promise<void> {
+    return this.objectOutcomes.acknowledgeMutationOutcome(mutationId);
+  }
+
   setServerPayloadForwarder(forwarder: ((payload: Uint8Array) => void) | null): void {
     if (this.isDisposedLike()) return;
     this.state.serverPayloadForwarder = forwarder;
@@ -266,6 +295,31 @@ export class WorkerBridge {
     if (this.isDisposedLike()) return;
     this.runtime.removeServer();
     this.runtime.addServer();
+  }
+
+  private async requestMutationOutcomeAcknowledgement(mutationId: string): Promise<void> {
+    if (this.isDisposedLike()) {
+      throw new Error("WorkerBridge has been disposed");
+    }
+
+    const responsePromise = waitForMessage<WorkerToMainMessage>(
+      this.worker,
+      (msg) =>
+        (msg.type === "acknowledge-mutation-outcome-ok" && msg.mutationId === mutationId) ||
+        msg.type === "error",
+      ACK_RESPONSE_TIMEOUT_MS,
+      "Mutation outcome acknowledgement timeout",
+    );
+
+    this.worker.postMessage({
+      type: "acknowledge-mutation-outcome",
+      mutationId,
+    });
+
+    const response = await responsePromise;
+    if (response.type === "error") {
+      throw new Error(`Mutation outcome acknowledgement failed: ${response.message}`);
+    }
   }
 
   onPeerSync(listener: (batch: PeerSyncBatch) => void): void {

--- a/packages/jazz-tools/src/runtime/worker-bridge.ts
+++ b/packages/jazz-tools/src/runtime/worker-bridge.ts
@@ -9,8 +9,8 @@
 import type { Runtime } from "./client.js";
 import {
   ObjectOutcomeMirror,
+  type ObjectOutcomeEvent,
   type ObjectOutcomeSource,
-  type RuntimeObjectOutcomeEvent,
 } from "./object-outcomes.js";
 import type {
   InitMessage,
@@ -271,9 +271,7 @@ export class WorkerBridge implements ObjectOutcomeSource {
     return this.objectOutcomes.getObjectOutcome(objectId);
   }
 
-  subscribeObjectOutcomeEvents(
-    listener: (events: RuntimeObjectOutcomeEvent[]) => void,
-  ): () => void {
+  subscribeObjectOutcomeEvents(listener: (events: ObjectOutcomeEvent[]) => void): () => void {
     return this.objectOutcomes.subscribeObjectOutcomeEvents(listener);
   }
 

--- a/packages/jazz-tools/src/types/jazz-wasm.d.ts
+++ b/packages/jazz-tools/src/types/jazz-wasm.d.ts
@@ -1,4 +1,18 @@
 declare module "jazz-wasm" {
+  type WasmMutationRejectCode = "permission_denied" | "session_required" | "catalogue_write_denied";
+  type WasmObjectOutcomeState =
+    | { type: "pending"; mutationId: string }
+    | { type: "accepted"; mutationId: string }
+    | {
+        type: "errored";
+        mutationId: string;
+        code: WasmMutationRejectCode;
+        reason: string;
+      };
+  type WasmObjectOutcomeEvent = {
+    objectId: string;
+    outcome: WasmObjectOutcomeState | null;
+  };
   type SyncOutboxCallbackArgs =
     | [
         destinationKind: "server" | "client",
@@ -62,6 +76,10 @@ declare module "jazz-wasm" {
     unsubscribe(handle: number): void;
     onSyncMessageReceived(messageJson: string): void;
     onSyncMessageToSend(callback: SyncOutboxCallback): void;
+    setMutationJournalEnabled(enabled: boolean): void;
+    listObjectOutcomes(): WasmObjectOutcomeEvent[];
+    takeObjectOutcomeEvents(): WasmObjectOutcomeEvent[];
+    acknowledgeMutationOutcome(mutationId: string): void;
     addServer(): void;
     removeServer(): void;
     addClient(): string;

--- a/packages/jazz-tools/src/worker/jazz-worker.ts
+++ b/packages/jazz-tools/src/worker/jazz-worker.ts
@@ -7,6 +7,7 @@
  */
 
 import type { InitMessage, MainToWorkerMessage, WorkerToMainMessage } from "./worker-protocol.js";
+import type { RuntimeObjectOutcomeEvent } from "../runtime/object-outcomes.js";
 import {
   sendSyncPayload,
   readBinaryFrames,
@@ -112,6 +113,28 @@ function post(msg: WorkerToMainMessage): void {
       ? collectPayloadTransferables(msg.payload)
       : undefined;
   self.postMessage(msg, transfer);
+}
+
+function listObjectOutcomes(): RuntimeObjectOutcomeEvent[] {
+  if (!runtime?.listObjectOutcomes) {
+    return [];
+  }
+  return runtime.listObjectOutcomes() as RuntimeObjectOutcomeEvent[];
+}
+
+function takeObjectOutcomeEvents(): RuntimeObjectOutcomeEvent[] {
+  if (!runtime?.takeObjectOutcomeEvents) {
+    return [];
+  }
+  return runtime.takeObjectOutcomeEvents() as RuntimeObjectOutcomeEvent[];
+}
+
+function flushObjectOutcomeEvents(): void {
+  const events = takeObjectOutcomeEvents();
+  if (events.length === 0) {
+    return;
+  }
+  post({ type: "object-outcome-events", events });
 }
 
 function collectPayloadTransferables(payloads: (Uint8Array | string)[]): Transferable[] {
@@ -282,7 +305,11 @@ async function handleInit(msg: InitMessage): Promise<void> {
       bootstrapCatalogueForwarding = false;
     }
 
-    post({ type: "init-ok", clientId: mainClientId! });
+    post({
+      type: "init-ok",
+      clientId: mainClientId!,
+      objectOutcomes: listObjectOutcomes(),
+    });
 
     // Connect upstream in background (do not block init).
     if (activeServerUrl) {
@@ -406,7 +433,10 @@ async function connectStream(): Promise<void> {
     await readBinaryFrames(
       reader,
       {
-        onSyncMessage: (payload) => runtime?.onSyncMessageReceived(payload),
+        onSyncMessage: (payload) => {
+          runtime?.onSyncMessageReceived(payload);
+          flushObjectOutcomeEvents();
+        },
         onConnected: (clientId) => {
           console.log("[worker] Stream connected", { clientId });
           serverClientId = clientId;
@@ -501,6 +531,7 @@ self.onmessage = async (event: MessageEvent<MainToWorkerMessage>) => {
         for (const payload of payloads) {
           runtime.onSyncMessageReceivedFromClient(mainClientId, payload);
         }
+        flushObjectOutcomeEvents();
       } else {
         pendingSyncMessages.push(...payloads);
       }
@@ -529,6 +560,7 @@ self.onmessage = async (event: MessageEvent<MainToWorkerMessage>) => {
       for (const payload of msg.payload) {
         runtime.onSyncMessageReceivedFromClient(peerClientId, payload);
       }
+      flushObjectOutcomeEvents();
       break;
     }
 
@@ -556,6 +588,26 @@ self.onmessage = async (event: MessageEvent<MainToWorkerMessage>) => {
       detachServer();
       if (activeServerUrl && !isShuttingDown) {
         scheduleReconnect();
+      }
+      break;
+
+    case "acknowledge-mutation-outcome":
+      if (!runtime || !initComplete) {
+        post({
+          type: "error",
+          message: "acknowledge-mutation-outcome requested before worker init complete",
+        });
+        break;
+      }
+      try {
+        runtime.acknowledgeMutationOutcome(msg.mutationId);
+        flushObjectOutcomeEvents();
+        post({ type: "acknowledge-mutation-outcome-ok", mutationId: msg.mutationId });
+      } catch (error: any) {
+        post({
+          type: "error",
+          message: `acknowledge-mutation-outcome failed: ${error?.message ?? error}`,
+        });
       }
       break;
 

--- a/packages/jazz-tools/src/worker/worker-protocol.ts
+++ b/packages/jazz-tools/src/worker/worker-protocol.ts
@@ -4,6 +4,8 @@
  * Pure type definitions — no runtime code.
  */
 
+import type { RuntimeObjectOutcomeEvent } from "../runtime/object-outcomes.js";
+
 // ============================================================================
 // Main Thread → Worker Messages
 // ============================================================================
@@ -80,6 +82,12 @@ export interface UpdateAuthMessage {
   localAuthToken?: string;
 }
 
+/** Acknowledge a surfaced mutation outcome in the worker-owned journal. */
+export interface AcknowledgeMutationOutcomeMessage {
+  type: "acknowledge-mutation-outcome";
+  mutationId: string;
+}
+
 /** Request graceful shutdown. */
 export interface ShutdownMessage {
   type: "shutdown";
@@ -113,6 +121,7 @@ export type MainToWorkerMessage =
   | PeerSyncToWorkerMessage
   | PeerCloseMessage
   | UpdateAuthMessage
+  | AcknowledgeMutationOutcomeMessage
   | ShutdownMessage
   | SimulateCrashMessage
   | DebugSchemaStateMessage
@@ -131,6 +140,7 @@ export interface ReadyMessage {
 export interface InitOkMessage {
   type: "init-ok";
   clientId: string;
+  objectOutcomes: RuntimeObjectOutcomeEvent[];
 }
 
 /** Forward a sync payload from worker to main thread. */
@@ -147,6 +157,12 @@ export interface PeerSyncToMainMessage {
   payload: Uint8Array[];
 }
 
+/** Worker-owned object outcome changes mirrored to the main thread. */
+export interface ObjectOutcomeEventsMessage {
+  type: "object-outcome-events";
+  events: RuntimeObjectOutcomeEvent[];
+}
+
 /** Worker encountered an error. */
 export interface ErrorMessage {
   type: "error";
@@ -156,6 +172,12 @@ export interface ErrorMessage {
 /** Worker has completed shutdown (OPFS handles released). */
 export interface ShutdownOkMessage {
   type: "shutdown-ok";
+}
+
+/** Worker confirmed a mutation outcome acknowledgement. */
+export interface AcknowledgeMutationOutcomeOkMessage {
+  type: "acknowledge-mutation-outcome-ok";
+  mutationId: string;
 }
 
 export interface DebugLensEdgeState {
@@ -187,7 +209,9 @@ export type WorkerToMainMessage =
   | InitOkMessage
   | SyncToMainMessage
   | PeerSyncToMainMessage
+  | ObjectOutcomeEventsMessage
   | ErrorMessage
+  | AcknowledgeMutationOutcomeOkMessage
   | ShutdownOkMessage
   | DebugSchemaStateOkMessage
   | DebugSeedLiveSchemaOkMessage;

--- a/specs/todo/a_mvp/permissions_and_optimistic_updates.md
+++ b/specs/todo/a_mvp/permissions_and_optimistic_updates.md
@@ -1,56 +1,666 @@
-# Permissions & Optimistic Update DX — TODO
+# Mutation Outcome And Rejection Infrastructure (Rust-First, MVP)
 
-Declarative permission policies with good DX for optimistic local-first writes.
+## Status
 
-## Phasing
+Proposed for immediate implementation.
 
-- **MVP**: Sync settlement tracking — spec and implement "accepted by sync server" state on mutations. Declarative ReBAC policies already exist.
-- **Launch**: API design for exposing settlement state + developer recommendations for handling rejections, offline duration, pending UI patterns.
+## Goals
 
-## Overview
+1. Add shared Rust-core infrastructure for tracking local mutations after they leave the local-first fast path.
+2. Distinguish durability from authoritative sync outcome.
+3. Persist mutation outcome state so rejections survive restart and long offline periods.
+4. Make rejection handling available to all bindings through core event and lookup APIs rather than TS-only logic.
+5. Roll back rejected local mutations in core so the canonical local database converges back to accepted state.
 
-Permissions are enforced **on the server only**. Local writes are applied immediately as optimistic updates, then confirmed or rejected by the server after sync.
+## Non-Goals
 
-### Permission Model (exists as ReBAC)
+1. Defining app UX defaults in core APIs.
+2. Shipping a TS-specific issue inbox abstraction.
+3. Storing app-specific draft payloads or recovery UI state in core storage.
+4. Solving multi-row transactions or cross-object atomic outcome tracking.
+5. Reworking read durability semantics; this RFC is write-focused.
 
-Declarative policies already exist. JWT-native auth allows policies to inspect token claims directly. The backend creates **scoped clients** per JWT — Jazz enforces permissions, not backend code.
+## Problem
 
-### MVP: Sync Settlement Tracking
+Current behavior is insufficient in four ways:
 
-The immediate need is tracking whether a mutation has been accepted by the sync server:
+1. The server already emits permission denials as `SyncPayload::Error(SyncError::PermissionDenied { ... })`, but the client path mostly logs or ignores them.
+2. There is no persisted mutation ledger, so a rejection that arrives hours later cannot be surfaced reliably after restart.
+3. There is no core rollback path for rejected optimistic writes, so rejected local commits can remain visible indefinitely.
+4. Durable mutation waiters only understand `PersistenceAck`; a mutation rejected before the requested remote ack can hang forever.
 
-- Each mutation carries a settlement state (local → synced → accepted / rejected)
-- The sync protocol already has PersistenceAck — extend this to cover permission acceptance
-- Internal state only for MVP; API exposure comes at launch
+This is fundamentally a Rust-core concern, not a frontend concern. Bindings should consume shared mutation outcome state rather than each inventing separate rejection tracking.
 
-### Launch: Optimistic Update API & DX
+## Terminology
 
-**Default behavior** (good for most apps):
+### Durability
 
-- Writes appear immediately in the local query results
-- If the server rejects, the write disappears (rollback)
-- Reactive queries update automatically on rollback
+Whether a commit has been persisted at a tier (`worker < edge < global`).
 
-**Explicit pending state** (for apps that need it):
+This remains modeled by `PersistenceAck`.
 
-- Rows/mutations carry a settlement tier indicator
-- Developers can show "pending" / "confirmed" / "rejected" states in UI
-- Query filter: "only show confirmed rows" or "show all including pending"
+### Outcome
 
-## Scoped Backend Clients
+Whether the first authoritative sync server has accepted or rejected a local mutation.
 
-When a backend needs to interact with Jazz (e.g., for side effects, webhooks):
+Outcome is not the same thing as durability:
 
-- Receive the calling user's JWT
-- Create a Jazz client scoped to that JWT
-- All queries/mutations through that client respect the user's permissions
-- No need for imperative permission checks in backend code
+1. A mutation may be durable at `worker` and still later be rejected remotely.
+2. A mutation may be accepted by the authority but not yet durable at the caller's requested tier.
 
-## Open Questions
+### Mutation Record
 
-- Policy language: SQL-like `WHERE` clauses? DSL expressions? Both?
-- How to test permissions? (Unit test policies against mock JWTs?)
-- Can policies reference related tables? (e.g., "allow if user is member of the row's organization")
-- Admin override: how do admin/peer clients bypass policies?
-- How to communicate rejection reason to the client? (Generic "permission denied" vs. specific?)
-- Offline duration: if a user is offline for days with optimistic writes, what happens when they come back and many are rejected?
+A persisted local record describing one local write operation and its lifecycle.
+
+### Rejection
+
+An authoritative negative outcome for a local mutation, including the reason and the commits that must be rolled back.
+
+## Design Summary
+
+The MVP introduces four pieces:
+
+1. A persisted mutation journal in Rust storage.
+2. An explicit sync protocol payload for mutation outcome (`accepted` or `rejected`).
+3. RuntimeCore watchers and event queues that bindings can expose as callbacks/promises/lookups.
+4. Core rollback of rejected local commit chains.
+5. An explicit acknowledgement step that bounds retained rejected outcomes and prunes dead local commits.
+
+The core rule is:
+
+`PersistenceAck` answers "is this durable at tier T?"
+
+`MutationOutcome` answers "did the authority accept or reject this write?"
+
+Both are required.
+
+The retention rule is:
+
+1. `pending` outcomes are retained while unresolved
+2. `rejected` outcomes are retained until acknowledged by the app
+3. `accepted` outcomes may be compacted aggressively and do not require user acknowledgement
+4. unacknowledged rejected outcomes are capped by a high count bound to avoid unbounded storage growth if the app never acknowledges them
+
+## Proposed Rust Types
+
+### Identifiers And Basic Enums
+
+```rust
+pub struct MutationId(pub Uuid);
+
+pub enum MutationOperation {
+    Insert,
+    Update,
+    Delete,
+}
+
+pub enum MutationRejectCode {
+    PermissionDenied,
+    SessionRequired,
+    CatalogueWriteDenied,
+}
+```
+
+### Outcome Payloads
+
+```rust
+pub enum MutationOutcome {
+    Accepted(MutationAcceptance),
+    Rejected(MutationRejection),
+}
+
+pub struct MutationAcceptance {
+    pub object_id: ObjectId,
+    pub branch_name: BranchName,
+    pub operation: MutationOperation,
+    pub commit_ids: Vec<CommitId>,
+    pub previous_commit_ids: Vec<CommitId>,
+    pub accepted_at_micros: u64,
+}
+
+pub struct MutationRejection {
+    pub object_id: ObjectId,
+    pub branch_name: BranchName,
+    pub operation: MutationOperation,
+    pub commit_ids: Vec<CommitId>,
+    pub previous_commit_ids: Vec<CommitId>,
+    pub code: MutationRejectCode,
+    pub reason: String,
+    pub rejected_at_micros: u64,
+}
+```
+
+Why commit IDs, not protocol-level mutation IDs:
+
+1. Commit IDs already exist at mutation creation time.
+2. Server-side permission evaluation already has access to the rejected payload and therefore its commit IDs.
+3. This avoids adding client-only correlation fields to `ObjectUpdated`.
+
+Local `MutationId` still exists in storage and lookup APIs, but wire correlation uses commit IDs in MVP.
+
+### Persisted Mutation Journal
+
+```rust
+pub enum MutationOutcomeState {
+    Pending,
+    Accepted,
+    Rejected(MutationRejection),
+    SupersededByRejection { root_mutation_id: MutationId },
+}
+
+pub struct MutationRecord {
+    pub id: MutationId,
+    pub object_id: ObjectId,
+    pub branch_name: BranchName,
+    pub table: Option<String>,
+    pub operation: MutationOperation,
+    pub commit_ids: Vec<CommitId>,
+    pub previous_commit_ids: Vec<CommitId>,
+    pub recorded_at_micros: u64,
+    pub highest_acked_tier: Option<DurabilityTier>,
+    pub outcome: MutationOutcomeState,
+}
+```
+
+`highest_acked_tier` and `outcome` are intentionally separate fields.
+
+Rejected mutation records are durable until explicitly acknowledged. Accepted records are allowed to be compacted after they have served event/overlay consumers.
+
+Wall-clock timestamps are part of the MVP. Use microseconds since Unix epoch for consistency with existing commit timestamps and ordering.
+
+### Object Outcome Overlay
+
+Bindings need a row-visible outcome surface that does not require a separate TS-only issue store.
+
+Core should therefore also expose an object-scoped overlay:
+
+```rust
+pub enum ObjectOutcomeState {
+    Pending {
+        mutation_id: MutationId,
+    },
+    Accepted {
+        mutation_id: MutationId,
+    },
+    Errored {
+        mutation_id: MutationId,
+        code: MutationRejectCode,
+        reason: String,
+    },
+}
+```
+
+This is derived state, not a second journal.
+
+Rules:
+
+1. It is keyed by `object_id`.
+2. It represents the latest locally relevant outcome that has not yet been compacted away.
+3. `Errored` remains until acknowledgement.
+4. `Accepted` is transient and may disappear after bindings have had a chance to surface it.
+
+### Runtime Events
+
+```rust
+pub enum MutationEvent {
+    Recorded { mutation_id: MutationId },
+    AckAdvanced {
+        mutation_id: MutationId,
+        tier: DurabilityTier,
+    },
+    Accepted {
+        mutation_id: MutationId,
+    },
+    Rejected {
+        mutation_id: MutationId,
+        rejection: MutationRejection,
+    },
+    SupersededByRejection {
+        mutation_id: MutationId,
+        root_mutation_id: MutationId,
+    },
+    Acknowledged {
+        mutation_id: MutationId,
+    },
+}
+```
+
+Bindings can turn these into callbacks, observables, or event emitters. Core only needs a drainable queue.
+
+## Sync Protocol Changes
+
+### New Payload Variant
+
+`SyncPayload` gains:
+
+```rust
+SyncPayload::MutationOutcome(MutationOutcome)
+```
+
+`SyncPayload::Error` remains for non-mutation protocol failures such as:
+
+1. `QuerySubscriptionRejected`
+2. general sync/server diagnostics
+
+Mutation denials stop using generic `SyncPayload::Error` and instead use `SyncPayload::MutationOutcome(MutationOutcome::Rejected(...))`.
+
+### Emission Rules
+
+The first authoritative server that processes a client-originated write must send one terminal outcome back to the originating client:
+
+1. `Accepted` after the write is successfully applied server-side.
+2. `Rejected` if the write is denied before apply.
+
+This includes:
+
+1. User writes denied by ReBAC.
+2. Immediate write denials such as `SessionRequired` or `CatalogueWriteDenied`.
+3. Trusted backend/admin writes that are accepted without ReBAC still emit `Accepted`.
+
+Peer/server-to-server relays do not need local mutation outcome tracking.
+
+Only the first authority emits acceptance or rejection for a given client-originated mutation. Upstream authorities do not re-emit accepted outcomes for the same mutation.
+
+### Ordering
+
+`MutationOutcome` is terminal and single-shot per source mutation.
+
+Invariants:
+
+1. A mutation cannot emit both `Accepted` and `Rejected`.
+2. If a parent commit is rejected, a descendant mutation from the same local chain must not later be accepted.
+3. `PersistenceAck` may arrive before or after `Accepted`, depending on topology, but `Rejected` forbids any later acceptance.
+
+## Core State Ownership
+
+### SyncManager
+
+`SyncManager` should gain:
+
+1. `received_mutation_outcomes: Vec<MutationOutcome>`
+2. helper methods for emitting `MutationOutcome` to a source client
+
+Responsibilities:
+
+1. Turn server-side write results into `MutationOutcome` payloads.
+2. Queue inbound `MutationOutcome` messages for `RuntimeCore`.
+
+### RuntimeCore
+
+`RuntimeCore` should gain:
+
+1. a persisted mutation journal facade backed by `Storage`
+2. mutation waiters keyed by local `MutationId`
+3. a drainable `mutation_events` queue
+4. object outcome overlay lookup/invalidation
+
+Suggested fields:
+
+```rust
+mutation_events: Vec<MutationEvent>,
+mutation_waiters: HashMap<MutationId, Vec<oneshot::Sender<Result<(), MutationRejection>>>>,
+commit_to_mutation: HashMap<CommitId, MutationId>,
+```
+
+`commit_to_mutation` may be reconstructed from storage on startup or lazily hydrated.
+
+### Storage
+
+`Storage` should gain first-class mutation journal methods.
+
+Suggested trait additions:
+
+```rust
+fn put_mutation_record(&mut self, record: MutationRecord) -> Result<(), StorageError>;
+
+fn load_mutation_record(
+    &self,
+    mutation_id: MutationId,
+) -> Result<Option<MutationRecord>, StorageError>;
+
+fn load_mutation_record_by_commit(
+    &self,
+    commit_id: CommitId,
+) -> Result<Option<MutationRecord>, StorageError>;
+
+fn delete_mutation_record(
+    &mut self,
+    mutation_id: MutationId,
+) -> Result<(), StorageError>;
+
+fn list_mutation_records_by_outcome(
+    &self,
+    outcome: MutationOutcomeFilter,
+) -> Result<Vec<MutationRecord>, StorageError>;
+```
+
+The exact storage indexing can differ by backend. The important requirement is that mutation state survives restart and is queryable by commit ID and outcome state.
+
+The journal does not need to retain acknowledged rejected records or compacted accepted records.
+
+### Retention Bound
+
+Add a hard safety bound for unacknowledged rejected outcomes:
+
+```rust
+const MAX_RETAINED_UNACKNOWLEDGED_REJECTIONS: usize = 10_000;
+```
+
+Scope:
+
+1. per local app database / storage namespace
+2. applies only to rejected outcomes awaiting acknowledgement
+
+When the bound is exceeded:
+
+1. the oldest rejected outcomes by `rejected_at_micros` are force-compacted oldest-first
+2. their dead/local-unreachable commit chains are pruned
+3. their object outcome overlays are cleared
+
+This is a storage safety valve, not the primary user-facing flow.
+
+## Mutation Recording
+
+Every local write recorded by RuntimeCore should create a `MutationRecord` immediately after the local commit is created.
+
+This applies to:
+
+1. `insert`
+2. `update`
+3. `delete`
+4. durable variants of the above
+
+Recording rules:
+
+1. Generate a `MutationId`.
+2. Capture `object_id`, `branch_name`, `operation`, `commit_ids`, `previous_commit_ids`, and table name if known.
+3. Persist the record with `outcome = Pending`.
+4. Emit `MutationEvent::Recorded`.
+
+This must happen for both sync and durable mutation APIs so later lookup works uniformly.
+
+If the write affects a currently visible object, the object outcome overlay should become `Pending` and active subscriptions for rows containing that object should be invalidated.
+
+## Durable Mutation Waiter Semantics
+
+Durable mutation APIs remain durability-based, but they must also understand rejection.
+
+Rules:
+
+1. A waiter for `edge` or `global` must reject if the mutation is authoritatively rejected before the requested ack arrives.
+2. A waiter for `worker` may resolve before remote outcome. Later rejection is then surfaced only through mutation events and lookup APIs.
+3. Durable waiters must never hang forever after a terminal rejection.
+
+This preserves the meaning of durability tiers while fixing the current missing negative path.
+
+## Acceptance Handling
+
+On inbound `MutationOutcome::Accepted`:
+
+1. Find local mutation record(s) by commit ID.
+2. Mark outcome as `Accepted`.
+3. Persist the update.
+4. Emit `MutationEvent::Accepted`.
+
+Acceptance does not resolve durability waiters by itself. Only `PersistenceAck` resolves durability thresholds.
+
+If an object remains visible after acceptance, the object outcome overlay may briefly transition to `Accepted` before being compacted.
+
+## Rejection Handling
+
+On inbound `MutationOutcome::Rejected`:
+
+1. Find the root local mutation record by rejected commit ID.
+2. Compute all pending local descendant mutations that depend on the rejected commit chain.
+3. Roll back the affected local commits from the canonical object graph.
+4. Mark the root record `Rejected`.
+5. Mark descendant local records `SupersededByRejection { root_mutation_id }`.
+6. Persist all state updates.
+7. Reject unresolved durable waiters for the root and descendants.
+8. Emit `Rejected` and `SupersededByRejection` events.
+
+The rejection payload itself should be persisted on the root mutation record.
+
+## Rollback Semantics
+
+Rollback is a correctness requirement, not just UX.
+
+### Scope
+
+Rollback is per object/branch mutation chain in MVP.
+
+The affected set is:
+
+1. the rejected mutation's commits
+2. any still-pending local descendant mutations whose `previous_commit_ids` depend on that chain
+
+### Restore Point
+
+Restore tips are the nearest surviving ancestor commit IDs not included in the affected rejected/superseded set.
+
+Examples:
+
+1. rejected insert with no prior history: object disappears locally
+2. rejected update after accepted commit `c1`: branch tip restores to `c1`
+3. rejected delete after accepted commit `c7`: branch tip restores to `c7`
+
+### Implementation Shape
+
+The rollback operation should live below bindings, likely as a `QueryManager`/`ObjectManager` helper invoked by RuntimeCore. It must:
+
+1. remove rejected local commit(s) from the active branch tips so they no longer affect canonical query results
+2. restore prior tips
+3. retain the rejected commit chain as locally dead/unreachable until acknowledgement
+4. trigger the same query invalidation/update path as ordinary data changes
+
+No app code should have to manually revert rejected writes.
+
+This split is important:
+
+1. rejection rollback is immediate for correctness
+2. physical pruning is deferred until acknowledgement so the rejection can still be inspected and surfaced
+
+## Acknowledgement And Pruning
+
+Rejected outcomes must be bounded. The mechanism is explicit acknowledgement.
+
+Core should expose:
+
+```rust
+pub fn acknowledge_mutation_outcome(
+    &mut self,
+    mutation_id: MutationId,
+) -> Result<(), RuntimeError>;
+```
+
+Semantics:
+
+1. The call is valid for rejected outcomes and idempotent for already-removed records.
+2. It clears the unacknowledged rejected outcome from the durable journal.
+3. It prunes the rejected dead/local-unreachable commit chain that was retained after rollback.
+4. It clears any object outcome overlay derived from that rejected outcome.
+5. It emits `MutationEvent::Acknowledged`.
+
+This is the primitive both row-level and global notification surfaces should call.
+
+Accepted outcomes do not require acknowledgement and should usually be compacted automatically.
+
+If a rejected outcome is removed by the high count bound rather than explicit acknowledgement, core should perform the same prune-and-clear behavior without surfacing it as a user acknowledgement.
+
+## Notification Model
+
+Core should support two notification surfaces.
+
+### Visible Data: Row Outcome Overlay
+
+For rows that are currently visible through active queries, bindings should be able to expose a reserved `$outcome` field derived from `ObjectOutcomeState`.
+
+Conceptually:
+
+```ts
+$outcome:
+  | { type: "pending" }
+  | { type: "accepted" }
+  | { type: "errored", code, reason, acknowledge: () => void }
+```
+
+The closure is binding-created. Core only needs to provide the underlying `mutation_id`.
+
+Important consequence:
+
+Active subscriptions must re-fire when `$outcome` changes, even if the row's ordinary columns do not.
+
+That means outcome overlay changes are part of the subscription invalidation model, not merely a passive lookup table.
+
+### Invisible Data: Global Outcome Events
+
+For mutations that no active query currently surfaces, bindings should expose a global hook/event stream.
+
+Example shape at the binding layer:
+
+```ts
+onMutationOutcome((event) => {
+  if (event.type === "rejected") {
+    event.acknowledge();
+  }
+});
+```
+
+Again, the callback is binding-level sugar over `acknowledge_mutation_outcome(mutation_id)`.
+
+### Rejected Inserts
+
+A rejected insert often will not have any visible row after rollback, so the global outcome hook remains necessary even if row overlays exist.
+
+## Lookup APIs
+
+Core should expose shared lookup methods instead of embedding UI concepts.
+
+Suggested RuntimeCore surface:
+
+```rust
+pub fn take_mutation_events(&mut self) -> Vec<MutationEvent>;
+
+pub fn get_mutation_record(
+    &self,
+    mutation_id: MutationId,
+) -> Result<Option<MutationRecord>, RuntimeError>;
+
+pub fn get_mutation_record_by_commit(
+    &self,
+    commit_id: CommitId,
+) -> Result<Option<MutationRecord>, RuntimeError>;
+
+pub fn list_rejected_mutations(&self) -> Result<Vec<MutationRecord>, RuntimeError>;
+
+pub fn list_pending_mutations(&self) -> Result<Vec<MutationRecord>, RuntimeError>;
+
+pub fn list_mutations_for_object(
+    &self,
+    object_id: ObjectId,
+) -> Result<Vec<MutationRecord>, RuntimeError>;
+
+pub fn get_object_outcome(
+    &self,
+    object_id: ObjectId,
+) -> Result<Option<ObjectOutcomeState>, RuntimeError>;
+
+pub fn acknowledge_mutation_outcome(
+    &mut self,
+    mutation_id: MutationId,
+) -> Result<(), RuntimeError>;
+```
+
+Bindings may wrap these as:
+
+1. callbacks
+2. event emitters
+3. reactive stores
+4. row enrichment with `$outcome`
+5. promise rejection helpers
+
+The Rust core should not define a TS-only inbox abstraction.
+
+## Binding Guidance
+
+Bindings should build language-appropriate APIs on top of core state:
+
+1. callback-style: `onMutationOutcome(...)`
+2. lookup-style: `listRejectedMutations()`, `getMutationRecord(...)`
+3. row-level `$outcome` enrichment for visible data
+4. global notifications for invisible data
+5. durable API rejection for unresolved remote-tier waiters
+
+Bindings should not duplicate mutation journals in binding-local storage.
+
+## Documentation Guidance
+
+Docs should recommend app patterns, but those patterns are not part of the Rust core contract.
+
+Recommended topics for docs and examples:
+
+1. show inline row-level state when the affected object is visible
+2. also surface delayed rejections in a global sync issues area
+3. explain that `worker` durability does not imply remote acceptance
+4. recommend app-managed draft recovery if rejected payload content must be restorable
+5. explain how `acknowledge()` clears a surfaced rejection and prunes retained dead commits
+6. explain how to query mutation records by object ID after an update/delete call
+
+This guidance should live in docs/examples, not in core types.
+
+## Migration From Current Behavior
+
+### SyncError
+
+Move these out of generic mutation-error handling:
+
+1. `PermissionDenied`
+2. `SessionRequired`
+3. `CatalogueWriteDenied`
+
+They become `MutationRejectCode` values carried by `MutationOutcome::Rejected`.
+
+`SyncError::QuerySubscriptionRejected` stays as-is.
+
+### Durable APIs
+
+No API rename is required for this RFC.
+
+Behavior changes:
+
+1. edge/global durable waiters reject on terminal rejection
+2. worker durable waiters may still resolve before later rejection
+3. visible rows can expose `$outcome` via shared core lookups/invalidation
+4. rejected outcomes remain until acknowledged, then are pruned
+
+## Implementation Plan
+
+1. Add mutation types and `SyncPayload::MutationOutcome` in `sync_manager/types.rs`.
+2. Emit accepted/rejected outcome messages in `sync_manager/permissions.rs` and direct-write paths in `sync_manager/inbox.rs`.
+3. Add inbound outcome queue plumbing in `SyncManager`.
+4. Extend `Storage` and all backends with mutation journal persistence.
+5. Record local mutations in `RuntimeCore` write paths.
+6. Add RuntimeCore mutation waiters, `take_mutation_events()`, and `acknowledge_mutation_outcome(...)`.
+7. Implement rollback helper(s) in QueryManager/ObjectManager for rejected local commit chains, with deferred prune-on-acknowledge.
+8. Invalidate subscriptions when object outcome overlays change.
+9. Update bindings to consume core mutation events/lookups and expose `$outcome`/global hooks.
+10. Add docs/examples describing recommended surfacing patterns.
+
+## Tests Required
+
+1. rejection persists across restart and remains queryable
+2. rejected mutation rolls back local visible state
+3. descendant pending mutations are superseded when an ancestor is rejected
+4. `edge`/`global` durable waiters reject instead of hanging
+5. `worker` durable waiters may resolve before later rejection, and rejection still appears in mutation events
+6. accepted outcome marks mutation as accepted without resolving durability prematurely
+7. immediate denials (`SessionRequired`, `CatalogueWriteDenied`) use `MutationOutcome::Rejected`
+8. generic query-subscription errors still flow through `SyncError`
+9. acknowledging a rejected outcome clears the overlay, removes the journal entry, and prunes the dead commit chain
+10. subscriptions re-fire when `$outcome` changes even without ordinary row data changes
+
+## Resolved Decisions
+
+1. Mutation records and accepted/rejected outcomes include wall-clock timestamps in microseconds since Unix epoch.
+2. Accepted/rejected outcomes are emitted only by the first authority for a client-originated mutation.
+3. Rejected outcomes awaiting acknowledgement are capped by a high count bound of `10_000`, with oldest-first forced compaction as a storage safety valve.

--- a/specs/todo/a_mvp/permissions_and_optimistic_updates.md
+++ b/specs/todo/a_mvp/permissions_and_optimistic_updates.md
@@ -664,3 +664,215 @@ Behavior changes:
 1. Mutation records and accepted/rejected outcomes include wall-clock timestamps in microseconds since Unix epoch.
 2. Accepted/rejected outcomes are emitted only by the first authority for a client-originated mutation.
 3. Rejected outcomes awaiting acknowledgement are capped by a high count bound of `10_000`, with oldest-first forced compaction as a storage safety valve.
+
+## Detailed Implementation Plan
+
+The safest way to land this is as a sequence of narrow Rust-core steps, with bindings consuming the new primitives only after the core behavior is stable.
+
+### Phase 1: Core Types And Wire Format
+
+Target files:
+
+1. `crates/jazz-tools/src/sync_manager/types.rs`
+2. `crates/jazz-tools/src/sync_manager/mod.rs`
+3. `crates/jazz-tools/src/sync_manager/tests.rs`
+
+Work:
+
+1. Add `MutationId`, `MutationOperation`, `MutationRejectCode`, `MutationAcceptance`, `MutationRejection`, `MutationOutcome`, `MutationOutcomeState`, `ObjectOutcomeState`, and filter types.
+2. Add `SyncPayload::MutationOutcome(MutationOutcome)`.
+3. Add `received_mutation_outcomes` to `SyncManager`.
+4. Add serialization tests for new sync payloads.
+5. Remove write-denial use of `SyncError` in the RFC sense, while keeping `QuerySubscriptionRejected` on the generic error path.
+
+Exit criteria:
+
+1. New mutation outcome payloads serialize and deserialize in all Rust tests.
+2. Existing non-mutation sync payload behavior remains unchanged.
+
+### Phase 2: Storage Journal
+
+Target files:
+
+1. `crates/jazz-tools/src/storage/mod.rs`
+2. `crates/jazz-tools/src/storage/key_codec.rs`
+3. `crates/jazz-tools/src/storage/opfs_btree.rs`
+4. `crates/jazz-tools/src/storage/fjall.rs`
+
+Work:
+
+1. Add `put_mutation_record`, `load_mutation_record`, `load_mutation_record_by_commit`, `list_mutation_records_by_outcome`, and `delete_mutation_record`.
+2. Add storage keys/indexing for:
+   1. mutation record by `MutationId`
+   2. commit-to-mutation reverse lookup
+   3. rejected-outcome retention ordering by `rejected_at_micros`
+3. Add storage tests covering persistence across reopen/restart.
+4. Add bound-enforcement helpers for `MAX_RETAINED_UNACKNOWLEDGED_REJECTIONS`.
+
+Exit criteria:
+
+1. Mutation records survive restart.
+2. Commit lookup works without in-memory state.
+3. Forced compaction removes the oldest rejected records first.
+
+### Phase 3: Local Mutation Recording In RuntimeCore
+
+Target files:
+
+1. `crates/jazz-tools/src/runtime_core.rs`
+2. `crates/jazz-tools/src/runtime_core/writes.rs`
+3. `crates/jazz-tools/src/runtime_core/ticks.rs`
+
+Work:
+
+1. Record a `MutationRecord` immediately after each successful local insert/update/delete commit is created.
+2. Populate `commit_to_mutation`, `mutation_waiters`, and `mutation_events`.
+3. Add `take_mutation_events`, `get_mutation_record`, `get_mutation_record_by_commit`, `list_rejected_mutations`, `list_pending_mutations`, `list_mutations_for_object`, `get_object_outcome`, and `acknowledge_mutation_outcome`.
+4. Update durable waiters so remote-tier requests reject on `MutationOutcome::Rejected` instead of hanging forever.
+5. Keep `worker` durability semantics unchanged: worker-tier callers may resolve before later rejection.
+
+Exit criteria:
+
+1. Local writes create durable journal entries.
+2. Remote-tier durable waiters reject on terminal rejection.
+3. Lookup methods work after runtime restart.
+
+### Phase 4: Server Emission Of Outcomes
+
+Target files:
+
+1. `crates/jazz-tools/src/sync_manager/inbox.rs`
+2. `crates/jazz-tools/src/sync_manager/permissions.rs`
+3. `crates/jazz-tools/src/query_manager/manager.rs`
+4. `crates/jazz-tools/src/query_manager/server_queries.rs`
+
+Work:
+
+1. Emit `MutationOutcome::Rejected` for:
+   1. ReBAC denials
+   2. `SessionRequired`
+   3. `CatalogueWriteDenied`
+2. Emit `MutationOutcome::Accepted` after the first authority successfully applies a client-originated write.
+3. Ensure only the first authority emits the outcome.
+4. Queue inbound mutation outcomes into `received_mutation_outcomes`.
+
+Exit criteria:
+
+1. A client-originated write gets exactly one terminal accepted/rejected outcome from the first authority.
+2. Existing `PersistenceAck` behavior remains intact.
+
+### Phase 5: RuntimeCore Outcome Consumption
+
+Target files:
+
+1. `crates/jazz-tools/src/runtime_core/ticks.rs`
+2. `crates/jazz-tools/src/sync_manager/mod.rs`
+
+Work:
+
+1. Drain `received_mutation_outcomes` during tick processing.
+2. Update mutation journal entries to `Accepted`, `Rejected`, or `SupersededByRejection`.
+3. Emit `MutationEvent` values.
+4. Update object outcome overlays for affected `object_id`s.
+5. Trigger subscription invalidation when outcome overlays change, even when row data does not.
+
+Exit criteria:
+
+1. Pending -> accepted/rejected transitions are observable through `MutationEvent`.
+2. Visible rows can react to `$outcome` changes without requiring data-column changes.
+
+### Phase 6: Rollback, Dead Retention, And Acknowledge-Prune
+
+Target files:
+
+1. `crates/jazz-tools/src/query_manager/writes.rs`
+2. `crates/jazz-tools/src/object_manager/mod.rs`
+3. `crates/jazz-tools/src/runtime_core/ticks.rs`
+4. `crates/jazz-tools/src/storage/mod.rs`
+
+Work:
+
+1. Add a rollback helper that removes rejected commit chains from active tips without immediately pruning stored commits.
+2. Compute descendant pending mutations and mark them `SupersededByRejection`.
+3. On `acknowledge_mutation_outcome`, prune the retained dead commit chain and delete the journal entry.
+4. Apply the same prune-and-clear behavior for forced compaction caused by the rejection-count bound.
+
+Exit criteria:
+
+1. Rejected optimistic writes disappear from canonical query results immediately.
+2. The retained dead chain is still available for inspection until acknowledgement or forced compaction.
+3. Acknowledge clears the overlay and removes stored rejection state.
+
+### Phase 7: Subscription And Query Overlay Integration
+
+Target files:
+
+1. `crates/jazz-tools/src/query_manager/manager.rs`
+2. `crates/jazz-tools/src/query_manager/types/*`
+3. binding-layer query adapters that materialize rows
+
+Work:
+
+1. Decide the internal representation of the reserved `$outcome` overlay.
+2. Ensure row-level subscription updates include outcome-only changes.
+3. Define how bindings map `ObjectOutcomeState` to per-row `$outcome`.
+
+Exit criteria:
+
+1. Visible rows can surface `{ type: "pending" | "accepted" | "errored" }`.
+2. Rejected inserts still surface through the global event path after rollback removes the row itself.
+
+### Phase 8: Binding Surfaces
+
+Target files:
+
+1. `crates/jazz-wasm/src/runtime.rs`
+2. `crates/jazz-napi/src/lib.rs`
+3. `crates/jazz-rn/rust/src/lib.rs`
+4. `packages/jazz-tools/src/runtime/*`
+
+Work:
+
+1. Expose mutation events and lookup methods from Rust bindings.
+2. Add binding-level `acknowledge()` wrappers over `acknowledge_mutation_outcome(mutation_id)`.
+3. Add a global outcome hook for invisible data.
+4. Add row-level `$outcome` enrichment in the TS runtime layer.
+
+Exit criteria:
+
+1. No binding keeps a separate mutation journal.
+2. All bindings share the same Rust-core semantics for pending/accepted/rejected/acknowledged flow.
+
+### Phase 9: Docs And E2E Tests
+
+Target files:
+
+1. docs and examples
+2. browser integration tests
+3. native/NAPI integration tests
+
+Work:
+
+1. Document visible-row `$outcome` behavior.
+2. Document global rejected-outcome hooks.
+3. Document acknowledgement semantics and the difference between user acknowledgement and `PersistenceAck`.
+4. Add E2E tests for long-offline rejection followed by acknowledgement.
+
+Exit criteria:
+
+1. Docs explain the two notification surfaces clearly.
+2. End-to-end tests cover both visible and invisible rejection scenarios.
+
+## Recommended Landing Order
+
+1. Phase 1
+2. Phase 2
+3. Phase 3
+4. Phase 4
+5. Phase 5
+6. Phase 6
+7. Phase 7
+8. Phase 8
+9. Phase 9
+
+Do not start binding-level `$outcome` work before Phases 1 through 6 are stable. The binding surface depends on rollback, acknowledgement, and retained-dead-chain semantics being correct in Rust first.

--- a/specs/todo/a_mvp/permissions_and_optimistic_updates.md
+++ b/specs/todo/a_mvp/permissions_and_optimistic_updates.md
@@ -304,6 +304,36 @@ commit_to_mutation: HashMap<CommitId, MutationId>,
 
 `commit_to_mutation` may be reconstructed from storage on startup or lazily hydrated.
 
+### Multi-Runtime Client Ownership
+
+Persisted mutation outcome state should exist only in the local runtime that owns durable client storage for a given app database.
+
+This is stricter than "all clients persist outcomes":
+
+1. a browser main-thread cache runtime should not keep its own durable mutation journal
+2. a browser worker runtime backed by OPFS should own the durable mutation journal
+3. native single-runtime clients with local disk storage should own the durable mutation journal in that single runtime
+4. servers and relay peers may emit or forward mutation outcomes, but do not persist client-facing mutation journals
+
+Rationale:
+
+1. there must be exactly one acknowledgement/pruning authority per local app database
+2. duplicating the journal across cooperating runtimes would create split-brain acknowledgement semantics
+3. restart recovery should be sourced from the persistence-owning runtime, not reconstructed independently by each cache/runtime wrapper
+
+For the browser memory-main-thread plus persistent-worker setup, the intended model is:
+
+1. the worker persistent runtime records `MutationRecord`s durably
+2. the worker persistent runtime owns `acknowledge_mutation_outcome(...)` and dead-chain pruning
+3. the main thread receives mirrored mutation events and object outcome overlays as ephemeral state only
+4. on main-thread startup or reconnect, bindings rehydrate visible outcome state from the worker runtime rather than a separate main-thread journal
+
+Object outcome overlay remains derived state:
+
+1. the persistence-owning runtime may rebuild it from the journal on startup
+2. non-owning runtimes may cache or mirror it in memory
+3. non-owning runtimes do not durably persist a second copy
+
 ### Storage
 
 `Storage` should gain first-class mutation journal methods.


### PR DESCRIPTION
## Summary
- add Rust mutation outcome payload types and plumb `SyncPayload::MutationOutcome` through sync processing
- convert write denials and permission rejections from generic sync errors into typed rejected mutation outcomes
- expose received mutation outcomes through `RuntimeCore`/`TokioRuntime` and add focused runtime + sync tests

## Commits
- `1ab89a0d` spec: add mutation outcome RFC
- `7512df9f` spec: append mutation outcome implementation plan
- `4ceba26f` sync: add mutation outcome protocol plumbing

## Testing
- `cargo test -p jazz-tools mutation_outcome -- --nocapture`
- `cargo test -p jazz-tools server_permission_checks_reject_missing_scalar_fk_writes -- --nocapture`
