### PR TITLE
Align docs restructure with current schema workflow

### DIFF
--- a/docs/content/docs/auth/permissions.mdx
+++ b/docs/content/docs/auth/permissions.mdx
@@ -10,7 +10,7 @@ Permissions control who can read, insert, update, and delete rows. Jazz enforces
 
 ## Authoring workflow
 
-Permissions are authored in TypeScript. The SQL snippets below show the equivalent row-level policy shape.
+Permissions are authored in TypeScript.
 
 If we have the following schema:
 
@@ -25,11 +25,12 @@ We can define permissions in `permissions.ts`:
 </include>
 
 <Callout type="info">
-  Author permissions in the root `permissions.ts` next to `schema.ts`, then run `npx jazz-tools
-  validate` for a local preflight check. Permission-only changes do not require migrations.
+  Author permissions in the root `permissions.ts` next to `schema.ts`. `npx jazz-tools@alpha
+  validate` is a useful local sanity check before publishing. Permission-only changes do not require
+  migrations, but they do still require `npx jazz-tools@alpha permissions push`.
 </Callout>
 
-Apps that do not need user-scoped filtering can still define explicit allow-all policies (`policy.todos.allowRead.always()` or `policy.todos.allowRead.where({})` / `USING (TRUE)`).
+Apps that do not need user-scoped filtering can still define explicit allow-all policies (`policy.todos.allowRead.always()` or `policy.todos.allowRead.where({})`).
 
 ## Basic policies
 
@@ -37,54 +38,26 @@ Apps that do not need user-scoped filtering can still define explicit allow-all 
 
 Use the policy helpers `allowRead`, `allowInsert`, `allowUpdate`, and `allowDelete` with [`.where(...)`](/docs/reference/where-operators) to restrict access based on column values.
 
-<Tabs groupId="jazz-schema-format" items={["TypeScript", "SQL"]} persist updateAnchor>
-  <Tab value="TypeScript">
-    <include cwd lang="ts" meta='title="permissions.ts"'>
-      ../examples/docs/todo-server-ts/src/permissions-snippets.ts#permissions-simple-ts
-    </include>
-  </Tab>
-  <Tab value="SQL">
-    <include cwd lang="sql" meta='title="permissions.sql"'>
-      ../examples/docs/todo-server-ts/docs/permissions-snippets.sql#permissions-simple-sql
-    </include>
-  </Tab>
-</Tabs>
+<include cwd lang="ts" meta='title="permissions.ts"'>
+  ../examples/docs/todo-server-ts/src/permissions-snippets.ts#permissions-simple-ts
+</include>
 
 ### `.always()`
 
-Use `.always()` when an operation should always be permitted. It is equivalent to
-`.where({})` and compiles to a `TRUE` policy expression.
+Use `.always()` when an operation should always be permitted. It is equivalent to `.where({})`.
 
-<Tabs groupId="jazz-schema-format" items={["TypeScript", "SQL"]} persist updateAnchor>
-  <Tab value="TypeScript">
-    <include cwd lang="ts" meta='title="permissions.ts"'>
-      ../examples/docs/todo-server-ts/src/permissions-snippets.ts#permissions-always-ts
-    </include>
-  </Tab>
-  <Tab value="SQL">
-    <include cwd lang="sql" meta='title="permissions.sql"'>
-      ../examples/docs/todo-server-ts/docs/permissions-snippets.sql#permissions-always-sql
-    </include>
-  </Tab>
-</Tabs>
+<include cwd lang="ts" meta='title="permissions.ts"'>
+  ../examples/docs/todo-server-ts/src/permissions-snippets.ts#permissions-always-ts
+</include>
 
 ### `.never()`
 
 Use `.never()` when an operation should be impossible. It is equivalent to
-`.where(anyOf([]))` and compiles to a `FALSE` policy expression.
+`.where(anyOf([]))`.
 
-<Tabs groupId="jazz-schema-format" items={["TypeScript", "SQL"]} persist updateAnchor>
-  <Tab value="TypeScript">
-    <include cwd lang="ts" meta='title="permissions.ts"'>
-      ../examples/docs/todo-server-ts/src/permissions-snippets.ts#permissions-never-ts
-    </include>
-  </Tab>
-  <Tab value="SQL">
-    <include cwd lang="sql" meta='title="permissions.sql"'>
-      ../examples/docs/todo-server-ts/docs/permissions-snippets.sql#permissions-never-sql
-    </include>
-  </Tab>
-</Tabs>
+<include cwd lang="ts" meta='title="permissions.ts"'>
+  ../examples/docs/todo-server-ts/src/permissions-snippets.ts#permissions-never-ts
+</include>
 
 ## Composing policies
 
@@ -92,74 +65,39 @@ Use `.never()` when an operation should be impossible. It is equivalent to
 
 Combine conditions with `allOf` (all must match) or `anyOf` (any can match).
 
-<Tabs groupId="jazz-schema-format" items={["TypeScript", "SQL"]} persist updateAnchor>
-  <Tab value="TypeScript">
-    <include cwd lang="ts" meta='title="permissions.ts"'>
-      ../examples/docs/todo-server-ts/src/permissions-snippets.ts#permissions-combinators-ts
-    </include>
-  </Tab>
-  <Tab value="SQL">
-    <include cwd lang="sql" meta='title="permissions.sql"'>
-      ../examples/docs/todo-server-ts/docs/permissions-snippets.sql#permissions-combinators-sql
-    </include>
-  </Tab>
-</Tabs>
+<include cwd lang="ts" meta='title="permissions.ts"'>
+  ../examples/docs/todo-server-ts/src/permissions-snippets.ts#permissions-combinators-ts
+</include>
 
 ### JWT session claims
 
 When external auth JWTs carry claims, `session.where(...)` lets you check them directly in permissions without mapping them onto row columns first.
 
-<Tabs groupId="jazz-schema-format" items={["TypeScript", "SQL"]} persist updateAnchor>
-  <Tab value="TypeScript">
-    <include cwd lang="ts" meta='title="permissions.ts"'>
-      ../examples/docs/todo-server-ts/src/permissions-snippets.ts#permissions-session-claims-ts
-    </include>
-  </Tab>
-  <Tab value="SQL">
-    <include cwd lang="sql" meta='title="permissions.sql"'>
-      ../examples/docs/todo-server-ts/docs/permissions-snippets.sql#permissions-session-claims-sql
-    </include>
-  </Tab>
-</Tabs>
+<include cwd lang="ts" meta='title="permissions.ts"'>
+  ../examples/docs/todo-server-ts/src/permissions-snippets.ts#permissions-session-claims-ts
+</include>
 
 ### Inherited access (`allowedTo.*`)
 
-A row can inherit its access from a related row. Use `allowedTo.read/insert/update/delete(...)` in TypeScript, or `INHERITS` in SQL.
+A row can inherit its access from a related row. Use
+`allowedTo.read/insert/update/delete(...)` to express that inheritance.
 
-<Tabs groupId="jazz-schema-format" items={["TypeScript", "SQL"]} persist updateAnchor>
-  <Tab value="TypeScript">
-    <include cwd lang="ts" meta='title="permissions.ts"'>
-      ../examples/docs/todo-server-ts/src/permissions-snippets.ts#permissions-allowed-to-ts
-    </include>
-  </Tab>
-  <Tab value="SQL">
-    <include cwd lang="sql" meta='title="permissions.sql"'>
-      ../examples/docs/todo-server-ts/docs/permissions-snippets.sql#permissions-inherits-sql
-    </include>
-  </Tab>
-</Tabs>
+<include cwd lang="ts" meta='title="permissions.ts"'>
+  ../examples/docs/todo-server-ts/src/permissions-snippets.ts#permissions-allowed-to-ts
+</include>
 
 ### Share-based access
 
 Sometimes access isn't determined by ownership or a parent relationship, but by a separate "shares" table. Use `policy.<table>.exists.where(...)` to check whether a matching row exists in another table.
 
-<Tabs groupId="jazz-schema-format" items={["TypeScript", "SQL"]} persist updateAnchor>
-  <Tab value="TypeScript">
-    <include cwd lang="ts" meta='title="permissions.ts"'>
-      ../examples/docs/todo-server-ts/src/permissions-snippets.ts#permissions-shares-ts
-    </include>
-  </Tab>
-  <Tab value="SQL">
-    <include cwd lang="sql" meta='title="permissions.sql"'>
-      ../examples/docs/todo-server-ts/docs/permissions-snippets.sql#permissions-shares-sql
-    </include>
-  </Tab>
-</Tabs>
+<include cwd lang="ts" meta='title="permissions.ts"'>
+  ../examples/docs/todo-server-ts/src/permissions-snippets.ts#permissions-shares-ts
+</include>
 
 The callback form `(todo) => ...` gives you access to the current row, so you can correlate it with rows in other tables.
 
 <Accordions type="single">
-<Accordion title="Recursive INHERITS">
+<Accordion title="Recursive inheritance">
 
 If a table references itself (e.g. a comment that can have sub-comments), you can inherit access recursively up to a fixed depth.
 

--- a/docs/content/docs/auth/permissions.mdx
+++ b/docs/content/docs/auth/permissions.mdx
@@ -6,40 +6,30 @@ reviewedAt: "14cd73f0"
 
 import { Accordion, Accordions } from "fumadocs-ui/components/accordion";
 
-Permissions control who can read, insert, update, and delete rows. Jazz enforces them server-side using row-level policies defined in `schema/permissions.ts`. Clients that fail a policy check have their writes rejected and their reads filtered.
+Permissions control who can read, insert, update, and delete rows. Jazz enforces them server-side using row-level policies defined in `permissions.ts`. Clients that fail a policy check have their writes rejected and their reads filtered.
 
-## Schema policy syntax
+## Authoring workflow
 
-Jazz allows you to define policies using either TypeScript or SQL.
+Permissions are authored in TypeScript. The SQL snippets below show the equivalent row-level policy shape.
 
-<Tabs groupId="jazz-schema-format" items={["TypeScript", "SQL"]} persist updateAnchor>
-  <Tab value="TypeScript">
-    If we have the following schema:
+If we have the following schema:
 
-    <include cwd lang="ts" meta='title="schema/current.ts"'>
-      ../examples/docs/todo-server-ts/src/permissions-snippets.ts#permissions-schema-ts
-    </include>
+<include cwd lang="ts" meta='title="schema.ts"'>
+  ../examples/docs/todo-server-ts/src/permissions-snippets.ts#permissions-schema-ts
+</include>
 
-    We can define permissions in `schema/permissions.ts`:
+We can define permissions in `permissions.ts`:
 
-    <include cwd lang="ts" meta='title="schema/permissions.ts"'>
-      ../examples/docs/todo-server-ts/schema/permissions.ts
-    </include>
-
-  </Tab>
-  <Tab value="SQL">
-    <include cwd lang="sql" meta='title="schema/current.sql"'>
-      ../examples/docs/todo-server-ts/schema/current.sql
-    </include>
-  </Tab>
-</Tabs>
-
-Apps that do not need user-scoped filtering can still define explicit allow-all policies (`policy.todos.allowRead.always()` or `policy.todos.allowRead.where({})` / `USING (TRUE)`).
+<include cwd lang="ts" meta='title="permissions.ts"'>
+  ../examples/docs/todo-server-ts/permissions.ts
+</include>
 
 <Callout type="info">
-  You should use the exact file names `schema/current.ts` and `schema/permissions.ts` so that Jazz
-  can find them.
+  Author permissions in the root `permissions.ts` next to `schema.ts`, then run `npx jazz-tools
+  validate` for a local preflight check. Permission-only changes do not require migrations.
 </Callout>
+
+Apps that do not need user-scoped filtering can still define explicit allow-all policies (`policy.todos.allowRead.always()` or `policy.todos.allowRead.where({})` / `USING (TRUE)`).
 
 ## Basic policies
 
@@ -49,12 +39,12 @@ Use the policy helpers `allowRead`, `allowInsert`, `allowUpdate`, and `allowDele
 
 <Tabs groupId="jazz-schema-format" items={["TypeScript", "SQL"]} persist updateAnchor>
   <Tab value="TypeScript">
-    <include cwd lang="ts" meta='title="schema/permissions.ts"'>
+    <include cwd lang="ts" meta='title="permissions.ts"'>
       ../examples/docs/todo-server-ts/src/permissions-snippets.ts#permissions-simple-ts
     </include>
   </Tab>
   <Tab value="SQL">
-    <include cwd lang="sql" meta='title="schema/permissions.sql"'>
+    <include cwd lang="sql" meta='title="permissions.sql"'>
       ../examples/docs/todo-server-ts/docs/permissions-snippets.sql#permissions-simple-sql
     </include>
   </Tab>
@@ -67,12 +57,12 @@ Use `.always()` when an operation should always be permitted. It is equivalent t
 
 <Tabs groupId="jazz-schema-format" items={["TypeScript", "SQL"]} persist updateAnchor>
   <Tab value="TypeScript">
-    <include cwd lang="ts" meta='title="schema/permissions.ts"'>
+    <include cwd lang="ts" meta='title="permissions.ts"'>
       ../examples/docs/todo-server-ts/src/permissions-snippets.ts#permissions-always-ts
     </include>
   </Tab>
   <Tab value="SQL">
-    <include cwd lang="sql" meta='title="schema/permissions.sql"'>
+    <include cwd lang="sql" meta='title="permissions.sql"'>
       ../examples/docs/todo-server-ts/docs/permissions-snippets.sql#permissions-always-sql
     </include>
   </Tab>
@@ -85,12 +75,12 @@ Use `.never()` when an operation should be impossible. It is equivalent to
 
 <Tabs groupId="jazz-schema-format" items={["TypeScript", "SQL"]} persist updateAnchor>
   <Tab value="TypeScript">
-    <include cwd lang="ts" meta='title="schema/permissions.ts"'>
+    <include cwd lang="ts" meta='title="permissions.ts"'>
       ../examples/docs/todo-server-ts/src/permissions-snippets.ts#permissions-never-ts
     </include>
   </Tab>
   <Tab value="SQL">
-    <include cwd lang="sql" meta='title="schema/permissions.sql"'>
+    <include cwd lang="sql" meta='title="permissions.sql"'>
       ../examples/docs/todo-server-ts/docs/permissions-snippets.sql#permissions-never-sql
     </include>
   </Tab>
@@ -104,12 +94,12 @@ Combine conditions with `allOf` (all must match) or `anyOf` (any can match).
 
 <Tabs groupId="jazz-schema-format" items={["TypeScript", "SQL"]} persist updateAnchor>
   <Tab value="TypeScript">
-    <include cwd lang="ts" meta='title="schema/permissions.ts"'>
+    <include cwd lang="ts" meta='title="permissions.ts"'>
       ../examples/docs/todo-server-ts/src/permissions-snippets.ts#permissions-combinators-ts
     </include>
   </Tab>
   <Tab value="SQL">
-    <include cwd lang="sql" meta='title="schema/permissions.sql"'>
+    <include cwd lang="sql" meta='title="permissions.sql"'>
       ../examples/docs/todo-server-ts/docs/permissions-snippets.sql#permissions-combinators-sql
     </include>
   </Tab>
@@ -121,12 +111,12 @@ When external auth JWTs carry claims, `session.where(...)` lets you check them d
 
 <Tabs groupId="jazz-schema-format" items={["TypeScript", "SQL"]} persist updateAnchor>
   <Tab value="TypeScript">
-    <include cwd lang="ts" meta='title="schema/permissions.ts"'>
+    <include cwd lang="ts" meta='title="permissions.ts"'>
       ../examples/docs/todo-server-ts/src/permissions-snippets.ts#permissions-session-claims-ts
     </include>
   </Tab>
   <Tab value="SQL">
-    <include cwd lang="sql" meta='title="schema/permissions.sql"'>
+    <include cwd lang="sql" meta='title="permissions.sql"'>
       ../examples/docs/todo-server-ts/docs/permissions-snippets.sql#permissions-session-claims-sql
     </include>
   </Tab>
@@ -138,12 +128,12 @@ A row can inherit its access from a related row. Use `allowedTo.read/insert/upda
 
 <Tabs groupId="jazz-schema-format" items={["TypeScript", "SQL"]} persist updateAnchor>
   <Tab value="TypeScript">
-    <include cwd lang="ts" meta='title="schema/permissions.ts"'>
+    <include cwd lang="ts" meta='title="permissions.ts"'>
       ../examples/docs/todo-server-ts/src/permissions-snippets.ts#permissions-allowed-to-ts
     </include>
   </Tab>
   <Tab value="SQL">
-    <include cwd lang="sql" meta='title="schema/permissions.sql"'>
+    <include cwd lang="sql" meta='title="permissions.sql"'>
       ../examples/docs/todo-server-ts/docs/permissions-snippets.sql#permissions-inherits-sql
     </include>
   </Tab>
