### PR TITLE
Allow allowedTo to accept relation names without Id suffix

### DIFF
--- a/.changeset/allow-fk-ref-without-id.md
+++ b/.changeset/allow-fk-ref-without-id.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+`allowedTo` now accepts bare relation names (e.g. `"project"`) in addition to full FK column names (`"projectId"`).

--- a/packages/jazz-tools/src/permissions/index.test.ts
+++ b/packages/jazz-tools/src/permissions/index.test.ts
@@ -931,6 +931,69 @@ describe("permissions DSL", () => {
     ).toThrow(/where condition bound to current/i);
   });
 
+  it("resolves allowedTo without Id suffix to the FK column", () => {
+    const compiled = definePermissions(app, ({ policy, allowedTo }) => [
+      policy.todos.allowRead.where(allowedTo.read("project")),
+    ]);
+
+    expect(compiled.todos!.select?.using).toEqual({
+      type: "Inherits",
+      operation: "Select",
+      via_column: "projectId",
+    });
+  });
+
+  it("resolves allowedTo without Id suffix for insert/update/delete", () => {
+    const compiled = definePermissions(app, ({ policy, allowedTo }) => [
+      policy.todos.allowInsert.where(allowedTo.insert("project")),
+      policy.todos.allowDelete.where(allowedTo.delete("project")),
+      policy.todos.allowUpdate
+        .whereOld(allowedTo.update("project"))
+        .whereNew(allowedTo.update("project")),
+    ]);
+
+    expect(compiled.todos!.insert?.with_check).toEqual({
+      type: "Inherits",
+      operation: "Insert",
+      via_column: "projectId",
+    });
+    expect(compiled.todos!.delete?.using).toEqual({
+      type: "Inherits",
+      operation: "Delete",
+      via_column: "projectId",
+    });
+    expect(compiled.todos!.update?.using).toEqual({
+      type: "Inherits",
+      operation: "Update",
+      via_column: "projectId",
+    });
+  });
+
+  it("resolves readReferencing without Id suffix", () => {
+    const compiled = definePermissions(app, ({ policy, allowedTo }) => [
+      policy.projects.allowRead.where(allowedTo.readReferencing(policy.todos, "project")),
+    ]);
+
+    expect(compiled.projects!.select?.using).toEqual({
+      type: "InheritsReferencing",
+      operation: "Select",
+      source_table: "todos",
+      via_column: "projectId",
+    });
+  });
+
+  it("still accepts the full FK column name with Id suffix", () => {
+    const compiled = definePermissions(app, ({ policy, allowedTo }) => [
+      policy.todos.allowRead.where(allowedTo.read("projectId")),
+    ]);
+
+    expect(compiled.todos!.select?.using).toEqual({
+      type: "Inherits",
+      operation: "Select",
+      via_column: "projectId",
+    });
+  });
+
   it("rejects allowedTo when column is not a foreign key", () => {
     expect(() =>
       definePermissions(app, ({ policy, allowedTo }) => [

--- a/packages/jazz-tools/src/permissions/index.ts
+++ b/packages/jazz-tools/src/permissions/index.ts
@@ -1761,7 +1761,7 @@ function compileCondition(
     return undefined;
   }
   if (isPolicyExpr(condition)) {
-    assertInheritsColumns(condition, table, fkReferencesByTable);
+    resolveAndAssertInheritsColumns(condition, table, fkReferencesByTable);
     return condition;
   }
   if (isSessionWhereCondition(condition)) {
@@ -1775,7 +1775,7 @@ function compileCondition(
   }
   if (isExistsCondition(condition)) {
     const compiledCondition = whereObjectToCondition(condition.where, { allowRowRefs: true });
-    assertInheritsColumns(compiledCondition, table, fkReferencesByTable);
+    resolveAndAssertInheritsColumns(compiledCondition, table, fkReferencesByTable);
     if (!compiledCondition) {
       throw new Error(
         `Failed to compile exists(...) condition for table "${condition.table}" in permissions.ts`,
@@ -1803,7 +1803,16 @@ function compileCondition(
   throw new Error("Unsupported condition in permissions compiler.");
 }
 
-function assertInheritsColumns(
+function resolveFkColumn(name: string, fkColumns: Map<string, string>): string | undefined {
+  if (fkColumns.has(name)) return name;
+  const withId = name + "Id";
+  if (fkColumns.has(withId)) return withId;
+  const withUnderId = name + "_id";
+  if (fkColumns.has(withUnderId)) return withUnderId;
+  return undefined;
+}
+
+function resolveAndAssertInheritsColumns(
   expr: PolicyExpr,
   table: string,
   fkReferencesByTable: Map<string, Map<string, string>>,
@@ -1818,7 +1827,8 @@ function assertInheritsColumns(
               `table metadata is missing in app.wasmSchema.`,
           );
         }
-        if (!fkColumns.has(node.via_column)) {
+        const resolved = resolveFkColumn(node.via_column, fkColumns);
+        if (!resolved) {
           const fkList = [...fkColumns.keys()].sort();
           const available = fkList.length > 0 ? fkList.join(", ") : "(none)";
           throw new Error(
@@ -1826,28 +1836,32 @@ function assertInheritsColumns(
               `column is not a foreign key reference. Available FK columns: ${available}.`,
           );
         }
+        node.via_column = resolved;
         break;
       }
       case "InheritsReferencing": {
+        const originalColumn = node.via_column;
         const sourceFks = fkReferencesByTable.get(node.source_table);
         if (!sourceFks) {
           throw new Error(
-            `allowedTo.${node.operation.toLowerCase()}Referencing(policy.${node.source_table}, "${node.via_column}") is invalid for table "${currentTable}": ` +
+            `allowedTo.${node.operation.toLowerCase()}Referencing(policy.${node.source_table}, "${originalColumn}") is invalid for table "${currentTable}": ` +
               `source table metadata is missing in app.wasmSchema.`,
           );
         }
-        const referenced = sourceFks.get(node.via_column);
-        if (!referenced) {
+        const resolved = resolveFkColumn(originalColumn, sourceFks);
+        if (!resolved) {
           const fkList = [...sourceFks.keys()].sort();
           const available = fkList.length > 0 ? fkList.join(", ") : "(none)";
           throw new Error(
-            `allowedTo.${node.operation.toLowerCase()}Referencing(policy.${node.source_table}, "${node.via_column}") is invalid for table "${currentTable}": ` +
+            `allowedTo.${node.operation.toLowerCase()}Referencing(policy.${node.source_table}, "${originalColumn}") is invalid for table "${currentTable}": ` +
               `column is not a foreign key reference on source table. Available FK columns: ${available}.`,
           );
         }
+        node.via_column = resolved;
+        const referenced = sourceFks.get(resolved);
         if (referenced !== currentTable) {
           throw new Error(
-            `allowedTo.${node.operation.toLowerCase()}Referencing(policy.${node.source_table}, "${node.via_column}") is invalid for table "${currentTable}": ` +
+            `allowedTo.${node.operation.toLowerCase()}Referencing(policy.${node.source_table}, "${originalColumn}") is invalid for table "${currentTable}": ` +
               `source FK references "${referenced}" but this rule is for "${currentTable}".`,
           );
         }


### PR DESCRIPTION
## Summary

- `allowedTo.read("project")` is now the idiomatic form — it reads as "inherit read permission from the project", which matches the actual semantics
- The `Id`/`_id` suffix is a storage-layer column naming convention that doesn't belong in the permissions DSL
- Resolution falls back through exact match → `Id` suffix → `_id` suffix, so existing `allowedTo.read("projectId")` continues to work

## Test plan

- [x] `allowedTo.read("project")` resolves to `via_column: "projectId"`
- [x] `allowedTo.insert/update/delete("project")` all resolve correctly
- [x] `allowedTo.readReferencing(policy.todos, "project")` resolves correctly
- [x] Backwards-compat: `allowedTo.read("projectId")` still works
- [x] Existing rejection tests still pass (non-FK columns, missing schema)