### PR TITLE
Docs: add Rust examples to files-and-blobs page

### DIFF
--- a/docs/content/docs/writing/files-and-blobs.mdx
+++ b/docs/content/docs/writing/files-and-blobs.mdx
@@ -1,7 +1,7 @@
 ---
 title: Files & Blobs
 description: Chunked browser Blob and stream storage using conventional files and file_parts tables.
-reviewedAt: "4059cdef"
+reviewedAt: "f7048c19"
 ---
 
 import { Callout } from "fumadocs-ui/components/callout";
@@ -12,9 +12,9 @@ For larger files, use the chunked storage described below.
 ## Add the conventional tables
 
 `db.createFileFromBlob`, `db.createFileFromStream`, `db.loadFileAsBlob`, and
-`db.loadFileAsStream` currently expect these exact table and column names on `app`:
+`db.loadFileAsStream` expect these exact table and column names on `app`:
 
-<include cwd lang="ts" meta='title="schema.ts"'>
+<include cwd lang="ts">
   ../examples/docs/todo-client-localfirst-ts/schema.ts#schema-files-and-blobs-ts
 </include>
 
@@ -26,7 +26,7 @@ is optional metadata; `createFileFromBlob(...)` fills it from `File.name` when a
 
 ## Add permissions
 
-<include cwd lang="ts" meta='title="files-and-blobs-permissions.ts"'>
+<include cwd lang="ts">
   ../examples/docs/todo-client-localfirst-ts/files-and-blobs-permissions.ts#files-permissions-ts
 </include>
 
@@ -34,62 +34,111 @@ is optional metadata; `createFileFromBlob(...)` fills it from `File.name` when a
 `file_parts` inherit from `files.partIds`.
 
 <Callout type="warn" title="Insert permissions are direct for now">
-  `createFileFromBlob(...)` and `createFileFromStream(...)` create `file_parts` and `files` before
-  your parent row exists, so insert inheritance does not naturally apply yet. Currently, grant
-  direct insert access to the clients that may upload, or perform uploads in a trusted backend
-  context.
+  File parts and files are created before the parent upload row exists, so insert inheritance does
+  not naturally apply yet. Currently, grant direct insert access to the clients that may upload, or
+  perform uploads in a trusted backend context.
 </Callout>
 
-Files are currently write-once, so `files` and `file_parts` normally do not need update
+Files are write-once, so `files` and `file_parts` normally do not need update
 policies.
 
 ## Create from a blob
 
-<include cwd lang="ts" meta='title="src/files-and-blobs-snippets.ts"'>
-  ../examples/docs/todo-client-localfirst-ts/src/files-and-blobs-snippets.ts#files-create-from-blob-ts
-</include>
+<Tabs groupId="jazz-environment" items={["TypeScript", "Rust"]} persist updateAnchor>
+  <Tab value="TypeScript">
+    <include cwd lang="ts">
+      ../examples/docs/todo-client-localfirst-ts/src/files-and-blobs-snippets.ts#files-create-from-blob-ts
+    </include>
+  </Tab>
+  <Tab value="Rust">
+    <include cwd lang="rs">
+      ../examples/docs/todo-server-rs/src/docs_snippets.rs#files-create-from-bytes-rust
+    </include>
+
+    <include cwd lang="rs">
+      ../examples/docs/todo-server-rs/src/docs_snippets.rs#files-create-upload-rust
+    </include>
+
+  </Tab>
+</Tabs>
 
 Returns the file row; store its id on your own table.
 
 ## Create from a stream
 
