### PR TITLE
feat(jazz-tools): add BIP39 recovery phrase for local-first identity

### DIFF
--- a/.changeset/local-first-recovery-phrase.md
+++ b/.changeset/local-first-recovery-phrase.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": minor
+---
+
+Add BIP39 recovery phrase for local-first identity, exposed at the new `jazz-tools/passphrase` subpath. `RecoveryPhrase.fromSecret` / `RecoveryPhrase.toSecret` encode and decode the 32-byte local-first auth secret as a 24-word English mnemonic, with structured `RecoveryPhraseError` codes and forgiving whitespace/case normalization. Also fixes a latent cache bug in `BrowserAuthSecretStore` and `ExpoAuthSecretStore` where `saveSecret` did not invalidate `cachedPromise`, so a restore after `getOrCreateSecret` would silently keep the pre-restore secret.

--- a/examples/docs/todo-client-localfirst-expo/src/auth-snippets.tsx
+++ b/examples/docs/todo-client-localfirst-expo/src/auth-snippets.tsx
@@ -1,7 +1,7 @@
 import { Text, View } from "react-native";
 import { JazzProvider } from "jazz-tools/react-native";
 import { use } from "react";
-import { BrowserAuthSecretStore } from "jazz-tools";
+import { ExpoAuthSecretStore } from "jazz-tools/expo/auth-secret-store";
 
 function TodoApp() {
   return null;
@@ -9,7 +9,7 @@ function TodoApp() {
 
 // #region auth-localfirst-expo
 export function LocalFirstAuthExpoApp() {
-  const secret = use(BrowserAuthSecretStore.getOrCreateSecret());
+  const secret = use(ExpoAuthSecretStore.getOrCreateSecret());
 
   return (
     <JazzProvider
@@ -26,3 +26,20 @@ export function LocalFirstAuthExpoApp() {
   );
 }
 // #endregion auth-localfirst-expo
+
+// #region auth-localfirst-expo-backup
+export async function getRecoveryPhraseForBackup(): Promise<string | null> {
+  const secret = await ExpoAuthSecretStore.loadSecret();
+  if (!secret) return null;
+  const { RecoveryPhrase } = await import("jazz-tools/passphrase");
+  return RecoveryPhrase.fromSecret(secret);
+}
+// #endregion auth-localfirst-expo-backup
+
+// #region auth-localfirst-expo-restore
+export async function restoreFromRecoveryPhrase(userInput: string): Promise<void> {
+  const { RecoveryPhrase } = await import("jazz-tools/passphrase");
+  const secret = RecoveryPhrase.toSecret(userInput);
+  await ExpoAuthSecretStore.saveSecret(secret);
+}
+// #endregion auth-localfirst-expo-restore

--- a/examples/docs/todo-client-localfirst-react/src/auth-snippets.tsx
+++ b/examples/docs/todo-client-localfirst-react/src/auth-snippets.tsx
@@ -38,3 +38,20 @@ export function JwtAuthApp() {
   );
 }
 // #endregion auth-jwt-react
+
+// #region auth-localfirst-react-backup
+export async function getRecoveryPhraseForBackup(): Promise<string | null> {
+  const secret = await BrowserAuthSecretStore.loadSecret();
+  if (!secret) return null;
+  const { RecoveryPhrase } = await import("jazz-tools/passphrase");
+  return RecoveryPhrase.fromSecret(secret);
+}
+// #endregion auth-localfirst-react-backup
+
+// #region auth-localfirst-react-restore
+export async function restoreFromRecoveryPhrase(userInput: string): Promise<void> {
+  const { RecoveryPhrase } = await import("jazz-tools/passphrase");
+  const secret = RecoveryPhrase.toSecret(userInput);
+  await BrowserAuthSecretStore.saveSecret(secret);
+}
+// #endregion auth-localfirst-react-restore

--- a/packages/jazz-tools/package.json
+++ b/packages/jazz-tools/package.json
@@ -79,6 +79,10 @@
       "react-native": "./dist/expo/auth-secret-store.js",
       "default": "./dist/expo/auth-secret-store.js"
     },
+    "./passphrase": {
+      "types": "./dist/passphrase.d.ts",
+      "default": "./dist/passphrase.js"
+    },
     "./package.json": "./package.json"
   },
   "publishConfig": {
@@ -98,6 +102,7 @@
     "pack:dry-run": "npm pack --dry-run"
   },
   "dependencies": {
+    "@scure/bip39": "^2.0.1",
     "@standard-schema/spec": "^1.1.0",
     "esbuild": "^0.27.0",
     "jazz-rn": "workspace:*",

--- a/packages/jazz-tools/src/expo/auth-secret-store.test.ts
+++ b/packages/jazz-tools/src/expo/auth-secret-store.test.ts
@@ -75,4 +75,19 @@ describe("ExpoAuthSecretStore", () => {
     await store.saveSecret("test-secret");
     expect(await secureStore.getItemAsync("jazz-auth-secret")).toBe("test-secret");
   });
+
+  it("saveSecret updates getOrCreateSecret's cache", async () => {
+    const first = await store.getOrCreateSecret();
+    const replacement = "replacement-secret-base64url-value-xyz";
+    expect(replacement).not.toBe(first);
+    await store.saveSecret(replacement);
+    expect(await store.getOrCreateSecret()).toBe(replacement);
+  });
+
+  it("saveSecret updates loadSecret even after getOrCreateSecret was cached", async () => {
+    await store.getOrCreateSecret();
+    const replacement = "replacement-secret-base64url-value-xyz";
+    await store.saveSecret(replacement);
+    expect(await store.loadSecret()).toBe(replacement);
+  });
 });

