### PR TITLE
Fix NAPI timestamp writes from TS number conversion

### DIFF
--- a/.changeset/fix-napi-timestamp-writes.md
+++ b/.changeset/fix-napi-timestamp-writes.md
@@ -1,0 +1,7 @@
+---
+"jazz-tools": patch
+---
+
+Fix backend N-API timestamp writes when `Timestamp` values arrive from TypeScript as JS numbers.
+
+`createJazzContext(...)` and other backend N-API mutation paths now accept integral epoch-millisecond timestamp payloads produced by the TS value converter, instead of rejecting modern dates as floating-point values during Rust deserialization.

--- a/crates/jazz-tools/src/query_manager/types/tests.rs
+++ b/crates/jazz-tools/src/query_manager/types/tests.rs
@@ -92,6 +92,22 @@ fn value_column_type() {
     assert_eq!(Value::Null.column_type(), None);
 }
 
+#[test]
+fn value_deserializes_timestamp_from_integral_float() {
+    let value: Value = serde_json::from_str(r#"{"type":"Timestamp","value":1773285322816.0}"#)
+        .expect("deserialize timestamp");
+
+    assert_eq!(value, Value::Timestamp(1773285322816));
+}
+
+#[test]
+fn value_rejects_fractional_float_timestamp() {
+    let error = serde_json::from_str::<Value>(r#"{"type":"Timestamp","value":1.5}"#)
+        .expect_err("fractional timestamp should be rejected");
+
+    assert!(error.to_string().contains("timestamp must be an integer"));
+}
+
 // ========================================================================
 // Tuple Model Tests
 // ========================================================================

--- a/crates/jazz-tools/src/query_manager/types/value.rs
+++ b/crates/jazz-tools/src/query_manager/types/value.rs
@@ -1,3 +1,4 @@
+use serde::de::{self, Visitor};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::object::ObjectId;
@@ -43,7 +44,7 @@ enum ValueHuman {
     Double(f64),
     Boolean(bool),
     Text(String),
-    Timestamp(u64),
+    Timestamp(#[serde(deserialize_with = "deserialize_timestamp_value")] u64),
     Uuid(ObjectId),
     Bytea(Vec<u8>),
     Array(Vec<ValueHuman>),
@@ -72,6 +73,55 @@ enum ValueBinary {
     Array(Vec<ValueBinary>),
     Row(Vec<ValueBinary>),
     Null,
+}
+
+fn deserialize_timestamp_value<'de, D>(deserializer: D) -> Result<u64, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    // JS numbers crossing the NAPI JSON boundary can surface as integral f64s.
+    struct TimestampValueVisitor;
+
+    impl Visitor<'_> for TimestampValueVisitor {
+        type Value = u64;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str("a non-negative integer timestamp")
+        }
+
+        fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E> {
+            Ok(value)
+        }
+
+        fn visit_i64<E>(self, value: i64) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            u64::try_from(value).map_err(|_| E::custom("timestamp must be non-negative"))
+        }
+
+        fn visit_f64<E>(self, value: f64) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            if !value.is_finite() {
+                return Err(E::custom("timestamp must be finite"));
+            }
+            if value < 0.0 {
+                return Err(E::custom("timestamp must be non-negative"));
+            }
+            if value.fract() != 0.0 {
+                return Err(E::custom("timestamp must be an integer"));
+            }
+            if value > u64::MAX as f64 {
+                return Err(E::custom("timestamp is out of range"));
+            }
+
+            Ok(value as u64)
+        }
+    }
+
+    deserializer.deserialize_any(TimestampValueVisitor)
 }
 
 impl From<&Value> for ValueHuman {

--- a/packages/jazz-tools/src/runtime/napi.integration.test.ts
+++ b/packages/jazz-tools/src/runtime/napi.integration.test.ts
@@ -60,6 +60,16 @@ const TEST_SCHEMA: WasmSchema = {
   },
 };
 
+const TIMESTAMP_SCHEMA: WasmSchema = {
+  projects: {
+    columns: [
+      { name: "name", column_type: { type: "Text" }, nullable: false },
+      { name: "created_at", column_type: { type: "Timestamp" }, nullable: false },
+      { name: "updated_at", column_type: { type: "Timestamp" }, nullable: false },
+    ],
+  },
+};
+
 const TODO_SERVER_WASM_SCHEMA: WasmSchema = {
   projects: {
     columns: [{ name: "name", column_type: { type: "Text" }, nullable: false }],
@@ -1268,6 +1278,53 @@ describe("NAPI integration", () => {
       }
       if (reopenedContext) {
         await reopenedContext.shutdown();
+      }
+      await rm(dataRoot, { recursive: true, force: true });
+    }
+  }, 30_000);
+
+  it("accepts modern epoch-millisecond timestamps from the TS value converter on backend durable writes", async () => {
+    const dataRoot = await createTempDir("jazz-napi-timestamp-");
+    const dataPath = join(dataRoot, "runtime.skv");
+    const timestamp = 1773285322816;
+    let context: {
+      client(): JazzClient;
+      shutdown(): Promise<void>;
+    } | null = null;
+
+    try {
+      const { createJazzContext } = await import("../backend/create-jazz-context.js");
+      const { toValueArray } = await import("./value-converter.js");
+
+      context = createJazzContext({
+        appId: randomUUID(),
+        app: { wasmSchema: TIMESTAMP_SCHEMA },
+        driver: { type: "persistent", dataPath },
+      });
+
+      const values = toValueArray(
+        {
+          name: "timestamp-probe",
+          created_at: new Date(timestamp),
+          updated_at: new Date(timestamp),
+        },
+        TIMESTAMP_SCHEMA,
+        "projects",
+      );
+
+      await expect(
+        context.client().createDurable("projects", values, { tier: "worker" }),
+      ).resolves.toEqual({
+        id: expect.any(String),
+        values: [
+          { type: "Text", value: "timestamp-probe" },
+          { type: "Timestamp", value: timestamp },
+          { type: "Timestamp", value: timestamp },
+        ],
+      });
+    } finally {
+      if (context) {
+        await context.shutdown();
       }
       await rm(dataRoot, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- add a regression test covering backend NAPI durable writes for modern epoch-millisecond `Timestamp` values produced by the TS value converter
- accept integral floating-point timestamp payloads when deserializing human-readable `Value::Timestamp` at the Rust boundary
- add Rust unit coverage for integral-float acceptance and fractional-float rejection

## Testing
- `pnpm exec oxfmt packages/jazz-tools/src/runtime/napi.integration.test.ts`
- `pnpm exec oxlint packages/jazz-tools/src/runtime/napi.integration.test.ts`
- `cargo fmt --all -- crates/jazz-tools/src/query_manager/types/value.rs crates/jazz-tools/src/query_manager/types/tests.rs`
- `cargo test -p jazz-tools value_deserializes_timestamp_from_integral_float`
- `cargo test -p jazz-tools value_rejects_fractional_float_timestamp`
- `cargo clippy -p jazz-tools --lib -- -D warnings`
- `pnpm --filter jazz-napi build:debug`
- `pnpm --filter jazz-tools exec vitest run --config vitest.config.ts src/runtime/napi.integration.test.ts -t "accepts modern epoch-millisecond timestamps from the TS value converter on backend durable writes"`
