### PR TITLE
Add policy and subscribe-all integration tests and test helper cleanup

### DIFF
--- a/crates/jazz-tools/src/server/mod.rs
+++ b/crates/jazz-tools/src/server/mod.rs
@@ -17,7 +17,7 @@ mod testing;
 pub use builder::{BuiltServer, ServerBuilder};
 pub use external_identity_store::{ExternalIdentityRow, ExternalIdentityStore};
 #[cfg(feature = "test-utils")]
-pub use testing::{TestingJwksServer, TestingServer, TestingServerOptions};
+pub use testing::{TestingJwksServer, TestingServer, TestingServerBuilder};
 
 pub type DynStorage = Box<dyn Storage + Send>;
 

--- a/crates/jazz-tools/src/server/testing.rs
+++ b/crates/jazz-tools/src/server/testing.rs
@@ -26,6 +26,7 @@ pub struct TestingServerOptions {
     pub port: Option<u16>,
     pub app_id: Option<AppId>,
     pub data_dir: Option<PathBuf>,
+    pub schema: Option<Schema>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -86,6 +87,14 @@ impl TestingServer {
         Self::start_with_options(TestingServerOptions::default()).await
     }
 
+    pub async fn start_with_schema(schema: Schema) -> Self {
+        Self::start_with_options(TestingServerOptions {
+            schema: Some(schema),
+            ..TestingServerOptions::default()
+        })
+        .await
+    }
+
     pub async fn start_with_options(options: TestingServerOptions) -> Self {
         let port = options.port.unwrap_or_else(get_free_port);
         let app_id = options.app_id.unwrap_or_else(Self::default_app_id);
@@ -101,12 +110,13 @@ impl TestingServer {
             admin_secret: Some(Self::ADMIN_SECRET.to_string()),
         };
 
-        let built = ServerBuilder::new(app_id)
+        let mut builder = ServerBuilder::new(app_id)
             .with_auth_config(auth_config)
-            .with_persistent_storage(data_dir.to_string_lossy().into_owned())
-            .build()
-            .await
-            .expect("build test server");
+            .with_persistent_storage(data_dir.to_string_lossy().into_owned());
+        if let Some(schema) = options.schema {
+            builder = builder.with_schema(schema);
+        }
+        let built = builder.build().await.expect("build test server");
 
         let listener = tokio::net::TcpListener::bind(("127.0.0.1", port))
             .await

--- a/crates/jazz-tools/src/server/testing.rs
+++ b/crates/jazz-tools/src/server/testing.rs
@@ -21,12 +21,44 @@ const DEFAULT_APP_ID_STR: &str = "00000000-0000-0000-0000-000000000001";
 const JWT_KID: &str = "test-jwks-kid";
 const JWT_SECRET: &str = "test-jwt-secret-for-integration";
 
+/// Builder for configuring and starting a [`TestingServer`].
 #[derive(Debug, Default)]
-pub struct TestingServerOptions {
-    pub port: Option<u16>,
-    pub app_id: Option<AppId>,
-    pub data_dir: Option<PathBuf>,
-    pub schema: Option<Schema>,
+pub struct TestingServerBuilder {
+    port: Option<u16>,
+    app_id: Option<AppId>,
+    data_dir: Option<PathBuf>,
+    schema: Option<Schema>,
+}
+
+impl TestingServerBuilder {
+    /// Creates a builder with the default test-server configuration.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_port(mut self, port: u16) -> Self {
+        self.port = Some(port);
+        self
+    }
+
+    pub fn with_app_id(mut self, app_id: AppId) -> Self {
+        self.app_id = Some(app_id);
+        self
+    }
+
+    pub fn with_data_dir(mut self, data_dir: impl Into<PathBuf>) -> Self {
+        self.data_dir = Some(data_dir.into());
+        self
+    }
+
+    pub fn with_schema(mut self, schema: Schema) -> Self {
+        self.schema = Some(schema);
+        self
+    }
+
+    pub async fn start(self) -> TestingServer {
+        TestingServer::start_from_builder(self).await
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -83,22 +115,30 @@ impl TestingServer {
     pub const BACKEND_SECRET: &str = "backend-secret-for-integration-tests";
     pub const ADMIN_SECRET: &str = "admin-secret-for-integration-tests";
 
+    /// Creates a builder for configuring a test server before startup.
+    pub fn builder() -> TestingServerBuilder {
+        TestingServerBuilder::new()
+    }
+
     pub async fn start() -> Self {
-        Self::start_with_options(TestingServerOptions::default()).await
+        Self::builder().start().await
     }
 
     pub async fn start_with_schema(schema: Schema) -> Self {
-        Self::start_with_options(TestingServerOptions {
-            schema: Some(schema),
-            ..TestingServerOptions::default()
-        })
-        .await
+        Self::builder().with_schema(schema).start().await
     }
 
-    pub async fn start_with_options(options: TestingServerOptions) -> Self {
-        let port = options.port.unwrap_or_else(get_free_port);
-        let app_id = options.app_id.unwrap_or_else(Self::default_app_id);
-        let (data_dir, owned_data_dir) = prepare_data_dir(options.data_dir);
+    async fn start_from_builder(builder: TestingServerBuilder) -> Self {
+        let TestingServerBuilder {
+            port,
+            app_id,
+            data_dir,
+            schema,
+        } = builder;
+
+        let port = port.unwrap_or_else(get_free_port);
+        let app_id = app_id.unwrap_or_else(Self::default_app_id);
+        let (data_dir, owned_data_dir) = prepare_data_dir(data_dir);
         let jwks_server = TestingJwksServer::start().await;
 
         let auth_config = AuthConfig {
@@ -110,13 +150,13 @@ impl TestingServer {
             admin_secret: Some(Self::ADMIN_SECRET.to_string()),
         };
 
-        let mut builder = ServerBuilder::new(app_id)
+        let mut server_builder = ServerBuilder::new(app_id)
             .with_auth_config(auth_config)
             .with_persistent_storage(data_dir.to_string_lossy().into_owned());
-        if let Some(schema) = options.schema {
-            builder = builder.with_schema(schema);
+        if let Some(schema) = schema {
+            server_builder = server_builder.with_schema(schema);
         }
-        let built = builder.build().await.expect("build test server");
+        let built = server_builder.build().await.expect("build test server");
 
         let listener = tokio::net::TcpListener::bind(("127.0.0.1", port))
             .await

--- a/crates/jazz-tools/tests/AGENTS.md
+++ b/crates/jazz-tools/tests/AGENTS.md
@@ -1,0 +1,23 @@
+# Test Guidelines
+
+## No mocks
+
+All tests are integration tests against a real `TestingServer`. No mocked transports, no stubbed storage. If a behavior can't be exercised end-to-end, it's not tested here.
+
+## Document each test
+
+Every test function must have a doc comment (`///`) that states:
+
+1. What contract or behavior it exercises
+2. The actors involved (use human names: `alice`, `bob`, `mallory`)
+3. An ASCII flow sketch when the causal order is non-trivial
+
+Document with comments any non-obvious test instruction.
+
+### ASCII sketch conventions
+
+```
+writer ──insert──► server ──broadcast──► subscriber
+                      │
+                      └── policy check ──✗── intruder
+```

--- a/crates/jazz-tools/tests/policies_integration.rs
+++ b/crates/jazz-tools/tests/policies_integration.rs
@@ -87,7 +87,10 @@ async fn create_document(client: &JazzClient, owner_id: &str, title: &str) -> Ob
 #[tokio::test]
 async fn select_policies_filter_subscription_results_per_client_session() {
     let schema = select_policy_schema();
-    let server = TestingServer::start_with_schema(schema.clone()).await;
+    let server = TestingServer::builder()
+        .with_schema(schema.clone())
+        .start()
+        .await;
     let alice =
         connect_jwt_client(&server, schema.clone(), "alice", "documents", READY_TIMEOUT).await;
     let bob = connect_jwt_client(&server, schema, "bob", "documents", READY_TIMEOUT).await;
@@ -171,7 +174,10 @@ async fn select_policies_filter_subscription_results_per_client_session() {
 #[tokio::test]
 async fn insert_policies_are_enforced_by_server_for_client_sync() {
     let schema = write_policy_schema();
-    let server = TestingServer::start_with_schema(schema.clone()).await;
+    let server = TestingServer::builder()
+        .with_schema(schema.clone())
+        .start()
+        .await;
     let intruder = connect_jwt_client(
         &server,
         schema.clone(),
@@ -262,7 +268,10 @@ async fn insert_policies_are_enforced_by_server_for_client_sync() {
 #[tokio::test]
 async fn update_and_delete_policies_block_unauthorized_server_mutations() {
     let schema = write_policy_schema();
-    let server = TestingServer::start_with_schema(schema.clone()).await;
+    let server = TestingServer::builder()
+        .with_schema(schema.clone())
+        .start()
+        .await;
     let alice =
         connect_jwt_client(&server, schema.clone(), "alice", "documents", READY_TIMEOUT).await;
     let bob = connect_jwt_client(&server, schema.clone(), "bob", "documents", READY_TIMEOUT).await;

--- a/crates/jazz-tools/tests/policies_integration.rs
+++ b/crates/jazz-tools/tests/policies_integration.rs
@@ -1,0 +1,344 @@
+#![cfg(feature = "test-utils")]
+
+mod support;
+
+use std::time::Duration;
+
+use jazz_tools::query_manager::policy::PolicyExpr;
+use jazz_tools::query_manager::types::TablePolicies;
+use jazz_tools::server::TestingServer;
+use jazz_tools::{
+    ColumnType, DurabilityTier, JazzClient, ObjectId, QueryBuilder, Schema, SchemaBuilder,
+    TableSchema, Value,
+};
+use support::{
+    collect_stream_deltas, connect_jwt_client, has_added, has_any_change, has_removed, has_updated,
+    wait_for_rows, wait_for_subscription_update,
+};
+
+const READY_TIMEOUT: Duration = Duration::from_secs(30);
+const QUERY_TIMEOUT: Duration = Duration::from_secs(25);
+const NO_DELTA_WINDOW: Duration = Duration::from_millis(100);
+
+fn select_policy_schema() -> Schema {
+    SchemaBuilder::new()
+        .table(
+            TableSchema::builder("documents")
+                .column("owner_id", ColumnType::Text)
+                .column("title", ColumnType::Text)
+                .policies(
+                    TablePolicies::new()
+                        .with_select(PolicyExpr::eq_session("owner_id", vec!["user_id".into()]))
+                        .with_insert(PolicyExpr::eq_session("owner_id", vec!["user_id".into()])),
+                ),
+        )
+        .build()
+}
+
+fn write_policy_schema() -> Schema {
+    let owner_policy = PolicyExpr::eq_session("owner_id", vec!["user_id".into()]);
+
+    SchemaBuilder::new()
+        .table(
+            TableSchema::builder("documents")
+                .column("owner_id", ColumnType::Text)
+                .column("title", ColumnType::Text)
+                .policies(
+                    TablePolicies::new()
+                        .with_insert(owner_policy.clone())
+                        .with_update(Some(owner_policy.clone()), PolicyExpr::True)
+                        .with_delete(owner_policy),
+                ),
+        )
+        .build()
+}
+
+fn document_values(owner_id: &str, title: &str) -> Vec<Value> {
+    vec![
+        Value::Text(owner_id.to_string()),
+        Value::Text(title.to_string()),
+    ]
+}
+
+async fn create_document(client: &JazzClient, owner_id: &str, title: &str) -> ObjectId {
+    client
+        .create("documents", document_values(owner_id, title))
+        .await
+        .expect("create document")
+        .0
+}
+
+/// Verifies that `SELECT` policies scope subscription updates and query results
+/// to the requesting client's own session, preventing cross-user data leakage.
+///
+/// Alice and bob each insert a document they own. The schema enforces
+/// `owner_id = session.user_id` on SELECT, so each client's subscription must
+/// only fire for their own row. Query results are checked independently too.
+///
+/// ```text
+/// alice ──insert "Alice Only"──► server ──► alice stream (add ✓)
+///                                    │
+///                                    └── SELECT policy ──✗──► bob stream (silent)
+///
+/// bob ──insert "Bob Only"──► server ──► bob stream (add ✓)
+///                                │
+///                                └── SELECT policy ──✗──► alice stream (silent)
+/// ```
+#[tokio::test]
+async fn select_policies_filter_subscription_results_per_client_session() {
+    let schema = select_policy_schema();
+    let server = TestingServer::start_with_schema(schema.clone()).await;
+    let alice =
+        connect_jwt_client(&server, schema.clone(), "alice", "documents", READY_TIMEOUT).await;
+    let bob = connect_jwt_client(&server, schema, "bob", "documents", READY_TIMEOUT).await;
+    let query = QueryBuilder::new("documents").build();
+
+    let mut alice_stream = alice
+        .subscribe(query.clone())
+        .await
+        .expect("subscribe alice");
+    let mut bob_stream = bob.subscribe(query.clone()).await.expect("subscribe bob");
+    let mut alice_log = Vec::new();
+    let mut bob_log = Vec::new();
+
+    let alice_doc = create_document(&alice, "alice", "Alice Only").await;
+    wait_for_subscription_update(
+        &mut alice_stream,
+        &mut alice_log,
+        QUERY_TIMEOUT,
+        "alice add delta",
+        |log| has_added(log, alice_doc),
+    )
+    .await;
+    // alice's stream delta fires only after the server has dispatched (or
+    // withheld) notifications to all subscribers. A short drain is enough to
+    // flush any buffered messages on the loopback connection.
+    collect_stream_deltas(&mut bob_stream, &mut bob_log, NO_DELTA_WINDOW).await;
+    assert!(
+        !has_any_change(&bob_log, alice_doc),
+        "bob should not receive alice's document"
+    );
+
+    let bob_doc = create_document(&bob, "bob", "Bob Only").await;
+    wait_for_subscription_update(
+        &mut bob_stream,
+        &mut bob_log,
+        QUERY_TIMEOUT,
+        "bob add delta",
+        |log| has_added(log, bob_doc),
+    )
+    .await;
+    // Symmetric check: bob's stream delta is the barrier, then drain alice.
+    collect_stream_deltas(&mut alice_stream, &mut alice_log, NO_DELTA_WINDOW).await;
+    assert!(
+        !has_any_change(&alice_log, bob_doc),
+        "alice should not receive bob's document"
+    );
+
+    let alice_rows = wait_for_rows(&alice, query.clone(), "alice visible rows", |rows| {
+        (rows.len() == 1 && rows[0].0 == alice_doc).then_some(rows)
+    })
+    .await;
+    assert_eq!(alice_rows[0].1, document_values("alice", "Alice Only"));
+
+    let bob_rows = wait_for_rows(&bob, query, "bob visible rows", |rows| {
+        (rows.len() == 1 && rows[0].0 == bob_doc).then_some(rows)
+    })
+    .await;
+    assert_eq!(bob_rows[0].1, document_values("bob", "Bob Only"));
+
+    alice.shutdown().await.expect("shutdown alice");
+    bob.shutdown().await.expect("shutdown bob");
+    server.shutdown().await;
+}
+
+/// Verifies that the server silently drops inserts that fail the `INSERT` policy
+/// and does not broadcast those rows to any subscriber.
+///
+/// Mallory attempts to forge a document with alice's `owner_id`. Alice then
+/// creates a legitimate document of her own. Alice's insert serves as the
+/// causal barrier: once the observer's stream receives alice's add delta, the
+/// server has already committed alice's row — and therefore has also processed
+/// and rejected mallory's earlier request.
+///
+/// ```text
+/// mallory ──insert owner="alice"──► server ──✗ rejected, not broadcast
+///
+/// alice ──insert owner="alice"────► server ──► observer stream (add ✓)
+///                                       │
+///                                       └── observer query: only alice's row
+/// ```
+#[tokio::test]
+async fn insert_policies_are_enforced_by_server_for_client_sync() {
+    let schema = write_policy_schema();
+    let server = TestingServer::start_with_schema(schema.clone()).await;
+    let intruder = connect_jwt_client(
+        &server,
+        schema.clone(),
+        "mallory",
+        "documents",
+        READY_TIMEOUT,
+    )
+    .await;
+    let observer = connect_jwt_client(
+        &server,
+        schema.clone(),
+        "observer",
+        "documents",
+        READY_TIMEOUT,
+    )
+    .await;
+    let alice = connect_jwt_client(&server, schema, "alice", "documents", READY_TIMEOUT).await;
+    let query = QueryBuilder::new("documents").build();
+
+    let mut observer_stream = observer
+        .subscribe(query.clone())
+        .await
+        .expect("subscribe observer");
+    let mut observer_log = Vec::new();
+
+    let forged_id = intruder
+        .create("documents", document_values("alice", "forged"))
+        .await
+        .expect("optimistic local create")
+        .0;
+
+    // Alice's insert is the causal barrier: once the observer receives this add
+    // delta the server has already committed alice's row, meaning it has also
+    // processed and rejected mallory's earlier insert.
+    let accepted_doc = create_document(&alice, "alice", "allowed").await;
+    wait_for_subscription_update(
+        &mut observer_stream,
+        &mut observer_log,
+        QUERY_TIMEOUT,
+        "observer sees allowed insert",
+        |log| has_added(log, accepted_doc),
+    )
+    .await;
+
+    assert!(
+        !has_any_change(&observer_log, forged_id),
+        "server should not broadcast a row rejected by insert policy"
+    );
+
+    let rows = wait_for_rows(
+        &observer,
+        query,
+        "observer sees only accepted row",
+        |rows| (rows.len() == 1 && rows[0].0 == accepted_doc).then_some(rows),
+    )
+    .await;
+    assert_eq!(rows[0].1, document_values("alice", "allowed"));
+
+    intruder.shutdown().await.expect("shutdown intruder");
+    observer.shutdown().await.expect("shutdown observer");
+    alice.shutdown().await.expect("shutdown alice");
+    server.shutdown().await;
+}
+
+/// Verifies that update and delete attempts from a client that fails the write
+/// policy are rejected by the server and never broadcast to subscribers.
+///
+/// Alice creates a document. Bob can read it (no SELECT restriction) but does
+/// not own it. Bob's update and delete are applied optimistically on his local
+/// client but silently dropped by the server. An EdgeServer-tier query after
+/// each attempt serves as the causal barrier: it blocks until the server has
+/// settled, so if the value is still "original" the rejection is confirmed.
+/// The observer's stream is then drained to verify no mutation delta arrived.
+///
+/// ```text
+/// alice ──insert "original"──────────► server ──► observer (add ✓)
+///
+/// bob ──update title="hacked"────────► server ──✗ rejected (owner_id ≠ bob)
+///                                          │
+///                                          └── observer query (EdgeServer) → "original"
+///                                          └── observer stream → no update delta
+///
+/// bob ──delete────────────────────────► server ──✗ rejected
+///                                           │
+///                                           └── observer query (EdgeServer) → row present
+///                                           └── observer stream → no remove delta
+/// ```
+#[tokio::test]
+async fn update_and_delete_policies_block_unauthorized_server_mutations() {
+    let schema = write_policy_schema();
+    let server = TestingServer::start_with_schema(schema.clone()).await;
+    let alice =
+        connect_jwt_client(&server, schema.clone(), "alice", "documents", READY_TIMEOUT).await;
+    let bob = connect_jwt_client(&server, schema.clone(), "bob", "documents", READY_TIMEOUT).await;
+    let observer =
+        connect_jwt_client(&server, schema, "observer", "documents", READY_TIMEOUT).await;
+    let query = QueryBuilder::new("documents").build();
+
+    let mut observer_stream = observer
+        .subscribe(query.clone())
+        .await
+        .expect("subscribe observer");
+    let mut observer_log = Vec::new();
+
+    let doc_id = create_document(&alice, "alice", "original").await;
+    wait_for_subscription_update(
+        &mut observer_stream,
+        &mut observer_log,
+        QUERY_TIMEOUT,
+        "observer sees initial row",
+        |log| has_added(log, doc_id),
+    )
+    .await;
+
+    wait_for_rows(&bob, query.clone(), "bob sees readable row", |rows| {
+        rows.iter()
+            .find(|(id, values)| *id == doc_id && *values == document_values("alice", "original"))
+            .map(|_| ())
+    })
+    .await;
+
+    bob.update(
+        doc_id,
+        vec![("title".to_string(), Value::Text("hacked".to_string()))],
+    )
+    .await
+    .expect("optimistic local update");
+
+    // EdgeServer query is the causal barrier: it blocks until the server has
+    // settled, guaranteeing bob's attempted update has been accepted or rejected.
+    let rows_after_update = observer
+        .query(query.clone(), Some(DurabilityTier::EdgeServer))
+        .await
+        .expect("EdgeServer query after unauthorized update");
+    assert!(
+        rows_after_update
+            .iter()
+            .any(|(id, values)| *id == doc_id && *values == document_values("alice", "original")),
+        "unauthorized update should not be persisted at EdgeServer: rows={rows_after_update:?}"
+    );
+    collect_stream_deltas(&mut observer_stream, &mut observer_log, NO_DELTA_WINDOW).await;
+    assert!(
+        !has_updated(&observer_log, doc_id),
+        "unauthorized update should not be broadcast to subscribers: log={observer_log:?}"
+    );
+
+    bob.delete(doc_id).await.expect("optimistic local delete");
+
+    // Same barrier for the delete attempt.
+    let rows_after_delete = observer
+        .query(query.clone(), Some(DurabilityTier::EdgeServer))
+        .await
+        .expect("EdgeServer query after unauthorized delete");
+    assert!(
+        rows_after_delete
+            .iter()
+            .any(|(id, values)| *id == doc_id && *values == document_values("alice", "original")),
+        "unauthorized delete should not be persisted at EdgeServer: rows={rows_after_delete:?}"
+    );
+    collect_stream_deltas(&mut observer_stream, &mut observer_log, NO_DELTA_WINDOW).await;
+    assert!(
+        !has_removed(&observer_log, doc_id),
+        "unauthorized delete should not be broadcast to subscribers: log={observer_log:?}"
+    );
+
+    alice.shutdown().await.expect("shutdown alice");
+    bob.shutdown().await.expect("shutdown bob");
+    observer.shutdown().await.expect("shutdown observer");
+    server.shutdown().await;
+}

--- a/crates/jazz-tools/tests/policies_integration.rs
+++ b/crates/jazz-tools/tests/policies_integration.rs
@@ -12,7 +12,7 @@ use jazz_tools::{
     TableSchema, Value,
 };
 use support::{
-    collect_stream_deltas, connect_jwt_client, has_added, has_any_change, has_removed, has_updated,
+    collect_stream_deltas, connect_client, has_added, has_any_change, has_removed, has_updated,
     wait_for_rows, wait_for_subscription_update,
 };
 
@@ -91,9 +91,8 @@ async fn select_policies_filter_subscription_results_per_client_session() {
         .with_schema(schema.clone())
         .start()
         .await;
-    let alice =
-        connect_jwt_client(&server, schema.clone(), "alice", "documents", READY_TIMEOUT).await;
-    let bob = connect_jwt_client(&server, schema, "bob", "documents", READY_TIMEOUT).await;
+    let alice = connect_client(&server, schema.clone(), "alice", "documents", READY_TIMEOUT).await;
+    let bob = connect_client(&server, schema, "bob", "documents", READY_TIMEOUT).await;
     let query = QueryBuilder::new("documents").build();
 
     let mut alice_stream = alice
@@ -178,7 +177,7 @@ async fn insert_policies_are_enforced_by_server_for_client_sync() {
         .with_schema(schema.clone())
         .start()
         .await;
-    let intruder = connect_jwt_client(
+    let intruder = connect_client(
         &server,
         schema.clone(),
         "mallory",
@@ -186,7 +185,7 @@ async fn insert_policies_are_enforced_by_server_for_client_sync() {
         READY_TIMEOUT,
     )
     .await;
-    let observer = connect_jwt_client(
+    let observer = connect_client(
         &server,
         schema.clone(),
         "observer",
@@ -194,7 +193,7 @@ async fn insert_policies_are_enforced_by_server_for_client_sync() {
         READY_TIMEOUT,
     )
     .await;
-    let alice = connect_jwt_client(&server, schema, "alice", "documents", READY_TIMEOUT).await;
+    let alice = connect_client(&server, schema, "alice", "documents", READY_TIMEOUT).await;
     let query = QueryBuilder::new("documents").build();
 
     let mut observer_stream = observer
@@ -272,11 +271,9 @@ async fn update_and_delete_policies_block_unauthorized_server_mutations() {
         .with_schema(schema.clone())
         .start()
         .await;
-    let alice =
-        connect_jwt_client(&server, schema.clone(), "alice", "documents", READY_TIMEOUT).await;
-    let bob = connect_jwt_client(&server, schema.clone(), "bob", "documents", READY_TIMEOUT).await;
-    let observer =
-        connect_jwt_client(&server, schema, "observer", "documents", READY_TIMEOUT).await;
+    let alice = connect_client(&server, schema.clone(), "alice", "documents", READY_TIMEOUT).await;
+    let bob = connect_client(&server, schema.clone(), "bob", "documents", READY_TIMEOUT).await;
+    let observer = connect_client(&server, schema, "observer", "documents", READY_TIMEOUT).await;
     let query = QueryBuilder::new("documents").build();
 
     let mut observer_stream = observer

--- a/crates/jazz-tools/tests/subscribe_all_integration.rs
+++ b/crates/jazz-tools/tests/subscribe_all_integration.rs
@@ -1,0 +1,1079 @@
+#![cfg(feature = "test-utils")]
+
+mod support;
+
+use std::time::Duration;
+
+use jazz_tools::server::TestingServer;
+use jazz_tools::{
+    ColumnType, JazzClient, ObjectId, Query, QueryBuilder, Schema, SchemaBuilder, TableSchema,
+    Value,
+};
+use support::{
+    collect_stream_deltas, connect_client, has_added, has_any_change, has_removed, has_updated,
+    wait_for_rows, wait_for_subscription_update,
+};
+
+const READY_TIMEOUT: Duration = Duration::from_secs(30);
+const QUERY_TIMEOUT: Duration = Duration::from_secs(25);
+const NO_DELTA_WINDOW: Duration = Duration::from_millis(500);
+
+fn subscription_schema() -> Schema {
+    SchemaBuilder::new()
+        .table(TableSchema::builder("orgs").column("name", ColumnType::Text))
+        .table(
+            TableSchema::builder("teams")
+                .column("name", ColumnType::Text)
+                .nullable_fk_column("org_id", "orgs")
+                .nullable_fk_column("parent_id", "teams"),
+        )
+        .table(
+            TableSchema::builder("team_edges")
+                .column("child_team", ColumnType::Uuid)
+                .column("parent_team", ColumnType::Uuid),
+        )
+        .table(
+            TableSchema::builder("users")
+                .column("name", ColumnType::Text)
+                .nullable_fk_column("team_id", "teams"),
+        )
+        .table(
+            TableSchema::builder("todos")
+                .column("title", ColumnType::Text)
+                .column("done", ColumnType::Boolean)
+                .nullable_column("priority", ColumnType::Integer)
+                .nullable_fk_column("owner_id", "users")
+                .column(
+                    "tags",
+                    ColumnType::Array {
+                        element: Box::new(ColumnType::Text),
+                    },
+                )
+                .nullable_column("payload", ColumnType::Bytea),
+        )
+        .table(TableSchema::builder("file_parts").column("label", ColumnType::Text))
+        .table(
+            TableSchema::builder("files")
+                .column("name", ColumnType::Text)
+                .column(
+                    "parts",
+                    ColumnType::Array {
+                        element: Box::new(ColumnType::Uuid),
+                    },
+                ),
+        )
+        .build()
+}
+
+struct ClientPair {
+    server: TestingServer,
+    writer: JazzClient,
+    subscriber: JazzClient,
+}
+
+impl ClientPair {
+    async fn start() -> Self {
+        let server = TestingServer::start().await;
+        let schema = subscription_schema();
+        let writer = connect_client(
+            &server,
+            schema.clone(),
+            "subscribe-all-writer",
+            "todos",
+            READY_TIMEOUT,
+        )
+        .await;
+        let subscriber = connect_client(
+            &server,
+            schema,
+            "subscribe-all-subscriber",
+            "todos",
+            READY_TIMEOUT,
+        )
+        .await;
+
+        Self {
+            server,
+            writer,
+            subscriber,
+        }
+    }
+
+    async fn shutdown(self) {
+        self.writer.shutdown().await.expect("shutdown writer");
+        self.subscriber
+            .shutdown()
+            .await
+            .expect("shutdown subscriber");
+        self.server.shutdown().await;
+    }
+}
+
+#[derive(Clone, Copy)]
+struct TodoSeed {
+    title: &'static str,
+    done: bool,
+    priority: Option<i32>,
+    tags: &'static [&'static str],
+    payload: Option<&'static [u8]>,
+}
+
+impl TodoSeed {
+    fn values(self) -> Vec<Value> {
+        vec![
+            Value::Text(self.title.to_string()),
+            Value::Boolean(self.done),
+            self.priority.map(Value::Integer).unwrap_or(Value::Null),
+            Value::Null,
+            Value::Array(
+                self.tags
+                    .iter()
+                    .map(|tag| Value::Text((*tag).to_string()))
+                    .collect(),
+            ),
+            self.payload
+                .map(|bytes| Value::Bytea(bytes.to_vec()))
+                .unwrap_or(Value::Null),
+        ]
+    }
+}
+
+async fn create_org(client: &JazzClient, name: &str) -> ObjectId {
+    client
+        .create("orgs", vec![Value::Text(name.to_string())])
+        .await
+        .expect("create org")
+        .0
+}
+
+async fn create_team(
+    client: &JazzClient,
+    name: &str,
+    org_id: Option<ObjectId>,
+    parent_id: Option<ObjectId>,
+) -> ObjectId {
+    client
+        .create(
+            "teams",
+            vec![
+                Value::Text(name.to_string()),
+                org_id.map(Value::Uuid).unwrap_or(Value::Null),
+                parent_id.map(Value::Uuid).unwrap_or(Value::Null),
+            ],
+        )
+        .await
+        .expect("create team")
+        .0
+}
+
+async fn create_user(client: &JazzClient, name: &str, team_id: Option<ObjectId>) -> ObjectId {
+    client
+        .create(
+            "users",
+            vec![
+                Value::Text(name.to_string()),
+                team_id.map(Value::Uuid).unwrap_or(Value::Null),
+            ],
+        )
+        .await
+        .expect("create user")
+        .0
+}
+
+async fn create_team_edge(
+    client: &JazzClient,
+    child_team: ObjectId,
+    parent_team: ObjectId,
+) -> ObjectId {
+    client
+        .create(
+            "team_edges",
+            vec![Value::Uuid(child_team), Value::Uuid(parent_team)],
+        )
+        .await
+        .expect("create team edge")
+        .0
+}
+
+async fn create_todo(client: &JazzClient, seed: TodoSeed) -> ObjectId {
+    client
+        .create("todos", seed.values())
+        .await
+        .expect("create todo")
+        .0
+}
+
+async fn create_file_part(client: &JazzClient, label: &str) -> ObjectId {
+    client
+        .create("file_parts", vec![Value::Text(label.to_string())])
+        .await
+        .expect("create file part")
+        .0
+}
+
+async fn create_file(client: &JazzClient, name: &str, parts: &[ObjectId]) -> ObjectId {
+    client
+        .create(
+            "files",
+            vec![
+                Value::Text(name.to_string()),
+                Value::Array(parts.iter().copied().map(Value::Uuid).collect()),
+            ],
+        )
+        .await
+        .expect("create file")
+        .0
+}
+
+/// Verifies that a subscription emits add, update, and remove deltas as a row
+/// enters, changes within, and leaves the query result set, and that the
+/// materialized query result stays consistent throughout.
+///
+/// The writer creates a todo filtered by `done=false`, updates its title, then
+/// marks it done. The subscriber observes the full lifecycle. Setting `done=true`
+/// moves the row out of the filter, which must produce a remove delta.
+///
+/// ```text
+/// writer ──insert (done=false)──► server ──► subscriber (add ✓)
+/// writer ──update title──────────► server ──► subscriber (update ✓)
+/// writer ──update done=true──────► server ──► subscriber (remove ✓)
+///                                               query result: empty
+/// ```
+#[tokio::test]
+async fn subscribe_all_emits_add_update_remove_and_tracks_current_results() {
+    let pair = ClientPair::start().await;
+    let query = QueryBuilder::new("todos")
+        .filter_eq("done", Value::Boolean(false))
+        .build();
+
+    let mut stream = pair
+        .subscriber
+        .subscribe(query.clone())
+        .await
+        .expect("subscribe to todos");
+    let mut log = Vec::new();
+
+    let todo_id = create_todo(
+        &pair.writer,
+        TodoSeed {
+            title: "watch-me",
+            done: false,
+            priority: Some(1),
+            tags: &["x"],
+            payload: None,
+        },
+    )
+    .await;
+
+    wait_for_subscription_update(
+        &mut stream,
+        &mut log,
+        QUERY_TIMEOUT,
+        "todo add delta",
+        |log| has_added(log, todo_id),
+    )
+    .await;
+
+    pair.writer
+        .update(
+            todo_id,
+            vec![(
+                "title".to_string(),
+                Value::Text("watch-me-updated".to_string()),
+            )],
+        )
+        .await
+        .expect("update todo title");
+
+    wait_for_subscription_update(
+        &mut stream,
+        &mut log,
+        QUERY_TIMEOUT,
+        "todo update delta",
+        |log| has_updated(log, todo_id),
+    )
+    .await;
+
+    pair.writer
+        .update(todo_id, vec![("done".to_string(), Value::Boolean(true))])
+        .await
+        .expect("mark todo done");
+
+    wait_for_subscription_update(
+        &mut stream,
+        &mut log,
+        QUERY_TIMEOUT,
+        "todo remove delta",
+        |log| has_removed(log, todo_id),
+    )
+    .await;
+
+    let rows = wait_for_rows(
+        &pair.subscriber,
+        query,
+        "todo removed from current results",
+        |rows| (!rows.iter().any(|(id, _)| *id == todo_id)).then_some(rows),
+    )
+    .await;
+    assert!(
+        !rows.iter().any(|(id, _)| *id == todo_id),
+        "latest query results should no longer include the removed todo"
+    );
+
+    pair.shutdown().await;
+}
+
+/// Verifies that each supported filter operator emits an add delta and returns
+/// the inserted row in query results when a matching row is written.
+///
+/// Operators covered: `eq`, `ne`, `gt`, `gte`, `lt`, `lte`, `is_null`,
+/// `contains` on an array column, `contains` on a text column (substring),
+/// `contains` with an empty string (matches all), and `eq` on a bytea column.
+///
+/// Each case uses a dedicated subscriber so subscriptions are isolated. A shared
+/// writer is reused to reduce server startup overhead. The writer's inserts
+/// accumulate across cases, so each subscriber's query result may contain rows
+/// from earlier cases — assertions only check for the presence of the expected row,
+/// not an exact total count.
+#[tokio::test]
+async fn subscribe_all_supports_condition_filters() {
+    struct ConditionCase {
+        name: &'static str,
+        query: Query,
+        insert: TodoSeed,
+    }
+
+    let server = TestingServer::start().await;
+    let schema = subscription_schema();
+    let writer = connect_client(
+        &server,
+        schema.clone(),
+        "condition-writer",
+        "todos",
+        READY_TIMEOUT,
+    )
+    .await;
+
+    let cases = vec![
+        ConditionCase {
+            name: "eq",
+            query: QueryBuilder::new("todos")
+                .filter_eq("title", Value::Text("eq-hit".to_string()))
+                .build(),
+            insert: TodoSeed {
+                title: "eq-hit",
+                done: false,
+                priority: Some(1),
+                tags: &["x"],
+                payload: None,
+            },
+        },
+        ConditionCase {
+            name: "ne",
+            query: QueryBuilder::new("todos")
+                .filter_ne("title", Value::Text("blocked".to_string()))
+                .build(),
+            insert: TodoSeed {
+                title: "ne-hit",
+                done: false,
+                priority: Some(2),
+                tags: &["x"],
+                payload: None,
+            },
+        },
+        ConditionCase {
+            name: "gt",
+            query: QueryBuilder::new("todos")
+                .filter_gt("priority", Value::Integer(10))
+                .build(),
+            insert: TodoSeed {
+                title: "gt-hit",
+                done: false,
+                priority: Some(11),
+                tags: &["x"],
+                payload: None,
+            },
+        },
+        ConditionCase {
+            name: "gte",
+            query: QueryBuilder::new("todos")
+                .filter_ge("priority", Value::Integer(10))
+                .build(),
+            insert: TodoSeed {
+                title: "gte-hit",
+                done: false,
+                priority: Some(10),
+                tags: &["x"],
+                payload: None,
+            },
+        },
+        ConditionCase {
+            name: "lt",
+            query: QueryBuilder::new("todos")
+                .filter_lt("priority", Value::Integer(0))
+                .build(),
+            insert: TodoSeed {
+                title: "lt-hit",
+                done: false,
+                priority: Some(-1),
+                tags: &["x"],
+                payload: None,
+            },
+        },
+        ConditionCase {
+            name: "lte",
+            query: QueryBuilder::new("todos")
+                .filter_le("priority", Value::Integer(0))
+                .build(),
+            insert: TodoSeed {
+                title: "lte-hit",
+                done: false,
+                priority: Some(0),
+                tags: &["x"],
+                payload: None,
+            },
+        },
+        ConditionCase {
+            name: "is_null",
+            query: QueryBuilder::new("todos")
+                .filter_is_null("priority")
+                .build(),
+            insert: TodoSeed {
+                title: "null-hit",
+                done: false,
+                priority: None,
+                tags: &["x"],
+                payload: None,
+            },
+        },
+        ConditionCase {
+            name: "contains_array",
+            query: QueryBuilder::new("todos")
+                .filter_contains("tags", Value::Text("needle".to_string()))
+                .build(),
+            insert: TodoSeed {
+                title: "contains-array-hit",
+                done: false,
+                priority: Some(1),
+                tags: &["needle", "hay"],
+                payload: None,
+            },
+        },
+        ConditionCase {
+            name: "contains_text",
+            query: QueryBuilder::new("todos")
+                .filter_contains("title", Value::Text("needle".to_string()))
+                .build(),
+            insert: TodoSeed {
+                title: "hay-needle-title",
+                done: false,
+                priority: Some(1),
+                tags: &["x"],
+                payload: None,
+            },
+        },
+        ConditionCase {
+            name: "contains_text_empty",
+            query: QueryBuilder::new("todos")
+                .filter_contains("title", Value::Text(String::new()))
+                .build(),
+            insert: TodoSeed {
+                title: "any-title",
+                done: false,
+                priority: Some(1),
+                tags: &["x"],
+                payload: None,
+            },
+        },
+        ConditionCase {
+            name: "eq_bytea",
+            query: QueryBuilder::new("todos")
+                .filter_eq("payload", Value::Bytea(vec![1, 2, 3]))
+                .build(),
+            insert: TodoSeed {
+                title: "eq-bytea-hit",
+                done: false,
+                priority: Some(1),
+                tags: &["x"],
+                payload: Some(&[1, 2, 3]),
+            },
+        },
+    ];
+
+    for case in cases {
+        let subscriber = connect_client(
+            &server,
+            schema.clone(),
+            &format!("condition-subscriber-{}", case.name),
+            "todos",
+            READY_TIMEOUT,
+        )
+        .await;
+        let mut stream = subscriber
+            .subscribe(case.query.clone())
+            .await
+            .expect("subscribe for condition case");
+        let mut log = Vec::new();
+
+        let inserted_id = create_todo(&writer, case.insert).await;
+
+        wait_for_subscription_update(
+            &mut stream,
+            &mut log,
+            QUERY_TIMEOUT,
+            format!("condition {} add delta", case.name),
+            |log| has_added(log, inserted_id),
+        )
+        .await;
+
+        let rows = wait_for_rows(
+            &subscriber,
+            case.query,
+            format!("condition {} query rows", case.name),
+            |rows| {
+                rows.iter()
+                    .any(|(id, _)| *id == inserted_id)
+                    .then_some(rows)
+            },
+        )
+        .await;
+        assert!(
+            rows.iter().any(|(id, _)| *id == inserted_id),
+            "condition {} should include the inserted row",
+            case.name
+        );
+
+        subscriber
+            .shutdown()
+            .await
+            .expect("shutdown condition subscriber");
+    }
+
+    writer.shutdown().await.expect("shutdown condition writer");
+    server.shutdown().await;
+}
+
+/// Verifies that a `Bytea` column value, including interior zero bytes, survives
+/// the write → sync → subscription delta → query result round-trip unmodified.
+///
+/// The writer inserts a todo with `payload = [9, 8, 7, 0]`. The subscriber
+/// receives the add delta and queries the row. The payload byte sequence must
+/// be identical at every stage — zero bytes must not truncate the value.
+#[tokio::test]
+async fn subscribe_all_preserves_bytea_values() {
+    let pair = ClientPair::start().await;
+    let query = QueryBuilder::new("todos")
+        .filter_eq("title", Value::Text("bytes-hit".to_string()))
+        .build();
+
+    let mut stream = pair
+        .subscriber
+        .subscribe(query.clone())
+        .await
+        .expect("subscribe to bytea query");
+    let mut log = Vec::new();
+
+    let todo_id = create_todo(
+        &pair.writer,
+        TodoSeed {
+            title: "bytes-hit",
+            done: false,
+            priority: Some(1),
+            tags: &["x"],
+            payload: Some(&[9, 8, 7, 0]),
+        },
+    )
+    .await;
+
+    wait_for_subscription_update(
+        &mut stream,
+        &mut log,
+        QUERY_TIMEOUT,
+        "bytea add delta",
+        |log| has_added(log, todo_id),
+    )
+    .await;
+
+    let row = wait_for_rows(&pair.subscriber, query, "bytea query row", |rows| {
+        rows.into_iter().find(|(id, _)| *id == todo_id)
+    })
+    .await;
+    assert_eq!(row.1[5], Value::Bytea(vec![9, 8, 7, 0]));
+
+    pair.shutdown().await;
+}
+
+/// Verifies that a subscription with `ORDER BY DESC`, `OFFSET 1`, and `LIMIT 1`
+/// surfaces the correct single row once enough data is inserted to fill the window.
+///
+/// The writer inserts todos with priorities 1, 2, and 3. Sorted descending that
+/// is [3, 2, 1]; offset 1 skips the highest, limit 1 takes the next. The
+/// subscriber must eventually see exactly the priority-2 row as the sole result.
+#[tokio::test]
+async fn subscribe_all_supports_order_by_limit_and_offset() {
+    let pair = ClientPair::start().await;
+    let query = QueryBuilder::new("todos")
+        .order_by_desc("priority")
+        .offset(1)
+        .limit(1)
+        .build();
+
+    let mut stream = pair
+        .subscriber
+        .subscribe(query.clone())
+        .await
+        .expect("subscribe to ordered query");
+    let mut log = Vec::new();
+
+    create_todo(
+        &pair.writer,
+        TodoSeed {
+            title: "p1",
+            done: false,
+            priority: Some(1),
+            tags: &["x"],
+            payload: None,
+        },
+    )
+    .await;
+    create_todo(
+        &pair.writer,
+        TodoSeed {
+            title: "p2",
+            done: false,
+            priority: Some(2),
+            tags: &["x"],
+            payload: None,
+        },
+    )
+    .await;
+    create_todo(
+        &pair.writer,
+        TodoSeed {
+            title: "p3",
+            done: false,
+            priority: Some(3),
+            tags: &["x"],
+            payload: None,
+        },
+    )
+    .await;
+
+    wait_for_subscription_update(
+        &mut stream,
+        &mut log,
+        QUERY_TIMEOUT,
+        "ordered query delta",
+        |log| log.iter().any(|delta| !delta.is_empty()),
+    )
+    .await;
+
+    let rows = wait_for_rows(
+        &pair.subscriber,
+        query,
+        "ordered page current row",
+        |rows| {
+            (rows.len() == 1 && rows[0].1.first() == Some(&Value::Text("p2".to_string())))
+                .then_some(rows)
+        },
+    )
+    .await;
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].1[0], Value::Text("p2".to_string()));
+
+    pair.shutdown().await;
+}
+
+/// Verifies that inserting a row whose text value does not contain the filter
+/// string does not emit a spurious add delta on a `contains` subscription.
+///
+/// The writer inserts a todo with a title that does not include "needle". The
+/// subscriber's query result must remain empty and no add delta must appear.
+/// An EdgeServer query on the subscriber is used as the causal barrier before
+/// draining the stream: once the server confirms the empty result set, any
+/// notification it was going to send has already been sent or withheld.
+///
+/// ```text
+/// writer ──insert "completely unrelated"──► server
+///                                              │
+///                              contains("needle") filter ──✗── subscriber stream (no add)
+/// ```
+#[tokio::test]
+async fn subscribe_all_does_not_emit_add_for_non_matching_contains_query() {
+    let pair = ClientPair::start().await;
+    let query = QueryBuilder::new("todos")
+        .filter_contains("title", Value::Text("needle".to_string()))
+        .build();
+
+    let mut stream = pair
+        .subscriber
+        .subscribe(query.clone())
+        .await
+        .expect("subscribe to contains query");
+    let mut log = Vec::new();
+
+    let inserted_id = create_todo(
+        &pair.writer,
+        TodoSeed {
+            title: "completely unrelated",
+            done: false,
+            priority: Some(1),
+            tags: &["x"],
+            payload: None,
+        },
+    )
+    .await;
+
+    // The EdgeServer query returning empty is the causal barrier: by the time
+    // the server confirms no matching rows, it has already decided whether to
+    // send a subscription notification. The drain then flushes any buffered
+    // messages before the negative assertion.
+    wait_for_rows(
+        &pair.subscriber,
+        query,
+        "empty contains query results",
+        |rows| rows.is_empty().then_some(()),
+    )
+    .await;
+    collect_stream_deltas(&mut stream, &mut log, NO_DELTA_WINDOW).await;
+
+    assert!(
+        !has_added(&log, inserted_id),
+        "non-matching text contains insert should not emit an add delta"
+    );
+
+    pair.shutdown().await;
+}
+
+/// Verifies that a `with_array` projected include delivers a correctly typed
+/// sub-array column, starting empty when the parent row has no related rows.
+///
+/// The query fetches users with an inline `todos_via_owner` array correlated on
+/// `owner_id`. The writer creates a user with no todos. The subscriber must
+/// receive an add delta for the user and the include column must be an empty
+/// array — not null or missing.
+#[tokio::test]
+async fn subscribe_all_supports_array_include_queries() {
+    let pair = ClientPair::start().await;
+    let query = QueryBuilder::new("users")
+        .with_array("todos_via_owner", |sub| {
+            sub.from("todos").correlate("owner_id", "_id")
+        })
+        .build();
+
+    let mut stream = pair
+        .subscriber
+        .subscribe(query.clone())
+        .await
+        .expect("subscribe to include query");
+    let mut log = Vec::new();
+
+    let user_id = create_user(&pair.writer, "Owner", None).await;
+
+    wait_for_subscription_update(
+        &mut stream,
+        &mut log,
+        QUERY_TIMEOUT,
+        "include query add delta",
+        |log| has_added(log, user_id),
+    )
+    .await;
+
+    let rows = wait_for_rows(&pair.subscriber, query, "include query row", |rows| {
+        rows.iter().any(|(id, _)| *id == user_id).then_some(rows)
+    })
+    .await;
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].0, user_id);
+    assert_eq!(rows[0].1[0], Value::Text("Owner".to_string()));
+    assert_eq!(rows[0].1[1], Value::Null);
+    assert!(
+        rows[0].1[2]
+            .as_array()
+            .expect("include column should be an array")
+            .is_empty(),
+        "new owner should start with an empty included todos array"
+    );
+
+    pair.shutdown().await;
+}
+
+/// Verifies that a two-hop projected join traverses users → teams → orgs and
+/// emits the org row (result_element_index 2) as the subscription result.
+///
+/// The writer creates an org, a team in that org, and a user in that team. The
+/// subscription must surface the org as an add delta once all three rows are
+/// present, and the query result must contain the org's data.
+///
+/// ```text
+/// writer ──create org──────────────────► server
+/// writer ──create team (org_id=org)───► server
+/// writer ──create user (team_id=team)─► server
+///                                          │
+///              query: users → teams → orgs [result=orgs]
+///                                          │
+///                                          └──► subscriber (add delta: org ✓)
+/// ```
+#[tokio::test]
+async fn subscribe_all_supports_hop_queries_via_projected_joins() {
+    let pair = ClientPair::start().await;
+    let query = QueryBuilder::new("users")
+        .join("teams")
+        .on("users.team_id", "teams._id")
+        .join("orgs")
+        .on("teams.org_id", "orgs._id")
+        .result_element_index(2)
+        .build();
+
+    let mut stream = pair
+        .subscriber
+        .subscribe(query.clone())
+        .await
+        .expect("subscribe to hop query");
+    let mut log = Vec::new();
+
+    let org_id = create_org(&pair.writer, "Hop Org").await;
+    let team_id = create_team(&pair.writer, "Hop Team", Some(org_id), None).await;
+    let _user_id = create_user(&pair.writer, "Hop User", Some(team_id)).await;
+
+    wait_for_subscription_update(
+        &mut stream,
+        &mut log,
+        QUERY_TIMEOUT,
+        "hop query add delta",
+        |log| has_added(log, org_id),
+    )
+    .await;
+
+    let rows = wait_for_rows(&pair.subscriber, query, "hop query rows", |rows| {
+        (rows.len() == 1 && rows[0].0 == org_id).then_some(rows)
+    })
+    .await;
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].0, org_id);
+    assert_eq!(rows[0].1[0], Value::Text("Hop Org".to_string()));
+
+    pair.shutdown().await;
+}
+
+/// Verifies that updating a scalar foreign key causes a projected join
+/// subscription to swap from the old joined row to the new one.
+///
+/// A user "Mover" starts assigned to Team A. The subscription projects
+/// users → teams (result_element_index 1), so it surfaces the team row. The
+/// writer reassigns the user to Team B. Both Team A and Team B must appear
+/// somewhere in the stream log (one exits, one enters), and the final query
+/// result must contain only Team B.
+///
+/// ```text
+/// writer ──create user (team_id=team_a)──► server
+/// subscriber query result: [team_a]
+///
+/// writer ──update user.team_id → team_b──► server ──► subscriber
+///   stream: change for team_a AND team_b
+///   query result: [team_b]
+/// ```
+#[tokio::test]
+async fn subscribe_all_reacts_to_scalar_fk_updates_in_projected_join_queries() {
+    let pair = ClientPair::start().await;
+
+    let org_a = create_org(&pair.writer, "Org A").await;
+    let org_b = create_org(&pair.writer, "Org B").await;
+    let team_a = create_team(&pair.writer, "Team A", Some(org_a), None).await;
+    let team_b = create_team(&pair.writer, "Team B", Some(org_b), None).await;
+    let user_id = create_user(&pair.writer, "Mover", Some(team_a)).await;
+
+    let query = QueryBuilder::new("users")
+        .join("teams")
+        .on("users.team_id", "teams._id")
+        .result_element_index(1)
+        .build();
+
+    let mut stream = pair
+        .subscriber
+        .subscribe(query.clone())
+        .await
+        .expect("subscribe to team hop query");
+    let mut log = Vec::new();
+
+    wait_for_rows(
+        &pair.subscriber,
+        query.clone(),
+        "initial team row",
+        |rows| (rows.len() == 1 && rows[0].0 == team_a).then_some(()),
+    )
+    .await;
+
+    pair.writer
+        .update(user_id, vec![("team_id".to_string(), Value::Uuid(team_b))])
+        .await
+        .expect("move user to new team");
+
+    let rows = wait_for_rows(&pair.subscriber, query, "updated team row", |rows| {
+        (rows.len() == 1 && rows[0].0 == team_b).then_some(rows)
+    })
+    .await;
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].0, team_b);
+    assert_eq!(rows[0].1[0], Value::Text("Team B".to_string()));
+
+    // The query result transitioning to team_b is the causal barrier above.
+    // Draining the stream afterwards captures any remaining delta batches
+    // before asserting both teams were touched.
+    collect_stream_deltas(&mut stream, &mut log, NO_DELTA_WINDOW).await;
+    // Both the old and new joined rows must appear in the log: the join
+    // re-evaluated when team_id changed, removing team_a and adding team_b.
+    assert!(has_any_change(&log, team_a));
+    assert!(has_any_change(&log, team_b));
+
+    pair.shutdown().await;
+}
+
+/// Verifies that replacing a UUID array foreign key causes a projected join
+/// subscription to react to both the departing and arriving joined rows.
+///
+/// A file starts with `parts = [part_a]`. The subscription projects
+/// files → file_parts (result_element_index 1), surfacing part rows. The
+/// writer replaces the array with `[part_b]`. Both part_a and part_b must
+/// appear somewhere in the stream log, and the final query result must
+/// contain only part_b.
+///
+/// ```text
+/// writer ──create file (parts=[part_a])────► server
+/// subscriber query result: [part_a]
+///
+/// writer ──update file.parts → [part_b]───► server ──► subscriber
+///   stream: change for part_a AND part_b
+///   query result: [part_b]
+/// ```
+#[tokio::test]
+async fn subscribe_all_reacts_to_uuid_array_fk_updates_in_projected_join_queries() {
+    let pair = ClientPair::start().await;
+
+    let part_a = create_file_part(&pair.writer, "A").await;
+    let part_b = create_file_part(&pair.writer, "B").await;
+    let file_id = create_file(&pair.writer, "File", &[part_a]).await;
+
+    let query = QueryBuilder::new("files")
+        .join("file_parts")
+        .on("files.parts", "file_parts._id")
+        .result_element_index(1)
+        .build();
+
+    let mut stream = pair
+        .subscriber
+        .subscribe(query.clone())
+        .await
+        .expect("subscribe to file parts hop query");
+    let mut log = Vec::new();
+
+    wait_for_rows(
+        &pair.subscriber,
+        query.clone(),
+        "initial file part row",
+        |rows| (rows.len() == 1 && rows[0].0 == part_a).then_some(()),
+    )
+    .await;
+
+    pair.writer
+        .update(
+            file_id,
+            vec![("parts".to_string(), Value::Array(vec![Value::Uuid(part_b)]))],
+        )
+        .await
+        .expect("swap file part ids");
+
+    let rows = wait_for_rows(&pair.subscriber, query, "updated file part row", |rows| {
+        (rows.len() == 1 && rows[0].0 == part_b).then_some(rows)
+    })
+    .await;
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].0, part_b);
+    assert_eq!(rows[0].1[0], Value::Text("B".to_string()));
+
+    // Same pattern as the scalar FK test: drain after query convergence,
+    // then assert both the old part and the new part were affected.
+    collect_stream_deltas(&mut stream, &mut log, NO_DELTA_WINDOW).await;
+    assert!(has_any_change(&log, part_a));
+    assert!(has_any_change(&log, part_b));
+
+    pair.shutdown().await;
+}
+
+/// Verifies that a recursive gather query seeds on a matching row and
+/// transitively reaches all ancestor rows by following the edge table.
+///
+/// Three teams form a chain: leaf → mid → root, connected via `team_edges`
+/// (child_team, parent_team). The query seeds on `teams(name="leaf")` and
+/// gathers upward. The subscriber must eventually see all three teams in the
+/// result set, regardless of insertion order.
+///
+/// ```text
+/// teams:   leaf ──edge──► mid ──edge──► root
+///
+/// query: seed = teams WHERE name="leaf"
+///        gather via team_edges(child_team=_id) → select parent_team → hop teams
+///
+/// expected result: {leaf, mid, root}
+/// ```
+#[tokio::test]
+async fn subscribe_all_supports_recursive_gather_queries() {
+    let pair = ClientPair::start().await;
+    let query = QueryBuilder::new("teams")
+        .filter_eq("name", Value::Text("leaf".to_string()))
+        .with_recursive(|r| {
+            r.from("team_edges")
+                .correlate("child_team", "_id")
+                .select(&["parent_team"])
+                .hop("teams", "parent_team")
+                .max_depth(10)
+        })
+        .build();
+
+    let mut stream = pair
+        .subscriber
+        .subscribe(query.clone())
+        .await
+        .expect("subscribe to recursive gather query");
+    let mut log = Vec::new();
+
+    let root_id = create_team(&pair.writer, "root", None, None).await;
+    let mid_id = create_team(&pair.writer, "mid", None, None).await;
+    let leaf_id = create_team(&pair.writer, "leaf", None, None).await;
+    let _edge_one = create_team_edge(&pair.writer, leaf_id, mid_id).await;
+    let _edge_two = create_team_edge(&pair.writer, mid_id, root_id).await;
+
+    wait_for_subscription_update(
+        &mut stream,
+        &mut log,
+        QUERY_TIMEOUT,
+        "recursive gather add delta",
+        |log| has_added(log, leaf_id),
+    )
+    .await;
+
+    let rows = wait_for_rows(&pair.subscriber, query, "recursive gather rows", |rows| {
+        let mut names = rows
+            .iter()
+            .filter_map(|(_, values)| match values.first() {
+                Some(Value::Text(name)) => Some(name.clone()),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        names.sort();
+
+        (names == vec!["leaf".to_string(), "mid".to_string(), "root".to_string()]).then_some(rows)
+    })
+    .await;
+    let mut names = rows
+        .iter()
+        .filter_map(|(_, values)| match values.first() {
+            Some(Value::Text(name)) => Some(name.clone()),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    names.sort();
+    assert_eq!(names, vec!["leaf", "mid", "root"]);
+
+    pair.shutdown().await;
+}

--- a/crates/jazz-tools/tests/subscribe_all_integration.rs
+++ b/crates/jazz-tools/tests/subscribe_all_integration.rs
@@ -10,8 +10,8 @@ use jazz_tools::{
     Value,
 };
 use support::{
-    collect_stream_deltas, connect_client, has_added, has_any_change, has_removed, has_updated,
-    wait_for_rows, wait_for_subscription_update,
+    collect_stream_deltas, connect_admin_client, has_added, has_any_change, has_removed,
+    has_updated, wait_for_rows, wait_for_subscription_update,
 };
 
 const READY_TIMEOUT: Duration = Duration::from_secs(30);
@@ -75,7 +75,7 @@ impl ClientPair {
     async fn start() -> Self {
         let server = TestingServer::start().await;
         let schema = subscription_schema();
-        let writer = connect_client(
+        let writer = connect_admin_client(
             &server,
             schema.clone(),
             "subscribe-all-writer",
@@ -83,7 +83,7 @@ impl ClientPair {
             READY_TIMEOUT,
         )
         .await;
-        let subscriber = connect_client(
+        let subscriber = connect_admin_client(
             &server,
             schema,
             "subscribe-all-subscriber",
@@ -345,7 +345,7 @@ async fn subscribe_all_supports_condition_filters() {
 
     let server = TestingServer::start().await;
     let schema = subscription_schema();
-    let writer = connect_client(
+    let writer = connect_admin_client(
         &server,
         schema.clone(),
         "condition-writer",
@@ -501,7 +501,7 @@ async fn subscribe_all_supports_condition_filters() {
     ];
 
     for case in cases {
-        let subscriber = connect_client(
+        let subscriber = connect_admin_client(
             &server,
             schema.clone(),
             &format!("condition-subscriber-{}", case.name),

--- a/crates/jazz-tools/tests/support/mod.rs
+++ b/crates/jazz-tools/tests/support/mod.rs
@@ -120,7 +120,7 @@ pub async fn wait_for_edge_query_ready(client: &JazzClient, table: &str, timeout
 /// This keeps the testing server's backend/admin secrets intact, which is
 /// appropriate for general integration tests that are not asserting user policy
 /// enforcement.
-pub async fn connect_client(
+pub async fn connect_admin_client(
     server: &TestingServer,
     schema: Schema,
     user_id: &str,
@@ -141,7 +141,7 @@ pub async fn connect_client(
 ///
 /// This strips the testing server's backend/admin secrets so policy tests
 /// exercise the same authorization path as a normal user client.
-pub async fn connect_jwt_client(
+pub async fn connect_client(
     server: &TestingServer,
     schema: Schema,
     user_id: &str,

--- a/crates/jazz-tools/tests/support/mod.rs
+++ b/crates/jazz-tools/tests/support/mod.rs
@@ -1,14 +1,27 @@
 use std::future::Future;
 use std::time::Duration;
 
-use jazz_tools::{DurabilityTier, JazzClient, ObjectId, Query, Value};
+use jazz_tools::server::TestingServer;
+use jazz_tools::{
+    AppContext, DurabilityTier, JazzClient, ObjectId, OrderedRowDelta, Query, QueryBuilder, Schema,
+    SubscriptionStream, Value,
+};
 
 const DEFAULT_POLL_INTERVAL: Duration = Duration::from_millis(250);
 const DEFAULT_QUERY_TIMEOUT: Duration = Duration::from_secs(8);
+#[allow(dead_code)]
+const DEFAULT_ROWS_TIMEOUT: Duration = Duration::from_secs(25);
+#[allow(dead_code)]
+const DEFAULT_STREAM_POLL_INTERVAL: Duration = Duration::from_millis(50);
 
+/// Convenience shape for query results returned by test helpers.
 pub type QueryRows = Vec<(ObjectId, Vec<Value>)>;
 
 #[allow(dead_code)]
+/// Polls an async predicate until it returns a value or the timeout expires.
+///
+/// This is the lowest-level waiting primitive used by the test helpers in this
+/// module.
 pub async fn wait_for<T, F, Fut>(
     timeout: Duration,
     description: impl Into<String>,
@@ -34,6 +47,11 @@ where
     }
 }
 
+/// Re-runs a query until its rows satisfy the provided matcher or the timeout
+/// expires.
+///
+/// Per-attempt query timeouts and transient query errors are retried until the
+/// outer deadline is reached.
 pub async fn wait_for_query<T, F>(
     client: &JazzClient,
     query: Query,
@@ -48,21 +66,222 @@ where
     let description = description.into();
     let deadline = tokio::time::Instant::now() + timeout;
 
+    let mut last_error: Option<String> = None;
+
     loop {
-        if let Ok(Ok(rows)) = tokio::time::timeout(
+        match tokio::time::timeout(
             DEFAULT_QUERY_TIMEOUT,
             client.query(query.clone(), durability_tier),
         )
         .await
-            && let Some(value) = check_rows(rows)
         {
-            return value;
+            Ok(Ok(rows)) => {
+                if let Some(value) = check_rows(rows) {
+                    return value;
+                }
+                last_error = None;
+            }
+            Ok(Err(e)) => last_error = Some(e.to_string()),
+            Err(_) => {} // per-attempt timeout, will retry
         }
 
         if tokio::time::Instant::now() >= deadline {
-            panic!("timed out waiting for {description}");
+            match last_error {
+                Some(e) => panic!("timed out waiting for {description}: last query error: {e}"),
+                None => panic!("timed out waiting for {description}"),
+            }
         }
 
         tokio::time::sleep(DEFAULT_POLL_INTERVAL).await;
     }
+}
+
+#[allow(dead_code)]
+/// Waits until a trivial EdgeServer query against `table` succeeds.
+///
+/// Tests use this after connecting a client so subscription and query checks do
+/// not race the initial schema/catalogue sync.
+pub async fn wait_for_edge_query_ready(client: &JazzClient, table: &str, timeout: Duration) {
+    wait_for_query(
+        client,
+        QueryBuilder::new(table).build(),
+        Some(DurabilityTier::EdgeServer),
+        timeout,
+        format!("EdgeServer query readiness for {table}"),
+        |_| Some(()),
+    )
+    .await;
+}
+
+#[allow(dead_code)]
+/// Connects a test client using the default testing context and waits for the
+/// requested table to become queryable on the edge server.
+///
+/// This keeps the testing server's backend/admin secrets intact, which is
+/// appropriate for general integration tests that are not asserting user policy
+/// enforcement.
+pub async fn connect_client(
+    server: &TestingServer,
+    schema: Schema,
+    user_id: &str,
+    ready_table: &str,
+    ready_timeout: Duration,
+) -> JazzClient {
+    connect_client_with_context(
+        server.make_client_context_for_user(schema, user_id),
+        ready_table,
+        ready_timeout,
+    )
+    .await
+}
+
+#[allow(dead_code)]
+/// Connects a test client using only its JWT session and waits for the
+/// requested table to become queryable on the edge server.
+///
+/// This strips the testing server's backend/admin secrets so policy tests
+/// exercise the same authorization path as a normal user client.
+pub async fn connect_jwt_client(
+    server: &TestingServer,
+    schema: Schema,
+    user_id: &str,
+    ready_table: &str,
+    ready_timeout: Duration,
+) -> JazzClient {
+    let mut context = server.make_client_context_for_user(schema, user_id);
+    context.backend_secret = None;
+    context.admin_secret = None;
+
+    connect_client_with_context(context, ready_table, ready_timeout).await
+}
+
+#[allow(dead_code)]
+/// Shared implementation for test client connection helpers.
+async fn connect_client_with_context(
+    context: AppContext,
+    ready_table: &str,
+    ready_timeout: Duration,
+) -> JazzClient {
+    let client = JazzClient::connect(context)
+        .await
+        .expect("connect test client");
+    wait_for_edge_query_ready(&client, ready_table, ready_timeout).await;
+    client
+}
+
+#[allow(dead_code)]
+/// Re-runs an EdgeServer query until its rows satisfy the matcher, using the
+/// module's default row timeout.
+pub async fn wait_for_rows<T, F>(
+    client: &JazzClient,
+    query: Query,
+    description: impl Into<String>,
+    check_rows: F,
+) -> T
+where
+    F: FnMut(QueryRows) -> Option<T>,
+{
+    wait_for_query(
+        client,
+        query,
+        Some(DurabilityTier::EdgeServer),
+        DEFAULT_ROWS_TIMEOUT,
+        description,
+        check_rows,
+    )
+    .await
+}
+
+#[allow(dead_code)]
+/// Reads subscription deltas until the accumulated log satisfies the provided
+/// predicate or the timeout expires.
+///
+/// The matching delta is appended to `log` before the predicate is checked
+/// again, so callers can assert against the full sequence of observed changes.
+pub async fn wait_for_subscription_update<F>(
+    stream: &mut SubscriptionStream,
+    log: &mut Vec<OrderedRowDelta>,
+    timeout: Duration,
+    description: impl Into<String>,
+    mut predicate: F,
+) where
+    F: FnMut(&[OrderedRowDelta]) -> bool,
+{
+    let description = description.into();
+    let deadline = tokio::time::Instant::now() + timeout;
+
+    loop {
+        if predicate(log) {
+            return;
+        }
+
+        let now = tokio::time::Instant::now();
+        if now >= deadline {
+            panic!("timed out waiting for {description}");
+        }
+
+        let delta = tokio::time::timeout(deadline - now, stream.next())
+            .await
+            .unwrap_or_else(|_| panic!("timed out waiting for {description}"))
+            .unwrap_or_else(|| {
+                panic!("subscription stream closed while waiting for {description}")
+            });
+
+        log.push(delta);
+    }
+}
+
+#[allow(dead_code)]
+/// Collects any subscription deltas that arrive within a fixed window.
+///
+/// This is useful for asserting that no extra updates were broadcast after an
+/// operation, while still recording any unexpected deltas for debug output.
+pub async fn collect_stream_deltas(
+    stream: &mut SubscriptionStream,
+    log: &mut Vec<OrderedRowDelta>,
+    duration: Duration,
+) {
+    let deadline = tokio::time::Instant::now() + duration;
+
+    loop {
+        let now = tokio::time::Instant::now();
+        if now >= deadline {
+            return;
+        }
+
+        let next_wait = (deadline - now).min(DEFAULT_STREAM_POLL_INTERVAL);
+        match tokio::time::timeout(next_wait, stream.next()).await {
+            Ok(Some(delta)) => log.push(delta),
+            Ok(None) => return,
+            Err(_) => continue,
+        }
+    }
+}
+
+#[allow(dead_code)]
+/// Returns true if any logged subscription delta contains `id` in its added set.
+pub fn has_added(log: &[OrderedRowDelta], id: ObjectId) -> bool {
+    log.iter()
+        .any(|delta| delta.added.iter().any(|change| change.id == id))
+}
+
+#[allow(dead_code)]
+/// Returns true if any logged subscription delta contains `id` in its removed set.
+pub fn has_removed(log: &[OrderedRowDelta], id: ObjectId) -> bool {
+    log.iter()
+        .any(|delta| delta.removed.iter().any(|change| change.id == id))
+}
+
+#[allow(dead_code)]
+/// Returns true if any logged subscription delta contains `id` in its updated set.
+pub fn has_updated(log: &[OrderedRowDelta], id: ObjectId) -> bool {
+    log.iter()
+        .any(|delta| delta.updated.iter().any(|change| change.id == id))
+}
+
+#[allow(dead_code)]
+/// Returns true if any logged subscription delta references `id` as an add,
+/// update, or removal.
+pub fn has_any_change(log: &[OrderedRowDelta], id: ObjectId) -> bool {
+    has_added(log, id) || has_updated(log, id) || has_removed(log, id)
 }


### PR DESCRIPTION
This PR now contains the testing improvements from the original branch after the insert-policy fix landed separately in #329.

Included here:
- policy and subscribe-all integration tests
- TestingServer builder cleanup to simplify test setup
- client connection helper renames/cleanup used by the tests

Removed from this PR:
- the narrower client-originated insert policy fix commit, since #329 already landed the broader fix

This keeps the added coverage and test ergonomics without reintroducing the overlapping fix.