### PR TITLE
Add sqlite and rocksdb native benchmark lanes

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -74,55 +74,70 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p bench-out/native
-          cat > bench-out/native/metadata.json <<EOF
-          {
-            "workflow": "${GITHUB_WORKFLOW}",
-            "run_id": "${GITHUB_RUN_ID}",
-            "run_attempt": "${GITHUB_RUN_ATTEMPT}",
-            "repository": "${GITHUB_REPOSITORY}",
-            "sha": "${BENCH_SHA}",
-            "ref": "${BENCH_REF}",
-            "branch": "${BENCH_BRANCH}",
-            "profile": "${BENCH_PROFILE}",
-            "runner_name": "${RUNNER_NAME}",
-            "runner_os": "${RUNNER_OS}",
-            "runner_arch": "${RUNNER_ARCH}"
-          }
-          EOF
           rustc -V > bench-out/native/rustc.txt
           uname -a > bench-out/native/uname.txt
           lscpu > bench-out/native/lscpu.txt
+          for engine in rocksdb sqlite; do
+            mkdir -p "bench-out/native/${engine}"
+            cat > "bench-out/native/${engine}/metadata.json" <<EOF
+            {
+              "workflow": "${GITHUB_WORKFLOW}",
+              "run_id": "${GITHUB_RUN_ID}",
+              "run_attempt": "${GITHUB_RUN_ATTEMPT}",
+              "repository": "${GITHUB_REPOSITORY}",
+              "sha": "${BENCH_SHA}",
+              "ref": "${BENCH_REF}",
+              "branch": "${BENCH_BRANCH}",
+              "profile": "${BENCH_PROFILE}",
+              "runner_name": "${RUNNER_NAME}",
+              "runner_os": "${RUNNER_OS}",
+              "runner_arch": "${RUNNER_ARCH}",
+              "storage_engine": "${engine}"
+            }
+            EOF
+            cp bench-out/native/rustc.txt "bench-out/native/${engine}/rustc.txt"
+            cp bench-out/native/uname.txt "bench-out/native/${engine}/uname.txt"
+            cp bench-out/native/lscpu.txt "bench-out/native/${engine}/lscpu.txt"
+          done
 
       - name: Build native benchmark binaries
         run: |
           set -euo pipefail
           cargo build --release -p jazz-tools --features client,rocksdb --example realistic_bench
+          cargo build --release -p jazz-tools --features client,sqlite --example realistic_bench
           cargo bench -p jazz-tools --features rocksdb --bench realistic_phase1 --no-run
+          cargo bench -p jazz-tools --features sqlite --bench realistic_phase1 --no-run
 
       - name: Run native benchmark suite
         run: |
           set -euo pipefail
           sleep 10
-          taskset -c "${BENCH_CPUSET}" node benchmarks/realistic/run_ci_benchmarks.mjs \
-            --suite native \
-            --out-dir bench-out/native \
-            --profile "${BENCH_PROFILE}" \
-            --skip-set benchmarks/realistic/ci_skip_set.json \
-            --repeat-count "${BENCH_REPEAT_COUNT}" \
-            --timeout-seconds "${BENCH_TIMEOUT_SECONDS}"
-
-      - name: Export Criterion artifacts
-        run: |
-          set -euo pipefail
-          node benchmarks/realistic/export_criterion.mjs \
-            --allow-empty \
-            --out bench-out/native/criterion_realistic_phase1.json \
-            --summary-md bench-out/native/criterion_realistic_phase1.md
+          for engine in rocksdb sqlite; do
+            rm -rf target/criterion
+            out_dir="bench-out/native/${engine}"
+            taskset -c "${BENCH_CPUSET}" node benchmarks/realistic/run_ci_benchmarks.mjs \
+              --suite native \
+              --storage-engine "${engine}" \
+              --out-dir "${out_dir}" \
+              --profile "${BENCH_PROFILE}" \
+              --skip-set benchmarks/realistic/ci_skip_set.json \
+              --repeat-count "${BENCH_REPEAT_COUNT}" \
+              --timeout-seconds "${BENCH_TIMEOUT_SECONDS}"
+            node benchmarks/realistic/export_criterion.mjs \
+              --allow-empty \
+              --out "${out_dir}/criterion_realistic_phase1.json" \
+              --summary-md "${out_dir}/criterion_realistic_phase1.md"
+          done
 
       - name: Publish native execution summary
         run: |
           set -euo pipefail
-          cat bench-out/native/summary.md >> "$GITHUB_STEP_SUMMARY"
+          for summary in bench-out/native/*/summary.md; do
+            if [ -f "$summary" ]; then
+              cat "$summary" >> "$GITHUB_STEP_SUMMARY"
+              printf '\n' >> "$GITHUB_STEP_SUMMARY"
+            fi
+          done
 
       - name: Build native manifest
         run: |
@@ -134,49 +149,54 @@ jobs:
               printf ''
             fi
           }
-          jq -n \
-            --arg workflow "${GITHUB_WORKFLOW}" \
-            --arg run_id "${GITHUB_RUN_ID}" \
-            --arg run_attempt "${GITHUB_RUN_ATTEMPT}" \
-            --arg repository "${GITHUB_REPOSITORY}" \
-            --arg sha "${BENCH_SHA}" \
-            --arg ref "${BENCH_REF}" \
-            --arg branch "${BENCH_BRANCH}" \
-            --arg profile "${BENCH_PROFILE}" \
-            --arg generated_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-            --arg w1_sha256 "$(file_sha bench-out/native/w1_interactive.json)" \
-            --arg w4_sha256 "$(file_sha bench-out/native/w4_cold_start.json)" \
-            --arg status_sha256 "$(file_sha bench-out/native/suite_status.json)" \
-            --arg summary_sha256 "$(file_sha bench-out/native/summary.md)" \
-            --arg skip_candidates_sha256 "$(file_sha bench-out/native/skip_candidates.json)" \
-            --arg criterion_json_sha256 "$(file_sha bench-out/native/criterion_realistic_phase1.json)" \
-            --arg criterion_md_sha256 "$(file_sha bench-out/native/criterion_realistic_phase1.md)" \
-            'def nullable($value): if $value == "" then null else $value end;
-            {
-              kind: "realistic-bench-native",
-              generated_at: $generated_at,
-              workflow: $workflow,
-              run_id: $run_id,
-              run_attempt: $run_attempt,
-              repository: $repository,
-              sha: $sha,
-              ref: $ref,
-              branch: $branch,
-              profile: $profile,
-              files: [
-                { path: "metadata.json" },
-                { path: "rustc.txt" },
-                { path: "uname.txt" },
-                { path: "lscpu.txt" },
-                { path: "suite_status.json", sha256: nullable($status_sha256) },
-                { path: "summary.md", sha256: nullable($summary_sha256) },
-                { path: "skip_candidates.json", sha256: nullable($skip_candidates_sha256) },
-                { path: "w1_interactive.json", sha256: nullable($w1_sha256) },
-                { path: "w4_cold_start.json", sha256: nullable($w4_sha256) },
-                { path: "criterion_realistic_phase1.json", sha256: nullable($criterion_json_sha256) },
-                { path: "criterion_realistic_phase1.md", sha256: nullable($criterion_md_sha256) }
-              ]
-            }' > bench-out/native/manifest.json
+          for engine in rocksdb sqlite; do
+            dir="bench-out/native/${engine}"
+            jq -n \
+              --arg workflow "${GITHUB_WORKFLOW}" \
+              --arg run_id "${GITHUB_RUN_ID}" \
+              --arg run_attempt "${GITHUB_RUN_ATTEMPT}" \
+              --arg repository "${GITHUB_REPOSITORY}" \
+              --arg sha "${BENCH_SHA}" \
+              --arg ref "${BENCH_REF}" \
+              --arg branch "${BENCH_BRANCH}" \
+              --arg profile "${BENCH_PROFILE}" \
+              --arg storage_engine "${engine}" \
+              --arg generated_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+              --arg w1_sha256 "$(file_sha "${dir}/w1_interactive.json")" \
+              --arg w4_sha256 "$(file_sha "${dir}/w4_cold_start.json")" \
+              --arg status_sha256 "$(file_sha "${dir}/suite_status.json")" \
+              --arg summary_sha256 "$(file_sha "${dir}/summary.md")" \
+              --arg skip_candidates_sha256 "$(file_sha "${dir}/skip_candidates.json")" \
+              --arg criterion_json_sha256 "$(file_sha "${dir}/criterion_realistic_phase1.json")" \
+              --arg criterion_md_sha256 "$(file_sha "${dir}/criterion_realistic_phase1.md")" \
+              'def nullable($value): if $value == "" then null else $value end;
+              {
+                kind: "realistic-bench-native",
+                generated_at: $generated_at,
+                workflow: $workflow,
+                run_id: $run_id,
+                run_attempt: $run_attempt,
+                repository: $repository,
+                sha: $sha,
+                ref: $ref,
+                branch: $branch,
+                profile: $profile,
+                storage_engine: $storage_engine,
+                files: [
+                  { path: "metadata.json" },
+                  { path: "rustc.txt" },
+                  { path: "uname.txt" },
+                  { path: "lscpu.txt" },
+                  { path: "suite_status.json", sha256: nullable($status_sha256) },
+                  { path: "summary.md", sha256: nullable($summary_sha256) },
+                  { path: "skip_candidates.json", sha256: nullable($skip_candidates_sha256) },
+                  { path: "w1_interactive.json", sha256: nullable($w1_sha256) },
+                  { path: "w4_cold_start.json", sha256: nullable($w4_sha256) },
+                  { path: "criterion_realistic_phase1.json", sha256: nullable($criterion_json_sha256) },
+                  { path: "criterion_realistic_phase1.md", sha256: nullable($criterion_md_sha256) }
+                ]
+              }' > "${dir}/manifest.json"
+          done
 
       - name: Upload native artifacts
         uses: actions/upload-artifact@v4
@@ -241,7 +261,8 @@ jobs:
             "profile": "${BENCH_PROFILE}",
             "runner_name": "${RUNNER_NAME}",
             "runner_os": "${RUNNER_OS}",
-            "runner_arch": "${RUNNER_ARCH}"
+            "runner_arch": "${RUNNER_ARCH}",
+            "storage_engine": "opfs-btree"
           }
           EOF
           node -v > bench-out/browser/node.txt
@@ -308,6 +329,7 @@ jobs:
               ref: $ref,
               branch: $branch,
               profile: $profile,
+              storage_engine: "opfs-btree",
               files: [
                 { path: "metadata.json" },
                 { path: "node.txt" },
@@ -438,10 +460,10 @@ jobs:
       - name: Update benchmark skip set
         run: |
           set -euo pipefail
-          args=(
-            --skip-set benchmarks/realistic/ci_skip_set.json
-            --status site-input/native/suite_status.json
-          )
+          args=(--skip-set benchmarks/realistic/ci_skip_set.json)
+          while IFS= read -r status_file; do
+            args+=(--status "$status_file")
+          done < <(find site-input/native -name suite_status.json -type f | sort)
           if [ -f site-input/browser/suite_status.json ]; then
             args+=(--status site-input/browser/suite_status.json)
           fi
@@ -558,7 +580,7 @@ jobs:
           if [ -n "${BENCH_SITE_URL:-}" ]; then
             printf 'Preview site: %s\n\n' "${BENCH_SITE_URL}" >> bench-out/pr-report.md
           fi
-          for summary in site-input/native/summary.md site-input/browser/summary.md; do
+          for summary in site-input/native/*/summary.md site-input/browser/summary.md; do
             if [ -f "$summary" ]; then
               cat "$summary" >> bench-out/pr-report.md
               printf '\n' >> bench-out/pr-report.md

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -79,22 +79,21 @@ jobs:
           lscpu > bench-out/native/lscpu.txt
           for engine in rocksdb sqlite; do
             mkdir -p "bench-out/native/${engine}"
-            cat > "bench-out/native/${engine}/metadata.json" <<EOF
-            {
-              "workflow": "${GITHUB_WORKFLOW}",
-              "run_id": "${GITHUB_RUN_ID}",
-              "run_attempt": "${GITHUB_RUN_ATTEMPT}",
-              "repository": "${GITHUB_REPOSITORY}",
-              "sha": "${BENCH_SHA}",
-              "ref": "${BENCH_REF}",
-              "branch": "${BENCH_BRANCH}",
-              "profile": "${BENCH_PROFILE}",
-              "runner_name": "${RUNNER_NAME}",
-              "runner_os": "${RUNNER_OS}",
-              "runner_arch": "${RUNNER_ARCH}",
-              "storage_engine": "${engine}"
-            }
-            EOF
+            printf '%s\n' \
+              '{' \
+              "  \"workflow\": \"${GITHUB_WORKFLOW}\"," \
+              "  \"run_id\": \"${GITHUB_RUN_ID}\"," \
+              "  \"run_attempt\": \"${GITHUB_RUN_ATTEMPT}\"," \
+              "  \"repository\": \"${GITHUB_REPOSITORY}\"," \
+              "  \"sha\": \"${BENCH_SHA}\"," \
+              "  \"ref\": \"${BENCH_REF}\"," \
+              "  \"branch\": \"${BENCH_BRANCH}\"," \
+              "  \"profile\": \"${BENCH_PROFILE}\"," \
+              "  \"runner_name\": \"${RUNNER_NAME}\"," \
+              "  \"runner_os\": \"${RUNNER_OS}\"," \
+              "  \"runner_arch\": \"${RUNNER_ARCH}\"," \
+              "  \"storage_engine\": \"${engine}\"" \
+              '}' > "bench-out/native/${engine}/metadata.json"
             cp bench-out/native/rustc.txt "bench-out/native/${engine}/rustc.txt"
             cp bench-out/native/uname.txt "bench-out/native/${engine}/uname.txt"
             cp bench-out/native/lscpu.txt "bench-out/native/${engine}/lscpu.txt"

--- a/benchmarks/realistic/build_site.mjs
+++ b/benchmarks/realistic/build_site.mjs
@@ -414,6 +414,12 @@ function buildHtml() {
       browser: "Browser",
       "native-criterion": "Native CR",
     };
+    const STORAGE_ENGINE_ORDER = ["rocksdb", "sqlite", "opfs-btree"];
+    const STORAGE_ENGINE_LABELS = {
+      rocksdb: "RocksDB",
+      sqlite: "SQLite",
+      "opfs-btree": "OPFS-btree",
+    };
     const CORE_METRICS = ["wall_time_ms", "throughput_ops_per_sec"];
     const OP_METRIC_ORDER = ["avg_ms", "p95_ms"];
     const SCENARIO_CARD_WIDTH = 296;
