### PR TITLE
Update auth examples to use $createdBy mutation policies

### DIFF
--- a/examples/auth-betterauth-chat/README.md
+++ b/examples/auth-betterauth-chat/README.md
@@ -9,7 +9,7 @@ What it demonstrates:
 - The `admin` plugin to assign roles (`admin` / `member`) to users
 - Fetching the JWT from the Better Auth session and passing it to `JazzProvider`
 - Falling back to anonymous `localAuth` when no session exists
-- Role-based UI gating (`admin` can post to Announcements; `member` can post to the general chat). Permissions are defined in [permissions.ts](./permissions.ts).
+- Role-based UI gating (`admin` can post to Announcements; `member` can post to the general chat). Permissions are defined in [permissions.ts](./permissions.ts), with generic-chat message ownership enforced via `$createdBy`.
 
 One default account is seeded on startup: `admin@example.com / admin` with `role = "admin"`.
 New sign-ups receive `role = "member"` by default (configured via the `admin` plugin).

--- a/examples/auth-betterauth-chat/permissions.ts
+++ b/examples/auth-betterauth-chat/permissions.ts
@@ -3,42 +3,23 @@ import { ANNOUNCEMENTS_CHAT_ID, CHAT_ID } from "./constants";
 import { app } from "./schema";
 
 export default definePermissions(app, ({ policy, allOf, anyOf, session }) => {
-  policy.messages.allowRead.where({ chat_id: ANNOUNCEMENTS_CHAT_ID });
-  policy.messages.allowRead.where(
-    allOf([{ chat_id: CHAT_ID }, session.where({ "claims.role": { in: ["admin", "member"] } })]),
-  );
+  const isAdmin = session.where({ "claims.role": "admin" });
+  const isMemberOrAdmin = session.where({ "claims.role": { in: ["admin", "member"] } });
+  const canMutateGenericChat = anyOf([{ $createdBy: session.user_id }, isAdmin]);
 
-  policy.messages.allowInsert.where(
-    allOf([{ chat_id: ANNOUNCEMENTS_CHAT_ID }, session.where({ "claims.role": "admin" })]),
-  );
-  policy.messages.allowInsert.where(
-    allOf([
-      { chat_id: CHAT_ID },
-      anyOf([{ author_id: session.user_id }, session.where({ "claims.role": "admin" })]),
-    ]),
-  );
+  policy.messages.allowRead.where({ chat_id: ANNOUNCEMENTS_CHAT_ID });
+  policy.messages.allowRead.where(allOf([{ chat_id: CHAT_ID }, isMemberOrAdmin]));
+
+  policy.messages.allowInsert.where(allOf([{ chat_id: ANNOUNCEMENTS_CHAT_ID }, isAdmin]));
+  policy.messages.allowInsert.where(allOf([{ chat_id: CHAT_ID }, isMemberOrAdmin]));
 
   policy.messages.allowUpdate
-    .whereOld(
-      allOf([{ chat_id: ANNOUNCEMENTS_CHAT_ID }, session.where({ "claims.role": "admin" })]),
-    )
+    .whereOld(allOf([{ chat_id: ANNOUNCEMENTS_CHAT_ID }, isAdmin]))
     .whereNew({ chat_id: ANNOUNCEMENTS_CHAT_ID });
   policy.messages.allowUpdate
-    .whereOld(
-      allOf([
-        { chat_id: CHAT_ID },
-        anyOf([{ author_id: session.user_id }, session.where({ "claims.role": "admin" })]),
-      ]),
-    )
+    .whereOld(allOf([{ chat_id: CHAT_ID }, canMutateGenericChat]))
     .whereNew({ chat_id: CHAT_ID });
 
-  policy.messages.allowDelete.where(
-    allOf([{ chat_id: ANNOUNCEMENTS_CHAT_ID }, session.where({ "claims.role": "admin" })]),
-  );
-  policy.messages.allowDelete.where(
-    allOf([
-      { chat_id: CHAT_ID },
-      anyOf([{ author_id: session.user_id }, session.where({ "claims.role": "admin" })]),
-    ]),
-  );
+  policy.messages.allowDelete.where(allOf([{ chat_id: ANNOUNCEMENTS_CHAT_ID }, isAdmin]));
+  policy.messages.allowDelete.where(allOf([{ chat_id: CHAT_ID }, canMutateGenericChat]));
 });

