### PR TITLE
ci: add sccache to iOS build job

### DIFF
--- a/.github/workflows/publish-jazz-tools-alpha.yml
+++ b/.github/workflows/publish-jazz-tools-alpha.yml
@@ -666,12 +666,20 @@ jobs:
         with:
           cache-on-failure: true
 
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: sccache
+
       - name: Install/build React Native iOS prerequisites
         env:
           JAZZ_RN_PLATFORM: ios
         run: pnpm run ensure:rust-toolchain
 
       - name: Build jazz-rn iOS native payload
+        env:
+          RUSTC_WRAPPER: sccache
+          SCCACHE_GHA_ENABLED: on
+          SCCACHE_CACHE_SIZE: 8G
         run: pnpm --filter jazz-rn build:rn:ios
 
       - name: Verify built jazz-rn iOS native payload


### PR DESCRIPTION
Asked Claude to investigate why https://github.com/garden-co/jazz2/pull/495 hasn't improved the preview release timings:

> The improvement is modest — about 15s (~2.4%) off the average. The range also looks a bit tighter (no outlier like the 892s run before). The PR's main win was removing libclang and using prebuilt
RocksDB archives, but the Preview jazz-tools alpha release workflow is iOS-heavy (Build jazz-rn iOS payload averages 364s at p95 516s), so the RocksDB compilation savings don't dominate its runtime.

Then they pointed out that sscache was missing in the ios job, and introducing it might help us sparing ~90s

The fix is simple so worth a shot.