### PR TITLE
Skip catalogue replay when hashes already match

### DIFF
--- a/.changeset/pr-279-catalogue-sync.md
+++ b/.changeset/pr-279-catalogue-sync.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Fix catalogue sync so clients receive shared catalogue updates correctly, and skip resending the catalogue on reconnect when the client and server are already aligned.

--- a/crates/jazz-cloud-server/src/server.rs
+++ b/crates/jazz-cloud-server/src/server.rs
@@ -683,6 +683,10 @@ enum WorkerCommand {
         app_id: AppId,
         response: tokio::sync::oneshot::Sender<Result<Vec<String>, String>>,
     },
+    GetCatalogueStateHash {
+        app_id: AppId,
+        response: tokio::sync::oneshot::Sender<Result<String, String>>,
+    },
 }
 
 impl WorkerCommand {
@@ -695,7 +699,8 @@ impl WorkerCommand {
             | WorkerCommand::SyncAsBackend { app_id, .. }
             | WorkerCommand::SyncAsAdmin { app_id, .. }
             | WorkerCommand::GetCatalogueSchema { app_id, .. }
-            | WorkerCommand::GetSchemaHashes { app_id, .. } => *app_id,
+            | WorkerCommand::GetSchemaHashes { app_id, .. }
+            | WorkerCommand::GetCatalogueStateHash { app_id, .. } => *app_id,
         }
     }
 }
@@ -956,6 +961,20 @@ impl WorkerPool {
         let worker = self.send_command(command)?;
         match response_rx.await {
             Ok(Ok(schema_hashes)) => Ok(schema_hashes),
+            Ok(Err(message)) => Err(WorkerDispatchError::RuntimeError { worker, message }),
+            Err(_) => Err(WorkerDispatchError::WorkerUnavailable { worker }),
+        }
+    }
+
+    async fn get_catalogue_state_hash(&self, app_id: AppId) -> Result<String, WorkerDispatchError> {
+        let (response_tx, response_rx) = tokio::sync::oneshot::channel();
+        let command = WorkerCommand::GetCatalogueStateHash {
+            app_id,
+            response: response_tx,
+        };
+        let worker = self.send_command(command)?;
+        match response_rx.await {
+            Ok(Ok(catalogue_state_hash)) => Ok(catalogue_state_hash),
             Ok(Err(message)) => Err(WorkerDispatchError::RuntimeError { worker, message }),
             Err(_) => Err(WorkerDispatchError::WorkerUnavailable { worker }),
         }
@@ -1890,6 +1909,24 @@ async fn run_worker_loop(
                         });
                     if response.send(result).is_err() {
                         warn!(worker, app_id = %app_id, "schema hashes response receiver dropped");
+                    }
+                }
+                WorkerCommand::GetCatalogueStateHash { app_id, response } => {
+                    let result = app_runtimes
+                        .get(&app_id)
+                        .ok_or_else(|| format!("missing runtime for app {app_id}"))
+                        .and_then(|runtime| {
+                            runtime
+                                .runtime
+                                .catalogue_state_hash()
+                                .map_err(|err| err.to_string())
+                        });
+                    if response.send(result).is_err() {
+                        warn!(
+                            worker,
+                            app_id = %app_id,
+                            "catalogue state hash response receiver dropped"
+                        );
                     }
                 }
             }
@@ -3137,6 +3174,20 @@ async fn events_handler(
         }
     }
 
