### PR TITLE
docs: internals page, docs gap fixes, and housekeeping

### DIFF
--- a/crates/jazz-tools/src/client.rs
+++ b/crates/jazz-tools/src/client.rs
@@ -1129,7 +1129,7 @@ fn handle_server_event(
                     row_count = warning.row_count,
                     from_hash = %warning.from_hash,
                     to_hash = %warning.to_hash,
-                    "Detected {} rows of {} with differing schema versions. To ensure data visibility and forward/backward compatibility please create a new migration with `npx jazz-tools migrations create {} {}`",
+                    "Detected {} rows of {} with differing schema versions. To ensure data visibility and forward/backward compatibility please create a new migration with `npx jazz-tools@alpha migrations create {} {}`",
                     warning.row_count,
                     warning.table_name,
                     short_hash(&warning.from_hash),

--- a/crates/jazz-tools/src/query_manager/manager.rs
+++ b/crates/jazz-tools/src/query_manager/manager.rs
@@ -417,7 +417,7 @@ impl QueryManager {
             row_count = warning.row_count,
             from_hash = %warning.from_hash,
             to_hash = %warning.to_hash,
-            "Detected {} rows of {} with differing schema versions. To ensure data visibility and forward/backward compatibility please create a new migration with `npx jazz-tools migrations create {} {}`",
+            "Detected {} rows of {} with differing schema versions. To ensure data visibility and forward/backward compatibility please create a new migration with `npx jazz-tools@alpha migrations create {} {}`",
             warning.row_count,
             warning.table_name,
             short_hash(&warning.from_hash),

--- a/crates/jazz-tools/src/sync_manager/inbox.rs
+++ b/crates/jazz-tools/src/sync_manager/inbox.rs
@@ -18,7 +18,7 @@ fn log_schema_warning(origin: &str, warning: &SchemaWarning) {
         row_count = warning.row_count,
         from_hash = %warning.from_hash,
         to_hash = %warning.to_hash,
-        "Detected {} rows of {} with differing schema versions. To ensure data visibility and forward/backward compatibility please create a new migration with `npx jazz-tools migrations create {} {}`",
+        "Detected {} rows of {} with differing schema versions. To ensure data visibility and forward/backward compatibility please create a new migration with `npx jazz-tools@alpha migrations create {} {}`",
         warning.row_count,
         warning.table_name,
         short_hash(&warning.from_hash),

--- a/docs/content/docs/auth/authentication.mdx
+++ b/docs/content/docs/auth/authentication.mdx
@@ -1,7 +1,7 @@
 ---
 title: Authentication
 description: "How and when to use Jazz's three different auth modes: anonymous, demo, and external JWTs."
-reviewedAt: "4059cdef"
+reviewedAt: "f6535a533"
 ---
 
 import { Accordion, Accordions } from "fumadocs-ui/components/accordion";
@@ -161,18 +161,7 @@ For more details, the [Auth0 docs](https://auth0.com/docs/secure/tokens/json-web
 
 ### Server configuration
 
-| Flag                | Purpose                                                                                   | Development | Production                                                          |
-| ------------------- | ----------------------------------------------------------------------------------------- | ----------- | ------------------------------------------------------------------- |
-| `--port`            | Port to listen on (defaults to 1625)                                                      | Optional    | Optional                                                            |
-| `--data-dir`        | Directory for persistent storage (defaults to `./data`)                                   | Optional    | Optional                                                            |
-| `--in-memory`       | Use in-memory storage instead of Fjall-backed files. Data is lost when the process exits. | Optional    | Optional                                                            |
-| `--jwks-url <url>`  | JWKS endpoint for JWT signature verification                                              | Optional    | Optional, but required if using JWT auth to validate JWT signatures |
-| `--backend-secret`  | Secret for backend session impersonation                                                  | Optional    | Optional                                                            |
-| `--admin-secret`    | Secret for admin operations (schema/policy sync)                                          | Optional    | Optional                                                            |
-| `--allow-anonymous` | Allow anonymous auth                                                                      | Enabled     | Disabled                                                            |
-| `--allow-demo`      | Allow demo auth                                                                           | Enabled     | Disabled                                                            |
-
-Production mode activates when `NODE_ENV=production`.
+See [Server Setup](/docs/reference/server-setup) for the full list of server flags and storage options. In production (`NODE_ENV=production`), anonymous and demo auth are disabled unless explicitly enabled with `--allow-anonymous` / `--allow-demo`.
 
 <include cwd lang="bash" meta='title="Terminal"'>
   ../examples/docs/todo-server-ts/docs/auth-server-cli.sh#auth-server-cli
@@ -182,10 +171,10 @@ Production mode activates when `NODE_ENV=production`.
 
 When the server receives a request, it tries each auth method in priority order and uses the first match:
 
-1. **Backend impersonation** &hairsp;—&hairsp; the request includes `X-Jazz-Backend-Secret` and `X-Jazz-Session` headers. A trusted backend service (e.g. a cron job or webhook handler) can act as any user by providing the shared secret and a base64-encoded session identifying the user to impersonate.
-2. **External JWT** &hairsp;—&hairsp; the request includes an `Authorization: Bearer <jwt>` header. The token is validated against the JWKS endpoint configured with `--jwks-url`.
-3. **Local auth** &hairsp;—&hairsp; the request includes `X-Jazz-Local-Mode` and `X-Jazz-Local-Token` headers. Used by anonymous and demo auth in development.
-4. **No session** &hairsp;—&hairsp; none of the above matched.
+1. **Backend impersonation**&hairsp;—&hairsp;the request includes `X-Jazz-Backend-Secret` and `X-Jazz-Session` headers. A trusted backend service (e.g. a cron job or webhook handler) can act as any user by providing the shared secret and the session as a base64-encoded JSON string in `X-Jazz-Session`.
+2. **External JWT**&hairsp;—&hairsp;the request includes an `Authorization: Bearer <jwt>` header. The token is validated against the JWKS endpoint configured with `--jwks-url`.
+3. **Local auth**&hairsp;—&hairsp;the request includes `X-Jazz-Local-Mode` and `X-Jazz-Local-Token` headers. Used by anonymous and demo auth in development.
+4. **No session**&hairsp;—&hairsp;none of the above matched.
 
 Backend impersonation always takes precedence, so a backend service can reliably impersonate users even if the request also carries a JWT.
 

--- a/docs/content/docs/auth/permissions.mdx
+++ b/docs/content/docs/auth/permissions.mdx
@@ -1,7 +1,7 @@
 ---
 title: Permissions
 description: Jazz's approach to row-level security using relationship-based access controls, and how to build policies of varying complexity.
-reviewedAt: "4059cdef"
+reviewedAt: "f6535a533"
 ---
 
 import { Accordion, Accordions } from "fumadocs-ui/components/accordion";
@@ -111,6 +111,19 @@ If a table references itself (e.g. a comment that can have sub-comments), you ca
 </Accordion>
 </Accordions>
 
+### Update policies: old row vs new row
+
+Update policies can check both the row **before** the update (`.whereOld(...)`) and the row
+**after** the update (`.whereNew(...)`). This is useful when you need to verify that the user had
+permission to modify the original row and that the result is also valid.
+
+<include cwd lang="ts" meta='title="permissions.ts"'>
+  ../examples/docs/todo-server-ts/src/permissions-snippets.ts#permissions-whereold-wherenew-ts
+</include>
+
+If you only use `.whereOld(...)`, the same condition is applied to both the old and new row. The
+same applies if you only use `.whereNew(...)`. Use both when the old-row and new-row checks differ.
+
 ## Policy enforcement and request context
 
 Every policy is evaluated against a session. On the frontend, this is the authenticated user's session. In a backend handler, create a scoped session per request so queries run with the right identity.
@@ -119,7 +132,7 @@ Every policy is evaluated against a session. On the frontend, this is the authen
   ../examples/docs/todo-server-ts/src/request-context.ts#backend-request-handler-ts
 </include>
 
-See [Setup](/docs/reference/server-setup) for context setup details.
+See [Server Setup](/docs/reference/server-setup#context-setup) for context setup details.
 
 <Callout type="info">
   Policies are enforced on the sync server, not on the client. A client can write any data locally,

--- a/docs/content/docs/concepts/local-first-data-model.mdx
+++ b/docs/content/docs/concepts/local-first-data-model.mdx
@@ -1,7 +1,7 @@
 ---
 title: Local-First Data Model
 description: An overview of how Jazz manages versions, history, conflicts, and avoids loading states.
-reviewedAt: "4059cdef"
+reviewedAt: "f6535a533"
 ---
 
 Jazz embeds a database on each device and syncs to the server in the background.
@@ -23,7 +23,11 @@ Devices can't show data they don't have. On the very first load from the server,
 
 ## Versioned objects
 
-Every update or change made to a row in Jazz is recorded as a **commit**, and each commit results in a new, immutable version of the row it affects. Under the hood, each row's history is an append-only log of commits. The full history of each row is available, allowing you to view a row as it looked at any point in history, including intermediate, conflicting states.
+Under the hood, every row in Jazz is a standalone versioned object. Each row has its own identity (a UUIDv7, which is the `id` column) and can sync independently.
+
+Every change to a row&hairsp;—&hairsp;an insert, update, or delete&hairsp;—&hairsp;is recorded as a **commit**. Each commit is immutable and produces a new version of the row it affects. Because commits are content-addressed, two clients that independently make the same change will produce identical commits, and sync can deduplicate them automatically.
+
+The full history of each row is preserved, so you can view a row as it looked at any point in time, including intermediate or conflicting states.
 
 Each version links back to its parent, forming a chain.
 

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -1,12 +1,33 @@
 ---
 title: Overview
 description: The database that syncs.
-reviewedAt: "4059cdef"
+reviewedAt: "f6535a533"
 ---
 
-Jazz is a local-first relational database: your app reads from and writes to a local replica, then syncs with a server.
+Jazz is a local-first relational database with row-level permissions, real-time sync, and offline support&hairsp;—&hairsp;no separate API layer needed. Your app reads from and writes to a local replica, and Jazz syncs it with a server in the background.
 
-You can use Jazz from React, Vue, Expo/React Native, and Svelte clients, plus backend/server contexts in TypeScript and Rust.
+```ts
+import { schema as s } from "jazz-tools";
+
+// Define your schema
+const schema = {
+  todos: s.table({
+    title: s.string(),
+    done: s.boolean(),
+  }),
+};
+const app = s.defineApp(schema);
+
+// Write — instant, works offline
+db.insert(app.todos, { title: "Ship it", done: false });
+
+// Read — reactive, stays up to date across devices
+db.subscribeAll(app.todos.where({ done: false }), ({ all }) => {
+  console.log(all);
+});
+```
+
+Jazz works with React, Vue, Expo/React Native, Svelte, plain TypeScript, and Rust.
 
 ## Quickstarts
 

--- a/docs/content/docs/reading/includes-and-relations.mdx
+++ b/docs/content/docs/reading/includes-and-relations.mdx
@@ -1,7 +1,7 @@
 ---
 title: Includes & Relations
 description: Resolve references with include(), pick columns with select(), inspect permissions, and run recursive queries.
-reviewedAt: "4059cdef"
+reviewedAt: "f6535a533"
 ---
 
 import { Accordion, Accordions } from "fumadocs-ui/components/accordion";
@@ -70,7 +70,9 @@ Use `select(...)` to narrow a row to `id` plus the columns you pick. You can com
 
 Jazz is distributed and supports offline edits, so a referenced row won't always be available locally&hairsp;—&hairsp;it might not have synced yet, or another peer might have deleted it.
 
-When you `include` a relation and the FK is set but the target row can't be resolved (not yet synced, deleted, or hidden by permissions), **the row is filtered out** (inner join semantics). If the FK column is `null` (nullable and unset), the row is still returned with the included field set to `null`. This filtering only applies when you explicitly load references with `include`&hairsp;—&hairsp;without it, the row appears in results with only its own columns.
+When you don't load a reference, the FK column contains its raw value (the UUID string) and the row always appears in results.
+
+When you do load a reference (TypeScript `include`, Rust `join`/`on`), Jazz uses inner-join semantics. If the FK is set but the target row can't be resolved&hairsp;—&hairsp;not yet synced, deleted, or hidden by permissions&hairsp;—&hairsp;**the row is filtered out**. If the FK column is `null` (nullable and unset), the row is still returned with the included field set to `null`.
 
 ### Requiring includes
 
@@ -93,27 +95,9 @@ To also filter out rows where the FK is `null`, use `.requireIncludes()`. This d
 (`todosViaOwner`, etc.) are unaffected. When used inside a nested `include`, it applies at that
 nesting level only.
 
-## Computed permissions columns
+## Magic columns
 
-Jazz exposes three computed columns&hairsp;—&hairsp;`$canRead`, `$canEdit`, and `$canDelete`&hairsp;—&hairsp;that reflect the current session's permissions on each row. They are computed at query time and don't exist in the database. They are omitted from `select("*")`, so you opt in explicitly&hairsp;—&hairsp;for example, `select("*", "$canDelete")` returns the normal row columns plus `$canDelete`.
-
-- `$canRead`&hairsp;—&hairsp;whether the current session can read the row. Since read policies already gate which rows appear, this will usually be `true`.
-- `$canEdit`&hairsp;—&hairsp;whether the current session passes the row's update policy.
-- `$canDelete`&hairsp;—&hairsp;whether the current session passes the row's delete policy.
-- Without a session, all three return `null`.
-
-<Tabs groupId="jazz-environment" items={["TypeScript", "Rust"]} persist updateAnchor>
-  <Tab value="TypeScript">
-    <include cwd lang="ts">
-      ../examples/docs/todo-client-localfirst-ts/src/docs-snippets.ts#reading-magic-columns-ts
-    </include>
-  </Tab>
-  <Tab value="Rust">
-    <include cwd lang="rs">
-      ../examples/docs/todo-server-rs/src/docs_snippets.rs#reading-magic-columns-rust
-    </include>
-  </Tab>
-</Tabs>
+Jazz exposes computed columns for permission introspection (`$canRead`, `$canEdit`, `$canDelete`) and edit metadata (`$createdBy`, `$createdAt`, `$updatedBy`, `$updatedAt`). See [Magic columns](/docs/reading/queries#magic-columns) for details and examples.
 
 ## Recursive queries with `gather` and `hopTo`
 

--- a/docs/content/docs/reading/queries.mdx
+++ b/docs/content/docs/reading/queries.mdx
@@ -1,7 +1,7 @@
 ---
 title: Queries
 description: One-shot queries, subscriptions, framework hooks, Suspense integration, and read durability options.
-reviewedAt: "4059cdef"
+reviewedAt: "f6535a533"
 ---
 
 ## One-shot queries
@@ -145,6 +145,32 @@ Pass `undefined` instead of a query to skip evaluation. This is useful when buil
     </include>
   </Tab>
 </Tabs>
+
+### Read durability
+
+By default, queries deliver results from local storage immediately. Pass a `tier` option to wait for
+a specific durability level before the first result arrives.
+
+<Tabs groupId="jazz-environment" items={["TypeScript", "Rust"]} persist updateAnchor>
+  <Tab value="TypeScript">
+    <include cwd lang="ts">
+      ../examples/docs/todo-client-localfirst-ts/src/docs-snippets.ts#reading-durability-tier-ts
+    </include>
+  </Tab>
+  <Tab value="Rust">
+    <include cwd lang="rs">
+      ../examples/docs/todo-server-rs/src/docs_snippets.rs#reading-durability-tier-rust
+    </include>
+  </Tab>
+</Tabs>
+
+<Callout type="info" title="Subscriptions and durability">
+  For subscriptions, the durability tier applies only to the first result. After that, updates
+  stream in as they become available and are not guaranteed to have reached any particular tier.
+</Callout>
+
+See [Durability Tiers](/docs/reference/durability-tiers) for the full reference, including
+`localUpdates`, `propagation`, and how tiers interact with subscriptions.
 
 ### React Suspense and Transitions
 

--- a/docs/content/docs/reference/durability-tiers.mdx
+++ b/docs/content/docs/reference/durability-tiers.mdx
@@ -1,7 +1,7 @@
 ---
 title: Durability Tiers
 description: "API reference for read and write durability tiers: the options that control how far data must propagate before an operation confirms."
-reviewedAt: "4059cdef"
+reviewedAt: "f6535a533"
 ---
 
 import DurabilityTiersTable from "../../partials/durability-tiers-table.mdx";
@@ -26,11 +26,11 @@ See [Writing Data](/docs/writing/writing-data#write-durability-tiers) for detail
 
 Read durability controls when the **first result** of a query or subscription is delivered.
 
-| Option         | Values                               | Default        | What it does                                                                                                                                                                                                                     |
-| -------------- | ------------------------------------ | -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `tier`         | `"worker"` \| `"edge"` \| `"global"` | Same as writes | How far the first result must come from before the query delivers.                                                                                                                                                               |
-| `localUpdates` | `"immediate"` \| `"deferred"`        | `"immediate"`  | With `"immediate"`, local changes appear in the subscription while still waiting for the tier to confirm. With `"deferred"`, the subscription is held until the tier confirms&hairsp;—&hairsp;you only see the confirmed result. |
-| `propagation`  | `"full"` \| `"local-only"`           | `"full"`       | With `"full"`, the subscription is sent to upstream servers, which push matching data back. With `"local-only"`, only local storage is queried&hairsp;—&hairsp;no server communication.                                          |
+| Option         | Values                               | Default        | What it does                                                                                                                                                                                                                                                                     |
+| -------------- | ------------------------------------ | -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `tier`         | `"worker"` \| `"edge"` \| `"global"` | Same as writes | How far the first result must come from before the query delivers.                                                                                                                                                                                                               |
+| `localUpdates` | `"immediate"` \| `"deferred"`        | `"immediate"`  | With `"immediate"`, your own local writes appear in the subscription while still waiting for the tier to confirm the initial snapshot. This only takes effect after the subscription has settled at least once. With `"deferred"`, all delivery is held until the tier confirms. |
+| `propagation`  | `"full"` \| `"local-only"`           | `"full"`       | With `"full"`, the subscription is sent to upstream servers, which push matching data back. With `"local-only"`, only local storage is queried&hairsp;—&hairsp;no server communication.                                                                                          |
 
 These options apply to:
 
@@ -53,7 +53,7 @@ These options apply to:
     </include>
   </Tab>
   <Tab value="Vue">
-    <include cwd lang="ts">
+    <include cwd lang="ts" meta='title="App.vue"'>
       ../examples/docs/todo-client-localfirst-vue/src/docs-snippets.ts#reading-tier-vue
     </include>
   </Tab>
@@ -63,7 +63,7 @@ These options apply to:
     </include>
   </Tab>
   <Tab value="Expo">
-    <include cwd lang="ts">
+    <include cwd lang="ts" meta='title="App.tsx"'>
       ../examples/docs/todo-client-localfirst-expo/src/docs-snippets.ts#reading-tier-expo
     </include>
   </Tab>
@@ -80,3 +80,12 @@ These options apply to:
 </Tabs>
 
 For most queries and subscriptions, omitting a tier is the right choice: Jazz delivers results from local storage immediately and streams in remote updates as they arrive. Reserve explicit tiers for cases where eventual consistency is not acceptable.
+
+<Callout type="warn">
+  The read tier gates the **first** delivery of a subscription only. After the initial snapshot
+  arrives at the requested tier, subsequent updates are delivered as they reach the local node,
+  regardless of which tier they've propagated to. For example, a subscription with `tier: "global"`
+  guarantees a globally-consistent initial snapshot, but later incremental updates from other
+  clients may arrive through edge tiers before being globally available **even if the durability of
+  the write is set to 'global'**.
+</Callout>

--- a/docs/content/docs/reference/faq.mdx
+++ b/docs/content/docs/reference/faq.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ
 description: Frequently asked questions about Jazz.
-reviewedAt: "4059cdef"
+reviewedAt: "f6535a533"
 ---
 
 import { Accordion, Accordions } from "fumadocs-ui/components/accordion";
@@ -28,7 +28,7 @@ This is useful when iterating on your schema during development.
 
 <Accordion id="undefined-vs-empty-array" title="Why does useAll return undefined?">
 
-`useAll` and `QuerySubscription` return `undefined` until the first server response arrives. After that, the value is an array — empty (`[]`) if no rows match, or populated. See [The undefined loading state](/docs/reading/queries#the-undefined-loading-state) for details.
+`useAll` and `QuerySubscription` return `undefined` until the first response arrives from the requested tier. After that, the value is an array&hairsp;—&hairsp;empty (`[]`) if no rows match, or populated. See [The undefined loading state](/docs/reading/queries#the-undefined-loading-state) for details.
 
 </Accordion>
 
@@ -47,6 +47,24 @@ Yes. Link the local identity to an external one when the user signs in. See [Upg
 <Accordion id="rust-migrations" title="Do Rust apps need separate migration files?">
 
 No. Rust services use the same TypeScript migration files. The Rust runtime consumes the compiled schema representation through the CLI. See [Migrations](/docs/schemas/migrations) for details.
+
+</Accordion>
+
+<Accordion id="common-errors" title="What do the sync error messages mean?">
+
+Jazz may return the following errors when a client's request is rejected by the server:
+
+- **`PermissionDenied`**&hairsp;—&hairsp;a write was rejected because it failed the table's
+  [permission policy](/docs/auth/permissions). Check that the session has the right to perform
+  that operation on the row.
+- **`SessionRequired`**&hairsp;—&hairsp;a write was attempted without an authenticated session.
+  Make sure the client is using a valid auth mode (anonymous, demo, or external JWT).
+- **`CatalogueWriteDenied`**&hairsp;—&hairsp;a client attempted to write a schema or lens
+  catalogue object without the required admin secret. In production, catalogue writes require
+  `--admin-secret`.
+- **`QuerySubscriptionRejected`**&hairsp;—&hairsp;a query subscription was rejected by the
+  server, typically because the query references a table or schema the server doesn't know about.
+  This can happen if the schema hasn't synced yet or if there's a version mismatch.
 
 </Accordion>
 

--- a/docs/content/docs/reference/internals.mdx
+++ b/docs/content/docs/reference/internals.mdx
@@ -1,6 +1,6 @@
 ---
 title: Advanced Internals
-description: How Jazz works under the hood: the storage engine, sync protocol, query pipeline, and browser architecture.
+description: "How Jazz works under the hood: the storage engine, sync protocol, query pipeline, and browser architecture."
 reviewedAt: "f6535a533"
 ---
 

--- a/docs/content/docs/reference/internals.mdx
+++ b/docs/content/docs/reference/internals.mdx
@@ -1,0 +1,241 @@
+---
+title: Advanced Internals
+description: How Jazz works under the hood: the storage engine, sync protocol, query pipeline, and browser architecture.
+reviewedAt: "f6535a533"
+---
+
+This page describes Jazz's internal architecture. You don't need any of this to use Jazz, but it
+can help if you're debugging, reasoning about performance, or understanding why the system behaves the
+way it does. It's also useful for anyone who may want to contribute to Jazz.
+
+## Data model
+
+### Row = Object
+
+Every table row is a standalone Jazz object identified by a UUIDv7. The row's `id` column is its
+ObjectId. This means each row carries its own version history, can sync independently, and has
+content-addressed commits. Two clients creating identical commits independently produce the same
+CommitId, so sync can detect and skip duplicates.
+
+### Automatic column indexing
+
+Every column in every table gets a single-column index automatically. There is no manual index
+management. The `_id` index for each table doubles as the authoritative row manifest&hairsp;—
+&hairsp;discovering all rows in a table is just an `_id` index scan.
+
+This is a deliberate trade-off: local-first databases are small enough that index overhead is
+negligible, and it guarantees every `where` filter hits an index rather than scanning rows.
+Custom index configuration is planned as a future feature.
+
+### Deletion
+
+The user-facing `delete` and `deleteDurable` APIs perform a **soft delete**: the row's content is
+preserved but it is hidden from queries. Internally, the row moves from the `_id` index to a
+separate `_id_deleted` index.
+
+A **hard delete** mode also exists at the storage layer (content emptied, irreversible, always wins
+in conflicts), but it is not currently exposed to application code.
+
+### History and truncation
+
+Each row's history is an append-only DAG of commits. History grows unboundedly by default. A
+low-level API for branch truncation exists, which removes ancestor commits below a
+specified boundary while preserving the current state, but this is not yet exposed to
+application code. Exposing history truncation is planned as a future feature.
+
+### Monotonic timestamps
+
+Each runtime instance maintains a monotonic timestamp counter. Every commit gets a timestamp that is
+strictly greater than the previous one from the same node. This guarantees causal ordering within a
+single instance, which is what makes last-writer-wins conflict resolution deterministic when commits
+originate from the same device.
+
+### Cold start
+
+On startup, Jazz loads indices first (not all row data), then lazy-loads row objects on demand as
+queries reference them. As a result, startup time is proportional to index size, not total data size.
+
+## Browser architecture
+
+### Dual-runtime model
+
+In the browser, Jazz runs two runtime instances:
+
+- **Main thread**&hairsp;— &hairsp;an in-memory runtime that serves all reads and writes instantly.
+- **Dedicated worker**&hairsp;— &hairsp;a persistent runtime backed by OPFS (Origin Private File
+  System) that owns durable storage and upstream server sync.
+
+The main thread treats the worker as its upstream server. Writes apply to the in-memory runtime
+immediately, then sync to the worker via `postMessage`. The worker persists them to OPFS and
+forwards them to the edge server. Incoming server updates flow the reverse path: edge &rarr; worker
+&rarr; main thread &rarr; your UI callback.
+
+```text
+Main thread (MemoryStorage)
+  ↕ postMessage
+Dedicated worker (OPFS via OpfsBTreeStorage)
+  ↕ HTTP/SSE
+Edge server (FjallStorage)
+```
+
+With `driver: { type: "memory" }`, the worker and OPFS are skipped entirely&hairsp;— &hairsp;the
+main-thread runtime syncs directly with the server.
+
+### OPFS crash safety
+
+The OPFS storage engine uses checkpoint-based persistence with two superblock slots (A/B). Each
+checkpoint writes dirty pages, flushes, then swaps the active superblock. On reopen after a crash or
+torn write, the highest valid superblock generation wins, recovering to the last complete checkpoint.
+
+### Tab coordination
+
+Jazz uses the Web Locks API (`navigator.locks`) to elect a single tab as the storage leader; other
+tabs route through it via `BroadcastChannel`. When a leader tab closes, the browser releases the
+lock and the first follower to acquire it becomes the new leader.
+
+### React Native
+
+React Native uses a separate runtime adapter with no web worker or OPFS path. Local persistence
+works differently from the browser&hairsp;— &hairsp;there is no OPFS equivalent. The sync layer
+connects directly to the server from the main runtime.
+
+## Query engine
+
+### Execution pipeline
+
+Queries compile into a graph of processing nodes:
+
+```text
+IndexScan → [Union] → Materialize → [PolicyFilter]
+  → [ArraySubquery] → [Filter] → [Sort] → [LimitOffset]
+  → [Project] → Output
+```
+
+Index scans are per `(branch, filter-disjunct)` pair. Nodes in brackets are only present when the
+query requires them. The graph processes deltas (added/removed/updated tuples) incrementally, which means that on data changes, only dirty nodes re-evaluate. This is what makes live
+subscriptions efficient: when a single row changes, the engine doesn't re-run the whole query.
+
+### One-shot queries
+
+`db.all()` and `db.one()` are implemented as "subscribe, receive first durability-qualified
+snapshot, then auto-unsubscribe." They share the same reactive machinery as live subscriptions,
+which is why both participate in durability-tier gating and lens transforms.
+
+### Include performance
+
+Each outer row in an `include()` / array subquery gets its own compiled sub-graph. With 1,000 outer
+rows, that's 1,000 sub-graphs. Any change to the inner table re-settles all instances. This is
+correct and simple, but worth knowing if you're including across large result sets&hairsp;—&hairsp;limiting includes can improve performance.
+
+## Sync protocol
+
+### Transport
+
+Jazz uses HTTP with binary framing&hairsp;— &hairsp;not WebSockets or raw SSE text.
+
+- **Server &rarr; client**: `GET /events?client_id=<uuid>`&hairsp;— &hairsp;a persistent binary
+  stream of length-prefixed JSON frames (`[4-byte u32 BE length][JSON payload]`). Event types:
+  `Connected`, `SyncUpdate`, `Heartbeat` (every 30 seconds).
+- **Client &rarr; server**: `POST /sync`&hairsp;— &hairsp;sends mutations and subscription changes.
+- **Admin**: `GET /schemas`, `GET /schema/:hash`&hairsp;— &hairsp;schema catalogue reads (requires
+  admin secret).
+- **Health**: `GET /health`.
+
+### Client identity
+
+Each client generates and persists a UUID `ClientId` (v7 in Rust, v4 in TypeScript). On reconnect with the same ID, the server's
+tip tracking means it only sends data that's new since the last connection.
+
+### Reconnection
+
+The TypeScript client uses exponential backoff with jitter (base 300ms, cap 10s, 0–199ms random
+jitter). On reconnect, active query subscriptions are replayed as anti-entropy (meaning any divergence between client and server is repaired): the server re-evaluates them and sends any data the client is missing.
+
+### Trust model and client roles
+
+Sync is asymmetric:
+
+- **Upward** (client &rarr; server): all objects are pushed. Servers are trusted.
+- **Downward** (server &rarr; client): only objects matching the client's active query subscriptions
+  are sent. Clients are untrusted and never receive data they haven't asked for.
+
+Each client connection has a **role** that determines how writes are routed:
+
+| Role    | Write handling                                              |
+| ------- | ----------------------------------------------------------- |
+| `User`  | Writes queued for permission policy evaluation before apply |
+| `Admin` | Writes applied directly, no permission check                |
+| `Peer`  | Writes applied directly, used for server-to-server sync     |
+
+Frontend clients authenticate as `User`. Backend services with a backend secret authenticate as
+`Admin` or `Peer`. The role is invisible to application code&hairsp;— &hairsp;it's determined by the
+auth mechanism used when connecting.
+
+## Schema evolution
+
+### Lenses
+
+Migrations in Jazz produce **lenses**&hairsp;— &hairsp;bidirectional transformations between schema
+versions. When `jazz-tools migrations create` diffs two schemas, it generates a lens with
+declarative operations:
+
+| Operation      | Forward                        | Backward (auto-generated)               |
+| -------------- | ------------------------------ | --------------------------------------- |
+| `AddColumn`    | Adds column with default value | Removes the column                      |
+| `RemoveColumn` | Removes column                 | Adds column back with backwards default |
+| `RenameColumn` | Renames from old to new        | Renames from new to old                 |
+| `AddTable`     | Adds table                     | Removes the table                       |
+| `RemoveTable`  | Removes table                  | Adds table back                         |
+
+The backward transform is always computed automatically from the forward transform.
+
+#### At query time
+
+When a query touches data written under an older schema, the lens chain converts rows transparently.
+Index lookups translate column names through the chain (e.g. v1's `email` becomes v2's
+`email_address`), and row loading applies the lens transform to add default values for new columns
+or reshape the data.
+
+Results from all reachable schema versions are unioned together, with last-writer-wins deduplication
+by ObjectId when the same row appears on multiple schema branches.
+
+#### At write time
+
+Updating a row that lives on an old-schema branch triggers a **copy-on-write**: the row is loaded,
+lens-transformed to the current schema, the update is applied, and the result is written to the
+current schema's branch. The old branch data stays untouched.
+
+### Draft lenses
+
+Auto-generated lenses may contain **draft** operations&hairsp;— &hairsp;uncertain transformations
+like potential renames (same column type, different name) or non-nullable columns without sensible
+defaults. A draft lens in the path to any live schema will fail at startup, forcing you to review
+and resolve the ambiguity before the app can run.
+
+### Catalogue sync
+
+Schemas and lenses are themselves Jazz objects. When a client connects, its schema and lens objects
+propagate through normal sync. Servers discover schemas lazily and activate them on demand&hairsp;— &hairsp;no deployment coordination is needed when clients ship new schema versions.
+
+## Durability signals
+
+Jazz separates two durability concepts:
+
+| Signal           | Gates               | Question it answers                         |
+| ---------------- | ------------------- | ------------------------------------------- |
+| `QuerySettled`   | First read delivery | "Has the query result arrived from tier T?" |
+| `PersistenceAck` | Write completion    | "Is this commit durable at tier T?"         |
+
+Both use the same tier lattice (`worker` < `edge` < `global`), but they answer different questions. A
+query's first callback is held until `QuerySettled` arrives at the requested tier. A durable write's
+promise resolves when `PersistenceAck` arrives at the requested tier.
+
+<Callout type="warn">
+  The read durability tier only gates the **first** delivery of a subscription. After the initial
+  snapshot arrives at the requested tier, subsequent updates are delivered as they reach the local
+  node, regardless of which tier they've propagated to. This means a subscription with `tier:
+  "global"` guarantees a globally-consistent initial snapshot, but later incremental updates may
+  arrive before reaching the global tier. The `localUpdates: "immediate"` option (the default)
+  additionally allows your own local writes to appear in the subscription before even the first
+  delivery, but only after the subscription has settled at least once.
+</Callout>

--- a/docs/content/docs/reference/meta.json
+++ b/docs/content/docs/reference/meta.json
@@ -7,6 +7,7 @@
     "framework-patterns",
     "server-setup",
     "mcp",
+    "internals",
     "faq"
   ]
 }

--- a/docs/content/docs/reference/server-setup.mdx
+++ b/docs/content/docs/reference/server-setup.mdx
@@ -1,7 +1,7 @@
 ---
 title: Server Setup
 description: Hosted and self-hosted database server configuration, app provisioning, and runtime context setup.
-reviewedAt: "4059cdef"
+reviewedAt: "f6535a533"
 ---
 
 import CreateJazzClientReference from "../../partials/create-jazz-client-reference.mdx";
@@ -23,17 +23,17 @@ App IDs are provisioned on request. Ask in the `jazz2-adopters` Discord channel 
 
 `jazz-tools server <APP_ID>` currently supports:
 
-| Option                              | Purpose                                                                     | Environment variable   | Default                   |
-| ----------------------------------- | --------------------------------------------------------------------------- | ---------------------- | ------------------------- |
-| `<APP_ID>` (positional)             | App namespace identifier (required)                                         | -                      | -                         |
-| `-p, --port <PORT>`                 | Listen port                                                                 | -                      | `1625`                    |
-| `-d, --data-dir <DATA_DIR>`         | Persistent storage directory                                                | -                      | `./data`                  |
-| `--in-memory`                       | Use in-memory storage instead of files; data is lost when the process exits | -                      | off                       |
-| `--jwks-url <JWKS_URL>`             | JWKS endpoint for external JWT validation                                   | `JAZZ_JWKS_URL`        | unset                     |
-| `--allow-anonymous`                 | Allow local anonymous auth (`X-Jazz-Local-Mode: anonymous`)                 | `JAZZ_ALLOW_ANONYMOUS` | see `NODE_ENV` note below |
-| `--allow-demo`                      | Allow local demo auth (`X-Jazz-Local-Mode: demo`)                           | `JAZZ_ALLOW_DEMO`      | see `NODE_ENV` note below |
-| `--backend-secret <BACKEND_SECRET>` | Enable backend session impersonation                                        | `JAZZ_BACKEND_SECRET`  | unset                     |
-| `--admin-secret <ADMIN_SECRET>`     | Enable admin operations (schema/policy sync)                                | `JAZZ_ADMIN_SECRET`    | unset                     |
+| Option                              | Purpose                                                                                                                                            | Environment variable   | Default                   |
+| ----------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------- | ------------------------- |
+| `<APP_ID>` (positional)             | App namespace identifier (required)                                                                                                                | -                      | -                         |
+| `-p, --port <PORT>`                 | Listen port                                                                                                                                        | -                      | `1625`                    |
+| `-d, --data-dir <DATA_DIR>`         | Persistent storage directory                                                                                                                       | -                      | `./data`                  |
+| `--in-memory`                       | Use in-memory storage instead of files; data is lost when the process exits                                                                        | -                      | off                       |
+| `--jwks-url <JWKS_URL>`             | JWKS endpoint for external JWT validation                                                                                                          | `JAZZ_JWKS_URL`        | unset                     |
+| `--allow-anonymous`                 | Allow local anonymous auth (`X-Jazz-Local-Mode: anonymous`)                                                                                        | `JAZZ_ALLOW_ANONYMOUS` | see `NODE_ENV` note below |
+| `--allow-demo`                      | Allow local demo auth (`X-Jazz-Local-Mode: demo`)                                                                                                  | `JAZZ_ALLOW_DEMO`      | see `NODE_ENV` note below |
+| `--backend-secret <BACKEND_SECRET>` | Enable backend session impersonation                                                                                                               | `JAZZ_BACKEND_SECRET`  | unset                     |
+| `--admin-secret <ADMIN_SECRET>`     | Required for `permissions push`, `migrations push`, and schema catalogue reads. In development mode, structural schema auto-sync works without it. | `JAZZ_ADMIN_SECRET`    | unset                     |
 
 Local auth defaults depend on `NODE_ENV`:
 
@@ -82,8 +82,16 @@ For auth modes and upgrade/link flow, see [Authentication](/docs/auth/authentica
 
 <CreateJazzClientReference />
 
-In browser clients, omitting local auth fields defaults to anonymous synthetic auth with a persisted local token.
+In browser clients, omitting `jwtToken` and `localAuthToken` defaults to anonymous auth with a persisted local token.
 For React Native/Expo clients, make sure `serverUrl` points to a host your runtime can reach (for example Android emulator often uses `10.0.2.2`).
+
+### Storage driver
+
+By default, browser clients use `driver: { type: "persistent" }`, which runs a dedicated worker
+with OPFS-backed storage for offline support and local durability. Set `driver: { type: "memory" }`
+to skip the worker and OPFS entirely &hairsp;— &hairsp;the runtime keeps data in memory only and
+syncs directly with the server. `memory` mode requires `serverUrl` to be set, since there is no
+local persistence.
 
 ### Backend context setup
 

--- a/docs/content/docs/schemas/migrations.mdx
+++ b/docs/content/docs/schemas/migrations.mdx
@@ -1,7 +1,7 @@
 ---
 title: Migrations
 description: Structural schema evolution workflow and reviewed migration edges.
-reviewedAt: "4059cdef"
+reviewedAt: "f6535a533"
 ---
 
 <Callout type="info" title="You can skip this first">
@@ -14,13 +14,13 @@ Traditional migration systems run a linear sequence and require peers to converg
 
 ## Workflow
 
-1. **Edit `schema.ts`** — change the data shape as needed.
-2. **Validate locally** — optionally run `npx jazz-tools@alpha validate` to catch authoring errors
+1. **Edit `schema.ts`**&hairsp;—&hairsp;change the data shape as needed.
+2. **Validate locally**&hairsp;—&hairsp;optionally run `npx jazz-tools@alpha validate` to catch authoring errors
    before connecting.
-3. **Connect a dev client** — on development servers (`NODE_ENV` unset or anything except
+3. **Connect a dev client**&hairsp;—&hairsp;on development servers (`NODE_ENV` unset or anything except
    `production`), clients auto-publish the new structural schema hash when they connect. This
    teaches the server the new hash but does not create compatibility edges for existing data.
-4. **Generate a migration stub** — once Jazz reports the old and new hash pair, run:
+4. **Generate a migration stub**&hairsp;—&hairsp;once Jazz reports the old and new hash pair, run:
 
    ```bash
    npx jazz-tools@alpha migrations create <fromHash> <toHash>
@@ -29,9 +29,9 @@ Traditional migration systems run a linear sequence and require peers to converg
    This writes a typed `defineMigration(...)` file into `migrations/` with the structural diff
    pre-filled and `from`/`to` schema witnesses for type safety.
 
-5. **Review and customise** — rename the file to something meaningful, adjust defaults, add
+5. **Review and customise**&hairsp;—&hairsp;rename the file to something meaningful, adjust defaults, add
    backwards defaults if needed (see below).
-6. **Publish** — push the migration to the server:
+6. **Publish**&hairsp;—&hairsp;push the migration to the server:
 
    ```bash
    npx jazz-tools@alpha migrations push <fromHash> <toHash>
@@ -41,6 +41,18 @@ Permission-only changes in `permissions.ts` do not need migrations, but they do 
 `npx jazz-tools@alpha permissions push`. See [Permissions](/docs/auth/permissions) for details.
 
 ## Generated stub
+
+Under the hood, each migration produces a **lens**&hairsp;—&hairsp;a bidirectional transformation
+between two schema versions. The forward direction applies the migration; the backward direction is
+generated automatically so older clients can still read data written under the new schema. The
+generated stub contains the structural diff as declarative operations.
+
+<Callout type="warn">
+  If the diff contains ambiguities (e.g. a column was removed and a same-typed column was added,
+  which could be a rename), the generated lens is marked as a **draft**. Draft lenses will fail at
+  startup if they are in the path to a live schema. You need to review the draft lens and resolve
+  the ambiguity before publishing.
+</Callout>
 
 Here's a generated stub for adding a `description` column:
 

--- a/examples/docs/todo-client-localfirst-ts/src/quickstart.ts
+++ b/examples/docs/todo-client-localfirst-ts/src/quickstart.ts
@@ -6,6 +6,7 @@ import { renderTodoItem } from "./TodoItem.js";
 const db = await createDb({
   appId: "my-todo-app",
 });
+// use db.shutdown() to clean up when finished
 // #endregion setup-ts
 
 // #region list-ts

--- a/examples/docs/todo-server-ts/src/permissions-snippets.ts
+++ b/examples/docs/todo-server-ts/src/permissions-snippets.ts
@@ -120,3 +120,12 @@ s.definePermissions(exampleApp, ({ policy, anyOf, session }) => {
   );
 });
 // #endregion permissions-shares-ts
+
+// #region permissions-whereold-wherenew-ts
+s.definePermissions(exampleApp, ({ policy, session }) => {
+  // User can only update their own rows, and the result must still be owned by them
+  policy.todos.allowUpdate
+    .whereOld({ owner_id: session.user_id })
+    .whereNew({ owner_id: session.user_id });
+});
+// #endregion permissions-whereold-wherenew-ts

--- a/packages/jazz-tools/src/runtime/sync-transport.test.ts
+++ b/packages/jazz-tools/src/runtime/sync-transport.test.ts
@@ -527,7 +527,7 @@ describe("sync-transport", () => {
       expect.stringContaining("[client] Detected 3 rows of todos with differing schema versions."),
     );
     expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining("npx jazz-tools migrations create aaaaaaaaaaaa bbbbbbbbbbbb"),
+      expect.stringContaining("npx jazz-tools@alpha migrations create aaaaaaaaaaaa bbbbbbbbbbbb"),
     );
     expect(onSyncMessage).toHaveBeenCalledWith(
       JSON.stringify({

--- a/packages/jazz-tools/src/runtime/sync-transport.ts
+++ b/packages/jazz-tools/src/runtime/sync-transport.ts
@@ -113,7 +113,7 @@ function logSchemaWarningPayload(payload: any, logPrefix = ""): void {
   console.warn(
     `${logPrefix}Detected ${rowCount} rows of ${tableName} with differing schema versions. ` +
       `To ensure data visibility and forward/backward compatibility please create a new migration with ` +
-      `\`npx jazz-tools migrations create ${shortHash(fromHash)} ${shortHash(toHash)}\``,
+      `\`npx jazz-tools@alpha migrations create ${shortHash(fromHash)} ${shortHash(toHash)}\``,
   );
 }
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,7 @@ packages:
   - docs
   - packages/*
   - examples/*
+  - "!examples/world-tour"
   - examples/docs/*
   - stress-tests/*
   - crates


### PR DESCRIPTION
## Summary

- **New Advanced Internals reference page** covering data model (row=object, auto-indexing, deletion, history, cold start), browser architecture (dual-runtime, OPFS crash safety, tab coordination, React Native), query engine (pipeline, one-shot queries, include performance), sync protocol (transport, client identity, reconnection, trust model, client roles), schema evolution (lenses, draft lenses, catalogue sync), and durability signals (QuerySettled vs PersistenceAck).

- **Docs gap fixes** identified by auditing all 14 status-quo specs against the public docs:
  - Clarify versioned objects and content-addressed commits in local-first data model page
  - Document read durability tier behaviour (gates first delivery only, `localUpdates` semantics, known limitation)
  - Add durable reads section to queries page
  - Document `.whereOld()` / `.whereNew()` for update permission policies
  - Clarify `--admin-secret` dev vs prod behaviour and add storage driver section to server setup
  - Add common sync errors FAQ entry
  - Clarify Rust `join()`/`on()` has same inner-join semantics as TS `include()`
  - Add lens and draft lens explanation to migrations page
  - Clarify base64 encoding for `X-Jazz-Session`
  - Improve docs landing page with differentiator and hero code snippet
  - Add `db.shutdown()` comment to TS quickstart

- **Fix** bare `npx jazz-tools` references missing `@alpha` tag in 4 runtime error messages (3 Rust, 1 TypeScript)

- **Exclude** `examples/world-tour` from pnpm workspace to avoid pulling in maplibre (~8MB) on every install

## Test plan

- [ ] Docs site builds (`pnpm build` in docs/)
- [ ] Verify internals page renders correctly
- [ ] Verify all edited pages render without broken links or includes
- [ ] `pnpm install` from repo root no longer pulls maplibre