### PR TITLE
Fix Rust client loss and add a todo spec for sync reliability issues

### DIFF
--- a/crates/jazz-tools/src/client.rs
+++ b/crates/jazz-tools/src/client.rs
@@ -311,7 +311,7 @@ impl JazzClient {
         // tx is moved directly into the callback so the delta is never dropped due
         // to the race where immediate_tick fires the callback before we can insert
         // tx into a shared map.
-        let (tx, rx) = mpsc::channel::<OrderedRowDelta>(64);
+        let (tx, rx) = mpsc::unbounded_channel::<OrderedRowDelta>();
 
         // Register with runtime using callback pattern
         // The callback bridges runtime updates to the channel
@@ -320,9 +320,9 @@ impl JazzClient {
             .subscribe(
                 query.clone(),
                 move |delta| {
-                    // Route delta to the subscription's channel.
-                    // Note: We use try_send since we're in a sync callback.
-                    let _ = tx.try_send(delta.ordered_delta);
+                    // Route delta to the subscription stream without dropping
+                    // updates when the consumer falls briefly behind.
+                    let _ = tx.send(delta.ordered_delta);
                 },
                 session,
             )

--- a/crates/jazz-tools/src/lib.rs
+++ b/crates/jazz-tools/src/lib.rs
@@ -149,13 +149,13 @@ pub struct SubscriptionHandle(pub u64);
 /// Stream of row deltas from a subscription.
 #[cfg(feature = "client")]
 pub struct SubscriptionStream {
-    receiver: tokio::sync::mpsc::Receiver<OrderedRowDelta>,
+    receiver: tokio::sync::mpsc::UnboundedReceiver<OrderedRowDelta>,
 }
 
 #[cfg(feature = "client")]
 impl SubscriptionStream {
     /// Create a new subscription stream.
-    pub(crate) fn new(receiver: tokio::sync::mpsc::Receiver<OrderedRowDelta>) -> Self {
+    pub(crate) fn new(receiver: tokio::sync::mpsc::UnboundedReceiver<OrderedRowDelta>) -> Self {
         Self { receiver }
     }
 

--- a/crates/jazz-tools/tests/subscribe_all_integration.rs
+++ b/crates/jazz-tools/tests/subscribe_all_integration.rs
@@ -8,13 +8,14 @@ use jazz_tools::query_manager::encoding::decode_row;
 use jazz_tools::query_manager::types::RowDescriptor;
 use jazz_tools::server::TestingServer;
 use jazz_tools::{
-    ColumnType, JazzClient, ObjectId, OrderedRowDelta, Query, QueryBuilder, Schema, SchemaBuilder,
-    TableSchema, Value,
+    AppContext, AppId, ClientStorage, ColumnType, JazzClient, ObjectId, OrderedRowDelta, Query,
+    QueryBuilder, Schema, SchemaBuilder, TableSchema, Value,
 };
 use support::{
     TestingClient, collect_stream_deltas, has_added, has_any_change, has_removed, has_updated,
-    wait_for_rows, wait_for_subscription_update,
+    wait_for_query, wait_for_rows, wait_for_subscription_update,
 };
+use tempfile::TempDir;
 
 const READY_TIMEOUT: Duration = Duration::from_secs(30);
 const QUERY_TIMEOUT: Duration = Duration::from_secs(25);
@@ -256,6 +257,67 @@ fn last_updated_todo_title(
     })
 }
 
+fn last_row_bearing_todo_title(
+    log: &[OrderedRowDelta],
+    descriptor: &RowDescriptor,
+    todo_id: ObjectId,
+) -> Option<String> {
+    let title_index = descriptor.column_index("title")?;
+
+    log.iter().rev().find_map(|delta| {
+        delta
+            .updated
+            .iter()
+            .rev()
+            .find_map(|change| {
+                if change.id != todo_id {
+                    return None;
+                }
+
+                let row = change.row.as_ref()?;
+                let values = decode_row(descriptor, &row.data).ok()?;
+                match values.get(title_index) {
+                    Some(Value::Text(title)) => Some(title.clone()),
+                    _ => None,
+                }
+            })
+            .or_else(|| {
+                delta.added.iter().rev().find_map(|change| {
+                    if change.id != todo_id {
+                        return None;
+                    }
+
+                    let values = decode_row(descriptor, &change.row.data).ok()?;
+                    match values.get(title_index) {
+                        Some(Value::Text(title)) => Some(title.clone()),
+                        _ => None,
+                    }
+                })
+            })
+    })
+}
+
+async fn start_local_client(schema: Schema) -> (TempDir, JazzClient) {
+    let temp_dir = TempDir::new().expect("create local client temp dir");
+    let context = AppContext {
+        app_id: AppId::from_name("subscribe-all-local-overflow"),
+        client_id: None,
+        schema,
+        server_url: String::new(),
+        data_dir: temp_dir.path().to_path_buf(),
+        storage: ClientStorage::Memory,
+        jwt_token: None,
+        backend_secret: None,
+        admin_secret: None,
+    };
+
+    let client = JazzClient::connect(context)
+        .await
+        .expect("connect local test client");
+
+    (temp_dir, client)
+}
+
 /// Verifies that a subscription emits add, update, and remove deltas as a row
 /// enters, changes within, and leaves the query result set, and that the
 /// materialized query result stays consistent throughout.
@@ -365,25 +427,22 @@ async fn subscribe_all_emits_add_update_remove_and_tracks_current_results() {
 ///
 /// TODO:
 /// Keep this test ignored until the client preserves "latest write wins" during
-/// a burst of updates. The assertion is fine; the client path in src/client.rs
-/// still has two burst-load bugs:
+/// a burst of updates. The assertion is fine; the remaining burst-load bug is
+/// in the writer's outbound sync path:
 ///
 /// 1. Outgoing updates are sent in separate spawned tasks, so a fast sequence of
 ///    writes can reach the server in a different order than the writer produced
 ///    them.
-/// 2. Incoming subscription updates are pushed with `try_send` into a fixed-size
-///    channel, so a slow subscriber can silently drop updates, including the
-///    final one that should carry the last title.
 ///
-/// That means Bob can read the correct final row state from the server, while
-/// Bob's live subscription stream still ends on an older value.
+/// The subscriber-side drop case is avoided by using an unbounded local stream,
+/// but that still does not fix out-of-order delivery to the server.
 ///
 /// ```text
 /// intended
 /// --------
 /// Alice writes:  title-001 -> title-002 -> ... -> title-500
 /// Server state:  title-001 -> title-002 -> ... -> title-500
-/// Bob stream:    add ...... update ...... last update = title-500
+/// Bob stream:    add ...... update ...... last row-bearing delta = title-500
 ///
 /// current failure modes
 /// ---------------------
@@ -391,16 +450,12 @@ async fn subscribe_all_emits_add_update_remove_and_tracks_current_results() {
 /// Alice writes:  title-001 -> title-002 -> title-003
 /// Server sees:   title-002 -> title-001 -> title-003
 ///
-/// subscriber channel can overflow:
-/// Server sends:  add -> update -> update -> ... -> update(final)
-/// Bob channel:   keep   keep     keep         full -> drop(final)
-///
 /// result:
 /// Bob snapshot query    = title-500
 /// Bob last stream delta != title-500
 /// ```
 #[tokio::test]
-#[ignore = "TODO: fix burst update ordering/dropping in crates/jazz-tools/src/client.rs"]
+#[ignore = "TODO: fix the sync reliability gaps specs/todo/a_mvp/sync_protocol_reliability_gaps.md"]
 async fn subscription_reflects_final_state_after_rapid_bulk_updates() {
     const RAPID_UPDATES: usize = 500;
 
@@ -720,6 +775,103 @@ async fn subscribe_all_supports_condition_filters() {
 
     writer.shutdown().await.expect("shutdown condition writer");
     server.shutdown().await;
+}
+
+/// Verifies that a rapid burst of local updates still leaves the subscription
+/// stream carrying the final row state.
+///
+/// This test uses a single local client so it isolates the subscription
+/// delivery path from server sync ordering.
+#[tokio::test]
+async fn local_subscription_preserves_final_state_under_rapid_updates() {
+    const RAPID_UPDATES: usize = 100;
+
+    let (_temp_dir, client) = start_local_client(subscription_schema()).await;
+    let query = QueryBuilder::new("todos").build();
+    let runtime_schema = client.schema().await.expect("load local runtime schema");
+    let descriptor = todo_descriptor(&runtime_schema);
+
+    let mut stream = client
+        .subscribe(query.clone())
+        .await
+        .expect("subscribe to local todos");
+    let mut log = Vec::new();
+
+    let todo_id = create_todo(
+        &client,
+        TodoSeed {
+            title: "local-bulk-000",
+            done: false,
+            priority: Some(1),
+            tags: &["burst"],
+            payload: None,
+        },
+    )
+    .await;
+
+    wait_for_subscription_update(
+        &mut stream,
+        &mut log,
+        QUERY_TIMEOUT,
+        "initial local add before rapid updates",
+        |log| has_added(log, todo_id),
+    )
+    .await;
+    log.clear();
+
+    let final_title = format!("local-bulk-{RAPID_UPDATES:03}");
+    for revision in 1..=RAPID_UPDATES {
+        client
+            .update(
+                todo_id,
+                vec![(
+                    "title".to_string(),
+                    Value::Text(format!("local-bulk-{revision:03}")),
+                )],
+            )
+            .await
+            .expect("apply rapid local update");
+        tokio::time::sleep(Duration::from_millis(1)).await;
+    }
+
+    let rows = wait_for_query(
+        &client,
+        query.clone(),
+        None,
+        QUERY_TIMEOUT,
+        format!("local client sees final bulk title {final_title}"),
+        |rows| {
+            (rows.len() == 1
+                && rows[0].0 == todo_id
+                && rows[0].1.first() == Some(&Value::Text(final_title.clone())))
+            .then_some(rows)
+        },
+    )
+    .await;
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].1[0], Value::Text(final_title.clone()));
+
+    wait_for_subscription_update(
+        &mut stream,
+        &mut log,
+        QUERY_TIMEOUT,
+        "local stream carries the final row-bearing delta after rapid updates",
+        |log| {
+            last_row_bearing_todo_title(log, &descriptor, todo_id).as_deref()
+                == Some(final_title.as_str())
+        },
+    )
+    .await;
+    collect_stream_deltas(&mut stream, &mut log, NO_DELTA_WINDOW).await;
+
+    let latest_delta_title = last_row_bearing_todo_title(&log, &descriptor, todo_id);
+    assert_eq!(
+        latest_delta_title.as_deref(),
+        Some(final_title.as_str()),
+        "last row-bearing local delta should converge to the final title after rapid updates"
+    );
+
+    client.shutdown().await.expect("shutdown local client");
 }
 
 /// Verifies that a `Bytea` column value, including interior zero bytes, survives

--- a/specs/todo/a_mvp/sync_protocol_reliability_gaps.md
+++ b/specs/todo/a_mvp/sync_protocol_reliability_gaps.md
@@ -1,0 +1,225 @@
+# Sync Protocol Reliability Gaps (MVP)
+
+This note describes the main reliability gaps in the current HTTP/SSE sync path.
+
+## Summary
+
+Today, the sync path is good at "send this soon", but weak at "prove this arrived, in order, and recover if it did not."
+
+The biggest problems are:
+
+1. Client updates can be sent out of order.
+2. The client forgets an outgoing message before it knows the server accepted it.
+3. If one message is lost, later incremental sync can build on the false assumption that the server already has it.
+4. The server already returns per-message results, but the Rust client does not read them.
+5. Reconnecting the receive stream is stronger than reconnecting the send path, so a connection can look healthy while client-to-server state is still wrong.
+
+In user terms, this means:
+
+- a local change can look successful but never reach other devices
+- a query subscription can stay active on the server after the client thought it unsubscribed
+- a durability wait can stall because an acknowledgement was lost
+- reconnect can restore live updates without actually repairing hidden divergence
+
+## Current Model
+
+At a high level, the current path looks like this:
+
+```text
+local write
+  ->
+runtime outbox
+  ->
+async callback
+  ->
+HTTP POST /sync
+  ->
+server inbox
+  ->
+server event stream to other clients
+```
+
+The important detail is where the "source of truth" disappears.
+
+```text
+local write
+  ->
+runtime outbox
+  -- drained and cleared -->
+async send task
+  -- maybe succeeds, maybe fails -->
+server
+```
+
+Once the runtime hands a message to the async send task, the protocol mostly acts as if the server will eventually receive it.
+
+## 1. Outbound Messages Can Arrive Out of Order
+
+The current Rust client starts one independent async task per outbound payload.
+
+That means the client can produce changes in the right order but send them in a different order if one task is delayed by scheduling, network timing, or test delay hooks.
+
+```text
+Runtime produces:   A -----> B
+
+Send tasks:         send(A) ----sleep-----> POST A
+                    send(B) ------POST B--->
+
+Server sees:        B first, A second
+```
+
+Why this matters:
+
+- later updates can arrive before earlier updates that they logically depend on
+- control messages can also reorder, not just data messages
+- the protocol becomes timing-sensitive instead of state-driven
+
+This is especially risky because the same path carries both object updates and control traffic like subscriptions, unsubscriptions, acknowledgements, and settlement notifications.
+
+There is already an ignored regression test for this burst-ordering failure:
+[`subscription_reflects_final_state_after_rapid_bulk_updates`](../../../crates/jazz-tools/tests/subscribe_all_integration.rs).
+
+## 2. The Client Forgets Outbound Messages Too Early
+
+The runtime drains its sync outbox before network success is known.
+
+In plain language: we take the letter out of the outbox before the courier confirms pickup.
+
+```text
+Step 1: write is recorded locally
+Step 2: runtime puts sync message in outbox
+Step 3: batched tick drains and clears that outbox
+Step 4: async HTTP send happens later
+Step 5: if HTTP fails, there is no built-in resend record
+```
+
+Why this matters:
+
+- a transient network failure can permanently drop a message
+- a process crash between "outbox drained" and "server accepted" loses work from the sync path
+- the only current reaction is mostly a warning log, not protocol recovery
+
+This is the core reliability gap in the current design.
+
+## 3. A Lost Message Can Poison Later Incremental Sync
+
+The protocol keeps sender-side memory about what it believes the server has already seen.
+
+That memory moves forward before delivery is confirmed.
+
+```text
+Client history:     C1 -----> C2
+
+What client believes:
+server has C1
+
+What actually happened:
+C1 was lost
+
+Next incremental send:
+client sends only "what changed after C1"
+
+Server reality:
+missing C1, receives later history anyway
+```
+
+This creates a sticky failure mode:
+
+- the first lost message is bad
+- later messages may stop including the missing history
+- the system can remain divergent until some explicit full re-sync repairs it
+
+An important amplifier here is that the receiver currently accepts incoming commits without clearly failing fast on missing parent history. So a dropped earlier update does not necessarily become a clean, visible error. It can turn into harder-to-diagnose inconsistent history instead.
+
+## 4. The Server Reports Per-Message Results, but the Client Ignores Them
+
+The `/sync` endpoint already returns a structured result for each payload:
+
+```text
+POST /sync
+  ->
+HTTP 200
+  + response body:
+    [ok, ok, failed, ok]
+```
+
+The current Rust transport checks the HTTP status code, but it does not read the response body that says whether each payload succeeded.
+
+So these two cases currently look the same to the client:
+
+- "the server accepted everything"
+- "the server returned 200 but one or more payloads failed"
+
+Why this matters:
+
+- application errors can be hidden behind a successful HTTP status
+- the client loses the chance to retry, resync, or surface a meaningful error
+- the protocol already has a richer signal, but the client drops it on the floor
+
+## 5. Reconnect Repairs the Receive Side Better Than the Send Side
+
+The incoming event stream has an explicit reconnect loop and stream sequence handling.
+
+The outgoing `/sync` path does not have a matching recovery story.
+
+```text
+server -> client stream
+  has reconnect loop
+  has stream sequence
+
+client -> server POST /sync
+  no delivery acknowledgement
+  no resend queue
+  no explicit replay on reconnect
+```
+
+Practical consequence:
+
+- after a disconnect, the client can resume receiving fresh server updates
+- but that does not prove the server received the client's earlier unsent or failed outbound messages
+
+So the UI can look "reconnected" while client-to-server divergence is still present.
+
+There is also implementation drift here: reconnect behavior is not driven by one shared state machine across clients, which makes it harder to state and test one protocol story.
+
+## 6. Data Messages and Control Messages Share the Same Fragile Path
+
+The sync pipe is not only row data.
+
+It also carries control messages such as:
+
+- query subscriptions
+- query unsubscriptions
+- persistence acknowledgements
+- query-settled notifications
+
+That means the same reliability gap affects both "the row value changed" and "the server should stop doing work for this query."
+
+Simple examples:
+
+```text
+lost QuerySubscription
+  -> server never starts sending a result set
+
+lost QueryUnsubscription
+  -> server keeps work alive after the client thinks it is done
+
+lost PersistenceAck
+  -> a durability waiter can wait longer than it should
+```
+
+This is why the problem is larger than "maybe one row update is late."
+
+## Engineering Landmarks
+
+These are the main code paths behind the issues above.
+
+- Per-payload async send from the Rust client callback: `crates/jazz-tools/src/client.rs`
+- Test hook showing send timing can be perturbed for `ObjectUpdated`: `crates/jazz-tools/src/client.rs`
+- Runtime drains and clears the outbox before the network handoff completes: `crates/jazz-tools/src/runtime_core/ticks.rs`, `crates/jazz-tools/src/sync_manager/mod.rs`
+- Sender-side `sent_tips` bookkeeping advances before delivery confirmation: `crates/jazz-tools/src/sync_manager/sync_logic.rs`
+- Receiver applies incoming commits in `apply_object_updated()` / `receive_commit()`: `crates/jazz-tools/src/sync_manager/inbox.rs`, `crates/jazz-tools/src/object_manager/mod.rs`
+- `/sync` returns `SyncBatchResponse` with per-payload results: `crates/jazz-tools/src/transport_protocol.rs`, `crates/jazz-tools/src/routes.rs`
+- Rust client transport currently checks HTTP status but does not consume the response body: `crates/jazz-tools/src/transport.rs`
+- Rust client stream reconnect loop and initial server registration: `crates/jazz-tools/src/client.rs`
+- TS runtime/worker shared stream controller, showing the broader reconnect split across implementations: `packages/jazz-tools/src/runtime/sync-transport.ts`


### PR DESCRIPTION
## Summary
- Added a document that describes the sync reliability issues we have currently. [Preview](https://github.com/garden-co/jazz2/blob/fix/jazz-client-rs-loss/specs/todo/a_mvp/sync_protocol_reliability_gaps.md)
- Switch Rust client subscription streams from a fixed-size queue to an unbounded local stream so bursty inbound updates are not silently dropped when a subscriber briefly falls behind.
- Add a high-level local-client regression test that isolates the subscription delivery path and proves the final row-bearing delta converges to the last rapid update.

## Design choices

I've gone for the simplest fix of going for an unbounded local stream and dropping the backpressure management because JazzClient in RS isn't now part of our main focus.

Other possible solutions could have been:
- skipping updates when the queue is full, ensuring that only the last one is delivered. It would mean merging deltas on every dropped update, better on the perf side but more complex to implement and still lossy. I don't know enough on the possible use-cases of JazzClient in rs to go for this road.
- close the channel and reconnect the subscription after the burst. Proven actually to be more complex than the solution above, so I've dropped it.

So went for the most defensive and simple solution, which was just switching the subscription channel to be unbounded, which is practically the same we do in WASM.

NAPI could have a similar bug, need to investigate.