### PR TITLE
docs: apply pending review feedback from #417

### DIFF
--- a/docs/content/docs/auth/permissions.mdx
+++ b/docs/content/docs/auth/permissions.mdx
@@ -25,9 +25,10 @@ We can define permissions in `permissions.ts`:
 </include>
 
 <Callout type="info">
-  Author permissions in the root `permissions.ts` next to `schema.ts`. `npx jazz-tools@alpha
-  validate` is a useful local sanity check before publishing. Permission-only changes do not require
-  migrations, but they do still require `npx jazz-tools@alpha permissions push`.
+  Write your permissions policies in `permissions.ts` at the root of your project (next to `schema.ts`).
+
+Run `npx jazz-tools@alpha validate` before publishing to identify any issues. You do not need to write a schema migration to update permissions policies, you can push the updated policies by running `npx jazz-tools@alpha permissions push`.
+
 </Callout>
 
 Apps that do not need user-scoped filtering can still define explicit allow-all policies (`policy.todos.allowRead.always()` or `policy.todos.allowRead.where({})`).

--- a/docs/content/docs/quickstarts/client.mdx
+++ b/docs/content/docs/quickstarts/client.mdx
@@ -364,11 +364,9 @@ Update your client config to use the same app ID, and add `serverUrl`:
 }
 ```
 
-Clients learn the structural schema when they connect. If you later change `permissions.ts`,
-publish the new permissions bundle explicitly with `npx jazz-tools@alpha permissions push`.
-If you change `schema.ts` structurally after data already exists, create and push a
-[reviewed migration edge](/docs/schemas/migrations) before old and new clients mix on the same
-shared server.
+Clients pick up the schema from the server when they connect. If you update `schema.ts` you need to [create and push a migration to the new schema](/docs/schemas/migrations) so that clients can understand existing data with the new schema.
+
+Permissions can be updated without adding a new schema by using `npx jazz-tools@alpha permissions push`.
 
 For production deployment and hosting options, see [Server Setup](/docs/reference/server-setup).
 

--- a/docs/content/docs/schemas/defining-tables.mdx
+++ b/docs/content/docs/schemas/defining-tables.mdx
@@ -14,8 +14,6 @@ Tables are defined in `schema.ts` using the Jazz DSL. Each `s.table(...)` call r
   ../examples/docs/todo-client-localfirst-ts/schema.ts#schema-todo-client-ts
 </include>
 
-The TypeScript DSL uses `s.string`, `s.boolean`, `s.ref`, and the other builders documented in [Column Types](/docs/reference/column-types). Rust consumers read the compiled structural schema, but authoring lives in TypeScript today.
-
 <Callout type="warn">
   `s.ref()` columns must be named with an `Id` or `_id` suffix (for example `projectId` or
   `owner_id`). For `s.array(s.ref())`, use an `Ids` or `_ids` suffix instead. The runtime enforces
@@ -26,8 +24,6 @@ The TypeScript DSL uses `s.string`, `s.boolean`, `s.ref`, and the other builders
 
 <SchemaSetup />
 
-`schema.ts` is the source of truth. Jazz no longer generates `schema/app.ts` or `current.sql`.
-
-When you change your schema structurally on a shared app, create and push a reviewed migration edge. See [Migrations](/docs/schemas/migrations) for details.
+When you change your schema on a shared app, create and push a migration. See [Migrations](/docs/schemas/migrations) for details.
 
 If you need to clear local browser data after a schema change, see [How do I reset browser storage?](/docs/reference/faq#reset-browser-storage).

--- a/docs/content/docs/schemas/migrations.mdx
+++ b/docs/content/docs/schemas/migrations.mdx
@@ -14,15 +14,15 @@ Traditional migration systems run a linear sequence and require peers to converg
 
 ## Workflow
 
-1. Edit `schema.ts` when you are changing data shape.
-2. Optionally run `npx jazz-tools@alpha validate` to catch local authoring errors.
-3. Once Jazz reports an old and new structural hash pair, generate a migration stub:
+1. Edit `schema.ts`.
+2. Run `npx jazz-tools@alpha validate` to catch errors locally (optional, but recommended).
+3. Generate a migration between the old and new schemas.
 
 <include cwd lang="bash">
   ../examples/docs/todo-server-ts/docs/migrations-workflow.sh#migrations-workflow-ts
 </include>
 
-4. Review the generated file, rename it to something meaningful, then publish the reviewed edge.
+4. Review the generated file, rename it to something meaningful, then publish it.
 
 Permission-only changes in `permissions.ts` do not need migrations, but they do still require
 `npx jazz-tools@alpha permissions push`.

--- a/docs/content/partials/schema-setup.mdx
+++ b/docs/content/partials/schema-setup.mdx
@@ -1,20 +1,15 @@
 import { Callout } from "fumadocs-ui/components/callout";
 
-Run an optional schema sanity check from your app root:
+Validate your schema and permissions locally:
 
 `npx jazz-tools@alpha validate`
 
 This validates `schema.ts` and the optional `permissions.ts`, then compiles them into Jazz's
 internal schema representation.
 
-When Jazz later reports an old and new schema hash pair, create and review a migration edge as
-described in [Migrations](/docs/schemas/migrations):
+When Jazz reports a difference between the old and new schema hashes after changing `schema.ts`, and your app already has data, you should create and push a migration edge as described in [Migrations](/docs/schemas/migrations):
 
 ```bash
 npx jazz-tools@alpha migrations create <fromHash> <toHash>
 npx jazz-tools@alpha migrations push <fromHash> <toHash>
 ```
-
-<Callout title="Source of truth">
-  `schema.ts` is the source of truth. Jazz no longer generates `schema/app.ts` or `current.sql`.
-</Callout>


### PR DESCRIPTION
## Summary

I had a pending review on #417 that was unsubmitted, so none of the feedback was visible. Since #417 is already merged, this PR extracts those suggestions into a standalone changeset.

Changes across 5 files:

- **permissions.mdx** — rewrite authoring workflow callout for clarity
- **client.mdx** — separate schema changes (need migration) from permission changes (just push)
- **defining-tables.mdx** — drop non-load-bearing paragraphs (TS-vs-Rust contrast, `schema.ts` source-of-truth note), simplify migration sentence
- **migrations.mdx** — simplify workflow steps wording
- **schema-setup.mdx** — rewrite intro line, rewrite migration prompt, drop redundant "Source of truth" callout

## Test plan

- [ ] Docs build passes
- [ ] Read through each changed page and verify nothing is missing or misleading