### PR TITLE
fix: start server in RowPolicyMode::Enforcing

### DIFF
--- a/crates/jazz-tools/src/query_manager/manager.rs
+++ b/crates/jazz-tools/src/query_manager/manager.rs
@@ -521,6 +521,15 @@ impl QueryManager {
         self.authorization_schema_required = true;
     }
 
+    #[cfg(test)]
+    pub(crate) fn debug_authorization_state(&self) -> (RowPolicyMode, bool, bool) {
+        (
+            self.row_policy_mode,
+            self.authorization_schema_required,
+            self.authorization_schema.is_some(),
+        )
+    }
+
     /// Add a live schema (one we can read from but don't write to).
     ///
     /// Creates indices for the schema's branch.

--- a/crates/jazz-tools/src/query_manager/server_queries.rs
+++ b/crates/jazz-tools/src/query_manager/server_queries.rs
@@ -710,18 +710,6 @@ impl QueryManager {
                 deferred.push(sub);
                 continue;
             };
-            if self
-                .authorization_schema_for_context(
-                    &subscription_context.env,
-                    &subscription_context.user_branch,
-                )
-                .is_none()
-                && self.schema.is_empty()
-                && self.authorization_schema_required
-            {
-                deferred.push(sub);
-                continue;
-            }
 
             // Defence in depth: if the subscription has no session (client omitted
             // it), fall back to the connection-level session set during JWT auth

