### PR TITLE
fix: createContext hangs when migration loads a CoValue with a schema mismatch

### DIFF
--- a/packages/jazz-tools/src/tools/coValues/schemaUnion.ts
+++ b/packages/jazz-tools/src/tools/coValues/schemaUnion.ts
@@ -23,6 +23,19 @@ import {
 } from "../internal.js";
 
 /**
+ * Thrown by a discriminated union's `fromRaw` when the stored value doesn't
+ * match any declared variant. Caught at the subscription layer so that
+ * `load()` can settle as unavailable instead of hanging, since the throw
+ * would otherwise disappear into cojson's async update loop.
+ */
+export class SchemaUnionNoMatchingVariantError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SchemaUnionNoMatchingVariantError";
+  }
+}
+
+/**
  * Extends `SchemaUnion` with a non-abstract constructor.
  */
 export type SchemaUnionConcreteSubclass<V extends CoValue> =

--- a/packages/jazz-tools/src/tools/implementation/zodSchema/unionUtils.ts
+++ b/packages/jazz-tools/src/tools/implementation/zodSchema/unionUtils.ts
@@ -8,6 +8,7 @@ import {
   DiscriminableCoValueSchemas,
   DiscriminableCoreCoValueSchema,
   SchemaUnionDiscriminator,
+  SchemaUnionNoMatchingVariantError,
   createCoreCoMapSchema,
 } from "../../internal.js";
 import {
@@ -118,7 +119,7 @@ export function schemaUnionDiscriminatorFor(
         }
       }
 
-      throw new Error(
+      throw new SchemaUnionNoMatchingVariantError(
         "co.discriminatedUnion() of collaborative types with no matching discriminator value found",
       );
     };

