### PR TITLE
fix handshake schema hash diagnostics

### DIFF
--- a/.changeset/codex-connection-schema-hash.md
+++ b/.changeset/codex-connection-schema-hash.md
@@ -1,0 +1,7 @@
+---
+"jazz-tools": patch
+---
+
+Fix misleading schema-mismatch recovery guidance during client/server handshakes.
+
+The transport handshake now sends the client's declared structural schema hash separately from the catalogue-state digest, so server-side connection diagnostics only suggest migrations for real schema hashes that the CLI can resolve.

--- a/crates/jazz-tools/src/routes.rs
+++ b/crates/jazz-tools/src/routes.rs
@@ -1076,6 +1076,23 @@ fn parse_schema_hash_param(hash_text: &str) -> Result<SchemaHash, String> {
     Ok(SchemaHash::from_bytes(hash_bytes))
 }
 
+fn connection_schema_diagnostics_from_handshake(
+    state: &Arc<ServerState>,
+    handshake: &crate::transport_manager::AuthHandshake,
+) -> Result<
+    Option<crate::sync_manager::ConnectionSchemaDiagnostics>,
+    crate::runtime_tokio::RuntimeError,
+> {
+    let Some(client_schema_hash) = handshake.declared_schema_hash() else {
+        return Ok(None);
+    };
+
+    let diagnostics = state
+        .runtime
+        .with_schema_manager(|sm| sm.connection_schema_diagnostics(client_schema_hash))?;
+    Ok(diagnostics.has_issues().then_some(diagnostics))
+}
+
 fn parse_object_id_param(object_id_text: &str) -> Result<ObjectId, String> {
     let uuid = Uuid::parse_str(object_id_text)
         .map_err(|_| "invalid object id: expected UUID".to_string())?;
@@ -1356,28 +1373,21 @@ async fn handle_ws_connection(mut socket: WebSocket, state: Arc<ServerState>) {
         }
     }
 
