### PR TITLE
Add From impls on Value and row_input! macro

### DIFF
--- a/.changeset/row-input-macro.md
+++ b/.changeset/row-input-macro.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Add `From<T>` impls on `Value` for common types and a `row_input!` macro for ergonomic `HashMap<String, Value>` construction.

--- a/crates/jazz-tools/src/query_manager/types/value.rs
+++ b/crates/jazz-tools/src/query_manager/types/value.rs
@@ -331,6 +331,92 @@ impl Value {
     }
 }
 
+// ── From impls for ergonomic Value construction ─────────────────────
+// Note: no `From<u64>` for `Timestamp` — a bare u64 is ambiguous (could be a
+// large integer or a millisecond timestamp). Use `Value::Timestamp(ts)` explicitly.
+
+impl From<bool> for Value {
+    fn from(v: bool) -> Self {
+        Value::Boolean(v)
+    }
+}
+
+impl From<i32> for Value {
+    fn from(v: i32) -> Self {
+        Value::Integer(v)
+    }
+}
+
+impl From<i64> for Value {
+    fn from(v: i64) -> Self {
+        Value::BigInt(v)
+    }
+}
+
+impl From<f64> for Value {
+    fn from(v: f64) -> Self {
+        Value::Double(v)
+    }
+}
+
+impl From<&str> for Value {
+    fn from(v: &str) -> Self {
+        Value::Text(v.to_string())
+    }
+}
+
+impl From<String> for Value {
+    fn from(v: String) -> Self {
+        Value::Text(v)
+    }
+}
+
+impl From<ObjectId> for Value {
+    fn from(v: ObjectId) -> Self {
+        Value::Uuid(v)
+    }
+}
+
+/// Produces `Bytea`, not `Array` of integers. Use `Value::Array(...)` explicitly
+/// if you need an integer array.
+impl From<Vec<u8>> for Value {
+    fn from(v: Vec<u8>) -> Self {
+        Value::Bytea(v)
+    }
+}
+
+impl From<Vec<Value>> for Value {
+    fn from(v: Vec<Value>) -> Self {
+        Value::Array(v)
+    }
+}
+
+impl<T: Into<Value>> From<Option<T>> for Value {
+    fn from(v: Option<T>) -> Self {
+        match v {
+            Some(inner) => inner.into(),
+            None => Value::Null,
+        }
+    }
+}
+
+/// Build a `HashMap<String, Value>` from key-value pairs with heterogeneous types.
+///
+/// Each value can be any type that implements `Into<Value>`.
+///
+/// ```ignore
+/// row_input!("name" => "Alice", "age" => 30i32)
+/// ```
+#[macro_export]
+macro_rules! row_input {
+    ($( $col:expr => $val:expr ),* $(,)?) => {{
+        #[allow(unused_mut)]
+        let mut map = std::collections::HashMap::<String, $crate::query_manager::types::Value>::new();
+        $( map.insert($col.to_string(), <_ as Into<$crate::query_manager::types::Value>>::into($val)); )*
+        map
+    }};
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -443,11 +529,11 @@ mod tests {
         assert_eq!(v, Value::Text("hey".to_string()));
     }
 
-    // ── row_input ───────────────────────────────────────────────────
+    // ── row_input! ──────────────────────────────────────────────────
 
     #[test]
     fn row_input_builds_hashmap() {
-        let map = row_input([("name", "Alice"), ("age", 30i32)]);
+        let map = row_input!("name" => "Alice", "age" => 30i32);
 
         let mut expected = HashMap::new();
         expected.insert("name".to_string(), Value::Text("Alice".to_string()));
@@ -458,13 +544,16 @@ mod tests {
 
     #[test]
     fn row_input_empty() {
-        let map: HashMap<String, Value> = row_input([]);
+        let map: HashMap<String, Value> = row_input!();
         assert!(map.is_empty());
     }
 
     #[test]
     fn row_input_with_option_null() {
-        let map = row_input([("present", Some("yes")), ("absent", None)]);
+        let map = row_input!(
+            "present" => Some("yes"),
+            "absent" => Option::<&str>::None,
+        );
 
         assert_eq!(map["present"], Value::Text("yes".to_string()));
         assert_eq!(map["absent"], Value::Null);

--- a/crates/jazz-tools/src/query_manager/types/value.rs
+++ b/crates/jazz-tools/src/query_manager/types/value.rs
@@ -330,3 +330,143 @@ impl Value {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    // ── From<bool> ──────────────────────────────────────────────────
+
+    #[test]
+    fn from_bool_true() {
+        let v: Value = true.into();
+        assert_eq!(v, Value::Boolean(true));
+    }
+
+    #[test]
+    fn from_bool_false() {
+        let v: Value = false.into();
+        assert_eq!(v, Value::Boolean(false));
+    }
+
+    // ── From<i32> ───────────────────────────────────────────────────
+
+    #[test]
+    fn from_i32() {
+        let v: Value = 42i32.into();
+        assert_eq!(v, Value::Integer(42));
+    }
+
+    #[test]
+    fn from_i32_negative() {
+        let v: Value = (-1i32).into();
+        assert_eq!(v, Value::Integer(-1));
+    }
+
+    // ── From<i64> ───────────────────────────────────────────────────
+
+    #[test]
+    fn from_i64() {
+        let v: Value = 1_000_000_000_000i64.into();
+        assert_eq!(v, Value::BigInt(1_000_000_000_000));
+    }
+
+    // ── From<f64> ───────────────────────────────────────────────────
+
+    #[test]
+    fn from_f64() {
+        let v: Value = 3.14f64.into();
+        assert_eq!(v, Value::Double(3.14));
+    }
+
+    // ── From<&str> ──────────────────────────────────────────────────
+
+    #[test]
+    fn from_str_ref() {
+        let v: Value = "hello".into();
+        assert_eq!(v, Value::Text("hello".to_string()));
+    }
+
+    // ── From<String> ────────────────────────────────────────────────
+
+    #[test]
+    fn from_string() {
+        let v: Value = String::from("world").into();
+        assert_eq!(v, Value::Text("world".to_string()));
+    }
+
+    // ── From<ObjectId> ──────────────────────────────────────────────
+
+    #[test]
+    fn from_object_id() {
+        let oid = ObjectId::new();
+        let v: Value = oid.into();
+        assert_eq!(v, Value::Uuid(oid));
+    }
+
+    // ── From<Vec<u8>> ───────────────────────────────────────────────
+
+    #[test]
+    fn from_vec_u8() {
+        let bytes = vec![0xDE, 0xAD, 0xBE, 0xEF];
+        let v: Value = bytes.clone().into();
+        assert_eq!(v, Value::Bytea(bytes));
+    }
+
+    // ── From<Vec<Value>> ────────────────────────────────────────────
+
+    #[test]
+    fn from_vec_value() {
+        let arr = vec![Value::Integer(1), Value::Integer(2)];
+        let v: Value = arr.clone().into();
+        assert_eq!(v, Value::Array(arr));
+    }
+
+    // ── From<Option<T>> ─────────────────────────────────────────────
+
+    #[test]
+    fn from_option_some() {
+        let v: Value = Some(42i32).into();
+        assert_eq!(v, Value::Integer(42));
+    }
+
+    #[test]
+    fn from_option_none() {
+        let v: Value = Option::<i32>::None.into();
+        assert_eq!(v, Value::Null);
+    }
+
+    #[test]
+    fn from_option_some_string() {
+        let v: Value = Some("hey".to_string()).into();
+        assert_eq!(v, Value::Text("hey".to_string()));
+    }
+
+    // ── row_input ───────────────────────────────────────────────────
+
+    #[test]
+    fn row_input_builds_hashmap() {
+        let map = row_input([("name", "Alice"), ("age", 30i32)]);
+
+        let mut expected = HashMap::new();
+        expected.insert("name".to_string(), Value::Text("Alice".to_string()));
+        expected.insert("age".to_string(), Value::Integer(30));
+
+        assert_eq!(map, expected);
+    }
+
+    #[test]
+    fn row_input_empty() {
+        let map: HashMap<String, Value> = row_input([]);
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn row_input_with_option_null() {
+        let map = row_input([("present", Some("yes")), ("absent", None)]);
+
+        assert_eq!(map["present"], Value::Text("yes".to_string()));
+        assert_eq!(map["absent"], Value::Null);
+    }
+}

--- a/crates/jazz-tools/tests/policies_integration/authorship_policies.rs
+++ b/crates/jazz-tools/tests/policies_integration/authorship_policies.rs
@@ -6,6 +6,7 @@ use jazz_tools::jazz_transport::{SyncBatchRequest, SyncBatchResponse};
 use jazz_tools::query_manager::policy::PolicyExpr;
 use jazz_tools::query_manager::session::{Session, WriteContext};
 use jazz_tools::query_manager::types::{TablePolicies, TableSchemaBuilder};
+use jazz_tools::row_input;
 use jazz_tools::runtime_core::{NoopScheduler, RuntimeCore, VecSyncSender};
 use jazz_tools::schema_manager::SchemaManager;
 use jazz_tools::server::TestingServer;
@@ -24,15 +25,11 @@ fn make_notes_schema(table_name: &str, policies: TablePolicies) -> TableSchemaBu
 }
 
 fn note_input(title: &str) -> HashMap<String, Value> {
-    HashMap::from([("title".to_string(), Value::Text(title.to_string()))])
+    row_input!("title" => title)
 }
 
 fn provenance_values(title: &str, created_by: &str, updated_by: &str) -> Vec<Value> {
-    vec![
-        Value::Text(title.to_string()),
-        Value::Text(created_by.to_string()),
-        Value::Text(updated_by.to_string()),
-    ]
+    vec![title.into(), created_by.into(), updated_by.into()]
 }
 
 async fn create_note_as(client: &JazzClient, user_id: &str, title: &str) -> ObjectId {
@@ -197,10 +194,7 @@ async fn created_by_policies_scope_crud_to_creators() {
 
     let denied_update = bob
         .for_session(Session::new("bob"))
-        .update(
-            alice_note,
-            vec![("title".to_string(), Value::Text("bob edit".into()))],
-        )
+        .update(alice_note, vec![("title".to_string(), "bob edit".into())])
         .await;
     assert!(
         denied_update.is_err(),
@@ -292,10 +286,7 @@ async fn created_by_policies_hide_server_generated_rows_without_attribution() {
     .await;
     assert_eq!(
         alice_rows[0].1,
-        vec![
-            Value::Text("alice note".into()),
-            Value::Text("alice".into())
-        ]
+        vec![Value::from("alice note"), "alice".into()]
     );
     assert!(
         alice_rows.iter().all(|(id, _)| *id != system_note),
@@ -334,8 +325,7 @@ async fn created_by_policies_hide_server_generated_rows_without_attribution() {
 #[tokio::test]
 async fn created_by_policies_can_allow_reads_from_system_author() {
     let created_by_policy = PolicyExpr::eq_session("$createdBy", vec!["user_id".into()]);
-    let system_author_policy =
-        PolicyExpr::eq_literal("$createdBy", Value::Text("jazz:system".into()));
+    let system_author_policy = PolicyExpr::eq_literal("$createdBy", "jazz:system".into());
     let schema = SchemaBuilder::new()
         .table(make_notes_schema(
             "notes",
@@ -377,10 +367,7 @@ async fn created_by_policies_can_allow_reads_from_system_author() {
         .expect("alice-owned row should be visible");
     assert_eq!(
         alice_owned.1,
-        vec![
-            Value::Text("alice note".into()),
-            Value::Text("alice".into())
-        ]
+        vec![Value::from("alice note"), "alice".into()]
     );
     let system_owned = alice_rows
         .iter()
@@ -388,10 +375,7 @@ async fn created_by_policies_can_allow_reads_from_system_author() {
         .expect("system-authored row should be visible");
     assert_eq!(
         system_owned.1,
-        vec![
-            Value::Text("server-generated".into()),
-            Value::Text("jazz:system".into())
-        ]
+        vec![Value::from("server-generated"), "jazz:system".into()]
     );
 
     let bob_rows = wait_for_rows(
@@ -403,10 +387,7 @@ async fn created_by_policies_can_allow_reads_from_system_author() {
     .await;
     assert_eq!(
         bob_rows[0].1,
-        vec![
-            Value::Text("server-generated".into()),
-            Value::Text("jazz:system".into())
-        ]
+        vec![Value::from("server-generated"), "jazz:system".into()]
     );
 
     backend.shutdown().await.expect("shutdown backend");
@@ -488,7 +469,7 @@ async fn created_by_policies_allow_backend_attribution_to_specific_user() {
 #[tokio::test]
 async fn updated_by_select_policy_moves_visibility_to_last_editor() {
     let updated_by_policy = PolicyExpr::eq_session("$updatedBy", vec!["user_id".into()]);
-    let shared_policy = PolicyExpr::eq_literal("shared", Value::Boolean(true));
+    let shared_policy = PolicyExpr::eq_literal("shared", true.into());
     let schema = SchemaBuilder::new()
         .table(
             TableSchema::builder("notes")
@@ -517,13 +498,7 @@ async fn updated_by_select_policy_moves_visibility_to_last_editor() {
     // `$updatedBy` handoff on the later update.
     let note_id = alice
         .for_session(Session::new("alice"))
-        .create(
-            "notes",
-            HashMap::from([
-                ("title".to_string(), Value::Text("draft".to_string())),
-                ("shared".to_string(), Value::Boolean(true)),
-            ]),
-        )
+        .create("notes", row_input!("title" => "draft", "shared" => true))
         .await
         .expect("alice creates shared draft")
         .0;
@@ -535,10 +510,10 @@ async fn updated_by_select_policy_moves_visibility_to_last_editor() {
         |rows| (rows.len() == 1 && rows[0].0 == note_id).then_some(rows),
     )
     .await;
-    assert_eq!(initial_rows[0].1[0], Value::Text("draft".into()));
-    assert_eq!(initial_rows[0].1[1], Value::Boolean(true));
-    assert_eq!(initial_rows[0].1[2], Value::Text("alice".into()));
-    assert_eq!(initial_rows[0].1[3], Value::Text("alice".into()));
+    assert_eq!(initial_rows[0].1[0], Value::from("draft"));
+    assert_eq!(initial_rows[0].1[1], Value::from(true));
+    assert_eq!(initial_rows[0].1[2], Value::from("alice"));
+    assert_eq!(initial_rows[0].1[3], Value::from("alice"));
     let Value::Timestamp(initial_created_at) = initial_rows[0].1[4] else {
         panic!("$createdAt should decode as timestamp")
     };
@@ -553,17 +528,17 @@ async fn updated_by_select_policy_moves_visibility_to_last_editor() {
         |rows| (rows.len() == 1 && rows[0].0 == note_id).then_some(rows),
     )
     .await;
-    assert_eq!(bob_rows[0].1[0], Value::Text("draft".into()));
-    assert_eq!(bob_rows[0].1[1], Value::Boolean(true));
-    assert_eq!(bob_rows[0].1[2], Value::Text("alice".into()));
-    assert_eq!(bob_rows[0].1[3], Value::Text("alice".into()));
+    assert_eq!(bob_rows[0].1[0], Value::from("draft"));
+    assert_eq!(bob_rows[0].1[1], Value::from(true));
+    assert_eq!(bob_rows[0].1[2], Value::from("alice"));
+    assert_eq!(bob_rows[0].1[3], Value::from("alice"));
 
     bob.for_session(Session::new("bob"))
         .update(
             note_id,
             vec![
-                ("title".to_string(), Value::Text("revised by bob".into())),
-                ("shared".to_string(), Value::Boolean(false)),
+                ("title".to_string(), "revised by bob".into()),
+                ("shared".to_string(), false.into()),
             ],
         )
         .await
@@ -585,10 +560,10 @@ async fn updated_by_select_policy_moves_visibility_to_last_editor() {
         |rows| (rows.len() == 1 && rows[0].0 == note_id).then_some(rows),
     )
     .await;
-    assert_eq!(bob_rows[0].1[0], Value::Text("revised by bob".into()));
-    assert_eq!(bob_rows[0].1[1], Value::Boolean(false));
-    assert_eq!(bob_rows[0].1[2], Value::Text("alice".into()));
-    assert_eq!(bob_rows[0].1[3], Value::Text("bob".into()));
+    assert_eq!(bob_rows[0].1[0], Value::from("revised by bob"));
+    assert_eq!(bob_rows[0].1[1], Value::from(false));
+    assert_eq!(bob_rows[0].1[2], Value::from("alice"));
+    assert_eq!(bob_rows[0].1[3], Value::from("bob"));
     let Value::Timestamp(updated_created_at) = bob_rows[0].1[4] else {
         panic!("updated $createdAt should decode as timestamp")
     };
@@ -652,9 +627,9 @@ async fn provenance_magic_columns_expose_user_principals_and_insert_timestamps()
         .iter()
         .find(|(id, _)| *id == alice_note)
         .expect("alice-authored row should be present");
-    assert_eq!(alice_row.1[0], Value::Text("alice note".into()));
-    assert_eq!(alice_row.1[1], Value::Text("alice".into()));
-    assert_eq!(alice_row.1[2], Value::Text("alice".into()));
+    assert_eq!(alice_row.1[0], Value::from("alice note"));
+    assert_eq!(alice_row.1[1], Value::from("alice"));
+    assert_eq!(alice_row.1[2], Value::from("alice"));
     let Value::Timestamp(alice_created_at) = alice_row.1[3] else {
         panic!("alice $createdAt should decode as timestamp")
     };
@@ -667,9 +642,9 @@ async fn provenance_magic_columns_expose_user_principals_and_insert_timestamps()
         .iter()
         .find(|(id, _)| *id == bob_note)
         .expect("bob-authored row should be present");
-    assert_eq!(bob_row.1[0], Value::Text("bob note".into()));
-    assert_eq!(bob_row.1[1], Value::Text("bob".into()));
-    assert_eq!(bob_row.1[2], Value::Text("bob".into()));
+    assert_eq!(bob_row.1[0], Value::from("bob note"));
+    assert_eq!(bob_row.1[1], Value::from("bob"));
+    assert_eq!(bob_row.1[2], Value::from("bob"));
     let Value::Timestamp(bob_created_at) = bob_row.1[3] else {
         panic!("bob $createdAt should decode as timestamp")
     };

--- a/crates/jazz-tools/tests/policies_integration/claims_policies.rs
+++ b/crates/jazz-tools/tests/policies_integration/claims_policies.rs
@@ -45,47 +45,27 @@ fn make_claim_compound_schema(table_name: &str, policies: TablePolicies) -> Tabl
 // -- Value constructors --
 
 fn title_document_values(title: &str) -> Vec<Value> {
-    vec![Value::Text(title.to_string())]
+    vec![title.into()]
 }
 
 fn title_document_input(title: &str) -> HashMap<String, Value> {
-    HashMap::from([("title".to_string(), Value::Text(title.to_string()))])
+    row_input!("title" => title.to_string())
 }
 
 fn group_document_values(group_slug: &str, title: &str) -> Vec<Value> {
-    vec![
-        Value::Text(group_slug.to_string()),
-        Value::Text(title.to_string()),
-    ]
+    vec![group_slug.into(), title.into()]
 }
 
 fn group_document_input(group_slug: &str, title: &str) -> HashMap<String, Value> {
-    HashMap::from([
-        (
-            "group_slug".to_string(),
-            Value::Text(group_slug.to_string()),
-        ),
-        ("title".to_string(), Value::Text(title.to_string())),
-    ])
+    row_input!("group_slug" => group_slug.to_string(), "title" => title.to_string())
 }
 
 fn claim_compound_values(group_slug: &str, published: bool, title: &str) -> Vec<Value> {
-    vec![
-        Value::Text(group_slug.to_string()),
-        Value::Boolean(published),
-        Value::Text(title.to_string()),
-    ]
+    vec![group_slug.into(), published.into(), title.into()]
 }
 
 fn claim_compound_input(group_slug: &str, published: bool, title: &str) -> HashMap<String, Value> {
-    HashMap::from([
-        (
-            "group_slug".to_string(),
-            Value::Text(group_slug.to_string()),
-        ),
-        ("published".to_string(), Value::Boolean(published)),
-        ("title".to_string(), Value::Text(title.to_string())),
-    ])
+    row_input!("group_slug" => group_slug.to_string(), "published" => published, "title" => title.to_string())
 }
 
 // -- Seed helpers --
@@ -214,10 +194,7 @@ async fn admin_role_claims_allow_admin_mutations_and_member_reads() {
     admin
         .update(
             admin_doc,
-            vec![(
-                "title".to_string(),
-                Value::Text("admin updated".to_string()),
-            )],
+            vec![("title".to_string(), "admin updated".into())],
         )
         .await
         .expect("admin update");
@@ -392,10 +369,7 @@ async fn admin_role_claims_reject_member_mutations() {
     member
         .update(
             admin_doc,
-            vec![(
-                "title".to_string(),
-                Value::Text("member hacked".to_string()),
-            )],
+            vec![("title".to_string(), "member hacked".into())],
         )
         .await
         .expect("optimistic local member update");

--- a/crates/jazz-tools/tests/policies_integration/complex_policies.rs
+++ b/crates/jazz-tools/tests/policies_integration/complex_policies.rs
@@ -32,7 +32,7 @@ fn row_changes<const N: usize>(pairs: [(&str, Value); N]) -> Vec<(String, Value)
 }
 
 fn title_document_values(title: &str) -> Vec<Value> {
-    vec![Value::Text(title.to_string())]
+    vec![title.into()]
 }
 
 fn complex_document_values(
@@ -42,9 +42,9 @@ fn complex_document_values(
     folder_id: Option<ObjectId>,
 ) -> Vec<Value> {
     vec![
-        Value::Text(team_slug.to_string()),
-        Value::Boolean(published),
-        Value::Text(title.to_string()),
+        team_slug.into(),
+        published.into(),
+        title.into(),
         folder_id.into(),
     ]
 }
@@ -175,7 +175,7 @@ fn hop_membership_select_policy() -> PolicyExpr {
 
 fn mixed_complex_select_policy() -> PolicyExpr {
     PolicyExpr::and(vec![
-        PolicyExpr::eq_literal("published", Value::Boolean(true)),
+        PolicyExpr::eq_literal("published", true.into()),
         PolicyExpr::in_session("team_slug", vec!["claims".into(), "team_slugs".into()]),
         PolicyExpr::Exists {
             table: "document_flags".into(),
@@ -185,7 +185,7 @@ fn mixed_complex_select_policy() -> PolicyExpr {
                     op: CmpOp::Eq,
                     value: outer_row_id_ref(),
                 },
-                PolicyExpr::eq_literal("flag", Value::Text("allow".to_string())),
+                PolicyExpr::eq_literal("flag", "allow".into()),
             ])),
         },
         PolicyExpr::and(vec![
@@ -406,10 +406,7 @@ async fn exists_outer_row_refs_grant_deny_and_track_related_row_mutations() {
     assert_eq!(bob_rows.len(), 1);
 
     admin
-        .update(
-            share_id,
-            row_changes([("user_id", Value::Text("dave".to_string()))]),
-        )
+        .update(share_id, row_changes([("user_id", "dave".into())]))
         .await
         .expect("update document share user");
     wait_for_subscription_update(
@@ -789,12 +786,9 @@ async fn rejected_optimistic_exists_updates_reconcile_to_server_authoritative_st
     )
     .await;
 
-    bob.update(
-        doc_id,
-        row_changes([("title", Value::Text("Hacked".to_string()))]),
-    )
-    .await
-    .expect("optimistic local exists update");
+    bob.update(doc_id, row_changes([("title", "Hacked".into())]))
+        .await
+        .expect("optimistic local exists update");
 
     let rows_after_update = observer
         .query(query.clone(), Some(DurabilityTier::EdgeServer))

--- a/crates/jazz-tools/tests/policies_integration/complex_policies.rs
+++ b/crates/jazz-tools/tests/policies_integration/complex_policies.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::time::Duration;
 
 use super::support::{
@@ -25,13 +24,6 @@ const READY_TIMEOUT: Duration = Duration::from_secs(30);
 const QUERY_TIMEOUT: Duration = Duration::from_secs(25);
 const NO_DELTA_WINDOW: Duration = Duration::from_millis(100);
 
-fn row_input<const N: usize>(pairs: [(&str, Value); N]) -> HashMap<String, Value> {
-    pairs
-        .into_iter()
-        .map(|(column, value)| (column.to_string(), value))
-        .collect()
-}
-
 fn row_changes<const N: usize>(pairs: [(&str, Value); N]) -> Vec<(String, Value)> {
     pairs
         .into_iter()
@@ -53,7 +45,7 @@ fn complex_document_values(
         Value::Text(team_slug.to_string()),
         Value::Boolean(published),
         Value::Text(title.to_string()),
-        folder_id.map(Value::Uuid).unwrap_or(Value::Null),
+        folder_id.into(),
     ]
 }
 
@@ -305,10 +297,7 @@ fn exists_update_policy_schema() -> Schema {
 
 async fn create_title_document(client: &JazzClient, title: &str) -> ObjectId {
     client
-        .create(
-            "documents",
-            row_input([("title", Value::Text(title.to_string()))]),
-        )
+        .create("documents", row_input!("title" => title.to_string()))
         .await
         .expect("create title document")
         .0
@@ -318,10 +307,7 @@ async fn create_document_grant(client: &JazzClient, document_id: ObjectId, group
     client
         .create(
             "document_grants",
-            row_input([
-                ("document_id", Value::Uuid(document_id)),
-                ("group_slug", Value::Text(group_slug.to_string())),
-            ]),
+            row_input!("document_id" => document_id, "group_slug" => group_slug.to_string()),
         )
         .await
         .expect("create document grant");
@@ -331,10 +317,7 @@ async fn create_group_membership(client: &JazzClient, user_id: &str, group_slug:
     client
         .create(
             "group_memberships",
-            row_input([
-                ("user_id", Value::Text(user_id.to_string())),
-                ("group_slug", Value::Text(group_slug.to_string())),
-            ]),
+            row_input!("user_id" => user_id.to_string(), "group_slug" => group_slug.to_string()),
         )
         .await
         .expect("create group membership");
@@ -400,10 +383,7 @@ async fn exists_outer_row_refs_grant_deny_and_track_related_row_mutations() {
     let share_id = admin
         .create(
             "document_shares",
-            row_input([
-                ("document_id", Value::Uuid(doc_id)),
-                ("user_id", Value::Text("bob".to_string())),
-            ]),
+            row_input!("document_id" => doc_id, "user_id" => "bob"),
         )
         .await
         .expect("create document share")
@@ -614,10 +594,7 @@ async fn mixed_predicates_claims_exists_and_inherits_fail_closed() {
         client
             .create(
                 "folders",
-                row_input([
-                    ("owner_id", Value::Text(owner_id.to_string())),
-                    ("name", Value::Text(name.to_string())),
-                ]),
+                row_input!("owner_id" => owner_id.to_string(), "name" => name.to_string()),
             )
             .await
             .expect("create folder")
@@ -634,15 +611,12 @@ async fn mixed_predicates_claims_exists_and_inherits_fail_closed() {
         client
             .create(
                 "documents",
-                row_input([
-                    ("team_slug", Value::Text(team_slug.to_string())),
-                    ("published", Value::Boolean(published)),
-                    ("title", Value::Text(title.to_string())),
-                    (
-                        "folder_id",
-                        folder_id.map(Value::Uuid).unwrap_or(Value::Null),
-                    ),
-                ]),
+                row_input!(
+                    "team_slug" => team_slug.to_string(),
+                    "published" => published,
+                    "title" => title.to_string(),
+                    "folder_id" => folder_id,
+                ),
             )
             .await
             .expect("create complex document")
@@ -653,10 +627,7 @@ async fn mixed_predicates_claims_exists_and_inherits_fail_closed() {
         client
             .create(
                 "document_flags",
-                row_input([
-                    ("document_id", Value::Uuid(document_id)),
-                    ("flag", Value::Text(flag.to_string())),
-                ]),
+                row_input!("document_id" => document_id, "flag" => flag.to_string()),
             )
             .await
             .expect("create document flag");
@@ -793,10 +764,7 @@ async fn rejected_optimistic_exists_updates_reconcile_to_server_authoritative_st
     admin
         .create(
             "document_editors",
-            row_input([
-                ("document_id", Value::Uuid(doc_id)),
-                ("user_id", Value::Text("alice".to_string())),
-            ]),
+            row_input!("document_id" => doc_id, "user_id" => "alice"),
         )
         .await
         .expect("create document editor");

--- a/crates/jazz-tools/tests/policies_integration/inherited_policies.rs
+++ b/crates/jazz-tools/tests/policies_integration/inherited_policies.rs
@@ -198,7 +198,7 @@ fn folder_document_values(
         Value::Text(owner_id.to_string()),
         Value::Text(title.to_string()),
         Value::Boolean(archived),
-        folder_id.map(Value::Uuid).unwrap_or(Value::Null),
+        folder_id.into(),
     ]
 }
 
@@ -212,10 +212,7 @@ fn folder_document_input(
         ("owner_id".to_string(), Value::Text(owner_id.to_string())),
         ("title".to_string(), Value::Text(title.to_string())),
         ("archived".to_string(), Value::Boolean(archived)),
-        (
-            "folder_id".to_string(),
-            folder_id.map(Value::Uuid).unwrap_or(Value::Null),
-        ),
+        ("folder_id".to_string(), folder_id.into()),
     ])
 }
 
@@ -230,8 +227,8 @@ fn multi_folder_document_values(
         Value::Text(owner_id.to_string()),
         Value::Text(title.to_string()),
         Value::Boolean(archived),
-        primary_folder_id.map(Value::Uuid).unwrap_or(Value::Null),
-        secondary_folder_id.map(Value::Uuid).unwrap_or(Value::Null),
+        primary_folder_id.into(),
+        secondary_folder_id.into(),
     ]
 }
 
@@ -246,13 +243,10 @@ fn multi_folder_document_input(
         ("owner_id".to_string(), Value::Text(owner_id.to_string())),
         ("title".to_string(), Value::Text(title.to_string())),
         ("archived".to_string(), Value::Boolean(archived)),
-        (
-            "primary_folder_id".to_string(),
-            primary_folder_id.map(Value::Uuid).unwrap_or(Value::Null),
-        ),
+        ("primary_folder_id".to_string(), primary_folder_id.into()),
         (
             "secondary_folder_id".to_string(),
-            secondary_folder_id.map(Value::Uuid).unwrap_or(Value::Null),
+            secondary_folder_id.into(),
         ),
     ])
 }
@@ -279,10 +273,7 @@ fn todo_scalar_ref_input(
     HashMap::from([
         ("owner_id".to_string(), Value::Text(owner_id.to_string())),
         ("title".to_string(), Value::Text(title.to_string())),
-        (
-            "image".to_string(),
-            image.map(Value::Uuid).unwrap_or(Value::Null),
-        ),
+        ("image".to_string(), image.into()),
     ])
 }
 

--- a/crates/jazz-tools/tests/policies_integration/inherited_policies.rs
+++ b/crates/jazz-tools/tests/policies_integration/inherited_policies.rs
@@ -173,19 +173,11 @@ fn inherited_non_null_policy_with_depth(
 // -- Value constructors --
 
 fn folder_input(title: &str, owners: &[&str], archived: bool) -> HashMap<String, Value> {
-    HashMap::from([
-        ("title".to_string(), Value::Text(title.to_string())),
-        (
-            "owners".to_string(),
-            Value::Array(
-                owners
-                    .iter()
-                    .map(|owner| Value::Text((*owner).to_string()))
-                    .collect(),
-            ),
-        ),
-        ("archived".to_string(), Value::Boolean(archived)),
-    ])
+    row_input!(
+        "title" => title,
+        "owners" => Value::Array(owners.iter().map(|owner| (*owner).into()).collect()),
+        "archived" => archived
+    )
 }
 
 fn folder_document_values(
@@ -195,9 +187,9 @@ fn folder_document_values(
     folder_id: Option<ObjectId>,
 ) -> Vec<Value> {
     vec![
-        Value::Text(owner_id.to_string()),
-        Value::Text(title.to_string()),
-        Value::Boolean(archived),
+        owner_id.into(),
+        title.into(),
+        archived.into(),
         folder_id.into(),
     ]
 }
@@ -208,12 +200,12 @@ fn folder_document_input(
     archived: bool,
     folder_id: Option<ObjectId>,
 ) -> HashMap<String, Value> {
-    HashMap::from([
-        ("owner_id".to_string(), Value::Text(owner_id.to_string())),
-        ("title".to_string(), Value::Text(title.to_string())),
-        ("archived".to_string(), Value::Boolean(archived)),
-        ("folder_id".to_string(), folder_id.into()),
-    ])
+    row_input!(
+        "owner_id" => owner_id,
+        "title" => title,
+        "archived" => archived,
+        "folder_id" => folder_id
+    )
 }
 
 fn multi_folder_document_values(
@@ -224,9 +216,9 @@ fn multi_folder_document_values(
     secondary_folder_id: Option<ObjectId>,
 ) -> Vec<Value> {
     vec![
-        Value::Text(owner_id.to_string()),
-        Value::Text(title.to_string()),
-        Value::Boolean(archived),
+        owner_id.into(),
+        title.into(),
+        archived.into(),
         primary_folder_id.into(),
         secondary_folder_id.into(),
     ]
@@ -239,30 +231,24 @@ fn multi_folder_document_input(
     primary_folder_id: Option<ObjectId>,
     secondary_folder_id: Option<ObjectId>,
 ) -> HashMap<String, Value> {
-    HashMap::from([
-        ("owner_id".to_string(), Value::Text(owner_id.to_string())),
-        ("title".to_string(), Value::Text(title.to_string())),
-        ("archived".to_string(), Value::Boolean(archived)),
-        ("primary_folder_id".to_string(), primary_folder_id.into()),
-        (
-            "secondary_folder_id".to_string(),
-            secondary_folder_id.into(),
-        ),
-    ])
+    row_input!(
+        "owner_id" => owner_id,
+        "title" => title,
+        "archived" => archived,
+        "primary_folder_id" => primary_folder_id,
+        "secondary_folder_id" => secondary_folder_id
+    )
 }
 
 fn file_input(owner_id: &str, name: &str) -> HashMap<String, Value> {
-    HashMap::from([
-        ("owner_id".to_string(), Value::Text(owner_id.to_string())),
-        ("name".to_string(), Value::Text(name.to_string())),
-    ])
+    row_input!(
+        "owner_id" => owner_id,
+        "name" => name
+    )
 }
 
 fn file_values(owner_id: &str, name: &str) -> Vec<Value> {
-    vec![
-        Value::Text(owner_id.to_string()),
-        Value::Text(name.to_string()),
-    ]
+    vec![owner_id.into(), name.into()]
 }
 
 fn todo_scalar_ref_input(
@@ -270,11 +256,11 @@ fn todo_scalar_ref_input(
     title: &str,
     image: Option<ObjectId>,
 ) -> HashMap<String, Value> {
-    HashMap::from([
-        ("owner_id".to_string(), Value::Text(owner_id.to_string())),
-        ("title".to_string(), Value::Text(title.to_string())),
-        ("image".to_string(), image.into()),
-    ])
+    row_input!(
+        "owner_id" => owner_id,
+        "title" => title,
+        "image" => image
+    )
 }
 
 fn todo_array_ref_input(
@@ -282,14 +268,11 @@ fn todo_array_ref_input(
     title: &str,
     images: &[ObjectId],
 ) -> HashMap<String, Value> {
-    HashMap::from([
-        ("owner_id".to_string(), Value::Text(owner_id.to_string())),
-        ("title".to_string(), Value::Text(title.to_string())),
-        (
-            "images".to_string(),
-            Value::Array(images.iter().copied().map(Value::Uuid).collect()),
-        ),
-    ])
+    row_input!(
+        "owner_id" => owner_id,
+        "title" => title,
+        "images" => Value::Array(images.iter().copied().map(Value::Uuid).collect())
+    )
 }
 
 fn file_row_count(rows: &[(ObjectId, Vec<Value>)], row_id: ObjectId) -> usize {
@@ -1634,10 +1617,7 @@ async fn inherited_folder_update_allows_folder_owner_and_blocks_other_users() {
     update_row(
         &alice,
         doc_id,
-        vec![(
-            "title".to_string(),
-            Value::Text("Edited By Folder Owner".into()),
-        )],
+        vec![("title".to_string(), "Edited By Folder Owner".into())],
     )
     .await;
     let rows_after_alice = wait_for_rows(
@@ -1668,7 +1648,7 @@ async fn inherited_folder_update_allows_folder_owner_and_blocks_other_users() {
     update_row(
         &bob,
         doc_id,
-        vec![("title".to_string(), Value::Text("Edited By Bob".into()))],
+        vec![("title".to_string(), "Edited By Bob".into())],
     )
     .await;
     let rows_after_bob = wait_for_query(
@@ -1998,10 +1978,10 @@ async fn inherited_multi_hop_forward_chain_grants_access_to_leaf_rows() {
     let file_id = admin
         .create(
             "files",
-            HashMap::from([
-                ("title".to_string(), Value::Text("Spec.pdf".into())),
-                ("folder_id".to_string(), Value::Uuid(folder_id)),
-            ]),
+            row_input!(
+                "title" => "Spec.pdf",
+                "folder_id" => Value::Uuid(folder_id)
+            ),
         )
         .await
         .expect("create file")
@@ -2009,10 +1989,10 @@ async fn inherited_multi_hop_forward_chain_grants_access_to_leaf_rows() {
     let part_id = admin
         .create(
             "file_parts",
-            HashMap::from([
-                ("title".to_string(), Value::Text("Page 1".into())),
-                ("file_id".to_string(), Value::Uuid(file_id)),
-            ]),
+            row_input!(
+                "title" => "Page 1",
+                "file_id" => Value::Uuid(file_id)
+            ),
         )
         .await
         .expect("create file part")
@@ -2027,7 +2007,7 @@ async fn inherited_multi_hop_forward_chain_grants_access_to_leaf_rows() {
             has_row(
                 &rows,
                 part_id,
-                &[Value::Text("Page 1".into()), Value::Uuid(file_id)],
+                &["Page 1".into(), Value::Uuid(file_id)],
             )
             .then_some(rows)
         },
@@ -2036,7 +2016,7 @@ async fn inherited_multi_hop_forward_chain_grants_access_to_leaf_rows() {
     assert!(has_row(
         &alice_rows,
         part_id,
-        &[Value::Text("Page 1".into()), Value::Uuid(file_id)],
+        &["Page 1".into(), Value::Uuid(file_id)],
     ));
 
     let dave_rows = wait_for_query(
@@ -2119,10 +2099,7 @@ async fn inherited_parent_policy_change_propagates_to_child_on_active_subscripti
     update_row(
         &admin,
         folder_id,
-        vec![(
-            "owners".to_string(),
-            Value::Array(vec![Value::Text("alice".into())]),
-        )],
+        vec![("owners".to_string(), Value::Array(vec!["alice".into()]))],
     )
     .await;
 

--- a/crates/jazz-tools/tests/policies_integration/main.rs
+++ b/crates/jazz-tools/tests/policies_integration/main.rs
@@ -1,5 +1,8 @@
 #![cfg(feature = "test")]
 
+#[macro_use]
+extern crate jazz_tools;
+
 #[path = "../support/mod.rs"]
 mod support;
 

--- a/crates/jazz-tools/tests/policies_integration/recursive_policies.rs
+++ b/crates/jazz-tools/tests/policies_integration/recursive_policies.rs
@@ -211,7 +211,7 @@ fn recursive_folder_values(owner_id: &str, name: &str, parent_id: Option<ObjectI
     vec![
         Value::Text(owner_id.to_string()),
         Value::Text(name.to_string()),
-        parent_id.map(Value::Uuid).unwrap_or(Value::Null),
+        parent_id.into(),
     ]
 }
 
@@ -223,10 +223,7 @@ fn recursive_folder_input(
     HashMap::from([
         ("owner_id".to_string(), Value::Text(owner_id.to_string())),
         ("name".to_string(), Value::Text(name.to_string())),
-        (
-            "parent_id".to_string(),
-            parent_id.map(Value::Uuid).unwrap_or(Value::Null),
-        ),
+        ("parent_id".to_string(), parent_id.into()),
     ])
 }
 
@@ -259,13 +256,7 @@ async fn update_recursive_folder_parent(
     parent_id: Option<ObjectId>,
 ) {
     client
-        .update(
-            folder_id,
-            vec![(
-                "parent_id".to_string(),
-                parent_id.map(Value::Uuid).unwrap_or(Value::Null),
-            )],
-        )
+        .update(folder_id, vec![("parent_id".to_string(), parent_id.into())])
         .await
         .expect("update recursive folder parent");
 }

--- a/crates/jazz-tools/tests/policies_integration/recursive_policies.rs
+++ b/crates/jazz-tools/tests/policies_integration/recursive_policies.rs
@@ -169,7 +169,7 @@ fn recursive_relation_document_select_policy() -> PolicyExpr {
                 PredicateExpr::Cmp {
                     left: ColumnRef::scoped("resource_access_edges", "grant_role"),
                     op: PredicateCmpOp::Eq,
-                    right: ValueRef::Literal(Value::Text("viewer".to_string())),
+                    right: ValueRef::Literal("viewer".into()),
                 },
             ]),
         },
@@ -208,11 +208,7 @@ fn recursive_relation_policy_schema() -> Schema {
 // -- Value constructors --
 
 fn recursive_folder_values(owner_id: &str, name: &str, parent_id: Option<ObjectId>) -> Vec<Value> {
-    vec![
-        Value::Text(owner_id.to_string()),
-        Value::Text(name.to_string()),
-        parent_id.into(),
-    ]
+    vec![owner_id.into(), name.into(), parent_id.into()]
 }
 
 fn recursive_folder_input(
@@ -220,15 +216,11 @@ fn recursive_folder_input(
     name: &str,
     parent_id: Option<ObjectId>,
 ) -> HashMap<String, Value> {
-    HashMap::from([
-        ("owner_id".to_string(), Value::Text(owner_id.to_string())),
-        ("name".to_string(), Value::Text(name.to_string())),
-        ("parent_id".to_string(), parent_id.into()),
-    ])
+    row_input!("owner_id" => owner_id, "name" => name, "parent_id" => parent_id)
 }
 
 fn title_document_values(title: &str) -> Vec<Value> {
-    vec![Value::Text(title.to_string())]
+    vec![title.into()]
 }
 
 // -- Seed / mutation helpers --
@@ -263,10 +255,7 @@ async fn update_recursive_folder_parent(
 
 async fn create_team(client: &JazzClient, name: &str) -> ObjectId {
     client
-        .create(
-            "teams",
-            HashMap::from([("name".to_string(), Value::Text(name.to_string()))]),
-        )
+        .create("teams", row_input!("name" => name))
         .await
         .expect("create team")
         .0
@@ -276,10 +265,7 @@ async fn create_team_edge(client: &JazzClient, child_team: ObjectId, parent_team
     client
         .create(
             "team_edges",
-            HashMap::from([
-                ("child_team".to_string(), Value::Uuid(child_team)),
-                ("parent_team".to_string(), Value::Uuid(parent_team)),
-            ]),
+            row_input!("child_team" => Value::Uuid(child_team), "parent_team" => Value::Uuid(parent_team)),
         )
         .await
         .expect("create team edge");
@@ -289,10 +275,7 @@ async fn create_team_membership(client: &JazzClient, user_id: &str, team_id: Obj
     client
         .create(
             "team_memberships",
-            HashMap::from([
-                ("user_id".to_string(), Value::Text(user_id.to_string())),
-                ("team_id".to_string(), Value::Uuid(team_id)),
-            ]),
+            row_input!("user_id" => user_id, "team_id" => Value::Uuid(team_id)),
         )
         .await
         .expect("create team membership");
@@ -307,14 +290,7 @@ async fn create_resource_access_edge(
     client
         .create(
             "resource_access_edges",
-            HashMap::from([
-                ("team_id".to_string(), Value::Uuid(team_id)),
-                ("resource_id".to_string(), Value::Uuid(resource_id)),
-                (
-                    "grant_role".to_string(),
-                    Value::Text(grant_role.to_string()),
-                ),
-            ]),
+            row_input!("team_id" => Value::Uuid(team_id), "resource_id" => Value::Uuid(resource_id), "grant_role" => grant_role),
         )
         .await
         .expect("create resource access edge");
@@ -322,10 +298,7 @@ async fn create_resource_access_edge(
 
 async fn create_title_document(client: &JazzClient, title: &str) -> ObjectId {
     client
-        .create(
-            "documents",
-            HashMap::from([("title".to_string(), Value::Text(title.to_string()))]),
-        )
+        .create("documents", row_input!("title" => title))
         .await
         .expect("create title document")
         .0

--- a/crates/jazz-tools/tests/policies_integration/session_cases.rs
+++ b/crates/jazz-tools/tests/policies_integration/session_cases.rs
@@ -104,10 +104,7 @@ fn make_documents_schema(table_name: &str, policies: TablePolicies) -> TableSche
 // -- Value constructors --
 
 fn document_input(owner_id: &str, title: &str) -> HashMap<String, Value> {
-    HashMap::from([
-        ("owner_id".to_string(), Value::Text(owner_id.to_string())),
-        ("title".to_string(), Value::Text(title.to_string())),
-    ])
+    row_input!("owner_id" => owner_id, "title" => title)
 }
 
 fn boolean_policy_document_input(
@@ -115,26 +112,16 @@ fn boolean_policy_document_input(
     title: &str,
     archived: bool,
 ) -> HashMap<String, Value> {
-    HashMap::from([
-        ("owner_id".to_string(), Value::Text(owner_id.to_string())),
-        ("title".to_string(), Value::Text(title.to_string())),
-        ("archived".to_string(), Value::Boolean(archived)),
-    ])
+    row_input!("owner_id" => owner_id, "title" => title, "archived" => archived)
 }
 
 fn team_document_input(team_id: ObjectId, title: &str) -> HashMap<String, Value> {
-    HashMap::from([
-        ("team_id".to_string(), Value::Uuid(team_id)),
-        ("title".to_string(), Value::Text(title.to_string())),
-    ])
+    row_input!("team_id" => Value::Uuid(team_id), "title" => title)
 }
 
 /// Returns row values for the 2-column `documents` table used in write policy tests.
 fn document_values(owner_id: &str, title: &str) -> Vec<Value> {
-    vec![
-        Value::Text(owner_id.to_string()),
-        Value::Text(title.to_string()),
-    ]
+    vec![owner_id.into(), title.into()]
 }
 
 fn document_row_values(owner_id: &str, title: &str) -> Vec<Value> {
@@ -142,15 +129,11 @@ fn document_row_values(owner_id: &str, title: &str) -> Vec<Value> {
 }
 
 fn boolean_policy_document_values(owner_id: &str, title: &str, archived: bool) -> Vec<Value> {
-    vec![
-        Value::Text(owner_id.to_string()),
-        Value::Text(title.to_string()),
-        Value::Boolean(archived),
-    ]
+    vec![owner_id.into(), title.into(), archived.into()]
 }
 
 fn team_document_values(team_id: ObjectId, title: &str) -> Vec<Value> {
-    vec![Value::Uuid(team_id), Value::Text(title.to_string())]
+    vec![Value::Uuid(team_id), title.into()]
 }
 
 fn team_document_row_values(team_id: ObjectId, title: &str) -> Vec<Value> {
@@ -186,10 +169,7 @@ async fn create_document(client: &JazzClient, owner_id: &str, title: &str) -> Ob
 
 async fn create_org(client: &JazzClient, name: &str) -> ObjectId {
     client
-        .create(
-            "orgs",
-            HashMap::from([("name".to_string(), Value::Text(name.to_string()))]),
-        )
+        .create("orgs", row_input!("name" => name))
         .await
         .expect("create org")
         .0
@@ -199,10 +179,7 @@ async fn create_team(client: &JazzClient, name: &str, org_id: ObjectId) -> Objec
     client
         .create(
             "teams",
-            HashMap::from([
-                ("name".to_string(), Value::Text(name.to_string())),
-                ("org_id".to_string(), Value::Uuid(org_id)),
-            ]),
+            row_input!("name" => name, "org_id" => Value::Uuid(org_id)),
         )
         .await
         .expect("create team")
@@ -217,10 +194,7 @@ async fn create_team_membership(
     client
         .create(
             "team_memberships",
-            HashMap::from([
-                ("owner_id".to_string(), Value::Text(owner_id.to_string())),
-                ("team_id".to_string(), Value::Uuid(team_id)),
-            ]),
+            row_input!("owner_id" => owner_id, "team_id" => Value::Uuid(team_id)),
         )
         .await
         .expect("create team membership")
@@ -237,10 +211,7 @@ async fn create_team_document(client: &JazzClient, team_id: ObjectId, title: &st
 
 async fn update_document_title(client: &JazzClient, document_id: ObjectId, title: &str) {
     client
-        .update(
-            document_id,
-            vec![("title".to_string(), Value::Text(title.to_string()))],
-        )
+        .update(document_id, vec![("title".to_string(), title.into())])
         .await
         .expect("update document title");
 }
@@ -620,8 +591,8 @@ async fn session_user_id_policies_scope_crud_to_owned_rows() {
         .update(
             alice_doc,
             vec![
-                ("owner_id".to_string(), Value::Text("bob".to_string())),
-                ("title".to_string(), Value::Text("transferred".to_string())),
+                ("owner_id".to_string(), "bob".into()),
+                ("title".to_string(), "transferred".into()),
             ],
         )
         .await
@@ -711,7 +682,7 @@ async fn session_user_id_policies_scope_crud_to_owned_rows() {
 #[tokio::test]
 async fn ownership_transfer_allowed_only_for_unarchived_documents() {
     let owner_policy = PolicyExpr::eq_session("owner_id", vec!["user_id".into()]);
-    let unarchived_policy = PolicyExpr::eq_literal("archived", Value::Boolean(false));
+    let unarchived_policy = PolicyExpr::eq_literal("archived", false.into());
     let schema = SchemaBuilder::new()
         .table(make_documents_schema(
             "documents",
@@ -767,11 +738,8 @@ async fn ownership_transfer_allowed_only_for_unarchived_documents() {
         .update(
             active_id,
             vec![
-                ("owner_id".to_string(), Value::Text("bob".to_string())),
-                (
-                    "title".to_string(),
-                    Value::Text("active transferred".to_string()),
-                ),
+                ("owner_id".to_string(), "bob".into()),
+                ("title".to_string(), "active transferred".into()),
             ],
         )
         .await
@@ -825,12 +793,9 @@ async fn ownership_transfer_allowed_only_for_unarchived_documents() {
         .update(
             transferable_id,
             vec![
-                ("owner_id".to_string(), Value::Text("bob".to_string())),
-                (
-                    "title".to_string(),
-                    Value::Text("transfer while archiving".to_string()),
-                ),
-                ("archived".to_string(), Value::Boolean(true)),
+                ("owner_id".to_string(), "bob".into()),
+                ("title".to_string(), "transfer while archiving".into()),
+                ("archived".to_string(), true.into()),
             ],
         )
         .await
@@ -860,11 +825,8 @@ async fn ownership_transfer_allowed_only_for_unarchived_documents() {
         .update(
             archived_id,
             vec![
-                ("owner_id".to_string(), Value::Text("bob".to_string())),
-                (
-                    "title".to_string(),
-                    Value::Text("archived transferred".to_string()),
-                ),
+                ("owner_id".to_string(), "bob".into()),
+                ("title".to_string(), "archived transferred".into()),
             ],
         )
         .await
@@ -983,13 +945,13 @@ async fn select_policy_excludes_rows_from_join_results() {
         |rows| (rows.len() == 1 && rows[0].0 == alice_org).then_some(rows),
     )
     .await;
-    assert_eq!(alice_rows[0].1, vec![Value::Text("Alice Org".to_string())]);
+    assert_eq!(alice_rows[0].1, vec![Value::from("Alice Org")]);
 
     let bob_rows = wait_for_rows(&bob, query, "bob visible orgs via membership", |rows| {
         (rows.len() == 1 && rows[0].0 == bob_org).then_some(rows)
     })
     .await;
-    assert_eq!(bob_rows[0].1, vec![Value::Text("Bob Org".to_string())]);
+    assert_eq!(bob_rows[0].1, vec![Value::from("Bob Org")]);
     assert!(
         bob_rows.iter().all(|(id, _)| *id != alice_org),
         "bob should not see org rows reachable only via alice's hidden membership"
@@ -1265,12 +1227,9 @@ async fn update_policies_block_unauthorized_server_mutations() {
     })
     .await;
 
-    bob.update(
-        doc_id,
-        vec![("title".to_string(), Value::Text("hacked".to_string()))],
-    )
-    .await
-    .expect("optimistic local update");
+    bob.update(doc_id, vec![("title".to_string(), "hacked".into())])
+        .await
+        .expect("optimistic local update");
 
     // EdgeServer query is the causal barrier: it blocks until the server has
     // settled, guaranteeing bob's attempted update has been accepted or rejected.
@@ -1472,12 +1431,9 @@ async fn update_policy_read_clause_differs_from_write_clause() {
 
     // Bob's update is applied optimistically on his local client but the
     // with_check policy fails on the server: owner_id="alice" ≠ bob's user_id.
-    bob.update(
-        doc_id,
-        vec![("title".to_string(), Value::Text("hacked".to_string()))],
-    )
-    .await
-    .expect("optimistic local update");
+    bob.update(doc_id, vec![("title".to_string(), "hacked".into())])
+        .await
+        .expect("optimistic local update");
 
     // EdgeServer query is the causal barrier.
     let rows_after = observer
@@ -1749,10 +1705,7 @@ async fn single_client_operations_reach_server_in_causal_order() {
 
     // Transfer ownership (allowed — USING checks current owner_id = "alice").
     alice
-        .update(
-            doc_id,
-            vec![("owner_id".to_string(), Value::Text("bob".to_string()))],
-        )
+        .update(doc_id, vec![("owner_id".to_string(), "bob".into())])
         .await
         .expect("optimistic local update: transfer ownership");
 
@@ -1767,10 +1720,7 @@ async fn single_client_operations_reach_server_in_causal_order() {
     // order, ownership has already moved to bob.
     for i in 0..500 {
         alice
-            .update(
-                doc_id,
-                vec![("title".to_string(), Value::Text("nope".to_string()))],
-            )
+            .update(doc_id, vec![("title".to_string(), "nope".into())])
             .await
             .expect(&format!(
                 "optimistic local update: title change after lockout {}",
@@ -1871,18 +1821,12 @@ async fn originating_client_receives_rollback_for_rejected_mutation() {
     .await;
 
     alice
-        .update(
-            doc_id,
-            vec![("owner_id".to_string(), Value::Text("bob".to_string()))],
-        )
+        .update(doc_id, vec![("owner_id".to_string(), "bob".into())])
         .await
         .expect("optimistic local update: transfer ownership");
 
     alice
-        .update(
-            doc_id,
-            vec![("title".to_string(), Value::Text("nope".to_string()))],
-        )
+        .update(doc_id, vec![("title".to_string(), "nope".into())])
         .await
         .expect("optimistic local update: title change after lockout");
 

--- a/crates/jazz-tools/tests/policies_integration/simple_policies.rs
+++ b/crates/jazz-tools/tests/policies_integration/simple_policies.rs
@@ -27,11 +27,7 @@ fn make_documents_schema(table_name: &str, policies: TablePolicies) -> TableSche
 }
 
 fn boolean_policy_document_values(owner_id: &str, title: &str, archived: bool) -> Vec<Value> {
-    vec![
-        Value::Text(owner_id.to_string()),
-        Value::Text(title.to_string()),
-        Value::Boolean(archived),
-    ]
+    vec![owner_id.into(), title.into(), archived.into()]
 }
 
 fn boolean_policy_document_input(
@@ -39,11 +35,7 @@ fn boolean_policy_document_input(
     title: &str,
     archived: bool,
 ) -> HashMap<String, Value> {
-    HashMap::from([
-        ("owner_id".to_string(), Value::Text(owner_id.to_string())),
-        ("title".to_string(), Value::Text(title.to_string())),
-        ("archived".to_string(), Value::Boolean(archived)),
-    ])
+    row_input!("owner_id" => owner_id, "title" => title, "archived" => archived)
 }
 
 fn row_changes<const N: usize>(pairs: [(&str, Value); N]) -> Vec<(String, Value)> {
@@ -84,20 +76,14 @@ async fn create_row(
 
 async fn update_document_title(client: &JazzClient, document_id: ObjectId, title: &str) {
     client
-        .update(
-            document_id,
-            vec![("title".to_string(), Value::Text(title.to_string()))],
-        )
+        .update(document_id, vec![("title".to_string(), title.into())])
         .await
         .expect("update document title");
 }
 
 async fn update_document_archived(client: &JazzClient, document_id: ObjectId, archived: bool) {
     client
-        .update(
-            document_id,
-            vec![("archived".to_string(), Value::Boolean(archived))],
-        )
+        .update(document_id, vec![("archived".to_string(), archived.into())])
         .await
         .expect("update document archived");
 }
@@ -118,7 +104,7 @@ fn make_priority_schema(table_name: &str, policies: TablePolicies) -> TableSchem
 }
 
 fn priority_values(title: &str, priority: i32) -> Vec<Value> {
-    vec![Value::Text(title.to_string()), Value::Integer(priority)]
+    vec![title.into(), priority.into()]
 }
 
 fn make_review_schema(table_name: &str, policies: TablePolicies) -> TableSchemaBuilder {
@@ -130,10 +116,8 @@ fn make_review_schema(table_name: &str, policies: TablePolicies) -> TableSchemaB
 
 fn review_values(title: &str, reviewer_id: Option<&str>) -> Vec<Value> {
     vec![
-        Value::Text(title.to_string()),
-        reviewer_id
-            .map(|value| Value::Text(value.to_string()))
-            .unwrap_or(Value::Null),
+        title.into(),
+        reviewer_id.map(|value| value.into()).unwrap_or(Value::Null),
     ]
 }
 
@@ -146,11 +130,7 @@ fn make_status_schema(table_name: &str, policies: TablePolicies) -> TableSchemaB
 }
 
 fn status_values(title: &str, status: &str, archived: bool) -> Vec<Value> {
-    vec![
-        Value::Text(title.to_string()),
-        Value::Text(status.to_string()),
-        Value::Boolean(archived),
-    ]
+    vec![title.into(), status.into(), archived.into()]
 }
 
 async fn start_alice_and_bob_server(schema: Schema) -> (TestingServer, JazzClient, JazzClient) {
@@ -336,7 +316,7 @@ async fn select_policies_filter_out_archived_rows() {
             table_name,
             TablePolicies::new()
                 .with_insert(PolicyExpr::True)
-                .with_select(PolicyExpr::eq_literal("archived", Value::Boolean(false))),
+                .with_select(PolicyExpr::eq_literal("archived", false.into())),
         ))
         .build();
 
@@ -571,8 +551,8 @@ async fn delete_policies_boolean() {
 /// ```
 #[tokio::test]
 async fn archived_state_policies_gate_insert_update_and_delete() {
-    let incomplete_policy = PolicyExpr::eq_literal("archived", Value::Boolean(false));
-    let archived_policy = PolicyExpr::eq_literal("archived", Value::Boolean(true));
+    let incomplete_policy = PolicyExpr::eq_literal("archived", false.into());
+    let archived_policy = PolicyExpr::eq_literal("archived", true.into());
     let table_name = "documents_archived_lifecycle";
 
     let schema = SchemaBuilder::new()
@@ -703,7 +683,7 @@ async fn select_policies_scalar_comparators_filter_rows() {
                 .with_select(PolicyExpr::Cmp {
                     column: "priority".into(),
                     op: CmpOp::Ne,
-                    value: PolicyValue::Literal(Value::Integer(3)),
+                    value: PolicyValue::Literal(3i32.into()),
                 }),
         ))
         .table(make_priority_schema(
@@ -713,7 +693,7 @@ async fn select_policies_scalar_comparators_filter_rows() {
                 .with_select(PolicyExpr::Cmp {
                     column: "priority".into(),
                     op: CmpOp::Gt,
-                    value: PolicyValue::Literal(Value::Integer(3)),
+                    value: PolicyValue::Literal(3i32.into()),
                 }),
         ))
         .table(make_priority_schema(
@@ -723,7 +703,7 @@ async fn select_policies_scalar_comparators_filter_rows() {
                 .with_select(PolicyExpr::Cmp {
                     column: "priority".into(),
                     op: CmpOp::Ge,
-                    value: PolicyValue::Literal(Value::Integer(3)),
+                    value: PolicyValue::Literal(3i32.into()),
                 }),
         ))
         .table(make_priority_schema(
@@ -733,7 +713,7 @@ async fn select_policies_scalar_comparators_filter_rows() {
                 .with_select(PolicyExpr::Cmp {
                     column: "priority".into(),
                     op: CmpOp::Lt,
-                    value: PolicyValue::Literal(Value::Integer(3)),
+                    value: PolicyValue::Literal(3i32.into()),
                 }),
         ))
         .table(make_priority_schema(
@@ -743,7 +723,7 @@ async fn select_policies_scalar_comparators_filter_rows() {
                 .with_select(PolicyExpr::Cmp {
                     column: "priority".into(),
                     op: CmpOp::Le,
-                    value: PolicyValue::Literal(Value::Integer(3)),
+                    value: PolicyValue::Literal(3i32.into()),
                 }),
         ))
         .build();
@@ -1153,7 +1133,7 @@ async fn null_predicates_on_nullable_columns_gate_reads_and_writes() {
     update_row(
         &alice,
         update_is_null_rejected,
-        row_changes([("reviewer_id", Value::Text("bob".into()))]),
+        row_changes([("reviewer_id", "bob".into())]),
     )
     .await;
 
@@ -1198,7 +1178,7 @@ async fn row_level_contains_and_in_list_policies_filter_rows() {
                 .with_insert(PolicyExpr::True)
                 .with_select(PolicyExpr::Contains {
                     column: "title".into(),
-                    value: PolicyValue::Literal(Value::Text("Launch".into())),
+                    value: PolicyValue::Literal("Launch".into()),
                 }),
         ))
         .table(make_status_schema(
@@ -1208,8 +1188,8 @@ async fn row_level_contains_and_in_list_policies_filter_rows() {
                 .with_select(PolicyExpr::InList {
                     column: "status".into(),
                     values: vec![
-                        PolicyValue::Literal(Value::Text("active".into())),
-                        PolicyValue::Literal(Value::Text("trial".into())),
+                        PolicyValue::Literal("active".into()),
+                        PolicyValue::Literal("trial".into()),
                     ],
                 }),
         ))
@@ -1346,7 +1326,7 @@ async fn read_and_write_policies_remain_independent() {
             "documents_write_only",
             TablePolicies::new()
                 .with_insert(PolicyExpr::True)
-                .with_select(PolicyExpr::eq_literal("archived", Value::Boolean(false)))
+                .with_select(PolicyExpr::eq_literal("archived", false.into()))
                 .with_update(Some(PolicyExpr::True), PolicyExpr::True),
         ))
         .build();
@@ -1497,7 +1477,7 @@ async fn authorized_mutations_emit_visibility_scoped_subscription_deltas() {
             table_name,
             TablePolicies::new()
                 .with_insert(PolicyExpr::True)
-                .with_select(PolicyExpr::eq_literal("archived", Value::Boolean(false)))
+                .with_select(PolicyExpr::eq_literal("archived", false.into()))
                 .with_update(Some(PolicyExpr::True), PolicyExpr::True),
         ))
         .build();

--- a/crates/jazz-tools/tests/policies_integration/simple_policies.rs
+++ b/crates/jazz-tools/tests/policies_integration/simple_policies.rs
@@ -46,13 +46,6 @@ fn boolean_policy_document_input(
     ])
 }
 
-fn row_input<const N: usize>(pairs: [(&str, Value); N]) -> HashMap<String, Value> {
-    pairs
-        .into_iter()
-        .map(|(column, value)| (column.to_string(), value))
-        .collect()
-}
-
 fn row_changes<const N: usize>(pairs: [(&str, Value); N]) -> Vec<(String, Value)> {
     pairs
         .into_iter()
@@ -760,113 +753,77 @@ async fn select_policies_scalar_comparators_filter_rows() {
     let ne_match = create_row(
         &alice,
         "documents_select_ne",
-        row_input([
-            ("title", Value::Text("different".into())),
-            ("priority", Value::Integer(5)),
-        ]),
+        row_input!("title" => "different", "priority" => 5i32),
     )
     .await;
     let ne_hidden = create_row(
         &alice,
         "documents_select_ne",
-        row_input([
-            ("title", Value::Text("exact".into())),
-            ("priority", Value::Integer(3)),
-        ]),
+        row_input!("title" => "exact", "priority" => 3i32),
     )
     .await;
 
     let gt_match = create_row(
         &alice,
         "documents_select_gt",
-        row_input([
-            ("title", Value::Text("higher".into())),
-            ("priority", Value::Integer(5)),
-        ]),
+        row_input!("title" => "higher", "priority" => 5i32),
     )
     .await;
     let gt_hidden = create_row(
         &alice,
         "documents_select_gt",
-        row_input([
-            ("title", Value::Text("equal".into())),
-            ("priority", Value::Integer(3)),
-        ]),
+        row_input!("title" => "equal", "priority" => 3i32),
     )
     .await;
 
     let gte_low = create_row(
         &alice,
         "documents_select_gte",
-        row_input([
-            ("title", Value::Text("low".into())),
-            ("priority", Value::Integer(1)),
-        ]),
+        row_input!("title" => "low", "priority" => 1i32),
     )
     .await;
     let gte_equal = create_row(
         &alice,
         "documents_select_gte",
-        row_input([
-            ("title", Value::Text("equal".into())),
-            ("priority", Value::Integer(3)),
-        ]),
+        row_input!("title" => "equal", "priority" => 3i32),
     )
     .await;
     let gte_high = create_row(
         &alice,
         "documents_select_gte",
-        row_input([
-            ("title", Value::Text("high".into())),
-            ("priority", Value::Integer(5)),
-        ]),
+        row_input!("title" => "high", "priority" => 5i32),
     )
     .await;
 
     let lt_match = create_row(
         &alice,
         "documents_select_lt",
-        row_input([
-            ("title", Value::Text("lower".into())),
-            ("priority", Value::Integer(1)),
-        ]),
+        row_input!("title" => "lower", "priority" => 1i32),
     )
     .await;
     let lt_hidden = create_row(
         &alice,
         "documents_select_lt",
-        row_input([
-            ("title", Value::Text("equal".into())),
-            ("priority", Value::Integer(3)),
-        ]),
+        row_input!("title" => "equal", "priority" => 3i32),
     )
     .await;
 
     let lte_low = create_row(
         &alice,
         "documents_select_lte",
-        row_input([
-            ("title", Value::Text("low".into())),
-            ("priority", Value::Integer(1)),
-        ]),
+        row_input!("title" => "low", "priority" => 1i32),
     )
     .await;
     let lte_equal = create_row(
         &alice,
         "documents_select_lte",
-        row_input([
-            ("title", Value::Text("equal".into())),
-            ("priority", Value::Integer(3)),
-        ]),
+        row_input!("title" => "equal", "priority" => 3i32),
     )
     .await;
     let lte_hidden = create_row(
         &alice,
         "documents_select_lte",
-        row_input([
-            ("title", Value::Text("high".into())),
-            ("priority", Value::Integer(5)),
-        ]),
+        row_input!("title" => "high", "priority" => 5i32),
     )
     .await;
 
@@ -1037,114 +994,78 @@ async fn null_predicates_on_nullable_columns_gate_reads_and_writes() {
     let select_eq_null_visible = create_row(
         &alice,
         "documents_select_eq_null",
-        row_input([
-            ("title", Value::Text("unassigned".into())),
-            ("reviewer_id", Value::Null),
-        ]),
+        row_input!("title" => "unassigned", "reviewer_id" => Value::Null),
     )
     .await;
     let select_eq_null_hidden = create_row(
         &alice,
         "documents_select_eq_null",
-        row_input([
-            ("title", Value::Text("assigned".into())),
-            ("reviewer_id", Value::Text("alice".into())),
-        ]),
+        row_input!("title" => "assigned", "reviewer_id" => "alice"),
     )
     .await;
 
     let select_ne_null_hidden = create_row(
         &alice,
         "documents_select_ne_null",
-        row_input([
-            ("title", Value::Text("unassigned".into())),
-            ("reviewer_id", Value::Null),
-        ]),
+        row_input!("title" => "unassigned", "reviewer_id" => Value::Null),
     )
     .await;
     let select_ne_null_visible = create_row(
         &alice,
         "documents_select_ne_null",
-        row_input([
-            ("title", Value::Text("assigned".into())),
-            ("reviewer_id", Value::Text("alice".into())),
-        ]),
+        row_input!("title" => "assigned", "reviewer_id" => "alice"),
     )
     .await;
 
     let select_is_null_visible = create_row(
         &alice,
         "documents_select_is_null",
-        row_input([
-            ("title", Value::Text("unassigned".into())),
-            ("reviewer_id", Value::Null),
-        ]),
+        row_input!("title" => "unassigned", "reviewer_id" => Value::Null),
     )
     .await;
     let select_is_null_hidden = create_row(
         &alice,
         "documents_select_is_null",
-        row_input([
-            ("title", Value::Text("assigned".into())),
-            ("reviewer_id", Value::Text("alice".into())),
-        ]),
+        row_input!("title" => "assigned", "reviewer_id" => "alice"),
     )
     .await;
 
     let insert_eq_null_visible = create_row(
         &alice,
         "documents_insert_eq_null",
-        row_input([
-            ("title", Value::Text("allowed null".into())),
-            ("reviewer_id", Value::Null),
-        ]),
+        row_input!("title" => "allowed null", "reviewer_id" => Value::Null),
     )
     .await;
     let insert_eq_null_hidden = create_row(
         &alice,
         "documents_insert_eq_null",
-        row_input([
-            ("title", Value::Text("rejected non-null".into())),
-            ("reviewer_id", Value::Text("alice".into())),
-        ]),
+        row_input!("title" => "rejected non-null", "reviewer_id" => "alice"),
     )
     .await;
 
     let insert_ne_null_hidden = create_row(
         &alice,
         "documents_insert_ne_null",
-        row_input([
-            ("title", Value::Text("rejected null".into())),
-            ("reviewer_id", Value::Null),
-        ]),
+        row_input!("title" => "rejected null", "reviewer_id" => Value::Null),
     )
     .await;
     let insert_ne_null_visible = create_row(
         &alice,
         "documents_insert_ne_null",
-        row_input([
-            ("title", Value::Text("allowed non-null".into())),
-            ("reviewer_id", Value::Text("alice".into())),
-        ]),
+        row_input!("title" => "allowed non-null", "reviewer_id" => "alice"),
     )
     .await;
 
     let update_is_null_allowed = create_row(
         &alice,
         "documents_update_is_null",
-        row_input([
-            ("title", Value::Text("becomes null".into())),
-            ("reviewer_id", Value::Text("alice".into())),
-        ]),
+        row_input!("title" => "becomes null", "reviewer_id" => "alice"),
     )
     .await;
     let update_is_null_rejected = create_row(
         &alice,
         "documents_update_is_null",
-        row_input([
-            ("title", Value::Text("stays null".into())),
-            ("reviewer_id", Value::Null),
-        ]),
+        row_input!("title" => "stays null", "reviewer_id" => Value::Null),
     )
     .await;
 
@@ -1308,63 +1229,39 @@ async fn row_level_contains_and_in_list_policies_filter_rows() {
     let contains_match = create_row(
         &alice,
         "documents_select_contains",
-        row_input([
-            ("title", Value::Text("Launch Checklist".into())),
-            ("status", Value::Text("active".into())),
-            ("archived", Value::Boolean(false)),
-        ]),
+        row_input!("title" => "Launch Checklist", "status" => "active", "archived" => false),
     )
     .await;
     let contains_hidden = create_row(
         &alice,
         "documents_select_contains",
-        row_input([
-            ("title", Value::Text("Backlog".into())),
-            ("status", Value::Text("active".into())),
-            ("archived", Value::Boolean(false)),
-        ]),
+        row_input!("title" => "Backlog", "status" => "active", "archived" => false),
     )
     .await;
 
     let in_active = create_row(
         &alice,
         "documents_select_in_list",
-        row_input([
-            ("title", Value::Text("Active".into())),
-            ("status", Value::Text("active".into())),
-            ("archived", Value::Boolean(false)),
-        ]),
+        row_input!("title" => "Active", "status" => "active", "archived" => false),
     )
     .await;
     let in_trial = create_row(
         &alice,
         "documents_select_in_list",
-        row_input([
-            ("title", Value::Text("Trial".into())),
-            ("status", Value::Text("trial".into())),
-            ("archived", Value::Boolean(false)),
-        ]),
+        row_input!("title" => "Trial", "status" => "trial", "archived" => false),
     )
     .await;
     let in_hidden = create_row(
         &alice,
         "documents_select_in_list",
-        row_input([
-            ("title", Value::Text("Archived".into())),
-            ("status", Value::Text("archived".into())),
-            ("archived", Value::Boolean(true)),
-        ]),
+        row_input!("title" => "Archived", "status" => "archived", "archived" => true),
     )
     .await;
 
     let empty_hidden = create_row(
         &alice,
         "documents_select_empty_in_list",
-        row_input([
-            ("title", Value::Text("Should stay hidden".into())),
-            ("status", Value::Text("active".into())),
-            ("archived", Value::Boolean(false)),
-        ]),
+        row_input!("title" => "Should stay hidden", "status" => "active", "archived" => false),
     )
     .await;
 

--- a/examples/docs/todo-server-rs/src/docs_snippets.rs
+++ b/examples/docs/todo-server-rs/src/docs_snippets.rs
@@ -1,8 +1,6 @@
 //! Documentation snippet sources compiled with the example crate.
 #![allow(dead_code)]
 
-use std::collections::HashMap;
-
 use axum::http::{HeaderMap, StatusCode, header::AUTHORIZATION};
 use jazz_tools::query_manager::policy::{Operation, PolicyExpr};
 use jazz_tools::query_manager::types::TablePolicies;
@@ -16,12 +14,11 @@ fn verify_jwt_and_extract_claims(_token: &str) -> (String, serde_json::Value) {
     ("replace-with-verified-sub".to_string(), json!({}))
 }
 
-fn todo_values(title: impl Into<String>, description: impl Into<String>) -> HashMap<String, Value> {
-    HashMap::from([
-        ("title".to_string(), Value::Text(title.into())),
-        ("done".to_string(), Value::Boolean(false)),
-        ("description".to_string(), Value::Text(description.into())),
-    ])
+fn todo_values(
+    title: impl Into<String>,
+    description: impl Into<String>,
+) -> std::collections::HashMap<String, Value> {
+    jazz_tools::row_input!("title" => title.into(), "done" => false, "description" => description.into())
 }
 
 // #region backend-request-session-rust

--- a/examples/docs/todo-server-rs/src/routes.rs
+++ b/examples/docs/todo-server-rs/src/routes.rs
@@ -1,6 +1,5 @@
 //! HTTP routes for the todo API.
 
-use std::collections::HashMap;
 use std::convert::Infallible;
 use std::sync::Arc;
 
@@ -98,12 +97,8 @@ fn row_to_todo(object_id: ObjectId, values: &[Value]) -> Option<Todo> {
     })
 }
 
-fn todo_values(title: String, description: String) -> HashMap<String, Value> {
-    HashMap::from([
-        ("title".to_string(), Value::Text(title)),
-        ("done".to_string(), Value::Boolean(false)),
-        ("description".to_string(), Value::Text(description)),
-    ])
+fn todo_values(title: String, description: String) -> std::collections::HashMap<String, Value> {
+    jazz_tools::row_input!("title" => title, "done" => false, "description" => description)
 }
 
 /// List all todos.

--- a/examples/docs/todo-server-rs/tests/integration.rs
+++ b/examples/docs/todo-server-rs/tests/integration.rs
@@ -2,7 +2,6 @@
 //!
 //! Tests the full HTTP API end-to-end.
 
-use std::collections::HashMap;
 use std::convert::Infallible;
 use std::path::PathBuf;
 use std::process::{Child, Command, Stdio};
@@ -137,12 +136,11 @@ fn row_to_todo(object_id: ObjectId, values: &[Value]) -> Option<Todo> {
     })
 }
 
-fn todo_values(title: impl Into<String>, description: impl Into<String>) -> HashMap<String, Value> {
-    HashMap::from([
-        ("title".to_string(), Value::Text(title.into())),
-        ("done".to_string(), Value::Boolean(false)),
-        ("description".to_string(), Value::Text(description.into())),
-    ])
+fn todo_values(
+    title: impl Into<String>,
+    description: impl Into<String>,
+) -> std::collections::HashMap<String, Value> {
+    jazz_tools::row_input!("title" => title.into(), "done" => false, "description" => description.into())
 }
 
 /// Broadcast current todos to all SSE connections.

--- a/examples/todo-server-rs/src/routes.rs
+++ b/examples/todo-server-rs/src/routes.rs
@@ -1,6 +1,5 @@
 //! HTTP routes for the todo API.
 
-use std::collections::HashMap;
 use std::convert::Infallible;
 use std::sync::Arc;
 
@@ -98,12 +97,8 @@ fn row_to_todo(object_id: ObjectId, values: &[Value]) -> Option<Todo> {
     })
 }
 
-fn todo_values(title: String, description: String) -> HashMap<String, Value> {
-    HashMap::from([
-        ("title".to_string(), Value::Text(title)),
-        ("done".to_string(), Value::Boolean(false)),
-        ("description".to_string(), Value::Text(description)),
-    ])
+fn todo_values(title: String, description: String) -> std::collections::HashMap<String, Value> {
+    jazz_tools::row_input!("title" => title, "done" => false, "description" => description)
 }
 
 /// List all todos.

--- a/examples/todo-server-rs/tests/integration.rs
+++ b/examples/todo-server-rs/tests/integration.rs
@@ -2,7 +2,6 @@
 //!
 //! Tests the full HTTP API end-to-end.
 
-use std::collections::HashMap;
 use std::convert::Infallible;
 use std::path::PathBuf;
 use std::process::{Child, Command, Stdio};
@@ -137,12 +136,11 @@ fn row_to_todo(object_id: ObjectId, values: &[Value]) -> Option<Todo> {
     })
 }
 
-fn todo_values(title: impl Into<String>, description: impl Into<String>) -> HashMap<String, Value> {
-    HashMap::from([
-        ("title".to_string(), Value::Text(title.into())),
-        ("done".to_string(), Value::Boolean(false)),
-        ("description".to_string(), Value::Text(description.into())),
-    ])
+fn todo_values(
+    title: impl Into<String>,
+    description: impl Into<String>,
+) -> std::collections::HashMap<String, Value> {
+    jazz_tools::row_input!("title" => title.into(), "done" => false, "description" => description.into())
 }
 
 /// Broadcast current todos to all SSE connections.


### PR DESCRIPTION
## Summary

- Add `From<T>` impls on `Value` for all common types (`bool`, `i32`, `i64`, `f64`, `&str`, `String`, `ObjectId`, `Vec<u8>`, `Vec<Value>`, `Option<T>`)
- Add `row_input!` macro for ergonomic `HashMap<String, Value>` construction with heterogeneous types
- Migrate all test and example call sites, deleting duplicate helpers and verbose `HashMap::from` / `map/unwrap_or` boilerplate (~250 lines removed)

## Test plan

- [x] 17 unit tests for all `From` impls and `row_input!` macro (red-green TDD)
- [x] 894 jazz-tools lib tests pass
- [x] todo-server and todo-server-docs examples compile and pass
- [x] clippy and rustfmt clean