### PR TITLE
Fix release preview runtime bootstrap verification

### DIFF
--- a/.github/workflows/publish-jazz-tools-alpha.yml
+++ b/.github/workflows/publish-jazz-tools-alpha.yml
@@ -1124,11 +1124,7 @@ jobs:
               ;;
           esac
 
-          node "${EXTRACT_DIR}/package/bin/jazz-tools.js" --help >/dev/null
-          test -x "${EXTRACT_DIR}/package/bin/native/${HOST_LINUX_BIN}" || {
-            echo "Packed native binary ${HOST_LINUX_BIN} is not executable after runtime bootstrap."
-            exit 1
-          }
+          node packages/jazz-tools/scripts/verify-packed-runtime-bootstrap.mjs "${EXTRACT_DIR}/package"
 
       - name: Verify packed jazz-rn manifest
         run: |

--- a/packages/jazz-tools/scripts/verify-packed-runtime-bootstrap.mjs
+++ b/packages/jazz-tools/scripts/verify-packed-runtime-bootstrap.mjs
@@ -1,0 +1,73 @@
+import { spawnSync } from "node:child_process";
+import { accessSync, chmodSync, constants, existsSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+const BINARIES = {
+  "darwin-arm64": "jazz-tools-darwin-arm64",
+  "darwin-x64": "jazz-tools-darwin-x64",
+  "linux-arm64": "jazz-tools-linux-arm64",
+  "linux-x64": "jazz-tools-linux-x64",
+  "win32-x64": "jazz-tools-windows-x64.exe",
+};
+
+function fail(message) {
+  console.error(message);
+  process.exit(1);
+}
+
+const packageDirArg = process.argv[2];
+
+if (!packageDirArg) {
+  fail("Usage: node scripts/verify-packed-runtime-bootstrap.mjs <packed-package-dir>");
+}
+
+const packageDir = resolve(packageDirArg);
+const wrapperPath = join(packageDir, "bin", "jazz-tools.js");
+const binaryName = BINARIES[`${process.platform}-${process.arch}`];
+
+if (!binaryName) {
+  fail(`Unsupported host platform for packed runtime bootstrap verification: ${process.platform}/${process.arch}`);
+}
+
+const binaryPath = join(packageDir, "bin", "native", binaryName);
+
+if (!existsSync(wrapperPath)) {
+  fail(`Packed wrapper missing: ${wrapperPath}`);
+}
+
+if (!existsSync(binaryPath)) {
+  fail(`Packed host binary missing: ${binaryPath}`);
+}
+
+if (process.platform !== "win32") {
+  // Simulate the mode we get after round-tripping through GitHub Actions artifacts.
+  chmodSync(binaryPath, 0o644);
+}
+
+const result = spawnSync(process.execPath, [wrapperPath, "create", "--help"], {
+  encoding: "utf8",
+  env: process.env,
+});
+
+if (result.error) {
+  fail(`Failed to launch packed wrapper: ${result.error.message}`);
+}
+
+if (result.status !== 0) {
+  const stderr = result.stderr?.trim();
+  const stdout = result.stdout?.trim();
+  const details = [stderr, stdout].filter(Boolean).join("\n");
+  fail(
+    details
+      ? `Packed runtime bootstrap probe failed.\n${details}`
+      : "Packed runtime bootstrap probe failed without output.",
+  );
+}
+
+if (process.platform !== "win32") {
+  try {
+    accessSync(binaryPath, constants.X_OK);
+  } catch {
+    fail(`Packed native binary ${binaryName} is not executable after runtime bootstrap.`);
+  }
+}

--- a/packages/jazz-tools/scripts/verify-packed-runtime-bootstrap.mjs
+++ b/packages/jazz-tools/scripts/verify-packed-runtime-bootstrap.mjs
@@ -26,7 +26,9 @@ const wrapperPath = join(packageDir, "bin", "jazz-tools.js");
 const binaryName = BINARIES[`${process.platform}-${process.arch}`];
 
 if (!binaryName) {
-  fail(`Unsupported host platform for packed runtime bootstrap verification: ${process.platform}/${process.arch}`);
+  fail(
+    `Unsupported host platform for packed runtime bootstrap verification: ${process.platform}/${process.arch}`,
+  );
 }
 
 const binaryPath = join(packageDir, "bin", "native", binaryName);

--- a/packages/jazz-tools/src/cli.test.ts
+++ b/packages/jazz-tools/src/cli.test.ts
@@ -1,5 +1,6 @@
 import { spawnSync, type SpawnSyncReturns } from "node:child_process";
-import { access, mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { constants } from "node:fs";
+import { access, chmod, copyFile, mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -17,6 +18,9 @@ const dslPath = fileURLToPath(new URL("./dsl.ts", import.meta.url));
 const indexPath = fileURLToPath(new URL("./index.ts", import.meta.url));
 const distIndexPath = fileURLToPath(new URL("../dist/index.js", import.meta.url));
 const binPath = fileURLToPath(new URL("../bin/jazz-tools.js", import.meta.url));
+const bootstrapVerifierPath = fileURLToPath(
+  new URL("../scripts/verify-packed-runtime-bootstrap.mjs", import.meta.url),
+);
 
 const tempRoots: string[] = [];
 
@@ -705,6 +709,21 @@ function runBin(args: string[]): SpawnSyncReturns<string> {
   });
 }
 
+function hostNativeBinaryName(): string | null {
+  switch (`${process.platform}-${process.arch}`) {
+    case "darwin-arm64":
+      return "jazz-tools-darwin-arm64";
+    case "darwin-x64":
+      return "jazz-tools-darwin-x64";
+    case "linux-arm64":
+      return "jazz-tools-linux-arm64";
+    case "linux-x64":
+      return "jazz-tools-linux-x64";
+    default:
+      return null;
+  }
+}
+
 describe("bin integration", () => {
   it("routes validate through the TypeScript CLI for a root schema.ts project", async () => {
     const { root } = await createWorkspace();
@@ -765,5 +784,40 @@ describe("bin integration", () => {
     expect(
       exported.todos.columns.some((column: { name: string }) => column.name === "ownerId"),
     ).toBe(true);
+  });
+
+  it("verifies packed runtime bootstrap with a native-only help probe", async () => {
+    const hostBinaryName = hostNativeBinaryName();
+
+    if (!hostBinaryName) {
+      return;
+    }
+
+    const { root } = await createWorkspace();
+    const packageRoot = join(root, "package");
+    const nativeDir = join(packageRoot, "bin", "native");
+    const argsPath = join(root, "captured-args.txt");
+    const binaryPath = join(nativeDir, hostBinaryName);
+
+    await mkdir(nativeDir, { recursive: true });
+    await copyFile(binPath, join(packageRoot, "bin", "jazz-tools.js"));
+    await writeFile(
+      binaryPath,
+      `#!/bin/sh
+printf '%s\n' "$@" > ${JSON.stringify(argsPath)}
+exit 0
+`,
+      "utf8",
+    );
+    await chmod(binaryPath, 0o644);
+
+    const result = spawnSync(process.execPath, [bootstrapVerifierPath, packageRoot], {
+      encoding: "utf8",
+      env: process.env,
+    });
+
+    expect(result.status).toBe(0);
+    expect(await readFile(argsPath, "utf8")).toBe("create\n--help\n");
+    await expect(access(binaryPath, constants.X_OK)).resolves.toBeUndefined();
   });
 });


### PR DESCRIPTION
## What changed
Fix the release preview check for packed `jazz-tools` native binaries.

The preview workflow was verifying runtime bootstrap by running top-level `jazz-tools --help`. After the wrapper grew a JS-only help path, that no longer exercised the native binary bootstrap at all, so the check stopped proving the behavior we actually care about.

This PR:
- adds a dedicated packed-runtime bootstrap verifier script
- makes the release workflow use that verifier instead of top-level `--help`
- simulates GitHub artifact permission loss by stripping execute bits before probing
- verifies the wrapper repairs executability via a native-only command path (`create --help`)
- adds a focused test covering that behavior

## Why
The failing preview run got all the way to package verification, then reported that the packed Linux binary was still non-executable after bootstrap. We confirmed the workflow still re-applies `chmod 755` before packing, so the real regression was that the verification probe had gone stale when top-level `--help` became JS-only.

## Impact
Release previews should now validate the real native bootstrap path again instead of a JS-only fast path.

This should let the existing `changeset-release/main` preview go green once that branch picks up the workflow change and reruns preview.

## Validation
- `pnpm --dir packages/jazz-tools exec vitest run src/cli.test.ts -t "verifies packed runtime bootstrap with a native-only help probe"`
- `pnpm --dir packages/jazz-tools build`
- `pnpm --dir packages/jazz-tools exec vitest run src/cli.test.ts`
