### PR TITLE
feat: use `null` instead of `undefined` for nullable columns

### DIFF
--- a/packages/jazz-tools/src/magic-columns.ts
+++ b/packages/jazz-tools/src/magic-columns.ts
@@ -6,8 +6,6 @@ export const PERMISSION_INTROSPECTION_COLUMNS = ["$canRead", "$canEdit", "$canDe
 
 export type PermissionIntrospectionColumn = (typeof PERMISSION_INTROSPECTION_COLUMNS)[number];
 
-export const PERMISSION_INTROSPECTION_TS_TYPE = "boolean | null";
-
 const MAGIC_COLUMN_SET = new Set<string>(PERMISSION_INTROSPECTION_COLUMNS);
 
 export function isPermissionIntrospectionColumn(

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -222,14 +222,6 @@ export interface TableProxy<T, Init> {
   readonly _initType: Init;
 }
 
-type UpdateValue<RowValue, InitValue> = undefined extends RowValue
-  ? InitValue | null
-  : InitValue | undefined;
-
-type UpdateData<T, Init> = {
-  [K in keyof Init]?: K extends keyof T ? UpdateValue<T[K], Init[K]> : Init[K] | undefined;
-};
-
 interface BroadcastChannelLike {
   postMessage(data: unknown): void;
   addEventListener(type: "message", listener: (event: MessageEvent) => void): void;
@@ -1029,7 +1021,7 @@ export class Db {
   /**
    * Update an existing row without waiting for durability.
    */
-  update<T, Init>(table: TableProxy<T, Init>, id: string, data: UpdateData<T, Init>): void {
+  update<T, Init>(table: TableProxy<T, Init>, id: string, data: Partial<Init>): void {
     const client = this.getClient(table._schema);
     const updates = toUpdateRecord(data as Record<string, unknown>, table._schema, table._table);
     client.update(id, updates);
@@ -1041,7 +1033,7 @@ export class Db {
   async updateDurable<T, Init>(
     table: TableProxy<T, Init>,
     id: string,
-    data: UpdateData<T, Init>,
+    data: Partial<Init>,
     options?: { tier?: DurabilityTier },
   ): Promise<void> {
     const client = this.getClient(table._schema);
@@ -1454,11 +1446,7 @@ class ClientBackedDb extends Db {
     return transformRow(row, table._schema, table._table);
   }
 
-  override update<T, Init>(
-    table: TableProxy<T, Init>,
-    id: string,
-    data: UpdateData<T, Init>,
-  ): void {
+  override update<T, Init>(table: TableProxy<T, Init>, id: string, data: Partial<Init>): void {
     const runtimeSchema = normalizeRuntimeSchema(this.runtimeClient.getSchema());
     const inputSchema = resolveSchemaWithTable(table._schema, runtimeSchema, table._table);
     const updates = toUpdateRecord(data as Record<string, unknown>, inputSchema, table._table);
@@ -1468,7 +1456,7 @@ class ClientBackedDb extends Db {
   override async updateDurable<T, Init>(
     table: TableProxy<T, Init>,
     id: string,
-    data: UpdateData<T, Init>,
+    data: Partial<Init>,
     options?: { tier?: DurabilityTier },
   ): Promise<void> {
     const runtimeSchema = normalizeRuntimeSchema(this.runtimeClient.getSchema());

--- a/packages/jazz-tools/src/runtime/query-adapter.test.ts
+++ b/packages/jazz-tools/src/runtime/query-adapter.test.ts
@@ -619,7 +619,7 @@ describe("translateQuery", () => {
       });
     });
 
-    it("translates null value", () => {
+    it("translates eq null value to IsNull", () => {
       const builderJson = JSON.stringify({
         table: "todos",
         conditions: [{ column: "priority", op: "eq", value: null }],
@@ -629,10 +629,23 @@ describe("translateQuery", () => {
 
       const result = parseTranslatedQuery(builderJson, basicSchema);
       expect(expectFilterPredicate(result)).toEqual({
-        type: "Cmp",
-        left: { scope: "todos", column: "priority" },
-        op: "Eq",
-        right: { type: "Literal", value: { Null: null } },
+        type: "IsNull",
+        column: { scope: "todos", column: "priority" },
+      });
+    });
+
+    it("translates ne null value to IsNotNull", () => {
+      const builderJson = JSON.stringify({
+        table: "todos",
+        conditions: [{ column: "priority", op: "ne", value: null }],
+        includes: {},
+        orderBy: [],
+      });
+
+      const result = parseTranslatedQuery(builderJson, basicSchema);
+      expect(expectFilterPredicate(result)).toEqual({
+        type: "IsNotNull",
+        column: { scope: "todos", column: "priority" },
       });
     });
 

--- a/packages/jazz-tools/src/runtime/query-adapter.ts
+++ b/packages/jazz-tools/src/runtime/query-adapter.ts
@@ -232,8 +232,14 @@ function conditionToArraySubqueryFilter(
 
   switch (cond.op) {
     case "eq":
+      if (cond.value === null) {
+        return { IsNull: { column } };
+      }
       return { Eq: { column, value: literalValue } };
     case "ne":
+      if (cond.value === null) {
+        return { IsNotNull: { column } };
+      }
       return { Ne: { column, value: literalValue } };
     case "gt":
       return { Gt: { column, value: literalValue } };
@@ -367,8 +373,14 @@ function conditionToRelPredicate(
   }
   switch (cond.op) {
     case "eq":
+      if (cond.value === null) {
+        return { IsNull: { column: columnRef } };
+      }
       return { Cmp: { left: columnRef, op: "Eq", right: rightLiteral } };
     case "ne":
+      if (cond.value === null) {
+        return { IsNotNull: { column: columnRef } };
+      }
       return {
         Cmp: {
           left: columnRef,

--- a/packages/jazz-tools/src/runtime/row-transformer.test.ts
+++ b/packages/jazz-tools/src/runtime/row-transformer.test.ts
@@ -63,9 +63,9 @@ describe("unwrapValue", () => {
     expect(Array.from(unwrapped as Uint8Array)).toEqual([0, 1, 255]);
   });
 
-  it("unwraps Null to undefined", () => {
+  it("unwraps Null to null", () => {
     const v: WasmValue = { type: "Null" };
-    expect(unwrapValue(v)).toBeUndefined();
+    expect(unwrapValue(v)).toBeNull();
   });
 
   it("unwraps Array recursively", () => {
@@ -217,13 +217,14 @@ describe("transformRows", () => {
       },
     ];
 
-    const result = transformRows<{ id: string; title: string; done: boolean; priority?: number }>(
-      rows,
-      schema,
-      "todos",
-    );
+    const result = transformRows<{
+      id: string;
+      title: string;
+      done: boolean;
+      priority: number | null;
+    }>(rows, schema, "todos");
 
-    expect(result[0]!.priority).toBeUndefined();
+    expect(result[0]!.priority).toBeNull();
   });
 
   it("throws for unknown table", () => {
@@ -346,7 +347,7 @@ describe("transformRows", () => {
       id: string;
       title: string;
       $canEdit: boolean;
-      $canDelete?: boolean;
+      $canDelete: boolean | null;
     }>(rows, schema, "todos", {}, ["title", "$canEdit", "$canDelete"]);
 
     expect(result).toEqual([
@@ -354,7 +355,7 @@ describe("transformRows", () => {
         id: "uuid-1",
         title: "Buy milk",
         $canEdit: true,
-        $canDelete: undefined,
+        $canDelete: null,
       },
     ]);
   });
@@ -397,7 +398,7 @@ describe("transformRows", () => {
         owner: {
           id: "user-1",
           name: "Alice",
-          manager_id: undefined,
+          manager_id: null,
         },
       },
     ]);
@@ -436,7 +437,7 @@ describe("transformRows", () => {
         owner: {
           id: "user-1",
           name: "Alice",
-          manager_id: undefined,
+          manager_id: null,
         },
       },
     ]);
@@ -473,7 +474,7 @@ describe("transformRows", () => {
         owner: {
           id: "user-1",
           name: "Alice",
-          manager_id: undefined,
+          manager_id: null,
         },
       },
     ]);
@@ -567,7 +568,7 @@ describe("transformRows", () => {
       {
         id: "user-1",
         name: "Alice",
-        manager_id: undefined,
+        manager_id: null,
         todosViaOwner: [
           { id: "todo-1", title: "Buy milk", owner_id: "user-1" },
           { id: "todo-2", title: "Write tests", owner_id: "user-1" },
@@ -630,7 +631,7 @@ describe("transformRows", () => {
           manager: {
             id: "user-2",
             name: "Manager",
-            manager_id: undefined,
+            manager_id: null,
           },
         },
       },

--- a/packages/jazz-tools/src/runtime/row-transformer.ts
+++ b/packages/jazz-tools/src/runtime/row-transformer.ts
@@ -113,7 +113,7 @@ function transformIncludedValue(value: WasmValue, plan: IncludePlan, schema: Was
     );
   });
 
-  return plan.relation.isArray ? rows : rows[0];
+  return plan.relation.isArray ? rows : (rows[0] ?? null);
 }
 
 function transformRowValues(
@@ -182,7 +182,7 @@ export function unwrapValue(v: WasmValue, columnType?: ColumnType): unknown {
     case "Bytea":
       return toByteArray((v as { value: unknown }).value);
     case "Null":
-      return undefined;
+      return null;
     case "Array":
       if (columnType?.type === "Array") {
         return v.value.map((entry) => unwrapValue(entry, columnType.element));

--- a/packages/jazz-tools/src/typed-app.ts
+++ b/packages/jazz-tools/src/typed-app.ts
@@ -152,6 +152,10 @@ type BuilderForColumn<
 type ColumnValue<TBuilder extends AnyTypedColumnBuilder> = TSTypeFromSqlType<
   ColumnBuilderSqlType<TBuilder>
 >;
+type ReturnedColumnValue<TBuilder extends AnyTypedColumnBuilder> =
+  ColumnBuilderOptional<TBuilder> extends true
+    ? ColumnValue<TBuilder> | null
+    : ColumnValue<TBuilder>;
 type InsertColumnValue<TBuilder extends AnyTypedColumnBuilder> =
   ColumnBuilderOptional<TBuilder> extends true
     ? ColumnValue<TBuilder> | null
@@ -192,7 +196,7 @@ export type TableRow<TSchema extends SchemaLike, TTable extends TableName<TSchem
       BuilderForColumn<TSchema, TTable, TColumn>
     >;
   } & {
-    [TColumn in OptionalColumnName<TSchema, TTable>]?: ColumnValue<
+    [TColumn in OptionalColumnName<TSchema, TTable>]: ReturnedColumnValue<
       BuilderForColumn<TSchema, TTable, TColumn>
     >;
   }
@@ -210,60 +214,69 @@ export type TableInit<TSchema extends SchemaLike, TTable extends TableName<TSche
   }
 >;
 
-type PrimitiveWhere<T> = T | { eq?: T; ne?: T };
-type NumberWhere<T extends number> = T | { eq?: T; ne?: T; gt?: T; gte?: T; lt?: T; lte?: T };
-type TimestampWhere =
-  | Date
-  | number
-  | {
-      eq?: Date | number;
-      gt?: Date | number;
-      gte?: Date | number;
-      lt?: Date | number;
-      lte?: Date | number;
-    };
+type MaybeNullableWhere<T, TOptional extends boolean> = TOptional extends true ? T | null : T;
+type WhereEqNe<T, TOptional extends boolean, TExtra extends object = {}> =
+  | MaybeNullableWhere<T, TOptional>
+  | ({
+      eq?: MaybeNullableWhere<T, TOptional>;
+      ne?: MaybeNullableWhere<T, TOptional>;
+    } & TExtra);
+type NumberWhere<T extends number, TOptional extends boolean> = WhereEqNe<
+  T,
+  TOptional,
+  { gt?: T; gte?: T; lt?: T; lte?: T }
+>;
+type TimestampWhere<TOptional extends boolean> = WhereEqNe<
+  Date | number,
+  TOptional,
+  {
+    gt?: Date | number;
+    gte?: Date | number;
+    lt?: Date | number;
+    lte?: Date | number;
+  }
+>;
 type UuidWhere<TOptional extends boolean, TRef extends string | undefined> = TRef extends string
-  ? TOptional extends true
-    ? string | { eq?: string; ne?: string; isNull?: boolean }
-    : string | { eq?: string; ne?: string }
-  : string | { eq?: string; ne?: string; in?: string[] };
+  ? WhereEqNe<string, TOptional, TOptional extends true ? { isNull?: boolean } : {}>
+  : WhereEqNe<
+      string,
+      TOptional,
+      TOptional extends true ? { in?: string[]; isNull?: boolean } : { in?: string[] }
+    >;
 
 type WhereInputForBuilder<TBuilder extends AnyTypedColumnBuilder> =
   ColumnBuilderSqlType<TBuilder> extends "TEXT"
-    ? string | { eq?: string; ne?: string; contains?: string }
+    ? WhereEqNe<string, ColumnBuilderOptional<TBuilder>, { contains?: string }>
     : ColumnBuilderSqlType<TBuilder> extends "BOOLEAN"
       ? boolean
       : ColumnBuilderSqlType<TBuilder> extends "INTEGER" | "REAL"
-        ? NumberWhere<number>
+        ? NumberWhere<number, ColumnBuilderOptional<TBuilder>>
         : ColumnBuilderSqlType<TBuilder> extends "TIMESTAMP"
-          ? TimestampWhere
+          ? TimestampWhere<ColumnBuilderOptional<TBuilder>>
           : ColumnBuilderSqlType<TBuilder> extends "UUID"
             ? UuidWhere<ColumnBuilderOptional<TBuilder>, ColumnBuilderReferences<TBuilder>>
             : ColumnBuilderSqlType<TBuilder> extends "BYTEA"
-              ? PrimitiveWhere<Uint8Array>
+              ? WhereEqNe<Uint8Array, ColumnBuilderOptional<TBuilder>>
               : ColumnBuilderSqlType<TBuilder> extends { kind: "JSON" }
-                ?
-                    | ColumnValue<TBuilder>
-                    | {
-                        eq?: ColumnValue<TBuilder>;
-                        ne?: ColumnValue<TBuilder>;
-                        in?: ColumnValue<TBuilder>[];
-                      }
+                ? WhereEqNe<
+                    ColumnValue<TBuilder>,
+                    ColumnBuilderOptional<TBuilder>,
+                    { in?: ColumnValue<TBuilder>[] }
+                  >
                 : ColumnBuilderSqlType<TBuilder> extends {
                       kind: "ENUM";
                       variants: readonly (infer TVariant extends string)[];
                     }
-                  ? TVariant | { eq?: TVariant; ne?: TVariant; in?: TVariant[] }
+                  ? WhereEqNe<TVariant, ColumnBuilderOptional<TBuilder>, { in?: TVariant[] }>
                   : ColumnBuilderSqlType<TBuilder> extends {
                         kind: "ARRAY";
                         element: infer TElementSql extends SqlType;
                       }
-                    ?
-                        | ColumnValue<TBuilder>
-                        | {
-                            eq?: ColumnValue<TBuilder>;
-                            contains?: TSTypeFromSqlType<TElementSql>;
-                          }
+                    ? WhereEqNe<
+                        ColumnValue<TBuilder>,
+                        ColumnBuilderOptional<TBuilder>,
+                        { contains?: TSTypeFromSqlType<TElementSql> }
+                      >
                     : never;
 
 export type TableWhereInput<
@@ -446,13 +459,13 @@ type ApplyRelationCardinality<
   TRequired extends boolean,
 > = TIsArray extends true
   ? TNullable extends true
-    ? TValue[] | undefined
+    ? TValue[] | null
     : TValue[]
-  : TNullable extends true
-    ? TValue | undefined
-    : TRequired extends true
-      ? TValue
-      : TValue | undefined;
+  : TRequired extends true
+    ? TNullable extends true
+      ? TValue | null
+      : TValue
+    : TValue | null;
 
 export type TableInclude<TSchema extends SchemaLike, TTable extends TableName<TSchema>> = {
   [TRelation in RelationName<TSchema, TTable>]?:

--- a/packages/jazz-tools/tests/ts-dsl/insert-api.test.ts
+++ b/packages/jazz-tools/tests/ts-dsl/insert-api.test.ts
@@ -118,7 +118,7 @@ describe("TS Insert API", () => {
       string: "default value",
       array: ["a", "b", "c"],
       boolean: true,
-      nullable: undefined,
+      nullable: null,
       refId: "00000000-0000-0000-0000-000000000000",
     });
   });
@@ -141,8 +141,8 @@ describe("TS Insert API", () => {
       string: "default value",
       array: ["a", "b", "c"],
       boolean: true,
-      nullable: undefined,
-      refId: undefined,
+      nullable: null,
+      refId: null,
     });
   });
 });

--- a/packages/jazz-tools/tests/ts-dsl/query-api.test.ts
+++ b/packages/jazz-tools/tests/ts-dsl/query-api.test.ts
@@ -71,8 +71,9 @@ describe("TS Query API", () => {
       expect(results.map((todo) => todo.id)).toEqual([todoWithOwner.id]);
     });
 
-    it("filters with explicit null values always return false", async () => {
-      const _todoWithoutOwner = insertTodo(db, {
+    // Note: this is a difference with respect to SQL, when =null checks always return false.
+    it("filters with explicit null values work as isNull:true", async () => {
+      const todoWithoutOwner = insertTodo(db, {
         title: "Todo without owner",
         ownerId: null,
       });
@@ -83,8 +84,8 @@ describe("TS Query API", () => {
 
       const resultsDirectNull = await db.all(app.todos.where({ ownerId: null }));
       const resultsEqNull = await db.all(app.todos.where({ ownerId: { eq: null } }));
-      expect(resultsDirectNull).toEqual([]);
-      expect(resultsEqNull).toEqual([]);
+      expect(resultsDirectNull.map((todo) => todo.id)).toEqual([todoWithoutOwner.id]);
+      expect(resultsEqNull.map((todo) => todo.id)).toEqual([todoWithoutOwner.id]);
     });
 
     it("filters with explicit undefined values are no-ops", async () => {

--- a/packages/jazz-tools/tests/ts-dsl/query-api.test.ts
+++ b/packages/jazz-tools/tests/ts-dsl/query-api.test.ts
@@ -1,5 +1,5 @@
 import { createDb, type Db } from "../../src/runtime/db.js";
-import { afterEach, describe, it, expect, assert, expectTypeOf } from "vitest";
+import { afterEach, beforeEach, describe, it, expect, assert, expectTypeOf } from "vitest";
 import { app, type Project, type Todo, type User } from "./fixtures/basic/schema";
 import { insertProject, insertTodo, insertUser, uniqueDbName } from "./factories";
 
@@ -16,34 +16,21 @@ function makeFriends(db: Db, user1: User, user2: User) {
 }
 
 describe("TS Query API", () => {
-  const dbs: Db[] = [];
+  let db: Db;
 
-  /** Track dbs for cleanup. */
-  function track(db: Db): Db {
-    dbs.push(db);
-    return db;
-  }
+  beforeEach(async () => {
+    db = await createDb({
+      appId: "test-app",
+      driver: { type: "persistent" },
+    });
+  });
 
   afterEach(async () => {
-    for (const db of dbs) {
-      try {
-        await db.shutdown();
-      } catch {
-        // Best effort
-      }
-    }
-    dbs.length = 0;
+    await db.shutdown();
   });
 
   describe("filtering", () => {
     it("queries by id", async () => {
-      const db = track(
-        await createDb({
-          appId: "test-app",
-          driver: { type: "persistent", dbName: uniqueDbName("query-by-id") },
-        }),
-      );
-
       const { id } = insertProject(db, "Project A");
 
       const results = await db.all(app.projects.where({ id: { eq: id } }));
@@ -54,14 +41,68 @@ describe("TS Query API", () => {
       expect(results[0]!.name).toBe("Project A");
     });
 
+    it("filters nullable columns with isNull:true", async () => {
+      const todoWithoutOwner = insertTodo(db, {
+        title: "Todo without owner",
+        ownerId: null,
+      });
+      const _todoWithOwner = insertTodo(db, {
+        title: "Todo with owner",
+        ownerId: insertUser(db).id,
+      });
+
+      const results = await db.all(app.todos.where({ ownerId: { isNull: true } }));
+
+      expect(results.map((todo) => todo.id)).toEqual([todoWithoutOwner.id]);
+    });
+
+    it("filters non-nullable columns with isNull:false", async () => {
+      const _todoWithoutOwner = insertTodo(db, {
+        title: "Todo without owner",
+        ownerId: null,
+      });
+      const todoWithOwner = insertTodo(db, {
+        title: "Todo with owner",
+        ownerId: insertUser(db).id,
+      });
+
+      const results = await db.all(app.todos.where({ ownerId: { isNull: false } }));
+
+      expect(results.map((todo) => todo.id)).toEqual([todoWithOwner.id]);
+    });
+
+    it("filters with explicit null values always return false", async () => {
+      const _todoWithoutOwner = insertTodo(db, {
+        title: "Todo without owner",
+        ownerId: null,
+      });
+      const _todoWithOwner = insertTodo(db, {
+        title: "Todo with owner",
+        ownerId: insertUser(db).id,
+      });
+
+      const resultsDirectNull = await db.all(app.todos.where({ ownerId: null }));
+      const resultsEqNull = await db.all(app.todos.where({ ownerId: { eq: null } }));
+      expect(resultsDirectNull).toEqual([]);
+      expect(resultsEqNull).toEqual([]);
+    });
+
+    it("filters with explicit undefined values are no-ops", async () => {
+      const todoWithoutOwner = insertTodo(db, {
+        title: "Todo without owner",
+        ownerId: null,
+      });
+      const todoWithOwner = insertTodo(db, {
+        title: "Todo with owner",
+        ownerId: insertUser(db).id,
+      });
+
+      const results = await db.all(app.todos.where({ ownerId: undefined }));
+      expect(results.map((todo) => todo.id)).toEqual([todoWithoutOwner.id, todoWithOwner.id]);
+    });
+
     describe("query by array column", () => {
       it("using eq", async () => {
-        const db = track(
-          await createDb({
-            appId: "test-app",
-            driver: { type: "persistent", dbName: uniqueDbName("query-by-array-column-equality") },
-          }),
-        );
         const { id: id1 } = insertTodo(db, {
           title: "Todo 1",
           tags: ["tag1"],
@@ -81,12 +122,6 @@ describe("TS Query API", () => {
       });
 
       it("using contains", async () => {
-        const db = track(
-          await createDb({
-            appId: "test-app",
-            driver: { type: "persistent", dbName: uniqueDbName("query-by-array-column-contains") },
-          }),
-        );
         const { id: id1 } = insertTodo(db, {
           title: "Todo 1",
           tags: ["tag1"],
@@ -110,13 +145,6 @@ describe("TS Query API", () => {
 
   describe("include", () => {
     it("include returns the related entity", async () => {
-      const db = track(
-        await createDb({
-          appId: "test-app",
-          driver: { type: "persistent", dbName: uniqueDbName("include-returns-entity") },
-        }),
-      );
-
       const { id: projectId } = insertProject(db, "Announcements");
       const { id: ownerId } = insertUser(db);
       const { id: todoId } = insertTodo(db, {
@@ -132,20 +160,13 @@ describe("TS Query API", () => {
       expect(results.length).toBe(1);
       const todo = results[0]!;
       expect(todo.title).toBe("Write tests");
-      expectTypeOf(todo.ownerId).toEqualTypeOf<string | undefined>();
+      expectTypeOf(todo.ownerId).toEqualTypeOf<string | null>();
       expect(todo.ownerId).toBe(ownerId);
-      expectTypeOf(todo.project).toEqualTypeOf<Project | undefined>();
+      expectTypeOf(todo.project).toEqualTypeOf<Project | null>();
       expect(todo.project?.name).toBe("Announcements");
     });
 
     it("include only resolves the provided columns, not all references", async () => {
-      const db = track(
-        await createDb({
-          appId: "test-app",
-          driver: { type: "persistent", dbName: uniqueDbName("select-root-columns") },
-        }),
-      );
-
       const { id: projectId } = insertProject(db, "Announcements");
       const { id: ownerId } = insertUser(db);
       const { id: todoId } = insertTodo(db, {
@@ -161,21 +182,14 @@ describe("TS Query API", () => {
       );
 
       assert(result, "Result is not defined");
-      expectTypeOf(result.ownerId).toEqualTypeOf<string | undefined>();
+      expectTypeOf(result.ownerId).toEqualTypeOf<string | null>();
       expect(result.ownerId).toBe(ownerId);
-      expectTypeOf(result.project).toEqualTypeOf<Project | undefined>();
+      expectTypeOf(result.project).toEqualTypeOf<Project | null>();
       assert(result.project, "Project include is not defined");
       expect(result.project.name).toBe("Announcements");
     });
 
-    it("include returns 'undefined' for null foreign key columns", async () => {
-      const db = track(
-        await createDb({
-          appId: "test-app",
-          driver: { type: "persistent", dbName: uniqueDbName("select-root-columns") },
-        }),
-      );
-
+    it("include returns null for null foreign key columns", async () => {
       const { id: todoId } = insertTodo(db, {
         ownerId: undefined,
       });
@@ -183,18 +197,11 @@ describe("TS Query API", () => {
       const result = await db.one(app.todos.where({ id: { eq: todoId } }).include({ owner: true }));
 
       assert(result, "Result is not defined");
-      expectTypeOf(result.owner).toEqualTypeOf<User | undefined>();
-      expect(result.owner).toBeUndefined();
+      expectTypeOf(result.owner).toEqualTypeOf<User | null>();
+      expect(result.owner).toBeNull();
     });
 
     it("text is not corrupted when using include", async () => {
-      const db = track(
-        await createDb({
-          appId: "test-app",
-          driver: { type: "persistent", dbName: uniqueDbName("include-corruption") },
-        }),
-      );
-
       const { id: projectId } = insertProject(db);
       const { id: ownerId } = insertUser(db);
       const { id: todoId } = insertTodo(db, {
@@ -217,14 +224,7 @@ describe("TS Query API", () => {
   });
 
   describe("missing reference handling", () => {
-    it("include returns 'undefined' for missing scalar referenced entities", async () => {
-      const db = track(
-        await createDb({
-          appId: "test-app",
-          driver: { type: "persistent", dbName: uniqueDbName("include-returns-entity") },
-        }),
-      );
-
+    it("include returns null for missing scalar referenced entities", async () => {
       const project = insertProject(db);
       const todo = insertTodo(db, {
         projectId: project.id,
@@ -236,18 +236,11 @@ describe("TS Query API", () => {
         app.todos.where({ id: { eq: todo.id } }).include({ project: true }),
       );
       assert(result, "Result is not defined");
-      expectTypeOf(result.project).toEqualTypeOf<Project | undefined>();
-      expect(result.project).toBeUndefined();
+      expectTypeOf(result.project).toEqualTypeOf<Project | null>();
+      expect(result.project).toBeNull();
     });
 
     it("include skips missing referenced entities in forward array relations", async () => {
-      const db = track(
-        await createDb({
-          appId: "test-app",
-          driver: { type: "persistent", dbName: uniqueDbName("include-returns-entity") },
-        }),
-      );
-
       const assignee1 = insertUser(db);
       const assignee2 = insertUser(db);
       const todo = insertTodo(db, {
@@ -265,13 +258,6 @@ describe("TS Query API", () => {
     });
 
     it("include skips missing referenced entities in reverse relations", async () => {
-      const db = track(
-        await createDb({
-          appId: "test-app",
-          driver: { type: "persistent", dbName: uniqueDbName("include-returns-entity") },
-        }),
-      );
-
       const owner = insertUser(db);
       const { id: todoId } = insertTodo(db, {
         ownerId: owner.id,
@@ -294,13 +280,6 @@ describe("TS Query API", () => {
 
     describe("requireIncludes", () => {
       it("requireIncludes filters out rows with missing scalar referenced entities", async () => {
-        const db = track(
-          await createDb({
-            appId: "test-app",
-            driver: { type: "persistent", dbName: uniqueDbName("require-includes-scalar-missing") },
-          }),
-        );
-
         const project = insertProject(db);
         const todo = insertTodo(db, {
           projectId: project.id,
@@ -322,13 +301,6 @@ describe("TS Query API", () => {
       });
 
       it("requireIncludes does not filter out rows with null scalar references", async () => {
-        const db = track(
-          await createDb({
-            appId: "test-app",
-            driver: { type: "persistent", dbName: uniqueDbName("require-includes-scalar-missing") },
-          }),
-        );
-
         const todo = insertTodo(db, {
           ownerId: undefined,
         });
@@ -342,18 +314,11 @@ describe("TS Query API", () => {
 
         assert(result, "Result is not defined");
         expect(result.id).toBe(todo.id);
-        expectTypeOf(result.owner).toEqualTypeOf<User | undefined>();
-        expect(result.owner).toBeUndefined();
+        expectTypeOf(result.owner).toEqualTypeOf<User | null>();
+        expect(result.owner).toBeNull();
       });
 
       it("requireIncludes filters out rows with missing entities in forward array relations", async () => {
-        const db = track(
-          await createDb({
-            appId: "test-app",
-            driver: { type: "persistent", dbName: uniqueDbName("require-includes-array-missing") },
-          }),
-        );
-
         const assignee1 = insertUser(db);
         const assignee2 = insertUser(db);
         const todo = insertTodo(db, {
@@ -373,13 +338,6 @@ describe("TS Query API", () => {
       });
 
       it("requireIncludes does not filter rows for reverse relations", async () => {
-        const db = track(
-          await createDb({
-            appId: "test-app",
-            driver: { type: "persistent", dbName: uniqueDbName("require-includes-reverse") },
-          }),
-        );
-
         const owner = insertUser(db);
         const { id: todoId } = insertTodo(db, {
           ownerId: owner.id,
@@ -401,13 +359,6 @@ describe("TS Query API", () => {
       });
 
       it("can use requireIncludes in nested includes", async () => {
-        const db = track(
-          await createDb({
-            appId: "test-app",
-            driver: { type: "persistent", dbName: uniqueDbName("require-includes-nested") },
-          }),
-        );
-
         const alice = insertUser(db);
         const bob = insertUser(db);
         const deletedUser = insertUser(db);
@@ -430,13 +381,6 @@ describe("TS Query API", () => {
       });
 
       it("top-level requireIncludes does not affect inner includes", async () => {
-        const db = track(
-          await createDb({
-            appId: "test-app",
-            driver: { type: "persistent", dbName: uniqueDbName("require-includes-scalar-missing") },
-          }),
-        );
-
         const alice = insertUser(db);
         const bob = insertUser(db);
         const deletedUser = insertUser(db);
@@ -462,13 +406,6 @@ describe("TS Query API", () => {
       });
 
       it("rows skipped by requireIncludes affect limit-offset pagination", async () => {
-        const db = track(
-          await createDb({
-            appId: "test-app",
-            driver: { type: "persistent", dbName: uniqueDbName("require-includes-limit-offset") },
-          }),
-        );
-
         const alice = insertUser(db);
         const bob = insertUser(db);
         const deletedUser = insertUser(db);
@@ -493,13 +430,6 @@ describe("TS Query API", () => {
 
   describe("select", () => {
     it("select narrows root columns while preserving id and includes", async () => {
-      const db = track(
-        await createDb({
-          appId: "test-app",
-          driver: { type: "persistent", dbName: uniqueDbName("select-root-columns") },
-        }),
-      );
-
       const { id: projectId } = insertProject(db, "Announcements");
       const { id: todoId } = insertTodo(db, {
         title: "Write tests",
@@ -518,7 +448,7 @@ describe("TS Query API", () => {
       assert(result, "Result is not defined");
       expectTypeOf(result.id).toEqualTypeOf<string>();
       expectTypeOf(result.title).toEqualTypeOf<string>();
-      expectTypeOf(result.project).toEqualTypeOf<Project | undefined>();
+      expectTypeOf(result.project).toEqualTypeOf<Project | null>();
       expect(result).toEqual({
         id: todoId,
         title: "Write tests",
@@ -532,13 +462,6 @@ describe("TS Query API", () => {
     });
 
     it('select("*") resets to all root columns', async () => {
-      const db = track(
-        await createDb({
-          appId: "test-app",
-          driver: { type: "persistent", dbName: uniqueDbName("select-all-columns") },
-        }),
-      );
-
       const { id: projectId } = insertProject(db);
       const { id: ownerId } = insertUser(db);
       const { id: todoId } = insertTodo(db, {
@@ -566,14 +489,12 @@ describe("TS Query API", () => {
     });
 
     it("selects and filters permission magic columns end to end", async () => {
-      const db = track(
-        await createDb({
-          appId: "test-app",
-          driver: { type: "persistent", dbName: uniqueDbName("select-magic-columns") },
-          localAuthMode: "anonymous",
-          localAuthToken: "magic-columns-user",
-        }),
-      );
+      const db = await createDb({
+        appId: "test-app",
+        driver: { type: "persistent", dbName: uniqueDbName("select-magic-columns") },
+        localAuthMode: "anonymous",
+        localAuthToken: "magic-columns-user",
+      });
 
       const { id: projectId } = insertProject(db, "Announcements");
       const { id: editableId } = insertTodo(db, {
@@ -665,20 +586,15 @@ describe("TS Query API", () => {
         done: false,
         tags: ["dev"],
         projectId,
-        ownerId: undefined,
+        ownerId: null,
         assigneesIds: [],
         $canDelete: true,
       });
+
+      await db.shutdown();
     });
 
     it("include builders can project nested relation columns", async () => {
-      const db = track(
-        await createDb({
-          appId: "test-app",
-          driver: { type: "persistent", dbName: uniqueDbName("select-nested-columns") },
-        }),
-      );
-
       const { id: projectId } = insertProject(db, "Announcements");
       const { id: ownerId } = insertUser(db);
       const { id: todoId } = insertTodo(db, {
@@ -715,13 +631,6 @@ describe("TS Query API", () => {
     });
 
     it("subscribeAll preserves projected root columns with includes", async () => {
-      const db = track(
-        await createDb({
-          appId: "test-app",
-          driver: { type: "persistent", dbName: uniqueDbName("subscribe-select-root-columns") },
-        }),
-      );
-
       const { id: projectId } = insertProject(db, "Announcements");
       const { id: ownerId } = insertUser(db);
 
@@ -781,8 +690,64 @@ describe("TS Query API", () => {
           },
         },
       ]);
-      expect("done" in delta.all[0]!).toBe(false);
-      expect("tags" in delta.all[0]!).toBe(false);
+      assert(delta.all[0]);
+      expect("done" in delta.all[0]).toBe(false);
+      expect("tags" in delta.all[0]).toBe(false);
+    });
+
+    it("subscribeAll returns null for selected nullable columns while omitting unselected columns", async () => {
+      const { id: projectId } = insertProject(db, "Announcements");
+
+      type SubscribedTodo = {
+        id: string;
+        title: string;
+        ownerId: string | null;
+      };
+
+      let unsubscribe = () => {};
+      let timeout: ReturnType<typeof setTimeout> | undefined;
+      const deltaPromise = new Promise<{ all: SubscribedTodo[] }>((resolve, reject) => {
+        timeout = setTimeout(() => {
+          unsubscribe();
+          reject(new Error("Timed out waiting for subscribeAll nullable update"));
+        }, 10_000);
+
+        unsubscribe = db.subscribeAll(app.todos.select("title", "ownerId"), (delta) => {
+          if (delta.all.length !== 1) {
+            return;
+          }
+
+          resolve(delta as { all: SubscribedTodo[] });
+        });
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      const { id: todoId } = insertTodo(db, {
+        title: "Watch nullable subscription",
+        done: false,
+        tags: ["dev"],
+        projectId,
+        ownerId: null,
+        assigneesIds: [],
+      });
+
+      const delta = await deltaPromise;
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+      unsubscribe();
+
+      expect(delta.all).toEqual([
+        {
+          id: todoId,
+          title: "Watch nullable subscription",
+          ownerId: null,
+        },
+      ]);
+      assert(delta.all[0]);
+      expect("done" in delta.all[0]).toBe(false);
+      expect("tags" in delta.all[0]).toBe(false);
     });
   });
 });

--- a/packages/jazz-tools/tests/ts-dsl/typed-app.test.ts
+++ b/packages/jazz-tools/tests/ts-dsl/typed-app.test.ts
@@ -106,7 +106,7 @@ describe("typed app prototype", () => {
     expectTypeOf(todoRow.done).toEqualTypeOf<boolean>();
     expectTypeOf(todoRow.tags).toEqualTypeOf<string[]>();
     expectTypeOf(todoRow.project).toEqualTypeOf<string>();
-    expectTypeOf(todoRow.owner).toEqualTypeOf<string | undefined>();
+    expectTypeOf(todoRow.owner).toEqualTypeOf<string | null>();
 
     expectTypeOf(todoInsert.title).toEqualTypeOf<string>();
     expectTypeOf(todoInsert.done).toEqualTypeOf<boolean>();
@@ -114,18 +114,18 @@ describe("typed app prototype", () => {
     expectTypeOf(todoInsert.project).toEqualTypeOf<string>();
     expectTypeOf(todoInsert.owner).toEqualTypeOf<string | null | undefined>();
 
-    expectTypeOf(undefined as TodoWhere["project"]).toEqualTypeOf<
+    expectTypeOf<TodoWhere["project"]>().toEqualTypeOf<
       string | { eq?: string; ne?: string } | undefined
     >();
-    expectTypeOf(undefined as TodoWhere["owner"]).toEqualTypeOf<
-      string | { eq?: string; ne?: string; isNull?: boolean } | undefined
+    expectTypeOf<TodoWhere["owner"]>().branded.toEqualTypeOf<
+      string | null | { eq?: string | null; ne?: string | null; isNull?: boolean } | undefined
     >();
-    expectTypeOf(undefined as TodoWhere["tags"]).toEqualTypeOf<
-      string[] | { eq?: string[]; contains?: string } | undefined
+    expectTypeOf<TodoWhere["tags"]>().branded.toEqualTypeOf<
+      string[] | { eq?: string[]; ne?: string[]; contains?: string } | undefined
     >();
 
-    const projectRecord: ProjectRecord | undefined = todoWithProject.project;
-    expectTypeOf(todoWithProject.owner).toEqualTypeOf<string | undefined>();
+    const projectRecord: ProjectRecord | null = todoWithProject.project;
+    expectTypeOf(todoWithProject.owner).toEqualTypeOf<string | null>();
     const todoTitleRecords: TodoTitleRecord[] = projectWithTitles.todosViaProject;
     const queryContract: QueryBuilder<TodoWithProject> = todoWithProjectQuery;
     const typedQueryContract: Query<"todos", { project: true }, any, AppSchema> =

--- a/packages/jazz-tools/tests/ts-dsl/update-api.test.ts
+++ b/packages/jazz-tools/tests/ts-dsl/update-api.test.ts
@@ -64,7 +64,7 @@ describe("TS Update API", () => {
 
     const updatedTodo = await db.one(app.todos.where({ id: { eq: todo.id } }));
     assert(updatedTodo);
-    expect(updatedTodo.ownerId).toBeUndefined();
+    expect(updatedTodo.ownerId).toBeNull();
   });
 
   it("required fields cannot be unset", async () => {


### PR DESCRIPTION
## Description

- Change Jazz read surfaces so selected row fields that currently come back as `undefined` because of runtime `NULL` instead come back as `null`.
- Apply that consistently to `db.all`, `db.one`, `db.insert`, `db.insertDurable`, nested includes, permission magic columns, and `subscribeAll`/delta item payloads.
- Update nullable `where(...)` typing to accept null and `eq/ne: null`

## Motivation

`null` & `undefined` already have distinct semantics in inserts and updates:
- for inserts: undefined means "use default value", null means "set column to null"
- for updates: undefined means "don't update the value", null means "set column to null"

Requiring to use `null` to set the value and returning `undefined` was definitely weird (see https://github.com/garden-co/jazz2/pull/349#discussion_r2948944380), and this change also aligns optional value handling more closely with SQL.