### PR TITLE
fix: type inference for default values

### DIFF
--- a/examples/chat-react/package.json
+++ b/examples/chat-react/package.json
@@ -47,15 +47,15 @@
     "@types/dompurify": "^3.2.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
-    "@vitejs/plugin-react": "^4.0.0",
+    "@vitejs/plugin-react": "catalog:default",
     "@vitest/browser": "catalog:default",
     "@vitest/browser-playwright": "catalog:default",
     "tsx": "^4.0.0",
     "tw-animate-css": "^1.4.0",
-    "typescript": "^5.8.0",
-    "vite": "^6.0.0",
-    "vite-plugin-top-level-await": "^1.6.0",
-    "vite-plugin-wasm": "^3.5.0",
+    "typescript": "catalog:default",
+    "vite": "catalog:default",
+    "vite-plugin-top-level-await": "catalog:default",
+    "vite-plugin-wasm": "catalog:default",
     "vitest": "catalog:default"
   }
 }

--- a/packages/jazz-tools/src/dsl.ts
+++ b/packages/jazz-tools/src/dsl.ts
@@ -96,115 +96,126 @@ export type TypedColumnBuilder<
   Sql extends SqlType = SqlType,
   Optional extends boolean = boolean,
   Ref extends string | undefined = string | undefined,
+  HasDefault extends boolean = boolean,
 > = Omit<ColumnBuilder, "optional" | "default"> & {
   readonly __jazzSqlType: Sql;
   readonly __jazzOptional: Optional;
   readonly __jazzReferences: Ref;
-  default(value: MaybeOptional<TSTypeFromSqlType<Sql>, Optional>): ColumnAlias<Sql, Optional, Ref>;
-  optional(): ColumnAlias<Sql, true, Ref>;
+  readonly __jazzHasDefault: HasDefault;
+  default(
+    value: MaybeOptional<TSTypeFromSqlType<Sql>, Optional>,
+  ): ColumnAlias<Sql, Optional, Ref, true>;
+  optional(): ColumnAlias<Sql, true, Ref, HasDefault>;
 };
 
-export type AnyTypedColumnBuilder = TypedColumnBuilder<SqlType, boolean, string | undefined>;
+export type AnyTypedColumnBuilder = TypedColumnBuilder<
+  SqlType,
+  boolean,
+  string | undefined,
+  boolean
+>;
 export type ColumnBuilderSqlType<TBuilder extends AnyTypedColumnBuilder> =
   TBuilder["__jazzSqlType"];
 export type ColumnBuilderOptional<TBuilder extends AnyTypedColumnBuilder> =
   TBuilder["__jazzOptional"];
 export type ColumnBuilderReferences<TBuilder extends AnyTypedColumnBuilder> =
   TBuilder["__jazzReferences"];
+export type ColumnBuilderHasDefault<TBuilder extends AnyTypedColumnBuilder> =
+  TBuilder["__jazzHasDefault"];
 
