### PR TITLE
Fix offline worker reconnect after network loss

### DIFF
--- a/.changeset/odd-bats-wave.md
+++ b/.changeset/odd-bats-wave.md
@@ -1,0 +1,7 @@
+---
+"jazz-tools": patch
+---
+
+Fix browser worker reconnect after network loss when offline `worker`-tier writes were queued locally.
+
+The worker now aborts its stale upstream events stream before scheduling reconnect after sync POST failures, which lets later writes promote normally once network access returns. This also adds browser regression coverage for the split-context reconnect case where one client stays online while another writes offline and reconnects.

--- a/packages/jazz-tools/src/worker/jazz-worker.ts
+++ b/packages/jazz-tools/src/worker/jazz-worker.ts
@@ -53,6 +53,11 @@ let initComplete = false;
 const DEFAULT_WASM_LOG_LEVEL = "warn";
 let bootstrapCatalogueForwarding = false;
 
+function abortActiveStreamForReconnect(): void {
+  if (!streamAbortController || streamAbortController.signal.aborted) return;
+  streamAbortController.abort();
+}
+
 // Accumulates non-catalogue server-bound payloads within a microtask boundary
 // and flushes them as a single ordered batch POST.
 const serverPayloadBatcher = new ServerPayloadBatcher(async (payloads) => {
@@ -75,6 +80,7 @@ const serverPayloadBatcher = new ServerPayloadBatcher(async (payloads) => {
     if (!isExpectedFetchAbortError(error)) {
       console.error("[worker] Sync batch POST error:", error);
     }
+    abortActiveStreamForReconnect();
     detachServer();
     scheduleReconnect();
   }
@@ -273,6 +279,7 @@ async function handleInit(msg: InitMessage): Promise<void> {
                 if (!isExpectedFetchAbortError(error)) {
                   console.error("[worker] Sync POST error:", error);
                 }
+                abortActiveStreamForReconnect();
                 detachServer();
                 scheduleReconnect();
               });

--- a/packages/jazz-tools/tests/browser/remote-browser-db-node.ts
+++ b/packages/jazz-tools/tests/browser/remote-browser-db-node.ts
@@ -1,0 +1,92 @@
+import type { Browser, BrowserContext, Page } from "playwright";
+import type {
+  RemoteBrowserDbCreateInput,
+  RemoteBrowserDbWaitForTitleInput,
+} from "./remote-db-harness.js";
+
+interface RemoteBrowserDbHandle {
+  context: BrowserContext;
+  page: Page;
+}
+
+const remoteBrowserDbs = new Map<string, RemoteBrowserDbHandle>();
+const remoteHarnessModulePath = "/tests/browser/remote-db-harness.ts";
+
+function getBrowserFromContext(context: BrowserContext): Browser {
+  const browser = context.browser();
+  if (!browser) {
+    throw new Error("Expected an attached Playwright browser for remote browser db commands");
+  }
+  return browser;
+}
+
+function harnessUrlFromPage(page: Page): string {
+  const currentUrl = page.url();
+  if (!currentUrl) {
+    throw new Error("Expected current test page to have a URL before opening remote browser db");
+  }
+  return new URL("/tests/browser/remote-db-harness.html", currentUrl).toString();
+}
+
+async function evaluateHarness<TArgs, TResult>(
+  page: Page,
+  moduleMethod: string,
+  args: TArgs,
+): Promise<TResult> {
+  return page.evaluate(
+    async ({ moduleMethod, args, modulePath }) => {
+      const harness = await import(/* @vite-ignore */ modulePath);
+      const method = (harness as Record<string, (value: TArgs) => Promise<TResult>>)[moduleMethod];
+      if (typeof method !== "function") {
+        throw new Error(`Remote browser harness method "${moduleMethod}" is unavailable`);
+      }
+      return method(args);
+    },
+    { moduleMethod, args, modulePath: remoteHarnessModulePath },
+  );
+}
+
+export async function createRemoteBrowserDb(
+  currentContext: BrowserContext,
+  currentPage: Page,
+  input: RemoteBrowserDbCreateInput,
+): Promise<void> {
+  await closeRemoteBrowserDb(input.id);
+
+  const browser = getBrowserFromContext(currentContext);
+  const remoteContext = await browser.newContext();
+  const remotePage = await remoteContext.newPage();
+  await remotePage.goto(harnessUrlFromPage(currentPage), { waitUntil: "domcontentloaded" });
+  await evaluateHarness(remotePage, "createRemoteBrowserDb", input);
+
+  remoteBrowserDbs.set(input.id, {
+    context: remoteContext,
+    page: remotePage,
+  });
+}
+
+export async function waitForRemoteBrowserDbTitle(
+  input: RemoteBrowserDbWaitForTitleInput,
+): Promise<Record<string, unknown>[]> {
+  const handle = remoteBrowserDbs.get(input.id);
+  if (!handle) {
+    throw new Error(`Remote browser db "${input.id}" is not open`);
+  }
+
+  return evaluateHarness(handle.page, "waitForRemoteBrowserDbTitle", input);
+}
+
+export async function closeRemoteBrowserDb(id: string): Promise<void> {
+  const handle = remoteBrowserDbs.get(id);
+  if (!handle) {
+    return;
+  }
+
+  remoteBrowserDbs.delete(id);
+  try {
+    await evaluateHarness(handle.page, "closeRemoteBrowserDb", id);
+  } catch {
+    // Best effort: page or worker may already be gone.
+  }
+  await handle.context.close();
+}

--- a/packages/jazz-tools/tests/browser/remote-browser-db.ts
+++ b/packages/jazz-tools/tests/browser/remote-browser-db.ts
@@ -1,0 +1,29 @@
+import { commands } from "vitest/browser";
+import type {
+  RemoteBrowserDbCreateInput,
+  RemoteBrowserDbWaitForTitleInput,
+} from "./remote-db-harness.js";
+
+declare module "vitest/internal/browser" {
+  interface BrowserCommands {
+    createRemoteBrowserDb: (input: RemoteBrowserDbCreateInput) => Promise<void>;
+    waitForRemoteBrowserDbTitle: (
+      input: RemoteBrowserDbWaitForTitleInput,
+    ) => Promise<Record<string, unknown>[]>;
+    closeRemoteBrowserDb: (id: string) => Promise<void>;
+  }
+}
+
+export function createRemoteBrowserDb(input: RemoteBrowserDbCreateInput): Promise<void> {
+  return commands.createRemoteBrowserDb(input);
+}
+
+export function waitForRemoteBrowserDbTitle(
+  input: RemoteBrowserDbWaitForTitleInput,
+): Promise<Record<string, unknown>[]> {
+  return commands.waitForRemoteBrowserDbTitle(input);
+}
+
+export function closeRemoteBrowserDb(id: string): Promise<void> {
+  return commands.closeRemoteBrowserDb(id);
+}

--- a/packages/jazz-tools/tests/browser/remote-db-harness.html
+++ b/packages/jazz-tools/tests/browser/remote-db-harness.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Jazz Remote DB Harness</title>
+    <script>
+      globalThis.__vitest_browser_runner__ = {
+        wrapDynamicImport(loader) {
+          return loader();
+        },
+      };
+    </script>
+  </head>
+  <body>
+    <p>Jazz remote DB harness</p>
+  </body>
+</html>

--- a/packages/jazz-tools/tests/browser/remote-db-harness.ts
+++ b/packages/jazz-tools/tests/browser/remote-db-harness.ts
@@ -1,0 +1,134 @@
+import { createDb, type Db, type QueryBuilder } from "../../src/runtime/db.js";
+import type { DbConfig } from "../../src/runtime/db.js";
+import type { WasmSchema } from "../../src/drivers/types.js";
+
+export interface RemoteBrowserDbCreateInput {
+  id: string;
+  appId: string;
+  dbName: string;
+  table: string;
+  schemaJson: string;
+  serverUrl?: string;
+  adminSecret?: string;
+  localAuthMode?: "anonymous" | "demo";
+  localAuthToken?: string;
+  logLevel?: DbConfig["logLevel"];
+}
+
+export interface RemoteBrowserDbWaitForTitleInput {
+  id: string;
+  title: string;
+  timeoutMs: number;
+  tier?: "worker" | "edge";
+}
+
+interface RemoteBrowserDbState {
+  db: Db;
+  query: QueryBuilder<Record<string, unknown>>;
+}
+
+declare global {
+  interface Window {
+    __jazzRemoteBrowserDbs__?: Map<string, RemoteBrowserDbState>;
+  }
+}
+
+function getRemoteStateStore(): Map<string, RemoteBrowserDbState> {
+  if (!window.__jazzRemoteBrowserDbs__) {
+    window.__jazzRemoteBrowserDbs__ = new Map();
+  }
+  return window.__jazzRemoteBrowserDbs__;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function makeAllRowsQuery(
+  table: string,
+  schema: WasmSchema,
+): QueryBuilder<Record<string, unknown>> {
+  return {
+    _table: table,
+    _schema: schema,
+    _rowType: {} as Record<string, unknown>,
+    _build() {
+      return JSON.stringify({
+        table,
+        conditions: [],
+        includes: {},
+        orderBy: [],
+      });
+    },
+  };
+}
+
+export async function createRemoteBrowserDb(input: RemoteBrowserDbCreateInput): Promise<void> {
+  const store = getRemoteStateStore();
+  const existing = store.get(input.id);
+  if (existing) {
+    await existing.db.shutdown();
+    store.delete(input.id);
+  }
+
+  const schema = JSON.parse(input.schemaJson) as WasmSchema;
+  const db = await createDb({
+    appId: input.appId,
+    driver: { type: "persistent", dbName: input.dbName },
+    serverUrl: input.serverUrl,
+    localAuthMode: input.localAuthMode,
+    localAuthToken: input.localAuthToken,
+    adminSecret: input.adminSecret,
+    logLevel: input.logLevel,
+  });
+
+  store.set(input.id, {
+    db,
+    query: makeAllRowsQuery(input.table, schema),
+  });
+}
+
+export async function waitForRemoteBrowserDbTitle(
+  input: RemoteBrowserDbWaitForTitleInput,
+): Promise<Record<string, unknown>[]> {
+  const store = getRemoteStateStore();
+  const state = store.get(input.id);
+  if (!state) {
+    throw new Error(`Remote browser db "${input.id}" was not initialized`);
+  }
+
+  const deadline = Date.now() + input.timeoutMs;
+  let lastRows: Record<string, unknown>[] = [];
+  let lastError: unknown = undefined;
+
+  while (Date.now() < deadline) {
+    try {
+      const rows = await state.db.all(state.query, { tier: input.tier });
+      if (rows.some((row) => row.title === input.title)) {
+        return rows;
+      }
+      lastRows = rows;
+    } catch (error) {
+      lastError = error;
+    }
+    await sleep(100);
+  }
+
+  const lastErrorMessage =
+    lastError instanceof Error ? lastError.message : lastError ? String(lastError) : "none";
+  throw new Error(
+    `Remote browser db "${input.id}" did not observe title "${input.title}" within ${input.timeoutMs}ms; ` +
+      `lastRows=${JSON.stringify(lastRows.slice(0, 10))}; lastError=${lastErrorMessage}`,
+  );
+}
+
+export async function closeRemoteBrowserDb(id: string): Promise<void> {
+  const store = getRemoteStateStore();
+  const state = store.get(id);
+  if (!state) {
+    return;
+  }
+
+  await state.db.shutdown();
+  store.delete(id);
+}

--- a/packages/jazz-tools/tests/browser/testing-server-node.ts
+++ b/packages/jazz-tools/tests/browser/testing-server-node.ts
@@ -1,4 +1,5 @@
 import { TestingServer } from "jazz-napi";
+import type { BrowserContext, Route } from "playwright";
 
 interface StartedTestingServer {
   server: TestingServer;
@@ -8,6 +9,7 @@ interface StartedTestingServer {
 }
 
 let testingServerPromise: Promise<StartedTestingServer> | null = null;
+const blockedServerRoutes = new WeakMap<BrowserContext, Map<string, (route: Route) => void>>();
 
 async function startTestingServer(): Promise<StartedTestingServer> {
   const server = await TestingServer.start();
@@ -62,4 +64,44 @@ export async function stopTestingServer(): Promise<void> {
     // Swallow all errors: either startup never produced a server (nothing to stop),
     // or stop() itself failed (nothing recoverable during teardown).
   }
+}
+
+function testingServerUrlPattern(serverUrl: string): string {
+  return `${serverUrl.replace(/\/+$/, "")}/**`;
+}
+
+export async function blockTestingServerNetwork(
+  context: BrowserContext,
+  serverUrl: string,
+): Promise<void> {
+  const pattern = testingServerUrlPattern(serverUrl);
+  let contextRoutes = blockedServerRoutes.get(context);
+  if (!contextRoutes) {
+    contextRoutes = new Map();
+    blockedServerRoutes.set(context, contextRoutes);
+  }
+  if (contextRoutes.has(pattern)) {
+    return;
+  }
+
+  const handler = (route: Route) => {
+    void route.abort("internetdisconnected");
+  };
+  contextRoutes.set(pattern, handler);
+  await context.route(pattern, handler);
+}
+
+export async function unblockTestingServerNetwork(
+  context: BrowserContext,
+  serverUrl: string,
+): Promise<void> {
+  const pattern = testingServerUrlPattern(serverUrl);
+  const contextRoutes = blockedServerRoutes.get(context);
+  const handler = contextRoutes?.get(pattern);
+  if (!handler) {
+    return;
+  }
+
+  await context.unroute(pattern, handler);
+  contextRoutes?.delete(pattern);
 }

--- a/packages/jazz-tools/tests/browser/testing-server.ts
+++ b/packages/jazz-tools/tests/browser/testing-server.ts
@@ -9,12 +9,22 @@ export interface TestingServerInfo {
 declare module "vitest/internal/browser" {
   interface BrowserCommands {
     testingServerInfo: () => Promise<TestingServerInfo>;
+    testingServerBlockNetwork: (serverUrl: string) => Promise<void>;
+    testingServerUnblockNetwork: (serverUrl: string) => Promise<void>;
     testingServerJwtForUser: (userId: string, claims?: Record<string, unknown>) => Promise<string>;
   }
 }
 
 export function getTestingServerInfo(): Promise<TestingServerInfo> {
   return commands.testingServerInfo();
+}
+
+export function blockTestingServerNetwork(serverUrl: string): Promise<void> {
+  return commands.testingServerBlockNetwork(serverUrl);
+}
+
+export function unblockTestingServerNetwork(serverUrl: string): Promise<void> {
+  return commands.testingServerUnblockNetwork(serverUrl);
 }
 
 export async function getTestingServerJwtForUser(

--- a/packages/jazz-tools/tests/browser/worker-bridge.test.ts
+++ b/packages/jazz-tools/tests/browser/worker-bridge.test.ts
@@ -20,6 +20,16 @@ import {
   waitForWorkerMessageType,
   withTimeout,
 } from "./support.js";
+import {
+  blockTestingServerNetwork,
+  getTestingServerInfo,
+  unblockTestingServerNetwork,
+} from "./testing-server.js";
+import {
+  closeRemoteBrowserDb,
+  createRemoteBrowserDb,
+  waitForRemoteBrowserDbTitle,
+} from "./remote-browser-db.js";
 
 interface DebugLensEdgeState {
   sourceHash: string;
@@ -173,6 +183,27 @@ const allCatalogueTodos: QueryBuilder<CatalogueTodo> = {
 
 describe("Worker Bridge with OPFS", () => {
   const ctx = new TestCleanup();
+  const remoteBrowserDbIds = new Set<string>();
+
+  function trackRemoteBrowserDb(id: string): string {
+    remoteBrowserDbIds.add(id);
+    return id;
+  }
+
+  async function waitForRemoteTodoTitle(
+    id: string,
+    title: string,
+    label: string,
+    timeoutMs: number,
+    tier?: "worker" | "edge",
+  ): Promise<Record<string, unknown>[]> {
+    try {
+      return await waitForRemoteBrowserDbTitle({ id, title, timeoutMs, tier });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(`${label}: ${message}`);
+    }
+  }
 
   /** Shorthand: track a Db for cleanup. */
   function track(db: Db): Db {
@@ -252,7 +283,17 @@ describe("Worker Bridge with OPFS", () => {
     return leader;
   }
 
-  afterEach(() => ctx.cleanup());
+  afterEach(async () => {
+    for (const id of remoteBrowserDbIds) {
+      try {
+        await closeRemoteBrowserDb(id);
+      } catch {
+        // Best effort
+      }
+    }
+    remoteBrowserDbIds.clear();
+    await ctx.cleanup();
+  });
 
   // -------------------------------------------------------------------------
   // 1. Worker initialization
@@ -816,6 +857,169 @@ describe("Worker Bridge with OPFS", () => {
     );
     expect(rowsOnA.some((row) => row.title === title)).toBe(true);
   }, 60000);
+
+  it("recovers sync after browser-side network loss with B in a separate context", async () => {
+    const sharedLocalAuthToken = `sync-network-recover-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const { appId, serverUrl, adminSecret } = await getTestingServerInfo();
+    const dbA = await createSyncedDb(ctx, "sync-recover-a", sharedLocalAuthToken);
+    const remoteDbId = trackRemoteBrowserDb(uniqueDbName("sync-recover-remote"));
+    await createRemoteBrowserDb({
+      id: remoteDbId,
+      appId,
+      dbName: uniqueDbName("sync-recover-b"),
+      table: "todos",
+      schemaJson: JSON.stringify(schema),
+      serverUrl,
+      adminSecret,
+      localAuthMode: "anonymous",
+      localAuthToken: sharedLocalAuthToken,
+    });
+
+    const baselineTitle = `baseline-network-recover-${Date.now()}`;
+    await withTimeout(
+      dbA.insertDurable(todos, { title: baselineTitle, done: false }, { tier: "worker" }),
+      10000,
+      "Baseline insert(worker) did not resolve",
+    );
+
+    await waitForRemoteTodoTitle(
+      remoteDbId,
+      baselineTitle,
+      "B sees baseline row before browser-side network block",
+      20000,
+    );
+
+    await blockTestingServerNetwork(serverUrl);
+    await sleep(500);
+    await unblockTestingServerNetwork(serverUrl);
+    await sleep(250);
+
+    (dbA as any).sendLifecycleHint?.("freeze");
+    await sleep(50);
+    (dbA as any).sendLifecycleHint?.("resume");
+    (dbA as any).workerBridge?.replayServerConnection?.();
+
+    const recoveredTitle = `network-recovered-${Date.now()}`;
+    await withTimeout(
+      dbA.insertDurable(todos, { title: recoveredTitle, done: false }, { tier: "worker" }),
+      10000,
+      "Recovered insert(worker) did not resolve",
+    );
+
+    const rowsOnB = await waitForRemoteTodoTitle(
+      remoteDbId,
+      recoveredTitle,
+      "B sees row written after browser-side network recovery",
+      20000,
+    );
+    expect(rowsOnB.some((row) => row.title === recoveredTitle)).toBe(true);
+  }, 60000);
+
+  /**
+   *   A ──baseline write──► server ◄── B sees baseline
+   *   browser blocks Jazz server traffic without reloading the page
+   *   A ──offline write(worker)──X server
+   *   A ──new online write──► server ◄── B sees control write
+   *   expected: the earlier offline worker write also promotes to B + fresh edge client
+   */
+  it("promotes offline worker rows after reconnect while the worker stays alive", async () => {
+    const sharedLocalAuthToken = `sync-offline-reconnect-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const { appId, serverUrl, adminSecret } = await getTestingServerInfo();
+    const dbA = await createSyncedDb(ctx, "sync-offline-a", sharedLocalAuthToken);
+    const remoteDbId = trackRemoteBrowserDb(uniqueDbName("sync-offline-remote"));
+    await createRemoteBrowserDb({
+      id: remoteDbId,
+      appId,
+      dbName: uniqueDbName("sync-offline-b"),
+      table: "todos",
+      schemaJson: JSON.stringify(schema),
+      serverUrl,
+      adminSecret,
+      localAuthMode: "anonymous",
+      localAuthToken: sharedLocalAuthToken,
+    });
+
+    const baselineTitle = `baseline-before-offline-${Date.now()}`;
+    await withTimeout(
+      dbA.insertDurable(todos, { title: baselineTitle, done: false }, { tier: "worker" }),
+      10000,
+      "Baseline insert(worker) did not resolve",
+    );
+
+    await waitForRemoteTodoTitle(
+      remoteDbId,
+      baselineTitle,
+      "B sees baseline row before disconnect",
+      20000,
+    );
+
+    await blockTestingServerNetwork(serverUrl);
+    await sleep(250);
+
+    const offlineTitle = `offline-worker-row-${Date.now()}`;
+    await withTimeout(
+      dbA.insertDurable(todos, { title: offlineTitle, done: true }, { tier: "worker" }),
+      10000,
+      "Offline insert(worker) did not resolve",
+    );
+
+    await waitForTodos(
+      dbA,
+      (rows) => rows.some((row) => row.title === offlineTitle),
+      "A sees offline worker row locally",
+      10000,
+      "worker",
+    );
+
+    await expect(
+      waitForRemoteTodoTitle(
+        remoteDbId,
+        offlineTitle,
+        "B should not see offline row while A is disconnected",
+        2500,
+      ),
+    ).rejects.toThrow();
+
+    await unblockTestingServerNetwork(serverUrl);
+    await sleep(250);
+
+    (dbA as any).sendLifecycleHint?.("freeze");
+    await sleep(50);
+    (dbA as any).sendLifecycleHint?.("resume");
+    (dbA as any).workerBridge?.replayServerConnection?.();
+
+    const postReconnectTitle = `post-reconnect-control-${Date.now()}`;
+    await withTimeout(
+      dbA.insertDurable(todos, { title: postReconnectTitle, done: false }, { tier: "worker" }),
+      10000,
+      "Post-reconnect control insert(worker) did not resolve",
+    );
+
+    await waitForRemoteTodoTitle(
+      remoteDbId,
+      postReconnectTitle,
+      "B sees control row written after reconnect",
+      20000,
+    );
+
+    const rowsOnB = await waitForRemoteTodoTitle(
+      remoteDbId,
+      offlineTitle,
+      "B sees offline worker row after reconnect",
+      20000,
+    );
+    expect(rowsOnB.some((row) => row.title === offlineTitle)).toBe(true);
+
+    const dbProbe = await createSyncedDb(ctx, "sync-offline-probe", sharedLocalAuthToken);
+    const rowsOnProbe = await waitForTodos(
+      dbProbe,
+      (rows) => rows.some((row) => row.title === offlineTitle),
+      "Fresh client sees offline worker row at edge after reconnect",
+      20000,
+      "edge",
+    );
+    expect(rowsOnProbe.some((row) => row.title === offlineTitle)).toBe(true);
+  }, 120000);
 
   it("local-only subscriptions receive rows from opfs", async () => {
     const dbName = uniqueDbName("sync-local-only");

--- a/packages/jazz-tools/tests/browser/worker-bridge.test.ts
+++ b/packages/jazz-tools/tests/browser/worker-bridge.test.ts
@@ -995,6 +995,13 @@ describe("Worker Bridge with OPFS", () => {
       "Post-reconnect control insert(worker) did not resolve",
     );
 
+    await waitForTodos(
+      dbA,
+      (rows) => rows.some((row) => row.title === postReconnectTitle),
+      "A sees control row locally after reconnect",
+      10000,
+      "worker",
+    );
     await waitForRemoteTodoTitle(
       remoteDbId,
       postReconnectTitle,

--- a/packages/jazz-tools/vitest.config.browser.ts
+++ b/packages/jazz-tools/vitest.config.browser.ts
@@ -3,7 +3,17 @@ import wasm from "vite-plugin-wasm";
 import topLevelAwait from "vite-plugin-top-level-await";
 import { resolve } from "node:path";
 import { playwright } from "@vitest/browser-playwright";
-import { testingServerInfo, testingServerJwtForUser } from "./tests/browser/testing-server-node.js";
+import {
+  blockTestingServerNetwork,
+  testingServerInfo,
+  testingServerJwtForUser,
+  unblockTestingServerNetwork,
+} from "./tests/browser/testing-server-node.js";
+import {
+  closeRemoteBrowserDb,
+  createRemoteBrowserDb,
+  waitForRemoteBrowserDbTitle,
+} from "./tests/browser/remote-browser-db-node.js";
 
 const realisticBrowserScenarios = process.env.JAZZ_REALISTIC_BROWSER_SCENARIOS ?? "";
 const realisticBrowserRunId = process.env.JAZZ_REALISTIC_BROWSER_RUN_ID ?? "";
@@ -43,6 +53,15 @@ export default defineConfig({
       instances: [{ browser: "chromium", headless: true }],
       commands: {
         testingServerInfo: async () => testingServerInfo(),
+        testingServerBlockNetwork: async ({ context }, serverUrl) =>
+          blockTestingServerNetwork(context, serverUrl),
+        testingServerUnblockNetwork: async ({ context }, serverUrl) =>
+          unblockTestingServerNetwork(context, serverUrl),
+        createRemoteBrowserDb: async ({ context, page }, input) =>
+          createRemoteBrowserDb(context, page, input),
+        waitForRemoteBrowserDbTitle: async (_commandContext, input) =>
+          waitForRemoteBrowserDbTitle(input),
+        closeRemoteBrowserDb: async (_commandContext, id) => closeRemoteBrowserDb(id),
         testingServerJwtForUser: async (_context, userId, claims) =>
           testingServerJwtForUser(userId, claims),
       },


### PR DESCRIPTION
## What changed

- add a browser regression harness that keeps client B in a separate Playwright browser context while blocking Jazz server traffic only for client A
- add a regression test for offline `worker` writes across browser-side disconnect and reconnect
- fix the worker reconnect path by aborting the stale events stream before detaching the server edge and scheduling a reconnect retry
- strengthen the regression by asserting the post-reconnect control write reaches A's local worker before waiting for B

## Why

The new browser repro showed a realistic failure mode:

1. A and B sync normally
2. only A loses network to the Jazz server
3. A performs an offline `worker` write
4. after network returns, even a fresh control write from A does not reach B

The root cause was that outbound POST failure detached the runtime server edge and scheduled reconnect, but left the old events stream alive. That kept the worker stuck in an effective `streamConnecting` state, so reconnect attempts were skipped and later writes never promoted upstream.

## Impact

- offline worker-tier writes now promote after reconnect in the split-context browser scenario
- ordinary browser-side reconnect without offline writes still works
- the new regression should keep this path covered going forward

## Validation

- `pnpm exec oxlint packages/jazz-tools/src/worker/jazz-worker.ts packages/jazz-tools/tests/browser/worker-bridge.test.ts`
- `pnpm --filter jazz-tools exec vitest run --config vitest.config.browser.ts tests/browser/worker-bridge.test.ts -t "promotes offline worker rows after reconnect while the worker stays alive|recovers sync after browser-side network loss with B in a separate context"`
