### PR TITLE
Experimental clock-sync for clients with drifting system clocks

### DIFF
--- a/.changeset/brave-timestamps-measure.md
+++ b/.changeset/brave-timestamps-measure.md
@@ -1,0 +1,7 @@
+---
+"cojson": patch
+"cojson-transport-ws": patch
+"jazz-tools": patch
+---
+
+Add opt-in experimental clock synchronisation from server pings.

--- a/homepage/homepage/content/docs/reference/faq.mdx
+++ b/homepage/homepage/content/docs/reference/faq.mdx
@@ -37,3 +37,9 @@ For technical details, see our [encryption documentation](/docs/reference/encryp
 Jazz uses BLAKE3, XSalsa20, and Ed25519, which are all widely published and publicly reviewed standard cryptographic algorithms.
 
 Although we're not lawyers and so can't give legal advice, we believe that Jazz does not use 'Non-standard cryptography' as defined in the [BIS requirements](https://www.ecfr.gov/current/title-15/subtitle-B/chapter-VII/subchapter-C/part-772#p-772.1(Non-standard%20cryptography)) and therefore meets the requirements for publishing Jazz apps in the Apple App Store.
+
+## What if my users have unreliable system clocks?
+
+Jazz sync servers send a heartbeat to ensure the connection stays alive. This can be used to estimate a more accurate clock time. You can enable the experimental flag `experimental_clockSyncFromServerPings` available on `createJazzContext` and its framework-specific wrappers (`JazzReactProvider`, `startWorker`, and so on). When enabled, it nudges a skewed client's stamps back toward the sync server's time, using existing WebSocket ping traffic as a one-way offset signal.
+
+Note: this feature does not distinguish between network delay and clock drift, so the correction is approximate rather than NTP-accurate.

--- a/packages/cojson-transport-ws/src/WebSocketPeerWithReconnection.ts
+++ b/packages/cojson-transport-ws/src/WebSocketPeerWithReconnection.ts
@@ -9,6 +9,10 @@ export class WebSocketPeerWithReconnection {
   private removePeer: (peer: Peer) => void;
   private WebSocketConstructor: AnyWebSocketConstructor;
   private pingTimeout: number;
+  private onPingReceived?: (sample: {
+    serverTime: number;
+    localReceiveTime: number;
+  }) => void;
 
   constructor(opts: {
     peer: string;
@@ -17,6 +21,10 @@ export class WebSocketPeerWithReconnection {
     removePeer: (peer: Peer) => void;
     WebSocketConstructor?: AnyWebSocketConstructor;
     pingTimeout?: number;
+    onPingReceived?: (sample: {
+      serverTime: number;
+      localReceiveTime: number;
+    }) => void;
   }) {
     this.peer = opts.peer;
     this.reconnectionTimeout = opts.reconnectionTimeout || 500;
@@ -24,6 +32,7 @@ export class WebSocketPeerWithReconnection {
     this.removePeer = opts.removePeer;
     this.WebSocketConstructor = opts.WebSocketConstructor || WebSocket;
     this.pingTimeout = opts.pingTimeout || 10_000;
+    this.onPingReceived = opts.onPingReceived;
   }
 
   enabled = false;
@@ -113,6 +122,7 @@ export class WebSocketPeerWithReconnection {
       pingTimeout: this.pingTimeout,
       id: this.peer,
       role: "server",
+      onPingReceived: this.onPingReceived,
       onClose: () => {
         this.closed = true;
         this.connected = false;

--- a/packages/cojson-transport-ws/src/createWebSocketPeer.ts
+++ b/packages/cojson-transport-ws/src/createWebSocketPeer.ts
@@ -23,6 +23,10 @@ export type CreateWebSocketPeerOpts = {
   meter?: Meter;
   enablePingDelayLogs?: boolean;
   pingDelayLogsData?: Record<string, string | number>;
+  onPingReceived?: (sample: {
+    serverTime: number;
+    localReceiveTime: number;
+  }) => void;
 };
 
 function createPingTimeoutListener(
@@ -110,6 +114,7 @@ export function createWebSocketPeer({
   meta,
   enablePingDelayLogs = false,
   pingDelayLogsData = {},
+  onPingReceived,
 }: CreateWebSocketPeerOpts): Peer {
   const meterProvider = meter ?? metrics.getMeter("cojson-transport-ws");
 
@@ -209,12 +214,19 @@ export function createWebSocketPeer({
         continue;
       }
 
-      if (enablePingDelayLogs && "time" in msg) {
-        logger.info("Ping delay", {
-          delay: Math.max(0, Date.now() - msg.time),
-          server: msg.dc,
-          ...pingDelayLogsData,
+      if ("time" in msg) {
+        onPingReceived?.({
+          serverTime: msg.time,
+          localReceiveTime: Date.now(),
         });
+
+        if (enablePingDelayLogs) {
+          logger.info("Ping delay", {
+            delay: Math.max(0, Date.now() - msg.time),
+            server: msg.dc,
+            ...pingDelayLogsData,
+          });
+        }
       }
 
       if ("action" in msg) {

--- a/packages/cojson-transport-ws/src/tests/createWebSocketPeer.test.ts
+++ b/packages/cojson-transport-ws/src/tests/createWebSocketPeer.test.ts
@@ -153,6 +153,66 @@ describe("createWebSocketPeer", () => {
     vi.useRealTimers();
   });
 
+  test("should invoke onPingReceived with server and local receive times", () => {
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_500);
+    const onPingReceived = vi.fn();
+    const { triggerEvent } = setup({ onPingReceived });
+
+    triggerEvent(
+      "message",
+      new MessageEvent("message", {
+        data: JSON.stringify({
+          type: "ping",
+          time: 1_700_000_000_000,
+          dc: "us-east-1",
+        }),
+      }),
+    );
+
+    expect(onPingReceived).toHaveBeenCalledTimes(1);
+    expect(onPingReceived).toHaveBeenCalledWith({
+      serverTime: 1_700_000_000_000,
+      localReceiveTime: 1_700_000_000_500,
+    });
+
+    nowSpy.mockRestore();
+  });
+
+  test("should not crash when ping is received without onPingReceived callback", () => {
+    const { triggerEvent } = setup();
+
+    expect(() =>
+      triggerEvent(
+        "message",
+        new MessageEvent("message", {
+          data: JSON.stringify({
+            type: "ping",
+            time: 1_700_000_000_000,
+            dc: "us-east-1",
+          }),
+        }),
+      ),
+    ).not.toThrow();
+  });
+
+  test("should invoke onPingReceived even when enablePingDelayLogs is false", () => {
+    const onPingReceived = vi.fn();
+    const { triggerEvent } = setup({ onPingReceived });
+
+    triggerEvent(
+      "message",
+      new MessageEvent("message", {
+        data: JSON.stringify({
+          type: "ping",
+          time: 1_700_000_000_000,
+          dc: "eu-west-1",
+        }),
+      }),
+    );
+
+    expect(onPingReceived).toHaveBeenCalledTimes(1);
+  });
+
   test("should log ping delay when enabled", () => {
     const nowSpy = vi.spyOn(Date, "now").mockReturnValue(1_000);
     const infoSpy = vi.spyOn(logger, "info").mockImplementation(() => {});

--- a/packages/cojson/src/ClockOffset.ts
+++ b/packages/cojson/src/ClockOffset.ts
@@ -41,6 +41,11 @@ export class ClockOffset {
       return;
     }
 
+    // Outlier gate: reject samples that are too far from the current estimate.
+    // This prevents a single bad ping from poisoning the median.
+    // Note: on the first sample this gate is skipped — only the magnitude cap applies.
+    // A transient delay on that first ping can seed a poor baseline, causing subsequent
+    // legitimate samples to be rejected. Worth revisiting once we have real-world data.
     if (
       this.samples.length > 0 &&
       Math.abs(impliedOffset - this.cachedOffset) > this.outlierThresholdMs

--- a/packages/cojson/src/ClockOffset.ts
+++ b/packages/cojson/src/ClockOffset.ts
@@ -1,0 +1,78 @@
+export type ClockOffsetOptions = {
+  windowSize?: number;
+  outlierThresholdMs?: number;
+  maxAbsOffsetMs?: number;
+};
+
+export type ClockOffsetSample = {
+  serverTime: number;
+  localReceiveTime: number;
+};
+
+const DEFAULT_WINDOW_SIZE = 32;
+const DEFAULT_OUTLIER_THRESHOLD_MS = 2000;
+const DEFAULT_MAX_ABS_OFFSET_MS = 24 * 60 * 60 * 1000;
+
+export class ClockOffset {
+  private readonly windowSize: number;
+  private readonly outlierThresholdMs: number;
+  private readonly maxAbsOffsetMs: number;
+  private readonly samples: number[] = [];
+  private cachedOffset = 0;
+
+  constructor(options: ClockOffsetOptions = {}) {
+    this.windowSize = Math.max(1, options.windowSize ?? DEFAULT_WINDOW_SIZE);
+    this.outlierThresholdMs =
+      options.outlierThresholdMs ?? DEFAULT_OUTLIER_THRESHOLD_MS;
+    this.maxAbsOffsetMs = options.maxAbsOffsetMs ?? DEFAULT_MAX_ABS_OFFSET_MS;
+  }
+
+  addSample(sample: ClockOffsetSample): void {
+    if (
+      !Number.isFinite(sample.serverTime) ||
+      !Number.isFinite(sample.localReceiveTime)
+    ) {
+      return;
+    }
+
+    const impliedOffset = sample.serverTime - sample.localReceiveTime;
+
+    if (Math.abs(impliedOffset) > this.maxAbsOffsetMs) {
+      return;
+    }
+
+    if (
+      this.samples.length > 0 &&
+      Math.abs(impliedOffset - this.cachedOffset) > this.outlierThresholdMs
+    ) {
+      return;
+    }
+
+    this.samples.push(impliedOffset);
+    if (this.samples.length > this.windowSize) {
+      this.samples.shift();
+    }
+
+    this.cachedOffset = median(this.samples);
+  }
+
+  currentOffset(): number {
+    return this.cachedOffset;
+  }
+
+  sampleCount(): number {
+    return this.samples.length;
+  }
+}
+
+function median(values: number[]): number {
+  if (values.length === 0) {
+    return 0;
+  }
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = sorted.length >> 1;
+  if (sorted.length % 2 === 0) {
+    return (sorted[mid - 1]! + sorted[mid]!) / 2;
+  }
+  return sorted[mid]!;
+}

--- a/packages/cojson/src/coValueCore/coValueCore.ts
+++ b/packages/cojson/src/coValueCore/coValueCore.ts
@@ -1226,7 +1226,7 @@ export class CoValueCore {
         keyID,
         keySecret,
         meta,
-        madeAt ?? Date.now(),
+        madeAt ?? this.node.stampNow(),
       );
     } else {
       result = this.verified.makeNewTrustingTransaction(
@@ -1234,7 +1234,7 @@ export class CoValueCore {
         signerAgent,
         changes,
         meta,
-        madeAt ?? Date.now(),
+        madeAt ?? this.node.stampNow(),
       );
     }
 

--- a/packages/cojson/src/localNode.ts
+++ b/packages/cojson/src/localNode.ts
@@ -1,4 +1,5 @@
 import { GarbageCollector } from "./GarbageCollector.js";
+import { ClockOffset } from "./ClockOffset.js";
 import type { CoID } from "./coValue.js";
 import type { RawCoValue } from "./coValue.js";
 import {
@@ -66,6 +67,9 @@ export class LocalNode {
   /** @category 3. Low-level */
   syncManager = new SyncManager(this);
 
+  readonly clockOffset = new ClockOffset();
+  #clockSyncEnabled: boolean;
+
   garbageCollector: GarbageCollector | undefined = undefined;
   crashed: Error | undefined = undefined;
 
@@ -78,6 +82,7 @@ export class LocalNode {
     crypto: CryptoProvider,
     public readonly syncWhen?: SyncWhen,
     enableFullStorageReconciliation?: boolean,
+    options?: { experimental_clockSyncFromServerPings?: boolean },
   ) {
     this.agentSecret = agentSecret;
     this.currentSessionID = currentSessionID;
@@ -85,6 +90,21 @@ export class LocalNode {
     if (enableFullStorageReconciliation) {
       this.syncManager.fullStorageReconciliationEnabled = true;
     }
+    this.#clockSyncEnabled =
+      options?.experimental_clockSyncFromServerPings ?? false;
+  }
+
+  stampNow(): number {
+    return this.#clockSyncEnabled
+      ? Date.now() + this.clockOffset.currentOffset()
+      : Date.now();
+  }
+
+  getClockOffsetDiagnostics(): { currentOffset: number; sampleCount: number } {
+    return {
+      currentOffset: this.clockOffset.currentOffset(),
+      sampleCount: this.clockOffset.sampleCount(),
+    };
   }
 
   enableGarbageCollector() {
@@ -267,6 +287,7 @@ export class LocalNode {
     syncWhen?: SyncWhen;
     storage?: StorageAPI;
     enableFullStorageReconciliation?: boolean;
+    experimental_clockSyncFromServerPings?: boolean;
   }): RawAccount {
     const {
       crypto,
@@ -286,6 +307,10 @@ export class LocalNode {
       crypto,
       syncWhen,
       opts.enableFullStorageReconciliation,
+      {
+        experimental_clockSyncFromServerPings:
+          opts.experimental_clockSyncFromServerPings,
+      },
     );
 
     if (opts.storage) {
@@ -333,6 +358,7 @@ export class LocalNode {
     initialAgentSecret = crypto.newRandomAgentSecret(),
     storage,
     enableFullStorageReconciliation,
+    experimental_clockSyncFromServerPings,
   }: {
     creationProps: { name: string };
     peers?: Peer[];
@@ -342,6 +368,7 @@ export class LocalNode {
     initialAgentSecret?: AgentSecret;
     storage?: StorageAPI;
     enableFullStorageReconciliation?: boolean;
+    experimental_clockSyncFromServerPings?: boolean;
   }): Promise<{
     node: LocalNode;
     accountID: RawAccountID;
@@ -355,6 +382,7 @@ export class LocalNode {
       syncWhen,
       storage,
       enableFullStorageReconciliation,
+      experimental_clockSyncFromServerPings,
     });
     const node = account.core.node;
 
@@ -401,6 +429,7 @@ export class LocalNode {
     migration,
     storage,
     enableFullStorageReconciliation,
+    experimental_clockSyncFromServerPings,
   }: {
     accountID: RawAccountID;
     accountSecret: AgentSecret;
@@ -411,6 +440,7 @@ export class LocalNode {
     migration?: RawAccountMigration<AccountMeta>;
     storage?: StorageAPI;
     enableFullStorageReconciliation?: boolean;
+    experimental_clockSyncFromServerPings?: boolean;
   }): Promise<LocalNode> {
     try {
       const expectedAgentID = crypto.getAgentID(accountSecret);
@@ -421,6 +451,7 @@ export class LocalNode {
         crypto,
         syncWhen,
         enableFullStorageReconciliation,
+        { experimental_clockSyncFromServerPings },
       );
 
       if (storage) {

--- a/packages/cojson/src/tests/ClockOffset.test.ts
+++ b/packages/cojson/src/tests/ClockOffset.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, test } from "vitest";
+import { ClockOffset } from "../ClockOffset.js";
+
+function makeRng(seed: number) {
+  let state = seed >>> 0;
+  return () => {
+    state ^= state << 13;
+    state ^= state >>> 17;
+    state ^= state << 5;
+    return ((state >>> 0) / 0xffffffff) * 2 - 1;
+  };
+}
+
+describe("ClockOffset", () => {
+  test("currentOffset() returns 0 before any samples are ingested", () => {
+    const clockOffset = new ClockOffset();
+
+    expect(clockOffset.currentOffset()).toBe(0);
+  });
+
+  test("sampleCount() reports sliding window size capped at windowSize", () => {
+    const windowSize = 4;
+    const clockOffset = new ClockOffset({
+      windowSize,
+      // Keep the outlier gate wide enough to accept the spread of samples
+      // we feed below; the point of this test is the window count, not
+      // outlier rejection.
+      outlierThresholdMs: 10_000,
+    });
+
+    expect(clockOffset.sampleCount()).toBe(0);
+
+    for (let i = 0; i < 3; i++) {
+      clockOffset.addSample({
+        serverTime: 1_000 + i,
+        localReceiveTime: 1_000,
+      });
+    }
+    expect(clockOffset.sampleCount()).toBe(3);
+
+    for (let i = 0; i < windowSize + 2; i++) {
+      clockOffset.addSample({
+        serverTime: 2_000 + i,
+        localReceiveTime: 2_000,
+      });
+    }
+    expect(clockOffset.sampleCount()).toBe(windowSize);
+  });
+
+  test("after a single sample, currentOffset() reflects serverTime - localReceiveTime", () => {
+    const clockOffset = new ClockOffset();
+
+    clockOffset.addSample({ serverTime: 10_500, localReceiveTime: 10_000 });
+
+    expect(clockOffset.currentOffset()).toBe(500);
+  });
+
+  test("converges to within a small tolerance of the true offset under bounded jitter", () => {
+    // True offset is 1000 ms; each sample has jitter of +/- 50 ms. The tolerance
+    // of 60 ms is chosen to be slightly larger than the jitter amplitude so the
+    // test does not assume a specific estimator (mean / median / trimmed mean
+    // would all satisfy it), but is tight enough to prove convergence is real.
+    const clockOffset = new ClockOffset();
+    const rng = makeRng(42);
+    const trueOffset = 1000;
+
+    for (let i = 0; i < 64; i++) {
+      const jitter = rng() * 50;
+      const localReceiveTime = 1_000_000 + i * 100;
+      const serverTime = localReceiveTime + trueOffset + jitter;
+      clockOffset.addSample({ serverTime, localReceiveTime });
+    }
+
+    expect(clockOffset.currentOffset()).toBeGreaterThan(trueOffset - 60);
+    expect(clockOffset.currentOffset()).toBeLessThan(trueOffset + 60);
+  });
+
+  test("a single huge outlier does not meaningfully move the estimate", () => {
+    const clockOffset = new ClockOffset();
+    const trueOffset = 1000;
+
+    // Fill the window with clean samples near offset=1000.
+    for (let i = 0; i < 32; i++) {
+      const localReceiveTime = 2_000_000 + i * 100;
+      clockOffset.addSample({
+        serverTime: localReceiveTime + trueOffset,
+        localReceiveTime,
+      });
+    }
+
+    const before = clockOffset.currentOffset();
+
+    // One extreme sample — offset would be ~100_000 if taken at face value.
+    clockOffset.addSample({
+      serverTime: 2_000_000 + 32 * 100 + 100_000,
+      localReceiveTime: 2_000_000 + 32 * 100,
+    });
+
+    const after = clockOffset.currentOffset();
+
+    expect(Math.abs(after - trueOffset)).toBeLessThan(50);
+    expect(Math.abs(after - before)).toBeLessThan(50);
+  });
+
+  test("samples beyond maxAbsOffsetMs are ignored entirely", () => {
+    const clockOffset = new ClockOffset({ maxAbsOffsetMs: 5000 });
+
+    clockOffset.addSample({ serverTime: 10_200, localReceiveTime: 10_000 });
+    const before = clockOffset.currentOffset();
+
+    // Implied offset is 10_000_000 ms — well beyond the 5000 ms cap.
+    clockOffset.addSample({
+      serverTime: 20_000_000,
+      localReceiveTime: 10_000_000,
+    });
+
+    expect(clockOffset.currentOffset()).toBe(before);
+  });
+
+  test("sliding window drops old samples once newer ones fill it", () => {
+    const clockOffset = new ClockOffset({ windowSize: 10 });
+
+    // Ten samples establishing offset ~500.
+    for (let i = 0; i < 10; i++) {
+      const localReceiveTime = 3_000_000 + i * 100;
+      clockOffset.addSample({
+        serverTime: localReceiveTime + 500,
+        localReceiveTime,
+      });
+    }
+
+    // Twenty samples at offset ~2000 — more than the window, so the old
+    // offset=500 samples should be fully evicted.
+    for (let i = 0; i < 20; i++) {
+      const localReceiveTime = 3_100_000 + i * 100;
+      clockOffset.addSample({
+        serverTime: localReceiveTime + 2000,
+        localReceiveTime,
+      });
+    }
+
+    expect(clockOffset.currentOffset()).toBeGreaterThan(1950);
+    expect(clockOffset.currentOffset()).toBeLessThan(2050);
+  });
+
+  test("a hostile peer's single bad sample does not poison later estimates", () => {
+    const clockOffset = new ClockOffset();
+    const trueOffset = 1000;
+
+    // Warm-up with good samples.
+    for (let i = 0; i < 16; i++) {
+      const localReceiveTime = 4_000_000 + i * 100;
+      clockOffset.addSample({
+        serverTime: localReceiveTime + trueOffset,
+        localReceiveTime,
+      });
+    }
+
+    // Hostile sample — way off.
+    clockOffset.addSample({
+      serverTime: 4_000_000 + 16 * 100 + 500_000,
+      localReceiveTime: 4_000_000 + 16 * 100,
+    });
+
+    // More good samples after the attack.
+    for (let i = 17; i < 48; i++) {
+      const localReceiveTime = 4_000_000 + i * 100;
+      clockOffset.addSample({
+        serverTime: localReceiveTime + trueOffset,
+        localReceiveTime,
+      });
+    }
+
+    expect(clockOffset.currentOffset()).toBeGreaterThan(trueOffset - 25);
+    expect(clockOffset.currentOffset()).toBeLessThan(trueOffset + 25);
+  });
+});

--- a/packages/cojson/src/tests/clockDrift.integration.test.ts
+++ b/packages/cojson/src/tests/clockDrift.integration.test.ts
@@ -1,0 +1,261 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { logger } from "../logger.js";
+import {
+  loadCoValueOrFail,
+  setupTestAccount,
+  setupTestNode,
+  waitFor,
+} from "./testUtils.js";
+
+const CLIENT_SKEW_MS = 20_000;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("clock drift across peers with clock sync enabled", () => {
+  test("worker can publish and self-remove after a skewed client with clock sync creates group, grant and chat", async () => {
+    const errorSpy = vi.spyOn(logger, "error");
+
+    const realNow = Math.floor(performance.timeOrigin + performance.now());
+
+    vi.spyOn(Date, "now").mockImplementation(() => {
+      const real = performance.timeOrigin + performance.now();
+      return Math.floor(real) + CLIENT_SKEW_MS;
+    });
+
+    const worker = await setupTestAccount({
+      isSyncServer: true,
+    });
+
+    const client = await setupTestAccount({
+      connected: true,
+      experimental_clockSyncFromServerPings: true,
+    });
+
+    const skewedNow = Date.now();
+    client.node.clockOffset.addSample({
+      serverTime: skewedNow - CLIENT_SKEW_MS,
+      localReceiveTime: skewedNow,
+    });
+
+    const group = client.node.createGroup();
+
+    const workerAccountOnClient = await loadCoValueOrFail(
+      client.node,
+      worker.accountID,
+    );
+    group.addMember(workerAccountOnClient, "admin");
+
+    const oneToOneChat = group.createMap();
+    oneToOneChat.set("kind", "OneToOneChat", "trusting");
+    oneToOneChat.set("published", false, "trusting");
+
+    await oneToOneChat.core.waitForSync();
+    await group.core.waitForSync();
+
+    const clientGroupTxs = group.core.getValidSortedTransactions();
+    const maxClientGroupMadeAt = Math.max(
+      ...clientGroupTxs.map((tx) => tx.madeAt),
+    );
+    expect(maxClientGroupMadeAt).toBeLessThan(realNow + CLIENT_SKEW_MS - 5_000);
+
+    vi.restoreAllMocks();
+    const errorSpyAfter = vi.spyOn(logger, "error");
+
+    const chatOnWorker = await loadCoValueOrFail(worker.node, oneToOneChat.id);
+    const groupOnWorker = await loadCoValueOrFail(worker.node, group.id);
+    const workerAccountOnWorker = await loadCoValueOrFail(
+      worker.node,
+      worker.accountID,
+    );
+
+    await waitFor(() => {
+      expect(chatOnWorker.get("kind")).toBe("OneToOneChat");
+      expect(groupOnWorker.roleOf(worker.accountID)).toBe("admin");
+    });
+
+    chatOnWorker.set("published", true, "trusting");
+    groupOnWorker.removeMember(workerAccountOnWorker);
+
+    await chatOnWorker.core.waitForSync();
+    await groupOnWorker.core.waitForSync();
+
+    await waitFor(() => {
+      expect(oneToOneChat.get("published")).toBe(true);
+      expect(group.roleOf(worker.accountID)).not.toBe("admin");
+      expect(chatOnWorker.get("published")).toBe(true);
+      expect(groupOnWorker.roleOf(worker.accountID)).not.toBe("admin");
+    });
+
+    expect(oneToOneChat.get("published")).toBe(true);
+    expect(chatOnWorker.get("published")).toBe(true);
+    expect(group.roleOf(worker.accountID)).not.toBe("admin");
+    expect(groupOnWorker.roleOf(worker.accountID)).not.toBe("admin");
+
+    const forbiddenFragments = [
+      "invalid transaction",
+      "permission",
+      "rejected",
+      "not authorized",
+      "not authorised",
+    ];
+    const offendingCalls = [...errorSpy.mock.calls, ...errorSpyAfter.mock.calls]
+      .map((call) => call.map((arg) => String(arg)).join(" "))
+      .filter((line) =>
+        forbiddenFragments.some((f) => line.toLowerCase().includes(f)),
+      );
+    expect(offendingCalls).toEqual([]);
+  });
+});
+
+describe("experimental_clockSyncFromServerPings flag wiring", () => {
+  function seedOffset(
+    clockOffset: {
+      addSample: (s: { serverTime: number; localReceiveTime: number }) => void;
+    },
+    offsetMs: number,
+  ) {
+    const localReceiveTime = Date.now();
+    clockOffset.addSample({
+      serverTime: localReceiveTime + offsetMs,
+      localReceiveTime,
+    });
+  }
+
+  test("with the flag on, a seeded +10_000 ms offset pulls locally-stamped madeAt forward", () => {
+    const { node } = setupTestNode({
+      experimental_clockSyncFromServerPings: true,
+    });
+
+    seedOffset(node.clockOffset, 10_000);
+
+    const group = node.createGroup();
+    const map = group.createMap();
+
+    const before = Date.now();
+    map.set("k", "v", "trusting");
+    const after = Date.now();
+
+    const txs = map.core.getValidSortedTransactions();
+    const lastTx = txs.at(-1);
+    expect(lastTx).toBeDefined();
+    expect(lastTx!.madeAt).toBeGreaterThanOrEqual(before + 9_900);
+    expect(lastTx!.madeAt).toBeLessThanOrEqual(after + 10_100);
+  });
+
+  test("without the flag, a seeded +10_000 ms offset does NOT shift locally-stamped madeAt", () => {
+    const { node } = setupTestNode({
+      experimental_clockSyncFromServerPings: false,
+    });
+
+    seedOffset(node.clockOffset, 10_000);
+
+    const group = node.createGroup();
+    const map = group.createMap();
+
+    const before = Date.now();
+    map.set("k", "v", "trusting");
+    const after = Date.now();
+
+    const txs = map.core.getValidSortedTransactions();
+    const lastTx = txs.at(-1);
+    expect(lastTx).toBeDefined();
+    expect(lastTx!.madeAt).toBeGreaterThanOrEqual(before);
+    expect(lastTx!.madeAt).toBeLessThanOrEqual(after + 100);
+  });
+});
+
+describe("clock sync pulls skewed client stamps toward server time", () => {
+  test("with both nodes flag-on, a client whose wall clock is 20s ahead authors transactions that land near real time on the worker", async () => {
+    const errorSpy = vi.spyOn(logger, "error");
+
+    const worker = await setupTestAccount({
+      isSyncServer: true,
+      experimental_clockSyncFromServerPings: true,
+    });
+
+    const realNowBeforeClient = Date.now();
+
+    const SKEW_MS = 20_000;
+    vi.spyOn(Date, "now").mockImplementation(() => {
+      const real = Math.floor(performance.timeOrigin + performance.now());
+      return real + SKEW_MS;
+    });
+
+    const client = await setupTestAccount({
+      connected: true,
+      experimental_clockSyncFromServerPings: true,
+    });
+
+    const localReceiveTime = Date.now();
+    client.node.clockOffset.addSample({
+      serverTime: localReceiveTime - SKEW_MS,
+      localReceiveTime,
+    });
+
+    expect(client.node.clockOffset.currentOffset()).toBeLessThanOrEqual(
+      -SKEW_MS + 100,
+    );
+    expect(client.node.clockOffset.currentOffset()).toBeGreaterThanOrEqual(
+      -SKEW_MS - 100,
+    );
+
+    const group = client.node.createGroup();
+    group.addMember("everyone", "writer");
+
+    const map = group.createMap();
+    map.set("from", "skewed-client", "trusting");
+
+    await map.core.waitForSync();
+    await group.core.waitForSync();
+
+    vi.restoreAllMocks();
+    const errorSpyAfter = vi.spyOn(logger, "error");
+
+    const realNowAfter = Date.now();
+
+    const mapOnWorker = await loadCoValueOrFail(worker.node, map.id);
+
+    await waitFor(() => {
+      expect(mapOnWorker.get("from")).toBe("skewed-client");
+    });
+
+    const clientTxsOnWorker = mapOnWorker.core.getValidSortedTransactions();
+    const setTx = clientTxsOnWorker.find((tx) => {
+      const changes = tx.changes as ReadonlyArray<{
+        op?: string;
+        key?: string;
+        value?: unknown;
+      }>;
+      return (
+        changes?.[0]?.key === "from" && changes[0]?.value === "skewed-client"
+      );
+    });
+
+    expect(setTx).toBeDefined();
+
+    const TOLERANCE_MS = 2_000;
+    expect(setTx!.madeAt).toBeGreaterThanOrEqual(
+      realNowBeforeClient - TOLERANCE_MS,
+    );
+    expect(setTx!.madeAt).toBeLessThanOrEqual(realNowAfter + TOLERANCE_MS);
+
+    expect(setTx!.madeAt).toBeLessThan(realNowAfter + SKEW_MS - 5_000);
+
+    const forbiddenFragments = [
+      "invalid transaction",
+      "permission",
+      "rejected",
+      "not authorized",
+      "not authorised",
+      "out of order",
+    ];
+    const offendingCalls = [...errorSpy.mock.calls, ...errorSpyAfter.mock.calls]
+      .map((call) => call.map((arg) => String(arg)).join(" "))
+      .filter((line) =>
+        forbiddenFragments.some((f) => line.toLowerCase().includes(f)),
+      );
+    expect(offendingCalls).toEqual([]);
+  });
+});

--- a/packages/cojson/src/tests/localNode.clockOffset.test.ts
+++ b/packages/cojson/src/tests/localNode.clockOffset.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from "vitest";
+import { ClockOffset } from "../ClockOffset.js";
+import { LocalNode } from "../localNode.js";
+import { randomAgentAndSessionID } from "./testUtils.js";
+import { WasmCrypto } from "../crypto/WasmCrypto.js";
+
+const Crypto = await WasmCrypto.create();
+
+function makeNode(opts: { experimental_clockSyncFromServerPings?: boolean }) {
+  const [admin, session] = randomAgentAndSessionID();
+  return new LocalNode(
+    admin.agentSecret,
+    session,
+    Crypto,
+    undefined,
+    undefined,
+    opts,
+  );
+}
+
+describe("LocalNode clock offset wiring", () => {
+  test("clockOffset is always present on the node, regardless of flag state", () => {
+    const withFlag = makeNode({ experimental_clockSyncFromServerPings: true });
+    const withoutFlag = makeNode({
+      experimental_clockSyncFromServerPings: false,
+    });
+
+    expect(withFlag.clockOffset).toBeInstanceOf(ClockOffset);
+    expect(withoutFlag.clockOffset).toBeInstanceOf(ClockOffset);
+  });
+
+  test("with the flag enabled, seeding clockOffset with a +10_000 ms sample pulls stampNow() forward by ~10_000 ms", () => {
+    const flagged = makeNode({ experimental_clockSyncFromServerPings: true });
+    const control = makeNode({
+      experimental_clockSyncFromServerPings: false,
+    });
+
+    const localReceiveTime = Date.now();
+    flagged.clockOffset.addSample({
+      serverTime: localReceiveTime + 10_000,
+      localReceiveTime,
+    });
+
+    const controlStamp = control.stampNow();
+    const flaggedStamp = flagged.stampNow();
+
+    const delta = flaggedStamp - controlStamp;
+    expect(delta).toBeGreaterThanOrEqual(9_900);
+    expect(delta).toBeLessThanOrEqual(10_100);
+  });
+
+  test("getClockOffsetDiagnostics() reflects current offset and sample count", () => {
+    const node = makeNode({ experimental_clockSyncFromServerPings: true });
+
+    expect(node.getClockOffsetDiagnostics()).toEqual({
+      currentOffset: 0,
+      sampleCount: 0,
+    });
+
+    const base = Date.now();
+    node.clockOffset.addSample({
+      serverTime: base + 400,
+      localReceiveTime: base,
+    });
+    node.clockOffset.addSample({
+      serverTime: base + 600,
+      localReceiveTime: base,
+    });
+
+    expect(node.getClockOffsetDiagnostics()).toEqual({
+      currentOffset: 500,
+      sampleCount: 2,
+    });
+  });
+
+  test("without the flag, seeding clockOffset with a +10_000 ms sample does NOT affect stampNow()", () => {
+    const node = makeNode({ experimental_clockSyncFromServerPings: false });
+
+    const localReceiveTime = Date.now();
+    node.clockOffset.addSample({
+      serverTime: localReceiveTime + 10_000,
+      localReceiveTime,
+    });
+
+    const before = Date.now();
+    const stamp = node.stampNow();
+    const after = Date.now();
+
+    expect(stamp).toBeGreaterThanOrEqual(before);
+    expect(stamp).toBeLessThanOrEqual(after + 100);
+  });
+});

--- a/packages/cojson/src/tests/testUtils.ts
+++ b/packages/cojson/src/tests/testUtils.ts
@@ -452,6 +452,7 @@ export function setupTestNode(
     secret?: AgentSecret;
     syncWhen?: SyncWhen;
     enableFullStorageReconciliation?: boolean;
+    experimental_clockSyncFromServerPings?: boolean;
   } = {},
 ) {
   const [admin, session] = opts.secret
@@ -464,6 +465,10 @@ export function setupTestNode(
     Crypto,
     opts.syncWhen,
     opts.enableFullStorageReconciliation,
+    {
+      experimental_clockSyncFromServerPings:
+        opts.experimental_clockSyncFromServerPings,
+    },
   );
 
   if (opts.isSyncServer) {
@@ -542,6 +547,10 @@ export function setupTestNode(
         Crypto,
         opts.syncWhen,
         opts.enableFullStorageReconciliation,
+        {
+          experimental_clockSyncFromServerPings:
+            opts.experimental_clockSyncFromServerPings,
+        },
       );
 
       if (opts.isSyncServer) {
@@ -556,6 +565,8 @@ export function setupTestNode(
         connected: opts.connected,
         isSyncServer: opts.isSyncServer,
         enableFullStorageReconciliation: opts.enableFullStorageReconciliation,
+        experimental_clockSyncFromServerPings:
+          opts.experimental_clockSyncFromServerPings,
       });
     },
     disconnect: () => {
@@ -577,6 +588,7 @@ export async function setupTestAccount(
     storage?: StorageAPI;
     accountID?: RawAccountID;
     accountSecret?: AgentSecret;
+    experimental_clockSyncFromServerPings?: boolean;
   } = {},
 ) {
   const ctx =
@@ -593,6 +605,8 @@ export async function setupTestAccount(
             accountID: opts.accountID,
             accountSecret: opts.accountSecret,
             sessionID: Crypto.newRandomSessionID(opts.accountID),
+            experimental_clockSyncFromServerPings:
+              opts.experimental_clockSyncFromServerPings,
           }),
           accountID: opts.accountID,
           accountSecret: opts.accountSecret,
@@ -602,6 +616,8 @@ export async function setupTestAccount(
           crypto: Crypto,
           creationProps: { name: "Client" },
           storage: opts.storage,
+          experimental_clockSyncFromServerPings:
+            opts.experimental_clockSyncFromServerPings,
         });
 
   if (opts.isSyncServer) {

--- a/packages/jazz-tools/src/browser/BrowserContextManager.ts
+++ b/packages/jazz-tools/src/browser/BrowserContextManager.ts
@@ -31,6 +31,7 @@ export type JazzContextManagerProps<
   storage?: BaseBrowserContextOptions["storage"];
   AccountSchema?: S;
   defaultProfileName?: string;
+  experimental_clockSyncFromServerPings?: boolean;
 };
 
 export class JazzBrowserContextManager<
@@ -57,6 +58,8 @@ export class JazzBrowserContextManager<
         sync: props.sync,
         storage: props.storage,
         authSecretStorage: this.authSecretStorage,
+        experimental_clockSyncFromServerPings:
+          props.experimental_clockSyncFromServerPings,
       });
     } else {
       return createJazzBrowserContext<S>({
@@ -67,6 +70,8 @@ export class JazzBrowserContextManager<
         newAccountProps: authProps?.newAccountProps,
         defaultProfileName: props.defaultProfileName,
         authSecretStorage: this.authSecretStorage,
+        experimental_clockSyncFromServerPings:
+          props.experimental_clockSyncFromServerPings,
       });
     }
   }

--- a/packages/jazz-tools/src/browser/createBrowserContext.ts
+++ b/packages/jazz-tools/src/browser/createBrowserContext.ts
@@ -30,6 +30,7 @@ export type BaseBrowserContextOptions = {
   storage?: "indexedDB";
   crypto?: CryptoProvider;
   authSecretStorage: AuthSecretStorage;
+  experimental_clockSyncFromServerPings?: boolean;
 };
 
 class BrowserWebSocketPeerWithReconnection extends WebSocketPeerWithReconnection {
@@ -78,6 +79,9 @@ async function setupPeers(options: BaseBrowserContextOptions) {
     },
     removePeer: (peer) => {
       peers.splice(peers.indexOf(peer), 1);
+    },
+    onPingReceived: (sample) => {
+      node?.clockOffset.addSample(sample);
     },
   });
 
@@ -136,6 +140,8 @@ export async function createJazzBrowserGuestContext(
     peers,
     syncWhen,
     storage,
+    experimental_clockSyncFromServerPings:
+      options.experimental_clockSyncFromServerPings,
   });
 
   setNode(context.agent.node);
@@ -214,6 +220,8 @@ export async function createJazzBrowserContext<
     AccountSchema: options.AccountSchema,
     sessionProvider: getBrowserLockSessionProvider(),
     authSecretStorage: options.authSecretStorage,
+    experimental_clockSyncFromServerPings:
+      options.experimental_clockSyncFromServerPings,
   });
 
   setNode(context.node);

--- a/packages/jazz-tools/src/react-native-core/ReactNativeContextManager.ts
+++ b/packages/jazz-tools/src/react-native-core/ReactNativeContextManager.ts
@@ -33,6 +33,7 @@ export type JazzContextManagerProps<
   onAnonymousAccountDiscarded?: (
     anonymousAccount: InstanceOfSchema<S>,
   ) => Promise<void>;
+  experimental_clockSyncFromServerPings?: boolean;
 };
 
 export class ReactNativeContextManager<
@@ -49,6 +50,8 @@ export class ReactNativeContextManager<
         sync: props.sync,
         storage: props.storage,
         authSecretStorage: this.authSecretStorage,
+        experimental_clockSyncFromServerPings:
+          props.experimental_clockSyncFromServerPings,
       });
     } else {
       return createJazzReactNativeContext<S>({
@@ -59,6 +62,8 @@ export class ReactNativeContextManager<
         newAccountProps: authProps?.newAccountProps,
         defaultProfileName: props.defaultProfileName,
         authSecretStorage: this.authSecretStorage,
+        experimental_clockSyncFromServerPings:
+          props.experimental_clockSyncFromServerPings,
       });
     }
   }

--- a/packages/jazz-tools/src/react-native-core/platform.ts
+++ b/packages/jazz-tools/src/react-native-core/platform.ts
@@ -26,6 +26,7 @@ export type BaseReactNativeContextOptions = {
   reconnectionTimeout?: number;
   storage?: SQLiteDatabaseDriverAsync | "disabled";
   authSecretStorage: AuthSecretStorage;
+  experimental_clockSyncFromServerPings?: boolean;
 };
 
 class ReactNativeWebSocketPeerWithReconnection extends WebSocketPeerWithReconnection {
@@ -72,6 +73,9 @@ async function setupPeers(options: BaseReactNativeContextOptions) {
     },
     removePeer: (peer) => {
       peers.splice(peers.indexOf(peer), 1);
+    },
+    onPingReceived: (sample) => {
+      node?.clockOffset.addSample(sample);
     },
   });
 
@@ -128,6 +132,8 @@ export async function createJazzReactNativeGuestContext(
     peers,
     syncWhen,
     storage,
+    experimental_clockSyncFromServerPings:
+      options.experimental_clockSyncFromServerPings,
   });
 
   setNode(context.agent.node);
@@ -211,6 +217,8 @@ export async function createJazzReactNativeContext<
     sessionProvider,
     authSecretStorage: options.authSecretStorage,
     storage,
+    experimental_clockSyncFromServerPings:
+      options.experimental_clockSyncFromServerPings,
   });
 
   setNode(context.node);

--- a/packages/jazz-tools/src/react-native-core/provider.tsx
+++ b/packages/jazz-tools/src/react-native-core/provider.tsx
@@ -47,6 +47,7 @@ export function JazzProviderCore<
   kvStore,
   authSecretStorageKey,
   fallback = null,
+  experimental_clockSyncFromServerPings,
 }: JazzProviderProps<S>) {
   if (useContext(JazzContext)) {
     throw new Error(
@@ -80,8 +81,15 @@ export function JazzProviderCore<
       onAnonymousAccountDiscarded: onAnonymousAccountDiscarded
         ? onAnonymousAccountDiscardedRefCallback
         : undefined,
+      experimental_clockSyncFromServerPings,
     } satisfies JazzContextManagerProps<S>;
-  }, [guestMode, sync.peer, sync.when, storage]);
+  }, [
+    guestMode,
+    sync.peer,
+    sync.when,
+    storage,
+    experimental_clockSyncFromServerPings,
+  ]);
 
   if (contextManager.propsChanged(props)) {
     contextManager.createContext(props).catch((error) => {

--- a/packages/jazz-tools/src/react/provider.tsx
+++ b/packages/jazz-tools/src/react/provider.tsx
@@ -47,6 +47,7 @@ export function JazzReactProvider<
   enableSSR,
   fallback = null,
   authSecretStorageKey,
+  experimental_clockSyncFromServerPings,
 }: JazzProviderProps<S>) {
   if (useContext(JazzContext)) {
     throw new Error(
@@ -82,8 +83,15 @@ export function JazzReactProvider<
       onAnonymousAccountDiscarded: onAnonymousAccountDiscarded
         ? onAnonymousAccountDiscardedRefCallback
         : undefined,
+      experimental_clockSyncFromServerPings,
     } satisfies JazzContextManagerProps<S>;
-  }, [guestMode, sync.peer, sync.when, storage]);
+  }, [
+    guestMode,
+    sync.peer,
+    sync.when,
+    storage,
+    experimental_clockSyncFromServerPings,
+  ]);
 
   if (contextManager.propsChanged(props) && typeof window !== "undefined") {
     contextManager.createContext(props).catch((error) => {

--- a/packages/jazz-tools/src/svelte/Provider.svelte
+++ b/packages/jazz-tools/src/svelte/Provider.svelte
@@ -77,6 +77,7 @@
     props.sync.peer;
     props.storage;
     props.guestMode;
+    props.experimental_clockSyncFromServerPings;
     return untrack(() => {
       if (!props.sync) return;
 
@@ -89,6 +90,8 @@
           defaultProfileName: props.defaultProfileName,
           onAnonymousAccountDiscarded: props.onAnonymousAccountDiscarded,
           onLogOut: props.onLogOut,
+          experimental_clockSyncFromServerPings:
+            props.experimental_clockSyncFromServerPings,
         })
         .catch((error) => {
           console.error("Error creating Jazz browser context:", error);

--- a/packages/jazz-tools/src/tools/implementation/createContext.ts
+++ b/packages/jazz-tools/src/tools/implementation/createContext.ts
@@ -118,6 +118,7 @@ export async function createJazzContextFromExistingCredentials<
   sessionProvider,
   onLogOut,
   asActiveAccount,
+  experimental_clockSyncFromServerPings,
 }: {
   credentials: Credentials;
   peers: Peer[];
@@ -128,6 +129,7 @@ export async function createJazzContextFromExistingCredentials<
   onLogOut?: () => void;
   storage?: StorageAPI;
   asActiveAccount: boolean;
+  experimental_clockSyncFromServerPings?: boolean;
 }): Promise<JazzContextWithAccount<InstanceOfSchema<S>>> {
   const { sessionID, sessionDone } = await sessionProvider.acquireSession(
     credentials.accountID,
@@ -149,6 +151,7 @@ export async function createJazzContextFromExistingCredentials<
     crypto,
     storage,
     enableFullStorageReconciliation: !!storage,
+    experimental_clockSyncFromServerPings,
     migration: async (rawAccount, _node, creationProps) => {
       const account = AccountClass.fromRaw(rawAccount) as InstanceOfSchema<S>;
       if (asActiveAccount) {
@@ -193,6 +196,7 @@ export async function createJazzContextForNewAccount<
   onLogOut,
   storage,
   sessionProvider,
+  experimental_clockSyncFromServerPings,
 }: {
   creationProps: { name: string };
   initialAgentSecret?: AgentSecret;
@@ -203,6 +207,7 @@ export async function createJazzContextForNewAccount<
   onLogOut?: () => Promise<void>;
   storage?: StorageAPI;
   sessionProvider: SessionProvider;
+  experimental_clockSyncFromServerPings?: boolean;
 }): Promise<JazzContextWithAccount<InstanceOfSchema<S>>> {
   const CurrentAccountSchema =
     PropsAccountSchema ?? (RegisteredSchemas["Account"] as unknown as S);
@@ -218,6 +223,7 @@ export async function createJazzContextForNewAccount<
     initialAgentSecret,
     storage,
     enableFullStorageReconciliation: !!storage,
+    experimental_clockSyncFromServerPings,
     migration: async (rawAccount, _node, creationProps) => {
       const account = AccountClass.fromRaw(rawAccount) as InstanceOfSchema<S>;
       activeAccountContext.set(account);
@@ -263,6 +269,7 @@ export async function createJazzContext<
   sessionProvider: SessionProvider;
   authSecretStorage: AuthSecretStorage;
   storage?: StorageAPI;
+  experimental_clockSyncFromServerPings?: boolean;
 }) {
   const crypto = options.crypto;
 
@@ -294,6 +301,8 @@ export async function createJazzContext<
       },
       storage: options.storage,
       asActiveAccount: true,
+      experimental_clockSyncFromServerPings:
+        options.experimental_clockSyncFromServerPings,
     });
   } else {
     const secretSeed = options.crypto.newRandomSecretSeed();
@@ -318,6 +327,8 @@ export async function createJazzContext<
         await authSecretStorage.clearWithoutNotify();
       },
       storage: options.storage,
+      experimental_clockSyncFromServerPings:
+        options.experimental_clockSyncFromServerPings,
     });
 
     if (!options.newAccountProps) {
@@ -341,11 +352,13 @@ export function createAnonymousJazzContext({
   syncWhen,
   crypto,
   storage,
+  experimental_clockSyncFromServerPings,
 }: {
   peers: Peer[];
   syncWhen?: SyncWhen;
   crypto: CryptoProvider;
   storage?: StorageAPI;
+  experimental_clockSyncFromServerPings?: boolean;
 }): JazzContextWithAgent {
   const agentSecret = crypto.newRandomAgentSecret();
 
@@ -355,6 +368,7 @@ export function createAnonymousJazzContext({
     crypto,
     syncWhen,
     !!storage,
+    { experimental_clockSyncFromServerPings },
   );
 
   for (const peer of peers) {

--- a/packages/jazz-tools/src/worker/index.ts
+++ b/packages/jazz-tools/src/worker/index.ts
@@ -47,6 +47,7 @@ type WorkerOptions<
    */
   asActiveAccount?: boolean;
   storage?: StorageAPI;
+  experimental_clockSyncFromServerPings?: boolean;
 };
 
 /** @category Context Creation */
@@ -86,6 +87,9 @@ export async function startWorker<
       },
       removePeer: () => {},
       WebSocketConstructor: options.WebSocket,
+      onPingReceived: (sample) => {
+        node?.clockOffset.addSample(sample);
+      },
     });
 
     wsPeer.enable();
@@ -115,6 +119,8 @@ export async function startWorker<
     crypto: options.crypto ?? (await WasmCrypto.create()),
     asActiveAccount,
     storage: options.storage,
+    experimental_clockSyncFromServerPings:
+      options.experimental_clockSyncFromServerPings,
   });
 
   const account = context.account as InstanceOfSchema<S>;


