### PR TITLE
Bound oversized index keys with prefix+hash overflow segments

### DIFF
--- a/.changeset/prefix-holes-preserve.md
+++ b/.changeset/prefix-holes-preserve.md
@@ -1,0 +1,10 @@
+---
+"jazz-tools": patch
+"jazz-napi": patch
+"jazz-wasm": patch
+"jazz-rn": patch
+---
+
+Bound oversized index keys by keeping as much real value prefix as fits in the durable key and appending a length plus hash overflow trailer.
+
+This keeps large indexed string and JSON equality lookups working without exceeding storage key limits, while preserving prefix-based ordering instead of collapsing oversized values to a pure hash ordering. Large `array(ref(...))` values also continue to support exact array equality and per-member reference indexing.

--- a/crates/jazz-tools/src/query_manager/manager_tests.rs
+++ b/crates/jazz-tools/src/query_manager/manager_tests.rs
@@ -133,12 +133,47 @@ fn large_index_schema() -> Schema {
         )])
         .into(),
     );
+    schema.insert(
+        TableName::new("documents"),
+        RowDescriptor::new(vec![ColumnDescriptor::new(
+            "payload",
+            ColumnType::Json { schema: None },
+        )])
+        .into(),
+    );
+    schema.insert(
+        TableName::new("file_parts"),
+        RowDescriptor::new(vec![ColumnDescriptor::new("label", ColumnType::Text)]).into(),
+    );
+    schema.insert(
+        TableName::new("files"),
+        RowDescriptor::new(vec![
+            ColumnDescriptor::new(
+                "parts",
+                ColumnType::Array {
+                    element: Box::new(ColumnType::Uuid),
+                },
+            )
+            .references("file_parts"),
+        ])
+        .into(),
+    );
     schema
 }
 
 #[cfg(all(feature = "fjall", not(target_arch = "wasm32")))]
 fn oversized_text() -> String {
     "x".repeat(40_000)
+}
+
+#[cfg(all(feature = "fjall", not(target_arch = "wasm32")))]
+fn oversized_json() -> String {
+    format!(r#"{{"body":"{}"}}"#, oversized_text())
+}
+
+#[cfg(all(feature = "fjall", not(target_arch = "wasm32")))]
+fn oversized_ref_array(member_id: ObjectId) -> Value {
+    Value::Array((0..1_500).map(|_| Value::Uuid(member_id)).collect())
 }
 
 /// Helper to execute a query synchronously via subscribe/process/unsubscribe.
@@ -705,75 +740,85 @@ fn update_row() {
 
 #[cfg(all(feature = "fjall", not(target_arch = "wasm32")))]
 #[test]
-fn fjall_oversized_text_insert_returns_index_error_instead_of_panicking() {
+fn fjall_oversized_text_insert_stays_queryable() {
     let sync_manager = SyncManager::new();
     let schema = large_index_schema();
     let (mut qm, _temp_dir, mut storage) = create_query_manager_with_fjall(sync_manager, schema);
 
-    let err = qm
+    let handle = qm
         .insert(
             &mut storage,
             "todos",
             &[Value::Text(oversized_text()), Value::Boolean(false)],
         )
-        .expect_err("oversized indexed text insert should fail cleanly");
-    assert!(
-        matches!(
-            &err,
-            QueryError::IndexValueTooLarge {
-                table,
-                column,
-                ..
-            } if *table == TableName::new("todos") && column == "title"
-        ),
-        "unexpected error: {err:?}"
-    );
+        .expect("oversized indexed text insert should succeed");
 
-    let query = qm.query("todos").build();
-    let rows = execute_query(&mut qm, &mut storage, query).expect("query after failed insert");
-    assert!(
-        rows.is_empty(),
-        "failed insert should not leave a partially inserted row behind"
-    );
+    let oversized = oversized_text();
+    let query = qm
+        .query("todos")
+        .filter_eq("title", Value::Text(oversized.clone()))
+        .build();
+    let rows = execute_query(&mut qm, &mut storage, query).expect("query oversized text");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].0, handle.row_id);
+    assert_eq!(rows[0].1[0], Value::Text(oversized));
 }
 
 #[cfg(all(feature = "fjall", not(target_arch = "wasm32")))]
 #[test]
-fn fjall_oversized_array_text_insert_returns_index_error_instead_of_panicking() {
+fn fjall_oversized_json_insert_stays_queryable() {
     let sync_manager = SyncManager::new();
     let schema = large_index_schema();
     let (mut qm, _temp_dir, mut storage) = create_query_manager_with_fjall(sync_manager, schema);
 
-    let err = qm
-        .insert(
-            &mut storage,
-            "tag_lists",
-            &[Value::Array(vec![Value::Text(oversized_text())])],
-        )
-        .expect_err("oversized indexed array(text) insert should fail cleanly");
-    assert!(
-        matches!(
-            &err,
-            QueryError::IndexValueTooLarge {
-                table,
-                column,
-                ..
-            } if *table == TableName::new("tag_lists") && column == "labels"
-        ),
-        "unexpected error: {err:?}"
-    );
+    let payload = oversized_json();
+    let handle = qm
+        .insert(&mut storage, "documents", &[Value::Text(payload.clone())])
+        .expect("oversized indexed json insert should succeed");
 
-    let query = qm.query("tag_lists").build();
-    let rows = execute_query(&mut qm, &mut storage, query).expect("query after failed insert");
+    let query = qm
+        .query("documents")
+        .filter_eq("payload", Value::Text(payload.clone()))
+        .build();
+    let rows = execute_query(&mut qm, &mut storage, query).expect("query oversized json");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].0, handle.row_id);
+    assert_eq!(rows[0].1, vec![Value::Text(payload)]);
+}
+
+#[cfg(all(feature = "fjall", not(target_arch = "wasm32")))]
+#[test]
+fn fjall_oversized_ref_array_insert_stays_queryable() {
+    let sync_manager = SyncManager::new();
+    let schema = large_index_schema();
+    let (mut qm, _temp_dir, mut storage) = create_query_manager_with_fjall(sync_manager, schema);
+
+    let member = qm
+        .insert(&mut storage, "file_parts", &[Value::Text("part-a".into())])
+        .expect("insert referenced row");
+    let parts = oversized_ref_array(member.row_id);
+    let handle = qm
+        .insert(&mut storage, "files", std::slice::from_ref(&parts))
+        .expect("oversized indexed array(ref) insert should succeed");
+
+    let query = qm.query("files").filter_eq("parts", parts.clone()).build();
+    let rows = execute_query(&mut qm, &mut storage, query).expect("query oversized array(ref)");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].0, handle.row_id);
+    assert_eq!(rows[0].1, vec![parts.clone()]);
+
+    let branch = get_branch(&qm);
+    let member_lookup =
+        storage.index_lookup("files", "parts", &branch, &Value::Uuid(member.row_id));
     assert!(
-        rows.is_empty(),
-        "failed insert should not leave a partially inserted row behind"
+        member_lookup.contains(&handle.row_id),
+        "array(ref) membership index should still track each referenced row id"
     );
 }
 
 #[cfg(all(feature = "fjall", not(target_arch = "wasm32")))]
 #[test]
