### PR TITLE
Surface oversized indexed mutation errors cleanly

### DIFF
--- a/.changeset/fix-oversized-index-mutation-errors.md
+++ b/.changeset/fix-oversized-index-mutation-errors.md
@@ -1,0 +1,10 @@
+---
+"jazz-tools": patch
+"jazz-napi": patch
+"jazz-wasm": patch
+"jazz-rn": patch
+---
+
+Fail indexed writes cleanly when an indexed value would exceed the storage key limit instead of panicking in native storage.
+
+Oversized indexed inserts and updates now return a normal mutation error to JS callers, and local updates can recover rows that were previously left in a partial index state by older panic-driven failures.

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -424,7 +424,7 @@ impl NapiRuntime {
             .map_err(|_| napi::Error::from_reason("lock"))?;
         let (object_id, row_values) = core
             .insert(&table, groove_values, None)
-            .map_err(|e| napi::Error::from_reason(format!("Insert failed: {:?}", e)))?;
+            .map_err(|e| napi::Error::from_reason(format!("Insert failed: {e}")))?;
         let row_values = align_row_values_to_declared_schema(
             &self.declared_schema,
             core.current_schema(),
@@ -457,7 +457,7 @@ impl NapiRuntime {
             .lock()
             .map_err(|_| napi::Error::from_reason("lock"))?;
         core.update(oid, updates, None)
-            .map_err(|e| napi::Error::from_reason(format!("Update failed: {:?}", e)))?;
+            .map_err(|e| napi::Error::from_reason(format!("Update failed: {e}")))?;
 
         Ok(())
     }
@@ -679,7 +679,7 @@ impl NapiRuntime {
                 .map_err(|_| napi::Error::from_reason("lock"))?;
             let ((object_id, row_values), receiver) = core
                 .insert_persisted(&table, groove_values, None, persistence_tier)
-                .map_err(|e| napi::Error::from_reason(format!("Insert failed: {:?}", e)))?;
+                .map_err(|e| napi::Error::from_reason(format!("Insert failed: {e}")))?;
             let row_values = align_row_values_to_declared_schema(
                 &self.declared_schema,
                 core.current_schema(),
@@ -719,7 +719,7 @@ impl NapiRuntime {
                 .lock()
                 .map_err(|_| napi::Error::from_reason("lock"))?;
             core.update_persisted(oid, updates, None, persistence_tier)
-                .map_err(|e| napi::Error::from_reason(format!("Update failed: {:?}", e)))?
+                .map_err(|e| napi::Error::from_reason(format!("Update failed: {e}")))?
         };
 
         let _ = receiver.await;

--- a/crates/jazz-rn/rust/src/lib.rs
+++ b/crates/jazz-rn/rust/src/lib.rs
@@ -64,9 +64,9 @@ fn json_err(e: serde_json::Error) -> JazzRnError {
     }
 }
 
-fn runtime_err<E: std::fmt::Debug>(e: E) -> JazzRnError {
+fn runtime_err<E: std::fmt::Display>(e: E) -> JazzRnError {
     JazzRnError::Runtime {
-        message: format!("{:?}", e),
+        message: e.to_string(),
     }
 }
 

--- a/crates/jazz-tools/src/query_manager/indices.rs
+++ b/crates/jazz-tools/src/query_manager/indices.rs
@@ -1,11 +1,30 @@
 use crate::object::ObjectId;
-use crate::storage::Storage;
+use crate::storage::{Storage, StorageError, validate_index_value_size};
 
 use super::encoding::decode_column;
 use super::manager::{QueryError, QueryManager};
-use super::types::{ColumnDescriptor, ColumnType, RowDescriptor, Value};
+use super::types::{ColumnDescriptor, ColumnType, RowDescriptor, TableName, Value};
 
 impl QueryManager {
+    fn map_index_storage_error(error: StorageError) -> QueryError {
+        match error {
+            StorageError::IndexKeyTooLarge {
+                table,
+                column,
+                branch,
+                key_bytes,
+                max_key_bytes,
+            } => QueryError::IndexValueTooLarge {
+                table: TableName::new(table),
+                column,
+                branch,
+                key_bytes,
+                max_key_bytes,
+            },
+            other => QueryError::IndexError(other.to_string()),
+        }
+    }
+
     fn expand_index_values(column: &ColumnDescriptor, value: &Value) -> Vec<Value> {
         let mut values = vec![value.clone()];
         if column.references.is_some()
@@ -25,6 +44,33 @@ impl QueryManager {
         values
     }
 
+    fn validate_column_index_values(
+        table: &str,
+        column: &ColumnDescriptor,
+        branch: &str,
+        value: &Value,
+    ) -> Result<(), QueryError> {
+        for index_value in Self::expand_index_values(column, value) {
+            validate_index_value_size(table, column.name.as_str(), branch, &index_value)
+                .map_err(Self::map_index_storage_error)?;
+        }
+        Ok(())
+    }
+
+    pub(super) fn validate_write_index_values_on_branch(
+        table: &str,
+        branch: &str,
+        values: &[Value],
+        descriptor: &RowDescriptor,
+    ) -> Result<(), QueryError> {
+        for (column, value) in descriptor.columns.iter().zip(values.iter()) {
+            if *value != Value::Null {
+                Self::validate_column_index_values(table, column, branch, value)?;
+            }
+        }
+        Ok(())
+    }
+
     fn insert_column_index_values(
         storage: &mut dyn Storage,
         table: &str,
@@ -36,7 +82,7 @@ impl QueryManager {
         for index_value in Self::expand_index_values(column, value) {
             storage
                 .index_insert(table, column.name.as_str(), branch, &index_value, object_id)
-                .map_err(|e| QueryError::IndexError(format!("{:?}", e)))?;
+                .map_err(Self::map_index_storage_error)?;
         }
         Ok(())
     }
@@ -48,11 +94,13 @@ impl QueryManager {
         branch: &str,
         value: &Value,
         object_id: ObjectId,
-    ) {
+    ) -> Result<(), QueryError> {
         for index_value in Self::expand_index_values(column, value) {
-            let _ =
-                storage.index_remove(table, column.name.as_str(), branch, &index_value, object_id);
+            storage
+                .index_remove(table, column.name.as_str(), branch, &index_value, object_id)
+                .map_err(Self::map_index_storage_error)?;
         }
+        Ok(())
     }
 
     /// Update indices when a row is inserted on a specific branch.
@@ -67,7 +115,7 @@ impl QueryManager {
         // Update "_id" index
         storage
             .index_insert(table, "_id", branch, &Value::Uuid(object_id), object_id)
-            .map_err(|e| QueryError::IndexError(format!("{:?}", e)))?;
+            .map_err(Self::map_index_storage_error)?;
 
         // Update column indices
         for (col_idx, col) in descriptor.columns.iter().enumerate() {
@@ -120,15 +168,15 @@ impl QueryManager {
             {
                 Self::remove_column_index_values(
                     storage, table, col, branch, &old_value, object_id,
-                );
+                )?;
             }
             // Add new value
             if let Ok(new_value) = decode_column(descriptor, new_data, col_idx)
                 && new_value != Value::Null
             {
-                let _ = Self::insert_column_index_values(
+                Self::insert_column_index_values(
                     storage, table, col, branch, &new_value, object_id,
-                );
+                )?;
             }
         }
 
@@ -166,14 +214,16 @@ impl QueryManager {
         descriptor: &RowDescriptor,
     ) -> Result<(), QueryError> {
         // Remove from "_id" index
-        let _ = storage.index_remove(table, "_id", branch, &Value::Uuid(object_id), object_id);
+        storage
+            .index_remove(table, "_id", branch, &Value::Uuid(object_id), object_id)
+            .map_err(Self::map_index_storage_error)?;
 
         // Remove from all column indices
         for (col_idx, col) in descriptor.columns.iter().enumerate() {
             if let Ok(value) = decode_column(descriptor, old_data, col_idx)
                 && value != Value::Null
             {
-                Self::remove_column_index_values(storage, table, col, branch, &value, object_id);
+                Self::remove_column_index_values(storage, table, col, branch, &value, object_id)?;
             }
         }
 
@@ -186,7 +236,7 @@ impl QueryManager {
                 &Value::Uuid(object_id),
                 object_id,
             )
-            .map_err(|e| QueryError::IndexError(format!("{:?}", e)))?;
+            .map_err(Self::map_index_storage_error)?;
 
         Ok(())
     }
@@ -220,7 +270,9 @@ impl QueryManager {
         descriptor: &RowDescriptor,
     ) -> Result<(), QueryError> {
         // Remove from "_id" index (may not be present if already soft-deleted)
-        let _ = storage.index_remove(table, "_id", branch, &Value::Uuid(object_id), object_id);
+        storage
+            .index_remove(table, "_id", branch, &Value::Uuid(object_id), object_id)
+            .map_err(Self::map_index_storage_error)?;
 
         // Remove from all column indices (if we have old data)
         if let Some(data) = old_data {
@@ -230,19 +282,21 @@ impl QueryManager {
                 {
                     Self::remove_column_index_values(
                         storage, table, col, branch, &value, object_id,
-                    );
+                    )?;
                 }
             }
         }
 
         // Remove from "_id_deleted" index (handles soft→hard upgrade)
-        let _ = storage.index_remove(
-            table,
-            "_id_deleted",
-            branch,
-            &Value::Uuid(object_id),
-            object_id,
-        );
+        storage
+            .index_remove(
+                table,
+                "_id_deleted",
+                branch,
+                &Value::Uuid(object_id),
+                object_id,
+            )
+            .map_err(Self::map_index_storage_error)?;
 
         Ok(())
     }
@@ -276,27 +330,27 @@ impl QueryManager {
         descriptor: &RowDescriptor,
     ) -> Result<(), QueryError> {
         // Remove from "_id_deleted" index
-        let _ = storage.index_remove(
-            table,
-            "_id_deleted",
-            branch,
-            &Value::Uuid(object_id),
-            object_id,
-        );
+        storage
+            .index_remove(
+                table,
+                "_id_deleted",
+                branch,
+                &Value::Uuid(object_id),
+                object_id,
+            )
+            .map_err(Self::map_index_storage_error)?;
 
         // Add to "_id" index
         storage
             .index_insert(table, "_id", branch, &Value::Uuid(object_id), object_id)
-            .map_err(|e| QueryError::IndexError(format!("{:?}", e)))?;
+            .map_err(Self::map_index_storage_error)?;
 
         // Add to all column indices
         for (col_idx, col) in descriptor.columns.iter().enumerate() {
             if let Ok(value) = decode_column(descriptor, new_data, col_idx)
                 && value != Value::Null
             {
-                let _ = Self::insert_column_index_values(
-                    storage, table, col, branch, &value, object_id,
-                );
+                Self::insert_column_index_values(storage, table, col, branch, &value, object_id)?;
             }
         }
 

--- a/crates/jazz-tools/src/query_manager/manager.rs
+++ b/crates/jazz-tools/src/query_manager/manager.rs
@@ -37,6 +37,13 @@ pub enum QueryError {
     EncodingError(String),
     ObjectNotFound(ObjectId),
     QueryCompilationError(String),
+    IndexValueTooLarge {
+        table: TableName,
+        column: String,
+        branch: String,
+        key_bytes: usize,
+        max_key_bytes: usize,
+    },
     IndexError(String),
     /// Cannot undelete or truncate a row that is not soft-deleted.
     RowNotDeleted(ObjectId),
@@ -66,6 +73,16 @@ impl std::fmt::Display for QueryError {
             QueryError::EncodingError(msg) => write!(f, "encoding error: {msg}"),
             QueryError::ObjectNotFound(id) => write!(f, "object not found: {:?}", id),
             QueryError::QueryCompilationError(msg) => write!(f, "query compilation error: {msg}"),
+            QueryError::IndexValueTooLarge {
+                table,
+                column,
+                branch,
+                key_bytes,
+                max_key_bytes,
+            } => write!(
+                f,
+                "indexed value too large for {table}.{column} on branch {branch}: index key would be {key_bytes} bytes (max {max_key_bytes})"
+            ),
             QueryError::IndexError(msg) => write!(f, "index error: {msg}"),
             QueryError::RowNotDeleted(id) => write!(f, "row not deleted: {:?}", id),
             QueryError::RowAlreadyDeleted(id) => write!(f, "row already deleted: {:?}", id),
@@ -1137,13 +1154,21 @@ impl QueryManager {
                     &Value::Uuid(update.object_id),
                     update.object_id,
                 );
-                let _ = storage.index_insert(
+                if let Err(error) = storage.index_insert(
                     &table,
                     "_id_deleted",
                     branch,
                     &Value::Uuid(update.object_id),
                     update.object_id,
-                );
+                ) {
+                    tracing::error!(
+                        table,
+                        branch,
+                        object_id = %update.object_id,
+                        %error,
+                        "failed to insert synced _id_deleted index entry"
+                    );
+                }
             }
             self.mark_subscriptions_dirty(&table);
             self.mark_row_deleted_in_subscriptions(&table, update.object_id);
@@ -1162,14 +1187,22 @@ impl QueryManager {
 
         if was_soft_deleted {
             // This is an undelete - remove from _id_deleted, add to _id and column indices
-            let _ = Self::update_indices_for_undelete_on_branch(
+            if let Err(error) = Self::update_indices_for_undelete_on_branch(
                 storage,
                 &table,
                 branch,
                 update.object_id,
                 &new_data,
                 &descriptor,
-            );
+            ) {
+                tracing::error!(
+                    table,
+                    branch,
+                    object_id = %update.object_id,
+                    %error,
+                    "failed to update indices for synced undelete"
+                );
+            }
             self.mark_subscriptions_dirty(&table);
             return;
         }
@@ -1177,18 +1210,26 @@ impl QueryManager {
         // Normal update handling
         if update.is_new_object || update.previous_commit_ids.is_empty() {
             // First commit on branch (new object or synced first commit) - insert into all indices
-            let _ = Self::update_indices_for_insert_on_branch(
+            if let Err(error) = Self::update_indices_for_insert_on_branch(
                 storage,
                 &table,
                 branch,
                 update.object_id,
                 &new_data,
                 &descriptor,
-            );
+            ) {
+                tracing::error!(
+                    table,
+                    branch,
+                    object_id = %update.object_id,
+                    %error,
+                    "failed to update indices for synced insert"
+                );
+            }
         } else if let Some(old_data) = update.old_content {
             // Synced update - compute index delta using old_content
             // TODO: Future merge strategies - currently last-writer-wins by timestamp
-            let _ = Self::update_indices_for_update_on_branch(
+            if let Err(error) = Self::update_indices_for_update_on_branch(
                 storage,
                 &table,
                 branch,
@@ -1196,7 +1237,15 @@ impl QueryManager {
                 &old_data,
                 &new_data,
                 &descriptor,
-            );
+            ) {
+                tracing::error!(
+                    table,
+                    branch,
+                    object_id = %update.object_id,
+                    %error,
+                    "failed to update indices for synced update"
+                );
+            }
         } else {
             panic!(
                 "missing old_content for historical sync update: object_id={}, table={}, branch={}, prev_tips={}, commit_ids={}",

--- a/crates/jazz-tools/src/query_manager/manager_tests.rs
+++ b/crates/jazz-tools/src/query_manager/manager_tests.rs
@@ -2,6 +2,9 @@
 //!
 //! Tests for CRUD operations, subscriptions, syncing, and deletions.
 
+#[cfg(all(feature = "fjall", not(target_arch = "wasm32")))]
+use std::panic::{AssertUnwindSafe, catch_unwind};
+
 use serde_json::json;
 use smallvec::smallvec;
 
@@ -14,6 +17,8 @@ use crate::query_manager::types::{
     ColumnDescriptor, ColumnType, PolicyExpr, RowDescriptor, Schema, TableName, TablePolicies,
     TableSchema, Value,
 };
+#[cfg(all(feature = "fjall", not(target_arch = "wasm32")))]
+use crate::storage::FjallStorage;
 use crate::storage::{MemoryStorage, Storage};
 use crate::sync_manager::SyncManager;
 
@@ -74,6 +79,21 @@ fn create_query_manager(
     (qm, MemoryStorage::new())
 }
 
+#[cfg(all(feature = "fjall", not(target_arch = "wasm32")))]
+fn create_query_manager_with_fjall(
+    sync_manager: SyncManager,
+    schema: Schema,
+) -> (QueryManager, tempfile::TempDir, FjallStorage) {
+    let mut qm = QueryManager::new(sync_manager);
+    qm.set_current_schema(schema, "dev", "main");
+
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("test.fjall");
+    let storage = FjallStorage::open(&db_path, 8 * 1024 * 1024).unwrap();
+
+    (qm, temp_dir, storage)
+}
+
 /// Get the current branch name from a QueryManager.
 fn get_branch(qm: &QueryManager) -> String {
     qm.schema_context().branch_name().as_str().to_string()
@@ -95,11 +115,40 @@ fn json_documents_schema(schema: Option<serde_json::Value>) -> Schema {
     out
 }
 
+#[cfg(all(feature = "fjall", not(target_arch = "wasm32")))]
+fn large_index_schema() -> Schema {
+    let mut schema = Schema::new();
+    schema.insert(
+        TableName::new("todos"),
+        RowDescriptor::new(vec![
+            ColumnDescriptor::new("title", ColumnType::Text),
+            ColumnDescriptor::new("done", ColumnType::Boolean),
+        ])
+        .into(),
+    );
+    schema.insert(
+        TableName::new("tag_lists"),
+        RowDescriptor::new(vec![ColumnDescriptor::new(
+            "labels",
+            ColumnType::Array {
+                element: Box::new(ColumnType::Text),
+            },
+        )])
+        .into(),
+    );
+    schema
+}
+
+#[cfg(all(feature = "fjall", not(target_arch = "wasm32")))]
+fn oversized_text() -> String {
+    "x".repeat(40_000)
+}
+
 /// Helper to execute a query synchronously via subscribe/process/unsubscribe.
 /// Returns Vec<(ObjectId, Vec<Value>)> matching old execute() return type.
-fn execute_query(
+fn execute_query<H: Storage>(
     qm: &mut QueryManager,
-    storage: &mut MemoryStorage,
+    storage: &mut H,
     query: Query,
 ) -> Result<Vec<(ObjectId, Vec<Value>)>, QueryError> {
     let sub_id = qm.subscribe(query)?;
@@ -654,6 +703,186 @@ fn update_row() {
         old_rows.len(),
         0,
         "Old indexed value should no longer match"
+    );
+}
+
+#[cfg(all(feature = "fjall", not(target_arch = "wasm32")))]
+#[test]
+fn fjall_oversized_text_insert_returns_index_error_instead_of_panicking() {
+    let sync_manager = SyncManager::new();
+    let schema = large_index_schema();
+    let (mut qm, _temp_dir, mut storage) = create_query_manager_with_fjall(sync_manager, schema);
+
+    let outcome = catch_unwind(AssertUnwindSafe(|| {
+        qm.insert(
+            &mut storage,
+            "todos",
+            &[Value::Text(oversized_text()), Value::Boolean(false)],
+        )
+    }));
+
+    let result = outcome
+        .expect("oversized indexed text insert should return QueryError instead of panicking");
+    let err = result.expect_err("oversized indexed text insert should fail cleanly");
+    assert!(
+        matches!(err, QueryError::IndexError(_)),
+        "unexpected error: {err:?}"
+    );
+
+    let query = qm.query("todos").build();
+    let rows = execute_query(&mut qm, &mut storage, query).expect("query after failed insert");
+    assert!(
+        rows.is_empty(),
+        "failed insert should not leave a partially inserted row behind"
+    );
+}
+
+#[cfg(all(feature = "fjall", not(target_arch = "wasm32")))]
+#[test]
+fn fjall_oversized_array_text_insert_returns_index_error_instead_of_panicking() {
+    let sync_manager = SyncManager::new();
+    let schema = large_index_schema();
+    let (mut qm, _temp_dir, mut storage) = create_query_manager_with_fjall(sync_manager, schema);
+
+    let outcome = catch_unwind(AssertUnwindSafe(|| {
+        qm.insert(
+            &mut storage,
+            "tag_lists",
+            &[Value::Array(vec![Value::Text(oversized_text())])],
+        )
+    }));
+
+    let result = outcome.expect(
+        "oversized indexed array(text) insert should return QueryError instead of panicking",
+    );
+    let err = result.expect_err("oversized indexed array(text) insert should fail cleanly");
+    assert!(
+        matches!(err, QueryError::IndexError(_)),
+        "unexpected error: {err:?}"
+    );
+
+    let query = qm.query("tag_lists").build();
+    let rows = execute_query(&mut qm, &mut storage, query).expect("query after failed insert");
+    assert!(
+        rows.is_empty(),
+        "failed insert should not leave a partially inserted row behind"
+    );
+}
+
+#[cfg(all(feature = "fjall", not(target_arch = "wasm32")))]
+#[test]
+fn fjall_oversized_text_update_returns_index_error_and_preserves_old_index() {
+    let sync_manager = SyncManager::new();
+    let schema = large_index_schema();
+    let (mut qm, _temp_dir, mut storage) = create_query_manager_with_fjall(sync_manager, schema);
+
+    let handle = qm
+        .insert(
+            &mut storage,
+            "todos",
+            &[Value::Text("keep-me".into()), Value::Boolean(false)],
+        )
+        .expect("insert initial row");
+
+    let outcome = catch_unwind(AssertUnwindSafe(|| {
+        qm.update(
+            &mut storage,
+            handle.row_id,
+            &[Value::Text(oversized_text()), Value::Boolean(false)],
+        )
+    }));
+
+    let result = outcome
+        .expect("oversized indexed text update should return QueryError instead of panicking");
+    let err = result.expect_err("oversized indexed text update should fail cleanly");
+    assert!(
+        matches!(err, QueryError::IndexError(_)),
+        "unexpected error: {err:?}"
+    );
+
+    let query = qm.query("todos").build();
+    let rows = execute_query(&mut qm, &mut storage, query).expect("query after failed update");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].0, handle.row_id);
+    assert_eq!(
+        rows[0].1,
+        vec![Value::Text("keep-me".into()), Value::Boolean(false)]
+    );
+
+    let old_query = qm
+        .query("todos")
+        .filter_eq("title", Value::Text("keep-me".into()))
+        .build();
+    let old_rows =
+        execute_query(&mut qm, &mut storage, old_query).expect("query old indexed value");
+    assert_eq!(
+        old_rows.len(),
+        1,
+        "failed update should keep the old title index entry queryable"
+    );
+
+    let new_query = qm
+        .query("todos")
+        .filter_eq("title", Value::Text(oversized_text()))
+        .build();
+    let new_rows =
+        execute_query(&mut qm, &mut storage, new_query).expect("query oversized indexed value");
+    assert_eq!(
+        new_rows.len(),
+        0,
+        "failed update should not expose the new value"
+    );
+}
+
+#[cfg(all(feature = "fjall", not(target_arch = "wasm32")))]
+#[test]
+fn fjall_oversized_array_text_update_returns_index_error_and_preserves_old_index() {
+    let sync_manager = SyncManager::new();
+    let schema = large_index_schema();
+    let (mut qm, _temp_dir, mut storage) = create_query_manager_with_fjall(sync_manager, schema);
+
+    let original_labels = Value::Array(vec![Value::Text("keep-me".into())]);
+    let handle = qm
+        .insert(
+            &mut storage,
+            "tag_lists",
+            std::slice::from_ref(&original_labels),
+        )
+        .expect("insert initial row");
+
+    let outcome = catch_unwind(AssertUnwindSafe(|| {
+        qm.update(
+            &mut storage,
+            handle.row_id,
+            &[Value::Array(vec![Value::Text(oversized_text())])],
+        )
+    }));
+
+    let result = outcome.expect(
+        "oversized indexed array(text) update should return QueryError instead of panicking",
+    );
+    let err = result.expect_err("oversized indexed array(text) update should fail cleanly");
+    assert!(
+        matches!(err, QueryError::IndexError(_)),
+        "unexpected error: {err:?}"
+    );
+
+    let query = qm.query("tag_lists").build();
+    let rows = execute_query(&mut qm, &mut storage, query).expect("query after failed update");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].0, handle.row_id);
+    assert_eq!(rows[0].1, vec![original_labels.clone()]);
+
+    let old_query = qm
+        .query("tag_lists")
+        .filter_eq("labels", original_labels)
+        .build();
+    let old_rows =
+        execute_query(&mut qm, &mut storage, old_query).expect("query old indexed array value");
+    assert_eq!(
+        old_rows.len(),
+        1,
+        "failed update should keep the old array index entry queryable"
     );
 }
 

--- a/crates/jazz-tools/src/query_manager/manager_tests.rs
+++ b/crates/jazz-tools/src/query_manager/manager_tests.rs
@@ -2,9 +2,6 @@
 //!
 //! Tests for CRUD operations, subscriptions, syncing, and deletions.
 
-#[cfg(all(feature = "fjall", not(target_arch = "wasm32")))]
-use std::panic::{AssertUnwindSafe, catch_unwind};
-
 use serde_json::json;
 use smallvec::smallvec;
 
@@ -713,19 +710,22 @@ fn fjall_oversized_text_insert_returns_index_error_instead_of_panicking() {
     let schema = large_index_schema();
     let (mut qm, _temp_dir, mut storage) = create_query_manager_with_fjall(sync_manager, schema);
 
-    let outcome = catch_unwind(AssertUnwindSafe(|| {
-        qm.insert(
+    let err = qm
+        .insert(
             &mut storage,
             "todos",
             &[Value::Text(oversized_text()), Value::Boolean(false)],
         )
-    }));
-
-    let result = outcome
-        .expect("oversized indexed text insert should return QueryError instead of panicking");
-    let err = result.expect_err("oversized indexed text insert should fail cleanly");
+        .expect_err("oversized indexed text insert should fail cleanly");
     assert!(
-        matches!(err, QueryError::IndexError(_)),
+        matches!(
+            &err,
+            QueryError::IndexValueTooLarge {
+                table,
+                column,
+                ..
+            } if *table == TableName::new("todos") && column == "title"
+        ),
         "unexpected error: {err:?}"
     );
 
@@ -744,20 +744,22 @@ fn fjall_oversized_array_text_insert_returns_index_error_instead_of_panicking() 
     let schema = large_index_schema();
     let (mut qm, _temp_dir, mut storage) = create_query_manager_with_fjall(sync_manager, schema);
 
-    let outcome = catch_unwind(AssertUnwindSafe(|| {
-        qm.insert(
+    let err = qm
+        .insert(
             &mut storage,
             "tag_lists",
             &[Value::Array(vec![Value::Text(oversized_text())])],
         )
-    }));
-
-    let result = outcome.expect(
-        "oversized indexed array(text) insert should return QueryError instead of panicking",
-    );
-    let err = result.expect_err("oversized indexed array(text) insert should fail cleanly");
+        .expect_err("oversized indexed array(text) insert should fail cleanly");
     assert!(
-        matches!(err, QueryError::IndexError(_)),
+        matches!(
+            &err,
+            QueryError::IndexValueTooLarge {
+                table,
+                column,
+                ..
+            } if *table == TableName::new("tag_lists") && column == "labels"
+        ),
         "unexpected error: {err:?}"
     );
 
@@ -784,19 +786,22 @@ fn fjall_oversized_text_update_returns_index_error_and_preserves_old_index() {
         )
         .expect("insert initial row");
 
-    let outcome = catch_unwind(AssertUnwindSafe(|| {
-        qm.update(
+    let err = qm
+        .update(
             &mut storage,
             handle.row_id,
             &[Value::Text(oversized_text()), Value::Boolean(false)],
         )
-    }));
-
-    let result = outcome
-        .expect("oversized indexed text update should return QueryError instead of panicking");
-    let err = result.expect_err("oversized indexed text update should fail cleanly");
+        .expect_err("oversized indexed text update should fail cleanly");
     assert!(
-        matches!(err, QueryError::IndexError(_)),
+        matches!(
+            &err,
+            QueryError::IndexValueTooLarge {
+                table,
+                column,
+                ..
+            } if *table == TableName::new("todos") && column == "title"
+        ),
         "unexpected error: {err:?}"
     );
 
@@ -850,20 +855,22 @@ fn fjall_oversized_array_text_update_returns_index_error_and_preserves_old_index
         )
         .expect("insert initial row");
 
-    let outcome = catch_unwind(AssertUnwindSafe(|| {
-        qm.update(
+    let err = qm
+        .update(
             &mut storage,
             handle.row_id,
             &[Value::Array(vec![Value::Text(oversized_text())])],
         )
-    }));
-
-    let result = outcome.expect(
-        "oversized indexed array(text) update should return QueryError instead of panicking",
-    );
-    let err = result.expect_err("oversized indexed array(text) update should fail cleanly");
+        .expect_err("oversized indexed array(text) update should fail cleanly");
     assert!(
-        matches!(err, QueryError::IndexError(_)),
+        matches!(
+            &err,
+            QueryError::IndexValueTooLarge {
+                table,
+                column,
+                ..
+            } if *table == TableName::new("tag_lists") && column == "labels"
+        ),
         "unexpected error: {err:?}"
     );
 
@@ -883,6 +890,80 @@ fn fjall_oversized_array_text_update_returns_index_error_and_preserves_old_index
         old_rows.len(),
         1,
         "failed update should keep the old array index entry queryable"
+    );
+}
+
+#[cfg(all(feature = "fjall", not(target_arch = "wasm32")))]
+#[test]
+fn fjall_update_can_heal_synced_row_with_oversized_index_value() {
+    use std::collections::HashMap;
+
+    use crate::commit::{Commit, StoredState};
+
+    let sync_manager = SyncManager::new();
+    let schema = large_index_schema();
+    let (mut qm, _temp_dir, mut storage) = create_query_manager_with_fjall(sync_manager, schema);
+    let branch = get_branch(&qm);
+    let row_id = ObjectId::new();
+    let oversized = oversized_text();
+
+    let mut metadata = HashMap::new();
+    metadata.insert(MetadataKey::Table.to_string(), "todos".to_string());
+    qm.sync_manager_mut()
+        .object_manager
+        .receive_object(&mut storage, row_id, metadata);
+
+    let descriptor = RowDescriptor::new(vec![
+        ColumnDescriptor::new("title", ColumnType::Text),
+        ColumnDescriptor::new("done", ColumnType::Boolean),
+    ]);
+    let commit = Commit {
+        parents: smallvec![],
+        content: encode_row(
+            &descriptor,
+            &[Value::Text(oversized.clone()), Value::Boolean(false)],
+        )
+        .unwrap(),
+        timestamp: 1000,
+        author: row_id,
+        metadata: None,
+        stored_state: StoredState::Stored,
+        ack_state: Default::default(),
+    };
+    qm.sync_manager_mut()
+        .object_manager
+        .receive_commit(&mut storage, row_id, &branch, commit)
+        .unwrap();
+    qm.process(&mut storage);
+
+    assert_eq!(
+        storage.index_lookup("todos", "title", &branch, &Value::Text(oversized.clone())),
+        Vec::<ObjectId>::new(),
+        "oversized synced value should not create a title index entry"
+    );
+
+    qm.update(
+        &mut storage,
+        row_id,
+        &[Value::Text("healed".into()), Value::Boolean(false)],
+    )
+    .expect("local update should heal a row left in partial index state");
+
+    let healed_query = qm
+        .query("todos")
+        .filter_eq("title", Value::Text("healed".into()))
+        .build();
+    let healed_rows =
+        execute_query(&mut qm, &mut storage, healed_query).expect("query healed indexed value");
+    assert_eq!(healed_rows.len(), 1);
+    assert_eq!(healed_rows[0].0, row_id);
+
+    let row = qm
+        .get_row(row_id)
+        .expect("row should still exist after healing");
+    assert_eq!(
+        row.1,
+        vec![Value::Text("healed".into()), Value::Boolean(false)]
     );
 }
 

--- a/crates/jazz-tools/src/query_manager/writes.rs
+++ b/crates/jazz-tools/src/query_manager/writes.rs
@@ -54,6 +54,12 @@ impl QueryManager {
         }
 
         self.validate_json_for_values(&descriptor, values)?;
+        Self::validate_write_index_values_on_branch(
+            table,
+            self.current_branch().as_str(),
+            values,
+            &descriptor,
+        )?;
 
         // Encode to binary
         let data = encode_row(&descriptor, values)
@@ -162,6 +168,7 @@ impl QueryManager {
         }
 
         self.validate_json_for_values(&descriptor, values)?;
+        Self::validate_write_index_values_on_branch(table, branch, values, &descriptor)?;
 
         // Encode to binary
         let data = encode_row(&descriptor, values)
@@ -776,6 +783,12 @@ impl QueryManager {
         }
 
         self.validate_json_for_values(&descriptor, values)?;
+        Self::validate_write_index_values_on_branch(
+            &table,
+            self.current_branch().as_str(),
+            values,
+            &descriptor,
+        )?;
 
         // Encode new data (used by WITH CHECK and commit write).
         let new_data = encode_row(&descriptor, values)
@@ -1049,7 +1062,6 @@ impl QueryManager {
             .get(&table_name)
             .ok_or(QueryError::TableNotFound(table_name))?;
         let descriptor = table_schema.columns.clone();
-
         // Get parent commit on this branch
         let tips = self
             .sync_manager
@@ -1143,6 +1155,12 @@ impl QueryManager {
         }
 
         self.validate_json_for_values(&descriptor, values)?;
+        Self::validate_write_index_values_on_branch(
+            &table,
+            self.current_branch().as_str(),
+            values,
+            &descriptor,
+        )?;
 
         // Encode new row data
         let new_data = encode_row(&descriptor, values)
@@ -1225,7 +1243,6 @@ impl QueryManager {
             .get(&table_name)
             .ok_or(QueryError::TableNotFound(table_name))?;
         let descriptor = table_schema.columns.clone();
-
         // Get parent commit
         let tips = self
             .sync_manager

--- a/crates/jazz-tools/src/runtime_core.rs
+++ b/crates/jazz-tools/src/runtime_core.rs
@@ -132,7 +132,7 @@ impl std::error::Error for RuntimeError {}
 
 impl From<QueryError> for RuntimeError {
     fn from(e: QueryError) -> Self {
-        RuntimeError::QueryError(format!("{:?}", e))
+        RuntimeError::QueryError(e.to_string())
     }
 }
 

--- a/crates/jazz-tools/src/runtime_core/subscriptions.rs
+++ b/crates/jazz-tools/src/runtime_core/subscriptions.rs
@@ -48,7 +48,7 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
                 durability.local_updates,
                 propagation,
             )
-            .map_err(|e| RuntimeError::QueryError(format!("{:?}", e)))
+            .map_err(|e| RuntimeError::QueryError(e.to_string()))
     }
 
     fn activate_subscription(
@@ -287,7 +287,7 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
         let query_sub_id = self
             .schema_manager
             .subscribe_with_schema_context(query, schema_context, session)
-            .map_err(|e| RuntimeError::QueryError(format!("{:?}", e)))?;
+            .map_err(|e| RuntimeError::QueryError(e.to_string()))?;
 
         self.immediate_tick();
         Ok(crate::sync_manager::QueryId(query_sub_id.0))
@@ -335,7 +335,7 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
             ) {
             Ok(id) => id,
             Err(e) => {
-                let _ = sender.send(Err(RuntimeError::QueryError(format!("{:?}", e))));
+                let _ = sender.send(Err(RuntimeError::QueryError(e.to_string())));
                 return QueryFuture::new(receiver);
             }
         };

--- a/crates/jazz-tools/src/runtime_core/writes.rs
+++ b/crates/jazz-tools/src/runtime_core/writes.rs
@@ -16,7 +16,7 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
         let result = self
             .schema_manager
             .insert_with_session(&mut self.storage, table, &values, session)
-            .map_err(|e| RuntimeError::WriteError(format!("{:?}", e)))?;
+            .map_err(|e| RuntimeError::WriteError(e.to_string()))?;
         let row_id = result.row_id;
         let row_values = result.row_values;
         debug!(object_id = %row_id, "inserted");
@@ -37,7 +37,7 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
         self.schema_manager
             .query_manager_mut()
             .update_with_session(&mut self.storage, object_id, &current_values, session)
-            .map_err(|e| RuntimeError::WriteError(format!("{:?}", e)))?;
+            .map_err(|e| RuntimeError::WriteError(e.to_string()))?;
 
         self.immediate_tick();
         Ok(())
@@ -53,7 +53,7 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
         self.schema_manager
             .query_manager_mut()
             .delete_with_session(&mut self.storage, object_id, session)
-            .map_err(|e| RuntimeError::WriteError(format!("{:?}", e)))?;
+            .map_err(|e| RuntimeError::WriteError(e.to_string()))?;
         debug!("deleted");
         self.immediate_tick();
         Ok(())
@@ -75,7 +75,7 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
         let result = self
             .schema_manager
             .insert_with_session(&mut self.storage, table, &values, session)
-            .map_err(|e| RuntimeError::WriteError(format!("{:?}", e)))?;
+            .map_err(|e| RuntimeError::WriteError(e.to_string()))?;
         let row_id = result.row_id;
         let row_commit_id = result.row_commit_id;
         let row_values = result.row_values;
@@ -114,7 +114,7 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
             .schema_manager
             .query_manager_mut()
             .update_with_session(&mut self.storage, object_id, &current_values, session)
-            .map_err(|e| RuntimeError::WriteError(format!("{:?}", e)))?;
+            .map_err(|e| RuntimeError::WriteError(e.to_string()))?;
 
         let (sender, receiver) = oneshot::channel();
         if self
@@ -178,7 +178,7 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
             .schema_manager
             .query_manager_mut()
             .delete_with_session(&mut self.storage, object_id, session)
-            .map_err(|e| RuntimeError::WriteError(format!("{:?}", e)))?;
+            .map_err(|e| RuntimeError::WriteError(e.to_string()))?;
 
         let (sender, receiver) = oneshot::channel();
         if self

--- a/crates/jazz-tools/src/runtime_tokio.rs
+++ b/crates/jazz-tools/src/runtime_tokio.rs
@@ -328,7 +328,7 @@ impl<S: Storage + Send + 'static> TokioRuntime<S> {
     {
         let mut core = self.core.lock().map_err(|_| RuntimeError::LockError)?;
         core.subscribe(query, callback, session)
-            .map_err(|e| RuntimeError::QueryError(format!("{:?}", e)))
+            .map_err(|e| RuntimeError::QueryError(e.to_string()))
     }
 
     /// Unsubscribe from a query.
@@ -483,7 +483,7 @@ impl<S: Storage + Send + 'static> TokioRuntime<S> {
         let mut core = self.core.lock().map_err(|_| RuntimeError::LockError)?;
         let result = core
             .subscribe_with_schema_context(query, schema_context, session)
-            .map_err(|e| RuntimeError::QueryError(format!("{:?}", e)))?;
+            .map_err(|e| RuntimeError::QueryError(e.to_string()))?;
         Ok(result)
     }
 }

--- a/crates/jazz-tools/src/storage/key_codec.rs
+++ b/crates/jazz-tools/src/storage/key_codec.rs
@@ -4,7 +4,85 @@ use crate::commit::CommitId;
 use crate::object::{BranchName, ObjectId};
 use crate::query_manager::types::Value;
 
-use super::encode_value;
+use super::{StorageError, encode_value};
+
+const INDEX_KEY_MAX_BYTES: usize = u16::MAX as usize;
+const INDEX_ENTRY_UUID_HEX_BYTES: usize = 32;
+
+fn index_entry_key_bytes(
+    table: &str,
+    column: &str,
+    branch: &str,
+    encoded_value_len: usize,
+) -> usize {
+    "idx:".len()
+        + table.len()
+        + 1
+        + column.len()
+        + 1
+        + branch.len()
+        + 1
+        + (encoded_value_len * 2)
+        + 1
+        + INDEX_ENTRY_UUID_HEX_BYTES
+}
+
+fn index_value_prefix_bytes(
+    table: &str,
+    column: &str,
+    branch: &str,
+    encoded_value_len: usize,
+) -> usize {
+    "idx:".len()
+        + table.len()
+        + 1
+        + column.len()
+        + 1
+        + branch.len()
+        + 1
+        + (encoded_value_len * 2)
+        + 1
+}
+
+pub(super) fn validate_index_entry_size(
+    table: &str,
+    column: &str,
+    branch: &str,
+    value: &Value,
+) -> Result<(), StorageError> {
+    let encoded_value_len = encode_value(value).len();
+    let key_bytes = index_entry_key_bytes(table, column, branch, encoded_value_len);
+    if key_bytes > INDEX_KEY_MAX_BYTES {
+        return Err(StorageError::IndexKeyTooLarge {
+            table: table.to_string(),
+            column: column.to_string(),
+            branch: branch.to_string(),
+            key_bytes,
+            max_key_bytes: INDEX_KEY_MAX_BYTES,
+        });
+    }
+    Ok(())
+}
+
+fn encode_index_value_hex(
+    table: &str,
+    column: &str,
+    branch: &str,
+    value: &Value,
+) -> Result<String, StorageError> {
+    let encoded_value = encode_value(value);
+    let key_bytes = index_entry_key_bytes(table, column, branch, encoded_value.len());
+    if key_bytes > INDEX_KEY_MAX_BYTES {
+        return Err(StorageError::IndexKeyTooLarge {
+            table: table.to_string(),
+            column: column.to_string(),
+            branch: branch.to_string(),
+            key_bytes,
+            max_key_bytes: INDEX_KEY_MAX_BYTES,
+        });
+    }
+    Ok(hex::encode(encoded_value))
+}
 
 /// Format an ObjectId as compact hex (no dashes).
 pub(super) fn format_uuid(id: ObjectId) -> String {
@@ -54,25 +132,40 @@ pub(super) fn index_entry_key(
     branch: &str,
     value: &Value,
     row_id: ObjectId,
-) -> String {
-    format!(
+) -> Result<String, StorageError> {
+    Ok(format!(
         "idx:{}:{}:{}:{}:{}",
         table,
         column,
         branch,
-        hex::encode(encode_value(value)),
+        encode_index_value_hex(table, column, branch, value)?,
         format_uuid(row_id)
-    )
+    ))
 }
 
-pub(super) fn index_value_prefix(table: &str, column: &str, branch: &str, value: &Value) -> String {
-    format!(
+pub(super) fn index_value_prefix(
+    table: &str,
+    column: &str,
+    branch: &str,
+    value: &Value,
+) -> Result<String, StorageError> {
+    let encoded_value = encode_value(value);
+    if index_value_prefix_bytes(table, column, branch, encoded_value.len()) > INDEX_KEY_MAX_BYTES {
+        return Err(StorageError::IndexKeyTooLarge {
+            table: table.to_string(),
+            column: column.to_string(),
+            branch: branch.to_string(),
+            key_bytes: index_value_prefix_bytes(table, column, branch, encoded_value.len()),
+            max_key_bytes: INDEX_KEY_MAX_BYTES,
+        });
+    }
+    Ok(format!(
         "idx:{}:{}:{}:{}:",
         table,
         column,
         branch,
-        hex::encode(encode_value(value))
-    )
+        hex::encode(encoded_value)
+    ))
 }
 
 pub(super) fn index_prefix(table: &str, column: &str, branch: &str) -> String {

--- a/crates/jazz-tools/src/storage/mod.rs
+++ b/crates/jazz-tools/src/storage/mod.rs
@@ -37,6 +37,43 @@ use crate::sync_manager::DurabilityTier;
 pub enum StorageError {
     NotFound,
     IoError(String),
+    IndexKeyTooLarge {
+        table: String,
+        column: String,
+        branch: String,
+        key_bytes: usize,
+        max_key_bytes: usize,
+    },
+}
+
+impl std::fmt::Display for StorageError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            StorageError::NotFound => write!(f, "not found"),
+            StorageError::IoError(message) => write!(f, "{message}"),
+            StorageError::IndexKeyTooLarge {
+                table,
+                column,
+                branch,
+                key_bytes,
+                max_key_bytes,
+            } => write!(
+                f,
+                "indexed value too large for {table}.{column} on branch {branch}: index key would be {key_bytes} bytes (max {max_key_bytes})"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for StorageError {}
+
+pub(crate) fn validate_index_value_size(
+    table: &str,
+    column: &str,
+    branch: &str,
+    value: &Value,
+) -> Result<(), StorageError> {
+    key_codec::validate_index_entry_size(table, column, branch, value)
 }
 
 // ============================================================================
@@ -751,6 +788,7 @@ impl Storage for MemoryStorage {
         value: &Value,
         row_id: ObjectId,
     ) -> Result<(), StorageError> {
+        validate_index_value_size(table, column, branch, value)?;
         let key = (table.to_string(), column.to_string(), branch.to_string());
         let index = self.indices.entry(key).or_default();
         let encoded = encode_value(value);
@@ -766,6 +804,12 @@ impl Storage for MemoryStorage {
         value: &Value,
         row_id: ObjectId,
     ) -> Result<(), StorageError> {
+        if matches!(
+            validate_index_value_size(table, column, branch, value),
+            Err(StorageError::IndexKeyTooLarge { .. })
+        ) {
+            return Ok(());
+        }
         let key = (table.to_string(), column.to_string(), branch.to_string());
         if let Some(index) = self.indices.get_mut(&key) {
             let encoded = encode_value(value);

--- a/crates/jazz-tools/src/storage/storage_core.rs
+++ b/crates/jazz-tools/src/storage/storage_core.rs
@@ -234,7 +234,7 @@ pub(super) fn index_insert_core(
     row_id: ObjectId,
     mut set: impl FnMut(&str, &[u8]) -> Result<(), StorageError>,
 ) -> Result<(), StorageError> {
-    let key = index_entry_key(table, column, branch, value, row_id);
+    let key = index_entry_key(table, column, branch, value, row_id)?;
     set(&key, &[0x01])
 }
 
@@ -246,7 +246,11 @@ pub(super) fn index_remove_core(
     row_id: ObjectId,
     mut delete: impl FnMut(&str) -> Result<(), StorageError>,
 ) -> Result<(), StorageError> {
-    let key = index_entry_key(table, column, branch, value, row_id);
+    let key = match index_entry_key(table, column, branch, value, row_id) {
+        Ok(key) => key,
+        Err(StorageError::IndexKeyTooLarge { .. }) => return Ok(()),
+        Err(error) => return Err(error),
+    };
     delete(&key)
 }
 
@@ -261,7 +265,9 @@ pub(super) fn index_lookup_core(
     if super::is_double_zero(value) {
         let mut result = HashSet::new();
         for zero in &[Value::Double(0.0), Value::Double(-0.0)] {
-            let prefix = index_value_prefix(table, column, branch, zero);
+            let Ok(prefix) = index_value_prefix(table, column, branch, zero) else {
+                continue;
+            };
             if let Ok(keys) = scan_prefix_keys(&prefix) {
                 for key in &keys {
                     if let Some(id) = parse_uuid_from_index_key(key) {
@@ -273,7 +279,9 @@ pub(super) fn index_lookup_core(
         return result.into_iter().collect();
     }
 
-    let prefix = index_value_prefix(table, column, branch, value);
+    let Ok(prefix) = index_value_prefix(table, column, branch, value) else {
+        return Vec::new();
+    };
     scan_prefix_keys(&prefix)
         .map(|keys| {
             keys.iter()

--- a/crates/jazz-wasm/src/runtime.rs
+++ b/crates/jazz-wasm/src/runtime.rs
@@ -596,7 +596,7 @@ impl WasmRuntime {
         let mut core = self.core.borrow_mut();
         let (object_id, row_values) = core
             .insert(table, groove_values, None)
-            .map_err(|e| JsError::new(&format!("Insert failed: {:?}", e)))?;
+            .map_err(|e| JsError::new(&format!("Insert failed: {e}")))?;
 
         let row = SubscriptionRow {
             id: object_id.uuid().to_string(),
@@ -668,7 +668,7 @@ impl WasmRuntime {
 
         let mut core = self.core.borrow_mut();
         core.update(oid, updates, None)
-            .map_err(|e| JsError::new(&format!("Update failed: {:?}", e)))?;
+            .map_err(|e| JsError::new(&format!("Update failed: {e}")))?;
 
         tracing::debug!(object_id, "updated");
         Ok(())
@@ -699,7 +699,7 @@ impl WasmRuntime {
 
         let mut core = self.core.borrow_mut();
         core.update(oid, updates, session.as_ref())
-            .map_err(|e| JsError::new(&format!("Update failed: {:?}", e)))?;
+            .map_err(|e| JsError::new(&format!("Update failed: {e}")))?;
 
         tracing::debug!(object_id, "updated_with_session");
         Ok(())
@@ -743,7 +743,7 @@ impl WasmRuntime {
         let ((object_id, row_values), receiver) = {
             let mut core = self.core.borrow_mut();
             core.insert_persisted(table, groove_values, None, persistence_tier)
-                .map_err(|e| JsError::new(&format!("Insert failed: {:?}", e)))?
+                .map_err(|e| JsError::new(&format!("Insert failed: {e}")))?
         };
 
         let row = SubscriptionRow {
@@ -780,7 +780,7 @@ impl WasmRuntime {
         let receiver = {
             let mut core = self.core.borrow_mut();
             core.update_persisted(oid, updates, None, persistence_tier)
-                .map_err(|e| JsError::new(&format!("Update failed: {:?}", e)))?
+                .map_err(|e| JsError::new(&format!("Update failed: {e}")))?
         };
 
         let promise = wasm_bindgen_futures::future_to_promise(async move {

--- a/packages/jazz-tools/src/runtime/client.mutations.test.ts
+++ b/packages/jazz-tools/src/runtime/client.mutations.test.ts
@@ -2,13 +2,13 @@ import { describe, expect, it } from "vitest";
 import { JazzClient, type Runtime } from "./client.js";
 import type { AppContext } from "./context.js";
 
-function makeClient() {
+function makeClient(runtimeOverrides: Partial<Runtime> = {}) {
   const updateCalls: Array<[string, Record<string, unknown>]> = [];
   const updateDurableCalls: Array<[string, Record<string, unknown>, string]> = [];
   const deleteCalls: string[] = [];
   const deleteDurableCalls: Array<[string, string]> = [];
 
-  const runtime: Runtime = {
+  const runtimeBase: Runtime = {
     insert: () => ({ id: "00000000-0000-0000-0000-000000000001", values: [] }),
     insertDurable: async () => ({ id: "00000000-0000-0000-0000-000000000001", values: [] }),
     update: (objectId: string, updates: Record<string, unknown>) => {
@@ -36,6 +36,7 @@ function makeClient() {
     getSchema: () => ({}),
     getSchemaHash: () => "schema-hash",
   };
+  const runtime: Runtime = { ...runtimeBase, ...runtimeOverrides };
 
   const context: AppContext = {
     appId: "test-app",
@@ -62,6 +63,24 @@ function makeClient() {
 }
 
 describe("JazzClient mutation durability split", () => {
+  it("rethrows synchronous runtime mutation errors", () => {
+    const insertError = new Error("Insert failed: indexed value too large");
+    const updateError = new Error("Update failed: indexed value too large");
+    const { client } = makeClient({
+      insert: () => {
+        throw insertError;
+      },
+      update: () => {
+        throw updateError;
+      },
+    });
+
+    expect(() => client.create("todos", [])).toThrow(insertError);
+    expect(() =>
+      client.update("row-1", { done: { type: "Boolean" as const, value: true } }),
+    ).toThrow(updateError);
+  });
+
   it("routes update/delete through the synchronous runtime methods", () => {
     const { client, updateCalls, deleteCalls } = makeClient();
     const updates = { done: { type: "Boolean" as const, value: true } };

--- a/packages/jazz-tools/src/runtime/napi.integration.test.ts
+++ b/packages/jazz-tools/src/runtime/napi.integration.test.ts
@@ -11,6 +11,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { beforeAll, describe, expect, it, vi } from "vitest";
+import { serializeRuntimeSchema } from "../drivers/schema-wire.js";
 import type { WasmSchema } from "../drivers/types.js";
 import type { JazzClient, Row } from "./client.js";
 import type { QueryBuilder } from "./db.js";
@@ -508,6 +509,55 @@ async function createTempDir(prefix: string): Promise<string> {
 }
 
 describe("NAPI integration", () => {
+  it("surfaces oversized indexed persistent mutation errors to JS callers", async () => {
+    const { NapiRuntime } = await loadNapiModule();
+    const dataPath = await createTempDir("jazz-napi-large-index-");
+    const runtime = new NapiRuntime(
+      serializeRuntimeSchema(TEST_SCHEMA),
+      `napi-large-index-${randomUUID()}`,
+      "test",
+      "main",
+      dataPath,
+    ) as unknown as {
+      insert(table: string, values: unknown): Row;
+      update(objectId: string, updates: Record<string, unknown>): void;
+      query(queryJson: string): Promise<Row[]>;
+      close(): void;
+    };
+
+    const oversizedTitle = "x".repeat(40_000);
+    const queryJson = translateQuery(allTodosQuery._build(), TEST_SCHEMA);
+
+    try {
+      expect(() =>
+        runtime.insert("todos", [
+          { type: "Text", value: oversizedTitle },
+          { type: "Boolean", value: false },
+        ]),
+      ).toThrow(/indexed value too large/i);
+
+      const insertedRow = runtime.insert("todos", [
+        { type: "Text", value: "kept title" },
+        { type: "Boolean", value: false },
+      ]);
+
+      expect(() =>
+        runtime.update(insertedRow.id, {
+          title: { type: "Text", value: oversizedTitle },
+        }),
+      ).toThrow(/indexed value too large/i);
+
+      const rows = await runtime.query(queryJson);
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toMatchObject({ id: insertedRow.id });
+      expect(rows[0]?.values[0]).toEqual({ type: "Text", value: "kept title" });
+      expect(rows[0]?.values[1]).toEqual({ type: "Boolean", value: false });
+    } finally {
+      runtime.close();
+      await rm(dataPath, { recursive: true, force: true });
+    }
+  }, 20_000);
+
   it("emits the real nested onSyncMessageToSend callback shape from the compiled addon", async () => {
     const runtime = await createNapiRuntime(TEST_SCHEMA, {
       appId: `napi-contract-${randomUUID()}`,


### PR DESCRIPTION
## Summary
- add fjall-backed regression tests for oversized indexed text and array(text) insert/update paths
- turn oversized index-key failures into structured mutation errors before local writes create partial state
- propagate readable mutation errors through jazz-tools, NAPI, WASM, and RN, and add a patch changeset for the published runtimes

## Testing
- pnpm lint
- cargo test -p jazz-tools --features fjall fjall_oversized -- --nocapture
- cargo test -p jazz-tools --features fjall fjall_update_can_heal_synced_row_with_oversized_index_value -- --nocapture
- pnpm --dir packages/jazz-tools exec vitest run src/runtime/client.mutations.test.ts src/runtime/napi.integration.test.ts -t "rethrows synchronous runtime mutation errors|surfaces oversized indexed persistent mutation errors to JS callers"