### PR TITLE
feat(starters): wire BetterAuth adapter into Next.js + SvelteKit starters

### DIFF
--- a/.changeset/managed-runtime-stale-env-fix.md
+++ b/.changeset/managed-runtime-stale-env-fix.md
@@ -1,0 +1,5 @@
+---
+"jazz-tools": patch
+---
+
+`ManagedDevRuntime` no longer throws when a prior in-process run leaves `*_JAZZ_SERVER_URL` set in `process.env`. The env var on its own is now treated as our own persisted value and ignored in favour of spinning up a fresh local server. The plugin still takes the "connect to an external server" path when the caller explicitly supplies an `adminSecret` option or sets `JAZZ_ADMIN_SECRET`. This makes Vite HMR restarts and repeated test runs work without stale-state errors.

--- a/.changeset/starters-wire-jazz-adapter.md
+++ b/.changeset/starters-wire-jazz-adapter.md
@@ -1,0 +1,7 @@
+---
+"create-jazz": patch
+---
+
+Wire the Jazz BetterAuth adapter into every starter that ships a BetterAuth backend — the six `*-betterauth` and `*-hybrid` starters across Next.js, SvelteKit, and React. Each starter now persists its auth tables in Jazz via `jazzAdapter` instead of the in-memory `memoryAdapter` stub, and publishes a `schema-better-auth/schema.ts` with the BetterAuth table definitions merged into the starter's main schema.
+
+React starters pin the Jazz dev-server to port 4002 so the standalone Hono backend can connect without coordinating runtime values through `.env`, flip their dev script so Vite starts first (populating `VITE_JAZZ_APP_ID`) and tsx waits on it, and pre-generate a shared `BACKEND_SECRET` up front via `scripts/ensure-env.js`.

--- a/packages/create-jazz/src/index.ts
+++ b/packages/create-jazz/src/index.ts
@@ -4,7 +4,7 @@ import * as path from "node:path";
 import { scaffold, validateAppName, type StarterName } from "./scaffold.js";
 import { detectPackageManager } from "./detect-pm.js";
 import { runHostedInit } from "./cloud-init.js";
-import { writeBetterAuthSecret } from "./init-secret.js";
+import { writeBackendSecret, writeBetterAuthSecret } from "./init-secret.js";
 
 type Framework = "next" | "sveltekit";
 type Hosting = "hosted" | "selfhosted";
@@ -191,6 +191,7 @@ async function main() {
       ? async (dir: string) => {
           if (needsBetterAuthSecret) {
             writeBetterAuthSecret(dir);
+            writeBackendSecret(dir);
           }
           if (hosting === "hosted") {
             const envKeys = envKeysForStarter(starter);

--- a/packages/create-jazz/src/init-secret.test.ts
+++ b/packages/create-jazz/src/init-secret.test.ts
@@ -1,0 +1,55 @@
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { beforeEach, describe, expect, it } from "vitest";
+import { writeBackendSecret, writeBetterAuthSecret } from "./init-secret.js";
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "init-secret-test-"));
+});
+
+function readEnv(): string {
+  return readFileSync(join(dir, ".env"), "utf8");
+}
+
+describe("writeBetterAuthSecret", () => {
+  it("writes BETTER_AUTH_SECRET when .env is absent", () => {
+    const secret = writeBetterAuthSecret(dir);
+    expect(secret).toMatch(/^[A-Za-z0-9_-]{43}$/);
+    expect(readEnv()).toContain(`BETTER_AUTH_SECRET=${secret}\n`);
+  });
+
+  it("is idempotent when the key is already present", () => {
+    writeFileSync(join(dir, ".env"), "BETTER_AUTH_SECRET=preset\n");
+    expect(writeBetterAuthSecret(dir)).toBeNull();
+    expect(readEnv()).toBe("BETTER_AUTH_SECRET=preset\n");
+  });
+
+  it("appends to an existing .env without trailing newline", () => {
+    writeFileSync(join(dir, ".env"), "OTHER=value");
+    const secret = writeBetterAuthSecret(dir);
+    expect(readEnv()).toBe(`OTHER=value\nBETTER_AUTH_SECRET=${secret}\n`);
+  });
+});
+
+describe("writeBackendSecret", () => {
+  it("writes BACKEND_SECRET when .env is absent", () => {
+    const secret = writeBackendSecret(dir);
+    expect(secret).toMatch(/^[0-9a-f]{64}$/);
+    expect(readEnv()).toContain(`BACKEND_SECRET=${secret}\n`);
+  });
+
+  it("is idempotent when the key is already present", () => {
+    writeFileSync(join(dir, ".env"), "BACKEND_SECRET=preset\n");
+    expect(writeBackendSecret(dir)).toBeNull();
+    expect(readEnv()).toBe("BACKEND_SECRET=preset\n");
+  });
+
+  it("appends alongside an existing BETTER_AUTH_SECRET entry", () => {
+    writeFileSync(join(dir, ".env"), "BETTER_AUTH_SECRET=abc\n");
+    const secret = writeBackendSecret(dir);
+    expect(readEnv()).toBe(`BETTER_AUTH_SECRET=abc\nBACKEND_SECRET=${secret}\n`);
+  });
+});

--- a/packages/create-jazz/src/init-secret.ts
+++ b/packages/create-jazz/src/init-secret.ts
@@ -15,17 +15,13 @@ function hasKey(content: string, key: string): boolean {
   return false;
 }
 
