### PR TITLE
test: stabilize jazz-tools flaky CI timeouts

### DIFF
--- a/packages/jazz-tools/src/cli.test.ts
+++ b/packages/jazz-tools/src/cli.test.ts
@@ -458,7 +458,7 @@ describe("bin integration", () => {
 
     const appTs = await readFile(join(schemaDir, "app.ts"), "utf8");
     expect(appTs).toContain("comments");
-  });
+  }, 15_000);
 
   it("generates migration SQL from stub on rebuild when current.sql already exists", async () => {
     const { schemaDir } = await createWorkspace();

--- a/packages/jazz-tools/src/mcp/build-index.test.ts
+++ b/packages/jazz-tools/src/mcp/build-index.test.ts
@@ -258,7 +258,7 @@ describe("buildIndex", () => {
       contentDir: contentDir(),
       outputDir: outputDir(),
     });
-  }, 10_000);
+  }, 30_000);
 
   afterAll(async () => {
     await cleanupFixtureTree(tmpDir);

--- a/packages/jazz-tools/src/runtime/cloud-server.integration.test.ts
+++ b/packages/jazz-tools/src/runtime/cloud-server.integration.test.ts
@@ -231,9 +231,10 @@ function getFreePort(): Promise<number> {
   });
 }
 
-async function waitForHealth(baseUrl: string): Promise<void> {
+async function waitForHealth(baseUrl: string, timeoutMs = 30_000): Promise<void> {
   const healthUrl = `${baseUrl}/health`;
-  for (let i = 0; i < 100; i++) {
+  const attempts = Math.ceil(timeoutMs / 100);
+  for (let i = 0; i < attempts; i++) {
     try {
       const response = await fetch(healthUrl);
       if (response.ok) return;


### PR DESCRIPTION
## Summary
- increase the timeout for the bin integration test that rebuilds `app.ts` after `current.ts` changes
- give the shared `buildIndex` integration setup more headroom under CI load
- let the cloud-server health check poll for up to 30s so it matches the surrounding integration test budgets

## Design Choices
- keep the fix repo-local and test-only; this PR does not change product behavior
- adjust only the three flaky timing budgets that showed up in CI instead of widening Vitest timeouts globally
- keep the cloud-server helper failure mode intact; it still fails fast when startup never succeeds, it just no longer bails out after 10s when the enclosing test already allows 30s
- no features were added or removed