### PR TITLE
feat: log error/warning for missing migrations when connecting to server

### DIFF
--- a/crates/jazz-tools/src/client.rs
+++ b/crates/jazz-tools/src/client.rs
@@ -10,7 +10,9 @@ use crate::jazz_transport::ServerEvent;
 use crate::query_manager::manager::LocalUpdates;
 use crate::query_manager::query::Query;
 use crate::query_manager::session::Session;
-use crate::query_manager::types::{OrderedRowDelta, RowDescriptor, Schema, TableName, Value};
+use crate::query_manager::types::{
+    OrderedRowDelta, RowDescriptor, Schema, SchemaHash, TableName, Value,
+};
 use crate::runtime_core::ReadDurabilityOptions;
 use crate::schema_manager::{SchemaManager, rehydrate_schema_manager_from_catalogue};
 #[cfg(all(feature = "sqlite", not(feature = "rocksdb")))]
@@ -206,7 +208,7 @@ impl JazzClient {
             let conn_for_stream = conn.clone();
             let client_id_str = client_id.to_string();
             let runtime_for_stream = runtime.clone();
-            let stream_headers = conn.build_stream_headers();
+            let stream_headers = conn.build_stream_headers(SchemaHash::compute(&declared_schema));
             let server_id_for_stream = server_id;
             let mut initial_stream_ready_tx = initial_stream_ready_tx;
             let tracer_for_incoming = context.sync_tracer.clone();

--- a/crates/jazz-tools/src/routes.rs
+++ b/crates/jazz-tools/src/routes.rs
@@ -31,7 +31,7 @@ use crate::query_manager::types::{
 };
 use crate::schema_manager::{AppId, Lens, LensOp, LensTransform};
 use crate::server::{CatalogueAuthorityMode, ConnectionState, ServerState};
-use crate::sync_manager::ClientId;
+use crate::sync_manager::{ClientId, SyncPayload};
 
 /// Runs an async closure when this guard is dropped.
 ///
@@ -86,6 +86,8 @@ struct EventsParams {
     /// Client-provided ID for reconnect support.
     client_id: Option<String>,
 }
+
+const CLIENT_SCHEMA_HASH_HEADER: &str = "X-Jazz-Client-Schema-Hash";
 
 #[derive(Debug, Serialize)]
 struct SchemaHashesResponse {
@@ -333,6 +335,19 @@ async fn events_handler(
         })?,
         None => ClientId::new(),
     };
+    let client_schema_hash = match headers
+        .get(CLIENT_SCHEMA_HASH_HEADER)
+        .and_then(|value| value.to_str().ok())
+    {
+        Some(hash_text) => Some(parse_schema_hash_param(hash_text).map_err(|message| {
+            (
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse::bad_request(message)),
+            )
+                .into_response()
+        })?),
+        None => None,
+    };
 
     {
         let _span = tracing::debug_span!("events_handler", %client_id).entered();
@@ -419,6 +434,27 @@ async fn events_handler(
         }
         ClientSetup::Session(session) => {
             let _ = state.runtime.ensure_client_with_session(client_id, session);
+        }
+    }
+
+    if let Some(client_schema_hash) = client_schema_hash {
+        match state.runtime.with_schema_manager(|schema_manager| {
+            schema_manager.connection_schema_diagnostics(client_schema_hash)
+        }) {
+            Ok(diagnostics) if diagnostics.has_issues() => {
+                state.connection_event_hub.dispatch_payload(
+                    client_id,
+                    SyncPayload::ConnectionSchemaDiagnostics(diagnostics),
+                );
+            }
+            Ok(_) => {}
+            Err(err) => {
+                tracing::error!(
+                    %client_id,
+                    %client_schema_hash,
+                    "failed to compute connection schema diagnostics: {err}"
+                );
+            }
         }
     }
 
@@ -1649,10 +1685,12 @@ mod tests {
         ColumnType, SchemaBuilder, TableSchema, Value as QueryValue,
     };
     use crate::sync_manager::{
-        ClientId, InboxEntry, QueryId, QueryPropagation, Source, SyncPayload,
+        ClientId, ConnectionSchemaDiagnostics, InboxEntry, QueryId, QueryPropagation, Source,
+        SyncPayload,
     };
     use axum::body;
     use axum::routing::{get, post};
