### PR TITLE
fix: improve RN runtime error reporting

### DIFF
--- a/.changeset/pr-376-rn-error-reporting.md
+++ b/.changeset/pr-376-rn-error-reporting.md
@@ -1,0 +1,7 @@
+---
+"jazz-tools": patch
+---
+
+Improve React Native runtime error reporting by normalizing UniFFI bridge failures into standard `Error` objects with stable `name`, `message`, `cause`, and `tag` metadata.
+
+Thanks [Schniz](https://github.com/Schniz)!

--- a/packages/jazz-tools/src/react-native/jazz-rn-runtime-adapter.test.ts
+++ b/packages/jazz-tools/src/react-native/jazz-rn-runtime-adapter.test.ts
@@ -238,6 +238,79 @@ describe("JazzRnRuntimeAdapter", () => {
     expect(() => adapter.delete("row-1")).not.toThrow();
   });
 
+  it("wraps Jazz RN errors with error name and cause", async () => {
+    const runtimeError = {
+      tag: "Runtime",
+      inner: {
+        message: "indexed value too large",
+      },
+    };
+    const binding = createBinding({
+      insert: vi.fn(() => {
+        throw runtimeError;
+      }),
+      query: vi.fn(() => {
+        throw runtimeError;
+      }),
+      update: vi.fn(() => {
+        throw runtimeError;
+      }),
+      delete_: vi.fn(() => {
+        throw runtimeError;
+      }),
+    });
+    const adapter = new JazzRnRuntimeAdapter(binding, {});
+
+    const insertError = (() => {
+      try {
+        adapter.insert("todos", []);
+        return null;
+      } catch (error) {
+        return error;
+      }
+    })();
+    expect(insertError).toBeInstanceOf(Error);
+    expect((insertError as Error).name).toBe("JazzRnRuntimeError");
+    expect((insertError as Error).message).toBe("indexed value too large");
+    expect((insertError as Error & { cause?: unknown }).cause).toBe(runtimeError);
+    expect((insertError as Error & { tag?: unknown }).tag).toBe("Runtime");
+
+    const queryError = await adapter.query("{}", null, null).catch((error: unknown) => error);
+    expect(queryError).toBeInstanceOf(Error);
+    expect((queryError as Error).name).toBe("JazzRnRuntimeError");
+    expect((queryError as Error).message).toBe("indexed value too large");
+    expect((queryError as Error & { cause?: unknown }).cause).toBe(runtimeError);
+    expect((queryError as Error & { tag?: unknown }).tag).toBe("Runtime");
+
+    const updateError = (() => {
+      try {
+        adapter.update("row-1", { done: true });
+        return null;
+      } catch (error) {
+        return error;
+      }
+    })();
+    expect(updateError).toBeInstanceOf(Error);
+    expect((updateError as Error).name).toBe("JazzRnRuntimeError");
+    expect((updateError as Error).message).toBe("indexed value too large");
+    expect((updateError as Error & { cause?: unknown }).cause).toBe(runtimeError);
+    expect((updateError as Error & { tag?: unknown }).tag).toBe("Runtime");
+
+    const deleteError = (() => {
+      try {
+        adapter.delete("row-1");
+        return null;
+      } catch (error) {
+        return error;
+      }
+    })();
+    expect(deleteError).toBeInstanceOf(Error);
+    expect((deleteError as Error).name).toBe("JazzRnRuntimeError");
+    expect((deleteError as Error).message).toBe("indexed value too large");
+    expect((deleteError as Error & { cause?: unknown }).cause).toBe(runtimeError);
+    expect((deleteError as Error & { tag?: unknown }).tag).toBe("Runtime");
+  });
+
   it("no-ops sync hooks after close", () => {
     const binding = createBinding();
     const adapter = new JazzRnRuntimeAdapter(binding, {});

--- a/packages/jazz-tools/src/react-native/jazz-rn-runtime-adapter.test.ts
+++ b/packages/jazz-tools/src/react-native/jazz-rn-runtime-adapter.test.ts
@@ -311,6 +311,59 @@ describe("JazzRnRuntimeAdapter", () => {
     expect((deleteError as Error & { tag?: unknown }).tag).toBe("Runtime");
   });
 
+  it("does not wrap non-Jazz errors", () => {
+    const binding = createBinding({
+      insert: vi.fn(() => {
+        throw new Error("plain failure");
+      }),
+    });
+    const adapter = new JazzRnRuntimeAdapter(binding, {});
+
+    const error = (() => {
+      try {
+        adapter.insert("todos", []);
+        return null;
+      } catch (caught) {
+        return caught;
+      }
+    })();
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).name).toBe("Error");
+    expect((error as Error).message).toBe("plain failure");
+    expect((error as Error & { tag?: unknown }).tag).toBeUndefined();
+  });
+
+  it("derives error name for non-runtime Jazz tags", () => {
+    const schemaError = {
+      tag: "Schema",
+      inner: {
+        message: "schema mismatch",
+      },
+    };
+    const binding = createBinding({
+      insert: vi.fn(() => {
+        throw schemaError;
+      }),
+    });
+    const adapter = new JazzRnRuntimeAdapter(binding, {});
+
+    const error = (() => {
+      try {
+        adapter.insert("todos", []);
+        return null;
+      } catch (caught) {
+        return caught;
+      }
+    })();
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).name).toBe("JazzRnSchemaError");
+    expect((error as Error).message).toBe("schema mismatch");
+    expect((error as Error & { tag?: unknown }).tag).toBe("Schema");
+    expect((error as Error & { cause?: unknown }).cause).toBe(schemaError);
+  });
+
   it("no-ops sync hooks after close", () => {
     const binding = createBinding();
     const adapter = new JazzRnRuntimeAdapter(binding, {});

--- a/packages/jazz-tools/src/react-native/jazz-rn-runtime-adapter.ts
+++ b/packages/jazz-tools/src/react-native/jazz-rn-runtime-adapter.ts
@@ -2,6 +2,19 @@ import type { WasmSchema } from "../drivers/types.js";
 import type { Row, Runtime } from "../runtime/client.js";
 import { OutboxDestinationKind } from "../runtime/sync-transport.js";
 
+type JazzRnErrorTag =
+  | "InvalidJson"
+  | "InvalidUuid"
+  | "InvalidTier"
+  | "Schema"
+  | "Runtime"
+  | "Internal";
+
+export type JazzRnNormalizedError = Error & {
+  tag: JazzRnErrorTag;
+  cause?: unknown;
+};
+
 export interface JazzRnRuntimeBinding {
   addClient(): string;
   addServer(serverCatalogueStateHash?: string | null): void;
@@ -96,7 +109,7 @@ function swallowMissingObjectMutation(context: string, error: unknown): boolean 
 
 function isJazzRnErrorLike(
   error: unknown,
-): error is { tag: string; inner?: { message?: unknown } } {
+): error is { tag: JazzRnErrorTag; inner?: { message?: unknown } } {
   if (!error || typeof error !== "object") {
     return false;
   }
@@ -123,7 +136,7 @@ function normalizeJazzRnError(error: unknown): Error {
   const normalized = createErrorWithCause(message, error);
   normalized.name = `JazzRn${error.tag}Error`;
   Object.assign(normalized, { tag: error.tag });
-  return normalized as Error;
+  return normalized as JazzRnNormalizedError;
 }
 
 function createErrorWithCause(message: string, cause: unknown): Error {

--- a/packages/jazz-tools/src/react-native/jazz-rn-runtime-adapter.ts
+++ b/packages/jazz-tools/src/react-native/jazz-rn-runtime-adapter.ts
@@ -101,7 +101,14 @@ function isJazzRnErrorLike(
     return false;
   }
   const candidate = error as { tag?: unknown; inner?: unknown };
-  return typeof candidate.tag === "string";
+  return (
+    candidate.tag === "InvalidJson" ||
+    candidate.tag === "InvalidUuid" ||
+    candidate.tag === "InvalidTier" ||
+    candidate.tag === "Schema" ||
+    candidate.tag === "Runtime" ||
+    candidate.tag === "Internal"
+  );
 }
 
 function normalizeJazzRnError(error: unknown): Error {

--- a/packages/jazz-tools/src/react-native/jazz-rn-runtime-adapter.ts
+++ b/packages/jazz-tools/src/react-native/jazz-rn-runtime-adapter.ts
@@ -94,6 +94,31 @@ function swallowMissingObjectMutation(context: string, error: unknown): boolean 
   return true;
 }
 
+function isJazzRnErrorLike(
+  error: unknown,
+): error is { tag: string; inner?: { message?: unknown } } {
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+  const candidate = error as { tag?: unknown; inner?: unknown };
+  return typeof candidate.tag === "string";
+}
+
+function normalizeJazzRnError(error: unknown): Error {
+  if (!isJazzRnErrorLike(error)) {
+    return error instanceof Error ? error : new Error(String(error));
+  }
+
+  const message =
+    typeof error.inner?.message === "string" && error.inner.message.length > 0
+      ? error.inner.message
+      : String(error);
+  const normalized = new Error(message, { cause: error });
+  normalized.name = `JazzRn${error.tag}Error`;
+  Object.assign(normalized, { tag: error.tag });
+  return normalized as Error;
+}
+
 function assertSyncMessageArgs(
   destinationKind: unknown,
   destinationId: unknown,
@@ -139,8 +164,12 @@ export class JazzRnRuntimeAdapter implements Runtime {
   }
 
   insert(table: string, values: any): Row {
-    const rowJson = this.binding.insert(table, JSON.stringify(values));
-    return JSON.parse(rowJson) as Row;
+    try {
+      const rowJson = this.binding.insert(table, JSON.stringify(values));
+      return JSON.parse(rowJson) as Row;
+    } catch (error) {
+      throw normalizeJazzRnError(error);
+    }
   }
 
   update(object_id: string, values: any): void {
@@ -148,7 +177,7 @@ export class JazzRnRuntimeAdapter implements Runtime {
       this.binding.update(object_id, JSON.stringify(values));
     } catch (error) {
       if (swallowMissingObjectMutation("update", error)) return;
-      throw error;
+      throw normalizeJazzRnError(error);
     }
   }
 
@@ -157,7 +186,7 @@ export class JazzRnRuntimeAdapter implements Runtime {
       this.binding.delete_(object_id);
     } catch (error) {
       if (swallowMissingObjectMutation("delete", error)) return;
-      throw error;
+      throw normalizeJazzRnError(error);
     }
   }
 
@@ -166,8 +195,12 @@ export class JazzRnRuntimeAdapter implements Runtime {
     session_json?: string | null,
     tier?: string | null,
   ): Promise<any> {
-    const rowsJson = this.binding.query(query_json, session_json ?? undefined, tier ?? undefined);
-    return JSON.parse(rowsJson);
+    try {
+      const rowsJson = this.binding.query(query_json, session_json ?? undefined, tier ?? undefined);
+      return JSON.parse(rowsJson);
+    } catch (error) {
+      throw normalizeJazzRnError(error);
+    }
   }
 
   createSubscription(

--- a/packages/jazz-tools/src/react-native/jazz-rn-runtime-adapter.ts
+++ b/packages/jazz-tools/src/react-native/jazz-rn-runtime-adapter.ts
@@ -2,7 +2,7 @@ import type { WasmSchema } from "../drivers/types.js";
 import type { Row, Runtime } from "../runtime/client.js";
 import { OutboxDestinationKind } from "../runtime/sync-transport.js";
 
-type JazzRnErrorTag =
+export type JazzRnErrorTag =
   | "InvalidJson"
   | "InvalidUuid"
   | "InvalidTier"
@@ -109,19 +109,12 @@ function swallowMissingObjectMutation(context: string, error: unknown): boolean 
 
 function isJazzRnErrorLike(
   error: unknown,
-): error is { tag: JazzRnErrorTag; inner?: { message?: unknown } } {
+): error is { tag: string; inner?: { message?: unknown } } {
   if (!error || typeof error !== "object") {
     return false;
   }
   const candidate = error as { tag?: unknown; inner?: unknown };
-  return (
-    candidate.tag === "InvalidJson" ||
-    candidate.tag === "InvalidUuid" ||
-    candidate.tag === "InvalidTier" ||
-    candidate.tag === "Schema" ||
-    candidate.tag === "Runtime" ||
-    candidate.tag === "Internal"
-  );
+  return typeof candidate.tag === "string";
 }
 
 function normalizeJazzRnError(error: unknown): Error {
@@ -133,10 +126,11 @@ function normalizeJazzRnError(error: unknown): Error {
     typeof error.inner?.message === "string" && error.inner.message.length > 0
       ? error.inner.message
       : String(error);
+  const tag = error.tag as JazzRnErrorTag;
   const normalized = createErrorWithCause(message, error);
-  normalized.name = `JazzRn${error.tag}Error`;
+  normalized.name = `JazzRn${tag}Error`;
   Object.defineProperty(normalized, "tag", {
-    value: error.tag,
+    value: tag,
     enumerable: false,
     configurable: true,
     writable: true,

--- a/packages/jazz-tools/src/react-native/jazz-rn-runtime-adapter.ts
+++ b/packages/jazz-tools/src/react-native/jazz-rn-runtime-adapter.ts
@@ -120,10 +120,25 @@ function normalizeJazzRnError(error: unknown): Error {
     typeof error.inner?.message === "string" && error.inner.message.length > 0
       ? error.inner.message
       : String(error);
-  const normalized = new Error(message, { cause: error });
+  const normalized = createErrorWithCause(message, error);
   normalized.name = `JazzRn${error.tag}Error`;
   Object.assign(normalized, { tag: error.tag });
   return normalized as Error;
+}
+
+function createErrorWithCause(message: string, cause: unknown): Error {
+  try {
+    return new Error(message, { cause });
+  } catch {
+    const fallback = new Error(message) as Error & { cause?: unknown };
+    Object.defineProperty(fallback, "cause", {
+      value: cause,
+      enumerable: false,
+      configurable: true,
+      writable: true,
+    });
+    return fallback;
+  }
 }
 
 function assertSyncMessageArgs(

--- a/packages/jazz-tools/src/react-native/jazz-rn-runtime-adapter.ts
+++ b/packages/jazz-tools/src/react-native/jazz-rn-runtime-adapter.ts
@@ -135,7 +135,12 @@ function normalizeJazzRnError(error: unknown): Error {
       : String(error);
   const normalized = createErrorWithCause(message, error);
   normalized.name = `JazzRn${error.tag}Error`;
-  Object.assign(normalized, { tag: error.tag });
+  Object.defineProperty(normalized, "tag", {
+    value: error.tag,
+    enumerable: false,
+    configurable: true,
+    writable: true,
+  });
   return normalized as JazzRnNormalizedError;
 }
 


### PR DESCRIPTION
## Summary
- normalize React Native runtime bridge failures into standard `Error` objects with clear `name` (`JazzRn{Tag}Error`), human-readable `message`, and `cause` set to the original UniFFI error payload
- keep `tag` metadata on normalized errors (non-enumerable) and trust Rust/UniFFI tag values directly, while preserving ObjectNotFound mutation swallowing behavior
- add RN-safe `cause` fallback for engines that do not support `new Error(message, { cause })`, and expand adapter tests to cover wrapping behavior, pass-through for non-Jazz errors, and tag/name derivation

## Testing
- pnpm -C packages/jazz-tools exec vitest src/react-native/jazz-rn-runtime-adapter.test.ts