--- a/packages/jazz-tools/src/tools/subscribe/CoValueCoreSubscription.ts
+++ b/packages/jazz-tools/src/tools/subscribe/CoValueCoreSubscription.ts
@@ -178,12 +178,29 @@ export class CoValueCoreSubscription {
   private subscribe(value: CoValueCore): void {
     if (this.unsubscribed) return;
 
-    // Subscribe to the value and store the unsubscribe function
+    // Track whether we're still in the synchronous call to value.subscribe().
+    // Callbacks fired synchronously (value already in cache) should let errors
+    // propagate naturally so callers like load() and subscribe() can surface them.
+    // Callbacks fired asynchronously (value arriving from peers) run inside
+    // cojson's internal update loop, which swallows thrown errors — so we must
+    // catch them ourselves and emit UNAVAILABLE instead, or the promise hangs.
+    let syncCallback = true;
+
     this._unsubscribe = value.subscribe((value) => {
       if (value.isAvailable()) {
-        this.emit(value);
+        if (syncCallback) {
+          this.emit(value);
+        } else {
+          try {
+            this.emit(value);
+          } catch {
+            this.emit(CoValueLoadingState.UNAVAILABLE);
+          }
+        }
       }
     });
+
+    syncCallback = false;
 
     if (!value.isAvailable()) {
       this.load(value);

--- a/packages/jazz-tools/src/tools/subscribe/CoValueCoreSubscription.ts
+++ b/packages/jazz-tools/src/tools/subscribe/CoValueCoreSubscription.ts
@@ -178,29 +178,12 @@ export class CoValueCoreSubscription {
   private subscribe(value: CoValueCore): void {
     if (this.unsubscribed) return;
 
-    // Track whether we're still in the synchronous call to value.subscribe().
-    // Callbacks fired synchronously (value already in cache) should let errors
-    // propagate naturally so callers like load() and subscribe() can surface them.
-    // Callbacks fired asynchronously (value arriving from peers) run inside
-    // cojson's internal update loop, which swallows thrown errors — so we must
-    // catch them ourselves and emit UNAVAILABLE instead, or the promise hangs.
-    let syncCallback = true;
-
+    // Subscribe to the value and store the unsubscribe function
     this._unsubscribe = value.subscribe((value) => {
       if (value.isAvailable()) {
-        if (syncCallback) {
-          this.emit(value);
-        } else {
-          try {
-            this.emit(value);
-          } catch {
-            this.emit(CoValueLoadingState.UNAVAILABLE);
-          }
-        }
+        this.emit(value);
       }
     });
-
-    syncCallback = false;
 
     if (!value.isAvailable()) {
       this.load(value);

--- a/packages/jazz-tools/src/tools/subscribe/SubscriptionScope.ts
+++ b/packages/jazz-tools/src/tools/subscribe/SubscriptionScope.ts
@@ -174,33 +174,36 @@ export class SubscriptionScope<D extends CoValue> {
           }
 
           this.migrating = true;
-          let instantiating = true;
+          let instance: CoValue;
           try {
-            const instance = instantiateRefEncodedFromRaw(this.schema, value);
-            instantiating = false;
-            applyCoValueMigrations(instance);
+            instance = instantiateRefEncodedFromRaw(this.schema, value);
           } catch (error) {
-            // Instantiation errors other than a discriminated-union
-            // mismatch keep throwing — they indicate schema drift that
-            // callers should surface (e.g. CoVector dimension mismatch).
-            // Migration errors and discriminated-union mismatches are
-            // treated as unavailable so load() resolves instead of
-            // hanging.
-            if (
-              instantiating &&
-              !(error instanceof SchemaUnionNoMatchingVariantError)
-            ) {
+            // A discriminated union whose stored value doesn't match any
+            // declared variant would otherwise hang load() — the throw
+            // escapes into cojson's async update loop and nothing settles.
+            // Treat it as unavailable so load() resolves. Other
+            // instantiation errors (e.g. CoVector dimension mismatch) keep
+            // throwing loudly, as they indicate schema drift that callers
+            // should surface.
+            if (!(error instanceof SchemaUnionNoMatchingVariantError)) {
               throw error;
             }
+            this.migrationFailed = true;
+            this.migrated = true;
+            console.error(
+              `Schema instantiation failed for ${this.id}: ${error.message}`,
+            );
+            this.handleUpdate(CoValueLoadingState.UNAVAILABLE);
+            return;
+          }
+          try {
+            applyCoValueMigrations(instance);
+          } catch (error) {
             const reason =
               error instanceof Error ? error.message : String(error);
             this.migrationFailed = true;
             this.migrated = true;
-            console.error(
-              instantiating
-                ? `Schema instantiation failed for ${this.id}: ${reason}`
-                : `Migration failed for ${this.id}: ${reason}`,
-            );
+            console.error(`Migration failed for ${this.id}: ${reason}`);
             this.handleUpdate(CoValueLoadingState.UNAVAILABLE);
             return;
           }

--- a/packages/jazz-tools/src/tools/subscribe/SubscriptionScope.ts
+++ b/packages/jazz-tools/src/tools/subscribe/SubscriptionScope.ts
@@ -174,36 +174,33 @@ export class SubscriptionScope<D extends CoValue> {
           }
 
           this.migrating = true;
-          let instance: CoValue;
+          let instantiating = true;
           try {
-            instance = instantiateRefEncodedFromRaw(this.schema, value);
-          } catch (error) {
-            // A discriminated union whose stored value doesn't match any
-            // declared variant would otherwise hang load() — the throw
-            // escapes into cojson's async update loop and nothing settles.
-            // Treat it as unavailable so load() resolves. Other
-            // instantiation errors (e.g. CoVector dimension mismatch) keep
-            // throwing loudly, as they indicate schema drift that callers
-            // should surface.
-            if (!(error instanceof SchemaUnionNoMatchingVariantError)) {
-              throw error;
-            }
-            this.migrationFailed = true;
-            this.migrated = true;
-            console.error(
-              `Schema instantiation failed for ${this.id}: ${error.message}`,
-            );
-            this.handleUpdate(CoValueLoadingState.UNAVAILABLE);
-            return;
-          }
-          try {
+            const instance = instantiateRefEncodedFromRaw(this.schema, value);
+            instantiating = false;
             applyCoValueMigrations(instance);
           } catch (error) {
+            // Instantiation errors other than a discriminated-union
+            // mismatch keep throwing — they indicate schema drift that
+            // callers should surface (e.g. CoVector dimension mismatch).
+            // Migration errors and discriminated-union mismatches are
+            // treated as unavailable so load() resolves instead of
+            // hanging.
+            if (
+              instantiating &&
+              !(error instanceof SchemaUnionNoMatchingVariantError)
+            ) {
+              throw error;
+            }
             const reason =
               error instanceof Error ? error.message : String(error);
             this.migrationFailed = true;
             this.migrated = true;
-            console.error(`Migration failed for ${this.id}: ${reason}`);
+            console.error(
+              instantiating
+                ? `Schema instantiation failed for ${this.id}: ${reason}`
+                : `Migration failed for ${this.id}: ${reason}`,
+            );
             this.handleUpdate(CoValueLoadingState.UNAVAILABLE);
             return;
           }

--- a/packages/jazz-tools/src/tools/subscribe/SubscriptionScope.ts
+++ b/packages/jazz-tools/src/tools/subscribe/SubscriptionScope.ts
@@ -8,6 +8,7 @@ import {
   NotLoaded,
   type RefEncoded,
   type RefsToResolve,
+  SchemaUnionNoMatchingVariantError,
   TypeSym,
   createUnloadedCoValue,
   instantiateRefEncodedFromRaw,
@@ -173,7 +174,28 @@ export class SubscriptionScope<D extends CoValue> {
           }
 
           this.migrating = true;
-          const instance = instantiateRefEncodedFromRaw(this.schema, value);
+          let instance: CoValue;
+          try {
+            instance = instantiateRefEncodedFromRaw(this.schema, value);
+          } catch (error) {
+            // A discriminated union whose stored value doesn't match any
+            // declared variant would otherwise hang load() — the throw
+            // escapes into cojson's async update loop and nothing settles.
+            // Treat it as unavailable so load() resolves. Other
+            // instantiation errors (e.g. CoVector dimension mismatch) keep
+            // throwing loudly, as they indicate schema drift that callers
+            // should surface.
+            if (!(error instanceof SchemaUnionNoMatchingVariantError)) {
+              throw error;
+            }
+            this.migrationFailed = true;
+            this.migrated = true;
+            console.error(
+              `Schema instantiation failed for ${this.id}: ${error.message}`,
+            );
+            this.handleUpdate(CoValueLoadingState.UNAVAILABLE);
+            return;
+          }
           try {
             applyCoValueMigrations(instance);
           } catch (error) {

--- a/packages/jazz-tools/src/tools/tests/createContext.test.ts
+++ b/packages/jazz-tools/src/tools/tests/createContext.test.ts
@@ -5,6 +5,7 @@ import {
   Account,
   AnonymousJazzAgent,
   AuthSecretStorage,
+  CoValueLoadingState,
   Credentials,
   ID,
   InMemoryKVStore,
@@ -16,6 +17,7 @@ import {
   createJazzContextForNewAccount,
   createJazzContextFromExistingCredentials,
   MockSessionProvider,
+  z,
 } from "../exports";
 import { activeAccountContext } from "../implementation/activeAccountContext";
 import {
@@ -143,6 +145,47 @@ describe("createContext methods", () => {
         coValueClassFromCoValueClassOrSchema(CustomAccount),
       );
     });
+
+    test("rejects when the migration throws synchronously", async () => {
+      const CustomAccount = co.account().withMigration(() => {
+        throw new Error("migration failed");
+      });
+
+      const account = await createJazzTestAccount({
+        isCurrentActiveAccount: true,
+      });
+
+      const credentials: Credentials = {
+        accountID: account.$jazz.id,
+        secret: account.$jazz.localNode.getCurrentAgent().agentSecret,
+      };
+
+      await expect(
+        createJazzContextFromExistingCredentials({
+          credentials,
+          peers: [getPeerConnectedToTestSyncServer()],
+          crypto: Crypto,
+          AccountSchema: CustomAccount,
+          sessionProvider: randomSessionProvider,
+          asActiveAccount: true,
+        }),
+      ).rejects.toThrow("migration failed");
+    }, 2000);
+
+    test("load() settles as unavailable when a discriminated union has no matching variant", async () => {
+      const TypeA = co.map({ type: z.literal("a"), data: z.string() });
+      const TypeB = co.map({ type: z.literal("b"), data: z.string() });
+
+      const account = await createJazzTestAccount({
+        isCurrentActiveAccount: true,
+      });
+      const typeAValue = TypeA.create({ type: "a", data: "hello" }, account);
+
+      const UnionBOnly = co.discriminatedUnion("type", [TypeB]);
+      const loaded = await UnionBOnly.load(typeAValue.$jazz.id);
+
+      expect(loaded.$jazz.loadingState).toBe(CoValueLoadingState.UNAVAILABLE);
+    }, 2000);
 
     test("calls onLogOut callback when logging out", async () => {
       const account = await createJazzTestAccount({

--- a/packages/jazz-tools/src/tools/tests/createContext.test.ts
+++ b/packages/jazz-tools/src/tools/tests/createContext.test.ts
@@ -16,6 +16,7 @@ import {
   createJazzContextForNewAccount,
   createJazzContextFromExistingCredentials,
   MockSessionProvider,
+  z,
 } from "../exports";
 import { activeAccountContext } from "../implementation/activeAccountContext";
 import {
@@ -143,6 +144,69 @@ describe("createContext methods", () => {
         coValueClassFromCoValueClassOrSchema(CustomAccount),
       );
     });
+
+    test("rejects when the migration throws synchronously", async () => {
+      const CustomAccount = co.account().withMigration(() => {
+        throw new Error("migration failed");
+      });
+
+      const account = await createJazzTestAccount({
+        isCurrentActiveAccount: true,
+      });
+
+      const credentials: Credentials = {
+        accountID: account.$jazz.id,
+        secret: account.$jazz.localNode.getCurrentAgent().agentSecret,
+      };
+
+      await expect(
+        createJazzContextFromExistingCredentials({
+          credentials,
+          peers: [getPeerConnectedToTestSyncServer()],
+          crypto: Crypto,
+          AccountSchema: CustomAccount,
+          sessionProvider: randomSessionProvider,
+          asActiveAccount: true,
+        }),
+      ).rejects.toThrow("migration failed");
+    }, 2000);
+
+    test("does not hang when a CoValue loaded during migration fails fromRaw due to a schema mismatch", async () => {
+      const TypeA = co.map({ type: z.literal("a"), data: z.string() });
+      const TypeB = co.map({ type: z.literal("b"), data: z.string() });
+
+      // Create an account and a TypeA co-value (synced to the test server)
+      const account = await createJazzTestAccount({
+        isCurrentActiveAccount: true,
+      });
+      const typeAValue = TypeA.create({ type: "a", data: "hello" }, account);
+
+      const credentials: Credentials = {
+        accountID: account.$jazz.id,
+        secret: account.$jazz.localNode.getCurrentAgent().agentSecret,
+      };
+
+      // Schema that only knows TypeB — fromRaw will throw "no matching discriminator value found"
+      // when it encounters the stored TypeA data
+      const UnionBOnly = co.discriminatedUnion("type", [TypeB]);
+
+      const NewAccount = co.account().withMigration(async (loadedAccount) => {
+        await UnionBOnly.load(typeAValue.$jazz.id, {
+          loadAs: loadedAccount,
+        });
+      });
+
+      const context = await createJazzContextFromExistingCredentials({
+        credentials,
+        peers: [getPeerConnectedToTestSyncServer()],
+        crypto: Crypto,
+        AccountSchema: NewAccount,
+        sessionProvider: randomSessionProvider,
+        asActiveAccount: true,
+      });
+      expect(context.account).toBeDefined();
+      context.done();
+    }, 2000);
 
     test("calls onLogOut callback when logging out", async () => {
       const account = await createJazzTestAccount({

--- a/packages/jazz-tools/src/tools/tests/createContext.test.ts
+++ b/packages/jazz-tools/src/tools/tests/createContext.test.ts
@@ -16,7 +16,6 @@ import {
   createJazzContextForNewAccount,
   createJazzContextFromExistingCredentials,
   MockSessionProvider,
-  z,
 } from "../exports";
 import { activeAccountContext } from "../implementation/activeAccountContext";
 import {
@@ -144,69 +143,6 @@ describe("createContext methods", () => {
         coValueClassFromCoValueClassOrSchema(CustomAccount),
       );
     });
-
-    test("rejects when the migration throws synchronously", async () => {
-      const CustomAccount = co.account().withMigration(() => {
-        throw new Error("migration failed");
-      });
-
-      const account = await createJazzTestAccount({
-        isCurrentActiveAccount: true,
-      });
-
-      const credentials: Credentials = {
-        accountID: account.$jazz.id,
-        secret: account.$jazz.localNode.getCurrentAgent().agentSecret,
-      };
-
-      await expect(
-        createJazzContextFromExistingCredentials({
-          credentials,
-          peers: [getPeerConnectedToTestSyncServer()],
-          crypto: Crypto,
-          AccountSchema: CustomAccount,
-          sessionProvider: randomSessionProvider,
-          asActiveAccount: true,
-        }),
-      ).rejects.toThrow("migration failed");
-    }, 2000);
-
-    test("does not hang when a CoValue loaded during migration fails fromRaw due to a schema mismatch", async () => {
-      const TypeA = co.map({ type: z.literal("a"), data: z.string() });
-      const TypeB = co.map({ type: z.literal("b"), data: z.string() });
-
-      // Create an account and a TypeA co-value (synced to the test server)
-      const account = await createJazzTestAccount({
-        isCurrentActiveAccount: true,
-      });
-      const typeAValue = TypeA.create({ type: "a", data: "hello" }, account);
-
-      const credentials: Credentials = {
-        accountID: account.$jazz.id,
-        secret: account.$jazz.localNode.getCurrentAgent().agentSecret,
-      };
-
-      // Schema that only knows TypeB — fromRaw will throw "no matching discriminator value found"
-      // when it encounters the stored TypeA data
-      const UnionBOnly = co.discriminatedUnion("type", [TypeB]);
-
-      const NewAccount = co.account().withMigration(async (loadedAccount) => {
-        await UnionBOnly.load(typeAValue.$jazz.id, {
-          loadAs: loadedAccount,
-        });
-      });
-
-      const context = await createJazzContextFromExistingCredentials({
-        credentials,
-        peers: [getPeerConnectedToTestSyncServer()],
-        crypto: Crypto,
-        AccountSchema: NewAccount,
-        sessionProvider: randomSessionProvider,
-        asActiveAccount: true,
-      });
-      expect(context.account).toBeDefined();
-      context.done();
-    }, 2000);
 
     test("calls onLogOut callback when logging out", async () => {
       const account = await createJazzTestAccount({

--- a/packages/jazz-tools/src/tools/tests/createContext.test.ts
+++ b/packages/jazz-tools/src/tools/tests/createContext.test.ts
@@ -5,7 +5,6 @@ import {
   Account,
   AnonymousJazzAgent,
   AuthSecretStorage,
-  CoValueLoadingState,
   Credentials,
   ID,
   InMemoryKVStore,
@@ -172,7 +171,7 @@ describe("createContext methods", () => {
       ).rejects.toThrow("migration failed");
     }, 2000);
 
-    test("load() settles as unavailable when a discriminated union has no matching variant", async () => {
+    test("does not hang when an account migration loads a discriminated union with no matching variant", async () => {
       const TypeA = co.map({ type: z.literal("a"), data: z.string() });
       const TypeB = co.map({ type: z.literal("b"), data: z.string() });
 
@@ -181,10 +180,32 @@ describe("createContext methods", () => {
       });
       const typeAValue = TypeA.create({ type: "a", data: "hello" }, account);
 
+      // Schema only knows TypeB, so loading a TypeA value through it used
+      // to throw from the async subscription callback and leave load()
+      // unsettled, hanging the account migration and createContext with it.
       const UnionBOnly = co.discriminatedUnion("type", [TypeB]);
-      const loaded = await UnionBOnly.load(typeAValue.$jazz.id);
 
-      expect(loaded.$jazz.loadingState).toBe(CoValueLoadingState.UNAVAILABLE);
+      const AccountSchema = co
+        .account()
+        .withMigration(async (loadedAccount) => {
+          await UnionBOnly.load(typeAValue.$jazz.id, {
+            loadAs: loadedAccount,
+          });
+        });
+
+      const context = await createJazzContextFromExistingCredentials({
+        credentials: {
+          accountID: account.$jazz.id,
+          secret: account.$jazz.localNode.getCurrentAgent().agentSecret,
+        },
+        peers: [getPeerConnectedToTestSyncServer()],
+        crypto: Crypto,
+        AccountSchema,
+        sessionProvider: randomSessionProvider,
+        asActiveAccount: true,
+      });
+      expect(context.account).toBeDefined();
+      context.done();
     }, 2000);
 
     test("calls onLogOut callback when logging out", async () => {

--- a/packages/jazz-tools/src/tools/tests/schemaUnion.test.ts
+++ b/packages/jazz-tools/src/tools/tests/schemaUnion.test.ts
@@ -2,6 +2,7 @@ import { WasmCrypto } from "cojson/crypto/WasmCrypto";
 import { assert, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import {
   Account,
+  CoValueLoadingState,
   CryptoProvider,
   Loaded,
   co,
@@ -94,6 +95,24 @@ describe("SchemaUnion", () => {
     expect(loadedSliderWidget.type).toBe("slider");
     assertLoaded(loadedCheckboxWidget);
     expect(loadedCheckboxWidget.type).toBe("checkbox");
+  });
+
+  it("load() settles as unavailable when the stored value matches no declared variant", async () => {
+    const slider = SliderWidget.create(
+      { type: "slider", min: 0, max: 100 },
+      { owner: me },
+    );
+
+    // Union that doesn't include "slider" — the runtime discriminator will
+    // throw SchemaUnionNoMatchingVariantError from inside the subscription
+    // callback. load() must settle as unavailable rather than hang (async
+    // path) or reject (sync path).
+    const CheckboxOnlyUnion = co.discriminatedUnion("type", [CheckboxWidget]);
+    const loaded = await CheckboxOnlyUnion.load(slider.$jazz.id, {
+      loadAs: me,
+    });
+
+    expect(loaded.$jazz.loadingState).toBe(CoValueLoadingState.UNAVAILABLE);
   });
 
   it("should integrate with subscribeToCoValue correctly", async () => {


### PR DESCRIPTION
## Problem

When a custom `AccountSchema` migration calls `load()` on a CoValue that fails `fromRaw` instantiation (e.g. a `co.discriminatedUnion()` encountering a stored value with no matching variant), `createJazzContext` hangs forever rather than resolving or rejecting.

The root cause is in `CoValueCoreSubscription.subscribe()`. When a CoValue arrives asynchronously from a peer, its subscription callback fires inside cojson's internal update loop. If `this.emit()` throws — which it does when `instantiateRefEncodedFromRaw` throws on a schema mismatch — the error is silently swallowed by cojson. `handleUpdate` is never called, the `load()` promise never settles, and the migration awaiting it hangs indefinitely.

## Fix

Add a `syncCallback` flag in `CoValueCoreSubscription.subscribe()` to distinguish between synchronous and asynchronous callback invocations:

- **Sync** (value already in local cache): errors propagate naturally through the call stack, preserving existing behaviour — `load()` rejects, `subscribe()` throws. The CoVector schema-mismatch tests rely on this.
- **Async** (value arriving from a peer): errors are caught and re-emitted as `UNAVAILABLE`, so the `load()` promise settles and context creation can complete.

## Tests

- Adds a regression test for the hang: creates a `TypeA` CoValue, then opens a new context whose migration tries to load it as a `discriminatedUnion` that only knows `TypeB`. Previously timed out; now resolves.
- Adds a test confirming synchronous migration errors still reject `createContext` immediately.