-<include cwd lang="ts" meta='title="src/files-and-blobs-snippets.ts"'>
-  ../examples/docs/todo-client-localfirst-ts/src/files-and-blobs-snippets.ts#files-create-from-stream-ts
-</include>
+<Tabs groupId="jazz-environment" items={["TypeScript", "Rust"]} persist updateAnchor>
+  <Tab value="TypeScript">
+    <include cwd lang="ts">
+      ../examples/docs/todo-client-localfirst-ts/src/files-and-blobs-snippets.ts#files-create-from-stream-ts
+    </include>
+  </Tab>
+  <Tab value="Rust">
+    Rust does not have a separate stream helper. Read your stream into chunks and create
+    `file_parts` rows as they arrive, using the same approach shown in [Create from a
+    blob](#create-from-a-blob) above.
+  </Tab>
+</Tabs>
 
 ## Load as a blob
 
-<include cwd lang="ts" meta='title="src/files-and-blobs-snippets.ts"'>
-  ../examples/docs/todo-client-localfirst-ts/src/files-and-blobs-snippets.ts#files-load-blob-ts
-</include>
+<Tabs groupId="jazz-environment" items={["TypeScript", "Rust"]} persist updateAnchor>
+  <Tab value="TypeScript">
+    <include cwd lang="ts">
+      ../examples/docs/todo-client-localfirst-ts/src/files-and-blobs-snippets.ts#files-load-blob-ts
+    </include>
+  </Tab>
+  <Tab value="Rust">
+    <include cwd lang="rs">
+      ../examples/docs/todo-server-rs/src/docs_snippets.rs#files-load-rust
+    </include>
+  </Tab>
+</Tabs>
 
 ## Load as a stream
 
-<include cwd lang="ts" meta='title="src/files-and-blobs-snippets.ts"'>
-  ../examples/docs/todo-client-localfirst-ts/src/files-and-blobs-snippets.ts#files-load-stream-ts
-</include>
+<Tabs groupId="jazz-environment" items={["TypeScript", "Rust"]} persist updateAnchor>
+  <Tab value="TypeScript">
+    <include cwd lang="ts">
+      ../examples/docs/todo-client-localfirst-ts/src/files-and-blobs-snippets.ts#files-load-stream-ts
+    </include>
+  </Tab>
+  <Tab value="Rust">
+    To stream chunks rather than collecting all bytes, walk `files.partIds` and query each
+    `file_parts` row individually, yielding chunks as they arrive instead of concatenating
+    into a single `Vec<u8>`.
+  </Tab>
+</Tabs>
 
-`loadFileAsBlob(...)` and `loadFileAsStream(...)` fetch each chunk sequentially rather than eager-loading every part in one query.
+Both approaches fetch each chunk sequentially rather than eager-loading every part in one query.
 
 ## Durability and incomplete local data
 
 The file helpers forward normal Jazz durability options:
 
-- Pass `tier` to `createFileFromBlob(...)` or `createFileFromStream(...)`.
-- Pass query options like `{ tier: "edge" }` to `loadFileAsBlob(...)` or `loadFileAsStream(...)`.
+- **TypeScript:** pass `tier` to `createFileFromBlob(...)` / `createFileFromStream(...)`, or query options like `{ tier: "edge" }` to `loadFileAsBlob(...)` / `loadFileAsStream(...)`.
+- **Rust:** pass `Some(DurabilityTier::EdgeServer)` or `Some(DurabilityTier::GlobalServer)` to `client.query(...)`.
 
-If the requested tier does not have the full file yet, `loadFileAsBlob(...)` fails the whole
-read and `loadFileAsStream(...)` errors when it reaches the missing part. Use `edge` or `global`
-when you need the read to wait for a more complete remote snapshot than local OPFS currently has.
+If the requested tier does not have the full file yet, the load fails when it reaches the missing
+part. Use `edge` or `global` when you need the read to wait for a more complete remote snapshot
+than the local store currently has.
 
 ## No automatic cascade yet
 
 Until file cascade delete lands, delete the chunk rows and the `files` row before deleting your
 parent app row so the [inherited delete policies](/docs/auth/permissions#inherited-access-allowedto) still match:
 
-<include cwd lang="ts" meta='title="src/files-and-blobs-snippets.ts"'>
-  ../examples/docs/todo-client-localfirst-ts/src/files-and-blobs-snippets.ts#files-delete-ts
-</include>
+<Tabs groupId="jazz-environment" items={["TypeScript", "Rust"]} persist updateAnchor>
+  <Tab value="TypeScript">
+    <include cwd lang="ts">
+      ../examples/docs/todo-client-localfirst-ts/src/files-and-blobs-snippets.ts#files-delete-ts
+    </include>
+  </Tab>
+  <Tab value="Rust">
+    <include cwd lang="rs">
+      ../examples/docs/todo-server-rs/src/docs_snippets.rs#files-delete-rust
+    </include>
+  </Tab>
+</Tabs>
 
 ## Example app
 

--- a/examples/docs/todo-server-rs/src/docs_snippets.rs
+++ b/examples/docs/todo-server-rs/src/docs_snippets.rs
@@ -528,10 +528,10 @@ pub async fn load_file_bytes(
                 Some(DurabilityTier::EdgeServer),
             )
             .await?;
-        if let Some((_, row)) = parts.first() {
-            if let Value::Bytea(chunk) = &row[0] {
-                data.extend_from_slice(chunk);
-            }
+        if let Some((_, row)) = parts.first()
+            && let Value::Bytea(chunk) = &row[0]
+        {
+            data.extend_from_slice(chunk);
         }
     }
 

--- a/examples/docs/todo-server-rs/src/docs_snippets.rs
+++ b/examples/docs/todo-server-rs/src/docs_snippets.rs
@@ -414,3 +414,176 @@ pub async fn clear_nullable_fields(
     Ok(())
 }
 // #endregion writing-nullable-update-rust
+
+const CHUNK_SIZE: usize = 64 * 1024;
+
+// #region files-create-from-bytes-rust
+pub async fn create_file_from_bytes(
+    client: &JazzClient,
+    data: &[u8],
+    name: Option<&str>,
+    mime_type: &str,
+) -> jazz_tools::Result<ObjectId> {
+    let mut part_ids = Vec::new();
+    let mut part_sizes = Vec::new();
+
+    for chunk in data.chunks(CHUNK_SIZE) {
+        let (part_id, _) = client
+            .create(
+                "file_parts",
+                HashMap::from([("data".to_string(), Value::Bytea(chunk.to_vec()))]),
+            )
+            .await?;
+        part_ids.push(Value::Uuid(part_id));
+        part_sizes.push(Value::Integer(chunk.len() as i32));
+    }
+
+    let mut file_values = HashMap::from([
+        ("mimeType".to_string(), Value::Text(mime_type.into())),
+        ("partIds".to_string(), Value::Array(part_ids)),
+        ("partSizes".to_string(), Value::Array(part_sizes)),
+    ]);
+    if let Some(name) = name {
+        file_values.insert("name".to_string(), Value::Text(name.into()));
+    }
+
+    let (file_id, _) = client.create("files", file_values).await?;
+    Ok(file_id)
+}
+// #endregion files-create-from-bytes-rust
+
+// #region files-create-upload-rust
+pub async fn create_upload_from_bytes(
+    client: &JazzClient,
+    data: &[u8],
+    owner_id: &str,
+) -> jazz_tools::Result<ObjectId> {
+    let file_id = create_file_from_bytes(client, data, Some("photo.jpg"), "image/jpeg").await?;
+
+    let (upload_id, _) = client
+        .create(
+            "uploads",
+            HashMap::from([
+                ("owner_id".to_string(), Value::Text(owner_id.into())),
+                ("label".to_string(), Value::Text("Profile photo".into())),
+                ("fileId".to_string(), Value::Uuid(file_id)),
+            ]),
+        )
+        .await?;
+
+    Ok(upload_id)
+}
+// #endregion files-create-upload-rust
+
+// #region files-load-rust
+pub async fn load_file_bytes(
+    client: &JazzClient,
+    upload_id: ObjectId,
+) -> jazz_tools::Result<Option<Vec<u8>>> {
+    let uploads = client
+        .query(
+            QueryBuilder::new("uploads")
+                .select(&["fileId"])
+                .filter_eq("_id", Value::Uuid(upload_id))
+                .build(),
+            Some(DurabilityTier::EdgeServer),
+        )
+        .await?;
+
+    let Some((_, row)) = uploads.first() else {
+        return Ok(None);
+    };
+    let Value::Uuid(file_id) = &row[0] else {
+        return Ok(None);
+    };
+
+    let files = client
+        .query(
+            QueryBuilder::new("files")
+                .select(&["partIds"])
+                .filter_eq("_id", Value::Uuid(*file_id))
+                .build(),
+            Some(DurabilityTier::EdgeServer),
+        )
+        .await?;
+
+    let Some((_, row)) = files.first() else {
+        return Ok(None);
+    };
+    let Value::Array(part_ids) = &row[0] else {
+        return Ok(None);
+    };
+
+    let mut data = Vec::new();
+    for part_ref in part_ids {
+        let Value::Uuid(part_id) = part_ref else {
+            continue;
+        };
+        let parts = client
+            .query(
+                QueryBuilder::new("file_parts")
+                    .select(&["data"])
+                    .filter_eq("_id", Value::Uuid(*part_id))
+                    .build(),
+                Some(DurabilityTier::EdgeServer),
+            )
+            .await?;
+        if let Some((_, row)) = parts.first() {
+            if let Value::Bytea(chunk) = &row[0] {
+                data.extend_from_slice(chunk);
+            }
+        }
+    }
+
+    Ok(Some(data))
+}
+// #endregion files-load-rust
+
+// #region files-delete-rust
+pub async fn delete_upload_with_file(
+    client: &JazzClient,
+    upload_id: ObjectId,
+) -> jazz_tools::Result<()> {
+    let uploads = client
+        .query(
+            QueryBuilder::new("uploads")
+                .select(&["fileId"])
+                .filter_eq("_id", Value::Uuid(upload_id))
+                .build(),
+            Some(DurabilityTier::EdgeServer),
+        )
+        .await?;
+
+    let Some((_, row)) = uploads.first() else {
+        return Ok(());
+    };
+    let Value::Uuid(file_id) = &row[0] else {
+        return Ok(());
+    };
+
+    let files = client
+        .query(
+            QueryBuilder::new("files")
+                .select(&["partIds"])
+                .filter_eq("_id", Value::Uuid(*file_id))
+                .build(),
+            Some(DurabilityTier::EdgeServer),
+        )
+        .await?;
+
+    if let Some((file_row_id, row)) = files.first() {
+        if let Value::Array(part_ids) = &row[0] {
+            // Delete chunks while the parent file row still exists.
+            for part_ref in part_ids {
+                if let Value::Uuid(part_id) = part_ref {
+                    client.delete(*part_id).await?;
+                }
+            }
+        }
+        client.delete(*file_row_id).await?;
+    }
+
+    client.delete(upload_id).await?;
+    Ok(())
+}
+// #endregion files-delete-rust


### PR DESCRIPTION
## Summary

- Add Rust tabs (create, load, delete) to the files-and-blobs docs page, matching the TS/Rust tab pattern used across the rest of the docs
- Schema and permissions sections remain TS-only (DSL-specific)
- Stream sections include prose guidance since Rust uses the same byte-level chunking approach

## Test plan

- [ ] Verify the docs site renders correctly at `/docs/writing/files-and-blobs`
- [ ] Confirm Rust tabs display code snippets and TS tabs are unchanged
- [ ] Check that prose-only Rust tabs (stream sections) render cleanly
- [ ] Verify all `#region` anchors resolve to the correct code