### PR TITLE
ci: cap test-ts turbo concurrency at 4 on 4-vcpu runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,5 +159,5 @@ jobs:
           key: playwright-browsers-${{ github.repository_id }}-${{ runner.os }}-v1
           path: /home/runner/.cache/ms-playwright
       - run: pnpm exec playwright install chromium
-      - run: pnpm test --filter=!moon-lander-react --filter=!@jazz/rust --filter=!jazz-rn
+      - run: pnpm test --filter=!moon-lander-react --filter=!@jazz/rust --filter=!jazz-rn -- --concurrency=4
       - run: pnpm --filter jazz-tools test:browser


### PR DESCRIPTION
## Summary
- Pass `--concurrency=4` to turbo in the `test-ts` CI step
- The `blacksmith-4vcpu` runner has 4 vCPUs; turbo's default concurrency is 10, which causes CPU starvation when 12+ packages run DOM/browser tests simultaneously
- Observed symptom: `inspector` LiveQuery test timing out at 15s despite using happy-dom (no real I/O), due to JS event loop starvation under load

## Notes
Change is scoped to the CI step only — not `package.json` — so local dev on larger machines is unaffected.