### PR TITLE
fix(runtime): use static bundler-detected URL pattern for worker

### DIFF
--- a/.changeset/worker-bundler-url-static.md
+++ b/.changeset/worker-bundler-url-static.md
@@ -1,0 +1,7 @@
+---
+"jazz-tools": patch
+---
+
+Use static `new URL(...)` import for worker when no explicit runtime sources are configured, allowing bundlers (Turbopack, webpack, Vite) to detect and co-bundle the worker script and its WASM dependency automatically.
+
+Also passes a computed `fallbackWasmUrl` in the worker init message so non-bundled (static HTML) deployments still receive an explicit WASM path as a last resort if `wasmModule.default()` fails.

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -48,7 +48,6 @@ import { normalizeBuiltQuery } from "./query-builder-shape.js";
 import {
   appendWorkerRuntimeWasmUrl,
   resolveRuntimeConfigSyncInitInput,
-  resolveRuntimeConfigWasmUrl,
   resolveWorkerBootstrapWasmUrl,
   resolveRuntimeConfigWorkerUrl,
 } from "./runtime-config.js";
@@ -655,6 +654,18 @@ export class Db {
       throw new Error("Worker bridge is only available for driver.type='persistent'");
     }
 
+    // For the static-URL spawn path (no explicit workerUrl/baseUrl), compute a
+    // fallback WASM URL for non-bundled contexts where wasmModule.default() may fail.
+    const runtimeSources = this.config.runtimeSources;
+    let fallbackWasmUrl: string | undefined;
+    if (!runtimeSources?.workerUrl && !runtimeSources?.baseUrl && !runtimeSources?.wasmUrl) {
+      const locationHref = typeof location !== "undefined" ? location.href : undefined;
+      if (!resolveRuntimeConfigSyncInitInput(runtimeSources)) {
+        fallbackWasmUrl =
+          resolveWorkerBootstrapWasmUrl(import.meta.url, locationHref, runtimeSources) ?? undefined;
+      }
+    }
+
     return {
       schemaJson,
       appId: this.config.appId,
@@ -666,6 +677,7 @@ export class Db {
       jwtToken: this.config.jwtToken,
       adminSecret: this.config.adminSecret,
       runtimeSources: this.config.runtimeSources,
+      fallbackWasmUrl,
       logLevel: this.config.logLevel,
     };
   }
