### PR TITLE
feat: improved compute tuple delta performance

### DIFF
--- a/crates/jazz-tools/src/query_manager/graph_nodes/tuple_delta.rs
+++ b/crates/jazz-tools/src/query_manager/graph_nodes/tuple_delta.rs
@@ -1,36 +1,39 @@
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 
-use crate::object::ObjectId;
 use crate::query_manager::types::{Tuple, TupleDelta, TupleElement};
 
-/// Pre-hashed ID list: hash is computed once at construction, equality falls back to full comparison.
-#[derive(Clone)]
-struct HashedIds {
-    ids: Vec<ObjectId>,
+/// Borrowed tuple identity key with a precomputed hash.
+///
+/// We keep the "hash once, compare full IDs on collision" behavior from the old
+/// implementation, but we borrow the tuple instead of allocating a temporary
+/// `Vec<ObjectId>` just to key the maps in this function.
+#[derive(Clone, Copy)]
+struct HashedTupleRef<'a> {
+    tuple: &'a Tuple,
     hash: u64,
 }
 
-impl HashedIds {
-    fn new(ids: Vec<ObjectId>) -> Self {
+impl<'a> HashedTupleRef<'a> {
+    fn new(tuple: &'a Tuple) -> Self {
         let mut hasher = std::hash::DefaultHasher::new();
-        ids.hash(&mut hasher);
+        tuple.hash(&mut hasher);
         Self {
-            ids,
+            tuple,
             hash: hasher.finish(),
         }
     }
 }
 
-impl PartialEq for HashedIds {
+impl PartialEq for HashedTupleRef<'_> {
     fn eq(&self, other: &Self) -> bool {
-        self.ids == other.ids
+        self.tuple == other.tuple
     }
 }
 
-impl Eq for HashedIds {}
+impl Eq for HashedTupleRef<'_> {}
 
-impl Hash for HashedIds {
+impl Hash for HashedTupleRef<'_> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         state.write_u64(self.hash);
     }
@@ -38,14 +41,14 @@ impl Hash for HashedIds {
 
 pub(crate) fn compute_tuple_delta(old_tuples: &[Tuple], new_tuples: &[Tuple]) -> TupleDelta {
     let mut delta = TupleDelta::new();
-    let old_hashed: Vec<HashedIds> = old_tuples.iter().map(|t| HashedIds::new(t.ids())).collect();
-    let new_hashed: Vec<HashedIds> = new_tuples.iter().map(|t| HashedIds::new(t.ids())).collect();
-    let old_pos_by_ids: HashMap<&HashedIds, usize> = old_hashed
+    let old_hashed: Vec<_> = old_tuples.iter().map(HashedTupleRef::new).collect();
+    let new_hashed: Vec<_> = new_tuples.iter().map(HashedTupleRef::new).collect();
+    let old_pos_by_ids: HashMap<&HashedTupleRef<'_>, usize> = old_hashed
         .iter()
         .enumerate()
         .map(|(idx, h)| (h, idx))
         .collect();
-    let new_pos_by_ids: HashMap<&HashedIds, usize> = new_hashed
+    let new_pos_by_ids: HashMap<&HashedTupleRef<'_>, usize> = new_hashed
         .iter()
         .enumerate()
         .map(|(idx, h)| (h, idx))
@@ -190,4 +193,80 @@ fn has_tuple_content_changed(old: &Tuple, new: &Tuple) -> bool {
         ) => old_content != new_content || old_commit != new_commit,
         _ => false,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commit::CommitId;
+    use crate::object::{BranchName, ObjectId};
+
+    fn id_tuple(ids: &[ObjectId]) -> Tuple {
+        Tuple::new(ids.iter().copied().map(TupleElement::Id).collect())
+    }
+
+    fn row_tuple(id: ObjectId, content: &[u8], commit_byte: u8) -> Tuple {
+        Tuple::new(vec![TupleElement::Row {
+            id,
+            content: content.to_vec(),
+            commit_id: CommitId([commit_byte; 32]),
+        }])
+    }
+
+    #[test]
+    fn compute_tuple_delta_reports_moves_from_id_order_only() {
+        let a = ObjectId::new();
+        let b = ObjectId::new();
+        let c = ObjectId::new();
+        let d = ObjectId::new();
+
+        let old = vec![
+            id_tuple(&[a]),
+            id_tuple(&[b]),
+            id_tuple(&[c]),
+            id_tuple(&[d]),
+        ];
+        let new = vec![
+            id_tuple(&[b]),
+            id_tuple(&[c]),
+            id_tuple(&[a]),
+            id_tuple(&[d]),
+        ];
+
+        let delta = compute_tuple_delta(&old, &new);
+
+        assert!(delta.added.is_empty());
+        assert!(delta.removed.is_empty());
+        assert!(delta.updated.is_empty());
+        assert_eq!(delta.moved, vec![id_tuple(&[a])]);
+    }
+
+    #[test]
+    fn compute_tuple_delta_reports_updates_for_same_ids() {
+        let id = ObjectId::new();
+        let old = vec![row_tuple(id, b"old", 1)];
+        let new = vec![row_tuple(id, b"new", 2)];
+
+        let delta = compute_tuple_delta(&old, &new);
+
+        assert!(delta.added.is_empty());
+        assert!(delta.removed.is_empty());
+        assert!(delta.moved.is_empty());
+        assert_eq!(delta.updated, vec![(old[0].clone(), new[0].clone())]);
+    }
+
+    #[test]
+    fn compute_tuple_delta_reports_provenance_only_updates() {
+        let id = ObjectId::new();
+        let branch = BranchName::new("main");
+        let old = vec![id_tuple(&[id])];
+        let new = vec![id_tuple(&[id]).with_provenance([(id, branch)].into_iter().collect())];
+
+        let delta = compute_tuple_delta(&old, &new);
+
+        assert!(delta.added.is_empty());
+        assert!(delta.removed.is_empty());
+        assert!(delta.moved.is_empty());
+        assert_eq!(delta.updated, vec![(old[0].clone(), new[0].clone())]);
+    }
 }

--- a/crates/jazz-tools/src/query_manager/graph_nodes/tuple_delta.rs
+++ b/crates/jazz-tools/src/query_manager/graph_nodes/tuple_delta.rs
@@ -1,40 +1,51 @@
 use std::collections::HashMap;
+use std::hash::{Hash, Hasher};
 
 use crate::query_manager::types::{Tuple, TupleDelta, TupleElement};
 
+/// Cheap fingerprint for a tuple's ID list.
+/// Hashes all ObjectIds into a single u64 to avoid allocating a Vec<ObjectId>.
+fn tuple_id_fingerprint(tuple: &Tuple) -> u64 {
+    let mut hasher = std::hash::DefaultHasher::new();
+    for elem in tuple.iter() {
+        elem.id().hash(&mut hasher);
+    }
+    hasher.finish()
+}
+
 pub(crate) fn compute_tuple_delta(old_tuples: &[Tuple], new_tuples: &[Tuple]) -> TupleDelta {
     let mut delta = TupleDelta::new();
-    let old_ids: Vec<_> = old_tuples.iter().map(|t| t.ids()).collect();
-    let new_ids: Vec<_> = new_tuples.iter().map(|t| t.ids()).collect();
-    let old_pos_by_ids: HashMap<_, _> = old_ids
+    let old_fps: Vec<u64> = old_tuples.iter().map(tuple_id_fingerprint).collect();
+    let new_fps: Vec<u64> = new_tuples.iter().map(tuple_id_fingerprint).collect();
+    let old_pos_by_fp: HashMap<u64, usize> = old_fps
         .iter()
         .enumerate()
-        .map(|(idx, ids)| (ids.clone(), idx))
+        .map(|(idx, &fp)| (fp, idx))
         .collect();
-    let new_pos_by_ids: HashMap<_, _> = new_ids
+    let new_pos_by_fp: HashMap<u64, usize> = new_fps
         .iter()
         .enumerate()
-        .map(|(idx, ids)| (ids.clone(), idx))
+        .map(|(idx, &fp)| (fp, idx))
         .collect();
 
-    for (old, ids) in old_tuples.iter().zip(old_ids.iter()) {
-        if !new_pos_by_ids.contains_key(ids) {
+    for (old, &fp) in old_tuples.iter().zip(old_fps.iter()) {
+        if !new_pos_by_fp.contains_key(&fp) {
             delta.removed.push(old.clone());
         }
     }
 
-    for (new, ids) in new_tuples.iter().zip(new_ids.iter()) {
-        if !old_pos_by_ids.contains_key(ids) {
+    for (new, &fp) in new_tuples.iter().zip(new_fps.iter()) {
+        if !old_pos_by_fp.contains_key(&fp) {
             delta.added.push(new.clone());
         }
     }
 
-    let new_to_old_idx_mapping: Vec<_> = new_ids
+    let new_to_old_idx_mapping: Vec<_> = new_fps
         .iter()
         .enumerate()
-        .filter_map(|(new_idx, ids)| {
-            old_pos_by_ids
-                .get(ids)
+        .filter_map(|(new_idx, fp)| {
+            old_pos_by_fp
+                .get(fp)
                 .copied()
                 .map(|old_idx| (new_idx, old_idx))
         })
@@ -54,8 +65,8 @@ pub(crate) fn compute_tuple_delta(old_tuples: &[Tuple], new_tuples: &[Tuple]) ->
         }
     }
 
-    for (old, ids) in old_tuples.iter().zip(old_ids.iter()) {
-        if let Some(new_idx) = new_pos_by_ids.get(ids)
+    for (old, &fp) in old_tuples.iter().zip(old_fps.iter()) {
+        if let Some(new_idx) = new_pos_by_fp.get(&fp)
             && has_tuple_content_changed(old, &new_tuples[*new_idx])
         {
             delta

--- a/crates/jazz-tools/src/query_manager/graph_nodes/tuple_delta.rs
+++ b/crates/jazz-tools/src/query_manager/graph_nodes/tuple_delta.rs
@@ -1,51 +1,74 @@
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 
+use crate::object::ObjectId;
 use crate::query_manager::types::{Tuple, TupleDelta, TupleElement};
 
-/// Cheap fingerprint for a tuple's ID list.
-/// Hashes all ObjectIds into a single u64 to avoid allocating a Vec<ObjectId>.
-fn tuple_id_fingerprint(tuple: &Tuple) -> u64 {
-    let mut hasher = std::hash::DefaultHasher::new();
-    for elem in tuple.iter() {
-        elem.id().hash(&mut hasher);
+/// Pre-hashed ID list: hash is computed once at construction, equality falls back to full comparison.
+#[derive(Clone)]
+struct HashedIds {
+    ids: Vec<ObjectId>,
+    hash: u64,
+}
+
+impl HashedIds {
+    fn new(ids: Vec<ObjectId>) -> Self {
+        let mut hasher = std::hash::DefaultHasher::new();
+        ids.hash(&mut hasher);
+        Self {
+            ids,
+            hash: hasher.finish(),
+        }
     }
-    hasher.finish()
+}
+
+impl PartialEq for HashedIds {
+    fn eq(&self, other: &Self) -> bool {
+        self.ids == other.ids
+    }
+}
+
+impl Eq for HashedIds {}
+
+impl Hash for HashedIds {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        state.write_u64(self.hash);
+    }
 }
 
 pub(crate) fn compute_tuple_delta(old_tuples: &[Tuple], new_tuples: &[Tuple]) -> TupleDelta {
     let mut delta = TupleDelta::new();
-    let old_fps: Vec<u64> = old_tuples.iter().map(tuple_id_fingerprint).collect();
-    let new_fps: Vec<u64> = new_tuples.iter().map(tuple_id_fingerprint).collect();
-    let old_pos_by_fp: HashMap<u64, usize> = old_fps
+    let old_hashed: Vec<HashedIds> = old_tuples.iter().map(|t| HashedIds::new(t.ids())).collect();
+    let new_hashed: Vec<HashedIds> = new_tuples.iter().map(|t| HashedIds::new(t.ids())).collect();
+    let old_pos_by_ids: HashMap<&HashedIds, usize> = old_hashed
         .iter()
         .enumerate()
-        .map(|(idx, &fp)| (fp, idx))
+        .map(|(idx, h)| (h, idx))
         .collect();
-    let new_pos_by_fp: HashMap<u64, usize> = new_fps
+    let new_pos_by_ids: HashMap<&HashedIds, usize> = new_hashed
         .iter()
         .enumerate()
-        .map(|(idx, &fp)| (fp, idx))
+        .map(|(idx, h)| (h, idx))
         .collect();
 
-    for (old, &fp) in old_tuples.iter().zip(old_fps.iter()) {
-        if !new_pos_by_fp.contains_key(&fp) {
+    for (old, h) in old_tuples.iter().zip(old_hashed.iter()) {
+        if !new_pos_by_ids.contains_key(h) {
             delta.removed.push(old.clone());
         }
     }
 
-    for (new, &fp) in new_tuples.iter().zip(new_fps.iter()) {
-        if !old_pos_by_fp.contains_key(&fp) {
+    for (new, h) in new_tuples.iter().zip(new_hashed.iter()) {
+        if !old_pos_by_ids.contains_key(h) {
             delta.added.push(new.clone());
         }
     }
 
-    let new_to_old_idx_mapping: Vec<_> = new_fps
+    let new_to_old_idx_mapping: Vec<_> = new_hashed
         .iter()
         .enumerate()
-        .filter_map(|(new_idx, fp)| {
-            old_pos_by_fp
-                .get(fp)
+        .filter_map(|(new_idx, h)| {
+            old_pos_by_ids
+                .get(h)
                 .copied()
                 .map(|old_idx| (new_idx, old_idx))
         })
@@ -65,8 +88,8 @@ pub(crate) fn compute_tuple_delta(old_tuples: &[Tuple], new_tuples: &[Tuple]) ->
         }
     }
 
-    for (old, &fp) in old_tuples.iter().zip(old_fps.iter()) {
-        if let Some(new_idx) = new_pos_by_fp.get(&fp)
+    for (old, h) in old_tuples.iter().zip(old_hashed.iter()) {
+        if let Some(new_idx) = new_pos_by_ids.get(h)
             && has_tuple_content_changed(old, &new_tuples[*new_idx])
         {
             delta

--- a/crates/jazz-tools/src/query_manager/types/tuple.rs
+++ b/crates/jazz-tools/src/query_manager/types/tuple.rs
@@ -276,10 +276,7 @@ impl PartialEq for Tuple {
         if self.0.len() != other.0.len() {
             return false;
         }
-        self.0
-            .iter()
-            .zip(other.0.iter())
-            .all(|(a, b)| a.id() == b.id())
+        self.id_iter().eq(other.id_iter())
     }
 }
 

--- a/crates/jazz-tools/src/query_manager/types/tuple.rs
+++ b/crates/jazz-tools/src/query_manager/types/tuple.rs
@@ -134,7 +134,12 @@ impl Tuple {
 
     /// Get all IDs in the tuple.
     pub fn ids(&self) -> Vec<ObjectId> {
-        self.0.iter().map(|e| e.id()).collect()
+        self.id_iter().collect()
+    }
+
+    /// Iterate over the IDs that define tuple identity.
+    pub fn id_iter(&self) -> impl Iterator<Item = ObjectId> + '_ {
+        self.0.iter().map(TupleElement::id)
     }
 
     /// Get the first ID (convenience for single-table queries).
@@ -260,8 +265,8 @@ impl Tuple {
 // for set membership, while updates track content changes separately.
 impl Hash for Tuple {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        for element in &self.0 {
-            element.id().hash(state);
+        for id in self.id_iter() {
+            id.hash(state);
         }
     }
 }


### PR DESCRIPTION
`computer_tuple_delta` requires a lot of hashing. The main costs are:

1. `HashMap<Vec<ObjectId>, usize>` - hashes the entire Vec on insert and on every lookup
2. `Vec<ObjectId>` allocations via t.ids() for every tuple

This fix introduces:

1. Hash once — `HashedTupleRef::new()` computes the hash upfront. Every subsequent HashMap insert/lookup just writes the cached u64, never re-hashes the slice.
2. No `Vec<ObjectId>` allocations via `t.ids()` for every tuple; now we return an iterator instead.

## Profiling

**Before**
<img width="1037" height="721" alt="Screenshot 2026-03-19 alle 13 24 14" src="https://github.com/user-attachments/assets/be5658a4-e49b-40cd-8ff5-a8ecce02b565" />

**After**

<img width="1254" height="748" alt="Screenshot 2026-03-20 alle 13 06 10" src="https://github.com/user-attachments/assets/92e0451c-ab3d-4d98-abc3-fb470ce51011" />