@@ -155,12 +145,12 @@ Sometimes access isn't determined by ownership or a parent relationship, but by 
 
 <Tabs groupId="jazz-schema-format" items={["TypeScript", "SQL"]} persist updateAnchor>
   <Tab value="TypeScript">
-    <include cwd lang="ts" meta='title="schema/permissions.ts"'>
+    <include cwd lang="ts" meta='title="permissions.ts"'>
       ../examples/docs/todo-server-ts/src/permissions-snippets.ts#permissions-shares-ts
     </include>
   </Tab>
   <Tab value="SQL">
-    <include cwd lang="sql" meta='title="schema/permissions.sql"'>
+    <include cwd lang="sql" meta='title="permissions.sql"'>
       ../examples/docs/todo-server-ts/docs/permissions-snippets.sql#permissions-shares-sql
     </include>
   </Tab>
@@ -173,7 +163,7 @@ The callback form `(todo) => ...` gives you access to the current row, so you ca
 
 If a table references itself (e.g. a comment that can have sub-comments), you can inherit access recursively up to a fixed depth.
 
-<include cwd lang="ts" meta='title="schema/permissions.ts"'>
+<include cwd lang="ts" meta='title="permissions.ts"'>
   ../examples/docs/todo-server-ts/src/permissions-snippets.ts#permissions-recursive-inherits-ts
 </include>
 

--- a/docs/content/docs/quickstarts/client.mdx
+++ b/docs/content/docs/quickstarts/client.mdx
@@ -6,6 +6,8 @@ reviewedAt: "14cd73f0"
 
 import { Callout } from "fumadocs-ui/components/callout";
 import { Accordion, Accordions } from "fumadocs-ui/components/accordion";
+import SchemaSetup from "../../partials/schema-setup.mdx";
+import QuickstartSchemaTypesSummary from "../../partials/schema-types-summary.mdx";
 
 ## Create a project
 
@@ -138,24 +140,17 @@ Install Jazz in your project.
 
 ## Define your schema
 
-Create a file at `schema/current.ts` describing the structure of your app's data.
+Create `schema.ts` at the root of your project. This is the source of truth for your data model.
 
-<include cwd lang="ts" meta='title="schema/current.ts"'>
-  ../examples/docs/todo-client-localfirst-react/schema/current.ts#schema-react
+<include cwd lang="ts" meta='title="schema.ts"'>
+  ../examples/docs/todo-client-localfirst-react/schema.ts#schema-react
 </include>
 
-### Run codegen
+<QuickstartSchemaTypesSummary />
 
-```bash title="Terminal"
-npx jazz-tools@alpha build
-```
+### Validate schema
 
-This generates `schema/app.ts`, which exports a typed `app` object with a property for each table (e.g. `app.todos`). Import `app` whenever you need to query or write data.
-
-<Callout title="Generated code">
-  Never edit `schema/app.ts` by hand. Edit `schema/current.ts` and re-run `npx jazz-tools@alpha
-  build`.
-</Callout>
+<SchemaSetup />
 
 [Learn more about schemas](/docs/schemas/defining-tables).
 
@@ -336,57 +331,54 @@ So far, your to-do list only works locally. To sync across devices, you need a s
 Generate an app ID:
 
 ```bash title="Terminal"
-npx jazz-tools@alpha create app
+npx jazz-tools create app
 # outputs a UUID like: 019d0ba1-519a-7e01-b0eb-0059ee898e4d
 ```
 
 Start the server with that ID and an admin secret (required for clients to push schemas). The default port is 1625, but you can use `--port` to change it:
 
 ```bash title="Terminal"
-npx jazz-tools@alpha server <your-app-id> --admin-secret secret
+npx jazz-tools server <your-app-id> --admin-secret secret
 ```
 
 ### Add permissions
 
 The server rejects all reads and writes unless you define [permissions](/docs/auth/permissions). For this quickstart, allow everything:
 
-```ts title="schema/permissions.ts"
-import { definePermissions } from "jazz-tools/permissions";
-import { app } from "./app.js";
+```ts title="permissions.ts"
+import { schema as s } from "jazz-tools";
+import { app } from "./schema.js";
 
-export default definePermissions(app, ({ policy }) => [
-  policy.todos.allowRead.always(),
-  policy.todos.allowInsert.always(),
-  policy.todos.allowUpdate.always(),
-  policy.todos.allowDelete.always(),
-]);
+export default s.definePermissions(app, ({ policy }) => {
+  policy.todos.allowRead.always();
+  policy.todos.allowInsert.always();
+  policy.todos.allowUpdate.always();
+  policy.todos.allowDelete.always();
+});
 ```
 
-Re-run codegen so the build picks up the new file:
+Validate locally so `schema.ts` and `permissions.ts` are checked together:
 
 ```bash title="Terminal"
-npx jazz-tools@alpha build
+npx jazz-tools validate
 ```
 
 ### Connect the client
 
-Update your client config to use the same app ID, and add `serverUrl` and `adminSecret`:
+Update your client config to use the same app ID, and add `serverUrl`:
 
 ```ts
 {
   appId: "<your-app-id>",
-  // Use your machine's LAN IP for mobile devices
+  // Use your machine's LAN IP for mobile devices.
   serverUrl: "http://127.0.0.1:1625",
-  adminSecret: "secret",
 }
 ```
 
-The schema and permissions are automatically published when the client connects. Data now syncs in real time between every connected client.
-
-<Callout type="warn" title="Likely to change">
-  The schema sync mechanism is under active development. Expect the admin secret flow and
-  auto-publish behaviour to change before launch.
-</Callout>
+Clients learn the structural schema when they connect. If you later change `permissions.ts`,
+publish the new permissions bundle explicitly with `npx jazz-tools permissions push`.
+If you change `schema.ts` structurally after data already exists, create and push a migration edge
+before old and new clients mix on the same shared server.
 
 For production deployment and hosting options, see [Server Setup](/docs/reference/server-setup).
 

--- a/docs/content/docs/quickstarts/client.mdx
+++ b/docs/content/docs/quickstarts/client.mdx
@@ -6,7 +6,6 @@ reviewedAt: "14cd73f0"
 
 import { Callout } from "fumadocs-ui/components/callout";
 import { Accordion, Accordions } from "fumadocs-ui/components/accordion";
-import SchemaSetup from "../../partials/schema-setup.mdx";
 import QuickstartSchemaTypesSummary from "../../partials/schema-types-summary.mdx";
 
 ## Create a project
@@ -148,11 +147,7 @@ Create `schema.ts` at the root of your project. This is the source of truth for 
 
 <QuickstartSchemaTypesSummary />
 
-### Validate schema
-
-<SchemaSetup />
-
-[Learn more about schemas](/docs/schemas/defining-tables).
+[Learn more about schemas, optional validation, and migrations](/docs/schemas/defining-tables).
 
 ## Set up your app
 
@@ -331,14 +326,14 @@ So far, your to-do list only works locally. To sync across devices, you need a s
 Generate an app ID:
 
 ```bash title="Terminal"
-npx jazz-tools create app
+npx jazz-tools@alpha create app
 # outputs a UUID like: 019d0ba1-519a-7e01-b0eb-0059ee898e4d
 ```
 
 Start the server with that ID and an admin secret (required for clients to push schemas). The default port is 1625, but you can use `--port` to change it:
 
 ```bash title="Terminal"
-npx jazz-tools server <your-app-id> --admin-secret secret
+npx jazz-tools@alpha server <your-app-id> --admin-secret secret
 ```
 
 ### Add permissions
@@ -357,12 +352,6 @@ export default s.definePermissions(app, ({ policy }) => {
 });
 ```
 
-Validate locally so `schema.ts` and `permissions.ts` are checked together:
-
-```bash title="Terminal"
-npx jazz-tools validate
-```
-
 ### Connect the client
 
 Update your client config to use the same app ID, and add `serverUrl`:
@@ -376,9 +365,10 @@ Update your client config to use the same app ID, and add `serverUrl`:
 ```
 
 Clients learn the structural schema when they connect. If you later change `permissions.ts`,
-publish the new permissions bundle explicitly with `npx jazz-tools permissions push`.
-If you change `schema.ts` structurally after data already exists, create and push a migration edge
-before old and new clients mix on the same shared server.
+publish the new permissions bundle explicitly with `npx jazz-tools@alpha permissions push`.
+If you change `schema.ts` structurally after data already exists, create and push a
+[reviewed migration edge](/docs/schemas/migrations) before old and new clients mix on the same
+shared server.
 
 For production deployment and hosting options, see [Server Setup](/docs/reference/server-setup).
 

--- a/docs/content/docs/quickstarts/typescript-server.mdx
+++ b/docs/content/docs/quickstarts/typescript-server.mdx
@@ -77,7 +77,8 @@ Create `src/index.ts`. This quickstart puts everything in one file; a real app w
 - Runtime storage path controls where local server state persists.
 
 Each route handler calls `context.forRequest(c.req)` to get a database handle with [permissions](/docs/auth/permissions) scoped to the request.
-For the unscoped `context.db()` helper and explicit backend mode, see [Server Setup](/docs/reference/server-setup).
+For server-owned work, use `context.asBackend()`. [Server Setup](/docs/reference/server-setup)
+covers that pattern in more detail.
 
 <Accordions type="single">
   <Accordion title="What does the driver do?">

--- a/docs/content/docs/quickstarts/typescript-server.mdx
+++ b/docs/content/docs/quickstarts/typescript-server.mdx
@@ -6,6 +6,9 @@ reviewedAt: "14cd73f0"
 
 import { Callout } from "fumadocs-ui/components/callout";
 import { Accordion, Accordions } from "fumadocs-ui/components/accordion";
+import SchemaSetup from "../../partials/schema-setup.mdx";
+import ServerAuthConfig from "../../partials/server-auth-config.mdx";
+import QuickstartSchemaTypesSummary from "../../partials/schema-types-summary.mdx";
 
 ## Create a project
 
@@ -27,24 +30,17 @@ pnpm add -D typescript tsx
 
 ## Define your schema
 
-Create a file at `schema/current.ts` describing the structure of your app's data.
+Create `schema.ts` at the root of your project. This is the source of truth for your data model.
 
-<include cwd lang="ts" meta='title="schema/current.ts"'>
-  ../examples/docs/todo-server-ts/schema/current.ts
+<include cwd lang="ts" meta='title="schema.ts"'>
+  ../examples/docs/todo-server-ts/schema.ts
 </include>
 
-### Run codegen
+<QuickstartSchemaTypesSummary />
 
-```bash title="Terminal"
-npx jazz-tools@alpha build
-```
+### Validate schema
 
-This generates `schema/app.ts`, which exports a typed `app` object with a property for each table (e.g. `app.todos`). Import `app` whenever you need to query or write data.
-
-<Callout type="info" title="Generated code">
-  Never edit `schema/app.ts` by hand. Edit `schema/current.ts` and re-run `npx jazz-tools@alpha
-  build`.
-</Callout>
+<SchemaSetup />
 
 [Learn more about schemas](/docs/schemas/defining-tables).
 
@@ -52,22 +48,22 @@ This generates `schema/app.ts`, which exports a typed `app` object with a proper
 
 The server rejects all reads and writes unless you define [permissions](/docs/auth/permissions). For this quickstart, allow everything:
 
-```ts title="schema/permissions.ts"
-import { definePermissions } from "jazz-tools/permissions";
-import { app } from "./app.js";
+```ts title="permissions.ts"
+import { schema as s } from "jazz-tools";
+import { app } from "./schema.js";
 
-export default definePermissions(app, ({ policy }) => [
-  policy.todos.allowRead.always(),
-  policy.todos.allowInsert.always(),
-  policy.todos.allowUpdate.always(),
-  policy.todos.allowDelete.always(),
-]);
+export default s.definePermissions(app, ({ policy }) => {
+  policy.todos.allowRead.always();
+  policy.todos.allowInsert.always();
+  policy.todos.allowUpdate.always();
+  policy.todos.allowDelete.always();
+});
 ```
 
-Re-run codegen so the build picks up the new file:
+Run validation again so the schema and permissions files are checked together:
 
 ```bash title="Terminal"
-npx jazz-tools@alpha build
+npx jazz-tools validate
 ```
 
 ## Set up your server
@@ -75,7 +71,7 @@ npx jazz-tools@alpha build
 Generate an app ID:
 
 ```bash title="Terminal"
-npx jazz-tools@alpha create app
+npx jazz-tools create app
 # outputs a UUID like: 019d0ba1-519a-7e01-b0eb-0059ee898e4d
 ```
 
@@ -85,9 +81,15 @@ Create `src/index.ts`. This quickstart puts everything in one file; a real app w
   ../examples/docs/todo-server-ts/src/quickstart-snippets.ts#quickstart-server-setup-ts
 </include>
 
+- `appId` identifies the app namespace for storage and sync.
+- `app` is your typed schema export (`app.wasmSchema` is loaded for runtime setup).
+- `context.db()` gives you a high-level `Db` using the context's configured runtime/auth.
+- `serverUrl` + `backendSecret` enable backend-authenticated handles via `context.asBackend()` and `context.forRequest(req)`.
+- Runtime storage path controls where local server state persists.
+
 Each route handler calls `context.forRequest(c.req)` to get a database handle with [permissions](/docs/auth/permissions) scoped to the request.
 
-You can also use `context.db()` to get a database handle that bypasses permission checks.
+You can also use `context.db()` to get a database handle that runs as the server's configured runtime identity.
 
 <Accordions type="single">
   <Accordion title="What does the driver do?">
@@ -166,6 +168,10 @@ curl -X DELETE http://localhost:3000/api/todos/<id> \
 <Callout type="info">
   `forRequest` extracts the caller's identity from the `Authorization` header. The dummy token above is an unsigned JWT with `{"sub": "test-user"}`&hairsp;—&hairsp;fine for local development. In production, your auth provider issues signed JWTs and the server validates them via JWKS. See [Authentication](/docs/auth/authentication) for how to set that up.
 </Callout>
+
+## Authentication
+
+<ServerAuthConfig />
 
 ## Next steps
 

--- a/docs/content/docs/quickstarts/typescript-server.mdx
+++ b/docs/content/docs/quickstarts/typescript-server.mdx
@@ -6,7 +6,6 @@ reviewedAt: "14cd73f0"
 
 import { Callout } from "fumadocs-ui/components/callout";
 import { Accordion, Accordions } from "fumadocs-ui/components/accordion";
-import SchemaSetup from "../../partials/schema-setup.mdx";
 import ServerAuthConfig from "../../partials/server-auth-config.mdx";
 import QuickstartSchemaTypesSummary from "../../partials/schema-types-summary.mdx";
 
@@ -38,11 +37,7 @@ Create `schema.ts` at the root of your project. This is the source of truth for 
 
 <QuickstartSchemaTypesSummary />
 
-### Validate schema
-
-<SchemaSetup />
-
-[Learn more about schemas](/docs/schemas/defining-tables).
+[Learn more about schemas, optional validation, and migrations](/docs/schemas/defining-tables).
 
 ### Add permissions
 
@@ -60,18 +55,12 @@ export default s.definePermissions(app, ({ policy }) => {
 });
 ```
 
-Run validation again so the schema and permissions files are checked together:
-
-```bash title="Terminal"
-npx jazz-tools validate
-```
-
 ## Set up your server
 
 Generate an app ID:
 
 ```bash title="Terminal"