--- a/packages/jazz-tools/src/expo/auth-secret-store.ts
+++ b/packages/jazz-tools/src/expo/auth-secret-store.ts
@@ -41,6 +41,7 @@ export class ExpoAuthSecretStore implements AuthSecretStore {
 
   async saveSecret(secret: string): Promise<void> {
     await this.store.setItemAsync(this.key, secret);
+    this.cachedPromise = Promise.resolve(secret);
   }
 
   async clearSecret(): Promise<void> {

--- a/packages/jazz-tools/src/passphrase.ts
+++ b/packages/jazz-tools/src/passphrase.ts
@@ -1,0 +1,1 @@
+export { RecoveryPhrase, RecoveryPhraseError } from "./runtime/recovery-phrase.js";

--- a/packages/jazz-tools/src/runtime/auth-secret-store.test.ts
+++ b/packages/jazz-tools/src/runtime/auth-secret-store.test.ts
@@ -87,4 +87,19 @@ describe("BrowserAuthSecretStore", () => {
     await store.saveSecret("test-secret");
     expect(storage.getItem("jazz-auth-secret")).toBe("test-secret");
   });
+
+  it("saveSecret updates getOrCreateSecret's cache", async () => {
+    const first = await store.getOrCreateSecret();
+    const replacement = generateAuthSecret();
+    expect(replacement).not.toBe(first);
+    await store.saveSecret(replacement);
+    expect(await store.getOrCreateSecret()).toBe(replacement);
+  });
+
+  it("saveSecret updates loadSecret even after getOrCreateSecret was cached", async () => {
+    await store.getOrCreateSecret();
+    const replacement = generateAuthSecret();
+    await store.saveSecret(replacement);
+    expect(await store.loadSecret()).toBe(replacement);
+  });
 });