+    use futures::StreamExt;
     use serde_json::Value;
     use tower::ServiceExt;
 
@@ -1720,6 +1758,7 @@ mod tests {
 
     fn make_test_router(state: Arc<ServerState>) -> axum::Router {
         axum::Router::new()
+            .route("/events", get(events_handler))
             .route("/schema/:hash", get(schema_handler))
             .route("/schemas", get(schema_hashes_handler))
             .route("/admin/schemas", post(publish_schema_handler))
@@ -1761,6 +1800,29 @@ mod tests {
         path: String,
         admin_secret: Option<String>,
         body: Option<Value>,
+    }
+
+    async fn read_server_events(body: axum::body::Body, expected_count: usize) -> Vec<ServerEvent> {
+        let mut stream = body.into_data_stream();
+        let mut events = Vec::new();
+        let mut buffered = Vec::new();
+
+        while events.len() < expected_count {
+            if let Some((event, consumed)) = ServerEvent::decode_frame(&buffered) {
+                events.push(event);
+                buffered.drain(..consumed);
+                continue;
+            }
+
+            let next_chunk = tokio::time::timeout(Duration::from_millis(250), stream.next())
+                .await
+                .expect("timed out waiting for stream chunk")
+                .expect("stream ended before expected events")
+                .expect("stream chunk should decode");
+            buffered.extend_from_slice(&next_chunk);
+        }
+
+        events
     }
 
     #[tokio::test]
@@ -2972,5 +3034,51 @@ mod tests {
                     .map(|query| query.contains("\"name\""))
                     .unwrap_or(false)
         }));
+    }
+
+    #[tokio::test]
+    async fn events_handler_emits_connection_schema_diagnostics_for_client_schema() {
+        let schema = SchemaBuilder::new()
+            .table(
+                TableSchema::builder("users")
+                    .column("id", ColumnType::Uuid)
+                    .column("name", ColumnType::Text),
+            )
+            .build();
+        let current_hash = SchemaHash::compute(&schema);
+        let declared_hash = SchemaHash::from_bytes([9; 32]);
+        let app = make_test_router(make_state_with_schema(schema).await);
+
+        let response = app
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri("/events")
+                    .header("X-Jazz-Local-Mode", "anonymous")
+                    .header("X-Jazz-Local-Token", "alice")
+                    .header("X-Jazz-Client-Schema-Hash", declared_hash.to_string())
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .expect("events response");
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let events = read_server_events(response.into_body(), 2).await;
+        assert!(matches!(events[0], ServerEvent::Connected { .. }));
+
+        match &events[1] {
+            ServerEvent::SyncUpdate { payload, .. } => {
+                assert_eq!(
+                    payload.as_ref(),
+                    &SyncPayload::ConnectionSchemaDiagnostics(ConnectionSchemaDiagnostics {
+                        client_schema_hash: declared_hash,
+                        disconnected_permissions_schema_hash: Some(current_hash),
+                        unreachable_schema_hashes: vec![],
+                    })
+                );
+            }
+            other => panic!("expected SyncUpdate, got {}", other.variant_name()),
+        }
     }
 }

--- a/crates/jazz-tools/src/schema_manager/manager.rs
+++ b/crates/jazz-tools/src/schema_manager/manager.rs
@@ -7,7 +7,10 @@
 //! - Integrated QueryManager for query/insert/update/delete operations
 //! - Catalogue persistence for schema/lens discovery via sync
 
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet, VecDeque},
+    sync::Arc,
+};
 
 use blake3::Hasher;
 
@@ -23,7 +26,7 @@ use crate::query_manager::writes::{RowBranchDelete, RowBranchWrite};
 use crate::row_format::decode_row;
 use crate::schema_manager::rehydrate::latest_catalogue_content;
 use crate::storage::Storage;
-use crate::sync_manager::SyncManager;
+use crate::sync_manager::{ConnectionSchemaDiagnostics, SyncManager};
 use uuid::Uuid;
 
 use super::auto_lens::generate_lens;
@@ -541,6 +544,68 @@ impl SchemaManager {
                 parent_bundle_object_id: head.parent_bundle_object_id,
                 bundle_object_id: head.bundle_object_id,
             })
