### PR TITLE
Run native benchmarks on RocksDB

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -96,8 +96,8 @@ jobs:
       - name: Build native benchmark binaries
         run: |
           set -euo pipefail
-          cargo build --release -p jazz-tools --features client --example realistic_bench
-          cargo bench -p jazz-tools --bench realistic_phase1 --no-run
+          cargo build --release -p jazz-tools --features client,rocksdb --example realistic_bench
+          cargo bench -p jazz-tools --features rocksdb --bench realistic_phase1 --no-run
 
       - name: Run native benchmark suite
         run: |

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -222,6 +222,7 @@ jobs:
 
       - run: corepack enable
       - run: pnpm install --frozen-lockfile
+      - run: pnpm --filter jazz-napi build
       - run: pnpm exec playwright install chromium
 
       - name: Collect host metadata

--- a/benchmarks/realistic/README.md
+++ b/benchmarks/realistic/README.md
@@ -89,10 +89,12 @@ pnpm bench:realistic:export-criterion -- \
 Run the browser benchmark test:
 
 ```bash
+pnpm --filter jazz-napi build
 pnpm --dir packages/jazz-tools run bench:realistic:browser
 ```
 
 The test runs against a real Chromium worker + OPFS runtime and emits JSON summaries to stdout.
+The Node-side test server used by the browser harness comes from `jazz-napi`, so its native binding needs to be built first in a workspace checkout.
 
 The browser benchmark sets `logLevel: "warn"` in `DbConfig` so WASM tracing output stays quiet.
 

--- a/benchmarks/realistic/README.md
+++ b/benchmarks/realistic/README.md
@@ -18,12 +18,12 @@ Shared benchmark definitions for the realistic, scenario-driven benchmark suite.
 - `scenarios/b6_server_hotspot_history.json`: deep-history hotspot updates + storage delta
 - `scenarios/r8_many_branches.json`: many linked branches on a single object
 
-## Native Runner (Fjall)
+## Native Runner (RocksDB)
 
 Run from workspace root:
 
 ```bash
-RUST_LOG=warn cargo run -p jazz-tools --features client --example realistic_bench -- \
+RUST_LOG=warn cargo run -p jazz-tools --features client,rocksdb --example realistic_bench -- \
   --profile benchmarks/realistic/profiles/s.json \
   --scenario benchmarks/realistic/scenarios/w1_interactive.json
 ```
@@ -31,7 +31,7 @@ RUST_LOG=warn cargo run -p jazz-tools --features client --example realistic_benc
 `W3` requires a running server and `--server-url`:
 
 ```bash
-RUST_LOG=warn cargo run -p jazz-tools --features client --example realistic_bench -- \
+RUST_LOG=warn cargo run -p jazz-tools --features client,rocksdb --example realistic_bench -- \
   --profile benchmarks/realistic/profiles/s.json \
   --scenario benchmarks/realistic/scenarios/w3_offline_reconnect.json \
   --server-url http://127.0.0.1:1625
@@ -42,7 +42,7 @@ RUST_LOG=warn cargo run -p jazz-tools --features client --example realistic_benc
 Run the local realistic benchmark suite:
 
 ```bash
-cargo bench -p jazz-tools --bench realistic_phase1
+cargo bench -p jazz-tools --features rocksdb --bench realistic_phase1
 ```
 
 It currently loads:
@@ -51,7 +51,7 @@ It currently loads:
 - scenario `R1`: `benchmarks/realistic/scenarios/r1_crud_sustained.json`
 - scenario `R2`: `benchmarks/realistic/scenarios/r2_reads_sustained.json`
 - scenario `R2B`: `benchmarks/realistic/scenarios/r2_reads_with_churn.json` (5% background write churn)
-- scenario `R3`: `benchmarks/realistic/scenarios/r3_cold_load_fjall.json` (cold open + first query, Fjall)
+- scenario `R3`: `benchmarks/realistic/scenarios/r3_cold_load.json` (cold open + first query, RocksDB)
 - scenario `R4`: `benchmarks/realistic/scenarios/r4_fanout_updates.json` (N={10,50,200} subscribers)
 - scenario `R5`: `benchmarks/realistic/scenarios/r5_permission_recursive.json` (recursive policy read/update with allow+deny mix)
 - scenario `R6`: `benchmarks/realistic/scenarios/r6_permission_write_heavy.json` (recursive policy write-heavy allow+deny mix)
@@ -63,7 +63,7 @@ Current topology coverage:
 - `T0_local`: `realistic_phase1/crud_sustained` and `realistic_phase1/reads_sustained`
 - mixed read/write churn: `realistic_phase1/reads_sustained_with_write_churn`
 - `T1_single_hop`: `realistic_phase1/crud_sustained_single_hop` and `realistic_phase1/reads_sustained_single_hop`
-- persisted cold-load (`M1_fjall`): `realistic_phase1/cold_load_fjall` (requires `--features fjall`)
+- persisted cold-load (`M1_rocksdb`): `realistic_phase1/cold_load_rocksdb` (requires `--features rocksdb`)
 - fanout delivery: `realistic_phase1/fanout_updates`
 - recursive permission read/write: `realistic_phase1/permission_recursive`
 - recursive permission write-heavy: `realistic_phase1/permission_write_heavy`
@@ -73,7 +73,7 @@ Current topology coverage:
 Run only the cold-load benchmark:
 
 ```bash
