### PR TITLE
docs: add session usage examples to authentication

### DIFF
--- a/docs/content/docs/authentication.mdx
+++ b/docs/content/docs/authentication.mdx
@@ -134,113 +134,27 @@ user, read the resolved session in your client and use `session.user_id`.
 
 <Tabs items={["React", "Vue", "Svelte", "TypeScript"]}>
   <Tab value="React">
-    ````tsx
-    import { useDb, useSession } from "jazz-tools/react";
-    import { app } from "../schema/app.js";
-
-    function TodoActions() {
-      const db = useDb();
-      const session = useSession();
-
-      function addTodo(title: string) {
-        if (!session) return;
-
-        db.insert(app.todos, {
-          title,
-          done: false,
-          owner_id: session.user_id,
-        });
-      }
-
-      async function loadMyTodos() {
-        if (!session) return [];
-        return db.all(app.todos.where({ owner_id: session.user_id }));
-      }
-
-      return null;
-    }
-    ````
+    <include cwd lang="tsx">
+      ../examples/docs/todo-client-localfirst-react/src/AuthSessionExamples.tsx#auth-session-react
+    </include>
 
   </Tab>
   <Tab value="Vue">
-    ````vue
-    <script setup lang="ts">
-    import { useDb, useSession } from "jazz-tools/vue";
-    import { app } from "../schema/app.js";
-
-    const db = useDb();
-    const session = useSession();
-
-    function addTodo(title: string) {
-      if (!session) return;
-
-      db.insert(app.todos, {
-        title,
-        done: false,
-        owner_id: session.user_id,
-      });
-    }
-
-    async function loadMyTodos() {
-      if (!session) return [];
-      return db.all(app.todos.where({ owner_id: session.user_id }));
-    }
-    </script>
-    ````
+    <include cwd lang="vue">
+      ../examples/docs/todo-client-localfirst-vue/src/AuthSessionExamples.vue#auth-session-vue
+    </include>
 
   </Tab>
   <Tab value="Svelte">
-    ````svelte
-    <script lang="ts">
-      import { getDb, getSession } from "jazz-tools/svelte";
-      import { app } from "../schema/app.js";
-
-      const db = getDb();
-      const session = getSession();
-
-      function addTodo(title: string) {
-        if (!session) return;
-
-        db.insert(app.todos, {
-          title,
-          done: false,
-          owner_id: session.user_id,
-        });
-      }
-
-      async function loadMyTodos() {
-        if (!session) return [];
-        return db.all(app.todos.where({ owner_id: session.user_id }));
-      }
-    </script>
-    ````
+    <include cwd lang="svelte">
+      ../examples/docs/todo-client-localfirst-svelte/src/AuthSessionExamples.svelte#auth-session-svelte
+    </include>
 
   </Tab>
   <Tab value="TypeScript">
-    ````ts
-    import { createDb, resolveClientSession } from "jazz-tools";
-    import { app } from "../schema/app.js";
-
-    const config = {
-      appId: "my-app",
-      serverUrl: "http://127.0.0.1:4200",
-    };
-
-    const db = await createDb(config);
-    const session = await resolveClientSession(config);
-
-    if (session) {
-      db.insert(app.todos, {
-        title: "Write docs",
-        done: false,
-        owner_id: session.user_id,
-      });
-
-      const myTodos = await db.all(
-        app.todos.where({ owner_id: session.user_id }),
-      );
-    }
-    ````
+    <include cwd lang="ts">
+      ../examples/docs/todo-client-localfirst-ts/src/auth-session-snippets.ts#auth-session-ts
+    </include>
 
   </Tab>
 </Tabs>

--- a/docs/content/docs/authentication.mdx
+++ b/docs/content/docs/authentication.mdx
@@ -130,30 +130,104 @@ After linking, external JWT sessions resolve to the same principal.
 ## Use the Current Session in Client Code
 
 When you want to attach rows to the current user, or fetch only the rows relevant to that