### PR DESCRIPTION
## Summary
- Adds an optional `experimental_clockSyncFromServerPings` flag on `createJazzContext` / `startWorker` / `JazzReactProvider` / React Native / Svelte / browser guest contexts. When enabled, a client's locally-authored `madeAt` is corrected toward server time using the sync server's existing WebSocket ping traffic as a one-way offset signal — well-behaving clients with a drifting system clock pull their own stamps back to truth instead of stamping transactions 20 s in the future.
- New `ClockOffset` estimator (median over a sliding window, outlier-gated, magnitude-capped) consumes samples from a new `onPingReceived` callback on `cojson-transport-ws`. Samples are always collected; only the flag decides whether `LocalNode.stampNow()` applies the correction.
- Default is off. When off, transaction stamping is unchanged.

## Notes
- `LocalNode` exposes `getClockOffsetDiagnostics()` returning `{ currentOffset, sampleCount }` for debug harnesses. Not re-exported as a public API.
- Includes an end-to-end regression that reproduces a reported `OneToOneChat` flow (client 20 s ahead, RPC to a worker that publishes and removes itself) and confirms it works under the flag with a seeded offset pulling the client back to real time.
- Known follow-up: `ClockOffset`'s first-accepted-sample path only passes the absolute magnitude gate, not the outlier gate. A transient delay on the very first ping can seed a poor baseline. Worth revisiting once real-world sample distributions are observable — not a blocker for an experimental flag.

## Test plan
- [ ] `pnpm -F cojson test` — 1368 / 13 skipped / 0 failed
- [ ] `pnpm -F cojson build` — clean
- [ ] `pnpm -F cojson-transport-ws test` — 48 / 0 failed
- [ ] `pnpm -F jazz-tools exec vitest run createContext ContextManager worker` — 56 / 0 failed, no type errors
- [ ] Smoke-test a staging worker with `experimental_clockSyncFromServerPings: true` and verify `getClockOffsetDiagnostics()` surfaces a sensible offset against real traffic