### PR TITLE
Fix wildcard permission introspection projections

### DIFF
--- a/.changeset/mixed-star-permissions.md
+++ b/.changeset/mixed-star-permissions.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Fix mixed `select("*", "$canDelete")` projections so permission introspection columns can be combined with wildcard row selection, including nested include projections, and document the supported query shape.

--- a/docs/content/docs/reading-data.mdx
+++ b/docs/content/docs/reading-data.mdx
@@ -245,6 +245,8 @@ Schema references used by the include examples:
 Permission introspection columns are computed for the current session and are omitted from
 `select("*")`, so you opt into them explicitly.
 
+For example, `select("*", "$canDelete")` returns the normal row columns plus `$canDelete`.
+
 - `$canRead` reflects whether the current session can read the row. Since read policies already
   gate which rows appear, returned rows will usually show `$canRead: true`.
 - `$canEdit` reflects whether the current session passes the row's `UPDATE USING` policy.

--- a/examples/docs/todo-client-localfirst-ts/src/docs-snippets.ts
+++ b/examples/docs/todo-client-localfirst-ts/src/docs-snippets.ts
@@ -77,6 +77,10 @@ export async function readTodoPermissionIntrospection(db: Db) {
   );
 }
 
+export async function readTodosWithDeletePermission(db: Db) {
+  return db.all(app.todos.select("*", "$canDelete").orderBy("title", "asc"));
+}
+
 export async function readEditableTodos(db: Db) {
   return db.all(app.todos.where({ $canEdit: true }).select("title", "$canEdit"));
 }