+    }
+
+    pub fn connection_schema_diagnostics(
+        &self,
+        client_schema_hash: SchemaHash,
+    ) -> ConnectionSchemaDiagnostics {
+        let active_permissions_hash = self
+            .current_permissions_head
+            .map(|head| head.schema_hash)
+            .or_else(|| self.has_current_schema().then_some(self.current_hash()));
+        let reachable_hashes = self.non_draft_reachable_hashes(client_schema_hash);
+        let disconnected_permissions_schema_hash = active_permissions_hash
+            .filter(|permissions_hash| !reachable_hashes.contains(permissions_hash));
+
+        let mut unreachable_schema_hashes: Vec<_> = self
+            .known_schema_hashes()
+            .into_iter()
+            .filter(|hash| *hash != client_schema_hash)
+            .filter(|hash| !reachable_hashes.contains(hash))
+            .filter(|hash| Some(*hash) != disconnected_permissions_schema_hash)
+            .collect();
+        unreachable_schema_hashes.sort_by(|left, right| left.as_bytes().cmp(right.as_bytes()));
+
+        ConnectionSchemaDiagnostics {
+            client_schema_hash,
+            disconnected_permissions_schema_hash,
+            unreachable_schema_hashes,
+        }
+    }
+
+    fn non_draft_reachable_hashes(&self, start_hash: SchemaHash) -> HashSet<SchemaHash> {
+        if !self.is_schema_known(&start_hash) {
+            return HashSet::new();
+        }
+
+        let mut reachable = HashSet::from([start_hash]);
+        let mut queue = VecDeque::from([start_hash]);
+
+        while let Some(current) = queue.pop_front() {
+            for (&(source_hash, target_hash), lens) in &self.context.lenses {
+                if lens.is_draft() {
+                    continue;
+                }
+
+                let next_hash = if source_hash == current {
+                    Some(target_hash)
+                } else if target_hash == current {
+                    Some(source_hash)
+                } else {
+                    None
+                };
+
+                if let Some(next_hash) = next_hash
+                    && self.is_schema_known(&next_hash)
+                    && reachable.insert(next_hash)
+                {
+                    queue.push_back(next_hash);
+                }
+            }
+        }
+
+        reachable
     }
 
     // =========================================================================
@@ -1959,6 +2024,84 @@ mod tests {
         // V2 has 3 columns (id, name, email)
         let v2_desc = manager.get_table_descriptor("users", &v2_hash).unwrap();
         assert_eq!(v2_desc.columns.len(), 3);
+    }
+
+    #[test]
+    fn connection_schema_diagnostics_treat_unknown_client_schema_as_disconnected() {
+        let schema = make_schema_v2();
+        let current_hash = SchemaHash::compute(&schema);
+        let manager =
+            SchemaManager::new(SyncManager::new(), schema, test_app_id(), "dev", "main").unwrap();
+
+        let diagnostics = manager.connection_schema_diagnostics(SchemaHash::from_bytes([7; 32]));
+
+        assert_eq!(
+            diagnostics.client_schema_hash,
+            SchemaHash::from_bytes([7; 32])
+        );
+        assert_eq!(
+            diagnostics.disconnected_permissions_schema_hash,
+            Some(current_hash)
+        );
+        assert!(diagnostics.unreachable_schema_hashes.is_empty());
+    }
+
+    #[test]
+    fn connection_schema_diagnostics_reports_other_unreachable_server_schemas() {
+        let v1 = make_schema_v1();
+        let v2 = make_schema_v2();
+        let v3 = SchemaBuilder::new()
+            .table(
+                TableSchema::builder("users")
+                    .column("id", ColumnType::Uuid)
+                    .column("name", ColumnType::Text)
+                    .nullable_column("email", ColumnType::Text)
+                    .nullable_column("nickname", ColumnType::Text),
+            )
+            .build();
+        let v1_hash = SchemaHash::compute(&v1);
+        let v3_hash = SchemaHash::compute(&v3);
+
+        let mut manager =
+            SchemaManager::new(SyncManager::new(), v2, test_app_id(), "dev", "main").unwrap();
+        manager.add_live_schema(v1).unwrap();
+        manager.add_known_schema(v3);
+
+        let diagnostics = manager.connection_schema_diagnostics(v1_hash);
+
+        assert_eq!(diagnostics.disconnected_permissions_schema_hash, None);
+        assert_eq!(diagnostics.unreachable_schema_hashes, vec![v3_hash]);
+    }
+
+    #[test]
+    fn connection_schema_diagnostics_ignore_draft_lenses() {
+        let v1 = make_schema_v1();
+        let v2 = SchemaBuilder::new()
+            .table(
+                TableSchema::builder("users")
+                    .column("id", ColumnType::Uuid)
+                    .column("name", ColumnType::Text)
+                    .column("org_id", ColumnType::Uuid),
+            )
+            .build();
+        let v1_hash = SchemaHash::compute(&v1);
+        let v2_hash = SchemaHash::compute(&v2);
+        let draft_lens = generate_lens(&v1, &v2);
+
+        assert!(draft_lens.is_draft());
+
+        let mut manager =
+            SchemaManager::new(SyncManager::new(), v2, test_app_id(), "dev", "main").unwrap();
+        manager.add_known_schema(v1);
+        manager.context.register_lens(draft_lens);
+
+        let diagnostics = manager.connection_schema_diagnostics(v1_hash);
+
+        assert_eq!(
+            diagnostics.disconnected_permissions_schema_hash,
+            Some(v2_hash)
+        );
+        assert!(diagnostics.unreachable_schema_hashes.is_empty());
     }
 
     #[test]

