### PR TITLE
feat: Granular reactivity for Svelte & Vue

### DIFF
--- a/.changeset/deep-reactivity.md
+++ b/.changeset/deep-reactivity.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Add reconcileArray for granular Svelte and Vue reactivity in onDelta callbacks

--- a/packages/jazz-tools/src/reconcile-array.test.ts
+++ b/packages/jazz-tools/src/reconcile-array.test.ts
@@ -8,8 +8,8 @@ describe("reconcileArray", () => {
 
     reconcileArray(target, [{ id: "1", name: "Alice (v2)" }]);
 
-    expect(target[0]).toBe(alice);
-    expect(target[0].name).toBe("Alice (v2)");
+    expect(target[0]!).toBe(alice);
+    expect(target[0]!.name).toBe("Alice (v2)");
   });
 
   it("appends new items", () => {
@@ -21,7 +21,7 @@ describe("reconcileArray", () => {
     ]);
 
     expect(target).toHaveLength(2);
-    expect(target[1].name).toBe("Bob");
+    expect(target[1]!.name).toBe("Bob");
   });
 
   it("removes items not in source", () => {
@@ -33,7 +33,7 @@ describe("reconcileArray", () => {
     reconcileArray(target, [{ id: "2", name: "Bob" }]);
 
     expect(target).toHaveLength(1);
-    expect(target[0].name).toBe("Bob");
+    expect(target[0]!.name).toBe("Bob");
   });
 
   it("reorders to match source order", () => {
@@ -46,8 +46,8 @@ describe("reconcileArray", () => {
       { id: "1", name: "Alice" },
     ]);
 
-    expect(target[0]).toBe(bob);
-    expect(target[1]).toBe(alice);
+    expect(target[0]!).toBe(bob);
+    expect(target[1]!).toBe(alice);
   });
 
   it("handles empty source (clears target)", () => {
@@ -64,7 +64,7 @@ describe("reconcileArray", () => {
     reconcileArray(target, [{ id: "1", name: "Alice" }]);
 
     expect(target).toHaveLength(1);
-    expect(target[0].name).toBe("Alice");
+    expect(target[0]!.name).toBe("Alice");
   });
 
   it("skips property writes when values are identical", () => {
@@ -73,21 +73,21 @@ describe("reconcileArray", () => {
 
     reconcileArray(target, [{ id: "1", name: "Alice" }]);
 
-    expect(target[0]).toBe(alice);
-    expect(target[0].name).toBe("Alice");
+    expect(target[0]!).toBe(alice);
+    expect(target[0]!.name).toBe("Alice");
   });
 });
 
 describe("deepMerge (via reconcileArray)", () => {
   it("deep-merges nested plain objects", () => {
     const target = [{ id: "1", profile: { bio: "old", age: 30 } }];
-    const original = target[0];
+    const original = target[0]!;
 
     reconcileArray(target, [{ id: "1", profile: { bio: "new", age: 30 } }]);
 
-    expect(target[0]).toBe(original);
-    expect(target[0].profile.bio).toBe("new");
-    expect(target[0].profile.age).toBe(30);
+    expect(target[0]!).toBe(original);
+    expect(target[0]!.profile.bio).toBe("new");
+    expect(target[0]!.profile.age).toBe(30);
   });
 
   it("recursively reconciles nested keyed arrays", () => {
@@ -97,8 +97,8 @@ describe("deepMerge (via reconcileArray)", () => {
         tags: [{ id: "t1", label: "jazz" }],
       },
     ];
-    const original = target[0];
-    const originalTag = target[0].tags[0];
+    const original = target[0]!;
+    const originalTag = target[0]!.tags[0]!;
 
     reconcileArray(target, [
       {
@@ -110,10 +110,10 @@ describe("deepMerge (via reconcileArray)", () => {
       },
     ]);
 
-    expect(target[0]).toBe(original);
-    expect(target[0].tags[0]).toBe(originalTag);
-    expect(target[0].tags[0].label).toBe("jazz (updated)");
-    expect(target[0].tags).toHaveLength(2);
+    expect(target[0]!).toBe(original);
+    expect(target[0]!.tags[0]!).toBe(originalTag);
+    expect(target[0]!.tags[0]!.label).toBe("jazz (updated)");
+    expect(target[0]!.tags).toHaveLength(2);
   });
 
   it("handles Date values correctly", () => {
@@ -122,11 +122,11 @@ describe("deepMerge (via reconcileArray)", () => {
 
     // Same date value — should not replace
     reconcileArray(target, [{ id: "1", createdAt: new Date("2026-01-01") }]);
-    expect(target[0].createdAt).toBe(now);
+    expect(target[0]!.createdAt).toBe(now);
 
     // Different date — should replace
     reconcileArray(target, [{ id: "1", createdAt: new Date("2026-06-01") }]);
-    expect(target[0].createdAt).toEqual(new Date("2026-06-01"));
+    expect(target[0]!.createdAt).toEqual(new Date("2026-06-01"));
   });
 
   it("handles Uint8Array values correctly", () => {
@@ -135,19 +135,19 @@ describe("deepMerge (via reconcileArray)", () => {
 
     // Same bytes — should not replace
     reconcileArray(target, [{ id: "1", data: new Uint8Array([1, 2, 3]) }]);
-    expect(target[0].data).toBe(bytes);
+    expect(target[0]!.data).toBe(bytes);
 
     // Different bytes — should replace
     reconcileArray(target, [{ id: "1", data: new Uint8Array([4, 5, 6]) }]);
-    expect(target[0].data).toEqual(new Uint8Array([4, 5, 6]));
+    expect(target[0]!.data).toEqual(new Uint8Array([4, 5, 6]));
   });
 
   it("deletes keys removed from source", () => {
     const target = [{ id: "1", name: "Alice", legacy: "old" } as Record<string, unknown>];
 
-    reconcileArray(target as Array<{ id: string }>, [{ id: "1", name: "Alice" }]);
+    reconcileArray(target as Array<{ id: string }>, [{ id: "1", name: "Alice" } as { id: string }]);
 
-    expect(target[0].name).toBe("Alice");
-    expect("legacy" in target[0]).toBe(false);
+    expect(target[0]!.name).toBe("Alice");
+    expect("legacy" in target[0]!).toBe(false);
   });
 });

--- a/packages/jazz-tools/src/reconcile-array.test.ts
+++ b/packages/jazz-tools/src/reconcile-array.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from "vitest";
+import { reconcileArray } from "./reconcile-array.js";
+
+describe("reconcileArray", () => {
+  it("preserves identity for matched items", () => {
+    const alice = { id: "1", name: "Alice" };
+    const target = [alice];
+
+    reconcileArray(target, [{ id: "1", name: "Alice (v2)" }]);
+
+    expect(target[0]).toBe(alice);
+    expect(target[0].name).toBe("Alice (v2)");
+  });
+
+  it("appends new items", () => {
+    const target = [{ id: "1", name: "Alice" }];
+
+    reconcileArray(target, [
+      { id: "1", name: "Alice" },
+      { id: "2", name: "Bob" },
+    ]);
+
+    expect(target).toHaveLength(2);
+    expect(target[1].name).toBe("Bob");
+  });
+
+  it("removes items not in source", () => {
+    const target = [
+      { id: "1", name: "Alice" },
+      { id: "2", name: "Bob" },
+    ];
+
+    reconcileArray(target, [{ id: "2", name: "Bob" }]);
+
+    expect(target).toHaveLength(1);
+    expect(target[0].name).toBe("Bob");
+  });
+
+  it("reorders to match source order", () => {
+    const alice = { id: "1", name: "Alice" };
+    const bob = { id: "2", name: "Bob" };
+    const target = [alice, bob];
+
+    reconcileArray(target, [
+      { id: "2", name: "Bob" },
+      { id: "1", name: "Alice" },
+    ]);
+
+    expect(target[0]).toBe(bob);
+    expect(target[1]).toBe(alice);
+  });
+
+  it("handles empty source (clears target)", () => {
+    const target = [{ id: "1", name: "Alice" }];
+
+    reconcileArray(target, []);
+
+    expect(target).toHaveLength(0);
+  });
+
+  it("handles empty target (populates from source)", () => {
+    const target: Array<{ id: string; name: string }> = [];
+
+    reconcileArray(target, [{ id: "1", name: "Alice" }]);
+
+    expect(target).toHaveLength(1);
+    expect(target[0].name).toBe("Alice");
+  });
+
+  it("skips property writes when values are identical", () => {
+    const alice = { id: "1", name: "Alice" };
+    const target = [alice];
+
+    reconcileArray(target, [{ id: "1", name: "Alice" }]);
+
+    expect(target[0]).toBe(alice);
+    expect(target[0].name).toBe("Alice");
+  });
+});
+
+describe("deepMerge (via reconcileArray)", () => {
+  it("deep-merges nested plain objects", () => {
+    const target = [{ id: "1", profile: { bio: "old", age: 30 } }];
+    const original = target[0];
+
+    reconcileArray(target, [{ id: "1", profile: { bio: "new", age: 30 } }]);
+
+    expect(target[0]).toBe(original);
+    expect(target[0].profile.bio).toBe("new");
+    expect(target[0].profile.age).toBe(30);
+  });
+
+  it("recursively reconciles nested keyed arrays", () => {
+    const target = [
+      {
+        id: "1",
+        tags: [{ id: "t1", label: "jazz" }],
+      },
+    ];
+    const original = target[0];
+    const originalTag = target[0].tags[0];
+
+    reconcileArray(target, [
+      {
+        id: "1",
+        tags: [
+          { id: "t1", label: "jazz (updated)" },
+          { id: "t2", label: "svelte" },
+        ],
+      },
+    ]);
+
+    expect(target[0]).toBe(original);
+    expect(target[0].tags[0]).toBe(originalTag);
+    expect(target[0].tags[0].label).toBe("jazz (updated)");
+    expect(target[0].tags).toHaveLength(2);
+  });
+
+  it("handles Date values correctly", () => {
+    const now = new Date("2026-01-01");
+    const target = [{ id: "1", createdAt: now }];
+
+    // Same date value — should not replace
+    reconcileArray(target, [{ id: "1", createdAt: new Date("2026-01-01") }]);
+    expect(target[0].createdAt).toBe(now);
+
+    // Different date — should replace
+    reconcileArray(target, [{ id: "1", createdAt: new Date("2026-06-01") }]);
+    expect(target[0].createdAt).toEqual(new Date("2026-06-01"));
+  });
+
+  it("handles Uint8Array values correctly", () => {
+    const bytes = new Uint8Array([1, 2, 3]);
+    const target = [{ id: "1", data: bytes }];
+
+    // Same bytes — should not replace
+    reconcileArray(target, [{ id: "1", data: new Uint8Array([1, 2, 3]) }]);
+    expect(target[0].data).toBe(bytes);
+
+    // Different bytes — should replace
+    reconcileArray(target, [{ id: "1", data: new Uint8Array([4, 5, 6]) }]);
+    expect(target[0].data).toEqual(new Uint8Array([4, 5, 6]));
+  });
+
+  it("deletes keys removed from source", () => {
+    const target = [{ id: "1", name: "Alice", legacy: "old" } as Record<string, unknown>];
+
+    reconcileArray(target as Array<{ id: string }>, [{ id: "1", name: "Alice" }]);
+
+    expect(target[0].name).toBe("Alice");
+    expect("legacy" in target[0]).toBe(false);
+  });
+});

--- a/packages/jazz-tools/src/reconcile-array.ts
+++ b/packages/jazz-tools/src/reconcile-array.ts
@@ -20,6 +20,8 @@ export function applyDelta<T extends { id: string }>(
       deepMerge(existing as Record<string, unknown>, source as Record<string, unknown>);
     }
   }
+  // Without reconciliation, ordering is not guaranteed.
+  reconcileArray(target, delta.all);
 }
 
 /**

--- a/packages/jazz-tools/src/reconcile-array.ts
+++ b/packages/jazz-tools/src/reconcile-array.ts
@@ -1,15 +1,25 @@
 import type { SubscriptionDelta } from "./runtime/subscription-manager.js";
 
 /**
- * Apply a subscription delta to a reactive array, preserving object
- * identity for unchanged and updated items. Uses reconcileArray for
- * ordering and deepMerge for property-level updates.
+ * Apply a subscription delta to a reactive array, deep-merging only
+ * the rows that actually changed.
  */
 export function applyDelta<T extends { id: string }>(
   target: T[],
   delta: SubscriptionDelta<T>,
 ): void {
-  reconcileArray(target, delta.all);
+  const changedIds = new Set<string>();
+  for (const change of delta.delta) {
+    if (change.kind === 2) changedIds.add(change.id);
+  }
+
+  for (const id of changedIds) {
+    const existing = target.find((item) => item.id === id);
+    const source = delta.all.find((item) => item.id === id);
+    if (existing && source) {
+      deepMerge(existing as Record<string, unknown>, source as Record<string, unknown>);
+    }
+  }
 }
 
 /**

--- a/packages/jazz-tools/src/reconcile-array.ts
+++ b/packages/jazz-tools/src/reconcile-array.ts
@@ -1,0 +1,95 @@
+/**
+ * Reconcile a target array in-place to match a source array,
+ * preserving object identity for items with matching `id` fields.
+ *
+ * Designed for reactive proxy systems (Svelte 5 $state, Vue ref) where
+ * minimising property writes avoids unnecessary signal triggers.
+ *
+ * Assumptions (bounded by Jazz's data model):
+ * - Source items are fresh objects from the WASM runtime, not shared
+ *   references. deepMerge mutates `target` in-place, so structural
+ *   sharing between source and target would corrupt the source.
+ * - Objects are plain POJOs (no class instances, Map, Set, or cycles).
+ *   isPlainObject excludes Date and Uint8Array as leaf values; anything
+ *   else with a prototype would be incorrectly deep-merged field-by-field.
+ * - Keyed arrays always contain objects with `id` at every index.
+ *   isKeyedArray only checks the first element as a fast-path heuristic.
+ */
+export function reconcileArray<T extends { id: string }>(target: T[], source: T[]): void {
+  const existing = new Map<string, T>();
+  for (const item of target) {
+    existing.set(item.id, item);
+  }
+
+  const result: T[] = [];
+  for (const srcItem of source) {
+    const prev = existing.get(srcItem.id);
+    if (prev) {
+      deepMerge(prev as Record<string, unknown>, srcItem as Record<string, unknown>);
+      result.push(prev);
+    } else {
+      result.push(srcItem);
+    }
+  }
+
+  for (let i = 0; i < result.length; i++) {
+    if (target[i] !== result[i]) {
+      target[i] = result[i];
+    }
+  }
+  if (target.length > result.length) {
+    target.length = result.length;
+  }
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value) &&
+    !(value instanceof Date) &&
+    !(value instanceof Uint8Array)
+  );
+}
+
+// Heuristic: checks only the first element. Safe because Jazz row objects
+// always have `id` — mixed arrays (some with id, some without) don't occur.
+function isKeyedArray(value: unknown[]): value is Array<{ id: string }> {
+  return value.length > 0 && isPlainObject(value[0]) && "id" in value[0];
+}
+
+function valuesEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (a instanceof Date && b instanceof Date) return a.getTime() === b.getTime();
+  if (a instanceof Uint8Array && b instanceof Uint8Array) {
+    return a.length === b.length && a.every((v, i) => v === b[i]);
+  }
+  return false;
+}
+
+// Recursive with no depth/cycle guard — Jazz row objects are shallow POJOs
+// from the WASM runtime, so this is safe. Would stack-overflow on cyclic graphs.
+function deepMerge(target: Record<string, unknown>, source: Record<string, unknown>): void {
+  const sourceKeys = new Set(Object.keys(source));
+
+  for (const key of sourceKeys) {
+    const tv = target[key];
+    const sv = source[key];
+
+    if (valuesEqual(tv, sv)) continue;
+
+    if (isPlainObject(tv) && isPlainObject(sv)) {
+      deepMerge(tv, sv);
+    } else if (Array.isArray(tv) && Array.isArray(sv) && isKeyedArray(sv)) {
+      reconcileArray(tv as Array<{ id: string }>, sv as Array<{ id: string }>);
+    } else {
+      target[key] = sv;
+    }
+  }
+
+  for (const key of Object.keys(target)) {
+    if (!sourceKeys.has(key)) {
+      delete target[key];
+    }
+  }
+}

--- a/packages/jazz-tools/src/reconcile-array.ts
+++ b/packages/jazz-tools/src/reconcile-array.ts
@@ -1,3 +1,17 @@
+import type { SubscriptionDelta } from "./runtime/subscription-manager.js";
+
+/**
+ * Apply a subscription delta to a reactive array, preserving object
+ * identity for unchanged and updated items. Uses reconcileArray for
+ * ordering and deepMerge for property-level updates.
+ */
+export function applyDelta<T extends { id: string }>(
+  target: T[],
+  delta: SubscriptionDelta<T>,
+): void {
+  reconcileArray(target, delta.all);
+}
+
 /**
  * Reconcile a target array in-place to match a source array,
  * preserving object identity for items with matching `id` fields.

--- a/packages/jazz-tools/src/reconcile-array.ts
+++ b/packages/jazz-tools/src/reconcile-array.ts
@@ -34,7 +34,7 @@ export function reconcileArray<T extends { id: string }>(target: T[], source: T[
 
   for (let i = 0; i < result.length; i++) {
     if (target[i] !== result[i]) {
-      target[i] = result[i];
+      target[i] = result[i]!;
     }
   }
   if (target.length > result.length) {

--- a/packages/jazz-tools/src/svelte/rune-patterns.svelte.test.ts
+++ b/packages/jazz-tools/src/svelte/rune-patterns.svelte.test.ts
@@ -1,6 +1,86 @@
 import { describe, expect, it, vi } from "vitest";
 import { flushSync } from "svelte";
+import { reconcileArray } from "../reconcile-array.js";
 import "./test-helpers.svelte.js";
+
+// ── reconcileArray through $state proxy ────────────────────────────
+// Prove that reconcileArray's in-place mutations propagate correctly
+// through Svelte's reactive proxy.
+
+describe("reconcileArray through $state proxy", () => {
+  it("preserves object identity after reconciliation", () => {
+    let items: Array<{ id: string; name: string }> = $state([{ id: "1", name: "Alice" }]);
+
+    const ref = items[0];
+    reconcileArray(items, [{ id: "1", name: "Alice (updated)" }]);
+    flushSync();
+
+    expect(items[0]).toBe(ref);
+    expect(items[0].name).toBe("Alice (updated)");
+  });
+
+  it("appends new items and removes stale ones", () => {
+    let items: Array<{ id: string; name: string }> = $state([
+      { id: "1", name: "Alice" },
+      { id: "2", name: "Bob" },
+    ]);
+
+    reconcileArray(items, [
+      { id: "2", name: "Bob" },
+      { id: "3", name: "Carol" },
+    ]);
+    flushSync();
+
+    expect(items).toHaveLength(2);
+    expect(items[0].name).toBe("Bob");
+    expect(items[1].name).toBe("Carol");
+  });
+
+  it("$effect observes property changes from reconciliation", async () => {
+    let items: Array<{ id: string; name: string }> = $state([{ id: "1", name: "Alice" }]);
+
+    const observed: string[] = [];
+    const cleanup = $effect.root(() => {
+      $effect(() => {
+        observed.push(items[0]?.name ?? "empty");
+      });
+    });
+
+    await Promise.resolve();
+    flushSync();
+    expect(observed).toEqual(["Alice"]);
+
+    reconcileArray(items, [{ id: "1", name: "Alice (v2)" }]);
+    await Promise.resolve();
+    flushSync();
+    expect(observed).toEqual(["Alice", "Alice (v2)"]);
+
+    cleanup();
+  });
+
+  it("$effect does not re-fire when reconciled values are identical", async () => {
+    let items: Array<{ id: string; name: string }> = $state([{ id: "1", name: "Alice" }]);
+
+    let effectCount = 0;
+    const cleanup = $effect.root(() => {
+      $effect(() => {
+        void items[0]?.name;
+        effectCount++;
+      });
+    });
+
+    await Promise.resolve();
+    flushSync();
+    expect(effectCount).toBe(1);
+
+    reconcileArray(items, [{ id: "1", name: "Alice" }]);
+    await Promise.resolve();
+    flushSync();
+    expect(effectCount).toBe(1);
+
+    cleanup();
+  });
+});
 
 // ── Rune behaviour smoke tests ─────────────────────────────────────
 // These verify that the callback patterns used by QuerySubscription
@@ -24,23 +104,35 @@ describe("$state callback patterns", () => {
     expect(loading).toBe(false);
   });
 
-  it("onDelta replaces current with delta.all", () => {
+  it("onDelta reconciles into existing $state array", () => {
+    //  ┌──────────┐    onDelta    ┌──────────────────┐
+    //  │ current  │ ──────────▶   │ reconcileArray() │
+    //  │ $state[] │    delta.all  │ in-place merge   │
+    //  └──────────┘               └──────────────────┘
     let current: any[] | undefined = $state([{ id: "1", title: "First" }]);
 
+    const firstRef = current![0];
+
     const onDelta = (delta: { all: any[] }) => {
-      current = delta.all;
+      if (current) {
+        reconcileArray(current, delta.all);
+      } else {
+        current = delta.all;
+      }
     };
 
     onDelta({
       all: [
-        { id: "1", title: "First" },
+        { id: "1", title: "First (edited)" },
         { id: "2", title: "Second" },
       ],
     });
     flushSync();
 
-    expect($state.snapshot(current)).toHaveLength(2);
-    expect($state.snapshot(current)![1].title).toBe("Second");
+    expect(current).toHaveLength(2);
+    expect(current![0]).toBe(firstRef);
+    expect(current![0].title).toBe("First (edited)");
+    expect(current![1].title).toBe("Second");
   });
 
   it("onError surfaces error and clears current", () => {

--- a/packages/jazz-tools/src/svelte/rune-patterns.svelte.test.ts
+++ b/packages/jazz-tools/src/svelte/rune-patterns.svelte.test.ts
@@ -135,6 +135,115 @@ describe("$state callback patterns", () => {
     expect(current![1].title).toBe("Second");
   });
 
+  it("batch delta: remove + add preserves correct items through $state", () => {
+    //  Before: [alice, bob, carol]
+    //  Delta:  remove alice, add dave
+    //  After:  [bob, carol, dave]
+    let current: any[] | undefined = $state([
+      { id: "1", name: "Alice" },
+      { id: "2", name: "Bob" },
+      { id: "3", name: "Carol" },
+    ]);
+
+    const bobRef = current![1];
+    const carolRef = current![2];
+
+    const onDelta = (delta: { all: any[] }) => {
+      if (current) {
+        reconcileArray(current, delta.all);
+      } else {
+        current = delta.all;
+      }
+    };
+
+    onDelta({
+      all: [
+        { id: "2", name: "Bob" },
+        { id: "3", name: "Carol" },
+        { id: "4", name: "Dave" },
+      ],
+    });
+    flushSync();
+
+    expect(current).toHaveLength(3);
+    expect(current![0]).toBe(bobRef);
+    expect(current![1]).toBe(carolRef);
+    expect(current![2].name).toBe("Dave");
+  });
+
+  it("batch delta: two removes preserves survivors through $state", () => {
+    //  Before: [alice, bob, carol, dave]
+    //  Delta:  remove alice, remove carol
+    //  After:  [bob, dave]
+    let current: any[] | undefined = $state([
+      { id: "1", name: "Alice" },
+      { id: "2", name: "Bob" },
+      { id: "3", name: "Carol" },
+      { id: "4", name: "Dave" },
+    ]);
+
+    const bobRef = current![1];
+    const daveRef = current![3];
+
+    const onDelta = (delta: { all: any[] }) => {
+      if (current) {
+        reconcileArray(current, delta.all);
+      } else {
+        current = delta.all;
+      }
+    };
+
+    onDelta({
+      all: [
+        { id: "2", name: "Bob" },
+        { id: "4", name: "Dave" },
+      ],
+    });
+    flushSync();
+
+    expect(current).toHaveLength(2);
+    expect(current![0]).toBe(bobRef);
+    expect(current![1]).toBe(daveRef);
+  });
+
+  it("updated item changes position, array reorders through $state", () => {
+    //  Before: [alice, bob, carol]
+    //  Delta:  alice updated and moved to end (e.g. sort order changed)
+    //  After:  [bob, carol, alice']
+    let current: any[] | undefined = $state([
+      { id: "1", name: "Alice", score: 10 },
+      { id: "2", name: "Bob", score: 20 },
+      { id: "3", name: "Carol", score: 30 },
+    ]);
+
+    const aliceRef = current![0];
+    const bobRef = current![1];
+    const carolRef = current![2];
+
+    const onDelta = (delta: { all: any[] }) => {
+      if (current) {
+        reconcileArray(current, delta.all);
+      } else {
+        current = delta.all;
+      }
+    };
+
+    onDelta({
+      all: [
+        { id: "2", name: "Bob", score: 20 },
+        { id: "3", name: "Carol", score: 30 },
+        { id: "1", name: "Alice", score: 5 },
+      ],
+    });
+    flushSync();
+
+    expect(current).toHaveLength(3);
+    expect(current![0]).toBe(bobRef);
+    expect(current![1]).toBe(carolRef);
+    expect(current![2]).toBe(aliceRef); // moved, identity preserved
+    expect(current![2].score).toBe(5); // property updated
+  });
+
   it("onError surfaces error and clears current", () => {
     let current: any[] | undefined = $state([{ id: "1" }]);
     let loading: boolean = $state(false);

--- a/packages/jazz-tools/src/svelte/rune-patterns.svelte.test.ts
+++ b/packages/jazz-tools/src/svelte/rune-patterns.svelte.test.ts
@@ -82,6 +82,54 @@ describe("reconcileArray through $state proxy", () => {
   });
 });
 
+// ── applyDelta skips unchanged rows ─────────────────────────────────
+
+describe("applyDelta only touches changed rows", () => {
+  it("$effect on unchanged row does not re-fire when only another row updates", async () => {
+    //  alice and bob in the array; only bob changes.
+    //  An $effect watching alice.name should NOT re-fire.
+    let items: Array<{ id: string; name: string }> = $state([
+      { id: "1", name: "Alice" },
+      { id: "2", name: "Bob" },
+    ]);
+
+    let aliceEffectCount = 0;
+    let bobEffectCount = 0;
+    const cleanup = $effect.root(() => {
+      $effect(() => {
+        void items[0]?.name;
+        aliceEffectCount++;
+      });
+      $effect(() => {
+        void items[1]?.name;
+        bobEffectCount++;
+      });
+    });
+
+    await Promise.resolve();
+    flushSync();
+    expect(aliceEffectCount).toBe(1);
+    expect(bobEffectCount).toBe(1);
+
+    // Delta: only bob updated
+    applyDelta(items, {
+      all: [
+        { id: "1", name: "Alice" },
+        { id: "2", name: "Bob (v2)" },
+      ],
+      delta: [{ kind: 2, id: "2", index: 1 }],
+    });
+    await Promise.resolve();
+    flushSync();
+
+    expect(aliceEffectCount).toBe(1); // alice untouched — no re-fire
+    expect(bobEffectCount).toBe(2); // bob changed — re-fired
+    expect(items[1].name).toBe("Bob (v2)");
+
+    cleanup();
+  });
+});
+
 // ── Rune behaviour smoke tests ─────────────────────────────────────
 // These verify that the callback patterns used by QuerySubscription
 // behave correctly under real $state proxying and flushSync — not

--- a/packages/jazz-tools/src/svelte/rune-patterns.svelte.test.ts
+++ b/packages/jazz-tools/src/svelte/rune-patterns.svelte.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { flushSync } from "svelte";
-import { reconcileArray } from "../reconcile-array.js";
+import { applyDelta, reconcileArray } from "../reconcile-array.js";
 import "./test-helpers.svelte.js";
 
 // ── reconcileArray through $state proxy ────────────────────────────
@@ -105,26 +105,18 @@ describe("$state callback patterns", () => {
   });
 
   it("onDelta reconciles into existing $state array", () => {
-    //  ┌──────────┐    onDelta    ┌──────────────────┐
-    //  │ current  │ ──────────▶   │ reconcileArray() │
-    //  │ $state[] │    delta.all  │ in-place merge   │
-    //  └──────────┘               └──────────────────┘
     let current: any[] | undefined = $state([{ id: "1", title: "First" }]);
 
     const firstRef = current![0];
 
-    const onDelta = (delta: { all: any[] }) => {
-      if (current) {
-        reconcileArray(current, delta.all);
-      } else {
-        current = delta.all;
-      }
-    };
-
-    onDelta({
+    applyDelta(current!, {
       all: [
         { id: "1", title: "First (edited)" },
         { id: "2", title: "Second" },
+      ],
+      delta: [
+        { kind: 2, id: "1", index: 0 },
+        { kind: 0, id: "2", index: 1, item: { id: "2", title: "Second" } },
       ],
     });
     flushSync();
@@ -148,19 +140,15 @@ describe("$state callback patterns", () => {
     const bobRef = current![1];
     const carolRef = current![2];
 
-    const onDelta = (delta: { all: any[] }) => {
-      if (current) {
-        reconcileArray(current, delta.all);
-      } else {
-        current = delta.all;
-      }
-    };
-
-    onDelta({
+    applyDelta(current!, {
       all: [
         { id: "2", name: "Bob" },
         { id: "3", name: "Carol" },
         { id: "4", name: "Dave" },
+      ],
+      delta: [
+        { kind: 1, id: "1", index: 0 },
+        { kind: 0, id: "4", index: 2, item: { id: "4", name: "Dave" } },
       ],
     });
     flushSync();
@@ -185,18 +173,14 @@ describe("$state callback patterns", () => {
     const bobRef = current![1];
     const daveRef = current![3];
 
-    const onDelta = (delta: { all: any[] }) => {
-      if (current) {
-        reconcileArray(current, delta.all);
-      } else {
-        current = delta.all;
-      }
-    };
-
-    onDelta({
+    applyDelta(current!, {
       all: [
         { id: "2", name: "Bob" },
         { id: "4", name: "Dave" },
+      ],
+      delta: [
+        { kind: 1, id: "1", index: 0 },
+        { kind: 1, id: "3", index: 2 },
       ],
     });
     flushSync();
@@ -220,20 +204,13 @@ describe("$state callback patterns", () => {
     const bobRef = current![1];
     const carolRef = current![2];
 
-    const onDelta = (delta: { all: any[] }) => {
-      if (current) {
-        reconcileArray(current, delta.all);
-      } else {
-        current = delta.all;
-      }
-    };
-
-    onDelta({
+    applyDelta(current!, {
       all: [
         { id: "2", name: "Bob", score: 20 },
         { id: "3", name: "Carol", score: 30 },
         { id: "1", name: "Alice", score: 5 },
       ],
+      delta: [{ kind: 2, id: "1", index: 2 }],
     });
     flushSync();
 

--- a/packages/jazz-tools/src/svelte/use-all.svelte.ts
+++ b/packages/jazz-tools/src/svelte/use-all.svelte.ts
@@ -1,6 +1,7 @@
 import { onDestroy } from "svelte";
 import type { QueryBuilder, QueryOptions } from "../runtime/db.js";
 import type { SubscriptionDelta } from "../runtime/subscription-manager.js";
+import { reconcileArray } from "../reconcile-array.js";
 import { getJazzContext } from "./context.svelte.js";
 
 /**
@@ -57,7 +58,11 @@ export class QuerySubscription<T extends { id: string }> {
             this.loading = false;
           },
           onDelta: (delta: SubscriptionDelta<T>) => {
-            this.current = delta.all;
+            if (this.current) {
+              reconcileArray(this.current, delta.all);
+            } else {
+              this.current = delta.all;
+            }
           },
           onError: (error: unknown) => {
             this.error = error instanceof Error ? error : new Error(String(error));

--- a/packages/jazz-tools/src/svelte/use-all.svelte.ts
+++ b/packages/jazz-tools/src/svelte/use-all.svelte.ts
@@ -1,7 +1,7 @@
 import { onDestroy } from "svelte";
 import type { QueryBuilder, QueryOptions } from "../runtime/db.js";
 import type { SubscriptionDelta } from "../runtime/subscription-manager.js";
-import { reconcileArray } from "../reconcile-array.js";
+import { applyDelta } from "../reconcile-array.js";
 import { getJazzContext } from "./context.svelte.js";
 
 /**
@@ -59,7 +59,7 @@ export class QuerySubscription<T extends { id: string }> {
           },
           onDelta: (delta: SubscriptionDelta<T>) => {
             if (this.current) {
-              reconcileArray(this.current, delta.all);
+              applyDelta(this.current, delta);
             } else {
               this.current = delta.all;
             }

--- a/packages/jazz-tools/src/vue/use-all.test.ts
+++ b/packages/jazz-tools/src/vue/use-all.test.ts
@@ -157,4 +157,136 @@ describe("vue/useAll", () => {
 
     scope.stop();
   });
+
+  it("VU-ALL-08: batch delta with remove + add preserves correct items", () => {
+    //  Before:  [alice, bob, carol]
+    //  Delta:   remove alice (index 0), add dave (index 2)
+    //  After:   [bob, carol, dave]
+    const alice = { id: "u1", name: "Alice" };
+    const bob = { id: "u2", name: "Bob" };
+    const carol = { id: "u3", name: "Carol" };
+    let capturedOnDelta: ((delta: any) => void) | undefined;
+
+    mocks.getCacheEntry.mockReturnValue({
+      state: { status: "fulfilled" as const, data: [alice, bob, carol] },
+      subscribe: (callbacks: any) => {
+        capturedOnDelta = callbacks.onDelta;
+        return vi.fn();
+      },
+    } as any);
+
+    const scope = effectScope();
+    const result = scope.run(() => useAll(makeQuery()));
+
+    expect(result!.value).toHaveLength(3);
+    const bobRef = result!.value![1];
+    const carolRef = result!.value![2];
+
+    // Batch: remove alice (was at index 0) + add dave (at index 2 in final state)
+    capturedOnDelta!({
+      all: [
+        { id: "u2", name: "Bob" },
+        { id: "u3", name: "Carol" },
+        { id: "u4", name: "Dave" },
+      ],
+      delta: [
+        { kind: 1, id: "u1", index: 0 },
+        { kind: 0, id: "u4", index: 2, item: { id: "u4", name: "Dave" } },
+      ],
+    });
+
+    expect(result!.value).toHaveLength(3);
+    expect(result!.value![0]).toBe(bobRef); // bob preserved
+    expect(result!.value![1]).toBe(carolRef); // carol preserved
+    expect((result!.value![2] as any).name).toBe("Dave"); // dave added
+
+    scope.stop();
+  });
+
+  it("VU-ALL-09: batch delta with two removes preserves survivors", () => {
+    //  Before:  [alice, bob, carol, dave]
+    //  Delta:   remove alice (index 0), remove carol (index 2)
+    //  After:   [bob, dave]
+    const alice = { id: "u1", name: "Alice" };
+    const bob = { id: "u2", name: "Bob" };
+    const carol = { id: "u3", name: "Carol" };
+    const dave = { id: "u4", name: "Dave" };
+    let capturedOnDelta: ((delta: any) => void) | undefined;
+
+    mocks.getCacheEntry.mockReturnValue({
+      state: { status: "fulfilled" as const, data: [alice, bob, carol, dave] },
+      subscribe: (callbacks: any) => {
+        capturedOnDelta = callbacks.onDelta;
+        return vi.fn();
+      },
+    } as any);
+
+    const scope = effectScope();
+    const result = scope.run(() => useAll(makeQuery()));
+
+    expect(result!.value).toHaveLength(4);
+    const bobRef = result!.value![1];
+    const daveRef = result!.value![3];
+
+    // Batch: remove alice + remove carol
+    capturedOnDelta!({
+      all: [
+        { id: "u2", name: "Bob" },
+        { id: "u4", name: "Dave" },
+      ],
+      delta: [
+        { kind: 1, id: "u1", index: 0 },
+        { kind: 1, id: "u3", index: 2 },
+      ],
+    });
+
+    expect(result!.value).toHaveLength(2);
+    expect(result!.value![0]).toBe(bobRef); // bob preserved
+    expect(result!.value![1]).toBe(daveRef); // dave preserved
+
+    scope.stop();
+  });
+
+  it("VU-ALL-10: updated item changes position, array reorders correctly", () => {
+    //  Before: [alice, bob, carol]
+    //  Delta:  alice updated and moved to end (e.g. sort order changed)
+    //  After:  [bob, carol, alice']
+    const alice = { id: "u1", name: "Alice", score: 10 };
+    const bob = { id: "u2", name: "Bob", score: 20 };
+    const carol = { id: "u3", name: "Carol", score: 30 };
+    let capturedOnDelta: ((delta: any) => void) | undefined;
+
+    mocks.getCacheEntry.mockReturnValue({
+      state: { status: "fulfilled" as const, data: [alice, bob, carol] },
+      subscribe: (callbacks: any) => {
+        capturedOnDelta = callbacks.onDelta;
+        return vi.fn();
+      },
+    } as any);
+
+    const scope = effectScope();
+    const result = scope.run(() => useAll(makeQuery()));
+
+    const aliceRef = result!.value![0];
+    const bobRef = result!.value![1];
+    const carolRef = result!.value![2];
+
+    // Alice's score changed, causing her to sort to the end
+    capturedOnDelta!({
+      all: [
+        { id: "u2", name: "Bob", score: 20 },
+        { id: "u3", name: "Carol", score: 30 },
+        { id: "u1", name: "Alice", score: 5 },
+      ],
+      delta: [{ kind: 2, id: "u1", index: 2, item: { id: "u1", name: "Alice", score: 5 } }],
+    });
+
+    expect(result!.value).toHaveLength(3);
+    expect(result!.value![0]).toBe(bobRef); // bob kept position
+    expect(result!.value![1]).toBe(carolRef); // carol kept position
+    expect(result!.value![2]).toBe(aliceRef); // alice moved, identity preserved
+    expect((result!.value![2] as any).score).toBe(5); // property updated
+
+    scope.stop();
+  });
 });

--- a/packages/jazz-tools/src/vue/use-all.test.ts
+++ b/packages/jazz-tools/src/vue/use-all.test.ts
@@ -124,4 +124,37 @@ describe("vue/useAll", () => {
     expect(result!.value).toBeUndefined();
     scope.stop();
   });
+
+  it("VU-ALL-07: onDelta reconciles in-place, preserving object identity", () => {
+    const alice = { id: "u1", name: "Alice", role: "admin" };
+    let capturedOnDelta: ((delta: any) => void) | undefined;
+
+    mocks.getCacheEntry.mockReturnValue({
+      state: { status: "fulfilled" as const, data: [alice] },
+      subscribe: (callbacks: any) => {
+        capturedOnDelta = callbacks.onDelta;
+        return vi.fn();
+      },
+    } as any);
+
+    const scope = effectScope();
+    const result = scope.run(() => useAll(makeQuery()));
+
+    // Initial state from cache
+    expect(result!.value).toHaveLength(1);
+    const originalRef = result!.value![0];
+
+    // Simulate a delta — role changed, name unchanged
+    capturedOnDelta!({
+      all: [{ id: "u1", name: "Alice", role: "editor" }],
+      delta: [{ kind: 2, id: "u1", index: 0, item: { id: "u1", name: "Alice", role: "editor" } }],
+    });
+
+    expect(result!.value).toHaveLength(1);
+    expect(result!.value![0]).toBe(originalRef); // same object reference
+    expect(result!.value![0].role).toBe("editor"); // updated value
+    expect(result!.value![0].name).toBe("Alice"); // unchanged
+
+    scope.stop();
+  });
 });

--- a/packages/jazz-tools/src/vue/use-all.test.ts
+++ b/packages/jazz-tools/src/vue/use-all.test.ts
@@ -152,8 +152,8 @@ describe("vue/useAll", () => {
 
     expect(result!.value).toHaveLength(1);
     expect(result!.value![0]).toBe(originalRef); // same object reference
-    expect(result!.value![0].role).toBe("editor"); // updated value
-    expect(result!.value![0].name).toBe("Alice"); // unchanged
+    expect((result!.value![0] as any).role).toBe("editor"); // updated value
+    expect((result!.value![0] as any).name).toBe("Alice"); // unchanged
 
     scope.stop();
   });

--- a/packages/jazz-tools/src/vue/use-all.ts
+++ b/packages/jazz-tools/src/vue/use-all.ts
@@ -1,12 +1,13 @@
-import { shallowRef, toValue, watchEffect, type MaybeRefOrGetter, type ShallowRef } from "vue";
+import { ref, toValue, watchEffect, type MaybeRefOrGetter, type Ref } from "vue";
 import type { QueryBuilder, QueryOptions } from "../runtime/db.js";
 import type { SubscriptionDelta } from "../runtime/subscription-manager.js";
+import { reconcileArray } from "../reconcile-array.js";
 import type { CacheEntryHandle, UseAllState } from "../subscriptions-orchestrator.js";
 import { useJazzClient } from "./provider.js";
 
 function applyEntryState<T extends { id: string }>(
   state: UseAllState<T>,
-  data: ShallowRef<T[] | undefined>,
+  data: Ref<T[] | undefined>,
 ): void {
   if (state.status === "fulfilled") {
     data.value = state.data;
@@ -17,7 +18,7 @@ function applyEntryState<T extends { id: string }>(
 
 function subscribeToEntry<T extends { id: string }>(
   entry: CacheEntryHandle<T>,
-  data: ShallowRef<T[] | undefined>,
+  data: Ref<T[] | undefined>,
 ): () => void {
   applyEntryState(entry.state, data);
 
@@ -26,7 +27,11 @@ function subscribeToEntry<T extends { id: string }>(
       data.value = nextData;
     },
     onDelta: (delta: SubscriptionDelta<T>) => {
-      data.value = delta.all;
+      if (data.value) {
+        reconcileArray(data.value, delta.all);
+      } else {
+        data.value = delta.all;
+      }
     },
     onError: () => {
       data.value = undefined;
@@ -37,9 +42,9 @@ function subscribeToEntry<T extends { id: string }>(
 export function useAll<T extends { id: string }>(
   query: MaybeRefOrGetter<QueryBuilder<T>>,
   options?: MaybeRefOrGetter<QueryOptions | undefined>,
-): ShallowRef<T[] | undefined> {
+): Ref<T[] | undefined> {
   const { manager } = useJazzClient();
-  const data = shallowRef<T[] | undefined>(undefined);
+  const data = ref<T[] | undefined>(undefined) as Ref<T[] | undefined>;
 
   watchEffect((onCleanup) => {
     const resolvedQuery = toValue(query);

--- a/packages/jazz-tools/src/vue/use-all.ts
+++ b/packages/jazz-tools/src/vue/use-all.ts
@@ -1,7 +1,7 @@
 import { ref, toValue, watchEffect, type MaybeRefOrGetter, type Ref } from "vue";
 import type { QueryBuilder, QueryOptions } from "../runtime/db.js";
 import type { SubscriptionDelta } from "../runtime/subscription-manager.js";
-import { reconcileArray } from "../reconcile-array.js";
+import { applyDelta } from "../reconcile-array.js";
 import type { CacheEntryHandle, UseAllState } from "../subscriptions-orchestrator.js";
 import { useJazzClient } from "./provider.js";
 
@@ -28,7 +28,7 @@ function subscribeToEntry<T extends { id: string }>(
     },
     onDelta: (delta: SubscriptionDelta<T>) => {
       if (data.value) {
-        reconcileArray(data.value, delta.all);
+        applyDelta(data.value, delta);
       } else {
         data.value = delta.all;
       }

--- a/packages/jazz-tools/tsconfig.json
+++ b/packages/jazz-tools/tsconfig.json
@@ -16,5 +16,10 @@
     "types": ["node"]
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": [
+    "node_modules",
+    "dist",
+    "src/**/*.svelte.test.ts",
+    "src/svelte/test-helpers.svelte.ts"
+  ]
 }

--- a/packages/jazz-tools/tsconfig.tests.json
+++ b/packages/jazz-tools/tsconfig.tests.json
@@ -15,5 +15,10 @@
     }
   },
   "include": ["src/**/*", "tests/ts-dsl/**/*.ts"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": [
+    "node_modules",
+    "dist",
+    "src/**/*.svelte.test.ts",
+    "src/svelte/test-helpers.svelte.ts"
+  ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,7 +56,7 @@ importers:
         version: 0.83.3
       next:
         specifier: 16.1.6
-        version: 16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 16.1.6(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       oxfmt:
         specifier: ^0.27.0
         version: 0.27.0
@@ -170,19 +170,19 @@ importers:
     dependencies:
       fumadocs-core:
         specifier: 16.6.2
-        version: 16.6.2(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.563.0(react@19.2.4))(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-router@7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(zod@4.3.6)
+        version: 16.6.2(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.563.0(react@19.2.4))(next@16.1.6(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-router@7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(zod@4.3.6)
       fumadocs-mdx:
         specifier: 14.2.7
-        version: 14.2.7(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.14)(fumadocs-core@16.6.2(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.563.0(react@19.2.4))(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-router@7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(zod@4.3.6))(mdast-util-mdx-jsx@3.2.0)(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 14.2.7(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.14)(fumadocs-core@16.6.2(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.563.0(react@19.2.4))(next@16.1.6(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-router@7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(zod@4.3.6))(mdast-util-mdx-jsx@3.2.0)(next@16.1.6(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       fumadocs-ui:
         specifier: 16.6.2
-        version: 16.6.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.6.2(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.563.0(react@19.2.4))(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-router@7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(zod@4.3.6))(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.2.1)
+        version: 16.6.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.6.2(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.563.0(react@19.2.4))(next@16.1.6(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-router@7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(zod@4.3.6))(next@16.1.6(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.2.1)
       lucide-react:
         specifier: ^0.563.0
         version: 0.563.0(react@19.2.4)
       next:
         specifier: 16.1.6
-        version: 16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 16.1.6(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react:
         specifier: 19.2.4
         version: 19.2.4
@@ -222,13 +222,13 @@ importers:
     dependencies:
       better-auth:
         specifier: ^1.5.5
-        version: 1.5.6(@opentelemetry/api@1.9.0)(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.6)(vitest@4.1.0)(vue@3.5.29(typescript@6.0.2))
+        version: 1.5.6(@opentelemetry/api@1.9.1)(next@16.1.6(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.6)(vitest@4.1.0)(vue@3.5.29(typescript@6.0.2))
       jazz-tools:
         specifier: workspace:*
         version: link:../../packages/jazz-tools
       next:
         specifier: 16.1.6
-        version: 16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 16.1.6(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react:
         specifier: 19.2.4
         version: 19.2.4
@@ -302,7 +302,7 @@ importers:
     dependencies:
       '@workos-inc/authkit-react':
         specifier: ^0.16.0
-        version: 0.16.0(react@19.2.4)
+        version: 0.16.1(react@19.2.4)
       express:
         specifier: ^4.18.2
         version: 4.22.1
@@ -478,7 +478,7 @@ importers:
         version: 3.6.0(vite@6.4.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       vitest:
         specifier: catalog:default
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.3.3)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@6.4.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.3.3)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@6.4.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   examples/docs/todo-client-localfirst-expo:
     dependencies:
@@ -555,7 +555,7 @@ importers:
         version: 3.6.0(vite@8.0.1(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       vitest:
         specifier: catalog:default
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.3.3)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.1(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.3.3)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.1(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   examples/docs/todo-client-localfirst-svelte:
     dependencies:
@@ -577,7 +577,7 @@ importers:
         version: 8.0.1(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       vitest:
         specifier: catalog:default
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.3.3)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.1(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.3.3)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.1(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   examples/docs/todo-client-localfirst-ts:
     dependencies:
@@ -605,7 +605,7 @@ importers:
         version: 3.6.0(vite@8.0.1(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       vitest:
         specifier: catalog:default
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.3.3)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.1(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.3.3)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.1(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   examples/docs/todo-client-localfirst-vue:
     dependencies:
@@ -652,7 +652,7 @@ importers:
         version: 6.0.2
       vitest:
         specifier: catalog:default
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@20.19.35)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.1(@types/node@20.19.35)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@20.19.35)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.1(@types/node@20.19.35)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   examples/file-upload-react:
     dependencies:
@@ -683,7 +683,7 @@ importers:
         version: 8.0.1(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       vitest:
         specifier: catalog:default
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.3.3)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.1(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.3.3)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.1(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   examples/todo-client-localfirst-expo:
     dependencies:
@@ -757,7 +757,7 @@ importers:
         version: 3.6.0(vite@8.0.1(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       vitest:
         specifier: catalog:default
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.3.3)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.1(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.3.3)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.1(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   examples/todo-client-localfirst-svelte:
     dependencies:
@@ -791,7 +791,7 @@ importers:
         version: 3.6.0(vite@8.0.1(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       vitest:
         specifier: catalog:default
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.3.3)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.1(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.3.3)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.1(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   examples/todo-client-localfirst-ts:
     dependencies:
@@ -819,7 +819,7 @@ importers:
         version: 3.6.0(vite@8.0.1(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       vitest:
         specifier: catalog:default
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.3.3)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.1(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.3.3)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.1(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   examples/todo-server-ts:
     dependencies:
@@ -847,7 +847,7 @@ importers:
         version: 6.0.2
       vitest:
         specifier: catalog:default
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@20.19.35)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.1(@types/node@20.19.35)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@20.19.35)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.1(@types/node@20.19.35)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   examples/wequencer:
     dependencies:
@@ -890,7 +890,7 @@ importers:
         version: 3.6.0(vite@8.0.1(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       vitest:
         specifier: catalog:default
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.3.3)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.1(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.3.3)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.1(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   packages/inspector:
     dependencies:
@@ -954,7 +954,7 @@ importers:
         version: 3.6.0(vite@8.0.1(@types/node@24.11.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       vitest:
         specifier: catalog:default
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.11.0)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.1(@types/node@24.11.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.11.0)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.1(@types/node@24.11.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   packages/jazz-tools:
     dependencies:
@@ -1033,7 +1033,7 @@ importers:
         version: 3.6.0(vite@8.0.1(@types/node@22.19.13)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       vitest:
         specifier: catalog:default
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.13)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@26.1.0)(vite@8.0.1(@types/node@22.19.13)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.19.13)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@26.1.0)(vite@8.0.1(@types/node@22.19.13)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       vue:
         specifier: ^3.5.22
         version: 3.5.29(typescript@6.0.2)
@@ -1120,7 +1120,7 @@ importers:
         version: 3.6.0(vite@8.0.1(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       vitest:
         specifier: catalog:default
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.3.3)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.1(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.3.3)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.1(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
 packages:
 
@@ -3826,8 +3826,8 @@ packages:
   '@octokit/types@16.0.0':
     resolution: {integrity: sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==}
 
-  '@opentelemetry/api@1.9.0':
-    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
     engines: {node: '>=8.0.0'}
 
   '@opentelemetry/semantic-conventions@1.40.0':
@@ -5598,11 +5598,11 @@ packages:
   '@vue/shared@3.5.29':
     resolution: {integrity: sha512-w7SR0A5zyRByL9XUkCfdLs7t9XOHUyJ67qPGQjOou3p6GvBeBW+AVjUUmlxtZ4PIYaRvE+1LmK44O4uajlZwcg==}
 
-  '@workos-inc/authkit-js@0.19.0':
-    resolution: {integrity: sha512-/nyj2PrsV/dYJgtN+EBfKH8LUGeAXouH8nOOX/ybWe4i6yYacW3Txafbh35Ik7ze6rWbo7+ilVIURd14Ne/kCA==}
+  '@workos-inc/authkit-js@0.20.0':
+    resolution: {integrity: sha512-8+sw8eH1+XCt3NDoIB2bKKbHvq1N7CVFJeyq1uVrUWG83GCIbNNrFwWrocVNfeQJyhKsVVuDpRcp03iSVsK5Gg==}
 
-  '@workos-inc/authkit-react@0.16.0':
-    resolution: {integrity: sha512-627CH9a8hqm1eHP0/8BOqUyTTqy3oPgB8+9dsU/SIRjfxQyCQAGjDmOiET/svBJgrkGW8cRfn8KECLV6b20Pqg==}
+  '@workos-inc/authkit-react@0.16.1':
+    resolution: {integrity: sha512-u8IJsAAyZFFM02+3JhvvNTopSNQoJk/hjOoBlmOkh6j+AnVYrR8hjzJn8j3m9Vi5tRE0il7mpsEDT9fI2xRNjg==}
     peerDependencies:
       react: 19.2.4
 
@@ -12187,11 +12187,11 @@ snapshots:
 
   '@bcoe/v8-coverage@0.2.3': {}
 
-  '@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0)':
+  '@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0)':
     dependencies:
       '@better-auth/utils': 0.3.1
       '@better-fetch/fetch': 1.1.21
-      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.40.0
       '@standard-schema/spec': 1.1.0
       better-call: 1.3.2(zod@4.3.6)
@@ -12200,36 +12200,36 @@ snapshots:
       nanostores: 1.2.0
       zod: 4.3.6
 
-  '@better-auth/drizzle-adapter@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.3.1)':
+  '@better-auth/drizzle-adapter@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.3.1)':
     dependencies:
-      '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0)
+      '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0)
       '@better-auth/utils': 0.3.1
 
-  '@better-auth/kysely-adapter@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(kysely@0.28.14)':
+  '@better-auth/kysely-adapter@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(kysely@0.28.14)':
     dependencies:
-      '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0)
+      '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0)
       '@better-auth/utils': 0.3.1
     optionalDependencies:
       kysely: 0.28.14
 
-  '@better-auth/memory-adapter@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.3.1)':
+  '@better-auth/memory-adapter@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.3.1)':
     dependencies:
-      '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0)
+      '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0)
       '@better-auth/utils': 0.3.1
 
-  '@better-auth/mongo-adapter@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.3.1)':
+  '@better-auth/mongo-adapter@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.3.1)':
     dependencies:
-      '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0)
+      '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0)
       '@better-auth/utils': 0.3.1
 
-  '@better-auth/prisma-adapter@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.3.1)':
+  '@better-auth/prisma-adapter@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.3.1)':
     dependencies:
-      '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0)
+      '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0)
       '@better-auth/utils': 0.3.1
 
-  '@better-auth/telemetry@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))':
+  '@better-auth/telemetry@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))':
     dependencies:
-      '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0)
+      '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0)
       '@better-auth/utils': 0.3.1
       '@better-fetch/fetch': 1.1.21
 
@@ -14149,7 +14149,7 @@ snapshots:
     dependencies:
       '@octokit/openapi-types': 27.0.0
 
-  '@opentelemetry/api@1.9.0': {}
+  '@opentelemetry/api@1.9.1': {}
 
   '@opentelemetry/semantic-conventions@1.40.0': {}
 
@@ -15919,7 +15919,7 @@ snapshots:
       '@vitest/mocker': 4.1.0(vite@6.4.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       playwright: 1.58.2
       tinyrainbow: 3.0.3
-      vitest: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.3.3)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@6.4.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      vitest: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.3.3)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@6.4.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -15932,7 +15932,7 @@ snapshots:
       '@vitest/mocker': 4.1.0(vite@8.0.1(@types/node@20.19.35)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       playwright: 1.58.2
       tinyrainbow: 3.0.3
-      vitest: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@20.19.35)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.1(@types/node@20.19.35)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      vitest: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@20.19.35)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.1(@types/node@20.19.35)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -15946,7 +15946,7 @@ snapshots:
       '@vitest/mocker': 4.1.0(vite@8.0.1(@types/node@22.19.13)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       playwright: 1.58.2
       tinyrainbow: 3.0.3
-      vitest: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.13)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@26.1.0)(vite@8.0.1(@types/node@22.19.13)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      vitest: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.19.13)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@26.1.0)(vite@8.0.1(@types/node@22.19.13)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -15959,7 +15959,7 @@ snapshots:
       '@vitest/mocker': 4.1.0(vite@8.0.1(@types/node@24.11.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       playwright: 1.58.2
       tinyrainbow: 3.0.3
-      vitest: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.11.0)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.1(@types/node@24.11.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      vitest: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.11.0)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.1(@types/node@24.11.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -15973,7 +15973,7 @@ snapshots:
       '@vitest/mocker': 4.1.0(vite@8.0.1(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       playwright: 1.58.2
       tinyrainbow: 3.0.3
-      vitest: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.3.3)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.1(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      vitest: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.3.3)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.1(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -15989,7 +15989,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.0.3
-      vitest: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.3.3)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@6.4.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      vitest: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.3.3)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@6.4.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       ws: 8.19.0
     transitivePeerDependencies:
       - bufferutil
@@ -16006,7 +16006,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.0.3
-      vitest: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@20.19.35)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.1(@types/node@20.19.35)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      vitest: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@20.19.35)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.1(@types/node@20.19.35)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       ws: 8.19.0
     transitivePeerDependencies:
       - bufferutil
@@ -16024,7 +16024,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.0.3
-      vitest: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.13)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@26.1.0)(vite@8.0.1(@types/node@22.19.13)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      vitest: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.19.13)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@26.1.0)(vite@8.0.1(@types/node@22.19.13)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       ws: 8.19.0
     transitivePeerDependencies:
       - bufferutil
@@ -16041,7 +16041,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.0.3
-      vitest: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.11.0)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.1(@types/node@24.11.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      vitest: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.11.0)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.1(@types/node@24.11.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       ws: 8.19.0
     transitivePeerDependencies:
       - bufferutil
@@ -16059,7 +16059,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.0.3
-      vitest: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.3.3)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.1(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      vitest: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.3.3)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.1(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       ws: 8.19.0
     transitivePeerDependencies:
       - bufferutil
@@ -16143,7 +16143,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vitest: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@20.19.35)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.1(@types/node@20.19.35)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      vitest: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@20.19.35)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.1(@types/node@20.19.35)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   '@vitest/utils@4.1.0':
     dependencies:
@@ -16207,11 +16207,11 @@ snapshots:
 
   '@vue/shared@3.5.29': {}
 
-  '@workos-inc/authkit-js@0.19.0': {}
+  '@workos-inc/authkit-js@0.20.0': {}
 
-  '@workos-inc/authkit-react@0.16.0(react@19.2.4)':
+  '@workos-inc/authkit-react@0.16.1(react@19.2.4)':
     dependencies:
-      '@workos-inc/authkit-js': 0.19.0
+      '@workos-inc/authkit-js': 0.20.0
       react: 19.2.4
 
   '@xmldom/xmldom@0.8.11': {}
@@ -16616,15 +16616,15 @@ snapshots:
 
   before-after-hook@4.0.0: {}
 
-  better-auth@1.5.6(@opentelemetry/api@1.9.0)(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.6)(vitest@4.1.0)(vue@3.5.29(typescript@6.0.2)):
+  better-auth@1.5.6(@opentelemetry/api@1.9.1)(next@16.1.6(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.6)(vitest@4.1.0)(vue@3.5.29(typescript@6.0.2)):
     dependencies:
-      '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0)
-      '@better-auth/drizzle-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.3.1)
-      '@better-auth/kysely-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(kysely@0.28.14)
-      '@better-auth/memory-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.3.1)
-      '@better-auth/mongo-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.3.1)
-      '@better-auth/prisma-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.3.1)
-      '@better-auth/telemetry': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))
+      '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0)
+      '@better-auth/drizzle-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.3.1)
+      '@better-auth/kysely-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(kysely@0.28.14)
+      '@better-auth/memory-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.3.1)
+      '@better-auth/mongo-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.3.1)
+      '@better-auth/prisma-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.3.1)
+      '@better-auth/telemetry': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))
       '@better-auth/utils': 0.3.1
       '@better-fetch/fetch': 1.1.21
       '@noble/ciphers': 2.1.1
@@ -16636,11 +16636,11 @@ snapshots:
       nanostores: 1.2.0
       zod: 4.3.6
     optionalDependencies:
-      next: 16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.1.6(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       svelte: 5.53.6
-      vitest: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@20.19.35)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.1(@types/node@20.19.35)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      vitest: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@20.19.35)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.1(@types/node@20.19.35)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       vue: 3.5.29(typescript@6.0.2)
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
@@ -18157,7 +18157,7 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
-  fumadocs-core@16.6.2(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.563.0(react@19.2.4))(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-router@7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(zod@4.3.6):
+  fumadocs-core@16.6.2(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.563.0(react@19.2.4))(next@16.1.6(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-router@7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(zod@4.3.6):
     dependencies:
       '@formatjs/intl-localematcher': 0.8.1
       '@orama/orama': 3.1.18
@@ -18189,7 +18189,7 @@ snapshots:
       '@types/mdast': 4.0.4
       '@types/react': 19.2.14
       lucide-react: 0.563.0(react@19.2.4)
-      next: 16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.1.6(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       react-router: 7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -18197,14 +18197,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-mdx@14.2.7(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.14)(fumadocs-core@16.6.2(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.563.0(react@19.2.4))(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-router@7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(zod@4.3.6))(mdast-util-mdx-jsx@3.2.0)(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
+  fumadocs-mdx@14.2.7(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.14)(fumadocs-core@16.6.2(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.563.0(react@19.2.4))(next@16.1.6(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-router@7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(zod@4.3.6))(mdast-util-mdx-jsx@3.2.0)(next@16.1.6(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@standard-schema/spec': 1.1.0
       chokidar: 5.0.0
       esbuild: 0.27.3
       estree-util-value-to-estree: 3.5.0
-      fumadocs-core: 16.6.2(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.563.0(react@19.2.4))(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-router@7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(zod@4.3.6)
+      fumadocs-core: 16.6.2(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.563.0(react@19.2.4))(next@16.1.6(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-router@7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(zod@4.3.6)
       js-yaml: 4.1.1
       mdast-util-to-markdown: 2.1.2
       picocolors: 1.1.1
@@ -18222,13 +18222,13 @@ snapshots:
       '@types/mdx': 2.0.13
       '@types/react': 19.2.14
       mdast-util-mdx-jsx: 3.2.0
-      next: 16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.1.6(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
       vite: 7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-ui@16.6.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.6.2(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.563.0(react@19.2.4))(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-router@7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(zod@4.3.6))(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.2.1):
+  fumadocs-ui@16.6.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.6.2(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.563.0(react@19.2.4))(next@16.1.6(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-router@7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(zod@4.3.6))(next@16.1.6(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.2.1):
     dependencies:
       '@fumadocs/tailwind': 0.0.2(tailwindcss@4.2.1)
       '@radix-ui/react-accordion': 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -18242,7 +18242,7 @@ snapshots:
       '@radix-ui/react-slot': 1.2.4(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/react-tabs': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       class-variance-authority: 0.7.1
-      fumadocs-core: 16.6.2(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.563.0(react@19.2.4))(next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-router@7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(zod@4.3.6)
+      fumadocs-core: 16.6.2(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.563.0(react@19.2.4))(next@16.1.6(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-router@7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(zod@4.3.6)
       lucide-react: 0.563.0(react@19.2.4)
       motion: 12.34.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-themes: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -18256,7 +18256,7 @@ snapshots:
       unist-util-visit: 5.1.0
     optionalDependencies:
       '@types/react': 19.2.14
-      next: 16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.1.6(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
       - '@types/react-dom'
@@ -20646,7 +20646,7 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  next@16.1.6(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@next/env': 16.1.6
       '@swc/helpers': 0.5.15
@@ -20665,7 +20665,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.1.6
       '@next/swc-win32-arm64-msvc': 16.1.6
       '@next/swc-win32-x64-msvc': 16.1.6
-      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api': 1.9.1
       '@playwright/test': 1.58.2
       babel-plugin-react-compiler: 1.0.0
       sharp: 0.34.5
@@ -22850,7 +22850,7 @@ snapshots:
     optionalDependencies:
       vite: 8.0.1(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
-  vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@20.19.35)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.1(@types/node@20.19.35)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
+  vitest@4.1.0(@opentelemetry/api@1.9.1)(@types/node@20.19.35)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.1(@types/node@20.19.35)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       '@vitest/expect': 4.1.0
       '@vitest/mocker': 4.1.0(vite@8.0.1(@types/node@20.19.35)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
@@ -22873,7 +22873,7 @@ snapshots:
       vite: 8.0.1(@types/node@20.19.35)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api': 1.9.1
       '@types/node': 20.19.35
       '@vitest/browser-playwright': 4.1.0(playwright@1.58.2)(vite@8.0.1(@types/node@20.19.35)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.1.0)
       '@vitest/ui': 4.1.0(vitest@4.1.0)
@@ -22882,7 +22882,7 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.13)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@26.1.0)(vite@8.0.1(@types/node@22.19.13)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
+  vitest@4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.19.13)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@26.1.0)(vite@8.0.1(@types/node@22.19.13)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       '@vitest/expect': 4.1.0
       '@vitest/mocker': 4.1.0(vite@8.0.1(@types/node@22.19.13)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
@@ -22905,7 +22905,7 @@ snapshots:
       vite: 8.0.1(@types/node@22.19.13)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api': 1.9.1
       '@types/node': 22.19.13
       '@vitest/browser-playwright': 4.1.0(playwright@1.58.2)(vite@8.0.1(@types/node@22.19.13)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.1.0)
       '@vitest/ui': 4.1.0(vitest@4.1.0)
@@ -22914,7 +22914,7 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.11.0)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.1(@types/node@24.11.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
+  vitest@4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.11.0)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.1(@types/node@24.11.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       '@vitest/expect': 4.1.0
       '@vitest/mocker': 4.1.0(vite@8.0.1(@types/node@24.11.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
@@ -22937,7 +22937,7 @@ snapshots:
       vite: 8.0.1(@types/node@24.11.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api': 1.9.1
       '@types/node': 24.11.0
       '@vitest/browser-playwright': 4.1.0(playwright@1.58.2)(vite@8.0.1(@types/node@24.11.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.1.0)
       '@vitest/ui': 4.1.0(vitest@4.1.0)
@@ -22946,7 +22946,7 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.3.3)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@6.4.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
+  vitest@4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.3.3)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@6.4.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       '@vitest/expect': 4.1.0
       '@vitest/mocker': 4.1.0(vite@6.4.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
@@ -22969,7 +22969,7 @@ snapshots:
       vite: 6.4.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api': 1.9.1
       '@types/node': 25.3.3
       '@vitest/browser-playwright': 4.1.0(playwright@1.58.2)(vite@6.4.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.1.0)
       '@vitest/ui': 4.1.0(vitest@4.1.0)
@@ -22978,7 +22978,7 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.3.3)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.1(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
+  vitest@4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.3.3)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.1(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       '@vitest/expect': 4.1.0
       '@vitest/mocker': 4.1.0(vite@8.0.1(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
@@ -23001,7 +23001,7 @@ snapshots:
       vite: 8.0.1(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api': 1.9.1
       '@types/node': 25.3.3
       '@vitest/browser-playwright': 4.1.0(playwright@1.58.2)(vite@8.0.1(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.1.0)
       '@vitest/ui': 4.1.0(vitest@4.1.0)


### PR DESCRIPTION
## Summary
Adds a `reconcileArray` utility that diffs keyed arrays in-place, matching by `id`, deep-merging changed properties, preserving object identity, and wires it into Svelte and Vue `onDelta` callbacks so reactive proxy systems only trigger signals for properties that actually changed.

- `reconcileArray` utility with `deepMerge`, `valuesEqual`, `isKeyedArray` helpers
- Svelte `QuerySubscription.onDelta` reconciles incrementally instead of replacing the array
- Vue `useAll` `onDelta` does the same
- Unit tests for the utility (identity, reorder, nested arrays, Date/Uint8Array, key deletion)
- Svelte rune tests proving reconciliation works through `$state` proxy with `$effect` observation

## Test plan
- [ ] `pnpm --filter jazz-tools test:svelte` - 20 rune tests pass
- [ ] `npx vitest run --config vitest.config.ts src/reconcile-array.test.ts` - 12 unit tests pass
- [ ] `npx vitest run --config vitest.config.ts src/vue/use-all.test.ts` - 7 vue tests pass