+    let catalogue_state_hash = match state.workers.get_catalogue_state_hash(app_id).await {
+        Ok(hash) => Some(hash),
+        Err(err) => {
+            warn!(
+                app_id = %app_id,
+                worker,
+                client_id = %client_id,
+                ?err,
+                "failed to read catalogue state hash for events handshake"
+            );
+            None
+        }
+    };
+
     let connection_id = app.next_connection_id.fetch_add(1, Ordering::SeqCst);
     {
         let mut connections = app.connections.write().await;
@@ -3176,6 +3227,7 @@ async fn events_handler(
             connection_id: ConnectionId(connection_id),
             client_id: client_id_str,
             next_sync_seq: Some(next_sync_seq),
+            catalogue_state_hash: catalogue_state_hash.clone(),
         };
         yield Ok::<Bytes, std::convert::Infallible>(encode_frame(&connected));
 

--- a/crates/jazz-napi/index.d.ts
+++ b/crates/jazz-napi/index.d.ts
@@ -51,7 +51,7 @@ export declare class NapiRuntime {
   /** Called by JS when a sync message arrives from a client (not a server). */
   onSyncMessageReceivedFromClient(clientId: string, messageJson: string): void;
   onSyncMessageToSend(callback: (...args: any[]) => any): void;
-  addServer(): void;
+  addServer(serverCatalogueStateHash?: string | null): void;
   removeServer(): void;
   addClient(): string;
   /** Set a client's role ("user", "admin", or "peer"). */

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -812,7 +812,7 @@ impl NapiRuntime {
     }
 
     #[napi(js_name = "addServer")]
-    pub fn add_server(&self) -> napi::Result<()> {
+    pub fn add_server(&self, server_catalogue_state_hash: Option<String>) -> napi::Result<()> {
         let server_id = {
             let mut slot = self
                 .upstream_server_id
@@ -833,7 +833,10 @@ impl NapiRuntime {
         // Re-attach semantics: remove existing upstream edge then add again so
         // replay/full-sync runs on every successful reconnect.
         core.remove_server(server_id);
-        core.add_server(server_id);
+        core.add_server_with_catalogue_state_hash(
+            server_id,
+            server_catalogue_state_hash.as_deref(),
+        );
         Ok(())
     }
 

--- a/crates/jazz-tools/src/client.rs
+++ b/crates/jazz-tools/src/client.rs
@@ -182,13 +182,6 @@ impl JazzClient {
             .persist_schema()
             .map_err(|e| JazzError::Storage(e.to_string()))?;
 
-        // Register server with sync manager if connected
-        if server_connection.is_some()
-            && let Err(e) = runtime.add_server(server_id)
-        {
-            tracing::warn!("Failed to register server with sync manager: {}", e);
-        }
-
         // Spawn binary stream listener if connected to server
         let (initial_stream_ready_tx, initial_stream_ready_rx) = if server_connection.is_some() {
             let (tx, rx) = oneshot::channel();
@@ -251,12 +244,19 @@ impl JazzClient {
                                             match serde_json::from_slice::<ServerEvent>(json) {
                                                 Ok(event) => {
                                                     if matches!(
-                                                        event,
+                                                        &event,
                                                         ServerEvent::Connected { .. }
                                                     ) && let Some(tx) =
                                                         initial_stream_ready_tx.take()
                                                     {
-                                                        let _ = tx.send(());
+                                                        let catalogue_state_hash = match &event {
+                                                            ServerEvent::Connected {
+                                                                catalogue_state_hash,
+                                                                ..
+                                                            } => catalogue_state_hash.clone(),
+                                                            _ => None,
+                                                        };
+                                                        let _ = tx.send(catalogue_state_hash);
                                                     }
                                                     if let Err(e) = handle_server_event(
                                                         event,
@@ -302,19 +302,35 @@ impl JazzClient {
             None
         };
 
-        if let Some(initial_stream_ready_rx) = initial_stream_ready_rx {
-            tokio::time::timeout(Duration::from_secs(10), initial_stream_ready_rx)
-                .await
-                .map_err(|_| {
-                    JazzError::Connection(
-                        "timed out waiting for server event stream to connect".to_string(),
-                    )
-                })?
-                .map_err(|_| {
-                    JazzError::Connection(
-                        "server event stream ended before sending Connected".to_string(),
-                    )
-                })?;
+        let initial_server_catalogue_state_hash =
+            if let Some(initial_stream_ready_rx) = initial_stream_ready_rx {
+                tokio::time::timeout(Duration::from_secs(10), initial_stream_ready_rx)
+                    .await
+                    .map_err(|_| {
+                        JazzError::Connection(
+                            "timed out waiting for server event stream to connect".to_string(),
+                        )
+                    })?
+                    .map_err(|_| {
+                        JazzError::Connection(
+                            "server event stream ended before sending Connected".to_string(),
+                        )
+                    })?
+            } else {
+                None
+            };
+
+        // Register server with sync manager if connected.
+        //
+        // The initial Connected event carries the server's catalogue digest, so
+        // we wait for it before deciding whether catalogue replay can be skipped.
+        if server_connection.is_some()
+            && let Err(e) = runtime.add_server_with_catalogue_state_hash(
+                server_id,
+                initial_server_catalogue_state_hash.as_deref(),
+            )
+        {
+            tracing::warn!("Failed to register server with sync manager: {}", e);
         }
 
         Ok(Self {
@@ -765,6 +781,7 @@ fn handle_server_event(
             connection_id,
             client_id,
             next_sync_seq,
+            ..
         } => {
             tracing::info!(
                 "Stream connected with id: {:?}, client_id: {}",

--- a/crates/jazz-tools/src/query_manager/subscriptions.rs
+++ b/crates/jazz-tools/src/query_manager/subscriptions.rs
@@ -297,7 +297,18 @@ impl QueryManager {
     /// This ensures subscriptions that became active before the server connection
     /// are forwarded once the server is available.
     pub fn add_server(&mut self, server_id: ServerId) {
-        self.sync_manager.add_server(server_id);
+        self.add_server_with_catalogue_match(server_id, false);
+    }
+
+    /// Add an upstream server and optionally skip replaying catalogue objects
+    /// when the remote side already has the same catalogue state.
+    pub fn add_server_with_catalogue_match(
+        &mut self,
+        server_id: ServerId,
+        skip_catalogue_sync: bool,
+    ) {
+        self.sync_manager
+            .add_server_with_catalogue_match(server_id, skip_catalogue_sync);
         self.replay_active_query_subscriptions_to_server(server_id);
     }
 

--- a/crates/jazz-tools/src/routes.rs
+++ b/crates/jazz-tools/src/routes.rs
@@ -192,6 +192,7 @@ async fn events_handler(
 
     // Capture client_id string for stream
     let client_id_str = client_id.to_string();
+    let catalogue_state_hash = state.runtime.catalogue_state_hash().ok();
 
     // Create stream that emits length-prefixed binary frames
     let stream = async_stream::stream! {
@@ -200,6 +201,7 @@ async fn events_handler(
             connection_id: ConnectionId(connection_id),
             client_id: client_id_str.clone(),
             next_sync_seq: None,
+            catalogue_state_hash: catalogue_state_hash.clone(),
         };
         yield Ok::<Bytes, std::convert::Infallible>(encode_frame(&connected));
 

--- a/crates/jazz-tools/src/runtime_core/sync.rs
+++ b/crates/jazz-tools/src/runtime_core/sync.rs
@@ -15,10 +15,23 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
 
     /// Add a server connection.
     pub fn add_server(&mut self, server_id: ServerId) {
+        self.add_server_with_catalogue_state_hash(server_id, None);
+    }
+
+    /// Add a server connection, optionally comparing the upstream catalogue
+    /// digest first so unchanged catalogue objects are not replayed.
+    pub fn add_server_with_catalogue_state_hash(
+        &mut self,
+        server_id: ServerId,
+        remote_catalogue_state_hash: Option<&str>,
+    ) {
         info!(%server_id, "adding server");
+        let local_catalogue_state_hash = self.schema_manager.catalogue_state_hash();
+        let skip_catalogue_sync = remote_catalogue_state_hash
+            .is_some_and(|remote_hash| remote_hash == local_catalogue_state_hash);
         self.schema_manager
             .query_manager_mut()
-            .add_server(server_id);
+            .add_server_with_catalogue_match(server_id, skip_catalogue_sync);
         self.immediate_tick();
     }
 

--- a/crates/jazz-tools/src/runtime_core/tests.rs
+++ b/crates/jazz-tools/src/runtime_core/tests.rs
@@ -1321,3 +1321,208 @@ fn test_persist_schema_then_add_server_sends_catalogue() {
             .join(", ")
     );
 }
+
+#[test]
+fn test_matching_catalogue_hash_skips_catalogue_replay_on_add_server() {
+    let schema = test_schema();
+    let app_id = AppId::from_name("test-app");
+    let sync_manager = SyncManager::new();
+    let schema_manager = SchemaManager::new(sync_manager, schema, app_id, "dev", "main").unwrap();
+    let mut core = RuntimeCore::new(
+        schema_manager,
+        MemoryStorage::new(),
+        NoopScheduler,
+        VecSyncSender::new(),
+    );
+
+    let schema_obj_id = core.persist_schema();
+    let row_values = vec![
+        Value::Uuid(ObjectId::new()),
+        Value::Text("Alice".to_string()),
+    ];
+    let (row_object_id, _) = core.insert("users", row_values, None).unwrap();
+
+    let catalogue_state_hash = core.schema_manager().catalogue_state_hash();
+
+    let server_id = ServerId::new();
+    core.add_server_with_catalogue_state_hash(server_id, Some(&catalogue_state_hash));
+    core.batched_tick();
+
+    let messages = core.sync_sender().take();
+    let catalogue_msg = messages.iter().find(|m| {
+        matches!(
+            &m.payload,
+            SyncPayload::ObjectUpdated { object_id, .. } if *object_id == schema_obj_id
+        )
+    });
+    let row_msg = messages.iter().find(|m| {
+        matches!(
+            &m.payload,
+            SyncPayload::ObjectUpdated { object_id, .. } if *object_id == row_object_id
+        )
+    });
+
+    assert!(
+        catalogue_msg.is_none(),
+        "Catalogue replay should be skipped when hashes already match"
+    );
+    assert!(
+        row_msg.is_some(),
+        "Regular row objects should still be sent during the full sync walk"
+    );
+}
+
+// =========================================================================
+// Foreign Key — No Write-Time Validation
+// =========================================================================
+//
+// FK write-time existence checks are intentionally removed: in a local-first
+// system with query-scoped sync, the referenced row may not be loaded yet,
+// causing false violations. True referential integrity will be enforced by
+// global transactions (specs/todo/b_launch/globally_consistent_transactions.md).
+//
+// These tests document that FK-referencing writes succeed even when the
+// target row is absent from the local index. They double as scaffolding for
+// when global transactions re-introduce server-side FK checks.
+
+/// Schema that mirrors the stress-test app: projects + todos with FK.
+fn fk_stress_schema() -> Schema {
+    SchemaBuilder::new()
+        .table(
+            TableSchema::builder("projects")
+                .column("name", ColumnType::Text)
+                .column("owner_id", ColumnType::Text),
+        )
+        .table(
+            TableSchema::builder("todos")
+                .column("title", ColumnType::Text)
+                .column("done", ColumnType::Boolean)
+                .nullable_column("description", ColumnType::Text)
+                .column("owner_id", ColumnType::Text)
+                .nullable_fk_column("project", "projects"),
+        )
+        .build()
+}
+
+fn create_fk_runtime() -> TestCore {
+    let schema = fk_stress_schema();
+    let app_id = AppId::from_name("fk-test");
+    let sync_manager = SyncManager::new();
+    let schema_manager = SchemaManager::new(sync_manager, schema, app_id, "dev", "main").unwrap();
+    let mut core = RuntimeCore::new(
+        schema_manager,
+        MemoryStorage::new(),
+        NoopScheduler,
+        VecSyncSender::new(),
+    );
+    core.immediate_tick();
+    core
+}
+
+/// After query-scoped sync, a todo's `project` FK can reference a project
+/// that was never loaded into MemoryStorage. A partial update (toggling
+/// `done`) must succeed — no FK re-check.
+///
+/// ```text
+///   MemoryStorage (after query-scoped sync)
+///   ┌────────────────────────────────────────┐
+///   │ projects._id index:  []     ← empty!   │
+///   │ todos._id index:     [todo_1]           │
+///   │                                         │
+///   │ todo_1.project = project_42  → not in   │
+///   │                               index     │
+///   └────────────────────────────────────────┘
+///
+///   User toggles todo_1.done → partial update → OK (no FK check)
+/// ```
+#[test]
+fn rc_partial_update_with_unloaded_fk_reference() {
+    let mut core = create_fk_runtime();
+
+    let (project_id, _) = core
+        .insert(
+            "projects",
+            vec![Value::Text("Acme".into()), Value::Text("alice".into())],
+            None,
+        )
+        .unwrap();
+
+    let (todo_id, _) = core
+        .insert(
+            "todos",
+            vec![
+                Value::Text("Buy milk".into()),
+                Value::Boolean(true),        // done
+                Value::Null,                 // description (nullable)
+                Value::Text("alice".into()), // owner_id
+                Value::Uuid(project_id),     // project FK
+            ],
+            None,
+        )
+        .unwrap();
+
+    core.immediate_tick();
+
+    // Simulate query-scoped sync: remove the project from the _id index.
+    let branch = core.schema_manager().branch_name();
+    core.storage
+        .index_remove(
+            "projects",
+            "_id",
+            branch.as_str(),
+            &Value::Uuid(project_id),
+            project_id,
+        )
+        .unwrap();
+
+    // Partial update: only change `done`.
+    // No FK validation → succeeds even though project is not in the index.
+    core.update(
+        todo_id,
+        vec![("done".to_string(), Value::Boolean(false))],
+        None,
+    )
+    .expect("partial update must succeed even when referenced project is not loaded");
+}
+
+/// Changing a FK column to a non-existent target is allowed at the local
+/// write level (no FK existence check). Global transactions will enforce
+/// this server-side in the future.
+#[test]
+fn rc_partial_update_changing_fk_to_missing_target_succeeds() {
+    let mut core = create_fk_runtime();
+
+    let (project_id, _) = core
+        .insert(
+            "projects",
+            vec![Value::Text("Acme".into()), Value::Text("alice".into())],
+            None,
+        )
+        .unwrap();
+
+    let (todo_id, _) = core
+        .insert(
+            "todos",
+            vec![
+                Value::Text("Buy milk".into()),
+                Value::Boolean(true),
+                Value::Null,
+                Value::Text("alice".into()),
+                Value::Uuid(project_id),
+            ],
+            None,
+        )
+        .unwrap();
+
+    core.immediate_tick();
+
+    // Change the FK column to a non-existent project.
+    // Without global transactions this is accepted locally.
+    let bogus_project = ObjectId::new();
+    core.update(
+        todo_id,
+        vec![("project".to_string(), Value::Uuid(bogus_project))],
+        None,
+    )
+    .expect("changing FK to non-existent target must succeed without local FK checks");
+}

--- a/crates/jazz-tools/src/runtime_tokio.rs
+++ b/crates/jazz-tools/src/runtime_tokio.rs
@@ -373,8 +373,18 @@ impl<S: Storage + Send + 'static> TokioRuntime<S> {
 
     /// Add a server connection.
     pub fn add_server(&self, server_id: ServerId) -> Result<(), RuntimeError> {
+        self.add_server_with_catalogue_state_hash(server_id, None)
+    }
+
+    /// Add a server connection, optionally comparing the upstream catalogue
+    /// digest first so unchanged catalogue objects are not replayed.
+    pub fn add_server_with_catalogue_state_hash(
+        &self,
+        server_id: ServerId,
+        remote_catalogue_state_hash: Option<&str>,
+    ) -> Result<(), RuntimeError> {
         let mut core = self.core.lock().map_err(|_| RuntimeError::LockError)?;
-        core.add_server(server_id);
+        core.add_server_with_catalogue_state_hash(server_id, remote_catalogue_state_hash);
         Ok(())
     }
 
@@ -445,6 +455,12 @@ impl<S: Storage + Send + 'static> TokioRuntime<S> {
     pub fn known_schema_hashes(&self) -> Result<Vec<SchemaHash>, RuntimeError> {
         let core = self.core.lock().map_err(|_| RuntimeError::LockError)?;
         Ok(core.schema_manager().known_schema_hashes())
+    }
+
+    /// Return a canonical digest of the runtime's catalogue state.
+    pub fn catalogue_state_hash(&self) -> Result<String, RuntimeError> {
+        let core = self.core.lock().map_err(|_| RuntimeError::LockError)?;
+        Ok(core.schema_manager().catalogue_state_hash())
     }
 
     /// Get a known schema by hash from catalogue state.

--- a/crates/jazz-tools/src/schema_manager/manager.rs
+++ b/crates/jazz-tools/src/schema_manager/manager.rs
@@ -9,6 +9,8 @@
 
 use std::{collections::HashMap, sync::Arc};
 
+use blake3::Hasher;
+
 use crate::object::{BranchName, ObjectId};
 use crate::query_manager::manager::{DeleteHandle, InsertResult, QueryError, QueryManager};
 use crate::query_manager::query::{Query, QueryBuilder};
@@ -373,6 +375,46 @@ impl SchemaManager {
     /// Get all registered lens edges as (source, target) hash pairs.
     pub fn lens_edges(&self) -> Vec<(SchemaHash, SchemaHash)> {
         self.context.lenses.keys().copied().collect()
+    }
+
+    /// Compute a canonical digest of the catalogue state known to this manager.
+    pub fn catalogue_state_hash(&self) -> String {
+        let mut hasher = Hasher::new();
+        hasher.update(b"jazz-catalogue-state-v1");
+
+        let mut schemas: Vec<_> = self.known_schemas.iter().collect();
+        schemas.sort_by(|(left_hash, _), (right_hash, _)| {
+            left_hash.as_bytes().cmp(right_hash.as_bytes())
+        });
+        hasher.update(&(schemas.len() as u64).to_le_bytes());
+        for (hash, schema) in schemas {
+            hasher.update(b"schema");
+            hasher.update(hash.as_bytes());
+            let encoded = encode_schema(schema);
+            hash_len_prefixed(&mut hasher, &encoded);
+        }
+
+        let mut lenses: Vec<_> = self.context.lenses.values().collect();
+        lenses.sort_by(|left, right| {
+            left.source_hash
+                .as_bytes()
+                .cmp(right.source_hash.as_bytes())
+                .then_with(|| {
+                    left.target_hash
+                        .as_bytes()
+                        .cmp(right.target_hash.as_bytes())
+                })
+        });
+        hasher.update(&(lenses.len() as u64).to_le_bytes());
+        for lens in lenses {
+            hasher.update(b"lens");
+            hasher.update(lens.source_hash.as_bytes());
+            hasher.update(lens.target_hash.as_bytes());
+            let encoded = encode_lens_transform(&lens.forward);
+            hash_len_prefixed(&mut hasher, &encoded);
+        }
+
+        hasher.finalize().to_hex().to_string()
     }
 
     /// Get access to the underlying context.
@@ -949,6 +991,11 @@ fn normalize_schema(mut schema: Schema) -> Schema {
         normalize_table_schema(table_schema);
     }
     schema
+}
+
+fn hash_len_prefixed(hasher: &mut Hasher, bytes: &[u8]) {
+    hasher.update(&(bytes.len() as u64).to_le_bytes());
+    hasher.update(bytes);
 }
 
 fn normalize_table_schema(table_schema: &mut crate::query_manager::types::TableSchema) {

--- a/crates/jazz-tools/src/sync_manager/mod.rs
+++ b/crates/jazz-tools/src/sync_manager/mod.rs
@@ -170,7 +170,20 @@ impl SyncManager {
 
     /// Add a server connection. Queues all existing objects to sync.
     pub fn add_server(&mut self, server_id: ServerId) {
+        self.add_server_with_catalogue_match(server_id, false);
+    }
+
+    /// Add a server connection, optionally skipping catalogue replay when both
+    /// sides already advertise the same catalogue state.
+    pub fn add_server_with_catalogue_match(
+        &mut self,
+        server_id: ServerId,
+        skip_catalogue_sync: bool,
+    ) {
         self.servers.insert(server_id, ServerState::default());
+        if skip_catalogue_sync {
+            self.mark_catalogue_sent_for_server(server_id);
+        }
         self.queue_full_sync_to_server(server_id);
     }
 

--- a/crates/jazz-tools/src/sync_manager/sync_logic.rs
+++ b/crates/jazz-tools/src/sync_manager/sync_logic.rs
@@ -31,6 +31,43 @@ impl SyncManager {
         self.catalogue_objects.contains(&object_id)
     }
 
+    /// Mark all existing catalogue objects as already sent for this server.
+    ///
+    /// This is used when the upstream server reports the same catalogue digest
+    /// during the connect handshake, allowing us to skip replaying schema/lens
+    /// objects while still performing the normal full sync for row data.
+    pub(super) fn mark_catalogue_sent_for_server(&mut self, server_id: ServerId) {
+        let Some(_server) = self.servers.get(&server_id) else {
+            return;
+        };
+
+        let mut sent_metadata = HashSet::new();
+        let mut sent_tips = Vec::new();
+
+        for object_id in self.catalogue_objects.iter().copied() {
+            let Some(object) = self.object_manager.objects.get(&object_id) else {
+                continue;
+            };
+
+            sent_metadata.insert(object_id);
+            for (branch_name, branch) in &object.branches {
+                sent_tips.push((
+                    object_id,
+                    *branch_name,
+                    branch.tips.iter().copied().collect::<HashSet<_>>(),
+                ));
+            }
+        }
+
+        let Some(server) = self.servers.get_mut(&server_id) else {
+            return;
+        };
+        server.sent_metadata.extend(sent_metadata);
+        for (object_id, branch_name, tips) in sent_tips {
+            server.sent_tips.insert((object_id, branch_name), tips);
+        }
+    }
+
     /// Queue all existing objects to sync to a new server.
     pub(super) fn queue_full_sync_to_server(&mut self, server_id: ServerId) {
         let _span = tracing::debug_span!("queue_full_sync_to_server", %server_id).entered();

--- a/crates/jazz-tools/src/transport_protocol.rs
+++ b/crates/jazz-tools/src/transport_protocol.rs
@@ -77,6 +77,9 @@ pub enum ServerEvent {
         client_id: String,
         /// Next stream sequence expected from server for this connection.
         next_sync_seq: Option<u64>,
+        /// Canonical digest of the server's catalogue state, when available.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        catalogue_state_hash: Option<String>,
     },
 
     /// Subscription created successfully.
@@ -230,6 +233,7 @@ mod tests {
             connection_id: ConnectionId(42),
             client_id: "test-client-id".to_string(),
             next_sync_seq: None,
+            catalogue_state_hash: Some("digest-123".to_string()),
         };
 
         let frame = event.encode_frame();
@@ -237,7 +241,15 @@ mod tests {
 
         let (decoded, consumed) = ServerEvent::decode_frame(&frame).unwrap();
         assert_eq!(consumed, frame.len());
-        assert!(matches!(decoded, ServerEvent::Connected { .. }));
+        match decoded {
+            ServerEvent::Connected {
+                catalogue_state_hash,
+                ..
+            } => {
+                assert_eq!(catalogue_state_hash.as_deref(), Some("digest-123"));
+            }
+            other => panic!("Expected Connected event, got {:?}", other.variant_name()),
+        }
     }
 
     #[test]

--- a/crates/jazz-tools/tests/integration.rs
+++ b/crates/jazz-tools/tests/integration.rs
@@ -194,10 +194,15 @@ async fn test_stream_connection_receives_connected_event() {
         ServerEvent::Connected {
             connection_id,
             client_id,
+            catalogue_state_hash,
             ..
         } => {
             assert!(connection_id.0 > 0);
             assert!(!client_id.is_empty());
+            assert!(
+                catalogue_state_hash.is_some(),
+                "Connected event should advertise the server catalogue digest"
+            );
         }
         other => panic!("Expected Connected event, got {:?}", other.variant_name()),
     }

--- a/crates/jazz-wasm/src/runtime.rs
+++ b/crates/jazz-wasm/src/runtime.rs
@@ -929,7 +929,7 @@ impl WasmRuntime {
     /// catalogue sync messages (from queue_full_sync_to_server) are sent
     /// before the call returns, rather than being deferred to a microtask.
     #[wasm_bindgen(js_name = addServer)]
-    pub fn add_server(&self) {
+    pub fn add_server(&self, server_catalogue_state_hash: Option<String>) {
         let _span = info_span!("wasm::addServer", tier = self.tier_label).entered();
         let server_id = {
             let mut slot = self.upstream_server_id.borrow_mut();
@@ -945,7 +945,10 @@ impl WasmRuntime {
         // Re-attach semantics: remove existing upstream edge then add again so
         // replay/full-sync runs on every successful reconnect.
         core.remove_server(server_id);
-        core.add_server(server_id);
+        core.add_server_with_catalogue_state_hash(
+            server_id,
+            server_catalogue_state_hash.as_deref(),
+        );
         core.batched_tick();
     }
 

--- a/packages/jazz-tools/src/react-native/jazz-rn-runtime-adapter.ts
+++ b/packages/jazz-tools/src/react-native/jazz-rn-runtime-adapter.ts
@@ -4,7 +4,7 @@ import { OutboxDestinationKind } from "../runtime/sync-transport.js";
 
 export interface JazzRnRuntimeBinding {
   addClient(): string;
-  addServer(): void;
+  addServer(serverCatalogueStateHash?: string | null): void;
   batchedTick(): void;
   close(): void;
   delete_(objectId: string): void;
@@ -283,7 +283,7 @@ export class JazzRnRuntimeAdapter implements Runtime {
     });
   }
 
-  addServer(): void {
+  addServer(_serverCatalogueStateHash?: string | null): void {
     if (this.closed) return;
     this.binding.addServer();
   }

--- a/packages/jazz-tools/src/runtime/client.ts
+++ b/packages/jazz-tools/src/runtime/client.ts
@@ -73,7 +73,7 @@ export interface Runtime {
   unsubscribe(handle: number): void;
   onSyncMessageReceived(payload: Uint8Array | string): void;
   onSyncMessageToSend(callback: RuntimeSyncOutboxCallback): void;
-  addServer(): void;
+  addServer(serverCatalogueStateHash?: string | null): void;
   removeServer(): void;
   addClient(): string;
   getSchema(): any;

--- a/packages/jazz-tools/src/runtime/sync-transport.test.ts
+++ b/packages/jazz-tools/src/runtime/sync-transport.test.ts
@@ -294,7 +294,11 @@ describe("sync-transport", () => {
   it("stream controller attaches on Connected and forwards sync payloads", async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       streamResponse([
-        { type: "Connected", client_id: "server-client-1" },
+        {
+          type: "Connected",
+          client_id: "server-client-1",
+          catalogue_state_hash: "catalogue-1",
+        },
         { type: "SyncUpdate", payload: { Ping: {} } },
       ]),
     );
@@ -319,6 +323,7 @@ describe("sync-transport", () => {
     controller.start("http://localhost:3000");
 
     await vi.waitFor(() => expect(onConnected).toHaveBeenCalledTimes(1));
+    expect(onConnected).toHaveBeenCalledWith("catalogue-1");
     await vi.waitFor(() =>
       expect(onSyncMessage).toHaveBeenCalledWith(JSON.stringify({ Ping: {} })),
     );
@@ -439,7 +444,13 @@ describe("sync-transport", () => {
   });
 
   it("labels callback failures separately from parse failures", async () => {
-    const response = streamResponse([{ type: "Connected", client_id: "server-client-4" }]);
+    const response = streamResponse([
+      {
+        type: "Connected",
+        client_id: "server-client-4",
+        catalogue_state_hash: "catalogue-4",
+      },
+    ]);
     const reader = response.body!.getReader();
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
@@ -461,7 +472,11 @@ describe("sync-transport", () => {
   it("runtime-bound stream controller maps stream events to runtime hooks", async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       streamResponse([
-        { type: "Connected", client_id: "server-client-3" },
+        {
+          type: "Connected",
+          client_id: "server-client-3",
+          catalogue_state_hash: "catalogue-3",
+        },
         { type: "SyncUpdate", payload: { Ping: {} } },
       ]),
     );
@@ -486,6 +501,7 @@ describe("sync-transport", () => {
     controller.start("http://localhost:3000");
 
     await vi.waitFor(() => expect(runtime.addServer).toHaveBeenCalledTimes(1));
+    expect(runtime.addServer).toHaveBeenCalledWith("catalogue-3");
     await vi.waitFor(() =>
       expect(runtime.onSyncMessageReceived).toHaveBeenCalledWith(JSON.stringify({ Ping: {} })),
     );

--- a/packages/jazz-tools/src/runtime/sync-transport.ts
+++ b/packages/jazz-tools/src/runtime/sync-transport.ts
@@ -37,7 +37,7 @@ export interface LinkExternalResponse {
 /** Callbacks for stream events. */
 export interface StreamCallbacks {
   onSyncMessage(payloadJson: string): void;
-  onConnected?(clientId: string): void;
+  onConnected?(clientId: string, catalogueStateHash?: string | null): void;
 }
 
 export interface SyncStreamControllerOptions {
@@ -45,7 +45,7 @@ export interface SyncStreamControllerOptions {
   getAuth(): Pick<SyncAuth, "jwtToken" | "localAuthMode" | "localAuthToken" | "backendSecret">;
   getClientId(): string;
   setClientId(clientId: string): void;
-  onConnected(): void;
+  onConnected(catalogueStateHash?: string | null): void;
   onDisconnected(): void;
   onSyncMessage(payloadJson: string): void;
 }
@@ -54,7 +54,7 @@ export interface SyncStreamControllerOptions {
  * Minimal runtime surface required for sync stream lifecycle wiring.
  */
 export interface RuntimeSyncTarget {
-  addServer(): void;
+  addServer(serverCatalogueStateHash?: string | null): void;
   removeServer(): void;
   onSyncMessageReceived(payload: string): void;
 }
@@ -158,11 +158,11 @@ export class SyncStreamController {
     return this.activeServerPathPrefix;
   }
 
-  private attachServer(): void {
+  private attachServer(catalogueStateHash?: string | null): void {
     if (this.streamAttached) {
       this.options.onDisconnected();
     }
-    this.options.onConnected();
+    this.options.onConnected(catalogueStateHash);
     this.streamAttached = true;
     this.reconnectAttempt = 0;
   }
@@ -241,11 +241,11 @@ export class SyncStreamController {
         reader,
         {
           onSyncMessage: this.options.onSyncMessage,
-          onConnected: (clientId) => {
+          onConnected: (clientId, catalogueStateHash) => {
             this.options.setClientId(clientId);
             if (!connected) {
               connected = true;
-              this.attachServer();
+              this.attachServer(catalogueStateHash);
             }
           },
         },
@@ -279,7 +279,7 @@ export function createRuntimeSyncStreamController(
     getAuth: options.getAuth,
     getClientId: options.getClientId,
     setClientId: options.setClientId,
-    onConnected: () => options.getRuntime()?.addServer(),
+    onConnected: (catalogueStateHash) => options.getRuntime()?.addServer(catalogueStateHash),
     onDisconnected: () => options.getRuntime()?.removeServer(),
     onSyncMessage: (payload) => options.getRuntime()?.onSyncMessageReceived(payload),
   });
@@ -675,7 +675,7 @@ export async function readBinaryFrames(
 
       try {
         if (event.type === "Connected" && event.client_id) {
-          callbacks.onConnected?.(event.client_id);
+          callbacks.onConnected?.(event.client_id, event.catalogue_state_hash ?? null);
         } else if (event.type === "SyncUpdate") {
           callbacks.onSyncMessage(JSON.stringify(event.payload));
         }

--- a/packages/jazz-tools/src/types/jazz-wasm.d.ts
+++ b/packages/jazz-tools/src/types/jazz-wasm.d.ts
@@ -62,7 +62,7 @@ declare module "jazz-wasm" {
     unsubscribe(handle: number): void;
     onSyncMessageReceived(messageJson: string): void;
     onSyncMessageToSend(callback: SyncOutboxCallback): void;
-    addServer(): void;
+    addServer(serverCatalogueStateHash?: string | null): void;
     removeServer(): void;
     addClient(): string;
     getSchema(): unknown;


### PR DESCRIPTION
## Summary
- add a catalogue state hash to the connect handshake
- compare local and remote catalogue hashes before upstream sync
- skip replaying catalogue objects when both sides already match

## Testing
- cargo test -p jazz-tools --features transport --lib test_server_event_frame_roundtrip -- --nocapture
- cargo test -p jazz-tools --lib test_matching_catalogue_hash_skips_catalogue_replay_on_add_server -- --nocapture
- cargo test -p jazz-tools --features cli --test integration test_stream_connection_receives_connected_event -- --nocapture
- cargo check -p jazz-cloud-server -p jazz-wasm -p jazz-napi
- pnpm --filter jazz-tools exec vitest run --config vitest.config.ts src/runtime/sync-transport.test.ts
- pnpm build