-/**
- * Generate a BETTER_AUTH_SECRET and write it to .env if not already set.
- * Idempotent — safe to call multiple times.
- */
-export function writeBetterAuthSecret(dir: string): string | null {
+function writeSecret(dir: string, key: string, generate: () => string): string | null {
   const envPath = join(dir, ".env");
   const existing = existsSync(envPath) ? readFileSync(envPath, "utf8") : "";
-  if (hasKey(existing, "BETTER_AUTH_SECRET")) return null;
+  if (hasKey(existing, key)) return null;
 
-  const secret = randomBytes(32).toString("base64url");
-  const line = `BETTER_AUTH_SECRET=${secret}\n`;
+  const secret = generate();
+  const line = `${key}=${secret}\n`;
   if (existing) {
     const prefix = existing.endsWith("\n") ? "" : "\n";
     appendFileSync(envPath, prefix + line, "utf8");
@@ -33,4 +29,20 @@ export function writeBetterAuthSecret(dir: string): string | null {
     writeFileSync(envPath, line, "utf8");
   }
   return secret;
+}
+
+/**
+ * Generate a BETTER_AUTH_SECRET and write it to .env if not already set.
+ * Idempotent — safe to call multiple times.
+ */
+export function writeBetterAuthSecret(dir: string): string | null {
+  return writeSecret(dir, "BETTER_AUTH_SECRET", () => randomBytes(32).toString("base64url"));
+}
+
+/**
+ * Generate a BACKEND_SECRET and write it to .env if not already set.
+ * Idempotent — safe to call multiple times.
+ */
+export function writeBackendSecret(dir: string): string | null {
+  return writeSecret(dir, "BACKEND_SECRET", () => randomBytes(32).toString("hex"));
 }

--- a/packages/jazz-tools/src/dev/expo.test.ts
+++ b/packages/jazz-tools/src/dev/expo.test.ts
@@ -120,14 +120,22 @@ describe("withJazz", () => {
     expect(pushSchemaCatalogue).toHaveBeenCalledTimes(2);
   }, 30_000);
 
-  it("throws when connecting to an existing server without adminSecret", async () => {
+  it("ignores a bare server URL env var with no adminSecret and starts a fresh local server", async () => {
+    // Simulates the env being populated by a prior initialize() call in the
+    // same process. A bare env var is our own leftover, not a request to
+    // connect externally.
     process.env.EXPO_PUBLIC_JAZZ_SERVER_URL = "http://127.0.0.1:4000";
     process.env.EXPO_PUBLIC_JAZZ_APP_ID = "00000000-0000-0000-0000-000000000111";
 
-    await expect(withJazz({})).rejects.toThrow(
-      "adminSecret is required when connecting to an existing server",
-    );
-  });
+    const port = await getAvailablePort();
+    const schemaDir = await tempRoots.create("jazz-expo-fallback-");
+    await writeFile(join(schemaDir, "schema.ts"), todoSchema());
+
+    const resolved = await withJazz({}, { server: { port }, schemaDir });
+
+    expect(resolved.extra?.jazzServerUrl).toBe(`http://127.0.0.1:${port}`);
+    expect(process.env.EXPO_PUBLIC_JAZZ_SERVER_URL).toBe(`http://127.0.0.1:${port}`);
+  }, 30_000);
 
   it("throws when connecting to an existing server without appId", async () => {
     process.env.EXPO_PUBLIC_JAZZ_SERVER_URL = "http://127.0.0.1:4000";

--- a/packages/jazz-tools/src/dev/managed-runtime.ts
+++ b/packages/jazz-tools/src/dev/managed-runtime.ts
@@ -215,15 +215,20 @@ export class ManagedDevRuntime {
           throw new Error(`${LOG_PREFIX} server=false should bypass initialization`);
         }
 
-        if (process.env[this.envKeys.serverUrl]) {
+        // A bare serverUrl env var on its own is treated as our own leftover
+        // from a previous run in the same process (Vite HMR restarts,
+        // `runtime.resetForTests()` in tests, etc., all re-enter initialize
+        // with process.env still set from before). The "external server"
+        // path here means "connect to a Jazz dev server someone else is
+        // running" — that intent only makes sense if the caller explicitly
+        // supplied an adminSecret, so use that as the signal. Otherwise we
+        // ignore the env URL and fall through to starting a fresh local
+        // server below.
+        const explicitAdminSecret = options.adminSecret ?? process.env.JAZZ_ADMIN_SECRET ?? null;
+        if (process.env[this.envKeys.serverUrl] && explicitAdminSecret) {
           serverUrl = process.env[this.envKeys.serverUrl]!;
-          adminSecret = options.adminSecret ?? process.env.JAZZ_ADMIN_SECRET ?? "";
+          adminSecret = explicitAdminSecret;
           appId = process.env[this.envKeys.appId] ?? options.appId ?? "";
-          if (!adminSecret) {
-            throw new Error(
-              `${LOG_PREFIX} adminSecret is required when connecting to an existing server`,
-            );
-          }
           if (!appId) {
             throw new Error(
               `${LOG_PREFIX} appId is required when connecting to an existing server`,

--- a/packages/jazz-tools/src/dev/next.test.ts
+++ b/packages/jazz-tools/src/dev/next.test.ts
@@ -211,13 +211,23 @@ describe("withJazz", () => {
     expect(pushSchemaCatalogue).toHaveBeenCalledTimes(2);
   }, 30_000);
 
-  it("throws when connecting to an existing server without adminSecret", async () => {
+  it("ignores a bare server URL env var with no adminSecret and starts a fresh local server", async () => {
+    // Simulates the env being populated by a prior initialize() call in the
+    // same process (Vite HMR restarts, repeated dev sessions in tests). A
+    // bare env var is our own leftover, not a request to connect externally.
     process.env.NEXT_PUBLIC_JAZZ_SERVER_URL = "http://127.0.0.1:4000";
     process.env.NEXT_PUBLIC_JAZZ_APP_ID = "00000000-0000-0000-0000-000000000111";
 
-    await expect(resolveWrappedConfig(withJazz({}), DEVELOPMENT_PHASE)).rejects.toThrow(
-      "adminSecret is required when connecting to an existing server",
+    const schemaDir = await tempRoots.create("jazz-next-fallback-");
+    await writeFile(join(schemaDir, "schema.ts"), todoSchema());
+    const port = await getAvailablePort();
+
+    const resolved = await resolveWrappedConfig(
+      withJazz({}, { server: { port }, schemaDir }),
+      DEVELOPMENT_PHASE,
     );
+
+    expect(resolved.env?.NEXT_PUBLIC_JAZZ_SERVER_URL).toBe(`http://127.0.0.1:${port}`);
   });
 
   it("throws when connecting to an existing server without appId", async () => {

--- a/packages/jazz-tools/src/dev/sveltekit.test.ts
+++ b/packages/jazz-tools/src/dev/sveltekit.test.ts
@@ -262,15 +262,24 @@ describe("jazzSvelteKit", () => {
     );
   });
 
-  it("throws when connecting to an existing server without adminSecret", async () => {
+  it("ignores a bare server URL env var with no adminSecret and starts a fresh local server", async () => {
+    // Simulates the env being populated by a prior initialize() call in the
+    // same process (Vite HMR restarts). A bare env var is our own leftover,
+    // not a request to connect externally.
     process.env.PUBLIC_JAZZ_SERVER_URL = "http://jazz-test-server:4000";
     process.env.PUBLIC_JAZZ_APP_ID = "00000000-0000-0000-0000-000000000010";
 
-    const plugin = jazzSvelteKit({});
-    await expect(
-      (plugin.configureServer as (s: ViteDevServer) => Promise<void>)(makeViteServer("serve")),
-    ).rejects.toThrow("adminSecret is required when connecting to an existing server");
-  });
+    const port = await getAvailablePort();
+    const root = await tempRoots.create("jazz-sveltekit-fallback-");
+    await mkdir(join(root, "src", "lib"), { recursive: true });
+    await writeFile(join(root, "src", "lib", "schema.ts"), todoSchema());
+
+    const plugin = jazzSvelteKit({ server: { port } });
+    const viteServer = makeViteServer("serve", root);
+    await (plugin.configureServer as (s: ViteDevServer) => Promise<void>)(viteServer);
+
+    expect(viteServer.config.env!.PUBLIC_JAZZ_SERVER_URL).toBe(`http://127.0.0.1:${port}`);
+  }, 30_000);
 
   it("throws when connecting to an existing server without appId", async () => {
     process.env.PUBLIC_JAZZ_SERVER_URL = "http://jazz-test-server:4000";

--- a/scripts/check-starters-parity.mjs
+++ b/scripts/check-starters-parity.mjs
@@ -30,9 +30,9 @@ const STARTERS = {
 // Files listed here must be byte-identical across every variant of the
 // same framework (a "horizontal" parity rule).
 const HORIZONTAL_FILES = {
-  next: ["schema.ts", "permissions.ts", "components/todo-widget.tsx"],
-  sveltekit: ["src/lib/schema.ts", "src/lib/permissions.ts", "src/lib/TodoWidget.svelte"],
-  react: ["schema.ts", "permissions.ts", "src/todo-widget.tsx"],
+  next: ["permissions.ts", "components/todo-widget.tsx"],
+  sveltekit: ["src/lib/permissions.ts", "src/lib/TodoWidget.svelte"],
+  react: ["permissions.ts", "src/todo-widget.tsx"],
 };
 
 // Files that must be byte-identical across all nine starters regardless of
@@ -43,12 +43,49 @@ const ALL_STARTERS_FILES = ["AGENTS.md"];
 // parity rule on top of the horizontal one). We resolve them per framework
 // via HORIZONTAL_FILES — the logical name is the dict key.
 const CROSS_FRAMEWORK_FILES = [
-  { logical: "schema", next: "schema.ts", sveltekit: "src/lib/schema.ts", react: "schema.ts" },
   {
     logical: "permissions",
     next: "permissions.ts",
     sveltekit: "src/lib/permissions.ts",
     react: "permissions.ts",
+  },
+];
+
+// Auth-mode groupings. `schema.ts` depends on auth mode — betterauth and
+// hybrid starters ship the BetterAuth tables alongside the domain schema;
+// localfirst starters don't. So the "all variants within a framework share
+// schema.ts" rule doesn't hold across auth modes, and we use per-auth-mode
+// parity instead.
+const AUTH_MODE_GROUPS = {
+  betterauth: [
+    "starters/next-betterauth",
+    "starters/sveltekit-betterauth",
+    "starters/react-betterauth",
+  ],
+  hybrid: ["starters/next-hybrid", "starters/sveltekit-hybrid", "starters/react-hybrid"],
+  localfirst: [
+    "starters/next-localfirst",
+    "starters/sveltekit-localfirst",
+    "starters/react-localfirst",
+  ],
+};
+
+// Files that must be byte-identical across the three framework variants of
+// the same auth mode. The path differs per framework; the logical key is
+// what we report on failure.
+const AUTH_MODE_FILES = [
+  { logical: "schema", next: "schema.ts", sveltekit: "src/lib/schema.ts", react: "schema.ts" },
+];
+
+// Files that must be byte-identical across every starter that uses the
+// BetterAuth adapter (betterauth + hybrid). Localfirst starters are
+// excluded because they have no BetterAuth tables.
+const ADAPTER_STARTER_FILES = [
+  {
+    logical: "schema-better-auth",
+    next: "schema-better-auth/schema.ts",
+    sveltekit: "src/lib/schema-better-auth/schema.ts",
+    react: "schema-better-auth/schema.ts",
   },
 ];
 
@@ -213,8 +250,72 @@ function checkAllStartersParity() {
   }
 }
 
+function resolveForStarter(dir, entry) {
+  if (dir.startsWith("starters/next-")) return `${dir}/${entry.next}`;
+  if (dir.startsWith("starters/sveltekit-")) return `${dir}/${entry.sveltekit}`;
+  if (dir.startsWith("starters/react-")) return `${dir}/${entry.react}`;
+  return null;
+}
+
+function checkAuthModeParity() {
+  for (const [mode, dirs] of Object.entries(AUTH_MODE_GROUPS)) {
+    for (const entry of AUTH_MODE_FILES) {
+      const hashes = new Map();
+      for (const dir of dirs) {
+        const path = resolveForStarter(dir, entry);
+        if (!path) continue;
+        const content = read(path);
+        if (content === null) {
+          errors.push(`Missing file: ${path}`);
+          continue;
+        }
+        const h = hash(content);
+        if (!hashes.has(h)) hashes.set(h, []);
+        hashes.get(h).push(path);
+      }
+      if (hashes.size > 1) {
+        const groups = [...hashes.entries()]
+          .map(([h, files]) => `  ${h.slice(0, 12)}  ${files.join(", ")}`)
+          .join("\n");
+        errors.push(
+          `Auth-mode drift in ${mode}: ${entry.logical} disagrees across frameworks\n${groups}`,
+        );
+      }
+    }
+  }
+}
+
+function checkAdapterStarterParity() {
+  const adapterDirs = [...AUTH_MODE_GROUPS.betterauth, ...AUTH_MODE_GROUPS.hybrid];
+  for (const entry of ADAPTER_STARTER_FILES) {
+    const hashes = new Map();
+    for (const dir of adapterDirs) {
+      const path = resolveForStarter(dir, entry);
+      if (!path) continue;
+      const content = read(path);
+      if (content === null) {
+        errors.push(`Missing file: ${path}`);
+        continue;
+      }
+      const h = hash(content);
+      if (!hashes.has(h)) hashes.set(h, []);
+      hashes.get(h).push(path);
+    }
+    if (hashes.size > 1) {
+      const groups = [...hashes.entries()]
+        .map(([h, files]) => `  ${h.slice(0, 12)}  ${files.join(", ")}`)
+        .join("\n");
+      errors.push(
+        `Adapter-starter drift: ${entry.logical} disagrees across adapter starters\n${groups}`,
+      );
+    }
+  }
+}
+
 checkHorizontalParity();
 checkCrossFrameworkParity();
+checkAuthModeParity();
+checkAdapterStarterParity();
 checkAllStartersParity();
 checkReadmeStructure();
 checkSharedReadmeBlocks();

--- a/starters/next-betterauth/README.md
+++ b/starters/next-betterauth/README.md
@@ -26,9 +26,9 @@ pnpm dev
 
 Open [http://localhost:3000](http://localhost:3000), create an account,
 and you'll land on `/dashboard` with a working todo list persisted via
-Jazz. The `withJazz` plugin spawns a local Jazz dev server automatically;
-set `BETTER_AUTH_SECRET` in `.env` before running (`openssl rand -base64
-32` or scaffold via `create-jazz`).
+Jazz. `pnpm install` seeds `.env` with a random `BETTER_AUTH_SECRET` and
+`BACKEND_SECRET`; the `withJazz` plugin spawns a local Jazz dev server
+automatically.
 
 ## Architecture
 
@@ -82,20 +82,20 @@ session on every row and the permission policy scopes reads/writes to it.
 
 ## Environment variables
 
-Scaffold via `create-jazz` to have `.env` populated automatically; otherwise
-write the values below by hand.
+`pnpm install` runs `scripts/ensure-env.js`, which seeds any missing keys
+in `.env` with random values. Override by setting values manually before
+install, or for cloud mode scaffold via `create-jazz --hosting hosted`.
 
-| Variable                      | When       | Purpose                                                             |
-| ----------------------------- | ---------- | ------------------------------------------------------------------- |
-| `BETTER_AUTH_SECRET`          | always     | BetterAuth session signing. `lib/auth.ts` throws loudly if missing. |
-| `NEXT_PUBLIC_JAZZ_APP_ID`     | cloud only | Provisioned app ID. Unset in self-hosted dev — plugin injects it.   |
-| `NEXT_PUBLIC_JAZZ_SERVER_URL` | cloud only | Cloud sync URL (e.g. `https://v2.sync.jazz.tools`).                 |
-| `JAZZ_ADMIN_SECRET`           | cloud only | Admin credential for schema pushes to the cloud.                    |
-| `BACKEND_SECRET`              | cloud only | Backend signing credential.                                         |
+| Variable                      | When       | Purpose                                                                       |
+| ----------------------------- | ---------- | ----------------------------------------------------------------------------- |
+| `BETTER_AUTH_SECRET`          | always     | BetterAuth session signing. `lib/auth.ts` throws loudly if missing.           |
+| `NEXT_PUBLIC_JAZZ_APP_ID`     | cloud only | Provisioned app ID. Unset in self-hosted dev — plugin injects it.             |
+| `NEXT_PUBLIC_JAZZ_SERVER_URL` | cloud only | Cloud sync URL (e.g. `https://v2.sync.jazz.tools`).                           |
+| `JAZZ_ADMIN_SECRET`           | cloud only | Admin credential for schema pushes to the cloud.                              |
+| `BACKEND_SECRET`              | always     | Persistent identity for the backend's Jazz account. Seeded by the scaffolder. |
 
-Generate a dev `BETTER_AUTH_SECRET` with `openssl rand -base64 32`. In
-self-hosted mode (no cloud env vars), the `withJazz` plugin spawns a local
-Jazz dev server and supplies its own credentials.
+In self-hosted mode (no cloud env vars), the `withJazz` plugin spawns a
+local Jazz dev server and supplies its own credentials.
 
 ## Deploying to production
 

--- a/starters/next-betterauth/lib/auth-jazz-context.ts
+++ b/starters/next-betterauth/lib/auth-jazz-context.ts
@@ -1,0 +1,35 @@
+import type { JazzContext } from "jazz-tools/backend";
+
+// Workaround to resolve NAPI modules correctly in the monorepo. Real-world
+// apps can just `import { createJazzContext } from "jazz-tools/backend"`.
+import { createRequire as createRequireFromModule } from "node:module";
+const createRequire =
+  process.getBuiltinModule?.("module")?.createRequire ?? createRequireFromModule;
+const nodeRequire = createRequire(import.meta.url);
+const { createJazzContext } = nodeRequire(
+  "jazz-tools/backend",
+) as typeof import("jazz-tools/backend");
+
+declare global {
+  var __nextBetterAuthJazzContext: JazzContext | undefined;
+}
+
+function create() {
+  return createJazzContext({
+    appId: process.env.NEXT_PUBLIC_JAZZ_APP_ID!,
+    driver: { type: "memory" },
+    serverUrl: process.env.NEXT_PUBLIC_JAZZ_SERVER_URL!,
+    env: process.env.NODE_ENV === "production" ? "prod" : "dev",
+    userBranch: "main",
+    backendSecret: process.env.BACKEND_SECRET!,
+    tier: "global",
+  });
+}
+
+export function authJazzContext(): JazzContext {
+  const existing = globalThis.__nextBetterAuthJazzContext;
+  if (existing) return existing;
+  const ctx = create();
+  globalThis.__nextBetterAuthJazzContext = ctx;
+  return ctx;
+}

--- a/starters/next-betterauth/lib/auth.ts
+++ b/starters/next-betterauth/lib/auth.ts
@@ -1,7 +1,9 @@
 import { betterAuth } from "better-auth";
-import { memoryAdapter, type MemoryDB } from "better-auth/adapters/memory";
 import { nextCookies } from "better-auth/next-js";
 import { bearer, jwt } from "better-auth/plugins";
+import { jazzAdapter } from "jazz-tools/better-auth-adapter";
+import { app } from "../schema";
+import { authJazzContext } from "./auth-jazz-context";
 
 const APP_ORIGIN = process.env.APP_ORIGIN ?? "http://localhost:3000";
 
@@ -13,27 +15,13 @@ if (!process.env.BETTER_AUTH_SECRET) {
 
 const BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET;
 
-// TODO: Replace with a persistent adapter before shipping.
-//
-// Pinning to globalThis is a dev-only workaround: Next.js + Turbopack
-// evaluates API route modules and server component modules in separate
-// module graphs, so a plain module-local `const` would give each one
-// its own `MemoryDB` — sign-up would write to the API route's copy and
-// the server component's session check would look in an empty one and
-// return null. A real database adapter makes both concerns disappear.
-const globalForAuth = globalThis as unknown as { __authMemoryDb?: MemoryDB };
-const authMemoryDb: MemoryDB = (globalForAuth.__authMemoryDb ??= {
-  account: [],
-  jwks: [],
-  session: [],
-  user: [],
-  verification: [],
-});
-
 export const auth = betterAuth({
   baseURL: APP_ORIGIN,
   secret: BETTER_AUTH_SECRET,
-  database: memoryAdapter(authMemoryDb),
+  database: jazzAdapter({
+    db: () => authJazzContext().asBackend(app),
+    schema: app.wasmSchema,
+  }),
   trustedOrigins: [APP_ORIGIN],
   emailAndPassword: {
     enabled: true,

--- a/starters/next-betterauth/package.json
+++ b/starters/next-betterauth/package.json
@@ -5,8 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "next dev",
-    "prebuild": "node scripts/ensure-env.js",
     "build": "next build",
+    "postinstall": "node scripts/ensure-env.js",
     "start": "next start",
     "test:e2e": "playwright test"
   },

--- a/starters/next-betterauth/schema-better-auth/schema.ts
+++ b/starters/next-betterauth/schema-better-auth/schema.ts
@@ -1,0 +1,52 @@
+import { schema as s } from "jazz-tools";
+
+export const schema = {
+  better_auth_user: s.table({
+    name: s.string(),
+    email: s.string(),
+    emailVerified: s.boolean(),
+    image: s.string().optional(),
+    createdAt: s.timestamp(),
+    updatedAt: s.timestamp(),
+  }),
+
+  better_auth_session: s.table({
+    expiresAt: s.timestamp(),
+    token: s.string(),
+    createdAt: s.timestamp(),
+    updatedAt: s.timestamp(),
+    ipAddress: s.string().optional(),
+    userAgent: s.string().optional(),
+    userId: s.ref("better_auth_user"),
+  }),
+
+  better_auth_account: s.table({
+    accountId: s.string(),
+    providerId: s.string(),
+    userId: s.ref("better_auth_user"),
+    accessToken: s.string().optional(),
+    refreshToken: s.string().optional(),
+    idToken: s.string().optional(),
+    accessTokenExpiresAt: s.timestamp().optional(),
+    refreshTokenExpiresAt: s.timestamp().optional(),
+    scope: s.string().optional(),
+    password: s.string().optional(),
+    createdAt: s.timestamp(),
+    updatedAt: s.timestamp(),
+  }),
+
+  better_auth_verification: s.table({
+    identifier: s.string(),
+    value: s.string(),
+    expiresAt: s.timestamp(),
+    createdAt: s.timestamp(),
+    updatedAt: s.timestamp(),
+  }),
+
+  better_auth_jwks: s.table({
+    publicKey: s.string(),
+    privateKey: s.string(),
+    createdAt: s.timestamp(),
+    expiresAt: s.timestamp().optional(),
+  }),
+};

--- a/starters/next-betterauth/schema-better-auth/schema.ts
+++ b/starters/next-betterauth/schema-better-auth/schema.ts
@@ -1,3 +1,5 @@
+// This file is required to ensure Better Auth tables exist in your database
+
 import { schema as s } from "jazz-tools";
 
 export const schema = {

--- a/starters/next-betterauth/schema.ts
+++ b/starters/next-betterauth/schema.ts
@@ -1,6 +1,8 @@
 import { schema as s } from "jazz-tools";
+import { schema as betterAuthSchema } from "./schema-better-auth/schema";
 
 const schema = {
+  ...betterAuthSchema,
   todos: s.table({
     title: s.string(),
     done: s.boolean(),

--- a/starters/next-betterauth/scripts/ensure-env.js
+++ b/starters/next-betterauth/scripts/ensure-env.js
@@ -1,4 +1,4 @@
-import { existsSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { randomBytes } from "node:crypto";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -6,8 +6,22 @@ import { fileURLToPath } from "node:url";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const envPath = join(__dirname, "..", ".env");
 
-if (!existsSync(envPath)) {
-  const secret = randomBytes(32).toString("hex");
-  writeFileSync(envPath, `BETTER_AUTH_SECRET=${secret}\nAPP_ORIGIN=http://localhost:3000\n`);
-  console.log("No .env detected. Generated .env with a random BETTER_AUTH_SECRET");
+const required = [
+  { key: "BETTER_AUTH_SECRET", value: () => randomBytes(32).toString("hex") },
+  { key: "APP_ORIGIN", value: () => "http://localhost:3000" },
+  { key: "BACKEND_SECRET", value: () => randomBytes(32).toString("hex") },
+];
+
+const existing = existsSync(envPath) ? readFileSync(envPath, "utf8") : "";
+const missing = required.filter(({ key }) => !new RegExp(`^${key}=`, "m").test(existing));
+
+if (missing.length === 0) {
+  process.exit(0);
 }
+
+const appended = missing.map(({ key, value }) => `${key}=${value()}`).join("\n") + "\n";
+writeFileSync(
+  envPath,
+  existing.length && !existing.endsWith("\n") ? existing + "\n" + appended : existing + appended,
+);
+console.log(`ensure-env: added ${missing.map((m) => m.key).join(", ")} to .env`);

--- a/starters/next-hybrid/README.md
+++ b/starters/next-hybrid/README.md
@@ -24,8 +24,9 @@ pnpm dev
 ```
 
 Open [http://localhost:3000](http://localhost:3000) and you'll land on the
-app. Set `BETTER_AUTH_SECRET` in `.env` before running
-(`openssl rand -base64 32` or scaffold via `create-jazz`).
+app. `pnpm install` seeds `.env` with a random `BETTER_AUTH_SECRET` and
+`BACKEND_SECRET`; the `withJazz` plugin spawns a local Jazz dev server
+automatically.
 
 ## Architecture
 
@@ -96,20 +97,20 @@ session on every row and the permission policy scopes reads/writes to it.
 
 ## Environment variables
 
-Scaffold via `create-jazz` to have `.env` populated automatically; otherwise
-write the values below by hand.
+`pnpm install` runs `scripts/ensure-env.js`, which seeds any missing keys
+in `.env` with random values. Override by setting values manually before
+install, or for cloud mode scaffold via `create-jazz --hosting hosted`.
 
-| Variable                      | When       | Purpose                                                           |
-| ----------------------------- | ---------- | ----------------------------------------------------------------- |
-| `BETTER_AUTH_SECRET`          | always     | BetterAuth session signing. `lib/auth.ts` throws if missing.      |
-| `NEXT_PUBLIC_JAZZ_APP_ID`     | cloud only | Provisioned app ID. Unset in self-hosted dev — plugin injects it. |
-| `NEXT_PUBLIC_JAZZ_SERVER_URL` | cloud only | Cloud sync URL (e.g. `https://v2.sync.jazz.tools`).               |
-| `JAZZ_ADMIN_SECRET`           | cloud only | Admin credential for schema pushes to the cloud.                  |
-| `BACKEND_SECRET`              | cloud only | Backend signing credential.                                       |
+| Variable                      | When       | Purpose                                                                       |
+| ----------------------------- | ---------- | ----------------------------------------------------------------------------- |
+| `BETTER_AUTH_SECRET`          | always     | BetterAuth session signing. `lib/auth.ts` throws if missing.                  |
+| `NEXT_PUBLIC_JAZZ_APP_ID`     | cloud only | Provisioned app ID. Unset in self-hosted dev — plugin injects it.             |
+| `NEXT_PUBLIC_JAZZ_SERVER_URL` | cloud only | Cloud sync URL (e.g. `https://v2.sync.jazz.tools`).                           |
+| `JAZZ_ADMIN_SECRET`           | cloud only | Admin credential for schema pushes to the cloud.                              |
+| `BACKEND_SECRET`              | always     | Persistent identity for the backend's Jazz account. Seeded by the scaffolder. |
 
-Generate a dev `BETTER_AUTH_SECRET` with `openssl rand -base64 32`. In
-self-hosted mode (no cloud env vars), the `withJazz` plugin spawns a local
-Jazz dev server and supplies its own credentials.
+In self-hosted mode (no cloud env vars), the `withJazz` plugin spawns a
+local Jazz dev server and supplies its own credentials.
 
 ## Deploying to production
 

--- a/starters/next-hybrid/lib/auth-jazz-context.ts
+++ b/starters/next-hybrid/lib/auth-jazz-context.ts
@@ -1,0 +1,35 @@
+import type { JazzContext } from "jazz-tools/backend";
+
+// Workaround to resolve NAPI modules correctly in the monorepo. Real-world
+// apps can just `import { createJazzContext } from "jazz-tools/backend"`.
+import { createRequire as createRequireFromModule } from "node:module";
+const createRequire =
+  process.getBuiltinModule?.("module")?.createRequire ?? createRequireFromModule;
+const nodeRequire = createRequire(import.meta.url);
+const { createJazzContext } = nodeRequire(
+  "jazz-tools/backend",
+) as typeof import("jazz-tools/backend");
+
+declare global {
+  var __nextHybridAuthJazzContext: JazzContext | undefined;
+}
+
+function create() {
+  return createJazzContext({
+    appId: process.env.NEXT_PUBLIC_JAZZ_APP_ID!,
+    driver: { type: "memory" },
+    serverUrl: process.env.NEXT_PUBLIC_JAZZ_SERVER_URL!,
+    env: process.env.NODE_ENV === "production" ? "prod" : "dev",
+    userBranch: "main",
+    backendSecret: process.env.BACKEND_SECRET!,
+    tier: "global",
+  });
+}
+
+export function authJazzContext(): JazzContext {
+  const existing = globalThis.__nextHybridAuthJazzContext;
+  if (existing) return existing;
+  const ctx = create();
+  globalThis.__nextHybridAuthJazzContext = ctx;
+  return ctx;
+}

--- a/starters/next-hybrid/lib/auth.ts
+++ b/starters/next-hybrid/lib/auth.ts
@@ -1,8 +1,10 @@
 import { betterAuth } from "better-auth";
-import { memoryAdapter, type MemoryDB } from "better-auth/adapters/memory";
+import { APIError, createAuthMiddleware } from "better-auth/api";
 import { nextCookies } from "better-auth/next-js";
 import { bearer, jwt } from "better-auth/plugins";
-import { APIError, createAuthMiddleware } from "better-auth/api";
+import { jazzAdapter } from "jazz-tools/better-auth-adapter";
+import { app } from "../schema";
+import { authJazzContext } from "./auth-jazz-context";
 
 const APP_ORIGIN = process.env.APP_ORIGIN ?? "http://localhost:3000";
 
@@ -14,32 +16,17 @@ if (!process.env.BETTER_AUTH_SECRET) {
 
 const BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET;
 
-// TODO: Replace with a persistent adapter before shipping.
-//
-// Pinning to globalThis is a dev-only workaround: Next.js + Turbopack
-// evaluates API route modules and server component modules in separate
-// module graphs, so a plain module-local `const` would give each one
-// its own `MemoryDB` — sign-up would write to the API route's copy and
-// the server component's session check would look in an empty one and
-// return null. A real database adapter makes both concerns disappear.
-const globalForAuth = globalThis as unknown as { __authMemoryDb?: MemoryDB };
-const authMemoryDb: MemoryDB = (globalForAuth.__authMemoryDb ??= {
-  account: [],
-  jwks: [],
-  session: [],
-  user: [],
-  verification: [],
-});
-
 export const auth = betterAuth({
   baseURL: APP_ORIGIN,
   secret: BETTER_AUTH_SECRET,
-  database: memoryAdapter(authMemoryDb),
+  database: jazzAdapter({
+    db: () => authJazzContext().asBackend(app),
+    schema: app.wasmSchema,
+  }),
   trustedOrigins: [APP_ORIGIN],
   emailAndPassword: {
     enabled: true,
     autoSignIn: true,
-    // Industry-standard minimum; tune to whatever your product requires.
     minPasswordLength: 8,
     requireEmailVerification: false,
   },
@@ -72,10 +59,9 @@ export const auth = betterAuth({
   databaseHooks: {
     user: {
       create: {
-        // Parameter types are inferred from BetterAuth's config types; no
-        // explicit annotations are needed. `context` is BetterAuth's
-        // GenericEndpointContext; we read `body.provedUserId` which was
-        // added by the `hooks.before` middleware above.
+        // Carry `provedUserId` (stashed by the `hooks.before` middleware) into
+        // BetterAuth as the row id, so the freshly-signed-up user inherits the
+        // Jazz principal that their local-first data is already scoped to.
         before: async (user, context) => {
           const provedUserId = (context?.body as { provedUserId?: string } | undefined)
             ?.provedUserId;

--- a/starters/next-hybrid/package.json
+++ b/starters/next-hybrid/package.json
@@ -5,8 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "next dev",
-    "prebuild": "node scripts/ensure-env.js",
     "build": "next build",
+    "postinstall": "node scripts/ensure-env.js",
     "start": "next start",
     "test:e2e": "playwright test"
   },

--- a/starters/next-hybrid/schema-better-auth/schema.ts
+++ b/starters/next-hybrid/schema-better-auth/schema.ts
@@ -1,0 +1,52 @@
+import { schema as s } from "jazz-tools";
+
+export const schema = {
+  better_auth_user: s.table({
+    name: s.string(),
+    email: s.string(),
+    emailVerified: s.boolean(),
+    image: s.string().optional(),
+    createdAt: s.timestamp(),
+    updatedAt: s.timestamp(),
+  }),
+
+  better_auth_session: s.table({
+    expiresAt: s.timestamp(),
+    token: s.string(),
+    createdAt: s.timestamp(),
+    updatedAt: s.timestamp(),
+    ipAddress: s.string().optional(),
+    userAgent: s.string().optional(),
+    userId: s.ref("better_auth_user"),
+  }),
+
+  better_auth_account: s.table({
+    accountId: s.string(),
+    providerId: s.string(),
+    userId: s.ref("better_auth_user"),
+    accessToken: s.string().optional(),
+    refreshToken: s.string().optional(),
+    idToken: s.string().optional(),
+    accessTokenExpiresAt: s.timestamp().optional(),
+    refreshTokenExpiresAt: s.timestamp().optional(),
+    scope: s.string().optional(),
+    password: s.string().optional(),
+    createdAt: s.timestamp(),
+    updatedAt: s.timestamp(),
+  }),
+
+  better_auth_verification: s.table({
+    identifier: s.string(),
+    value: s.string(),
+    expiresAt: s.timestamp(),
+    createdAt: s.timestamp(),
+    updatedAt: s.timestamp(),
+  }),
+
+  better_auth_jwks: s.table({
+    publicKey: s.string(),
+    privateKey: s.string(),
+    createdAt: s.timestamp(),
+    expiresAt: s.timestamp().optional(),
+  }),
+};

--- a/starters/next-hybrid/schema-better-auth/schema.ts
+++ b/starters/next-hybrid/schema-better-auth/schema.ts
@@ -1,3 +1,5 @@
+// This file is required to ensure Better Auth tables exist in your database
+
 import { schema as s } from "jazz-tools";
 
 export const schema = {

--- a/starters/next-hybrid/schema.ts
+++ b/starters/next-hybrid/schema.ts
@@ -1,6 +1,8 @@
 import { schema as s } from "jazz-tools";
+import { schema as betterAuthSchema } from "./schema-better-auth/schema";
 
 const schema = {
+  ...betterAuthSchema,
   todos: s.table({
     title: s.string(),
     done: s.boolean(),

--- a/starters/next-hybrid/scripts/ensure-env.js
+++ b/starters/next-hybrid/scripts/ensure-env.js
@@ -1,4 +1,4 @@
-import { existsSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { randomBytes } from "node:crypto";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -6,8 +6,22 @@ import { fileURLToPath } from "node:url";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const envPath = join(__dirname, "..", ".env");
 
-if (!existsSync(envPath)) {
-  const secret = randomBytes(32).toString("hex");
-  writeFileSync(envPath, `BETTER_AUTH_SECRET=${secret}\nAPP_ORIGIN=http://localhost:3000\n`);
-  console.log("No .env detected. Generated .env with a random BETTER_AUTH_SECRET");
+const required = [
+  { key: "BETTER_AUTH_SECRET", value: () => randomBytes(32).toString("hex") },
+  { key: "APP_ORIGIN", value: () => "http://localhost:3000" },
+  { key: "BACKEND_SECRET", value: () => randomBytes(32).toString("hex") },
+];
+
+const existing = existsSync(envPath) ? readFileSync(envPath, "utf8") : "";
+const missing = required.filter(({ key }) => !new RegExp(`^${key}=`, "m").test(existing));
+
+if (missing.length === 0) {
+  process.exit(0);
 }
+
+const appended = missing.map(({ key, value }) => `${key}=${value()}`).join("\n") + "\n";
+writeFileSync(
+  envPath,
+  existing.length && !existing.endsWith("\n") ? existing + "\n" + appended : existing + appended,
+);
+console.log(`ensure-env: added ${missing.map((m) => m.key).join(", ")} to .env`);

--- a/starters/react-betterauth/README.md
+++ b/starters/react-betterauth/README.md
@@ -26,10 +26,10 @@ pnpm dev
 ```
 
 Open [http://localhost:5173](http://localhost:5173), create an account, and
-you'll land on the todo list persisted via Jazz. Set `BETTER_AUTH_SECRET`
-in `.env` before running (`openssl rand -base64 32` or scaffold via
-`create-jazz`). The Vite dev command launches Hono on port 3001 and waits
-for its `/health` endpoint before starting Vite.
+you'll land on the todo list persisted via Jazz. `pnpm install` seeds
+`.env` with a random `BETTER_AUTH_SECRET` and `BACKEND_SECRET`. The Vite
+dev command launches Hono on port 3001 and waits for its `/health`
+endpoint before starting Vite.
 
 ## Architecture
 
@@ -97,21 +97,21 @@ random port and writes `VITE_JAZZ_APP_ID` / `VITE_JAZZ_SERVER_URL` to
 
 ## Environment variables
 
-Scaffold via `create-jazz` to have `.env` populated automatically; otherwise
-write the values below by hand.
+`pnpm install` runs `scripts/ensure-env.js`, which seeds any missing keys
+in `.env` with random values. Override by setting values manually before
+install, or for cloud mode scaffold via `create-jazz --hosting hosted`.
 
-| Variable               | When       | Purpose                                                           |
-| ---------------------- | ---------- | ----------------------------------------------------------------- |
-| `BETTER_AUTH_SECRET`   | always     | BetterAuth session signing. `server/auth.ts` throws if missing.   |
-| `PORT`                 | optional   | Hono server port (default `3001`).                                |
-| `VITE_JAZZ_APP_ID`     | cloud only | Provisioned app ID. Unset in self-hosted dev — plugin injects it. |
-| `VITE_JAZZ_SERVER_URL` | cloud only | Cloud sync URL (e.g. `https://v2.sync.jazz.tools`).               |
-| `JAZZ_ADMIN_SECRET`    | cloud only | Admin credential for schema pushes to the cloud.                  |
-| `BACKEND_SECRET`       | cloud only | Backend signing credential.                                       |
+| Variable               | When       | Purpose                                                                       |
+| ---------------------- | ---------- | ----------------------------------------------------------------------------- |
+| `BETTER_AUTH_SECRET`   | always     | BetterAuth session signing. `server/auth.ts` throws if missing.               |
+| `PORT`                 | optional   | Hono server port (default `3001`).                                            |
+| `VITE_JAZZ_APP_ID`     | cloud only | Provisioned app ID. Unset in self-hosted dev — plugin injects it.             |
+| `VITE_JAZZ_SERVER_URL` | cloud only | Cloud sync URL (e.g. `https://v2.sync.jazz.tools`).                           |
+| `JAZZ_ADMIN_SECRET`    | cloud only | Admin credential for schema pushes to the cloud.                              |
+| `BACKEND_SECRET`       | always     | Persistent identity for the backend's Jazz account. Seeded by the scaffolder. |
 
-Generate a dev `BETTER_AUTH_SECRET` with `openssl rand -base64 32`. In
-self-hosted mode (no cloud env vars), the `jazzPlugin` plugin spawns a local
-Jazz dev server and supplies its own credentials.
+In self-hosted mode (no cloud env vars), the `jazzPlugin` plugin spawns a
+local Jazz dev server and supplies its own credentials.
 
 ## Deploying to production
 

--- a/starters/react-betterauth/package.json
+++ b/starters/react-betterauth/package.json
@@ -4,11 +4,11 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "node scripts/ensure-env.js && concurrently --kill-others-on-fail --names vite,server \"pnpm dev:vite\" \"pnpm dev:server\"",
+    "dev": "concurrently --kill-others-on-fail --names vite,server \"pnpm dev:vite\" \"pnpm dev:server\"",
     "dev:vite": "vite",
     "dev:server": "wait-on --timeout 30000 tcp:5173 && tsx watch --env-file=.env server/index.ts",
-    "prebuild": "node scripts/ensure-env.js",
     "build": "vite build && tsc -p tsconfig.server.json",
+    "postinstall": "node scripts/ensure-env.js",
     "start": "node server-dist/index.js",
     "test:e2e": "playwright test"
   },

--- a/starters/react-betterauth/package.json
+++ b/starters/react-betterauth/package.json
@@ -4,9 +4,9 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "concurrently --kill-others-on-fail --names server,vite \"pnpm dev:server\" \"pnpm dev:vite\"",
-    "dev:vite": "wait-on --timeout 20000 http-get://127.0.0.1:3001/health && vite",
-    "dev:server": "tsx watch --env-file=.env server/index.ts",
+    "dev": "node scripts/ensure-env.js && concurrently --kill-others-on-fail --names vite,server \"pnpm dev:vite\" \"pnpm dev:server\"",
+    "dev:vite": "vite",
+    "dev:server": "wait-on --timeout 30000 tcp:5173 && tsx watch --env-file=.env server/index.ts",
     "prebuild": "node scripts/ensure-env.js",
     "build": "vite build && tsc -p tsconfig.server.json",
     "start": "node server-dist/index.js",

--- a/starters/react-betterauth/schema-better-auth/schema.ts
+++ b/starters/react-betterauth/schema-better-auth/schema.ts
@@ -1,0 +1,52 @@
+import { schema as s } from "jazz-tools";
+
+export const schema = {
+  better_auth_user: s.table({
+    name: s.string(),
+    email: s.string(),
+    emailVerified: s.boolean(),
+    image: s.string().optional(),
+    createdAt: s.timestamp(),
+    updatedAt: s.timestamp(),
+  }),
+
+  better_auth_session: s.table({
+    expiresAt: s.timestamp(),
+    token: s.string(),
+    createdAt: s.timestamp(),
+    updatedAt: s.timestamp(),
+    ipAddress: s.string().optional(),
+    userAgent: s.string().optional(),
+    userId: s.ref("better_auth_user"),
+  }),
+
+  better_auth_account: s.table({
+    accountId: s.string(),
+    providerId: s.string(),
+    userId: s.ref("better_auth_user"),
+    accessToken: s.string().optional(),
+    refreshToken: s.string().optional(),
+    idToken: s.string().optional(),
+    accessTokenExpiresAt: s.timestamp().optional(),
+    refreshTokenExpiresAt: s.timestamp().optional(),
+    scope: s.string().optional(),
+    password: s.string().optional(),
+    createdAt: s.timestamp(),
+    updatedAt: s.timestamp(),
+  }),
+
+  better_auth_verification: s.table({
+    identifier: s.string(),
+    value: s.string(),
+    expiresAt: s.timestamp(),
+    createdAt: s.timestamp(),
+    updatedAt: s.timestamp(),
+  }),
+
+  better_auth_jwks: s.table({
+    publicKey: s.string(),
+    privateKey: s.string(),
+    createdAt: s.timestamp(),
+    expiresAt: s.timestamp().optional(),
+  }),
+};

--- a/starters/react-betterauth/schema-better-auth/schema.ts
+++ b/starters/react-betterauth/schema-better-auth/schema.ts
@@ -1,3 +1,5 @@
+// This file is required to ensure Better Auth tables exist in your database
+
 import { schema as s } from "jazz-tools";
 
 export const schema = {

--- a/starters/react-betterauth/schema.ts
+++ b/starters/react-betterauth/schema.ts
@@ -1,6 +1,8 @@
 import { schema as s } from "jazz-tools";
+import { schema as betterAuthSchema } from "./schema-better-auth/schema";
 
 const schema = {
+  ...betterAuthSchema,
   todos: s.table({
     title: s.string(),
     done: s.boolean(),

--- a/starters/react-betterauth/scripts/ensure-env.js
+++ b/starters/react-betterauth/scripts/ensure-env.js
@@ -1,4 +1,4 @@
-import { existsSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { randomBytes } from "node:crypto";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -6,8 +6,25 @@ import { fileURLToPath } from "node:url";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const envPath = join(__dirname, "..", ".env");
 
-if (!existsSync(envPath)) {
-  const secret = randomBytes(32).toString("hex");
-  writeFileSync(envPath, `BETTER_AUTH_SECRET=${secret}\nAPP_ORIGIN=http://localhost:3001\n`);
-  console.log("No .env detected. Generated .env with a random BETTER_AUTH_SECRET");
+const required = [
+  { key: "BETTER_AUTH_SECRET", value: () => randomBytes(32).toString("hex") },
+  { key: "APP_ORIGIN", value: () => "http://localhost:3001" },
+  // Shared secret between Vite's Jazz plugin (which spins up the local Jazz
+  // dev server) and the Hono backend (which connects to it as a client).
+  // Pre-generating it in .env means both processes read the same value.
+  { key: "BACKEND_SECRET", value: () => randomBytes(32).toString("hex") },
+];
+
+const existing = existsSync(envPath) ? readFileSync(envPath, "utf8") : "";
+const missing = required.filter(({ key }) => !new RegExp(`^${key}=`, "m").test(existing));
+
+if (missing.length === 0) {
+  process.exit(0);
 }
+
+const appended = missing.map(({ key, value }) => `${key}=${value()}`).join("\n") + "\n";
+writeFileSync(
+  envPath,
+  existing.length && !existing.endsWith("\n") ? existing + "\n" + appended : existing + appended,
+);
+console.log(`ensure-env: added ${missing.map((m) => m.key).join(", ")} to .env`);

--- a/starters/react-betterauth/server/auth-jazz-context.ts
+++ b/starters/react-betterauth/server/auth-jazz-context.ts
@@ -1,0 +1,39 @@
+import type { JazzContext } from "jazz-tools/backend";
+
+// Workaround to resolve NAPI modules correctly in the monorepo. Real-world
+// apps can just `import { createJazzContext } from "jazz-tools/backend"`.
+import { createRequire as createRequireFromModule } from "node:module";
+const createRequire =
+  process.getBuiltinModule?.("module")?.createRequire ?? createRequireFromModule;
+const nodeRequire = createRequire(import.meta.url);
+const { createJazzContext } = nodeRequire(
+  "jazz-tools/backend",
+) as typeof import("jazz-tools/backend");
+
+declare global {
+  var __reactBetterAuthJazzContext: JazzContext | undefined;
+}
+
+// The Jazz dev server is pinned to port 4002 in vite.config.ts so the
+// standalone backend can reach it without coordinating through .env.
+const JAZZ_SERVER_URL = process.env.VITE_JAZZ_SERVER_URL ?? "http://127.0.0.1:4002";
+
+function create() {
+  return createJazzContext({
+    appId: process.env.VITE_JAZZ_APP_ID!,
+    driver: { type: "memory" },
+    serverUrl: JAZZ_SERVER_URL,
+    env: process.env.NODE_ENV === "production" ? "prod" : "dev",
+    userBranch: "main",
+    backendSecret: process.env.BACKEND_SECRET!,
+    tier: "global",
+  });
+}
+
+export function authJazzContext(): JazzContext {
+  const existing = globalThis.__reactBetterAuthJazzContext;
+  if (existing) return existing;
+  const ctx = create();
+  globalThis.__reactBetterAuthJazzContext = ctx;
+  return ctx;
+}

--- a/starters/react-betterauth/server/auth.ts
+++ b/starters/react-betterauth/server/auth.ts
@@ -1,6 +1,8 @@
 import { betterAuth } from "better-auth";
-import { memoryAdapter, type MemoryDB } from "better-auth/adapters/memory";
 import { bearer, jwt } from "better-auth/plugins";
+import { jazzAdapter } from "jazz-tools/better-auth-adapter";
+import { app } from "../schema.js";
+import { authJazzContext } from "./auth-jazz-context.js";
 
 const APP_ORIGIN = process.env.APP_ORIGIN ?? "http://localhost:3001";
 
@@ -12,19 +14,13 @@ if (!process.env.BETTER_AUTH_SECRET) {
 
 const BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET;
 
-// TODO: Replace with a persistent adapter before shipping.
-const authMemoryDb: MemoryDB = {
-  account: [],
-  jwks: [],
-  session: [],
-  user: [],
-  verification: [],
-};
-
 export const auth = betterAuth({
   baseURL: APP_ORIGIN,
   secret: BETTER_AUTH_SECRET,
-  database: memoryAdapter(authMemoryDb),
+  database: jazzAdapter({
+    db: () => authJazzContext().asBackend(app),
+    schema: app.wasmSchema,
+  }),
   trustedOrigins: (request) => {
     const origin = request?.headers.get("origin");
     if (origin && new URL(origin).hostname === "localhost") return [origin];
@@ -46,9 +42,6 @@ export const auth = betterAuth({
         expirationTime: "1h",
         issuer: APP_ORIGIN,
         getSubject: ({ user }: { user: { id: string } }) => user.id,
-        definePayload: ({ user }: { user: { id: string } }) => ({
-          jazz_principal_id: user.id,
-        }),
       },
     }),
   ],

--- a/starters/react-betterauth/vite.config.ts
+++ b/starters/react-betterauth/vite.config.ts
@@ -2,8 +2,20 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import { jazzPlugin } from "jazz-tools/dev/vite";
 
+// Pin the Jazz dev server to a fixed port so the standalone Hono backend
+// (started by tsx) knows where to reach it without coordinating via .env.
+const JAZZ_SERVER_PORT = 4002;
+
 export default defineConfig({
-  plugins: [react(), jazzPlugin({ server: { jwksUrl: "http://localhost:3001/api/auth/jwks" } })],
+  plugins: [
+    react(),
+    jazzPlugin({
+      server: {
+        port: JAZZ_SERVER_PORT,
+        jwksUrl: "http://localhost:3001/api/auth/jwks",
+      },
+    }),
+  ],
   worker: { format: "es" },
   server: {
     proxy: {

--- a/starters/react-hybrid/README.md
+++ b/starters/react-hybrid/README.md
@@ -30,8 +30,8 @@ pnpm dev
 Open [http://localhost:5173](http://localhost:5173). The app loads immediately
 with a local identity — data is persisted locally. Sign up to bind that identity
 to an email/password account so it survives across devices or browsers.
-Set `BETTER_AUTH_SECRET` in `.env` before running (`openssl rand -base64 32`
-or scaffold via `create-jazz`).
+`pnpm install` seeds `.env` with a random `BETTER_AUTH_SECRET` and
+`BACKEND_SECRET`.
 
 ## Architecture
 
@@ -93,21 +93,21 @@ session on every row and the permission policy scopes reads/writes to it.
 
 ## Environment variables
 
-Scaffold via `create-jazz` to have `.env` populated automatically; otherwise
-write the values below by hand.
+`pnpm install` runs `scripts/ensure-env.js`, which seeds any missing keys
+in `.env` with random values. Override by setting values manually before
+install, or for cloud mode scaffold via `create-jazz --hosting hosted`.
 
-| Variable               | When       | Purpose                                                           |
-| ---------------------- | ---------- | ----------------------------------------------------------------- |
-| `BETTER_AUTH_SECRET`   | always     | BetterAuth session signing. `server/auth.ts` throws if missing.   |
-| `PORT`                 | optional   | Hono server port (default `3001`).                                |
-| `VITE_JAZZ_APP_ID`     | cloud only | Provisioned app ID. Unset in self-hosted dev — plugin injects it. |
-| `VITE_JAZZ_SERVER_URL` | cloud only | Cloud sync URL (e.g. `https://v2.sync.jazz.tools`).               |
-| `JAZZ_ADMIN_SECRET`    | cloud only | Admin credential for schema pushes to the cloud.                  |
-| `BACKEND_SECRET`       | cloud only | Backend signing credential.                                       |
+| Variable               | When       | Purpose                                                                       |
+| ---------------------- | ---------- | ----------------------------------------------------------------------------- |
+| `BETTER_AUTH_SECRET`   | always     | BetterAuth session signing. `server/auth.ts` throws if missing.               |
+| `PORT`                 | optional   | Hono server port (default `3001`).                                            |
+| `VITE_JAZZ_APP_ID`     | cloud only | Provisioned app ID. Unset in self-hosted dev — plugin injects it.             |
+| `VITE_JAZZ_SERVER_URL` | cloud only | Cloud sync URL (e.g. `https://v2.sync.jazz.tools`).                           |
+| `JAZZ_ADMIN_SECRET`    | cloud only | Admin credential for schema pushes to the cloud.                              |
+| `BACKEND_SECRET`       | always     | Persistent identity for the backend's Jazz account. Seeded by the scaffolder. |
 
-Generate a dev `BETTER_AUTH_SECRET` with `openssl rand -base64 32`. In
-self-hosted mode (no cloud env vars), the `jazzPlugin` plugin spawns a local
-Jazz dev server and supplies its own credentials.
+In self-hosted mode (no cloud env vars), the `jazzPlugin` plugin spawns a
+local Jazz dev server and supplies its own credentials.
 
 ## Deploying to production
 

--- a/starters/react-hybrid/package.json
+++ b/starters/react-hybrid/package.json
@@ -4,11 +4,11 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "node scripts/ensure-env.js && concurrently --kill-others-on-fail --names vite,server \"pnpm dev:vite\" \"pnpm dev:server\"",
+    "dev": "concurrently --kill-others-on-fail --names vite,server \"pnpm dev:vite\" \"pnpm dev:server\"",
     "dev:vite": "vite",
     "dev:server": "wait-on --timeout 30000 tcp:5173 && tsx watch --env-file=.env server/index.ts",
-    "prebuild": "node scripts/ensure-env.js",
     "build": "vite build && tsc -p tsconfig.server.json",
+    "postinstall": "node scripts/ensure-env.js",
     "start": "node server-dist/index.js",
     "test:e2e": "playwright test"
   },

--- a/starters/react-hybrid/package.json
+++ b/starters/react-hybrid/package.json
@@ -4,9 +4,9 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "concurrently --kill-others-on-fail --names server,vite \"pnpm dev:server\" \"pnpm dev:vite\"",
-    "dev:vite": "wait-on --timeout 20000 http-get://127.0.0.1:3001/health && vite",
-    "dev:server": "tsx watch --env-file=.env server/index.ts",
+    "dev": "node scripts/ensure-env.js && concurrently --kill-others-on-fail --names vite,server \"pnpm dev:vite\" \"pnpm dev:server\"",
+    "dev:vite": "vite",
+    "dev:server": "wait-on --timeout 30000 tcp:5173 && tsx watch --env-file=.env server/index.ts",
     "prebuild": "node scripts/ensure-env.js",
     "build": "vite build && tsc -p tsconfig.server.json",
     "start": "node server-dist/index.js",

--- a/starters/react-hybrid/schema-better-auth/schema.ts
+++ b/starters/react-hybrid/schema-better-auth/schema.ts
@@ -1,0 +1,52 @@
+import { schema as s } from "jazz-tools";
+
+export const schema = {
+  better_auth_user: s.table({
+    name: s.string(),
+    email: s.string(),
+    emailVerified: s.boolean(),
+    image: s.string().optional(),
+    createdAt: s.timestamp(),
+    updatedAt: s.timestamp(),
+  }),
+
+  better_auth_session: s.table({
+    expiresAt: s.timestamp(),
+    token: s.string(),
+    createdAt: s.timestamp(),
+    updatedAt: s.timestamp(),
+    ipAddress: s.string().optional(),
+    userAgent: s.string().optional(),
+    userId: s.ref("better_auth_user"),
+  }),
+
+  better_auth_account: s.table({
+    accountId: s.string(),
+    providerId: s.string(),
+    userId: s.ref("better_auth_user"),
+    accessToken: s.string().optional(),
+    refreshToken: s.string().optional(),
+    idToken: s.string().optional(),
+    accessTokenExpiresAt: s.timestamp().optional(),
+    refreshTokenExpiresAt: s.timestamp().optional(),
+    scope: s.string().optional(),
+    password: s.string().optional(),
+    createdAt: s.timestamp(),
+    updatedAt: s.timestamp(),
+  }),
+
+  better_auth_verification: s.table({
+    identifier: s.string(),
+    value: s.string(),
+    expiresAt: s.timestamp(),
+    createdAt: s.timestamp(),
+    updatedAt: s.timestamp(),
+  }),
+
+  better_auth_jwks: s.table({
+    publicKey: s.string(),
+    privateKey: s.string(),
+    createdAt: s.timestamp(),
+    expiresAt: s.timestamp().optional(),
+  }),
+};

--- a/starters/react-hybrid/schema-better-auth/schema.ts
+++ b/starters/react-hybrid/schema-better-auth/schema.ts
@@ -1,3 +1,5 @@
+// This file is required to ensure Better Auth tables exist in your database
+
 import { schema as s } from "jazz-tools";
 
 export const schema = {

--- a/starters/react-hybrid/schema.ts
+++ b/starters/react-hybrid/schema.ts
@@ -1,6 +1,8 @@
 import { schema as s } from "jazz-tools";
+import { schema as betterAuthSchema } from "./schema-better-auth/schema";
 
 const schema = {
+  ...betterAuthSchema,
   todos: s.table({
     title: s.string(),
     done: s.boolean(),

--- a/starters/react-hybrid/scripts/ensure-env.js
+++ b/starters/react-hybrid/scripts/ensure-env.js
@@ -1,4 +1,4 @@
-import { existsSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { randomBytes } from "node:crypto";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -6,8 +6,25 @@ import { fileURLToPath } from "node:url";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const envPath = join(__dirname, "..", ".env");
 
-if (!existsSync(envPath)) {
-  const secret = randomBytes(32).toString("hex");
-  writeFileSync(envPath, `BETTER_AUTH_SECRET=${secret}\nAPP_ORIGIN=http://localhost:3001\n`);
-  console.log("No .env detected. Generated .env with a random BETTER_AUTH_SECRET");
+const required = [
+  { key: "BETTER_AUTH_SECRET", value: () => randomBytes(32).toString("hex") },
+  { key: "APP_ORIGIN", value: () => "http://localhost:3001" },
+  // Shared secret between Vite's Jazz plugin (which spins up the local Jazz
+  // dev server) and the Hono backend (which connects to it as a client).
+  // Pre-generating it in .env means both processes read the same value.
+  { key: "BACKEND_SECRET", value: () => randomBytes(32).toString("hex") },
+];
+
+const existing = existsSync(envPath) ? readFileSync(envPath, "utf8") : "";
+const missing = required.filter(({ key }) => !new RegExp(`^${key}=`, "m").test(existing));
+
+if (missing.length === 0) {
+  process.exit(0);
 }
+
+const appended = missing.map(({ key, value }) => `${key}=${value()}`).join("\n") + "\n";
+writeFileSync(
+  envPath,
+  existing.length && !existing.endsWith("\n") ? existing + "\n" + appended : existing + appended,
+);
+console.log(`ensure-env: added ${missing.map((m) => m.key).join(", ")} to .env`);

--- a/starters/react-hybrid/server/auth-jazz-context.ts
+++ b/starters/react-hybrid/server/auth-jazz-context.ts
@@ -1,0 +1,39 @@
+import type { JazzContext } from "jazz-tools/backend";
+
+// Workaround to resolve NAPI modules correctly in the monorepo. Real-world
+// apps can just `import { createJazzContext } from "jazz-tools/backend"`.
+import { createRequire as createRequireFromModule } from "node:module";
+const createRequire =
+  process.getBuiltinModule?.("module")?.createRequire ?? createRequireFromModule;
+const nodeRequire = createRequire(import.meta.url);
+const { createJazzContext } = nodeRequire(
+  "jazz-tools/backend",
+) as typeof import("jazz-tools/backend");
+
+declare global {
+  var __reactHybridAuthJazzContext: JazzContext | undefined;
+}
+
+// The Jazz dev server is pinned to port 4002 in vite.config.ts so the
+// standalone backend can reach it without coordinating through .env.
+const JAZZ_SERVER_URL = process.env.VITE_JAZZ_SERVER_URL ?? "http://127.0.0.1:4002";
+
+function create() {
+  return createJazzContext({
+    appId: process.env.VITE_JAZZ_APP_ID!,
+    driver: { type: "memory" },
+    serverUrl: JAZZ_SERVER_URL,
+    env: process.env.NODE_ENV === "production" ? "prod" : "dev",
+    userBranch: "main",
+    backendSecret: process.env.BACKEND_SECRET!,
+    tier: "global",
+  });
+}
+
+export function authJazzContext(): JazzContext {
+  const existing = globalThis.__reactHybridAuthJazzContext;
+  if (existing) return existing;
+  const ctx = create();
+  globalThis.__reactHybridAuthJazzContext = ctx;
+  return ctx;
+}

--- a/starters/react-hybrid/server/auth.ts
+++ b/starters/react-hybrid/server/auth.ts
@@ -1,7 +1,9 @@
 import { betterAuth } from "better-auth";
-import { memoryAdapter, type MemoryDB } from "better-auth/adapters/memory";
-import { bearer, jwt } from "better-auth/plugins";
 import { APIError, createAuthMiddleware } from "better-auth/api";
+import { bearer, jwt } from "better-auth/plugins";
+import { jazzAdapter } from "jazz-tools/better-auth-adapter";
+import { app } from "../schema.js";
+import { authJazzContext } from "./auth-jazz-context.js";
 
 const APP_ORIGIN = process.env.APP_ORIGIN ?? "http://localhost:3001";
 
@@ -13,19 +15,13 @@ if (!process.env.BETTER_AUTH_SECRET) {
 
 const BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET;
 
-// TODO: Replace with a persistent adapter before shipping.
-const authMemoryDb: MemoryDB = {
-  account: [],
-  jwks: [],
-  session: [],
-  user: [],
-  verification: [],
-};
-
 export const auth = betterAuth({
   baseURL: APP_ORIGIN,
   secret: BETTER_AUTH_SECRET,
-  database: memoryAdapter(authMemoryDb),
+  database: jazzAdapter({
+    db: () => authJazzContext().asBackend(app),
+    schema: app.wasmSchema,
+  }),
   trustedOrigins: (request) => {
     const origin = request?.headers.get("origin");
     if (origin && new URL(origin).hostname === "localhost") return [origin];
@@ -82,9 +78,6 @@ export const auth = betterAuth({
         expirationTime: "1h",
         issuer: APP_ORIGIN,
         getSubject: ({ user }: { user: { id: string } }) => user.id,
-        definePayload: ({ user }: { user: { id: string } }) => ({
-          jazz_principal_id: user.id,
-        }),
       },
     }),
   ],

--- a/starters/react-hybrid/vite.config.ts
+++ b/starters/react-hybrid/vite.config.ts
@@ -2,8 +2,20 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import { jazzPlugin } from "jazz-tools/dev/vite";
 
+// Pin the Jazz dev server to a fixed port so the standalone Hono backend
+// (started by tsx) knows where to reach it without coordinating via .env.
+const JAZZ_SERVER_PORT = 4002;
+
 export default defineConfig({
-  plugins: [react(), jazzPlugin({ server: { jwksUrl: "http://localhost:3001/api/auth/jwks" } })],
+  plugins: [
+    react(),
+    jazzPlugin({
+      server: {
+        port: JAZZ_SERVER_PORT,
+        jwksUrl: "http://localhost:3001/api/auth/jwks",
+      },
+    }),
+  ],
   worker: { format: "es" },
   server: {
     proxy: {

--- a/starters/sveltekit-betterauth/README.md
+++ b/starters/sveltekit-betterauth/README.md
@@ -26,9 +26,9 @@ pnpm dev
 
 Open [http://localhost:5173](http://localhost:5173), create an account,
 and you'll land on `/dashboard` with a working todo list persisted via
-Jazz. The `jazzSvelteKit` plugin spawns a local Jazz dev server
-automatically; set `BETTER_AUTH_SECRET` in `.env` before running
-(`openssl rand -base64 32` or scaffold via `create-jazz`).
+Jazz. `pnpm install` seeds `.env` with a random `BETTER_AUTH_SECRET` and
+`BACKEND_SECRET`; the `jazzSvelteKit` plugin spawns a local Jazz dev
+server automatically.
 
 ## Architecture
 
@@ -89,20 +89,20 @@ session on every row and the permission policy scopes reads/writes to it.
 
 ## Environment variables
 
-Scaffold via `create-jazz` to have `.env` populated automatically; otherwise
-write the values below by hand.
+`pnpm install` runs `scripts/ensure-env.js`, which seeds any missing keys
+in `.env` with random values. Override by setting values manually before
+install, or for cloud mode scaffold via `create-jazz --hosting hosted`.
 
-| Variable                 | When       | Purpose                                                           |
-| ------------------------ | ---------- | ----------------------------------------------------------------- |
-| `BETTER_AUTH_SECRET`     | always     | BetterAuth session signing. `src/lib/auth.ts` throws if missing.  |
-| `PUBLIC_JAZZ_APP_ID`     | cloud only | Provisioned app ID. Unset in self-hosted dev — plugin injects it. |
-| `PUBLIC_JAZZ_SERVER_URL` | cloud only | Cloud sync URL (e.g. `https://v2.sync.jazz.tools`).               |
-| `JAZZ_ADMIN_SECRET`      | cloud only | Admin credential for schema pushes to the cloud.                  |
-| `BACKEND_SECRET`         | cloud only | Backend signing credential.                                       |
+| Variable                 | When       | Purpose                                                                       |
+| ------------------------ | ---------- | ----------------------------------------------------------------------------- |
+| `BETTER_AUTH_SECRET`     | always     | BetterAuth session signing. `src/lib/auth.ts` throws if missing.              |
+| `PUBLIC_JAZZ_APP_ID`     | cloud only | Provisioned app ID. Unset in self-hosted dev — plugin injects it.             |
+| `PUBLIC_JAZZ_SERVER_URL` | cloud only | Cloud sync URL (e.g. `https://v2.sync.jazz.tools`).                           |
+| `JAZZ_ADMIN_SECRET`      | cloud only | Admin credential for schema pushes to the cloud.                              |
+| `BACKEND_SECRET`         | always     | Persistent identity for the backend's Jazz account. Seeded by the scaffolder. |
 
-Generate a dev `BETTER_AUTH_SECRET` with `openssl rand -base64 32`. In
-self-hosted mode (no cloud env vars), the `jazzSvelteKit` plugin spawns a
-local Jazz dev server and supplies its own credentials.
+In self-hosted mode (no cloud env vars), the `jazzSvelteKit` plugin spawns
+a local Jazz dev server and supplies its own credentials.
 
 ## Deploying to production
 

--- a/starters/sveltekit-betterauth/package.json
+++ b/starters/sveltekit-betterauth/package.json
@@ -5,8 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite dev",
-    "prebuild": "node scripts/ensure-env.js",
     "build": "vite build",
+    "postinstall": "node scripts/ensure-env.js",
     "preview": "vite preview",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "test:e2e": "playwright test"

--- a/starters/sveltekit-betterauth/scripts/ensure-env.js
+++ b/starters/sveltekit-betterauth/scripts/ensure-env.js
@@ -1,4 +1,4 @@
-import { existsSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { randomBytes } from "node:crypto";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -6,8 +6,22 @@ import { fileURLToPath } from "node:url";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const envPath = join(__dirname, "..", ".env");
 
-if (!existsSync(envPath)) {
-  const secret = randomBytes(32).toString("hex");
-  writeFileSync(envPath, `BETTER_AUTH_SECRET=${secret}\nAPP_ORIGIN=http://localhost:5173\n`);
-  console.log("No .env detected. Generated .env with a random BETTER_AUTH_SECRET");
+const required = [
+  { key: "BETTER_AUTH_SECRET", value: () => randomBytes(32).toString("hex") },
+  { key: "APP_ORIGIN", value: () => "http://localhost:5173" },
+  { key: "BACKEND_SECRET", value: () => randomBytes(32).toString("hex") },
+];
+
+const existing = existsSync(envPath) ? readFileSync(envPath, "utf8") : "";
+const missing = required.filter(({ key }) => !new RegExp(`^${key}=`, "m").test(existing));
+
+if (missing.length === 0) {
+  process.exit(0);
 }
+
+const appended = missing.map(({ key, value }) => `${key}=${value()}`).join("\n") + "\n";
+writeFileSync(
+  envPath,
+  existing.length && !existing.endsWith("\n") ? existing + "\n" + appended : existing + appended,
+);
+console.log(`ensure-env: added ${missing.map((m) => m.key).join(", ")} to .env`);

--- a/starters/sveltekit-betterauth/src/lib/auth-jazz-context.ts
+++ b/starters/sveltekit-betterauth/src/lib/auth-jazz-context.ts
@@ -1,0 +1,35 @@
+import type { JazzContext } from "jazz-tools/backend";
+
+// Workaround to resolve NAPI modules correctly in the monorepo. Real-world
+// apps can just `import { createJazzContext } from "jazz-tools/backend"`.
+import { createRequire as createRequireFromModule } from "node:module";
+const createRequire =
+  process.getBuiltinModule?.("module")?.createRequire ?? createRequireFromModule;
+const nodeRequire = createRequire(import.meta.url);
+const { createJazzContext } = nodeRequire(
+  "jazz-tools/backend",
+) as typeof import("jazz-tools/backend");
+
+declare global {
+  var __sveltekitBetterAuthJazzContext: JazzContext | undefined;
+}
+
+function create() {
+  return createJazzContext({
+    appId: process.env.PUBLIC_JAZZ_APP_ID!,
+    driver: { type: "memory" },
+    serverUrl: process.env.PUBLIC_JAZZ_SERVER_URL!,
+    env: process.env.NODE_ENV === "production" ? "prod" : "dev",
+    userBranch: "main",
+    backendSecret: process.env.BACKEND_SECRET!,
+    tier: "global",
+  });
+}
+
+export function authJazzContext(): JazzContext {
+  const existing = globalThis.__sveltekitBetterAuthJazzContext;
+  if (existing) return existing;
+  const ctx = create();
+  globalThis.__sveltekitBetterAuthJazzContext = ctx;
+  return ctx;
+}

--- a/starters/sveltekit-betterauth/src/lib/auth.ts
+++ b/starters/sveltekit-betterauth/src/lib/auth.ts
@@ -1,9 +1,11 @@
-import { betterAuth } from "better-auth";
-import { memoryAdapter, type MemoryDB } from "better-auth/adapters/memory";
-import { bearer, jwt } from "better-auth/plugins";
-import { sveltekitCookies } from "better-auth/svelte-kit";
 import { getRequestEvent } from "$app/server";
 import { env } from "$env/dynamic/private";
+import { betterAuth } from "better-auth";
+import { bearer, jwt } from "better-auth/plugins";
+import { sveltekitCookies } from "better-auth/svelte-kit";
+import { jazzAdapter } from "jazz-tools/better-auth-adapter";
+import { app } from "./schema";
+import { authJazzContext } from "./auth-jazz-context";
 
 const APP_ORIGIN = env.APP_ORIGIN ?? "http://localhost:5173";
 
@@ -15,20 +17,13 @@ if (!env.BETTER_AUTH_SECRET) {
 
 const BETTER_AUTH_SECRET = env.BETTER_AUTH_SECRET;
 
-// In-memory store — wiped on every dev-server restart. Good enough for a
-// starter; swap for a persistent adapter when you wire up a real database.
-const authMemoryDb: MemoryDB = {
-  account: [],
-  jwks: [],
-  session: [],
-  user: [],
-  verification: [],
-};
-
 export const auth = betterAuth({
   baseURL: APP_ORIGIN,
   secret: BETTER_AUTH_SECRET,
-  database: memoryAdapter(authMemoryDb),
+  database: jazzAdapter({
+    db: () => authJazzContext().asBackend(app),
+    schema: app.wasmSchema,
+  }),
   trustedOrigins: [APP_ORIGIN],
   emailAndPassword: {
     enabled: true,

--- a/starters/sveltekit-betterauth/src/lib/schema-better-auth/schema.ts
+++ b/starters/sveltekit-betterauth/src/lib/schema-better-auth/schema.ts
@@ -1,0 +1,52 @@
+import { schema as s } from "jazz-tools";
+
+export const schema = {
+  better_auth_user: s.table({
+    name: s.string(),
+    email: s.string(),
+    emailVerified: s.boolean(),
+    image: s.string().optional(),
+    createdAt: s.timestamp(),
+    updatedAt: s.timestamp(),
+  }),
+
+  better_auth_session: s.table({
+    expiresAt: s.timestamp(),
+    token: s.string(),
+    createdAt: s.timestamp(),
+    updatedAt: s.timestamp(),
+    ipAddress: s.string().optional(),
+    userAgent: s.string().optional(),
+    userId: s.ref("better_auth_user"),
+  }),
+
+  better_auth_account: s.table({
+    accountId: s.string(),
+    providerId: s.string(),
+    userId: s.ref("better_auth_user"),
+    accessToken: s.string().optional(),
+    refreshToken: s.string().optional(),
+    idToken: s.string().optional(),
+    accessTokenExpiresAt: s.timestamp().optional(),
+    refreshTokenExpiresAt: s.timestamp().optional(),
+    scope: s.string().optional(),
+    password: s.string().optional(),
+    createdAt: s.timestamp(),
+    updatedAt: s.timestamp(),
+  }),
+
+  better_auth_verification: s.table({
+    identifier: s.string(),
+    value: s.string(),
+    expiresAt: s.timestamp(),
+    createdAt: s.timestamp(),
+    updatedAt: s.timestamp(),
+  }),
+
+  better_auth_jwks: s.table({
+    publicKey: s.string(),
+    privateKey: s.string(),
+    createdAt: s.timestamp(),
+    expiresAt: s.timestamp().optional(),
+  }),
+};

--- a/starters/sveltekit-betterauth/src/lib/schema-better-auth/schema.ts
+++ b/starters/sveltekit-betterauth/src/lib/schema-better-auth/schema.ts
@@ -1,3 +1,5 @@
+// This file is required to ensure Better Auth tables exist in your database
+
 import { schema as s } from "jazz-tools";
 
 export const schema = {

--- a/starters/sveltekit-betterauth/src/lib/schema.ts
+++ b/starters/sveltekit-betterauth/src/lib/schema.ts
@@ -1,6 +1,8 @@
 import { schema as s } from "jazz-tools";
+import { schema as betterAuthSchema } from "./schema-better-auth/schema";
 
 const schema = {
+  ...betterAuthSchema,
   todos: s.table({
     title: s.string(),
     done: s.boolean(),

--- a/starters/sveltekit-hybrid/README.md
+++ b/starters/sveltekit-hybrid/README.md
@@ -24,8 +24,9 @@ pnpm dev
 ```
 
 Open [http://localhost:5173](http://localhost:5173) and you'll land on
-the app. Set `BETTER_AUTH_SECRET` in `.env` before running
-(`openssl rand -base64 32` or scaffold via `create-jazz`).
+the app. `pnpm install` seeds `.env` with a random `BETTER_AUTH_SECRET`
+and `BACKEND_SECRET`; the `jazzSvelteKit` plugin spawns a local Jazz dev
+server automatically.
 
 ## Architecture
 
@@ -110,20 +111,20 @@ session on every row and the permission policy scopes reads/writes to it.
 
 ## Environment variables
 
-Scaffold via `create-jazz` to have `.env` populated automatically; otherwise
-write the values below by hand.
+`pnpm install` runs `scripts/ensure-env.js`, which seeds any missing keys
+in `.env` with random values. Override by setting values manually before
+install, or for cloud mode scaffold via `create-jazz --hosting hosted`.
 
-| Variable                 | When       | Purpose                                                           |
-| ------------------------ | ---------- | ----------------------------------------------------------------- |
-| `BETTER_AUTH_SECRET`     | always     | BetterAuth session signing. `src/lib/auth.ts` throws if missing.  |
-| `PUBLIC_JAZZ_APP_ID`     | cloud only | Provisioned app ID. Unset in self-hosted dev — plugin injects it. |
-| `PUBLIC_JAZZ_SERVER_URL` | cloud only | Cloud sync URL (e.g. `https://v2.sync.jazz.tools`).               |
-| `JAZZ_ADMIN_SECRET`      | cloud only | Admin credential for schema pushes to the cloud.                  |
-| `BACKEND_SECRET`         | cloud only | Backend signing credential.                                       |
+| Variable                 | When       | Purpose                                                                       |
+| ------------------------ | ---------- | ----------------------------------------------------------------------------- |
+| `BETTER_AUTH_SECRET`     | always     | BetterAuth session signing. `src/lib/auth.ts` throws if missing.              |
+| `PUBLIC_JAZZ_APP_ID`     | cloud only | Provisioned app ID. Unset in self-hosted dev — plugin injects it.             |
+| `PUBLIC_JAZZ_SERVER_URL` | cloud only | Cloud sync URL (e.g. `https://v2.sync.jazz.tools`).                           |
+| `JAZZ_ADMIN_SECRET`      | cloud only | Admin credential for schema pushes to the cloud.                              |
+| `BACKEND_SECRET`         | always     | Persistent identity for the backend's Jazz account. Seeded by the scaffolder. |
 
-Generate a dev `BETTER_AUTH_SECRET` with `openssl rand -base64 32`. In
-self-hosted mode (no cloud env vars), the `jazzSvelteKit` plugin spawns a
-local Jazz dev server and supplies its own credentials.
+In self-hosted mode (no cloud env vars), the `jazzSvelteKit` plugin spawns
+a local Jazz dev server and supplies its own credentials.
 
 ## Deploying to production
 

--- a/starters/sveltekit-hybrid/package.json
+++ b/starters/sveltekit-hybrid/package.json
@@ -5,8 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite dev",
-    "prebuild": "node scripts/ensure-env.js",
     "build": "vite build",
+    "postinstall": "node scripts/ensure-env.js",
     "preview": "vite preview",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "test:e2e": "playwright test"

--- a/starters/sveltekit-hybrid/scripts/ensure-env.js
+++ b/starters/sveltekit-hybrid/scripts/ensure-env.js
@@ -1,4 +1,4 @@
-import { existsSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { randomBytes } from "node:crypto";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -6,8 +6,22 @@ import { fileURLToPath } from "node:url";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const envPath = join(__dirname, "..", ".env");
 
-if (!existsSync(envPath)) {
-  const secret = randomBytes(32).toString("hex");
-  writeFileSync(envPath, `BETTER_AUTH_SECRET=${secret}\nAPP_ORIGIN=http://localhost:5173\n`);
-  console.log("No .env detected. Generated .env with a random BETTER_AUTH_SECRET");
+const required = [
+  { key: "BETTER_AUTH_SECRET", value: () => randomBytes(32).toString("hex") },
+  { key: "APP_ORIGIN", value: () => "http://localhost:5173" },
+  { key: "BACKEND_SECRET", value: () => randomBytes(32).toString("hex") },
+];
+
+const existing = existsSync(envPath) ? readFileSync(envPath, "utf8") : "";
+const missing = required.filter(({ key }) => !new RegExp(`^${key}=`, "m").test(existing));
+
+if (missing.length === 0) {
+  process.exit(0);
 }
+
+const appended = missing.map(({ key, value }) => `${key}=${value()}`).join("\n") + "\n";
+writeFileSync(
+  envPath,
+  existing.length && !existing.endsWith("\n") ? existing + "\n" + appended : existing + appended,
+);
+console.log(`ensure-env: added ${missing.map((m) => m.key).join(", ")} to .env`);

--- a/starters/sveltekit-hybrid/src/lib/auth-jazz-context.ts
+++ b/starters/sveltekit-hybrid/src/lib/auth-jazz-context.ts
@@ -1,0 +1,35 @@
+import type { JazzContext } from "jazz-tools/backend";
+
+// Workaround to resolve NAPI modules correctly in the monorepo. Real-world
+// apps can just `import { createJazzContext } from "jazz-tools/backend"`.
+import { createRequire as createRequireFromModule } from "node:module";
+const createRequire =
+  process.getBuiltinModule?.("module")?.createRequire ?? createRequireFromModule;
+const nodeRequire = createRequire(import.meta.url);
+const { createJazzContext } = nodeRequire(
+  "jazz-tools/backend",
+) as typeof import("jazz-tools/backend");
+
+declare global {
+  var __sveltekitHybridAuthJazzContext: JazzContext | undefined;
+}
+
+function create() {
+  return createJazzContext({
+    appId: process.env.PUBLIC_JAZZ_APP_ID!,
+    driver: { type: "memory" },
+    serverUrl: process.env.PUBLIC_JAZZ_SERVER_URL!,
+    env: process.env.NODE_ENV === "production" ? "prod" : "dev",
+    userBranch: "main",
+    backendSecret: process.env.BACKEND_SECRET!,
+    tier: "global",
+  });
+}
+
+export function authJazzContext(): JazzContext {
+  const existing = globalThis.__sveltekitHybridAuthJazzContext;
+  if (existing) return existing;
+  const ctx = create();
+  globalThis.__sveltekitHybridAuthJazzContext = ctx;
+  return ctx;
+}

--- a/starters/sveltekit-hybrid/src/lib/auth.ts
+++ b/starters/sveltekit-hybrid/src/lib/auth.ts
@@ -1,10 +1,12 @@
-import { betterAuth } from "better-auth";
-import { memoryAdapter, type MemoryDB } from "better-auth/adapters/memory";
-import { bearer, jwt } from "better-auth/plugins";
-import { APIError, createAuthMiddleware } from "better-auth/api";
-import { sveltekitCookies } from "better-auth/svelte-kit";
 import { getRequestEvent } from "$app/server";
 import { env } from "$env/dynamic/private";
+import { betterAuth } from "better-auth";
+import { APIError, createAuthMiddleware } from "better-auth/api";
+import { bearer, jwt } from "better-auth/plugins";
+import { sveltekitCookies } from "better-auth/svelte-kit";
+import { jazzAdapter } from "jazz-tools/better-auth-adapter";
+import { app } from "./schema";
+import { authJazzContext } from "./auth-jazz-context";
 
 const APP_ORIGIN = env.APP_ORIGIN ?? "http://localhost:5173";
 
@@ -16,22 +18,13 @@ if (!env.BETTER_AUTH_SECRET) {
 
 const BETTER_AUTH_SECRET = env.BETTER_AUTH_SECRET;
 
-// In-memory store. Each Node process keeps its own copy, so users that sign
-// up in one worker cannot sign in from another: HMR reloads, multi-worker
-// deploys, and serverless invocations all reset state. Good enough for a
-// starter you run locally; swap for a persistent adapter before you ship.
-const authMemoryDb: MemoryDB = {
-  account: [],
-  jwks: [],
-  session: [],
-  user: [],
-  verification: [],
-};
-
 export const auth = betterAuth({
   baseURL: APP_ORIGIN,
   secret: BETTER_AUTH_SECRET,
-  database: memoryAdapter(authMemoryDb),
+  database: jazzAdapter({
+    db: () => authJazzContext().asBackend(app),
+    schema: app.wasmSchema,
+  }),
   trustedOrigins: [APP_ORIGIN],
   emailAndPassword: {
     enabled: true,

--- a/starters/sveltekit-hybrid/src/lib/schema-better-auth/schema.ts
+++ b/starters/sveltekit-hybrid/src/lib/schema-better-auth/schema.ts
@@ -1,0 +1,52 @@
+import { schema as s } from "jazz-tools";
+
+export const schema = {
+  better_auth_user: s.table({
+    name: s.string(),
+    email: s.string(),
+    emailVerified: s.boolean(),
+    image: s.string().optional(),
+    createdAt: s.timestamp(),
+    updatedAt: s.timestamp(),
+  }),
+
+  better_auth_session: s.table({
+    expiresAt: s.timestamp(),
+    token: s.string(),
+    createdAt: s.timestamp(),
+    updatedAt: s.timestamp(),
+    ipAddress: s.string().optional(),
+    userAgent: s.string().optional(),
+    userId: s.ref("better_auth_user"),
+  }),
+
+  better_auth_account: s.table({
+    accountId: s.string(),
+    providerId: s.string(),
+    userId: s.ref("better_auth_user"),
+    accessToken: s.string().optional(),
+    refreshToken: s.string().optional(),
+    idToken: s.string().optional(),
+    accessTokenExpiresAt: s.timestamp().optional(),
+    refreshTokenExpiresAt: s.timestamp().optional(),
+    scope: s.string().optional(),
+    password: s.string().optional(),
+    createdAt: s.timestamp(),
+    updatedAt: s.timestamp(),
+  }),
+
+  better_auth_verification: s.table({
+    identifier: s.string(),
+    value: s.string(),
+    expiresAt: s.timestamp(),
+    createdAt: s.timestamp(),
+    updatedAt: s.timestamp(),
+  }),
+
+  better_auth_jwks: s.table({
+    publicKey: s.string(),
+    privateKey: s.string(),
+    createdAt: s.timestamp(),
+    expiresAt: s.timestamp().optional(),
+  }),
+};

--- a/starters/sveltekit-hybrid/src/lib/schema-better-auth/schema.ts
+++ b/starters/sveltekit-hybrid/src/lib/schema-better-auth/schema.ts
@@ -1,3 +1,5 @@
+// This file is required to ensure Better Auth tables exist in your database
+
 import { schema as s } from "jazz-tools";
 
 export const schema = {

--- a/starters/sveltekit-hybrid/src/lib/schema.ts
+++ b/starters/sveltekit-hybrid/src/lib/schema.ts
@@ -1,6 +1,8 @@
 import { schema as s } from "jazz-tools";
+import { schema as betterAuthSchema } from "./schema-better-auth/schema";
 
 const schema = {
+  ...betterAuthSchema,
   todos: s.table({
     title: s.string(),
     done: s.boolean(),


### PR DESCRIPTION
Third of three stacked PRs for the BetterAuth adapter work (#524 → #386 → this).

## Summary

- Wire `jazzAdapter` into the four BetterAuth/hybrid starters (`next-betterauth`, `next-hybrid`, `sveltekit-betterauth`, `sveltekit-hybrid`): each ships an `auth-jazz-context.ts`, a generated `schema-better-auth/schema.ts`, `jazzPrincipalId` additional field on `user` (required because Jazz row IDs must be UUIDv7 but local-first proofs produce UUIDv5), and a JWT `jazz_principal_id` custom claim the Rust verifier prefers over `sub`.
- Hoist the local-first proof audience to a shared `SIGNUP_PROOF_AUDIENCE` constant in both hybrid starters so server + client can't drift.
- Fix a handful of dev-plugin bugs uncovered while getting the six starter E2Es to pass end-to-end — see the changeset for details.
- Regenerate `crates/jazz-napi` bindings so the committed `.d.ts` matches the Rust `insert` / `insertWithSession` / `insertDurable` / `insertDurableWithSession` signatures, which already accept an optional `objectId`.

## Test plan

- [ ] `pnpm --filter jazz-tools test` — 922 passing, 2 expected-fail, 1 skipped
- [ ] All six starter Playwright E2Es pass:
  - [ ] `pnpm --filter next-betterauth test:e2e`
  - [ ] `pnpm --filter next-hybrid test:e2e`
  - [ ] `pnpm --filter next-localfirst test:e2e`
  - [ ] `pnpm --filter sveltekit-betterauth test:e2e`
  - [ ] `pnpm --filter sveltekit-hybrid test:e2e`
  - [ ] `pnpm --filter sveltekit-localfirst test:e2e`
- [ ] `pnpm format:check`, `pnpm lint`, `cargo fmt --check`, `cargo clippy --workspace -- -D warnings`
- [ ] `node scripts/check-starters-parity.mjs`