### PR TITLE
Avoid declare in generated query builders

### DIFF
--- a/.changeset/expo-codegen-no-declare.md
+++ b/.changeset/expo-codegen-no-declare.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Stop generating `declare` phantom fields in query builder schema output so Expo/Metro can transpile generated `schema/app.ts` files without requiring Flow `allowDeclareFields`.

--- a/examples/docs/todo-client-localfirst-expo/schema/app.ts
+++ b/examples/docs/todo-client-localfirst-expo/schema/app.ts
@@ -269,8 +269,8 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
 > {
   readonly _table = "projects";
   readonly _schema: WasmSchema = wasmSchema;
-  declare readonly _rowType: ProjectWithIncludes<I>;
-  declare readonly _initType: ProjectInit;
+  readonly _rowType: ProjectWithIncludes<I> = undefined as unknown as ProjectWithIncludes<I>;
+  readonly _initType: ProjectInit = undefined as unknown as ProjectInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<ProjectInclude> = {};
   private _orderBys: Array<[string, "asc" | "desc"]> = [];
@@ -450,8 +450,8 @@ export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilde
 > {
   readonly _table = "todos";
   readonly _schema: WasmSchema = wasmSchema;
-  declare readonly _rowType: TodoWithIncludes<I>;
-  declare readonly _initType: TodoInit;
+  readonly _rowType: TodoWithIncludes<I> = undefined as unknown as TodoWithIncludes<I>;
+  readonly _initType: TodoInit = undefined as unknown as TodoInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<TodoInclude> = {};
   private _orderBys: Array<[string, "asc" | "desc"]> = [];

--- a/examples/docs/todo-client-localfirst-react/schema/app.ts
+++ b/examples/docs/todo-client-localfirst-react/schema/app.ts
@@ -256,8 +256,8 @@ export const wasmSchema: WasmSchema = {
 export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends ProjectSelectableColumn = keyof Project> implements QueryBuilder<ProjectSelectedWithIncludes<I, S>> {
   readonly _table = "projects";
   readonly _schema: WasmSchema = wasmSchema;
-  declare readonly _rowType: ProjectSelectedWithIncludes<I, S>;
-  declare readonly _initType: ProjectInit;
+  readonly _rowType: ProjectSelectedWithIncludes<I, S> = undefined as unknown as ProjectSelectedWithIncludes<I, S>;
+  readonly _initType: ProjectInit = undefined as unknown as ProjectInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<ProjectInclude> = {};
   private _selectColumns?: string[];
@@ -444,8 +444,8 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
 export class TodoQueryBuilder<I extends TodoInclude = {}, S extends TodoSelectableColumn = keyof Todo> implements QueryBuilder<TodoSelectedWithIncludes<I, S>> {
   readonly _table = "todos";
   readonly _schema: WasmSchema = wasmSchema;
-  declare readonly _rowType: TodoSelectedWithIncludes<I, S>;
-  declare readonly _initType: TodoInit;
+  readonly _rowType: TodoSelectedWithIncludes<I, S> = undefined as unknown as TodoSelectedWithIncludes<I, S>;
+  readonly _initType: TodoInit = undefined as unknown as TodoInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<TodoInclude> = {};
   private _selectColumns?: string[];

--- a/examples/docs/todo-client-localfirst-svelte/schema/app.ts
+++ b/examples/docs/todo-client-localfirst-svelte/schema/app.ts
@@ -256,8 +256,8 @@ export const wasmSchema: WasmSchema = {
 export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends ProjectSelectableColumn = keyof Project> implements QueryBuilder<ProjectSelectedWithIncludes<I, S>> {
   readonly _table = "projects";
   readonly _schema: WasmSchema = wasmSchema;
-  declare readonly _rowType: ProjectSelectedWithIncludes<I, S>;
-  declare readonly _initType: ProjectInit;
+  readonly _rowType: ProjectSelectedWithIncludes<I, S> = undefined as unknown as ProjectSelectedWithIncludes<I, S>;
+  readonly _initType: ProjectInit = undefined as unknown as ProjectInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<ProjectInclude> = {};
   private _selectColumns?: string[];
@@ -444,8 +444,8 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
 export class TodoQueryBuilder<I extends TodoInclude = {}, S extends TodoSelectableColumn = keyof Todo> implements QueryBuilder<TodoSelectedWithIncludes<I, S>> {
   readonly _table = "todos";
   readonly _schema: WasmSchema = wasmSchema;
-  declare readonly _rowType: TodoSelectedWithIncludes<I, S>;
-  declare readonly _initType: TodoInit;
+  readonly _rowType: TodoSelectedWithIncludes<I, S> = undefined as unknown as TodoSelectedWithIncludes<I, S>;
+  readonly _initType: TodoInit = undefined as unknown as TodoInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<TodoInclude> = {};
   private _selectColumns?: string[];

--- a/examples/docs/todo-client-localfirst-ts/schema/app.ts
+++ b/examples/docs/todo-client-localfirst-ts/schema/app.ts
@@ -229,8 +229,8 @@ export const wasmSchema: WasmSchema = {
 export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends ProjectSelectableColumn = keyof Project> implements QueryBuilder<ProjectSelectedWithIncludes<I, S>> {
   readonly _table = "projects";
   readonly _schema: WasmSchema = wasmSchema;
-  declare readonly _rowType: ProjectSelectedWithIncludes<I, S>;
-  declare readonly _initType: ProjectInit;
+  readonly _rowType: ProjectSelectedWithIncludes<I, S> = undefined as unknown as ProjectSelectedWithIncludes<I, S>;
+  readonly _initType: ProjectInit = undefined as unknown as ProjectInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<ProjectInclude> = {};
   private _selectColumns?: string[];
@@ -417,8 +417,8 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
 export class TodoQueryBuilder<I extends TodoInclude = {}, S extends TodoSelectableColumn = keyof Todo> implements QueryBuilder<TodoSelectedWithIncludes<I, S>> {
   readonly _table = "todos";
   readonly _schema: WasmSchema = wasmSchema;
-  declare readonly _rowType: TodoSelectedWithIncludes<I, S>;
-  declare readonly _initType: TodoInit;
+  readonly _rowType: TodoSelectedWithIncludes<I, S> = undefined as unknown as TodoSelectedWithIncludes<I, S>;
+  readonly _initType: TodoInit = undefined as unknown as TodoInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<TodoInclude> = {};
   private _selectColumns?: string[];

--- a/examples/docs/todo-client-localfirst-vue/schema/app.ts
+++ b/examples/docs/todo-client-localfirst-vue/schema/app.ts
@@ -256,8 +256,8 @@ export const wasmSchema: WasmSchema = {
 export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends ProjectSelectableColumn = keyof Project> implements QueryBuilder<ProjectSelectedWithIncludes<I, S>> {
   readonly _table = "projects";
   readonly _schema: WasmSchema = wasmSchema;
-  declare readonly _rowType: ProjectSelectedWithIncludes<I, S>;
-  declare readonly _initType: ProjectInit;
+  readonly _rowType: ProjectSelectedWithIncludes<I, S> = undefined as unknown as ProjectSelectedWithIncludes<I, S>;
+  readonly _initType: ProjectInit = undefined as unknown as ProjectInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<ProjectInclude> = {};
   private _selectColumns?: string[];
@@ -444,8 +444,8 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
 export class TodoQueryBuilder<I extends TodoInclude = {}, S extends TodoSelectableColumn = keyof Todo> implements QueryBuilder<TodoSelectedWithIncludes<I, S>> {
   readonly _table = "todos";
   readonly _schema: WasmSchema = wasmSchema;
-  declare readonly _rowType: TodoSelectedWithIncludes<I, S>;
-  declare readonly _initType: TodoInit;
+  readonly _rowType: TodoSelectedWithIncludes<I, S> = undefined as unknown as TodoSelectedWithIncludes<I, S>;
+  readonly _initType: TodoInit = undefined as unknown as TodoInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<TodoInclude> = {};
   private _selectColumns?: string[];

--- a/examples/docs/todo-server-ts/schema/app.ts
+++ b/examples/docs/todo-server-ts/schema/app.ts
@@ -235,8 +235,8 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
 > {
   readonly _table = "projects";
   readonly _schema: WasmSchema = wasmSchema;
-  declare readonly _rowType: ProjectWithIncludes<I>;
-  declare readonly _initType: ProjectInit;
+  readonly _rowType: ProjectWithIncludes<I> = undefined as unknown as ProjectWithIncludes<I>;
+  readonly _initType: ProjectInit = undefined as unknown as ProjectInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<ProjectInclude> = {};
   private _orderBys: Array<[string, "asc" | "desc"]> = [];
@@ -416,8 +416,8 @@ export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilde
 > {
   readonly _table = "todos";
   readonly _schema: WasmSchema = wasmSchema;
-  declare readonly _rowType: TodoWithIncludes<I>;
-  declare readonly _initType: TodoInit;
+  readonly _rowType: TodoWithIncludes<I> = undefined as unknown as TodoWithIncludes<I>;
+  readonly _initType: TodoInit = undefined as unknown as TodoInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<TodoInclude> = {};
   private _orderBys: Array<[string, "asc" | "desc"]> = [];

--- a/examples/todo-client-localfirst-expo/schema/app.ts
+++ b/examples/todo-client-localfirst-expo/schema/app.ts
@@ -229,8 +229,8 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
 > {
   readonly _table = "projects";
   readonly _schema: WasmSchema = wasmSchema;
-  declare readonly _rowType: ProjectWithIncludes<I>;
-  declare readonly _initType: ProjectInit;
+  readonly _rowType: ProjectWithIncludes<I> = undefined as unknown as ProjectWithIncludes<I>;
+  readonly _initType: ProjectInit = undefined as unknown as ProjectInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<ProjectInclude> = {};
   private _orderBys: Array<[string, "asc" | "desc"]> = [];
@@ -410,8 +410,8 @@ export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilde
 > {
   readonly _table = "todos";
   readonly _schema: WasmSchema = wasmSchema;
-  declare readonly _rowType: TodoWithIncludes<I>;
-  declare readonly _initType: TodoInit;
+  readonly _rowType: TodoWithIncludes<I> = undefined as unknown as TodoWithIncludes<I>;
+  readonly _initType: TodoInit = undefined as unknown as TodoInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<TodoInclude> = {};
   private _orderBys: Array<[string, "asc" | "desc"]> = [];

--- a/examples/todo-client-localfirst-react/schema/app.ts
+++ b/examples/todo-client-localfirst-react/schema/app.ts
@@ -271,8 +271,8 @@ export const wasmSchema: WasmSchema = {
 export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends ProjectSelectableColumn = keyof Project> implements QueryBuilder<ProjectSelectedWithIncludes<I, S>> {
   readonly _table = "projects";
   readonly _schema: WasmSchema = wasmSchema;
-  declare readonly _rowType: ProjectSelectedWithIncludes<I, S>;
-  declare readonly _initType: ProjectInit;
+  readonly _rowType: ProjectSelectedWithIncludes<I, S> = undefined as unknown as ProjectSelectedWithIncludes<I, S>;
+  readonly _initType: ProjectInit = undefined as unknown as ProjectInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<ProjectInclude> = {};
   private _selectColumns?: string[];
@@ -459,8 +459,8 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
 export class TodoQueryBuilder<I extends TodoInclude = {}, S extends TodoSelectableColumn = keyof Todo> implements QueryBuilder<TodoSelectedWithIncludes<I, S>> {
   readonly _table = "todos";
   readonly _schema: WasmSchema = wasmSchema;
-  declare readonly _rowType: TodoSelectedWithIncludes<I, S>;
-  declare readonly _initType: TodoInit;
+  readonly _rowType: TodoSelectedWithIncludes<I, S> = undefined as unknown as TodoSelectedWithIncludes<I, S>;
+  readonly _initType: TodoInit = undefined as unknown as TodoInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<TodoInclude> = {};
   private _selectColumns?: string[];

--- a/examples/todo-client-localfirst-svelte/schema/app.ts
+++ b/examples/todo-client-localfirst-svelte/schema/app.ts
@@ -271,8 +271,8 @@ export const wasmSchema: WasmSchema = {
 export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends ProjectSelectableColumn = keyof Project> implements QueryBuilder<ProjectSelectedWithIncludes<I, S>> {
   readonly _table = "projects";
   readonly _schema: WasmSchema = wasmSchema;
-  declare readonly _rowType: ProjectSelectedWithIncludes<I, S>;
-  declare readonly _initType: ProjectInit;
+  readonly _rowType: ProjectSelectedWithIncludes<I, S> = undefined as unknown as ProjectSelectedWithIncludes<I, S>;
+  readonly _initType: ProjectInit = undefined as unknown as ProjectInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<ProjectInclude> = {};
   private _selectColumns?: string[];
@@ -459,8 +459,8 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
 export class TodoQueryBuilder<I extends TodoInclude = {}, S extends TodoSelectableColumn = keyof Todo> implements QueryBuilder<TodoSelectedWithIncludes<I, S>> {
   readonly _table = "todos";
   readonly _schema: WasmSchema = wasmSchema;
-  declare readonly _rowType: TodoSelectedWithIncludes<I, S>;
-  declare readonly _initType: TodoInit;
+  readonly _rowType: TodoSelectedWithIncludes<I, S> = undefined as unknown as TodoSelectedWithIncludes<I, S>;
+  readonly _initType: TodoInit = undefined as unknown as TodoInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<TodoInclude> = {};
   private _selectColumns?: string[];

--- a/examples/todo-client-localfirst-ts/schema/app.ts
+++ b/examples/todo-client-localfirst-ts/schema/app.ts
@@ -271,8 +271,8 @@ export const wasmSchema: WasmSchema = {
 export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends ProjectSelectableColumn = keyof Project> implements QueryBuilder<ProjectSelectedWithIncludes<I, S>> {
   readonly _table = "projects";
   readonly _schema: WasmSchema = wasmSchema;
-  declare readonly _rowType: ProjectSelectedWithIncludes<I, S>;
-  declare readonly _initType: ProjectInit;
+  readonly _rowType: ProjectSelectedWithIncludes<I, S> = undefined as unknown as ProjectSelectedWithIncludes<I, S>;
+  readonly _initType: ProjectInit = undefined as unknown as ProjectInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<ProjectInclude> = {};
   private _selectColumns?: string[];
@@ -459,8 +459,8 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}, S extends Projec
 export class TodoQueryBuilder<I extends TodoInclude = {}, S extends TodoSelectableColumn = keyof Todo> implements QueryBuilder<TodoSelectedWithIncludes<I, S>> {
   readonly _table = "todos";
   readonly _schema: WasmSchema = wasmSchema;
-  declare readonly _rowType: TodoSelectedWithIncludes<I, S>;
-  declare readonly _initType: TodoInit;
+  readonly _rowType: TodoSelectedWithIncludes<I, S> = undefined as unknown as TodoSelectedWithIncludes<I, S>;
+  readonly _initType: TodoInit = undefined as unknown as TodoInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<TodoInclude> = {};
   private _selectColumns?: string[];

--- a/examples/todo-server-ts/schema/app.ts
+++ b/examples/todo-server-ts/schema/app.ts
@@ -235,8 +235,8 @@ export class ProjectQueryBuilder<I extends ProjectInclude = {}> implements Query
 > {
   readonly _table = "projects";
   readonly _schema: WasmSchema = wasmSchema;
-  declare readonly _rowType: ProjectWithIncludes<I>;
-  declare readonly _initType: ProjectInit;
+  readonly _rowType: ProjectWithIncludes<I> = undefined as unknown as ProjectWithIncludes<I>;
+  readonly _initType: ProjectInit = undefined as unknown as ProjectInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<ProjectInclude> = {};
   private _orderBys: Array<[string, "asc" | "desc"]> = [];
@@ -416,8 +416,8 @@ export class TodoQueryBuilder<I extends TodoInclude = {}> implements QueryBuilde
 > {
   readonly _table = "todos";
   readonly _schema: WasmSchema = wasmSchema;
-  declare readonly _rowType: TodoWithIncludes<I>;
-  declare readonly _initType: TodoInit;
+  readonly _rowType: TodoWithIncludes<I> = undefined as unknown as TodoWithIncludes<I>;
+  readonly _initType: TodoInit = undefined as unknown as TodoInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<TodoInclude> = {};
   private _orderBys: Array<[string, "asc" | "desc"]> = [];

--- a/examples/wequencer/schema/app.ts
+++ b/examples/wequencer/schema/app.ts
@@ -387,8 +387,8 @@ export const wasmSchema: WasmSchema = {
 export class InstrumentQueryBuilder<I extends InstrumentInclude = {}, S extends InstrumentSelectableColumn = keyof Instrument> implements QueryBuilder<InstrumentSelectedWithIncludes<I, S>> {
   readonly _table = "instruments";
   readonly _schema: WasmSchema = wasmSchema;
-  declare readonly _rowType: InstrumentSelectedWithIncludes<I, S>;
-  declare readonly _initType: InstrumentInit;
+  readonly _rowType: InstrumentSelectedWithIncludes<I, S> = undefined as unknown as InstrumentSelectedWithIncludes<I, S>;
+  readonly _initType: InstrumentInit = undefined as unknown as InstrumentInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<InstrumentInclude> = {};
   private _selectColumns?: string[];
@@ -575,8 +575,8 @@ export class InstrumentQueryBuilder<I extends InstrumentInclude = {}, S extends 
 export class JamQueryBuilder<I extends JamInclude = {}, S extends JamSelectableColumn = keyof Jam> implements QueryBuilder<JamSelectedWithIncludes<I, S>> {
   readonly _table = "jams";
   readonly _schema: WasmSchema = wasmSchema;
-  declare readonly _rowType: JamSelectedWithIncludes<I, S>;
-  declare readonly _initType: JamInit;
+  readonly _rowType: JamSelectedWithIncludes<I, S> = undefined as unknown as JamSelectedWithIncludes<I, S>;
+  readonly _initType: JamInit = undefined as unknown as JamInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<JamInclude> = {};
   private _selectColumns?: string[];
@@ -763,8 +763,8 @@ export class JamQueryBuilder<I extends JamInclude = {}, S extends JamSelectableC
 export class BeatQueryBuilder<I extends BeatInclude = {}, S extends BeatSelectableColumn = keyof Beat> implements QueryBuilder<BeatSelectedWithIncludes<I, S>> {
   readonly _table = "beats";
   readonly _schema: WasmSchema = wasmSchema;
-  declare readonly _rowType: BeatSelectedWithIncludes<I, S>;
-  declare readonly _initType: BeatInit;
+  readonly _rowType: BeatSelectedWithIncludes<I, S> = undefined as unknown as BeatSelectedWithIncludes<I, S>;
+  readonly _initType: BeatInit = undefined as unknown as BeatInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<BeatInclude> = {};
   private _selectColumns?: string[];
@@ -951,8 +951,8 @@ export class BeatQueryBuilder<I extends BeatInclude = {}, S extends BeatSelectab
 export class ParticipantQueryBuilder<I extends ParticipantInclude = {}, S extends ParticipantSelectableColumn = keyof Participant> implements QueryBuilder<ParticipantSelectedWithIncludes<I, S>> {
   readonly _table = "participants";
   readonly _schema: WasmSchema = wasmSchema;
-  declare readonly _rowType: ParticipantSelectedWithIncludes<I, S>;
-  declare readonly _initType: ParticipantInit;
+  readonly _rowType: ParticipantSelectedWithIncludes<I, S> = undefined as unknown as ParticipantSelectedWithIncludes<I, S>;
+  readonly _initType: ParticipantInit = undefined as unknown as ParticipantInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<ParticipantInclude> = {};
   private _selectColumns?: string[];

--- a/packages/jazz-tools/src/codegen/codegen.test.ts
+++ b/packages/jazz-tools/src/codegen/codegen.test.ts
@@ -1037,8 +1037,12 @@ describe("generateQueryBuilderClasses", () => {
     expect(output).toContain(
       "export class TodoQueryBuilder<I extends Record<string, never> = {}, S extends TodoSelectableColumn = keyof Todo> implements QueryBuilder<TodoSelected<S>> {",
     );
-    expect(output).toContain("declare readonly _rowType: TodoSelected<S>;");
-    expect(output).toContain("declare readonly _initType: TodoInit;");
+    expect(output).toContain(
+      "readonly _rowType: TodoSelected<S> = undefined as unknown as TodoSelected<S>;",
+    );
+    expect(output).toContain("readonly _initType: TodoInit = undefined as unknown as TodoInit;");
+    expect(output).not.toContain("declare readonly _rowType");
+    expect(output).not.toContain("declare readonly _initType");
     expect(output).toContain("where(conditions: TodoWhereInput)");
     expect(output).toContain(
       "select<NewS extends TodoSelectableColumn>(...columns: [NewS, ...NewS[]]): TodoQueryBuilder<I, NewS>",
@@ -1060,7 +1064,9 @@ describe("generateQueryBuilderClasses", () => {
     expect(output).toContain(
       "export class TodoQueryBuilder<I extends TodoInclude = {}, S extends TodoSelectableColumn = keyof Todo> implements QueryBuilder<TodoSelectedWithIncludes<I, S>> {",
     );
-    expect(output).toContain("declare readonly _rowType: TodoSelectedWithIncludes<I, S>;");
+    expect(output).toContain(
+      "readonly _rowType: TodoSelectedWithIncludes<I, S> = undefined as unknown as TodoSelectedWithIncludes<I, S>;",
+    );
   });
 
   it("generates include method for tables with relations", () => {

--- a/packages/jazz-tools/src/codegen/query-builder-generator.ts
+++ b/packages/jazz-tools/src/codegen/query-builder-generator.ts
@@ -160,9 +160,12 @@ function generateQueryBuilderClass(
   );
   lines.push(`  readonly _table = "${tableName}";`);
   lines.push(`  readonly _schema: WasmSchema = wasmSchema;`);
-  // Phantom fields used only for type inference.
-  lines.push(`  declare readonly _rowType: ${rowType};`);
-  lines.push(`  declare readonly _initType: ${interfaceName}Init;`);
+  // Phantom fields used only for type inference. Use initialized fields so
+  // Babel/Expo can strip the TypeScript syntax without requiring `declare`.
+  lines.push(`  readonly _rowType: ${rowType} = undefined as unknown as ${rowType};`);
+  lines.push(
+    `  readonly _initType: ${interfaceName}Init = undefined as unknown as ${interfaceName}Init;`,
+  );
   lines.push(`  private _conditions: Array<{ column: string; op: string; value: unknown }> = [];`);
   lines.push(`  private _includes: Partial<${includeConstraint}> = {};`);
   lines.push(`  private _selectColumns?: string[];`);

--- a/packages/jazz-tools/src/testing/fixtures/basic/app.ts
+++ b/packages/jazz-tools/src/testing/fixtures/basic/app.ts
@@ -49,8 +49,8 @@ export const wasmSchema: WasmSchema = {
 export class TodoQueryBuilder<I extends Record<string, never> = {}> implements QueryBuilder<Todo> {
   readonly _table = "todos";
   readonly _schema: WasmSchema = wasmSchema;
-  declare readonly _rowType: Todo;
-  declare readonly _initType: TodoInit;
+  readonly _rowType: Todo = undefined as unknown as Todo;
+  readonly _initType: TodoInit = undefined as unknown as TodoInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<Record<string, never>> = {};
   private _orderBys: Array<[string, "asc" | "desc"]> = [];

--- a/packages/jazz-tools/tests/ts-dsl/fixtures/basic/app.ts
+++ b/packages/jazz-tools/tests/ts-dsl/fixtures/basic/app.ts
@@ -336,8 +336,9 @@ export class UserQueryBuilder<
 > implements QueryBuilder<UserSelectedWithIncludes<I, S>> {
   readonly _table = "users";
   readonly _schema: WasmSchema = wasmSchema;
-  declare readonly _rowType: UserSelectedWithIncludes<I, S>;
-  declare readonly _initType: UserInit;
+  readonly _rowType: UserSelectedWithIncludes<I, S> =
+    undefined as unknown as UserSelectedWithIncludes<I, S>;
+  readonly _initType: UserInit = undefined as unknown as UserInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<UserInclude> = {};
   private _selectColumns?: string[];
@@ -536,8 +537,9 @@ export class ProjectQueryBuilder<
 > implements QueryBuilder<ProjectSelectedWithIncludes<I, S>> {
   readonly _table = "projects";
   readonly _schema: WasmSchema = wasmSchema;
-  declare readonly _rowType: ProjectSelectedWithIncludes<I, S>;
-  declare readonly _initType: ProjectInit;
+  readonly _rowType: ProjectSelectedWithIncludes<I, S> =
+    undefined as unknown as ProjectSelectedWithIncludes<I, S>;
+  readonly _initType: ProjectInit = undefined as unknown as ProjectInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<ProjectInclude> = {};
   private _selectColumns?: string[];
@@ -739,8 +741,9 @@ export class TodoQueryBuilder<
 > implements QueryBuilder<TodoSelectedWithIncludes<I, S>> {
   readonly _table = "todos";
   readonly _schema: WasmSchema = wasmSchema;
-  declare readonly _rowType: TodoSelectedWithIncludes<I, S>;
-  declare readonly _initType: TodoInit;
+  readonly _rowType: TodoSelectedWithIncludes<I, S> =
+    undefined as unknown as TodoSelectedWithIncludes<I, S>;
+  readonly _initType: TodoInit = undefined as unknown as TodoInit;
   private _conditions: Array<{ column: string; op: string; value: unknown }> = [];
   private _includes: Partial<TodoInclude> = {};
   private _selectColumns?: string[];


### PR DESCRIPTION
## Summary
- stop emitting `declare` phantom fields in generated query builders and use initialized readonly fields instead
- update codegen expectations plus checked-in generated fixtures/examples to match the new output
- add a patch changeset for `jazz-tools` describing the Expo/Metro compatibility fix

## Testing
- pnpm --filter jazz-tools exec vitest run src/codegen/codegen.test.ts
- pnpm --filter jazz-tools exec tsc --project tsconfig.tests.json
- pnpm format
- pnpm lint