-fn fjall_oversized_text_update_returns_index_error_and_preserves_old_index() {
+fn fjall_oversized_text_update_reindexes_to_new_value() {
     let sync_manager = SyncManager::new();
     let schema = large_index_schema();
     let (mut qm, _temp_dir, mut storage) = create_query_manager_with_fjall(sync_manager, schema);
@@ -786,32 +831,30 @@ fn fjall_oversized_text_update_returns_index_error_and_preserves_old_index() {
         )
         .expect("insert initial row");
 
-    let err = qm
-        .update(
-            &mut storage,
-            handle.row_id,
-            &[Value::Text(oversized_text()), Value::Boolean(false)],
-        )
-        .expect_err("oversized indexed text update should fail cleanly");
-    assert!(
-        matches!(
-            &err,
-            QueryError::IndexValueTooLarge {
-                table,
-                column,
-                ..
-            } if *table == TableName::new("todos") && column == "title"
-        ),
-        "unexpected error: {err:?}"
-    );
+    let oversized = oversized_text();
+    qm.update(
+        &mut storage,
+        handle.row_id,
+        &[Value::Text(oversized.clone()), Value::Boolean(false)],
+    )
+    .expect("oversized indexed text update should succeed");
+
+    let new_query = qm
+        .query("todos")
+        .filter_eq("title", Value::Text(oversized.clone()))
+        .build();
+    let new_rows =
+        execute_query(&mut qm, &mut storage, new_query).expect("query oversized indexed value");
+    assert_eq!(new_rows.len(), 1);
+    assert_eq!(new_rows[0].0, handle.row_id);
 
     let query = qm.query("todos").build();
-    let rows = execute_query(&mut qm, &mut storage, query).expect("query after failed update");
+    let rows = execute_query(&mut qm, &mut storage, query).expect("query after update");
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0].0, handle.row_id);
     assert_eq!(
         rows[0].1,
-        vec![Value::Text("keep-me".into()), Value::Boolean(false)]
+        vec![Value::Text(oversized), Value::Boolean(false)]
     );
 
     let old_query = qm