-user, read the resolved session in your client and use `session.user_id`.
+user, read the resolved session in your client and derive a user id from it.
+
+### 1. Get the Session and User ID
 
 <Tabs items={["React", "Vue", "Svelte", "TypeScript"]}>
   <Tab value="React">
     <include cwd lang="tsx">
-      ../examples/docs/todo-client-localfirst-react/src/AuthSessionExamples.tsx#auth-session-react
+      ../examples/docs/todo-client-localfirst-react/src/AuthSessionExamples.tsx#auth-session-react-hook
+    </include>
+    <include cwd lang="tsx">
+      ../examples/docs/todo-client-localfirst-react/src/AuthSessionExamples.tsx#auth-session-react-user-id
     </include>
 
   </Tab>
   <Tab value="Vue">
     <include cwd lang="vue">
-      ../examples/docs/todo-client-localfirst-vue/src/AuthSessionExamples.vue#auth-session-vue
+      ../examples/docs/todo-client-localfirst-vue/src/AuthSessionExamples.vue#auth-session-vue-hook
+    </include>
+    <include cwd lang="vue">
+      ../examples/docs/todo-client-localfirst-vue/src/AuthSessionExamples.vue#auth-session-vue-user-id
     </include>
 
   </Tab>
   <Tab value="Svelte">
     <include cwd lang="svelte">
-      ../examples/docs/todo-client-localfirst-svelte/src/AuthSessionExamples.svelte#auth-session-svelte
+      ../examples/docs/todo-client-localfirst-svelte/src/AuthSessionExamples.svelte#auth-session-svelte-hook
+    </include>
+    <include cwd lang="svelte">
+      ../examples/docs/todo-client-localfirst-svelte/src/AuthSessionExamples.svelte#auth-session-svelte-user-id
     </include>
 
   </Tab>
   <Tab value="TypeScript">
     <include cwd lang="ts">
-      ../examples/docs/todo-client-localfirst-ts/src/auth-session-snippets.ts#auth-session-ts
+      ../examples/docs/todo-client-localfirst-ts/src/auth-session-snippets.ts#auth-session-ts-hook
+    </include>
+    <include cwd lang="ts">
+      ../examples/docs/todo-client-localfirst-ts/src/auth-session-snippets.ts#auth-session-ts-user-id
+    </include>
+
+  </Tab>
+</Tabs>
+
+### 2. Read Rows Relevant to the Current User
+
+Use your framework's normal reactive read primitive with the same user-scoped filter.
+
+<Tabs items={["React", "Vue", "Svelte", "TypeScript"]}>
+  <Tab value="React">
+    <include cwd lang="tsx">
+      ../examples/docs/todo-client-localfirst-react/src/AuthSessionExamples.tsx#auth-session-react-query
+    </include>
+
+  </Tab>
+  <Tab value="Vue">
+    <include cwd lang="vue">
+      ../examples/docs/todo-client-localfirst-vue/src/AuthSessionExamples.vue#auth-session-vue-query
+    </include>
+
+  </Tab>
+  <Tab value="Svelte">
+    <include cwd lang="svelte">
+      ../examples/docs/todo-client-localfirst-svelte/src/AuthSessionExamples.svelte#auth-session-svelte-query
+    </include>
+
+  </Tab>
+  <Tab value="TypeScript">
+    <include cwd lang="ts">
+      ../examples/docs/todo-client-localfirst-ts/src/auth-session-snippets.ts#auth-session-ts-query
+    </include>
+
+  </Tab>
+</Tabs>
+
+### 3. Insert a User-Owned Row
+
+<Tabs items={["React", "Vue", "Svelte", "TypeScript"]}>
+  <Tab value="React">
+    <include cwd lang="tsx">
+      ../examples/docs/todo-client-localfirst-react/src/AuthSessionExamples.tsx#auth-session-react-insert
+    </include>
+
+  </Tab>
+  <Tab value="Vue">
+    <include cwd lang="vue">
+      ../examples/docs/todo-client-localfirst-vue/src/AuthSessionExamples.vue#auth-session-vue-insert
+    </include>
+
+  </Tab>
+  <Tab value="Svelte">
+    <include cwd lang="svelte">
+      ../examples/docs/todo-client-localfirst-svelte/src/AuthSessionExamples.svelte#auth-session-svelte-insert
+    </include>
+
+  </Tab>
+  <Tab value="TypeScript">
+    <include cwd lang="ts">
+      ../examples/docs/todo-client-localfirst-ts/src/auth-session-snippets.ts#auth-session-ts-insert
     </include>
 
   </Tab>