-export type StringColumn<Optional extends boolean = false> = TypedColumnBuilder<
-  "TEXT",
-  Optional,
-  undefined
->;
-export type BooleanColumn<Optional extends boolean = false> = TypedColumnBuilder<
-  "BOOLEAN",
-  Optional,
-  undefined
->;
-export type IntColumn<Optional extends boolean = false> = TypedColumnBuilder<
-  "INTEGER",
-  Optional,
-  undefined
->;
-export type TimestampColumn<Optional extends boolean = false> = TypedColumnBuilder<
-  "TIMESTAMP",
-  Optional,
-  undefined
->;
-export type FloatColumn<Optional extends boolean = false> = TypedColumnBuilder<
-  "REAL",
-  Optional,
-  undefined
->;
-export type BytesColumn<Optional extends boolean = false> = TypedColumnBuilder<
-  "BYTEA",
-  Optional,
-  undefined
->;
-export type JsonColumn<Output = JsonValue, Optional extends boolean = false> = TypedColumnBuilder<
-  JsonSqlType<Output>,
-  Optional,
-  undefined
->;
+export type StringColumn<
+  Optional extends boolean = false,
+  HasDefault extends boolean = false,
+> = TypedColumnBuilder<"TEXT", Optional, undefined, HasDefault>;
+export type BooleanColumn<
+  Optional extends boolean = false,
+  HasDefault extends boolean = false,
+> = TypedColumnBuilder<"BOOLEAN", Optional, undefined, HasDefault>;
+export type IntColumn<
+  Optional extends boolean = false,
+  HasDefault extends boolean = false,
+> = TypedColumnBuilder<"INTEGER", Optional, undefined, HasDefault>;
+export type TimestampColumn<
+  Optional extends boolean = false,
+  HasDefault extends boolean = false,
+> = TypedColumnBuilder<"TIMESTAMP", Optional, undefined, HasDefault>;
+export type FloatColumn<
+  Optional extends boolean = false,
+  HasDefault extends boolean = false,
+> = TypedColumnBuilder<"REAL", Optional, undefined, HasDefault>;
+export type BytesColumn<
+  Optional extends boolean = false,
+  HasDefault extends boolean = false,
+> = TypedColumnBuilder<"BYTEA", Optional, undefined, HasDefault>;
+export type JsonColumn<
+  Output = JsonValue,
+  Optional extends boolean = false,
+  HasDefault extends boolean = false,
+> = TypedColumnBuilder<JsonSqlType<Output>, Optional, undefined, HasDefault>;
 export type EnumColumn<
   Variants extends readonly string[] = readonly string[],
   Optional extends boolean = false,
+  HasDefault extends boolean = false,
 > = TypedColumnBuilder<
   {
     kind: "ENUM";
     variants: [...Variants];
   },
   Optional,
-  undefined
+  undefined,
+  HasDefault
 >;
 export type RefColumn<
   TargetTable extends string,
   Optional extends boolean = false,
-> = TypedColumnBuilder<"UUID", Optional, TargetTable>;
+  HasDefault extends boolean = false,
+> = TypedColumnBuilder<"UUID", Optional, TargetTable, HasDefault>;
 export type ArrayColumn<
   ElementSql extends SqlType = SqlType,
   Optional extends boolean = false,
   Ref extends string | undefined = undefined,
+  HasDefault extends boolean = false,
 > = TypedColumnBuilder<
   {
     kind: "ARRAY";
     element: ElementSql;
   },
   Optional,
-  Ref
+  Ref,
+  HasDefault
 >;
 export type ColumnAlias<
   Sql extends SqlType = SqlType,
   Optional extends boolean = boolean,
   Ref extends string | undefined = string | undefined,
-> = Ref extends string
-  ? RefColumn<Ref, Optional>
-  : Sql extends "TEXT"
-    ? StringColumn<Optional>
-    : Sql extends "BOOLEAN"
-      ? BooleanColumn<Optional>
-      : Sql extends "INTEGER"
-        ? IntColumn<Optional>
-        : Sql extends "TIMESTAMP"
-          ? TimestampColumn<Optional>
-          : Sql extends "REAL"
-            ? FloatColumn<Optional>
-            : Sql extends "BYTEA"
-              ? BytesColumn<Optional>
-              : Sql extends JsonSqlType<infer Output>
-                ? JsonColumn<Output, Optional>
-                : Sql extends {
-                      kind: "ENUM";
-                      variants: infer Variants extends readonly string[];
-                    }
-                  ? EnumColumn<Variants, Optional>
+  HasDefault extends boolean = boolean,
+> = Sql extends {
+  kind: "ARRAY";
+  element: infer ElementSql extends SqlType;
+}
+  ? ArrayColumn<ElementSql, Optional, Ref, HasDefault>
+  : Ref extends string
+    ? RefColumn<Ref, Optional, HasDefault>
+    : Sql extends "TEXT"
+      ? StringColumn<Optional, HasDefault>
+      : Sql extends "BOOLEAN"
+        ? BooleanColumn<Optional, HasDefault>
+        : Sql extends "INTEGER"
+          ? IntColumn<Optional, HasDefault>
+          : Sql extends "TIMESTAMP"
+            ? TimestampColumn<Optional, HasDefault>
+            : Sql extends "REAL"
+              ? FloatColumn<Optional, HasDefault>
+              : Sql extends "BYTEA"
+                ? BytesColumn<Optional, HasDefault>
+                : Sql extends JsonSqlType<infer Output>
+                  ? JsonColumn<Output, Optional, HasDefault>
                   : Sql extends {
-                        kind: "ARRAY";
-                        element: infer ElementSql extends SqlType;
+                        kind: "ENUM";
+                        variants: infer Variants extends readonly string[];
                       }