@@ -820,151 +863,7 @@ fn fjall_oversized_text_update_returns_index_error_and_preserves_old_index() {
         .build();
     let old_rows =
         execute_query(&mut qm, &mut storage, old_query).expect("query old indexed value");
-    assert_eq!(
-        old_rows.len(),
-        1,
-        "failed update should keep the old title index entry queryable"
-    );
-
-    let new_query = qm
-        .query("todos")
-        .filter_eq("title", Value::Text(oversized_text()))
-        .build();
-    let new_rows =
-        execute_query(&mut qm, &mut storage, new_query).expect("query oversized indexed value");
-    assert_eq!(
-        new_rows.len(),
-        0,
-        "failed update should not expose the new value"
-    );
-}
-
-#[cfg(all(feature = "fjall", not(target_arch = "wasm32")))]
-#[test]
-fn fjall_oversized_array_text_update_returns_index_error_and_preserves_old_index() {
-    let sync_manager = SyncManager::new();
-    let schema = large_index_schema();
-    let (mut qm, _temp_dir, mut storage) = create_query_manager_with_fjall(sync_manager, schema);
-
-    let original_labels = Value::Array(vec![Value::Text("keep-me".into())]);
-    let handle = qm
-        .insert(
-            &mut storage,
-            "tag_lists",
-            std::slice::from_ref(&original_labels),
-        )
-        .expect("insert initial row");
-
-    let err = qm
-        .update(
-            &mut storage,
-            handle.row_id,
-            &[Value::Array(vec![Value::Text(oversized_text())])],
-        )
-        .expect_err("oversized indexed array(text) update should fail cleanly");
-    assert!(
-        matches!(
-            &err,
-            QueryError::IndexValueTooLarge {
-                table,
-                column,
-                ..
-            } if *table == TableName::new("tag_lists") && column == "labels"
-        ),
-        "unexpected error: {err:?}"
-    );
-
-    let query = qm.query("tag_lists").build();
-    let rows = execute_query(&mut qm, &mut storage, query).expect("query after failed update");
-    assert_eq!(rows.len(), 1);
-    assert_eq!(rows[0].0, handle.row_id);
-    assert_eq!(rows[0].1, vec![original_labels.clone()]);
-
-    let old_query = qm
-        .query("tag_lists")
-        .filter_eq("labels", original_labels)
-        .build();
-    let old_rows =
-        execute_query(&mut qm, &mut storage, old_query).expect("query old indexed array value");
-    assert_eq!(
-        old_rows.len(),
-        1,
-        "failed update should keep the old array index entry queryable"
-    );
-}
-
-#[cfg(all(feature = "fjall", not(target_arch = "wasm32")))]
-#[test]
-fn fjall_update_can_heal_synced_row_with_oversized_index_value() {
-    use std::collections::HashMap;
-
-    use crate::commit::{Commit, StoredState};
-
-    let sync_manager = SyncManager::new();
-    let schema = large_index_schema();
-    let (mut qm, _temp_dir, mut storage) = create_query_manager_with_fjall(sync_manager, schema);
-    let branch = get_branch(&qm);
-    let row_id = ObjectId::new();
-    let oversized = oversized_text();
-
-    let mut metadata = HashMap::new();
-    metadata.insert(MetadataKey::Table.to_string(), "todos".to_string());
-    qm.sync_manager_mut()
-        .object_manager
-        .receive_object(&mut storage, row_id, metadata);
-
-    let descriptor = RowDescriptor::new(vec![
-        ColumnDescriptor::new("title", ColumnType::Text),
-        ColumnDescriptor::new("done", ColumnType::Boolean),
-    ]);
-    let commit = Commit {
-        parents: smallvec![],
-        content: encode_row(
-            &descriptor,
-            &[Value::Text(oversized.clone()), Value::Boolean(false)],
-        )
-        .unwrap(),
-        timestamp: 1000,
-        author: row_id,
-        metadata: None,
-        stored_state: StoredState::Stored,
-        ack_state: Default::default(),
-    };
-    qm.sync_manager_mut()
-        .object_manager
-        .receive_commit(&mut storage, row_id, &branch, commit)
-        .unwrap();
-    qm.process(&mut storage);
-
-    assert_eq!(
-        storage.index_lookup("todos", "title", &branch, &Value::Text(oversized.clone())),
-        Vec::<ObjectId>::new(),
-        "oversized synced value should not create a title index entry"
-    );
-
-    qm.update(
-        &mut storage,
-        row_id,
-        &[Value::Text("healed".into()), Value::Boolean(false)],
-    )
-    .expect("local update should heal a row left in partial index state");
-
-    let healed_query = qm
-        .query("todos")
-        .filter_eq("title", Value::Text("healed".into()))
-        .build();
-    let healed_rows =
-        execute_query(&mut qm, &mut storage, healed_query).expect("query healed indexed value");
-    assert_eq!(healed_rows.len(), 1);
-    assert_eq!(healed_rows[0].0, row_id);
-
-    let row = qm
-        .get_row(row_id)
-        .expect("row should still exist after healing");
-    assert_eq!(
-        row.1,
-        vec![Value::Text("healed".into()), Value::Boolean(false)]
-    );
+    assert_eq!(old_rows.len(), 0, "old title index entry should be removed");
 }
 
 #[test]

