### PR TITLE
fix(example): migrate remaining HashMap calls to row_input!, enable sqlite for tests

### DIFF
--- a/examples/docs/todo-server-rs/src/docs_snippets.rs
+++ b/examples/docs/todo-server-rs/src/docs_snippets.rs
@@ -428,20 +428,20 @@ pub async fn create_file_from_bytes(
         let (part_id, _) = client
             .create(
                 "file_parts",
-                HashMap::from([("data".to_string(), Value::Bytea(chunk.to_vec()))]),
+                jazz_tools::row_input!("data" => chunk.to_vec()),
             )
             .await?;
         part_ids.push(Value::Uuid(part_id));
         part_sizes.push(Value::Integer(chunk.len() as i32));
     }
 
-    let mut file_values = HashMap::from([
-        ("mimeType".to_string(), Value::Text(mime_type.into())),
-        ("partIds".to_string(), Value::Array(part_ids)),
-        ("partSizes".to_string(), Value::Array(part_sizes)),
-    ]);
+    let mut file_values = jazz_tools::row_input!(
+        "mimeType" => mime_type,
+        "partIds" => part_ids,
+        "partSizes" => part_sizes,
+    );
     if let Some(name) = name {
-        file_values.insert("name".to_string(), Value::Text(name.into()));
+        file_values.insert("name".to_string(), name.into());
     }
 
     let (file_id, _) = client.create("files", file_values).await?;
@@ -460,11 +460,11 @@ pub async fn create_upload_from_bytes(
     let (upload_id, _) = client
         .create(
             "uploads",
-            HashMap::from([
-                ("owner_id".to_string(), Value::Text(owner_id.into())),
-                ("label".to_string(), Value::Text("Profile photo".into())),
-                ("fileId".to_string(), Value::Uuid(file_id)),
-            ]),
+            jazz_tools::row_input!(
+                "owner_id" => owner_id,
+                "label" => "Profile photo",
+                "fileId" => file_id,
+            ),
         )
         .await?;
 

--- a/examples/todo-server-rs/Cargo.toml
+++ b/examples/todo-server-rs/Cargo.toml
@@ -24,6 +24,7 @@ uuid = { version = "1", features = ["v4"] }
 futures-util = "0.3"
 
 [dev-dependencies]
+jazz_tools = { package = "jazz-tools", path = "../../crates/jazz-tools", features = ["sqlite"] }
 tempfile = "3"
 reqwest = { version = "0.12", features = ["json"] }
 tower = { version = "0.5", features = ["util"] }


### PR DESCRIPTION
## Summary

- Migrate 3 remaining `HashMap::from(...)` call sites in `examples/docs/todo-server-rs/src/docs_snippets.rs` to `row_input!` — PR #475 removed the `HashMap` import but missed these, breaking the build
- Add `sqlite` feature to `todo-server` dev-dependencies so `ClientStorage::Persistent` actually uses sqlite instead of silently falling back to `MemoryStorage`, fixing 2 failing integration tests

## Test plan

- [x] `cargo check -p todo-server-docs` passes
- [x] `cargo check -p todo-server` passes
- [x] `cargo clippy -p todo-server-docs` clean
- [x] `cargo clippy -p todo-server --tests` clean
- [x] All 5 `todo-server` integration tests pass (previously 2 were failing)