### PR TITLE
Add caller-supplied UUIDv7 create and upsert APIs

### DIFF
--- a/.changeset/calm-badgers-borrow.md
+++ b/.changeset/calm-badgers-borrow.md
@@ -1,0 +1,8 @@
+---
+"jazz-tools": patch
+"jazz-wasm": patch
+"jazz-napi": patch
+"jazz-rn": patch
+---
+
+Add external UUIDv7 create APIs and id-based upsert APIs across the Rust and TypeScript client surfaces.

--- a/crates/jazz-napi/src/lib.rs
+++ b/crates/jazz-napi/src/lib.rs
@@ -25,7 +25,8 @@ use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use jazz_tools::binding_support::{
     align_query_rows_to_declared_schema, align_row_values_to_declared_schema, current_timestamp_ms,
     generate_id as generate_binding_id, parse_durability_tier as parse_binding_tier,
-    parse_query_input, parse_read_durability_options as parse_binding_read_durability_options,
+    parse_external_object_id, parse_query_input,
+    parse_read_durability_options as parse_binding_read_durability_options,
     parse_runtime_schema_input, parse_session_input, parse_write_context_input,
     query_rows_can_be_schema_aligned, serialize_outbox_entry, subscription_delta_to_json,
 };
@@ -542,13 +543,16 @@ impl NapiRuntime {
         &self,
         table: String,
         #[napi(ts_arg_type = "Record<string, unknown>")] values: FfiRecordArg,
+        object_id: Option<String>,
     ) -> napi::Result<serde_json::Value> {
+        let object_id =
+            parse_external_object_id(object_id.as_deref()).map_err(napi::Error::from_reason)?;
         let mut core = self
             .core
             .lock()
             .map_err(|_| napi::Error::from_reason("lock"))?;
         let (object_id, row_values) = core
-            .insert(&table, values.0, None)
+            .insert_with_id(&table, values.0, object_id, None)
             .map_err(|e| napi::Error::from_reason(format!("Insert failed: {e}")))?;
         let row_values = align_row_values_to_declared_schema(
             &self.declared_schema,
@@ -569,15 +573,18 @@ impl NapiRuntime {
         table: String,
         #[napi(ts_arg_type = "Record<string, unknown>")] values: FfiRecordArg,
         write_context_json: Option<String>,
+        object_id: Option<String>,
     ) -> napi::Result<serde_json::Value> {
         let write_context = parse_write_context_json(write_context_json)?;
+        let object_id =
+            parse_external_object_id(object_id.as_deref()).map_err(napi::Error::from_reason)?;
 
         let mut core = self
             .core
             .lock()
             .map_err(|_| napi::Error::from_reason("lock"))?;
         let (object_id, row_values) = core
-            .insert(&table, values.0, write_context.as_ref())
+            .insert_with_id(&table, values.0, object_id, write_context.as_ref())
             .map_err(|e| napi::Error::from_reason(format!("Insert failed: {:?}", e)))?;
         let row_values = align_row_values_to_declared_schema(
             &self.declared_schema,
@@ -862,8 +869,11 @@ impl NapiRuntime {
         table: String,
         #[napi(ts_arg_type = "Record<string, unknown>")] values: FfiRecordArg,
         tier: String,
+        object_id: Option<String>,
     ) -> napi::Result<serde_json::Value> {
         let persistence_tier = parse_tier(&tier)?;
+        let object_id =
+            parse_external_object_id(object_id.as_deref()).map_err(napi::Error::from_reason)?;
 
         let ((object_id, row_values), receiver) = {
             let mut core = self
@@ -871,7 +881,7 @@ impl NapiRuntime {
                 .lock()
                 .map_err(|_| napi::Error::from_reason("lock"))?;
             let ((object_id, row_values), receiver) = core
-                .insert_persisted(&table, values.0, None, persistence_tier)
+                .insert_persisted_with_id(&table, values.0, object_id, None, persistence_tier)
                 .map_err(|e| napi::Error::from_reason(format!("Insert failed: {e}")))?;
             let row_values = align_row_values_to_declared_schema(
                 &self.declared_schema,
@@ -896,9 +906,12 @@ impl NapiRuntime {
         #[napi(ts_arg_type = "Record<string, unknown>")] values: FfiRecordArg,
         write_context_json: Option<String>,
         tier: String,
+        object_id: Option<String>,
     ) -> napi::Result<serde_json::Value> {
         let persistence_tier = parse_tier(&tier)?;
         let write_context = parse_write_context_json(write_context_json)?;
+        let object_id =
+            parse_external_object_id(object_id.as_deref()).map_err(napi::Error::from_reason)?;
 
         let ((object_id, row_values), receiver) = {
             let mut core = self
@@ -906,7 +919,13 @@ impl NapiRuntime {
                 .lock()
                 .map_err(|_| napi::Error::from_reason("lock"))?;
             let ((object_id, row_values), receiver) = core
-                .insert_persisted(&table, values.0, write_context.as_ref(), persistence_tier)
+                .insert_persisted_with_id(
+                    &table,
+                    values.0,
+                    object_id,
+                    write_context.as_ref(),
+                    persistence_tier,
+                )
                 .map_err(|e| napi::Error::from_reason(format!("Insert failed: {:?}", e)))?;
             let row_values = align_row_values_to_declared_schema(
                 &self.declared_schema,

--- a/crates/jazz-rn/rust/src/lib.rs
+++ b/crates/jazz-rn/rust/src/lib.rs
@@ -16,7 +16,7 @@ use jazz_tools::binding_support::{
     current_timestamp_ms as binding_current_timestamp_ms,
     default_read_durability_options as default_binding_read_durability_options,
     generate_id as generate_binding_id, parse_durability_tier as parse_binding_tier,
-    parse_query_input, parse_session_input, parse_write_context_input,
+    parse_external_object_id, parse_query_input, parse_session_input, parse_write_context_input,
     query_rows_can_be_schema_aligned, serialize_outbox_entry, subscription_delta_to_json,
 };
 use jazz_tools::object::ObjectId;
@@ -455,14 +455,21 @@ impl RnRuntime {
     // CRUD
     // =========================================================================
 
-    pub fn insert(&self, table: String, values_json: String) -> Result<String, JazzRnError> {
+    pub fn insert(
+        &self,
+        table: String,
+        values_json: String,
+        object_id: Option<String>,
+    ) -> Result<String, JazzRnError> {
         with_panic_boundary("insert", || {
             let named_values = convert_insert_values(&values_json)?;
+            let object_id = parse_external_object_id(object_id.as_deref())
+                .map_err(|message| JazzRnError::InvalidUuid { message })?;
             let mut core = self.core.lock().map_err(|_| JazzRnError::Internal {
                 message: "lock poisoned".into(),
             })?;
             let (id, row_values) = core
-                .insert(&table, named_values, None)
+                .insert_with_id(&table, named_values, object_id, None)
                 .map_err(runtime_err)?;
             let row_values = align_row_values_to_declared_schema(
                 &self.declared_schema,
@@ -485,15 +492,18 @@ impl RnRuntime {
         table: String,
         values_json: String,
         write_context_json: Option<String>,
+        object_id: Option<String>,
     ) -> Result<String, JazzRnError> {
         with_panic_boundary("insert_with_session", || {
             let named_values = convert_insert_values(&values_json)?;
             let write_context = parse_write_context(write_context_json)?;
+            let object_id = parse_external_object_id(object_id.as_deref())
+                .map_err(|message| JazzRnError::InvalidUuid { message })?;
             let mut core = self.core.lock().map_err(|_| JazzRnError::Internal {
                 message: "lock poisoned".into(),
             })?;
             let (id, row_values) = core
-                .insert(&table, named_values, write_context.as_ref())
+                .insert_with_id(&table, named_values, object_id, write_context.as_ref())
                 .map_err(runtime_err)?;
             let row_values = align_row_values_to_declared_schema(
                 &self.declared_schema,

--- a/crates/jazz-tools/src/binding_support.rs
+++ b/crates/jazz-tools/src/binding_support.rs
@@ -6,6 +6,7 @@
 use std::collections::HashMap;
 
 use serde::Deserialize;
+use uuid::Uuid;
 
 use crate::object::ObjectId;
 use crate::query_manager::manager::LocalUpdates;
@@ -332,6 +333,22 @@ pub fn serialize_outbox_entry(message: &OutboxEntry) -> Result<SerializedOutboxE
 
 pub fn generate_id() -> String {
     ObjectId::new().uuid().to_string()
+}
+
+pub fn parse_external_object_id(object_id: Option<&str>) -> Result<Option<ObjectId>, String> {
+    let Some(object_id) = object_id else {
+        return Ok(None);
+    };
+
+    let uuid = Uuid::parse_str(object_id).map_err(|err| format!("Invalid ObjectId: {err}"))?;
+    if uuid.get_version_num() != 7 {
+        return Err(format!(
+            "Invalid ObjectId: expected UUIDv7, got version {}",
+            uuid.get_version_num()
+        ));
+    }
+
+    Ok(Some(ObjectId::from_uuid(uuid)))
 }
 
 pub fn current_timestamp_ms() -> i64 {

--- a/crates/jazz-tools/src/client.rs
+++ b/crates/jazz-tools/src/client.rs
@@ -28,6 +28,7 @@ use bytes::BytesMut;
 use futures::StreamExt;
 use serde::Deserialize;
 use tokio::sync::{RwLock, mpsc, oneshot};
+use uuid::Uuid;
 
 use crate::transport::{AuthConfig, ServerConnection};
 use crate::{
@@ -441,9 +442,25 @@ impl JazzClient {
         table: &str,
         values: HashMap<String, Value>,
     ) -> Result<(ObjectId, Vec<Value>)> {
+        self.create_with_id(table, Option::<Uuid>::None, values)
+            .await
+    }
+
+    /// Create a new row in a table using a caller-supplied UUIDv7.
+    pub async fn create_with_id(
+        &self,
+        table: &str,
+        object_id: impl Into<Option<Uuid>>,
+        values: HashMap<String, Value>,
+    ) -> Result<(ObjectId, Vec<Value>)> {
         let (object_id, row_values) = self
             .runtime
-            .insert(table, values, None)
+            .insert_with_id(
+                table,
+                values,
+                object_id.into().map(ObjectId::from_uuid),
+                None,
+            )
             .map_err(|e| JazzError::Write(e.to_string()))?;
         let row_values = match self.runtime.current_schema() {
             Ok(schema) => align_row_values_to_declared_schema(
@@ -464,9 +481,27 @@ impl JazzClient {
         values: HashMap<String, Value>,
         tier: DurabilityTier,
     ) -> Result<(ObjectId, Vec<Value>)> {
+        self.create_persisted_with_id(table, Option::<Uuid>::None, values, tier)
+            .await
+    }
+
+    /// Create a new row with a caller-supplied UUIDv7 and wait for durability.
+    pub async fn create_persisted_with_id(
+        &self,
+        table: &str,
+        object_id: impl Into<Option<Uuid>>,
+        values: HashMap<String, Value>,
+        tier: DurabilityTier,
+    ) -> Result<(ObjectId, Vec<Value>)> {
         let ((object_id, row_values), receiver) = self
             .runtime
-            .insert_persisted(table, values, None, tier)
+            .insert_persisted_with_id(
+                table,
+                values,
+                object_id.into().map(ObjectId::from_uuid),
+                None,
+                tier,
+            )
             .map_err(|e| JazzError::Write(e.to_string()))?;
         let row_values = match self.runtime.current_schema() {
             Ok(schema) => align_row_values_to_declared_schema(
@@ -479,6 +514,33 @@ impl JazzClient {
         };
         wait_for_persisted_write(receiver, "create row", tier).await?;
         Ok((object_id, row_values))
+    }
+
+    /// Create or update a row using a caller-supplied UUIDv7.
+    pub async fn upsert(
+        &self,
+        table: &str,
+        object_id: Uuid,
+        values: HashMap<String, Value>,
+    ) -> Result<()> {
+        self.runtime
+            .upsert_with_id(table, ObjectId::from_uuid(object_id), values, None)
+            .map_err(|e| JazzError::Write(e.to_string()))
+    }
+
+    /// Create or update a row and wait until it reaches the requested durability tier.
+    pub async fn upsert_persisted(
+        &self,
+        table: &str,
+        object_id: Uuid,
+        values: HashMap<String, Value>,
+        tier: DurabilityTier,
+    ) -> Result<()> {
+        let receiver = self
+            .runtime
+            .upsert_persisted_with_id(table, ObjectId::from_uuid(object_id), values, None, tier)
+            .map_err(|e| JazzError::Write(e.to_string()))?;
+        wait_for_persisted_write(receiver, "upsert row", tier).await
     }
 
     /// Update a row.
@@ -615,10 +677,25 @@ impl<'a> SessionClient<'a> {
         table: &str,
         values: HashMap<String, Value>,
     ) -> Result<(ObjectId, Vec<Value>)> {
+        self.create_with_id(table, Option::<Uuid>::None, values)
+            .await
+    }
+
+    pub async fn create_with_id(
+        &self,
+        table: &str,
+        object_id: impl Into<Option<Uuid>>,
+        values: HashMap<String, Value>,
+    ) -> Result<(ObjectId, Vec<Value>)> {
         let (object_id, row_values) = self
             .client
             .runtime
-            .insert(table, values, Some(&self.session))
+            .insert_with_id(
+                table,
+                values,
+                object_id.into().map(ObjectId::from_uuid),
+                Some(&self.session),
+            )
             .map_err(|e| JazzError::Write(e.to_string()))?;
         let row_values = match self.client.runtime.current_schema() {
             Ok(schema) => align_row_values_to_declared_schema(
@@ -638,10 +715,27 @@ impl<'a> SessionClient<'a> {
         values: HashMap<String, Value>,
         tier: DurabilityTier,
     ) -> Result<(ObjectId, Vec<Value>)> {
+        self.create_persisted_with_id(table, Option::<Uuid>::None, values, tier)
+            .await
+    }
+
+    pub async fn create_persisted_with_id(
+        &self,
+        table: &str,
+        object_id: impl Into<Option<Uuid>>,
+        values: HashMap<String, Value>,
+        tier: DurabilityTier,
+    ) -> Result<(ObjectId, Vec<Value>)> {
         let ((object_id, row_values), receiver) = self
             .client
             .runtime
-            .insert_persisted(table, values, Some(&self.session), tier)
+            .insert_persisted_with_id(
+                table,
+                values,
+                object_id.into().map(ObjectId::from_uuid),
+                Some(&self.session),
+                tier,
+            )
             .map_err(|e| JazzError::Write(e.to_string()))?;
         let row_values = match self.client.runtime.current_schema() {
             Ok(schema) => align_row_values_to_declared_schema(
@@ -654,6 +748,44 @@ impl<'a> SessionClient<'a> {
         };
         wait_for_persisted_write(receiver, "create row", tier).await?;
         Ok((object_id, row_values))
+    }
+
+    pub async fn upsert(
+        &self,
+        table: &str,
+        object_id: Uuid,
+        values: HashMap<String, Value>,
+    ) -> Result<()> {
+        self.client
+            .runtime
+            .upsert_with_id(
+                table,
+                ObjectId::from_uuid(object_id),
+                values,
+                Some(&self.session),
+            )
+            .map_err(|e| JazzError::Write(e.to_string()))
+    }
+
+    pub async fn upsert_persisted(
+        &self,
+        table: &str,
+        object_id: Uuid,
+        values: HashMap<String, Value>,
+        tier: DurabilityTier,
+    ) -> Result<()> {
+        let receiver = self
+            .client
+            .runtime
+            .upsert_persisted_with_id(
+                table,
+                ObjectId::from_uuid(object_id),
+                values,
+                Some(&self.session),
+                tier,
+            )
+            .map_err(|e| JazzError::Write(e.to_string()))?;
+        wait_for_persisted_write(receiver, "upsert row", tier).await
     }
 
     pub async fn update(&self, object_id: ObjectId, updates: Vec<(String, Value)>) -> Result<()> {

--- a/crates/jazz-tools/src/query_manager/writes.rs
+++ b/crates/jazz-tools/src/query_manager/writes.rs
@@ -51,6 +51,36 @@ pub struct RowBranchDelete<'a> {
 }
 
 impl QueryManager {
+    fn resolve_insert_object_id<H: Storage>(
+        &self,
+        storage: &H,
+        external_object_id: Option<ObjectId>,
+    ) -> Result<ObjectId, QueryError> {
+        if let Some(object_id) = external_object_id {
+            if object_id.uuid().get_version_num() != 7 {
+                return Err(QueryError::EncodingError(format!(
+                    "external create id must be UUIDv7, got version {} for {}",
+                    object_id.uuid().get_version_num(),
+                    object_id
+                )));
+            }
+
+            if storage
+                .load_row_locator(object_id)
+                .map_err(|err| QueryError::EncodingError(format!("load row locator: {err}")))?
+                .is_some()
+            {
+                return Err(QueryError::EncodingError(format!(
+                    "object already exists: {object_id}"
+                )));
+            }
+
+            return Ok(object_id);
+        }
+
+        Ok(ObjectId::new())
+    }
+
     fn resolve_write_author(write_context: Option<&WriteContext>) -> String {
         write_context
             .map(|write_context| write_context.author_principal().to_string())
@@ -602,6 +632,17 @@ impl QueryManager {
         values: &[Value],
         write_context: Option<&WriteContext>,
     ) -> Result<InsertResult, QueryError> {
+        self.insert_with_write_context_and_id(storage, table, values, None, write_context)
+    }
+
+    pub fn insert_with_write_context_and_id<H: Storage>(
+        &mut self,
+        storage: &mut H,
+        table: &str,
+        values: &[Value],
+        external_object_id: Option<ObjectId>,
+        write_context: Option<&WriteContext>,
+    ) -> Result<InsertResult, QueryError> {
         let _span = tracing::debug_span!("QM::insert", table).entered();
         let table_name = TableName::new(table);
         let table_schema = self
@@ -629,7 +670,7 @@ impl QueryManager {
         // Encode to binary
         let data = encode_row(&descriptor, values)
             .map_err(|e| QueryError::EncodingError(e.to_string()))?;
-        let object_id = ObjectId::new();
+        let object_id = self.resolve_insert_object_id(storage, external_object_id)?;
         let timestamp = self.reserve_write_timestamp();
         let provenance = self.row_provenance_for_insert(write_context, timestamp);
 
@@ -774,6 +815,25 @@ impl QueryManager {
         values: &[Value],
         write_context: Option<&WriteContext>,
     ) -> Result<InsertResult, QueryError> {
+        self.insert_on_branch_with_write_context_and_id(
+            storage,
+            table,
+            branch,
+            values,
+            None,
+            write_context,
+        )
+    }
+
+    pub fn insert_on_branch_with_write_context_and_id<H: Storage>(
+        &mut self,
+        storage: &mut H,
+        table: &str,
+        branch: &str,
+        values: &[Value],
+        external_object_id: Option<ObjectId>,
+        write_context: Option<&WriteContext>,
+    ) -> Result<InsertResult, QueryError> {
         let table_name = TableName::new(table);
         let table_schema = self
             .schema
@@ -795,7 +855,7 @@ impl QueryManager {
         // Encode to binary
         let data = encode_row(&descriptor, values)
             .map_err(|e| QueryError::EncodingError(e.to_string()))?;
-        let object_id = ObjectId::new();
+        let object_id = self.resolve_insert_object_id(storage, external_object_id)?;
         let timestamp = self.reserve_write_timestamp();
         let provenance = self.row_provenance_for_insert(write_context, timestamp);
 

--- a/crates/jazz-tools/src/runtime_core/writes.rs
+++ b/crates/jazz-tools/src/runtime_core/writes.rs
@@ -12,10 +12,27 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
         values: HashMap<String, Value>,
         write_context: Option<&WriteContext>,
     ) -> Result<InsertedRow, RuntimeError> {
+        self.insert_with_id(table, values, None, write_context)
+    }
+
+    /// Insert a row into a table with an optional external row id.
+    pub fn insert_with_id(
+        &mut self,
+        table: &str,
+        values: HashMap<String, Value>,
+        object_id: Option<ObjectId>,
+        write_context: Option<&WriteContext>,
+    ) -> Result<InsertedRow, RuntimeError> {
         let _span = debug_span!("insert", table).entered();
         let result = self
             .schema_manager
-            .insert_with_write_context(&mut self.storage, table, values, write_context)
+            .insert_with_write_context_and_id(
+                &mut self.storage,
+                table,
+                values,
+                object_id,
+                write_context,
+            )
             .map_err(|e| RuntimeError::WriteError(e.to_string()))?;
         let row_id = result.row_id;
         let row_values = result.row_values;
@@ -35,6 +52,30 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
         let _span = debug_span!("update", %object_id).entered();
         self.schema_manager
             .update_with_write_context(&mut self.storage, object_id, &values, write_context)
+            .map_err(|e| RuntimeError::WriteError(e.to_string()))?;
+
+        self.mark_storage_write_pending_flush();
+        self.immediate_tick();
+        Ok(())
+    }
+
+    /// Create or update a row with a caller-supplied external row id.
+    pub fn upsert_with_id(
+        &mut self,
+        table: &str,
+        object_id: ObjectId,
+        values: HashMap<String, Value>,
+        write_context: Option<&WriteContext>,
+    ) -> Result<(), RuntimeError> {
+        let _span = debug_span!("upsert", table, %object_id).entered();
+        self.schema_manager
+            .upsert_with_write_context_and_id(
+                &mut self.storage,
+                table,
+                object_id,
+                values,
+                write_context,
+            )
             .map_err(|e| RuntimeError::WriteError(e.to_string()))?;
 
         self.mark_storage_write_pending_flush();
@@ -71,9 +112,27 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
         write_context: Option<&WriteContext>,
         tier: DurabilityTier,
     ) -> Result<(InsertedRow, oneshot::Receiver<()>), RuntimeError> {
+        self.insert_persisted_with_id(table, values, None, write_context, tier)
+    }
+
+    /// Insert a row with an optional external row id and durability tracking.
+    pub fn insert_persisted_with_id(
+        &mut self,
+        table: &str,
+        values: HashMap<String, Value>,
+        object_id: Option<ObjectId>,
+        write_context: Option<&WriteContext>,
+        tier: DurabilityTier,
+    ) -> Result<(InsertedRow, oneshot::Receiver<()>), RuntimeError> {
         let result = self
             .schema_manager
-            .insert_with_write_context(&mut self.storage, table, values, write_context)
+            .insert_with_write_context_and_id(
+                &mut self.storage,
+                table,
+                values,
+                object_id,
+                write_context,
+            )
             .map_err(|e| RuntimeError::WriteError(e.to_string()))?;
         let row_id = result.row_id;
         let row_version_id = result.row_version_id;
@@ -113,6 +172,48 @@ impl<S: Storage, Sch: Scheduler, Sy: SyncSender> RuntimeCore<S, Sch, Sy> {
         let version_id = self
             .schema_manager
             .update_with_write_context(&mut self.storage, object_id, &values, write_context)
+            .map_err(|e| RuntimeError::WriteError(e.to_string()))?;
+        let row_version_key =
+            RowVersionKey::new(object_id, self.schema_manager.branch_name(), version_id);
+
+        let (sender, receiver) = oneshot::channel();
+        if self
+            .schema_manager
+            .query_manager()
+            .sync_manager()
+            .has_local_durability_at_least(tier)
+        {
+            let _ = sender.send(());
+        } else {
+            self.ack_watchers
+                .entry(row_version_key)
+                .or_default()
+                .push((tier, sender));
+        }
+
+        self.mark_storage_write_pending_flush();
+        self.immediate_tick();
+        Ok(receiver)
+    }
+
+    /// Create or update a row and wait for durability at the requested tier.
+    pub fn upsert_persisted_with_id(
+        &mut self,
+        table: &str,
+        object_id: ObjectId,
+        values: HashMap<String, Value>,
+        write_context: Option<&WriteContext>,
+        tier: DurabilityTier,
+    ) -> Result<oneshot::Receiver<()>, RuntimeError> {
+        let version_id = self
+            .schema_manager
+            .upsert_with_write_context_and_id(
+                &mut self.storage,
+                table,
+                object_id,
+                values,
+                write_context,
+            )
             .map_err(|e| RuntimeError::WriteError(e.to_string()))?;
         let row_version_key =
             RowVersionKey::new(object_id, self.schema_manager.branch_name(), version_id);

--- a/crates/jazz-tools/src/runtime_tokio.rs
+++ b/crates/jazz-tools/src/runtime_tokio.rs
@@ -259,9 +259,20 @@ impl<S: Storage + Send + 'static> TokioRuntime<S> {
         values: HashMap<String, Value>,
         session: Option<&Session>,
     ) -> Result<(ObjectId, Vec<Value>), RuntimeError> {
+        self.insert_with_id(table, values, None, session)
+    }
+
+    /// Insert a row into a table with an optional external row id.
+    pub fn insert_with_id(
+        &self,
+        table: &str,
+        values: HashMap<String, Value>,
+        object_id: Option<ObjectId>,
+        session: Option<&Session>,
+    ) -> Result<(ObjectId, Vec<Value>), RuntimeError> {
         let mut core = self.core.lock().map_err(|_| RuntimeError::LockError)?;
         let owned = session.cloned().map(WriteContext::from_session);
-        let result = core.insert(table, values, owned.as_ref())?;
+        let result = core.insert_with_id(table, values, object_id, owned.as_ref())?;
         Ok(result)
     }
 
@@ -274,9 +285,22 @@ impl<S: Storage + Send + 'static> TokioRuntime<S> {
         session: Option<&Session>,
         tier: DurabilityTier,
     ) -> Result<PersistedInsertResult, RuntimeError> {
+        self.insert_persisted_with_id(table, values, None, session, tier)
+    }
+
+    /// Insert a row with an optional external row id and durability tracking.
+    pub fn insert_persisted_with_id(
+        &self,
+        table: &str,
+        values: HashMap<String, Value>,
+        object_id: Option<ObjectId>,
+        session: Option<&Session>,
+        tier: DurabilityTier,
+    ) -> Result<PersistedInsertResult, RuntimeError> {
         let mut core = self.core.lock().map_err(|_| RuntimeError::LockError)?;
         let owned = session.cloned().map(WriteContext::from_session);
-        let result = core.insert_persisted(table, values, owned.as_ref(), tier)?;
+        let result =
+            core.insert_persisted_with_id(table, values, object_id, owned.as_ref(), tier)?;
         Ok(result)
     }
 
@@ -293,6 +317,20 @@ impl<S: Storage + Send + 'static> TokioRuntime<S> {
         Ok(())
     }
 
+    /// Create or update a row with a caller-supplied external row id.
+    pub fn upsert_with_id(
+        &self,
+        table: &str,
+        object_id: ObjectId,
+        values: HashMap<String, Value>,
+        session: Option<&Session>,
+    ) -> Result<(), RuntimeError> {
+        let mut core = self.core.lock().map_err(|_| RuntimeError::LockError)?;
+        let owned = session.cloned().map(WriteContext::from_session);
+        core.upsert_with_id(table, object_id, values, owned.as_ref())?;
+        Ok(())
+    }
+
     /// Update a row and return a receiver that resolves when the requested
     /// durability tier (or higher) acknowledges.
     pub fn update_persisted(
@@ -305,6 +343,23 @@ impl<S: Storage + Send + 'static> TokioRuntime<S> {
         let mut core = self.core.lock().map_err(|_| RuntimeError::LockError)?;
         let owned = session.cloned().map(WriteContext::from_session);
         let receiver = core.update_persisted(object_id, values, owned.as_ref(), tier)?;
+        Ok(receiver)
+    }
+
+    /// Create or update a row and return a receiver that resolves when the
+    /// requested durability tier (or higher) acknowledges.
+    pub fn upsert_persisted_with_id(
+        &self,
+        table: &str,
+        object_id: ObjectId,
+        values: HashMap<String, Value>,
+        session: Option<&Session>,
+        tier: DurabilityTier,
+    ) -> Result<PersistedWriteAck, RuntimeError> {
+        let mut core = self.core.lock().map_err(|_| RuntimeError::LockError)?;
+        let owned = session.cloned().map(WriteContext::from_session);
+        let receiver =
+            core.upsert_persisted_with_id(table, object_id, values, owned.as_ref(), tier)?;
         Ok(receiver)
     }
 

--- a/crates/jazz-tools/src/schema_manager/manager.rs
+++ b/crates/jazz-tools/src/schema_manager/manager.rs
@@ -1469,15 +1469,28 @@ impl SchemaManager {
         values: HashMap<String, Value>,
         write_context: Option<&WriteContext>,
     ) -> Result<InsertResult, QueryError> {
+        self.insert_with_write_context_and_id(storage, table, values, None, write_context)
+    }
+
+    pub fn insert_with_write_context_and_id<H: Storage>(
+        &mut self,
+        storage: &mut H,
+        table: &str,
+        values: HashMap<String, Value>,
+        object_id: Option<ObjectId>,
+        write_context: Option<&WriteContext>,
+    ) -> Result<InsertResult, QueryError> {
         let _ = self.ensure_current_schema_persisted(storage);
         let aligned_values = self.get_insert_values_with_defaults(table, values)?;
-        self.query_manager.insert_on_branch_with_write_context(
-            storage,
-            table,
-            self.context.branch_name().as_str(),
-            &aligned_values,
-            write_context,
-        )
+        self.query_manager
+            .insert_on_branch_with_write_context_and_id(
+                storage,
+                table,
+                self.context.branch_name().as_str(),
+                &aligned_values,
+                object_id,
+                write_context,
+            )
     }
 
     pub fn insert_with_session<H: Storage>(
@@ -1489,6 +1502,74 @@ impl SchemaManager {
     ) -> Result<InsertResult, QueryError> {
         let owned = session.cloned().map(WriteContext::from_session);
         self.insert_with_write_context(storage, table, values, owned.as_ref())
+    }
+
+    fn validate_external_upsert_object_id(object_id: ObjectId) -> Result<(), QueryError> {
+        if object_id.uuid().get_version_num() != 7 {
+            return Err(QueryError::EncodingError(format!(
+                "external upsert id must be UUIDv7, got version {} for {}",
+                object_id.uuid().get_version_num(),
+                object_id
+            )));
+        }
+
+        Ok(())
+    }
+
+    /// Create or update a row with a caller-supplied UUIDv7.
+    ///
+    /// If a visible row already exists for `object_id`, only the supplied
+    /// columns are updated. Otherwise a new row is inserted with that id.
+    pub fn upsert_with_write_context_and_id<H: Storage>(
+        &mut self,
+        storage: &mut H,
+        table: &str,
+        object_id: ObjectId,
+        values: HashMap<String, Value>,
+        write_context: Option<&WriteContext>,
+    ) -> Result<crate::commit::CommitId, QueryError> {
+        Self::validate_external_upsert_object_id(object_id)?;
+        let _ = self.ensure_current_schema_persisted(storage);
+        let branches = self.all_branch_strings();
+
+        if let Some((existing_table, ..)) = self
+            .query_manager
+            .load_row_for_schema_update(storage, object_id, &branches)
+        {
+            if existing_table != table {
+                return Err(QueryError::EncodingError(format!(
+                    "object {object_id} already exists in table {existing_table}, cannot upsert into {table}"
+                )));
+            }
+
+            return self.update_with_write_context(
+                storage,
+                object_id,
+                &values.into_iter().collect::<Vec<_>>(),
+                write_context,
+            );
+        }
+
+        let inserted = self.insert_with_write_context_and_id(
+            storage,
+            table,
+            values,
+            Some(object_id),
+            write_context,
+        )?;
+        Ok(inserted.row_version_id)
+    }
+
+    pub fn upsert_with_session<H: Storage>(
+        &mut self,
+        storage: &mut H,
+        table: &str,
+        object_id: ObjectId,
+        values: HashMap<String, Value>,
+        session: Option<&Session>,
+    ) -> Result<crate::commit::CommitId, QueryError> {
+        let owned = session.cloned().map(WriteContext::from_session);
+        self.upsert_with_write_context_and_id(storage, table, object_id, values, owned.as_ref())
     }
 
     /// Update a row using current-schema column names, performing copy-on-write

--- a/crates/jazz-tools/tests/clients_sync.rs
+++ b/crates/jazz-tools/tests/clients_sync.rs
@@ -11,6 +11,7 @@ use jazz_tools::{
     ColumnType, DurabilityTier, JazzClient, QueryBuilder, SchemaBuilder, TableSchema, Value,
 };
 use support::wait_for_query;
+use uuid::Uuid;
 
 fn test_schema() -> jazz_tools::Schema {
     SchemaBuilder::new()
@@ -210,6 +211,124 @@ async fn jazz_tools_cli_two_clients_sync_values() {
 
     client_a.shutdown().await.expect("shutdown client a");
     client_b.shutdown().await.expect("shutdown client b");
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn caller_supplied_uuidv7_is_used_for_created_row() {
+    let server = TestingServer::start().await;
+    let schema = test_schema();
+    let client = JazzClient::connect(server.make_client_context(schema.clone()))
+        .await
+        .expect("connect writer");
+
+    wait_for_edge_query_ready(&client, Duration::from_secs(30)).await;
+
+    let external_id =
+        Uuid::parse_str("01963f3e-5cbe-7a62-8d7c-123456789abc").expect("parse external uuidv7");
+
+    let (todo_id, expected_values) = client
+        .create_with_id(
+            "todos",
+            external_id,
+            HashMap::from([
+                (
+                    "title".to_string(),
+                    Value::Text("external-id-created".to_string()),
+                ),
+                ("completed".to_string(), Value::Boolean(false)),
+            ]),
+        )
+        .await
+        .expect("create row with external id");
+
+    assert_eq!(todo_id.uuid(), &external_id);
+
+    let rows = wait_for_query(
+        &client,
+        QueryBuilder::new("todos").build(),
+        Some(DurabilityTier::EdgeServer),
+        Duration::from_secs(25),
+        "query returns row created with external id",
+        |rows| {
+            (rows.len() == 1 && rows[0].0 == todo_id && rows[0].1 == expected_values)
+                .then_some(rows)
+        },
+    )
+    .await;
+
+    assert_eq!(rows[0].0.uuid(), &external_id);
+
+    client.shutdown().await.expect("shutdown writer");
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn upsert_uses_external_uuidv7_for_insert_and_updates_existing_row() {
+    let server = TestingServer::start().await;
+    let schema = test_schema();
+    let client = JazzClient::connect(server.make_client_context(schema.clone()))
+        .await
+        .expect("connect writer");
+
+    wait_for_edge_query_ready(&client, Duration::from_secs(30)).await;
+
+    let external_id =
+        Uuid::parse_str("01963f3e-5cbf-73d1-9f8a-123456789abc").expect("parse external uuidv7");
+
+    client
+        .upsert(
+            "todos",
+            external_id,
+            HashMap::from([
+                ("title".to_string(), Value::Text("first-title".to_string())),
+                ("completed".to_string(), Value::Boolean(false)),
+            ]),
+        )
+        .await
+        .expect("insert row through upsert");
+
+    client
+        .upsert(
+            "todos",
+            external_id,
+            HashMap::from([(
+                "title".to_string(),
+                Value::Text("updated-title".to_string()),
+            )]),
+        )
+        .await
+        .expect("update existing row through upsert");
+
+    let rows = wait_for_query(
+        &client,
+        QueryBuilder::new("todos").build(),
+        Some(DurabilityTier::EdgeServer),
+        Duration::from_secs(25),
+        "query returns updated row from upsert",
+        |rows| {
+            (rows.len() == 1
+                && rows[0].0.uuid() == &external_id
+                && rows[0].1
+                    == vec![
+                        Value::Text("updated-title".to_string()),
+                        Value::Boolean(false),
+                    ])
+            .then_some(rows)
+        },
+    )
+    .await;
+
+    assert_eq!(rows[0].0.uuid(), &external_id);
+    assert_eq!(
+        rows[0].1,
+        vec![
+            Value::Text("updated-title".to_string()),
+            Value::Boolean(false)
+        ]
+    );
+
+    client.shutdown().await.expect("shutdown writer");
     server.shutdown().await;
 }
 

--- a/crates/jazz-wasm/src/runtime.rs
+++ b/crates/jazz-wasm/src/runtime.rs
@@ -17,6 +17,7 @@ use std::collections::HashMap;
 use std::rc::{Rc, Weak};
 use std::sync::Once;
 
+use jazz_tools::binding_support::parse_external_object_id;
 use js_sys::Function;
 use js_sys::Uint8Array;
 use serde::Serialize;
@@ -654,13 +655,20 @@ impl WasmRuntime {
     /// # Returns
     /// The inserted row as `{ id, values }`.
     #[wasm_bindgen]
-    pub fn insert(&self, table: &str, values: JsValue) -> Result<JsValue, JsError> {
+    pub fn insert(
+        &self,
+        table: &str,
+        values: JsValue,
+        object_id: Option<String>,
+    ) -> Result<JsValue, JsError> {
         let _span = debug_span!("wasm::insert", tier = self.tier_label, table).entered();
         let named_values: HashMap<String, Value> = serde_wasm_bindgen::from_value(values)?;
+        let object_id = parse_external_object_id(object_id.as_deref())
+            .map_err(|message| JsError::new(&message))?;
 
         let mut core = self.core.borrow_mut();
         let (object_id, row_values) = core
-            .insert(table, named_values, None)
+            .insert_with_id(table, named_values, object_id, None)
             .map_err(|e| JsError::new(&format!("Insert failed: {e}")))?;
 
         let row = SubscriptionRow {
@@ -680,14 +688,17 @@ impl WasmRuntime {
         table: &str,
         values: JsValue,
         write_context_json: Option<String>,
+        object_id: Option<String>,
     ) -> Result<JsValue, JsError> {
         let _span = debug_span!("wasm::insertWithSession", tier = self.tier_label, table).entered();
         let named_values: HashMap<String, Value> = serde_wasm_bindgen::from_value(values)?;
         let write_context = parse_write_context_json(write_context_json)?;
+        let object_id = parse_external_object_id(object_id.as_deref())
+            .map_err(|message| JsError::new(&message))?;
 
         let mut core = self.core.borrow_mut();
         let (object_id, row_values) = core
-            .insert(table, named_values, write_context.as_ref())
+            .insert_with_id(table, named_values, object_id, write_context.as_ref())
             .map_err(|e| JsError::new(&format!("Insert failed: {:?}", e)))?;
 
         let row = SubscriptionRow {
@@ -848,14 +859,17 @@ impl WasmRuntime {
         table: &str,
         values: JsValue,
         tier: &str,
+        object_id: Option<String>,
     ) -> Result<js_sys::Promise, JsError> {
         let persistence_tier = parse_tier(tier)?;
 
         let named_values: HashMap<String, Value> = serde_wasm_bindgen::from_value(values)?;
+        let object_id = parse_external_object_id(object_id.as_deref())
+            .map_err(|message| JsError::new(&message))?;
 
         let ((object_id, row_values), receiver) = {
             let mut core = self.core.borrow_mut();
-            core.insert_persisted(table, named_values, None, persistence_tier)
+            core.insert_persisted_with_id(table, named_values, object_id, None, persistence_tier)
                 .map_err(|e| JsError::new(&format!("Insert failed: {e}")))?
         };
 
@@ -882,16 +896,20 @@ impl WasmRuntime {
         values: JsValue,
         write_context_json: Option<String>,
         tier: &str,
+        object_id: Option<String>,
     ) -> Result<js_sys::Promise, JsError> {
         let persistence_tier = parse_tier(tier)?;
         let named_values: HashMap<String, Value> = serde_wasm_bindgen::from_value(values)?;
         let write_context = parse_write_context_json(write_context_json)?;
+        let object_id = parse_external_object_id(object_id.as_deref())
+            .map_err(|message| JsError::new(&message))?;
 
         let ((object_id, row_values), receiver) = {
             let mut core = self.core.borrow_mut();
-            core.insert_persisted(
+            core.insert_persisted_with_id(
                 table,
                 named_values,
+                object_id,
                 write_context.as_ref(),
                 persistence_tier,
             )

--- a/packages/jazz-tools/src/react-native/jazz-rn-runtime-adapter.test.ts
+++ b/packages/jazz-tools/src/react-native/jazz-rn-runtime-adapter.test.ts
@@ -57,6 +57,7 @@ describe("JazzRnRuntimeAdapter", () => {
     expect(binding.insert).toHaveBeenCalledWith(
       "todos",
       JSON.stringify({ title: { type: "Text", value: "milk" } }),
+      undefined,
     );
 
     adapter.update("row-1", { done: { type: "Boolean", value: true } });
@@ -84,6 +85,7 @@ describe("JazzRnRuntimeAdapter", () => {
       JSON.stringify({
         data: { type: "Bytea", value: "0102ff" },
       }),
+      undefined,
     );
   });
 
@@ -161,6 +163,7 @@ describe("JazzRnRuntimeAdapter", () => {
       "todos",
       JSON.stringify({ title: { type: "Text", value: "milk" } }),
       writeContextJson,
+      undefined,
     );
 
     adapter.updateWithSession(

--- a/packages/jazz-tools/src/react-native/jazz-rn-runtime-adapter.ts
+++ b/packages/jazz-tools/src/react-native/jazz-rn-runtime-adapter.ts
@@ -25,11 +25,12 @@ export interface JazzRnRuntimeBinding {
   deleteWithSession?(objectId: string, writeContextJson: string | undefined): void;
   flush(): void;
   getSchemaHash(): string;
-  insert(table: string, valuesJson: string): string;
+  insert(table: string, valuesJson: string, objectId: string | undefined): string;
   insertWithSession?(
     table: string,
     valuesJson: string,
     writeContextJson: string | undefined,
+    objectId: string | undefined,
   ): string;
   onBatchedTickNeeded(
     callback:
@@ -219,21 +220,31 @@ export class JazzRnRuntimeAdapter implements Runtime {
     return runtimeMethod.bind(this.binding) as NonNullable<JazzRnRuntimeBinding[T]>;
   }
 
-  insert(table: string, values: InsertValues): Row {
+  insert(table: string, values: InsertValues, object_id?: string | null): Row {
     try {
-      const rowJson = this.binding.insert(table, encodeFFIRecordToJson(values));
+      const rowJson = this.binding.insert(
+        table,
+        encodeFFIRecordToJson(values),
+        object_id ?? undefined,
+      );
       return JSON.parse(rowJson) as Row;
     } catch (error) {
       throw normalizeJazzRnError(error);
     }
   }
 
-  insertWithSession(table: string, values: InsertValues, write_context_json?: string | null): Row {
+  insertWithSession(
+    table: string,
+    values: InsertValues,
+    write_context_json?: string | null,
+    object_id?: string | null,
+  ): Row {
     try {
       const rowJson = this.requireWriteContextMethod("insertWithSession")(
         table,
         encodeFFIRecordToJson(values),
         write_context_json ?? undefined,
+        object_id ?? undefined,
       );
       return JSON.parse(rowJson) as Row;
     } catch (error) {

--- a/packages/jazz-tools/src/react/create-jazz-client.integration.test.ts
+++ b/packages/jazz-tools/src/react/create-jazz-client.integration.test.ts
@@ -71,6 +71,33 @@ describe("react/create-jazz-client integration", () => {
     }
   }, 15000);
 
+  it("RC-I02: uses a caller-supplied uuidv7 for inserts", async () => {
+    let client: JazzClient | null = null;
+    const externalId = "01963f3e-5cbe-7a62-8d7c-123456789abc";
+
+    try {
+      client = await createJazzClient({ appId: makeAppId("external-id") });
+
+      const inserted = await client.db.insert(
+        todosTable,
+        { title: "with external id", done: false },
+        { id: externalId },
+      );
+      const rows = await client.db.all(allTodosQuery);
+
+      expect(inserted.id).toBe(externalId);
+      expect(
+        rows.some(
+          (row) => row.id === externalId && row.title === "with external id" && row.done === false,
+        ),
+      ).toBe(true);
+    } finally {
+      if (client) {
+        await client.shutdown();
+      }
+    }
+  }, 15000);
+
   it("RC-I03: shutdown after activity releases resources cleanly", async () => {
     let client: JazzClient | null = null;
 

--- a/packages/jazz-tools/src/runtime/client.mutations.test.ts
+++ b/packages/jazz-tools/src/runtime/client.mutations.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { JazzClient, type Runtime } from "./client.js";
 import type { AppContext, Session } from "./context.js";
 
@@ -236,6 +236,60 @@ describe("JazzClient mutation durability split", () => {
     expect(updateDurableWithSessionCalls).toEqual([["row-1", updates, attributedContext, "edge"]]);
     expect(deleteWithSessionCalls).toEqual([["row-1", attributedContext]]);
     expect(deleteDurableWithSessionCalls).toEqual([["row-1", attributedContext, "global"]]);
+  });
+
+  it("forwards caller-supplied create ids to runtime insert methods", async () => {
+    const externalId = "01963f3e-5cbe-7a62-8d7c-123456789abc";
+    const insert = vi.fn(
+      (table: string, values: Record<string, unknown>, objectId?: string | null) => {
+        return { id: objectId ?? "generated-id", values: [] };
+      },
+    );
+    const insertDurable = vi.fn(
+      async (
+        table: string,
+        values: Record<string, unknown>,
+        tier: string,
+        objectId?: string | null,
+      ) => {
+        return { id: objectId ?? "generated-id", values: [] };
+      },
+    );
+    const { client } = makeClient({ insert, insertDurable });
+    const insertValues = { title: { type: "Text" as const, value: "Draft" } };
+
+    const created = client.create("todos", insertValues, { id: externalId });
+    const createdDurable = await client.createDurable("todos", insertValues, { id: externalId });
+
+    expect(insert).toHaveBeenCalledWith("todos", insertValues, externalId);
+    expect(insertDurable).toHaveBeenCalledWith("todos", insertValues, "edge", externalId);
+    expect(created.id).toBe(externalId);
+    expect(createdDurable.id).toBe(externalId);
+  });
+
+  it("falls back to update when upsert sees an existing object id", async () => {
+    const externalId = "01963f3e-5cbe-7a62-8d7c-123456789abc";
+    const insertError = new Error(`encoding error: object already exists: ${externalId}`);
+    const insert = vi.fn(() => {
+      throw insertError;
+    });
+    const insertDurable = vi.fn(async () => {
+      throw insertError;
+    });
+    const update = vi.fn();
+    const updateDurable = vi.fn(async () => {});
+    const { client } = makeClient({ insert, insertDurable, update, updateDurable });
+    const values = { title: { type: "Text" as const, value: "Updated title" } };
+
+    expect(client.upsert("todos", values, { id: externalId })).toBeUndefined();
+    await expect(
+      client.upsertDurable("todos", values, { id: externalId }),
+    ).resolves.toBeUndefined();
+
+    expect(insert).toHaveBeenCalledWith("todos", values, externalId);
+    expect(insertDurable).toHaveBeenCalledWith("todos", values, "edge", externalId);
+    expect(update).toHaveBeenCalledWith(externalId, values);
+    expect(updateDurable).toHaveBeenCalledWith(externalId, values, "edge");
   });
 
   it("encodes session and attribution together when both are provided", () => {

--- a/packages/jazz-tools/src/runtime/client.ts
+++ b/packages/jazz-tools/src/runtime/client.ts
@@ -48,14 +48,25 @@ export interface RequestLike {
  * satisfy this interface, allowing `JazzClient` to work with either backend.
  */
 export interface Runtime {
-  insert(table: string, values: InsertValues): Row;
-  insertWithSession?(table: string, values: InsertValues, write_context_json?: string | null): Row;
-  insertDurable(table: string, values: InsertValues, tier: string): Promise<Row>;
+  insert(table: string, values: InsertValues, object_id?: string | null): Row;
+  insertWithSession?(
+    table: string,
+    values: InsertValues,
+    write_context_json?: string | null,
+    object_id?: string | null,
+  ): Row;
+  insertDurable(
+    table: string,
+    values: InsertValues,
+    tier: string,
+    object_id?: string | null,
+  ): Promise<Row>;
   insertDurableWithSession?(
     table: string,
     values: InsertValues,
     write_context_json: string | null | undefined,
     tier: string,
+    object_id?: string | null,
   ): Promise<Row>;
   update(object_id: string, values: Record<string, Value>): void;
   updateWithSession?(
@@ -138,6 +149,22 @@ export interface ResolvedQueryExecutionOptions {
 
 export interface WriteDurabilityOptions {
   tier?: DurabilityTier;
+}
+
+export interface CreateOptions {
+  id?: string;
+}
+
+export interface CreateDurabilityOptions extends WriteDurabilityOptions {
+  id?: string;
+}
+
+export interface UpsertOptions {
+  id: string;
+}
+
+export interface UpsertDurabilityOptions extends WriteDurabilityOptions {
+  id: string;
 }
 
 /**
@@ -481,6 +508,11 @@ export function sessionFromRequest(request: RequestLike): Session {
   return { user_id: typedPayload.sub, claims };
 }
 
+function isObjectAlreadyExistsError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.includes("object already exists") || message.includes("Create failed: Conflict");
+}
+
 /**
  * Session-scoped client for backend operations.
  *
@@ -499,7 +531,7 @@ export class SessionClient {
   /**
    * Create a new row as this session's user.
    */
-  async create(table: string, values: InsertValues): Promise<string> {
+  async create(table: string, values: InsertValues, options?: CreateOptions): Promise<string> {
     if (!this.client.getServerUrl()) {
       throw new Error("No server connection");
     }
@@ -511,6 +543,7 @@ export class SessionClient {
         table,
         values,
         schema_context: this.client.getSchemaContext(),
+        ...(options?.id ? { object_id: options.id } : {}),
       },
       this.session,
     );
@@ -521,6 +554,22 @@ export class SessionClient {
 
     const result = await response.json();
     return result.object_id;
+  }
+
+  /**
+   * Create or update a row as this session's user using a caller-supplied id.
+   */
+  async upsert(table: string, values: InsertValues, options: UpsertOptions): Promise<void> {
+    try {
+      await this.create(table, values, options);
+      return;
+    } catch (error) {
+      if (!isObjectAlreadyExistsError(error)) {
+        throw error;
+      }
+    }
+
+    await this.update(options.id, values as Record<string, Value>);
   }
 
   /**
@@ -1080,8 +1129,15 @@ export class JazzClient {
   /**
    * Insert a new row into a table without waiting for durability.
    */
-  create(table: string, values: InsertValues): Row {
-    return this.createInternal(table, values);
+  create(table: string, values: InsertValues, options?: CreateOptions): Row {
+    return this.createInternal(table, values, undefined, undefined, options);
+  }
+
+  /**
+   * Create or update a row with a caller-supplied id without waiting for durability.
+   */
+  upsert(table: string, values: InsertValues, options: UpsertOptions): void {
+    this.upsertInternal(table, values, options.id);
   }
 
   /**
@@ -1093,20 +1149,53 @@ export class JazzClient {
     values: InsertValues,
     session?: Session,
     attribution?: string,
+    options?: CreateOptions,
   ): Row {
     const effectiveSession = this.resolveWriteSession(session, attribution);
     const row =
       effectiveSession || attribution !== undefined
-        ? this.requireSessionWriteMethod("insertWithSession")(
-            table,
-            values,
-            this.encodeWriteContext(effectiveSession, attribution),
-          )
-        : this.runtime.insert(table, values);
+        ? options?.id
+          ? this.requireSessionWriteMethod("insertWithSession")(
+              table,
+              values,
+              this.encodeWriteContext(effectiveSession, attribution),
+              options.id,
+            )
+          : this.requireSessionWriteMethod("insertWithSession")(
+              table,
+              values,
+              this.encodeWriteContext(effectiveSession, attribution),
+            )
+        : options?.id
+          ? this.runtime.insert(table, values, options.id)
+          : this.runtime.insert(table, values);
     return {
       ...row,
       values: this.alignRowValuesToDeclaredSchema(table, row.values as Value[], this.getSchema()),
     };
+  }
+
+  /**
+   * Create or update a row with a caller-supplied id, optionally scoped to a session.
+   * @internal
+   */
+  upsertInternal(
+    table: string,
+    values: InsertValues,
+    objectId: string,
+    session?: Session,
+    attribution?: string,
+  ): void {
+    try {
+      this.createInternal(table, values, session, attribution, { id: objectId });
+      return;
+    } catch (error) {
+      if (!isObjectAlreadyExistsError(error)) {
+        throw error;
+      }
+    }
+
+    this.updateInternal(objectId, values as Record<string, Value>, session, attribution);
   }
 
   /**
@@ -1115,9 +1204,20 @@ export class JazzClient {
   async createDurable(
     table: string,
     values: InsertValues,
-    options?: WriteDurabilityOptions,
+    options?: CreateDurabilityOptions,
   ): Promise<Row> {
     return this.createDurableInternal(table, values, undefined, undefined, options);
+  }
+
+  /**
+   * Create or update a row with a caller-supplied id and wait for durability.
+   */
+  async upsertDurable(
+    table: string,
+    values: InsertValues,
+    options: UpsertDurabilityOptions,
+  ): Promise<void> {
+    await this.upsertDurableInternal(table, values, options.id, undefined, undefined, options);
   }
 
   /**
@@ -1129,23 +1229,67 @@ export class JazzClient {
     values: InsertValues,
     session?: Session,
     attribution?: string,
-    options?: WriteDurabilityOptions,
+    options?: CreateDurabilityOptions,
   ): Promise<Row> {
     const tier = this.resolveWriteTier(options);
     const effectiveSession = this.resolveWriteSession(session, attribution);
     const row =
       effectiveSession || attribution !== undefined
-        ? await this.requireSessionWriteMethod("insertDurableWithSession")(
-            table,
-            values,
-            this.encodeWriteContext(effectiveSession, attribution),
-            tier,
-          )
-        : await this.runtime.insertDurable(table, values, tier);
+        ? options?.id
+          ? await this.requireSessionWriteMethod("insertDurableWithSession")(
+              table,
+              values,
+              this.encodeWriteContext(effectiveSession, attribution),
+              tier,
+              options.id,
+            )
+          : await this.requireSessionWriteMethod("insertDurableWithSession")(
+              table,
+              values,
+              this.encodeWriteContext(effectiveSession, attribution),
+              tier,
+            )
+        : options?.id
+          ? await this.runtime.insertDurable(table, values, tier, options.id)
+          : await this.runtime.insertDurable(table, values, tier);
     return {
       ...row,
       values: this.alignRowValuesToDeclaredSchema(table, row.values as Value[], this.getSchema()),
     };
+  }
+
+  /**
+   * Create or update a row with a caller-supplied id and wait for durability,
+   * optionally scoped to a session.
+   * @internal
+   */
+  async upsertDurableInternal(
+    table: string,
+    values: InsertValues,
+    objectId: string,
+    session?: Session,
+    attribution?: string,
+    options?: WriteDurabilityOptions,
+  ): Promise<void> {
+    try {
+      await this.createDurableInternal(table, values, session, attribution, {
+        ...options,
+        id: objectId,
+      });
+      return;
+    } catch (error) {
+      if (!isObjectAlreadyExistsError(error)) {
+        throw error;
+      }
+    }
+
+    await this.updateDurableInternal(
+      objectId,
+      values as Record<string, Value>,
+      session,
+      attribution,
+      options,
+    );
   }
 
   /**

--- a/packages/jazz-tools/src/runtime/db.schema-order.test.ts
+++ b/packages/jazz-tools/src/runtime/db.schema-order.test.ts
@@ -165,6 +165,95 @@ describe("Db runtime schema order", () => {
     });
   });
 
+  it("forwards a caller-supplied create id to the runtime client", () => {
+    const generatedSchema: WasmSchema = {
+      todos: {
+        columns: [
+          { name: "title", column_type: { type: "Text" }, nullable: false },
+          { name: "done", column_type: { type: "Boolean" }, nullable: false },
+        ],
+      },
+    };
+    const externalId = "01963f3e-5cbe-7a62-8d7c-123456789abc";
+    const create = vi.fn<(...args: [string, InsertValues, { id: string }]) => Row>(() => ({
+      id: externalId,
+      values: [
+        { type: "Text", value: "Buy milk" },
+        { type: "Boolean", value: false },
+      ],
+    }));
+    const client = {
+      getSchema: () => new Map(),
+      create,
+    } as unknown as JazzClient;
+    const db = new TestDb(client);
+    const table = {
+      _table: "todos",
+      _schema: generatedSchema,
+      _rowType: {} as { id: string; title: string; done: boolean },
+      _initType: {} as { title: string; done: boolean },
+    } satisfies TableProxy<
+      { id: string; title: string; done: boolean },
+      { title: string; done: boolean }
+    >;
+
+    const row = db.insert(table, { title: "Buy milk", done: false }, { id: externalId });
+
+    expect(create).toHaveBeenCalledWith(
+      "todos",
+      {
+        title: { type: "Text", value: "Buy milk" },
+        done: { type: "Boolean", value: false },
+      },
+      { id: externalId },
+    );
+    expect(row).toEqual({
+      id: externalId,
+      title: "Buy milk",
+      done: false,
+    });
+  });
+
+  it("forwards caller-supplied upsert ids to the runtime client", () => {
+    const generatedSchema: WasmSchema = {
+      todos: {
+        columns: [
+          { name: "title", column_type: { type: "Text" }, nullable: false },
+          { name: "done", column_type: { type: "Boolean" }, nullable: false },
+        ],
+      },
+    };
+    const externalId = "01963f3e-5cbe-7a62-8d7c-123456789abc";
+    const upsert = vi.fn<(...args: [string, InsertValues, { id: string }]) => void>();
+    const client = {
+      getSchema: () => new Map(),
+      upsert,
+    } as unknown as JazzClient;
+    const db = new TestDb(client);
+    const table = {
+      _table: "todos",
+      _schema: generatedSchema,
+      _rowType: {} as { id: string; title: string; done: boolean },
+      _initType: {} as { title: string; done: boolean },
+    } satisfies TableProxy<
+      { id: string; title: string; done: boolean },
+      { title: string; done: boolean }
+    >;
+
+    expect(
+      db.upsert(table, { title: "Buy milk", done: false }, { id: externalId }),
+    ).toBeUndefined();
+
+    expect(upsert).toHaveBeenCalledWith(
+      "todos",
+      {
+        title: { type: "Text", value: "Buy milk" },
+        done: { type: "Boolean", value: false },
+      },
+      { id: externalId },
+    );
+  });
+
   it("falls back to the generated schema for query results when the runtime schema is missing a table", async () => {
     const generatedSchema: WasmSchema = {
       todos: {

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -17,6 +17,10 @@ import type { RuntimeSourcesConfig, Session } from "./context.js";
 import {
   JazzClient,
   loadWasmModule,
+  type CreateDurabilityOptions,
+  type CreateOptions,
+  type UpsertDurabilityOptions,
+  type UpsertOptions,
   type WasmModule,
   type DurabilityTier,
   type QueryExecutionOptions,
@@ -1125,12 +1129,14 @@ export class Db {
    * @param data Init object with column values
    * @returns Inserted row
    */
-  insert<T, Init>(table: TableProxy<T, Init>, data: Init): T {
+  insert<T, Init>(table: TableProxy<T, Init>, data: Init, options?: CreateOptions): T {
     const client = this.getClient(table._schema);
     // Don't wait for bridge to be ready in worker mode. Inserts will be propagated once the bridge is ready.
     // If the bridge fails to initialize, the insert will be lost on restart.
     const values = toInsertRecord(data as Record<string, unknown>, table._schema, table._table);
-    const row = client.create(table._table, values);
+    const row = options?.id
+      ? client.create(table._table, values, options)
+      : client.create(table._table, values);
     return transformRow(row, table._schema, table._table);
   }
 
@@ -1145,7 +1151,7 @@ export class Db {
   async insertDurable<T, Init>(
     table: TableProxy<T, Init>,
     data: Init,
-    options: { tier: DurabilityTier },
+    options: CreateDurabilityOptions,
   ): Promise<T> {
     const client = this.getClient(table._schema);
     const inputSchema = resolveSchemaWithTable(
@@ -1157,6 +1163,34 @@ export class Db {
     const values = toInsertRecord(data as Record<string, unknown>, inputSchema, table._table);
     const row = await client.createDurable(table._table, values, options);
     return transformRow(row, table._schema, table._table);
+  }
+
+  /**
+   * Create or update a row with a caller-supplied id without waiting for durability.
+   */
+  upsert<T, Init>(table: TableProxy<T, Init>, data: Partial<Init>, options: UpsertOptions): void {
+    const client = this.getClient(table._schema);
+    const values = toUpdateRecord(data as Record<string, unknown>, table._schema, table._table);
+    client.upsert(table._table, values, options);
+  }
+
+  /**
+   * Create or update a row with a caller-supplied id and wait for durability.
+   */
+  async upsertDurable<T, Init>(
+    table: TableProxy<T, Init>,
+    data: Partial<Init>,
+    options: UpsertDurabilityOptions,
+  ): Promise<void> {
+    const client = this.getClient(table._schema);
+    const inputSchema = resolveSchemaWithTable(
+      table._schema,
+      normalizeRuntimeSchema(client.getSchema()),
+      table._table,
+    );
+    await this.ensureBridgeReady();
+    const values = toUpdateRecord(data as Record<string, unknown>, inputSchema, table._table);
+    await client.upsertDurable(table._table, values, options);
   }
 
   /**

--- a/packages/jazz-tools/src/runtime/index.ts
+++ b/packages/jazz-tools/src/runtime/index.ts
@@ -1,4 +1,6 @@
 export {
+  type CreateDurabilityOptions,
+  type CreateOptions,
   JazzClient,
   type LocalUpdatesMode,
   SessionClient,
@@ -12,6 +14,8 @@ export {
   type Row,
   type Runtime,
   type SubscriptionCallback,
+  type UpsertDurabilityOptions,
+  type UpsertOptions,
   type WriteDurabilityOptions,
   type WasmModule,
 } from "./client.js";

--- a/packages/jazz-tools/src/types/jazz-wasm.d.ts
+++ b/packages/jazz-tools/src/types/jazz-wasm.d.ts
@@ -30,22 +30,29 @@ declare module "jazz-wasm" {
     );
     schedule?: (task: () => void) => void;
 
-    insert(table: string, values: InsertValues): { id: string; values: any[] };
+    insert(
+      table: string,
+      values: InsertValues,
+      objectId?: string | null,
+    ): { id: string; values: any[] };
     insertWithSession(
       table: string,
       values: InsertValues,
       sessionJson?: string | null,
+      objectId?: string | null,
     ): { id: string; values: any[] };
     insertDurable(
       table: string,
       values: InsertValues,
       tier: string,
+      objectId?: string | null,
     ): Promise<{ id: string; values: any[] }>;
     insertDurableWithSession(
       table: string,
       values: InsertValues,
       sessionJson: string | null | undefined,
       tier: string,
+      objectId?: string | null,
     ): Promise<{ id: string; values: any[] }>;
     update(objectId: string, values: unknown): void;
     updateWithSession(objectId: string, values: unknown, sessionJson?: string | null): void;


### PR DESCRIPTION
## What changed

This adds caller-supplied UUIDv7 support for create paths and new id-based upsert APIs across the Rust and TypeScript client surfaces.

It includes:
- Rust `JazzClient` and session-client `create_with_id`/`create_persisted_with_id` plus `upsert`/`upsert_persisted`
- TypeScript `JazzClient`, `SessionClient`, and `Db` upsert APIs
- Binding/runtime plumbing so external UUIDv7 ids flow through the Rust write stack
- A patch changeset for the fixed `jazz-tools`/`jazz-wasm`/`jazz-napi`/`jazz-rn` release group

## Why

Callers already needed a way to seed externally generated UUIDv7 ids on create. Once that exists, the next natural API is an id-based upsert so the same external id can be used for create-or-update flows without forcing a read-before-write round trip.

## Behavior

- External create ids must be UUIDv7.
- Upsert requires an external id.
- If the row does not exist, upsert inserts with that id.
- If the row already exists, upsert updates only the supplied fields.
- If the id already belongs to a different table, the write is rejected.

## User impact

Consumers can now:
- create rows with externally assigned UUIDv7 ids
- perform id-stable create-or-update flows from both Rust and TypeScript
- use the same capability through session-scoped clients and durable write paths

## Validation

- `pnpm lint`
- `cargo test -p jazz-tools --features test --test clients_sync`
- `node_modules/.bin/vitest run src/runtime/client.mutations.test.ts src/runtime/db.schema-order.test.ts --config vitest.config.ts`
