### PR TITLE
.never() permission

### DIFF
--- a/docs/content/docs/permissions.mdx
+++ b/docs/content/docs/permissions.mdx
@@ -29,7 +29,7 @@ Define policies in `schema/permissions.ts` for TypeScript DSL apps, or directly 
   </Tab>
 </Tabs>
 
-Apps that do not need user-scoped filtering can still define explicit allow-all policies (`policy.todos.allowRead.where({})` / `USING (TRUE)`).
+Apps that do not need user-scoped filtering can still define explicit allow-all policies (`policy.todos.allowRead.always()` or `policy.todos.allowRead.where({})` / `USING (TRUE)`).
 
 ## Simple Policies
 
@@ -42,6 +42,26 @@ Apps that do not need user-scoped filtering can still define explicit allow-all 
   <Tab value="SQL">
     <include cwd lang="sql">
       ../examples/docs/todo-server-ts/docs/permissions-snippets.sql#permissions-simple-sql
+    </include>
+  </Tab>
+</Tabs>
+
+## Explicitly Allow an Operation (`.always()`)
+
+Use `.always()` when an operation should always be permitted. It is equivalent to
+`.where({})` and compiles to a `TRUE` policy expression.
+
+This helper is available on read, insert, update, and delete policy builders.
+
+<Tabs groupId="jazz-schema-format" items={["TypeScript", "SQL"]} persist>
+  <Tab value="TypeScript">
+    <include cwd lang="ts">
+      ../examples/docs/todo-server-ts/src/permissions-snippets.ts#permissions-always-ts
+    </include>
+  </Tab>
+  <Tab value="SQL">
+    <include cwd lang="sql">
+      ../examples/docs/todo-server-ts/docs/permissions-snippets.sql#permissions-always-sql
     </include>
   </Tab>
 </Tabs>

--- a/docs/content/docs/permissions.mdx
+++ b/docs/content/docs/permissions.mdx
@@ -46,6 +46,26 @@ Apps that do not need user-scoped filtering can still define explicit allow-all 
   </Tab>
 </Tabs>
 
+## Explicitly Deny an Operation (`.never()`)
+
+Use `.never()` when an operation should be impossible. It is equivalent to
+`.where(anyOf([]))` and compiles to a `FALSE` policy expression.
+
+This helper is available on read, insert, update, and delete policy builders.
+
+<Tabs groupId="jazz-schema-format" items={["TypeScript", "SQL"]} persist>
+  <Tab value="TypeScript">
+    <include cwd lang="ts">
+      ../examples/docs/todo-server-ts/src/permissions-snippets.ts#permissions-never-ts
+    </include>
+  </Tab>
+  <Tab value="SQL">
+    <include cwd lang="sql">
+      ../examples/docs/todo-server-ts/docs/permissions-snippets.sql#permissions-never-sql
+    </include>
+  </Tab>
+</Tabs>
+
 ## Combining Conditions (`allOf` / `anyOf`)
 
 <Tabs groupId="jazz-environment" items={["TypeScript", "Rust"]} persist>

