### PR TITLE
[codex] Show full schema file and require schema namespace imports

### DIFF
--- a/docs/content/docs/schemas/defining-tables.mdx
+++ b/docs/content/docs/schemas/defining-tables.mdx
@@ -24,10 +24,12 @@ separate file. The `migrations/` directory holds reviewed migration stubs — se
 
 ## Table definitions
 
-Tables are defined in `schema.ts` using the Jazz DSL. Each `s.table(...)` call registers a table and `s.ref(...)` defines typed relations between them.
+Tables are defined in `schema.ts` using the Jazz DSL. A typical schema file imports the DSL,
+defines its tables, exports the typed `app`, and can derive helper types in the same module. Each
+`s.table(...)` call registers a table and `s.ref(...)` defines typed relations between them.
 
 <include cwd lang="ts" meta='title="schema.ts"'>
-  ../examples/docs/todo-client-localfirst-ts/schema.ts#schema-todo-client-ts
+  ../examples/docs/schema-defining-tables/schema.ts
 </include>
 
 <Callout type="warn">
@@ -46,12 +48,9 @@ If you need to clear local browser data after a schema change, see [How do I res
 
 ## Exporting the app
 
-`s.defineApp(schema)` converts your schema definition into a typed `app` object. This is what you
-pass to queries, mutations, and subscriptions throughout your application code.
-
-<include cwd lang="ts" meta='title="schema.ts"'>
-  ../examples/docs/todo-client-localfirst-ts/schema.ts#schema-define-app-ts
-</include>
+In the example above, `s.defineApp(schema)` converts your schema definition into a typed `app`
+object. This is what you pass to queries, mutations, and subscriptions throughout your application
+code.
 
 The `app` object has one typed table handle per table (e.g. `app.todos`, `app.projects`). Table handles are query builders&hairsp;—&hairsp;you chain `.where()`, `.include()`, `.orderBy()` and other methods directly on them.
 

--- a/examples/docs/schema-defining-tables/schema.ts
+++ b/examples/docs/schema-defining-tables/schema.ts
@@ -1,0 +1,20 @@
+import { schema as s } from "jazz-tools";
+
+const schema = {
+  projects: s.table({
+    name: s.string(),
+  }),
+  todos: s.table({
+    title: s.string(),
+    done: s.boolean(),
+    description: s.string().optional(),
+    parentId: s.ref("todos").optional(),
+    projectId: s.ref("projects").optional(),
+  }),
+};
+
+type AppSchema = s.Schema<typeof schema>;
+export const app: s.App<AppSchema> = s.defineApp(schema);
+
+export type Todo = s.RowOf<typeof app.todos>;
+export type TodoQueryBuilder = typeof app.todos;

--- a/examples/wequencer/schema/migration_v2_v3_942c3359fce7_f9bfb520269b.ts
+++ b/examples/wequencer/schema/migration_v2_v3_942c3359fce7_f9bfb520269b.ts
@@ -1,14 +1,14 @@
-import { migrate, col } from "jazz-tools";
+import { schema as s } from "jazz-tools";
 
-migrate("file_parts", {
+s.migrate("file_parts", {
   // TODO: Table-level operation not yet supported in TypeScript DSL
 });
 
-migrate("files", {
+s.migrate("files", {
   // TODO: Table-level operation not yet supported in TypeScript DSL
 });
 
-migrate("instruments", {
-  sound: col.drop().bytes({ backwardsDefault: new Uint8Array([]) }),
-  soundFileId: col.add().optional().string({ default: null }),
+s.migrate("instruments", {
+  sound: s.drop.bytes({ backwardsDefault: new Uint8Array([]) }),
+  soundFileId: s.add.string({ default: null }),
 });

--- a/packages/inspector/tests/browser/schema.ts
+++ b/packages/inspector/tests/browser/schema.ts
@@ -1,12 +1,12 @@
-import { col, defineApp, type Schema, type App } from "jazz-tools";
+import { schema as s } from "jazz-tools";
 
 const schema = {
-  todos: {
-    title: col.string(),
-    done: col.boolean(),
-  },
+  todos: s.table({
+    title: s.string(),
+    done: s.boolean(),
+  }),
 };
 
-type AppSchema = Schema<typeof schema>;
+type AppSchema = s.Schema<typeof schema>;
 
-export const app: App<AppSchema> = defineApp(schema);
+export const app: s.App<AppSchema> = s.defineApp(schema);

--- a/packages/jazz-tools/src/index.test.ts
+++ b/packages/jazz-tools/src/index.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import * as jazzTools from "./index.js";
+
+describe("public schema namespace exports", () => {
+  it("exposes schema helpers only through the schema namespace", () => {
+    expect(jazzTools.schema).toBeDefined();
+    expect(typeof jazzTools.schema.table).toBe("function");
+    expect(typeof jazzTools.schema.defineApp).toBe("function");
+    expect(typeof jazzTools.schema.defineMigration).toBe("function");
+    expect(typeof jazzTools.schema.definePermissions).toBe("function");
+    expect(typeof jazzTools.schema.migrate).toBe("function");
+
+    expect("table" in jazzTools).toBe(false);
+    expect("col" in jazzTools).toBe(false);
+    expect("defineSchema" in jazzTools).toBe(false);
+    expect("defineApp" in jazzTools).toBe(false);
+    expect("defineMigration" in jazzTools).toBe(false);
+    expect("definePermissions" in jazzTools).toBe(false);
+    expect("migrate" in jazzTools).toBe(false);
+    expect("getCollectedSchema" in jazzTools).toBe(false);
+    expect("getCollectedMigration" in jazzTools).toBe(false);
+    expect("resetCollectedState" in jazzTools).toBe(false);
+  });
+});

--- a/packages/jazz-tools/src/index.ts
+++ b/packages/jazz-tools/src/index.ts
@@ -1,13 +1,6 @@
 // Public exports
 
-import {
-  col,
-  getCollectedMigration,
-  getCollectedSchema,
-  migrate,
-  resetCollectedState,
-  table,
-} from "./dsl.js";
+import { col, migrate } from "./dsl.js";
 import { defineMigration } from "./migrations.js";
 import { definePermissions } from "./permissions/index.js";
 import {
@@ -29,15 +22,6 @@ import type {
   WhereOf as TypedWhereOf,
 } from "./typed-app.js";
 
-// DSL for schema definitions
-export {
-  table,
-  col,
-  migrate,
-  getCollectedSchema,
-  getCollectedMigration,
-  resetCollectedState,
-} from "./dsl.js";
 export type {
   Schema as SchemaAst,
   Table as SchemaAstTable,
@@ -100,21 +84,11 @@ export type {
 
 // Typed schema app
 export { schemaToWasm } from "./codegen/schema-reader.js";
-export {
-  defineSchema,
-  defineApp,
-  TypedTableQueryBuilder,
-  permissionIntrospectionColumns,
-} from "./typed-app.js";
-export { defineMigration } from "./migrations.js";
+export { TypedTableQueryBuilder, permissionIntrospectionColumns } from "./typed-app.js";
 export type {
-  Schema,
-  TableDefinition,
-  SchemaDefinition,
   Simplify,
   CompactSchema,
   DefinedSchema,
-  TableIndex,
   DefinedTable,
   TableRow,
   TableInit,
@@ -134,17 +108,13 @@ export type {
   Query,
   TableHandle,
   QueryHandle,
-  App,
   TypedApp,
-  RowOf,
-  InsertOf,
-  TableMetaOf,
-  WhereOf,
 } from "./typed-app.js";
 export type { DefinedMigration, MigrationShape, MigrationTableShape } from "./migrations.js";
 
 type RuntimeSchemaNamespace = typeof col & {
   table: typeof defineTable;
+  migrate: typeof migrate;
   defineSchema: typeof defineSchema;
   defineApp: typeof defineApp;
   defineMigration: typeof defineMigration;
@@ -154,6 +124,7 @@ type RuntimeSchemaNamespace = typeof col & {
 
 export const schema: RuntimeSchemaNamespace = Object.assign({}, col, {
   table: defineTable,
+  migrate,
   defineSchema,
   defineApp,
   defineMigration,
@@ -182,7 +153,15 @@ export * from "./drivers/index.js";
 export * from "./runtime/index.js";
 
 // Permissions DSL
-export * from "./permissions/index.js";
+export type {
+  PermissionRelation,
+  WhereInputOrCallback,
+  SessionContext,
+  AllowedToContext,
+  PolicyContext,
+  CompiledPermissions,
+} from "./permissions/index.js";
+export { relationToIr, relationExistsToPolicy, anyOf, allOf } from "./permissions/index.js";
 export * from "./dev-tools/index.js";
 
 // Local synthetic users and vanilla switcher UI

--- a/packages/jazz-tools/src/permissions/type-inference.test.ts
+++ b/packages/jazz-tools/src/permissions/type-inference.test.ts
@@ -1,5 +1,5 @@
 import { describe, expectTypeOf, it } from "vitest";
-import { definePermissions } from "./index.js";
+import { schema as s } from "../index.js";
 
 interface Todo {
   id: string;
@@ -171,7 +171,7 @@ const app = {
 
 describe("permissions type inference", () => {
   it("infers row callback and where key types", () => {
-    definePermissions(app, ({ policy, anyOf, allowedTo, session }) => {
+    s.definePermissions(app, ({ policy, anyOf, allowedTo, session }) => {
       expectTypeOf(session.user_id.path).toEqualTypeOf<string[]>();
       expectTypeOf(session.userId.path).toEqualTypeOf<string[]>();
       expectTypeOf(session["claims.role"]!.path).toEqualTypeOf<string[]>();
@@ -211,7 +211,7 @@ describe("permissions type inference", () => {
   });
 
   it("exposes never() on read/insert/update/delete builders", () => {
-    definePermissions(app, ({ policy }) => [
+    s.definePermissions(app, ({ policy }) => [
       policy.todos.allowRead.never(),
       policy.todos.allowInsert.never(),
       policy.todos.allowUpdate.never(),
@@ -220,7 +220,7 @@ describe("permissions type inference", () => {
   });
 
   it("exposes always() on read/insert/update/delete builders", () => {
-    definePermissions(app, ({ policy }) => [
+    s.definePermissions(app, ({ policy }) => [
       policy.todos.allowRead.always(),
       policy.todos.allowInsert.always(),
       policy.todos.allowUpdate.always(),
@@ -229,12 +229,12 @@ describe("permissions type inference", () => {
   });
 
   it("rejects invalid table/column usage at compile time where possible", () => {
-    definePermissions(app, ({ policy, allowedTo }) => [
+    s.definePermissions(app, ({ policy, allowedTo }) => [
       policy.todos.allowRead.where({ done: true }),
       policy.todos.allowRead.where(allowedTo.read("projectId")),
     ]);
 
-    definePermissions(app, ({ policy }) => {
+    s.definePermissions(app, ({ policy }) => {
       // Type-level negative checks only: keep unreachable in normal runs.
       if ((globalThis as { __typecheck_only__?: boolean }).__typecheck_only__) {
         // @ts-expect-error unknown table key

--- a/packages/jazz-tools/tests/ts-dsl/schema-namespace-only.typecheck.ts
+++ b/packages/jazz-tools/tests/ts-dsl/schema-namespace-only.typecheck.ts
@@ -35,3 +35,17 @@ import type { SchemaDefinition } from "jazz-tools";
 import type { TableIndex } from "jazz-tools";
 // @ts-expect-error use `s.TableMetaOf`
 import type { TableMetaOf } from "jazz-tools";
+
+void [col, table, migrate, defineSchema, defineApp, defineMigration, definePermissions];
+
+export type SchemaNamespaceOnlyTypeGuards = [
+  Schema,
+  App,
+  RowOf<never>,
+  InsertOf<never>,
+  WhereOf<never>,
+  TableDefinition,
+  SchemaDefinition,
+  TableIndex,
+  TableMetaOf<never>,
+];

--- a/packages/jazz-tools/tests/ts-dsl/schema-namespace-only.typecheck.ts
+++ b/packages/jazz-tools/tests/ts-dsl/schema-namespace-only.typecheck.ts
@@ -1,0 +1,37 @@
+import { schema as s } from "jazz-tools";
+
+void s;
+
+// @ts-expect-error use `schema` as the single root schema export
+import { col } from "jazz-tools";
+// @ts-expect-error use `schema` as the single root schema export
+import { table } from "jazz-tools";
+// @ts-expect-error use `schema` as the single root schema export
+import { migrate } from "jazz-tools";
+// @ts-expect-error use `schema` as the single root schema export
+import { defineSchema } from "jazz-tools";
+// @ts-expect-error use `schema` as the single root schema export
+import { defineApp } from "jazz-tools";
+// @ts-expect-error use `schema` as the single root schema export
+import { defineMigration } from "jazz-tools";
+// @ts-expect-error use `schema` as the single root schema export
+import { definePermissions } from "jazz-tools";
+
+// @ts-expect-error use `s.Schema`
+import type { Schema } from "jazz-tools";
+// @ts-expect-error use `s.App`
+import type { App } from "jazz-tools";
+// @ts-expect-error use `s.RowOf`
+import type { RowOf } from "jazz-tools";
+// @ts-expect-error use `s.InsertOf`
+import type { InsertOf } from "jazz-tools";
+// @ts-expect-error use `s.WhereOf`
+import type { WhereOf } from "jazz-tools";
+// @ts-expect-error use `s.TableDefinition`
+import type { TableDefinition } from "jazz-tools";
+// @ts-expect-error use `s.SchemaDefinition`
+import type { SchemaDefinition } from "jazz-tools";
+// @ts-expect-error use `s.TableIndex`
+import type { TableIndex } from "jazz-tools";
+// @ts-expect-error use `s.TableMetaOf`
+import type { TableMetaOf } from "jazz-tools";


### PR DESCRIPTION
## What changed

This PR now has two related cleanup passes:

- updated `/docs/schemas/defining-tables` to show a complete `schema.ts` example instead of separate partial snippets
- removed the legacy root schema authoring exports from `jazz-tools` so schema code uses `import { schema as s } from "jazz-tools"`
- added tests that lock the public export surface to the `schema` namespace path
- migrated the remaining in-repo callers that still used the old root schema imports

## Why

The schema docs page felt incomplete compared to the quickstarts because it showed only the table body first and made readers reconstruct the full file shape themselves.

At the same time, `jazz-tools` still exposed the older root schema exports even though the intended API is the namespaced `schema as s` style. Tightening that surface makes the docs, quickstarts, and package API all point at the same pattern.

## Impact

Readers now see a copy-pasteable full `schema.ts` example up front.

Library consumers must use the namespaced schema API for schema authoring and helper types, for example:

```ts
import { schema as s } from "jazz-tools";
```

## Validation

- `pnpm exec oxfmt --check docs/content/docs/schemas/defining-tables.mdx examples/docs/schema-defining-tables/schema.ts`
- `pnpm --filter docs run types:check`
- `pnpm --filter docs run build`
- `pnpm exec oxfmt --check packages/jazz-tools/src/index.ts packages/jazz-tools/src/index.test.ts packages/jazz-tools/tests/ts-dsl/schema-namespace-only.typecheck.ts packages/jazz-tools/src/permissions/type-inference.test.ts packages/inspector/tests/browser/schema.ts examples/wequencer/schema/migration_v2_v3_942c3359fce7_f9bfb520269b.ts`
- `pnpm --filter jazz-tools exec vitest run src/index.test.ts src/permissions/type-inference.test.ts --config vitest.config.ts`
- `pnpm --filter jazz-tools exec tsc --project tsconfig.tests.json`
