### PR TITLE
fix(transport): use real sleep in wasm backoff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1226,6 +1226,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "gloo-utils"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1747,6 +1759,7 @@ dependencies = [
  "criterion",
  "ed25519-dalek",
  "futures",
+ "gloo-timers",
  "hex",
  "insta",
  "internment",

--- a/crates/jazz-tools/Cargo.toml
+++ b/crates/jazz-tools/Cargo.toml
@@ -96,6 +96,9 @@ opentelemetry-otlp = { version = "0.31", features = ["grpc-tonic"], optional = t
 opentelemetry-stdout = { version = "0.31", features = ["trace"], optional = true }
 tracing-opentelemetry = { version = "0.32", optional = true }
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+gloo-timers = { version = "0.3", features = ["futures"] }
+
 [dev-dependencies]
 criterion = "0.5"
 insta = "1"

--- a/crates/jazz-tools/src/transport_manager.rs
+++ b/crates/jazz-tools/src/transport_manager.rs
@@ -176,9 +176,11 @@ impl ReconnectState {
         {
             tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
         }
-        // M-7: WASM / no-tokio: no real sleep is available. Yield one poll cycle to avoid
-        // a tight spin; outer reconnect loop relies on network I/O awaits for real backpressure.
-        #[cfg(any(target_arch = "wasm32", not(feature = "runtime-tokio")))]
+        #[cfg(target_arch = "wasm32")]
+        {
+            gloo_timers::future::sleep(std::time::Duration::from_millis(delay_ms)).await;
+        }
+        #[cfg(all(not(target_arch = "wasm32"), not(feature = "runtime-tokio")))]
         {
             let _ = delay_ms;
             futures::future::ready(()).await;


### PR DESCRIPTION
## Summary

`ReconnectState::backoff` in `crates/jazz-tools/src/transport_manager.rs` awaited `futures::future::ready(())` on the wasm arm, which only yields one poll cycle and discards the computed `delay_ms`. If `W::connect` failed synchronously (bad URL, immediate TLS reject, offline), the outer reconnect loop busy-spun with no backpressure — a real reconnect-storm risk on mobile Safari/Firefox under flaky connectivity.

This routes the wasm branch through `gloo_timers::future::sleep` so the exponential backoff actually delays. The tokio path was already correct; the yield-only fallback is preserved for the exotic native-without-`runtime-tokio` combo (not currently exercised in-tree, but kept for completeness).

## Changes

- `crates/jazz-tools/Cargo.toml`: add `gloo-timers = { version = "0.3", features = ["futures"] }` as a `cfg(target_arch = "wasm32")` target dep.
- `crates/jazz-tools/src/transport_manager.rs`: split the backoff cfg into three arms — tokio (native + `runtime-tokio`), `gloo_timers::future::sleep` (wasm32), and the yield-only fallback (native without `runtime-tokio`).

## Test plan

- [x] `cargo check -p jazz-tools --features client` — clean
- [x] `cargo check -p jazz-wasm --target wasm32-unknown-unknown` — clean
- [x] `cargo test -p jazz-tools --features client --lib transport_manager::` — 8/8 pass (including `shutdown_during_backoff`, `update_auth_during_backoff`)
- [ ] Manual: exercise a wasm client against an unreachable `wss://` URL and confirm reconnect attempts are paced (not a tight spin)