### PR TITLE
Replace crc32fast with xxHash32 for opfs-btree page checksums

### DIFF
--- a/.changeset/pr-326-opfs-checksum.md
+++ b/.changeset/pr-326-opfs-checksum.md
@@ -1,0 +1,8 @@
+---
+"jazz-tools": patch
+"jazz-wasm": patch
+---
+
+Use xxHash-based checksums for `opfs-btree` pages and superblocks to reduce checksum overhead in persistent browser storage.
+
+Existing OPFS stores created by older builds are not checksum-compatible with this change and will need to be recreated after upgrading.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,9 +39,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -60,9 +60,9 @@ checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -540,9 +540,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -550,9 +550,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -562,9 +562,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -574,9 +574,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cobs"
@@ -657,15 +657,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "crc32fast"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -2270,9 +2261,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -2288,9 +2279,9 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "openssl"
-version = "0.10.75"
+version = "0.10.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
 dependencies = [
  "bitflags 2.11.0",
  "cfg-if",
@@ -2320,9 +2311,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.111"
+version = "0.9.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
 dependencies = [
  "cc",
  "libc",
@@ -2422,7 +2413,6 @@ name = "opfs-btree"
 version = "0.1.0"
 dependencies = [
  "bf-tree",
- "crc32fast",
  "criterion",
  "fjall",
  "js-sys",
@@ -2436,6 +2426,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "xxhash-rust",
 ]
 
 [[package]]
@@ -3240,6 +3231,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3738,9 +3738,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_edit",
+]
+
+[[package]]
+name = "toml"
+version = "0.9.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned 1.0.4",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
 ]
 
 [[package]]
@@ -3753,6 +3768,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3760,9 +3784,18 @@ checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.9+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
+dependencies = [
  "winnow",
 ]
 
@@ -3771,6 +3804,12 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "toml_writer"
+version = "1.0.6+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
 name = "tonic"
