### PR TITLE
docs: spec planning

### DIFF
--- a/.agents/skills/project/SKILL.md
+++ b/.agents/skills/project/SKILL.md
@@ -3,131 +3,24 @@ name: project
 description: Shape Up spec workflow — use when designing a feature, shaping an idea into a spec, defining a project, writing a pitch, scoping work, or planning what to build. Triggers on "shape", "spec", "pitch", "scope", "design this", "plan this feature", "let's figure out how to build", "project for", "write a spec", or any intent to go from idea to concrete plan.
 ---
 
-# Shape Up Spec Workflow
+# Project / Spec Router
 
-Full design workflow producing shaping documents and a pitch. **No implementation is done here.**
+Before any design work, determine the scope of what's being built.
 
-For quick idea or issue capture, follow the workflows in `AGENTS.md` instead.
+## Step 1: Ask
 
-**After every write to `todo/`**, run `bash scripts/update-todo.sh` to regenerate `TODO.md`.
+> _"Before we start, one question: is this a **spec** (fits in a single PR) or a **project** (needs multiple PRs)?"_
+>
+> - **Spec** — self-contained change, one branch, one review cycle
+> - **Project** — multiple interconnected scopes, each delivered as its own PR
 
-## Directory Structure
+Wait for the user's answer. If unclear, help them decide: "Can the whole thing land in one PR without becoming unwieldy? If yes, spec. If it naturally breaks into independent pieces that each need their own review, project."
 
-```
-todo/projects/{feature-name}/
-├── pitch.md     <- shaped deliverable; input to the betting table
-└── scopes.md    <- created only after pitch approval
-```
+## Step 2: Load the workflow
 
-## Refinement Loop (mandatory before every approval gate)
+Based on the answer, read the corresponding file and follow it:
 
-After creating each document, run at least one refinement round before moving to the approval gate:
+- **Spec** — read `skills/project/spec.md` (in the same directory as this file) and follow it
+- **Project** — read `skills/project/project.md` (in the same directory as this file) and follow it
 