@@ -439,6 +445,32 @@ function buildHtml() {
 
     function suiteLabel(suite) {
       return SUITE_LABELS[suite] || suite || "Unknown";
+    }
+
+    function storageEngineRank(storageEngine) {
+      const idx = STORAGE_ENGINE_ORDER.indexOf(storageEngine);
+      return idx === -1 ? STORAGE_ENGINE_ORDER.length + 1 : idx;
+    }
+
+    function storageEngineLabel(storageEngine) {
+      return STORAGE_ENGINE_LABELS[storageEngine] || storageEngine || "";
+    }
+
+    function runLaneKey(run) {
+      return [run.suite || "", run.storage_engine || ""].join("::");
+    }
+
+    function runLaneLabel(run) {
+      const suite = suiteLabel(run && run.suite);
+      const storage = storageEngineLabel(run && (run.storage_engine || run.storageEngine));
+      return storage ? suite + " (" + storage + ")" : suite;
+    }
+
+    function laneRank(run) {
+      return (
+        suiteRank(run && run.suite) * 100 +
+        storageEngineRank(run && (run.storage_engine || run.storageEngine))
+      );
     }
 
     function runId(run) {
@@ -499,7 +531,7 @@ function buildHtml() {
             ref: run.ref || "",
             generated_at: run.generated_at || "",
             runs: [],
-            runs_by_suite: {},
+            runs_by_lane: {},
           };
           map.set(key, snapshot);
         }
@@ -508,12 +540,17 @@ function buildHtml() {
             ? run.generated_at || snapshot.generated_at
             : snapshot.generated_at;
         snapshot.runs.push(run);
-        snapshot.runs_by_suite[run.suite] = run;
+        snapshot.runs_by_lane[runLaneKey(run)] = run;
       }
 
       return [...map.values()]
         .map((snapshot) => {
-          snapshot.runs.sort((a, b) => suiteRank(a.suite) - suiteRank(b.suite) || compareText(a.suite, b.suite));
+          snapshot.runs.sort(
+            (a, b) =>
+              laneRank(a) - laneRank(b) ||
+              compareText(a.suite, b.suite) ||
+              compareText(a.storage_engine, b.storage_engine),
+          );
           return snapshot;
         })
         .sort(byGenerated);
@@ -524,15 +561,16 @@ function buildHtml() {
         snapshot.generated_at || "n/a",
         String(snapshot.sha || "n/a").slice(0, 12),
         runId(snapshot),
-        snapshot.runs.length + " suites",
+        snapshot.runs.length + " lanes",
       ].join(" • ");
     }
 
     function normalizeScenarioEntry(run, scenario) {
       const variantKey = scenarioVariant(scenario);
       return {
-        key: [run.suite || "", scenario.scenario_id || "", variantKey].join("::"),
+        key: [run.suite || "", run.storage_engine || "", scenario.scenario_id || "", variantKey].join("::"),
         suite: run.suite || "",
+        storageEngine: run.storage_engine || "",
         scenarioId: scenario.scenario_id || "unknown",
         scenarioName: scenario.scenario_name || scenario.scenario_id || "unknown",
         topology: scenario.topology || "",
@@ -546,8 +584,10 @@ function buildHtml() {
     }
 
     function compareScenarioEntries(a, b) {
-      const suiteCmp = suiteRank(a.suite) - suiteRank(b.suite);
-      if (suiteCmp !== 0) return suiteCmp;
+      const laneCmp =
+        suiteRank(a.suite) - suiteRank(b.suite) ||
+        storageEngineRank(a.storageEngine) - storageEngineRank(b.storageEngine);
+      if (laneCmp !== 0) return laneCmp;
       const scenarioCmp = compareText(a.scenarioId, b.scenarioId);
       if (scenarioCmp !== 0) return scenarioCmp;
       const variantCmp = compareText(a.variantKey, b.variantKey);
@@ -753,8 +793,13 @@ function buildHtml() {
       return descriptor.label;
     }
 
-    function scenarioPrefixText(suite, scenarioId) {
-      return suiteLabel(suite).toLowerCase() + "/" + String(scenarioId || "");
+    function scenarioPrefixText(suite, storageEngine, scenarioId) {
+      const parts = [suiteLabel(suite).toLowerCase()];
+      if (storageEngineLabel(storageEngine)) {
+        parts.push(storageEngineLabel(storageEngine).toLowerCase());
+      }
+      parts.push(String(scenarioId || ""));
+      return parts.join("/");
     }
 
     function formatPct(value) {
@@ -904,6 +949,7 @@ function buildHtml() {
         cards.push({
           key,
           suite: baseEntry.suite,
+          storageEngine: baseEntry.storageEngine,
           scenarioId: baseEntry.scenarioId,
           scenarioName: baseEntry.scenarioName,
           subtitle: baseEntry.variantLabel || baseEntry.topology || "",
@@ -920,6 +966,7 @@ function buildHtml() {
         for (const metricRow of card.metricRows) {
           rows.push({
             suite: card.suite,
+            storageEngine: card.storageEngine,
             scenarioId: card.scenarioId,
             scenarioName: card.scenarioName,
             subtitle: card.subtitle,
@@ -978,9 +1025,6 @@ function buildHtml() {
       const runs = Array.isArray(history.runs) ? [...history.runs].sort(byGenerated) : [];
       const snapshots = buildSnapshots(runs);
 
-      const suites = unique(runs.map((run) => run.suite).filter(Boolean)).sort(
-        (a, b) => suiteRank(a) - suiteRank(b) || compareText(a, b),
-      );
       const branches = unique(snapshots.map((snapshot) => snapshot.branch).filter(Boolean)).sort(compareText);
       const profiles = unique(snapshots.map((snapshot) => snapshot.profile).filter(Boolean)).sort(compareText);
 
@@ -1102,7 +1146,7 @@ function buildHtml() {
 
         for (const snapshot of snapshots.slice(0, 60)) {
           const tr = document.createElement("tr");
-          const suitesText = snapshot.runs.map((run) => suiteLabel(run.suite)).join(", ");
+          const suitesText = snapshot.runs.map((run) => runLaneLabel(run)).join(", ");
           const cardCount = scenarioEntries(snapshot).length;
           tr.innerHTML = [
             "<td>" + escapeHtml(snapshot.generated_at || "n/a") + "</td>",
@@ -1173,7 +1217,7 @@ function buildHtml() {
           if (card.subtitle) subtitleParts.push(card.subtitle);
           article.innerHTML = [
             '<div class="scenario-head">',
-            '  <span class="scenario-prefix">' + escapeHtml(scenarioPrefixText(card.suite, card.scenarioId)) + ":</span>",
+            '  <span class="scenario-prefix">' + escapeHtml(scenarioPrefixText(card.suite, card.storageEngine, card.scenarioId)) + ":</span>",
             '  <span class="scenario-title">' + escapeHtml(prettyToken(card.scenarioName)) + "</span>",
             subtitleParts.length
               ? '  <span class="scenario-subtitle">' + escapeHtml(prettyToken(subtitleParts.join(" • "))) + "</span>"
@@ -1243,7 +1287,7 @@ function buildHtml() {
           const tr = document.createElement("tr");
           tr.innerHTML = [
             "<td>" + escapeHtml(entry.branch) + "</td>",
-            "<td>" + escapeHtml(suiteLabel(diff.suite)) + "</td>",
+            "<td>" + escapeHtml(runLaneLabel(diff)) + "</td>",
             "<td>" + escapeHtml(diff.scenarioId) + "</td>",
             "<td>" + escapeHtml(diff.descriptor.label) + "</td>",
             '<td class="num ' + diff.deltaClass + '"' + inlineStyleAttr(diff.deltaStyle) + inlineTitleAttr(deltaTooltip(diff)) + ">" + escapeHtml(formatPct(diff.deltaPct)) + "</td>",

--- a/benchmarks/realistic/ci_benchmarks.mjs
+++ b/benchmarks/realistic/ci_benchmarks.mjs
@@ -3,12 +3,18 @@ import fs from "node:fs";
 export const DEFAULT_BENCHMARK_TIMEOUT_SECONDS = 60;
 export const DEFAULT_NOISE_REPEAT_COUNT = 3;
 
-export const NATIVE_BENCHMARKS = [
+export const NATIVE_STORAGE_ENGINES = ["rocksdb", "sqlite"];
+
+function nativeStorageEngineLabel(storageEngine) {
+  if (storageEngine === "rocksdb") return "RocksDB";
+  if (storageEngine === "sqlite") return "SQLite";
+  return storageEngine;
+}
+
+const NATIVE_EXAMPLE_SCENARIOS = [
   {
-    id: "native:w1_interactive",
-    suite: "native",
+    id: "w1_interactive",
     label: "W1 (interactive)",
-    kind: "native-example",
     output_path: "w1_interactive.json",
     log_path: "logs/w1_interactive.log",
     scenario_path: "benchmarks/realistic/ci/scenarios/w1_interactive.json",
@@ -16,149 +22,141 @@ export const NATIVE_BENCHMARKS = [
     prepare_seed: true,
   },
   {
-    id: "native:w4_cold_start",
-    suite: "native",
+    id: "w4_cold_start",
     label: "W4 (cold start)",
-    kind: "native-example",
     output_path: "w4_cold_start.json",
     log_path: "logs/w4_cold_start.log",
     scenario_path: "benchmarks/realistic/ci/scenarios/w4_cold_start.json",
     profile_path: "benchmarks/realistic/ci/profiles/s.json",
     prepare_seed: true,
   },
+];
+
+const NATIVE_CRITERION_SCENARIOS = [
   {
-    id: "native-criterion:r1_crud_sustained",
-    suite: "native",
+    id: "r1_crud_sustained",
     label: "Criterion R1 CRUD sustained",
-    kind: "criterion",
-    log_path: "logs/criterion_r1_crud_sustained.log",
-    criterion_filter: "realistic_phase1/crud_sustained/r1_s",
-    env: {
-      JAZZ_REALISTIC_VARIANT: "ci",
+    criterion_filter_by_engine: {
+      rocksdb: "realistic_phase1/crud_sustained_rocksdb",
+      sqlite: "realistic_phase1/crud_sustained_sqlite",
     },
   },
   {
-    id: "native-criterion:r1_crud_sustained_single_hop",
-    suite: "native",
+    id: "r1_crud_sustained_single_hop",
     label: "Criterion R1 CRUD single-hop",
-    kind: "criterion",
-    log_path: "logs/criterion_r1_crud_sustained_single_hop.log",
-    criterion_filter: "realistic_phase1/crud_sustained_single_hop",
-    env: {
-      JAZZ_REALISTIC_VARIANT: "ci",
+    criterion_filter_by_engine: {
+      rocksdb: "realistic_phase1/crud_sustained_single_hop_rocksdb",
+      sqlite: "realistic_phase1/crud_sustained_single_hop_sqlite",
     },
   },
   {
-    id: "native-criterion:r2_reads_sustained",
-    suite: "native",
+    id: "r2_reads_sustained",
     label: "Criterion R2 reads sustained",
-    kind: "criterion",
-    log_path: "logs/criterion_r2_reads_sustained.log",
-    criterion_filter: "realistic_phase1/reads_sustained/r2_s",
-    env: {
-      JAZZ_REALISTIC_VARIANT: "ci",
+    criterion_filter_by_engine: {
+      rocksdb: "realistic_phase1/reads_sustained_rocksdb",
+      sqlite: "realistic_phase1/reads_sustained_sqlite",
     },
   },
   {
-    id: "native-criterion:r2_reads_sustained_single_hop",
-    suite: "native",
+    id: "r2_reads_sustained_single_hop",
     label: "Criterion R2 reads single-hop",
-    kind: "criterion",
-    log_path: "logs/criterion_r2_reads_sustained_single_hop.log",
-    criterion_filter: "realistic_phase1/reads_sustained_single_hop",
-    env: {
-      JAZZ_REALISTIC_VARIANT: "ci",
+    criterion_filter_by_engine: {
+      rocksdb: "realistic_phase1/reads_sustained_single_hop_rocksdb",
+      sqlite: "realistic_phase1/reads_sustained_single_hop_sqlite",
     },
   },
   {
-    id: "native-criterion:r2_reads_with_write_churn",
-    suite: "native",
+    id: "r2_reads_with_write_churn",
     label: "Criterion R2 reads with churn",
-    kind: "criterion",
-    log_path: "logs/criterion_r2_reads_with_write_churn.log",
-    criterion_filter: "realistic_phase1/reads_sustained_with_write_churn",
-    env: {
-      JAZZ_REALISTIC_VARIANT: "ci",
+    criterion_filter_by_engine: {
+      rocksdb: "realistic_phase1/reads_sustained_with_write_churn_rocksdb",
+      sqlite: "realistic_phase1/reads_sustained_with_write_churn_sqlite",
     },
   },
   {
-    id: "native-criterion:r3_cold_load_rocksdb",
-    suite: "native",
-    label: "Criterion R3 cold-load RocksDB",
-    kind: "criterion",
-    log_path: "logs/criterion_r3_cold_load_rocksdb.log",
-    criterion_filter: "realistic_phase1/cold_load_rocksdb",
-    env: {
-      JAZZ_REALISTIC_VARIANT: "ci",
+    id: "r3_cold_load",
+    label: "Criterion R3 cold-load",
+    criterion_filter_by_engine: {
+      rocksdb: "realistic_phase1/cold_load_rocksdb",
+      sqlite: "realistic_phase1/cold_load_sqlite",
     },
   },
   {
-    id: "native-criterion:r4_fanout_updates",
-    suite: "native",
+    id: "r4_fanout_updates",
     label: "Criterion R4 fanout updates",
-    kind: "criterion",
-    log_path: "logs/criterion_r4_fanout_updates.log",
-    criterion_filter: "realistic_phase1/fanout_updates",
-    env: {
-      JAZZ_REALISTIC_VARIANT: "ci",
+    criterion_filter_by_engine: {
+      rocksdb: "realistic_phase1/fanout_updates_rocksdb",
+      sqlite: "realistic_phase1/fanout_updates_sqlite",
     },
   },
   {
-    id: "native-criterion:r5_permission_recursive",
-    suite: "native",
+    id: "r5_permission_recursive",
     label: "Criterion R5 permission recursive",
-    kind: "criterion",
-    log_path: "logs/criterion_r5_permission_recursive.log",
-    criterion_filter: "realistic_phase1/permission_recursive",
-    env: {
-      JAZZ_REALISTIC_VARIANT: "ci",
+    criterion_filter_by_engine: {
+      rocksdb: "realistic_phase1/permission_recursive_rocksdb",
+      sqlite: "realistic_phase1/permission_recursive_sqlite",
     },
   },
   {
-    id: "native-criterion:r6_permission_write_heavy",
-    suite: "native",
+    id: "r6_permission_write_heavy",
     label: "Criterion R6 permission write-heavy",
-    kind: "criterion",
-    log_path: "logs/criterion_r6_permission_write_heavy.log",
-    criterion_filter: "realistic_phase1/permission_write_heavy",
-    env: {
-      JAZZ_REALISTIC_VARIANT: "ci",
+    criterion_filter_by_engine: {
+      rocksdb: "realistic_phase1/permission_write_heavy_rocksdb",
+      sqlite: "realistic_phase1/permission_write_heavy_sqlite",
     },
   },
   {
-    id: "native-criterion:r7_hotspot_history",
-    suite: "native",
+    id: "r7_hotspot_history",
     label: "Criterion R7 hotspot history",
-    kind: "criterion",
-    log_path: "logs/criterion_r7_hotspot_history.log",
-    criterion_filter: "realistic_phase1/hotspot_history",
-    env: {
-      JAZZ_REALISTIC_VARIANT: "ci",
+    criterion_filter_by_engine: {
+      rocksdb: "realistic_phase1/hotspot_history_rocksdb",
+      sqlite: "realistic_phase1/hotspot_history_sqlite",
     },
   },
   {
-    id: "native-criterion:r8_many_branches",
-    suite: "native",
+    id: "r8_many_branches",
     label: "Criterion R8 many branches",
-    kind: "criterion",
-    log_path: "logs/criterion_r8_many_branches.log",
-    criterion_filter: "realistic_phase1/many_branches",
-    env: {
-      JAZZ_REALISTIC_VARIANT: "ci",
+    criterion_filter_by_engine: {
+      rocksdb: "realistic_phase1/many_branches_rocksdb",
+      sqlite: "realistic_phase1/many_branches_sqlite",
     },
   },
   {
-    id: "native-criterion:r9_subscribed_write_path",
-    suite: "native",
+    id: "r9_subscribed_write_path",
     label: "Criterion R9 subscribed write path",
-    kind: "criterion",
-    log_path: "logs/criterion_r9_subscribed_write_path.log",
-    criterion_filter: "realistic_phase1/subscribed_write_path",
-    env: {
-      JAZZ_REALISTIC_VARIANT: "ci",
+    criterion_filter_by_engine: {
+      rocksdb: "realistic_phase1/subscribed_write_path_rocksdb",
+      sqlite: "realistic_phase1/subscribed_write_path_sqlite",
     },
   },
 ];
+
+export const NATIVE_BENCHMARKS = NATIVE_STORAGE_ENGINES.flatMap((storage_engine) => [
+  ...NATIVE_EXAMPLE_SCENARIOS.map((scenario) => ({
+    id: `native:${storage_engine}:${scenario.id}`,
+    suite: "native",
+    storage_engine,
+    label: `${scenario.label} (${nativeStorageEngineLabel(storage_engine)})`,
+    kind: "native-example",
+    output_path: scenario.output_path,
+    log_path: scenario.log_path,
+    scenario_path: scenario.scenario_path,
+    profile_path: scenario.profile_path,
+    prepare_seed: scenario.prepare_seed,
+  })),
+  ...NATIVE_CRITERION_SCENARIOS.map((scenario) => ({
+    id: `native-criterion:${storage_engine}:${scenario.id}`,
+    suite: "native",
+    storage_engine,
+    label: `${scenario.label} (${nativeStorageEngineLabel(storage_engine)})`,
+    kind: "criterion",
+    log_path: `logs/criterion_${scenario.id}.log`,
+    criterion_filter: scenario.criterion_filter_by_engine[storage_engine],
+    env: {
+      JAZZ_REALISTIC_VARIANT: "ci",
+    },
+  })),
+]);
 
 export const BROWSER_BENCHMARKS = [
   {
@@ -235,8 +233,13 @@ export const BROWSER_BENCHMARKS = [
   },
 ];
 
-export function benchmarksForSuite(suite) {
-  if (suite === "native") return NATIVE_BENCHMARKS;
+export function benchmarksForSuite(suite, options = {}) {
+  if (suite === "native") {
+    if (!options.storageEngine) return NATIVE_BENCHMARKS;
+    return NATIVE_BENCHMARKS.filter(
+      (benchmark) => benchmark.storage_engine === options.storageEngine,
+    );
+  }
   if (suite === "browser") return BROWSER_BENCHMARKS;
   throw new Error(`Unsupported suite: ${suite}`);
 }

--- a/benchmarks/realistic/ci_benchmarks.test.mjs
+++ b/benchmarks/realistic/ci_benchmarks.test.mjs
@@ -6,27 +6,75 @@ import { NATIVE_BENCHMARKS } from "./ci_benchmarks.mjs";
 import {
   buildNativeCriterionCommand,
   buildNativeExampleBaseCommand,
-  NATIVE_CRITERION_FEATURES,
-  NATIVE_EXAMPLE_FEATURES,
+  NATIVE_CRITERION_FEATURES_BY_ENGINE,
+  NATIVE_EXAMPLE_FEATURES_BY_ENGINE,
 } from "./run_ci_benchmarks.mjs";
 
-test("native benchmark catalog targets RocksDB for the cold-load Criterion run", () => {
-  const benchmark = NATIVE_BENCHMARKS.find(
-    (entry) => entry.id === "native-criterion:r3_cold_load_rocksdb",
+test("native benchmark catalog defines RocksDB and SQLite variants for each native scenario", () => {
+  const ids = new Set(NATIVE_BENCHMARKS.map((entry) => entry.id));
+
+  assert.ok(ids.has("native:rocksdb:w1_interactive"));
+  assert.ok(ids.has("native:sqlite:w1_interactive"));
+  assert.ok(ids.has("native:rocksdb:w4_cold_start"));
+  assert.ok(ids.has("native:sqlite:w4_cold_start"));
+
+  assert.ok(ids.has("native-criterion:rocksdb:r1_crud_sustained"));
+  assert.ok(ids.has("native-criterion:sqlite:r1_crud_sustained"));
+  assert.ok(ids.has("native-criterion:rocksdb:r2_reads_sustained"));
+  assert.ok(ids.has("native-criterion:sqlite:r2_reads_sustained"));
+  assert.ok(ids.has("native-criterion:rocksdb:r3_cold_load"));
+  assert.ok(ids.has("native-criterion:sqlite:r3_cold_load"));
+  assert.ok(ids.has("native-criterion:rocksdb:r4_fanout_updates"));
+  assert.ok(ids.has("native-criterion:sqlite:r4_fanout_updates"));
+  assert.ok(ids.has("native-criterion:rocksdb:r5_permission_recursive"));
+  assert.ok(ids.has("native-criterion:sqlite:r5_permission_recursive"));
+  assert.ok(ids.has("native-criterion:rocksdb:r6_permission_write_heavy"));
+  assert.ok(ids.has("native-criterion:sqlite:r6_permission_write_heavy"));
+  assert.ok(ids.has("native-criterion:rocksdb:r7_hotspot_history"));
+  assert.ok(ids.has("native-criterion:sqlite:r7_hotspot_history"));
+  assert.ok(ids.has("native-criterion:rocksdb:r8_many_branches"));
+  assert.ok(ids.has("native-criterion:sqlite:r8_many_branches"));
+  assert.ok(ids.has("native-criterion:rocksdb:r9_subscribed_write_path"));
+  assert.ok(ids.has("native-criterion:sqlite:r9_subscribed_write_path"));
+});
+
+test("native benchmark catalog targets storage-backed engine-specific Criterion groups", () => {
+  const rocksdbCrud = NATIVE_BENCHMARKS.find(
+    (entry) => entry.id === "native-criterion:rocksdb:r1_crud_sustained",
+  );
+  const sqliteCrud = NATIVE_BENCHMARKS.find(
+    (entry) => entry.id === "native-criterion:sqlite:r1_crud_sustained",
+  );
+  const rocksdbColdLoad = NATIVE_BENCHMARKS.find(
+    (entry) => entry.id === "native-criterion:rocksdb:r3_cold_load",
+  );
+  const sqliteColdLoad = NATIVE_BENCHMARKS.find(
+    (entry) => entry.id === "native-criterion:sqlite:r3_cold_load",
   );
 
-  assert.ok(benchmark, "expected a RocksDB cold-load benchmark entry");
-  assert.equal(benchmark.label, "Criterion R3 cold-load RocksDB");
-  assert.equal(benchmark.log_path, "logs/criterion_r3_cold_load_rocksdb.log");
-  assert.equal(benchmark.criterion_filter, "realistic_phase1/cold_load_rocksdb");
+  assert.ok(rocksdbCrud, "expected RocksDB CRUD benchmark entry");
+  assert.equal(rocksdbCrud.storage_engine, "rocksdb");
+  assert.equal(rocksdbCrud.criterion_filter, "realistic_phase1/crud_sustained_rocksdb");
+
+  assert.ok(sqliteCrud, "expected SQLite CRUD benchmark entry");
+  assert.equal(sqliteCrud.storage_engine, "sqlite");
+  assert.equal(sqliteCrud.criterion_filter, "realistic_phase1/crud_sustained_sqlite");
+
+  assert.ok(rocksdbColdLoad, "expected RocksDB cold-load benchmark entry");
+  assert.equal(rocksdbColdLoad.criterion_filter, "realistic_phase1/cold_load_rocksdb");
+
+  assert.ok(sqliteColdLoad, "expected SQLite cold-load benchmark entry");
+  assert.equal(sqliteColdLoad.criterion_filter, "realistic_phase1/cold_load_sqlite");
 });
 
 test("native example command opts into the RocksDB storage backend", () => {
-  const benchmark = NATIVE_BENCHMARKS.find((entry) => entry.id === "native:w1_interactive");
-  assert.ok(benchmark, "expected the W1 native example benchmark");
+  const benchmark = NATIVE_BENCHMARKS.find(
+    (entry) => entry.id === "native:rocksdb:w1_interactive",
+  );
+  assert.ok(benchmark, "expected the RocksDB W1 native example benchmark");
 
   const command = buildNativeExampleBaseCommand(benchmark, { profile: "s" });
-  assert.equal(NATIVE_EXAMPLE_FEATURES, "client,rocksdb");
+  assert.equal(NATIVE_EXAMPLE_FEATURES_BY_ENGINE.rocksdb, "client,rocksdb");
   assert.deepEqual(command.slice(0, 8), [
     "cargo",
     "run",
@@ -39,14 +87,34 @@ test("native example command opts into the RocksDB storage backend", () => {
   ]);
 });
 
+test("native example command opts into the SQLite storage backend", () => {
+  const benchmark = NATIVE_BENCHMARKS.find(
+    (entry) => entry.id === "native:sqlite:w1_interactive",
+  );
+  assert.ok(benchmark, "expected the SQLite W1 native example benchmark");
+
+  const command = buildNativeExampleBaseCommand(benchmark, { profile: "s" });
+  assert.equal(NATIVE_EXAMPLE_FEATURES_BY_ENGINE.sqlite, "client,sqlite");
+  assert.deepEqual(command.slice(0, 8), [
+    "cargo",
+    "run",
+    "--release",
+    "-p",
+    "jazz-tools",
+    "--features",
+    "client,sqlite",
+    "--example",
+  ]);
+});
+
 test("native Criterion command opts into the RocksDB storage backend", () => {
   const benchmark = NATIVE_BENCHMARKS.find(
-    (entry) => entry.id === "native-criterion:r3_cold_load_rocksdb",
+    (entry) => entry.id === "native-criterion:rocksdb:r3_cold_load",
   );
-  assert.ok(benchmark, "expected the R3 native Criterion benchmark");
+  assert.ok(benchmark, "expected the RocksDB R3 native Criterion benchmark");
 
   const command = buildNativeCriterionCommand(benchmark);
-  assert.equal(NATIVE_CRITERION_FEATURES, "rocksdb");
+  assert.equal(NATIVE_CRITERION_FEATURES_BY_ENGINE.rocksdb, "rocksdb");
   assert.deepEqual(command, [
     "cargo",
     "bench",
@@ -61,7 +129,29 @@ test("native Criterion command opts into the RocksDB storage backend", () => {
   ]);
 });
 
-test("benchmark workflow prebuilds the RocksDB-backed native binaries", () => {
+test("native Criterion command opts into the SQLite storage backend", () => {
+  const benchmark = NATIVE_BENCHMARKS.find(
+    (entry) => entry.id === "native-criterion:sqlite:r3_cold_load",
+  );
+  assert.ok(benchmark, "expected the SQLite R3 native Criterion benchmark");
+
+  const command = buildNativeCriterionCommand(benchmark);
+  assert.equal(NATIVE_CRITERION_FEATURES_BY_ENGINE.sqlite, "sqlite");
+  assert.deepEqual(command, [
+    "cargo",
+    "bench",
+    "-p",
+    "jazz-tools",
+    "--features",
+    "sqlite",
+    "--bench",
+    "realistic_phase1",
+    "--",
+    "realistic_phase1/cold_load_sqlite",
+  ]);
+});
+
+test("benchmark workflow prebuilds the RocksDB-backed and SQLite-backed native binaries", () => {
   const workflow = readFileSync(
     new URL("../../.github/workflows/benchmarks.yml", import.meta.url),
     "utf8",
@@ -73,7 +163,15 @@ test("benchmark workflow prebuilds the RocksDB-backed native binaries", () => {
   );
   assert.match(
     workflow,
+    /cargo build --release -p jazz-tools --features client,sqlite --example realistic_bench/,
+  );
+  assert.match(
+    workflow,
     /cargo bench -p jazz-tools --features rocksdb --bench realistic_phase1 --no-run/,
+  );
+  assert.match(
+    workflow,
+    /cargo bench -p jazz-tools --features sqlite --bench realistic_phase1 --no-run/,
   );
 });
 

--- a/benchmarks/realistic/ci_benchmarks.test.mjs
+++ b/benchmarks/realistic/ci_benchmarks.test.mjs
@@ -68,9 +68,7 @@ test("native benchmark catalog targets storage-backed engine-specific Criterion 
 });
 
 test("native example command opts into the RocksDB storage backend", () => {
-  const benchmark = NATIVE_BENCHMARKS.find(
-    (entry) => entry.id === "native:rocksdb:w1_interactive",
-  );
+  const benchmark = NATIVE_BENCHMARKS.find((entry) => entry.id === "native:rocksdb:w1_interactive");
   assert.ok(benchmark, "expected the RocksDB W1 native example benchmark");
 
   const command = buildNativeExampleBaseCommand(benchmark, { profile: "s" });
@@ -88,9 +86,7 @@ test("native example command opts into the RocksDB storage backend", () => {
 });
 
 test("native example command opts into the SQLite storage backend", () => {
-  const benchmark = NATIVE_BENCHMARKS.find(
-    (entry) => entry.id === "native:sqlite:w1_interactive",
-  );
+  const benchmark = NATIVE_BENCHMARKS.find((entry) => entry.id === "native:sqlite:w1_interactive");
   assert.ok(benchmark, "expected the SQLite W1 native example benchmark");
 
   const command = buildNativeExampleBaseCommand(benchmark, { profile: "s" });

--- a/benchmarks/realistic/render_history_report.mjs
+++ b/benchmarks/realistic/render_history_report.mjs
@@ -210,8 +210,7 @@ function latestRun(runs, branch, suite, storageEngine, profile) {
         run.suite === suite &&
         (run.storage_engine ?? null) === (storageEngine ?? null) &&
         run.profile === profile,
-    ) ??
-    null
+    ) ?? null
   );
 }
 

--- a/benchmarks/realistic/render_history_report.mjs
+++ b/benchmarks/realistic/render_history_report.mjs
@@ -94,6 +94,13 @@ function scenarioLabel(scenario) {
   return parts.join(" / ");
 }
 
+function storageEngineLabel(storageEngine) {
+  if (storageEngine === "rocksdb") return "RocksDB";
+  if (storageEngine === "sqlite") return "SQLite";
+  if (storageEngine === "opfs-btree") return "OPFS-btree";
+  return storageEngine || "default";
+}
+
 function scenarioMap(run) {
   const map = new Map();
   for (const scenario of run?.scenarios ?? []) {
@@ -195,9 +202,15 @@ function fmtPct(value) {
   return `${sign}${fmt(Math.abs(value))}%`;
 }
 
-function latestRun(runs, branch, suite, profile) {
+function latestRun(runs, branch, suite, storageEngine, profile) {
   return (
-    runs.find((run) => run.branch === branch && run.suite === suite && run.profile === profile) ??
+    runs.find(
+      (run) =>
+        run.branch === branch &&
+        run.suite === suite &&
+        (run.storage_engine ?? null) === (storageEngine ?? null) &&
+        run.profile === profile,
+    ) ??
     null
   );
 }
@@ -269,7 +282,11 @@ function render(history, args) {
       (!profileFilter || run.profile === profileFilter),
   );
 
-  const suites = unique(candidateRuns.map((run) => run.suite).filter(Boolean)).sort();
+  const lanes = unique(
+    candidateRuns
+      .map((run) => [run.suite || "", run.storage_engine || ""].join("::"))
+      .filter(Boolean),
+  ).sort();
   const profiles = unique(candidateRuns.map((run) => run.profile).filter(Boolean)).sort();
 
   const sections = [];
@@ -282,15 +299,16 @@ function render(history, args) {
 
   let renderedComparisons = 0;
 
-  for (const suite of suites) {
+  for (const lane of lanes) {
+    const [suite, storageEngine] = lane.split("::");
     const suiteProfiles = profileFilter ? [profileFilter] : profiles.filter(Boolean);
     for (const profile of suiteProfiles) {
-      const baseRun = latestRun(runs, args.baseBranch, suite, profile);
-      const headRun = latestRun(runs, args.headBranch, suite, profile);
+      const baseRun = latestRun(runs, args.baseBranch, suite, storageEngine, profile);
+      const headRun = latestRun(runs, args.headBranch, suite, storageEngine, profile);
       if (!baseRun || !headRun) continue;
 
       const rows = comparableRows(baseRun, headRun);
-      sections.push(`## ${suite} / profile ${profile}`);
+      sections.push(`## ${suite} / ${storageEngineLabel(storageEngine)} / profile ${profile}`);
       sections.push(``);
       sections.push(
         `Base ${String(baseRun.sha ?? "").slice(0, 12)} (${baseRun.generated_at ?? "n/a"}) vs Head ${String(

--- a/benchmarks/realistic/run_ci_benchmarks.mjs
+++ b/benchmarks/realistic/run_ci_benchmarks.mjs
@@ -23,6 +23,7 @@ function printHelp() {
   node benchmarks/realistic/run_ci_benchmarks.mjs \\
     --suite native|browser \\
     --out-dir bench-out/native \\
+    [--storage-engine rocksdb|sqlite] \\
     [--profile s] \\
     [--skip-set benchmarks/realistic/ci_skip_set.json] \\
     [--repeat-count 3] \\
@@ -34,6 +35,7 @@ function parseArgs(argv) {
   const out = {
     suite: "",
     outDir: "",
+    storageEngine: "",
     profile: "s",
     skipSet: "benchmarks/realistic/ci_skip_set.json",
     repeatCount: DEFAULT_NOISE_REPEAT_COUNT,
@@ -49,6 +51,10 @@ function parseArgs(argv) {
     }
     if (arg === "--out-dir") {
       out.outDir = argv[++i] ?? "";
+      continue;
+    }
+    if (arg === "--storage-engine") {
+      out.storageEngine = argv[++i] ?? "";
       continue;
     }
     if (arg === "--profile") {
@@ -76,6 +82,12 @@ function parseArgs(argv) {
 
   if (!out.suite) fail("--suite is required");
   if (!out.outDir) fail("--out-dir is required");
+  if (out.suite === "native" && !["rocksdb", "sqlite"].includes(out.storageEngine)) {
+    fail("--storage-engine must be one of: rocksdb, sqlite");
+  }
+  if (out.suite === "browser" && out.storageEngine && out.storageEngine !== "opfs-btree") {
+    fail("--storage-engine is only supported for native suites");
+  }
   if (!Number.isFinite(out.timeoutSeconds) || out.timeoutSeconds < 1) {
     fail("--timeout-seconds must be a number >= 1");
   }
@@ -429,6 +441,7 @@ function summarizeBenchmark(benchmark, status, durationMs, extra = {}) {
   return {
     id: benchmark.id,
     suite: benchmark.suite,
+    storage_engine: benchmark.storage_engine ?? null,
     label: benchmark.label,
     kind: benchmark.kind,
     status,
@@ -443,10 +456,28 @@ function stripAnsi(value) {
 
 export const NATIVE_EXAMPLE_FEATURES = "client,rocksdb";
 export const NATIVE_CRITERION_FEATURES = "rocksdb";
+export const NATIVE_EXAMPLE_FEATURES_BY_ENGINE = {
+  rocksdb: "client,rocksdb",
+  sqlite: "client,sqlite",
+};
+export const NATIVE_CRITERION_FEATURES_BY_ENGINE = {
+  rocksdb: "rocksdb",
+  sqlite: "sqlite",
+};
+
+function nativeStorageEngine(benchmark, args = {}) {
+  return benchmark?.storage_engine ?? args.storageEngine ?? "";
+}
 
 export function buildNativeExampleBaseCommand(benchmark, args) {
   const profilePath =
     benchmark.profile_path ?? `benchmarks/realistic/profiles/${args.profile}.json`;
+  const features = NATIVE_EXAMPLE_FEATURES_BY_ENGINE[nativeStorageEngine(benchmark, args)];
+  if (!features) {
+    throw new Error(
+      `Unsupported native example storage engine: ${nativeStorageEngine(benchmark, args)}`,
+    );
+  }
 
   return [
     "cargo",
@@ -455,7 +486,7 @@ export function buildNativeExampleBaseCommand(benchmark, args) {
     "-p",
     "jazz-tools",
     "--features",
-    NATIVE_EXAMPLE_FEATURES,
+    features,
     "--example",
     "realistic_bench",
     "--",
@@ -467,13 +498,19 @@ export function buildNativeExampleBaseCommand(benchmark, args) {
 }
 
 export function buildNativeCriterionCommand(benchmark) {
+  const features = NATIVE_CRITERION_FEATURES_BY_ENGINE[nativeStorageEngine(benchmark)];
+  if (!features) {
+    throw new Error(
+      `Unsupported native Criterion storage engine: ${nativeStorageEngine(benchmark)}`,
+    );
+  }
   return [
     "cargo",
     "bench",
     "-p",
     "jazz-tools",
     "--features",
-    NATIVE_CRITERION_FEATURES,
+    features,
     "--bench",
     "realistic_phase1",
     "--",
@@ -800,10 +837,12 @@ function countByStatus(results) {
   return counts;
 }
 
-function summaryMarkdown(suite, results, timeoutSeconds, repeatCount) {
+function summaryMarkdown(suite, results, timeoutSeconds, repeatCount, storageEngine = "") {
   const counts = countByStatus(results);
   const lines = [];
-  lines.push(`## ${suite === "native" ? "Native" : "Browser"} benchmark status`);
+  const suiteTitle = suite === "native" ? "Native" : "Browser";
+  const storageSuffix = storageEngine ? ` (${storageEngine})` : "";
+  lines.push(`## ${suiteTitle}${storageSuffix} benchmark status`);
   lines.push("");
   lines.push(`Budget per benchmark: ${timeoutSeconds}s`);
   lines.push(`Repeated scenario benchmarks: ${repeatCount}x`);
@@ -845,7 +884,7 @@ async function main() {
 
   const skipSet = readSkipSet(path.resolve(args.skipSet));
   const skipIdSet = skipIds(skipSet);
-  const catalog = benchmarksForSuite(args.suite);
+  const catalog = benchmarksForSuite(args.suite, { storageEngine: args.storageEngine });
   const results = [];
 
   for (const benchmark of catalog) {
@@ -875,6 +914,7 @@ async function main() {
     version: 1,
     generated_at: generatedAt,
     suite: args.suite,
+    storage_engine: args.suite === "browser" ? "opfs-btree" : args.storageEngine,
     profile: args.profile,
     repeat_count: args.repeatCount,
     timeout_seconds: args.timeoutSeconds,
@@ -883,12 +923,19 @@ async function main() {
   writeJson(statusFile, statusPayload);
   fs.writeFileSync(
     summaryFile,
-    summaryMarkdown(args.suite, results, args.timeoutSeconds, args.repeatCount),
+    summaryMarkdown(
+      args.suite,
+      results,
+      args.timeoutSeconds,
+      args.repeatCount,
+      args.suite === "browser" ? "opfs-btree" : args.storageEngine,
+    ),
   );
   writeJson(skipCandidatesFile, {
     version: 1,
     generated_at: generatedAt,
     suite: args.suite,
+    storage_engine: args.suite === "browser" ? "opfs-btree" : args.storageEngine,
     timeout_seconds: args.timeoutSeconds,
     benchmark_ids: results
       .filter((result) => result.status === "timed_out")
@@ -903,6 +950,7 @@ async function main() {
       runner: "jazz-ts-browser-opfs",
       generated_at: generatedAt,
       profile: args.profile,
+      storage_engine: "opfs-btree",
       scenarios,
       benchmark_statuses: results.map(({ scenario, ...rest }) => rest),
     });

--- a/benchmarks/realistic/update_history.mjs
+++ b/benchmarks/realistic/update_history.mjs
@@ -97,6 +97,50 @@ function resolveBranch(metadata, manifest, fallbackRef) {
   return firstNonEmptyString(metadata?.branch, manifest?.branch) ?? toBranch(fallbackRef);
 }
 
+function normalizeStorageEngine(value) {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim().toLowerCase();
+  return normalized.length > 0 ? normalized : null;
+}
+
+function resolveStorageEngine(...values) {
+  for (const value of values) {
+    const normalized = normalizeStorageEngine(value);
+    if (normalized) return normalized;
+  }
+  return null;
+}
+
+function hasBenchmarkFiles(dir) {
+  if (!dir || !fs.existsSync(dir)) return false;
+  for (const file of [
+    "metadata.json",
+    "manifest.json",
+    "suite_status.json",
+    "realistic.json",
+    "criterion_realistic_phase1.json",
+  ]) {
+    if (fs.existsSync(path.join(dir, file))) return true;
+  }
+  return false;
+}
+
+function artifactDirs(rootDir) {
+  if (!rootDir || !fs.existsSync(rootDir)) return [];
+  const dirs = [];
+  if (hasBenchmarkFiles(rootDir)) dirs.push(rootDir);
+  for (const entry of fs.readdirSync(rootDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const dir = path.join(rootDir, entry.name);
+    if (hasBenchmarkFiles(dir)) dirs.push(dir);
+  }
+  return dirs;
+}
+
+function storageEngineFromDir(dir) {
+  return resolveStorageEngine(path.basename(dir));
+}
+
 function scenarioSummary(scenario) {
   return {
     scenario_id: scenario.scenario_id,
@@ -178,46 +222,83 @@ function passedBenchmarkIds(status) {
   );
 }
 
-function nativeBenchmarkIdForFile(file) {
-  if (file === "w1_interactive.json") return "native:w1_interactive";
-  if (file === "w4_cold_start.json") return "native:w4_cold_start";
+function nativeBenchmarkIdForFile(file, storageEngine) {
+  if (file === "w1_interactive.json") return `native:${storageEngine}:w1_interactive`;
+  if (file === "w4_cold_start.json") return `native:${storageEngine}:w4_cold_start`;
   return null;
 }
 
 function criterionBenchmarkId(benchmark) {
   const groupId = benchmark?.group_id;
-  if (groupId === "realistic_phase1/crud_sustained") {
-    return "native-criterion:r1_crud_sustained";
+  const exactMap = new Map([
+    ["realistic_phase1/crud_sustained_rocksdb", "native-criterion:rocksdb:r1_crud_sustained"],
+    ["realistic_phase1/crud_sustained_sqlite", "native-criterion:sqlite:r1_crud_sustained"],
+    [
+      "realistic_phase1/crud_sustained_single_hop_rocksdb",
+      "native-criterion:rocksdb:r1_crud_sustained_single_hop",
+    ],
+    [
+      "realistic_phase1/crud_sustained_single_hop_sqlite",
+      "native-criterion:sqlite:r1_crud_sustained_single_hop",
+    ],
+    ["realistic_phase1/reads_sustained_rocksdb", "native-criterion:rocksdb:r2_reads_sustained"],
+    ["realistic_phase1/reads_sustained_sqlite", "native-criterion:sqlite:r2_reads_sustained"],
+    [
+      "realistic_phase1/reads_sustained_single_hop_rocksdb",
+      "native-criterion:rocksdb:r2_reads_sustained_single_hop",
+    ],
+    [
+      "realistic_phase1/reads_sustained_single_hop_sqlite",
+      "native-criterion:sqlite:r2_reads_sustained_single_hop",
+    ],
+    [
+      "realistic_phase1/reads_sustained_with_write_churn_rocksdb",
+      "native-criterion:rocksdb:r2_reads_with_write_churn",
+    ],
+    [
+      "realistic_phase1/reads_sustained_with_write_churn_sqlite",
+      "native-criterion:sqlite:r2_reads_with_write_churn",
+    ],
+    ["realistic_phase1/cold_load_rocksdb", "native-criterion:rocksdb:r3_cold_load"],
+    ["realistic_phase1/cold_load_sqlite", "native-criterion:sqlite:r3_cold_load"],
+    ["realistic_phase1/fanout_updates_rocksdb", "native-criterion:rocksdb:r4_fanout_updates"],
+    ["realistic_phase1/fanout_updates_sqlite", "native-criterion:sqlite:r4_fanout_updates"],
+    [
+      "realistic_phase1/permission_recursive_rocksdb",
+      "native-criterion:rocksdb:r5_permission_recursive",
+    ],
+    [
+      "realistic_phase1/permission_recursive_sqlite",
+      "native-criterion:sqlite:r5_permission_recursive",
+    ],
+    [
+      "realistic_phase1/permission_write_heavy_rocksdb",
+      "native-criterion:rocksdb:r6_permission_write_heavy",
+    ],
+    [
+      "realistic_phase1/permission_write_heavy_sqlite",
+      "native-criterion:sqlite:r6_permission_write_heavy",
+    ],
+    ["realistic_phase1/hotspot_history_rocksdb", "native-criterion:rocksdb:r7_hotspot_history"],
+    ["realistic_phase1/hotspot_history_sqlite", "native-criterion:sqlite:r7_hotspot_history"],
+    [
+      "realistic_phase1/subscribed_write_path_rocksdb",
+      "native-criterion:rocksdb:r9_subscribed_write_path",
+    ],
+    [
+      "realistic_phase1/subscribed_write_path_sqlite",
+      "native-criterion:sqlite:r9_subscribed_write_path",
+    ],
+  ]);
+
+  if (exactMap.has(groupId)) {
+    return exactMap.get(groupId);
   }
-  if (groupId === "realistic_phase1/crud_sustained_single_hop") {
-    return "native-criterion:r1_crud_sustained_single_hop";
+  if (typeof groupId === "string" && groupId.startsWith("realistic_phase1/many_branches_rocksdb")) {
+    return "native-criterion:rocksdb:r8_many_branches";
   }
-  if (groupId === "realistic_phase1/reads_sustained") {
-    return "native-criterion:r2_reads_sustained";
-  }
-  if (groupId === "realistic_phase1/reads_sustained_single_hop") {
-    return "native-criterion:r2_reads_sustained_single_hop";
-  }
-  if (groupId === "realistic_phase1/reads_sustained_with_write_churn") {
-    return "native-criterion:r2_reads_with_write_churn";
-  }
-  if (groupId === "realistic_phase1/cold_load_rocksdb") {
-    return "native-criterion:r3_cold_load_rocksdb";
-  }
-  if (groupId === "realistic_phase1/fanout_updates") {
-    return "native-criterion:r4_fanout_updates";
-  }
-  if (groupId === "realistic_phase1/permission_recursive") {
-    return "native-criterion:r5_permission_recursive";
-  }
-  if (groupId === "realistic_phase1/permission_write_heavy") {
-    return "native-criterion:r6_permission_write_heavy";
-  }
-  if (groupId === "realistic_phase1/hotspot_history") {
-    return "native-criterion:r7_hotspot_history";
-  }
-  if (groupId === "realistic_phase1/subscribed_write_path") {
-    return "native-criterion:r9_subscribed_write_path";
+  if (typeof groupId === "string" && groupId.startsWith("realistic_phase1/many_branches_sqlite")) {
+    return "native-criterion:sqlite:r8_many_branches";
   }
   return null;
 }
@@ -229,10 +310,16 @@ function extractNative(nativeDir) {
   const metadata = readJsonIfExists(path.join(nativeDir, "metadata.json")) ?? {};
   const manifest = readJsonIfExists(path.join(nativeDir, "manifest.json")) ?? {};
   const suiteStatus = readJsonIfExists(path.join(nativeDir, "suite_status.json")) ?? {};
+  const storageEngine = resolveStorageEngine(
+    metadata?.storage_engine,
+    manifest?.storage_engine,
+    storageEngineFromDir(nativeDir),
+  );
+  if (!storageEngine) return [];
   const passedIds = passedBenchmarkIds(suiteStatus);
   const scenarios = [];
   for (const file of ["w1_interactive.json", "w4_cold_start.json"]) {
-    const benchmarkId = nativeBenchmarkIdForFile(file);
+    const benchmarkId = nativeBenchmarkIdForFile(file, storageEngine);
     if (passedIds.size > 0 && benchmarkId && !passedIds.has(benchmarkId)) {
       continue;
     }
@@ -251,12 +338,14 @@ function extractNative(nativeDir) {
     {
       id: buildRunId([
         "native",
+        storageEngine,
         metadata.run_id,
         metadata.run_attempt,
         metadata.sha,
         metadata.profile,
       ]),
       suite: "native",
+      storage_engine: storageEngine,
       generated_at: generatedAt,
       repository: metadata.repository ?? manifest.repository ?? null,
       run_id: metadata.run_id ?? manifest.run_id ?? null,
@@ -283,6 +372,13 @@ function extractNativeCriterion(nativeDir) {
   const passedIds = passedBenchmarkIds(suiteStatus);
   const criterion = readJsonIfExists(path.join(nativeDir, "criterion_realistic_phase1.json"));
   if (!criterion || !Array.isArray(criterion.benchmarks)) return [];
+  const storageEngine = resolveStorageEngine(
+    metadata?.storage_engine,
+    manifest?.storage_engine,
+    criterion?.storage_engine,
+    storageEngineFromDir(nativeDir),
+  );
+  if (!storageEngine) return [];
 
   const scenarios = criterion.benchmarks
     .filter((x) => x && typeof x === "object" && typeof x.full_id === "string")
@@ -304,12 +400,14 @@ function extractNativeCriterion(nativeDir) {
     {
       id: buildRunId([
         "native-criterion",
+        storageEngine,
         metadata.run_id,
         metadata.run_attempt,
         metadata.sha,
         metadata.profile,
       ]),
       suite: "native-criterion",
+      storage_engine: storageEngine,
       generated_at: generatedAt,
       repository: metadata.repository ?? manifest.repository ?? null,
       run_id: metadata.run_id ?? manifest.run_id ?? null,
@@ -334,6 +432,12 @@ function extractBrowser(browserDir) {
   const manifest = readJsonIfExists(path.join(browserDir, "manifest.json")) ?? {};
   const realistic = readJsonIfExists(path.join(browserDir, "realistic.json"));
   if (!realistic || !Array.isArray(realistic.scenarios)) return [];
+  const storageEngine =
+    resolveStorageEngine(
+      metadata?.storage_engine,
+      manifest?.storage_engine,
+      realistic?.storage_engine,
+    ) ?? "opfs-btree";
 
   const scenarios = realistic.scenarios
     .filter((x) => x && typeof x === "object" && typeof x.scenario_id === "string")
@@ -350,12 +454,14 @@ function extractBrowser(browserDir) {
     {
       id: buildRunId([
         "browser",
+        storageEngine,
         metadata.run_id,
         metadata.run_attempt,
         metadata.sha,
         metadata.profile,
       ]),
       suite: "browser",
+      storage_engine: storageEngine,
       generated_at: generatedAt,
       repository: metadata.repository ?? manifest.repository ?? null,
       run_id: metadata.run_id ?? manifest.run_id ?? null,
@@ -385,10 +491,11 @@ function main() {
   };
   if (!Array.isArray(existing.runs)) existing.runs = [];
 
+  const nativeDirs = artifactDirs(path.resolve(args.native || ""));
+  const browserDirs = artifactDirs(path.resolve(args.browser || ""));
   const incoming = [
-    ...extractNative(path.resolve(args.native || "")),
-    ...extractNativeCriterion(path.resolve(args.native || "")),
-    ...extractBrowser(path.resolve(args.browser || "")),
+    ...nativeDirs.flatMap((dir) => [...extractNative(dir), ...extractNativeCriterion(dir)]),
+    ...browserDirs.flatMap((dir) => extractBrowser(dir)),
   ];
   if (incoming.length === 0) {
     console.log("No benchmark inputs found; history unchanged.");

--- a/benchmarks/realistic/update_history.test.mjs
+++ b/benchmarks/realistic/update_history.test.mjs
@@ -161,10 +161,22 @@ test("update_history ingests engine-specific native and browser manifests from a
     ],
   });
 
-  execFileSync("node", ["benchmarks/realistic/update_history.mjs", "--history", historyPath, "--native", nativeRoot, "--browser", browserRoot], {
-    cwd: "/Users/anselm/.codex/worktrees/25dc/jazz2",
-    stdio: "pipe",
-  });
+  execFileSync(
+    "node",
+    [
+      "benchmarks/realistic/update_history.mjs",
+      "--history",
+      historyPath,
+      "--native",
+      nativeRoot,
+      "--browser",
+      browserRoot,
+    ],
+    {
+      cwd: "/Users/anselm/.codex/worktrees/25dc/jazz2",
+      stdio: "pipe",
+    },
+  );
 
   const history = readJson(historyPath);
   const runKeys = history.runs.map((run) => [run.suite, run.storage_engine]);

--- a/benchmarks/realistic/update_history.test.mjs
+++ b/benchmarks/realistic/update_history.test.mjs
@@ -1,0 +1,202 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+
+function writeJson(file, value) {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function readJson(file) {
+  return JSON.parse(fs.readFileSync(file, "utf8"));
+}
+
+test("update_history ingests engine-specific native and browser manifests from artifact roots", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "jazz-bench-history-"));
+  const historyPath = path.join(tempRoot, "history.json");
+  const nativeRoot = path.join(tempRoot, "native");
+  const browserRoot = path.join(tempRoot, "browser");
+
+  const nativeRocksdbDir = path.join(nativeRoot, "rocksdb");
+  writeJson(path.join(nativeRocksdbDir, "metadata.json"), {
+    repository: "garden-co/jazz2",
+    run_id: "100",
+    run_attempt: "1",
+    sha: "abc123",
+    ref: "refs/heads/main",
+    branch: "main",
+    profile: "s",
+    storage_engine: "rocksdb",
+  });
+  writeJson(path.join(nativeRocksdbDir, "manifest.json"), {
+    kind: "realistic-bench-native",
+    generated_at: "2026-04-08T10:00:00Z",
+    storage_engine: "rocksdb",
+  });
+  writeJson(path.join(nativeRocksdbDir, "suite_status.json"), {
+    benchmarks: [
+      { id: "native:rocksdb:w4_cold_start", status: "passed" },
+      { id: "native-criterion:rocksdb:r1_crud_sustained", status: "passed" },
+    ],
+  });
+  writeJson(path.join(nativeRocksdbDir, "w4_cold_start.json"), {
+    scenario_id: "W4",
+    scenario_name: "cold_start_reopen",
+    topology: "local_only",
+    total_operations: 150,
+    wall_time_ms: 1000,
+    throughput_ops_per_sec: 150,
+    operation_summaries: {},
+    extra: {},
+  });
+  writeJson(path.join(nativeRocksdbDir, "criterion_realistic_phase1.json"), {
+    generated_at: "2026-04-08T10:00:00Z",
+    benchmarks: [
+      {
+        full_id: "realistic_phase1/crud_sustained_rocksdb/r1_s_rocksdb",
+        group_id: "realistic_phase1/crud_sustained_rocksdb",
+        benchmark_id: "r1_s_rocksdb",
+        throughput_elements: 100,
+        scenario_id: "R1",
+        scenario_name: "crud",
+        metrics: {
+          mean_ms: 12,
+          mean_ci_low_ms: 11,
+          mean_ci_high_ms: 13,
+          elems_per_sec: 1000,
+          elems_per_sec_ci_low: 900,
+          elems_per_sec_ci_high: 1100,
+        },
+      },
+    ],
+  });
+
+  const nativeSqliteDir = path.join(nativeRoot, "sqlite");
+  writeJson(path.join(nativeSqliteDir, "metadata.json"), {
+    repository: "garden-co/jazz2",
+    run_id: "100",
+    run_attempt: "1",
+    sha: "abc123",
+    ref: "refs/heads/main",
+    branch: "main",
+    profile: "s",
+    storage_engine: "sqlite",
+  });
+  writeJson(path.join(nativeSqliteDir, "manifest.json"), {
+    kind: "realistic-bench-native",
+    generated_at: "2026-04-08T10:00:00Z",
+    storage_engine: "sqlite",
+  });
+  writeJson(path.join(nativeSqliteDir, "suite_status.json"), {
+    benchmarks: [
+      { id: "native:sqlite:w4_cold_start", status: "passed" },
+      { id: "native-criterion:sqlite:r1_crud_sustained", status: "passed" },
+    ],
+  });
+  writeJson(path.join(nativeSqliteDir, "w4_cold_start.json"), {
+    scenario_id: "W4",
+    scenario_name: "cold_start_reopen",
+    topology: "local_only",
+    total_operations: 150,
+    wall_time_ms: 1100,
+    throughput_ops_per_sec: 136,
+    operation_summaries: {},
+    extra: {},
+  });
+  writeJson(path.join(nativeSqliteDir, "criterion_realistic_phase1.json"), {
+    generated_at: "2026-04-08T10:00:00Z",
+    benchmarks: [
+      {
+        full_id: "realistic_phase1/crud_sustained_sqlite/r1_s_sqlite",
+        group_id: "realistic_phase1/crud_sustained_sqlite",
+        benchmark_id: "r1_s_sqlite",
+        throughput_elements: 100,
+        scenario_id: "R1",
+        scenario_name: "crud",
+        metrics: {
+          mean_ms: 15,
+          mean_ci_low_ms: 14,
+          mean_ci_high_ms: 16,
+          elems_per_sec: 800,
+          elems_per_sec_ci_low: 760,
+          elems_per_sec_ci_high: 840,
+        },
+      },
+    ],
+  });
+
+  writeJson(path.join(browserRoot, "metadata.json"), {
+    repository: "garden-co/jazz2",
+    run_id: "100",
+    run_attempt: "1",
+    sha: "abc123",
+    ref: "refs/heads/main",
+    branch: "main",
+    profile: "s",
+    storage_engine: "opfs-btree",
+  });
+  writeJson(path.join(browserRoot, "manifest.json"), {
+    kind: "realistic-bench-browser",
+    generated_at: "2026-04-08T10:00:00Z",
+    storage_engine: "opfs-btree",
+  });
+  writeJson(path.join(browserRoot, "realistic.json"), {
+    generated_at: "2026-04-08T10:00:00Z",
+    profile: "s",
+    storage_engine: "opfs-btree",
+    scenarios: [
+      {
+        scenario_id: "W4",
+        scenario_name: "cold_start_reopen",
+        topology: "local_only",
+        total_operations: 25,
+        wall_time_ms: 2000,
+        throughput_ops_per_sec: 12,
+        operation_summaries: {},
+        extra: {},
+      },
+    ],
+  });
+
+  execFileSync("node", ["benchmarks/realistic/update_history.mjs", "--history", historyPath, "--native", nativeRoot, "--browser", browserRoot], {
+    cwd: "/Users/anselm/.codex/worktrees/25dc/jazz2",
+    stdio: "pipe",
+  });
+
+  const history = readJson(historyPath);
+  const runKeys = history.runs.map((run) => [run.suite, run.storage_engine]);
+
+  assert.deepEqual(runKeys, [
+    ["native", "rocksdb"],
+    ["native-criterion", "rocksdb"],
+    ["native", "sqlite"],
+    ["native-criterion", "sqlite"],
+    ["browser", "opfs-btree"],
+  ]);
+
+  const nativeRocksdbRun = history.runs.find(
+    (run) => run.suite === "native" && run.storage_engine === "rocksdb",
+  );
+  const nativeSqliteCriterionRun = history.runs.find(
+    (run) => run.suite === "native-criterion" && run.storage_engine === "sqlite",
+  );
+  const browserRun = history.runs.find(
+    (run) => run.suite === "browser" && run.storage_engine === "opfs-btree",
+  );
+
+  assert.ok(nativeRocksdbRun, "expected native RocksDB run");
+  assert.equal(nativeRocksdbRun.id, "native:rocksdb:100:1:abc123:s");
+
+  assert.ok(nativeSqliteCriterionRun, "expected native criterion SQLite run");
+  assert.equal(nativeSqliteCriterionRun.id, "native-criterion:sqlite:100:1:abc123:s");
+  assert.equal(
+    nativeSqliteCriterionRun.scenarios[0].topology,
+    "realistic_phase1/crud_sustained_sqlite",
+  );
+
+  assert.ok(browserRun, "expected browser OPFS-btree run");
+  assert.equal(browserRun.id, "browser:opfs-btree:100:1:abc123:s");
+});

--- a/crates/jazz-tools/benches/common/schema.rs
+++ b/crates/jazz-tools/benches/common/schema.rs
@@ -15,10 +15,10 @@ use jazz_tools::query_manager::types::{
 };
 use jazz_tools::runtime_core::{NoopScheduler, RuntimeCore, VecSyncSender};
 use jazz_tools::schema_manager::{AppId, SchemaManager};
-use jazz_tools::storage::MemoryStorage;
+use jazz_tools::storage::{MemoryStorage, Storage};
 use jazz_tools::sync_manager::SyncManager;
 
-pub type BenchRuntime = RuntimeCore<MemoryStorage, NoopScheduler, VecSyncSender>;
+pub type BenchRuntime<S = MemoryStorage> = RuntimeCore<S, NoopScheduler, VecSyncSender>;
 
 fn row<const N: usize>(pairs: [(&str, Value); N]) -> HashMap<String, Value> {
     pairs
@@ -120,7 +120,11 @@ pub struct BenchmarkData {
 /// - 100_000 documents: 1000 teams, 10000 folders
 ///
 /// The session user owns 10% of teams and authors 50% of documents.
-pub fn setup_data(core: &mut BenchRuntime, scale: usize, user_id: &str) -> BenchmarkData {
+pub fn setup_data<S: Storage>(
+    core: &mut BenchRuntime<S>,
+    scale: usize,
+    user_id: &str,
+) -> BenchmarkData {
     let (num_teams, num_folders) = match scale {
         10_000 => (100, 1000),
         100_000 => (1000, 10000),
@@ -257,11 +261,7 @@ pub fn create_session(user_id: &str) -> Session {
     Session::new(user_id)
 }
 
-/// Create a new RuntimeCore with MemoryStorage for benchmarking.
-///
-/// Uses MemoryStorage which drops all storage requests, allowing
-/// benchmarks to measure pure in-memory performance without storage overhead.
-pub fn create_runtime() -> BenchRuntime {
+pub fn create_runtime_with_storage<S: Storage>(storage: S) -> BenchRuntime<S> {
     let sync_manager = SyncManager::new();
     let schema = create_schema();
     let schema_manager = SchemaManager::new(
@@ -272,12 +272,15 @@ pub fn create_runtime() -> BenchRuntime {
         "main",
     )
     .expect("schema manager");
-    RuntimeCore::new(
-        schema_manager,
-        MemoryStorage::new(),
-        NoopScheduler,
-        VecSyncSender::new(),
-    )
+    RuntimeCore::new(schema_manager, storage, NoopScheduler, VecSyncSender::new())
+}
+
+/// Create a new RuntimeCore with MemoryStorage for benchmarking.
+///
+/// Uses MemoryStorage which drops all storage requests, allowing
+/// benchmarks to measure pure in-memory performance without storage overhead.
+pub fn create_runtime() -> BenchRuntime {
+    create_runtime_with_storage(MemoryStorage::new())
 }
 
 /// Get the current timestamp in microseconds.

--- a/crates/jazz-tools/benches/realistic_phase1.rs
+++ b/crates/jazz-tools/benches/realistic_phase1.rs
@@ -48,8 +48,10 @@ use serde::Deserialize;
 ))]
 use tempfile::TempDir;
 
-type BenchRuntime = RuntimeCore<MemoryStorage, NoopScheduler, VecSyncSender>;
+type BenchRuntime<S = MemoryStorage> = RuntimeCore<S, NoopScheduler, VecSyncSender>;
 const OBSERVER_BENCH_USER_ID: &str = "benchmark_user";
+#[cfg(all(feature = "rocksdb", not(target_arch = "wasm32")))]
+const STORAGE_BENCH_CACHE_SIZE_BYTES: usize = 32 * 1024 * 1024;
 
 fn row<const N: usize>(pairs: [(&str, Value); N]) -> HashMap<String, Value> {
     pairs
@@ -205,6 +207,7 @@ struct R3Scenario {
     id: String,
     seed: u64,
     profile_path: String,
+    #[allow(dead_code)]
     cache_size_bytes: usize,
     target_project_index: usize,
 }
@@ -258,6 +261,7 @@ struct R8Scenario {
         all(feature = "rocksdb", not(target_arch = "wasm32")),
         all(feature = "sqlite", not(target_arch = "wasm32"))
     ))]
+    #[allow(dead_code)]
     cache_size_bytes: usize,
 }
 
@@ -353,26 +357,26 @@ struct R1State<S: Storage = MemoryStorage> {
     min_task_floor: usize,
 }
 
-struct SingleHopR1State {
-    client: R1State,
-    server: BenchRuntime,
+struct SingleHopR1State<S: Storage = MemoryStorage> {
+    client: R1State<S>,
+    server: BenchRuntime<S>,
     client_id_on_server: ClientId,
     server_id_on_client: ServerId,
     total_routed_messages: usize,
 }
 
-struct FanoutReader {
-    runtime: BenchRuntime,
+struct FanoutReader<S: Storage = MemoryStorage> {
+    runtime: BenchRuntime<S>,
     client_id_on_server: ClientId,
     server_id_on_client: ServerId,
 }
 
-struct FanoutR4State {
-    writer: R1State,
-    server: BenchRuntime,
+struct FanoutR4State<S: Storage = MemoryStorage> {
+    writer: R1State<S>,
+    server: BenchRuntime<S>,
     writer_client_id_on_server: ClientId,
     writer_server_id_on_client: ServerId,
-    readers: Vec<FanoutReader>,
+    readers: Vec<FanoutReader<S>>,
     hot_task_ids: Vec<ObjectId>,
     hot_task_cursor: usize,
     total_routed_messages: usize,
@@ -385,8 +389,8 @@ struct PermissionBatchResult {
     denied_updates: usize,
 }
 
-struct PermissionR5State {
-    runtime: BenchRuntime,
+struct PermissionR5State<S: Storage = MemoryStorage> {
+    runtime: BenchRuntime<S>,
     rng: Lcg,
     session_alice: Session,
     allowed_doc_ids: Vec<ObjectId>,
@@ -411,6 +415,7 @@ struct ColdLoadSeededDb {
     _tempdir: TempDir,
     db_path: PathBuf,
     target_project_id: ObjectId,
+    #[allow(dead_code)]
     cache_size_bytes: usize,
 }
 
@@ -1048,10 +1053,23 @@ impl ColdLoadSeededDb {
     }
 }
 
-impl SingleHopR1State {
+impl SingleHopR1State<MemoryStorage> {
     fn new(profile: &ProfileConfig, scenario: &R1Scenario) -> Self {
-        let mut client_runtime = create_runtime(project_board_schema());
-        let mut server_runtime = create_runtime(project_board_schema());
+        Self::with_runtime_factory(profile, scenario, || create_runtime(project_board_schema()))
+    }
+}
+
+impl<S: Storage> SingleHopR1State<S> {
+    fn with_runtime_factory<F>(
+        profile: &ProfileConfig,
+        scenario: &R1Scenario,
+        mut make_runtime: F,
+    ) -> Self
+    where
+        F: FnMut() -> BenchRuntime<S>,
+    {
+        let mut client_runtime = make_runtime();
+        let mut server_runtime = make_runtime();
         let client_id_on_server = ClientId::new();
         let server_id_on_client = ServerId::new();
 
@@ -1127,15 +1145,32 @@ impl SingleHopR1State {
     }
 }
 
-impl FanoutR4State {
+impl FanoutR4State<MemoryStorage> {
     fn new(
         profile: &ProfileConfig,
         seed: u64,
         target_project_index: usize,
         fanout_clients: usize,
     ) -> Self {
-        let mut writer_runtime = create_runtime(project_board_schema());
-        let mut server_runtime = create_runtime(project_board_schema());
+        Self::with_runtime_factory(profile, seed, target_project_index, fanout_clients, || {
+            create_runtime(project_board_schema())
+        })
+    }
+}
+
+impl<S: Storage> FanoutR4State<S> {
+    fn with_runtime_factory<F>(
+        profile: &ProfileConfig,
+        seed: u64,
+        target_project_index: usize,
+        fanout_clients: usize,
+        mut make_runtime: F,
+    ) -> Self
+    where
+        F: FnMut() -> BenchRuntime<S>,
+    {
+        let mut writer_runtime = make_runtime();
+        let mut server_runtime = make_runtime();
         let writer_client_id_on_server = ClientId::new();
         let writer_server_id_on_client = ServerId::new();
 
@@ -1166,7 +1201,7 @@ impl FanoutR4State {
         }
 
         for _ in 0..fanout_clients {
-            let mut reader_runtime = create_runtime(project_board_schema());
+            let mut reader_runtime = make_runtime();
             let reader_client_id_on_server = ClientId::new();
             let reader_server_id_on_client = ServerId::new();
 
@@ -1310,9 +1345,19 @@ impl FanoutR4State {
     }
 }
 
-impl PermissionR5State {
+impl PermissionR5State<MemoryStorage> {
     fn new(scenario: &R5Scenario, recursive_depth: usize) -> Self {
         let runtime = create_runtime(permission_recursive_schema(recursive_depth));
+        Self::with_runtime(scenario, recursive_depth, runtime)
+    }
+}
+
+impl<S: Storage> PermissionR5State<S> {
+    fn with_runtime(
+        scenario: &R5Scenario,
+        recursive_depth: usize,
+        runtime: BenchRuntime<S>,
+    ) -> Self {
         let session_alice = Session::new("alice");
         let mut state = Self {
             runtime,
@@ -1646,6 +1691,268 @@ fn realistic_r2_reads_with_write_churn(c: &mut Criterion) {
 }
 
 #[cfg(all(feature = "rocksdb", not(target_arch = "wasm32")))]
+fn realistic_r1_crud_single_hop_rocksdb(c: &mut Criterion) {
+    let profile: ProfileConfig = load_json("benchmarks/realistic/profiles/s.json");
+    let scenario = load_r1_scenario("benchmarks/realistic/scenarios/r1_crud_sustained.json");
+    let benchmark_name = format!(
+        "{}_{}_single_hop_rocksdb",
+        scenario.id.to_lowercase(),
+        profile.id.to_lowercase()
+    );
+
+    let mut group = c.benchmark_group("realistic_phase1/crud_sustained_single_hop_rocksdb");
+    configure_group(&mut group, 20, 10);
+    group.throughput(Throughput::Elements(scenario.operation_count as u64));
+
+    group.bench_with_input(
+        BenchmarkId::from_parameter(benchmark_name),
+        &scenario,
+        |b, scenario| {
+            let tempdir = TempDir::new().expect("create tempdir for rocksdb single-hop benchmark");
+            let mut runtime_idx = 0usize;
+            let mut state = SingleHopR1State::with_runtime_factory(&profile, scenario, || {
+                let db_path = tempdir
+                    .path()
+                    .join(format!("single_hop_{runtime_idx}.rocksdb"));
+                runtime_idx += 1;
+                create_rocksdb_runtime(
+                    project_board_schema(),
+                    &db_path,
+                    STORAGE_BENCH_CACHE_SIZE_BYTES,
+                )
+            });
+            b.iter(|| {
+                let executed = state.run_crud_batch(scenario);
+                black_box(executed);
+                black_box(state.total_routed_messages);
+            });
+            flush_and_close_runtime(&mut state.client.runtime);
+            flush_and_close_runtime(&mut state.server);
+        },
+    );
+
+    group.finish();
+}
+
+#[cfg(not(all(feature = "rocksdb", not(target_arch = "wasm32"))))]
+fn realistic_r1_crud_single_hop_rocksdb(_c: &mut Criterion) {}
+
+#[cfg(all(feature = "sqlite", not(target_arch = "wasm32")))]
+fn realistic_r1_crud_single_hop_sqlite(c: &mut Criterion) {
+    let profile: ProfileConfig = load_json("benchmarks/realistic/profiles/s.json");
+    let scenario = load_r1_scenario("benchmarks/realistic/scenarios/r1_crud_sustained.json");
+    let benchmark_name = format!(
+        "{}_{}_single_hop_sqlite",
+        scenario.id.to_lowercase(),
+        profile.id.to_lowercase()
+    );
+
+    let mut group = c.benchmark_group("realistic_phase1/crud_sustained_single_hop_sqlite");
+    configure_group(&mut group, 20, 10);
+    group.throughput(Throughput::Elements(scenario.operation_count as u64));
+
+    group.bench_with_input(
+        BenchmarkId::from_parameter(benchmark_name),
+        &scenario,
+        |b, scenario| {
+            let tempdir = TempDir::new().expect("create tempdir for sqlite single-hop benchmark");
+            let mut runtime_idx = 0usize;
+            let mut state = SingleHopR1State::with_runtime_factory(&profile, scenario, || {
+                let db_path = tempdir
+                    .path()
+                    .join(format!("single_hop_{runtime_idx}.sqlite"));
+                runtime_idx += 1;
+                create_sqlite_runtime(project_board_schema(), &db_path)
+            });
+            b.iter(|| {
+                let executed = state.run_crud_batch(scenario);
+                black_box(executed);
+                black_box(state.total_routed_messages);
+            });
+            flush_and_close_runtime(&mut state.client.runtime);
+            flush_and_close_runtime(&mut state.server);
+        },
+    );
+
+    group.finish();
+}
+
+#[cfg(not(all(feature = "sqlite", not(target_arch = "wasm32"))))]
+fn realistic_r1_crud_single_hop_sqlite(_c: &mut Criterion) {}
+
+#[cfg(all(feature = "rocksdb", not(target_arch = "wasm32")))]
+fn realistic_r2_reads_single_hop_rocksdb(c: &mut Criterion) {
+    let profile: ProfileConfig = load_json("benchmarks/realistic/profiles/s.json");
+    let scenario = load_r2_scenario("benchmarks/realistic/scenarios/r2_reads_sustained.json");
+    let seed_scenario = load_r1_scenario("benchmarks/realistic/scenarios/r1_crud_sustained.json");
+    let benchmark_name = format!(
+        "{}_{}_single_hop_rocksdb",
+        scenario.id.to_lowercase(),
+        profile.id.to_lowercase()
+    );
+
+    let mut group = c.benchmark_group("realistic_phase1/reads_sustained_single_hop_rocksdb");
+    configure_group(&mut group, 20, 10);
+    group.throughput(Throughput::Elements(scenario.operation_count as u64));
+
+    group.bench_with_input(
+        BenchmarkId::from_parameter(benchmark_name),
+        &scenario,
+        |b, scenario| {
+            let tempdir = TempDir::new().expect("create tempdir for rocksdb single-hop reads");
+            let mut runtime_idx = 0usize;
+            let mut state =
+                SingleHopR1State::with_runtime_factory(&profile, &seed_scenario, || {
+                    let db_path = tempdir
+                        .path()
+                        .join(format!("reads_single_hop_{runtime_idx}.rocksdb"));
+                    runtime_idx += 1;
+                    create_rocksdb_runtime(
+                        project_board_schema(),
+                        &db_path,
+                        STORAGE_BENCH_CACHE_SIZE_BYTES,
+                    )
+                });
+            b.iter(|| {
+                let total_rows = state.run_read_batch(scenario);
+                black_box(total_rows);
+                black_box(state.total_routed_messages);
+            });
+            flush_and_close_runtime(&mut state.client.runtime);
+            flush_and_close_runtime(&mut state.server);
+        },
+    );
+
+    group.finish();
+}
+
+#[cfg(not(all(feature = "rocksdb", not(target_arch = "wasm32"))))]
+fn realistic_r2_reads_single_hop_rocksdb(_c: &mut Criterion) {}
+
+#[cfg(all(feature = "sqlite", not(target_arch = "wasm32")))]
+fn realistic_r2_reads_single_hop_sqlite(c: &mut Criterion) {
+    let profile: ProfileConfig = load_json("benchmarks/realistic/profiles/s.json");
+    let scenario = load_r2_scenario("benchmarks/realistic/scenarios/r2_reads_sustained.json");
+    let seed_scenario = load_r1_scenario("benchmarks/realistic/scenarios/r1_crud_sustained.json");
+    let benchmark_name = format!(
+        "{}_{}_single_hop_sqlite",
+        scenario.id.to_lowercase(),
+        profile.id.to_lowercase()
+    );
+
+    let mut group = c.benchmark_group("realistic_phase1/reads_sustained_single_hop_sqlite");
+    configure_group(&mut group, 20, 10);
+    group.throughput(Throughput::Elements(scenario.operation_count as u64));
+
+    group.bench_with_input(
+        BenchmarkId::from_parameter(benchmark_name),
+        &scenario,
+        |b, scenario| {
+            let tempdir = TempDir::new().expect("create tempdir for sqlite single-hop reads");
+            let mut runtime_idx = 0usize;
+            let mut state =
+                SingleHopR1State::with_runtime_factory(&profile, &seed_scenario, || {
+                    let db_path = tempdir
+                        .path()
+                        .join(format!("reads_single_hop_{runtime_idx}.sqlite"));
+                    runtime_idx += 1;
+                    create_sqlite_runtime(project_board_schema(), &db_path)
+                });
+            b.iter(|| {
+                let total_rows = state.run_read_batch(scenario);
+                black_box(total_rows);
+                black_box(state.total_routed_messages);
+            });
+            flush_and_close_runtime(&mut state.client.runtime);
+            flush_and_close_runtime(&mut state.server);
+        },
+    );
+
+    group.finish();
+}
+
+#[cfg(not(all(feature = "sqlite", not(target_arch = "wasm32"))))]
+fn realistic_r2_reads_single_hop_sqlite(_c: &mut Criterion) {}
+
+#[cfg(all(feature = "rocksdb", not(target_arch = "wasm32")))]
+fn realistic_r2_reads_with_write_churn_rocksdb(c: &mut Criterion) {
+    let profile: ProfileConfig = load_json("benchmarks/realistic/profiles/s.json");
+    let read_scenario = load_r2_scenario("benchmarks/realistic/scenarios/r2_reads_with_churn.json");
+    let write_scenario = load_r1_scenario("benchmarks/realistic/scenarios/r1_crud_sustained.json");
+    let benchmark_name = format!(
+        "{}_{}_with_churn_rocksdb",
+        read_scenario.id.to_lowercase(),
+        profile.id.to_lowercase()
+    );
+
+    let mut group = c.benchmark_group("realistic_phase1/reads_sustained_with_write_churn_rocksdb");
+    configure_group(&mut group, 20, 10);
+    group.throughput(Throughput::Elements(read_scenario.operation_count as u64));
+
+    group.bench_with_input(
+        BenchmarkId::from_parameter(benchmark_name),
+        &read_scenario,
+        |b, scenario| {
+            let tempdir = TempDir::new().expect("create tempdir for rocksdb read churn benchmark");
+            let db_path = tempdir.path().join("reads_with_churn.rocksdb");
+            let runtime = create_rocksdb_runtime(
+                project_board_schema(),
+                &db_path,
+                STORAGE_BENCH_CACHE_SIZE_BYTES,
+            );
+            let mut state = R1State::with_runtime(runtime, &profile, profile.seed ^ scenario.seed);
+            b.iter(|| {
+                let total_rows = state.run_read_batch_with_churn(scenario, &write_scenario);
+                black_box(total_rows);
+            });
+            flush_and_close_runtime(&mut state.runtime);
+        },
+    );
+
+    group.finish();
+}
+
+#[cfg(not(all(feature = "rocksdb", not(target_arch = "wasm32"))))]
+fn realistic_r2_reads_with_write_churn_rocksdb(_c: &mut Criterion) {}
+
+#[cfg(all(feature = "sqlite", not(target_arch = "wasm32")))]
+fn realistic_r2_reads_with_write_churn_sqlite(c: &mut Criterion) {
+    let profile: ProfileConfig = load_json("benchmarks/realistic/profiles/s.json");
+    let read_scenario = load_r2_scenario("benchmarks/realistic/scenarios/r2_reads_with_churn.json");
+    let write_scenario = load_r1_scenario("benchmarks/realistic/scenarios/r1_crud_sustained.json");
+    let benchmark_name = format!(
+        "{}_{}_with_churn_sqlite",
+        read_scenario.id.to_lowercase(),
+        profile.id.to_lowercase()
+    );
+
+    let mut group = c.benchmark_group("realistic_phase1/reads_sustained_with_write_churn_sqlite");
+    configure_group(&mut group, 20, 10);
+    group.throughput(Throughput::Elements(read_scenario.operation_count as u64));
+
+    group.bench_with_input(
+        BenchmarkId::from_parameter(benchmark_name),
+        &read_scenario,
+        |b, scenario| {
+            let tempdir = TempDir::new().expect("create tempdir for sqlite read churn benchmark");
+            let db_path = tempdir.path().join("reads_with_churn.sqlite");
+            let runtime = create_sqlite_runtime(project_board_schema(), &db_path);
+            let mut state = R1State::with_runtime(runtime, &profile, profile.seed ^ scenario.seed);
+            b.iter(|| {
+                let total_rows = state.run_read_batch_with_churn(scenario, &write_scenario);
+                black_box(total_rows);
+            });
+            flush_and_close_runtime(&mut state.runtime);
+        },
+    );
+
+    group.finish();
+}
+
+#[cfg(not(all(feature = "sqlite", not(target_arch = "wasm32"))))]
+fn realistic_r2_reads_with_write_churn_sqlite(_c: &mut Criterion) {}
+
+#[cfg(all(feature = "rocksdb", not(target_arch = "wasm32")))]
 fn realistic_r1_crud_rocksdb(c: &mut Criterion) {
     let profile: ProfileConfig = load_json("benchmarks/realistic/profiles/s.json");
     let scenario = load_r1_scenario("benchmarks/realistic/scenarios/r1_crud_sustained.json");
@@ -1949,6 +2256,130 @@ fn realistic_r4_fanout_updates(c: &mut Criterion) {
     group.finish();
 }
 
+#[cfg(all(feature = "rocksdb", not(target_arch = "wasm32")))]
+fn realistic_r4_fanout_updates_rocksdb(c: &mut Criterion) {
+    let profile: ProfileConfig = load_json("benchmarks/realistic/profiles/s.json");
+    let scenario = load_r4_scenario(select_ci_path(
+        "benchmarks/realistic/scenarios/r4_fanout_updates.json",
+        "benchmarks/realistic/ci/scenarios/r4_fanout_updates.json",
+    ));
+
+    let mut group = c.benchmark_group("realistic_phase1/fanout_updates_rocksdb");
+    configure_group(&mut group, 10, 10);
+    group.throughput(Throughput::Elements(scenario.operation_count as u64));
+
+    for fanout_clients in &scenario.fanout_clients {
+        let bench_id = format!(
+            "{}_{}_n{}_rocksdb",
+            scenario.id.to_lowercase(),
+            profile.id.to_lowercase(),
+            fanout_clients
+        );
+        let scenario_seed = scenario.seed;
+        let target_project_index = scenario.target_project_index;
+        let operation_count = scenario.operation_count;
+        group.bench_with_input(
+            BenchmarkId::from_parameter(bench_id),
+            fanout_clients,
+            |b, fanout_clients| {
+                let tempdir = TempDir::new().expect("create tempdir for rocksdb fanout benchmark");
+                let mut runtime_idx = 0usize;
+                let mut state = FanoutR4State::with_runtime_factory(
+                    &profile,
+                    scenario_seed,
+                    target_project_index,
+                    *fanout_clients,
+                    || {
+                        let db_path = tempdir.path().join(format!("fanout_{runtime_idx}.rocksdb"));
+                        runtime_idx += 1;
+                        create_rocksdb_runtime(
+                            project_board_schema(),
+                            &db_path,
+                            STORAGE_BENCH_CACHE_SIZE_BYTES,
+                        )
+                    },
+                );
+                b.iter(|| {
+                    let (updates, notifications) = state.run_update_batch(operation_count);
+                    black_box(updates);
+                    black_box(notifications);
+                    black_box(state.total_routed_messages);
+                });
+                flush_and_close_runtime(&mut state.writer.runtime);
+                for reader in &mut state.readers {
+                    flush_and_close_runtime(&mut reader.runtime);
+                }
+                flush_and_close_runtime(&mut state.server);
+            },
+        );
+    }
+
+    group.finish();
+}
+
+#[cfg(not(all(feature = "rocksdb", not(target_arch = "wasm32"))))]
+fn realistic_r4_fanout_updates_rocksdb(_c: &mut Criterion) {}
+
+#[cfg(all(feature = "sqlite", not(target_arch = "wasm32")))]
+fn realistic_r4_fanout_updates_sqlite(c: &mut Criterion) {
+    let profile: ProfileConfig = load_json("benchmarks/realistic/profiles/s.json");
+    let scenario = load_r4_scenario(select_ci_path(
+        "benchmarks/realistic/scenarios/r4_fanout_updates.json",
+        "benchmarks/realistic/ci/scenarios/r4_fanout_updates.json",
+    ));
+
+    let mut group = c.benchmark_group("realistic_phase1/fanout_updates_sqlite");
+    configure_group(&mut group, 10, 10);
+    group.throughput(Throughput::Elements(scenario.operation_count as u64));
+
+    for fanout_clients in &scenario.fanout_clients {
+        let bench_id = format!(
+            "{}_{}_n{}_sqlite",
+            scenario.id.to_lowercase(),
+            profile.id.to_lowercase(),
+            fanout_clients
+        );
+        let scenario_seed = scenario.seed;
+        let target_project_index = scenario.target_project_index;
+        let operation_count = scenario.operation_count;
+        group.bench_with_input(
+            BenchmarkId::from_parameter(bench_id),
+            fanout_clients,
+            |b, fanout_clients| {
+                let tempdir = TempDir::new().expect("create tempdir for sqlite fanout benchmark");
+                let mut runtime_idx = 0usize;
+                let mut state = FanoutR4State::with_runtime_factory(
+                    &profile,
+                    scenario_seed,
+                    target_project_index,
+                    *fanout_clients,
+                    || {
+                        let db_path = tempdir.path().join(format!("fanout_{runtime_idx}.sqlite"));
+                        runtime_idx += 1;
+                        create_sqlite_runtime(project_board_schema(), &db_path)
+                    },
+                );
+                b.iter(|| {
+                    let (updates, notifications) = state.run_update_batch(operation_count);
+                    black_box(updates);
+                    black_box(notifications);
+                    black_box(state.total_routed_messages);
+                });
+                flush_and_close_runtime(&mut state.writer.runtime);
+                for reader in &mut state.readers {
+                    flush_and_close_runtime(&mut reader.runtime);
+                }
+                flush_and_close_runtime(&mut state.server);
+            },
+        );
+    }
+
+    group.finish();
+}
+
+#[cfg(not(all(feature = "sqlite", not(target_arch = "wasm32"))))]
+fn realistic_r4_fanout_updates_sqlite(_c: &mut Criterion) {}
+
 fn run_permission_scenario(c: &mut Criterion, group_name: &str, scenario_path: &str) {
     let scenario = load_r5_scenario(scenario_path);
     let mut group = c.benchmark_group(group_name);
@@ -1975,6 +2406,42 @@ fn run_permission_scenario(c: &mut Criterion, group_name: &str, scenario_path: &
     group.finish();
 }
 
+fn run_storage_permission_scenario<S: Storage, F: Copy + Fn(usize) -> BenchRuntime<S>>(
+    c: &mut Criterion,
+    group_name: &str,
+    scenario_path: &str,
+    make_runtime: F,
+) {
+    let scenario = load_r5_scenario(scenario_path);
+    let mut group = c.benchmark_group(group_name);
+    configure_group(&mut group, 10, 10);
+    group.throughput(Throughput::Elements(scenario.operation_count as u64));
+
+    for recursive_depth in &scenario.recursive_depths {
+        let bench_id = format!("{}_depth{recursive_depth}", scenario.id.to_lowercase());
+        group.bench_with_input(
+            BenchmarkId::from_parameter(bench_id),
+            recursive_depth,
+            |b, recursive_depth| {
+                let mut state = PermissionR5State::with_runtime(
+                    &scenario,
+                    *recursive_depth,
+                    make_runtime(*recursive_depth),
+                );
+                b.iter(|| {
+                    let result = state.run_batch(&scenario);
+                    black_box(result.total_rows);
+                    black_box(result.allowed_updates);
+                    black_box(result.denied_updates);
+                });
+                flush_and_close_runtime(&mut state.runtime);
+            },
+        );
+    }
+
+    group.finish();
+}
+
 fn realistic_r5_permission_recursive(c: &mut Criterion) {
     run_permission_scenario(
         c,
@@ -1993,6 +2460,101 @@ fn realistic_r6_permission_write_heavy(c: &mut Criterion) {
         ),
     );
 }
+
+#[cfg(all(feature = "rocksdb", not(target_arch = "wasm32")))]
+fn realistic_r5_permission_recursive_rocksdb(c: &mut Criterion) {
+    run_storage_permission_scenario(
+        c,
+        "realistic_phase1/permission_recursive_rocksdb",
+        "benchmarks/realistic/scenarios/r5_permission_recursive.json",
+        |recursive_depth| {
+            let tempdir = TempDir::new().expect("create tempdir for rocksdb permission benchmark");
+            let db_path = tempdir.path().join(format!(
+                "permission_recursive_depth_{recursive_depth}.rocksdb"
+            ));
+            std::mem::forget(tempdir);
+            create_rocksdb_runtime(
+                permission_recursive_schema(recursive_depth),
+                &db_path,
+                STORAGE_BENCH_CACHE_SIZE_BYTES,
+            )
+        },
+    );
+}
+
+#[cfg(not(all(feature = "rocksdb", not(target_arch = "wasm32"))))]
+fn realistic_r5_permission_recursive_rocksdb(_c: &mut Criterion) {}
+
+#[cfg(all(feature = "sqlite", not(target_arch = "wasm32")))]
+fn realistic_r5_permission_recursive_sqlite(c: &mut Criterion) {
+    run_storage_permission_scenario(
+        c,
+        "realistic_phase1/permission_recursive_sqlite",
+        "benchmarks/realistic/scenarios/r5_permission_recursive.json",
+        |recursive_depth| {
+            let tempdir = TempDir::new().expect("create tempdir for sqlite permission benchmark");
+            let db_path = tempdir.path().join(format!(
+                "permission_recursive_depth_{recursive_depth}.sqlite"
+            ));
+            std::mem::forget(tempdir);
+            create_sqlite_runtime(permission_recursive_schema(recursive_depth), &db_path)
+        },
+    );
+}
+
+#[cfg(not(all(feature = "sqlite", not(target_arch = "wasm32"))))]
+fn realistic_r5_permission_recursive_sqlite(_c: &mut Criterion) {}
+
+#[cfg(all(feature = "rocksdb", not(target_arch = "wasm32")))]
+fn realistic_r6_permission_write_heavy_rocksdb(c: &mut Criterion) {
+    run_storage_permission_scenario(
+        c,
+        "realistic_phase1/permission_write_heavy_rocksdb",
+        select_ci_path(
+            "benchmarks/realistic/scenarios/r6_permission_write_heavy.json",
+            "benchmarks/realistic/ci/scenarios/r6_permission_write_heavy.json",
+        ),
+        |recursive_depth| {
+            let tempdir =
+                TempDir::new().expect("create tempdir for rocksdb permission write-heavy");
+            let db_path = tempdir.path().join(format!(
+                "permission_write_heavy_depth_{recursive_depth}.rocksdb"
+            ));
+            std::mem::forget(tempdir);
+            create_rocksdb_runtime(
+                permission_recursive_schema(recursive_depth),
+                &db_path,
+                STORAGE_BENCH_CACHE_SIZE_BYTES,
+            )
+        },
+    );
+}
+
+#[cfg(not(all(feature = "rocksdb", not(target_arch = "wasm32"))))]
+fn realistic_r6_permission_write_heavy_rocksdb(_c: &mut Criterion) {}
+
+#[cfg(all(feature = "sqlite", not(target_arch = "wasm32")))]
+fn realistic_r6_permission_write_heavy_sqlite(c: &mut Criterion) {
+    run_storage_permission_scenario(
+        c,
+        "realistic_phase1/permission_write_heavy_sqlite",
+        select_ci_path(
+            "benchmarks/realistic/scenarios/r6_permission_write_heavy.json",
+            "benchmarks/realistic/ci/scenarios/r6_permission_write_heavy.json",
+        ),
+        |recursive_depth| {
+            let tempdir = TempDir::new().expect("create tempdir for sqlite permission write-heavy");
+            let db_path = tempdir.path().join(format!(
+                "permission_write_heavy_depth_{recursive_depth}.sqlite"
+            ));
+            std::mem::forget(tempdir);
+            create_sqlite_runtime(permission_recursive_schema(recursive_depth), &db_path)
+        },
+    );
+}
+
+#[cfg(not(all(feature = "sqlite", not(target_arch = "wasm32"))))]
+fn realistic_r6_permission_write_heavy_sqlite(_c: &mut Criterion) {}
 
 fn realistic_r7_hotspot_history(c: &mut Criterion) {
     let profile: ProfileConfig = load_json("benchmarks/realistic/profiles/s.json");
@@ -2025,6 +2587,90 @@ fn realistic_r7_hotspot_history(c: &mut Criterion) {
 
     group.finish();
 }
+
+#[cfg(all(feature = "rocksdb", not(target_arch = "wasm32")))]
+fn realistic_r7_hotspot_history_rocksdb(c: &mut Criterion) {
+    let profile: ProfileConfig = load_json("benchmarks/realistic/profiles/s.json");
+    let scenario = load_r7_scenario("benchmarks/realistic/scenarios/r7_hotspot_history.json");
+    let benchmark_name = format!(
+        "{}_{}_hot{}_rocksdb",
+        scenario.id.to_lowercase(),
+        profile.id.to_lowercase(),
+        scenario.hot_task_count
+    );
+
+    let mut group = c.benchmark_group("realistic_phase1/hotspot_history_rocksdb");
+    configure_group(&mut group, 20, 10);
+    group.throughput(Throughput::Elements(scenario.operation_count as u64));
+
+    group.bench_with_input(
+        BenchmarkId::from_parameter(benchmark_name),
+        &scenario,
+        |b, scenario| {
+            let tempdir = TempDir::new().expect("create tempdir for rocksdb hotspot benchmark");
+            let db_path = tempdir.path().join("hotspot_history.rocksdb");
+            let runtime = create_rocksdb_runtime(
+                project_board_schema(),
+                &db_path,
+                STORAGE_BENCH_CACHE_SIZE_BYTES,
+            );
+            let mut state = R1State::with_runtime(runtime, &profile, profile.seed ^ scenario.seed);
+            let hot_count = scenario.hot_task_count.max(1).min(state.active_tasks.len());
+            let hot_task_ids = state.active_tasks[..hot_count].to_vec();
+            b.iter(|| {
+                let updates =
+                    state.run_hotspot_update_batch(&hot_task_ids, scenario.operation_count);
+                black_box(updates);
+            });
+            flush_and_close_runtime(&mut state.runtime);
+        },
+    );
+
+    group.finish();
+}
+
+#[cfg(not(all(feature = "rocksdb", not(target_arch = "wasm32"))))]
+fn realistic_r7_hotspot_history_rocksdb(_c: &mut Criterion) {}
+
+#[cfg(all(feature = "sqlite", not(target_arch = "wasm32")))]
+fn realistic_r7_hotspot_history_sqlite(c: &mut Criterion) {
+    let profile: ProfileConfig = load_json("benchmarks/realistic/profiles/s.json");
+    let scenario = load_r7_scenario("benchmarks/realistic/scenarios/r7_hotspot_history.json");
+    let benchmark_name = format!(
+        "{}_{}_hot{}_sqlite",
+        scenario.id.to_lowercase(),
+        profile.id.to_lowercase(),
+        scenario.hot_task_count
+    );
+
+    let mut group = c.benchmark_group("realistic_phase1/hotspot_history_sqlite");
+    configure_group(&mut group, 20, 10);
+    group.throughput(Throughput::Elements(scenario.operation_count as u64));
+
+    group.bench_with_input(
+        BenchmarkId::from_parameter(benchmark_name),
+        &scenario,
+        |b, scenario| {
+            let tempdir = TempDir::new().expect("create tempdir for sqlite hotspot benchmark");
+            let db_path = tempdir.path().join("hotspot_history.sqlite");
+            let runtime = create_sqlite_runtime(project_board_schema(), &db_path);
+            let mut state = R1State::with_runtime(runtime, &profile, profile.seed ^ scenario.seed);
+            let hot_count = scenario.hot_task_count.max(1).min(state.active_tasks.len());
+            let hot_task_ids = state.active_tasks[..hot_count].to_vec();
+            b.iter(|| {
+                let updates =
+                    state.run_hotspot_update_batch(&hot_task_ids, scenario.operation_count);
+                black_box(updates);
+            });
+            flush_and_close_runtime(&mut state.runtime);
+        },
+    );
+
+    group.finish();
+}
+
+#[cfg(not(all(feature = "sqlite", not(target_arch = "wasm32"))))]
+fn realistic_r7_hotspot_history_sqlite(_c: &mut Criterion) {}
 
 fn realistic_r8_many_branches_write(c: &mut Criterion) {
     let profile: ProfileConfig = load_json("benchmarks/realistic/profiles/s.json");
@@ -2283,6 +2929,442 @@ fn realistic_r9_subscribed_write_path(c: &mut Criterion) {
     group.finish();
 }
 
+#[cfg(all(feature = "rocksdb", not(target_arch = "wasm32")))]
+fn realistic_r8_many_branches_rocksdb(c: &mut Criterion) {
+    let profile: ProfileConfig = load_json("benchmarks/realistic/profiles/s.json");
+    let scenario = load_r8_scenario(select_ci_path(
+        "benchmarks/realistic/scenarios/r8_many_branches.json",
+        "benchmarks/realistic/ci/scenarios/r8_many_branches.json",
+    ));
+
+    let mut write_group = c.benchmark_group("realistic_phase1/many_branches_rocksdb_write");
+    configure_group(&mut write_group, 10, 5);
+    write_group.throughput(Throughput::Elements(scenario.total_commits() as u64));
+    write_group.bench_with_input(
+        BenchmarkId::from_parameter(many_branches_benchmark_name(
+            &scenario,
+            &profile,
+            "rocksdb_write",
+        )),
+        &scenario,
+        |b, scenario| {
+            let tempdir = TempDir::new().expect("create tempdir for rocksdb many-branches write");
+            let mut dataset_idx = 0usize;
+            b.iter(|| {
+                let db_path = tempdir
+                    .path()
+                    .join(format!("many_branches_write_{dataset_idx}.rocksdb"));
+                dataset_idx += 1;
+                let mut storage = RocksDBStorage::open(&db_path, scenario.cache_size_bytes)
+                    .expect("open rocksdb for many-branches write benchmark");
+                let mut manager = ObjectManager::new();
+                let dataset = build_many_branches_dataset(&mut manager, &mut storage, scenario);
+                storage.flush();
+                storage.close().expect("close many-branches rocksdb write");
+                black_box(dataset.object_id);
+                black_box(dataset.branch_names.len());
+                black_box(dataset.leaf_branch_names.len());
+                black_box(dataset.total_commits);
+            });
+        },
+    );
+    write_group.finish();
+
+    let seeded = ManyBranchesSeededDb::new_rocksdb(&scenario);
+    let mut loaded_manager = ObjectManager::new();
+    let loaded_storage = RocksDBStorage::open(&seeded.db_path, seeded.cache_size_bytes)
+        .expect("open rocksdb for many-branches scan");
+    loaded_manager
+        .get_or_load(seeded.object_id, &loaded_storage, &seeded.branch_names)
+        .expect("load many-branches object from rocksdb");
+    loaded_storage.flush();
+    loaded_storage
+        .close()
+        .expect("close many-branches rocksdb scan storage");
+
+    let mut scan_heads_group =
+        c.benchmark_group("realistic_phase1/many_branches_rocksdb_scan_heads");
+    configure_group(&mut scan_heads_group, 10, 5);
+    scan_heads_group.throughput(Throughput::Elements(scenario.branch_count as u64));
+    scan_heads_group.bench_with_input(
+        BenchmarkId::from_parameter(many_branches_benchmark_name(
+            &scenario,
+            &profile,
+            "rocksdb_scan_heads",
+        )),
+        &seeded,
+        |b, seeded| {
+            let object = loaded_manager
+                .get(seeded.object_id)
+                .expect("many-branches object should stay loaded");
+            b.iter(|| {
+                let scan = scan_branch_heads(object, &seeded.prefix);
+                black_box(scan);
+            });
+        },
+    );
+    scan_heads_group.finish();
+
+    let mut scan_leaf_group =
+        c.benchmark_group("realistic_phase1/many_branches_rocksdb_scan_leaf_heads");
+    configure_group(&mut scan_leaf_group, 10, 5);
+    scan_leaf_group.throughput(Throughput::Elements(scenario.branch_count as u64));
+    scan_leaf_group.bench_with_input(
+        BenchmarkId::from_parameter(many_branches_benchmark_name(
+            &scenario,
+            &profile,
+            "rocksdb_scan_leaf_heads",
+        )),
+        &seeded,
+        |b, seeded| {
+            let object = loaded_manager
+                .get(seeded.object_id)
+                .expect("many-branches object should stay loaded");
+            b.iter(|| {
+                let scan =
+                    scan_leaf_like_branch_heads(object, &seeded.prefix, &seeded.leaf_branch_names);
+                black_box(scan);
+            });
+        },
+    );
+    scan_leaf_group.finish();
+
+    let mut cold_load_group = c.benchmark_group("realistic_phase1/many_branches_rocksdb_cold_load");
+    configure_group(&mut cold_load_group, 10, 5);
+    cold_load_group.throughput(Throughput::Elements(scenario.branch_count as u64));
+    cold_load_group.bench_with_input(
+        BenchmarkId::from_parameter(many_branches_benchmark_name(
+            &scenario,
+            &profile,
+            "rocksdb_cold_load",
+        )),
+        &seeded,
+        |b, seeded| {
+            b.iter(|| {
+                let storage = RocksDBStorage::open(&seeded.db_path, seeded.cache_size_bytes)
+                    .expect("open rocksdb for many-branches cold-load benchmark");
+                let mut manager = ObjectManager::new();
+                let object = manager
+                    .get_or_load(seeded.object_id, &storage, &seeded.branch_names)
+                    .expect("cold-load many-branches object");
+                let scan = scan_branch_heads(object, &seeded.prefix);
+                storage.flush();
+                storage
+                    .close()
+                    .expect("close many-branches rocksdb cold-load");
+                black_box(scan);
+            });
+        },
+    );
+    cold_load_group.finish();
+}
+
+#[cfg(not(all(feature = "rocksdb", not(target_arch = "wasm32"))))]
+fn realistic_r8_many_branches_rocksdb(_c: &mut Criterion) {}
+
+#[cfg(all(feature = "sqlite", not(target_arch = "wasm32")))]
+fn realistic_r8_many_branches_sqlite(c: &mut Criterion) {
+    let profile: ProfileConfig = load_json("benchmarks/realistic/profiles/s.json");
+    let scenario = load_r8_scenario(select_ci_path(
+        "benchmarks/realistic/scenarios/r8_many_branches.json",
+        "benchmarks/realistic/ci/scenarios/r8_many_branches.json",
+    ));
+
+    let mut write_group = c.benchmark_group("realistic_phase1/many_branches_sqlite_write");
+    configure_group(&mut write_group, 10, 5);
+    write_group.throughput(Throughput::Elements(scenario.total_commits() as u64));
+    write_group.bench_with_input(
+        BenchmarkId::from_parameter(many_branches_benchmark_name(
+            &scenario,
+            &profile,
+            "sqlite_write",
+        )),
+        &scenario,
+        |b, scenario| {
+            let tempdir = TempDir::new().expect("create tempdir for sqlite many-branches write");
+            let mut dataset_idx = 0usize;
+            b.iter(|| {
+                let db_path = tempdir
+                    .path()
+                    .join(format!("many_branches_write_{dataset_idx}.sqlite"));
+                dataset_idx += 1;
+                let mut storage = SqliteStorage::open(&db_path)
+                    .expect("open sqlite for many-branches write benchmark");
+                let mut manager = ObjectManager::new();
+                let dataset = build_many_branches_dataset(&mut manager, &mut storage, scenario);
+                storage.flush();
+                storage.close().expect("close many-branches sqlite write");
+                black_box(dataset.object_id);
+                black_box(dataset.branch_names.len());
+                black_box(dataset.leaf_branch_names.len());
+                black_box(dataset.total_commits);
+            });
+        },
+    );
+    write_group.finish();
+
+    let seeded = ManyBranchesSeededDb::new_sqlite(&scenario);
+    let mut loaded_manager = ObjectManager::new();
+    let loaded_storage =
+        SqliteStorage::open(&seeded.db_path).expect("open sqlite for many-branches scan");
+    loaded_manager
+        .get_or_load(seeded.object_id, &loaded_storage, &seeded.branch_names)
+        .expect("load many-branches object from sqlite");
+    loaded_storage.flush();
+    loaded_storage
+        .close()
+        .expect("close many-branches sqlite scan storage");
+
+    let mut scan_heads_group =
+        c.benchmark_group("realistic_phase1/many_branches_sqlite_scan_heads");
+    configure_group(&mut scan_heads_group, 10, 5);
+    scan_heads_group.throughput(Throughput::Elements(scenario.branch_count as u64));
+    scan_heads_group.bench_with_input(
+        BenchmarkId::from_parameter(many_branches_benchmark_name(
+            &scenario,
+            &profile,
+            "sqlite_scan_heads",
+        )),
+        &seeded,
+        |b, seeded| {
+            let object = loaded_manager
+                .get(seeded.object_id)
+                .expect("many-branches object should stay loaded");
+            b.iter(|| {
+                let scan = scan_branch_heads(object, &seeded.prefix);
+                black_box(scan);
+            });
+        },
+    );
+    scan_heads_group.finish();
+
+    let mut scan_leaf_group =
+        c.benchmark_group("realistic_phase1/many_branches_sqlite_scan_leaf_heads");
+    configure_group(&mut scan_leaf_group, 10, 5);
+    scan_leaf_group.throughput(Throughput::Elements(scenario.branch_count as u64));
+    scan_leaf_group.bench_with_input(
+        BenchmarkId::from_parameter(many_branches_benchmark_name(
+            &scenario,
+            &profile,
+            "sqlite_scan_leaf_heads",
+        )),
+        &seeded,
+        |b, seeded| {
+            let object = loaded_manager
+                .get(seeded.object_id)
+                .expect("many-branches object should stay loaded");
+            b.iter(|| {
+                let scan =
+                    scan_leaf_like_branch_heads(object, &seeded.prefix, &seeded.leaf_branch_names);
+                black_box(scan);
+            });
+        },
+    );
+    scan_leaf_group.finish();
+
+    let mut cold_load_group = c.benchmark_group("realistic_phase1/many_branches_sqlite_cold_load");
+    configure_group(&mut cold_load_group, 10, 5);
+    cold_load_group.throughput(Throughput::Elements(scenario.branch_count as u64));
+    cold_load_group.bench_with_input(
+        BenchmarkId::from_parameter(many_branches_benchmark_name(
+            &scenario,
+            &profile,
+            "sqlite_cold_load",
+        )),
+        &seeded,
+        |b, seeded| {
+            b.iter(|| {
+                let storage = SqliteStorage::open(&seeded.db_path)
+                    .expect("open sqlite for many-branches cold-load benchmark");
+                let mut manager = ObjectManager::new();
+                let object = manager
+                    .get_or_load(seeded.object_id, &storage, &seeded.branch_names)
+                    .expect("cold-load many-branches object");
+                let scan = scan_branch_heads(object, &seeded.prefix);
+                storage.flush();
+                storage
+                    .close()
+                    .expect("close many-branches sqlite cold-load");
+                black_box(scan);
+            });
+        },
+    );
+    cold_load_group.finish();
+}
+
+#[cfg(not(all(feature = "sqlite", not(target_arch = "wasm32"))))]
+fn realistic_r8_many_branches_sqlite(_c: &mut Criterion) {}
+
+#[cfg(all(feature = "rocksdb", not(target_arch = "wasm32")))]
+fn realistic_r9_subscribed_write_path_rocksdb(c: &mut Criterion) {
+    let profile: ProfileConfig = load_json("benchmarks/realistic/profiles/s.json");
+    let scenario = load_r9_scenario(select_ci_path(
+        "benchmarks/realistic/scenarios/r9_subscribed_write_path.json",
+        "benchmarks/realistic/ci/scenarios/r9_subscribed_write_path.json",
+    ));
+    let benchmark_name = format!(
+        "{}_{}_docs{}_subs{}_rocksdb",
+        scenario.id.to_lowercase(),
+        profile.id.to_lowercase(),
+        scenario.scale,
+        scenario.subscription_count
+    );
+
+    let mut group = c.benchmark_group("realistic_phase1/subscribed_write_path_rocksdb");
+    configure_group(&mut group, 10, 10);
+    group.throughput(Throughput::Elements(1));
+
+    group.bench_with_input(
+        BenchmarkId::from_parameter(benchmark_name),
+        &scenario,
+        |b, scenario| {
+            let tempdir = TempDir::new().expect("create tempdir for rocksdb subscribed write path");
+            let db_path = tempdir.path().join("subscribed_write_path.rocksdb");
+            let storage = RocksDBStorage::open(&db_path, STORAGE_BENCH_CACHE_SIZE_BYTES)
+                .expect("open rocksdb for subscribed write path benchmark");
+            let mut core = permission_bench_common::create_runtime_with_storage(storage);
+            let data = permission_bench_common::setup_data(
+                &mut core,
+                scenario.scale,
+                OBSERVER_BENCH_USER_ID,
+            );
+            let session = permission_bench_common::create_session(OBSERVER_BENCH_USER_ID);
+            let mut handles = Vec::with_capacity(scenario.subscription_count);
+
+            for _ in 0..scenario.subscription_count {
+                let handle = core
+                    .subscribe(Query::new("documents"), |_delta| {}, Some(session.clone()))
+                    .expect("subscribe observe_all");
+                handles.push(handle);
+            }
+            core.immediate_tick();
+            core.batched_tick();
+
+            let doc_ids = data.owned_documents;
+            let mut doc_idx = 0usize;
+            let mut update_counter = 0u64;
+            let write_context = WriteContext::from_session(session.clone());
+
+            b.iter(|| {
+                update_counter += 1;
+                let doc_id = doc_ids[doc_idx % doc_ids.len()];
+                doc_idx += 1;
+
+                core.update(
+                    doc_id,
+                    vec![
+                        (
+                            "content".to_string(),
+                            Value::Text(format!("Observed updated content {}", update_counter)),
+                        ),
+                        (
+                            "created_at".to_string(),
+                            Value::Timestamp(
+                                permission_bench_common::current_timestamp() + update_counter,
+                            ),
+                        ),
+                    ],
+                    Some(&write_context),
+                )
+                .expect("update with observer should succeed");
+            });
+
+            black_box(handles.len());
+            flush_and_close_runtime(&mut core);
+        },
+    );
+
+    group.finish();
+}
+
+#[cfg(not(all(feature = "rocksdb", not(target_arch = "wasm32"))))]
+fn realistic_r9_subscribed_write_path_rocksdb(_c: &mut Criterion) {}
+
+#[cfg(all(feature = "sqlite", not(target_arch = "wasm32")))]
+fn realistic_r9_subscribed_write_path_sqlite(c: &mut Criterion) {
+    let profile: ProfileConfig = load_json("benchmarks/realistic/profiles/s.json");
+    let scenario = load_r9_scenario(select_ci_path(
+        "benchmarks/realistic/scenarios/r9_subscribed_write_path.json",
+        "benchmarks/realistic/ci/scenarios/r9_subscribed_write_path.json",
+    ));
+    let benchmark_name = format!(
+        "{}_{}_docs{}_subs{}_sqlite",
+        scenario.id.to_lowercase(),
+        profile.id.to_lowercase(),
+        scenario.scale,
+        scenario.subscription_count
+    );
+
+    let mut group = c.benchmark_group("realistic_phase1/subscribed_write_path_sqlite");
+    configure_group(&mut group, 10, 10);
+    group.throughput(Throughput::Elements(1));
+
+    group.bench_with_input(
+        BenchmarkId::from_parameter(benchmark_name),
+        &scenario,
+        |b, scenario| {
+            let tempdir = TempDir::new().expect("create tempdir for sqlite subscribed write path");
+            let db_path = tempdir.path().join("subscribed_write_path.sqlite");
+            let storage = SqliteStorage::open(&db_path)
+                .expect("open sqlite for subscribed write path benchmark");
+            let mut core = permission_bench_common::create_runtime_with_storage(storage);
+            let data = permission_bench_common::setup_data(
+                &mut core,
+                scenario.scale,
+                OBSERVER_BENCH_USER_ID,
+            );
+            let session = permission_bench_common::create_session(OBSERVER_BENCH_USER_ID);
+            let mut handles = Vec::with_capacity(scenario.subscription_count);
+
+            for _ in 0..scenario.subscription_count {
+                let handle = core
+                    .subscribe(Query::new("documents"), |_delta| {}, Some(session.clone()))
+                    .expect("subscribe observe_all");
+                handles.push(handle);
+            }
+            core.immediate_tick();
+            core.batched_tick();
+
+            let doc_ids = data.owned_documents;
+            let mut doc_idx = 0usize;
+            let mut update_counter = 0u64;
+            let write_context = WriteContext::from_session(session.clone());
+
+            b.iter(|| {
+                update_counter += 1;
+                let doc_id = doc_ids[doc_idx % doc_ids.len()];
+                doc_idx += 1;
+
+                core.update(
+                    doc_id,
+                    vec![
+                        (
+                            "content".to_string(),
+                            Value::Text(format!("Observed updated content {}", update_counter)),
+                        ),
+                        (
+                            "created_at".to_string(),
+                            Value::Timestamp(
+                                permission_bench_common::current_timestamp() + update_counter,
+                            ),
+                        ),
+                    ],
+                    Some(&write_context),
+                )
+                .expect("update with observer should succeed");
+            });
+
+            black_box(handles.len());
+            flush_and_close_runtime(&mut core);
+        },
+    );
+
+    group.finish();
+}
+
+#[cfg(not(all(feature = "sqlite", not(target_arch = "wasm32"))))]
+fn realistic_r9_subscribed_write_path_sqlite(_c: &mut Criterion) {}
+
 #[cfg(any(
     all(feature = "rocksdb", not(target_arch = "wasm32")),
     all(feature = "sqlite", not(target_arch = "wasm32"))
@@ -2292,7 +3374,9 @@ struct ManyBranchesSeededDb {
     db_path: PathBuf,
     object_id: ObjectId,
     branch_names: Vec<String>,
+    leaf_branch_names: HashSet<String>,
     prefix: String,
+    #[allow(dead_code)]
     cache_size_bytes: usize,
 }
 
@@ -2314,6 +3398,7 @@ impl ManyBranchesSeededDb {
             db_path,
             object_id: dataset.object_id,
             branch_names: dataset.branch_names,
+            leaf_branch_names: dataset.leaf_branch_names,
             prefix: dataset.prefix,
             cache_size_bytes: scenario.cache_size_bytes,
         }
@@ -2338,6 +3423,7 @@ impl ManyBranchesSeededDb {
             db_path,
             object_id: dataset.object_id,
             branch_names: dataset.branch_names,
+            leaf_branch_names: dataset.leaf_branch_names,
             prefix: dataset.prefix,
             cache_size_bytes: 0,
         }
@@ -2703,7 +3789,12 @@ fn workspace_path(path: &str) -> PathBuf {
         .join(path)
 }
 
-fn create_runtime(schema: Schema) -> BenchRuntime {
+fn flush_and_close_runtime<S: Storage>(runtime: &mut BenchRuntime<S>) {
+    runtime.flush_storage();
+    runtime.storage().close().expect("close benchmark storage");
+}
+
+fn create_runtime_with_storage<S: Storage>(schema: Schema, storage: S) -> BenchRuntime<S> {
     let sync_manager = SyncManager::new();
     let schema_manager = SchemaManager::new(
         sync_manager,
@@ -2714,12 +3805,11 @@ fn create_runtime(schema: Schema) -> BenchRuntime {
     )
     .expect("create schema manager");
 
-    RuntimeCore::new(
-        schema_manager,
-        MemoryStorage::new(),
-        NoopScheduler,
-        VecSyncSender::new(),
-    )
+    RuntimeCore::new(schema_manager, storage, NoopScheduler, VecSyncSender::new())
+}
+
+fn create_runtime(schema: Schema) -> BenchRuntime {
+    create_runtime_with_storage(schema, MemoryStorage::new())
 }
 
 #[cfg(all(feature = "rocksdb", not(target_arch = "wasm32")))]
@@ -2728,21 +3818,9 @@ fn create_rocksdb_runtime(
     db_path: &Path,
     cache_size_bytes: usize,
 ) -> RuntimeCore<RocksDBStorage, NoopScheduler, VecSyncSender> {
-    let sync_manager = SyncManager::new();
-    let schema_manager = SchemaManager::new(
-        sync_manager,
+    create_runtime_with_storage(
         schema,
-        AppId::from_name("realistic-phase1-bench"),
-        "dev",
-        "main",
-    )
-    .expect("create schema manager");
-
-    RuntimeCore::new(
-        schema_manager,
         RocksDBStorage::open(db_path, cache_size_bytes).expect("open rocksdb for benchmark"),
-        NoopScheduler,
-        VecSyncSender::new(),
     )
 }
 
@@ -2751,21 +3829,9 @@ fn create_sqlite_runtime(
     schema: Schema,
     db_path: &Path,
 ) -> RuntimeCore<SqliteStorage, NoopScheduler, VecSyncSender> {
-    let sync_manager = SyncManager::new();
-    let schema_manager = SchemaManager::new(
-        sync_manager,
+    create_runtime_with_storage(
         schema,
-        AppId::from_name("realistic-phase1-bench"),
-        "dev",
-        "main",
-    )
-    .expect("create schema manager");
-
-    RuntimeCore::new(
-        schema_manager,
         SqliteStorage::open(db_path).expect("open sqlite for benchmark"),
-        NoopScheduler,
-        VecSyncSender::new(),
     )
 }
 
@@ -2882,22 +3948,40 @@ criterion_group!(
     realistic_r1_crud_rocksdb,
     realistic_r1_crud_sqlite,
     realistic_r1_crud_single_hop,
+    realistic_r1_crud_single_hop_rocksdb,
+    realistic_r1_crud_single_hop_sqlite,
     realistic_r2_reads,
     realistic_r2_reads_rocksdb,
     realistic_r2_reads_sqlite,
     realistic_r2_reads_single_hop,
+    realistic_r2_reads_single_hop_rocksdb,
+    realistic_r2_reads_single_hop_sqlite,
     realistic_r2_reads_with_write_churn,
+    realistic_r2_reads_with_write_churn_rocksdb,
+    realistic_r2_reads_with_write_churn_sqlite,
     realistic_r3_cold_load_rocksdb,
     realistic_r3_cold_load_sqlite,
     realistic_r4_fanout_updates,
+    realistic_r4_fanout_updates_rocksdb,
+    realistic_r4_fanout_updates_sqlite,
     realistic_r5_permission_recursive,
+    realistic_r5_permission_recursive_rocksdb,
+    realistic_r5_permission_recursive_sqlite,
     realistic_r6_permission_write_heavy,
+    realistic_r6_permission_write_heavy_rocksdb,
+    realistic_r6_permission_write_heavy_sqlite,
     realistic_r7_hotspot_history,
+    realistic_r7_hotspot_history_rocksdb,
+    realistic_r7_hotspot_history_sqlite,
     realistic_r8_many_branches_write,
     realistic_r8_many_branches_scan_heads,
     realistic_r8_many_branches_scan_leaf_heads,
     realistic_r8_many_branches_cold_load_rocksdb,
     realistic_r8_many_branches_cold_load_sqlite,
-    realistic_r9_subscribed_write_path
+    realistic_r8_many_branches_rocksdb,
+    realistic_r8_many_branches_sqlite,
+    realistic_r9_subscribed_write_path,
+    realistic_r9_subscribed_write_path_rocksdb,
+    realistic_r9_subscribed_write_path_sqlite
 );
 criterion_main!(benches);


### PR DESCRIPTION
## What changed

This updates the realistic benchmark pipeline so browser remains the existing `opfs-btree` lane, while native and native Criterion now run as explicit storage-engine lanes for both `rocksdb` and `sqlite`.

It also extends the Rust realistic Criterion bench so every native scenario has storage-backed variants instead of falling back to in-memory groups for several cases.

## Why this changed

We wanted the benchmark suite and rendering page to reflect the actual storage engines we care about comparing. Before this change, browser was already OPFS-backed, but native/native Criterion mixed together a single native lane and several memory-backed Criterion scenarios.

## Impact

The benchmark site, history ingestion, and CI artifacts now preserve `storage_engine` metadata, so same-suite runs no longer overwrite each other.

CI will build and run separate native RocksDB and SQLite lanes, and the benchmark catalog now points to engine-specific Criterion groups for every native scenario.

## Root cause

The native benchmark runner and history/site pipeline assumed there was only one native run per suite, and the realistic Criterion bench still left a number of scenarios on memory-backed groups instead of storage-backed ones.

## Validation

- `node --test benchmarks/realistic/ci_benchmarks.test.mjs benchmarks/realistic/update_history.test.mjs`
- `cargo bench -p jazz-tools --features rocksdb --bench realistic_phase1 --no-run`
- `cargo bench -p jazz-tools --features sqlite --bench realistic_phase1 --no-run`
- `cargo bench -p jazz-tools --features rocksdb --bench realistic_phase1 -- --list`
- `cargo bench -p jazz-tools --features sqlite --bench realistic_phase1 -- --list`