### PR TITLE
fix(codegen): replace declare class fields for Expo compatibility

### DIFF
--- a/.changeset/fix-expo-declare-fields-codegen.md
+++ b/.changeset/fix-expo-declare-fields-codegen.md
@@ -1,0 +1,7 @@
+---
+"jazz-tools": patch
+---
+
+Fix generated `schema/app.ts` query builder class fields for Expo compatibility by replacing `declare readonly` phantom fields with `readonly ...!:`.
+
+Expo's Babel pipeline rejects `declare` class fields without Flow-specific options, causing generated schemas to fail compilation in React Native apps. This change keeps the same type inference intent and does not change runtime behavior.

--- a/examples/docs/todo-client-localfirst-expo/schema/app.ts
+++ b/examples/docs/todo-client-localfirst-expo/schema/app.ts
@@ -1,6 +1,12 @@
 // AUTO-GENERATED FILE - DO NOT EDIT
 import type { WasmSchema, QueryBuilder } from "jazz-tools";
-export type JsonValue = string | number | boolean | null | { [key: string]: JsonValue } | JsonValue[];
+export type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: JsonValue }
+  | JsonValue[];
 
 export type PermissionIntrospectionColumn = "$canRead" | "$canEdit" | "$canDelete";
 export interface PermissionIntrospectionColumns {
@@ -72,32 +78,30 @@ export interface TodoInclude {
 }
 
 export type ProjectIncludedRelations<I extends ProjectInclude = {}> = {
-  [K in keyof I]-?:
-    K extends "todosViaProject"
-      ? NonNullable<I["todosViaProject"]> extends infer RelationInclude
-        ? RelationInclude extends true
-          ? Todo[]
-          : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
-            ? QueryRow[]
-            : RelationInclude extends TodoInclude
-              ? TodoWithIncludes<RelationInclude>[]
-              : never
-        : never
+  [K in keyof I]-?: K extends "todosViaProject"
+    ? NonNullable<I["todosViaProject"]> extends infer RelationInclude
+      ? RelationInclude extends true
+        ? Todo[]
+        : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
+          ? QueryRow[]
+          : RelationInclude extends TodoInclude
+            ? TodoWithIncludes<RelationInclude>[]
+            : never
+      : never
     : never;
 };
 
 export type TodoIncludedRelations<I extends TodoInclude = {}> = {
-  [K in keyof I]-?:
-    K extends "parent"
-      ? NonNullable<I["parent"]> extends infer RelationInclude
-        ? RelationInclude extends true
-          ? Todo | undefined
-          : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
-            ? QueryRow | undefined
-            : RelationInclude extends TodoInclude
-              ? TodoWithIncludes<RelationInclude> | undefined
-              : never
-        : never
+  [K in keyof I]-?: K extends "parent"
+    ? NonNullable<I["parent"]> extends infer RelationInclude
+      ? RelationInclude extends true
+        ? Todo | undefined
+        : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
+          ? QueryRow | undefined
+          : RelationInclude extends TodoInclude
+            ? TodoWithIncludes<RelationInclude> | undefined
+            : never
+      : never
     : K extends "todosViaParent"
       ? NonNullable<I["todosViaParent"]> extends infer RelationInclude
         ? RelationInclude extends true
@@ -108,17 +112,17 @@ export type TodoIncludedRelations<I extends TodoInclude = {}> = {
               ? TodoWithIncludes<RelationInclude>[]
               : never
         : never
-    : K extends "project"
-      ? NonNullable<I["project"]> extends infer RelationInclude
-        ? RelationInclude extends true
-          ? Project | undefined
-          : RelationInclude extends AnyProjectQueryBuilder<infer QueryRow>
-            ? QueryRow | undefined
-            : RelationInclude extends ProjectInclude
-              ? ProjectWithIncludes<RelationInclude> | undefined
-              : never
-        : never
-    : never;
+      : K extends "project"
+        ? NonNullable<I["project"]> extends infer RelationInclude
+          ? RelationInclude extends true
+            ? Project | undefined
+            : RelationInclude extends AnyProjectQueryBuilder<infer QueryRow>
+              ? QueryRow | undefined
+              : RelationInclude extends ProjectInclude
+                ? ProjectWithIncludes<RelationInclude> | undefined
+                : never
+          : never
+        : never;
 };
 
 export interface ProjectRelations {
@@ -131,186 +135,200 @@ export interface TodoRelations {
   project: Project;
 }
 
-export type ProjectWithIncludes<I extends ProjectInclude = {}> = Omit<Project, Extract<keyof I, keyof Project>> & ProjectIncludedRelations<I>;
+export type ProjectWithIncludes<I extends ProjectInclude = {}> = Omit<
+  Project,
+  Extract<keyof I, keyof Project>
+> &
+  ProjectIncludedRelations<I>;
 
-export type TodoWithIncludes<I extends TodoInclude = {}> = Omit<Todo, Extract<keyof I, keyof Todo>> & TodoIncludedRelations<I>;
+export type TodoWithIncludes<I extends TodoInclude = {}> = Omit<
+  Todo,
+  Extract<keyof I, keyof Todo>
+> &
+  TodoIncludedRelations<I>;
 
 export type ProjectSelectableColumn = keyof Project | PermissionIntrospectionColumn | "*";
 export type ProjectOrderableColumn = keyof Project | PermissionIntrospectionColumn;
 
-export type ProjectSelected<S extends ProjectSelectableColumn = keyof Project> = "*" extends S ? Project : Pick<Project, Extract<S | "id", keyof Project>> & Pick<PermissionIntrospectionColumns, Extract<S, PermissionIntrospectionColumn>>;
+export type ProjectSelected<S extends ProjectSelectableColumn = keyof Project> = "*" extends S
+  ? Project
+  : Pick<Project, Extract<S | "id", keyof Project>> &
+      Pick<PermissionIntrospectionColumns, Extract<S, PermissionIntrospectionColumn>>;
 
-export type ProjectSelectedWithIncludes<I extends ProjectInclude = {}, S extends ProjectSelectableColumn = keyof Project> = Omit<ProjectSelected<S>, Extract<keyof I, keyof ProjectSelected<S>>> & ProjectIncludedRelations<I>;
+export type ProjectSelectedWithIncludes<
+  I extends ProjectInclude = {},
+  S extends ProjectSelectableColumn = keyof Project,
+> = Omit<ProjectSelected<S>, Extract<keyof I, keyof ProjectSelected<S>>> &
+  ProjectIncludedRelations<I>;
 
 export type TodoSelectableColumn = keyof Todo | PermissionIntrospectionColumn | "*";
 export type TodoOrderableColumn = keyof Todo | PermissionIntrospectionColumn;
 
-export type TodoSelected<S extends TodoSelectableColumn = keyof Todo> = "*" extends S ? Todo : Pick<Todo, Extract<S | "id", keyof Todo>> & Pick<PermissionIntrospectionColumns, Extract<S, PermissionIntrospectionColumn>>;
+export type TodoSelected<S extends TodoSelectableColumn = keyof Todo> = "*" extends S
+  ? Todo
+  : Pick<Todo, Extract<S | "id", keyof Todo>> &
+      Pick<PermissionIntrospectionColumns, Extract<S, PermissionIntrospectionColumn>>;
 
-export type TodoSelectedWithIncludes<I extends TodoInclude = {}, S extends TodoSelectableColumn = keyof Todo> = Omit<TodoSelected<S>, Extract<keyof I, keyof TodoSelected<S>>> & TodoIncludedRelations<I>;
+export type TodoSelectedWithIncludes<
+  I extends TodoInclude = {},
+  S extends TodoSelectableColumn = keyof Todo,
+> = Omit<TodoSelected<S>, Extract<keyof I, keyof TodoSelected<S>>> & TodoIncludedRelations<I>;
 
 export const wasmSchema: WasmSchema = {
-  "projects": {
-    "columns": [
+  projects: {
+    columns: [
       {
-        "name": "name",
-        "column_type": {
-          "type": "Text"
+        name: "name",
+        column_type: {
+          type: "Text",
         },
-        "nullable": false
-      }
-    ]
-  },
-  "todos": {
-    "columns": [
-      {
-        "name": "title",
-        "column_type": {
-          "type": "Text"
-        },
-        "nullable": false
+        nullable: false,
       },
-      {
-        "name": "done",
-        "column_type": {
-          "type": "Boolean"
-        },
-        "nullable": false
-      },
-      {
-        "name": "description",
-        "column_type": {
-          "type": "Text"
-        },
-        "nullable": true
-      },
-      {
-        "name": "owner_id",
-        "column_type": {
-          "type": "Text"
-        },
-        "nullable": false
-      },
-      {
-        "name": "parent",
-        "column_type": {
-          "type": "Uuid"
-        },
-        "nullable": true,
-        "references": "todos"
-      },
-      {
-        "name": "project",
-        "column_type": {
-          "type": "Uuid"
-        },
-        "nullable": true,
-        "references": "projects"
-      }
     ],
-    "policies": {
-      "select": {
-        "using": {
-          "type": "Cmp",
-          "column": "owner_id",
-          "op": "Eq",
-          "value": {
-            "type": "SessionRef",
-            "path": [
-              "user_id"
-            ]
-          }
-        }
-      },
-      "insert": {
-        "with_check": {
-          "type": "Cmp",
-          "column": "owner_id",
-          "op": "Eq",
-          "value": {
-            "type": "SessionRef",
-            "path": [
-              "user_id"
-            ]
-          }
-        }
-      },
-      "update": {
-        "using": {
-          "type": "And",
-          "exprs": [
-            {
-              "type": "Cmp",
-              "column": "owner_id",
-              "op": "Eq",
-              "value": {
-                "type": "SessionRef",
-                "path": [
-                  "user_id"
-                ]
-              }
-            },
-            {
-              "type": "Cmp",
-              "column": "done",
-              "op": "Eq",
-              "value": {
-                "type": "Literal",
-                "value": {
-                  "type": "Boolean",
-                  "value": false
-                }
-              }
-            }
-          ]
+  },
+  todos: {
+    columns: [
+      {
+        name: "title",
+        column_type: {
+          type: "Text",
         },
-        "with_check": {
-          "type": "Cmp",
-          "column": "owner_id",
-          "op": "Eq",
-          "value": {
-            "type": "SessionRef",
-            "path": [
-              "user_id"
-            ]
-          }
-        }
+        nullable: false,
       },
-      "delete": {
-        "using": {
-          "type": "And",
-          "exprs": [
+      {
+        name: "done",
+        column_type: {
+          type: "Boolean",
+        },
+        nullable: false,
+      },
+      {
+        name: "description",
+        column_type: {
+          type: "Text",
+        },
+        nullable: true,
+      },
+      {
+        name: "owner_id",
+        column_type: {
+          type: "Text",
+        },
+        nullable: false,
+      },
+      {
+        name: "parent",
+        column_type: {
+          type: "Uuid",
+        },
+        nullable: true,
+        references: "todos",
+      },
+      {
+        name: "project",
+        column_type: {
+          type: "Uuid",
+        },
+        nullable: true,
+        references: "projects",
+      },
+    ],
+    policies: {
+      select: {
+        using: {
+          type: "Cmp",
+          column: "owner_id",
+          op: "Eq",
+          value: {
+            type: "SessionRef",
+            path: ["user_id"],
+          },
+        },
+      },
+      insert: {
+        with_check: {
+          type: "Cmp",
+          column: "owner_id",
+          op: "Eq",
+          value: {
+            type: "SessionRef",
+            path: ["user_id"],
+          },
+        },
+      },
+      update: {
+        using: {
+          type: "And",
+          exprs: [
             {
-              "type": "Cmp",
-              "column": "owner_id",
-              "op": "Eq",
-              "value": {
-                "type": "SessionRef",
-                "path": [
-                  "user_id"
-                ]
-              }
+              type: "Cmp",
+              column: "owner_id",
+              op: "Eq",
+              value: {
+                type: "SessionRef",
+                path: ["user_id"],
+              },
             },
             {
-              "type": "Cmp",
-              "column": "done",
-              "op": "Eq",
-              "value": {
-                "type": "Literal",
-                "value": {
-                  "type": "Boolean",
-                  "value": false
-                }
-              }
-            }
-          ]
-        }
-      }
-    }
-  }
+              type: "Cmp",
+              column: "done",
+              op: "Eq",
+              value: {
+                type: "Literal",
+                value: {
+                  type: "Boolean",
+                  value: false,
+                },
+              },
+            },
+          ],
+        },
+        with_check: {
+          type: "Cmp",
+          column: "owner_id",
+          op: "Eq",
+          value: {
+            type: "SessionRef",
+            path: ["user_id"],
+          },
+        },
+      },
+      delete: {
+        using: {
+          type: "And",
+          exprs: [
+            {
+              type: "Cmp",
+              column: "owner_id",
+              op: "Eq",
+              value: {
+                type: "SessionRef",
+                path: ["user_id"],
+              },
+            },
+            {
+              type: "Cmp",
+              column: "done",
+              op: "Eq",
+              value: {
+                type: "Literal",
+                value: {
+                  type: "Boolean",
+                  value: false,
+                },
+              },
+            },
+          ],
+        },
+      },
+    },
+  },
 };
 
-export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends ProjectSelectableColumn = keyof Project> implements QueryBuilder<ProjectSelectedWithIncludes<I, S>> {
+export class ProjectQueryBuilder<
+  I extends ProjectInclude = {},
+  S extends ProjectSelectableColumn = keyof Project,
+> implements QueryBuilder<ProjectSelectedWithIncludes<I, S>> {
   readonly _table = "projects";
   readonly _schema: WasmSchema = wasmSchema;
   readonly _rowType!: ProjectSelectedWithIncludes<I, S>;
@@ -347,7 +365,9 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
     return clone;
   }
 
-  select<NewS extends ProjectSelectableColumn>(...columns: [NewS, ...NewS[]]): ProjectQueryBuilder<I, NewS> {
+  select<NewS extends ProjectSelectableColumn>(
+    ...columns: [NewS, ...NewS[]]
+  ): ProjectQueryBuilder<I, NewS> {
     const clone = this._clone<I, NewS>();
     clone._selectColumns = [...columns] as string[];
     return clone;
@@ -359,7 +379,10 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
     return clone;
   }
 
-  orderBy(column: ProjectOrderableColumn, direction: "asc" | "desc" = "asc"): ProjectQueryBuilder<I, S> {
+  orderBy(
+    column: ProjectOrderableColumn,
+    direction: "asc" | "desc" = "asc",
+  ): ProjectQueryBuilder<I, S> {
     const clone = this._clone();
     clone._orderBys.push([column as string, direction]);
     return clone;
@@ -408,13 +431,15 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
 
     const currentToken = "__jazz_gather_current__";
     const stepOutput = options.step({ current: currentToken });
-    if (!stepOutput || typeof stepOutput !== "object" || typeof (stepOutput as { _build?: unknown })._build !== "function") {
+    if (
+      !stepOutput ||
+      typeof stepOutput !== "object" ||
+      typeof (stepOutput as { _build?: unknown })._build !== "function"
+    ) {
       throw new Error("gather(...) step must return a query expression built from app.<table>.");
     }
 
-    const stepBuilt = JSON.parse(
-      stepOutput._build(),
-    ) as {
+    const stepBuilt = JSON.parse(stepOutput._build()) as {
       table?: unknown;
       conditions?: Array<{ column: string; op: string; value: unknown }>;
       hops?: unknown;
@@ -438,7 +463,9 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
       (condition) => condition.op === "eq" && condition.value === currentToken,
     );
     if (currentConditions.length !== 1) {
-      throw new Error("gather(...) step must include exactly one where condition bound to current.");
+      throw new Error(
+        "gather(...) step must include exactly one where condition bound to current.",
+      );
     }
 
     const currentCondition = currentConditions[0];
@@ -478,7 +505,10 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
     return JSON.parse(this._build());
   }
 
-  private _clone<CloneI extends ProjectInclude = I, CloneS extends ProjectSelectableColumn = S>(): ProjectQueryBuilder<CloneI, CloneS> {
+  private _clone<
+    CloneI extends ProjectInclude = I,
+    CloneS extends ProjectSelectableColumn = S,
+  >(): ProjectQueryBuilder<CloneI, CloneS> {
     const clone = new ProjectQueryBuilder<CloneI, CloneS>();
     clone._conditions = [...this._conditions];
     clone._includes = { ...this._includes };
@@ -498,7 +528,10 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
   }
 }
 
-export class TodoQueryBuilder<I extends TodoInclude = {}, S extends TodoSelectableColumn = keyof Todo> implements QueryBuilder<TodoSelectedWithIncludes<I, S>> {
+export class TodoQueryBuilder<
+  I extends TodoInclude = {},
+  S extends TodoSelectableColumn = keyof Todo,
+> implements QueryBuilder<TodoSelectedWithIncludes<I, S>> {
   readonly _table = "todos";
   readonly _schema: WasmSchema = wasmSchema;
   readonly _rowType!: TodoSelectedWithIncludes<I, S>;
@@ -535,7 +568,9 @@ export class TodoQueryBuilder<I extends TodoInclude = {}, S extends TodoSelectab
     return clone;
   }
 
-  select<NewS extends TodoSelectableColumn>(...columns: [NewS, ...NewS[]]): TodoQueryBuilder<I, NewS> {
+  select<NewS extends TodoSelectableColumn>(
+    ...columns: [NewS, ...NewS[]]
+  ): TodoQueryBuilder<I, NewS> {
     const clone = this._clone<I, NewS>();
     clone._selectColumns = [...columns] as string[];
     return clone;
@@ -596,13 +631,15 @@ export class TodoQueryBuilder<I extends TodoInclude = {}, S extends TodoSelectab
 
     const currentToken = "__jazz_gather_current__";
     const stepOutput = options.step({ current: currentToken });
-    if (!stepOutput || typeof stepOutput !== "object" || typeof (stepOutput as { _build?: unknown })._build !== "function") {
+    if (
+      !stepOutput ||
+      typeof stepOutput !== "object" ||
+      typeof (stepOutput as { _build?: unknown })._build !== "function"
+    ) {
       throw new Error("gather(...) step must return a query expression built from app.<table>.");
     }
 
-    const stepBuilt = JSON.parse(
-      stepOutput._build(),
-    ) as {
+    const stepBuilt = JSON.parse(stepOutput._build()) as {
       table?: unknown;
       conditions?: Array<{ column: string; op: string; value: unknown }>;
       hops?: unknown;
@@ -626,7 +663,9 @@ export class TodoQueryBuilder<I extends TodoInclude = {}, S extends TodoSelectab
       (condition) => condition.op === "eq" && condition.value === currentToken,
     );
     if (currentConditions.length !== 1) {
-      throw new Error("gather(...) step must include exactly one where condition bound to current.");
+      throw new Error(
+        "gather(...) step must include exactly one where condition bound to current.",
+      );
     }
 
     const currentCondition = currentConditions[0];
@@ -666,7 +705,10 @@ export class TodoQueryBuilder<I extends TodoInclude = {}, S extends TodoSelectab
     return JSON.parse(this._build());
   }
 
-  private _clone<CloneI extends TodoInclude = I, CloneS extends TodoSelectableColumn = S>(): TodoQueryBuilder<CloneI, CloneS> {
+  private _clone<
+    CloneI extends TodoInclude = I,
+    CloneS extends TodoSelectableColumn = S,
+  >(): TodoQueryBuilder<CloneI, CloneS> {
     const clone = new TodoQueryBuilder<CloneI, CloneS>();
     clone._conditions = [...this._conditions];
     clone._includes = { ...this._includes };

--- a/examples/docs/todo-client-localfirst-expo/schema/app.ts
+++ b/examples/docs/todo-client-localfirst-expo/schema/app.ts
@@ -1,12 +1,13 @@
 // AUTO-GENERATED FILE - DO NOT EDIT
 import type { WasmSchema, QueryBuilder } from "jazz-tools";
-export type JsonValue =
-  | string
-  | number
-  | boolean
-  | null
-  | { [key: string]: JsonValue }
-  | JsonValue[];
+export type JsonValue = string | number | boolean | null | { [key: string]: JsonValue } | JsonValue[];
+
+export type PermissionIntrospectionColumn = "$canRead" | "$canEdit" | "$canDelete";
+export interface PermissionIntrospectionColumns {
+  $canRead: boolean | null;
+  $canEdit: boolean | null;
+  $canDelete: boolean | null;
+}
 
 export interface Project {
   id: string;
@@ -39,6 +40,9 @@ export interface TodoInit {
 export interface ProjectWhereInput {
   id?: string | { eq?: string; ne?: string; in?: string[] };
   name?: string | { eq?: string; ne?: string; contains?: string };
+  $canRead?: boolean;
+  $canEdit?: boolean;
+  $canDelete?: boolean;
 }
 
 export interface TodoWhereInput {
@@ -49,17 +53,73 @@ export interface TodoWhereInput {
   owner_id?: string | { eq?: string; ne?: string; contains?: string };
   parent?: string | { eq?: string; ne?: string; isNull?: boolean };
   project?: string | { eq?: string; ne?: string; isNull?: boolean };
+  $canRead?: boolean;
+  $canEdit?: boolean;
+  $canDelete?: boolean;
 }
 
+type AnyProjectQueryBuilder<T = any> = { readonly _table: "projects" } & QueryBuilder<T>;
+type AnyTodoQueryBuilder<T = any> = { readonly _table: "todos" } & QueryBuilder<T>;
+
 export interface ProjectInclude {
-  todosViaProject?: true | TodoInclude | TodoQueryBuilder;
+  todosViaProject?: true | TodoInclude | AnyTodoQueryBuilder<any>;
 }
 
 export interface TodoInclude {
-  parent?: true | TodoInclude | TodoQueryBuilder;
-  todosViaParent?: true | TodoInclude | TodoQueryBuilder;
-  project?: true | ProjectInclude | ProjectQueryBuilder;
+  parent?: true | TodoInclude | AnyTodoQueryBuilder<any>;
+  todosViaParent?: true | TodoInclude | AnyTodoQueryBuilder<any>;
+  project?: true | ProjectInclude | AnyProjectQueryBuilder<any>;
 }
+
+export type ProjectIncludedRelations<I extends ProjectInclude = {}> = {
+  [K in keyof I]-?:
+    K extends "todosViaProject"
+      ? NonNullable<I["todosViaProject"]> extends infer RelationInclude
+        ? RelationInclude extends true
+          ? Todo[]
+          : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
+            ? QueryRow[]
+            : RelationInclude extends TodoInclude
+              ? TodoWithIncludes<RelationInclude>[]
+              : never
+        : never
+    : never;
+};
+
+export type TodoIncludedRelations<I extends TodoInclude = {}> = {
+  [K in keyof I]-?:
+    K extends "parent"
+      ? NonNullable<I["parent"]> extends infer RelationInclude
+        ? RelationInclude extends true
+          ? Todo | undefined
+          : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
+            ? QueryRow | undefined
+            : RelationInclude extends TodoInclude
+              ? TodoWithIncludes<RelationInclude> | undefined
+              : never
+        : never
+    : K extends "todosViaParent"
+      ? NonNullable<I["todosViaParent"]> extends infer RelationInclude
+        ? RelationInclude extends true
+          ? Todo[]
+          : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
+            ? QueryRow[]
+            : RelationInclude extends TodoInclude
+              ? TodoWithIncludes<RelationInclude>[]
+              : never
+        : never
+    : K extends "project"
+      ? NonNullable<I["project"]> extends infer RelationInclude
+        ? RelationInclude extends true
+          ? Project | undefined
+          : RelationInclude extends AnyProjectQueryBuilder<infer QueryRow>
+            ? QueryRow | undefined
+            : RelationInclude extends ProjectInclude
+              ? ProjectWithIncludes<RelationInclude> | undefined
+              : never
+        : never
+    : never;
+};
 
 export interface ProjectRelations {
   todosViaProject: Todo[];
@@ -71,208 +131,193 @@ export interface TodoRelations {
   project: Project;
 }
 
-export type ProjectWithIncludes<I extends ProjectInclude = {}> = Project & {
-  todosViaProject?: NonNullable<I["todosViaProject"]> extends infer RelationInclude
-    ? RelationInclude extends true
-      ? Todo[]
-      : RelationInclude extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
-        ? TodoWithIncludes<QueryInclude>[]
-        : RelationInclude extends TodoInclude
-          ? TodoWithIncludes<RelationInclude>[]
-          : never
-    : never;
-};
+export type ProjectWithIncludes<I extends ProjectInclude = {}> = Omit<Project, Extract<keyof I, keyof Project>> & ProjectIncludedRelations<I>;
 
-export type TodoWithIncludes<I extends TodoInclude = {}> = Todo & {
-  parent?: NonNullable<I["parent"]> extends infer RelationInclude
-    ? RelationInclude extends true
-      ? Todo
-      : RelationInclude extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
-        ? TodoWithIncludes<QueryInclude>
-        : RelationInclude extends TodoInclude
-          ? TodoWithIncludes<RelationInclude>
-          : never
-    : never;
-  todosViaParent?: NonNullable<I["todosViaParent"]> extends infer RelationInclude
-    ? RelationInclude extends true
-      ? Todo[]
-      : RelationInclude extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
-        ? TodoWithIncludes<QueryInclude>[]
-        : RelationInclude extends TodoInclude
-          ? TodoWithIncludes<RelationInclude>[]
-          : never
-    : never;
-  project?: NonNullable<I["project"]> extends infer RelationInclude
-    ? RelationInclude extends true
-      ? Project
-      : RelationInclude extends ProjectQueryBuilder<infer QueryInclude extends ProjectInclude>
-        ? ProjectWithIncludes<QueryInclude>
-        : RelationInclude extends ProjectInclude
-          ? ProjectWithIncludes<RelationInclude>
-          : never
-    : never;
-};
+export type TodoWithIncludes<I extends TodoInclude = {}> = Omit<Todo, Extract<keyof I, keyof Todo>> & TodoIncludedRelations<I>;
+
+export type ProjectSelectableColumn = keyof Project | PermissionIntrospectionColumn | "*";
+export type ProjectOrderableColumn = keyof Project | PermissionIntrospectionColumn;
+
+export type ProjectSelected<S extends ProjectSelectableColumn = keyof Project> = "*" extends S ? Project : Pick<Project, Extract<S | "id", keyof Project>> & Pick<PermissionIntrospectionColumns, Extract<S, PermissionIntrospectionColumn>>;
+
+export type ProjectSelectedWithIncludes<I extends ProjectInclude = {}, S extends ProjectSelectableColumn = keyof Project> = Omit<ProjectSelected<S>, Extract<keyof I, keyof ProjectSelected<S>>> & ProjectIncludedRelations<I>;
+
+export type TodoSelectableColumn = keyof Todo | PermissionIntrospectionColumn | "*";
+export type TodoOrderableColumn = keyof Todo | PermissionIntrospectionColumn;
+
+export type TodoSelected<S extends TodoSelectableColumn = keyof Todo> = "*" extends S ? Todo : Pick<Todo, Extract<S | "id", keyof Todo>> & Pick<PermissionIntrospectionColumns, Extract<S, PermissionIntrospectionColumn>>;
+
+export type TodoSelectedWithIncludes<I extends TodoInclude = {}, S extends TodoSelectableColumn = keyof Todo> = Omit<TodoSelected<S>, Extract<keyof I, keyof TodoSelected<S>>> & TodoIncludedRelations<I>;
 
 export const wasmSchema: WasmSchema = {
-  projects: {
-    columns: [
+  "projects": {
+    "columns": [
       {
-        name: "name",
-        column_type: {
-          type: "Text",
+        "name": "name",
+        "column_type": {
+          "type": "Text"
         },
-        nullable: false,
-      },
-    ],
+        "nullable": false
+      }
+    ]
   },
-  todos: {
-    columns: [
+  "todos": {
+    "columns": [
       {
-        name: "title",
-        column_type: {
-          type: "Text",
+        "name": "title",
+        "column_type": {
+          "type": "Text"
         },
-        nullable: false,
+        "nullable": false
       },
       {
-        name: "done",
-        column_type: {
-          type: "Boolean",
+        "name": "done",
+        "column_type": {
+          "type": "Boolean"
         },
-        nullable: false,
+        "nullable": false
       },
       {
-        name: "description",
-        column_type: {
-          type: "Text",
+        "name": "description",
+        "column_type": {
+          "type": "Text"
         },
-        nullable: true,
+        "nullable": true
       },
       {
-        name: "owner_id",
-        column_type: {
-          type: "Text",
+        "name": "owner_id",
+        "column_type": {
+          "type": "Text"
         },
-        nullable: false,
+        "nullable": false
       },
       {
-        name: "parent",
-        column_type: {
-          type: "Uuid",
+        "name": "parent",
+        "column_type": {
+          "type": "Uuid"
         },
-        nullable: true,
-        references: "todos",
+        "nullable": true,
+        "references": "todos"
       },
       {
-        name: "project",
-        column_type: {
-          type: "Uuid",
+        "name": "project",
+        "column_type": {
+          "type": "Uuid"
         },
-        nullable: true,
-        references: "projects",
-      },
+        "nullable": true,
+        "references": "projects"
+      }
     ],
-    policies: {
-      select: {
-        using: {
-          type: "Cmp",
-          column: "owner_id",
-          op: "Eq",
-          value: {
-            type: "SessionRef",
-            path: ["user_id"],
-          },
-        },
+    "policies": {
+      "select": {
+        "using": {
+          "type": "Cmp",
+          "column": "owner_id",
+          "op": "Eq",
+          "value": {
+            "type": "SessionRef",
+            "path": [
+              "user_id"
+            ]
+          }
+        }
       },
-      insert: {
-        with_check: {
-          type: "Cmp",
-          column: "owner_id",
-          op: "Eq",
-          value: {
-            type: "SessionRef",
-            path: ["user_id"],
-          },
-        },
+      "insert": {
+        "with_check": {
+          "type": "Cmp",
+          "column": "owner_id",
+          "op": "Eq",
+          "value": {
+            "type": "SessionRef",
+            "path": [
+              "user_id"
+            ]
+          }
+        }
       },
-      update: {
-        using: {
-          type: "And",
-          exprs: [
+      "update": {
+        "using": {
+          "type": "And",
+          "exprs": [
             {
-              type: "Cmp",
-              column: "owner_id",
-              op: "Eq",
-              value: {
-                type: "SessionRef",
-                path: ["user_id"],
-              },
+              "type": "Cmp",
+              "column": "owner_id",
+              "op": "Eq",
+              "value": {
+                "type": "SessionRef",
+                "path": [
+                  "user_id"
+                ]
+              }
             },
             {
-              type: "Cmp",
-              column: "done",
-              op: "Eq",
-              value: {
-                type: "Literal",
-                value: {
-                  type: "Boolean",
-                  value: false,
-                },
-              },
-            },
-          ],
+              "type": "Cmp",
+              "column": "done",
+              "op": "Eq",
+              "value": {
+                "type": "Literal",
+                "value": {
+                  "type": "Boolean",
+                  "value": false
+                }
+              }
+            }
+          ]
         },
-        with_check: {
-          type: "Cmp",
-          column: "owner_id",
-          op: "Eq",
-          value: {
-            type: "SessionRef",
-            path: ["user_id"],
-          },
-        },
+        "with_check": {
+          "type": "Cmp",
+          "column": "owner_id",
+          "op": "Eq",
+          "value": {
+            "type": "SessionRef",
+            "path": [
+              "user_id"
+            ]
+          }
+        }
       },
-      delete: {
-        using: {
-          type: "And",
-          exprs: [
+      "delete": {
+        "using": {
+          "type": "And",
+          "exprs": [
             {
-              type: "Cmp",
-              column: "owner_id",
-              op: "Eq",
-              value: {
-                type: "SessionRef",
-                path: ["user_id"],
-              },
+              "type": "Cmp",
+              "column": "owner_id",
+              "op": "Eq",
+              "value": {
+                "type": "SessionRef",
+                "path": [
+                  "user_id"
+                ]
+              }
             },
             {
-              type: "Cmp",
-              column: "done",
-              op: "Eq",
-              value: {
-                type: "Literal",
-                value: {
-                  type: "Boolean",
-                  value: false,
-                },
-              },
-            },
-          ],
-        },
-      },
-    },
-  },
+              "type": "Cmp",
+              "column": "done",
+              "op": "Eq",
+              "value": {
+                "type": "Literal",
+                "value": {
+                  "type": "Boolean",
+                  "value": false
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
 };
 
-export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements QueryBuilder<
-  ProjectWithIncludes<I>
-> {
+export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends ProjectSelectableColumn = keyof Project> implements QueryBuilder<ProjectSelectedWithIncludes<I, S>> {
   readonly _table = "projects";
   readonly _schema: WasmSchema = wasmSchema;
-  declare readonly _rowType: ProjectWithIncludes<I>;
-  declare readonly _initType: ProjectInit;
+  readonly _rowType!: ProjectSelectedWithIncludes<I, S>;
+  readonly _initType!: ProjectInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<ProjectInclude> = {};
+  private _selectColumns?: string[];
   private _orderBys: Array<[string, "asc" | "desc"]> = [];
   private _limitVal?: number;
   private _offsetVal?: number;
@@ -285,7 +330,7 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
     step_hops: string[];
   };
 
-  where(conditions: ProjectWhereInput): ProjectQueryBuilder<I> {
+  where(conditions: ProjectWhereInput): ProjectQueryBuilder<I, S> {
     const clone = this._clone();
     for (const [key, value] of Object.entries(conditions)) {
       if (value === undefined) continue;
@@ -302,31 +347,37 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
     return clone;
   }
 
-  include<NewI extends ProjectInclude>(relations: NewI): ProjectQueryBuilder<I & NewI> {
-    const clone = this._clone<I & NewI>();
+  select<NewS extends ProjectSelectableColumn>(...columns: [NewS, ...NewS[]]): ProjectQueryBuilder<I, NewS> {
+    const clone = this._clone<I, NewS>();
+    clone._selectColumns = [...columns] as string[];
+    return clone;
+  }
+
+  include<NewI extends ProjectInclude>(relations: NewI): ProjectQueryBuilder<I & NewI, S> {
+    const clone = this._clone<I & NewI, S>();
     clone._includes = { ...this._includes, ...relations };
     return clone;
   }
 
-  orderBy(column: keyof Project, direction: "asc" | "desc" = "asc"): ProjectQueryBuilder<I> {
+  orderBy(column: ProjectOrderableColumn, direction: "asc" | "desc" = "asc"): ProjectQueryBuilder<I, S> {
     const clone = this._clone();
     clone._orderBys.push([column as string, direction]);
     return clone;
   }
 
-  limit(n: number): ProjectQueryBuilder<I> {
+  limit(n: number): ProjectQueryBuilder<I, S> {
     const clone = this._clone();
     clone._limitVal = n;
     return clone;
   }
 
-  offset(n: number): ProjectQueryBuilder<I> {
+  offset(n: number): ProjectQueryBuilder<I, S> {
     const clone = this._clone();
     clone._offsetVal = n;
     return clone;
   }
 
-  hopTo(relation: "todosViaProject"): ProjectQueryBuilder<I> {
+  hopTo(relation: "todosViaProject"): ProjectQueryBuilder<I, S> {
     const clone = this._clone();
     clone._hops.push(relation);
     return clone;
@@ -336,7 +387,7 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
     start: ProjectWhereInput;
     step: (ctx: { current: string }) => QueryBuilder<unknown>;
     maxDepth?: number;
-  }): ProjectQueryBuilder<I> {
+  }): ProjectQueryBuilder<I, S> {
     if (options.start === undefined) {
       throw new Error("gather(...) requires start where conditions.");
     }
@@ -357,15 +408,13 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
 
     const currentToken = "__jazz_gather_current__";
     const stepOutput = options.step({ current: currentToken });
-    if (
-      !stepOutput ||
-      typeof stepOutput !== "object" ||
-      typeof (stepOutput as { _build?: unknown })._build !== "function"
-    ) {
+    if (!stepOutput || typeof stepOutput !== "object" || typeof (stepOutput as { _build?: unknown })._build !== "function") {
       throw new Error("gather(...) step must return a query expression built from app.<table>.");
     }
 
-    const stepBuilt = JSON.parse(stepOutput._build()) as {
+    const stepBuilt = JSON.parse(
+      stepOutput._build(),
+    ) as {
       table?: unknown;
       conditions?: Array<{ column: string; op: string; value: unknown }>;
       hops?: unknown;
@@ -389,9 +438,7 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
       (condition) => condition.op === "eq" && condition.value === currentToken,
     );
     if (currentConditions.length !== 1) {
-      throw new Error(
-        "gather(...) step must include exactly one where condition bound to current.",
-      );
+      throw new Error("gather(...) step must include exactly one where condition bound to current.");
     }
 
     const currentCondition = currentConditions[0];
@@ -418,6 +465,7 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
       table: this._table,
       conditions: this._conditions,
       includes: this._includes,
+      select: this._selectColumns,
       orderBy: this._orderBys,
       limit: this._limitVal,
       offset: this._offsetVal,
@@ -426,10 +474,15 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
     });
   }
 
-  private _clone<CloneI extends ProjectInclude = I>(): ProjectQueryBuilder<CloneI> {
-    const clone = new ProjectQueryBuilder<CloneI>();
+  toJSON(): unknown {
+    return JSON.parse(this._build());
+  }
+
+  private _clone<CloneI extends ProjectInclude = I, CloneS extends ProjectSelectableColumn = S>(): ProjectQueryBuilder<CloneI, CloneS> {
+    const clone = new ProjectQueryBuilder<CloneI, CloneS>();
     clone._conditions = [...this._conditions];
     clone._includes = { ...this._includes };
+    clone._selectColumns = this._selectColumns ? [...this._selectColumns] : undefined;
     clone._orderBys = [...this._orderBys];
     clone._limitVal = this._limitVal;
     clone._offsetVal = this._offsetVal;
@@ -445,15 +498,14 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
   }
 }
 
-export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilder<
-  TodoWithIncludes<I>
-> {
+export class TodoQueryBuilder<I extends TodoInclude = {}, S extends TodoSelectableColumn = keyof Todo> implements QueryBuilder<TodoSelectedWithIncludes<I, S>> {
   readonly _table = "todos";
   readonly _schema: WasmSchema = wasmSchema;
-  declare readonly _rowType: TodoWithIncludes<I>;
-  declare readonly _initType: TodoInit;
+  readonly _rowType!: TodoSelectedWithIncludes<I, S>;
+  readonly _initType!: TodoInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<TodoInclude> = {};
+  private _selectColumns?: string[];
   private _orderBys: Array<[string, "asc" | "desc"]> = [];
   private _limitVal?: number;
   private _offsetVal?: number;
@@ -466,7 +518,7 @@ export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilde
     step_hops: string[];
   };
 
-  where(conditions: TodoWhereInput): TodoQueryBuilder<I> {
+  where(conditions: TodoWhereInput): TodoQueryBuilder<I, S> {
     const clone = this._clone();
     for (const [key, value] of Object.entries(conditions)) {
       if (value === undefined) continue;
@@ -483,31 +535,37 @@ export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilde
     return clone;
   }
 
-  include<NewI extends TodoInclude>(relations: NewI): TodoQueryBuilder<I & NewI> {
-    const clone = this._clone<I & NewI>();
+  select<NewS extends TodoSelectableColumn>(...columns: [NewS, ...NewS[]]): TodoQueryBuilder<I, NewS> {
+    const clone = this._clone<I, NewS>();
+    clone._selectColumns = [...columns] as string[];
+    return clone;
+  }
+
+  include<NewI extends TodoInclude>(relations: NewI): TodoQueryBuilder<I & NewI, S> {
+    const clone = this._clone<I & NewI, S>();
     clone._includes = { ...this._includes, ...relations };
     return clone;
   }
 
-  orderBy(column: keyof Todo, direction: "asc" | "desc" = "asc"): TodoQueryBuilder<I> {
+  orderBy(column: TodoOrderableColumn, direction: "asc" | "desc" = "asc"): TodoQueryBuilder<I, S> {
     const clone = this._clone();
     clone._orderBys.push([column as string, direction]);
     return clone;
   }
 
-  limit(n: number): TodoQueryBuilder<I> {
+  limit(n: number): TodoQueryBuilder<I, S> {
     const clone = this._clone();
     clone._limitVal = n;
     return clone;
   }
 
-  offset(n: number): TodoQueryBuilder<I> {
+  offset(n: number): TodoQueryBuilder<I, S> {
     const clone = this._clone();
     clone._offsetVal = n;
     return clone;
   }
 
-  hopTo(relation: "parent" | "todosViaParent" | "project"): TodoQueryBuilder<I> {
+  hopTo(relation: "parent" | "todosViaParent" | "project"): TodoQueryBuilder<I, S> {
     const clone = this._clone();
     clone._hops.push(relation);
     return clone;
@@ -517,7 +575,7 @@ export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilde
     start: TodoWhereInput;
     step: (ctx: { current: string }) => QueryBuilder<unknown>;
     maxDepth?: number;
-  }): TodoQueryBuilder<I> {
+  }): TodoQueryBuilder<I, S> {
     if (options.start === undefined) {
       throw new Error("gather(...) requires start where conditions.");
     }
@@ -538,15 +596,13 @@ export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilde
 
     const currentToken = "__jazz_gather_current__";
     const stepOutput = options.step({ current: currentToken });
-    if (
-      !stepOutput ||
-      typeof stepOutput !== "object" ||
-      typeof (stepOutput as { _build?: unknown })._build !== "function"
-    ) {
+    if (!stepOutput || typeof stepOutput !== "object" || typeof (stepOutput as { _build?: unknown })._build !== "function") {
       throw new Error("gather(...) step must return a query expression built from app.<table>.");
     }
 
-    const stepBuilt = JSON.parse(stepOutput._build()) as {
+    const stepBuilt = JSON.parse(
+      stepOutput._build(),
+    ) as {
       table?: unknown;
       conditions?: Array<{ column: string; op: string; value: unknown }>;
       hops?: unknown;
@@ -570,9 +626,7 @@ export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilde
       (condition) => condition.op === "eq" && condition.value === currentToken,
     );
     if (currentConditions.length !== 1) {
-      throw new Error(
-        "gather(...) step must include exactly one where condition bound to current.",
-      );
+      throw new Error("gather(...) step must include exactly one where condition bound to current.");
     }
 
     const currentCondition = currentConditions[0];
@@ -599,6 +653,7 @@ export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilde
       table: this._table,
       conditions: this._conditions,
       includes: this._includes,
+      select: this._selectColumns,
       orderBy: this._orderBys,
       limit: this._limitVal,
       offset: this._offsetVal,
@@ -607,10 +662,15 @@ export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilde
     });
   }
 
-  private _clone<CloneI extends TodoInclude = I>(): TodoQueryBuilder<CloneI> {
-    const clone = new TodoQueryBuilder<CloneI>();
+  toJSON(): unknown {
+    return JSON.parse(this._build());
+  }
+
+  private _clone<CloneI extends TodoInclude = I, CloneS extends TodoSelectableColumn = S>(): TodoQueryBuilder<CloneI, CloneS> {
+    const clone = new TodoQueryBuilder<CloneI, CloneS>();
     clone._conditions = [...this._conditions];
     clone._includes = { ...this._includes };
+    clone._selectColumns = this._selectColumns ? [...this._selectColumns] : undefined;
     clone._orderBys = [...this._orderBys];
     clone._limitVal = this._limitVal;
     clone._offsetVal = this._offsetVal;

--- a/examples/docs/todo-client-localfirst-react/schema/app.ts
+++ b/examples/docs/todo-client-localfirst-react/schema/app.ts
@@ -256,8 +256,8 @@ export const wasmSchema: WasmSchema = {
 export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends ProjectSelectableColumn = keyof Project> implements QueryBuilder<ProjectSelectedWithIncludes<I, S>> {
   readonly _table = "projects";
   readonly _schema: WasmSchema = wasmSchema;
-  declare readonly _rowType: ProjectSelectedWithIncludes<I, S>;
-  declare readonly _initType: ProjectInit;
+  readonly _rowType!: ProjectSelectedWithIncludes<I, S>;
+  readonly _initType!: ProjectInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<ProjectInclude> = {};
   private _selectColumns?: string[];
@@ -444,8 +444,8 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
 export class TodoQueryBuilder<I extends TodoInclude = {}, S extends TodoSelectableColumn = keyof Todo> implements QueryBuilder<TodoSelectedWithIncludes<I, S>> {
   readonly _table = "todos";
   readonly _schema: WasmSchema = wasmSchema;
-  declare readonly _rowType: TodoSelectedWithIncludes<I, S>;
-  declare readonly _initType: TodoInit;
+  readonly _rowType!: TodoSelectedWithIncludes<I, S>;
+  readonly _initType!: TodoInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<TodoInclude> = {};
   private _selectColumns?: string[];

--- a/examples/docs/todo-client-localfirst-react/schema/app.ts
+++ b/examples/docs/todo-client-localfirst-react/schema/app.ts
@@ -1,6 +1,12 @@
 // AUTO-GENERATED FILE - DO NOT EDIT
 import type { WasmSchema, QueryBuilder } from "jazz-tools";
-export type JsonValue = string | number | boolean | null | { [key: string]: JsonValue } | JsonValue[];
+export type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: JsonValue }
+  | JsonValue[];
 
 export type PermissionIntrospectionColumn = "$canRead" | "$canEdit" | "$canDelete";
 export interface PermissionIntrospectionColumns {
@@ -69,32 +75,30 @@ export interface TodoInclude {
 }
 
 export type ProjectIncludedRelations<I extends ProjectInclude = {}> = {
-  [K in keyof I]-?:
-    K extends "todosViaProject"
-      ? NonNullable<I["todosViaProject"]> extends infer RelationInclude
-        ? RelationInclude extends true
-          ? Todo[]
-          : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
-            ? QueryRow[]
-            : RelationInclude extends TodoInclude
-              ? TodoWithIncludes<RelationInclude>[]
-              : never
-        : never
+  [K in keyof I]-?: K extends "todosViaProject"
+    ? NonNullable<I["todosViaProject"]> extends infer RelationInclude
+      ? RelationInclude extends true
+        ? Todo[]
+        : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
+          ? QueryRow[]
+          : RelationInclude extends TodoInclude
+            ? TodoWithIncludes<RelationInclude>[]
+            : never
+      : never
     : never;
 };
 
 export type TodoIncludedRelations<I extends TodoInclude = {}> = {
-  [K in keyof I]-?:
-    K extends "parent"
-      ? NonNullable<I["parent"]> extends infer RelationInclude
-        ? RelationInclude extends true
-          ? Todo | undefined
-          : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
-            ? QueryRow | undefined
-            : RelationInclude extends TodoInclude
-              ? TodoWithIncludes<RelationInclude> | undefined
-              : never
-        : never
+  [K in keyof I]-?: K extends "parent"
+    ? NonNullable<I["parent"]> extends infer RelationInclude
+      ? RelationInclude extends true
+        ? Todo | undefined
+        : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
+          ? QueryRow | undefined
+          : RelationInclude extends TodoInclude
+            ? TodoWithIncludes<RelationInclude> | undefined
+            : never
+      : never
     : K extends "todosViaParent"
       ? NonNullable<I["todosViaParent"]> extends infer RelationInclude
         ? RelationInclude extends true
@@ -105,17 +109,17 @@ export type TodoIncludedRelations<I extends TodoInclude = {}> = {
               ? TodoWithIncludes<RelationInclude>[]
               : never
         : never
-    : K extends "project"
-      ? NonNullable<I["project"]> extends infer RelationInclude
-        ? RelationInclude extends true
-          ? Project | undefined
-          : RelationInclude extends AnyProjectQueryBuilder<infer QueryRow>
-            ? QueryRow | undefined
-            : RelationInclude extends ProjectInclude
-              ? ProjectWithIncludes<RelationInclude> | undefined
-              : never
-        : never
-    : never;
+      : K extends "project"
+        ? NonNullable<I["project"]> extends infer RelationInclude
+          ? RelationInclude extends true
+            ? Project | undefined
+            : RelationInclude extends AnyProjectQueryBuilder<infer QueryRow>
+              ? QueryRow | undefined
+              : RelationInclude extends ProjectInclude
+                ? ProjectWithIncludes<RelationInclude> | undefined
+                : never
+          : never
+        : never;
 };
 
 export interface ProjectRelations {
@@ -128,132 +132,156 @@ export interface TodoRelations {
   project: Project;
 }
 
-export type ProjectWithIncludes<I extends ProjectInclude = {}> = Omit<Project, Extract<keyof I, keyof Project>> & ProjectIncludedRelations<I>;
+export type ProjectWithIncludes<I extends ProjectInclude = {}> = Omit<
+  Project,
+  Extract<keyof I, keyof Project>
+> &
+  ProjectIncludedRelations<I>;
 
-export type TodoWithIncludes<I extends TodoInclude = {}> = Omit<Todo, Extract<keyof I, keyof Todo>> & TodoIncludedRelations<I>;
+export type TodoWithIncludes<I extends TodoInclude = {}> = Omit<
+  Todo,
+  Extract<keyof I, keyof Todo>
+> &
+  TodoIncludedRelations<I>;
 
 export type ProjectSelectableColumn = keyof Project | PermissionIntrospectionColumn | "*";
 export type ProjectOrderableColumn = keyof Project | PermissionIntrospectionColumn;
 
-export type ProjectSelected<S extends ProjectSelectableColumn = keyof Project> = "*" extends S ? Project : Pick<Project, Extract<S | "id", keyof Project>> & Pick<PermissionIntrospectionColumns, Extract<S, PermissionIntrospectionColumn>>;
+export type ProjectSelected<S extends ProjectSelectableColumn = keyof Project> = "*" extends S
+  ? Project
+  : Pick<Project, Extract<S | "id", keyof Project>> &
+      Pick<PermissionIntrospectionColumns, Extract<S, PermissionIntrospectionColumn>>;
 
-export type ProjectSelectedWithIncludes<I extends ProjectInclude = {}, S extends ProjectSelectableColumn = keyof Project> = Omit<ProjectSelected<S>, Extract<keyof I, keyof ProjectSelected<S>>> & ProjectIncludedRelations<I>;
+export type ProjectSelectedWithIncludes<
+  I extends ProjectInclude = {},
+  S extends ProjectSelectableColumn = keyof Project,
+> = Omit<ProjectSelected<S>, Extract<keyof I, keyof ProjectSelected<S>>> &
+  ProjectIncludedRelations<I>;
 
 export type TodoSelectableColumn = keyof Todo | PermissionIntrospectionColumn | "*";
 export type TodoOrderableColumn = keyof Todo | PermissionIntrospectionColumn;
 
-export type TodoSelected<S extends TodoSelectableColumn = keyof Todo> = "*" extends S ? Todo : Pick<Todo, Extract<S | "id", keyof Todo>> & Pick<PermissionIntrospectionColumns, Extract<S, PermissionIntrospectionColumn>>;
+export type TodoSelected<S extends TodoSelectableColumn = keyof Todo> = "*" extends S
+  ? Todo
+  : Pick<Todo, Extract<S | "id", keyof Todo>> &
+      Pick<PermissionIntrospectionColumns, Extract<S, PermissionIntrospectionColumn>>;
 
-export type TodoSelectedWithIncludes<I extends TodoInclude = {}, S extends TodoSelectableColumn = keyof Todo> = Omit<TodoSelected<S>, Extract<keyof I, keyof TodoSelected<S>>> & TodoIncludedRelations<I>;
+export type TodoSelectedWithIncludes<
+  I extends TodoInclude = {},
+  S extends TodoSelectableColumn = keyof Todo,
+> = Omit<TodoSelected<S>, Extract<keyof I, keyof TodoSelected<S>>> & TodoIncludedRelations<I>;
 
 export const wasmSchema: WasmSchema = {
-  "projects": {
-    "columns": [
+  projects: {
+    columns: [
       {
-        "name": "name",
-        "column_type": {
-          "type": "Text"
+        name: "name",
+        column_type: {
+          type: "Text",
         },
-        "nullable": false
-      }
-    ]
-  },
-  "todos": {
-    "columns": [
-      {
-        "name": "title",
-        "column_type": {
-          "type": "Text"
-        },
-        "nullable": false
+        nullable: false,
       },
-      {
-        "name": "done",
-        "column_type": {
-          "type": "Boolean"
-        },
-        "nullable": false
-      },
-      {
-        "name": "description",
-        "column_type": {
-          "type": "Text"
-        },
-        "nullable": true
-      },
-      {
-        "name": "parent",
-        "column_type": {
-          "type": "Uuid"
-        },
-        "nullable": true,
-        "references": "todos"
-      },
-      {
-        "name": "project",
-        "column_type": {
-          "type": "Uuid"
-        },
-        "nullable": true,
-        "references": "projects"
-      }
     ],
-    "policies": {
-      "select": {
-        "using": {
-          "type": "True"
-        }
-      },
-      "insert": {
-        "with_check": {
-          "type": "Cmp",
-          "column": "done",
-          "op": "Eq",
-          "value": {
-            "type": "Literal",
-            "value": {
-              "type": "Boolean",
-              "value": false
-            }
-          }
-        }
-      },
-      "update": {
-        "using": {
-          "type": "Cmp",
-          "column": "done",
-          "op": "Eq",
-          "value": {
-            "type": "Literal",
-            "value": {
-              "type": "Boolean",
-              "value": false
-            }
-          }
+  },
+  todos: {
+    columns: [
+      {
+        name: "title",
+        column_type: {
+          type: "Text",
         },
-        "with_check": {
-          "type": "True"
-        }
+        nullable: false,
       },
-      "delete": {
-        "using": {
-          "type": "Cmp",
-          "column": "done",
-          "op": "Eq",
-          "value": {
-            "type": "Literal",
-            "value": {
-              "type": "Boolean",
-              "value": false
-            }
-          }
-        }
-      }
-    }
-  }
+      {
+        name: "done",
+        column_type: {
+          type: "Boolean",
+        },
+        nullable: false,
+      },
+      {
+        name: "description",
+        column_type: {
+          type: "Text",
+        },
+        nullable: true,
+      },
+      {
+        name: "parent",
+        column_type: {
+          type: "Uuid",
+        },
+        nullable: true,
+        references: "todos",
+      },
+      {
+        name: "project",
+        column_type: {
+          type: "Uuid",
+        },
+        nullable: true,
+        references: "projects",
+      },
+    ],
+    policies: {
+      select: {
+        using: {
+          type: "True",
+        },
+      },
+      insert: {
+        with_check: {
+          type: "Cmp",
+          column: "done",
+          op: "Eq",
+          value: {
+            type: "Literal",
+            value: {
+              type: "Boolean",
+              value: false,
+            },
+          },
+        },
+      },
+      update: {
+        using: {
+          type: "Cmp",
+          column: "done",
+          op: "Eq",
+          value: {
+            type: "Literal",
+            value: {
+              type: "Boolean",
+              value: false,
+            },
+          },
+        },
+        with_check: {
+          type: "True",
+        },
+      },
+      delete: {
+        using: {
+          type: "Cmp",
+          column: "done",
+          op: "Eq",
+          value: {
+            type: "Literal",
+            value: {
+              type: "Boolean",
+              value: false,
+            },
+          },
+        },
+      },
+    },
+  },
 };
 
-export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends ProjectSelectableColumn = keyof Project> implements QueryBuilder<ProjectSelectedWithIncludes<I, S>> {
+export class ProjectQueryBuilder<
+  I extends ProjectInclude = {},
+  S extends ProjectSelectableColumn = keyof Project,
+> implements QueryBuilder<ProjectSelectedWithIncludes<I, S>> {
   readonly _table = "projects";
   readonly _schema: WasmSchema = wasmSchema;
   readonly _rowType!: ProjectSelectedWithIncludes<I, S>;
@@ -290,7 +318,9 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
     return clone;
   }
 
-  select<NewS extends ProjectSelectableColumn>(...columns: [NewS, ...NewS[]]): ProjectQueryBuilder<I, NewS> {
+  select<NewS extends ProjectSelectableColumn>(
+    ...columns: [NewS, ...NewS[]]
+  ): ProjectQueryBuilder<I, NewS> {
     const clone = this._clone<I, NewS>();
     clone._selectColumns = [...columns] as string[];
     return clone;
@@ -302,7 +332,10 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
     return clone;
   }
 
-  orderBy(column: ProjectOrderableColumn, direction: "asc" | "desc" = "asc"): ProjectQueryBuilder<I, S> {
+  orderBy(
+    column: ProjectOrderableColumn,
+    direction: "asc" | "desc" = "asc",
+  ): ProjectQueryBuilder<I, S> {
     const clone = this._clone();
     clone._orderBys.push([column as string, direction]);
     return clone;
@@ -351,13 +384,15 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
 
     const currentToken = "__jazz_gather_current__";
     const stepOutput = options.step({ current: currentToken });
-    if (!stepOutput || typeof stepOutput !== "object" || typeof (stepOutput as { _build?: unknown })._build !== "function") {
+    if (
+      !stepOutput ||
+      typeof stepOutput !== "object" ||
+      typeof (stepOutput as { _build?: unknown })._build !== "function"
+    ) {
       throw new Error("gather(...) step must return a query expression built from app.<table>.");
     }
 
-    const stepBuilt = JSON.parse(
-      stepOutput._build(),
-    ) as {
+    const stepBuilt = JSON.parse(stepOutput._build()) as {
       table?: unknown;
       conditions?: Array<{ column: string; op: string; value: unknown }>;
       hops?: unknown;
@@ -381,7 +416,9 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
       (condition) => condition.op === "eq" && condition.value === currentToken,
     );
     if (currentConditions.length !== 1) {
-      throw new Error("gather(...) step must include exactly one where condition bound to current.");
+      throw new Error(
+        "gather(...) step must include exactly one where condition bound to current.",
+      );
     }
 
     const currentCondition = currentConditions[0];
@@ -421,7 +458,10 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
     return JSON.parse(this._build());
   }
 
-  private _clone<CloneI extends ProjectInclude = I, CloneS extends ProjectSelectableColumn = S>(): ProjectQueryBuilder<CloneI, CloneS> {
+  private _clone<
+    CloneI extends ProjectInclude = I,
+    CloneS extends ProjectSelectableColumn = S,
+  >(): ProjectQueryBuilder<CloneI, CloneS> {
     const clone = new ProjectQueryBuilder<CloneI, CloneS>();
     clone._conditions = [...this._conditions];
     clone._includes = { ...this._includes };
@@ -441,7 +481,10 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
   }
 }
 
-export class TodoQueryBuilder<I extends TodoInclude = {}, S extends TodoSelectableColumn = keyof Todo> implements QueryBuilder<TodoSelectedWithIncludes<I, S>> {
+export class TodoQueryBuilder<
+  I extends TodoInclude = {},
+  S extends TodoSelectableColumn = keyof Todo,
+> implements QueryBuilder<TodoSelectedWithIncludes<I, S>> {
   readonly _table = "todos";
   readonly _schema: WasmSchema = wasmSchema;
   readonly _rowType!: TodoSelectedWithIncludes<I, S>;
@@ -478,7 +521,9 @@ export class TodoQueryBuilder<I extends TodoInclude = {}, S extends TodoSelectab
     return clone;
   }
 
-  select<NewS extends TodoSelectableColumn>(...columns: [NewS, ...NewS[]]): TodoQueryBuilder<I, NewS> {
+  select<NewS extends TodoSelectableColumn>(
+    ...columns: [NewS, ...NewS[]]
+  ): TodoQueryBuilder<I, NewS> {
     const clone = this._clone<I, NewS>();
     clone._selectColumns = [...columns] as string[];
     return clone;
@@ -539,13 +584,15 @@ export class TodoQueryBuilder<I extends TodoInclude = {}, S extends TodoSelectab
 
     const currentToken = "__jazz_gather_current__";
     const stepOutput = options.step({ current: currentToken });
-    if (!stepOutput || typeof stepOutput !== "object" || typeof (stepOutput as { _build?: unknown })._build !== "function") {
+    if (
+      !stepOutput ||
+      typeof stepOutput !== "object" ||
+      typeof (stepOutput as { _build?: unknown })._build !== "function"
+    ) {
       throw new Error("gather(...) step must return a query expression built from app.<table>.");
     }
 
-    const stepBuilt = JSON.parse(
-      stepOutput._build(),
-    ) as {
+    const stepBuilt = JSON.parse(stepOutput._build()) as {
       table?: unknown;
       conditions?: Array<{ column: string; op: string; value: unknown }>;
       hops?: unknown;
@@ -569,7 +616,9 @@ export class TodoQueryBuilder<I extends TodoInclude = {}, S extends TodoSelectab
       (condition) => condition.op === "eq" && condition.value === currentToken,
     );
     if (currentConditions.length !== 1) {
-      throw new Error("gather(...) step must include exactly one where condition bound to current.");
+      throw new Error(
+        "gather(...) step must include exactly one where condition bound to current.",
+      );
     }
 
     const currentCondition = currentConditions[0];
@@ -609,7 +658,10 @@ export class TodoQueryBuilder<I extends TodoInclude = {}, S extends TodoSelectab
     return JSON.parse(this._build());
   }
 
-  private _clone<CloneI extends TodoInclude = I, CloneS extends TodoSelectableColumn = S>(): TodoQueryBuilder<CloneI, CloneS> {
+  private _clone<
+    CloneI extends TodoInclude = I,
+    CloneS extends TodoSelectableColumn = S,
+  >(): TodoQueryBuilder<CloneI, CloneS> {
     const clone = new TodoQueryBuilder<CloneI, CloneS>();
     clone._conditions = [...this._conditions];
     clone._includes = { ...this._includes };

--- a/examples/docs/todo-client-localfirst-svelte/schema/app.ts
+++ b/examples/docs/todo-client-localfirst-svelte/schema/app.ts
@@ -256,8 +256,8 @@ export const wasmSchema: WasmSchema = {
 export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends ProjectSelectableColumn = keyof Project> implements QueryBuilder<ProjectSelectedWithIncludes<I, S>> {
   readonly _table = "projects";
   readonly _schema: WasmSchema = wasmSchema;
-  declare readonly _rowType: ProjectSelectedWithIncludes<I, S>;
-  declare readonly _initType: ProjectInit;
+  readonly _rowType!: ProjectSelectedWithIncludes<I, S>;
+  readonly _initType!: ProjectInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<ProjectInclude> = {};
   private _selectColumns?: string[];
@@ -444,8 +444,8 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
 export class TodoQueryBuilder<I extends TodoInclude = {}, S extends TodoSelectableColumn = keyof Todo> implements QueryBuilder<TodoSelectedWithIncludes<I, S>> {
   readonly _table = "todos";
   readonly _schema: WasmSchema = wasmSchema;
-  declare readonly _rowType: TodoSelectedWithIncludes<I, S>;
-  declare readonly _initType: TodoInit;
+  readonly _rowType!: TodoSelectedWithIncludes<I, S>;
+  readonly _initType!: TodoInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<TodoInclude> = {};
   private _selectColumns?: string[];

--- a/examples/docs/todo-client-localfirst-svelte/schema/app.ts
+++ b/examples/docs/todo-client-localfirst-svelte/schema/app.ts
@@ -1,6 +1,12 @@
 // AUTO-GENERATED FILE - DO NOT EDIT
 import type { WasmSchema, QueryBuilder } from "jazz-tools";
-export type JsonValue = string | number | boolean | null | { [key: string]: JsonValue } | JsonValue[];
+export type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: JsonValue }
+  | JsonValue[];
 
 export type PermissionIntrospectionColumn = "$canRead" | "$canEdit" | "$canDelete";
 export interface PermissionIntrospectionColumns {
@@ -69,32 +75,30 @@ export interface TodoInclude {
 }
 
 export type ProjectIncludedRelations<I extends ProjectInclude = {}> = {
-  [K in keyof I]-?:
-    K extends "todosViaProject"
-      ? NonNullable<I["todosViaProject"]> extends infer RelationInclude
-        ? RelationInclude extends true
-          ? Todo[]
-          : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
-            ? QueryRow[]
-            : RelationInclude extends TodoInclude
-              ? TodoWithIncludes<RelationInclude>[]
-              : never
-        : never
+  [K in keyof I]-?: K extends "todosViaProject"
+    ? NonNullable<I["todosViaProject"]> extends infer RelationInclude
+      ? RelationInclude extends true
+        ? Todo[]
+        : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
+          ? QueryRow[]
+          : RelationInclude extends TodoInclude
+            ? TodoWithIncludes<RelationInclude>[]
+            : never
+      : never
     : never;
 };
 
 export type TodoIncludedRelations<I extends TodoInclude = {}> = {
-  [K in keyof I]-?:
-    K extends "parent"
-      ? NonNullable<I["parent"]> extends infer RelationInclude
-        ? RelationInclude extends true
-          ? Todo | undefined
-          : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
-            ? QueryRow | undefined
-            : RelationInclude extends TodoInclude
-              ? TodoWithIncludes<RelationInclude> | undefined
-              : never
-        : never
+  [K in keyof I]-?: K extends "parent"
+    ? NonNullable<I["parent"]> extends infer RelationInclude
+      ? RelationInclude extends true
+        ? Todo | undefined
+        : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
+          ? QueryRow | undefined
+          : RelationInclude extends TodoInclude
+            ? TodoWithIncludes<RelationInclude> | undefined
+            : never
+      : never
     : K extends "todosViaParent"
       ? NonNullable<I["todosViaParent"]> extends infer RelationInclude
         ? RelationInclude extends true
@@ -105,17 +109,17 @@ export type TodoIncludedRelations<I extends TodoInclude = {}> = {
               ? TodoWithIncludes<RelationInclude>[]
               : never
         : never
-    : K extends "project"
-      ? NonNullable<I["project"]> extends infer RelationInclude
-        ? RelationInclude extends true
-          ? Project | undefined
-          : RelationInclude extends AnyProjectQueryBuilder<infer QueryRow>
-            ? QueryRow | undefined
-            : RelationInclude extends ProjectInclude
-              ? ProjectWithIncludes<RelationInclude> | undefined
-              : never
-        : never
-    : never;
+      : K extends "project"
+        ? NonNullable<I["project"]> extends infer RelationInclude
+          ? RelationInclude extends true
+            ? Project | undefined
+            : RelationInclude extends AnyProjectQueryBuilder<infer QueryRow>
+              ? QueryRow | undefined
+              : RelationInclude extends ProjectInclude
+                ? ProjectWithIncludes<RelationInclude> | undefined
+                : never
+          : never
+        : never;
 };
 
 export interface ProjectRelations {
@@ -128,132 +132,156 @@ export interface TodoRelations {
   project: Project;
 }
 
-export type ProjectWithIncludes<I extends ProjectInclude = {}> = Omit<Project, Extract<keyof I, keyof Project>> & ProjectIncludedRelations<I>;
+export type ProjectWithIncludes<I extends ProjectInclude = {}> = Omit<
+  Project,
+  Extract<keyof I, keyof Project>
+> &
+  ProjectIncludedRelations<I>;
 
-export type TodoWithIncludes<I extends TodoInclude = {}> = Omit<Todo, Extract<keyof I, keyof Todo>> & TodoIncludedRelations<I>;
+export type TodoWithIncludes<I extends TodoInclude = {}> = Omit<
+  Todo,
+  Extract<keyof I, keyof Todo>
+> &
+  TodoIncludedRelations<I>;
 
 export type ProjectSelectableColumn = keyof Project | PermissionIntrospectionColumn | "*";
 export type ProjectOrderableColumn = keyof Project | PermissionIntrospectionColumn;
 
-export type ProjectSelected<S extends ProjectSelectableColumn = keyof Project> = "*" extends S ? Project : Pick<Project, Extract<S | "id", keyof Project>> & Pick<PermissionIntrospectionColumns, Extract<S, PermissionIntrospectionColumn>>;
+export type ProjectSelected<S extends ProjectSelectableColumn = keyof Project> = "*" extends S
+  ? Project
+  : Pick<Project, Extract<S | "id", keyof Project>> &
+      Pick<PermissionIntrospectionColumns, Extract<S, PermissionIntrospectionColumn>>;
 
-export type ProjectSelectedWithIncludes<I extends ProjectInclude = {}, S extends ProjectSelectableColumn = keyof Project> = Omit<ProjectSelected<S>, Extract<keyof I, keyof ProjectSelected<S>>> & ProjectIncludedRelations<I>;
+export type ProjectSelectedWithIncludes<
+  I extends ProjectInclude = {},
+  S extends ProjectSelectableColumn = keyof Project,
+> = Omit<ProjectSelected<S>, Extract<keyof I, keyof ProjectSelected<S>>> &
+  ProjectIncludedRelations<I>;
 
 export type TodoSelectableColumn = keyof Todo | PermissionIntrospectionColumn | "*";
 export type TodoOrderableColumn = keyof Todo | PermissionIntrospectionColumn;
 
-export type TodoSelected<S extends TodoSelectableColumn = keyof Todo> = "*" extends S ? Todo : Pick<Todo, Extract<S | "id", keyof Todo>> & Pick<PermissionIntrospectionColumns, Extract<S, PermissionIntrospectionColumn>>;
+export type TodoSelected<S extends TodoSelectableColumn = keyof Todo> = "*" extends S
+  ? Todo
+  : Pick<Todo, Extract<S | "id", keyof Todo>> &
+      Pick<PermissionIntrospectionColumns, Extract<S, PermissionIntrospectionColumn>>;
 
-export type TodoSelectedWithIncludes<I extends TodoInclude = {}, S extends TodoSelectableColumn = keyof Todo> = Omit<TodoSelected<S>, Extract<keyof I, keyof TodoSelected<S>>> & TodoIncludedRelations<I>;
+export type TodoSelectedWithIncludes<
+  I extends TodoInclude = {},
+  S extends TodoSelectableColumn = keyof Todo,
+> = Omit<TodoSelected<S>, Extract<keyof I, keyof TodoSelected<S>>> & TodoIncludedRelations<I>;
 
 export const wasmSchema: WasmSchema = {
-  "projects": {
-    "columns": [
+  projects: {
+    columns: [
       {
-        "name": "name",
-        "column_type": {
-          "type": "Text"
+        name: "name",
+        column_type: {
+          type: "Text",
         },
-        "nullable": false
-      }
-    ]
-  },
-  "todos": {
-    "columns": [
-      {
-        "name": "title",
-        "column_type": {
-          "type": "Text"
-        },
-        "nullable": false
+        nullable: false,
       },
-      {
-        "name": "done",
-        "column_type": {
-          "type": "Boolean"
-        },
-        "nullable": false
-      },
-      {
-        "name": "description",
-        "column_type": {
-          "type": "Text"
-        },
-        "nullable": true
-      },
-      {
-        "name": "parent",
-        "column_type": {
-          "type": "Uuid"
-        },
-        "nullable": true,
-        "references": "todos"
-      },
-      {
-        "name": "project",
-        "column_type": {
-          "type": "Uuid"
-        },
-        "nullable": true,
-        "references": "projects"
-      }
     ],
-    "policies": {
-      "select": {
-        "using": {
-          "type": "True"
-        }
-      },
-      "insert": {
-        "with_check": {
-          "type": "Cmp",
-          "column": "done",
-          "op": "Eq",
-          "value": {
-            "type": "Literal",
-            "value": {
-              "type": "Boolean",
-              "value": false
-            }
-          }
-        }
-      },
-      "update": {
-        "using": {
-          "type": "Cmp",
-          "column": "done",
-          "op": "Eq",
-          "value": {
-            "type": "Literal",
-            "value": {
-              "type": "Boolean",
-              "value": false
-            }
-          }
+  },
+  todos: {
+    columns: [
+      {
+        name: "title",
+        column_type: {
+          type: "Text",
         },
-        "with_check": {
-          "type": "True"
-        }
+        nullable: false,
       },
-      "delete": {
-        "using": {
-          "type": "Cmp",
-          "column": "done",
-          "op": "Eq",
-          "value": {
-            "type": "Literal",
-            "value": {
-              "type": "Boolean",
-              "value": false
-            }
-          }
-        }
-      }
-    }
-  }
+      {
+        name: "done",
+        column_type: {
+          type: "Boolean",
+        },
+        nullable: false,
+      },
+      {
+        name: "description",
+        column_type: {
+          type: "Text",
+        },
+        nullable: true,
+      },
+      {
+        name: "parent",
+        column_type: {
+          type: "Uuid",
+        },
+        nullable: true,
+        references: "todos",
+      },
+      {
+        name: "project",
+        column_type: {
+          type: "Uuid",
+        },
+        nullable: true,
+        references: "projects",
+      },
+    ],
+    policies: {
+      select: {
+        using: {
+          type: "True",
+        },
+      },
+      insert: {
+        with_check: {
+          type: "Cmp",
+          column: "done",
+          op: "Eq",
+          value: {
+            type: "Literal",
+            value: {
+              type: "Boolean",
+              value: false,
+            },
+          },
+        },
+      },
+      update: {
+        using: {
+          type: "Cmp",
+          column: "done",
+          op: "Eq",
+          value: {
+            type: "Literal",
+            value: {
+              type: "Boolean",
+              value: false,
+            },
+          },
+        },
+        with_check: {
+          type: "True",
+        },
+      },
+      delete: {
+        using: {
+          type: "Cmp",
+          column: "done",
+          op: "Eq",
+          value: {
+            type: "Literal",
+            value: {
+              type: "Boolean",
+              value: false,
+            },
+          },
+        },
+      },
+    },
+  },
 };
 
-export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends ProjectSelectableColumn = keyof Project> implements QueryBuilder<ProjectSelectedWithIncludes<I, S>> {
+export class ProjectQueryBuilder<
+  I extends ProjectInclude = {},
+  S extends ProjectSelectableColumn = keyof Project,
+> implements QueryBuilder<ProjectSelectedWithIncludes<I, S>> {
   readonly _table = "projects";
   readonly _schema: WasmSchema = wasmSchema;
   readonly _rowType!: ProjectSelectedWithIncludes<I, S>;
@@ -290,7 +318,9 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
     return clone;
   }
 
-  select<NewS extends ProjectSelectableColumn>(...columns: [NewS, ...NewS[]]): ProjectQueryBuilder<I, NewS> {
+  select<NewS extends ProjectSelectableColumn>(
+    ...columns: [NewS, ...NewS[]]
+  ): ProjectQueryBuilder<I, NewS> {
     const clone = this._clone<I, NewS>();
     clone._selectColumns = [...columns] as string[];
     return clone;
@@ -302,7 +332,10 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
     return clone;
   }
 
-  orderBy(column: ProjectOrderableColumn, direction: "asc" | "desc" = "asc"): ProjectQueryBuilder<I, S> {
+  orderBy(
+    column: ProjectOrderableColumn,
+    direction: "asc" | "desc" = "asc",
+  ): ProjectQueryBuilder<I, S> {
     const clone = this._clone();
     clone._orderBys.push([column as string, direction]);
     return clone;
@@ -351,13 +384,15 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
 
     const currentToken = "__jazz_gather_current__";
     const stepOutput = options.step({ current: currentToken });
-    if (!stepOutput || typeof stepOutput !== "object" || typeof (stepOutput as { _build?: unknown })._build !== "function") {
+    if (
+      !stepOutput ||
+      typeof stepOutput !== "object" ||
+      typeof (stepOutput as { _build?: unknown })._build !== "function"
+    ) {
       throw new Error("gather(...) step must return a query expression built from app.<table>.");
     }
 
-    const stepBuilt = JSON.parse(
-      stepOutput._build(),
-    ) as {
+    const stepBuilt = JSON.parse(stepOutput._build()) as {
       table?: unknown;
       conditions?: Array<{ column: string; op: string; value: unknown }>;
       hops?: unknown;
@@ -381,7 +416,9 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
       (condition) => condition.op === "eq" && condition.value === currentToken,
     );
     if (currentConditions.length !== 1) {
-      throw new Error("gather(...) step must include exactly one where condition bound to current.");
+      throw new Error(
+        "gather(...) step must include exactly one where condition bound to current.",
+      );
     }
 
     const currentCondition = currentConditions[0];
@@ -421,7 +458,10 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
     return JSON.parse(this._build());
   }
 
-  private _clone<CloneI extends ProjectInclude = I, CloneS extends ProjectSelectableColumn = S>(): ProjectQueryBuilder<CloneI, CloneS> {
+  private _clone<
+    CloneI extends ProjectInclude = I,
+    CloneS extends ProjectSelectableColumn = S,
+  >(): ProjectQueryBuilder<CloneI, CloneS> {
     const clone = new ProjectQueryBuilder<CloneI, CloneS>();
     clone._conditions = [...this._conditions];
     clone._includes = { ...this._includes };
@@ -441,7 +481,10 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
   }
 }
 
-export class TodoQueryBuilder<I extends TodoInclude = {}, S extends TodoSelectableColumn = keyof Todo> implements QueryBuilder<TodoSelectedWithIncludes<I, S>> {
+export class TodoQueryBuilder<
+  I extends TodoInclude = {},
+  S extends TodoSelectableColumn = keyof Todo,
+> implements QueryBuilder<TodoSelectedWithIncludes<I, S>> {
   readonly _table = "todos";
   readonly _schema: WasmSchema = wasmSchema;
   readonly _rowType!: TodoSelectedWithIncludes<I, S>;
@@ -478,7 +521,9 @@ export class TodoQueryBuilder<I extends TodoInclude = {}, S extends TodoSelectab
     return clone;
   }
 
-  select<NewS extends TodoSelectableColumn>(...columns: [NewS, ...NewS[]]): TodoQueryBuilder<I, NewS> {
+  select<NewS extends TodoSelectableColumn>(
+    ...columns: [NewS, ...NewS[]]
+  ): TodoQueryBuilder<I, NewS> {
     const clone = this._clone<I, NewS>();
     clone._selectColumns = [...columns] as string[];
     return clone;
@@ -539,13 +584,15 @@ export class TodoQueryBuilder<I extends TodoInclude = {}, S extends TodoSelectab
 
     const currentToken = "__jazz_gather_current__";
     const stepOutput = options.step({ current: currentToken });
-    if (!stepOutput || typeof stepOutput !== "object" || typeof (stepOutput as { _build?: unknown })._build !== "function") {
+    if (
+      !stepOutput ||
+      typeof stepOutput !== "object" ||
+      typeof (stepOutput as { _build?: unknown })._build !== "function"
+    ) {
       throw new Error("gather(...) step must return a query expression built from app.<table>.");
     }
 
-    const stepBuilt = JSON.parse(
-      stepOutput._build(),
-    ) as {
+    const stepBuilt = JSON.parse(stepOutput._build()) as {
       table?: unknown;
       conditions?: Array<{ column: string; op: string; value: unknown }>;
       hops?: unknown;
@@ -569,7 +616,9 @@ export class TodoQueryBuilder<I extends TodoInclude = {}, S extends TodoSelectab
       (condition) => condition.op === "eq" && condition.value === currentToken,
     );
     if (currentConditions.length !== 1) {
-      throw new Error("gather(...) step must include exactly one where condition bound to current.");
+      throw new Error(
+        "gather(...) step must include exactly one where condition bound to current.",
+      );
     }
 
     const currentCondition = currentConditions[0];
@@ -609,7 +658,10 @@ export class TodoQueryBuilder<I extends TodoInclude = {}, S extends TodoSelectab
     return JSON.parse(this._build());
   }
 
-  private _clone<CloneI extends TodoInclude = I, CloneS extends TodoSelectableColumn = S>(): TodoQueryBuilder<CloneI, CloneS> {
+  private _clone<
+    CloneI extends TodoInclude = I,
+    CloneS extends TodoSelectableColumn = S,
+  >(): TodoQueryBuilder<CloneI, CloneS> {
     const clone = new TodoQueryBuilder<CloneI, CloneS>();
     clone._conditions = [...this._conditions];
     clone._includes = { ...this._includes };

--- a/examples/docs/todo-client-localfirst-ts/schema/app.ts
+++ b/examples/docs/todo-client-localfirst-ts/schema/app.ts
@@ -229,8 +229,8 @@ export const wasmSchema: WasmSchema = {
 export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends ProjectSelectableColumn = keyof Project> implements QueryBuilder<ProjectSelectedWithIncludes<I, S>> {
   readonly _table = "projects";
   readonly _schema: WasmSchema = wasmSchema;
-  declare readonly _rowType: ProjectSelectedWithIncludes<I, S>;
-  declare readonly _initType: ProjectInit;
+  readonly _rowType!: ProjectSelectedWithIncludes<I, S>;
+  readonly _initType!: ProjectInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<ProjectInclude> = {};
   private _selectColumns?: string[];
@@ -417,8 +417,8 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
 export class TodoQueryBuilder<I extends TodoInclude = {}, S extends TodoSelectableColumn = keyof Todo> implements QueryBuilder<TodoSelectedWithIncludes<I, S>> {
   readonly _table = "todos";
   readonly _schema: WasmSchema = wasmSchema;
-  declare readonly _rowType: TodoSelectedWithIncludes<I, S>;
-  declare readonly _initType: TodoInit;
+  readonly _rowType!: TodoSelectedWithIncludes<I, S>;
+  readonly _initType!: TodoInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<TodoInclude> = {};
   private _selectColumns?: string[];

--- a/examples/docs/todo-client-localfirst-ts/schema/app.ts
+++ b/examples/docs/todo-client-localfirst-ts/schema/app.ts
@@ -1,6 +1,12 @@
 // AUTO-GENERATED FILE - DO NOT EDIT
 import type { WasmSchema, QueryBuilder } from "jazz-tools";
-export type JsonValue = string | number | boolean | null | { [key: string]: JsonValue } | JsonValue[];
+export type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: JsonValue }
+  | JsonValue[];
 
 export type PermissionIntrospectionColumn = "$canRead" | "$canEdit" | "$canDelete";
 export interface PermissionIntrospectionColumns {
@@ -69,32 +75,30 @@ export interface TodoInclude {
 }
 
 export type ProjectIncludedRelations<I extends ProjectInclude = {}> = {
-  [K in keyof I]-?:
-    K extends "todosViaProject"
-      ? NonNullable<I["todosViaProject"]> extends infer RelationInclude
-        ? RelationInclude extends true
-          ? Todo[]
-          : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
-            ? QueryRow[]
-            : RelationInclude extends TodoInclude
-              ? TodoWithIncludes<RelationInclude>[]
-              : never
-        : never
+  [K in keyof I]-?: K extends "todosViaProject"
+    ? NonNullable<I["todosViaProject"]> extends infer RelationInclude
+      ? RelationInclude extends true
+        ? Todo[]
+        : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
+          ? QueryRow[]
+          : RelationInclude extends TodoInclude
+            ? TodoWithIncludes<RelationInclude>[]
+            : never
+      : never
     : never;
 };
 
 export type TodoIncludedRelations<I extends TodoInclude = {}> = {
-  [K in keyof I]-?:
-    K extends "parent"
-      ? NonNullable<I["parent"]> extends infer RelationInclude
-        ? RelationInclude extends true
-          ? Todo | undefined
-          : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
-            ? QueryRow | undefined
-            : RelationInclude extends TodoInclude
-              ? TodoWithIncludes<RelationInclude> | undefined
-              : never
-        : never
+  [K in keyof I]-?: K extends "parent"
+    ? NonNullable<I["parent"]> extends infer RelationInclude
+      ? RelationInclude extends true
+        ? Todo | undefined
+        : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
+          ? QueryRow | undefined
+          : RelationInclude extends TodoInclude
+            ? TodoWithIncludes<RelationInclude> | undefined
+            : never
+      : never
     : K extends "todosViaParent"
       ? NonNullable<I["todosViaParent"]> extends infer RelationInclude
         ? RelationInclude extends true
@@ -105,17 +109,17 @@ export type TodoIncludedRelations<I extends TodoInclude = {}> = {
               ? TodoWithIncludes<RelationInclude>[]
               : never
         : never
-    : K extends "project"
-      ? NonNullable<I["project"]> extends infer RelationInclude
-        ? RelationInclude extends true
-          ? Project | undefined
-          : RelationInclude extends AnyProjectQueryBuilder<infer QueryRow>
-            ? QueryRow | undefined
-            : RelationInclude extends ProjectInclude
-              ? ProjectWithIncludes<RelationInclude> | undefined
-              : never
-        : never
-    : never;
+      : K extends "project"
+        ? NonNullable<I["project"]> extends infer RelationInclude
+          ? RelationInclude extends true
+            ? Project | undefined
+            : RelationInclude extends AnyProjectQueryBuilder<infer QueryRow>
+              ? QueryRow | undefined
+              : RelationInclude extends ProjectInclude
+                ? ProjectWithIncludes<RelationInclude> | undefined
+                : never
+          : never
+        : never;
 };
 
 export interface ProjectRelations {
@@ -128,105 +132,129 @@ export interface TodoRelations {
   project: Project;
 }
 
-export type ProjectWithIncludes<I extends ProjectInclude = {}> = Omit<Project, Extract<keyof I, keyof Project>> & ProjectIncludedRelations<I>;
+export type ProjectWithIncludes<I extends ProjectInclude = {}> = Omit<
+  Project,
+  Extract<keyof I, keyof Project>
+> &
+  ProjectIncludedRelations<I>;
 
-export type TodoWithIncludes<I extends TodoInclude = {}> = Omit<Todo, Extract<keyof I, keyof Todo>> & TodoIncludedRelations<I>;
+export type TodoWithIncludes<I extends TodoInclude = {}> = Omit<
+  Todo,
+  Extract<keyof I, keyof Todo>
+> &
+  TodoIncludedRelations<I>;
 
 export type ProjectSelectableColumn = keyof Project | PermissionIntrospectionColumn | "*";
 export type ProjectOrderableColumn = keyof Project | PermissionIntrospectionColumn;
 
-export type ProjectSelected<S extends ProjectSelectableColumn = keyof Project> = "*" extends S ? Project : Pick<Project, Extract<S | "id", keyof Project>> & Pick<PermissionIntrospectionColumns, Extract<S, PermissionIntrospectionColumn>>;
+export type ProjectSelected<S extends ProjectSelectableColumn = keyof Project> = "*" extends S
+  ? Project
+  : Pick<Project, Extract<S | "id", keyof Project>> &
+      Pick<PermissionIntrospectionColumns, Extract<S, PermissionIntrospectionColumn>>;
 
-export type ProjectSelectedWithIncludes<I extends ProjectInclude = {}, S extends ProjectSelectableColumn = keyof Project> = Omit<ProjectSelected<S>, Extract<keyof I, keyof ProjectSelected<S>>> & ProjectIncludedRelations<I>;
+export type ProjectSelectedWithIncludes<
+  I extends ProjectInclude = {},
+  S extends ProjectSelectableColumn = keyof Project,
+> = Omit<ProjectSelected<S>, Extract<keyof I, keyof ProjectSelected<S>>> &
+  ProjectIncludedRelations<I>;
 
 export type TodoSelectableColumn = keyof Todo | PermissionIntrospectionColumn | "*";
 export type TodoOrderableColumn = keyof Todo | PermissionIntrospectionColumn;
 
-export type TodoSelected<S extends TodoSelectableColumn = keyof Todo> = "*" extends S ? Todo : Pick<Todo, Extract<S | "id", keyof Todo>> & Pick<PermissionIntrospectionColumns, Extract<S, PermissionIntrospectionColumn>>;
+export type TodoSelected<S extends TodoSelectableColumn = keyof Todo> = "*" extends S
+  ? Todo
+  : Pick<Todo, Extract<S | "id", keyof Todo>> &
+      Pick<PermissionIntrospectionColumns, Extract<S, PermissionIntrospectionColumn>>;
 
-export type TodoSelectedWithIncludes<I extends TodoInclude = {}, S extends TodoSelectableColumn = keyof Todo> = Omit<TodoSelected<S>, Extract<keyof I, keyof TodoSelected<S>>> & TodoIncludedRelations<I>;
+export type TodoSelectedWithIncludes<
+  I extends TodoInclude = {},
+  S extends TodoSelectableColumn = keyof Todo,
+> = Omit<TodoSelected<S>, Extract<keyof I, keyof TodoSelected<S>>> & TodoIncludedRelations<I>;
 
 export const wasmSchema: WasmSchema = {
-  "projects": {
-    "columns": [
+  projects: {
+    columns: [
       {
-        "name": "name",
-        "column_type": {
-          "type": "Text"
+        name: "name",
+        column_type: {
+          type: "Text",
         },
-        "nullable": false
-      }
-    ]
-  },
-  "todos": {
-    "columns": [
-      {
-        "name": "title",
-        "column_type": {
-          "type": "Text"
-        },
-        "nullable": false
+        nullable: false,
       },
-      {
-        "name": "done",
-        "column_type": {
-          "type": "Boolean"
-        },
-        "nullable": false
-      },
-      {
-        "name": "description",
-        "column_type": {
-          "type": "Text"
-        },
-        "nullable": true
-      },
-      {
-        "name": "parent",
-        "column_type": {
-          "type": "Uuid"
-        },
-        "nullable": true,
-        "references": "todos"
-      },
-      {
-        "name": "project",
-        "column_type": {
-          "type": "Uuid"
-        },
-        "nullable": true,
-        "references": "projects"
-      }
     ],
-    "policies": {
-      "select": {
-        "using": {
-          "type": "True"
-        }
-      },
-      "insert": {
-        "with_check": {
-          "type": "True"
-        }
-      },
-      "update": {
-        "using": {
-          "type": "True"
+  },
+  todos: {
+    columns: [
+      {
+        name: "title",
+        column_type: {
+          type: "Text",
         },
-        "with_check": {
-          "type": "True"
-        }
+        nullable: false,
       },
-      "delete": {
-        "using": {
-          "type": "True"
-        }
-      }
-    }
-  }
+      {
+        name: "done",
+        column_type: {
+          type: "Boolean",
+        },
+        nullable: false,
+      },
+      {
+        name: "description",
+        column_type: {
+          type: "Text",
+        },
+        nullable: true,
+      },
+      {
+        name: "parent",
+        column_type: {
+          type: "Uuid",
+        },
+        nullable: true,
+        references: "todos",
+      },
+      {
+        name: "project",
+        column_type: {
+          type: "Uuid",
+        },
+        nullable: true,
+        references: "projects",
+      },
+    ],
+    policies: {
+      select: {
+        using: {
+          type: "True",
+        },
+      },
+      insert: {
+        with_check: {
+          type: "True",
+        },
+      },
+      update: {
+        using: {
+          type: "True",
+        },
+        with_check: {
+          type: "True",
+        },
+      },
+      delete: {
+        using: {
+          type: "True",
+        },
+      },
+    },
+  },
 };
 
-export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends ProjectSelectableColumn = keyof Project> implements QueryBuilder<ProjectSelectedWithIncludes<I, S>> {
+export class ProjectQueryBuilder<
+  I extends ProjectInclude = {},
+  S extends ProjectSelectableColumn = keyof Project,
+> implements QueryBuilder<ProjectSelectedWithIncludes<I, S>> {
   readonly _table = "projects";
   readonly _schema: WasmSchema = wasmSchema;
   readonly _rowType!: ProjectSelectedWithIncludes<I, S>;
@@ -263,7 +291,9 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
     return clone;
   }
 
-  select<NewS extends ProjectSelectableColumn>(...columns: [NewS, ...NewS[]]): ProjectQueryBuilder<I, NewS> {
+  select<NewS extends ProjectSelectableColumn>(
+    ...columns: [NewS, ...NewS[]]
+  ): ProjectQueryBuilder<I, NewS> {
     const clone = this._clone<I, NewS>();
     clone._selectColumns = [...columns] as string[];
     return clone;
@@ -275,7 +305,10 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
     return clone;
   }
 
-  orderBy(column: ProjectOrderableColumn, direction: "asc" | "desc" = "asc"): ProjectQueryBuilder<I, S> {
+  orderBy(
+    column: ProjectOrderableColumn,
+    direction: "asc" | "desc" = "asc",
+  ): ProjectQueryBuilder<I, S> {
     const clone = this._clone();
     clone._orderBys.push([column as string, direction]);
     return clone;
@@ -324,13 +357,15 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
 
     const currentToken = "__jazz_gather_current__";
     const stepOutput = options.step({ current: currentToken });
-    if (!stepOutput || typeof stepOutput !== "object" || typeof (stepOutput as { _build?: unknown })._build !== "function") {
+    if (
+      !stepOutput ||
+      typeof stepOutput !== "object" ||
+      typeof (stepOutput as { _build?: unknown })._build !== "function"
+    ) {
       throw new Error("gather(...) step must return a query expression built from app.<table>.");
     }
 
-    const stepBuilt = JSON.parse(
-      stepOutput._build(),
-    ) as {
+    const stepBuilt = JSON.parse(stepOutput._build()) as {
       table?: unknown;
       conditions?: Array<{ column: string; op: string; value: unknown }>;
       hops?: unknown;
@@ -354,7 +389,9 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
       (condition) => condition.op === "eq" && condition.value === currentToken,
     );
     if (currentConditions.length !== 1) {
-      throw new Error("gather(...) step must include exactly one where condition bound to current.");
+      throw new Error(
+        "gather(...) step must include exactly one where condition bound to current.",
+      );
     }
 
     const currentCondition = currentConditions[0];
@@ -394,7 +431,10 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
     return JSON.parse(this._build());
   }
 
-  private _clone<CloneI extends ProjectInclude = I, CloneS extends ProjectSelectableColumn = S>(): ProjectQueryBuilder<CloneI, CloneS> {
+  private _clone<
+    CloneI extends ProjectInclude = I,
+    CloneS extends ProjectSelectableColumn = S,
+  >(): ProjectQueryBuilder<CloneI, CloneS> {
     const clone = new ProjectQueryBuilder<CloneI, CloneS>();
     clone._conditions = [...this._conditions];
     clone._includes = { ...this._includes };
@@ -414,7 +454,10 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
   }
 }
 
-export class TodoQueryBuilder<I extends TodoInclude = {}, S extends TodoSelectableColumn = keyof Todo> implements QueryBuilder<TodoSelectedWithIncludes<I, S>> {
+export class TodoQueryBuilder<
+  I extends TodoInclude = {},
+  S extends TodoSelectableColumn = keyof Todo,
+> implements QueryBuilder<TodoSelectedWithIncludes<I, S>> {
   readonly _table = "todos";
   readonly _schema: WasmSchema = wasmSchema;
   readonly _rowType!: TodoSelectedWithIncludes<I, S>;
@@ -451,7 +494,9 @@ export class TodoQueryBuilder<I extends TodoInclude = {}, S extends TodoSelectab
     return clone;
   }
 
-  select<NewS extends TodoSelectableColumn>(...columns: [NewS, ...NewS[]]): TodoQueryBuilder<I, NewS> {
+  select<NewS extends TodoSelectableColumn>(
+    ...columns: [NewS, ...NewS[]]
+  ): TodoQueryBuilder<I, NewS> {
     const clone = this._clone<I, NewS>();
     clone._selectColumns = [...columns] as string[];
     return clone;
@@ -512,13 +557,15 @@ export class TodoQueryBuilder<I extends TodoInclude = {}, S extends TodoSelectab
 
     const currentToken = "__jazz_gather_current__";
     const stepOutput = options.step({ current: currentToken });
-    if (!stepOutput || typeof stepOutput !== "object" || typeof (stepOutput as { _build?: unknown })._build !== "function") {
+    if (
+      !stepOutput ||
+      typeof stepOutput !== "object" ||
+      typeof (stepOutput as { _build?: unknown })._build !== "function"
+    ) {
       throw new Error("gather(...) step must return a query expression built from app.<table>.");
     }
 
-    const stepBuilt = JSON.parse(
-      stepOutput._build(),
-    ) as {
+    const stepBuilt = JSON.parse(stepOutput._build()) as {
       table?: unknown;
       conditions?: Array<{ column: string; op: string; value: unknown }>;
       hops?: unknown;
@@ -542,7 +589,9 @@ export class TodoQueryBuilder<I extends TodoInclude = {}, S extends TodoSelectab
       (condition) => condition.op === "eq" && condition.value === currentToken,
     );
     if (currentConditions.length !== 1) {
-      throw new Error("gather(...) step must include exactly one where condition bound to current.");
+      throw new Error(
+        "gather(...) step must include exactly one where condition bound to current.",
+      );
     }
 
     const currentCondition = currentConditions[0];
@@ -582,7 +631,10 @@ export class TodoQueryBuilder<I extends TodoInclude = {}, S extends TodoSelectab
     return JSON.parse(this._build());
   }
 
-  private _clone<CloneI extends TodoInclude = I, CloneS extends TodoSelectableColumn = S>(): TodoQueryBuilder<CloneI, CloneS> {
+  private _clone<
+    CloneI extends TodoInclude = I,
+    CloneS extends TodoSelectableColumn = S,
+  >(): TodoQueryBuilder<CloneI, CloneS> {
     const clone = new TodoQueryBuilder<CloneI, CloneS>();
     clone._conditions = [...this._conditions];
     clone._includes = { ...this._includes };

--- a/examples/docs/todo-client-localfirst-vue/schema/app.ts
+++ b/examples/docs/todo-client-localfirst-vue/schema/app.ts
@@ -256,8 +256,8 @@ export const wasmSchema: WasmSchema = {
 export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends ProjectSelectableColumn = keyof Project> implements QueryBuilder<ProjectSelectedWithIncludes<I, S>> {
   readonly _table = "projects";
   readonly _schema: WasmSchema = wasmSchema;
-  declare readonly _rowType: ProjectSelectedWithIncludes<I, S>;
-  declare readonly _initType: ProjectInit;
+  readonly _rowType!: ProjectSelectedWithIncludes<I, S>;
+  readonly _initType!: ProjectInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<ProjectInclude> = {};
   private _selectColumns?: string[];
@@ -444,8 +444,8 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
 export class TodoQueryBuilder<I extends TodoInclude = {}, S extends TodoSelectableColumn = keyof Todo> implements QueryBuilder<TodoSelectedWithIncludes<I, S>> {
   readonly _table = "todos";
   readonly _schema: WasmSchema = wasmSchema;
-  declare readonly _rowType: TodoSelectedWithIncludes<I, S>;
-  declare readonly _initType: TodoInit;
+  readonly _rowType!: TodoSelectedWithIncludes<I, S>;
+  readonly _initType!: TodoInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<TodoInclude> = {};
   private _selectColumns?: string[];

--- a/examples/docs/todo-client-localfirst-vue/schema/app.ts
+++ b/examples/docs/todo-client-localfirst-vue/schema/app.ts
@@ -1,6 +1,12 @@
 // AUTO-GENERATED FILE - DO NOT EDIT
 import type { WasmSchema, QueryBuilder } from "jazz-tools";
-export type JsonValue = string | number | boolean | null | { [key: string]: JsonValue } | JsonValue[];
+export type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: JsonValue }
+  | JsonValue[];
 
 export type PermissionIntrospectionColumn = "$canRead" | "$canEdit" | "$canDelete";
 export interface PermissionIntrospectionColumns {
@@ -69,32 +75,30 @@ export interface TodoInclude {
 }
 
 export type ProjectIncludedRelations<I extends ProjectInclude = {}> = {
-  [K in keyof I]-?:
-    K extends "todosViaProject"
-      ? NonNullable<I["todosViaProject"]> extends infer RelationInclude
-        ? RelationInclude extends true
-          ? Todo[]
-          : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
-            ? QueryRow[]
-            : RelationInclude extends TodoInclude
-              ? TodoWithIncludes<RelationInclude>[]
-              : never
-        : never
+  [K in keyof I]-?: K extends "todosViaProject"
+    ? NonNullable<I["todosViaProject"]> extends infer RelationInclude
+      ? RelationInclude extends true
+        ? Todo[]
+        : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
+          ? QueryRow[]
+          : RelationInclude extends TodoInclude
+            ? TodoWithIncludes<RelationInclude>[]
+            : never
+      : never
     : never;
 };
 
 export type TodoIncludedRelations<I extends TodoInclude = {}> = {
-  [K in keyof I]-?:
-    K extends "parent"
-      ? NonNullable<I["parent"]> extends infer RelationInclude
-        ? RelationInclude extends true
-          ? Todo | undefined
-          : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
-            ? QueryRow | undefined
-            : RelationInclude extends TodoInclude
-              ? TodoWithIncludes<RelationInclude> | undefined
-              : never
-        : never
+  [K in keyof I]-?: K extends "parent"
+    ? NonNullable<I["parent"]> extends infer RelationInclude
+      ? RelationInclude extends true
+        ? Todo | undefined
+        : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
+          ? QueryRow | undefined
+          : RelationInclude extends TodoInclude
+            ? TodoWithIncludes<RelationInclude> | undefined
+            : never
+      : never
     : K extends "todosViaParent"
       ? NonNullable<I["todosViaParent"]> extends infer RelationInclude
         ? RelationInclude extends true
@@ -105,17 +109,17 @@ export type TodoIncludedRelations<I extends TodoInclude = {}> = {
               ? TodoWithIncludes<RelationInclude>[]
               : never
         : never
-    : K extends "project"
-      ? NonNullable<I["project"]> extends infer RelationInclude
-        ? RelationInclude extends true
-          ? Project | undefined
-          : RelationInclude extends AnyProjectQueryBuilder<infer QueryRow>
-            ? QueryRow | undefined
-            : RelationInclude extends ProjectInclude
-              ? ProjectWithIncludes<RelationInclude> | undefined
-              : never
-        : never
-    : never;
+      : K extends "project"
+        ? NonNullable<I["project"]> extends infer RelationInclude
+          ? RelationInclude extends true
+            ? Project | undefined
+            : RelationInclude extends AnyProjectQueryBuilder<infer QueryRow>
+              ? QueryRow | undefined
+              : RelationInclude extends ProjectInclude
+                ? ProjectWithIncludes<RelationInclude> | undefined
+                : never
+          : never
+        : never;
 };
 
 export interface ProjectRelations {
@@ -128,132 +132,156 @@ export interface TodoRelations {
   project: Project;
 }
 
-export type ProjectWithIncludes<I extends ProjectInclude = {}> = Omit<Project, Extract<keyof I, keyof Project>> & ProjectIncludedRelations<I>;
+export type ProjectWithIncludes<I extends ProjectInclude = {}> = Omit<
+  Project,
+  Extract<keyof I, keyof Project>
+> &
+  ProjectIncludedRelations<I>;
 
-export type TodoWithIncludes<I extends TodoInclude = {}> = Omit<Todo, Extract<keyof I, keyof Todo>> & TodoIncludedRelations<I>;
+export type TodoWithIncludes<I extends TodoInclude = {}> = Omit<
+  Todo,
+  Extract<keyof I, keyof Todo>
+> &
+  TodoIncludedRelations<I>;
 
 export type ProjectSelectableColumn = keyof Project | PermissionIntrospectionColumn | "*";
 export type ProjectOrderableColumn = keyof Project | PermissionIntrospectionColumn;
 
-export type ProjectSelected<S extends ProjectSelectableColumn = keyof Project> = "*" extends S ? Project : Pick<Project, Extract<S | "id", keyof Project>> & Pick<PermissionIntrospectionColumns, Extract<S, PermissionIntrospectionColumn>>;
+export type ProjectSelected<S extends ProjectSelectableColumn = keyof Project> = "*" extends S
+  ? Project
+  : Pick<Project, Extract<S | "id", keyof Project>> &
+      Pick<PermissionIntrospectionColumns, Extract<S, PermissionIntrospectionColumn>>;
 
-export type ProjectSelectedWithIncludes<I extends ProjectInclude = {}, S extends ProjectSelectableColumn = keyof Project> = Omit<ProjectSelected<S>, Extract<keyof I, keyof ProjectSelected<S>>> & ProjectIncludedRelations<I>;
+export type ProjectSelectedWithIncludes<
+  I extends ProjectInclude = {},
+  S extends ProjectSelectableColumn = keyof Project,
+> = Omit<ProjectSelected<S>, Extract<keyof I, keyof ProjectSelected<S>>> &
+  ProjectIncludedRelations<I>;
 
 export type TodoSelectableColumn = keyof Todo | PermissionIntrospectionColumn | "*";
 export type TodoOrderableColumn = keyof Todo | PermissionIntrospectionColumn;
 
-export type TodoSelected<S extends TodoSelectableColumn = keyof Todo> = "*" extends S ? Todo : Pick<Todo, Extract<S | "id", keyof Todo>> & Pick<PermissionIntrospectionColumns, Extract<S, PermissionIntrospectionColumn>>;
+export type TodoSelected<S extends TodoSelectableColumn = keyof Todo> = "*" extends S
+  ? Todo
+  : Pick<Todo, Extract<S | "id", keyof Todo>> &
+      Pick<PermissionIntrospectionColumns, Extract<S, PermissionIntrospectionColumn>>;
 
-export type TodoSelectedWithIncludes<I extends TodoInclude = {}, S extends TodoSelectableColumn = keyof Todo> = Omit<TodoSelected<S>, Extract<keyof I, keyof TodoSelected<S>>> & TodoIncludedRelations<I>;
+export type TodoSelectedWithIncludes<
+  I extends TodoInclude = {},
+  S extends TodoSelectableColumn = keyof Todo,
+> = Omit<TodoSelected<S>, Extract<keyof I, keyof TodoSelected<S>>> & TodoIncludedRelations<I>;
 
 export const wasmSchema: WasmSchema = {
-  "projects": {
-    "columns": [
+  projects: {
+    columns: [
       {
-        "name": "name",
-        "column_type": {
-          "type": "Text"
+        name: "name",
+        column_type: {
+          type: "Text",
         },
-        "nullable": false
-      }
-    ]
-  },
-  "todos": {
-    "columns": [
-      {
-        "name": "title",
-        "column_type": {
-          "type": "Text"
-        },
-        "nullable": false
+        nullable: false,
       },
-      {
-        "name": "done",
-        "column_type": {
-          "type": "Boolean"
-        },
-        "nullable": false
-      },
-      {
-        "name": "description",
-        "column_type": {
-          "type": "Text"
-        },
-        "nullable": true
-      },
-      {
-        "name": "parent",
-        "column_type": {
-          "type": "Uuid"
-        },
-        "nullable": true,
-        "references": "todos"
-      },
-      {
-        "name": "project",
-        "column_type": {
-          "type": "Uuid"
-        },
-        "nullable": true,
-        "references": "projects"
-      }
     ],
-    "policies": {
-      "select": {
-        "using": {
-          "type": "True"
-        }
-      },
-      "insert": {
-        "with_check": {
-          "type": "Cmp",
-          "column": "done",
-          "op": "Eq",
-          "value": {
-            "type": "Literal",
-            "value": {
-              "type": "Boolean",
-              "value": false
-            }
-          }
-        }
-      },
-      "update": {
-        "using": {
-          "type": "Cmp",
-          "column": "done",
-          "op": "Eq",
-          "value": {
-            "type": "Literal",
-            "value": {
-              "type": "Boolean",
-              "value": false
-            }
-          }
+  },
+  todos: {
+    columns: [
+      {
+        name: "title",
+        column_type: {
+          type: "Text",
         },
-        "with_check": {
-          "type": "True"
-        }
+        nullable: false,
       },
-      "delete": {
-        "using": {
-          "type": "Cmp",
-          "column": "done",
-          "op": "Eq",
-          "value": {
-            "type": "Literal",
-            "value": {
-              "type": "Boolean",
-              "value": false
-            }
-          }
-        }
-      }
-    }
-  }
+      {
+        name: "done",
+        column_type: {
+          type: "Boolean",
+        },
+        nullable: false,
+      },
+      {
+        name: "description",
+        column_type: {
+          type: "Text",
+        },
+        nullable: true,
+      },
+      {
+        name: "parent",
+        column_type: {
+          type: "Uuid",
+        },
+        nullable: true,
+        references: "todos",
+      },
+      {
+        name: "project",
+        column_type: {
+          type: "Uuid",
+        },
+        nullable: true,
+        references: "projects",
+      },
+    ],
+    policies: {
+      select: {
+        using: {
+          type: "True",
+        },
+      },
+      insert: {
+        with_check: {
+          type: "Cmp",
+          column: "done",
+          op: "Eq",
+          value: {
+            type: "Literal",
+            value: {
+              type: "Boolean",
+              value: false,
+            },
+          },
+        },
+      },
+      update: {
+        using: {
+          type: "Cmp",
+          column: "done",
+          op: "Eq",
+          value: {
+            type: "Literal",
+            value: {
+              type: "Boolean",
+              value: false,
+            },
+          },
+        },
+        with_check: {
+          type: "True",
+        },
+      },
+      delete: {
+        using: {
+          type: "Cmp",
+          column: "done",
+          op: "Eq",
+          value: {
+            type: "Literal",
+            value: {
+              type: "Boolean",
+              value: false,
+            },
+          },
+        },
+      },
+    },
+  },
 };
 
-export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends ProjectSelectableColumn = keyof Project> implements QueryBuilder<ProjectSelectedWithIncludes<I, S>> {
+export class ProjectQueryBuilder<
+  I extends ProjectInclude = {},
+  S extends ProjectSelectableColumn = keyof Project,
+> implements QueryBuilder<ProjectSelectedWithIncludes<I, S>> {
   readonly _table = "projects";
   readonly _schema: WasmSchema = wasmSchema;
   readonly _rowType!: ProjectSelectedWithIncludes<I, S>;
@@ -290,7 +318,9 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
     return clone;
   }
 
-  select<NewS extends ProjectSelectableColumn>(...columns: [NewS, ...NewS[]]): ProjectQueryBuilder<I, NewS> {
+  select<NewS extends ProjectSelectableColumn>(
+    ...columns: [NewS, ...NewS[]]
+  ): ProjectQueryBuilder<I, NewS> {
     const clone = this._clone<I, NewS>();
     clone._selectColumns = [...columns] as string[];
     return clone;
@@ -302,7 +332,10 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
     return clone;
   }
 
-  orderBy(column: ProjectOrderableColumn, direction: "asc" | "desc" = "asc"): ProjectQueryBuilder<I, S> {
+  orderBy(
+    column: ProjectOrderableColumn,
+    direction: "asc" | "desc" = "asc",
+  ): ProjectQueryBuilder<I, S> {
     const clone = this._clone();
     clone._orderBys.push([column as string, direction]);
     return clone;
@@ -351,13 +384,15 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
 
     const currentToken = "__jazz_gather_current__";
     const stepOutput = options.step({ current: currentToken });
-    if (!stepOutput || typeof stepOutput !== "object" || typeof (stepOutput as { _build?: unknown })._build !== "function") {
+    if (
+      !stepOutput ||
+      typeof stepOutput !== "object" ||
+      typeof (stepOutput as { _build?: unknown })._build !== "function"
+    ) {
       throw new Error("gather(...) step must return a query expression built from app.<table>.");
     }
 
-    const stepBuilt = JSON.parse(
-      stepOutput._build(),
-    ) as {
+    const stepBuilt = JSON.parse(stepOutput._build()) as {
       table?: unknown;
       conditions?: Array<{ column: string; op: string; value: unknown }>;
       hops?: unknown;
@@ -381,7 +416,9 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
       (condition) => condition.op === "eq" && condition.value === currentToken,
     );
     if (currentConditions.length !== 1) {
-      throw new Error("gather(...) step must include exactly one where condition bound to current.");
+      throw new Error(
+        "gather(...) step must include exactly one where condition bound to current.",
+      );
     }
 
     const currentCondition = currentConditions[0];
@@ -421,7 +458,10 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
     return JSON.parse(this._build());
   }
 
-  private _clone<CloneI extends ProjectInclude = I, CloneS extends ProjectSelectableColumn = S>(): ProjectQueryBuilder<CloneI, CloneS> {
+  private _clone<
+    CloneI extends ProjectInclude = I,
+    CloneS extends ProjectSelectableColumn = S,
+  >(): ProjectQueryBuilder<CloneI, CloneS> {
     const clone = new ProjectQueryBuilder<CloneI, CloneS>();
     clone._conditions = [...this._conditions];
     clone._includes = { ...this._includes };
@@ -441,7 +481,10 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
   }
 }
 
-export class TodoQueryBuilder<I extends TodoInclude = {}, S extends TodoSelectableColumn = keyof Todo> implements QueryBuilder<TodoSelectedWithIncludes<I, S>> {
+export class TodoQueryBuilder<
+  I extends TodoInclude = {},
+  S extends TodoSelectableColumn = keyof Todo,
+> implements QueryBuilder<TodoSelectedWithIncludes<I, S>> {
   readonly _table = "todos";
   readonly _schema: WasmSchema = wasmSchema;
   readonly _rowType!: TodoSelectedWithIncludes<I, S>;
@@ -478,7 +521,9 @@ export class TodoQueryBuilder<I extends TodoInclude = {}, S extends TodoSelectab
     return clone;
   }
 
-  select<NewS extends TodoSelectableColumn>(...columns: [NewS, ...NewS[]]): TodoQueryBuilder<I, NewS> {
+  select<NewS extends TodoSelectableColumn>(
+    ...columns: [NewS, ...NewS[]]
+  ): TodoQueryBuilder<I, NewS> {
     const clone = this._clone<I, NewS>();
     clone._selectColumns = [...columns] as string[];
     return clone;
@@ -539,13 +584,15 @@ export class TodoQueryBuilder<I extends TodoInclude = {}, S extends TodoSelectab
 
     const currentToken = "__jazz_gather_current__";
     const stepOutput = options.step({ current: currentToken });
-    if (!stepOutput || typeof stepOutput !== "object" || typeof (stepOutput as { _build?: unknown })._build !== "function") {
+    if (
+      !stepOutput ||
+      typeof stepOutput !== "object" ||
+      typeof (stepOutput as { _build?: unknown })._build !== "function"
+    ) {
       throw new Error("gather(...) step must return a query expression built from app.<table>.");
     }
 
-    const stepBuilt = JSON.parse(
-      stepOutput._build(),
-    ) as {
+    const stepBuilt = JSON.parse(stepOutput._build()) as {
       table?: unknown;
       conditions?: Array<{ column: string; op: string; value: unknown }>;
       hops?: unknown;
@@ -569,7 +616,9 @@ export class TodoQueryBuilder<I extends TodoInclude = {}, S extends TodoSelectab
       (condition) => condition.op === "eq" && condition.value === currentToken,
     );
     if (currentConditions.length !== 1) {
-      throw new Error("gather(...) step must include exactly one where condition bound to current.");
+      throw new Error(
+        "gather(...) step must include exactly one where condition bound to current.",
+      );
     }
 
     const currentCondition = currentConditions[0];
@@ -609,7 +658,10 @@ export class TodoQueryBuilder<I extends TodoInclude = {}, S extends TodoSelectab
     return JSON.parse(this._build());
   }
 
-  private _clone<CloneI extends TodoInclude = I, CloneS extends TodoSelectableColumn = S>(): TodoQueryBuilder<CloneI, CloneS> {
+  private _clone<
+    CloneI extends TodoInclude = I,
+    CloneS extends TodoSelectableColumn = S,
+  >(): TodoQueryBuilder<CloneI, CloneS> {
     const clone = new TodoQueryBuilder<CloneI, CloneS>();
     clone._conditions = [...this._conditions];
     clone._includes = { ...this._includes };

--- a/examples/docs/todo-server-ts/schema/app.ts
+++ b/examples/docs/todo-server-ts/schema/app.ts
@@ -1,6 +1,12 @@
 // AUTO-GENERATED FILE - DO NOT EDIT
 import type { WasmSchema, QueryBuilder } from "jazz-tools";
-export type JsonValue = string | number | boolean | null | { [key: string]: JsonValue } | JsonValue[];
+export type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: JsonValue }
+  | JsonValue[];
 
 export type PermissionIntrospectionColumn = "$canRead" | "$canEdit" | "$canDelete";
 export interface PermissionIntrospectionColumns {
@@ -72,32 +78,30 @@ export interface TodoInclude {
 }
 
 export type ProjectIncludedRelations<I extends ProjectInclude = {}> = {
-  [K in keyof I]-?:
-    K extends "todosViaProject"
-      ? NonNullable<I["todosViaProject"]> extends infer RelationInclude
-        ? RelationInclude extends true
-          ? Todo[]
-          : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
-            ? QueryRow[]
-            : RelationInclude extends TodoInclude
-              ? TodoWithIncludes<RelationInclude>[]
-              : never
-        : never
+  [K in keyof I]-?: K extends "todosViaProject"
+    ? NonNullable<I["todosViaProject"]> extends infer RelationInclude
+      ? RelationInclude extends true
+        ? Todo[]
+        : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
+          ? QueryRow[]
+          : RelationInclude extends TodoInclude
+            ? TodoWithIncludes<RelationInclude>[]
+            : never
+      : never
     : never;
 };
 
 export type TodoIncludedRelations<I extends TodoInclude = {}> = {
-  [K in keyof I]-?:
-    K extends "parent"
-      ? NonNullable<I["parent"]> extends infer RelationInclude
-        ? RelationInclude extends true
-          ? Todo | undefined
-          : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
-            ? QueryRow | undefined
-            : RelationInclude extends TodoInclude
-              ? TodoWithIncludes<RelationInclude> | undefined
-              : never
-        : never
+  [K in keyof I]-?: K extends "parent"
+    ? NonNullable<I["parent"]> extends infer RelationInclude
+      ? RelationInclude extends true
+        ? Todo | undefined
+        : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
+          ? QueryRow | undefined
+          : RelationInclude extends TodoInclude
+            ? TodoWithIncludes<RelationInclude> | undefined
+            : never
+      : never
     : K extends "todosViaParent"
       ? NonNullable<I["todosViaParent"]> extends infer RelationInclude
         ? RelationInclude extends true
@@ -108,17 +112,17 @@ export type TodoIncludedRelations<I extends TodoInclude = {}> = {
               ? TodoWithIncludes<RelationInclude>[]
               : never
         : never
-    : K extends "project"
-      ? NonNullable<I["project"]> extends infer RelationInclude
-        ? RelationInclude extends true
-          ? Project | undefined
-          : RelationInclude extends AnyProjectQueryBuilder<infer QueryRow>
-            ? QueryRow | undefined
-            : RelationInclude extends ProjectInclude
-              ? ProjectWithIncludes<RelationInclude> | undefined
-              : never
-        : never
-    : never;
+      : K extends "project"
+        ? NonNullable<I["project"]> extends infer RelationInclude
+          ? RelationInclude extends true
+            ? Project | undefined
+            : RelationInclude extends AnyProjectQueryBuilder<infer QueryRow>
+              ? QueryRow | undefined
+              : RelationInclude extends ProjectInclude
+                ? ProjectWithIncludes<RelationInclude> | undefined
+                : never
+          : never
+        : never;
 };
 
 export interface ProjectRelations {
@@ -131,152 +135,166 @@ export interface TodoRelations {
   project: Project;
 }
 
-export type ProjectWithIncludes<I extends ProjectInclude = {}> = Omit<Project, Extract<keyof I, keyof Project>> & ProjectIncludedRelations<I>;
+export type ProjectWithIncludes<I extends ProjectInclude = {}> = Omit<
+  Project,
+  Extract<keyof I, keyof Project>
+> &
+  ProjectIncludedRelations<I>;
 
-export type TodoWithIncludes<I extends TodoInclude = {}> = Omit<Todo, Extract<keyof I, keyof Todo>> & TodoIncludedRelations<I>;
+export type TodoWithIncludes<I extends TodoInclude = {}> = Omit<
+  Todo,
+  Extract<keyof I, keyof Todo>
+> &
+  TodoIncludedRelations<I>;
 
 export type ProjectSelectableColumn = keyof Project | PermissionIntrospectionColumn | "*";
 export type ProjectOrderableColumn = keyof Project | PermissionIntrospectionColumn;
 
-export type ProjectSelected<S extends ProjectSelectableColumn = keyof Project> = "*" extends S ? Project : Pick<Project, Extract<S | "id", keyof Project>> & Pick<PermissionIntrospectionColumns, Extract<S, PermissionIntrospectionColumn>>;
+export type ProjectSelected<S extends ProjectSelectableColumn = keyof Project> = "*" extends S
+  ? Project
+  : Pick<Project, Extract<S | "id", keyof Project>> &
+      Pick<PermissionIntrospectionColumns, Extract<S, PermissionIntrospectionColumn>>;
 
-export type ProjectSelectedWithIncludes<I extends ProjectInclude = {}, S extends ProjectSelectableColumn = keyof Project> = Omit<ProjectSelected<S>, Extract<keyof I, keyof ProjectSelected<S>>> & ProjectIncludedRelations<I>;
+export type ProjectSelectedWithIncludes<
+  I extends ProjectInclude = {},
+  S extends ProjectSelectableColumn = keyof Project,
+> = Omit<ProjectSelected<S>, Extract<keyof I, keyof ProjectSelected<S>>> &
+  ProjectIncludedRelations<I>;
 
 export type TodoSelectableColumn = keyof Todo | PermissionIntrospectionColumn | "*";
 export type TodoOrderableColumn = keyof Todo | PermissionIntrospectionColumn;
 
-export type TodoSelected<S extends TodoSelectableColumn = keyof Todo> = "*" extends S ? Todo : Pick<Todo, Extract<S | "id", keyof Todo>> & Pick<PermissionIntrospectionColumns, Extract<S, PermissionIntrospectionColumn>>;
+export type TodoSelected<S extends TodoSelectableColumn = keyof Todo> = "*" extends S
+  ? Todo
+  : Pick<Todo, Extract<S | "id", keyof Todo>> &
+      Pick<PermissionIntrospectionColumns, Extract<S, PermissionIntrospectionColumn>>;
 
-export type TodoSelectedWithIncludes<I extends TodoInclude = {}, S extends TodoSelectableColumn = keyof Todo> = Omit<TodoSelected<S>, Extract<keyof I, keyof TodoSelected<S>>> & TodoIncludedRelations<I>;
+export type TodoSelectedWithIncludes<
+  I extends TodoInclude = {},
+  S extends TodoSelectableColumn = keyof Todo,
+> = Omit<TodoSelected<S>, Extract<keyof I, keyof TodoSelected<S>>> & TodoIncludedRelations<I>;
 
 export const wasmSchema: WasmSchema = {
-  "projects": {
-    "columns": [
+  projects: {
+    columns: [
       {
-        "name": "name",
-        "column_type": {
-          "type": "Text"
+        name: "name",
+        column_type: {
+          type: "Text",
         },
-        "nullable": false
-      }
-    ]
-  },
-  "todos": {
-    "columns": [
-      {
-        "name": "title",
-        "column_type": {
-          "type": "Text"
-        },
-        "nullable": false
+        nullable: false,
       },
-      {
-        "name": "done",
-        "column_type": {
-          "type": "Boolean"
-        },
-        "nullable": false
-      },
-      {
-        "name": "description",
-        "column_type": {
-          "type": "Text"
-        },
-        "nullable": true
-      },
-      {
-        "name": "parent",
-        "column_type": {
-          "type": "Uuid"
-        },
-        "nullable": true,
-        "references": "todos"
-      },
-      {
-        "name": "project",
-        "column_type": {
-          "type": "Uuid"
-        },
-        "nullable": true,
-        "references": "projects"
-      },
-      {
-        "name": "owner_id",
-        "column_type": {
-          "type": "Text"
-        },
-        "nullable": false
-      }
     ],
-    "policies": {
-      "select": {
-        "using": {
-          "type": "Cmp",
-          "column": "owner_id",
-          "op": "Eq",
-          "value": {
-            "type": "SessionRef",
-            "path": [
-              "user_id"
-            ]
-          }
-        }
-      },
-      "insert": {
-        "with_check": {
-          "type": "Cmp",
-          "column": "owner_id",
-          "op": "Eq",
-          "value": {
-            "type": "SessionRef",
-            "path": [
-              "user_id"
-            ]
-          }
-        }
-      },
-      "update": {
-        "using": {
-          "type": "Cmp",
-          "column": "owner_id",
-          "op": "Eq",
-          "value": {
-            "type": "SessionRef",
-            "path": [
-              "user_id"
-            ]
-          }
+  },
+  todos: {
+    columns: [
+      {
+        name: "title",
+        column_type: {
+          type: "Text",
         },
-        "with_check": {
-          "type": "Cmp",
-          "column": "owner_id",
-          "op": "Eq",
-          "value": {
-            "type": "SessionRef",
-            "path": [
-              "user_id"
-            ]
-          }
-        }
+        nullable: false,
       },
-      "delete": {
-        "using": {
-          "type": "Cmp",
-          "column": "owner_id",
-          "op": "Eq",
-          "value": {
-            "type": "SessionRef",
-            "path": [
-              "user_id"
-            ]
-          }
-        }
-      }
-    }
-  }
+      {
+        name: "done",
+        column_type: {
+          type: "Boolean",
+        },
+        nullable: false,
+      },
+      {
+        name: "description",
+        column_type: {
+          type: "Text",
+        },
+        nullable: true,
+      },
+      {
+        name: "parent",
+        column_type: {
+          type: "Uuid",
+        },
+        nullable: true,
+        references: "todos",
+      },
+      {
+        name: "project",
+        column_type: {
+          type: "Uuid",
+        },
+        nullable: true,
+        references: "projects",
+      },
+      {
+        name: "owner_id",
+        column_type: {
+          type: "Text",
+        },
+        nullable: false,
+      },
+    ],
+    policies: {
+      select: {
+        using: {
+          type: "Cmp",
+          column: "owner_id",
+          op: "Eq",
+          value: {
+            type: "SessionRef",
+            path: ["user_id"],
+          },
+        },
+      },
+      insert: {
+        with_check: {
+          type: "Cmp",
+          column: "owner_id",
+          op: "Eq",
+          value: {
+            type: "SessionRef",
+            path: ["user_id"],
+          },
+        },
+      },
+      update: {
+        using: {
+          type: "Cmp",
+          column: "owner_id",
+          op: "Eq",
+          value: {
+            type: "SessionRef",
+            path: ["user_id"],
+          },
+        },
+        with_check: {
+          type: "Cmp",
+          column: "owner_id",
+          op: "Eq",
+          value: {
+            type: "SessionRef",
+            path: ["user_id"],
+          },
+        },
+      },
+      delete: {
+        using: {
+          type: "Cmp",
+          column: "owner_id",
+          op: "Eq",
+          value: {
+            type: "SessionRef",
+            path: ["user_id"],
+          },
+        },
+      },
+    },
+  },
 };
 
-export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends ProjectSelectableColumn = keyof Project> implements QueryBuilder<ProjectSelectedWithIncludes<I, S>> {
+export class ProjectQueryBuilder<
+  I extends ProjectInclude = {},
+  S extends ProjectSelectableColumn = keyof Project,
+> implements QueryBuilder<ProjectSelectedWithIncludes<I, S>> {
   readonly _table = "projects";
   readonly _schema: WasmSchema = wasmSchema;
   readonly _rowType!: ProjectSelectedWithIncludes<I, S>;
@@ -313,7 +331,9 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
     return clone;
   }
 
-  select<NewS extends ProjectSelectableColumn>(...columns: [NewS, ...NewS[]]): ProjectQueryBuilder<I, NewS> {
+  select<NewS extends ProjectSelectableColumn>(
+    ...columns: [NewS, ...NewS[]]
+  ): ProjectQueryBuilder<I, NewS> {
     const clone = this._clone<I, NewS>();
     clone._selectColumns = [...columns] as string[];
     return clone;
@@ -325,7 +345,10 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
     return clone;
   }
 
-  orderBy(column: ProjectOrderableColumn, direction: "asc" | "desc" = "asc"): ProjectQueryBuilder<I, S> {
+  orderBy(
+    column: ProjectOrderableColumn,
+    direction: "asc" | "desc" = "asc",
+  ): ProjectQueryBuilder<I, S> {
     const clone = this._clone();
     clone._orderBys.push([column as string, direction]);
     return clone;
@@ -374,13 +397,15 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
 
     const currentToken = "__jazz_gather_current__";
     const stepOutput = options.step({ current: currentToken });
-    if (!stepOutput || typeof stepOutput !== "object" || typeof (stepOutput as { _build?: unknown })._build !== "function") {
+    if (
+      !stepOutput ||
+      typeof stepOutput !== "object" ||
+      typeof (stepOutput as { _build?: unknown })._build !== "function"
+    ) {
       throw new Error("gather(...) step must return a query expression built from app.<table>.");
     }
 
-    const stepBuilt = JSON.parse(
-      stepOutput._build(),
-    ) as {
+    const stepBuilt = JSON.parse(stepOutput._build()) as {
       table?: unknown;
       conditions?: Array<{ column: string; op: string; value: unknown }>;
       hops?: unknown;
@@ -404,7 +429,9 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
       (condition) => condition.op === "eq" && condition.value === currentToken,
     );
     if (currentConditions.length !== 1) {
-      throw new Error("gather(...) step must include exactly one where condition bound to current.");
+      throw new Error(
+        "gather(...) step must include exactly one where condition bound to current.",
+      );
     }
 
     const currentCondition = currentConditions[0];
@@ -444,7 +471,10 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
     return JSON.parse(this._build());
   }
 
-  private _clone<CloneI extends ProjectInclude = I, CloneS extends ProjectSelectableColumn = S>(): ProjectQueryBuilder<CloneI, CloneS> {
+  private _clone<
+    CloneI extends ProjectInclude = I,
+    CloneS extends ProjectSelectableColumn = S,
+  >(): ProjectQueryBuilder<CloneI, CloneS> {
     const clone = new ProjectQueryBuilder<CloneI, CloneS>();
     clone._conditions = [...this._conditions];
     clone._includes = { ...this._includes };
@@ -464,7 +494,10 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
   }
 }
 
-export class TodoQueryBuilder<I extends TodoInclude = {}, S extends TodoSelectableColumn = keyof Todo> implements QueryBuilder<TodoSelectedWithIncludes<I, S>> {
+export class TodoQueryBuilder<
+  I extends TodoInclude = {},
+  S extends TodoSelectableColumn = keyof Todo,
+> implements QueryBuilder<TodoSelectedWithIncludes<I, S>> {
   readonly _table = "todos";
   readonly _schema: WasmSchema = wasmSchema;
   readonly _rowType!: TodoSelectedWithIncludes<I, S>;
@@ -501,7 +534,9 @@ export class TodoQueryBuilder<I extends TodoInclude = {}, S extends TodoSelectab
     return clone;
   }
 
-  select<NewS extends TodoSelectableColumn>(...columns: [NewS, ...NewS[]]): TodoQueryBuilder<I, NewS> {
+  select<NewS extends TodoSelectableColumn>(
+    ...columns: [NewS, ...NewS[]]
+  ): TodoQueryBuilder<I, NewS> {
     const clone = this._clone<I, NewS>();
     clone._selectColumns = [...columns] as string[];
     return clone;
@@ -562,13 +597,15 @@ export class TodoQueryBuilder<I extends TodoInclude = {}, S extends TodoSelectab
 
     const currentToken = "__jazz_gather_current__";
     const stepOutput = options.step({ current: currentToken });
-    if (!stepOutput || typeof stepOutput !== "object" || typeof (stepOutput as { _build?: unknown })._build !== "function") {
+    if (
+      !stepOutput ||
+      typeof stepOutput !== "object" ||
+      typeof (stepOutput as { _build?: unknown })._build !== "function"
+    ) {
       throw new Error("gather(...) step must return a query expression built from app.<table>.");
     }
 
-    const stepBuilt = JSON.parse(
-      stepOutput._build(),
-    ) as {
+    const stepBuilt = JSON.parse(stepOutput._build()) as {
       table?: unknown;
       conditions?: Array<{ column: string; op: string; value: unknown }>;
       hops?: unknown;
@@ -592,7 +629,9 @@ export class TodoQueryBuilder<I extends TodoInclude = {}, S extends TodoSelectab
       (condition) => condition.op === "eq" && condition.value === currentToken,
     );
     if (currentConditions.length !== 1) {
-      throw new Error("gather(...) step must include exactly one where condition bound to current.");
+      throw new Error(
+        "gather(...) step must include exactly one where condition bound to current.",
+      );
     }
 
     const currentCondition = currentConditions[0];
@@ -632,7 +671,10 @@ export class TodoQueryBuilder<I extends TodoInclude = {}, S extends TodoSelectab
     return JSON.parse(this._build());
   }
 
-  private _clone<CloneI extends TodoInclude = I, CloneS extends TodoSelectableColumn = S>(): TodoQueryBuilder<CloneI, CloneS> {
+  private _clone<
+    CloneI extends TodoInclude = I,
+    CloneS extends TodoSelectableColumn = S,
+  >(): TodoQueryBuilder<CloneI, CloneS> {
     const clone = new TodoQueryBuilder<CloneI, CloneS>();
     clone._conditions = [...this._conditions];
     clone._includes = { ...this._includes };

--- a/examples/docs/todo-server-ts/schema/app.ts
+++ b/examples/docs/todo-server-ts/schema/app.ts
@@ -1,12 +1,13 @@
 // AUTO-GENERATED FILE - DO NOT EDIT
 import type { WasmSchema, QueryBuilder } from "jazz-tools";
-export type JsonValue =
-  | string
-  | number
-  | boolean
-  | null
-  | { [key: string]: JsonValue }
-  | JsonValue[];
+export type JsonValue = string | number | boolean | null | { [key: string]: JsonValue } | JsonValue[];
+
+export type PermissionIntrospectionColumn = "$canRead" | "$canEdit" | "$canDelete";
+export interface PermissionIntrospectionColumns {
+  $canRead: boolean | null;
+  $canEdit: boolean | null;
+  $canDelete: boolean | null;
+}
 
 export interface Project {
   id: string;
@@ -39,6 +40,9 @@ export interface TodoInit {
 export interface ProjectWhereInput {
   id?: string | { eq?: string; ne?: string; in?: string[] };
   name?: string | { eq?: string; ne?: string; contains?: string };
+  $canRead?: boolean;
+  $canEdit?: boolean;
+  $canDelete?: boolean;
 }
 
 export interface TodoWhereInput {
@@ -49,17 +53,73 @@ export interface TodoWhereInput {
   parent?: string | { eq?: string; ne?: string; isNull?: boolean };
   project?: string | { eq?: string; ne?: string; isNull?: boolean };
   owner_id?: string | { eq?: string; ne?: string; contains?: string };
+  $canRead?: boolean;
+  $canEdit?: boolean;
+  $canDelete?: boolean;
 }
 
+type AnyProjectQueryBuilder<T = any> = { readonly _table: "projects" } & QueryBuilder<T>;
+type AnyTodoQueryBuilder<T = any> = { readonly _table: "todos" } & QueryBuilder<T>;
+
 export interface ProjectInclude {
-  todosViaProject?: true | TodoInclude | TodoQueryBuilder;
+  todosViaProject?: true | TodoInclude | AnyTodoQueryBuilder<any>;
 }
 
 export interface TodoInclude {
-  parent?: true | TodoInclude | TodoQueryBuilder;
-  todosViaParent?: true | TodoInclude | TodoQueryBuilder;
-  project?: true | ProjectInclude | ProjectQueryBuilder;
+  parent?: true | TodoInclude | AnyTodoQueryBuilder<any>;
+  todosViaParent?: true | TodoInclude | AnyTodoQueryBuilder<any>;
+  project?: true | ProjectInclude | AnyProjectQueryBuilder<any>;
 }
+
+export type ProjectIncludedRelations<I extends ProjectInclude = {}> = {
+  [K in keyof I]-?:
+    K extends "todosViaProject"
+      ? NonNullable<I["todosViaProject"]> extends infer RelationInclude
+        ? RelationInclude extends true
+          ? Todo[]
+          : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
+            ? QueryRow[]
+            : RelationInclude extends TodoInclude
+              ? TodoWithIncludes<RelationInclude>[]
+              : never
+        : never
+    : never;
+};
+
+export type TodoIncludedRelations<I extends TodoInclude = {}> = {
+  [K in keyof I]-?:
+    K extends "parent"
+      ? NonNullable<I["parent"]> extends infer RelationInclude
+        ? RelationInclude extends true
+          ? Todo | undefined
+          : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
+            ? QueryRow | undefined
+            : RelationInclude extends TodoInclude
+              ? TodoWithIncludes<RelationInclude> | undefined
+              : never
+        : never
+    : K extends "todosViaParent"
+      ? NonNullable<I["todosViaParent"]> extends infer RelationInclude
+        ? RelationInclude extends true
+          ? Todo[]
+          : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
+            ? QueryRow[]
+            : RelationInclude extends TodoInclude
+              ? TodoWithIncludes<RelationInclude>[]
+              : never
+        : never
+    : K extends "project"
+      ? NonNullable<I["project"]> extends infer RelationInclude
+        ? RelationInclude extends true
+          ? Project | undefined
+          : RelationInclude extends AnyProjectQueryBuilder<infer QueryRow>
+            ? QueryRow | undefined
+            : RelationInclude extends ProjectInclude
+              ? ProjectWithIncludes<RelationInclude> | undefined
+              : never
+        : never
+    : never;
+};
 
 export interface ProjectRelations {
   todosViaProject: Todo[];
@@ -71,174 +131,159 @@ export interface TodoRelations {
   project: Project;
 }
 
-export type ProjectWithIncludes<I extends ProjectInclude = {}> = Project & {
-  todosViaProject?: NonNullable<I["todosViaProject"]> extends infer RelationInclude
-    ? RelationInclude extends true
-      ? Todo[]
-      : RelationInclude extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
-        ? TodoWithIncludes<QueryInclude>[]
-        : RelationInclude extends TodoInclude
-          ? TodoWithIncludes<RelationInclude>[]
-          : never
-    : never;
-};
+export type ProjectWithIncludes<I extends ProjectInclude = {}> = Omit<Project, Extract<keyof I, keyof Project>> & ProjectIncludedRelations<I>;
 
-export type TodoWithIncludes<I extends TodoInclude = {}> = Todo & {
-  parent?: NonNullable<I["parent"]> extends infer RelationInclude
-    ? RelationInclude extends true
-      ? Todo
-      : RelationInclude extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
-        ? TodoWithIncludes<QueryInclude>
-        : RelationInclude extends TodoInclude
-          ? TodoWithIncludes<RelationInclude>
-          : never
-    : never;
-  todosViaParent?: NonNullable<I["todosViaParent"]> extends infer RelationInclude
-    ? RelationInclude extends true
-      ? Todo[]
-      : RelationInclude extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
-        ? TodoWithIncludes<QueryInclude>[]
-        : RelationInclude extends TodoInclude
-          ? TodoWithIncludes<RelationInclude>[]
-          : never
-    : never;
-  project?: NonNullable<I["project"]> extends infer RelationInclude
-    ? RelationInclude extends true
-      ? Project
-      : RelationInclude extends ProjectQueryBuilder<infer QueryInclude extends ProjectInclude>
-        ? ProjectWithIncludes<QueryInclude>
-        : RelationInclude extends ProjectInclude
-          ? ProjectWithIncludes<RelationInclude>
-          : never
-    : never;
-};
+export type TodoWithIncludes<I extends TodoInclude = {}> = Omit<Todo, Extract<keyof I, keyof Todo>> & TodoIncludedRelations<I>;
+
+export type ProjectSelectableColumn = keyof Project | PermissionIntrospectionColumn | "*";
+export type ProjectOrderableColumn = keyof Project | PermissionIntrospectionColumn;
+
+export type ProjectSelected<S extends ProjectSelectableColumn = keyof Project> = "*" extends S ? Project : Pick<Project, Extract<S | "id", keyof Project>> & Pick<PermissionIntrospectionColumns, Extract<S, PermissionIntrospectionColumn>>;
+
+export type ProjectSelectedWithIncludes<I extends ProjectInclude = {}, S extends ProjectSelectableColumn = keyof Project> = Omit<ProjectSelected<S>, Extract<keyof I, keyof ProjectSelected<S>>> & ProjectIncludedRelations<I>;
+
+export type TodoSelectableColumn = keyof Todo | PermissionIntrospectionColumn | "*";
+export type TodoOrderableColumn = keyof Todo | PermissionIntrospectionColumn;
+
+export type TodoSelected<S extends TodoSelectableColumn = keyof Todo> = "*" extends S ? Todo : Pick<Todo, Extract<S | "id", keyof Todo>> & Pick<PermissionIntrospectionColumns, Extract<S, PermissionIntrospectionColumn>>;
+
+export type TodoSelectedWithIncludes<I extends TodoInclude = {}, S extends TodoSelectableColumn = keyof Todo> = Omit<TodoSelected<S>, Extract<keyof I, keyof TodoSelected<S>>> & TodoIncludedRelations<I>;
 
 export const wasmSchema: WasmSchema = {
-  projects: {
-    columns: [
+  "projects": {
+    "columns": [
       {
-        name: "name",
-        column_type: {
-          type: "Text",
+        "name": "name",
+        "column_type": {
+          "type": "Text"
         },
-        nullable: false,
-      },
-    ],
+        "nullable": false
+      }
+    ]
   },
-  todos: {
-    columns: [
+  "todos": {
+    "columns": [
       {
-        name: "title",
-        column_type: {
-          type: "Text",
+        "name": "title",
+        "column_type": {
+          "type": "Text"
         },
-        nullable: false,
+        "nullable": false
       },
       {
-        name: "done",
-        column_type: {
-          type: "Boolean",
+        "name": "done",
+        "column_type": {
+          "type": "Boolean"
         },
-        nullable: false,
+        "nullable": false
       },
       {
-        name: "description",
-        column_type: {
-          type: "Text",
+        "name": "description",
+        "column_type": {
+          "type": "Text"
         },
-        nullable: true,
+        "nullable": true
       },
       {
-        name: "parent",
-        column_type: {
-          type: "Uuid",
+        "name": "parent",
+        "column_type": {
+          "type": "Uuid"
         },
-        nullable: true,
-        references: "todos",
+        "nullable": true,
+        "references": "todos"
       },
       {
-        name: "project",
-        column_type: {
-          type: "Uuid",
+        "name": "project",
+        "column_type": {
+          "type": "Uuid"
         },
-        nullable: true,
-        references: "projects",
+        "nullable": true,
+        "references": "projects"
       },
       {
-        name: "owner_id",
-        column_type: {
-          type: "Text",
+        "name": "owner_id",
+        "column_type": {
+          "type": "Text"
         },
-        nullable: false,
-      },
+        "nullable": false
+      }
     ],
-    policies: {
-      select: {
-        using: {
-          type: "Cmp",
-          column: "owner_id",
-          op: "Eq",
-          value: {
-            type: "SessionRef",
-            path: ["user_id"],
-          },
-        },
+    "policies": {
+      "select": {
+        "using": {
+          "type": "Cmp",
+          "column": "owner_id",
+          "op": "Eq",
+          "value": {
+            "type": "SessionRef",
+            "path": [
+              "user_id"
+            ]
+          }
+        }
       },
-      insert: {
-        with_check: {
-          type: "Cmp",
-          column: "owner_id",
-          op: "Eq",
-          value: {
-            type: "SessionRef",
-            path: ["user_id"],
-          },
-        },
+      "insert": {
+        "with_check": {
+          "type": "Cmp",
+          "column": "owner_id",
+          "op": "Eq",
+          "value": {
+            "type": "SessionRef",
+            "path": [
+              "user_id"
+            ]
+          }
+        }
       },
-      update: {
-        using: {
-          type: "Cmp",
-          column: "owner_id",
-          op: "Eq",
-          value: {
-            type: "SessionRef",
-            path: ["user_id"],
-          },
+      "update": {
+        "using": {
+          "type": "Cmp",
+          "column": "owner_id",
+          "op": "Eq",
+          "value": {
+            "type": "SessionRef",
+            "path": [
+              "user_id"
+            ]
+          }
         },
-        with_check: {
-          type: "Cmp",
-          column: "owner_id",
-          op: "Eq",
-          value: {
-            type: "SessionRef",
-            path: ["user_id"],
-          },
-        },
+        "with_check": {
+          "type": "Cmp",
+          "column": "owner_id",
+          "op": "Eq",
+          "value": {
+            "type": "SessionRef",
+            "path": [
+              "user_id"
+            ]
+          }
+        }
       },
-      delete: {
-        using: {
-          type: "Cmp",
-          column: "owner_id",
-          op: "Eq",
-          value: {
-            type: "SessionRef",
-            path: ["user_id"],
-          },
-        },
-      },
-    },
-  },
+      "delete": {
+        "using": {
+          "type": "Cmp",
+          "column": "owner_id",
+          "op": "Eq",
+          "value": {
+            "type": "SessionRef",
+            "path": [
+              "user_id"
+            ]
+          }
+        }
+      }
+    }
+  }
 };
 
-export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements QueryBuilder<
-  ProjectWithIncludes<I>
-> {
+export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends ProjectSelectableColumn = keyof Project> implements QueryBuilder<ProjectSelectedWithIncludes<I, S>> {
   readonly _table = "projects";
   readonly _schema: WasmSchema = wasmSchema;
-  declare readonly _rowType: ProjectWithIncludes<I>;
-  declare readonly _initType: ProjectInit;
+  readonly _rowType!: ProjectSelectedWithIncludes<I, S>;
+  readonly _initType!: ProjectInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<ProjectInclude> = {};
+  private _selectColumns?: string[];
   private _orderBys: Array<[string, "asc" | "desc"]> = [];
   private _limitVal?: number;
   private _offsetVal?: number;
@@ -251,7 +296,7 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
     step_hops: string[];
   };
 
-  where(conditions: ProjectWhereInput): ProjectQueryBuilder<I> {
+  where(conditions: ProjectWhereInput): ProjectQueryBuilder<I, S> {
     const clone = this._clone();
     for (const [key, value] of Object.entries(conditions)) {
       if (value === undefined) continue;
@@ -268,31 +313,37 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
     return clone;
   }
 
-  include<NewI extends ProjectInclude>(relations: NewI): ProjectQueryBuilder<I & NewI> {
-    const clone = this._clone<I & NewI>();
+  select<NewS extends ProjectSelectableColumn>(...columns: [NewS, ...NewS[]]): ProjectQueryBuilder<I, NewS> {
+    const clone = this._clone<I, NewS>();
+    clone._selectColumns = [...columns] as string[];
+    return clone;
+  }
+
+  include<NewI extends ProjectInclude>(relations: NewI): ProjectQueryBuilder<I & NewI, S> {
+    const clone = this._clone<I & NewI, S>();
     clone._includes = { ...this._includes, ...relations };
     return clone;
   }
 
-  orderBy(column: keyof Project, direction: "asc" | "desc" = "asc"): ProjectQueryBuilder<I> {
+  orderBy(column: ProjectOrderableColumn, direction: "asc" | "desc" = "asc"): ProjectQueryBuilder<I, S> {
     const clone = this._clone();
     clone._orderBys.push([column as string, direction]);
     return clone;
   }
 
-  limit(n: number): ProjectQueryBuilder<I> {
+  limit(n: number): ProjectQueryBuilder<I, S> {
     const clone = this._clone();
     clone._limitVal = n;
     return clone;
   }
 
-  offset(n: number): ProjectQueryBuilder<I> {
+  offset(n: number): ProjectQueryBuilder<I, S> {
     const clone = this._clone();
     clone._offsetVal = n;
     return clone;
   }
 
-  hopTo(relation: "todosViaProject"): ProjectQueryBuilder<I> {
+  hopTo(relation: "todosViaProject"): ProjectQueryBuilder<I, S> {
     const clone = this._clone();
     clone._hops.push(relation);
     return clone;
@@ -302,7 +353,7 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
     start: ProjectWhereInput;
     step: (ctx: { current: string }) => QueryBuilder<unknown>;
     maxDepth?: number;
-  }): ProjectQueryBuilder<I> {
+  }): ProjectQueryBuilder<I, S> {
     if (options.start === undefined) {
       throw new Error("gather(...) requires start where conditions.");
     }
@@ -323,15 +374,13 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
 
     const currentToken = "__jazz_gather_current__";
     const stepOutput = options.step({ current: currentToken });
-    if (
-      !stepOutput ||
-      typeof stepOutput !== "object" ||
-      typeof (stepOutput as { _build?: unknown })._build !== "function"
-    ) {
+    if (!stepOutput || typeof stepOutput !== "object" || typeof (stepOutput as { _build?: unknown })._build !== "function") {
       throw new Error("gather(...) step must return a query expression built from app.<table>.");
     }
 
-    const stepBuilt = JSON.parse(stepOutput._build()) as {
+    const stepBuilt = JSON.parse(
+      stepOutput._build(),
+    ) as {
       table?: unknown;
       conditions?: Array<{ column: string; op: string; value: unknown }>;
       hops?: unknown;
@@ -355,9 +404,7 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
       (condition) => condition.op === "eq" && condition.value === currentToken,
     );
     if (currentConditions.length !== 1) {
-      throw new Error(
-        "gather(...) step must include exactly one where condition bound to current.",
-      );
+      throw new Error("gather(...) step must include exactly one where condition bound to current.");
     }
 
     const currentCondition = currentConditions[0];
@@ -384,6 +431,7 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
       table: this._table,
       conditions: this._conditions,
       includes: this._includes,
+      select: this._selectColumns,
       orderBy: this._orderBys,
       limit: this._limitVal,
       offset: this._offsetVal,
@@ -392,10 +440,15 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
     });
   }
 
-  private _clone<CloneI extends ProjectInclude = I>(): ProjectQueryBuilder<CloneI> {
-    const clone = new ProjectQueryBuilder<CloneI>();
+  toJSON(): unknown {
+    return JSON.parse(this._build());
+  }
+
+  private _clone<CloneI extends ProjectInclude = I, CloneS extends ProjectSelectableColumn = S>(): ProjectQueryBuilder<CloneI, CloneS> {
+    const clone = new ProjectQueryBuilder<CloneI, CloneS>();
     clone._conditions = [...this._conditions];
     clone._includes = { ...this._includes };
+    clone._selectColumns = this._selectColumns ? [...this._selectColumns] : undefined;
     clone._orderBys = [...this._orderBys];
     clone._limitVal = this._limitVal;
     clone._offsetVal = this._offsetVal;
@@ -411,15 +464,14 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
   }
 }
 
-export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilder<
-  TodoWithIncludes<I>
-> {
+export class TodoQueryBuilder<I extends TodoInclude = {}, S extends TodoSelectableColumn = keyof Todo> implements QueryBuilder<TodoSelectedWithIncludes<I, S>> {
   readonly _table = "todos";
   readonly _schema: WasmSchema = wasmSchema;
-  declare readonly _rowType: TodoWithIncludes<I>;
-  declare readonly _initType: TodoInit;
+  readonly _rowType!: TodoSelectedWithIncludes<I, S>;
+  readonly _initType!: TodoInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<TodoInclude> = {};
+  private _selectColumns?: string[];
   private _orderBys: Array<[string, "asc" | "desc"]> = [];
   private _limitVal?: number;
   private _offsetVal?: number;
@@ -432,7 +484,7 @@ export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilde
     step_hops: string[];
   };
 
-  where(conditions: TodoWhereInput): TodoQueryBuilder<I> {
+  where(conditions: TodoWhereInput): TodoQueryBuilder<I, S> {
     const clone = this._clone();
     for (const [key, value] of Object.entries(conditions)) {
       if (value === undefined) continue;
@@ -449,31 +501,37 @@ export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilde
     return clone;
   }
 
-  include<NewI extends TodoInclude>(relations: NewI): TodoQueryBuilder<I & NewI> {
-    const clone = this._clone<I & NewI>();
+  select<NewS extends TodoSelectableColumn>(...columns: [NewS, ...NewS[]]): TodoQueryBuilder<I, NewS> {
+    const clone = this._clone<I, NewS>();
+    clone._selectColumns = [...columns] as string[];
+    return clone;
+  }
+
+  include<NewI extends TodoInclude>(relations: NewI): TodoQueryBuilder<I & NewI, S> {
+    const clone = this._clone<I & NewI, S>();
     clone._includes = { ...this._includes, ...relations };
     return clone;
   }
 
-  orderBy(column: keyof Todo, direction: "asc" | "desc" = "asc"): TodoQueryBuilder<I> {
+  orderBy(column: TodoOrderableColumn, direction: "asc" | "desc" = "asc"): TodoQueryBuilder<I, S> {
     const clone = this._clone();
     clone._orderBys.push([column as string, direction]);
     return clone;
   }
 
-  limit(n: number): TodoQueryBuilder<I> {
+  limit(n: number): TodoQueryBuilder<I, S> {
     const clone = this._clone();
     clone._limitVal = n;
     return clone;
   }
 
-  offset(n: number): TodoQueryBuilder<I> {
+  offset(n: number): TodoQueryBuilder<I, S> {
     const clone = this._clone();
     clone._offsetVal = n;
     return clone;
   }
 
-  hopTo(relation: "parent" | "todosViaParent" | "project"): TodoQueryBuilder<I> {
+  hopTo(relation: "parent" | "todosViaParent" | "project"): TodoQueryBuilder<I, S> {
     const clone = this._clone();
     clone._hops.push(relation);
     return clone;
@@ -483,7 +541,7 @@ export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilde
     start: TodoWhereInput;
     step: (ctx: { current: string }) => QueryBuilder<unknown>;
     maxDepth?: number;
-  }): TodoQueryBuilder<I> {
+  }): TodoQueryBuilder<I, S> {
     if (options.start === undefined) {
       throw new Error("gather(...) requires start where conditions.");
     }
@@ -504,15 +562,13 @@ export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilde
 
     const currentToken = "__jazz_gather_current__";
     const stepOutput = options.step({ current: currentToken });
-    if (
-      !stepOutput ||
-      typeof stepOutput !== "object" ||
-      typeof (stepOutput as { _build?: unknown })._build !== "function"
-    ) {
+    if (!stepOutput || typeof stepOutput !== "object" || typeof (stepOutput as { _build?: unknown })._build !== "function") {
       throw new Error("gather(...) step must return a query expression built from app.<table>.");
     }
 
-    const stepBuilt = JSON.parse(stepOutput._build()) as {
+    const stepBuilt = JSON.parse(
+      stepOutput._build(),
+    ) as {
       table?: unknown;
       conditions?: Array<{ column: string; op: string; value: unknown }>;
       hops?: unknown;
@@ -536,9 +592,7 @@ export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilde
       (condition) => condition.op === "eq" && condition.value === currentToken,
     );
     if (currentConditions.length !== 1) {
-      throw new Error(
-        "gather(...) step must include exactly one where condition bound to current.",
-      );
+      throw new Error("gather(...) step must include exactly one where condition bound to current.");
     }
 
     const currentCondition = currentConditions[0];
@@ -565,6 +619,7 @@ export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilde
       table: this._table,
       conditions: this._conditions,
       includes: this._includes,
+      select: this._selectColumns,
       orderBy: this._orderBys,
       limit: this._limitVal,
       offset: this._offsetVal,
@@ -573,10 +628,15 @@ export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilde
     });
   }
 
-  private _clone<CloneI extends TodoInclude = I>(): TodoQueryBuilder<CloneI> {
-    const clone = new TodoQueryBuilder<CloneI>();
+  toJSON(): unknown {
+    return JSON.parse(this._build());
+  }
+
+  private _clone<CloneI extends TodoInclude = I, CloneS extends TodoSelectableColumn = S>(): TodoQueryBuilder<CloneI, CloneS> {
+    const clone = new TodoQueryBuilder<CloneI, CloneS>();
     clone._conditions = [...this._conditions];
     clone._includes = { ...this._includes };
+    clone._selectColumns = this._selectColumns ? [...this._selectColumns] : undefined;
     clone._orderBys = [...this._orderBys];
     clone._limitVal = this._limitVal;
     clone._offsetVal = this._offsetVal;

--- a/examples/todo-client-localfirst-expo/schema/app.ts
+++ b/examples/todo-client-localfirst-expo/schema/app.ts
@@ -1,12 +1,13 @@
 // AUTO-GENERATED FILE - DO NOT EDIT
 import type { WasmSchema, QueryBuilder } from "jazz-tools";
-export type JsonValue =
-  | string
-  | number
-  | boolean
-  | null
-  | { [key: string]: JsonValue }
-  | JsonValue[];
+export type JsonValue = string | number | boolean | null | { [key: string]: JsonValue } | JsonValue[];
+
+export type PermissionIntrospectionColumn = "$canRead" | "$canEdit" | "$canDelete";
+export interface PermissionIntrospectionColumns {
+  $canRead: boolean | null;
+  $canEdit: boolean | null;
+  $canDelete: boolean | null;
+}
 
 export interface Project {
   id: string;
@@ -39,6 +40,9 @@ export interface TodoInit {
 export interface ProjectWhereInput {
   id?: string | { eq?: string; ne?: string; in?: string[] };
   name?: string | { eq?: string; ne?: string; contains?: string };
+  $canRead?: boolean;
+  $canEdit?: boolean;
+  $canDelete?: boolean;
 }
 
 export interface TodoWhereInput {
@@ -49,17 +53,73 @@ export interface TodoWhereInput {
   owner_id?: string | { eq?: string; ne?: string; contains?: string };
   parent?: string | { eq?: string; ne?: string; isNull?: boolean };
   project?: string | { eq?: string; ne?: string; isNull?: boolean };
+  $canRead?: boolean;
+  $canEdit?: boolean;
+  $canDelete?: boolean;
 }
 
+type AnyProjectQueryBuilder<T = any> = { readonly _table: "projects" } & QueryBuilder<T>;
+type AnyTodoQueryBuilder<T = any> = { readonly _table: "todos" } & QueryBuilder<T>;
+
 export interface ProjectInclude {
-  todosViaProject?: true | TodoInclude | TodoQueryBuilder;
+  todosViaProject?: true | TodoInclude | AnyTodoQueryBuilder<any>;
 }
 
 export interface TodoInclude {
-  parent?: true | TodoInclude | TodoQueryBuilder;
-  todosViaParent?: true | TodoInclude | TodoQueryBuilder;
-  project?: true | ProjectInclude | ProjectQueryBuilder;
+  parent?: true | TodoInclude | AnyTodoQueryBuilder<any>;
+  todosViaParent?: true | TodoInclude | AnyTodoQueryBuilder<any>;
+  project?: true | ProjectInclude | AnyProjectQueryBuilder<any>;
 }
+
+export type ProjectIncludedRelations<I extends ProjectInclude = {}> = {
+  [K in keyof I]-?:
+    K extends "todosViaProject"
+      ? NonNullable<I["todosViaProject"]> extends infer RelationInclude
+        ? RelationInclude extends true
+          ? Todo[]
+          : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
+            ? QueryRow[]
+            : RelationInclude extends TodoInclude
+              ? TodoWithIncludes<RelationInclude>[]
+              : never
+        : never
+    : never;
+};
+
+export type TodoIncludedRelations<I extends TodoInclude = {}> = {
+  [K in keyof I]-?:
+    K extends "parent"
+      ? NonNullable<I["parent"]> extends infer RelationInclude
+        ? RelationInclude extends true
+          ? Todo | undefined
+          : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
+            ? QueryRow | undefined
+            : RelationInclude extends TodoInclude
+              ? TodoWithIncludes<RelationInclude> | undefined
+              : never
+        : never
+    : K extends "todosViaParent"
+      ? NonNullable<I["todosViaParent"]> extends infer RelationInclude
+        ? RelationInclude extends true
+          ? Todo[]
+          : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
+            ? QueryRow[]
+            : RelationInclude extends TodoInclude
+              ? TodoWithIncludes<RelationInclude>[]
+              : never
+        : never
+    : K extends "project"
+      ? NonNullable<I["project"]> extends infer RelationInclude
+        ? RelationInclude extends true
+          ? Project | undefined
+          : RelationInclude extends AnyProjectQueryBuilder<infer QueryRow>
+            ? QueryRow | undefined
+            : RelationInclude extends ProjectInclude
+              ? ProjectWithIncludes<RelationInclude> | undefined
+              : never
+        : never
+    : never;
+};
 
 export interface ProjectRelations {
   todosViaProject: Todo[];
@@ -71,168 +131,151 @@ export interface TodoRelations {
   project: Project;
 }
 
-export type ProjectWithIncludes<I extends ProjectInclude = {}> = Project & {
-  todosViaProject?: NonNullable<I["todosViaProject"]> extends infer RelationInclude
-    ? RelationInclude extends true
-      ? Todo[]
-      : RelationInclude extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
-        ? TodoWithIncludes<QueryInclude>[]
-        : RelationInclude extends TodoInclude
-          ? TodoWithIncludes<RelationInclude>[]
-          : never
-    : never;
-};
+export type ProjectWithIncludes<I extends ProjectInclude = {}> = Omit<Project, Extract<keyof I, keyof Project>> & ProjectIncludedRelations<I>;
 
-export type TodoWithIncludes<I extends TodoInclude = {}> = Todo & {
-  parent?: NonNullable<I["parent"]> extends infer RelationInclude
-    ? RelationInclude extends true
-      ? Todo
-      : RelationInclude extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
-        ? TodoWithIncludes<QueryInclude>
-        : RelationInclude extends TodoInclude
-          ? TodoWithIncludes<RelationInclude>
-          : never
-    : never;
-  todosViaParent?: NonNullable<I["todosViaParent"]> extends infer RelationInclude
-    ? RelationInclude extends true
-      ? Todo[]
-      : RelationInclude extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
-        ? TodoWithIncludes<QueryInclude>[]
-        : RelationInclude extends TodoInclude
-          ? TodoWithIncludes<RelationInclude>[]
-          : never
-    : never;
-  project?: NonNullable<I["project"]> extends infer RelationInclude
-    ? RelationInclude extends true
-      ? Project
-      : RelationInclude extends ProjectQueryBuilder<infer QueryInclude extends ProjectInclude>
-        ? ProjectWithIncludes<QueryInclude>
-        : RelationInclude extends ProjectInclude
-          ? ProjectWithIncludes<RelationInclude>
-          : never
-    : never;
-};
+export type TodoWithIncludes<I extends TodoInclude = {}> = Omit<Todo, Extract<keyof I, keyof Todo>> & TodoIncludedRelations<I>;
+
+export type ProjectSelectableColumn = keyof Project | PermissionIntrospectionColumn | "*";
+export type ProjectOrderableColumn = keyof Project | PermissionIntrospectionColumn;
+
+export type ProjectSelected<S extends ProjectSelectableColumn = keyof Project> = "*" extends S ? Project : Pick<Project, Extract<S | "id", keyof Project>> & Pick<PermissionIntrospectionColumns, Extract<S, PermissionIntrospectionColumn>>;
+
+export type ProjectSelectedWithIncludes<I extends ProjectInclude = {}, S extends ProjectSelectableColumn = keyof Project> = Omit<ProjectSelected<S>, Extract<keyof I, keyof ProjectSelected<S>>> & ProjectIncludedRelations<I>;
+
+export type TodoSelectableColumn = keyof Todo | PermissionIntrospectionColumn | "*";
+export type TodoOrderableColumn = keyof Todo | PermissionIntrospectionColumn;
+
+export type TodoSelected<S extends TodoSelectableColumn = keyof Todo> = "*" extends S ? Todo : Pick<Todo, Extract<S | "id", keyof Todo>> & Pick<PermissionIntrospectionColumns, Extract<S, PermissionIntrospectionColumn>>;
+
+export type TodoSelectedWithIncludes<I extends TodoInclude = {}, S extends TodoSelectableColumn = keyof Todo> = Omit<TodoSelected<S>, Extract<keyof I, keyof TodoSelected<S>>> & TodoIncludedRelations<I>;
 
 export const wasmSchema: WasmSchema = {
-  projects: {
-    columns: [
+  "projects": {
+    "columns": [
       {
-        name: "name",
-        column_type: {
-          type: "Text",
+        "name": "name",
+        "column_type": {
+          "type": "Text"
         },
-        nullable: false,
-      },
-    ],
+        "nullable": false
+      }
+    ]
   },
-  todos: {
-    columns: [
+  "todos": {
+    "columns": [
       {
-        name: "title",
-        column_type: {
-          type: "Text",
+        "name": "title",
+        "column_type": {
+          "type": "Text"
         },
-        nullable: false,
+        "nullable": false
       },
       {
-        name: "done",
-        column_type: {
-          type: "Boolean",
+        "name": "done",
+        "column_type": {
+          "type": "Boolean"
         },
-        nullable: false,
+        "nullable": false
       },
       {
-        name: "description",
-        column_type: {
-          type: "Text",
+        "name": "description",
+        "column_type": {
+          "type": "Text"
         },
-        nullable: true,
+        "nullable": true
       },
       {
-        name: "owner_id",
-        column_type: {
-          type: "Text",
+        "name": "owner_id",
+        "column_type": {
+          "type": "Text"
         },
-        nullable: false,
+        "nullable": false
       },
       {
-        name: "parent",
-        column_type: {
-          type: "Uuid",
+        "name": "parent",
+        "column_type": {
+          "type": "Uuid"
         },
-        nullable: true,
-        references: "todos",
+        "nullable": true,
+        "references": "todos"
       },
       {
-        name: "project",
-        column_type: {
-          type: "Uuid",
+        "name": "project",
+        "column_type": {
+          "type": "Uuid"
         },
-        nullable: true,
-        references: "projects",
-      },
+        "nullable": true,
+        "references": "projects"
+      }
     ],
-    policies: {
-      select: {
-        using: {
-          type: "True",
-        },
+    "policies": {
+      "select": {
+        "using": {
+          "type": "True"
+        }
       },
-      insert: {
-        with_check: {
-          type: "Cmp",
-          column: "owner_id",
-          op: "Eq",
-          value: {
-            type: "SessionRef",
-            path: ["user_id"],
-          },
-        },
+      "insert": {
+        "with_check": {
+          "type": "Cmp",
+          "column": "owner_id",
+          "op": "Eq",
+          "value": {
+            "type": "SessionRef",
+            "path": [
+              "user_id"
+            ]
+          }
+        }
       },
-      update: {
-        using: {
-          type: "Cmp",
-          column: "owner_id",
-          op: "Eq",
-          value: {
-            type: "SessionRef",
-            path: ["user_id"],
-          },
+      "update": {
+        "using": {
+          "type": "Cmp",
+          "column": "owner_id",
+          "op": "Eq",
+          "value": {
+            "type": "SessionRef",
+            "path": [
+              "user_id"
+            ]
+          }
         },
-        with_check: {
-          type: "Cmp",
-          column: "owner_id",
-          op: "Eq",
-          value: {
-            type: "SessionRef",
-            path: ["user_id"],
-          },
-        },
+        "with_check": {
+          "type": "Cmp",
+          "column": "owner_id",
+          "op": "Eq",
+          "value": {
+            "type": "SessionRef",
+            "path": [
+              "user_id"
+            ]
+          }
+        }
       },
-      delete: {
-        using: {
-          type: "Cmp",
-          column: "owner_id",
-          op: "Eq",
-          value: {
-            type: "SessionRef",
-            path: ["user_id"],
-          },
-        },
-      },
-    },
-  },
+      "delete": {
+        "using": {
+          "type": "Cmp",
+          "column": "owner_id",
+          "op": "Eq",
+          "value": {
+            "type": "SessionRef",
+            "path": [
+              "user_id"
+            ]
+          }
+        }
+      }
+    }
+  }
 };
 
-export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements QueryBuilder<
-  ProjectWithIncludes<I>
-> {
+export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends ProjectSelectableColumn = keyof Project> implements QueryBuilder<ProjectSelectedWithIncludes<I, S>> {
   readonly _table = "projects";
   readonly _schema: WasmSchema = wasmSchema;
-  declare readonly _rowType: ProjectWithIncludes<I>;
-  declare readonly _initType: ProjectInit;
+  readonly _rowType!: ProjectSelectedWithIncludes<I, S>;
+  readonly _initType!: ProjectInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<ProjectInclude> = {};
+  private _selectColumns?: string[];
   private _orderBys: Array<[string, "asc" | "desc"]> = [];
   private _limitVal?: number;
   private _offsetVal?: number;
@@ -245,7 +288,7 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
     step_hops: string[];
   };
 
-  where(conditions: ProjectWhereInput): ProjectQueryBuilder<I> {
+  where(conditions: ProjectWhereInput): ProjectQueryBuilder<I, S> {
     const clone = this._clone();
     for (const [key, value] of Object.entries(conditions)) {
       if (value === undefined) continue;
@@ -262,31 +305,37 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
     return clone;
   }
 
-  include<NewI extends ProjectInclude>(relations: NewI): ProjectQueryBuilder<I & NewI> {
-    const clone = this._clone<I & NewI>();
+  select<NewS extends ProjectSelectableColumn>(...columns: [NewS, ...NewS[]]): ProjectQueryBuilder<I, NewS> {
+    const clone = this._clone<I, NewS>();
+    clone._selectColumns = [...columns] as string[];
+    return clone;
+  }
+
+  include<NewI extends ProjectInclude>(relations: NewI): ProjectQueryBuilder<I & NewI, S> {
+    const clone = this._clone<I & NewI, S>();
     clone._includes = { ...this._includes, ...relations };
     return clone;
   }
 
-  orderBy(column: keyof Project, direction: "asc" | "desc" = "asc"): ProjectQueryBuilder<I> {
+  orderBy(column: ProjectOrderableColumn, direction: "asc" | "desc" = "asc"): ProjectQueryBuilder<I, S> {
     const clone = this._clone();
     clone._orderBys.push([column as string, direction]);
     return clone;
   }
 
-  limit(n: number): ProjectQueryBuilder<I> {
+  limit(n: number): ProjectQueryBuilder<I, S> {
     const clone = this._clone();
     clone._limitVal = n;
     return clone;
   }
 
-  offset(n: number): ProjectQueryBuilder<I> {
+  offset(n: number): ProjectQueryBuilder<I, S> {
     const clone = this._clone();
     clone._offsetVal = n;
     return clone;
   }
 
-  hopTo(relation: "todosViaProject"): ProjectQueryBuilder<I> {
+  hopTo(relation: "todosViaProject"): ProjectQueryBuilder<I, S> {
     const clone = this._clone();
     clone._hops.push(relation);
     return clone;
@@ -296,7 +345,7 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
     start: ProjectWhereInput;
     step: (ctx: { current: string }) => QueryBuilder<unknown>;
     maxDepth?: number;
-  }): ProjectQueryBuilder<I> {
+  }): ProjectQueryBuilder<I, S> {
     if (options.start === undefined) {
       throw new Error("gather(...) requires start where conditions.");
     }
@@ -317,15 +366,13 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
 
     const currentToken = "__jazz_gather_current__";
     const stepOutput = options.step({ current: currentToken });
-    if (
-      !stepOutput ||
-      typeof stepOutput !== "object" ||
-      typeof (stepOutput as { _build?: unknown })._build !== "function"
-    ) {
+    if (!stepOutput || typeof stepOutput !== "object" || typeof (stepOutput as { _build?: unknown })._build !== "function") {
       throw new Error("gather(...) step must return a query expression built from app.<table>.");
     }
 
-    const stepBuilt = JSON.parse(stepOutput._build()) as {
+    const stepBuilt = JSON.parse(
+      stepOutput._build(),
+    ) as {
       table?: unknown;
       conditions?: Array<{ column: string; op: string; value: unknown }>;
       hops?: unknown;
@@ -349,9 +396,7 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
       (condition) => condition.op === "eq" && condition.value === currentToken,
     );
     if (currentConditions.length !== 1) {
-      throw new Error(
-        "gather(...) step must include exactly one where condition bound to current.",
-      );
+      throw new Error("gather(...) step must include exactly one where condition bound to current.");
     }
 
     const currentCondition = currentConditions[0];
@@ -378,6 +423,7 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
       table: this._table,
       conditions: this._conditions,
       includes: this._includes,
+      select: this._selectColumns,
       orderBy: this._orderBys,
       limit: this._limitVal,
       offset: this._offsetVal,
@@ -386,10 +432,15 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
     });
   }
 
-  private _clone<CloneI extends ProjectInclude = I>(): ProjectQueryBuilder<CloneI> {
-    const clone = new ProjectQueryBuilder<CloneI>();
+  toJSON(): unknown {
+    return JSON.parse(this._build());
+  }
+
+  private _clone<CloneI extends ProjectInclude = I, CloneS extends ProjectSelectableColumn = S>(): ProjectQueryBuilder<CloneI, CloneS> {
+    const clone = new ProjectQueryBuilder<CloneI, CloneS>();
     clone._conditions = [...this._conditions];
     clone._includes = { ...this._includes };
+    clone._selectColumns = this._selectColumns ? [...this._selectColumns] : undefined;
     clone._orderBys = [...this._orderBys];
     clone._limitVal = this._limitVal;
     clone._offsetVal = this._offsetVal;
@@ -405,15 +456,14 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
   }
 }
 
-export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilder<
-  TodoWithIncludes<I>
-> {
+export class TodoQueryBuilder<I extends TodoInclude = {}, S extends TodoSelectableColumn = keyof Todo> implements QueryBuilder<TodoSelectedWithIncludes<I, S>> {
   readonly _table = "todos";
   readonly _schema: WasmSchema = wasmSchema;
-  declare readonly _rowType: TodoWithIncludes<I>;
-  declare readonly _initType: TodoInit;
+  readonly _rowType!: TodoSelectedWithIncludes<I, S>;
+  readonly _initType!: TodoInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<TodoInclude> = {};
+  private _selectColumns?: string[];
   private _orderBys: Array<[string, "asc" | "desc"]> = [];
   private _limitVal?: number;
   private _offsetVal?: number;
@@ -426,7 +476,7 @@ export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilde
     step_hops: string[];
   };
 
-  where(conditions: TodoWhereInput): TodoQueryBuilder<I> {
+  where(conditions: TodoWhereInput): TodoQueryBuilder<I, S> {
     const clone = this._clone();
     for (const [key, value] of Object.entries(conditions)) {
       if (value === undefined) continue;
@@ -443,31 +493,37 @@ export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilde
     return clone;
   }
 
-  include<NewI extends TodoInclude>(relations: NewI): TodoQueryBuilder<I & NewI> {
-    const clone = this._clone<I & NewI>();
+  select<NewS extends TodoSelectableColumn>(...columns: [NewS, ...NewS[]]): TodoQueryBuilder<I, NewS> {
+    const clone = this._clone<I, NewS>();
+    clone._selectColumns = [...columns] as string[];
+    return clone;
+  }
+
+  include<NewI extends TodoInclude>(relations: NewI): TodoQueryBuilder<I & NewI, S> {
+    const clone = this._clone<I & NewI, S>();
     clone._includes = { ...this._includes, ...relations };
     return clone;
   }
 
-  orderBy(column: keyof Todo, direction: "asc" | "desc" = "asc"): TodoQueryBuilder<I> {
+  orderBy(column: TodoOrderableColumn, direction: "asc" | "desc" = "asc"): TodoQueryBuilder<I, S> {
     const clone = this._clone();
     clone._orderBys.push([column as string, direction]);
     return clone;
   }
 
-  limit(n: number): TodoQueryBuilder<I> {
+  limit(n: number): TodoQueryBuilder<I, S> {
     const clone = this._clone();
     clone._limitVal = n;
     return clone;
   }
 
-  offset(n: number): TodoQueryBuilder<I> {
+  offset(n: number): TodoQueryBuilder<I, S> {
     const clone = this._clone();
     clone._offsetVal = n;
     return clone;
   }
 
-  hopTo(relation: "parent" | "todosViaParent" | "project"): TodoQueryBuilder<I> {
+  hopTo(relation: "parent" | "todosViaParent" | "project"): TodoQueryBuilder<I, S> {
     const clone = this._clone();
     clone._hops.push(relation);
     return clone;
@@ -477,7 +533,7 @@ export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilde
     start: TodoWhereInput;
     step: (ctx: { current: string }) => QueryBuilder<unknown>;
     maxDepth?: number;
-  }): TodoQueryBuilder<I> {
+  }): TodoQueryBuilder<I, S> {
     if (options.start === undefined) {
       throw new Error("gather(...) requires start where conditions.");
     }
@@ -498,15 +554,13 @@ export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilde
 
     const currentToken = "__jazz_gather_current__";
     const stepOutput = options.step({ current: currentToken });
-    if (
-      !stepOutput ||
-      typeof stepOutput !== "object" ||
-      typeof (stepOutput as { _build?: unknown })._build !== "function"
-    ) {
+    if (!stepOutput || typeof stepOutput !== "object" || typeof (stepOutput as { _build?: unknown })._build !== "function") {
       throw new Error("gather(...) step must return a query expression built from app.<table>.");
     }
 
-    const stepBuilt = JSON.parse(stepOutput._build()) as {
+    const stepBuilt = JSON.parse(
+      stepOutput._build(),
+    ) as {
       table?: unknown;
       conditions?: Array<{ column: string; op: string; value: unknown }>;
       hops?: unknown;
@@ -530,9 +584,7 @@ export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilde
       (condition) => condition.op === "eq" && condition.value === currentToken,
     );
     if (currentConditions.length !== 1) {
-      throw new Error(
-        "gather(...) step must include exactly one where condition bound to current.",
-      );
+      throw new Error("gather(...) step must include exactly one where condition bound to current.");
     }
 
     const currentCondition = currentConditions[0];
@@ -559,6 +611,7 @@ export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilde
       table: this._table,
       conditions: this._conditions,
       includes: this._includes,
+      select: this._selectColumns,
       orderBy: this._orderBys,
       limit: this._limitVal,
       offset: this._offsetVal,
@@ -567,10 +620,15 @@ export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilde
     });
   }
 
-  private _clone<CloneI extends TodoInclude = I>(): TodoQueryBuilder<CloneI> {
-    const clone = new TodoQueryBuilder<CloneI>();
+  toJSON(): unknown {
+    return JSON.parse(this._build());
+  }
+
+  private _clone<CloneI extends TodoInclude = I, CloneS extends TodoSelectableColumn = S>(): TodoQueryBuilder<CloneI, CloneS> {
+    const clone = new TodoQueryBuilder<CloneI, CloneS>();
     clone._conditions = [...this._conditions];
     clone._includes = { ...this._includes };
+    clone._selectColumns = this._selectColumns ? [...this._selectColumns] : undefined;
     clone._orderBys = [...this._orderBys];
     clone._limitVal = this._limitVal;
     clone._offsetVal = this._offsetVal;

--- a/examples/todo-client-localfirst-expo/schema/app.ts
+++ b/examples/todo-client-localfirst-expo/schema/app.ts
@@ -1,6 +1,12 @@
 // AUTO-GENERATED FILE - DO NOT EDIT
 import type { WasmSchema, QueryBuilder } from "jazz-tools";
-export type JsonValue = string | number | boolean | null | { [key: string]: JsonValue } | JsonValue[];
+export type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: JsonValue }
+  | JsonValue[];
 
 export type PermissionIntrospectionColumn = "$canRead" | "$canEdit" | "$canDelete";
 export interface PermissionIntrospectionColumns {
@@ -72,32 +78,30 @@ export interface TodoInclude {
 }
 
 export type ProjectIncludedRelations<I extends ProjectInclude = {}> = {
-  [K in keyof I]-?:
-    K extends "todosViaProject"
-      ? NonNullable<I["todosViaProject"]> extends infer RelationInclude
-        ? RelationInclude extends true
-          ? Todo[]
-          : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
-            ? QueryRow[]
-            : RelationInclude extends TodoInclude
-              ? TodoWithIncludes<RelationInclude>[]
-              : never
-        : never
+  [K in keyof I]-?: K extends "todosViaProject"
+    ? NonNullable<I["todosViaProject"]> extends infer RelationInclude
+      ? RelationInclude extends true
+        ? Todo[]
+        : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
+          ? QueryRow[]
+          : RelationInclude extends TodoInclude
+            ? TodoWithIncludes<RelationInclude>[]
+            : never
+      : never
     : never;
 };
 
 export type TodoIncludedRelations<I extends TodoInclude = {}> = {
-  [K in keyof I]-?:
-    K extends "parent"
-      ? NonNullable<I["parent"]> extends infer RelationInclude
-        ? RelationInclude extends true
-          ? Todo | undefined
-          : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
-            ? QueryRow | undefined
-            : RelationInclude extends TodoInclude
-              ? TodoWithIncludes<RelationInclude> | undefined
-              : never
-        : never
+  [K in keyof I]-?: K extends "parent"
+    ? NonNullable<I["parent"]> extends infer RelationInclude
+      ? RelationInclude extends true
+        ? Todo | undefined
+        : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
+          ? QueryRow | undefined
+          : RelationInclude extends TodoInclude
+            ? TodoWithIncludes<RelationInclude> | undefined
+            : never
+      : never
     : K extends "todosViaParent"
       ? NonNullable<I["todosViaParent"]> extends infer RelationInclude
         ? RelationInclude extends true
@@ -108,17 +112,17 @@ export type TodoIncludedRelations<I extends TodoInclude = {}> = {
               ? TodoWithIncludes<RelationInclude>[]
               : never
         : never
-    : K extends "project"
-      ? NonNullable<I["project"]> extends infer RelationInclude
-        ? RelationInclude extends true
-          ? Project | undefined
-          : RelationInclude extends AnyProjectQueryBuilder<infer QueryRow>
-            ? QueryRow | undefined
-            : RelationInclude extends ProjectInclude
-              ? ProjectWithIncludes<RelationInclude> | undefined
-              : never
-        : never
-    : never;
+      : K extends "project"
+        ? NonNullable<I["project"]> extends infer RelationInclude
+          ? RelationInclude extends true
+            ? Project | undefined
+            : RelationInclude extends AnyProjectQueryBuilder<infer QueryRow>
+              ? QueryRow | undefined
+              : RelationInclude extends ProjectInclude
+                ? ProjectWithIncludes<RelationInclude> | undefined
+                : never
+          : never
+        : never;
 };
 
 export interface ProjectRelations {
@@ -131,144 +135,160 @@ export interface TodoRelations {
   project: Project;
 }
 
-export type ProjectWithIncludes<I extends ProjectInclude = {}> = Omit<Project, Extract<keyof I, keyof Project>> & ProjectIncludedRelations<I>;
+export type ProjectWithIncludes<I extends ProjectInclude = {}> = Omit<
+  Project,
+  Extract<keyof I, keyof Project>
+> &
+  ProjectIncludedRelations<I>;
 
-export type TodoWithIncludes<I extends TodoInclude = {}> = Omit<Todo, Extract<keyof I, keyof Todo>> & TodoIncludedRelations<I>;
+export type TodoWithIncludes<I extends TodoInclude = {}> = Omit<
+  Todo,
+  Extract<keyof I, keyof Todo>
+> &
+  TodoIncludedRelations<I>;
 
 export type ProjectSelectableColumn = keyof Project | PermissionIntrospectionColumn | "*";
 export type ProjectOrderableColumn = keyof Project | PermissionIntrospectionColumn;
 
-export type ProjectSelected<S extends ProjectSelectableColumn = keyof Project> = "*" extends S ? Project : Pick<Project, Extract<S | "id", keyof Project>> & Pick<PermissionIntrospectionColumns, Extract<S, PermissionIntrospectionColumn>>;
+export type ProjectSelected<S extends ProjectSelectableColumn = keyof Project> = "*" extends S
+  ? Project
+  : Pick<Project, Extract<S | "id", keyof Project>> &
+      Pick<PermissionIntrospectionColumns, Extract<S, PermissionIntrospectionColumn>>;
 
-export type ProjectSelectedWithIncludes<I extends ProjectInclude = {}, S extends ProjectSelectableColumn = keyof Project> = Omit<ProjectSelected<S>, Extract<keyof I, keyof ProjectSelected<S>>> & ProjectIncludedRelations<I>;
+export type ProjectSelectedWithIncludes<
+  I extends ProjectInclude = {},
+  S extends ProjectSelectableColumn = keyof Project,
+> = Omit<ProjectSelected<S>, Extract<keyof I, keyof ProjectSelected<S>>> &
+  ProjectIncludedRelations<I>;
 
 export type TodoSelectableColumn = keyof Todo | PermissionIntrospectionColumn | "*";
 export type TodoOrderableColumn = keyof Todo | PermissionIntrospectionColumn;
 
-export type TodoSelected<S extends TodoSelectableColumn = keyof Todo> = "*" extends S ? Todo : Pick<Todo, Extract<S | "id", keyof Todo>> & Pick<PermissionIntrospectionColumns, Extract<S, PermissionIntrospectionColumn>>;
+export type TodoSelected<S extends TodoSelectableColumn = keyof Todo> = "*" extends S
+  ? Todo
+  : Pick<Todo, Extract<S | "id", keyof Todo>> &
+      Pick<PermissionIntrospectionColumns, Extract<S, PermissionIntrospectionColumn>>;
 
-export type TodoSelectedWithIncludes<I extends TodoInclude = {}, S extends TodoSelectableColumn = keyof Todo> = Omit<TodoSelected<S>, Extract<keyof I, keyof TodoSelected<S>>> & TodoIncludedRelations<I>;
+export type TodoSelectedWithIncludes<
+  I extends TodoInclude = {},
+  S extends TodoSelectableColumn = keyof Todo,
+> = Omit<TodoSelected<S>, Extract<keyof I, keyof TodoSelected<S>>> & TodoIncludedRelations<I>;
 
 export const wasmSchema: WasmSchema = {
-  "projects": {
-    "columns": [
+  projects: {
+    columns: [
       {
-        "name": "name",
-        "column_type": {
-          "type": "Text"
+        name: "name",
+        column_type: {
+          type: "Text",
         },
-        "nullable": false
-      }
-    ]
-  },
-  "todos": {
-    "columns": [
-      {
-        "name": "title",
-        "column_type": {
-          "type": "Text"
-        },
-        "nullable": false
+        nullable: false,
       },
-      {
-        "name": "done",
-        "column_type": {
-          "type": "Boolean"
-        },
-        "nullable": false
-      },
-      {
-        "name": "description",
-        "column_type": {
-          "type": "Text"
-        },
-        "nullable": true
-      },
-      {
-        "name": "owner_id",
-        "column_type": {
-          "type": "Text"
-        },
-        "nullable": false
-      },
-      {
-        "name": "parent",
-        "column_type": {
-          "type": "Uuid"
-        },
-        "nullable": true,
-        "references": "todos"
-      },
-      {
-        "name": "project",
-        "column_type": {
-          "type": "Uuid"
-        },
-        "nullable": true,
-        "references": "projects"
-      }
     ],
-    "policies": {
-      "select": {
-        "using": {
-          "type": "True"
-        }
-      },
-      "insert": {
-        "with_check": {
-          "type": "Cmp",
-          "column": "owner_id",
-          "op": "Eq",
-          "value": {
-            "type": "SessionRef",
-            "path": [
-              "user_id"
-            ]
-          }
-        }
-      },
-      "update": {
-        "using": {
-          "type": "Cmp",
-          "column": "owner_id",
-          "op": "Eq",
-          "value": {
-            "type": "SessionRef",
-            "path": [
-              "user_id"
-            ]
-          }
+  },
+  todos: {
+    columns: [
+      {
+        name: "title",
+        column_type: {
+          type: "Text",
         },
-        "with_check": {
-          "type": "Cmp",
-          "column": "owner_id",
-          "op": "Eq",
-          "value": {
-            "type": "SessionRef",
-            "path": [
-              "user_id"
-            ]
-          }
-        }
+        nullable: false,
       },
-      "delete": {
-        "using": {
-          "type": "Cmp",
-          "column": "owner_id",
-          "op": "Eq",
-          "value": {
-            "type": "SessionRef",
-            "path": [
-              "user_id"
-            ]
-          }
-        }
-      }
-    }
-  }
+      {
+        name: "done",
+        column_type: {
+          type: "Boolean",
+        },
+        nullable: false,
+      },
+      {
+        name: "description",
+        column_type: {
+          type: "Text",
+        },
+        nullable: true,
+      },
+      {
+        name: "owner_id",
+        column_type: {
+          type: "Text",
+        },
+        nullable: false,
+      },
+      {
+        name: "parent",
+        column_type: {
+          type: "Uuid",
+        },
+        nullable: true,
+        references: "todos",
+      },
+      {
+        name: "project",
+        column_type: {
+          type: "Uuid",
+        },
+        nullable: true,
+        references: "projects",
+      },
+    ],
+    policies: {
+      select: {
+        using: {
+          type: "True",
+        },
+      },
+      insert: {
+        with_check: {
+          type: "Cmp",
+          column: "owner_id",
+          op: "Eq",
+          value: {
+            type: "SessionRef",
+            path: ["user_id"],
+          },
+        },
+      },
+      update: {
+        using: {
+          type: "Cmp",
+          column: "owner_id",
+          op: "Eq",
+          value: {
+            type: "SessionRef",
+            path: ["user_id"],
+          },
+        },
+        with_check: {
+          type: "Cmp",
+          column: "owner_id",
+          op: "Eq",
+          value: {
+            type: "SessionRef",
+            path: ["user_id"],
+          },
+        },
+      },
+      delete: {
+        using: {
+          type: "Cmp",
+          column: "owner_id",
+          op: "Eq",
+          value: {
+            type: "SessionRef",
+            path: ["user_id"],
+          },
+        },
+      },
+    },
+  },
 };
 
-export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends ProjectSelectableColumn = keyof Project> implements QueryBuilder<ProjectSelectedWithIncludes<I, S>> {
+export class ProjectQueryBuilder<
+  I extends ProjectInclude = {},
+  S extends ProjectSelectableColumn = keyof Project,
+> implements QueryBuilder<ProjectSelectedWithIncludes<I, S>> {
   readonly _table = "projects";
   readonly _schema: WasmSchema = wasmSchema;
   readonly _rowType!: ProjectSelectedWithIncludes<I, S>;
@@ -305,7 +325,9 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
     return clone;
   }
 
-  select<NewS extends ProjectSelectableColumn>(...columns: [NewS, ...NewS[]]): ProjectQueryBuilder<I, NewS> {
+  select<NewS extends ProjectSelectableColumn>(
+    ...columns: [NewS, ...NewS[]]
+  ): ProjectQueryBuilder<I, NewS> {
     const clone = this._clone<I, NewS>();
     clone._selectColumns = [...columns] as string[];
     return clone;
@@ -317,7 +339,10 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
     return clone;
   }
 
-  orderBy(column: ProjectOrderableColumn, direction: "asc" | "desc" = "asc"): ProjectQueryBuilder<I, S> {
+  orderBy(
+    column: ProjectOrderableColumn,
+    direction: "asc" | "desc" = "asc",
+  ): ProjectQueryBuilder<I, S> {
     const clone = this._clone();
     clone._orderBys.push([column as string, direction]);
     return clone;
@@ -366,13 +391,15 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
 
     const currentToken = "__jazz_gather_current__";
     const stepOutput = options.step({ current: currentToken });
-    if (!stepOutput || typeof stepOutput !== "object" || typeof (stepOutput as { _build?: unknown })._build !== "function") {
+    if (
+      !stepOutput ||
+      typeof stepOutput !== "object" ||
+      typeof (stepOutput as { _build?: unknown })._build !== "function"
+    ) {
       throw new Error("gather(...) step must return a query expression built from app.<table>.");
     }
 
-    const stepBuilt = JSON.parse(
-      stepOutput._build(),
-    ) as {
+    const stepBuilt = JSON.parse(stepOutput._build()) as {
       table?: unknown;
       conditions?: Array<{ column: string; op: string; value: unknown }>;
       hops?: unknown;
@@ -396,7 +423,9 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
       (condition) => condition.op === "eq" && condition.value === currentToken,
     );
     if (currentConditions.length !== 1) {
-      throw new Error("gather(...) step must include exactly one where condition bound to current.");
+      throw new Error(
+        "gather(...) step must include exactly one where condition bound to current.",
+      );
     }
 
     const currentCondition = currentConditions[0];
@@ -436,7 +465,10 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
     return JSON.parse(this._build());
   }
 
-  private _clone<CloneI extends ProjectInclude = I, CloneS extends ProjectSelectableColumn = S>(): ProjectQueryBuilder<CloneI, CloneS> {
+  private _clone<
+    CloneI extends ProjectInclude = I,
+    CloneS extends ProjectSelectableColumn = S,
+  >(): ProjectQueryBuilder<CloneI, CloneS> {
     const clone = new ProjectQueryBuilder<CloneI, CloneS>();
     clone._conditions = [...this._conditions];
     clone._includes = { ...this._includes };
@@ -456,7 +488,10 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
   }
 }
 
-export class TodoQueryBuilder<I extends TodoInclude = {}, S extends TodoSelectableColumn = keyof Todo> implements QueryBuilder<TodoSelectedWithIncludes<I, S>> {
+export class TodoQueryBuilder<
+  I extends TodoInclude = {},
+  S extends TodoSelectableColumn = keyof Todo,
+> implements QueryBuilder<TodoSelectedWithIncludes<I, S>> {
   readonly _table = "todos";
   readonly _schema: WasmSchema = wasmSchema;
   readonly _rowType!: TodoSelectedWithIncludes<I, S>;
@@ -493,7 +528,9 @@ export class TodoQueryBuilder<I extends TodoInclude = {}, S extends TodoSelectab
     return clone;
   }
 
-  select<NewS extends TodoSelectableColumn>(...columns: [NewS, ...NewS[]]): TodoQueryBuilder<I, NewS> {
+  select<NewS extends TodoSelectableColumn>(
+    ...columns: [NewS, ...NewS[]]
+  ): TodoQueryBuilder<I, NewS> {
     const clone = this._clone<I, NewS>();
     clone._selectColumns = [...columns] as string[];
     return clone;
@@ -554,13 +591,15 @@ export class TodoQueryBuilder<I extends TodoInclude = {}, S extends TodoSelectab
 
     const currentToken = "__jazz_gather_current__";
     const stepOutput = options.step({ current: currentToken });
-    if (!stepOutput || typeof stepOutput !== "object" || typeof (stepOutput as { _build?: unknown })._build !== "function") {
+    if (
+      !stepOutput ||
+      typeof stepOutput !== "object" ||
+      typeof (stepOutput as { _build?: unknown })._build !== "function"
+    ) {
       throw new Error("gather(...) step must return a query expression built from app.<table>.");
     }
 
-    const stepBuilt = JSON.parse(
-      stepOutput._build(),
-    ) as {
+    const stepBuilt = JSON.parse(stepOutput._build()) as {
       table?: unknown;
       conditions?: Array<{ column: string; op: string; value: unknown }>;
       hops?: unknown;
@@ -584,7 +623,9 @@ export class TodoQueryBuilder<I extends TodoInclude = {}, S extends TodoSelectab
       (condition) => condition.op === "eq" && condition.value === currentToken,
     );
     if (currentConditions.length !== 1) {
-      throw new Error("gather(...) step must include exactly one where condition bound to current.");
+      throw new Error(
+        "gather(...) step must include exactly one where condition bound to current.",
+      );
     }
 
     const currentCondition = currentConditions[0];
@@ -624,7 +665,10 @@ export class TodoQueryBuilder<I extends TodoInclude = {}, S extends TodoSelectab
     return JSON.parse(this._build());
   }
 
-  private _clone<CloneI extends TodoInclude = I, CloneS extends TodoSelectableColumn = S>(): TodoQueryBuilder<CloneI, CloneS> {
+  private _clone<
+    CloneI extends TodoInclude = I,
+    CloneS extends TodoSelectableColumn = S,
+  >(): TodoQueryBuilder<CloneI, CloneS> {
     const clone = new TodoQueryBuilder<CloneI, CloneS>();
     clone._conditions = [...this._conditions];
     clone._includes = { ...this._includes };

--- a/examples/todo-client-localfirst-react/schema/app.ts
+++ b/examples/todo-client-localfirst-react/schema/app.ts
@@ -271,8 +271,8 @@ export const wasmSchema: WasmSchema = {
 export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends ProjectSelectableColumn = keyof Project> implements QueryBuilder<ProjectSelectedWithIncludes<I, S>> {
   readonly _table = "projects";
   readonly _schema: WasmSchema = wasmSchema;
-  declare readonly _rowType: ProjectSelectedWithIncludes<I, S>;
-  declare readonly _initType: ProjectInit;
+  readonly _rowType!: ProjectSelectedWithIncludes<I, S>;
+  readonly _initType!: ProjectInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<ProjectInclude> = {};
   private _selectColumns?: string[];
@@ -459,8 +459,8 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
 export class TodoQueryBuilder<I extends TodoInclude = {}, S extends TodoSelectableColumn = keyof Todo> implements QueryBuilder<TodoSelectedWithIncludes<I, S>> {
   readonly _table = "todos";
   readonly _schema: WasmSchema = wasmSchema;
-  declare readonly _rowType: TodoSelectedWithIncludes<I, S>;
-  declare readonly _initType: TodoInit;
+  readonly _rowType!: TodoSelectedWithIncludes<I, S>;
+  readonly _initType!: TodoInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<TodoInclude> = {};
   private _selectColumns?: string[];

--- a/examples/todo-client-localfirst-react/schema/app.ts
+++ b/examples/todo-client-localfirst-react/schema/app.ts
@@ -1,6 +1,12 @@
 // AUTO-GENERATED FILE - DO NOT EDIT
 import type { WasmSchema, QueryBuilder } from "jazz-tools";
-export type JsonValue = string | number | boolean | null | { [key: string]: JsonValue } | JsonValue[];
+export type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: JsonValue }
+  | JsonValue[];
 
 export type PermissionIntrospectionColumn = "$canRead" | "$canEdit" | "$canDelete";
 export interface PermissionIntrospectionColumns {
@@ -72,32 +78,30 @@ export interface TodoInclude {
 }
 
 export type ProjectIncludedRelations<I extends ProjectInclude = {}> = {
-  [K in keyof I]-?:
-    K extends "todosViaProject"
-      ? NonNullable<I["todosViaProject"]> extends infer RelationInclude
-        ? RelationInclude extends true
-          ? Todo[]
-          : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
-            ? QueryRow[]
-            : RelationInclude extends TodoInclude
-              ? TodoWithIncludes<RelationInclude>[]
-              : never
-        : never
+  [K in keyof I]-?: K extends "todosViaProject"
+    ? NonNullable<I["todosViaProject"]> extends infer RelationInclude
+      ? RelationInclude extends true
+        ? Todo[]
+        : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
+          ? QueryRow[]
+          : RelationInclude extends TodoInclude
+            ? TodoWithIncludes<RelationInclude>[]
+            : never
+      : never
     : never;
 };
 
 export type TodoIncludedRelations<I extends TodoInclude = {}> = {
-  [K in keyof I]-?:
-    K extends "parent"
-      ? NonNullable<I["parent"]> extends infer RelationInclude
-        ? RelationInclude extends true
-          ? Todo | undefined
-          : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
-            ? QueryRow | undefined
-            : RelationInclude extends TodoInclude
-              ? TodoWithIncludes<RelationInclude> | undefined
-              : never
-        : never
+  [K in keyof I]-?: K extends "parent"
+    ? NonNullable<I["parent"]> extends infer RelationInclude
+      ? RelationInclude extends true
+        ? Todo | undefined
+        : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
+          ? QueryRow | undefined
+          : RelationInclude extends TodoInclude
+            ? TodoWithIncludes<RelationInclude> | undefined
+            : never
+      : never
     : K extends "todosViaParent"
       ? NonNullable<I["todosViaParent"]> extends infer RelationInclude
         ? RelationInclude extends true
@@ -108,17 +112,17 @@ export type TodoIncludedRelations<I extends TodoInclude = {}> = {
               ? TodoWithIncludes<RelationInclude>[]
               : never
         : never
-    : K extends "project"
-      ? NonNullable<I["project"]> extends infer RelationInclude
-        ? RelationInclude extends true
-          ? Project | undefined
-          : RelationInclude extends AnyProjectQueryBuilder<infer QueryRow>
-            ? QueryRow | undefined
-            : RelationInclude extends ProjectInclude
-              ? ProjectWithIncludes<RelationInclude> | undefined
-              : never
-        : never
-    : never;
+      : K extends "project"
+        ? NonNullable<I["project"]> extends infer RelationInclude
+          ? RelationInclude extends true
+            ? Project | undefined
+            : RelationInclude extends AnyProjectQueryBuilder<infer QueryRow>
+              ? QueryRow | undefined
+              : RelationInclude extends ProjectInclude
+                ? ProjectWithIncludes<RelationInclude> | undefined
+                : never
+          : never
+        : never;
 };
 
 export interface ProjectRelations {
@@ -131,144 +135,160 @@ export interface TodoRelations {
   project: Project;
 }
 
-export type ProjectWithIncludes<I extends ProjectInclude = {}> = Omit<Project, Extract<keyof I, keyof Project>> & ProjectIncludedRelations<I>;
+export type ProjectWithIncludes<I extends ProjectInclude = {}> = Omit<
+  Project,
+  Extract<keyof I, keyof Project>
+> &
+  ProjectIncludedRelations<I>;
 
-export type TodoWithIncludes<I extends TodoInclude = {}> = Omit<Todo, Extract<keyof I, keyof Todo>> & TodoIncludedRelations<I>;
+export type TodoWithIncludes<I extends TodoInclude = {}> = Omit<
+  Todo,
+  Extract<keyof I, keyof Todo>
+> &
+  TodoIncludedRelations<I>;
 
 export type ProjectSelectableColumn = keyof Project | PermissionIntrospectionColumn | "*";
 export type ProjectOrderableColumn = keyof Project | PermissionIntrospectionColumn;
 
-export type ProjectSelected<S extends ProjectSelectableColumn = keyof Project> = "*" extends S ? Project : Pick<Project, Extract<S | "id", keyof Project>> & Pick<PermissionIntrospectionColumns, Extract<S, PermissionIntrospectionColumn>>;
+export type ProjectSelected<S extends ProjectSelectableColumn = keyof Project> = "*" extends S
+  ? Project
+  : Pick<Project, Extract<S | "id", keyof Project>> &
+      Pick<PermissionIntrospectionColumns, Extract<S, PermissionIntrospectionColumn>>;
 
-export type ProjectSelectedWithIncludes<I extends ProjectInclude = {}, S extends ProjectSelectableColumn = keyof Project> = Omit<ProjectSelected<S>, Extract<keyof I, keyof ProjectSelected<S>>> & ProjectIncludedRelations<I>;
+export type ProjectSelectedWithIncludes<
+  I extends ProjectInclude = {},
+  S extends ProjectSelectableColumn = keyof Project,
+> = Omit<ProjectSelected<S>, Extract<keyof I, keyof ProjectSelected<S>>> &
+  ProjectIncludedRelations<I>;
 
 export type TodoSelectableColumn = keyof Todo | PermissionIntrospectionColumn | "*";
 export type TodoOrderableColumn = keyof Todo | PermissionIntrospectionColumn;
 
-export type TodoSelected<S extends TodoSelectableColumn = keyof Todo> = "*" extends S ? Todo : Pick<Todo, Extract<S | "id", keyof Todo>> & Pick<PermissionIntrospectionColumns, Extract<S, PermissionIntrospectionColumn>>;
+export type TodoSelected<S extends TodoSelectableColumn = keyof Todo> = "*" extends S
+  ? Todo
+  : Pick<Todo, Extract<S | "id", keyof Todo>> &
+      Pick<PermissionIntrospectionColumns, Extract<S, PermissionIntrospectionColumn>>;
 
-export type TodoSelectedWithIncludes<I extends TodoInclude = {}, S extends TodoSelectableColumn = keyof Todo> = Omit<TodoSelected<S>, Extract<keyof I, keyof TodoSelected<S>>> & TodoIncludedRelations<I>;
+export type TodoSelectedWithIncludes<
+  I extends TodoInclude = {},
+  S extends TodoSelectableColumn = keyof Todo,
+> = Omit<TodoSelected<S>, Extract<keyof I, keyof TodoSelected<S>>> & TodoIncludedRelations<I>;
 
 export const wasmSchema: WasmSchema = {
-  "projects": {
-    "columns": [
+  projects: {
+    columns: [
       {
-        "name": "name",
-        "column_type": {
-          "type": "Text"
+        name: "name",
+        column_type: {
+          type: "Text",
         },
-        "nullable": false
-      }
-    ]
-  },
-  "todos": {
-    "columns": [
-      {
-        "name": "title",
-        "column_type": {
-          "type": "Text"
-        },
-        "nullable": false
+        nullable: false,
       },
-      {
-        "name": "done",
-        "column_type": {
-          "type": "Boolean"
-        },
-        "nullable": false
-      },
-      {
-        "name": "description",
-        "column_type": {
-          "type": "Text"
-        },
-        "nullable": true
-      },
-      {
-        "name": "owner_id",
-        "column_type": {
-          "type": "Text"
-        },
-        "nullable": false
-      },
-      {
-        "name": "parent",
-        "column_type": {
-          "type": "Uuid"
-        },
-        "nullable": true,
-        "references": "todos"
-      },
-      {
-        "name": "project",
-        "column_type": {
-          "type": "Uuid"
-        },
-        "nullable": true,
-        "references": "projects"
-      }
     ],
-    "policies": {
-      "select": {
-        "using": {
-          "type": "True"
-        }
-      },
-      "insert": {
-        "with_check": {
-          "type": "Cmp",
-          "column": "owner_id",
-          "op": "Eq",
-          "value": {
-            "type": "SessionRef",
-            "path": [
-              "user_id"
-            ]
-          }
-        }
-      },
-      "update": {
-        "using": {
-          "type": "Cmp",
-          "column": "owner_id",
-          "op": "Eq",
-          "value": {
-            "type": "SessionRef",
-            "path": [
-              "user_id"
-            ]
-          }
+  },
+  todos: {
+    columns: [
+      {
+        name: "title",
+        column_type: {
+          type: "Text",
         },
-        "with_check": {
-          "type": "Cmp",
-          "column": "owner_id",
-          "op": "Eq",
-          "value": {
-            "type": "SessionRef",
-            "path": [
-              "user_id"
-            ]
-          }
-        }
+        nullable: false,
       },
-      "delete": {
-        "using": {
-          "type": "Cmp",
-          "column": "owner_id",
-          "op": "Eq",
-          "value": {
-            "type": "SessionRef",
-            "path": [
-              "user_id"
-            ]
-          }
-        }
-      }
-    }
-  }
+      {
+        name: "done",
+        column_type: {
+          type: "Boolean",
+        },
+        nullable: false,
+      },
+      {
+        name: "description",
+        column_type: {
+          type: "Text",
+        },
+        nullable: true,
+      },
+      {
+        name: "owner_id",
+        column_type: {
+          type: "Text",
+        },
+        nullable: false,
+      },
+      {
+        name: "parent",
+        column_type: {
+          type: "Uuid",
+        },
+        nullable: true,
+        references: "todos",
+      },
+      {
+        name: "project",
+        column_type: {
+          type: "Uuid",
+        },
+        nullable: true,
+        references: "projects",
+      },
+    ],
+    policies: {
+      select: {
+        using: {
+          type: "True",
+        },
+      },
+      insert: {
+        with_check: {
+          type: "Cmp",
+          column: "owner_id",
+          op: "Eq",
+          value: {
+            type: "SessionRef",
+            path: ["user_id"],
+          },
+        },
+      },
+      update: {
+        using: {
+          type: "Cmp",
+          column: "owner_id",
+          op: "Eq",
+          value: {
+            type: "SessionRef",
+            path: ["user_id"],
+          },
+        },
+        with_check: {
+          type: "Cmp",
+          column: "owner_id",
+          op: "Eq",
+          value: {
+            type: "SessionRef",
+            path: ["user_id"],
+          },
+        },
+      },
+      delete: {
+        using: {
+          type: "Cmp",
+          column: "owner_id",
+          op: "Eq",
+          value: {
+            type: "SessionRef",
+            path: ["user_id"],
+          },
+        },
+      },
+    },
+  },
 };
 
-export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends ProjectSelectableColumn = keyof Project> implements QueryBuilder<ProjectSelectedWithIncludes<I, S>> {
+export class ProjectQueryBuilder<
+  I extends ProjectInclude = {},
+  S extends ProjectSelectableColumn = keyof Project,
+> implements QueryBuilder<ProjectSelectedWithIncludes<I, S>> {
   readonly _table = "projects";
   readonly _schema: WasmSchema = wasmSchema;
   readonly _rowType!: ProjectSelectedWithIncludes<I, S>;
@@ -305,7 +325,9 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
     return clone;
   }
 
-  select<NewS extends ProjectSelectableColumn>(...columns: [NewS, ...NewS[]]): ProjectQueryBuilder<I, NewS> {
+  select<NewS extends ProjectSelectableColumn>(
+    ...columns: [NewS, ...NewS[]]
+  ): ProjectQueryBuilder<I, NewS> {
     const clone = this._clone<I, NewS>();
     clone._selectColumns = [...columns] as string[];
     return clone;
@@ -317,7 +339,10 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
     return clone;
   }
 
-  orderBy(column: ProjectOrderableColumn, direction: "asc" | "desc" = "asc"): ProjectQueryBuilder<I, S> {
+  orderBy(
+    column: ProjectOrderableColumn,
+    direction: "asc" | "desc" = "asc",
+  ): ProjectQueryBuilder<I, S> {
     const clone = this._clone();
     clone._orderBys.push([column as string, direction]);
     return clone;
@@ -366,13 +391,15 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
 
     const currentToken = "__jazz_gather_current__";
     const stepOutput = options.step({ current: currentToken });
-    if (!stepOutput || typeof stepOutput !== "object" || typeof (stepOutput as { _build?: unknown })._build !== "function") {
+    if (
+      !stepOutput ||
+      typeof stepOutput !== "object" ||
+      typeof (stepOutput as { _build?: unknown })._build !== "function"
+    ) {
       throw new Error("gather(...) step must return a query expression built from app.<table>.");
     }
 
-    const stepBuilt = JSON.parse(
-      stepOutput._build(),
-    ) as {
+    const stepBuilt = JSON.parse(stepOutput._build()) as {
       table?: unknown;
       conditions?: Array<{ column: string; op: string; value: unknown }>;
       hops?: unknown;
@@ -396,7 +423,9 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
       (condition) => condition.op === "eq" && condition.value === currentToken,
     );
     if (currentConditions.length !== 1) {
-      throw new Error("gather(...) step must include exactly one where condition bound to current.");
+      throw new Error(
+        "gather(...) step must include exactly one where condition bound to current.",
+      );
     }
 
     const currentCondition = currentConditions[0];
@@ -436,7 +465,10 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
     return JSON.parse(this._build());
   }
 
-  private _clone<CloneI extends ProjectInclude = I, CloneS extends ProjectSelectableColumn = S>(): ProjectQueryBuilder<CloneI, CloneS> {
+  private _clone<
+    CloneI extends ProjectInclude = I,
+    CloneS extends ProjectSelectableColumn = S,
+  >(): ProjectQueryBuilder<CloneI, CloneS> {
     const clone = new ProjectQueryBuilder<CloneI, CloneS>();
     clone._conditions = [...this._conditions];
     clone._includes = { ...this._includes };
@@ -456,7 +488,10 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
   }
 }
 
-export class TodoQueryBuilder<I extends TodoInclude = {}, S extends TodoSelectableColumn = keyof Todo> implements QueryBuilder<TodoSelectedWithIncludes<I, S>> {
+export class TodoQueryBuilder<
+  I extends TodoInclude = {},
+  S extends TodoSelectableColumn = keyof Todo,
+> implements QueryBuilder<TodoSelectedWithIncludes<I, S>> {
   readonly _table = "todos";
   readonly _schema: WasmSchema = wasmSchema;
   readonly _rowType!: TodoSelectedWithIncludes<I, S>;
@@ -493,7 +528,9 @@ export class TodoQueryBuilder<I extends TodoInclude = {}, S extends TodoSelectab
     return clone;
   }
 
-  select<NewS extends TodoSelectableColumn>(...columns: [NewS, ...NewS[]]): TodoQueryBuilder<I, NewS> {
+  select<NewS extends TodoSelectableColumn>(
+    ...columns: [NewS, ...NewS[]]
+  ): TodoQueryBuilder<I, NewS> {
     const clone = this._clone<I, NewS>();
     clone._selectColumns = [...columns] as string[];
     return clone;
@@ -554,13 +591,15 @@ export class TodoQueryBuilder<I extends TodoInclude = {}, S extends TodoSelectab
 
     const currentToken = "__jazz_gather_current__";
     const stepOutput = options.step({ current: currentToken });
-    if (!stepOutput || typeof stepOutput !== "object" || typeof (stepOutput as { _build?: unknown })._build !== "function") {
+    if (
+      !stepOutput ||
+      typeof stepOutput !== "object" ||
+      typeof (stepOutput as { _build?: unknown })._build !== "function"
+    ) {
       throw new Error("gather(...) step must return a query expression built from app.<table>.");
     }
 
-    const stepBuilt = JSON.parse(
-      stepOutput._build(),
-    ) as {
+    const stepBuilt = JSON.parse(stepOutput._build()) as {
       table?: unknown;
       conditions?: Array<{ column: string; op: string; value: unknown }>;
       hops?: unknown;
@@ -584,7 +623,9 @@ export class TodoQueryBuilder<I extends TodoInclude = {}, S extends TodoSelectab
       (condition) => condition.op === "eq" && condition.value === currentToken,
     );
     if (currentConditions.length !== 1) {
-      throw new Error("gather(...) step must include exactly one where condition bound to current.");
+      throw new Error(
+        "gather(...) step must include exactly one where condition bound to current.",
+      );
     }
 
     const currentCondition = currentConditions[0];
@@ -624,7 +665,10 @@ export class TodoQueryBuilder<I extends TodoInclude = {}, S extends TodoSelectab
     return JSON.parse(this._build());
   }
 
-  private _clone<CloneI extends TodoInclude = I, CloneS extends TodoSelectableColumn = S>(): TodoQueryBuilder<CloneI, CloneS> {
+  private _clone<
+    CloneI extends TodoInclude = I,
+    CloneS extends TodoSelectableColumn = S,
+  >(): TodoQueryBuilder<CloneI, CloneS> {
     const clone = new TodoQueryBuilder<CloneI, CloneS>();
     clone._conditions = [...this._conditions];
     clone._includes = { ...this._includes };

--- a/examples/todo-client-localfirst-svelte/schema/app.ts
+++ b/examples/todo-client-localfirst-svelte/schema/app.ts
@@ -271,8 +271,8 @@ export const wasmSchema: WasmSchema = {
 export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends ProjectSelectableColumn = keyof Project> implements QueryBuilder<ProjectSelectedWithIncludes<I, S>> {
   readonly _table = "projects";
   readonly _schema: WasmSchema = wasmSchema;
-  declare readonly _rowType: ProjectSelectedWithIncludes<I, S>;
-  declare readonly _initType: ProjectInit;
+  readonly _rowType!: ProjectSelectedWithIncludes<I, S>;
+  readonly _initType!: ProjectInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<ProjectInclude> = {};
   private _selectColumns?: string[];
@@ -459,8 +459,8 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
 export class TodoQueryBuilder<I extends TodoInclude = {}, S extends TodoSelectableColumn = keyof Todo> implements QueryBuilder<TodoSelectedWithIncludes<I, S>> {
   readonly _table = "todos";
   readonly _schema: WasmSchema = wasmSchema;
-  declare readonly _rowType: TodoSelectedWithIncludes<I, S>;
-  declare readonly _initType: TodoInit;
+  readonly _rowType!: TodoSelectedWithIncludes<I, S>;
+  readonly _initType!: TodoInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<TodoInclude> = {};
   private _selectColumns?: string[];

--- a/examples/todo-client-localfirst-svelte/schema/app.ts
+++ b/examples/todo-client-localfirst-svelte/schema/app.ts
@@ -1,6 +1,12 @@
 // AUTO-GENERATED FILE - DO NOT EDIT
 import type { WasmSchema, QueryBuilder } from "jazz-tools";
-export type JsonValue = string | number | boolean | null | { [key: string]: JsonValue } | JsonValue[];
+export type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: JsonValue }
+  | JsonValue[];
 
 export type PermissionIntrospectionColumn = "$canRead" | "$canEdit" | "$canDelete";
 export interface PermissionIntrospectionColumns {
@@ -72,32 +78,30 @@ export interface TodoInclude {
 }
 
 export type ProjectIncludedRelations<I extends ProjectInclude = {}> = {
-  [K in keyof I]-?:
-    K extends "todosViaProject"
-      ? NonNullable<I["todosViaProject"]> extends infer RelationInclude
-        ? RelationInclude extends true
-          ? Todo[]
-          : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
-            ? QueryRow[]
-            : RelationInclude extends TodoInclude
-              ? TodoWithIncludes<RelationInclude>[]
-              : never
-        : never
+  [K in keyof I]-?: K extends "todosViaProject"
+    ? NonNullable<I["todosViaProject"]> extends infer RelationInclude
+      ? RelationInclude extends true
+        ? Todo[]
+        : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
+          ? QueryRow[]
+          : RelationInclude extends TodoInclude
+            ? TodoWithIncludes<RelationInclude>[]
+            : never
+      : never
     : never;
 };
 
 export type TodoIncludedRelations<I extends TodoInclude = {}> = {
-  [K in keyof I]-?:
-    K extends "parent"
-      ? NonNullable<I["parent"]> extends infer RelationInclude
-        ? RelationInclude extends true
-          ? Todo | undefined
-          : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
-            ? QueryRow | undefined
-            : RelationInclude extends TodoInclude
-              ? TodoWithIncludes<RelationInclude> | undefined
-              : never
-        : never
+  [K in keyof I]-?: K extends "parent"
+    ? NonNullable<I["parent"]> extends infer RelationInclude
+      ? RelationInclude extends true
+        ? Todo | undefined
+        : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
+          ? QueryRow | undefined
+          : RelationInclude extends TodoInclude
+            ? TodoWithIncludes<RelationInclude> | undefined
+            : never
+      : never
     : K extends "todosViaParent"
       ? NonNullable<I["todosViaParent"]> extends infer RelationInclude
         ? RelationInclude extends true
@@ -108,17 +112,17 @@ export type TodoIncludedRelations<I extends TodoInclude = {}> = {
               ? TodoWithIncludes<RelationInclude>[]
               : never
         : never
-    : K extends "project"
-      ? NonNullable<I["project"]> extends infer RelationInclude
-        ? RelationInclude extends true
-          ? Project | undefined
-          : RelationInclude extends AnyProjectQueryBuilder<infer QueryRow>
-            ? QueryRow | undefined
-            : RelationInclude extends ProjectInclude
-              ? ProjectWithIncludes<RelationInclude> | undefined
-              : never
-        : never
-    : never;
+      : K extends "project"
+        ? NonNullable<I["project"]> extends infer RelationInclude
+          ? RelationInclude extends true
+            ? Project | undefined
+            : RelationInclude extends AnyProjectQueryBuilder<infer QueryRow>
+              ? QueryRow | undefined
+              : RelationInclude extends ProjectInclude
+                ? ProjectWithIncludes<RelationInclude> | undefined
+                : never
+          : never
+        : never;
 };
 
 export interface ProjectRelations {
@@ -131,144 +135,160 @@ export interface TodoRelations {
   project: Project;
 }
 
-export type ProjectWithIncludes<I extends ProjectInclude = {}> = Omit<Project, Extract<keyof I, keyof Project>> & ProjectIncludedRelations<I>;
+export type ProjectWithIncludes<I extends ProjectInclude = {}> = Omit<
+  Project,
+  Extract<keyof I, keyof Project>
+> &
+  ProjectIncludedRelations<I>;
 
-export type TodoWithIncludes<I extends TodoInclude = {}> = Omit<Todo, Extract<keyof I, keyof Todo>> & TodoIncludedRelations<I>;
+export type TodoWithIncludes<I extends TodoInclude = {}> = Omit<
+  Todo,
+  Extract<keyof I, keyof Todo>
+> &
+  TodoIncludedRelations<I>;
 
 export type ProjectSelectableColumn = keyof Project | PermissionIntrospectionColumn | "*";
 export type ProjectOrderableColumn = keyof Project | PermissionIntrospectionColumn;
 
-export type ProjectSelected<S extends ProjectSelectableColumn = keyof Project> = "*" extends S ? Project : Pick<Project, Extract<S | "id", keyof Project>> & Pick<PermissionIntrospectionColumns, Extract<S, PermissionIntrospectionColumn>>;
+export type ProjectSelected<S extends ProjectSelectableColumn = keyof Project> = "*" extends S
+  ? Project
+  : Pick<Project, Extract<S | "id", keyof Project>> &
+      Pick<PermissionIntrospectionColumns, Extract<S, PermissionIntrospectionColumn>>;
 
-export type ProjectSelectedWithIncludes<I extends ProjectInclude = {}, S extends ProjectSelectableColumn = keyof Project> = Omit<ProjectSelected<S>, Extract<keyof I, keyof ProjectSelected<S>>> & ProjectIncludedRelations<I>;
+export type ProjectSelectedWithIncludes<
+  I extends ProjectInclude = {},
+  S extends ProjectSelectableColumn = keyof Project,
+> = Omit<ProjectSelected<S>, Extract<keyof I, keyof ProjectSelected<S>>> &
+  ProjectIncludedRelations<I>;
 
 export type TodoSelectableColumn = keyof Todo | PermissionIntrospectionColumn | "*";
 export type TodoOrderableColumn = keyof Todo | PermissionIntrospectionColumn;
 
-export type TodoSelected<S extends TodoSelectableColumn = keyof Todo> = "*" extends S ? Todo : Pick<Todo, Extract<S | "id", keyof Todo>> & Pick<PermissionIntrospectionColumns, Extract<S, PermissionIntrospectionColumn>>;
+export type TodoSelected<S extends TodoSelectableColumn = keyof Todo> = "*" extends S
+  ? Todo
+  : Pick<Todo, Extract<S | "id", keyof Todo>> &
+      Pick<PermissionIntrospectionColumns, Extract<S, PermissionIntrospectionColumn>>;
 
-export type TodoSelectedWithIncludes<I extends TodoInclude = {}, S extends TodoSelectableColumn = keyof Todo> = Omit<TodoSelected<S>, Extract<keyof I, keyof TodoSelected<S>>> & TodoIncludedRelations<I>;
+export type TodoSelectedWithIncludes<
+  I extends TodoInclude = {},
+  S extends TodoSelectableColumn = keyof Todo,
+> = Omit<TodoSelected<S>, Extract<keyof I, keyof TodoSelected<S>>> & TodoIncludedRelations<I>;
 
 export const wasmSchema: WasmSchema = {
-  "projects": {
-    "columns": [
+  projects: {
+    columns: [
       {
-        "name": "name",
-        "column_type": {
-          "type": "Text"
+        name: "name",
+        column_type: {
+          type: "Text",
         },
-        "nullable": false
-      }
-    ]
-  },
-  "todos": {
-    "columns": [
-      {
-        "name": "title",
-        "column_type": {
-          "type": "Text"
-        },
-        "nullable": false
+        nullable: false,
       },
-      {
-        "name": "done",
-        "column_type": {
-          "type": "Boolean"
-        },
-        "nullable": false
-      },
-      {
-        "name": "description",
-        "column_type": {
-          "type": "Text"
-        },
-        "nullable": true
-      },
-      {
-        "name": "owner_id",
-        "column_type": {
-          "type": "Text"
-        },
-        "nullable": false
-      },
-      {
-        "name": "parent",
-        "column_type": {
-          "type": "Uuid"
-        },
-        "nullable": true,
-        "references": "todos"
-      },
-      {
-        "name": "project",
-        "column_type": {
-          "type": "Uuid"
-        },
-        "nullable": true,
-        "references": "projects"
-      }
     ],
-    "policies": {
-      "select": {
-        "using": {
-          "type": "True"
-        }
-      },
-      "insert": {
-        "with_check": {
-          "type": "Cmp",
-          "column": "owner_id",
-          "op": "Eq",
-          "value": {
-            "type": "SessionRef",
-            "path": [
-              "user_id"
-            ]
-          }
-        }
-      },
-      "update": {
-        "using": {
-          "type": "Cmp",
-          "column": "owner_id",
-          "op": "Eq",
-          "value": {
-            "type": "SessionRef",
-            "path": [
-              "user_id"
-            ]
-          }
+  },
+  todos: {
+    columns: [
+      {
+        name: "title",
+        column_type: {
+          type: "Text",
         },
-        "with_check": {
-          "type": "Cmp",
-          "column": "owner_id",
-          "op": "Eq",
-          "value": {
-            "type": "SessionRef",
-            "path": [
-              "user_id"
-            ]
-          }
-        }
+        nullable: false,
       },
-      "delete": {
-        "using": {
-          "type": "Cmp",
-          "column": "owner_id",
-          "op": "Eq",
-          "value": {
-            "type": "SessionRef",
-            "path": [
-              "user_id"
-            ]
-          }
-        }
-      }
-    }
-  }
+      {
+        name: "done",
+        column_type: {
+          type: "Boolean",
+        },
+        nullable: false,
+      },
+      {
+        name: "description",
+        column_type: {
+          type: "Text",
+        },
+        nullable: true,
+      },
+      {
+        name: "owner_id",
+        column_type: {
+          type: "Text",
+        },
+        nullable: false,
+      },
+      {
+        name: "parent",
+        column_type: {
+          type: "Uuid",
+        },
+        nullable: true,
+        references: "todos",
+      },
+      {
+        name: "project",
+        column_type: {
+          type: "Uuid",
+        },
+        nullable: true,
+        references: "projects",
+      },
+    ],
+    policies: {
+      select: {
+        using: {
+          type: "True",
+        },
+      },
+      insert: {
+        with_check: {
+          type: "Cmp",
+          column: "owner_id",
+          op: "Eq",
+          value: {
+            type: "SessionRef",
+            path: ["user_id"],
+          },
+        },
+      },
+      update: {
+        using: {
+          type: "Cmp",
+          column: "owner_id",
+          op: "Eq",
+          value: {
+            type: "SessionRef",
+            path: ["user_id"],
+          },
+        },
+        with_check: {
+          type: "Cmp",
+          column: "owner_id",
+          op: "Eq",
+          value: {
+            type: "SessionRef",
+            path: ["user_id"],
+          },
+        },
+      },
+      delete: {
+        using: {
+          type: "Cmp",
+          column: "owner_id",
+          op: "Eq",
+          value: {
+            type: "SessionRef",
+            path: ["user_id"],
+          },
+        },
+      },
+    },
+  },
 };
 
-export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends ProjectSelectableColumn = keyof Project> implements QueryBuilder<ProjectSelectedWithIncludes<I, S>> {
+export class ProjectQueryBuilder<
+  I extends ProjectInclude = {},
+  S extends ProjectSelectableColumn = keyof Project,
+> implements QueryBuilder<ProjectSelectedWithIncludes<I, S>> {
   readonly _table = "projects";
   readonly _schema: WasmSchema = wasmSchema;
   readonly _rowType!: ProjectSelectedWithIncludes<I, S>;
@@ -305,7 +325,9 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
     return clone;
   }
 
-  select<NewS extends ProjectSelectableColumn>(...columns: [NewS, ...NewS[]]): ProjectQueryBuilder<I, NewS> {
+  select<NewS extends ProjectSelectableColumn>(
+    ...columns: [NewS, ...NewS[]]
+  ): ProjectQueryBuilder<I, NewS> {
     const clone = this._clone<I, NewS>();
     clone._selectColumns = [...columns] as string[];
     return clone;
@@ -317,7 +339,10 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
     return clone;
   }
 
-  orderBy(column: ProjectOrderableColumn, direction: "asc" | "desc" = "asc"): ProjectQueryBuilder<I, S> {
+  orderBy(
+    column: ProjectOrderableColumn,
+    direction: "asc" | "desc" = "asc",
+  ): ProjectQueryBuilder<I, S> {
     const clone = this._clone();
     clone._orderBys.push([column as string, direction]);
     return clone;
@@ -366,13 +391,15 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
 
     const currentToken = "__jazz_gather_current__";
     const stepOutput = options.step({ current: currentToken });
-    if (!stepOutput || typeof stepOutput !== "object" || typeof (stepOutput as { _build?: unknown })._build !== "function") {
+    if (
+      !stepOutput ||
+      typeof stepOutput !== "object" ||
+      typeof (stepOutput as { _build?: unknown })._build !== "function"
+    ) {
       throw new Error("gather(...) step must return a query expression built from app.<table>.");
     }
 
-    const stepBuilt = JSON.parse(
-      stepOutput._build(),
-    ) as {
+    const stepBuilt = JSON.parse(stepOutput._build()) as {
       table?: unknown;
       conditions?: Array<{ column: string; op: string; value: unknown }>;
       hops?: unknown;
@@ -396,7 +423,9 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
       (condition) => condition.op === "eq" && condition.value === currentToken,
     );
     if (currentConditions.length !== 1) {
-      throw new Error("gather(...) step must include exactly one where condition bound to current.");
+      throw new Error(
+        "gather(...) step must include exactly one where condition bound to current.",
+      );
     }
 
     const currentCondition = currentConditions[0];
@@ -436,7 +465,10 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
     return JSON.parse(this._build());
   }
 
-  private _clone<CloneI extends ProjectInclude = I, CloneS extends ProjectSelectableColumn = S>(): ProjectQueryBuilder<CloneI, CloneS> {
+  private _clone<
+    CloneI extends ProjectInclude = I,
+    CloneS extends ProjectSelectableColumn = S,
+  >(): ProjectQueryBuilder<CloneI, CloneS> {
     const clone = new ProjectQueryBuilder<CloneI, CloneS>();
     clone._conditions = [...this._conditions];
     clone._includes = { ...this._includes };
@@ -456,7 +488,10 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
   }
 }
 
-export class TodoQueryBuilder<I extends TodoInclude = {}, S extends TodoSelectableColumn = keyof Todo> implements QueryBuilder<TodoSelectedWithIncludes<I, S>> {
+export class TodoQueryBuilder<
+  I extends TodoInclude = {},
+  S extends TodoSelectableColumn = keyof Todo,
+> implements QueryBuilder<TodoSelectedWithIncludes<I, S>> {
   readonly _table = "todos";
   readonly _schema: WasmSchema = wasmSchema;
   readonly _rowType!: TodoSelectedWithIncludes<I, S>;
@@ -493,7 +528,9 @@ export class TodoQueryBuilder<I extends TodoInclude = {}, S extends TodoSelectab
     return clone;
   }
 
-  select<NewS extends TodoSelectableColumn>(...columns: [NewS, ...NewS[]]): TodoQueryBuilder<I, NewS> {
+  select<NewS extends TodoSelectableColumn>(
+    ...columns: [NewS, ...NewS[]]
+  ): TodoQueryBuilder<I, NewS> {
     const clone = this._clone<I, NewS>();
     clone._selectColumns = [...columns] as string[];
     return clone;
@@ -554,13 +591,15 @@ export class TodoQueryBuilder<I extends TodoInclude = {}, S extends TodoSelectab
 
     const currentToken = "__jazz_gather_current__";
     const stepOutput = options.step({ current: currentToken });
-    if (!stepOutput || typeof stepOutput !== "object" || typeof (stepOutput as { _build?: unknown })._build !== "function") {
+    if (
+      !stepOutput ||
+      typeof stepOutput !== "object" ||
+      typeof (stepOutput as { _build?: unknown })._build !== "function"
+    ) {
       throw new Error("gather(...) step must return a query expression built from app.<table>.");
     }
 
-    const stepBuilt = JSON.parse(
-      stepOutput._build(),
-    ) as {
+    const stepBuilt = JSON.parse(stepOutput._build()) as {
       table?: unknown;
       conditions?: Array<{ column: string; op: string; value: unknown }>;
       hops?: unknown;
@@ -584,7 +623,9 @@ export class TodoQueryBuilder<I extends TodoInclude = {}, S extends TodoSelectab
       (condition) => condition.op === "eq" && condition.value === currentToken,
     );
     if (currentConditions.length !== 1) {
-      throw new Error("gather(...) step must include exactly one where condition bound to current.");
+      throw new Error(
+        "gather(...) step must include exactly one where condition bound to current.",
+      );
     }
 
     const currentCondition = currentConditions[0];
@@ -624,7 +665,10 @@ export class TodoQueryBuilder<I extends TodoInclude = {}, S extends TodoSelectab
     return JSON.parse(this._build());
   }
 
-  private _clone<CloneI extends TodoInclude = I, CloneS extends TodoSelectableColumn = S>(): TodoQueryBuilder<CloneI, CloneS> {
+  private _clone<
+    CloneI extends TodoInclude = I,
+    CloneS extends TodoSelectableColumn = S,
+  >(): TodoQueryBuilder<CloneI, CloneS> {
     const clone = new TodoQueryBuilder<CloneI, CloneS>();
     clone._conditions = [...this._conditions];
     clone._includes = { ...this._includes };

--- a/examples/todo-client-localfirst-ts/schema/app.ts
+++ b/examples/todo-client-localfirst-ts/schema/app.ts
@@ -271,8 +271,8 @@ export const wasmSchema: WasmSchema = {
 export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends ProjectSelectableColumn = keyof Project> implements QueryBuilder<ProjectSelectedWithIncludes<I, S>> {
   readonly _table = "projects";
   readonly _schema: WasmSchema = wasmSchema;
-  declare readonly _rowType: ProjectSelectedWithIncludes<I, S>;
-  declare readonly _initType: ProjectInit;
+  readonly _rowType!: ProjectSelectedWithIncludes<I, S>;
+  readonly _initType!: ProjectInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<ProjectInclude> = {};
   private _selectColumns?: string[];
@@ -459,8 +459,8 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
 export class TodoQueryBuilder<I extends TodoInclude = {}, S extends TodoSelectableColumn = keyof Todo> implements QueryBuilder<TodoSelectedWithIncludes<I, S>> {
   readonly _table = "todos";
   readonly _schema: WasmSchema = wasmSchema;
-  declare readonly _rowType: TodoSelectedWithIncludes<I, S>;
-  declare readonly _initType: TodoInit;
+  readonly _rowType!: TodoSelectedWithIncludes<I, S>;
+  readonly _initType!: TodoInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<TodoInclude> = {};
   private _selectColumns?: string[];

--- a/examples/todo-client-localfirst-ts/schema/app.ts
+++ b/examples/todo-client-localfirst-ts/schema/app.ts
@@ -1,6 +1,12 @@
 // AUTO-GENERATED FILE - DO NOT EDIT
 import type { WasmSchema, QueryBuilder } from "jazz-tools";
-export type JsonValue = string | number | boolean | null | { [key: string]: JsonValue } | JsonValue[];
+export type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: JsonValue }
+  | JsonValue[];
 
 export type PermissionIntrospectionColumn = "$canRead" | "$canEdit" | "$canDelete";
 export interface PermissionIntrospectionColumns {
@@ -72,32 +78,30 @@ export interface TodoInclude {
 }
 
 export type ProjectIncludedRelations<I extends ProjectInclude = {}> = {
-  [K in keyof I]-?:
-    K extends "todosViaProject"
-      ? NonNullable<I["todosViaProject"]> extends infer RelationInclude
-        ? RelationInclude extends true
-          ? Todo[]
-          : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
-            ? QueryRow[]
-            : RelationInclude extends TodoInclude
-              ? TodoWithIncludes<RelationInclude>[]
-              : never
-        : never
+  [K in keyof I]-?: K extends "todosViaProject"
+    ? NonNullable<I["todosViaProject"]> extends infer RelationInclude
+      ? RelationInclude extends true
+        ? Todo[]
+        : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
+          ? QueryRow[]
+          : RelationInclude extends TodoInclude
+            ? TodoWithIncludes<RelationInclude>[]
+            : never
+      : never
     : never;
 };
 
 export type TodoIncludedRelations<I extends TodoInclude = {}> = {
-  [K in keyof I]-?:
-    K extends "parent"
-      ? NonNullable<I["parent"]> extends infer RelationInclude
-        ? RelationInclude extends true
-          ? Todo | undefined
-          : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
-            ? QueryRow | undefined
-            : RelationInclude extends TodoInclude
-              ? TodoWithIncludes<RelationInclude> | undefined
-              : never
-        : never
+  [K in keyof I]-?: K extends "parent"
+    ? NonNullable<I["parent"]> extends infer RelationInclude
+      ? RelationInclude extends true
+        ? Todo | undefined
+        : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
+          ? QueryRow | undefined
+          : RelationInclude extends TodoInclude
+            ? TodoWithIncludes<RelationInclude> | undefined
+            : never
+      : never
     : K extends "todosViaParent"
       ? NonNullable<I["todosViaParent"]> extends infer RelationInclude
         ? RelationInclude extends true
@@ -108,17 +112,17 @@ export type TodoIncludedRelations<I extends TodoInclude = {}> = {
               ? TodoWithIncludes<RelationInclude>[]
               : never
         : never
-    : K extends "project"
-      ? NonNullable<I["project"]> extends infer RelationInclude
-        ? RelationInclude extends true
-          ? Project | undefined
-          : RelationInclude extends AnyProjectQueryBuilder<infer QueryRow>
-            ? QueryRow | undefined
-            : RelationInclude extends ProjectInclude
-              ? ProjectWithIncludes<RelationInclude> | undefined
-              : never
-        : never
-    : never;
+      : K extends "project"
+        ? NonNullable<I["project"]> extends infer RelationInclude
+          ? RelationInclude extends true
+            ? Project | undefined
+            : RelationInclude extends AnyProjectQueryBuilder<infer QueryRow>
+              ? QueryRow | undefined
+              : RelationInclude extends ProjectInclude
+                ? ProjectWithIncludes<RelationInclude> | undefined
+                : never
+          : never
+        : never;
 };
 
 export interface ProjectRelations {
@@ -131,144 +135,160 @@ export interface TodoRelations {
   project: Project;
 }
 
-export type ProjectWithIncludes<I extends ProjectInclude = {}> = Omit<Project, Extract<keyof I, keyof Project>> & ProjectIncludedRelations<I>;
+export type ProjectWithIncludes<I extends ProjectInclude = {}> = Omit<
+  Project,
+  Extract<keyof I, keyof Project>
+> &
+  ProjectIncludedRelations<I>;
 
-export type TodoWithIncludes<I extends TodoInclude = {}> = Omit<Todo, Extract<keyof I, keyof Todo>> & TodoIncludedRelations<I>;
+export type TodoWithIncludes<I extends TodoInclude = {}> = Omit<
+  Todo,
+  Extract<keyof I, keyof Todo>
+> &
+  TodoIncludedRelations<I>;
 
 export type ProjectSelectableColumn = keyof Project | PermissionIntrospectionColumn | "*";
 export type ProjectOrderableColumn = keyof Project | PermissionIntrospectionColumn;
 
-export type ProjectSelected<S extends ProjectSelectableColumn = keyof Project> = "*" extends S ? Project : Pick<Project, Extract<S | "id", keyof Project>> & Pick<PermissionIntrospectionColumns, Extract<S, PermissionIntrospectionColumn>>;
+export type ProjectSelected<S extends ProjectSelectableColumn = keyof Project> = "*" extends S
+  ? Project
+  : Pick<Project, Extract<S | "id", keyof Project>> &
+      Pick<PermissionIntrospectionColumns, Extract<S, PermissionIntrospectionColumn>>;
 
-export type ProjectSelectedWithIncludes<I extends ProjectInclude = {}, S extends ProjectSelectableColumn = keyof Project> = Omit<ProjectSelected<S>, Extract<keyof I, keyof ProjectSelected<S>>> & ProjectIncludedRelations<I>;
+export type ProjectSelectedWithIncludes<
+  I extends ProjectInclude = {},
+  S extends ProjectSelectableColumn = keyof Project,
+> = Omit<ProjectSelected<S>, Extract<keyof I, keyof ProjectSelected<S>>> &
+  ProjectIncludedRelations<I>;
 
 export type TodoSelectableColumn = keyof Todo | PermissionIntrospectionColumn | "*";
 export type TodoOrderableColumn = keyof Todo | PermissionIntrospectionColumn;
 
-export type TodoSelected<S extends TodoSelectableColumn = keyof Todo> = "*" extends S ? Todo : Pick<Todo, Extract<S | "id", keyof Todo>> & Pick<PermissionIntrospectionColumns, Extract<S, PermissionIntrospectionColumn>>;
+export type TodoSelected<S extends TodoSelectableColumn = keyof Todo> = "*" extends S
+  ? Todo
+  : Pick<Todo, Extract<S | "id", keyof Todo>> &
+      Pick<PermissionIntrospectionColumns, Extract<S, PermissionIntrospectionColumn>>;
 
-export type TodoSelectedWithIncludes<I extends TodoInclude = {}, S extends TodoSelectableColumn = keyof Todo> = Omit<TodoSelected<S>, Extract<keyof I, keyof TodoSelected<S>>> & TodoIncludedRelations<I>;
+export type TodoSelectedWithIncludes<
+  I extends TodoInclude = {},
+  S extends TodoSelectableColumn = keyof Todo,
+> = Omit<TodoSelected<S>, Extract<keyof I, keyof TodoSelected<S>>> & TodoIncludedRelations<I>;
 
 export const wasmSchema: WasmSchema = {
-  "projects": {
-    "columns": [
+  projects: {
+    columns: [
       {
-        "name": "name",
-        "column_type": {
-          "type": "Text"
+        name: "name",
+        column_type: {
+          type: "Text",
         },
-        "nullable": false
-      }
-    ]
-  },
-  "todos": {
-    "columns": [
-      {
-        "name": "title",
-        "column_type": {
-          "type": "Text"
-        },
-        "nullable": false
+        nullable: false,
       },
-      {
-        "name": "done",
-        "column_type": {
-          "type": "Boolean"
-        },
-        "nullable": false
-      },
-      {
-        "name": "description",
-        "column_type": {
-          "type": "Text"
-        },
-        "nullable": true
-      },
-      {
-        "name": "owner_id",
-        "column_type": {
-          "type": "Text"
-        },
-        "nullable": false
-      },
-      {
-        "name": "parent",
-        "column_type": {
-          "type": "Uuid"
-        },
-        "nullable": true,
-        "references": "todos"
-      },
-      {
-        "name": "project",
-        "column_type": {
-          "type": "Uuid"
-        },
-        "nullable": true,
-        "references": "projects"
-      }
     ],
-    "policies": {
-      "select": {
-        "using": {
-          "type": "True"
-        }
-      },
-      "insert": {
-        "with_check": {
-          "type": "Cmp",
-          "column": "owner_id",
-          "op": "Eq",
-          "value": {
-            "type": "SessionRef",
-            "path": [
-              "user_id"
-            ]
-          }
-        }
-      },
-      "update": {
-        "using": {
-          "type": "Cmp",
-          "column": "owner_id",
-          "op": "Eq",
-          "value": {
-            "type": "SessionRef",
-            "path": [
-              "user_id"
-            ]
-          }
+  },
+  todos: {
+    columns: [
+      {
+        name: "title",
+        column_type: {
+          type: "Text",
         },
-        "with_check": {
-          "type": "Cmp",
-          "column": "owner_id",
-          "op": "Eq",
-          "value": {
-            "type": "SessionRef",
-            "path": [
-              "user_id"
-            ]
-          }
-        }
+        nullable: false,
       },
-      "delete": {
-        "using": {
-          "type": "Cmp",
-          "column": "owner_id",
-          "op": "Eq",
-          "value": {
-            "type": "SessionRef",
-            "path": [
-              "user_id"
-            ]
-          }
-        }
-      }
-    }
-  }
+      {
+        name: "done",
+        column_type: {
+          type: "Boolean",
+        },
+        nullable: false,
+      },
+      {
+        name: "description",
+        column_type: {
+          type: "Text",
+        },
+        nullable: true,
+      },
+      {
+        name: "owner_id",
+        column_type: {
+          type: "Text",
+        },
+        nullable: false,
+      },
+      {
+        name: "parent",
+        column_type: {
+          type: "Uuid",
+        },
+        nullable: true,
+        references: "todos",
+      },
+      {
+        name: "project",
+        column_type: {
+          type: "Uuid",
+        },
+        nullable: true,
+        references: "projects",
+      },
+    ],
+    policies: {
+      select: {
+        using: {
+          type: "True",
+        },
+      },
+      insert: {
+        with_check: {
+          type: "Cmp",
+          column: "owner_id",
+          op: "Eq",
+          value: {
+            type: "SessionRef",
+            path: ["user_id"],
+          },
+        },
+      },
+      update: {
+        using: {
+          type: "Cmp",
+          column: "owner_id",
+          op: "Eq",
+          value: {
+            type: "SessionRef",
+            path: ["user_id"],
+          },
+        },
+        with_check: {
+          type: "Cmp",
+          column: "owner_id",
+          op: "Eq",
+          value: {
+            type: "SessionRef",
+            path: ["user_id"],
+          },
+        },
+      },
+      delete: {
+        using: {
+          type: "Cmp",
+          column: "owner_id",
+          op: "Eq",
+          value: {
+            type: "SessionRef",
+            path: ["user_id"],
+          },
+        },
+      },
+    },
+  },
 };
 
-export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends ProjectSelectableColumn = keyof Project> implements QueryBuilder<ProjectSelectedWithIncludes<I, S>> {
+export class ProjectQueryBuilder<
+  I extends ProjectInclude = {},
+  S extends ProjectSelectableColumn = keyof Project,
+> implements QueryBuilder<ProjectSelectedWithIncludes<I, S>> {
   readonly _table = "projects";
   readonly _schema: WasmSchema = wasmSchema;
   readonly _rowType!: ProjectSelectedWithIncludes<I, S>;
@@ -305,7 +325,9 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
     return clone;
   }
 
-  select<NewS extends ProjectSelectableColumn>(...columns: [NewS, ...NewS[]]): ProjectQueryBuilder<I, NewS> {
+  select<NewS extends ProjectSelectableColumn>(
+    ...columns: [NewS, ...NewS[]]
+  ): ProjectQueryBuilder<I, NewS> {
     const clone = this._clone<I, NewS>();
     clone._selectColumns = [...columns] as string[];
     return clone;
@@ -317,7 +339,10 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
     return clone;
   }
 
-  orderBy(column: ProjectOrderableColumn, direction: "asc" | "desc" = "asc"): ProjectQueryBuilder<I, S> {
+  orderBy(
+    column: ProjectOrderableColumn,
+    direction: "asc" | "desc" = "asc",
+  ): ProjectQueryBuilder<I, S> {
     const clone = this._clone();
     clone._orderBys.push([column as string, direction]);
     return clone;
@@ -366,13 +391,15 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
 
     const currentToken = "__jazz_gather_current__";
     const stepOutput = options.step({ current: currentToken });
-    if (!stepOutput || typeof stepOutput !== "object" || typeof (stepOutput as { _build?: unknown })._build !== "function") {
+    if (
+      !stepOutput ||
+      typeof stepOutput !== "object" ||
+      typeof (stepOutput as { _build?: unknown })._build !== "function"
+    ) {
       throw new Error("gather(...) step must return a query expression built from app.<table>.");
     }
 
-    const stepBuilt = JSON.parse(
-      stepOutput._build(),
-    ) as {
+    const stepBuilt = JSON.parse(stepOutput._build()) as {
       table?: unknown;
       conditions?: Array<{ column: string; op: string; value: unknown }>;
       hops?: unknown;
@@ -396,7 +423,9 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
       (condition) => condition.op === "eq" && condition.value === currentToken,
     );
     if (currentConditions.length !== 1) {
-      throw new Error("gather(...) step must include exactly one where condition bound to current.");
+      throw new Error(
+        "gather(...) step must include exactly one where condition bound to current.",
+      );
     }
 
     const currentCondition = currentConditions[0];
@@ -436,7 +465,10 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
     return JSON.parse(this._build());
   }
 
-  private _clone<CloneI extends ProjectInclude = I, CloneS extends ProjectSelectableColumn = S>(): ProjectQueryBuilder<CloneI, CloneS> {
+  private _clone<
+    CloneI extends ProjectInclude = I,
+    CloneS extends ProjectSelectableColumn = S,
+  >(): ProjectQueryBuilder<CloneI, CloneS> {
     const clone = new ProjectQueryBuilder<CloneI, CloneS>();
     clone._conditions = [...this._conditions];
     clone._includes = { ...this._includes };
@@ -456,7 +488,10 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
   }
 }
 
-export class TodoQueryBuilder<I extends TodoInclude = {}, S extends TodoSelectableColumn = keyof Todo> implements QueryBuilder<TodoSelectedWithIncludes<I, S>> {
+export class TodoQueryBuilder<
+  I extends TodoInclude = {},
+  S extends TodoSelectableColumn = keyof Todo,
+> implements QueryBuilder<TodoSelectedWithIncludes<I, S>> {
   readonly _table = "todos";
   readonly _schema: WasmSchema = wasmSchema;
   readonly _rowType!: TodoSelectedWithIncludes<I, S>;
@@ -493,7 +528,9 @@ export class TodoQueryBuilder<I extends TodoInclude = {}, S extends TodoSelectab
     return clone;
   }
 
-  select<NewS extends TodoSelectableColumn>(...columns: [NewS, ...NewS[]]): TodoQueryBuilder<I, NewS> {
+  select<NewS extends TodoSelectableColumn>(
+    ...columns: [NewS, ...NewS[]]
+  ): TodoQueryBuilder<I, NewS> {
     const clone = this._clone<I, NewS>();
     clone._selectColumns = [...columns] as string[];
     return clone;
@@ -554,13 +591,15 @@ export class TodoQueryBuilder<I extends TodoInclude = {}, S extends TodoSelectab
 
     const currentToken = "__jazz_gather_current__";
     const stepOutput = options.step({ current: currentToken });
-    if (!stepOutput || typeof stepOutput !== "object" || typeof (stepOutput as { _build?: unknown })._build !== "function") {
+    if (
+      !stepOutput ||
+      typeof stepOutput !== "object" ||
+      typeof (stepOutput as { _build?: unknown })._build !== "function"
+    ) {
       throw new Error("gather(...) step must return a query expression built from app.<table>.");
     }
 
-    const stepBuilt = JSON.parse(
-      stepOutput._build(),
-    ) as {
+    const stepBuilt = JSON.parse(stepOutput._build()) as {
       table?: unknown;
       conditions?: Array<{ column: string; op: string; value: unknown }>;
       hops?: unknown;
@@ -584,7 +623,9 @@ export class TodoQueryBuilder<I extends TodoInclude = {}, S extends TodoSelectab
       (condition) => condition.op === "eq" && condition.value === currentToken,
     );
     if (currentConditions.length !== 1) {
-      throw new Error("gather(...) step must include exactly one where condition bound to current.");
+      throw new Error(
+        "gather(...) step must include exactly one where condition bound to current.",
+      );
     }
 
     const currentCondition = currentConditions[0];
@@ -624,7 +665,10 @@ export class TodoQueryBuilder<I extends TodoInclude = {}, S extends TodoSelectab
     return JSON.parse(this._build());
   }
 
-  private _clone<CloneI extends TodoInclude = I, CloneS extends TodoSelectableColumn = S>(): TodoQueryBuilder<CloneI, CloneS> {
+  private _clone<
+    CloneI extends TodoInclude = I,
+    CloneS extends TodoSelectableColumn = S,
+  >(): TodoQueryBuilder<CloneI, CloneS> {
     const clone = new TodoQueryBuilder<CloneI, CloneS>();
     clone._conditions = [...this._conditions];
     clone._includes = { ...this._includes };

--- a/examples/todo-server-ts/schema/app.ts
+++ b/examples/todo-server-ts/schema/app.ts
@@ -1,6 +1,12 @@
 // AUTO-GENERATED FILE - DO NOT EDIT
 import type { WasmSchema, QueryBuilder } from "jazz-tools";
-export type JsonValue = string | number | boolean | null | { [key: string]: JsonValue } | JsonValue[];
+export type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: JsonValue }
+  | JsonValue[];
 
 export type PermissionIntrospectionColumn = "$canRead" | "$canEdit" | "$canDelete";
 export interface PermissionIntrospectionColumns {
@@ -72,32 +78,30 @@ export interface TodoInclude {
 }
 
 export type ProjectIncludedRelations<I extends ProjectInclude = {}> = {
-  [K in keyof I]-?:
-    K extends "todosViaProject"
-      ? NonNullable<I["todosViaProject"]> extends infer RelationInclude
-        ? RelationInclude extends true
-          ? Todo[]
-          : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
-            ? QueryRow[]
-            : RelationInclude extends TodoInclude
-              ? TodoWithIncludes<RelationInclude>[]
-              : never
-        : never
+  [K in keyof I]-?: K extends "todosViaProject"
+    ? NonNullable<I["todosViaProject"]> extends infer RelationInclude
+      ? RelationInclude extends true
+        ? Todo[]
+        : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
+          ? QueryRow[]
+          : RelationInclude extends TodoInclude
+            ? TodoWithIncludes<RelationInclude>[]
+            : never
+      : never
     : never;
 };
 
 export type TodoIncludedRelations<I extends TodoInclude = {}> = {
-  [K in keyof I]-?:
-    K extends "parent"
-      ? NonNullable<I["parent"]> extends infer RelationInclude
-        ? RelationInclude extends true
-          ? Todo | undefined
-          : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
-            ? QueryRow | undefined
-            : RelationInclude extends TodoInclude
-              ? TodoWithIncludes<RelationInclude> | undefined
-              : never
-        : never
+  [K in keyof I]-?: K extends "parent"
+    ? NonNullable<I["parent"]> extends infer RelationInclude
+      ? RelationInclude extends true
+        ? Todo | undefined
+        : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
+          ? QueryRow | undefined
+          : RelationInclude extends TodoInclude
+            ? TodoWithIncludes<RelationInclude> | undefined
+            : never
+      : never
     : K extends "todosViaParent"
       ? NonNullable<I["todosViaParent"]> extends infer RelationInclude
         ? RelationInclude extends true
@@ -108,17 +112,17 @@ export type TodoIncludedRelations<I extends TodoInclude = {}> = {
               ? TodoWithIncludes<RelationInclude>[]
               : never
         : never
-    : K extends "project"
-      ? NonNullable<I["project"]> extends infer RelationInclude
-        ? RelationInclude extends true
-          ? Project | undefined
-          : RelationInclude extends AnyProjectQueryBuilder<infer QueryRow>
-            ? QueryRow | undefined
-            : RelationInclude extends ProjectInclude
-              ? ProjectWithIncludes<RelationInclude> | undefined
-              : never
-        : never
-    : never;
+      : K extends "project"
+        ? NonNullable<I["project"]> extends infer RelationInclude
+          ? RelationInclude extends true
+            ? Project | undefined
+            : RelationInclude extends AnyProjectQueryBuilder<infer QueryRow>
+              ? QueryRow | undefined
+              : RelationInclude extends ProjectInclude
+                ? ProjectWithIncludes<RelationInclude> | undefined
+                : never
+          : never
+        : never;
 };
 
 export interface ProjectRelations {
@@ -131,152 +135,166 @@ export interface TodoRelations {
   project: Project;
 }
 
-export type ProjectWithIncludes<I extends ProjectInclude = {}> = Omit<Project, Extract<keyof I, keyof Project>> & ProjectIncludedRelations<I>;
+export type ProjectWithIncludes<I extends ProjectInclude = {}> = Omit<
+  Project,
+  Extract<keyof I, keyof Project>
+> &
+  ProjectIncludedRelations<I>;
 
-export type TodoWithIncludes<I extends TodoInclude = {}> = Omit<Todo, Extract<keyof I, keyof Todo>> & TodoIncludedRelations<I>;
+export type TodoWithIncludes<I extends TodoInclude = {}> = Omit<
+  Todo,
+  Extract<keyof I, keyof Todo>
+> &
+  TodoIncludedRelations<I>;
 
 export type ProjectSelectableColumn = keyof Project | PermissionIntrospectionColumn | "*";
 export type ProjectOrderableColumn = keyof Project | PermissionIntrospectionColumn;
 
-export type ProjectSelected<S extends ProjectSelectableColumn = keyof Project> = "*" extends S ? Project : Pick<Project, Extract<S | "id", keyof Project>> & Pick<PermissionIntrospectionColumns, Extract<S, PermissionIntrospectionColumn>>;
+export type ProjectSelected<S extends ProjectSelectableColumn = keyof Project> = "*" extends S
+  ? Project
+  : Pick<Project, Extract<S | "id", keyof Project>> &
+      Pick<PermissionIntrospectionColumns, Extract<S, PermissionIntrospectionColumn>>;
 
-export type ProjectSelectedWithIncludes<I extends ProjectInclude = {}, S extends ProjectSelectableColumn = keyof Project> = Omit<ProjectSelected<S>, Extract<keyof I, keyof ProjectSelected<S>>> & ProjectIncludedRelations<I>;
+export type ProjectSelectedWithIncludes<
+  I extends ProjectInclude = {},
+  S extends ProjectSelectableColumn = keyof Project,
+> = Omit<ProjectSelected<S>, Extract<keyof I, keyof ProjectSelected<S>>> &
+  ProjectIncludedRelations<I>;
 
 export type TodoSelectableColumn = keyof Todo | PermissionIntrospectionColumn | "*";
 export type TodoOrderableColumn = keyof Todo | PermissionIntrospectionColumn;
 
-export type TodoSelected<S extends TodoSelectableColumn = keyof Todo> = "*" extends S ? Todo : Pick<Todo, Extract<S | "id", keyof Todo>> & Pick<PermissionIntrospectionColumns, Extract<S, PermissionIntrospectionColumn>>;
+export type TodoSelected<S extends TodoSelectableColumn = keyof Todo> = "*" extends S
+  ? Todo
+  : Pick<Todo, Extract<S | "id", keyof Todo>> &
+      Pick<PermissionIntrospectionColumns, Extract<S, PermissionIntrospectionColumn>>;
 
-export type TodoSelectedWithIncludes<I extends TodoInclude = {}, S extends TodoSelectableColumn = keyof Todo> = Omit<TodoSelected<S>, Extract<keyof I, keyof TodoSelected<S>>> & TodoIncludedRelations<I>;
+export type TodoSelectedWithIncludes<
+  I extends TodoInclude = {},
+  S extends TodoSelectableColumn = keyof Todo,
+> = Omit<TodoSelected<S>, Extract<keyof I, keyof TodoSelected<S>>> & TodoIncludedRelations<I>;
 
 export const wasmSchema: WasmSchema = {
-  "projects": {
-    "columns": [
+  projects: {
+    columns: [
       {
-        "name": "name",
-        "column_type": {
-          "type": "Text"
+        name: "name",
+        column_type: {
+          type: "Text",
         },
-        "nullable": false
-      }
-    ]
-  },
-  "todos": {
-    "columns": [
-      {
-        "name": "title",
-        "column_type": {
-          "type": "Text"
-        },
-        "nullable": false
+        nullable: false,
       },
-      {
-        "name": "done",
-        "column_type": {
-          "type": "Boolean"
-        },
-        "nullable": false
-      },
-      {
-        "name": "description",
-        "column_type": {
-          "type": "Text"
-        },
-        "nullable": true
-      },
-      {
-        "name": "parent",
-        "column_type": {
-          "type": "Uuid"
-        },
-        "nullable": true,
-        "references": "todos"
-      },
-      {
-        "name": "project",
-        "column_type": {
-          "type": "Uuid"
-        },
-        "nullable": true,
-        "references": "projects"
-      },
-      {
-        "name": "owner_id",
-        "column_type": {
-          "type": "Text"
-        },
-        "nullable": false
-      }
     ],
-    "policies": {
-      "select": {
-        "using": {
-          "type": "Cmp",
-          "column": "owner_id",
-          "op": "Eq",
-          "value": {
-            "type": "SessionRef",
-            "path": [
-              "user_id"
-            ]
-          }
-        }
-      },
-      "insert": {
-        "with_check": {
-          "type": "Cmp",
-          "column": "owner_id",
-          "op": "Eq",
-          "value": {
-            "type": "SessionRef",
-            "path": [
-              "user_id"
-            ]
-          }
-        }
-      },
-      "update": {
-        "using": {
-          "type": "Cmp",
-          "column": "owner_id",
-          "op": "Eq",
-          "value": {
-            "type": "SessionRef",
-            "path": [
-              "user_id"
-            ]
-          }
+  },
+  todos: {
+    columns: [
+      {
+        name: "title",
+        column_type: {
+          type: "Text",
         },
-        "with_check": {
-          "type": "Cmp",
-          "column": "owner_id",
-          "op": "Eq",
-          "value": {
-            "type": "SessionRef",
-            "path": [
-              "user_id"
-            ]
-          }
-        }
+        nullable: false,
       },
-      "delete": {
-        "using": {
-          "type": "Cmp",
-          "column": "owner_id",
-          "op": "Eq",
-          "value": {
-            "type": "SessionRef",
-            "path": [
-              "user_id"
-            ]
-          }
-        }
-      }
-    }
-  }
+      {
+        name: "done",
+        column_type: {
+          type: "Boolean",
+        },
+        nullable: false,
+      },
+      {
+        name: "description",
+        column_type: {
+          type: "Text",
+        },
+        nullable: true,
+      },
+      {
+        name: "parent",
+        column_type: {
+          type: "Uuid",
+        },
+        nullable: true,
+        references: "todos",
+      },
+      {
+        name: "project",
+        column_type: {
+          type: "Uuid",
+        },
+        nullable: true,
+        references: "projects",
+      },
+      {
+        name: "owner_id",
+        column_type: {
+          type: "Text",
+        },
+        nullable: false,
+      },
+    ],
+    policies: {
+      select: {
+        using: {
+          type: "Cmp",
+          column: "owner_id",
+          op: "Eq",
+          value: {
+            type: "SessionRef",
+            path: ["user_id"],
+          },
+        },
+      },
+      insert: {
+        with_check: {
+          type: "Cmp",
+          column: "owner_id",
+          op: "Eq",
+          value: {
+            type: "SessionRef",
+            path: ["user_id"],
+          },
+        },
+      },
+      update: {
+        using: {
+          type: "Cmp",
+          column: "owner_id",
+          op: "Eq",
+          value: {
+            type: "SessionRef",
+            path: ["user_id"],
+          },
+        },
+        with_check: {
+          type: "Cmp",
+          column: "owner_id",
+          op: "Eq",
+          value: {
+            type: "SessionRef",
+            path: ["user_id"],
+          },
+        },
+      },
+      delete: {
+        using: {
+          type: "Cmp",
+          column: "owner_id",
+          op: "Eq",
+          value: {
+            type: "SessionRef",
+            path: ["user_id"],
+          },
+        },
+      },
+    },
+  },
 };
 
-export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends ProjectSelectableColumn = keyof Project> implements QueryBuilder<ProjectSelectedWithIncludes<I, S>> {
+export class ProjectQueryBuilder<
+  I extends ProjectInclude = {},
+  S extends ProjectSelectableColumn = keyof Project,
+> implements QueryBuilder<ProjectSelectedWithIncludes<I, S>> {
   readonly _table = "projects";
   readonly _schema: WasmSchema = wasmSchema;
   readonly _rowType!: ProjectSelectedWithIncludes<I, S>;
@@ -313,7 +331,9 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
     return clone;
   }
 
-  select<NewS extends ProjectSelectableColumn>(...columns: [NewS, ...NewS[]]): ProjectQueryBuilder<I, NewS> {
+  select<NewS extends ProjectSelectableColumn>(
+    ...columns: [NewS, ...NewS[]]
+  ): ProjectQueryBuilder<I, NewS> {
     const clone = this._clone<I, NewS>();
     clone._selectColumns = [...columns] as string[];
     return clone;
@@ -325,7 +345,10 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
     return clone;
   }
 
-  orderBy(column: ProjectOrderableColumn, direction: "asc" | "desc" = "asc"): ProjectQueryBuilder<I, S> {
+  orderBy(
+    column: ProjectOrderableColumn,
+    direction: "asc" | "desc" = "asc",
+  ): ProjectQueryBuilder<I, S> {
     const clone = this._clone();
     clone._orderBys.push([column as string, direction]);
     return clone;
@@ -374,13 +397,15 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
 
     const currentToken = "__jazz_gather_current__";
     const stepOutput = options.step({ current: currentToken });
-    if (!stepOutput || typeof stepOutput !== "object" || typeof (stepOutput as { _build?: unknown })._build !== "function") {
+    if (
+      !stepOutput ||
+      typeof stepOutput !== "object" ||
+      typeof (stepOutput as { _build?: unknown })._build !== "function"
+    ) {
       throw new Error("gather(...) step must return a query expression built from app.<table>.");
     }
 
-    const stepBuilt = JSON.parse(
-      stepOutput._build(),
-    ) as {
+    const stepBuilt = JSON.parse(stepOutput._build()) as {
       table?: unknown;
       conditions?: Array<{ column: string; op: string; value: unknown }>;
       hops?: unknown;
@@ -404,7 +429,9 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
       (condition) => condition.op === "eq" && condition.value === currentToken,
     );
     if (currentConditions.length !== 1) {
-      throw new Error("gather(...) step must include exactly one where condition bound to current.");
+      throw new Error(
+        "gather(...) step must include exactly one where condition bound to current.",
+      );
     }
 
     const currentCondition = currentConditions[0];
@@ -444,7 +471,10 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
     return JSON.parse(this._build());
   }
 
-  private _clone<CloneI extends ProjectInclude = I, CloneS extends ProjectSelectableColumn = S>(): ProjectQueryBuilder<CloneI, CloneS> {
+  private _clone<
+    CloneI extends ProjectInclude = I,
+    CloneS extends ProjectSelectableColumn = S,
+  >(): ProjectQueryBuilder<CloneI, CloneS> {
     const clone = new ProjectQueryBuilder<CloneI, CloneS>();
     clone._conditions = [...this._conditions];
     clone._includes = { ...this._includes };
@@ -464,7 +494,10 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
   }
 }
 
-export class TodoQueryBuilder<I extends TodoInclude = {}, S extends TodoSelectableColumn = keyof Todo> implements QueryBuilder<TodoSelectedWithIncludes<I, S>> {
+export class TodoQueryBuilder<
+  I extends TodoInclude = {},
+  S extends TodoSelectableColumn = keyof Todo,
+> implements QueryBuilder<TodoSelectedWithIncludes<I, S>> {
   readonly _table = "todos";
   readonly _schema: WasmSchema = wasmSchema;
   readonly _rowType!: TodoSelectedWithIncludes<I, S>;
@@ -501,7 +534,9 @@ export class TodoQueryBuilder<I extends TodoInclude = {}, S extends TodoSelectab
     return clone;
   }
 
-  select<NewS extends TodoSelectableColumn>(...columns: [NewS, ...NewS[]]): TodoQueryBuilder<I, NewS> {
+  select<NewS extends TodoSelectableColumn>(
+    ...columns: [NewS, ...NewS[]]
+  ): TodoQueryBuilder<I, NewS> {
     const clone = this._clone<I, NewS>();
     clone._selectColumns = [...columns] as string[];
     return clone;
@@ -562,13 +597,15 @@ export class TodoQueryBuilder<I extends TodoInclude = {}, S extends TodoSelectab
 
     const currentToken = "__jazz_gather_current__";
     const stepOutput = options.step({ current: currentToken });
-    if (!stepOutput || typeof stepOutput !== "object" || typeof (stepOutput as { _build?: unknown })._build !== "function") {
+    if (
+      !stepOutput ||
+      typeof stepOutput !== "object" ||
+      typeof (stepOutput as { _build?: unknown })._build !== "function"
+    ) {
       throw new Error("gather(...) step must return a query expression built from app.<table>.");
     }
 
-    const stepBuilt = JSON.parse(
-      stepOutput._build(),
-    ) as {
+    const stepBuilt = JSON.parse(stepOutput._build()) as {
       table?: unknown;
       conditions?: Array<{ column: string; op: string; value: unknown }>;
       hops?: unknown;
@@ -592,7 +629,9 @@ export class TodoQueryBuilder<I extends TodoInclude = {}, S extends TodoSelectab
       (condition) => condition.op === "eq" && condition.value === currentToken,
     );
     if (currentConditions.length !== 1) {
-      throw new Error("gather(...) step must include exactly one where condition bound to current.");
+      throw new Error(
+        "gather(...) step must include exactly one where condition bound to current.",
+      );
     }
 
     const currentCondition = currentConditions[0];
@@ -632,7 +671,10 @@ export class TodoQueryBuilder<I extends TodoInclude = {}, S extends TodoSelectab
     return JSON.parse(this._build());
   }
 
-  private _clone<CloneI extends TodoInclude = I, CloneS extends TodoSelectableColumn = S>(): TodoQueryBuilder<CloneI, CloneS> {
+  private _clone<
+    CloneI extends TodoInclude = I,
+    CloneS extends TodoSelectableColumn = S,
+  >(): TodoQueryBuilder<CloneI, CloneS> {
     const clone = new TodoQueryBuilder<CloneI, CloneS>();
     clone._conditions = [...this._conditions];
     clone._includes = { ...this._includes };

--- a/examples/todo-server-ts/schema/app.ts
+++ b/examples/todo-server-ts/schema/app.ts
@@ -1,12 +1,13 @@
 // AUTO-GENERATED FILE - DO NOT EDIT
 import type { WasmSchema, QueryBuilder } from "jazz-tools";
-export type JsonValue =
-  | string
-  | number
-  | boolean
-  | null
-  | { [key: string]: JsonValue }
-  | JsonValue[];
+export type JsonValue = string | number | boolean | null | { [key: string]: JsonValue } | JsonValue[];
+
+export type PermissionIntrospectionColumn = "$canRead" | "$canEdit" | "$canDelete";
+export interface PermissionIntrospectionColumns {
+  $canRead: boolean | null;
+  $canEdit: boolean | null;
+  $canDelete: boolean | null;
+}
 
 export interface Project {
   id: string;
@@ -39,6 +40,9 @@ export interface TodoInit {
 export interface ProjectWhereInput {
   id?: string | { eq?: string; ne?: string; in?: string[] };
   name?: string | { eq?: string; ne?: string; contains?: string };
+  $canRead?: boolean;
+  $canEdit?: boolean;
+  $canDelete?: boolean;
 }
 
 export interface TodoWhereInput {
@@ -49,17 +53,73 @@ export interface TodoWhereInput {
   parent?: string | { eq?: string; ne?: string; isNull?: boolean };
   project?: string | { eq?: string; ne?: string; isNull?: boolean };
   owner_id?: string | { eq?: string; ne?: string; contains?: string };
+  $canRead?: boolean;
+  $canEdit?: boolean;
+  $canDelete?: boolean;
 }
 
+type AnyProjectQueryBuilder<T = any> = { readonly _table: "projects" } & QueryBuilder<T>;
+type AnyTodoQueryBuilder<T = any> = { readonly _table: "todos" } & QueryBuilder<T>;
+
 export interface ProjectInclude {
-  todosViaProject?: true | TodoInclude | TodoQueryBuilder;
+  todosViaProject?: true | TodoInclude | AnyTodoQueryBuilder<any>;
 }
 
 export interface TodoInclude {
-  parent?: true | TodoInclude | TodoQueryBuilder;
-  todosViaParent?: true | TodoInclude | TodoQueryBuilder;
-  project?: true | ProjectInclude | ProjectQueryBuilder;
+  parent?: true | TodoInclude | AnyTodoQueryBuilder<any>;
+  todosViaParent?: true | TodoInclude | AnyTodoQueryBuilder<any>;
+  project?: true | ProjectInclude | AnyProjectQueryBuilder<any>;
 }
+
+export type ProjectIncludedRelations<I extends ProjectInclude = {}> = {
+  [K in keyof I]-?:
+    K extends "todosViaProject"
+      ? NonNullable<I["todosViaProject"]> extends infer RelationInclude
+        ? RelationInclude extends true
+          ? Todo[]
+          : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
+            ? QueryRow[]
+            : RelationInclude extends TodoInclude
+              ? TodoWithIncludes<RelationInclude>[]
+              : never
+        : never
+    : never;
+};
+
+export type TodoIncludedRelations<I extends TodoInclude = {}> = {
+  [K in keyof I]-?:
+    K extends "parent"
+      ? NonNullable<I["parent"]> extends infer RelationInclude
+        ? RelationInclude extends true
+          ? Todo | undefined
+          : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
+            ? QueryRow | undefined
+            : RelationInclude extends TodoInclude
+              ? TodoWithIncludes<RelationInclude> | undefined
+              : never
+        : never
+    : K extends "todosViaParent"
+      ? NonNullable<I["todosViaParent"]> extends infer RelationInclude
+        ? RelationInclude extends true
+          ? Todo[]
+          : RelationInclude extends AnyTodoQueryBuilder<infer QueryRow>
+            ? QueryRow[]
+            : RelationInclude extends TodoInclude
+              ? TodoWithIncludes<RelationInclude>[]
+              : never
+        : never
+    : K extends "project"
+      ? NonNullable<I["project"]> extends infer RelationInclude
+        ? RelationInclude extends true
+          ? Project | undefined
+          : RelationInclude extends AnyProjectQueryBuilder<infer QueryRow>
+            ? QueryRow | undefined
+            : RelationInclude extends ProjectInclude
+              ? ProjectWithIncludes<RelationInclude> | undefined
+              : never
+        : never
+    : never;
+};
 
 export interface ProjectRelations {
   todosViaProject: Todo[];
@@ -71,174 +131,159 @@ export interface TodoRelations {
   project: Project;
 }
 
-export type ProjectWithIncludes<I extends ProjectInclude = {}> = Project & {
-  todosViaProject?: NonNullable<I["todosViaProject"]> extends infer RelationInclude
-    ? RelationInclude extends true
-      ? Todo[]
-      : RelationInclude extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
-        ? TodoWithIncludes<QueryInclude>[]
-        : RelationInclude extends TodoInclude
-          ? TodoWithIncludes<RelationInclude>[]
-          : never
-    : never;
-};
+export type ProjectWithIncludes<I extends ProjectInclude = {}> = Omit<Project, Extract<keyof I, keyof Project>> & ProjectIncludedRelations<I>;
 
-export type TodoWithIncludes<I extends TodoInclude = {}> = Todo & {
-  parent?: NonNullable<I["parent"]> extends infer RelationInclude
-    ? RelationInclude extends true
-      ? Todo
-      : RelationInclude extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
-        ? TodoWithIncludes<QueryInclude>
-        : RelationInclude extends TodoInclude
-          ? TodoWithIncludes<RelationInclude>
-          : never
-    : never;
-  todosViaParent?: NonNullable<I["todosViaParent"]> extends infer RelationInclude
-    ? RelationInclude extends true
-      ? Todo[]
-      : RelationInclude extends TodoQueryBuilder<infer QueryInclude extends TodoInclude>
-        ? TodoWithIncludes<QueryInclude>[]
-        : RelationInclude extends TodoInclude
-          ? TodoWithIncludes<RelationInclude>[]
-          : never
-    : never;
-  project?: NonNullable<I["project"]> extends infer RelationInclude
-    ? RelationInclude extends true
-      ? Project
-      : RelationInclude extends ProjectQueryBuilder<infer QueryInclude extends ProjectInclude>
-        ? ProjectWithIncludes<QueryInclude>
-        : RelationInclude extends ProjectInclude
-          ? ProjectWithIncludes<RelationInclude>
-          : never
-    : never;
-};
+export type TodoWithIncludes<I extends TodoInclude = {}> = Omit<Todo, Extract<keyof I, keyof Todo>> & TodoIncludedRelations<I>;
+
+export type ProjectSelectableColumn = keyof Project | PermissionIntrospectionColumn | "*";
+export type ProjectOrderableColumn = keyof Project | PermissionIntrospectionColumn;
+
+export type ProjectSelected<S extends ProjectSelectableColumn = keyof Project> = "*" extends S ? Project : Pick<Project, Extract<S | "id", keyof Project>> & Pick<PermissionIntrospectionColumns, Extract<S, PermissionIntrospectionColumn>>;
+
+export type ProjectSelectedWithIncludes<I extends ProjectInclude = {}, S extends ProjectSelectableColumn = keyof Project> = Omit<ProjectSelected<S>, Extract<keyof I, keyof ProjectSelected<S>>> & ProjectIncludedRelations<I>;
+
+export type TodoSelectableColumn = keyof Todo | PermissionIntrospectionColumn | "*";
+export type TodoOrderableColumn = keyof Todo | PermissionIntrospectionColumn;
+
+export type TodoSelected<S extends TodoSelectableColumn = keyof Todo> = "*" extends S ? Todo : Pick<Todo, Extract<S | "id", keyof Todo>> & Pick<PermissionIntrospectionColumns, Extract<S, PermissionIntrospectionColumn>>;
+
+export type TodoSelectedWithIncludes<I extends TodoInclude = {}, S extends TodoSelectableColumn = keyof Todo> = Omit<TodoSelected<S>, Extract<keyof I, keyof TodoSelected<S>>> & TodoIncludedRelations<I>;
 
 export const wasmSchema: WasmSchema = {
-  projects: {
-    columns: [
+  "projects": {
+    "columns": [
       {
-        name: "name",
-        column_type: {
-          type: "Text",
+        "name": "name",
+        "column_type": {
+          "type": "Text"
         },
-        nullable: false,
-      },
-    ],
+        "nullable": false
+      }
+    ]
   },
-  todos: {
-    columns: [
+  "todos": {
+    "columns": [
       {
-        name: "title",
-        column_type: {
-          type: "Text",
+        "name": "title",
+        "column_type": {
+          "type": "Text"
         },
-        nullable: false,
+        "nullable": false
       },
       {
-        name: "done",
-        column_type: {
-          type: "Boolean",
+        "name": "done",
+        "column_type": {
+          "type": "Boolean"
         },
-        nullable: false,
+        "nullable": false
       },
       {
-        name: "description",
-        column_type: {
-          type: "Text",
+        "name": "description",
+        "column_type": {
+          "type": "Text"
         },
-        nullable: true,
+        "nullable": true
       },
       {
-        name: "parent",
-        column_type: {
-          type: "Uuid",
+        "name": "parent",
+        "column_type": {
+          "type": "Uuid"
         },
-        nullable: true,
-        references: "todos",
+        "nullable": true,
+        "references": "todos"
       },
       {
-        name: "project",
-        column_type: {
-          type: "Uuid",
+        "name": "project",
+        "column_type": {
+          "type": "Uuid"
         },
-        nullable: true,
-        references: "projects",
+        "nullable": true,
+        "references": "projects"
       },
       {
-        name: "owner_id",
-        column_type: {
-          type: "Text",
+        "name": "owner_id",
+        "column_type": {
+          "type": "Text"
         },
-        nullable: false,
-      },
+        "nullable": false
+      }
     ],
-    policies: {
-      select: {
-        using: {
-          type: "Cmp",
-          column: "owner_id",
-          op: "Eq",
-          value: {
-            type: "SessionRef",
-            path: ["user_id"],
-          },
-        },
+    "policies": {
+      "select": {
+        "using": {
+          "type": "Cmp",
+          "column": "owner_id",
+          "op": "Eq",
+          "value": {
+            "type": "SessionRef",
+            "path": [
+              "user_id"
+            ]
+          }
+        }
       },
-      insert: {
-        with_check: {
-          type: "Cmp",
-          column: "owner_id",
-          op: "Eq",
-          value: {
-            type: "SessionRef",
-            path: ["user_id"],
-          },
-        },
+      "insert": {
+        "with_check": {
+          "type": "Cmp",
+          "column": "owner_id",
+          "op": "Eq",
+          "value": {
+            "type": "SessionRef",
+            "path": [
+              "user_id"
+            ]
+          }
+        }
       },
-      update: {
-        using: {
-          type: "Cmp",
-          column: "owner_id",
-          op: "Eq",
-          value: {
-            type: "SessionRef",
-            path: ["user_id"],
-          },
+      "update": {
+        "using": {
+          "type": "Cmp",
+          "column": "owner_id",
+          "op": "Eq",
+          "value": {
+            "type": "SessionRef",
+            "path": [
+              "user_id"
+            ]
+          }
         },
-        with_check: {
-          type: "Cmp",
-          column: "owner_id",
-          op: "Eq",
-          value: {
-            type: "SessionRef",
-            path: ["user_id"],
-          },
-        },
+        "with_check": {
+          "type": "Cmp",
+          "column": "owner_id",
+          "op": "Eq",
+          "value": {
+            "type": "SessionRef",
+            "path": [
+              "user_id"
+            ]
+          }
+        }
       },
-      delete: {
-        using: {
-          type: "Cmp",
-          column: "owner_id",
-          op: "Eq",
-          value: {
-            type: "SessionRef",
-            path: ["user_id"],
-          },
-        },
-      },
-    },
-  },
+      "delete": {
+        "using": {
+          "type": "Cmp",
+          "column": "owner_id",
+          "op": "Eq",
+          "value": {
+            "type": "SessionRef",
+            "path": [
+              "user_id"
+            ]
+          }
+        }
+      }
+    }
+  }
 };
 
-export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements QueryBuilder<
-  ProjectWithIncludes<I>
-> {
+export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends ProjectSelectableColumn = keyof Project> implements QueryBuilder<ProjectSelectedWithIncludes<I, S>> {
   readonly _table = "projects";
   readonly _schema: WasmSchema = wasmSchema;
-  declare readonly _rowType: ProjectWithIncludes<I>;
-  declare readonly _initType: ProjectInit;
+  readonly _rowType!: ProjectSelectedWithIncludes<I, S>;
+  readonly _initType!: ProjectInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<ProjectInclude> = {};
+  private _selectColumns?: string[];
   private _orderBys: Array<[string, "asc" | "desc"]> = [];
   private _limitVal?: number;
   private _offsetVal?: number;
@@ -251,7 +296,7 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
     step_hops: string[];
   };
 
-  where(conditions: ProjectWhereInput): ProjectQueryBuilder<I> {
+  where(conditions: ProjectWhereInput): ProjectQueryBuilder<I, S> {
     const clone = this._clone();
     for (const [key, value] of Object.entries(conditions)) {
       if (value === undefined) continue;
@@ -268,31 +313,37 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
     return clone;
   }
 
-  include<NewI extends ProjectInclude>(relations: NewI): ProjectQueryBuilder<I & NewI> {
-    const clone = this._clone<I & NewI>();
+  select<NewS extends ProjectSelectableColumn>(...columns: [NewS, ...NewS[]]): ProjectQueryBuilder<I, NewS> {
+    const clone = this._clone<I, NewS>();
+    clone._selectColumns = [...columns] as string[];
+    return clone;
+  }
+
+  include<NewI extends ProjectInclude>(relations: NewI): ProjectQueryBuilder<I & NewI, S> {
+    const clone = this._clone<I & NewI, S>();
     clone._includes = { ...this._includes, ...relations };
     return clone;
   }
 
-  orderBy(column: keyof Project, direction: "asc" | "desc" = "asc"): ProjectQueryBuilder<I> {
+  orderBy(column: ProjectOrderableColumn, direction: "asc" | "desc" = "asc"): ProjectQueryBuilder<I, S> {
     const clone = this._clone();
     clone._orderBys.push([column as string, direction]);
     return clone;
   }
 
-  limit(n: number): ProjectQueryBuilder<I> {
+  limit(n: number): ProjectQueryBuilder<I, S> {
     const clone = this._clone();
     clone._limitVal = n;
     return clone;
   }
 
-  offset(n: number): ProjectQueryBuilder<I> {
+  offset(n: number): ProjectQueryBuilder<I, S> {
     const clone = this._clone();
     clone._offsetVal = n;
     return clone;
   }
 
-  hopTo(relation: "todosViaProject"): ProjectQueryBuilder<I> {
+  hopTo(relation: "todosViaProject"): ProjectQueryBuilder<I, S> {
     const clone = this._clone();
     clone._hops.push(relation);
     return clone;
@@ -302,7 +353,7 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
     start: ProjectWhereInput;
     step: (ctx: { current: string }) => QueryBuilder<unknown>;
     maxDepth?: number;
-  }): ProjectQueryBuilder<I> {
+  }): ProjectQueryBuilder<I, S> {
     if (options.start === undefined) {
       throw new Error("gather(...) requires start where conditions.");
     }
@@ -323,15 +374,13 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
 
     const currentToken = "__jazz_gather_current__";
     const stepOutput = options.step({ current: currentToken });
-    if (
-      !stepOutput ||
-      typeof stepOutput !== "object" ||
-      typeof (stepOutput as { _build?: unknown })._build !== "function"
-    ) {
+    if (!stepOutput || typeof stepOutput !== "object" || typeof (stepOutput as { _build?: unknown })._build !== "function") {
       throw new Error("gather(...) step must return a query expression built from app.<table>.");
     }
 
-    const stepBuilt = JSON.parse(stepOutput._build()) as {
+    const stepBuilt = JSON.parse(
+      stepOutput._build(),
+    ) as {
       table?: unknown;
       conditions?: Array<{ column: string; op: string; value: unknown }>;
       hops?: unknown;
@@ -355,9 +404,7 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
       (condition) => condition.op === "eq" && condition.value === currentToken,
     );
     if (currentConditions.length !== 1) {
-      throw new Error(
-        "gather(...) step must include exactly one where condition bound to current.",
-      );
+      throw new Error("gather(...) step must include exactly one where condition bound to current.");
     }
 
     const currentCondition = currentConditions[0];
@@ -384,6 +431,7 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
       table: this._table,
       conditions: this._conditions,
       includes: this._includes,
+      select: this._selectColumns,
       orderBy: this._orderBys,
       limit: this._limitVal,
       offset: this._offsetVal,
@@ -392,10 +440,15 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
     });
   }
 
-  private _clone<CloneI extends ProjectInclude = I>(): ProjectQueryBuilder<CloneI> {
-    const clone = new ProjectQueryBuilder<CloneI>();
+  toJSON(): unknown {
+    return JSON.parse(this._build());
+  }
+
+  private _clone<CloneI extends ProjectInclude = I, CloneS extends ProjectSelectableColumn = S>(): ProjectQueryBuilder<CloneI, CloneS> {
+    const clone = new ProjectQueryBuilder<CloneI, CloneS>();
     clone._conditions = [...this._conditions];
     clone._includes = { ...this._includes };
+    clone._selectColumns = this._selectColumns ? [...this._selectColumns] : undefined;
     clone._orderBys = [...this._orderBys];
     clone._limitVal = this._limitVal;
     clone._offsetVal = this._offsetVal;
@@ -411,15 +464,14 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
   }
 }
 
-export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilder<
-  TodoWithIncludes<I>
-> {
+export class TodoQueryBuilder<I extends TodoInclude = {}, S extends TodoSelectableColumn = keyof Todo> implements QueryBuilder<TodoSelectedWithIncludes<I, S>> {
   readonly _table = "todos";
   readonly _schema: WasmSchema = wasmSchema;
-  declare readonly _rowType: TodoWithIncludes<I>;
-  declare readonly _initType: TodoInit;
+  readonly _rowType!: TodoSelectedWithIncludes<I, S>;
+  readonly _initType!: TodoInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<TodoInclude> = {};
+  private _selectColumns?: string[];
   private _orderBys: Array<[string, "asc" | "desc"]> = [];
   private _limitVal?: number;
   private _offsetVal?: number;
@@ -432,7 +484,7 @@ export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilde
     step_hops: string[];
   };
 
-  where(conditions: TodoWhereInput): TodoQueryBuilder<I> {
+  where(conditions: TodoWhereInput): TodoQueryBuilder<I, S> {
     const clone = this._clone();
     for (const [key, value] of Object.entries(conditions)) {
       if (value === undefined) continue;
@@ -449,31 +501,37 @@ export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilde
     return clone;
   }
 
-  include<NewI extends TodoInclude>(relations: NewI): TodoQueryBuilder<I & NewI> {
-    const clone = this._clone<I & NewI>();
+  select<NewS extends TodoSelectableColumn>(...columns: [NewS, ...NewS[]]): TodoQueryBuilder<I, NewS> {
+    const clone = this._clone<I, NewS>();
+    clone._selectColumns = [...columns] as string[];
+    return clone;
+  }
+
+  include<NewI extends TodoInclude>(relations: NewI): TodoQueryBuilder<I & NewI, S> {
+    const clone = this._clone<I & NewI, S>();
     clone._includes = { ...this._includes, ...relations };
     return clone;
   }
 
-  orderBy(column: keyof Todo, direction: "asc" | "desc" = "asc"): TodoQueryBuilder<I> {
+  orderBy(column: TodoOrderableColumn, direction: "asc" | "desc" = "asc"): TodoQueryBuilder<I, S> {
     const clone = this._clone();
     clone._orderBys.push([column as string, direction]);
     return clone;
   }
 
-  limit(n: number): TodoQueryBuilder<I> {
+  limit(n: number): TodoQueryBuilder<I, S> {
     const clone = this._clone();
     clone._limitVal = n;
     return clone;
   }
 
-  offset(n: number): TodoQueryBuilder<I> {
+  offset(n: number): TodoQueryBuilder<I, S> {
     const clone = this._clone();
     clone._offsetVal = n;
     return clone;
   }
 
-  hopTo(relation: "parent" | "todosViaParent" | "project"): TodoQueryBuilder<I> {
+  hopTo(relation: "parent" | "todosViaParent" | "project"): TodoQueryBuilder<I, S> {
     const clone = this._clone();
     clone._hops.push(relation);
     return clone;
@@ -483,7 +541,7 @@ export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilde
     start: TodoWhereInput;
     step: (ctx: { current: string }) => QueryBuilder<unknown>;
     maxDepth?: number;
-  }): TodoQueryBuilder<I> {
+  }): TodoQueryBuilder<I, S> {
     if (options.start === undefined) {
       throw new Error("gather(...) requires start where conditions.");
     }
@@ -504,15 +562,13 @@ export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilde
 
     const currentToken = "__jazz_gather_current__";
     const stepOutput = options.step({ current: currentToken });
-    if (
-      !stepOutput ||
-      typeof stepOutput !== "object" ||
-      typeof (stepOutput as { _build?: unknown })._build !== "function"
-    ) {
+    if (!stepOutput || typeof stepOutput !== "object" || typeof (stepOutput as { _build?: unknown })._build !== "function") {
       throw new Error("gather(...) step must return a query expression built from app.<table>.");
     }
 
-    const stepBuilt = JSON.parse(stepOutput._build()) as {
+    const stepBuilt = JSON.parse(
+      stepOutput._build(),
+    ) as {
       table?: unknown;
       conditions?: Array<{ column: string; op: string; value: unknown }>;
       hops?: unknown;
@@ -536,9 +592,7 @@ export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilde
       (condition) => condition.op === "eq" && condition.value === currentToken,
     );
     if (currentConditions.length !== 1) {
-      throw new Error(
-        "gather(...) step must include exactly one where condition bound to current.",
-      );
+      throw new Error("gather(...) step must include exactly one where condition bound to current.");
     }
 
     const currentCondition = currentConditions[0];
@@ -565,6 +619,7 @@ export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilde
       table: this._table,
       conditions: this._conditions,
       includes: this._includes,
+      select: this._selectColumns,
       orderBy: this._orderBys,
       limit: this._limitVal,
       offset: this._offsetVal,
@@ -573,10 +628,15 @@ export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilde
     });
   }
 
-  private _clone<CloneI extends TodoInclude = I>(): TodoQueryBuilder<CloneI> {
-    const clone = new TodoQueryBuilder<CloneI>();
+  toJSON(): unknown {
+    return JSON.parse(this._build());
+  }
+
+  private _clone<CloneI extends TodoInclude = I, CloneS extends TodoSelectableColumn = S>(): TodoQueryBuilder<CloneI, CloneS> {
+    const clone = new TodoQueryBuilder<CloneI, CloneS>();
     clone._conditions = [...this._conditions];
     clone._includes = { ...this._includes };
+    clone._selectColumns = this._selectColumns ? [...this._selectColumns] : undefined;
     clone._orderBys = [...this._orderBys];
     clone._limitVal = this._limitVal;
     clone._offsetVal = this._offsetVal;

--- a/examples/wequencer/schema/app.ts
+++ b/examples/wequencer/schema/app.ts
@@ -1,6 +1,12 @@
 // AUTO-GENERATED FILE - DO NOT EDIT
 import type { WasmSchema, QueryBuilder } from "jazz-tools";
-export type JsonValue = string | number | boolean | null | { [key: string]: JsonValue } | JsonValue[];
+export type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: JsonValue }
+  | JsonValue[];
 
 export type PermissionIntrospectionColumn = "$canRead" | "$canEdit" | "$canDelete";
 export interface PermissionIntrospectionColumns {
@@ -69,7 +75,9 @@ export interface InstrumentWhereInput {
   id?: string | { eq?: string; ne?: string; in?: string[] };
   name?: string | { eq?: string; ne?: string; contains?: string };
   sound?: Uint8Array | { eq?: Uint8Array; ne?: Uint8Array };
-  display_order?: number | { eq?: number; ne?: number; gt?: number; gte?: number; lt?: number; lte?: number };
+  display_order?:
+    | number
+    | { eq?: number; ne?: number; gt?: number; gte?: number; lt?: number; lte?: number };
   $canRead?: boolean;
   $canEdit?: boolean;
   $canDelete?: boolean;
@@ -77,10 +85,30 @@ export interface InstrumentWhereInput {
 
 export interface JamWhereInput {
   id?: string | { eq?: string; ne?: string; in?: string[] };
-  created_at?: Date | number | { eq?: Date | number; gt?: Date | number; gte?: Date | number; lt?: Date | number; lte?: Date | number };
-  transport_start?: Date | number | { eq?: Date | number; gt?: Date | number; gte?: Date | number; lt?: Date | number; lte?: Date | number };
+  created_at?:
+    | Date
+    | number
+    | {
+        eq?: Date | number;
+        gt?: Date | number;
+        gte?: Date | number;
+        lt?: Date | number;
+        lte?: Date | number;
+      };
+  transport_start?:
+    | Date
+    | number
+    | {
+        eq?: Date | number;
+        gt?: Date | number;
+        gte?: Date | number;
+        lt?: Date | number;
+        lte?: Date | number;
+      };
   bpm?: number | { eq?: number; ne?: number; gt?: number; gte?: number; lt?: number; lte?: number };
-  beat_count?: number | { eq?: number; ne?: number; gt?: number; gte?: number; lt?: number; lte?: number };
+  beat_count?:
+    | number
+    | { eq?: number; ne?: number; gt?: number; gte?: number; lt?: number; lte?: number };
   $canRead?: boolean;
   $canEdit?: boolean;
   $canDelete?: boolean;
@@ -90,7 +118,9 @@ export interface BeatWhereInput {
   id?: string | { eq?: string; ne?: string; in?: string[] };
   jam?: string | { eq?: string; ne?: string };
   instrument?: string | { eq?: string; ne?: string };
-  beat_index?: number | { eq?: number; ne?: number; gt?: number; gte?: number; lt?: number; lte?: number };
+  beat_index?:
+    | number
+    | { eq?: number; ne?: number; gt?: number; gte?: number; lt?: number; lte?: number };
   placed_by?: string | { eq?: string; ne?: string; contains?: string };
   $canRead?: boolean;
   $canEdit?: boolean;
@@ -131,32 +161,30 @@ export interface ParticipantInclude {
 }
 
 export type InstrumentIncludedRelations<I extends InstrumentInclude = {}> = {
-  [K in keyof I]-?:
-    K extends "beatsViaInstrument"
-      ? NonNullable<I["beatsViaInstrument"]> extends infer RelationInclude
-        ? RelationInclude extends true
-          ? Beat[]
-          : RelationInclude extends AnyBeatQueryBuilder<infer QueryRow>
-            ? QueryRow[]
-            : RelationInclude extends BeatInclude
-              ? BeatWithIncludes<RelationInclude>[]
-              : never
-        : never
+  [K in keyof I]-?: K extends "beatsViaInstrument"
+    ? NonNullable<I["beatsViaInstrument"]> extends infer RelationInclude
+      ? RelationInclude extends true
+        ? Beat[]
+        : RelationInclude extends AnyBeatQueryBuilder<infer QueryRow>
+          ? QueryRow[]
+          : RelationInclude extends BeatInclude
+            ? BeatWithIncludes<RelationInclude>[]
+            : never
+      : never
     : never;
 };
 
 export type JamIncludedRelations<I extends JamInclude = {}> = {
-  [K in keyof I]-?:
-    K extends "beatsViaJam"
-      ? NonNullable<I["beatsViaJam"]> extends infer RelationInclude
-        ? RelationInclude extends true
-          ? Beat[]
-          : RelationInclude extends AnyBeatQueryBuilder<infer QueryRow>
-            ? QueryRow[]
-            : RelationInclude extends BeatInclude
-              ? BeatWithIncludes<RelationInclude>[]
-              : never
-        : never
+  [K in keyof I]-?: K extends "beatsViaJam"
+    ? NonNullable<I["beatsViaJam"]> extends infer RelationInclude
+      ? RelationInclude extends true
+        ? Beat[]
+        : RelationInclude extends AnyBeatQueryBuilder<infer QueryRow>
+          ? QueryRow[]
+          : RelationInclude extends BeatInclude
+            ? BeatWithIncludes<RelationInclude>[]
+            : never
+      : never
     : K extends "participantsViaJam"
       ? NonNullable<I["participantsViaJam"]> extends infer RelationInclude
         ? RelationInclude extends true
@@ -167,21 +195,20 @@ export type JamIncludedRelations<I extends JamInclude = {}> = {
               ? ParticipantWithIncludes<RelationInclude>[]
               : never
         : never
-    : never;
+      : never;
 };
 
 export type BeatIncludedRelations<I extends BeatInclude = {}> = {
-  [K in keyof I]-?:
-    K extends "jam"
-      ? NonNullable<I["jam"]> extends infer RelationInclude
-        ? RelationInclude extends true
-          ? Jam
-          : RelationInclude extends AnyJamQueryBuilder<infer QueryRow>
-            ? QueryRow
-            : RelationInclude extends JamInclude
-              ? JamWithIncludes<RelationInclude>
-              : never
-        : never
+  [K in keyof I]-?: K extends "jam"
+    ? NonNullable<I["jam"]> extends infer RelationInclude
+      ? RelationInclude extends true
+        ? Jam
+        : RelationInclude extends AnyJamQueryBuilder<infer QueryRow>
+          ? QueryRow
+          : RelationInclude extends JamInclude
+            ? JamWithIncludes<RelationInclude>
+            : never
+      : never
     : K extends "instrument"
       ? NonNullable<I["instrument"]> extends infer RelationInclude
         ? RelationInclude extends true
@@ -192,21 +219,20 @@ export type BeatIncludedRelations<I extends BeatInclude = {}> = {
               ? InstrumentWithIncludes<RelationInclude>
               : never
         : never
-    : never;
+      : never;
 };
 
 export type ParticipantIncludedRelations<I extends ParticipantInclude = {}> = {
-  [K in keyof I]-?:
-    K extends "jam"
-      ? NonNullable<I["jam"]> extends infer RelationInclude
-        ? RelationInclude extends true
-          ? Jam
-          : RelationInclude extends AnyJamQueryBuilder<infer QueryRow>
-            ? QueryRow
-            : RelationInclude extends JamInclude
-              ? JamWithIncludes<RelationInclude>
-              : never
-        : never
+  [K in keyof I]-?: K extends "jam"
+    ? NonNullable<I["jam"]> extends infer RelationInclude
+      ? RelationInclude extends true
+        ? Jam
+        : RelationInclude extends AnyJamQueryBuilder<infer QueryRow>
+          ? QueryRow
+          : RelationInclude extends JamInclude
+            ? JamWithIncludes<RelationInclude>
+            : never
+      : never
     : never;
 };
 
@@ -228,163 +254,207 @@ export interface ParticipantRelations {
   jam: Jam;
 }
 
-export type InstrumentWithIncludes<I extends InstrumentInclude = {}> = Omit<Instrument, Extract<keyof I, keyof Instrument>> & InstrumentIncludedRelations<I>;
+export type InstrumentWithIncludes<I extends InstrumentInclude = {}> = Omit<
+  Instrument,
+  Extract<keyof I, keyof Instrument>
+> &
+  InstrumentIncludedRelations<I>;
 
-export type JamWithIncludes<I extends JamInclude = {}> = Omit<Jam, Extract<keyof I, keyof Jam>> & JamIncludedRelations<I>;
+export type JamWithIncludes<I extends JamInclude = {}> = Omit<Jam, Extract<keyof I, keyof Jam>> &
+  JamIncludedRelations<I>;
 
-export type BeatWithIncludes<I extends BeatInclude = {}> = Omit<Beat, Extract<keyof I, keyof Beat>> & BeatIncludedRelations<I>;
+export type BeatWithIncludes<I extends BeatInclude = {}> = Omit<
+  Beat,
+  Extract<keyof I, keyof Beat>
+> &
+  BeatIncludedRelations<I>;
 
-export type ParticipantWithIncludes<I extends ParticipantInclude = {}> = Omit<Participant, Extract<keyof I, keyof Participant>> & ParticipantIncludedRelations<I>;
+export type ParticipantWithIncludes<I extends ParticipantInclude = {}> = Omit<
+  Participant,
+  Extract<keyof I, keyof Participant>
+> &
+  ParticipantIncludedRelations<I>;
 
 export type InstrumentSelectableColumn = keyof Instrument | PermissionIntrospectionColumn | "*";
 export type InstrumentOrderableColumn = keyof Instrument | PermissionIntrospectionColumn;
 
-export type InstrumentSelected<S extends InstrumentSelectableColumn = keyof Instrument> = "*" extends S ? Instrument : Pick<Instrument, Extract<S | "id", keyof Instrument>> & Pick<PermissionIntrospectionColumns, Extract<S, PermissionIntrospectionColumn>>;
+export type InstrumentSelected<S extends InstrumentSelectableColumn = keyof Instrument> =
+  "*" extends S
+    ? Instrument
+    : Pick<Instrument, Extract<S | "id", keyof Instrument>> &
+        Pick<PermissionIntrospectionColumns, Extract<S, PermissionIntrospectionColumn>>;
 
-export type InstrumentSelectedWithIncludes<I extends InstrumentInclude = {}, S extends InstrumentSelectableColumn = keyof Instrument> = Omit<InstrumentSelected<S>, Extract<keyof I, keyof InstrumentSelected<S>>> & InstrumentIncludedRelations<I>;
+export type InstrumentSelectedWithIncludes<
+  I extends InstrumentInclude = {},
+  S extends InstrumentSelectableColumn = keyof Instrument,
+> = Omit<InstrumentSelected<S>, Extract<keyof I, keyof InstrumentSelected<S>>> &
+  InstrumentIncludedRelations<I>;
 
 export type JamSelectableColumn = keyof Jam | PermissionIntrospectionColumn | "*";
 export type JamOrderableColumn = keyof Jam | PermissionIntrospectionColumn;
 
-export type JamSelected<S extends JamSelectableColumn = keyof Jam> = "*" extends S ? Jam : Pick<Jam, Extract<S | "id", keyof Jam>> & Pick<PermissionIntrospectionColumns, Extract<S, PermissionIntrospectionColumn>>;
+export type JamSelected<S extends JamSelectableColumn = keyof Jam> = "*" extends S
+  ? Jam
+  : Pick<Jam, Extract<S | "id", keyof Jam>> &
+      Pick<PermissionIntrospectionColumns, Extract<S, PermissionIntrospectionColumn>>;
 
-export type JamSelectedWithIncludes<I extends JamInclude = {}, S extends JamSelectableColumn = keyof Jam> = Omit<JamSelected<S>, Extract<keyof I, keyof JamSelected<S>>> & JamIncludedRelations<I>;
+export type JamSelectedWithIncludes<
+  I extends JamInclude = {},
+  S extends JamSelectableColumn = keyof Jam,
+> = Omit<JamSelected<S>, Extract<keyof I, keyof JamSelected<S>>> & JamIncludedRelations<I>;
 
 export type BeatSelectableColumn = keyof Beat | PermissionIntrospectionColumn | "*";
 export type BeatOrderableColumn = keyof Beat | PermissionIntrospectionColumn;
 
-export type BeatSelected<S extends BeatSelectableColumn = keyof Beat> = "*" extends S ? Beat : Pick<Beat, Extract<S | "id", keyof Beat>> & Pick<PermissionIntrospectionColumns, Extract<S, PermissionIntrospectionColumn>>;
+export type BeatSelected<S extends BeatSelectableColumn = keyof Beat> = "*" extends S
+  ? Beat
+  : Pick<Beat, Extract<S | "id", keyof Beat>> &
+      Pick<PermissionIntrospectionColumns, Extract<S, PermissionIntrospectionColumn>>;
 
-export type BeatSelectedWithIncludes<I extends BeatInclude = {}, S extends BeatSelectableColumn = keyof Beat> = Omit<BeatSelected<S>, Extract<keyof I, keyof BeatSelected<S>>> & BeatIncludedRelations<I>;
+export type BeatSelectedWithIncludes<
+  I extends BeatInclude = {},
+  S extends BeatSelectableColumn = keyof Beat,
+> = Omit<BeatSelected<S>, Extract<keyof I, keyof BeatSelected<S>>> & BeatIncludedRelations<I>;
 
 export type ParticipantSelectableColumn = keyof Participant | PermissionIntrospectionColumn | "*";
 export type ParticipantOrderableColumn = keyof Participant | PermissionIntrospectionColumn;
 
-export type ParticipantSelected<S extends ParticipantSelectableColumn = keyof Participant> = "*" extends S ? Participant : Pick<Participant, Extract<S | "id", keyof Participant>> & Pick<PermissionIntrospectionColumns, Extract<S, PermissionIntrospectionColumn>>;
+export type ParticipantSelected<S extends ParticipantSelectableColumn = keyof Participant> =
+  "*" extends S
+    ? Participant
+    : Pick<Participant, Extract<S | "id", keyof Participant>> &
+        Pick<PermissionIntrospectionColumns, Extract<S, PermissionIntrospectionColumn>>;
 
-export type ParticipantSelectedWithIncludes<I extends ParticipantInclude = {}, S extends ParticipantSelectableColumn = keyof Participant> = Omit<ParticipantSelected<S>, Extract<keyof I, keyof ParticipantSelected<S>>> & ParticipantIncludedRelations<I>;
+export type ParticipantSelectedWithIncludes<
+  I extends ParticipantInclude = {},
+  S extends ParticipantSelectableColumn = keyof Participant,
+> = Omit<ParticipantSelected<S>, Extract<keyof I, keyof ParticipantSelected<S>>> &
+  ParticipantIncludedRelations<I>;
 
 export const wasmSchema: WasmSchema = {
-  "instruments": {
-    "columns": [
+  instruments: {
+    columns: [
       {
-        "name": "name",
-        "column_type": {
-          "type": "Text"
+        name: "name",
+        column_type: {
+          type: "Text",
         },
-        "nullable": false
+        nullable: false,
       },
       {
-        "name": "sound",
-        "column_type": {
-          "type": "Bytea"
+        name: "sound",
+        column_type: {
+          type: "Bytea",
         },
-        "nullable": false
+        nullable: false,
       },
       {
-        "name": "display_order",
-        "column_type": {
-          "type": "Integer"
+        name: "display_order",
+        column_type: {
+          type: "Integer",
         },
-        "nullable": false
-      }
-    ]
+        nullable: false,
+      },
+    ],
   },
-  "jams": {
-    "columns": [
+  jams: {
+    columns: [
       {
-        "name": "created_at",
-        "column_type": {
-          "type": "Timestamp"
+        name: "created_at",
+        column_type: {
+          type: "Timestamp",
         },
-        "nullable": false
+        nullable: false,
       },
       {
-        "name": "transport_start",
-        "column_type": {
-          "type": "Timestamp"
+        name: "transport_start",
+        column_type: {
+          type: "Timestamp",
         },
-        "nullable": true
+        nullable: true,
       },
       {
-        "name": "bpm",
-        "column_type": {
-          "type": "Integer"
+        name: "bpm",
+        column_type: {
+          type: "Integer",
         },
-        "nullable": false
+        nullable: false,
       },
       {
-        "name": "beat_count",
-        "column_type": {
-          "type": "Integer"
+        name: "beat_count",
+        column_type: {
+          type: "Integer",
         },
-        "nullable": false
-      }
-    ]
+        nullable: false,
+      },
+    ],
   },
-  "beats": {
-    "columns": [
+  beats: {
+    columns: [
       {
-        "name": "jam",
-        "column_type": {
-          "type": "Uuid"
+        name: "jam",
+        column_type: {
+          type: "Uuid",
         },
-        "nullable": false,
-        "references": "jams"
+        nullable: false,
+        references: "jams",
       },
       {
-        "name": "instrument",
-        "column_type": {
-          "type": "Uuid"
+        name: "instrument",
+        column_type: {
+          type: "Uuid",
         },
-        "nullable": false,
-        "references": "instruments"
+        nullable: false,
+        references: "instruments",
       },
       {
-        "name": "beat_index",
-        "column_type": {
-          "type": "Integer"
+        name: "beat_index",
+        column_type: {
+          type: "Integer",
         },
-        "nullable": false
+        nullable: false,
       },
       {
-        "name": "placed_by",
-        "column_type": {
-          "type": "Text"
+        name: "placed_by",
+        column_type: {
+          type: "Text",
         },
-        "nullable": false
-      }
-    ]
+        nullable: false,
+      },
+    ],
   },
-  "participants": {
-    "columns": [
+  participants: {
+    columns: [
       {
-        "name": "jam",
-        "column_type": {
-          "type": "Uuid"
+        name: "jam",
+        column_type: {
+          type: "Uuid",
         },
-        "nullable": false,
-        "references": "jams"
+        nullable: false,
+        references: "jams",
       },
       {
-        "name": "user_id",
-        "column_type": {
-          "type": "Text"
+        name: "user_id",
+        column_type: {
+          type: "Text",
         },
-        "nullable": false
+        nullable: false,
       },
       {
-        "name": "display_name",
-        "column_type": {
-          "type": "Text"
+        name: "display_name",
+        column_type: {
+          type: "Text",
         },
-        "nullable": false
-      }
-    ]
-  }
+        nullable: false,
+      },
+    ],
+  },
 };
 
-export class InstrumentQueryBuilder<I extends InstrumentInclude = {}, S extends InstrumentSelectableColumn = keyof Instrument> implements QueryBuilder<InstrumentSelectedWithIncludes<I, S>> {
+export class InstrumentQueryBuilder<
+  I extends InstrumentInclude = {},
+  S extends InstrumentSelectableColumn = keyof Instrument,
+> implements QueryBuilder<InstrumentSelectedWithIncludes<I, S>> {
   readonly _table = "instruments";
   readonly _schema: WasmSchema = wasmSchema;
   readonly _rowType!: InstrumentSelectedWithIncludes<I, S>;
@@ -421,7 +491,9 @@ export class InstrumentQueryBuilder<I extends InstrumentInclude = {}, S extends 
     return clone;
   }
 
-  select<NewS extends InstrumentSelectableColumn>(...columns: [NewS, ...NewS[]]): InstrumentQueryBuilder<I, NewS> {
+  select<NewS extends InstrumentSelectableColumn>(
+    ...columns: [NewS, ...NewS[]]
+  ): InstrumentQueryBuilder<I, NewS> {
     const clone = this._clone<I, NewS>();
     clone._selectColumns = [...columns] as string[];
     return clone;
@@ -433,7 +505,10 @@ export class InstrumentQueryBuilder<I extends InstrumentInclude = {}, S extends 
     return clone;
   }
 
-  orderBy(column: InstrumentOrderableColumn, direction: "asc" | "desc" = "asc"): InstrumentQueryBuilder<I, S> {
+  orderBy(
+    column: InstrumentOrderableColumn,
+    direction: "asc" | "desc" = "asc",
+  ): InstrumentQueryBuilder<I, S> {
     const clone = this._clone();
     clone._orderBys.push([column as string, direction]);
     return clone;
@@ -482,13 +557,15 @@ export class InstrumentQueryBuilder<I extends InstrumentInclude = {}, S extends 
 
     const currentToken = "__jazz_gather_current__";
     const stepOutput = options.step({ current: currentToken });
-    if (!stepOutput || typeof stepOutput !== "object" || typeof (stepOutput as { _build?: unknown })._build !== "function") {
+    if (
+      !stepOutput ||
+      typeof stepOutput !== "object" ||
+      typeof (stepOutput as { _build?: unknown })._build !== "function"
+    ) {
       throw new Error("gather(...) step must return a query expression built from app.<table>.");
     }
 
-    const stepBuilt = JSON.parse(
-      stepOutput._build(),
-    ) as {
+    const stepBuilt = JSON.parse(stepOutput._build()) as {
       table?: unknown;
       conditions?: Array<{ column: string; op: string; value: unknown }>;
       hops?: unknown;
@@ -512,7 +589,9 @@ export class InstrumentQueryBuilder<I extends InstrumentInclude = {}, S extends 
       (condition) => condition.op === "eq" && condition.value === currentToken,
     );
     if (currentConditions.length !== 1) {
-      throw new Error("gather(...) step must include exactly one where condition bound to current.");
+      throw new Error(
+        "gather(...) step must include exactly one where condition bound to current.",
+      );
     }
 
     const currentCondition = currentConditions[0];
@@ -552,7 +631,10 @@ export class InstrumentQueryBuilder<I extends InstrumentInclude = {}, S extends 
     return JSON.parse(this._build());
   }
 
-  private _clone<CloneI extends InstrumentInclude = I, CloneS extends InstrumentSelectableColumn = S>(): InstrumentQueryBuilder<CloneI, CloneS> {
+  private _clone<
+    CloneI extends InstrumentInclude = I,
+    CloneS extends InstrumentSelectableColumn = S,
+  >(): InstrumentQueryBuilder<CloneI, CloneS> {
     const clone = new InstrumentQueryBuilder<CloneI, CloneS>();
     clone._conditions = [...this._conditions];
     clone._includes = { ...this._includes };
@@ -572,7 +654,10 @@ export class InstrumentQueryBuilder<I extends InstrumentInclude = {}, S extends 
   }
 }
 
-export class JamQueryBuilder<I extends JamInclude = {}, S extends JamSelectableColumn = keyof Jam> implements QueryBuilder<JamSelectedWithIncludes<I, S>> {
+export class JamQueryBuilder<
+  I extends JamInclude = {},
+  S extends JamSelectableColumn = keyof Jam,
+> implements QueryBuilder<JamSelectedWithIncludes<I, S>> {
   readonly _table = "jams";
   readonly _schema: WasmSchema = wasmSchema;
   readonly _rowType!: JamSelectedWithIncludes<I, S>;
@@ -609,7 +694,9 @@ export class JamQueryBuilder<I extends JamInclude = {}, S extends JamSelectableC
     return clone;
   }
 
-  select<NewS extends JamSelectableColumn>(...columns: [NewS, ...NewS[]]): JamQueryBuilder<I, NewS> {
+  select<NewS extends JamSelectableColumn>(
+    ...columns: [NewS, ...NewS[]]
+  ): JamQueryBuilder<I, NewS> {
     const clone = this._clone<I, NewS>();
     clone._selectColumns = [...columns] as string[];
     return clone;
@@ -670,13 +757,15 @@ export class JamQueryBuilder<I extends JamInclude = {}, S extends JamSelectableC
 
     const currentToken = "__jazz_gather_current__";
     const stepOutput = options.step({ current: currentToken });
-    if (!stepOutput || typeof stepOutput !== "object" || typeof (stepOutput as { _build?: unknown })._build !== "function") {
+    if (
+      !stepOutput ||
+      typeof stepOutput !== "object" ||
+      typeof (stepOutput as { _build?: unknown })._build !== "function"
+    ) {
       throw new Error("gather(...) step must return a query expression built from app.<table>.");
     }
 
-    const stepBuilt = JSON.parse(
-      stepOutput._build(),
-    ) as {
+    const stepBuilt = JSON.parse(stepOutput._build()) as {
       table?: unknown;
       conditions?: Array<{ column: string; op: string; value: unknown }>;
       hops?: unknown;
@@ -700,7 +789,9 @@ export class JamQueryBuilder<I extends JamInclude = {}, S extends JamSelectableC
       (condition) => condition.op === "eq" && condition.value === currentToken,
     );
     if (currentConditions.length !== 1) {
-      throw new Error("gather(...) step must include exactly one where condition bound to current.");
+      throw new Error(
+        "gather(...) step must include exactly one where condition bound to current.",
+      );
     }
 
     const currentCondition = currentConditions[0];
@@ -740,7 +831,10 @@ export class JamQueryBuilder<I extends JamInclude = {}, S extends JamSelectableC
     return JSON.parse(this._build());
   }
 
-  private _clone<CloneI extends JamInclude = I, CloneS extends JamSelectableColumn = S>(): JamQueryBuilder<CloneI, CloneS> {
+  private _clone<
+    CloneI extends JamInclude = I,
+    CloneS extends JamSelectableColumn = S,
+  >(): JamQueryBuilder<CloneI, CloneS> {
     const clone = new JamQueryBuilder<CloneI, CloneS>();
     clone._conditions = [...this._conditions];
     clone._includes = { ...this._includes };
@@ -760,7 +854,10 @@ export class JamQueryBuilder<I extends JamInclude = {}, S extends JamSelectableC
   }
 }
 
-export class BeatQueryBuilder<I extends BeatInclude = {}, S extends BeatSelectableColumn = keyof Beat> implements QueryBuilder<BeatSelectedWithIncludes<I, S>> {
+export class BeatQueryBuilder<
+  I extends BeatInclude = {},
+  S extends BeatSelectableColumn = keyof Beat,
+> implements QueryBuilder<BeatSelectedWithIncludes<I, S>> {
   readonly _table = "beats";
   readonly _schema: WasmSchema = wasmSchema;
   readonly _rowType!: BeatSelectedWithIncludes<I, S>;
@@ -797,7 +894,9 @@ export class BeatQueryBuilder<I extends BeatInclude = {}, S extends BeatSelectab
     return clone;
   }
 
-  select<NewS extends BeatSelectableColumn>(...columns: [NewS, ...NewS[]]): BeatQueryBuilder<I, NewS> {
+  select<NewS extends BeatSelectableColumn>(
+    ...columns: [NewS, ...NewS[]]
+  ): BeatQueryBuilder<I, NewS> {
     const clone = this._clone<I, NewS>();
     clone._selectColumns = [...columns] as string[];
     return clone;
@@ -858,13 +957,15 @@ export class BeatQueryBuilder<I extends BeatInclude = {}, S extends BeatSelectab
 
     const currentToken = "__jazz_gather_current__";
     const stepOutput = options.step({ current: currentToken });
-    if (!stepOutput || typeof stepOutput !== "object" || typeof (stepOutput as { _build?: unknown })._build !== "function") {
+    if (
+      !stepOutput ||
+      typeof stepOutput !== "object" ||
+      typeof (stepOutput as { _build?: unknown })._build !== "function"
+    ) {
       throw new Error("gather(...) step must return a query expression built from app.<table>.");
     }
 
-    const stepBuilt = JSON.parse(
-      stepOutput._build(),
-    ) as {
+    const stepBuilt = JSON.parse(stepOutput._build()) as {
       table?: unknown;
       conditions?: Array<{ column: string; op: string; value: unknown }>;
       hops?: unknown;
@@ -888,7 +989,9 @@ export class BeatQueryBuilder<I extends BeatInclude = {}, S extends BeatSelectab
       (condition) => condition.op === "eq" && condition.value === currentToken,
     );
     if (currentConditions.length !== 1) {
-      throw new Error("gather(...) step must include exactly one where condition bound to current.");
+      throw new Error(
+        "gather(...) step must include exactly one where condition bound to current.",
+      );
     }
 
     const currentCondition = currentConditions[0];
@@ -928,7 +1031,10 @@ export class BeatQueryBuilder<I extends BeatInclude = {}, S extends BeatSelectab
     return JSON.parse(this._build());
   }
 
-  private _clone<CloneI extends BeatInclude = I, CloneS extends BeatSelectableColumn = S>(): BeatQueryBuilder<CloneI, CloneS> {
+  private _clone<
+    CloneI extends BeatInclude = I,
+    CloneS extends BeatSelectableColumn = S,
+  >(): BeatQueryBuilder<CloneI, CloneS> {
     const clone = new BeatQueryBuilder<CloneI, CloneS>();
     clone._conditions = [...this._conditions];
     clone._includes = { ...this._includes };
@@ -948,7 +1054,10 @@ export class BeatQueryBuilder<I extends BeatInclude = {}, S extends BeatSelectab
   }
 }
 
-export class ParticipantQueryBuilder<I extends ParticipantInclude = {}, S extends ParticipantSelectableColumn = keyof Participant> implements QueryBuilder<ParticipantSelectedWithIncludes<I, S>> {
+export class ParticipantQueryBuilder<
+  I extends ParticipantInclude = {},
+  S extends ParticipantSelectableColumn = keyof Participant,
+> implements QueryBuilder<ParticipantSelectedWithIncludes<I, S>> {
   readonly _table = "participants";
   readonly _schema: WasmSchema = wasmSchema;
   readonly _rowType!: ParticipantSelectedWithIncludes<I, S>;
@@ -985,7 +1094,9 @@ export class ParticipantQueryBuilder<I extends ParticipantInclude = {}, S extend
     return clone;
   }
 
-  select<NewS extends ParticipantSelectableColumn>(...columns: [NewS, ...NewS[]]): ParticipantQueryBuilder<I, NewS> {
+  select<NewS extends ParticipantSelectableColumn>(
+    ...columns: [NewS, ...NewS[]]
+  ): ParticipantQueryBuilder<I, NewS> {
     const clone = this._clone<I, NewS>();
     clone._selectColumns = [...columns] as string[];
     return clone;
@@ -997,7 +1108,10 @@ export class ParticipantQueryBuilder<I extends ParticipantInclude = {}, S extend
     return clone;
   }
 
-  orderBy(column: ParticipantOrderableColumn, direction: "asc" | "desc" = "asc"): ParticipantQueryBuilder<I, S> {
+  orderBy(
+    column: ParticipantOrderableColumn,
+    direction: "asc" | "desc" = "asc",
+  ): ParticipantQueryBuilder<I, S> {
     const clone = this._clone();
     clone._orderBys.push([column as string, direction]);
     return clone;
@@ -1046,13 +1160,15 @@ export class ParticipantQueryBuilder<I extends ParticipantInclude = {}, S extend
 
     const currentToken = "__jazz_gather_current__";
     const stepOutput = options.step({ current: currentToken });
-    if (!stepOutput || typeof stepOutput !== "object" || typeof (stepOutput as { _build?: unknown })._build !== "function") {
+    if (
+      !stepOutput ||
+      typeof stepOutput !== "object" ||
+      typeof (stepOutput as { _build?: unknown })._build !== "function"
+    ) {
       throw new Error("gather(...) step must return a query expression built from app.<table>.");
     }
 
-    const stepBuilt = JSON.parse(
-      stepOutput._build(),
-    ) as {
+    const stepBuilt = JSON.parse(stepOutput._build()) as {
       table?: unknown;
       conditions?: Array<{ column: string; op: string; value: unknown }>;
       hops?: unknown;
@@ -1076,7 +1192,9 @@ export class ParticipantQueryBuilder<I extends ParticipantInclude = {}, S extend
       (condition) => condition.op === "eq" && condition.value === currentToken,
     );
     if (currentConditions.length !== 1) {
-      throw new Error("gather(...) step must include exactly one where condition bound to current.");
+      throw new Error(
+        "gather(...) step must include exactly one where condition bound to current.",
+      );
     }
 
     const currentCondition = currentConditions[0];
@@ -1116,7 +1234,10 @@ export class ParticipantQueryBuilder<I extends ParticipantInclude = {}, S extend
     return JSON.parse(this._build());
   }
 
-  private _clone<CloneI extends ParticipantInclude = I, CloneS extends ParticipantSelectableColumn = S>(): ParticipantQueryBuilder<CloneI, CloneS> {
+  private _clone<
+    CloneI extends ParticipantInclude = I,
+    CloneS extends ParticipantSelectableColumn = S,
+  >(): ParticipantQueryBuilder<CloneI, CloneS> {
     const clone = new ParticipantQueryBuilder<CloneI, CloneS>();
     clone._conditions = [...this._conditions];
     clone._includes = { ...this._includes };

--- a/examples/wequencer/schema/app.ts
+++ b/examples/wequencer/schema/app.ts
@@ -387,8 +387,8 @@ export const wasmSchema: WasmSchema = {
 export class InstrumentQueryBuilder<I extends InstrumentInclude = {}, S extends InstrumentSelectableColumn = keyof Instrument> implements QueryBuilder<InstrumentSelectedWithIncludes<I, S>> {
   readonly _table = "instruments";
   readonly _schema: WasmSchema = wasmSchema;
-  declare readonly _rowType: InstrumentSelectedWithIncludes<I, S>;
-  declare readonly _initType: InstrumentInit;
+  readonly _rowType!: InstrumentSelectedWithIncludes<I, S>;
+  readonly _initType!: InstrumentInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<InstrumentInclude> = {};
   private _selectColumns?: string[];
@@ -575,8 +575,8 @@ export class InstrumentQueryBuilder<I extends InstrumentInclude = {}, S extends 
 export class JamQueryBuilder<I extends JamInclude = {}, S extends JamSelectableColumn = keyof Jam> implements QueryBuilder<JamSelectedWithIncludes<I, S>> {
   readonly _table = "jams";
   readonly _schema: WasmSchema = wasmSchema;
-  declare readonly _rowType: JamSelectedWithIncludes<I, S>;
-  declare readonly _initType: JamInit;
+  readonly _rowType!: JamSelectedWithIncludes<I, S>;
+  readonly _initType!: JamInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<JamInclude> = {};
   private _selectColumns?: string[];
@@ -763,8 +763,8 @@ export class JamQueryBuilder<I extends JamInclude = {}, S extends JamSelectableC
 export class BeatQueryBuilder<I extends BeatInclude = {}, S extends BeatSelectableColumn = keyof Beat> implements QueryBuilder<BeatSelectedWithIncludes<I, S>> {
   readonly _table = "beats";
   readonly _schema: WasmSchema = wasmSchema;
-  declare readonly _rowType: BeatSelectedWithIncludes<I, S>;
-  declare readonly _initType: BeatInit;
+  readonly _rowType!: BeatSelectedWithIncludes<I, S>;
+  readonly _initType!: BeatInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<BeatInclude> = {};
   private _selectColumns?: string[];
@@ -951,8 +951,8 @@ export class BeatQueryBuilder<I extends BeatInclude = {}, S extends BeatSelectab
 export class ParticipantQueryBuilder<I extends ParticipantInclude = {}, S extends ParticipantSelectableColumn = keyof Participant> implements QueryBuilder<ParticipantSelectedWithIncludes<I, S>> {
   readonly _table = "participants";
   readonly _schema: WasmSchema = wasmSchema;
-  declare readonly _rowType: ParticipantSelectedWithIncludes<I, S>;
-  declare readonly _initType: ParticipantInit;
+  readonly _rowType!: ParticipantSelectedWithIncludes<I, S>;
+  readonly _initType!: ParticipantInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<ParticipantInclude> = {};
   private _selectColumns?: string[];

--- a/packages/inspector/tests/browser/schema/app.ts
+++ b/packages/inspector/tests/browser/schema/app.ts
@@ -1,5 +1,19 @@
 // AUTO-GENERATED FILE - DO NOT EDIT
 import type { WasmSchema, QueryBuilder } from "jazz-tools";
+export type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: JsonValue }
+  | JsonValue[];
+
+export type PermissionIntrospectionColumn = "$canRead" | "$canEdit" | "$canDelete";
+export interface PermissionIntrospectionColumns {
+  $canRead: boolean | null;
+  $canEdit: boolean | null;
+  $canDelete: boolean | null;
+}
 
 export interface Todo {
   id: string;
@@ -16,7 +30,20 @@ export interface TodoWhereInput {
   id?: string | { eq?: string; ne?: string; in?: string[] };
   title?: string | { eq?: string; ne?: string; contains?: string };
   done?: boolean;
+  $canRead?: boolean;
+  $canEdit?: boolean;
+  $canDelete?: boolean;
 }
+
+type AnyTodoQueryBuilder<T = any> = { readonly _table: "todos" } & QueryBuilder<T>;
+
+export type TodoSelectableColumn = keyof Todo | PermissionIntrospectionColumn | "*";
+export type TodoOrderableColumn = keyof Todo | PermissionIntrospectionColumn;
+
+export type TodoSelected<S extends TodoSelectableColumn = keyof Todo> = "*" extends S
+  ? Todo
+  : Pick<Todo, Extract<S | "id", keyof Todo>> &
+      Pick<PermissionIntrospectionColumns, Extract<S, PermissionIntrospectionColumn>>;
 
 export const wasmSchema: WasmSchema = {
   todos: {
@@ -39,6 +66,200 @@ export const wasmSchema: WasmSchema = {
   },
 };
 
-export const app = {
+export class TodoQueryBuilder<
+  I extends Record<string, never> = {},
+  S extends TodoSelectableColumn = keyof Todo,
+> implements QueryBuilder<TodoSelected<S>> {
+  readonly _table = "todos";
+  readonly _schema: WasmSchema = wasmSchema;
+  readonly _rowType!: TodoSelected<S>;
+  readonly _initType!: TodoInit;
+  private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
+  private _includes: Partial<Record<string, never>> = {};
+  private _selectColumns?: string[];
+  private _orderBys: Array<[string, "asc" | "desc"]> = [];
+  private _limitVal?: number;
+  private _offsetVal?: number;
+  private _hops: string[] = [];
+  private _gatherVal?: {
+    max_depth: number;
+    step_table: string;
+    step_current_column: string;
+    step_conditions: Array<{ column: string; op: string; value: unknown }>;
+    step_hops: string[];
+  };
+
+  where(conditions: TodoWhereInput): TodoQueryBuilder<I, S> {
+    const clone = this._clone();
+    for (const [key, value] of Object.entries(conditions)) {
+      if (value === undefined) continue;
+      if (typeof value === "object" && value !== null && !Array.isArray(value)) {
+        for (const [op, opValue] of Object.entries(value)) {
+          if (opValue !== undefined) {
+            clone._conditions.push({ column: key, op, value: opValue });
+          }
+        }
+      } else {
+        clone._conditions.push({ column: key, op: "eq", value });
+      }
+    }
+    return clone;
+  }
+
+  select<NewS extends TodoSelectableColumn>(
+    ...columns: [NewS, ...NewS[]]
+  ): TodoQueryBuilder<I, NewS> {
+    const clone = this._clone<I, NewS>();
+    clone._selectColumns = [...columns] as string[];
+    return clone;
+  }
+
+  orderBy(column: TodoOrderableColumn, direction: "asc" | "desc" = "asc"): TodoQueryBuilder<I, S> {
+    const clone = this._clone();
+    clone._orderBys.push([column as string, direction]);
+    return clone;
+  }
+
+  limit(n: number): TodoQueryBuilder<I, S> {
+    const clone = this._clone();
+    clone._limitVal = n;
+    return clone;
+  }
+
+  offset(n: number): TodoQueryBuilder<I, S> {
+    const clone = this._clone();
+    clone._offsetVal = n;
+    return clone;
+  }
+
+  gather(options: {
+    start: TodoWhereInput;
+    step: (ctx: { current: string }) => QueryBuilder<unknown>;
+    maxDepth?: number;
+  }): TodoQueryBuilder<I, S> {
+    if (options.start === undefined) {
+      throw new Error("gather(...) requires start where conditions.");
+    }
+    if (typeof options.step !== "function") {
+      throw new Error("gather(...) requires step callback.");
+    }
+
+    const maxDepth = options.maxDepth ?? 10;
+    if (!Number.isInteger(maxDepth) || maxDepth <= 0) {
+      throw new Error("gather(...) maxDepth must be a positive integer.");
+    }
+    if (Object.keys(this._includes).length > 0) {
+      throw new Error("gather(...) does not support include(...) in MVP.");
+    }
+    if (this._hops.length > 0) {
+      throw new Error("gather(...) must be called before hopTo(...).");
+    }
+
+    const currentToken = "__jazz_gather_current__";
+    const stepOutput = options.step({ current: currentToken });
+    if (
+      !stepOutput ||
+      typeof stepOutput !== "object" ||
+      typeof (stepOutput as { _build?: unknown })._build !== "function"
+    ) {
+      throw new Error("gather(...) step must return a query expression built from app.<table>.");
+    }
+
+    const stepBuilt = JSON.parse(stepOutput._build()) as {
+      table?: unknown;
+      conditions?: Array<{ column: string; op: string; value: unknown }>;
+      hops?: unknown;
+    };
+
+    if (typeof stepBuilt.table !== "string" || !stepBuilt.table) {
+      throw new Error("gather(...) step query is missing table metadata.");
+    }
+    if (!Array.isArray(stepBuilt.conditions)) {
+      throw new Error("gather(...) step query is missing condition metadata.");
+    }
+
+    const stepHops = Array.isArray(stepBuilt.hops)
+      ? stepBuilt.hops.filter((hop): hop is string => typeof hop === "string")
+      : [];
+    if (stepHops.length !== 1) {
+      throw new Error("gather(...) step must include exactly one hopTo(...).");
+    }
+
+    const currentConditions = stepBuilt.conditions.filter(
+      (condition) => condition.op === "eq" && condition.value === currentToken,
+    );
+    if (currentConditions.length !== 1) {
+      throw new Error(
+        "gather(...) step must include exactly one where condition bound to current.",
+      );
+    }
+
+    const currentCondition = currentConditions[0];
+    const stepConditions = stepBuilt.conditions.filter(
+      (condition) => !(condition.op === "eq" && condition.value === currentToken),
+    );
+
+    const withStart = this.where(options.start);
+    const clone = withStart._clone();
+    clone._hops = [];
+    clone._gatherVal = {
+      max_depth: maxDepth,
+      step_table: stepBuilt.table,
+      step_current_column: currentCondition.column,
+      step_conditions: stepConditions,
+      step_hops: stepHops,
+    };
+
+    return clone;
+  }
+
+  _build(): string {
+    return JSON.stringify({
+      table: this._table,
+      conditions: this._conditions,
+      includes: this._includes,
+      select: this._selectColumns,
+      orderBy: this._orderBys,
+      limit: this._limitVal,
+      offset: this._offsetVal,
+      hops: this._hops,
+      gather: this._gatherVal,
+    });
+  }
+
+  toJSON(): unknown {
+    return JSON.parse(this._build());
+  }
+
+  private _clone<
+    CloneI extends Record<string, never> = I,
+    CloneS extends TodoSelectableColumn = S,
+  >(): TodoQueryBuilder<CloneI, CloneS> {
+    const clone = new TodoQueryBuilder<CloneI, CloneS>();
+    clone._conditions = [...this._conditions];
+    clone._includes = { ...this._includes };
+    clone._selectColumns = this._selectColumns ? [...this._selectColumns] : undefined;
+    clone._orderBys = [...this._orderBys];
+    clone._limitVal = this._limitVal;
+    clone._offsetVal = this._offsetVal;
+    clone._hops = [...this._hops];
+    clone._gatherVal = this._gatherVal
+      ? {
+          ...this._gatherVal,
+          step_conditions: this._gatherVal.step_conditions.map((condition) => ({ ...condition })),
+          step_hops: [...this._gatherVal.step_hops],
+        }
+      : undefined;
+    return clone;
+  }
+}
+
+export interface GeneratedApp {
+  todos: TodoQueryBuilder;
+  wasmSchema: WasmSchema;
+}
+
+export const app: GeneratedApp = {
+  todos: new TodoQueryBuilder(),
   wasmSchema,
 };

--- a/packages/jazz-tools/src/codegen/codegen.test.ts
+++ b/packages/jazz-tools/src/codegen/codegen.test.ts
@@ -1037,8 +1037,8 @@ describe("generateQueryBuilderClasses", () => {
     expect(output).toContain(
       "export class TodoQueryBuilder<I extends Record<string, never> = {}, S extends TodoSelectableColumn = keyof Todo> implements QueryBuilder<TodoSelected<S>> {",
     );
-    expect(output).toContain("declare readonly _rowType: TodoSelected<S>;");
-    expect(output).toContain("declare readonly _initType: TodoInit;");
+    expect(output).toContain("readonly _rowType!: TodoSelected<S>;");
+    expect(output).toContain("readonly _initType!: TodoInit;");
     expect(output).toContain("where(conditions: TodoWhereInput)");
     expect(output).toContain(
       "select<NewS extends TodoSelectableColumn>(...columns: [NewS, ...NewS[]]): TodoQueryBuilder<I, NewS>",
@@ -1060,7 +1060,7 @@ describe("generateQueryBuilderClasses", () => {
     expect(output).toContain(
       "export class TodoQueryBuilder<I extends TodoInclude = {}, S extends TodoSelectableColumn = keyof Todo> implements QueryBuilder<TodoSelectedWithIncludes<I, S>> {",
     );
-    expect(output).toContain("declare readonly _rowType: TodoSelectedWithIncludes<I, S>;");
+    expect(output).toContain("readonly _rowType!: TodoSelectedWithIncludes<I, S>;");
   });
 
   it("generates include method for tables with relations", () => {

--- a/packages/jazz-tools/src/codegen/query-builder-generator.ts
+++ b/packages/jazz-tools/src/codegen/query-builder-generator.ts
@@ -161,8 +161,8 @@ function generateQueryBuilderClass(
   lines.push(`  readonly _table = "${tableName}";`);
   lines.push(`  readonly _schema: WasmSchema = wasmSchema;`);
   // Phantom fields used only for type inference.
-  lines.push(`  declare readonly _rowType: ${rowType};`);
-  lines.push(`  declare readonly _initType: ${interfaceName}Init;`);
+  lines.push(`  readonly _rowType!: ${rowType};`);
+  lines.push(`  readonly _initType!: ${interfaceName}Init;`);
   lines.push(`  private _conditions: Array<{ column: string; op: string; value: unknown }> = [];`);
   lines.push(`  private _includes: Partial<${includeConstraint}> = {};`);
   lines.push(`  private _selectColumns?: string[];`);

--- a/packages/jazz-tools/tests/ts-dsl/fixtures/basic/app.ts
+++ b/packages/jazz-tools/tests/ts-dsl/fixtures/basic/app.ts
@@ -336,8 +336,8 @@ export class UserQueryBuilder<
 > implements QueryBuilder<UserSelectedWithIncludes<I, S>> {
   readonly _table = "users";
   readonly _schema: WasmSchema = wasmSchema;
-  declare readonly _rowType: UserSelectedWithIncludes<I, S>;
-  declare readonly _initType: UserInit;
+  readonly _rowType!: UserSelectedWithIncludes<I, S>;
+  readonly _initType!: UserInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<UserInclude> = {};
   private _selectColumns?: string[];
@@ -536,8 +536,8 @@ export class ProjectQueryBuilder<
 > implements QueryBuilder<ProjectSelectedWithIncludes<I, S>> {
   readonly _table = "projects";
   readonly _schema: WasmSchema = wasmSchema;
-  declare readonly _rowType: ProjectSelectedWithIncludes<I, S>;
-  declare readonly _initType: ProjectInit;
+  readonly _rowType!: ProjectSelectedWithIncludes<I, S>;
+  readonly _initType!: ProjectInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<ProjectInclude> = {};
   private _selectColumns?: string[];
@@ -739,8 +739,8 @@ export class TodoQueryBuilder<
 > implements QueryBuilder<TodoSelectedWithIncludes<I, S>> {
   readonly _table = "todos";
   readonly _schema: WasmSchema = wasmSchema;
-  declare readonly _rowType: TodoSelectedWithIncludes<I, S>;
-  declare readonly _initType: TodoInit;
+  readonly _rowType!: TodoSelectedWithIncludes<I, S>;
+  readonly _initType!: TodoInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<TodoInclude> = {};
   private _selectColumns?: string[];


### PR DESCRIPTION
## Summary
- Fix `jazz-tools build` TypeScript codegen so generated `schema/app.ts` query builder classes use `readonly _rowType!: T` and `readonly _initType!: T` instead of `declare readonly ...`.
- Expo (React Native) fails to compile generated files that contain `declare` class fields unless Flow-specific Babel options are enabled; this removes that incompatibility.
- This is a type-only emission change for phantom inference fields and is intended to preserve runtime behavior.

## Context
Expo error from generated `schema/app.ts`:

```text
ERROR  SyntaxError: <project>/schema/app.ts: The 'declare' modifier is only allowed when the 'allowDeclareFields' option of @babel/plugin-transform-flow-strip-types or @babel/preset-flow is enabled.
  384 |   readonly _table = "messages";
  385 |   readonly _schema: WasmSchema = wasmSchema;
> 386 |   declare readonly _rowType: MessageSelected<S>;
      |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  387 |   declare readonly _initType: MessageInit;
  388 |   private _conditions: Array<{ column: string; op: string; value: unknown }> =
  389 |     [];
```

## Tests
- Updated codegen snapshot-style assertions in `packages/jazz-tools/src/codegen/codegen.test.ts` to expect the new field form.
- Verified with:
  - `pnpm --filter jazz-tools exec vitest run src/codegen/codegen.test.ts`