### PR TITLE
Fix flaky chat rename test

### DIFF
--- a/examples/chat-react/tests/browser/chat-settings.test.tsx
+++ b/examples/chat-react/tests/browser/chat-settings.test.tsx
@@ -152,6 +152,13 @@ describe("ChatHeader + ChatSettings E2E", () => {
 
     await act(async () => typeInto(nameInput!, "Weekend plans"));
 
+    // Wait for the DB update to round-trip back into the controlled input
+    await waitFor(
+      () => nameInput!.value === "Weekend plans",
+      5000,
+      "Chat name input should reflect the persisted value",
+    );
+
     // Close the sheet
     const closeButton = document
       .querySelector('[data-slot="sheet-content"] .lucide-x')


### PR DESCRIPTION
## Summary

- Wait for the DB round-trip to complete before closing the settings sheet in the "renames a chat via the settings sheet" test
- The test was closing the sheet immediately after `typeInto`, before `db.update` had propagated back through the reactive query, so the name never stuck under CI load

## Test plan

- [ ] CI green — the flaky `chat-settings.test.tsx > renames a chat via the settings sheet` test should pass consistently