### PR TITLE
Fix policy context sync for session-scoped downstream queries

### DIFF
--- a/crates/jazz-tools/src/query_manager/manager_tests.rs
+++ b/crates/jazz-tools/src/query_manager/manager_tests.rs
@@ -9630,6 +9630,96 @@ fn e2e_permissions_prevent_new_row_sync() {
     assert_eq!(results[0].1[0], Value::Text("Alice's doc".into()));
 }
 
+/// E2E: Untrusted synced clients still need relation-backed policy context rows.
+#[test]
+fn e2e_untrusted_client_syncs_exists_policy_dependencies() {
+    use crate::query_manager::policy::{CmpOp, OUTER_ROW_SESSION_PREFIX, PolicyValue};
+    use crate::sync_manager::{ClientId, ServerId};
+    use uuid::Uuid;
+
+    let mut schema = Schema::new();
+    schema.insert(
+        TableName::new("documents"),
+        TableSchema::with_policies(
+            RowDescriptor::new(vec![ColumnDescriptor::new("title", ColumnType::Text)]),
+            TablePolicies::new().with_select(PolicyExpr::Exists {
+                table: "document_shares".into(),
+                condition: Box::new(PolicyExpr::and(vec![
+                    PolicyExpr::Cmp {
+                        column: "document_id".into(),
+                        op: CmpOp::Eq,
+                        value: PolicyValue::SessionRef(vec![
+                            OUTER_ROW_SESSION_PREFIX.into(),
+                            "id".into(),
+                        ]),
+                    },
+                    PolicyExpr::eq_session("user_id", vec!["user_id".into()]),
+                ])),
+            }),
+        ),
+    );
+    schema.insert(
+        TableName::new("document_shares"),
+        RowDescriptor::new(vec![
+            ColumnDescriptor::new("document_id", ColumnType::Uuid),
+            ColumnDescriptor::new("user_id", ColumnType::Text),
+        ])
+        .into(),
+    );
+
+    let (mut server, mut server_io) = create_query_manager(SyncManager::new(), schema.clone());
+    let doc_id = server
+        .insert(
+            &mut server_io,
+            "documents",
+            &[Value::Text("Shared doc".into())],
+        )
+        .unwrap()
+        .row_id;
+    server
+        .insert(
+            &mut server_io,
+            "document_shares",
+            &[Value::Uuid(doc_id), Value::Text("bob".into())],
+        )
+        .unwrap();
+    server.process(&mut server_io);
+
+    let (mut client, mut client_io) = create_query_manager(SyncManager::new(), schema.clone());
+
+    let server_id = ServerId(Uuid::new_v7(uuid::Timestamp::now(uuid::NoContext)));
+    let client_id = ClientId(Uuid::new_v7(uuid::Timestamp::now(uuid::NoContext)));
+
+    client.sync_manager_mut().add_server(server_id);
+    server.sync_manager_mut().add_client(client_id);
+    let _ = client.sync_manager_mut().take_outbox();
+
+    let sub_id = client
+        .subscribe_with_sync(
+            client.query("documents").build(),
+            Some(PolicySession::new("bob")),
+            None,
+        )
+        .unwrap();
+
+    pump_messages(
+        &mut client,
+        &mut server,
+        &mut client_io,
+        &mut server_io,
+        client_id,
+        server_id,
+    );
+
+    let results = client.get_subscription_results(sub_id);
+    assert_eq!(
+        results.len(),
+        1,
+        "Untrusted synced clients should receive the rows needed to realize EXISTS-backed visibility"
+    );
+    assert_eq!(results[0].1[0], Value::Text("Shared doc".into()));
+}
+
 /// E2E: In a 3-tier topology, upstream must sync policy-evaluation dependencies.
 ///
 /// Scenario:
@@ -9759,9 +9849,10 @@ fn e2e_three_tier_policy_dependencies_must_sync_downstream() {
     );
 }
 
-/// E2E: Untrusted downstream clients keep result-set-only scope (no policy context rows).
+/// E2E: Untrusted downstream clients still receive policy dependencies needed
+/// to realize inherited visibility locally.
 #[test]
