### PR TITLE
Fix permissions.ts app import loading during schema build

### DIFF
--- a/packages/jazz-tools/src/cli.test.ts
+++ b/packages/jazz-tools/src/cli.test.ts
@@ -76,10 +76,10 @@ table("todos", {
 `;
 }
 
-function permissionsSchema(): string {
+function permissionsSchema(appImportPath: string = "./app.js"): string {
   return `
 import { definePermissions } from ${JSON.stringify(permissionsDslPath)};
-import { app } from "./app";
+import { app } from ${JSON.stringify(appImportPath)};
 
 export default definePermissions(app, ({ policy, session }) => [
   policy.todos.allowRead.where({ owner_id: session.user_id }),
@@ -108,7 +108,7 @@ export const nope = 42;
 function permissionsSchemaNamedExport(): string {
   return `
 import { definePermissions } from ${JSON.stringify(permissionsDslPath)};
-import { app } from "./app";
+import { app } from "./app.js";
 
 export const permissions = definePermissions(app, ({ policy, session }) => [
   policy.todos.allowRead.where({ owner_id: session.user_id }),
@@ -277,6 +277,32 @@ describe("cli build permissions generation", () => {
     expect(appTs).toContain('"type": "SessionRef"');
     expect(appTs).toContain('"column": "owner_id"');
     expect(permissionsTest).toContain("Permissions test starter.");
+  });
+
+  it("loads permissions.ts when it imports app from ./app.ts", async () => {
+    const { schemaDir, jazzBin } = await createWorkspace();
+    await writeFile(join(schemaDir, "current.ts"), currentSchemaWithoutInlinePermissions());
+    await writeFile(join(schemaDir, "permissions.ts"), permissionsSchema("./app.ts"));
+
+    await build({ schemaDir, jazzBin });
+
+    const sql = await readFile(join(schemaDir, "current.sql"), "utf8");
+    expect(sql).toContain(
+      "CREATE POLICY todos_select_policy ON todos FOR SELECT USING (owner_id = @session.user_id);",
+    );
+  });
+
+  it("loads permissions.ts when it imports app from ./app", async () => {
+    const { schemaDir, jazzBin } = await createWorkspace();
+    await writeFile(join(schemaDir, "current.ts"), currentSchemaWithoutInlinePermissions());
+    await writeFile(join(schemaDir, "permissions.ts"), permissionsSchema("./app"));
+
+    await build({ schemaDir, jazzBin });
+
+    const sql = await readFile(join(schemaDir, "current.sql"), "utf8");
+    expect(sql).toContain(
+      "CREATE POLICY todos_select_policy ON todos FOR SELECT USING (owner_id = @session.user_id);",
+    );
   });
 
   it("fails when current.ts uses inline table permissions", async () => {

--- a/packages/jazz-tools/src/cli.test.ts
+++ b/packages/jazz-tools/src/cli.test.ts
@@ -11,6 +11,9 @@ const permissionsDslPath = fileURLToPath(new URL("./permissions/index.ts", impor
 // Bin integration tests run in a subprocess that loads dist/cli.js, so current.ts must import
 // from the compiled dist to share the same dsl module instance (and thus _collectedSchema state).
 const distDslPath = fileURLToPath(new URL("../dist/dsl.js", import.meta.url));
+const distPermissionsDslPath = fileURLToPath(
+  new URL("../dist/permissions/index.js", import.meta.url),
+);
 
 const tempRoots: string[] = [];
 
@@ -167,6 +170,17 @@ migrate("messages", {
 migrate("canvases", {
   isPublic: col.drop().boolean({ backwardsDefault: false }),
 });
+`;
+}
+
+function binPermissionsSchema(appImportPath: string = "./app.js"): string {
+  return `
+import { definePermissions } from ${JSON.stringify(distPermissionsDslPath)};
+import { app } from ${JSON.stringify(appImportPath)};
+
+export default definePermissions(app, ({ policy, session }) => [
+  policy.todos.allowRead.where({ owner_id: session.user_id }),
+]);
 `;
 }
 
@@ -460,5 +474,19 @@ describe("bin integration", () => {
 
     await readFile(join(schemaDir, "migration_v1_v2_fwd_aaaaaaaaaaaa_bbbbbbbbbbbb.sql"), "utf8");
     await readFile(join(schemaDir, "migration_v1_v2_bwd_aaaaaaaaaaaa_bbbbbbbbbbbb.sql"), "utf8");
+  });
+
+  it("loads permissions.ts that imports ./app via bin entry point", async () => {
+    const { schemaDir } = await createWorkspace();
+    const rustBin = await createFakeRustBin();
+    await writeFile(join(schemaDir, "current.ts"), binCurrentSchema());
+    await writeFile(join(schemaDir, "permissions.ts"), binPermissionsSchema("./app"));
+
+    runBinBuild(schemaDir, rustBin);
+
+    const sql = await readFile(join(schemaDir, "current.sql"), "utf8");
+    expect(sql).toContain(
+      "CREATE POLICY todos_select_policy ON todos FOR SELECT USING (owner_id = @session.user_id);",
+    );
   });
 });

--- a/packages/jazz-tools/src/cli.ts
+++ b/packages/jazz-tools/src/cli.ts
@@ -4,7 +4,7 @@
 
 import { spawn } from "child_process";
 import { access, readdir, writeFile } from "fs/promises";
-import { join, basename, dirname } from "path";
+import { join, basename, dirname, resolve } from "path";
 import { pathToFileURL } from "url";
 import { register as registerCjs } from "tsx/cjs/api";
 import { register as registerEsm } from "tsx/esm/api";
@@ -44,7 +44,7 @@ let importCounter = 0;
 function requirePermissionsModule<T>(filePath: string): T {
   const loader = registerCjs({ namespace: `jazz-tools-cli-permissions-${++importCounter}` });
   try {
-    return loader.require(filePath, import.meta.url) as T;
+    return loader.require(resolve(filePath), import.meta.url) as T;
   } finally {
     loader.unregister();
   }

--- a/packages/jazz-tools/src/cli.ts
+++ b/packages/jazz-tools/src/cli.ts
@@ -6,14 +6,12 @@ import { spawn } from "child_process";
 import { access, readdir, writeFile } from "fs/promises";
 import { join, basename, dirname } from "path";
 import { pathToFileURL } from "url";
-import { register } from "tsx/esm/api";
+import { register as registerCjs } from "tsx/cjs/api";
+import { register as registerEsm } from "tsx/esm/api";
 import { schemaToSql, lensesToSql } from "./sql-gen.js";
 import { getCollectedSchema, getCollectedMigrations, resetCollectedState } from "./dsl.js";
 import { generateClient } from "./codegen/index.js";
 import type { Lens, Schema, TablePolicies, OperationPolicy } from "./schema.js";
-
-// Allow loading `.ts` schema files when invoked via `node dist/cli.js`.
-register();
 
 export interface BuildOptions {
   jazzBin: string;
@@ -37,12 +35,23 @@ function parseArgs(): { command: string; options: BuildOptions } {
   return { command, options: { jazzBin, schemaDir } };
 }
 
-// Counter for cache-busting dynamic imports
+// Allow loading `.ts` schema files when invoked via `node dist/cli.js`.
+registerEsm();
+
+// Counter for cache-busting module loads.
 let importCounter = 0;
+
+function requirePermissionsModule<T>(filePath: string): T {
+  const loader = registerCjs({ namespace: `jazz-tools-cli-permissions-${++importCounter}` });
+  try {
+    return loader.require(filePath, import.meta.url) as T;
+  } finally {
+    loader.unregister();
+  }
+}
 
 async function loadSchemaModule(filePath: string): Promise<void> {
   resetCollectedState();
-  // Add cache-busting query param since Node.js caches dynamic imports
   const url = pathToFileURL(filePath).href + `?v=${++importCounter}`;
   await import(url);
 }
@@ -54,7 +63,6 @@ async function loadSchema(filePath: string): Promise<Schema> {
 
 async function loadMigrationModule(filePath: string): Promise<Lens[]> {
   resetCollectedState();
-  // Add cache-busting query param since Node.js caches dynamic imports
   const url = pathToFileURL(filePath).href + `?v=${++importCounter}`;
   await import(url);
   return getCollectedMigrations();
@@ -154,8 +162,7 @@ function isPermissionsMap(input: unknown): input is Record<string, TablePolicies
 }
 
 async function loadPermissionsModule(filePath: string): Promise<Record<string, TablePolicies>> {
-  const url = pathToFileURL(filePath).href + `?v=${++importCounter}`;
-  const module = await import(url);
+  const module = requirePermissionsModule<Record<string, unknown>>(filePath);
   const candidate = module.default ?? module.permissions ?? null;
   if (!candidate) {
     throw new Error(


### PR DESCRIPTION
## Summary
- load  through 's CJS loader while keeping  and migrations on the existing ESM path
- preserve generated  compatibility for , , and bare  imports from 
- add CLI regression tests covering all three import spellings

## Testing
- pnpm exec vitest run src/cli.test.ts --config vitest.config.ts
- reproduced the failure in  with published 
- verified the patched local wrapper succeeds against a temp workspace built from the real  schema