@@ -3937,9 +3976,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -4095,7 +4134,7 @@ dependencies = [
  "serde",
  "tempfile",
  "textwrap",
- "toml 0.8.23",
+ "toml 0.9.12+spec-1.1.0",
  "uniffi_internal_macros 0.30.0",
  "uniffi_meta 0.30.0",
  "uniffi_pipeline 0.30.0",
@@ -4193,7 +4232,7 @@ dependencies = [
  "quote",
  "serde",
  "syn",
- "toml 0.8.23",
+ "toml 0.9.12+spec-1.1.0",
  "uniffi_meta 0.30.0",
 ]
 

--- a/crates/opfs-btree/Cargo.toml
+++ b/crates/opfs-btree/Cargo.toml
@@ -17,7 +17,7 @@ rustc-hash = "2"
 thiserror = "2"
 tracing = "0.1"
 serde = { version = "1", features = ["derive"] }
-xxhash-rust = { version = "0.8", features = ["xxh32"] }
+xxhash-rust = { version = "0.8", features = ["xxh3"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 bf-tree = { version = "0.4.8", optional = true }

--- a/crates/opfs-btree/Cargo.toml
+++ b/crates/opfs-btree/Cargo.toml
@@ -13,11 +13,11 @@ crate-type = ["cdylib", "rlib"]
 compare-native = ["dep:bf-tree", "dep:rocksdb", "dep:fjall"]
 
 [dependencies]
-crc32fast = "1"
 rustc-hash = "2"
 thiserror = "2"
 tracing = "0.1"
 serde = { version = "1", features = ["derive"] }
+xxhash-rust = { version = "0.8", features = ["xxh32"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 bf-tree = { version = "0.4.8", optional = true }

--- a/crates/opfs-btree/src/checksum.rs
+++ b/crates/opfs-btree/src/checksum.rs
@@ -1,13 +1,13 @@
-use xxhash_rust::xxh32;
+use xxhash_rust::xxh3;
 
 pub(crate) struct Hasher {
-    state: xxh32::Xxh32,
+    state: xxh3::Xxh3,
 }
 
 impl Hasher {
     pub(crate) fn new() -> Self {
         Self {
-            state: xxh32::Xxh32::new(0),
+            state: xxh3::Xxh3::new(),
         }
     }
 
@@ -16,13 +16,13 @@ impl Hasher {
     }
 
     pub(crate) fn finalize(self) -> u32 {
-        self.state.digest()
+        self.state.digest() as u32
     }
 }
 
 #[inline]
 pub(crate) fn hash(bytes: &[u8]) -> u32 {
-    xxh32::xxh32(bytes, 0)
+    xxh3::xxh3_64(bytes) as u32
 }
 
 #[cfg(test)]
@@ -30,14 +30,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn xxh32_standard_test_vectors() {
-        assert_eq!(hash(b""), 0x02CC_5D05);
-        assert_eq!(hash(b"123456789"), 0x937B_AD67);
-    }
-
-    #[test]
     fn streaming_matches_one_shot() {
-        let data = b"hello world, this is a test of streaming xxhash32";
+        let data = b"hello world, this is a test of streaming xxh3";
         let one_shot = hash(data);
 
         for split in 0..=data.len() {

--- a/crates/opfs-btree/src/checksum.rs
+++ b/crates/opfs-btree/src/checksum.rs
@@ -1,0 +1,85 @@
+use xxhash_rust::xxh32;
+
+pub(crate) struct Hasher {
+    state: xxh32::Xxh32,
+}
+
+impl Hasher {
+    pub(crate) fn new() -> Self {
+        Self {
+            state: xxh32::Xxh32::new(0),
+        }
+    }
+
+    pub(crate) fn update(&mut self, data: &[u8]) {
+        self.state.update(data);
+    }
+
+    pub(crate) fn finalize(self) -> u32 {
+        self.state.digest()
+    }
+}
+
+#[inline]
+pub(crate) fn hash(bytes: &[u8]) -> u32 {
+    xxh32::xxh32(bytes, 0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn xxh32_standard_test_vectors() {
+        assert_eq!(hash(b""), 0x02CC_5D05);
+        assert_eq!(hash(b"123456789"), 0x937B_AD67);
+    }
+
+    #[test]
+    fn streaming_matches_one_shot() {
+        let data = b"hello world, this is a test of streaming xxhash32";
+        let one_shot = hash(data);
+
+        for split in 0..=data.len() {
+            let mut h = Hasher::new();
+            h.update(&data[..split]);
+            h.update(&data[split..]);
+            assert_eq!(h.finalize(), one_shot, "split={split}");
+        }
+    }
+
+    #[test]
+    fn streaming_matches_one_shot_large() {
+        let mut data = vec![0u8; 1024];
+        for (i, b) in data.iter_mut().enumerate() {
+            *b = (i as u8).wrapping_mul(31).wrapping_add(7);
+        }
+        let one_shot = hash(&data);
+
+        for split in (0..=128).chain([256, 512, 513, 1023, 1024].iter().copied()) {
+            let split = split.min(data.len());
+            let mut h = Hasher::new();
+            h.update(&data[..split]);
+            h.update(&data[split..]);
+            assert_eq!(h.finalize(), one_shot, "split={split}");
+        }
+    }
+
+    #[test]
+    fn streaming_skip_segment_differs() {
+        let full = b"AAAAbbbbCCCCCCCC";
+        let full_hash = hash(full);
+
+        let mut h = Hasher::new();
+        h.update(&full[..4]);
+        h.update(&full[8..]);
+        let skip_hash = h.finalize();
+
+        assert_ne!(full_hash, skip_hash);
+    }
+
+    #[test]
+    fn hash_deterministic() {
+        assert_eq!(hash(b"determinism"), hash(b"determinism"));
+    }
+}

--- a/crates/opfs-btree/src/lib.rs
+++ b/crates/opfs-btree/src/lib.rs
@@ -1,3 +1,4 @@
+mod checksum;
 mod db;
 mod error;
 mod file;

--- a/crates/opfs-btree/src/page.rs
+++ b/crates/opfs-btree/src/page.rs
@@ -1,4 +1,4 @@
-use crate::BTreeError;
+use crate::{BTreeError, checksum};
 
 pub(crate) type PageId = u64;
 
@@ -1339,10 +1339,10 @@ fn page_payload_capacity(page_size: usize) -> Result<usize, BTreeError> {
 }
 
 fn page_checksum(raw: &[u8]) -> u32 {
-    let mut hasher = crc32fast::Hasher::new();
-    hasher.update(&raw[..20]);
-    hasher.update(&raw[24..]);
-    hasher.finalize()
+    let mut h = checksum::Hasher::new();
+    h.update(&raw[..20]);
+    h.update(&raw[24..]);
+    h.finalize()
 }
 
 #[inline]

--- a/crates/opfs-btree/src/superblock.rs
+++ b/crates/opfs-btree/src/superblock.rs
@@ -1,4 +1,4 @@
-use crate::BTreeError;
+use crate::{BTreeError, checksum};
 
 const MAGIC: [u8; 8] = *b"OPFSBT01";
 const FORMAT_VERSION: u32 = 1;
@@ -89,7 +89,7 @@ impl Superblock {
         page[OFFSET_TOTAL_PAGES..OFFSET_TOTAL_PAGES + 8]
             .copy_from_slice(&self.total_pages.to_le_bytes());
 
-        let checksum = crc32fast::hash(&page[..OFFSET_CHECKSUM]);
+        let checksum = checksum::hash(&page[..OFFSET_CHECKSUM]);
         page[OFFSET_CHECKSUM..OFFSET_CHECKSUM + 4].copy_from_slice(&checksum.to_le_bytes());
         Ok(())
     }
@@ -138,7 +138,7 @@ impl Superblock {
                 .try_into()
                 .expect("superblock checksum slice"),
         );
-        let actual_checksum = crc32fast::hash(&page[..OFFSET_CHECKSUM]);
+        let actual_checksum = checksum::hash(&page[..OFFSET_CHECKSUM]);
         if expected_checksum != actual_checksum {
             return Err(BTreeError::Corrupt(format!(
                 "superblock checksum mismatch: expected {}, got {}",


### PR DESCRIPTION
## Summary

- Replace `crc32fast` (CRC32) with `xxhash-rust` (xxh3_64) for B-tree page and superblock checksums.
- Introduces a thin `checksum` module wrapping xxh3 with a streaming `Hasher` for the page checksum's skip-4-bytes pattern.
- The xxh3_64 output is truncated to `u32` to fit the existing 4-byte checksum field — no page format change.

## WASM checksum benchmark (Chromium, 1M iterations per cell)

Throughput in MB/s, measured via `pnpm --filter @jazz/opfs-btree run bench:wasm:hash -- --count 1000000`:

| Data size | crc32 | xxh32 | rapidhash | **xxh3_64** |
|-----------|------:|------:|----------:|------------:|
| 4 KB      | 2,117 | 2,987 |     5,878 |  **16,672** |
| **16 KB** (page size) | 2,144 | 3,049 | 5,676 | **17,165** |
| 64 KB     | 1,945 | 2,788 |     5,744 |  **15,695** |

At the 16 KB page size used by opfs-btree, xxh3 is **3x faster than rapidhash**, **5.6x faster than xxh32**, and **8x faster than crc32**.

## Why xxh3 dominates on WASM

All three algorithms fall back to pure software on WASM (no hardware CRC, no SIMD by default). Their performance separates along two axes: **memory access pattern** and **instruction-level parallelism**.

|  | CRC32 (software) | xxHash32 | xxh3_64 |
|---|---|---|---|
| **Static tables** | 16 KB (16 × 256 × 4 B) | 0 B | 0 B |
| **Per-byte work** | 1 random table lookup + XOR | ~1 arith op (add/mul/rot) | ~1 arith op (add/mul/rot) |
| **Accumulator lanes** | 1 (serial) | 4 (32-bit) | 8 (64-bit) |
| **ILP** | Each byte depends on the previous | 4-way parallel | 8-way parallel, wider multiply |
| **Cache pressure** | Every byte touches a random cache line in the table | None | None |

CRC32's table lookups are the worst possible pattern on WASM engines — data-dependent loads from a 16 KB table that compete for L1 with the page data itself. On native x86/ARM, `crc32fast` bypasses this entirely with single-cycle hardware CRC instructions (SSE4.2 / NEON), but those don't exist in WASM.

xxh32 eliminates the tables but is limited to 4 × 32-bit accumulator lanes. xxh3 goes further: 8 × 64-bit lanes with wider multiplies, giving the WASM engine's pipeline much more independent work per loop iteration. The result is near-linear scaling with data size — hitting ~17 GB/s at 16 KB, close to memory bandwidth.

### What about WASM SIMD?

We benchmarked with `-C target-feature=+simd128` enabled. Surprisingly, explicit SIMD made xxh3 **slower** (7.4 GB/s vs 16.8 GB/s at 16 KB). The V8 JIT appears to do a better job auto-optimizing the scalar xxh3 loop than executing the explicit `core::arch::wasm32` SIMD intrinsics from xxhash-rust. SIMD is left off.


Before:
<img width="762" height="893" alt="Screenshot 2026-03-13 at 17 37 01" src="https://github.com/user-attachments/assets/8668d782-0b4f-4b8f-a497-5aa6ce61e0af" />

After:
<img width="753" height="906" alt="Screenshot 2026-03-13 at 17 38 58" src="https://github.com/user-attachments/assets/6c35c77b-b5ab-43cf-a448-9fac159d2234" />

