### PR TITLE
Trim CI benchmark workloads for storage backends

### DIFF
--- a/benchmarks/realistic/ci/scenarios/r1_crud_sustained.json
+++ b/benchmarks/realistic/ci/scenarios/r1_crud_sustained.json
@@ -1,0 +1,11 @@
+{
+  "id": "R1",
+  "name": "sustained_crud_throughput",
+  "seed": 20260222,
+  "operation_count": 256,
+  "mix": [
+    { "operation": "insert_task", "weight": 25 },
+    { "operation": "update_task", "weight": 50 },
+    { "operation": "delete_task", "weight": 25 }
+  ]
+}

--- a/benchmarks/realistic/ci/scenarios/r2_reads_sustained.json
+++ b/benchmarks/realistic/ci/scenarios/r2_reads_sustained.json
@@ -1,0 +1,12 @@
+{
+  "id": "R2",
+  "name": "sustained_read_throughput",
+  "seed": 20260222,
+  "operation_count": 256,
+  "mix": [
+    { "operation": "query_board", "weight": 40 },
+    { "operation": "query_my_work", "weight": 30 },
+    { "operation": "query_task_detail", "weight": 20 },
+    { "operation": "query_activity_feed", "weight": 10 }
+  ]
+}

--- a/benchmarks/realistic/ci/scenarios/r2_reads_with_churn.json
+++ b/benchmarks/realistic/ci/scenarios/r2_reads_with_churn.json
@@ -1,0 +1,13 @@
+{
+  "id": "R2B",
+  "name": "sustained_read_throughput_with_background_write_churn",
+  "seed": 20260222,
+  "operation_count": 256,
+  "background_write_ratio": 0.05,
+  "mix": [
+    { "operation": "query_board", "weight": 40 },
+    { "operation": "query_my_work", "weight": 30 },
+    { "operation": "query_task_detail", "weight": 20 },
+    { "operation": "query_activity_feed", "weight": 10 }
+  ]
+}

--- a/benchmarks/realistic/ci/scenarios/r4_fanout_updates.json
+++ b/benchmarks/realistic/ci/scenarios/r4_fanout_updates.json
@@ -2,7 +2,7 @@
   "id": "R4",
   "name": "update_fanout_to_many_clients",
   "seed": 20260222,
-  "operation_count": 64,
-  "fanout_clients": [10, 50],
+  "operation_count": 8,
+  "fanout_clients": [10, 20],
   "target_project_index": 0
 }

--- a/benchmarks/realistic/ci/scenarios/r5_permission_recursive.json
+++ b/benchmarks/realistic/ci/scenarios/r5_permission_recursive.json
@@ -1,0 +1,15 @@
+{
+  "id": "R5",
+  "name": "recursive_permission_read_write_mix",
+  "seed": 20260222,
+  "operation_count": 128,
+  "mix": [
+    { "operation": "query_visible_docs", "weight": 60 },
+    { "operation": "update_allowed_doc", "weight": 25 },
+    { "operation": "update_denied_doc", "weight": 15 }
+  ],
+  "recursive_depths": [1, 3, 6],
+  "shared_chain_depth": 4,
+  "docs_per_folder": 24,
+  "denied_docs": 96
+}

--- a/benchmarks/realistic/ci/scenarios/r7_hotspot_history.json
+++ b/benchmarks/realistic/ci/scenarios/r7_hotspot_history.json
@@ -1,0 +1,7 @@
+{
+  "id": "R7A",
+  "name": "deep_history_hotspot_updates",
+  "seed": 20260222,
+  "operation_count": 1024,
+  "hot_task_count": 10
+}

--- a/benchmarks/realistic/ci/scenarios/r9_subscribed_write_path.json
+++ b/benchmarks/realistic/ci/scenarios/r9_subscribed_write_path.json
@@ -1,6 +1,6 @@
 {
   "id": "R9",
   "name": "Subscribed write path",
-  "scale": 1000,
+  "scale": 500,
   "subscription_count": 1
 }

--- a/benchmarks/realistic/ci/scenarios/w1_interactive.json
+++ b/benchmarks/realistic/ci/scenarios/w1_interactive.json
@@ -3,7 +3,7 @@
   "name": "interactive_board_session",
   "seed": 9001,
   "mode": "interactive",
