### PR TITLE
feat: add TestingServer rust module

### DIFF
--- a/crates/jazz-tools/Cargo.toml
+++ b/crates/jazz-tools/Cargo.toml
@@ -37,6 +37,7 @@ cli = [
   "dep:bytes",
   "dep:reqwest",
 ]
+test-utils = ["cli", "client"]
 otel = [
   "cli",
   "dep:opentelemetry",

--- a/crates/jazz-tools/src/commands/server.rs
+++ b/crates/jazz-tools/src/commands/server.rs
@@ -1,324 +1,42 @@
 //! Server command implementation.
 
-use std::collections::HashMap;
 use std::net::SocketAddr;
-use std::path::Path;
-use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
 
-use jazz_tools::query_manager::query::QueryBuilder;
-use jazz_tools::query_manager::types::{ColumnType, SchemaBuilder, TableSchema, Value};
-use jazz_tools::runtime_core::ReadDurabilityOptions;
-use jazz_tools::runtime_tokio::TokioRuntime;
-use jazz_tools::schema_manager::{AppId, SchemaManager, rehydrate_schema_manager_from_manifest};
-use jazz_tools::storage::FjallStorage;
-use jazz_tools::sync_manager::{ClientId, Destination, DurabilityTier, SyncManager, SyncPayload};
-use jsonwebtoken::jwk::JwkSet;
-use tokio::sync::{RwLock, broadcast};
+use jazz_tools::middleware::AuthConfig;
+use jazz_tools::schema_manager::AppId;
+use jazz_tools::server::ServerBuilder;
 use tracing::info;
-
-use crate::middleware::AuthConfig;
-use crate::routes;
-
-const EXTERNAL_IDENTITIES_TABLE: &str = "external_identities";
-
-#[derive(Debug, Clone)]
-pub struct ExternalIdentityRow {
-    pub issuer: String,
-    pub subject: String,
-    pub principal_id: String,
-}
-
-/// Persistent storage for external identity -> principal mappings.
-pub struct ExternalIdentityStore {
-    runtime: TokioRuntime<FjallStorage>,
-}
-
-impl ExternalIdentityStore {
-    pub fn new(data_dir: &str) -> Result<Self, String> {
-        let meta_dir = Path::new(data_dir).join("meta");
-        std::fs::create_dir_all(&meta_dir)
-            .map_err(|e| format!("failed to create meta dir '{}': {e}", meta_dir.display()))?;
-
-        let schema = SchemaBuilder::new()
-            .table(
-                TableSchema::builder(EXTERNAL_IDENTITIES_TABLE)
-                    .column("app_id", ColumnType::Uuid)
-                    .column("issuer", ColumnType::Text)
-                    .column("subject", ColumnType::Text)
-                    .column("principal_id", ColumnType::Text)
-                    .column("created_at", ColumnType::Timestamp)
-                    .column("updated_at", ColumnType::Timestamp),
-            )
-            .build();
-
-        let sync_manager = SyncManager::new()
-            .with_durability_tiers([DurabilityTier::EdgeServer, DurabilityTier::GlobalServer]);
-        let schema_manager = SchemaManager::new(
-            sync_manager,
-            schema,
-            AppId::from_name("jazz-tools-meta"),
-            "meta",
-            "main",
-        )
-        .map_err(|e| format!("failed to initialize meta schema manager: {e:?}"))?;
-
-        let db_path = meta_dir.join("jazz.fjall");
-        let storage = FjallStorage::open(&db_path, 64 * 1024 * 1024)
-            .map_err(|e| format!("failed to open meta storage '{}': {e:?}", db_path.display()))?;
-
-        let runtime = TokioRuntime::new(schema_manager, storage, |_entry| {});
-
-        Ok(Self { runtime })
-    }
-
-    pub async fn list_external_identities(
-        &self,
-        app_id: AppId,
-    ) -> Result<Vec<ExternalIdentityRow>, String> {
-        let query = QueryBuilder::new(EXTERNAL_IDENTITIES_TABLE)
-            .filter_eq("app_id", Value::Uuid(app_id.as_object_id()))
-            .build();
-
-        let future = self
-            .runtime
-            .query(query, None, ReadDurabilityOptions::default())
-            .map_err(|e| format!("external identity query error: {e}"))?;
-        let rows = future
-            .await
-            .map_err(|e| format!("external identity query await error: {e}"))?;
-
-        rows.into_iter()
-            .map(|(_, values)| Self::decode_external_identity_row(&values))
-            .collect()
-    }
-
-    pub async fn get_external_identity(
-        &self,
-        app_id: AppId,
-        issuer: &str,
-        subject: &str,
-    ) -> Result<Option<ExternalIdentityRow>, String> {
-        let query = QueryBuilder::new(EXTERNAL_IDENTITIES_TABLE)
-            .filter_eq("app_id", Value::Uuid(app_id.as_object_id()))
-            .filter_eq("issuer", Value::Text(issuer.to_string()))
-            .filter_eq("subject", Value::Text(subject.to_string()))
-            .build();
-
-        let future = self
-            .runtime
-            .query(query, None, ReadDurabilityOptions::default())
-            .map_err(|e| format!("external identity query error: {e}"))?;
-        let mut rows = future
-            .await
-            .map_err(|e| format!("external identity query await error: {e}"))?;
-
-        if let Some((_object_id, values)) = rows.pop() {
-            Ok(Some(Self::decode_external_identity_row(&values)?))
-        } else {
-            Ok(None)
-        }
-    }
-
-    pub async fn create_external_identity(
-        &self,
-        app_id: AppId,
-        issuer: &str,
-        subject: &str,
-        principal_id: &str,
-    ) -> Result<(), String> {
-        let now = now_timestamp_us();
-        let values = vec![
-            Value::Uuid(app_id.as_object_id()),
-            Value::Text(issuer.to_string()),
-            Value::Text(subject.to_string()),
-            Value::Text(principal_id.to_string()),
-            Value::Timestamp(now),
-            Value::Timestamp(now),
-        ];
-
-        self.runtime
-            .insert(EXTERNAL_IDENTITIES_TABLE, values, None)
-            .map_err(|e| format!("failed to insert external identity: {e}"))?;
-        Ok(())
-    }
-
-    fn decode_external_identity_row(values: &[Value]) -> Result<ExternalIdentityRow, String> {
-        if values.len() < 6 {
-            return Err(format!(
-                "external identity row has invalid column count: expected at least 6, got {}",
-                values.len()
-            ));
-        }
-
-        let issuer = match &values[1] {
-            Value::Text(s) => s.clone(),
-            other => {
-                return Err(format!(
-                    "external identity field issuer expected text, got {other:?}"
-                ));
-            }
-        };
-
-        let subject = match &values[2] {
-            Value::Text(s) => s.clone(),
-            other => {
-                return Err(format!(
-                    "external identity field subject expected text, got {other:?}"
-                ));
-            }
-        };
-
-        let principal_id = match &values[3] {
-            Value::Text(s) => s.clone(),
-            other => {
-                return Err(format!(
-                    "external identity field principal_id expected text, got {other:?}"
-                ));
-            }
-        };
-
-        Ok(ExternalIdentityRow {
-            issuer,
-            subject,
-            principal_id,
-        })
-    }
-}
-
-/// Server state shared across request handlers.
-pub struct ServerState {
-    pub runtime: TokioRuntime<FjallStorage>,
-    #[allow(dead_code)]
-    pub app_id: AppId,
-    pub connections: RwLock<HashMap<u64, ConnectionState>>,
-    pub next_connection_id: std::sync::atomic::AtomicU64,
-    /// Broadcast channel for sending sync payloads to SSE clients
-    pub sync_broadcast: broadcast::Sender<(ClientId, SyncPayload)>,
-    /// Authentication configuration
-    pub auth_config: AuthConfig,
-    /// Persistent external identity mapping store.
-    pub external_identity_store: Arc<ExternalIdentityStore>,
-    /// In-memory cache: (issuer, subject) -> principal_id.
-    pub external_identities: RwLock<HashMap<(String, String), String>>,
-}
-
-/// State for a single SSE connection.
-pub struct ConnectionState {
-    pub _client_id: ClientId,
-}
 
 /// Run the Jazz server.
 pub async fn run(
     app_id_str: &str,
     port: u16,
     data_dir: &str,
-    mut auth_config: AuthConfig,
+    in_memory: bool,
+    auth_config: AuthConfig,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    // Parse app ID
     let app_id = AppId::from_string(app_id_str)?;
 
     info!("Starting Jazz server for app: {}", app_id);
-    info!("Data directory: {}", data_dir);
-
-    // Create data directory if it doesn't exist
-    std::fs::create_dir_all(data_dir)?;
-
-    // Create managers (server mode - no fixed current schema)
-    let sync_manager = SyncManager::new()
-        .with_durability_tiers([DurabilityTier::EdgeServer, DurabilityTier::GlobalServer]);
-    let mut schema_manager = SchemaManager::new_server(sync_manager, app_id, "prod");
-
-    // Create broadcast channel for SSE updates
-    let (sync_tx, _) = broadcast::channel::<(ClientId, SyncPayload)>(256);
-    let sync_tx_clone = sync_tx.clone();
-
-    // Create persistent storage
-    let db_path = format!("{}/jazz.fjall", data_dir);
-    let storage = FjallStorage::open(&db_path, 64 * 1024 * 1024)
-        .map_err(|e| format!("Failed to open storage: {:?}", e))?;
-
-    rehydrate_schema_manager_from_manifest(&mut schema_manager, &storage, app_id)
-        .map_err(|e| format!("failed to rehydrate schema manager: {e}"))?;
-
-    // Create runtime with sync callback that routes to SSE clients
-    let runtime = TokioRuntime::new(schema_manager, storage, move |entry| {
-        // Route to appropriate client via broadcast
-        if let Destination::Client(client_id) = entry.destination {
-            eprintln!(
-                "DEBUG [server sync_cb]: Broadcasting {} to client {}",
-                entry.payload.variant_name(),
-                client_id
-            );
-            let _ = sync_tx_clone.send((client_id, entry.payload));
-        }
-        // Server destinations would be handled differently (e.g., HTTP push)
-    });
-
-    // Preload JWKS when configured.
-    if let Some(jwks_url) = &auth_config.jwks_url {
-        let jwks = reqwest::get(jwks_url).await?.json::<JwkSet>().await?;
-        auth_config.jwks_set = Some(jwks);
-    }
-
-    // Log auth configuration (without revealing secrets)
-    if auth_config.is_configured() {
-        info!(
-            "Auth configured: anonymous={}, demo={}, jwks={}, backend={}, admin={}",
-            auth_config.allow_anonymous,
-            auth_config.allow_demo,
-            auth_config.jwks_url.is_some(),
-            auth_config.backend_secret.is_some(),
-            auth_config.admin_secret.is_some()
-        );
+    if in_memory {
+        info!("Storage mode: in-memory");
     } else {
-        info!(
-            "Auth configured: anonymous={}, demo={}, jwks=false, backend=false, admin=false",
-            auth_config.allow_anonymous, auth_config.allow_demo
-        );
+        info!("Data directory: {}", data_dir);
     }
 
-    let external_identity_store = Arc::new(
-        ExternalIdentityStore::new(data_dir)
-            .map_err(|e| format!("failed to initialize external identity store: {e}"))?,
-    );
-    let external_identity_rows = external_identity_store
-        .list_external_identities(app_id)
-        .await
-        .map_err(|e| format!("failed to load external identities: {e}"))?;
-    let mut external_identities = HashMap::with_capacity(external_identity_rows.len());
-    for row in external_identity_rows {
-        external_identities.insert((row.issuer, row.subject), row.principal_id);
+    let builder = ServerBuilder::new(app_id).with_auth_config(auth_config);
+    let built = if in_memory {
+        builder.with_in_memory_storage().build().await
+    } else {
+        builder.with_persistent_storage(data_dir).build().await
     }
+    .map_err(|e| format!("failed to build server: {e}"))?;
 
-    // Build server state
-    let state = Arc::new(ServerState {
-        runtime,
-        app_id,
-        connections: RwLock::new(HashMap::new()),
-        next_connection_id: std::sync::atomic::AtomicU64::new(1),
-        sync_broadcast: sync_tx,
-        auth_config,
-        external_identity_store,
-        external_identities: RwLock::new(external_identities),
-    });
-
-    // Build router
-    let app = routes::create_router(state);
-
-    // Start server
     let addr = SocketAddr::from(([0, 0, 0, 0], port));
     info!("Listening on http://{}", addr);
 
     let listener = tokio::net::TcpListener::bind(addr).await?;
-    axum::serve(listener, app).await?;
+    axum::serve(listener, built.app).await?;
 
     Ok(())
-}
-
-fn now_timestamp_us() -> u64 {
-    match SystemTime::now().duration_since(UNIX_EPOCH) {
-        Ok(duration) => duration.as_micros().min(u128::from(u64::MAX)) as u64,
-        Err(_) => 0,
-    }
 }

--- a/crates/jazz-tools/src/lib.rs
+++ b/crates/jazz-tools/src/lib.rs
@@ -1,11 +1,17 @@
 pub mod binding_support;
 pub mod commit;
 pub mod metadata;
+#[cfg(feature = "cli")]
+pub mod middleware;
 pub mod object;
 pub mod object_manager;
 pub mod query_manager;
+#[cfg(feature = "cli")]
+pub mod routes;
 pub mod runtime_core;
 pub mod schema_manager;
+#[cfg(feature = "cli")]
+pub mod server;
 pub mod storage;
 pub mod sync_manager;
 pub mod wire_types;

--- a/crates/jazz-tools/src/main.rs
+++ b/crates/jazz-tools/src/main.rs
@@ -8,13 +8,11 @@
 //! ```
 
 mod commands;
-mod middleware;
 #[cfg(feature = "otel")]
 mod otel;
-mod routes;
 
 use clap::{Parser, Subcommand};
-use middleware::AuthConfig;
+use jazz_tools::middleware::AuthConfig;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum NodeEnvMode {
@@ -94,7 +92,7 @@ enum Commands {
         #[arg(short, long, default_value = "./data")]
         data_dir: String,
 
-        /// Use a temporary directory for storage (ephemeral, created on the fly)
+        /// Use in-memory storage instead of Fjall-backed files.
         #[arg(long)]
         in_memory: bool,
 
@@ -186,17 +184,6 @@ async fn main() {
             backend_secret,
             admin_secret,
         } => {
-            let data_dir = if in_memory {
-                let tmp =
-                    std::env::temp_dir().join(format!("jazz-server-{}", uuid::Uuid::new_v4()));
-                std::fs::create_dir_all(&tmp).expect("failed to create temp dir for --in-memory");
-                tmp.into_os_string()
-                    .into_string()
-                    .expect("temp path is valid UTF-8")
-            } else {
-                data_dir
-            };
-
             let node_env_mode = resolve_node_env_mode();
             let allow_anonymous = match node_env_mode {
                 NodeEnvMode::Production => allow_anonymous,
@@ -215,7 +202,9 @@ async fn main() {
                 backend_secret,
                 admin_secret,
             };
-            if let Err(e) = commands::server::run(&app_id, port, &data_dir, auth_config).await {
+            if let Err(e) =
+                commands::server::run(&app_id, port, &data_dir, in_memory, auth_config).await
+            {
                 eprintln!("Server error: {}", e);
                 shutdown_tracing();
                 std::process::exit(1);

--- a/crates/jazz-tools/src/middleware/auth.rs
+++ b/crates/jazz-tools/src/middleware/auth.rs
@@ -26,8 +26,6 @@ use axum::{
     http::{HeaderMap, StatusCode, header::AUTHORIZATION, request::Parts},
 };
 use base64::Engine;
-use jazz_tools::query_manager::session::Session;
-use jazz_tools::schema_manager::AppId;
 use jsonwebtoken::{
     Algorithm, DecodingKey, Validation, decode, decode_header,
     jwk::{Jwk, JwkSet, KeyAlgorithm},
@@ -35,7 +33,9 @@ use jsonwebtoken::{
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
-use crate::commands::server::ServerState;
+use crate::query_manager::session::Session;
+use crate::schema_manager::AppId;
+use crate::server::ServerState;
 
 const LOCAL_MODE_HEADER: &str = "X-Jazz-Local-Mode";
 const LOCAL_TOKEN_HEADER: &str = "X-Jazz-Local-Token";

--- a/crates/jazz-tools/src/routes.rs
+++ b/crates/jazz-tools/src/routes.rs
@@ -11,22 +11,22 @@ use axum::{
     routing::{get, post},
 };
 use bytes::Bytes;
-use jazz_tools::jazz_transport::{
-    ConnectionId, ErrorResponse, ServerEvent, SyncBatchRequest, SyncBatchResponse,
-    SyncPayloadResult,
-};
-use jazz_tools::sync_manager::ClientId;
 use serde::{Deserialize, Serialize};
 use tower_http::cors::CorsLayer;
 use tower_http::trace::TraceLayer;
 
-use crate::commands::server::{ConnectionState, ServerState};
+use crate::jazz_transport::{
+    ConnectionId, ErrorResponse, ServerEvent, SyncBatchRequest, SyncBatchResponse,
+    SyncPayloadResult,
+};
 use crate::middleware::auth::{
     derive_local_principal_id, extract_session, parse_local_auth_headers, validate_admin_secret,
     validate_backend_secret, validate_jwt_identity,
 };
-use jazz_tools::query_manager::types::SchemaHash;
-use jazz_tools::schema_manager::AppId;
+use crate::query_manager::types::SchemaHash;
+use crate::schema_manager::AppId;
+use crate::server::{ConnectionState, ServerState};
+use crate::sync_manager::ClientId;
 
 /// Create the router with all routes.
 pub fn create_router(state: Arc<ServerState>) -> Router {
@@ -74,7 +74,7 @@ struct AdminSubscriptionIntrospectionParams {
 struct AdminSubscriptionIntrospectionResponse {
     app_id: String,
     generated_at: u64,
-    queries: Vec<jazz_tools::query_manager::manager::ServerSubscriptionTelemetryGroup>,
+    queries: Vec<crate::query_manager::manager::ServerSubscriptionTelemetryGroup>,
 }
 
 #[derive(Debug, Serialize)]
@@ -269,7 +269,7 @@ async fn sync_handler(
     headers: HeaderMap,
     Json(request): Json<SyncBatchRequest>,
 ) -> impl IntoResponse {
-    use jazz_tools::sync_manager::{InboxEntry, Source};
+    use crate::sync_manager::{InboxEntry, Source};
 
     tracing::debug!(
         client_id = %request.client_id,
@@ -792,28 +792,21 @@ async fn health_handler() -> impl IntoResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::HashMap;
 
-    use axum::body;
-    use axum::routing::get;
-    use jazz_tools::query_manager::query::QueryBuilder;
-    use jazz_tools::query_manager::types::{
+    use crate::query_manager::query::QueryBuilder;
+    use crate::query_manager::types::{
         ColumnType, SchemaBuilder, TableSchema, Value as QueryValue,
     };
-    use jazz_tools::runtime_tokio::TokioRuntime;
-    use jazz_tools::schema_manager::{AppId, SchemaManager};
-    use jazz_tools::storage::FjallStorage;
-    use jazz_tools::sync_manager::{
-        ClientId, DurabilityTier, InboxEntry, QueryId, QueryPropagation, Source, SyncManager,
-        SyncPayload,
+    use crate::sync_manager::{
+        ClientId, InboxEntry, QueryId, QueryPropagation, Source, SyncPayload,
     };
+    use axum::body;
+    use axum::routing::get;
     use serde_json::Value;
-    use tempfile::TempDir;
-    use tokio::sync::{RwLock, broadcast};
     use tower::ServiceExt;
 
-    use crate::commands::server::{ExternalIdentityStore, ServerState};
     use crate::middleware::AuthConfig;
+    use crate::server::{ServerBuilder, ServerState};
 
     fn test_auth_config() -> AuthConfig {
         AuthConfig {
@@ -829,17 +822,7 @@ mod tests {
     /// Spin up the full router backed by an in-process runtime.
     /// `backend_secret` is wired into `AuthConfig` so tests can authenticate
     /// via the `X-Jazz-Backend-Secret` header without needing JWT setup.
-    fn make_sync_test_app(backend_secret: &str) -> (axum::Router, TempDir) {
-        let data_dir = TempDir::new().expect("temp dir");
-        let db_path = data_dir.path().join("groove.fjall");
-        let storage = FjallStorage::open(&db_path, 64 * 1024 * 1024).expect("open test storage");
-
-        let sync_manager = SyncManager::new()
-            .with_durability_tiers([DurabilityTier::EdgeServer, DurabilityTier::GlobalServer]);
-        let schema_manager =
-            SchemaManager::new_server(sync_manager, AppId::from_name("test-app"), "prod");
-        let runtime = TokioRuntime::new(schema_manager, storage, |_entry| {});
-
+    async fn make_sync_test_app(backend_secret: &str) -> axum::Router {
         let auth_config = AuthConfig {
             backend_secret: Some(backend_secret.to_string()),
             admin_secret: None,
@@ -849,59 +832,26 @@ mod tests {
             jwks_set: None,
         };
 
-        let (sync_tx, _) = broadcast::channel::<(ClientId, SyncPayload)>(16);
-
-        let state = Arc::new(ServerState {
-            runtime,
-            app_id: AppId::from_name("test-app"),
-            connections: RwLock::new(HashMap::new()),
-            next_connection_id: std::sync::atomic::AtomicU64::new(1),
-            sync_broadcast: sync_tx,
-            auth_config,
-            external_identity_store: Arc::new(
-                ExternalIdentityStore::new(data_dir.path().to_str().unwrap()).unwrap(),
-            ),
-            external_identities: RwLock::new(HashMap::new()),
-        });
-
-        (create_router(state), data_dir)
+        ServerBuilder::new(AppId::from_name("test-app"))
+            .with_auth_config(auth_config)
+            .with_in_memory_storage()
+            .build()
+            .await
+            .expect("build sync test app")
+            .app
     }
 
-    fn make_state_with_schema(
-        schema: jazz_tools::query_manager::types::Schema,
-    ) -> (TempDir, Arc<ServerState>) {
-        let data_dir = TempDir::new().expect("temp dir");
-        let db_path = data_dir.path().join("groove.fjall");
-        let storage = FjallStorage::open(&db_path, 64 * 1024 * 1024).expect("open test storage");
-
-        let sync_manager = SyncManager::new()
-            .with_durability_tiers([DurabilityTier::EdgeServer, DurabilityTier::GlobalServer]);
-        let schema_manager = SchemaManager::new(
-            sync_manager,
-            schema,
-            AppId::from_name("test-app"),
-            "prod",
-            "main",
-        )
-        .expect("schema manager");
-        let runtime = TokioRuntime::new(schema_manager, storage, |_entry| {});
-
-        let (sync_tx, _) = broadcast::channel::<(ClientId, SyncPayload)>(16);
-
-        let state = Arc::new(ServerState {
-            runtime,
-            app_id: AppId::from_name("test-app"),
-            connections: RwLock::new(HashMap::new()),
-            next_connection_id: std::sync::atomic::AtomicU64::new(1),
-            sync_broadcast: sync_tx,
-            auth_config: test_auth_config(),
-            external_identity_store: Arc::new(
-                ExternalIdentityStore::new(data_dir.path().to_str().unwrap()).unwrap(),
-            ),
-            external_identities: RwLock::new(HashMap::new()),
-        });
-
-        (data_dir, state)
+    async fn make_state_with_schema(
+        schema: crate::query_manager::types::Schema,
+    ) -> Arc<ServerState> {
+        ServerBuilder::new(AppId::from_name("test-app"))
+            .with_auth_config(test_auth_config())
+            .with_in_memory_storage()
+            .with_schema(schema)
+            .build()
+            .await
+            .expect("build state with schema")
+            .state
     }
 
     fn make_test_router(state: Arc<ServerState>) -> axum::Router {
@@ -949,7 +899,7 @@ mod tests {
         //                          apply p2 → ok
         //    ◄────────────────── {results:[ok,ok]}
 
-        let (app, _dir) = make_sync_test_app("test-backend-secret");
+        let app = make_sync_test_app("test-backend-secret").await;
         let client_id = ClientId::new();
 
         let body = serde_json::json!({
@@ -989,7 +939,7 @@ mod tests {
     #[tokio::test]
     async fn sync_batch_requires_auth() {
         // No auth headers → 401 before any payloads are applied
-        let (app, _dir) = make_sync_test_app("test-backend-secret");
+        let app = make_sync_test_app("test-backend-secret").await;
 
         let body = serde_json::json!({
             "payloads": [object_updated_payload("00000000-0000-0000-0000-000000000001")],
@@ -1016,7 +966,7 @@ mod tests {
     async fn sync_batch_returns_one_result_per_payload() {
         // bob sends 60 position updates in one tick — server must return
         // exactly 60 results, one per payload, in order
-        let (app, _dir) = make_sync_test_app("test-backend-secret");
+        let app = make_sync_test_app("test-backend-secret").await;
         let client_id = ClientId::new();
 
         let payloads: Vec<Value> = (0..60)
@@ -1057,39 +1007,20 @@ mod tests {
 
     #[tokio::test]
     async fn schema_handler_requires_admin_secret() {
-        let data_dir = TempDir::new().expect("temp dir");
-        let db_path = data_dir.path().join("groove.fjall");
-        let storage = FjallStorage::open(&db_path, 64 * 1024 * 1024).expect("open test storage");
-
-        let sync_manager = SyncManager::new()
-            .with_durability_tiers([DurabilityTier::EdgeServer, DurabilityTier::GlobalServer]);
-        let schema_manager =
-            SchemaManager::new_server(sync_manager, AppId::from_name("test-app"), "prod");
-        let runtime = TokioRuntime::new(schema_manager, storage, |_entry| {});
-
-        let auth_config = AuthConfig {
-            backend_secret: None,
-            admin_secret: Some("admin-secret".to_string()),
-            allow_anonymous: true,
-            allow_demo: true,
-            jwks_url: None,
-            jwks_set: None,
-        };
-
-        let (sync_tx, _) = broadcast::channel::<(ClientId, SyncPayload)>(16);
-
-        let state = Arc::new(ServerState {
-            runtime,
-            app_id: AppId::from_name("test-app"),
-            connections: RwLock::new(HashMap::new()),
-            next_connection_id: std::sync::atomic::AtomicU64::new(1),
-            sync_broadcast: sync_tx,
-            auth_config,
-            external_identity_store: Arc::new(
-                ExternalIdentityStore::new(data_dir.path().to_str().unwrap()).unwrap(),
-            ),
-            external_identities: RwLock::new(HashMap::new()),
-        });
+        let state = ServerBuilder::new(AppId::from_name("test-app"))
+            .with_auth_config(AuthConfig {
+                backend_secret: None,
+                admin_secret: Some("admin-secret".to_string()),
+                allow_anonymous: true,
+                allow_demo: true,
+                jwks_url: None,
+                jwks_set: None,
+            })
+            .with_in_memory_storage()
+            .build()
+            .await
+            .expect("build server state")
+            .state;
 
         let app = axum::Router::new()
             .route("/schema/:hash", get(schema_handler))
@@ -1146,7 +1077,7 @@ mod tests {
             )
             .build();
         let schema_hash = SchemaHash::compute(&schema);
-        let (_data_dir, state) = make_state_with_schema(schema);
+        let state = make_state_with_schema(schema).await;
 
         let app = make_test_router(state);
 
@@ -1207,7 +1138,7 @@ mod tests {
                     .column("name", ColumnType::Text),
             )
             .build();
-        let (_data_dir, state) = make_state_with_schema(schema);
+        let state = make_state_with_schema(schema).await;
         let app = make_test_router(state.clone());
 
         let without_secret = app
@@ -1282,7 +1213,7 @@ mod tests {
                     .column("name", ColumnType::Text),
             )
             .build();
-        let (_data_dir, state) = make_state_with_schema(schema);
+        let state = make_state_with_schema(schema).await;
 
         let repeated_query = QueryBuilder::new("users").build();
         let filtered_query = QueryBuilder::new("users")

--- a/crates/jazz-tools/src/server/builder.rs
+++ b/crates/jazz-tools/src/server/builder.rs
@@ -1,0 +1,265 @@
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::Arc;
+
+use axum::Router;
+use jsonwebtoken::jwk::JwkSet;
+use tokio::sync::{RwLock, broadcast};
+use tracing::info;
+
+use crate::middleware::AuthConfig;
+use crate::query_manager::types::Schema;
+use crate::routes;
+use crate::runtime_tokio::TokioRuntime;
+use crate::schema_manager::{AppId, SchemaManager, rehydrate_schema_manager_from_manifest};
+use crate::server::{DynStorage, ExternalIdentityStore, ServerState};
+use crate::storage::{FjallStorage, MemoryStorage, Storage};
+use crate::sync_manager::{ClientId, Destination, DurabilityTier, SyncManager, SyncPayload};
+
+const STORAGE_CACHE_SIZE_BYTES: usize = 64 * 1024 * 1024;
+const SYNC_BROADCAST_CAPACITY: usize = 256;
+
+pub struct BuiltServer {
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub state: Arc<ServerState>,
+    pub app: Router,
+}
+
+#[cfg_attr(not(test), allow(dead_code))]
+enum ServerSchemaMode {
+    Dynamic,
+    Fixed(Schema),
+}
+
+enum ServerStorageMode {
+    Persistent { data_dir: String },
+    InMemory,
+}
+
+pub struct ServerBuilder {
+    app_id: AppId,
+    auth_config: AuthConfig,
+    schema_mode: ServerSchemaMode,
+    storage_mode: ServerStorageMode,
+}
+
+impl ServerBuilder {
+    pub fn new(app_id: AppId) -> Self {
+        Self {
+            app_id,
+            auth_config: AuthConfig::default(),
+            schema_mode: ServerSchemaMode::Dynamic,
+            storage_mode: ServerStorageMode::Persistent {
+                data_dir: "./data".to_string(),
+            },
+        }
+    }
+
+    pub fn with_auth_config(mut self, auth_config: AuthConfig) -> Self {
+        self.auth_config = auth_config;
+        self
+    }
+
+    pub fn with_persistent_storage(mut self, data_dir: impl Into<String>) -> Self {
+        self.storage_mode = ServerStorageMode::Persistent {
+            data_dir: data_dir.into(),
+        };
+        self
+    }
+
+    pub fn with_in_memory_storage(mut self) -> Self {
+        self.storage_mode = ServerStorageMode::InMemory;
+        self
+    }
+
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub fn with_schema(mut self, schema: Schema) -> Self {
+        self.schema_mode = ServerSchemaMode::Fixed(schema);
+        self
+    }
+
+    pub async fn build(self) -> Result<BuiltServer, String> {
+        let mut auth_config = self.auth_config.clone();
+        preload_jwks(&mut auth_config).await?;
+        log_auth_config(&auth_config);
+
+        let (runtime, sync_broadcast) = self.build_runtime()?;
+        let external_identity_store = Arc::new(self.build_external_identity_store()?);
+        let external_identity_rows = external_identity_store
+            .list_external_identities(self.app_id)
+            .await
+            .map_err(|e| format!("failed to load external identities: {e}"))?;
+
+        let mut external_identities = HashMap::with_capacity(external_identity_rows.len());
+        for row in external_identity_rows {
+            external_identities.insert((row.issuer, row.subject), row.principal_id);
+        }
+
+        let state = Arc::new(ServerState {
+            runtime,
+            app_id: self.app_id,
+            connections: RwLock::new(HashMap::new()),
+            next_connection_id: std::sync::atomic::AtomicU64::new(1),
+            sync_broadcast,
+            auth_config,
+            external_identity_store,
+            external_identities: RwLock::new(external_identities),
+        });
+
+        let app = routes::create_router(state.clone());
+        Ok(BuiltServer { state, app })
+    }
+
+    fn build_runtime(
+        &self,
+    ) -> Result<
+        (
+            TokioRuntime<DynStorage>,
+            broadcast::Sender<(ClientId, SyncPayload)>,
+        ),
+        String,
+    > {
+        let (sync_tx, _) = broadcast::channel::<(ClientId, SyncPayload)>(SYNC_BROADCAST_CAPACITY);
+        let sync_tx_clone = sync_tx.clone();
+
+        let storage = self.build_main_storage()?;
+        let schema_manager = self.build_schema_manager(storage.as_ref())?;
+        let runtime = TokioRuntime::new(schema_manager, storage, move |entry| {
+            if let Destination::Client(client_id) = entry.destination {
+                let _ = sync_tx_clone.send((client_id, entry.payload));
+            }
+        });
+
+        Ok((runtime, sync_tx))
+    }
+
+    fn build_schema_manager(&self, storage: &dyn Storage) -> Result<SchemaManager, String> {
+        let sync_manager = server_sync_manager();
+
+        match &self.schema_mode {
+            ServerSchemaMode::Dynamic => {
+                let mut schema_manager =
+                    SchemaManager::new_server(sync_manager, self.app_id, "prod");
+                rehydrate_schema_manager_from_manifest(&mut schema_manager, storage, self.app_id)
+                    .map_err(|e| format!("failed to rehydrate schema manager: {e}"))?;
+                Ok(schema_manager)
+            }
+            ServerSchemaMode::Fixed(schema) => {
+                SchemaManager::new(sync_manager, schema.clone(), self.app_id, "prod", "main")
+                    .map_err(|e| format!("failed to initialize schema manager: {e:?}"))
+            }
+        }
+    }
+
+    fn build_main_storage(&self) -> Result<DynStorage, String> {
+        match &self.storage_mode {
+            ServerStorageMode::Persistent { data_dir } => {
+                std::fs::create_dir_all(data_dir)
+                    .map_err(|e| format!("failed to create data dir '{}': {e}", data_dir))?;
+
+                let db_path = Path::new(data_dir).join("jazz.fjall");
+                let storage =
+                    FjallStorage::open(&db_path, STORAGE_CACHE_SIZE_BYTES).map_err(|e| {
+                        format!("failed to open storage '{}': {e:?}", db_path.display())
+                    })?;
+                Ok(Box::new(storage))
+            }
+            ServerStorageMode::InMemory => Ok(Box::new(MemoryStorage::new())),
+        }
+    }
+
+    fn build_external_identity_store(&self) -> Result<ExternalIdentityStore, String> {
+        match &self.storage_mode {
+            ServerStorageMode::Persistent { data_dir } => {
+                let meta_dir = Path::new(data_dir).join("meta");
+                std::fs::create_dir_all(&meta_dir).map_err(|e| {
+                    format!("failed to create meta dir '{}': {e}", meta_dir.display())
+                })?;
+
+                let db_path = meta_dir.join("jazz.fjall");
+                let storage =
+                    FjallStorage::open(&db_path, STORAGE_CACHE_SIZE_BYTES).map_err(|e| {
+                        format!("failed to open meta storage '{}': {e:?}", db_path.display())
+                    })?;
+                ExternalIdentityStore::new_with_storage(Box::new(storage))
+            }
+            ServerStorageMode::InMemory => {
+                ExternalIdentityStore::new_with_storage(Box::new(MemoryStorage::new()))
+            }
+        }
+    }
+}
+
+fn server_sync_manager() -> SyncManager {
+    SyncManager::new()
+        .with_durability_tiers([DurabilityTier::EdgeServer, DurabilityTier::GlobalServer])
+}
+
+async fn preload_jwks(auth_config: &mut AuthConfig) -> Result<(), String> {
+    let Some(jwks_url) = auth_config.jwks_url.as_deref() else {
+        return Ok(());
+    };
+
+    let jwks = reqwest::get(jwks_url)
+        .await
+        .map_err(|e| format!("failed to fetch JWKS from {jwks_url}: {e}"))?
+        .json::<JwkSet>()
+        .await
+        .map_err(|e| format!("failed to decode JWKS from {jwks_url}: {e}"))?;
+    auth_config.jwks_set = Some(jwks);
+    Ok(())
+}
+
+fn log_auth_config(auth_config: &AuthConfig) {
+    if auth_config.is_configured() {
+        info!(
+            "Auth configured: anonymous={}, demo={}, jwks={}, backend={}, admin={}",
+            auth_config.allow_anonymous,
+            auth_config.allow_demo,
+            auth_config.jwks_url.is_some(),
+            auth_config.backend_secret.is_some(),
+            auth_config.admin_secret.is_some()
+        );
+    } else {
+        info!(
+            "Auth configured: anonymous={}, demo={}, jwks=false, backend=false, admin=false",
+            auth_config.allow_anonymous, auth_config.allow_demo
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn in_memory_builder_creates_working_external_identity_store() {
+        let app_id = AppId::from_name("builder-test-app");
+        let built = ServerBuilder::new(app_id)
+            .with_in_memory_storage()
+            .build()
+            .await
+            .expect("build server");
+
+        built
+            .state
+            .external_identity_store
+            .create_external_identity(
+                app_id,
+                "https://issuer.example",
+                "subject-123",
+                "principal-123",
+            )
+            .await
+            .expect("create external identity");
+
+        let existing = built
+            .state
+            .external_identity_store
+            .get_external_identity(app_id, "https://issuer.example", "subject-123")
+            .await
+            .expect("query external identity");
+
+        assert!(existing.is_some());
+    }
+}

--- a/crates/jazz-tools/src/server/external_identity_store.rs
+++ b/crates/jazz-tools/src/server/external_identity_store.rs
@@ -1,0 +1,222 @@
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::query_manager::query::QueryBuilder;
+use crate::query_manager::types::{
+    ColumnType, RowDescriptor, SchemaBuilder, TableName, TableSchema, Value,
+};
+use crate::runtime_core::ReadDurabilityOptions;
+use crate::runtime_tokio::TokioRuntime;
+use crate::schema_manager::{AppId, SchemaManager};
+use crate::server::DynStorage;
+use crate::sync_manager::{DurabilityTier, SyncManager};
+
+const EXTERNAL_IDENTITIES_TABLE: &str = "external_identities";
+
+#[derive(Debug, Clone)]
+pub struct ExternalIdentityRow {
+    pub issuer: String,
+    pub subject: String,
+    pub principal_id: String,
+}
+
+/// Persistent storage for external identity -> principal mappings.
+pub struct ExternalIdentityStore {
+    runtime: TokioRuntime<DynStorage>,
+    insert_descriptor: RowDescriptor,
+    read_descriptor: RowDescriptor,
+}
+
+impl ExternalIdentityStore {
+    pub fn new_with_storage(storage: DynStorage) -> Result<Self, String> {
+        let schema = SchemaBuilder::new()
+            .table(
+                TableSchema::builder(EXTERNAL_IDENTITIES_TABLE)
+                    .column("app_id", ColumnType::Uuid)
+                    .column("issuer", ColumnType::Text)
+                    .column("subject", ColumnType::Text)
+                    .column("principal_id", ColumnType::Text)
+                    .column("created_at", ColumnType::Timestamp)
+                    .column("updated_at", ColumnType::Timestamp),
+            )
+            .build();
+
+        let insert_descriptor = schema
+            .get(&TableName::new(EXTERNAL_IDENTITIES_TABLE))
+            .ok_or_else(|| "meta schema missing external_identities table".to_string())?
+            .columns
+            .clone();
+        let mut read_descriptor = insert_descriptor.clone();
+        normalize_row_descriptor(&mut read_descriptor);
+
+        let sync_manager = SyncManager::new()
+            .with_durability_tiers([DurabilityTier::EdgeServer, DurabilityTier::GlobalServer]);
+        let schema_manager = SchemaManager::new(
+            sync_manager,
+            schema,
+            AppId::from_name("jazz-tools-meta"),
+            "meta",
+            "main",
+        )
+        .map_err(|e| format!("failed to initialize meta schema manager: {e:?}"))?;
+
+        let runtime = TokioRuntime::new(schema_manager, storage, |_entry| {});
+        Ok(Self {
+            runtime,
+            insert_descriptor,
+            read_descriptor,
+        })
+    }
+
+    pub async fn list_external_identities(
+        &self,
+        app_id: AppId,
+    ) -> Result<Vec<ExternalIdentityRow>, String> {
+        let query = QueryBuilder::new(EXTERNAL_IDENTITIES_TABLE)
+            .filter_eq("app_id", Value::Uuid(app_id.as_object_id()))
+            .build();
+
+        let future = self
+            .runtime
+            .query(query, None, ReadDurabilityOptions::default())
+            .map_err(|e| format!("external identity query error: {e}"))?;
+        let rows = future
+            .await
+            .map_err(|e| format!("external identity query await error: {e}"))?;
+
+        rows.into_iter()
+            .map(|(_, values)| self.decode_external_identity_row(&values))
+            .collect()
+    }
+
+    pub async fn get_external_identity(
+        &self,
+        app_id: AppId,
+        issuer: &str,
+        subject: &str,
+    ) -> Result<Option<ExternalIdentityRow>, String> {
+        let query = QueryBuilder::new(EXTERNAL_IDENTITIES_TABLE)
+            .filter_eq("app_id", Value::Uuid(app_id.as_object_id()))
+            .filter_eq("issuer", Value::Text(issuer.to_string()))
+            .filter_eq("subject", Value::Text(subject.to_string()))
+            .build();
+
+        let future = self
+            .runtime
+            .query(query, None, ReadDurabilityOptions::default())
+            .map_err(|e| format!("external identity query error: {e}"))?;
+        let mut rows = future
+            .await
+            .map_err(|e| format!("external identity query await error: {e}"))?;
+
+        if let Some((_object_id, values)) = rows.pop() {
+            Ok(Some(self.decode_external_identity_row(&values)?))
+        } else {
+            Ok(None)
+        }
+    }
+
+    pub async fn create_external_identity(
+        &self,
+        app_id: AppId,
+        issuer: &str,
+        subject: &str,
+        principal_id: &str,
+    ) -> Result<(), String> {
+        let now = now_timestamp_us();
+        let values: Vec<Value> = self
+            .insert_descriptor
+            .columns
+            .iter()
+            .map(|column| match column.name.as_str() {
+                "app_id" => Value::Uuid(app_id.as_object_id()),
+                "created_at" => Value::Timestamp(now),
+                "issuer" => Value::Text(issuer.to_string()),
+                "principal_id" => Value::Text(principal_id.to_string()),
+                "subject" => Value::Text(subject.to_string()),
+                "updated_at" => Value::Timestamp(now),
+                other => panic!("unexpected external identity column {other}"),
+            })
+            .collect();
+
+        self.runtime
+            .insert(EXTERNAL_IDENTITIES_TABLE, values, None)
+            .map_err(|e| format!("failed to insert external identity: {e}"))?;
+        Ok(())
+    }
+
+    pub async fn close(&self) -> Result<(), String> {
+        self.runtime
+            .flush()
+            .await
+            .map_err(|e| format!("failed to flush external identity store: {e}"))?;
+        self.runtime
+            .with_storage(|storage| {
+                storage.flush();
+                storage.flush_wal();
+                let _ = storage.close();
+            })
+            .map_err(|e| format!("failed to close external identity store: {e}"))?;
+        Ok(())
+    }
+
+    fn decode_external_identity_row(
+        &self,
+        values: &[Value],
+    ) -> Result<ExternalIdentityRow, String> {
+        let issuer = match descriptor_value(&self.read_descriptor, values, "issuer") {
+            Some(Value::Text(s)) => s.clone(),
+            other => {
+                return Err(format!(
+                    "external identity field issuer expected text, got {other:?}"
+                ));
+            }
+        };
+
+        let subject = match descriptor_value(&self.read_descriptor, values, "subject") {
+            Some(Value::Text(s)) => s.clone(),
+            other => {
+                return Err(format!(
+                    "external identity field subject expected text, got {other:?}"
+                ));
+            }
+        };
+
+        let principal_id = match descriptor_value(&self.read_descriptor, values, "principal_id") {
+            Some(Value::Text(s)) => s.clone(),
+            other => {
+                return Err(format!(
+                    "external identity field principal_id expected text, got {other:?}"
+                ));
+            }
+        };
+
+        Ok(ExternalIdentityRow {
+            issuer,
+            subject,
+            principal_id,
+        })
+    }
+}
+
+fn normalize_row_descriptor(descriptor: &mut RowDescriptor) {
+    descriptor
+        .columns
+        .sort_unstable_by(|left, right| left.name.as_str().cmp(right.name.as_str()));
+}
+
+fn descriptor_value<'a>(
+    descriptor: &RowDescriptor,
+    values: &'a [Value],
+    column: &str,
+) -> Option<&'a Value> {
+    descriptor
+        .column_index(column)
+        .and_then(|index| values.get(index))
+}
+
+fn now_timestamp_us() -> u64 {
+    match SystemTime::now().duration_since(UNIX_EPOCH) {
+        Ok(duration) => duration.as_micros().min(u128::from(u64::MAX)) as u64,
+        Err(_) => 0,
+    }
+}

--- a/crates/jazz-tools/src/server/mod.rs
+++ b/crates/jazz-tools/src/server/mod.rs
@@ -1,0 +1,44 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use tokio::sync::{RwLock, broadcast};
+
+use crate::middleware::AuthConfig;
+use crate::runtime_tokio::TokioRuntime;
+use crate::schema_manager::AppId;
+use crate::storage::Storage;
+use crate::sync_manager::{ClientId, SyncPayload};
+
+mod builder;
+mod external_identity_store;
+#[cfg(feature = "test-utils")]
+mod testing;
+
+pub use builder::{BuiltServer, ServerBuilder};
+pub use external_identity_store::{ExternalIdentityRow, ExternalIdentityStore};
+#[cfg(feature = "test-utils")]
+pub use testing::{TestingJwksServer, TestingServer, TestingServerOptions};
+
+pub type DynStorage = Box<dyn Storage + Send>;
+
+/// Server state shared across request handlers.
+pub struct ServerState {
+    pub runtime: TokioRuntime<DynStorage>,
+    #[allow(dead_code)]
+    pub app_id: AppId,
+    pub connections: RwLock<HashMap<u64, ConnectionState>>,
+    pub next_connection_id: std::sync::atomic::AtomicU64,
+    /// Broadcast channel for sending sync payloads to SSE clients.
+    pub sync_broadcast: broadcast::Sender<(ClientId, SyncPayload)>,
+    /// Authentication configuration.
+    pub auth_config: AuthConfig,
+    /// Persistent external identity mapping store.
+    pub external_identity_store: Arc<ExternalIdentityStore>,
+    /// In-memory cache: (issuer, subject) -> principal_id.
+    pub external_identities: RwLock<HashMap<(String, String), String>>,
+}
+
+/// State for a single SSE connection.
+pub struct ConnectionState {
+    pub _client_id: ClientId,
+}

--- a/crates/jazz-tools/src/server/testing.rs
+++ b/crates/jazz-tools/src/server/testing.rs
@@ -1,0 +1,318 @@
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use axum::{Json, Router, routing::get};
+use base64::Engine;
+use jsonwebtoken::{Algorithm, EncodingKey, Header, encode};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value as JsonValue, json};
+use tokio::sync::oneshot;
+use uuid::Uuid;
+
+use crate::AppContext;
+use crate::middleware::AuthConfig;
+use crate::query_manager::types::Schema;
+use crate::schema_manager::AppId;
+
+use super::{ServerBuilder, ServerState};
+
+const DEFAULT_APP_ID_STR: &str = "00000000-0000-0000-0000-000000000001";
+const JWT_KID: &str = "test-jwks-kid";
+const JWT_SECRET: &str = "test-jwt-secret-for-integration";
+
+#[derive(Debug, Default)]
+pub struct TestingServerOptions {
+    pub port: Option<u16>,
+    pub app_id: Option<AppId>,
+    pub data_dir: Option<PathBuf>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct JwtClaims {
+    sub: String,
+    claims: JsonValue,
+    exp: u64,
+}
+
+pub struct TestingJwksServer {
+    addr: std::net::SocketAddr,
+    task: tokio::task::JoinHandle<()>,
+}
+
+impl TestingJwksServer {
+    pub async fn start() -> Self {
+        let app = Router::new().route("/jwks", get(jwks_handler));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind jwks server");
+        let addr = listener.local_addr().expect("jwks local addr");
+        let task = tokio::spawn(async move {
+            axum::serve(listener, app).await.expect("serve jwks");
+        });
+        Self { addr, task }
+    }
+
+    pub fn endpoint(&self) -> String {
+        format!("http://{}/jwks", self.addr)
+    }
+}
+
+impl Drop for TestingJwksServer {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+pub struct TestingServer {
+    state: Arc<ServerState>,
+    task: Option<tokio::task::JoinHandle<()>>,
+    shutdown_tx: Option<oneshot::Sender<()>>,
+    port: u16,
+    client: reqwest::Client,
+    app_id: AppId,
+    data_dir: PathBuf,
+    default_client_user_id: String,
+    client_data_dirs: Mutex<Vec<OwnedTempDir>>,
+    _owned_data_dir: Option<OwnedTempDir>,
+    _jwks_server: TestingJwksServer,
+}
+
+impl TestingServer {
+    pub const BACKEND_SECRET: &str = "backend-secret-for-integration-tests";
+    pub const ADMIN_SECRET: &str = "admin-secret-for-integration-tests";
+
+    pub async fn start() -> Self {
+        Self::start_with_options(TestingServerOptions::default()).await
+    }
+
+    pub async fn start_with_options(options: TestingServerOptions) -> Self {
+        let port = options.port.unwrap_or_else(get_free_port);
+        let app_id = options.app_id.unwrap_or_else(Self::default_app_id);
+        let (data_dir, owned_data_dir) = prepare_data_dir(options.data_dir);
+        let jwks_server = TestingJwksServer::start().await;
+
+        let auth_config = AuthConfig {
+            jwks_url: Some(jwks_server.endpoint()),
+            jwks_set: None,
+            allow_anonymous: true,
+            allow_demo: true,
+            backend_secret: Some(Self::BACKEND_SECRET.to_string()),
+            admin_secret: Some(Self::ADMIN_SECRET.to_string()),
+        };
+
+        let built = ServerBuilder::new(app_id)
+            .with_auth_config(auth_config)
+            .with_persistent_storage(data_dir.to_string_lossy().into_owned())
+            .build()
+            .await
+            .expect("build test server");
+
+        let listener = tokio::net::TcpListener::bind(("127.0.0.1", port))
+            .await
+            .expect("bind test server listener");
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+        let task = tokio::spawn(async move {
+            axum::serve(listener, built.app)
+                .with_graceful_shutdown(async {
+                    let _ = shutdown_rx.await;
+                })
+                .await
+                .expect("serve jazz server");
+        });
+
+        let server = Self {
+            state: built.state.clone(),
+            task: Some(task),
+            shutdown_tx: Some(shutdown_tx),
+            port,
+            client: reqwest::Client::new(),
+            app_id,
+            data_dir,
+            default_client_user_id: format!("testing-user-{}", Uuid::new_v4()),
+            client_data_dirs: Mutex::new(Vec::new()),
+            _owned_data_dir: owned_data_dir,
+            _jwks_server: jwks_server,
+        };
+        server.wait_ready().await;
+        server
+    }
+
+    pub fn default_app_id() -> AppId {
+        AppId::from_string(DEFAULT_APP_ID_STR).expect("parse default app id")
+    }
+
+    pub fn jwt_for_user(sub: &str) -> String {
+        let claims = JwtClaims {
+            sub: sub.to_string(),
+            claims: json!({"role": "user"}),
+            exp: SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("clock drift")
+                .as_secs()
+                + 3600,
+        };
+
+        let mut header = Header::new(Algorithm::HS256);
+        header.kid = Some(JWT_KID.to_string());
+
+        encode(
+            &header,
+            &claims,
+            &EncodingKey::from_secret(JWT_SECRET.as_bytes()),
+        )
+        .expect("encode jwt")
+    }
+
+    pub fn app_id(&self) -> AppId {
+        self.app_id
+    }
+
+    pub fn base_url(&self) -> String {
+        format!("http://127.0.0.1:{}", self.port)
+    }
+
+    pub fn make_client_context(&self, schema: Schema) -> AppContext {
+        self.make_client_context_for_user(schema, &self.default_client_user_id)
+    }
+
+    pub fn make_client_context_for_user(
+        &self,
+        schema: Schema,
+        user_id: impl AsRef<str>,
+    ) -> AppContext {
+        let client_data_dir = OwnedTempDir::new("jazz-tools-testing-client");
+        let data_dir = client_data_dir.path().to_path_buf();
+        self.client_data_dirs
+            .lock()
+            .expect("lock test client data dirs")
+            .push(client_data_dir);
+
+        AppContext {
+            app_id: self.app_id,
+            client_id: None,
+            schema,
+            server_url: self.base_url(),
+            data_dir,
+            jwt_token: Some(Self::jwt_for_user(user_id.as_ref())),
+            backend_secret: Some(Self::BACKEND_SECRET.to_string()),
+            admin_secret: Some(Self::ADMIN_SECRET.to_string()),
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn data_dir(&self) -> &Path {
+        &self.data_dir
+    }
+
+    async fn wait_ready(&self) {
+        let health_url = format!("{}/health", self.base_url());
+        for _ in 0..80 {
+            if let Ok(response) = self.client.get(&health_url).send().await
+                && response.status().is_success()
+            {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+        panic!("jazz-tools server did not become ready in time");
+    }
+
+    pub async fn shutdown(mut self) {
+        self.state
+            .runtime
+            .flush()
+            .await
+            .expect("flush server runtime");
+        if let Some(tx) = self.shutdown_tx.take() {
+            let _ = tx.send(());
+        }
+        if let Some(mut task) = self.task.take() {
+            if tokio::time::timeout(Duration::from_millis(500), &mut task)
+                .await
+                .is_err()
+            {
+                task.abort();
+                let _ = task.await;
+            }
+        }
+        self.state
+            .runtime
+            .with_storage(|storage| {
+                storage.flush();
+                storage.flush_wal();
+                let _ = storage.close();
+            })
+            .expect("flush and close server storage");
+        self.state
+            .external_identity_store
+            .close()
+            .await
+            .expect("close external identity store");
+    }
+}
+
+impl Drop for TestingServer {
+    fn drop(&mut self) {
+        if let Some(tx) = self.shutdown_tx.take() {
+            let _ = tx.send(());
+        }
+        if let Some(task) = self.task.take() {
+            task.abort();
+        }
+    }
+}
+
+struct OwnedTempDir {
+    path: PathBuf,
+}
+
+impl OwnedTempDir {
+    fn new(prefix: &str) -> Self {
+        let path = std::env::temp_dir().join(format!("{prefix}-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&path).expect("create temp server dir");
+        Self { path }
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for OwnedTempDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.path);
+    }
+}
+
+fn prepare_data_dir(data_dir: Option<PathBuf>) -> (PathBuf, Option<OwnedTempDir>) {
+    match data_dir {
+        Some(path) => {
+            std::fs::create_dir_all(&path).expect("create test server data dir");
+            (path, None)
+        }
+        None => {
+            let temp_dir = OwnedTempDir::new("jazz-tools-testing-server");
+            (temp_dir.path().to_path_buf(), Some(temp_dir))
+        }
+    }
+}
+
+fn get_free_port() -> u16 {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind port 0");
+    listener.local_addr().expect("local addr").port()
+}
+
+async fn jwks_handler() -> Json<JsonValue> {
+    let encoded = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(JWT_SECRET.as_bytes());
+    Json(json!({
+        "keys": [
+            {
+                "kty": "oct",
+                "kid": JWT_KID,
+                "alg": "HS256",
+                "k": encoded,
+            }
+        ]
+    }))
+}

--- a/crates/jazz-tools/tests/clients_sync.rs
+++ b/crates/jazz-tools/tests/clients_sync.rs
@@ -1,0 +1,217 @@
+#![cfg(feature = "test-utils")]
+
+mod support;
+
+use std::collections::BTreeSet;
+use std::time::Duration;
+
+use jazz_tools::server::TestingServer;
+use jazz_tools::{
+    ColumnType, DurabilityTier, JazzClient, QueryBuilder, SchemaBuilder, TableSchema, Value,
+};
+use support::wait_for_query;
+
+fn test_schema() -> jazz_tools::Schema {
+    SchemaBuilder::new()
+        .table(
+            TableSchema::builder("todos")
+                .column("title", ColumnType::Text)
+                .column("completed", ColumnType::Boolean),
+        )
+        .build()
+}
+
+async fn wait_for_edge_query_ready(client: &JazzClient, timeout: Duration) {
+    let query = QueryBuilder::new("todos").build();
+    wait_for_query(
+        client,
+        query,
+        Some(DurabilityTier::EdgeServer),
+        timeout,
+        "EdgeServer query readiness",
+        |_| Some(()),
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn jazz_tools_cli_two_clients_sync_values() {
+    let server = TestingServer::start().await;
+    let client_a = JazzClient::connect(server.make_client_context(test_schema()))
+        .await
+        .expect("connect client a");
+    let client_b = JazzClient::connect(server.make_client_context(test_schema()))
+        .await
+        .expect("connect client b");
+
+    wait_for_edge_query_ready(&client_a, Duration::from_secs(30)).await;
+    wait_for_edge_query_ready(&client_b, Duration::from_secs(30)).await;
+
+    client_a
+        .create(
+            "todos",
+            vec![
+                Value::Text("shared-through-server".to_string()),
+                Value::Boolean(false),
+            ],
+        )
+        .await
+        .expect("create from client a");
+
+    let rows_on_b = wait_for_query(
+        &client_b,
+        QueryBuilder::new("todos").build(),
+        Some(DurabilityTier::EdgeServer),
+        Duration::from_secs(25),
+        "todos count 1",
+        |rows| (rows.len() == 1).then_some(rows),
+    )
+    .await;
+    let todo_id = rows_on_b[0].0;
+
+    client_b
+        .update(
+            todo_id,
+            vec![("completed".to_string(), Value::Boolean(true))],
+        )
+        .await
+        .expect("update from client b");
+
+    let rows_on_a = wait_for_query(
+        &client_a,
+        QueryBuilder::new("todos").build(),
+        Some(DurabilityTier::EdgeServer),
+        Duration::from_secs(25),
+        "todo completed=true",
+        |rows| {
+            let has_expected_completed = rows.iter().any(|(_, values)| {
+                values
+                    .iter()
+                    .any(|value| matches!(value, Value::Boolean(flag) if *flag))
+            });
+
+            (!rows.is_empty() && has_expected_completed).then_some(rows)
+        },
+    )
+    .await;
+    assert!(
+        rows_on_a[0]
+            .1
+            .iter()
+            .any(|value| matches!(value, Value::Boolean(true))),
+        "client a should observe client b's update through the server"
+    );
+
+    client_a.shutdown().await.expect("shutdown client a");
+    client_b.shutdown().await.expect("shutdown client b");
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn jazz_tools_cli_two_different_users_sync_values() {
+    let server = TestingServer::start().await;
+    let client_alice =
+        JazzClient::connect(server.make_client_context_for_user(test_schema(), "alice-sync-user"))
+            .await
+            .expect("connect alice client");
+    let client_bob =
+        JazzClient::connect(server.make_client_context_for_user(test_schema(), "bob-sync-user"))
+            .await
+            .expect("connect bob client");
+
+    wait_for_edge_query_ready(&client_alice, Duration::from_secs(30)).await;
+    wait_for_edge_query_ready(&client_bob, Duration::from_secs(30)).await;
+
+    client_alice
+        .create(
+            "todos",
+            vec![
+                Value::Text("shared-across-users".to_string()),
+                Value::Boolean(false),
+            ],
+        )
+        .await
+        .expect("alice creates todo");
+
+    let rows_on_bob = wait_for_query(
+        &client_bob,
+        QueryBuilder::new("todos").build(),
+        Some(DurabilityTier::EdgeServer),
+        Duration::from_secs(25),
+        "todos count 1",
+        |rows| (rows.len() == 1).then_some(rows),
+    )
+    .await;
+    let shared_todo_id = rows_on_bob[0].0;
+
+    client_bob
+        .update(
+            shared_todo_id,
+            vec![("completed".to_string(), Value::Boolean(true))],
+        )
+        .await
+        .expect("bob updates alice todo");
+
+    let _ = wait_for_query(
+        &client_alice,
+        QueryBuilder::new("todos").build(),
+        Some(DurabilityTier::EdgeServer),
+        Duration::from_secs(25),
+        "todo completed=true",
+        |rows| {
+            let has_expected_completed = rows.iter().any(|(_, values)| {
+                values
+                    .iter()
+                    .any(|value| matches!(value, Value::Boolean(flag) if *flag))
+            });
+
+            (!rows.is_empty() && has_expected_completed).then_some(rows)
+        },
+    )
+    .await;
+
+    client_bob
+        .create(
+            "todos",
+            vec![Value::Text("from-bob".to_string()), Value::Boolean(false)],
+        )
+        .await
+        .expect("bob creates todo");
+
+    let expected_titles = ["shared-across-users", "from-bob"]
+        .into_iter()
+        .map(str::to_string)
+        .collect::<BTreeSet<_>>();
+    let rows_on_alice = wait_for_query(
+        &client_alice,
+        QueryBuilder::new("todos").build(),
+        Some(DurabilityTier::EdgeServer),
+        Duration::from_secs(25),
+        format!("titles {:?}", expected_titles),
+        |rows| {
+            let titles = rows
+                .iter()
+                .flat_map(|(_, values)| values.iter())
+                .filter_map(|value| match value {
+                    Value::Text(text) => Some(text.clone()),
+                    _ => None,
+                })
+                .collect::<BTreeSet<_>>();
+
+            (titles == expected_titles).then_some(rows)
+        },
+    )
+    .await;
+    assert_eq!(
+        rows_on_alice.len(),
+        2,
+        "alice should observe both shared rows across users"
+    );
+
+    client_alice
+        .shutdown()
+        .await
+        .expect("shutdown alice client");
+    client_bob.shutdown().await.expect("shutdown bob client");
+    server.shutdown().await;
+}

--- a/crates/jazz-tools/tests/integration.rs
+++ b/crates/jazz-tools/tests/integration.rs
@@ -21,12 +21,14 @@ struct TestServer {
     port: u16,
     #[allow(dead_code)]
     data_dir: TempDir,
+    configured_data_dir: PathBuf,
 }
 
 impl TestServer {
     /// Start a test server on the given port.
     async fn start(port: u16) -> Self {
         let data_dir = TempDir::new().expect("create temp dir");
+        let configured_data_dir = data_dir.path().to_path_buf();
 
         // Use a deterministic UUID app ID for testing
         let app_id = "00000000-0000-0000-0000-000000000001";
@@ -40,7 +42,7 @@ impl TestServer {
                 "--port",
                 &port.to_string(),
                 "--data-dir",
-                data_dir.path().to_str().unwrap(),
+                configured_data_dir.to_str().unwrap(),
             ])
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
@@ -56,11 +58,51 @@ impl TestServer {
             process,
             port,
             data_dir,
+            configured_data_dir,
         };
 
         // Wait for server to be ready
         server.wait_ready().await;
 
+        server
+    }
+
+    /// Start a test server with the CLI `--in-memory` flag enabled.
+    async fn start_in_memory(port: u16) -> Self {
+        let data_dir = TempDir::new().expect("create temp dir");
+        let configured_data_dir = data_dir.path().join("should-not-exist");
+
+        let app_id = "00000000-0000-0000-0000-000000000001";
+        let jazz_binary = Self::find_jazz_binary();
+
+        let process = Command::new(&jazz_binary)
+            .args([
+                "server",
+                app_id,
+                "--port",
+                &port.to_string(),
+                "--data-dir",
+                configured_data_dir.to_str().unwrap(),
+                "--in-memory",
+            ])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .unwrap_or_else(|e| {
+                panic!(
+                    "Failed to spawn jazz-tools server at {:?}: {}",
+                    jazz_binary, e
+                )
+            });
+
+        let server = Self {
+            process,
+            port,
+            data_dir,
+            configured_data_dir,
+        };
+
+        server.wait_ready().await;
         server
     }
 
@@ -160,6 +202,25 @@ async fn test_server_health_check() {
 
     let body: serde_json::Value = resp.json().await.expect("parse json");
     assert_eq!(body["status"], "healthy");
+}
+
+#[tokio::test]
+async fn test_server_health_check_in_memory_does_not_create_data_dir() {
+    let port = get_free_port();
+    let server = TestServer::start_in_memory(port).await;
+
+    let client = Client::new();
+    let resp = client
+        .get(format!("{}/health", server.base_url()))
+        .send()
+        .await
+        .expect("health check");
+
+    assert!(resp.status().is_success());
+    assert!(
+        !server.configured_data_dir.exists(),
+        "--in-memory should not create the configured data directory"
+    );
 }
 
 #[tokio::test]

--- a/crates/jazz-tools/tests/support/mod.rs
+++ b/crates/jazz-tools/tests/support/mod.rs
@@ -1,0 +1,68 @@
+use std::future::Future;
+use std::time::Duration;
+
+use jazz_tools::{DurabilityTier, JazzClient, ObjectId, Query, Value};
+
+const DEFAULT_POLL_INTERVAL: Duration = Duration::from_millis(250);
+const DEFAULT_QUERY_TIMEOUT: Duration = Duration::from_secs(8);
+
+pub type QueryRows = Vec<(ObjectId, Vec<Value>)>;
+
+#[allow(dead_code)]
+pub async fn wait_for<T, F, Fut>(
+    timeout: Duration,
+    description: impl Into<String>,
+    mut check: F,
+) -> T
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Option<T>>,
+{
+    let description = description.into();
+    let deadline = tokio::time::Instant::now() + timeout;
+
+    loop {
+        if let Some(value) = check().await {
+            return value;
+        }
+
+        if tokio::time::Instant::now() >= deadline {
+            panic!("timed out waiting for {description}");
+        }
+
+        tokio::time::sleep(DEFAULT_POLL_INTERVAL).await;
+    }
+}
+
+pub async fn wait_for_query<T, F>(
+    client: &JazzClient,
+    query: Query,
+    durability_tier: Option<DurabilityTier>,
+    timeout: Duration,
+    description: impl Into<String>,
+    mut check_rows: F,
+) -> T
+where
+    F: FnMut(QueryRows) -> Option<T>,
+{
+    let description = description.into();
+    let deadline = tokio::time::Instant::now() + timeout;
+
+    loop {
+        if let Ok(Ok(rows)) = tokio::time::timeout(
+            DEFAULT_QUERY_TIMEOUT,
+            client.query(query.clone(), durability_tier),
+        )
+        .await
+            && let Some(value) = check_rows(rows)
+        {
+            return value;
+        }
+
+        if tokio::time::Instant::now() >= deadline {
+            panic!("timed out waiting for {description}");
+        }
+
+        tokio::time::sleep(DEFAULT_POLL_INTERVAL).await;
+    }
+}


### PR DESCRIPTION
This PR adds a ServerBuilder and TestingServer modules to make it eaiser to spin up a server programmatically and run a TestingServer with "fake stuff" around to make it work.

Thinking about adopting the builder pattern for TestingServer as well, to make it easier to reproduce broken scenarios like unrechable JwksServer.
