### PR TITLE
Fix inherited write checks on the payload branch

### DIFF
--- a/crates/jazz-tools/src/object_manager/mod.rs
+++ b/crates/jazz-tools/src/object_manager/mod.rs
@@ -6,7 +6,7 @@ use smolset::SmolSet;
 
 use crate::commit::{Commit, CommitId, StoredState};
 use crate::object::{Branch, BranchLoadedState, BranchName, Object, ObjectId};
-use crate::storage::{Storage, StorageError};
+use crate::storage::{LoadedBranch, Storage, StorageError};
 
 /// Unique identifier for a subscription.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -169,6 +169,39 @@ impl ObjectManager {
         id
     }
 
+    fn branch_from_loaded(loaded: LoadedBranch) -> Branch {
+        let mut commits = HashMap::new();
+        // Compute tips correctly: a tip is a commit not referenced
+        // as a parent by any other commit in the branch.
+        let mut all_ids: HashSet<CommitId> = HashSet::new();
+        let mut parent_ids: HashSet<CommitId> = HashSet::new();
+        for commit in &loaded.commits {
+            all_ids.insert(commit.id());
+            for parent in &commit.parents {
+                parent_ids.insert(*parent);
+            }
+        }
+        let mut tips: SmolSet<[CommitId; 2]> = SmolSet::new();
+        for cid in &all_ids {
+            if !parent_ids.contains(cid) {
+                tips.insert(*cid);
+            }
+        }
+        for commit in loaded.commits {
+            commits.insert(commit.id(), commit);
+        }
+        Branch {
+            commits,
+            tips,
+            tails: if loaded.tails.is_empty() {
+                None
+            } else {
+                Some(loaded.tails.into_iter().collect())
+            },
+            loaded_state: BranchLoadedState::AllCommits,
+        }
+    }
+
     /// Get an object by id.
     pub fn get(&self, id: ObjectId) -> Option<&Object> {
         self.objects.get(&id)
@@ -203,53 +236,35 @@ impl ObjectManager {
             });
         }
 
