### PR TITLE
fix(auth): sync useIsAuthenticated and useAccount on sign in

### DIFF
--- a/packages/jazz-tools/src/tools/auth/clerk/index.ts
+++ b/packages/jazz-tools/src/tools/auth/clerk/index.ts
@@ -118,6 +118,12 @@ export class JazzClerkAuth {
 
     await this.authenticate(credentials);
 
+    await Account.getMe().$jazz.ensureLoaded({
+      resolve: {
+        profile: true,
+      },
+    });
+
     await JazzClerkAuth.loadClerkAuthData(
       {
         jazzAccountID: credentials.accountID,


### PR DESCRIPTION
## Summary

This fixes a race condition where `useIsAuthenticated` could become `true` before `useAccount` returned the authenticated user's data. This happened because the authenticated state was set before the new account data was fully loaded. The fix is to explicitly wait for the account data to be loaded after authentication and before setting the authenticated state in storage, ensuring both hooks update in sync.

## Changes

- **packages/jazz-tools/src/tools/auth/clerk/index.ts**: In the `logIn` method, added a call to `Account.getMe().$jazz.ensureLoaded()` after authenticating and before setting the auth data in storage. This ensures the account data is loaded before the `isAuthenticated` flag is set, preventing a race condition between `useIsAuthenticated` and `useAccount` hooks.

## Related Issue

Closes #3209

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the Clerk authentication flow by adding an extra await to load the current account before writing auth secrets, which could affect sign-in timing and error behavior. Low code churn, but it’s in a security-adjacent, user-login path.
> 
> **Overview**
> Fixes a sign-in race where auth state could be persisted (and `useIsAuthenticated` flip to true) before `useAccount` had loaded the authenticated user.
> 
> After `authenticate()` in `JazzClerkAuth.logIn`, it now awaits `Account.getMe().$jazz.ensureLoaded({ resolve: { profile: true } })` before calling `loadClerkAuthData`, keeping the authenticated flag and account data in sync.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 844be7c2c279f3c335e75d58dc25cc361138dd40. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->