--- a/crates/jazz-tools/src/storage/key_codec.rs
+++ b/crates/jazz-tools/src/storage/key_codec.rs
@@ -8,12 +8,17 @@ use super::{StorageError, encode_value};
 
 const INDEX_KEY_MAX_BYTES: usize = u16::MAX as usize;
 const INDEX_ENTRY_UUID_HEX_BYTES: usize = 32;
+const OVERFLOW_INDEX_VALUE_MARKER: char = '~';
+const OVERFLOW_INDEX_VALUE_LEN_HEX_BYTES: usize = 16;
+const OVERFLOW_INDEX_VALUE_HASH_HEX_BYTES: usize = blake3::OUT_LEN * 2;
+const OVERFLOW_INDEX_VALUE_TRAILER_BYTES: usize =
+    1 + OVERFLOW_INDEX_VALUE_LEN_HEX_BYTES + OVERFLOW_INDEX_VALUE_HASH_HEX_BYTES;
 
 fn index_entry_key_bytes(
     table: &str,
     column: &str,
     branch: &str,
-    encoded_value_len: usize,
+    value_segment_len: usize,
 ) -> usize {
     "idx:".len()
         + table.len()
@@ -22,7 +27,7 @@ fn index_entry_key_bytes(
         + 1
         + branch.len()
         + 1
-        + (encoded_value_len * 2)
+        + value_segment_len
         + 1
         + INDEX_ENTRY_UUID_HEX_BYTES
 }
@@ -31,17 +36,82 @@ fn index_value_prefix_bytes(
     table: &str,
     column: &str,
     branch: &str,
-    encoded_value_len: usize,
+    value_segment_len: usize,
 ) -> usize {
-    "idx:".len()
-        + table.len()
-        + 1
-        + column.len()
-        + 1
-        + branch.len()
-        + 1
-        + (encoded_value_len * 2)
-        + 1
+    "idx:".len() + table.len() + 1 + column.len() + 1 + branch.len() + 1 + value_segment_len + 1
+}
+
+fn index_key_too_large_error(
+    table: &str,
+    column: &str,
+    branch: &str,
+    key_bytes: usize,
+) -> StorageError {
+    StorageError::IndexKeyTooLarge {
+        table: table.to_string(),
+        column: column.to_string(),
+        branch: branch.to_string(),
+        key_bytes,
+        max_key_bytes: INDEX_KEY_MAX_BYTES,
+    }
+}
+
+fn max_index_value_segment_len(table: &str, column: &str, branch: &str) -> Option<usize> {
+    INDEX_KEY_MAX_BYTES.checked_sub(index_entry_key_bytes(table, column, branch, 0))
+}
+
+fn overflow_index_value_segment(
+    encoded_value: &[u8],
+    encoded_hex: &str,
+    prefix_hex_len: usize,
+) -> String {
+    let hash = blake3::hash(encoded_value);
+    let prefix = &encoded_hex[..prefix_hex_len];
+    format!(
+        "{}{}{:016x}{}",
+        prefix,
+        OVERFLOW_INDEX_VALUE_MARKER,
+        encoded_value.len() as u64,
+        hex::encode(hash.as_bytes())
+    )
+}
+
+fn encode_index_value_segment(
+    table: &str,
+    column: &str,
+    branch: &str,
+    value: &Value,
+) -> Result<String, StorageError> {
+    let encoded_value = encode_value(value);
+    let encoded_hex = hex::encode(&encoded_value);
+    let Some(max_segment_len) = max_index_value_segment_len(table, column, branch) else {
+        return Err(index_key_too_large_error(
+            table,
+            column,
+            branch,
+            index_entry_key_bytes(table, column, branch, 0),
+        ));
+    };
+
+    if encoded_hex.len() <= max_segment_len {
+        return Ok(encoded_hex);
+    }
+
+    let Some(prefix_hex_len) = max_segment_len.checked_sub(OVERFLOW_INDEX_VALUE_TRAILER_BYTES)
+    else {
+        return Err(index_key_too_large_error(
+            table,
+            column,
+            branch,
+            index_entry_key_bytes(table, column, branch, OVERFLOW_INDEX_VALUE_TRAILER_BYTES),
+        ));
+    };
+
+    Ok(overflow_index_value_segment(
+        &encoded_value,
+        &encoded_hex,
+        prefix_hex_len,
+    ))
 }
 
 pub(super) fn validate_index_entry_size(
@@ -50,38 +120,7 @@ pub(super) fn validate_index_entry_size(
     branch: &str,
     value: &Value,
 ) -> Result<(), StorageError> {
-    let encoded_value_len = encode_value(value).len();
-    let key_bytes = index_entry_key_bytes(table, column, branch, encoded_value_len);
-    if key_bytes > INDEX_KEY_MAX_BYTES {
-        return Err(StorageError::IndexKeyTooLarge {
-            table: table.to_string(),
-            column: column.to_string(),
-            branch: branch.to_string(),
-            key_bytes,
-            max_key_bytes: INDEX_KEY_MAX_BYTES,
-        });
-    }
-    Ok(())
-}
-
-fn encode_index_value_hex(
-    table: &str,
-    column: &str,
-    branch: &str,
-    value: &Value,
-) -> Result<String, StorageError> {
-    let encoded_value = encode_value(value);
-    let key_bytes = index_entry_key_bytes(table, column, branch, encoded_value.len());
-    if key_bytes > INDEX_KEY_MAX_BYTES {
-        return Err(StorageError::IndexKeyTooLarge {
-            table: table.to_string(),
-            column: column.to_string(),
-            branch: branch.to_string(),
-            key_bytes,
-            max_key_bytes: INDEX_KEY_MAX_BYTES,
-        });
-    }
-    Ok(hex::encode(encoded_value))
+    encode_index_value_segment(table, column, branch, value).map(|_| ())
 }
 
 /// Format an ObjectId as compact hex (no dashes).
@@ -138,7 +177,7 @@ pub(super) fn index_entry_key(
         table,
         column,
         branch,
-        encode_index_value_hex(table, column, branch, value)?,
+        encode_index_value_segment(table, column, branch, value)?,
         format_uuid(row_id)
     ))
 }