-    // 5b. Dispatch connection schema diagnostics if client sent a schema hash.
-    if let Some(ref hash_str) = handshake.catalogue_state_hash
-        && let Ok(client_schema_hash) = parse_schema_hash_param(hash_str)
-    {
-        match state
-            .runtime
-            .with_schema_manager(|sm| sm.connection_schema_diagnostics(client_schema_hash))
-        {
-            Ok(diagnostics) if diagnostics.has_issues() => {
-                state.connection_event_hub.dispatch_payload(
-                    client_id,
-                    crate::sync_manager::SyncPayload::ConnectionSchemaDiagnostics(diagnostics),
-                );
-            }
-            Ok(_) => {}
-            Err(err) => {
-                tracing::error!(
-                    %client_id,
-                    %client_schema_hash,
-                    "failed to compute connection schema diagnostics: {err}"
-                );
-            }
+    // 5b. Dispatch connection schema diagnostics if client sent a declared schema hash.
+    match connection_schema_diagnostics_from_handshake(&state, &handshake) {
+        Ok(Some(diagnostics)) => {
+            state.connection_event_hub.dispatch_payload(
+                client_id,
+                crate::sync_manager::SyncPayload::ConnectionSchemaDiagnostics(diagnostics),
+            );
+        }
+        Ok(None) => {}
+        Err(err) => {
+            tracing::error!(
+                %client_id,
+                declared_schema_hash = ?handshake.declared_schema_hash,
+                "failed to compute connection schema diagnostics: {err}"
+            );
         }
     }
 
@@ -1730,6 +1740,7 @@ mod tests {
             client_id: client_id.to_string(),
             auth: crate::transport_manager::AuthConfig::default(),
             catalogue_state_hash: None,
+            declared_schema_hash: None,
         };
 
         // Authenticate should fail — the `authenticate_ws_handshake` function is
@@ -2994,6 +3005,31 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn ws_handler_uses_declared_schema_hash_for_connection_diagnostics() {
+        let schema = SchemaBuilder::new()
+            .table(
+                TableSchema::builder("users")
+                    .column("id", ColumnType::Uuid)
+                    .column("name", ColumnType::Text),
+            )
+            .build();
+        let state = make_state_with_schema(schema).await;
+        let declared_hash = SchemaHash::from_bytes([9; 32]);
+        let handshake = crate::transport_manager::AuthHandshake {
+            client_id: ClientId::new().to_string(),
+            auth: crate::transport_manager::AuthConfig::default(),
+            catalogue_state_hash: state.runtime.catalogue_state_hash().ok(),
+            declared_schema_hash: Some(declared_hash.to_string()),
+        };
+
+        let diagnostics = connection_schema_diagnostics_from_handshake(&state, &handshake)
+            .expect("compute diagnostics")
+            .expect("declared schema mismatch should produce diagnostics");
+
+        assert_eq!(diagnostics.client_schema_hash, declared_hash);
+    }
+
     #[tokio::test(flavor = "current_thread")]
     async fn ws_handler_logs_when_connection_is_established() {
         // Exercise the real /ws route so the assertion covers the actual
@@ -3024,6 +3060,7 @@ mod tests {
                 ..Default::default()
             },
             catalogue_state_hash: None,
+            declared_schema_hash: None,
         };
         let payload = serde_json::to_vec(&handshake).expect("serialize handshake");
         ws.send(WsMessage::Binary(

--- a/crates/jazz-tools/src/runtime_core.rs
+++ b/crates/jazz-tools/src/runtime_core.rs
@@ -474,6 +474,11 @@ where
     );
     let (handle, manager) = crate::transport_manager::create::<W, T>(url, auth, tick);
     handle.set_catalogue_state_hash(Some(core.schema_manager().catalogue_state_hash()));
+    handle.set_declared_schema_hash(
+        core.schema_manager()
+            .has_current_schema()
+            .then(|| core.schema_manager().current_hash().to_string()),
+    );
     core.schema_manager
         .query_manager_mut()
         .sync_manager_mut()

--- a/crates/jazz-tools/src/runtime_core/tests.rs
+++ b/crates/jazz-tools/src/runtime_core/tests.rs
@@ -995,7 +995,7 @@ mod install_transport_tests {
     }
 
     #[test]
-    fn install_transport_seeds_catalogue_hash_and_registers_handle() {
+    fn install_transport_seeds_catalogue_hash_and_declared_schema_hash() {
         let mut core = create_test_runtime();
 
         let _manager = crate::runtime_core::install_transport::<_, _, NopStreamAdapter, _>(
@@ -1015,10 +1015,21 @@ mod install_transport_tests {
             .as_ref()
             .unwrap()
             .catalogue_state_hash_for_test();
+        let expected_schema_hash = core.schema_manager().current_hash().to_string();
+        let handle_schema_hash = core
+            .transport
+            .as_ref()
+            .unwrap()
+            .declared_schema_hash_for_test();
         assert_eq!(
             handle_hash.as_deref(),
             Some(expected_hash.as_str()),
             "install_transport must seed the handle's catalogue_state_hash",
+        );
+        assert_eq!(
+            handle_schema_hash.as_deref(),
+            Some(expected_schema_hash.as_str()),
+            "install_transport must seed the handle's declared_schema_hash",
         );
     }
 

--- a/crates/jazz-tools/src/transport_manager.rs
+++ b/crates/jazz-tools/src/transport_manager.rs
@@ -3,6 +3,7 @@
 //! TransportHandle is held by RuntimeCore (replaces SyncSender).
 //! TransportManager owns the live WebSocket connection and reconnects on failure.
 
+use crate::query_manager::types::SchemaHash;
 use crate::sync_manager::types::{ClientId, InboxEntry, OutboxEntry, ServerId};
 use futures::channel::mpsc;
 
@@ -61,11 +62,15 @@ pub struct TransportHandle {
     pub inbound_rx: mpsc::UnboundedReceiver<TransportInbound>,
     pub ever_connected: std::sync::Arc<std::sync::atomic::AtomicBool>,
     pub control_tx: mpsc::UnboundedSender<TransportControl>,
-    /// Client's current catalogue state hash. The TransportManager reads
-    /// this at each handshake attempt and includes it in `AuthHandshake`
-    /// so the server can dispatch `ConnectionSchemaDiagnostics` when the
-    /// client is on a stale schema. Shared with the manager via `Arc`.
+    /// Client's current catalogue-state digest. The TransportManager reads
+    /// this at each handshake attempt so reconnects can tell the server
+    /// whether catalogue replay is necessary. Shared with the manager via
+    /// `Arc`.
     pub(crate) catalogue_state_hash: std::sync::Arc<std::sync::Mutex<Option<String>>>,
+    /// Client's declared structural schema hash. Sent separately from the
+    /// catalogue-state digest so the server can emit schema diagnostics
+    /// against a real schema hash.
+    pub(crate) declared_schema_hash: std::sync::Arc<std::sync::Mutex<Option<String>>>,
 }
 
 impl TransportHandle {
@@ -102,6 +107,23 @@ impl TransportHandle {
     #[cfg(test)]
     pub fn catalogue_state_hash_for_test(&self) -> Option<String> {
         self.catalogue_state_hash
+            .lock()
+            .ok()
+            .and_then(|g| g.clone())
+    }
+
+    /// Update the declared schema hash sent in subsequent auth handshakes.
+    pub fn set_declared_schema_hash(&self, hash: Option<String>) {
+        if let Ok(mut slot) = self.declared_schema_hash.lock() {
+            *slot = hash;
+        }
+    }
+
+    /// Test-only accessor: returns the current declared schema hash stored in
+    /// this handle.
+    #[cfg(test)]
+    pub fn declared_schema_hash_for_test(&self) -> Option<String> {
+        self.declared_schema_hash
             .lock()
             .ok()
             .and_then(|g| g.clone())
@@ -143,6 +165,44 @@ pub struct AuthHandshake {
     pub client_id: String,
     pub auth: AuthConfig,
     pub catalogue_state_hash: Option<String>,
+    pub declared_schema_hash: Option<String>,
+}
+
+impl AuthHandshake {
+    pub fn declared_schema_hash(&self) -> Option<SchemaHash> {
+        self.declared_schema_hash
+            .as_deref()
+            .and_then(SchemaHash::from_hex)
+    }
+}
+
+#[cfg(test)]
+mod handshake_tests {
+    use super::*;
+    use crate::query_manager::types::SchemaHash;
+
+    #[test]
+    fn auth_handshake_uses_declared_schema_hash_not_catalogue_state_hash() {
+        let declared_hash = SchemaHash::from_bytes([7; 32]);
+        let catalogue_hash = "ab".repeat(32);
+        let handshake = AuthHandshake {
+            client_id: "client-1".to_string(),
+            auth: AuthConfig::default(),
+            catalogue_state_hash: Some(catalogue_hash.clone()),
+            declared_schema_hash: Some(declared_hash.to_string()),
+        };
+
+        assert_eq!(handshake.declared_schema_hash(), Some(declared_hash));
+
+        let handshake_without_declared_hash = AuthHandshake {
+            client_id: "client-1".to_string(),
+            auth: AuthConfig::default(),
+            catalogue_state_hash: Some(catalogue_hash),
+            declared_schema_hash: None,
+        };
+
+        assert_eq!(handshake_without_declared_hash.declared_schema_hash(), None);
+    }
 }
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
@@ -201,6 +261,9 @@ pub struct TransportManager<W: StreamAdapter, T: TickNotifier> {
     /// Shared with `TransportHandle::catalogue_state_hash`. Read at each
     /// handshake attempt so reconnects can reflect catalogue changes.
     catalogue_state_hash: std::sync::Arc<std::sync::Mutex<Option<String>>>,
+    /// Shared with `TransportHandle::declared_schema_hash`. Read at each
+    /// handshake attempt so the server sees the client's structural schema.
+    declared_schema_hash: std::sync::Arc<std::sync::Mutex<Option<String>>>,
     _stream: std::marker::PhantomData<W>,
 }
 
@@ -216,6 +279,7 @@ pub fn create<W: StreamAdapter, T: TickNotifier>(
     let (control_tx, control_rx) = mpsc::unbounded();
     let ever_connected = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
     let catalogue_state_hash = std::sync::Arc::new(std::sync::Mutex::new(None::<String>));
+    let declared_schema_hash = std::sync::Arc::new(std::sync::Mutex::new(None::<String>));
     let handle = TransportHandle {
         server_id,
         client_id,
@@ -224,6 +288,7 @@ pub fn create<W: StreamAdapter, T: TickNotifier>(
         ever_connected: ever_connected.clone(),
         control_tx,
         catalogue_state_hash: catalogue_state_hash.clone(),
+        declared_schema_hash: declared_schema_hash.clone(),
     };
     let manager = TransportManager {
         server_id,
@@ -237,6 +302,7 @@ pub fn create<W: StreamAdapter, T: TickNotifier>(
         ever_connected,
         control_rx,
         catalogue_state_hash,
+        declared_schema_hash,
         _stream: std::marker::PhantomData,
     };
     (handle, manager)
@@ -279,10 +345,15 @@ pub(crate) enum HandshakeResult {
 /// Handshake helpers shared between the Tokio and WASM run loops.
 impl<W: StreamAdapter + 'static, T: TickNotifier + 'static> TransportManager<W, T> {
     /// Build the length-prefixed handshake frame from the current client identity, auth,
-    /// and the latest catalogue state hash known to the caller.
+    /// and the latest catalogue + declared schema hashes known to the caller.
     fn build_handshake_frame(&self) -> Vec<u8> {
         let catalogue_state_hash = self
             .catalogue_state_hash
+            .lock()
+            .ok()
+            .and_then(|g| g.clone());
+        let declared_schema_hash = self
+            .declared_schema_hash
             .lock()
             .ok()
             .and_then(|g| g.clone());
@@ -290,6 +361,7 @@ impl<W: StreamAdapter + 'static, T: TickNotifier + 'static> TransportManager<W, 
             client_id: self.client_id.to_string(),
             auth: self.auth.clone(),
             catalogue_state_hash,
+            declared_schema_hash,
         };
         let payload =
             serde_json::to_vec(&handshake).expect("AuthHandshake serialisation infallible");

--- a/crates/jazz-tools/tests/auth_test.rs
+++ b/crates/jazz-tools/tests/auth_test.rs
@@ -112,6 +112,7 @@ async fn ws_handshake(server: &TestServer, auth: AuthConfig) -> Result<Connected
         client_id: ClientId::new().to_string(),
         auth,
         catalogue_state_hash: None,
+        declared_schema_hash: None,
     };
     let payload = serde_json::to_vec(&handshake).expect("serialize AuthHandshake");
     ws.send(Message::Binary(frame_encode(&payload).into()))

--- a/crates/jazz-tools/tests/integration.rs
+++ b/crates/jazz-tools/tests/integration.rs
@@ -57,6 +57,7 @@ async fn ws_handshake(port: u16, jwt_token: &str) -> Result<ConnectedResponse, S
             ..Default::default()
         },
         catalogue_state_hash: None,
+        declared_schema_hash: None,
     };
     let payload = serde_json::to_vec(&handshake).expect("serialize AuthHandshake");
     ws.send(Message::Binary(frame_encode(&payload).into()))
@@ -309,6 +310,7 @@ async fn test_ws_connection_stays_open_after_handshake() {
             ..Default::default()
         },
         catalogue_state_hash: None,
+        declared_schema_hash: None,
     };
     let payload = serde_json::to_vec(&handshake).expect("serialize AuthHandshake");
     ws.send(Message::Binary(frame_encode(&payload).into()))


### PR DESCRIPTION
## Summary
- send the client's declared structural schema hash separately from the catalogue-state digest during transport handshakes
- compute connection schema diagnostics from the declared schema hash so migration guidance only references real schema snapshots
- add a patch changeset and regressions covering handshake parsing, transport seeding, and route-level diagnostics

## Root cause
The websocket handshake only carried `catalogue_state_hash`, but the server treated that digest like a schema hash when building `ConnectionSchemaDiagnostics`. Because the digest is still a 64-character hex string, the warning path could suggest `--toHash` values that did not correspond to any stored schema, which made the CLI recovery command self-contradictory.

## Impact
Clients now report stale-schema diagnostics against actual structural schema hashes, so the suggested recovery commands line up with the schemas the CLI can resolve from snapshots or the server.

## Validation
- `pnpm lint`
- `target/debug/deps/jazz_tools-be7d2b9ffdb387c1 transport_manager::handshake_tests::auth_handshake_uses_declared_schema_hash_not_catalogue_state_hash --exact --nocapture`
- `target/debug/deps/jazz_tools-5bd0cf87e7975956 runtime_core::tests::install_transport_tests::install_transport_seeds_catalogue_hash_and_declared_schema_hash --exact --nocapture`
- `target/debug/deps/jazz_tools-495fa521c3223e62 routes::tests::ws_handler_uses_declared_schema_hash_for_connection_diagnostics --exact --nocapture`