### PR TITLE
fix: restore scoped jazz-napi loader

### DIFF
--- a/.changeset/fix-jazz-napi-loader-scope-regression.md
+++ b/.changeset/fix-jazz-napi-loader-scope-regression.md
@@ -1,0 +1,5 @@
+---
+"jazz-napi": patch
+---
+
+Restore scoped `@garden-co/*` native binding package resolution in the published N-API loader after the recent generated loader regression.

--- a/crates/jazz-napi/index.js
+++ b/crates/jazz-napi/index.js
@@ -6,6 +6,11 @@
 const { readFileSync } = require('node:fs')
 let nativeBinding = null
 const loadErrors = []
+const NATIVE_BINDING_PACKAGE_SCOPE = '@garden-co'
+const resolveNativeBindingPackage = (name) => `${NATIVE_BINDING_PACKAGE_SCOPE}/${name}`
+const requireNativeBindingPackage = (name) => require(resolveNativeBindingPackage(name))
+const getNativeBindingPackageVersion = (name) =>
+  require(`${resolveNativeBindingPackage(name)}/package.json`).version
 
 const isMusl = () => {
   let musl = false
@@ -75,8 +80,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('jazz-napi-android-arm64')
-        const bindingPackageVersion = require('jazz-napi-android-arm64/package.json').version
+        const binding = requireNativeBindingPackage('jazz-napi-android-arm64')
+        const bindingPackageVersion = getNativeBindingPackageVersion('jazz-napi-android-arm64')
         if (bindingPackageVersion !== '2.0.0-alpha.16' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.16 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -91,8 +96,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('jazz-napi-android-arm-eabi')
-        const bindingPackageVersion = require('jazz-napi-android-arm-eabi/package.json').version
+        const binding = requireNativeBindingPackage('jazz-napi-android-arm-eabi')
+        const bindingPackageVersion = getNativeBindingPackageVersion('jazz-napi-android-arm-eabi')
         if (bindingPackageVersion !== '2.0.0-alpha.16' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.16 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -112,8 +117,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('jazz-napi-win32-x64-gnu')
-        const bindingPackageVersion = require('jazz-napi-win32-x64-gnu/package.json').version
+        const binding = requireNativeBindingPackage('jazz-napi-win32-x64-gnu')
+        const bindingPackageVersion = getNativeBindingPackageVersion('jazz-napi-win32-x64-gnu')
         if (bindingPackageVersion !== '2.0.0-alpha.16' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.16 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -128,8 +133,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('jazz-napi-win32-x64-msvc')
-        const bindingPackageVersion = require('jazz-napi-win32-x64-msvc/package.json').version
+        const binding = requireNativeBindingPackage('jazz-napi-win32-x64-msvc')
+        const bindingPackageVersion = getNativeBindingPackageVersion('jazz-napi-win32-x64-msvc')
         if (bindingPackageVersion !== '2.0.0-alpha.16' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.16 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -145,8 +150,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('jazz-napi-win32-ia32-msvc')
-        const bindingPackageVersion = require('jazz-napi-win32-ia32-msvc/package.json').version
+        const binding = requireNativeBindingPackage('jazz-napi-win32-ia32-msvc')
+        const bindingPackageVersion = getNativeBindingPackageVersion('jazz-napi-win32-ia32-msvc')
         if (bindingPackageVersion !== '2.0.0-alpha.16' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.16 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -161,8 +166,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('jazz-napi-win32-arm64-msvc')
-        const bindingPackageVersion = require('jazz-napi-win32-arm64-msvc/package.json').version
+        const binding = requireNativeBindingPackage('jazz-napi-win32-arm64-msvc')
+        const bindingPackageVersion = getNativeBindingPackageVersion('jazz-napi-win32-arm64-msvc')
         if (bindingPackageVersion !== '2.0.0-alpha.16' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.16 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -180,8 +185,8 @@ function requireNative() {
       loadErrors.push(e)
     }
     try {
-      const binding = require('jazz-napi-darwin-universal')
-      const bindingPackageVersion = require('jazz-napi-darwin-universal/package.json').version
+      const binding = requireNativeBindingPackage('jazz-napi-darwin-universal')
+      const bindingPackageVersion = getNativeBindingPackageVersion('jazz-napi-darwin-universal')
       if (bindingPackageVersion !== '2.0.0-alpha.16' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
         throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.16 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
@@ -196,8 +201,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('jazz-napi-darwin-x64')
-        const bindingPackageVersion = require('jazz-napi-darwin-x64/package.json').version
+        const binding = requireNativeBindingPackage('jazz-napi-darwin-x64')
+        const bindingPackageVersion = getNativeBindingPackageVersion('jazz-napi-darwin-x64')
         if (bindingPackageVersion !== '2.0.0-alpha.16' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.16 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -212,8 +217,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('jazz-napi-darwin-arm64')
-        const bindingPackageVersion = require('jazz-napi-darwin-arm64/package.json').version
+        const binding = requireNativeBindingPackage('jazz-napi-darwin-arm64')
+        const bindingPackageVersion = getNativeBindingPackageVersion('jazz-napi-darwin-arm64')
         if (bindingPackageVersion !== '2.0.0-alpha.16' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.16 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -232,8 +237,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('jazz-napi-freebsd-x64')
-        const bindingPackageVersion = require('jazz-napi-freebsd-x64/package.json').version
+        const binding = requireNativeBindingPackage('jazz-napi-freebsd-x64')
+        const bindingPackageVersion = getNativeBindingPackageVersion('jazz-napi-freebsd-x64')
         if (bindingPackageVersion !== '2.0.0-alpha.16' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.16 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -248,8 +253,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('jazz-napi-freebsd-arm64')
-        const bindingPackageVersion = require('jazz-napi-freebsd-arm64/package.json').version
+        const binding = requireNativeBindingPackage('jazz-napi-freebsd-arm64')
+        const bindingPackageVersion = getNativeBindingPackageVersion('jazz-napi-freebsd-arm64')
         if (bindingPackageVersion !== '2.0.0-alpha.16' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.16 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -269,8 +274,8 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          const binding = require('jazz-napi-linux-x64-musl')
-          const bindingPackageVersion = require('jazz-napi-linux-x64-musl/package.json').version
+          const binding = requireNativeBindingPackage('jazz-napi-linux-x64-musl')
+          const bindingPackageVersion = getNativeBindingPackageVersion('jazz-napi-linux-x64-musl')
           if (bindingPackageVersion !== '2.0.0-alpha.16' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.16 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
@@ -285,8 +290,8 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          const binding = require('jazz-napi-linux-x64-gnu')
-          const bindingPackageVersion = require('jazz-napi-linux-x64-gnu/package.json').version
+          const binding = requireNativeBindingPackage('jazz-napi-linux-x64-gnu')
+          const bindingPackageVersion = getNativeBindingPackageVersion('jazz-napi-linux-x64-gnu')
           if (bindingPackageVersion !== '2.0.0-alpha.16' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.16 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
@@ -303,8 +308,8 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          const binding = require('jazz-napi-linux-arm64-musl')
-          const bindingPackageVersion = require('jazz-napi-linux-arm64-musl/package.json').version
+          const binding = requireNativeBindingPackage('jazz-napi-linux-arm64-musl')
+          const bindingPackageVersion = getNativeBindingPackageVersion('jazz-napi-linux-arm64-musl')
           if (bindingPackageVersion !== '2.0.0-alpha.16' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.16 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
@@ -319,8 +324,8 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          const binding = require('jazz-napi-linux-arm64-gnu')
-          const bindingPackageVersion = require('jazz-napi-linux-arm64-gnu/package.json').version
+          const binding = requireNativeBindingPackage('jazz-napi-linux-arm64-gnu')
+          const bindingPackageVersion = getNativeBindingPackageVersion('jazz-napi-linux-arm64-gnu')
           if (bindingPackageVersion !== '2.0.0-alpha.16' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.16 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
@@ -337,8 +342,8 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          const binding = require('jazz-napi-linux-arm-musleabihf')
-          const bindingPackageVersion = require('jazz-napi-linux-arm-musleabihf/package.json').version
+          const binding = requireNativeBindingPackage('jazz-napi-linux-arm-musleabihf')
+          const bindingPackageVersion = getNativeBindingPackageVersion('jazz-napi-linux-arm-musleabihf')
           if (bindingPackageVersion !== '2.0.0-alpha.16' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.16 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
@@ -353,8 +358,8 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          const binding = require('jazz-napi-linux-arm-gnueabihf')
-          const bindingPackageVersion = require('jazz-napi-linux-arm-gnueabihf/package.json').version
+          const binding = requireNativeBindingPackage('jazz-napi-linux-arm-gnueabihf')
+          const bindingPackageVersion = getNativeBindingPackageVersion('jazz-napi-linux-arm-gnueabihf')
           if (bindingPackageVersion !== '2.0.0-alpha.16' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.16 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
@@ -371,8 +376,8 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          const binding = require('jazz-napi-linux-loong64-musl')
-          const bindingPackageVersion = require('jazz-napi-linux-loong64-musl/package.json').version
+          const binding = requireNativeBindingPackage('jazz-napi-linux-loong64-musl')
+          const bindingPackageVersion = getNativeBindingPackageVersion('jazz-napi-linux-loong64-musl')
           if (bindingPackageVersion !== '2.0.0-alpha.16' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.16 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
@@ -387,8 +392,8 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          const binding = require('jazz-napi-linux-loong64-gnu')
-          const bindingPackageVersion = require('jazz-napi-linux-loong64-gnu/package.json').version
+          const binding = requireNativeBindingPackage('jazz-napi-linux-loong64-gnu')
+          const bindingPackageVersion = getNativeBindingPackageVersion('jazz-napi-linux-loong64-gnu')
           if (bindingPackageVersion !== '2.0.0-alpha.16' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.16 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
@@ -405,8 +410,8 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          const binding = require('jazz-napi-linux-riscv64-musl')
-          const bindingPackageVersion = require('jazz-napi-linux-riscv64-musl/package.json').version
+          const binding = requireNativeBindingPackage('jazz-napi-linux-riscv64-musl')
+          const bindingPackageVersion = getNativeBindingPackageVersion('jazz-napi-linux-riscv64-musl')
           if (bindingPackageVersion !== '2.0.0-alpha.16' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.16 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
@@ -421,8 +426,8 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          const binding = require('jazz-napi-linux-riscv64-gnu')
-          const bindingPackageVersion = require('jazz-napi-linux-riscv64-gnu/package.json').version
+          const binding = requireNativeBindingPackage('jazz-napi-linux-riscv64-gnu')
+          const bindingPackageVersion = getNativeBindingPackageVersion('jazz-napi-linux-riscv64-gnu')
           if (bindingPackageVersion !== '2.0.0-alpha.16' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.16 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
@@ -438,8 +443,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('jazz-napi-linux-ppc64-gnu')
-        const bindingPackageVersion = require('jazz-napi-linux-ppc64-gnu/package.json').version
+        const binding = requireNativeBindingPackage('jazz-napi-linux-ppc64-gnu')
+        const bindingPackageVersion = getNativeBindingPackageVersion('jazz-napi-linux-ppc64-gnu')
         if (bindingPackageVersion !== '2.0.0-alpha.16' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.16 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -454,8 +459,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('jazz-napi-linux-s390x-gnu')
-        const bindingPackageVersion = require('jazz-napi-linux-s390x-gnu/package.json').version
+        const binding = requireNativeBindingPackage('jazz-napi-linux-s390x-gnu')
+        const bindingPackageVersion = getNativeBindingPackageVersion('jazz-napi-linux-s390x-gnu')
         if (bindingPackageVersion !== '2.0.0-alpha.16' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.16 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -474,8 +479,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('jazz-napi-openharmony-arm64')
-        const bindingPackageVersion = require('jazz-napi-openharmony-arm64/package.json').version
+        const binding = requireNativeBindingPackage('jazz-napi-openharmony-arm64')
+        const bindingPackageVersion = getNativeBindingPackageVersion('jazz-napi-openharmony-arm64')
         if (bindingPackageVersion !== '2.0.0-alpha.16' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.16 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -490,8 +495,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('jazz-napi-openharmony-x64')
-        const bindingPackageVersion = require('jazz-napi-openharmony-x64/package.json').version
+        const binding = requireNativeBindingPackage('jazz-napi-openharmony-x64')
+        const bindingPackageVersion = getNativeBindingPackageVersion('jazz-napi-openharmony-x64')
         if (bindingPackageVersion !== '2.0.0-alpha.16' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.16 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -506,8 +511,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('jazz-napi-openharmony-arm')
-        const bindingPackageVersion = require('jazz-napi-openharmony-arm/package.json').version
+        const binding = requireNativeBindingPackage('jazz-napi-openharmony-arm')
+        const bindingPackageVersion = getNativeBindingPackageVersion('jazz-napi-openharmony-arm')
         if (bindingPackageVersion !== '2.0.0-alpha.16' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 2.0.0-alpha.16 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -538,7 +543,7 @@ if (!nativeBinding || process.env.NAPI_RS_FORCE_WASI) {
   }
   if (!nativeBinding || process.env.NAPI_RS_FORCE_WASI) {
     try {
-      wasiBinding = require('jazz-napi-wasm32-wasi')
+      wasiBinding = requireNativeBindingPackage('jazz-napi-wasm32-wasi')
       nativeBinding = wasiBinding
     } catch (err) {
       if (process.env.NAPI_RS_FORCE_WASI) {


### PR DESCRIPTION
## Summary
- restore `@garden-co/*` native binding package resolution in `crates/jazz-napi/index.js`
- add a patch changeset so the regression fix can flow through the alpha release process
- fix the exact packed-loader assertion that failed in the preview publish job

## Context
The preview publish job in https://github.com/garden-co/jazz2/actions/runs/23021141779/job/66859459450 failed because the packed `jazz-napi` loader no longer referenced scoped native packages.

## Verification
- `node -c crates/jazz-napi/index.js`
- source check: loader contains `@garden-co` references and zero unscoped `require("jazz-napi-...")` calls
- `pnpm --filter jazz-napi pack --pack-destination <tmp>` and verified the packed `index.js` uses scoped native package names