--- a/packages/jazz-tools/src/codegen/codegen.test.ts
+++ b/packages/jazz-tools/src/codegen/codegen.test.ts
@@ -1032,7 +1032,7 @@ describe("generateTypes with relations", () => {
       "export type TodoSelected<S extends TodoSelectableColumn = keyof Todo>",
     );
     expect(output).toContain(
-      '"*" extends S ? Todo : Pick<Todo, Extract<S | "id", keyof Todo>> & Pick<PermissionIntrospectionColumns, Extract<S, PermissionIntrospectionColumn>>',
+      '("*" extends S ? Todo : Pick<Todo, Extract<S | "id", keyof Todo>>) & Pick<PermissionIntrospectionColumns, Extract<S, PermissionIntrospectionColumn>>',
     );
     expect(output).toContain(
       "export type TodoSelectedWithIncludes<I extends TodoInclude = {}, S extends TodoSelectableColumn = keyof Todo, R extends boolean = false>",

--- a/packages/jazz-tools/src/codegen/type-generator.ts
+++ b/packages/jazz-tools/src/codegen/type-generator.ts
@@ -349,7 +349,7 @@ function generateSelectionTypes(schema: WasmSchema, relations: Map<string, Relat
     lines.push("");
 
     lines.push(
-      `export type ${baseInterface}Selected<S extends ${selectableColumnType} = keyof ${baseInterface}> = "*" extends S ? ${baseInterface} : Pick<${baseInterface}, Extract<S | "id", keyof ${baseInterface}>> & Pick<PermissionIntrospectionColumns, Extract<S, PermissionIntrospectionColumn>>;`,
+      `export type ${baseInterface}Selected<S extends ${selectableColumnType} = keyof ${baseInterface}> = ("*" extends S ? ${baseInterface} : Pick<${baseInterface}, Extract<S | "id", keyof ${baseInterface}>>) & Pick<PermissionIntrospectionColumns, Extract<S, PermissionIntrospectionColumn>>;`,
     );
     lines.push("");
 

--- a/packages/jazz-tools/src/runtime/client.for-request.test.ts
+++ b/packages/jazz-tools/src/runtime/client.for-request.test.ts
@@ -963,6 +963,155 @@ describe("JazzClient schema order", () => {
     ]);
   });
 
+  it("keeps magic projection values ahead of included rows during schema alignment", async () => {
+    const runtime: Runtime = {
+      insert: () => mockRow(),
+      update: () => {},
+      delete: () => {},
+      query: async () => [
+        {
+          id: "todo-1",
+          values: [
+            { type: "Text", value: "Buy milk" },
+            { type: "Boolean", value: true },
+            {
+              type: "Array",
+              value: [
+                {
+                  type: "Row",
+                  value: {
+                    id: "project-1",
+                    values: [
+                      { type: "Text", value: "inbox" },
+                      { type: "Text", value: "Inbox" },
+                    ],
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      subscribe: () => 0,
+      createSubscription: () => 0,
+      executeSubscription: () => {},
+      unsubscribe: () => {},
+      insertDurable: async () => mockRow(),
+      updateDurable: async () => {},
+      deleteDurable: async () => {},
+      onSyncMessageReceived: () => {},
+      onSyncMessageToSend: () => {},
+      addServer: () => {},
+      removeServer: () => {},
+      addClient: () => "client-1",
+      getSchema: () =>
+        new Map([
+          [
+            "todos",
+            {
+              columns: [
+                {
+                  name: "done",
+                  column_type: { type: "Boolean" as const },
+                  nullable: false,
+                },
+                {
+                  name: "title",
+                  column_type: { type: "Text" as const },
+                  nullable: false,
+                },
+              ],
+            },
+          ],
+          [
+            "projects",
+            {
+              columns: [
+                {
+                  name: "slug",
+                  column_type: { type: "Text" as const },
+                  nullable: false,
+                },
+                {
+                  name: "name",
+                  column_type: { type: "Text" as const },
+                  nullable: false,
+                },
+              ],
+            },
+          ],
+        ]),
+      getSchemaHash: () => "schema-hash",
+    };
+    const client = JazzClient.connectWithRuntime(runtime, {
+      appId: "test-app",
+      schema: {
+        todos: {
+          columns: [
+            {
+              name: "title",
+              column_type: { type: "Text" as const },
+              nullable: false,
+            },
+            {
+              name: "done",
+              column_type: { type: "Boolean" as const },
+              nullable: false,
+            },
+          ],
+        },
+        projects: {
+          columns: [
+            {
+              name: "name",
+              column_type: { type: "Text" as const },
+              nullable: false,
+            },
+            {
+              name: "slug",
+              column_type: { type: "Text" as const },
+              nullable: false,
+            },
+          ],
+        },
+      },
+    });
+
+    const rows = await client.query(
+      JSON.stringify({
+        table: "todos",
+        relation_ir: { TableScan: { table: "todos" } },
+        select_columns: ["title", "$canDelete", "__jazz_include_project"],
+        array_subqueries: [{ table: "projects", nested_arrays: [] }],
+      }),
+    );
+
+    expect(rows).toEqual([
+      {
+        id: "todo-1",
+        values: [
+          { type: "Text", value: "Buy milk" },
+          { type: "Boolean", value: true },
+          {
+            type: "Array",
+            value: [
+              {
+                type: "Row",
+                value: {
+                  id: "project-1",
+                  values: [
+                    { type: "Text", value: "Inbox" },
+                    { type: "Text", value: "inbox" },
+                  ],
+                },
+              },
+            ],
+          },
+        ],
+      },
+    ]);
+  });
+
   it("reorders subscription deltas back to the declared schema order", async () => {
     let onUpdate: ((delta: unknown) => void) | undefined;
     const runtime: Runtime = {

--- a/packages/jazz-tools/src/runtime/client.ts
+++ b/packages/jazz-tools/src/runtime/client.ts
@@ -25,6 +25,7 @@ import {
 import { resolveLocalAuthDefaults } from "./local-auth.js";
 import { resolveClientSessionSync } from "./client-session.js";
 import { translateQuery } from "./query-adapter.js";
+import { isHiddenIncludeColumnName, resolveSelectedColumns } from "./select-projection.js";
 
 /**
  * Minimal request shape supported by `JazzClient.forRequest()`.
@@ -837,20 +838,20 @@ export class JazzClient {
       return values;
     }
 
-    const projectedBaseColumnCount =
+    const projectedVisibleColumnCount =
       selectColumns.length > 0
-        ? selectColumns.filter((columnName) =>
-            declaredTable.columns.some((column) => column.name === columnName),
+        ? resolveSelectedColumns(table, this.context.schema, selectColumns).filter(
+            (columnName) => !isHiddenIncludeColumnName(columnName),
           ).length
         : 0;
 
-    if (projectedBaseColumnCount > 0) {
-      if (values.length < projectedBaseColumnCount) {
+    if (projectedVisibleColumnCount > 0) {
+      if (values.length < projectedVisibleColumnCount) {
         return values;
       }
 
-      const projectedValues = values.slice(0, projectedBaseColumnCount);
-      const trailingValues = values.slice(projectedBaseColumnCount);
+      const projectedValues = values.slice(0, projectedVisibleColumnCount);
+      const trailingValues = values.slice(projectedVisibleColumnCount);
       if (arraySubqueries.length === 0) {
         return projectedValues.concat(trailingValues);
       }

--- a/packages/jazz-tools/src/runtime/query-adapter.test.ts
+++ b/packages/jazz-tools/src/runtime/query-adapter.test.ts
@@ -133,7 +133,41 @@ describe("translateQuery", () => {
 
       const result = parseTranslatedQuery(builderJson, basicSchema);
 
-      expect(result.select_columns).toBeUndefined();
+      expect(result.select_columns).toEqual([
+        "title",
+        "done",
+        "priority",
+        "status",
+        "project",
+        "tags",
+        "metadata",
+        "created_at",
+      ]);
+      expect(result.relation_ir).toEqual({ type: "TableScan", table: "todos" });
+    });
+
+    it('expands mixed select(["*", "$canDelete"]) into explicit runtime columns', () => {
+      const builderJson = JSON.stringify({
+        table: "todos",
+        conditions: [],
+        includes: {},
+        select: ["*", "$canDelete"],
+        orderBy: [],
+      });
+
+      const result = parseTranslatedQuery(builderJson, basicSchema);
+
+      expect(result.select_columns).toEqual([
+        "title",
+        "done",
+        "priority",
+        "status",
+        "project",
+        "tags",
+        "metadata",
+        "created_at",
+        "$canDelete",
+      ]);
       expect(result.relation_ir).toEqual({ type: "TableScan", table: "todos" });
     });
   });
@@ -1203,6 +1237,94 @@ describe("translateQuery", () => {
       ]);
     });
 
+    it("translates include builders with mixed wildcard and magic projections", () => {
+      const nestedSchema: WasmSchema = {
+        comments: {
+          columns: [
+            { name: "text", column_type: { type: "Text" }, nullable: false },
+            {
+              name: "todo_id",
+              column_type: { type: "Uuid" },
+              nullable: false,
+              references: "todos",
+            },
+          ],
+        },
+        todos: {
+          columns: [
+            { name: "title", column_type: { type: "Text" }, nullable: false },
+            {
+              name: "owner_id",
+              column_type: { type: "Uuid" },
+              nullable: false,
+              references: "users",
+            },
+          ],
+        },
+        users: {
+          columns: [
+            { name: "name", column_type: { type: "Text" }, nullable: false },
+            { name: "email", column_type: { type: "Text" }, nullable: false },
+          ],
+        },
+      };
+
+      const builderJson = JSON.stringify({
+        table: "comments",
+        conditions: [],
+        includes: {
+          todo: {
+            table: "todos",
+            conditions: [],
+            includes: {
+              owner: {
+                table: "users",
+                conditions: [],
+                includes: {},
+                select: ["*", "$canEdit"],
+                orderBy: [],
+                hops: [],
+              },
+            },
+            select: ["*", "$canDelete"],
+            orderBy: [],
+            hops: [],
+          },
+        },
+        orderBy: [],
+      });
+
+      const result = parseTranslatedQuery(builderJson, nestedSchema);
+
+      expect(result.array_subqueries).toEqual([
+        {
+          column_name: "todo",
+          table: "todos",
+          inner_column: "id",
+          outer_column: "comments.todo_id",
+          filters: [],
+          joins: [],
+          select_columns: ["title", "owner_id", "$canDelete", "__jazz_include_owner"],
+          order_by: [],
+          limit: null,
+          nested_arrays: [
+            {
+              column_name: "__jazz_include_owner",
+              table: "users",
+              inner_column: "id",
+              outer_column: "todos.owner_id",
+              filters: [],
+              joins: [],
+              select_columns: ["name", "email", "$canEdit"],
+              order_by: [],
+              limit: null,
+              nested_arrays: [],
+            },
+          ],
+        },
+      ]);
+    });
+
     it("omits implicit id from include builder projections", () => {
       const builderJson = JSON.stringify({
         table: "users",
@@ -1234,6 +1356,84 @@ describe("translateQuery", () => {
           order_by: [],
           limit: null,
           nested_arrays: [],
+        },
+      ]);
+    });
+
+    it('keeps projected include mode for include builders that select only "id"', () => {
+      const nestedSchema: WasmSchema = {
+        users: {
+          columns: [{ name: "name", column_type: { type: "Text" }, nullable: false }],
+        },
+        todos: {
+          columns: [
+            { name: "title", column_type: { type: "Text" }, nullable: false },
+            {
+              name: "owner_id",
+              column_type: { type: "Uuid" },
+              nullable: false,
+              references: "users",
+            },
+          ],
+        },
+        comments: {
+          columns: [
+            { name: "text", column_type: { type: "Text" }, nullable: false },
+            {
+              name: "todo_id",
+              column_type: { type: "Uuid" },
+              nullable: false,
+              references: "todos",
+            },
+          ],
+        },
+      };
+
+      const builderJson = JSON.stringify({
+        table: "comments",
+        conditions: [],
+        includes: {
+          todo: {
+            table: "todos",
+            conditions: [],
+            includes: {
+              owner: true,
+            },
+            select: ["id"],
+            orderBy: [],
+            hops: [],
+          },
+        },
+        orderBy: [],
+      });
+
+      const result = parseTranslatedQuery(builderJson, nestedSchema);
+
+      expect(result.array_subqueries).toEqual([
+        {
+          column_name: "todo",
+          table: "todos",
+          inner_column: "id",
+          outer_column: "comments.todo_id",
+          filters: [],
+          joins: [],
+          select_columns: ["__jazz_include_owner"],
+          order_by: [],
+          limit: null,
+          nested_arrays: [
+            {
+              column_name: "__jazz_include_owner",
+              table: "users",
+              inner_column: "id",
+              outer_column: "todos.owner_id",
+              filters: [],
+              joins: [],
+              select_columns: null,
+              order_by: [],
+              limit: null,
+              nested_arrays: [],
+            },
+          ],
         },
       ]);
     });

--- a/packages/jazz-tools/src/runtime/query-adapter.ts
+++ b/packages/jazz-tools/src/runtime/query-adapter.ts
@@ -19,6 +19,7 @@ import {
   type NormalizedIncludeEntry,
   type NormalizedIncludeSpec,
 } from "./query-builder-shape.js";
+import { hiddenIncludeColumnName, resolveSelectedColumns } from "./select-projection.js";
 import type {
   RelColumnRef,
   RelExpr,
@@ -163,18 +164,6 @@ function toWasmValue(value: unknown, columnType: ColumnType): object {
   throw new Error(`Unsupported value type: ${typeof value}`);
 }
 
-/**
- * Translate includes to array_subqueries for the WASM query format.
- *
- * @param includes Object mapping relation names to boolean or nested includes
- * @param tableName Current table name
- * @param relations Map from table name to relations on that table
- * @returns Array of array_subquery objects
- */
-function hiddenIncludeColumnName(relationName: string): string {
-  return `__jazz_include_${relationName}`;
-}
-
 function includeRequirementForRelation(
   relation: Relation,
   requireIncludes: boolean,
@@ -187,12 +176,10 @@ function includeRequirementForRelation(
 }
 
 function visibleSelectColumns(
-  select: readonly string[],
+  resolvedSelect: readonly string[],
   includeProjectionColumns: readonly string[] = [],
 ): string[] | null {
-  // `id` is not an explicit column, and is always included
-  const explicitColumns = select.filter((column) => column !== "id");
-  const columns = [...explicitColumns, ...includeProjectionColumns];
+  const columns = [...resolvedSelect, ...includeProjectionColumns];
   return columns.length > 0 ? columns : null;
 }
 
@@ -285,10 +272,13 @@ function toArraySubqueries(
     }
     validateIncludeBuilderSpec(rel, spec, relName);
 
-    const includeProjectionColumns =
-      spec.select.length > 0
-        ? Object.keys(spec.includes).map((relationName) => hiddenIncludeColumnName(relationName))
-        : [];
+    const hasExplicitSelect = spec.select.length > 0;
+    const resolvedSelectColumns = hasExplicitSelect
+      ? resolveSelectedColumns(rel.toTable, schema, spec.select)
+      : [];
+    const includeProjectionColumns = hasExplicitSelect
+      ? Object.keys(spec.includes).map((relationName) => hiddenIncludeColumnName(relationName))
+      : [];
     const filters = spec.conditions.map((condition) =>
       conditionToArraySubqueryFilter(condition, schema, rel.toTable),
     );
@@ -297,10 +287,10 @@ function toArraySubqueries(
       direction === "desc" ? "Descending" : "Ascending",
     ]);
     const nestedArrays = toArraySubqueries(spec.includes, rel.toTable, relations, schema, {
-      hideCurrentLevelColumnNames: spec.select.length > 0,
+      hideCurrentLevelColumnNames: hasExplicitSelect,
       requireIncludes: spec.requireIncludes,
     });
-    const selectColumns = visibleSelectColumns(spec.select, includeProjectionColumns);
+    const selectColumns = visibleSelectColumns(resolvedSelectColumns, includeProjectionColumns);
 
     // Build the subquery based on relation type
     if (rel.type === "forward") {
@@ -691,16 +681,18 @@ export function translateQuery(builderJson: string, schema: WasmSchema): string 
   const builder = normalizeBuiltQuery(JSON.parse(builderJson), "");
   const relations = analyzeRelations(schema);
   const relation = translateBuilderToRelationIr(builderJson, schema);
-  const selectColumns = builder.select;
-  const includeProjectionColumns =
-    selectColumns.length > 0
-      ? Object.keys(builder.includes).map((relationName) => hiddenIncludeColumnName(relationName))
-      : [];
+  const hasExplicitSelect = builder.select.length > 0;
+  const selectColumns = hasExplicitSelect
+    ? resolveSelectedColumns(builder.table, schema, builder.select)
+    : [];
+  const includeProjectionColumns = hasExplicitSelect
+    ? Object.keys(builder.includes).map((relationName) => hiddenIncludeColumnName(relationName))
+    : [];
   const projectedColumns = visibleSelectColumns(selectColumns, includeProjectionColumns);
   const query = {
     table: builder.table,
     array_subqueries: toArraySubqueries(builder.includes, builder.table, relations, schema, {
-      hideCurrentLevelColumnNames: selectColumns.length > 0,
+      hideCurrentLevelColumnNames: hasExplicitSelect,
       requireIncludes: builder.requireIncludes,
     }),
     relation_ir: relation,

--- a/packages/jazz-tools/src/runtime/query-builder-shape.ts
+++ b/packages/jazz-tools/src/runtime/query-builder-shape.ts
@@ -93,8 +93,7 @@ function normalizeSelect(value: unknown): string[] {
     return [];
   }
 
-  const select = value.filter((column): column is string => typeof column === "string");
-  return select.includes("*") ? [] : select;
+  return value.filter((column): column is string => typeof column === "string");
 }
 
 function normalizeGather(value: unknown): BuiltGather | undefined {

--- a/packages/jazz-tools/src/runtime/row-transformer.test.ts
+++ b/packages/jazz-tools/src/runtime/row-transformer.test.ts
@@ -359,6 +359,50 @@ describe("transformRows", () => {
     ]);
   });
 
+  it("expands mixed wildcard and magic projections while preserving includes", () => {
+    const rows: WasmRow[] = [
+      {
+        id: "todo-1",
+        values: [
+          { type: "Text", value: "Buy milk" },
+          { type: "Uuid", value: "user-1" },
+          { type: "Boolean", value: true },
+          {
+            type: "Array",
+            value: [
+              {
+                type: "Row",
+                value: {
+                  id: "user-1",
+                  values: [{ type: "Text", value: "Alice" }, { type: "Null" }],
+                },
+              },
+            ],
+          },
+        ],
+      },
+    ];
+
+    const result = transformRows(rows, relationSchema, "todos", { owner: true }, [
+      "*",
+      "$canDelete",
+    ]);
+
+    expect(result).toEqual([
+      {
+        id: "todo-1",
+        title: "Buy milk",
+        owner_id: "user-1",
+        $canDelete: true,
+        owner: {
+          id: "user-1",
+          name: "Alice",
+          manager_id: undefined,
+        },
+      },
+    ]);
+  });
+
   it("maps forward include arrays to relation names with id", () => {
     const rows: WasmRow[] = [
       {

--- a/packages/jazz-tools/src/runtime/row-transformer.ts
+++ b/packages/jazz-tools/src/runtime/row-transformer.ts
@@ -7,6 +7,7 @@ import type { ColumnType } from "../drivers/types.js";
 import { analyzeRelations, type Relation } from "../codegen/relation-analyzer.js";
 import { magicColumnType } from "../magic-columns.js";
 import { normalizeIncludeEntries, type NormalizedIncludeSpec } from "./query-builder-shape.js";
+import { resolveSelectedColumns } from "./select-projection.js";
 
 export type { WasmValue };
 
@@ -30,17 +31,7 @@ function resolveBaseColumns(
     throw new Error(`Unknown table "${tableName}" in schema`);
   }
 
-  if (!projection || projection.length === 0) {
-    return table.columns.map((column) => ({
-      name: column.name,
-      columnType: column.column_type,
-    }));
-  }
-
-  return projection
-    .filter(
-      (columnName): columnName is string => typeof columnName === "string" && columnName !== "id",
-    )
+  return resolveSelectedColumns(tableName, schema, projection)
     .map((columnName) => {
       const magicType = magicColumnType(columnName);
       if (magicType) {

--- a/packages/jazz-tools/src/runtime/select-projection.ts
+++ b/packages/jazz-tools/src/runtime/select-projection.ts
@@ -1,0 +1,61 @@
+import type { WasmSchema } from "../drivers/types.js";
+
+export const HIDDEN_INCLUDE_COLUMN_PREFIX = "__jazz_include_";
+
+export function hiddenIncludeColumnName(relationName: string): string {
+  return `${HIDDEN_INCLUDE_COLUMN_PREFIX}${relationName}`;
+}
+
+export function isHiddenIncludeColumnName(columnName: string): boolean {
+  return columnName.startsWith(HIDDEN_INCLUDE_COLUMN_PREFIX);
+}
+
+export function resolveSelectedColumns(
+  tableName: string,
+  schema: WasmSchema,
+  projection: readonly string[] | undefined,
+): string[] {
+  const table = schema[tableName];
+  if (!table) {
+    throw new Error(`Unknown table "${tableName}" in schema`);
+  }
+
+  if (!projection || projection.length === 0) {
+    return table.columns.map((column) => column.name);
+  }
+
+  const schemaColumnNames = new Set(table.columns.map((column) => column.name));
+  const selection = {
+    explicitColumnsInSchema: new Set<string>(),
+    explicitColumnsNotInSchema: new Set<string>(),
+    hasWildcard: false,
+  };
+
+  for (const column of projection) {
+    if (column === "*") {
+      selection.hasWildcard = true;
+      continue;
+    }
+    if (column === "id") {
+      continue;
+    }
+    if (schemaColumnNames.has(column)) {
+      selection.explicitColumnsInSchema.add(column);
+    } else {
+      selection.explicitColumnsNotInSchema.add(column);
+    }
+  }
+
+  // if no wildcard, return all explicitly selected columns
+  if (!selection.hasWildcard) {
+    return [...selection.explicitColumnsInSchema, ...selection.explicitColumnsNotInSchema];
+  }
+
+  if (selection.explicitColumnsNotInSchema.size === 0) {
+    return [...schemaColumnNames];
+  }
+
+  // If wildcard is present, return all schema columns plus explicit non-schema columns like
+  // permission introspection fields.
+  return [...schemaColumnNames, ...selection.explicitColumnsNotInSchema];
+}

--- a/packages/jazz-tools/tests/ts-dsl/fixtures/basic/app.ts
+++ b/packages/jazz-tools/tests/ts-dsl/fixtures/basic/app.ts
@@ -234,10 +234,10 @@ export type TodoWithIncludes<I extends TodoInclude = {}, R extends boolean = fal
 export type UserSelectableColumn = keyof User | PermissionIntrospectionColumn | "*";
 export type UserOrderableColumn = keyof User | PermissionIntrospectionColumn;
 
-export type UserSelected<S extends UserSelectableColumn = keyof User> = "*" extends S
+export type UserSelected<S extends UserSelectableColumn = keyof User> = ("*" extends S
   ? User
-  : Pick<User, Extract<S | "id", keyof User>> &
-      Pick<PermissionIntrospectionColumns, Extract<S, PermissionIntrospectionColumn>>;
+  : Pick<User, Extract<S | "id", keyof User>>) &
+  Pick<PermissionIntrospectionColumns, Extract<S, PermissionIntrospectionColumn>>;
 
 export type UserSelectedWithIncludes<
   I extends UserInclude = {},
@@ -248,10 +248,10 @@ export type UserSelectedWithIncludes<
 export type ProjectSelectableColumn = keyof Project | PermissionIntrospectionColumn | "*";
 export type ProjectOrderableColumn = keyof Project | PermissionIntrospectionColumn;
 
-export type ProjectSelected<S extends ProjectSelectableColumn = keyof Project> = "*" extends S
+export type ProjectSelected<S extends ProjectSelectableColumn = keyof Project> = ("*" extends S
   ? Project
-  : Pick<Project, Extract<S | "id", keyof Project>> &
-      Pick<PermissionIntrospectionColumns, Extract<S, PermissionIntrospectionColumn>>;
+  : Pick<Project, Extract<S | "id", keyof Project>>) &
+  Pick<PermissionIntrospectionColumns, Extract<S, PermissionIntrospectionColumn>>;
 
 export type ProjectSelectedWithIncludes<
   I extends ProjectInclude = {},
@@ -262,10 +262,10 @@ export type ProjectSelectedWithIncludes<
 export type TodoSelectableColumn = keyof Todo | PermissionIntrospectionColumn | "*";
 export type TodoOrderableColumn = keyof Todo | PermissionIntrospectionColumn;
 
-export type TodoSelected<S extends TodoSelectableColumn = keyof Todo> = "*" extends S
+export type TodoSelected<S extends TodoSelectableColumn = keyof Todo> = ("*" extends S
   ? Todo
-  : Pick<Todo, Extract<S | "id", keyof Todo>> &
-      Pick<PermissionIntrospectionColumns, Extract<S, PermissionIntrospectionColumn>>;
+  : Pick<Todo, Extract<S | "id", keyof Todo>>) &
+  Pick<PermissionIntrospectionColumns, Extract<S, PermissionIntrospectionColumn>>;
 
 export type TodoSelectedWithIncludes<
   I extends TodoInclude = {},

--- a/packages/jazz-tools/tests/ts-dsl/generated-app.test.ts
+++ b/packages/jazz-tools/tests/ts-dsl/generated-app.test.ts
@@ -35,6 +35,17 @@ describe("generated TS DSL fixture", () => {
     });
   });
 
+  it('serializes mixed select("*", "$canDelete") metadata on generated query builders', () => {
+    expect(JSON.parse(app.todos.select("*", "$canDelete")._build())).toEqual({
+      table: "todos",
+      conditions: [],
+      includes: {},
+      select: ["*", "$canDelete"],
+      orderBy: [],
+      hops: [],
+    });
+  });
+
   it("serializes nested include builders as query objects", () => {
     expect(
       JSON.parse(app.projects.include({ todosViaProject: app.todos.select("title") })._build()),

--- a/packages/jazz-tools/tests/ts-dsl/query-api.test.ts
+++ b/packages/jazz-tools/tests/ts-dsl/query-api.test.ts
@@ -674,6 +674,23 @@ describe("TS Query API", () => {
           $canDelete: true,
         },
       ]);
+
+      const fullRowWithDeletePermission = await db.one(
+        app.todos.select("*", "$canDelete").where({ id: { eq: editableId } }),
+      );
+
+      assert(fullRowWithDeletePermission, "Result is not defined");
+      expectTypeOf(fullRowWithDeletePermission.$canDelete).toEqualTypeOf<boolean | null>();
+      expect(fullRowWithDeletePermission).toEqual({
+        id: editableId,
+        title: "Draft docs",
+        done: false,
+        tags: ["dev"],
+        projectId,
+        ownerId: undefined,
+        assigneesIds: [],
+        $canDelete: true,
+      });
     });
 
     it("include builders can project nested relation columns", async () => {


### PR DESCRIPTION
## Summary
- preserve mixed `select("*", "$canDelete")` projections across query translation, row transformation, and client-side schema alignment
- keep projected include mode working for `select("id")` while adding support for wildcard-plus-magic selections in nested includes
- update generated TypeScript selection types and docs to reflect wildcard queries with explicit permission introspection columns
- add a patch changeset for the `jazz-tools` fix

## Testing
- `pnpm --filter jazz-tools exec vitest run --config vitest.config.ts tests/ts-dsl/generated-app.test.ts src/runtime/query-adapter.test.ts src/runtime/row-transformer.test.ts src/runtime/client.for-request.test.ts tests/ts-dsl/query-api.test.ts src/codegen/codegen.test.ts`
- `pnpm --filter jazz-tools exec vitest run --config vitest.config.ts src/runtime/query-adapter.test.ts tests/ts-dsl/query-api.test.ts`
- `pnpm --filter jazz-tools exec tsc --noEmit`
- `pnpm --filter jazz-tools exec tsc --project tsconfig.tests.json --noEmit`