### PR TITLE
jazz-auth

### DIFF
--- a/packages/jazz-auth/README.md
+++ b/packages/jazz-auth/README.md
@@ -1,0 +1,12 @@
+# jazz-auth
+
+Jazz Auth starter package.
+
+## Entry points
+
+- `jazz-auth` for the simplified app-facing client helpers and `jazzAuthTables()`
+- `jazz-auth/hosted` for hosted auth UI components, Better Auth wiring, and Next.js route helpers
+
+## Status
+
+This is an initial implementation scaffold. The hosted side currently defaults to Better Auth's in-memory adapter until the Jazz-backed Better Auth adapter is wired in.

--- a/packages/jazz-auth/package.json
+++ b/packages/jazz-auth/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "jazz-auth",
+  "version": "2.0.0-alpha.26",
+  "files": [
+    "dist/**",
+    "README.md"
+  ],
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./hosted": {
+      "types": "./dist/hosted/index.d.ts",
+      "default": "./dist/hosted/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "rm -rf dist && tsc",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@radix-ui/react-label": "^2.1.8",
+    "@radix-ui/react-slot": "^1.2.4",
+    "better-auth": "1.5.6",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
+    "jazz-tools": "workspace:*",
+    "next": "16.1.6",
+    "react": "19.2.4",
+    "react-dom": "19.2.4",
+    "tailwind-merge": "^3.4.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "typescript": "catalog:default",
+    "vitest": "catalog:default"
+  }
+}

