### PR TITLE
Make auth expiry deterministic in tests

### DIFF
--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -1424,6 +1424,7 @@ impl DevServer {
             allow_local_first_auth: opts.allow_local_first_auth.unwrap_or(true),
             backend_secret: opts.backend_secret.clone(),
             admin_secret: opts.admin_secret.clone(),
+            ..Default::default()
         };
 
         let in_memory = opts.in_memory.unwrap_or(false);

--- a/crates/jazz-tools/src/identity.rs
+++ b/crates/jazz-tools/src/identity.rs
@@ -61,10 +61,7 @@ pub fn mint_local_first_token(
     audience: &str,
     ttl_seconds: u64,
 ) -> Result<String, String> {
-    let now = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map_err(|e| e.to_string())?
-        .as_secs();
+    let now = current_unix_timestamp_secs()?;
     mint_local_first_token_at(seed, audience, ttl_seconds, now)
 }
 
@@ -122,10 +119,11 @@ pub fn verify_local_first_identity_proof(
     token: &str,
     expected_audience: &str,
 ) -> Result<VerifiedLocalFirst, String> {
-    verify_local_first_identity_proof_with_max_ttl(
+    verify_local_first_identity_proof_with_max_ttl_at(
         token,
         expected_audience,
         DEFAULT_MAX_TTL_SECONDS,
+        current_unix_timestamp_secs()?,
     )
 }
 
@@ -133,6 +131,33 @@ pub fn verify_local_first_identity_proof_with_max_ttl(
     token: &str,
     expected_audience: &str,
     max_ttl_seconds: u64,
+) -> Result<VerifiedLocalFirst, String> {
+    verify_local_first_identity_proof_with_max_ttl_at(
+        token,
+        expected_audience,
+        max_ttl_seconds,
+        current_unix_timestamp_secs()?,
+    )
+}
+
+pub fn verify_local_first_identity_proof_at(
+    token: &str,
+    expected_audience: &str,
+    now_seconds: u64,
+) -> Result<VerifiedLocalFirst, String> {
+    verify_local_first_identity_proof_with_max_ttl_at(
+        token,
+        expected_audience,
+        DEFAULT_MAX_TTL_SECONDS,
+        now_seconds,
+    )
+}
+
+pub fn verify_local_first_identity_proof_with_max_ttl_at(
+    token: &str,
+    expected_audience: &str,
+    max_ttl_seconds: u64,
+    now_seconds: u64,
 ) -> Result<VerifiedLocalFirst, String> {
     // Normalize expected audience the same way as minting
     let normalized_expected = match Uuid::parse_str(expected_audience) {
@@ -223,10 +248,7 @@ pub fn verify_local_first_identity_proof_with_max_ttl(
     let iat = claims.iat.ok_or("missing iat")?;
     let exp = claims.exp.ok_or("missing exp")?;
 
-    let now = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map_err(|e| e.to_string())?
-        .as_secs();
+    let now = now_seconds;
 
     // iat must not be in the future (allow 60s clock skew)
     if iat > now + 60 {
@@ -246,6 +268,13 @@ pub fn verify_local_first_identity_proof_with_max_ttl(
         user_id: derived_user_id.to_string(),
         public_key_bytes: pub_key_bytes,
     })
+}
+
+fn current_unix_timestamp_secs() -> Result<u64, String> {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|e| e.to_string())
+        .map(|duration| duration.as_secs())
 }
 
 /// Derive a signing key from a 32-byte seed and a domain string.

--- a/crates/jazz-tools/src/main.rs
+++ b/crates/jazz-tools/src/main.rs
@@ -151,6 +151,7 @@ async fn main() {
                 allow_local_first_auth,
                 backend_secret,
                 admin_secret,
+                ..Default::default()
             };
             let catalogue_authority = match catalogue_authority {
                 CatalogueAuthorityArg::Local => CatalogueAuthorityMode::Local,

--- a/crates/jazz-tools/src/middleware/auth.rs
+++ b/crates/jazz-tools/src/middleware/auth.rs
@@ -21,6 +21,7 @@
 //! 3. No session
 
 use std::collections::HashMap;
+use std::fmt;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -65,6 +66,72 @@ pub type ExternalIdentityMap = HashMap<(String, String), String>;
 // Auth Configuration
 // ============================================================================
 
+#[derive(Clone)]
+pub struct AuthClock {
+    now_seconds: Arc<dyn Fn() -> u64 + Send + Sync>,
+}
+
+impl AuthClock {
+    pub fn system() -> Self {
+        Self {
+            now_seconds: Arc::new(system_now_seconds),
+        }
+    }
+
+    pub fn now_seconds(&self) -> u64 {
+        (self.now_seconds)()
+    }
+}
+
+impl Default for AuthClock {
+    fn default() -> Self {
+        Self::system()
+    }
+}
+
+impl fmt::Debug for AuthClock {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("AuthClock").finish_non_exhaustive()
+    }
+}
+
+#[cfg(feature = "test-utils")]
+#[derive(Clone, Debug)]
+pub struct TestClock {
+    now_seconds: Arc<AtomicU64>,
+}
+
+#[cfg(feature = "test-utils")]
+impl TestClock {
+    pub fn new(now_seconds: u64) -> Self {
+        Self {
+            now_seconds: Arc::new(AtomicU64::new(now_seconds)),
+        }
+    }
+
+    pub fn now_seconds(&self) -> u64 {
+        self.now_seconds.load(Ordering::SeqCst)
+    }
+
+    pub fn set(&self, now_seconds: u64) {
+        self.now_seconds.store(now_seconds, Ordering::SeqCst);
+    }
+
+    pub fn advance(&self, delta: Duration) {
+        self.now_seconds
+            .fetch_add(delta.as_secs(), Ordering::SeqCst);
+    }
+}
+
+#[cfg(feature = "test-utils")]
+impl From<TestClock> for AuthClock {
+    fn from(clock: TestClock) -> Self {
+        Self {
+            now_seconds: Arc::new(move || clock.now_seconds()),
+        }
+    }
+}
+
 /// Authentication configuration for the server.
 #[derive(Debug, Clone, Default)]
 pub struct AuthConfig {
@@ -76,6 +143,8 @@ pub struct AuthConfig {
     pub backend_secret: Option<String>,
     /// Secret for admin operations (schema/policy sync).
     pub admin_secret: Option<String>,
+    /// Time source for auth expiry checks. Defaults to the system clock.
+    pub clock: AuthClock,
 }
 
 impl AuthConfig {
@@ -328,6 +397,21 @@ fn now_timestamp_us() -> u64 {
     }
 }
 
+fn system_now_seconds() -> u64 {
+    match SystemTime::now().duration_since(UNIX_EPOCH) {
+        Ok(duration) => duration.as_secs(),
+        Err(_) => 0,
+    }
+}
+
+fn local_first_auth_error(message: String) -> UnauthenticatedResponse {
+    if message.starts_with("token expired:") {
+        UnauthenticatedResponse::expired("JWT has expired")
+    } else {
+        UnauthenticatedResponse::invalid(message)
+    }
+}
+
 // ============================================================================
 // Extractors
 // ============================================================================
@@ -572,15 +656,10 @@ pub fn verify_jwt_signature_with_jwks(
     )))
 }
 
