### PR TITLE
[codex] Add opt-in transaction reconciliation spec

### DIFF
--- a/specs/todo/a_mvp/opt_in_transactions_replayable_reconciliation.md
+++ b/specs/todo/a_mvp/opt_in_transactions_replayable_reconciliation.md
@@ -19,7 +19,7 @@ This MVP assumes the batch-branch substrate from [Batch Branches and Prefix-Inde
 
 - opt-in transactions
 - replayable write reconciliation
-- persisted accepted/rejected outcomes
+- persisted accepted/rejected settlement states
 - strict query visibility after reconnect and offline restart
 
 ## Related
@@ -66,40 +66,39 @@ The intent of this spec is not to make every write transactional. It is to keep 
 
 ### After (`#415` substrate + this spec)
 
-| Topic                     | Proposed MVP                                                                 |
-| ------------------------- | ---------------------------------------------------------------------------- |
-| History unit              | explicit batches under a shared prefix                                       |
-| Default write model       | direct public batches remain default                                         |
-| Transactional write model | explicit opt-in, authority-decided                                           |
-| Durable completion        | replayable batch outcome + confirmed tier                                    |
-| Write rejection           | one replayable batch-outcome model                                           |
-| Tier-gated reads          | per visible commit, not per subscription high-water mark                     |
-| Reconnect                 | replay first, snapshot fallback, pending-batch reconciliation                |
-| Offline restart           | persisted local batch records + replayable accepted transactional merge refs |
+| Topic                     | Proposed MVP                                                                  |
+| ------------------------- | ----------------------------------------------------------------------------- |
+| History unit              | explicit batches under a shared prefix                                        |
+| Default write model       | direct public batches remain default                                          |
+| Transactional write model | explicit opt-in, authority-decided                                            |
+| Durable completion        | replayable batch settlement                                                   |
+| Write rejection           | one replayable batch-settlement model                                         |
+| Tier-gated reads          | per visible batch, not per subscription high-water mark                       |
+| Reconnect                 | replay first, snapshot fallback, pending-batch reconciliation                 |
+| Offline restart           | persisted local batch records + replayable accepted transactional public refs |
 
 ## Terms used here
 
 - **replayable**: a fact is replayable if the client can recover it after a dropped live event, reconnect, or restart from durable protocol state such as ordered replay, snapshot fallback, or persisted local records. In other words, it is not "only true if you happened to catch the live callback"
-- **public prefix**: the ordinary reader-visible branch-prefix namespace introduced by the batch-branch substrate. Concretely, within an `(object_id, branch_name)` lineage, this is the prefix where direct public batches and accepted transactional merges are stored under their `BatchId`
+- **public prefix**: the ordinary reader-visible branch-prefix namespace introduced by the batch-branch substrate. Concretely, within an `(object_id, branch_name)` lineage, this is the prefix where direct public batches and accepted transactional public refs are stored under their `BatchId`
 - **tx-private prefix**: a sibling branch-prefix namespace used only for staging transactional batches before acceptance. Ordinary readers ignore it
-- **authority**: the first durable upstream node allowed to turn a local batch into replayable truth; this is a responsibility of the existing upstream owner path, not a new server tier introduced by this spec. For transactional batches that same durable upstream node also validates the batch and emits the accepted merge set
+- **authority**: the first durable upstream node allowed to turn a local batch into replayable truth; this is a responsibility of the existing upstream owner path, not a new server tier introduced by this spec. For transactional batches that same durable upstream node also validates the batch and emits the accepted public-ref set
 - **remote visibility**: whether a change is allowed to affect what another runtime, or any non-local subscription result, can see over sync
 - **strict transaction visibility**: an opt-in query mode that waits for accepted transactional results to be complete for the query's current local scope before showing them
 
 One master invariant runs through the whole design:
 
-- only public commits may affect remote visibility
-- tx-private commits are staging state and optional local overlay state only
+- only public-prefix batches may affect remote visibility
+- tx-private batches are staging state and optional local overlay state only
 
 ## Goals
 
 - Keep ordinary local-first writes as the default write path.
 - Add an explicit opt-in transaction path for writes that need authority-decided fate.
 - Reuse batch-branch history as the only write-history substrate.
-- Separate three questions cleanly:
-  - was this write accepted?
-  - how durable is the accepted result?
-  - is this accepted transaction complete for this query's current local scope?
+- Separate two questions cleanly:
+  - what replayable settlement has this batch reached?
+  - if this is an accepted transaction, is it complete for this query's current local scope?
 - Make reconnect and offline restart converge from replayable protocol state, not just live event timing.
 - Make `tier: "global"` mean the same thing for later deliveries that it means for first delivery.
 - Keep optimistic local UX for the writer without letting remote edge-only data bypass strict visibility.
@@ -181,61 +180,69 @@ Example:
 - she touches `todo/1` and `project/9`
 - those become separate physical branches that both carry `BatchId = B7`
 
-### 4. One fate model, separate durability and completeness
+### 4. One batch-settlement model folds fate and durability together
 
-The status quo mixes or conflates these concepts. The MVP should keep them distinct:
+The status quo spreads write truth across separate concepts. The MVP should collapse that into one replayable settlement model, while still keeping transaction completeness separate.
 
-- **fate**: what replayable outcome did the authority report for this batch?
-- **durability**: for accepted public commits, what is the highest `confirmed_tier`?
-- **completeness**: for an accepted transaction, is it complete for this query's current local scope?
-
-Every pending local batch, whether direct or transactional, should reconcile through one replayable outcome type:
+Every pending local batch, whether direct or transactional, should reconcile through one replayable settlement type:
 
 ```text
-BatchOutcome =
+BatchSettlement =
   Missing { batch_id }
   Rejected { batch_id, code, reason }
-  AcceptedDirect { batch_id }
-  AcceptedTransaction { batch_id, merges: Vec<MergeRef> }
+  DurableDirect {
+    batch_id,
+    confirmed_tier,
+    public_refs: Vec<PublicRef>,
+  }
+  AcceptedTransaction {
+    batch_id,
+    confirmed_tier,
+    public_refs: Vec<PublicRef>,
+  }
 ```
 
-`MergeRef` identifies one authoritative accepted public merge commit:
+`PublicRef` identifies one public-prefix batch materialization:
 
 ```text
-MergeRef {
+PublicRef {
   object_id,
   branch_name,
   batch_id,
-  commit_id,
 }
 ```
 
-These answer different questions:
+`confirmed_tier` is a property of the whole batch settlement, not of individual commits. For any settled public batch, its `confirmed_tier` is the minimum confirmed tier reached by its `public_refs`.
 
-- a batch can have a replayable accepted outcome before its visible public commits reach `Global`
-- a transactional batch can have an accepted outcome before a given query has all relevant accepted merges locally
-- a dropped batch can be `Missing` even though the local client believes it was sent
+This means:
 
-This one `BatchOutcome` model replaces two separate reconciliation languages:
+- a single-ref batch behaves exactly like the old intuitive model
+- a multi-ref batch only reaches tier `T` when every public ref in that batch reaches `T`
+- if an application wants independent visibility, it should emit independent batches
 
-- a special status type for ordinary direct writes
+`Rejected` is terminal. `Missing` is a replayable absence result that tells the client to retransmit the original submission if it still cares about that batch. `DurableDirect` and `AcceptedTransaction` are monotonic replayable states whose `confirmed_tier` may advance over time.
+
+This one `BatchSettlement` model replaces three separate ideas:
+
+- special status for ordinary direct writes
 - a separate transactional fate type
+- a separate per-commit confirmed-tier stream
 
-### 5. Per-commit confirmed tier becomes the read-side durability truth
+### 5. Batch settlement becomes the read-side durability truth
 
 `QuerySettled` should no longer mean "this query permanently achieved tier T".
 
 Instead:
 
 - `QueryFrontierSettled` means "all query updates through sequence N have been emitted"
-- `CommitConfirmedTier` means "this accepted public commit is confirmed at tier T"
+- `BatchSettlement` means "this public batch currently exists at confirmed tier T, or was rejected, or is missing"
 
-Read delivery should check the currently visible commits, not a subscription-wide high-water mark.
+Read delivery should check the currently visible batches, not a subscription-wide high-water mark.
 
 In plain terms:
 
-- `BatchOutcome.Accepted*` answers "did the authority durably accept this batch?"
-- `CommitConfirmedTier` answers "how far has each accepted public commit advanced through the durability lattice?"
+- `BatchSettlement.DurableDirect` answers "this direct public batch exists durably at tier T"
+- `BatchSettlement.AcceptedTransaction` answers "this transaction was accepted and its published public refs currently sit at tier T"
 
 ### 6. Strict transaction visibility is opt-in and has one optional local overlay
 
@@ -245,7 +252,7 @@ A caller may opt into strict transaction visibility. In that mode:
 
 - only accepted public transactional results may affect the visible query result
 - a transaction is visible only when it is complete for the query's current local scope
-- any requested durability tier must be satisfied by the visible accepted commits
+- any requested durability tier must be satisfied by the visible accepted batches
 
 Queries that do not opt into this mode keep ordinary public-prefix behavior. Accepted transactional results become atomic only for queries that explicitly ask for strict transaction visibility.
 
@@ -291,23 +298,26 @@ Behavior:
 1. the client creates a new public `BatchId`
 2. writes append directly to the ordinary public prefix
 3. local optimistic UX behaves as today
-4. the batch remains pending until reconciliation yields one replayable `BatchOutcome`
+4. the batch remains pending until reconciliation yields one replayable `BatchSettlement`
 
-For direct public batches, the relevant outcomes are:
+For direct public batches, the relevant settled states are:
 
 - `Missing`
 - `Rejected`
-- `AcceptedDirect`
+- `DurableDirect`
 
-`AcceptedDirect` does **not** mean "globally durable". It only means:
+`DurableDirect` means:
 
-- the authority durably knows this public batch
-- the write is no longer in the "maybe dropped before acceptance" state
+- this direct public batch exists durably on the public prefix
+- its current `confirmed_tier` applies to the whole batch
+- the write is no longer in the "maybe dropped before publication" state
 
 Durable completion for a direct public batch requires:
 
-1. `AcceptedDirect`
-2. every written public commit reaching the caller's requested `confirmed_tier`
+1. `BatchSettlement.DurableDirect`
+2. `confirmed_tier >= requested_tier`
+
+If a direct public batch spans multiple public refs, its batch `confirmed_tier` is the minimum across those refs. Apps that want one row to become visible independently of another should issue separate batches.
 
 ### Transactional batches (explicit opt-in)
 
@@ -319,8 +329,8 @@ Behavior:
 2. all staged row changes land on tx-private prefixes
 3. ordinary readers do not include tx-private prefixes
 4. the authority validates the batch against its captured frontier
-5. the authority emits one terminal `BatchOutcome`
-6. if accepted, the authority creates accepted public merge batches
+5. the authority emits one replayable `BatchSettlement`
+6. if accepted, the authority creates accepted public batches
 7. if rejected, the tx-private batches never become public and local pending state rolls back
 
 Because transactionality is opt-in:
@@ -335,24 +345,24 @@ For a successful transactional batch, the end-to-end shape is:
 1. create one `BatchId`
 2. stage changes on tx-private prefixes carrying that `BatchId`
 3. ask the authority to validate and decide that batch
-4. receive `BatchOutcome.AcceptedTransaction { batch_id, merges }`
-5. wait for the accepted public merge commits in `merges` to become locally present and reach any requested `confirmed_tier`
+4. receive `BatchSettlement.AcceptedTransaction { batch_id, confirmed_tier, public_refs }`
+5. wait for the accepted public refs in `public_refs` to become locally present and for `confirmed_tier` to satisfy any requested tier
 
 For a rejected transactional batch, the shape is shorter:
 
 1. create one `BatchId`
 2. stage local tx-private changes
-3. receive `BatchOutcome.Rejected`
+3. receive `BatchSettlement.Rejected`
 4. roll back the local pending view and retain the rejection across restart until acknowledged
 
-## Authority outcomes
+## Batch settlement semantics
 
-Semantics for the unified `BatchOutcome` model:
+Semantics for the unified `BatchSettlement` model:
 
 - `Missing`: the authority has no durable record of this batch; the client must retransmit the original direct or transactional submission
 - `Rejected`: the batch was refused before or during authoritative apply
-- `AcceptedDirect`: the authority durably knows a direct public batch
-- `AcceptedTransaction`: the authority accepted a transactional batch and returns the authoritative accepted public merge set
+- `DurableDirect`: a direct public batch exists durably on the public prefix and currently has batch `confirmed_tier = T`
+- `AcceptedTransaction`: the authority accepted a transactional batch, published the authoritative public refs, and those public refs currently have batch `confirmed_tier = T`
 
 `Rejected` covers cases such as:
 
@@ -360,21 +370,20 @@ Semantics for the unified `BatchOutcome` model:
 - session required
 - catalogue write denied
 
-### Accepted merge commit metadata
+### Accepted public-batch metadata
 
-Every accepted public merge commit should carry enough metadata to point back at the originating transactional batch.
+Every accepted transactional public ref should carry enough metadata to mark it as an accepted transaction output rather than an ordinary direct public batch.
 
 Minimum metadata:
 
-- `tx_batch_id`
-- `tx_role=accepted_merge`
+- `tx_role=accepted_transaction_output`
 
 This is needed for two reasons:
 
-1. after restart, the runtime must be able to map a visible accepted public commit back to its transaction
-2. `BatchOutcome.AcceptedTransaction { merges }` and the public commit graph must agree about which commits belong to which accepted transaction
+1. after restart, the runtime must be able to map a visible public ref back to accepted-transaction semantics rather than treating it like an ordinary direct batch
+2. `BatchSettlement.AcceptedTransaction { public_refs }` and the public history must agree about which public refs belong to the accepted transaction
 
-`AcceptedTransaction { merges }` remains the authoritative fate record. The accepted merge commit metadata exists so the public history itself still carries transaction attribution after persistence and reload.
+`AcceptedTransaction { public_refs }` remains the authoritative replayable settlement. The accepted public-batch metadata exists so the public history itself still carries transaction attribution after persistence and reload.
 
 ## Local persisted records
 
@@ -385,7 +394,7 @@ LocalBatchRecord {
   batch_id,
   mode: Direct | Transactional,
   requested_tier,
-  latest_outcome,
+  latest_settlement,
 }
 ```
 
@@ -395,8 +404,8 @@ High-level state machine:
 Pending
   -> Missing
   -> Rejected
-  -> AcceptedDirect + waiting for tier
-  -> AcceptedTransaction + waiting for tier / completeness
+  -> DurableDirect(tier) + waiting for requested tier
+  -> AcceptedTransaction(tier) + waiting for requested tier / completeness
 ```
 
 Persisted local records exist to support:
@@ -416,11 +425,13 @@ Ordinary queries keep today's overall shape:
 - they ignore tx-private prefixes
 - they may still request a durability tier
 
-The important fix is that durability is checked per visible commit, not per subscription high-water mark.
+The important fix is that durability is checked per visible batch, not per subscription high-water mark.
 
-A later remote update must not become visible until the visible public commits for that delivery satisfy the requested tier.
+A later remote update must not become visible until every visible batch for that delivery satisfies the requested tier.
 
-Ordinary queries do **not** get transactional completeness guarantees. If an accepted transactional merge reaches a public prefix and satisfies any requested tier, ordinary queries may observe it like any other public update.
+This is intentionally batch-wide. If a query sees any part of batch `B`, it gates on batch `B`'s current `confirmed_tier`, not just the specific visible ref.
+
+Ordinary queries do **not** get transactional completeness guarantees. If an accepted transactional batch reaches a public prefix and its batch `confirmed_tier` satisfies any requested tier, ordinary queries may observe it like any other public update.
 
 ### Strict transaction visibility (opt-in)
 
@@ -435,15 +446,15 @@ The MVP completeness rule stays the one from the earlier transaction work:
 Definition:
 
 1. compute the query's current local contributing scope
-2. intersect that scope with the batch's accepted `merges`
-3. the transaction is complete for that query only when every intersecting accepted merge is locally present
+2. intersect that scope with the batch's accepted `public_refs`
+3. the transaction is complete for that query only when every intersecting accepted public ref is locally present
 
 This is intentionally weaker than exact global query completeness.
 
 It is still strong enough to guarantee:
 
 - no partial accepted transaction visibility inside the query's current local scope
-- restart-safe re-derivation from persisted accepted merge refs
+- restart-safe re-derivation from persisted accepted public refs
 
 ### Optional local pending overlay
 
@@ -459,12 +470,12 @@ That exception is intentionally narrow:
 
 To make strict visibility concrete, the query layer needs two pieces of shadow state for visible output:
 
-1. which accepted public commit ids are currently visible for this row/tuple
+1. which visible `BatchId`s currently contribute to this row/tuple
 2. which objects/branches are in the current contributing scope
 
-This is broader than today's row-level `commit_id` field.
+This replaces per-visible-commit tracking with per-visible-batch tracking.
 
-Single-table queries can often derive visible accepted commit ids directly from the row version. Joins, array subqueries, and other derived outputs must union the visible accepted commit ids of every contributing tuple element.
+Single-table queries can often derive visible batch ids directly from the row version. Joins, array subqueries, and other derived outputs must union the visible batch ids of every contributing tuple element.
 
 This shadow provenance is internal delivery state. It does not need to become a public row shape in the MVP.
 
@@ -473,7 +484,7 @@ This shadow provenance is internal delivery state. It does not need to become a 
 Reconnect has two separate responsibilities:
 
 1. rebuild desired query state upstream
-2. repair missed write outcome, durability, and strict-visibility state
+2. repair missed write settlement and strict-visibility state
 
 Those should stay separate.
 
@@ -508,24 +519,23 @@ If the replay window still covers `last_seen_seq + 1 .. current`, the server rep
 
 - `ObjectUpdated`
 - `QueryFrontierSettled`
-- `CommitConfirmedTier`
-- `BatchOutcome`
+- `BatchSettlement`
 
 ### Snapshot fallback
 
 If the replay window is gone, the server sends compact current truth:
 
 - the current query frontier for active queries
-- current confirmed tiers for the relevant frontier commits
-- `BatchOutcome` for each `pending_batches` entry
+- current `BatchSettlement` for the visible batches in that frontier
+- `BatchSettlement` for each `pending_batches` entry not already covered by the frontier state
 
 The client then:
 
-- resolves accepted direct batches waiting only on tier
+- resolves direct batches waiting only on tier
 - resolves accepted transactional batches waiting on completeness and tier
 - retransmits `Missing` batches
 - fails `Rejected` batches
-- re-checks strict query visibility using the now-current frontier, confirmed tiers, and accepted merge refs
+- re-checks strict query visibility using the now-current frontier and accepted public refs
 
 ## Before / After flow sketches
 
@@ -552,19 +562,18 @@ Reconnect:
 Alice writes public batch B1 with tier=global
   -> LocalBatchRecord(B1, mode=Direct, Pending)
 
-Live CommitConfirmedTier(B1, global) is dropped
+Live BatchSettlement.DurableDirect(B1, confirmed_tier=global, public_refs=[...]) is dropped
 
 Reconnect:
   -> replay active queries
   -> ResumeSync(last_seen_seq=N, pending_batches=[{B1, Direct}])
 
 Server replies:
-  -> BatchOutcome.AcceptedDirect(B1)
-  -> CommitConfirmedTier(B1, global) via replay or snapshot
+  -> BatchSettlement.DurableDirect(B1, confirmed_tier=global, public_refs=[...]) via replay or snapshot
 
 Alice:
-  -> marks B1 accepted
-  -> sees B1 confirmed at global
+  -> marks B1 durably published
+  -> sees B1 settled at global
   -> resolves waiter
 ```
 
@@ -589,13 +598,13 @@ Later Bob writes C2 on Alice's edge only
 Alice subscribes with tier=global
 
 QueryFrontierSettled(through_seq=41) arrives
-CommitConfirmedTier(C1, global) arrives
+BatchSettlement.DurableDirect(B1, confirmed_tier=global, public_refs=[...]) arrives
   -> first delivery allowed
 
-Later Bob writes C2 on Alice's edge only
-  -> visible commits now include C2
-  -> delivery gate checks C2.confirmed_tier
-  -> C2 held back until confirmed at global
+Later Bob writes batch B2 on Alice's edge only
+  -> visible batches now include B2
+  -> delivery gate checks settlement(B2).confirmed_tier
+  -> B2 held back until confirmed at global
 ```
 
 ### Scenario 3: opt-in transaction accepted
@@ -618,13 +627,17 @@ Alice starts transactional batch B7
   -> strict mode + local pending overlay lets Alice see her own pending state
 
 Authority validates B7
-  -> BatchOutcome.AcceptedTransaction(B7, merges=[todo merge, project merge])
+  -> BatchSettlement.AcceptedTransaction(
+       B7,
+       confirmed_tier=edge,
+       public_refs=[todo ref, project ref],
+     )
 
 Bob runs a strict transaction-visible query
   -> Bob sees nothing until:
      - AcceptedTransaction is present
-     - accepted merges relevant to Bob's local query scope are present
-     - visible accepted commits satisfy any requested tier
+     - accepted public refs relevant to Bob's local query scope are present
+     - the batch's confirmed_tier satisfies any requested tier
 ```
 
 ### Scenario 4: opt-in transaction rejected after optimistic local work
@@ -645,7 +658,7 @@ Alice starts transactional batch B8
   -> local pending view visible only to Alice via the optional local pending overlay
 
 Authority rejects B8
-  -> BatchOutcome.Rejected(B8, code=permission_denied)
+  -> BatchSettlement.Rejected(B8, code=permission_denied)
 
 Alice runtime:
   -> rolls back pending tx-private view
@@ -660,8 +673,8 @@ After restart, a durable runtime should be able to reconstruct:
 
 - still-pending direct public batches
 - still-pending transactional batches
-- accepted public commits and their confirmed tiers
-- accepted transaction merge refs
+- public batch settlements and their current confirmed tiers
+- accepted transaction public refs
 - rejected outcomes awaiting acknowledgement
 
 What it should **not** need:
@@ -673,15 +686,14 @@ What it should **not** need:
 This is why the MVP needs:
 
 - persisted `LocalBatchRecord`s
-- replayable `BatchOutcome`s
-- per-commit confirmed-tier state
+- replayable `BatchSettlement`s
 
 ## Rabbit Holes
 
 - Exact naming and encoding of tx-private prefixes on top of the batch-branch substrate.
 - Efficiently computing `complete_for_current_local_scope` for joins, arrays, and recursive query shapes.
 - Re-triggering delivery when tier state changes without row bytes changing.
-- Deciding whether direct-batch accepted outcomes should always be emitted live or can sometimes be synthesized only from replay/snapshot state.
+- Deciding whether batch confirmed tier should always be emitted live or can sometimes be synthesized only from replay/snapshot state.
 - Garbage collection of rejected tx-private branches without losing debuggability too early.
 - Single durable owner semantics when a browser app has both a persistent worker runtime and a memory main-thread mirror.
 
@@ -699,12 +711,12 @@ This is why the MVP needs:
 Prefer RuntimeCore and SchemaManager integration tests with realistic actors and explicit flow sketches.
 
 - `alice` writes a direct public batch with `tier: "global"`, the live tier update is dropped, reconnect happens, and the write resolves from replay or snapshot rather than hanging.
-- `alice` and `carol` subscribe with `tier: "global"` on different edges, `bob` writes on one edge, and neither sees the later update until the visible public commit reaches global.
+- `alice` and `carol` subscribe with `tier: "global"` on different edges, `bob` writes one direct public batch on one edge, and neither sees that batch until its batch settlement reaches global.
 - `alice` starts transactional batch `B7` touching two objects, the authority accepts it, and a strict transaction-visible subscription only sees the accepted result after `complete_for_current_local_scope` is satisfied.
 - `alice` starts transactional batch `B8`, the authority rejects it, the local pending view rolls back, and the rejected outcome survives restart until acknowledged.
-- a reconnect within the replay window replays missed `ObjectUpdated`, `QueryFrontierSettled`, `CommitConfirmedTier`, and `BatchOutcome` events without needing a full snapshot.
+- a reconnect within the replay window replays missed `ObjectUpdated`, `QueryFrontierSettled`, and `BatchSettlement` events without needing a full snapshot.
 - a reconnect after the replay window expires falls back to a frontier snapshot plus pending-batch reconciliation and still converges.
-- the optional local pending overlay shows Alice her own pending transactional edits locally, while Bob never sees those pending edits and still waits for accepted public merges.
+- the optional local pending overlay shows Alice her own pending transactional edits locally, while Bob never sees those pending edits and still waits for accepted public refs.
 
 ## Planning summary
 
@@ -712,13 +724,13 @@ The MVP should be shaped as one design with two write modes over one shared batc
 
 1. **direct public batches remain the default**
    - local-first
-   - replayable `BatchOutcome`
-   - fixed per-commit tier gating
+   - replayable `BatchSettlement`
+   - fixed per-batch tier gating
 
 2. **transactional batches are explicit opt-in**
    - `BatchId` also acts as tx id
-   - authority emits `AcceptedTransaction` or `Rejected`
-   - accepted public merges drive strict query visibility
+   - authority emits `AcceptedTransaction` or `Rejected` inside `BatchSettlement`
+   - accepted public refs drive strict query visibility
    - rejected outcomes roll back and survive restart
 
 This keeps the everyday local-first path simple while giving applications one coherent stricter path when they explicitly need it.

--- a/specs/todo/a_mvp/opt_in_transactions_replayable_reconciliation.md
+++ b/specs/todo/a_mvp/opt_in_transactions_replayable_reconciliation.md
@@ -66,16 +66,28 @@ The intent of this spec is not to make every write transactional. It is to keep 
 
 ### After (`#415` substrate + this spec)
 
-| Topic                     | Proposed MVP                                                    |
-| ------------------------- | --------------------------------------------------------------- | ------- | ----------------------- |
-| History unit              | explicit batches under a shared prefix                          |
-| Default write model       | ordinary public batches remain default                          |
-| Transactional write model | explicit opt-in, authority-decided                              |
-| Durable completion        | authority outcome + confirmed tier                              |
-| Write rejection           | replayable `Accepted                                            | Missing | Rejected`or`TxDecision` |
-| Tier-gated reads          | per visible commit, not per subscription high-water mark        |
-| Reconnect                 | replay first, snapshot fallback, pending-write reconciliation   |
-| Offline restart           | persisted local batch records + persisted transaction decisions |
+| Topic                     | Proposed MVP                                                                 |
+| ------------------------- | ---------------------------------------------------------------------------- |
+| History unit              | explicit batches under a shared prefix                                       |
+| Default write model       | direct public batches remain default                                         |
+| Transactional write model | explicit opt-in, authority-decided                                           |
+| Durable completion        | replayable batch outcome + confirmed tier                                    |
+| Write rejection           | one replayable batch-outcome model                                           |
+| Tier-gated reads          | per visible commit, not per subscription high-water mark                     |
+| Reconnect                 | replay first, snapshot fallback, pending-batch reconciliation                |
+| Offline restart           | persisted local batch records + replayable accepted transactional merge refs |
+
+## Terms used here
+
+- **public prefix**: the ordinary reader-visible prefix where direct writes and accepted transactional merges live
+- **tx-private prefix**: a staging prefix used only for transactional batches before acceptance
+- **authority**: the first durable upstream node allowed to turn a local batch into replayable truth; this is a responsibility of the existing upstream owner path, not a new server tier introduced by this spec. For transactional batches that same durable upstream node also validates the batch and emits the accepted merge set
+- **strict transaction visibility**: an opt-in query mode that waits for accepted transactional results to be complete for the query's current local scope before showing them
+
+One master invariant runs through the whole design:
+
+- only public commits participate in remote visibility
+- tx-private commits are staging state and optional local overlay state only
 
 ## Goals
 
@@ -117,10 +129,10 @@ This spec does not add a separate transaction log format or second object-histor
 
 Jazz keeps two write modes:
 
-1. **ordinary public batches** — default
+1. **direct public batches** — default
 2. **transactional batches** — explicit opt-in
 
-Ordinary public batches preserve the current local-first shape:
+Direct public batches preserve the current local-first shape:
 
 - they write directly to the ordinary public prefix
 - they do not require authority-decided multi-object acceptance
@@ -148,7 +160,6 @@ For a transactional write, there is no second semantic id beside the batch id.
 
 - `BatchId` is the logical transaction id
 - the same `BatchId` is reused across every touched prefix/object
-- `BatchOrd` remains only a per-`(object, prefix)` storage ordinal
 
 This means:
 
@@ -161,19 +172,45 @@ Example:
 - she touches `todo/1` and `project/9`
 - those become separate physical branches that both carry `BatchId = B7`
 
-### 4. Fate, durability, and completeness stay separate
+### 4. One fate model, separate durability and completeness
 
 The status quo mixes or conflates these concepts. The MVP should keep them distinct:
 
-- **fate**: did the first authority accept, reject, or never receive this write?
+- **fate**: what replayable outcome did the authority report for this batch?
 - **durability**: for accepted public commits, what is the highest `confirmed_tier`?
 - **completeness**: for an accepted transaction, is it complete for this query's current local scope?
 
+Every pending local batch, whether direct or transactional, should reconcile through one replayable outcome type:
+
+```text
+BatchOutcome =
+  Missing { batch_id }
+  Rejected { batch_id, code, reason }
+  AcceptedDirect { batch_id }
+  AcceptedTransaction { batch_id, merges: Vec<MergeRef> }
+```
+
+`MergeRef` identifies one authoritative accepted public merge commit:
+
+```text
+MergeRef {
+  object_id,
+  branch_name,
+  batch_id,
+  commit_id,
+}
+```
+
 These answer different questions:
 
-- a write can be accepted before it reaches `Global`
-- a transaction can be accepted before a given query has all relevant accepted merges locally
-- a dropped write can be `Missing` even though the local client believes it was sent
+- a batch can have a replayable accepted outcome before its visible public commits reach `Global`
+- a transactional batch can have an accepted outcome before a given query has all relevant accepted merges locally
+- a dropped batch can be `Missing` even though the local client believes it was sent
+
+This one `BatchOutcome` model replaces two separate reconciliation languages:
+
+- a special status type for ordinary direct writes
+- a separate transactional fate type
 
 ### 5. Per-commit confirmed tier becomes the read-side durability truth
 
@@ -186,24 +223,28 @@ Instead:
 
 Read delivery should check the currently visible commits, not a subscription-wide high-water mark.
 
-### 6. Strict transaction visibility is also opt-in
+In plain terms:
 
-Queries and subscriptions keep ordinary behavior by default. A caller may opt into transaction-aware visibility modes:
+- `BatchOutcome.Accepted*` answers "did the authority durably accept this batch?"
+- `CommitConfirmedTier` answers "how far has each accepted public commit advanced through the durability lattice?"
 
-- `confirmed_only`
-- `confirmed_plus_local_pending`
+### 6. Strict transaction visibility is opt-in and has one optional local overlay
 
-`confirmed_only` means:
+Queries and subscriptions keep ordinary behavior by default.
 
-- only accepted public transaction results may affect the visible query result
+A caller may opt into strict transaction visibility. In that mode:
+
+- only accepted public transactional results may affect the visible query result
 - a transaction is visible only when it is complete for the query's current local scope
 - any requested durability tier must be satisfied by the visible accepted commits
 
-`confirmed_plus_local_pending` adds exactly one exception:
+Queries that do not opt into this mode keep ordinary public-prefix behavior. Accepted transactional results become atomic only for queries that explicitly ask for strict transaction visibility.
 
-- the current runtime may overlay its own local pending transactional state
+Strict mode may additionally enable one optional local overlay:
 
-This replaces the broad "local updates while waiting" loophole with a narrower rule:
+- the current runtime may also show its own pending transactional state locally
+
+That optional overlay is the narrow replacement for today's broad "local updates while waiting" loophole:
 
 - only the author's own local pending transaction may bypass acceptance
 - remote edge-only updates must not bypass strict visibility
@@ -222,7 +263,7 @@ Replay remains the fast path. Snapshot fallback remains the correctness path.
 
 ### 8. Rejected outcomes survive restart until acknowledged
 
-For both ordinary public batches and transactional batches:
+For both direct public batches and transactional batches:
 
 - rejected outcomes must survive restart
 - they must be queryable after long offline periods
@@ -232,7 +273,7 @@ This is required for correctness and debuggability. A rejection should not exist
 
 ## Write modes
 
-### Ordinary public batches (default)
+### Direct public batches (default)
 
 This is the default write mode for today's insert/update/delete APIs.
 
@@ -241,19 +282,22 @@ Behavior:
 1. the client creates a new public `BatchId`
 2. writes append directly to the ordinary public prefix
 3. local optimistic UX behaves as today
-4. reconnect reconciliation tracks whether the first authority reports that batch as:
-   - `Accepted`
-   - `Missing`
-   - `Rejected`
+4. the batch remains pending until reconciliation yields one replayable `BatchOutcome`
 
-`Accepted` here does **not** mean "globally durable". It only means:
+For direct public batches, the relevant outcomes are:
 
-- the first authority durably knows this public batch
+- `Missing`
+- `Rejected`
+- `AcceptedDirect`
+
+`AcceptedDirect` does **not** mean "globally durable". It only means:
+
+- the authority durably knows this public batch
 - the write is no longer in the "maybe dropped before acceptance" state
 
-Durable completion for an ordinary public batch requires:
+Durable completion for a direct public batch requires:
 
-1. `Accepted`
+1. `AcceptedDirect`
 2. every written public commit reaching the caller's requested `confirmed_tier`
 
 ### Transactional batches (explicit opt-in)
@@ -266,7 +310,7 @@ Behavior:
 2. all staged row changes land on tx-private prefixes
 3. ordinary readers do not include tx-private prefixes
 4. the authority validates the batch against its captured frontier
-5. the authority emits one terminal `TxDecision`
+5. the authority emits one terminal `BatchOutcome`
 6. if accepted, the authority creates accepted public merge batches
 7. if rejected, the tx-private batches never become public and local pending state rolls back
 
@@ -275,68 +319,37 @@ Because transactionality is opt-in:
 - ordinary writes keep current latency/availability semantics
 - the authority is only on the path for writes that asked for transactional guarantees
 
+### Transactional batch lifecycle at a glance
+
+For a successful transactional batch, the end-to-end shape is:
+
+1. create one `BatchId`
+2. stage changes on tx-private prefixes carrying that `BatchId`
+3. ask the authority to validate and decide that batch
+4. receive `BatchOutcome.AcceptedTransaction { batch_id, merges }`
+5. wait for the accepted public merge commits in `merges` to become locally present and reach any requested `confirmed_tier`
+
+For a rejected transactional batch, the shape is shorter:
+
+1. create one `BatchId`
+2. stage local tx-private changes
+3. receive `BatchOutcome.Rejected`
+4. roll back the local pending view and retain the rejection across restart until acknowledged
+
 ## Authority outcomes
 
-### Ordinary public batch reconciliation
+Semantics for the unified `BatchOutcome` model:
 
-Ordinary public batches reconcile to:
-
-```text
-PendingPublicBatchStatus =
-  Accepted { batch_id }
-  Missing  { batch_id }
-  Rejected { batch_id, code, reason }
-```
-
-Semantics:
-
-- `Accepted`: the first authority durably knows the public batch
-- `Missing`: the first authority has no durable record of the public batch; the client must retransmit
+- `Missing`: the authority has no durable record of this batch; the client must retransmit the original direct or transactional submission
 - `Rejected`: the batch was refused before or during authoritative apply
+- `AcceptedDirect`: the authority durably knows a direct public batch
+- `AcceptedTransaction`: the authority accepted a transactional batch and returns the authoritative accepted public merge set
 
 `Rejected` covers cases such as:
 
 - permission denied
 - session required
 - catalogue write denied
-
-It may also cover later ordinary-write rejection paths if the first authority validates something stronger than today's direct apply path.
-
-### Transactional fate
-
-Transactional batches reconcile through a durable `TxDecision`:
-
-```text
-TxDecision =
-  Accepted {
-    batch_id,
-    decision_seq,
-    merges: Vec<MergeRef>,
-  }
-  Rejected {
-    batch_id,
-    code,
-    reason,
-  }
-```
-
-`MergeRef` identifies one authoritative accepted public merge commit:
-
-```text
-MergeRef {
-  object_id,
-  branch_name,
-  batch_id,
-  commit_id,
-}
-```
-
-`decision_seq` is a monotonic per-authority ordering token. The MVP only needs one semantically central authority, so no distributed sequence design is required.
-
-Why `TxDecision` exists separately from `BatchId`:
-
-- `BatchId` identifies the logical transaction
-- `TxDecision` tells us its fate, order, and accepted public merge set
 
 ### Accepted merge commit metadata
 
@@ -350,9 +363,9 @@ Minimum metadata:
 This is needed for two reasons:
 
 1. after restart, the runtime must be able to map a visible accepted public commit back to its transaction
-2. `TxDecision.Accepted { merges }` and the public commit graph must agree about which commits belong to which accepted transaction
+2. `BatchOutcome.AcceptedTransaction { merges }` and the public commit graph must agree about which commits belong to which accepted transaction
 
-`TxDecision` remains the authoritative fate record. The accepted merge commit metadata exists so the public history itself still carries transaction attribution after persistence and reload.
+`AcceptedTransaction { merges }` remains the authoritative fate record. The accepted merge commit metadata exists so the public history itself still carries transaction attribution after persistence and reload.
 
 ## Local persisted records
 
@@ -361,9 +374,9 @@ Each runtime with durable local storage should persist one record for each still
 ```text
 LocalBatchRecord {
   batch_id,
-  mode: Public | Transactional,
+  mode: Direct | Transactional,
   requested_tier,
-  state,
+  latest_outcome,
 }
 ```
 
@@ -371,12 +384,11 @@ High-level state machine:
 
 ```text
 Pending
-  -> Accepted + waiting for tier
   -> Missing
   -> Rejected
+  -> AcceptedDirect + waiting for tier
+  -> AcceptedTransaction + waiting for tier / completeness
 ```
-
-For transactional batches, `Accepted` points at the current `TxDecision.Accepted { merges }`.
 
 Persisted local records exist to support:
 
@@ -399,9 +411,11 @@ The important fix is that durability is checked per visible commit, not per subs
 
 A later remote update must not become visible until the visible public commits for that delivery satisfy the requested tier.
 
-### Transaction-aware queries
+Ordinary queries do **not** get transactional completeness guarantees. If an accepted transactional merge reaches a public prefix and satisfies any requested tier, ordinary queries may observe it like any other public update.
 
-Transaction-aware queries add one more rule on top of ordinary public visibility:
+### Strict transaction visibility (opt-in)
+
+Strict transaction visibility adds one more rule on top of ordinary public visibility:
 
 - accepted transaction results are only visible when complete for the query's current local scope
 
@@ -412,7 +426,7 @@ The MVP completeness rule stays the one from the earlier transaction work:
 Definition:
 
 1. compute the query's current local contributing scope
-2. intersect that scope with `TxDecision.Accepted.merges`
+2. intersect that scope with the batch's accepted `merges`
 3. the transaction is complete for that query only when every intersecting accepted merge is locally present
 
 This is intentionally weaker than exact global query completeness.
@@ -422,9 +436,9 @@ It is still strong enough to guarantee:
 - no partial accepted transaction visibility inside the query's current local scope
 - restart-safe re-derivation from persisted accepted merge refs
 
-### `confirmed_plus_local_pending`
+### Optional local pending overlay
 
-If the caller opts into `confirmed_plus_local_pending`, the runtime may overlay its own local pending transactional state before authority acceptance.
+If the caller opts into the local pending overlay, the runtime may overlay its own local pending transactional state before authority acceptance.
 
 That exception is intentionally narrow:
 
@@ -468,8 +482,12 @@ After query replay, the client sends:
 ```text
 ResumeSync {
   last_seen_seq,
-  pending_public_batch_ids,
-  pending_tx_batch_ids,
+  pending_batches: Vec<PendingBatchRef>,
+}
+
+PendingBatchRef {
+  batch_id,
+  mode: Direct | Transactional,
 }
 ```
 
@@ -482,8 +500,7 @@ If the replay window still covers `last_seen_seq + 1 .. current`, the server rep
 - `ObjectUpdated`
 - `QueryFrontierSettled`
 - `CommitConfirmedTier`
-- `TxDecision`
-- current-status responses for pending ordinary public batches where needed
+- `BatchOutcome`
 
 ### Snapshot fallback
 
@@ -491,12 +508,12 @@ If the replay window is gone, the server sends compact current truth:
 
 - the current query frontier for active queries
 - current confirmed tiers for the relevant frontier commits
-- `PendingPublicBatchStatus` for `pending_public_batch_ids`
-- `TxDecision` or `Missing` for `pending_tx_batch_ids`
+- `BatchOutcome` for each `pending_batches` entry
 
 The client then:
 
-- resolves accepted writes waiting only on tier
+- resolves accepted direct batches waiting only on tier
+- resolves accepted transactional batches waiting on completeness and tier
 - retransmits `Missing` batches
 - fails `Rejected` batches
 - re-checks strict query visibility using the now-current frontier, confirmed tiers, and accepted merge refs
@@ -524,16 +541,16 @@ Reconnect:
 
 ```text
 Alice writes public batch B1 with tier=global
-  -> LocalBatchRecord(B1, mode=Public, Pending)
+  -> LocalBatchRecord(B1, mode=Direct, Pending)
 
 Live CommitConfirmedTier(B1, global) is dropped
 
 Reconnect:
   -> replay active queries
-  -> ResumeSync(last_seen_seq=N, pending_public_batch_ids=[B1])
+  -> ResumeSync(last_seen_seq=N, pending_batches=[{B1, Direct}])
 
 Server replies:
-  -> PendingPublicBatchStatus(B1 -> Accepted)
+  -> BatchOutcome.AcceptedDirect(B1)
   -> CommitConfirmedTier(B1, global) via replay or snapshot
 
 Alice:
@@ -579,7 +596,7 @@ Later Bob writes C2 on Alice's edge only
 ```text
 Alice wants one strict write touching todo/1 and project/9
 
-Only ordinary public optimistic writes exist
+Only direct public optimistic writes exist
   -> partial visibility and rollback semantics are ad hoc
   -> reconnect cannot re-derive one authority-owned fate record
 ```
@@ -589,14 +606,14 @@ Only ordinary public optimistic writes exist
 ```text
 Alice starts transactional batch B7
   -> writes stage on tx-private prefixes for todo/1 and project/9
-  -> local mode is confirmed_plus_local_pending, so Alice may see her own pending state
+  -> strict mode + local pending overlay lets Alice see her own pending state
 
 Authority validates B7
-  -> TxDecision.Accepted(B7, merges=[todo merge, project merge])
+  -> BatchOutcome.AcceptedTransaction(B7, merges=[todo merge, project merge])
 
-Bob runs confirmed_only query
+Bob runs a strict transaction-visible query
   -> Bob sees nothing until:
-     - TxDecision.Accepted is present
+     - AcceptedTransaction is present
      - accepted merges relevant to Bob's local query scope are present
      - visible accepted commits satisfy any requested tier
 ```
@@ -616,10 +633,10 @@ Alice makes an optimistic multi-object change
 
 ```text
 Alice starts transactional batch B8
-  -> local pending view visible only to Alice via confirmed_plus_local_pending
+  -> local pending view visible only to Alice via the optional local pending overlay
 
 Authority rejects B8
-  -> TxDecision.Rejected(B8, code=permission_denied)
+  -> BatchOutcome.Rejected(B8, code=permission_denied)
 
 Alice runtime:
   -> rolls back pending tx-private view
@@ -632,7 +649,7 @@ Alice runtime:
 
 After restart, a durable runtime should be able to reconstruct:
 
-- still-pending ordinary public batches
+- still-pending direct public batches
 - still-pending transactional batches
 - accepted public commits and their confirmed tiers
 - accepted transaction merge refs
@@ -647,7 +664,7 @@ What it should **not** need:
 This is why the MVP needs:
 
 - persisted `LocalBatchRecord`s
-- replayable `TxDecision`s
+- replayable `BatchOutcome`s
 - per-commit confirmed-tier state
 
 ## Rabbit Holes
@@ -655,7 +672,7 @@ This is why the MVP needs:
 - Exact naming and encoding of tx-private prefixes on top of the batch-branch substrate.
 - Efficiently computing `complete_for_current_local_scope` for joins, arrays, and recursive query shapes.
 - Re-triggering delivery when tier state changes without row bytes changing.
-- Deciding how much ordinary public-batch acceptance state needs a live event versus only replay/snapshot synthesis.
+- Deciding whether direct-batch accepted outcomes should always be emitted live or can sometimes be synthesized only from replay/snapshot state.
 - Garbage collection of rejected tx-private branches without losing debuggability too early.
 - Single durable owner semantics when a browser app has both a persistent worker runtime and a memory main-thread mirror.
 
@@ -672,26 +689,26 @@ This is why the MVP needs:
 
 Prefer RuntimeCore and SchemaManager integration tests with realistic actors and explicit flow sketches.
 
-- `alice` writes an ordinary public batch with `tier: "global"`, the live tier update is dropped, reconnect happens, and the write resolves from replay or snapshot rather than hanging.
+- `alice` writes a direct public batch with `tier: "global"`, the live tier update is dropped, reconnect happens, and the write resolves from replay or snapshot rather than hanging.
 - `alice` and `carol` subscribe with `tier: "global"` on different edges, `bob` writes on one edge, and neither sees the later update until the visible public commit reaches global.
-- `alice` starts transactional batch `B7` touching two objects, the authority accepts it, and a `confirmed_only` subscription only sees the accepted result after `complete_for_current_local_scope` is satisfied.
+- `alice` starts transactional batch `B7` touching two objects, the authority accepts it, and a strict transaction-visible subscription only sees the accepted result after `complete_for_current_local_scope` is satisfied.
 - `alice` starts transactional batch `B8`, the authority rejects it, the local pending view rolls back, and the rejected outcome survives restart until acknowledged.
-- a reconnect within the replay window replays missed `ObjectUpdated`, `QueryFrontierSettled`, `CommitConfirmedTier`, and `TxDecision` events without needing a full snapshot.
+- a reconnect within the replay window replays missed `ObjectUpdated`, `QueryFrontierSettled`, `CommitConfirmedTier`, and `BatchOutcome` events without needing a full snapshot.
 - a reconnect after the replay window expires falls back to a frontier snapshot plus pending-batch reconciliation and still converges.
-- `confirmed_plus_local_pending` shows Alice her own pending transactional edits locally, while Bob never sees those pending edits and still waits for accepted public merges.
+- the optional local pending overlay shows Alice her own pending transactional edits locally, while Bob never sees those pending edits and still waits for accepted public merges.
 
 ## Planning summary
 
 The MVP should be shaped as one design with two write modes over one shared batch-history substrate:
 
-1. **ordinary public batches remain the default**
+1. **direct public batches remain the default**
    - local-first
-   - replayable `Accepted | Missing | Rejected`
+   - replayable `BatchOutcome`
    - fixed per-commit tier gating
 
 2. **transactional batches are explicit opt-in**
    - `BatchId` also acts as tx id
-   - authority emits `TxDecision`
+   - authority emits `AcceptedTransaction` or `Rejected`
    - accepted public merges drive strict query visibility
    - rejected outcomes roll back and survive restart
 

--- a/specs/todo/a_mvp/opt_in_transactions_replayable_reconciliation.md
+++ b/specs/todo/a_mvp/opt_in_transactions_replayable_reconciliation.md
@@ -1,0 +1,698 @@
+# Opt-In Transactions, Replayable Reconciliation, and Strict Visibility — TODO (MVP)
+
+This spec is written for readers who know the status quo on `main`.
+
+Today Jazz has one optimistic sync pipeline:
+
+- writes become ordinary object-branch commits
+- `PersistenceAck` tracks durability
+- `QuerySettled` gates only the first tiered delivery
+- reconnect replays active query subscriptions, but does not reconcile pending writes or strict visibility from one coherent source of truth
+
+That leaves three correctness gaps:
+
+1. durable writes can hang forever after a missed live ack
+2. `tier: "global"` only reliably gates first delivery
+3. there is no clean opt-in transaction model for authority-decided multi-object fate
+
+This MVP assumes the batch-branch substrate from [Batch Branches and Prefix-Indexed Storage](../b_launch/batch_branches_and_prefix_storage.md) has landed first. On top of that substrate, it adds one coherent model for:
+
+- opt-in transactions
+- replayable write reconciliation
+- persisted accepted/rejected outcomes
+- strict query visibility after reconnect and offline restart
+
+## Related
+
+- [Sync Manager — Status Quo](../../status-quo/sync_manager.md)
+- [Query/Sync Integration — Status Quo](../../status-quo/query_sync_integration.md)
+- [Object Manager — Status Quo](../../status-quo/object_manager.md)
+- [Batch Branches and Prefix-Indexed Storage](../b_launch/batch_branches_and_prefix_storage.md)
+- [Globally Consistent Transactions](../b_launch/globally_consistent_transactions.md)
+
+## Why this exists
+
+The current status quo on `main` splits related truth across mechanisms that do not reconcile together:
+
+- object history is branch/tip based
+- `PersistenceAck` answers write durability only if the live event arrives
+- `QuerySettled` acts as a subscription-wide durability high-water mark
+- reconnect rebuilds active query subscriptions, but not pending write state
+- rejected optimistic writes are not a replayable, persisted terminal state
+
+That creates four user-visible failure modes:
+
+1. **Missed live acks strand durable writes.** If a commit was accepted upstream but the live ack was dropped, the write can remain pending forever.
+2. **Tier-gated reads are too coarse.** Once a subscription has ever seen `QuerySettled(Global)`, later remote updates can bypass the requested tier.
+3. **Rejection is not a first-class outcome.** Permission denial, session denial, backpressure loss, and authority rejection do not all converge through one persisted replayable path.
+4. **There is no opt-in strict write model.** Multi-object correctness, rollback, and restart-safe visibility are sketched separately from the main sync path instead of using one shared batch/history model.
+
+The intent of this spec is not to make every write transactional. It is to keep the current default local-first path for ordinary writes, while making strict correctness available when an app explicitly asks for it.
+
+## Before / After
+
+### Before (`main`)
+
+| Topic                     | Status quo                                                 |
+| ------------------------- | ---------------------------------------------------------- |
+| History unit              | one branch may have many concurrent tips                   |
+| Default write model       | optimistic direct write to public branch                   |
+| Transactional write model | none                                                       |
+| Durable completion        | live `PersistenceAck` watcher                              |
+| Write rejection           | partial / non-replayable                                   |
+| Tier-gated reads          | first delivery only                                        |
+| Reconnect                 | replay active queries only                                 |
+| Offline restart           | no single persisted source of truth for pending write fate |
+
+### After (`#415` substrate + this spec)
+
+| Topic                     | Proposed MVP                                                    |
+| ------------------------- | --------------------------------------------------------------- | ------- | ----------------------- |
+| History unit              | explicit batches under a shared prefix                          |
+| Default write model       | ordinary public batches remain default                          |
+| Transactional write model | explicit opt-in, authority-decided                              |
+| Durable completion        | authority outcome + confirmed tier                              |
+| Write rejection           | replayable `Accepted                                            | Missing | Rejected`or`TxDecision` |
+| Tier-gated reads          | per visible commit, not per subscription high-water mark        |
+| Reconnect                 | replay first, snapshot fallback, pending-write reconciliation   |
+| Offline restart           | persisted local batch records + persisted transaction decisions |
+
+## Goals
+
+- Keep ordinary local-first writes as the default write path.
+- Add an explicit opt-in transaction path for writes that need authority-decided fate.
+- Reuse batch-branch history as the only write-history substrate.
+- Separate three questions cleanly:
+  - was this write accepted?
+  - how durable is the accepted result?
+  - is this accepted transaction complete for this query's current local scope?
+- Make reconnect and offline restart converge from replayable protocol state, not just live event timing.
+- Make `tier: "global"` mean the same thing for later deliveries that it means for first delivery.
+- Keep optimistic local UX for the writer without letting remote edge-only data bypass strict visibility.
+
+## Non-goals
+
+- No change to the default local-first behavior for writes that do not opt into transactions.
+- No distributed or multi-owner transaction authority in the MVP.
+- No exact global query completeness.
+- No secrecy of row existence or transaction touch sets beyond existing content permissions.
+- No ack-the-ack protocol.
+- No whole-state hash or Merkle tree as the primary repair mechanism.
+- No second history substrate beside batch branches.
+
+## Core decisions
+
+### 1. Batch branches are the prerequisite substrate
+
+This spec assumes [Batch Branches and Prefix-Indexed Storage](../b_launch/batch_branches_and_prefix_storage.md) already exists.
+
+That prerequisite does two important things:
+
+1. it turns "a write" into an explicit `BatchId`
+2. it gives transaction-private and public accepted history the same physical shape
+
+This spec does not add a separate transaction log format or second object-history model on top of that.
+
+### 2. Transactionality is opt-in
+
+Jazz keeps two write modes:
+
+1. **ordinary public batches** — default
+2. **transactional batches** — explicit opt-in
+
+Ordinary public batches preserve the current local-first shape:
+
+- they write directly to the ordinary public prefix
+- they do not require authority-decided multi-object acceptance
+- they still benefit from replayable reconciliation and fixed tier gating
+
+Transactional batches are for writes that need a stricter contract:
+
+- one logical decision for the whole write
+- authoritative accepted or rejected fate
+- restart-safe visibility
+- rollback on rejection
+
+The exact opt-in API shape is not the important part of this spec. It can be:
+
+- an explicit `transaction(...)` or `runTransaction(...)` API
+- an explicit write option selecting transactional mode
+
+What matters is that the stricter mode is chosen deliberately rather than becoming the default for every write.
+
+The MVP should not make applications pay transaction latency, authority dependency, or stricter visibility costs unless they opt in explicitly.
+
+### 3. `BatchId` is the transaction id for transactional writes
+
+For a transactional write, there is no second semantic id beside the batch id.
+
+- `BatchId` is the logical transaction id
+- the same `BatchId` is reused across every touched prefix/object
+- `BatchOrd` remains only a per-`(object, prefix)` storage ordinal
+
+This means:
+
+- every transaction is exactly one logical batch id
+- one transaction may still materialize as multiple per-prefix batch branches
+
+Example:
+
+- Alice starts transactional batch `B7`
+- she touches `todo/1` and `project/9`
+- those become separate physical branches that both carry `BatchId = B7`
+
+### 4. Fate, durability, and completeness stay separate
+
+The status quo mixes or conflates these concepts. The MVP should keep them distinct:
+
+- **fate**: did the first authority accept, reject, or never receive this write?
+- **durability**: for accepted public commits, what is the highest `confirmed_tier`?
+- **completeness**: for an accepted transaction, is it complete for this query's current local scope?
+
+These answer different questions:
+
+- a write can be accepted before it reaches `Global`
+- a transaction can be accepted before a given query has all relevant accepted merges locally
+- a dropped write can be `Missing` even though the local client believes it was sent
+
+### 5. Per-commit confirmed tier becomes the read-side durability truth
+
+`QuerySettled` should no longer mean "this query permanently achieved tier T".
+
+Instead:
+
+- `QueryFrontierSettled` means "all query updates through sequence N have been emitted"
+- `CommitConfirmedTier` means "this accepted public commit is confirmed at tier T"
+
+Read delivery should check the currently visible commits, not a subscription-wide high-water mark.
+
+### 6. Strict transaction visibility is also opt-in
+
+Queries and subscriptions keep ordinary behavior by default. A caller may opt into transaction-aware visibility modes:
+
+- `confirmed_only`
+- `confirmed_plus_local_pending`
+
+`confirmed_only` means:
+
+- only accepted public transaction results may affect the visible query result
+- a transaction is visible only when it is complete for the query's current local scope
+- any requested durability tier must be satisfied by the visible accepted commits
+
+`confirmed_plus_local_pending` adds exactly one exception:
+
+- the current runtime may overlay its own local pending transactional state
+
+This replaces the broad "local updates while waiting" loophole with a narrower rule:
+
+- only the author's own local pending transaction may bypass acceptance
+- remote edge-only updates must not bypass strict visibility
+
+### 7. Replay first, snapshot fallback
+
+Reconnect should converge from ordered replay when possible, and from compact current truth when replay history is gone.
+
+The protocol should be designed around:
+
+- `last_seen_seq`
+- active query replay as desired state
+- reconciliation of still-pending writes
+
+Replay remains the fast path. Snapshot fallback remains the correctness path.
+
+### 8. Rejected outcomes survive restart until acknowledged
+
+For both ordinary public batches and transactional batches:
+
+- rejected outcomes must survive restart
+- they must be queryable after long offline periods
+- acknowledged rejections may be compacted and pruned later
+
+This is required for correctness and debuggability. A rejection should not exist only as an ephemeral live callback.
+
+## Write modes
+
+### Ordinary public batches (default)
+
+This is the default write mode for today's insert/update/delete APIs.
+
+Behavior:
+
+1. the client creates a new public `BatchId`
+2. writes append directly to the ordinary public prefix
+3. local optimistic UX behaves as today
+4. reconnect reconciliation tracks whether the first authority reports that batch as:
+   - `Accepted`
+   - `Missing`
+   - `Rejected`
+
+`Accepted` here does **not** mean "globally durable". It only means:
+
+- the first authority durably knows this public batch
+- the write is no longer in the "maybe dropped before acceptance" state
+
+Durable completion for an ordinary public batch requires:
+
+1. `Accepted`
+2. every written public commit reaching the caller's requested `confirmed_tier`
+
+### Transactional batches (explicit opt-in)
+
+This is the stricter write mode.
+
+Behavior:
+
+1. the client explicitly starts a transactional batch
+2. all staged row changes land on tx-private prefixes
+3. ordinary readers do not include tx-private prefixes
+4. the authority validates the batch against its captured frontier
+5. the authority emits one terminal `TxDecision`
+6. if accepted, the authority creates accepted public merge batches
+7. if rejected, the tx-private batches never become public and local pending state rolls back
+
+Because transactionality is opt-in:
+
+- ordinary writes keep current latency/availability semantics
+- the authority is only on the path for writes that asked for transactional guarantees
+
+## Authority outcomes
+
+### Ordinary public batch reconciliation
+
+Ordinary public batches reconcile to:
+
+```text
+PendingPublicBatchStatus =
+  Accepted { batch_id }
+  Missing  { batch_id }
+  Rejected { batch_id, code, reason }
+```
+
+Semantics:
+
+- `Accepted`: the first authority durably knows the public batch
+- `Missing`: the first authority has no durable record of the public batch; the client must retransmit
+- `Rejected`: the batch was refused before or during authoritative apply
+
+`Rejected` covers cases such as:
+
+- permission denied
+- session required
+- catalogue write denied
+
+It may also cover later ordinary-write rejection paths if the first authority validates something stronger than today's direct apply path.
+
+### Transactional fate
+
+Transactional batches reconcile through a durable `TxDecision`:
+
+```text
+TxDecision =
+  Accepted {
+    batch_id,
+    decision_seq,
+    merges: Vec<MergeRef>,
+  }
+  Rejected {
+    batch_id,
+    code,
+    reason,
+  }
+```
+
+`MergeRef` identifies one authoritative accepted public merge commit:
+
+```text
+MergeRef {
+  object_id,
+  branch_name,
+  batch_id,
+  commit_id,
+}
+```
+
+`decision_seq` is a monotonic per-authority ordering token. The MVP only needs one semantically central authority, so no distributed sequence design is required.
+
+Why `TxDecision` exists separately from `BatchId`:
+
+- `BatchId` identifies the logical transaction
+- `TxDecision` tells us its fate, order, and accepted public merge set
+
+### Accepted merge commit metadata
+
+Every accepted public merge commit should carry enough metadata to point back at the originating transactional batch.
+
+Minimum metadata:
+
+- `tx_batch_id`
+- `tx_role=accepted_merge`
+
+This is needed for two reasons:
+
+1. after restart, the runtime must be able to map a visible accepted public commit back to its transaction
+2. `TxDecision.Accepted { merges }` and the public commit graph must agree about which commits belong to which accepted transaction
+
+`TxDecision` remains the authoritative fate record. The accepted merge commit metadata exists so the public history itself still carries transaction attribution after persistence and reload.
+
+## Local persisted records
+
+Each runtime with durable local storage should persist one record for each still-relevant local batch:
+
+```text
+LocalBatchRecord {
+  batch_id,
+  mode: Public | Transactional,
+  requested_tier,
+  state,
+}
+```
+
+High-level state machine:
+
+```text
+Pending
+  -> Accepted + waiting for tier
+  -> Missing
+  -> Rejected
+```
+
+For transactional batches, `Accepted` points at the current `TxDecision.Accepted { merges }`.
+
+Persisted local records exist to support:
+
+- reconnect reconciliation
+- restart-safe rejection handling
+- rollback of rejected optimistic state
+- user-facing outcome inspection and acknowledgement
+
+## Query visibility
+
+### Ordinary queries
+
+Ordinary queries keep today's overall shape:
+
+- they read public prefixes
+- they ignore tx-private prefixes
+- they may still request a durability tier
+
+The important fix is that durability is checked per visible commit, not per subscription high-water mark.
+
+A later remote update must not become visible until the visible public commits for that delivery satisfy the requested tier.
+
+### Transaction-aware queries
+
+Transaction-aware queries add one more rule on top of ordinary public visibility:
+
+- accepted transaction results are only visible when complete for the query's current local scope
+
+The MVP completeness rule stays the one from the earlier transaction work:
+
+- `complete_for_current_local_scope`
+
+Definition:
+
+1. compute the query's current local contributing scope
+2. intersect that scope with `TxDecision.Accepted.merges`
+3. the transaction is complete for that query only when every intersecting accepted merge is locally present
+
+This is intentionally weaker than exact global query completeness.
+
+It is still strong enough to guarantee:
+
+- no partial accepted transaction visibility inside the query's current local scope
+- restart-safe re-derivation from persisted accepted merge refs
+
+### `confirmed_plus_local_pending`
+
+If the caller opts into `confirmed_plus_local_pending`, the runtime may overlay its own local pending transactional state before authority acceptance.
+
+That exception is intentionally narrow:
+
+- it applies only to the current runtime's own pending transactional writes
+- it does not make remote pending state visible
+- it does not let remote edge-only updates bypass durability or transaction completeness
+
+## Read-side provenance requirements
+
+To make strict visibility concrete, the query layer needs two pieces of shadow state for visible output:
+
+1. which accepted public commit ids are currently visible for this row/tuple
+2. which objects/branches are in the current contributing scope
+
+This is broader than today's row-level `commit_id` field.
+
+Single-table queries can often derive visible accepted commit ids directly from the row version. Joins, array subqueries, and other derived outputs must union the visible accepted commit ids of every contributing tuple element.
+
+This shadow provenance is internal delivery state. It does not need to become a public row shape in the MVP.
+
+## Reconnect and reconciliation
+
+Reconnect has two separate responsibilities:
+
+1. rebuild desired query state upstream
+2. repair missed write outcome, durability, and strict-visibility state
+
+Those should stay separate.
+
+### Step 1: replay active queries as desired state
+
+This remains as it works today:
+
+- active query subscriptions are replayed on reconnect
+- the server rebuilds current scope and query execution state
+
+### Step 2: reconcile still-pending local batches
+
+After query replay, the client sends:
+
+```text
+ResumeSync {
+  last_seen_seq,
+  pending_public_batch_ids,
+  pending_tx_batch_ids,
+}
+```
+
+The server responds in one of two modes.
+
+### Replay path
+
+If the replay window still covers `last_seen_seq + 1 .. current`, the server replays:
+
+- `ObjectUpdated`
+- `QueryFrontierSettled`
+- `CommitConfirmedTier`
+- `TxDecision`
+- current-status responses for pending ordinary public batches where needed
+
+### Snapshot fallback
+
+If the replay window is gone, the server sends compact current truth:
+
+- the current query frontier for active queries
+- current confirmed tiers for the relevant frontier commits
+- `PendingPublicBatchStatus` for `pending_public_batch_ids`
+- `TxDecision` or `Missing` for `pending_tx_batch_ids`
+
+The client then:
+
+- resolves accepted writes waiting only on tier
+- retransmits `Missing` batches
+- fails `Rejected` batches
+- re-checks strict query visibility using the now-current frontier, confirmed tiers, and accepted merge refs
+
+## Before / After flow sketches
+
+### Scenario 1: ordinary durable write, live ack dropped
+
+**Today on `main`**
+
+```text
+Alice writes public batch B1 with tier=global
+  -> public commit sent upstream
+  -> durable waiter watches for live PersistenceAck
+
+PersistenceAck(B1, global) is dropped
+
+Reconnect:
+  -> active queries replay
+  -> nothing reconciles B1
+  -> waiter hangs forever
+```
+
+**After this spec**
+
+```text
+Alice writes public batch B1 with tier=global
+  -> LocalBatchRecord(B1, mode=Public, Pending)
+
+Live CommitConfirmedTier(B1, global) is dropped
+
+Reconnect:
+  -> replay active queries
+  -> ResumeSync(last_seen_seq=N, pending_public_batch_ids=[B1])
+
+Server replies:
+  -> PendingPublicBatchStatus(B1 -> Accepted)
+  -> CommitConfirmedTier(B1, global) via replay or snapshot
+
+Alice:
+  -> marks B1 accepted
+  -> sees B1 confirmed at global
+  -> resolves waiter
+```
+
+### Scenario 2: tier-gated query delivery
+
+**Today on `main`**
+
+```text
+Alice subscribes with tier=global
+
+QuerySettled(Global) arrives once
+  -> achieved_tiers = { Global }
+
+Later Bob writes C2 on Alice's edge only
+  -> delivery gate sees achieved_tiers already satisfied
+  -> Alice sees C2 before Global confirmation
+```
+
+**After this spec**
+
+```text
+Alice subscribes with tier=global
+
+QueryFrontierSettled(through_seq=41) arrives
+CommitConfirmedTier(C1, global) arrives
+  -> first delivery allowed
+
+Later Bob writes C2 on Alice's edge only
+  -> visible commits now include C2
+  -> delivery gate checks C2.confirmed_tier
+  -> C2 held back until confirmed at global
+```
+
+### Scenario 3: opt-in transaction accepted
+
+**Today on `main`**
+
+```text
+Alice wants one strict write touching todo/1 and project/9
+
+Only ordinary public optimistic writes exist
+  -> partial visibility and rollback semantics are ad hoc
+  -> reconnect cannot re-derive one authority-owned fate record
+```
+
+**After this spec**
+
+```text
+Alice starts transactional batch B7
+  -> writes stage on tx-private prefixes for todo/1 and project/9
+  -> local mode is confirmed_plus_local_pending, so Alice may see her own pending state
+
+Authority validates B7
+  -> TxDecision.Accepted(B7, merges=[todo merge, project merge])
+
+Bob runs confirmed_only query
+  -> Bob sees nothing until:
+     - TxDecision.Accepted is present
+     - accepted merges relevant to Bob's local query scope are present
+     - visible accepted commits satisfy any requested tier
+```
+
+### Scenario 4: opt-in transaction rejected after optimistic local work
+
+**Today on `main`**
+
+```text
+Alice makes an optimistic multi-object change
+  -> no first-class persisted rejected tx outcome
+  -> restart may lose the rejection surface
+  -> rollback is not one coherent replayable rule
+```
+
+**After this spec**
+
+```text
+Alice starts transactional batch B8
+  -> local pending view visible only to Alice via confirmed_plus_local_pending
+
+Authority rejects B8
+  -> TxDecision.Rejected(B8, code=permission_denied)
+
+Alice runtime:
+  -> rolls back pending tx-private view
+  -> persists rejected outcome
+  -> any dependent local pending txs may be superseded
+  -> rejection survives restart until acknowledged
+```
+
+## Restart semantics
+
+After restart, a durable runtime should be able to reconstruct:
+
+- still-pending ordinary public batches
+- still-pending transactional batches
+- accepted public commits and their confirmed tiers
+- accepted transaction merge refs
+- rejected outcomes awaiting acknowledgement
+
+What it should **not** need:
+
+- a live connection
+- replay of every historical event
+- a second hidden transaction store unrelated to batch-branch history
+
+This is why the MVP needs:
+
+- persisted `LocalBatchRecord`s
+- replayable `TxDecision`s
+- per-commit confirmed-tier state
+
+## Rabbit Holes
+
+- Exact naming and encoding of tx-private prefixes on top of the batch-branch substrate.
+- Efficiently computing `complete_for_current_local_scope` for joins, arrays, and recursive query shapes.
+- Re-triggering delivery when tier state changes without row bytes changing.
+- Deciding how much ordinary public-batch acceptance state needs a live event versus only replay/snapshot synthesis.
+- Garbage collection of rejected tx-private branches without losing debuggability too early.
+- Single durable owner semantics when a browser app has both a persistent worker runtime and a memory main-thread mirror.
+
+## No-gos
+
+- No change that makes all writes transactional by default.
+- No second transaction id beside `BatchId` for transactional writes.
+- No subscription-wide durability watermark as the read-side source of truth.
+- No exact global atomic visibility guarantees for every query shape.
+- No distributed authority placement, leases, or multi-owner consensus in the MVP.
+- No transport rewrite just to support this design.
+
+## Testing Strategy
+
+Prefer RuntimeCore and SchemaManager integration tests with realistic actors and explicit flow sketches.
+
+- `alice` writes an ordinary public batch with `tier: "global"`, the live tier update is dropped, reconnect happens, and the write resolves from replay or snapshot rather than hanging.
+- `alice` and `carol` subscribe with `tier: "global"` on different edges, `bob` writes on one edge, and neither sees the later update until the visible public commit reaches global.
+- `alice` starts transactional batch `B7` touching two objects, the authority accepts it, and a `confirmed_only` subscription only sees the accepted result after `complete_for_current_local_scope` is satisfied.
+- `alice` starts transactional batch `B8`, the authority rejects it, the local pending view rolls back, and the rejected outcome survives restart until acknowledged.
+- a reconnect within the replay window replays missed `ObjectUpdated`, `QueryFrontierSettled`, `CommitConfirmedTier`, and `TxDecision` events without needing a full snapshot.
+- a reconnect after the replay window expires falls back to a frontier snapshot plus pending-batch reconciliation and still converges.
+- `confirmed_plus_local_pending` shows Alice her own pending transactional edits locally, while Bob never sees those pending edits and still waits for accepted public merges.
+
+## Planning summary
+
+The MVP should be shaped as one design with two write modes over one shared batch-history substrate:
+
+1. **ordinary public batches remain the default**
+   - local-first
+   - replayable `Accepted | Missing | Rejected`
+   - fixed per-commit tier gating
+
+2. **transactional batches are explicit opt-in**
+   - `BatchId` also acts as tx id
+   - authority emits `TxDecision`
+   - accepted public merges drive strict query visibility
+   - rejected outcomes roll back and survive restart
+
+This keeps the everyday local-first path simple while giving applications one coherent stricter path when they explicitly need it.

--- a/specs/todo/a_mvp/opt_in_transactions_replayable_reconciliation.md
+++ b/specs/todo/a_mvp/opt_in_transactions_replayable_reconciliation.md
@@ -79,14 +79,16 @@ The intent of this spec is not to make every write transactional. It is to keep 
 
 ## Terms used here
 
-- **public prefix**: the ordinary reader-visible prefix where direct writes and accepted transactional merges live
-- **tx-private prefix**: a staging prefix used only for transactional batches before acceptance
+- **replayable**: a fact is replayable if the client can recover it after a dropped live event, reconnect, or restart from durable protocol state such as ordered replay, snapshot fallback, or persisted local records. In other words, it is not "only true if you happened to catch the live callback"
+- **public prefix**: the ordinary reader-visible branch-prefix namespace introduced by the batch-branch substrate. Concretely, within an `(object_id, branch_name)` lineage, this is the prefix where direct public batches and accepted transactional merges are stored under their `BatchId`
+- **tx-private prefix**: a sibling branch-prefix namespace used only for staging transactional batches before acceptance. Ordinary readers ignore it
 - **authority**: the first durable upstream node allowed to turn a local batch into replayable truth; this is a responsibility of the existing upstream owner path, not a new server tier introduced by this spec. For transactional batches that same durable upstream node also validates the batch and emits the accepted merge set
+- **remote visibility**: whether a change is allowed to affect what another runtime, or any non-local subscription result, can see over sync
 - **strict transaction visibility**: an opt-in query mode that waits for accepted transactional results to be complete for the query's current local scope before showing them
 
 One master invariant runs through the whole design:
 
-- only public commits participate in remote visibility
+- only public commits may affect remote visibility
 - tx-private commits are staging state and optional local overlay state only
 
 ## Goals
@@ -156,7 +158,14 @@ The MVP should not make applications pay transaction latency, authority dependen
 
 ### 3. `BatchId` is the transaction id for transactional writes
 
-For a transactional write, there is no second semantic id beside the batch id.
+For every write, `BatchId` remains the batch identifier from the batch-branch substrate.
+
+The only extra rule is:
+
+- for **direct public batches**, `BatchId` is just the batch id
+- for **transactional batches**, that same `BatchId` also acts as the transaction id
+
+So for a transactional write, there is no second semantic id beside the batch id.
 
 - `BatchId` is the logical transaction id
 - the same `BatchId` is reused across every touched prefix/object

--- a/specs/todo/a_mvp/opt_in_transactions_replayable_reconciliation.md
+++ b/specs/todo/a_mvp/opt_in_transactions_replayable_reconciliation.md
@@ -66,23 +66,25 @@ The intent of this spec is not to make every write transactional. It is to keep 
 
 ### After (`#415` substrate + this spec)
 
-| Topic                     | Proposed MVP                                                                  |
-| ------------------------- | ----------------------------------------------------------------------------- |
-| History unit              | explicit batches under a shared prefix                                        |
-| Default write model       | direct public batches remain default                                          |
-| Transactional write model | explicit opt-in, authority-decided                                            |
-| Durable completion        | replayable batch settlement                                                   |
-| Write rejection           | one replayable batch-settlement model                                         |
-| Tier-gated reads          | per visible batch, not per subscription high-water mark                       |
-| Reconnect                 | replay first, snapshot fallback, pending-batch reconciliation                 |
-| Offline restart           | persisted local batch records + replayable accepted transactional public refs |
+| Topic                     | Proposed MVP                                                                           |
+| ------------------------- | -------------------------------------------------------------------------------------- |
+| History unit              | explicit batches under a shared prefix                                                 |
+| Default write model       | direct public batches remain default                                                   |
+| Transactional write model | explicit opt-in, authority-decided                                                     |
+| Durable completion        | replayable batch settlement                                                            |
+| Write rejection           | one replayable batch-settlement model                                                  |
+| Tier-gated reads          | per visible batch, not per subscription high-water mark                                |
+| Reconnect                 | replay first, snapshot fallback, pending-batch reconciliation                          |
+| Offline restart           | persisted local batch records + replayable accepted transactional public batch members |
 
 ## Terms used here
 
 - **replayable**: a fact is replayable if the client can recover it after a dropped live event, reconnect, or restart from durable protocol state such as ordered replay, snapshot fallback, or persisted local records. In other words, it is not "only true if you happened to catch the live callback"
-- **public prefix**: the ordinary reader-visible branch-prefix namespace introduced by the batch-branch substrate. Concretely, within an `(object_id, branch_name)` lineage, this is the prefix where direct public batches and accepted transactional public refs are stored under their `BatchId`
+- **logical batch**: one user-visible write unit identified by one `BatchId`. A logical batch may touch multiple objects/branches, so it may materialize as multiple per-object batch members
+- **public batch member**: one per-object `(object_id, branch_name, batch_id)` materialization of a logical batch on the public prefix
+- **public prefix**: the ordinary reader-visible branch-prefix namespace introduced by the batch-branch substrate. Concretely, within an `(object_id, branch_name)` lineage, this is the prefix where direct public batch members and accepted transactional public batch members are stored under their shared `BatchId`
 - **tx-private prefix**: a sibling branch-prefix namespace used only for staging transactional batches before acceptance. Ordinary readers ignore it
-- **authority**: the first durable upstream node allowed to turn a local batch into replayable truth; this is a responsibility of the existing upstream owner path, not a new server tier introduced by this spec. For transactional batches that same durable upstream node also validates the batch and emits the accepted public-ref set
+- **authority**: the first durable upstream node allowed to turn a local batch into replayable truth; this is a responsibility of the existing upstream owner path, not a new server tier introduced by this spec. For transactional batches that same durable upstream node also validates the batch and emits the accepted public-batch-member set
 - **remote visibility**: whether a change is allowed to affect what another runtime, or any non-local subscription result, can see over sync
 - **strict transaction visibility**: an opt-in query mode that waits for accepted transactional results to be complete for the query's current local scope before showing them
 
@@ -193,31 +195,31 @@ BatchSettlement =
   DurableDirect {
     batch_id,
     confirmed_tier,
-    public_refs: Vec<PublicRef>,
+    public_members: Vec<PublicBatchMember>,
   }
   AcceptedTransaction {
     batch_id,
     confirmed_tier,
-    public_refs: Vec<PublicRef>,
+    public_members: Vec<PublicBatchMember>,
   }
 ```
 
-`PublicRef` identifies one public-prefix batch materialization:
+`PublicBatchMember` identifies one per-object public-prefix member of a logical batch:
 
 ```text
-PublicRef {
+PublicBatchMember {
   object_id,
   branch_name,
   batch_id,
 }
 ```
 
-`confirmed_tier` is a property of the whole batch settlement, not of individual commits. For any settled public batch, its `confirmed_tier` is the minimum confirmed tier reached by its `public_refs`.
+`confirmed_tier` is a property of the whole batch settlement, not of individual commits. For any settled public batch, its `confirmed_tier` is the minimum confirmed tier reached by its `public_members`.
 
 This means:
 
 - a single-ref batch behaves exactly like the old intuitive model
-- a multi-ref batch only reaches tier `T` when every public ref in that batch reaches `T`
+- a multi-member batch only reaches tier `T` when every public batch member in that batch reaches `T`
 - if an application wants independent visibility, it should emit independent batches
 
 `Rejected` is terminal. `Missing` is a replayable absence result that tells the client to retransmit the original submission if it still cares about that batch. `DurableDirect` and `AcceptedTransaction` are monotonic replayable states whose `confirmed_tier` may advance over time.
@@ -242,7 +244,7 @@ Read delivery should check the currently visible batches, not a subscription-wid
 In plain terms:
 
 - `BatchSettlement.DurableDirect` answers "this direct public batch exists durably at tier T"
-- `BatchSettlement.AcceptedTransaction` answers "this transaction was accepted and its published public refs currently sit at tier T"
+- `BatchSettlement.AcceptedTransaction` answers "this transaction was accepted and its published public batch members currently sit at tier T"
 
 ### 6. Strict transaction visibility is opt-in and has one optional local overlay
 
@@ -317,7 +319,7 @@ Durable completion for a direct public batch requires:
 1. `BatchSettlement.DurableDirect`
 2. `confirmed_tier >= requested_tier`
 
-If a direct public batch spans multiple public refs, its batch `confirmed_tier` is the minimum across those refs. Apps that want one row to become visible independently of another should issue separate batches.
+If a direct public batch spans multiple public batch members, its batch `confirmed_tier` is the minimum across those members. Apps that want one row to become visible independently of another should issue separate batches.
 
 ### Transactional batches (explicit opt-in)
 
@@ -345,8 +347,8 @@ For a successful transactional batch, the end-to-end shape is:
 1. create one `BatchId`
 2. stage changes on tx-private prefixes carrying that `BatchId`
 3. ask the authority to validate and decide that batch
-4. receive `BatchSettlement.AcceptedTransaction { batch_id, confirmed_tier, public_refs }`
-5. wait for the accepted public refs in `public_refs` to become locally present and for `confirmed_tier` to satisfy any requested tier
+4. receive `BatchSettlement.AcceptedTransaction { batch_id, confirmed_tier, public_members }`
+5. wait for the accepted public batch members in `public_members` to become locally present and for `confirmed_tier` to satisfy any requested tier
 
 For a rejected transactional batch, the shape is shorter:
 
@@ -362,7 +364,7 @@ Semantics for the unified `BatchSettlement` model:
 - `Missing`: the authority has no durable record of this batch; the client must retransmit the original direct or transactional submission
 - `Rejected`: the batch was refused before or during authoritative apply
 - `DurableDirect`: a direct public batch exists durably on the public prefix and currently has batch `confirmed_tier = T`
-- `AcceptedTransaction`: the authority accepted a transactional batch, published the authoritative public refs, and those public refs currently have batch `confirmed_tier = T`
+- `AcceptedTransaction`: the authority accepted a transactional batch, published the authoritative public batch members, and those public batch members currently have batch `confirmed_tier = T`
 
 `Rejected` covers cases such as:
 
@@ -370,9 +372,9 @@ Semantics for the unified `BatchSettlement` model:
 - session required
 - catalogue write denied
 
-### Accepted public-batch metadata
+### Accepted public-batch-member metadata
 
-Every accepted transactional public ref should carry enough metadata to mark it as an accepted transaction output rather than an ordinary direct public batch.
+Every accepted transactional public batch member should carry enough metadata to mark it as an accepted transaction output rather than an ordinary direct public batch member.
 
 Minimum metadata:
 
@@ -380,10 +382,10 @@ Minimum metadata:
 
 This is needed for two reasons:
 
-1. after restart, the runtime must be able to map a visible public ref back to accepted-transaction semantics rather than treating it like an ordinary direct batch
-2. `BatchSettlement.AcceptedTransaction { public_refs }` and the public history must agree about which public refs belong to the accepted transaction
+1. after restart, the runtime must be able to map a visible public batch member back to accepted-transaction semantics rather than treating it like an ordinary direct batch member
+2. `BatchSettlement.AcceptedTransaction { public_members }` and the public history must agree about which public batch members belong to the accepted transaction
 
-`AcceptedTransaction { public_refs }` remains the authoritative replayable settlement. The accepted public-batch metadata exists so the public history itself still carries transaction attribution after persistence and reload.
+`AcceptedTransaction { public_members }` remains the authoritative replayable settlement. The accepted public-batch-member metadata exists so the public history itself still carries transaction attribution after persistence and reload.
 
 ## Local persisted records
 
@@ -446,15 +448,15 @@ The MVP completeness rule stays the one from the earlier transaction work:
 Definition:
 
 1. compute the query's current local contributing scope
-2. intersect that scope with the batch's accepted `public_refs`
-3. the transaction is complete for that query only when every intersecting accepted public ref is locally present
+2. intersect that scope with the batch's accepted `public_members`
+3. the transaction is complete for that query only when every intersecting accepted public batch member is locally present
 
 This is intentionally weaker than exact global query completeness.
 
 It is still strong enough to guarantee:
 
 - no partial accepted transaction visibility inside the query's current local scope
-- restart-safe re-derivation from persisted accepted public refs
+- restart-safe re-derivation from persisted accepted public batch members
 
 ### Optional local pending overlay
 
@@ -535,7 +537,7 @@ The client then:
 - resolves accepted transactional batches waiting on completeness and tier
 - retransmits `Missing` batches
 - fails `Rejected` batches
-- re-checks strict query visibility using the now-current frontier and accepted public refs
+- re-checks strict query visibility using the now-current frontier and accepted public batch members
 
 ## Before / After flow sketches
 
@@ -562,14 +564,14 @@ Reconnect:
 Alice writes public batch B1 with tier=global
   -> LocalBatchRecord(B1, mode=Direct, Pending)
 
-Live BatchSettlement.DurableDirect(B1, confirmed_tier=global, public_refs=[...]) is dropped
+Live BatchSettlement.DurableDirect(B1, confirmed_tier=global, public_members=[...]) is dropped
 
 Reconnect:
   -> replay active queries
   -> ResumeSync(last_seen_seq=N, pending_batches=[{B1, Direct}])
 
 Server replies:
-  -> BatchSettlement.DurableDirect(B1, confirmed_tier=global, public_refs=[...]) via replay or snapshot
+  -> BatchSettlement.DurableDirect(B1, confirmed_tier=global, public_members=[...]) via replay or snapshot
 
 Alice:
   -> marks B1 durably published
@@ -598,7 +600,7 @@ Later Bob writes C2 on Alice's edge only
 Alice subscribes with tier=global
 
 QueryFrontierSettled(through_seq=41) arrives
-BatchSettlement.DurableDirect(B1, confirmed_tier=global, public_refs=[...]) arrives
+BatchSettlement.DurableDirect(B1, confirmed_tier=global, public_members=[...]) arrives
   -> first delivery allowed
 
 Later Bob writes batch B2 on Alice's edge only
@@ -630,13 +632,13 @@ Authority validates B7
   -> BatchSettlement.AcceptedTransaction(
        B7,
        confirmed_tier=edge,
-       public_refs=[todo ref, project ref],
+       public_members=[todo member, project member],
      )
 
 Bob runs a strict transaction-visible query
   -> Bob sees nothing until:
      - AcceptedTransaction is present
-     - accepted public refs relevant to Bob's local query scope are present
+     - accepted public batch members relevant to Bob's local query scope are present
      - the batch's confirmed_tier satisfies any requested tier
 ```
 
@@ -674,7 +676,7 @@ After restart, a durable runtime should be able to reconstruct:
 - still-pending direct public batches
 - still-pending transactional batches
 - public batch settlements and their current confirmed tiers
-- accepted transaction public refs
+- accepted transaction public batch members
 - rejected outcomes awaiting acknowledgement
 
 What it should **not** need:
@@ -716,7 +718,7 @@ Prefer RuntimeCore and SchemaManager integration tests with realistic actors and
 - `alice` starts transactional batch `B8`, the authority rejects it, the local pending view rolls back, and the rejected outcome survives restart until acknowledged.
 - a reconnect within the replay window replays missed `ObjectUpdated`, `QueryFrontierSettled`, and `BatchSettlement` events without needing a full snapshot.
 - a reconnect after the replay window expires falls back to a frontier snapshot plus pending-batch reconciliation and still converges.
-- the optional local pending overlay shows Alice her own pending transactional edits locally, while Bob never sees those pending edits and still waits for accepted public refs.
+- the optional local pending overlay shows Alice her own pending transactional edits locally, while Bob never sees those pending edits and still waits for accepted public batch members.
 
 ## Planning summary
 
@@ -730,7 +732,7 @@ The MVP should be shaped as one design with two write modes over one shared batc
 2. **transactional batches are explicit opt-in**
    - `BatchId` also acts as tx id
    - authority emits `AcceptedTransaction` or `Rejected` inside `BatchSettlement`
-   - accepted public refs drive strict query visibility
+   - accepted public batch members drive strict query visibility
    - rejected outcomes roll back and survive restart
 
 This keeps the everyday local-first path simple while giving applications one coherent stricter path when they explicitly need it.

--- a/specs/todo/a_mvp/opt_in_transactions_replayable_reconciliation.md
+++ b/specs/todo/a_mvp/opt_in_transactions_replayable_reconciliation.md
@@ -56,7 +56,7 @@ The intent of this spec is not to make every write transactional. It is to keep 
 | Topic                     | Status quo                                                 |
 | ------------------------- | ---------------------------------------------------------- |
 | History unit              | one branch may have many concurrent tips                   |
-| Default write model       | optimistic direct write to public branch                   |
+| Default write model       | optimistic direct write to visible branch state            |
 | Transactional write model | none                                                       |
 | Durable completion        | live `PersistenceAck` watcher                              |
 | Write rejection           | partial / non-replayable                                   |
@@ -66,32 +66,32 @@ The intent of this spec is not to make every write transactional. It is to keep 
 
 ### After (`#415` substrate + this spec)
 
-| Topic                     | Proposed MVP                                                                           |
-| ------------------------- | -------------------------------------------------------------------------------------- |
-| History unit              | explicit batches under a shared prefix                                                 |
-| Default write model       | direct public batches remain default                                                   |
-| Transactional write model | explicit opt-in, authority-decided                                                     |
-| Durable completion        | replayable batch settlement                                                            |
-| Write rejection           | one replayable batch-settlement model                                                  |
-| Tier-gated reads          | per visible batch, not per subscription high-water mark                                |
-| Reconnect                 | replay first, snapshot fallback, pending-batch reconciliation                          |
-| Offline restart           | persisted local batch records + replayable accepted transactional public batch members |
+| Topic                     | Proposed MVP                                                                            |
+| ------------------------- | --------------------------------------------------------------------------------------- |
+| History unit              | explicit batches under a shared prefix                                                  |
+| Default write model       | direct visible batches remain default                                                   |
+| Transactional write model | explicit opt-in, authority-decided                                                      |
+| Durable completion        | replayable batch settlement                                                             |
+| Write rejection           | one replayable batch-settlement model                                                   |
+| Tier-gated reads          | per visible batch, not per subscription high-water mark                                 |
+| Reconnect                 | replay first, snapshot fallback, pending-batch reconciliation                           |
+| Offline restart           | persisted local batch records + replayable accepted transactional visible batch members |
 
 ## Terms used here
 
 - **replayable**: a fact is replayable if the client can recover it after a dropped live event, reconnect, or restart from durable protocol state such as ordered replay, snapshot fallback, or persisted local records. In other words, it is not "only true if you happened to catch the live callback"
 - **logical batch**: one user-visible write unit identified by one `BatchId`. A logical batch may touch multiple objects/branches, so it may materialize as multiple per-object batch members
-- **public batch member**: one per-object `(object_id, branch_name, batch_id)` materialization of a logical batch on the public prefix
-- **public prefix**: the ordinary reader-visible branch-prefix namespace introduced by the batch-branch substrate. Concretely, within an `(object_id, branch_name)` lineage, this is the prefix where direct public batch members and accepted transactional public batch members are stored under their shared `BatchId`
-- **tx-private prefix**: a sibling branch-prefix namespace used only for staging transactional batches before acceptance. Ordinary readers ignore it
-- **authority**: the first durable upstream node allowed to turn a local batch into replayable truth; this is a responsibility of the existing upstream owner path, not a new server tier introduced by this spec. For transactional batches that same durable upstream node also validates the batch and emits the accepted public-batch-member set
+- **visible batch member**: one per-object `(object_id, branch_name, batch_id)` materialization of a logical batch on the visible prefix
+- **visible prefix**: the full user-meaningful branch-prefix namespace introduced by the batch-branch substrate. Concretely, within an `(object_id, branch_name)` lineage, this is the prefix normal reads use, and where direct visible batch members and accepted transactional visible batch members are stored under their shared `BatchId`
+- **staging prefix**: a sibling branch-prefix namespace used only for staging transactional batches before acceptance. Ordinary reads ignore it
+- **authority**: the first durable upstream node allowed to turn a local batch into replayable truth; this is a responsibility of the existing upstream owner path, not a new server tier introduced by this spec. For transactional batches that same durable upstream node also validates the batch and emits the accepted visible-batch-member set
 - **remote visibility**: whether a change is allowed to affect what another runtime, or any non-local subscription result, can see over sync
 - **strict transaction visibility**: an opt-in query mode that waits for accepted transactional results to be complete for the query's current local scope before showing them
 
 One master invariant runs through the whole design:
 
-- only public-prefix batches may affect remote visibility
-- tx-private batches are staging state and optional local overlay state only
+- only visible-prefix batches may affect remote visibility
+- staging batches are staging state and optional local overlay state only
 
 ## Goals
 
@@ -124,7 +124,7 @@ This spec assumes [Batch Branches and Prefix-Indexed Storage](../b_launch/batch_
 That prerequisite does two important things:
 
 1. it turns "a write" into an explicit `BatchId`
-2. it gives transaction-private and public accepted history the same physical shape
+2. it gives staging and visible accepted history the same physical shape
 
 This spec does not add a separate transaction log format or second object-history model on top of that.
 
@@ -132,12 +132,12 @@ This spec does not add a separate transaction log format or second object-histor
 
 Jazz keeps two write modes:
 
-1. **direct public batches** — default
+1. **direct visible batches** — default
 2. **transactional batches** — explicit opt-in
 
-Direct public batches preserve the current local-first shape:
+Direct visible batches preserve the current local-first shape:
 
-- they write directly to the ordinary public prefix
+- they write directly to the visible prefix
 - they do not require authority-decided multi-object acceptance
 - they still benefit from replayable reconciliation and fixed tier gating
 
@@ -163,7 +163,7 @@ For every write, `BatchId` remains the batch identifier from the batch-branch su
 
 The only extra rule is:
 
-- for **direct public batches**, `BatchId` is just the batch id
+- for **direct visible batches**, `BatchId` is just the batch id
 - for **transactional batches**, that same `BatchId` also acts as the transaction id
 
 So for a transactional write, there is no second semantic id beside the batch id.
@@ -195,31 +195,31 @@ BatchSettlement =
   DurableDirect {
     batch_id,
     confirmed_tier,
-    public_members: Vec<PublicBatchMember>,
+    visible_members: Vec<VisibleBatchMember>,
   }
   AcceptedTransaction {
     batch_id,
     confirmed_tier,
-    public_members: Vec<PublicBatchMember>,
+    visible_members: Vec<VisibleBatchMember>,
   }
 ```
 
-`PublicBatchMember` identifies one per-object public-prefix member of a logical batch:
+`VisibleBatchMember` identifies one per-object visible-prefix member of a logical batch:
 
 ```text
-PublicBatchMember {
+VisibleBatchMember {
   object_id,
   branch_name,
   batch_id,
 }
 ```
 
-`confirmed_tier` is a property of the whole batch settlement, not of individual commits. For any settled public batch, its `confirmed_tier` is the minimum confirmed tier reached by its `public_members`.
+`confirmed_tier` is a property of the whole batch settlement, not of individual commits. For any settled visible batch, its `confirmed_tier` is the minimum confirmed tier reached by its `visible_members`.
 
 This means:
 
 - a single-ref batch behaves exactly like the old intuitive model
-- a multi-member batch only reaches tier `T` when every public batch member in that batch reaches `T`
+- a multi-member batch only reaches tier `T` when every visible batch member in that batch reaches `T`
 - if an application wants independent visibility, it should emit independent batches
 
 `Rejected` is terminal. `Missing` is a replayable absence result that tells the client to retransmit the original submission if it still cares about that batch. `DurableDirect` and `AcceptedTransaction` are monotonic replayable states whose `confirmed_tier` may advance over time.
@@ -237,14 +237,14 @@ This one `BatchSettlement` model replaces three separate ideas:
 Instead:
 
 - `QueryFrontierSettled` means "all query updates through sequence N have been emitted"
-- `BatchSettlement` means "this public batch currently exists at confirmed tier T, or was rejected, or is missing"
+- `BatchSettlement` means "this visible batch currently exists at confirmed tier T, or was rejected, or is missing"
 
 Read delivery should check the currently visible batches, not a subscription-wide high-water mark.
 
 In plain terms:
 
-- `BatchSettlement.DurableDirect` answers "this direct public batch exists durably at tier T"
-- `BatchSettlement.AcceptedTransaction` answers "this transaction was accepted and its published public batch members currently sit at tier T"
+- `BatchSettlement.DurableDirect` answers "this direct visible batch exists durably at tier T"
+- `BatchSettlement.AcceptedTransaction` answers "this transaction was accepted and its published visible batch members currently sit at tier T"
 
 ### 6. Strict transaction visibility is opt-in and has one optional local overlay
 
@@ -252,11 +252,11 @@ Queries and subscriptions keep ordinary behavior by default.
 
 A caller may opt into strict transaction visibility. In that mode:
 
-- only accepted public transactional results may affect the visible query result
+- only accepted visible transactional results may affect the visible query result
 - a transaction is visible only when it is complete for the query's current local scope
 - any requested durability tier must be satisfied by the visible accepted batches
 
-Queries that do not opt into this mode keep ordinary public-prefix behavior. Accepted transactional results become atomic only for queries that explicitly ask for strict transaction visibility.
+Queries that do not opt into this mode keep ordinary visible-prefix behavior. Accepted transactional results become atomic only for queries that explicitly ask for strict transaction visibility.
 
 Strict mode may additionally enable one optional local overlay:
 
@@ -281,7 +281,7 @@ Replay remains the fast path. Snapshot fallback remains the correctness path.
 
 ### 8. Rejected outcomes survive restart until acknowledged
 
-For both direct public batches and transactional batches:
+For both direct visible batches and transactional batches:
 
 - rejected outcomes must survive restart
 - they must be queryable after long offline periods
@@ -291,18 +291,18 @@ This is required for correctness and debuggability. A rejection should not exist
 
 ## Write modes
 
-### Direct public batches (default)
+### Direct visible batches (default)
 
 This is the default write mode for today's insert/update/delete APIs.
 
 Behavior:
 
-1. the client creates a new public `BatchId`
-2. writes append directly to the ordinary public prefix
+1. the client creates a new `BatchId` for the visible write
+2. writes append directly to the visible prefix
 3. local optimistic UX behaves as today
 4. the batch remains pending until reconciliation yields one replayable `BatchSettlement`
 
-For direct public batches, the relevant settled states are:
+For direct visible batches, the relevant settled states are:
 
 - `Missing`
 - `Rejected`
@@ -310,16 +310,16 @@ For direct public batches, the relevant settled states are:
 
 `DurableDirect` means:
 
-- this direct public batch exists durably on the public prefix
+- this direct visible batch exists durably on the visible prefix
 - its current `confirmed_tier` applies to the whole batch
 - the write is no longer in the "maybe dropped before publication" state
 
-Durable completion for a direct public batch requires:
+Durable completion for a direct visible batch requires:
 
 1. `BatchSettlement.DurableDirect`
 2. `confirmed_tier >= requested_tier`
 
-If a direct public batch spans multiple public batch members, its batch `confirmed_tier` is the minimum across those members. Apps that want one row to become visible independently of another should issue separate batches.
+If a direct visible batch spans multiple visible batch members, its batch `confirmed_tier` is the minimum across those members. Apps that want one row to become visible independently of another should issue separate batches.
 
 ### Transactional batches (explicit opt-in)
 
@@ -328,12 +328,12 @@ This is the stricter write mode.
 Behavior:
 
 1. the client explicitly starts a transactional batch
-2. all staged row changes land on tx-private prefixes
-3. ordinary readers do not include tx-private prefixes
+2. all staged row changes land on staging prefixes
+3. ordinary readers do not include staging prefixes
 4. the authority validates the batch against its captured frontier
 5. the authority emits one replayable `BatchSettlement`
-6. if accepted, the authority creates accepted public batches
-7. if rejected, the tx-private batches never become public and local pending state rolls back
+6. if accepted, the authority creates accepted visible batch members
+7. if rejected, the staging batches never become visible and local pending state rolls back
 
 Because transactionality is opt-in:
 
@@ -345,15 +345,15 @@ Because transactionality is opt-in:
 For a successful transactional batch, the end-to-end shape is:
 
 1. create one `BatchId`
-2. stage changes on tx-private prefixes carrying that `BatchId`
+2. stage changes on staging prefixes carrying that `BatchId`
 3. ask the authority to validate and decide that batch
-4. receive `BatchSettlement.AcceptedTransaction { batch_id, confirmed_tier, public_members }`
-5. wait for the accepted public batch members in `public_members` to become locally present and for `confirmed_tier` to satisfy any requested tier
+4. receive `BatchSettlement.AcceptedTransaction { batch_id, confirmed_tier, visible_members }`
+5. wait for the accepted visible batch members in `visible_members` to become locally present and for `confirmed_tier` to satisfy any requested tier
 
 For a rejected transactional batch, the shape is shorter:
 
 1. create one `BatchId`
-2. stage local tx-private changes
+2. stage local changes on the staging prefix
 3. receive `BatchSettlement.Rejected`
 4. roll back the local pending view and retain the rejection across restart until acknowledged
 
@@ -363,8 +363,8 @@ Semantics for the unified `BatchSettlement` model:
 
 - `Missing`: the authority has no durable record of this batch; the client must retransmit the original direct or transactional submission
 - `Rejected`: the batch was refused before or during authoritative apply
-- `DurableDirect`: a direct public batch exists durably on the public prefix and currently has batch `confirmed_tier = T`
-- `AcceptedTransaction`: the authority accepted a transactional batch, published the authoritative public batch members, and those public batch members currently have batch `confirmed_tier = T`
+- `DurableDirect`: a direct visible batch exists durably on the visible prefix and currently has batch `confirmed_tier = T`
+- `AcceptedTransaction`: the authority accepted a transactional batch, published the authoritative visible batch members, and those visible batch members currently have batch `confirmed_tier = T`
 
 `Rejected` covers cases such as:
 
@@ -372,9 +372,9 @@ Semantics for the unified `BatchSettlement` model:
 - session required
 - catalogue write denied
 
-### Accepted public-batch-member metadata
+### Accepted Visible Batch Member Metadata
 
-Every accepted transactional public batch member should carry enough metadata to mark it as an accepted transaction output rather than an ordinary direct public batch member.
+Every accepted transactional visible batch member should carry enough metadata to mark it as an accepted transaction output rather than an ordinary direct visible batch member.
 
 Minimum metadata:
 
@@ -382,10 +382,10 @@ Minimum metadata:
 
 This is needed for two reasons:
 
-1. after restart, the runtime must be able to map a visible public batch member back to accepted-transaction semantics rather than treating it like an ordinary direct batch member
-2. `BatchSettlement.AcceptedTransaction { public_members }` and the public history must agree about which public batch members belong to the accepted transaction
+1. after restart, the runtime must be able to map a visible batch member back to accepted-transaction semantics rather than treating it like an ordinary direct visible batch member
+2. `BatchSettlement.AcceptedTransaction { visible_members }` and the visible-prefix history must agree about which visible batch members belong to the accepted transaction
 
-`AcceptedTransaction { public_members }` remains the authoritative replayable settlement. The accepted public-batch-member metadata exists so the public history itself still carries transaction attribution after persistence and reload.
+`AcceptedTransaction { visible_members }` remains the authoritative replayable settlement. The accepted visible-batch-member metadata exists so the visible-prefix history itself still carries transaction attribution after persistence and reload.
 
 ## Local persisted records
 
@@ -423,8 +423,8 @@ Persisted local records exist to support:
 
 Ordinary queries keep today's overall shape:
 
-- they read public prefixes
-- they ignore tx-private prefixes
+- they read visible prefixes
+- they ignore staging prefixes
 - they may still request a durability tier
 
 The important fix is that durability is checked per visible batch, not per subscription high-water mark.
@@ -433,7 +433,7 @@ A later remote update must not become visible until every visible batch for that
 
 This is intentionally batch-wide. If a query sees any part of batch `B`, it gates on batch `B`'s current `confirmed_tier`, not just the specific visible ref.
 
-Ordinary queries do **not** get transactional completeness guarantees. If an accepted transactional batch reaches a public prefix and its batch `confirmed_tier` satisfies any requested tier, ordinary queries may observe it like any other public update.
+Ordinary queries do **not** get transactional completeness guarantees. If an accepted transactional batch reaches the visible prefix and its batch `confirmed_tier` satisfies any requested tier, ordinary queries may observe it like any other visible update.
 
 ### Strict transaction visibility (opt-in)
 
@@ -448,15 +448,15 @@ The MVP completeness rule stays the one from the earlier transaction work:
 Definition:
 
 1. compute the query's current local contributing scope
-2. intersect that scope with the batch's accepted `public_members`
-3. the transaction is complete for that query only when every intersecting accepted public batch member is locally present
+2. intersect that scope with the batch's accepted `visible_members`
+3. the transaction is complete for that query only when every intersecting accepted visible batch member is locally present
 
 This is intentionally weaker than exact global query completeness.
 
 It is still strong enough to guarantee:
 
 - no partial accepted transaction visibility inside the query's current local scope
-- restart-safe re-derivation from persisted accepted public batch members
+- restart-safe re-derivation from persisted accepted visible batch members
 
 ### Optional local pending overlay
 
@@ -537,7 +537,7 @@ The client then:
 - resolves accepted transactional batches waiting on completeness and tier
 - retransmits `Missing` batches
 - fails `Rejected` batches
-- re-checks strict query visibility using the now-current frontier and accepted public batch members
+- re-checks strict query visibility using the now-current frontier and accepted visible batch members
 
 ## Before / After flow sketches
 
@@ -546,8 +546,8 @@ The client then:
 **Today on `main`**
 
 ```text
-Alice writes public batch B1 with tier=global
-  -> public commit sent upstream
+Alice writes visible batch B1 with tier=global
+  -> visible write sent upstream
   -> durable waiter watches for live PersistenceAck
 
 PersistenceAck(B1, global) is dropped
@@ -561,17 +561,17 @@ Reconnect:
 **After this spec**
 
 ```text
-Alice writes public batch B1 with tier=global
+Alice writes visible batch B1 with tier=global
   -> LocalBatchRecord(B1, mode=Direct, Pending)
 
-Live BatchSettlement.DurableDirect(B1, confirmed_tier=global, public_members=[...]) is dropped
+Live BatchSettlement.DurableDirect(B1, confirmed_tier=global, visible_members=[...]) is dropped
 
 Reconnect:
   -> replay active queries
   -> ResumeSync(last_seen_seq=N, pending_batches=[{B1, Direct}])
 
 Server replies:
-  -> BatchSettlement.DurableDirect(B1, confirmed_tier=global, public_members=[...]) via replay or snapshot
+  -> BatchSettlement.DurableDirect(B1, confirmed_tier=global, visible_members=[...]) via replay or snapshot
 
 Alice:
   -> marks B1 durably published
@@ -600,7 +600,7 @@ Later Bob writes C2 on Alice's edge only
 Alice subscribes with tier=global
 
 QueryFrontierSettled(through_seq=41) arrives
-BatchSettlement.DurableDirect(B1, confirmed_tier=global, public_members=[...]) arrives
+BatchSettlement.DurableDirect(B1, confirmed_tier=global, visible_members=[...]) arrives
   -> first delivery allowed
 
 Later Bob writes batch B2 on Alice's edge only
@@ -616,7 +616,7 @@ Later Bob writes batch B2 on Alice's edge only
 ```text
 Alice wants one strict write touching todo/1 and project/9
 
-Only direct public optimistic writes exist
+Only direct visible optimistic writes exist
   -> partial visibility and rollback semantics are ad hoc
   -> reconnect cannot re-derive one authority-owned fate record
 ```
@@ -625,20 +625,20 @@ Only direct public optimistic writes exist
 
 ```text
 Alice starts transactional batch B7
-  -> writes stage on tx-private prefixes for todo/1 and project/9
+  -> writes stage on staging prefixes for todo/1 and project/9
   -> strict mode + local pending overlay lets Alice see her own pending state
 
 Authority validates B7
   -> BatchSettlement.AcceptedTransaction(
        B7,
        confirmed_tier=edge,
-       public_members=[todo member, project member],
+       visible_members=[todo member, project member],
      )
 
 Bob runs a strict transaction-visible query
   -> Bob sees nothing until:
      - AcceptedTransaction is present
-     - accepted public batch members relevant to Bob's local query scope are present
+     - accepted visible batch members relevant to Bob's local query scope are present
      - the batch's confirmed_tier satisfies any requested tier
 ```
 
@@ -663,7 +663,7 @@ Authority rejects B8
   -> BatchSettlement.Rejected(B8, code=permission_denied)
 
 Alice runtime:
-  -> rolls back pending tx-private view
+  -> rolls back pending staging view
   -> persists rejected outcome
   -> any dependent local pending txs may be superseded
   -> rejection survives restart until acknowledged
@@ -673,10 +673,10 @@ Alice runtime:
 
 After restart, a durable runtime should be able to reconstruct:
 
-- still-pending direct public batches
+- still-pending direct visible batches
 - still-pending transactional batches
-- public batch settlements and their current confirmed tiers
-- accepted transaction public batch members
+- visible batch settlements and their current confirmed tiers
+- accepted transaction visible batch members
 - rejected outcomes awaiting acknowledgement
 
 What it should **not** need:
@@ -692,11 +692,11 @@ This is why the MVP needs:
 
 ## Rabbit Holes
 
-- Exact naming and encoding of tx-private prefixes on top of the batch-branch substrate.
+- Exact naming and encoding of staging prefixes on top of the batch-branch substrate.
 - Efficiently computing `complete_for_current_local_scope` for joins, arrays, and recursive query shapes.
 - Re-triggering delivery when tier state changes without row bytes changing.
 - Deciding whether batch confirmed tier should always be emitted live or can sometimes be synthesized only from replay/snapshot state.
-- Garbage collection of rejected tx-private branches without losing debuggability too early.
+- Garbage collection of rejected staging branches without losing debuggability too early.
 - Single durable owner semantics when a browser app has both a persistent worker runtime and a memory main-thread mirror.
 
 ## No-gos
@@ -712,19 +712,19 @@ This is why the MVP needs:
 
 Prefer RuntimeCore and SchemaManager integration tests with realistic actors and explicit flow sketches.
 
-- `alice` writes a direct public batch with `tier: "global"`, the live tier update is dropped, reconnect happens, and the write resolves from replay or snapshot rather than hanging.
-- `alice` and `carol` subscribe with `tier: "global"` on different edges, `bob` writes one direct public batch on one edge, and neither sees that batch until its batch settlement reaches global.
+- `alice` writes a direct visible batch with `tier: "global"`, the live tier update is dropped, reconnect happens, and the write resolves from replay or snapshot rather than hanging.
+- `alice` and `carol` subscribe with `tier: "global"` on different edges, `bob` writes one direct visible batch on one edge, and neither sees that batch until its batch settlement reaches global.
 - `alice` starts transactional batch `B7` touching two objects, the authority accepts it, and a strict transaction-visible subscription only sees the accepted result after `complete_for_current_local_scope` is satisfied.
 - `alice` starts transactional batch `B8`, the authority rejects it, the local pending view rolls back, and the rejected outcome survives restart until acknowledged.
 - a reconnect within the replay window replays missed `ObjectUpdated`, `QueryFrontierSettled`, and `BatchSettlement` events without needing a full snapshot.
 - a reconnect after the replay window expires falls back to a frontier snapshot plus pending-batch reconciliation and still converges.
-- the optional local pending overlay shows Alice her own pending transactional edits locally, while Bob never sees those pending edits and still waits for accepted public batch members.
+- the optional local pending overlay shows Alice her own pending transactional edits locally, while Bob never sees those pending edits and still waits for accepted visible batch members.
 
 ## Planning summary
 
 The MVP should be shaped as one design with two write modes over one shared batch-history substrate:
 
-1. **direct public batches remain the default**
+1. **direct visible batches remain the default**
    - local-first
    - replayable `BatchSettlement`
    - fixed per-batch tier gating
@@ -732,7 +732,7 @@ The MVP should be shaped as one design with two write modes over one shared batc
 2. **transactional batches are explicit opt-in**
    - `BatchId` also acts as tx id
    - authority emits `AcceptedTransaction` or `Rejected` inside `BatchSettlement`
-   - accepted public batch members drive strict query visibility
+   - accepted visible batch members drive strict query visibility
    - rejected outcomes roll back and survive restart
 
 This keeps the everyday local-first path simple while giving applications one coherent stricter path when they explicitly need it.


### PR DESCRIPTION
## Summary

- add a new MVP spec in `specs/todo/a_mvp/opt_in_transactions_replayable_reconciliation.md`
- assume the batch-branch substrate lands first, then describe one combined design for:
  - opt-in transactions
  - replayable write reconciliation
  - persisted accepted/rejected outcomes
  - strict query visibility after reconnect and offline restart
- write the spec for readers who only know the status quo on `main`, with explicit before/after contrast instead of branch-specific context

## Why

The current design questions are spread across separate exploration threads:

- replayable write reconciliation
- mutation / rejection handling
- transaction visibility and authority-decided fate

This PR replaces that split framing with one standalone spec that keeps ordinary public batches as the default write path, makes transactionality explicitly opt-in, and separates:

- write fate
- durability tier
- query completeness

## Impact

- spec-only change
- no runtime behavior changes in this PR
- intended as a design target for follow-up implementation work after the batch-branch base exists

## Validation

- `git diff --check`
- pre-commit hooks passed:
  - `oxfmt`