-npx jazz-tools create app
+npx jazz-tools@alpha create app
 # outputs a UUID like: 019d0ba1-519a-7e01-b0eb-0059ee898e4d
 ```
 
@@ -83,13 +72,12 @@ Create `src/index.ts`. This quickstart puts everything in one file; a real app w
 
 - `appId` identifies the app namespace for storage and sync.
 - `app` is your typed schema export (`app.wasmSchema` is loaded for runtime setup).
-- `context.db()` gives you a high-level `Db` using the context's configured runtime/auth.
-- `serverUrl` + `backendSecret` enable backend-authenticated handles via `context.asBackend()` and `context.forRequest(req)`.
+- `permissions` is the server-side policy bundle evaluated for request-scoped reads and writes.
+- `serverUrl` + `backendSecret` let request-scoped handles sync through a Jazz server and enable explicit backend mode via `context.asBackend()`.
 - Runtime storage path controls where local server state persists.
 
 Each route handler calls `context.forRequest(c.req)` to get a database handle with [permissions](/docs/auth/permissions) scoped to the request.
-
-You can also use `context.db()` to get a database handle that runs as the server's configured runtime identity.
+For the unscoped `context.db()` helper and explicit backend mode, see [Server Setup](/docs/reference/server-setup).
 
 <Accordions type="single">
   <Accordion title="What does the driver do?">

--- a/docs/content/docs/reading/includes-and-relations.mdx
+++ b/docs/content/docs/reading/includes-and-relations.mdx
@@ -12,18 +12,9 @@ Use `include(...)` to load related rows as nested objects in a single query resu
 
 Including a relation adds the resolved object alongside the foreign-key column — it does not replace it. For example, `include({ project: true })` gives you both `projectId` (the FK string) and `project` (the resolved row).
 
-<Tabs groupId="jazz-schema-format" items={["TypeScript", "SQL"]} persist updateAnchor>
-  <Tab value="TypeScript">
-    <include cwd lang="ts" meta='title="schema.ts"'>
-      ../examples/docs/todo-client-localfirst-ts/schema/current.ts#schema-todo-client-ts
-    </include>
-  </Tab>
-  <Tab value="SQL">
-    <include cwd lang="sql" meta='title="schema.sql"'>
-      ../examples/docs/todo-server-rs/schema/current.sql
-    </include>
-  </Tab>
-</Tabs>
+<include cwd lang="ts" meta='title="schema.ts"'>
+  ../examples/docs/todo-client-localfirst-ts/schema.ts#schema-todo-client-ts
+</include>
 
 <Tabs groupId="jazz-environment" items={["TypeScript", "Rust"]} persist updateAnchor>
   <Tab value="TypeScript">

--- a/docs/content/docs/reference/column-types.mdx
+++ b/docs/content/docs/reference/column-types.mdx
@@ -6,6 +6,6 @@ reviewedAt: "14cd73f0"
 
 import AvailableColumnTypes from "../../partials/available-column-types.mdx";
 
-Any column can be made nullable by chaining `.optional()`. For binary data like images and file uploads, use the [Files & Blobs](/docs/writing/files-and-blobs) pattern rather than `col.bytes()` directly.
+Any column can be made nullable by chaining `.optional()`. For binary data like images and file uploads, use the [Files & Blobs](/docs/writing/files-and-blobs) pattern rather than `s.bytes()` directly.
 
 <AvailableColumnTypes />

--- a/docs/content/docs/reference/server-setup.mdx
+++ b/docs/content/docs/reference/server-setup.mdx
@@ -100,10 +100,17 @@ For React Native/Expo clients, make sure `serverUrl` points to a host your runti
 
 ### Backend identity pattern
 
-On the client side, queries automatically run as the logged-in user. On a backend, create the context once at startup, then choose whether a request should run as the server or as the caller.
+On the client side, queries automatically run as the logged-in user. On a backend, create the
+context once at startup, then choose whether work should run as an unscoped local runtime, as an
+explicit backend connection, or as the caller.
 
-- `context.db()` returns a `Db` that runs queries as the configured runtime identity, useful for admin tasks or background jobs that aren't tied to a specific user.
-- `context.forRequest(req)` returns a `Db` that runs queries as the authenticated user who made the request, so permission policies apply to them rather than the server.
+- `context.db()` returns the shared high-level `Db` for the context with no per-request user
+  session attached, useful for local-only jobs or server-owned work that is not impersonating a
+  caller.
+- `context.asBackend()` returns a `Db` that uses `backendSecret` for sync/auth when this process
+  talks to a Jazz server.
+- `context.forRequest(req)` returns a `Db` that runs queries as the authenticated user who made
+  the request, so permission policies apply to them rather than the process itself.
 
 In TypeScript backends, create the context once with both `app` and `permissions`, then call `context.forRequest(req)` when you need a bearer-JWT-scoped high-level `Db`.
 

--- a/docs/content/docs/reference/server-setup.mdx
+++ b/docs/content/docs/reference/server-setup.mdx
@@ -100,21 +100,25 @@ For React Native/Expo clients, make sure `serverUrl` points to a host your runti
 
 ### Backend identity pattern
 
-On the client side, queries automatically run as the logged-in user. On a backend, create the
-context once at startup, then choose whether work should run as an unscoped local runtime, as an
-explicit backend connection, or as the caller.
+On the client side, queries automatically run as the logged-in user. On a server-connected backend,
+create the context once at startup, then choose whether work should run as the backend itself or as
+the caller.
 
-- `context.db()` returns the shared high-level `Db` for the context with no per-request user
-  session attached, useful for local-only jobs or server-owned work that is not impersonating a
-  caller.
 - `context.asBackend()` returns a `Db` that uses `backendSecret` for sync/auth when this process
   talks to a Jazz server.
 - `context.forRequest(req)` returns a `Db` that runs queries as the authenticated user who made
   the request, so permission policies apply to them rather than the process itself.
 
-In TypeScript backends, create the context once with both `app` and `permissions`, then call `context.forRequest(req)` when you need a bearer-JWT-scoped high-level `Db`.
+In TypeScript backends, create the context once with both `app` and `permissions`, then use
+`context.asBackend()` for server-owned work and `context.forRequest(req)` when you need a
+bearer-JWT-scoped high-level `Db`.
 
 `forRequest` reads authentication from standard HTTP headers, so `req` can be any object that exposes them: Express, Hono, Fastify, or a Web Fetch API `Request` all work.
+
+<Callout type="info">
+  `context.db()` still exists for embedded or local-only runtime setups, but it is not the primary
+  pattern for server-connected backends.
+</Callout>
 
 #### Per-request user-scoped client
 

--- a/docs/content/docs/reference/server-setup.mdx
+++ b/docs/content/docs/reference/server-setup.mdx
@@ -100,14 +100,14 @@ For React Native/Expo clients, make sure `serverUrl` points to a host your runti
 
 ### Backend identity pattern
 
-On the client side, queries automatically run as the logged-in user. On a backend, you choose which identity each query runs as.
+On the client side, queries automatically run as the logged-in user. On a backend, create the context once at startup, then choose whether a request should run as the server or as the caller.
 
-Call `createJazzContext(...)` once when your server starts. This gives you a shared context that holds the connection to the Jazz server. From there you have two options:
-
-- `context.db()` returns a `Db` that runs queries as the server itself, useful for admin tasks or background jobs that aren't tied to a specific user.
+- `context.db()` returns a `Db` that runs queries as the configured runtime identity, useful for admin tasks or background jobs that aren't tied to a specific user.
 - `context.forRequest(req)` returns a `Db` that runs queries as the authenticated user who made the request, so permission policies apply to them rather than the server.
 
-`forRequest` reads authentication from standard HTTP headers, so `req` can be any object that exposes them&hairsp;—&hairsp;Express, Hono, Fastify, or a Web Fetch API `Request` all work.
+In TypeScript backends, create the context once with both `app` and `permissions`, then call `context.forRequest(req)` when you need a bearer-JWT-scoped high-level `Db`.
+
+`forRequest` reads authentication from standard HTTP headers, so `req` can be any object that exposes them: Express, Hono, Fastify, or a Web Fetch API `Request` all work.
 
 #### Per-request user-scoped client
 

--- a/docs/content/docs/reference/server-setup.mdx
+++ b/docs/content/docs/reference/server-setup.mdx
@@ -116,8 +116,7 @@ bearer-JWT-scoped high-level `Db`.
 `forRequest` reads authentication from standard HTTP headers, so `req` can be any object that exposes them: Express, Hono, Fastify, or a Web Fetch API `Request` all work.
 
 <Callout type="info">
-  `context.db()` still exists for embedded or local-only runtime setups, but it is not the primary
-  pattern for server-connected backends.
+  For embedded or local-only runtime setups where your backend is not connected to a server, use `context.db()` to get an unscoped, unauthenticated handle. This allows read/write access to the database directly, without permissions being evaluated.
 </Callout>
 
 #### Per-request user-scoped client

--- a/docs/content/docs/schemas/defining-tables.mdx
+++ b/docs/content/docs/schemas/defining-tables.mdx
@@ -1,42 +1,33 @@
 ---
 title: Defining Tables
-description: Define tables and relationships using the TypeScript DSL or SQL.
+description: Define tables and relationships in schema.ts using the TypeScript DSL.
 reviewedAt: "14cd73f0"
 ---
 
+import SchemaSetup from "../../partials/schema-setup.mdx";
+
 ## Table definitions
 
-Tables are defined in `schema/current.ts` using the Jazz DSL. Each `table()` call registers a table with its columns.
+Tables are defined in `schema.ts` using the Jazz DSL. Each `s.table(...)` call registers a table and `s.ref(...)` defines typed relations between them.
 
-<Tabs groupId="jazz-schema-format" items={["TypeScript", "SQL"]} persist updateAnchor>
-  <Tab value="TypeScript">
-    <include cwd lang="ts" meta='title="schema/current.ts"'>
-      ../examples/docs/todo-client-localfirst-ts/schema/current.ts#schema-todo-client-ts
-    </include>
-  </Tab>
-  <Tab value="SQL">
-    <include cwd lang="sql" meta='title="schema/current.sql"'>
-      ../examples/docs/todo-server-rs/schema/current.sql
-    </include>
-  </Tab>
-</Tabs>
-
-The TypeScript DSL uses `col.string`, `col.boolean`, `col.ref`, etc. SQL uses the equivalent `TEXT`, `BOOLEAN`, `UUID REFERENCES ...`. Use SQL when your project is Rust-first. See [Column Types](/docs/reference/column-types) for the full list.
-
-<Callout type="warn">
-  `col.ref()` columns must be named with an `Id` or `_id` suffix (e.g. `projectId`, `owner_id`). For
-  `col.array(col.ref())`, use an `Ids` or `_ids` suffix instead. The runtime enforces this
-  convention and will throw if a ref column name does not match.
-</Callout>
-
-## Codegen
-
-<include cwd lang="bash" meta='title="Terminal"'>
-  ../examples/docs/todo-client-localfirst-ts/docs/schema-codegen.sh#schemas-ts-codegen-cli
+<include cwd lang="ts" meta='title="schema.ts"'>
+  ../examples/docs/todo-client-localfirst-ts/schema.ts#schema-todo-client-ts
 </include>
 
-Run this from your project root. It regenerates `schema/current.sql` and typed client bindings (e.g. `schema/app.ts`) from `schema/current.ts`.
+The TypeScript DSL uses `s.string`, `s.boolean`, `s.ref`, and the other builders documented in [Column Types](/docs/reference/column-types). Rust consumers read the compiled structural schema, but authoring lives in TypeScript today.
 
-When you change your schema, Jazz generates migration stubs that translate data between versions. See [Migrations](/docs/schemas/migrations) for details.
+<Callout type="warn">
+  `s.ref()` columns must be named with an `Id` or `_id` suffix (for example `projectId` or
+  `owner_id`). For `s.array(s.ref())`, use an `Ids` or `_ids` suffix instead. The runtime enforces
+  this convention and will throw if a ref column name does not match.
+</Callout>
+
+## Validate locally
+
+<SchemaSetup />
+
+`schema.ts` is the source of truth. Jazz no longer generates `schema/app.ts` or `current.sql`.
+
+When you change your schema structurally on a shared app, create and push a reviewed migration edge. See [Migrations](/docs/schemas/migrations) for details.
 
 If you need to clear local browser data after a schema change, see [How do I reset browser storage?](/docs/reference/faq#reset-browser-storage).

--- a/docs/content/docs/schemas/migrations.mdx
+++ b/docs/content/docs/schemas/migrations.mdx
@@ -1,6 +1,6 @@
 ---
 title: Migrations
-description: Schema evolution workflow and generated migration stubs.
+description: Structural schema evolution workflow and reviewed migration edges.
 reviewedAt: "14cd73f0"
 ---
 
@@ -14,30 +14,50 @@ Traditional migration systems run a linear sequence and require peers to converg
 
 ## Workflow
 
-Edit your schema, then run `npx jazz-tools@alpha build` to generate migration stubs automatically:
+1. Edit `schema.ts` when you are changing data shape.
+2. Optionally run `npx jazz-tools validate` to catch local authoring errors.
+3. Once Jazz reports an old and new structural hash pair, generate a migration stub:
 
 <include cwd lang="bash">
   ../examples/docs/todo-server-ts/docs/migrations-workflow.sh#migrations-workflow-ts
 </include>
 
-Review the generated files, adjust any defaults, then commit.
+4. Review the generated file, rename it to something meaningful, then publish the reviewed edge.
+
+Permission-only changes in `permissions.ts` do not need migrations.
 
 ## Generated stub
 
-`npx jazz-tools@alpha build` generates a complete migration file per schema change, with the `migrate` section auto-populated&hairsp;—&hairsp;adds, drops, possible renames, and sensible defaults (nullable columns get `null`, non-nullable columns get type-appropriate defaults like `""` or `0`).
+`npx jazz-tools migrations create <fromHash> <toHash>` generates a `s.defineMigration(...)` stub with the structural diff already filled in.
 
 Here's a generated stub for adding a `description` column:
 
-<include cwd lang="ts" meta='title="migration_v1_v2_generated_stub.ts"'>
-  ../examples/docs/todo-server-ts/schema/migration_v1_v2_generated_stub_example.ts#migration-generated-stub-example
+<include cwd lang="ts" meta='title="migrations/20260318-unnamed-a01f5c72ec47-311995e9a178.ts"'>
+  ../examples/docs/todo-server-ts/migrations/20260318-unnamed-a01f5c72ec47-311995e9a178.ts
+</include>
+
+## Customizing defaults
+
+Review generated defaults before you publish. For example, you might replace a nullable default with a domain-specific value:
+
+<include
+  cwd
+  lang="ts"
+  meta='title="migrations/20260318-add-description-a01f5c72ec47-311995e9a178.ts"'
+>
+  ../examples/docs/todo-server-ts/migrations/20260318-add-description-a01f5c72ec47-311995e9a178.ts
 </include>
 
 ## Backwards defaults
 
 When a newer schema drops a column that older clients still expect, define a backwards default so the lens can supply a value for those clients:
 
-<include cwd lang="ts" meta='title="migration_v1_v2_backwards_default_example.ts"'>
-  ../examples/docs/todo-server-ts/schema/migration_v1_v2_backwards_default_example.ts#backwards-default-example
+<include
+  cwd
+  lang="ts"
+  meta='title="migrations/20260318-drop-legacy-priority-311995e9a178-73b65d082ab8.ts"'
+>
+  ../examples/docs/todo-server-ts/migrations/20260318-drop-legacy-priority-311995e9a178-73b65d082ab8.ts
 </include>
 
 ## Next steps

--- a/docs/content/docs/schemas/migrations.mdx
+++ b/docs/content/docs/schemas/migrations.mdx
@@ -15,7 +15,7 @@ Traditional migration systems run a linear sequence and require peers to converg
 ## Workflow
 
 1. Edit `schema.ts` when you are changing data shape.
-2. Optionally run `npx jazz-tools validate` to catch local authoring errors.
+2. Optionally run `npx jazz-tools@alpha validate` to catch local authoring errors.
 3. Once Jazz reports an old and new structural hash pair, generate a migration stub:
 
 <include cwd lang="bash">
@@ -24,11 +24,13 @@ Traditional migration systems run a linear sequence and require peers to converg
 
 4. Review the generated file, rename it to something meaningful, then publish the reviewed edge.
 
-Permission-only changes in `permissions.ts` do not need migrations.
+Permission-only changes in `permissions.ts` do not need migrations, but they do still require
+`npx jazz-tools@alpha permissions push`.
 
 ## Generated stub
 
-`npx jazz-tools migrations create <fromHash> <toHash>` generates a `s.defineMigration(...)` stub with the structural diff already filled in.
+`npx jazz-tools@alpha migrations create <fromHash> <toHash>` generates a
+`s.defineMigration(...)` stub with the structural diff already filled in.
 
 Here's a generated stub for adding a `description` column:
 

--- a/docs/content/docs/writing/files-and-blobs.mdx
+++ b/docs/content/docs/writing/files-and-blobs.mdx
@@ -8,7 +8,7 @@ This page explains how to store images and other binary blobs in Jazz using brow
 `File`, and `ReadableStream` values. These files benefit from the same sync, local-first storage,
 and permission model as the rest of your structured data.
 
-Use plain `col.bytes()` when the binary value is small, naturally belongs on the row itself, and
+Use plain `s.bytes()` when the binary value is small, naturally belongs on the row itself, and
 should always load together with the rest of that row.
 
 ## Add the Conventional Tables
@@ -16,8 +16,8 @@ should always load together with the rest of that row.
 `db.createFileFromBlob`, `db.createFileFromStream`, `db.loadFileAsBlob`, and
 `db.loadFileAsStream` currently expect these exact table and column names on `app`:
 
-<include cwd lang="ts" meta='title="schema/current.ts"'>
-  ../examples/docs/todo-client-localfirst-ts/schema/current.ts#schema-files-and-blobs-ts
+<include cwd lang="ts" meta='title="schema.ts"'>
+  ../examples/docs/todo-client-localfirst-ts/schema.ts#schema-files-and-blobs-ts
 </include>
 
 `file_parts.data` stores the raw chunk bytes. `files.partIds` keeps the ordered chunk ids, and
@@ -28,8 +28,8 @@ is optional metadata; `createFileFromBlob(...)` fills it from `File.name` when a
 
 ## Add Permissions
 
-<include cwd lang="ts" meta='title="schema/files-and-blobs-permissions.ts"'>
-  ../examples/docs/todo-client-localfirst-ts/schema/files-and-blobs-permissions.ts#files-permissions-ts
+<include cwd lang="ts" meta='title="files-and-blobs-permissions.ts"'>
+  ../examples/docs/todo-client-localfirst-ts/files-and-blobs-permissions.ts#files-permissions-ts
 </include>
 
 `uploads` owns access. `files` inherit read and delete access from `uploads.file`, and

--- a/docs/content/partials/available-column-types.mdx
+++ b/docs/content/partials/available-column-types.mdx
@@ -1,17 +1,21 @@
-| DSL                       | TypeScript type      | SQL type        |
-| ------------------------- | -------------------- | --------------- |
-| `col.string()`            | `string`             | `TEXT`          |
-| `col.boolean()`           | `boolean`            | `BOOLEAN`       |
-| `col.int()`               | `number`             | `INTEGER`       |
-| `col.float()`             | `number`             | `REAL`          |
-| `col.timestamp()`         | `Date \| number`     | `TIMESTAMP`     |
-| `col.bytes()`             | `Uint8Array`         | `BYTEA`         |
-| `col.ref("table")`        | `string` (row ID)    | `UUID` (FK)     |
-| `col.array(col.string())` | `string[]`           | `TEXT[]`        |
-| `col.enum("a", "b")`      | `"a" \| "b"`         | `ENUM('a','b')` |
-| `col.json()`              | `JsonValue`          | `JSON`          |
-| `col.json(schema)`        | inferred from schema | `JSON`          |
+There are a number of column types available which cover most common use cases:
 
-> **JSON columns are atomic.** The entire value is replaced on every write — you cannot update individual keys. Use `col.json()` for untyped JSON, or `col.json(schema)` with a [Zod](https://zod.dev)-compatible schema for typed validation. For structured data that needs per-field updates, use separate columns or a related table instead.
+| DSL                   | TypeScript type      | SQL type        |
+| --------------------- | -------------------- | --------------- |
+| `s.string()`          | `string`             | `TEXT`          |
+| `s.boolean()`         | `boolean`            | `BOOLEAN`       |
+| `s.int()`             | `number`             | `INTEGER`       |
+| `s.float()`           | `number`             | `REAL`          |
+| `s.timestamp()`       | `Date \| number`     | `TIMESTAMP`     |
+| `s.bytes()`           | `Uint8Array`         | `BYTEA`         |
+| `s.ref("table")`      | `string` (row ID)    | `UUID` (FK)     |
+| `s.array(s.string())` | `string[]`           | `TEXT[]`        |
+| `s.enum("a", "b")`    | `"a" \| "b"`         | `ENUM('a','b')` |
+| `s.json()`            | `JsonValue`          | `JSON`          |
+| `s.json(schema)`      | inferred from schema | `JSON`          |
 
-> **Ref naming convention:** `col.ref()` columns must have a name ending in `Id` or `_id`. For `col.array(col.ref())`, the name must end in `Ids` or `_ids`. The runtime will throw if a ref column does not follow this convention.
+Any column can be made nullable with `.optional()`.
+
+> **JSON columns are atomic.** The entire value is replaced on every write. Use `s.json()` for untyped JSON, or `s.json(schema)` with a [Zod](https://zod.dev)-compatible schema for typed validation. For structured data that needs per-field updates, use separate columns or a related table instead.
+
+> **Ref naming convention:** `s.ref()` columns must have a name ending in `Id` or `_id`. For `s.array(s.ref())`, the name must end in `Ids` or `_ids`. The runtime will throw if a ref column does not follow this convention.

--- a/docs/content/partials/mcp/install.sh
+++ b/docs/content/partials/mcp/install.sh
@@ -1,16 +1,16 @@
 #!/usr/bin/env bash
 # #region claude-code
-claude mcp add jazz-docs -- npx jazz-tools@alpha mcp
+claude mcp add jazz-docs -- npx jazz-tools mcp
 # #endregion claude-code
 
 # #region gemini
-gemini mcp add jazz-docs npx jazz-tools@alpha mcp
+gemini mcp add jazz-docs npx jazz-tools mcp
 # #endregion gemini
 
 # #region codex
-codex mcp add jazz-docs -- npx jazz-tools@alpha mcp
+codex mcp add jazz-docs -- npx jazz-tools mcp
 # #endregion codex
 
 # #region opencode
-opencode mcp add jazz-docs -- npx jazz-tools@alpha mcp
+opencode mcp add jazz-docs -- npx jazz-tools mcp
 # #endregion opencode

--- a/docs/content/partials/mcp/install.sh
+++ b/docs/content/partials/mcp/install.sh
@@ -1,16 +1,16 @@
 #!/usr/bin/env bash
 # #region claude-code
-claude mcp add jazz-docs -- npx jazz-tools mcp
+claude mcp add jazz-docs -- npx jazz-tools@alpha mcp
 # #endregion claude-code
 
 # #region gemini
-gemini mcp add jazz-docs npx jazz-tools mcp
+gemini mcp add jazz-docs npx jazz-tools@alpha mcp
 # #endregion gemini
 
 # #region codex
-codex mcp add jazz-docs -- npx jazz-tools mcp
+codex mcp add jazz-docs -- npx jazz-tools@alpha mcp
 # #endregion codex
 
 # #region opencode
-opencode mcp add jazz-docs -- npx jazz-tools mcp
+opencode mcp add jazz-docs -- npx jazz-tools@alpha mcp
 # #endregion opencode

--- a/docs/content/partials/schema-setup.mdx
+++ b/docs/content/partials/schema-setup.mdx
@@ -1,17 +1,18 @@
 import { Callout } from "fumadocs-ui/components/callout";
 
-Run the schema CLI from your app root:
+Run an optional schema sanity check from your app root:
 
-`npx jazz-tools validate`
+`npx jazz-tools@alpha validate`
 
 This validates `schema.ts` and the optional `permissions.ts`, then compiles them into Jazz's
 internal schema representation.
 
-When Jazz later reports an old and new schema hash pair, create and review a migration edge with:
+When Jazz later reports an old and new schema hash pair, create and review a migration edge as
+described in [Migrations](/docs/schemas/migrations):
 
 ```bash