-cargo bench -p jazz-tools --features fjall --bench realistic_phase1 cold_load_fjall
+cargo bench -p jazz-tools --features rocksdb --bench realistic_phase1 cold_load_rocksdb
 ```
 
 Export consolidated Criterion artifacts (JSON + markdown summary) from `target/criterion`:

--- a/benchmarks/realistic/ci_benchmarks.mjs
+++ b/benchmarks/realistic/ci_benchmarks.mjs
@@ -82,12 +82,12 @@ export const NATIVE_BENCHMARKS = [
     },
   },
   {
-    id: "native-criterion:r3_cold_load_fjall",
+    id: "native-criterion:r3_cold_load_rocksdb",
     suite: "native",
-    label: "Criterion R3 cold-load Fjall",
+    label: "Criterion R3 cold-load RocksDB",
     kind: "criterion",
-    log_path: "logs/criterion_r3_cold_load_fjall.log",
-    criterion_filter: "realistic_phase1/cold_load_fjall",
+    log_path: "logs/criterion_r3_cold_load_rocksdb.log",
+    criterion_filter: "realistic_phase1/cold_load_rocksdb",
     env: {
       JAZZ_REALISTIC_VARIANT: "ci",
     },

--- a/benchmarks/realistic/ci_benchmarks.test.mjs
+++ b/benchmarks/realistic/ci_benchmarks.test.mjs
@@ -1,0 +1,78 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+import { NATIVE_BENCHMARKS } from "./ci_benchmarks.mjs";
+import {
+  buildNativeCriterionCommand,
+  buildNativeExampleBaseCommand,
+  NATIVE_CRITERION_FEATURES,
+  NATIVE_EXAMPLE_FEATURES,
+} from "./run_ci_benchmarks.mjs";
+
+test("native benchmark catalog targets RocksDB for the cold-load Criterion run", () => {
+  const benchmark = NATIVE_BENCHMARKS.find(
+    (entry) => entry.id === "native-criterion:r3_cold_load_rocksdb",
+  );
+
+  assert.ok(benchmark, "expected a RocksDB cold-load benchmark entry");
+  assert.equal(benchmark.label, "Criterion R3 cold-load RocksDB");
+  assert.equal(benchmark.log_path, "logs/criterion_r3_cold_load_rocksdb.log");
+  assert.equal(benchmark.criterion_filter, "realistic_phase1/cold_load_rocksdb");
+});
+
+test("native example command opts into the RocksDB storage backend", () => {
+  const benchmark = NATIVE_BENCHMARKS.find((entry) => entry.id === "native:w1_interactive");
+  assert.ok(benchmark, "expected the W1 native example benchmark");
+
+  const command = buildNativeExampleBaseCommand(benchmark, { profile: "s" });
+  assert.equal(NATIVE_EXAMPLE_FEATURES, "client,rocksdb");
+  assert.deepEqual(command.slice(0, 8), [
+    "cargo",
+    "run",
+    "--release",
+    "-p",
+    "jazz-tools",
+    "--features",
+    "client,rocksdb",
+    "--example",
+  ]);
+});
+
+test("native Criterion command opts into the RocksDB storage backend", () => {
+  const benchmark = NATIVE_BENCHMARKS.find(
+    (entry) => entry.id === "native-criterion:r3_cold_load_rocksdb",
+  );
+  assert.ok(benchmark, "expected the R3 native Criterion benchmark");
+
+  const command = buildNativeCriterionCommand(benchmark);
+  assert.equal(NATIVE_CRITERION_FEATURES, "rocksdb");
+  assert.deepEqual(command, [
+    "cargo",
+    "bench",
+    "-p",
+    "jazz-tools",
+    "--features",
+    "rocksdb",
+    "--bench",
+    "realistic_phase1",
+    "--",
+    "realistic_phase1/cold_load_rocksdb",
+  ]);
+});
+
+test("benchmark workflow prebuilds the RocksDB-backed native binaries", () => {
+  const workflow = readFileSync(
+    new URL("../../.github/workflows/benchmarks.yml", import.meta.url),
+    "utf8",
+  );
+
+  assert.match(
+    workflow,
+    /cargo build --release -p jazz-tools --features client,rocksdb --example realistic_bench/,
+  );
+  assert.match(
+    workflow,
+    /cargo bench -p jazz-tools --features rocksdb --bench realistic_phase1 --no-run/,
+  );
+});

--- a/benchmarks/realistic/ci_benchmarks.test.mjs
+++ b/benchmarks/realistic/ci_benchmarks.test.mjs
@@ -76,3 +76,12 @@ test("benchmark workflow prebuilds the RocksDB-backed native binaries", () => {
     /cargo bench -p jazz-tools --features rocksdb --bench realistic_phase1 --no-run/,
   );
 });
+
+test("benchmark workflow builds jazz-napi before browser benchmarks", () => {
+  const workflow = readFileSync(
+    new URL("../../.github/workflows/benchmarks.yml", import.meta.url),
+    "utf8",
+  );
+
+  assert.match(workflow, /pnpm --filter jazz-napi build/);
+});

--- a/benchmarks/realistic/run_ci_benchmarks.mjs
+++ b/benchmarks/realistic/run_ci_benchmarks.mjs
@@ -3,6 +3,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { spawn } from "node:child_process";
+import { pathToFileURL } from "node:url";
 import {
   benchmarksForSuite,
   DEFAULT_BENCHMARK_TIMEOUT_SECONDS,
@@ -440,28 +441,53 @@ function stripAnsi(value) {
   return String(value ?? "").replace(/\x1B\[[0-9;]*m/g, "");
 }
 
+export const NATIVE_EXAMPLE_FEATURES = "client,rocksdb";
+export const NATIVE_CRITERION_FEATURES = "rocksdb";
+
+export function buildNativeExampleBaseCommand(benchmark, args) {
+  const profilePath =
+    benchmark.profile_path ?? `benchmarks/realistic/profiles/${args.profile}.json`;
+
+  return [
+    "cargo",
+    "run",
+    "--release",
+    "-p",
+    "jazz-tools",
+    "--features",
+    NATIVE_EXAMPLE_FEATURES,
+    "--example",
+    "realistic_bench",
+    "--",
+    "--profile",
+    profilePath,
+    "--scenario",
+    benchmark.scenario_path,
+  ];
+}
+
+export function buildNativeCriterionCommand(benchmark) {
+  return [
+    "cargo",
+    "bench",
+    "-p",
+    "jazz-tools",
+    "--features",
+    NATIVE_CRITERION_FEATURES,
+    "--bench",
+    "realistic_phase1",
+    "--",
+    benchmark.criterion_filter,
+  ];
+}
+
 async function runNativeBenchmark(benchmark, args) {
   if (benchmark.kind === "native-example") {
     const outputFile = path.resolve(args.outDir, benchmark.output_path);
+    const env = { ...process.env, ...(benchmark.env ?? {}) };
     const profilePath =
       benchmark.profile_path ?? `benchmarks/realistic/profiles/${args.profile}.json`;
-    const env = { ...process.env, ...(benchmark.env ?? {}) };
-    const baseCommand = [
-      "cargo",
-      "run",
-      "--release",
-      "-p",
-      "jazz-tools",
-      "--features",
-      "client",
-      "--example",
-      "realistic_bench",
-      "--",
-      "--profile",
-      profilePath,
-      "--scenario",
-      benchmark.scenario_path,
-    ];
+    const baseCommand = buildNativeExampleBaseCommand(benchmark, args);
     const repeatCount = repeatCountForBenchmark(benchmark, args.repeatCount);
     const attempts = [];
     const scenarios = [];
@@ -631,18 +657,7 @@ async function runNativeBenchmark(benchmark, args) {
 
   const logFile = path.resolve(args.outDir, benchmark.log_path);
 
-  const command = [
-    "cargo",
-    "bench",
-    "-p",
-    "jazz-tools",
-    "--features",
-    "fjall",
-    "--bench",
-    "realistic_phase1",
-    "--",
-    benchmark.criterion_filter,
-  ];
+  const command = buildNativeCriterionCommand(benchmark);
 
   console.log(`\n==> ${benchmark.label}`);
   console.log(shellQuote(command));
@@ -896,7 +911,9 @@ async function main() {
   console.log(fs.readFileSync(summaryFile, "utf8"));
 }
 
-main().catch((error) => {
-  console.error(error instanceof Error ? (error.stack ?? error.message) : String(error));
-  process.exit(1);
-});
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? (error.stack ?? error.message) : String(error));
+    process.exit(1);
+  });
+}

--- a/benchmarks/realistic/update_history.mjs
+++ b/benchmarks/realistic/update_history.mjs
@@ -201,8 +201,8 @@ function criterionBenchmarkId(benchmark) {
   if (groupId === "realistic_phase1/reads_sustained_with_write_churn") {
     return "native-criterion:r2_reads_with_write_churn";
   }
-  if (groupId === "realistic_phase1/cold_load_fjall") {
-    return "native-criterion:r3_cold_load_fjall";
+  if (groupId === "realistic_phase1/cold_load_rocksdb") {
+    return "native-criterion:r3_cold_load_rocksdb";
   }
   if (groupId === "realistic_phase1/fanout_updates") {
     return "native-criterion:r4_fanout_updates";

--- a/packages/jazz-tools/tests/browser/testing-server-node.ts
+++ b/packages/jazz-tools/tests/browser/testing-server-node.ts
@@ -1,8 +1,9 @@
-import { TestingServer } from "jazz-napi";
 import type { BrowserContext, Route } from "playwright";
 
+type JazzNapiTestingServer = import("jazz-napi").TestingServer;
+
 interface StartedTestingServer {
-  server: TestingServer;
+  server: JazzNapiTestingServer;
   appId: string;
   serverUrl: string;
   adminSecret: string;
@@ -11,7 +12,21 @@ interface StartedTestingServer {
 let testingServerPromise: Promise<StartedTestingServer> | null = null;
 const blockedServerRoutes = new WeakMap<BrowserContext, Map<string, (route: Route) => void>>();
 
+async function loadTestingServer(): Promise<typeof import("jazz-napi").TestingServer> {
+  try {
+    const module = await import("jazz-napi");
+    return module.TestingServer;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      "Browser tests require the jazz-napi TestingServer host binding. Run `pnpm --filter jazz-napi build` first.\n\n" +
+        `Original error: ${message}`,
+    );
+  }
+}
+
 async function startTestingServer(): Promise<StartedTestingServer> {
+  const TestingServer = await loadTestingServer();
   const server = await TestingServer.start();
   return {
     server,


### PR DESCRIPTION
## What changed
- switched the native realistic example runner to `--features client,rocksdb`
- switched the native Criterion runner and workflow prebuild step to `--features rocksdb`
- renamed the R3 cold-load benchmark catalog/history mapping from Fjall to RocksDB
- added a regression test that locks the native benchmark catalog, cargo commands, and workflow prebuild flags to RocksDB

## Why
The native benchmark plumbing had drifted after the backend switch. The realistic example runner still built with only `client`, which meant `ClientStorage::Persistent` did not actually use RocksDB there, and the Criterion cold-load slot plus workflow still referenced Fjall.

## Impact
Native benchmark runs and the benchmark workflow now target RocksDB consistently, and the cold-load benchmark metadata is labeled and mapped to the RocksDB-backed group.

## Checks
- `node --test benchmarks/realistic/ci_benchmarks.test.mjs`
- started `cargo run -p jazz-tools --features client,rocksdb --example realistic_bench -- --help`
- started `cargo bench -p jazz-tools --features rocksdb --bench realistic_phase1 --no-run`

The RocksDB cargo commands entered `librocksdb-sys` native compilation locally, but I did not wait for full completion before opening this draft.