### PR TITLE
Add session.where support for session-only permission predicates

### DIFF
--- a/crates/jazz-tools/src/query_manager/policy.rs
+++ b/crates/jazz-tools/src/query_manager/policy.rs
@@ -87,17 +87,36 @@ pub enum PolicyExpr {
         value: PolicyValue,
     },
 
+    /// Compare a session value against a literal value.
+    SessionCmp {
+        path: Vec<String>,
+        op: CmpOp,
+        value: Value,
+    },
+
     /// Check if a column is NULL.
     IsNull { column: String },
 
+    /// Check if a session value is NULL.
+    SessionIsNull { path: Vec<String> },
+
     /// Check if a column is NOT NULL.
     IsNotNull { column: String },
+
+    /// Check if a session value is NOT NULL.
+    SessionIsNotNull { path: Vec<String> },
 
     /// Check if a column contains a value.
     ///
     /// - For TEXT columns this means substring containment.
     /// - For ARRAY columns this means element membership.
     Contains { column: String, value: PolicyValue },
+
+    /// Check if a session value contains a literal value.
+    ///
+    /// - For TEXT session values this means substring containment.
+    /// - For ARRAY session values this means element membership.
+    SessionContains { path: Vec<String>, value: Value },
 
     /// Check if a column value is in a session array.
     /// The session_path must point to an array in the session claims.