--- a/examples/docs/todo-server-ts/docs/permissions-snippets.sql
+++ b/examples/docs/todo-server-ts/docs/permissions-snippets.sql
@@ -5,6 +5,13 @@ CREATE POLICY todos_update_policy ON todos FOR UPDATE USING ((owner_id = @sessio
 CREATE POLICY todos_delete_policy ON todos FOR DELETE USING (owner_id = @session.user_id);
 -- #endregion permissions-simple-sql
 
+-- #region permissions-always-sql
+CREATE POLICY todos_select_policy ON todos FOR SELECT USING (TRUE);
+CREATE POLICY todos_insert_policy ON todos FOR INSERT WITH CHECK (TRUE);
+CREATE POLICY todos_update_policy ON todos FOR UPDATE USING (TRUE) WITH CHECK (TRUE);
+CREATE POLICY todos_delete_policy ON todos FOR DELETE USING (TRUE);
+-- #endregion permissions-always-sql
+
 -- #region permissions-never-sql
 CREATE POLICY todos_select_policy ON todos FOR SELECT USING (FALSE);
 CREATE POLICY todos_insert_policy ON todos FOR INSERT WITH CHECK (FALSE);

--- a/examples/docs/todo-server-ts/docs/permissions-snippets.sql
+++ b/examples/docs/todo-server-ts/docs/permissions-snippets.sql
@@ -5,6 +5,13 @@ CREATE POLICY todos_update_policy ON todos FOR UPDATE USING ((owner_id = @sessio
 CREATE POLICY todos_delete_policy ON todos FOR DELETE USING (owner_id = @session.user_id);
 -- #endregion permissions-simple-sql
 
+-- #region permissions-never-sql
+CREATE POLICY todos_select_policy ON todos FOR SELECT USING (FALSE);
+CREATE POLICY todos_insert_policy ON todos FOR INSERT WITH CHECK (FALSE);
+CREATE POLICY todos_update_policy ON todos FOR UPDATE USING (FALSE) WITH CHECK (FALSE);
+CREATE POLICY todos_delete_policy ON todos FOR DELETE USING (FALSE);
+-- #endregion permissions-never-sql
+
 -- #region permissions-inherits-sql
 CREATE POLICY todos_select_policy ON todos FOR SELECT USING ((done = FALSE) OR (INHERITS SELECT VIA project));
 CREATE POLICY todos_update_policy ON todos FOR UPDATE USING ((INHERITS UPDATE VIA project) AND (done = FALSE)) WITH CHECK (INHERITS UPDATE VIA project);

--- a/examples/docs/todo-server-ts/src/permissions-snippets.ts
+++ b/examples/docs/todo-server-ts/src/permissions-snippets.ts
@@ -33,6 +33,15 @@ definePermissions(app, ({ policy, allOf, session }) => {
 });
 // #endregion permissions-simple-ts
 
+// #region permissions-always-ts
+definePermissions(app, ({ policy }) => {
+  policy.todos.allowRead.always();
+  policy.todos.allowInsert.always();
+  policy.todos.allowUpdate.always();
+  policy.todos.allowDelete.always();
+});
+// #endregion permissions-always-ts
+
 // #region permissions-never-ts
 definePermissions(app, ({ policy }) => {
   policy.todos.allowRead.never();

--- a/examples/docs/todo-server-ts/src/permissions-snippets.ts
+++ b/examples/docs/todo-server-ts/src/permissions-snippets.ts
@@ -33,6 +33,15 @@ definePermissions(app, ({ policy, allOf, session }) => {
 });
 // #endregion permissions-simple-ts
 
+// #region permissions-never-ts
+definePermissions(app, ({ policy }) => {
+  policy.todos.allowRead.never();
+  policy.todos.allowInsert.never();
+  policy.todos.allowUpdate.never();
+  policy.todos.allowDelete.never();
+});
+// #endregion permissions-never-ts
+
 // #region permissions-allowed-to-ts
 definePermissions(app, ({ policy, anyOf, allOf, allowedTo }) => {
   policy.todos.allowRead.where(anyOf([{ done: false }, allowedTo.read("project")]));

--- a/packages/jazz-tools/src/permissions/index.test.ts
+++ b/packages/jazz-tools/src/permissions/index.test.ts
@@ -498,6 +498,21 @@ describe("permissions DSL", () => {
     expect(compiled.todos.delete?.using).toEqual({ type: "False" });
   });
 
+  it("supports always() across read/insert/update/delete policies", () => {
+    const compiled = definePermissions(app, ({ policy }) => [
+      policy.todos.allowRead.always(),
+      policy.todos.allowInsert.always(),
+      policy.todos.allowUpdate.always(),
+      policy.todos.allowDelete.always(),
+    ]);
+
+    expect(compiled.todos.select?.using).toEqual({ type: "True" });
+    expect(compiled.todos.insert?.with_check).toEqual({ type: "True" });
+    expect(compiled.todos.update?.using).toEqual({ type: "True" });
+    expect(compiled.todos.update?.with_check).toEqual({ type: "True" });
+    expect(compiled.todos.delete?.using).toEqual({ type: "True" });
+  });
+
   it("supports allowedTo.readReferencing helper", () => {
     const compiled = definePermissions(app, ({ policy, allowedTo }) => [
       policy.projects.allowRead.where(allowedTo.readReferencing(policy.todos, "projectId")),

--- a/packages/jazz-tools/src/permissions/index.test.ts
+++ b/packages/jazz-tools/src/permissions/index.test.ts
@@ -483,6 +483,21 @@ describe("permissions DSL", () => {
     });
   });
 
+  it("supports never() across read/insert/update/delete policies", () => {
+    const compiled = definePermissions(app, ({ policy }) => [
+      policy.todos.allowRead.never(),
+      policy.todos.allowInsert.never(),
+      policy.todos.allowUpdate.never(),
+      policy.todos.allowDelete.never(),
+    ]);
+
+    expect(compiled.todos.select?.using).toEqual({ type: "False" });
+    expect(compiled.todos.insert?.with_check).toEqual({ type: "False" });
+    expect(compiled.todos.update?.using).toEqual({ type: "False" });
+    expect(compiled.todos.update?.with_check).toEqual({ type: "False" });
+    expect(compiled.todos.delete?.using).toEqual({ type: "False" });
+  });
+
   it("supports allowedTo.readReferencing helper", () => {
     const compiled = definePermissions(app, ({ policy, allowedTo }) => [
       policy.projects.allowRead.where(allowedTo.readReferencing(policy.todos, "projectId")),

--- a/packages/jazz-tools/src/permissions/index.ts
+++ b/packages/jazz-tools/src/permissions/index.ts
@@ -423,6 +423,7 @@ interface ActionBuilder<WhereInput, Row> {
   where(
     input: Condition | PermissionWhereInput<WhereInput> | ((row: RowContext<Row>) => unknown),
   ): Rule;
+  always(): Rule;
   never(): Rule;
 }
 
@@ -501,6 +502,10 @@ class UpdateRuleBuilder<WhereInput, Row> {
 
   never(): Rule {
     return this.where(neverCondition());
+  }
+
+  always(): Rule {
+    return this.where(alwaysCondition());
   }
 
   whereOld(
@@ -634,15 +639,18 @@ function buildTablePolicyBuilder(
   };
   const read: ActionBuilder<unknown, unknown> = {
     where: (input) => registerRule({ table, action: "read", using: resolveWhereInput(input) }),
+    always: () => read.where(alwaysCondition()),
     never: () => read.where(neverCondition()),
   };
   const insert: ActionBuilder<unknown, unknown> = {
     where: (input) =>
       registerRule({ table, action: "insert", withCheck: resolveWhereInput(input) }),
+    always: () => insert.where(alwaysCondition()),
     never: () => insert.where(neverCondition()),
   };
   const del: ActionBuilder<unknown, unknown> = {
     where: (input) => registerRule({ table, action: "delete", using: resolveWhereInput(input) }),
+    always: () => del.where(alwaysCondition()),
     never: () => del.where(neverCondition()),
   };
   const updateFactory = (): UpdateRuleBuilder<unknown, unknown> =>
@@ -1441,6 +1449,10 @@ export function anyOf(conditions: readonly unknown[]): Condition {
 
 export function allOf(conditions: readonly unknown[]): Condition {
   return compoundCondition("And", conditions);
+}
+
+function alwaysCondition(): Condition {
+  return allOf([]);
 }
 
 function neverCondition(): Condition {

--- a/packages/jazz-tools/src/permissions/index.ts
+++ b/packages/jazz-tools/src/permissions/index.ts
@@ -423,6 +423,7 @@ interface ActionBuilder<WhereInput, Row> {
   where(
     input: Condition | PermissionWhereInput<WhereInput> | ((row: RowContext<Row>) => unknown),
   ): Rule;
+  never(): Rule;
 }
 
 interface TableRelationBuilder<WhereInput, Row> extends TableJoinTarget, PermissionRelation {
@@ -496,6 +497,10 @@ class UpdateRuleBuilder<WhereInput, Row> {
     };
     this.registerRule?.(rule);
     return rule;
+  }
+
+  never(): Rule {
+    return this.where(neverCondition());
   }
 
   whereOld(
@@ -629,13 +634,16 @@ function buildTablePolicyBuilder(
   };
   const read: ActionBuilder<unknown, unknown> = {
     where: (input) => registerRule({ table, action: "read", using: resolveWhereInput(input) }),
+    never: () => read.where(neverCondition()),
   };
   const insert: ActionBuilder<unknown, unknown> = {
     where: (input) =>
       registerRule({ table, action: "insert", withCheck: resolveWhereInput(input) }),
+    never: () => insert.where(neverCondition()),
   };
   const del: ActionBuilder<unknown, unknown> = {
     where: (input) => registerRule({ table, action: "delete", using: resolveWhereInput(input) }),
+    never: () => del.where(neverCondition()),
   };
   const updateFactory = (): UpdateRuleBuilder<unknown, unknown> =>
     new UpdateRuleBuilder(table, collectRule);
@@ -1433,6 +1441,10 @@ export function anyOf(conditions: readonly unknown[]): Condition {
 
 export function allOf(conditions: readonly unknown[]): Condition {
   return compoundCondition("And", conditions);
+}
+
+function neverCondition(): Condition {
+  return anyOf([]);
 }
 
 function compoundCondition(op: "And" | "Or", inputs: readonly unknown[]): CompoundCondition {

--- a/packages/jazz-tools/src/permissions/type-inference.test.ts
+++ b/packages/jazz-tools/src/permissions/type-inference.test.ts
@@ -216,6 +216,15 @@ describe("permissions type inference", () => {
     ]);
   });
 
+  it("exposes always() on read/insert/update/delete builders", () => {
+    definePermissions(app, ({ policy }) => [
+      policy.todos.allowRead.always(),
+      policy.todos.allowInsert.always(),
+      policy.todos.allowUpdate.always(),
+      policy.todos.allowDelete.always(),
+    ]);
+  });
+
   it("rejects invalid table/column usage at compile time where possible", () => {
     definePermissions(app, ({ policy, allowedTo }) => [
       policy.todos.allowRead.where({ done: true }),

--- a/packages/jazz-tools/src/permissions/type-inference.test.ts
+++ b/packages/jazz-tools/src/permissions/type-inference.test.ts
@@ -207,6 +207,15 @@ describe("permissions type inference", () => {
     });
   });
 
+  it("exposes never() on read/insert/update/delete builders", () => {
+    definePermissions(app, ({ policy }) => [
+      policy.todos.allowRead.never(),
+      policy.todos.allowInsert.never(),
+      policy.todos.allowUpdate.never(),
+      policy.todos.allowDelete.never(),
+    ]);
+  });
+
   it("rejects invalid table/column usage at compile time where possible", () => {
     definePermissions(app, ({ policy, allowedTo }) => [
       policy.todos.allowRead.where({ done: true }),


### PR DESCRIPTION
**Summary**

Adds a `.never()` helper to the TypeScript permissions DSL for explicitly denying operations.

**What changed**

- Added `.never()` for read, insert, update, and delete permission builders
- Made it equivalent to `.where(anyOf([]))`, compiling to a `FALSE` policy
- Updated the permissions docs with TypeScript and SQL examples
- Added behavior and type-inference tests for the new API