### PR TITLE
test(napi): add Fjall integration coverage

### DIFF
--- a/packages/jazz-tools/src/runtime/napi.fjall.db.all.integration.test.ts
+++ b/packages/jazz-tools/src/runtime/napi.fjall.db.all.integration.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+import {
+  allTodosQuery,
+  createNapiFjallTestEnv,
+  readRowDone,
+  readRowTitle,
+  todoValues,
+} from "./napi.fjall.test-helpers.js";
+
+const env = createNapiFjallTestEnv();
+
+describe("db.all NAPI Fjall integration", () => {
+  it("queries durable rows from a Fjall-backed runtime", async () => {
+    const store = await env.createPersistentStore("query-durable");
+    const { client } = await env.openPersistentClient(store);
+
+    const first = await client.createDurable("todos", todoValues("Task A", false), {
+      tier: "worker",
+    });
+    const second = await client.createDurable("todos", todoValues("Task B", true), {
+      tier: "worker",
+    });
+
+    const rows = await env.waitForRows(client, allTodosQuery, (entries) => entries.length === 2);
+    const titles = rows.map(readRowTitle).sort();
+
+    expect(titles).toEqual(["Task A", "Task B"]);
+    expect(rows.find((row) => row.id === first.id)).toBeDefined();
+    expect(rows.find((row) => row.id === second.id)).toBeDefined();
+    expect(readRowDone(rows.find((row) => row.id === first.id)!)).toBe(false);
+    expect(readRowDone(rows.find((row) => row.id === second.id)!)).toBe(true);
+  }, 20_000);
+
+  it("applies durable update and delete operations against Fjall storage", async () => {
+    const store = await env.createPersistentStore("update-delete");
+    const { client } = await env.openPersistentClient(store);
+
+    const survivor = await client.createDurable("todos", todoValues("survivor", false), {
+      tier: "worker",
+    });
+    const removed = await client.createDurable("todos", todoValues("removed", false), {
+      tier: "worker",
+    });
+
+    await client.updateDurable(
+      survivor.id,
+      {
+        title: { type: "Text", value: "survivor-updated" },
+        done: { type: "Boolean", value: true },
+      },
+      { tier: "worker" },
+    );
+    await client.deleteDurable(removed.id, { tier: "worker" });
+
+    const rows = await env.waitForRows(
+      client,
+      allTodosQuery,
+      (entries) =>
+        entries.length === 1 &&
+        entries[0]?.id === survivor.id &&
+        readRowTitle(entries[0]) === "survivor-updated" &&
+        readRowDone(entries[0]) === true,
+    );
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.id).toBe(survivor.id);
+  }, 20_000);
+
+  it("reopens a Fjall store with the latest durable state", async () => {
+    const store = await env.createPersistentStore("reopen-state");
+    const initial = await env.openPersistentClient(store);
+
+    const persisted = await initial.client.createDurable("todos", todoValues("persist-me", false), {
+      tier: "worker",
+    });
+    const removed = await initial.client.createDurable("todos", todoValues("remove-me", false), {
+      tier: "worker",
+    });
+
+    await initial.client.updateDurable(
+      persisted.id,
+      {
+        title: { type: "Text", value: "persist-me-updated" },
+        done: { type: "Boolean", value: true },
+      },
+      { tier: "worker" },
+    );
+    await initial.client.deleteDurable(removed.id, { tier: "worker" });
+
+    await env.waitForRows(
+      initial.client,
+      allTodosQuery,
+      (entries) =>
+        entries.length === 1 &&
+        entries[0]?.id === persisted.id &&
+        readRowTitle(entries[0]) === "persist-me-updated" &&
+        readRowDone(entries[0]) === true,
+    );
+
+    await initial.shutdown();
+
+    const reopened = await env.openPersistentClient(store);
+    const reopenedRows = await env.waitForRows(
+      reopened.client,
+      allTodosQuery,
+      (entries) =>
+        entries.length === 1 &&
+        entries[0]?.id === persisted.id &&
+        readRowTitle(entries[0]) === "persist-me-updated" &&
+        readRowDone(entries[0]) === true,
+    );
+
+    expect(reopenedRows).toHaveLength(1);
+    expect(reopenedRows[0]?.id).toBe(persisted.id);
+
+    const appended = await reopened.client.createDurable(
+      "todos",
+      todoValues("after-reopen", false),
+      {
+        tier: "worker",
+      },
+    );
+    const finalRows = await env.waitForRows(
+      reopened.client,
+      allTodosQuery,
+      (entries) => entries.length === 2 && entries.some((row) => row.id === appended.id),
+    );
+
+    expect(finalRows.map(readRowTitle).sort()).toEqual(["after-reopen", "persist-me-updated"]);
+  }, 25_000);
+});

