### PR TITLE
fix: commits order is deterministic even with equal ts

### DIFF
--- a/crates/jazz-tools/src/commit.rs
+++ b/crates/jazz-tools/src/commit.rs
@@ -8,7 +8,7 @@ use crate::object::ObjectId;
 use crate::sync_manager::DurabilityTier;
 
 /// BLAKE3 hash identifying a commit.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct CommitId(pub [u8; 32]);
 
 /// Persistence acknowledgment state (runtime only, not serialized).

--- a/crates/jazz-tools/src/object_manager/mod.rs
+++ b/crates/jazz-tools/src/object_manager/mod.rs
@@ -756,7 +756,7 @@ impl ObjectManager {
         tips: &SmolSet<[CommitId; 2]>,
     ) -> Vec<CommitId> {
         let mut tip_vec: Vec<_> = tips.iter().copied().collect();
-        tip_vec.sort_by_key(|id| commits.get(id).map(|c| c.timestamp).unwrap_or(0));
+        tip_vec.sort_by_key(|id| (commits.get(id).map(|c| c.timestamp).unwrap_or(0), *id));
         tip_vec
     }
 

--- a/crates/jazz-tools/src/query_manager/manager.rs
+++ b/crates/jazz-tools/src/query_manager/manager.rs
@@ -731,7 +731,7 @@ impl QueryManager {
                 let obj = obj?;
                 // Find the newest commit across all subscription branches (LWW)
                 // Also track which branch it came from for schema transformation
-                let mut best: Option<(u64, Vec<u8>, CommitId, String)> = None;
+                let mut best: Option<(u64, CommitId, Vec<u8>, String)> = None;
 
                 for branch_name in branches {
                     if let Some(branch) = obj.branches.get(&BranchName::new(branch_name)) {
@@ -741,16 +741,18 @@ impl QueryManager {
                                     None => {
                                         best = Some((
                                             commit.timestamp,
-                                            commit.content.clone(),
                                             tip_id,
+                                            commit.content.clone(),
                                             branch_name.clone(),
                                         ));
                                     }
-                                    Some((best_ts, _, _, _)) if commit.timestamp > *best_ts => {
+                                    Some((best_ts, best_id, _, _))
+                                        if (commit.timestamp, tip_id) > (*best_ts, *best_id) =>
+                                    {
                                         best = Some((
                                             commit.timestamp,
-                                            commit.content.clone(),
                                             tip_id,
+                                            commit.content.clone(),
                                             branch_name.clone(),
                                         ));
                                     }
@@ -762,8 +764,8 @@ impl QueryManager {
                 }
 
                 // Filter out empty content (hard delete tombstones only)
-                let (_, content, commit_id, source_branch) =
-                    best.filter(|(_, content, _, _)| !content.is_empty())?;
+                let (_, commit_id, content, source_branch) =
+                    best.filter(|(_, _, content, _)| !content.is_empty())?;
 
                 // Apply lens transform if row is from an old schema branch
                 if let Some(&source_hash) = branch_schema_map.get(&source_branch)
@@ -901,7 +903,7 @@ impl QueryManager {
         self.settle_server_subscriptions(storage_ref);
     }
     /// Load a row's data from a specific branch using LWW (last-writer-wins by timestamp).
-    /// When multiple concurrent tips exist, returns content from the tip with highest timestamp.
+    /// When timestamps tie, CommitId provides a deterministic secondary ordering.
     pub(super) fn load_row_from_object_on_branch(
         &self,
         row_id: ObjectId,
@@ -909,9 +911,14 @@ impl QueryManager {
     ) -> Option<(Vec<u8>, CommitId)> {
         let obj = self.sync_manager.object_manager.get(row_id)?;
         let branch = obj.branches.get(&BranchName::new(branch_name))?;
-        // Sort tips by timestamp (oldest first), take last (newest = LWW winner)
+        // Sort tips by (timestamp, CommitId) ascending, take last (newest = LWW winner)
         let mut tips: Vec<_> = branch.tips.iter().copied().collect();
-        tips.sort_by_key(|id| branch.commits.get(id).map(|c| c.timestamp).unwrap_or(0));
+        tips.sort_by_key(|id| {
+            (
+                branch.commits.get(id).map(|c| c.timestamp).unwrap_or(0),
+                *id,
+            )
+        });
         let tip_id = tips.last()?;
         let commit = branch.commits.get(tip_id)?;
         Some((commit.content.clone(), *tip_id))

--- a/crates/jazz-tools/src/query_manager/server_queries.rs
+++ b/crates/jazz-tools/src/query_manager/server_queries.rs
@@ -295,7 +295,7 @@ impl QueryManager {
             let table = sub.query.table.as_str().to_string();
             let row_loader = |id: ObjectId| -> Option<LoadedRow> {
                 let obj = om.get_or_load(id, storage_ref, &branches)?;
-                let mut best: Option<(u64, Vec<u8>, CommitId, BranchName)> = None;
+                let mut best: Option<(u64, CommitId, Vec<u8>, BranchName)> = None;
                 for branch_name in &branches {
                     let branch_name = BranchName::new(branch_name);
                     if let Some(branch) = obj.branches.get(&branch_name) {
@@ -305,16 +305,18 @@ impl QueryManager {
                                     None => {
                                         best = Some((
                                             commit.timestamp,
-                                            commit.content.clone(),
                                             tip_id,
+                                            commit.content.clone(),
                                             branch_name,
                                         ));
                                     }
-                                    Some((best_ts, _, _, _)) if commit.timestamp > *best_ts => {
+                                    Some((best_ts, best_id, _, _))
+                                        if (commit.timestamp, tip_id) > (*best_ts, *best_id) =>
+                                    {
                                         best = Some((
                                             commit.timestamp,
-                                            commit.content.clone(),
                                             tip_id,
+                                            commit.content.clone(),
                                             branch_name,
                                         ));
                                     }
@@ -324,8 +326,8 @@ impl QueryManager {
                         }
                     }
                 }
-                let (_, content, commit_id, branch_name) =
-                    best.filter(|(_, content, _, _)| !content.is_empty())?;
+                let (_, commit_id, content, branch_name) =
+                    best.filter(|(_, _, content, _)| !content.is_empty())?;
                 Self::load_row_with_schema_transform(
                     id,
                     content,
@@ -461,7 +463,7 @@ impl QueryManager {
             // Row loader for this subscription
             let row_loader = |id: ObjectId| -> Option<LoadedRow> {
                 let obj = om.get_or_load(id, storage, branches)?;
-                let mut best: Option<(u64, Vec<u8>, CommitId, BranchName)> = None;
+                let mut best: Option<(u64, CommitId, Vec<u8>, BranchName)> = None;
                 for branch_name in branches {
                     let branch_name = BranchName::new(branch_name);
                     if let Some(branch) = obj.branches.get(&branch_name) {
@@ -471,16 +473,18 @@ impl QueryManager {
                                     None => {
                                         best = Some((
                                             commit.timestamp,
-                                            commit.content.clone(),
                                             tip_id,
+                                            commit.content.clone(),
                                             branch_name,
                                         ));
                                     }
-                                    Some((best_ts, _, _, _)) if commit.timestamp > *best_ts => {
+                                    Some((best_ts, best_id, _, _))
+                                        if (commit.timestamp, tip_id) > (*best_ts, *best_id) =>
+                                    {
                                         best = Some((
                                             commit.timestamp,
-                                            commit.content.clone(),
                                             tip_id,
+                                            commit.content.clone(),
                                             branch_name,
                                         ));
                                     }
@@ -490,8 +494,8 @@ impl QueryManager {
                         }
                     }
                 }
-                let (_, content, commit_id, branch_name) =
-                    best.filter(|(_, content, _, _)| !content.is_empty())?;
+                let (_, commit_id, content, branch_name) =
+                    best.filter(|(_, _, content, _)| !content.is_empty())?;
                 Self::load_row_with_schema_transform(
                     id,
                     content,

--- a/crates/jazz-tools/src/schema_manager/rehydrate.rs
+++ b/crates/jazz-tools/src/schema_manager/rehydrate.rs
@@ -21,7 +21,7 @@ fn latest_catalogue_content<S: Storage + ?Sized>(
         branch_data
             .commits
             .into_iter()
-            .max_by_key(|commit| commit.timestamp)
+            .max_by_key(|commit| (commit.timestamp, commit.id()))
             .map(|commit| commit.content)
             .filter(|content| !content.is_empty())
     }))


### PR DESCRIPTION
When two browser clients updated the same row concurrently, they could fail to converge on a single final value.

The issue was not in normal sync propagation: sequential updates and remote subscriptions still worked. The failure only appeared on true conflicts, where both replicas produced competing tips for the same object.

The root cause was that our LWW resolution used timestamp as the winner, but equal-timestamp conflicts did not have a canonical tie-break. In that case, the selected winner depended on local tip iteration order, which could differ between runtimes. That meant one client could keep `alice-edit` while another kept `bob-edit`, so the browser conflict tests timed out waiting for convergence and fresh clients could observe inconsistent state.

This PR solves the failing test in: https://github.com/garden-co/jazz2/pull/385
