### PR TITLE
feat: add new co.snapshotRef covalue

### DIFF
--- a/.changeset/stale-cobras-tap.md
+++ b/.changeset/stale-cobras-tap.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Add new co.snapshotRef() CoValue that abstracts away cursor-based snapshotting and allows snapshots of values to be seamlessly referenced

--- a/examples/chat/src/chatScreen.tsx
+++ b/examples/chat/src/chatScreen.tsx
@@ -1,9 +1,10 @@
 import { Account } from "jazz-tools";
 import { createImage } from "jazz-tools/media";
 import { useSuspenseAccount, useSuspenseCoState } from "jazz-tools/react";
-import { useState } from "react";
-import { Chat, Message } from "./schema.ts";
+import { useRef, useState } from "react";
+import { Chat, Message, MessageSnapshot } from "./schema.ts";
 import {
+  BubbleActions,
   BubbleBody,
   BubbleContainer,
   BubbleImage,
@@ -13,6 +14,8 @@ import {
   EmptyChatMessage,
   ImageInput,
   InputBar,
+  InputBarBanner,
+  ReplyPreviewBubble,
   TextInput,
 } from "./ui.tsx";
 import { useCoStates } from "jazz-tools/react-core";
@@ -25,6 +28,9 @@ export function ChatScreen(props: { chatID: string }) {
   const [showNLastMessages, setShowNLastMessages] = useState(
     INITIAL_MESSAGES_TO_SHOW,
   );
+  const [replyingTo, setReplyingTo] = useState<Message | null>(null);
+  const [editingMessage, setEditingMessage] = useState<Message | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
 
   const messageIds = Array.from(chat.$jazz.refs)
     // We call slice before reverse to avoid mutating the original array
@@ -57,13 +63,65 @@ export function ChatScreen(props: { chatID: string }) {
     });
   };
 