--- a/packages/jazz-tools/src/runtime/napi.fjall.db.all.integration.test.ts
+++ b/packages/jazz-tools/src/runtime/napi.fjall.db.all.integration.test.ts
@@ -29,7 +29,7 @@ describe("db.all NAPI Fjall integration", () => {
     expect(rows.find((row) => row.id === second.id)).toBeDefined();
     expect(readRowDone(rows.find((row) => row.id === first.id)!)).toBe(false);
     expect(readRowDone(rows.find((row) => row.id === second.id)!)).toBe(true);
-  }, 20_000);
+  });
 
   it("applies durable update and delete operations against Fjall storage", async () => {
     const store = await env.createPersistentStore("update-delete");
@@ -64,7 +64,7 @@ describe("db.all NAPI Fjall integration", () => {
 
     expect(rows).toHaveLength(1);
     expect(rows[0]?.id).toBe(survivor.id);
-  }, 20_000);
+  });
 
   it("reopens a Fjall store with the latest durable state", async () => {
     const store = await env.createPersistentStore("reopen-state");
@@ -127,5 +127,5 @@ describe("db.all NAPI Fjall integration", () => {
     );
 
     expect(finalRows.map(readRowTitle).sort()).toEqual(["after-reopen", "persist-me-updated"]);
-  }, 25_000);
+  });
 });

--- a/packages/jazz-tools/src/runtime/napi.fjall.db.subscribeAll.integration.test.ts
+++ b/packages/jazz-tools/src/runtime/napi.fjall.db.subscribeAll.integration.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi } from "vitest";
+import type { RowDelta } from "../drivers/types.js";
+import {
+  allTodosQuery,
+  createNapiFjallTestEnv,
+  readRowTitle,
+  todoValues,
+  todosByDone,
+} from "./napi.fjall.test-helpers.js";
+
+const env = createNapiFjallTestEnv();
+
+describe("db.subscribeAll NAPI Fjall integration", () => {
+  it("emits add changes for durable inserts in Fjall storage", async () => {
+    const store = await env.createPersistentStore("subscription-insert");
+    const { client } = await env.openPersistentClient(store);
+    const deltas: RowDelta[] = [];
+
+    const subscriptionId = client.subscribe(
+      allTodosQuery,
+      (delta) => {
+        deltas.push(delta);
+      },
+      { tier: "worker" },
+    );
+
+    try {
+      await client.createDurable("todos", todoValues("watch-me", false), { tier: "worker" });
+
+      await vi.waitFor(
+        () => {
+          expect(
+            deltas.some((delta) =>
+              delta.some(
+                (change) =>
+                  change.kind === 0 && change.row && readRowTitle(change.row) === "watch-me",
+              ),
+            ),
+          ).toBe(true);
+        },
+        { timeout: 10_000 },
+      );
+    } finally {
+      client.unsubscribe(subscriptionId);
+    }
+  }, 20_000);
+
+  it("supports condition filters for Fjall-backed subscriptions", async () => {
+    const store = await env.createPersistentStore("subscription-filter");
+    const { client } = await env.openPersistentClient(store);
+    const deltas: RowDelta[] = [];
+
+    const subscriptionId = client.subscribe(
+      todosByDone(false),
+      (delta) => {
+        deltas.push(delta);
+      },
+      { tier: "worker" },
+    );
+
+    try {
+      await client.createDurable("todos", todoValues("visible", false), { tier: "worker" });
+      await client.createDurable("todos", todoValues("hidden", true), { tier: "worker" });
+
+      await vi.waitFor(
+        () => {
+          expect(
+            deltas.some((delta) =>
+              delta.some(
+                (change) =>
+                  change.kind === 0 && change.row && readRowTitle(change.row) === "visible",
+              ),
+            ),
+          ).toBe(true);
+        },
+        { timeout: 10_000 },
+      );
+
+      expect(
+        deltas.some((delta) =>
+          delta.some(
+            (change) =>
+              change.row !== undefined &&
+              change.row !== null &&
+              readRowTitle(change.row) === "hidden",
+          ),
+        ),
+      ).toBe(false);
+
+      const rows = await env.waitForRows(
+        client,
+        todosByDone(false),
+        (entries) => entries.length === 1 && readRowTitle(entries[0]) === "visible",
+      );
+
+      expect(rows).toHaveLength(1);
+      expect(readRowTitle(rows[0]!)).toBe("visible");
+    } finally {
+      client.unsubscribe(subscriptionId);
+    }
+  }, 20_000);
+});

