### PR TITLE
test: cover basic catalogue sync integration test

### DIFF
--- a/crates/jazz-tools/src/schema_catalogue.rs
+++ b/crates/jazz-tools/src/schema_catalogue.rs
@@ -175,7 +175,7 @@ async fn wait_for_in_flight_pushes(in_flight_pushes: &Arc<AtomicUsize>) {
     }
 }
 
-/// Push schema catalogue objects to a sync server.
+/// Push schema catalogue objects to a sync server from a filesystem directory.
 pub async fn push(
     server_url: &str,
     app_id: &str,
@@ -185,10 +185,6 @@ pub async fn push(
     schema_dir: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let app_id = AppId::from_string(app_id)?;
-    let connection = Arc::new(SyncServerClient::connect(server_url, admin_secret).await?);
-    let client_id = ClientId::new();
-    let in_flight_pushes = Arc::new(AtomicUsize::new(0));
-    let push_errors = Arc::new(Mutex::new(Vec::<String>::new()));
 
     let schema_directory = SchemaDirectory::new(schema_dir);
     let schema_versions = schema_directory.schema_versions()?;
@@ -197,30 +193,13 @@ pub async fn push(
     }
 
     let mut schema_info_by_hash = HashMap::new();
+    let mut schemas = Vec::new();
     for schema_info in &schema_versions {
         schema_info_by_hash.insert(schema_info.hash.clone(), schema_info.clone());
+        schemas.push(schema_directory.schema_by_info(schema_info)?);
     }
 
-    for schema_info in &schema_versions {
-        let schema = schema_directory.schema_by_info(schema_info)?;
-        let schema_manager =
-            SchemaManager::new(SyncManager::new(), schema, app_id, env, user_branch).map_err(
-                |error| format!("Failed to initialize schema manager for schema push: {error:?}"),
-            )?;
-        let runtime = build_runtime(
-            schema_manager,
-            MemoryStorage::default(),
-            connection.clone(),
-            client_id,
-            in_flight_pushes.clone(),
-            push_errors.clone(),
-        );
-
-        runtime.persist_schema()?;
-        runtime.add_server(ServerId::default())?;
-        runtime.flush().await?;
-    }
-
+    let mut lenses = Vec::new();
     let forward_migrations = collect_forward_migration_files(&schema_directory)?;
     for migration in &forward_migrations {
         let source_schema_info =
@@ -267,20 +246,87 @@ pub async fn push(
         } else {
             forward_transform.invert()
         };
-        let lens = Lens::with_backward(
+        lenses.push(Lens::with_backward(
             source_hash,
             target_hash,
             forward_transform,
             backward_transform,
+        ));
+    }
+
+    push_in_memory(
+        server_url,
+        app_id,
+        env,
+        user_branch,
+        admin_secret,
+        &schemas,
+        &lenses,
+    )
+    .await
+}
+
+/// Push in-memory schemas and lenses to a sync server.
+///
+/// Same pipeline as [`push`] but accepts pre-built [`Schema`] and [`Lens`]
+/// values instead of reading from a filesystem directory.
+pub async fn push_in_memory(
+    server_url: &str,
+    app_id: AppId,
+    env: &str,
+    user_branch: &str,
+    admin_secret: &str,
+    schemas: &[crate::query_manager::types::Schema],
+    lenses: &[Lens],
+) -> Result<(), Box<dyn std::error::Error>> {
+    let connection = Arc::new(SyncServerClient::connect(server_url, admin_secret).await?);
+    let client_id = ClientId::new();
+    let in_flight_pushes = Arc::new(AtomicUsize::new(0));
+    let push_errors = Arc::new(Mutex::new(Vec::<String>::new()));
+
+    // Push each schema and build hash lookup for lens source resolution
+    let mut schema_by_hash: HashMap<SchemaHash, &crate::query_manager::types::Schema> =
+        HashMap::with_capacity(schemas.len());
+    for schema in schemas {
+        schema_by_hash.insert(SchemaHash::compute(schema), schema);
+        let schema_manager =
+            SchemaManager::new(SyncManager::new(), schema.clone(), app_id, env, user_branch)
+                .map_err(|error| {
+                    format!("Failed to initialize schema manager for schema push: {error:?}")
+                })?;
+        let runtime = build_runtime(
+            schema_manager,
+            MemoryStorage::default(),
+            connection.clone(),
+            client_id,
+            in_flight_pushes.clone(),
+            push_errors.clone(),
         );
 
+        runtime.persist_schema()?;
+        runtime.add_server(ServerId::default())?;
+        runtime.flush().await?;
+    }
+
+    // Push each lens
+    for lens in lenses {
+        let source_schema = schema_by_hash.get(&lens.source_hash).ok_or_else(|| {
+            format!(
+                "No schema provided for lens source hash {}",
+                lens.source_hash
+            )
+        })?;
+
         let mut storage = MemoryStorage::default();
-        let mut schema_manager =
-            SchemaManager::new(SyncManager::new(), source_schema, app_id, env, user_branch)
-                .map_err(|error| {
-                    format!("Failed to initialize schema manager for lens push: {error:?}")
-                })?;
-        schema_manager.persist_lens(&mut storage, &lens);
+        let mut schema_manager = SchemaManager::new(
+            SyncManager::new(),
+            (*source_schema).clone(),
+            app_id,
+            env,
+            user_branch,
+        )
+        .map_err(|error| format!("Failed to initialize schema manager for lens push: {error:?}"))?;
+        schema_manager.persist_lens(&mut storage, lens);
         let runtime = build_runtime(
             schema_manager,
             storage,

--- a/crates/jazz-tools/tests/catalogue_sync_integration.rs
+++ b/crates/jazz-tools/tests/catalogue_sync_integration.rs
@@ -1,0 +1,156 @@
+#![cfg(feature = "test")]
+
+//! E2E catalogue sync integration test.
+//!
+//! Verifies that schema+lens catalogue objects propagate through the full
+//! SyncManager pipeline (not via direct `process_catalogue_update()` calls).
+
+mod support;
+
+use std::time::Duration;
+
+use jazz_tools::query_manager::types::SchemaHash;
+use jazz_tools::schema_catalogue;
+use jazz_tools::schema_manager::{Lens, LensOp, LensTransform};
+use jazz_tools::server::TestingServer;
+use jazz_tools::{
+    ColumnType, DurabilityTier, JazzClient, QueryBuilder, SchemaBuilder, TableSchema, Value,
+};
+use support::{wait_for_edge_query_ready, wait_for_query};
+
+fn schema_v1() -> jazz_tools::Schema {
+    SchemaBuilder::new()
+        .table(
+            TableSchema::builder("users")
+                .column("id", ColumnType::Uuid)
+                .column("name", ColumnType::Text),
+        )
+        .build()
+}
+
+fn schema_v2() -> jazz_tools::Schema {
+    SchemaBuilder::new()
+        .table(
+            TableSchema::builder("users")
+                .column("id", ColumnType::Uuid)
+                .column("name", ColumnType::Text)
+                .nullable_column("email", ColumnType::Text),
+        )
+        .build()
+}
+
+fn v1_to_v2_lens() -> Lens {
+    let v1_hash = SchemaHash::compute(&schema_v1());
+    let v2_hash = SchemaHash::compute(&schema_v2());
+    let forward = LensTransform::with_ops(vec![LensOp::AddColumn {
+        table: "users".to_string(),
+        column: "email".to_string(),
+        column_type: ColumnType::Text,
+        default: Value::Null,
+    }]);
+    Lens::new(v1_hash, v2_hash, forward)
+}
+
+/// Alice writes under schema v1. The v2 schema and v1→v2 lens are pushed
+/// to the server via the real catalogue sync pipeline. Bob connects with
+/// schema v2 and sees Alice's data transformed through the lens.
+///
+/// ```text
+/// alice (v1) ──create user──► server
+///                                │
+///              push v2 schema + lens via HTTP /sync
+///                                │
+///                  bob (v2) connects and queries
+///                                │
+///                                └──► user row with email: null
+/// ```
+#[tokio::test]
+async fn catalogue_sync_e2e_schema_evolution_through_sync_manager() {
+    let server = TestingServer::start().await;
+
+    // === Alice connects with v1, creates a user ===
+    let alice =
+        JazzClient::connect(server.make_client_context_for_user(schema_v1(), "alice-catalogue"))
+            .await
+            .expect("connect alice");
+
+    wait_for_edge_query_ready(&alice, "users", Duration::from_secs(30)).await;
+
+    let user_id_value = jazz_tools::ObjectId::new();
+    let (user_obj_id, _) = alice
+        .create(
+            "users",
+            vec![
+                Value::Uuid(user_id_value),
+                Value::Text("Alice Smith".to_string()),
+            ],
+        )
+        .await
+        .expect("alice creates user");
+
+    // Wait for Alice's row to settle at EdgeServer
+    wait_for_query(
+        &alice,
+        QueryBuilder::new("users").build(),
+        Some(DurabilityTier::EdgeServer),
+        Duration::from_secs(25),
+        "alice's user settled at edge",
+        |rows| (rows.len() == 1 && rows[0].0 == user_obj_id).then_some(rows),
+    )
+    .await;
+
+    // === Push v2 schema + lens to server through the real sync pipeline ===
+    schema_catalogue::push_in_memory(
+        &server.base_url(),
+        server.app_id(),
+        "dev",
+        "main",
+        server.admin_secret(),
+        &[schema_v1(), schema_v2()],
+        &[v1_to_v2_lens()],
+    )
+    .await
+    .expect("push catalogue");
+
+    // === Bob connects with v2, queries — should see Alice's row with email: null ===
+    let bob =
+        JazzClient::connect(server.make_client_context_for_user(schema_v2(), "bob-catalogue"))
+            .await
+            .expect("connect bob");
+
+    wait_for_edge_query_ready(&bob, "users", Duration::from_secs(30)).await;
+
+    let bob_rows = wait_for_query(
+        &bob,
+        QueryBuilder::new("users").build(),
+        Some(DurabilityTier::EdgeServer),
+        Duration::from_secs(25),
+        "bob sees alice's user with email column",
+        |rows| (rows.len() == 1 && rows[0].0 == user_obj_id).then_some(rows),
+    )
+    .await;
+
+    assert_eq!(bob_rows.len(), 1, "bob should see exactly one user");
+    assert_eq!(bob_rows[0].0, user_obj_id);
+
+    let values = &bob_rows[0].1;
+    assert_eq!(
+        values[0],
+        Value::Uuid(user_id_value),
+        "id should match alice's user"
+    );
+    assert_eq!(
+        values[1],
+        Value::Text("Alice Smith".to_string()),
+        "name should match alice's user"
+    );
+    assert_eq!(
+        values[2],
+        Value::Null,
+        "email should be null (default from lens transform)"
+    );
+
+    alice.shutdown().await.expect("shutdown alice");
+    bob.shutdown().await.expect("shutdown bob");
+    server.shutdown().await;
+}


### PR DESCRIPTION
Adds a push_in_memory method to push a schema migration without reading from the FS and cover the catalogue sync with an integration test.