--- a/crates/jazz-tools/src/sync_manager/inbox.rs
+++ b/crates/jazz-tools/src/sync_manager/inbox.rs
@@ -262,6 +262,9 @@ impl SyncManager {
                     }
                 }
             }
+            SyncPayload::ConnectionSchemaDiagnostics(diagnostics) => {
+                super::log_connection_schema_diagnostics(&diagnostics, Some("server"));
+            }
             SyncPayload::Error(err) => {
                 // Log or handle server error
                 eprintln!("Error from server {:?}: {:?}", server_id, err);
@@ -549,6 +552,12 @@ impl SyncManager {
                     %client_id,
                     query_id = warning.query_id.0,
                     "client attempted to send SchemaWarning payload; ignoring"
+                );
+            }
+            SyncPayload::ConnectionSchemaDiagnostics(_) => {
+                tracing::warn!(
+                    %client_id,
+                    "client attempted to send ConnectionSchemaDiagnostics payload; ignoring"
                 );
             }
             // Clients shouldn't send these

--- a/crates/jazz-tools/src/sync_manager/mod.rs
+++ b/crates/jazz-tools/src/sync_manager/mod.rs
@@ -136,6 +136,44 @@ pub(crate) fn log_schema_warning(
     );
 }
 
+pub(crate) fn log_connection_schema_diagnostics(
+    diagnostics: &ConnectionSchemaDiagnostics,
+    origin: Option<&str>,
+) {
+    let client_hash = short_hash(&diagnostics.client_schema_hash);
+
+    if let Some(permissions_hash) = diagnostics.disconnected_permissions_schema_hash {
+        let permissions_hash = short_hash(&permissions_hash);
+        tracing::error!(
+            origin = origin,
+            client_schema_hash = %client_hash,
+            permissions_schema_hash = %permissions_hash,
+            "Your declared schema {} is disconnected from the schema used to enforce permissions: {}. Reads and writes may fail until you add a migration. To recover, run `npx jazz-tools@alpha migrations create --fromHash {} --toHash {}`.",
+            client_hash,
+            permissions_hash,
+            permissions_hash,
+            client_hash,
+        );
+    }
+
+    if !diagnostics.unreachable_schema_hashes.is_empty() {
+        let unreachable_hashes: Vec<String> = diagnostics
+            .unreachable_schema_hashes
+            .iter()
+            .map(short_hash)
+            .collect();
+        tracing::warn!(
+            origin = origin,
+            client_schema_hash = %client_hash,
+            unreachable_schema_hashes = ?unreachable_hashes,
+            "Server knows schema branches that are unreachable from your declared schema {}: {}. Some data may be missing from reads until you add migrations. To recover, run `npx jazz-tools@alpha migrations create --fromHash <unreachableHash> --toHash {}` for each listed schema.",
+            client_hash,
+            unreachable_hashes.join(", "),
+            client_hash,
+        );
+    }
+}
+
 impl SyncManager {
     pub fn new() -> Self {
         Self {

--- a/crates/jazz-tools/src/sync_manager/types.rs
+++ b/crates/jazz-tools/src/sync_manager/types.rs
@@ -299,6 +299,9 @@ pub enum SyncPayload {
     /// Warning that rows exist on an older schema branch but are currently unreachable.
     SchemaWarning(SchemaWarning),
 
+    /// Connection-time schema diagnostics for observability.
+    ConnectionSchemaDiagnostics(ConnectionSchemaDiagnostics),
+
     /// Error response.
     Error(SyncError),
 }
@@ -313,6 +316,23 @@ pub struct SchemaWarning {
     pub row_count: usize,
     pub from_hash: SchemaHash,
     pub to_hash: SchemaHash,
+}
+
+/// Warning sent to the client when its schema is either disconnected from the permissions schema
+/// or not connected to other schemas known to the server.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConnectionSchemaDiagnostics {
+    pub client_schema_hash: SchemaHash,
+    pub disconnected_permissions_schema_hash: Option<SchemaHash>,
+    pub unreachable_schema_hashes: Vec<SchemaHash>,
+}
+
+impl ConnectionSchemaDiagnostics {
+    pub fn has_issues(&self) -> bool {
+        self.disconnected_permissions_schema_hash.is_some()
+            || !self.unreachable_schema_hashes.is_empty()
+    }
 }
 
 /// Sessions contain claims as a JSON object.
@@ -443,6 +463,7 @@ impl SyncPayload {
             SyncPayload::QueryUnsubscription { .. } => "QueryUnsubscription",
             SyncPayload::QuerySettled { .. } => "QuerySettled",
             SyncPayload::SchemaWarning(_) => "SchemaWarning",
+            SyncPayload::ConnectionSchemaDiagnostics(_) => "ConnectionSchemaDiagnostics",
             SyncPayload::Error(_) => "Error",
         }
     }

--- a/crates/jazz-tools/src/sync_tracer.rs
+++ b/crates/jazz-tools/src/sync_tracer.rs
@@ -911,6 +911,9 @@ impl<'a> Normalizer<'a> {
             SyncPayload::SchemaWarning(w) => {
                 format!("query:{} table:{}", w.query_id.0, w.table_name)
             }
+            SyncPayload::ConnectionSchemaDiagnostics(diagnostics) => {
+                format!("client_schema:{}", diagnostics.client_schema_hash.short())
+            }
             SyncPayload::Error(e) => {
                 format!("{:?}", e)
             }
@@ -1011,6 +1014,9 @@ fn format_payload_details(payload: &SyncPayload, names: &Names<'_>) -> String {
         }
         SyncPayload::SchemaWarning(w) => {
             format!("query:{} table:{}", w.query_id.0, w.table_name)
+        }
+        SyncPayload::ConnectionSchemaDiagnostics(diagnostics) => {
+            format!("client_schema:{}", diagnostics.client_schema_hash.short())
         }
         SyncPayload::Error(e) => {
             format!("{:?}", e)

--- a/crates/jazz-tools/src/transport.rs
+++ b/crates/jazz-tools/src/transport.rs
@@ -2,6 +2,7 @@
 
 use crate::jazz_transport::SyncBatchRequest;
 use crate::query_manager::session::Session;
+use crate::query_manager::types::SchemaHash;
 use crate::sync_manager::{ClientId, SyncPayload};
 use base64::Engine;
 use reqwest::Client;
@@ -117,9 +118,12 @@ impl ServerConnection {
     /// Build auth headers for the binary streaming connection.
     ///
     /// Same auth as `build_headers` but without Content-Type.
-    pub fn build_stream_headers(&self) -> HeaderMap {
+    pub fn build_stream_headers(&self, schema_hash: SchemaHash) -> HeaderMap {
         let mut headers = self.build_headers(None);
         headers.remove(CONTENT_TYPE);
+        if let Ok(schema_hash) = HeaderValue::from_str(&schema_hash.to_string()) {
+            headers.insert("X-Jazz-Client-Schema-Hash", schema_hash);
+        }
         headers
     }
 

--- a/packages/jazz-tools/src/runtime/client.ts
+++ b/packages/jazz-tools/src/runtime/client.ts
@@ -642,6 +642,7 @@ export class JazzClient {
     this.streamController = createRuntimeSyncStreamController({
       getRuntime: () => this.runtime,
       getAuth: () => this.getSyncAuth(),
+      getSchemaHash: () => this.runtime.getSchemaHash(),
       getClientId: () => this.serverClientId,
       setClientId: (clientId) => {
         this.serverClientId = clientId;

--- a/packages/jazz-tools/src/runtime/sync-transport.test.ts
+++ b/packages/jazz-tools/src/runtime/sync-transport.test.ts
@@ -468,6 +468,7 @@ describe("sync-transport", () => {
 
     const controller = new SyncStreamController({
       getAuth: () => ({ backendSecret: "backend-secret" }),
+      getSchemaHash: () => "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
       getClientId: () => "initial-client-id",
       setClientId: vi.fn(),
       onConnected: vi.fn(),
@@ -481,6 +482,8 @@ describe("sync-transport", () => {
     expect(fetchMock.mock.calls[0]![1].headers).toMatchObject({
       Accept: "application/octet-stream",
       "X-Jazz-Backend-Secret": "backend-secret",
+      "X-Jazz-Client-Schema-Hash":
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
     });
     expect(fetchMock.mock.calls[0]![1].headers).not.toHaveProperty("Authorization");
 
@@ -561,50 +564,6 @@ describe("sync-transport", () => {
 
     expect(errorSpy).toHaveBeenCalledWith("[client] Stream callback error:", expect.any(Error));
     expect(errorSpy).not.toHaveBeenCalledWith("[client] Stream parse error:", expect.any(Error));
-  });
-
-  it("logs schema warnings that arrive over the stream", async () => {
-    const response = streamResponse([
-      {
-        type: "SyncUpdate",
-        payload: {
-          SchemaWarning: {
-            queryId: 7,
-            tableName: "todos",
-            rowCount: 3,
-            fromHash: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-            toHash: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-          },
-        },
-      },
-    ]);
-    const reader = response.body!.getReader();
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const onSyncMessage = vi.fn();
-
-    await readBinaryFrames(
-      reader,
-      {
-        onSyncMessage,
-      },
-      "[client] ",
-    );
-
-    expect(warnSpy).toHaveBeenCalledWith(
-      "[client] Detected 3 rows of todos with differing schema versions. To ensure data visibility and forward/backward compatibility, run `npx jazz-tools@alpha schema export --schema-hash aaaaaaaaaaaa`. Then generate a migration with `npx jazz-tools@alpha migrations create --fromHash aaaaaaaaaaaa --toHash <targetHash>`",
-    );
-    expect(onSyncMessage).toHaveBeenCalledWith(
-      JSON.stringify({
-        SchemaWarning: {
-          queryId: 7,
-          tableName: "todos",
-          rowCount: 3,
-          fromHash: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-          toHash: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-        },
-      }),
-      null,
-    );
   });
 
   it("runtime-bound stream controller maps stream events to runtime hooks", async () => {

--- a/packages/jazz-tools/src/runtime/sync-transport.ts
+++ b/packages/jazz-tools/src/runtime/sync-transport.ts
@@ -49,6 +49,7 @@ export interface StreamCallbacks {
 export interface SyncStreamControllerOptions {
   logPrefix?: string;
   getAuth(): Pick<SyncAuth, "jwtToken" | "localAuthMode" | "localAuthToken" | "backendSecret">;
+  getSchemaHash?(): string | undefined;
   getClientId(): string;
   setClientId(clientId: string): void;
   onConnected(catalogueStateHash?: string | null, nextSyncSeq?: number | null): void;
@@ -70,6 +71,7 @@ export interface RuntimeSyncStreamControllerOptions {
   logPrefix?: string;
   getRuntime(): RuntimeSyncTarget | null | undefined;
   getAuth(): Pick<SyncAuth, "jwtToken" | "localAuthMode" | "localAuthToken" | "backendSecret">;
+  getSchemaHash?(): string | undefined;
   getClientId(): string;
   setClientId(clientId: string): void;
   onConnected?(catalogueStateHash?: string | null, nextSyncSeq?: number | null): void;
@@ -125,26 +127,6 @@ export function isExpectedFetchAbortError(error: unknown, signal?: AbortSignal):
   }
 
   return false;
-}
-
-function logSchemaWarningPayload(payload: any, logPrefix = ""): void {
-  const warning = payload?.SchemaWarning;
-  if (!warning) return;
-
-  const rowCount = warning.rowCount ?? warning.row_count ?? 0;
-  const tableName = warning.tableName ?? warning.table_name ?? "unknown";
-  const fromHash = warning.fromHash ?? warning.from_hash ?? "unknown";
-  const shortHash = (hash: string) =>
-    typeof hash === "string" && /^[0-9a-f]{12,}$/i.test(hash) ? hash.slice(0, 12) : hash;
-
-  const sourceHash = shortHash(fromHash);
-  console.warn(
-    `${logPrefix}Detected ${rowCount} rows of ${tableName} with differing schema versions. ` +
-      `To ensure data visibility and forward/backward compatibility, run ` +
-      `\`npx jazz-tools@alpha schema export --schema-hash ${sourceHash}\`. ` +
-      `Then generate a migration with ` +
-      `\`npx jazz-tools@alpha migrations create --fromHash ${sourceHash} --toHash <targetHash>\``,
-  );
 }
 
 export async function readSyncAuthError(response: Response): Promise<SyncAuthError | null> {
@@ -310,6 +292,10 @@ export class SyncStreamController {
       Accept: "application/octet-stream",
     };
     applySyncAuthHeaders(headers, this.options.getAuth());
+    const schemaHash = this.options.getSchemaHash?.();
+    if (schemaHash) {
+      headers["X-Jazz-Client-Schema-Hash"] = schemaHash;
+    }
 
     const abortController = new AbortController();
     this.streamAbortController = abortController;
@@ -381,6 +367,7 @@ export function createRuntimeSyncStreamController(
   return new SyncStreamController({
     logPrefix: options.logPrefix,
     getAuth: options.getAuth,
+    getSchemaHash: options.getSchemaHash,
     getClientId: options.getClientId,
     setClientId: options.setClientId,
     onConnected: (catalogueStateHash, nextSyncSeq) => {
@@ -843,7 +830,6 @@ export async function readBinaryFrames(
             event.next_sync_seq ?? null,
           );
         } else if (event.type === "SyncUpdate") {
-          logSchemaWarningPayload(event.payload, logPrefix);
           callbacks.onSyncMessage(JSON.stringify(event.payload), event.seq ?? null);
         }
       } catch (error) {

--- a/packages/jazz-tools/src/worker/jazz-worker.ts
+++ b/packages/jazz-tools/src/worker/jazz-worker.ts
@@ -494,6 +494,10 @@ async function connectStream(): Promise<void> {
     Accept: "application/octet-stream",
   };
   applyUserAuthHeaders(headers, { jwtToken, localAuthMode, localAuthToken });
+  const schemaHash = runtime?.getSchemaHash?.();
+  if (schemaHash) {
+    headers["X-Jazz-Client-Schema-Hash"] = schemaHash;
+  }
 
   streamAbortController = new AbortController();
   let streamConnectTimedOut = false;


### PR DESCRIPTION
## Description

When a client connects to a sync server, the client's schema may not be able to interoperate with the schema currently used for permissions enforcement by the server, or that server may know schemas (and rows) that are unreachable from the client's schema. Today that state is mostly invisible until reads quietly return less data than expected or writes fail later under policy evaluation. The result is user confusion: the connection succeeds, but the app behaves as if data is missing or permissions are broken without a clear explanation.

This PR adds a connection-time log making this situation clearer:
- if the client's schema is disconnected from the permissions schema, the client logs an error, because reads and writes are effectively blocked
- if the server knows additional unreachable schemas, the client logs a warning so developers understand why some historical data may stay invisible until migrations are published.

## Validation

### Error

<img width="1728" height="626" alt="error" src="https://github.com/user-attachments/assets/ebb94354-4e7d-4b5d-80ca-edeb6f1d1e17" />

### Warning

<img width="1728" height="626" alt="warning" src="https://github.com/user-attachments/assets/686c42b1-cca5-4875-b56c-06eb51ebb175" />