--- a/packages/jazz-tools/src/runtime/napi.fjall.db.subscribeAll.integration.test.ts
+++ b/packages/jazz-tools/src/runtime/napi.fjall.db.subscribeAll.integration.test.ts
@@ -73,8 +73,8 @@ describe("db.subscribeAll NAPI Fjall integration", () => {
         deltas.some((delta) =>
           delta.some(
             (change) =>
-              change.row !== undefined &&
-              change.row !== null &&
+              (change.kind === 0 || change.kind === 2) &&
+              change.row &&
               readRowTitle(change.row) === "hidden",
           ),
         ),

--- a/packages/jazz-tools/src/runtime/napi.fjall.db.subscribeAll.integration.test.ts
+++ b/packages/jazz-tools/src/runtime/napi.fjall.db.subscribeAll.integration.test.ts
@@ -27,23 +27,20 @@ describe("db.subscribeAll NAPI Fjall integration", () => {
     try {
       await client.createDurable("todos", todoValues("watch-me", false), { tier: "worker" });
 
-      await vi.waitFor(
-        () => {
-          expect(
-            deltas.some((delta) =>
-              delta.some(
-                (change) =>
-                  change.kind === 0 && change.row && readRowTitle(change.row) === "watch-me",
-              ),
+      await vi.waitFor(() => {
+        expect(
+          deltas.some((delta) =>
+            delta.some(
+              (change) =>
+                change.kind === 0 && change.row && readRowTitle(change.row) === "watch-me",
             ),
-          ).toBe(true);
-        },
-        { timeout: 10_000 },
-      );
+          ),
+        ).toBe(true);
+      });
     } finally {
       client.unsubscribe(subscriptionId);
     }
-  }, 20_000);
+  });
 
   it("supports condition filters for Fjall-backed subscriptions", async () => {
     const store = await env.createPersistentStore("subscription-filter");
@@ -62,19 +59,15 @@ describe("db.subscribeAll NAPI Fjall integration", () => {
       await client.createDurable("todos", todoValues("visible", false), { tier: "worker" });
       await client.createDurable("todos", todoValues("hidden", true), { tier: "worker" });
 
-      await vi.waitFor(
-        () => {
-          expect(
-            deltas.some((delta) =>
-              delta.some(
-                (change) =>
-                  change.kind === 0 && change.row && readRowTitle(change.row) === "visible",
-              ),
+      await vi.waitFor(() => {
+        expect(
+          deltas.some((delta) =>
+            delta.some(
+              (change) => change.kind === 0 && change.row && readRowTitle(change.row) === "visible",
             ),
-          ).toBe(true);
-        },
-        { timeout: 10_000 },
-      );
+          ),
+        ).toBe(true);
+      });
 
       expect(
         deltas.some((delta) =>
@@ -98,5 +91,5 @@ describe("db.subscribeAll NAPI Fjall integration", () => {
     } finally {
       client.unsubscribe(subscriptionId);
     }
-  }, 20_000);
+  });
 });

--- a/packages/jazz-tools/src/runtime/napi.fjall.test-helpers.ts
+++ b/packages/jazz-tools/src/runtime/napi.fjall.test-helpers.ts
@@ -1,0 +1,229 @@
+import { randomUUID } from "node:crypto";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeAll } from "vitest";
+import type { Value, WasmSchema } from "../drivers/types.js";
+import { JazzClient, type Row } from "./client.js";
+import type { QueryBuilder } from "./db.js";
+import { createPersistentNapiRuntime, loadNapiModule } from "./testing/napi-runtime-test-utils.js";
+
+export type Todo = {
+  id: string;
+  title: string;
+  done: boolean;
+};
+
+type PersistentStore = {
+  appId: string;
+  dataPath: string;
+  cleanup(): Promise<void>;
+};
+
+type PersistentClientHandle = {
+  client: JazzClient;
+  shutdown(): Promise<void>;
+};
+
+export const TEST_SCHEMA: WasmSchema = {
+  todos: {
+    columns: [
+      { name: "title", column_type: { type: "Text" }, nullable: false },
+      { name: "done", column_type: { type: "Boolean" }, nullable: false },
+    ],
+  },
+};
+
+export const allTodosQuery: QueryBuilder<Todo> = {
+  _table: "todos",
+  _schema: TEST_SCHEMA,
+  _rowType: undefined as unknown as Todo,
+  _build() {
+    return JSON.stringify({
+      table: "todos",
+      conditions: [],
+      includes: {},
+      orderBy: [],
+      offset: 0,
+    });
+  },
+};
+
+export function todosByDone(done: boolean): QueryBuilder<Todo> {
+  return {
+    _table: "todos",
+    _schema: TEST_SCHEMA,
+    _rowType: undefined as unknown as Todo,
+    _build() {
+      return JSON.stringify({
+        table: "todos",
+        conditions: [{ column: "done", op: "eq", value: done }],
+        includes: {},
+        orderBy: [],
+        offset: 0,
+      });
+    },
+  };
+}
+
+export function todoValues(title: string, done: boolean): Value[] {
+  return [
+    { type: "Text", value: title },
+    { type: "Boolean", value: done },
+  ];
+}
+
+function readText(values: Value[], index: number): string {
+  const value = values[index];
+  if (value?.type !== "Text") {
+    throw new Error(`expected Text at column ${index}, got ${JSON.stringify(value)}`);
+  }
+  return value.value;
+}
+
+function readBoolean(values: Value[], index: number): boolean {
+  const value = values[index];
+  if (value?.type !== "Boolean") {
+    throw new Error(`expected Boolean at column ${index}, got ${JSON.stringify(value)}`);
+  }
+  return value.value;
+}
+
+export function readRowTitle(row: { values: Value[] }): string {
+  return readText(row.values, 0);
+}
+
+export function readRowDone(row: { values: Value[] }): boolean {
+  return readBoolean(row.values, 1);
+}
+
+export function createNapiFjallTestEnv(): {
+  createPersistentStore(label: string): Promise<PersistentStore>;
+  openPersistentClient(store: PersistentStore): Promise<PersistentClientHandle>;
+  waitForRows(
+    client: JazzClient,
+    query: QueryBuilder<Todo>,
+    predicate: (rows: Row[]) => boolean,
+    timeoutMs?: number,
+  ): Promise<Row[]>;
+} {
+  const stores: PersistentStore[] = [];
+  const clients: PersistentClientHandle[] = [];
+
+  beforeAll(async () => {
+    await loadNapiModule();
+  });
+
+  afterEach(async () => {
+    for (const client of clients.splice(0).reverse()) {
+      try {
+        await client.shutdown();
+      } catch {
+        // Best effort cleanup for native runtime handles.
+      }
+    }
+
+    for (const store of stores.splice(0).reverse()) {
+      try {
+        await store.cleanup();
+      } catch {
+        // Best effort cleanup for temporary Fjall directories.
+      }
+    }
+  });
+
+  async function createPersistentStore(label: string): Promise<PersistentStore> {
+    const dataRoot = await mkdtemp(join(tmpdir(), `jazz-napi-fjall-${label}-`));
+    let cleaned = false;
+    const store: PersistentStore = {
+      appId: `napi-fjall-${label}-${randomUUID()}`,
+      dataPath: join(dataRoot, "runtime.skv"),
+      async cleanup() {
+        if (cleaned) {
+          return;
+        }
+        cleaned = true;
+        await rm(dataRoot, { recursive: true, force: true });
+      },
+    };
+
+    stores.push(store);
+    return store;
+  }
+
+  async function openPersistentClient(store: PersistentStore): Promise<PersistentClientHandle> {
+    const runtime = await createPersistentNapiRuntime(TEST_SCHEMA, store.dataPath, {
+      appId: store.appId,
+      env: "test",
+      userBranch: "main",
+      tier: "worker",
+    });
+
+    const client = JazzClient.connectWithRuntime(runtime, {
+      appId: store.appId,
+      schema: TEST_SCHEMA,
+      env: "test",
+      userBranch: "main",
+      tier: "worker",
+      defaultDurabilityTier: "worker",
+    });
+
+    let closed = false;
+    const handle: PersistentClientHandle = {
+      client,
+      async shutdown() {
+        if (closed) {
+          return;
+        }
+        closed = true;
+        await client.shutdown();
+      },
+    };
+
+    clients.push(handle);
+    return handle;
+  }
+
+  async function waitForRows(
+    client: JazzClient,
+    query: QueryBuilder<Todo>,
+    predicate: (rows: Row[]) => boolean,
+    timeoutMs = 10_000,
+  ): Promise<Row[]> {
+    const deadline = Date.now() + timeoutMs;
+    let lastRows: Row[] = [];
+    let lastError: unknown = undefined;
+
+    while (Date.now() < deadline) {
+      try {
+        const rows = await client.query(query, { tier: "worker" });
+        if (predicate(rows)) {
+          return rows;
+        }
+        lastRows = rows;
+      } catch (error) {
+        lastError = error;
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+
+    const lastErrorMessage =
+      lastError instanceof Error ? lastError.message : lastError ? String(lastError) : "none";
+    throw new Error(
+      `timed out waiting for rows; lastRows=${JSON.stringify(
+        lastRows.map((row) => ({
+          id: row.id,
+          title: row.values[0],
+          done: row.values[1],
+        })),
+      )}; lastError=${lastErrorMessage}`,
+    );
+  }
+
+  return {
+    createPersistentStore,
+    openPersistentClient,
+    waitForRows,
+  };
+}

--- a/packages/jazz-tools/src/runtime/testing/napi-runtime-test-utils.ts
+++ b/packages/jazz-tools/src/runtime/testing/napi-runtime-test-utils.ts
@@ -11,6 +11,16 @@ const require = createRequire(import.meta.url);
 
 let napiModulePromise: Promise<NapiModule> | null = null;
 
+function registerRuntimeCleanup(runtime: { close?: () => void }): void {
+  onTestFinished(() => {
+    try {
+      runtime.close?.();
+    } catch {
+      // Best effort cleanup for native runtimes during test shutdown.
+    }
+  });
+}
+
 function formatNapiLoadError(error: unknown): Error {
   const message = error instanceof Error ? error.message : String(error);
   return new Error(
@@ -59,13 +69,32 @@ export async function createNapiRuntime(
     opts?.tier,
   );
 
-  onTestFinished(() => {
-    try {
-      runtime.close();
-    } catch {
-      // Best effort cleanup for native runtimes during test shutdown.
-    }
-  });
+  registerRuntimeCleanup(runtime);
+
+  return runtime as unknown as TestNapiRuntime;
+}
+
+export async function createPersistentNapiRuntime(
+  schema: WasmSchema,
+  dataPath: string,
+  opts?: {
+    appId?: string;
+    env?: string;
+    userBranch?: string;
+    tier?: string;
+  },
+): Promise<TestNapiRuntime> {
+  const { NapiRuntime } = await loadNapiModule();
+  const runtime = new NapiRuntime(
+    serializeRuntimeSchema(schema),
+    opts?.appId ?? "test-app",
+    opts?.env ?? "test",
+    opts?.userBranch ?? "main",
+    dataPath,
+    opts?.tier,
+  );
+
+  registerRuntimeCleanup(runtime);
 
   return runtime as unknown as TestNapiRuntime;
 }


### PR DESCRIPTION
Includes:
- durable `db.all` integration tests for the NAPI Fjall runtime
- durable `db.subscribeAll` integration tests for the NAPI Fjall runtime
- shared Fjall test helpers and the supporting runtime test utility updates