### PR TITLE
fix: update WASM URL handling to being used in next.js

### DIFF
--- a/packages/jazz-tools/src/runtime/client.browser-assets.test.ts
+++ b/packages/jazz-tools/src/runtime/client.browser-assets.test.ts
@@ -104,7 +104,10 @@ describe("loadWasmModule runtimeSources bootstrap", () => {
     });
   });
 
-  it("uses an HTTP wasm URL when the runtime module itself is loaded from file://", async () => {
+  it("lets wasm-bindgen self-resolve the URL when the page is web-hosted and module is file://", async () => {
+    // Covers bundlers (Turbopack, webpack) that compile import.meta.url of client.ts
+    // to a file:// URL in the browser bundle. The bundler already bakes the correct
+    // asset URL into jazz_wasm.js, so we must not override it.
     setBrowserLikeProcess();
     (globalThis as Record<string, unknown>).location = {
       href: "http://localhost:3000/",
@@ -113,8 +116,6 @@ describe("loadWasmModule runtimeSources bootstrap", () => {
     await loadWasmModule();
 
     expect(wasmDefaultInit).toHaveBeenCalledTimes(1);
-    expect(wasmDefaultInit).toHaveBeenCalledWith({
-      module_or_path: "http://localhost:3000/jazz_wasm_bg.wasm",
-    });
+    expect(wasmDefaultInit).toHaveBeenCalledWith();
   });
 });

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -46,6 +46,7 @@ import {
   appendWorkerRuntimeWasmUrl,
   resolveRuntimeConfigSyncInitInput,
   resolveRuntimeConfigWasmUrl,
+  resolveWorkerBootstrapWasmUrl,
   resolveRuntimeConfigWorkerUrl,
 } from "./runtime-config.js";
 
@@ -995,7 +996,7 @@ export class Db {
     const syncInitInput = resolveRuntimeConfigSyncInitInput(runtimeSources);
     const wasmUrl = syncInitInput
       ? null
-      : resolveRuntimeConfigWasmUrl(import.meta.url, locationHref, runtimeSources);
+      : resolveWorkerBootstrapWasmUrl(import.meta.url, locationHref, runtimeSources);
     const workerUrl = appendWorkerRuntimeWasmUrl(
       resolveRuntimeConfigWorkerUrl(import.meta.url, locationHref, runtimeSources),
       wasmUrl,

--- a/packages/jazz-tools/src/runtime/runtime-config.ts
+++ b/packages/jazz-tools/src/runtime/runtime-config.ts
@@ -1,6 +1,6 @@
 import type { RuntimeSourcesConfig } from "./context.js";
 
-function isHttpModuleUrl(moduleUrl: string): boolean {
+function isHttpUrl(moduleUrl: string): boolean {
   const protocol = new URL(moduleUrl).protocol;
   return protocol === "http:" || protocol === "https:";
 }
@@ -26,6 +26,22 @@ function resolveConfiguredBaseUrl(
   }
 
   return new URL(baseUrl, locationHref).href;
+}
+
+function resolveDerivedWasmUrl(
+  runtimeModuleUrl: string,
+  locationHref: string | undefined,
+  allowHttpPageFallback: boolean,
+): string | null {
+  if (
+    !locationHref ||
+    isHttpUrl(runtimeModuleUrl) ||
+    (!allowHttpPageFallback && isHttpUrl(locationHref))
+  ) {
+    return null;
+  }
+
+  return new URL("jazz_wasm_bg.wasm", resolveBrowserAssetBase(locationHref)).href;
 }
 
 export function resolveRuntimeConfigSyncInitInput(
@@ -58,11 +74,35 @@ export function resolveRuntimeConfigWasmUrl(
     }
   }
 
-  if (!locationHref || isHttpModuleUrl(runtimeModuleUrl)) {
-    return null;
+  // In any web-hosted context (HTTP/HTTPS page), we are inside a bundled app.
+  // Bundlers (Vite, Turbopack, webpack) transform the `new URL('*.wasm', import.meta.url)`
+  // pattern in jazz_wasm.js and bake in the correct asset URL at build time.
+  // Returning null lets wasm-bindgen use that bundler-resolved URL.
+  // We only fall through to compute a root-relative URL when the page is served
+  // from a non-HTTP origin (e.g. file://) — a static HTML page with the WASM
+  // copied to the same directory.
+  return resolveDerivedWasmUrl(runtimeModuleUrl, locationHref, false);
+}
+
+export function resolveWorkerBootstrapWasmUrl(
+  runtimeModuleUrl: string,
+  locationHref: string | undefined,
+  runtime?: RuntimeSourcesConfig,
+): string | null {
+  if (runtime?.wasmUrl) {
+    return resolveConfiguredUrl(runtime.wasmUrl, locationHref);
   }
 
-  return new URL("jazz_wasm_bg.wasm", resolveBrowserAssetBase(locationHref)).href;
+  if (runtime?.baseUrl) {
+    const baseUrl = resolveConfiguredBaseUrl(runtime.baseUrl, locationHref);
+    if (baseUrl) {
+      return new URL("jazz_wasm_bg.wasm", baseUrl).href;
+    }
+  }
+
+  // Worker bootstrap still needs an explicit wasm URL when the page is HTTP-hosted
+  // but the runtime module itself is bundled from a file:// URL.
+  return resolveDerivedWasmUrl(runtimeModuleUrl, locationHref, true);
 }
 
 export function resolveRuntimeConfigWorkerUrl(
@@ -81,7 +121,7 @@ export function resolveRuntimeConfigWorkerUrl(
     }
   }
 
-  if (!locationHref || isHttpModuleUrl(runtimeModuleUrl)) {
+  if (!locationHref || isHttpUrl(runtimeModuleUrl)) {
     return new URL("../worker/jazz-worker.js", runtimeModuleUrl).href;
   }
 


### PR DESCRIPTION
#478 changed how WASM modules are loaded. In Next.js, during development, it caused them to be loaded from the root instead of the static assets directory

## Testing
- `cd examples/nextjs-csr-ssr && pnpm run test:e2e`