### PR TITLE
Fix Svelte state_referenced_locally warnings

### DIFF
--- a/.changeset/fix-svelte-state-referenced-locally.md
+++ b/.changeset/fix-svelte-state-referenced-locally.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Fix `state_referenced_locally` compiler warnings in Svelte components by moving prop reads into reactive contexts.

--- a/packages/jazz-tools/src/svelte/JazzSvelteProvider.svelte
+++ b/packages/jazz-tools/src/svelte/JazzSvelteProvider.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { onDestroy } from 'svelte';
 	import type { Db } from '../runtime/db.js';
 	import { initJazzContext } from './context.svelte.js';
 	import type { JazzClient } from './create-jazz-client.js';
@@ -13,30 +12,33 @@
 	let { client, children, fallback }: Props = $props();
 
 	const ctx = initJazzContext();
-	let resolvedClient: JazzClient | null = null;
 	let error = $state<Error | null>(null);
-	let cancelled = false;
 
-	Promise.resolve(client)
-		.then((c) => {
-			if (cancelled) {
-				c.shutdown();
-				return;
+	$effect(() => {
+		let cancelled = false;
+		let resolved: JazzClient | null = null;
+
+		Promise.resolve(client)
+			.then((c) => {
+				if (cancelled) {
+					c.shutdown();
+					return;
+				}
+				resolved = c;
+				ctx.db = c.db;
+				ctx.session = c.session;
+				ctx.manager = c.manager;
+			})
+			.catch((reason) => {
+				error = reason instanceof Error ? reason : new Error(String(reason));
+			});
+
+		return () => {
+			cancelled = true;
+			if (resolved) {
+				resolved.shutdown();
 			}
-			resolvedClient = c;
-			ctx.db = c.db;
-			ctx.session = c.session;
-			ctx.manager = c.manager;
-		})
-		.catch((reason) => {
-			error = reason instanceof Error ? reason : new Error(String(reason));
-		});
-
-	onDestroy(() => {
-		cancelled = true;
-		if (resolvedClient) {
-			void resolvedClient.shutdown();
-		}
+		};
 	});
 </script>
 

--- a/packages/jazz-tools/src/svelte/SyntheticUserSwitcher.svelte
+++ b/packages/jazz-tools/src/svelte/SyntheticUserSwitcher.svelte
@@ -27,9 +27,13 @@
 		defaultMode
 	}: Props = $props();
 
-	const storageOptions: SyntheticUserStorageOptions = { storage, storageKey, defaultMode };
+	let storageOptions = $derived({ storage, storageKey, defaultMode });
 
-	let store = $state<SyntheticUserStore>(loadSyntheticUserStore(appId, storageOptions));
+	let store = $state<SyntheticUserStore>(undefined!);
+
+	$effect.pre(() => {
+		store = loadSyntheticUserStore(appId, storageOptions);
+	});
 
 	function getActiveProfile(s: SyntheticUserStore): SyntheticUserProfile {
 		return s.profiles.find((p) => p.id === s.activeProfileId) ?? s.profiles[0];

--- a/packages/jazz-tools/src/svelte/compiler-warnings.svelte.test.ts
+++ b/packages/jazz-tools/src/svelte/compiler-warnings.svelte.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { compile, preprocess } from "svelte/compiler";
+import { readFileSync } from "fs";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+import { vitePreprocess } from "@sveltejs/vite-plugin-svelte";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+async function compileAndWarn(filename: string) {
+  const filepath = resolve(__dirname, filename);
+  const source = readFileSync(filepath, "utf-8");
+  const preprocessed = await preprocess(source, vitePreprocess(), {
+    filename: filepath,
+  });
+  const result = compile(preprocessed.code, {
+    filename: filepath,
+    generate: "client",
+  });
+  return result.warnings;
+}
+
+describe("svelte components produce no state_referenced_locally warnings", () => {
+  it("JazzSvelteProvider.svelte", async () => {
+    const warnings = await compileAndWarn("JazzSvelteProvider.svelte");
+    const bad = warnings.filter((w) => w.code === "state_referenced_locally");
+    expect(bad, bad.map((w) => w.message).join("\n")).toEqual([]);
+  });
+
+  it("SyntheticUserSwitcher.svelte", async () => {
+    const warnings = await compileAndWarn("SyntheticUserSwitcher.svelte");
+    const bad = warnings.filter((w) => w.code === "state_referenced_locally");
+    expect(bad, bad.map((w) => w.message).join("\n")).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- Move prop reads in `JazzSvelteProvider.svelte` and `SyntheticUserSwitcher.svelte` into reactive contexts (`$effect`, `$derived`, `$effect.pre`) so the Svelte 5 compiler no longer emits `state_referenced_locally` warnings to consumers
- Also improves `JazzSvelteProvider` lifecycle — `$effect` cleanup replaces `onDestroy`, correctly handling client prop changes
- Adds a compiler-level regression test that asserts zero `state_referenced_locally` warnings from both components

## Test plan

- [x] New `compiler-warnings.svelte.test.ts` compiles both `.svelte` files and asserts no `state_referenced_locally` warnings
- [x] All 26 existing Svelte tests pass
- [x] `pnpm build:svelte` succeeds
- [x] `oxlint` and `oxfmt` clean