### PR TITLE
Feat/sync tracer

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,3 +50,42 @@ sudo apt install libclang-dev
 ```sh
 sudo dnf install clang-devel
 ```
+
+## Testing
+
+### Running tests
+
+```sh
+pnpm test          # everything (via turbo)
+cargo test -p jazz-tools --features test   # rust core only
+```
+
+### Snapshot testing with insta in rust
+
+Sync integration tests use [insta](https://insta.rs) for inline snapshot assertions. Snapshots live directly in the test source as `@"..."` strings — no separate `.snap` files.
+
+```rust
+insta::assert_snapshot!(tracer.tally(), @"
+alice    -> server  : ObjectUpdated (1)
+server   -> alice   : PersistenceAck (2)
+");
+```
+
+When a snapshot doesn't match, the test fails and insta records the new value. To review and update:
+
+```sh
+# Install the insta CLI (once)
+cargo install cargo-insta
+
+# Run the failing tests
+cargo test -p jazz-tools --features test
+
+# Review each pending change interactively — shows a diff, asks accept/reject
+cargo insta review
+
+# Or accept all pending snapshots at once (when you trust the new output)
+cargo insta accept
+```
+
+`cargo insta review` rewrites the `@"..."` string in the source file directly.
+No git-tracked `.snap` files to manage.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -600,6 +600,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea0095f6103c2a8b44acd6fd15960c801dafebf02e21940360833e0673f48ba7"
 
 [[package]]
+name = "console"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "console_error_panic_hook"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -860,6 +871,12 @@ name = "embedded-io"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -1577,6 +1594,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "insta"
+version = "1.47.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99322078b2c076829a1db959d49da554fabc4342257fc0ba5a070a1eb3a01cd8"
+dependencies = [
+ "console",
+ "once_cell",
+ "similar",
+ "tempfile",
+]
+
+[[package]]
 name = "internment"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1741,6 +1770,7 @@ dependencies = [
  "fjall",
  "futures",
  "hex",
+ "insta",
  "internment",
  "jsonschema",
  "jsonwebtoken",
@@ -3296,6 +3326,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "simple_asn1"

--- a/crates/jazz-cloud-server/tests/client_multi_integration.rs
+++ b/crates/jazz-cloud-server/tests/client_multi_integration.rs
@@ -266,6 +266,7 @@ fn make_context(
         jwt_token: Some(jwt_token),
         backend_secret: Some(BACKEND_SECRET.to_string()),
         admin_secret: Some(ADMIN_SECRET.to_string()),
+        sync_tracer: None,
     }
 }
 

--- a/crates/jazz-tools/Cargo.toml
+++ b/crates/jazz-tools/Cargo.toml
@@ -99,6 +99,7 @@ tracing-opentelemetry = { version = "0.32", optional = true }
 
 [dev-dependencies]
 criterion = "0.5"
+insta = "1"
 reqwest = { version = "0.12", default-features = false, features = [
   "json",
   "stream",

--- a/crates/jazz-tools/examples/realistic_bench.rs
+++ b/crates/jazz-tools/examples/realistic_bench.rs
@@ -361,6 +361,7 @@ async fn connect_client(
         jwt_token: None,
         backend_secret: None,
         admin_secret: None,
+        sync_tracer: None,
     };
     Ok(JazzClient::connect(context).await?)
 }

--- a/crates/jazz-tools/src/client.rs
+++ b/crates/jazz-tools/src/client.rs
@@ -132,6 +132,11 @@ impl JazzClient {
             ClientStorage::Memory => context.client_id.unwrap_or_default(),
         };
 
+        // Register client name with tracer so server-side hooks resolve the human name
+        if let Some((ref tracer, ref name)) = context.sync_tracer {
+            tracer.register_client(client_id, name);
+        }
+
         // Connect to server if URL provided (before creating runtime so we have the connection)
         let auth_config = AuthConfig::from_context(&context);
         let server_connection = if !context.server_url.is_empty() {
@@ -157,9 +162,14 @@ impl JazzClient {
         let server_conn_for_sync = server_connection.clone();
         let client_id_for_sync = client_id;
         let server_id = ServerId::default();
+        let tracer_for_outgoing = context.sync_tracer.clone();
 
         // Create runtime with sync callback
         let runtime = TokioRuntime::new(schema_manager, storage, move |entry| {
+            // Record outgoing message to tracer if present
+            if let Some((ref tracer, ref name)) = tracer_for_outgoing {
+                tracer.record_outgoing(name, &entry.destination, &entry.payload);
+            }
             // Send to server if connected and destination is server
             if let Destination::Server(_) = entry.destination
                 && let Some(ref conn) = server_conn_for_sync
@@ -199,6 +209,7 @@ impl JazzClient {
             let stream_headers = conn.build_stream_headers();
             let server_id_for_stream = server_id;
             let mut initial_stream_ready_tx = initial_stream_ready_tx;
+            let tracer_for_incoming = context.sync_tracer.clone();
 
             Some(tokio::spawn(async move {
                 let http_client = reqwest::Client::new();
@@ -264,6 +275,7 @@ impl JazzClient {
                                                         event,
                                                         &runtime_for_stream,
                                                         server_id_for_stream,
+                                                        tracer_for_incoming.as_ref(),
                                                     ) {
                                                         tracing::warn!(
                                                             "Error handling server event: {}",
@@ -730,6 +742,7 @@ mod tests {
             jwt_token: None,
             backend_secret: None,
             admin_secret: None,
+            sync_tracer: None,
         }
     }
 
@@ -1096,6 +1109,7 @@ fn handle_server_event(
     event: ServerEvent,
     runtime: &ClientRuntime,
     server_id: ServerId,
+    sync_tracer: Option<&(crate::sync_tracer::SyncTracer, String)>,
 ) -> Result<()> {
     fn short_hash(hash: &impl ToString) -> String {
         let hash = hash.to_string();
@@ -1135,6 +1149,10 @@ fn handle_server_event(
                     short_hash(&warning.from_hash),
                     short_hash(&warning.to_hash),
                 );
+            }
+            // Record incoming message to tracer if present
+            if let Some((tracer, name)) = sync_tracer {
+                tracer.record_incoming(&Source::Server(server_id), name, &payload);
             }
             let entry = InboxEntry {
                 source: Source::Server(server_id),

--- a/crates/jazz-tools/src/lib.rs
+++ b/crates/jazz-tools/src/lib.rs
@@ -14,6 +14,7 @@ pub mod schema_manager;
 pub mod server;
 pub mod storage;
 pub mod sync_manager;
+pub mod sync_tracer;
 pub mod wire_types;
 
 #[cfg(feature = "runtime-tokio")]
@@ -89,6 +90,10 @@ pub struct AppContext {
     /// Admin secret for schema/policy sync.
     /// Required to sync catalogue objects.
     pub admin_secret: Option<String>,
+
+    /// Optional sync message tracer for test observability.
+    /// Set via `TestingClient::with_tracer()` — `None` in production.
+    pub sync_tracer: Option<(crate::sync_tracer::SyncTracer, String)>,
 }
 
 /// Local storage backend for a client application.

--- a/crates/jazz-tools/src/routes.rs
+++ b/crates/jazz-tools/src/routes.rs
@@ -594,6 +594,10 @@ async fn sync_handler(
     // Apply each payload in order, collecting per-payload results.
     let mut results = Vec::with_capacity(request.payloads.len());
     for payload in request.payloads {
+        // Record incoming message to tracer if present
+        if let Some(ref tracer) = state.sync_tracer {
+            tracer.record_incoming(&Source::Client(request.client_id), "server", &payload);
+        }
         let entry = InboxEntry {
             source: Source::Client(request.client_id),
             payload,

--- a/crates/jazz-tools/src/server/builder.rs
+++ b/crates/jazz-tools/src/server/builder.rs
@@ -47,6 +47,7 @@ pub struct ServerBuilder {
     catalogue_authority: CatalogueAuthorityMode,
     schema_mode: ServerSchemaMode,
     storage_mode: ServerStorageMode,
+    sync_tracer: Option<crate::sync_tracer::SyncTracer>,
 }
 
 impl ServerBuilder {
@@ -59,7 +60,13 @@ impl ServerBuilder {
             storage_mode: ServerStorageMode::Persistent {
                 data_dir: "./data".to_string(),
             },
+            sync_tracer: None,
         }
+    }
+
+    pub fn with_sync_tracer(mut self, tracer: crate::sync_tracer::SyncTracer) -> Self {
+        self.sync_tracer = Some(tracer);
+        self
     }
 
     pub fn with_auth_config(mut self, auth_config: AuthConfig) -> Self {
@@ -125,6 +132,7 @@ impl ServerBuilder {
             external_identities: RwLock::new(external_identities),
             disconnect_candidates: RwLock::new(HashMap::new()),
             client_ttl: RwLock::new(Duration::from_secs(300)),
+            sync_tracer: self.sync_tracer.clone(),
         });
 
         // Spawn periodic client state sweep (uses Weak so the task exits
@@ -162,11 +170,16 @@ impl ServerBuilder {
     > {
         let (sync_tx, _) = broadcast::channel::<(ClientId, SyncPayload)>(SYNC_BROADCAST_CAPACITY);
         let sync_tx_clone = sync_tx.clone();
+        let tracer_for_outgoing = self.sync_tracer.clone();
 
         let storage = self.build_main_storage()?;
         let schema_manager = self.build_schema_manager(storage.as_ref())?;
         let runtime = TokioRuntime::new(schema_manager, storage, move |entry| {
             if let Destination::Client(client_id) = entry.destination {
+                // Record outgoing server message to tracer if present
+                if let Some(ref tracer) = tracer_for_outgoing {
+                    tracer.record_outgoing("server", &entry.destination, &entry.payload);
+                }
                 let _ = sync_tx_clone.send((client_id, entry.payload));
             }
         });

--- a/crates/jazz-tools/src/server/mod.rs
+++ b/crates/jazz-tools/src/server/mod.rs
@@ -79,6 +79,8 @@ pub struct ServerState {
     /// Client state TTL. Default: 5 minutes.
     /// Disconnected clients are reaped after this duration.
     pub client_ttl: RwLock<Duration>,
+    /// Optional sync message tracer for test observability.
+    pub sync_tracer: Option<crate::sync_tracer::SyncTracer>,
 }
 
 /// State for a single SSE connection.

--- a/crates/jazz-tools/src/server/testing.rs
+++ b/crates/jazz-tools/src/server/testing.rs
@@ -23,7 +23,7 @@ const JWT_KID: &str = "test-jwks-kid";
 const JWT_SECRET: &str = "test-jwt-secret-for-integration";
 
 /// Builder for configuring and starting a [`TestingServer`].
-#[derive(Debug, Default)]
+#[derive(Default)]
 pub struct TestingServerBuilder {
     port: Option<u16>,
     app_id: Option<AppId>,
@@ -33,6 +33,18 @@ pub struct TestingServerBuilder {
     admin_secret: Option<String>,
     backend_secret: Option<String>,
     jwks_url: Option<String>,
+    sync_tracer: Option<crate::sync_tracer::SyncTracer>,
+}
+
+impl std::fmt::Debug for TestingServerBuilder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TestingServerBuilder")
+            .field("port", &self.port)
+            .field("app_id", &self.app_id)
+            .field("persistent_storage", &self.persistent_storage)
+            .field("has_tracer", &self.sync_tracer.is_some())
+            .finish()
+    }
 }
 
 impl TestingServerBuilder {
@@ -78,6 +90,11 @@ impl TestingServerBuilder {
 
     pub fn with_jwks_url(mut self, jwks_url: impl Into<String>) -> Self {
         self.jwks_url = Some(jwks_url.into());
+        self
+    }
+
+    pub fn with_tracer(mut self, tracer: crate::sync_tracer::SyncTracer) -> Self {
+        self.sync_tracer = Some(tracer);
         self
     }
 
@@ -165,6 +182,7 @@ impl TestingServer {
             admin_secret,
             backend_secret,
             jwks_url,
+            sync_tracer,
         } = builder;
 
         let app_id = app_id.unwrap_or_else(Self::default_app_id);
@@ -202,6 +220,9 @@ impl TestingServer {
 
         if let Some(schema) = schema {
             server_builder = server_builder.with_schema(schema);
+        }
+        if let Some(tracer) = sync_tracer {
+            server_builder = server_builder.with_sync_tracer(tracer);
         }
         let built = server_builder.build().await.expect("build test server");
 
@@ -355,6 +376,7 @@ impl TestingServer {
             jwt_token: Some(Self::jwt_for_user(user_id.as_ref())),
             backend_secret: Some(self.backend_secret.clone()),
             admin_secret: Some(self.admin_secret.clone()),
+            sync_tracer: None,
         }
     }
 

--- a/crates/jazz-tools/src/sync_tracer.rs
+++ b/crates/jazz-tools/src/sync_tracer.rs
@@ -1,0 +1,1146 @@
+//! Test-only message recorder for the sync protocol.
+//!
+//! Captures every sync message flowing between named participants (alice, bob,
+//! server) and provides querying and pretty-printing for test assertions and
+//! debugging.
+//!
+//! # Example
+//!
+//! ```ignore
+//! let tracer = SyncTracer::new();
+//! // ... attach to server + clients via builders ...
+//!
+//! println!("{}", tracer.dump());
+//! // [001] +  0ms  alice    -> server   ObjectUpdated        obj:a1b2c3d4 branch:main commits:[e5f6a7b8]
+//! // [002] +  3ms  server   -> alice    PersistenceAck       obj:a1b2c3d4 confirmed:[e5f6a7b8] tier:EdgeServer
+//! // [003] +  5ms  server   -> bob      ObjectUpdated        obj:a1b2c3d4 branch:main commits:[e5f6a7b8]
+//!
+//! assert!(tracer.from("alice").iter().any(|m| m.is_object_updated()));
+//! assert!(tracer.to("bob").iter().any(|m| m.is_object_updated()));
+//! ```
+
+use std::collections::HashMap;
+use std::fmt;
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
+
+use crate::commit::CommitId;
+use crate::object::ObjectId;
+use crate::sync_manager::{ClientId, Destination, QueryId, Source, SyncPayload};
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/// Human-readable participant name.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Participant(pub String);
+
+impl Participant {
+    pub fn new(name: impl Into<String>) -> Self {
+        Participant(name.into())
+    }
+
+    pub fn name(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for Participant {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// Which side recorded the message.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Side {
+    /// Recorded by the sender (outgoing hook).
+    Send,
+    /// Recorded by the receiver (incoming hook).
+    Recv,
+}
+
+impl fmt::Display for Side {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Side::Send => write!(f, "send"),
+            Side::Recv => write!(f, "recv"),
+        }
+    }
+}
+
+impl Side {
+    /// `=>` for send, `->` for recv.
+    fn arrow(&self) -> &'static str {
+        match self {
+            Side::Send => "=>",
+            Side::Recv => "->",
+        }
+    }
+}
+
+/// A single recorded sync message.
+#[derive(Debug, Clone)]
+pub struct SyncMessage {
+    /// Monotonic sequence number (recording order).
+    pub seq: usize,
+    /// Milliseconds elapsed since the tracer was created.
+    pub elapsed_ms: u64,
+    /// Who sent this message.
+    pub from: Participant,
+    /// Who this message was addressed to.
+    pub to: Participant,
+    /// Which side recorded this message.
+    pub side: Side,
+    /// The raw sync payload.
+    pub payload: SyncPayload,
+}
+
+impl SyncMessage {
+    /// True if this is an `ObjectUpdated` payload.
+    pub fn is_object_updated(&self) -> bool {
+        matches!(self.payload, SyncPayload::ObjectUpdated { .. })
+    }
+
+    /// True if this is a `PersistenceAck` payload.
+    pub fn is_persistence_ack(&self) -> bool {
+        matches!(self.payload, SyncPayload::PersistenceAck { .. })
+    }
+
+    /// True if this is a `QuerySubscription` payload.
+    pub fn is_query_subscription(&self) -> bool {
+        matches!(self.payload, SyncPayload::QuerySubscription { .. })
+    }
+
+    /// True if this is a `QuerySettled` payload.
+    pub fn is_query_settled(&self) -> bool {
+        matches!(self.payload, SyncPayload::QuerySettled { .. })
+    }
+
+    /// True if this is an `Error` payload.
+    pub fn is_error(&self) -> bool {
+        matches!(self.payload, SyncPayload::Error(_))
+    }
+
+    /// Extract object_id from payloads that carry one.
+    pub fn object_id(&self) -> Option<ObjectId> {
+        match &self.payload {
+            SyncPayload::ObjectUpdated { object_id, .. } => Some(*object_id),
+            SyncPayload::ObjectTruncated { object_id, .. } => Some(*object_id),
+            SyncPayload::PersistenceAck { object_id, .. } => Some(*object_id),
+            _ => None,
+        }
+    }
+
+    /// Extract query_id from payloads that carry one.
+    pub fn query_id(&self) -> Option<QueryId> {
+        match &self.payload {
+            SyncPayload::QuerySubscription { query_id, .. } => Some(*query_id),
+            SyncPayload::QueryUnsubscription { query_id } => Some(*query_id),
+            SyncPayload::QuerySettled { query_id, .. } => Some(*query_id),
+            _ => None,
+        }
+    }
+
+    /// Extract commit IDs from ObjectUpdated or PersistenceAck.
+    pub fn commit_ids(&self) -> Vec<CommitId> {
+        match &self.payload {
+            SyncPayload::ObjectUpdated { commits, .. } => commits.iter().map(|c| c.id()).collect(),
+            SyncPayload::PersistenceAck {
+                confirmed_commits, ..
+            } => confirmed_commits.iter().copied().collect(),
+            _ => vec![],
+        }
+    }
+}
+
+// ============================================================================
+// SyncTracer
+// ============================================================================
+
+struct Inner {
+    messages: Vec<SyncMessage>,
+    next_seq: usize,
+    start: Instant,
+    /// ClientId -> human name mapping.
+    client_names: HashMap<ClientId, String>,
+    /// ObjectId -> human name mapping.
+    object_names: HashMap<ObjectId, String>,
+    /// CommitId -> human name mapping.
+    commit_names: HashMap<CommitId, String>,
+}
+
+/// Thread-safe sync message recorder.
+///
+/// Create one per test, share across all participants. Each participant records
+/// messages via `record_outgoing` / `record_incoming`. Query with `messages()`,
+/// `from()`, `to()`, `for_object()`, etc.
+#[derive(Clone)]
+pub struct SyncTracer {
+    inner: Arc<Mutex<Inner>>,
+}
+
+impl SyncTracer {
+    pub fn new() -> Self {
+        SyncTracer {
+            inner: Arc::new(Mutex::new(Inner {
+                messages: Vec::new(),
+                next_seq: 1,
+                start: Instant::now(),
+                client_names: HashMap::new(),
+                object_names: HashMap::new(),
+                commit_names: HashMap::new(),
+            })),
+        }
+    }
+
+    /// Register a ClientId -> human name mapping.
+    ///
+    /// Call this when a client connects so the tracer can display "alice"
+    /// instead of a UUID.
+    pub fn register_client(&self, client_id: ClientId, name: impl Into<String>) {
+        let mut inner = self.inner.lock().unwrap();
+        inner.client_names.insert(client_id, name.into());
+    }
+
+    /// Register an ObjectId -> human name mapping.
+    ///
+    /// ```ignore
+    /// let (todo_id, _) = alice.create("todos", ...).await?;
+    /// tracer.register_object(todo_id, "alice-todo");
+    /// // Trace now shows "alice-todo" instead of "019d3fc7"
+    /// ```
+    pub fn register_object(&self, object_id: ObjectId, name: impl Into<String>) {
+        let mut inner = self.inner.lock().unwrap();
+        inner.object_names.insert(object_id, name.into());
+    }
+
+    /// Register a CommitId -> human name mapping.
+    ///
+    /// ```ignore
+    /// tracer.register_commit(commit_id, "C1");
+    /// // Trace now shows "C1" instead of "e5f6a7b8"
+    /// ```
+    pub fn register_commit(&self, commit_id: CommitId, name: impl Into<String>) {
+        let mut inner = self.inner.lock().unwrap();
+        inner.commit_names.insert(commit_id, name.into());
+    }
+
+    // --- Recording ---
+
+    /// Record an outgoing message (from a named participant to a Destination).
+    pub fn record_outgoing(
+        &self,
+        from_name: &str,
+        destination: &Destination,
+        payload: &SyncPayload,
+    ) {
+        let mut inner = self.inner.lock().unwrap();
+        let to_name = match destination {
+            Destination::Server(_) => "server".to_string(),
+            Destination::Client(cid) => inner
+                .client_names
+                .get(cid)
+                .cloned()
+                .unwrap_or_else(|| short_uuid(&cid.0)),
+        };
+        let msg = SyncMessage {
+            seq: inner.next_seq,
+            elapsed_ms: inner.start.elapsed().as_millis() as u64,
+            from: Participant::new(from_name),
+            to: Participant::new(to_name),
+            side: Side::Send,
+            payload: payload.clone(),
+        };
+        inner.next_seq += 1;
+        inner.messages.push(msg);
+    }
+
+    /// Record an incoming message (from a Source to a named participant).
+    pub fn record_incoming(&self, source: &Source, to_name: &str, payload: &SyncPayload) {
+        let mut inner = self.inner.lock().unwrap();
+        let from_name = match source {
+            Source::Server(_) => "server".to_string(),
+            Source::Client(cid) => inner
+                .client_names
+                .get(cid)
+                .cloned()
+                .unwrap_or_else(|| short_uuid(&cid.0)),
+        };
+        let msg = SyncMessage {
+            seq: inner.next_seq,
+            elapsed_ms: inner.start.elapsed().as_millis() as u64,
+            from: Participant::new(from_name),
+            to: Participant::new(to_name),
+            side: Side::Recv,
+            payload: payload.clone(),
+        };
+        inner.next_seq += 1;
+        inner.messages.push(msg);
+    }
+
+    // --- Query API ---
+
+    /// All recorded messages.
+    pub fn messages(&self) -> Vec<SyncMessage> {
+        self.inner.lock().unwrap().messages.clone()
+    }
+
+    /// Messages sent by a specific participant.
+    pub fn from(&self, name: &str) -> Vec<SyncMessage> {
+        self.inner
+            .lock()
+            .unwrap()
+            .messages
+            .iter()
+            .filter(|m| m.from.name() == name)
+            .cloned()
+            .collect()
+    }
+
+    /// Messages received by a specific participant.
+    pub fn to(&self, name: &str) -> Vec<SyncMessage> {
+        self.inner
+            .lock()
+            .unwrap()
+            .messages
+            .iter()
+            .filter(|m| m.to.name() == name)
+            .cloned()
+            .collect()
+    }
+
+    /// Messages between two participants (either direction).
+    pub fn between(&self, a: &str, b: &str) -> Vec<SyncMessage> {
+        self.inner
+            .lock()
+            .unwrap()
+            .messages
+            .iter()
+            .filter(|m| {
+                (m.from.name() == a && m.to.name() == b) || (m.from.name() == b && m.to.name() == a)
+            })
+            .cloned()
+            .collect()
+    }
+
+    /// Messages involving a specific object (ObjectUpdated, PersistenceAck, ObjectTruncated).
+    pub fn for_object(&self, object_id: ObjectId) -> Vec<SyncMessage> {
+        self.inner
+            .lock()
+            .unwrap()
+            .messages
+            .iter()
+            .filter(|m| m.object_id() == Some(object_id))
+            .cloned()
+            .collect()
+    }
+
+    /// Messages of a specific payload variant (e.g. "ObjectUpdated", "PersistenceAck").
+    pub fn of_type(&self, variant: &str) -> Vec<SyncMessage> {
+        self.inner
+            .lock()
+            .unwrap()
+            .messages
+            .iter()
+            .filter(|m| m.payload.variant_name() == variant)
+            .cloned()
+            .collect()
+    }
+
+    /// Number of recorded messages.
+    pub fn count(&self) -> usize {
+        self.inner.lock().unwrap().messages.len()
+    }
+
+    /// Clear all recorded messages and reset sequence counter.
+    pub fn clear(&self) {
+        let mut inner = self.inner.lock().unwrap();
+        inner.messages.clear();
+        inner.next_seq = 1;
+        inner.start = Instant::now();
+    }
+
+    // --- Display ---
+
+    /// Deterministic grouped summary: counts messages by (from, to, type).
+    ///
+    /// Output is sorted alphabetically by direction then type, making it
+    /// stable across runs regardless of async message interleaving.
+    ///
+    /// ```text
+    /// alice  -> server : ObjectUpdated (2), QueryUnsubscription (1)
+    /// server -> alice  : PersistenceAck (4)
+    /// server -> bob    : ObjectUpdated (2), QuerySettled (4)
+    /// ```
+    pub fn tally(&self) -> String {
+        let inner = self.inner.lock().unwrap();
+        tally_messages(&inner.messages)
+    }
+
+    /// Deterministic grouped summary filtered by participant.
+    pub fn tally_for(&self, name: &str) -> String {
+        let inner = self.inner.lock().unwrap();
+        let filtered: Vec<_> = inner
+            .messages
+            .iter()
+            .filter(|m| m.from.name() == name || m.to.name() == name)
+            .cloned()
+            .collect();
+        tally_messages(&filtered)
+    }
+
+    /// Pretty-print all recorded messages with named objects/commits.
+    pub fn dump(&self) -> String {
+        let inner = self.inner.lock().unwrap();
+        let names = Names {
+            objects: &inner.object_names,
+            commits: &inner.commit_names,
+        };
+        format_messages(&inner.messages, &names)
+    }
+
+    /// Pretty-print messages involving a specific participant.
+    pub fn dump_for(&self, name: &str) -> String {
+        let inner = self.inner.lock().unwrap();
+        let names = Names {
+            objects: &inner.object_names,
+            commits: &inner.commit_names,
+        };
+        let filtered: Vec<_> = inner
+            .messages
+            .iter()
+            .filter(|m| m.from.name() == name || m.to.name() == name)
+            .cloned()
+            .collect();
+        format_messages(&filtered, &names)
+    }
+
+    /// Detailed trace without timing — stable for `insta` inline snapshots.
+    ///
+    /// Shows named objects/commits, one line per message:
+    /// ```text
+    /// alice    -> server   ObjectUpdated        obj:alice-todo branch:main commits:[C1]
+    /// server   -> alice    PersistenceAck       obj:alice-todo confirmed:[C1] tier:EdgeServer
+    /// ```
+    pub fn trace(&self) -> String {
+        let inner = self.inner.lock().unwrap();
+        let names = Names {
+            objects: &inner.object_names,
+            commits: &inner.commit_names,
+        };
+        format_trace(&inner.messages, &names)
+    }
+
+    /// Normalized trace for stable inline snapshots.
+    ///
+    /// Like `trace()` but auto-assigns deterministic names to commits and
+    /// branches as they appear: first commit → `C1`, second → `C2`, etc.
+    /// Branch names are stripped of the random client-ID prefix.
+    /// Registered object names are used; unregistered objects get `obj-1`, `obj-2`.
+    ///
+    /// ```text
+    /// alice    -> server   ObjectUpdated        obj:my-todo branch:main commits:[C1]
+    /// server   -> alice    PersistenceAck       obj:my-todo confirmed:[C1] tier:EdgeServer
+    /// ```
+    pub fn trace_normalized(&self) -> String {
+        let inner = self.inner.lock().unwrap();
+        let mut normalizer = Normalizer::new(&inner.object_names);
+
+        let mut out = String::from("# => sent, -> received\n");
+
+        // Build lines with sort key (from, to, variant, details)
+        let mut lines: Vec<(String, String, String, String, String)> = inner
+            .messages
+            .iter()
+            .map(|msg| {
+                let details = normalizer.format_payload(&msg.payload);
+                let line = format!(
+                    "{:<8} {} {:<8}  {:<20} {}",
+                    msg.from.name(),
+                    msg.side.arrow(),
+                    msg.to.name(),
+                    msg.payload.variant_name(),
+                    details,
+                );
+                (
+                    msg.from.name().to_string(),
+                    msg.to.name().to_string(),
+                    msg.payload.variant_name().to_string(),
+                    details,
+                    line,
+                )
+            })
+            .collect();
+
+        // Stable sort: preserve causal order within the same direction,
+        // but sort by (from, to, variant, details) for full determinism.
+        lines.sort_by(|a, b| {
+            a.0.cmp(&b.0)
+                .then(a.1.cmp(&b.1))
+                .then(a.2.cmp(&b.2))
+                .then(a.3.cmp(&b.3))
+        });
+
+        for (_, _, _, _, line) in &lines {
+            out.push_str(line);
+            out.push('\n');
+        }
+        out
+    }
+
+    /// Detailed trace filtered by participant, without timing.
+    pub fn trace_for(&self, name: &str) -> String {
+        let inner = self.inner.lock().unwrap();
+        let names = Names {
+            objects: &inner.object_names,
+            commits: &inner.commit_names,
+        };
+        let filtered: Vec<_> = inner
+            .messages
+            .iter()
+            .filter(|m| m.from.name() == name || m.to.name() == name)
+            .cloned()
+            .collect();
+        format_trace(&filtered, &names)
+    }
+
+    // --- Snapshot assertions ---
+
+    /// Compact shape summary: one line per message, showing only
+    /// `from -> to  MessageType`.
+    ///
+    /// ```text
+    /// alice  -> server  ObjectUpdated
+    /// server -> alice   PersistenceAck
+    /// server -> bob     ObjectUpdated
+    /// ```
+    pub fn summary(&self) -> String {
+        let inner = self.inner.lock().unwrap();
+        summary_lines(&inner.messages)
+    }
+
+    /// Summary filtered by participants involved.
+    pub fn summary_for(&self, name: &str) -> String {
+        let inner = self.inner.lock().unwrap();
+        let filtered: Vec<_> = inner
+            .messages
+            .iter()
+            .filter(|m| m.from.name() == name || m.to.name() == name)
+            .cloned()
+            .collect();
+        summary_lines(&filtered)
+    }
+
+    /// Assert the message flow matches an expected shape.
+    ///
+    /// Each line in `expected` should be `from -> to  MessageType`.
+    /// Blank lines and leading/trailing whitespace are ignored.
+    /// Dynamic values (object IDs, commits, etc.) are not compared.
+    ///
+    /// # Panics
+    ///
+    /// Panics with a diff if the actual flow doesn't match.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// tracer.expect("
+    ///     alice  -> server  ObjectUpdated
+    ///     server -> alice   PersistenceAck
+    ///     server -> bob     ObjectUpdated
+    /// ");
+    /// ```
+    pub fn expect(&self, expected: &str) {
+        let actual = self.summary();
+        let expected_lines = normalize_expectation(expected);
+        let actual_lines = normalize_expectation(&actual);
+
+        if expected_lines != actual_lines {
+            let mut diff = String::new();
+            diff.push_str("SyncTracer expectation mismatch!\n\n");
+            diff.push_str("=== Expected ===\n");
+            for line in &expected_lines {
+                diff.push_str(line);
+                diff.push('\n');
+            }
+            diff.push_str("\n=== Actual ===\n");
+            for line in &actual_lines {
+                diff.push_str(line);
+                diff.push('\n');
+            }
+            diff.push_str("\n=== Full trace (with details) ===\n");
+            diff.push_str(&self.dump());
+            panic!("{diff}");
+        }
+    }
+
+    /// Assert that the message flow **contains** the expected subsequence.
+    ///
+    /// Like `expect`, but the actual trace may have additional messages
+    /// before, after, or between the expected lines. Each expected line
+    /// must appear in order, but not necessarily consecutively.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// tracer.expect_contains("
+    ///     alice  -> server  ObjectUpdated
+    ///     server -> bob     ObjectUpdated
+    /// ");
+    /// ```
+    pub fn expect_contains(&self, expected: &str) {
+        let actual = self.summary();
+        let expected_lines = normalize_expectation(expected);
+        let actual_lines = normalize_expectation(&actual);
+
+        let mut actual_idx = 0;
+        let mut matched = Vec::new();
+
+        for expected_line in &expected_lines {
+            let mut found = false;
+            while actual_idx < actual_lines.len() {
+                if &actual_lines[actual_idx] == expected_line {
+                    matched.push(actual_idx);
+                    actual_idx += 1;
+                    found = true;
+                    break;
+                }
+                actual_idx += 1;
+            }
+            if !found {
+                let mut diff = String::new();
+                diff.push_str("SyncTracer expect_contains mismatch!\n\n");
+                diff.push_str(&format!(
+                    "Could not find expected line: {expected_line}\n\n"
+                ));
+                diff.push_str("=== Expected subsequence ===\n");
+                for line in &expected_lines {
+                    diff.push_str(line);
+                    diff.push('\n');
+                }
+                diff.push_str("\n=== Actual (full) ===\n");
+                for (i, line) in actual_lines.iter().enumerate() {
+                    let marker = if matched.contains(&i) { "✓ " } else { "  " };
+                    diff.push_str(marker);
+                    diff.push_str(line);
+                    diff.push('\n');
+                }
+                diff.push_str("\n=== Full trace (with details) ===\n");
+                diff.push_str(&self.dump());
+                panic!("{diff}");
+            }
+        }
+    }
+}
+
+impl Default for SyncTracer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl fmt::Debug for SyncTracer {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SyncTracer")
+            .field("message_count", &self.count())
+            .finish()
+    }
+}
+
+// ============================================================================
+// Formatting
+// ============================================================================
+
+fn tally_messages(messages: &[SyncMessage]) -> String {
+    use std::collections::BTreeMap;
+
+    // Group by (from, arrow, to) -> type -> count
+    let mut groups: BTreeMap<(String, &str, String), BTreeMap<String, usize>> = BTreeMap::new();
+
+    for msg in messages {
+        let key = (
+            msg.from.name().to_string(),
+            msg.side.arrow(),
+            msg.to.name().to_string(),
+        );
+        let type_counts = groups.entry(key).or_default();
+        *type_counts
+            .entry(msg.payload.variant_name().to_string())
+            .or_default() += 1;
+    }
+
+    let mut out = String::new();
+    for ((from, arrow, to), type_counts) in &groups {
+        let types: Vec<String> = type_counts
+            .iter()
+            .map(|(t, c)| format!("{t} ({c})"))
+            .collect();
+        out.push_str(&format!(
+            "{from:<8} {arrow} {to:<8}: {}\n",
+            types.join(", ")
+        ));
+    }
+    out
+}
+
+fn summary_lines(messages: &[SyncMessage]) -> String {
+    let mut out = String::new();
+    for msg in messages {
+        out.push_str(&format!(
+            "{:<8} {} {:<8} {}",
+            msg.from.name(),
+            msg.side.arrow(),
+            msg.to.name(),
+            msg.payload.variant_name(),
+        ));
+        out.push('\n');
+    }
+    out
+}
+
+/// Normalize an expectation string: trim, remove blank lines, normalize whitespace.
+fn normalize_expectation(s: &str) -> Vec<String> {
+    s.lines()
+        .map(|l| l.trim())
+        .filter(|l| !l.is_empty())
+        .map(|l| {
+            // Collapse multiple spaces to single space for flexible formatting
+            let mut result = String::new();
+            let mut prev_space = false;
+            for c in l.chars() {
+                if c.is_whitespace() {
+                    if !prev_space {
+                        result.push(' ');
+                    }
+                    prev_space = true;
+                } else {
+                    result.push(c);
+                    prev_space = false;
+                }
+            }
+            result
+        })
+        .collect()
+}
+
+/// Name maps for resolving IDs to human-readable names in formatted output.
+struct Names<'a> {
+    objects: &'a HashMap<ObjectId, String>,
+    commits: &'a HashMap<CommitId, String>,
+}
+
+impl Names<'_> {
+    fn object(&self, id: &ObjectId) -> String {
+        self.objects
+            .get(id)
+            .cloned()
+            .unwrap_or_else(|| short_object_id(id))
+    }
+
+    fn commit(&self, id: &CommitId) -> String {
+        self.commits
+            .get(id)
+            .cloned()
+            .unwrap_or_else(|| short_commit_id(id))
+    }
+}
+
+/// Auto-normalizes dynamic values (commit hashes, branch names, object IDs)
+/// into deterministic labels for stable snapshot testing.
+struct Normalizer<'a> {
+    object_names: &'a HashMap<ObjectId, String>,
+    commit_map: HashMap<CommitId, String>,
+    next_commit: usize,
+    object_map: HashMap<ObjectId, String>,
+    next_object: usize,
+    branch_map: HashMap<String, String>,
+    next_branch: usize,
+}
+
+impl<'a> Normalizer<'a> {
+    fn new(object_names: &'a HashMap<ObjectId, String>) -> Self {
+        Self {
+            object_names,
+            commit_map: HashMap::new(),
+            next_commit: 1,
+            object_map: HashMap::new(),
+            next_object: 1,
+            branch_map: HashMap::new(),
+            next_branch: 1,
+        }
+    }
+
+    fn commit(&mut self, id: &CommitId) -> String {
+        self.commit_map
+            .entry(*id)
+            .or_insert_with(|| {
+                let name = format!("C{}", self.next_commit);
+                self.next_commit += 1;
+                name
+            })
+            .clone()
+    }
+
+    fn object(&mut self, id: &ObjectId) -> String {
+        if let Some(name) = self.object_names.get(id) {
+            return name.clone();
+        }
+        self.object_map
+            .entry(*id)
+            .or_insert_with(|| {
+                let name = format!("obj-{}", self.next_object);
+                self.next_object += 1;
+                name
+            })
+            .clone()
+    }
+
+    fn branch(&mut self, name: &crate::object::BranchName) -> String {
+        let raw = name.to_string();
+        self.branch_map
+            .entry(raw.clone())
+            .or_insert_with(|| {
+                // Strip "client-<random>-" prefix if present
+                if let Some(suffix) = raw.strip_prefix("client-")
+                    && let Some((_random, rest)) = suffix.split_once('-')
+                {
+                    return rest.to_string();
+                }
+                let label = format!("branch-{}", self.next_branch);
+                self.next_branch += 1;
+                label
+            })
+            .clone()
+    }
+
+    fn format_payload(&mut self, payload: &SyncPayload) -> String {
+        match payload {
+            SyncPayload::ObjectUpdated {
+                object_id,
+                branch_name,
+                commits,
+                ..
+            } => {
+                let commit_ids: Vec<String> =
+                    commits.iter().map(|c| self.commit(&c.id())).collect();
+                format!(
+                    "obj:{} branch:{} commits:[{}]",
+                    self.object(object_id),
+                    self.branch(branch_name),
+                    commit_ids.join(","),
+                )
+            }
+            SyncPayload::ObjectTruncated {
+                object_id,
+                branch_name,
+                tails,
+            } => {
+                let tail_ids: Vec<String> = tails.iter().map(|id| self.commit(id)).collect();
+                format!(
+                    "obj:{} branch:{} tails:[{}]",
+                    self.object(object_id),
+                    self.branch(branch_name),
+                    tail_ids.join(","),
+                )
+            }
+            SyncPayload::PersistenceAck {
+                object_id,
+                branch_name,
+                confirmed_commits,
+                tier,
+            } => {
+                let commit_ids: Vec<String> =
+                    confirmed_commits.iter().map(|id| self.commit(id)).collect();
+                format!(
+                    "obj:{} branch:{} confirmed:[{}] tier:{:?}",
+                    self.object(object_id),
+                    self.branch(branch_name),
+                    commit_ids.join(","),
+                    tier,
+                )
+            }
+            SyncPayload::QuerySubscription { query_id, .. } => {
+                format!("query:{}", query_id.0)
+            }
+            SyncPayload::QueryUnsubscription { query_id } => {
+                format!("query:{}", query_id.0)
+            }
+            SyncPayload::QuerySettled {
+                query_id,
+                tier,
+                through_seq,
+            } => {
+                format!(
+                    "query:{} tier:{:?} through_seq:{}",
+                    query_id.0, tier, through_seq
+                )
+            }
+            SyncPayload::SchemaWarning(w) => {
+                format!("query:{} table:{}", w.query_id.0, w.table_name)
+            }
+            SyncPayload::Error(e) => {
+                format!("{:?}", e)
+            }
+        }
+    }
+}
+
+fn format_trace(messages: &[SyncMessage], names: &Names<'_>) -> String {
+    let mut out = String::new();
+    for msg in messages {
+        let details = format_payload_details(&msg.payload, names);
+        out.push_str(&format!(
+            "{:<8} {} {:<8}  {:<20} {}\n",
+            msg.from.name(),
+            msg.side.arrow(),
+            msg.to.name(),
+            msg.payload.variant_name(),
+            details,
+        ));
+    }
+    out
+}
+
+fn format_messages(messages: &[SyncMessage], names: &Names<'_>) -> String {
+    let mut out = String::new();
+    for msg in messages {
+        out.push_str(&format_message(msg, names));
+        out.push('\n');
+    }
+    out
+}
+
+fn format_message(msg: &SyncMessage, names: &Names<'_>) -> String {
+    let details = format_payload_details(&msg.payload, names);
+    format!(
+        "[{:03}] +{:>5}ms  {:<8} {} {:<8}  {:<20} {}",
+        msg.seq,
+        msg.elapsed_ms,
+        msg.from.name(),
+        msg.side.arrow(),
+        msg.to.name(),
+        msg.payload.variant_name(),
+        details,
+    )
+}
+
+fn format_payload_details(payload: &SyncPayload, names: &Names<'_>) -> String {
+    match payload {
+        SyncPayload::ObjectUpdated {
+            object_id,
+            branch_name,
+            commits,
+            ..
+        } => {
+            let commit_ids: Vec<String> = commits.iter().map(|c| names.commit(&c.id())).collect();
+            format!(
+                "obj:{} branch:{} commits:[{}]",
+                names.object(object_id),
+                branch_name,
+                commit_ids.join(","),
+            )
+        }
+        SyncPayload::ObjectTruncated {
+            object_id,
+            branch_name,
+            tails,
+        } => {
+            let tail_ids: Vec<String> = tails.iter().map(|id| names.commit(id)).collect();
+            format!(
+                "obj:{} branch:{} tails:[{}]",
+                names.object(object_id),
+                branch_name,
+                tail_ids.join(","),
+            )
+        }
+        SyncPayload::PersistenceAck {
+            object_id,
+            branch_name,
+            confirmed_commits,
+            tier,
+        } => {
+            let commit_ids: Vec<String> = confirmed_commits
+                .iter()
+                .map(|id| names.commit(id))
+                .collect();
+            format!(
+                "obj:{} branch:{} confirmed:[{}] tier:{:?}",
+                names.object(object_id),
+                branch_name,
+                commit_ids.join(","),
+                tier,
+            )
+        }
+        SyncPayload::QuerySubscription { query_id, .. } => {
+            format!("query:{}", query_id.0)
+        }
+        SyncPayload::QueryUnsubscription { query_id } => {
+            format!("query:{}", query_id.0)
+        }
+        SyncPayload::QuerySettled {
+            query_id,
+            tier,
+            through_seq,
+        } => {
+            format!(
+                "query:{} tier:{:?} through_seq:{}",
+                query_id.0, tier, through_seq,
+            )
+        }
+        SyncPayload::SchemaWarning(w) => {
+            format!("query:{} table:{}", w.query_id.0, w.table_name)
+        }
+        SyncPayload::Error(e) => {
+            format!("{:?}", e)
+        }
+    }
+}
+
+/// First 4 bytes of a CommitId as hex (8 chars).
+fn short_commit_id(id: &CommitId) -> String {
+    hex::encode(&id.0[..4])
+}
+
+/// First 8 chars of an ObjectId UUID.
+fn short_object_id(id: &ObjectId) -> String {
+    let s = id.to_string();
+    s[..8.min(s.len())].to_string()
+}
+
+/// First 8 chars of a UUID.
+fn short_uuid(uuid: &uuid::Uuid) -> String {
+    let s = uuid.to_string();
+    s[..8.min(s.len())].to_string()
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commit::Commit;
+    use crate::object::BranchName;
+    use crate::sync_manager::ServerId;
+    use smallvec::smallvec;
+
+    fn make_commit(byte: u8) -> Commit {
+        Commit {
+            parents: smallvec![],
+            content: vec![byte],
+            timestamp: 1000,
+            author: ObjectId::new(),
+            metadata: None,
+            stored_state: Default::default(),
+            ack_state: Default::default(),
+        }
+    }
+
+    #[test]
+    fn record_and_query() {
+        let tracer = SyncTracer::new();
+        let server_id = ServerId::default();
+
+        let payload = SyncPayload::ObjectUpdated {
+            object_id: ObjectId::new(),
+            metadata: None,
+            branch_name: BranchName::from("main"),
+            commits: vec![make_commit(1)],
+        };
+
+        tracer.record_outgoing("alice", &Destination::Server(server_id), &payload);
+        tracer.record_outgoing(
+            "server",
+            &Destination::Client(ClientId::default()),
+            &payload,
+        );
+
+        assert_eq!(tracer.count(), 2);
+        assert_eq!(tracer.from("alice").len(), 1);
+        assert_eq!(tracer.from("server").len(), 1);
+        assert_eq!(tracer.of_type("ObjectUpdated").len(), 2);
+        assert_eq!(tracer.of_type("PersistenceAck").len(), 0);
+    }
+
+    #[test]
+    fn between_filters_both_directions() {
+        let tracer = SyncTracer::new();
+        let server_id = ServerId::default();
+
+        let obj_id = ObjectId::new();
+        let outgoing = SyncPayload::ObjectUpdated {
+            object_id: obj_id,
+            metadata: None,
+            branch_name: BranchName::from("main"),
+            commits: vec![make_commit(1)],
+        };
+        let incoming = SyncPayload::PersistenceAck {
+            object_id: obj_id,
+            branch_name: BranchName::from("main"),
+            confirmed_commits: std::collections::HashSet::new(),
+            tier: crate::sync_manager::DurabilityTier::EdgeServer,
+        };
+
+        tracer.record_outgoing("alice", &Destination::Server(server_id), &outgoing);
+        tracer.record_incoming(&Source::Server(server_id), "alice", &incoming);
+
+        let msgs = tracer.between("alice", "server");
+        assert_eq!(msgs.len(), 2);
+        assert!(msgs[0].is_object_updated());
+        assert!(msgs[1].is_persistence_ack());
+    }
+
+    #[test]
+    fn dump_produces_readable_output() {
+        let tracer = SyncTracer::new();
+        let server_id = ServerId::default();
+
+        let payload = SyncPayload::ObjectUpdated {
+            object_id: ObjectId::new(),
+            metadata: None,
+            branch_name: BranchName::from("main"),
+            commits: vec![make_commit(1)],
+        };
+
+        tracer.record_outgoing("alice", &Destination::Server(server_id), &payload);
+
+        let dump = tracer.dump();
+        assert!(dump.contains("alice"));
+        assert!(dump.contains("server"));
+        assert!(dump.contains("ObjectUpdated"));
+        assert!(dump.contains("branch:main"));
+    }
+
+    #[test]
+    fn clear_resets_state() {
+        let tracer = SyncTracer::new();
+        let server_id = ServerId::default();
+
+        let payload = SyncPayload::QueryUnsubscription {
+            query_id: QueryId(42),
+        };
+        tracer.record_outgoing("bob", &Destination::Server(server_id), &payload);
+        assert_eq!(tracer.count(), 1);
+
+        tracer.clear();
+        assert_eq!(tracer.count(), 0);
+    }
+
+    #[test]
+    fn client_name_resolution() {
+        let tracer = SyncTracer::new();
+        let cid = ClientId::default();
+        tracer.register_client(cid, "bob");
+
+        let payload = SyncPayload::QueryUnsubscription {
+            query_id: QueryId(1),
+        };
+        tracer.record_outgoing("server", &Destination::Client(cid), &payload);
+
+        let msgs = tracer.to("bob");
+        assert_eq!(msgs.len(), 1);
+    }
+}

--- a/crates/jazz-tools/src/sync_tracer.rs
+++ b/crates/jazz-tools/src/sync_tracer.rs
@@ -354,6 +354,39 @@ impl SyncTracer {
         self.inner.lock().unwrap().messages.len()
     }
 
+    /// Wait until the tally output stops changing (no new messages for
+    /// `stable_for` consecutive polls at 50ms intervals).
+    ///
+    /// Panics with the current tally if `timeout` expires before stabilising.
+    #[cfg(feature = "test")]
+    pub async fn wait_until_settled(&self, timeout: std::time::Duration) {
+        let stable_for_target = 3; // require 3 consecutive identical polls (~150ms quiet)
+        let mut stable_count = 0u32;
+        let mut last_tally = String::new();
+        let start = Instant::now();
+
+        loop {
+            let current = self.tally();
+            if current == last_tally && !current.is_empty() {
+                stable_count += 1;
+                if stable_count >= stable_for_target {
+                    return;
+                }
+            } else {
+                stable_count = 0;
+                last_tally = current;
+            }
+            if start.elapsed() >= timeout {
+                panic!(
+                    "SyncTracer: timed out waiting for tally to settle\n\
+                     Current tally:\n{}",
+                    self.tally()
+                );
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+    }
+
     /// Clear all recorded messages and reset sequence counter.
     pub fn clear(&self) {
         let mut inner = self.inner.lock().unwrap();

--- a/crates/jazz-tools/src/sync_tracer.rs
+++ b/crates/jazz-tools/src/sync_tracer.rs
@@ -149,7 +149,11 @@ impl SyncMessage {
             SyncPayload::ObjectUpdated { commits, .. } => commits.iter().map(|c| c.id()).collect(),
             SyncPayload::PersistenceAck {
                 confirmed_commits, ..
-            } => confirmed_commits.iter().copied().collect(),
+            } => {
+                let mut ids: Vec<_> = confirmed_commits.iter().copied().collect();
+                ids.sort();
+                ids
+            }
             _ => vec![],
         }
     }
@@ -367,7 +371,7 @@ impl SyncTracer {
 
         loop {
             let current = self.tally();
-            if current == last_tally && !current.is_empty() {
+            if current == last_tally {
                 stable_count += 1;
                 if stable_count >= stable_for_target {
                     return;
@@ -870,7 +874,9 @@ impl<'a> Normalizer<'a> {
                 branch_name,
                 tails,
             } => {
-                let tail_ids: Vec<String> = tails.iter().map(|id| self.commit(id)).collect();
+                let mut sorted_tails: Vec<_> = tails.iter().collect();
+                sorted_tails.sort();
+                let tail_ids: Vec<String> = sorted_tails.iter().map(|id| self.commit(id)).collect();
                 format!(
                     "obj:{} branch:{} tails:[{}]",
                     self.object(object_id),
@@ -884,8 +890,10 @@ impl<'a> Normalizer<'a> {
                 confirmed_commits,
                 tier,
             } => {
+                let mut sorted_commits: Vec<_> = confirmed_commits.iter().collect();
+                sorted_commits.sort();
                 let commit_ids: Vec<String> =
-                    confirmed_commits.iter().map(|id| self.commit(id)).collect();
+                    sorted_commits.iter().map(|id| self.commit(id)).collect();
                 format!(
                     "obj:{} branch:{} confirmed:[{}] tier:{:?}",
                     self.object(object_id),
@@ -980,7 +988,8 @@ fn format_payload_details(payload: &SyncPayload, names: &Names<'_>) -> String {
             branch_name,
             tails,
         } => {
-            let tail_ids: Vec<String> = tails.iter().map(|id| names.commit(id)).collect();
+            let mut tail_ids: Vec<String> = tails.iter().map(|id| names.commit(id)).collect();
+            tail_ids.sort();
             format!(
                 "obj:{} branch:{} tails:[{}]",
                 names.object(object_id),
@@ -994,10 +1003,11 @@ fn format_payload_details(payload: &SyncPayload, names: &Names<'_>) -> String {
             confirmed_commits,
             tier,
         } => {
-            let commit_ids: Vec<String> = confirmed_commits
+            let mut commit_ids: Vec<String> = confirmed_commits
                 .iter()
                 .map(|id| names.commit(id))
                 .collect();
+            commit_ids.sort();
             format!(
                 "obj:{} branch:{} confirmed:[{}] tier:{:?}",
                 names.object(object_id),

--- a/crates/jazz-tools/src/sync_tracer.rs
+++ b/crates/jazz-tools/src/sync_tracer.rs
@@ -1032,7 +1032,7 @@ mod tests {
             parents: smallvec![],
             content: vec![byte],
             timestamp: 1000,
-            author: ObjectId::new(),
+            author: ObjectId::new().to_string(),
             metadata: None,
             stored_state: Default::default(),
             ack_state: Default::default(),

--- a/crates/jazz-tools/tests/.gitignore
+++ b/crates/jazz-tools/tests/.gitignore
@@ -1,0 +1,1 @@
+.sync_tracer_integration.rs.pending-snap

--- a/crates/jazz-tools/tests/client_restart_integration.rs
+++ b/crates/jazz-tools/tests/client_restart_integration.rs
@@ -211,6 +211,7 @@ fn make_context(
         jwt_token: Some(jwt_token),
         backend_secret: Some(BACKEND_SECRET.to_string()),
         admin_secret: Some(ADMIN_SECRET.to_string()),
+        sync_tracer: None,
     }
 }
 
@@ -423,6 +424,7 @@ async fn memory_storage_client_does_not_persist_local_state_to_disk() {
         jwt_token: None,
         backend_secret: None,
         admin_secret: None,
+        sync_tracer: None,
     };
 
     let client = JazzClient::connect(context.clone())

--- a/crates/jazz-tools/tests/policies_integration/session_cases.rs
+++ b/crates/jazz-tools/tests/policies_integration/session_cases.rs
@@ -10,6 +10,7 @@ use jazz_tools::middleware::auth::{LocalAuthMode, derive_local_principal_id};
 use jazz_tools::query_manager::policy::PolicyExpr;
 use jazz_tools::query_manager::types::{TablePolicies, TableSchemaBuilder};
 use jazz_tools::server::TestingServer;
+use jazz_tools::sync_tracer::SyncTracer;
 use jazz_tools::{
     ColumnType, DurabilityTier, JazzClient, ObjectId, QueryBuilder, Schema, SchemaBuilder,
     TableSchema, Value,

--- a/crates/jazz-tools/tests/rocksdb_storage_integration.rs
+++ b/crates/jazz-tools/tests/rocksdb_storage_integration.rs
@@ -84,6 +84,7 @@ async fn make_client_external_jwks(
         jwt_token: Some(TestingServer::jwt_for_user(user_id)),
         backend_secret: Some(TestingServer::BACKEND_SECRET.to_string()),
         admin_secret: Some(TestingServer::ADMIN_SECRET.to_string()),
+        sync_tracer: None,
     };
 
     let client = JazzClient::connect(context).await.expect("connect client");

--- a/crates/jazz-tools/tests/subscribe_all_integration.rs
+++ b/crates/jazz-tools/tests/subscribe_all_integration.rs
@@ -8,6 +8,7 @@ use std::time::Duration;
 use jazz_tools::query_manager::encoding::decode_row;
 use jazz_tools::query_manager::types::RowDescriptor;
 use jazz_tools::server::TestingServer;
+use jazz_tools::sync_tracer::SyncTracer;
 use jazz_tools::{
     AppContext, AppId, ClientStorage, ColumnType, JazzClient, ObjectId, OrderedRowDelta, Query,
     QueryBuilder, Schema, SchemaBuilder, TableSchema, Value,
@@ -77,22 +78,42 @@ struct ClientPair {
 
 impl ClientPair {
     async fn start() -> Self {
-        let server = TestingServer::start().await;
+        Self::start_inner(None).await
+    }
+
+    async fn start_traced(tracer: &jazz_tools::sync_tracer::SyncTracer) -> Self {
+        Self::start_inner(Some(tracer)).await
+    }
+
+    async fn start_inner(tracer: Option<&jazz_tools::sync_tracer::SyncTracer>) -> Self {
+        let server = if let Some(t) = tracer {
+            TestingServer::builder()
+                .with_tracer(t.clone())
+                .start()
+                .await
+        } else {
+            TestingServer::start().await
+        };
         let schema = subscription_schema();
-        let writer = TestingClient::builder()
+        let mut writer_builder = TestingClient::builder()
             .with_server(&server)
             .with_schema(schema.clone())
             .with_user_id("subscribe-all-writer")
-            .ready_on("todos", READY_TIMEOUT)
-            .connect()
-            .await;
-        let subscriber = TestingClient::builder()
+            .ready_on("todos", READY_TIMEOUT);
+        if let Some(t) = tracer {
+            writer_builder = writer_builder.with_tracer(t, "alice");
+        }
+        let writer = writer_builder.connect().await;
+
+        let mut subscriber_builder = TestingClient::builder()
             .with_server(&server)
             .with_schema(schema)
             .with_user_id("subscribe-all-subscriber")
-            .ready_on("todos", READY_TIMEOUT)
-            .connect()
-            .await;
+            .ready_on("todos", READY_TIMEOUT);
+        if let Some(t) = tracer {
+            subscriber_builder = subscriber_builder.with_tracer(t, "bob");
+        }
+        let subscriber = subscriber_builder.connect().await;
 
         Self {
             server,
@@ -340,6 +361,7 @@ async fn start_local_client(schema: Schema) -> (TempDir, JazzClient) {
         jwt_token: None,
         backend_secret: None,
         admin_secret: None,
+        sync_tracer: None,
     };
 
     let client = JazzClient::connect(context)

--- a/crates/jazz-tools/tests/support/mod.rs
+++ b/crates/jazz-tools/tests/support/mod.rs
@@ -117,6 +117,7 @@ pub struct TestingClient<'a> {
     storage: TestingClientStorage,
     ready_table: Option<String>,
     ready_timeout: Option<Duration>,
+    sync_tracer: Option<(jazz_tools::sync_tracer::SyncTracer, String)>,
 }
 
 #[allow(dead_code)]
@@ -130,6 +131,7 @@ impl<'a> TestingClient<'a> {
             storage: TestingClientStorage::Memory,
             ready_table: None,
             ready_timeout: None,
+            sync_tracer: None,
         }
     }
 
@@ -173,6 +175,15 @@ impl<'a> TestingClient<'a> {
 
     pub fn with_persistent_storage(mut self) -> Self {
         self.storage = TestingClientStorage::Persistent;
+        self
+    }
+
+    pub fn with_tracer(
+        mut self,
+        tracer: &jazz_tools::sync_tracer::SyncTracer,
+        name: impl Into<String>,
+    ) -> Self {
+        self.sync_tracer = Some((tracer.clone(), name.into()));
         self
     }
 
@@ -247,6 +258,8 @@ impl<'a> TestingClient<'a> {
             TestingClientStorage::Memory => ClientStorage::Memory,
             TestingClientStorage::Persistent => ClientStorage::Persistent,
         };
+
+        context.sync_tracer = self.sync_tracer.clone();
 
         context
     }

--- a/crates/jazz-tools/tests/sync_tracer_integration.rs
+++ b/crates/jazz-tools/tests/sync_tracer_integration.rs
@@ -176,18 +176,44 @@ async fn bob_updates_alice_todo() {
     )
     .await;
 
-    insta::assert_snapshot!(tracer.tally_for("alice"), @"
-    alice    -> server  : QuerySubscription (1)
-    alice    => server  : QuerySubscription (1), QueryUnsubscription (1)
-    server   -> alice   : ObjectUpdated (2), QuerySettled (2)
-    server   => alice   : ObjectUpdated (2), QuerySettled (2)
-    ");
+    tracer.wait_until_settled(Duration::from_secs(10)).await;
 
-    insta::assert_snapshot!(tracer.tally_for("bob"), @"
-    bob      -> server  : ObjectUpdated (1), QueryUnsubscription (1)
-    bob      => server  : ObjectUpdated (1)
-    server   => bob     : PersistenceAck (2)
-    ");
+    // Assert message flow shape (types present, not exact counts — the server
+    // may batch ObjectUpdated messages non-deterministically).
+    tracer.expect_contains(
+        "
+        alice    -> server   QuerySubscription
+        server   -> alice    ObjectUpdated
+        server   -> alice    QuerySettled
+    ",
+    );
+    tracer.expect_contains(
+        "
+        bob      -> server   ObjectUpdated
+        server   -> bob      PersistenceAck
+    ",
+    );
+
+    // Bob sent an ObjectUpdated to server
+    let bob_sent = tracer.from("bob");
+    assert!(
+        bob_sent.iter().any(|m| m.is_object_updated()),
+        "bob should have sent ObjectUpdated"
+    );
+
+    // Alice received at least one ObjectUpdated from server
+    let alice_recv = tracer.to("alice");
+    assert!(
+        alice_recv.iter().any(|m| m.is_object_updated()),
+        "alice should have received ObjectUpdated from server"
+    );
+
+    // Bob received PersistenceAck from server
+    let bob_recv = tracer.to("bob");
+    assert!(
+        bob_recv.iter().any(|m| m.is_persistence_ack()),
+        "bob should have received PersistenceAck"
+    );
 
     alice.shutdown().await.expect("shutdown alice");
     bob.shutdown().await.expect("shutdown bob");
@@ -226,8 +252,7 @@ async fn single_writer_flow() {
         .await
         .expect("create todo");
 
-    // Wait for server round-trip
-    tokio::time::sleep(Duration::from_millis(500)).await;
+    tracer.wait_until_settled(Duration::from_secs(10)).await;
 
     insta::assert_snapshot!(tracer.tally(), @"
     alice    -> server  : ObjectUpdated (1), QueryUnsubscription (1)
@@ -276,8 +301,7 @@ async fn named_object_trace() {
 
     tracer.register_object(todo_id, "my-todo");
 
-    // Wait for server round-trip
-    tokio::time::sleep(Duration::from_millis(500)).await;
+    tracer.wait_until_settled(Duration::from_secs(10)).await;
 
     insta::assert_snapshot!(tracer.trace_normalized(), @"
     # => sent, -> received

--- a/crates/jazz-tools/tests/sync_tracer_integration.rs
+++ b/crates/jazz-tools/tests/sync_tracer_integration.rs
@@ -176,13 +176,16 @@ async fn bob_updates_alice_todo() {
     )
     .await;
 
-    insta::assert_snapshot!(tracer.tally(), @"
+    insta::assert_snapshot!(tracer.tally_for("alice"), @"
     alice    -> server  : QuerySubscription (1)
     alice    => server  : QuerySubscription (1), QueryUnsubscription (1)
-    bob      -> server  : ObjectUpdated (1), QueryUnsubscription (1)
-    bob      => server  : ObjectUpdated (1)
     server   -> alice   : ObjectUpdated (2), QuerySettled (2)
     server   => alice   : ObjectUpdated (2), QuerySettled (2)
+    ");
+
+    insta::assert_snapshot!(tracer.tally_for("bob"), @"
+    bob      -> server  : ObjectUpdated (1), QueryUnsubscription (1)
+    bob      => server  : ObjectUpdated (1)
     server   => bob     : PersistenceAck (2)
     ");
 

--- a/crates/jazz-tools/tests/sync_tracer_integration.rs
+++ b/crates/jazz-tools/tests/sync_tracer_integration.rs
@@ -1,0 +1,292 @@
+#![cfg(feature = "test")]
+
+mod support;
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use jazz_tools::server::TestingServer;
+use jazz_tools::sync_tracer::SyncTracer;
+use jazz_tools::{ColumnType, DurabilityTier, QueryBuilder, SchemaBuilder, TableSchema, Value};
+use support::{TestingClient, wait_for_query};
+
+fn test_schema() -> jazz_tools::Schema {
+    SchemaBuilder::new()
+        .table(
+            TableSchema::builder("todos")
+                .column("title", ColumnType::Text)
+                .column("completed", ColumnType::Boolean),
+        )
+        .build()
+}
+
+/// Alice creates a todo, bob sees it. The tracer captures the full flow.
+///
+/// ```text
+/// alice ──ObjectUpdated──► server ──ObjectUpdated──► bob
+///       ◄──PersistenceAck──
+/// ```
+#[tokio::test]
+async fn alice_write_bob_read() {
+    let tracer = SyncTracer::new();
+
+    let server = TestingServer::builder()
+        .with_tracer(tracer.clone())
+        .start()
+        .await;
+
+    let alice = TestingClient::builder()
+        .with_server(&server)
+        .with_schema(test_schema())
+        .with_user_id("alice")
+        .with_tracer(&tracer, "alice")
+        .ready_on("todos", Duration::from_secs(30))
+        .connect()
+        .await;
+
+    let bob = TestingClient::builder()
+        .with_server(&server)
+        .with_schema(test_schema())
+        .with_user_id("bob")
+        .with_tracer(&tracer, "bob")
+        .ready_on("todos", Duration::from_secs(30))
+        .connect()
+        .await;
+
+    // Clear catalogue/schema setup noise
+    tracer.clear();
+
+    alice
+        .create(
+            "todos",
+            HashMap::from([
+                ("title".to_string(), Value::Text("traced-todo".to_string())),
+                ("completed".to_string(), Value::Boolean(false)),
+            ]),
+        )
+        .await
+        .expect("alice creates todo");
+
+    wait_for_query(
+        &bob,
+        QueryBuilder::new("todos").build(),
+        Some(DurabilityTier::EdgeServer),
+        Duration::from_secs(25),
+        "bob sees traced-todo",
+        |rows| (rows.len() == 1).then_some(rows),
+    )
+    .await;
+
+    insta::assert_snapshot!(tracer.tally(), @"
+    alice    -> server  : ObjectUpdated (1)
+    alice    => server  : ObjectUpdated (1)
+    bob      -> server  : QuerySubscription (1), QueryUnsubscription (1)
+    bob      => server  : QuerySubscription (1), QueryUnsubscription (1)
+    server   -> alice   : PersistenceAck (2)
+    server   -> bob     : ObjectUpdated (1), QuerySettled (2)
+    server   => alice   : PersistenceAck (2)
+    server   => bob     : ObjectUpdated (1), QuerySettled (2)
+    ");
+
+    alice.shutdown().await.expect("shutdown alice");
+    bob.shutdown().await.expect("shutdown bob");
+    server.shutdown().await;
+}
+
+/// Bob updates alice's todo. The round-trip is visible in the trace.
+///
+/// ```text
+/// alice ──create──► server ──► bob
+/// bob   ──update──► server ──► alice
+/// ```
+#[tokio::test]
+async fn bob_updates_alice_todo() {
+    let tracer = SyncTracer::new();
+
+    let server = TestingServer::builder()
+        .with_tracer(tracer.clone())
+        .start()
+        .await;
+
+    let alice = TestingClient::builder()
+        .with_server(&server)
+        .with_schema(test_schema())
+        .with_user_id("alice")
+        .with_tracer(&tracer, "alice")
+        .ready_on("todos", Duration::from_secs(30))
+        .connect()
+        .await;
+
+    let bob = TestingClient::builder()
+        .with_server(&server)
+        .with_schema(test_schema())
+        .with_user_id("bob")
+        .with_tracer(&tracer, "bob")
+        .ready_on("todos", Duration::from_secs(30))
+        .connect()
+        .await;
+
+    tracer.clear();
+
+    // Alice creates
+    let (todo_id, _) = alice
+        .create(
+            "todos",
+            HashMap::from([
+                ("title".to_string(), Value::Text("collab-todo".to_string())),
+                ("completed".to_string(), Value::Boolean(false)),
+            ]),
+        )
+        .await
+        .expect("alice creates todo");
+
+    // Bob sees it
+    wait_for_query(
+        &bob,
+        QueryBuilder::new("todos").build(),
+        Some(DurabilityTier::EdgeServer),
+        Duration::from_secs(25),
+        "bob sees todo",
+        |rows| (rows.len() == 1).then_some(rows),
+    )
+    .await;
+
+    tracer.clear();
+
+    // Bob updates
+    bob.update(
+        todo_id,
+        vec![("completed".to_string(), Value::Boolean(true))],
+    )
+    .await
+    .expect("bob updates todo");
+
+    // Alice sees the update
+    wait_for_query(
+        &alice,
+        QueryBuilder::new("todos").build(),
+        Some(DurabilityTier::EdgeServer),
+        Duration::from_secs(25),
+        "alice sees completed=true",
+        |rows| {
+            rows.iter()
+                .any(|(_, vals)| vals.iter().any(|v| matches!(v, Value::Boolean(true))))
+                .then_some(rows)
+        },
+    )
+    .await;
+
+    insta::assert_snapshot!(tracer.tally(), @"
+    alice    -> server  : QuerySubscription (1)
+    alice    => server  : QuerySubscription (1), QueryUnsubscription (1)
+    bob      -> server  : ObjectUpdated (1), QueryUnsubscription (1)
+    bob      => server  : ObjectUpdated (1)
+    server   -> alice   : ObjectUpdated (2), QuerySettled (2)
+    server   => alice   : ObjectUpdated (2), QuerySettled (2)
+    server   => bob     : PersistenceAck (2)
+    ");
+
+    alice.shutdown().await.expect("shutdown alice");
+    bob.shutdown().await.expect("shutdown bob");
+    server.shutdown().await;
+}
+
+/// Single-writer flow: alice writes, server acks.
+#[tokio::test]
+async fn single_writer_flow() {
+    let tracer = SyncTracer::new();
+
+    let server = TestingServer::builder()
+        .with_tracer(tracer.clone())
+        .start()
+        .await;
+
+    let alice = TestingClient::builder()
+        .with_server(&server)
+        .with_schema(test_schema())
+        .with_user_id("alice")
+        .with_tracer(&tracer, "alice")
+        .ready_on("todos", Duration::from_secs(30))
+        .connect()
+        .await;
+
+    tracer.clear();
+
+    alice
+        .create(
+            "todos",
+            HashMap::from([
+                ("title".to_string(), Value::Text("solo-todo".to_string())),
+                ("completed".to_string(), Value::Boolean(false)),
+            ]),
+        )
+        .await
+        .expect("create todo");
+
+    // Wait for server round-trip
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    insta::assert_snapshot!(tracer.tally(), @"
+    alice    -> server  : ObjectUpdated (1), QueryUnsubscription (1)
+    alice    => server  : ObjectUpdated (1)
+    server   -> alice   : PersistenceAck (2)
+    server   => alice   : PersistenceAck (2)
+    ");
+
+    alice.shutdown().await.expect("shutdown alice");
+    server.shutdown().await;
+}
+
+/// Named objects: trace shows "my-todo" instead of hex IDs.
+///
+/// Single-writer so message order is deterministic — safe for `trace()` snapshots.
+#[tokio::test]
+async fn named_object_trace() {
+    let tracer = SyncTracer::new();
+
+    let server = TestingServer::builder()
+        .with_tracer(tracer.clone())
+        .start()
+        .await;
+
+    let alice = TestingClient::builder()
+        .with_server(&server)
+        .with_schema(test_schema())
+        .with_user_id("alice")
+        .with_tracer(&tracer, "alice")
+        .ready_on("todos", Duration::from_secs(30))
+        .connect()
+        .await;
+
+    tracer.clear();
+
+    let (todo_id, _) = alice
+        .create(
+            "todos",
+            HashMap::from([
+                ("title".to_string(), Value::Text("buy milk".to_string())),
+                ("completed".to_string(), Value::Boolean(false)),
+            ]),
+        )
+        .await
+        .expect("create todo");
+
+    tracer.register_object(todo_id, "my-todo");
+
+    // Wait for server round-trip
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    insta::assert_snapshot!(tracer.trace_normalized(), @"
+    # => sent, -> received
+    alice    => server    ObjectUpdated        obj:my-todo branch:main commits:[C1]
+    alice    -> server    ObjectUpdated        obj:my-todo branch:main commits:[C1]
+    alice    -> server    QueryUnsubscription  query:0
+    server   => alice     PersistenceAck       obj:my-todo branch:main confirmed:[C1] tier:EdgeServer
+    server   -> alice     PersistenceAck       obj:my-todo branch:main confirmed:[C1] tier:EdgeServer
+    server   => alice     PersistenceAck       obj:my-todo branch:main confirmed:[C1] tier:GlobalServer
+    server   -> alice     PersistenceAck       obj:my-todo branch:main confirmed:[C1] tier:GlobalServer
+    ");
+
+    alice.shutdown().await.expect("shutdown alice");
+    server.shutdown().await;
+}

--- a/examples/docs/todo-server-rs/src/main.rs
+++ b/examples/docs/todo-server-rs/src/main.rs
@@ -114,6 +114,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         jwt_token: None,
         backend_secret: None,
         admin_secret: None,
+        sync_tracer: None,
     };
     // #endregion context-setup-rust-backend
 

--- a/examples/docs/todo-server-rs/tests/integration.rs
+++ b/examples/docs/todo-server-rs/tests/integration.rs
@@ -88,6 +88,7 @@ async fn setup_test_app_with_path(data_dir: PathBuf) -> Router {
         jwt_token: None,
         backend_secret: None,
         admin_secret: None,
+        sync_tracer: None,
     };
 
     let client = JazzClient::connect(context).await.unwrap();
@@ -455,6 +456,7 @@ async fn test_local_persistence() {
             jwt_token: None,
             backend_secret: None,
             admin_secret: None,
+            sync_tracer: None,
         };
         let client = JazzClient::connect(context).await.unwrap();
 
@@ -485,6 +487,7 @@ async fn test_local_persistence() {
             jwt_token: None,
             backend_secret: None,
             admin_secret: None,
+            sync_tracer: None,
         };
         let client = JazzClient::connect(context).await.unwrap();
 
@@ -748,6 +751,7 @@ async fn test_server_resync() {
             jwt_token: Some(make_test_jwt("client1-user")),
             backend_secret: None,
             admin_secret: Some(TEST_ADMIN_SECRET.to_string()),
+            sync_tracer: None,
         };
         let client = JazzClient::connect(context).await.unwrap();
 
@@ -786,6 +790,7 @@ async fn test_server_resync() {
             jwt_token: Some(make_test_jwt("client2-user")),
             backend_secret: None,
             admin_secret: None, // Intentionally no admin - server already has schema
+            sync_tracer: None,
         };
         let client = JazzClient::connect(context).await.unwrap();
 

--- a/examples/todo-server-rs/src/main.rs
+++ b/examples/todo-server-rs/src/main.rs
@@ -112,6 +112,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         jwt_token: None,
         backend_secret: None,
         admin_secret: None,
+        sync_tracer: None,
     };
 
     let client = JazzClient::connect(context).await?;

--- a/examples/todo-server-rs/tests/integration.rs
+++ b/examples/todo-server-rs/tests/integration.rs
@@ -88,6 +88,7 @@ async fn setup_test_app_with_path(data_dir: PathBuf) -> Router {
         jwt_token: None,
         backend_secret: None,
         admin_secret: None,
+        sync_tracer: None,
     };
 
     let client = JazzClient::connect(context).await.unwrap();
@@ -455,6 +456,7 @@ async fn test_local_persistence() {
             jwt_token: None,
             backend_secret: None,
             admin_secret: None,
+            sync_tracer: None,
         };
         let client = JazzClient::connect(context).await.unwrap();
 
@@ -485,6 +487,7 @@ async fn test_local_persistence() {
             jwt_token: None,
             backend_secret: None,
             admin_secret: None,
+            sync_tracer: None,
         };
         let client = JazzClient::connect(context).await.unwrap();
 
@@ -748,6 +751,7 @@ async fn test_server_resync() {
             jwt_token: Some(make_test_jwt("client1-user")),
             backend_secret: None,
             admin_secret: Some(TEST_ADMIN_SECRET.to_string()),
+            sync_tracer: None,
         };
         let client = JazzClient::connect(context).await.unwrap();
 
@@ -786,6 +790,7 @@ async fn test_server_resync() {
             jwt_token: Some(make_test_jwt("client2-user")),
             backend_secret: None,
             admin_secret: None, // Intentionally no admin - server already has schema
+            sync_tracer: None,
         };
         let client = JazzClient::connect(context).await.unwrap();
 


### PR DESCRIPTION
**Summary**
Adds SyncTracer - a test-only message recorder that captures every sync protocol message flowing between named participants and provides querying, pretty-printing, and insta snapshot support for deterministic test assertions.

**The problem**
Debugging multi-client sync flows (alice writes → server persists → bob receives) requires reasoning about async message interleaving across HTTP and SSE boundaries. Without visibility into what actually happened on the wire, sync bugs manifest as flaky timeouts or wrong query results with no trail to follow.

**Setup**
```rs
let tracer = SyncTracer::new();

let server = TestingServer::builder()
    .with_tracer(tracer.clone())
    .start()
    .await;

let alice = TestingClient::builder()
    .with_server(&server)
    .with_schema(schema)
    .with_user_id("alice")
    .with_tracer(&tracer, "alice")   // name for trace output
    .connect()
    .await;

let bob = TestingClient::builder()
    .with_server(&server)
    .with_schema(schema)
    .with_user_id("bob")
    .with_tracer(&tracer, "bob")
    .connect()
    .await;

// Clear catalogue/schema handshake noise before the interesting part
tracer.clear();
```
**API**
```rs
tracer.messages()                    // all recorded messages
tracer.from("alice")                 // messages sent by alice
tracer.to("bob")                     // messages received by bob
tracer.between("alice", "server")    // both directions
tracer.for_object(todo_id)           // messages about a specific object
tracer.of_type("PersistenceAck")     // by payload variant name
tracer.count()                       // total message count
```

## Output formats
`dump()` — full detail with timestamps, sequence numbers, registered names:

```
[001] +  0ms  alice    => server    ObjectUpdated        obj:my-todo branch:main commits:[e5f6a7b8]
[002] +  3ms  server   -> alice     PersistenceAck       obj:my-todo confirmed:[e5f6a7b8] tier:EdgeServer
```

`tally()` — deterministic grouped counts, stable for snapshots regardless of message ordering:

```
alice    -> server  : ObjectUpdated (1)
alice    => server  : ObjectUpdated (1)
server   -> alice   : PersistenceAck (2)
server   => alice   : PersistenceAck (2)
```

`trace_normalized()` — sorted, with auto-assigned deterministic labels (C1, C2, ...) for commits and stripped branch prefixes. Registered object names are preserved; unregistered objects get obj-1, obj-2:

```
# => sent, -> received
alice    => server    ObjectUpdated        obj:my-todo branch:main commits:[C1]
alice    -> server    ObjectUpdated        obj:my-todo branch:main commits:[C1]
server   => alice     PersistenceAck       obj:my-todo branch:main confirmed:[C1] tier:EdgeServer
server   -> alice     PersistenceAck       obj:my-todo branch:main confirmed:[C1] tier:GlobalServer
```

Arrows distinguish recording side: 

`=>` = recorded by sender (outgoing hook)

`->` = recorded by receiver (incoming hook).

## Snapshot 

I added `insta` for inline snapshots:
```rs
// tally() for message-count assertions (order-independent)
insta::assert_snapshot!(tracer.tally(), @"
alice    -> server  : ObjectUpdated (1)
server   -> alice   : PersistenceAck (2)
");

// trace_normalized() for exact message-level assertions
tracer.register_object(todo_id, "my-todo");
insta::assert_snapshot!(tracer.trace_normalized(), @"
# => sent, -> received
alice    => server    ObjectUpdated        obj:my-todo branch:main commits:[C1]
server   => alice     PersistenceAck       obj:my-todo branch:main confirmed:[C1] tier:EdgeServer
");
```
When the sync protocol changes and existing snapshots break:
```bash
# Run tests — insta shows diffs for mismatched inline snapshots
cargo test -p jazz-tools --features test sync_tracer

# Review and accept all pending snapshots interactively
cargo insta review
```

**Shape assertions** (for multi-writer tests where exact ordering is non-deterministic):

```rs
// Exact match (same count, same order)
tracer.expect("
    alice  -> server  ObjectUpdated
    server -> alice   PersistenceAck
");

// Subsequence match (expected lines appear in order, but other messages may exist between them)
tracer.expect_contains("
    bob    -> server  ObjectUpdated
    server -> alice   ObjectUpdated
");
```

