### PR TITLE
Fix generated app.ts under noUncheckedIndexedAccess

### DIFF
--- a/packages/jazz-tools/package.json
+++ b/packages/jazz-tools/package.json
@@ -68,7 +68,7 @@
     "build": "tsc && cp src/worker/jazz-worker.ts dist/worker/jazz-worker.ts && pnpm build:test && pnpm build:svelte",
     "build:svelte": "svelte-package -i src/svelte -o dist/svelte --tsconfig tsconfig.svelte.json && node scripts/cleanup-generated-src-types.mjs",
     "test": "vitest run --config vitest.config.ts",
-    "build:test": "node dist/cli.js build --schema-dir tests/ts-dsl/fixtures/basic && tsc --project tsconfig.tests.json",
+    "build:test": "node dist/cli.js build --schema-dir tests/ts-dsl/fixtures/basic && tsc --project tsconfig.typecheck.tests.json && tsc --project tsconfig.tests.json",
     "test:browser": "vitest run --config vitest.config.browser.ts",
     "bench:realistic:browser": "vitest run --config vitest.config.browser.ts tests/browser/realistic-bench.test.ts",
     "stage:local": "node scripts/stage-local-binary.mjs",

--- a/packages/jazz-tools/src/codegen/codegen.test.ts
+++ b/packages/jazz-tools/src/codegen/codegen.test.ts
@@ -1314,6 +1314,7 @@ describe("generateQueryBuilderClasses", () => {
     expect(output).toContain("step: (ctx: { current: string }) => QueryBuilder<unknown>;");
     expect(output).toContain("const stepOutput = options.step({ current: currentToken });");
     expect(output).toContain("if (stepHops.length !== 1) {");
+    expect(output).toContain("if (currentCondition === undefined) {");
     expect(output).toContain("const withStart = this.where(options.start);");
     expect(output).toContain("clone._gatherVal = {");
   });

--- a/packages/jazz-tools/src/codegen/query-builder-generator.ts
+++ b/packages/jazz-tools/src/codegen/query-builder-generator.ts
@@ -333,6 +333,11 @@ function generateQueryBuilderClass(
   lines.push(`    }`);
   lines.push(``);
   lines.push(`    const currentCondition = currentConditions[0];`);
+  lines.push(`    if (currentCondition === undefined) {`);
+  lines.push(
+    `      throw new Error("gather(...) step must include exactly one where condition bound to current.");`,
+  );
+  lines.push(`    }`);
   lines.push(`    const stepConditions = stepBuilt.conditions.filter(`);
   lines.push(`      (condition) => !(condition.op === "eq" && condition.value === currentToken),`);
   lines.push(`    );`);

--- a/packages/jazz-tools/src/testing/fixtures/basic/app.ts
+++ b/packages/jazz-tools/src/testing/fixtures/basic/app.ts
@@ -163,6 +163,11 @@ export class TodoQueryBuilder<I extends Record<string, never> = {}> implements Q
     }
 
     const currentCondition = currentConditions[0];
+    if (currentCondition === undefined) {
+      throw new Error(
+        "gather(...) step must include exactly one where condition bound to current.",
+      );
+    }
     const stepConditions = stepBuilt.conditions.filter(
       (condition) => !(condition.op === "eq" && condition.value === currentToken),
     );

--- a/packages/jazz-tools/tests/ts-dsl/fixtures/basic/app.ts
+++ b/packages/jazz-tools/tests/ts-dsl/fixtures/basic/app.ts
@@ -561,6 +561,11 @@ export class UserQueryBuilder<
     }
 
     const currentCondition = currentConditions[0];
+    if (currentCondition === undefined) {
+      throw new Error(
+        "gather(...) step must include exactly one where condition bound to current.",
+      );
+    }
     const stepConditions = stepBuilt.conditions.filter(
       (condition) => !(condition.op === "eq" && condition.value === currentToken),
     );
@@ -775,6 +780,11 @@ export class ProjectQueryBuilder<
     }
 
     const currentCondition = currentConditions[0];
+    if (currentCondition === undefined) {
+      throw new Error(
+        "gather(...) step must include exactly one where condition bound to current.",
+      );
+    }
     const stepConditions = stepBuilt.conditions.filter(
       (condition) => !(condition.op === "eq" && condition.value === currentToken),
     );
@@ -989,6 +999,11 @@ export class TodoQueryBuilder<
     }
 
     const currentCondition = currentConditions[0];
+    if (currentCondition === undefined) {
+      throw new Error(
+        "gather(...) step must include exactly one where condition bound to current.",
+      );
+    }
     const stepConditions = stepBuilt.conditions.filter(
       (condition) => !(condition.op === "eq" && condition.value === currentToken),
     );

--- a/packages/jazz-tools/tsconfig.typecheck.tests.json
+++ b/packages/jazz-tools/tsconfig.typecheck.tests.json
@@ -1,15 +1,19 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "baseUrl": ".",
     "declaration": false,
     "declarationMap": false,
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "noEmit": true,
-    "noUncheckedIndexedAccess": true,
     "rootDir": ".",
-    "sourceMap": false
+    "sourceMap": false,
+    "paths": {
+      "jazz-tools": ["./src/index.ts"],
+      "jazz-tools/*": ["./src/*"]
+    }
   },
-  "include": ["src/testing/fixtures/basic/app.ts", "tests/ts-dsl/fixtures/basic/app.ts"],
+  "include": ["src/**/*", "tests/ts-dsl/**/*.ts"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## Summary
- guard generated `currentConditions[0]` accesses so `gather(...)` output compiles with `noUncheckedIndexedAccess`
- add a focused strict generated-fixture typecheck in `tsconfig.tests.json`
- preserve the existing broader test typecheck in a separate `tsconfig.typecheck.tests.json`

## Testing
- `pnpm --dir packages/jazz-tools exec vitest run --config vitest.config.ts src/codegen/codegen.test.ts`
- `pnpm --dir packages/jazz-tools exec tsc --project tsconfig.typecheck.tests.json`
- `pnpm --dir packages/jazz-tools exec tsc --project tsconfig.tests.json`
- `pnpm --dir packages/jazz-tools build:test`