### PR TITLE
fix: regenerate lockfile for stress-tests/todo-react typescript 6.0

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -972,7 +972,7 @@ importers:
         version: 4.1.0(playwright@1.58.2)(vite@8.0.1(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.1.0)
       typescript:
         specifier: catalog:default
-        version: 5.9.3
+        version: 6.0.2
       vite:
         specifier: catalog:default
         version: 8.0.1(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)


### PR DESCRIPTION
## Summary

- Fix `ERR_PNPM_LOCKFILE_MISSING_DEPENDENCY: no entry for 'typescript@5.9.3'` breaking CI
- The stress-test-react PR was merged after the TS 6.0 upgrade but its lockfile entry still referenced `typescript@5.9.3` instead of `6.0.2`
- Single-line lockfile fix: `version: 5.9.3` → `version: 6.0.2` for `stress-tests/todo-react`

## Test plan

- [x] `pnpm install --frozen-lockfile` succeeds
- [ ] CI `Setup Source Code` step passes