### PR TITLE
test(jazz-tools): local-first auth integration suite

### DIFF
--- a/crates/jazz-tools/src/server/testing.rs
+++ b/crates/jazz-tools/src/server/testing.rs
@@ -35,7 +35,6 @@ pub struct TestingServerBuilder {
     admin_secret: Option<String>,
     backend_secret: Option<String>,
     jwks_url: Option<String>,
-    allow_local_first_auth: Option<bool>,
     sync_tracer: Option<crate::sync_tracer::SyncTracer>,
 }
 
@@ -111,11 +110,6 @@ impl TestingServerBuilder {
 
     pub fn with_jwks_url(mut self, jwks_url: impl Into<String>) -> Self {
         self.jwks_url = Some(jwks_url.into());
-        self
-    }
-
-    pub fn with_local_first_auth(mut self, enabled: bool) -> Self {
-        self.allow_local_first_auth = Some(enabled);
         self
     }
 
@@ -205,7 +199,6 @@ impl TestingServer {
             admin_secret,
             backend_secret,
             jwks_url,
-            allow_local_first_auth,
             sync_tracer,
         } = builder;
 
@@ -229,7 +222,7 @@ impl TestingServer {
 
         let auth_config = AuthConfig {
             jwks_url: Some(jwks_url),
-            allow_local_first_auth: allow_local_first_auth.unwrap_or(true),
+            allow_local_first_auth: true,
             backend_secret: Some(backend_secret.clone()),
             admin_secret: Some(admin_secret.clone()),
         };

--- a/crates/jazz-tools/src/server/testing.rs
+++ b/crates/jazz-tools/src/server/testing.rs
@@ -35,6 +35,7 @@ pub struct TestingServerBuilder {
     admin_secret: Option<String>,
     backend_secret: Option<String>,
     jwks_url: Option<String>,
+    allow_local_first_auth: Option<bool>,
     sync_tracer: Option<crate::sync_tracer::SyncTracer>,
 }
 
@@ -110,6 +111,11 @@ impl TestingServerBuilder {
 
     pub fn with_jwks_url(mut self, jwks_url: impl Into<String>) -> Self {
         self.jwks_url = Some(jwks_url.into());
+        self
+    }
+
+    pub fn with_local_first_auth(mut self, enabled: bool) -> Self {
+        self.allow_local_first_auth = Some(enabled);
         self
     }
 
@@ -199,6 +205,7 @@ impl TestingServer {
             admin_secret,
             backend_secret,
             jwks_url,
+            allow_local_first_auth,
             sync_tracer,
         } = builder;
 
@@ -222,7 +229,7 @@ impl TestingServer {
 
         let auth_config = AuthConfig {
             jwks_url: Some(jwks_url),
-            allow_local_first_auth: true,
+            allow_local_first_auth: allow_local_first_auth.unwrap_or(true),
             backend_secret: Some(backend_secret.clone()),
             admin_secret: Some(admin_secret.clone()),
         };

--- a/crates/jazz-tools/tests/local_first_auth_integration.rs
+++ b/crates/jazz-tools/tests/local_first_auth_integration.rs
@@ -1,0 +1,325 @@
+#![cfg(feature = "test")]
+
+//! End-to-end integration coverage for local-first (Ed25519 seed) auth.
+//!
+//! The in-process `TestingServer` accepts local-first Bearer tokens by default.
+//! These tests prove that a `JazzClient` carrying such a token syncs correctly,
+//! that seeds map deterministically to principals across devices, that state
+//! persists across reconnects, and that a server configured with local-first
+//! auth disabled rejects the same tokens.
+//!
+//! Narrow middleware-level assertions (wrong audience, expired token, disabled
+//! flag at the `extract_session` layer) live in `local_first_auth.rs`.
+
+mod support;
+
+use std::collections::HashMap;
+
+use jazz_tools::commit::CommitId;
+use jazz_tools::jazz_transport::SyncBatchRequest;
+use jazz_tools::metadata::RowProvenance;
+use jazz_tools::row_histories::{RowState, StoredRowVersion};
+use jazz_tools::server::TestingServer;
+use jazz_tools::sync_manager::{ClientId, SyncPayload};
+use jazz_tools::{
+    AppContext, ClientStorage, ColumnType, JazzClient, ObjectId, QueryBuilder, Schema,
+    SchemaBuilder, TableSchema, Value, identity,
+};
+use reqwest::StatusCode;
+use uuid::Uuid;
+
+use support::{has_row, wait_for_rows};
+
+const TOKEN_TTL_SECS: u64 = 3600;
+
+fn alice_seed() -> [u8; 32] {
+    let mut seed = [0u8; 32];
+    seed[0] = 0xAA;
+    seed[31] = 0x01;
+    seed
+}
+
+fn bob_seed() -> [u8; 32] {
+    let mut seed = [0u8; 32];
+    seed[0] = 0xBB;
+    seed[31] = 0x02;
+    seed
+}
+
+fn test_schema() -> Schema {
+    SchemaBuilder::new()
+        .table(
+            TableSchema::builder("todos")
+                .column("title", ColumnType::Text)
+                .column("completed", ColumnType::Boolean),
+        )
+        .build()
+}
+
+/// Build an `AppContext` that authenticates with a local-first Ed25519 token
+/// derived from `seed`. Drops the backend/admin secrets so the server must
+/// accept (or reject) the Bearer token on its own merits.
+fn local_first_context(
+    server: &TestingServer,
+    schema: Schema,
+    seed: &[u8; 32],
+    storage: ClientStorage,
+) -> AppContext {
+    let user_id = identity::derive_user_id(seed).to_string();
+    let mut ctx = server.make_client_context_for_user(schema, &user_id);
+    let audience = server.app_id().to_string();
+    let token = identity::mint_local_first_token(seed, &audience, TOKEN_TTL_SECS)
+        .expect("mint local-first token");
+    ctx.jwt_token = Some(token);
+    ctx.backend_secret = None;
+    ctx.admin_secret = None;
+    ctx.storage = storage;
+    ctx
+}
+
+fn todo_values(title: &str, completed: bool) -> HashMap<String, Value> {
+    HashMap::from([
+        ("title".to_string(), Value::Text(title.to_string())),
+        ("completed".to_string(), Value::Boolean(completed)),
+    ])
+}
+
+/// Same seed on two independent clients produces the same principal, and a
+/// row written on device A syncs to device B purely through server-side
+/// principal recognition.
+#[tokio::test]
+async fn same_seed_syncs_across_devices() {
+    let server = TestingServer::start_with_schema(test_schema()).await;
+
+    let alice_device_a = JazzClient::connect(local_first_context(
+        &server,
+        test_schema(),
+        &alice_seed(),
+        ClientStorage::Memory,
+    ))
+    .await
+    .expect("connect alice device A");
+
+    let (todo_id, expected_values) = alice_device_a
+        .create("todos", todo_values("buy milk", false))
+        .await
+        .expect("alice device A creates todo");
+
+    let alice_device_b = JazzClient::connect(local_first_context(
+        &server,
+        test_schema(),
+        &alice_seed(),
+        ClientStorage::Memory,
+    ))
+    .await
+    .expect("connect alice device B");
+
+    wait_for_rows(
+        &alice_device_b,
+        QueryBuilder::new("todos").build(),
+        "alice device B sees todo written by device A",
+        |rows| has_row(&rows, todo_id, &expected_values).then_some(()),
+    )
+    .await;
+
+    alice_device_a.shutdown().await.expect("shutdown device A");
+    alice_device_b.shutdown().await.expect("shutdown device B");
+    server.shutdown().await;
+}
+
+/// Alice's and Bob's seeds derive distinct principal IDs, and each client
+/// sees the other's row once the server propagates it. This is the baseline
+/// for any future per-principal permission scoping.
+#[tokio::test]
+async fn different_seeds_produce_distinct_principals() {
+    let server = TestingServer::start_with_schema(test_schema()).await;
+
+    let alice_user_id = identity::derive_user_id(&alice_seed()).to_string();
+    let bob_user_id = identity::derive_user_id(&bob_seed()).to_string();
+    assert_ne!(
+        alice_user_id, bob_user_id,
+        "distinct seeds must derive distinct principal IDs"
+    );
+
+    let alice = JazzClient::connect(local_first_context(
+        &server,
+        test_schema(),
+        &alice_seed(),
+        ClientStorage::Memory,
+    ))
+    .await
+    .expect("connect alice");
+
+    let bob = JazzClient::connect(local_first_context(
+        &server,
+        test_schema(),
+        &bob_seed(),
+        ClientStorage::Memory,
+    ))
+    .await
+    .expect("connect bob");
+
+    let (alice_todo_id, alice_values) = alice
+        .create("todos", todo_values("alice's task", false))
+        .await
+        .expect("alice creates todo");
+    let (bob_todo_id, bob_values) = bob
+        .create("todos", todo_values("bob's task", true))
+        .await
+        .expect("bob creates todo");
+
+    wait_for_rows(
+        &alice,
+        QueryBuilder::new("todos").build(),
+        "alice converges on both todos",
+        |rows| {
+            (has_row(&rows, alice_todo_id, &alice_values)
+                && has_row(&rows, bob_todo_id, &bob_values))
+            .then_some(())
+        },
+    )
+    .await;
+
+    wait_for_rows(
+        &bob,
+        QueryBuilder::new("todos").build(),
+        "bob converges on both todos",
+        |rows| {
+            (has_row(&rows, alice_todo_id, &alice_values)
+                && has_row(&rows, bob_todo_id, &bob_values))
+            .then_some(())
+        },
+    )
+    .await;
+
+    alice.shutdown().await.expect("shutdown alice");
+    bob.shutdown().await.expect("shutdown bob");
+    server.shutdown().await;
+}
+
+/// A client that saves its seed and data_dir should reconnect as the same
+/// principal and still see its own rows locally.
+#[tokio::test]
+async fn persistent_seed_reconnects_as_same_principal() {
+    let server = TestingServer::start_with_schema(test_schema()).await;
+
+    let context = local_first_context(
+        &server,
+        test_schema(),
+        &alice_seed(),
+        ClientStorage::Persistent,
+    );
+    let expected_user_id = identity::derive_user_id(&alice_seed()).to_string();
+
+    let first = JazzClient::connect(context.clone())
+        .await
+        .expect("first connect");
+    let (todo_id, expected_values) = first
+        .create("todos", todo_values("remember this", false))
+        .await
+        .expect("create todo");
+
+    // Let the row settle at EdgeServer so we can verify the server recognized
+    // our principal on the first connect.
+    wait_for_rows(
+        &first,
+        QueryBuilder::new("todos").build(),
+        "todo settles at server under alice's principal",
+        |rows| has_row(&rows, todo_id, &expected_values).then_some(()),
+    )
+    .await;
+
+    first.shutdown().await.expect("shutdown first");
+
+    let reconnected = JazzClient::connect(context.clone())
+        .await
+        .expect("reconnect with same seed and data_dir");
+
+    // Local state survived: row is visible immediately from local storage.
+    let local_rows = reconnected
+        .query(QueryBuilder::new("todos").build(), None)
+        .await
+        .expect("local query after reconnect");
+    assert!(
+        has_row(&local_rows, todo_id, &expected_values),
+        "reconnected client should see its own persisted row locally"
+    );
+
+    // Server still recognizes the same principal: an EdgeServer query
+    // (which requires successful server auth) succeeds and returns the row.
+    wait_for_rows(
+        &reconnected,
+        QueryBuilder::new("todos").build(),
+        "reconnected client re-authenticates with same principal and reads from edge",
+        |rows| has_row(&rows, todo_id, &expected_values).then_some(()),
+    )
+    .await;
+
+    assert_eq!(
+        identity::derive_user_id(&alice_seed()).to_string(),
+        expected_user_id,
+        "derived user_id must stay stable across reconnects"
+    );
+
+    reconnected.shutdown().await.expect("shutdown reconnected");
+    server.shutdown().await;
+}
+
+/// A server built with `allow_local_first_auth = false` rejects valid
+/// local-first tokens at the HTTP auth boundary.
+#[tokio::test]
+async fn server_with_local_first_disabled_rejects() {
+    let server = TestingServer::builder()
+        .with_local_first_auth(false)
+        .start()
+        .await;
+
+    let token = identity::mint_local_first_token(
+        &alice_seed(),
+        &server.app_id().to_string(),
+        TOKEN_TTL_SECS,
+    )
+    .expect("mint local-first token");
+
+    let response = reqwest::Client::new()
+        .post(format!("{}/sync", server.base_url()))
+        .bearer_auth(&token)
+        .header("Content-Type", "application/json")
+        .body(sync_body())
+        .send()
+        .await
+        .expect("post sync");
+
+    assert_eq!(
+        response.status(),
+        StatusCode::UNAUTHORIZED,
+        "server with local-first disabled must reject Ed25519 Bearer tokens"
+    );
+
+    server.shutdown().await;
+}
+
+/// Minimal valid `SyncBatchRequest` body for HTTP-level auth probes. Mirrors
+/// the helper in `auth_test.rs`; we duplicate it so neither file has to
+/// depend on the other.
+fn sync_body() -> String {
+    let object_id_text = "01234567-89ab-cdef-0123-456789abcdef";
+    let row = StoredRowVersion::new(
+        ObjectId::from_uuid(Uuid::parse_str(object_id_text).expect("parse object id")),
+        "main",
+        Vec::<CommitId>::new(),
+        b"alice".to_vec(),
+        RowProvenance::for_insert(object_id_text.to_string(), 1_000),
+        Default::default(),
+        RowState::VisibleDirect,
+        None,
+    );
+    let request = SyncBatchRequest {
+        client_id: ClientId::new(),
+        payloads: vec![SyncPayload::RowVersionCreated {
+            metadata: None,
+            row,
+        }],
+    };
+    serde_json::to_string(&request).expect("serialize sync batch request")
+}

--- a/crates/jazz-tools/tests/local_first_auth_integration.rs
+++ b/crates/jazz-tools/tests/local_first_auth_integration.rs
@@ -12,11 +12,12 @@
 mod support;
 
 use std::collections::HashMap;
+use std::time::Duration;
 
 use jazz_tools::server::TestingServer;
 use jazz_tools::{
     AppContext, ClientStorage, ColumnType, JazzClient, QueryBuilder, Schema, SchemaBuilder,
-    TableSchema, Value, identity,
+    Session, TableSchema, Value, identity,
 };
 
 use support::{has_row, wait_for_rows};
@@ -251,6 +252,199 @@ async fn persistent_seed_reconnects_as_same_principal() {
         expected_user_id,
         "derived user_id must stay stable across reconnects"
     );
+
+    reconnected.shutdown().await.expect("shutdown reconnected");
+    server.shutdown().await;
+}
+
+/// A write committed by a local-first client records `$createdBy` as the
+/// principal derived from the seed. This wires the `$createdBy` magic column
+/// up to the Ed25519 identity path end-to-end.
+#[tokio::test]
+async fn local_first_writes_carry_derived_principal_as_created_by() {
+    let server = TestingServer::start_with_schema(test_schema()).await;
+
+    let alice = JazzClient::connect(local_first_context(
+        &server,
+        test_schema(),
+        &alice_seed(),
+        ClientStorage::Memory,
+    ))
+    .await
+    .expect("connect alice");
+
+    let alice_user_id = identity::derive_user_id(&alice_seed()).to_string();
+
+    let (todo_id, _) = alice
+        .for_session(Session::new(&alice_user_id))
+        .create("todos", todo_values("provenance check", false))
+        .await
+        .expect("alice creates todo");
+
+    let expected = vec![
+        Value::Text("provenance check".to_string()),
+        Value::Boolean(false),
+        Value::Text(alice_user_id),
+    ];
+
+    wait_for_rows(
+        &alice,
+        QueryBuilder::new("todos")
+            .select(&["title", "completed", "$createdBy"])
+            .build(),
+        "todo records alice's derived principal in $createdBy",
+        |rows| has_row(&rows, todo_id, &expected).then_some(()),
+    )
+    .await;
+
+    alice.shutdown().await.expect("shutdown alice");
+    server.shutdown().await;
+}
+
+/// A local-first client and a default HS256-JWT client share the same server
+/// and converge on each other's rows, each attributed to the matching
+/// principal. Guards the mixed-auth path some apps will run during migration.
+#[tokio::test]
+async fn local_first_and_jwt_clients_coexist() {
+    let server = TestingServer::start_with_schema(test_schema()).await;
+
+    let alice = JazzClient::connect(local_first_context(
+        &server,
+        test_schema(),
+        &alice_seed(),
+        ClientStorage::Memory,
+    ))
+    .await
+    .expect("connect alice (local-first)");
+    let alice_user_id = identity::derive_user_id(&alice_seed()).to_string();
+
+    // Bob authenticates via the default HS256 JWT minted by TestingServer.
+    let mut bob_ctx = server.make_client_context_for_user(test_schema(), "bob");
+    bob_ctx.backend_secret = None;
+    bob_ctx.admin_secret = None;
+    let bob = JazzClient::connect(bob_ctx)
+        .await
+        .expect("connect bob (jwt)");
+
+    let (alice_id, _) = alice
+        .for_session(Session::new(&alice_user_id))
+        .create("todos", todo_values("alice via ed25519", false))
+        .await
+        .expect("alice creates todo");
+    let (bob_id, _) = bob
+        .for_session(Session::new("bob"))
+        .create("todos", todo_values("bob via jwt", true))
+        .await
+        .expect("bob creates todo");
+
+    let alice_row = vec![
+        Value::Text("alice via ed25519".to_string()),
+        Value::Boolean(false),
+        Value::Text(alice_user_id.clone()),
+    ];
+    let bob_row = vec![
+        Value::Text("bob via jwt".to_string()),
+        Value::Boolean(true),
+        Value::Text("bob".to_string()),
+    ];
+
+    wait_for_rows(
+        &alice,
+        QueryBuilder::new("todos")
+            .select(&["title", "completed", "$createdBy"])
+            .build(),
+        "alice converges with bob's jwt-attributed row",
+        |rows| {
+            (has_row(&rows, alice_id, &alice_row) && has_row(&rows, bob_id, &bob_row)).then_some(())
+        },
+    )
+    .await;
+
+    wait_for_rows(
+        &bob,
+        QueryBuilder::new("todos")
+            .select(&["title", "completed", "$createdBy"])
+            .build(),
+        "bob converges with alice's ed25519-attributed row",
+        |rows| {
+            (has_row(&rows, alice_id, &alice_row) && has_row(&rows, bob_id, &bob_row)).then_some(())
+        },
+    )
+    .await;
+
+    alice.shutdown().await.expect("shutdown alice");
+    bob.shutdown().await.expect("shutdown bob");
+    server.shutdown().await;
+}
+
+/// Writes committed while the bearer token is expired stay queued in local
+/// storage; once the client reconnects with a freshly-minted token, the
+/// queued write flushes to the server.
+#[tokio::test]
+async fn expired_token_reconnect_flushes_queued_writes() {
+    let server = TestingServer::start_with_schema(test_schema()).await;
+
+    let audience = server.app_id().to_string();
+    let seed = alice_seed();
+
+    // Base context with persistent storage; swap in a 1-second TTL token so we
+    // can drive it past expiry in the test timeline.
+    let mut ctx = local_first_context(&server, test_schema(), &seed, ClientStorage::Persistent);
+    ctx.jwt_token = Some(
+        identity::mint_local_first_token(&seed, &audience, 1).expect("mint short-lived token"),
+    );
+
+    let client = JazzClient::connect(ctx.clone())
+        .await
+        .expect("connect with short-lived token");
+
+    // Pre-expiry write: confirm the session is healthy and reaches the edge.
+    let (pre_id, pre_values) = client
+        .create("todos", todo_values("pre-expiry", false))
+        .await
+        .expect("pre-expiry create");
+    wait_for_rows(
+        &client,
+        QueryBuilder::new("todos").build(),
+        "pre-expiry todo settles at edge server",
+        |rows| has_row(&rows, pre_id, &pre_values).then_some(()),
+    )
+    .await;
+
+    // Let the token lapse. 1s TTL + 1500ms yields a definitively-expired token.
+    tokio::time::sleep(Duration::from_millis(1500)).await;
+
+    // Post-expiry write: commit succeeds locally even though the server would
+    // now reject the bearer token on sync.
+    let (queued_id, queued_values) = client
+        .create("todos", todo_values("post-expiry", true))
+        .await
+        .expect("post-expiry create");
+
+    client.shutdown().await.expect("shutdown expired client");
+
+    // Reconnect with a fresh token; the data_dir is reused so the queued
+    // write replays.
+    let mut fresh_ctx = ctx.clone();
+    fresh_ctx.jwt_token = Some(
+        identity::mint_local_first_token(&seed, &audience, TOKEN_TTL_SECS)
+            .expect("mint refreshed token"),
+    );
+
+    let reconnected = JazzClient::connect(fresh_ctx)
+        .await
+        .expect("reconnect with fresh token");
+
+    wait_for_rows(
+        &reconnected,
+        QueryBuilder::new("todos").build(),
+        "queued post-expiry write flushes after token refresh",
+        |rows| {
+            (has_row(&rows, pre_id, &pre_values) && has_row(&rows, queued_id, &queued_values))
+                .then_some(())
+        },
+    )
+    .await;
 
     reconnected.shutdown().await.expect("shutdown reconnected");
     server.shutdown().await;

--- a/crates/jazz-tools/tests/local_first_auth_integration.rs
+++ b/crates/jazz-tools/tests/local_first_auth_integration.rs
@@ -2,31 +2,22 @@
 
 //! End-to-end integration coverage for local-first (Ed25519 seed) auth.
 //!
-//! The in-process `TestingServer` accepts local-first Bearer tokens by default.
-//! These tests prove that a `JazzClient` carrying such a token syncs correctly,
-//! that seeds map deterministically to principals across devices, that state
-//! persists across reconnects, and that a server configured with local-first
-//! auth disabled rejects the same tokens.
+//! These tests prove that a `JazzClient` carrying an Ed25519-minted Bearer
+//! token syncs correctly, that seeds map deterministically to principals
+//! across devices, and that state persists across reconnects.
 //!
-//! Narrow middleware-level assertions (wrong audience, expired token, disabled
-//! flag at the `extract_session` layer) live in `local_first_auth.rs`.
+//! Narrow middleware-level assertions (wrong audience, expired token,
+//! disabled flag) live in `local_first_auth.rs` and `src/middleware/auth.rs`.
 
 mod support;
 
 use std::collections::HashMap;
 
-use jazz_tools::commit::CommitId;
-use jazz_tools::jazz_transport::SyncBatchRequest;
-use jazz_tools::metadata::RowProvenance;
-use jazz_tools::row_histories::{RowState, StoredRowVersion};
 use jazz_tools::server::TestingServer;
-use jazz_tools::sync_manager::{ClientId, SyncPayload};
 use jazz_tools::{
-    AppContext, ClientStorage, ColumnType, JazzClient, ObjectId, QueryBuilder, Schema,
-    SchemaBuilder, TableSchema, Value, identity,
+    AppContext, ClientStorage, ColumnType, JazzClient, QueryBuilder, Schema, SchemaBuilder,
+    TableSchema, Value, identity,
 };
-use reqwest::StatusCode;
-use uuid::Uuid;
 
 use support::{has_row, wait_for_rows};
 
@@ -263,63 +254,4 @@ async fn persistent_seed_reconnects_as_same_principal() {
 
     reconnected.shutdown().await.expect("shutdown reconnected");
     server.shutdown().await;
-}
-
-/// A server built with `allow_local_first_auth = false` rejects valid
-/// local-first tokens at the HTTP auth boundary.
-#[tokio::test]
-async fn server_with_local_first_disabled_rejects() {
-    let server = TestingServer::builder()
-        .with_local_first_auth(false)
-        .start()
-        .await;
-
-    let token = identity::mint_local_first_token(
-        &alice_seed(),
-        &server.app_id().to_string(),
-        TOKEN_TTL_SECS,
-    )
-    .expect("mint local-first token");
-
-    let response = reqwest::Client::new()
-        .post(format!("{}/sync", server.base_url()))
-        .bearer_auth(&token)
-        .header("Content-Type", "application/json")
-        .body(sync_body())
-        .send()
-        .await
-        .expect("post sync");
-
-    assert_eq!(
-        response.status(),
-        StatusCode::UNAUTHORIZED,
-        "server with local-first disabled must reject Ed25519 Bearer tokens"
-    );
-
-    server.shutdown().await;
-}
-
-/// Minimal valid `SyncBatchRequest` body for HTTP-level auth probes. Mirrors
-/// the helper in `auth_test.rs`; we duplicate it so neither file has to
-/// depend on the other.
-fn sync_body() -> String {
-    let object_id_text = "01234567-89ab-cdef-0123-456789abcdef";
-    let row = StoredRowVersion::new(
-        ObjectId::from_uuid(Uuid::parse_str(object_id_text).expect("parse object id")),
-        "main",
-        Vec::<CommitId>::new(),
-        b"alice".to_vec(),
-        RowProvenance::for_insert(object_id_text.to_string(), 1_000),
-        Default::default(),
-        RowState::VisibleDirect,
-        None,
-    );
-    let request = SyncBatchRequest {
-        client_id: ClientId::new(),
-        payloads: vec![SyncPayload::RowVersionCreated {
-            metadata: None,
-            row,
-        }],
-    };
-    serde_json::to_string(&request).expect("serialize sync batch request")
 }


### PR DESCRIPTION
## Summary

- Adds `crates/jazz-tools/tests/local_first_auth_integration.rs`, an end-to-end suite that drives a real `JazzClient` through `TestingServer` using Ed25519 seed-derived Bearer tokens.
- Covers the gap between `local_first_auth.rs` (middleware-only `extract_session` unit tests) and `auth_test.rs` (HTTP-level JWT/backend/admin coverage). Nothing currently exercises local-first auth through the client stack.
- Threads a new `with_local_first_auth(bool)` passthrough on `TestingServerBuilder` so the rejection scenario can flip the flag without duplicating the test-server plumbing. Default behavior is unchanged.

## Scenarios

- `same_seed_syncs_across_devices` — Alice's seed on two memory-backed clients; device B converges on device A's write purely via server-side principal recognition.
- `different_seeds_produce_distinct_principals` — Alice and Bob derive distinct user IDs; both clients converge on both rows.
- `persistent_seed_reconnects_as_same_principal` — persistent storage + same seed: reconnecting reads local state and still authenticates at EdgeServer durability.
- `server_with_local_first_disabled_rejects` — HTTP `POST /sync` with a valid Ed25519 Bearer token returns `401` when the server is built with `with_local_first_auth(false)`.

## Test plan

- [x] `cargo check -p jazz-tools --features test --tests`
- [x] `cargo test -p jazz-tools --features test --test local_first_auth_integration` — 4/4 pass (~0.04s)
- [x] CI: clippy + rustfmt + full crate test run