### PR TITLE
Fix browser benchmark file selection

### DIFF
--- a/packages/jazz-tools/src/browser-benchmark-mode.test.ts
+++ b/packages/jazz-tools/src/browser-benchmark-mode.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { shouldExcludeRealisticBrowserBench } from "./browser-benchmark-mode.js";
+
+describe("shouldExcludeRealisticBrowserBench", () => {
+  it("keeps realistic browser benchmarks out of ordinary browser test runs", () => {
+    expect(
+      shouldExcludeRealisticBrowserBench({
+        argv: ["node", "vitest", "run", "--config", "vitest.config.browser.ts"],
+        lifecycleEvent: "test:browser",
+      }),
+    ).toBe(true);
+  });
+
+  it("includes realistic browser benchmarks for the dedicated benchmark script", () => {
+    expect(
+      shouldExcludeRealisticBrowserBench({
+        argv: [
+          "node",
+          "vitest",
+          "run",
+          "--config",
+          "vitest.config.browser.ts",
+          "tests/browser/realistic-bench.test.ts",
+        ],
+        lifecycleEvent: "bench:realistic:browser",
+      }),
+    ).toBe(false);
+  });
+
+  it("includes realistic browser benchmarks when the file is targeted explicitly", () => {
+    expect(
+      shouldExcludeRealisticBrowserBench({
+        argv: [
+          "node",
+          "vitest",
+          "run",
+          "--config",
+          "vitest.config.browser.ts",
+          "tests/browser/realistic-bench.test.ts",
+        ],
+        lifecycleEvent: "",
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/jazz-tools/src/browser-benchmark-mode.ts
+++ b/packages/jazz-tools/src/browser-benchmark-mode.ts
@@ -1,0 +1,19 @@
+export const REALISTIC_BROWSER_BENCH_TEST = "tests/browser/realistic-bench.test.ts";
+
+function normalizeArg(value: string): string {
+  return value.replaceAll("\\", "/");
+}
+
+export function shouldExcludeRealisticBrowserBench(input?: {
+  argv?: string[];
+  lifecycleEvent?: string;
+}): boolean {
+  const argv = input?.argv ?? process.argv;
+  const lifecycleEvent = input?.lifecycleEvent ?? process.env.npm_lifecycle_event ?? "";
+
+  if (lifecycleEvent === "bench:realistic:browser") {
+    return false;
+  }
+
+  return !argv.some((value) => normalizeArg(value).endsWith(REALISTIC_BROWSER_BENCH_TEST));
+}

--- a/packages/jazz-tools/vitest.config.browser.ts
+++ b/packages/jazz-tools/vitest.config.browser.ts
@@ -15,9 +15,14 @@ import {
   createRemoteBrowserDb,
   waitForRemoteBrowserDbTitle,
 } from "./tests/browser/remote-browser-db-node.js";
+import {
+  REALISTIC_BROWSER_BENCH_TEST,
+  shouldExcludeRealisticBrowserBench,
+} from "./src/browser-benchmark-mode.js";
 
 const realisticBrowserScenarios = process.env.JAZZ_REALISTIC_BROWSER_SCENARIOS ?? "";
 const realisticBrowserRunId = process.env.JAZZ_REALISTIC_BROWSER_RUN_ID ?? "";
+const excludeRealisticBrowserBench = shouldExcludeRealisticBrowserBench();
 
 export default defineConfig({
   define: {
@@ -70,7 +75,7 @@ export default defineConfig({
       },
     },
     include: ["tests/browser/**/*.test.ts", "tests/browser/**/*.test.tsx"],
-    exclude: ["tests/browser/realistic-bench.test.ts"],
+    exclude: excludeRealisticBrowserBench ? [REALISTIC_BROWSER_BENCH_TEST] : [],
     globalSetup: ["tests/browser/global-setup.ts"],
     testTimeout: 30000,
   },


### PR DESCRIPTION
## What changed

This makes the dedicated browser benchmark run include `tests/browser/realistic-bench.test.ts` again while keeping that file excluded from ordinary `test:browser` runs.

The change adds a small helper that detects benchmark mode from the invoked file / lifecycle event, wires that into `vitest.config.browser.ts`, and adds a regression test for the inclusion logic.

## Why

Recent `main` benchmark runs were uploading browser artifacts, but the rendered benchmark site showed base snapshots as `2 suites` because the browser artifact contained zero scenarios.

The root cause was that `bench:realistic:browser` still invoked `tests/browser/realistic-bench.test.ts`, while `vitest.config.browser.ts` had started excluding that same file. Vitest therefore exited with `No test files found`, every browser benchmark failed quickly, and `realistic.json` was emitted with `scenario_count: 0`.

## Impact

Browser benchmark artifacts from `main` should start contributing browser suite results to benchmark history and the published site again.

Ordinary browser test runs remain unchanged and continue to skip the realistic benchmark file.

## Validation

- `pnpm --dir packages/jazz-tools exec vitest run --config vitest.config.ts src/browser-benchmark-mode.test.ts`
- Confirmed against the latest `main` benchmark artifact that the previous failure mode was `No test files found` with all browser scenarios marked failed and `scenario_count: 0` in `realistic.json`.
