### PR TITLE
Trim CI build graph and RN bootstrap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 10
     env:
+      JAZZ_SKIP_RN_DEPS: "1"
       RUSTC_WRAPPER: sccache
       SCCACHE_DIR: /home/runner/.cache/sccache
       SCCACHE_CACHE_SIZE: 8G
@@ -26,7 +27,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: 1.93.1
-          targets: wasm32-unknown-unknown, aarch64-linux-android, armv7-linux-androideabi, i686-linux-android, x86_64-linux-android
+          targets: wasm32-unknown-unknown
           components: clippy, rustfmt
 
       - uses: actions/setup-node@v6
@@ -55,12 +56,12 @@ jobs:
 
       - run: pnpm format:check
       - run: pnpm lint
-      - run: cargo clippy --workspace -- -D warnings
 
   test-rust:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 15
     env:
+      JAZZ_SKIP_RN_DEPS: "1"
       RUSTC_WRAPPER: sccache
       SCCACHE_DIR: /home/runner/.cache/sccache
       SCCACHE_CACHE_SIZE: 8G
@@ -71,7 +72,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: 1.93.1
-          targets: wasm32-unknown-unknown, aarch64-linux-android, armv7-linux-androideabi, i686-linux-android, x86_64-linux-android
+          targets: wasm32-unknown-unknown
           components: clippy, rustfmt
 
       - uses: actions/setup-node@v6
@@ -105,6 +106,7 @@ jobs:
     timeout-minutes: 15
     env:
       JAZZ_NAPI_RELEASE: "0"
+      JAZZ_SKIP_RN_DEPS: "1"
       RUSTC_WRAPPER: sccache
       SCCACHE_DIR: /home/runner/.cache/sccache
       SCCACHE_CACHE_SIZE: 8G
@@ -115,7 +117,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: 1.93.1
-          targets: wasm32-unknown-unknown, aarch64-linux-android, armv7-linux-androideabi, i686-linux-android, x86_64-linux-android
+          targets: wasm32-unknown-unknown
           components: clippy, rustfmt
 
       - uses: actions/setup-node@v6
@@ -146,7 +148,7 @@ jobs:
           key: sccache-${{ github.repository_id }}-${{ runner.os }}-v1
           path: /home/runner/.cache/sccache
 
-      - run: pnpm build
+      - run: pnpm build:ci
       - name: Mount Playwright sticky disk
         uses: useblacksmith/stickydisk@v1
         with:

--- a/.github/workflows/rn-build-reusable.yml
+++ b/.github/workflows/rn-build-reusable.yml
@@ -1,8 +1,6 @@
 name: Build jazz-rn (React Native)
 
 "on":
-  pull_request:
-    types: [opened, synchronize, reopened]
   workflow_call:
     inputs:
       concurrency:

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "ensure:rust-toolchain": "bash scripts/install-jazz-rn-deps.sh",
     "build:vercel-docs": "export PATH=\"${CARGO_HOME:-$HOME/.cargo}/bin:$PATH\" && JAZZ_SKIP_RN_DEPS=1 pnpm run ensure:rust-toolchain && turbo run --env-mode=loose build:crates --filter=@jazz/rust && turbo run --env-mode=loose build --filter=docs --only",
     "build": "turbo run build:crates --filter=@jazz/rust && turbo run build --filter=jazz-wasm && turbo run build --filter=!jazz-rn --filter=!jazz-wasm --only",
+    "build:ci": "turbo run build:crates --filter=@jazz/rust && turbo run build --filter=jazz-wasm && turbo run build --filter=jazz-napi --filter=jazz-tools --only",
     "build:all": "turbo run build:crates --filter=@jazz/rust && turbo run build --filter=jazz-wasm && turbo run build:rn --filter=jazz-rn && turbo run build --filter=!jazz-rn --filter=!jazz-wasm --only",
     "release:version": "changeset version",
     "release:version:alpha": "changeset version --snapshot alpha",


### PR DESCRIPTION
## Summary
This trims the PR CI path so `test-ts` builds only the artifacts that the TypeScript and browser tests actually consume.

It also removes React Native setup work from the main CI jobs and stops the standalone React Native PR build workflow from running on every pull request.

## Design choices
The main change is a dedicated `build:ci` script in the root [package.json](https://github.com/garden-co/jazz2/blob/main/package.json). The previous `pnpm build` path fanned out into example, docs, and other package builds that the `test-ts` job did not need. The new script keeps the pre-test build focused on the core artifacts the suite uses: Rust crates, `jazz-wasm`, `jazz-napi`, and `jazz-tools`.

In the main CI workflow, the Rust toolchain is reduced to `wasm32-unknown-unknown` and `JAZZ_SKIP_RN_DEPS=1` is set for `lint`, `test-rust`, and `test-ts`. This keeps the regular PR loop from paying the React Native bootstrap cost when those jobs do not need Android targets or RN-specific dependencies.

The `lint` job also drops the second `cargo clippy` invocation. `pnpm lint` already runs clippy, so the extra workflow step was duplicate work without extra coverage.

## Removed behavior
The standalone `Build jazz-rn (React Native)` workflow no longer runs directly on pull requests. The reusable workflow stays in place for callers, so the Expo Maestro E2E workflow still builds the Android artifacts it needs. The change here is that PRs no longer pay for a separate RN build job when changeset branch builds already cover that path.
