### PR TITLE
Fix NULL literal handling in policy evaluation

### DIFF
--- a/crates/jazz-tools/src/query_manager/policy.rs
+++ b/crates/jazz-tools/src/query_manager/policy.rs
@@ -880,6 +880,20 @@ pub fn evaluate_cmp(
         None => return false,
     };
 
+    if cmp_value.is_null() {
+        return match column_is_null(descriptor, content, col_index) {
+            Ok(is_null) => match op {
+                CmpOp::Eq => is_null,
+                CmpOp::Ne => !is_null,
+                CmpOp::Lt => false,
+                CmpOp::Le => is_null,
+                CmpOp::Gt => !is_null,
+                CmpOp::Ge => true,
+            },
+            Err(_) => false,
+        };
+    }
+
     // Encode the comparison value to bytes
     let encoded = encode_value(&cmp_value);
 
@@ -2238,6 +2252,28 @@ mod tests {
         .unwrap()
     }
 
+    fn nullable_descriptor() -> RowDescriptor {
+        RowDescriptor::new(vec![
+            ColumnDescriptor::new("owner_id", ColumnType::Text),
+            ColumnDescriptor::new("deleted_at", ColumnType::Text).nullable(),
+        ])
+    }
+
+    fn make_nullable_row_content(owner: &str, deleted_at: Option<&str>) -> Vec<u8> {
+        let desc = nullable_descriptor();
+        encode_row(
+            &desc,
+            &[
+                Value::Text(owner.into()),
+                match deleted_at {
+                    Some(value) => Value::Text(value.into()),
+                    None => Value::Null,
+                },
+            ],
+        )
+        .unwrap()
+    }
+
     #[test]
     fn test_simple_parts_true_false() {
         let desc = test_descriptor();
@@ -2268,6 +2304,161 @@ mod tests {
         let content2 = make_row_content("user2", "eng", "active");
         let result = evaluate_simple_parts(&expr, &content2, &desc, &session);
         assert!(!result.passed);
+    }
+
+    #[test]
+    fn test_row_null_literal_comparisons_use_value_level_semantics() {
+        let desc = nullable_descriptor();
+        let session = Session::new("user1");
+        let null_content = make_nullable_row_content("user1", None);
+        let non_null_content = make_nullable_row_content("user1", Some("2026-03-30T12:00:00Z"));
+
+        let eq_null = PolicyExpr::eq_literal("deleted_at", Value::Null);
+        let eq_simple = evaluate_simple_parts(&eq_null, &null_content, &desc, &session);
+        assert!(eq_simple.passed);
+        assert!(eq_simple.complex_clauses.is_empty());
+        assert!(evaluate_policy_expr(
+            &eq_null,
+            &null_content,
+            &desc,
+            &session
+        ));
+        assert!(!evaluate_policy_expr(
+            &eq_null,
+            &non_null_content,
+            &desc,
+            &session,
+        ));
+
+        let ne_null = PolicyExpr::Cmp {
+            column: "deleted_at".into(),
+            op: CmpOp::Ne,
+            value: PolicyValue::Literal(Value::Null),
+        };
+        assert!(!evaluate_policy_expr(
+            &ne_null,
+            &null_content,
+            &desc,
+            &session
+        ));
+        assert!(evaluate_policy_expr(
+            &ne_null,
+            &non_null_content,
+            &desc,
+            &session,
+        ));
+
+        let lt_null = PolicyExpr::Cmp {
+            column: "deleted_at".into(),
+            op: CmpOp::Lt,
+            value: PolicyValue::Literal(Value::Null),
+        };
+        assert!(!evaluate_policy_expr(
+            &lt_null,
+            &null_content,
+            &desc,
+            &session
+        ));
+        assert!(!evaluate_policy_expr(
+            &lt_null,
+            &non_null_content,
+            &desc,
+            &session,
+        ));
+
+        let le_null = PolicyExpr::Cmp {
+            column: "deleted_at".into(),
+            op: CmpOp::Le,
+            value: PolicyValue::Literal(Value::Null),
+        };
+        assert!(evaluate_policy_expr(
+            &le_null,
+            &null_content,
+            &desc,
+            &session
+        ));
+        assert!(!evaluate_policy_expr(
+            &le_null,
+            &non_null_content,
+            &desc,
+            &session,
+        ));
+
+        let gt_null = PolicyExpr::Cmp {
+            column: "deleted_at".into(),
+            op: CmpOp::Gt,
+            value: PolicyValue::Literal(Value::Null),
+        };
+        assert!(!evaluate_policy_expr(
+            &gt_null,
+            &null_content,
+            &desc,
+            &session
+        ));
+        assert!(evaluate_policy_expr(
+            &gt_null,
+            &non_null_content,
+            &desc,
+            &session,
+        ));
+
+        let ge_null = PolicyExpr::Cmp {
+            column: "deleted_at".into(),
+            op: CmpOp::Ge,
+            value: PolicyValue::Literal(Value::Null),
+        };
+        assert!(evaluate_policy_expr(
+            &ge_null,
+            &null_content,
+            &desc,
+            &session
+        ));
+        assert!(evaluate_policy_expr(
+            &ge_null,
+            &non_null_content,
+            &desc,
+            &session,
+        ));
+    }
+
+    #[test]
+    fn test_row_explicit_null_checks() {
+        let desc = nullable_descriptor();
+        let session = Session::new("user1");
+        let null_content = make_nullable_row_content("user1", None);
+        let non_null_content = make_nullable_row_content("user1", Some("2026-03-30T12:00:00Z"));
+
+        let is_null = PolicyExpr::IsNull {
+            column: "deleted_at".into(),
+        };
+        assert!(evaluate_policy_expr(
+            &is_null,
+            &null_content,
+            &desc,
+            &session
+        ));
+        assert!(!evaluate_policy_expr(
+            &is_null,
+            &non_null_content,
+            &desc,
+            &session,
+        ));
+
+        let is_not_null = PolicyExpr::IsNotNull {
+            column: "deleted_at".into(),
+        };
+        assert!(!evaluate_policy_expr(
+            &is_not_null,
+            &null_content,
+            &desc,
+            &session,
+        ));
+        assert!(evaluate_policy_expr(
+            &is_not_null,
+            &non_null_content,
+            &desc,
+            &session,
+        ));
     }
 
     #[test]

--- a/crates/jazz-tools/src/query_manager/query.rs
+++ b/crates/jazz-tools/src/query_manager/query.rs
@@ -146,21 +146,27 @@ impl Condition {
 
     /// Check if this condition can be used for an index scan.
     pub fn is_index_scannable(&self) -> bool {
-        !is_magic_column_name(self.column())
-            && matches!(
-                self,
-                Condition::Eq { .. }
-                    | Condition::Lt { .. }
-                    | Condition::Le { .. }
-                    | Condition::Gt { .. }
-                    | Condition::Ge { .. }
-                    | Condition::Between { .. }
-            )
+        if is_magic_column_name(self.column()) {
+            return false;
+        }
+
+        match self {
+            Condition::Eq { value, .. }
+            | Condition::Lt { value, .. }
+            | Condition::Le { value, .. }
+            | Condition::Gt { value, .. }
+            | Condition::Ge { value, .. } => !value.is_null(),
+            Condition::Between { min, max, .. } => !min.is_null() && !max.is_null(),
+            _ => false,
+        }
     }
 
     /// Convert to a Predicate for filter evaluation.
     pub fn to_predicate(&self, descriptor: &RowDescriptor) -> Option<Predicate> {
         let col_index = descriptor.column_index(self.column())?;
+        if let Some(predicate) = self.null_literal_predicate(col_index) {
+            return Some(predicate);
+        }
         let col_type = &descriptor.columns[col_index].column_type;
 
         Some(match self {
@@ -210,6 +216,9 @@ impl Condition {
     /// Convert to a Predicate using a TupleDescriptor so scoped join refs can resolve.
     pub fn to_tuple_predicate(&self, tuple_descriptor: &TupleDescriptor) -> Option<Predicate> {
         let col_index = tuple_condition_column_index(tuple_descriptor, self.raw_column())?;
+        if let Some(predicate) = self.null_literal_predicate(col_index) {
+            return Some(predicate);
+        }
         let combined_descriptor = tuple_descriptor.combined_descriptor();
         let col_type = &combined_descriptor.columns[col_index].column_type;
 
@@ -255,6 +264,22 @@ impl Condition {
             Condition::IsNull { .. } => Predicate::IsNull { col_index },
             Condition::IsNotNull { .. } => Predicate::IsNotNull { col_index },
         })
+    }
+
+    fn null_literal_predicate(&self, col_index: usize) -> Option<Predicate> {
+        match self {
+            Condition::Eq { value, .. } if value.is_null() => Some(Predicate::IsNull { col_index }),
+            Condition::Ne { value, .. } if value.is_null() => {
+                Some(Predicate::IsNotNull { col_index })
+            }
+            Condition::Lt { value, .. } if value.is_null() => Some(Predicate::Or(vec![])),
+            Condition::Le { value, .. } if value.is_null() => Some(Predicate::IsNull { col_index }),
+            Condition::Gt { value, .. } if value.is_null() => {
+                Some(Predicate::IsNotNull { col_index })
+            }
+            Condition::Ge { value, .. } if value.is_null() => Some(Predicate::True),
+            _ => None,
+        }
     }
 }
 
@@ -1374,6 +1399,21 @@ mod tests {
 
         let predicate = query.to_predicate(&descriptor);
         assert!(matches!(predicate, Predicate::Eq { col_index: 2, .. }));
+    }
+
+    #[test]
+    fn query_to_predicate_eq_null_becomes_is_null() {
+        let descriptor = RowDescriptor::new(vec![
+            ColumnDescriptor::new("id", ColumnType::Integer),
+            ColumnDescriptor::new("deleted_at", ColumnType::Text).nullable(),
+        ]);
+        let query = QueryBuilder::new("users")
+            .filter_eq("deleted_at", Value::Null)
+            .build();
+
+        let predicate = query.to_predicate(&descriptor);
+        assert!(matches!(predicate, Predicate::IsNull { col_index: 1 }));
+        assert!(query.disjuncts[0].best_index_condition().is_none());
     }
 
     #[test]

--- a/crates/jazz-tools/src/query_manager/query.rs
+++ b/crates/jazz-tools/src/query_manager/query.rs
@@ -13,6 +13,7 @@ use super::relation_ir::ColumnRef;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum QueryBuildError {
     UnsupportedShape,
+    NullBetweenBound { column: String },
 }
 
 impl fmt::Display for QueryBuildError {
@@ -22,6 +23,12 @@ impl fmt::Display for QueryBuildError {
                 write!(
                     f,
                     "query shape is not supported by relation IR normalization"
+                )
+            }
+            QueryBuildError::NullBetweenBound { column } => {
+                write!(
+                    f,
+                    "BETWEEN does not support NULL bounds for column '{column}'"
                 )
             }
         }
@@ -164,10 +171,10 @@ impl Condition {
     /// Convert to a Predicate for filter evaluation.
     pub fn to_predicate(&self, descriptor: &RowDescriptor) -> Option<Predicate> {
         let col_index = descriptor.column_index(self.column())?;
+        let col_type = &descriptor.columns[col_index].column_type;
         if let Some(predicate) = self.null_literal_predicate(col_index) {
             return Some(predicate);
         }
-        let col_type = &descriptor.columns[col_index].column_type;
 
         Some(match self {
             Condition::Eq { value, .. } => Predicate::Eq {
@@ -216,11 +223,11 @@ impl Condition {
     /// Convert to a Predicate using a TupleDescriptor so scoped join refs can resolve.
     pub fn to_tuple_predicate(&self, tuple_descriptor: &TupleDescriptor) -> Option<Predicate> {
         let col_index = tuple_condition_column_index(tuple_descriptor, self.raw_column())?;
+        let combined_descriptor = tuple_descriptor.combined_descriptor();
+        let col_type = &combined_descriptor.columns[col_index].column_type;
         if let Some(predicate) = self.null_literal_predicate(col_index) {
             return Some(predicate);
         }
-        let combined_descriptor = tuple_descriptor.combined_descriptor();
-        let col_type = &combined_descriptor.columns[col_index].column_type;
 
         Some(match self {
             Condition::Eq { value, .. } => Predicate::Eq {
@@ -566,6 +573,39 @@ fn default_disjuncts() -> Vec<Conjunction> {
 }
 
 impl Query {
+    fn validate_conditions(conditions: &[Condition]) -> Result<(), QueryBuildError> {
+        for condition in conditions {
+            match condition {
+                Condition::Between { column, min, max } if min.is_null() || max.is_null() => {
+                    return Err(QueryBuildError::NullBetweenBound {
+                        column: column.clone(),
+                    });
+                }
+                _ => {}
+            }
+        }
+        Ok(())
+    }
+
+    fn validate_array_subqueries(specs: &[ArraySubquerySpec]) -> Result<(), QueryBuildError> {
+        for spec in specs {
+            Self::validate_conditions(&spec.filters)?;
+            Self::validate_array_subqueries(&spec.nested_arrays)?;
+        }
+        Ok(())
+    }
+
+    fn validate(&self) -> Result<(), QueryBuildError> {
+        for disjunct in &self.disjuncts {
+            Self::validate_conditions(&disjunct.conditions)?;
+        }
+        Self::validate_array_subqueries(&self.array_subqueries)?;
+        if let Some(recursive) = &self.recursive {
+            Self::validate_conditions(&recursive.filters)?;
+        }
+        Ok(())
+    }
+
     /// Create a new query for a table (internal use - branches not set).
     fn new_internal(table: impl Into<TableName>) -> Self {
         let table = table.into();
@@ -611,6 +651,7 @@ impl Query {
 
     /// Rebuild relation IR from the query DSL fields.
     pub fn refresh_relation_ir(&mut self) -> Result<(), QueryBuildError> {
+        self.validate()?;
         self.relation_ir =
             normalize_query_to_rel_expr(self).ok_or(QueryBuildError::UnsupportedShape)?;
         Ok(())
@@ -985,7 +1026,7 @@ impl QueryBuilder {
 
     pub fn build(self) -> Query {
         self.try_build()
-            .expect("QueryBuilder::build produced an unsupported relation IR shape")
+            .unwrap_or_else(|err| panic!("QueryBuilder::build failed: {err}"))
     }
 }
 
@@ -1414,6 +1455,34 @@ mod tests {
         let predicate = query.to_predicate(&descriptor);
         assert!(matches!(predicate, Predicate::IsNull { col_index: 1 }));
         assert!(query.disjuncts[0].best_index_condition().is_none());
+    }
+
+    #[test]
+    fn query_builder_rejects_between_null_lower_bound() {
+        let result = QueryBuilder::new("users")
+            .filter_between("score", Value::Null, Value::Integer(10))
+            .try_build();
+
+        assert_eq!(
+            result,
+            Err(QueryBuildError::NullBetweenBound {
+                column: "score".into()
+            })
+        );
+    }
+
+    #[test]
+    fn query_builder_rejects_between_null_upper_bound() {
+        let result = QueryBuilder::new("users")
+            .filter_between("score", Value::Integer(10), Value::Null)
+            .try_build();
+
+        assert_eq!(
+            result,
+            Err(QueryBuildError::NullBetweenBound {
+                column: "score".into()
+            })
+        );
     }
 
     #[test]

--- a/crates/jazz-tools/src/query_manager/rebac_tests.rs
+++ b/crates/jazz-tools/src/query_manager/rebac_tests.rs
@@ -2237,6 +2237,135 @@ fn local_insert_with_exists_rel_policy_denies_non_admin() {
 }
 
 #[test]
+fn local_insert_policy_with_null_literal_allows_null_rows_and_denies_non_null_rows() {
+    let mut schema = Schema::new();
+    let tasks_descriptor = RowDescriptor::new(vec![
+        ColumnDescriptor::new("title", ColumnType::Text),
+        ColumnDescriptor::new("deleted_at", ColumnType::Text).nullable(),
+    ]);
+    let tasks_policies =
+        TablePolicies::new().with_insert(PolicyExpr::eq_literal("deleted_at", Value::Null));
+    schema.insert(
+        TableName::new("tasks"),
+        TableSchema::with_policies(tasks_descriptor, tasks_policies),
+    );
+
+    let sync_manager = SyncManager::new();
+    let mut qm = create_query_manager(sync_manager, schema);
+    let mut storage = MemoryStorage::new();
+
+    qm.insert_with_session(
+        &mut storage,
+        "tasks",
+        &[Value::Text("draft".into()), Value::Null],
+        Some(&Session::new("alice")),
+    )
+    .expect("null row should satisfy deleted_at = NULL policy");
+
+    let archived_err = qm
+        .insert_with_session(
+            &mut storage,
+            "tasks",
+            &[
+                Value::Text("archived".into()),
+                Value::Text("2026-03-30T12:00:00Z".into()),
+            ],
+            Some(&Session::new("alice")),
+        )
+        .expect_err("non-null row should fail deleted_at = NULL policy");
+    assert!(matches!(
+        archived_err,
+        QueryError::PolicyDenied {
+            table,
+            operation: Operation::Insert
+        } if table == TableName::new("tasks")
+    ));
+}
+
+#[test]
+fn local_insert_with_exists_rel_null_literal_predicate_matches_null_rows() {
+    let mut schema = Schema::new();
+    let admins_descriptor = RowDescriptor::new(vec![
+        ColumnDescriptor::new("user_id", ColumnType::Text),
+        ColumnDescriptor::new("revoked_at", ColumnType::Text).nullable(),
+    ]);
+    schema.insert(
+        TableName::new("admins"),
+        TableSchema::new(admins_descriptor.clone()),
+    );
+
+    let projects_descriptor =
+        RowDescriptor::new(vec![ColumnDescriptor::new("name", ColumnType::Text)]);
+    let projects_policies = TablePolicies::new().with_insert(PolicyExpr::ExistsRel {
+        rel: RelExpr::Filter {
+            input: Box::new(RelExpr::TableScan {
+                table: TableName::new("admins"),
+            }),
+            predicate: PredicateExpr::And(vec![
+                PredicateExpr::Cmp {
+                    left: ColumnRef::unscoped("user_id"),
+                    op: PredicateCmpOp::Eq,
+                    right: ValueRef::SessionRef(vec!["user_id".into()]),
+                },
+                PredicateExpr::Cmp {
+                    left: ColumnRef::unscoped("revoked_at"),
+                    op: PredicateCmpOp::Eq,
+                    right: ValueRef::Literal(Value::Null),
+                },
+            ]),
+        },
+    });
+    schema.insert(
+        TableName::new("projects"),
+        TableSchema::with_policies(projects_descriptor, projects_policies),
+    );
+
+    let sync_manager = SyncManager::new();
+    let mut qm = create_query_manager(sync_manager, schema);
+    let mut storage = MemoryStorage::new();
+
+    qm.insert(
+        &mut storage,
+        "admins",
+        &[Value::Text("alice".into()), Value::Null],
+    )
+    .expect("seed active admin row");
+    qm.insert(
+        &mut storage,
+        "admins",
+        &[
+            Value::Text("carol".into()),
+            Value::Text("2026-03-30T12:00:00Z".into()),
+        ],
+    )
+    .expect("seed revoked admin row");
+
+    qm.insert_with_session(
+        &mut storage,
+        "projects",
+        &[Value::Text("alice project".into())],
+        Some(&Session::new("alice")),
+    )
+    .expect("active admin row should satisfy revoked_at = NULL predicate");
+
+    let carol_err = qm
+        .insert_with_session(
+            &mut storage,
+            "projects",
+            &[Value::Text("carol project".into())],
+            Some(&Session::new("carol")),
+        )
+        .expect_err("revoked admin row should fail revoked_at = NULL predicate");
+    assert!(matches!(
+        carol_err,
+        QueryError::PolicyDenied {
+            table,
+            operation: Operation::Insert
+        } if table == TableName::new("projects")
+    ));
+}
+
+#[test]
 fn local_update_with_check_inherits_denies_when_parent_is_not_updateable() {
     let mut schema = Schema::new();
     let folders_descriptor = RowDescriptor::new(vec![
@@ -2305,6 +2434,141 @@ fn local_update_with_check_inherits_denies_when_parent_is_not_updateable() {
             operation: Operation::Update
         } if table == TableName::new("folders")
     ));
+}
+
+#[test]
+fn rebac_select_policy_with_null_literal_filters_query_results() {
+    use crate::query_manager::query::QueryBuilder;
+
+    let mut schema = Schema::new();
+    let documents_descriptor = RowDescriptor::new(vec![
+        ColumnDescriptor::new("title", ColumnType::Text),
+        ColumnDescriptor::new("deleted_at", ColumnType::Text).nullable(),
+    ]);
+    let documents_policies =
+        TablePolicies::new().with_select(PolicyExpr::eq_literal("deleted_at", Value::Null));
+    schema.insert(
+        TableName::new("documents"),
+        TableSchema::with_policies(documents_descriptor, documents_policies),
+    );
+
+    let sync_manager = SyncManager::new();
+    let mut qm = create_query_manager(sync_manager, schema);
+    let mut storage = MemoryStorage::new();
+
+    let visible_id = qm
+        .insert(
+            &mut storage,
+            "documents",
+            &[Value::Text("draft".into()), Value::Null],
+        )
+        .unwrap()
+        .row_id;
+    let hidden_id = qm
+        .insert(
+            &mut storage,
+            "documents",
+            &[
+                Value::Text("soft-deleted".into()),
+                Value::Text("2026-03-30T12:00:00Z".into()),
+            ],
+        )
+        .unwrap()
+        .row_id;
+
+    let sub_id = qm
+        .subscribe_with_session(
+            QueryBuilder::new("documents").build(),
+            Some(Session::new("alice")),
+            None,
+        )
+        .unwrap();
+
+    for _ in 0..10 {
+        qm.process(&mut storage);
+    }
+
+    let visible_ids: HashSet<_> = qm
+        .get_subscription_results(sub_id)
+        .into_iter()
+        .map(|(id, _)| id)
+        .collect();
+    assert!(
+        visible_ids.contains(&visible_id),
+        "rows with deleted_at = NULL should remain visible"
+    );
+    assert!(
+        !visible_ids.contains(&hidden_id),
+        "rows with non-null deleted_at should be filtered out"
+    );
+}
+
+#[test]
+fn rebac_select_policy_with_is_null_filters_query_results() {
+    use crate::query_manager::query::QueryBuilder;
+
+    let mut schema = Schema::new();
+    let documents_descriptor = RowDescriptor::new(vec![
+        ColumnDescriptor::new("title", ColumnType::Text),
+        ColumnDescriptor::new("deleted_at", ColumnType::Text).nullable(),
+    ]);
+    let documents_policies = TablePolicies::new().with_select(PolicyExpr::IsNull {
+        column: "deleted_at".into(),
+    });
+    schema.insert(
+        TableName::new("documents"),
+        TableSchema::with_policies(documents_descriptor, documents_policies),
+    );
+
+    let sync_manager = SyncManager::new();
+    let mut qm = create_query_manager(sync_manager, schema);
+    let mut storage = MemoryStorage::new();
+
+    let visible_id = qm
+        .insert(
+            &mut storage,
+            "documents",
+            &[Value::Text("draft".into()), Value::Null],
+        )
+        .unwrap()
+        .row_id;
+    let hidden_id = qm
+        .insert(
+            &mut storage,
+            "documents",
+            &[
+                Value::Text("soft-deleted".into()),
+                Value::Text("2026-03-30T12:00:00Z".into()),
+            ],
+        )
+        .unwrap()
+        .row_id;
+
+    let sub_id = qm
+        .subscribe_with_session(
+            QueryBuilder::new("documents").build(),
+            Some(Session::new("alice")),
+            None,
+        )
+        .unwrap();
+
+    for _ in 0..10 {
+        qm.process(&mut storage);
+    }
+
+    let visible_ids: HashSet<_> = qm
+        .get_subscription_results(sub_id)
+        .into_iter()
+        .map(|(id, _)| id)
+        .collect();
+    assert!(
+        visible_ids.contains(&visible_id),
+        "rows with deleted_at IS NULL should remain visible"
+    );
+    assert!(
+        !visible_ids.contains(&hidden_id),
+        "rows with non-null deleted_at should be filtered out by IS NULL"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Before this change, comparisons like column = NULL were evaluated through the normal scalar encoding path. That works for ordinary values, but it gives the wrong result for Value::Null, where the engine needs null-aware semantics instead of byte comparison.


- handle `Value::Null` with value-level semantics in row policy comparisons instead of encoded-byte comparison
- normalize null-valued query conditions into `IS NULL` and `IS NOT NULL` predicates and prevent them from being treated as index-scannable scalar filters
- add coverage for null literal comparisons in direct policy evaluation, query predicate lowering, ReBAC inserts, `EXISTS REL`, and select filtering

## Testing
- `cargo test -p jazz-tools null_`