### PR TITLE
Allow dev clients to auto-push schema without admin secret

### DIFF
--- a/.changeset/dev-schema-autopush-help.md
+++ b/.changeset/dev-schema-autopush-help.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Allow development-mode clients to auto-publish the current structural schema from `schema.ts` without an admin secret, while keeping non-schema catalogue writes admin-only. Improve `jazz-tools --help` and the docs so the CLI and publishing workflow more clearly explain when schema auto-push is enough versus when to run `permissions push` or `migrations push`.

--- a/crates/jazz-tools/src/middleware/auth.rs
+++ b/crates/jazz-tools/src/middleware/auth.rs
@@ -868,8 +868,9 @@ pub fn validate_backend_secret(
 
 /// Check if admin secret is valid.
 ///
-/// Catalogue operations (schema/lens sync) require admin authentication.
-/// If admin_secret is not configured, catalogue sync is disabled.
+/// Admin publication endpoints require admin authentication. Development-mode
+/// schema auto-push from ordinary clients flows through `/sync` and does not
+/// use this helper.
 pub fn validate_admin_secret(
     provided: Option<&str>,
     config: &AuthConfig,
@@ -881,9 +882,6 @@ pub fn validate_admin_secret(
             StatusCode::UNAUTHORIZED,
             "Admin secret required for this operation",
         )),
-        // TODO: Consider making catalogue sync opt-in or handling this more gracefully.
-        // Currently, if admin auth isn't configured, clients can't sync schemas to server.
-        // This is correct for security but may cause silent failures in dev setups.
         (None, _) => Err((StatusCode::FORBIDDEN, "Admin auth not configured")),
     }
 }

--- a/crates/jazz-tools/src/server/builder.rs
+++ b/crates/jazz-tools/src/server/builder.rs
@@ -207,8 +207,21 @@ impl ServerBuilder {
 }
 
 fn server_sync_manager() -> SyncManager {
-    SyncManager::new()
-        .with_durability_tiers([DurabilityTier::EdgeServer, DurabilityTier::GlobalServer])
+    let sync_manager = SyncManager::new()
+        .with_durability_tiers([DurabilityTier::EdgeServer, DurabilityTier::GlobalServer]);
+
+    if should_allow_unprivileged_schema_catalogue_writes() {
+        sync_manager.with_unprivileged_schema_catalogue_writes()
+    } else {
+        sync_manager
+    }
+}
+
+fn should_allow_unprivileged_schema_catalogue_writes() -> bool {
+    !matches!(
+        std::env::var("NODE_ENV"),
+        Ok(value) if value.eq_ignore_ascii_case("production")
+    )
 }
 
 async fn build_jwks_cache(auth_config: &AuthConfig) -> Result<Option<JwksCache>, String> {

--- a/crates/jazz-tools/src/sync_manager/inbox.rs
+++ b/crates/jazz-tools/src/sync_manager/inbox.rs
@@ -229,8 +229,15 @@ impl SyncManager {
                             });
                             return;
                         };