--- a/crates/jazz-tools/src/schema_manager/manager.rs
+++ b/crates/jazz-tools/src/schema_manager/manager.rs
@@ -213,7 +213,8 @@ impl SchemaManager {
     /// Queries are executed with explicit `QuerySchemaContext` rather than
     /// using implicit current schema context.
     pub fn new_server(sync_manager: SyncManager, app_id: AppId, _env: &str) -> Self {
-        let query_manager = QueryManager::new(sync_manager);
+        let mut query_manager = QueryManager::new(sync_manager);
+        query_manager.require_authorization_schema();
         Self {
             context: SchemaContext::empty(),
             query_manager,
@@ -1818,8 +1819,8 @@ mod tests {
     use super::*;
     use crate::query_manager::policy::PolicyExpr;
     use crate::query_manager::types::{
-        ColumnDescriptor, ColumnType, RowDescriptor, SchemaBuilder, SchemaHash, TableName,
-        TablePolicies, TableSchema,
+        ColumnDescriptor, ColumnType, RowDescriptor, RowPolicyMode, SchemaBuilder, SchemaHash,
+        TableName, TablePolicies, TableSchema,
     };
 
     fn test_app_id() -> AppId {
@@ -1871,6 +1872,18 @@ mod tests {
         assert_eq!(manager.env(), "dev");
         assert_eq!(manager.user_branch(), "main");
         assert_eq!(manager.app_id(), test_app_id());
+    }
+
+    #[test]
+    fn schema_manager_new_server_requires_authorization_schema_from_boot() {
+        let manager = SchemaManager::new_server(SyncManager::new(), test_app_id(), "dev");
+        let (row_policy_mode, authorization_schema_required, has_authorization_schema) =
+            manager.query_manager.debug_authorization_state();
+
+        assert!(!manager.has_current_schema());
+        assert!(matches!(row_policy_mode, RowPolicyMode::Enforcing));
+        assert!(authorization_schema_required);
+        assert!(!has_authorization_schema);
     }
 
     #[test]

--- a/crates/jazz-tools/tests/catalogue_sync_integration.rs
+++ b/crates/jazz-tools/tests/catalogue_sync_integration.rs
@@ -674,11 +674,10 @@ async fn catalogue_sync_e2e_schema_evolution_keeps_authorization_through_v1_head
     let v1_schema = schema_v1();
     publish_allow_all_permissions(&server.base_url(), server.admin_secret(), &v1_schema).await;
     push_catalogue_in_memory(
-        &server.base_url(),
+        server.server_state(),
         server.app_id(),
         "dev",
         "main",
-        server.admin_secret(),
         &[v1_schema, schema_v2()],
         &[v1_to_v2_lens()],
     )

--- a/crates/jazz-tools/tests/catalogue_sync_integration.rs
+++ b/crates/jazz-tools/tests/catalogue_sync_integration.rs
@@ -15,7 +15,11 @@ use jazz_tools::server::TestingServer;
 use jazz_tools::{
     ColumnType, DurabilityTier, JazzClient, QueryBuilder, SchemaBuilder, TableSchema, Value,
 };
-use support::{push_catalogue_in_memory, wait_for_edge_query_ready, wait_for_query};
+use support::{
+    TestingClient, deny_all_select_permissions, has_added, has_removed,
+    publish_allow_all_permissions, publish_permissions, push_catalogue_in_memory,
+    wait_for_edge_query_ready, wait_for_query, wait_for_subscription_update,
+};
 
 fn user_values_v1(id: jazz_tools::ObjectId, name: &str) -> HashMap<String, Value> {
     HashMap::from([
@@ -57,6 +61,389 @@ fn v1_to_v2_lens() -> Lens {
     generate_lens(&schema_v1(), &schema_v2())
 }
 
+/// A dynamic server should fail closed before any permissions head is
+/// published, then expose rows once an explicit head is installed.
+#[tokio::test]
+async fn dynamic_server_denies_reads_until_permissions_head_is_published() {
+    let server = TestingServer::start().await;
+    let schema = schema_v1();
+
+    let admin =
+        JazzClient::connect(server.make_client_context_for_user(schema.clone(), "admin-dynamic"))
+            .await
+            .expect("connect admin");
+    wait_for_edge_query_ready(&admin, "users", Duration::from_secs(30)).await;
+
+    let user_id_value = jazz_tools::ObjectId::new();
+    let (user_obj_id, _) = admin
+        .create(
+            "users",
+            user_values_v1(user_id_value, "hidden before permissions"),
+        )
+        .await
+        .expect("admin creates user");
+
+    wait_for_query(
+        &admin,
+        QueryBuilder::new("users").build(),
+        Some(DurabilityTier::EdgeServer),
+        Duration::from_secs(25),
+        "admin row settled at dynamic server",
+        |rows| (rows.len() == 1 && rows[0].0 == user_obj_id).then_some(rows),
+    )
+    .await;
+
+    let mut reader_context = server.make_client_context_for_user(schema.clone(), "reader-dynamic");
+    reader_context.backend_secret = None;
+    reader_context.admin_secret = None;
+    let reader = JazzClient::connect(reader_context)
+        .await
+        .expect("connect reader");
+    wait_for_edge_query_ready(&reader, "users", Duration::from_secs(30)).await;
+
+    let rows_before_permissions = wait_for_query(
+        &reader,
+        QueryBuilder::new("users").build(),
+        Some(DurabilityTier::EdgeServer),
+        Duration::from_secs(10),
+        "reader query before permissions head",
+        Some,
+    )
+    .await;
+    assert!(
+        rows_before_permissions.is_empty(),
+        "dynamic server should deny reads before any permissions head is published"
+    );
+
+    publish_allow_all_permissions(&server.base_url(), server.admin_secret(), &schema).await;
+
+    let rows_after_permissions = wait_for_query(
+        &reader,
+        QueryBuilder::new("users").build(),
+        Some(DurabilityTier::EdgeServer),
+        Duration::from_secs(25),
+        "reader sees row after permissions head publish",
+        |rows| (rows.len() == 1 && rows[0].0 == user_obj_id).then_some(rows),
+    )
+    .await;
+    assert_eq!(
+        rows_after_permissions[0].1,
+        vec![
+            Value::Uuid(user_id_value),
+            Value::Text("hidden before permissions".to_string()),
+        ]
+    );
+
+    admin.shutdown().await.expect("shutdown admin");
+    reader.shutdown().await.expect("shutdown reader");
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn dynamic_server_approves_queued_user_write_when_permissions_arrive_in_time() {
+    let server = TestingServer::start().await;
+    let schema = schema_v1();
+    let query = QueryBuilder::new("users").build();
+    let observer = TestingClient::builder()
+        .with_server(&server)
+        .with_schema(schema.clone())
+        .with_user_id("observer-queued-write")
+        .ready_on("users", Duration::from_secs(30))
+        .connect()
+        .await;
+    let writer = TestingClient::builder()
+        .with_server(&server)
+        .with_schema(schema.clone())
+        .with_user_id("writer-queued-write")
+        .as_user()
+        .ready_on("users", Duration::from_secs(30))
+        .connect()
+        .await;
+
+    let queued_user_id = jazz_tools::ObjectId::new();
+    let (queued_row_id, _) = writer
+        .create(
+            "users",
+            user_values_v1(queued_user_id, "queued before permissions"),
+        )
+        .await
+        .expect("optimistic local create before permissions");
+
+    let rows_before_permissions = wait_for_query(
+        &observer,
+        query.clone(),
+        Some(DurabilityTier::EdgeServer),
+        Duration::from_secs(5),
+        "observer query before permissions for queued write",
+        Some,
+    )
+    .await;
+    assert!(
+        rows_before_permissions.is_empty(),
+        "server should keep queued user writes invisible before permissions arrive"
+    );
+
+    publish_allow_all_permissions(&server.base_url(), server.admin_secret(), &schema).await;
+
+    let rows_after_publish = wait_for_query(
+        &observer,
+        query.clone(),
+        Some(DurabilityTier::EdgeServer),
+        Duration::from_secs(25),
+        "queued user write becomes visible after permissions publish",
+        |rows| (rows.len() == 1 && rows[0].0 == queued_row_id).then_some(rows),
+    )
+    .await;
+    assert_eq!(
+        rows_after_publish[0].1,
+        vec![
+            Value::Uuid(queued_user_id),
+            Value::Text("queued before permissions".to_string()),
+        ]
+    );
+
+    writer
+        .update_persisted(
+            queued_row_id,
+            vec![(
+                "name".to_string(),
+                Value::Text("updated after permissions".to_string()),
+            )],
+            DurabilityTier::EdgeServer,
+        )
+        .await
+        .expect("update should succeed once permissions exist");
+
+    let rows_after_update = wait_for_query(
+        &observer,
+        query.clone(),
+        Some(DurabilityTier::EdgeServer),
+        Duration::from_secs(25),
+        "observer sees update after permissions publish",
+        |rows| {
+            (rows.len() == 1
+                && rows[0].0 == queued_row_id
+                && rows[0].1
+                    == vec![
+                        Value::Uuid(queued_user_id),
+                        Value::Text("updated after permissions".to_string()),
+                    ])
+            .then_some(rows)
+        },
+    )
+    .await;
+    assert_eq!(rows_after_update.len(), 1);
+
+    writer
+        .delete_persisted(queued_row_id, DurabilityTier::EdgeServer)
+        .await
+        .expect("delete should succeed once permissions exist");
+
+    let rows_after_delete = wait_for_query(
+        &observer,
+        query,
+        Some(DurabilityTier::EdgeServer),
+        Duration::from_secs(25),
+        "observer sees delete after permissions publish",
+        |rows| rows.is_empty().then_some(rows),
+    )
+    .await;
+    assert!(rows_after_delete.is_empty());
+
+    observer.shutdown().await.expect("shutdown observer");
+    writer.shutdown().await.expect("shutdown writer");
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn dynamic_server_rejects_user_write_after_permissions_timeout() {
+    let server = TestingServer::start().await;
+    let schema = schema_v1();
+    let query = QueryBuilder::new("users").build();
+    let observer = TestingClient::builder()
+        .with_server(&server)
+        .with_schema(schema.clone())
+        .with_user_id("observer-timeout-write")
+        .ready_on("users", Duration::from_secs(30))
+        .connect()
+        .await;
+    let writer = TestingClient::builder()
+        .with_server(&server)
+        .with_schema(schema.clone())
+        .with_user_id("writer-timeout-write")
+        .as_user()
+        .ready_on("users", Duration::from_secs(30))
+        .connect()
+        .await;
+
+    let denied_user_id = jazz_tools::ObjectId::new();
+    let (denied_row_id, _) = writer
+        .create(
+            "users",
+            user_values_v1(denied_user_id, "timed out before permissions"),
+        )
+        .await
+        .expect("optimistic local create before timeout");
+
+    tokio::time::sleep(Duration::from_secs(12)).await;
+    let rows_after_timeout = wait_for_query(
+        &observer,
+        query.clone(),
+        Some(DurabilityTier::EdgeServer),
+        Duration::from_secs(5),
+        "observer query after timeout before permissions publish",
+        Some,
+    )
+    .await;
+    assert!(
+        rows_after_timeout.is_empty(),
+        "timed-out write should still be absent before permissions are published"
+    );
+    publish_allow_all_permissions(&server.base_url(), server.admin_secret(), &schema).await;
+
+    let allowed_user_id = jazz_tools::ObjectId::new();
+    let (allowed_row_id, _) = writer
+        .create_persisted(
+            "users",
+            user_values_v1(allowed_user_id, "accepted after timeout window"),
+            DurabilityTier::EdgeServer,
+        )
+        .await
+        .expect("create should succeed after permissions publish");
+
+    let observer_rows = wait_for_query(
+        &observer,
+        query,
+        Some(DurabilityTier::EdgeServer),
+        Duration::from_secs(25),
+        "observer sees only post-timeout allowed row",
+        |rows| (rows.len() == 1 && rows[0].0 == allowed_row_id).then_some(rows),
+    )
+    .await;
+    assert_eq!(observer_rows.len(), 1);
+    assert_eq!(observer_rows[0].0, allowed_row_id);
+    assert_ne!(
+        observer_rows[0].0, denied_row_id,
+        "timed-out row should stay rejected even after permissions arrive"
+    );
+    assert_eq!(
+        observer_rows[0].1,
+        vec![
+            Value::Uuid(allowed_user_id),
+            Value::Text("accepted after timeout window".to_string()),
+        ]
+    );
+
+    observer.shutdown().await.expect("shutdown observer");
+    writer.shutdown().await.expect("shutdown writer");
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn dynamic_server_live_subscription_replays_on_first_permissions_head_and_retightening() {
+    let server = TestingServer::start().await;
+    let schema = schema_v1();
+    let query = QueryBuilder::new("users").build();
+
+    let admin =
+        JazzClient::connect(server.make_client_context_for_user(schema.clone(), "admin-subscribe"))
+            .await
+            .expect("connect admin");
+    wait_for_edge_query_ready(&admin, "users", Duration::from_secs(30)).await;
+
+    let user_id_value = jazz_tools::ObjectId::new();
+    let (user_obj_id, _) = admin
+        .create(
+            "users",
+            user_values_v1(user_id_value, "subscription target"),
+        )
+        .await
+        .expect("admin creates user");
+
+    wait_for_query(
+        &admin,
+        query.clone(),
+        Some(DurabilityTier::EdgeServer),
+        Duration::from_secs(25),
+        "admin row settled for subscription test",
+        |rows| (rows.len() == 1 && rows[0].0 == user_obj_id).then_some(rows),
+    )
+    .await;
+
+    let reader = TestingClient::builder()
+        .with_server(&server)
+        .with_schema(schema.clone())
+        .with_user_id("reader-subscribe")
+        .as_user()
+        .ready_on("users", Duration::from_secs(30))
+        .connect()
+        .await;
+    let mut stream = reader
+        .subscribe(query.clone())
+        .await
+        .expect("subscribe reader before permissions");
+    let mut log = Vec::new();
+
+    wait_for_subscription_update(
+        &mut stream,
+        &mut log,
+        Duration::from_secs(10),
+        "initial empty subscription snapshot before permissions",
+        |updates| !updates.is_empty(),
+    )
+    .await;
+    assert!(
+        log[0].is_empty(),
+        "first subscription snapshot should fail closed as an empty delta"
+    );
+
+    let allow_head =
+        publish_allow_all_permissions(&server.base_url(), server.admin_secret(), &schema).await;
+    wait_for_subscription_update(
+        &mut stream,
+        &mut log,
+        Duration::from_secs(25),
+        "subscription add after first permissions head",
+        |updates| has_added(updates, user_obj_id),
+    )
+    .await;
+
+    publish_permissions(
+        &server.base_url(),
+        server.admin_secret(),
+        &schema,
+        deny_all_select_permissions(&schema),
+        Some(allow_head.bundle_object_id),
+    )
+    .await;
+    wait_for_subscription_update(
+        &mut stream,
+        &mut log,
+        Duration::from_secs(25),
+        "subscription remove after tighter permissions head",
+        |updates| has_removed(updates, user_obj_id),
+    )
+    .await;
+
+    let rows_after_retighten = wait_for_query(
+        &reader,
+        query,
+        Some(DurabilityTier::EdgeServer),
+        Duration::from_secs(25),
+        "reader query after tighter permissions head",
+        Some,
+    )
+    .await;
+    assert!(
+        rows_after_retighten.is_empty(),
+        "reader should lose visibility after permissions are tightened"
+    );
+
+    admin.shutdown().await.expect("shutdown admin");
+    reader.shutdown().await.expect("shutdown reader");
+    server.shutdown().await;
+}
+
 /// Alice writes under schema v1. The v2 schema and v1→v2 lens are pushed
 /// to the server via the real catalogue sync pipeline. Bob connects with
 /// schema v2 and sees Alice's data transformed through the lens.
@@ -73,6 +460,7 @@ fn v1_to_v2_lens() -> Lens {
 #[tokio::test]
 async fn catalogue_sync_e2e_schema_evolution_through_sync_manager() {
     let server = TestingServer::start().await;
+    let target_schema = schema_v2();
 
     // === Alice connects with v1, creates a user ===
     let alice =
@@ -110,10 +498,11 @@ async fn catalogue_sync_e2e_schema_evolution_through_sync_manager() {
     )
     .await
     .expect("push catalogue");
+    publish_allow_all_permissions(&server.base_url(), server.admin_secret(), &target_schema).await;
 
     // === Bob connects with v2, queries — should see Alice's row with email: null ===
     let bob =
-        JazzClient::connect(server.make_client_context_for_user(schema_v2(), "bob-catalogue"))
+        JazzClient::connect(server.make_client_context_for_user(target_schema, "bob-catalogue"))
             .await
             .expect("connect bob");
 
@@ -170,6 +559,7 @@ async fn catalogue_sync_e2e_schema_evolution_through_sync_manager() {
 #[tokio::test]
 async fn catalogue_sync_e2e_backward_data_migration_through_sync_manager() {
     let server = TestingServer::start().await;
+    let target_schema = schema_v2();
 
     // Seed the server with both schemas and the v1<->v2 lens before clients connect.
     push_catalogue_in_memory(
@@ -182,6 +572,7 @@ async fn catalogue_sync_e2e_backward_data_migration_through_sync_manager() {
     )
     .await
     .expect("push catalogue");
+    publish_allow_all_permissions(&server.base_url(), server.admin_secret(), &target_schema).await;
 
     // === Bob connects with v2, creates a user with the new email column ===
     let bob = JazzClient::connect(server.make_client_context_for_user(schema_v2(), "bob-backward"))
@@ -250,5 +641,74 @@ async fn catalogue_sync_e2e_backward_data_migration_through_sync_manager() {
 
     bob.shutdown().await.expect("shutdown bob");
     alice.shutdown().await.expect("shutdown alice");
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn catalogue_sync_e2e_schema_evolution_keeps_authorization_through_v1_head() {
+    let server = TestingServer::start().await;
+    let query = QueryBuilder::new("users").build();
+    let alice =
+        JazzClient::connect(server.make_client_context_for_user(schema_v1(), "alice-v1-head"))
+            .await
+            .expect("connect alice");
+
+    wait_for_edge_query_ready(&alice, "users", Duration::from_secs(30)).await;
+
+    let user_id_value = jazz_tools::ObjectId::new();
+    let (user_obj_id, _) = alice
+        .create("users", user_values_v1(user_id_value, "Alice Through Lens"))
+        .await
+        .expect("alice creates user");
+
+    wait_for_query(
+        &alice,
+        query.clone(),
+        Some(DurabilityTier::EdgeServer),
+        Duration::from_secs(25),
+        "alice row settled before v1 permissions publish",
+        |rows| (rows.len() == 1 && rows[0].0 == user_obj_id).then_some(rows),
+    )
+    .await;
+
+    let v1_schema = schema_v1();
+    publish_allow_all_permissions(&server.base_url(), server.admin_secret(), &v1_schema).await;
+    push_catalogue_in_memory(
+        &server.base_url(),
+        server.app_id(),
+        "dev",
+        "main",
+        server.admin_secret(),
+        &[v1_schema, schema_v2()],
+        &[v1_to_v2_lens()],
+    )
+    .await
+    .expect("push catalogue after v1 permissions head");
+
+    let bob = JazzClient::connect(server.make_client_context_for_user(schema_v2(), "bob-v2-head"))
+        .await
+        .expect("connect bob");
+    wait_for_edge_query_ready(&bob, "users", Duration::from_secs(30)).await;
+
+    let bob_rows = wait_for_query(
+        &bob,
+        query,
+        Some(DurabilityTier::EdgeServer),
+        Duration::from_secs(25),
+        "bob sees alice row through v1 authorization schema",
+        |rows| (rows.len() == 1 && rows[0].0 == user_obj_id).then_some(rows),
+    )
+    .await;
+    assert_eq!(
+        bob_rows[0].1,
+        vec![
+            Value::Uuid(user_id_value),
+            Value::Text("Alice Through Lens".to_string()),
+            Value::Null,
+        ]
+    );
+
+    alice.shutdown().await.expect("shutdown alice");
+    bob.shutdown().await.expect("shutdown bob");
     server.shutdown().await;
 }

--- a/crates/jazz-tools/tests/clients_sync.rs
+++ b/crates/jazz-tools/tests/clients_sync.rs
@@ -55,8 +55,8 @@ async fn wait_for_edge_query_ready(client: &JazzClient, timeout: Duration) {
 async fn fresh_client_resolves_object_with_deep_update_history() {
     const DEEP_HISTORY_UPDATES: usize = 100;
 
-    let server = TestingServer::start().await;
     let schema = test_schema();
+    let server = TestingServer::start_with_schema(schema.clone()).await;
     let writer =
         JazzClient::connect(server.make_client_context_for_user(schema.clone(), "alice-history"))
             .await
@@ -140,11 +140,12 @@ async fn fresh_client_resolves_object_with_deep_update_history() {
 
 #[tokio::test]
 async fn jazz_tools_cli_two_clients_sync_values() {
-    let server = TestingServer::start().await;
-    let client_a = JazzClient::connect(server.make_client_context(test_schema()))
+    let schema = test_schema();
+    let server = TestingServer::start_with_schema(schema.clone()).await;
+    let client_a = JazzClient::connect(server.make_client_context(schema.clone()))
         .await
         .expect("connect client a");
-    let client_b = JazzClient::connect(server.make_client_context(test_schema()))
+    let client_b = JazzClient::connect(server.make_client_context(schema))
         .await
         .expect("connect client b");
 
@@ -334,13 +335,14 @@ async fn upsert_uses_external_uuidv7_for_insert_and_updates_existing_row() {
 
 #[tokio::test]
 async fn jazz_tools_cli_two_different_users_sync_values() {
-    let server = TestingServer::start().await;
+    let schema = test_schema();
+    let server = TestingServer::start_with_schema(schema.clone()).await;
     let client_alice =
-        JazzClient::connect(server.make_client_context_for_user(test_schema(), "alice-sync-user"))
+        JazzClient::connect(server.make_client_context_for_user(schema.clone(), "alice-sync-user"))
             .await
             .expect("connect alice client");
     let client_bob =
-        JazzClient::connect(server.make_client_context_for_user(test_schema(), "bob-sync-user"))
+        JazzClient::connect(server.make_client_context_for_user(schema, "bob-sync-user"))
             .await
             .expect("connect bob client");
 

--- a/crates/jazz-tools/tests/disconnect_lifecycle_integration.rs
+++ b/crates/jazz-tools/tests/disconnect_lifecycle_integration.rs
@@ -37,8 +37,8 @@ fn test_schema() -> jazz_tools::Schema {
 /// ```
 #[tokio::test]
 async fn client_reconnects_after_server_reaps_stale_state() {
-    let server = TestingServer::start().await;
     let schema = test_schema();
+    let server = TestingServer::start_with_schema(schema.clone()).await;
 
     // Phase 1: Alice connects and creates a todo
     let alice = TestingClient::builder()
@@ -211,8 +211,8 @@ async fn client_reconnects_after_server_reaps_stale_state() {
 /// ```
 #[tokio::test]
 async fn sweep_reaps_disconnected_client_without_affecting_connected_client() {
-    let server = TestingServer::start().await;
     let schema = test_schema();
+    let server = TestingServer::start_with_schema(schema.clone()).await;
 
     let alice = TestingClient::builder()
         .with_server(&server)
@@ -337,8 +337,8 @@ async fn sweep_reaps_disconnected_client_without_affecting_connected_client() {
 /// ```
 #[tokio::test]
 async fn background_sweep_task_reaps_expired_candidates() {
-    let server = TestingServer::start().await;
     let schema = test_schema();
+    let server = TestingServer::start_with_schema(schema.clone()).await;
 
     let alice = TestingClient::builder()
         .with_server(&server)

--- a/crates/jazz-tools/tests/history_conflict.rs
+++ b/crates/jazz-tools/tests/history_conflict.rs
@@ -51,8 +51,8 @@ fn todo_values(title: &str) -> HashMap<String, Value> {
 #[tokio::test]
 async fn concurrent_updates_resolve_to_lww_winner() {
     let _suite_guard = lock_history_conflict_suite().await;
-    let server = TestingServer::start().await;
     let schema = test_schema();
+    let server = TestingServer::start_with_schema(schema.clone()).await;
 
     let alice = TestingClient::builder()
         .with_server(&server)
@@ -174,8 +174,8 @@ async fn concurrent_updates_resolve_to_lww_winner() {
 #[tokio::test]
 async fn concurrent_creates_both_survive() {
     let _suite_guard = lock_history_conflict_suite().await;
-    let server = TestingServer::start().await;
     let schema = test_schema();
+    let server = TestingServer::start_with_schema(schema.clone()).await;
 
     let alice = TestingClient::builder()
         .with_server(&server)
@@ -261,8 +261,8 @@ async fn concurrent_creates_both_survive() {
 #[tokio::test]
 async fn rapid_concurrent_updates_converge() {
     let _suite_guard = lock_history_conflict_suite().await;
-    let server = TestingServer::start().await;
     let schema = test_schema();
+    let server = TestingServer::start_with_schema(schema.clone()).await;
 
     let alice = TestingClient::builder()
         .with_server(&server)
@@ -386,8 +386,8 @@ async fn rapid_concurrent_updates_converge() {
 #[tokio::test]
 async fn fresh_client_sees_lww_winner_after_conflict() {
     let _suite_guard = lock_history_conflict_suite().await;
-    let server = TestingServer::start().await;
     let schema = test_schema();
+    let server = TestingServer::start_with_schema(schema.clone()).await;
 
     let alice = TestingClient::builder()
         .with_server(&server)
@@ -542,8 +542,8 @@ async fn fresh_client_sees_lww_winner_after_conflict() {
 #[tokio::test]
 async fn subscription_reflects_concurrent_update() {
     let _suite_guard = lock_history_conflict_suite().await;
-    let server = TestingServer::start().await;
     let schema = test_schema();
+    let server = TestingServer::start_with_schema(schema.clone()).await;
 
     let alice = TestingClient::builder()
         .with_server(&server)
@@ -615,8 +615,8 @@ async fn subscription_reflects_concurrent_update() {
 #[tokio::test]
 async fn sequential_updates_preserve_latest() {
     let _suite_guard = lock_history_conflict_suite().await;
-    let server = TestingServer::start().await;
     let schema = test_schema();
+    let server = TestingServer::start_with_schema(schema.clone()).await;
 
     let alice = TestingClient::builder()
         .with_server(&server)
@@ -711,8 +711,8 @@ async fn sequential_updates_preserve_latest() {
 #[tokio::test]
 async fn concurrent_edits_on_different_fields() {
     let _suite_guard = lock_history_conflict_suite().await;
-    let server = TestingServer::start().await;
     let schema = test_schema();
+    let server = TestingServer::start_with_schema(schema.clone()).await;
 
     let alice = TestingClient::builder()
         .with_server(&server)
@@ -843,8 +843,8 @@ async fn establish_offline_reconnect_baseline(
     alice_user_id: &str,
     bob_user_id: &str,
 ) -> OfflineReconnectBaseline {
-    let server = TestingServer::start().await;
     let schema = test_schema();
+    let server = TestingServer::start_with_schema(schema.clone()).await;
 
     let alice = TestingClient::builder()
         .with_server(&server)

--- a/crates/jazz-tools/tests/rocksdb_storage_integration.rs
+++ b/crates/jazz-tools/tests/rocksdb_storage_integration.rs
@@ -10,7 +10,7 @@ use jazz_tools::{
     AppContext, ClientStorage, ColumnType, DurabilityTier, JazzClient, QueryBuilder, SchemaBuilder,
     TableSchema, Value,
 };
-use support::{TestingClient, wait_for_query};
+use support::{TestingClient, publish_allow_all_permissions, wait_for_query};
 use tempfile::TempDir;
 
 const READY_TIMEOUT: Duration = Duration::from_secs(30);
@@ -57,13 +57,17 @@ async fn make_client(
     user_id: &str,
     ready_table: &str,
 ) -> JazzClient {
-    TestingClient::builder()
+    let client = TestingClient::builder()
         .with_server(server)
-        .with_schema(schema)
+        .with_schema(schema.clone())
         .with_user_id(user_id)
         .ready_on(ready_table, READY_TIMEOUT)
         .connect()
-        .await
+        .await;
+
+    publish_allow_all_permissions(&server.base_url(), server.admin_secret(), &schema).await;
+
+    client
 }
 
 /// Connects a client to a server that uses an external JWKS URL (where the
@@ -77,7 +81,7 @@ async fn make_client_external_jwks(
     let context = AppContext {
         app_id: server.app_id(),
         client_id: None,
-        schema,
+        schema: schema.clone(),
         server_url: server.base_url(),
         data_dir: tempfile::TempDir::new().expect("temp client dir").keep(),
         storage: ClientStorage::Memory,
@@ -98,6 +102,7 @@ async fn make_client_external_jwks(
         |_| Some(()),
     )
     .await;
+    publish_allow_all_permissions(&server.base_url(), server.admin_secret(), &schema).await;
 
     client
 }

--- a/crates/jazz-tools/tests/sqlite_storage_integration.rs
+++ b/crates/jazz-tools/tests/sqlite_storage_integration.rs
@@ -10,7 +10,7 @@ use jazz_tools::{
     AppContext, ClientStorage, ColumnType, DurabilityTier, JazzClient, QueryBuilder, SchemaBuilder,
     TableSchema, Value,
 };
-use support::{TestingClient, wait_for_query};
+use support::{TestingClient, publish_allow_all_permissions, wait_for_query};
 use tempfile::TempDir;
 
 const READY_TIMEOUT: Duration = Duration::from_secs(30);
@@ -57,13 +57,17 @@ async fn make_client(
     user_id: &str,
     ready_table: &str,
 ) -> JazzClient {
-    TestingClient::builder()
+    let client = TestingClient::builder()
         .with_server(server)
-        .with_schema(schema)
+        .with_schema(schema.clone())
         .with_user_id(user_id)
         .ready_on(ready_table, READY_TIMEOUT)
         .connect()
-        .await
+        .await;
+
+    publish_allow_all_permissions(&server.base_url(), server.admin_secret(), &schema).await;
+
+    client
 }
 
 /// Connects a client to a server that uses an external JWKS URL (where the
@@ -77,7 +81,7 @@ async fn make_client_external_jwks(
     let context = AppContext {
         app_id: server.app_id(),
         client_id: None,
-        schema,
+        schema: schema.clone(),
         server_url: server.base_url(),
         data_dir: tempfile::TempDir::new().expect("temp client dir").keep(),
         storage: ClientStorage::Memory,
@@ -98,6 +102,7 @@ async fn make_client_external_jwks(
         |_| Some(()),
     )
     .await;
+    publish_allow_all_permissions(&server.base_url(), server.admin_secret(), &schema).await;
 
     client
 }

--- a/crates/jazz-tools/tests/subscribe_all_integration.rs
+++ b/crates/jazz-tools/tests/subscribe_all_integration.rs
@@ -86,15 +86,16 @@ impl ClientPair {
     }
 
     async fn start_inner(tracer: Option<&jazz_tools::sync_tracer::SyncTracer>) -> Self {
+        let schema = subscription_schema();
         let server = if let Some(t) = tracer {
             TestingServer::builder()
+                .with_schema(schema.clone())
                 .with_tracer(t.clone())
                 .start()
                 .await
         } else {
-            TestingServer::start().await
+            TestingServer::start_with_schema(schema.clone()).await
         };
-        let schema = subscription_schema();
         let mut writer_builder = TestingClient::builder()
             .with_server(&server)
             .with_schema(schema.clone())
@@ -621,8 +622,8 @@ async fn subscribe_all_supports_condition_filters() {
         insert: TodoSeed,
     }
 
-    let server = TestingServer::start().await;
     let schema = subscription_schema();
+    let server = TestingServer::start_with_schema(schema.clone()).await;
     let writer = TestingClient::builder()
         .with_server(&server)
         .with_schema(schema.clone())

--- a/crates/jazz-tools/tests/support/mod.rs
+++ b/crates/jazz-tools/tests/support/mod.rs
@@ -17,6 +17,8 @@ use jsonwebtoken::{EncodingKey, Header, encode};
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 
+mod permissions;
+
 const DEFAULT_POLL_INTERVAL: Duration = Duration::from_millis(50);
 const DEFAULT_QUERY_TIMEOUT: Duration = Duration::from_secs(8);
 #[allow(dead_code)]
@@ -28,6 +30,64 @@ const TEST_JWT_KID: &str = "test-jwks-kid";
 
 /// Convenience shape for query results returned by test helpers.
 pub type QueryRows = Vec<(ObjectId, Vec<Value>)>;
+
+#[allow(unused_imports)]
+pub use permissions::{
+    PublishedPermissionsHead, allow_all_permissions, deny_all_select_permissions,
+    publish_allow_all_permissions, publish_permissions,
+};
+
+struct SyncServerClient {
+    http_client: Client,
+    base_url: String,
+    route_prefix: String,
+    admin_secret: String,
+}
+
+impl SyncServerClient {
+    async fn connect(
+        server_url: &str,
+        admin_secret: &str,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
+        let http_client = Client::new();
+        let (base_url, route_prefix) = split_base_url(server_url)?;
+
+        let health_url = format!("{base_url}/health");
+        http_client
+            .get(health_url)
+            .send()
+            .await?
+            .error_for_status()?;
+
+        Ok(Self {
+            http_client,
+            base_url,
+            route_prefix,
+            admin_secret: admin_secret.to_string(),
+        })
+    }
+
+    async fn push_sync(
+        &self,
+        payload: jazz_tools::sync_manager::SyncPayload,
+        client_id: ClientId,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let request = SyncBatchRequest {
+            payloads: vec![payload],
+            client_id,
+        };
+        let sync_url = format!("{}{}/sync", self.base_url, self.route_prefix);
+        self.http_client
+            .post(sync_url)
+            .header(CONTENT_TYPE, "application/json")
+            .header("X-Jazz-Admin-Secret", &self.admin_secret)
+            .json(&request)
+            .send()
+            .await?
+            .error_for_status()?;
+        Ok(())
+    }
+}
 
 #[derive(Debug, Serialize, Deserialize)]
 struct JwtClaims {

--- a/crates/jazz-tools/tests/support/mod.rs
+++ b/crates/jazz-tools/tests/support/mod.rs
@@ -9,11 +9,14 @@ use jazz_tools::schema_manager::{AppId, Lens, SchemaManager};
 use jazz_tools::server::{ServerState, TestingServer};
 use jazz_tools::storage::MemoryStorage;
 use jazz_tools::sync_manager::{ClientId, Destination, OutboxEntry, ServerId, SyncManager};
+use jazz_tools::transport_protocol::SyncBatchRequest;
 use jazz_tools::{
     AppContext, ClientStorage, DurabilityTier, JazzClient, ObjectId, OrderedRowDelta, Query,
     QueryBuilder, Schema, SubscriptionStream, Value,
 };
 use jsonwebtoken::{EncodingKey, Header, encode};
+use reqwest::Client;
+use reqwest::header::CONTENT_TYPE;
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 
@@ -87,6 +90,23 @@ impl SyncServerClient {
             .error_for_status()?;
         Ok(())
     }
+}
+
+fn split_base_url(server_url: &str) -> Result<(String, String), Box<dyn std::error::Error>> {
+    let mut url = reqwest::Url::parse(server_url)?;
+    let route_prefix = match url.path().trim_end_matches('/') {
+        "" | "/" => String::new(),
+        path => path.to_string(),
+    };
+
+    url.set_path("");
+    url.set_query(None);
+    url.set_fragment(None);
+
+    Ok((
+        url.to_string().trim_end_matches('/').to_string(),
+        route_prefix,
+    ))
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -549,6 +569,29 @@ where
         }
 
         tokio::time::sleep(DEFAULT_POLL_INTERVAL).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::split_base_url;
+
+    #[test]
+    fn split_base_url_handles_plain_origin() {
+        let (base_url, route_prefix) =
+            split_base_url("http://127.0.0.1:31337").expect("split base url");
+
+        assert_eq!(base_url, "http://127.0.0.1:31337");
+        assert_eq!(route_prefix, "");
+    }
+
+    #[test]
+    fn split_base_url_preserves_route_prefix_without_trailing_slash() {
+        let (base_url, route_prefix) =
+            split_base_url("http://127.0.0.1:31337/api/v1/").expect("split base url");
+
+        assert_eq!(base_url, "http://127.0.0.1:31337");
+        assert_eq!(route_prefix, "/api/v1");
     }
 }
 

--- a/crates/jazz-tools/tests/support/permissions.rs
+++ b/crates/jazz-tools/tests/support/permissions.rs
@@ -1,0 +1,153 @@
+#![allow(dead_code)]
+
+use std::time::{Duration, Instant};
+
+use jazz_tools::Schema;
+use jazz_tools::query_manager::types::SchemaHash;
+use reqwest::{Client, StatusCode};
+use serde::Deserialize;
+use serde_json::{Map, Value as JsonValue, json};
+
+const PUBLISH_RETRY_TIMEOUT: Duration = Duration::from_secs(30);
+const PUBLISH_RETRY_INTERVAL: Duration = Duration::from_millis(100);
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct PublishedPermissionsHead {
+    #[serde(rename = "schemaHash")]
+    pub schema_hash: String,
+    pub version: u64,
+    #[serde(rename = "parentBundleObjectId")]
+    pub parent_bundle_object_id: Option<String>,
+    #[serde(rename = "bundleObjectId")]
+    pub bundle_object_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct PermissionsHeadResponse {
+    head: Option<PublishedPermissionsHead>,
+}
+
+pub fn allow_all_permissions(schema: &Schema) -> Map<String, JsonValue> {
+    schema
+        .keys()
+        .map(|table_name| {
+            (
+                table_name.to_string(),
+                json!({
+                    "select": { "using": { "type": "True" } },
+                    "insert": { "with_check": { "type": "True" } },
+                    "update": {
+                        "using": { "type": "True" },
+                        "with_check": { "type": "True" }
+                    },
+                    "delete": { "using": { "type": "True" } }
+                }),
+            )
+        })
+        .collect()
+}
+
+pub fn deny_all_select_permissions(schema: &Schema) -> Map<String, JsonValue> {
+    schema
+        .keys()
+        .map(|table_name| {
+            (
+                table_name.to_string(),
+                json!({
+                    "select": { "using": { "type": "False" } }
+                }),
+            )
+        })
+        .collect()
+}
+
+pub async fn publish_allow_all_permissions(
+    base_url: &str,
+    admin_secret: &str,
+    schema: &Schema,
+) -> PublishedPermissionsHead {
+    publish_permissions(
+        base_url,
+        admin_secret,
+        schema,
+        allow_all_permissions(schema),
+        None,
+    )
+    .await
+}
+
+pub async fn publish_permissions(
+    base_url: &str,
+    admin_secret: &str,
+    schema: &Schema,
+    permissions: Map<String, JsonValue>,
+    mut expected_parent_bundle_object_id: Option<String>,
+) -> PublishedPermissionsHead {
+    let client = Client::new();
+    let schema_hash = SchemaHash::compute(schema);
+    let deadline = Instant::now() + PUBLISH_RETRY_TIMEOUT;
+    let mut fetched_parent_after_conflict = false;
+
+    loop {
+        let response = client
+            .post(format!("{base_url}/admin/permissions"))
+            .header("X-Jazz-Admin-Secret", admin_secret)
+            .json(&json!({
+                "schemaHash": schema_hash.to_string(),
+                "permissions": permissions,
+                "expectedParentBundleObjectId": expected_parent_bundle_object_id,
+            }))
+            .send()
+            .await
+            .expect("publish permissions request");
+        let status = response.status();
+
+        match status {
+            StatusCode::CREATED => {
+                let response_json: PermissionsHeadResponse = response
+                    .json()
+                    .await
+                    .expect("decode permissions publish response");
+                return response_json
+                    .head
+                    .expect("permissions publish response should include head");
+            }
+            StatusCode::NOT_FOUND if Instant::now() < deadline => {
+                tokio::time::sleep(PUBLISH_RETRY_INTERVAL).await;
+            }
+            StatusCode::CONFLICT if !fetched_parent_after_conflict => {
+                expected_parent_bundle_object_id =
+                    fetch_current_parent_bundle_object_id(&client, base_url, admin_secret).await;
+                fetched_parent_after_conflict = true;
+            }
+            _ => {
+                let body = response
+                    .text()
+                    .await
+                    .unwrap_or_else(|_| "<unreadable response body>".to_string());
+                panic!("failed to publish permissions: {status} {body}");
+            }
+        }
+    }
+}
+
+async fn fetch_current_parent_bundle_object_id(
+    client: &Client,
+    base_url: &str,
+    admin_secret: &str,
+) -> Option<String> {
+    let response = client
+        .get(format!("{base_url}/admin/permissions/head"))
+        .header("X-Jazz-Admin-Secret", admin_secret)
+        .send()
+        .await
+        .expect("fetch permissions head");
+    let status = response.status();
+    assert_eq!(status, StatusCode::OK, "unexpected permissions head status");
+
+    let response_json: PermissionsHeadResponse = response
+        .json()
+        .await
+        .expect("decode permissions head response");
+    response_json.head.map(|head| head.bundle_object_id)
+}

--- a/crates/jazz-tools/tests/sync_tracer_integration.rs
+++ b/crates/jazz-tools/tests/sync_tracer_integration.rs
@@ -29,15 +29,17 @@ fn test_schema() -> jazz_tools::Schema {
 #[tokio::test]
 async fn alice_write_bob_read() {
     let tracer = SyncTracer::new();
+    let schema = test_schema();
 
     let server = TestingServer::builder()
+        .with_schema(schema.clone())
         .with_tracer(tracer.clone())
         .start()
         .await;
 
     let alice = TestingClient::builder()
         .with_server(&server)
-        .with_schema(test_schema())
+        .with_schema(schema.clone())
         .with_user_id("alice")
         .with_tracer(&tracer, "alice")
         .ready_on("todos", Duration::from_secs(30))
@@ -46,7 +48,7 @@ async fn alice_write_bob_read() {
 
     let bob = TestingClient::builder()
         .with_server(&server)
-        .with_schema(test_schema())
+        .with_schema(schema)
         .with_user_id("bob")
         .with_tracer(&tracer, "bob")
         .ready_on("todos", Duration::from_secs(30))
@@ -102,15 +104,17 @@ async fn alice_write_bob_read() {
 #[tokio::test]
 async fn bob_updates_alice_todo() {
     let tracer = SyncTracer::new();
+    let schema = test_schema();
 
     let server = TestingServer::builder()
+        .with_schema(schema.clone())
         .with_tracer(tracer.clone())
         .start()
         .await;
 
     let alice = TestingClient::builder()
         .with_server(&server)
-        .with_schema(test_schema())
+        .with_schema(schema.clone())
         .with_user_id("alice")
         .with_tracer(&tracer, "alice")
         .ready_on("todos", Duration::from_secs(30))
@@ -119,7 +123,7 @@ async fn bob_updates_alice_todo() {
 
     let bob = TestingClient::builder()
         .with_server(&server)
-        .with_schema(test_schema())
+        .with_schema(schema)
         .with_user_id("bob")
         .with_tracer(&tracer, "bob")
         .ready_on("todos", Duration::from_secs(30))
@@ -223,15 +227,17 @@ async fn bob_updates_alice_todo() {
 #[tokio::test]
 async fn single_writer_flow() {
     let tracer = SyncTracer::new();
+    let schema = test_schema();
 
     let server = TestingServer::builder()
+        .with_schema(schema.clone())
         .with_tracer(tracer.clone())
         .start()
         .await;
 
     let alice = TestingClient::builder()
         .with_server(&server)
-        .with_schema(test_schema())
+        .with_schema(schema)
         .with_user_id("alice")
         .with_tracer(&tracer, "alice")
         .ready_on("todos", Duration::from_secs(30))
@@ -270,15 +276,17 @@ async fn single_writer_flow() {
 #[tokio::test]
 async fn named_object_trace() {
     let tracer = SyncTracer::new();
+    let schema = test_schema();
 
     let server = TestingServer::builder()
+        .with_schema(schema.clone())
         .with_tracer(tracer.clone())
         .start()
         .await;
 
     let alice = TestingClient::builder()
         .with_server(&server)
-        .with_schema(test_schema())
+        .with_schema(schema)
         .with_user_id("alice")
         .with_tracer(&tracer, "alice")
         .ready_on("todos", Duration::from_secs(30))

--- a/examples/docs/todo-client-localfirst-react/tests/browser/global-setup.ts
+++ b/examples/docs/todo-client-localfirst-react/tests/browser/global-setup.ts
@@ -1,4 +1,5 @@
-import { TestingServer } from "jazz-tools/testing";
+import { join } from "node:path";
+import { TestingServer, pushSchemaCatalogue } from "jazz-tools/testing";
 import { TEST_PORT, ADMIN_SECRET, APP_ID } from "./test-constants.js";
 
 export { TEST_PORT, ADMIN_SECRET, APP_ID };
@@ -16,7 +17,14 @@ export async function setup(): Promise<void> {
     adminSecret: ADMIN_SECRET,
   });
 
-  await server;
+  const serverHandle = await server;
+
+  await pushSchemaCatalogue({
+    serverUrl: serverHandle.url,
+    appId: serverHandle.appId,
+    adminSecret: serverHandle.adminSecret,
+    schemaDir: join(import.meta.dirname ?? __dirname, "../.."),
+  });
 }
 
 export async function teardown(): Promise<void> {

--- a/examples/docs/todo-client-localfirst-ts/tests/browser/global-setup.ts
+++ b/examples/docs/todo-client-localfirst-ts/tests/browser/global-setup.ts
@@ -1,4 +1,5 @@
-import { TestingServer } from "jazz-tools/testing";
+import { join } from "node:path";
+import { pushSchemaCatalogue, TestingServer } from "jazz-tools/testing";
 import { TEST_PORT, ADMIN_SECRET, APP_ID } from "./test-constants.js";
 
 export { TEST_PORT, ADMIN_SECRET, APP_ID };
@@ -16,7 +17,14 @@ export async function setup(): Promise<void> {
     adminSecret: ADMIN_SECRET,
   });
 
-  await server;
+  const serverHandle = await server;
+
+  await pushSchemaCatalogue({
+    serverUrl: serverHandle.url,
+    appId: serverHandle.appId,
+    adminSecret: serverHandle.adminSecret,
+    schemaDir: join(import.meta.dirname ?? __dirname, "../.."),
+  });
 }
 
 export async function teardown(): Promise<void> {

--- a/examples/docs/todo-server-rs/tests/integration.rs
+++ b/examples/docs/todo-server-rs/tests/integration.rs
@@ -2,6 +2,9 @@
 //!
 //! Tests the full HTTP API end-to-end.
 
+#[path = "../../../../crates/jazz-tools/tests/support/permissions.rs"]
+mod permissions_support;
+
 use std::convert::Infallible;
 use std::path::PathBuf;
 use std::process::{Child, Command, Stdio};
@@ -752,6 +755,13 @@ async fn test_server_resync() {
             sync_tracer: None,
         };
         let client = JazzClient::connect(context).await.unwrap();
+        let permissions_schema = test_schema();
+        permissions_support::publish_allow_all_permissions(
+            &server.base_url(),
+            TEST_ADMIN_SECRET,
+            &permissions_schema,
+        )
+        .await;
 
         // Create a todo
         let values = todo_values("Synced todo", "");

--- a/examples/todo-client-localfirst-ts/tests/browser/global-setup.ts
+++ b/examples/todo-client-localfirst-ts/tests/browser/global-setup.ts
@@ -1,4 +1,5 @@
-import { TestingServer } from "jazz-tools/testing";
+import { join } from "node:path";
+import { pushSchemaCatalogue, TestingServer } from "jazz-tools/testing";
 import { TEST_PORT, JWT_SECRET, ADMIN_SECRET, APP_ID } from "./test-constants.js";
 
 export { TEST_PORT, JWT_SECRET, ADMIN_SECRET, APP_ID };
@@ -16,7 +17,14 @@ export async function setup(): Promise<void> {
     adminSecret: ADMIN_SECRET,
   });
 
-  await server;
+  const serverHandle = await server;
+
+  await pushSchemaCatalogue({
+    serverUrl: serverHandle.url,
+    appId: serverHandle.appId,
+    adminSecret: serverHandle.adminSecret,
+    schemaDir: join(import.meta.dirname ?? __dirname, "../.."),
+  });
 }
 
 export async function teardown(): Promise<void> {

--- a/examples/todo-server-rs/tests/integration.rs
+++ b/examples/todo-server-rs/tests/integration.rs
@@ -2,6 +2,9 @@
 //!
 //! Tests the full HTTP API end-to-end.
 
+#[path = "../../../crates/jazz-tools/tests/support/permissions.rs"]
+mod permissions_support;
+
 use std::convert::Infallible;
 use std::path::PathBuf;
 use std::process::{Child, Command, Stdio};
@@ -752,6 +755,13 @@ async fn test_server_resync() {
             sync_tracer: None,
         };
         let client = JazzClient::connect(context).await.unwrap();
+        let permissions_schema = test_schema();
+        permissions_support::publish_allow_all_permissions(
+            &server.base_url(),
+            TEST_ADMIN_SECRET,
+            &permissions_schema,
+        )
+        .await;
 
         // Create a todo
         let values = todo_values("Synced todo", "");

--- a/packages/jazz-tools/src/runtime/index.ts
+++ b/packages/jazz-tools/src/runtime/index.ts
@@ -36,7 +36,9 @@ export type { AuthFailureReason, AuthState } from "./auth-state.js";
 export {
   fetchSchemaHashes,
   fetchStoredWasmSchema,
+  publishStoredPermissions,
   type FetchStoredWasmSchemaOptions,
+  type PublishStoredPermissionsOptions,
 } from "./schema-fetch.js";
 export {
   fetchServerSubscriptions,

--- a/packages/jazz-tools/tests/browser/db.auth-refresh.test.ts
+++ b/packages/jazz-tools/tests/browser/db.auth-refresh.test.ts
@@ -1,5 +1,13 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { createDb, type Db, type QueryBuilder, type TableProxy } from "../../src/runtime/db.js";
+import {
+  createDb,
+  fetchSchemaHashes,
+  publishStoredPermissions,
+  type Db,
+  type QueryBuilder,
+  type TableProxy,
+} from "../../src/runtime/index.js";
+import { publishStoredSchema } from "../../src/runtime/schema-fetch.js";
 import type { WasmSchema } from "../../src/drivers/types.js";
 import { TestCleanup, uniqueDbName, waitForCondition, waitForQuery } from "./support.js";
 import { getTestingServerInfo, getTestingServerJwtForUser } from "./testing-server.js";
@@ -53,7 +61,8 @@ describe("Db auth refresh browser integration", () => {
   });
 
   it("recovers from auth loss after updateAuthToken and flushes queued local writes", async () => {
-    const { appId, serverUrl } = await getTestingServerInfo();
+    const { appId, serverUrl, adminSecret } = await getTestingServerInfo();
+
     const dbNameA = uniqueDbName("auth-refresh-a");
     const dbNameB = uniqueDbName("auth-refresh-b");
     const invalidJwt = makeFakeJwt({
@@ -79,6 +88,38 @@ describe("Db auth refresh browser integration", () => {
         driver: { type: "persistent", dbName: dbNameB },
       }),
     );
+
+    const { hash: publishedSchemaHash } = await publishStoredSchema(serverUrl, {
+      adminSecret,
+      schema,
+    });
+
+    let latestSchemaHash: string | null = publishedSchemaHash;
+    await waitForCondition(
+      async () => {
+        const { hashes } = await fetchSchemaHashes(serverUrl, { adminSecret });
+        latestSchemaHash = hashes.at(-1) ?? publishedSchemaHash;
+        return latestSchemaHash !== null;
+      },
+      20_000,
+      "expected at least one published schema hash before publishing test permissions",
+    );
+
+    await publishStoredPermissions(serverUrl, {
+      adminSecret,
+      schemaHash: latestSchemaHash!,
+      permissions: {
+        todos: {
+          select: { using: { type: "True" } },
+          insert: { with_check: { type: "True" } },
+          update: {
+            using: { type: "True" },
+            with_check: { type: "True" },
+          },
+          delete: { using: { type: "True" } },
+        },
+      },
+    });
 
     const marker = `queued-after-auth-loss-${Date.now()}`;
     writer.insert(todos, {

--- a/packages/jazz-tools/tests/browser/db.auth-refresh.test.ts
+++ b/packages/jazz-tools/tests/browser/db.auth-refresh.test.ts
@@ -7,7 +7,7 @@ import {
   type QueryBuilder,
   type TableProxy,
 } from "../../src/runtime/index.js";
-import { publishStoredSchema } from "../../src/runtime/schema-fetch.js";
+import { fetchPermissionsHead, publishStoredSchema } from "../../src/runtime/schema-fetch.js";
 import type { WasmSchema } from "../../src/drivers/types.js";
 import { TestCleanup, uniqueDbName, waitForCondition, waitForQuery } from "./support.js";
 import { getTestingServerInfo, getTestingServerJwtForUser } from "./testing-server.js";
@@ -105,6 +105,8 @@ describe("Db auth refresh browser integration", () => {
       "expected at least one published schema hash before publishing test permissions",
     );
 
+    const { head } = await fetchPermissionsHead(serverUrl, { adminSecret });
+
     await publishStoredPermissions(serverUrl, {
       adminSecret,
       schemaHash: latestSchemaHash!,
@@ -119,6 +121,7 @@ describe("Db auth refresh browser integration", () => {
           delete: { using: { type: "True" } },
         },
       },
+      expectedParentBundleObjectId: head?.bundleObjectId ?? null,
     });
 
     const marker = `queued-after-auth-loss-${Date.now()}`;

--- a/packages/jazz-tools/tests/browser/history-conflict.test.ts
+++ b/packages/jazz-tools/tests/browser/history-conflict.test.ts
@@ -10,7 +10,7 @@
  */
 
 import { describe, it, expect, afterEach, beforeEach } from "vitest";
-import type { TableProxy } from "../../src/runtime/db.js";
+import type { Db, TableProxy } from "../../src/runtime/db.js";
 import type { WasmSchema } from "../../src/drivers/types.js";
 import { generateAuthSecret } from "../../src/runtime/auth-secret-store.js";
 import {
@@ -18,11 +18,16 @@ import {
   publishStoredPermissions,
   publishStoredSchema,
 } from "../../src/runtime/schema-fetch.js";
-import { getTestingServerInfo } from "./testing-server.js";
+import {
+  getTestingServerInfo,
+  unblockTestingServerNetwork,
+  type TestingServerInfo,
+} from "./testing-server.js";
 import {
   TestCleanup,
   createSyncedDb,
   makeQuery,
+  uniqueDbName,
   waitForCondition,
   waitForQuery,
   withTimeout,
@@ -67,9 +72,12 @@ const allTodos = makeQuery<Todo>("todos", schema);
 
 describe("History & Conflict Management", () => {
   const ctx = new TestCleanup();
+  let testingServer: TestingServerInfo;
   afterEach(() => ctx.cleanup());
   beforeEach(async () => {
-    const { serverUrl, adminSecret } = await getTestingServerInfo();
+    testingServer = await getTestingServerInfo(uniqueDbName("history-conflict-app"));
+    const { serverUrl, adminSecret } = testingServer;
+    await unblockTestingServerNetwork(serverUrl);
     const { hash: schemaHash } = await publishStoredSchema(serverUrl, {
       adminSecret,
       schema,
@@ -107,8 +115,9 @@ describe("History & Conflict Management", () => {
    */
   it("concurrent updates converge in browser", async () => {
     const token = generateAuthSecret();
-    const dbAlice = await createSyncedDb(ctx, "hc-alice-concurrent", token);
-    const dbBob = await createSyncedDb(ctx, "hc-bob-concurrent", token);
+    const dbAlice = await createReadySyncedDb(ctx, "hc-alice-concurrent", token, testingServer);
+    const dbBob = await createReadySyncedDb(ctx, "hc-bob-concurrent", token, testingServer);
+    await waitForPeerSync(dbAlice, dbBob, "hc-concurrent");
 
     // Alice inserts a todo
     const uniqueTitle = `original-${Date.now()}`;
@@ -155,8 +164,9 @@ describe("History & Conflict Management", () => {
 
   it("sequential update propagates from A to B", async () => {
     const token = generateAuthSecret();
-    const dbAlice = await createSyncedDb(ctx, "hc-alice-seq-upd", token);
-    const dbBob = await createSyncedDb(ctx, "hc-bob-seq-upd", token);
+    const dbAlice = await createReadySyncedDb(ctx, "hc-alice-seq-upd", token, testingServer);
+    const dbBob = await createReadySyncedDb(ctx, "hc-bob-seq-upd", token, testingServer);
+    await waitForPeerSync(dbAlice, dbBob, "hc-seq-upd");
 
     // Alice inserts
     const { id } = await withTimeout(
@@ -206,8 +216,9 @@ describe("History & Conflict Management", () => {
    */
   it("concurrent creates both visible in browser", async () => {
     const token = generateAuthSecret();
-    const dbAlice = await createSyncedDb(ctx, "hc-alice-creates", token);
-    const dbBob = await createSyncedDb(ctx, "hc-bob-creates", token);
+    const dbAlice = await createReadySyncedDb(ctx, "hc-alice-creates", token, testingServer);
+    const dbBob = await createReadySyncedDb(ctx, "hc-bob-creates", token, testingServer);
+    await waitForPeerSync(dbAlice, dbBob, "hc-creates");
 
     const milkTitle = `buy-milk-${Date.now()}`;
     const eggsTitle = `buy-eggs-${Date.now()}`;
@@ -260,8 +271,9 @@ describe("History & Conflict Management", () => {
    */
   it("subscription fires on remote concurrent update", async () => {
     const token = generateAuthSecret();
-    const dbAlice = await createSyncedDb(ctx, "hc-alice-sub", token);
-    const dbBob = await createSyncedDb(ctx, "hc-bob-sub", token);
+    const dbAlice = await createReadySyncedDb(ctx, "hc-alice-sub", token, testingServer);
+    const dbBob = await createReadySyncedDb(ctx, "hc-bob-sub", token, testingServer);
+    await waitForPeerSync(dbAlice, dbBob, "hc-sub");
 
     // Alice inserts a todo
     const originalTitle = `sub-test-${Date.now()}`;
@@ -327,8 +339,9 @@ describe("History & Conflict Management", () => {
    */
   it("fresh db sees converged state", async () => {
     const token = generateAuthSecret();
-    const dbAlice = await createSyncedDb(ctx, "hc-alice-fresh", token);
-    const dbBob = await createSyncedDb(ctx, "hc-bob-fresh", token);
+    const dbAlice = await createReadySyncedDb(ctx, "hc-alice-fresh", token, testingServer);
+    const dbBob = await createReadySyncedDb(ctx, "hc-bob-fresh", token, testingServer);
+    await waitForPeerSync(dbAlice, dbBob, "hc-fresh");
 
     // Alice inserts a todo
     const originalTitle = `fresh-test-${Date.now()}`;
@@ -377,7 +390,7 @@ describe("History & Conflict Management", () => {
     );
 
     // Charlie connects fresh — must see the same winner
-    const dbCharlie = await createSyncedDb(ctx, "hc-charlie-fresh", token);
+    const dbCharlie = await createReadySyncedDb(ctx, "hc-charlie-fresh", token, testingServer);
 
     const charlieRows = await waitForQuery(
       dbCharlie,
@@ -401,8 +414,8 @@ describe("History & Conflict Management", () => {
    */
   it.skip("concurrent edits on different fields", async () => {
     const token = generateAuthSecret();
-    const dbAlice = await createSyncedDb(ctx, "hc-alice-fields", token);
-    const dbBob = await createSyncedDb(ctx, "hc-bob-fields", token);
+    const dbAlice = await createReadySyncedDb(ctx, "hc-alice-fields", token, testingServer);
+    const dbBob = await createReadySyncedDb(ctx, "hc-bob-fields", token, testingServer);
 
     const { id } = await withTimeout(
       dbAlice.insertDurable(todos, { title: "task", done: false }, { tier: "worker" }),
@@ -439,3 +452,70 @@ describe("History & Conflict Management", () => {
     );
   }, 90000);
 });
+
+async function createReadySyncedDb(
+  ctx: TestCleanup,
+  label: string,
+  secret: string,
+  testingServer: TestingServerInfo,
+): Promise<Db> {
+  const db = await createSyncedDb(ctx, label, secret, testingServer);
+  const warmupTitle = `warmup-${label}-${Date.now()}`;
+
+  await waitForCondition(
+    async () => {
+      try {
+        await withTimeout(
+          db.insertDurable(todos, { title: warmupTitle, done: false }, { tier: "worker" }),
+          2_000,
+          `${label} warmup insert did not resolve`,
+        );
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    12_000,
+    `${label} should accept durable writes after permissions publication`,
+  );
+
+  return db;
+}
+
+async function waitForPeerSync(dbAlice: Db, dbBob: Db, label: string): Promise<void> {
+  const { id: aliceToBobId } = await withTimeout(
+    dbAlice.insertDurable(
+      todos,
+      { title: `peer-sync-a2b-${label}-${Date.now()}`, done: false },
+      { tier: "worker" },
+    ),
+    10_000,
+    `${label} Alice->Bob peer sync insert did not resolve`,
+  );
+
+  await waitForQuery(
+    dbBob,
+    allTodos,
+    (rows) => rows.some((row) => row.id === aliceToBobId),
+    `${label} Alice->Bob peer sync should reach Bob`,
+    20_000,
+  );
+
+  const { id: bobToAliceId } = await withTimeout(
+    dbBob.insertDurable(
+      todos,
+      { title: `peer-sync-b2a-${label}-${Date.now()}`, done: false },
+      { tier: "worker" },
+    ),
+    10_000,
+    `${label} Bob->Alice peer sync insert did not resolve`,
+  );
+
+  await waitForQuery(
+    dbAlice,
+    allTodos,
+    (rows) => rows.some((row) => row.id === bobToAliceId),
+    `${label} Bob->Alice peer sync should reach Alice`,
+    20_000,
+  );
+}

--- a/packages/jazz-tools/tests/browser/history-conflict.test.ts
+++ b/packages/jazz-tools/tests/browser/history-conflict.test.ts
@@ -9,10 +9,16 @@
  * rather than specific LWW winners, making them timing-tolerant.
  */
 
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect, afterEach, beforeEach } from "vitest";
 import type { TableProxy } from "../../src/runtime/db.js";
 import type { WasmSchema } from "../../src/drivers/types.js";
 import { generateAuthSecret } from "../../src/runtime/auth-secret-store.js";
+import {
+  fetchPermissionsHead,
+  publishStoredPermissions,
+  publishStoredSchema,
+} from "../../src/runtime/schema-fetch.js";
+import { getTestingServerInfo } from "./testing-server.js";
 import {
   TestCleanup,
   createSyncedDb,
@@ -62,6 +68,30 @@ const allTodos = makeQuery<Todo>("todos", schema);
 describe("History & Conflict Management", () => {
   const ctx = new TestCleanup();
   afterEach(() => ctx.cleanup());
+  beforeEach(async () => {
+    const { serverUrl, adminSecret } = await getTestingServerInfo();
+    const { hash: schemaHash } = await publishStoredSchema(serverUrl, {
+      adminSecret,
+      schema,
+    });
+    const { head } = await fetchPermissionsHead(serverUrl, { adminSecret });
+    await publishStoredPermissions(serverUrl, {
+      adminSecret,
+      schemaHash,
+      permissions: {
+        todos: {
+          select: { using: { type: "True" } },
+          insert: { with_check: { type: "True" } },
+          update: {
+            using: { type: "True" },
+            with_check: { type: "True" },
+          },
+          delete: { using: { type: "True" } },
+        },
+      },
+      expectedParentBundleObjectId: head?.bundleObjectId ?? null,
+    });
+  });
 
   /**
    * Two browser clients update the same todo concurrently. Both must

--- a/packages/jazz-tools/tests/browser/support.ts
+++ b/packages/jazz-tools/tests/browser/support.ts
@@ -8,6 +8,7 @@
 import { createDb, Db, type QueryBuilder } from "../../src/runtime/db.js";
 import type { WasmSchema } from "../../src/drivers/types.js";
 import { getTestingServerInfo } from "./testing-server.js";
+import type { TestingServerInfo } from "./testing-server.js";
 import { generateAuthSecret } from "../../src/runtime/auth-secret-store.js";
 
 // ---------------------------------------------------------------------------
@@ -263,9 +264,10 @@ export async function createSyncedDb(
   ctx: TestCleanup,
   label: string,
   secret?: string,
+  testingServer?: TestingServerInfo,
 ): Promise<Db> {
   const localFirstSecret = secret ?? generateAuthSecret();
-  const { appId, serverUrl, adminSecret } = await getTestingServerInfo();
+  const { appId, serverUrl, adminSecret } = testingServer ?? (await getTestingServerInfo());
   return ctx.track(
     await createDb({
       appId,

--- a/packages/jazz-tools/tests/browser/testing-server-node.ts
+++ b/packages/jazz-tools/tests/browser/testing-server-node.ts
@@ -9,7 +9,8 @@ interface StartedTestingServer {
   adminSecret: string;
 }
 
-let testingServerPromise: Promise<StartedTestingServer> | null = null;
+const DEFAULT_TESTING_SERVER_KEY = "__default__";
+const testingServerPromises = new Map<string, Promise<StartedTestingServer>>();
 const blockedServerRoutes = new WeakMap<BrowserContext, Map<string, (route: Route) => void>>();
 const browserContextIds = new WeakMap<BrowserContext, number>();
 let nextBrowserContextId = 1;
@@ -27,9 +28,9 @@ async function loadTestingServer(): Promise<typeof import("jazz-napi").TestingSe
   }
 }
 
-async function startTestingServer(): Promise<StartedTestingServer> {
+async function startTestingServer(appId?: string): Promise<StartedTestingServer> {
   const TestingServer = await loadTestingServer();
-  const server = await TestingServer.start();
+  const server = await TestingServer.start(appId ? { appId } : undefined);
   return {
     server,
     appId: server.appId,
@@ -38,24 +39,33 @@ async function startTestingServer(): Promise<StartedTestingServer> {
   };
 }
 
-async function getOrStartTestingServer(): Promise<StartedTestingServer> {
-  if (!testingServerPromise) {
-    testingServerPromise = startTestingServer().catch((error) => {
-      testingServerPromise = null;
+async function getOrStartTestingServer(appId?: string): Promise<StartedTestingServer> {
+  const key = appId ?? DEFAULT_TESTING_SERVER_KEY;
+  const existing = testingServerPromises.get(key);
+
+  if (!existing) {
+    const startedServer = startTestingServer(appId).catch((error) => {
+      testingServerPromises.delete(key);
       throw error;
     });
+    testingServerPromises.set(key, startedServer);
+    return startedServer;
   }
 
-  return testingServerPromise;
+  return existing;
 }
 
-export async function testingServerInfo(): Promise<{
+export async function testingServerInfo(appId?: string): Promise<{
   appId: string;
   serverUrl: string;
   adminSecret: string;
 }> {
-  const { appId, serverUrl, adminSecret } = await getOrStartTestingServer();
-  return { appId, serverUrl, adminSecret };
+  const serverInfo = await getOrStartTestingServer(appId);
+  return {
+    appId: serverInfo.appId,
+    serverUrl: serverInfo.serverUrl,
+    adminSecret: serverInfo.adminSecret,
+  };
 }
 
 export async function testingServerJwtForUser(
@@ -67,19 +77,21 @@ export async function testingServerJwtForUser(
 }
 
 export async function stopTestingServer(): Promise<void> {
-  const runningServer = testingServerPromise;
-  testingServerPromise = null;
+  const runningServers = [...testingServerPromises.values()];
+  testingServerPromises.clear();
 
-  if (!runningServer) {
+  if (runningServers.length === 0) {
     return;
   }
 
-  try {
-    const { server } = await runningServer;
-    await server.stop();
-  } catch {
-    // Swallow all errors: either startup never produced a server (nothing to stop),
-    // or stop() itself failed (nothing recoverable during teardown).
+  for (const runningServer of runningServers) {
+    try {
+      const { server } = await runningServer;
+      await server.stop();
+    } catch {
+      // Swallow all errors: either startup never produced a server (nothing to stop),
+      // or stop() itself failed (nothing recoverable during teardown).
+    }
   }
 }
 

--- a/packages/jazz-tools/tests/browser/testing-server.ts
+++ b/packages/jazz-tools/tests/browser/testing-server.ts
@@ -15,7 +15,7 @@ export interface TestingServerNetworkDebugState {
 
 declare module "vitest/internal/browser" {
   interface BrowserCommands {
-    testingServerInfo: () => Promise<TestingServerInfo>;
+    testingServerInfo: (appId?: string) => Promise<TestingServerInfo>;
     testingServerBlockNetwork: (serverUrl: string) => Promise<void>;
     testingServerUnblockNetwork: (serverUrl: string) => Promise<void>;
     testingServerNetworkDebug: (serverUrl: string) => Promise<TestingServerNetworkDebugState>;
@@ -23,8 +23,8 @@ declare module "vitest/internal/browser" {
   }
 }
 
-export function getTestingServerInfo(): Promise<TestingServerInfo> {
-  return commands.testingServerInfo();
+export function getTestingServerInfo(appId?: string): Promise<TestingServerInfo> {
+  return commands.testingServerInfo(appId);
 }
 
 export function blockTestingServerNetwork(serverUrl: string): Promise<void> {

--- a/packages/jazz-tools/tests/browser/worker-bridge.test.ts
+++ b/packages/jazz-tools/tests/browser/worker-bridge.test.ts
@@ -25,6 +25,7 @@ import {
   blockTestingServerNetwork,
   getTestingServerInfo,
   getTestingServerNetworkDebug,
+  type TestingServerInfo,
   unblockTestingServerNetwork,
 } from "./testing-server.js";
 import {
@@ -994,10 +995,10 @@ describe("Worker Bridge with OPFS", () => {
   // -------------------------------------------------------------------------
 
   it("propagates synced row from client A to client B", async () => {
-    await publishSyncServerSchemaAndPermissions();
+    const syncServer = await publishSyncServerSchemaAndPermissions("sync-a-to-b");
     const sharedLocalAuthToken = generateAuthSecret();
-    const dbA = await createSyncedDb(ctx, "sync-a", sharedLocalAuthToken);
-    const dbB = await createSyncedDb(ctx, "sync-b", sharedLocalAuthToken);
+    const dbA = await createSyncedDb(ctx, "sync-a", sharedLocalAuthToken, syncServer);
+    const dbB = await createSyncedDb(ctx, "sync-b", sharedLocalAuthToken, syncServer);
 
     const title = `sync-a-to-b-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     await withTimeout(
@@ -1016,10 +1017,10 @@ describe("Worker Bridge with OPFS", () => {
   }, 60000);
 
   it("propagates synced row from client B to client A", async () => {
-    await publishSyncServerSchemaAndPermissions();
+    const syncServer = await publishSyncServerSchemaAndPermissions("sync-b-to-a");
     const sharedLocalAuthToken = generateAuthSecret();
-    const dbA = await createSyncedDb(ctx, "sync-a-reverse", sharedLocalAuthToken);
-    const dbB = await createSyncedDb(ctx, "sync-b-reverse", sharedLocalAuthToken);
+    const dbA = await createSyncedDb(ctx, "sync-a-reverse", sharedLocalAuthToken, syncServer);
+    const dbB = await createSyncedDb(ctx, "sync-b-reverse", sharedLocalAuthToken, syncServer);
 
     const title = `sync-b-to-a-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     await withTimeout(
@@ -1038,10 +1039,10 @@ describe("Worker Bridge with OPFS", () => {
   }, 60000);
 
   it("recovers sync after browser-side network loss with B in a separate context", async () => {
-    await publishSyncServerSchemaAndPermissions();
+    const syncServer = await publishSyncServerSchemaAndPermissions("sync-recover");
     const sharedLocalAuthToken = generateAuthSecret();
-    const { appId, serverUrl, adminSecret } = await getTestingServerInfo();
-    const dbA = await createSyncedDb(ctx, "sync-recover-a", sharedLocalAuthToken);
+    const { appId, serverUrl, adminSecret } = syncServer;
+    const dbA = await createSyncedDb(ctx, "sync-recover-a", sharedLocalAuthToken, syncServer);
     const remoteDbId = trackRemoteBrowserDb(uniqueDbName("sync-recover-remote"));
     await createRemoteBrowserDb({
       id: remoteDbId,
@@ -1102,10 +1103,15 @@ describe("Worker Bridge with OPFS", () => {
    *   expected: the first fresh edge query completes without needing a second client recreate
    */
   it("replays a fresh edge query once upstream attaches after init", async () => {
-    await publishSyncServerSchemaAndPermissions();
+    const syncServer = await publishSyncServerSchemaAndPermissions("edge-late-attach");
     const sharedLocalAuthToken = generateAuthSecret();
-    const { serverUrl } = await getTestingServerInfo();
-    const dbWriter = await createSyncedDb(ctx, "edge-late-attach-writer", sharedLocalAuthToken);
+    const { serverUrl } = syncServer;
+    const dbWriter = await createSyncedDb(
+      ctx,
+      "edge-late-attach-writer",
+      sharedLocalAuthToken,
+      syncServer,
+    );
     const writerProbe = attachWorkerMessageProbe(dbWriter);
     let probeProbe: WorkerMessageProbe | null = null;
 
@@ -1135,7 +1141,12 @@ describe("Worker Bridge with OPFS", () => {
       await blockTestingServerNetwork(serverUrl);
       await sleep(250);
 
-      const dbProbe = await createSyncedDb(ctx, "edge-late-attach-probe", sharedLocalAuthToken);
+      const dbProbe = await createSyncedDb(
+        ctx,
+        "edge-late-attach-probe",
+        sharedLocalAuthToken,
+        syncServer,
+      );
       probeProbe = attachWorkerMessageProbe(dbProbe);
       const probeRowsPromise = waitForTodos(
         dbProbe,
@@ -1176,10 +1187,10 @@ describe("Worker Bridge with OPFS", () => {
    *   expected: the earlier offline worker write also promotes to B + fresh edge client
    */
   it("promotes offline worker rows after reconnect while the worker stays alive", async () => {
-    await publishSyncServerSchemaAndPermissions();
+    const syncServer = await publishSyncServerSchemaAndPermissions("sync-offline");
     const sharedLocalAuthToken = generateAuthSecret();
-    const { appId, serverUrl, adminSecret } = await getTestingServerInfo();
-    const dbA = await createSyncedDb(ctx, "sync-offline-a", sharedLocalAuthToken);
+    const { appId, serverUrl, adminSecret } = syncServer;
+    const dbA = await createSyncedDb(ctx, "sync-offline-a", sharedLocalAuthToken, syncServer);
     const dbAProbe = attachWorkerMessageProbe(dbA);
     const remoteDbId = trackRemoteBrowserDb(uniqueDbName("sync-offline-remote"));
     await createRemoteBrowserDb({
@@ -1279,7 +1290,12 @@ describe("Worker Bridge with OPFS", () => {
 
     let dbProbeTrace: WorkerMessageProbe | null = null;
     try {
-      const dbProbe = await createSyncedDb(ctx, "sync-offline-probe", sharedLocalAuthToken);
+      const dbProbe = await createSyncedDb(
+        ctx,
+        "sync-offline-probe",
+        sharedLocalAuthToken,
+        syncServer,
+      );
       dbProbeTrace = attachWorkerMessageProbe(dbProbe);
       const rowsOnProbe = await waitForTodos(
         dbProbe,
@@ -1356,10 +1372,10 @@ describe("Worker Bridge with OPFS", () => {
   }, 60000);
 
   it("local-only subscriptions do not receive rows from sync server", async () => {
-    await publishSyncServerSchemaAndPermissions();
+    const syncServer = await publishSyncServerSchemaAndPermissions("sync-local-only");
     const sharedLocalAuthToken = generateAuthSecret();
-    const dbA = await createSyncedDb(ctx, "sync-local-only-a", sharedLocalAuthToken);
-    const dbB = await createSyncedDb(ctx, "sync-local-only-b", sharedLocalAuthToken);
+    const dbA = await createSyncedDb(ctx, "sync-local-only-a", sharedLocalAuthToken, syncServer);
+    const dbB = await createSyncedDb(ctx, "sync-local-only-b", sharedLocalAuthToken, syncServer);
 
     const snapshots: Todo[][] = [];
     const unsub = trackSubscription(
@@ -1548,8 +1564,9 @@ async function waitForTodos(
   return waitForQuery(db, allTodos, predicate, label, timeoutMs, tier);
 }
 
-async function publishSyncServerSchemaAndPermissions(): Promise<void> {
-  const { serverUrl, adminSecret } = await getTestingServerInfo();
+async function publishSyncServerSchemaAndPermissions(scope: string): Promise<TestingServerInfo> {
+  const testingServer = await getTestingServerInfo(uniqueDbName(`worker-bridge-${scope}`));
+  const { serverUrl, adminSecret } = testingServer;
   const { hash: schemaHash } = await publishStoredSchema(serverUrl, {
     adminSecret,
     schema,
@@ -1580,6 +1597,8 @@ async function publishSyncServerSchemaAndPermissions(): Promise<void> {
     },
     expectedParentBundleObjectId: head?.bundleObjectId ?? null,
   });
+
+  return testingServer;
 }
 
 function hasRestoredCatalogueState(state: DebugSchemaState): boolean {

--- a/packages/jazz-tools/tests/browser/worker-bridge.test.ts
+++ b/packages/jazz-tools/tests/browser/worker-bridge.test.ts
@@ -32,6 +32,11 @@ import {
   createRemoteBrowserDb,
   waitForRemoteBrowserDbTitle,
 } from "./remote-browser-db.js";
+import {
+  fetchPermissionsHead,
+  publishStoredPermissions,
+  publishStoredSchema,
+} from "../../src/runtime/schema-fetch.js";
 
 interface DebugLensEdgeState {
   sourceHash: string;
@@ -989,6 +994,7 @@ describe("Worker Bridge with OPFS", () => {
   // -------------------------------------------------------------------------
 
   it("propagates synced row from client A to client B", async () => {
+    await publishSyncServerSchemaAndPermissions();
     const sharedLocalAuthToken = generateAuthSecret();
     const dbA = await createSyncedDb(ctx, "sync-a", sharedLocalAuthToken);
     const dbB = await createSyncedDb(ctx, "sync-b", sharedLocalAuthToken);
@@ -1010,6 +1016,7 @@ describe("Worker Bridge with OPFS", () => {
   }, 60000);
 
   it("propagates synced row from client B to client A", async () => {
+    await publishSyncServerSchemaAndPermissions();
     const sharedLocalAuthToken = generateAuthSecret();
     const dbA = await createSyncedDb(ctx, "sync-a-reverse", sharedLocalAuthToken);
     const dbB = await createSyncedDb(ctx, "sync-b-reverse", sharedLocalAuthToken);
@@ -1031,6 +1038,7 @@ describe("Worker Bridge with OPFS", () => {
   }, 60000);
 
   it("recovers sync after browser-side network loss with B in a separate context", async () => {
+    await publishSyncServerSchemaAndPermissions();
     const sharedLocalAuthToken = generateAuthSecret();
     const { appId, serverUrl, adminSecret } = await getTestingServerInfo();
     const dbA = await createSyncedDb(ctx, "sync-recover-a", sharedLocalAuthToken);
@@ -1094,6 +1102,7 @@ describe("Worker Bridge with OPFS", () => {
    *   expected: the first fresh edge query completes without needing a second client recreate
    */
   it("replays a fresh edge query once upstream attaches after init", async () => {
+    await publishSyncServerSchemaAndPermissions();
     const sharedLocalAuthToken = generateAuthSecret();
     const { serverUrl } = await getTestingServerInfo();
     const dbWriter = await createSyncedDb(ctx, "edge-late-attach-writer", sharedLocalAuthToken);
@@ -1141,7 +1150,7 @@ describe("Worker Bridge with OPFS", () => {
           serverUrl,
           [
             { name: "writer", db: dbWriter, probe: writerProbe },
-            { name: "probe", db: dbProbe, probe: probeProbe },
+            { name: "probe", db: dbProbe, probe: probeProbe ?? undefined },
           ],
         ),
       );
@@ -1167,6 +1176,7 @@ describe("Worker Bridge with OPFS", () => {
    *   expected: the earlier offline worker write also promotes to B + fresh edge client
    */
   it("promotes offline worker rows after reconnect while the worker stays alive", async () => {
+    await publishSyncServerSchemaAndPermissions();
     const sharedLocalAuthToken = generateAuthSecret();
     const { appId, serverUrl, adminSecret } = await getTestingServerInfo();
     const dbA = await createSyncedDb(ctx, "sync-offline-a", sharedLocalAuthToken);
@@ -1284,7 +1294,7 @@ describe("Worker Bridge with OPFS", () => {
           serverUrl,
           [
             { name: "writer-a", db: dbA, probe: dbAProbe },
-            { name: "probe", db: dbProbe, probe: dbProbeTrace },
+            { name: "probe", db: dbProbe, probe: dbProbeTrace ?? undefined },
           ],
         ),
       );
@@ -1346,6 +1356,7 @@ describe("Worker Bridge with OPFS", () => {
   }, 60000);
 
   it("local-only subscriptions do not receive rows from sync server", async () => {
+    await publishSyncServerSchemaAndPermissions();
     const sharedLocalAuthToken = generateAuthSecret();
     const dbA = await createSyncedDb(ctx, "sync-local-only-a", sharedLocalAuthToken);
     const dbB = await createSyncedDb(ctx, "sync-local-only-b", sharedLocalAuthToken);
@@ -1535,6 +1546,40 @@ async function waitForTodos(
   tier?: "worker" | "edge",
 ): Promise<Todo[]> {
   return waitForQuery(db, allTodos, predicate, label, timeoutMs, tier);
+}
+
+async function publishSyncServerSchemaAndPermissions(): Promise<void> {
+  const { serverUrl, adminSecret } = await getTestingServerInfo();
+  const { hash: schemaHash } = await publishStoredSchema(serverUrl, {
+    adminSecret,
+    schema,
+  });
+  const { head } = await fetchPermissionsHead(serverUrl, { adminSecret });
+  await publishStoredPermissions(serverUrl, {
+    adminSecret,
+    schemaHash,
+    permissions: {
+      todos: {
+        select: { using: { type: "True" } },
+        insert: { with_check: { type: "True" } },
+        update: {
+          using: { type: "True" },
+          with_check: { type: "True" },
+        },
+        delete: { using: { type: "True" } },
+      },
+      projects: {
+        select: { using: { type: "True" } },
+        insert: { with_check: { type: "True" } },
+        update: {
+          using: { type: "True" },
+          with_check: { type: "True" },
+        },
+        delete: { using: { type: "True" } },
+      },
+    },
+    expectedParentBundleObjectId: head?.bundleObjectId ?? null,
+  });
 }
 
 function hasRestoredCatalogueState(state: DebugSchemaState): boolean {

--- a/packages/jazz-tools/vitest.config.browser.ts
+++ b/packages/jazz-tools/vitest.config.browser.ts
@@ -58,7 +58,7 @@ export default defineConfig({
       provider: playwright(),
       instances: [{ browser: "chromium", headless: true }],
       commands: {
-        testingServerInfo: async () => testingServerInfo(),
+        testingServerInfo: async (_context, appId) => testingServerInfo(appId),
         testingServerBlockNetwork: async ({ context }, serverUrl) =>
           blockTestingServerNetwork(context, serverUrl),
         testingServerUnblockNetwork: async ({ context }, serverUrl) =>

--- a/specs/status-quo/query_manager.md
+++ b/specs/status-quo/query_manager.md
@@ -115,7 +115,9 @@ needing to understand policy evaluation itself.
 The current runtime also carries an explicit row-policy mode:
 
 - `PermissiveLocal`: no compiled policy bundle is loaded in this runtime
-- `Enforcing`: a compiled policy bundle is loaded, even if it is empty
+- `Enforcing`: this runtime must fail closed for missing explicit policy,
+  either because a compiled policy bundle is loaded or because a dynamic server
+  is waiting for its current permissions head
 
 That mode is shared across local query compilation, subscription filtering,
 server-side authorization, and sync-scope derivation.
@@ -134,6 +136,8 @@ In `Enforcing`, missing explicit clauses deny by default:
   denies
 - inherited and recursive checks fail closed when the parent policy or graph
   context cannot be resolved
+- dynamic servers that have learned schema but not yet learned a permissions
+  head stay closed instead of temporarily behaving like local permissive runtimes
 
 ## Key Files
 

--- a/specs/status-quo/schema_manager.md
+++ b/specs/status-quo/schema_manager.md
@@ -114,9 +114,10 @@ A server may learn schemas gradually from connected clients through catalogue
 sync. It can then answer queries for several client schema hashes at once
 without restarting or rebuilding the runtime from scratch.
 
-Backends and sync runtimes are normally enforcing runtimes because they load or
-receive permissions bundles explicitly. An empty loaded bundle is still distinct
-from "no bundle loaded" and still means explicit grants only.
+Dynamic servers boot in fail-closed mode even before they have learned the
+current permissions head. Once they receive a permissions head and its bundle,
+they keep enforcing with that authorization schema. An empty loaded bundle is
+still distinct from "no bundle loaded" and still means explicit grants only.
 
 The JS/native runtime schema wire payload now carries that loaded-bundle bit so
 an empty loaded bundle stays distinguishable from a structural-schema-only boot.


### PR DESCRIPTION
## Summary

This fixes a security issue where a sync server could start in a permissive mode and allow authenticated clients to read or mutate data before any permissions bundle had been published.

After this change, server runtimes always start in enforcing mode and deny access until permissions are available. Client runtimes keep their existing behavior and remain permissive until they learn permissions from the server.

## What changed

- Make dynamic servers start with authorization required, even before a permissions head exists
- Make fixed-schema servers use enforcing row policy mode instead of inheriting client-style permissive behavior
- Reject server-side sync writes immediately when current permissions are unavailable, rather than leaving them pending
- Add regression tests covering:
  - server-mode reads without a permissions head
  - server-mode sync writes without a permissions head
  - client runtimes remaining permissive before permissions arrive