-  "operation_count": 100000,
+  "operation_count": 75000,
   "mix": [
     { "operation": "query_board", "weight": 30 },
     { "operation": "query_my_work", "weight": 20 },

--- a/benchmarks/realistic/ci_scenarios.test.mjs
+++ b/benchmarks/realistic/ci_scenarios.test.mjs
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+function readJson(path) {
+  return JSON.parse(readFileSync(new URL(path, import.meta.url), "utf8"));
+}
+
+test("CI scenario fixtures cap the heavy workloads that have been timing out in storage-backed CI", () => {
+  const w1Ci = readJson("./ci/scenarios/w1_interactive.json");
+  assert.equal(w1Ci.operation_count, 75000);
+
+  const r1Ci = readJson("./ci/scenarios/r1_crud_sustained.json");
+  assert.equal(r1Ci.operation_count, 256);
+
+  const r2Ci = readJson("./ci/scenarios/r2_reads_sustained.json");
+  assert.equal(r2Ci.operation_count, 256);
+
+  const r2ChurnCi = readJson("./ci/scenarios/r2_reads_with_churn.json");
+  assert.equal(r2ChurnCi.operation_count, 256);
+
+  const r4Ci = readJson("./ci/scenarios/r4_fanout_updates.json");
+  assert.equal(r4Ci.operation_count, 8);
+  assert.deepEqual(r4Ci.fanout_clients, [10, 20]);
+
+  const r5Ci = readJson("./ci/scenarios/r5_permission_recursive.json");
+  assert.equal(r5Ci.operation_count, 128);
+  assert.equal(r5Ci.shared_chain_depth, 4);
+  assert.equal(r5Ci.docs_per_folder, 24);
+  assert.equal(r5Ci.denied_docs, 96);
+  assert.deepEqual(r5Ci.recursive_depths, [1, 3, 6]);
+
+  const r7Ci = readJson("./ci/scenarios/r7_hotspot_history.json");
+  assert.equal(r7Ci.operation_count, 1024);
+
+  const r9Ci = readJson("./ci/scenarios/r9_subscribed_write_path.json");
+  assert.equal(r9Ci.scale, 500);
+});

--- a/crates/jazz-tools/benches/realistic_phase1.rs
+++ b/crates/jazz-tools/benches/realistic_phase1.rs
@@ -1547,8 +1547,8 @@ impl<S: Storage> PermissionR5State<S> {
 }
 
 fn realistic_r1_crud(c: &mut Criterion) {
-    let profile: ProfileConfig = load_json("benchmarks/realistic/profiles/s.json");
-    let scenario = load_r1_scenario("benchmarks/realistic/scenarios/r1_crud_sustained.json");
+    let profile: ProfileConfig = load_json(profile_config_path());
+    let scenario = load_r1_scenario(r1_scenario_path());
     let benchmark_name = format!(
         "{}_{}",
         scenario.id.to_lowercase(),
@@ -1575,8 +1575,8 @@ fn realistic_r1_crud(c: &mut Criterion) {
 }
 
 fn realistic_r1_crud_single_hop(c: &mut Criterion) {
-    let profile: ProfileConfig = load_json("benchmarks/realistic/profiles/s.json");
-    let scenario = load_r1_scenario("benchmarks/realistic/scenarios/r1_crud_sustained.json");
+    let profile: ProfileConfig = load_json(profile_config_path());
+    let scenario = load_r1_scenario(r1_scenario_path());
     let benchmark_name = format!(
         "{}_{}_single_hop",
         scenario.id.to_lowercase(),
@@ -1604,8 +1604,8 @@ fn realistic_r1_crud_single_hop(c: &mut Criterion) {
 }
 
 fn realistic_r2_reads(c: &mut Criterion) {
-    let profile: ProfileConfig = load_json("benchmarks/realistic/profiles/s.json");
-    let scenario = load_r2_scenario("benchmarks/realistic/scenarios/r2_reads_sustained.json");
+    let profile: ProfileConfig = load_json(profile_config_path());
+    let scenario = load_r2_scenario(r2_sustained_scenario_path());
     let benchmark_name = format!(
         "{}_{}",
         scenario.id.to_lowercase(),
@@ -1632,9 +1632,9 @@ fn realistic_r2_reads(c: &mut Criterion) {
 }
 
 fn realistic_r2_reads_single_hop(c: &mut Criterion) {
-    let profile: ProfileConfig = load_json("benchmarks/realistic/profiles/s.json");
-    let scenario = load_r2_scenario("benchmarks/realistic/scenarios/r2_reads_sustained.json");
-    let seed_scenario = load_r1_scenario("benchmarks/realistic/scenarios/r1_crud_sustained.json");
+    let profile: ProfileConfig = load_json(profile_config_path());
+    let scenario = load_r2_scenario(r2_sustained_scenario_path());
+    let seed_scenario = load_r1_scenario(r1_scenario_path());
     let benchmark_name = format!(
         "{}_{}_single_hop",
         scenario.id.to_lowercase(),
@@ -1662,9 +1662,9 @@ fn realistic_r2_reads_single_hop(c: &mut Criterion) {
 }
 
 fn realistic_r2_reads_with_write_churn(c: &mut Criterion) {
-    let profile: ProfileConfig = load_json("benchmarks/realistic/profiles/s.json");
-    let read_scenario = load_r2_scenario("benchmarks/realistic/scenarios/r2_reads_with_churn.json");
-    let write_scenario = load_r1_scenario("benchmarks/realistic/scenarios/r1_crud_sustained.json");
+    let profile: ProfileConfig = load_json(profile_config_path());
+    let read_scenario = load_r2_scenario(r2_reads_with_churn_scenario_path());
+    let write_scenario = load_r1_scenario(r1_scenario_path());
     let benchmark_name = format!(
         "{}_{}_with_churn",
         read_scenario.id.to_lowercase(),
@@ -1692,8 +1692,8 @@ fn realistic_r2_reads_with_write_churn(c: &mut Criterion) {
 
 #[cfg(all(feature = "rocksdb", not(target_arch = "wasm32")))]
 fn realistic_r1_crud_single_hop_rocksdb(c: &mut Criterion) {
-    let profile: ProfileConfig = load_json("benchmarks/realistic/profiles/s.json");
-    let scenario = load_r1_scenario("benchmarks/realistic/scenarios/r1_crud_sustained.json");
+    let profile: ProfileConfig = load_json(profile_config_path());
+    let scenario = load_r1_scenario(r1_scenario_path());
     let benchmark_name = format!(
         "{}_{}_single_hop_rocksdb",
         scenario.id.to_lowercase(),
@@ -1739,8 +1739,8 @@ fn realistic_r1_crud_single_hop_rocksdb(_c: &mut Criterion) {}
 
 #[cfg(all(feature = "sqlite", not(target_arch = "wasm32")))]
 fn realistic_r1_crud_single_hop_sqlite(c: &mut Criterion) {
-    let profile: ProfileConfig = load_json("benchmarks/realistic/profiles/s.json");
-    let scenario = load_r1_scenario("benchmarks/realistic/scenarios/r1_crud_sustained.json");
+    let profile: ProfileConfig = load_json(profile_config_path());
+    let scenario = load_r1_scenario(r1_scenario_path());
     let benchmark_name = format!(
         "{}_{}_single_hop_sqlite",
         scenario.id.to_lowercase(),
@@ -1782,9 +1782,9 @@ fn realistic_r1_crud_single_hop_sqlite(_c: &mut Criterion) {}
 
 #[cfg(all(feature = "rocksdb", not(target_arch = "wasm32")))]
 fn realistic_r2_reads_single_hop_rocksdb(c: &mut Criterion) {
-    let profile: ProfileConfig = load_json("benchmarks/realistic/profiles/s.json");
-    let scenario = load_r2_scenario("benchmarks/realistic/scenarios/r2_reads_sustained.json");
-    let seed_scenario = load_r1_scenario("benchmarks/realistic/scenarios/r1_crud_sustained.json");
+    let profile: ProfileConfig = load_json(profile_config_path());
+    let scenario = load_r2_scenario(r2_sustained_scenario_path());
+    let seed_scenario = load_r1_scenario(r1_scenario_path());
     let benchmark_name = format!(
         "{}_{}_single_hop_rocksdb",
         scenario.id.to_lowercase(),
@@ -1831,9 +1831,9 @@ fn realistic_r2_reads_single_hop_rocksdb(_c: &mut Criterion) {}
 
 #[cfg(all(feature = "sqlite", not(target_arch = "wasm32")))]
 fn realistic_r2_reads_single_hop_sqlite(c: &mut Criterion) {
-    let profile: ProfileConfig = load_json("benchmarks/realistic/profiles/s.json");
-    let scenario = load_r2_scenario("benchmarks/realistic/scenarios/r2_reads_sustained.json");
-    let seed_scenario = load_r1_scenario("benchmarks/realistic/scenarios/r1_crud_sustained.json");
+    let profile: ProfileConfig = load_json(profile_config_path());
+    let scenario = load_r2_scenario(r2_sustained_scenario_path());
+    let seed_scenario = load_r1_scenario(r1_scenario_path());
     let benchmark_name = format!(
         "{}_{}_single_hop_sqlite",
         scenario.id.to_lowercase(),
@@ -1876,9 +1876,9 @@ fn realistic_r2_reads_single_hop_sqlite(_c: &mut Criterion) {}
 
 #[cfg(all(feature = "rocksdb", not(target_arch = "wasm32")))]
 fn realistic_r2_reads_with_write_churn_rocksdb(c: &mut Criterion) {
-    let profile: ProfileConfig = load_json("benchmarks/realistic/profiles/s.json");
-    let read_scenario = load_r2_scenario("benchmarks/realistic/scenarios/r2_reads_with_churn.json");
-    let write_scenario = load_r1_scenario("benchmarks/realistic/scenarios/r1_crud_sustained.json");
+    let profile: ProfileConfig = load_json(profile_config_path());
+    let read_scenario = load_r2_scenario(r2_reads_with_churn_scenario_path());
+    let write_scenario = load_r1_scenario(r1_scenario_path());
     let benchmark_name = format!(
         "{}_{}_with_churn_rocksdb",
         read_scenario.id.to_lowercase(),
@@ -1917,9 +1917,9 @@ fn realistic_r2_reads_with_write_churn_rocksdb(_c: &mut Criterion) {}
 
 #[cfg(all(feature = "sqlite", not(target_arch = "wasm32")))]
 fn realistic_r2_reads_with_write_churn_sqlite(c: &mut Criterion) {
-    let profile: ProfileConfig = load_json("benchmarks/realistic/profiles/s.json");
-    let read_scenario = load_r2_scenario("benchmarks/realistic/scenarios/r2_reads_with_churn.json");
-    let write_scenario = load_r1_scenario("benchmarks/realistic/scenarios/r1_crud_sustained.json");
+    let profile: ProfileConfig = load_json(profile_config_path());
+    let read_scenario = load_r2_scenario(r2_reads_with_churn_scenario_path());
+    let write_scenario = load_r1_scenario(r1_scenario_path());
     let benchmark_name = format!(
         "{}_{}_with_churn_sqlite",
         read_scenario.id.to_lowercase(),
@@ -1954,8 +1954,8 @@ fn realistic_r2_reads_with_write_churn_sqlite(_c: &mut Criterion) {}
 
 #[cfg(all(feature = "rocksdb", not(target_arch = "wasm32")))]
 fn realistic_r1_crud_rocksdb(c: &mut Criterion) {
-    let profile: ProfileConfig = load_json("benchmarks/realistic/profiles/s.json");
-    let scenario = load_r1_scenario("benchmarks/realistic/scenarios/r1_crud_sustained.json");
+    let profile: ProfileConfig = load_json(profile_config_path());
+    let scenario = load_r1_scenario(r1_scenario_path());
     let benchmark_name = format!(
         "{}_{}_rocksdb",
         scenario.id.to_lowercase(),
@@ -1993,8 +1993,8 @@ fn realistic_r1_crud_rocksdb(_c: &mut Criterion) {}
 
 #[cfg(all(feature = "sqlite", not(target_arch = "wasm32")))]
 fn realistic_r1_crud_sqlite(c: &mut Criterion) {
-    let profile: ProfileConfig = load_json("benchmarks/realistic/profiles/s.json");
-    let scenario = load_r1_scenario("benchmarks/realistic/scenarios/r1_crud_sustained.json");
+    let profile: ProfileConfig = load_json(profile_config_path());
+    let scenario = load_r1_scenario(r1_scenario_path());
     let benchmark_name = format!(
         "{}_{}_sqlite",
         scenario.id.to_lowercase(),
@@ -2031,8 +2031,8 @@ fn realistic_r1_crud_sqlite(_c: &mut Criterion) {}
 
 #[cfg(all(feature = "rocksdb", not(target_arch = "wasm32")))]
 fn realistic_r2_reads_rocksdb(c: &mut Criterion) {
-    let profile: ProfileConfig = load_json("benchmarks/realistic/profiles/s.json");
-    let scenario = load_r2_scenario("benchmarks/realistic/scenarios/r2_reads_sustained.json");
+    let profile: ProfileConfig = load_json(profile_config_path());
+    let scenario = load_r2_scenario(r2_sustained_scenario_path());
     let benchmark_name = format!(
         "{}_{}_rocksdb",
         scenario.id.to_lowercase(),
@@ -2070,8 +2070,8 @@ fn realistic_r2_reads_rocksdb(_c: &mut Criterion) {}
 
 #[cfg(all(feature = "sqlite", not(target_arch = "wasm32")))]
 fn realistic_r2_reads_sqlite(c: &mut Criterion) {
-    let profile: ProfileConfig = load_json("benchmarks/realistic/profiles/s.json");
-    let scenario = load_r2_scenario("benchmarks/realistic/scenarios/r2_reads_sustained.json");
+    let profile: ProfileConfig = load_json(profile_config_path());
+    let scenario = load_r2_scenario(r2_sustained_scenario_path());
     let benchmark_name = format!(
         "{}_{}_sqlite",
         scenario.id.to_lowercase(),
@@ -2213,7 +2213,7 @@ fn realistic_r3_cold_load_sqlite(c: &mut Criterion) {
 fn realistic_r3_cold_load_sqlite(_c: &mut Criterion) {}
 
 fn realistic_r4_fanout_updates(c: &mut Criterion) {
-    let profile: ProfileConfig = load_json("benchmarks/realistic/profiles/s.json");
+    let profile: ProfileConfig = load_json(profile_config_path());
     let scenario = load_r4_scenario(select_ci_path(
         "benchmarks/realistic/scenarios/r4_fanout_updates.json",
         "benchmarks/realistic/ci/scenarios/r4_fanout_updates.json",
@@ -2258,7 +2258,7 @@ fn realistic_r4_fanout_updates(c: &mut Criterion) {
 
 #[cfg(all(feature = "rocksdb", not(target_arch = "wasm32")))]
 fn realistic_r4_fanout_updates_rocksdb(c: &mut Criterion) {
-    let profile: ProfileConfig = load_json("benchmarks/realistic/profiles/s.json");
+    let profile: ProfileConfig = load_json(profile_config_path());
     let scenario = load_r4_scenario(select_ci_path(
         "benchmarks/realistic/scenarios/r4_fanout_updates.json",
         "benchmarks/realistic/ci/scenarios/r4_fanout_updates.json",
@@ -2322,7 +2322,7 @@ fn realistic_r4_fanout_updates_rocksdb(_c: &mut Criterion) {}
 
 #[cfg(all(feature = "sqlite", not(target_arch = "wasm32")))]
 fn realistic_r4_fanout_updates_sqlite(c: &mut Criterion) {
-    let profile: ProfileConfig = load_json("benchmarks/realistic/profiles/s.json");
+    let profile: ProfileConfig = load_json(profile_config_path());
     let scenario = load_r4_scenario(select_ci_path(
         "benchmarks/realistic/scenarios/r4_fanout_updates.json",
         "benchmarks/realistic/ci/scenarios/r4_fanout_updates.json",
@@ -2446,7 +2446,7 @@ fn realistic_r5_permission_recursive(c: &mut Criterion) {
     run_permission_scenario(
         c,
         "realistic_phase1/permission_recursive",
-        "benchmarks/realistic/scenarios/r5_permission_recursive.json",
+        r5_permission_recursive_scenario_path(),
     );
 }
 
@@ -2466,7 +2466,7 @@ fn realistic_r5_permission_recursive_rocksdb(c: &mut Criterion) {
     run_storage_permission_scenario(
         c,
         "realistic_phase1/permission_recursive_rocksdb",
-        "benchmarks/realistic/scenarios/r5_permission_recursive.json",
+        r5_permission_recursive_scenario_path(),
         |recursive_depth| {
             let tempdir = TempDir::new().expect("create tempdir for rocksdb permission benchmark");
             let db_path = tempdir.path().join(format!(
@@ -2490,7 +2490,7 @@ fn realistic_r5_permission_recursive_sqlite(c: &mut Criterion) {
     run_storage_permission_scenario(
         c,
         "realistic_phase1/permission_recursive_sqlite",
-        "benchmarks/realistic/scenarios/r5_permission_recursive.json",
+        r5_permission_recursive_scenario_path(),
         |recursive_depth| {
             let tempdir = TempDir::new().expect("create tempdir for sqlite permission benchmark");
             let db_path = tempdir.path().join(format!(
@@ -2557,8 +2557,8 @@ fn realistic_r6_permission_write_heavy_sqlite(c: &mut Criterion) {
 fn realistic_r6_permission_write_heavy_sqlite(_c: &mut Criterion) {}
 
 fn realistic_r7_hotspot_history(c: &mut Criterion) {
-    let profile: ProfileConfig = load_json("benchmarks/realistic/profiles/s.json");
-    let scenario = load_r7_scenario("benchmarks/realistic/scenarios/r7_hotspot_history.json");
+    let profile: ProfileConfig = load_json(profile_config_path());
+    let scenario = load_r7_scenario(r7_hotspot_history_scenario_path());
     let benchmark_name = format!(
         "{}_{}_hot{}",
         scenario.id.to_lowercase(),
@@ -2590,8 +2590,8 @@ fn realistic_r7_hotspot_history(c: &mut Criterion) {
 
 #[cfg(all(feature = "rocksdb", not(target_arch = "wasm32")))]
 fn realistic_r7_hotspot_history_rocksdb(c: &mut Criterion) {
-    let profile: ProfileConfig = load_json("benchmarks/realistic/profiles/s.json");
-    let scenario = load_r7_scenario("benchmarks/realistic/scenarios/r7_hotspot_history.json");
+    let profile: ProfileConfig = load_json(profile_config_path());
+    let scenario = load_r7_scenario(r7_hotspot_history_scenario_path());
     let benchmark_name = format!(
         "{}_{}_hot{}_rocksdb",
         scenario.id.to_lowercase(),
@@ -2634,8 +2634,8 @@ fn realistic_r7_hotspot_history_rocksdb(_c: &mut Criterion) {}
 
 #[cfg(all(feature = "sqlite", not(target_arch = "wasm32")))]
 fn realistic_r7_hotspot_history_sqlite(c: &mut Criterion) {
-    let profile: ProfileConfig = load_json("benchmarks/realistic/profiles/s.json");
-    let scenario = load_r7_scenario("benchmarks/realistic/scenarios/r7_hotspot_history.json");
+    let profile: ProfileConfig = load_json(profile_config_path());
+    let scenario = load_r7_scenario(r7_hotspot_history_scenario_path());
     let benchmark_name = format!(
         "{}_{}_hot{}_sqlite",
         scenario.id.to_lowercase(),
@@ -2673,7 +2673,7 @@ fn realistic_r7_hotspot_history_sqlite(c: &mut Criterion) {
 fn realistic_r7_hotspot_history_sqlite(_c: &mut Criterion) {}
 
 fn realistic_r8_many_branches_write(c: &mut Criterion) {
-    let profile: ProfileConfig = load_json("benchmarks/realistic/profiles/s.json");
+    let profile: ProfileConfig = load_json(profile_config_path());
     let scenario = load_r8_scenario(select_ci_path(
         "benchmarks/realistic/scenarios/r8_many_branches.json",
         "benchmarks/realistic/ci/scenarios/r8_many_branches.json",
@@ -2704,7 +2704,7 @@ fn realistic_r8_many_branches_write(c: &mut Criterion) {
 }
 
 fn realistic_r8_many_branches_scan_heads(c: &mut Criterion) {
-    let profile: ProfileConfig = load_json("benchmarks/realistic/profiles/s.json");
+    let profile: ProfileConfig = load_json(profile_config_path());
     let scenario = load_r8_scenario(select_ci_path(
         "benchmarks/realistic/scenarios/r8_many_branches.json",
         "benchmarks/realistic/ci/scenarios/r8_many_branches.json",
@@ -2737,7 +2737,7 @@ fn realistic_r8_many_branches_scan_heads(c: &mut Criterion) {
 }
 
 fn realistic_r8_many_branches_scan_leaf_heads(c: &mut Criterion) {
-    let profile: ProfileConfig = load_json("benchmarks/realistic/profiles/s.json");
+    let profile: ProfileConfig = load_json(profile_config_path());
     let scenario = load_r8_scenario(select_ci_path(
         "benchmarks/realistic/scenarios/r8_many_branches.json",
         "benchmarks/realistic/ci/scenarios/r8_many_branches.json",
@@ -2775,7 +2775,7 @@ fn realistic_r8_many_branches_scan_leaf_heads(c: &mut Criterion) {
 
 #[cfg(all(feature = "rocksdb", not(target_arch = "wasm32")))]
 fn realistic_r8_many_branches_cold_load_rocksdb(c: &mut Criterion) {
-    let profile: ProfileConfig = load_json("benchmarks/realistic/profiles/s.json");
+    let profile: ProfileConfig = load_json(profile_config_path());
     let scenario = load_r8_scenario(select_ci_path(
         "benchmarks/realistic/scenarios/r8_many_branches.json",
         "benchmarks/realistic/ci/scenarios/r8_many_branches.json",
@@ -2816,7 +2816,7 @@ fn realistic_r8_many_branches_cold_load_rocksdb(_c: &mut Criterion) {}
 
 #[cfg(all(feature = "sqlite", not(target_arch = "wasm32")))]
 fn realistic_r8_many_branches_cold_load_sqlite(c: &mut Criterion) {
-    let profile: ProfileConfig = load_json("benchmarks/realistic/profiles/s.json");
+    let profile: ProfileConfig = load_json(profile_config_path());
     let scenario = load_r8_scenario(select_ci_path(
         "benchmarks/realistic/scenarios/r8_many_branches.json",
         "benchmarks/realistic/ci/scenarios/r8_many_branches.json",
@@ -2854,7 +2854,7 @@ fn realistic_r8_many_branches_cold_load_sqlite(c: &mut Criterion) {
 fn realistic_r8_many_branches_cold_load_sqlite(_c: &mut Criterion) {}
 
 fn realistic_r9_subscribed_write_path(c: &mut Criterion) {
-    let profile: ProfileConfig = load_json("benchmarks/realistic/profiles/s.json");
+    let profile: ProfileConfig = load_json(profile_config_path());
     let scenario = load_r9_scenario(select_ci_path(
         "benchmarks/realistic/scenarios/r9_subscribed_write_path.json",
         "benchmarks/realistic/ci/scenarios/r9_subscribed_write_path.json",
@@ -2931,7 +2931,7 @@ fn realistic_r9_subscribed_write_path(c: &mut Criterion) {
 
 #[cfg(all(feature = "rocksdb", not(target_arch = "wasm32")))]
 fn realistic_r8_many_branches_rocksdb(c: &mut Criterion) {
-    let profile: ProfileConfig = load_json("benchmarks/realistic/profiles/s.json");
+    let profile: ProfileConfig = load_json(profile_config_path());
     let scenario = load_r8_scenario(select_ci_path(
         "benchmarks/realistic/scenarios/r8_many_branches.json",
         "benchmarks/realistic/ci/scenarios/r8_many_branches.json",
@@ -3064,7 +3064,7 @@ fn realistic_r8_many_branches_rocksdb(_c: &mut Criterion) {}
 
 #[cfg(all(feature = "sqlite", not(target_arch = "wasm32")))]
 fn realistic_r8_many_branches_sqlite(c: &mut Criterion) {
-    let profile: ProfileConfig = load_json("benchmarks/realistic/profiles/s.json");
+    let profile: ProfileConfig = load_json(profile_config_path());
     let scenario = load_r8_scenario(select_ci_path(
         "benchmarks/realistic/scenarios/r8_many_branches.json",
         "benchmarks/realistic/ci/scenarios/r8_many_branches.json",
@@ -3197,7 +3197,7 @@ fn realistic_r8_many_branches_sqlite(_c: &mut Criterion) {}
 
 #[cfg(all(feature = "rocksdb", not(target_arch = "wasm32")))]
 fn realistic_r9_subscribed_write_path_rocksdb(c: &mut Criterion) {
-    let profile: ProfileConfig = load_json("benchmarks/realistic/profiles/s.json");
+    let profile: ProfileConfig = load_json(profile_config_path());
     let scenario = load_r9_scenario(select_ci_path(
         "benchmarks/realistic/scenarios/r9_subscribed_write_path.json",
         "benchmarks/realistic/ci/scenarios/r9_subscribed_write_path.json",
@@ -3282,7 +3282,7 @@ fn realistic_r9_subscribed_write_path_rocksdb(_c: &mut Criterion) {}
 
 #[cfg(all(feature = "sqlite", not(target_arch = "wasm32")))]
 fn realistic_r9_subscribed_write_path_sqlite(c: &mut Criterion) {
-    let profile: ProfileConfig = load_json("benchmarks/realistic/profiles/s.json");
+    let profile: ProfileConfig = load_json(profile_config_path());
     let scenario = load_r9_scenario(select_ci_path(
         "benchmarks/realistic/scenarios/r9_subscribed_write_path.json",
         "benchmarks/realistic/ci/scenarios/r9_subscribed_write_path.json",
@@ -3737,6 +3737,48 @@ fn select_ci_path<'a>(default_path: &'a str, ci_path: &'a str) -> &'a str {
     } else {
         default_path
     }
+}
+
+fn r1_scenario_path() -> &'static str {
+    select_ci_path(
+        "benchmarks/realistic/scenarios/r1_crud_sustained.json",
+        "benchmarks/realistic/ci/scenarios/r1_crud_sustained.json",
+    )
+}
+
+fn r2_sustained_scenario_path() -> &'static str {
+    select_ci_path(
+        "benchmarks/realistic/scenarios/r2_reads_sustained.json",
+        "benchmarks/realistic/ci/scenarios/r2_reads_sustained.json",
+    )
+}
+
+fn r2_reads_with_churn_scenario_path() -> &'static str {
+    select_ci_path(
+        "benchmarks/realistic/scenarios/r2_reads_with_churn.json",
+        "benchmarks/realistic/ci/scenarios/r2_reads_with_churn.json",
+    )
+}
+
+fn r5_permission_recursive_scenario_path() -> &'static str {
+    select_ci_path(
+        "benchmarks/realistic/scenarios/r5_permission_recursive.json",
+        "benchmarks/realistic/ci/scenarios/r5_permission_recursive.json",
+    )
+}
+
+fn r7_hotspot_history_scenario_path() -> &'static str {
+    select_ci_path(
+        "benchmarks/realistic/scenarios/r7_hotspot_history.json",
+        "benchmarks/realistic/ci/scenarios/r7_hotspot_history.json",
+    )
+}
+
+fn profile_config_path() -> &'static str {
+    select_ci_path(
+        "benchmarks/realistic/profiles/s.json",
+        "benchmarks/realistic/ci/profiles/s.json",
+    )
 }
 
 fn configured_sample_size(default_size: usize) -> usize {


### PR DESCRIPTION
## What changed

This trims the benchmark workloads used only for CI when running the storage-backed native and Criterion suites.

It adds CI-specific scenario fixtures for the heavy `R1`, `R2`, `R2 with churn`, `R5`, and `R7` cases, and further reduces the existing CI fixtures for `W1`, `R4`, and `R9`.

It also updates the realistic Criterion bench so `JAZZ_REALISTIC_VARIANT=ci` uses the smaller CI profile as well as the CI scenario paths, instead of seeding the full default benchmark profile.

## Why this changed

After #489 landed on `main`, the benchmark workflow stayed green overall, but several RocksDB scenarios and a handful of SQLite scenarios still exceeded the 60-second per-benchmark timeout budget.

The main remaining issue was that Criterion was still loading the full default profile in CI, so setup cost dominated several storage-backed benchmarks even after introducing engine-specific lanes.

## Impact

This keeps the full benchmark definitions intact for non-CI runs while making the CI variant fit the existing timeout budget more reliably.

## Validation

- `node --test benchmarks/realistic/ci_benchmarks.test.mjs benchmarks/realistic/ci_scenarios.test.mjs`
- `cargo fmt --all`
- Local CI-variant timing spot checks:
  - `W1 RocksDB`: `35.4s`
  - `W1 SQLite`: `22.85s`
  - `R1 single-hop RocksDB`: `20.18s`
  - `R2 single-hop RocksDB`: `14.66s`
  - `R4 fanout RocksDB`: `26.72s`
  - `R2 single-hop SQLite`: `18.98s`
  - `R4 fanout SQLite`: `21.74s`
  - `R5 SQLite`: `28.07s`
  - `R9 SQLite`: `12.59s`