@@ -110,6 +129,12 @@ pub enum PolicyExpr {
     InList {
         column: String,
         values: Vec<PolicyValue>,
+    },
+
+    /// Check if a scalar session value is contained in a list of literal values.
+    SessionInList {
+        path: Vec<String>,
+        values: Vec<Value>,
     },
 
     /// Check if a subquery returns any rows.
@@ -200,15 +225,30 @@ enum PolicyExprSerde {
         op: CmpOp,
         value: PolicyValue,
     },
+    SessionCmp {
+        path: Vec<String>,
+        op: CmpOp,
+        value: Value,
+    },
     IsNull {
         column: String,
+    },
+    SessionIsNull {
+        path: Vec<String>,
     },
     IsNotNull {
         column: String,
     },
+    SessionIsNotNull {
+        path: Vec<String>,
+    },
     Contains {
         column: String,
         value: PolicyValue,
+    },
+    SessionContains {
+        path: Vec<String>,
+        value: Value,
     },
     In {
         column: String,
@@ -217,6 +257,10 @@ enum PolicyExprSerde {
     InList {
         column: String,
         values: Vec<PolicyValue>,
+    },
+    SessionInList {
+        path: Vec<String>,
+        values: Vec<Value>,
     },
     Exists {
         table: String,
@@ -253,9 +297,17 @@ impl From<PolicyExprSerde> for PolicyExpr {
     fn from(value: PolicyExprSerde) -> Self {
         match value {
             PolicyExprSerde::Cmp { column, op, value } => PolicyExpr::Cmp { column, op, value },
+            PolicyExprSerde::SessionCmp { path, op, value } => {
+                PolicyExpr::SessionCmp { path, op, value }
+            }
             PolicyExprSerde::IsNull { column } => PolicyExpr::IsNull { column },
+            PolicyExprSerde::SessionIsNull { path } => PolicyExpr::SessionIsNull { path },
             PolicyExprSerde::IsNotNull { column } => PolicyExpr::IsNotNull { column },
+            PolicyExprSerde::SessionIsNotNull { path } => PolicyExpr::SessionIsNotNull { path },
             PolicyExprSerde::Contains { column, value } => PolicyExpr::Contains { column, value },
+            PolicyExprSerde::SessionContains { path, value } => {
+                PolicyExpr::SessionContains { path, value }
+            }
             PolicyExprSerde::In {
                 column,
                 session_path,
@@ -264,6 +316,9 @@ impl From<PolicyExprSerde> for PolicyExpr {
                 session_path,
             },
             PolicyExprSerde::InList { column, values } => PolicyExpr::InList { column, values },
+            PolicyExprSerde::SessionInList { path, values } => {
+                PolicyExpr::SessionInList { path, values }
+            }
             PolicyExprSerde::Exists { table, condition } => PolicyExpr::Exists {
                 table,
                 condition: Box::new((*condition).into()),
@@ -306,9 +361,17 @@ impl From<PolicyExpr> for PolicyExprSerde {
     fn from(value: PolicyExpr) -> Self {
         match value {
             PolicyExpr::Cmp { column, op, value } => PolicyExprSerde::Cmp { column, op, value },
+            PolicyExpr::SessionCmp { path, op, value } => {
+                PolicyExprSerde::SessionCmp { path, op, value }
+            }
             PolicyExpr::IsNull { column } => PolicyExprSerde::IsNull { column },
+            PolicyExpr::SessionIsNull { path } => PolicyExprSerde::SessionIsNull { path },
             PolicyExpr::IsNotNull { column } => PolicyExprSerde::IsNotNull { column },
+            PolicyExpr::SessionIsNotNull { path } => PolicyExprSerde::SessionIsNotNull { path },
             PolicyExpr::Contains { column, value } => PolicyExprSerde::Contains { column, value },
+            PolicyExpr::SessionContains { path, value } => {
+                PolicyExprSerde::SessionContains { path, value }
+            }
             PolicyExpr::In {
                 column,
                 session_path,
@@ -317,6 +380,9 @@ impl From<PolicyExpr> for PolicyExprSerde {
                 session_path,
             },
             PolicyExpr::InList { column, values } => PolicyExprSerde::InList { column, values },
+            PolicyExpr::SessionInList { path, values } => {
+                PolicyExprSerde::SessionInList { path, values }
+            }
             PolicyExpr::Exists { table, condition } => PolicyExprSerde::Exists {
                 table,
                 condition: Box::new((*condition).into()),
@@ -544,6 +610,9 @@ where
         PolicyExpr::Cmp { column, op, value } => {
             evaluate_cmp(column, op, value, content, descriptor, ctx.session)
         }
+        PolicyExpr::SessionCmp { path, op, value } => {
+            evaluate_session_cmp(path, op, value, ctx.session)
+        }
 
         PolicyExpr::IsNull { column } => {
             if let Some(col_index) = descriptor.column_index(column) {
@@ -551,6 +620,9 @@ where
             } else {
                 false
             }
+        }
+        PolicyExpr::SessionIsNull { path } => {
+            matches!(resolve_session_value(path, ctx.session), Some(Value::Null))
         }
 
         PolicyExpr::IsNotNull { column } => {
@@ -560,9 +632,15 @@ where
                 false
             }
         }
+        PolicyExpr::SessionIsNotNull { path } => {
+            matches!(resolve_session_value(path, ctx.session), Some(value) if !value.is_null())
+        }
 
         PolicyExpr::Contains { column, value } => {
             evaluate_contains(column, value, content, descriptor, ctx.session)
+        }
+        PolicyExpr::SessionContains { path, value } => {
+            evaluate_session_contains(path, value, ctx.session)
         }
 
         PolicyExpr::In {
@@ -572,6 +650,9 @@ where
 
         PolicyExpr::InList { column, values } => {
             evaluate_in_list(column, values, content, descriptor, ctx.session)
+        }
+        PolicyExpr::SessionInList { path, values } => {
+            evaluate_session_in_list(path, values, ctx.session)
         }
 
         PolicyExpr::And(exprs) => exprs
@@ -721,16 +802,28 @@ fn evaluate_expr_simple(
         PolicyExpr::Cmp { column, op, value } => {
             evaluate_cmp(column, op, value, content, descriptor, session)
         }
+        PolicyExpr::SessionCmp { path, op, value } => {
+            evaluate_session_cmp(path, op, value, session)
+        }
         PolicyExpr::IsNull { column } => descriptor
             .column_index(column)
             .map(|i| column_is_null(descriptor, content, i).unwrap_or(false))
             .unwrap_or(false),
+        PolicyExpr::SessionIsNull { path } => {
+            matches!(resolve_session_value(path, session), Some(Value::Null))
+        }
         PolicyExpr::IsNotNull { column } => descriptor
             .column_index(column)
             .map(|i| !column_is_null(descriptor, content, i).unwrap_or(true))
             .unwrap_or(false),
+        PolicyExpr::SessionIsNotNull { path } => {
+            matches!(resolve_session_value(path, session), Some(value) if !value.is_null())
+        }
         PolicyExpr::Contains { column, value } => {
             evaluate_contains(column, value, content, descriptor, session)
+        }
+        PolicyExpr::SessionContains { path, value } => {
+            evaluate_session_contains(path, value, session)
         }
         PolicyExpr::In {
             column,
@@ -738,6 +831,9 @@ fn evaluate_expr_simple(
         } => evaluate_in(column, session_path, content, descriptor, session),
         PolicyExpr::InList { column, values } => {
             evaluate_in_list(column, values, content, descriptor, session)
+        }
+        PolicyExpr::SessionInList { path, values } => {
+            evaluate_session_in_list(path, values, session)
         }
         PolicyExpr::And(exprs) => exprs
             .iter()
@@ -824,6 +920,58 @@ pub fn evaluate_cmp(
     }
 }
 
+fn evaluate_session_cmp(path: &[String], op: &CmpOp, value: &Value, session: &Session) -> bool {
+    let Some(session_value) = resolve_session_value(path, session) else {
+        return false;
+    };
+    compare_values(&session_value, op, value)
+}
+
+fn compare_values(left: &Value, op: &CmpOp, right: &Value) -> bool {
+    match op {
+        CmpOp::Eq => left == right,
+        CmpOp::Ne => left != right,
+        CmpOp::Lt => compare_values_for_ordering(left, right)
+            .map(|ordering| ordering == std::cmp::Ordering::Less)
+            .unwrap_or(false),
+        CmpOp::Le => compare_values_for_ordering(left, right)
+            .map(|ordering| {
+                matches!(
+                    ordering,
+                    std::cmp::Ordering::Less | std::cmp::Ordering::Equal
+                )
+            })
+            .unwrap_or(false),
+        CmpOp::Gt => compare_values_for_ordering(left, right)
+            .map(|ordering| ordering == std::cmp::Ordering::Greater)
+            .unwrap_or(false),
+        CmpOp::Ge => compare_values_for_ordering(left, right)
+            .map(|ordering| {
+                matches!(
+                    ordering,
+                    std::cmp::Ordering::Greater | std::cmp::Ordering::Equal
+                )
+            })
+            .unwrap_or(false),
+    }
+}
+
+fn compare_values_for_ordering(left: &Value, right: &Value) -> Option<std::cmp::Ordering> {
+    match (left, right) {
+        (Value::Integer(a), Value::Integer(b)) => Some(a.cmp(b)),
+        (Value::BigInt(a), Value::BigInt(b)) => Some(a.cmp(b)),
+        (Value::Double(a), Value::Double(b)) => Some(a.total_cmp(b)),
+        (Value::Boolean(a), Value::Boolean(b)) => Some(a.cmp(b)),
+        (Value::Text(a), Value::Text(b)) => Some(a.cmp(b)),
+        (Value::Timestamp(a), Value::Timestamp(b)) => Some(a.cmp(b)),
+        (Value::Uuid(a), Value::Uuid(b)) => Some(a.cmp(b)),
+        (Value::Null, Value::Null) => Some(std::cmp::Ordering::Equal),
+        (Value::Null, _) => Some(std::cmp::Ordering::Less),
+        (_, Value::Null) => Some(std::cmp::Ordering::Greater),
+        _ => None,
+    }
+}
+
 fn resolve_policy_value(value: &PolicyValue, session: &Session) -> Option<Value> {
     match value {
         PolicyValue::Literal(v) => Some(v.clone()),
@@ -890,12 +1038,23 @@ pub fn bind_outer_row_refs(
                 value: bound_value,
             })
         }
+        PolicyExpr::SessionCmp { path, op, value } => Some(PolicyExpr::SessionCmp {
+            path: path.clone(),
+            op: op.clone(),
+            value: value.clone(),
+        }),
         PolicyExpr::IsNull { column } => Some(PolicyExpr::IsNull {
             column: column.clone(),
         }),
+        PolicyExpr::SessionIsNull { path } => {
+            Some(PolicyExpr::SessionIsNull { path: path.clone() })
+        }
         PolicyExpr::IsNotNull { column } => Some(PolicyExpr::IsNotNull {
             column: column.clone(),
         }),
+        PolicyExpr::SessionIsNotNull { path } => {
+            Some(PolicyExpr::SessionIsNotNull { path: path.clone() })
+        }
         PolicyExpr::Contains { column, value } => {
             let bound_value = match value {
                 PolicyValue::Literal(v) => PolicyValue::Literal(v.clone()),
@@ -918,6 +1077,10 @@ pub fn bind_outer_row_refs(
                 value: bound_value,
             })
         }
+        PolicyExpr::SessionContains { path, value } => Some(PolicyExpr::SessionContains {
+            path: path.clone(),
+            value: value.clone(),
+        }),
         PolicyExpr::In {
             column,
             session_path,
@@ -955,6 +1118,10 @@ pub fn bind_outer_row_refs(
                 values: bound_values,
             })
         }
+        PolicyExpr::SessionInList { path, values } => Some(PolicyExpr::SessionInList {
+            path: path.clone(),
+            values: values.clone(),
+        }),
         PolicyExpr::Exists { table, condition } => Some(PolicyExpr::Exists {
             table: table.clone(),
             // Keep nested EXISTS conditions unbound at this level so they can be
@@ -1368,19 +1535,31 @@ pub fn evaluate_in_list(
     })
 }
 
+fn evaluate_session_in_list(path: &[String], values: &[Value], session: &Session) -> bool {
+    let Some(session_value) = resolve_session_value(path, session) else {
+        return false;
+    };
+
+    values.iter().any(|candidate| candidate == &session_value)
+}
+
 /// Resolve a session path to a Value. Public for use by PolicyFilterNode.
 pub fn resolve_session_value(path: &[String], session: &Session) -> Option<Value> {
     if path.is_empty() {
         return None;
     }
 
-    if path[0] == "user_id" && path.len() == 1 {
+    if is_user_id_path(path) {
         return Some(Value::Text(session.user_id.clone()));
     }
 
     // For claims paths, convert JSON to Value
     let json_value = session.get_path(path)?;
     json_to_value(json_value)
+}
+
+fn is_user_id_path(path: &[String]) -> bool {
+    matches!(path, [segment] if segment == "user_id" || segment == "userId")
 }
 
 fn json_to_value(json: &serde_json::Value) -> Option<Value> {
@@ -1400,6 +1579,26 @@ fn json_to_value(json: &serde_json::Value) -> Option<Value> {
         serde_json::Value::Bool(b) => Some(Value::Boolean(*b)),
         serde_json::Value::Null => Some(Value::Null),
         _ => None,
+    }
+}
+
+fn evaluate_session_contains(path: &[String], value: &Value, session: &Session) -> bool {
+    if let Some(text) = session.get_string(path) {
+        return matches!(value, Value::Text(substr) if text.contains(substr));
+    }
+
+    let Some(json_value) = session.get_path(path) else {
+        return false;
+    };
+
+    match json_value {
+        serde_json::Value::Array(values) => values
+            .iter()
+            .any(|entry| json_to_value(entry).is_some_and(|candidate| candidate == *value)),
+        serde_json::Value::String(text) => {
+            matches!(value, Value::Text(substr) if text.contains(substr))
+        }
+        _ => false,
     }
 }
 
@@ -1510,6 +1709,13 @@ fn evaluate_simple_recursive(
                 SimpleEvalResult::fail()
             }
         }
+        PolicyExpr::SessionCmp { path, op, value } => {
+            if evaluate_session_cmp(path, op, value, session) {
+                SimpleEvalResult::pass()
+            } else {
+                SimpleEvalResult::fail()
+            }
+        }
 
         PolicyExpr::IsNull { column } => {
             let result = descriptor
@@ -1517,6 +1723,13 @@ fn evaluate_simple_recursive(
                 .map(|i| column_is_null(descriptor, content, i).unwrap_or(false))
                 .unwrap_or(false);
             if result {
+                SimpleEvalResult::pass()
+            } else {
+                SimpleEvalResult::fail()
+            }
+        }
+        PolicyExpr::SessionIsNull { path } => {
+            if matches!(resolve_session_value(path, session), Some(Value::Null)) {
                 SimpleEvalResult::pass()
             } else {
                 SimpleEvalResult::fail()
@@ -1534,9 +1747,23 @@ fn evaluate_simple_recursive(
                 SimpleEvalResult::fail()
             }
         }
+        PolicyExpr::SessionIsNotNull { path } => {
+            if matches!(resolve_session_value(path, session), Some(value) if !value.is_null()) {
+                SimpleEvalResult::pass()
+            } else {
+                SimpleEvalResult::fail()
+            }
+        }
 
         PolicyExpr::Contains { column, value } => {
             if evaluate_contains(column, value, content, descriptor, session) {
+                SimpleEvalResult::pass()
+            } else {
+                SimpleEvalResult::fail()
+            }
+        }
+        PolicyExpr::SessionContains { path, value } => {
+            if evaluate_session_contains(path, value, session) {
                 SimpleEvalResult::pass()
             } else {
                 SimpleEvalResult::fail()
@@ -1548,6 +1775,13 @@ fn evaluate_simple_recursive(
             session_path,
         } => {
             if evaluate_in(column, session_path, content, descriptor, session) {
+                SimpleEvalResult::pass()
+            } else {
+                SimpleEvalResult::fail()
+            }
+        }
+        PolicyExpr::SessionInList { path, values } => {
+            if evaluate_session_in_list(path, values, session) {
                 SimpleEvalResult::pass()
             } else {
                 SimpleEvalResult::fail()
@@ -1675,6 +1909,7 @@ fn evaluate_simple_recursive(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
 
     #[test]
     fn test_policy_expr_builders() {
@@ -2110,6 +2345,147 @@ mod tests {
     }
 
     #[test]
+    fn test_session_left_scalar_comparisons_and_identity_aliases() {
+        let desc = test_descriptor();
+        let content = make_row_content("user1", "eng", "active");
+        let session = Session::new("user1").with_claims(json!({
+            "role": "manager",
+            "login_count": 7,
+            "beta": true,
+        }));
+
+        assert!(evaluate_policy_expr(
+            &PolicyExpr::SessionCmp {
+                path: vec!["claims".into(), "role".into()],
+                op: CmpOp::Eq,
+                value: Value::Text("manager".into()),
+            },
+            &content,
+            &desc,
+            &session,
+        ));
+        assert!(evaluate_policy_expr(
+            &PolicyExpr::SessionCmp {
+                path: vec!["claims".into(), "login_count".into()],
+                op: CmpOp::Gt,
+                value: Value::Integer(3),
+            },
+            &content,
+            &desc,
+            &session,
+        ));
+        assert!(evaluate_policy_expr(
+            &PolicyExpr::SessionCmp {
+                path: vec!["claims".into(), "beta".into()],
+                op: CmpOp::Eq,
+                value: Value::Boolean(true),
+            },
+            &content,
+            &desc,
+            &session,
+        ));
+        assert!(evaluate_policy_expr(
+            &PolicyExpr::SessionCmp {
+                path: vec!["user_id".into()],
+                op: CmpOp::Eq,
+                value: Value::Text("user1".into()),
+            },
+            &content,
+            &desc,
+            &session,
+        ));
+        assert!(evaluate_policy_expr(
+            &PolicyExpr::SessionCmp {
+                path: vec!["userId".into()],
+                op: CmpOp::Eq,
+                value: Value::Text("user1".into()),
+            },
+            &content,
+            &desc,
+            &session,
+        ));
+        assert!(!evaluate_policy_expr(
+            &PolicyExpr::SessionCmp {
+                path: vec!["claims".into(), "role".into()],
+                op: CmpOp::Eq,
+                value: Value::Text("viewer".into()),
+            },
+            &content,
+            &desc,
+            &session,
+        ));
+    }
+
+    #[test]
+    fn test_session_left_in_list_contains_and_null_semantics() {
+        let desc = test_descriptor();
+        let content = make_row_content("user1", "eng", "active");
+        let session = Session::new("user1").with_claims(json!({
+            "plan": "pro",
+            "teamIds": ["team_a", "team_b"],
+            "bio": "manager for the platform team",
+            "deleted_at": null,
+        }));
+
+        assert!(evaluate_policy_expr(
+            &PolicyExpr::SessionInList {
+                path: vec!["claims".into(), "plan".into()],
+                values: vec![
+                    Value::Text("free".into()),
+                    Value::Text("pro".into()),
+                    Value::Text("enterprise".into()),
+                ],
+            },
+            &content,
+            &desc,
+            &session,
+        ));
+        assert!(evaluate_policy_expr(
+            &PolicyExpr::SessionContains {
+                path: vec!["claims".into(), "teamIds".into()],
+                value: Value::Text("team_a".into()),
+            },
+            &content,
+            &desc,
+            &session,
+        ));
+        assert!(evaluate_policy_expr(
+            &PolicyExpr::SessionContains {
+                path: vec!["claims".into(), "bio".into()],
+                value: Value::Text("platform".into()),
+            },
+            &content,
+            &desc,
+            &session,
+        ));
+        assert!(evaluate_policy_expr(
+            &PolicyExpr::SessionIsNull {
+                path: vec!["claims".into(), "deleted_at".into()],
+            },
+            &content,
+            &desc,
+            &session,
+        ));
+        assert!(!evaluate_policy_expr(
+            &PolicyExpr::SessionIsNull {
+                path: vec!["claims".into(), "missing".into()],
+            },
+            &content,
+            &desc,
+            &session,
+        ));
+        assert!(!evaluate_policy_expr(
+            &PolicyExpr::SessionContains {
+                path: vec!["claims".into(), "teamIds".into()],
+                value: Value::Text("team_c".into()),
+            },
+            &content,
+            &desc,
+            &session,
+        ));
+    }
+
+    #[test]
     fn test_exists_outer_row_refs_bind_for_contains_and_in_list() {
         let descriptor = RowDescriptor::new(vec![
             ColumnDescriptor::new("id", ColumnType::Text),
@@ -2194,6 +2570,36 @@ mod tests {
         ]);
         let result = evaluate_simple_parts(&expr, &content, &desc, &session);
         assert!(!result.passed);
+    }
+
+    #[test]
+    fn test_simple_parts_treats_session_left_predicates_as_simple_clauses() {
+        let desc = test_descriptor();
+        let content = make_row_content("user1", "eng", "active");
+        let session = Session::new("user1").with_claims(json!({
+            "role": "manager",
+        }));
+
+        let expr = PolicyExpr::And(vec![
+            PolicyExpr::eq_session("owner_id", vec!["user_id".into()]),
+            PolicyExpr::SessionCmp {
+                path: vec!["claims".into(), "role".into()],
+                op: CmpOp::Eq,
+                value: Value::Text("manager".into()),
+            },
+        ]);
+        let result = evaluate_simple_parts(&expr, &content, &desc, &session);
+        assert!(result.passed);
+        assert!(result.complex_clauses.is_empty());
+
+        let denied = evaluate_simple_parts(
+            &expr,
+            &make_row_content("user2", "eng", "active"),
+            &desc,
+            &session,
+        );
+        assert!(!denied.passed);
+        assert!(denied.complex_clauses.is_empty());
     }
 
     #[test]

--- a/crates/jazz-tools/src/query_manager/policy.rs
+++ b/crates/jazz-tools/src/query_manager/policy.rs
@@ -1539,6 +1539,9 @@ fn evaluate_session_in_list(path: &[String], values: &[Value], session: &Session
     let Some(session_value) = resolve_session_value(path, session) else {
         return false;
     };
+    if matches!(session_value, Value::Null) {
+        return false;
+    }
 
     values.iter().any(|candidate| candidate == &session_value)
 }
@@ -2461,6 +2464,15 @@ mod tests {
         assert!(evaluate_policy_expr(
             &PolicyExpr::SessionIsNull {
                 path: vec!["claims".into(), "deleted_at".into()],
+            },
+            &content,
+            &desc,
+            &session,
+        ));
+        assert!(!evaluate_policy_expr(
+            &PolicyExpr::SessionInList {
+                path: vec!["claims".into(), "deleted_at".into()],
+                values: vec![Value::Null, Value::Text("fallback".into())],
             },
             &content,
             &desc,

--- a/crates/jazz-tools/src/query_manager/session.rs
+++ b/crates/jazz-tools/src/query_manager/session.rs
@@ -20,6 +20,10 @@ pub struct Session {
 }
 
 impl Session {
+    fn is_user_id_path(path: &[String]) -> bool {
+        matches!(path, [segment] if segment == "user_id" || segment == "userId")
+    }
+
     /// Create a new session with just a user ID.
     pub fn new(user_id: impl Into<String>) -> Self {
         Self {
@@ -45,7 +49,7 @@ impl Session {
             return None;
         }
 
-        if path[0] == "user_id" {
+        if Self::is_user_id_path(path) {
             // Special case: user_id is stored as a String, not JsonValue
             // Return None here; use get_user_id() instead
             return None;
@@ -84,7 +88,7 @@ impl Session {
         if path.is_empty() {
             return false;
         }
-        if path[0] == "user_id" && path.len() == 1 {
+        if Self::is_user_id_path(path) {
             return true;
         }
         self.get_path(path).is_some()
@@ -98,7 +102,7 @@ impl Session {
         if path.is_empty() {
             return None;
         }
-        if path[0] == "user_id" && path.len() == 1 {
+        if Self::is_user_id_path(path) {
             return Some(&self.user_id);
         }
         self.get_path(path).and_then(|v| v.as_str())
@@ -122,7 +126,9 @@ mod tests {
         let session = Session::new("user123");
         assert_eq!(session.get_user_id(), "user123");
         assert_eq!(session.get_string(&["user_id".into()]), Some("user123"));
+        assert_eq!(session.get_string(&["userId".into()]), Some("user123"));
         assert!(session.has_path(&["user_id".into()]));
+        assert!(session.has_path(&["userId".into()]));
     }
 
     #[test]

--- a/crates/jazz-tools/src/query_manager/types/branch.rs
+++ b/crates/jazz-tools/src/query_manager/types/branch.rs
@@ -139,15 +139,45 @@ fn hash_policy_expr(hasher: &mut blake3::Hasher, expr: &PolicyExpr) {
                 }
             }
         }
+        PolicyExpr::SessionCmp { path, op, value } => {
+            hasher.update(&[16]);
+            for part in path {
+                hasher.update(part.as_bytes());
+                hasher.update(&[0]);
+            }
+            match op {
+                CmpOp::Eq => hasher.update(&[1]),
+                CmpOp::Ne => hasher.update(&[2]),
+                CmpOp::Lt => hasher.update(&[3]),
+                CmpOp::Le => hasher.update(&[4]),
+                CmpOp::Gt => hasher.update(&[5]),
+                CmpOp::Ge => hasher.update(&[6]),
+            };
+            hash_value(hasher, value);
+        }
         PolicyExpr::IsNull { column } => {
             hasher.update(&[2]);
             hasher.update(column.as_bytes());
             hasher.update(&[0]);
         }
+        PolicyExpr::SessionIsNull { path } => {
+            hasher.update(&[17]);
+            for part in path {
+                hasher.update(part.as_bytes());
+                hasher.update(&[0]);
+            }
+        }
         PolicyExpr::IsNotNull { column } => {
             hasher.update(&[3]);
             hasher.update(column.as_bytes());
             hasher.update(&[0]);
+        }
+        PolicyExpr::SessionIsNotNull { path } => {
+            hasher.update(&[18]);
+            for part in path {
+                hasher.update(part.as_bytes());
+                hasher.update(&[0]);
+            }
         }
         PolicyExpr::Contains { column, value } => {
             hasher.update(&[14]);
@@ -166,6 +196,14 @@ fn hash_policy_expr(hasher: &mut blake3::Hasher, expr: &PolicyExpr) {
                     }
                 }
             }
+        }
+        PolicyExpr::SessionContains { path, value } => {
+            hasher.update(&[19]);
+            for part in path {
+                hasher.update(part.as_bytes());
+                hasher.update(&[0]);
+            }
+            hash_value(hasher, value);
         }
         PolicyExpr::In {
             column,
@@ -198,6 +236,17 @@ fn hash_policy_expr(hasher: &mut blake3::Hasher, expr: &PolicyExpr) {
                         }
                     }
                 }
+            }
+        }
+        PolicyExpr::SessionInList { path, values } => {
+            hasher.update(&[20]);
+            for part in path {
+                hasher.update(part.as_bytes());
+                hasher.update(&[0]);
+            }
+            hasher.update(&(values.len() as u64).to_le_bytes());
+            for value in values {
+                hash_value(hasher, value);
             }
         }
         PolicyExpr::Exists { table, condition } => {

--- a/crates/jazz-tools/src/schema_manager/encoding.rs
+++ b/crates/jazz-tools/src/schema_manager/encoding.rs
@@ -637,6 +637,11 @@ const POLICY_EXPR_EXISTS_REL: u8 = 13;
 const POLICY_EXPR_INHERITS_REFERENCING: u8 = 14;
 const POLICY_EXPR_CONTAINS: u8 = 15;
 const POLICY_EXPR_IN_LIST: u8 = 16;
+const POLICY_EXPR_SESSION_CMP: u8 = 17;
+const POLICY_EXPR_SESSION_IS_NULL: u8 = 18;
+const POLICY_EXPR_SESSION_IS_NOT_NULL: u8 = 19;
+const POLICY_EXPR_SESSION_CONTAINS: u8 = 20;
+const POLICY_EXPR_SESSION_IN_LIST: u8 = 21;
 
 const POLICY_VALUE_LITERAL: u8 = 1;
 const POLICY_VALUE_SESSION_REF: u8 = 2;
@@ -708,18 +713,49 @@ fn encode_policy_expr(buf: &mut Vec<u8>, expr: &PolicyExpr) {
             encode_cmp_op(buf, op);
             encode_policy_value(buf, value);
         }
+        PolicyExpr::SessionCmp { path, op, value } => {
+            buf.push(POLICY_EXPR_SESSION_CMP);
+            write_u32(buf, path.len() as u32);
+            for part in path {
+                write_string(buf, part);
+            }
+            encode_cmp_op(buf, op);
+            encode_value(buf, value);
+        }
         PolicyExpr::IsNull { column } => {
             buf.push(POLICY_EXPR_IS_NULL);
             write_string(buf, column);
+        }
+        PolicyExpr::SessionIsNull { path } => {
+            buf.push(POLICY_EXPR_SESSION_IS_NULL);
+            write_u32(buf, path.len() as u32);
+            for part in path {
+                write_string(buf, part);
+            }
         }
         PolicyExpr::IsNotNull { column } => {
             buf.push(POLICY_EXPR_IS_NOT_NULL);
             write_string(buf, column);
         }
+        PolicyExpr::SessionIsNotNull { path } => {
+            buf.push(POLICY_EXPR_SESSION_IS_NOT_NULL);
+            write_u32(buf, path.len() as u32);
+            for part in path {
+                write_string(buf, part);
+            }
+        }
         PolicyExpr::Contains { column, value } => {
             buf.push(POLICY_EXPR_CONTAINS);
             write_string(buf, column);
             encode_policy_value(buf, value);
+        }
+        PolicyExpr::SessionContains { path, value } => {
+            buf.push(POLICY_EXPR_SESSION_CONTAINS);
+            write_u32(buf, path.len() as u32);
+            for part in path {
+                write_string(buf, part);
+            }
+            encode_value(buf, value);
         }
         PolicyExpr::In {
             column,
@@ -738,6 +774,17 @@ fn encode_policy_expr(buf: &mut Vec<u8>, expr: &PolicyExpr) {
             write_u32(buf, values.len() as u32);
             for value in values {
                 encode_policy_value(buf, value);
+            }
+        }
+        PolicyExpr::SessionInList { path, values } => {
+            buf.push(POLICY_EXPR_SESSION_IN_LIST);
+            write_u32(buf, path.len() as u32);
+            for part in path {
+                write_string(buf, part);
+            }
+            write_u32(buf, values.len() as u32);
+            for value in values {
+                encode_value(buf, value);
             }
         }
         PolicyExpr::Exists { table, condition } => {
@@ -820,18 +867,57 @@ fn decode_policy_expr(
             let value = decode_policy_value(data, offset)?;
             Ok(PolicyExpr::Cmp { column, op, value })
         }
+        POLICY_EXPR_SESSION_CMP => {
+            let count = read_u32(data, offset)? as usize;
+            let mut path = Vec::with_capacity(count);
+            for _ in 0..count {
+                path.push(read_string(data, offset, "policy_session_cmp_path")?);
+            }
+            let op = decode_cmp_op(data, offset)?;
+            let value = decode_value(data, offset)?;
+            Ok(PolicyExpr::SessionCmp { path, op, value })
+        }
         POLICY_EXPR_IS_NULL => {
             let column = read_string(data, offset, "policy_is_null_column")?;
             Ok(PolicyExpr::IsNull { column })
+        }
+        POLICY_EXPR_SESSION_IS_NULL => {
+            let count = read_u32(data, offset)? as usize;
+            let mut path = Vec::with_capacity(count);
+            for _ in 0..count {
+                path.push(read_string(data, offset, "policy_session_is_null_path")?);
+            }
+            Ok(PolicyExpr::SessionIsNull { path })
         }
         POLICY_EXPR_IS_NOT_NULL => {
             let column = read_string(data, offset, "policy_is_not_null_column")?;
             Ok(PolicyExpr::IsNotNull { column })
         }
+        POLICY_EXPR_SESSION_IS_NOT_NULL => {
+            let count = read_u32(data, offset)? as usize;
+            let mut path = Vec::with_capacity(count);
+            for _ in 0..count {
+                path.push(read_string(
+                    data,
+                    offset,
+                    "policy_session_is_not_null_path",
+                )?);
+            }
+            Ok(PolicyExpr::SessionIsNotNull { path })
+        }
         POLICY_EXPR_CONTAINS => {
             let column = read_string(data, offset, "policy_contains_column")?;
             let value = decode_policy_value(data, offset)?;
             Ok(PolicyExpr::Contains { column, value })
+        }
+        POLICY_EXPR_SESSION_CONTAINS => {
+            let count = read_u32(data, offset)? as usize;
+            let mut path = Vec::with_capacity(count);
+            for _ in 0..count {
+                path.push(read_string(data, offset, "policy_session_contains_path")?);
+            }
+            let value = decode_value(data, offset)?;
+            Ok(PolicyExpr::SessionContains { path, value })
         }
         POLICY_EXPR_IN => {
             let column = read_string(data, offset, "policy_in_column")?;
@@ -853,6 +939,19 @@ fn decode_policy_expr(
                 values.push(decode_policy_value(data, offset)?);
             }
             Ok(PolicyExpr::InList { column, values })
+        }
+        POLICY_EXPR_SESSION_IN_LIST => {
+            let path_count = read_u32(data, offset)? as usize;
+            let mut path = Vec::with_capacity(path_count);
+            for _ in 0..path_count {
+                path.push(read_string(data, offset, "policy_session_in_list_path")?);
+            }
+            let value_count = read_u32(data, offset)? as usize;
+            let mut values = Vec::with_capacity(value_count);
+            for _ in 0..value_count {
+                values.push(decode_value(data, offset)?);
+            }
+            Ok(PolicyExpr::SessionInList { path, values })
         }
         POLICY_EXPR_EXISTS => {
             let table = read_string(data, offset, "policy_exists_table")?;
@@ -1577,6 +1676,55 @@ mod tests {
                         ]
             )
         ));
+    }
+
+    #[test]
+    fn schema_roundtrip_with_session_left_policy() {
+        let expected = PolicyExpr::And(vec![
+            PolicyExpr::SessionCmp {
+                path: vec!["claims".to_string(), "role".to_string()],
+                op: CmpOp::Eq,
+                value: Value::Text("manager".to_string()),
+            },
+            PolicyExpr::SessionInList {
+                path: vec!["claims".to_string(), "plan".to_string()],
+                values: vec![
+                    Value::Text("pro".to_string()),
+                    Value::Text("enterprise".to_string()),
+                ],
+            },
+            PolicyExpr::SessionContains {
+                path: vec!["claims".to_string(), "teamIds".to_string()],
+                value: Value::Text("team_a".to_string()),
+            },
+            PolicyExpr::SessionIsNull {
+                path: vec!["claims".to_string(), "deleted_at".to_string()],
+            },
+            PolicyExpr::SessionIsNotNull {
+                path: vec!["userId".to_string()],
+            },
+        ]);
+        let schema = SchemaBuilder::new()
+            .table(
+                TableSchema::builder("todos")
+                    .column("id", ColumnType::Uuid)
+                    .column("owner_id", ColumnType::Text)
+                    .policies(TablePolicies::new().with_select(expected.clone())),
+            )
+            .build();
+
+        let encoded = encode_schema(&schema);
+        let decoded = decode_schema(&encoded).expect("schema should decode");
+        let using = decoded
+            .get(&TableName::new("todos"))
+            .expect("todos table should exist")
+            .policies
+            .select
+            .using
+            .as_ref()
+            .expect("select policy should exist");
+
+        assert_eq!(using, &expected);
     }
 
     #[test]

--- a/crates/jazz-tools/src/schema_manager/sql.rs
+++ b/crates/jazz-tools/src/schema_manager/sql.rs
@@ -552,6 +552,16 @@ impl Parser {
         Ok(PolicyValue::Literal(self.parse_value()?))
     }
 
+    fn parse_policy_literal_value(&mut self) -> Result<Value, SqlParseError> {
+        if self.peek() == Some(&Token::At) {
+            return Err(SqlParseError::Expected(
+                "literal value, session references are not allowed here".to_string(),
+            ));
+        }
+
+        self.parse_value()
+    }
+
     fn parse_policy_in_list(&mut self) -> Result<Vec<PolicyValue>, SqlParseError> {
         self.expect(&Token::LParen)?;
         if self.peek() == Some(&Token::RParen) {
@@ -564,6 +574,24 @@ impl Parser {
         while self.peek() == Some(&Token::Comma) {
             self.advance();
             values.push(self.parse_policy_value()?);
+        }
+
+        self.expect(&Token::RParen)?;
+        Ok(values)
+    }
+
+    fn parse_policy_literal_in_list(&mut self) -> Result<Vec<Value>, SqlParseError> {
+        self.expect(&Token::LParen)?;
+        if self.peek() == Some(&Token::RParen) {
+            return Err(SqlParseError::Expected(
+                "at least one literal value in IN (...) policy list".to_string(),
+            ));
+        }
+
+        let mut values = vec![self.parse_policy_literal_value()?];
+        while self.peek() == Some(&Token::Comma) {
+            self.advance();
+            values.push(self.parse_policy_literal_value()?);
         }
 
         self.expect(&Token::RParen)?;
@@ -661,6 +689,90 @@ impl Parser {
                     table,
                     condition: Box::new(condition),
                 })
+            }
+            Some(Token::At) => {
+                let path = self.parse_session_path()?;
+
+                match self.peek() {
+                    Some(Token::Eq) => {
+                        self.advance();
+                        Ok(PolicyExpr::SessionCmp {
+                            path,
+                            op: CmpOp::Eq,
+                            value: self.parse_policy_literal_value()?,
+                        })
+                    }
+                    Some(Token::Ne) => {
+                        self.advance();
+                        Ok(PolicyExpr::SessionCmp {
+                            path,
+                            op: CmpOp::Ne,
+                            value: self.parse_policy_literal_value()?,
+                        })
+                    }
+                    Some(Token::Lt) => {
+                        self.advance();
+                        Ok(PolicyExpr::SessionCmp {
+                            path,
+                            op: CmpOp::Lt,
+                            value: self.parse_policy_literal_value()?,
+                        })
+                    }
+                    Some(Token::Le) => {
+                        self.advance();
+                        Ok(PolicyExpr::SessionCmp {
+                            path,
+                            op: CmpOp::Le,
+                            value: self.parse_policy_literal_value()?,
+                        })
+                    }
+                    Some(Token::Gt) => {
+                        self.advance();
+                        Ok(PolicyExpr::SessionCmp {
+                            path,
+                            op: CmpOp::Gt,
+                            value: self.parse_policy_literal_value()?,
+                        })
+                    }
+                    Some(Token::Ge) => {
+                        self.advance();
+                        Ok(PolicyExpr::SessionCmp {
+                            path,
+                            op: CmpOp::Ge,
+                            value: self.parse_policy_literal_value()?,
+                        })
+                    }
+                    Some(Token::Contains) => {
+                        self.advance();
+                        Ok(PolicyExpr::SessionContains {
+                            path,
+                            value: self.parse_policy_literal_value()?,
+                        })
+                    }
+                    Some(Token::In) => {
+                        self.advance();
+                        Ok(PolicyExpr::SessionInList {
+                            path,
+                            values: self.parse_policy_literal_in_list()?,
+                        })
+                    }
+                    Some(Token::Is) => {
+                        self.advance();
+                        if self.peek() == Some(&Token::Not) {
+                            self.advance();
+                            self.expect(&Token::Null)?;
+                            Ok(PolicyExpr::SessionIsNotNull { path })
+                        } else {
+                            self.expect(&Token::Null)?;
+                            Ok(PolicyExpr::SessionIsNull { path })
+                        }
+                    }
+                    Some(t) => Err(SqlParseError::Expected(format!(
+                        "policy operator after session path, got {:?}",
+                        t
+                    ))),
+                    None => Err(SqlParseError::UnexpectedEnd),
+                }
             }
             Some(Token::Ident(_)) => {
                 let column = self.expect_ident()?;
@@ -1147,11 +1259,16 @@ pub fn parse_schema(sql: &str) -> Result<Schema, SqlParseError> {
                 Ok(())
             }
             PolicyExpr::Not(inner) => validate_policy_expr_for_bytea(descriptor, inner),
-            PolicyExpr::IsNull { .. }
+            PolicyExpr::SessionCmp { .. }
+            | PolicyExpr::IsNull { .. }
+            | PolicyExpr::SessionIsNull { .. }
             | PolicyExpr::IsNotNull { .. }
+            | PolicyExpr::SessionIsNotNull { .. }
             | PolicyExpr::Contains { .. }
+            | PolicyExpr::SessionContains { .. }
             | PolicyExpr::In { .. }
             | PolicyExpr::InList { .. }
+            | PolicyExpr::SessionInList { .. }
             | PolicyExpr::Exists { .. }
             | PolicyExpr::ExistsRel { .. }
             | PolicyExpr::Inherits { .. }
@@ -1437,13 +1554,34 @@ fn policy_expr_to_sql(expr: &PolicyExpr) -> String {
                 policy_value_to_sql(value)
             )
         }
+        PolicyExpr::SessionCmp { path, op, value } => {
+            format!(
+                "@session.{} {} {}",
+                session_path_to_sql(path),
+                cmp_op_to_sql(op),
+                value_to_sql(value)
+            )
+        }
         PolicyExpr::IsNull { column } => format!("{} IS NULL", quote_identifier(column)),
+        PolicyExpr::SessionIsNull { path } => {
+            format!("@session.{} IS NULL", session_path_to_sql(path))
+        }
         PolicyExpr::IsNotNull { column } => format!("{} IS NOT NULL", quote_identifier(column)),
+        PolicyExpr::SessionIsNotNull { path } => {
+            format!("@session.{} IS NOT NULL", session_path_to_sql(path))
+        }
         PolicyExpr::Contains { column, value } => {
             format!(
                 "{} CONTAINS {}",
                 quote_identifier(column),
                 policy_value_to_sql(value)
+            )
+        }
+        PolicyExpr::SessionContains { path, value } => {
+            format!(
+                "@session.{} CONTAINS {}",
+                session_path_to_sql(path),
+                value_to_sql(value)
             )
         }
         PolicyExpr::In {
@@ -1460,6 +1598,15 @@ fn policy_expr_to_sql(expr: &PolicyExpr) -> String {
             values
                 .iter()
                 .map(policy_value_to_sql)
+                .collect::<Vec<_>>()
+                .join(", ")
+        ),
+        PolicyExpr::SessionInList { path, values } => format!(
+            "@session.{} IN ({})",
+            session_path_to_sql(path),
+            values
+                .iter()
+                .map(value_to_sql)
                 .collect::<Vec<_>>()
                 .join(", ")
         ),
@@ -1926,6 +2073,86 @@ mod tests {
                             PolicyValue::SessionRef(vec!["user_id".into()])
                         ]
         ));
+    }
+
+    const SESSION_LEFT_POLICY_SQL: &str = r#"
+        CREATE TABLE todos (
+            owner_id TEXT NOT NULL
+        );
+
+        CREATE POLICY todos_select_policy ON todos FOR SELECT
+            USING (
+                (@session.claims.role = 'manager')
+                AND (@session.claims.plan IN ('pro', 'enterprise'))
+                AND (@session.claims.teamIds CONTAINS 'team_a')
+                AND (@session.claims.deleted_at IS NULL)
+                AND (@session.userId IS NOT NULL)
+            );
+    "#;
+
+    #[test]
+    fn parse_create_policy_with_session_left_predicates() {
+        let schema = parse_schema(SESSION_LEFT_POLICY_SQL).unwrap();
+        let using = schema
+            .get(&TableName::new("todos"))
+            .unwrap()
+            .policies
+            .select
+            .using
+            .as_ref()
+            .expect("missing select policy");
+
+        assert_eq!(
+            using,
+            &PolicyExpr::And(vec![
+                PolicyExpr::SessionCmp {
+                    path: vec!["claims".into(), "role".into()],
+                    op: CmpOp::Eq,
+                    value: Value::Text("manager".into()),
+                },
+                PolicyExpr::SessionInList {
+                    path: vec!["claims".into(), "plan".into()],
+                    values: vec![Value::Text("pro".into()), Value::Text("enterprise".into())],
+                },
+                PolicyExpr::SessionContains {
+                    path: vec!["claims".into(), "teamIds".into()],
+                    value: Value::Text("team_a".into()),
+                },
+                PolicyExpr::SessionIsNull {
+                    path: vec!["claims".into(), "deleted_at".into()],
+                },
+                PolicyExpr::SessionIsNotNull {
+                    path: vec!["userId".into()],
+                },
+            ])
+        );
+    }
+
+    #[test]
+    fn policy_expr_to_sql_formats_session_left_predicates() {
+        let expr = PolicyExpr::And(vec![
+            PolicyExpr::SessionCmp {
+                path: vec!["claims".into(), "role".into()],
+                op: CmpOp::Eq,
+                value: Value::Text("manager".into()),
+            },
+            PolicyExpr::SessionInList {
+                path: vec!["claims".into(), "plan".into()],
+                values: vec![Value::Text("pro".into()), Value::Text("enterprise".into())],
+            },
+            PolicyExpr::SessionContains {
+                path: vec!["claims".into(), "teamIds".into()],
+                value: Value::Text("team_a".into()),
+            },
+            PolicyExpr::SessionIsNull {
+                path: vec!["claims".into(), "deleted_at".into()],
+            },
+        ]);
+
+        assert_eq!(
+            policy_expr_to_sql(&expr),
+            "(@session.claims.role = 'manager') AND (@session.claims.plan IN ('pro', 'enterprise')) AND (@session.claims.teamIds CONTAINS 'team_a') AND (@session.claims.deleted_at IS NULL)"
+        );
     }
 
     #[test]
@@ -2908,5 +3135,35 @@ mod tests {
             .unwrap();
 
         assert_eq!(original_using, reparsed_using);
+    }
+
+    #[test]
+    fn policy_session_left_round_trip() {
+        let schema = parse_schema(SESSION_LEFT_POLICY_SQL).unwrap();
+        let regenerated = schema_to_sql(&schema);
+        let reparsed = parse_schema(&regenerated).unwrap();
+
+        let original_using = schema
+            .get(&TableName::new("todos"))
+            .unwrap()
+            .policies
+            .select
+            .using
+            .as_ref()
+            .unwrap();
+        let reparsed_using = reparsed
+            .get(&TableName::new("todos"))
+            .unwrap()
+            .policies
+            .select
+            .using
+            .as_ref()
+            .unwrap();
+
+        assert_eq!(original_using, reparsed_using);
+        assert!(regenerated.contains("@session.claims.role = 'manager'"));
+        assert!(regenerated.contains("@session.claims.plan IN ('pro', 'enterprise')"));
+        assert!(regenerated.contains("@session.claims.teamIds CONTAINS 'team_a'"));
+        assert!(regenerated.contains("@session.claims.deleted_at IS NULL"));
     }
 }

--- a/docs/content/docs/permissions.mdx
+++ b/docs/content/docs/permissions.mdx
@@ -63,6 +63,14 @@ Apps that do not need user-scoped filtering can still define explicit allow-all 
 
 `allOf([...])` compiles to logical `AND`, and `anyOf([...])` compiles to logical `OR`.
 
+## JWT Session Claims
+
+When external auth JWTs carry claims, `session.where(...)` lets you check them directly in permissions without mapping them onto row columns first.
+
+<include cwd lang="ts">
+  ../examples/docs/todo-server-ts/src/permissions-snippets.ts#permissions-session-claims-ts
+</include>
+
 ## Inherited Access Policies (`allowedTo.*`)
 
 TypeScript DSL exposes inherited access via `allowedTo.read/insert/update/delete(...)`, which compiles to `INHERITS` policy expressions.

--- a/examples/docs/todo-server-ts/src/permissions-snippets.ts
+++ b/examples/docs/todo-server-ts/src/permissions-snippets.ts
@@ -50,6 +50,14 @@ definePermissions(app, ({ policy, allOf, anyOf, allowedTo, session }) => {
 });
 // #endregion permissions-combinators-ts
 
+// #region permissions-session-claims-ts
+definePermissions(app, ({ policy, anyOf, session }) => {
+  policy.todos.allowRead.where(
+    anyOf([{ owner_id: session.user_id }, session.where({ "claims.role": "manager" })]),
+  );
+});
+// #endregion permissions-session-claims-ts
+
 // #region permissions-recursive-inherits-ts
 definePermissions(app, ({ policy, allowedTo }) => {
   policy.todos.allowRead.where(allowedTo.read("parent"));

--- a/packages/jazz-tools/src/codegen/codegen.test.ts
+++ b/packages/jazz-tools/src/codegen/codegen.test.ts
@@ -324,6 +324,65 @@ describe("schemaToWasm", () => {
       delete: {},
     });
   });
+
+  it("carries session-left policies into wasm schema", () => {
+    table("todos", { owner_id: col.string() });
+    const schema = getCollectedSchema();
+    schema.tables[0]!.policies = {
+      select: {
+        using: {
+          type: "And",
+          exprs: [
+            {
+              type: "SessionCmp",
+              path: ["claims", "role"],
+              op: "Eq",
+              value: { type: "Literal", value: "manager" },
+            },
+            {
+              type: "SessionContains",
+              path: ["claims", "teamIds"],
+              value: { type: "Literal", value: "team_a" },
+            },
+            {
+              type: "SessionInList",
+              path: ["claims", "plan"],
+              values: [
+                { type: "Literal", value: "pro" },
+                { type: "Literal", value: "enterprise" },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const wasm = schemaToWasm(schema);
+    expect(wasm.todos.policies?.select?.using).toEqual({
+      type: "And",
+      exprs: [
+        {
+          type: "SessionCmp",
+          path: ["claims", "role"],
+          op: "Eq",
+          value: { type: "Literal", value: { type: "Text", value: "manager" } },
+        },
+        {
+          type: "SessionContains",
+          path: ["claims", "teamIds"],
+          value: { type: "Literal", value: { type: "Text", value: "team_a" } },
+        },
+        {
+          type: "SessionInList",
+          path: ["claims", "plan"],
+          values: [
+            { type: "Literal", value: { type: "Text", value: "pro" } },
+            { type: "Literal", value: { type: "Text", value: "enterprise" } },
+          ],
+        },
+      ],
+    });
+  });
 });
 
 describe("generateTypes", () => {

--- a/packages/jazz-tools/src/codegen/codegen.test.ts
+++ b/packages/jazz-tools/src/codegen/codegen.test.ts
@@ -365,19 +365,19 @@ describe("schemaToWasm", () => {
           type: "SessionCmp",
           path: ["claims", "role"],
           op: "Eq",
-          value: { type: "Literal", value: { type: "Text", value: "manager" } },
+          value: { type: "Text", value: "manager" },
         },
         {
           type: "SessionContains",
           path: ["claims", "teamIds"],
-          value: { type: "Literal", value: { type: "Text", value: "team_a" } },
+          value: { type: "Text", value: "team_a" },
         },
         {
           type: "SessionInList",
           path: ["claims", "plan"],
           values: [
-            { type: "Literal", value: { type: "Text", value: "pro" } },
-            { type: "Literal", value: { type: "Text", value: "enterprise" } },
+            { type: "Text", value: "pro" },
+            { type: "Text", value: "enterprise" },
           ],
         },
       ],

--- a/packages/jazz-tools/src/codegen/schema-reader.ts
+++ b/packages/jazz-tools/src/codegen/schema-reader.ts
@@ -92,7 +92,7 @@ function clonePolicyValue(value: DslPolicyValue): PolicyValue {
 }
 
 function clonePolicyLiteralValue(value: DslPolicyLiteralValue): PolicyLiteralValue {
-  return { type: "Literal", value: literalToWasmValue(value.value) };
+  return literalToWasmValue(value.value);
 }
 
 function clonePolicyExpr(expr: DslPolicyExpr): PolicyExpr {

--- a/packages/jazz-tools/src/codegen/schema-reader.ts
+++ b/packages/jazz-tools/src/codegen/schema-reader.ts
@@ -98,14 +98,31 @@ function clonePolicyExpr(expr: DslPolicyExpr): PolicyExpr {
         op: expr.op,
         value: clonePolicyValue(expr.value),
       };
+    case "SessionCmp":
+      return {
+        type: "SessionCmp",
+        path: [...expr.path],
+        op: expr.op,
+        value: clonePolicyValue(expr.value),
+      };
     case "IsNull":
       return { type: "IsNull", column: expr.column };
+    case "SessionIsNull":
+      return { type: "SessionIsNull", path: [...expr.path] };
     case "IsNotNull":
       return { type: "IsNotNull", column: expr.column };
+    case "SessionIsNotNull":
+      return { type: "SessionIsNotNull", path: [...expr.path] };
     case "Contains":
       return {
         type: "Contains",
         column: expr.column,
+        value: clonePolicyValue(expr.value),
+      };
+    case "SessionContains":
+      return {
+        type: "SessionContains",
+        path: [...expr.path],
         value: clonePolicyValue(expr.value),
       };
     case "In":
@@ -118,6 +135,12 @@ function clonePolicyExpr(expr: DslPolicyExpr): PolicyExpr {
       return {
         type: "InList",
         column: expr.column,
+        values: expr.values.map(clonePolicyValue),
+      };
+    case "SessionInList":
+      return {
+        type: "SessionInList",
+        path: [...expr.path],
         values: expr.values.map(clonePolicyValue),
       };
     case "Exists":

--- a/packages/jazz-tools/src/codegen/schema-reader.ts
+++ b/packages/jazz-tools/src/codegen/schema-reader.ts
@@ -8,6 +8,7 @@ import type {
   SqlType,
   TablePolicies as DslTablePolicies,
   PolicyExpr as DslPolicyExpr,
+  PolicyLiteralValue as DslPolicyLiteralValue,
   PolicyValue as DslPolicyValue,
 } from "../schema.js";
 import type {
@@ -17,6 +18,7 @@ import type {
   TableSchema,
   TablePolicies,
   PolicyExpr,
+  PolicyLiteralValue,
   PolicyValue,
   Value,
 } from "../drivers/types.js";
@@ -89,6 +91,10 @@ function clonePolicyValue(value: DslPolicyValue): PolicyValue {
   return { type: "Literal", value: literalToWasmValue(value.value) };
 }
 
+function clonePolicyLiteralValue(value: DslPolicyLiteralValue): PolicyLiteralValue {
+  return { type: "Literal", value: literalToWasmValue(value.value) };
+}
+
 function clonePolicyExpr(expr: DslPolicyExpr): PolicyExpr {
   switch (expr.type) {
     case "Cmp":
@@ -103,7 +109,7 @@ function clonePolicyExpr(expr: DslPolicyExpr): PolicyExpr {
         type: "SessionCmp",
         path: [...expr.path],
         op: expr.op,
-        value: clonePolicyValue(expr.value),
+        value: clonePolicyLiteralValue(expr.value),
       };
     case "IsNull":
       return { type: "IsNull", column: expr.column };
@@ -123,7 +129,7 @@ function clonePolicyExpr(expr: DslPolicyExpr): PolicyExpr {
       return {
         type: "SessionContains",
         path: [...expr.path],
-        value: clonePolicyValue(expr.value),
+        value: clonePolicyLiteralValue(expr.value),
       };
     case "In":
       return {
@@ -141,7 +147,7 @@ function clonePolicyExpr(expr: DslPolicyExpr): PolicyExpr {
       return {
         type: "SessionInList",
         path: [...expr.path],
-        values: expr.values.map(clonePolicyValue),
+        values: expr.values.map(clonePolicyLiteralValue),
       };
     case "Exists":
       return {

--- a/packages/jazz-tools/src/drivers/types.ts
+++ b/packages/jazz-tools/src/drivers/types.ts
@@ -79,13 +79,20 @@ export type PolicyValue =
   | { type: "Literal"; value: Value }
   | { type: "SessionRef"; path: string[] };
 
+export type PolicyLiteralValue = Extract<PolicyValue, { type: "Literal" }>;
+
 export type PolicyExpr =
   | { type: "Cmp"; column: string; op: PolicyCmpOp; value: PolicyValue }
+  | { type: "SessionCmp"; path: string[]; op: PolicyCmpOp; value: PolicyLiteralValue }
   | { type: "IsNull"; column: string }
+  | { type: "SessionIsNull"; path: string[] }
   | { type: "IsNotNull"; column: string }
+  | { type: "SessionIsNotNull"; path: string[] }
   | { type: "Contains"; column: string; value: PolicyValue }
+  | { type: "SessionContains"; path: string[]; value: PolicyLiteralValue }
   | { type: "In"; column: string; session_path: string[] }
   | { type: "InList"; column: string; values: PolicyValue[] }
+  | { type: "SessionInList"; path: string[]; values: PolicyLiteralValue[] }
   | { type: "Exists"; table: string; condition: PolicyExpr }
   | { type: "ExistsRel"; rel: unknown }
   | { type: "Inherits"; operation: PolicyOperation; via_column: string; max_depth?: number }

--- a/packages/jazz-tools/src/drivers/types.ts
+++ b/packages/jazz-tools/src/drivers/types.ts
@@ -79,7 +79,7 @@ export type PolicyValue =
   | { type: "Literal"; value: Value }
   | { type: "SessionRef"; path: string[] };
 
-export type PolicyLiteralValue = Extract<PolicyValue, { type: "Literal" }>;
+export type PolicyLiteralValue = Value;
 
 export type PolicyExpr =
   | { type: "Cmp"; column: string; op: PolicyCmpOp; value: PolicyValue }

--- a/packages/jazz-tools/src/permissions/index.test.ts
+++ b/packages/jazz-tools/src/permissions/index.test.ts
@@ -964,6 +964,124 @@ describe("permissions DSL", () => {
     expect(emptyInCompiled.todos.select?.using).toEqual({ type: "False" });
   });
 
+  it("compiles session.where(...) predicates and composes them with row predicates", () => {
+    const compiled = definePermissions(app, ({ policy, allOf, anyOf, session }) => [
+      policy.todos.allowRead.where(
+        allOf([
+          { ownerId: session.userId },
+          session.where({
+            "claims.role": "manager",
+            user_id: { ne: null },
+          }),
+        ]),
+      ),
+      policy.todos.allowRead.where(
+        anyOf([
+          session.where({ "claims.plan": { in: ["pro", "enterprise"] } }),
+          session.where({ "claims.teamIds": { contains: "team_a" } }),
+        ]),
+      ),
+    ]);
+
+    expect(compiled.todos.select?.using).toEqual({
+      type: "Or",
+      exprs: [
+        {
+          type: "And",
+          exprs: [
+            {
+              type: "Cmp",
+              column: "ownerId",
+              op: "Eq",
+              value: {
+                type: "SessionRef",
+                path: ["userId"],
+              },
+            },
+            {
+              type: "And",
+              exprs: [
+                {
+                  type: "SessionCmp",
+                  path: ["claims", "role"],
+                  op: "Eq",
+                  value: {
+                    type: "Literal",
+                    value: "manager",
+                  },
+                },
+                {
+                  type: "SessionIsNotNull",
+                  path: ["user_id"],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          type: "SessionInList",
+          path: ["claims", "plan"],
+          values: [
+            {
+              type: "Literal",
+              value: "pro",
+            },
+            {
+              type: "Literal",
+              value: "enterprise",
+            },
+          ],
+        },
+        {
+          type: "SessionContains",
+          path: ["claims", "teamIds"],
+          value: {
+            type: "Literal",
+            value: "team_a",
+          },
+        },
+      ],
+    });
+  });
+
+  it("rejects invalid session.where(...) value shapes", () => {
+    expect(() =>
+      definePermissions(app, ({ policy, session }) => [
+        policy.todos.allowRead.where(session.where({ "claims.role": session.userId })),
+      ]),
+    ).toThrow(/session references are not supported/i);
+
+    expect(() =>
+      definePermissions(app, ({ policy, session }) => [
+        policy.todos.allowRead.where((todo) => session.where({ "claims.role": todo.ownerId })),
+      ]),
+    ).toThrow(/row references are not supported/i);
+
+    expect(() =>
+      definePermissions(app, ({ policy, session }) => [
+        policy.todos.allowRead.where(session.where({ claims: { role: "manager" } })),
+      ]),
+    ).toThrow(/nested object claim syntax is not supported|dotted path keys/i);
+
+    expect(() =>
+      definePermissions(app, ({ policy, session }) => [
+        policy.todos.allowRead.where(
+          session.where({ "claims.plan": { in: "pro" } as unknown as Record<string, unknown> }),
+        ),
+      ]),
+    ).toThrow(/expects an array of literal values/i);
+
+    expect(() =>
+      definePermissions(app, ({ policy, session }) => [
+        policy.todos.allowRead.where(
+          session.where({
+            "claims.role": { startsWith: "man" } as unknown as Record<string, unknown>,
+          }),
+        ),
+      ]),
+    ).toThrow(/unsupported session\.where operator "startsWith"/i);
+  });
+
   it("rejects unsupported where operators and invalid compound combinator inputs", () => {
     expect(() =>
       definePermissions(app, ({ policy }) => [

--- a/packages/jazz-tools/src/permissions/index.ts
+++ b/packages/jazz-tools/src/permissions/index.ts
@@ -2,6 +2,7 @@ import type {
   OperationPolicy,
   PolicyCmpOp,
   PolicyExpr,
+  PolicyLiteralValue,
   PolicyValue,
   TablePolicies,
 } from "../schema.js";
@@ -51,6 +52,14 @@ interface SessionRefValue {
   readonly path: string[];
 }
 
+interface SessionWhereCondition {
+  readonly __jazzPermissionKind: "session-where";
+  readonly where: Record<string, unknown>;
+}
+
+type SessionWhereBuilder = SessionRefValue &
+  ((input: Record<string, unknown>) => SessionWhereCondition);
+
 interface RecursiveDepthOptions {
   maxDepth?: number;
 }
@@ -77,7 +86,12 @@ interface CompoundCondition {
   readonly conditions: Condition[];
 }
 
-type Condition = PolicyExpr | CompoundCondition | ExistsCondition | ExistsRelationCondition;
+type Condition =
+  | PolicyExpr
+  | CompoundCondition
+  | ExistsCondition
+  | ExistsRelationCondition
+  | SessionWhereCondition;
 
 interface RelationJoinSpec {
   table: string;
@@ -386,7 +400,11 @@ export type WhereInputOrCallback<WhereInput, Row> =
   | WhereInput
   | ((row: RowContext<Row>) => WhereInput | Condition);
 
-export type SessionContext = Record<string, SessionRefValue>;
+export type SessionContext = Record<string, SessionRefValue> & {
+  readonly user_id: SessionRefValue;
+  readonly userId: SessionRefValue;
+  where: SessionWhereBuilder;
+};
 
 export interface AllowedToContext {
   read(fkColumn: string, options?: RecursiveDepthOptions): PolicyExpr;
@@ -1127,9 +1145,16 @@ function createSessionContext(): SessionContext {
     __jazzPermissionKind: "session-ref",
     path: normalizeSessionPath(path),
   });
+  const whereBuilder = ((input: Record<string, unknown>): SessionWhereCondition => ({
+    __jazzPermissionKind: "session-where",
+    where: normalizeWhereObject(input),
+  })) as SessionWhereBuilder;
   return new Proxy({} as SessionContext, {
     get(_target, prop, _receiver) {
       if (typeof prop === "string") {
+        if (prop === "where") {
+          return whereBuilder;
+        }
         return claimRef(prop);
       }
       return undefined;
@@ -1261,6 +1286,9 @@ function resolveWhereInput(input: unknown): Condition {
     const result = input(createRowContext());
     return resolveWhereInput(result);
   }
+  if (isSessionWhereCondition(input)) {
+    return input;
+  }
   if (isExistsCondition(input)) {
     return input;
   }
@@ -1289,6 +1317,17 @@ function whereObjectToCondition(
       continue;
     }
     exprs.push(...columnFilterToExprs(column, raw, options));
+  }
+  return andExpr(exprs);
+}
+
+function sessionWhereObjectToCondition(where: Record<string, unknown>): PolicyExpr {
+  const exprs: PolicyExpr[] = [];
+  for (const [path, raw] of Object.entries(where)) {
+    if (raw === undefined) {
+      continue;
+    }
+    exprs.push(...sessionPathFilterToExprs(path, raw));
   }
   return andExpr(exprs);
 }
@@ -1387,6 +1426,101 @@ function columnFilterToExprs(
   return [cmpExpr(column, "Eq", raw, options)];
 }
 
+function sessionPathFilterToExprs(path: string, raw: unknown): PolicyExpr[] {
+  const sessionPath = normalizeSessionPath(path);
+  if (sessionPath.length === 0) {
+    throw new Error("session.where(...) requires non-empty session path keys.");
+  }
+
+  if (raw === null) {
+    return [{ type: "SessionIsNull", path: sessionPath }];
+  }
+  if (
+    !isPlainObject(raw) ||
+    isSessionRefValue(raw) ||
+    isRowRefValue(raw) ||
+    isRecursiveCurrentValue(raw) ||
+    isExistsCondition(raw) ||
+    isExistsRelationCondition(raw) ||
+    isCompoundCondition(raw) ||
+    isPolicyExpr(raw)
+  ) {
+    return [sessionCmpExpr(sessionPath, "Eq", raw, path)];
+  }
+
+  const exprs: PolicyExpr[] = [];
+  for (const [op, value] of Object.entries(raw)) {
+    if (value === undefined) {
+      continue;
+    }
+    switch (op) {
+      case "eq":
+        if (value === null) {
+          exprs.push({ type: "SessionIsNull", path: sessionPath });
+        } else {
+          exprs.push(sessionCmpExpr(sessionPath, "Eq", value, path));
+        }
+        break;
+      case "ne":
+        if (value === null) {
+          exprs.push({ type: "SessionIsNotNull", path: sessionPath });
+        } else {
+          exprs.push(sessionCmpExpr(sessionPath, "Ne", value, path));
+        }
+        break;
+      case "gt":
+        exprs.push(sessionCmpExpr(sessionPath, "Gt", value, path));
+        break;
+      case "gte":
+        exprs.push(sessionCmpExpr(sessionPath, "Ge", value, path));
+        break;
+      case "lt":
+        exprs.push(sessionCmpExpr(sessionPath, "Lt", value, path));
+        break;
+      case "lte":
+        exprs.push(sessionCmpExpr(sessionPath, "Le", value, path));
+        break;
+      case "isNull":
+        if (typeof value !== "boolean") {
+          throw new Error(`session.where("${path}.isNull") expects a boolean value.`);
+        }
+        exprs.push(
+          value
+            ? { type: "SessionIsNull", path: sessionPath }
+            : { type: "SessionIsNotNull", path: sessionPath },
+        );
+        break;
+      case "contains":
+        exprs.push({
+          type: "SessionContains",
+          path: sessionPath,
+          value: toPolicyLiteralValue(value, `session.where("${path}.contains")`),
+        });
+        break;
+      case "in":
+        if (!Array.isArray(value)) {
+          throw new Error(`session.where("${path}.in") expects an array of literal values.`);
+        }
+        if (value.length === 0) {
+          exprs.push({ type: "False" });
+          break;
+        }
+        exprs.push({
+          type: "SessionInList",
+          path: sessionPath,
+          values: value.map((entry) => toPolicyLiteralValue(entry, `session.where("${path}.in")`)),
+        });
+        break;
+      default:
+        throw new Error(
+          `Unsupported session.where operator "${op}" in permissions DSL. Nested object claim syntax is not supported; use dotted path keys instead.`,
+        );
+    }
+  }
+
+  return exprs.length === 0 ? [{ type: "True" }] : exprs;
+}
+
 function cmpExpr(
   column: string,
   op: PolicyCmpOp,
@@ -1398,6 +1532,20 @@ function cmpExpr(
     column,
     op,
     value: toPolicyValue(value, options),
+  };
+}
+
+function sessionCmpExpr(
+  path: string[],
+  op: PolicyCmpOp,
+  value: unknown,
+  originalPath: string,
+): PolicyExpr {
+  return {
+    type: "SessionCmp",
+    path,
+    op,
+    value: toPolicyLiteralValue(value, `session.where("${originalPath}")`),
   };
 }
 
@@ -1415,6 +1563,49 @@ function toPolicyValue(value: unknown, options: { allowRowRefs: boolean }): Poli
     };
   }
   return { type: "Literal", value };
+}
+
+function toPolicyLiteralValue(value: unknown, context: string): PolicyLiteralValue {
+  assertSessionWhereLiteralValue(value, context);
+  return { type: "Literal", value };
+}
+
+function assertSessionWhereLiteralValue(value: unknown, context: string): void {
+  if (isSessionRefValue(value)) {
+    throw new Error(
+      `${context} only accepts literal values; session references are not supported.`,
+    );
+  }
+  if (isRowRefValue(value)) {
+    throw new Error(`${context} only accepts literal values; row references are not supported.`);
+  }
+  if (isRecursiveCurrentValue(value)) {
+    throw new Error(
+      `${context} only accepts literal values; recursive current refs are not supported.`,
+    );
+  }
+  if (
+    isExistsCondition(value) ||
+    isExistsRelationCondition(value) ||
+    isCompoundCondition(value) ||
+    isPolicyExpr(value)
+  ) {
+    throw new Error(
+      `${context} only accepts literal values; relation and policy expressions are not supported.`,
+    );
+  }
+  if (typeof value === "function" || value === undefined) {
+    throw new Error(`${context} only accepts literal values.`);
+  }
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      assertSessionWhereLiteralValue(entry, context);
+    }
+    return;
+  }
+  if (isPlainObject(value)) {
+    throw new Error(`${context} only accepts literal values; nested objects are not supported.`);
+  }
 }
 
 function andExpr(exprs: PolicyExpr[]): PolicyExpr {
@@ -1544,6 +1735,9 @@ function compileCondition(
     assertInheritsColumns(condition, table, fkReferencesByTable);
     return condition;
   }
+  if (isSessionWhereCondition(condition)) {
+    return sessionWhereObjectToCondition(condition.where);
+  }
   if (isExistsRelationCondition(condition)) {
     return {
       type: "ExistsRel",
@@ -1666,6 +1860,14 @@ function isSessionRefValue(input: unknown): input is SessionRefValue {
   );
 }
 
+function isSessionWhereCondition(input: unknown): input is SessionWhereCondition {
+  return (
+    isPlainObject(input) &&
+    input.__jazzPermissionKind === "session-where" &&
+    isPlainObject(input.where)
+  );
+}
+
 function isRowRefValue(input: unknown): input is RowRefValue {
   return (
     isPlainObject(input) &&
@@ -1698,6 +1900,10 @@ function isCompoundCondition(input: unknown): input is CompoundCondition {
     (input.op === "And" || input.op === "Or") &&
     Array.isArray(input.conditions)
   );
+}
+
+function isRecursiveCurrentValue(input: unknown): input is RecursiveCurrentValue {
+  return isPlainObject(input) && input.__jazzPermissionKind === "recursive-current";
 }
 
 function isUpdateRuleBuilder(input: unknown): input is UpdateRuleBuilder<unknown, unknown> {

--- a/packages/jazz-tools/src/permissions/type-inference.test.ts
+++ b/packages/jazz-tools/src/permissions/type-inference.test.ts
@@ -172,7 +172,9 @@ const app = {
 describe("permissions type inference", () => {
   it("infers row callback and where key types", () => {
     definePermissions(app, ({ policy, anyOf, allowedTo, session }) => {
+      expectTypeOf(session.user_id.path).toEqualTypeOf<string[]>();
       expectTypeOf(session.userId.path).toEqualTypeOf<string[]>();
+      expectTypeOf(session["claims.role"].path).toEqualTypeOf<string[]>();
 
       const reachableTeams = policy.teams.gather({
         start: { kind: "individual", identity_key: session.userId },
@@ -192,6 +194,7 @@ describe("permissions type inference", () => {
         policy.todos.allowRead.where((todo) =>
           anyOf([
             { done: false },
+            session.where({ "claims.role": "manager" }),
             policy.projects.exists.where({
               id: todo.projectId,
               ownerId: session.userId,

--- a/packages/jazz-tools/src/schema.ts
+++ b/packages/jazz-tools/src/schema.ts
@@ -98,6 +98,8 @@ export type PolicyValue =
       path: string[];
     };
 
+export type PolicyLiteralValue = Extract<PolicyValue, { type: "Literal" }>;
+
 export type PolicyExpr =
   | {
       type: "Cmp";
@@ -106,17 +108,36 @@ export type PolicyExpr =
       value: PolicyValue;
     }
   | {
+      type: "SessionCmp";
+      path: string[];
+      op: PolicyCmpOp;
+      value: PolicyLiteralValue;
+    }
+  | {
       type: "IsNull";
       column: string;
+    }
+  | {
+      type: "SessionIsNull";
+      path: string[];
     }
   | {
       type: "IsNotNull";
       column: string;
     }
   | {
+      type: "SessionIsNotNull";
+      path: string[];
+    }
+  | {
       type: "Contains";
       column: string;
       value: PolicyValue;
+    }
+  | {
+      type: "SessionContains";
+      path: string[];
+      value: PolicyLiteralValue;
     }
   | {
       type: "In";
@@ -127,6 +148,11 @@ export type PolicyExpr =
       type: "InList";
       column: string;
       values: PolicyValue[];
+    }
+  | {
+      type: "SessionInList";
+      path: string[];
+      values: PolicyLiteralValue[];
     }
   | {
       type: "Exists";

--- a/packages/jazz-tools/src/sql-gen.test.ts
+++ b/packages/jazz-tools/src/sql-gen.test.ts
@@ -308,6 +308,51 @@ CREATE POLICY todos_delete_policy ON todos FOR DELETE USING (owner_id = @session
       "CREATE POLICY todos_select_policy ON todos FOR SELECT USING ((owner_id CONTAINS 'ali') AND (status IN ('active', 'trial')));",
     );
   });
+
+  it("generates session-left policy expressions", () => {
+    resetCollectedState();
+    table("todos", {
+      owner_id: col.string(),
+    });
+    const schema = getCollectedSchema();
+    schema.tables[0]!.policies = {
+      select: {
+        using: {
+          type: "And",
+          exprs: [
+            {
+              type: "SessionCmp",
+              path: ["claims", "role"],
+              op: "Eq",
+              value: { type: "Literal", value: "manager" },
+            },
+            {
+              type: "SessionInList",
+              path: ["claims", "plan"],
+              values: [
+                { type: "Literal", value: "pro" },
+                { type: "Literal", value: "enterprise" },
+              ],
+            },
+            {
+              type: "SessionContains",
+              path: ["claims", "teamIds"],
+              value: { type: "Literal", value: "team_a" },
+            },
+            {
+              type: "SessionIsNull",
+              path: ["claims", "deleted_at"],
+            },
+          ],
+        },
+      },
+    };
+
+    const sql = schemaToSql(schema);
+    expect(sql).toContain(
+      "CREATE POLICY todos_select_policy ON todos FOR SELECT USING ((@session.claims.role = 'manager') AND (@session.claims.plan IN ('pro', 'enterprise')) AND (@session.claims.teamIds CONTAINS 'team_a') AND (@session.claims.deleted_at IS NULL));",
+    );
+  });
 });
 
 describe("lensToSql", () => {

--- a/packages/jazz-tools/src/sql-gen.ts
+++ b/packages/jazz-tools/src/sql-gen.ts
@@ -102,16 +102,26 @@ function policyExprToSql(expr: PolicyExpr): string {
   switch (expr.type) {
     case "Cmp":
       return `${sqlIdentifier(expr.column)} ${cmpOpToSql(expr.op)} ${policyValueToSql(expr.value)}`;
+    case "SessionCmp":
+      return `@session.${sessionPathToSql(expr.path)} ${cmpOpToSql(expr.op)} ${policyValueToSql(expr.value)}`;
     case "IsNull":
       return `${sqlIdentifier(expr.column)} IS NULL`;
+    case "SessionIsNull":
+      return `@session.${sessionPathToSql(expr.path)} IS NULL`;
     case "IsNotNull":
       return `${sqlIdentifier(expr.column)} IS NOT NULL`;
+    case "SessionIsNotNull":
+      return `@session.${sessionPathToSql(expr.path)} IS NOT NULL`;
     case "Contains":
       return `${sqlIdentifier(expr.column)} CONTAINS ${policyValueToSql(expr.value)}`;
+    case "SessionContains":
+      return `@session.${sessionPathToSql(expr.path)} CONTAINS ${policyValueToSql(expr.value)}`;
     case "In":
       return `${sqlIdentifier(expr.column)} IN @session.${sessionPathToSql(expr.session_path)}`;
     case "InList":
       return `${sqlIdentifier(expr.column)} IN (${expr.values.map(policyValueToSql).join(", ")})`;
+    case "SessionInList":
+      return `@session.${sessionPathToSql(expr.path)} IN (${expr.values.map(policyValueToSql).join(", ")})`;
     case "Exists":
       return `EXISTS (SELECT FROM ${sqlIdentifier(expr.table)} WHERE ${policyExprToSql(expr.condition)})`;
     case "ExistsRel":

--- a/specs/README.md
+++ b/specs/README.md
@@ -74,3 +74,4 @@ Remaining work items and future designs live in [`specs/todo/`](todo/). Notable:
 - **[Storage: Multi-tab Leader Election](todo/a_mvp/multi_tab_leader_election.md)** — Browser tab ownership for OPFS-backed worker storage
 - **[Storage: Browser E2E Suite](todo/a_mvp/browser_e2e_test_suite.md)** — End-to-end verification for browser runtime + worker + sync
 - **[TypeScript Client Codegen: Relations Demo](todo/a_mvp/codegen_relations_demo.md)** — Example app coverage for generated relation APIs
+- **[Policy Query-Time Constant Folding](todo/c_later/policy_query_time_constant_folding.md)** — Track broader follow-up work for evaluating row-independent policy checks once per query instead of once per row

--- a/specs/todo/c_later/policy_query_time_constant_folding.md
+++ b/specs/todo/c_later/policy_query_time_constant_folding.md
@@ -1,0 +1,108 @@
+# Policy Query-Time Constant Folding — TODO (Later)
+
+Some policy checks do not depend on row data and should be evaluated once per query (or once per policy-graph instance) instead of once per row.
+
+## Status Note
+
+This is partially addressed today:
+
+- session-only `PolicyExpr` subtrees can already be simplified once when a `PolicyFilterNode` is constructed
+- simple cases like `session.where({ "claims.role": "manager" })` no longer need to be re-evaluated for every row in that filter node
+
+What remains open is the broader design for query-time folding/caching across all policy evaluation paths.
+
+> Status quo background:
+>
+> - [PolicyFilter lifecycle](../../status-quo/life_of_a_subscription.md#11-read-policy-checks-in-compilation-and-settlement)
+> - [Query Manager](../../status-quo/query_manager.md)
+> - [TypeScript permissions DSL](../a_mvp/permissions_ts_policy_dsl.md)
+
+## Problem
+
+Today, policy evaluation is still fundamentally row-oriented:
+
+- `PolicyFilterNode` evaluates row visibility tuple-by-tuple
+- contextual checks (`EXISTS`, `INHERITS`, `EXISTS REL`) can spawn or recurse into additional policy evaluation work
+- some of that work is row-independent, but we still pay evaluation overhead repeatedly
+
+This is correct and simple, but it leaves performance on the table when a policy contains clauses that are constant for the lifetime of a single query settlement.
+
+## Goal
+
+Evaluate row-independent policy subtrees once per query / once per `PolicyFilterNode` / once per ad-hoc `PolicyGraph` instance, then reuse the boolean result or simplified expression during row processing.
+
+The important boundary is:
+
+- optimize within a single compiled query or policy graph instance
+- do not introduce a global cross-query cache as the first step
+
+## Examples
+
+Should fold once per query:
+
+```ts
+session.where({ "claims.role": "manager" });
+```
+
+```ts
+allOf([
+  { owner_id: session.user_id },
+  session.where({ "claims.plan": { in: ["pro", "enterprise"] } }),
+]);
+```
+
+In the second example, only the `session.where(...)` branch is query-constant; `{ owner_id: session.user_id }` still depends on the current row and must remain per-row.
+
+Should not be folded as query-constant:
+
+- `Cmp`, `Contains`, `In`, `InList` when they read a row column
+- `EXISTS` conditions that depend on outer-row bindings
+- `INHERITS` checks that require loading related rows
+- relation expressions or graph traversals whose truth value changes with the current row
+
+## Candidate Scope
+
+### 1. Expand constant folding beyond the current session-only fast path
+
+Current folding is intentionally narrow. Follow-up work can identify additional row-independent shapes and collapse them earlier.
+
+### 2. Apply folding consistently across all policy entry points
+
+Not every policy is evaluated through the same construction path. Follow-up work should audit:
+
+- top-level `SELECT` `PolicyFilterNode`s
+- ad-hoc `PolicyGraph`s created for `EXISTS` and write checks
+- recursive parent-policy evaluation paths used by `INHERITS`
+
+### 3. Add constant-result fast paths
+
+When a whole policy simplifies to `True` or `False`, settlement should avoid unnecessary per-row expression dispatch and, where possible, avoid tracking irrelevant policy dependencies.
+
+### 4. Preserve dependency correctness
+
+If folding removes a branch containing `EXISTS`/`INHERITS`, dependency-table tracking must shrink accordingly. If folding keeps a contextual branch, dependency tracking must remain unchanged.
+
+## Non-goals
+
+- changing policy semantics
+- introducing arbitrary expression rewriting across row refs / session refs / relation refs
+- adding a global memoization layer shared across unrelated queries
+- weakening fail-closed behavior for missing claims or unresolved graph-backed checks
+
+## Suggested Work Plan
+
+1. Benchmark current row-by-row overhead for mixed row/session policies.
+2. Enumerate which `PolicyExpr` shapes are provably row-independent.
+3. Apply the same simplification pass at every policy evaluation entry point.
+4. Add explicit fast paths for fully constant `True` / `False` policies.
+5. Measure impact on:
+   - query settle time
+   - rows/sec under permission-heavy scans
+   - number of contextual policy evaluations per query
+
+## Success Criteria
+
+- session-only or otherwise row-independent policy branches are evaluated once per query instance
+- mixed policies still preserve row-by-row correctness for row-dependent clauses
+- dependency invalidation behavior remains correct
+- benchmarks show measurable improvement for permission-heavy reads without making the policy runtime much harder to reason about


### PR DESCRIPTION
## Summary
- add `session.where(...)` to the TypeScript permissions DSL for literal-only session claim checks
- introduce additive `Session*` policy AST variants and carry them through schema cloning, serialization, hashing, and SQL generation
- extend Rust SQL parsing and runtime evaluation for session-left comparisons, `IN`, `CONTAINS`, and `IS [NOT] NULL`
- preserve existing row-vs-session predicates and support both `session.user_id` and `session.userId`
- add docs and example snippets showing JWT claim checks in permissions

## Testing
- `pnpm --filter jazz-tools exec vitest run src/permissions/index.test.ts src/permissions/type-inference.test.ts src/sql-gen.test.ts src/codegen/codegen.test.ts`
- `cargo test -p jazz-tools`