### PR TITLE
Fix enum literals in nested policies

### DIFF
--- a/.changeset/fix-nested-policy-enum-literals.md
+++ b/.changeset/fix-nested-policy-enum-literals.md
@@ -1,0 +1,7 @@
+---
+"jazz-tools": patch
+---
+
+Fix enum literals in nested policies
+
+Nested relation-backed permission filters now serialize enum literals as tagged runtime values instead of raw strings, so publishing permissions and loading them into `createJazzContext(...)` works for cases like `grant_role: "viewer"`.

--- a/packages/jazz-tools/src/backend/create-jazz-context.test.ts
+++ b/packages/jazz-tools/src/backend/create-jazz-context.test.ts
@@ -126,6 +126,52 @@ const TODO_PERMISSIONS: CompiledPermissions = {
     select: { using: { type: "True" } },
   },
 };
+const RELATION_LITERAL_PERMISSIONS: CompiledPermissions = {
+  resources: {
+    select: {
+      using: {
+        type: "ExistsRel",
+        rel: {
+          Filter: {
+            input: {
+              TableScan: {
+                table: "resource_access_edges",
+              },
+            },
+            predicate: {
+              And: [
+                {
+                  Cmp: {
+                    left: {
+                      scope: "resource_access_edges",
+                      column: "kind",
+                    },
+                    op: "Eq",
+                    right: {
+                      Literal: "individual",
+                    },
+                  },
+                },
+                {
+                  Cmp: {
+                    left: {
+                      scope: "resource_access_edges",
+                      column: "grant_role",
+                    },
+                    op: "Eq",
+                    right: {
+                      Literal: "viewer",
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        },
+      },
+    },
+  },
+};
 
 function makeJwt(payload: Record<string, unknown>): string {
   const encode = (value: unknown) =>
@@ -278,6 +324,86 @@ describe("backend/create-jazz-context", () => {
         todos: {
           columns: [],
           policies: TODO_PERMISSIONS.todos as any,
+        },
+      }),
+      "server-app",
+      "dev",
+      "main",
+      "/tmp/jazz.db",
+      "edge",
+    );
+  });
+
+  it("BC-U04b: normalizes relation literals before serializing runtime schema JSON", () => {
+    const context = createJazzContext({
+      appId: "server-app",
+      app: {
+        wasmSchema: {
+          resources: {
+            columns: [],
+          },
+        },
+      },
+      permissions: RELATION_LITERAL_PERMISSIONS,
+      driver: { type: "persistent", dataPath: "/tmp/jazz.db" },
+    });
+
+    context.db();
+
+    expect(mocks.runtimeCtor).toHaveBeenCalledWith(
+      serializeRuntimeSchema({
+        resources: {
+          columns: [],
+          policies: {
+            select: {
+              using: {
+                type: "ExistsRel",
+                rel: {
+                  Filter: {
+                    input: {
+                      TableScan: {
+                        table: "resource_access_edges",
+                      },
+                    },
+                    predicate: {
+                      And: [
+                        {
+                          Cmp: {
+                            left: {
+                              scope: "resource_access_edges",
+                              column: "kind",
+                            },
+                            op: "Eq",
+                            right: {
+                              Literal: {
+                                type: "Text",
+                                value: "individual",
+                              },
+                            },
+                          },
+                        },
+                        {
+                          Cmp: {
+                            left: {
+                              scope: "resource_access_edges",
+                              column: "grant_role",
+                            },
+                            op: "Eq",
+                            right: {
+                              Literal: {
+                                type: "Text",
+                                value: "viewer",
+                              },
+                            },
+                          },
+                        },
+                      ],
+                    },
+                  },
+                },
+              },
+            },
+          },
         },
       }),
       "server-app",

--- a/packages/jazz-tools/src/cli.test.ts
+++ b/packages/jazz-tools/src/cli.test.ts
@@ -129,25 +129,6 @@ export const app: s.App<AppSchema> = s.defineApp(schema);
 `;
 }
 
-function rootSchemaWithEnumResourceAccess(indexImportPath: string = indexPath): string {
-  return `
-import { schema as s } from ${JSON.stringify(indexImportPath)};
-
-const Role = s.enum("viewer", "editor", "manager");
-
-const schema = {
-  resources: s.table({}),
-  resource_access_edges: s.table({
-    resource: s.ref("resources"),
-    grant_role: Role,
-  }),
-};
-
-type AppSchema = s.Schema<typeof schema>;
-export const app: s.App<AppSchema> = s.defineApp(schema);
-`;
-}
-
 function rootSchemaWithTodoNotes(indexImportPath: string = indexPath): string {
   return `
 import { schema as s } from ${JSON.stringify(indexImportPath)};
@@ -206,27 +187,6 @@ import { app } from ${JSON.stringify(appImportPath)};
 
 export default s.definePermissions(app, ({ policy }) => [
   policy.todos.allowRead.where({ done: true }),
-]);
-`;
-}
-
-function rootRelationEnumLiteralPermissionsSchema(
-  appImportPath: string = "./schema.ts",
-  importPath: string = indexPath,
-): string {
-  return `
-import { schema as s } from ${JSON.stringify(importPath)};
-import { app } from ${JSON.stringify(appImportPath)};
-
-export default s.definePermissions(app, ({ policy }) => [
-  policy.resources.allowRead.where((resource) =>
-    policy.exists(
-      policy.resource_access_edges.where({
-        resource: resource.id,
-        grant_role: "viewer",
-      }),
-    ),
-  ),
 ]);
 `;
 }
@@ -1377,123 +1337,6 @@ describe("cli permissions", () => {
             value: {
               type: "Boolean",
               value: true,
-            },
-          },
-        });
-        return new Response(
-          JSON.stringify({
-            head: {
-              schemaHash,
-              version: 1,
-              parentBundleObjectId: null,
-              bundleObjectId: "99999999-9999-9999-9999-999999999999",
-            },
-          }),
-          { status: 201 },
-        );
-      }
-
-      throw new Error(`Unexpected fetch: ${input}`);
-    });
-    vi.stubGlobal("fetch", fetchMock);
-
-    await pushPermissions({
-      serverUrl: "http://localhost:1625",
-      adminSecret: "admin-secret",
-      schemaDir: root,
-    });
-
-    expect(fetchMock).toHaveBeenCalled();
-  });
-
-  it("publishes nested relation literals using tagged wire values", async () => {
-    const { root } = await createWorkspace();
-    await writeFile(join(root, "schema.ts"), rootSchemaWithEnumResourceAccess());
-    await writeFile(join(root, "permissions.ts"), rootRelationEnumLiteralPermissionsSchema());
-
-    const schemaHash = "cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd";
-    const fetchMock = vi.fn(async (input: string, init?: RequestInit) => {
-      if (input.endsWith("/schemas")) {
-        return new Response(JSON.stringify({ hashes: [schemaHash] }), { status: 200 });
-      }
-
-      if (input.endsWith(`/schema/${schemaHash}`)) {
-        return new Response(
-          JSON.stringify({
-            resources: {
-              columns: [],
-            },
-            resource_access_edges: {
-              columns: [
-                {
-                  name: "resource",
-                  column_type: { type: "Uuid" },
-                  nullable: false,
-                  references: "resources",
-                },
-                {
-                  name: "grant_role",
-                  column_type: {
-                    type: "Enum",
-                    variants: ["editor", "manager", "viewer"],
-                  },
-                  nullable: false,
-                },
-              ],
-            },
-          }),
-          { status: 200 },
-        );
-      }
-
-      if (input.endsWith("/admin/permissions/head")) {
-        return new Response(JSON.stringify({ head: null }), { status: 200 });
-      }
-
-      if (input.endsWith("/admin/permissions")) {
-        const body = JSON.parse(String(init?.body));
-        expect(body.permissions.resources.select.using).toEqual({
-          type: "ExistsRel",
-          rel: {
-            Filter: {
-              input: {
-                TableScan: {
-                  table: "resource_access_edges",
-                },
-              },
-              predicate: {
-                And: [
-                  {
-                    Cmp: {
-                      left: {
-                        scope: "resource_access_edges",
-                        column: "resource",
-                      },
-                      op: "Eq",
-                      right: {
-                        OuterColumn: {
-                          column: "id",
-                        },
-                      },
-                    },
-                  },
-                  {
-                    Cmp: {
-                      left: {
-                        scope: "resource_access_edges",
-                        column: "grant_role",
-                      },
-                      op: "Eq",
-                      right: {
-                        Literal: {
-                          type: "Text",
-                          value: "viewer",
-                        },
-                      },
-                    },
-                  },
-                ],
-              },
             },
           },
         });

--- a/packages/jazz-tools/src/cli.test.ts
+++ b/packages/jazz-tools/src/cli.test.ts
@@ -129,6 +129,25 @@ export const app: s.App<AppSchema> = s.defineApp(schema);
 `;
 }
 
+function rootSchemaWithEnumResourceAccess(indexImportPath: string = indexPath): string {
+  return `
+import { schema as s } from ${JSON.stringify(indexImportPath)};
+
+const Role = s.enum("viewer", "editor", "manager");
+
+const schema = {
+  resources: s.table({}),
+  resource_access_edges: s.table({
+    resource: s.ref("resources"),
+    grant_role: Role,
+  }),
+};
+
+type AppSchema = s.Schema<typeof schema>;
+export const app: s.App<AppSchema> = s.defineApp(schema);
+`;
+}
+
 function rootSchemaWithTodoNotes(indexImportPath: string = indexPath): string {
   return `
 import { schema as s } from ${JSON.stringify(indexImportPath)};
@@ -187,6 +206,27 @@ import { app } from ${JSON.stringify(appImportPath)};
 
 export default s.definePermissions(app, ({ policy }) => [
   policy.todos.allowRead.where({ done: true }),
+]);
+`;
+}
+
+function rootRelationEnumLiteralPermissionsSchema(
+  appImportPath: string = "./schema.ts",
+  importPath: string = indexPath,
+): string {
+  return `
+import { schema as s } from ${JSON.stringify(importPath)};
+import { app } from ${JSON.stringify(appImportPath)};
+
+export default s.definePermissions(app, ({ policy }) => [
+  policy.resources.allowRead.where((resource) =>
+    policy.exists(
+      policy.resource_access_edges.where({
+        resource: resource.id,
+        grant_role: "viewer",
+      }),
+    ),
+  ),
 ]);
 `;
 }
@@ -1337,6 +1377,123 @@ describe("cli permissions", () => {
             value: {
               type: "Boolean",
               value: true,
+            },
+          },
+        });
+        return new Response(
+          JSON.stringify({
+            head: {
+              schemaHash,
+              version: 1,
+              parentBundleObjectId: null,
+              bundleObjectId: "99999999-9999-9999-9999-999999999999",
+            },
+          }),
+          { status: 201 },
+        );
+      }
+
+      throw new Error(`Unexpected fetch: ${input}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await pushPermissions({
+      serverUrl: "http://localhost:1625",
+      adminSecret: "admin-secret",
+      schemaDir: root,
+    });
+
+    expect(fetchMock).toHaveBeenCalled();
+  });
+
+  it("publishes nested relation literals using tagged wire values", async () => {
+    const { root } = await createWorkspace();
+    await writeFile(join(root, "schema.ts"), rootSchemaWithEnumResourceAccess());
+    await writeFile(join(root, "permissions.ts"), rootRelationEnumLiteralPermissionsSchema());
+
+    const schemaHash = "cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd";
+    const fetchMock = vi.fn(async (input: string, init?: RequestInit) => {
+      if (input.endsWith("/schemas")) {
+        return new Response(JSON.stringify({ hashes: [schemaHash] }), { status: 200 });
+      }
+
+      if (input.endsWith(`/schema/${schemaHash}`)) {
+        return new Response(
+          JSON.stringify({
+            resources: {
+              columns: [],
+            },
+            resource_access_edges: {
+              columns: [
+                {
+                  name: "resource",
+                  column_type: { type: "Uuid" },
+                  nullable: false,
+                  references: "resources",
+                },
+                {
+                  name: "grant_role",
+                  column_type: {
+                    type: "Enum",
+                    variants: ["editor", "manager", "viewer"],
+                  },
+                  nullable: false,
+                },
+              ],
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (input.endsWith("/admin/permissions/head")) {
+        return new Response(JSON.stringify({ head: null }), { status: 200 });
+      }
+
+      if (input.endsWith("/admin/permissions")) {
+        const body = JSON.parse(String(init?.body));
+        expect(body.permissions.resources.select.using).toEqual({
+          type: "ExistsRel",
+          rel: {
+            Filter: {
+              input: {
+                TableScan: {
+                  table: "resource_access_edges",
+                },
+              },
+              predicate: {
+                And: [
+                  {
+                    Cmp: {
+                      left: {
+                        scope: "resource_access_edges",
+                        column: "resource",
+                      },
+                      op: "Eq",
+                      right: {
+                        OuterColumn: {
+                          column: "id",
+                        },
+                      },
+                    },
+                  },
+                  {
+                    Cmp: {
+                      left: {
+                        scope: "resource_access_edges",
+                        column: "grant_role",
+                      },
+                      op: "Eq",
+                      right: {
+                        Literal: {
+                          type: "Text",
+                          value: "viewer",
+                        },
+                      },
+                    },
+                  },
+                ],
+              },
             },
           },
         });

--- a/packages/jazz-tools/src/runtime/schema-fetch.test.ts
+++ b/packages/jazz-tools/src/runtime/schema-fetch.test.ts
@@ -3,7 +3,6 @@ import {
   fetchSchemaHashes,
   fetchStoredWasmSchema,
   publishStoredPermissions,
-  publishStoredMigration,
 } from "./schema-fetch.js";
 import { fetchServerSubscriptions } from "./introspection-fetch.js";
 

--- a/packages/jazz-tools/src/runtime/schema-fetch.test.ts
+++ b/packages/jazz-tools/src/runtime/schema-fetch.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   fetchSchemaHashes,
   fetchStoredWasmSchema,
+  publishStoredPermissions,
   publishStoredMigration,
 } from "./schema-fetch.js";
 import { fetchServerSubscriptions } from "./introspection-fetch.js";
@@ -105,6 +106,141 @@ describe("schema-fetch", () => {
     expect(fetchMock.mock.calls[0]![0]).toBe(
       "http://localhost:1625/schema/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
     );
+  });
+
+  it("publishes nested relation literals as tagged wire values", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 201,
+      statusText: "Created",
+      json: async () => ({
+        head: {
+          schemaHash: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          version: 1,
+          parentBundleObjectId: null,
+          bundleObjectId: "99999999-9999-9999-9999-999999999999",
+        },
+      }),
+    });
+    (globalThis as { fetch: typeof fetch }).fetch = fetchMock as unknown as typeof fetch;
+
+    await publishStoredPermissions("http://localhost:1625/", {
+      adminSecret: "admin-secret",
+      schemaHash: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      permissions: {
+        resources: {
+          select: {
+            using: {
+              type: "ExistsRel",
+              rel: {
+                Filter: {
+                  input: {
+                    TableScan: {
+                      table: "resource_access_edges",
+                    },
+                  },
+                  predicate: {
+                    And: [
+                      {
+                        Cmp: {
+                          left: {
+                            scope: "resource_access_edges",
+                            column: "resource",
+                          },
+                          op: "Eq",
+                          right: {
+                            OuterColumn: {
+                              column: "id",
+                            },
+                          },
+                        },
+                      },
+                      {
+                        Cmp: {
+                          left: {
+                            scope: "resource_access_edges",
+                            column: "grant_role",
+                          },
+                          op: "Eq",
+                          right: {
+                            Literal: "viewer",
+                          },
+                        },
+                      },
+                    ],
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0]![0]).toBe("http://localhost:1625/admin/permissions");
+    expect(fetchMock.mock.calls[0]![1]).toMatchObject({
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Jazz-Admin-Secret": "admin-secret",
+      },
+    });
+    expect(JSON.parse(String(fetchMock.mock.calls[0]![1]?.body))).toEqual({
+      schemaHash: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      expectedParentBundleObjectId: null,
+      permissions: {
+        resources: {
+          select: {
+            using: {
+              type: "ExistsRel",
+              rel: {
+                Filter: {
+                  input: {
+                    TableScan: {
+                      table: "resource_access_edges",
+                    },
+                  },
+                  predicate: {
+                    And: [
+                      {
+                        Cmp: {
+                          left: {
+                            scope: "resource_access_edges",
+                            column: "resource",
+                          },
+                          op: "Eq",
+                          right: {
+                            OuterColumn: {
+                              column: "id",
+                            },
+                          },
+                        },
+                      },
+                      {
+                        Cmp: {
+                          left: {
+                            scope: "resource_access_edges",
+                            column: "grant_role",
+                          },
+                          op: "Eq",
+                          right: {
+                            Literal: {
+                              type: "Text",
+                              value: "viewer",
+                            },
+                          },
+                        },
+                      },
+                    ],
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
   });
 
   it("fetches grouped server subscriptions with admin secret and app id", async () => {

--- a/packages/jazz-tools/src/schema-permissions.test.ts
+++ b/packages/jazz-tools/src/schema-permissions.test.ts
@@ -42,4 +42,109 @@ describe("normalizePermissionsForWasm", () => {
       },
     });
   });
+
+  it("encodes nested relation literals inside ExistsRel filters", () => {
+    const permissions: CompiledPermissionsMap = {
+      resources: {
+        select: {
+          using: {
+            type: "ExistsRel",
+            rel: {
+              Filter: {
+                input: {
+                  TableScan: {
+                    table: "resource_access_edges",
+                  },
+                },
+                predicate: {
+                  And: [
+                    {
+                      Cmp: {
+                        left: {
+                          scope: "resource_access_edges",
+                          column: "kind",
+                        },
+                        op: "Eq",
+                        right: {
+                          Literal: "individual",
+                        },
+                      },
+                    },
+                    {
+                      Cmp: {
+                        left: {
+                          scope: "resource_access_edges",
+                          column: "grant_role",
+                        },
+                        op: "Eq",
+                        right: {
+                          Literal: "viewer",
+                        },
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    expect(normalizePermissionsForWasm(permissions)).toEqual({
+      resources: {
+        select: {
+          using: {
+            type: "ExistsRel",
+            rel: {
+              Filter: {
+                input: {
+                  TableScan: {
+                    table: "resource_access_edges",
+                  },
+                },
+                predicate: {
+                  And: [
+                    {
+                      Cmp: {
+                        left: {
+                          scope: "resource_access_edges",
+                          column: "kind",
+                        },
+                        op: "Eq",
+                        right: {
+                          Literal: {
+                            type: "Text",
+                            value: "individual",
+                          },
+                        },
+                      },
+                    },
+                    {
+                      Cmp: {
+                        left: {
+                          scope: "resource_access_edges",
+                          column: "grant_role",
+                        },
+                        op: "Eq",
+                        right: {
+                          Literal: {
+                            type: "Text",
+                            value: "viewer",
+                          },
+                        },
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        },
+        insert: undefined,
+        update: undefined,
+        delete: undefined,
+      },
+    });
+  });
 });

--- a/packages/jazz-tools/src/schema-permissions.ts
+++ b/packages/jazz-tools/src/schema-permissions.ts
@@ -6,6 +6,7 @@ import type {
   Value as WasmValue,
   WasmSchema,
 } from "./drivers/types.js";
+import type { RelExpr, RelPredicateExpr, RelValueRef } from "./ir.js";
 import type {
   OperationPolicy,
   PolicyExpr,
@@ -151,6 +152,146 @@ function normalizePolicyLiteralValueForWasm(value: PolicyLiteralValue): WasmValu
   return normalizeWasmLiteral(value.value);
 }
 
+function normalizeRelationValueRefForWasm(value: RelValueRef): RelValueRef {
+  if ("Literal" in value) {
+    return {
+      Literal: normalizeWasmLiteral(value.Literal),
+    };
+  }
+  return value;
+}
+
+function normalizeRelationPredicateForWasm(predicate: RelPredicateExpr): RelPredicateExpr {
+  if (predicate === "True" || predicate === "False") {
+    return predicate;
+  }
+
+  if ("Cmp" in predicate) {
+    return {
+      Cmp: {
+        ...predicate.Cmp,
+        right: normalizeRelationValueRefForWasm(predicate.Cmp.right),
+      },
+    };
+  }
+
+  if ("Contains" in predicate) {
+    return {
+      Contains: {
+        ...predicate.Contains,
+        right: normalizeRelationValueRefForWasm(predicate.Contains.right),
+      },
+    };
+  }
+
+  if ("In" in predicate) {
+    return {
+      In: {
+        ...predicate.In,
+        values: predicate.In.values.map((value) => normalizeRelationValueRefForWasm(value)),
+      },
+    };
+  }
+
+  if ("And" in predicate) {
+    return {
+      And: predicate.And.map((child) => normalizeRelationPredicateForWasm(child)),
+    };
+  }
+
+  if ("Or" in predicate) {
+    return {
+      Or: predicate.Or.map((child) => normalizeRelationPredicateForWasm(child)),
+    };
+  }
+
+  if ("Not" in predicate) {
+    return {
+      Not: normalizeRelationPredicateForWasm(predicate.Not),
+    };
+  }
+
+  return predicate;
+}
+
+function normalizeRelationExprForWasm(expr: RelExpr): RelExpr {
+  if ("TableScan" in expr) {
+    return expr;
+  }
+
+  if ("Filter" in expr) {
+    return {
+      Filter: {
+        input: normalizeRelationExprForWasm(expr.Filter.input),
+        predicate: normalizeRelationPredicateForWasm(expr.Filter.predicate),
+      },
+    };
+  }
+
+  if ("Join" in expr) {
+    return {
+      Join: {
+        ...expr.Join,
+        left: normalizeRelationExprForWasm(expr.Join.left),
+        right: normalizeRelationExprForWasm(expr.Join.right),
+      },
+    };
+  }
+
+  if ("Project" in expr) {
+    return {
+      Project: {
+        ...expr.Project,
+        input: normalizeRelationExprForWasm(expr.Project.input),
+      },
+    };
+  }
+
+  if ("Gather" in expr) {
+    return {
+      Gather: {
+        ...expr.Gather,
+        seed: normalizeRelationExprForWasm(expr.Gather.seed),
+        step: normalizeRelationExprForWasm(expr.Gather.step),
+      },
+    };
+  }
+
+  if ("Distinct" in expr) {
+    return {
+      Distinct: {
+        ...expr.Distinct,
+        input: normalizeRelationExprForWasm(expr.Distinct.input),
+      },
+    };
+  }
+
+  if ("OrderBy" in expr) {
+    return {
+      OrderBy: {
+        ...expr.OrderBy,
+        input: normalizeRelationExprForWasm(expr.OrderBy.input),
+      },
+    };
+  }
+
+  if ("Offset" in expr) {
+    return {
+      Offset: {
+        ...expr.Offset,
+        input: normalizeRelationExprForWasm(expr.Offset.input),
+      },
+    };
+  }
+
+  return {
+    Limit: {
+      ...expr.Limit,
+      input: normalizeRelationExprForWasm(expr.Limit.input),
+    },
+  };
+}
+
 function normalizePolicyExprForWasm(expr: PolicyExpr): WasmPolicyExpr {
   switch (expr.type) {
     case "Cmp":
@@ -206,6 +347,10 @@ function normalizePolicyExprForWasm(expr: PolicyExpr): WasmPolicyExpr {
         condition: normalizePolicyExprForWasm(expr.condition),
       };
     case "ExistsRel":
+      return {
+        type: "ExistsRel",
+        rel: normalizeRelationExprForWasm(expr.rel),
+      };
     case "Inherits":
     case "InheritsReferencing":
     case "True":


### PR DESCRIPTION
## What changed
- normalize nested relation IR literals inside `ExistsRel` when converting compiled permissions to the WASM/runtime wire shape
- add a regression test at the shared normalizer seam for `ExistsRel` string literals
- add runtime-schema coverage for `createJazzContext(...)`
- add a CLI publish regression that exercises nested relation literals through `permissions.ts`

## Why
Permission literal normalization only handled top-level policy expressions. Literals nested inside relation IR filters were left as raw JSON scalars like `"viewer"`, which later failed runtime/server deserialization because the wire format expects tagged `Value` objects.

## Impact
This fixes enum literal comparisons used inside relation-backed permission expressions, including the publish path and the backend/runtime schema serialization path. The fix also covers other literal types inside relation IR, not just enum-backed strings.

## Validation
- `./node_modules/.bin/vitest run src/schema-permissions.test.ts src/backend/create-jazz-context.test.ts src/cli.test.ts -t "tagged wire values|relation literals before serializing runtime schema JSON"`
- `./node_modules/.bin/tsc --noEmit -p tsconfig.json`

## Notes
A broader `src/cli.test.ts` run still has existing local-environment failures in this checkout due missing built `jazz-wasm` / `dist/cli.js` assets; the targeted publish regressions added here pass.