@@ -1028,19 +1040,27 @@ export class Db {
   }
 
   private static async spawnWorker(runtimeSources?: RuntimeSourcesConfig): Promise<Worker> {
-    const locationHref = typeof location !== "undefined" ? location.href : undefined;
-    const syncInitInput = resolveRuntimeConfigSyncInitInput(runtimeSources);
-    const wasmUrl = syncInitInput
-      ? null
-      : resolveWorkerBootstrapWasmUrl(import.meta.url, locationHref, runtimeSources);
-    const workerUrl = appendWorkerRuntimeWasmUrl(
-      resolveRuntimeConfigWorkerUrl(import.meta.url, locationHref, runtimeSources),
-      wasmUrl,
-    );
+    let worker: Worker;
 
-    const worker = new Worker(workerUrl, {
-      type: "module",
-    });
+    if (runtimeSources?.workerUrl || runtimeSources?.baseUrl) {
+      // Explicit worker location — use dynamic URL resolution.
+      const locationHref = typeof location !== "undefined" ? location.href : undefined;
+      const syncInitInput = resolveRuntimeConfigSyncInitInput(runtimeSources);
+      const wasmUrl = syncInitInput
+        ? null
+        : resolveWorkerBootstrapWasmUrl(import.meta.url, locationHref, runtimeSources);
+      const workerUrl = appendWorkerRuntimeWasmUrl(
+        resolveRuntimeConfigWorkerUrl(import.meta.url, locationHref, runtimeSources),
+        wasmUrl,
+      );
+      worker = new Worker(workerUrl, { type: "module" });
+    } else {
+      // Static URL pattern — bundlers (Turbopack, webpack, Vite) detect this
+      // and automatically bundle the worker script + its WASM dependency.
+      worker = new Worker(new URL("../worker/jazz-worker.js", import.meta.url), {
+        type: "module",
+      });
+    }
 
     await new Promise<void>((resolve, reject) => {
       const timeout = setTimeout(() => reject(new Error("Worker bootstrap timeout")), 15000);

--- a/packages/jazz-tools/src/runtime/db.worker-bootstrap.test.ts
+++ b/packages/jazz-tools/src/runtime/db.worker-bootstrap.test.ts
@@ -167,7 +167,7 @@ describe("Db worker runtime bootstrap", () => {
     ]);
   });
 
-  it("spawns the browser worker from an HTTP URL and passes the wasm URL through bootstrap params", async () => {
+  it("uses the static bundler-detected URL pattern when no runtimeSources are provided", async () => {
     const spawnedWorkerUrls: string[] = [];
 
     class FakeWorker extends EventTarget {
@@ -203,9 +203,44 @@ describe("Db worker runtime bootstrap", () => {
     await db.shutdown();
 
     expect(loadWasmModuleMock).toHaveBeenCalledTimes(1);
-    expect(spawnedWorkerUrls).toEqual([
-      "http://localhost:3000/worker/jazz-worker.js?jazz-wasm-url=http%3A%2F%2Flocalhost%3A3000%2Fjazz_wasm_bg.wasm",
-    ]);
+    expect(spawnedWorkerUrls).toHaveLength(1);
+    expect(spawnedWorkerUrls[0]).toMatch(/worker\/jazz-worker\.js$/);
+  });
+
+  it("includes a fallbackWasmUrl in bridge options when no runtimeSources are provided", async () => {
+    class FakeWorker extends EventTarget {
+      constructor(_url: string | URL, _options?: WorkerOptions) {
+        super();
+        queueMicrotask(() => {
+          const event = new Event("message");
+          Object.defineProperty(event, "data", {
+            value: { type: "ready" },
+            configurable: true,
+          });
+          this.dispatchEvent(event);
+        });
+      }
+
+      postMessage(): void {}
+
+      terminate(): void {}
+    }
+
+    (globalThis as Record<string, unknown>).window = {};
+    (globalThis as Record<string, unknown>).location = {
+      href: "http://localhost:3000/",
+    };
+    (globalThis as Record<string, unknown>).Worker = FakeWorker;
+
+    const db = await Db.createWithWorker({
+      appId: "worker-bootstrap-fallback-wasm",
+      driver: { type: "persistent", dbName: "worker-bootstrap-fallback-wasm" },
+    });
+
+    const options = (db as any).buildWorkerBridgeOptions("{}");
+    await db.shutdown();
+
+    expect(options.fallbackWasmUrl).toMatch(/jazz_wasm_bg\.wasm$/);
   });
 
   it("does not append a bootstrap wasm URL when runtimeSources provides in-memory wasmSource", async () => {

--- a/packages/jazz-tools/src/runtime/worker-bridge.ts
+++ b/packages/jazz-tools/src/runtime/worker-bridge.ts
@@ -30,6 +30,7 @@ export interface WorkerBridgeOptions {
   jwtToken?: string;
   adminSecret?: string;
   runtimeSources?: RuntimeSourcesConfig;
+  fallbackWasmUrl?: string;
   logLevel?: "error" | "warn" | "info" | "debug" | "trace";
 }
 
@@ -176,6 +177,7 @@ export class WorkerBridge {
       jwtToken: options.jwtToken,
       adminSecret: options.adminSecret,
       runtimeSources: options.runtimeSources,
+      fallbackWasmUrl: options.fallbackWasmUrl,
       logLevel: options.logLevel,
       clientId: "", // Worker generates its own client ID for main thread
     };

--- a/packages/jazz-tools/src/worker/jazz-worker.ts
+++ b/packages/jazz-tools/src/worker/jazz-worker.ts
@@ -142,7 +142,8 @@ async function ensureWorkerWasmInitialized(
   try {
     await runWithRootRelativeFetchSupport(() => wasmModule.default());
   } catch (error) {
-    const absoluteWasmUrl = resolveAbsoluteWasmUrlFromInitError(error) ?? msg?.fallbackWasmUrl ?? null;
+    const absoluteWasmUrl =
+      resolveAbsoluteWasmUrlFromInitError(error) ?? msg?.fallbackWasmUrl ?? null;
     if (!absoluteWasmUrl) {
       throw error;
     }

--- a/packages/jazz-tools/src/worker/jazz-worker.ts
+++ b/packages/jazz-tools/src/worker/jazz-worker.ts
@@ -110,7 +110,7 @@ async function runWithRootRelativeFetchSupport<T>(operation: () => Promise<T>): 
 
 async function ensureWorkerWasmInitialized(
   wasmModule: any,
-  msg: Pick<InitMessage, "runtimeSources"> | undefined,
+  msg: Pick<InitMessage, "runtimeSources" | "fallbackWasmUrl"> | undefined,
 ): Promise<void> {
   if (wasmInitialized) {
     return;
@@ -142,7 +142,7 @@ async function ensureWorkerWasmInitialized(
   try {
     await runWithRootRelativeFetchSupport(() => wasmModule.default());
   } catch (error) {
-    const absoluteWasmUrl = resolveAbsoluteWasmUrlFromInitError(error);
+    const absoluteWasmUrl = resolveAbsoluteWasmUrlFromInitError(error) ?? msg?.fallbackWasmUrl ?? null;
     if (!absoluteWasmUrl) {
       throw error;
     }

--- a/packages/jazz-tools/src/worker/worker-protocol.ts
+++ b/packages/jazz-tools/src/worker/worker-protocol.ts
@@ -25,6 +25,8 @@ export interface InitMessage {
   jwtToken?: string;
   adminSecret?: string;
   runtimeSources?: RuntimeSourcesConfig;
+  /** Computed WASM URL fallback for non-bundled contexts — used after wasmModule.default() fails. */
+  fallbackWasmUrl?: string;
   /** Optional WASM tracing log level for this worker runtime (default: "warn"). */
   logLevel?: "error" | "warn" | "info" | "debug" | "trace";
 }


### PR DESCRIPTION
## What

Previously, `Db.spawnWorker` always resolved the worker URL dynamically at runtime — computing paths relative to `location.href` and appending a WASM URL query param. This works when `runtimeSources` provides an explicit `workerUrl` or `baseUrl`, but breaks in bundled apps (Next.js/Turbopack, Vite, webpack) where those tools need a static `new URL(...)` expression at compile time to detect and co-bundle the worker script and its WASM dependency.

When no `workerUrl` or `baseUrl` is provided, the worker is now spawned with:

```js
new Worker(new URL("../worker/jazz-worker.js", import.meta.url), { type: "module" })
```

The dynamic path is preserved for the explicit-runtimeSources case (CDN, custom deployments, etc.).

A computed `fallbackWasmUrl` is also threaded through the worker init message so non-bundled (static HTML) deployments still receive an explicit WASM path as a last resort if `wasmModule.default()` fails. Bundled contexts are unaffected — they always go via `wasmModule.default()` first.

## Why now

This was the root cause of worker loading failures in the Next.js/Turbopack starter — the worker and its WASM weren't being bundled because Turbopack couldn't statically analyse the URL.

## Test plan

- [x] Existing worker bootstrap tests pass
- [x] Updated test asserts static URL pattern (`/worker/jazz-worker\.js$/`) rather than the old dynamic URL with `?jazz-wasm-url=` appended
- [x] New test asserts `fallbackWasmUrl` is present in bridge options when no `runtimeSources` are provided