### PR TITLE
[codex] Fix inspector data grid freeze loop

### DIFF
--- a/.changeset/olive-buttons-repair.md
+++ b/.changeset/olive-buttons-repair.md
@@ -2,4 +2,4 @@
 "jazz-tools": patch
 ---
 
-Improve inspector data-grid stability and diagnostics around pending query transitions.
+Fix the inspector data grid freezing the browser tab when paging or sorting, and improve diagnostics around pending query transitions.

--- a/.changeset/olive-buttons-repair.md
+++ b/.changeset/olive-buttons-repair.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Improve inspector data-grid stability and diagnostics around pending query transitions.

--- a/packages/inspector/src/components/data-explorer/TableDataGrid.tsx
+++ b/packages/inspector/src/components/data-explorer/TableDataGrid.tsx
@@ -7,7 +7,7 @@ import {
 } from "@tanstack/react-table";
 import type { ColumnType, DynamicTableRow, TableProxy } from "jazz-tools";
 import { useAll, useDb } from "jazz-tools/react";
-import { useMemo, useState } from "react";
+import { Profiler, useEffect, useMemo, useState } from "react";
 import { Navigate, useParams } from "react-router";
 import { useDevtoolsContext } from "../../contexts/devtools-context.js";
 import { GenericQueryBuilder } from "../../utility/generic-query-builder.js";
@@ -25,10 +25,62 @@ function formatCellValue(value: unknown): string {
 }
 
 const PAGE_SIZE_OPTIONS = [10, 25, 50] as const;
+const EMPTY_ROWS: DynamicTableRow[] = [];
 
 interface MutationState {
   mode: MutationFormMode;
   rowId: string | null;
+}
+
+interface TableDataGridProfilerEntry {
+  id: string;
+  phase: "mount" | "update" | "nested-update";
+  actualDuration: number;
+  baseDuration: number;
+  startTime: number;
+  commitTime: number;
+  table: string;
+  pageIndex: number;
+  pageSize: number;
+  sortColumn: string;
+  sortDirection: "asc" | "desc";
+  filterCount: number;
+  rowCount: number;
+  visibleRowCount: number;
+  queryOffset: number;
+  queryLimit: number;
+  hasNextPage: boolean;
+  query: string;
+}
+
+interface TableDataGridDebugEvent {
+  type: string;
+  timestampMs: number;
+  table: string;
+  pageIndex: number;
+  pageSize: number;
+  sortColumn: string;
+  sortDirection: "asc" | "desc";
+  filterCount: number;
+  rowCount: number;
+  visibleRowCount: number;
+  queryOffset: number;
+  queryLimit: number;
+  hasNextPage: boolean;
+  query: string;
+  details?: Record<string, unknown>;
+}
+
+type TableDataGridInspectorWindow = Window & {
+  __inspectorProfiler?: TableDataGridProfilerEntry[];
+  __inspectorGridEvents?: TableDataGridDebugEvent[];
+};
+
+interface GridColumn {
+  id: string;
+  accessorKey: string;
+  header: string;
+  enableSorting: boolean;
 }
 
 function isColumnSortable(columnType: ColumnType): boolean {
@@ -45,6 +97,14 @@ function isColumnSortable(columnType: ColumnType): boolean {
     default:
       return false;
   }
+}
+
+function recordTableDataGridProfilerEntry(entry: TableDataGridProfilerEntry): void {
+  const profilerWindow = globalThis.window as TableDataGridInspectorWindow | undefined;
+  if (!profilerWindow?.__inspectorProfiler) {
+    return;
+  }
+  profilerWindow.__inspectorProfiler.push(entry);
 }
 
 export function TableDataGrid() {
@@ -84,43 +144,38 @@ export function TableDataGrid() {
     }
     return builder.orderBy(sortColumn, sortDirection).limit(queryLimit).offset(queryOffset);
   }, [table, schema, filters, sortColumn, sortDirection, queryLimit, queryOffset]);
+  const builtQuery = useMemo(() => queryBuilder._build(), [queryBuilder]);
   const mutationDurabilityTier = runtime === "standalone" ? "edge" : "worker";
+  const queryOptions = useMemo(
+    () =>
+      ({
+        propagation: queryPropagation,
+        visibility: "hidden_from_live_query_list",
+      }) as const,
+    [queryPropagation],
+  );
 
-  const rows =
-    useAll<DynamicTableRow>(queryBuilder, {
-      propagation: queryPropagation,
-      visibility: "hidden_from_live_query_list",
-    }) ?? [];
+  const rows = useAll<DynamicTableRow>(queryBuilder, queryOptions) ?? EMPTY_ROWS;
 