--- a/packages/jazz-auth/src/hosted/index.tsx
+++ b/packages/jazz-auth/src/hosted/index.tsx
@@ -1,0 +1,572 @@
+import type * as React from "react";
+import * as LabelPrimitive from "@radix-ui/react-label";
+import { Slot } from "@radix-ui/react-slot";
+import { memoryAdapter, type MemoryDB } from "better-auth/adapters/memory";
+import { betterAuth } from "better-auth";
+import { nextCookies, toNextJsHandler } from "better-auth/next-js";
+import { jwt } from "better-auth/plugins";
+import { cva, type VariantProps } from "class-variance-authority";
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center gap-2 rounded-xl px-4 py-2 text-sm font-medium transition-colors disabled:pointer-events-none disabled:opacity-50",
+  {
+    defaultVariants: {
+      size: "default",
+      variant: "default",
+    },
+    variants: {
+      size: {
+        default: "h-11",
+        sm: "h-9 px-3 text-xs",
+      },
+      variant: {
+        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        ghost: "bg-transparent text-foreground hover:bg-accent hover:text-accent-foreground",
+        outline: "border border-border bg-background text-foreground hover:bg-accent",
+      },
+    },
+  },
+);
+
+function Button({
+  asChild = false,
+  className,
+  size,
+  variant,
+  ...props
+}: React.ComponentProps<"button"> &
+  VariantProps<typeof buttonVariants> & {
+    asChild?: boolean;
+  }) {
+  const Comp = asChild ? Slot : "button";
+
+  return <Comp className={cn(buttonVariants({ className, size, variant }))} {...props} />;
+}
+
+function Card({ className, ...props }: React.ComponentProps<"section">) {
+  return (
+    <section
+      className={cn(
+        "rounded-[28px] border border-border/70 bg-card/90 shadow-[0_32px_90px_-48px_rgba(15,23,42,0.55)] backdrop-blur",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return <div className={cn("space-y-2 p-8 pb-4", className)} {...props} />;
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<"h1">) {
+  return (
+    <h1
+      className={cn("text-3xl font-semibold tracking-tight text-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+function CardDescription({ className, ...props }: React.ComponentProps<"p">) {
+  return <p className={cn("text-sm leading-6 text-muted-foreground", className)} {...props} />;
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<"div">) {
+  return <div className={cn("space-y-6 p-8 pt-2", className)} {...props} />;
+}
+
+function Input({ className, ...props }: React.ComponentProps<"input">) {
+  return (
+    <input
+      className={cn(
+        "flex h-11 w-full rounded-xl border border-border bg-background px-4 py-2 text-sm text-foreground shadow-sm outline-none transition focus:border-primary focus:ring-4 focus:ring-primary/10",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function Label({ className, ...props }: React.ComponentProps<typeof LabelPrimitive.Root>) {
+  return (
+    <LabelPrimitive.Root
+      className={cn("text-sm font-medium text-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+function AuthShell({
+  badge,
+  brandName,
+  children,
+  description,
+  title,
+}: {
+  badge?: string;
+  brandName: string;
+  children: React.ReactNode;
+  description: string;
+  title: string;
+}) {
+  return (
+    <main className="min-h-screen bg-[radial-gradient(circle_at_top,_rgba(20,184,166,0.18),_transparent_32%),linear-gradient(180deg,_rgba(255,255,255,0.96),_rgba(244,247,245,0.98))] px-6 py-12 text-foreground">
+      <div className="mx-auto flex min-h-[calc(100vh-6rem)] max-w-5xl items-center justify-center">
+        <div className="grid w-full gap-8 lg:grid-cols-[1.1fr_0.9fr]">
+          <section className="hidden rounded-[32px] border border-white/60 bg-white/75 p-10 shadow-[0_28px_70px_-50px_rgba(15,23,42,0.45)] backdrop-blur lg:flex lg:flex-col lg:justify-between">
+            <div className="space-y-5">
+              <span className="inline-flex w-fit rounded-full border border-primary/15 bg-primary/8 px-4 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-primary">
+                {badge ?? "Hosted auth"}
+              </span>
+              <h2 className="max-w-sm text-5xl font-semibold tracking-tight text-balance text-slate-900">
+                {brandName}
+              </h2>
+              <p className="max-w-md text-base leading-7 text-slate-600">
+                Jazz-hosted auth for local-first apps. Keep your product UI in your app, and hand
+                off only the credential boundary.
+              </p>
+            </div>
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div className="rounded-2xl border border-border/70 bg-background/85 p-4">
+                <p className="text-sm font-medium text-foreground">Redirect-first UX</p>
+                <p className="mt-2 text-sm leading-6 text-muted-foreground">
+                  Your app keeps the button design and simply opens the hosted auth flow when it
+                  matters.
+                </p>
+              </div>
+              <div className="rounded-2xl border border-border/70 bg-background/85 p-4">
+                <p className="text-sm font-medium text-foreground">Stable Jazz principal</p>
+                <p className="mt-2 text-sm leading-6 text-muted-foreground">
+                  JWTs carry a single Jazz principal id so the sync server only needs JWKS
+                  verification.
+                </p>
+              </div>
+            </div>
+          </section>
+
+          <Card className="overflow-hidden">
+            <CardHeader>
+              <p className="text-xs font-semibold uppercase tracking-[0.22em] text-primary">
+                {brandName}
+              </p>
+              <CardTitle>{title}</CardTitle>
+              <CardDescription>{description}</CardDescription>
+            </CardHeader>
+            <CardContent>{children}</CardContent>
+          </Card>
+        </div>
+      </div>
+    </main>
+  );
+}
+
+function InlineError({ error }: { error?: string | null }) {
+  if (!error) {
+    return null;
+  }
+
+  return (
+    <div className="rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+      {error}
+    </div>
+  );
+}
+
+export interface JazzHostedPageProps {
+  action: string;
+  brandName?: string;
+  error?: string | null;
+  redirectTo?: string | null;
+  signInHref?: string;
+  signUpHref?: string;
+}
+
+function buildHostedNavHref(path: string, redirectTo?: string | null): string {
+  if (!redirectTo) {
+    return path;
+  }
+
+  const url = new URL(path, "https://jazz-auth.local");
+  url.searchParams.set("redirectTo", redirectTo);
+  return `${url.pathname}${url.search}`;
+}
+
+export function JazzHostedSignInPage({
+  action,
+  brandName = "Jazz Auth",
+  error,
+  redirectTo,
+  signUpHref,
+}: JazzHostedPageProps) {
+  return (
+    <AuthShell
+      badge="Sign in"
+      brandName={brandName}
+      description="Use the hosted Jazz Auth flow, then redirect back to your app with a fresh session."
+      title="Sign in"
+    >
+      <form action={action} className="space-y-5" method="post">
+        <InlineError error={error} />
+        <input name="redirectTo" type="hidden" value={redirectTo ?? ""} />
+        <div className="space-y-2">
+          <Label htmlFor="email">Email</Label>
+          <Input
+            autoComplete="email"
+            id="email"
+            name="email"
+            placeholder="alice@example.com"
+            required
+            type="email"
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="password">Password</Label>
+          <Input
+            autoComplete="current-password"
+            id="password"
+            name="password"
+            required
+            type="password"
+          />
+        </div>
+        <Button className="w-full" type="submit">
+          Continue
+        </Button>
+      </form>
+      <div className="flex items-center justify-between gap-3 text-sm text-muted-foreground">
+        <span>Need an account?</span>
+        <Button asChild size="sm" variant="ghost">
+          <a href={signUpHref ?? buildHostedNavHref("/auth/sign-up", redirectTo)}>Create one</a>
+        </Button>
+      </div>
+    </AuthShell>
+  );
+}
+
+export function JazzHostedSignUpPage({
+  action,
+  brandName = "Jazz Auth",
+  error,
+  redirectTo,
+  signInHref,
+}: JazzHostedPageProps) {
+  return (
+    <AuthShell
+      badge="Create account"
+      brandName={brandName}
+      description="New accounts can start syncing immediately after the hosted flow completes."
+      title="Create your account"
+    >
+      <form action={action} className="space-y-5" method="post">
+        <InlineError error={error} />
+        <input name="redirectTo" type="hidden" value={redirectTo ?? ""} />
+        <div className="space-y-2">
+          <Label htmlFor="name">Display name</Label>
+          <Input
+            autoComplete="name"
+            id="name"
+            name="name"
+            placeholder="Alice"
+            required
+            type="text"
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="email">Email</Label>
+          <Input
+            autoComplete="email"
+            id="email"
+            name="email"
+            placeholder="alice@example.com"
+            required
+            type="email"
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="password">Password</Label>
+          <Input
+            autoComplete="new-password"
+            id="password"
+            minLength={8}
+            name="password"
+            required
+            type="password"
+          />
+        </div>
+        <Button className="w-full" type="submit">
+          Create account
+        </Button>
+      </form>
+      <div className="flex items-center justify-between gap-3 text-sm text-muted-foreground">
+        <span>Already have an account?</span>
+        <Button asChild size="sm" variant="ghost">
+          <a href={signInHref ?? buildHostedNavHref("/auth/sign-in", redirectTo)}>Sign in</a>
+        </Button>
+      </div>
+    </AuthShell>
+  );
+}
+
+export interface JazzHostedAuthOptions {
+  apiBasePath?: string;
+  baseURL: string;
+  database?: Parameters<typeof betterAuth>[0]["database"];
+  emailAndPassword?: Parameters<typeof betterAuth>[0]["emailAndPassword"];
+  hostedBasePath?: string;
+  issuer?: string;
+  secret: string;
+  trustedOrigins?: string[];
+}
+
+export interface JazzHostedAuth {
+  apiBasePath: string;
+  auth: ReturnType<typeof betterAuth>;
+  handlers: ReturnType<typeof toNextJsHandler>;
+  hostedBasePath: string;
+}
+
+export function getJazzHostedAuthHandlers(hosted: JazzHostedAuth): JazzHostedAuth["handlers"] {
+  return hosted.handlers;
+}
+
+function createMemoryDatabase(): MemoryDB {
+  return {
+    account: [],
+    jwks: [],
+    rateLimit: [],
+    session: [],
+    user: [],
+    verification: [],
+  };
+}
+
+function resolveJazzPrincipalId(user: Record<string, unknown>): string {
+  const principalId =
+    (typeof user.jazzPrincipalId === "string" && user.jazzPrincipalId) ||
+    (typeof user.principalId === "string" && user.principalId) ||
+    (typeof user.id === "string" && user.id);
+
+  if (!principalId) {
+    throw new Error("Jazz Auth expected a stable principal id on the Better Auth user record.");
+  }
+
+  return principalId;
+}
+
+export function createJazzHostedAuth(options: JazzHostedAuthOptions): JazzHostedAuth {
+  const apiBasePath = options.apiBasePath ?? "/api/auth";
+  const hostedBasePath = options.hostedBasePath ?? "/auth";
+  const auth = betterAuth({
+    basePath: apiBasePath,
+    baseURL: options.baseURL,
+    database: options.database ?? memoryAdapter(createMemoryDatabase()),
+    emailAndPassword: {
+      autoSignIn: true,
+      enabled: true,
+      minPasswordLength: 8,
+      requireEmailVerification: false,
+      ...options.emailAndPassword,
+    },
+    plugins: [
+      nextCookies(),
+      jwt({
+        jwks: {
+          keyPairConfig: {
+            alg: "ES256",
+          },
+        },
+        jwt: {
+          definePayload: ({ user }) => ({
+            email: user.email,
+            jazz_principal_id: resolveJazzPrincipalId(user as Record<string, unknown>),
+            name: user.name,
+          }),
+          expirationTime: "15m",
+          getSubject: ({ user }) => resolveJazzPrincipalId(user as Record<string, unknown>),
+          issuer: options.issuer ?? options.baseURL,
+        },
+      }),
+    ],
+    secret: options.secret,
+    trustedOrigins: options.trustedOrigins ?? [options.baseURL],
+  }) as unknown as ReturnType<typeof betterAuth>;
+
+  return {
+    apiBasePath,
+    auth,
+    handlers: toNextJsHandler(auth),
+    hostedBasePath,
+  };
+}
+
+function copySetCookieHeaders(source: Headers, target: Headers): void {
+  const setCookies =
+    typeof source.getSetCookie === "function"
+      ? source.getSetCookie()
+      : source.get("set-cookie")
+        ? [source.get("set-cookie")!]
+        : [];
+
+  if (setCookies.length === 0) {
+    return;
+  }
+
+  target.delete("set-cookie");
+  for (const setCookie of setCookies) {
+    target.append("set-cookie", setCookie);
+  }
+}
+
+function redirectResponse(location: URL | string): Response {
+  return new Response(null, {
+    headers: {
+      location: String(location),
+    },
+    status: 303,
+  });
+}
+
+function withRedirectTo(url: URL, redirectTo?: string | null, error?: string | null): URL {
+  if (redirectTo) {
+    url.searchParams.set("redirectTo", redirectTo);
+  }
+  if (error) {
+    url.searchParams.set("error", error);
+  }
+  return url;
+}
+
+async function readErrorMessage(response: Response): Promise<string | null> {
+  try {
+    const payload = (await response.json()) as { error?: string; message?: string };
+    return payload.message ?? payload.error ?? null;
+  } catch {
+    return null;
+  }
+}
+
+async function finalizeAuthRedirect(
+  authResponse: Response,
+  request: Request,
+  redirectTo?: string | null,
+): Promise<Response> {
+  let nextLocation = redirectTo ?? "/";
+
+  try {
+    const payload = (await authResponse.clone().json()) as { url?: string; redirect?: boolean };
+    if (payload.redirect && payload.url) {
+      nextLocation = payload.url;
+    }
+  } catch {}
+
+  const response = redirectResponse(new URL(nextLocation, request.url));
+  copySetCookieHeaders(authResponse.headers, response.headers);
+  return response;
+}
+
+async function forwardJsonRequest(
+  hosted: JazzHostedAuth,
+  request: Request,
+  endpoint: string,
+  body: Record<string, unknown>,
+): Promise<Response> {
+  const headers = new Headers();
+  request.headers.forEach((value, key) => {
+    if (key.toLowerCase() === "content-length") {
+      return;
+    }
+    headers.set(key, value);
+  });
+  headers.set("accept", "application/json");
+  headers.set("content-type", "application/json");
+
+  return hosted.auth.handler(
+    new Request(new URL(`${hosted.apiBasePath}${endpoint}`, request.url), {
+      body: JSON.stringify(body),
+      headers,
+      method: "POST",
+    }),
+  );
+}
+
+export async function handleJazzHostedSignIn(
+  hosted: JazzHostedAuth,
+  request: Request,
+): Promise<Response> {
+  const formData = await request.formData();
+  const redirectTo = String(formData.get("redirectTo") ?? "") || "/";
+  const authResponse = await forwardJsonRequest(hosted, request, "/sign-in/email", {
+    callbackURL: redirectTo,
+    email: String(formData.get("email") ?? ""),
+    password: String(formData.get("password") ?? ""),
+    rememberMe: true,
+  });
+
+  if (!authResponse.ok) {
+    return redirectResponse(
+      withRedirectTo(
+        new URL(`${hosted.hostedBasePath}/sign-in`, request.url),
+        redirectTo,
+        await readErrorMessage(authResponse),
+      ),
+    );
+  }
+
+  return finalizeAuthRedirect(authResponse, request, redirectTo);
+}
+
+export async function handleJazzHostedSignUp(
+  hosted: JazzHostedAuth,
+  request: Request,
+): Promise<Response> {
+  const formData = await request.formData();
+  const redirectTo = String(formData.get("redirectTo") ?? "") || "/";
+  const authResponse = await forwardJsonRequest(hosted, request, "/sign-up/email", {
+    callbackURL: redirectTo,
+    email: String(formData.get("email") ?? ""),
+    name: String(formData.get("name") ?? ""),
+    password: String(formData.get("password") ?? ""),
+    rememberMe: true,
+  });
+
+  if (!authResponse.ok) {
+    return redirectResponse(
+      withRedirectTo(
+        new URL(`${hosted.hostedBasePath}/sign-up`, request.url),
+        redirectTo,
+        await readErrorMessage(authResponse),
+      ),
+    );
+  }
+
+  return finalizeAuthRedirect(authResponse, request, redirectTo);
+}
+
+export async function handleJazzHostedSignOut(
+  hosted: JazzHostedAuth,
+  request: Request,
+): Promise<Response> {
+  const requestUrl = new URL(request.url);
+  const redirectTo = requestUrl.searchParams.get("redirectTo") ?? "/";
+  const authResponse = await hosted.auth.handler(
+    new Request(new URL(`${hosted.apiBasePath}/sign-out`, request.url), {
+      headers: request.headers,
+      method: "POST",
+    }),
+  );
+
+  if (!authResponse.ok) {
+    return redirectResponse(
+      withRedirectTo(new URL(`${hosted.hostedBasePath}/sign-in`, request.url), redirectTo),
+    );
+  }
+
+  return finalizeAuthRedirect(authResponse, request, redirectTo);
+}

--- a/packages/jazz-auth/src/hosted/index.tsx
+++ b/packages/jazz-auth/src/hosted/index.tsx
@@ -323,6 +323,7 @@ export interface JazzHostedAuthOptions {
   issuer?: string;
   secret: string;
   trustedOrigins?: string[];
+  useNextCookies?: boolean;
 }
 
 export interface JazzHostedAuth {
@@ -363,6 +364,32 @@ function resolveJazzPrincipalId(user: Record<string, unknown>): string {
 export function createJazzHostedAuth(options: JazzHostedAuthOptions): JazzHostedAuth {
   const apiBasePath = options.apiBasePath ?? "/api/auth";
   const hostedBasePath = options.hostedBasePath ?? "/auth";
+  const plugins = [];
+
+  if (options.useNextCookies !== false) {
+    plugins.push(nextCookies());
+  }
+
+  plugins.push(
+    jwt({
+      jwks: {
+        keyPairConfig: {
+          alg: "ES256",
+        },
+      },
+      jwt: {
+        definePayload: ({ user }) => ({
+          email: user.email,
+          jazz_principal_id: resolveJazzPrincipalId(user as Record<string, unknown>),
+          name: user.name,
+        }),
+        expirationTime: "15m",
+        getSubject: ({ user }) => resolveJazzPrincipalId(user as Record<string, unknown>),
+        issuer: options.issuer ?? options.baseURL,
+      },
+    }),
+  );
+
   const auth = betterAuth({
     basePath: apiBasePath,
     baseURL: options.baseURL,
@@ -374,26 +401,7 @@ export function createJazzHostedAuth(options: JazzHostedAuthOptions): JazzHosted
       requireEmailVerification: false,
       ...options.emailAndPassword,
     },
-    plugins: [
-      nextCookies(),
-      jwt({
-        jwks: {
-          keyPairConfig: {
-            alg: "ES256",
-          },
-        },
-        jwt: {
-          definePayload: ({ user }) => ({
-            email: user.email,
-            jazz_principal_id: resolveJazzPrincipalId(user as Record<string, unknown>),
-            name: user.name,
-          }),
-          expirationTime: "15m",
-          getSubject: ({ user }) => resolveJazzPrincipalId(user as Record<string, unknown>),
-          issuer: options.issuer ?? options.baseURL,
-        },
-      }),
-    ],
+    plugins,
     secret: options.secret,
     trustedOrigins: options.trustedOrigins ?? [options.baseURL],
   }) as unknown as ReturnType<typeof betterAuth>;
@@ -570,3 +578,9 @@ export async function handleJazzHostedSignOut(
 
   return finalizeAuthRedirect(authResponse, request, redirectTo);
 }
+
+export {
+  startJazzHostedAuthServer,
+  type JazzHostedAuthServerHandle,
+  type JazzHostedAuthServerOptions,
+} from "./server.js";

--- a/packages/jazz-auth/src/hosted/server.test.ts
+++ b/packages/jazz-auth/src/hosted/server.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { startJazzHostedAuthServer } from "./server.js";
+
+const activeHandles: Array<{ close(): Promise<void> }> = [];
+
+afterEach(async () => {
+  await Promise.all(
+    activeHandles
+      .splice(0)
+      .reverse()
+      .map((handle) => handle.close()),
+  );
+});
+
+describe("startJazzHostedAuthServer", () => {
+  it("serves hosted auth pages, health, and JWKS from the bundled auth server", async () => {
+    const server = await startJazzHostedAuthServer({
+      baseURL: "http://127.0.0.1:4100",
+      port: 0,
+      secret: "development-secret",
+    });
+    activeHandles.push(server);
+
+    const healthResponse = await fetch(`${server.url}/health`);
+    await expect(healthResponse.json()).resolves.toEqual({ status: "ok" });
+
+    const signInResponse = await fetch(`${server.url}/auth/sign-in?redirectTo=/app`);
+    expect(signInResponse.status).toBe(200);
+    const signInHtml = await signInResponse.text();
+    expect(signInHtml).toContain("Sign in");
+    expect(signInHtml).toContain("/auth/sign-in/submit");
+
+    const jwksResponse = await fetch(`${server.url}/.well-known/jwks.json`);
+    expect(jwksResponse.status).toBe(200);
+    const jwks = (await jwksResponse.json()) as { keys?: Array<{ kid?: string }> };
+    expect(Array.isArray(jwks.keys)).toBe(true);
+    expect(jwks.keys?.[0]?.kid).toBeTruthy();
+  });
+});

--- a/packages/jazz-auth/src/hosted/server.ts
+++ b/packages/jazz-auth/src/hosted/server.ts
@@ -1,0 +1,474 @@
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import type { AddressInfo } from "node:net";
+import { Readable } from "node:stream";
+import {
+  createJazzHostedAuth,
+  handleJazzHostedSignIn,
+  handleJazzHostedSignOut,
+  handleJazzHostedSignUp,
+  type JazzHostedAuth,
+  type JazzHostedAuthOptions,
+} from "./index.js";
+
+const DEFAULT_BIND_HOST = "127.0.0.1";
+
+export interface JazzHostedAuthServerOptions extends JazzHostedAuthOptions {
+  bindHost?: string;
+  brandName?: string;
+  port?: number;
+}
+
+export interface JazzHostedAuthServerHandle {
+  close(): Promise<void>;
+  hosted: JazzHostedAuth;
+  port: number;
+  url: string;
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+function renderHostedPageDocument({
+  action,
+  alternateHref,
+  alternateLabel,
+  alternatePrompt,
+  brandName,
+  description,
+  error,
+  extraField,
+  redirectTo,
+  title,
+}: {
+  action: string;
+  alternateHref: string;
+  alternateLabel: string;
+  alternatePrompt: string;
+  brandName: string;
+  description: string;
+  error?: string | null;
+  extraField?: string;
+  redirectTo?: string | null;
+  title: string;
+}) {
+  const errorBanner = error ? `<p class="error">${escapeHtml(error)}</p>` : "";
+
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>${escapeHtml(title)} · ${escapeHtml(brandName)}</title>
+    <style>
+      :root {
+        color-scheme: light;
+        --bg: #f4f7f5;
+        --card: rgba(255, 255, 255, 0.96);
+        --border: #d6e1dc;
+        --text: #18343a;
+        --muted: #5d7378;
+        --primary: #147b73;
+        --primary-foreground: #f4fffe;
+        --error-bg: #fef2f2;
+        --error-border: #fecaca;
+        --error-text: #b91c1c;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        font-family: "Instrument Sans", "Avenir Next", "Segoe UI", sans-serif;
+        background:
+          radial-gradient(circle at top, rgba(20, 184, 166, 0.18), transparent 32%),
+          linear-gradient(180deg, rgba(255, 255, 255, 0.96), rgba(244, 247, 245, 0.98));
+        color: var(--text);
+      }
+
+      main {
+        min-height: 100vh;
+        display: grid;
+        place-items: center;
+        padding: 24px;
+      }
+
+      .card {
+        width: min(100%, 460px);
+        border-radius: 28px;
+        border: 1px solid var(--border);
+        background: var(--card);
+        box-shadow: 0 32px 90px -48px rgba(15, 23, 42, 0.55);
+        padding: 32px;
+      }
+
+      .eyebrow {
+        margin: 0 0 10px;
+        font-size: 12px;
+        font-weight: 700;
+        letter-spacing: 0.22em;
+        text-transform: uppercase;
+        color: var(--primary);
+      }
+
+      h1 {
+        margin: 0;
+        font-size: 32px;
+        line-height: 1.1;
+      }
+
+      .description {
+        margin: 12px 0 0;
+        color: var(--muted);
+        line-height: 1.6;
+      }
+
+      form {
+        margin-top: 28px;
+      }
+
+      label {
+        display: block;
+        margin-bottom: 8px;
+        font-size: 14px;
+        font-weight: 600;
+      }
+
+      input {
+        width: 100%;
+        height: 44px;
+        margin-bottom: 18px;
+        border-radius: 14px;
+        border: 1px solid var(--border);
+        padding: 0 14px;
+        font: inherit;
+        color: inherit;
+        background: #fff;
+      }
+
+      button {
+        width: 100%;
+        height: 46px;
+        border: none;
+        border-radius: 14px;
+        font: inherit;
+        font-weight: 700;
+        background: var(--primary);
+        color: var(--primary-foreground);
+        cursor: pointer;
+      }
+
+      .footer {
+        margin-top: 18px;
+        display: flex;
+        justify-content: space-between;
+        gap: 12px;
+        align-items: center;
+        font-size: 14px;
+        color: var(--muted);
+      }
+
+      .footer a {
+        color: var(--primary);
+        text-decoration: none;
+        font-weight: 600;
+      }
+
+      .error {
+        margin: 0 0 18px;
+        border-radius: 14px;
+        border: 1px solid var(--error-border);
+        background: var(--error-bg);
+        color: var(--error-text);
+        padding: 12px 14px;
+        line-height: 1.5;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <section class="card">
+        <p class="eyebrow">${escapeHtml(brandName)}</p>
+        <h1>${escapeHtml(title)}</h1>
+        <p class="description">${escapeHtml(description)}</p>
+        <form action="${escapeHtml(action)}" method="post">
+          ${errorBanner}
+          <input type="hidden" name="redirectTo" value="${escapeHtml(redirectTo ?? "")}" />
+          ${extraField ?? ""}
+          <label for="email">Email</label>
+          <input id="email" name="email" type="email" autocomplete="email" placeholder="alice@example.com" required />
+          <label for="password">Password</label>
+          <input id="password" name="password" type="password" autocomplete="current-password" required />
+          <button type="submit">${escapeHtml(title)}</button>
+        </form>
+        <div class="footer">
+          <span>${escapeHtml(alternatePrompt)}</span>
+          <a href="${escapeHtml(alternateHref)}">${escapeHtml(alternateLabel)}</a>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>`;
+}
+
+function buildNavHref(path: string, redirectTo?: string | null): string {
+  if (!redirectTo) {
+    return path;
+  }
+
+  const url = new URL(path, "https://jazz-auth.local");
+  url.searchParams.set("redirectTo", redirectTo);
+  return `${url.pathname}${url.search}`;
+}
+
+function renderSignInPage(hosted: JazzHostedAuth, brandName: string, requestUrl: URL): string {
+  const redirectTo = requestUrl.searchParams.get("redirectTo");
+  return renderHostedPageDocument({
+    action: `${hosted.hostedBasePath}/sign-in/submit`,
+    alternateHref: buildNavHref(`${hosted.hostedBasePath}/sign-up`, redirectTo),
+    alternateLabel: "Create one",
+    alternatePrompt: "Need an account?",
+    brandName,
+    description:
+      "Use the hosted Jazz Auth flow, then redirect back to your app with a fresh session.",
+    error: requestUrl.searchParams.get("error"),
+    redirectTo,
+    title: "Sign in",
+  });
+}
+
+function renderSignUpPage(hosted: JazzHostedAuth, brandName: string, requestUrl: URL): string {
+  const redirectTo = requestUrl.searchParams.get("redirectTo");
+  return renderHostedPageDocument({
+    action: `${hosted.hostedBasePath}/sign-up/submit`,
+    alternateHref: buildNavHref(`${hosted.hostedBasePath}/sign-in`, redirectTo),
+    alternateLabel: "Sign in",
+    alternatePrompt: "Already have an account?",
+    brandName,
+    description: "New accounts can start syncing immediately after the hosted flow completes.",
+    error: requestUrl.searchParams.get("error"),
+    extraField:
+      '<label for="name">Display name</label><input id="name" name="name" type="text" autocomplete="name" placeholder="Alice" required />',
+    redirectTo,
+    title: "Create account",
+  });
+}
+
+function htmlResponse(html: string): Response {
+  return new Response(html, {
+    headers: {
+      "content-type": "text/html; charset=utf-8",
+    },
+    status: 200,
+  });
+}
+
+async function readNodeRequestBody(request: IncomingMessage): Promise<Buffer | undefined> {
+  if (request.method === "GET" || request.method === "HEAD") {
+    return undefined;
+  }
+
+  const chunks: Buffer[] = [];
+  for await (const chunk of request) {
+    chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
+  }
+  return Buffer.concat(chunks);
+}
+
+function buildFetchRequestUrl(request: IncomingMessage, fallbackBaseURL: string): string {
+  const forwardedProto = request.headers["x-forwarded-proto"];
+  const forwardedHost = request.headers["x-forwarded-host"];
+  const protocol =
+    typeof forwardedProto === "string"
+      ? forwardedProto
+      : new URL(fallbackBaseURL).protocol.replace(/:$/, "");
+  const host =
+    typeof forwardedHost === "string"
+      ? forwardedHost
+      : typeof request.headers.host === "string"
+        ? request.headers.host
+        : new URL(fallbackBaseURL).host;
+
+  return new URL(request.url ?? "/", `${protocol}://${host}`).toString();
+}
+
+async function toFetchRequest(request: IncomingMessage, fallbackBaseURL: string): Promise<Request> {
+  const headers = new Headers();
+
+  for (const [key, value] of Object.entries(request.headers)) {
+    if (value === undefined) {
+      continue;
+    }
+
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        headers.append(key, item);
+      }
+      continue;
+    }
+
+    headers.set(key, value);
+  }
+
+  const body = await readNodeRequestBody(request);
+
+  return new Request(buildFetchRequestUrl(request, fallbackBaseURL), {
+    body: body ? new Uint8Array(body) : undefined,
+    headers,
+    method: request.method ?? "GET",
+  });
+}
+
+async function writeFetchResponse(nodeResponse: ServerResponse, response: Response): Promise<void> {
+  const headers: Record<string, string | string[]> = {};
+
+  for (const [key, value] of response.headers) {
+    if (key.toLowerCase() === "set-cookie") {
+      continue;
+    }
+    headers[key] = value;
+  }
+
+  const setCookies =
+    typeof response.headers.getSetCookie === "function" ? response.headers.getSetCookie() : [];
+  if (setCookies.length > 0) {
+    headers["set-cookie"] = setCookies;
+  }
+
+  nodeResponse.writeHead(response.status, headers);
+
+  if (!response.body) {
+    nodeResponse.end();
+    return;
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    Readable.fromWeb(response.body as unknown as Parameters<typeof Readable.fromWeb>[0])
+      .on("error", reject)
+      .on("end", () => resolve())
+      .pipe(nodeResponse);
+  });
+}
+
+async function handleBundledAuthRequest(
+  hosted: JazzHostedAuth,
+  brandName: string,
+  request: Request,
+): Promise<Response> {
+  const requestUrl = new URL(request.url);
+  const path = requestUrl.pathname;
+
+  if (request.method === "GET" && path === "/health") {
+    return Response.json({ status: "ok" });
+  }
+
+  if (
+    request.method === "GET" &&
+    (path === hosted.hostedBasePath || path === `${hosted.hostedBasePath}/`)
+  ) {
+    return Response.redirect(new URL(`${hosted.hostedBasePath}/sign-in`, request.url), 303);
+  }
+
+  if (request.method === "GET" && path === `${hosted.hostedBasePath}/sign-in`) {
+    return htmlResponse(renderSignInPage(hosted, brandName, requestUrl));
+  }
+
+  if (request.method === "GET" && path === `${hosted.hostedBasePath}/sign-up`) {
+    return htmlResponse(renderSignUpPage(hosted, brandName, requestUrl));
+  }
+
+  if (request.method === "POST" && path === `${hosted.hostedBasePath}/sign-in/submit`) {
+    return handleJazzHostedSignIn(hosted, request);
+  }
+
+  if (request.method === "POST" && path === `${hosted.hostedBasePath}/sign-up/submit`) {
+    return handleJazzHostedSignUp(hosted, request);
+  }
+
+  if (
+    (request.method === "GET" || request.method === "POST") &&
+    path === `${hosted.hostedBasePath}/sign-out`
+  ) {
+    return handleJazzHostedSignOut(hosted, request);
+  }
+
+  if (request.method === "GET" && (path === "/.well-known/jwks.json" || path === "/jwks")) {
+    return hosted.auth.handler(
+      new Request(new URL(`${hosted.apiBasePath}/jwks`, request.url), {
+        headers: request.headers,
+        method: "GET",
+      }),
+    );
+  }
+
+  if (path === hosted.apiBasePath || path.startsWith(`${hosted.apiBasePath}/`)) {
+    return hosted.auth.handler(request);
+  }
+
+  return new Response("Not Found", { status: 404 });
+}
+
+export async function startJazzHostedAuthServer(
+  options: JazzHostedAuthServerOptions,
+): Promise<JazzHostedAuthServerHandle> {
+  const bindHost = options.bindHost ?? DEFAULT_BIND_HOST;
+  const port = options.port ?? 0;
+  const brandName = options.brandName ?? "Jazz Auth";
+  const hosted = createJazzHostedAuth({
+    ...options,
+    useNextCookies: false,
+  });
+
+  const server = createServer(async (request, response) => {
+    try {
+      const fetchRequest = await toFetchRequest(request, options.baseURL);
+      const fetchResponse = await handleBundledAuthRequest(hosted, brandName, fetchRequest);
+      await writeFetchResponse(response, fetchResponse);
+    } catch (error) {
+      response.writeHead(500, { "content-type": "application/json; charset=utf-8" });
+      response.end(
+        JSON.stringify({
+          error: "auth_server_error",
+          message: error instanceof Error ? error.message : String(error),
+        }),
+      );
+    }
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.listen(port, bindHost, (error?: Error) => {
+      if (error) {
+        reject(error);
+      } else {
+        resolve();
+      }
+    });
+  });
+
+  const address = server.address() as AddressInfo;
+
+  return {
+    async close(): Promise<void> {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+          } else {
+            resolve();
+          }
+        });
+      });
+    },
+    hosted,
+    port: address.port,
+    url: `http://${bindHost}:${address.port}`,
+  };
+}

--- a/packages/jazz-auth/src/index.test.ts
+++ b/packages/jazz-auth/src/index.test.ts
@@ -1,0 +1,199 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createJazzAuthClient, jazzAuthTables } from "./index.js";
+import {
+  createJazzHostedAuth,
+  handleJazzHostedSignIn,
+  handleJazzHostedSignOut,
+  handleJazzHostedSignUp,
+} from "./hosted/index.js";
+
+describe("jazzAuthTables", () => {
+  it("returns the Better Auth core and JWT tables Jazz expects", () => {
+    const tables = jazzAuthTables();
+
+    expect(Object.keys(tables)).toEqual([
+      "authUsers",
+      "authAccounts",
+      "authSessions",
+      "authVerifications",
+      "authRateLimits",
+      "authJwks",
+    ]);
+    expect(tables.authUsers.columns).toHaveProperty("principalId");
+    expect(tables.authAccounts.columns).toHaveProperty("providerId");
+    expect(tables.authSessions.columns).toHaveProperty("token");
+    expect(tables.authVerifications.columns).toHaveProperty("identifier");
+    expect(tables.authRateLimits.columns).toHaveProperty("key");
+    expect(tables.authJwks.columns).toHaveProperty("publicKey");
+  });
+});
+
+describe("createJazzAuthClient", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("builds hosted sign-in and sign-up redirect URLs", () => {
+    const client = createJazzAuthClient({
+      baseURL: "https://auth.example.com",
+    });
+
+    expect(client.getSignInUrl({ redirectTo: "/app" })).toBe(
+      "https://auth.example.com/auth/sign-in?redirectTo=%2Fapp",
+    );
+    expect(client.getSignUpUrl({ redirectTo: "/welcome" })).toBe(
+      "https://auth.example.com/auth/sign-up?redirectTo=%2Fwelcome",
+    );
+  });
+
+  it("redirects through the hosted sign-in flow and aliases login()", () => {
+    const assign = vi.fn();
+    const client = createJazzAuthClient({
+      baseURL: "https://auth.example.com",
+      location: { assign },
+    });
+
+    expect(client.signIn({ redirectTo: "/app" })).toBe(
+      "https://auth.example.com/auth/sign-in?redirectTo=%2Fapp",
+    );
+    expect(client.login({ redirectTo: "/app" })).toBe(
+      "https://auth.example.com/auth/sign-in?redirectTo=%2Fapp",
+    );
+    expect(assign).toHaveBeenCalledTimes(2);
+  });
+
+  it("fetches the hosted Jazz JWT from the Better Auth token endpoint", async () => {
+    const fetchMock = vi.fn(async () => {
+      return new Response(JSON.stringify({ token: "jwt-123" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+    const client = createJazzAuthClient({
+      baseURL: "https://auth.example.com",
+      fetch: fetchMock as typeof fetch,
+    });
+
+    await expect(client.getJwt()).resolves.toBe("jwt-123");
+    expect(fetchMock).toHaveBeenCalledWith("https://auth.example.com/api/auth/token", {
+      credentials: "include",
+      headers: { accept: "application/json" },
+      method: "GET",
+    });
+  });
+});
+
+describe("createJazzHostedAuth", () => {
+  it("creates Better Auth handlers with Jazz defaults", () => {
+    const hosted = createJazzHostedAuth({
+      baseURL: "https://auth.example.com",
+      secret: "development-secret",
+    });
+
+    expect(hosted.apiBasePath).toBe("/api/auth");
+    expect(hosted.hostedBasePath).toBe("/auth");
+    expect(typeof hosted.handlers.GET).toBe("function");
+    expect(typeof hosted.handlers.POST).toBe("function");
+  });
+
+  it("redirects successful hosted sign-in responses and preserves every auth cookie", async () => {
+    const headers = new Headers();
+    headers.append("set-cookie", "session=abc; Path=/; HttpOnly");
+    headers.append("set-cookie", "csrf=def; Path=/; Secure");
+
+    const response = await handleJazzHostedSignIn(
+      {
+        apiBasePath: "/api/auth",
+        auth: {
+          handler: vi.fn(async () => {
+            return new Response(JSON.stringify({ redirect: true, url: "/app" }), {
+              headers,
+              status: 200,
+            });
+          }),
+        },
+        handlers: {} as never,
+        hostedBasePath: "/auth",
+      },
+      new Request("https://auth.example.com/auth/sign-in/submit", {
+        body: new URLSearchParams({
+          email: "alice@example.com",
+          password: "secret-password",
+          redirectTo: "/chat",
+        }),
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        method: "POST",
+      }),
+    );
+
+    expect(response.status).toBe(303);
+    expect(response.headers.get("location")).toBe("https://auth.example.com/app");
+    expect(response.headers.getSetCookie()).toEqual([
+      "session=abc; Path=/; HttpOnly",
+      "csrf=def; Path=/; Secure",
+    ]);
+  });
+
+  it("redirects failed hosted sign-up responses back to the hosted page with an error", async () => {
+    const response = await handleJazzHostedSignUp(
+      {
+        apiBasePath: "/api/auth",
+        auth: {
+          handler: vi.fn(async () => {
+            return new Response(JSON.stringify({ message: "Email already exists" }), {
+              headers: { "content-type": "application/json" },
+              status: 400,
+            });
+          }),
+        },
+        handlers: {} as never,
+        hostedBasePath: "/auth",
+      },
+      new Request("https://auth.example.com/auth/sign-up/submit", {
+        body: new URLSearchParams({
+          email: "alice@example.com",
+          name: "Alice",
+          password: "secret-password",
+          redirectTo: "/chat",
+        }),
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        method: "POST",
+      }),
+    );
+
+    expect(response.status).toBe(303);
+    expect(response.headers.get("location")).toBe(
+      "https://auth.example.com/auth/sign-up?redirectTo=%2Fchat&error=Email+already+exists",
+    );
+  });
+
+  it("posts sign-out through Better Auth and redirects back to the app", async () => {
+    const authHandler = vi.fn(async () => {
+      return new Response(JSON.stringify({ redirect: true, url: "/signed-out" }), {
+        headers: { "set-cookie": "session=; Max-Age=0; Path=/; HttpOnly" },
+        status: 200,
+      });
+    });
+
+    const response = await handleJazzHostedSignOut(
+      {
+        apiBasePath: "/api/auth",
+        auth: {
+          handler: authHandler,
+        },
+        handlers: {} as never,
+        hostedBasePath: "/auth",
+      },
+      new Request("https://auth.example.com/auth/sign-out?redirectTo=/bye", {
+        method: "GET",
+      }),
+    );
+
+    expect(authHandler).toHaveBeenCalledTimes(1);
+    const forwardedRequest = authHandler.mock.calls[0]?.[0] as Request;
+    expect(forwardedRequest.method).toBe("POST");
+    expect(forwardedRequest.url).toBe("https://auth.example.com/api/auth/sign-out");
+    expect(response.status).toBe(303);
+    expect(response.headers.get("location")).toBe("https://auth.example.com/signed-out");
+  });
+});

--- a/packages/jazz-auth/src/index.ts
+++ b/packages/jazz-auth/src/index.ts
@@ -1,0 +1,181 @@
+import { schema as s } from "jazz-tools";
+
+export interface JazzAuthRedirectOptions {
+  redirectTo?: string | null;
+}
+
+export interface JazzAuthClientOptions {
+  apiBasePath?: string;
+  baseURL: string;
+  fetch?: typeof fetch;
+  hostedBasePath?: string;
+  location?: Pick<Location, "assign">;
+}
+
+export interface JazzAuthClient {
+  getJwt(): Promise<string | null>;
+  getSignInUrl(options?: JazzAuthRedirectOptions): string;
+  getSignOutUrl(options?: JazzAuthRedirectOptions): string;
+  getSignUpUrl(options?: JazzAuthRedirectOptions): string;
+  login(options?: JazzAuthRedirectOptions): string;
+  logout(options?: JazzAuthRedirectOptions): string;
+  signIn(options?: JazzAuthRedirectOptions): string;
+  signOut(options?: JazzAuthRedirectOptions): string;
+  signUp(options?: JazzAuthRedirectOptions): string;
+  signin(options?: JazzAuthRedirectOptions): string;
+}
+
+function normalizeBaseURL(baseURL: string): string {
+  return baseURL.replace(/\/+$/, "");
+}
+
+function appendRedirectTo(url: URL, redirectTo?: string | null): string {
+  if (redirectTo) {
+    url.searchParams.set("redirectTo", redirectTo);
+  }
+  return url.toString();
+}
+
+function buildHostedUrl(
+  baseURL: string,
+  hostedBasePath: string,
+  path: string,
+  options?: JazzAuthRedirectOptions,
+): string {
+  return appendRedirectTo(
+    new URL(`${hostedBasePath}${path}`, normalizeBaseURL(baseURL)),
+    options?.redirectTo,
+  );
+}
+
+export function createJazzAuthClient(options: JazzAuthClientOptions): JazzAuthClient {
+  const apiBasePath = options.apiBasePath ?? "/api/auth";
+  const hostedBasePath = options.hostedBasePath ?? "/auth";
+  const fetchImpl = options.fetch ?? globalThis.fetch;
+  const location = options.location ?? globalThis.location;
+
+  function maybeRedirect(url: string): string {
+    location?.assign?.(url);
+    return url;
+  }
+
+  return {
+    async getJwt(): Promise<string | null> {
+      const response = await fetchImpl(`${normalizeBaseURL(options.baseURL)}${apiBasePath}/token`, {
+        credentials: "include",
+        headers: { accept: "application/json" },
+        method: "GET",
+      });
+
+      if (!response.ok) {
+        return null;
+      }
+
+      const payload = (await response.json()) as { token?: string | null };
+      return payload.token ?? null;
+    },
+    getSignInUrl(redirectOptions?: JazzAuthRedirectOptions): string {
+      return buildHostedUrl(options.baseURL, hostedBasePath, "/sign-in", redirectOptions);
+    },
+    getSignOutUrl(redirectOptions?: JazzAuthRedirectOptions): string {
+      return buildHostedUrl(options.baseURL, hostedBasePath, "/sign-out", redirectOptions);
+    },
+    getSignUpUrl(redirectOptions?: JazzAuthRedirectOptions): string {
+      return buildHostedUrl(options.baseURL, hostedBasePath, "/sign-up", redirectOptions);
+    },
+    login(redirectOptions?: JazzAuthRedirectOptions): string {
+      return maybeRedirect(
+        buildHostedUrl(options.baseURL, hostedBasePath, "/sign-in", redirectOptions),
+      );
+    },
+    logout(redirectOptions?: JazzAuthRedirectOptions): string {
+      return maybeRedirect(
+        buildHostedUrl(options.baseURL, hostedBasePath, "/sign-out", redirectOptions),
+      );
+    },
+    signIn(redirectOptions?: JazzAuthRedirectOptions): string {
+      return maybeRedirect(
+        buildHostedUrl(options.baseURL, hostedBasePath, "/sign-in", redirectOptions),
+      );
+    },
+    signOut(redirectOptions?: JazzAuthRedirectOptions): string {
+      return maybeRedirect(
+        buildHostedUrl(options.baseURL, hostedBasePath, "/sign-out", redirectOptions),
+      );
+    },
+    signUp(redirectOptions?: JazzAuthRedirectOptions): string {
+      return maybeRedirect(
+        buildHostedUrl(options.baseURL, hostedBasePath, "/sign-up", redirectOptions),
+      );
+    },
+    signin(redirectOptions?: JazzAuthRedirectOptions): string {
+      return maybeRedirect(
+        buildHostedUrl(options.baseURL, hostedBasePath, "/sign-in", redirectOptions),
+      );
+    },
+  };
+}
+
+export function jazzAuthTables() {
+  return {
+    authUsers: s
+      .table({
+        email: s.string(),
+        emailVerified: s.boolean().default(false),
+        image: s.string().optional(),
+        name: s.string(),
+        principalId: s.string(),
+      })
+      .index("auth_users_email_idx", ["email"])
+      .index("auth_users_principal_id_idx", ["principalId"]),
+    authAccounts: s
+      .table({
+        accessToken: s.string().optional(),
+        accessTokenExpiresAt: s.timestamp().optional(),
+        accountId: s.string(),
+        idToken: s.string().optional(),
+        password: s.string().optional(),
+        providerId: s.string(),
+        refreshToken: s.string().optional(),
+        refreshTokenExpiresAt: s.timestamp().optional(),
+        scope: s.string().optional(),
+        userId: s.ref("authUsers"),
+      })
+      .index("auth_accounts_user_id_idx", ["userId"])
+      .index("auth_accounts_provider_account_idx", ["providerId", "accountId"]),
+    authSessions: s
+      .table({
+        expiresAt: s.timestamp(),
+        ipAddress: s.string().optional(),
+        token: s.string(),
+        userAgent: s.string().optional(),
+        userId: s.ref("authUsers"),
+      })
+      .index("auth_sessions_user_id_idx", ["userId"])
+      .index("auth_sessions_token_idx", ["token"]),
+    authVerifications: s
+      .table({
+        expiresAt: s.timestamp(),
+        identifier: s.string(),
+        value: s.string(),
+      })
+      .index("auth_verifications_identifier_idx", ["identifier"]),
+    authRateLimits: s
+      .table({
+        count: s.int(),
+        key: s.string(),
+        lastRequest: s.int(),
+      })
+      .index("auth_rate_limits_key_idx", ["key"]),
+    authJwks: s
+      .table({
+        createdAt: s.timestamp(),
+        expiresAt: s.timestamp().optional(),
+        privateKey: s.string(),
+        publicKey: s.string(),
+      })
+      .index("auth_jwks_created_at_idx", ["createdAt"]),
+  };
+}
+
+export type JazzAuthTables = ReturnType<typeof jazzAuthTables>;

--- a/packages/jazz-auth/tsconfig.json
+++ b/packages/jazz-auth/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["DOM", "DOM.Iterable", "ES2022"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "skipLibCheck": true,
+    "jsx": "react-jsx",
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
+}

--- a/packages/jazz-tools/bin/jazz-tools.js
+++ b/packages/jazz-tools/bin/jazz-tools.js
@@ -107,6 +107,7 @@ function printWrapperHelp() {
     "  migrations create     Generate a typed structural migration stub from snapshots or schema hashes",
   );
   console.log("  migrations push       Push a reviewed migration edge to the server");
+  console.log("  auth init             Scaffold a hosted Jazz Auth Next.js app");
   console.log("  create                Create a new resource");
   console.log("  server                Run a Jazz server");
   console.log("  mcp                   Run the Jazz MCP server");
@@ -137,7 +138,8 @@ if (!command || command === "--help" || command === "-h") {
   command === "validate" ||
   command === "migrations" ||
   command === "permissions" ||
-  command === "schema"
+  command === "schema" ||
+  command === "auth"
 ) {
   const tsCliPath = join(here, "..", "dist", "cli.js");
   if (!existsSync(tsCliPath)) {

--- a/packages/jazz-tools/bin/jazz-tools.js
+++ b/packages/jazz-tools/bin/jazz-tools.js
@@ -107,9 +107,8 @@ function printWrapperHelp() {
     "  migrations create     Generate a typed structural migration stub from snapshots or schema hashes",
   );
   console.log("  migrations push       Push a reviewed migration edge to the server");
-  console.log("  auth init             Scaffold a hosted Jazz Auth Next.js app");
   console.log("  create                Create a new resource");
-  console.log("  server                Run a Jazz server");
+  console.log("  server                Run a Jazz server with bundled Jazz Auth");
   console.log("  mcp                   Run the Jazz MCP server");
   console.log("  help                  Print this message");
   console.log("");
@@ -121,6 +120,45 @@ const here = dirname(fileURLToPath(import.meta.url));
 
 const { args, rustBinOverride } = parseWrapperArgs(process.argv.slice(2));
 const command = args[0];
+
+function resolveRustBinaryPath() {
+  const key = `${process.platform}-${process.arch}`;
+  const binaryName = BINARIES[key];
+  const localBinaryName = process.platform === "win32" ? "jazz-tools.exe" : "jazz-tools";
+  const fallbackCandidates = [
+    join(here, "..", "..", "..", "target", "debug", localBinaryName),
+    join(here, "..", "..", "..", "target", "release", localBinaryName),
+  ];
+
+  const bundledBinaryPath = binaryName ? join(here, "native", binaryName) : undefined;
+  if (rustBinOverride && !existsSync(rustBinOverride)) {
+    fail(`Configured Rust binary missing: ${rustBinOverride}`);
+  }
+
+  const binaryPath =
+    rustBinOverride ??
+    (bundledBinaryPath && existsSync(bundledBinaryPath)
+      ? bundledBinaryPath
+      : fallbackCandidates.find((candidate) => existsSync(candidate)));
+
+  if (!binaryPath) {
+    const lines = [];
+    if (!binaryName) {
+      lines.push(
+        `jazz-tools does not include a bundled binary for ${process.platform}/${process.arch}.`,
+      );
+    } else {
+      lines.push(`Bundled binary missing: ${binaryName}`);
+      lines.push("This package may be corrupted or published without target artifacts.");
+    }
+    lines.push("No local Cargo build was found in target/debug or target/release.");
+    lines.push("Run `cargo build -p jazz-tools --bin jazz-tools --features cli` to build locally.");
+    fail(lines.join("\n"));
+  }
+
+  ensureExecutable(binaryPath, rustBinOverride ?? binaryName ?? localBinaryName);
+  return { binaryName, binaryPath };
+}
 
 // Handle the MCP server before any Rust binary resolution.
 if (!command || command === "--help" || command === "-h") {
@@ -151,42 +189,23 @@ if (!command || command === "--help" || command === "-h") {
     env: process.env,
   });
   exitWithSpawnResult(tsCommandResult, "TypeScript schema CLI");
+} else if (command === "server") {
+  const combinedServerPath = join(here, "..", "dist", "combined-server.js");
+  if (!existsSync(combinedServerPath)) {
+    fail(`Combined server runner missing: ${combinedServerPath}`);
+  }
+
+  const wantsHelp = args.includes("--help") || args.includes("-h");
+  const extraEnv = wantsHelp
+    ? process.env
+    : { ...process.env, JAZZ_TOOLS_RUST_BIN: resolveRustBinaryPath().binaryPath };
+  const combinedServerResult = spawnSync(process.execPath, [combinedServerPath, ...args], {
+    stdio: "inherit",
+    env: extraEnv,
+  });
+  exitWithSpawnResult(combinedServerResult, "Combined Jazz server runner");
 } else {
-  const key = `${process.platform}-${process.arch}`;
-  const binaryName = BINARIES[key];
-  const localBinaryName = process.platform === "win32" ? "jazz-tools.exe" : "jazz-tools";
-  const fallbackCandidates = [
-    join(here, "..", "..", "..", "target", "debug", localBinaryName),
-    join(here, "..", "..", "..", "target", "release", localBinaryName),
-  ];
-
-  const bundledBinaryPath = binaryName ? join(here, "native", binaryName) : undefined;
-  if (rustBinOverride && !existsSync(rustBinOverride)) {
-    fail(`Configured Rust binary missing: ${rustBinOverride}`);
-  }
-  const binaryPath =
-    rustBinOverride ??
-    (bundledBinaryPath && existsSync(bundledBinaryPath)
-      ? bundledBinaryPath
-      : fallbackCandidates.find((candidate) => existsSync(candidate)));
-
-  if (!binaryPath) {
-    const lines = [];
-    if (!binaryName) {
-      lines.push(
-        `jazz-tools does not include a bundled binary for ${process.platform}/${process.arch}.`,
-      );
-    } else {
-      lines.push(`Bundled binary missing: ${binaryName}`);
-      lines.push("This package may be corrupted or published without target artifacts.");
-    }
-    lines.push("No local Cargo build was found in target/debug or target/release.");
-    lines.push("Run `cargo build -p jazz-tools --bin jazz-tools --features cli` to build locally.");
-    fail(lines.join("\n"));
-  }
-
-  ensureExecutable(binaryPath, rustBinOverride ?? binaryName ?? localBinaryName);
-
+  const { binaryName, binaryPath } = resolveRustBinaryPath();
   const result = spawnSync(binaryPath, args, { stdio: "inherit", env: process.env });
   exitWithSpawnResult(result, binaryName ?? binaryPath);
 }

--- a/packages/jazz-tools/package.json
+++ b/packages/jazz-tools/package.json
@@ -66,7 +66,7 @@
   },
   "scripts": {
     "build": "pnpm build:runtime && pnpm build:test && pnpm build:svelte",
-    "build:runtime": "tsc && cp src/worker/jazz-worker.ts dist/worker/jazz-worker.ts",
+    "build:runtime": "tsc && cp src/worker/jazz-worker.ts dist/worker/jazz-worker.ts && pnpm --filter jazz-auth build && rm -rf dist/vendor/jazz-auth && mkdir -p dist/vendor/jazz-auth && cp -R ../jazz-auth/dist/* dist/vendor/jazz-auth/",
     "build:svelte": "svelte-package -i src/svelte -o dist/svelte --tsconfig tsconfig.svelte.json && node scripts/cleanup-generated-src-types.mjs",
     "test": "vitest run --config vitest.config.ts && vitest run --config vitest.config.svelte.ts",
     "test:svelte": "vitest run --config vitest.config.svelte.ts",

--- a/packages/jazz-tools/src/cli.test.ts
+++ b/packages/jazz-tools/src/cli.test.ts
@@ -19,6 +19,7 @@ import { loadWasmModule } from "./runtime/client.js";
 import {
   createMigration,
   exportSchema,
+  initAuthApp,
   permissionsStatus,
   pushMigration,
   pushPermissions,
@@ -439,6 +440,51 @@ describe("cli schema export", () => {
       "title",
       "ownerId",
     ]);
+  });
+});
+
+describe("cli auth", () => {
+  it("scaffolds a standalone hosted auth Next app", async () => {
+    const { root } = await createWorkspace();
+    const authAppDir = join(root, "hosted-auth");
+
+    const { logs } = await captureConsoleLogs(() =>
+      initAuthApp({
+        dir: authAppDir,
+        appName: "jazz-auth-hosted",
+      }),
+    );
+
+    expect(await fileExists(join(authAppDir, "package.json"))).toBe(true);
+    expect(await fileExists(join(authAppDir, "README.md"))).toBe(true);
+    expect(await fileExists(join(authAppDir, "components.json"))).toBe(true);
+    expect(await fileExists(join(authAppDir, "app", "layout.tsx"))).toBe(true);
+    expect(await fileExists(join(authAppDir, "app", "globals.css"))).toBe(true);
+    expect(await fileExists(join(authAppDir, "app", "auth", "sign-in", "page.tsx"))).toBe(true);
+    expect(await fileExists(join(authAppDir, "app", "auth", "sign-up", "page.tsx"))).toBe(true);
+    expect(await fileExists(join(authAppDir, "app", "auth", "sign-out", "route.ts"))).toBe(true);
+    expect(await fileExists(join(authAppDir, "app", "api", "auth", "[...all]", "route.ts"))).toBe(
+      true,
+    );
+    expect(await fileExists(join(authAppDir, "src", "lib", "auth.ts"))).toBe(true);
+
+    const routeSource = await readFile(
+      join(authAppDir, "app", "api", "auth", "[...all]", "route.ts"),
+      "utf8",
+    );
+    expect(routeSource).toContain('from "jazz-auth/hosted"');
+
+    const componentConfig = await readFile(join(authAppDir, "components.json"), "utf8");
+    expect(componentConfig).toContain('"ui": "@/components/ui"');
+
+    const packageJson = await readFile(join(authAppDir, "package.json"), "utf8");
+    expect(packageJson).toContain("shadcn:init");
+    expect(packageJson).toContain("b2D0wqNxT");
+
+    expect(logs).toContain(
+      "Remember to merge ...jazzAuthTables() into your main Jazz schema before switching off the in-memory adapter.",
+    );
+    expect(logs).toContain("The scaffold includes a shadcn init script for preset b2D0wqNxT.");
   });
 });
 

--- a/packages/jazz-tools/src/cli.ts
+++ b/packages/jazz-tools/src/cli.ts
@@ -3,7 +3,7 @@
 // CLI for jazz-tools schema tooling
 
 import { access, mkdir, readFile, readdir, writeFile } from "fs/promises";
-import { basename, join, resolve } from "path";
+import { basename, dirname, join, resolve } from "path";
 import { pathToFileURL } from "url";
 import { register as registerEsm } from "tsx/esm/api";
 import type {
@@ -40,8 +40,14 @@ export interface SchemaExportOptions {
   adminSecret?: string;
 }
 
+export interface InitAuthAppOptions {
+  appName?: string;
+  dir: string;
+}
+
 const PERMISSIONS_LIFECYCLE_NOTE =
   "Permission-only changes do not create schema hashes or require migrations.";
+const SHADCN_PRESET = "b2D0wqNxT";
 
 function parseArgs(): { command: string; options: BuildOptions } {
   const args = process.argv.slice(2);
@@ -105,6 +111,348 @@ export async function exportSchema(options: SchemaExportOptions): Promise<void> 
   const currentSchema = await loadCurrentSchema(options.schemaDir);
   await ensureLocalSnapshot(options.schemaDir, currentSchema);
   process.stdout.write(`${JSON.stringify(currentSchema.schema, null, 2)}\n`);
+}
+
+function createAuthAppPackageJson(appName: string, jazzAuthVersion: string): string {
+  return `${JSON.stringify(
+    {
+      name: appName,
+      private: true,
+      scripts: {
+        build: "next build",
+        dev: "next dev",
+        "shadcn:init": `pnpm dlx shadcn@latest init --preset ${SHADCN_PRESET}`,
+        start: "next start",
+      },
+      type: "module",
+      dependencies: {
+        "better-auth": "1.5.6",
+        "jazz-auth": jazzAuthVersion,
+        next: "16.1.6",
+        react: "19.2.4",
+        "react-dom": "19.2.4",
+      },
+      devDependencies: {
+        "@tailwindcss/postcss": "^4",
+        "@types/node": "^20.0.0",
+        "@types/react": "^19.0.0",
+        "@types/react-dom": "^19.0.0",
+        tailwindcss: "^4",
+        typescript: "^6.0.2",
+      },
+    },
+    null,
+    2,
+  )}\n`;
+}
+
+function createAuthAppReadme(appName: string): string {
+  return `# ${appName}
+
+Hosted Jazz Auth app scaffold.
+
+## Included
+
+- Pure SSR Next.js app router scaffold
+- Hosted Jazz Auth pages under \`/auth/*\`
+- Better Auth route handler under \`/api/auth/*\`
+- shadcn-compatible \`components.json\`
+
+## shadcn preset
+
+To refresh the local shadcn layer with the requested preset, run:
+
+\`\`\`bash
+pnpm run shadcn:init
+\`\`\`
+
+This uses preset \`${SHADCN_PRESET}\`.
+`;
+}
+
+function createAuthAppTsconfig(): string {
+  return `{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}
+`;
+}
+
+function createComponentsJson(): string {
+  return `{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "new-york",
+  "rsc": true,
+  "tsx": true,
+  "tailwind": {
+    "config": "",
+    "css": "app/globals.css",
+    "baseColor": "neutral",
+    "cssVariables": true,
+    "prefix": ""
+  },
+  "aliases": {
+    "components": "@/components",
+    "hooks": "@/hooks",
+    "lib": "@/lib",
+    "ui": "@/components/ui",
+    "utils": "@/lib/utils"
+  }
+}
+`;
+}
+
+function createAuthGlobalsCss(): string {
+  return `@import "tailwindcss";
+@source "../node_modules/jazz-auth/dist/**/*.{js,mjs}";
+
+@theme inline {
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-border: var(--border);
+  --radius-xl: calc(var(--radius) + 0.25rem);
+  --radius-2xl: calc(var(--radius) + 0.75rem);
+}
+
+:root {
+  --background: oklch(0.985 0.006 95);
+  --foreground: oklch(0.26 0.025 255);
+  --card: oklch(1 0 0);
+  --card-foreground: oklch(0.26 0.025 255);
+  --primary: oklch(0.61 0.14 176);
+  --primary-foreground: oklch(0.99 0.01 180);
+  --secondary: oklch(0.95 0.012 176);
+  --secondary-foreground: oklch(0.3 0.03 255);
+  --muted: oklch(0.95 0.008 230);
+  --muted-foreground: oklch(0.5 0.02 255);
+  --accent: oklch(0.93 0.025 176);
+  --accent-foreground: oklch(0.28 0.03 255);
+  --border: oklch(0.88 0.01 235);
+  --radius: 1rem;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  min-height: 100%;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  background: var(--background);
+  color: var(--foreground);
+  font-family:
+    "Instrument Sans",
+    "Avenir Next",
+    "Segoe UI",
+    sans-serif;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+`;
+}
+
+function createAuthLayout(appName: string): string {
+  return `import type { Metadata } from "next";
+import "./globals.css";
+
+export const metadata: Metadata = {
+  title: ${JSON.stringify(appName)},
+  description: "Hosted Jazz Auth server and UI",
+};
+
+export default function RootLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}
+`;
+}
+
+function createAuthIndexPage(): string {
+  return `import { redirect } from "next/navigation";
+
+export default function Page() {
+  redirect("/auth/sign-in");
+}
+`;
+}
+
+function createHostedAuthLibFile(): string {
+  return `import { createJazzHostedAuth } from "jazz-auth/hosted";
+
+const baseURL = process.env.JAZZ_AUTH_BASE_URL ?? "http://localhost:3000";
+
+export const hostedAuth = createJazzHostedAuth({
+  baseURL,
+  secret: process.env.JAZZ_AUTH_SECRET ?? "jazz-auth-development-secret",
+});
+
+export const auth = hostedAuth.auth;
+export const authHandlers = hostedAuth.handlers;
+`;
+}
+
+function createHostedAuthRouteFile(): string {
+  return `import { getJazzHostedAuthHandlers } from "jazz-auth/hosted";
+import { hostedAuth } from "../../../../src/lib/auth";
+
+const authHandlers = getJazzHostedAuthHandlers(hostedAuth);
+
+export const GET = authHandlers.GET;
+export const POST = authHandlers.POST;
+export const PATCH = authHandlers.PATCH;
+export const PUT = authHandlers.PUT;
+export const DELETE = authHandlers.DELETE;
+`;
+}
+
+function createHostedPageFile(kind: "sign-in" | "sign-up"): string {
+  const componentName = kind === "sign-in" ? "JazzHostedSignInPage" : "JazzHostedSignUpPage";
+  const actionPath = kind === "sign-in" ? "/auth/sign-in/submit" : "/auth/sign-up/submit";
+
+  return `import { ${componentName} } from "jazz-auth/hosted";
+
+export default async function Page({
+  searchParams,
+}: {
+  searchParams: Promise<{
+    error?: string;
+    redirectTo?: string;
+  }>;
+}) {
+  const params = await searchParams;
+
+  return (
+    <${componentName}
+      action=${JSON.stringify(actionPath)}
+      error={params.error}
+      redirectTo={params.redirectTo}
+    />
+  );
+}
+`;
+}
+
+function createHostedSubmitRoute(kind: "sign-in" | "sign-up"): string {
+  const handlerName = kind === "sign-in" ? "handleJazzHostedSignIn" : "handleJazzHostedSignUp";
+
+  return `import { ${handlerName} } from "jazz-auth/hosted";
+import { hostedAuth } from "../../../../src/lib/auth";
+
+export async function POST(request: Request) {
+  return ${handlerName}(hostedAuth, request);
+}
+`;
+}
+
+function createHostedSignOutRoute(): string {
+  return `import { handleJazzHostedSignOut } from "jazz-auth/hosted";
+import { hostedAuth } from "../../../src/lib/auth";
+
+export async function GET(request: Request) {
+  return handleJazzHostedSignOut(hostedAuth, request);
+}
+`;
+}
+
+async function writeGeneratedFile(filePath: string, contents: string): Promise<void> {
+  await mkdir(dirname(filePath), { recursive: true });
+  await writeFile(filePath, contents);
+}
+
+export async function initAuthApp(options: InitAuthAppOptions): Promise<void> {
+  const dir = resolve(process.cwd(), options.dir);
+  const appName = options.appName?.trim() || basename(dir) || "jazz-auth-hosted";
+  const jazzAuthVersion = await packageVersion();
+
+  await mkdir(dir, { recursive: true });
+
+  const files = new Map<string, string>([
+    [join(dir, "package.json"), createAuthAppPackageJson(appName, jazzAuthVersion)],
+    [join(dir, "tsconfig.json"), createAuthAppTsconfig()],
+    [
+      join(dir, "next-env.d.ts"),
+      `/// <reference types="next" />\n/// <reference types="next/image-types/global" />\n`,
+    ],
+    [
+      join(dir, "next.config.mjs"),
+      `/** @type {import("next").NextConfig} */\nconst nextConfig = {};\n\nexport default nextConfig;\n`,
+    ],
+    [
+      join(dir, "postcss.config.mjs"),
+      `export default {\n  plugins: {\n    "@tailwindcss/postcss": {},\n  },\n};\n`,
+    ],
+    [join(dir, "components.json"), createComponentsJson()],
+    [
+      join(dir, ".env.example"),
+      `JAZZ_AUTH_BASE_URL=http://localhost:3000\nJAZZ_AUTH_SECRET=jazz-auth-development-secret\n`,
+    ],
+    [join(dir, "README.md"), createAuthAppReadme(appName)],
+    [join(dir, "app", "globals.css"), createAuthGlobalsCss()],
+    [join(dir, "app", "layout.tsx"), createAuthLayout(appName)],
+    [join(dir, "app", "page.tsx"), createAuthIndexPage()],
+    [join(dir, "app", "auth", "sign-in", "page.tsx"), createHostedPageFile("sign-in")],
+    [join(dir, "app", "auth", "sign-in", "submit", "route.ts"), createHostedSubmitRoute("sign-in")],
+    [join(dir, "app", "auth", "sign-up", "page.tsx"), createHostedPageFile("sign-up")],
+    [join(dir, "app", "auth", "sign-up", "submit", "route.ts"), createHostedSubmitRoute("sign-up")],
+    [join(dir, "app", "auth", "sign-out", "route.ts"), createHostedSignOutRoute()],
+    [join(dir, "app", "api", "auth", "[...all]", "route.ts"), createHostedAuthRouteFile()],
+    [join(dir, "src", "lib", "auth.ts"), createHostedAuthLibFile()],
+  ]);
+
+  await Promise.all(
+    [...files.entries()].map(async ([filePath, contents]) => {
+      await writeGeneratedFile(filePath, contents);
+    }),
+  );
+
+  console.log(`Created Jazz Auth hosted app in ${dir}.`);
+  console.log(`The scaffold includes a shadcn init script for preset ${SHADCN_PRESET}.`);
+  console.log(
+    "Swap the in-memory fallback in src/lib/auth.ts for your Jazz Better Auth adapter when it is ready.",
+  );
+  console.log(
+    "Remember to merge ...jazzAuthTables() into your main Jazz schema before switching off the in-memory adapter.",
+  );
 }
 
 export interface MigrationCommandOptions {
@@ -1556,6 +1904,23 @@ if (isMainModule()) {
       console.error(err.message);
       process.exit(1);
     });
+  } else if (command === "auth") {
+    const subcommand = process.argv[3] ?? "";
+    const args = process.argv.slice(4);
+    const task =
+      subcommand === "init"
+        ? initAuthApp({
+            appName: getFlagValue(args, "--name"),
+            dir: resolve(process.cwd(), getFlagValue(args, "--dir") ?? "jazz-auth-hosted"),
+          })
+        : Promise.reject(
+            new Error("Usage: node dist/cli.js auth init [--dir <path>] [--name <app-name>]"),
+          );
+
+    task.catch((err) => {
+      console.error(err.message);
+      process.exit(1);
+    });
   } else {
     console.log("Usage: node <path-to-jazz-tools>/dist/cli.js <command> [options]");
     console.log("\nCommands:");
@@ -1569,6 +1934,7 @@ if (isMainModule()) {
       "  migrations create     Generate a typed structural migration stub between two schema versions",
     );
     console.log("  migrations push       Push a reviewed migration edge to the server");
+    console.log("  auth init             Scaffold a hosted Jazz Auth Next.js app");
     console.log("\nValidation options:");
     console.log("  --schema-dir <path>   Path to app root containing schema.ts (default: .)");
     console.log("\nSchema export options:");
@@ -1591,6 +1957,9 @@ if (isMainModule()) {
     );
     console.log("  --toHash <hash>       Optional target schema hash (defaults to current schema)");
     console.log("  --name <name>         Optional migration filename label (default: unnamed)");
+    console.log("\nAuth scaffold options:");
+    console.log("  --dir <path>          Output directory for the hosted auth app");
+    console.log("  --name <app-name>     package.json name for the hosted auth app");
     process.exit(command ? 1 : 0);
   }
 }

--- a/packages/jazz-tools/src/combined-server.test.ts
+++ b/packages/jazz-tools/src/combined-server.test.ts
@@ -1,0 +1,157 @@
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import type { AddressInfo } from "node:net";
+import { afterEach, describe, expect, it } from "vitest";
+import { parseCombinedServerCommand, startReverseProxyServer } from "./combined-server.js";
+
+interface TestHttpServerHandle {
+  close(): Promise<void>;
+  url: string;
+}
+
+async function startTestHttpServer(
+  handler: (req: IncomingMessage, res: ServerResponse) => void,
+): Promise<TestHttpServerHandle> {
+  const server = createServer(handler);
+
+  await new Promise<void>((resolve, reject) => {
+    server.listen(0, "127.0.0.1", (error?: Error) => {
+      if (error) {
+        reject(error);
+      } else {
+        resolve();
+      }
+    });
+  });
+
+  const address = server.address() as AddressInfo;
+
+  return {
+    async close(): Promise<void> {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+          } else {
+            resolve();
+          }
+        });
+      });
+    },
+    url: `http://127.0.0.1:${address.port}`,
+  };
+}
+
+const activeHandles: Array<{ close(): Promise<void> }> = [];
+
+afterEach(async () => {
+  await Promise.all(
+    activeHandles
+      .splice(0)
+      .reverse()
+      .map((handle) => handle.close()),
+  );
+});
+
+describe("startReverseProxyServer", () => {
+  it("parses bundled-auth server options without leaking auth-only flags to Rust", () => {
+    expect(
+      parseCombinedServerCommand([
+        "server",
+        "app-123",
+        "--port",
+        "1700",
+        "--auth=none",
+        "--data-dir",
+        "./data",
+      ]),
+    ).toEqual({
+      appId: "app-123",
+      authMode: "none",
+      explicitJwksUrl: undefined,
+      publicPort: 1700,
+      rustArgs: ["server", "app-123", "--port", "1700", "--data-dir", "./data"],
+    });
+  });
+
+  it("routes auth-owned paths to the bundled auth server and sync paths to the Rust server", async () => {
+    const authServer = await startTestHttpServer((req, res) => {
+      if (req.url === "/auth/sign-in") {
+        res.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+        res.end("<h1>auth-sign-in</h1>");
+        return;
+      }
+
+      if (req.url === "/.well-known/jwks.json") {
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify({ keys: [{ kid: "auth-key" }] }));
+        return;
+      }
+
+      if (req.url === "/api/auth/sign-in/email" && req.method === "POST") {
+        let body = "";
+        req.setEncoding("utf8");
+        req.on("data", (chunk) => {
+          body += chunk;
+        });
+        req.on("end", () => {
+          res.writeHead(200, { "content-type": "application/json" });
+          res.end(JSON.stringify({ upstream: "auth", body }));
+        });
+        return;
+      }
+
+      res.writeHead(404);
+      res.end("auth-not-found");
+    });
+    activeHandles.push(authServer);
+
+    const syncServer = await startTestHttpServer((req, res) => {
+      if (req.url === "/health") {
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify({ upstream: "sync" }));
+        return;
+      }
+
+      if (req.url === "/sync") {
+        res.writeHead(200, { "content-type": "text/plain; charset=utf-8" });
+        res.end("sync-route");
+        return;
+      }
+
+      res.writeHead(404);
+      res.end("sync-not-found");
+    });
+    activeHandles.push(syncServer);
+
+    const proxy = await startReverseProxyServer({
+      authOrigin: authServer.url,
+      port: 0,
+      syncOrigin: syncServer.url,
+    });
+    activeHandles.push(proxy);
+
+    const signInResponse = await fetch(`${proxy.url}/auth/sign-in`);
+    expect(signInResponse.status).toBe(200);
+    await expect(signInResponse.text()).resolves.toContain("auth-sign-in");
+
+    const jwksResponse = await fetch(`${proxy.url}/.well-known/jwks.json`);
+    expect(jwksResponse.status).toBe(200);
+    await expect(jwksResponse.json()).resolves.toEqual({ keys: [{ kid: "auth-key" }] });
+
+    const authApiResponse = await fetch(`${proxy.url}/api/auth/sign-in/email`, {
+      body: JSON.stringify({ email: "alice@example.com" }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    });
+    await expect(authApiResponse.json()).resolves.toEqual({
+      body: JSON.stringify({ email: "alice@example.com" }),
+      upstream: "auth",
+    });
+
+    const healthResponse = await fetch(`${proxy.url}/health`);
+    await expect(healthResponse.json()).resolves.toEqual({ upstream: "sync" });
+
+    const syncResponse = await fetch(`${proxy.url}/sync`);
+    await expect(syncResponse.text()).resolves.toBe("sync-route");
+  });
+});

--- a/packages/jazz-tools/src/combined-server.ts
+++ b/packages/jazz-tools/src/combined-server.ts
@@ -1,0 +1,532 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import {
+  createServer,
+  request as httpRequest,
+  type IncomingMessage,
+  type ServerResponse,
+} from "node:http";
+import { existsSync } from "node:fs";
+import { createServer as createNetServer, type AddressInfo } from "node:net";
+import { fileURLToPath } from "node:url";
+
+export interface ReverseProxyServerOptions {
+  authOrigin: string;
+  bindHost?: string;
+  port: number;
+  syncOrigin: string;
+}
+
+export interface ReverseProxyServerHandle {
+  close(): Promise<void>;
+  port: number;
+  url: string;
+}
+
+export interface ParsedCombinedServerCommand {
+  appId: string;
+  authMode: "bundled" | "none";
+  explicitJwksUrl?: string;
+  publicPort: number;
+  rustArgs: string[];
+}
+
+export interface RunCombinedServerCommandOptions {
+  env?: NodeJS.ProcessEnv;
+  rustBinaryPath?: string;
+}
+
+const DEFAULT_BIND_HOST = "127.0.0.1";
+const DEFAULT_PUBLIC_PORT = 1625;
+const DEFAULT_HEALTH_TIMEOUT_MS = 30_000;
+const HEALTH_POLL_INTERVAL_MS = 100;
+
+export function isAuthOwnedPath(pathname: string): boolean {
+  return (
+    pathname === "/auth" ||
+    pathname.startsWith("/auth/") ||
+    pathname === "/api/auth" ||
+    pathname.startsWith("/api/auth/") ||
+    pathname === "/.well-known/jwks.json" ||
+    pathname === "/jwks"
+  );
+}
+
+function getFlagValue(args: string[], flag: string): string | undefined {
+  for (let index = 0; index < args.length; index += 1) {
+    const value = args[index];
+    if (!value) {
+      continue;
+    }
+
+    if (value === flag) {
+      return args[index + 1];
+    }
+
+    const prefix = `${flag}=`;
+    if (value.startsWith(prefix)) {
+      return value.slice(prefix.length);
+    }
+  }
+
+  return undefined;
+}
+
+function withoutAuthFlags(args: string[]): string[] {
+  const filtered: string[] = [];
+
+  for (let index = 0; index < args.length; index += 1) {
+    const value = args[index];
+    if (!value) {
+      continue;
+    }
+
+    if (value === "--auth") {
+      index += 1;
+      continue;
+    }
+
+    if (value.startsWith("--auth=")) {
+      continue;
+    }
+
+    filtered.push(value);
+  }
+
+  return filtered;
+}
+
+function replaceOrAppendFlag(args: string[], flag: string, nextValue: string): string[] {
+  const updated = [...args];
+
+  for (let index = 0; index < updated.length; index += 1) {
+    const value = updated[index];
+    if (!value) {
+      continue;
+    }
+
+    if (value === flag) {
+      updated[index + 1] = nextValue;
+      return updated;
+    }
+
+    const prefix = `${flag}=`;
+    if (value.startsWith(prefix)) {
+      updated[index] = `${flag}=${nextValue}`;
+      return updated;
+    }
+  }
+
+  updated.push(flag, nextValue);
+  return updated;
+}
+
+export function parseCombinedServerCommand(rawArgs: string[]): ParsedCombinedServerCommand {
+  if (rawArgs[0] !== "server") {
+    throw new Error("Combined server runner expects arguments starting with `server`.");
+  }
+
+  const appId = rawArgs[1];
+  if (!appId || appId.startsWith("-")) {
+    throw new Error("Missing app ID. Usage: jazz-tools server <APP_ID> [options]");
+  }
+
+  const serverArgs = rawArgs.slice(2);
+  const portValue = getFlagValue(serverArgs, "--port") ?? getFlagValue(serverArgs, "-p");
+  const authModeValue = getFlagValue(serverArgs, "--auth") ?? "bundled";
+  const authMode =
+    authModeValue === "none" || authModeValue === "bundled"
+      ? authModeValue
+      : (() => {
+          throw new Error(`Unsupported auth mode: ${authModeValue}`);
+        })();
+
+  return {
+    appId,
+    authMode,
+    explicitJwksUrl: getFlagValue(serverArgs, "--jwks-url"),
+    publicPort: portValue ? Number.parseInt(portValue, 10) : DEFAULT_PUBLIC_PORT,
+    rustArgs: withoutAuthFlags(rawArgs),
+  };
+}
+
+function printCombinedServerHelp(): void {
+  console.log("Usage: jazz-tools server <APP_ID> [options]");
+  console.log("");
+  console.log("Options:");
+  console.log("  --port <port>         Public port for the combined server (default: 1625)");
+  console.log("  --auth <mode>         Auth mode: bundled or none (default: bundled)");
+  console.log("  --data-dir <path>     Data directory forwarded to the Rust sync server");
+  console.log("  --jwks-url <url>      External JWKS URL (requires --auth=none)");
+  console.log("  -h, --help            Print help");
+}
+
+function buildUpstreamUrl(origin: string, requestPath: string): URL {
+  return new URL(requestPath || "/", origin);
+}
+
+function proxyRequest(request: IncomingMessage, response: ServerResponse, target: URL): void {
+  const forwardedHeaders: Record<string, string | string[]> = {};
+
+  for (const [key, value] of Object.entries(request.headers)) {
+    if (value === undefined) {
+      continue;
+    }
+
+    if (key.toLowerCase() === "host") {
+      continue;
+    }
+
+    forwardedHeaders[key] = value;
+  }
+
+  if (request.headers.host) {
+    forwardedHeaders["x-forwarded-host"] = request.headers.host;
+  }
+  forwardedHeaders["x-forwarded-proto"] = target.protocol.replace(/:$/, "");
+  forwardedHeaders.host = target.host;
+
+  const upstreamRequest = httpRequest(
+    {
+      headers: forwardedHeaders,
+      hostname: target.hostname,
+      method: request.method,
+      path: `${target.pathname}${target.search}`,
+      port: target.port,
+      protocol: target.protocol,
+    },
+    (upstreamResponse) => {
+      response.writeHead(upstreamResponse.statusCode ?? 502, upstreamResponse.headers);
+      upstreamResponse.pipe(response);
+    },
+  );
+
+  upstreamRequest.on("error", (error) => {
+    if (response.headersSent) {
+      response.destroy(error);
+      return;
+    }
+
+    response.writeHead(502, { "content-type": "application/json; charset=utf-8" });
+    response.end(JSON.stringify({ error: "upstream_proxy_failed", message: error.message }));
+  });
+
+  request.pipe(upstreamRequest);
+}
+
+export async function startReverseProxyServer(
+  options: ReverseProxyServerOptions,
+): Promise<ReverseProxyServerHandle> {
+  const bindHost = options.bindHost ?? DEFAULT_BIND_HOST;
+  const authOrigin = new URL(options.authOrigin);
+  const syncOrigin = new URL(options.syncOrigin);
+
+  const server = createServer((request, response) => {
+    const parsed = new URL(request.url ?? "/", "http://jazz-tools.local");
+    const target = isAuthOwnedPath(parsed.pathname)
+      ? buildUpstreamUrl(authOrigin.toString(), `${parsed.pathname}${parsed.search}`)
+      : buildUpstreamUrl(syncOrigin.toString(), `${parsed.pathname}${parsed.search}`);
+
+    proxyRequest(request, response, target);
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.listen(options.port, bindHost, (error?: Error) => {
+      if (error) {
+        reject(error);
+      } else {
+        resolve();
+      }
+    });
+  });
+
+  const address = server.address() as AddressInfo;
+
+  return {
+    async close(): Promise<void> {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+          } else {
+            resolve();
+          }
+        });
+      });
+    },
+    port: address.port,
+    url: `http://${bindHost}:${address.port}`,
+  };
+}
+
+function defaultRustBinaryPath(): string {
+  return fileURLToPath(new URL("../../../../target/debug/jazz-tools", import.meta.url));
+}
+
+async function reservePort(bindHost: string = DEFAULT_BIND_HOST): Promise<number> {
+  const server = createNetServer();
+
+  await new Promise<void>((resolve, reject) => {
+    server.listen(0, bindHost, (error?: Error) => {
+      if (error) {
+        reject(error);
+      } else {
+        resolve();
+      }
+    });
+  });
+
+  const address = server.address() as AddressInfo;
+  const port = address.port;
+
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+      } else {
+        resolve();
+      }
+    });
+  });
+
+  return port;
+}
+
+async function waitForHealthy(
+  url: string,
+  timeoutMs: number = DEFAULT_HEALTH_TIMEOUT_MS,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(url);
+      if (response.ok) {
+        return;
+      }
+    } catch {}
+
+    await new Promise((resolve) => setTimeout(resolve, HEALTH_POLL_INTERVAL_MS));
+  }
+
+  throw new Error(`Timed out waiting for ${url} to become healthy.`);
+}
+
+async function waitForChildExit(child: ChildProcess): Promise<number> {
+  return await new Promise<number>((resolve, reject) => {
+    child.once("error", reject);
+    child.once("exit", (code, signal) => {
+      if (typeof code === "number") {
+        resolve(code);
+        return;
+      }
+
+      if (signal) {
+        resolve(1);
+        return;
+      }
+
+      resolve(0);
+    });
+  });
+}
+
+async function terminateChild(child: ChildProcess): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return;
+  }
+
+  child.kill("SIGTERM");
+
+  await new Promise<void>((resolve) => {
+    const timeout = setTimeout(() => {
+      child.kill("SIGKILL");
+      resolve();
+    }, 2_000);
+
+    child.once("exit", () => {
+      clearTimeout(timeout);
+      resolve();
+    });
+  });
+}
+
+function spawnRustServer(binaryPath: string, args: string[], env: NodeJS.ProcessEnv): ChildProcess {
+  return spawn(binaryPath, args, {
+    env,
+    stdio: "inherit",
+  });
+}
+
+async function loadVendoredJazzAuthServer(): Promise<{
+  startJazzHostedAuthServer: (options: {
+    baseURL: string;
+    bindHost?: string;
+    port?: number;
+    secret: string;
+  }) => Promise<{ close(): Promise<void>; port: number; url: string }>;
+}> {
+  const moduleUrl = new URL("./vendor/jazz-auth/hosted/server.js", import.meta.url);
+  return (await import(moduleUrl.href)) as {
+    startJazzHostedAuthServer: (options: {
+      baseURL: string;
+      bindHost?: string;
+      port?: number;
+      secret: string;
+    }) => Promise<{ close(): Promise<void>; port: number; url: string }>;
+  };
+}
+
+async function runRustOnlyServer(
+  parsed: ParsedCombinedServerCommand,
+  options: RunCombinedServerCommandOptions,
+): Promise<number> {
+  const rustBinaryPath =
+    options.rustBinaryPath ?? options.env?.JAZZ_TOOLS_RUST_BIN ?? defaultRustBinaryPath();
+
+  if (!existsSync(rustBinaryPath)) {
+    throw new Error(`Rust server binary not found at ${rustBinaryPath}.`);
+  }
+
+  const child = spawnRustServer(rustBinaryPath, parsed.rustArgs, {
+    ...process.env,
+    ...options.env,
+  });
+
+  return waitForChildExit(child);
+}
+
+export async function runCombinedServerCommand(
+  rawArgs: string[],
+  options: RunCombinedServerCommandOptions = {},
+): Promise<number> {
+  const parsed = parseCombinedServerCommand(rawArgs);
+
+  if (parsed.authMode === "none") {
+    return runRustOnlyServer(parsed, options);
+  }
+
+  if (parsed.explicitJwksUrl) {
+    throw new Error(
+      "Bundled Jazz Auth cannot be combined with --jwks-url. Use --auth=none to keep an external JWKS issuer.",
+    );
+  }
+
+  const rustBinaryPath =
+    options.rustBinaryPath ?? options.env?.JAZZ_TOOLS_RUST_BIN ?? defaultRustBinaryPath();
+  if (!existsSync(rustBinaryPath)) {
+    throw new Error(`Rust server binary not found at ${rustBinaryPath}.`);
+  }
+
+  const publicBaseURL =
+    options.env?.JAZZ_AUTH_BASE_URL ??
+    process.env.JAZZ_AUTH_BASE_URL ??
+    `http://${DEFAULT_BIND_HOST}:${parsed.publicPort}`;
+  const authSecret =
+    options.env?.JAZZ_AUTH_SECRET ?? process.env.JAZZ_AUTH_SECRET ?? "jazz-auth-development-secret";
+  const syncPort = await reservePort();
+  const authPort = await reservePort();
+
+  const { startJazzHostedAuthServer } = await loadVendoredJazzAuthServer();
+  const authServer = await startJazzHostedAuthServer({
+    baseURL: publicBaseURL,
+    bindHost: DEFAULT_BIND_HOST,
+    port: authPort,
+    secret: authSecret,
+  });
+
+  let rustChild: ChildProcess | null = null;
+  let proxy: ReverseProxyServerHandle | null = null;
+
+  const cleanup = async () => {
+    await Promise.allSettled([
+      proxy?.close(),
+      authServer.close(),
+      rustChild ? terminateChild(rustChild) : Promise.resolve(),
+    ]);
+  };
+
+  const onSignal = async (signal: NodeJS.Signals) => {
+    process.off("SIGINT", onSigInt);
+    process.off("SIGTERM", onSigTerm);
+    await cleanup();
+    process.exit(signal === "SIGINT" ? 130 : 143);
+  };
+
+  const onSigInt = () => {
+    void onSignal("SIGINT");
+  };
+  const onSigTerm = () => {
+    void onSignal("SIGTERM");
+  };
+
+  process.once("SIGINT", onSigInt);
+  process.once("SIGTERM", onSigTerm);
+
+  try {
+    const syncOrigin = `http://${DEFAULT_BIND_HOST}:${syncPort}`;
+    const rustArgsWithPort = replaceOrAppendFlag(parsed.rustArgs, "--port", String(syncPort));
+    const rustArgs = replaceOrAppendFlag(
+      rustArgsWithPort,
+      "--jwks-url",
+      `${authServer.url}/.well-known/jwks.json`,
+    );
+
+    rustChild = spawnRustServer(rustBinaryPath, rustArgs, {
+      ...process.env,
+      ...options.env,
+    });
+
+    await Promise.all([
+      waitForHealthy(`${syncOrigin}/health`),
+      waitForHealthy(`${authServer.url}/health`),
+    ]);
+
+    proxy = await startReverseProxyServer({
+      authOrigin: authServer.url,
+      bindHost: DEFAULT_BIND_HOST,
+      port: parsed.publicPort,
+      syncOrigin,
+    });
+
+    console.log(`Jazz server listening on ${proxy.url}`);
+    console.log(`Bundled Jazz Auth available at ${proxy.url}/auth/sign-in`);
+
+    const exitCode = await waitForChildExit(rustChild);
+    await cleanup();
+    process.off("SIGINT", onSigInt);
+    process.off("SIGTERM", onSigTerm);
+    return exitCode;
+  } catch (error) {
+    process.off("SIGINT", onSigInt);
+    process.off("SIGTERM", onSigTerm);
+    await cleanup();
+    throw error;
+  }
+}
+
+async function main(): Promise<void> {
+  try {
+    const rawArgs = process.argv.slice(2);
+    const wantsHelp =
+      rawArgs[0] === "server" && (rawArgs.includes("--help") || rawArgs.includes("-h"));
+    if (wantsHelp) {
+      printCombinedServerHelp();
+      process.exit(0);
+    }
+
+    const exitCode = await runCombinedServerCommand(rawArgs, {
+      env: process.env,
+      rustBinaryPath: process.env.JAZZ_TOOLS_RUST_BIN,
+    });
+    process.exit(exitCode);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}
+
+const currentFilePath = fileURLToPath(import.meta.url);
+
+if (process.argv[1] && currentFilePath === process.argv[1]) {
+  void main();
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1090,6 +1090,55 @@ importers:
         specifier: catalog:default
         version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.11.0)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.1(@types/node@24.11.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
+  packages/jazz-auth:
+    dependencies:
+      '@radix-ui/react-label':
+        specifier: ^2.1.8
+        version: 2.1.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slot':
+        specifier: ^1.2.4
+        version: 1.2.4(@types/react@19.2.14)(react@19.2.4)
+      better-auth:
+        specifier: 1.5.6
+        version: 1.5.6(@opentelemetry/api@1.9.1)(next@16.1.6(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(svelte@5.53.6)(vitest@4.1.0)(vue@3.5.29(typescript@6.0.2))
+      class-variance-authority:
+        specifier: ^0.7.1
+        version: 0.7.1
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
+      jazz-tools:
+        specifier: workspace:*
+        version: link:../jazz-tools
+      next:
+        specifier: 16.1.6
+        version: 16.1.6(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react:
+        specifier: 19.2.4
+        version: 19.2.4
+      react-dom:
+        specifier: 19.2.4
+        version: 19.2.4(react@19.2.4)
+      tailwind-merge:
+        specifier: ^3.4.0
+        version: 3.5.0
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.13
+      '@types/react':
+        specifier: ^19.0.0
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.0.0
+        version: 19.2.3(@types/react@19.2.14)
+      typescript:
+        specifier: catalog:default
+        version: 6.0.2
+      vitest:
+        specifier: catalog:default
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.19.13)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.1(@types/node@22.19.13)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+
   packages/jazz-tools:
     dependencies:
       '@standard-schema/spec':
@@ -16902,7 +16951,7 @@ snapshots:
       '@vitest/mocker': 4.1.0(vite@8.0.1(@types/node@22.19.13)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       playwright: 1.58.2
       tinyrainbow: 3.0.3
-      vitest: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.19.13)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@26.1.0)(vite@8.0.1(@types/node@22.19.13)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      vitest: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.19.13)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.1(@types/node@22.19.13)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -16980,7 +17029,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.0.3
-      vitest: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.19.13)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@26.1.0)(vite@8.0.1(@types/node@22.19.13)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      vitest: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.19.13)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.1(@types/node@22.19.13)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       ws: 8.19.0
     transitivePeerDependencies:
       - bufferutil
@@ -24197,6 +24246,38 @@ snapshots:
       '@vitest/ui': 4.1.0(vitest@4.1.0)
       happy-dom: 20.8.4
       jsdom: 26.1.0
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.19.13)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.1(@types/node@22.19.13)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
+    dependencies:
+      '@vitest/expect': 4.1.0
+      '@vitest/mocker': 4.1.0(vite@8.0.1(@types/node@22.19.13)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/pretty-format': 4.1.0
+      '@vitest/runner': 4.1.0
+      '@vitest/snapshot': 4.1.0
+      '@vitest/spy': 4.1.0
+      '@vitest/utils': 4.1.0
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.0.3
+      vite: 8.0.1(@types/node@22.19.13)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 22.19.13
+      '@vitest/browser-playwright': 4.1.0(playwright@1.58.2)(vite@8.0.1(@types/node@22.19.13)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.1.0)
+      '@vitest/ui': 4.1.0(vitest@4.1.0)
+      happy-dom: 20.8.4
+      jsdom: 28.1.0(@noble/hashes@2.0.1)
     transitivePeerDependencies:
       - msw
 

--- a/specs/README.md
+++ b/specs/README.md
@@ -71,6 +71,7 @@ Testing details are documented in the layer specs above (especially Query/Sync i
 Remaining work items and future designs live in [`specs/todo/`](todo/). Notable:
 
 - **[Batch Branches and Prefix-Indexed Storage](todo/b_launch/batch_branches_and_prefix_storage.md)** — Replace multi-tip branches with linear per-batch histories under a shared prefix, optimized for millions of batches per object and fast leaf-head lookup
+- **[Jazz Auth](todo/b_launch/auth_integrations.md)** — Hosted auth sidecar plus a self-host compatible Better Auth escape hatch, layered on top of Jazz's existing JWT/JWKS auth path
 - **[Sharding Design Sketch](todo/b_launch/sharding_design_sketch.md)** — Future architecture for distributing data across storage shards (nothing implemented)
 - **[Storage: Browser E2E Suite](todo/a_mvp/browser_e2e_test_suite.md)** — End-to-end verification for browser runtime + worker + sync
 - **[Built-in File Storage](todo/a_mvp/built_in_file_storage.md)** — Framework-native file/blob storage using relational tables and chunked binary parts

--- a/specs/todo/b_launch/auth_integrations.md
+++ b/specs/todo/b_launch/auth_integrations.md
@@ -1,26 +1,487 @@
-# BetterAuth & WorkOS Integration — TODO
+# Jazz Auth (Hosted + Better Auth Compatible) - TODO
 
-Integrate with external auth providers for production-grade authentication.
+Built-in auth product for Jazz apps, implemented as a Node.js sidecar around Better Auth and exposed through a Jazz-owned SDK and hosted UI.
 
 ## Overview
 
-The current auth is JWT-based with a shared secret. For production use, integrate with:
+Jazz should offer a zero-config auth experience that feels built in:
 
-- **BetterAuth** — open-source auth library (email/password, OAuth, magic links)
-- **WorkOS** — enterprise SSO (SAML, SCIM, directory sync)
+- browser apps start anonymous by default
+- developers enable hosted auth for their app without wiring their own auth stack first
+- app code calls a tiny Jazz auth API (`signIn`, `signUp`, `signOut`, `completeRedirect`)
+- Jazz hosts the credential UI and returns a JWT that the sync server already knows how to validate via JWKS
 
-The integration should map external user identities to jazz2 sessions and client roles.
+Under the hood, auth is not implemented inside the sync server itself. Instead, Jazz runs an auth sidecar process in Node.js using Better Auth plus Jazz-specific adapter/hooks/JWT configuration.
 
-## Hosted Integration Plan
+This sidecar is the default hosted auth implementation and also defines a "self-host compatible Better Auth" escape hatch:
 
-- Auto-provision a WorkOS org per jazz app (via developer dashboard)
-- Offer hosted BetterAuth instance as a less vendor-locked alternative
-- See `developer_dashboard_billing.md` and `infra_and_dashboard.md` for the control plane
+- developers can later paste a generated Better Auth config into their own Next app, Hono server, or separate auth service
+- that self-hosted Better Auth instance uses the same Jazz adapter, schema, plugin set, principal mapping, and JWT/JWKS profile
+- hosted Jazz Auth and self-hosted compatible Better Auth should be able to operate concurrently against the same auth data
+
+The default Jazz developer experience should not mention Better Auth at all. Better Auth is an implementation detail until the developer explicitly chooses to self-host the compatible stack.
+
+## Why
+
+We want three properties at once:
+
+1. Jazz keeps its beloved anonymous-first onboarding loop
+2. production apps get a polished built-in auth story instead of stitching together a separate auth product
+3. developers who outgrow the hosted UX can drop down to a compatible self-hosted auth stack without changing their data model
+
+This design keeps Jazz core narrow:
+
+- the sync server remains a JWT/JWKS consumer
+- auth account/session/linking behavior lives in the auth sidecar
+- app schemas do not need to include core auth tables
+
+## Goals
+
+- Zero-config hosted auth for Jazz apps
+- Redirect-first auth flow with popup support
+- Anonymous-by-default browser startup
+- Hosted login/signup UI branded as Jazz, not Better Auth
+- App-owned pre-click UI and layout
+- Stable `jazz_principal_id` JWT claim for sync server auth
+- Self-host compatible Better Auth mode as an explicit escape hatch
+- Hosted Jazz Auth and compatible self-hosted Better Auth can run concurrently against the same auth data
+- No auth tables required in the app's own schema
+- Principal changes handled with full reload instead of live session rebinding
+
+## Non-Goals (MVP)
+
+- No iframe auth flow
+- No requirement that hosted and self-hosted deployments share browser cookies across different origins
+- No arbitrary Better Auth configuration compatibility; only Jazz-compatible Better Auth is in scope
+- No automatic merge of an existing remote account with unrelated anonymous local data
+- No enterprise SSO control plane in the first cut; WorkOS and similar providers are follow-up work
+- No auth implementation inside `jazz-tools` / `jazz-cloud-server` process itself
+
+## Product Modes
+
+### 1. Hosted Jazz Auth (default)
+
+Jazz runs the auth sidecar and hosted UI for the app.
+
+Developer experience:
+
+- enable auth in dashboard / app config
+- call Jazz auth helpers from the client
+- optionally override copy, button design, provider chooser, and email input in the app
+
+The app is unaware that Better Auth is used underneath.
+
+### 2. Self-Host Compatible Better Auth (escape hatch)
+
+Jazz provides a generated Better Auth config snippet plus env values for developers who want to own routes/UI/server deployment.
+
+Compatibility means:
+
+- same auth tables and adapter behavior
+- same Jazz principal mapping hooks
+- same JWT/JWKS profile
+- same Better Auth major/minor compatibility target and plugin allowlist
+
+This mode is intended for:
+
+- custom UI in Next or another full-stack framework
+- separate auth services owned by the developer
+- gradual migration away from Jazz-hosted auth without rewriting identity data
+
+### 3. Ejected / arbitrary Better Auth
+
+Developers may customize Better Auth beyond the Jazz-compatible profile, but once they do, seamless coexistence with hosted Jazz Auth is no longer guaranteed.
+
+Jazz should describe this clearly as an unsupported compatibility boundary, not a bug.
+
+## High-Level Architecture
+
+### Auth sidecar
+
+A Node.js service that:
+
+- mounts Better Auth at an internal base path
+- serves Jazz-owned hosted auth pages
+- stores auth data through the Jazz Better Auth adapter
+- mints JWTs for Jazz sync access
+- exposes a JWKS endpoint for sync server validation
+- owns principal mapping and auth intent state
+
+### Sync server
+
+The sync server does not run Better Auth. It only:
+
+- validates JWTs against the configured JWKS endpoint
+- reads `jazz_principal_id` and standard claims
+- turns that into `Session.user_id` / `Session.claims`
+
+This keeps the current `external` JWT auth path intact and makes Jazz Auth an auth provider layered on top of it.
+
+### Hosted deployment boundary
+
+The sidecar is a separate process, but hosted Jazz should present it as one product surface via routing/proxying. From the app's point of view, auth should feel integrated with the Jazz server product, even if the implementation is split.
+
+## Better Auth Compatibility Contract
+
+Hosted Jazz Auth and self-hosted compatible Better Auth only interoperate if they use the same Jazz compatibility profile.
+
+That profile includes:
+
+- pinned Better Auth version range
+- pinned plugin allowlist
+- Jazz Better Auth adapter configuration
+- Jazz principal mapping hook/plugin
+- JWT/JWKS plugin configuration
+- account-to-principal claim mapping (`jazz_principal_id`)
+- route and callback semantics expected by the Jazz SDK
+
+This should be expressed as code, not documentation alone. Provide a package or generated snippet built around a shared helper, for example:
+
+```ts
+import { betterAuth } from "better-auth";
+import {
+  jazzAuthAdapter,
+  jazzCompatiblePlugins,
+  jazzCompatibleHooks,
+} from "@jazz/auth/better-auth";
+
+export const auth = betterAuth({
+  baseURL: process.env.AUTH_BASE_URL!,
+  basePath: "/api/auth",
+  secret: process.env.JAZZ_AUTH_SECRET!,
+  database: jazzAuthAdapter({
+    appId: process.env.JAZZ_APP_ID!,
+    serverUrl: process.env.JAZZ_SERVER_URL!,
+    adminSecret: process.env.JAZZ_ADMIN_SECRET!,
+  }),
+  plugins: jazzCompatiblePlugins(),
+  hooks: jazzCompatibleHooks(),
+});
+```
+
+The generated config should still be recognizable Better Auth config so developers can continue using Better Auth client/server APIs directly.
+
+## Auth Data Ownership
+
+Jazz should not require developers to add auth tables to their application schema.
+
+Instead:
+
+- Better Auth core tables live in a system-owned auth schema / namespace via the Jazz adapter
+- Jazz sidecar adds only the extra records it needs for compatibility
+- app-level tables remain focused on application data
+
+Minimum Jazz-owned auth data beyond Better Auth core tables:
+
+- account/user to `jazz_principal_id` mapping
+- short-lived auth intents
+- optional compatibility metadata / versioning
+
+Later we can expose selected auth records to apps through generated read-only helpers, but that is not required for MVP.
+
+## Principal Model
+
+### Anonymous local principals remain the bootstrap path
+
+Browser clients continue to default to anonymous local auth as described in `unified_auth_methods.md`.
+
+Local principal derivation stays the same:
+
+- `local:<base64url(sha256(app_id || ":" || mode || ":" || token))>`
+
+### Auth sidecar owns account-to-principal mapping
+
+Jazz Auth should move anonymous-to-account linking out of Jazz core and into the auth sidecar.
+
+The sidecar owns the decision:
+
+- when a new auth account should adopt the current anonymous principal
+- when an auth account should keep its existing principal
+- when a conflict requires the current anonymous data to remain separate
+
+### JWT claim contract
+
+Every JWT issued for sync access must include:
+
+- `iss`
+- `sub`
+- `jazz_principal_id`
+- optional `claims`
+
+The sync server should continue to treat `jazz_principal_id` as the preferred `Session.user_id`.
+
+## Auth Intent Flow
+
+Jazz Auth needs a first-class auth intent so the app can own pre-click UI while the sidecar owns the sensitive credential step.
+
+### Why
+
+The intent captures:
+
+- app id
+- desired screen (`sign-in` or `sign-up`)
+- selected provider / auth method
+- optional `loginHint` (for example prefilled email)
+- callback URL
+- popup vs redirect mode
+- current local principal context, if present
+
+This keeps the actual hosted auth step small and lets the app render its own buttons, email field, and surrounding layout before handing off.
+
+### Start flow
+
+1. App renders its own CTA / provider picker / optional email field
+2. App calls Jazz SDK helper
+3. SDK creates an auth intent with the sidecar
+4. Sidecar returns a signed short-lived intent reference / URL
+5. SDK redirects or opens popup to hosted Jazz auth page
+
+### Finish flow
+
+1. Hosted page completes auth through Better Auth
+2. Sidecar resolves or creates the Jazz principal for that account
+3. Sidecar returns a one-time code to the app callback, not a raw JWT in the URL
+4. App calls `completeRedirect()` or popup completion helper
+5. Sidecar exchanges the code for a Jazz sync JWT and auth metadata
+6. SDK stores the new JWT and reloads the app
+
+## Anonymous-to-Account Behavior
+
+### New account from anonymous session
+
+If signup begins from an anonymous Jazz client and the target account does not yet have a Jazz principal, the sidecar should adopt the current anonymous principal for that new account.
+
+Result:
+
+- no data migration is required
+- the issued JWT uses the same `jazz_principal_id`
+- the SDK still reloads for simplicity and consistency
+
+### Existing account sign-in
+
+If the user signs into an existing account, the sidecar should issue that account's existing `jazz_principal_id`.
+
+If it differs from the current anonymous principal:
+
+- the SDK reloads into the authenticated principal
+- the current anonymous data remains separate
+- Jazz does not attempt implicit account merge
+
+Explicit merge / claim flows can be added later as product work, but they are not part of MVP.
+
+## Client SDK Surface
+
+The primary Jazz auth API should be tiny and headless:
+
+- `signIn(options?)`
+- `signUp(options?)`
+- `signOut(options?)`
+- `completeRedirect()`
+- `getSignInUrl(options?)`
+- `openSignInPopup(options?)`
+
+Options may include:
+
+- `provider`
+- `loginHint`
+- `redirectTo`
+- `screen`
+
+Framework wrappers can expose hooks/components on top of this, but the contract should remain plain runtime primitives first.
+
+### Anonymous bootstrap API
+
+Do not make `becomeAnonUser()` a required browser API in MVP.
+
+Browser Jazz clients already know how to bootstrap anonymous local auth. Requiring an explicit callback would add ceremony without buying us anything.
+
+If we need an explicit helper later for non-browser clients or testing, add `ensureAnonymous()` as a thin utility instead of making it the primary path.
+
+## UI Ownership
+
+### What the app owns
+
+- button design
+- surrounding layout
+- copy and marketing context
+- provider choice UI
+- optional inline email input
+
+### What hosted Jazz Auth owns
+
+- credential collection / validation screen
+- OAuth redirects and callbacks
+- password reset / verification flows
+- issuance of Jazz-compatible JWTs
+
+This gives apps inlinability before the auth boundary without embedding the sensitive auth step itself.
+
+## Redirect and Popup
+
+### Redirect is the default
+
+It is the simplest flow for:
+
+- mobile web
+- strict browser privacy settings
+- OAuth providers that dislike popup blockers and iframe embedding
+
+### Popup is optional
+
+Popup support is useful for desktop web apps that want less navigation churn, but it should reuse the same auth intent and completion flow as redirect mode.
+
+### No iframe
+
+Do not support iframe login/signup UIs.
+
+Reasons:
+
+- third-party cookie restrictions
+- storage partitioning
+- provider frame restrictions
+- more complex clickjacking and `postMessage` surface
+- worse debugging and product ergonomics
+
+## Principal Changes and Reloads
+
+Jazz runtime currently does not support changing principals on a live client without recreating the DB/session graph.
+
+MVP behavior:
+
+- after successful sign-in completion, reload the app
+- after sign-out, reload the app
+- reload even when the principal remains the same, if that keeps the implementation simpler
+
+This is acceptable in MVP and lets us avoid threading auth upgrades through live subscriptions before we have proper rebinding semantics.
+
+## Better Auth Feature Allowlist
+
+Given Better Auth's fast release cadence and bug/security churn, Jazz should deliberately keep the compatibility profile narrow.
+
+Initial allowlist:
+
+- email/password
+- email one-time code or magic link
+- OAuth / OIDC providers
+- JWT/JWKS support
+
+Deferred:
+
+- API keys
+- organizations / active org switching
+- enterprise SSO management UI
+- broad plugin surface area not needed for Jazz Auth launch
+
+## Better Auth Risk Mitigation
+
+Better Auth is active, but also high-churn. Jazz should adopt it with guardrails:
+
+- pin Better Auth to an explicit compatibility version range
+- expose only a small audited plugin set in Jazz-compatible mode
+- maintain Jazz-owned integration tests around redirect, popup, signup, sign-in, sign-out, password reset, and JWT/JWKS behavior
+- keep Jazz SDK and hosted UI thin wrappers over a shared compatibility profile
+- be ready to upgrade quickly when Better Auth ships security fixes
+
+The compatibility contract should let us upgrade hosted Jazz Auth centrally while still telling self-hosters exactly which version/config profile they need to match.
+
+## Security
+
+- Never place long-lived JWTs directly in redirect URLs
+- Use one-time code exchange on redirect/popup completion
+- Use `state` and PKCE-style anti-replay protections for provider flows
+- Keep sync JWTs short-lived
+- Prefer refresh through sidecar session state rather than issuing long-lived bearer tokens
+- Treat popup completion as same-origin / explicit-origin `postMessage` only
+- Keep Better Auth CSRF and origin protections enabled in compatible mode
+- Distinguish between identity compatibility and cookie/session sharing across origins
+
+## Hosted Routes
+
+Suggested externally visible routes:
+
+- `/auth/sign-in`
+- `/auth/sign-up`
+- `/auth/callback`
+- `/auth/popup-complete`
+- `/auth/sign-out`
+- `/.well-known/jwks.json`
+
+Suggested internal Better Auth mount:
+
+- `/api/auth/*`
+
+Hosted Jazz routes should remain stable even if internal Better Auth routes evolve.
+
+## Self-Host Compatible Better Auth
+
+The escape hatch should be explicit in the Jazz product:
+
+- dashboard action or CLI command generates a Jazz-compatible Better Auth config snippet
+- generated env vars include the values needed for principal mapping and JWT/JWKS compatibility
+- developers can mount the config in Next, Hono, Express, or another Node environment
+
+Supported promise:
+
+- hosted Jazz Auth and self-hosted compatible Better Auth can read/write the same auth data
+- both can mint Jazz-compatible JWTs for the sync server
+- developers may use Better Auth client/server SDKs directly once they self-host
+
+Unsupported promise:
+
+- arbitrary Better Auth plugin mixes remain compatible forever
+- different origins automatically share browser session cookies
+
+## Dashboard / Control Plane Impact
+
+The developer dashboard should eventually manage:
+
+- hosted auth enabled/disabled
+- allowed auth methods
+- provider credentials
+- generated self-host compatibility snippet
+- Better Auth compatibility version
+- JWKS endpoint shown to self-hosted sync deployments if needed
+
+This is the control plane layer on top of the sidecar, not part of the sync server itself.
+
+## Relationship to Existing Jazz Auth Paths
+
+This spec does not remove generic external JWT auth.
+
+Instead:
+
+- generic external JWT auth remains the primitive supported by sync servers
+- Jazz Auth becomes one concrete JWT-issuing auth provider for that primitive
+- existing local auth bootstrap stays in place
+
+Over time, hosted Jazz Auth may replace some direct `link-external` usage for first-party Jazz apps, but the lower-level JWT/JWKS path should remain available.
+
+## Phased Rollout
+
+1. Keep current anonymous/demo/external JWT support as-is
+2. Add Node auth sidecar with Better Auth, Jazz adapter, and JWKS endpoint
+3. Add Jazz principal mapping and auth intent flow
+4. Ship hosted Jazz auth pages with redirect completion
+5. Add popup flow
+6. Add generated self-host compatible Better Auth config
+7. Add provider management in dashboard
+
+## Test Plan
+
+- Hosted signup from anonymous client adopts the anonymous principal
+- Hosted sign-in to existing account returns that account's principal and reloads cleanly
+- Redirect completion exchanges one-time code for Jazz JWT without putting the JWT in the URL
+- Popup completion works with strict origin checks
+- Sync server accepts hosted-sidecar JWTs via JWKS
+- Self-hosted compatible Better Auth mints JWTs accepted by the same sync server
+- Hosted and self-hosted compatible Better Auth can operate concurrently against the same auth data
+- Sign-out reloads and returns to anonymous bootstrap state
+- Generated compatibility config stays in lockstep with hosted profile
 
 ## Open Questions
 
-- Where does the auth boundary sit? (Middleware before jazz2, or built into the server?)
-- Session token format: keep JWTs or switch to opaque tokens with server-side lookup?
-- How do external user IDs map to jazz2's session/client model?
-- Row-level access control: can we derive permissions from WorkOS roles/groups?
-- Self-hosted vs. cloud auth — both paths needed?
+- Should compatible self-host mode require the exact same Better Auth patch version, or a tested semver range?
+- Should sync JWT issuance be handled directly by Better Auth's JWT plugin, or by a Jazz wrapper endpoint layered on top of Better Auth session state?
+- How much of Better Auth's session cookie model should we preserve versus treating it as an implementation detail behind Jazz APIs?
+- Should we expose read-only auth/user helpers in generated Jazz app clients later?
+- Should passwordless email be the default hosted option, with password auth opt-in?

--- a/specs/todo/b_launch/developer_dashboard_billing.md
+++ b/specs/todo/b_launch/developer_dashboard_billing.md
@@ -14,7 +14,7 @@ A hosted dashboard where developers can:
 
 ## Auth Integration
 
-The dashboard should integrate with WorkOS platform to auto-provision a WorkOS org per jazz app (and environment?). Should also include a hosted BetterAuth instance as a less vendor-locked auth option. See `auth_integrations.md` for details.
+The dashboard should manage Jazz Auth configuration for each app: hosted auth enablement, provider setup, and generated self-host compatible Better Auth snippets. Enterprise SSO / WorkOS-style integrations are follow-up work layered on top of this. See `auth_integrations.md` for details.
 
 ## Open Questions
 


### PR DESCRIPTION
## What changed

This PR expands the auth launch spec into a concrete `Jazz Auth` design built around a Node.js auth sidecar using Better Auth under the hood.

It now covers:

- hosted Jazz auth as the default experience
- a self-host compatible Better Auth escape hatch
- the Jazz-owned SDK surface and hosted redirect/popup flows
- principal mapping, JWT/JWKS boundaries, and reload-on-principal-change behavior
- Better Auth compatibility constraints, risk mitigation, and phased rollout

It also updates the dashboard billing doc and the specs index to point at the new design.

## Why

We converged on a design that keeps Jazz core focused on JWT/JWKS validation while moving auth account/session/linking behavior into a separate auth subsystem.

That gives us a smooth built-in auth DX without forcing app authors to own auth tables or wire their own provider from day one, while still preserving an escape hatch to paste a Jazz-compatible Better Auth config into their own app later.

## Impact

This is a spec-only change. No runtime behavior changes yet.

## Validation

- reviewed the updated auth spec against the existing auth/docs structure
- updated adjacent docs so they no longer describe the older hosted BetterAuth + WorkOS sketch as the active plan