@@ -149,22 +188,14 @@ pub(super) fn index_value_prefix(
     branch: &str,
     value: &Value,
 ) -> Result<String, StorageError> {
-    let encoded_value = encode_value(value);
-    if index_value_prefix_bytes(table, column, branch, encoded_value.len()) > INDEX_KEY_MAX_BYTES {
-        return Err(StorageError::IndexKeyTooLarge {
-            table: table.to_string(),
-            column: column.to_string(),
-            branch: branch.to_string(),
-            key_bytes: index_value_prefix_bytes(table, column, branch, encoded_value.len()),
-            max_key_bytes: INDEX_KEY_MAX_BYTES,
-        });
+    let value_segment = encode_index_value_segment(table, column, branch, value)?;
+    let key_bytes = index_value_prefix_bytes(table, column, branch, value_segment.len());
+    if key_bytes > INDEX_KEY_MAX_BYTES {
+        return Err(index_key_too_large_error(table, column, branch, key_bytes));
     }
     Ok(format!(
         "idx:{}:{}:{}:{}:",
-        table,
-        column,
-        branch,
-        hex::encode(encoded_value)
+        table, column, branch, value_segment
     ))
 }
 
@@ -186,21 +217,25 @@ pub(super) fn index_range_scan_bounds(
     // so both zeros are treated as the same point.
     let neg_zero = Value::Double(-0.0);
     let pos_zero = Value::Double(0.0);
+    let neg_zero_segment = encode_index_value_segment(table, column, branch, &neg_zero).ok()?;
+    let pos_zero_segment = encode_index_value_segment(table, column, branch, &pos_zero).ok()?;
 
     let start_key = match start {
         Bound::Included(v) if super::is_double_zero(v) => {
-            format!("{}{}", base_prefix, hex::encode(encode_value(&neg_zero)))
+            format!("{}{}", base_prefix, neg_zero_segment)
         }
         Bound::Excluded(v) if super::is_double_zero(v) => {
-            let encoded = hex::encode(encode_value(&pos_zero));
-            let mut key = format!("{}{}:", base_prefix, encoded);
+            let mut key = format!("{}{}:", base_prefix, pos_zero_segment);
             increment_string(&mut key);
             key
         }
-        Bound::Included(v) => format!("{}{}", base_prefix, hex::encode(encode_value(v))),
+        Bound::Included(v) => {
+            let segment = encode_index_value_segment(table, column, branch, v).ok()?;
+            format!("{}{}", base_prefix, segment)
+        }
         Bound::Excluded(v) => {
-            let encoded = hex::encode(encode_value(v));
-            let mut key = format!("{}{}:", base_prefix, encoded);
+            let segment = encode_index_value_segment(table, column, branch, v).ok()?;
+            let mut key = format!("{}{}:", base_prefix, segment);
             increment_string(&mut key);
             key
         }
@@ -209,21 +244,23 @@ pub(super) fn index_range_scan_bounds(
 
     let end_key = match end {
         Bound::Included(v) if super::is_double_zero(v) => {
-            let encoded = hex::encode(encode_value(&pos_zero));
-            let mut key = format!("{}{}:", base_prefix, encoded);
+            let mut key = format!("{}{}:", base_prefix, pos_zero_segment);
             increment_string(&mut key);
             key
         }
         Bound::Excluded(v) if super::is_double_zero(v) => {
-            format!("{}{}", base_prefix, hex::encode(encode_value(&neg_zero)))
+            format!("{}{}", base_prefix, neg_zero_segment)
         }
         Bound::Included(v) => {
-            let encoded = hex::encode(encode_value(v));
-            let mut key = format!("{}{}:", base_prefix, encoded);
+            let segment = encode_index_value_segment(table, column, branch, v).ok()?;
+            let mut key = format!("{}{}:", base_prefix, segment);
             increment_string(&mut key);
             key
         }
-        Bound::Excluded(v) => format!("{}{}", base_prefix, hex::encode(encode_value(v))),
+        Bound::Excluded(v) => {
+            let segment = encode_index_value_segment(table, column, branch, v).ok()?;
+            format!("{}{}", base_prefix, segment)
+        }
         Bound::Unbounded => {
             let mut end = base_prefix.clone();
             increment_string(&mut end);
@@ -235,7 +272,7 @@ pub(super) fn index_range_scan_bounds(
 }
 
 /// Parse a UUID from the last segment of an index key.
-/// Key format: `idx:{table}:{col}:{branch}:{hex_value}:{uuid_hex}`
+/// Key format: `idx:{table}:{col}:{branch}:{value_segment}:{uuid_hex}`
 pub(super) fn parse_uuid_from_index_key(key: &str) -> Option<ObjectId> {
     let uuid_hex = key.rsplit(':').next()?;
     let bytes = hex::decode(uuid_hex).ok()?;
@@ -263,4 +300,69 @@ pub(super) fn increment_string(s: &mut String) {
     let mut bytes = std::mem::take(s).into_bytes();
     increment_bytes(&mut bytes);
     *s = String::from_utf8(bytes).unwrap_or_default();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn short_text_index_segments_stay_inline() {
+        let segment =
+            encode_index_value_segment("todos", "title", "main", &Value::Text("hello".into()))
+                .expect("short text should fit inline");
+        assert_eq!(
+            segment,
+            hex::encode(encode_value(&Value::Text("hello".into())))
+        );
+        assert!(!segment.contains(OVERFLOW_INDEX_VALUE_MARKER));
+    }
+
+    #[test]
+    fn oversized_text_index_segments_preserve_real_prefix() {
+        let value = Value::Text("x".repeat(40_000));
+        let encoded_hex = hex::encode(encode_value(&value));
+        let segment = encode_index_value_segment("todos", "title", "main", &value)
+            .expect("oversized text should use overflow segment");
+        let (prefix, suffix) = segment
+            .split_once(OVERFLOW_INDEX_VALUE_MARKER)
+            .expect("overflow segment should include marker");
+        assert!(
+            !prefix.is_empty(),
+            "overflow segment should keep some real prefix"
+        );
+        assert_eq!(prefix, &encoded_hex[..prefix.len()]);
+        assert_eq!(
+            suffix.len(),
+            OVERFLOW_INDEX_VALUE_LEN_HEX_BYTES + OVERFLOW_INDEX_VALUE_HASH_HEX_BYTES
+        );
+    }
+
+    #[test]
+    fn oversized_text_segments_sort_by_prefix() {
+        let a =
+            encode_index_value_segment("todos", "title", "main", &Value::Text("a".repeat(40_000)))
+                .expect("a segment");
+        let b =
+            encode_index_value_segment("todos", "title", "main", &Value::Text("b".repeat(40_000)))
+                .expect("b segment");
+        assert!(a < b, "overflow segments should preserve prefix ordering");
+    }
+
+    #[test]
+    fn range_bounds_support_oversized_text_values() {
+        let min = Value::Text("a".repeat(40_000));
+        let max = Value::Text("b".repeat(40_000));
+        let bounds = index_range_scan_bounds(
+            "todos",
+            "title",
+            "main",
+            Bound::Included(&min),
+            Bound::Included(&max),
+        );
+        assert!(
+            bounds.is_some(),
+            "overflow text values should still produce range bounds"
+        );
+    }
 }

--- a/crates/jazz-tools/src/storage/mod.rs
+++ b/crates/jazz-tools/src/storage/mod.rs
@@ -589,16 +589,17 @@ pub(crate) fn encode_value(value: &Value) -> Vec<u8> {
         }
 
         Value::Array(_) => {
-            // Arrays not typically indexed; use hash for equality only
+            // Arrays use serialized bytes for equality semantics.
+            // The durable key codec hashes oversized segments if needed.
             let mut bytes = vec![0x07];
-            // Simple approach: serialize and hash. Not order-preserving.
             let json = serde_json::to_string(value).unwrap_or_default();
             bytes.extend_from_slice(json.as_bytes());
             bytes
         }
 
         Value::Row { .. } => {
-            // Rows not typically indexed; use hash for equality only
+            // Rows use serialized bytes for equality semantics.
+            // The durable key codec hashes oversized segments if needed.
             let mut bytes = vec![0x08];
             let json = serde_json::to_string(value).unwrap_or_default();
             bytes.extend_from_slice(json.as_bytes());

--- a/packages/jazz-tools/src/runtime/napi.integration.test.ts
+++ b/packages/jazz-tools/src/runtime/napi.integration.test.ts
@@ -592,7 +592,7 @@ async function createTempDir(prefix: string): Promise<string> {
 }
 
 describe("NAPI integration", () => {
-  it("surfaces oversized indexed persistent mutation errors to JS callers", async () => {
+  it("supports oversized indexed persistent mutations from JS callers", async () => {
     const { NapiRuntime } = await loadNapiModule();
     const dataPath = await createTempDir("jazz-napi-large-index-");
     const runtime = new NapiRuntime(
@@ -609,32 +609,45 @@ describe("NAPI integration", () => {
     };
 
     const oversizedTitle = "x".repeat(40_000);
+    const updatedOversizedTitle = "y".repeat(45_000);
     const queryJson = translateQuery(allTodosQuery._build(), TEST_SCHEMA);
 
     try {
-      expect(() =>
-        runtime.insert("todos", [
-          { type: "Text", value: oversizedTitle },
-          { type: "Boolean", value: false },
-        ]),
-      ).toThrow(/indexed value too large/i);
-
       const insertedRow = runtime.insert("todos", [
+        { type: "Text", value: oversizedTitle },
+        { type: "Boolean", value: false },
+      ]);
+
+      let rows = await runtime.query(queryJson);
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toMatchObject({ id: insertedRow.id });
+      expect(rows[0]?.values[0]).toEqual({ type: "Text", value: oversizedTitle });
+      expect(rows[0]?.values[1]).toEqual({ type: "Boolean", value: false });
+
+      const secondRow = runtime.insert("todos", [
         { type: "Text", value: "kept title" },
         { type: "Boolean", value: false },
       ]);
 
-      expect(() =>
-        runtime.update(insertedRow.id, {
-          title: { type: "Text", value: oversizedTitle },
-        }),
-      ).toThrow(/indexed value too large/i);
+      runtime.update(secondRow.id, {
+        title: { type: "Text", value: updatedOversizedTitle },
+      });
 
-      const rows = await runtime.query(queryJson);
-      expect(rows).toHaveLength(1);
-      expect(rows[0]).toMatchObject({ id: insertedRow.id });
-      expect(rows[0]?.values[0]).toEqual({ type: "Text", value: "kept title" });
-      expect(rows[0]?.values[1]).toEqual({ type: "Boolean", value: false });
+      rows = await runtime.query(queryJson);
+      expect(rows).toHaveLength(2);
+
+      const insertedOversized = rows.find((row) => row.id === insertedRow.id);
+      expect(insertedOversized).toBeDefined();
+      expect(insertedOversized?.values[0]).toEqual({ type: "Text", value: oversizedTitle });
+      expect(insertedOversized?.values[1]).toEqual({ type: "Boolean", value: false });
+
+      const updatedOversized = rows.find((row) => row.id === secondRow.id);
+      expect(updatedOversized).toBeDefined();
+      expect(updatedOversized?.values[0]).toEqual({
+        type: "Text",
+        value: updatedOversizedTitle,
+      });
+      expect(updatedOversized?.values[1]).toEqual({ type: "Boolean", value: false });
     } finally {
       runtime.close();
       await rm(dataPath, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- bound oversized durable index keys by keeping as much real value prefix as fits, then appending a length+blake3 trailer
- keep exact-match lookup behavior for large string/json/array(ref) values while preserving prefix-based ordering instead of falling back to pure hash ordering
- replace the old oversized-index failure regressions with successful fjall coverage for large string/json/array(ref) inserts and updates, and add codec-level tests for overflow segments

## Testing
- cargo test -q -p jazz-tools key_codec --features fjall
- cargo test -q -p jazz-tools fjall_oversized --features fjall