### PR TITLE
 fix: permissions push

### DIFF
--- a/.changeset/swift-heads-kneel.md
+++ b/.changeset/swift-heads-kneel.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Fix schema comparison in `permissions push` CLI command

--- a/crates/jazz-tools/src/query_manager/types/schema.rs
+++ b/crates/jazz-tools/src/query_manager/types/schema.rs
@@ -217,6 +217,7 @@ pub struct ColumnDescriptor {
     pub column_type: ColumnType,
     pub nullable: bool,
     /// Optional foreign key reference to another table.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub references: Option<TableName>,
     /// Optional schema-level default used for omitted values on insert.
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/jazz-tools/src/schema_manager/catalogue_export.rs
+++ b/crates/jazz-tools/src/schema_manager/catalogue_export.rs
@@ -25,6 +25,9 @@ mod tests {
         assert_eq!(users["columns"][2]["name"], "email");
         assert_eq!(users["columns"][2]["column_type"]["type"], "Text");
         assert_eq!(users["columns"][2]["nullable"], true);
+        assert!(users["columns"][0].get("references").is_none());
+        assert!(users["columns"][1].get("references").is_none());
+        assert!(users["columns"][2].get("references").is_none());
         assert!(users["columns"][2].get("default").is_none());
     }
 }

--- a/packages/jazz-tools/src/cli.test.ts
+++ b/packages/jazz-tools/src/cli.test.ts
@@ -196,6 +196,20 @@ function storedRootSchema() {
   };
 }
 
+function storedRootSchemaWithReorderedColumns() {
+  return {
+    projects: {
+      columns: [{ name: "name", column_type: { type: "Text" }, nullable: false }],
+    },
+    todos: {
+      columns: [
+        { name: "ownerId", column_type: { type: "Text" }, nullable: false },
+        { name: "title", column_type: { type: "Text" }, nullable: false },
+      ],
+    },
+  };
+}
+
 describe("cli validate", () => {
   it("validates root schema.ts without generating SQL or app artifacts", async () => {
     const { root } = await createWorkspace();
@@ -644,6 +658,44 @@ describe("cli permissions", () => {
 
     expect(logs).toContain(`Loaded structural schema from ${join(srcDir, "schema.ts")}.`);
     expect(logs).toContain(`Loaded current permissions from ${join(srcDir, "permissions.ts")}.`);
+  });
+
+  it("matches stored schemas even when server column order differs", async () => {
+    const { root } = await createWorkspace();
+    await writeFile(join(root, "schema.ts"), rootSchemaWithoutInlinePermissions());
+    await writeFile(join(root, "permissions.ts"), rootPermissionsSchema());
+
+    const schemaHash = "ababeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
+    const fetchMock = vi.fn(async (input: string) => {
+      if (input.endsWith("/schemas")) {
+        return new Response(JSON.stringify({ hashes: [schemaHash] }), { status: 200 });
+      }
+
+      if (input.endsWith(`/schema/${schemaHash}`)) {
+        return new Response(JSON.stringify(storedRootSchemaWithReorderedColumns()), {
+          status: 200,
+        });
+      }
+
+      if (input.endsWith("/admin/permissions/head")) {
+        return new Response(JSON.stringify({ head: null }), { status: 200 });
+      }
+
+      throw new Error(`Unexpected fetch: ${input}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { logs } = await captureConsoleLogs(() =>
+      permissionsStatus({
+        serverUrl: "http://localhost:1625",
+        adminSecret: "admin-secret",
+        schemaDir: root,
+      }),
+    );
+
+    expect(logs).toContain(
+      `Local structural schema matches stored hash ${schemaHash.slice(0, 12)}.`,
+    );
   });
 
   it("publishes permissions with the current head bundle as the expected parent", async () => {

--- a/packages/jazz-tools/src/cli.ts
+++ b/packages/jazz-tools/src/cli.ts
@@ -250,7 +250,10 @@ function tableSchemasEqual(
     return false;
   }
 
-  return left.columns.every((column, index) => columnsEqual(column, right.columns[index]!));
+  const leftColumns = [...left.columns].sort((a, b) => a.name.localeCompare(b.name));
+  const rightColumns = [...right.columns].sort((a, b) => a.name.localeCompare(b.name));
+
+  return leftColumns.every((column, index) => columnsEqual(column, rightColumns[index]!));
 }
 
 function wasmSchemasEqual(left: WasmSchema, right: WasmSchema): boolean {

--- a/packages/jazz-tools/tsconfig.tests.json
+++ b/packages/jazz-tools/tsconfig.tests.json
@@ -6,7 +6,6 @@
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "noEmit": true,
-    "noUncheckedIndexedAccess": true,
     "rootDir": ".",
     "sourceMap": false,
     "paths": {


### PR DESCRIPTION
## Description

`jazz-tools permissions push` was failing even when the local schema matched the server schema, because the schemas were not considered equal:
- the server incorrectly returned `references: null` for each column without a reference
- columns could be reordered, and the CLI didn't account for this