-        let object = self.objects.get_mut(&id)?;
-        for branch_name in branches {
-            let bn = BranchName::new(branch_name);
-            if object.branches.contains_key(&bn) {
-                continue;
-            }
-            if let Ok(Some(loaded)) = storage.load_branch(id, &bn) {
-                let mut commits = HashMap::new();
-                // Compute tips correctly: a tip is a commit not referenced
-                // as a parent by any other commit in the branch.
-                let mut all_ids: HashSet<CommitId> = HashSet::new();
-                let mut parent_ids: HashSet<CommitId> = HashSet::new();
-                for commit in &loaded.commits {
-                    all_ids.insert(commit.id());
-                    for parent in &commit.parents {
-                        parent_ids.insert(*parent);
+        {
+            let object = self.objects.get_mut(&id)?;
+            for branch_name in branches {
+                let bn = BranchName::new(branch_name);
+                if object.branches.contains_key(&bn) {
+                    continue;
+                }
+                match storage.load_branch(id, &bn) {
+                    Ok(Some(loaded)) => {
+                        object.branches.insert(bn, Self::branch_from_loaded(loaded));
+                    }
+                    Ok(None) => {}
+                    Err(err) => {
+                        tracing::warn!(
+                            %id,
+                            branch = %bn,
+                            error = ?err,
+                            "get_or_load: failed to hydrate requested branch"
+                        );
                     }
                 }
-                let mut tips: SmolSet<[CommitId; 2]> = SmolSet::new();
-                for cid in &all_ids {
-                    if !parent_ids.contains(cid) {
-                        tips.insert(*cid);
-                    }
-                }
-                for commit in loaded.commits {
-                    commits.insert(commit.id(), commit);
-                }
-                object.branches.insert(
-                    bn,
-                    Branch {
-                        commits,
-                        tips,
-                        tails: if loaded.tails.is_empty() {
-                            None
-                        } else {
-                            Some(loaded.tails.into_iter().collect())
-                        },
-                        loaded_state: BranchLoadedState::AllCommits,
-                    },
-                );
             }
         }
 
+        let object = self.objects.get(&id)?;
         let branch_count = object.branches.len();
         let commit_count: usize = object.branches.values().map(|b| b.commits.len()).sum();
         tracing::trace!(%id, branch_count, commit_count, "get_or_load: loaded from storage");
-        self.objects.get(&id)
+        Some(object)
     }
 
     /// Get mutable object by id.

--- a/crates/jazz-tools/src/object_manager/tests.rs
+++ b/crates/jazz-tools/src/object_manager/tests.rs
@@ -1005,7 +1005,7 @@ fn get_or_load_computes_correct_tips_for_multi_commit_branch() {
 }
 
 #[test]
-fn get_or_load_hydrates_missing_branches_into_cached_object() {
+fn get_or_load_hydrates_missing_requested_branches_for_cached_objects() {
     let mut io = MemoryStorage::new();
     let author = ObjectId::new();
 
@@ -1017,9 +1017,9 @@ fn get_or_load_hydrates_missing_branches_into_cached_object() {
         mgr.add_commit(
             &mut io,
             oid,
-            "dev-other-main",
+            "draft",
             vec![],
-            b"other".to_vec(),
+            b"draft".to_vec(),
             author,
             None,
         )
@@ -1027,30 +1027,23 @@ fn get_or_load_hydrates_missing_branches_into_cached_object() {
         oid
     };
 
-    let mut mgr2 = ObjectManager::new();
-    let loaded_main = mgr2
-        .get_or_load(object_id, &io, &["main".to_string()])
-        .expect("object should load on main branch");
-    assert!(loaded_main.branches.contains_key(&BranchName::new("main")));
+    let mut mgr = ObjectManager::new();
+    mgr.get_or_load(object_id, &io, &["main".to_string()]);
+
+    let object = mgr.get(object_id).expect("object should be cached");
+    assert!(object.branches.contains_key(&BranchName::new("main")));
     assert!(
-        !loaded_main
-            .branches
-            .contains_key(&BranchName::new("dev-other-main"))
+        !object.branches.contains_key(&BranchName::new("draft")),
+        "setup should start with only the first requested branch cached"
     );
 
-    let loaded_with_fallback = mgr2
-        .get_or_load(object_id, &io, &["dev-other-main".to_string()])
-        .expect("object should load on dev-other-main branch");
+    mgr.get_or_load(object_id, &io, &["draft".to_string()]);
+
+    let object = mgr.get(object_id).expect("object should stay cached");
+    assert!(object.branches.contains_key(&BranchName::new("main")));
     assert!(
-        loaded_with_fallback
-            .branches
-            .contains_key(&BranchName::new("dev-other-main"))
-    );
-    // Main branch was already cached, so it's also returned
-    assert!(
-        loaded_with_fallback
-            .branches
-            .contains_key(&BranchName::new("main"))
+        object.branches.contains_key(&BranchName::new("draft")),
+        "subsequent get_or_load calls should hydrate newly requested branches"
     );
 }
 

--- a/crates/jazz-tools/src/query_manager/manager.rs
+++ b/crates/jazz-tools/src/query_manager/manager.rs
@@ -229,6 +229,8 @@ pub(super) struct PolicyCheckState {
     pub(super) graphs: Vec<PolicyGraph>,
     /// Table name for error messages.
     pub(super) table: TableName,
+    /// Branch the write is being evaluated on.
+    pub(super) branch: BranchName,
     /// The original pending permission check.
     pub(super) pending_check: PendingPermissionCheck,
 }
@@ -1725,6 +1727,7 @@ impl QueryManager {
             policy_checks += 48; // HashMap entry
             policy_checks += state.graphs.len() * 1024; // Rough estimate per PolicyGraph
             policy_checks += state.table.0.len();
+            policy_checks += state.branch.as_str().len();
         }
 
         let total = indices + subscriptions + policy_checks;

--- a/crates/jazz-tools/src/query_manager/rebac_tests.rs
+++ b/crates/jazz-tools/src/query_manager/rebac_tests.rs
@@ -10,7 +10,7 @@ use smallvec::smallvec;
 
 use crate::commit::Commit;
 use crate::metadata::MetadataKey;
-use crate::object::ObjectId;
+use crate::object::{BranchName, ObjectId};
 use crate::storage::MemoryStorage;
 use crate::sync_manager::{
     ClientId, Destination, InboxEntry, ObjectMetadata, QueryId, Source, SyncError, SyncManager,
@@ -183,11 +183,156 @@ fn encode_document(owner_id: &str, title: &str, folder_id: Option<ObjectId>) -> 
     .unwrap()
 }
 
+fn encode_folder(owner_id: &str, name: &str) -> Vec<u8> {
+    let folders_desc = RowDescriptor::new(vec![
+        ColumnDescriptor::new("owner_id", ColumnType::Text),
+        ColumnDescriptor::new("name", ColumnType::Text),
+    ]);
+    encode_row(
+        &folders_desc,
+        &[Value::Text(owner_id.into()), Value::Text(name.into())],
+    )
+    .unwrap()
+}
+
 /// Helper to create a document metadata map
 fn document_metadata() -> std::collections::HashMap<String, String> {
     let mut m = std::collections::HashMap::new();
     m.insert(MetadataKey::Table.to_string(), "documents".to_string());
     m
+}
+
+fn folder_metadata() -> std::collections::HashMap<String, String> {
+    let mut m = std::collections::HashMap::new();
+    m.insert(MetadataKey::Table.to_string(), "folders".to_string());
+    m
+}
+
+fn inherited_insert_schema() -> (Schema, RowDescriptor, SchemaHash) {
+    let mut schema = Schema::new();
+
+    let folders_descriptor = RowDescriptor::new(vec![
+        ColumnDescriptor::new("owner_id", ColumnType::Text),
+        ColumnDescriptor::new("name", ColumnType::Text),
+    ]);
+    let folders_policies = TablePolicies::new()
+        .with_select(PolicyExpr::eq_session("owner_id", vec!["user_id".into()]));
+    schema.insert(
+        TableName::new("folders"),
+        TableSchema::with_policies(folders_descriptor.clone(), folders_policies),
+    );
+
+    let documents_descriptor = RowDescriptor::new(vec![
+        ColumnDescriptor::new("owner_id", ColumnType::Text),
+        ColumnDescriptor::new("title", ColumnType::Text),
+        ColumnDescriptor::new("folder_id", ColumnType::Uuid)
+            .nullable()
+            .references("folders"),
+    ]);
+    let documents_policies = TablePolicies::new().with_insert(PolicyExpr::And(vec![
+        PolicyExpr::eq_session("owner_id", vec!["user_id".into()]),
+        PolicyExpr::Or(vec![
+            PolicyExpr::IsNull {
+                column: "folder_id".into(),
+            },
+            PolicyExpr::inherits(Operation::Select, "folder_id"),
+        ]),
+    ]));
+    schema.insert(
+        TableName::new("documents"),
+        TableSchema::with_policies(documents_descriptor, documents_policies),
+    );
+
+    let schema_hash = SchemaHash::compute(&schema);
+    (schema, folders_descriptor, schema_hash)
+}
+
+fn inherited_insert_branch(schema_hash: SchemaHash) -> String {
+    ComposedBranchName::new("dev", schema_hash, "client-alice-main")
+        .to_branch_name()
+        .as_str()
+        .to_string()
+}
+
+fn create_server_mode_query_manager(schema: Schema, schema_hash: SchemaHash) -> QueryManager {
+    let sync_manager = SyncManager::new();
+    let mut qm = QueryManager::new(sync_manager);
+    qm.schema = Arc::new(schema.clone());
+    let mut known_schemas = HashMap::new();
+    known_schemas.insert(schema_hash, schema);
+    qm.set_known_schemas(Arc::new(known_schemas));
+    qm
+}
+
+fn seed_folder_on_branch(
+    qm: &mut QueryManager,
+    storage: &mut MemoryStorage,
+    branch: &str,
+    owner_id: &str,
+    name: &str,
+    folders_descriptor: &RowDescriptor,
+) -> ObjectId {
+    let folder_id = qm
+        .sync_manager_mut()
+        .object_manager
+        .create(storage, Some(folder_metadata()));
+    let folder_content = encode_folder(owner_id, name);
+    qm.sync_manager_mut()
+        .object_manager
+        .add_commit(
+            storage,
+            folder_id,
+            branch,
+            vec![],
+            folder_content.clone(),
+            ObjectId::new(),
+            None,
+        )
+        .unwrap();
+    QueryManager::update_indices_for_insert_on_branch(
+        storage,
+        "folders",
+        branch,
+        folder_id,
+        &folder_content,
+        folders_descriptor,
+    )
+    .unwrap();
+    folder_id
+}
+
+fn enqueue_inherited_insert(
+    qm: &mut QueryManager,
+    client_id: ClientId,
+    doc_id: ObjectId,
+    branch: &str,
+    folder_id: ObjectId,
+    title: &str,
+) -> Commit {
+    let commit = Commit {
+        parents: smallvec![],
+        content: encode_document("alice", title, Some(folder_id)),
+        timestamp: 1000,
+        author: ObjectId::new(),
+        metadata: None,
+        stored_state: crate::commit::StoredState::Stored,
+        ack_state: Default::default(),
+    };
+
+    qm.sync_manager_mut().push_inbox(InboxEntry {
+        source: Source::Client(client_id),
+        payload: SyncPayload::ObjectUpdated {
+            object_id: doc_id,
+            metadata: Some(ObjectMetadata {
+                id: doc_id,
+                metadata: document_metadata(),
+            }),
+            branch_name: branch.into(),
+            commits: vec![commit.clone()],
+        },
+    });
+
+    commit
 }
 
 fn run_recursive_folder_update(max_depth: Option<usize>) -> (bool, bool) {
@@ -637,6 +782,278 @@ fn rebac_insert_denied_for_new_object_uses_payload_metadata_in_server_mode() {
     assert!(
         tips.is_err() || !tips.unwrap().contains(&commit.id()),
         "Denied insert should not be applied on the branch"
+    );
+}
+
+#[test]
+fn rebac_inherited_insert_uses_payload_branch_for_parent_lookup() {
+    let (schema, folders_descriptor, schema_hash) = inherited_insert_schema();
+    let branch = inherited_insert_branch(schema_hash);
+
+    // Server mode keeps current_branch() at "main", while the write arrives on
+    // a composed client branch. The inherited parent lookup must use payload
+    // branch context, not current_branch().
+    let mut qm = create_server_mode_query_manager(schema, schema_hash);
+
+    assert_ne!(qm.current_branch(), branch);
+
+    let mut storage = MemoryStorage::new();
+    let client_id = ClientId::new();
+    qm.sync_manager_mut().add_client(client_id);
+    qm.sync_manager_mut()
+        .set_client_session(client_id, Session::new("alice"));
+
+    let folder_id = seed_folder_on_branch(
+        &mut qm,
+        &mut storage,
+        &branch,
+        "alice",
+        "Shared Folder",
+        &folders_descriptor,
+    );
+    let doc_id = qm
+        .sync_manager_mut()
+        .object_manager
+        .create(&mut storage, Some(document_metadata()));
+
+    let mut scope = HashSet::new();
+    scope.insert((doc_id, branch.clone().into()));
+    qm.sync_manager_mut()
+        .set_client_query_scope(client_id, QueryId(1), scope, None);
+    qm.sync_manager_mut().take_outbox();
+
+    let commit = enqueue_inherited_insert(
+        &mut qm,
+        client_id,
+        doc_id,
+        &branch,
+        folder_id,
+        "Allowed via folder ownership",
+    );
+
+    for _ in 0..10 {
+        qm.process(&mut storage);
+    }
+
+    let outbox = qm.sync_manager_mut().take_outbox();
+    let denied = outbox.iter().any(|entry| {
+        matches!(
+            (&entry.destination, &entry.payload),
+            (
+                Destination::Client(id),
+                SyncPayload::Error(SyncError::PermissionDenied { .. }),
+            ) if *id == client_id
+        )
+    });
+    assert!(
+        !denied,
+        "Inherited insert should use the payload branch to find the parent folder"
+    );
+
+    let tips = qm
+        .sync_manager_mut()
+        .object_manager
+        .get_tip_ids(doc_id, &branch)
+        .unwrap();
+    assert!(
+        tips.contains(&commit.id()),
+        "Document insert should be applied when the parent folder is visible on the payload branch"
+    );
+}
+
+#[test]
+fn rebac_inherited_insert_uses_payload_branch_after_cold_start() {
+    let (schema, folders_descriptor, schema_hash) = inherited_insert_schema();
+    let branch = inherited_insert_branch(schema_hash);
+    let mut storage = MemoryStorage::new();
+
+    let mut seed_qm = create_server_mode_query_manager(schema.clone(), schema_hash);
+    let folder_id = seed_folder_on_branch(
+        &mut seed_qm,
+        &mut storage,
+        &branch,
+        "alice",
+        "Cold Folder",
+        &folders_descriptor,
+    );
+
+    let mut qm = create_server_mode_query_manager(schema, schema_hash);
+    let client_id = ClientId::new();
+    qm.sync_manager_mut().add_client(client_id);
+    qm.sync_manager_mut()
+        .set_client_session(client_id, Session::new("alice"));
+    qm.sync_manager_mut().take_outbox();
+
+    let doc_id = ObjectId::new();
+    let commit = enqueue_inherited_insert(
+        &mut qm,
+        client_id,
+        doc_id,
+        &branch,
+        folder_id,
+        "Cold-start branch lookup",
+    );
+
+    // Cold start:
+    //   storage: folder exists only on the composed payload branch
+    //   cache:   parent folder is not loaded at all
+    //   write:   document insert must still authorize on that payload branch
+    qm.process(&mut storage);
+
+    let outbox = qm.sync_manager_mut().take_outbox();
+    let denied = outbox.iter().any(|entry| {
+        matches!(
+            (&entry.destination, &entry.payload),
+            (
+                Destination::Client(id),
+                SyncPayload::Error(SyncError::PermissionDenied { .. }),
+            ) if *id == client_id
+        )
+    });
+    assert!(
+        !denied,
+        "Inherited insert should authorize on the payload branch even after a cold start"
+    );
+
+    let cached_folder = qm
+        .sync_manager()
+        .object_manager
+        .get(folder_id)
+        .expect("authorization should hydrate the parent folder");
+    assert!(
+        cached_folder
+            .branches
+            .contains_key(&BranchName::new(&branch)),
+        "authorization should load the parent from the payload branch"
+    );
+
+    let tips = qm
+        .sync_manager_mut()
+        .object_manager
+        .get_tip_ids(doc_id, &branch)
+        .unwrap();
+    assert!(
+        tips.contains(&commit.id()),
+        "Document insert should be applied after settlement loads the parent from storage"
+    );
+}
+
+#[test]
+fn rebac_inherited_insert_hydrates_requested_branch_instead_of_reusing_cached_branch() {
+    let (schema, folders_descriptor, schema_hash) = inherited_insert_schema();
+    let branch = inherited_insert_branch(schema_hash);
+    let mut storage = MemoryStorage::new();
+
+    let mut seed_qm = create_server_mode_query_manager(schema.clone(), schema_hash);
+    let folder_id = seed_folder_on_branch(
+        &mut seed_qm,
+        &mut storage,
+        "main",
+        "bob",
+        "Main Folder",
+        &folders_descriptor,
+    );
+    seed_qm
+        .sync_manager_mut()
+        .object_manager
+        .add_commit(
+            &mut storage,
+            folder_id,
+            &branch,
+            vec![],
+            encode_folder("alice", "Dev Folder"),
+            ObjectId::new(),
+            None,
+        )
+        .unwrap();
+    QueryManager::update_indices_for_insert_on_branch(
+        &mut storage,
+        "folders",
+        &branch,
+        folder_id,
+        &encode_folder("alice", "Dev Folder"),
+        &folders_descriptor,
+    )
+    .unwrap();
+
+    let mut qm = create_server_mode_query_manager(schema, schema_hash);
+    let client_id = ClientId::new();
+    qm.sync_manager_mut().add_client(client_id);
+    qm.sync_manager_mut()
+        .set_client_session(client_id, Session::new("alice"));
+    qm.sync_manager_mut().take_outbox();
+
+    qm.sync_manager_mut()
+        .object_manager
+        .get_or_load(folder_id, &storage, &["main".to_string()]);
+    let cached_folder = qm
+        .sync_manager()
+        .object_manager
+        .get(folder_id)
+        .expect("folder should be cached on main");
+    assert!(
+        cached_folder
+            .branches
+            .contains_key(&BranchName::new("main"))
+    );
+    assert!(
+        !cached_folder
+            .branches
+            .contains_key(&BranchName::new(&branch)),
+        "setup should start with only the unrelated branch cached"
+    );
+
+    let doc_id = ObjectId::new();
+    let commit = enqueue_inherited_insert(
+        &mut qm,
+        client_id,
+        doc_id,
+        &branch,
+        folder_id,
+        "Hydrate branch instead of reusing main",
+    );
+
+    // Wrong-branch cache:
+    //   storage: folder[main] = bob, folder[dev] = alice
+    //   cache:   only folder[main] is loaded before authorization
+    //   write:   document[dev] must hydrate folder[dev], not reuse folder[main]
+    qm.process(&mut storage);
+
+    let outbox = qm.sync_manager_mut().take_outbox();
+    let denied = outbox.iter().any(|entry| {
+        matches!(
+            (&entry.destination, &entry.payload),
+            (
+                Destination::Client(id),
+                SyncPayload::Error(SyncError::PermissionDenied { .. }),
+            ) if *id == client_id
+        )
+    });
+    assert!(
+        !denied,
+        "Inherited insert should hydrate the requested payload branch instead of reusing cached main"
+    );
+
+    let cached_folder = qm
+        .sync_manager()
+        .object_manager
+        .get(folder_id)
+        .expect("folder should remain cached");
+    assert!(
+        cached_folder
+            .branches
+            .contains_key(&BranchName::new(&branch)),
+        "authorization should hydrate the requested branch onto the cached object"
+    );
+
+    let tips = qm
+        .sync_manager_mut()
+        .object_manager
+        .get_tip_ids(doc_id, &branch)
+        .unwrap();
+    assert!(
+        tips.contains(&commit.id()),
+        "Document insert should apply once the requested parent branch is hydrated"
     );
 }
 

--- a/crates/jazz-tools/src/query_manager/server_queries.rs
+++ b/crates/jazz-tools/src/query_manager/server_queries.rs
@@ -1495,9 +1495,9 @@ impl QueryManager {
         descriptor: &RowDescriptor,
         _table: &TableName,
         session: &Session,
+        branch: &str,
     ) -> Vec<PolicyGraph> {
         let mut graphs = Vec::new();
-        let branch = self.current_branch();
 
         for clause in clauses {
             match clause {
@@ -1522,7 +1522,7 @@ impl QueryManager {
                     if super::encoding::column_is_null(descriptor, content, col_idx)
                         .unwrap_or(false)
                     {
-                        continue; // NULL FK passes INHERITS
+                        continue;
                     }
 
                     // Decode the FK value to get parent ObjectId
@@ -1558,7 +1558,7 @@ impl QueryManager {
                         parent_policy,
                         session,
                         &self.schema,
-                        &branch,
+                        branch,
                         1,
                     ) {
                         graphs.push(graph);
@@ -1571,13 +1571,13 @@ impl QueryManager {
                         condition,
                         session,
                         &self.schema,
-                        &branch,
+                        branch,
                     ) {
                         graphs.push(graph);
                     }
                 }
                 ComplexClause::ExistsRel { rel } => {
-                    if let Some(graph) = PolicyGraph::for_exists_rel(rel, &self.schema, &branch) {
+                    if let Some(graph) = PolicyGraph::for_exists_rel(rel, &self.schema, branch) {
                         graphs.push(graph);
                     }
                 }
@@ -1597,27 +1597,25 @@ impl QueryManager {
         let mut to_reject = Vec::new();
 
         // Create row loader for settling
-        let current_branch = self.current_branch();
-        let branches = vec![current_branch.clone()];
         let om = &mut self.sync_manager.object_manager;
         let storage_ref: &dyn Storage = storage;
 
         // Settle each active policy check
         for (pending_id, state) in &mut self.active_policy_checks {
+            let branch = state.branch;
+            let branches = vec![branch.as_str().to_string()];
             let mut row_loader = |id: ObjectId| -> Option<LoadedRow> {
                 let obj = om.get_or_load(id, storage_ref, &branches)?;
-                let branch = obj.branches.get(&BranchName::new(&current_branch))?;
-                let tip_id = branch.tips.iter().next()?;
-                let commit = branch.commits.get(tip_id)?;
+                let branch_state = obj.branches.get(&branch)?;
+                let tip_id = branch_state.tips.iter().next()?;
+                let commit = branch_state.commits.get(tip_id)?;
                 if commit.content.is_empty() {
                     return None;
                 }
                 Some(LoadedRow::new(
                     commit.content.clone(),
                     *tip_id,
-                    [(id, BranchName::new(&current_branch))]
-                        .into_iter()
-                        .collect(),
+                    [(id, branch)].into_iter().collect(),
                 ))
             };
 

--- a/crates/jazz-tools/src/query_manager/writes.rs
+++ b/crates/jazz-tools/src/query_manager/writes.rs
@@ -790,6 +790,7 @@ impl QueryManager {
             descriptor,
             &table_name,
             session,
+            branch,
         );
         if graphs.is_empty() {
             return true;
@@ -798,9 +799,10 @@ impl QueryManager {
         let branches = vec![branch.to_string()];
         let storage_ref: &dyn Storage = storage;
         let om = &mut self.sync_manager.object_manager;
+        let branch_name = BranchName::new(branch);
         let mut row_loader = |id: ObjectId| -> Option<LoadedRow> {
             let obj = om.get_or_load(id, storage_ref, &branches)?;
-            let branch_state = obj.branches.get(&BranchName::new(branch))?;
+            let branch_state = obj.branches.get(&branch_name)?;
             let tip_id = branch_state.tips.iter().next()?;
             let commit = branch_state.commits.get(tip_id)?;
             if commit.content.is_empty() {
@@ -809,7 +811,7 @@ impl QueryManager {
             Some(LoadedRow::new(
                 commit.content.clone(),
                 *tip_id,
-                [(id, BranchName::new(branch))].into_iter().collect(),
+                [(id, branch_name)].into_iter().collect(),
             ))
         };
 


### PR DESCRIPTION
## Summary

Fix server-side inherited write checks so they evaluate against the mutation's actual branch, not `current_branch()`.

## Example
It happened while testing inheritance permission policies. 
Considering the tables:
`folders { title: string; owner_id: session.user_id}`
`documents { title:string, owner_id: session.user_id, folder: ref(folders)}`

A failing case was an insert into `documents` where Alice wrote:

- `owner_id = alice; folder_id = shared_folder`

The policy was valid because the row owner matched the session, and `folder_id` pointed at a folder Alice owned. But the server still rejected the write with `complex policy check failed`.

The reason was that the inherited parent lookup for `folder_id` was being evaluated on the wrong branch. `INHERITS` compiles to a graph that loads the parent row and evaluates its policy; if that graph scans a different branch than the incoming mutation, it can miss the parent row entirely or read stale state and incorrectly deny an otherwise valid write.

## Fix

Thread the payload branch through complex policy evaluation instead of falling back to `current_branch()`:

- use the mutation branch when building policy graphs for `INHERITS` / `EXISTS`
- keep that branch on deferred policy checks so settlement uses the same branch context
- hydrate the requested branch on cached objects, so settlement doesn't accidentally reuse an unrelated already-loaded branch
