### PR TITLE
Ensure synced soft deletes respect delete policies

### DIFF
--- a/.changeset/fix-sync-soft-delete-permissions.md
+++ b/.changeset/fix-sync-soft-delete-permissions.md
@@ -1,0 +1,7 @@
+---
+"jazz-tools": patch
+---
+
+Fix a sync-server permission bypass where replicated soft deletes could skip `DELETE` policy evaluation.
+
+User writes received as `ObjectUpdated` payloads now inspect delete metadata before the sync permission check is queued. Soft-delete commits are classified as `DELETE` operations instead of `UPDATE`, so replicated row deletions correctly use delete policies and are rejected when the client lacks delete access.

--- a/crates/jazz-tools/src/query_manager/rebac_tests.rs
+++ b/crates/jazz-tools/src/query_manager/rebac_tests.rs
@@ -2412,6 +2412,121 @@ fn local_delete_with_exists_rel_policy_allows_admin_and_denies_non_admin() {
 }
 
 #[test]
+fn synced_soft_delete_should_use_delete_policy() {
+    let mut schema = Schema::new();
+    let admins_descriptor =
+        RowDescriptor::new(vec![ColumnDescriptor::new("user_id", ColumnType::Text)]);
+    schema.insert(
+        TableName::new("admins"),
+        TableSchema::new(admins_descriptor.clone()),
+    );
+
+    let protected_descriptor =
+        RowDescriptor::new(vec![ColumnDescriptor::new("data", ColumnType::Text)]);
+    let protected_policies = TablePolicies::new().with_delete(PolicyExpr::ExistsRel {
+        rel: RelExpr::Filter {
+            input: Box::new(RelExpr::TableScan {
+                table: TableName::new("admins"),
+            }),
+            predicate: PredicateExpr::Cmp {
+                left: ColumnRef::unscoped("user_id"),
+                op: PredicateCmpOp::Eq,
+                right: ValueRef::SessionRef(vec!["user_id".into()]),
+            },
+        },
+    });
+    schema.insert(
+        TableName::new("protected"),
+        TableSchema::with_policies(protected_descriptor.clone(), protected_policies),
+    );
+
+    let sync_manager = SyncManager::new();
+    let mut qm = create_query_manager(sync_manager, schema);
+    let mut storage = MemoryStorage::new();
+
+    qm.insert(&mut storage, "admins", &[Value::Text("alice".into())])
+        .expect("seed admin row");
+    let protected = qm
+        .insert(&mut storage, "protected", &[Value::Text("initial".into())])
+        .expect("seed protected row");
+    let branch = get_branch(&qm);
+
+    let protected_metadata = qm
+        .sync_manager()
+        .object_manager
+        .get(protected.row_id)
+        .map(|obj| obj.metadata.clone())
+        .expect("protected row metadata");
+
+    let bob_client = ClientId::new();
+    qm.sync_manager_mut().add_client(bob_client);
+    qm.sync_manager_mut()
+        .set_client_session(bob_client, Session::new("bob"));
+
+    let mut bob_scope = HashSet::new();
+    bob_scope.insert((protected.row_id, branch.clone().into()));
+    qm.sync_manager_mut()
+        .set_client_query_scope(bob_client, QueryId(1), bob_scope, None);
+    qm.sync_manager_mut().take_outbox();
+
+    let delete_content =
+        encode_row(&protected_descriptor, &[Value::Text("initial".into())]).unwrap();
+    let delete_commit = Commit {
+        parents: smallvec![protected.row_commit_id],
+        content: delete_content,
+        timestamp: 2000,
+        author: ObjectId::new(),
+        metadata: Some(crate::metadata::soft_delete_metadata()),
+        stored_state: crate::commit::StoredState::Stored,
+        ack_state: Default::default(),
+    };
+
+    qm.sync_manager_mut().push_inbox(InboxEntry {
+        source: Source::Client(bob_client),
+        payload: SyncPayload::ObjectUpdated {
+            object_id: protected.row_id,
+            metadata: Some(ObjectMetadata {
+                id: protected.row_id,
+                metadata: protected_metadata,
+            }),
+            branch_name: branch.clone().into(),
+            commits: vec![delete_commit.clone()],
+        },
+    });
+
+    for _ in 0..10 {
+        qm.process(&mut storage);
+    }
+
+    let outbox = qm.sync_manager_mut().take_outbox();
+    let denied = outbox.iter().any(|entry| {
+        matches!(
+            (&entry.destination, &entry.payload),
+            (Destination::Client(id), SyncPayload::Error(SyncError::PermissionDenied { .. }))
+                if *id == bob_client
+        )
+    });
+    assert!(
+        denied,
+        "soft deletes replicated over sync should be checked against DELETE policy"
+    );
+
+    let tips = qm
+        .sync_manager_mut()
+        .object_manager
+        .get_tip_ids(protected.row_id, &branch)
+        .unwrap();
+    assert!(
+        !tips.contains(&delete_commit.id()),
+        "denied synced soft delete should not be applied"
+    );
+    assert!(
+        !qm.row_is_deleted(&storage, "protected", protected.row_id),
+        "denied synced soft delete should leave the row visible"
+    );
+}
+
+#[test]
 fn magic_columns_reactively_track_update_and_delete_permissions() {
     let schema = magic_introspection_schema();
     let sync_manager = SyncManager::new();

--- a/crates/jazz-tools/src/sync_manager/inbox.rs
+++ b/crates/jazz-tools/src/sync_manager/inbox.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::commit::{Commit, CommitId};
+use crate::metadata::MetadataKey;
 use crate::object::{BranchName, ObjectId};
 use crate::query_manager::policy::Operation;
 use crate::storage::Storage;
@@ -237,8 +238,15 @@ impl SyncManager {
                         } else {
                             stored_metadata
                         };
-                        let new_content = commits.last().map(|c| c.content.clone());
-                        let operation = if old_content.is_some() {
+                        let is_delete = Self::is_deleted_update(commits);
+                        let new_content = if is_delete {
+                            None
+                        } else {
+                            commits.last().map(|c| c.content.clone())
+                        };
+                        let operation = if is_delete {
+                            Operation::Delete
+                        } else if old_content.is_some() {
                             Operation::Update
                         } else {
                             Operation::Insert
@@ -546,5 +554,16 @@ impl SyncManager {
             }
         }
         persisted
+    }
+
+    /// Soft deletes travel over sync as `ObjectUpdated`; we infer them from the
+    /// newest commit carrying delete metadata on the payload's tip.
+    fn is_deleted_update(commits: &[Commit]) -> bool {
+        commits.last().is_some_and(|commit| {
+            commit
+                .metadata
+                .as_ref()
+                .is_some_and(|metadata| metadata.contains_key(MetadataKey::Delete.as_str()))
+        })
     }
 }