-                    ? ArrayColumn<ElementSql, Optional, Ref>
-                    : TypedColumnBuilder<Sql, Optional, Ref>;
+                    ? EnumColumn<Variants, Optional, HasDefault>
+                    : TypedColumnBuilder<Sql, Optional, Ref, HasDefault>;
 
 type RefColumnKey = `${string}Id` | `${string}_id`;
 type RefArrayColumnKey = `${string}Ids` | `${string}_ids`;

--- a/packages/jazz-tools/src/typed-app.ts
+++ b/packages/jazz-tools/src/typed-app.ts
@@ -1,5 +1,6 @@
 import type {
   AnyTypedColumnBuilder,
+  ColumnBuilderHasDefault,
   ColumnBuilderOptional,
   ColumnBuilderReferences,
   ColumnBuilderSqlType,
@@ -151,6 +152,10 @@ type BuilderForColumn<
 type ColumnValue<TBuilder extends AnyTypedColumnBuilder> = TSTypeFromSqlType<
   ColumnBuilderSqlType<TBuilder>
 >;
+type InsertColumnValue<TBuilder extends AnyTypedColumnBuilder> =
+  ColumnBuilderOptional<TBuilder> extends true
+    ? ColumnValue<TBuilder> | null
+    : ColumnValue<TBuilder>;
 
 type OptionalColumnName<TSchema extends SchemaLike, TTable extends TableName<TSchema>> = {
   [TColumn in ColumnName<TSchema, TTable>]-?: ColumnBuilderOptional<
@@ -164,6 +169,20 @@ type RequiredColumnName<TSchema extends SchemaLike, TTable extends TableName<TSc
   ColumnName<TSchema, TTable>,
   OptionalColumnName<TSchema, TTable>
 >;
+type DefaultedColumnName<TSchema extends SchemaLike, TTable extends TableName<TSchema>> = {
+  [TColumn in ColumnName<TSchema, TTable>]-?: ColumnBuilderHasDefault<
+    BuilderForColumn<TSchema, TTable, TColumn>
+  > extends true
+    ? TColumn
+    : never;
+}[ColumnName<TSchema, TTable>];
+type OptionalInsertColumnName<TSchema extends SchemaLike, TTable extends TableName<TSchema>> =
+  | OptionalColumnName<TSchema, TTable>
+  | DefaultedColumnName<TSchema, TTable>;
+type RequiredInsertColumnName<
+  TSchema extends SchemaLike,
+  TTable extends TableName<TSchema>,
+> = Exclude<ColumnName<TSchema, TTable>, OptionalInsertColumnName<TSchema, TTable>>;
 
 export type TableRow<TSchema extends SchemaLike, TTable extends TableName<TSchema>> = Simplify<
   {
@@ -181,11 +200,11 @@ export type TableRow<TSchema extends SchemaLike, TTable extends TableName<TSchem
 
 export type TableInit<TSchema extends SchemaLike, TTable extends TableName<TSchema>> = Simplify<
   {
-    [TColumn in RequiredColumnName<TSchema, TTable>]: ColumnValue<
+    [TColumn in RequiredInsertColumnName<TSchema, TTable>]: InsertColumnValue<
       BuilderForColumn<TSchema, TTable, TColumn>
     >;
   } & {
-    [TColumn in OptionalColumnName<TSchema, TTable>]?: ColumnValue<
+    [TColumn in OptionalInsertColumnName<TSchema, TTable>]?: InsertColumnValue<
       BuilderForColumn<TSchema, TTable, TColumn>
     >;
   }
@@ -525,11 +544,13 @@ export type TableRelationMap = Record<string, TableRelation>;
 export interface TableMeta<
   TName extends string = string,
   TRow extends { id: string } = { id: string },
+  TInit extends object = Record<string, never>,
   TWhere extends object = Record<string, never>,
   TRelations extends TableRelationMap = {},
 > {
   readonly name: TName;
   readonly row: TRow;
+  readonly init: TInit;
   readonly where: TWhere;
   readonly relations: TRelations;
 }
@@ -538,12 +559,13 @@ export type AnyTableMeta = TableMeta<
   string,
   { id: string },
   Record<string, unknown>,
+  Record<string, unknown>,
   TableRelationMap
 >;
 
 type TableNameFromMeta<TMeta extends AnyTableMeta> = TMeta["name"];
 type TableRowFromMeta<TMeta extends AnyTableMeta> = TMeta["row"];
-type TableInitFromMeta<TMeta extends AnyTableMeta> = Simplify<Omit<TableRowFromMeta<TMeta>, "id">>;
+type TableInitFromMeta<TMeta extends AnyTableMeta> = TMeta["init"];
 type TableWhereFromMeta<TMeta extends AnyTableMeta> = TMeta["where"];
 type TableRelationsFromMeta<TMeta extends AnyTableMeta> = TMeta["relations"];
 type RelationNameFromMeta<TMeta extends AnyTableMeta> = Extract<
@@ -595,6 +617,7 @@ export type SchemaTable<TTable extends string, TSchema extends SchemaLike> =
     ? TableMeta<
         TTable,
         TableRow<TSchema, TTable>,
+        TableInit<TSchema, TTable>,
         TableWhereInput<TSchema, TTable>,
         SchemaRelations<TTable, TSchema>
       >

--- a/packages/jazz-tools/tests/ts-dsl/fixtures/basic/schema.ts
+++ b/packages/jazz-tools/tests/ts-dsl/fixtures/basic/schema.ts
@@ -3,6 +3,12 @@ import { schemaToWasm } from "../../../../src/codegen/schema-reader.js";
 import { schemaDefinitionToAst } from "../../../../src/migrations.js";
 import type { CompiledPermissions } from "../../../../src/permissions/index.js";
 import { mergePermissionsIntoSchema } from "../../../../src/schema-permissions.js";
+import { z } from "zod";
+
+const jsonSchema = z.object({
+  name: z.string(),
+  age: z.number().optional(),
+});
 
 export const schema = {
   users: s.table({
@@ -15,13 +21,27 @@ export const schema = {
   todos: s
     .table({
       title: s.string(),
-      done: s.boolean(),
-      tags: s.array(s.string()),
+      done: s.boolean().default(false),
+      tags: s.array(s.string()).default([]),
       projectId: s.ref("projects"),
       ownerId: s.ref("users").optional(),
-      assigneesIds: s.array(s.ref("users")),
+      assigneesIds: s.array(s.ref("users")).default([]),
     })
     .index("by_done", ["done"]),
+  table_with_defaults: s.table({
+    integer: s.int().default(1),
+    float: s.float().default(1),
+    bytes: s.bytes().default(new Uint8Array([0, 1, 255])),
+    enum: s.enum("a", "b", "c").default("a"),
+    json: s.json(jsonSchema).default({ name: "default name" }),
+    timestampDate: s.timestamp().default(new Date("2026-01-01")),
+    timestampNumber: s.timestamp().default(0),
+    string: s.string().default("default value"),
+    array: s.array(s.string()).default(["a", "b", "c"]),
+    boolean: s.boolean().default(true),
+    nullable: s.string().optional().default(null),
+    refId: s.ref("todos").optional().default("00000000-0000-0000-0000-000000000000"),
+  }),
 };
 
 export type AppSchema = s.Schema<typeof schema>;

--- a/packages/jazz-tools/tests/ts-dsl/insert-api.test.ts
+++ b/packages/jazz-tools/tests/ts-dsl/insert-api.test.ts
@@ -1,7 +1,7 @@
 import { createDb, type Db } from "../../src/runtime/db.js";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { app } from "./fixtures/basic/schema";
-import { insertUser, uniqueDbName } from "./factories";
+import { insertProject, insertUser, uniqueDbName } from "./factories";
 
 describe("TS Insert API", () => {
   let db: Db;
@@ -83,91 +83,66 @@ describe("TS Insert API", () => {
     });
   });
 
-  it("updates rows synchronously without returning a promise", async () => {
-    const project = db.insert(app.projects, { name: "Test Project" });
+  it("uses default values missing from the insert data", async () => {
+    const project = insertProject(db);
     const owner = insertUser(db);
     const todo = db.insert(app.todos, {
       title: "Test Todo",
-      done: false,
-      tags: ["tag1", "tag2"],
       projectId: project.id,
       ownerId: owner.id,
-      assigneesIds: [],
     });
 
-    const result = db.update(app.todos, todo.id, { done: true });
-    expect(result).toBeUndefined();
-
-    const [updated] = await db.all(app.todos.where({ id: { eq: todo.id } }));
-    expect(updated!.done).toBe(true);
-  });
-
-  it("can wait for updates to be persisted up to a specific durability tier", async () => {
-    const project = db.insert(app.projects, { name: "Test Project" });
-    const owner = insertUser(db);
-    const todo = db.insert(app.todos, {
+    expect(todo).toEqual({
+      id: todo.id,
       title: "Test Todo",
-      done: false,
-      tags: ["tag1", "tag2"],
       projectId: project.id,
       ownerId: owner.id,
-      assigneesIds: [],
-    });
-
-    const pending = db.updateDurable(app.todos, todo.id, { done: true }, { tier: "worker" });
-    expect(pending).toBeInstanceOf(Promise);
-
-    await pending;
-
-    const [updated] = await db.all(app.todos.where({ id: { eq: todo.id } }), { tier: "worker" });
-    expect(updated!.done).toBe(true);
-  });
-
-  it("deletes rows synchronously without returning a promise", async () => {
-    const project = db.insert(app.projects, { name: "Test Project" });
-    const owner = insertUser(db);
-    const todo = db.insert(app.todos, {
-      title: "Test Todo",
       done: false,
-      tags: ["tag1", "tag2"],
-      projectId: project.id,
-      ownerId: owner.id,
+      tags: [],
       assigneesIds: [],
     });
-
-    const result = db.delete(app.todos, todo.id);
-    expect(result).toBeUndefined();
-
-    const rows = await db.all(app.todos.where({ id: { eq: todo.id } }));
-    expect(rows).toEqual([]);
   });
 
-  it("can wait for deletes to be persisted up to a specific durability tier", async () => {
-    const project = await db.insertDurable(
-      app.projects,
-      { name: "Test Project" },
-      { tier: "worker" },
-    );
-    const owner = insertUser(db);
-    const todo = await db.insertDurable(
-      app.todos,
-      {
-        title: "Test Todo",
-        done: false,
-        tags: ["tag1", "tag2"],
-        projectId: project.id,
-        ownerId: owner.id,
-        assigneesIds: [],
-      },
-      { tier: "worker" },
-    );
+  it("support schema defaults for all data types", async () => {
+    const row_with_defaults = db.insert(app.table_with_defaults, {});
 
-    const pending = db.deleteDurable(app.todos, todo.id, { tier: "worker" });
-    expect(pending).toBeInstanceOf(Promise);
+    expect(row_with_defaults).toEqual({
+      id: expect.any(String),
+      integer: 1,
+      float: 1,
+      bytes: new Uint8Array([0, 1, 255]),
+      enum: "a",
+      json: { name: "default name" },
+      timestampDate: new Date("2026-01-01"),
+      timestampNumber: new Date(0),
+      string: "default value",
+      array: ["a", "b", "c"],
+      boolean: true,
+      nullable: undefined,
+      refId: "00000000-0000-0000-0000-000000000000",
+    });
+  });
 
-    await pending;
+  it("allows explicit null for nullable fields without triggering defaults", async () => {
+    const row_with_defaults = db.insert(app.table_with_defaults, {
+      nullable: null,
+      refId: null,
+    });
 
-    const rows = await db.all(app.todos.where({ id: { eq: todo.id } }), { tier: "worker" });
-    expect(rows).toEqual([]);
+    expect(row_with_defaults).toEqual({
+      id: expect.any(String),
+      integer: 1,
+      float: 1,
+      bytes: new Uint8Array([0, 1, 255]),
+      enum: "a",
+      json: { name: "default name" },
+      timestampDate: new Date("2026-01-01"),
+      timestampNumber: new Date(0),
+      string: "default value",
+      array: ["a", "b", "c"],
+      boolean: true,
+      nullable: undefined,
+      refId: undefined,
+    });
   });
 });

--- a/packages/jazz-tools/tests/ts-dsl/typed-app.test.ts
+++ b/packages/jazz-tools/tests/ts-dsl/typed-app.test.ts
@@ -33,6 +33,25 @@ const schema = {
 type AppSchema = s.Schema<typeof schema>;
 const app: s.App<AppSchema> = s.defineApp(schema);
 
+const defaultedSchema = {
+  users: s.table({
+    name: s.string(),
+  }),
+  projects: s.table({
+    name: s.string(),
+  }),
+  todos: s.table({
+    title: s.string(),
+    done: s.boolean().default(false),
+    tags: s.array(s.string()).default([]),
+    projectId: s.ref("projects"),
+    ownerId: s.ref("users").optional().default(null),
+    assigneesIds: s.array(s.ref("users")).default([]),
+  }),
+};
+type DefaultedAppSchema = s.Schema<typeof defaultedSchema>;
+const defaultedApp: s.App<DefaultedAppSchema> = s.defineApp(defaultedSchema);
+
 describe("typed app prototype", () => {
   it("serializes select/include metadata without codegen", () => {
     expect(JSON.parse(app.todos.select("title").include({ project: true })._build())).toEqual({
@@ -93,7 +112,7 @@ describe("typed app prototype", () => {
     expectTypeOf(todoInsert.done).toEqualTypeOf<boolean>();
     expectTypeOf(todoInsert.tags).toEqualTypeOf<string[]>();
     expectTypeOf(todoInsert.project).toEqualTypeOf<string>();
-    expectTypeOf(todoInsert.owner).toEqualTypeOf<string | undefined>();
+    expectTypeOf(todoInsert.owner).toEqualTypeOf<string | null | undefined>();
 
     expectTypeOf(undefined as TodoWhere["project"]).toEqualTypeOf<
       string | { eq?: string; ne?: string } | undefined
@@ -160,6 +179,37 @@ describe("typed app prototype", () => {
 
       // @ts-expect-error invalid ref target table name inside array ref
       s.defineApp(invalidArrayRefSchema);
+    }
+  });
+
+  it("infers fields with defaults as optional for init payloads", () => {
+    type TodoInsert = s.InsertOf<typeof defaultedApp.todos>;
+    const minimalInsert: TodoInsert = {
+      title: "Ship defaults",
+      projectId: "00000000-0000-0000-0000-000000000001",
+    };
+    const explicitOptionalValues: TodoInsert = {
+      title: "Ship defaults",
+      projectId: "00000000-0000-0000-0000-000000000001",
+      ownerId: null,
+      assigneesIds: ["00000000-0000-0000-0000-000000000002"],
+    };
+
+    expectTypeOf(minimalInsert.title).toEqualTypeOf<string>();
+    expectTypeOf(minimalInsert.projectId).toEqualTypeOf<string>();
+    expectTypeOf(minimalInsert.done).toEqualTypeOf<boolean | undefined>();
+    expectTypeOf(minimalInsert.tags).toEqualTypeOf<string[] | undefined>();
+    expectTypeOf(explicitOptionalValues.ownerId).toEqualTypeOf<string | null | undefined>();
+    expectTypeOf(explicitOptionalValues.assigneesIds).toEqualTypeOf<string[] | undefined>();
+
+    if ((globalThis as { __typecheck_only__?: boolean }).__typecheck_only__) {
+      const invalidDefaultedNull: TodoInsert = {
+        title: "Broken",
+        projectId: "00000000-0000-0000-0000-000000000001",
+        // @ts-expect-error non-nullable defaulted columns still reject null
+        done: null,
+      };
+      void invalidDefaultedNull;
     }
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -378,7 +378,7 @@ importers:
         version: 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@tailwindcss/vite':
         specifier: ^4.1.18
-        version: 4.2.2(vite@6.4.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.2.2(vite@8.0.1(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -450,14 +450,14 @@ importers:
         specifier: ^19.0.0
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
-        specifier: ^4.0.0
-        version: 4.7.0(vite@6.4.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        specifier: catalog:default
+        version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.1(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       '@vitest/browser':
         specifier: catalog:default
-        version: 4.1.0(vite@6.4.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.1.0)
+        version: 4.1.0(vite@8.0.1(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.1.0)
       '@vitest/browser-playwright':
         specifier: catalog:default
-        version: 4.1.0(playwright@1.58.2)(vite@6.4.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.1.0)
+        version: 4.1.0(playwright@1.58.2)(vite@8.0.1(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.1.0)
       tsx:
         specifier: ^4.0.0
         version: 4.21.0
@@ -465,20 +465,20 @@ importers:
         specifier: ^1.4.0
         version: 1.4.0
       typescript:
-        specifier: ^5.8.0
-        version: 5.9.3
+        specifier: catalog:default
+        version: 6.0.2
       vite:
-        specifier: ^6.0.0
-        version: 6.4.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        specifier: catalog:default
+        version: 8.0.1(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       vite-plugin-top-level-await:
-        specifier: ^1.6.0
-        version: 1.6.0(rollup@4.59.0)(vite@6.4.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        specifier: catalog:default
+        version: 1.6.0(rollup@4.59.0)(vite@8.0.1(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       vite-plugin-wasm:
-        specifier: ^3.5.0
-        version: 3.6.0(vite@6.4.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        specifier: catalog:default
+        version: 3.6.0(vite@8.0.1(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       vitest:
         specifier: catalog:default
-        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.3.3)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@6.4.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.3.3)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.1(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   examples/docs/todo-client-localfirst-expo:
     dependencies:
@@ -10627,11 +10627,6 @@ packages:
   typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
-    engines: {node: '>=14.17'}
-    hasBin: true
-
   typescript@6.0.2:
     resolution: {integrity: sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==}
     engines: {node: '>=14.17'}
@@ -15504,12 +15499,12 @@ snapshots:
       postcss: 8.5.6
       tailwindcss: 4.2.1
 
-  '@tailwindcss/vite@4.2.2(vite@6.4.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
+  '@tailwindcss/vite@4.2.2(vite@8.0.1(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@tailwindcss/node': 4.2.2
       '@tailwindcss/oxide': 4.2.2
       tailwindcss: 4.2.2
-      vite: 6.4.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 8.0.1(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   '@tanstack/react-table@8.21.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
@@ -15888,18 +15883,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0)
-      '@rolldown/pluginutils': 1.0.0-beta.27
-      '@types/babel__core': 7.20.5
-      react-refresh: 0.17.0
-      vite: 6.4.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
-    transitivePeerDependencies:
-      - supports-color
-
   '@vitejs/plugin-react@6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.1(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
@@ -15912,19 +15895,6 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.2
       vite: 8.0.1(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       vue: 3.5.29(typescript@6.0.2)
-
-  '@vitest/browser-playwright@4.1.0(playwright@1.58.2)(vite@6.4.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.1.0)':
-    dependencies:
-      '@vitest/browser': 4.1.0(vite@6.4.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.1.0)
-      '@vitest/mocker': 4.1.0(vite@6.4.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
-      playwright: 1.58.2
-      tinyrainbow: 3.0.3
-      vitest: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.3.3)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@6.4.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
-    transitivePeerDependencies:
-      - bufferutil
-      - msw
-      - utf-8-validate
-      - vite
 
   '@vitest/browser-playwright@4.1.0(playwright@1.58.2)(vite@8.0.1(@types/node@20.19.35)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.1.0)':
     dependencies:
@@ -15974,23 +15944,6 @@ snapshots:
       playwright: 1.58.2
       tinyrainbow: 3.0.3
       vitest: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.3.3)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.1(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
-    transitivePeerDependencies:
-      - bufferutil
-      - msw
-      - utf-8-validate
-      - vite
-
-  '@vitest/browser@4.1.0(vite@6.4.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.1.0)':
-    dependencies:
-      '@blazediff/core': 1.9.1
-      '@vitest/mocker': 4.1.0(vite@6.4.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
-      '@vitest/utils': 4.1.0
-      magic-string: 0.30.21
-      pngjs: 7.0.0
-      sirv: 3.0.2
-      tinyrainbow: 3.0.3
-      vitest: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.3.3)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@6.4.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
-      ws: 8.19.0
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -16075,14 +16028,6 @@ snapshots:
       '@vitest/utils': 4.1.0
       chai: 6.2.2
       tinyrainbow: 3.0.3
-
-  '@vitest/mocker@4.1.0(vite@6.4.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
-    dependencies:
-      '@vitest/spy': 4.1.0
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 6.4.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/mocker@4.1.0(vite@8.0.1(@types/node@20.19.35)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
@@ -22504,8 +22449,6 @@ snapshots:
 
   typedarray@0.0.6: {}
 
-  typescript@5.9.3: {}
-
   typescript@6.0.2: {}
 
   uglify-js@3.19.3:
@@ -22666,17 +22609,6 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-plugin-top-level-await@1.6.0(rollup@4.59.0)(vite@6.4.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
-    dependencies:
-      '@rollup/plugin-virtual': 3.0.2(rollup@4.59.0)
-      '@swc/core': 1.15.18
-      '@swc/wasm': 1.15.18
-      uuid: 10.0.0
-      vite: 6.4.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
-    transitivePeerDependencies:
-      - '@swc/helpers'
-      - rollup
-
   vite-plugin-top-level-await@1.6.0(rollup@4.59.0)(vite@8.0.1(@types/node@22.19.13)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       '@rollup/plugin-virtual': 3.0.2(rollup@4.59.0)
@@ -22710,10 +22642,6 @@ snapshots:
       - '@swc/helpers'
       - rollup
 
-  vite-plugin-wasm@3.6.0(vite@6.4.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
-    dependencies:
-      vite: 6.4.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
-
   vite-plugin-wasm@3.6.0(vite@8.0.1(@types/node@22.19.13)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       vite: 8.0.1(@types/node@22.19.13)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
@@ -22736,23 +22664,6 @@ snapshots:
       tinyglobby: 0.2.15
     optionalDependencies:
       '@types/node': 20.19.35
-      fsevents: 2.3.3
-      jiti: 2.6.1
-      lightningcss: 1.32.0
-      terser: 5.46.0
-      tsx: 4.21.0
-      yaml: 2.8.2
-
-  vite@6.4.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
-    dependencies:
-      esbuild: 0.25.12
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-      postcss: 8.5.8
-      rollup: 4.59.0
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      '@types/node': 25.3.3
       fsevents: 2.3.3
       jiti: 2.6.1
       lightningcss: 1.32.0
@@ -22940,38 +22851,6 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@types/node': 24.11.0
       '@vitest/browser-playwright': 4.1.0(playwright@1.58.2)(vite@8.0.1(@types/node@24.11.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.1.0)
-      '@vitest/ui': 4.1.0(vitest@4.1.0)
-      happy-dom: 20.8.4
-      jsdom: 28.1.0(@noble/hashes@2.0.1)
-    transitivePeerDependencies:
-      - msw
-
-  vitest@4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.3.3)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@6.4.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
-    dependencies:
-      '@vitest/expect': 4.1.0
-      '@vitest/mocker': 4.1.0(vite@6.4.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
-      '@vitest/pretty-format': 4.1.0
-      '@vitest/runner': 4.1.0
-      '@vitest/snapshot': 4.1.0
-      '@vitest/spy': 4.1.0
-      '@vitest/utils': 4.1.0
-      es-module-lexer: 2.0.0
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      obug: 2.1.1
-      pathe: 2.0.3
-      picomatch: 4.0.3
-      std-env: 4.0.0
-      tinybench: 2.9.0
-      tinyexec: 1.0.2
-      tinyglobby: 0.2.15
-      tinyrainbow: 3.0.3
-      vite: 6.4.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@opentelemetry/api': 1.9.1
-      '@types/node': 25.3.3
-      '@vitest/browser-playwright': 4.1.0(playwright@1.58.2)(vite@6.4.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.1.0)
       '@vitest/ui': 4.1.0(vitest@4.1.0)
       happy-dom: 20.8.4
       jsdom: 28.1.0(@noble/hashes@2.0.1)


### PR DESCRIPTION
## Description

Modifies type inference for the TS DSL to make fields with default values optional when inserting a record.

Also restores tests that were deleted by https://github.com/garden-co/jazz2/pull/316