-                        // User cannot write catalogue objects
+                        // User cannot write catalogue objects, except for
+                        // development-only structural schema auto-push.
                         if payload.is_catalogue() {
+                            if self.allow_unprivileged_schema_catalogue_writes
+                                && payload.is_structural_schema_catalogue()
+                            {
+                                self.apply_payload_from_client(storage, client_id, payload, false);
+                                return;
+                            }
                             self.outbox.push(OutboxEntry {
                                 destination: Destination::Client(client_id),
                                 payload: SyncPayload::Error(SyncError::CatalogueWriteDenied {

--- a/crates/jazz-tools/src/sync_manager/mod.rs
+++ b/crates/jazz-tools/src/sync_manager/mod.rs
@@ -34,6 +34,7 @@ pub use types::*;
 pub struct SyncManager {
     pub object_manager: ObjectManager,
     pub(super) catalogue_objects: HashSet<ObjectId>,
+    pub(super) allow_unprivileged_schema_catalogue_writes: bool,
 
     pub(super) servers: HashMap<ServerId, ServerState>,
     pub(super) clients: HashMap<ClientId, ClientState>,
@@ -68,6 +69,10 @@ impl std::fmt::Debug for SyncManager {
         f.debug_struct("SyncManager")
             .field("object_manager", &self.object_manager)
             .field("catalogue_objects", &self.catalogue_objects)
+            .field(
+                "allow_unprivileged_schema_catalogue_writes",
+                &self.allow_unprivileged_schema_catalogue_writes,
+            )
             .field("servers", &self.servers)
             .field("clients", &self.clients)
             .field("inbox", &self.inbox)
@@ -115,6 +120,7 @@ impl SyncManager {
         Self {
             object_manager,
             catalogue_objects,
+            allow_unprivileged_schema_catalogue_writes: false,
             servers: HashMap::new(),
             clients: HashMap::new(),
             inbox: Vec::new(),
@@ -134,6 +140,13 @@ impl SyncManager {
     /// Add a durability identity for this node (enables durability notifications).
     pub fn with_durability_tier(mut self, tier: DurabilityTier) -> Self {
         self.my_tiers.insert(tier);
+        self
+    }
+
+    /// Allow authenticated user clients to publish structural schema catalogue
+    /// objects directly. Intended for development servers only.
+    pub fn with_unprivileged_schema_catalogue_writes(mut self) -> Self {
+        self.allow_unprivileged_schema_catalogue_writes = true;
         self
     }
 

--- a/crates/jazz-tools/src/sync_manager/tests.rs
+++ b/crates/jazz-tools/src/sync_manager/tests.rs
@@ -1138,6 +1138,130 @@ fn user_catalogue_write_rejected() {
 }
 
 #[test]
+fn user_schema_catalogue_write_allowed_when_enabled() {
+    let mut sm = SyncManager::new().with_unprivileged_schema_catalogue_writes();
+    let mut io = MemoryStorage::new();
+
+    let client_id = ClientId::new();
+    sm.add_client(client_id);
+    sm.set_client_session(client_id, Session::new("alice"));
+
+    let obj_id = ObjectId::new();
+    let author = ObjectId::new();
+    let commit = Commit {
+        parents: smallvec![],
+        content: b"schema data".to_vec(),
+        timestamp: 1000,
+        author: author.to_string(),
+        metadata: None,
+        stored_state: crate::commit::StoredState::Stored,
+        ack_state: Default::default(),
+    };
+
+    let mut cat_metadata = HashMap::new();
+    cat_metadata.insert(
+        crate::metadata::MetadataKey::Type.to_string(),
+        crate::metadata::ObjectType::CatalogueSchema.to_string(),
+    );
+
+    sm.push_inbox(InboxEntry {
+        source: Source::Client(client_id),
+        payload: SyncPayload::ObjectUpdated {
+            object_id: obj_id,
+            metadata: Some(ObjectMetadata {
+                id: obj_id,
+                metadata: cat_metadata,
+            }),
+            branch_name: "main".into(),
+            commits: vec![commit.clone()],
+        },
+    });
+
+    sm.process_inbox(&mut io);
+
+    assert!(
+        sm.take_outbox().is_empty(),
+        "schema catalogue writes should apply directly when enabled"
+    );
+    assert!(
+        sm.take_pending_permission_checks().is_empty(),
+        "schema catalogue writes should not go through row permission checks"
+    );
+
+    let object = sm
+        .object_manager
+        .get(obj_id)
+        .expect("schema catalogue object should be stored");
+    assert_eq!(
+        object
+            .metadata
+            .get(crate::metadata::MetadataKey::Type.as_str())
+            .map(String::as_str),
+        Some(crate::metadata::ObjectType::CatalogueSchema.as_str())
+    );
+    let tips = sm
+        .object_manager
+        .get_tip_ids(obj_id, "main")
+        .expect("schema branch should exist");
+    assert!(tips.contains(&commit.id()));
+}
+
+#[test]
+fn user_non_schema_catalogue_write_still_rejected_when_enabled() {
+    let mut sm = SyncManager::new().with_unprivileged_schema_catalogue_writes();
+    let mut io = MemoryStorage::new();
+
+    let client_id = ClientId::new();
+    sm.add_client(client_id);
+    sm.set_client_session(client_id, Session::new("alice"));
+
+    let obj_id = ObjectId::new();
+    let author = ObjectId::new();
+    let commit = Commit {
+        parents: smallvec![],
+        content: b"lens data".to_vec(),
+        timestamp: 1000,
+        author: author.to_string(),
+        metadata: None,
+        stored_state: crate::commit::StoredState::Stored,
+        ack_state: Default::default(),
+    };
+
+    let mut cat_metadata = HashMap::new();
+    cat_metadata.insert(
+        crate::metadata::MetadataKey::Type.to_string(),
+        crate::metadata::ObjectType::CatalogueLens.to_string(),
+    );
+
+    sm.push_inbox(InboxEntry {
+        source: Source::Client(client_id),
+        payload: SyncPayload::ObjectUpdated {
+            object_id: obj_id,
+            metadata: Some(ObjectMetadata {
+                id: obj_id,
+                metadata: cat_metadata,
+            }),
+            branch_name: "main".into(),
+            commits: vec![commit],
+        },
+    });
+
+    sm.process_inbox(&mut io);
+
+    let outbox = sm.take_outbox();
+    assert_eq!(outbox.len(), 1);
+    assert!(matches!(
+        &outbox[0],
+        OutboxEntry {
+            destination: Destination::Client(id),
+            payload:
+                SyncPayload::Error(SyncError::CatalogueWriteDenied { object_id, branch_name }),
+        } if *id == client_id && *object_id == obj_id && branch_name.as_str() == "main"
+    ));
+    assert!(sm.object_manager.get(obj_id).is_none());
+}
+
+#[test]
 fn add_client_then_set_peer_role() {
     let mut sm = SyncManager::new();
     let client_id = ClientId::new();

--- a/crates/jazz-tools/src/sync_manager/types.rs
+++ b/crates/jazz-tools/src/sync_manager/types.rs
@@ -110,7 +110,8 @@ pub(super) type BranchSyncData = (
 /// Role-based access control for client connections.
 ///
 /// Determines how incoming writes from a client are routed:
-/// - `User`: Requires session, ReBAC for rows, rejected for catalogue
+/// - `User`: Requires session, ReBAC for rows, rejected for catalogue unless
+///   development-only schema auto-push is enabled
 /// - `Backend`: Trusted backend data access (rows only, no catalogue writes)
 /// - `Admin`: Full access (catalogue + data, no ReBAC)
 /// - `Peer`: Trusted relay (server-to-server), bypasses all auth
@@ -340,6 +341,20 @@ mod query_subscription_session_serde {
 }
 
 impl SyncPayload {
+    fn catalogue_object_type(&self) -> Option<&str> {
+        let metadata = match self {
+            SyncPayload::ObjectUpdated {
+                metadata: Some(m), ..
+            } => &m.metadata,
+            SyncPayload::ObjectTruncated { .. } => return None,
+            _ => return None,
+        };
+
+        metadata
+            .get(crate::metadata::MetadataKey::Type.as_str())
+            .map(String::as_str)
+    }
+
     /// Encode this payload using postcard.
     pub fn to_bytes(&self) -> Result<Vec<u8>, postcard::Error> {
         postcard::to_allocvec(self)
@@ -360,22 +375,17 @@ impl SyncPayload {
 
     /// Check if this payload carries a catalogue object (schema or lens).
     pub fn is_catalogue(&self) -> bool {
-        let metadata = match self {
-            SyncPayload::ObjectUpdated {
-                metadata: Some(m), ..
-            } => &m.metadata,
-            SyncPayload::ObjectTruncated { .. } => {
-                // Truncation could be catalogue, but we check conservatively.
-                // The object_id might not have metadata attached to the truncation payload,
-                // so we can't determine type from the payload alone.
-                // Catalogue truncation is rare; treat as non-catalogue for routing.
-                return false;
-            }
-            _ => return false,
-        };
         matches!(
-            metadata.get(crate::metadata::MetadataKey::Type.as_str()).map(|s| s.as_str()),
+            self.catalogue_object_type(),
             Some(t) if crate::metadata::ObjectType::is_catalogue_type_str(t)
+        )
+    }
+
+    /// Check if this payload carries a structural schema catalogue object.
+    pub fn is_structural_schema_catalogue(&self) -> bool {
+        matches!(
+            self.catalogue_object_type(),
+            Some(t) if t == crate::metadata::ObjectType::CatalogueSchema.as_str()
         )
     }
 

--- a/docs/content/docs/auth/permissions.mdx
+++ b/docs/content/docs/auth/permissions.mdx
@@ -27,7 +27,9 @@ We can define permissions in `permissions.ts`:
 <Callout type="info">
   Author permissions in the root `permissions.ts` next to `schema.ts`. `npx jazz-tools@alpha
   validate` is a useful local sanity check before publishing. Permission-only changes do not require
-  migrations, but they do still require `npx jazz-tools@alpha permissions push`.
+  migrations, but they do still require `npx jazz-tools@alpha permissions push`. Development-mode
+  schema auto-push only publishes the structural schema from `schema.ts`; it does not publish
+  permissions for you.
 </Callout>
 
 Apps that do not need user-scoped filtering can still define explicit allow-all policies (`policy.todos.allowRead.always()` or `policy.todos.allowRead.where({})`).

--- a/docs/content/docs/quickstarts/client.mdx
+++ b/docs/content/docs/quickstarts/client.mdx
@@ -330,7 +330,12 @@ npx jazz-tools@alpha create app
 # outputs a UUID like: 019d0ba1-519a-7e01-b0eb-0059ee898e4d
 ```
 
-Start the server with that ID and an admin secret (required for clients to push schemas). The default port is 1625, but you can use `--port` to change it:
+Start the server with that ID. In development-like mode (`NODE_ENV` unset or anything except
+`production`), clients auto-publish the current structural schema from `schema.ts` when they
+connect, so you do not need to expose an admin secret to the browser just to get the latest schema
+onto a fresh dev server. Keep an admin secret around for explicit admin commands like
+`permissions push` and `migrations push`. The default port is 1625, but you can use `--port` to
+change it:
 
 ```bash title="Terminal"
 npx jazz-tools@alpha server <your-app-id> --admin-secret secret
@@ -352,6 +357,14 @@ export default s.definePermissions(app, ({ policy }) => {
 });
 ```
 
+Then publish the permissions bundle:
+
+```bash title="Terminal"
+npx jazz-tools@alpha permissions push \
+  --server-url http://127.0.0.1:1625 \
+  --admin-secret secret
+```
+
 ### Connect the client
 
 Update your client config to use the same app ID, and add `serverUrl`:
@@ -364,11 +377,12 @@ Update your client config to use the same app ID, and add `serverUrl`:
 }
 ```
 
-Clients learn the structural schema when they connect. If you later change `permissions.ts`,
-publish the new permissions bundle explicitly with `npx jazz-tools@alpha permissions push`.
-If you change `schema.ts` structurally after data already exists, create and push a
-[reviewed migration edge](/docs/schemas/migrations) before old and new clients mix on the same
-shared server.
+On development-like servers, clients learn and auto-publish the current structural schema when
+they connect. If you later change `permissions.ts`, publish the new permissions bundle explicitly
+with `npx jazz-tools@alpha permissions push`. If you change `schema.ts` structurally after data
+already exists, create and push a [reviewed migration edge](/docs/schemas/migrations) before old
+and new clients mix on the same shared server. Auto-pushing the latest schema does not replace
+reviewed migration edges for existing data.
 
 For production deployment and hosting options, see [Server Setup](/docs/reference/server-setup).
 

--- a/docs/content/docs/schemas/migrations.mdx
+++ b/docs/content/docs/schemas/migrations.mdx
@@ -16,6 +16,9 @@ Traditional migration systems run a linear sequence and require peers to converg
 
 1. Edit `schema.ts` when you are changing data shape.
 2. Optionally run `npx jazz-tools@alpha validate` to catch local authoring errors.
+   On development-like servers, clients auto-publish the latest structural schema when they
+   connect, but that only teaches the server the new hash. It does not create compatibility edges
+   for existing data.
 3. Once Jazz reports an old and new structural hash pair, generate a migration stub:
 
 <include cwd lang="bash">

--- a/docs/content/partials/schema-setup.mdx
+++ b/docs/content/partials/schema-setup.mdx
@@ -7,6 +7,10 @@ Run an optional schema sanity check from your app root:
 This validates `schema.ts` and the optional `permissions.ts`, then compiles them into Jazz's
 internal schema representation.
 
+On development-like servers (`NODE_ENV` unset or anything except `production`), clients
+auto-publish the latest structural schema from `schema.ts` when they connect. That does not
+publish permissions, and it does not replace reviewed migration edges for existing data.
+
 When Jazz later reports an old and new schema hash pair, create and review a migration edge as
 described in [Migrations](/docs/schemas/migrations):
 

--- a/examples/chat-react/scripts/dev.ts
+++ b/examples/chat-react/scripts/dev.ts
@@ -1,11 +1,12 @@
 /**
- * Unified dev entrypoint: starts a local jazz server, pushes the schema
- * catalogue, then launches Vite. Ctrl+C tears everything down.
+ * Unified dev entrypoint: starts a local jazz server, then launches Vite.
+ * In development mode the client auto-publishes the current structural schema
+ * on first connect. Ctrl+C tears everything down.
  */
 
 import { spawn, type ChildProcess } from "node:child_process";
 import { join } from "node:path";
-import { startLocalJazzServer, pushSchemaCatalogue } from "jazz-tools/testing";
+import { startLocalJazzServer } from "jazz-tools/testing";
 
 const APP_ID = "00000000-0000-0000-0000-000000000003";
 const PORT = 4200;
@@ -24,15 +25,6 @@ async function main() {
     enableLogs: true,
   });
   console.log(`Jazz server ready at ${server.url}`);
-
-  console.log("Pushing schema catalogue...");
-  await pushSchemaCatalogue({
-    serverUrl: server.url,
-    appId: APP_ID,
-    adminSecret: ADMIN_SECRET,
-    schemaDir: join(ROOT, "schema"),
-  });
-  console.log("Schema pushed.");
 
   vite = spawn("npx", ["vite"], {
     cwd: ROOT,

--- a/examples/wequencer/scripts/dev.ts
+++ b/examples/wequencer/scripts/dev.ts
@@ -1,6 +1,6 @@
 import { spawn, type ChildProcess } from "node:child_process";
 import { join } from "node:path";
-import { TestingServer, pushSchemaCatalogue } from "jazz-tools/testing";
+import { TestingServer } from "jazz-tools/testing";
 
 const APP_ID = "00000000-0000-0000-0000-000000000099";
 const PORT = 4200;
@@ -16,15 +16,7 @@ async function main() {
     port: PORT,
   });
   console.log(`Jazz server ready at ${server.url}`);
-
-  console.log("Pushing schema catalogue...");
-  await pushSchemaCatalogue({
-    serverUrl: server.url,
-    appId: server.appId,
-    adminSecret: server.adminSecret,
-    schemaDir: ROOT,
-  });
-  console.log("Schema pushed.");
+  console.log("Client will auto-publish the current schema on first connect.");
 
   vite = spawn("npx", ["vite", "--host"], {
     cwd: ROOT,

--- a/packages/jazz-tools/bin/jazz-tools.js
+++ b/packages/jazz-tools/bin/jazz-tools.js
@@ -91,13 +91,40 @@ function exitWithSpawnResult(result, name) {
   process.exit(1);
 }
 
+function printWrapperHelp() {
+  console.log("Jazz distributed database CLI");
+  console.log("");
+  console.log("Usage: jazz-tools <COMMAND> [options]");
+  console.log("");
+  console.log("Commands:");
+  console.log("  validate              Validate root schema.ts and optional permissions.ts");
+  console.log("  schema export         Print the compiled structural schema as JSON");
+  console.log("  permissions status    Show the current server permissions head for this app");
+  console.log("  permissions push      Publish the current permissions.ts with head-parent checks");
+  console.log(
+    "  migrations create     Generate a typed structural migration stub from two known schema hashes",
+  );
+  console.log("  migrations push       Push a reviewed migration edge to the server");
+  console.log("  create                Create a new resource");
+  console.log("  server                Run a Jazz server");
+  console.log("  mcp                   Run the Jazz MCP server");
+  console.log("  help                  Print this message");
+  console.log("");
+  console.log("Options:");
+  console.log("  -h, --help            Print help");
+}
+
 const here = dirname(fileURLToPath(import.meta.url));
 
 const { args, rustBinOverride } = parseWrapperArgs(process.argv.slice(2));
 const command = args[0];
 
 // Handle the MCP server before any Rust binary resolution.
-if (command === "mcp") {
+if (!command || command === "--help" || command === "-h") {
+  printWrapperHelp();
+} else if (command === "help" && args.length === 1) {
+  printWrapperHelp();
+} else if (command === "mcp") {
   const mcpPath = join(here, "..", "dist", "mcp", "server.js");
   const { runServer } = await import(mcpPath);
   await runServer();

--- a/packages/jazz-tools/src/cli.test.ts
+++ b/packages/jazz-tools/src/cli.test.ts
@@ -766,4 +766,16 @@ describe("bin integration", () => {
       exported.todos.columns.some((column: { name: string }) => column.name === "ownerId"),
     ).toBe(true);
   });
+
+  it("shows the wrapper command surface in --help output", () => {
+    const result = runBin(["--help"]);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("validate");
+    expect(result.stdout).toContain("schema export");
+    expect(result.stdout).toContain("permissions push");
+    expect(result.stdout).toContain("migrations push");
+    expect(result.stdout).toContain("server");
+    expect(result.stdout).toContain("create");
+  });
 });

--- a/packages/jazz-tools/src/runtime/sync-transport.test.ts
+++ b/packages/jazz-tools/src/runtime/sync-transport.test.ts
@@ -193,7 +193,7 @@ describe("sync-transport", () => {
     expect(fetchMock.mock.calls[0]![1].headers).not.toHaveProperty("X-Jazz-Local-Token");
   });
 
-  it("skips catalogue payload sync when admin secret is missing", async () => {
+  it("posts schema catalogue payloads with user auth when admin secret is missing", async () => {
     const fetchMock = vi.fn().mockResolvedValue({ ok: true, statusText: "OK" });
     (globalThis as { fetch: typeof fetch }).fetch = fetchMock as unknown as typeof fetch;
 
@@ -204,6 +204,33 @@ describe("sync-transport", () => {
           metadata: {
             metadata: {
               type: "catalogue_schema",
+            },
+          },
+        },
+      }),
+      true,
+      { jwtToken: "jwt-token" },
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0]![1].headers).toMatchObject({
+      "Content-Type": "application/json",
+      Authorization: "Bearer jwt-token",
+    });
+    expect(fetchMock.mock.calls[0]![1].headers).not.toHaveProperty("X-Jazz-Admin-Secret");
+  });
+
+  it("still skips non-schema catalogue payload sync when admin secret is missing", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, statusText: "OK" });
+    (globalThis as { fetch: typeof fetch }).fetch = fetchMock as unknown as typeof fetch;
+
+    await sendSyncPayload(
+      "http://localhost:3000",
+      JSON.stringify({
+        ObjectUpdated: {
+          metadata: {
+            metadata: {
+              type: "catalogue_lens",
             },
           },
         },

--- a/packages/jazz-tools/src/runtime/sync-transport.ts
+++ b/packages/jazz-tools/src/runtime/sync-transport.ts
@@ -536,11 +536,35 @@ async function postSyncBatch(
   }
 }
 
+function catalogueObjectTypeFromPayloadJson(payloadJson: string): string | null {
+  try {
+    const parsed = JSON.parse(payloadJson) as {
+      ObjectUpdated?: {
+        metadata?: {
+          metadata?: {
+            type?: unknown;
+          };
+        };
+      };
+    };
+    const kind = parsed.ObjectUpdated?.metadata?.metadata?.type;
+    return typeof kind === "string" ? kind : null;
+  } catch {
+    return null;
+  }
+}
+
+function isStructuralSchemaCataloguePayload(payloadJson: string): boolean {
+  return catalogueObjectTypeFromPayloadJson(payloadJson) === "catalogue_schema";
+}
+
 /**
  * POST a sync payload to the server.
  *
  * User auth headers are always applied first (JWT or local auth).
- * Catalogue payloads additionally include the admin-secret header when available.
+ * Structural schema catalogue payloads can also flow with ordinary user auth so
+ * development servers can learn schemas without exposing an admin secret to the client.
+ * Other catalogue payloads still require the admin secret.
  */
 export async function sendSyncPayload(
   serverUrl: string,
@@ -549,12 +573,14 @@ export async function sendSyncPayload(
   auth: SyncAuth,
   logPrefix = "",
 ): Promise<void> {
-  if (isCatalogue && !auth.adminSecret) {
+  const isSchemaCatalogue = isCatalogue && isStructuralSchemaCataloguePayload(payloadJson);
+
+  if (isCatalogue && !auth.adminSecret && !isSchemaCatalogue) {
     return;
   }
 
   const headers: Record<string, string> = { "Content-Type": "application/json" };
-  if (isCatalogue) {
+  if (isCatalogue && auth.adminSecret) {
     headers["X-Jazz-Admin-Secret"] = auth.adminSecret!;
   } else {
     applySyncAuthHeaders(headers, auth);


### PR DESCRIPTION
## Summary
- allow development-mode servers to accept structural schema catalogue writes from ordinary authenticated clients without an admin secret
- keep non-schema catalogue writes admin-only, update the JS wrapper help so it matches the real TS command surface, and add focused tests
- document dev schema auto-push versus when to run `permissions push` and `migrations push`, and simplify dev example scripts that no longer need explicit schema publication

## Testing
- `node node_modules/vitest/vitest.mjs run --config vitest.config.ts src/runtime/sync-transport.test.ts src/cli.test.ts`
- `cargo test -p jazz-tools user_ -- --nocapture`
- `cargo build -p jazz-tools --bin jazz-tools --features cli`