@@ -162,9 +236,6 @@ user, read the resolved session in your client and use `session.user_id`.
 Use whatever column matches your schema, such as `owner_id`, `author_id`, `assignee_id`, or
 `user_id`. The same pattern works whether a row is strictly owned by one user or simply scoped
 to a user.
-
-For live UI queries, use the same `where({ ...: session.user_id })` filter with your framework's
-normal query helper.
 
 These client-side filters are useful for UX, but they do not make data private on their own.
 Use [Permissions](/docs/permissions) to define row-level policies that actually enforce which

--- a/docs/content/docs/authentication.mdx
+++ b/docs/content/docs/authentication.mdx
@@ -127,6 +127,135 @@ Use `JazzClient.linkExternalIdentity(...)` directly:
 
 After linking, external JWT sessions resolve to the same principal.
 
+## Use the Current Session in Client Code
+
+When you want to attach rows to the current user, or fetch only the rows relevant to that
+user, read the resolved session in your client and use `session.user_id`.
+
+<Tabs items={["React", "Vue", "Svelte", "TypeScript"]}>
+  <Tab value="React">
+    ````tsx
+    import { useDb, useSession } from "jazz-tools/react";
+    import { app } from "../schema/app.js";
+
+    function TodoActions() {
+      const db = useDb();
+      const session = useSession();
+
+      function addTodo(title: string) {
+        if (!session) return;
+
+        db.insert(app.todos, {
+          title,
+          done: false,
+          owner_id: session.user_id,
+        });
+      }
+
+      async function loadMyTodos() {
+        if (!session) return [];
+        return db.all(app.todos.where({ owner_id: session.user_id }));
+      }
+
+      return null;
+    }
+    ````
+
+  </Tab>
+  <Tab value="Vue">
+    ````vue
+    <script setup lang="ts">
+    import { useDb, useSession } from "jazz-tools/vue";
+    import { app } from "../schema/app.js";
+
+    const db = useDb();
+    const session = useSession();
+
+    function addTodo(title: string) {
+      if (!session) return;
+
+      db.insert(app.todos, {
+        title,
+        done: false,
+        owner_id: session.user_id,
+      });
+    }
+
+    async function loadMyTodos() {
+      if (!session) return [];
+      return db.all(app.todos.where({ owner_id: session.user_id }));
+    }
+    </script>
+    ````
+
+  </Tab>
+  <Tab value="Svelte">
+    ````svelte
+    <script lang="ts">
+      import { getDb, getSession } from "jazz-tools/svelte";
+      import { app } from "../schema/app.js";
+
+      const db = getDb();
+      const session = getSession();
+
+      function addTodo(title: string) {
+        if (!session) return;
+
+        db.insert(app.todos, {
+          title,
+          done: false,
+          owner_id: session.user_id,
+        });
+      }
+
+      async function loadMyTodos() {
+        if (!session) return [];
+        return db.all(app.todos.where({ owner_id: session.user_id }));
+      }
+    </script>
+    ````
+
+  </Tab>
+  <Tab value="TypeScript">
+    ````ts
+    import { createDb, resolveClientSession } from "jazz-tools";
+    import { app } from "../schema/app.js";
+
+    const config = {
+      appId: "my-app",
+      serverUrl: "http://127.0.0.1:4200",
+    };
+
+    const db = await createDb(config);
+    const session = await resolveClientSession(config);
+
+    if (session) {
+      db.insert(app.todos, {
+        title: "Write docs",
+        done: false,
+        owner_id: session.user_id,
+      });
+
+      const myTodos = await db.all(
+        app.todos.where({ owner_id: session.user_id }),
+      );
+    }
+    ````
+
+  </Tab>
+</Tabs>
+
+Use whatever column matches your schema, such as `owner_id`, `author_id`, `assignee_id`, or
+`user_id`. The same pattern works whether a row is strictly owned by one user or simply scoped
+to a user.
+
+For live UI queries, use the same `where({ ...: session.user_id })` filter with your framework's
+normal query helper.
+
+These client-side filters are useful for UX, but they do not make data private on their own.
+Use [Permissions](/docs/permissions) to define row-level policies that actually enforce which
+sessions can read or mutate a row.
+
 ## Session Resolution Order
 
 For `jazz-tools server`:

--- a/examples/docs/todo-client-localfirst-react/schema/session-app.ts
+++ b/examples/docs/todo-client-localfirst-react/schema/session-app.ts
@@ -1,0 +1,3 @@
+// Reuse the session-scoped todo schema from the Expo docs example so auth snippets
+// stay aligned across frontend frameworks.
+export { app } from "../../todo-client-localfirst-expo/schema/app.js";

--- a/examples/docs/todo-client-localfirst-react/src/App.tsx
+++ b/examples/docs/todo-client-localfirst-react/src/App.tsx
@@ -1,7 +1,11 @@
 import * as React from "react";
 import { JazzProvider } from "jazz-tools/react";
 import type { DbConfig } from "jazz-tools";
+import { AuthSessionExamples } from "./AuthSessionExamples.js";
 import { TodoList } from "./TodoList.js";
+
+// Keep docs-only auth snippets in the compiled example app.
+void AuthSessionExamples;
 
 function readEnvAppId(): string | undefined {
   return (import.meta as ImportMeta & { env?: Record<string, string | undefined> }).env

--- a/examples/docs/todo-client-localfirst-react/src/AuthSessionExamples.tsx
+++ b/examples/docs/todo-client-localfirst-react/src/AuthSessionExamples.tsx
@@ -1,0 +1,26 @@
+// #region auth-session-react
+import { useDb, useSession } from "jazz-tools/react";
+import { app } from "../schema/session-app.js";
+
+export function AuthSessionExamples() {
+  const db = useDb();
+  const session = useSession();
+
+  async function loadOwnedTodos() {
+    if (!session) return [];
+    return db.all(app.todos.where({ owner_id: session.user_id }));
+  }
+
+  function addOwnedTodo(title: string) {
+    if (!session) return;
+
+    db.insert(app.todos, {
+      title,
+      done: false,
+      owner_id: session.user_id,
+    });
+  }
+
+  return null;
+}
+// #endregion auth-session-react

--- a/examples/docs/todo-client-localfirst-react/src/AuthSessionExamples.tsx
+++ b/examples/docs/todo-client-localfirst-react/src/AuthSessionExamples.tsx
@@ -1,26 +1,36 @@
-// #region auth-session-react
-import { useDb, useSession } from "jazz-tools/react";
+import { useAll, useDb, useSession } from "jazz-tools/react";
 import { app } from "../schema/session-app.js";
 
 export function AuthSessionExamples() {
   const db = useDb();
+
+  // #region auth-session-react-hook
   const session = useSession();
+  // #endregion auth-session-react-hook
 
-  async function loadOwnedTodos() {
-    if (!session) return [];
-    return db.all(app.todos.where({ owner_id: session.user_id }));
-  }
+  // #region auth-session-react-user-id
+  const sessionUserId = session?.user_id ?? null;
+  // #endregion auth-session-react-user-id
 
+  // #region auth-session-react-query
+  const ownedTodos =
+    useAll(sessionUserId ? app.todos.where({ owner_id: sessionUserId }) : undefined) ?? [];
+  // #endregion auth-session-react-query
+
+  // #region auth-session-react-insert
   function addOwnedTodo(title: string) {
-    if (!session) return;
+    if (!sessionUserId) return;
 
     db.insert(app.todos, {
       title,
       done: false,
-      owner_id: session.user_id,
+      owner_id: sessionUserId,
     });
   }
+  // #endregion auth-session-react-insert
+
+  void ownedTodos;
+  void addOwnedTodo;
 
   return null;
 }
-// #endregion auth-session-react

--- a/examples/docs/todo-client-localfirst-svelte/schema/session-app.ts
+++ b/examples/docs/todo-client-localfirst-svelte/schema/session-app.ts
@@ -1,0 +1,3 @@
+// Reuse the session-scoped todo schema from the Expo docs example so auth snippets
+// stay aligned across frontend frameworks.
+export { app } from "../../todo-client-localfirst-expo/schema/app.js";

--- a/examples/docs/todo-client-localfirst-svelte/src/App.svelte
+++ b/examples/docs/todo-client-localfirst-svelte/src/App.svelte
@@ -1,7 +1,11 @@
 <!-- #region provider-svelte -->
 <script lang="ts">
 	import { createJazzClient, JazzSvelteProvider } from 'jazz-tools/svelte';
+	import AuthSessionExamples from './AuthSessionExamples.svelte';
 	import TodoList from './TodoList.svelte';
+
+	// Keep docs-only auth snippets in the compiled example app.
+	void AuthSessionExamples;
 
 	const client = createJazzClient({
 		appId: 'todo-svelte-example',

--- a/examples/docs/todo-client-localfirst-svelte/src/AuthSessionExamples.svelte
+++ b/examples/docs/todo-client-localfirst-svelte/src/AuthSessionExamples.svelte
@@ -1,24 +1,35 @@
-<!-- #region auth-session-svelte -->
 <script lang="ts">
-	import { getDb, getSession } from 'jazz-tools/svelte';
+	import { getDb, getSession, QuerySubscription } from 'jazz-tools/svelte';
 	import { app } from '../schema/session-app.js';
 
 	const db = getDb();
+
+	// #region auth-session-svelte-hook
 	const session = getSession();
+	// #endregion auth-session-svelte-hook
 
-	async function loadOwnedTodos() {
-		if (!session) return [];
-		return db.all(app.todos.where({ owner_id: session.user_id }));
-	}
+	// #region auth-session-svelte-user-id
+	const sessionUserId = $derived(session?.user_id ?? null);
+	// #endregion auth-session-svelte-user-id
 
+	// #region auth-session-svelte-query
+	const ownedTodos = new QuerySubscription(
+		app.todos.where({ owner_id: sessionUserId ?? '__no-session__' }),
+	);
+	// #endregion auth-session-svelte-query
+
+	// #region auth-session-svelte-insert
 	function addOwnedTodo(title: string) {
-		if (!session) return;
+		if (!sessionUserId) return;
 
 		db.insert(app.todos, {
 			title,
 			done: false,
-			owner_id: session.user_id,
+			owner_id: sessionUserId,
 		});
 	}
+	// #endregion auth-session-svelte-insert
+
+	void ownedTodos;
+	void addOwnedTodo;
 </script>
-<!-- #endregion auth-session-svelte -->

--- a/examples/docs/todo-client-localfirst-svelte/src/AuthSessionExamples.svelte
+++ b/examples/docs/todo-client-localfirst-svelte/src/AuthSessionExamples.svelte
@@ -1,0 +1,24 @@
+<!-- #region auth-session-svelte -->
+<script lang="ts">
+	import { getDb, getSession } from 'jazz-tools/svelte';
+	import { app } from '../schema/session-app.js';
+
+	const db = getDb();
+	const session = getSession();
+
+	async function loadOwnedTodos() {
+		if (!session) return [];
+		return db.all(app.todos.where({ owner_id: session.user_id }));
+	}
+
+	function addOwnedTodo(title: string) {
+		if (!session) return;
+
+		db.insert(app.todos, {
+			title,
+			done: false,
+			owner_id: session.user_id,
+		});
+	}
+</script>
+<!-- #endregion auth-session-svelte -->

--- a/examples/docs/todo-client-localfirst-ts/schema/session-app.ts
+++ b/examples/docs/todo-client-localfirst-ts/schema/session-app.ts
@@ -1,0 +1,3 @@
+// Reuse the session-scoped todo schema from the Expo docs example so auth snippets
+// stay aligned across frontend frameworks.
+export { app } from "../../todo-client-localfirst-expo/schema/app.js";

--- a/examples/docs/todo-client-localfirst-ts/src/auth-session-snippets.ts
+++ b/examples/docs/todo-client-localfirst-ts/src/auth-session-snippets.ts
@@ -1,0 +1,21 @@
+// #region auth-session-ts
+import { createDb, resolveClientSession, type DbConfig } from "jazz-tools";
+import { app } from "../schema/session-app.js";
+
+export async function readAndWriteOwnedTodos(config: DbConfig) {
+  const db = await createDb(config);
+  const session = await resolveClientSession(config);
+
+  if (!session) {
+    return [];
+  }
+
+  db.insert(app.todos, {
+    title: "Write docs",
+    done: false,
+    owner_id: session.user_id,
+  });
+
+  return db.all(app.todos.where({ owner_id: session.user_id }));
+}
+// #endregion auth-session-ts

--- a/examples/docs/todo-client-localfirst-ts/src/auth-session-snippets.ts
+++ b/examples/docs/todo-client-localfirst-ts/src/auth-session-snippets.ts
@@ -1,21 +1,37 @@
-// #region auth-session-ts
 import { createDb, resolveClientSession, type DbConfig } from "jazz-tools";
 import { app } from "../schema/session-app.js";
 
-export async function readAndWriteOwnedTodos(config: DbConfig) {
+export async function authSessionExamples(config: DbConfig) {
   const db = await createDb(config);
+
+  // #region auth-session-ts-hook
   const session = await resolveClientSession(config);
+  // #endregion auth-session-ts-hook
 
-  if (!session) {
-    return [];
+  // #region auth-session-ts-user-id
+  const sessionUserId = session?.user_id ?? null;
+  // #endregion auth-session-ts-user-id
+
+  // #region auth-session-ts-query
+  const ownedTodos = sessionUserId
+    ? await db.all(app.todos.where({ owner_id: sessionUserId }))
+    : [];
+  // #endregion auth-session-ts-query
+
+  // #region auth-session-ts-insert
+  function addOwnedTodo(title: string) {
+    if (!sessionUserId) return;
+
+    db.insert(app.todos, {
+      title,
+      done: false,
+      owner_id: sessionUserId,
+    });
   }
+  // #endregion auth-session-ts-insert
 
-  db.insert(app.todos, {
-    title: "Write docs",
-    done: false,
-    owner_id: session.user_id,
-  });
+  void ownedTodos;
+  void addOwnedTodo;
 
-  return db.all(app.todos.where({ owner_id: session.user_id }));
+  return db;
 }
-// #endregion auth-session-ts

--- a/examples/docs/todo-client-localfirst-ts/src/main.ts
+++ b/examples/docs/todo-client-localfirst-ts/src/main.ts
@@ -1,9 +1,9 @@
 import { createDb, type DbConfig, type Db } from "jazz-tools";
-import { readAndWriteOwnedTodos } from "./auth-session-snippets.js";
+import { authSessionExamples } from "./auth-session-snippets.js";
 import { app, Todo } from "../schema/app.js";
 
 // Keep docs-only auth snippets in the compiled example app.
-void readAndWriteOwnedTodos;
+void authSessionExamples;
 
 function readEnvAppId(): string | undefined {
   return (import.meta as ImportMeta & { env?: Record<string, string | undefined> }).env

--- a/examples/docs/todo-client-localfirst-ts/src/main.ts
+++ b/examples/docs/todo-client-localfirst-ts/src/main.ts
@@ -1,5 +1,9 @@
 import { createDb, type DbConfig, type Db } from "jazz-tools";
+import { readAndWriteOwnedTodos } from "./auth-session-snippets.js";
 import { app, Todo } from "../schema/app.js";
+
+// Keep docs-only auth snippets in the compiled example app.
+void readAndWriteOwnedTodos;
 
 function readEnvAppId(): string | undefined {
   return (import.meta as ImportMeta & { env?: Record<string, string | undefined> }).env

--- a/examples/docs/todo-client-localfirst-vue/schema/session-app.ts
+++ b/examples/docs/todo-client-localfirst-vue/schema/session-app.ts
@@ -1,0 +1,3 @@
+// Reuse the session-scoped todo schema from the Expo docs example so auth snippets
+// stay aligned across frontend frameworks.
+export { app } from "../../todo-client-localfirst-expo/schema/app.js";

--- a/examples/docs/todo-client-localfirst-vue/src/App.vue
+++ b/examples/docs/todo-client-localfirst-vue/src/App.vue
@@ -1,6 +1,10 @@
 <script setup lang="ts">
 import { createJazzClient, JazzProvider } from "jazz-tools/vue";
+import AuthSessionExamples from "./AuthSessionExamples.vue";
 import TodoList from "./TodoList.vue";
+
+// Keep docs-only auth snippets in the compiled example app.
+void AuthSessionExamples;
 
 const client = createJazzClient({
   appId: "todo-vue-example",

--- a/examples/docs/todo-client-localfirst-vue/src/AuthSessionExamples.vue
+++ b/examples/docs/todo-client-localfirst-vue/src/AuthSessionExamples.vue
@@ -1,26 +1,35 @@
-<!-- #region auth-session-vue -->
 <script setup lang="ts">
-import { useDb, useSession } from "jazz-tools/vue";
+import { useAll, useDb, useSession } from "jazz-tools/vue";
 import { app } from "../schema/session-app.js";
 
 const db = useDb();
+
+// #region auth-session-vue-hook
 const session = useSession();
+// #endregion auth-session-vue-hook
 
-async function loadOwnedTodos() {
-  if (!session) return [];
-  return db.all(app.todos.where({ owner_id: session.user_id }));
-}
+// #region auth-session-vue-user-id
+const sessionUserId = session?.user_id ?? null;
+// #endregion auth-session-vue-user-id
 
+// #region auth-session-vue-query
+const ownedTodos = useAll(app.todos.where({ owner_id: sessionUserId ?? "__no-session__" }));
+// #endregion auth-session-vue-query
+
+// #region auth-session-vue-insert
 function addOwnedTodo(title: string) {
-  if (!session) return;
+  if (!sessionUserId) return;
 
   db.insert(app.todos, {
     title,
     done: false,
-    owner_id: session.user_id,
+    owner_id: sessionUserId,
   });
 }
+// #endregion auth-session-vue-insert
+
+void ownedTodos;
+void addOwnedTodo;
 </script>
 
 <template></template>
-<!-- #endregion auth-session-vue -->

--- a/examples/docs/todo-client-localfirst-vue/src/AuthSessionExamples.vue
+++ b/examples/docs/todo-client-localfirst-vue/src/AuthSessionExamples.vue
@@ -1,0 +1,26 @@
+<!-- #region auth-session-vue -->
+<script setup lang="ts">
+import { useDb, useSession } from "jazz-tools/vue";
+import { app } from "../schema/session-app.js";
+
+const db = useDb();
+const session = useSession();
+
+async function loadOwnedTodos() {
+  if (!session) return [];
+  return db.all(app.todos.where({ owner_id: session.user_id }));
+}
+
+function addOwnedTodo(title: string) {
+  if (!session) return;
+
+  db.insert(app.todos, {
+    title,
+    done: false,
+    owner_id: session.user_id,
+  });
+}
+</script>
+
+<template></template>
+<!-- #endregion auth-session-vue -->


### PR DESCRIPTION
## Summary
- add a new auth docs section showing how to read the current session across React, Vue, Svelte, and vanilla TypeScript
- include examples for both user-scoped inserts and user-scoped queries using `session.user_id`
- link to the permissions docs to clarify that RLS/policies are what enforce user privacy

## Testing
- pre-commit `oxfmt` ran successfully during `git commit`