--- a/packages/jazz-tools/src/runtime/auth-secret-store.ts
+++ b/packages/jazz-tools/src/runtime/auth-secret-store.ts
@@ -68,6 +68,7 @@ export class BrowserAuthSecretStore implements AuthSecretStore {
 
   async saveSecret(secret: string): Promise<void> {
     this.storage.setItem(this.key, secret);
+    this.cachedPromise = Promise.resolve(secret);
   }
 
   async clearSecret(): Promise<void> {

--- a/packages/jazz-tools/src/runtime/recovery-phrase.integration.test.ts
+++ b/packages/jazz-tools/src/runtime/recovery-phrase.integration.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from "vitest";
+import { BrowserAuthSecretStore } from "./auth-secret-store.js";
+import { ExpoAuthSecretStore } from "../expo/auth-secret-store.js";
+import { RecoveryPhrase } from "./recovery-phrase.js";
+import { createDb } from "./db.js";
+
+function createMockStorage(): Pick<Storage, "getItem" | "setItem" | "removeItem"> {
+  const map = new Map<string, string>();
+  return {
+    getItem: (k) => map.get(k) ?? null,
+    setItem: (k, v) => {
+      map.set(k, v);
+    },
+    removeItem: (k) => {
+      map.delete(k);
+    },
+  };
+}
+
+function createMockSecureStore() {
+  const map = new Map<string, string>();
+  return {
+    getItemAsync: (k: string) => Promise.resolve(map.get(k) ?? null),
+    setItemAsync: (k: string, v: string) => {
+      map.set(k, v);
+      return Promise.resolve();
+    },
+    deleteItemAsync: (k: string) => {
+      map.delete(k);
+      return Promise.resolve();
+    },
+  };
+}
+
+describe("RecoveryPhrase integration — BrowserAuthSecretStore", () => {
+  it("round-trips a secret through backup + restore", async () => {
+    const originStorage = createMockStorage();
+    const origin = new BrowserAuthSecretStore({ storage: originStorage });
+    const original = await origin.getOrCreateSecret();
+
+    const phrase = RecoveryPhrase.fromSecret(original);
+    const restored = RecoveryPhrase.toSecret(phrase);
+    expect(restored).toBe(original);
+
+    const targetStorage = createMockStorage();
+    const target = new BrowserAuthSecretStore({ storage: targetStorage });
+    await target.saveSecret(restored);
+    expect(await target.loadSecret()).toBe(original);
+  });
+});
+
+describe("RecoveryPhrase integration — ExpoAuthSecretStore", () => {
+  it("round-trips a secret through backup + restore", async () => {
+    const originSecureStore = createMockSecureStore();
+    const origin = new ExpoAuthSecretStore({ secureStore: originSecureStore });
+    const original = await origin.getOrCreateSecret();
+
+    const phrase = RecoveryPhrase.fromSecret(original);
+    const restored = RecoveryPhrase.toSecret(phrase);
+    expect(restored).toBe(original);
+
+    const targetSecureStore = createMockSecureStore();
+    const target = new ExpoAuthSecretStore({ secureStore: targetSecureStore });
+    await target.saveSecret(restored);
+    expect(await target.loadSecret()).toBe(original);
+  });
+});
+
+describe("RecoveryPhrase integration — restore over an existing session", () => {
+  it("overwrites the browser store's primed cache so the next getOrCreateSecret returns the restored secret", async () => {
+    const storage = createMockStorage();
+    const store = new BrowserAuthSecretStore({ storage });
+    const original = await store.getOrCreateSecret();
+
+    const phrase = RecoveryPhrase.fromSecret(original);
+    const replacementBytes = new Uint8Array(32).fill(7);
+    let binary = "";
+    for (const b of replacementBytes) binary += String.fromCharCode(b);
+    const replacement = btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+    expect(replacement).not.toBe(original);
+    expect(RecoveryPhrase.fromSecret(replacement)).not.toBe(phrase);
+
+    await store.saveSecret(replacement);
+    expect(await store.getOrCreateSecret()).toBe(replacement);
+  });
+});
+
+describe("RecoveryPhrase integration — identity continuity", () => {
+  it("two createDb calls with secrets derived from the same phrase yield the same user_id", async () => {
+    const originStorage = createMockStorage();
+    const origin = new BrowserAuthSecretStore({ storage: originStorage });
+    const originalSecret = await origin.getOrCreateSecret();
+
+    const phrase = RecoveryPhrase.fromSecret(originalSecret);
+    const restoredSecret = RecoveryPhrase.toSecret(phrase);
+
+    const dbA = await createDb({
+      appId: "recovery-phrase-test",
+      auth: { localFirstSecret: originalSecret },
+    });
+    const dbB = await createDb({
+      appId: "recovery-phrase-test",
+      auth: { localFirstSecret: restoredSecret },
+    });
+
+    try {
+      const idA = dbA.getAuthState().session?.user_id ?? null;
+      const idB = dbB.getAuthState().session?.user_id ?? null;
+      expect(idA).not.toBeNull();
+      expect(idB).toBe(idA);
+    } finally {
+      await dbA.shutdown();
+      await dbB.shutdown();
+    }
+  });
+});

--- a/packages/jazz-tools/src/runtime/recovery-phrase.test.ts
+++ b/packages/jazz-tools/src/runtime/recovery-phrase.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from "vitest";
+import { RecoveryPhrase, RecoveryPhraseError } from "./recovery-phrase.js";
+
+const ZERO_SECRET = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+const ZERO_PHRASE =
+  "abandon abandon abandon abandon abandon abandon abandon abandon " +
+  "abandon abandon abandon abandon abandon abandon abandon abandon " +
+  "abandon abandon abandon abandon abandon abandon abandon art";
+
+describe("RecoveryPhrase.fromSecret", () => {
+  it("encodes a 32-byte base64url secret as 24 BIP39 English words", () => {
+    const phrase = RecoveryPhrase.fromSecret(ZERO_SECRET);
+    expect(phrase.split(" ")).toHaveLength(24);
+    expect(phrase).toBe(ZERO_PHRASE);
+  });
+
+  it("produces a lowercase single-space-separated phrase", () => {
+    const phrase = RecoveryPhrase.fromSecret(ZERO_SECRET);
+    expect(phrase).toBe(phrase.toLowerCase());
+    expect(phrase).not.toMatch(/\s{2,}/);
+    expect(phrase.trim()).toBe(phrase);
+  });
+});
+
+describe("RecoveryPhrase.toSecret", () => {
+  it("decodes the canonical phrase back to the original secret", () => {
+    expect(RecoveryPhrase.toSecret(ZERO_PHRASE)).toBe(ZERO_SECRET);
+  });
+});
+
+describe("RecoveryPhrase round-trip", () => {
+  it("round-trips 10 random 32-byte secrets", () => {
+    for (let i = 0; i < 10; i += 1) {
+      const bytes = new Uint8Array(32);
+      crypto.getRandomValues(bytes);
+      let binary = "";
+      for (const b of bytes) binary += String.fromCharCode(b);
+      const secret = btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+
+      const phrase = RecoveryPhrase.fromSecret(secret);
+      expect(RecoveryPhrase.toSecret(phrase)).toBe(secret);
+    }
+  });
+});
+
+const VALID_PHRASE =
+  "abandon abandon abandon abandon abandon abandon abandon abandon " +
+  "abandon abandon abandon abandon abandon abandon abandon abandon " +
+  "abandon abandon abandon abandon abandon abandon abandon art";
+
+function expectCode(fn: () => unknown, code: RecoveryPhraseError["code"]) {
+  try {
+    fn();
+  } catch (err) {
+    expect(err).toBeInstanceOf(RecoveryPhraseError);
+    expect((err as RecoveryPhraseError).code).toBe(code);
+    return;
+  }
+  throw new Error(`expected ${code} but function did not throw`);
+}
+
+describe("RecoveryPhrase.toSecret — normalization", () => {
+  it("accepts UPPER CASE", () => {
+    expect(RecoveryPhrase.toSecret(VALID_PHRASE.toUpperCase())).toBeTypeOf("string");
+  });
+
+  it("accepts leading and trailing whitespace", () => {
+    expect(RecoveryPhrase.toSecret(`   ${VALID_PHRASE}\n\t`)).toBeTypeOf("string");
+  });
+
+  it("accepts multiple spaces, tabs, and newlines between words", () => {
+    const weird = VALID_PHRASE.split(" ").join("  \n\t");
+    expect(RecoveryPhrase.toSecret(weird)).toBeTypeOf("string");
+  });
+});
+
+describe("RecoveryPhrase.toSecret — errors", () => {
+  it("throws invalid-length for 23 words", () => {
+    const short = VALID_PHRASE.split(" ").slice(0, 23).join(" ");
+    expectCode(() => RecoveryPhrase.toSecret(short), "invalid-length");
+  });
+
+  it("throws invalid-length for 25 words", () => {
+    const long = VALID_PHRASE + " art";
+    expectCode(() => RecoveryPhrase.toSecret(long), "invalid-length");
+  });
+
+  it("throws invalid-word when a word is not in the list", () => {
+    const bad = VALID_PHRASE.replace(/art$/, "notaword");
+    expectCode(() => RecoveryPhrase.toSecret(bad), "invalid-word");
+  });
+
+  it("throws invalid-checksum when the last word does not match", () => {
+    const badChecksum = VALID_PHRASE.replace(/art$/, "zoo");
+    expectCode(() => RecoveryPhrase.toSecret(badChecksum), "invalid-checksum");
+  });
+});
+
+describe("RecoveryPhrase.fromSecret — errors", () => {
+  it("throws invalid-secret for a non-base64url string", () => {
+    expectCode(() => RecoveryPhrase.fromSecret("this is not base64url!!!"), "invalid-secret");
+  });
+
+  it("throws invalid-secret for a base64url string that decodes to !=32 bytes", () => {
+    const tooShort = "AAAAAAAAAAAAAAAAAAAAAA";
+    expectCode(() => RecoveryPhrase.fromSecret(tooShort), "invalid-secret");
+  });
+
+  it("throws invalid-secret for non-string input", () => {
+    expectCode(() => RecoveryPhrase.fromSecret(undefined as unknown as string), "invalid-secret");
+  });
+});

--- a/packages/jazz-tools/src/runtime/recovery-phrase.ts
+++ b/packages/jazz-tools/src/runtime/recovery-phrase.ts
@@ -1,0 +1,94 @@
+import { entropyToMnemonic, mnemonicToEntropy } from "@scure/bip39";
+import { wordlist } from "@scure/bip39/wordlists/english.js";
+
+export type RecoveryPhraseErrorCode =
+  | "invalid-word"
+  | "invalid-checksum"
+  | "invalid-length"
+  | "invalid-secret";
+
+export class RecoveryPhraseError extends Error {
+  readonly code: RecoveryPhraseErrorCode;
+  constructor(code: RecoveryPhraseErrorCode, message: string) {
+    super(message);
+    this.name = "RecoveryPhraseError";
+    this.code = code;
+  }
+}
+
+const WORDSET = new Set(wordlist);
+
+function base64urlToBytes(input: string): Uint8Array {
+  const normalized = input.replace(/-/g, "+").replace(/_/g, "/");
+  const padding = normalized.length % 4;
+  const padded = padding === 0 ? normalized : normalized + "=".repeat(4 - padding);
+  const binary = atob(padded);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+function bytesToBase64url(bytes: Uint8Array): string {
+  let binary = "";
+  for (const b of bytes) binary += String.fromCharCode(b);
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function normalize(phrase: string): string[] {
+  const trimmed = phrase.trim();
+  if (trimmed.length === 0) return [];
+  return trimmed.toLowerCase().split(/\s+/u);
+}
+
+export const RecoveryPhrase = {
+  fromSecret(secret: string): string {
+    if (typeof secret !== "string") {
+      throw new RecoveryPhraseError("invalid-secret", "Secret must be a string");
+    }
+    let bytes: Uint8Array;
+    try {
+      bytes = base64urlToBytes(secret);
+    } catch {
+      throw new RecoveryPhraseError("invalid-secret", "Secret is not valid base64url");
+    }
+    if (bytes.length !== 32) {
+      throw new RecoveryPhraseError(
+        "invalid-secret",
+        `Secret must decode to 32 bytes, got ${bytes.length}`,
+      );
+    }
+    return entropyToMnemonic(bytes, wordlist);
+  },
+
+  toSecret(phrase: string): string {
+    if (typeof phrase !== "string") {
+      throw new RecoveryPhraseError("invalid-length", "Phrase must be a string");
+    }
+    const words = normalize(phrase);
+    if (words.length !== 24) {
+      throw new RecoveryPhraseError("invalid-length", `Expected 24 words, got ${words.length}`);
+    }
+    for (let i = 0; i < words.length; i += 1) {
+      const word = words[i]!;
+      if (!WORDSET.has(word)) {
+        throw new RecoveryPhraseError(
+          "invalid-word",
+          `Word ${i + 1} ("${word}") is not in the recovery word list`,
+        );
+      }
+    }
+    let bytes: Uint8Array;
+    try {
+      bytes = mnemonicToEntropy(words.join(" "), wordlist);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (/checksum/i.test(message)) {
+        throw new RecoveryPhraseError("invalid-checksum", "Recovery phrase checksum is invalid");
+      }
+      throw new RecoveryPhraseError("invalid-length", message);
+    }
+    return bytesToBase64url(bytes);
+  },
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1113,6 +1113,9 @@ importers:
 
   packages/jazz-tools:
     dependencies:
+      '@scure/bip39':
+        specifier: ^2.0.1
+        version: 2.0.1
       '@standard-schema/spec':
         specifier: ^1.1.0
         version: 1.1.0
@@ -5167,6 +5170,12 @@ packages:
     resolution: {integrity: sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==}
     cpu: [x64]
     os: [win32]
+
+  '@scure/base@2.0.0':
+    resolution: {integrity: sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==}
+
+  '@scure/bip39@2.0.1':
+    resolution: {integrity: sha512-PsxdFj/d2AcJcZDX1FXN3dDgitDDTmwf78rKZq1a6c1P1Nan1X/Sxc7667zU3U+AN60g7SxxP0YCVw2H/hBycg==}
 
   '@shikijs/core@3.23.0':
     resolution: {integrity: sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==}
@@ -16091,6 +16100,13 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.59.0':
     optional: true
 
+  '@scure/base@2.0.0': {}
+
+  '@scure/bip39@2.0.1':
+    dependencies:
+      '@noble/hashes': 2.0.1
+      '@scure/base': 2.0.0
+
   '@shikijs/core@3.23.0':
     dependencies:
       '@shikijs/types': 3.23.0
@@ -17156,7 +17172,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vitest: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@20.19.35)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.1(@types/node@20.19.35)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      vitest: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.19.13)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jsdom@26.1.0)(vite@8.0.1(@types/node@22.19.13)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   '@vitest/utils@4.1.0':
     dependencies:


### PR DESCRIPTION
This PR adds a RecoveryPhrase primitive to work as building block for letting users to implement the same BIP39 passhprase flow we have in Jazz1

Making the primitive first, then going to think about how to compose it in the normal auth flows.

Since the API is syncronous, I think it would work nicely in composition with a `useLocalFirstAuth` API

Current API:

```ts
export async function restoreFromRecoveryPhrase(userInput: string): Promise<void> {
  const secret = RecoveryPhrase.toSecret(userInput);
  await BrowserAuthSecretStore.saveSecret(secret);
}
```

Possible generic hook for lofi auth:
```ts
function UserSettings() {
   const auth = useLocalFirstAuth();
   const currentRecoveryPhrase = auth.secret ? RecoveryPhrase.fromSecret(auth.secret) : undefined;
   
   function handleLogin(userInput: string) {
      auth.login(RecoveryPhrase.toSecret(userInput))
   }
}
```

Explicit, composable, clean.