-fn e2e_three_tier_untrusted_downstream_keeps_result_only_scope() {
+fn e2e_three_tier_untrusted_downstream_syncs_policy_dependencies() {
     use crate::query_manager::policy::Operation;
     use crate::sync_manager::{ClientId, ServerId};
     use uuid::Uuid;
@@ -9863,7 +9954,7 @@ fn e2e_three_tier_untrusted_downstream_keeps_result_only_scope() {
     let results = client.get_subscription_results(sub_id);
     assert_eq!(
         results.len(),
-        0,
-        "Untrusted downstream should keep current result-only sync behavior"
+        1,
+        "Untrusted downstream should receive docs visible via INHERITS once policy dependencies sync"
     );
 }

--- a/crates/jazz-tools/src/query_manager/server_queries.rs
+++ b/crates/jazz-tools/src/query_manager/server_queries.rs
@@ -669,8 +669,8 @@ impl QueryManager {
         })
     }
 
-    fn should_sync_policy_context_rows(&self, client_id: ClientId) -> bool {
-        self.client_bypasses_authorization_filtering(client_id)
+    fn should_sync_policy_context_rows(&self, session: Option<&Session>) -> bool {
+        session.is_some()
     }
 
     fn client_bypasses_authorization_filtering(&self, client_id: ClientId) -> bool {
@@ -797,7 +797,8 @@ impl QueryManager {
                 continue;
             };
 
-            let sync_policy_context_rows = self.should_sync_policy_context_rows(sub.client_id);
+            let sync_policy_context_rows =
+                self.should_sync_policy_context_rows(session_for_policy.as_ref());
             let branch_schema_map = Self::branch_schema_map_for_context(&subscription_context);
 
             // Initial settle to populate the graph
@@ -860,7 +861,8 @@ impl QueryManager {
                     session_for_policy.as_ref(),
                 )
             };
-            // Trusted clients (Peer/Admin) also need policy context rows.
+            // Session-scoped clients need policy context rows to reproduce
+            // relation-backed authorization locally after sync.
             let scope = if sync_policy_context_rows {
                 let om = &self.sync_manager.object_manager;
                 Self::scope_with_policy_context_rows_from_object_manager(
@@ -1031,7 +1033,7 @@ impl QueryManager {
                         sub.session.as_ref(),
                     )
                 };
-                if self.should_sync_policy_context_rows(client_id) {
+                if self.should_sync_policy_context_rows(sub.session.as_ref()) {
                     let om = &self.sync_manager.object_manager;
                     Self::scope_with_policy_context_rows_from_object_manager(
                         &result_scope,


### PR DESCRIPTION
## Summary

This fixes a sync/auth mismatch for relation-backed read permissions.

Before this change, session-scoped downstream clients still evaluated `policy.exists(...)` / forward `INHERITS` locally, but the server only synced the related policy-context rows to trusted peers. That meant the server could decide a row was visible, sync the result row, and the client would still hide it locally because the dependent rows were missing.

Example:

```ts
policy.documents.allowRead.where((document) =>
  policy.exists(
    policy.document_shares.where({
      documentId: document.id,
      userId: session.user_id,
    }),
  ),
)
```

If Bob is granted access through `document_shares`, the client needs both the `documents` row and the matching `document_shares` row to realize the same permission locally. This change makes session-scoped downstream queries sync those policy dependencies as well, so local subscription visibility matches the server’s authorization result.


- sync policy context rows for any session-scoped downstream query, not just trusted clients
- fix local realization of relation-backed `EXISTS` and `INHERITS` visibility after sync
- add coverage for untrusted synced clients in direct and 3-tier query flows
- update the 3-tier regression test to assert the corrected behavior

## Testing
- `cargo test -p jazz-tools query_manager::manager_tests::e2e_untrusted_client_syncs_exists_policy_dependencies -- --exact`
- `cargo test -p jazz-tools query_manager::manager_tests::e2e_three_tier_untrusted_downstream_syncs_policy_dependencies -- --exact`