-fn ensure_jwt_not_expired(verified: &VerifiedJwt) -> Result<(), JwtError> {
+fn ensure_jwt_not_expired_at(verified: &VerifiedJwt, now: u64) -> Result<(), JwtError> {
     let Some(exp) = verified.exp else {
         return Ok(());
     };
-
-    let now = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs();
 
     if exp <= now {
         return Err(JwtError::Expired);
@@ -599,6 +678,14 @@ pub async fn validate_jwt_with_cache(
     token: &str,
     cache: &JwksCache,
 ) -> Result<VerifiedJwt, JwtError> {
+    validate_jwt_with_cache_at(token, cache, system_now_seconds()).await
+}
+
+pub async fn validate_jwt_with_cache_at(
+    token: &str,
+    cache: &JwksCache,
+    now_seconds: u64,
+) -> Result<VerifiedJwt, JwtError> {
     let cached_jwks = cache.load(false).await.map_err(|e| {
         warn!(error = %e, "failed to load cached JWKS");
         JwtError::Invalid("unable to load JWKS".to_string())
@@ -606,7 +693,7 @@ pub async fn validate_jwt_with_cache(
 
     match verify_jwt_signature_with_jwks(token, &cached_jwks) {
         Ok(verified) => {
-            ensure_jwt_not_expired(&verified)?;
+            ensure_jwt_not_expired_at(&verified, now_seconds)?;
             return Ok(verified);
         }
         Err(JwtVerificationError::Fatal(e)) => return Err(JwtError::Invalid(e)),
@@ -625,7 +712,7 @@ pub async fn validate_jwt_with_cache(
 
     match verify_jwt_signature_with_jwks(token, &refreshed_jwks) {
         Ok(verified) => {
-            ensure_jwt_not_expired(&verified)?;
+            ensure_jwt_not_expired_at(&verified, now_seconds)?;
             Ok(verified)
         }
         Err(JwtVerificationError::Retryable(e) | JwtVerificationError::Fatal(e)) => {
@@ -792,8 +879,12 @@ pub async fn extract_session(
                     "Self-signed auth is not enabled for this app",
                 ));
             }
-            let verified = identity::verify_local_first_identity_proof(token, &app_id.to_string())
-                .map_err(UnauthenticatedResponse::invalid)?;
+            let verified = identity::verify_local_first_identity_proof_at(
+                token,
+                &app_id.to_string(),
+                config.clock.now_seconds(),
+            )
+            .map_err(local_first_auth_error)?;
             return Ok(Some(Session {
                 user_id: verified.user_id,
                 claims: serde_json::json!({
@@ -804,7 +895,7 @@ pub async fn extract_session(
 
         // JWKS JWT path
         let jwt_result = if let Some(cache) = jwks_cache {
-            validate_jwt_with_cache(token, cache).await
+            validate_jwt_with_cache_at(token, cache, config.clock.now_seconds()).await
         } else {
             Err(JwtError::NoKeyConfigured)
         };
@@ -902,6 +993,7 @@ mod tests {
             allow_local_first_auth: false,
             backend_secret: Some("backend-secret-12345".to_string()),
             admin_secret: Some("admin-secret-67890".to_string()),
+            ..Default::default()
         }
     }
 
@@ -1224,6 +1316,7 @@ mod tests {
             allow_local_first_auth: true,
             backend_secret: None,
             admin_secret: None,
+            ..Default::default()
         }
     }
 
@@ -1263,6 +1356,42 @@ mod tests {
         headers.insert(AUTHORIZATION, format!("Bearer {token}").parse().unwrap());
         let result = extract_session(&headers, app_id, &config, None, None).await;
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn local_first_auth_expiry_uses_configured_test_clock() {
+        let app_id = test_app_id();
+        let clock = TestClock::new(1_700_000_000);
+        let config = AuthConfig {
+            allow_local_first_auth: true,
+            clock: clock.clone().into(),
+            ..Default::default()
+        };
+        let token = identity::mint_local_first_token_at(
+            &alice_seed(),
+            &app_id.to_string(),
+            5,
+            clock.now_seconds(),
+        )
+        .unwrap();
+
+        let mut headers = HeaderMap::new();
+        headers.insert(AUTHORIZATION, format!("Bearer {token}").parse().unwrap());
+
+        let session = extract_session(&headers, app_id, &config, None, None)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            session.user_id,
+            identity::derive_user_id(&alice_seed()).to_string()
+        );
+
+        clock.advance(Duration::from_secs(6));
+
+        let result = extract_session(&headers, app_id, &config, None, None).await;
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().code, UnauthenticatedCode::Expired);
     }
 
     #[tokio::test]

--- a/crates/jazz-tools/src/routes.rs
+++ b/crates/jazz-tools/src/routes.rs
@@ -1490,6 +1490,7 @@ mod tests {
             admin_secret: Some("admin-secret".to_string()),
             allow_local_first_auth: true,
             jwks_url: None,
+            ..Default::default()
         }
     }
 
@@ -1507,6 +1508,7 @@ mod tests {
             admin_secret: None,
             allow_local_first_auth: false,
             jwks_url: None,
+            ..Default::default()
         };
 
         ServerBuilder::new(AppId::from_name("test-app"))
@@ -1749,6 +1751,7 @@ mod tests {
                 admin_secret: Some("admin-secret".to_string()),
                 allow_local_first_auth: false,
                 jwks_url: None,
+                ..Default::default()
             })
             .with_in_memory_storage()
             .build()

--- a/crates/jazz-tools/src/server/testing.rs
+++ b/crates/jazz-tools/src/server/testing.rs
@@ -35,6 +35,7 @@ pub struct TestingServerBuilder {
     admin_secret: Option<String>,
     backend_secret: Option<String>,
     jwks_url: Option<String>,
+    auth_clock: Option<crate::middleware::auth::AuthClock>,
     sync_tracer: Option<crate::sync_tracer::SyncTracer>,
 }
 
@@ -113,6 +114,11 @@ impl TestingServerBuilder {
         self
     }
 
+    pub fn with_auth_clock(mut self, clock: crate::middleware::auth::TestClock) -> Self {
+        self.auth_clock = Some(clock.into());
+        self
+    }
+
     pub fn with_tracer(mut self, tracer: crate::sync_tracer::SyncTracer) -> Self {
         self.sync_tracer = Some(tracer);
         self
@@ -168,6 +174,7 @@ pub struct TestingServer {
     client_data_dirs: Mutex<Vec<OwnedTempDir>>,
     _owned_data_dir: Option<OwnedTempDir>,
     embedded_jwks_server: Option<TestingJwksServer>,
+    auth_clock: crate::middleware::auth::AuthClock,
 }
 
 impl TestingServer {
@@ -199,6 +206,7 @@ impl TestingServer {
             admin_secret,
             backend_secret,
             jwks_url,
+            auth_clock,
             sync_tracer,
         } = builder;
 
@@ -219,12 +227,14 @@ impl TestingServer {
 
         let admin_secret = admin_secret.unwrap_or_else(|| Self::ADMIN_SECRET.to_string());
         let backend_secret = backend_secret.unwrap_or_else(|| Self::BACKEND_SECRET.to_string());
+        let auth_clock = auth_clock.unwrap_or_default();
 
         let auth_config = AuthConfig {
             jwks_url: Some(jwks_url),
             allow_local_first_auth: true,
             backend_secret: Some(backend_secret.clone()),
             admin_secret: Some(admin_secret.clone()),
+            clock: auth_clock.clone(),
         };
 
         let server_builder = ServerBuilder::new(app_id).with_auth_config(auth_config);
@@ -264,6 +274,7 @@ impl TestingServer {
             client_data_dirs: Mutex::new(Vec::new()),
             _owned_data_dir: owned_data_dir,
             embedded_jwks_server,
+            auth_clock,
         }
     }
 
@@ -276,10 +287,14 @@ impl TestingServer {
     }
 
     pub fn jwt_for_user_with_claims(sub: &str, claims: JsonValue) -> String {
+        Self::jwt_for_user_with_claims_at(sub, claims, SystemTime::now())
+    }
+
+    fn jwt_for_user_with_claims_at(sub: &str, claims: JsonValue, now: SystemTime) -> String {
         let claims = JwtClaims {
             sub: sub.to_string(),
             claims,
-            exp: SystemTime::now()
+            exp: now
                 .duration_since(UNIX_EPOCH)
                 .expect("clock drift")
                 .as_secs()
@@ -374,6 +389,7 @@ impl TestingServer {
             .expect("lock test client data dirs")
             .push(client_data_dir);
 
+        let jwt_token = self.jwt_for_user_for_server_clock(user_id.as_ref());
         AppContext {
             app_id: self.app_id,
             client_id: None,
@@ -381,7 +397,7 @@ impl TestingServer {
             server_url: self.base_url(),
             data_dir,
             storage: crate::ClientStorage::Memory,
-            jwt_token: Some(Self::jwt_for_user(user_id.as_ref())),
+            jwt_token: Some(jwt_token),
             backend_secret: Some(self.backend_secret.clone()),
             admin_secret: Some(self.admin_secret.clone()),
             sync_tracer: None,
@@ -395,6 +411,11 @@ impl TestingServer {
 
     pub async fn shutdown(mut self) {
         self.hosted.shutdown().await;
+    }
+
+    fn jwt_for_user_for_server_clock(&self, sub: &str) -> String {
+        let now = UNIX_EPOCH + Duration::from_secs(self.auth_clock.now_seconds());
+        Self::jwt_for_user_with_claims_at(sub, json!({"role": "user"}), now)
     }
 }
 

--- a/crates/jazz-tools/tests/local_first_auth_integration.rs
+++ b/crates/jazz-tools/tests/local_first_auth_integration.rs
@@ -14,6 +14,7 @@ mod support;
 use std::collections::HashMap;
 use std::time::Duration;
 
+use jazz_tools::middleware::auth::TestClock;
 use jazz_tools::server::TestingServer;
 use jazz_tools::{
     AppContext, ClientStorage, ColumnType, JazzClient, QueryBuilder, Schema, SchemaBuilder,
@@ -382,16 +383,23 @@ async fn local_first_and_jwt_clients_coexist() {
 /// queued write flushes to the server.
 #[tokio::test]
 async fn expired_token_reconnect_flushes_queued_writes() {
-    let server = TestingServer::start_with_schema(test_schema()).await;
+    let auth_clock = TestClock::new(1_700_000_000);
+    let server = TestingServer::builder()
+        .with_schema(test_schema())
+        .with_auth_clock(auth_clock.clone())
+        .start()
+        .await;
 
     let audience = server.app_id().to_string();
     let seed = alice_seed();
 
-    // Base context with persistent storage; swap in a 1-second TTL token so we
-    // can drive it past expiry in the test timeline.
+    // Base context with persistent storage; swap in a token minted against the
+    // server's test auth clock so the test can advance expiry deterministically
+    // without sleeping on wall time.
     let mut ctx = local_first_context(&server, test_schema(), &seed, ClientStorage::Persistent);
     ctx.jwt_token = Some(
-        identity::mint_local_first_token(&seed, &audience, 1).expect("mint short-lived token"),
+        identity::mint_local_first_token_at(&seed, &audience, 5, auth_clock.now_seconds())
+            .expect("mint short-lived token"),
     );
 
     let client = JazzClient::connect(ctx.clone())
@@ -411,8 +419,9 @@ async fn expired_token_reconnect_flushes_queued_writes() {
     )
     .await;
 
-    // Let the token lapse. 1s TTL + 1500ms yields a definitively-expired token.
-    tokio::time::sleep(Duration::from_millis(1500)).await;
+    // Advance the server's auth clock past the token TTL. The live client keeps
+    // running; only subsequent server auth checks see the token as expired.
+    auth_clock.advance(Duration::from_secs(6));
 
     // Post-expiry write: commit succeeds locally even though the server would
     // now reject the bearer token on sync.
@@ -427,8 +436,13 @@ async fn expired_token_reconnect_flushes_queued_writes() {
     // write replays.
     let mut fresh_ctx = ctx.clone();
     fresh_ctx.jwt_token = Some(
-        identity::mint_local_first_token(&seed, &audience, TOKEN_TTL_SECS)
-            .expect("mint refreshed token"),
+        identity::mint_local_first_token_at(
+            &seed,
+            &audience,
+            TOKEN_TTL_SECS,
+            auth_clock.now_seconds(),
+        )
+        .expect("mint refreshed token"),
     );
 
     let reconnected = JazzClient::connect(fresh_ctx)


### PR DESCRIPTION
## What changed

- added an injectable auth clock for server-side token expiry checks
- threaded a `TestClock` through `TestingServer` so auth-sensitive integration tests can control time explicitly
- rewrote `expired_token_reconnect_flushes_queued_writes` to advance auth time instead of sleeping against wall clock
- mapped expired local-first auth failures to `expired` rather than generic `invalid`

## Why

The flaky CI failure was happening before queued-write replay: the test minted a token with a 1 second TTL, and CI could lose the race during the initial connect path before the reconnect behavior was exercised.

Using an explicit auth clock makes the test deterministic and keeps the reconnect/replay assertion focused on the behavior it actually cares about.

## Impact

- removes wall-clock timing from this integration test path
- makes local-first auth expiry tests deterministic
- preserves production behavior by defaulting to system time outside tests

## Validation

- `cargo fmt --all`
- `cargo test -p jazz-tools --lib local_first_auth_expiry_uses_configured_test_clock --features test`
- `cargo test -p jazz-tools --test local_first_auth --features test`
- `cargo test -p jazz-tools --test local_first_auth_integration --features test`
- `cargo test -p jazz-tools --bin jazz-tools server_command_parses_allow_local_first_auth_flag --features test`