-1. Review the document critically — flag weak sections, vague language, missing pieces
-2. Ask the user targeted questions:
-   > _"This is a first draft. Before we move to approval, I have a few questions to make it more solid: [list]"_
-3. Update the document based on answers
-4. Confirm it's solid, or run another round if still weak
-5. Then present the approval gate
-
-**Never skip the refinement loop.** A document is not ready for approval unless it has been challenged.
-
-## Optional Step Handling
-
-Before any optional step, explicitly ask:
-
-> _"[Step name] is optional. Do you want to include it, or skip to the next step?"_
-
-The user must choose. Never skip silently.
-
----
-
-### Step 1: Create feature directory
-
-Create `todo/projects/{feature-name}/` using kebab-case for the feature name.
-
----
-
-### Step 2: Pitch — `pitch.md` _(required)_
-
-Create at `todo/projects/{feature-name}/pitch.md`. The pitch opens with the problem framing as its first paragraph (no separate problem document). Include:
-
-- **Problem** _(opening paragraph)_ — what's broken or missing, who is affected, concrete examples. This replaces a standalone problem document.
-- **Appetite** _(optional)_ — if the user wants to define a time budget (small batch: 1-2 weeks, big batch: 4-6 weeks), include it after the problem. Ask: _"Do you want to include an appetite (time budget) in the pitch?"_
-- **Solution** — described at the right level of abstraction:
-  - _Breadboards_: text-based UI/flow descriptions — no wireframes needed
-  - _Fat marker sketches_: high-level architecture, data flow, component interactions
-  - Core code snippets following Jazz conventions:
-    - Rust for core logic (`crates/groove`)
-    - TypeScript for client layers (`packages/`)
-    - WASM + NAPI bindings where relevant
-    - SQL (Jazz's custom dialect subset) for relational semantics
-- **Rabbit Holes** — technical risks and what to avoid; **this section cannot be empty**
-- **No-gos** — explicitly out of scope; **this section cannot be empty**
-- **Testing Strategy** — integration-first (SchemaManager, RuntimeCore level), realistic fixtures with human actor names (alice, bob), not mocks
-
-**Refinement loop**: This is the most critical review. Challenge every section:
-
-- "The solution is still too vague — describe what happens step by step when a user does X?"
-- "Rabbit holes only has one item — what else could derail this?"
-- "No-gos is empty — what are we explicitly not doing?"
-- "Does this solution actually fit the appetite, or are we doing too much?"
-- "Are the breadboards concrete enough to build from?"
-- "Would a new team member understand the intended user experience from this pitch alone?"
-- Review to find any gaps or improvement areas. Give the pitch a confidence score from 1 to 10.
-
-**Pitch Approval Gate**
-
-> "The pitch is looking solid. Does it reflect what you want to build? If so, we'll move on to scopes."
-
-Wait for explicit approval before proceeding.
-
----
-
-### Step 3: Scopes — `scopes.md` _(required, created after pitch approval)_
-
-Break work into named, interconnected scopes. Scopes emerge from the solution — they are not a flat numbered task list.
-
-```markdown
-# Scopes
-
-## [Scope Name] — [what it solves]
-
-- [ ] Task
-- [ ] Task
-
-## [Scope Name] — [what it solves]
-
-- [ ] Task
-```
-
-**Refinement loop**: Challenge the scope breakdown:
-
-- "Are these scopes truly independent, or does [A] block [B]?"
-- "This scope looks too large — can it be split?"
-- "Are all tasks in [scope] actually required by the pitch, or is this gold-plating?"
-- "Is there a scope that could be deferred if we run out of time?"
-- Review to find any gaps or improvement areas. Give the document a confidence score from 1 to 10.
-
-**Scopes Approval Gate**
-
-> "The scopes look solid. Do they match what you expected? If so, we're done with planning."
-
-Wait for explicit approval before proceeding.
-
----
-
-### Step 4: Stop
-
-**Do not write any code.** The workflow ends here. Implementation is a separate activity initiated by the user.
-
-### Rules (Spec)
-
-1. Never skip steps (except explicitly optional ones, after asking the user)
-2. Refinement loop is mandatory — at least one round before every approval gate
-3. Optional steps require an explicit choice — ask "include or skip?" before proceeding
-4. Always wait for explicit approval before advancing
-5. No implementation — this workflow is for planning only
-6. Rabbit holes and No-gos sections in `pitch.md` cannot be empty
-7. `scopes.md` is only created after pitch approval
-8. Appetite is a constraint, not an estimate — it shapes what solution is possible
+**Do not proceed without reading the sub-skill file.** The instructions below this point are in those files.

--- a/.agents/skills/project/plan.md
+++ b/.agents/skills/project/plan.md
@@ -1,0 +1,127 @@
+# Plan Workflow
+
+Write a comprehensive implementation plan from an approved spec. The plan assumes the engineer has zero context for the codebase. Document everything: which files to touch, code, testing, how to verify. Bite-sized tasks. TDD. Frequent commits.
+
+**Save to:** `todo/projects/{feature-name}/plan.md`
+
+## Scope Check
+
+The spec should describe a single-PR change. If it covers multiple independent subsystems, suggest breaking into separate plans — one per subsystem. Each plan should produce working, testable software on its own.
+
+## File Structure
+
+Before defining tasks, map out which files will be created or modified and what each one is responsible for. This is where decomposition decisions get locked in.
+
+- Design units with clear boundaries and well-defined interfaces. Each file should have one clear responsibility.
+- Prefer smaller, focused files over large ones that do too much.
+- Files that change together should live together. Split by responsibility, not by technical layer.
+- Follow established patterns in the codebase.
+
+This structure informs the task decomposition. Each task should produce self-contained changes that make sense independently.
+
+## Bite-Sized Task Granularity
+
+**Each step is one action (2-5 minutes):**
+
+- "Write the failing test" — step
+- "Run it to make sure it fails" — step
+- "Implement the minimal code to make the test pass" — step
+- "Run the tests and make sure they pass" — step
+- "Commit" — step
+
+## Plan Document Header
+
+**Every plan MUST start with this header:**
+
+```markdown
+# [Feature Name] Implementation Plan
+
+**Goal:** [One sentence describing what this builds]
+
+**Architecture:** [2-3 sentences about approach]
+
+**Tech Stack:** [Key technologies/libraries]
+
+---
+```
+
+## Task Structure
+
+````markdown
+### Task N: [Component Name]
+
+**Files:**
+
+- Create: `exact/path/to/file`
+- Modify: `exact/path/to/existing:123-145`
+- Test: `tests/exact/path/to/test`
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn test_specific_behavior() {
+    let result = function(input);
+    assert_eq!(result, expected);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test test_specific_behavior`
+Expected: FAIL with "cannot find function"
+
+- [ ] **Step 3: Write minimal implementation**
+
+```rust
+fn function(input: Type) -> Type {
+    expected
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test test_specific_behavior`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add path/to/files
+git commit -m "feat: add specific feature"
+```
+````
+
+## No Placeholders
+
+Every step must contain the actual content an engineer needs. These are **plan failures** — never write them:
+
+- "TBD", "TODO", "implement later", "fill in details"
+- "Add appropriate error handling" / "add validation" / "handle edge cases"
+- "Write tests for the above" (without actual test code)
+- "Similar to Task N" (repeat the code — the engineer may be reading tasks out of order)
+- Steps that describe what to do without showing how (code blocks required for code steps)
+- References to types, functions, or methods not defined in any task
+
+## Remember
+
+- Exact file paths always
+- Complete code in every step — if a step changes code, show the code
+- Exact commands with expected output
+- DRY, YAGNI, TDD, frequent commits
+
+## Self-Review
+
+After writing the complete plan, review it against the spec:
+
+**1. Spec coverage:** Skim each section/requirement in the spec. Can you point to a task that implements it? List any gaps.
+
+**2. Placeholder scan:** Search the plan for red flags — any of the patterns from the "No Placeholders" section above. Fix them.
+
+**3. Type consistency:** Do the types, method signatures, and property names used in later tasks match what was defined in earlier tasks? A function called `clear_layers()` in Task 3 but `clear_full_layers()` in Task 7 is a bug.
+
+Fix issues inline. If a spec requirement has no task, add the task.
+
+## Done
+
+After saving the plan, stop. Implementation is a separate activity initiated by the user.

--- a/.agents/skills/project/project.md
+++ b/.agents/skills/project/project.md
@@ -1,0 +1,130 @@
+# Project Workflow (Multiple PRs)
+
+Full Shape Up workflow for work that spans multiple PRs. Produces a pitch and scopes. **No implementation is done here.**
+
+For quick idea or issue capture, follow the workflows in `AGENTS.md` instead.
+
+**After every write to `todo/`**, run `bash scripts/update-todo.sh` to regenerate `TODO.md`.
+
+## Directory Structure
+
+```
+todo/projects/{feature-name}/
+├── pitch.md     <- shaped deliverable; input to the betting table
+└── scopes.md    <- created only after pitch approval
+```
+
+## Refinement Loop (mandatory before every approval gate)
+
+After creating each document, run at least one refinement round before moving to the approval gate:
+
+1. Review the document critically — flag weak sections, vague language, missing pieces
+2. Ask the user targeted questions:
+   > _"This is a first draft. Before we move to approval, I have a few questions to make it more solid: [list]"_
+3. Update the document based on answers
+4. Confirm it's solid, or run another round if still weak
+5. Then present the approval gate
+
+**Never skip the refinement loop.** A document is not ready for approval unless it has been challenged.
+
+## Optional Step Handling
+
+Before any optional step, explicitly ask:
+
+> _"[Step name] is optional. Do you want to include it, or skip to the next step?"_
+
+The user must choose. Never skip silently.
+
+---
+
+### Step 1: Create feature directory
+
+Create `todo/projects/{feature-name}/` using kebab-case for the feature name.
+
+---
+
+### Step 2: Pitch — `pitch.md` _(required)_
+
+Create at `todo/projects/{feature-name}/pitch.md`. The pitch opens with the problem framing as its first paragraph (no separate problem document). Include:
+
+- **Problem** _(opening paragraph)_ — what's broken or missing, who is affected, concrete examples. This replaces a standalone problem document.
+- **Appetite** _(optional)_ — if the user wants to define a time budget (small batch: 1-2 weeks, big batch: 4-6 weeks), include it after the problem. Ask: _"Do you want to include an appetite (time budget) in the pitch?"_
+- **Solution** — described at the right level of abstraction:
+  - _Breadboards_: text-based UI/flow descriptions — no wireframes needed
+  - _Fat marker sketches_: high-level architecture, data flow, component interactions
+  - Core code snippets following Jazz conventions:
+    - Rust for core logic (`crates/groove`)
+    - TypeScript for client layers (`packages/`)
+    - WASM + NAPI bindings where relevant
+    - SQL (Jazz's custom dialect subset) for relational semantics
+- **Rabbit Holes** — technical risks and what to avoid; **this section cannot be empty**
+- **No-gos** — explicitly out of scope; **this section cannot be empty**
+- **Testing Strategy** — integration-first (SchemaManager, RuntimeCore level), realistic fixtures with human actor names (alice, bob), not mocks
+
+**Refinement loop**: This is the most critical review. Challenge every section:
+
+- "The solution is still too vague — describe what happens step by step when a user does X?"
+- "Rabbit holes only has one item — what else could derail this?"
+- "No-gos is empty — what are we explicitly not doing?"
+- "Does this solution actually fit the appetite, or are we doing too much?"
+- "Are the breadboards concrete enough to build from?"
+- "Would a new team member understand the intended user experience from this pitch alone?"
+- Review to find any gaps or improvement areas. Give the pitch a confidence score from 1 to 10.
+
+**Pitch Approval Gate**
+
+> "The pitch is looking solid. Does it reflect what you want to build? If so, we'll move on to scopes."
+
+Wait for explicit approval before proceeding.
+
+---
+
+### Step 3: Scopes — `scopes.md` _(required, created after pitch approval)_
+
+Break work into named, interconnected scopes. Scopes emerge from the solution — they are not a flat numbered task list. Each scope maps to a PR.
+
+```markdown
+# Scopes
+
+## [Scope Name] — [what it solves]
+
+- [ ] Task
+- [ ] Task
+
+## [Scope Name] — [what it solves]
+
+- [ ] Task
+```
+
+**Refinement loop**: Challenge the scope breakdown:
+
+- "Are these scopes truly independent, or does [A] block [B]?"
+- "This scope looks too large — can it be split?"
+- "Are all tasks in [scope] actually required by the pitch, or is this gold-plating?"
+- "Is there a scope that could be deferred if we run out of time?"
+- "Does each scope make sense as a standalone PR?"
+- Review to find any gaps or improvement areas. Give the document a confidence score from 1 to 10.
+
+**Scopes Approval Gate**
+
+> "The scopes look solid. Do they match what you expected? If so, we're done with planning."
+
+Wait for explicit approval before proceeding.
+
+---
+
+### Step 4: Stop
+
+**Do not write any code.** The workflow ends here. Implementation is a separate activity initiated by the user — each scope becomes its own spec/PR cycle.
+
+### Rules
+
+1. Never skip steps (except explicitly optional ones, after asking the user)
+2. Refinement loop is mandatory — at least one round before every approval gate
+3. Optional steps require an explicit choice — ask "include or skip?" before proceeding
+4. Always wait for explicit approval before advancing
+5. No implementation — this workflow is for planning only
+6. Rabbit Holes and No-gos sections in `pitch.md` cannot be empty
+7. `scopes.md` is only created after pitch approval
+8. Appetite is a constraint, not an estimate — it shapes what solution is possible
+9. Each scope should be deliverable as an independent PR

--- a/.agents/skills/project/spec.md
+++ b/.agents/skills/project/spec.md
@@ -1,0 +1,97 @@
+# Spec Workflow (Single PR)
+
+A design-then-plan workflow for changes that fit in one PR. Two phases: **spec** (what to build) and **plan** (how to build it). No implementation happens here.
+
+For quick idea or issue capture, follow the workflows in `AGENTS.md` instead.
+
+**After every write to `todo/`**, run `bash scripts/update-todo.sh` to regenerate `TODO.md`.
+
+## Directory Structure
+
+```
+todo/projects/{feature-name}/
+├── spec.md      <- shaped design; what to build and why
+└── plan.md      <- implementation plan; created only after spec approval
+```
+
+---
+
+## Phase 1: Spec — `spec.md`
+
+### Step 1: Explore context
+
+Check relevant files, docs, recent commits to understand the current state.
+
+### Step 2: Ask clarifying questions
+
+One question at a time. Prefer multiple choice when possible. Understand purpose, constraints, success criteria.
+
+### Step 3: Propose approaches
+
+Present 2-3 approaches with trade-offs and your recommendation. Lead with the recommended option.
+
+### Step 4: Write the spec
+
+Create `todo/projects/{feature-name}/spec.md`. Include:
+
+- **Problem** _(opening paragraph)_ — what's broken or missing, who is affected, concrete examples
+- **Appetite** _(optional)_ — ask: _"Do you want to include an appetite (time budget) in the spec?"_
+- **Solution** — described at the right level of abstraction:
+  - _Breadboards_: text-based UI/flow descriptions
+  - _Fat marker sketches_: high-level architecture, data flow, component interactions
+  - Core code snippets following Jazz conventions:
+    - Rust for core logic (`crates/groove`)
+    - TypeScript for client layers (`packages/`)
+    - WASM + NAPI bindings where relevant
+    - SQL (Jazz's custom dialect subset) for relational semantics
+- **Rabbit Holes** — technical risks and what to avoid; **cannot be empty**
+- **No-gos** — explicitly out of scope; **cannot be empty**
+- **Testing Strategy** — integration-first (SchemaManager, RuntimeCore level), realistic fixtures with human actor names (alice, bob), not mocks
+
+### Step 5: Spec self-review
+
+Review the spec critically before showing it to the user:
+
+1. **Placeholder scan** — any "TBD", "TODO", vague requirements? Fix them.
+2. **Internal consistency** — do sections contradict each other?
+3. **Ambiguity check** — could any requirement be interpreted two ways? Pick one and make it explicit.
+4. **Challenge every section:**
+   - "The solution is still too vague — describe what happens step by step when a user does X?"
+   - "Rabbit holes only has one item — what else could derail this?"
+   - "No-gos is empty — what are we explicitly not doing?"
+   - "Does this solution actually fit the appetite, or are we doing too much?"
+   - "Are the breadboards concrete enough to build from?"
+   - "Would a new team member understand the intended user experience from this spec alone?"
+5. Give the spec a confidence score from 1 to 10. Fix issues inline.
+
+### Step 6: Refinement with user
+
+Present the spec to the user with targeted questions:
+
+> _"This is a first draft. Before we move to approval, I have a few questions to make it more solid: [list]"_
+
+Update based on answers. Run another round if still weak.
+
+**Spec Approval Gate**
+
+> "The spec is looking solid. Does it reflect what you want to build? If so, we'll move on to the implementation plan."
+
+Wait for explicit approval before proceeding.
+
+---
+
+## Phase 2: Plan — `plan.md`
+
+Created only after spec approval. Read `skills/project/plan.md` (in the same directory as this file) and follow it. Pass the approved spec as context.
+
+---
+
+## Rules
+
+1. Never skip phases or steps
+2. Spec self-review is mandatory before showing to user
+3. At least one refinement round with user before spec approval gate
+4. Always wait for explicit approval before advancing to Phase 2
+5. No implementation — this workflow is for planning only
+6. Rabbit Holes and No-gos sections in `spec.md` cannot be empty
+7. `plan.md` is only created after spec approval, via the plan sub-skill


### PR DESCRIPTION
Noticed that:
- Claude doesn't pick the skill when asking to "write a spec"
- Sometimes we don't need a multi-PR pitch but a spec+plan is ok

Updating the project skill to address these problems