+  const handleReply = (msg: Message) => {
+    setEditingMessage(null);
+    setReplyingTo(msg);
+    if (inputRef.current) {
+      inputRef.current.value = "";
+      inputRef.current.focus();
+    }
+  };
+
+  const handleEdit = (msg: Message) => {
+    setReplyingTo(null);
+    setEditingMessage(msg);
+    if (inputRef.current) {
+      inputRef.current.value = msg.text.toString();
+      inputRef.current.focus();
+    }
+  };
+
+  const handleCancelReply = () => {
+    setReplyingTo(null);
+    inputRef.current?.focus();
+  };
+
+  const handleCancelEdit = () => {
+    setEditingMessage(null);
+    if (inputRef.current) {
+      inputRef.current.value = "";
+      inputRef.current.focus();
+    }
+  };
+
+  const handleSubmit = async (text: string) => {
+    if (editingMessage) {
+      editingMessage.text.$jazz.applyDiff(text);
+      setEditingMessage(null);
+    } else if (replyingTo) {
+      const snapshot = await MessageSnapshot.create(replyingTo, {
+        owner: chat.$jazz.owner,
+      });
+      chat.$jazz.push({ text, replyOf: snapshot });
+      setReplyingTo(null);
+    } else {
+      chat.$jazz.push({ text });
+    }
+  };
+
   return (
     <>
       <ChatBody>
         {messages.length > 0 ? (
           messages.map((msg) =>
             msg.$isLoaded ? (
-              <ChatBubble me={me} msg={msg} key={msg.$jazz.id} />
+              <ChatBubble
+                me={me}
+                msg={msg}
+                key={msg.$jazz.id}
+                onReply={handleReply}
+                onEdit={handleEdit}
+              />
             ) : null,
           )
         ) : (
@@ -80,28 +138,110 @@ export function ChatScreen(props: { chatID: string }) {
       </ChatBody>
 
       <InputBar>
-        <ImageInput onImageChange={sendImage} />
-
-        <TextInput
-          onSubmit={(text) => {
-            chat.$jazz.push({ text });
-          }}
-        />
+        {replyingTo && (
+          <InputBarBanner
+            label="Replying to"
+            text={replyingTo.text.toString()}
+            onCancel={handleCancelReply}
+          />
+        )}
+        {editingMessage && (
+          <InputBarBanner label="Editing message" onCancel={handleCancelEdit} />
+        )}
+        <div className="flex gap-1">
+          {!editingMessage && <ImageInput onImageChange={sendImage} />}
+          <TextInput
+            inputRef={inputRef}
+            onSubmit={handleSubmit}
+            onCancel={
+              editingMessage
+                ? handleCancelEdit
+                : replyingTo
+                  ? handleCancelReply
+                  : undefined
+            }
+            placeholder={
+              editingMessage
+                ? "Edit message..."
+                : replyingTo
+                  ? "Reply..."
+                  : "Message"
+            }
+          />
+        </div>
       </InputBar>
     </>
   );
 }
 
-function ChatBubble({ me, msg }: { me: Account; msg: Message }) {
+function ChatBubble({
+  me,
+  msg,
+  onReply,
+  onEdit,
+}: {
+  me: Account;
+  msg: Message;
+  onReply: (msg: Message) => void;
+  onEdit: (msg: Message) => void;
+}) {
   const fromMe = msg.$jazz.createdBy === me.$jazz.id;
+  const isEdited =
+    msg.text.$jazz.raw.core.latestTxMadeAt >
+    msg.text.$jazz.raw.core.earliestTxMadeAt;
 
   return (
-    <BubbleContainer fromMe={fromMe}>
+    <BubbleContainer fromMe={fromMe} messageId={msg.$jazz.id}>
       <BubbleInfo by={msg.$jazz.createdBy} madeAt={msg.$jazz.createdAt} />
-      <BubbleBody fromMe={fromMe}>
-        {msg.image ? <BubbleImage image={msg.image} /> : null}
-        <BubbleText text={msg.text} />
-      </BubbleBody>
+      <div className="group relative max-w-[calc(100%-5rem)]">
+        <BubbleBody fromMe={fromMe}>
+          {msg.replyOf ? (
+            <ReplyContext replyOf={msg.replyOf} fromMe={fromMe} />
+          ) : null}
+          {msg.image ? <BubbleImage image={msg.image} /> : null}
+          <BubbleText text={msg.text} />
+          {isEdited ? (
+            <div className="text-right text-xs opacity-70 mr-2">Edited</div>
+          ) : null}
+        </BubbleBody>
+        <BubbleActions
+          fromMe={fromMe}
+          onReply={() => onReply(msg)}
+          onEdit={fromMe ? () => onEdit(msg) : undefined}
+        />
+      </div>
     </BubbleContainer>
+  );
+}
+
+function ReplyContext({
+  replyOf,
+  fromMe,
+}: {
+  replyOf: MessageSnapshot;
+  fromMe: boolean;
+}) {
+  const scrollToOriginal = () => {
+    const el = document.querySelector(
+      `[data-message-id="${replyOf.ref.$jazz.id}"]`,
+    );
+    if (!el) return;
+
+    el.scrollIntoView({ behavior: "smooth", block: "center" });
+    el.animate(
+      [
+        { backgroundColor: "rgba(59,130,246,0.3)" },
+        { backgroundColor: "transparent" },
+      ],
+      { duration: 2500, easing: "ease-out" },
+    );
+  };
+
+  return (
+    <ReplyPreviewBubble
+      text={replyOf.ref.text.toString()}
+      fromMe={fromMe}
+      onClick={scrollToOriginal}
+    />
   );
 }

--- a/examples/chat/src/schema.ts
+++ b/examples/chat/src/schema.ts
@@ -2,19 +2,33 @@ import { co, setDefaultValidationMode } from "jazz-tools";
 
 setDefaultValidationMode("strict");
 
-export const Message = co
-  .map({
-    text: co.plainText(),
-    image: co.optional(co.image()),
-  })
-  .resolved({
-    text: true,
-    image: true,
-  })
-  .withPermissions({
-    onInlineCreate: "sameAsContainer",
-  });
+const BaseMessage = co.map({
+  text: co.plainText(),
+  image: co.optional(co.image()),
+  get replyOf() {
+    return co.optional(MessageSnapshot);
+  },
+});
+
+export const Message = BaseMessage.resolved({
+  text: true,
+  image: true,
+  replyOf: { ref: { text: true } },
+}).withPermissions({
+  onInlineCreate: "sameAsContainer",
+});
+
 export type Message = co.loaded<typeof Message>;
+
+export const MessageSnapshot: co.Snapshot<
+  typeof BaseMessage,
+  { text: true },
+  { ref: { text: true } }
+> = co
+  .snapshotRef(BaseMessage, { cursorResolve: { text: true } })
+  .resolved({ ref: { text: true } });
+
+export type MessageSnapshot = co.loaded<typeof MessageSnapshot>;
 
 export const Chat = co.list(Message).withPermissions({
   onCreate: (owner) => owner.addMember("everyone", "writer"),

--- a/examples/chat/src/ui.tsx
+++ b/examples/chat/src/ui.tsx
@@ -1,7 +1,13 @@
 import clsx from "clsx";
 import { CoPlainText, ImageDefinition, Account } from "jazz-tools";
 import { Image, useCoState } from "jazz-tools/react";
-import { ImageIcon, SendIcon } from "lucide-react";
+import {
+  ImageIcon,
+  PencilIcon,
+  ReplyIcon,
+  SendIcon,
+  XIcon,
+} from "lucide-react";
 import { useId, useRef } from "react";
 import { inIframe } from "@/util.ts";
 
@@ -52,10 +58,15 @@ export function EmptyChatMessage() {
 export function BubbleContainer(props: {
   children: React.ReactNode;
   fromMe: boolean | undefined;
+  messageId?: string;
 }) {
   const align = props.fromMe ? "items-end" : "items-start";
   return (
-    <div className={`${align} flex flex-col m-3`} role="row">
+    <div
+      className={`${align} flex flex-col m-3`}
+      role="row"
+      data-message-id={props.messageId}
+    >
       {props.children}
     </div>
   );
@@ -69,7 +80,7 @@ export function BubbleBody(props: {
     <div
       className={clsx(
         "line-clamp-10 text-ellipsis whitespace-pre-wrap",
-        "rounded-2xl overflow-hidden max-w-[calc(100%-5rem)] shadow-sm p-1",
+        "rounded-2xl overflow-hidden shadow-sm p-1",
         props.fromMe
           ? "bg-white dark:bg-stone-900 dark:text-white"
           : "bg-blue text-white",
@@ -119,7 +130,7 @@ export function BubbleInfo(props: { by: string | undefined; madeAt: number }) {
 
 export function InputBar(props: { children: React.ReactNode }) {
   return (
-    <div className="px-3 pb-3 pt-1 bg-stone-100 mt-auto flex gap-1 dark:bg-transparent dark:border-stone-900">
+    <div className="px-3 pb-3 pt-1 bg-stone-100 mt-auto flex flex-col gap-1 dark:bg-transparent dark:border-stone-900">
       {props.children}
     </div>
   );
@@ -161,9 +172,15 @@ export function ImageInput({
   );
 }
 
-export function TextInput(props: { onSubmit: (text: string) => void }) {
+export function TextInput(props: {
+  onSubmit: (text: string) => void;
+  onCancel?: () => void;
+  inputRef?: React.RefObject<HTMLInputElement | null>;
+  placeholder?: string;
+}) {
   const inputId = useId();
-  const inputRef = useRef<HTMLInputElement>(null);
+  const internalRef = useRef<HTMLInputElement>(null);
+  const inputRef = props.inputRef ?? internalRef;
 
   const handleSubmit = () => {
     const input = inputRef.current;
@@ -181,11 +198,11 @@ export function TextInput(props: { onSubmit: (text: string) => void }) {
         ref={inputRef}
         id={inputId}
         className="rounded-full h-10 px-4 border border-stone-400 block w-full placeholder:text-stone-500 dark:bg-stone-925 dark:text-white dark:border-stone-900"
-        placeholder="Message"
+        placeholder={props.placeholder ?? "Message"}
         maxLength={2048}
         onKeyDown={({ key }) => {
-          if (key !== "Enter") return;
-          handleSubmit();
+          if (key === "Enter") handleSubmit();
+          else if (key === "Escape" && props.onCancel) props.onCancel();
         }}
       />
 
@@ -197,6 +214,84 @@ export function TextInput(props: { onSubmit: (text: string) => void }) {
         className="text-stone-500 dark:text-stone-400 absolute right-1 top-1/2 -translate-y-1/2 h-8 w-8 grid place-items-center cursor-pointer rounded-full hover:bg-stone-100 hover:text-stone-800 dark:hover:bg-stone-900 dark:hover:text-stone-200 transition-colors"
       >
         <SendIcon className="size-4" />
+      </button>
+    </div>
+  );
+}
+
+export function BubbleActions(props: {
+  fromMe: boolean | undefined;
+  onReply: () => void;
+  onEdit?: () => void;
+}) {
+  return (
+    <div className="absolute -top-3 right-1 opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity flex bg-white dark:bg-stone-800 rounded-full shadow-sm border border-stone-200 dark:border-stone-700">
+      <button
+        type="button"
+        onClick={props.onReply}
+        className="p-1.5 text-stone-500 hover:text-stone-800 dark:text-stone-400 dark:hover:text-stone-200 hover:bg-stone-100 dark:hover:bg-stone-700 rounded-full transition-colors cursor-pointer"
+        title="Reply"
+        aria-label="Reply to message"
+      >
+        <ReplyIcon size={14} />
+      </button>
+      {props.onEdit && (
+        <button
+          type="button"
+          onClick={props.onEdit}
+          className="p-1.5 text-stone-500 hover:text-stone-800 dark:text-stone-400 dark:hover:text-stone-200 hover:bg-stone-100 dark:hover:bg-stone-700 rounded-full transition-colors cursor-pointer"
+          title="Edit"
+          aria-label="Edit message"
+        >
+          <PencilIcon size={14} />
+        </button>
+      )}
+    </div>
+  );
+}
+
+export function ReplyPreviewBubble(props: {
+  text: string;
+  fromMe: boolean;
+  onClick?: () => void;
+}) {
+  return (
+    <div
+      className={clsx(
+        "mx-2 mt-1.5 px-2 py-1 text-xs rounded border-l-2 truncate",
+        props.fromMe
+          ? "opacity-70 bg-black/5 dark:bg-white/10 border-blue"
+          : "opacity-80 bg-white/15 border-white/50",
+        props.onClick && "cursor-pointer",
+      )}
+      onClick={props.onClick}
+    >
+      {props.text}
+    </div>
+  );
+}
+
+export function InputBarBanner(props: {
+  label: string;
+  text?: string;
+  onCancel: () => void;
+}) {
+  return (
+    <div className="flex items-center gap-2 px-3 py-1.5 text-xs text-stone-600 dark:text-stone-400 bg-stone-200/50 dark:bg-stone-800/50 rounded-lg">
+      <span className="font-medium shrink-0">{props.label}</span>
+      {props.text && (
+        <span className="truncate flex-1 text-stone-500 dark:text-stone-500">
+          {props.text}
+        </span>
+      )}
+      <button
+        type="button"
+        onClick={props.onCancel}
+        className="ml-auto shrink-0 text-stone-400 hover:text-stone-700 dark:hover:text-stone-200 cursor-pointer transition-colors"
+        title="Cancel"
+        aria-label="Cancel"
+      >
+        <XIcon size={14} />
       </button>
     </div>
   );

--- a/packages/jazz-tools/src/tools/coValues/deepLoading.ts
+++ b/packages/jazz-tools/src/tools/coValues/deepLoading.ts
@@ -157,7 +157,20 @@ export type RefsToResolve<
                 | boolean
             : V extends { [TypeSym]: "CoPlainText" | "BinaryCoStream" }
               ? boolean | OnError
-              : boolean);
+              : V extends {
+                    [TypeSym]: "SnapshotRef";
+                    ref: infer Item;
+                  }
+                ?
+                    | ({
+                        ref: RefsToResolve<
+                          AsLoaded<Item>,
+                          DepthLimit,
+                          [0, ...CurrentDepth]
+                        >;
+                      } & OnError)
+                    | boolean
+                : boolean);
 
 export type RefsToResolveStrict<T, V> = [V] extends [RefsToResolve<T>]
   ? RefsToResolve<T>
@@ -268,28 +281,46 @@ export type DeeplyLoaded<
               CoMapLikeLoaded<V, Depth, DepthLimit, CurrentDepth>
         : [V] extends [
               {
-                [TypeSym]: "CoStream";
-                byMe: CoFeedEntry<infer Item> | undefined;
+                [TypeSym]: "SnapshotRef";
+                ref: infer Item;
               },
             ]
-          ? // Deeply loaded CoStream
-            {
-              byMe?: { value: AsLoaded<Item> };
-              inCurrentSession?: { value: AsLoaded<Item> };
-              perSession: {
-                [key: SessionID]: { value: AsLoaded<Item> };
-              };
-            } & { [key: ID<Account>]: { value: AsLoaded<Item> } } & V // same reason as in CoList
+          ? Depth extends { ref: infer ItemDepth }
+            ? {
+                readonly ref:
+                  | DeeplyLoaded<
+                      AsLoaded<Item>,
+                      ItemDepth,
+                      DepthLimit,
+                      [0, ...CurrentDepth]
+                    >
+                  | OnErrorResolvedValue<AsLoaded<Item>, ItemDepth>;
+              } & V
+            : V
           : [V] extends [
                 {
-                  [TypeSym]: "BinaryCoStream";
+                  [TypeSym]: "CoStream";
+                  byMe: CoFeedEntry<infer Item> | undefined;
                 },
               ]
-            ? V
+            ? // Deeply loaded CoStream
+              {
+                byMe?: { value: AsLoaded<Item> };
+                inCurrentSession?: { value: AsLoaded<Item> };
+                perSession: {
+                  [key: SessionID]: { value: AsLoaded<Item> };
+                };
+              } & { [key: ID<Account>]: { value: AsLoaded<Item> } } & V // same reason as in CoList
             : [V] extends [
                   {
-                    [TypeSym]: "CoPlainText";
+                    [TypeSym]: "BinaryCoStream";
                   },
                 ]
               ? V
-              : never;
+              : [V] extends [
+                    {
+                      [TypeSym]: "CoPlainText";
+                    },
+                  ]
+                ? V
+                : never;

--- a/packages/jazz-tools/src/tools/coValues/interfaces.ts
+++ b/packages/jazz-tools/src/tools/coValues/interfaces.ts
@@ -524,6 +524,19 @@ export function isAnonymousAgentInstance(
   return TypeSym in instance && instance[TypeSym] === "Anonymous";
 }
 
+export function isAccountOrGroup(
+  instance: unknown,
+): instance is Account | Group {
+  if (typeof instance !== "object" || instance === null) {
+    return false;
+  }
+
+  return (
+    TypeSym in instance &&
+    (instance[TypeSym] === "Account" || instance[TypeSym] === "Group")
+  );
+}
+
 export type CoValueCreateOptions<
   MoreOptions extends object = {},
   Owner extends Group | Account = Group,
@@ -576,25 +589,15 @@ export function parseCoValueCreateOptions(
     };
   }
 
-  if (TypeSym in options) {
-    if (options[TypeSym] === "Account") {
-      const owner = accountOrGroupToGroup(options);
-      onCreate?.(owner);
-      return {
-        owner,
-        uniqueness: undefined,
-        firstComesWins: false,
-        restrictDeletion: undefined,
-      };
-    } else if (options[TypeSym] === "Group") {
-      onCreate?.(options);
-      return {
-        owner: options,
-        uniqueness: undefined,
-        firstComesWins: false,
-        restrictDeletion: undefined,
-      };
-    }
+  if (isAccountOrGroup(options)) {
+    const owner = accountOrGroupToGroup(options);
+    onCreate?.(owner);
+    return {
+      owner,
+      uniqueness: undefined,
+      firstComesWins: false,
+      restrictDeletion: undefined,
+    };
   }
 
   const firstComesWins = options.firstComesWins ?? false;
@@ -638,7 +641,7 @@ export function parseGroupCreateOptions(
     return { owner: activeAccountContext.get() };
   }
 
-  if (TypeSym in options && isAccountInstance(options)) {
+  if (isAccountInstance(options)) {
     return { owner: options };
   }
 
@@ -652,8 +655,9 @@ export function getIdFromHeader(
 ) {
   loadAs ||= activeAccountContext.get();
 
-  const node =
-    loadAs[TypeSym] === "Anonymous" ? loadAs.node : loadAs.$jazz.localNode;
+  const node = isAnonymousAgentInstance(loadAs)
+    ? loadAs.node
+    : loadAs.$jazz.localNode;
 
   return cojsonInternals.idforHeader(header, node.crypto);
 }
@@ -760,8 +764,9 @@ export async function internalLoadUnique<
 ): Promise<Settled<Resolved<V, R>>> {
   const loadAs = options.owner.$jazz.loadedAs;
 
-  const node =
-    loadAs[TypeSym] === "Anonymous" ? loadAs.node : loadAs.$jazz.localNode;
+  const node = isAnonymousAgentInstance(loadAs)
+    ? loadAs.node
+    : loadAs.$jazz.localNode;
 
   const header = getUniqueHeader(
     options.type,

--- a/packages/jazz-tools/src/tools/coValues/registeredSchemas.ts
+++ b/packages/jazz-tools/src/tools/coValues/registeredSchemas.ts
@@ -1,4 +1,4 @@
-import type { Account, CoMap, Group } from "../internal.js";
+import { Account, CoMap, Group } from "../internal.js";
 
 /**
  * Regisering schemas into this Record to avoid circular dependencies.

--- a/packages/jazz-tools/src/tools/coValues/snapshotRef.ts
+++ b/packages/jazz-tools/src/tools/coValues/snapshotRef.ts
@@ -1,0 +1,364 @@
+import { CoValueUniqueness, LocalNode, type RawCoMap } from "cojson";
+import {
+  CoValue,
+  getCoValueOwner,
+  Group,
+  ID,
+  RefEncoded,
+  RefsToResolve,
+  RefsToResolveStrict,
+  Resolved,
+  TypeSym,
+  CoValueBase,
+  CoValueJazzApi,
+  ensureCoValueLoaded,
+  CoreSnapshotRefSchema,
+  CoValueClass,
+  parseCoValueCreateOptions,
+  ResolveQuery,
+  internalLoadUnique,
+  Account,
+  AnonymousJazzAgent,
+  Settled,
+  loadCoValueWithoutMe,
+  ItemsSym,
+  resolveCoSchemaField,
+  CoValueCursor,
+  instantiateRefEncodedFromRaw,
+  coValueClassFromCoValueClassOrSchema,
+  Loaded,
+  inspect,
+  isAccountOrGroup,
+  CoValueCreateOptions,
+  SchemaPermissions,
+  withSchemaPermissions,
+  accessChildByKey,
+} from "../internal.js";
+import { assertCoValueSchema } from "../implementation/zodSchema/schemaInvariant.js";
+import { base58 } from "@scure/base";
+import { CoreCoValueSchema } from "../implementation/zodSchema/schemaTypes/CoValueSchema.js";
+
+type SnapshotRefInner<T extends SnapshotRef> = T extends SnapshotRef<
+  infer Inner
+>
+  ? Inner
+  : never;
+
+const textEncoder = new TextEncoder();
+
+/**
+ * A SnapshotRef captures a point-in-time reference to a CoValue.
+ *
+ * It stores a target CoValue ID and a cursor that together identify
+ * a specific snapshot of the referenced value. This is useful for
+ * creating immutable references to collaborative data at a known state.
+ *
+ * @category CoValues
+ */
+export class SnapshotRef<out Inner = any>
+  extends CoValueBase
+  implements CoValue
+{
+  /** @category Type Helpers */
+  declare [TypeSym]: "SnapshotRef";
+  static {
+    this.prototype[TypeSym] = "SnapshotRef";
+  }
+
+  /** @internal This is only a marker type and doesn't exist at runtime */
+  [ItemsSym]!: Inner;
+
+  /**
+   * Jazz methods for SnapshotRefs are inside this property.
+   *
+   * This allows SnapshotRefs to be used as plain objects while still having
+   * access to Jazz methods.
+   */
+  declare $jazz: SnapshotRefJazzApi<this>;
+
+  static coValueSchema?: CoreSnapshotRefSchema;
+
+  /** @internal */
+  constructor(options: {
+    fromRaw: RawCoMap;
+    operation?: "create" | "load";
+  }) {
+    super();
+
+    const snapshotRefSchema = assertCoValueSchema(
+      this.constructor,
+      "SnapshotRef",
+      options.operation ?? "load",
+    );
+
+    Object.defineProperties(this, {
+      $jazz: {
+        value: new SnapshotRefJazzApi(
+          this,
+          () => options.fromRaw,
+          snapshotRefSchema,
+        ),
+        enumerable: false,
+        configurable: true,
+      },
+    });
+  }
+
+  /**
+   * The referenced value this snapshot reference points to.
+   *
+   * @category Content
+   */
+  get ref(): Inner {
+    return accessChildByKey(
+      this,
+      this.$jazz.raw.get("ref") as string,
+      "ref",
+    ) as Inner;
+  }
+
+  /**
+   * The cursor identifying the specific point-in-time state of the target CoValue.
+   *
+   * @category Content
+   */
+  get cursor(): CoValueCursor {
+    return this.$jazz.raw.get("cursor") as CoValueCursor;
+  }
+
+  static load<S extends SnapshotRef, const R extends RefsToResolve<S> = true>(
+    this: CoValueClass<S>,
+    id: ID<S>,
+    options?: {
+      resolve?: RefsToResolveStrict<S, R>;
+      loadAs?: Account | AnonymousJazzAgent;
+      skipRetry?: boolean;
+    },
+  ): Promise<Settled<Resolved<S, R>>> {
+    return loadCoValueWithoutMe(this, id, options);
+  }
+
+  private static createSnapshotUniqueness({
+    ref,
+    cursor,
+    node,
+  }: {
+    ref: string;
+    cursor: string;
+    node: LocalNode;
+  }): CoValueUniqueness {
+    const uniquenessObject = {
+      version: 1,
+      ref,
+      cursor,
+    };
+
+    return {
+      uniqueness: base58.encode(
+        node.crypto.blake3HashOnce(
+          textEncoder.encode(JSON.stringify(uniquenessObject)),
+        ),
+      ),
+    };
+  }
+
+  private static createRawMap(options: {
+    ref: string;
+    cursor: string;
+    owner: Group;
+    uniqueness?: CoValueUniqueness;
+    firstComesWins?: boolean;
+  }) {
+    return options.owner.$jazz.raw.createMap(
+      {
+        ref: options.ref,
+        cursor: options.cursor,
+      },
+      null,
+      "private",
+      options.uniqueness,
+      options.firstComesWins ? { fww: "init" } : undefined,
+    );
+  }
+
+  /**
+   * Create a new `SnapshotRef` pointing to the given CoValue.
+   *
+   * Captures the current state of the value by recording its ID and a cursor.
+   * The SnapshotRef will immediately be persisted and synced to connected peers.
+   *
+   * @category Creation
+   */
+  static async create<
+    S extends SnapshotRef,
+    const R extends ResolveQuery<SnapshotRefInner<S>>,
+  >(
+    this: CoValueClass<S>,
+    createInit: {
+      value: Loaded<SnapshotRefInner<S>>;
+      cursorResolve?: RefsToResolveStrict<SnapshotRefInner<S>, R>;
+    },
+    permissions: SchemaPermissions,
+    options?: CoValueCreateOptions,
+  ): Promise<Settled<S>> {
+    const snapshotRefSchema = assertCoValueSchema(
+      this,
+      "SnapshotRef",
+      "create",
+    );
+
+    const loadedCoValue = await ensureCoValueLoaded(
+      createInit.value as CoValue,
+      {
+        // @ts-expect-error
+        resolve: createInit.cursorResolve,
+      },
+    );
+
+    const cursor = loadedCoValue.$jazz.createCursor();
+    const createOptions = isAccountOrGroup(options)
+      ? { owner: options }
+      : { ...options };
+    const me = loadedCoValue.$jazz.loadedAs;
+
+    // if no owner was passed, pass the coValue owner if possible in order to deduplicate based on uniqueness
+    if (
+      !createOptions.owner &&
+      loadedCoValue.$jazz.owner &&
+      me.canWrite(loadedCoValue)
+    ) {
+      createOptions.owner = loadedCoValue.$jazz.owner;
+    }
+
+    const { owner } = parseCoValueCreateOptions(
+      withSchemaPermissions(createOptions, permissions),
+    );
+
+    const loadAs = owner.$jazz.loadedAs;
+    const node =
+      loadAs[TypeSym] === "Anonymous" ? loadAs.node : loadAs.$jazz.localNode;
+
+    const ref = loadedCoValue.$jazz.id;
+
+    const uniqueness = SnapshotRef.createSnapshotUniqueness({
+      ref,
+      cursor,
+      node,
+    });
+
+    const snapshotMap = await internalLoadUnique(
+      snapshotRefSchema.snapshotRefMapSchema.getCoValueClass(),
+      {
+        type: "comap",
+        unique: uniqueness.uniqueness,
+        owner,
+        onCreateWhenMissing: () => {
+          SnapshotRef.createRawMap({
+            ref,
+            cursor,
+            owner,
+            uniqueness,
+            firstComesWins: true,
+          });
+        },
+      },
+    );
+
+    if (!snapshotMap.$isLoaded) {
+      return snapshotMap;
+    }
+
+    return instantiateRefEncodedFromRaw(
+      {
+        ref: coValueClassFromCoValueClassOrSchema(this),
+        optional: false,
+      },
+      snapshotMap.$jazz.raw,
+    );
+  }
+
+  toJSON() {
+    return {
+      $jazz: { id: this.$jazz.id },
+      ref: this.ref,
+      cursor: this.cursor,
+    };
+  }
+
+  [inspect]() {
+    return this.toJSON();
+  }
+}
+
+/**
+ * Contains SnapshotRef Jazz methods that are part of the {@link SnapshotRef.$jazz`} property.
+ */
+class SnapshotRefJazzApi<M extends SnapshotRef> extends CoValueJazzApi<M> {
+  private innerDescriptorCached: RefEncoded<CoValue> | undefined;
+
+  constructor(
+    private snapshotRef: M,
+    private getRaw: () => RawCoMap,
+    private coreSnapshotRefSchema: CoreSnapshotRefSchema,
+  ) {
+    super(snapshotRef);
+  }
+
+  /** The `Group` that owns this SnapshotRef and controls access. */
+  get owner(): Group {
+    return getCoValueOwner(this.snapshotRef);
+  }
+
+  /**
+   * Given an already loaded `SnapshotRef`, ensure that the specified fields are loaded to the specified depth.
+   *
+   * Works like `SnapshotRef.load()`, but you don't need to pass the ID or the account to load as again.
+   *
+   * @category Subscription & Loading
+   */
+  ensureLoaded<S extends SnapshotRef, const R extends RefsToResolve<S>>(
+    this: SnapshotRefJazzApi<S>,
+    options: {
+      resolve: RefsToResolveStrict<S, R>;
+    },
+  ): Promise<Resolved<S, R>> {
+    return ensureCoValueLoaded(this.snapshotRef, options);
+  }
+
+  /**
+   * Wait for the `SnapshotRef` to be uploaded to the other peers.
+   *
+   * @category Subscription & Loading
+   */
+  async waitForSync(options?: { timeout?: number }): Promise<void> {
+    await this.raw.core.waitForSync(options);
+  }
+
+  /** @internal */
+  getDescriptor(key: string): RefEncoded<CoValue> | undefined {
+    if (key !== "ref") {
+      return undefined;
+    }
+
+    if (this.innerDescriptorCached) {
+      return this.innerDescriptorCached;
+    }
+
+    const descriptor = {
+      ...(resolveCoSchemaField(
+        this.coreSnapshotRefSchema.innerSchema as CoreCoValueSchema & {
+          getCoValueClass: () => CoValueClass;
+        },
+      ) as RefEncoded<CoValue>),
+      isSnapshot: true,
+    } satisfies RefEncoded<CoValue>;
+
+    this.innerDescriptorCached = descriptor;
+    return descriptor;
+  }
+
+  /** @internal */
+  override get raw() {
+    return this.getRaw();
+  }
+}

--- a/packages/jazz-tools/src/tools/implementation/schemaRuntime.ts
+++ b/packages/jazz-tools/src/tools/implementation/schemaRuntime.ts
@@ -29,6 +29,7 @@ export type RefEncoded<V extends CoValue> = {
   ref: CoValueClass<V> | ((raw: RawCoValue) => CoValueClass<V>);
   optional: boolean;
   permissions?: RefPermissions;
+  isSnapshot?: boolean;
 };
 
 export function isRefEncoded<V extends CoValue>(

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/coExport.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/coExport.ts
@@ -8,6 +8,7 @@ export { PlainTextSchema as PlainText } from "./schemaTypes/PlainTextSchema.js";
 export { RichTextSchema as RichText } from "./schemaTypes/RichTextSchema.js";
 export { FileStreamSchema as FileStream } from "./schemaTypes/FileStreamSchema.js";
 export { CoVectorSchema as Vector } from "./schemaTypes/CoVectorSchema.js";
+export { SnapshotRefSchema as Snapshot } from "./schemaTypes/SnapshotRefSchema.js";
 export { CoInput as input } from "./typeConverters/CoFieldSchemaInit.js";
 export {
   AccountSchema as Account,
@@ -25,6 +26,7 @@ export {
   coRichTextDefiner as richText,
   coFileStreamDefiner as fileStream,
   coVectorDefiner as vector,
+  snapshotRefDefiner as snapshotRef,
   coImageDefiner as image,
   coAccountDefiner as account,
   coGroupDefiner as group,

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/runtimeConverters/coValueSchemaTransformation.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/runtimeConverters/coValueSchemaTransformation.ts
@@ -18,11 +18,13 @@ import {
   schemaUnionClassFromDiscriminator,
   isCoValueClass,
   CoVector as CoVectorClass,
+  SnapshotRef as SnapshotRefClass,
 } from "../../../internal.js";
 
 import { CoreCoValueSchema } from "../schemaTypes/CoValueSchema.js";
 import { RichTextSchema } from "../schemaTypes/RichTextSchema.js";
 import { GroupSchema } from "../schemaTypes/GroupSchema.js";
+import { SnapshotRefSchema } from "../schemaTypes/SnapshotRefSchema.js";
 import { schemaUnionDiscriminatorFor } from "../unionUtils.js";
 import {
   AnyCoreCoValueSchema,
@@ -72,6 +74,14 @@ export function hydrateCoreCoValueSchema<S extends AnyCoreCoValueSchema>(
   } else if (schema.builtin === "CoMap") {
     const coValueClass = class _CoMap extends CoMapClass {};
     coValueClass.coValueSchema = new CoMapSchema(
+      schema as any,
+      coValueClass as any,
+    );
+
+    return coValueClass.coValueSchema as unknown as CoValueSchemaFromCoreSchema<S>;
+  } else if (schema.builtin === "SnapshotRef") {
+    const coValueClass = class _SnapshotRef extends SnapshotRefClass {};
+    coValueClass.coValueSchema = new SnapshotRefSchema(
       schema as any,
       coValueClass as any,
     );

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/runtimeConverters/schemaFieldToCoFieldDef.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/runtimeConverters/schemaFieldToCoFieldDef.ts
@@ -111,7 +111,7 @@ function unsupportedZodTypeError(schema: SchemaField): Error {
   );
 }
 
-function resolveCoSchemaField(
+export function resolveCoSchemaField(
   schema: CoreCoValueSchema & { getCoValueClass: () => CoValueClass },
 ): Schema {
   return {

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaInvariant.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaInvariant.ts
@@ -3,6 +3,7 @@ import type { CoreCoFeedSchema } from "./schemaTypes/CoFeedSchema.js";
 import type { CoreCoListSchema } from "./schemaTypes/CoListSchema.js";
 import type { CoreCoMapSchema } from "./schemaTypes/CoMapSchema.js";
 import type { CoreCoValueSchema } from "./schemaTypes/CoValueSchema.js";
+import type { SnapshotRefSchema } from "./schemaTypes/SnapshotRefSchema.js";
 
 type ConstructorWithSchema<S extends CoreCoValueSchema = CoreCoValueSchema> = {
   name?: string;
@@ -38,7 +39,8 @@ type CoValueSchema =
   | CoreCoMapSchema
   | CoreCoListSchema
   | CoreCoFeedSchema
-  | CoreAccountSchema;
+  | CoreAccountSchema
+  | SnapshotRefSchema;
 
 export function assertCoValueSchema<
   T extends CoValueSchema["builtin"],

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaPermissions.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaPermissions.ts
@@ -1,10 +1,8 @@
 import {
   Account,
-  CoValueCreateOptions,
-  CoValueCreateOptionsInternal,
   Group,
-  TypeSym,
   type GroupRole,
+  isAccountOrGroup,
 } from "../../internal.js";
 
 /**
@@ -189,7 +187,7 @@ export function withSchemaPermissions<T extends { owner?: Account | Group }>(
       ...(schemaRestrictDeletion ? { restrictDeletion: true } : {}),
     } as T & { onCreate?: OnCreateCallback };
   }
-  if (TypeSym in options) {
+  if (isAccountOrGroup(options)) {
     return {
       owner: options,
       onCreate,

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoDiscriminatedUnionSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/CoDiscriminatedUnionSchema.ts
@@ -14,7 +14,6 @@ import {
   SubscribeCallback,
   SubscribeListenerOptions,
   coOptionalDefiner,
-  CoValueCursor,
   LoadCoValueCursorOption,
 } from "../../../internal.js";
 import { z } from "../zodReExport.js";

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/SnapshotRefSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/schemaTypes/SnapshotRefSchema.ts
@@ -1,0 +1,259 @@
+import {
+  Account,
+  AnonymousJazzAgent,
+  CoValueCreateOptions,
+  RefsToResolve,
+  RefsToResolveStrict,
+  Settled,
+  coOptionalDefiner,
+  InstanceOfSchemaCoValuesMaybeLoaded,
+  hydrateCoreCoValueSchema,
+  coMapDefiner,
+  CoMapSchema,
+  SnapshotRef,
+  Resolved,
+  InstanceOfSchema,
+  AsLoaded,
+} from "../../../internal.js";
+import { withSchemaResolveQuery } from "../../schemaUtils.js";
+import {
+  DEFAULT_SCHEMA_PERMISSIONS,
+  SchemaPermissions,
+} from "../schemaPermissions.js";
+import { z } from "../zodReExport.js";
+import { CoOptionalSchema } from "./CoOptionalSchema.js";
+import { CoreCoValueSchema, CoreResolveQuery } from "./CoValueSchema.js";
+
+type SnapshotRefInstanceMaybeLoaded<S extends CoreCoValueSchema> = SnapshotRef<
+  InstanceOfSchemaCoValuesMaybeLoaded<S>
+>;
+
+type SnapshotRefMapSchema = CoMapSchema<{
+  ref: z.ZodString;
+  cursor: z.ZodString;
+}>;
+
+/**
+ * Core schema definition for a SnapshotRef CoValue.
+ *
+ * Contains the minimal shape information needed to hydrate a full {@link SnapshotRefSchema}.
+ *
+ * @category Schema
+ */
+export interface CoreSnapshotRefSchema<
+  S extends CoreCoValueSchema = CoreCoValueSchema,
+  R extends CoreResolveQuery = true,
+> extends CoreCoValueSchema {
+  builtin: "SnapshotRef";
+  snapshotRefMapSchema: SnapshotRefMapSchema;
+  innerSchema: S;
+  cursorResolveQuery: R;
+}
+
+/**
+ * Schema definition for a `SnapshotRef` CoValue.
+ *
+ * Provides methods to create, load, and configure SnapshotRef instances.
+ * Use `co.snapshotRef(innerSchema)` to obtain a `SnapshotRefSchema`.
+ *
+ * @category Schema
+ */
+export class SnapshotRefSchema<
+  S extends CoreCoValueSchema = CoreCoValueSchema,
+  CursorResolveQuery extends CoreResolveQuery = true,
+  DefaultResolveQuery extends CoreResolveQuery = true,
+> implements CoreSnapshotRefSchema<S, CursorResolveQuery>
+{
+  readonly collaborative = true as const;
+  readonly builtin = "SnapshotRef" as const;
+  /** The inner CoValue schema that SnapshotRef instances will reference. */
+  readonly innerSchema: S;
+  /** The underlying CoMap schema used to persist the snapshot reference data. */
+  readonly snapshotRefMapSchema: SnapshotRefMapSchema;
+  /** The resolve query applied when loading the snapshot's cursor. */
+  readonly cursorResolveQuery: CursorResolveQuery;
+
+  /**
+   * Default resolve query to be used when loading instances of this schema.
+   * This resolve query will be used when no resolve query is provided to the load method.
+   * @default true
+   */
+  resolveQuery: DefaultResolveQuery = true as DefaultResolveQuery;
+
+  #permissions: SchemaPermissions | null = null;
+
+  /**
+   * Permissions to be used when creating or composing CoValues
+   * @internal
+   */
+  get permissions(): SchemaPermissions {
+    return this.#permissions ?? DEFAULT_SCHEMA_PERMISSIONS;
+  }
+
+  /** @internal */
+  getValidationSchema: CoreCoValueSchema["getValidationSchema"];
+
+  /** @internal */
+  static _refMapSchema:
+    | CoMapSchema<{
+        ref: z.ZodString;
+        cursor: z.ZodString;
+      }>
+    | undefined;
+
+  /** @internal */
+  static get refMapSchema() {
+    if (this._refMapSchema) {
+      return this._refMapSchema;
+    }
+
+    this._refMapSchema = coMapDefiner({
+      ref: z.string(),
+      cursor: z.string(),
+    });
+
+    return this._refMapSchema;
+  }
+
+  /** @internal */
+  constructor(
+    coreSchema: CoreSnapshotRefSchema<S, CursorResolveQuery>,
+    private coValueClass: typeof SnapshotRef,
+  ) {
+    this.innerSchema = coreSchema.innerSchema;
+    this.cursorResolveQuery = coreSchema.cursorResolveQuery;
+    this.getValidationSchema = coreSchema.getValidationSchema;
+    this.snapshotRefMapSchema = coreSchema.snapshotRefMapSchema;
+  }
+
+  /**
+   * Create a new `SnapshotRef` pointing to the given CoValue.
+   *
+   * The passed CoValue does not need to be fully loaded — the function will
+   * deeply load and snapshot the structure based on the schema's `cursorResolveQuery`.
+   *
+   * The SnapshotRef will immediately be persisted and synced to connected peers.
+   *
+   * @category Creation
+   */
+  async create(
+    value: AsLoaded<InstanceOfSchemaCoValuesMaybeLoaded<S>>,
+    options?: CoValueCreateOptions,
+  ): Promise<
+    // @ts-expect-error - cannot statically enforce CursorResolveQuery validity
+    Settled<SnapshotRef<Resolved<InstanceOfSchema<S>, CursorResolveQuery>>>
+  > {
+    // @ts-expect-error
+    return this.coValueClass.create(
+      {
+        // @ts-expect-error
+        value,
+        // @ts-expect-error cannot statically enforce schema default resolve validity
+        cursorResolve: this.cursorResolveQuery,
+      },
+      this.permissions,
+      options,
+    );
+  }
+
+  async load<
+    const R extends RefsToResolve<
+      SnapshotRefInstanceMaybeLoaded<S>
+      // @ts-expect-error
+    > = DefaultResolveQuery,
+  >(
+    id: string,
+    options?: {
+      resolve?: RefsToResolveStrict<SnapshotRefInstanceMaybeLoaded<S>, R>;
+      loadAs?: Account | AnonymousJazzAgent;
+      skipRetry?: boolean;
+    },
+  ): Promise<Settled<Resolved<SnapshotRefInstanceMaybeLoaded<S>, R>>> {
+    // @ts-expect-error
+    return this.coValueClass.load(
+      id,
+      // @ts-expect-error
+      withSchemaResolveQuery(options, this.resolveQuery),
+    );
+  }
+
+  /** @internal */
+  getCoValueClass(): typeof SnapshotRef {
+    return this.coValueClass;
+  }
+
+  /**
+   * Mark this schema field as optional when used inside a CoMap schema.
+   */
+  optional(): CoOptionalSchema<this> {
+    return coOptionalDefiner(this);
+  }
+
+  private copy<ResolveQuery extends CoreResolveQuery = DefaultResolveQuery>({
+    permissions,
+    resolveQuery,
+  }: {
+    permissions?: SchemaPermissions;
+    resolveQuery?: ResolveQuery;
+  }): SnapshotRefSchema<S, CursorResolveQuery, ResolveQuery> {
+    const coreSchema = createCoreSnapshotRefSchema(this.innerSchema, {
+      cursorResolve: this.cursorResolveQuery,
+    });
+
+    // @ts-expect-error
+    const copy: SnapshotRefSchema<S, R, ResolveQuery> =
+      hydrateCoreCoValueSchema(coreSchema);
+    // @ts-expect-error TS cannot infer that the resolveQuery type is valid
+    copy.resolveQuery = resolveQuery ?? this.resolveQuery;
+    copy.#permissions = permissions ?? this.#permissions;
+    return copy;
+  }
+
+  /**
+   * Adds a default resolve query to be used when loading instances of this schema.
+   * This resolve query will be used when no resolve query is provided to the load method.
+   */
+  resolved<
+    const ResolveQuery extends RefsToResolve<
+      SnapshotRefInstanceMaybeLoaded<S>
+    > = true,
+  >(
+    resolveQuery: RefsToResolveStrict<
+      SnapshotRefInstanceMaybeLoaded<S>,
+      ResolveQuery
+    >,
+  ): SnapshotRefSchema<S, CursorResolveQuery, ResolveQuery> {
+    return this.copy({ resolveQuery: resolveQuery as ResolveQuery });
+  }
+
+  /**
+   * Configure permissions to be used when creating or composing CoValues
+   */
+  withPermissions(
+    permissions: SchemaPermissions,
+  ): SnapshotRefSchema<S, CursorResolveQuery, DefaultResolveQuery> {
+    return this.copy({ permissions });
+  }
+}
+
+/** @internal */
+export function createCoreSnapshotRefSchema<
+  S extends CoreCoValueSchema,
+  R extends CoreResolveQuery = true,
+>(
+  schema: S,
+  options?: {
+    cursorResolve?: R;
+  },
+): CoreSnapshotRefSchema<S, R> {
+  return {
+    collaborative: true as const,
+    builtin: "SnapshotRef" as const,
+    innerSchema: schema,
+    snapshotRefMapSchema: SnapshotRefSchema.refMapSchema,
+    resolveQuery: true,
+    // @ts-expect-error
+    cursorResolveQuery: options?.cursorResolve ?? (true as const),
+    getValidationSchema: () => z.any(),
+  };
+}

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/CoFieldSchemaInit.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/CoFieldSchemaInit.ts
@@ -8,6 +8,9 @@ import {
   CoreCoVectorSchema,
   CorePlainTextSchema,
   Simplify,
+  CoreSnapshotRefSchema,
+  SnapshotRef,
+  InstanceOfSchemaCoValuesMaybeLoaded,
 } from "../../../internal.js";
 import { CoreCoOptionalSchema } from "../schemaTypes/CoOptionalSchema.js";
 import { CoreCoValueSchema } from "../schemaTypes/CoValueSchema.js";
@@ -24,25 +27,27 @@ import { TypeOfZodSchema } from "./TypeOfZodSchema.js";
  */
 export type CoFieldSchemaInit<S extends CoValueClass | AnyZodOrCoValueSchema> =
   S extends CoreCoValueSchema
-    ?
-        | Loaded<S>
-        | (S extends CoreCoRecordSchema<infer K, infer V>
-            ? CoMapSchemaInit<{ [key in z.output<K> & string]: V }>
-            : S extends CoreCoMapSchema<infer Shape>
-              ? CoMapSchemaInit<Shape>
-              : S extends CoreCoListSchema<infer T>
-                ? CoListSchemaInit<T>
-                : S extends CoreCoFeedSchema<infer T>
-                  ? CoFeedSchemaInit<T>
-                  : S extends CoreCoVectorSchema
-                    ? CoVectorSchemaInit
-                    : S extends CorePlainTextSchema | CoreRichTextSchema
-                      ? string
-                      : S extends CoreCoOptionalSchema<infer T>
-                        ? CoFieldSchemaInit<T> | undefined
-                        : S extends CoDiscriminatedUnionSchema<infer Members>
-                          ? CoFieldSchemaInit<Members[number]>
-                          : never)
+    ? S extends CoreSnapshotRefSchema<infer T, any>
+      ? SnapshotRef<InstanceOfSchemaCoValuesMaybeLoaded<T>>
+      :
+          | Loaded<S>
+          | (S extends CoreCoRecordSchema<infer K, infer V>
+              ? CoMapSchemaInit<{ [key in z.output<K> & string]: V }>
+              : S extends CoreCoMapSchema<infer Shape>
+                ? CoMapSchemaInit<Shape>
+                : S extends CoreCoListSchema<infer T>
+                  ? CoListSchemaInit<T>
+                  : S extends CoreCoFeedSchema<infer T>
+                    ? CoFeedSchemaInit<T>
+                    : S extends CoreCoVectorSchema
+                      ? CoVectorSchemaInit
+                      : S extends CorePlainTextSchema | CoreRichTextSchema
+                        ? string
+                        : S extends CoreCoOptionalSchema<infer T>
+                          ? CoFieldSchemaInit<T> | undefined
+                          : S extends CoDiscriminatedUnionSchema<infer Members>
+                            ? CoFieldSchemaInit<Members[number]>
+                            : never)
     : S extends z.core.$ZodType
       ? TypeOfZodSchema<S>
       : S extends CoValueClass

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/InstanceOfSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/InstanceOfSchema.ts
@@ -14,6 +14,8 @@ import {
   CoreCoVectorSchema,
   FileStream,
   Group,
+  CoreSnapshotRefSchema,
+  SnapshotRef,
 } from "../../../internal.js";
 import { CoreGroupSchema } from "../schemaTypes/GroupSchema.js";
 import { CoreCoFeedSchema } from "../schemaTypes/CoFeedSchema.js";
@@ -70,11 +72,15 @@ export type InstanceOfSchema<S extends CoValueClass | AnyZodOrCoValueSchema> =
                       ? FileStream
                       : S extends CoreCoVectorSchema
                         ? Readonly<CoVector>
-                        : S extends CoreCoOptionalSchema<infer T>
-                          ? InstanceOrPrimitiveOfSchema<T> | undefined
-                          : S extends CoDiscriminatedUnionSchema<infer Members>
-                            ? InstanceOrPrimitiveOfSchema<Members[number]>
-                            : never
+                        : S extends CoreSnapshotRefSchema<infer T, any>
+                          ? SnapshotRef<InstanceOfSchema<T>>
+                          : S extends CoreCoOptionalSchema<infer T>
+                            ? InstanceOrPrimitiveOfSchema<T> | undefined
+                            : S extends CoDiscriminatedUnionSchema<
+                                  infer Members
+                                >
+                              ? InstanceOrPrimitiveOfSchema<Members[number]>
+                              : never
     : S extends CoValueClass
       ? InstanceType<S>
       : never;

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/InstanceOfSchemaCoValuesMaybeLoaded.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/typeConverters/InstanceOfSchemaCoValuesMaybeLoaded.ts
@@ -18,6 +18,7 @@ import {
   FileStream,
   Group,
   MaybeLoaded,
+  SnapshotRef,
 } from "../../../internal.js";
 import { CoreCoOptionalSchema } from "../schemaTypes/CoOptionalSchema.js";
 import { CoreCoValueSchema } from "../schemaTypes/CoValueSchema.js";
@@ -25,6 +26,7 @@ import { CoreFileStreamSchema } from "../schemaTypes/FileStreamSchema.js";
 import { CorePlainTextSchema } from "../schemaTypes/PlainTextSchema.js";
 import { CoreRichTextSchema } from "../schemaTypes/RichTextSchema.js";
 import { CoreGroupSchema } from "../schemaTypes/GroupSchema.js";
+import { CoreSnapshotRefSchema } from "../schemaTypes/SnapshotRefSchema.js";
 import { z } from "../zodReExport.js";
 import { InstanceOrPrimitiveOfSchemaCoValuesMaybeLoaded } from "./InstanceOrPrimitiveOfSchemaCoValuesMaybeLoaded.js";
 
@@ -82,17 +84,23 @@ export type InstanceOfSchemaCoValuesMaybeLoaded<
                     ? MaybeLoaded<FileStream>
                     : S extends CoreCoVectorSchema
                       ? MaybeLoaded<Readonly<CoVector>>
-                      : S extends CoreCoOptionalSchema<infer Inner>
-                        ?
-                            | InstanceOrPrimitiveOfSchemaCoValuesMaybeLoaded<Inner>
-                            | undefined
-                        : S extends CoreCoDiscriminatedUnionSchema<
-                              infer Members
+                      : S extends CoreSnapshotRefSchema<infer Inner, any>
+                        ? MaybeLoaded<
+                            SnapshotRef<
+                              InstanceOrPrimitiveOfSchemaCoValuesMaybeLoaded<Inner>
                             >
-                          ? InstanceOrPrimitiveOfSchemaCoValuesMaybeLoaded<
-                              Members[number]
-                            >
-                          : never
+                          >
+                        : S extends CoreCoOptionalSchema<infer Inner>
+                          ?
+                              | InstanceOrPrimitiveOfSchemaCoValuesMaybeLoaded<Inner>
+                              | undefined
+                          : S extends CoreCoDiscriminatedUnionSchema<
+                                infer Members
+                              >
+                            ? InstanceOrPrimitiveOfSchemaCoValuesMaybeLoaded<
+                                Members[number]
+                              >
+                            : never
   : S extends CoValueClass
     ? MaybeLoaded<InstanceType<S>>
     : never;

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/zodCo.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/zodCo.ts
@@ -23,6 +23,8 @@ import {
   hydrateCoreCoValueSchema,
   isAnyCoValueSchema,
   isCoValueClass,
+  ResolveQuery,
+  RefsToResolveStrict,
 } from "../../internal.js";
 import { removeGetters } from "../schemaUtils.js";
 import {
@@ -31,6 +33,10 @@ import {
   createCoreCoDiscriminatedUnionSchema,
 } from "./schemaTypes/CoDiscriminatedUnionSchema.js";
 import { CoOptionalSchema } from "./schemaTypes/CoOptionalSchema.js";
+import {
+  SnapshotRefSchema,
+  createCoreSnapshotRefSchema,
+} from "./schemaTypes/SnapshotRefSchema.js";
 import type { CoreCoValueSchema } from "./schemaTypes/CoValueSchema.js";
 import {
   RichTextSchema,
@@ -240,4 +246,15 @@ export const coDiscriminatedUnionDefiner = <
     schemas,
   );
   return hydrateCoreCoValueSchema(coreSchema);
+};
+
+export const snapshotRefDefiner = <
+  S extends CoreCoValueSchema,
+  const R extends ResolveQuery<S> = true,
+>(
+  schema: S,
+  options?: { cursorResolve?: RefsToResolveStrict<S, R> },
+): SnapshotRefSchema<S, R> => {
+  const coreSchema = createCoreSnapshotRefSchema(schema, options);
+  return hydrateCoreCoValueSchema(coreSchema) as SnapshotRefSchema<S, R>;
 };

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/zodSchema.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/zodSchema.ts
@@ -11,7 +11,7 @@ import {
   RefsToResolve,
   RefsToResolveStrict,
   Resolved,
-  Simplify,
+  SnapshotRefSchema,
 } from "../../internal.js";
 import {
   AccountSchema,
@@ -46,6 +46,7 @@ import {
   CoreRichTextSchema,
   RichTextSchema,
 } from "./schemaTypes/RichTextSchema.js";
+import { CoreSnapshotRefSchema } from "./schemaTypes/SnapshotRefSchema.js";
 import { InstanceOfSchemaCoValuesMaybeLoaded } from "./typeConverters/InstanceOfSchemaCoValuesMaybeLoaded.js";
 import { z } from "./zodReExport.js";
 import { CoreGroupSchema } from "./schemaTypes/GroupSchema.js";
@@ -88,7 +89,12 @@ export type CoValueSchemaFromCoreSchema<S extends CoreCoValueSchema> =
                               infer Members
                             >
                           ? CoDiscriminatedUnionSchema<Members>
-                          : never;
+                          : S extends CoreSnapshotRefSchema<
+                                infer Inner,
+                                infer R
+                              >
+                            ? SnapshotRefSchema<Inner, R>
+                            : never;
 
 export type CoValueClassFromAnySchema<S extends CoValueClassOrSchema> =
   S extends CoValueClass<any>
@@ -114,7 +120,8 @@ export type AnyCoreCoValueSchema =
   | CorePlainTextSchema
   | CoreRichTextSchema
   | CoreFileStreamSchema
-  | CoreCoVectorSchema;
+  | CoreCoVectorSchema
+  | CoreSnapshotRefSchema<any, any>;
 
 export type AnyZodSchema = z.core.$ZodType;
 

--- a/packages/jazz-tools/src/tools/internal.ts
+++ b/packages/jazz-tools/src/tools/internal.ts
@@ -17,6 +17,7 @@ export * from "./coValues/coPlainText.js";
 export * from "./coValues/coRichText.js";
 export * from "./coValues/schemaUnion.js";
 export * from "./coValues/coVector.js";
+export * from "./coValues/snapshotRef.js";
 
 export type * from "./subscribe/types.js";
 
@@ -38,6 +39,7 @@ export * from "./implementation/zodSchema/zodSchema.js";
 export * from "./implementation/zodSchema/zodCo.js";
 export * as co from "./implementation/zodSchema/coExport.js";
 export * from "./implementation/zodSchema/schemaTypes/CoMapSchema.js";
+export * from "./implementation/zodSchema/schemaTypes/SnapshotRefSchema.js";
 export * from "./implementation/zodSchema/schemaTypes/CoDiscriminatedUnionSchema.js";
 export * from "./implementation/zodSchema/schemaTypes/CoRecordSchema.js";
 export * from "./implementation/zodSchema/schemaTypes/CoListSchema.js";

--- a/packages/jazz-tools/src/tools/subscribe/SubscriptionScope.ts
+++ b/packages/jazz-tools/src/tools/subscribe/SubscriptionScope.ts
@@ -792,7 +792,11 @@ export class SubscriptionScope<D extends CoValue> {
     // This helps alot with correctness when triggering the autoloading while rendering components (on React and Svelte)
     this.silenceUpdates = true;
 
-    if (value[TypeSym] === "CoMap" || value[TypeSym] === "Account") {
+    if (
+      value[TypeSym] === "CoMap" ||
+      value[TypeSym] === "Account" ||
+      value[TypeSym] === "SnapshotRef"
+    ) {
       const map = value as unknown as CoMap;
 
       this.loadCoMapKey(map, key, true);
@@ -918,7 +922,8 @@ export class SubscriptionScope<D extends CoValue> {
       if (
         coValueType === "CoMap" ||
         coValueType === "Account" ||
-        coValueType === "Group"
+        coValueType === "Group" ||
+        coValueType === "SnapshotRef"
       ) {
         const map = value as unknown as CoMap;
         const keys =
@@ -1036,7 +1041,11 @@ export class SubscriptionScope<D extends CoValue> {
 
     if (isRefEncoded(descriptor)) {
       if (id) {
-        this.loadChildNode(id, depth, descriptor, key);
+        const cursor = descriptor.isSnapshot
+          ? (map.$jazz.raw.get("cursor") as CoValueCursor)
+          : undefined;
+
+        this.loadChildNode(id, depth, descriptor, key, cursor);
         this.validationErrors.delete(key);
 
         return id;
@@ -1105,6 +1114,7 @@ export class SubscriptionScope<D extends CoValue> {
     query: RefsToResolve<any>,
     descriptor: RefEncoded<any>,
     key?: string,
+    cursorOverride?: CoValueCursor,
   ) {
     if (this.isSubscribedToId(id)) {
       return;
@@ -1135,6 +1145,14 @@ export class SubscriptionScope<D extends CoValue> {
       this.pendingAutoloadedChildren.add(id);
     }
 
+    let subscriptionCursor: typeof this._cursor | CoValueCursor = this._cursor;
+
+    if (cursorOverride) {
+      subscriptionCursor = cursorOverride;
+    } else if (isAutoloaded) {
+      subscriptionCursor = undefined;
+    }
+
     const child = new SubscriptionScope(
       this.node,
       resolve,
@@ -1143,7 +1161,7 @@ export class SubscriptionScope<D extends CoValue> {
       this.skipRetry,
       this.bestEffortResolution,
       this.unstable_branch,
-      isAutoloaded ? undefined : this._cursor,
+      subscriptionCursor,
     );
     this.childNodes.set(id, child);
     child.setListener((value) => this.handleChildUpdate(id, value, key));

--- a/packages/jazz-tools/src/tools/tests/snapshotRef.test.ts
+++ b/packages/jazz-tools/src/tools/tests/snapshotRef.test.ts
@@ -1,0 +1,688 @@
+import { cojsonInternals } from "cojson";
+import { beforeEach, describe, expect, expectTypeOf, test } from "vitest";
+import { Group, co, z, ResolveQuery, isControlledAccount } from "../exports.js";
+import { ControlledAccount, CoValueLoadingState } from "../internal.js";
+import { createJazzTestAccount, setupJazzTestSync } from "../testing.js";
+import { assertLoaded, setupTwoNodes } from "./utils.js";
+
+const Pet = co.map({
+  nickname: z.string(),
+});
+
+const Person = co.map({
+  name: z.string(),
+  pet: Pet,
+});
+
+const PersonSnapshot = co.snapshotRef(Person, {
+  cursorResolve: { pet: true },
+});
+
+const Toy = co.map({
+  label: z.string(),
+});
+
+const DeepPet = co.map({
+  nickname: z.string(),
+  favoriteToy: Toy,
+});
+
+const DeepPerson = co.map({
+  name: z.string(),
+  pet: DeepPet,
+});
+
+const deepPersonResolve = {
+  pet: {
+    favoriteToy: true,
+  },
+} satisfies ResolveQuery<typeof DeepPerson>;
+
+const DeepPersonSnapshot = co.snapshotRef(DeepPerson, {
+  cursorResolve: deepPersonResolve,
+});
+
+describe("SnapshotRef", () => {
+  let me: ControlledAccount;
+
+  beforeEach(async () => {
+    cojsonInternals.CO_VALUE_LOADING_CONFIG.RETRY_DELAY = 1000;
+
+    await setupJazzTestSync();
+
+    const account = await createJazzTestAccount({
+      isCurrentActiveAccount: true,
+      creationProps: { name: "Hermes Puggington" },
+    });
+
+    if (!isControlledAccount(account)) {
+      throw new Error("account is not a controlled account");
+    }
+
+    me = account;
+  });
+
+  describe("creation", () => {
+    test("creates snapshot from created CoValue", async () => {
+      const person = Person.create({ name: "John", pet: { nickname: "Rex" } });
+
+      const snapshot = await PersonSnapshot.create(person);
+
+      assertLoaded(snapshot);
+      expect(snapshot.cursor).toMatch(/^cursor_z/);
+      expect(snapshot.ref.$jazz.id).toBe(person.$jazz.id);
+    });
+
+    test("creates snapshot from loaded CoValue", async () => {
+      const person = Person.create({ name: "John", pet: { nickname: "Rex" } });
+      const loadedPerson = await Person.load(person.$jazz.id);
+
+      assertLoaded(loadedPerson);
+
+      const snapshot = await PersonSnapshot.create(loadedPerson);
+
+      assertLoaded(snapshot);
+      expect(snapshot.cursor).toMatch(/^cursor_z/);
+      expect(snapshot.ref.$jazz.id).toBe(person.$jazz.id);
+    });
+
+    test("creates snapshot from shallow-loaded CoValue", async () => {
+      const person = Person.create({
+        name: "Bob",
+        pet: { nickname: "Fluffy" },
+      });
+
+      const shallowLoaded = await Person.load(person.$jazz.id);
+      assertLoaded(shallowLoaded);
+
+      const snapshot = await PersonSnapshot.create(shallowLoaded);
+
+      assertLoaded(snapshot);
+      expect(snapshot.ref.$jazz.id).toBe(person.$jazz.id);
+      expect(snapshot.ref.pet.$isLoaded).toBe(false);
+    });
+
+    test("create snapshot of coList", async () => {
+      const PetList = co.list(Pet);
+      const PetListSnapshot = co.snapshotRef(PetList, {
+        cursorResolve: { $each: true },
+      });
+      const petList = PetList.create([
+        { nickname: "Rex" },
+        { nickname: "Puff" },
+      ]);
+
+      const snapshot = await PetListSnapshot.create(petList);
+
+      assertLoaded(snapshot);
+      expect(snapshot.cursor).toMatch(/^cursor_z/);
+      expect(snapshot.ref.$jazz.id).toBe(petList.$jazz.id);
+      expect(snapshot.ref[0]?.$jazz.id).toBe(petList[0]?.$jazz.id);
+    });
+
+    test("create snapshot of coFeed", async () => {
+      const PetFeed = co.feed(Pet);
+      const PetFeedSnapshot = co.snapshotRef(PetFeed, {
+        cursorResolve: { $each: true },
+      });
+      const petFeed = PetFeed.create([{ nickname: "Rex" }]);
+
+      const snapshot = await PetFeedSnapshot.create(petFeed);
+
+      assertLoaded(snapshot);
+      expect(snapshot.cursor).toMatch(/^cursor_z/);
+      expect(snapshot.ref.$jazz.id).toBe(petFeed.$jazz.id);
+    });
+
+    test("create snapshot of coPlainText", async () => {
+      const PlainText = co.plainText();
+      const PlainTextSnapshot = co.snapshotRef(PlainText);
+      const text = PlainText.create("hello world");
+
+      const snapshot = await PlainTextSnapshot.create(text);
+
+      assertLoaded(snapshot);
+      expect(snapshot.cursor).toMatch(/^cursor_z/);
+      expect(snapshot.ref.$jazz.id).toBe(text.$jazz.id);
+      expect(snapshot.ref.toString()).toBe("hello world");
+    });
+  });
+
+  describe("ownership and deduplication", () => {
+    test("use explicit owner when creating snapshot", async () => {
+      const owner = Group.create({ owner: me });
+      const person = Person.create({ name: "Mina", pet: { nickname: "Pico" } });
+
+      const snapshot = await PersonSnapshot.create(person, { owner });
+
+      assertLoaded(snapshot);
+      expect(snapshot.$jazz.owner.$jazz.id).toBe(owner.$jazz.id);
+    });
+
+    test("deduplicate snapshots by default if no owner is set", async () => {
+      const person = Person.create({
+        name: "Alice",
+        pet: { nickname: "Spot" },
+      });
+
+      const snapshot1 = await PersonSnapshot.create(person);
+      const snapshot2 = await PersonSnapshot.create(person);
+
+      assertLoaded(snapshot1);
+      assertLoaded(snapshot2);
+      expect(snapshot1.$jazz.id).toBe(snapshot2.$jazz.id);
+    });
+
+    test("cannot deduplicate snapshots without write access on referenced value", async () => {
+      const alice = await createJazzTestAccount();
+      const secretGroup = Group.create({ owner: alice }).makePublic("reader");
+
+      const person = Person.create(
+        { name: "Alice", pet: { nickname: "Spot" } },
+        { owner: secretGroup },
+      );
+
+      const personLoadedAsMe = await Person.load(person.$jazz.id);
+      assertLoaded(personLoadedAsMe);
+
+      const snapshot1 = await PersonSnapshot.create(personLoadedAsMe);
+      const snapshot2 = await PersonSnapshot.create(personLoadedAsMe);
+
+      assertLoaded(snapshot1);
+      assertLoaded(snapshot2);
+      expect(snapshot1.$jazz.id).not.toBe(snapshot2.$jazz.id);
+    });
+
+    test("deduplicate snapshots if same explicit owner is passed", async () => {
+      const owner = Group.create({ owner: me });
+      const person = Person.create({
+        name: "Alice",
+        pet: { nickname: "Spot" },
+      });
+
+      const snapshot1 = await PersonSnapshot.create(person, owner);
+      const snapshot2 = await PersonSnapshot.create(person, owner);
+
+      assertLoaded(snapshot1);
+      assertLoaded(snapshot2);
+      expect(snapshot1.$jazz.id).toBe(snapshot2.$jazz.id);
+    });
+
+    test("skips withPermissions default group if account has write access on value", async () => {
+      const owner = Group.create({ owner: me });
+      const SnapshotWithOwner = PersonSnapshot.withPermissions({
+        default: () => owner,
+      });
+      const person = Person.create({ name: "Mina", pet: { nickname: "Pico" } });
+
+      const snapshot = await SnapshotWithOwner.create(person);
+
+      assertLoaded(snapshot);
+      expect(snapshot.$jazz.owner.$jazz.id).not.toBe(owner.$jazz.id);
+      expect(snapshot.$jazz.owner.$jazz.id).toBe(person.$jazz.owner.$jazz.id);
+    });
+
+    test("uses default group from withPermissions if no write access on value", async () => {
+      const alice = await createJazzTestAccount();
+
+      const meGroup = Group.create({ owner: me });
+      const readOnlyGroup = Group.create({ owner: alice }).makePublic("reader");
+
+      const person = Person.create(
+        { name: "Mina", pet: { nickname: "Pico" } },
+        readOnlyGroup,
+      );
+      const personLoadedAsMe = await Person.load(person.$jazz.id);
+      assertLoaded(personLoadedAsMe);
+
+      const SnapshotWithOwner = PersonSnapshot.withPermissions({
+        default: () => meGroup,
+      });
+      const snapshot = await SnapshotWithOwner.create(personLoadedAsMe);
+
+      assertLoaded(snapshot);
+      expect(snapshot.$jazz.owner.$jazz.id).toBe(meGroup.$jazz.id);
+    });
+  });
+
+  describe("SnapshotRef.load()", () => {
+    test("load snapshotRef using .load()", async () => {
+      const person = Person.create({ name: "John", pet: { nickname: "Rex" } });
+      const snapshot = await PersonSnapshot.create(person);
+      assertLoaded(snapshot);
+
+      const loadedSnapshot = await PersonSnapshot.load(snapshot.$jazz.id);
+
+      assertLoaded(loadedSnapshot);
+      expect(loadedSnapshot.$jazz.id).toBe(snapshot.$jazz.id);
+      expect(loadedSnapshot.ref.$jazz.id).toBe(person.$jazz.id);
+      expect(loadedSnapshot.cursor).toBe(snapshot.cursor);
+    });
+
+    test("load non-existent snapshotRef", async () => {
+      const loadedSnapshot = await PersonSnapshot.load("co_zNonExistent", {
+        skipRetry: true,
+      });
+
+      expect(loadedSnapshot.$isLoaded).toBe(false);
+      expect(loadedSnapshot.$jazz.loadingState).toBe(
+        CoValueLoadingState.UNAVAILABLE,
+      );
+    });
+
+    test("load() then ensureLoaded() with no resolve", async () => {
+      const person = Person.create({ name: "John", pet: { nickname: "Rex" } });
+      const snapshot = await PersonSnapshot.create(person);
+      const loadedSnapshot = await PersonSnapshot.load(snapshot.$jazz.id);
+
+      assertLoaded(loadedSnapshot);
+
+      const resolvedSnapshot = await loadedSnapshot.$jazz.ensureLoaded({
+        resolve: true,
+      });
+
+      assertLoaded(resolvedSnapshot);
+      expectTypeOf(resolvedSnapshot.ref.$isLoaded).toEqualTypeOf<boolean>();
+    });
+
+    test("load() then ensureLoaded() with resolve", async () => {
+      const person = Person.create({ name: "John", pet: { nickname: "Rex" } });
+      const snapshot = await PersonSnapshot.create(person);
+      const loadedSnapshot = await PersonSnapshot.load(snapshot.$jazz.id);
+
+      assertLoaded(loadedSnapshot);
+
+      const resolvedSnapshot = await loadedSnapshot.$jazz.ensureLoaded({
+        resolve: {
+          ref: true,
+        },
+      });
+
+      assertLoaded(resolvedSnapshot);
+      expectTypeOf(resolvedSnapshot.ref.$isLoaded).toEqualTypeOf<true>();
+      expectTypeOf(resolvedSnapshot.ref.pet.$isLoaded).toEqualTypeOf<boolean>();
+      expect(resolvedSnapshot.ref.name).toBe("John");
+    });
+
+    test("load() then ensureLoaded() with with subset resolve", async () => {
+      const person = DeepPerson.create({
+        name: "John",
+        pet: {
+          nickname: "Rex",
+          favoriteToy: { label: "Ball" },
+        },
+      });
+      const snapshot = await DeepPersonSnapshot.create(person);
+      const loadedSnapshot = await DeepPersonSnapshot.load(snapshot.$jazz.id);
+
+      assertLoaded(loadedSnapshot);
+
+      const loadedValue = await loadedSnapshot.$jazz.ensureLoaded({
+        resolve: { ref: { pet: true } },
+      });
+
+      expect(loadedValue.ref.name).toBe("John");
+      expect(loadedValue.ref.pet.nickname).toBe("Rex");
+      expect(loadedValue.ref.pet.favoriteToy.$isLoaded).toBe(false);
+    });
+  });
+
+  describe("composition", () => {
+    test("snapshot as CoMap field", async () => {
+      const Comment = co.map({
+        text: z.string(),
+        author: PersonSnapshot,
+      });
+      const person = Person.create({ name: "John", pet: { nickname: "Rex" } });
+      const personSnapshot = await PersonSnapshot.create(person);
+      assertLoaded(personSnapshot);
+
+      const comment = Comment.create({
+        text: "hello",
+        author: personSnapshot,
+      });
+
+      const loadedComment = await Comment.load(comment.$jazz.id, {
+        resolve: { author: { ref: { pet: true } } },
+      });
+
+      assertLoaded(loadedComment);
+      expect(loadedComment.author.ref.name).toBe("John");
+      expect(loadedComment.author.ref.pet.nickname).toBe("Rex");
+    });
+
+    test("setting snapshot in CoMap field", async () => {
+      const Comment = co.map({
+        text: z.string(),
+        author: PersonSnapshot,
+      });
+      const person = Person.create({ name: "John", pet: { nickname: "Rex" } });
+      const personSnapshot = await PersonSnapshot.create(person);
+      assertLoaded(personSnapshot);
+
+      const comment = Comment.create({
+        text: "hello",
+        author: personSnapshot,
+      });
+
+      person.$jazz.applyDiff({
+        name: "Jane",
+        pet: { nickname: "Puff" },
+      });
+
+      const newSnapshot = await PersonSnapshot.create(person);
+      assertLoaded(newSnapshot);
+
+      comment.$jazz.set("author", newSnapshot);
+
+      const loadedComment = await Comment.load(comment.$jazz.id, {
+        resolve: { author: { ref: { pet: true } } },
+      });
+
+      assertLoaded(loadedComment);
+      expect(loadedComment.author.ref.name).toBe("Jane");
+      expect(loadedComment.author.ref.pet.nickname).toBe("Puff");
+    });
+
+    test("setting snapshot in CoMap field from another deeply loaded snapshot", async () => {
+      const Comment = co.map({
+        text: z.string(),
+        author: PersonSnapshot,
+      });
+      const person = Person.create({ name: "John", pet: { nickname: "Rex" } });
+      const personSnapshot = await PersonSnapshot.create(person);
+      assertLoaded(personSnapshot);
+
+      const comment = Comment.create({
+        text: "hello",
+        author: personSnapshot,
+      });
+
+      const loadedComment = await Comment.load(comment.$jazz.id, {
+        resolve: { author: true },
+      });
+      assertLoaded(loadedComment);
+
+      const anotherComment = Comment.create({
+        text: "World",
+        author: loadedComment.author,
+      });
+
+      const loadedSecondComment = await Comment.load(anotherComment.$jazz.id, {
+        resolve: { author: true },
+      });
+      assertLoaded(loadedSecondComment);
+
+      expect(loadedComment.author.$jazz.id).toBe(
+        loadedSecondComment.author.$jazz.id,
+      );
+      expect(loadedComment.author.ref.$jazz.id).toBe(
+        loadedSecondComment.author.ref.$jazz.id,
+      );
+    });
+
+    test("snapshot in CoList", async () => {
+      const SnapshotList = co.list(PersonSnapshot);
+      const person = Person.create({ name: "Ava", pet: { nickname: "Puff" } });
+      const snapshot = await PersonSnapshot.create(person);
+      assertLoaded(snapshot);
+
+      const list = SnapshotList.create([snapshot]);
+
+      const loadedList = await SnapshotList.load(list.$jazz.id, {
+        resolve: {
+          $each: { ref: { pet: true } },
+        },
+      });
+
+      assertLoaded(loadedList);
+      assertLoaded(loadedList[0]!);
+
+      expect(loadedList[0]!.ref.name).toBe("Ava");
+      expect(loadedList[0]!.ref.pet.nickname).toBe("Puff");
+    });
+
+    test("deep loading through composition", async () => {
+      const Comment = co.map({
+        body: z.string(),
+        author: PersonSnapshot,
+      });
+      const Thread = co.map({
+        title: z.string(),
+        comments: co.list(Comment),
+      });
+      const person = Person.create({
+        name: "Iris",
+        pet: { nickname: "Mochi" },
+      });
+      const snapshot = await PersonSnapshot.create(person);
+      assertLoaded(snapshot);
+
+      const thread = Thread.create({
+        title: "Snapshots",
+        comments: [{ body: "first", author: snapshot }],
+      });
+
+      const loadedThread = await Thread.load(thread.$jazz.id, {
+        resolve: {
+          comments: {
+            $each: {
+              author: { ref: { pet: true } },
+            },
+          },
+        },
+      });
+
+      assertLoaded(loadedThread);
+      expect(loadedThread.comments[0]?.author.ref.name).toBe("Iris");
+      expect(loadedThread.comments[0]?.author.ref.pet.nickname).toBe("Mochi");
+    });
+  });
+
+  describe("edge cases", () => {
+    test("optional inner refs", async () => {
+      const OptionalPerson = co.map({
+        name: z.string(),
+        pet: co.optional(Pet),
+      });
+      const OptionalPersonSnapshot = co.snapshotRef(OptionalPerson, {
+        cursorResolve: { pet: true },
+      });
+
+      const person = OptionalPerson.create({ name: "Nia" });
+      const snapshot = await OptionalPersonSnapshot.create(person);
+      assertLoaded(snapshot);
+
+      person.$jazz.set("pet", Pet.create({ nickname: "Later" }));
+
+      const result = await OptionalPersonSnapshot.load(snapshot.$jazz.id, {
+        resolve: { ref: { pet: true } },
+      });
+
+      const latest = await OptionalPerson.load(person.$jazz.id, {
+        resolve: { pet: true },
+      });
+
+      assertLoaded(result);
+      assertLoaded(latest);
+
+      expect(result.ref.pet).toBeUndefined();
+      expect(latest.pet?.nickname).toBe("Later");
+    });
+
+    test("$onError catch", async () => {
+      const alice = await createJazzTestAccount({
+        creationProps: { name: "Alice" },
+      });
+      const publicOwner = Group.create({ owner: alice }).makePublic("reader");
+      const secretOwner = Group.create({ owner: alice });
+      const person = Person.create(
+        {
+          name: "Casey",
+          pet: Pet.create({ nickname: "Shadow" }, { owner: secretOwner }),
+        },
+        { owner: publicOwner },
+      );
+
+      const snapshot = await PersonSnapshot.create(person, {
+        owner: publicOwner,
+      });
+
+      const result = await PersonSnapshot.load(snapshot.$jazz.id, {
+        loadAs: me,
+        resolve: {
+          ref: {
+            $onError: "catch",
+            pet: true,
+          },
+        },
+      });
+      assertLoaded(result);
+
+      expect(result.$isLoaded).toBe(true);
+      expect(result.ref.$jazz.loadingState).toBe(
+        CoValueLoadingState.UNAUTHORIZED,
+      );
+    });
+
+    test("inner $onError catch", async () => {
+      const Family = co.map({
+        sibling: PersonSnapshot,
+      });
+
+      const alice = await createJazzTestAccount({
+        creationProps: { name: "Alice" },
+      });
+      const publicOwner = Group.create({ owner: alice }).makePublic("reader");
+      const secretOwner = Group.create({ owner: alice });
+      const person = Person.create(
+        {
+          name: "Casey",
+          pet: Pet.create({ nickname: "Shadow" }, { owner: secretOwner }),
+        },
+        { owner: publicOwner },
+      );
+
+      const snapshot = await PersonSnapshot.create(person, {
+        owner: publicOwner,
+      });
+      assertLoaded(snapshot);
+
+      const family = Family.create({
+        sibling: snapshot,
+      });
+
+      const result = await Family.load(family.$jazz.id, {
+        loadAs: me,
+        resolve: {
+          sibling: {
+            ref: {
+              pet: {
+                $onError: "catch",
+              },
+            },
+          },
+        },
+      });
+
+      assertLoaded(result);
+      expect(result.$isLoaded).toBe(true);
+      expect(result.sibling.ref.$isLoaded).toBe(true);
+      expect(result.sibling.ref.pet.$isLoaded).toBe(false);
+      expect(result.sibling.ref.pet.$jazz.loadingState).toBe(
+        CoValueLoadingState.UNAUTHORIZED,
+      );
+    });
+
+    test("$onError catch deleted snapshot referenced value", async () => {
+      const Family = co.map({
+        sibling: PersonSnapshot,
+      });
+
+      const person = Person.create({ name: "Jane", pet: { nickname: "Rex" } });
+      const personSnapshot = await PersonSnapshot.create(person);
+      assertLoaded(personSnapshot);
+
+      const family = Family.create({ sibling: personSnapshot });
+
+      person.$jazz.raw.core.deleteCoValue();
+
+      const loadedFamily = await Family.load(family.$jazz.id, {
+        resolve: {
+          sibling: {
+            ref: {
+              pet: true,
+              $onError: "catch",
+            },
+          },
+        },
+      });
+
+      assertLoaded(loadedFamily);
+      expect(loadedFamily.$isLoaded).toBe(true);
+      expect(loadedFamily.sibling.ref.$isLoaded).toBe(false);
+      expect(loadedFamily.sibling.ref.$jazz.loadingState).toBe(
+        CoValueLoadingState.DELETED,
+      );
+    });
+
+    test("sync between peers", async () => {
+      const { clientNode, clientAccount, serverAccount } =
+        await setupTwoNodes();
+      const owner = Group.create(clientAccount).makePublic("reader");
+      const person = Person.create(
+        {
+          name: "Rae",
+          pet: { nickname: "Pip" },
+        },
+        { owner },
+      );
+
+      const snapshot = await PersonSnapshot.create(person, {
+        owner,
+      });
+
+      await clientAccount.$jazz.waitForAllCoValuesSync({ timeout: 1000 });
+      await clientNode.gracefulShutdown();
+
+      const result = await PersonSnapshot.load(snapshot.$jazz.id, {
+        loadAs: serverAccount,
+        resolve: { ref: { pet: true } },
+      });
+
+      assertLoaded(result);
+      expect(result.ref.name).toBe("Rae");
+      expect(result.ref.pet.nickname).toBe("Pip");
+    });
+
+    test("snapshot of deleted CoValue", async () => {
+      const owner = Group.create(me).makePublic("reader");
+      const person = Person.create(
+        {
+          name: "Mara",
+          pet: { nickname: "Ghost" },
+        },
+        { owner },
+      );
+
+      const snapshot = await PersonSnapshot.create(person, { owner });
+
+      person.$jazz.raw.core.deleteCoValue();
+      await person.$jazz.raw.core.waitForSync();
+
+      const viewer = await createJazzTestAccount({
+        creationProps: { name: "Viewer" },
+      });
+      const result = await PersonSnapshot.load(snapshot.$jazz.id, {
+        loadAs: viewer,
+        skipRetry: true,
+        resolve: {
+          ref: true,
+        },
+      });
+
+      expect(result.$isLoaded).toBe(false);
+      expect(result.$jazz.loadingState).toBe(CoValueLoadingState.DELETED);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Adds `co.snapshotRef()` — a new CoValue primitive that captures an immutable, point-in-time reference to another CoValue. This allows developers more easily leverage Jazz's history functionality and makes it trivial to build use cases like message replies, quoting/citing content, pinned versions of documents where you need to reference a specific state of collaborative data without it changing under you.

### How it works
A `SnapshotRef` stores a `targetId` and a `cursor. When loaded through the subscription system, the SnapshotRef is **transparently resolved** — consumers receive the inner CoValue directly with a `$snapshotRef` handle attached, rather than the wrapper. This passthrough design means existing resolve queries and deep loading work seamlessly on snapshot-referenced data.
Deduplication is built in: two snapshots of the same CoValue at the same cursor state and assigned the same owner produce the same underlying CoMap (via blake3-hashed uniqueness), so repeated snapshots for unchanged data are free. However, this needs an owner to be passed explicitly.

### Key changes
- **`co.snapshotRef(schema, { cursorResolve })`** — new schema definer that wraps any CoValue schema. The `cursorResolve` option controls how deep the cursor captures (e.g. `{ pet: true }` to include nested refs in the snapshot boundary).
- **`SnapshotRef` class + `SnapshotRefSchema`** — full CoValue implementation with `create()`, `load()`, `loadRef()`, `loadReferencedValue()`, plus standard schema methods (`.resolved()`, `.withPermissions()`, `.optional()`).
- **`SubscriptionScope` passthrough** — when the subscription target is a SnapshotRef, the scope loads the ref map first, then transparently redirects to the inner CoValue with the captured cursor applied. Child ID mapping is handled so parent scopes find their children correctly.
- **Type system integration** — `CoFieldInit`, `InstanceOfSchema`, `InstanceOfSchemaCoValuesMaybeLoaded`, and `CoFieldSchemaInit` all updated to support SnapshotRef passthrough types.
- **Chat example updated** — demonstrates the feature with message replying (snapshot the replied-to message), message editing (`applyDiff`), reply preview bubbles with scroll-to-original, and hover action buttons.
- **Test suite** covering creation, deduplication, loading, passthrough, deep nesting, cross-node sync, and error cases