### PR TITLE
Add creator policy shorthands for permissions DSL

### DIFF
--- a/docs/content/docs/auth/permissions.mdx
+++ b/docs/content/docs/auth/permissions.mdx
@@ -189,5 +189,11 @@ shorthand for the same `$createdBy === session.user_id` condition. You can still
   ../examples/docs/todo-server-ts/src/permissions-snippets.ts#permissions-created-by-ts
 </include>
 
+When you want to reuse the same check inside a larger rule, compose `isCreator` directly:
+
+<include cwd lang="ts" meta='title="permissions.ts"'>
+  ../examples/docs/todo-server-ts/src/permissions-snippets.ts#permissions-created-by-combinator-ts
+</include>
+
 For more dynamic sharing or ownership models, prefer explicit tables and relations rather than
 encoding extra meaning into authorship alone.

--- a/docs/content/docs/auth/permissions.mdx
+++ b/docs/content/docs/auth/permissions.mdx
@@ -181,6 +181,10 @@ Jazz always tracks this metadata; select the columns explicitly to include them 
 You can use these edit metadata magic columns directly in `permissions.ts`. This is useful for simple
 "creator can read/edit/delete their own rows" policies without adding explicit `owner_id` columns.
 
+For the most common case, Jazz also exposes `policy.<table>.managedByCreator()` and `isCreator` as
+shorthand for the same `$createdBy === session.user_id` condition. You can still write the raw
+`$createdBy` comparison yourself whenever you want the explicit form.
+
 <include cwd lang="ts" meta='title="permissions.ts"'>
   ../examples/docs/todo-server-ts/src/permissions-snippets.ts#permissions-created-by-ts
 </include>

