### PR TITLE
Add adminSecret row access for sync and inspector clients

### DIFF
--- a/crates/jazz-tools/src/lib.rs
+++ b/crates/jazz-tools/src/lib.rs
@@ -90,8 +90,8 @@ pub struct AppContext {
     /// Backend secret for session impersonation.
     /// Enables `for_session()` to act as any user.
     pub backend_secret: Option<String>,
-    /// Admin secret for schema/policy sync.
-    /// Required to sync catalogue objects.
+    /// Admin secret for privileged sync over WebSocket and `/admin/*` HTTP.
+    /// On `/ws`, a valid admin secret authenticates this client as the backend.
     pub admin_secret: Option<String>,
 
     /// Optional sync message tracer for test observability.

--- a/crates/jazz-tools/src/routes.rs
+++ b/crates/jazz-tools/src/routes.rs
@@ -1155,15 +1155,14 @@ pub async fn ws_handler(ws: WebSocketUpgrade, State(state): State<Arc<ServerStat
 /// Outcome of authenticating a WS handshake — mirrors `ClientSetup` in
 /// the old `/sync` + `/events` handlers.
 enum WsClientSetup {
-    Admin,
     Backend,
     Session(crate::query_manager::session::Session),
 }
 
 /// Authenticate a WebSocket `AuthHandshake`.
 ///
-/// Priority matches the old HTTP handler pair:
-/// 1. `admin_secret` valid → `WsClientSetup::Admin` (full catalogue access)
+/// Priority is:
+/// 1. `admin_secret` valid → `WsClientSetup::Backend`
 /// 2. `backend_secret` present + no session header → `WsClientSetup::Backend`
 /// 3. Otherwise → `extract_session` → `WsClientSetup::Session`
 ///
@@ -1178,6 +1177,14 @@ async fn authenticate_ws_handshake(
 
     let auth = &handshake.auth;
 
+    // `admin_secret` is an explicit request to run this WS transport as the
+    // backend. Validate it first and short-circuit all user-scoped auth.
+    if let Some(admin_secret) = auth.admin_secret.as_deref() {
+        validate_admin_secret(Some(admin_secret), &state.auth_config)
+            .map_err(|(_, msg)| msg.to_string())?;
+        return Ok(WsClientSetup::Backend);
+    }
+
     // Build a synthetic HeaderMap from the handshake auth fields.
     let mut headers = HeaderMap::new();
 
@@ -1191,11 +1198,6 @@ async fn authenticate_ws_handshake(
             .map_err(|e| format!("invalid backend_secret header value: {e}"))?;
         headers.insert("X-Jazz-Backend-Secret", value);
     }
-    if let Some(admin) = &auth.admin_secret {
-        let value = HeaderValue::from_str(admin)
-            .map_err(|e| format!("invalid admin_secret header value: {e}"))?;
-        headers.insert("X-Jazz-Admin-Secret", value);
-    }
     if let Some(session_val) = &auth.backend_session {
         let json = serde_json::to_string(session_val)
             .map_err(|e| format!("failed to serialise backend_session: {e}"))?;
@@ -1207,23 +1209,9 @@ async fn authenticate_ws_handshake(
 
     let has_jwt = headers.get(axum::http::header::AUTHORIZATION).is_some();
     let has_session_header = headers.get("X-Jazz-Session").is_some();
-    let admin_secret = headers
-        .get("X-Jazz-Admin-Secret")
-        .and_then(|v| v.to_str().ok());
     let backend_secret = headers
         .get("X-Jazz-Backend-Secret")
         .and_then(|v| v.to_str().ok());
-
-    // 1. Admin secret — only when no user-scoped credential (JWT or session) is
-    //    present.  Browser workers send both admin_secret and jwt_token; the JWT
-    //    must win so the connection carries a session and row-level policies are
-    //    applied correctly.  Pure admin/tooling clients that have no JWT still
-    //    get full Admin access.
-    if admin_secret.is_some() && !has_jwt && !has_session_header {
-        validate_admin_secret(admin_secret, &state.auth_config)
-            .map_err(|(_, msg)| msg.to_string())?;
-        return Ok(WsClientSetup::Admin);
-    }
 
     // 2. Backend secret — only when no user-scoped JWT is present.  Clients
     //    that carry both a backend_secret and a jwt_token (e.g. test helpers
@@ -1248,15 +1236,6 @@ async fn authenticate_ws_handshake(
         .await
         .map_err(|e| serde_json::to_string(&e).unwrap_or_else(|_| "authentication failed".into()))?
     };
-
-    // 4. Fallback: admin secret when JWT auth produced no session (e.g. JWT is
-    //    absent but admin_secret was provided alongside a session header for
-    //    backend impersonation with elevated access).
-    if session.is_none() && admin_secret.is_some() {
-        validate_admin_secret(admin_secret, &state.auth_config)
-            .map_err(|(_, msg)| msg.to_string())?;
-        return Ok(WsClientSetup::Admin);
-    }
 
     let session =
         session.ok_or_else(|| "Session required. Provide JWT or backend secret.".to_string())?;
@@ -1325,7 +1304,6 @@ async fn handle_ws_connection(mut socket: WebSocket, state: Arc<ServerState>) {
         }
     };
     let role = match &setup {
-        WsClientSetup::Admin => "admin",
         WsClientSetup::Backend => "backend",
         WsClientSetup::Session(_) => "session",
     };
@@ -1345,9 +1323,6 @@ async fn handle_ws_connection(mut socket: WebSocket, state: Arc<ServerState>) {
 
     // 5. Ensure the client state in the runtime.
     match setup {
-        WsClientSetup::Admin => {
-            let _ = state.runtime.ensure_client_as_admin(client_id);
-        }
         WsClientSetup::Backend => {
             let _ = state.runtime.ensure_client_as_backend(client_id);
         }

--- a/crates/jazz-tools/src/server/testing.rs
+++ b/crates/jazz-tools/src/server/testing.rs
@@ -405,7 +405,7 @@ impl TestingServer {
             storage: crate::ClientStorage::Memory,
             jwt_token: Some(jwt_token),
             backend_secret: Some(self.backend_secret.clone()),
-            admin_secret: Some(self.admin_secret.clone()),
+            admin_secret: None,
             sync_tracer: None,
         }
     }
@@ -515,6 +515,7 @@ mod tests {
         assert!(server.built_in_jwt_helpers_available());
         assert!(!server.uses_external_jwks());
         assert!(context.jwt_token.is_some());
+        assert!(context.admin_secret.is_none());
 
         server.shutdown().await;
     }

--- a/crates/jazz-tools/tests/auth_test.rs
+++ b/crates/jazz-tools/tests/auth_test.rs
@@ -9,18 +9,23 @@
 
 mod test_server;
 
+use std::collections::HashMap;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use base64::Engine;
 use futures::SinkExt as _;
+use jazz_tools::catalogue::CatalogueEntry;
+use jazz_tools::metadata::{MetadataKey, ObjectType};
 use jazz_tools::query_manager::session::Session;
-use jazz_tools::sync_manager::ClientId;
+use jazz_tools::schema_manager::encoding::encode_schema;
+use jazz_tools::sync_manager::{ClientId, SyncError, SyncPayload};
 use jazz_tools::transport_manager::{AuthConfig, AuthHandshake, ConnectedResponse};
 use jsonwebtoken::{EncodingKey, Header, encode};
 use reqwest::{Client, StatusCode};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use tokio_tungstenite::{connect_async, tungstenite::Message};
+use tokio::net::TcpStream;
+use tokio_tungstenite::{MaybeTlsStream, WebSocketStream, connect_async, tungstenite::Message};
 
 use test_server::TestServer;
 
@@ -98,11 +103,12 @@ fn frame_decode(data: &[u8]) -> Option<&[u8]> {
     Some(&data[4..4 + len])
 }
 
-/// Perform a WS handshake against `ws://host/ws` with the given auth config.
-///
-/// Returns `Ok(ConnectedResponse)` on success, or `Err(message)` if the
-/// server sends an error frame or closes the connection unexpectedly.
-async fn ws_handshake(server: &TestServer, auth: AuthConfig) -> Result<ConnectedResponse, String> {
+type WsStream = WebSocketStream<MaybeTlsStream<TcpStream>>;
+
+async fn ws_handshake_open(
+    server: &TestServer,
+    auth: AuthConfig,
+) -> Result<(WsStream, ConnectedResponse), String> {
     let ws_url = format!("ws://127.0.0.1:{}/ws", server.port);
     let (mut ws, _) = connect_async(&ws_url)
         .await
@@ -122,25 +128,77 @@ async fn ws_handshake(server: &TestServer, auth: AuthConfig) -> Result<Connected
     match ws.next().await {
         Some(Ok(Message::Binary(bytes))) => {
             let inner = frame_decode(&bytes).ok_or("malformed response frame")?;
-            // Try to parse as ConnectedResponse first, then as ServerEvent::Error.
             if let Ok(connected) = serde_json::from_slice::<ConnectedResponse>(inner) {
-                return Ok(connected);
+                Ok((ws, connected))
+            } else {
+                let msg = serde_json::from_slice::<serde_json::Value>(inner)
+                    .ok()
+                    .and_then(|v| {
+                        v.get("message")
+                            .and_then(|m| m.as_str())
+                            .map(str::to_string)
+                    })
+                    .unwrap_or_else(|| "auth rejected".to_string());
+                Err(msg)
             }
-            // Must be an error frame.
-            let msg = serde_json::from_slice::<serde_json::Value>(inner)
-                .ok()
-                .and_then(|v| {
-                    v.get("message")
-                        .and_then(|m| m.as_str())
-                        .map(str::to_string)
-                })
-                .unwrap_or_else(|| "auth rejected".to_string());
-            Err(msg)
         }
         Some(Ok(Message::Close(_))) | None => Err("server closed connection".to_string()),
         Some(Ok(other)) => Err(format!("unexpected WS message: {other:?}")),
         Some(Err(e)) => Err(format!("ws recv error: {e}")),
     }
+}
+
+async fn ws_send_sync_payload(ws: &mut WsStream, payload: SyncPayload) -> Result<(), String> {
+    let batch = jazz_tools::transport_protocol::SyncBatchRequest {
+        client_id: ClientId::new(),
+        payloads: vec![payload],
+    };
+    let bytes = serde_json::to_vec(&batch).expect("serialize SyncBatchRequest");
+    ws.send(Message::Binary(frame_encode(&bytes).into()))
+        .await
+        .map_err(|e| format!("ws send sync payload failed: {e}"))
+}
+
+async fn ws_recv_server_event(
+    ws: &mut WsStream,
+) -> Result<jazz_tools::transport_protocol::ServerEvent, String> {
+    use futures::StreamExt as _;
+
+    let message = tokio::time::timeout(std::time::Duration::from_secs(2), ws.next())
+        .await
+        .map_err(|_| "timed out waiting for server event".to_string())?;
+
+    match message {
+        Some(Ok(Message::Binary(bytes))) => {
+            let inner = frame_decode(&bytes).ok_or("malformed response frame")?;
+            serde_json::from_slice(inner).map_err(|e| format!("invalid server event: {e}"))
+        }
+        Some(Ok(Message::Close(_))) | None => Err("server closed connection".to_string()),
+        Some(Ok(other)) => Err(format!("unexpected WS message: {other:?}")),
+        Some(Err(e)) => Err(format!("ws recv error: {e}")),
+    }
+}
+
+async fn ws_wait_for_sync_error(ws: &mut WsStream) -> Result<SyncError, String> {
+    for _ in 0..8 {
+        let event = ws_recv_server_event(ws).await?;
+        if let jazz_tools::transport_protocol::ServerEvent::SyncUpdate { payload, .. } = event
+            && let SyncPayload::Error(error) = *payload
+        {
+            return Ok(error);
+        }
+    }
+
+    Err("expected SyncUpdate error event".to_string())
+}
+
+/// Perform a WS handshake against `ws://host/ws` with the given auth config.
+///
+/// Returns `Ok(ConnectedResponse)` on success, or `Err(message)` if the
+/// server sends an error frame or closes the connection unexpectedly.
+async fn ws_handshake(server: &TestServer, auth: AuthConfig) -> Result<ConnectedResponse, String> {
+    let (_ws, response) = ws_handshake_open(server, auth).await?;
+    Ok(response)
 }
 
 /// Build AuthConfig with a JWT token.
@@ -156,6 +214,14 @@ fn backend_auth(secret: &str, session: &Session) -> AuthConfig {
     AuthConfig {
         backend_secret: Some(secret.to_string()),
         backend_session: Some(serde_json::to_value(session).unwrap()),
+        ..Default::default()
+    }
+}
+
+/// Build AuthConfig with an admin secret.
+fn admin_auth(secret: &str) -> AuthConfig {
+    AuthConfig {
+        admin_secret: Some(secret.to_string()),
         ..Default::default()
     }
 }
@@ -312,6 +378,108 @@ mod integration_tests {
             result.is_ok(),
             "Backend auth should take priority over JWT; got: {result:?}"
         );
+    }
+
+    /// Admin-secret-authenticated handshakes should connect successfully.
+    #[tokio::test]
+    async fn test_admin_secret_ws_handshake() {
+        let server = TestServer::start().await;
+
+        let result = ws_handshake(&server, admin_auth(ADMIN_SECRET)).await;
+        assert!(
+            result.is_ok(),
+            "admin secret should allow WS handshake; got: {result:?}"
+        );
+    }
+
+    /// Valid admin secret should connect even when a bearer token is invalid.
+    #[tokio::test]
+    async fn test_admin_secret_short_circuits_invalid_jwt_on_ws_handshake() {
+        let server = TestServer::start().await;
+
+        let auth = AuthConfig {
+            jwt_token: Some("invalid-token".to_string()),
+            admin_secret: Some(ADMIN_SECRET.to_string()),
+            ..Default::default()
+        };
+        let result = ws_handshake(&server, auth).await;
+        assert!(
+            result.is_ok(),
+            "valid admin secret should win over an invalid JWT on WS handshake; got: {result:?}"
+        );
+    }
+
+    /// Invalid admin secret must reject the handshake even if the JWT is valid.
+    #[tokio::test]
+    async fn test_invalid_admin_secret_rejects_valid_jwt_on_ws_handshake() {
+        let server = TestServer::start().await;
+        let token = make_jwt("jwt-user", json!({"role": "user"}), JWT_SECRET);
+
+        let auth = AuthConfig {
+            jwt_token: Some(token),
+            admin_secret: Some("wrong-admin-secret".to_string()),
+            ..Default::default()
+        };
+        let result = ws_handshake(&server, auth).await;
+        assert!(
+            result.is_err(),
+            "invalid admin secret should reject the handshake even when JWT is valid"
+        );
+    }
+
+    /// A WS connection authenticated with admin secret should behave like a strict
+    /// backend client and reject structural schema catalogue sync.
+    #[tokio::test]
+    async fn test_admin_secret_ws_connection_rejects_structural_schema_catalogue_sync() {
+        let server = TestServer::start().await;
+        let token = make_jwt("jwt-user", json!({"role": "user"}), JWT_SECRET);
+        let auth = AuthConfig {
+            jwt_token: Some(token),
+            admin_secret: Some(ADMIN_SECRET.to_string()),
+            ..Default::default()
+        };
+        let (mut ws, _connected) = ws_handshake_open(&server, auth)
+            .await
+            .expect("handshake with admin secret");
+
+        let schema = SchemaBuilder::new()
+            .table(TableSchema::builder("todos").column("title", ColumnType::Text))
+            .build();
+        let schema_hash = SchemaHash::compute(&schema);
+        let object_id = schema_hash.to_object_id();
+        let entry = CatalogueEntry {
+            object_id,
+            metadata: HashMap::from([
+                (
+                    MetadataKey::Type.to_string(),
+                    ObjectType::CatalogueSchema.to_string(),
+                ),
+                (
+                    MetadataKey::AppId.to_string(),
+                    "00000000-0000-0000-0000-000000000001".to_string(),
+                ),
+                (MetadataKey::SchemaHash.to_string(), schema_hash.to_string()),
+            ]),
+            content: encode_schema(&schema),
+        };
+
+        ws_send_sync_payload(&mut ws, SyncPayload::CatalogueEntryUpdated { entry })
+            .await
+            .expect("send structural schema catalogue payload");
+
+        let error = ws_wait_for_sync_error(&mut ws)
+            .await
+            .expect("receive server response for structural schema sync");
+        assert_eq!(
+            error,
+            SyncError::CatalogueWriteDenied {
+                object_id,
+                branch_name: jazz_tools::object::BranchName::new("main"),
+            },
+            "admin-secret-authenticated WS clients should be treated as strict backend clients"
+        );
+
+        let _ = ws.close(None).await;
     }
 
     // ========================================================================

--- a/crates/jazz-tools/tests/claims_merge_integration.rs
+++ b/crates/jazz-tools/tests/claims_merge_integration.rs
@@ -70,6 +70,7 @@ async fn ephemeral_claims_merged_into_session() {
         .with_server(&server)
         .with_schema(schema.clone())
         .with_user_id("admin")
+        .as_admin()
         .ready_on("rooms", READY_TIMEOUT)
         .connect()
         .await;

--- a/crates/jazz-tools/tests/client_restart_integration.rs
+++ b/crates/jazz-tools/tests/client_restart_integration.rs
@@ -210,8 +210,8 @@ fn make_context(
         data_dir,
         storage: ClientStorage::Persistent,
         jwt_token: Some(jwt_token),
-        backend_secret: Some(BACKEND_SECRET.to_string()),
-        admin_secret: Some(ADMIN_SECRET.to_string()),
+        backend_secret: None,
+        admin_secret: None,
         sync_tracer: None,
     }
 }

--- a/crates/jazz-tools/tests/policies_integration/inherited_policies.rs
+++ b/crates/jazz-tools/tests/policies_integration/inherited_policies.rs
@@ -419,6 +419,7 @@ async fn inherited_folder_documents_are_visible_to_all_folder_owners() {
         .with_server(&server)
         .with_schema(schema.clone())
         .with_user_id("admin")
+        .as_admin()
         .ready_on("documents", READY_TIMEOUT)
         .connect()
         .await;
@@ -709,6 +710,7 @@ async fn inherited_folder_access_extends_document_visibility_beyond_direct_owner
         .with_server(&server)
         .with_schema(schema.clone())
         .with_user_id("admin")
+        .as_admin()
         .ready_on("documents", READY_TIMEOUT)
         .connect()
         .await;
@@ -1116,6 +1118,7 @@ async fn inherited_folder_delete_allows_folder_owner_to_delete_folder_and_docume
         .with_server(&server)
         .with_schema(schema.clone())
         .with_user_id("admin")
+        .as_admin()
         .ready_on("documents", READY_TIMEOUT)
         .connect()
         .await;
@@ -1260,6 +1263,7 @@ async fn inherited_folder_delete_allows_document_owner_but_blocks_other_non_owne
         .with_server(&server)
         .with_schema(schema.clone())
         .with_user_id("admin")
+        .as_admin()
         .ready_on("documents", READY_TIMEOUT)
         .connect()
         .await;

--- a/crates/jazz-tools/tests/policies_integration/session_cases.rs
+++ b/crates/jazz-tools/tests/policies_integration/session_cases.rs
@@ -906,6 +906,7 @@ async fn select_policy_excludes_rows_from_join_results() {
         .with_server(&server)
         .with_schema(schema.clone())
         .with_user_id("admin")
+        .as_admin()
         .ready_on("team_memberships", READY_TIMEOUT)
         .connect()
         .await;
@@ -991,6 +992,7 @@ async fn in_session_array_policy_gates_visibility_by_membership() {
         .with_server(&server)
         .with_schema(schema.clone())
         .with_user_id("admin")
+        .as_admin()
         .ready_on("team_documents", READY_TIMEOUT)
         .connect()
         .await;

--- a/crates/jazz-tools/tests/policies_integration/simple_policies.rs
+++ b/crates/jazz-tools/tests/policies_integration/simple_policies.rs
@@ -1670,3 +1670,71 @@ async fn authorized_mutations_emit_visibility_scoped_subscription_deltas() {
     observer.shutdown().await.expect("shutdown observer");
     server.shutdown().await;
 }
+
+/// Verifies that adding `admin_secret` to an otherwise user-scoped WS client
+/// bypasses row-level SELECT policies by authenticating the transport as a
+/// backend connection.
+#[tokio::test]
+async fn admin_secret_ws_client_bypasses_row_select_policies() {
+    let table_name = "documents_admin_secret_backend";
+    let schema = SchemaBuilder::new()
+        .table(make_documents_schema(
+            table_name,
+            TablePolicies::new()
+                .with_insert(PolicyExpr::True)
+                .with_select(PolicyExpr::eq_session("owner_id", vec!["user_id".into()])),
+        ))
+        .build();
+    let server = TestingServer::builder()
+        .with_schema(schema.clone())
+        .start()
+        .await;
+
+    let alice = connect_ready_user(&server, &schema, "alice", table_name, READY_TIMEOUT).await;
+    let observer =
+        connect_ready_user(&server, &schema, "observer", table_name, READY_TIMEOUT).await;
+
+    let mut privileged_ctx = server.make_client_context_for_user(schema.clone(), "observer");
+    privileged_ctx.backend_secret = None;
+    privileged_ctx.admin_secret = Some(server.admin_secret().to_string());
+    let privileged = JazzClient::connect(privileged_ctx)
+        .await
+        .expect("connect privileged observer");
+
+    let row_id = seed_document(&alice, table_name, "alice", "private doc", false).await;
+    let expected_values = boolean_policy_document_values("alice", "private doc", false);
+
+    let observer_rows = wait_for_query(
+        &observer,
+        QueryBuilder::new(table_name).build(),
+        Some(DurabilityTier::EdgeServer),
+        Duration::from_secs(3),
+        "ordinary observer stays filtered by select policy",
+        Some,
+    )
+    .await;
+    assert!(
+        observer_rows.is_empty(),
+        "ordinary observer should not see alice's row"
+    );
+
+    let privileged_rows = wait_for_rows(
+        &privileged,
+        QueryBuilder::new(table_name).build(),
+        "admin_secret observer bypasses select policy",
+        |rows| has_row(&rows, row_id, &expected_values).then_some(rows),
+    )
+    .await;
+    assert!(
+        has_row(&privileged_rows, row_id, &expected_values),
+        "admin_secret observer should see alice's row via backend WS auth"
+    );
+
+    alice.shutdown().await.expect("shutdown alice");
+    observer.shutdown().await.expect("shutdown observer");
+    privileged
+        .shutdown()
+        .await
+        .expect("shutdown privileged observer");
+    server.shutdown().await;
+}

--- a/crates/jazz-tools/tests/rocksdb_storage_integration.rs
+++ b/crates/jazz-tools/tests/rocksdb_storage_integration.rs
@@ -86,8 +86,8 @@ async fn make_client_external_jwks(
         data_dir: tempfile::TempDir::new().expect("temp client dir").keep(),
         storage: ClientStorage::Memory,
         jwt_token: Some(TestingServer::jwt_for_user(user_id)),
-        backend_secret: Some(TestingServer::BACKEND_SECRET.to_string()),
-        admin_secret: Some(TestingServer::ADMIN_SECRET.to_string()),
+        backend_secret: None,
+        admin_secret: None,
         sync_tracer: None,
     };
 

--- a/crates/jazz-tools/tests/sqlite_storage_integration.rs
+++ b/crates/jazz-tools/tests/sqlite_storage_integration.rs
@@ -86,8 +86,8 @@ async fn make_client_external_jwks(
         data_dir: tempfile::TempDir::new().expect("temp client dir").keep(),
         storage: ClientStorage::Memory,
         jwt_token: Some(TestingServer::jwt_for_user(user_id)),
-        backend_secret: Some(TestingServer::BACKEND_SECRET.to_string()),
-        admin_secret: Some(TestingServer::ADMIN_SECRET.to_string()),
+        backend_secret: None,
+        admin_secret: None,
         sync_tracer: None,
     };
 

--- a/crates/jazz-tools/tests/support/mod.rs
+++ b/crates/jazz-tools/tests/support/mod.rs
@@ -152,7 +152,7 @@ impl<'a> TestingClient<'a> {
             server: None,
             schema: None,
             user_id: None,
-            auth: TestingClientAuth::Admin,
+            auth: TestingClientAuth::User,
             storage: TestingClientStorage::Memory,
             ready_table: None,
             ready_timeout: None,
@@ -172,6 +172,12 @@ impl<'a> TestingClient<'a> {
 
     pub fn with_user_id(mut self, user_id: impl Into<String>) -> Self {
         self.user_id = Some(user_id.into());
+        self
+    }
+
+    #[allow(dead_code)]
+    pub fn as_admin(mut self) -> Self {
+        self.auth = TestingClientAuth::Admin;
         self
     }
 
@@ -267,7 +273,14 @@ impl<'a> TestingClient<'a> {
             );
 
         match &self.auth {
-            TestingClientAuth::Admin => {}
+            TestingClientAuth::Admin => {
+                context.admin_secret = Some(
+                    self.server
+                        .expect("TestingClient requires `with_server(...)` before building")
+                        .admin_secret()
+                        .to_string(),
+                );
+            }
             TestingClientAuth::User => {
                 context.backend_secret = None;
                 context.admin_secret = None;

--- a/docs/content/partials/create-jazz-client-reference.mdx
+++ b/docs/content/partials/create-jazz-client-reference.mdx
@@ -4,7 +4,7 @@
 | `serverUrl`      | no       | Jazz sync server URL. Omit for fully local/offline mode.                    |
 | `auth`           | no       | Local-first auth config: `{ localFirstSecret: string }`.                    |
 | `jwtToken`       | no       | External auth bearer JWT. Requires server-side JWKS configuration.          |
-| `adminSecret`    | no       | Admin secret for schema catalog sync.                                       |
+| `adminSecret`    | no       | Admin secret for privileged sync and `/admin/*` catalogue operations.       |
 | `runtimeSources` | no       | Runtime source overrides for browser workers, Wasm URLs, or Wasm input.     |
 | `driver`         | no       | Storage driver: `{ type: "persistent" }` (default) or `{ type: "memory" }`. |
 | `dbName`         | no       | Local database name. Defaults to `appId`.                                   |

--- a/examples/docs/todo-server-rs/Cargo.toml
+++ b/examples/docs/todo-server-rs/Cargo.toml
@@ -24,6 +24,7 @@ uuid = { version = "1", features = ["v4"] }
 futures-util = "0.3"
 
 [dev-dependencies]
+jazz_tools = { package = "jazz-tools", path = "../../../crates/jazz-tools", features = ["sqlite"] }
 tempfile = "3"
 reqwest = { version = "0.12", features = ["json"] }
 tower = { version = "0.5", features = ["util"] }

--- a/examples/docs/todo-server-rs/tests/integration.rs
+++ b/examples/docs/todo-server-rs/tests/integration.rs
@@ -738,9 +738,9 @@ async fn test_server_resync() {
     // IMPORTANT: Client app_id must match server's app_id for schema sync to work
     let test_app_id = AppId::from_string("00000000-0000-0000-0000-000000000001").unwrap();
 
-    // 2. Create client with todos schema, add data
-    // This client has admin_secret so it can sync the catalogue (schema) to server.
-    // JWT token provides a session for the client's SSE and sync requests.
+    // 2. Create a normal JWT client with todos schema, then add data.
+    // User-scoped WS sync is what publishes the initial schema and rows here.
+    // Adding admin_secret would now force backend mode and reject catalogue writes.
     {
         let context = AppContext {
             app_id: test_app_id,
@@ -751,7 +751,7 @@ async fn test_server_resync() {
             storage: ClientStorage::Persistent,
             jwt_token: Some(make_test_jwt("client1-user")),
             backend_secret: None,
-            admin_secret: Some(TEST_ADMIN_SECRET.to_string()),
+            admin_secret: None,
             sync_tracer: None,
         };
         let client = JazzClient::connect(context).await.unwrap();

--- a/examples/docs/todo-server-ts/tests/integration.test.ts
+++ b/examples/docs/todo-server-ts/tests/integration.test.ts
@@ -9,7 +9,7 @@ import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { tmpdir } from "node:os";
 import { mkdtempSync } from "node:fs";
 import { join } from "node:path";
-import { TestingServer } from "jazz-tools/testing";
+import { pushSchemaCatalogue, TestingServer } from "jazz-tools/testing";
 import {
   createServer,
   startServer,
@@ -25,6 +25,13 @@ describe("Todo Server Integration", () => {
 
   beforeAll(async () => {
     upstream = await TestingServer.start();
+
+    await pushSchemaCatalogue({
+      serverUrl: upstream.url,
+      appId: upstream.appId,
+      adminSecret: upstream.adminSecret,
+      schemaDir: join(import.meta.dirname ?? __dirname, ".."),
+    });
 
     // Create server with temp persistent storage plus an ephemeral upstream server.
     const todoServer = await createServer({
@@ -259,6 +266,12 @@ describe("Todo Server Integration", () => {
     it("streams all todos and updates on changes", async () => {
       // Use an isolated upstream and local server so this test starts from a clean global state.
       const sseUpstream = await TestingServer.start();
+      await pushSchemaCatalogue({
+        serverUrl: sseUpstream.url,
+        appId: sseUpstream.appId,
+        adminSecret: sseUpstream.adminSecret,
+        schemaDir: join(import.meta.dirname ?? __dirname, ".."),
+      });
       const sseServer = await startServer(
         await createServer({
           appId: sseUpstream.appId,

--- a/examples/docs/todo-server-ts/vitest.config.ts
+++ b/examples/docs/todo-server-ts/vitest.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     environment: "node",
-    hookTimeout: 60_000,
-    testTimeout: 60_000,
+    hookTimeout: 6_000,
+    testTimeout: 6_000,
   },
 });

--- a/examples/todo-server-rs/tests/integration.rs
+++ b/examples/todo-server-rs/tests/integration.rs
@@ -738,9 +738,9 @@ async fn test_server_resync() {
     // IMPORTANT: Client app_id must match server's app_id for schema sync to work
     let test_app_id = AppId::from_string("00000000-0000-0000-0000-000000000001").unwrap();
 
-    // 2. Create client with todos schema, add data
-    // This client has admin_secret so it can sync the catalogue (schema) to server.
-    // JWT token provides a session for the client's SSE and sync requests.
+    // 2. Create a normal JWT client with todos schema, then add data.
+    // User-scoped WS sync is what publishes the initial schema and rows here.
+    // Adding admin_secret would now force backend mode and reject catalogue writes.
     {
         let context = AppContext {
             app_id: test_app_id,
@@ -751,7 +751,7 @@ async fn test_server_resync() {
             storage: ClientStorage::Persistent,
             jwt_token: Some(make_test_jwt("client1-user")),
             backend_secret: None,
-            admin_secret: Some(TEST_ADMIN_SECRET.to_string()),
+            admin_secret: None,
             sync_tracer: None,
         };
         let client = JazzClient::connect(context).await.unwrap();

--- a/packages/inspector/src/App.tsx
+++ b/packages/inspector/src/App.tsx
@@ -114,7 +114,6 @@ export default function App() {
             env: storedConfig.env,
             userBranch: storedConfig.branch,
             adminSecret: storedConfig.adminSecret,
-            auth: { localFirstSecret: "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8" },
             driver: { type: "memory" },
           }),
           fetchStoredWasmSchema(storedConfig.serverUrl, {

--- a/packages/jazz-tools/src/runtime/client.ts
+++ b/packages/jazz-tools/src/runtime/client.ts
@@ -136,7 +136,7 @@ export interface AuthConfig {
   jwt_token?: string;
   /** Backend service secret for server-to-server calls. */
   backend_secret?: string;
-  /** Admin secret for privileged operations. */
+  /** Admin secret for privileged sync and `/admin/*` catalogue operations. */
   admin_secret?: string;
   /** Opaque session payload forwarded by a backend proxy. */
   backend_session?: unknown;

--- a/packages/jazz-tools/src/runtime/context.ts
+++ b/packages/jazz-tools/src/runtime/context.ts
@@ -87,8 +87,8 @@ export interface AppContext {
   backendSecret?: string;
 
   /**
-   * Admin secret for schema/policy sync.
-   * Required to sync catalogue objects.
+   * Admin secret for privileged sync and `/admin/*` catalogue endpoints.
+   * On `/ws`, a valid admin secret authenticates this client as the backend.
    */
   adminSecret?: string;
 

--- a/packages/jazz-tools/tests/browser/support.ts
+++ b/packages/jazz-tools/tests/browser/support.ts
@@ -267,14 +267,13 @@ export async function createSyncedDb(
   testingServer?: TestingServerInfo,
 ): Promise<Db> {
   const localFirstSecret = secret ?? generateAuthSecret();
-  const { appId, serverUrl, adminSecret } = testingServer ?? (await getTestingServerInfo());
+  const { appId, serverUrl } = testingServer ?? (await getTestingServerInfo());
   return ctx.track(
     await createDb({
       appId,
       driver: { type: "persistent", dbName: uniqueDbName(label) },
       serverUrl,
       auth: { localFirstSecret },
-      adminSecret,
     }),
   );
 }


### PR DESCRIPTION
## Summary
- Treat `adminSecret` as trusted backend auth for row sync and event connections
- Keep catalogue and admin endpoints on the existing admin-secret path
- Update client, worker, and framework wrappers so inspector and reactive subscriptions honor the new behavior
- Add tests for transport auth precedence, route handling, and inspector/browser coverage

## Why
The inspector needs a privileged account to read/write data, skipping all permission policies. It also needs adminSecret to access admin endpoints, such as the schemas and permissions lists.

## Why now
Since we changed both the deny-by-default policies and the authentication methods, cutting out the inspector's access to the whole database.