### PR TITLE
chore: add changesets for #3519 and #3520

### DIFF
--- a/.changeset/brave-sessions-wait.md
+++ b/.changeset/brave-sessions-wait.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Fix a Better Auth race condition where a slow `/get-session` request returning `null` after a successful sign-in would incorrectly log the user out. The client plugin now tracks an `authGeneration` counter, attaches it to `/get-session` requests via an `x-jazz-auth-generation` header, and ignores stale null responses whose generation no longer matches the current one.

--- a/.changeset/quiet-unions-settle.md
+++ b/.changeset/quiet-unions-settle.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+Fix `createJazzContext` hanging when an account migration loads a `co.discriminatedUnion()` CoValue whose stored value matches no declared variant. The runtime discriminator now throws a dedicated `SchemaUnionNoMatchingVariantError` that `SubscriptionScope` catches and surfaces as `UNAVAILABLE`, so `load()` settles instead of hanging. Other instantiation errors (e.g. `CoVector` dimension mismatches) still throw loudly.


### PR DESCRIPTION
## Summary

- Adds a patch changeset for #3520 (fix: `createJazzContext` hang on discriminated-union schema mismatch during migration).
- Adds a patch changeset for #3519 (fix: Better Auth stale `/get-session` null response logging users out, via `authGeneration` tracking).

Both target `jazz-tools` as patch bumps.

## Test plan

- [ ] CI green
- [ ] `pnpm changeset status` lists both entries