--- a/examples/docs/todo-server-ts/src/permissions-snippets.ts
+++ b/examples/docs/todo-server-ts/src/permissions-snippets.ts
@@ -38,13 +38,12 @@ s.definePermissions(exampleApp, ({ policy, allOf, session }) => {
 // #endregion permissions-simple-ts
 
 // #region permissions-created-by-ts
-s.definePermissions(exampleApp, ({ policy, session }) => {
-  policy.todos.allowRead.where({ $createdBy: session.user_id });
-  policy.todos.allowInsert.always();
-  policy.todos.allowUpdate
-    .whereOld({ $createdBy: session.user_id })
-    .whereNew({ $createdBy: session.user_id });
-  policy.todos.allowDelete.where({ $createdBy: session.user_id });
+s.definePermissions(exampleApp, ({ policy, anyOf, isCreator }) => {
+  // Sugar for applying `$createdBy === session.user_id` to read/insert/update/delete.
+  policy.todos.managedByCreator();
+
+  // The same creator condition can still be composed with other rules.
+  policy.todos.allowRead.where(anyOf([isCreator, { done: true }]));
 });
 // #endregion permissions-created-by-ts
 

--- a/examples/docs/todo-server-ts/src/permissions-snippets.ts
+++ b/examples/docs/todo-server-ts/src/permissions-snippets.ts
@@ -38,14 +38,18 @@ s.definePermissions(exampleApp, ({ policy, allOf, session }) => {
 // #endregion permissions-simple-ts
 
 // #region permissions-created-by-ts
-s.definePermissions(exampleApp, ({ policy, anyOf, isCreator }) => {
+s.definePermissions(exampleApp, ({ policy }) => {
   // Sugar for applying `$createdBy === session.user_id` to read/insert/update/delete.
   policy.todos.managedByCreator();
+});
+// #endregion permissions-created-by-ts
 
+// #region permissions-created-by-combinator-ts
+s.definePermissions(exampleApp, ({ policy, anyOf, isCreator }) => {
   // The same creator condition can still be composed with other rules.
   policy.todos.allowRead.where(anyOf([isCreator, { done: true }]));
 });
-// #endregion permissions-created-by-ts
+// #endregion permissions-created-by-combinator-ts
 
 // #region permissions-always-ts
 s.definePermissions(exampleApp, ({ policy }) => {

--- a/packages/jazz-tools/src/permissions/index.test.ts
+++ b/packages/jazz-tools/src/permissions/index.test.ts
@@ -318,6 +318,16 @@ const socialApp = {
   },
 };
 
+const creatorCondition = {
+  type: "Cmp",
+  column: "$createdBy",
+  op: "Eq",
+  value: {
+    type: "SessionRef",
+    path: ["user_id"],
+  },
+};
+
 describe("permissions DSL", () => {
   it("compiles read/insert/update/delete policies", () => {
     const compiled = definePermissions(app, ({ policy, allOf, allowedTo, session }) => [
@@ -416,6 +426,66 @@ describe("permissions DSL", () => {
         type: "SessionRef",
         path: ["userId"],
       },
+    });
+  });
+
+  it("exposes isCreator as creator-based condition sugar", () => {
+    const compiled = definePermissions(app, ({ policy, isCreator }) => [
+      policy.todos.allowRead.where(isCreator),
+      policy.todos.allowUpdate.where(isCreator),
+    ]);
+
+    expect(compiled.todos!.select?.using).toEqual(creatorCondition);
+    expect(compiled.todos!.update?.using).toEqual(creatorCondition);
+    expect(compiled.todos!.update?.with_check).toEqual(creatorCondition);
+  });
+
+  it("compiles managedByCreator() to creator-scoped CRUD rules", () => {
+    const compiled = definePermissions(app, ({ policy }) => {
+      policy.todos.managedByCreator();
+    });
+
+    expect(compiled.todos!.select?.using).toEqual(creatorCondition);
+    expect(compiled.todos!.insert?.with_check).toEqual(creatorCondition);
+    expect(compiled.todos!.update?.using).toEqual(creatorCondition);
+    expect(compiled.todos!.update?.with_check).toEqual(creatorCondition);
+    expect(compiled.todos!.delete?.using).toEqual(creatorCondition);
+  });
+
+  it("composes isCreator inside anyOf()", () => {
+    const compiled = definePermissions(app, ({ policy, anyOf, isCreator }) => [
+      policy.todos.allowUpdate.where(anyOf([isCreator, { done: true }])),
+    ]);
+
+    expect(compiled.todos!.update?.using).toEqual({
+      type: "Or",
+      exprs: [
+        creatorCondition,
+        {
+          type: "Cmp",
+          column: "done",
+          op: "Eq",
+          value: {
+            type: "Literal",
+            value: true,
+          },
+        },
+      ],
+    });
+    expect(compiled.todos!.update?.with_check).toEqual({
+      type: "Or",
+      exprs: [
+        creatorCondition,
+        {
+          type: "Cmp",
+          column: "done",
+          op: "Eq",
+          value: {
+            type: "Literal",
+            value: true,
+          },
+        },
+      ],
     });
   });
 

--- a/packages/jazz-tools/src/permissions/index.ts
+++ b/packages/jazz-tools/src/permissions/index.ts
@@ -46,6 +46,15 @@ type PolicyAction = "read" | "insert" | "update" | "delete";
 const OUTER_ROW_SESSION_PREFIX = "__jazz_outer_row";
 const RECURSIVE_POLICY_MAX_DEPTH_DEFAULT = 10;
 const RECURSIVE_POLICY_MAX_DEPTH_HARD_CAP = 64;
+const CREATOR_CONDITION = {
+  type: "Cmp",
+  column: "$createdBy",
+  op: "Eq",
+  value: {
+    type: "SessionRef",
+    path: ["user_id"],
+  },
+} satisfies PolicyExpr;
 
 interface SessionRefValue {
   readonly __jazzPermissionKind: "session-ref";
@@ -466,6 +475,7 @@ interface TablePolicyBuilder<WhereInput, Row> extends TableRelationBuilder<Where
   allowDeletes: ActionBuilder<WhereInput, Row>;
   allowUpdate: UpdateRuleBuilder<WhereInput, Row>;
   allowUpdates: UpdateRuleBuilder<WhereInput, Row>;
+  managedByCreator(): void;
   exists: ExistsBuilder<WhereInput>;
 }
 
@@ -480,6 +490,7 @@ export type PolicyContext<TApp extends AppLike> = {
   };
   anyOf: (conditions: readonly unknown[]) => Condition;
   allOf: (conditions: readonly unknown[]) => Condition;
+  isCreator: Condition;
   allowedTo: AllowedToContext;
   session: SessionContext;
 };
@@ -588,6 +599,7 @@ export function definePermissions<TApp extends AppLike>(
     policy: buildPolicyContext(tableNames, relationsByTable, collectRule),
     anyOf,
     allOf,
+    isCreator: CREATOR_CONDITION,
     allowedTo: createAllowedToContext(),
     session: createSessionContext(),
   } as unknown as PolicyContext<TApp>;
@@ -678,6 +690,12 @@ function buildTablePolicyBuilder(
   };
   const updateFactory = (): UpdateRuleBuilder<unknown, unknown> =>
     new UpdateRuleBuilder(table, collectRule);
+  const managedByCreator = (): void => {
+    read.where(CREATOR_CONDITION);
+    insert.where(CREATOR_CONDITION);
+    updateFactory().where(CREATOR_CONDITION);
+    del.where(CREATOR_CONDITION);
+  };
   const exists: ExistsBuilder<unknown> = {
     where: (input) => ({
       __jazzPermissionKind: "exists",
@@ -701,6 +719,7 @@ function buildTablePolicyBuilder(
     get allowUpdates() {
       return updateFactory();
     },
+    managedByCreator,
     exists,
     where(input: unknown): PermissionRelation {
       return createTableRelation(table, relationsByTable).where(input);

--- a/packages/jazz-tools/src/permissions/type-inference.test.ts
+++ b/packages/jazz-tools/src/permissions/type-inference.test.ts
@@ -171,10 +171,11 @@ const app = {
 
 describe("permissions type inference", () => {
   it("infers row callback and where key types", () => {
-    definePermissions(app, ({ policy, anyOf, allowedTo, session }) => {
+    definePermissions(app, ({ policy, anyOf, allowedTo, session, isCreator }) => {
       expectTypeOf(session.user_id.path).toEqualTypeOf<string[]>();
       expectTypeOf(session.userId.path).toEqualTypeOf<string[]>();
       expectTypeOf(session["claims.role"]!.path).toEqualTypeOf<string[]>();
+      expectTypeOf(isCreator).toMatchTypeOf<Parameters<typeof anyOf>[0][number]>();
 
       const reachableTeams = policy.teams.gather({
         start: { kind: "individual", identity_key: session.userId },
@@ -182,18 +183,20 @@ describe("permissions type inference", () => {
           policy.team_team_edges.where({ child_team: current }).hopTo("parent_team"),
       });
 
-      const hasViewerGrant = (resource: unknown) =>
-        policy.exists(
+      function hasViewerGrant(resource: unknown) {
+        return policy.exists(
           reachableTeams.hopTo("resource_access_edgesViaTeam").where({
             "resource_access_edges.resource": resource,
             grant_role: "viewer",
           }),
         );
+      }
 
       return [
         policy.todos.allowRead.where((todo) =>
           anyOf([
             { done: false },
+            isCreator,
             session.where({ "claims.role": "manager" }),
             policy.projects.exists.where({
               id: todo.projectId,
@@ -253,6 +256,13 @@ describe("permissions type inference", () => {
         policy.todos.allowRead.where((todo) => ({ ownerId: todo.missingColumn }));
       }
 
+      return [];
+    });
+  });
+
+  it("exposes managedByCreator() on table builders", () => {
+    definePermissions(app, ({ policy }) => {
+      policy.todos.managedByCreator();
       return [];
     });
   });

--- a/packages/jazz-tools/src/runtime/cloud-server.integration.test.ts
+++ b/packages/jazz-tools/src/runtime/cloud-server.integration.test.ts
@@ -1725,6 +1725,203 @@ describe("cloud-server integration (Jazz TS)", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Creator shorthand integration
+// ---------------------------------------------------------------------------
+
+interface CreatorManagedItem {
+  id: string;
+  title: string;
+  shared: boolean;
+}
+
+interface CreatorManagedItemWhere {
+  id?: string;
+  title?: string;
+  shared?: boolean;
+}
+
+class CreatorManagedItemQueryBuilder {
+  declare readonly _rowType: CreatorManagedItem;
+  where(_input: CreatorManagedItemWhere): CreatorManagedItemQueryBuilder {
+    return this;
+  }
+}
+
+function buildCreatorManagedItemsSchema(): WasmSchema {
+  const schema: WasmSchema = {
+    creator_items: {
+      columns: [
+        { name: "title", column_type: { type: "Text" }, nullable: false },
+        { name: "shared", column_type: { type: "Boolean" }, nullable: false },
+      ],
+    },
+  };
+
+  const app = {
+    creator_items: new CreatorManagedItemQueryBuilder(),
+    wasmSchema: schema,
+  };
+
+  const permissions = normalizePermissionsForWasm(
+    definePermissions(app, ({ policy, anyOf, isCreator }) => {
+      policy.creator_items.managedByCreator();
+      policy.creator_items.allowRead.where(anyOf([isCreator, { shared: true }]));
+    }),
+  );
+
+  const tables: WasmSchema = {};
+  for (const [tableName, tableSchema] of Object.entries(schema)) {
+    const tablePolicies = permissions[tableName];
+    tables[tableName] = tablePolicies
+      ? ({
+          ...tableSchema,
+          policies: tablePolicies as unknown as (typeof tableSchema)["policies"],
+        } as (typeof tables)[string])
+      : tableSchema;
+  }
+  return tables;
+}
+
+describe("Creator policy shorthands", () => {
+  beforeAll(() => {
+    assertIntegrationPrerequisites();
+  });
+
+  it("enforces managedByCreator() and composes isCreator with other rules", async () => {
+    function rowTitles(rows: Row[]): string[] {
+      return rows.map((row) => (row.values[0] as { type: "Text"; value: string }).value).sort();
+    }
+
+    const schema = buildCreatorManagedItemsSchema();
+    const queryAllItems = buildAllRowsQuery(schema, "creator_items");
+
+    const jwks = await JwksServer.start(JWT_SECRET);
+    const dataRoot = allocTempDir("jazz-ts-creator-shorthands-");
+    const server = await startCloudServer({ dataRoot });
+    let aliceClient: JazzClient | null = null;
+    let bobClient: JazzClient | null = null;
+    let systemClient: JazzClient | null = null;
+
+    try {
+      const app = await createApp(server.baseUrl, jwks.url);
+      await publishInlineSchemaAndPermissions(server.baseUrl, `/apps/${app.app_id}`, schema);
+
+      aliceClient = await connectClient(
+        makeContext(
+          app.app_id,
+          server.baseUrl,
+          signJwt("alice", JWT_SECRET, { principalId: "alice" }),
+          schema,
+        ),
+      );
+      bobClient = await connectClient(
+        makeContext(
+          app.app_id,
+          server.baseUrl,
+          signJwt("bob", JWT_SECRET, { principalId: "bob" }),
+          schema,
+        ),
+      );
+      systemClient = (
+        await connectClient({
+          appId: app.app_id,
+          schema,
+          serverUrl: server.baseUrl,
+          serverPathPrefix: `/apps/${app.app_id}`,
+          env: "test",
+          userBranch: "main",
+          backendSecret: BACKEND_SECRET,
+        })
+      ).asBackend();
+
+      const alicePrivateId = (
+        await aliceClient.createDurable(
+          "creator_items",
+          {
+            title: { type: "Text", value: "alice-private" },
+            shared: { type: "Boolean", value: false },
+          },
+          { tier: "edge" },
+        )
+      ).id;
+      const aliceSharedId = (
+        await aliceClient.createDurable(
+          "creator_items",
+          {
+            title: { type: "Text", value: "alice-shared" },
+            shared: { type: "Boolean", value: true },
+          },
+          { tier: "edge" },
+        )
+      ).id;
+      const bobOwnId = (
+        await bobClient.createDurable(
+          "creator_items",
+          {
+            title: { type: "Text", value: "bob-own" },
+            shared: { type: "Boolean", value: false },
+          },
+          { tier: "edge" },
+        )
+      ).id;
+
+      const systemRowId = (
+        await systemClient.createDurable(
+          "creator_items",
+          {
+            title: { type: "Text", value: "system-row" },
+            shared: { type: "Boolean", value: false },
+          },
+          { tier: "edge" },
+        )
+      ).id;
+
+      const aliceRows = await waitForRows(aliceClient, queryAllItems, (rows) => rows.length === 2);
+      expect(rowTitles(aliceRows)).toEqual(["alice-private", "alice-shared"]);
+      expect(aliceRows.some((row) => row.id === systemRowId)).toBe(false);
+
+      const bobRows = await waitForRows(bobClient, queryAllItems, (rows) => rows.length === 2);
+      expect(rowTitles(bobRows)).toEqual(["alice-shared", "bob-own"]);
+
+      expect(bobRows.some((row) => row.id === aliceSharedId)).toBe(true);
+      expect(bobRows.some((row) => row.id === bobOwnId)).toBe(true);
+      expect(bobRows.some((row) => row.id === alicePrivateId)).toBe(false);
+      expect(bobRows.some((row) => row.id === systemRowId)).toBe(false);
+
+      await expect(
+        bobClient.updateDurable(
+          alicePrivateId,
+          { title: { type: "Text", value: "bob-edit" } },
+          { tier: "edge" },
+        ),
+      ).rejects.toBeTruthy();
+      await expect(bobClient.deleteDurable(aliceSharedId, { tier: "edge" })).rejects.toBeTruthy();
+
+      const aliceRowsAfterRejects = await waitForRows(
+        aliceClient,
+        queryAllItems,
+        (rows) =>
+          rows.length === 2 &&
+          rows.some(
+            (row) =>
+              row.id === alicePrivateId &&
+              row.values[0]?.type === "Text" &&
+              row.values[0].value === "alice-private",
+          ) &&
+          rows.some((row) => row.id === aliceSharedId),
+      );
+      expect(aliceRowsAfterRejects.some((row) => row.id === bobOwnId)).toBe(false);
+    } finally {
+      if (aliceClient) await aliceClient.shutdown();
+      if (bobClient) await bobClient.shutdown();
+      if (systemClient) await systemClient.shutdown();
+      await stopProcess(server.child);
+      await jwks.stop();
+    }
+  }, 60000);
+});
+
+// ---------------------------------------------------------------------------
 // Policy bypass reproduction: subscription without session skips filtering
 // ---------------------------------------------------------------------------
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -530,7 +530,7 @@ importers:
         version: 19.2.14
       babel-preset-expo:
         specifier: ~54.0.10
-        version: 54.0.10(@babel/core@7.29.0)(@babel/runtime@7.29.2)(expo@54.0.33(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.1(typescript@6.0.2))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4))(react-refresh@0.17.0)
+        version: 54.0.10(@babel/core@7.29.0)(@babel/runtime@7.28.6)(expo@54.0.33(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.0.1(typescript@6.0.2))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4))(react-refresh@0.14.2)
       typescript:
         specifier: catalog:default
         version: 6.0.2
@@ -16992,7 +16992,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vitest: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.11.0)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.1(@types/node@24.11.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      vitest: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@20.19.35)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.1(@types/node@20.19.35)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   '@vitest/utils@4.1.0':
     dependencies:


### PR DESCRIPTION
## Summary
- add `policy.<table>.managedByCreator()` as shorthand for creator-scoped read/insert/update/delete policies
- expose `isCreator` in `definePermissions(...)` so creator checks can be reused inside `anyOf(...)` and other composed rules
- add DSL, type inference, integration, and docs/example coverage for the new shorthand APIs
- document the shorthand examples separately from the composable `isCreator` example
- include unrelated `pnpm-lock.yaml` cleanup for the excluded `examples/world-tour` workspace