--- a/crates/jazz-tools/src/sync_manager/tests.rs
+++ b/crates/jazz-tools/src/sync_manager/tests.rs
@@ -1173,6 +1173,63 @@ fn write_with_session_goes_to_pending_permission_checks() {
 }
 
 #[test]
+fn soft_delete_object_updated_is_queued_as_delete_permission_check() {
+    let mut sm = SyncManager::new();
+    let mut io = MemoryStorage::new();
+
+    let obj_id = sm.object_manager.create(&mut io, None);
+    let author = ObjectId::new();
+    let c1 = sm
+        .object_manager
+        .add_commit(
+            &mut io,
+            obj_id,
+            "main",
+            vec![],
+            b"original".to_vec(),
+            author,
+            None,
+        )
+        .unwrap();
+
+    let client_id = ClientId::new();
+    sm.add_client(client_id);
+    sm.set_client_session(client_id, Session::new("user123"));
+    sm.take_outbox();
+
+    let delete_commit = Commit {
+        parents: smallvec![c1],
+        content: b"original".to_vec(),
+        timestamp: 2000,
+        author,
+        metadata: Some(crate::metadata::soft_delete_metadata()),
+        stored_state: crate::commit::StoredState::Stored,
+        ack_state: Default::default(),
+    };
+
+    sm.push_inbox(InboxEntry {
+        source: Source::Client(client_id),
+        payload: SyncPayload::ObjectUpdated {
+            object_id: obj_id,
+            metadata: None,
+            branch_name: "main".into(),
+            commits: vec![delete_commit.clone()],
+        },
+    });
+
+    sm.process_inbox(&mut io);
+
+    let pending = sm.take_pending_permission_checks();
+    assert_eq!(pending.len(), 1);
+    assert_eq!(pending[0].operation, Operation::Delete);
+    assert_eq!(pending[0].old_content, Some(b"original".to_vec()));
+    assert_eq!(pending[0].new_content, None);
+
+    let tips = sm.object_manager.get_tip_ids(obj_id, "main").unwrap();
+    assert!(!tips.contains(&delete_commit.id()));
+}
+
+#[test]
 fn approve_permission_check_applies_write() {
     let mut sm = SyncManager::new();
     let mut io = MemoryStorage::new();


### PR DESCRIPTION
## Summary

Fix a sync-server permission bug where replicated soft deletes could bypass `DELETE` policy checks.

## What changed

Synced row deletions arrive as `ObjectUpdated` payloads with delete metadata. We now detect those writes in the sync inbox before queuing permission evaluation and classify them as `DELETE` operations instead of `UPDATE`.

## Why

Without this, a replicated soft delete could be evaluated against update permissions rather than delete permissions, allowing a client to remove rows they should not be allowed to delete.