### PR TITLE
Add vercel.json to inspector to fix reload

### DIFF
--- a/packages/inspector/vercel.json
+++ b/packages/inspector/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
+}


### PR DESCRIPTION
It's now possible to reload on https://jazz2-inspector-git-add-vercel-json-inspector-garden-co.vercel.app/data-explorer without 404