### PR TITLE
feat: activate expo native modules autolinking

### DIFF
--- a/examples/todo-client-localfirst-expo/package.json
+++ b/examples/todo-client-localfirst-expo/package.json
@@ -15,7 +15,6 @@
   },
   "dependencies": {
     "expo": "^54.0.0",
-    "jazz-rn": "workspace:*",
     "jazz-tools": "workspace:*",
     "metro-runtime": "0.83.3",
     "react": "19.2.4",

--- a/packages/jazz-tools/package.json
+++ b/packages/jazz-tools/package.json
@@ -76,6 +76,7 @@
   },
   "dependencies": {
     "@standard-schema/spec": "^1.1.0",
+    "jazz-rn": "workspace:*",
     "jazz-wasm": "workspace:*",
     "json-schema-to-ts": "^3.1.1",
     "pluralize-esm": "^9.0.5",
@@ -91,7 +92,6 @@
     "@vitest/browser": "catalog:default",
     "@vitest/browser-playwright": "catalog:default",
     "fake-indexeddb": "^5.0.2",
-    "jazz-rn": "workspace:*",
     "react-dom": "^19.0.0",
     "svelte": "^5.0.0",
     "typescript": "catalog:default",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -388,9 +388,6 @@ importers:
       expo:
         specifier: ^54.0.0
         version: 54.0.33(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.1(typescript@5.9.3))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4)
-      jazz-rn:
-        specifier: workspace:*
-        version: link:../../crates/jazz-rn
       jazz-tools:
         specifier: workspace:*
         version: link:../../packages/jazz-tools
@@ -662,6 +659,9 @@ importers:
       expo:
         specifier: '>=54'
         version: 54.0.33(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.1(typescript@5.9.3))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4)
+      jazz-rn:
+        specifier: workspace:*
+        version: link:../../crates/jazz-rn
       jazz-wasm:
         specifier: workspace:*
         version: link:../../crates/jazz-wasm
@@ -708,9 +708,6 @@ importers:
       fake-indexeddb:
         specifier: ^5.0.2
         version: 5.0.2
-      jazz-rn:
-        specifier: workspace:*
-        version: link:../../crates/jazz-rn
       react-dom:
         specifier: 19.2.4
         version: 19.2.4(react@19.2.4)


### PR DESCRIPTION
This allows us not to install jazz-rn separately. The expo autolink should automatically detect the native module. 