### PR TITLE
feat: new migration flow cleanup

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -14,7 +14,6 @@
 
 - [**duplicated-sync-transport-state-machines**](todo/issues/duplicated-sync-transport-state-machines.md) — Main-thread client and worker each implement similar reconnect/auth/streaming logic, creating divergence risk and duplicated bug-fix cost.
 - [**intentional-index-staleness-fallback**](todo/issues/intentional-index-staleness-fallback.md) — Update paths tolerate stale indexing when old row content is missing, making query correctness probabilistic under some sync histories.
-- [**lens-transform-silent-degradation**](todo/issues/lens-transform-silent-degradation.md) — Failed lens transforms fall back to original data and continue, silently propagating schema mismatches.
 - [**policy-error-reasons**](todo/issues/policy-error-reasons.md) — Policy-denied errors (e.g. `WriteError("policy denied INSERT on table todos")`) include
 
 ## Ideas

--- a/crates/jazz-tools/src/routes.rs
+++ b/crates/jazz-tools/src/routes.rs
@@ -92,6 +92,13 @@ struct SchemaHashesResponse {
     hashes: Vec<String>,
 }
 
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct StoredSchemaResponse {
+    schema: Schema,
+    published_at: Option<u64>,
+}
+
 #[derive(Debug, Deserialize)]
 struct AdminSubscriptionIntrospectionParams {
     #[serde(rename = "appId")]
@@ -626,7 +633,7 @@ async fn sync_handler(
     Json(SyncBatchResponse { results }).into_response()
 }
 
-/// Return the catalogue schema for the given hash.
+/// Return the catalogue schema for the given hash plus its publish timestamp.
 ///
 /// Requires a valid admin secret; returns 404 if no schema exists for the hash.
 async fn schema_handler(
@@ -675,11 +682,26 @@ async fn schema_handler(
 
     match state.runtime.known_schema(&schema_hash) {
         Ok(Some(schema)) => {
+            let published_at = match state.runtime.schema_published_at(&schema_hash) {
+                Ok(timestamp) => timestamp,
+                Err(err) => {
+                    return (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        Json(ErrorResponse::internal(format!(
+                            "failed to read schema publish timestamp: {err}"
+                        ))),
+                    )
+                        .into_response();
+                }
+            };
             tracing::info!(
                 requested_hash = %schema_hash.short(),
                 "schema request: returning requested hash"
             );
-            let body = schema.clone();
+            let body = StoredSchemaResponse {
+                schema: schema.clone(),
+                published_at,
+            };
             Json(body).into_response()
         }
         Ok(None) => (
@@ -1937,7 +1959,7 @@ mod tests {
             )
             .build();
         let schema_hash = SchemaHash::compute(&schema);
-        let state = make_state_with_schema(schema).await;
+        let state = make_state_with_schema(schema.clone()).await;
 
         let app = make_test_router(state);
 
@@ -1975,6 +1997,13 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(schema_response.status(), StatusCode::OK);
+        let schema_body = body::to_bytes(schema_response.into_body(), usize::MAX)
+            .await
+            .expect("schema body");
+        let schema_json: Value = serde_json::from_slice(&schema_body).expect("schema json");
+        let expected_schema_json = serde_json::to_value(schema).expect("expected schema json");
+        assert_eq!(schema_json["schema"], expected_schema_json);
+        assert!(schema_json.get("publishedAt").is_some());
 
         let bad_hash_response = app
             .oneshot(

--- a/crates/jazz-tools/src/runtime_tokio.rs
+++ b/crates/jazz-tools/src/runtime_tokio.rs
@@ -521,6 +521,15 @@ impl<S: Storage + Send + 'static> TokioRuntime<S> {
         Ok(core.schema_manager().get_known_schema(schema_hash).cloned())
     }
 
+    /// Return the latest publish timestamp for a schema catalogue object.
+    pub fn schema_published_at(
+        &self,
+        schema_hash: &SchemaHash,
+    ) -> Result<Option<u64>, RuntimeError> {
+        let core = self.core.lock().map_err(|_| RuntimeError::LockError)?;
+        Ok(core.schema_manager().schema_published_at(schema_hash))
+    }
+
     /// Seed an additional known schema into the in-memory schema manager.
     pub fn add_known_schema(&self, schema: Schema) -> Result<(), RuntimeError> {
         let mut core = self.core.lock().map_err(|_| RuntimeError::LockError)?;

--- a/crates/jazz-tools/tests/auth_test.rs
+++ b/crates/jazz-tools/tests/auth_test.rs
@@ -986,6 +986,7 @@ mod integration_tests {
         assert_eq!(schema_response.status(), StatusCode::OK);
         let schema_json: Value = schema_response.json().await.unwrap();
         let expected_schema_json = serde_json::to_value(schema.clone()).unwrap();
-        assert_eq!(schema_json, expected_schema_json);
+        assert_eq!(schema_json["schema"], expected_schema_json);
+        assert!(schema_json.get("publishedAt").is_some());
     }
 }

--- a/docs/content/docs/schemas/migrations.mdx
+++ b/docs/content/docs/schemas/migrations.mdx
@@ -14,23 +14,27 @@ Traditional migration systems run a linear sequence and require peers to converg
 
 ## Workflow
 
-1. **Edit `schema.ts`**&hairsp;—&hairsp;change the data shape as needed.
-2. **Validate locally**&hairsp;—&hairsp;optionally run `npx jazz-tools@alpha validate` to catch authoring errors
-   before connecting.
-3. **Connect a dev client**&hairsp;—&hairsp;on development servers (`NODE_ENV` unset or anything except
-   `production`), clients auto-publish the new structural schema hash when they connect. This
-   teaches the server the new hash but does not create compatibility edges for existing data.
-4. **Generate a migration stub**&hairsp;—&hairsp;once Jazz reports the old and new hash pair, run:
+1. If this is the first migration you are creating, run:
 
    ```bash
-   npx jazz-tools@alpha migrations create <fromHash> <toHash>
+   npx jazz-tools@alpha migrations create
    ```
 
-   This writes a typed `defineMigration(...)` file into `migrations/` with the structural diff
-   pre-filled and `from`/`to` schema witnesses for type safety.
+   This creates an initial snapshot of your schema in `migrations/snapshots/`. No migration file is created yet because there is no previous schema to diff against.
 
-5. **Review and customise**&hairsp;—&hairsp;rename the file to something meaningful, adjust defaults, add
-   backwards defaults if needed (see below).
+2. **Edit `schema.ts`**&hairsp;—&hairsp;change the data shape as needed.
+3. **Validate locally**&hairsp;—&hairsp;optionally run `npx jazz-tools@alpha validate` to catch authoring errors
+   before connecting.
+4. **Create a migration stub for the updated schema**&hairsp;—&hairsp;run:
+
+   ```bash
+   npx jazz-tools@alpha migrations create --name <your-migration-name>
+   ```
+
+   By default, Jazz diffs the latest committed snapshot in `migrations/snapshots/` against the
+   current schema and writes a stub migration file into `migrations/`. It also saves a snapshot of the generated schema.
+
+5. **Review and customise**&hairsp;—&hairsp; the migration, if needed (see below).
 6. **Publish**&hairsp;—&hairsp;push the migration to the server:
 
    ```bash
@@ -84,19 +88,61 @@ When a newer schema drops a column that older clients still expect, define a bac
   ../examples/docs/todo-server-ts/migrations/20260318-drop-legacy-priority-311995e9a178-73b65d082ab8.ts
 </include>
 
+## Migrating historical schemas
+
+Jazz does not require you to create a migration for every schema change. You can just use the app and create new data.
+Existing data will still be available, but you will not be able to read it until you create a migration.
+
+This is particularly useful when you are iterating on a feature that is not yet ready to be released.
+
+The Jazz server will detect when there are rows that are not reachable from the current schema. It will log a warning and suggest you create a migration.
+
+In order to do so, you'll need to **create the migration using explicit to/from schema hashes**:
+
+```bash
+npx jazz-tools@alpha migrations create --fromHash <fromHash>
+npx jazz-tools@alpha migrations create --fromHash <fromHash> --toHash <toHash>
+```
+
+`--toHash` defaults to the current local schema. When a requested hash is not already saved locally, Jazz resolves it from the
+server and saves a snapshot in `migrations/snapshots/`.
+
 ## Exporting the compiled schema
 
-`npx jazz-tools@alpha schema export` prints the compiled structural schema as JSON to stdout. This is useful for inspecting the exact schema the runtime sees, or for piping into external tooling.
+`npx jazz-tools@alpha schema export` prints the compiled structural schema as JSON to stdout. It
+also saves a snapshot of the schema in the local snapshot directory.
 
 ```bash
 npx jazz-tools@alpha schema export
 npx jazz-tools@alpha schema export --schema-dir ./packages/app
+npx jazz-tools@alpha schema export --schema-hash <hash> --server-url http://localhost:4200 --admin-secret <secret>
 ```
 
-| Flag                  | Default           | Description                                 |
-| --------------------- | ----------------- | ------------------------------------------- |
-| `--schema-dir <path>` | current directory | Path to app root containing `schema.ts`     |
-| `--format json`       | `json`            | Output format (only `json` supported today) |
+Without `--schema-hash`, Jazz exports the current local `schema.ts`. With `--schema-hash`, it
+loads the schema from the local snapshot folder or, if missing, from the server.
+`--schema-dir` and `--schema-hash` are mutually exclusive.
+
+| Flag                   | Default             | Description                                                     |
+| ---------------------- | ------------------- | --------------------------------------------------------------- |
+| `--schema-dir <path>`  | current directory   | Path to app root containing `schema.ts`                         |
+| `--schema-hash <hash>` | none                | Export a stored structural schema by hash                       |
+| `--migrations-dir <p>` | `./migrations`      | Path to migrations directory and snapshot folder                |
+| `--server-url <url>`   | `JAZZ_SERVER_URL`   | Server URL used when `--schema-hash` is not available locally   |
+| `--admin-secret <sec>` | `JAZZ_ADMIN_SECRET` | Admin secret used when `--schema-hash` is not available locally |
+
+## Migration flags
+
+`migrations create` uses flags rather than positional hashes.
+
+| Flag                   | Default             | Description                                      |
+| ---------------------- | ------------------- | ------------------------------------------------ |
+| `--schema-dir <path>`  | current directory   | Path to app root containing `schema.ts`          |
+| `--migrations-dir <p>` | `./migrations`      | Path to migrations directory and snapshot folder |
+| `--server-url <url>`   | `JAZZ_SERVER_URL`   | Server URL used when resolving missing schema    |
+| `--admin-secret <sec>` | `JAZZ_ADMIN_SECRET` | Admin secret used when resolving missing schema  |
+| `--fromHash <hash>`    | latest snapshot     | Optional source schema hash                      |
+| `--toHash <hash>`      | current schema      | Optional target schema hash                      |
+| `--name <name>`        | `unnamed`           | Optional migration filename label                |
 
 ## Next steps
 

--- a/examples/docs/todo-server-rs/src/main.rs
+++ b/examples/docs/todo-server-rs/src/main.rs
@@ -51,14 +51,7 @@ pub struct AppState {
 fn load_schema_from_cli(schema_dir: &str) -> Result<Schema, Box<dyn std::error::Error>> {
     let jazz_tools_bin = std::env::var("JAZZ_TOOLS_BIN").unwrap_or_else(|_| "jazz-tools".into());
     let output = Command::new(jazz_tools_bin)
-        .args([
-            "schema",
-            "export",
-            "--schema-dir",
-            schema_dir,
-            "--format",
-            "json",
-        ])
+        .args(["schema", "export", "--schema-dir", schema_dir])
         .output()?;
 
     if !output.status.success() {

--- a/examples/todo-server-rs/src/main.rs
+++ b/examples/todo-server-rs/src/main.rs
@@ -50,14 +50,7 @@ pub struct AppState {
 fn load_schema_from_cli(schema_dir: &str) -> Result<Schema, Box<dyn std::error::Error>> {
     let jazz_tools_bin = std::env::var("JAZZ_TOOLS_BIN").unwrap_or_else(|_| "jazz-tools".into());
     let output = Command::new(jazz_tools_bin)
-        .args([
-            "schema",
-            "export",
-            "--schema-dir",
-            schema_dir,
-            "--format",
-            "json",
-        ])
+        .args(["schema", "export", "--schema-dir", schema_dir])
         .output()?;
 
     if !output.status.success() {

--- a/packages/jazz-tools/bin/docs-index.txt
+++ b/packages/jazz-tools/bin/docs-index.txt
@@ -3939,7 +3939,7 @@ type AppSchema = s.Schema<typeof schema>;
     In practice, a Rust app runs the schema export command and deserializes the JSON into Jazz's Rust `Schema` type:
 
     ```bash
-    npx jazz-tools schema export --format json
+    npx jazz-tools schema export
     ```
 
     The Rust examples shell out to this command at startup, so the schema definition stays unified even when the app itself is written in Rust. See [Setup](/docs/setup) for the end-to-end backend context pattern.

--- a/packages/jazz-tools/src/cli.test.ts
+++ b/packages/jazz-tools/src/cli.test.ts
@@ -259,6 +259,20 @@ function storedRootSchemaWithReorderedColumns() {
   };
 }
 
+function storedSchemaResponse(
+  schema: object,
+  publishedAt: number | null = null,
+  status: number = 200,
+) {
+  return new Response(
+    JSON.stringify({
+      schema,
+      publishedAt,
+    }),
+    { status },
+  );
+}
+
 describe("cli validate", () => {
   it("validates root schema.ts without generating SQL or app artifacts", async () => {
     const { root } = await createWorkspace();
@@ -565,14 +579,11 @@ describe("cli migrations", () => {
       }
 
       if (input.endsWith(`/schema/${fromHash}`)) {
-        return new Response(
-          JSON.stringify({
-            todos: {
-              columns: [{ name: "title", column_type: { type: "Text" }, nullable: false }],
-            },
-          }),
-          { status: 200 },
-        );
+        return storedSchemaResponse({
+          todos: {
+            columns: [{ name: "title", column_type: { type: "Text" }, nullable: false }],
+          },
+        });
       }
 
       throw new Error(`Unexpected fetch: ${input}`);
@@ -625,34 +636,28 @@ describe("cli migrations", () => {
       }
 
       if (input.endsWith(`/schema/${fromHash}`)) {
-        return new Response(
-          JSON.stringify({
-            todos: {
-              columns: [{ name: "title", column_type: { type: "Text" }, nullable: false }],
-            },
-            legacy_users: {
-              columns: [{ name: "email", column_type: { type: "Text" }, nullable: false }],
-            },
-          }),
-          { status: 200 },
-        );
+        return storedSchemaResponse({
+          todos: {
+            columns: [{ name: "title", column_type: { type: "Text" }, nullable: false }],
+          },
+          legacy_users: {
+            columns: [{ name: "email", column_type: { type: "Text" }, nullable: false }],
+          },
+        });
       }
 
       if (input.endsWith(`/schema/${toHash}`)) {
-        return new Response(
-          JSON.stringify({
-            todos: {
-              columns: [
-                { name: "title", column_type: { type: "Text" }, nullable: false },
-                { name: "notes", column_type: { type: "Text" }, nullable: true },
-              ],
-            },
-            users: {
-              columns: [{ name: "name", column_type: { type: "Text" }, nullable: false }],
-            },
-          }),
-          { status: 200 },
-        );
+        return storedSchemaResponse({
+          todos: {
+            columns: [
+              { name: "title", column_type: { type: "Text" }, nullable: false },
+              { name: "notes", column_type: { type: "Text" }, nullable: true },
+            ],
+          },
+          users: {
+            columns: [{ name: "name", column_type: { type: "Text" }, nullable: false }],
+          },
+        });
       }
 
       throw new Error(`Unexpected fetch: ${input}`);
@@ -694,25 +699,19 @@ describe("cli migrations", () => {
       }
 
       if (input.endsWith(`/schema/${fromHash}`)) {
-        return new Response(
-          JSON.stringify({
-            users: {
-              columns: [{ name: "email", column_type: { type: "Text" }, nullable: false }],
-            },
-          }),
-          { status: 200 },
-        );
+        return storedSchemaResponse({
+          users: {
+            columns: [{ name: "email", column_type: { type: "Text" }, nullable: false }],
+          },
+        });
       }
 
       if (input.endsWith(`/schema/${toHash}`)) {
-        return new Response(
-          JSON.stringify({
-            people: {
-              columns: [{ name: "email", column_type: { type: "Text" }, nullable: false }],
-            },
-          }),
-          { status: 200 },
-        );
+        return storedSchemaResponse({
+          people: {
+            columns: [{ name: "email", column_type: { type: "Text" }, nullable: false }],
+          },
+        });
       }
 
       throw new Error(`Unexpected fetch: ${input}`);
@@ -753,31 +752,25 @@ describe("cli migrations", () => {
       }
 
       if (input.endsWith(`/schema/${fromHash}`)) {
-        return new Response(
-          JSON.stringify({
-            users: {
-              columns: [{ name: "email", column_type: { type: "Text" }, nullable: false }],
-            },
-            orgs: {
-              columns: [{ name: "slug", column_type: { type: "Text" }, nullable: false }],
-            },
-          }),
-          { status: 200 },
-        );
+        return storedSchemaResponse({
+          users: {
+            columns: [{ name: "email", column_type: { type: "Text" }, nullable: false }],
+          },
+          orgs: {
+            columns: [{ name: "slug", column_type: { type: "Text" }, nullable: false }],
+          },
+        });
       }
 
       if (input.endsWith(`/schema/${toHash}`)) {
-        return new Response(
-          JSON.stringify({
-            companies: {
-              columns: [{ name: "slug", column_type: { type: "Text" }, nullable: false }],
-            },
-            people: {
-              columns: [{ name: "email", column_type: { type: "Text" }, nullable: false }],
-            },
-          }),
-          { status: 200 },
-        );
+        return storedSchemaResponse({
+          companies: {
+            columns: [{ name: "slug", column_type: { type: "Text" }, nullable: false }],
+          },
+          people: {
+            columns: [{ name: "email", column_type: { type: "Text" }, nullable: false }],
+          },
+        });
       }
 
       throw new Error(`Unexpected fetch: ${input}`);
@@ -821,28 +814,22 @@ describe("cli migrations", () => {
       }
 
       if (input.endsWith(`/schema/${fromHash}`)) {
-        return new Response(
-          JSON.stringify({
-            archived_users: {
-              columns: [{ name: "email", column_type: { type: "Text" }, nullable: false }],
-            },
-            users: {
-              columns: [{ name: "email", column_type: { type: "Text" }, nullable: false }],
-            },
-          }),
-          { status: 200 },
-        );
+        return storedSchemaResponse({
+          archived_users: {
+            columns: [{ name: "email", column_type: { type: "Text" }, nullable: false }],
+          },
+          users: {
+            columns: [{ name: "email", column_type: { type: "Text" }, nullable: false }],
+          },
+        });
       }
 
       if (input.endsWith(`/schema/${toHash}`)) {
-        return new Response(
-          JSON.stringify({
-            people: {
-              columns: [{ name: "email", column_type: { type: "Text" }, nullable: false }],
-            },
-          }),
-          { status: 200 },
-        );
+        return storedSchemaResponse({
+          people: {
+            columns: [{ name: "email", column_type: { type: "Text" }, nullable: false }],
+          },
+        });
       }
 
       throw new Error(`Unexpected fetch: ${input}`);
@@ -1118,7 +1105,7 @@ describe("cli permissions", () => {
       }
 
       if (input.endsWith(`/schema/${schemaHash}`)) {
-        return new Response(JSON.stringify(storedRootSchema()), { status: 200 });
+        return storedSchemaResponse(storedRootSchema());
       }
 
       if (input.endsWith("/admin/permissions/head")) {
@@ -1172,7 +1159,7 @@ describe("cli permissions", () => {
       }
 
       if (input.endsWith(`/schema/${schemaHash}`)) {
-        return new Response(JSON.stringify(storedRootSchema()), { status: 200 });
+        return storedSchemaResponse(storedRootSchema());
       }
 
       if (input.endsWith("/admin/permissions/head")) {
@@ -1207,9 +1194,7 @@ describe("cli permissions", () => {
       }
 
       if (input.endsWith(`/schema/${schemaHash}`)) {
-        return new Response(JSON.stringify(storedRootSchemaWithReorderedColumns()), {
-          status: 200,
-        });
+        return storedSchemaResponse(storedRootSchemaWithReorderedColumns());
       }
 
       if (input.endsWith("/admin/permissions/head")) {
@@ -1252,7 +1237,7 @@ describe("cli permissions", () => {
       }
 
       if (input.endsWith(`/schema/${schemaHash}`)) {
-        return new Response(JSON.stringify(storedRootSchema()), { status: 200 });
+        return storedSchemaResponse(storedRootSchema());
       }
 
       if (input.endsWith("/admin/permissions/head")) {
@@ -1309,17 +1294,14 @@ describe("cli permissions", () => {
       }
 
       if (input.endsWith(`/schema/${schemaHash}`)) {
-        return new Response(
-          JSON.stringify({
-            todos: {
-              columns: [
-                { name: "title", column_type: { type: "Text" }, nullable: false },
-                { name: "done", column_type: { type: "Boolean" }, nullable: false },
-              ],
-            },
-          }),
-          { status: 200 },
-        );
+        return storedSchemaResponse({
+          todos: {
+            columns: [
+              { name: "title", column_type: { type: "Text" }, nullable: false },
+              { name: "done", column_type: { type: "Boolean" }, nullable: false },
+            ],
+          },
+        });
       }
 
       if (input.endsWith("/admin/permissions/head")) {
@@ -1543,6 +1525,7 @@ describe("bin integration", () => {
     const { root } = await createWorkspace();
     const schema = storedRootSchema();
     const schemaHash = await computeTestSchemaHash(schema);
+    const publishedAt = Date.UTC(2026, 3, 6, 12, 0, 0);
     const writes: string[] = [];
     const originalWrite = process.stdout.write.bind(process.stdout);
     const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(((
@@ -1556,7 +1539,7 @@ describe("bin integration", () => {
       expect(input).toContain(`/schema/${schemaHash}`);
       expect(init?.method).toBe("GET");
       expect(init?.headers).toMatchObject({ "X-Jazz-Admin-Secret": "admin-secret" });
-      return new Response(JSON.stringify(schema), { status: 200 });
+      return storedSchemaResponse(schema, publishedAt);
     });
     vi.stubGlobal("fetch", fetchMock);
 
@@ -1578,7 +1561,7 @@ describe("bin integration", () => {
       name.endsWith(`-${shortSchemaHash}.json`),
     );
     expect(snapshotFiles).toHaveLength(1);
-    expect(snapshotFiles[0]).toMatch(/^\d{8}T\d{6}-[0-9a-f]{12}\.json$/i);
+    expect(snapshotFiles[0]).toBe(`20260406T120000-${shortSchemaHash}.json`);
     expect(
       JSON.parse(await readFile(join(root, "migrations", "snapshots", snapshotFiles[0]!), "utf8")),
     ).toEqual(schema);
@@ -1590,6 +1573,7 @@ describe("bin integration", () => {
     const migrationsDir = join(root, "db", "generated-migrations");
     const schema = storedRootSchema();
     const schemaHash = await computeTestSchemaHash(schema);
+    const publishedAt = Date.UTC(2026, 3, 6, 12, 0, 0);
     await writeFile(join(root, "schema.ts"), rootSchemaWithTodoNotes());
 
     const writes: string[] = [];
@@ -1605,7 +1589,7 @@ describe("bin integration", () => {
       expect(input).toContain(`/schema/${schemaHash}`);
       expect(init?.method).toBe("GET");
       expect(init?.headers).toMatchObject({ "X-Jazz-Admin-Secret": "admin-secret" });
-      return new Response(JSON.stringify(schema), { status: 200 });
+      return storedSchemaResponse(schema, publishedAt);
     });
     vi.stubGlobal("fetch", exportFetchMock);
 

--- a/packages/jazz-tools/src/cli.test.ts
+++ b/packages/jazz-tools/src/cli.test.ts
@@ -367,7 +367,7 @@ describe("cli schema export", () => {
     }) as typeof process.stdout.write);
 
     try {
-      await exportSchema({ schemaDir: root, format: "json" });
+      await exportSchema({ schemaDir: root });
     } finally {
       writeSpy.mockRestore();
       process.stdout.write = originalWrite;
@@ -397,8 +397,8 @@ describe("cli schema export", () => {
     }) as typeof process.stdout.write);
 
     try {
-      await exportSchema({ schemaDir: root, format: "json" });
-      await exportSchema({ schemaDir: root, format: "json" });
+      await exportSchema({ schemaDir: root });
+      await exportSchema({ schemaDir: root });
     } finally {
       writeSpy.mockRestore();
       process.stdout.write = originalWrite;
@@ -427,7 +427,7 @@ describe("cli schema export", () => {
     }) as typeof process.stdout.write);
 
     try {
-      await exportSchema({ schemaDir: root, format: "json" });
+      await exportSchema({ schemaDir: root });
     } finally {
       writeSpy.mockRestore();
       process.stdout.write = originalWrite;
@@ -1475,7 +1475,7 @@ describe("bin integration", () => {
       rootPermissionsSchema("./schema.ts", distIndexPath),
     );
 
-    const result = runBin(["schema", "export", "--schema-dir", root, "--format", "json"]);
+    const result = runBin(["schema", "export", "--schema-dir", root]);
 
     expect(result.status).toBe(0);
     const exported = JSON.parse(String(result.stdout));
@@ -1509,9 +1509,31 @@ describe("bin integration", () => {
       "utf8",
     );
 
-    const result = runBin(["schema", "export", "--schema-hash", schemaHash, "--format", "json"], {
+    const result = runBin(["schema", "export", "--schema-hash", schemaHash], {
       cwd: root,
     });
+
+    expect(result.status).toBe(0);
+    expect(JSON.parse(String(result.stdout))).toEqual(schema);
+  });
+
+  it("loads schema export --schema-hash from a custom migrations dir", async () => {
+    const { root } = await createWorkspace();
+    const schema = storedRootSchema();
+    const schemaHash = await computeTestSchemaHash(schema);
+    const migrationsDir = join(root, "db", "generated-migrations");
+    const snapshotsDir = join(migrationsDir, "snapshots");
+    await mkdir(snapshotsDir, { recursive: true });
+    await writeFile(
+      join(snapshotsDir, `20260406T120000-${schemaHash.slice(0, 12)}.json`),
+      JSON.stringify(schema, null, 2),
+      "utf8",
+    );
+
+    const result = runBin(
+      ["schema", "export", "--schema-hash", schemaHash, "--migrations-dir", migrationsDir],
+      { cwd: root },
+    );
 
     expect(result.status).toBe(0);
     expect(JSON.parse(String(result.stdout))).toEqual(schema);
@@ -1540,12 +1562,11 @@ describe("bin integration", () => {
 
     try {
       await exportSchema({
-        format: "json",
         schemaHash,
         schemaDir: root,
         serverUrl: "http://localhost:1625",
         adminSecret: "admin-secret",
-      } as any);
+      });
     } finally {
       writeSpy.mockRestore();
       process.stdout.write = originalWrite;
@@ -1562,6 +1583,71 @@ describe("bin integration", () => {
       JSON.parse(await readFile(join(root, "migrations", "snapshots", snapshotFiles[0]!), "utf8")),
     ).toEqual(schema);
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("persists schema export --schema-hash into a custom migrations dir", async () => {
+    const { root } = await createWorkspace();
+    const migrationsDir = join(root, "db", "generated-migrations");
+    const schema = storedRootSchema();
+    const schemaHash = await computeTestSchemaHash(schema);
+    await writeFile(join(root, "schema.ts"), rootSchemaWithTodoNotes());
+
+    const writes: string[] = [];
+    const originalWrite = process.stdout.write.bind(process.stdout);
+    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(((
+      chunk: string | Uint8Array,
+    ) => {
+      writes.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"));
+      return true;
+    }) as typeof process.stdout.write);
+
+    const exportFetchMock = vi.fn(async (input: string, init?: RequestInit) => {
+      expect(input).toContain(`/schema/${schemaHash}`);
+      expect(init?.method).toBe("GET");
+      expect(init?.headers).toMatchObject({ "X-Jazz-Admin-Secret": "admin-secret" });
+      return new Response(JSON.stringify(schema), { status: 200 });
+    });
+    vi.stubGlobal("fetch", exportFetchMock);
+
+    try {
+      await exportSchema({
+        schemaHash,
+        schemaDir: root,
+        migrationsDir,
+        serverUrl: "http://localhost:1625",
+        adminSecret: "admin-secret",
+      });
+    } finally {
+      writeSpy.mockRestore();
+      process.stdout.write = originalWrite;
+    }
+
+    expect(JSON.parse(writes.join(""))).toEqual(schema);
+    const snapshotFiles = (await readdir(join(migrationsDir, "snapshots"))).filter((name) =>
+      name.endsWith(`-${schemaHash.slice(0, 12)}.json`),
+    );
+    expect(snapshotFiles).toHaveLength(1);
+    expect(
+      JSON.parse(await readFile(join(migrationsDir, "snapshots", snapshotFiles[0]!), "utf8")),
+    ).toEqual(schema);
+    expect(exportFetchMock).toHaveBeenCalledTimes(1);
+
+    // Later migrations use the exported local snapshot
+    const migrationFetchMock = vi.fn(async () => {
+      throw new Error("Expected createMigration() to use the exported local snapshot.");
+    });
+    vi.stubGlobal("fetch", migrationFetchMock);
+
+    const filePath = await createMigration({
+      schemaDir: root,
+      migrationsDir,
+      fromHash: schemaHash.slice(0, 12),
+      serverUrl: "http://localhost:1625",
+      adminSecret: "admin-secret",
+    });
+
+    expect(filePath).not.toBeNull();
+    expect(migrationFetchMock).not.toHaveBeenCalled();
   });
 
   it("verifies packed runtime bootstrap with a native-only help probe", async () => {

--- a/packages/jazz-tools/src/cli.ts
+++ b/packages/jazz-tools/src/cli.ts
@@ -344,10 +344,11 @@ async function writeSnapshotSchema(
   migrationsDir: string | undefined,
   hash: string,
   schema: WasmSchema,
+  timestamp: string = createTimestamp(),
 ): Promise<string> {
   const dir = snapshotsDir(schemaDir, migrationsDir);
   await mkdir(dir, { recursive: true });
-  const filePath = join(dir, snapshotFilename(hash));
+  const filePath = join(dir, snapshotFilename(hash, timestamp));
   await writeFile(filePath, `${JSON.stringify(schema, null, 2)}\n`);
   return filePath;
 }
@@ -431,14 +432,18 @@ async function resolveExportedSchemaByHash(options: SchemaExportOptions): Promis
           "schema hash",
           (await fetchSchemaHashes(serverUrl, { adminSecret })).hashes,
         );
-  const schema = (
-    await fetchStoredWasmSchema(serverUrl, {
-      adminSecret,
-      schemaHash: resolvedHash,
-    })
-  ).schema;
-  await writeSnapshotSchema(options.schemaDir, options.migrationsDir, resolvedHash, schema);
-  return schema;
+  const storedSchema = await fetchStoredWasmSchema(serverUrl, {
+    adminSecret,
+    schemaHash: resolvedHash,
+  });
+  await writeSnapshotSchema(
+    options.schemaDir,
+    options.migrationsDir,
+    resolvedHash,
+    storedSchema.schema,
+    createSnapshotTimestampFromPublishedAt(storedSchema.publishedAt),
+  );
+  return storedSchema.schema;
 }
 
 let wasmModulePromise: Promise<any> | null = null;
@@ -991,6 +996,17 @@ function createTimestamp(now: Date = new Date()): string {
   return `${year}${month}${day}T${hours}${minutes}${seconds}`;
 }
 
+function createSnapshotTimestampFromPublishedAt(
+  publishedAt: number | null | undefined,
+  fallbackNow: Date = new Date(),
+): string {
+  if (typeof publishedAt !== "number" || !Number.isFinite(publishedAt) || publishedAt < 0) {
+    return createTimestamp(fallbackNow);
+  }
+
+  return createTimestamp(new Date(publishedAt));
+}
+
 function normalizeMigrationName(name: string): string {
   const normalized = name
     .trim()
@@ -1227,14 +1243,19 @@ async function resolveHistoricalSchema(
   const resolvedAdminSecret = requireSchemaExportServerValue(adminSecret, "adminSecret");
 
   try {
-    const schema = (
-      await fetchStoredWasmSchema(resolvedServerUrl, {
-        adminSecret: resolvedAdminSecret,
-        schemaHash: resolvedHash,
-      })
-    ).schema;
-    await writeSnapshotSchemaForMigrations(migrationsDir, snapshotFilename(resolvedHash), schema);
-    return { hash: resolvedHash, schema };
+    const storedSchema = await fetchStoredWasmSchema(resolvedServerUrl, {
+      adminSecret: resolvedAdminSecret,
+      schemaHash: resolvedHash,
+    });
+    await writeSnapshotSchemaForMigrations(
+      migrationsDir,
+      snapshotFilename(
+        resolvedHash,
+        createSnapshotTimestampFromPublishedAt(storedSchema.publishedAt),
+      ),
+      storedSchema.schema,
+    );
+    return { hash: resolvedHash, schema: storedSchema.schema };
   } catch (error) {
     if (error instanceof Error && /Schema fetch failed: 404/i.test(error.message)) {
       throw new Error(`No stored schema found for ${label} ${resolvedHash}.`);

--- a/packages/jazz-tools/src/cli.ts
+++ b/packages/jazz-tools/src/cli.ts
@@ -34,7 +34,7 @@ export interface BuildOptions {
 
 export interface SchemaExportOptions {
   schemaDir: string;
-  format: "json";
+  migrationsDir?: string;
   schemaHash?: string;
   serverUrl?: string;
   adminSecret?: string;
@@ -92,10 +92,6 @@ export async function validate(options: BuildOptions): Promise<void> {
 }
 
 export async function exportSchema(options: SchemaExportOptions): Promise<void> {
-  if (options.format !== "json") {
-    throw new Error(`Unsupported schema export format: ${options.format}`);
-  }
-
   if (options.schemaHash) {
     const schema = await resolveExportedSchemaByHash(options);
     process.stdout.write(`${JSON.stringify(schema, null, 2)}\n`);
@@ -103,7 +99,7 @@ export async function exportSchema(options: SchemaExportOptions): Promise<void> 
   }
 
   const currentSchema = await loadCurrentSchema(options.schemaDir);
-  await ensureLocalSnapshot(options.schemaDir, currentSchema);
+  await ensureLocalSnapshot(options.schemaDir, options.migrationsDir, currentSchema);
   process.stdout.write(`${JSON.stringify(currentSchema.schema, null, 2)}\n`);
 }
 
@@ -236,12 +232,16 @@ function defaultMigrationsDir(schemaDir: string): string {
   return join(schemaDir, "migrations");
 }
 
+function resolvedMigrationsDir(schemaDir: string, migrationsDir?: string): string {
+  return migrationsDir ?? defaultMigrationsDir(schemaDir);
+}
+
 function snapshotsDirForMigrations(migrationsDir: string): string {
   return join(migrationsDir, "snapshots");
 }
 
-function snapshotsDir(schemaDir: string): string {
-  return snapshotsDirForMigrations(defaultMigrationsDir(schemaDir));
+function snapshotsDir(schemaDir: string, migrationsDir?: string): string {
+  return snapshotsDirForMigrations(resolvedMigrationsDir(schemaDir, migrationsDir));
 }
 
 interface SnapshotEntry {
@@ -281,8 +281,11 @@ async function listSnapshotEntries(dir: string): Promise<SnapshotEntry[]> {
   );
 }
 
-async function listLocalSnapshotEntries(schemaDir: string): Promise<SnapshotEntry[]> {
-  return listSnapshotEntries(snapshotsDir(schemaDir));
+async function listLocalSnapshotEntries(
+  schemaDir: string,
+  migrationsDir?: string,
+): Promise<SnapshotEntry[]> {
+  return listSnapshotEntries(snapshotsDir(schemaDir, migrationsDir));
 }
 
 async function listSnapshotEntriesForMigrations(migrationsDir: string): Promise<SnapshotEntry[]> {
@@ -291,10 +294,11 @@ async function listSnapshotEntriesForMigrations(migrationsDir: string): Promise<
 
 async function resolveLocalSnapshotEntry(
   schemaDir: string,
+  migrationsDir: string | undefined,
   hash: string,
   label: string,
 ): Promise<SnapshotEntry | null> {
-  const entries = await listLocalSnapshotEntries(schemaDir);
+  const entries = await listLocalSnapshotEntries(schemaDir, migrationsDir);
   if (entries.length === 0) {
     return null;
   }
@@ -320,10 +324,11 @@ async function resolveLocalSnapshotEntry(
 
 async function loadLocalSnapshotSchema(
   schemaDir: string,
+  migrationsDir: string | undefined,
   hash: string,
   label: string,
 ): Promise<{ hash: string; schema: WasmSchema } | null> {
-  const entry = await resolveLocalSnapshotEntry(schemaDir, hash, label);
+  const entry = await resolveLocalSnapshotEntry(schemaDir, migrationsDir, hash, label);
   if (!entry) {
     return null;
   }
@@ -336,10 +341,11 @@ async function loadLocalSnapshotSchema(
 
 async function writeSnapshotSchema(
   schemaDir: string,
+  migrationsDir: string | undefined,
   hash: string,
   schema: WasmSchema,
 ): Promise<string> {
-  const dir = snapshotsDir(schemaDir);
+  const dir = snapshotsDir(schemaDir, migrationsDir);
   await mkdir(dir, { recursive: true });
   const filePath = join(dir, snapshotFilename(hash));
   await writeFile(filePath, `${JSON.stringify(schema, null, 2)}\n`);
@@ -348,14 +354,15 @@ async function writeSnapshotSchema(
 
 async function ensureLocalSnapshot(
   schemaDir: string,
+  migrationsDir: string | undefined,
   schema: { hash: string; schema: WasmSchema },
 ): Promise<string | null> {
-  const entries = await listLocalSnapshotEntries(schemaDir);
+  const entries = await listLocalSnapshotEntries(schemaDir, migrationsDir);
   if (entries.some((entry) => entry.hash === schema.hash)) {
     return null;
   }
 
-  return writeSnapshotSchema(schemaDir, schema.hash, schema.schema);
+  return writeSnapshotSchema(schemaDir, migrationsDir, schema.hash, schema.schema);
 }
 
 async function writeSnapshotSchemaForMigrations(
@@ -397,7 +404,12 @@ function requireMigrationServerOptions(options: MigrationCommandOptions): {
 
 async function resolveExportedSchemaByHash(options: SchemaExportOptions): Promise<WasmSchema> {
   const schemaHash = normalizeSchemaHashInput(options.schemaHash!, "schema hash");
-  const local = await loadLocalSnapshotSchema(options.schemaDir, schemaHash, "schema hash");
+  const local = await loadLocalSnapshotSchema(
+    options.schemaDir,
+    options.migrationsDir,
+    schemaHash,
+    "schema hash",
+  );
   if (local) {
     return local.schema;
   }
@@ -425,7 +437,7 @@ async function resolveExportedSchemaByHash(options: SchemaExportOptions): Promis
       schemaHash: resolvedHash,
     })
   ).schema;
-  await writeSnapshotSchema(options.schemaDir, resolvedHash, schema);
+  await writeSnapshotSchema(options.schemaDir, options.migrationsDir, resolvedHash, schema);
   return schema;
 }
 
@@ -1474,7 +1486,7 @@ if (isMainModule()) {
     const subcommand = process.argv[3] ?? "";
     if (subcommand !== "export") {
       console.error(
-        "Usage: node dist/cli.js schema export [--schema-dir <path> | --schema-hash <hash>] [--server-url <url>] [--admin-secret <secret>] [--format json]",
+        "Usage: node dist/cli.js schema export [--schema-dir <path> | --schema-hash <hash>] [--migrations-dir <path>] [--server-url <url>] [--admin-secret <secret>]",
       );
       process.exit(1);
     }
@@ -1488,18 +1500,14 @@ if (isMainModule()) {
     }
 
     const schemaDir = resolve(process.cwd(), schemaDirFlag ?? process.cwd());
-    const formatValue = getFlagValue(args, "--format") ?? "json";
-    if (formatValue !== "json") {
-      console.error(`Unsupported schema export format: ${formatValue}`);
-      process.exit(1);
-    }
-
     exportSchema({
       schemaDir,
+      migrationsDir: getFlagValue(args, "--migrations-dir")
+        ? resolve(process.cwd(), getFlagValue(args, "--migrations-dir")!)
+        : undefined,
       schemaHash,
       serverUrl: getFlagValue(args, "--server-url") ?? process.env.JAZZ_SERVER_URL,
       adminSecret: getFlagValue(args, "--admin-secret") ?? process.env.JAZZ_ADMIN_SECRET,
-      format: "json",
     }).catch((err) => {
       console.error(err.message);
       process.exit(1);
@@ -1574,9 +1582,9 @@ if (isMainModule()) {
     console.log("\nSchema export options:");
     console.log("  --schema-dir <path>   Path to app root containing schema.ts (default: .)");
     console.log("  --schema-hash <hash>  Export a stored structural schema by hash");
+    console.log("  --migrations-dir <p>  Path to migrations directory (default: ./migrations)");
     console.log("  --server-url <url>    Jazz server URL (or set JAZZ_SERVER_URL)");
     console.log("  --admin-secret <sec>  Admin secret (or set JAZZ_ADMIN_SECRET)");
-    console.log("  --format json         Output the compiled schema as JSON");
     console.log("\nPermissions options:");
     console.log("  --schema-dir <path>   Path to app root containing schema.ts (default: .)");
     console.log("  --server-url <url>    Jazz server URL (or set JAZZ_SERVER_URL)");

--- a/packages/jazz-tools/src/runtime/schema-fetch.test.ts
+++ b/packages/jazz-tools/src/runtime/schema-fetch.test.ts
@@ -19,7 +19,10 @@ describe("schema-fetch", () => {
       ok: true,
       status: 200,
       statusText: "OK",
-      json: async () => ({ users: { columns: [] } }),
+      json: async () => ({
+        schema: { users: { columns: [] } },
+        publishedAt: 1_744_011_200_000,
+      }),
     });
     (globalThis as { fetch: typeof fetch }).fetch = fetchMock as unknown as typeof fetch;
 
@@ -31,6 +34,7 @@ describe("schema-fetch", () => {
     });
 
     expect(result.schema.users).toBeDefined();
+    expect(result.publishedAt).toBe(1_744_011_200_000);
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(fetchMock.mock.calls[0]![0]).toBe(`http://localhost:1625/apps/app-123/schema/${hash}`);
     expect(fetchMock.mock.calls[0]![1]).toMatchObject({
@@ -93,7 +97,10 @@ describe("schema-fetch", () => {
       ok: true,
       status: 200,
       statusText: "OK",
-      json: async () => ({ users: { columns: [] } }),
+      json: async () => ({
+        schema: { users: { columns: [] } },
+        publishedAt: null,
+      }),
     });
     (globalThis as { fetch: typeof fetch }).fetch = fetchMock as unknown as typeof fetch;
 

--- a/packages/jazz-tools/src/runtime/schema-fetch.ts
+++ b/packages/jazz-tools/src/runtime/schema-fetch.ts
@@ -12,7 +12,7 @@ export interface FetchStoredWasmSchemaOptions {
 export async function fetchStoredWasmSchema(
   serverUrl: string,
   options: FetchStoredWasmSchemaOptions,
-): Promise<{ schema: WasmSchema }> {
+): Promise<{ schema: WasmSchema; publishedAt: number | null }> {
   const schemaUrl = buildEndpointUrl(
     serverUrl,
     `/schema/${encodeURIComponent(options.schemaHash)}`,
@@ -32,8 +32,15 @@ export async function fetchStoredWasmSchema(
     throw new Error(`Schema fetch failed: ${response.status} ${response.statusText}${detail}`);
   }
 
-  const schema = (await response.json()) as WasmSchema;
-  return { schema };
+  const body = (await response.json()) as {
+    schema: WasmSchema;
+    publishedAt?: number | null;
+  };
+
+  return {
+    schema: body.schema,
+    publishedAt: body.publishedAt ?? null,
+  };
 }
 
 export interface FetchStoredSchemasOptions {


### PR DESCRIPTION
## Description

- Follow-up to address comments from https://github.com/garden-co/jazz2/pull/471#pullrequestreview-4076753436.
- Updates the docs with the new migration flow.
- Removes the `--format` option from `schema export`, since the only possible option was `json`. We can add it back later if we want to support other formats.