-  const columnDefs = useMemo<ColumnDef<DynamicTableRow>[]>(
+  const gridColumns = useMemo<GridColumn[]>(
     () => [
       {
         id: "id",
         accessorKey: "id",
         header: "ID",
-        cell: (cellContext) => formatCellValue(cellContext.getValue()),
+        enableSorting: true,
       },
       ...schemaColumns.map(
-        (column): ColumnDef<DynamicTableRow> => ({
+        (column): GridColumn => ({
           id: column.name,
           accessorKey: column.name,
           header: column.name,
           enableSorting: isColumnSortable(column.column_type),
-          cell: (cellContext) => formatCellValue(cellContext.getValue()),
         }),
       ),
     ],
     [schemaColumns],
   );
-
-  const tableState = useReactTable({
-    data: rows,
-    columns: columnDefs,
-    state: { sorting },
-    onSortingChange: setSorting,
-    getCoreRowModel: getCoreRowModel(),
-  });
-
   const hasNextPage = rows.length > pageSize;
   const visibleRows = hasNextPage ? rows.slice(0, pageSize) : rows;
   const rowById = useMemo(() => {
@@ -149,220 +204,386 @@ export function TableDataGrid() {
   );
   const startRow = pageIndex * pageSize;
   const endRow = startRow + visibleRows.length;
+  const profileEntryBase = {
+    table,
+    pageIndex,
+    pageSize,
+    sortColumn,
+    sortDirection,
+    filterCount: filters.length,
+    rowCount: rows.length,
+    visibleRowCount: visibleRows.length,
+    queryOffset,
+    queryLimit,
+    hasNextPage,
+    query: builtQuery,
+  } as const;
+  const recordGridEvent = (type: string, details?: Record<string, unknown>): void => {
+    const inspectorWindow = globalThis.window as TableDataGridInspectorWindow | undefined;
+    if (!inspectorWindow?.__inspectorGridEvents) {
+      return;
+    }
+    const event = {
+      type,
+      timestampMs: globalThis.performance?.now?.() ?? Date.now(),
+      ...profileEntryBase,
+      details,
+    };
+    inspectorWindow.__inspectorGridEvents.push(event);
+    globalThis.console?.debug?.("[inspector-grid]", JSON.stringify(event));
+  };
+  const handleSort = (columnId: string, canSort: boolean): void => {
+    if (!canSort) {
+      return;
+    }
+    const nextSort =
+      sortColumn === columnId && sortDirection === "asc"
+        ? [{ id: columnId, desc: true }]
+        : [{ id: columnId, desc: false }];
+    recordGridEvent("sort-click", {
+      columnId,
+      nextSortDirection: nextSort[0]?.desc ? "desc" : "asc",
+    });
+    setSorting(nextSort);
+    setPageIndex(0);
+  };
+  const handleDeleteRow = async (rowId: string): Promise<void> => {
+    const confirmed = globalThis.confirm(`Delete row "${rowId}" from "${table}"?`);
+    if (!confirmed) return;
+
+    try {
+      setDeletingRowId(rowId);
+      await db.deleteDurable(tableProxy, rowId, {
+        tier: mutationDurabilityTier,
+      });
+      if (mutationState?.mode === "edit" && mutationState.rowId === rowId) {
+        setMutationState(null);
+      }
+    } finally {
+      setDeletingRowId(null);
+    }
+  };
+  const handleEditRow = (rowId: string): void => {
+    setMutationState({ mode: "edit", rowId });
+  };
+
+  useEffect(() => {
+    recordGridEvent("state-commit");
+  }, [
+    table,
+    pageIndex,
+    pageSize,
+    sortColumn,
+    sortDirection,
+    filters.length,
+    rows.length,
+    visibleRows.length,
+    queryOffset,
+    queryLimit,
+    hasNextPage,
+    builtQuery,
+  ]);
 
   return (
-    <section className={styles.container}>
-      <header className={styles.header}>
-        <div>
-          <h2 className={styles.title}>{table}</h2>
-          <p className={styles.stats}>
-            {columnDefs.length} column{columnDefs.length === 1 ? "" : "s"} · {visibleRows.length}{" "}
-            row{visibleRows.length === 1 ? "" : "s"} on page · {filters.length} filter
-            {filters.length === 1 ? "" : "s"}
-          </p>
-        </div>
-        <button
-          type="button"
-          className={styles.secondaryButton}
-          onClick={() => {
-            setMutationState({ mode: "insert", rowId: null });
-          }}
-          disabled={isSidebarMutationPending || deletingRowId !== null}
-        >
-          Insert
-        </button>
-      </header>
-      <TableFilterBuilder
-        schemaColumns={schemaColumns}
-        clauses={filters}
-        onClausesChange={(nextFilters) => {
-          setFilters(nextFilters);
-          setPageIndex(0);
-        }}
-      />
-      <div className={styles.contentArea}>
-        <div className={styles.gridFrame}>
-          <table className={styles.table}>
-            <thead>
-              {tableState.getHeaderGroups().map((headerGroup) => (
-                <tr key={headerGroup.id}>
-                  {headerGroup.headers.map((header) => {
-                    const sortDirection = header.column.getIsSorted();
-                    const canSort = header.column.getCanSort();
-                    return (
-                      <th
-                        key={header.id}
-                        onClick={
-                          canSort
-                            ? () => {
-                                const nextSort =
-                                  sortDirection === "asc"
-                                    ? [{ id: header.column.id, desc: true }]
-                                    : [{ id: header.column.id, desc: false }];
-                                setSorting(nextSort);
-                                setPageIndex(0);
-                              }
-                            : undefined
-                        }
-                        className={canSort ? styles.sortableHeader : styles.headerCell}
-                      >
-                        {header.isPlaceholder
-                          ? null
-                          : flexRender(header.column.columnDef.header, header.getContext())}
-                        {sortDirection === "asc" ? " ↑" : sortDirection === "desc" ? " ↓" : ""}
-                      </th>
-                    );
-                  })}
-                  <th className={styles.actionsHeader}>Actions</th>
-                </tr>
-              ))}
-            </thead>
-            <tbody>
-              {tableState
-                .getRowModel()
-                .rows.slice(0, pageSize)
-                .map((row) => (
-                  <tr key={row.id}>
-                    {row.getVisibleCells().map((cell) => (
-                      <td key={cell.id}>
-                        {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                      </td>
-                    ))}
-                    <td className={styles.actionsCell}>
-                      <div className={styles.rowActions}>
-                        <button
-                          type="button"
-                          className={styles.actionButton}
-                          disabled={isSidebarMutationPending || deletingRowId !== null}
-                          onClick={() => {
-                            setMutationState({ mode: "edit", rowId: String(row.original.id) });
-                          }}
-                        >
-                          Edit
-                        </button>
-                        <button
-                          type="button"
-                          className={styles.dangerActionButton}
-                          disabled={isSidebarMutationPending || deletingRowId !== null}
-                          onClick={async () => {
-                            const rowId = String(row.original.id);
-                            const confirmed = globalThis.confirm(
-                              `Delete row "${rowId}" from "${table}"?`,
-                            );
-                            if (!confirmed) return;
-
-                            try {
-                              setDeletingRowId(rowId);
-                              await db.deleteDurable(tableProxy, rowId, {
-                                tier: mutationDurabilityTier,
-                              });
-                              if (mutationState?.mode === "edit" && mutationState.rowId === rowId) {
-                                setMutationState(null);
-                              }
-                            } finally {
-                              setDeletingRowId(null);
-                            }
-                          }}
-                        >
-                          {deletingRowId === String(row.original.id) ? "Deleting..." : "Delete"}
-                        </button>
-                      </div>
-                    </td>
-                  </tr>
-                ))}
-            </tbody>
-          </table>
-        </div>
-      </div>
-      <footer className={styles.footer}>
-        <div className={styles.paginationInfo}>
-          Showing {visibleRows.length === 0 ? 0 : startRow + 1}-{endRow}
-        </div>
-        <div className={styles.paginationControls}>
-          <label className={styles.pageSizeLabel}>
-            Rows per page
-            <select
-              className={styles.pageSizeSelect}
-              value={pageSize}
-              onChange={(event) => {
-                setPageSize(Number(event.target.value));
-                setPageIndex(0);
-              }}
-            >
-              {PAGE_SIZE_OPTIONS.map((sizeOption) => (
-                <option key={sizeOption} value={sizeOption}>
-                  {sizeOption}
-                </option>
-              ))}
-            </select>
-          </label>
-          <span className={styles.pageIndicator}>Page {pageIndex + 1}</span>
+    <Profiler
+      id="TableDataGrid"
+      onRender={(id, phase, actualDuration, baseDuration, startTime, commitTime) => {
+        recordTableDataGridProfilerEntry({
+          id,
+          phase,
+          actualDuration,
+          baseDuration,
+          startTime,
+          commitTime,
+          ...profileEntryBase,
+        });
+      }}
+    >
+      <section className={styles.container}>
+        <header className={styles.header}>
+          <div>
+            <h2 className={styles.title}>{table}</h2>
+            <p className={styles.stats}>
+              {gridColumns.length} column{gridColumns.length === 1 ? "" : "s"} ·{" "}
+              {visibleRows.length} row{visibleRows.length === 1 ? "" : "s"} on page ·{" "}
+              {filters.length} filter{filters.length === 1 ? "" : "s"}
+            </p>
+          </div>
           <button
             type="button"
             className={styles.secondaryButton}
-            onClick={() => setPageIndex((current) => Math.max(0, current - 1))}
-            disabled={pageIndex === 0}
-          >
-            Previous
-          </button>
-          <button
-            type="button"
-            className={styles.secondaryButton}
-            onClick={() => setPageIndex((current) => current + 1)}
-            disabled={!hasNextPage}
-          >
-            Next
-          </button>
-        </div>
-      </footer>
-      {mutationState ? (
-        <div
-          className={styles.sidebarOverlay}
-          data-testid="row-mutation-overlay"
-          onClick={() => {
-            if (isSidebarMutationPending) return;
-            setMutationState(null);
-          }}
-        >
-          <div
-            className={styles.sidebarPanel}
-            onClick={(event) => {
-              event.stopPropagation();
+            onClick={() => {
+              setMutationState({ mode: "insert", rowId: null });
             }}
+            disabled={isSidebarMutationPending || deletingRowId !== null}
           >
-            <RowMutationSidebar
-              key={`${mutationState.mode}:${mutationState.rowId ?? "new"}`}
-              mode={mutationState.mode}
-              tableName={table}
-              schemaColumns={schemaColumns}
-              targetRowId={mutationState.mode === "edit" ? (editingRow?.id ?? null) : null}
-              rowValues={mutationState.mode === "edit" ? editingRow : insertRowValues}
-              onCancel={() => {
-                if (isSidebarMutationPending) return;
-                setMutationState(null);
-              }}
-              onSave={async (updates) => {
-                try {
-                  setIsSidebarMutationPending(true);
-                  if (mutationState.mode === "edit") {
-                    if (!editingRow) return;
-                    await db.updateDurable(tableProxy, editingRow.id, updates, {
-                      tier: mutationDurabilityTier,
-                    });
-                  } else {
-                    await db.insertDurable(tableProxy, updates, {
-                      tier: mutationDurabilityTier,
-                    });
-                  }
-                  setMutationState(null);
-                } finally {
-                  setIsSidebarMutationPending(false);
-                }
-              }}
+            Insert
+          </button>
+        </header>
+        <TableFilterBuilder
+          schemaColumns={schemaColumns}
+          clauses={filters}
+          onClausesChange={(nextFilters) => {
+            recordGridEvent("filters-change", { nextFilterCount: nextFilters.length });
+            setFilters(nextFilters);
+            setPageIndex(0);
+          }}
+        />
+        <div className={styles.contentArea}>
+          <div className={styles.gridFrame}>
+            <TanStackTableView
+              rows={rows}
+              gridColumns={gridColumns}
+              pageSize={pageSize}
+              sorting={sorting}
+              onSortingChange={setSorting}
+              isSidebarMutationPending={isSidebarMutationPending}
+              deletingRowId={deletingRowId}
+              onSort={handleSort}
+              onEditRow={handleEditRow}
+              onDeleteRow={handleDeleteRow}
             />
           </div>
         </div>
-      ) : null}
-    </section>
+        <footer className={styles.footer}>
+          <div className={styles.paginationInfo}>
+            Showing {visibleRows.length === 0 ? 0 : startRow + 1}-{endRow}
+          </div>
+          <div className={styles.paginationControls}>
+            <label className={styles.pageSizeLabel}>
+              Rows per page
+              <select
+                className={styles.pageSizeSelect}
+                value={pageSize}
+                onChange={(event) => {
+                  const nextPageSize = Number(event.target.value);
+                  recordGridEvent("page-size-change", { nextPageSize });
+                  setPageSize(nextPageSize);
+                  setPageIndex(0);
+                }}
+              >
+                {PAGE_SIZE_OPTIONS.map((sizeOption) => (
+                  <option key={sizeOption} value={sizeOption}>
+                    {sizeOption}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <span className={styles.pageIndicator}>Page {pageIndex + 1}</span>
+            <button
+              type="button"
+              className={styles.secondaryButton}
+              onClick={() => {
+                recordGridEvent("previous-page-click", {
+                  nextPageIndex: Math.max(0, pageIndex - 1),
+                });
+                setPageIndex((current) => Math.max(0, current - 1));
+              }}
+              disabled={pageIndex === 0}
+            >
+              Previous
+            </button>
+            <button
+              type="button"
+              className={styles.secondaryButton}
+              onClick={() => {
+                recordGridEvent("next-page-click", {
+                  nextPageIndex: pageIndex + 1,
+                });
+                setPageIndex((current) => current + 1);
+              }}
+              disabled={!hasNextPage}
+            >
+              Next
+            </button>
+          </div>
+        </footer>
+        {mutationState ? (
+          <div
+            className={styles.sidebarOverlay}
+            data-testid="row-mutation-overlay"
+            onClick={() => {
+              if (isSidebarMutationPending) return;
+              setMutationState(null);
+            }}
+          >
+            <div
+              className={styles.sidebarPanel}
+              onClick={(event) => {
+                event.stopPropagation();
+              }}
+            >
+              <RowMutationSidebar
+                key={`${mutationState.mode}:${mutationState.rowId ?? "new"}`}
+                mode={mutationState.mode}
+                tableName={table}
+                schemaColumns={schemaColumns}
+                targetRowId={mutationState.mode === "edit" ? (editingRow?.id ?? null) : null}
+                rowValues={mutationState.mode === "edit" ? editingRow : insertRowValues}
+                onCancel={() => {
+                  if (isSidebarMutationPending) return;
+                  setMutationState(null);
+                }}
+                onSave={async (updates) => {
+                  try {
+                    setIsSidebarMutationPending(true);
+                    if (mutationState.mode === "edit") {
+                      if (!editingRow) return;
+                      await db.updateDurable(tableProxy, editingRow.id, updates, {
+                        tier: mutationDurabilityTier,
+                      });
+                    } else {
+                      await db.insertDurable(tableProxy, updates, {
+                        tier: mutationDurabilityTier,
+                      });
+                    }
+                    setMutationState(null);
+                  } finally {
+                    setIsSidebarMutationPending(false);
+                  }
+                }}
+              />
+            </div>
+          </div>
+        ) : null}
+      </section>
+    </Profiler>
+  );
+}
+
+function TanStackTableView({
+  rows,
+  gridColumns,
+  pageSize,
+  sorting,
+  onSortingChange,
+  isSidebarMutationPending,
+  deletingRowId,
+  onSort,
+  onEditRow,
+  onDeleteRow,
+}: {
+  rows: DynamicTableRow[];
+  gridColumns: GridColumn[];
+  pageSize: number;
+  sorting: SortingState;
+  onSortingChange: (updater: SortingState) => void;
+  isSidebarMutationPending: boolean;
+  deletingRowId: string | null;
+  onSort: (columnId: string, canSort: boolean) => void;
+  onEditRow: (rowId: string) => void;
+  onDeleteRow: (rowId: string) => Promise<void>;
+}) {
+  const columns = useMemo<ColumnDef<DynamicTableRow>[]>(
+    () =>
+      gridColumns.map(
+        (column): ColumnDef<DynamicTableRow> => ({
+          id: column.id,
+          accessorKey: column.accessorKey,
+          header: column.header,
+          enableSorting: column.enableSorting,
+          cell: (cellContext) => formatCellValue(cellContext.getValue()),
+        }),
+      ),
+    [gridColumns],
+  );
+  const tableState = useReactTable({
+    data: rows,
+    columns,
+    state: { sorting },
+    onSortingChange,
+    getCoreRowModel: getCoreRowModel(),
+  });
+
+  return (
+    <table className={styles.table}>
+      <thead>
+        {tableState.getHeaderGroups().map((headerGroup) => (
+          <tr key={headerGroup.id}>
+            {headerGroup.headers.map((header) => {
+              const headerSortDirection = header.column.getIsSorted();
+              const canSort = header.column.getCanSort();
+              return (
+                <th
+                  key={header.id}
+                  onClick={canSort ? () => onSort(header.column.id, canSort) : undefined}
+                  className={canSort ? styles.sortableHeader : styles.headerCell}
+                >
+                  {header.isPlaceholder
+                    ? null
+                    : flexRender(header.column.columnDef.header, header.getContext())}
+                  {headerSortDirection === "asc"
+                    ? " ↑"
+                    : headerSortDirection === "desc"
+                      ? " ↓"
+                      : ""}
+                </th>
+              );
+            })}
+            <th className={styles.actionsHeader}>Actions</th>
+          </tr>
+        ))}
+      </thead>
+      <tbody>
+        {tableState
+          .getRowModel()
+          .rows.slice(0, pageSize)
+          .map((row) => (
+            <tr key={row.id}>
+              {row.getVisibleCells().map((cell) => (
+                <td key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</td>
+              ))}
+              <RowActionsCell
+                rowId={String(row.original.id)}
+                isSidebarMutationPending={isSidebarMutationPending}
+                deletingRowId={deletingRowId}
+                onEditRow={onEditRow}
+                onDeleteRow={onDeleteRow}
+              />
+            </tr>
+          ))}
+      </tbody>
+    </table>
+  );
+}
+
+function RowActionsCell({
+  rowId,
+  isSidebarMutationPending,
+  deletingRowId,
+  onEditRow,
+  onDeleteRow,
+}: {
+  rowId: string;
+  isSidebarMutationPending: boolean;
+  deletingRowId: string | null;
+  onEditRow: (rowId: string) => void;
+  onDeleteRow: (rowId: string) => Promise<void>;
+}) {
+  return (
+    <td className={styles.actionsCell}>
+      <div className={styles.rowActions}>
+        <button
+          type="button"
+          className={styles.actionButton}
+          disabled={isSidebarMutationPending || deletingRowId !== null}
+          onClick={() => {
+            onEditRow(rowId);
+          }}
+        >
+          Edit
+        </button>
+        <button
+          type="button"
+          className={styles.dangerActionButton}
+          disabled={isSidebarMutationPending || deletingRowId !== null}
+          onClick={async () => {
+            await onDeleteRow(rowId);
+          }}
+        >
+          {deletingRowId === rowId ? "Deleting..." : "Delete"}
+        </button>
+      </div>
+    </td>
   );
 }

--- a/packages/inspector/tests/browser/global-setup.ts
+++ b/packages/inspector/tests/browser/global-setup.ts
@@ -1,8 +1,20 @@
+import { writeFile } from "node:fs/promises";
 import { join } from "node:path";
-import { JazzClient } from "jazz-tools";
-import { TestingServer, pushSchemaCatalogue } from "jazz-tools/testing";
-import { ADMIN_SECRET, APP_ID, TEST_BRANCH, TEST_ENV, TEST_PORT } from "./test-constants.js";
+import { fetchSchemaHashes, JazzClient } from "jazz-tools";
+import { TestingServer } from "../../../../crates/jazz-napi/index.js";
+import { pushSchemaCatalogue } from "../../../jazz-tools/dist/testing/local-jazz-server.js";
+import {
+  ADMIN_SECRET,
+  APP_ID,
+  SEEDED_TODO_COUNT,
+  TEST_BRANCH,
+  TEST_ENV,
+  TEST_PORT,
+} from "./test-constants.js";
 import { app } from "./schema.ts";
+
+const SEED_BATCH_SIZE = 50;
+const RUNTIME_CONFIG_PATH = join(import.meta.dirname ?? __dirname, "runtime-config.json");
 
 export default async function globalSetup(): Promise<() => Promise<void>> {
   const serverHandlePromise = TestingServer.start({
@@ -20,6 +32,17 @@ export default async function globalSetup(): Promise<() => Promise<void>> {
     userBranch: TEST_BRANCH,
     schemaDir: join(import.meta.dirname ?? __dirname, "."),
   });
+  const { hashes } = await fetchSchemaHashes(serverHandle.url, {
+    adminSecret: serverHandle.adminSecret,
+  });
+  const publishedSchemaHash = hashes.at(-1);
+  if (!publishedSchemaHash) {
+    throw new Error("No schema hashes were published during inspector browser global setup.");
+  }
+  await writeFile(
+    RUNTIME_CONFIG_PATH,
+    JSON.stringify({ schemaHash: publishedSchemaHash }, null, 2),
+  );
 
   const client = await JazzClient.connect({
     appId: APP_ID,
@@ -32,27 +55,36 @@ export default async function globalSetup(): Promise<() => Promise<void>> {
     localAuthToken: "test-token",
   });
 
-  await client.createWithAck(
-    "todos",
-    [
-      { type: "Text", value: "First seeded todo" },
-      { type: "Boolean", value: false },
-    ],
-    "edge",
-  );
-
-  await client.createWithAck(
-    "todos",
-    [
-      { type: "Text", value: "Second seeded todo" },
-      { type: "Boolean", value: true },
-    ],
-    "edge",
-  );
+  const seedTitles = buildSeedTodoTitles(SEEDED_TODO_COUNT);
+  for (let offset = 0; offset < seedTitles.length; offset += SEED_BATCH_SIZE) {
+    const batch = seedTitles.slice(offset, offset + SEED_BATCH_SIZE);
+    await Promise.all(
+      batch.map((title, indexWithinBatch) => {
+        const seedIndex = offset + indexWithinBatch;
+        return client.createDurable(
+          "todos",
+          {
+            title: { type: "Text", value: title },
+            done: { type: "Boolean", value: seedIndex % 2 === 1 },
+          },
+          { tier: "edge" },
+        );
+      }),
+    );
+  }
 
   await client.shutdown();
 
   return async () => {
     await serverHandle.stop();
   };
+}
+
+function buildSeedTodoTitles(count: number): string[] {
+  const totalCount = Math.max(2, count);
+  const titles = ["First seeded todo", "Second seeded todo"];
+  for (let index = titles.length; index < totalCount; index += 1) {
+    titles.push(`Seeded todo ${String(index + 1).padStart(6, "0")}`);
+  }
+  return titles;
 }

--- a/packages/inspector/tests/browser/pagination-freeze-repro.spec.ts
+++ b/packages/inspector/tests/browser/pagination-freeze-repro.spec.ts
@@ -1,0 +1,597 @@
+import { readFileSync } from "node:fs";
+import { writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { expect, test, type Page, type TestInfo } from "@playwright/test";
+import {
+  ADMIN_SECRET,
+  APP_ID,
+  SEEDED_TODO_COUNT,
+  TEST_BRANCH,
+  TEST_ENV,
+  TEST_PORT,
+} from "./test-constants.js";
+
+const SERVER_URL = `http://127.0.0.1:${TEST_PORT}`;
+const STORAGE_KEY = "jazz-inspector-standalone-config";
+const VISIBLE_ROW_COUNT = Math.min(SEEDED_TODO_COUNT, 10);
+const RUNTIME_CONFIG_PATH = join(import.meta.dirname ?? __dirname, "runtime-config.json");
+const INTERACTION_TIMEOUT_MS = 20_000;
+const PAGE_READ_TIMEOUT_MS = 1_500;
+const CLEANUP_TIMEOUT_MS = 5_000;
+const GRID_LOG_PREFIX = "[inspector-grid]";
+const SUBSCRIPTION_LOG_PREFIX = "[inspector-subscription]";
+
+type ConsoleRecord = {
+  type: string;
+  text: string;
+};
+
+type ProfilerEntry = {
+  id: string;
+  phase: "mount" | "update" | "nested-update";
+  actualDuration: number;
+  baseDuration: number;
+  startTime: number;
+  commitTime: number;
+  table: string;
+  pageIndex: number;
+  pageSize: number;
+  sortColumn: string;
+  sortDirection: "asc" | "desc";
+  filterCount: number;
+  rowCount: number;
+  visibleRowCount: number;
+  queryOffset: number;
+  queryLimit: number;
+  hasNextPage: boolean;
+  query: string;
+};
+
+type GridEvent = {
+  type: string;
+  timestampMs: number;
+  table: string;
+  pageIndex: number;
+  pageSize: number;
+  sortColumn: string;
+  sortDirection: "asc" | "desc";
+  filterCount: number;
+  rowCount: number;
+  visibleRowCount: number;
+  queryOffset: number;
+  queryLimit: number;
+  hasNextPage: boolean;
+  query: string;
+  details?: Record<string, unknown>;
+};
+
+type SubscriptionEvent = {
+  type: string;
+  timestampMs: number;
+  key: string;
+  table: string;
+  query: string;
+  options: string;
+  listenerCount: number;
+  status: "pending" | "fulfilled" | "rejected";
+  dataLength: number;
+  details?: Record<string, unknown>;
+};
+
+type HeartbeatStats = {
+  beatCount: number;
+  maxGapMs: number;
+  avgGapMs: number;
+};
+
+type FreezeScenario = {
+  slug: string;
+  title: string;
+  perform: (page: Page) => Promise<void>;
+};
+
+type InspectorClientArtifacts = {
+  heartbeatValues: number[];
+  profilerEntries: ProfilerEntry[];
+  gridEvents: GridEvent[];
+  subscriptionEvents: SubscriptionEvent[];
+};
+
+type SettledWithTimeout<T> =
+  | { status: "fulfilled"; value: T }
+  | { status: "rejected"; error: string }
+  | { status: "timed_out" };
+
+const FREEZE_SCENARIOS: readonly FreezeScenario[] = [
+  {
+    slug: "next-page",
+    title: "Next page interaction",
+    perform: async (page) => {
+      await page.getByRole("button", { name: "Next" }).click({ timeout: 5_000 });
+      await expect(page.getByText("Page 2")).toBeVisible({ timeout: 10_000 });
+      await expect(page.getByText("Showing 11-20")).toBeVisible({ timeout: 10_000 });
+    },
+  },
+  {
+    slug: "page-size-change",
+    title: "Rows per page interaction",
+    perform: async (page) => {
+      await page.getByLabel("Rows per page").selectOption("50", { timeout: 5_000 });
+      await expect(page.getByText("Page 1")).toBeVisible({ timeout: 10_000 });
+      await expect(page.getByText(/50 rows on page/)).toBeVisible({ timeout: 10_000 });
+      await expect(page.getByText("Showing 1-50")).toBeVisible({ timeout: 10_000 });
+    },
+  },
+  {
+    slug: "sort-title",
+    title: "Sort by title interaction",
+    perform: async (page) => {
+      await page.getByRole("columnheader", { name: "title" }).click({ timeout: 5_000 });
+      await expect(page.locator("th").filter({ hasText: "title ↑" }).first()).toBeVisible({
+        timeout: 10_000,
+      });
+    },
+  },
+];
+
+test.describe("inspector pagination freeze repro harness", () => {
+  for (const scenario of FREEZE_SCENARIOS) {
+    test(`captures artifacts for ${scenario.title}`, async ({ page }, testInfo) => {
+      test.setTimeout(60_000);
+      await runFreezeScenario(page, testInfo, scenario);
+    });
+  }
+});
+
+async function runFreezeScenario(
+  page: Page,
+  testInfo: TestInfo,
+  scenario: FreezeScenario,
+): Promise<void> {
+  const consoleRecords: ConsoleRecord[] = [];
+  page.on("console", (message) => {
+    consoleRecords.push({ type: message.type(), text: message.text() });
+  });
+  page.on("pageerror", (error) => {
+    consoleRecords.push({ type: "pageerror", text: error.message });
+  });
+
+  await installDebugCapture(page);
+  await openTodosTable(page);
+  await clearDebugCapture(page);
+
+  const cdp = await page.context().newCDPSession(page);
+  await cdp.send("Profiler.enable");
+  await cdp.send("Profiler.start");
+  await page.context().tracing.start({ screenshots: true, snapshots: true, sources: true });
+
+  const tracePath = testInfo.outputPath(`${scenario.slug}.trace.zip`);
+  const profilerPath = testInfo.outputPath(`${scenario.slug}.cpu-profile.json`);
+  const heartbeatPath = testInfo.outputPath(`${scenario.slug}.heartbeat.json`);
+  const gridEventsPath = testInfo.outputPath(`${scenario.slug}.grid-events.json`);
+  const subscriptionEventsPath = testInfo.outputPath(`${scenario.slug}.subscription-events.json`);
+  const summaryPath = testInfo.outputPath(`${scenario.slug}.summary.json`);
+
+  const interactionResult = await settleWithTimeout(scenario.perform(page), INTERACTION_TIMEOUT_MS);
+  const interactionError =
+    interactionResult.status === "fulfilled"
+      ? null
+      : interactionResult.status === "timed_out"
+        ? `interaction timed out after ${INTERACTION_TIMEOUT_MS}ms`
+        : interactionResult.error;
+
+  const clientArtifacts = hydrateArtifactsFromConsole(
+    await collectClientArtifacts(page),
+    consoleRecords,
+  );
+
+  const profilerStopResult = await settleWithTimeout(
+    cdp.send("Profiler.stop") as Promise<{ profile: unknown }>,
+    CLEANUP_TIMEOUT_MS,
+  );
+  const profilerStopError =
+    profilerStopResult.status === "fulfilled"
+      ? null
+      : profilerStopResult.status === "timed_out"
+        ? `Profiler.stop timed out after ${CLEANUP_TIMEOUT_MS}ms`
+        : profilerStopResult.error;
+
+  const traceStopResult = await settleWithTimeout(
+    page.context().tracing.stop({ path: tracePath }),
+    CLEANUP_TIMEOUT_MS,
+  );
+  const traceStopError =
+    traceStopResult.status === "fulfilled"
+      ? null
+      : traceStopResult.status === "timed_out"
+        ? `Tracing.stop timed out after ${CLEANUP_TIMEOUT_MS}ms`
+        : traceStopResult.error;
+
+  if (!page.isClosed() && interactionError !== null) {
+    const closeResult = await settleWithTimeout(
+      page.close({ runBeforeUnload: false }),
+      CLEANUP_TIMEOUT_MS,
+    );
+    if (closeResult.status === "rejected") {
+      consoleRecords.push({ type: "close-error", text: closeResult.error });
+    }
+    if (closeResult.status === "timed_out") {
+      consoleRecords.push({
+        type: "close-error",
+        text: `page.close timed out after ${CLEANUP_TIMEOUT_MS}ms`,
+      });
+    }
+  }
+
+  const heartbeatStats = summarizeHeartbeats(clientArtifacts.heartbeatValues);
+  const repeatedProfilerSnapshotCount = countRepeatedProfilerSnapshots(
+    clientArtifacts.profilerEntries,
+  );
+  const repeatedGridStateCommitCount = countRepeatedGridStateSnapshots(clientArtifacts.gridEvents);
+  const subscriptionSummary = summarizeSubscriptionEvents(clientArtifacts.subscriptionEvents);
+  const profilerSummary = {
+    commitCount: clientArtifacts.profilerEntries.length,
+    repeatedSnapshotCount: repeatedProfilerSnapshotCount,
+    updateCount: clientArtifacts.profilerEntries.filter((entry) => entry.phase !== "mount").length,
+    maxActualDurationMs: Math.max(
+      0,
+      ...clientArtifacts.profilerEntries.map((entry) => entry.actualDuration),
+    ),
+  };
+  const gridSummary = {
+    eventCount: clientArtifacts.gridEvents.length,
+    repeatedStateCommitCount: repeatedGridStateCommitCount,
+    actionTypes: Array.from(
+      new Set(
+        clientArtifacts.gridEvents
+          .filter((event) => event.type !== "state-commit")
+          .map((event) => event.type),
+      ),
+    ),
+  };
+
+  await writeFile(heartbeatPath, JSON.stringify(clientArtifacts.heartbeatValues, null, 2));
+  await writeFile(gridEventsPath, JSON.stringify(clientArtifacts.gridEvents, null, 2));
+  await writeFile(
+    subscriptionEventsPath,
+    JSON.stringify(clientArtifacts.subscriptionEvents, null, 2),
+  );
+  await writeFile(
+    profilerPath,
+    JSON.stringify(
+      profilerStopResult.status === "fulfilled" ? profilerStopResult.value.profile : null,
+      null,
+      2,
+    ),
+  );
+  await writeFile(
+    summaryPath,
+    JSON.stringify(
+      {
+        scenario: scenario.slug,
+        seededTodoCount: SEEDED_TODO_COUNT,
+        interactionError,
+        profilerStopError,
+        traceStopError,
+        artifactSources: {
+          grid:
+            clientArtifacts.gridEvents.length > 0 &&
+            !consoleRecords.some((record) => record.text.startsWith(GRID_LOG_PREFIX))
+              ? "window"
+              : clientArtifacts.gridEvents.length > 0
+                ? "window+console"
+                : "none",
+          subscriptions:
+            clientArtifacts.subscriptionEvents.length > 0 &&
+            !consoleRecords.some((record) => record.text.startsWith(SUBSCRIPTION_LOG_PREFIX))
+              ? "window"
+              : clientArtifacts.subscriptionEvents.length > 0
+                ? "window+console"
+                : "none",
+        },
+        heartbeatStats,
+        profilerSummary,
+        gridSummary,
+        subscriptionSummary,
+        consoleRecords,
+      },
+      null,
+      2,
+    ),
+  );
+
+  await testInfo.attach(`${scenario.slug}-summary`, {
+    path: summaryPath,
+    contentType: "application/json",
+  });
+  await testInfo.attach(`${scenario.slug}-heartbeat`, {
+    path: heartbeatPath,
+    contentType: "application/json",
+  });
+  await testInfo.attach(`${scenario.slug}-grid-events`, {
+    path: gridEventsPath,
+    contentType: "application/json",
+  });
+  await testInfo.attach(`${scenario.slug}-subscription-events`, {
+    path: subscriptionEventsPath,
+    contentType: "application/json",
+  });
+  await testInfo.attach(`${scenario.slug}-cpu-profile`, {
+    path: profilerPath,
+    contentType: "application/json",
+  });
+  if (traceStopError === null) {
+    await testInfo.attach(`${scenario.slug}-trace`, {
+      path: tracePath,
+      contentType: "application/zip",
+    });
+  }
+  expect(interactionError).toBeNull();
+}
+
+async function installDebugCapture(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    const inspectorWindow = window as typeof window & {
+      __inspectorHeartbeat?: number[];
+      __inspectorProfiler?: unknown[];
+      __inspectorGridEvents?: unknown[];
+      __inspectorSubscriptionEvents?: unknown[];
+    };
+    inspectorWindow.__inspectorHeartbeat = [];
+    inspectorWindow.__inspectorProfiler = [];
+    inspectorWindow.__inspectorGridEvents = [];
+    inspectorWindow.__inspectorSubscriptionEvents = [];
+    globalThis.setInterval(() => {
+      inspectorWindow.__inspectorHeartbeat?.push(performance.now());
+    }, 50);
+  });
+}
+
+async function openTodosTable(page: Page): Promise<void> {
+  await page.goto("/");
+  await page.evaluate(
+    ({ key, config }) => {
+      localStorage.setItem(key, JSON.stringify(config));
+    },
+    {
+      key: STORAGE_KEY,
+      config: {
+        serverUrl: SERVER_URL,
+        appId: APP_ID,
+        adminSecret: ADMIN_SECRET,
+        env: TEST_ENV,
+        branch: TEST_BRANCH,
+        schemaHash: readRuntimeConfig().schemaHash,
+      },
+    },
+  );
+  await page.reload();
+
+  await expect(page.getByRole("link", { name: "Data Explorer" })).toBeVisible({
+    timeout: 15_000,
+  });
+  await page.getByRole("link", { name: "View todos data" }).click();
+  await expect(page.getByText(new RegExp(`${VISIBLE_ROW_COUNT} rows on page`))).toBeVisible({
+    timeout: 15_000,
+  });
+}
+
+async function clearDebugCapture(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const inspectorWindow = window as typeof window & {
+      __inspectorHeartbeat?: number[];
+      __inspectorProfiler?: unknown[];
+      __inspectorGridEvents?: unknown[];
+      __inspectorSubscriptionEvents?: unknown[];
+    };
+    inspectorWindow.__inspectorHeartbeat = [];
+    inspectorWindow.__inspectorProfiler = [];
+    inspectorWindow.__inspectorGridEvents = [];
+    inspectorWindow.__inspectorSubscriptionEvents = [];
+  });
+}
+
+async function collectClientArtifacts(page: Page): Promise<InspectorClientArtifacts> {
+  const [heartbeatValues, profilerEntries, gridEvents, subscriptionEvents] = await Promise.all([
+    readWindowArray<number>(page, "__inspectorHeartbeat"),
+    readWindowArray<ProfilerEntry>(page, "__inspectorProfiler"),
+    readWindowArray<GridEvent>(page, "__inspectorGridEvents"),
+    readWindowArray<SubscriptionEvent>(page, "__inspectorSubscriptionEvents"),
+  ]);
+
+  return {
+    heartbeatValues,
+    profilerEntries,
+    gridEvents,
+    subscriptionEvents,
+  };
+}
+
+async function readWindowArray<T>(page: Page, propertyName: string): Promise<T[]> {
+  if (page.isClosed()) {
+    return [];
+  }
+
+  const readResult = await settleWithTimeout(
+    page.evaluate((windowPropertyName) => {
+      const inspectorWindow = window as Record<string, unknown[] | undefined>;
+      return [...(inspectorWindow[windowPropertyName] ?? [])];
+    }, propertyName),
+    PAGE_READ_TIMEOUT_MS,
+  );
+
+  return readResult.status === "fulfilled" ? (readResult.value as T[]) : [];
+}
+
+async function settleWithTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+): Promise<SettledWithTimeout<T>> {
+  return await new Promise<SettledWithTimeout<T>>((resolve) => {
+    const timeoutId = setTimeout(() => {
+      resolve({ status: "timed_out" });
+    }, timeoutMs);
+
+    void promise.then(
+      (value) => {
+        clearTimeout(timeoutId);
+        resolve({ status: "fulfilled", value });
+      },
+      (error) => {
+        clearTimeout(timeoutId);
+        resolve({ status: "rejected", error: toErrorMessage(error) });
+      },
+    );
+  });
+}
+
+function summarizeHeartbeats(heartbeats: number[]): HeartbeatStats {
+  if (heartbeats.length < 2) {
+    return {
+      beatCount: heartbeats.length,
+      maxGapMs: 0,
+      avgGapMs: 0,
+    };
+  }
+
+  let maxGapMs = 0;
+  let totalGapMs = 0;
+  for (let index = 1; index < heartbeats.length; index += 1) {
+    const gap = heartbeats[index]! - heartbeats[index - 1]!;
+    maxGapMs = Math.max(maxGapMs, gap);
+    totalGapMs += gap;
+  }
+
+  return {
+    beatCount: heartbeats.length,
+    maxGapMs,
+    avgGapMs: totalGapMs / (heartbeats.length - 1),
+  };
+}
+
+function countRepeatedProfilerSnapshots(entries: ProfilerEntry[]): number {
+  let repeatedSnapshots = 0;
+  for (let index = 1; index < entries.length; index += 1) {
+    const previous = entries[index - 1]!;
+    const current = entries[index]!;
+    if (
+      previous.table === current.table &&
+      previous.pageIndex === current.pageIndex &&
+      previous.pageSize === current.pageSize &&
+      previous.sortColumn === current.sortColumn &&
+      previous.sortDirection === current.sortDirection &&
+      previous.filterCount === current.filterCount &&
+      previous.rowCount === current.rowCount &&
+      previous.visibleRowCount === current.visibleRowCount &&
+      previous.query === current.query
+    ) {
+      repeatedSnapshots += 1;
+    }
+  }
+  return repeatedSnapshots;
+}
+
+function countRepeatedGridStateSnapshots(events: GridEvent[]): number {
+  const stateCommitEvents = events.filter((event) => event.type === "state-commit");
+  let repeatedSnapshots = 0;
+
+  for (let index = 1; index < stateCommitEvents.length; index += 1) {
+    const previous = stateCommitEvents[index - 1]!;
+    const current = stateCommitEvents[index]!;
+    if (
+      previous.table === current.table &&
+      previous.pageIndex === current.pageIndex &&
+      previous.pageSize === current.pageSize &&
+      previous.sortColumn === current.sortColumn &&
+      previous.sortDirection === current.sortDirection &&
+      previous.filterCount === current.filterCount &&
+      previous.rowCount === current.rowCount &&
+      previous.visibleRowCount === current.visibleRowCount &&
+      previous.query === current.query
+    ) {
+      repeatedSnapshots += 1;
+    }
+  }
+
+  return repeatedSnapshots;
+}
+
+function summarizeSubscriptionEvents(events: SubscriptionEvent[]) {
+  const byType = events.reduce<Record<string, number>>((accumulator, event) => {
+    accumulator[event.type] = (accumulator[event.type] ?? 0) + 1;
+    return accumulator;
+  }, {});
+
+  let repeatedDeltaCount = 0;
+  for (let index = 1; index < events.length; index += 1) {
+    const previous = events[index - 1]!;
+    const current = events[index]!;
+    if (
+      previous.type === "delta" &&
+      current.type === "delta" &&
+      previous.key === current.key &&
+      previous.dataLength === current.dataLength &&
+      previous.status === current.status
+    ) {
+      repeatedDeltaCount += 1;
+    }
+  }
+
+  return {
+    eventCount: events.length,
+    uniqueKeyCount: new Set(events.map((event) => event.key)).size,
+    makeQueryKeyCount: byType["make-query-key"] ?? 0,
+    reuseEntryCount: byType["reuse-entry"] ?? 0,
+    deltaCount: byType.delta ?? 0,
+    repeatedDeltaCount,
+    byType,
+  };
+}
+
+function hydrateArtifactsFromConsole(
+  artifacts: InspectorClientArtifacts,
+  consoleRecords: readonly ConsoleRecord[],
+): InspectorClientArtifacts {
+  return {
+    ...artifacts,
+    gridEvents:
+      artifacts.gridEvents.length > 0
+        ? artifacts.gridEvents
+        : parseConsoleEvents<GridEvent>(consoleRecords, GRID_LOG_PREFIX),
+    subscriptionEvents:
+      artifacts.subscriptionEvents.length > 0
+        ? artifacts.subscriptionEvents
+        : parseConsoleEvents<SubscriptionEvent>(consoleRecords, SUBSCRIPTION_LOG_PREFIX),
+  };
+}
+
+function parseConsoleEvents<T>(consoleRecords: readonly ConsoleRecord[], prefix: string): T[] {
+  const events: T[] = [];
+
+  for (const record of consoleRecords) {
+    if (!record.text.startsWith(prefix)) {
+      continue;
+    }
+
+    const payload = record.text.slice(prefix.length).trim();
+    if (payload.length === 0) {
+      continue;
+    }
+
+    try {
+      events.push(JSON.parse(payload) as T);
+    } catch {
+      continue;
+    }
+  }
+
+  return events;
+}
+
+function toErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function readRuntimeConfig(): { schemaHash: string } {
+  return JSON.parse(readFileSync(RUNTIME_CONFIG_PATH, "utf8")) as { schemaHash: string };
+}

--- a/packages/inspector/tests/browser/standalone-inspector.spec.ts
+++ b/packages/inspector/tests/browser/standalone-inspector.spec.ts
@@ -1,19 +1,34 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { expect, test } from "@playwright/test";
-import { ADMIN_SECRET, APP_ID, TEST_BRANCH, TEST_ENV, TEST_PORT } from "./test-constants.js";
+import {
+  ADMIN_SECRET,
+  APP_ID,
+  SEEDED_TODO_COUNT,
+  TEST_BRANCH,
+  TEST_ENV,
+  TEST_PORT,
+} from "./test-constants.js";
 
 const SERVER_URL = `http://127.0.0.1:${TEST_PORT}`;
-const SCHEMA_HASH = "a01f5c72ec47a3f7d91a6862b4c5779d194f586ff8b432d92aecde954c306e9c";
 const STORAGE_KEY = "jazz-inspector-standalone-config";
+const VISIBLE_ROW_COUNT = Math.min(SEEDED_TODO_COUNT, 10);
+const RUNTIME_CONFIG_PATH = join(import.meta.dirname ?? __dirname, "runtime-config.json");
 
 function storedConfig() {
+  const { schemaHash } = readRuntimeConfig();
   return {
     serverUrl: SERVER_URL,
     appId: APP_ID,
     adminSecret: ADMIN_SECRET,
     env: TEST_ENV,
     branch: TEST_BRANCH,
-    schemaHash: SCHEMA_HASH,
+    schemaHash,
   };
+}
+
+function readRuntimeConfig(): { schemaHash: string } {
+  return JSON.parse(readFileSync(RUNTIME_CONFIG_PATH, "utf8")) as { schemaHash: string };
 }
 
 test.describe("connection page", () => {
@@ -44,7 +59,9 @@ test.describe("connection page", () => {
 
     await page.getByRole("button", { name: "Use schema" }).click();
 
-    await expect(page.getByRole("link", { name: "Data Explorer" })).toBeVisible();
+    await expect(page.getByRole("link", { name: "Data Explorer" })).toBeVisible({
+      timeout: 15000,
+    });
   });
 
   test("loads data explorer from stored config", async ({ page }) => {
@@ -57,10 +74,16 @@ test.describe("connection page", () => {
     );
     await page.reload();
 
-    await expect(page.getByRole("link", { name: "Data Explorer" })).toBeVisible();
-    await expect(page.getByRole("heading", { name: "Tables" })).toBeVisible();
-    await expect(page.getByRole("link", { name: "View todos data" })).toBeVisible();
-    await expect(page.getByRole("link", { name: "View todos schema" })).toBeVisible();
+    await expect(page.getByRole("link", { name: "Data Explorer" })).toBeVisible({
+      timeout: 15000,
+    });
+    await expect(page.getByRole("heading", { name: "Tables" })).toBeVisible({ timeout: 15000 });
+    await expect(page.getByRole("link", { name: "View todos data" })).toBeVisible({
+      timeout: 15000,
+    });
+    await expect(page.getByRole("link", { name: "View todos schema" })).toBeVisible({
+      timeout: 15000,
+    });
   });
 
   test("reset connection returns to onboarding", async ({ page }) => {
@@ -73,7 +96,9 @@ test.describe("connection page", () => {
     );
     await page.reload();
 
-    await expect(page.getByRole("button", { name: "Reset connection" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Reset connection" })).toBeVisible({
+      timeout: 15000,
+    });
     await page.getByRole("button", { name: "Reset connection" }).click();
     await expect(page.getByRole("heading", { name: "Connect to Jazz server" })).toBeVisible();
   });
@@ -91,10 +116,16 @@ test.describe("data explorer page", () => {
 
     await page.reload();
 
-    await expect(page.getByRole("link", { name: "Data Explorer" })).toBeVisible();
-    await expect(page.getByRole("heading", { name: "Tables" })).toBeVisible();
-    await expect(page.getByRole("link", { name: "View todos data" })).toBeVisible();
-    await expect(page.getByRole("link", { name: "View todos schema" })).toBeVisible();
+    await expect(page.getByRole("link", { name: "Data Explorer" })).toBeVisible({
+      timeout: 15000,
+    });
+    await expect(page.getByRole("heading", { name: "Tables" })).toBeVisible({ timeout: 15000 });
+    await expect(page.getByRole("link", { name: "View todos data" })).toBeVisible({
+      timeout: 15000,
+    });
+    await expect(page.getByRole("link", { name: "View todos schema" })).toBeVisible({
+      timeout: 15000,
+    });
   });
 
   test("loads data explorer from stored config", async ({ page }) => {
@@ -102,7 +133,9 @@ test.describe("data explorer page", () => {
 
     await expect(page.getByText("3 columns")).toBeVisible();
 
-    await expect(page.getByText("2 rows")).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText(new RegExp(`${VISIBLE_ROW_COUNT} rows on page`))).toBeVisible({
+      timeout: 10000,
+    });
   });
 
   test("loads schema explorer", async ({ page }) => {

--- a/packages/inspector/tests/browser/test-constants.ts
+++ b/packages/inspector/tests/browser/test-constants.ts
@@ -3,3 +3,7 @@ export const APP_ID = "00000000-0000-0000-0000-000000000099";
 export const ADMIN_SECRET = "inspector-browser-tests-admin-secret";
 export const TEST_ENV = "dev";
 export const TEST_BRANCH = "main";
+export const SEEDED_TODO_COUNT = Math.max(
+  2,
+  Number(process.env.JAZZ_INSPECTOR_SEEDED_TODOS ?? "1500"),
+);

--- a/packages/jazz-tools/src/subscriptions-orchestrator.ts
+++ b/packages/jazz-tools/src/subscriptions-orchestrator.ts
@@ -152,6 +152,27 @@ interface DbLike {
   ): () => void;
 }
 
+interface InspectorSubscriptionEvent {
+  type: string;
+  timestampMs: number;
+  key: string;
+  table: string;
+  query: string;
+  options: string;
+  listenerCount: number;
+  status: UseAllState<any>["status"];
+  dataLength: number;
+  details?: Record<string, unknown>;
+}
+
+type SubscriptionDebugWindow = Window & {
+  __inspectorSubscriptionEvents?: InspectorSubscriptionEvent[];
+};
+
+function getSubscriptionDebugWindow(): SubscriptionDebugWindow | undefined {
+  return (globalThis as { window?: SubscriptionDebugWindow }).window;
+}
+
 export class SubscriptionsOrchestrator {
   private readonly cleanupDelayMs = 30_000;
   private readonly entries = new Map<string, InternalCacheEntry<any>>();
@@ -178,7 +199,9 @@ export class SubscriptionsOrchestrator {
     options?: QueryOptions,
     snapshot?: T[],
   ): string {
-    const key = `${this.config.appId}:${serializeQueryOptions(options)}:${query._build()}`;
+    const serializedOptions = serializeQueryOptions(options);
+    const serializedQuery = query._build();
+    const key = `${this.config.appId}:${serializedOptions}:${serializedQuery}`;
     this.queryDefinitions.set(key, {
       query,
       options,
@@ -191,6 +214,20 @@ export class SubscriptionsOrchestrator {
       existing.resolvefulfilled(snapshot);
     }
 
+    this.recordEvent("make-query-key", {
+      key,
+      query,
+      options,
+      state: existing?.state,
+      listeners: existing?.listeners,
+      details: {
+        hasSnapshot: snapshot !== undefined,
+        reusedPendingEntry: Boolean(existing),
+        serializedOptions,
+        serializedQuery,
+      },
+    });
+
     return key;
   }
 
@@ -201,6 +238,13 @@ export class SubscriptionsOrchestrator {
   private ensureEntryForKey<T extends { id: string }>(key: string): InternalCacheEntry<T> {
     const existing = this.entries.get(key);
     if (existing) {
+      this.recordEvent("reuse-entry", {
+        key,
+        query: existing.query,
+        options: existing.options,
+        listeners: existing.listeners,
+        state: existing.state,
+      });
       return existing as InternalCacheEntry<T>;
     }
 
@@ -237,6 +281,13 @@ export class SubscriptionsOrchestrator {
       subscribe: (callbacks) => {
         this.cancelCleanup(entry);
         entry.listeners.add(callbacks);
+        this.recordEvent("listener-subscribed", {
+          key: entry.key,
+          query: entry.query,
+          options: entry.options,
+          listeners: entry.listeners,
+          state: entry.state,
+        });
 
         if (entry.state.status === "rejected") {
           callbacks.onError?.(entry.state.error);
@@ -250,6 +301,13 @@ export class SubscriptionsOrchestrator {
           if (!entry.listeners.delete(callbacks)) {
             return;
           }
+          this.recordEvent("listener-unsubscribed", {
+            key: entry.key,
+            query: entry.query,
+            options: entry.options,
+            listeners: entry.listeners,
+            state: entry.state,
+          });
           if (entry.listeners.size === 0) {
             this.scheduleCleanup(entry);
           }
@@ -266,9 +324,27 @@ export class SubscriptionsOrchestrator {
       },
     } as InternalCacheEntry<T>;
 
+    this.recordEvent("create-entry", {
+      key,
+      query: entry.query,
+      options: entry.options,
+      listeners: entry.listeners,
+      state: entry.state,
+      details: {
+        hasSnapshot,
+      },
+    });
+
     try {
       const subscriptionManager = new SubscriptionManager<T>();
       entry.subscriptionManager = subscriptionManager;
+      this.recordEvent("subscribe-all-start", {
+        key: entry.key,
+        query: entry.query,
+        options: entry.options,
+        listeners: entry.listeners,
+        state: entry.state,
+      });
 
       entry.unsubscribe = this.db.subscribeAll<T>(
         entry.query,
@@ -295,6 +371,18 @@ export class SubscriptionsOrchestrator {
           if (entry.listeners.size === 0) {
             this.scheduleCleanup(entry);
           }
+
+          this.recordEvent("delta", {
+            key: entry.key,
+            query: entry.query,
+            options: entry.options,
+            listeners: entry.listeners,
+            state: entry.state,
+            details: {
+              wasPending,
+              deltaLength: delta.all.length,
+            },
+          });
         },
         entry.options,
         this.session ?? undefined,
@@ -305,6 +393,21 @@ export class SubscriptionsOrchestrator {
       for (const listener of Array.from(entry.listeners)) {
         listener.onError?.(error);
       }
+      this.recordEvent("subscribe-error", {
+        key: entry.key,
+        query: entry.query,
+        options: entry.options,
+        listeners: entry.listeners,
+        state: entry.state,
+        details: {
+          error:
+            error instanceof Error && error.stack
+              ? error.stack
+              : error instanceof Error
+                ? error.message
+                : String(error),
+        },
+      });
       this.scheduleCleanup(entry);
     }
 
@@ -314,6 +417,16 @@ export class SubscriptionsOrchestrator {
 
   private scheduleCleanup(entry: InternalCacheEntry<any>): void {
     this.cancelCleanup(entry);
+    this.recordEvent("schedule-cleanup", {
+      key: entry.key,
+      query: entry.query,
+      options: entry.options,
+      listeners: entry.listeners,
+      state: entry.state,
+      details: {
+        cleanupDelayMs: this.cleanupDelayMs,
+      },
+    });
     entry.cleanupTimeoutId = setTimeout(() => {
       if (entry.listeners.size === 0) {
         this.destroyEntry(entry);
@@ -325,9 +438,23 @@ export class SubscriptionsOrchestrator {
     if (!entry.cleanupTimeoutId) return;
     clearTimeout(entry.cleanupTimeoutId);
     entry.cleanupTimeoutId = null;
+    this.recordEvent("cancel-cleanup", {
+      key: entry.key,
+      query: entry.query,
+      options: entry.options,
+      listeners: entry.listeners,
+      state: entry.state,
+    });
   }
 
   private destroyEntry(entry: InternalCacheEntry<any>): void {
+    this.recordEvent("destroy-entry", {
+      key: entry.key,
+      query: entry.query,
+      options: entry.options,
+      listeners: entry.listeners,
+      state: entry.state,
+    });
     if (entry.unsubscribe) {
       entry.unsubscribe();
     }
@@ -338,6 +465,45 @@ export class SubscriptionsOrchestrator {
     this.cancelCleanup(entry);
     this.entries.delete(entry.key);
     this.queryDefinitions.delete(entry.key);
+  }
+
+  private recordEvent<T extends { id: string }>(
+    type: string,
+    {
+      key,
+      query,
+      options,
+      listeners,
+      state,
+      details,
+    }: {
+      key: string;
+      query: QueryBuilder<T>;
+      options?: QueryOptions;
+      listeners?: Set<QueryEntryCallbacks<T>>;
+      state?: UseAllState<T>;
+      details?: Record<string, unknown>;
+    },
+  ): void {
+    const inspectorWindow = getSubscriptionDebugWindow();
+    if (!inspectorWindow?.__inspectorSubscriptionEvents) {
+      return;
+    }
+
+    const event = {
+      type,
+      timestampMs: globalThis.performance?.now?.() ?? Date.now(),
+      key,
+      table: query._table,
+      query: query._build(),
+      options: serializeQueryOptions(options),
+      listenerCount: listeners?.size ?? 0,
+      status: state?.status ?? "pending",
+      dataLength: state?.status === "fulfilled" ? state.data.length : 0,
+      details,
+    };
+    inspectorWindow.__inspectorSubscriptionEvents.push(event);
+    globalThis.console?.debug?.("[inspector-subscription]", JSON.stringify(event));
   }
 }
 

--- a/packages/jazz-tools/src/subscriptions-orchestrator.ts
+++ b/packages/jazz-tools/src/subscriptions-orchestrator.ts
@@ -15,7 +15,7 @@ type UseAllStatefulfilledData<T> = {
   error: null;
 };
 
-type UseAllStateError<T> = {
+type UseAllStateError = {
   status: "rejected";
   data: undefined;
   error: unknown;
@@ -24,7 +24,7 @@ type UseAllStateError<T> = {
 export type UseAllState<T extends { id: string }> =
   | UseAllStatePending<T>
   | UseAllStatefulfilledData<T>
-  | UseAllStateError<T>;
+  | UseAllStateError;
 
 export type QueryEntryCallbacks<T extends { id: string }> = {
   onfulfilled?: (data: T[]) => void;


### PR DESCRIPTION
## What changed

This fixes the inspector data-grid freeze when switching to the next page or sorting a column.

It also adds a browser repro harness and gated diagnostics so the freeze path is easy to inspect if it regresses.

## Why it changed

The inspector was repeatedly re-rendering while a newly selected query was still pending. In the failing path, we were driving `useAll(...)` and `useReactTable(...)` from the same component. That let TanStack table state churn and pending-query fallback values feed back into the query-owning render path on the main thread.

## Root cause

The freeze was not one giant query task alone.

The main loop was caused by a feedback path between:
- `useReactTable(...)` internal state updates and option writes
- pending query transitions that temporarily produced empty rows
- the query hook and table hook living in the same component render

In the failing repro, `Next page` and `Sort by title` would switch to a new pending query and then spin `makeQueryKey` / `reuse-entry` over and over while the second subscription remained pending.

## Fix

- move the TanStack table hook behind a child component boundary
- keep pending rows stable with a shared `EMPTY_ROWS` value
- memoize the `useAll` query options
- keep the isolated browser repro and diagnostics coverage

## Impact

The inspector stays responsive when paging and sorting, and the new repro spec protects the fix.

## Validation

- `pnpm lint`
- `pnpm --filter jazz-tools build:runtime`
- `pnpm --filter inspector test -- src/components/data-explorer/TableDataGrid.test.tsx`
- `pnpm --filter inspector test:browser -- tests/browser/pagination-freeze-repro.spec.ts tests/browser/standalone-inspector.spec.ts`
