### PR TITLE
Add more integration tests, default to MemoryStorage for TestingClient and TestingServer

### DIFF
--- a/crates/jazz-cloud-server/tests/client_multi_integration.rs
+++ b/crates/jazz-cloud-server/tests/client_multi_integration.rs
@@ -254,6 +254,7 @@ fn make_context(
         schema: test_schema(),
         server_url: format!("{server_url}/apps/{app_id}"),
         data_dir,
+        storage: jazz_tools::ClientStorage::Fjall,
         jwt_token: Some(jwt_token),
         backend_secret: Some(BACKEND_SECRET.to_string()),
         admin_secret: Some(ADMIN_SECRET.to_string()),

--- a/crates/jazz-tools/examples/realistic_bench.rs
+++ b/crates/jazz-tools/examples/realistic_bench.rs
@@ -350,6 +350,7 @@ async fn connect_client(
         schema: benchmark_schema(),
         server_url: server_url.unwrap_or("").to_string(),
         data_dir,
+        storage: jazz_tools::ClientStorage::Fjall,
         jwt_token: None,
         backend_secret: None,
         admin_secret: None,

--- a/crates/jazz-tools/src/client.rs
+++ b/crates/jazz-tools/src/client.rs
@@ -13,7 +13,7 @@ use crate::query_manager::session::Session;
 use crate::query_manager::types::{OrderedRowDelta, RowDescriptor, Schema, TableName, Value};
 use crate::runtime_core::ReadDurabilityOptions;
 use crate::schema_manager::SchemaManager;
-use crate::storage::{FjallStorage, Storage, StorageError};
+use crate::storage::{FjallStorage, MemoryStorage, Storage, StorageError};
 use crate::sync_manager::{
     ClientId, Destination, DurabilityTier, InboxEntry, ServerId, Source, SyncManager, SyncPayload,
 };
@@ -22,16 +22,21 @@ use futures::StreamExt;
 use tokio::sync::{RwLock, mpsc, oneshot};
 
 use crate::transport::{AuthConfig, ServerConnection};
-use crate::{AppContext, JazzError, ObjectId, Result, SubscriptionHandle, SubscriptionStream};
+use crate::{
+    AppContext, ClientStorage, JazzError, ObjectId, Result, SubscriptionHandle, SubscriptionStream,
+};
+
+type DynStorage = Box<dyn Storage + Send>;
+type ClientRuntime = TokioRuntime<DynStorage>;
 
 /// Jazz client for building applications.
 ///
-/// Combines local persistence with server sync.
+/// Combines local storage with server sync.
 pub struct JazzClient {
     /// Schema as declared by the client/app code.
     declared_schema: Schema,
     /// Handle to the local runtime.
-    runtime: TokioRuntime<FjallStorage>,
+    runtime: ClientRuntime,
     /// Connection to the server (shared for event processor).
     server_connection: Option<Arc<ServerConnection>>,
     /// Active subscriptions (metadata).
@@ -51,34 +56,15 @@ impl JazzClient {
     /// Connect to Jazz with the given configuration.
     ///
     /// This will:
-    /// 1. Open local Fjall storage
+    /// 1. Open local storage
     /// 2. Initialize the runtime
     /// 3. Connect to the server (if URL provided)
     /// 4. Start syncing
     pub async fn connect(context: AppContext) -> Result<Self> {
         let declared_schema = context.schema.clone();
-        // Create data directory if needed
-        std::fs::create_dir_all(&context.data_dir)?;
-
-        // Load or generate persistent client_id
-        let client_id_path = context.data_dir.join("client_id");
-        let client_id = if client_id_path.exists() {
-            let id_str = std::fs::read_to_string(&client_id_path)?;
-            ClientId::parse(id_str.trim()).unwrap_or_else(|| {
-                // File corrupted - generate new ID and overwrite
-                let id = context.client_id.unwrap_or_default();
-                let _ = std::fs::write(&client_id_path, id.to_string());
-                id
-            })
-        } else if let Some(id) = context.client_id {
-            // Use explicitly provided client_id and persist it
-            std::fs::write(&client_id_path, id.to_string())?;
-            id
-        } else {
-            // Generate new client_id and persist it
-            let id = ClientId::new();
-            std::fs::write(&client_id_path, id.to_string())?;
-            id
+        let client_id = match context.storage {
+            ClientStorage::Fjall => load_or_create_persistent_client_id(&context)?,
+            ClientStorage::Memory => context.client_id.unwrap_or_default(),
         };
 
         // Create managers
@@ -106,49 +92,9 @@ impl JazzClient {
             None
         };
 
-        // Create persistent storage.
-        //
-        // Fjall lock release can lag slightly after a close() in the same process.
-        // Retry briefly on lock errors so immediate reopen flows remain reliable.
-        let db_path = context.data_dir.join("jazz.fjall");
-        let storage = {
-            const MAX_ATTEMPTS: usize = 100;
-            const RETRY_DELAY_MS: u64 = 25;
-
-            let mut opened = None;
-            let mut last_err = None;
-
-            for attempt in 0..MAX_ATTEMPTS {
-                match FjallStorage::open(&db_path, 64 * 1024 * 1024) {
-                    Ok(storage) => {
-                        opened = Some(storage);
-                        break;
-                    }
-                    Err(err) => {
-                        let is_lock_error = matches!(
-                            &err,
-                            StorageError::IoError(msg)
-                                if msg.contains("lock")
-                                    || msg.contains("Lock")
-                                    || msg.contains("busy")
-                        );
-                        if !is_lock_error || attempt + 1 == MAX_ATTEMPTS {
-                            last_err = Some(err);
-                            break;
-                        }
-                        tokio::time::sleep(Duration::from_millis(RETRY_DELAY_MS)).await;
-                    }
-                }
-            }
-
-            if let Some(storage) = opened {
-                storage
-            } else {
-                let err = last_err.unwrap_or_else(|| {
-                    StorageError::IoError("fjall open failed without error details".to_string())
-                });
-                return Err(JazzError::Storage(format!("{:?}", err)));
-            }
+        let storage: DynStorage = match context.storage {
+            ClientStorage::Fjall => Box::new(open_fjall_storage(&context.data_dir).await?),
+            ClientStorage::Memory => Box::new(MemoryStorage::new()),
         };
 
         // Clone server connection for sync callback
@@ -494,7 +440,11 @@ impl JazzClient {
 
         // Flush storage state to disk for persistence
         self.runtime
-            .with_storage(|storage| storage.flush())
+            .with_storage(|storage| {
+                storage.flush();
+                storage.close()
+            })
+            .map_err(|e| JazzError::Storage(e.to_string()))?
             .map_err(|e| JazzError::Storage(e.to_string()))?;
 
         Ok(())
@@ -773,7 +723,7 @@ fn test_send_delay_for_object_updated(payload: &SyncPayload) -> Option<Duration>
 /// Handle incoming server events.
 fn handle_server_event(
     event: ServerEvent,
-    runtime: &TokioRuntime<FjallStorage>,
+    runtime: &ClientRuntime,
     server_id: ServerId,
 ) -> Result<()> {
     match event {
@@ -823,5 +773,69 @@ fn handle_server_event(
             tracing::trace!("Heartbeat received");
             Ok(())
         }
+    }
+}
+
+fn load_or_create_persistent_client_id(context: &AppContext) -> Result<ClientId> {
+    std::fs::create_dir_all(&context.data_dir)?;
+
+    let client_id_path = context.data_dir.join("client_id");
+    let client_id = if client_id_path.exists() {
+        let id_str = std::fs::read_to_string(&client_id_path)?;
+        ClientId::parse(id_str.trim()).unwrap_or_else(|| {
+            let id = context.client_id.unwrap_or_default();
+            let _ = std::fs::write(&client_id_path, id.to_string());
+            id
+        })
+    } else if let Some(id) = context.client_id {
+        std::fs::write(&client_id_path, id.to_string())?;
+        id
+    } else {
+        let id = ClientId::new();
+        std::fs::write(&client_id_path, id.to_string())?;
+        id
+    };
+
+    Ok(client_id)
+}
+
+async fn open_fjall_storage(data_dir: &std::path::Path) -> Result<FjallStorage> {
+    const MAX_ATTEMPTS: usize = 100;
+    const RETRY_DELAY_MS: u64 = 25;
+
+    std::fs::create_dir_all(data_dir)?;
+
+    let db_path = data_dir.join("jazz.fjall");
+    let mut opened = None;
+    let mut last_err = None;
+
+    for attempt in 0..MAX_ATTEMPTS {
+        match FjallStorage::open(&db_path, 64 * 1024 * 1024) {
+            Ok(storage) => {
+                opened = Some(storage);
+                break;
+            }
+            Err(err) => {
+                let is_lock_error = matches!(
+                    &err,
+                    StorageError::IoError(msg)
+                        if msg.contains("lock") || msg.contains("Lock") || msg.contains("busy")
+                );
+                if !is_lock_error || attempt + 1 == MAX_ATTEMPTS {
+                    last_err = Some(err);
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(RETRY_DELAY_MS)).await;
+            }
+        }
+    }
+
+    if let Some(storage) = opened {
+        Ok(storage)
+    } else {
+        let err = last_err.unwrap_or_else(|| {
+            StorageError::IoError("fjall open failed without error details".to_string())
+        });
+        Err(JazzError::Storage(format!("{:?}", err)))
     }
 }

--- a/crates/jazz-tools/src/lib.rs
+++ b/crates/jazz-tools/src/lib.rs
@@ -74,8 +74,10 @@ pub struct AppContext {
     pub schema: Schema,
     /// Server URL for sync (e.g., "http://localhost:1625").
     pub server_url: String,
-    /// Local data directory for Fjall storage.
+    /// Local data directory for persistent storage.
     pub data_dir: PathBuf,
+    /// Local storage backend.
+    pub storage: ClientStorage,
 
     // Authentication fields
     /// JWT token for frontend authentication.
@@ -87,6 +89,17 @@ pub struct AppContext {
     /// Admin secret for schema/policy sync.
     /// Required to sync catalogue objects.
     pub admin_secret: Option<String>,
+}
+
+/// Local storage backend for a client application.
+#[cfg(feature = "client")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ClientStorage {
+    /// Persist client state to disk using Fjall under `AppContext::data_dir`.
+    #[default]
+    Fjall,
+    /// Keep all client state in memory for the lifetime of the process only.
+    Memory,
 }
 
 /// Errors from Jazz client operations.

--- a/crates/jazz-tools/src/server/testing.rs
+++ b/crates/jazz-tools/src/server/testing.rs
@@ -28,6 +28,7 @@ pub struct TestingServerBuilder {
     app_id: Option<AppId>,
     data_dir: Option<PathBuf>,
     schema: Option<Schema>,
+    in_memory: bool,
 }
 
 impl TestingServerBuilder {
@@ -53,6 +54,16 @@ impl TestingServerBuilder {
 
     pub fn with_schema(mut self, schema: Schema) -> Self {
         self.schema = Some(schema);
+        self
+    }
+
+    /// Use in-memory storage instead of a persistent on-disk fjall store.
+    ///
+    /// Prefer this in tests that don't need durability — it avoids allocating
+    /// temp directories and opening file descriptors, which matters when many
+    /// tests run in parallel.
+    pub fn with_in_memory_storage(mut self) -> Self {
+        self.in_memory = true;
         self
     }
 
@@ -134,11 +145,16 @@ impl TestingServer {
             app_id,
             data_dir,
             schema,
+            in_memory,
         } = builder;
 
         let port = port.unwrap_or_else(get_free_port);
         let app_id = app_id.unwrap_or_else(Self::default_app_id);
-        let (data_dir, owned_data_dir) = prepare_data_dir(data_dir);
+        let (data_dir, owned_data_dir) = if in_memory {
+            (PathBuf::new(), None)
+        } else {
+            prepare_data_dir(data_dir)
+        };
         let jwks_server = TestingJwksServer::start().await;
 
         let auth_config = AuthConfig {
@@ -150,9 +166,12 @@ impl TestingServer {
             admin_secret: Some(Self::ADMIN_SECRET.to_string()),
         };
 
-        let mut server_builder = ServerBuilder::new(app_id)
-            .with_auth_config(auth_config)
-            .with_persistent_storage(data_dir.to_string_lossy().into_owned());
+        let mut server_builder = ServerBuilder::new(app_id).with_auth_config(auth_config);
+        server_builder = if in_memory {
+            server_builder.with_in_memory_storage()
+        } else {
+            server_builder.with_persistent_storage(data_dir.to_string_lossy().into_owned())
+        };
         if let Some(schema) = schema {
             server_builder = server_builder.with_schema(schema);
         }

--- a/crates/jazz-tools/src/server/testing.rs
+++ b/crates/jazz-tools/src/server/testing.rs
@@ -162,10 +162,8 @@ impl TestingServer {
 
         let mut server_builder = ServerBuilder::new(app_id).with_auth_config(auth_config);
         server_builder = if persistent_storage {
-            println!("with_persistent_storage");
             server_builder.with_persistent_storage(data_dir.to_string_lossy().into_owned())
         } else {
-            println!("with_in_memory_storage");
             server_builder.with_in_memory_storage()
         };
 

--- a/crates/jazz-tools/src/server/testing.rs
+++ b/crates/jazz-tools/src/server/testing.rs
@@ -28,7 +28,7 @@ pub struct TestingServerBuilder {
     app_id: Option<AppId>,
     data_dir: Option<PathBuf>,
     schema: Option<Schema>,
-    in_memory: bool,
+    persistent_storage: bool,
 }
 
 impl TestingServerBuilder {
@@ -57,13 +57,8 @@ impl TestingServerBuilder {
         self
     }
 
-    /// Use in-memory storage instead of a persistent on-disk fjall store.
-    ///
-    /// Prefer this in tests that don't need durability — it avoids allocating
-    /// temp directories and opening file descriptors, which matters when many
-    /// tests run in parallel.
-    pub fn with_in_memory_storage(mut self) -> Self {
-        self.in_memory = true;
+    pub fn with_persistent_storage(mut self) -> Self {
+        self.persistent_storage = true;
         self
     }
 
@@ -145,15 +140,14 @@ impl TestingServer {
             app_id,
             data_dir,
             schema,
-            in_memory,
+            persistent_storage,
         } = builder;
 
-        let port = port.unwrap_or_else(get_free_port);
         let app_id = app_id.unwrap_or_else(Self::default_app_id);
-        let (data_dir, owned_data_dir) = if in_memory {
-            (PathBuf::new(), None)
-        } else {
+        let (data_dir, owned_data_dir) = if persistent_storage {
             prepare_data_dir(data_dir)
+        } else {
+            (PathBuf::new(), None)
         };
         let jwks_server = TestingJwksServer::start().await;
 
@@ -167,19 +161,23 @@ impl TestingServer {
         };
 
         let mut server_builder = ServerBuilder::new(app_id).with_auth_config(auth_config);
-        server_builder = if in_memory {
-            server_builder.with_in_memory_storage()
-        } else {
+        server_builder = if persistent_storage {
+            println!("with_persistent_storage");
             server_builder.with_persistent_storage(data_dir.to_string_lossy().into_owned())
+        } else {
+            println!("with_in_memory_storage");
+            server_builder.with_in_memory_storage()
         };
+
         if let Some(schema) = schema {
             server_builder = server_builder.with_schema(schema);
         }
         let built = server_builder.build().await.expect("build test server");
 
-        let listener = tokio::net::TcpListener::bind(("127.0.0.1", port))
+        let listener = tokio::net::TcpListener::bind(("127.0.0.1", port.unwrap_or(0)))
             .await
             .expect("bind test server listener");
+        let port = listener.local_addr().expect("local addr").port();
         let (shutdown_tx, shutdown_rx) = oneshot::channel();
         let task = tokio::spawn(async move {
             axum::serve(listener, built.app)
@@ -263,6 +261,7 @@ impl TestingServer {
             schema,
             server_url: self.base_url(),
             data_dir,
+            storage: crate::ClientStorage::Memory,
             jwt_token: Some(Self::jwt_for_user(user_id.as_ref())),
             backend_secret: Some(Self::BACKEND_SECRET.to_string()),
             admin_secret: Some(Self::ADMIN_SECRET.to_string()),
@@ -365,11 +364,6 @@ fn prepare_data_dir(data_dir: Option<PathBuf>) -> (PathBuf, Option<OwnedTempDir>
             (temp_dir.path().to_path_buf(), Some(temp_dir))
         }
     }
-}
-
-fn get_free_port() -> u16 {
-    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind port 0");
-    listener.local_addr().expect("local addr").port()
 }
 
 async fn jwks_handler() -> Json<JsonValue> {

--- a/crates/jazz-tools/tests/client_restart_integration.rs
+++ b/crates/jazz-tools/tests/client_restart_integration.rs
@@ -8,8 +8,8 @@ use axum::{Json, Router, routing::get};
 use base64::Engine;
 use jazz_tools::storage::{FjallStorage, Storage};
 use jazz_tools::{
-    AppContext, AppId, ColumnType, DurabilityTier, JazzClient, QueryBuilder, SchemaBuilder,
-    TableSchema, Value,
+    AppContext, AppId, ClientId, ClientStorage, ColumnType, DurabilityTier, JazzClient,
+    QueryBuilder, SchemaBuilder, TableSchema, Value,
 };
 use jsonwebtoken::{Algorithm, EncodingKey, Header, encode};
 use serde::{Deserialize, Serialize};
@@ -202,6 +202,7 @@ fn make_context(
         schema: test_schema(),
         server_url,
         data_dir,
+        storage: ClientStorage::Fjall,
         jwt_token: Some(jwt_token),
         backend_secret: Some(BACKEND_SECRET.to_string()),
         admin_secret: Some(ADMIN_SECRET.to_string()),
@@ -383,4 +384,73 @@ async fn jazz_tools_cli_existing_client_keeps_working_after_server_restart_witho
 
     client.shutdown().await.expect("shutdown client");
     drop(restarted);
+}
+
+#[tokio::test]
+async fn memory_storage_client_does_not_persist_local_state_to_disk() {
+    let data_dir = TempDir::new().expect("temp client dir");
+    let context = AppContext {
+        app_id: AppId::from_string(APP_ID_STR).expect("parse app id"),
+        client_id: Some(ClientId::new()),
+        schema: test_schema(),
+        server_url: String::new(),
+        data_dir: data_dir.path().to_path_buf(),
+        storage: ClientStorage::Memory,
+        jwt_token: None,
+        backend_secret: None,
+        admin_secret: None,
+    };
+
+    let client = JazzClient::connect(context.clone())
+        .await
+        .expect("connect memory client");
+
+    client
+        .create(
+            "todos",
+            vec![
+                Value::Text("only-in-memory".to_string()),
+                Value::Boolean(false),
+            ],
+        )
+        .await
+        .expect("create todo");
+
+    let initial_rows = client
+        .query(QueryBuilder::new("todos").build(), None)
+        .await
+        .expect("query rows before restart");
+    assert_eq!(
+        initial_rows.len(),
+        1,
+        "memory client should serve local rows"
+    );
+
+    client.shutdown().await.expect("shutdown memory client");
+
+    assert!(
+        !data_dir.path().join("jazz.fjall").exists(),
+        "memory storage should not create a Fjall database on disk"
+    );
+    assert!(
+        !data_dir.path().join("client_id").exists(),
+        "memory storage should not persist a client_id file"
+    );
+
+    let restarted = JazzClient::connect(context)
+        .await
+        .expect("reconnect memory client");
+    let rows_after_restart = restarted
+        .query(QueryBuilder::new("todos").build(), None)
+        .await
+        .expect("query rows after restart");
+    assert_eq!(
+        rows_after_restart.len(),
+        0,
+        "memory storage should not retain rows across reconnects"
+    );
+    restarted
+        .shutdown()
+        .await
+        .expect("shutdown restarted memory client");
 }

--- a/crates/jazz-tools/tests/clients_sync.rs
+++ b/crates/jazz-tools/tests/clients_sync.rs
@@ -34,6 +34,108 @@ async fn wait_for_edge_query_ready(client: &JazzClient, timeout: Duration) {
     .await;
 }
 
+/// Verifies that a fresh client resolves the latest state for a single object
+/// after a long chain of overwrites has already compacted through the server.
+///
+/// Alice creates one todo, updates its `title` 100 times, and waits until the
+/// final title is Edge-settled. Bob then connects from a fresh local state and
+/// queries the table. Bob must observe the final title rather than an earlier
+/// revision from the object's history.
+///
+/// ```text
+/// alice ──create + title update ×100──► server
+///                                          │
+///                          bob connects fresh and queries
+///                                          │
+///                                          └──► latest title only
+/// ```
+#[tokio::test]
+async fn fresh_client_resolves_object_with_deep_update_history() {
+    const DEEP_HISTORY_UPDATES: usize = 100;
+
+    let server = TestingServer::start().await;
+    let schema = test_schema();
+    let writer =
+        JazzClient::connect(server.make_client_context_for_user(schema.clone(), "alice-history"))
+            .await
+            .expect("connect history writer");
+
+    wait_for_edge_query_ready(&writer, Duration::from_secs(30)).await;
+
+    let (todo_id, _) = writer
+        .create(
+            "todos",
+            vec![
+                Value::Text("revision-000".to_string()),
+                Value::Boolean(false),
+            ],
+        )
+        .await
+        .expect("create deep-history todo");
+
+    let final_title = format!("revision-{DEEP_HISTORY_UPDATES:03}");
+    for revision in 1..=DEEP_HISTORY_UPDATES {
+        writer
+            .update(
+                todo_id,
+                vec![(
+                    "title".to_string(),
+                    Value::Text(format!("revision-{revision:03}")),
+                )],
+            )
+            .await
+            .expect("update deep-history todo");
+    }
+
+    let writer_rows = wait_for_query(
+        &writer,
+        QueryBuilder::new("todos").build(),
+        Some(DurabilityTier::EdgeServer),
+        Duration::from_secs(25),
+        format!("writer sees final title {final_title}"),
+        |rows| {
+            (rows.len() == 1
+                && rows[0].0 == todo_id
+                && rows[0].1.first() == Some(&Value::Text(final_title.clone())))
+            .then_some(rows)
+        },
+    )
+    .await;
+    assert_eq!(writer_rows.len(), 1);
+    assert_eq!(writer_rows[0].1[0], Value::Text(final_title.clone()));
+
+    let fresh_client =
+        JazzClient::connect(server.make_client_context_for_user(schema, "bob-fresh-history"))
+            .await
+            .expect("connect fresh history reader");
+    wait_for_edge_query_ready(&fresh_client, Duration::from_secs(30)).await;
+
+    let fresh_rows = wait_for_query(
+        &fresh_client,
+        QueryBuilder::new("todos").build(),
+        Some(DurabilityTier::EdgeServer),
+        Duration::from_secs(25),
+        format!("fresh client sees final title {final_title}"),
+        |rows| {
+            (rows.len() == 1
+                && rows[0].0 == todo_id
+                && rows[0].1.first() == Some(&Value::Text(final_title.clone())))
+            .then_some(rows)
+        },
+    )
+    .await;
+    assert_eq!(fresh_rows.len(), 1);
+    assert_eq!(fresh_rows[0].0, todo_id);
+    assert_eq!(fresh_rows[0].1[0], Value::Text(final_title));
+
+    writer.shutdown().await.expect("shutdown history writer");
+    fresh_client
+        .shutdown()
+        .await
+        .expect("shutdown fresh history reader");
+    server.shutdown().await;
+}
+
 #[tokio::test]
 async fn jazz_tools_cli_two_clients_sync_values() {
     let server = TestingServer::start().await;

--- a/crates/jazz-tools/tests/policies_integration.rs
+++ b/crates/jazz-tools/tests/policies_integration.rs
@@ -186,7 +186,6 @@ async fn select_policies_filter_subscription_results_per_client_session() {
     let schema = select_policy_schema();
     let server = TestingServer::builder()
         .with_schema(schema.clone())
-        .with_in_memory_storage()
         .start()
         .await;
     let alice = TestingClient::builder()
@@ -289,7 +288,6 @@ async fn select_policy_excludes_rows_from_join_results() {
     let schema = join_select_policy_schema();
     let server = TestingServer::builder()
         .with_schema(schema.clone())
-        .with_in_memory_storage()
         .start()
         .await;
     let admin = TestingClient::builder()
@@ -375,7 +373,6 @@ async fn in_session_array_policy_gates_visibility_by_membership() {
     let schema = in_session_array_policy_schema();
     let server = TestingServer::builder()
         .with_schema(schema.clone())
-        .with_in_memory_storage()
         .start()
         .await;
     let admin = TestingClient::builder()
@@ -466,7 +463,6 @@ async fn insert_policies_are_enforced_by_server_for_client_sync() {
     let schema = write_policy_schema();
     let server = TestingServer::builder()
         .with_schema(schema.clone())
-        .with_in_memory_storage()
         .start()
         .await;
     let intruder = TestingClient::builder()
@@ -563,7 +559,6 @@ async fn update_policies_block_unauthorized_server_mutations() {
     let schema = write_policy_schema();
     let server = TestingServer::builder()
         .with_schema(schema.clone())
-        .with_in_memory_storage()
         .start()
         .await;
     let alice = TestingClient::builder()
@@ -668,7 +663,6 @@ async fn insert_policy_violation_does_not_leak_to_pristine_subscriber() {
     let schema = write_policy_schema();
     let server = TestingServer::builder()
         .with_schema(schema.clone())
-        .with_in_memory_storage()
         .start()
         .await;
     let mallory = TestingClient::builder()
@@ -767,7 +761,6 @@ async fn update_policy_read_clause_differs_from_write_clause() {
     let schema = write_check_policy_schema();
     let server = TestingServer::builder()
         .with_schema(schema.clone())
-        .with_in_memory_storage()
         .start()
         .await;
     let alice = TestingClient::builder()
@@ -866,7 +859,6 @@ async fn delete_then_reinsert_by_owner_visible_to_others() {
     let schema = write_policy_schema();
     let server = TestingServer::builder()
         .with_schema(schema.clone())
-        .with_in_memory_storage()
         .start()
         .await;
     let alice = TestingClient::builder()
@@ -959,7 +951,6 @@ async fn delete_policies_block_unauthorized_server_mutations() {
     let schema = write_policy_schema();
     let server = TestingServer::builder()
         .with_schema(schema.clone())
-        .with_in_memory_storage()
         .start()
         .await;
     let alice = TestingClient::builder()

--- a/crates/jazz-tools/tests/policies_integration.rs
+++ b/crates/jazz-tools/tests/policies_integration.rs
@@ -74,6 +74,22 @@ fn write_policy_schema() -> Schema {
         .build()
 }
 
+/// Schema with an UPDATE policy where `using = True` (anyone can target any row)
+/// and `with_check = owner_policy` (only the owner may commit the new value).
+/// This lets tests verify that the two clauses are evaluated independently.
+fn write_check_policy_schema() -> Schema {
+    let owner_policy = PolicyExpr::eq_session("owner_id", vec!["user_id".into()]);
+
+    SchemaBuilder::new()
+        .table(
+            TableSchema::builder("documents")
+                .column("owner_id", ColumnType::Text)
+                .column("title", ColumnType::Text)
+                .policies(TablePolicies::new().with_update(Some(PolicyExpr::True), owner_policy)),
+        )
+        .build()
+}
+
 fn in_session_array_policy_schema() -> Schema {
     SchemaBuilder::new()
         .table(
@@ -170,6 +186,7 @@ async fn select_policies_filter_subscription_results_per_client_session() {
     let schema = select_policy_schema();
     let server = TestingServer::builder()
         .with_schema(schema.clone())
+        .with_in_memory_storage()
         .start()
         .await;
     let alice = TestingClient::builder()
@@ -272,6 +289,7 @@ async fn select_policy_excludes_rows_from_join_results() {
     let schema = join_select_policy_schema();
     let server = TestingServer::builder()
         .with_schema(schema.clone())
+        .with_in_memory_storage()
         .start()
         .await;
     let admin = TestingClient::builder()
@@ -357,6 +375,7 @@ async fn in_session_array_policy_gates_visibility_by_membership() {
     let schema = in_session_array_policy_schema();
     let server = TestingServer::builder()
         .with_schema(schema.clone())
+        .with_in_memory_storage()
         .start()
         .await;
     let admin = TestingClient::builder()
@@ -447,6 +466,7 @@ async fn insert_policies_are_enforced_by_server_for_client_sync() {
     let schema = write_policy_schema();
     let server = TestingServer::builder()
         .with_schema(schema.clone())
+        .with_in_memory_storage()
         .start()
         .await;
     let intruder = TestingClient::builder()
@@ -543,6 +563,7 @@ async fn update_policies_block_unauthorized_server_mutations() {
     let schema = write_policy_schema();
     let server = TestingServer::builder()
         .with_schema(schema.clone())
+        .with_in_memory_storage()
         .start()
         .await;
     let alice = TestingClient::builder()
@@ -625,6 +646,296 @@ async fn update_policies_block_unauthorized_server_mutations() {
     server.shutdown().await;
 }
 
+/// Verifies that a row rejected by the INSERT policy is invisible to a
+/// subscriber that connects **after** the rejected insert has been processed.
+///
+/// Mallory forges a document claiming alice's `owner_id`. Alice then creates
+/// a legitimate document, which serves as the causal barrier: once alice can
+/// see her own row at EdgeServer tier, the inbox has processed (and dropped)
+/// mallory's earlier insert. A fresh subscriber that connects after the barrier
+/// must find only alice's legitimate row in its initial query result.
+///
+/// ```text
+/// mallory ──insert owner="alice"──► server ──✗ rejected (INSERT policy)
+///
+/// alice ──insert "legitimate"────► server ──► committed
+///   └── EdgeServer query barrier ──────────────────────► (server settled)
+///
+/// fresh subscriber (connects after) ──query──► [alice's row only]
+/// ```
+#[tokio::test]
+async fn insert_policy_violation_does_not_leak_to_pristine_subscriber() {
+    let schema = write_policy_schema();
+    let server = TestingServer::builder()
+        .with_schema(schema.clone())
+        .with_in_memory_storage()
+        .start()
+        .await;
+    let mallory = TestingClient::builder()
+        .with_server(&server)
+        .with_schema(schema.clone())
+        .with_user_id("mallory")
+        .as_user()
+        .ready_on("documents", READY_TIMEOUT)
+        .connect()
+        .await;
+    let alice = TestingClient::builder()
+        .with_server(&server)
+        .with_schema(schema.clone())
+        .with_user_id("alice")
+        .as_user()
+        .ready_on("documents", READY_TIMEOUT)
+        .connect()
+        .await;
+    let query = QueryBuilder::new("documents").build();
+
+    // Mallory tries to insert a row claiming alice's ownership.
+    let forged_id = mallory
+        .create("documents", document_values("alice", "forged"))
+        .await
+        .expect("optimistic local create")
+        .0;
+
+    // Alice's legitimate insert is the causal barrier: her /sync request is
+    // sent after mallory's, so once the server has committed alice's row the
+    // inbox has already processed (and rejected) mallory's earlier request.
+    let legit_id = create_document(&alice, "alice", "legitimate").await;
+    wait_for_rows(
+        &alice,
+        query.clone(),
+        "barrier: alice sees own committed row",
+        |rows| rows.iter().any(|(id, _)| *id == legit_id).then_some(()),
+    )
+    .await;
+
+    // Connect the fresh subscriber only after the server has settled.
+    let fresh_subscriber = TestingClient::builder()
+        .with_server(&server)
+        .with_schema(schema)
+        .with_user_id("observer")
+        .as_user()
+        .ready_on("documents", READY_TIMEOUT)
+        .connect()
+        .await;
+
+    // The fresh subscriber's initial query must contain alice's row but not
+    // the forged row that was silently dropped by the INSERT policy.
+    let rows = wait_for_rows(
+        &fresh_subscriber,
+        query,
+        "fresh subscriber initial results",
+        |rows| rows.iter().any(|(id, _)| *id == legit_id).then_some(rows),
+    )
+    .await;
+    assert!(
+        rows.iter().all(|(id, _)| *id != forged_id),
+        "forged row must not appear in pristine subscriber's initial sync result"
+    );
+
+    mallory.shutdown().await.expect("shutdown mallory");
+    alice.shutdown().await.expect("shutdown alice");
+    fresh_subscriber
+        .shutdown()
+        .await
+        .expect("shutdown fresh_subscriber");
+    server.shutdown().await;
+}
+
+/// Verifies that the UPDATE `using` clause and `with_check` clause are
+/// evaluated independently: a `using = True` policy lets every client target
+/// any row, but a `with_check = owner_policy` still rejects writes from
+/// non-owners.
+///
+/// Bob can read alice's row because there is no SELECT policy and `using = True`
+/// means he can attempt to update it. But the server rejects his write because
+/// the committed row state (`owner_id = "alice"`) fails the `with_check` when
+/// evaluated against bob's session (`user_id = "bob"`). An EdgeServer-tier
+/// query then confirms the original value persisted and the observer's stream
+/// received no update delta.
+///
+/// ```text
+/// alice ──insert "original"──────────► server ──► observer (add ✓)
+///
+/// bob (using=True → can target row) ──update title="hacked"──► server
+///   └── with_check: owner_id="alice" ≠ bob ──✗ rejected
+///
+/// observer ──EdgeServer query──► "original" (unchanged)
+/// observer stream → no update delta
+/// ```
+#[tokio::test]
+async fn update_policy_read_clause_differs_from_write_clause() {
+    let schema = write_check_policy_schema();
+    let server = TestingServer::builder()
+        .with_schema(schema.clone())
+        .with_in_memory_storage()
+        .start()
+        .await;
+    let alice = TestingClient::builder()
+        .with_server(&server)
+        .with_schema(schema.clone())
+        .with_user_id("alice")
+        .as_user()
+        .ready_on("documents", READY_TIMEOUT)
+        .connect()
+        .await;
+    let bob = TestingClient::builder()
+        .with_server(&server)
+        .with_schema(schema.clone())
+        .with_user_id("bob")
+        .as_user()
+        .ready_on("documents", READY_TIMEOUT)
+        .connect()
+        .await;
+    let observer = TestingClient::builder()
+        .with_server(&server)
+        .with_schema(schema)
+        .with_user_id("observer")
+        .as_user()
+        .ready_on("documents", READY_TIMEOUT)
+        .connect()
+        .await;
+    let query = QueryBuilder::new("documents").build();
+
+    let mut observer_stream = observer
+        .subscribe(query.clone())
+        .await
+        .expect("subscribe observer");
+    let mut observer_log = Vec::new();
+
+    let doc_id = create_document(&alice, "alice", "original").await;
+    wait_for_subscription_update(
+        &mut observer_stream,
+        &mut observer_log,
+        QUERY_TIMEOUT,
+        "observer sees initial row",
+        |log| has_added(log, doc_id),
+    )
+    .await;
+
+    // Bob can read alice's row — no SELECT restriction and using=True passes.
+    wait_for_rows(&bob, query.clone(), "bob sees alice's row", |rows| {
+        rows.iter()
+            .find(|(id, values)| *id == doc_id && *values == document_values("alice", "original"))
+            .map(|_| ())
+    })
+    .await;
+
+    // Bob's update is applied optimistically on his local client but the
+    // with_check policy fails on the server: owner_id="alice" ≠ bob's user_id.
+    bob.update(
+        doc_id,
+        vec![("title".to_string(), Value::Text("hacked".to_string()))],
+    )
+    .await
+    .expect("optimistic local update");
+
+    // EdgeServer query is the causal barrier.
+    let rows_after = observer
+        .query(query.clone(), Some(DurabilityTier::EdgeServer))
+        .await
+        .expect("EdgeServer query after unauthorized update");
+    assert!(
+        rows_after
+            .iter()
+            .any(|(id, values)| *id == doc_id && *values == document_values("alice", "original")),
+        "update rejected by with_check must not persist at EdgeServer: rows={rows_after:?}"
+    );
+    collect_stream_deltas(&mut observer_stream, &mut observer_log, NO_DELTA_WINDOW).await;
+    assert!(
+        !has_updated(&observer_log, doc_id),
+        "update rejected by with_check must not be broadcast: log={observer_log:?}"
+    );
+
+    alice.shutdown().await.expect("shutdown alice");
+    bob.shutdown().await.expect("shutdown bob");
+    observer.shutdown().await.expect("shutdown observer");
+    server.shutdown().await;
+}
+
+/// Verifies that after an owner deletes her row and then re-creates it, the
+/// re-created row appears in the observer's stream as a fresh **add** delta
+/// (new `ObjectId`), not as an **update** delta on the old one.
+///
+/// ```text
+/// alice ──insert doc1──► observer stream (add ✓)
+/// alice ──delete doc1──► observer stream (remove ✓)
+/// alice ──insert doc2──► observer stream (add ✓, NOT update)
+/// ```
+#[tokio::test]
+async fn delete_then_reinsert_by_owner_visible_to_others() {
+    let schema = write_policy_schema();
+    let server = TestingServer::builder()
+        .with_schema(schema.clone())
+        .with_in_memory_storage()
+        .start()
+        .await;
+    let alice = TestingClient::builder()
+        .with_server(&server)
+        .with_schema(schema.clone())
+        .with_user_id("alice")
+        .as_user()
+        .ready_on("documents", READY_TIMEOUT)
+        .connect()
+        .await;
+    let observer = TestingClient::builder()
+        .with_server(&server)
+        .with_schema(schema)
+        .with_user_id("observer")
+        .as_user()
+        .ready_on("documents", READY_TIMEOUT)
+        .connect()
+        .await;
+    let query = QueryBuilder::new("documents").build();
+
+    let mut observer_stream = observer
+        .subscribe(query.clone())
+        .await
+        .expect("subscribe observer");
+    let mut observer_log = Vec::new();
+
+    let doc1_id = create_document(&alice, "alice", "first").await;
+    wait_for_subscription_update(
+        &mut observer_stream,
+        &mut observer_log,
+        QUERY_TIMEOUT,
+        "observer sees first document added",
+        |log| has_added(log, doc1_id),
+    )
+    .await;
+
+    alice.delete(doc1_id).await.expect("delete first document");
+    wait_for_subscription_update(
+        &mut observer_stream,
+        &mut observer_log,
+        QUERY_TIMEOUT,
+        "observer sees first document removed",
+        |log| has_removed(log, doc1_id),
+    )
+    .await;
+
+    // Alice re-creates a document with equivalent content — a new ObjectId is
+    // assigned, so the observer must see an add delta, not an update.
+    let doc2_id = create_document(&alice, "alice", "first").await;
+    wait_for_subscription_update(
+        &mut observer_stream,
+        &mut observer_log,
+        QUERY_TIMEOUT,
+        "observer sees re-created document as add delta",
+        |log| has_added(log, doc2_id),
+    )
+    .await;
+
+    assert_ne!(doc1_id, doc2_id, "re-created row must have a new ObjectId");
+    assert!(
+        !has_updated(&observer_log, doc2_id),
+        "re-created row must arrive as add, not update: log={observer_log:?}"
+    );
+
+    alice.shutdown().await.expect("shutdown alice");
+    observer.shutdown().await.expect("shutdown observer");
+    server.shutdown().await;
+}
+
 /// Verifies that a delete attempt from a client that fails the write policy is
 /// rejected by the server and never broadcast to subscribers.
 ///
@@ -648,6 +959,7 @@ async fn delete_policies_block_unauthorized_server_mutations() {
     let schema = write_policy_schema();
     let server = TestingServer::builder()
         .with_schema(schema.clone())
+        .with_in_memory_storage()
         .start()
         .await;
     let alice = TestingClient::builder()

--- a/crates/jazz-tools/tests/subscribe_all_integration.rs
+++ b/crates/jazz-tools/tests/subscribe_all_integration.rs
@@ -364,20 +364,40 @@ async fn subscribe_all_emits_add_update_remove_and_tracks_current_results() {
 /// same final title.
 ///
 /// TODO:
-/// This is currently ignored because the client path still has two burst-load
-/// bugs in [client.rs](/Users/guidodorsi/workspace/jazz2/crates/jazz-tools/src/client.rs):
-/// server-bound object updates are sent via one detached task per payload, so
-/// the runtime's ordered outbox can arrive at the server out of order; and the
-/// subscription callback forwards deltas with `try_send` into a bounded channel,
-/// so the terminal row-bearing delta can be dropped when the subscriber lags.
+/// Keep this test ignored until the client preserves "latest write wins" during
+/// a burst of updates. The assertion is fine; the client path in src/client.rs
+/// still has two burst-load bugs:
+///
+/// 1. Outgoing updates are sent in separate spawned tasks, so a fast sequence of
+///    writes can reach the server in a different order than the writer produced
+///    them.
+/// 2. Incoming subscription updates are pushed with `try_send` into a fixed-size
+///    channel, so a slow subscriber can silently drop updates, including the
+///    final one that should carry the last title.
+///
+/// That means Bob can read the correct final row state from the server, while
+/// Bob's live subscription stream still ends on an older value.
 ///
 /// ```text
-/// alice ──create todo──────────────► server ──► bob subscription (initial add)
-/// alice ──title update ×500────────► server
-///                                       │
-///                          bob EdgeServer query => final title
-///                                       │
-///                          bob last update delta => final title
+/// intended
+/// --------
+/// Alice writes:  title-001 -> title-002 -> ... -> title-500
+/// Server state:  title-001 -> title-002 -> ... -> title-500
+/// Bob stream:    add ...... update ...... last update = title-500
+///
+/// current failure modes
+/// ---------------------
+/// send tasks can race:
+/// Alice writes:  title-001 -> title-002 -> title-003
+/// Server sees:   title-002 -> title-001 -> title-003
+///
+/// subscriber channel can overflow:
+/// Server sends:  add -> update -> update -> ... -> update(final)
+/// Bob channel:   keep   keep     keep         full -> drop(final)
+///
+/// result:
+/// Bob snapshot query    = title-500
+/// Bob last stream delta != title-500
 /// ```
 #[tokio::test]
 #[ignore = "TODO: fix burst update ordering/dropping in crates/jazz-tools/src/client.rs"]

--- a/crates/jazz-tools/tests/subscribe_all_integration.rs
+++ b/crates/jazz-tools/tests/subscribe_all_integration.rs
@@ -4,10 +4,12 @@ mod support;
 
 use std::time::Duration;
 
+use jazz_tools::query_manager::encoding::decode_row;
+use jazz_tools::query_manager::types::RowDescriptor;
 use jazz_tools::server::TestingServer;
 use jazz_tools::{
-    ColumnType, JazzClient, ObjectId, Query, QueryBuilder, Schema, SchemaBuilder, TableSchema,
-    Value,
+    ColumnType, JazzClient, ObjectId, OrderedRowDelta, Query, QueryBuilder, Schema, SchemaBuilder,
+    TableSchema, Value,
 };
 use support::{
     TestingClient, collect_stream_deltas, has_added, has_any_change, has_removed, has_updated,
@@ -223,6 +225,37 @@ async fn create_file(client: &JazzClient, name: &str, parts: &[ObjectId]) -> Obj
         .0
 }
 
+fn todo_descriptor(schema: &Schema) -> RowDescriptor {
+    schema
+        .get(&"todos".into())
+        .expect("todos table should exist in runtime schema")
+        .columns
+        .clone()
+}
+
+fn last_updated_todo_title(
+    log: &[OrderedRowDelta],
+    descriptor: &RowDescriptor,
+    todo_id: ObjectId,
+) -> Option<String> {
+    let title_index = descriptor.column_index("title")?;
+
+    log.iter().rev().find_map(|delta| {
+        delta.updated.iter().rev().find_map(|change| {
+            if change.id != todo_id {
+                return None;
+            }
+
+            let row = change.row.as_ref()?;
+            let values = decode_row(descriptor, &row.data).ok()?;
+            match values.get(title_index) {
+                Some(Value::Text(title)) => Some(title.clone()),
+                _ => None,
+            }
+        })
+    })
+}
+
 /// Verifies that a subscription emits add, update, and remove deltas as a row
 /// enters, changes within, and leaves the query result set, and that the
 /// materialized query result stays consistent throughout.
@@ -316,6 +349,126 @@ async fn subscribe_all_emits_add_update_remove_and_tracks_current_results() {
     assert!(
         !rows.iter().any(|(id, _)| *id == todo_id),
         "latest query results should no longer include the removed todo"
+    );
+
+    pair.shutdown().await;
+}
+
+/// Verifies that rapid overwrites on a single subscribed row still leave the
+/// subscriber with a last delta that carries the final value.
+///
+/// Alice creates one todo and Bob subscribes before the hot update burst. Alice
+/// then overwrites `title` 500 times in a tight loop. Intermediate deltas may
+/// be coalesced, but once the subscriber's EdgeServer query returns the final
+/// title, the last row-bearing update delta in Bob's stream must decode to that
+/// same final title.
+///
+/// TODO:
+/// This is currently ignored because the client path still has two burst-load
+/// bugs in [client.rs](/Users/guidodorsi/workspace/jazz2/crates/jazz-tools/src/client.rs):
+/// server-bound object updates are sent via one detached task per payload, so
+/// the runtime's ordered outbox can arrive at the server out of order; and the
+/// subscription callback forwards deltas with `try_send` into a bounded channel,
+/// so the terminal row-bearing delta can be dropped when the subscriber lags.
+///
+/// ```text
+/// alice ──create todo──────────────► server ──► bob subscription (initial add)
+/// alice ──title update ×500────────► server
+///                                       │
+///                          bob EdgeServer query => final title
+///                                       │
+///                          bob last update delta => final title
+/// ```
+#[tokio::test]
+#[ignore = "TODO: fix burst update ordering/dropping in crates/jazz-tools/src/client.rs"]
+async fn subscription_reflects_final_state_after_rapid_bulk_updates() {
+    const RAPID_UPDATES: usize = 500;
+
+    let pair = ClientPair::start().await;
+    let query = QueryBuilder::new("todos").build();
+    let runtime_schema = pair
+        .subscriber
+        .schema()
+        .await
+        .expect("load subscriber runtime schema");
+    let descriptor = todo_descriptor(&runtime_schema);
+
+    let todo_id = create_todo(
+        &pair.writer,
+        TodoSeed {
+            title: "bulk-000",
+            done: false,
+            priority: Some(1),
+            tags: &["burst"],
+            payload: None,
+        },
+    )
+    .await;
+
+    let mut stream = pair
+        .subscriber
+        .subscribe(query.clone())
+        .await
+        .expect("subscribe to bulk-updated todo");
+    let mut log = Vec::new();
+
+    wait_for_subscription_update(
+        &mut stream,
+        &mut log,
+        QUERY_TIMEOUT,
+        "initial add before rapid updates",
+        |log| has_added(log, todo_id),
+    )
+    .await;
+    log.clear();
+
+    let final_title = format!("bulk-{RAPID_UPDATES:03}");
+    for revision in 1..=RAPID_UPDATES {
+        pair.writer
+            .update(
+                todo_id,
+                vec![(
+                    "title".to_string(),
+                    Value::Text(format!("bulk-{revision:03}")),
+                )],
+            )
+            .await
+            .expect("apply rapid bulk update");
+    }
+
+    let rows = wait_for_rows(
+        &pair.subscriber,
+        query.clone(),
+        format!("subscriber sees final bulk title {final_title}"),
+        |rows| {
+            (rows.len() == 1
+                && rows[0].0 == todo_id
+                && rows[0].1.first() == Some(&Value::Text(final_title.clone())))
+            .then_some(rows)
+        },
+    )
+    .await;
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].1[0], Value::Text(final_title.clone()));
+
+    wait_for_subscription_update(
+        &mut stream,
+        &mut log,
+        QUERY_TIMEOUT,
+        "final row-bearing bulk update delta",
+        |log| {
+            last_updated_todo_title(log, &descriptor, todo_id).as_deref()
+                == Some(final_title.as_str())
+        },
+    )
+    .await;
+    collect_stream_deltas(&mut stream, &mut log, NO_DELTA_WINDOW).await;
+
+    let latest_delta_title = last_updated_todo_title(&log, &descriptor, todo_id);
+    assert_eq!(
+        latest_delta_title.as_deref(),
+        Some(final_title.as_str()),
+        "last row-bearing update delta should decode to the final rapid-update title"
     );
 
     pair.shutdown().await;

--- a/crates/jazz-tools/tests/support/mod.rs
+++ b/crates/jazz-tools/tests/support/mod.rs
@@ -3,8 +3,8 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use jazz_tools::server::TestingServer;
 use jazz_tools::{
-    AppContext, DurabilityTier, JazzClient, ObjectId, OrderedRowDelta, Query, QueryBuilder, Schema,
-    SubscriptionStream, Value,
+    AppContext, ClientStorage, DurabilityTier, JazzClient, ObjectId, OrderedRowDelta, Query,
+    QueryBuilder, Schema, SubscriptionStream, Value,
 };
 use jsonwebtoken::{EncodingKey, Header, encode};
 use serde::{Deserialize, Serialize};
@@ -36,6 +36,12 @@ enum TestingClientAuth {
     Claims(JsonValue),
 }
 
+#[derive(Clone, Copy)]
+enum TestingClientStorage {
+    Memory,
+    Persistent,
+}
+
 /// Builder-style helper for test clients backed by `TestingServer`.
 ///
 /// Supports the three common auth shapes used across the integration suite:
@@ -46,6 +52,7 @@ pub struct TestingClient<'a> {
     schema: Option<Schema>,
     user_id: Option<String>,
     auth: TestingClientAuth,
+    storage: TestingClientStorage,
     ready_table: Option<String>,
     ready_timeout: Option<Duration>,
 }
@@ -58,6 +65,7 @@ impl<'a> TestingClient<'a> {
             schema: None,
             user_id: None,
             auth: TestingClientAuth::Admin,
+            storage: TestingClientStorage::Memory,
             ready_table: None,
             ready_timeout: None,
         }
@@ -96,12 +104,25 @@ impl<'a> TestingClient<'a> {
         self
     }
 
+    pub fn with_memory_storage(mut self) -> Self {
+        self.storage = TestingClientStorage::Memory;
+        self
+    }
+
+    pub fn with_persistent_storage(mut self) -> Self {
+        self.storage = TestingClientStorage::Persistent;
+        self
+    }
+
     pub async fn connect(self) -> JazzClient {
         self.connect_with_context().await.1
     }
 
     /// Connects the client and also returns the exact `AppContext` used for
-    /// the connection so callers can later reconnect with the same local state.
+    /// the connection so callers can later reconnect with the same configuration.
+    ///
+    /// Persistent storage reuses local state across reconnects; memory storage
+    /// does not.
     pub async fn connect_with_context(self) -> (AppContext, JazzClient) {
         let ready_table = self.ready_table.clone();
         let ready_timeout = self.ready_timeout;
@@ -159,6 +180,11 @@ impl<'a> TestingClient<'a> {
                 context.admin_secret = None;
             }
         }
+
+        context.storage = match self.storage {
+            TestingClientStorage::Memory => ClientStorage::Memory,
+            TestingClientStorage::Persistent => ClientStorage::Fjall,
+        };
 
         context
     }

--- a/examples/docs/todo-server-rs/src/main.rs
+++ b/examples/docs/todo-server-rs/src/main.rs
@@ -33,7 +33,7 @@ use std::sync::Arc;
 
 use axum::Router;
 use jazz_tools::schema_manager::SchemaDirectory;
-use jazz_tools::{AppContext, AppId, JazzClient};
+use jazz_tools::{AppContext, AppId, ClientStorage, JazzClient};
 use tokio::sync::broadcast;
 use tower_http::cors::CorsLayer;
 use tower_http::trace::TraceLayer;
@@ -90,6 +90,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         schema,
         server_url,
         data_dir: PathBuf::from(data_dir),
+        storage: ClientStorage::Fjall,
         jwt_token: None,
         backend_secret: None,
         admin_secret: None,

--- a/examples/docs/todo-server-rs/tests/integration.rs
+++ b/examples/docs/todo-server-rs/tests/integration.rs
@@ -17,7 +17,8 @@ use futures_util::StreamExt as _;
 use futures_util::stream::Stream;
 use http_body_util::BodyExt;
 use jazz_tools::{
-    AppContext, AppId, ColumnType, DurabilityTier, JazzClient, SchemaBuilder, TableSchema,
+    AppContext, AppId, ClientStorage, ColumnType, DurabilityTier, JazzClient, SchemaBuilder,
+    TableSchema,
 };
 use serde::{Deserialize, Serialize};
 use tempfile::TempDir;
@@ -82,6 +83,7 @@ async fn setup_test_app_with_path(data_dir: PathBuf) -> Router {
         schema: test_schema(),
         server_url: String::new(),
         data_dir,
+        storage: ClientStorage::Fjall,
         jwt_token: None,
         backend_secret: None,
         admin_secret: None,
@@ -446,6 +448,7 @@ async fn test_local_persistence() {
             schema: test_schema(),
             server_url: String::new(),
             data_dir: data_path.clone(),
+            storage: ClientStorage::Fjall,
             jwt_token: None,
             backend_secret: None,
             admin_secret: None,
@@ -481,6 +484,7 @@ async fn test_local_persistence() {
             schema: test_schema(),
             server_url: String::new(),
             data_dir: data_path,
+            storage: ClientStorage::Fjall,
             jwt_token: None,
             backend_secret: None,
             admin_secret: None,
@@ -743,6 +747,7 @@ async fn test_server_resync() {
             schema: test_schema(),
             server_url: server.base_url(),
             data_dir: data_path.clone(),
+            storage: ClientStorage::Fjall,
             jwt_token: Some(make_test_jwt("client1-user")),
             backend_secret: None,
             admin_secret: Some(TEST_ADMIN_SECRET.to_string()),
@@ -786,6 +791,7 @@ async fn test_server_resync() {
             schema: test_schema(),
             server_url: server.base_url(),
             data_dir: data_path,
+            storage: ClientStorage::Fjall,
             jwt_token: Some(make_test_jwt("client2-user")),
             backend_secret: None,
             admin_secret: None, // Intentionally no admin - server already has schema

--- a/examples/todo-server-rs/src/main.rs
+++ b/examples/todo-server-rs/src/main.rs
@@ -32,7 +32,7 @@ use std::sync::Arc;
 
 use axum::Router;
 use jazz_tools::schema_manager::SchemaDirectory;
-use jazz_tools::{AppContext, AppId, JazzClient};
+use jazz_tools::{AppContext, AppId, ClientStorage, JazzClient};
 use tokio::sync::broadcast;
 use tower_http::cors::CorsLayer;
 use tower_http::trace::TraceLayer;
@@ -88,6 +88,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         schema,
         server_url,
         data_dir: PathBuf::from(data_dir),
+        storage: ClientStorage::Fjall,
         jwt_token: None,
         backend_secret: None,
         admin_secret: None,

--- a/examples/todo-server-rs/tests/integration.rs
+++ b/examples/todo-server-rs/tests/integration.rs
@@ -17,7 +17,8 @@ use futures_util::StreamExt as _;
 use futures_util::stream::Stream;
 use http_body_util::BodyExt;
 use jazz_tools::{
-    AppContext, AppId, ColumnType, DurabilityTier, JazzClient, SchemaBuilder, TableSchema,
+    AppContext, AppId, ClientStorage, ColumnType, DurabilityTier, JazzClient, SchemaBuilder,
+    TableSchema,
 };
 use serde::{Deserialize, Serialize};
 use tempfile::TempDir;
@@ -82,6 +83,7 @@ async fn setup_test_app_with_path(data_dir: PathBuf) -> Router {
         schema: test_schema(),
         server_url: String::new(),
         data_dir,
+        storage: ClientStorage::Fjall,
         jwt_token: None,
         backend_secret: None,
         admin_secret: None,
@@ -446,6 +448,7 @@ async fn test_local_persistence() {
             schema: test_schema(),
             server_url: String::new(),
             data_dir: data_path.clone(),
+            storage: ClientStorage::Fjall,
             jwt_token: None,
             backend_secret: None,
             admin_secret: None,
@@ -481,6 +484,7 @@ async fn test_local_persistence() {
             schema: test_schema(),
             server_url: String::new(),
             data_dir: data_path,
+            storage: ClientStorage::Fjall,
             jwt_token: None,
             backend_secret: None,
             admin_secret: None,
@@ -743,6 +747,7 @@ async fn test_server_resync() {
             schema: test_schema(),
             server_url: server.base_url(),
             data_dir: data_path.clone(),
+            storage: ClientStorage::Fjall,
             jwt_token: Some(make_test_jwt("client1-user")),
             backend_secret: None,
             admin_secret: Some(TEST_ADMIN_SECRET.to_string()),
@@ -786,6 +791,7 @@ async fn test_server_resync() {
             schema: test_schema(),
             server_url: server.base_url(),
             data_dir: data_path,
+            storage: ClientStorage::Fjall,
             jwt_token: Some(make_test_jwt("client2-user")),
             backend_secret: None,
             admin_secret: None, // Intentionally no admin - server already has schema


### PR DESCRIPTION
Started getting the following error:
- `Storage("IoError(\"fjall open: FjallError: Io(Os { code: 24, kind: Uncategorized, message: \\\"Too many open files\\\" })\")")`

As fix I've changed the default for integration tests to not use the persistent storage but go for the MemoryStorage.

Added a bunch of more integration tests, including a failing one related to the server not propagating correctly "latest write wins" during a burst of updates.