--- a/examples/auth-betterauth-chat/schema.ts
+++ b/examples/auth-betterauth-chat/schema.ts
@@ -2,7 +2,6 @@ import { schema as s } from "jazz-tools";
 
 const schema = {
   messages: s.table({
-    author_id: s.string(),
     author_name: s.string(),
     chat_id: s.string(),
     text: s.string(),

--- a/examples/auth-simple-chat/README.md
+++ b/examples/auth-simple-chat/README.md
@@ -7,7 +7,7 @@ What it demonstrates:
 - A local Express auth server that issues ES256 JWTs and exposes a JWKS endpoint
 - Passing a JWT token directly to `JazzProvider` to authenticate as a named user
 - Falling back to anonymous `localAuth` when no token is present
-- Role-based UI gating (`admin` can post to Announcements; `member` can post to the general chat). Permissions are defined in [permissions.ts](./permissions.ts).
+- Role-based UI gating (`admin` can post to Announcements; `member` can post to the general chat). Permissions are defined in [permissions.ts](./permissions.ts), with generic-chat message ownership enforced via `$createdBy`.
 
 Passwords are stored in plain text in memory for example simplicity only.
 One default account is seeded on startup: `admin@example.com / admin` with `role = "admin"`.

--- a/examples/auth-simple-chat/permissions.ts
+++ b/examples/auth-simple-chat/permissions.ts
@@ -3,42 +3,23 @@ import { ANNOUNCEMENTS_CHAT_ID, CHAT_ID } from "./constants.js";
 import { app } from "./schema.js";
 
 export default definePermissions(app, ({ policy, allOf, anyOf, session }) => {
-  policy.messages.allowRead.where({ chat_id: ANNOUNCEMENTS_CHAT_ID });
-  policy.messages.allowRead.where(
-    allOf([{ chat_id: CHAT_ID }, session.where({ "claims.role": { in: ["admin", "member"] } })]),
-  );
+  const isAdmin = session.where({ "claims.role": "admin" });
+  const isMemberOrAdmin = session.where({ "claims.role": { in: ["admin", "member"] } });
+  const canMutateGenericChat = anyOf([{ $createdBy: session.user_id }, isAdmin]);
 
-  policy.messages.allowInsert.where(
-    allOf([{ chat_id: ANNOUNCEMENTS_CHAT_ID }, session.where({ "claims.role": "admin" })]),
-  );
-  policy.messages.allowInsert.where(
-    allOf([
-      { chat_id: CHAT_ID },
-      anyOf([{ author_id: session.user_id }, session.where({ "claims.role": "admin" })]),
-    ]),
-  );
+  policy.messages.allowRead.where({ chat_id: ANNOUNCEMENTS_CHAT_ID });
+  policy.messages.allowRead.where(allOf([{ chat_id: CHAT_ID }, isMemberOrAdmin]));
+
+  policy.messages.allowInsert.where(allOf([{ chat_id: ANNOUNCEMENTS_CHAT_ID }, isAdmin]));
+  policy.messages.allowInsert.where(allOf([{ chat_id: CHAT_ID }, isMemberOrAdmin]));
 
   policy.messages.allowUpdate
-    .whereOld(
-      allOf([{ chat_id: ANNOUNCEMENTS_CHAT_ID }, session.where({ "claims.role": "admin" })]),
-    )
+    .whereOld(allOf([{ chat_id: ANNOUNCEMENTS_CHAT_ID }, isAdmin]))
     .whereNew({ chat_id: ANNOUNCEMENTS_CHAT_ID });
   policy.messages.allowUpdate
-    .whereOld(
-      allOf([
-        { chat_id: CHAT_ID },
-        anyOf([{ author_id: session.user_id }, session.where({ "claims.role": "admin" })]),
-      ]),
-    )
+    .whereOld(allOf([{ chat_id: CHAT_ID }, canMutateGenericChat]))
     .whereNew({ chat_id: CHAT_ID });
 
-  policy.messages.allowDelete.where(
-    allOf([{ chat_id: ANNOUNCEMENTS_CHAT_ID }, session.where({ "claims.role": "admin" })]),
-  );
-  policy.messages.allowDelete.where(
-    allOf([
-      { chat_id: CHAT_ID },
-      anyOf([{ author_id: session.user_id }, session.where({ "claims.role": "admin" })]),
-    ]),
-  );
+  policy.messages.allowDelete.where(allOf([{ chat_id: ANNOUNCEMENTS_CHAT_ID }, isAdmin]));
+  policy.messages.allowDelete.where(allOf([{ chat_id: CHAT_ID }, canMutateGenericChat]));
 });

--- a/examples/auth-simple-chat/schema.ts
+++ b/examples/auth-simple-chat/schema.ts
@@ -2,7 +2,6 @@ import { schema as s } from "jazz-tools";
 
 const schema = {
   messages: s.table({
-    author_id: s.string(),
     author_name: s.string(),
     chat_id: s.string(),
     text: s.string(),

--- a/examples/auth-simple-chat/src/ChatPanel.tsx
+++ b/examples/auth-simple-chat/src/ChatPanel.tsx
@@ -56,7 +56,6 @@ export function ChatPanel({
       await db.insertDurable(
         app.messages,
         {
-          author_id: sessionUserId,
           author_name: authorName,
           chat_id: chatId,
           text: messageText.trim(),

--- a/examples/auth-workos-chat/README.md
+++ b/examples/auth-workos-chat/README.md
@@ -8,7 +8,7 @@ What it demonstrates:
 - Pointing the Jazz sync server at WorkOS's hosted JWKS endpoint — no local auth server needed
 - Calling `getAccessToken()` from the AuthKit hook and passing the WorkOS access token directly to `JazzProvider`
 - Falling back to anonymous `localAuth` when no WorkOS session exists
-- Role-based UI gating derived from JWT claims (`admin` posts to Announcements; `member` posts to the general chat)
+- Role-based UI gating derived from JWT claims (`admin` posts to Announcements; `member` posts to the general chat), with generic-chat message ownership enforced via `$createdBy` in `permissions.ts`
 
 There is no local auth server in this example. WorkOS issues and signs all tokens;
 the JWKS is fetched from `https://api.workos.com/sso/jwks/<clientId>`.

--- a/examples/auth-workos-chat/permissions.ts
+++ b/examples/auth-workos-chat/permissions.ts
@@ -5,24 +5,21 @@ import { app } from "./schema.js";
 export default definePermissions(app, ({ policy, allOf, anyOf, session }) => {
   const isAdmin = session.where({ "claims.role": "admin" });
   const isMemberOrAdmin = session.where({ "claims.role": { in: ["admin", "member"] } });
+  const canMutateGenericChat = anyOf([{ $createdBy: session.user_id }, isAdmin]);
 
   policy.messages.allowRead.where({ chat_id: ANNOUNCEMENTS_CHAT_ID });
   policy.messages.allowRead.where(allOf([{ chat_id: CHAT_ID }, isMemberOrAdmin]));
 
   policy.messages.allowInsert.where(allOf([{ chat_id: ANNOUNCEMENTS_CHAT_ID }, isAdmin]));
-  policy.messages.allowInsert.where(
-    allOf([{ chat_id: CHAT_ID }, anyOf([{ author_id: session.user_id }, isAdmin])]),
-  );
+  policy.messages.allowInsert.where(allOf([{ chat_id: CHAT_ID }, isMemberOrAdmin]));
 
   policy.messages.allowUpdate
     .whereOld(allOf([{ chat_id: ANNOUNCEMENTS_CHAT_ID }, isAdmin]))
     .whereNew({ chat_id: ANNOUNCEMENTS_CHAT_ID });
   policy.messages.allowUpdate
-    .whereOld(allOf([{ chat_id: CHAT_ID }, anyOf([{ author_id: session.user_id }, isAdmin])]))
+    .whereOld(allOf([{ chat_id: CHAT_ID }, canMutateGenericChat]))
     .whereNew({ chat_id: CHAT_ID });
 
   policy.messages.allowDelete.where(allOf([{ chat_id: ANNOUNCEMENTS_CHAT_ID }, isAdmin]));
-  policy.messages.allowDelete.where(
-    allOf([{ chat_id: CHAT_ID }, anyOf([{ author_id: session.user_id }, isAdmin])]),
-  );
+  policy.messages.allowDelete.where(allOf([{ chat_id: CHAT_ID }, canMutateGenericChat]));
 });

--- a/examples/auth-workos-chat/schema.ts
+++ b/examples/auth-workos-chat/schema.ts
@@ -2,7 +2,6 @@ import { schema as s } from "jazz-tools";
 
 const schema = {
   messages: s.table({
-    author_id: s.string(),
     author_name: s.string(),
     chat_id: s.string(),
     text: s.string(),


### PR DESCRIPTION
## Summary
- migrate auth chat examples from field-based mutation ownership checks to `$createdBy`
