### PR TITLE
fix(transport): thread serverPathPrefix through connectTransport

### DIFF
--- a/packages/jazz-tools/src/backend/create-jazz-context.ts
+++ b/packages/jazz-tools/src/backend/create-jazz-context.ts
@@ -175,11 +175,15 @@ export class JazzContext {
 
     // Wire Rust-owned WebSocket transport when a server URL is configured.
     if (this.config.serverUrl) {
-      this.clientInstance.connectTransport(this.config.serverUrl, {
-        backend_secret: this.config.backendSecret,
-        admin_secret: this.config.adminSecret,
-        jwt_token: this.config.jwtToken,
-      });
+      this.clientInstance.connectTransport(
+        this.config.serverUrl,
+        {
+          backend_secret: this.config.backendSecret,
+          admin_secret: this.config.adminSecret,
+          jwt_token: this.config.jwtToken,
+        },
+        this.config.serverPathPrefix,
+      );
     }
 
     return this.clientInstance;

--- a/packages/jazz-tools/src/react-native/db.test.ts
+++ b/packages/jazz-tools/src/react-native/db.test.ts
@@ -259,10 +259,14 @@ describe("react-native Db", () => {
     });
     db.exposeGetClient(makeSchema("todos"));
 
-    expect(stub.connectTransport).toHaveBeenCalledWith("https://example.test", {
-      jwt_token: "jwt-x",
-      admin_secret: "admin-y",
-    });
+    expect(stub.connectTransport).toHaveBeenCalledWith(
+      "https://example.test",
+      {
+        jwt_token: "jwt-x",
+        admin_secret: "admin-y",
+      },
+      "/apps/rn-app",
+    );
   });
 
   it("RNDB-U09 does not call connectTransport when serverUrl is absent", () => {

--- a/packages/jazz-tools/src/react-native/db.ts
+++ b/packages/jazz-tools/src/react-native/db.ts
@@ -53,10 +53,14 @@ export class Db extends RuntimeDb {
       );
 
       if (this.nativeConfig.serverUrl) {
-        client.connectTransport(this.nativeConfig.serverUrl, {
-          jwt_token: this.nativeConfig.jwtToken,
-          admin_secret: this.nativeConfig.adminSecret,
-        });
+        client.connectTransport(
+          this.nativeConfig.serverUrl,
+          {
+            jwt_token: this.nativeConfig.jwtToken,
+            admin_secret: this.nativeConfig.adminSecret,
+          },
+          this.nativeConfig.serverPathPrefix,
+        );
       }
 
       this.nativeClients.set(key, client);

--- a/packages/jazz-tools/src/runtime/client.ts
+++ b/packages/jazz-tools/src/runtime/client.ts
@@ -1486,14 +1486,15 @@ export class JazzClient {
    * passing it to the underlying Rust runtime's `connect()`.  Already-WS URLs
    * are passed through unchanged.
    *
-   * @param url  Server URL — http(s):// or ws(s)://. `/ws` is appended automatically.
-   * @param auth Authentication credentials for the connection.
+   * @param url        Server URL — http(s):// or ws(s)://. `/ws` is appended automatically.
+   * @param auth       Authentication credentials for the connection.
+   * @param pathPrefix Optional path prefix inserted before `/ws` (e.g. `/apps/<id>`).
    */
-  connectTransport(url: string, auth: AuthConfig): void {
+  connectTransport(url: string, auth: AuthConfig, pathPrefix?: string): void {
     if (!this.runtime.connect) {
       throw new Error("Underlying runtime does not support connect()");
     }
-    this.runtime.connect(httpUrlToWs(url), JSON.stringify(auth));
+    this.runtime.connect(httpUrlToWs(url, pathPrefix), JSON.stringify(auth));
   }
 
   /**

--- a/packages/jazz-tools/src/runtime/db.transport.test.ts
+++ b/packages/jazz-tools/src/runtime/db.transport.test.ts
@@ -37,7 +37,7 @@ describe("runtime/Db direct path upstream wiring", () => {
     vi.restoreAllMocks();
   });
 
-  it("DBRT-U01 calls connectTransport when serverUrl is configured and no worker", () => {
+  it("DBRT-U01 calls connectTransport with serverUrl and serverPathPrefix when configured and no worker", () => {
     const client = makeClientStub();
     const connectSyncSpy = vi.spyOn(JazzClient, "connectSync").mockReturnValue(client);
 
@@ -51,10 +51,36 @@ describe("runtime/Db direct path upstream wiring", () => {
     db.exposeGetClient(makeSchema());
 
     expect(connectSyncSpy).toHaveBeenCalledTimes(1);
-    expect((client as any).connectTransport).toHaveBeenCalledWith("https://example.test", {
-      jwt_token: "jwt-x",
-      admin_secret: "admin-y",
+    expect((client as any).connectTransport).toHaveBeenCalledWith(
+      "https://example.test",
+      {
+        jwt_token: "jwt-x",
+        admin_secret: "admin-y",
+      },
+      "/apps/app",
+    );
+  });
+
+  it("DBRT-U01b calls connectTransport without prefix when serverPathPrefix is absent", () => {
+    const client = makeClientStub();
+    vi.spyOn(JazzClient, "connectSync").mockReturnValue(client);
+
+    const db = new TestDb({
+      appId: "app",
+      serverUrl: "https://example.test",
+      jwtToken: "jwt-x",
+      adminSecret: "admin-y",
     });
+    db.exposeGetClient(makeSchema());
+
+    expect((client as any).connectTransport).toHaveBeenCalledWith(
+      "https://example.test",
+      {
+        jwt_token: "jwt-x",
+        admin_secret: "admin-y",
+      },
+      undefined,
+    );
   });
 
   it("DBRT-U02 does not call connectTransport when serverUrl is absent", () => {

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -593,10 +593,14 @@ export class Db {
       // Direct (non-worker) clients with a serverUrl must open their own
       // Rust transport — the worker bridge is not doing it for them.
       if (!this.worker && this.config.serverUrl) {
-        client.connectTransport(this.config.serverUrl, {
-          jwt_token: this.config.jwtToken,
-          admin_secret: this.config.adminSecret,
-        });
+        client.connectTransport(
+          this.config.serverUrl,
+          {
+            jwt_token: this.config.jwtToken,
+            admin_secret: this.config.adminSecret,
+          },
+          this.config.serverPathPrefix,
+        );
       }
 
       this.clients.set(key, client);


### PR DESCRIPTION
## Summary

- `JazzClient.connectTransport` called `httpUrlToWs` on the bare `serverUrl` and ignored the configured `serverPathPrefix`, so direct (non-worker) browser/RN/backend clients dialed root `/ws` even when the Jazz server was mounted at `/apps/<id>` or similar. Worker init was already fixed; the direct path regressed.
- Changed `connectTransport(url, auth)` → `connectTransport(url, auth, pathPrefix?)` and compose the WS URL via `httpUrlToWs(url, pathPrefix)`.
- Updated the three call sites to pass `config.serverPathPrefix`: `runtime/db.ts`, `react-native/db.ts`, `backend/create-jazz-context.ts`.

## Why

Deployments that mount Jazz behind a reverse-proxy path prefix (multiple apps on one origin) silently failed to sync upstream on the direct-client path — the symptom looked like "edge tier never catches up."

With this fix, configuring `serverUrl: "https://host"` + `serverPathPrefix: "/apps/<id>"` dials `wss://host/apps/<id>/ws` on the direct path, matching the worker path.

## Tests

- Updated `DBRT-U01` and `RNDB-U08` which previously locked in the buggy shape (asserted `connectTransport` was called without the prefix).
- Added `DBRT-U01b` covering the no-prefix case to prevent regression in the common config.

## Test plan

- [x] `vitest run src/runtime/db.transport.test.ts src/react-native/db.test.ts` — 12/12 pass
- [x] Backend / url / worker tests unaffected
- [ ] Manual smoke: direct client against a prefix-mounted server reaches `wss://host/<prefix>/ws`