-npx jazz-tools migrations create <fromHash> <toHash>
-npx jazz-tools migrations push <fromHash> <toHash>
+npx jazz-tools@alpha migrations create <fromHash> <toHash>
+npx jazz-tools@alpha migrations push <fromHash> <toHash>
 ```
 
 <Callout title="Source of truth">

--- a/docs/content/partials/schema-setup.mdx
+++ b/docs/content/partials/schema-setup.mdx
@@ -1,0 +1,19 @@
+import { Callout } from "fumadocs-ui/components/callout";
+
+Run the schema CLI from your app root:
+
+`npx jazz-tools validate`
+
+This validates `schema.ts` and the optional `permissions.ts`, then compiles them into Jazz's
+internal schema representation.
+
+When Jazz later reports an old and new schema hash pair, create and review a migration edge with:
+
+```bash
+npx jazz-tools migrations create <fromHash> <toHash>
+npx jazz-tools migrations push <fromHash> <toHash>
+```
+
+<Callout title="Source of truth">
+  `schema.ts` is the source of truth. Jazz no longer generates `schema/app.ts` or `current.sql`.
+</Callout>

--- a/docs/content/partials/schema-types-summary.mdx
+++ b/docs/content/partials/schema-types-summary.mdx
@@ -1,3 +1,3 @@
-The most common DSL column builders are `col.string()`, `col.boolean()`, `col.int()`, `col.float()`, `col.timestamp()`, `col.bytes()`, `col.ref("table")`, `col.array(col.string())`, `col.enum("a", "b")`, `col.json()`, and `col.json(schema)`.
+The most common DSL column builders are `s.string()`, `s.boolean()`, `s.int()`, `s.float()`, `s.timestamp()`, `s.bytes()`, `s.ref("table")`, `s.array(s.string())`, `s.enum("a", "b")`, `s.json()`, and `s.json(schema)`.
 
 For the full TypeScript/SQL mapping table, see [Schemas: available column types](/docs/reference/column-types).

--- a/docs/content/partials/where-operators-table.mdx
+++ b/docs/content/partials/where-operators-table.mdx
@@ -1,13 +1,15 @@
-| Column kind                       | Operators / shape                     |
-| --------------------------------- | ------------------------------------- |
-| `id`                              | `eq`, `ne`, `in`                      |
-| `col.string()`                    | `eq`, `ne`, `contains`                |
-| `col.boolean()`                   | plain boolean equality (`done: true`) |
-| `col.int()` / `col.float()`       | `eq`, `ne`, `gt`, `gte`, `lt`, `lte`  |
-| `col.timestamp()`                 | `eq`, `ne`, `gt`, `gte`, `lt`, `lte`  |
-| `col.bytes()`                     | `eq`, `ne`                            |
-| `col.ref("...")` (required)       | `eq`, `ne`                            |
-| `col.ref("...").optional()`       | `eq`, `ne`, `isNull`                  |
-| `col.enum(...)`                   | `eq`, `ne`, `in`                      |
-| `col.array(...)`                  | `eq`, `contains`                      |
-| `col.json()` / `col.json(schema)` | `eq`, `ne`, `in`                      |
+Operator support by column type (TypeScript):
+
+| Column kind                   | Operators / shape                     |
+| ----------------------------- | ------------------------------------- |
+| `id`                          | `eq`, `ne`, `in`                      |
+| `s.string()`                  | `eq`, `ne`, `contains`                |
+| `s.boolean()`                 | plain boolean equality (`done: true`) |
+| `s.int()` / `s.float()`       | `eq`, `ne`, `gt`, `gte`, `lt`, `lte`  |
+| `s.timestamp()`               | `eq`, `ne`, `gt`, `gte`, `lt`, `lte`  |
+| `s.bytes()`                   | `eq`, `ne`                            |
+| `s.ref("...")` (required)     | `eq`, `ne`                            |
+| `s.ref("...").optional()`     | `eq`, `ne`, `isNull`                  |
+| `s.enum(...)`                 | `eq`, `ne`, `in`                      |
+| `s.array(...)`                | `eq`, `contains`                      |
+| `s.json()` / `s.json(schema)` | `eq`, `ne`, `in`                      |

--- a/docs/global.d.ts
+++ b/docs/global.d.ts
@@ -1,0 +1,2 @@
+// Allow Next.js global CSS side-effect imports
+declare module "*.css";

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "baseUrl": ".",
     "target": "ESNext",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
@@ -17,7 +16,7 @@
     "incremental": true,
     "paths": {
       "@/*": ["./*"],
-      "fumadocs-mdx:collections/*": [".source/*"]
+      "fumadocs-mdx:collections/*": ["./.source/*"]
     },
     "plugins": [
       {

--- a/examples/docs/todo-client-localfirst-expo/babel.config.cjs
+++ b/examples/docs/todo-client-localfirst-expo/babel.config.cjs
@@ -2,10 +2,5 @@ module.exports = function (api) {
   api.cache(true);
   return {
     presets: [["babel-preset-expo", { unstable_transformImportMeta: true }]],
-    plugins: [
-      // Jazz codegen emits `declare` fields; the default flow-strip-types
-      // plugin rejects them unless this option is set.
-      ["@babel/plugin-transform-flow-strip-types", { allowDeclareFields: true }],
-    ],
   };
 };

--- a/examples/docs/todo-client-localfirst-expo/package.json
+++ b/examples/docs/todo-client-localfirst-expo/package.json
@@ -8,7 +8,7 @@
     "start": "expo start --clear",
     "android": "expo run:android",
     "ios": "expo run:ios",
-    "build": "jazz-tools build && tsc --noEmit",
+    "build": "jazz-tools validate && tsc --noEmit",
     "test": "tsc --noEmit",
     "prebuild": "expo prebuild --clean",
     "verify:expo:android": "expo prebuild --platform android --clean --no-install --non-interactive",

--- a/examples/docs/todo-client-localfirst-expo/permissions.ts
+++ b/examples/docs/todo-client-localfirst-expo/permissions.ts
@@ -1,0 +1,16 @@
+import { schema as s } from "jazz-tools";
+import { app } from "./schema.js";
+
+// #region permissions-basic-expo
+export default s.definePermissions(app, ({ policy, allOf, session }) => [
+  // Each user only sees their own rows.
+  policy.todos.allowRead.where({ ownerId: session.user_id }),
+  // New rows must belong to the current user.
+  policy.todos.allowInsert.where({ ownerId: session.user_id }),
+  // Users can only mutate their own incomplete todos.
+  policy.todos.allowUpdate
+    .whereOld(allOf([{ ownerId: session.user_id }, { done: false }]))
+    .whereNew({ ownerId: session.user_id }),
+  policy.todos.allowDelete.where(allOf([{ ownerId: session.user_id }, { done: false }])),
+]);
+// #endregion permissions-basic-expo

--- a/examples/docs/todo-client-localfirst-expo/schema.ts
+++ b/examples/docs/todo-client-localfirst-expo/schema.ts
@@ -1,0 +1,22 @@
+// #region schema-expo
+import { schema as s } from "jazz-tools";
+
+const schema = {
+  projects: s.table({
+    name: s.string(),
+  }),
+  todos: s.table({
+    title: s.string(),
+    done: s.boolean(),
+    description: s.string().optional(),
+    ownerId: s.string(),
+    parentId: s.ref("todos").optional(),
+    projectId: s.ref("projects").optional(),
+  }),
+};
+
+type AppSchema = s.Schema<typeof schema>;
+export const app: s.App<AppSchema> = s.defineApp(schema);
+
+export type Todo = s.RowOf<typeof app.todos>;
+// #endregion schema-expo

--- a/examples/docs/todo-client-localfirst-expo/src/AddTodo.tsx
+++ b/examples/docs/todo-client-localfirst-expo/src/AddTodo.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { Pressable, Text, TextInput, View } from "react-native";
 import { useDb } from "jazz-tools/react-native";
-import { app } from "../schema/app";
+import { app } from "../schema";
 
 export function AddTodo() {
   const db = useDb();

--- a/examples/docs/todo-client-localfirst-expo/src/ConditionalQueryExample.tsx
+++ b/examples/docs/todo-client-localfirst-expo/src/ConditionalQueryExample.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { Text, TextInput, View } from "react-native";
 import { useAll } from "jazz-tools/react-native";
-import { app } from "../schema/app";
+import { app } from "../schema";
 
 // #region reading-conditional-query-expo
 export function FilteredTodos() {

--- a/examples/docs/todo-client-localfirst-expo/src/LoadingStateExample.tsx
+++ b/examples/docs/todo-client-localfirst-expo/src/LoadingStateExample.tsx
@@ -1,6 +1,6 @@
 import { Text } from "react-native";
 import { useAll } from "jazz-tools/react-native";
-import { app } from "../schema/app";
+import { app } from "../schema";
 
 // #region reading-loading-state-expo
 export function TodoList() {

--- a/examples/docs/todo-client-localfirst-expo/src/TodoList.tsx
+++ b/examples/docs/todo-client-localfirst-expo/src/TodoList.tsx
@@ -10,7 +10,7 @@ import {
   type ListRenderItem,
 } from "react-native";
 import { useAll, useDb, useSession } from "jazz-tools/react-native";
-import { app, type Todo } from "../schema/app";
+import { app, type Todo } from "../schema";
 
 // #region read-write-expo
 export function TodoList() {

--- a/examples/docs/todo-client-localfirst-expo/src/docs-snippets.ts
+++ b/examples/docs/todo-client-localfirst-expo/src/docs-snippets.ts
@@ -1,5 +1,5 @@
 import type { Db } from "jazz-tools/react-native";
-import { app } from "../schema/app";
+import { app } from "../schema";
 
 const EXAMPLE_TODO_ID = "00000000-0000-0000-0000-000000000000";
 const EXAMPLE_PROJECT_ID = "00000000-0000-0000-0000-000000000000";

--- a/examples/docs/todo-client-localfirst-expo/src/quickstart-add.tsx
+++ b/examples/docs/todo-client-localfirst-expo/src/quickstart-add.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { Pressable, Text, TextInput, View } from "react-native";
 import { useDb, useSession } from "jazz-tools/react-native";
-import { app } from "../schema/app";
+import { app } from "../schema";
 
 export function AddTodo() {
   const db = useDb();

--- a/examples/docs/todo-client-localfirst-expo/src/quickstart-item.tsx
+++ b/examples/docs/todo-client-localfirst-expo/src/quickstart-item.tsx
@@ -1,6 +1,6 @@
 import { Pressable, Switch, Text, View } from "react-native";
 import { useDb, useAll } from "jazz-tools/react-native";
-import { app } from "../schema/app";
+import { app } from "../schema";
 
 export function TodoItem({ id }: { id: string }) {
   const db = useDb();

--- a/examples/docs/todo-client-localfirst-expo/src/quickstart-list.tsx
+++ b/examples/docs/todo-client-localfirst-expo/src/quickstart-list.tsx
@@ -1,6 +1,6 @@
 import { FlatList, View } from "react-native";
 import { useAll } from "jazz-tools/react-native";
-import { app } from "../schema/app";
+import { app } from "../schema";
 import { TodoItem } from "./TodoItem";
 import { AddTodo } from "./AddTodo";
 

--- a/examples/docs/todo-client-localfirst-expo/tsconfig.json
+++ b/examples/docs/todo-client-localfirst-expo/tsconfig.json
@@ -10,7 +10,6 @@
     "jsx": "react-jsx",
     "typeRoots": ["./node_modules/@types"]
   },
-  "include": ["App.tsx", "src/**/*", "schema/**/*"],
-  "exclude": ["schema/**/*.test.ts"],
+  "include": ["App.tsx", "src/**/*", "schema.ts", "permissions.ts"],
   "extends": "expo/tsconfig.base"
 }

--- a/examples/docs/todo-client-localfirst-react/package.json
+++ b/examples/docs/todo-client-localfirst-react/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "node ../../../packages/jazz-tools/dist/cli.js build && vite build",
+    "build": "node ../../../packages/jazz-tools/dist/cli.js validate && vite build",
     "preview": "vite preview",
     "test": "vitest run --config vitest.config.browser.ts"
   },

--- a/examples/docs/todo-client-localfirst-react/permissions.ts
+++ b/examples/docs/todo-client-localfirst-react/permissions.ts
@@ -1,0 +1,15 @@
+import { schema as s } from "jazz-tools";
+import { app } from "./schema.js";
+
+// #region permissions-basic-react
+export default s.definePermissions(app, ({ policy }) => [
+  // Everyone can read todos.
+  policy.todos.allowRead.where({}),
+  // New todos start as incomplete.
+  policy.todos.allowInsert.where({ done: false }),
+  // Completed todos are immutable.
+  policy.todos.allowUpdate.whereOld({ done: false }).whereNew({}),
+  // Only open todos can be deleted.
+  policy.todos.allowDelete.where({ done: false }),
+]);
+// #endregion permissions-basic-react

--- a/examples/docs/todo-client-localfirst-react/schema.ts
+++ b/examples/docs/todo-client-localfirst-react/schema.ts
@@ -1,0 +1,22 @@
+// #region schema-react
+import { schema as s } from "jazz-tools";
+
+const schema = {
+  projects: s.table({
+    name: s.string(),
+  }),
+  todos: s.table({
+    title: s.string(),
+    done: s.boolean(),
+    description: s.string().optional(),
+    parentId: s.ref("todos").optional(),
+    projectId: s.ref("projects").optional(),
+  }),
+};
+
+type AppSchema = s.Schema<typeof schema>;
+export const app: s.App<AppSchema> = s.defineApp(schema);
+
+export type Todo = s.RowOf<typeof app.todos>;
+export type TodoQueryBuilder = typeof app.todos;
+// #endregion schema-react

--- a/examples/docs/todo-client-localfirst-react/session-app.ts
+++ b/examples/docs/todo-client-localfirst-react/session-app.ts
@@ -1,0 +1,3 @@
+// Reuse the session-scoped todo schema from the Expo docs example so auth snippets
+// stay aligned across frontend frameworks.
+export { app } from "../todo-client-localfirst-expo/schema.js";

--- a/examples/docs/todo-client-localfirst-react/src/AuthSessionExamples.tsx
+++ b/examples/docs/todo-client-localfirst-react/src/AuthSessionExamples.tsx
@@ -1,5 +1,5 @@
 import { useAll, useDb, useSession } from "jazz-tools/react";
-import { app } from "../schema/session-app.js";
+import { app } from "../session-app.js";
 
 export function AuthSessionExamples() {
   const db = useDb();
@@ -14,7 +14,7 @@ export function AuthSessionExamples() {
 
   // #region auth-session-react-query
   const ownedTodos =
-    useAll(sessionUserId ? app.todos.where({ owner_id: sessionUserId }) : undefined) ?? [];
+    useAll(sessionUserId ? app.todos.where({ ownerId: sessionUserId }) : undefined) ?? [];
   // #endregion auth-session-react-query
 
   // #region auth-session-react-insert
@@ -24,7 +24,7 @@ export function AuthSessionExamples() {
     db.insert(app.todos, {
       title,
       done: false,
-      owner_id: sessionUserId,
+      ownerId: sessionUserId,
     });
   }
   // #endregion auth-session-react-insert

--- a/examples/docs/todo-client-localfirst-react/src/ConcurrentTodoList.tsx
+++ b/examples/docs/todo-client-localfirst-react/src/ConcurrentTodoList.tsx
@@ -1,6 +1,6 @@
 import { Suspense } from "react";
 import { useAllSuspense } from "jazz-tools/react";
-import { app } from "../schema/app.js";
+import { app } from "../schema.js";
 
 // #region reading-concurrent-rendering-react
 function TodoList() {

--- a/examples/docs/todo-client-localfirst-react/src/TodoList.tsx
+++ b/examples/docs/todo-client-localfirst-react/src/TodoList.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 // #region reading-reactive-hooks-react
 import { useDb, useAll } from "jazz-tools/react";
-import { app } from "../schema/app.js";
+import { app } from "../schema.js";
 
 export function TodoList() {
   // #region read-write-react

--- a/examples/docs/todo-client-localfirst-react/src/docs-snippets.ts
+++ b/examples/docs/todo-client-localfirst-react/src/docs-snippets.ts
@@ -1,5 +1,5 @@
 import type { Db } from "jazz-tools";
-import { app } from "../schema/app.js";
+import { app } from "../schema.js";
 
 const EXAMPLE_TODO_ID = "00000000-0000-0000-0000-000000000000";
 const EXAMPLE_PROJECT_ID = "00000000-0000-0000-0000-000000000000";
@@ -29,7 +29,7 @@ export async function whereExamples(db: Db) {
 
   // Explicit operators
   await db.all(app.todos.where({ title: { contains: "milk" } }));
-  await db.all(app.todos.where({ project: { ne: EXAMPLE_PROJECT_ID } }));
+  await db.all(app.todos.where({ projectId: { ne: EXAMPLE_PROJECT_ID } }));
 }
 // #endregion where-operators-react
 

--- a/examples/docs/todo-client-localfirst-react/src/framework-pattern-snippets.tsx
+++ b/examples/docs/todo-client-localfirst-react/src/framework-pattern-snippets.tsx
@@ -1,5 +1,5 @@
 import { JazzProvider, useAll, useDb, useSession } from "jazz-tools/react";
-import { app } from "../schema/app.js";
+import { app } from "../schema.js";
 
 function YourApp() {
   return null;

--- a/examples/docs/todo-client-localfirst-react/src/quickstart-add.tsx
+++ b/examples/docs/todo-client-localfirst-react/src/quickstart-add.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useDb } from "jazz-tools/react";
-import { app } from "../schema/app.js";
+import { app } from "../schema.js";
 
 export function AddTodo() {
   const db = useDb();

--- a/examples/docs/todo-client-localfirst-react/src/quickstart-item.tsx
+++ b/examples/docs/todo-client-localfirst-react/src/quickstart-item.tsx
@@ -1,5 +1,5 @@
 import { useDb, useAll } from "jazz-tools/react";
-import { app } from "../schema/app.js";
+import { app } from "../schema.js";
 
 export function TodoItem({ id }: { id: string }) {
   const db = useDb();

--- a/examples/docs/todo-client-localfirst-react/src/quickstart-list.tsx
+++ b/examples/docs/todo-client-localfirst-react/src/quickstart-list.tsx
@@ -1,5 +1,5 @@
 import { useAll } from "jazz-tools/react";
-import { app } from "../schema/app.js";
+import { app } from "../schema.js";
 import { TodoItem } from "./TodoItem.js";
 import { AddTodo } from "./AddTodo.js";
 

--- a/examples/docs/todo-client-localfirst-react/tsconfig.json
+++ b/examples/docs/todo-client-localfirst-react/tsconfig.json
@@ -9,5 +9,5 @@
     "resolveJsonModule": true,
     "jsx": "react-jsx"
   },
-  "include": ["src", "schema"]
+  "include": ["src", "schema.ts", "permissions.ts", "session-app.ts"]
 }

--- a/examples/docs/todo-client-localfirst-svelte/package.json
+++ b/examples/docs/todo-client-localfirst-svelte/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "node ../../../packages/jazz-tools/dist/cli.js build && vite build",
+    "build": "node ../../../packages/jazz-tools/dist/cli.js validate && vite build",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/examples/docs/todo-client-localfirst-svelte/permissions.ts
+++ b/examples/docs/todo-client-localfirst-svelte/permissions.ts
@@ -1,0 +1,15 @@
+import { schema as s } from "jazz-tools";
+import { app } from "./schema.js";
+
+// #region permissions-basic-svelte
+export default s.definePermissions(app, ({ policy }) => [
+  // Everyone can read todos.
+  policy.todos.allowRead.where({}),
+  // New todos start as incomplete.
+  policy.todos.allowInsert.where({ done: false }),
+  // Completed todos are immutable.
+  policy.todos.allowUpdate.whereOld({ done: false }).whereNew({}),
+  // Only open todos can be deleted.
+  policy.todos.allowDelete.where({ done: false }),
+]);
+// #endregion permissions-basic-svelte

--- a/examples/docs/todo-client-localfirst-svelte/schema.ts
+++ b/examples/docs/todo-client-localfirst-svelte/schema.ts
@@ -1,0 +1,19 @@
+// #region schema-svelte
+import { schema as s } from "jazz-tools";
+
+const schema = {
+  projects: s.table({
+    name: s.string(),
+  }),
+  todos: s.table({
+    title: s.string(),
+    done: s.boolean(),
+    description: s.string().optional(),
+    parentId: s.ref("todos").optional(),
+    projectId: s.ref("projects").optional(),
+  }),
+};
+
+type AppSchema = s.Schema<typeof schema>;
+export const app: s.App<AppSchema> = s.defineApp(schema);
+// #endregion schema-svelte

--- a/examples/docs/todo-client-localfirst-svelte/session-app.ts
+++ b/examples/docs/todo-client-localfirst-svelte/session-app.ts
@@ -1,0 +1,3 @@
+// Reuse the session-scoped todo schema from the Expo docs example so auth snippets
+// stay aligned across frontend frameworks.
+export { app } from "../todo-client-localfirst-expo/schema.js";

--- a/examples/docs/todo-client-localfirst-svelte/src/AuthSessionExamples.svelte
+++ b/examples/docs/todo-client-localfirst-svelte/src/AuthSessionExamples.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  import { getDb, getSession, QuerySubscription } from 'jazz-tools/svelte';
-  import { app } from '../schema/session-app.js';
+	import { getDb, getSession, QuerySubscription } from 'jazz-tools/svelte';
+	import { app } from '../session-app.js';
 
   const db = getDb();
 
@@ -14,7 +14,7 @@
 
   // #region auth-session-svelte-query
   const ownedTodos = new QuerySubscription(
-    app.todos.where({ owner_id: sessionUserId ?? '__no-session__' }),
+    app.todos.where({ ownerId: sessionUserId ?? '__no-session__' }),
   );
   // #endregion auth-session-svelte-query
 
@@ -25,7 +25,7 @@
     db.insert(app.todos, {
       title,
       done: false,
-      owner_id: sessionUserId,
+      ownerId: sessionUserId,
     });
   }
   // #endregion auth-session-svelte-insert

--- a/examples/docs/todo-client-localfirst-svelte/src/ConditionalQueryExample.svelte
+++ b/examples/docs/todo-client-localfirst-svelte/src/ConditionalQueryExample.svelte
@@ -1,7 +1,7 @@
 <!-- #region reading-conditional-query-svelte -->
 <script lang="ts">
   import { QuerySubscription } from 'jazz-tools/svelte';
-  import { app } from '../schema/app.js';
+  import { app } from '../schema.js';
 
   let filter = $state<string | null>(null);
 

--- a/examples/docs/todo-client-localfirst-svelte/src/DbSessionExamples.svelte
+++ b/examples/docs/todo-client-localfirst-svelte/src/DbSessionExamples.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { getDb, getSession } from 'jazz-tools/svelte';
-  import { app } from '../schema/app.js';
+  import { app } from '../schema.js';
 
   // #region db-access-svelte
   // Callable anywhere — component, store, or utility module

--- a/examples/docs/todo-client-localfirst-svelte/src/LiveQueryExample.svelte
+++ b/examples/docs/todo-client-localfirst-svelte/src/LiveQueryExample.svelte
@@ -1,7 +1,7 @@
 <!-- #region reading-loading-state-svelte -->
 <script lang="ts">
   import { QuerySubscription } from 'jazz-tools/svelte';
-  import { app } from '../schema/app.js';
+  import { app } from '../schema.js';
 
   const todos = new QuerySubscription(app.todos);
   // .current: undefined = not yet connected; [] = connected, no rows; [...] = rows present

--- a/examples/docs/todo-client-localfirst-svelte/src/QuerySubscriptionExample.svelte
+++ b/examples/docs/todo-client-localfirst-svelte/src/QuerySubscriptionExample.svelte
@@ -1,7 +1,7 @@
 <!-- #region query-subscription-svelte -->
 <script lang="ts">
   import { QuerySubscription } from 'jazz-tools/svelte';
-  import { app } from '../schema/app.js';
+  import { app } from '../schema.js';
 
   const todos = new QuerySubscription(
     app.todos.where({ done: false }),

--- a/examples/docs/todo-client-localfirst-svelte/src/TodoList.svelte
+++ b/examples/docs/todo-client-localfirst-svelte/src/TodoList.svelte
@@ -1,10 +1,10 @@
 <!-- #region read-write-svelte -->
 <script lang="ts">
-  // #region reading-reactive-svelte
-  import { getDb, QuerySubscription } from 'jazz-tools/svelte';
-  import { app } from '../schema/app.js';
+	import { getDb, QuerySubscription } from 'jazz-tools/svelte';
+	import { app } from '../schema.js';
 
   const db = getDb();
+  // #region reading-reactive-svelte
   const todos = new QuerySubscription(app.todos);
   // #endregion reading-reactive-svelte
 

--- a/examples/docs/todo-client-localfirst-svelte/src/docs-snippets.ts
+++ b/examples/docs/todo-client-localfirst-svelte/src/docs-snippets.ts
@@ -1,5 +1,5 @@
 import type { Db } from "jazz-tools";
-import { app } from "../schema/app.js";
+import { app } from "../schema.js";
 
 // #region oneshot-svelte
 export async function readTodosOneshot(db: Db) {

--- a/examples/docs/todo-client-localfirst-svelte/src/quickstart-add.svelte
+++ b/examples/docs/todo-client-localfirst-svelte/src/quickstart-add.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { getDb } from 'jazz-tools/svelte';
-  import { app } from '../schema/app.js';
+  import { app } from '../schema.js';
 
   const db = getDb();
   let title = $state('');

--- a/examples/docs/todo-client-localfirst-svelte/src/quickstart-item.svelte
+++ b/examples/docs/todo-client-localfirst-svelte/src/quickstart-item.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { getDb, QuerySubscription } from 'jazz-tools/svelte';
-  import { app } from '../schema/app.js';
+  import { app } from '../schema.js';
 
   const { id }: { id: string } = $props();
 

--- a/examples/docs/todo-client-localfirst-svelte/src/quickstart-list.svelte
+++ b/examples/docs/todo-client-localfirst-svelte/src/quickstart-list.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { QuerySubscription } from 'jazz-tools/svelte';
-  import { app } from '../schema/app.js';
+  import { app } from '../schema.js';
   import TodoItem from './TodoItem.svelte';
   import AddTodo from './AddTodo.svelte';
 

--- a/examples/docs/todo-client-localfirst-svelte/tsconfig.json
+++ b/examples/docs/todo-client-localfirst-svelte/tsconfig.json
@@ -8,5 +8,5 @@
     "skipLibCheck": true,
     "resolveJsonModule": true
   },
-  "include": ["src", "schema"]
+  "include": ["src", "schema.ts", "permissions.ts", "session-app.ts"]
 }

--- a/examples/docs/todo-client-localfirst-ts/docs/schema-codegen.sh
+++ b/examples/docs/todo-client-localfirst-ts/docs/schema-codegen.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-
-# #region schemas-ts-codegen-cli
-# Regenerate SQL and typed TS bindings from schema/current.ts.
-npx jazz-tools@alpha build
-# #endregion schemas-ts-codegen-cli

--- a/examples/docs/todo-client-localfirst-ts/files-and-blobs-permissions.ts
+++ b/examples/docs/todo-client-localfirst-ts/files-and-blobs-permissions.ts
@@ -1,0 +1,21 @@
+import { schema as s } from "jazz-tools";
+import { app } from "./schema.js";
+
+// #region files-permissions-ts
+export const fileBlobPermissions = s.definePermissions(app, ({ policy, allowedTo, session }) => {
+  policy.uploads.allowRead.where({ ownerId: session.user_id });
+  policy.uploads.allowInsert.where({ ownerId: session.user_id });
+  policy.uploads.allowUpdate.where({ ownerId: session.user_id });
+  policy.uploads.allowDelete.where({ ownerId: session.user_id });
+
+  // Files are created before the parent upload row exists, so inserts are direct for now.
+  policy.files.allowInsert.where({});
+  policy.file_parts.allowInsert.where({});
+
+  policy.files.allowRead.where(allowedTo.readReferencing(policy.uploads, "fileId"));
+  policy.file_parts.allowRead.where(allowedTo.readReferencing(policy.files, "partIds"));
+
+  policy.files.allowDelete.where(allowedTo.deleteReferencing(policy.uploads, "fileId"));
+  policy.file_parts.allowDelete.where(allowedTo.deleteReferencing(policy.files, "partIds"));
+});
+// #endregion files-permissions-ts

--- a/examples/docs/todo-client-localfirst-ts/package.json
+++ b/examples/docs/todo-client-localfirst-ts/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "node ../../../packages/jazz-tools/dist/cli.js build && vite build",
+    "build": "node ../../../packages/jazz-tools/dist/cli.js validate && vite build",
     "preview": "vite preview",
     "test": "vitest run --config vitest.config.browser.ts"
   },

--- a/examples/docs/todo-client-localfirst-ts/permissions.ts
+++ b/examples/docs/todo-client-localfirst-ts/permissions.ts
@@ -1,0 +1,9 @@
+import { schema as s } from "jazz-tools";
+import { app } from "./schema.js";
+
+export default s.definePermissions(app, ({ policy }) => {
+  policy.todos.allowRead.where({});
+  policy.todos.allowInsert.where({});
+  policy.todos.allowUpdate.where({});
+  policy.todos.allowDelete.where({});
+});

--- a/examples/docs/todo-client-localfirst-ts/schema.ts
+++ b/examples/docs/todo-client-localfirst-ts/schema.ts
@@ -1,0 +1,39 @@
+import { schema as s } from "jazz-tools";
+
+const schema = {
+  // #region schema-todo-client-ts
+  projects: s.table({
+    name: s.string(),
+  }),
+  todos: s.table({
+    title: s.string(),
+    done: s.boolean(),
+    description: s.string().optional(),
+    ownerId: s.string().optional(),
+    parentId: s.ref("todos").optional(),
+    projectId: s.ref("projects").optional(),
+  }),
+  // #endregion schema-todo-client-ts
+
+  // #region schema-files-and-blobs-ts
+  file_parts: s.table({
+    data: s.bytes(),
+  }),
+  files: s.table({
+    name: s.string().optional(),
+    mimeType: s.string(),
+    partIds: s.array(s.ref("file_parts")),
+    partSizes: s.array(s.int()),
+  }),
+  uploads: s.table({
+    ownerId: s.string(),
+    label: s.string(),
+    fileId: s.ref("files"),
+  }),
+  // #endregion schema-files-and-blobs-ts
+};
+
+type AppSchema = s.Schema<typeof schema>;
+export const app: s.App<AppSchema> = s.defineApp(schema);
+
+export type Todo = s.RowOf<typeof app.todos>;

--- a/examples/docs/todo-client-localfirst-ts/session-app.ts
+++ b/examples/docs/todo-client-localfirst-ts/session-app.ts
@@ -1,0 +1,3 @@
+// Reuse the session-scoped todo schema from the Expo docs example so auth snippets
+// stay aligned across frontend frameworks.
+export { app } from "../todo-client-localfirst-expo/schema.js";

--- a/examples/docs/todo-client-localfirst-ts/src/auth-session-snippets.ts
+++ b/examples/docs/todo-client-localfirst-ts/src/auth-session-snippets.ts
@@ -1,5 +1,5 @@
 import { createDb, resolveClientSession, type DbConfig } from "jazz-tools";
-import { app } from "../schema/session-app.js";
+import { app } from "../session-app.js";
 
 export async function authSessionExamples(config: DbConfig) {
   const db = await createDb(config);

--- a/examples/docs/todo-client-localfirst-ts/src/docs-snippets.ts
+++ b/examples/docs/todo-client-localfirst-ts/src/docs-snippets.ts
@@ -1,5 +1,5 @@
 import type { Db } from "jazz-tools";
-import { app } from "../schema/app.js";
+import { app } from "../schema.js";
 
 const EXAMPLE_PROJECT_ID = "00000000-0000-0000-0000-000000000000";
 const EXAMPLE_OWNER_ID = "local:example-owner";

--- a/examples/docs/todo-client-localfirst-ts/src/files-and-blobs-snippets.ts
+++ b/examples/docs/todo-client-localfirst-ts/src/files-and-blobs-snippets.ts
@@ -1,5 +1,5 @@
 import type { Db } from "jazz-tools";
-import { app } from "../schema/app.js";
+import { app } from "../schema.js";
 
 const EXAMPLE_OWNER_ID = "local:example-owner";
 

--- a/examples/docs/todo-client-localfirst-ts/src/main.ts
+++ b/examples/docs/todo-client-localfirst-ts/src/main.ts
@@ -1,6 +1,6 @@
 import { createDb, type DbConfig, type Db } from "jazz-tools";
 import { authSessionExamples } from "./auth-session-snippets.js";
-import { app, Todo } from "../schema/app.js";
+import { app, type Todo } from "../schema.js";
 
 // Keep docs-only auth snippets in the compiled example app.
 void authSessionExamples;

--- a/examples/docs/todo-client-localfirst-ts/src/quickstart-item.ts
+++ b/examples/docs/todo-client-localfirst-ts/src/quickstart-item.ts
@@ -1,7 +1,7 @@
 import type { Db } from "jazz-tools";
-import type { Todo, GeneratedApp } from "../schema/app.js";
+import { app as schemaApp, type Todo } from "../schema.js";
 
-export function renderTodoItem(todo: Todo, db: Db, app: GeneratedApp) {
+export function renderTodoItem(todo: Todo, db: Db, app: typeof schemaApp) {
   const li = Object.assign(document.createElement("li"), {
     textContent: todo.title,
   });

--- a/examples/docs/todo-client-localfirst-ts/src/quickstart-list.html
+++ b/examples/docs/todo-client-localfirst-ts/src/quickstart-list.html
@@ -8,7 +8,7 @@
     </form>
     <script type="module">
       import { createDb } from "jazz-tools";
-      import { app } from "./schema/app.js";
+      import { app } from "./schema.js";
 
       const db = await createDb({
         appId: "my-todo-app",

--- a/examples/docs/todo-client-localfirst-ts/src/quickstart.ts
+++ b/examples/docs/todo-client-localfirst-ts/src/quickstart.ts
@@ -1,6 +1,6 @@
 // #region setup-ts
 import { createDb } from "jazz-tools";
-import { app } from "../schema/app.js";
+import { app } from "../schema.js";
 import { renderTodoItem } from "./TodoItem.js";
 
 const db = await createDb({

--- a/examples/docs/todo-client-localfirst-ts/tests/browser/files-and-blobs-snippets.test.ts
+++ b/examples/docs/todo-client-localfirst-ts/tests/browser/files-and-blobs-snippets.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { Db } from "jazz-tools";
-import { app } from "../../schema/app.js";
-import { fileBlobPermissions } from "../../schema/files-and-blobs-permissions.js";
+import { app } from "../../schema.js";
+import { fileBlobPermissions } from "../../files-and-blobs-permissions.js";
 import {
   createUploadFromBlob,
   createUploadFromStream,

--- a/examples/docs/todo-client-localfirst-ts/tsconfig.json
+++ b/examples/docs/todo-client-localfirst-ts/tsconfig.json
@@ -8,5 +8,11 @@
     "skipLibCheck": true,
     "resolveJsonModule": true
   },
-  "include": ["src", "schema"]
+  "include": [
+    "src",
+    "schema.ts",
+    "permissions.ts",
+    "files-and-blobs-permissions.ts",
+    "session-app.ts"
+  ]
 }

--- a/examples/docs/todo-client-localfirst-vue/package.json
+++ b/examples/docs/todo-client-localfirst-vue/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "node ../../../packages/jazz-tools/dist/cli.js build && vite build",
+    "build": "node ../../../packages/jazz-tools/dist/cli.js validate && vite build",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/examples/docs/todo-client-localfirst-vue/permissions.ts
+++ b/examples/docs/todo-client-localfirst-vue/permissions.ts
@@ -1,0 +1,11 @@
+import { schema as s } from "jazz-tools";
+import { app } from "./schema.js";
+
+// #region permissions-basic-vue
+export default s.definePermissions(app, ({ policy }) => [
+  policy.todos.allowRead.where({}),
+  policy.todos.allowInsert.where({ done: false }),
+  policy.todos.allowUpdate.whereOld({ done: false }).whereNew({}),
+  policy.todos.allowDelete.where({ done: false }),
+]);
+// #endregion permissions-basic-vue

--- a/examples/docs/todo-client-localfirst-vue/schema.ts
+++ b/examples/docs/todo-client-localfirst-vue/schema.ts
@@ -1,0 +1,19 @@
+// #region schema-vue
+import { schema as s } from "jazz-tools";
+
+const schema = {
+  projects: s.table({
+    name: s.string(),
+  }),
+  todos: s.table({
+    title: s.string(),
+    done: s.boolean(),
+    description: s.string().optional(),
+    parentId: s.ref("todos").optional(),
+    projectId: s.ref("projects").optional(),
+  }),
+};
+
+type AppSchema = s.Schema<typeof schema>;
+export const app: s.App<AppSchema> = s.defineApp(schema);
+// #endregion schema-vue

--- a/examples/docs/todo-client-localfirst-vue/session-app.ts
+++ b/examples/docs/todo-client-localfirst-vue/session-app.ts
@@ -1,0 +1,3 @@
+// Reuse the session-scoped todo schema from the Expo docs example so auth snippets
+// stay aligned across frontend frameworks.
+export { app } from "../todo-client-localfirst-expo/schema.js";

--- a/examples/docs/todo-client-localfirst-vue/src/AuthSessionExamples.vue
+++ b/examples/docs/todo-client-localfirst-vue/src/AuthSessionExamples.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { useAll, useDb, useSession } from "jazz-tools/vue";
-import { app } from "../schema/session-app.js";
+import { app } from "../session-app.js";
 
 const db = useDb();
 
@@ -13,7 +13,7 @@ const sessionUserId = session?.user_id ?? null;
 // #endregion auth-session-vue-user-id
 
 // #region auth-session-vue-query
-const ownedTodos = useAll(app.todos.where({ owner_id: sessionUserId ?? "__no-session__" }));
+const ownedTodos = useAll(app.todos.where({ ownerId: sessionUserId ?? "__no-session__" }));
 // #endregion auth-session-vue-query
 
 // #region auth-session-vue-insert
@@ -23,7 +23,7 @@ function addOwnedTodo(title: string) {
   db.insert(app.todos, {
     title,
     done: false,
-    owner_id: sessionUserId,
+    ownerId: sessionUserId,
   });
 }
 // #endregion auth-session-vue-insert

--- a/examples/docs/todo-client-localfirst-vue/src/ConditionalQueryExample.vue
+++ b/examples/docs/todo-client-localfirst-vue/src/ConditionalQueryExample.vue
@@ -2,7 +2,7 @@
 <script setup lang="ts">
 import { ref, computed } from "vue";
 import { useAll } from "jazz-tools/vue";
-import { app } from "../schema/app.js";
+import { app } from "../schema.js";
 
 const filter = ref<string | null>(null);
 const query = computed(() =>

--- a/examples/docs/todo-client-localfirst-vue/src/DbSessionExamples.vue
+++ b/examples/docs/todo-client-localfirst-vue/src/DbSessionExamples.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { useDb, useSession } from "jazz-tools/vue";
-import { app } from "../schema/app.js";
+import { app } from "../schema.js";
 
 // #region db-access-vue
 // Must be called inside setup() or <script setup>

--- a/examples/docs/todo-client-localfirst-vue/src/LiveQueryExample.vue
+++ b/examples/docs/todo-client-localfirst-vue/src/LiveQueryExample.vue
@@ -1,7 +1,7 @@
 <!-- #region reading-loading-state-vue -->
 <script setup lang="ts">
 import { useAll } from "jazz-tools/vue";
-import { app } from "../schema/app.js";
+import { app } from "../schema.js";
 
 const todos = useAll(app.todos);
 // undefined = not yet connected; [] = connected, no rows; [...] = rows present

--- a/examples/docs/todo-client-localfirst-vue/src/QuerySubscriptionExample.vue
+++ b/examples/docs/todo-client-localfirst-vue/src/QuerySubscriptionExample.vue
@@ -1,7 +1,7 @@
 <!-- #region query-subscription-vue -->
 <script setup lang="ts">
 import { useAll } from "jazz-tools/vue";
-import { app } from "../schema/app.js";
+import { app } from "../schema.js";
 
 const todos = useAll(app.todos.where({ done: false }));
 </script>

--- a/examples/docs/todo-client-localfirst-vue/src/TodoList.vue
+++ b/examples/docs/todo-client-localfirst-vue/src/TodoList.vue
@@ -2,7 +2,7 @@
 import { ref } from "vue";
 // #region reading-reactive-hooks-vue
 import { useAll, useDb } from "jazz-tools/vue";
-import { app } from "../schema/app.js";
+import { app } from "../schema.js";
 
 const db = useDb();
 const todos = useAll(app.todos);

--- a/examples/docs/todo-client-localfirst-vue/src/docs-snippets.ts
+++ b/examples/docs/todo-client-localfirst-vue/src/docs-snippets.ts
@@ -1,5 +1,5 @@
 import type { Db } from "jazz-tools";
-import { app } from "../schema/app.js";
+import { app } from "../schema.js";
 
 const EXAMPLE_TODO_ID = "00000000-0000-0000-0000-000000000000";
 const EXAMPLE_PROJECT_ID = "00000000-0000-0000-0000-000000000000";
@@ -26,7 +26,7 @@ export function subscribeTodos(db: Db, onUpdate: (results: unknown[]) => void) {
 export async function whereExamples(db: Db) {
   await db.all(app.todos.where({ done: false }));
   await db.all(app.todos.where({ title: { contains: "milk" } }));
-  await db.all(app.todos.where({ project: { ne: EXAMPLE_PROJECT_ID } }));
+  await db.all(app.todos.where({ projectId: { ne: EXAMPLE_PROJECT_ID } }));
 }
 // #endregion where-operators-vue
 

--- a/examples/docs/todo-client-localfirst-vue/src/quickstart-add.vue
+++ b/examples/docs/todo-client-localfirst-vue/src/quickstart-add.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref } from "vue";
 import { useDb } from "jazz-tools/vue";
-import { app } from "../schema/app.js";
+import { app } from "../schema.js";
 
 const db = useDb();
 const title = ref("");

--- a/examples/docs/todo-client-localfirst-vue/src/quickstart-item.vue
+++ b/examples/docs/todo-client-localfirst-vue/src/quickstart-item.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed } from "vue";
 import { useDb, useAll } from "jazz-tools/vue";
-import { app } from "../schema/app.js";
+import { app } from "../schema.js";
 
 const props = defineProps<{ id: string }>();
 

--- a/examples/docs/todo-client-localfirst-vue/src/quickstart-list.vue
+++ b/examples/docs/todo-client-localfirst-vue/src/quickstart-list.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { useAll } from "jazz-tools/vue";
-import { app } from "../schema/app.js";
+import { app } from "../schema.js";
 import TodoItem from "./TodoItem.vue";
 import AddTodo from "./AddTodo.vue";
 

--- a/examples/docs/todo-client-localfirst-vue/src/vite-env.d.ts
+++ b/examples/docs/todo-client-localfirst-vue/src/vite-env.d.ts
@@ -1,1 +1,8 @@
 /// <reference types="vite/client" />
+
+declare module "*.vue" {
+  import type { DefineComponent } from "vue";
+
+  const component: DefineComponent<Record<string, never>, Record<string, never>, any>;
+  export default component;
+}

--- a/examples/docs/todo-client-localfirst-vue/tsconfig.json
+++ b/examples/docs/todo-client-localfirst-vue/tsconfig.json
@@ -11,5 +11,5 @@
     "resolveJsonModule": true,
     "types": ["vite/client"]
   },
-  "include": ["src", "schema"]
+  "include": ["src", "schema.ts", "permissions.ts", "session-app.ts"]
 }

--- a/examples/docs/todo-server-rs/docs/migrations-workflow.sh
+++ b/examples/docs/todo-server-rs/docs/migrations-workflow.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
 
-# #region migrations-workflow-sql
-# 1) Edit schema/current.sql.
-# 2) Generate migration stubs from the updated schema.
-npx jazz-tools@alpha build
-# #endregion migrations-workflow-sql
+# #region migrations-workflow-rust
+# 1) Edit schema.ts during development and watch for Jazz migration warnings.
+
+# 2) Generate a typed migration stub after Jazz reports the old/new hashes.
+npx jazz-tools migrations create <fromHash> <toHash>
+
+# 3) Fill in migrate, rename the file, then publish the reviewed edge.
+npx jazz-tools migrations push <fromHash> <toHash>
+# #endregion migrations-workflow-rust

--- a/examples/docs/todo-server-rs/docs/migrations-workflow.sh
+++ b/examples/docs/todo-server-rs/docs/migrations-workflow.sh
@@ -4,8 +4,8 @@
 # 1) Edit schema.ts during development and watch for Jazz migration warnings.
 
 # 2) Generate a typed migration stub after Jazz reports the old/new hashes.
-npx jazz-tools migrations create <fromHash> <toHash>
+npx jazz-tools@alpha migrations create <fromHash> <toHash>
 
 # 3) Fill in migrate, rename the file, then publish the reviewed edge.
-npx jazz-tools migrations push <fromHash> <toHash>
+npx jazz-tools@alpha migrations push <fromHash> <toHash>
 # #endregion migrations-workflow-rust

--- a/examples/docs/todo-server-rs/docs/self-host-cli.sh
+++ b/examples/docs/todo-server-rs/docs/self-host-cli.sh
@@ -4,7 +4,7 @@
 export JAZZ_APP_ID="replace-with-your-app-id"
 export JAZZ_ADMIN_SECRET="replace-with-admin-secret"
 
-npx jazz-tools server "$JAZZ_APP_ID" \
+npx jazz-tools@alpha server "$JAZZ_APP_ID" \
   --port 1625 \
   --data-dir ./data \
   --admin-secret "$JAZZ_ADMIN_SECRET"

--- a/examples/docs/todo-server-rs/docs/self-host-cli.sh
+++ b/examples/docs/todo-server-rs/docs/self-host-cli.sh
@@ -4,7 +4,7 @@
 export JAZZ_APP_ID="replace-with-your-app-id"
 export JAZZ_ADMIN_SECRET="replace-with-admin-secret"
 
-npx jazz-tools@alpha server "$JAZZ_APP_ID" \
+npx jazz-tools server "$JAZZ_APP_ID" \
   --port 1625 \
   --data-dir ./data \
   --admin-secret "$JAZZ_ADMIN_SECRET"

--- a/examples/docs/todo-server-rs/migrations/20260318-unnamed-a01f5c72ec47-311995e9a178.ts
+++ b/examples/docs/todo-server-rs/migrations/20260318-unnamed-a01f5c72ec47-311995e9a178.ts
@@ -1,0 +1,29 @@
+import { schema as s } from "jazz-tools";
+
+// Rust apps use the same TypeScript migration files and push them with the same CLI.
+export default s.defineMigration({
+  migrate: {
+    todos: {
+      description: s.add.string({ default: null }),
+    },
+  },
+  fromHash: "a01f5c72ec47",
+  toHash: "311995e9a178",
+  from: {
+    todos: s.table({
+      title: s.string(),
+      done: s.boolean(),
+      parent: s.ref("todos").optional(),
+      project: s.ref("projects").optional(),
+    }),
+  },
+  to: {
+    todos: s.table({
+      title: s.string(),
+      done: s.boolean(),
+      description: s.string().optional(),
+      parent: s.ref("todos").optional(),
+      project: s.ref("projects").optional(),
+    }),
+  },
+});

--- a/examples/docs/todo-server-rs/permissions.ts
+++ b/examples/docs/todo-server-rs/permissions.ts
@@ -1,0 +1,9 @@
+import { schema as s } from "jazz-tools";
+import { app } from "./schema.js";
+
+export default s.definePermissions(app, ({ policy }) => [
+  policy.todos.allowRead.where({}),
+  policy.todos.allowInsert.where({}),
+  policy.todos.allowUpdate.where({}),
+  policy.todos.allowDelete.where({}),
+]);

--- a/examples/docs/todo-server-rs/schema.ts
+++ b/examples/docs/todo-server-rs/schema.ts
@@ -1,0 +1,17 @@
+import { schema as s } from "jazz-tools";
+
+const schema = {
+  projects: s.table({
+    name: s.string(),
+  }),
+  todos: s.table({
+    title: s.string(),
+    done: s.boolean(),
+    description: s.string().optional(),
+    parent: s.ref("todos").optional(),
+    project: s.ref("projects").optional(),
+  }),
+};
+
+type AppSchema = s.Schema<typeof schema>;
+export const app: s.App<AppSchema> = s.defineApp(schema);

--- a/examples/docs/todo-server-rs/src/docs_snippets.rs
+++ b/examples/docs/todo-server-rs/src/docs_snippets.rs
@@ -14,6 +14,14 @@ fn verify_jwt_and_extract_claims(_token: &str) -> (String, serde_json::Value) {
     ("replace-with-verified-sub".to_string(), json!({}))
 }
 
+fn todo_values(title: impl Into<String>, description: impl Into<String>) -> Vec<Value> {
+    vec![
+        Value::Text(title.into()),
+        Value::Boolean(false),
+        Value::Text(description.into()),
+    ]
+}
+
 // #region backend-request-session-rust
 pub fn requester_session_from_headers(headers: &HeaderMap) -> Result<Session, StatusCode> {
     let auth = headers
@@ -348,13 +356,7 @@ pub async fn clear_nullable_fields(
 
 // #region writing-crud-rust
 pub async fn write_todo_crud(client: &JazzClient, existing_id: ObjectId) -> jazz_tools::Result<()> {
-    let values = vec![
-        Value::Text("Write docs".to_string()),
-        Value::Boolean(false),
-        Value::Text(String::new()),
-        Value::Null,
-        Value::Null,
-    ];
+    let values = todo_values("Write docs", "");
 
     let _new_row = client.create("todos", values).await?;
     client
@@ -372,20 +374,18 @@ pub async fn write_todo_crud(client: &JazzClient, existing_id: ObjectId) -> jazz
 // JazzClient.create/update/delete use the default durability tier
 // (edge for server-connected clients, worker for browser clients).
 //
-// Explicit tier control is available on RuntimeCore via
-// insert_persisted / update_persisted / delete_persisted,
-// but not yet exposed on JazzClient.
-pub async fn write_todo_with_defaults(client: &JazzClient) -> jazz_tools::Result<ObjectId> {
-    let values = vec![
-        Value::Text("Write docs".to_string()),
-        Value::Boolean(false),
-        Value::Text(String::new()),
-        Value::Null,
-        Value::Null,
-    ];
+// Writes apply locally first, then sync asynchronously to higher tiers.
+pub async fn write_todo_with_default_durability(
+    client: &JazzClient,
+) -> jazz_tools::Result<ObjectId> {
+    let (id, _row_values) = client
+        .create(
+            "todos",
+            todo_values("Write docs with default durability behavior", ""),
+        )
+        .await?;
 
     // Uses the default tier (edge for server-connected clients).
-    let (id, _row_values) = client.create("todos", values).await?;
     Ok(id)
 }
 // #endregion writing-durability-tier-rust

--- a/examples/docs/todo-server-rs/src/main.rs
+++ b/examples/docs/todo-server-rs/src/main.rs
@@ -29,11 +29,11 @@ mod routes;
 
 use std::net::SocketAddr;
 use std::path::PathBuf;
+use std::process::Command;
 use std::sync::Arc;
 
 use axum::Router;
-use jazz_tools::schema_manager::SchemaDirectory;
-use jazz_tools::{AppContext, AppId, ClientStorage, JazzClient};
+use jazz_tools::{AppContext, AppId, ClientStorage, JazzClient, Schema};
 use tokio::sync::broadcast;
 use tower_http::cors::CorsLayer;
 use tower_http::trace::TraceLayer;
@@ -46,6 +46,27 @@ pub struct AppState {
     pub client: JazzClient,
     /// Broadcast channel for SSE updates. Sends the full list of todos.
     pub sse_tx: broadcast::Sender<Vec<Todo>>,
+}
+
+fn load_schema_from_cli(schema_dir: &str) -> Result<Schema, Box<dyn std::error::Error>> {
+    let jazz_tools_bin = std::env::var("JAZZ_TOOLS_BIN").unwrap_or_else(|_| "jazz-tools".into());
+    let output = Command::new(jazz_tools_bin)
+        .args([
+            "schema",
+            "export",
+            "--schema-dir",
+            schema_dir,
+            "--format",
+            "json",
+        ])
+        .output()?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("schema export failed: {stderr}").into());
+    }
+
+    Ok(serde_json::from_slice(&output.stdout)?)
 }
 
 #[tokio::main]
@@ -74,11 +95,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     info!("Jazz server: {}", server_url);
     info!("Data directory: {}", data_dir);
 
-    // Load schema from file
-    let schema_dir = SchemaDirectory::new("./schema");
-    let schema = schema_dir.current_schema()?;
+    let schema_root = env!("CARGO_MANIFEST_DIR");
+    let schema = load_schema_from_cli(schema_root)?;
     info!(
-        "Loaded schema from schema/current.sql ({} tables)",
+        "Loaded schema from {schema_root}/schema.ts ({} tables)",
         schema.len()
     );
 

--- a/examples/docs/todo-server-ts/docs/migrations-workflow.sh
+++ b/examples/docs/todo-server-ts/docs/migrations-workflow.sh
@@ -4,8 +4,8 @@
 # 1) Edit schema.ts during development and watch for Jazz migration warnings.
 
 # 2) Generate a typed migration stub after Jazz reports the old/new hashes.
-npx jazz-tools migrations create <fromHash> <toHash>
+npx jazz-tools@alpha migrations create <fromHash> <toHash>
 
 # 3) Fill in migrate, rename the file, then publish the reviewed edge.
-npx jazz-tools migrations push <fromHash> <toHash>
+npx jazz-tools@alpha migrations push <fromHash> <toHash>
 # #endregion migrations-workflow-ts

--- a/examples/docs/todo-server-ts/docs/migrations-workflow.sh
+++ b/examples/docs/todo-server-ts/docs/migrations-workflow.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
 
 # #region migrations-workflow-ts
-# 1) Edit schema/current.ts.
-# 2) Generate migration stubs from the updated schema.
-npx jazz-tools@alpha build
+# 1) Edit schema.ts during development and watch for Jazz migration warnings.
+
+# 2) Generate a typed migration stub after Jazz reports the old/new hashes.
+npx jazz-tools migrations create <fromHash> <toHash>
+
+# 3) Fill in migrate, rename the file, then publish the reviewed edge.
+npx jazz-tools migrations push <fromHash> <toHash>
 # #endregion migrations-workflow-ts

--- a/examples/docs/todo-server-ts/migrations/20260318-add-description-a01f5c72ec47-311995e9a178.ts
+++ b/examples/docs/todo-server-ts/migrations/20260318-add-description-a01f5c72ec47-311995e9a178.ts
@@ -1,0 +1,31 @@
+import { schema as s } from "jazz-tools";
+
+// Example of editing a generated migration stub.
+export default s.defineMigration({
+  migrate: {
+    todos: {
+      description: s.add.string({ default: "No description" }),
+    },
+  },
+  fromHash: "a01f5c72ec47",
+  toHash: "311995e9a178",
+  from: {
+    todos: s.table({
+      title: s.string(),
+      done: s.boolean(),
+      parentId: s.ref("todos").optional(),
+      projectId: s.ref("projects").optional(),
+      owner_id: s.string(),
+    }),
+  },
+  to: {
+    todos: s.table({
+      title: s.string(),
+      done: s.boolean(),
+      description: s.string().optional(),
+      parentId: s.ref("todos").optional(),
+      projectId: s.ref("projects").optional(),
+      owner_id: s.string(),
+    }),
+  },
+});

--- a/examples/docs/todo-server-ts/migrations/20260318-drop-legacy-priority-311995e9a178-73b65d082ab8.ts
+++ b/examples/docs/todo-server-ts/migrations/20260318-drop-legacy-priority-311995e9a178-73b65d082ab8.ts
@@ -1,0 +1,34 @@
+import { schema as s } from "jazz-tools";
+
+// Example: dropping a column with a backwards default.
+// Clients still on the older schema continue seeing legacy_priority.
+export default s.defineMigration({
+  migrate: {
+    todos: {
+      legacy_priority: s.drop.int({ backwardsDefault: 0 }),
+    },
+  },
+  fromHash: "311995e9a178",
+  toHash: "73b65d082ab8",
+  from: {
+    todos: s.table({
+      title: s.string(),
+      done: s.boolean(),
+      description: s.string().optional(),
+      parentId: s.ref("todos").optional(),
+      projectId: s.ref("projects").optional(),
+      owner_id: s.string(),
+      legacy_priority: s.int(),
+    }),
+  },
+  to: {
+    todos: s.table({
+      title: s.string(),
+      done: s.boolean(),
+      description: s.string().optional(),
+      parentId: s.ref("todos").optional(),
+      projectId: s.ref("projects").optional(),
+      owner_id: s.string(),
+    }),
+  },
+});

--- a/examples/docs/todo-server-ts/migrations/20260318-unnamed-a01f5c72ec47-311995e9a178.ts
+++ b/examples/docs/todo-server-ts/migrations/20260318-unnamed-a01f5c72ec47-311995e9a178.ts
@@ -1,0 +1,30 @@
+import { schema as s } from "jazz-tools";
+
+export default s.defineMigration({
+  migrate: {
+    todos: {
+      description: s.add.string({ default: null }),
+    },
+  },
+  fromHash: "a01f5c72ec47",
+  toHash: "311995e9a178",
+  from: {
+    todos: s.table({
+      title: s.string(),
+      done: s.boolean(),
+      parentId: s.ref("todos").optional(),
+      projectId: s.ref("projects").optional(),
+      owner_id: s.string(),
+    }),
+  },
+  to: {
+    todos: s.table({
+      title: s.string(),
+      done: s.boolean(),
+      description: s.string().optional(),
+      parentId: s.ref("todos").optional(),
+      projectId: s.ref("projects").optional(),
+      owner_id: s.string(),
+    }),
+  },
+});

--- a/examples/docs/todo-server-ts/permissions.ts
+++ b/examples/docs/todo-server-ts/permissions.ts
@@ -1,0 +1,10 @@
+import { schema as s } from "jazz-tools";
+import { app } from "./schema.js";
+
+export default s.definePermissions(app, ({ policy, session }) => {
+  // Users can only read, create, update, and delete their own todos.
+  policy.todos.allowRead.where({ owner_id: session.user_id });
+  policy.todos.allowInsert.where({ owner_id: session.user_id });
+  policy.todos.allowUpdate.where({ owner_id: session.user_id });
+  policy.todos.allowDelete.where({ owner_id: session.user_id });
+});

--- a/examples/docs/todo-server-ts/schema.ts
+++ b/examples/docs/todo-server-ts/schema.ts
@@ -1,0 +1,18 @@
+import { schema as s } from "jazz-tools";
+
+const schema = {
+  projects: s.table({
+    name: s.string(),
+  }),
+  todos: s.table({
+    title: s.string(),
+    done: s.boolean(),
+    description: s.string().optional(),
+    parentId: s.ref("todos").optional(),
+    projectId: s.ref("projects").optional(),
+    owner_id: s.string(),
+  }),
+};
+
+type AppSchema = s.Schema<typeof schema>;
+export const app: s.App<AppSchema> = s.defineApp(schema);

--- a/examples/docs/todo-server-ts/src/main.ts
+++ b/examples/docs/todo-server-ts/src/main.ts
@@ -61,6 +61,15 @@ export interface RunningServer extends TodoServer {
 export async function createServer(dataPath?: string): Promise<TodoServer> {
   const dbPath = dataPath ?? join(mkdtempSync(join(tmpdir(), "jazz-todo-")), "jazz.db");
   const appId = process.env.JAZZ_APP_ID ?? "todo-server-ts";
+  const serverUrl = process.env.JAZZ_SERVER_URL?.trim();
+  const backendSecret = process.env.JAZZ_BACKEND_SECRET?.trim();
+  const adminSecret = process.env.JAZZ_ADMIN_SECRET?.trim();
+
+  if (!serverUrl || !backendSecret) {
+    throw new Error(
+      "JAZZ_SERVER_URL and JAZZ_BACKEND_SECRET are required for the upstream-backed server example.",
+    );
+  }
 
   // #region context-setup-ts-backend
   const context = createJazzContext({
@@ -68,10 +77,13 @@ export async function createServer(dataPath?: string): Promise<TodoServer> {
     app: schemaApp,
     permissions,
     driver: { type: "persistent", dataPath: dbPath },
+    serverUrl,
+    backendSecret,
+    adminSecret,
     env: "dev",
     userBranch: "main",
   });
-  const db = context.db();
+  const db = context.asBackend();
   // #endregion context-setup-ts-backend
 
   // Create Express app

--- a/examples/docs/todo-server-ts/src/main.ts
+++ b/examples/docs/todo-server-ts/src/main.ts
@@ -11,7 +11,8 @@ import { tmpdir } from "node:os";
 import { mkdtempSync } from "node:fs";
 import { join } from "node:path";
 import { createJazzContext, type Db } from "jazz-tools/backend";
-import { app as schemaApp } from "../schema/app.js";
+import { app as schemaApp } from "../schema.js";
+import permissions from "../permissions.js";
 
 // ============================================================================
 // Types
@@ -65,6 +66,7 @@ export async function createServer(dataPath?: string): Promise<TodoServer> {
   const context = createJazzContext({
     appId,
     app: schemaApp,
+    permissions,
     driver: { type: "persistent", dataPath: dbPath },
     env: "dev",
     userBranch: "main",

--- a/examples/docs/todo-server-ts/src/permissions-snippets.ts
+++ b/examples/docs/todo-server-ts/src/permissions-snippets.ts
@@ -1,31 +1,30 @@
-import { col, table } from "jazz-tools";
-import { definePermissions } from "jazz-tools/permissions";
-import { app } from "../schema/app.js";
+import { schema as s } from "jazz-tools";
 
 // #region permissions-schema-ts
-table("projects", {
-  name: col.string(),
-  owner_id: col.string(),
-});
-
-table("todos", {
-  title: col.string(),
-  done: col.boolean(),
-  parentId: col.ref("todos").optional(),
-  projectId: col.ref("projects").optional(),
-  owner_id: col.string(),
-});
-
-table("todoShares", {
-  todoId: col.ref("todos"),
-  user_id: col.string(),
-  can_read: col.boolean(),
-});
+const schema = {
+  projects: s.table({
+    name: s.string(),
+    owner_id: s.string(),
+  }),
+  todos: s.table({
+    title: s.string(),
+    done: s.boolean(),
+    parentId: s.ref("todos").optional(),
+    projectId: s.ref("projects").optional(),
+    owner_id: s.string(),
+  }),
+  todoShares: s.table({
+    todoId: s.ref("todos"),
+    user_id: s.string(),
+    can_read: s.boolean(),
+  }),
+};
 // #endregion permissions-schema-ts
 
+const exampleApp = s.defineApp(schema);
+
 // #region permissions-simple-ts
-definePermissions(app, ({ policy, allOf, session }) => {
-  // Users can only read their own todos
+s.definePermissions(exampleApp, ({ policy, allOf, session }) => {
   policy.todos.allowRead.where({ owner_id: session.user_id });
   // Users cannot create todos with different owners
   policy.todos.allowInsert.where({ owner_id: session.user_id });
@@ -39,7 +38,7 @@ definePermissions(app, ({ policy, allOf, session }) => {
 // #endregion permissions-simple-ts
 
 // #region permissions-always-ts
-definePermissions(app, ({ policy }) => {
+s.definePermissions(exampleApp, ({ policy }) => {
   policy.todos.allowRead.always();
   policy.todos.allowInsert.always();
   policy.todos.allowUpdate.always();
@@ -48,7 +47,7 @@ definePermissions(app, ({ policy }) => {
 // #endregion permissions-always-ts
 
 // #region permissions-never-ts
-definePermissions(app, ({ policy }) => {
+s.definePermissions(exampleApp, ({ policy }) => {
   policy.todos.allowRead.never();
   policy.todos.allowInsert.never();
   policy.todos.allowUpdate.never();
@@ -57,10 +56,10 @@ definePermissions(app, ({ policy }) => {
 // #endregion permissions-never-ts
 
 // #region permissions-allowed-to-ts
-definePermissions(app, ({ policy, anyOf, allOf, allowedTo }) => {
-  // Users can read a todo if it's not done, or if they can read its project
+s.definePermissions(exampleApp, ({ policy, anyOf, allOf, allowedTo }) => {
+  // Users can read a todo if it's not done, or if they can read its project.
   policy.todos.allowRead.where(anyOf([{ done: false }, allowedTo.read("project")]));
-  // Users can update a todo if they can update its project and it's not done
+  // Users can update a todo if they can update its project and it's not done.
   policy.todos.allowUpdate
     .whereOld(allOf([allowedTo.update("project"), { done: false }]))
     .whereNew(allowedTo.update("project"));
@@ -68,19 +67,27 @@ definePermissions(app, ({ policy, anyOf, allOf, allowedTo }) => {
 // #endregion permissions-allowed-to-ts
 
 // #region permissions-combinators-ts
-definePermissions(app, ({ policy, allOf, anyOf, allowedTo, session }) => {
-  // Users can read a todo if they own it, or if it's not done and they can read its project
+s.definePermissions(exampleApp, ({ policy, allOf, anyOf, allowedTo, session }) => {
+  // Users can read a todo if they own it, or if it's not done and they can read its project.
   policy.todos.allowRead.where(
     anyOf([{ owner_id: session.user_id }, allOf([{ done: false }, allowedTo.read("project")])]),
   );
 });
 // #endregion permissions-combinators-ts
 
+// #region permissions-session-claims-ts
+s.definePermissions(exampleApp, ({ policy, anyOf, session }) => {
+  policy.todos.allowRead.where(
+    anyOf([{ owner_id: session.user_id }, session.where({ "claims.role": "manager" })]),
+  );
+});
+// #endregion permissions-session-claims-ts
+
 // #region permissions-recursive-inherits-ts
-definePermissions(app, ({ policy, allowedTo }) => {
-  // Users can read a todo if they can read its parent (follows the chain upward)
+s.definePermissions(exampleApp, ({ policy, allowedTo }) => {
+  // Users can read a todo if they can read its parent (follows the chain upward).
   policy.todos.allowRead.where(allowedTo.read("parent"));
-  // Users can update a todo if they can update its parent, up to 5 levels deep
+  // Users can update a todo if they can update its parent, up to 5 levels deep.
   policy.todos.allowUpdate
     .whereOld(allowedTo.update("parent", { maxDepth: 5 }))
     .whereNew(allowedTo.update("parent", { maxDepth: 5 }));
@@ -88,8 +95,8 @@ definePermissions(app, ({ policy, allowedTo }) => {
 // #endregion permissions-recursive-inherits-ts
 
 // #region permissions-shares-ts
-definePermissions(app, ({ policy, anyOf, session }) => {
-  // Users can read a todo if they own it, or if someone shared it with them
+s.definePermissions(exampleApp, ({ policy, anyOf, session }) => {
+  // Users can read a todo if they own it, or if someone shared it with them.
   policy.todos.allowRead.where((todo) =>
     anyOf([
       { owner_id: session.user_id },
@@ -102,11 +109,3 @@ definePermissions(app, ({ policy, anyOf, session }) => {
   );
 });
 // #endregion permissions-shares-ts
-
-// #region permissions-session-claims-ts
-definePermissions(app, ({ policy, anyOf, session }) => {
-  policy.todos.allowRead.where(
-    anyOf([{ owner_id: session.user_id }, session.where({ "claims.role": "manager" })]),
-  );
-});
-// #endregion permissions-session-claims-ts

--- a/examples/docs/todo-server-ts/src/quickstart-snippets.ts
+++ b/examples/docs/todo-server-ts/src/quickstart-snippets.ts
@@ -2,12 +2,16 @@
 import { Hono } from "hono";
 import { serve } from "@hono/node-server";
 import { createJazzContext } from "jazz-tools/backend";
-import { app as schema } from "../schema/app.js";
+import { app as schemaApp } from "../schema.js";
+import permissions from "../permissions.js";
 
 const context = createJazzContext({
-  appId: "<your-app-id>",
-  app: schema,
+  appId: "todo-server-ts",
+  app: schemaApp,
+  permissions,
   driver: { type: "persistent", dataPath: "./data/jazz.db" },
+  serverUrl: process.env.JAZZ_SERVER_URL,
+  backendSecret: process.env.JAZZ_BACKEND_SECRET,
 });
 
 const api = new Hono();
@@ -18,7 +22,7 @@ api.post("/api/todos", async (c) => {
   const db = context.forRequest(c.req);
   const { title } = await c.req.json();
 
-  const todo = db.insert(schema.todos, {
+  const todo = db.insert(schemaApp.todos, {
     title,
     done: false,
     owner_id: "system",
@@ -32,7 +36,7 @@ api.post("/api/todos", async (c) => {
 api.get("/api/todos", async (c) => {
   const db = context.forRequest(c.req);
   const todos = await db.all(
-    schema.todos.where({ done: false }).orderBy("title", "asc").limit(100),
+    schemaApp.todos.where({ done: false }).orderBy("title", "asc").limit(100),
   );
   return c.json(todos);
 });
@@ -43,14 +47,14 @@ api.patch("/api/todos/:id", async (c) => {
   const db = context.forRequest(c.req);
   const { id } = c.req.param();
   const { done } = await c.req.json();
-  db.update(schema.todos, id, { done });
+  db.update(schemaApp.todos, id, { done });
   return c.json({ ok: true });
 });
 
 api.delete("/api/todos/:id", async (c) => {
   const db = context.forRequest(c.req);
   const { id } = c.req.param();
-  db.delete(schema.todos, id);
+  db.delete(schemaApp.todos, id);
   return c.json({ ok: true });
 });
 // #endregion quickstart-server-update-ts

--- a/examples/docs/todo-server-ts/src/request-context.ts
+++ b/examples/docs/todo-server-ts/src/request-context.ts
@@ -1,6 +1,6 @@
 import type { Request, Response } from "express";
 import type { JazzContext } from "jazz-tools/backend";
-import { app as schemaApp } from "../schema/app.js";
+import { app as schemaApp } from "../schema.js";
 
 declare const context: JazzContext;
 

--- a/examples/docs/todo-server-ts/tests/backend-context.test.ts
+++ b/examples/docs/todo-server-ts/tests/backend-context.test.ts
@@ -1,0 +1,56 @@
+import { afterAll, describe, expect, it } from "vitest";
+import { TestingServer } from "jazz-tools/testing";
+import { createServer, startServer, stopServer, type RunningServer } from "../src/main.ts";
+
+const originalEnv = {
+  appId: process.env.JAZZ_APP_ID,
+  serverUrl: process.env.JAZZ_SERVER_URL,
+  backendSecret: process.env.JAZZ_BACKEND_SECRET,
+  adminSecret: process.env.JAZZ_ADMIN_SECRET,
+};
+
+function restoreEnv(): void {
+  process.env.JAZZ_APP_ID = originalEnv.appId;
+  process.env.JAZZ_SERVER_URL = originalEnv.serverUrl;
+  process.env.JAZZ_BACKEND_SECRET = originalEnv.backendSecret;
+  process.env.JAZZ_ADMIN_SECRET = originalEnv.adminSecret;
+}
+
+describe("Todo Server backend context", () => {
+  afterAll(() => {
+    restoreEnv();
+  });
+
+  it("requires upstream sync config", async () => {
+    delete process.env.JAZZ_SERVER_URL;
+    delete process.env.JAZZ_BACKEND_SECRET;
+    delete process.env.JAZZ_ADMIN_SECRET;
+
+    await expect(createServer()).rejects.toThrow(
+      /JAZZ_SERVER_URL and JAZZ_BACKEND_SECRET are required/i,
+    );
+  });
+
+  it("boots against an upstream Jazz server", async () => {
+    const upstream = await TestingServer.start();
+    let server: RunningServer | undefined;
+    try {
+      process.env.JAZZ_APP_ID = upstream.appId;
+      process.env.JAZZ_SERVER_URL = upstream.url;
+      process.env.JAZZ_BACKEND_SECRET = upstream.backendSecret;
+      process.env.JAZZ_ADMIN_SECRET = upstream.adminSecret;
+
+      server = await startServer(await createServer(), 0);
+
+      const res = await fetch(`${server.baseUrl}/health`);
+      expect(res.status).toBe(200);
+      await expect(res.json()).resolves.toEqual({ status: "healthy" });
+    } finally {
+      if (server) {
+        await stopServer(server);
+      }
+      await upstream.stop();
+      restoreEnv();
+    }
+  });
+});

--- a/examples/docs/todo-server-ts/tsconfig.json
+++ b/examples/docs/todo-server-ts/tsconfig.json
@@ -10,6 +10,6 @@
     "outDir": "dist",
     "declaration": true
   },
-  "include": ["src/**/*", "schema/**/*"],
+  "include": ["src/**/*", "schema.ts", "permissions.ts"],
   "exclude": ["node_modules", "dist"]
 }

--- a/packages/jazz-tools/src/backend/create-jazz-context.ts
+++ b/packages/jazz-tools/src/backend/create-jazz-context.ts
@@ -196,7 +196,7 @@ export class JazzContext {
   }
 
   /**
-   * Get a high-level `Db` using the context's configured auth/runtime identity.
+   * Get the shared high-level `Db` for this context with no per-request session attached.
    */
   db(source?: BackendSchemaInput): Db {
     return this.wrapDb(this.getClient(source));

--- a/specs/a_mvp/backend_context_helper_cleanup.md
+++ b/specs/a_mvp/backend_context_helper_cleanup.md
@@ -1,0 +1,54 @@
+# Backend Context Helper Cleanup — TODO (MVP)
+
+This follow-up tracks the remaining API/docs cleanup after switching the server-connected TypeScript
+docs example to `context.asBackend()`.
+
+## Goal
+
+Make the `createJazzContext(...)` helper surface legible and intentional:
+
+- `context.asBackend()` for server-owned work against an upstream Jazz server
+- `context.forRequest(req)` / `context.forSession(session)` for user-scoped work
+- `context.db()` only for clearly documented embedded or local-only runtime usage, if it remains
+
+## Scope
+
+- Audit backend docs and examples so server-connected flows do not present `context.db()` as the
+  default or as interchangeable with `context.asBackend()`.
+- Decide whether `context.db()` should remain public, be renamed, or be documented explicitly as an
+  embedded-runtime helper.
+- Split example coverage so server-connected and embedded/local runtime patterns are demonstrated
+  separately instead of being blended together.
+- Add focused tests around helper selection and startup expectations for each supported pattern.
+
+Out of scope:
+
+- Auth-provider changes or JWT format changes.
+- New backend permission semantics.
+
+## Desired Semantics
+
+### Server-connected backend
+
+- `context.asBackend()` is the default unscoped helper for trusted server-owned work.
+- `context.forRequest(req)` is the default helper for request handlers acting on behalf of callers.
+- `context.forSession(session)` is the explicit impersonation/testing path.
+
+### Embedded or local-only runtime
+
+- If `context.db()` remains, docs should describe it as the embedded/local-runtime path only.
+- Embedded usage should not be confused with upstream-connected backend auth.
+
+## Invariants
+
+- Server-connected docs/examples must not imply that `context.db()` and `context.asBackend()` are
+  equivalent.
+- Request-scoped examples must continue to use `forRequest(req)` or `forSession(session)`.
+- Any remaining `context.db()` examples must be obviously local-only.
+
+## Testing Strategy
+
+- Keep a targeted boot test for the upstream-backed docs server example.
+- Add or preserve separate coverage for embedded/local runtime usage if `context.db()` remains part
+  of the public API.
+- Avoid relying on a single example to cover both helper patterns.


### PR DESCRIPTION
## What changed

This is a stacked follow-up on top of #380 / `joe/docs-restructure`.

Instead of rebasing Joe's branch onto current `main`, this keeps Joe's docs structure intact and layers the schema-workflow changes from #316 on top as a narrow diff.

Concretely, this updates the docs/examples to the current schema model:

- root-level `schema.ts` and `permissions.ts`
- `npx jazz-tools validate` instead of the old `build` workflow
- reviewed migrations under `migrations/`
- current permissions lifecycle language (`permissions push`, no schema hash churn for permission-only changes)
- example snippet imports that point at the new root schema entrypoints

To keep this PR readable against Joe's branch, the legacy generated `schema/` directories on the base branch are mostly left in place rather than being mass-deleted here.

## Why

Joe asked for a readable stacked diff rather than a `main`-based replacement PR. The earlier restack against `main` made the compare too noisy for review because `joe/docs-restructure` does not contain the already-merged #316 changes.

This branch backports the relevant docs/example layer so reviewers can see just the schema-workflow alignment on top of Joe's structure.

## Validation

- `pnpm --filter docs types:check`
- `pnpm --filter todo-server-ts-docs build`
- `pnpm --filter todo-client-localfirst-react-docs build`
- `pnpm --filter todo-client-localfirst-vue-docs build`
- `pnpm --filter todo-client-localfirst-svelte-docs build`
- `pnpm --filter todo-client-localfirst-ts-docs build`

## Notes

This is intentionally scoped as a stacked docs/example backport. It carries the new schema workflow into Joe's restructure branch without pulling unrelated `main` history into the PR diff.
