### PR TITLE
Add HttpOnly cookie auth support

### DIFF
--- a/.changeset/cookie-auth-session-mirror.md
+++ b/.changeset/cookie-auth-session-mirror.md
@@ -1,0 +1,8 @@
+---
+"jazz-tools": patch
+---
+
+Add HttpOnly cookie auth support to `jazz-tools` with a mirrored browser
+`cookieSession` for local permission evaluation. Servers can now accept JWT auth
+from a configured auth cookie, and cookie-backed websocket handshakes are
+restricted to same-origin requests.

--- a/crates/jazz-tools/src/main.rs
+++ b/crates/jazz-tools/src/main.rs
@@ -78,6 +78,10 @@ enum Commands {
         #[arg(long, env = "JAZZ_JWKS_URL")]
         jwks_url: Option<String>,
 
+        /// Cookie name used for browser auth on the `/ws` upgrade.
+        #[arg(long, env = "JAZZ_AUTH_COOKIE_NAME")]
+        auth_cookie_name: Option<String>,
+
         /// Enable local-first auth (Authorization: Bearer <self-signed Jazz JWT>).
         ///
         /// Required in NODE_ENV=production.
@@ -135,6 +139,7 @@ async fn main() {
             data_dir,
             in_memory,
             jwks_url,
+            auth_cookie_name,
             allow_local_first_auth,
             backend_secret,
             admin_secret,
@@ -148,6 +153,7 @@ async fn main() {
 
             let auth_config = AuthConfig {
                 jwks_url,
+                auth_cookie_name,
                 allow_local_first_auth,
                 backend_secret,
                 admin_secret,

--- a/crates/jazz-tools/src/middleware/auth.rs
+++ b/crates/jazz-tools/src/middleware/auth.rs
@@ -137,6 +137,8 @@ impl From<TestClock> for AuthClock {
 pub struct AuthConfig {
     /// URL to fetch JWKS keys (production).
     pub jwks_url: Option<String>,
+    /// Cookie name used to read browser auth tokens during the WS upgrade.
+    pub auth_cookie_name: Option<String>,
     /// Whether local-first Ed25519 JWT auth is allowed (default: true for new apps).
     pub allow_local_first_auth: bool,
     /// Secret for backend session impersonation.
@@ -151,6 +153,7 @@ impl AuthConfig {
     /// Check if any auth is configured.
     pub fn is_configured(&self) -> bool {
         self.jwks_url.is_some()
+            || self.auth_cookie_name.is_some()
             || self.allow_local_first_auth
             || self.backend_secret.is_some()
             || self.admin_secret.is_some()
@@ -410,6 +413,26 @@ fn local_first_auth_error(message: String) -> UnauthenticatedResponse {
     } else {
         UnauthenticatedResponse::invalid(message)
     }
+}
+
+fn extract_cookie_value<'a>(cookie_header: &'a str, name: &str) -> Option<&'a str> {
+    cookie_header.split(';').find_map(|segment| {
+        let trimmed = segment.trim();
+        let (candidate_name, candidate_value) = trimmed.split_once('=')?;
+        if candidate_name == name && !candidate_value.is_empty() {
+            Some(candidate_value)
+        } else {
+            None
+        }
+    })
+}
+
+fn read_auth_token_from_cookie<'a>(headers: &'a HeaderMap, config: &AuthConfig) -> Option<&'a str> {
+    let cookie_name = config.auth_cookie_name.as_deref()?;
+    let cookie_header = headers
+        .get(axum::http::header::COOKIE)
+        .and_then(|value| value.to_str().ok())?;
+    extract_cookie_value(cookie_header, cookie_name).map(str::trim)
 }
 
 // ============================================================================
@@ -815,7 +838,7 @@ fn is_local_first_identity_proof(token: &str) -> bool {
 ///
 /// Priority:
 /// 1. Backend impersonation (X-Jazz-Backend-Secret + X-Jazz-Session)
-/// 2. JWT auth (Authorization: Bearer)
+/// 2. JWT auth (`Authorization: Bearer`, or auth cookie when configured)
 /// 3. No session
 ///
 /// When `jwks_cache` is provided, JWT validation uses the cache with on-demand
@@ -860,7 +883,7 @@ pub async fn extract_session(
     }
 
     // Priority 2: JWT auth
-    if let Some(auth_value) = headers.get(AUTHORIZATION).and_then(|v| v.to_str().ok()) {
+    let token = if let Some(auth_value) = headers.get(AUTHORIZATION).and_then(|v| v.to_str().ok()) {
         let Some(token) = auth_value.strip_prefix("Bearer ") else {
             return Err(UnauthenticatedResponse::invalid(
                 "Invalid Authorization header format",
@@ -871,7 +894,12 @@ pub async fn extract_session(
         if token.is_empty() {
             return Err(UnauthenticatedResponse::invalid("Empty bearer token"));
         }
+        Some(token)
+    } else {
+        read_auth_token_from_cookie(headers, config)
+    };
 
+    if let Some(token) = token {
         // Self-signed JWT path
         if is_local_first_identity_proof(token) {
             if !config.allow_local_first_auth {
@@ -1157,6 +1185,35 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_extract_session_jwt_cookie_fallback() {
+        let mut config = make_test_config();
+        config.auth_cookie_name = Some("jazz-auth".to_string());
+        let cache = test_jwks_cache();
+        let mut headers = HeaderMap::new();
+
+        let claims = JwtClaims {
+            sub: "cookie-user".to_string(),
+            iss: Some("https://issuer.example".to_string()),
+            jazz_principal_id: Some("principal-123".to_string()),
+            claims: serde_json::json!({ "role": "editor" }),
+            exp: None,
+            iat: None,
+        };
+        let token = make_jwt(&claims, TEST_JWKS_SECRET, TEST_JWKS_KID);
+
+        headers.insert(
+            axum::http::header::COOKIE,
+            format!("other=value; jazz-auth={token}").parse().unwrap(),
+        );
+
+        let result = extract_session(&headers, test_app_id(), &config, None, Some(&cache))
+            .await
+            .unwrap();
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().user_id, "principal-123");
+    }
+
+    #[tokio::test]
     async fn test_extract_session_jwt_uses_external_mapping_fallback() {
         let config = make_test_config();
         let cache = test_jwks_cache();
@@ -1358,6 +1415,7 @@ mod tests {
         assert!(result.is_err());
     }
 
+    #[cfg(feature = "test-utils")]
     #[tokio::test]
     async fn local_first_auth_expiry_uses_configured_test_clock() {
         let app_id = test_app_id();

--- a/crates/jazz-tools/src/routes.rs
+++ b/crates/jazz-tools/src/routes.rs
@@ -1261,12 +1261,17 @@ async fn health_handler() -> impl IntoResponse {
 /// Clients send an `AuthHandshake` binary frame (4-byte length prefix + JSON),
 /// receive a `ConnectedResponse` frame, then exchange binary frames
 /// bidirectionally until the connection closes.
-pub async fn ws_handler(ws: WebSocketUpgrade, State(state): State<Arc<ServerState>>) -> Response {
-    ws.on_upgrade(move |socket| handle_ws_connection(socket, state))
+pub async fn ws_handler(
+    ws: WebSocketUpgrade,
+    State(state): State<Arc<ServerState>>,
+    headers: HeaderMap,
+) -> Response {
+    ws.on_upgrade(move |socket| handle_ws_connection(socket, state, headers))
 }
 
 /// Outcome of authenticating a WS handshake — mirrors `ClientSetup` in
 /// the old `/sync` + `/events` handlers.
+#[derive(Debug)]
 enum WsClientSetup {
     Backend,
     Session(crate::query_manager::session::Session),
@@ -1283,6 +1288,7 @@ enum WsClientSetup {
 /// `ServerEvent::Error` frame before closing.
 async fn authenticate_ws_handshake(
     handshake: &crate::transport_manager::AuthHandshake,
+    request_headers: &HeaderMap,
     state: &Arc<ServerState>,
 ) -> Result<WsClientSetup, String> {
     use axum::http::HeaderValue;
@@ -1298,8 +1304,13 @@ async fn authenticate_ws_handshake(
         return Ok(WsClientSetup::Backend);
     }
 
-    // Build a synthetic HeaderMap from the handshake auth fields.
-    let mut headers = HeaderMap::new();
+    if request_uses_cookie_auth(handshake, request_headers, &state.auth_config) {
+        validate_ws_cookie_origin(request_headers)?;
+    }
+
+    // Build a synthetic HeaderMap from the handshake auth fields, layered on
+    // top of the original upgrade request so cookie-based auth remains visible.
+    let mut headers = request_headers.clone();
 
     if let Some(jwt) = &auth.jwt_token {
         let value = HeaderValue::from_str(&format!("Bearer {jwt}"))
@@ -1356,6 +1367,80 @@ async fn authenticate_ws_handshake(
     Ok(WsClientSetup::Session(session))
 }
 
+fn request_uses_cookie_auth(
+    handshake: &crate::transport_manager::AuthHandshake,
+    request_headers: &HeaderMap,
+    auth_config: &crate::middleware::AuthConfig,
+) -> bool {
+    let Some(cookie_name) = auth_config.auth_cookie_name.as_deref() else {
+        return false;
+    };
+
+    let has_explicit_auth = handshake.auth.jwt_token.is_some()
+        || handshake.auth.backend_secret.is_some()
+        || handshake.auth.backend_session.is_some()
+        || handshake.auth.admin_secret.is_some()
+        || request_headers
+            .get(axum::http::header::AUTHORIZATION)
+            .is_some()
+        || request_headers.get("X-Jazz-Backend-Secret").is_some()
+        || request_headers.get("X-Jazz-Session").is_some()
+        || request_headers.get("X-Jazz-Admin-Secret").is_some();
+
+    if has_explicit_auth {
+        return false;
+    }
+
+    request_cookie_value(request_headers, cookie_name).is_some()
+}
+
+fn request_cookie_value<'a>(headers: &'a HeaderMap, name: &str) -> Option<&'a str> {
+    let cookie_header = headers
+        .get(axum::http::header::COOKIE)
+        .and_then(|value| value.to_str().ok())?;
+
+    cookie_header.split(';').find_map(|segment| {
+        let trimmed = segment.trim();
+        let (candidate_name, candidate_value) = trimmed.split_once('=')?;
+        if candidate_name == name && !candidate_value.is_empty() {
+            Some(candidate_value)
+        } else {
+            None
+        }
+    })
+}
+
+fn validate_ws_cookie_origin(headers: &HeaderMap) -> Result<(), String> {
+    let host = headers
+        .get("X-Forwarded-Host")
+        .or_else(|| headers.get(axum::http::header::HOST))
+        .and_then(|value| value.to_str().ok())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| "Cookie auth requires Host header".to_string())?;
+
+    let origin = headers
+        .get(axum::http::header::ORIGIN)
+        .and_then(|value| value.to_str().ok())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| "Cookie auth requires Origin header".to_string())?;
+
+    let origin_uri: axum::http::Uri = origin
+        .parse()
+        .map_err(|_| "Cookie auth requires a valid Origin header".to_string())?;
+    let origin_authority = origin_uri
+        .authority()
+        .map(|authority| authority.as_str())
+        .ok_or_else(|| "Cookie auth requires an Origin authority".to_string())?;
+
+    if origin_authority.eq_ignore_ascii_case(host) {
+        Ok(())
+    } else {
+        Err("Cookie auth Origin must match Host".to_string())
+    }
+}
+
 /// Send a `ServerEvent::Error` frame on the socket, best-effort.
 async fn send_ws_error(socket: &mut WebSocket, message: &str) {
     use crate::jazz_transport::ErrorCode;
@@ -1372,7 +1457,11 @@ async fn send_ws_error(socket: &mut WebSocket, message: &str) {
     }
 }
 
-async fn handle_ws_connection(mut socket: WebSocket, state: Arc<ServerState>) {
+async fn handle_ws_connection(
+    mut socket: WebSocket,
+    state: Arc<ServerState>,
+    request_headers: HeaderMap,
+) {
     // 1. Read the first binary frame — expected to be AuthHandshake.
     let first = match socket.recv().await {
         Some(Ok(Message::Binary(b))) => b,
@@ -1408,7 +1497,7 @@ async fn handle_ws_connection(mut socket: WebSocket, state: Arc<ServerState>) {
     };
 
     // 3. Authenticate.
-    let setup = match authenticate_ws_handshake(&handshake, &state).await {
+    let setup = match authenticate_ws_handshake(&handshake, &request_headers, &state).await {
         Ok(s) => s,
         Err(msg) => {
             send_ws_error(&mut socket, &msg).await;
@@ -1823,6 +1912,88 @@ mod tests {
         // handshakes are rejected at the transport layer — covered fully in auth_test.rs
         // integration tests that connect over the wire.
         let _ = (handshake, client_registered);
+    }
+
+    #[tokio::test]
+    async fn ws_handshake_accepts_same_origin_cookie_auth() {
+        let token = mint_test_token("test-app");
+        let auth_config = AuthConfig {
+            backend_secret: Some("test-backend-secret".to_string()),
+            admin_secret: None,
+            allow_local_first_auth: true,
+            jwks_url: None,
+            auth_cookie_name: Some("jazz-auth".to_string()),
+            ..Default::default()
+        };
+        let state = ServerBuilder::new(AppId::from_name("test-app"))
+            .with_auth_config(auth_config)
+            .with_in_memory_storage()
+            .build()
+            .await
+            .expect("build sync test state")
+            .state;
+        let handshake = crate::transport_manager::AuthHandshake {
+            client_id: ClientId::new().to_string(),
+            auth: crate::transport_manager::AuthConfig::default(),
+            catalogue_state_hash: None,
+        };
+        let mut request_headers = HeaderMap::new();
+        request_headers.insert(axum::http::header::HOST, "example.test".parse().unwrap());
+        request_headers.insert(
+            axum::http::header::ORIGIN,
+            "https://example.test".parse().unwrap(),
+        );
+        request_headers.insert(
+            axum::http::header::COOKIE,
+            format!("jazz-auth={token}").parse().unwrap(),
+        );
+
+        let setup = authenticate_ws_handshake(&handshake, &request_headers, &state)
+            .await
+            .expect("cookie auth should succeed");
+
+        assert!(matches!(setup, WsClientSetup::Session(_)));
+    }
+
+    #[tokio::test]
+    async fn ws_handshake_rejects_cross_origin_cookie_auth() {
+        let token = mint_test_token("test-app");
+        let auth_config = AuthConfig {
+            backend_secret: Some("test-backend-secret".to_string()),
+            admin_secret: None,
+            allow_local_first_auth: true,
+            jwks_url: None,
+            auth_cookie_name: Some("jazz-auth".to_string()),
+            ..Default::default()
+        };
+        let state = ServerBuilder::new(AppId::from_name("test-app"))
+            .with_auth_config(auth_config)
+            .with_in_memory_storage()
+            .build()
+            .await
+            .expect("build sync test state")
+            .state;
+        let handshake = crate::transport_manager::AuthHandshake {
+            client_id: ClientId::new().to_string(),
+            auth: crate::transport_manager::AuthConfig::default(),
+            catalogue_state_hash: None,
+        };
+        let mut request_headers = HeaderMap::new();
+        request_headers.insert(axum::http::header::HOST, "example.test".parse().unwrap());
+        request_headers.insert(
+            axum::http::header::ORIGIN,
+            "https://evil.example".parse().unwrap(),
+        );
+        request_headers.insert(
+            axum::http::header::COOKIE,
+            format!("jazz-auth={token}").parse().unwrap(),
+        );
+
+        let error = authenticate_ws_handshake(&handshake, &request_headers, &state)
+            .await
+            .expect_err("cross-origin cookie auth should fail");
+
+        assert!(error.to_lowercase().contains("origin"));
     }
 
     #[tokio::test]

--- a/crates/jazz-tools/src/routes.rs
+++ b/crates/jazz-tools/src/routes.rs
@@ -1936,6 +1936,7 @@ mod tests {
             client_id: ClientId::new().to_string(),
             auth: crate::transport_manager::AuthConfig::default(),
             catalogue_state_hash: None,
+            declared_schema_hash: None,
         };
         let mut request_headers = HeaderMap::new();
         request_headers.insert(axum::http::header::HOST, "example.test".parse().unwrap());
@@ -1977,6 +1978,7 @@ mod tests {
             client_id: ClientId::new().to_string(),
             auth: crate::transport_manager::AuthConfig::default(),
             catalogue_state_hash: None,
+            declared_schema_hash: None,
         };
         let mut request_headers = HeaderMap::new();
         request_headers.insert(axum::http::header::HOST, "example.test".parse().unwrap());

--- a/crates/jazz-tools/src/server/builder.rs
+++ b/crates/jazz-tools/src/server/builder.rs
@@ -455,9 +455,10 @@ fn log_auth_config(auth_config: &AuthConfig, catalogue_authority: &CatalogueAuth
         }
     };
     info!(
-        "Auth configured: local_first={}, jwks={}, backend={}, admin={}, catalogue_authority={}",
+        "Auth configured: local_first={}, jwks={}, cookie={}, backend={}, admin={}, catalogue_authority={}",
         auth_config.allow_local_first_auth,
         auth_config.jwks_url.is_some(),
+        auth_config.auth_cookie_name.is_some(),
         auth_config.backend_secret.is_some(),
         auth_config.admin_secret.is_some(),
         authority_mode

--- a/crates/jazz-tools/src/server/testing.rs
+++ b/crates/jazz-tools/src/server/testing.rs
@@ -235,6 +235,7 @@ impl TestingServer {
             backend_secret: Some(backend_secret.clone()),
             admin_secret: Some(admin_secret.clone()),
             clock: auth_clock.clone(),
+            ..Default::default()
         };
 
         let server_builder = ServerBuilder::new(app_id).with_auth_config(auth_config);

--- a/packages/jazz-tools/src/runtime/auth-state.ts
+++ b/packages/jazz-tools/src/runtime/auth-state.ts
@@ -20,7 +20,7 @@ export function mapAuthReason(reason: string): AuthFailureReason {
 export type AuthState =
   | {
       status: "authenticated";
-      transport: "bearer" | "backend";
+      transport: "bearer" | "cookie" | "backend";
       session: Session | null;
     }
   | {
@@ -108,6 +108,36 @@ export function createAuthStateStore(input: ClientSessionInput, options?: AuthSt
       const nextState = deriveAuthenticatedState({
         appId: input.appId,
         jwtToken,
+        cookieSession: input.cookieSession,
+      });
+
+      const currentUserId = authUserId(state);
+      const nextUserId = authUserId(nextState);
+
+      if (currentUserId !== nextUserId) {
+        throw new Error(
+          "Changing auth principal on a live client is not supported. Recreate the Db.",
+        );
+      }
+
+      if (authStateEquals(state, nextState)) {
+        return state;
+      }
+
+      state = nextState;
+      emit();
+      return state;
+    },
+
+    applyCookieSession(cookieSession?: Session): AuthState {
+      if (options?.lockAuthenticatedState) {
+        return state;
+      }
+
+      const nextState = deriveAuthenticatedState({
+        appId: input.appId,
+        jwtToken: input.jwtToken,
+        cookieSession,
       });
 
       const currentUserId = authUserId(state);

--- a/packages/jazz-tools/src/runtime/client-session.test.ts
+++ b/packages/jazz-tools/src/runtime/client-session.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import type { Session } from "./context.js";
 import { resolveClientSessionSync, resolveClientSessionStateSync } from "./client-session.js";
 
 function toBase64Url(value: string): string {
@@ -15,6 +16,28 @@ function makeJwt(payload: Record<string, unknown>): string {
 }
 
 describe("client session resolution", () => {
+  it("uses a mirrored cookie session when provided", () => {
+    const session: Session = {
+      user_id: "cookie-user",
+      claims: {
+        role: "writer",
+        auth_mode: "external",
+        subject: "subject-123",
+        issuer: "https://issuer.example",
+      },
+    };
+
+    expect(
+      resolveClientSessionStateSync({
+        appId: "cookie-app",
+        cookieSession: session,
+      }),
+    ).toEqual({
+      transport: "cookie",
+      session,
+    });
+  });
+
   it("prefers jazz_principal_id from JWT when present", () => {
     const jwt = makeJwt({
       sub: "user-subject",

--- a/packages/jazz-tools/src/runtime/client-session.ts
+++ b/packages/jazz-tools/src/runtime/client-session.ts
@@ -3,9 +3,10 @@ import type { Session } from "./context.js";
 export interface ClientSessionInput {
   appId: string;
   jwtToken?: string;
+  cookieSession?: Session;
 }
 
-export type ClientSessionTransport = "bearer";
+export type ClientSessionTransport = "bearer" | "cookie";
 
 export interface ClientSessionState {
   transport: ClientSessionTransport | null;
@@ -42,25 +43,6 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function maybeBuffer(): BufferLike | undefined {
   return (globalThis as { Buffer?: BufferLike }).Buffer;
-}
-
-function utf8Encode(value: string): Uint8Array {
-  if (typeof TextEncoder !== "undefined") {
-    return new TextEncoder().encode(value);
-  }
-
-  const encoded = encodeURIComponent(value);
-  const bytes: number[] = [];
-  for (let i = 0; i < encoded.length; i += 1) {
-    const char = encoded[i]!;
-    if (char === "%") {
-      bytes.push(Number.parseInt(encoded.slice(i + 1, i + 3), 16));
-      i += 2;
-    } else {
-      bytes.push(char.charCodeAt(0));
-    }
-  }
-  return Uint8Array.from(bytes);
 }
 
 function base64UrlToBase64(input: string): string {
@@ -154,6 +136,13 @@ export function resolveClientSessionStateSync(config: ClientSessionInput): Clien
     return {
       transport: "bearer",
       session: jwtSession,
+    };
+  }
+
+  if (config.cookieSession) {
+    return {
+      transport: "cookie",
+      session: config.cookieSession,
     };
   }
 

--- a/packages/jazz-tools/src/runtime/client.test.ts
+++ b/packages/jazz-tools/src/runtime/client.test.ts
@@ -114,3 +114,37 @@ describe("JazzClient.updateAuthToken", () => {
     });
   });
 });
+
+describe("JazzClient.updateCookieSession", () => {
+  it("refreshes transport auth without requiring a JS-readable JWT", () => {
+    const runtime = makeFakeRuntime();
+    const client = JazzClient.connectWithRuntime(runtime as any, {
+      appId: "cookie-app",
+      schema: {},
+      serverUrl: "https://example.test",
+      cookieSession: {
+        user_id: "alice",
+        claims: {
+          role: "reader",
+          auth_mode: "external",
+          subject: "alice-subject",
+          issuer: "https://issuer.example",
+        },
+      },
+    });
+
+    client.updateCookieSession({
+      user_id: "alice",
+      claims: {
+        role: "writer",
+        auth_mode: "external",
+        subject: "alice-subject",
+        issuer: "https://issuer.example",
+      },
+    });
+
+    expect(runtime.updateAuth).toHaveBeenCalledTimes(1);
+    const arg = runtime.updateAuth.mock.calls[0][0] as string;
+    expect(JSON.parse(arg)).toMatchObject({ jwt_token: null });
+  });
+});

--- a/packages/jazz-tools/src/runtime/client.ts
+++ b/packages/jazz-tools/src/runtime/client.ts
@@ -1148,6 +1148,33 @@ export class JazzClient {
   private readonly acknowledgedRejectedBatchErrors = new Map<string, PersistedWriteRejectedError>();
   private shutdownPromise: Promise<void> | null = null;
 
+  private resolveSessionFromContext(): Session | null {
+    return resolveClientSessionStateSync({
+      appId: this.context.appId,
+      jwtToken: this.context.jwtToken,
+      cookieSession: this.context.cookieSession,
+    }).session;
+  }
+
+  private buildTransportAuthPayload(): {
+    jwt_token: string | null;
+    admin_secret?: string;
+    backend_secret?: string;
+  } {
+    const payload: {
+      jwt_token: string | null;
+      admin_secret?: string;
+      backend_secret?: string;
+    } = { jwt_token: this.context.jwtToken ?? null };
+    if (this.context.adminSecret) {
+      payload.admin_secret = this.context.adminSecret;
+    }
+    if (this.context.backendSecret) {
+      payload.backend_secret = this.context.backendSecret;
+    }
+    return payload;
+  }
+
   private constructor(
     runtime: Runtime,
     context: AppContext,
@@ -1158,10 +1185,7 @@ export class JazzClient {
     this.scheduler = getScheduler();
     this.context = context;
     this.defaultDurabilityTier = defaultDurabilityTier;
-    this.resolvedSession = resolveClientSessionStateSync({
-      appId: context.appId,
-      jwtToken: context.jwtToken,
-    }).session;
+    this.resolvedSession = this.resolveSessionFromContext();
 
     if (runtimeOptions?.onAuthFailure) {
       const handler = runtimeOptions.onAuthFailure;
@@ -1389,28 +1413,20 @@ export class JazzClient {
 
   updateAuthToken(jwtToken?: string): void {
     this.context.jwtToken = jwtToken;
-    this.resolvedSession = resolveClientSessionStateSync({
-      appId: this.context.appId,
-      jwtToken,
-    }).session;
+    this.resolvedSession = this.resolveSessionFromContext();
     // Push the refreshed credentials into the Rust transport. `updateAuth`
     // is optional on the Runtime interface because not every binding exposes
     // it yet; bindings that do will route this to TransportControl::UpdateAuth.
     // Carry forward admin/backend secrets from context — omitting them here
     // would deserialise to None on the Rust side and silently erase any
     // privileged credentials the transport was connected with.
-    const payload: {
-      jwt_token: string | null;
-      admin_secret?: string;
-      backend_secret?: string;
-    } = { jwt_token: jwtToken ?? null };
-    if (this.context.adminSecret) {
-      payload.admin_secret = this.context.adminSecret;
-    }
-    if (this.context.backendSecret) {
-      payload.backend_secret = this.context.backendSecret;
-    }
-    this.runtime.updateAuth?.(JSON.stringify(payload));
+    this.runtime.updateAuth?.(JSON.stringify(this.buildTransportAuthPayload()));
+  }
+
+  updateCookieSession(cookieSession?: Session): void {
+    this.context.cookieSession = cookieSession;
+    this.resolvedSession = this.resolveSessionFromContext();
+    this.runtime.updateAuth?.(JSON.stringify(this.buildTransportAuthPayload()));
   }
 
   private normalizeQueryExecutionOptions(

--- a/packages/jazz-tools/src/runtime/context.ts
+++ b/packages/jazz-tools/src/runtime/context.ts
@@ -81,6 +81,12 @@ export interface AppContext {
   jwtToken?: string;
 
   /**
+   * Mirrored session used for local permission evaluation when auth rides on
+   * an HttpOnly cookie instead of a JS-readable bearer token.
+   */
+  cookieSession?: Session;
+
+  /**
    * Backend secret for session impersonation.
    * Enables `forSession()` to act as any user.
    */

--- a/packages/jazz-tools/src/runtime/db.auth-state.test.ts
+++ b/packages/jazz-tools/src/runtime/db.auth-state.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { createDbFromClient } from "./db.js";
 import type { AuthState } from "./auth-state.js";
+import type { Session } from "./context.js";
 
 function toBase64Url(value: unknown): string {
   const encoded = Buffer.from(JSON.stringify(value), "utf8").toString("base64");
@@ -28,7 +29,45 @@ function makeDbWithJwt(jwtToken: string) {
   return { db, runtimeClient };
 }
 
+function makeDbWithCookieSession(cookieSession: Session) {
+  const runtimeClient = {
+    updateAuthToken: vi.fn(),
+    updateCookieSession: vi.fn(),
+  };
+
+  const db = createDbFromClient(
+    {
+      appId: "cookie-auth-app",
+      cookieSession,
+    },
+    runtimeClient as any,
+  );
+
+  return { db, runtimeClient };
+}
+
 describe("Db auth state", () => {
+  it("returns the initial cookie auth state", () => {
+    const { db } = makeDbWithCookieSession({
+      user_id: "alice",
+      claims: {
+        role: "reader",
+        auth_mode: "external",
+        subject: "alice-subject",
+        issuer: "https://issuer.example",
+      },
+    });
+
+    expect(db.getAuthState()).toMatchObject({
+      status: "authenticated",
+      transport: "cookie",
+      session: {
+        user_id: "alice",
+        claims: expect.objectContaining({ role: "reader" }),
+      },
+    });
+  });
+
   it("reports backend-scoped auth state for session-backed dbs", () => {
     const session = {
       user_id: "alice",
@@ -181,6 +220,49 @@ describe("Db auth state", () => {
       session: {
         user_id: "alice",
       },
+    });
+  });
+
+  it("updates mirrored cookie auth for the same principal", () => {
+    const { db, runtimeClient } = makeDbWithCookieSession({
+      user_id: "alice",
+      claims: {
+        role: "reader",
+        auth_mode: "external",
+        subject: "alice-subject",
+        issuer: "https://issuer.example",
+      },
+    });
+    const refreshed: Session = {
+      user_id: "alice",
+      claims: {
+        role: "writer",
+        auth_mode: "external",
+        subject: "alice-subject",
+        issuer: "https://issuer.example",
+      },
+    };
+    const states: AuthState[] = [];
+
+    const stop = db.onAuthChanged((state) => {
+      states.push(state);
+    });
+
+    db.updateCookieSession(refreshed);
+    stop();
+
+    expect(runtimeClient.updateCookieSession).toHaveBeenCalledWith(refreshed);
+    expect(db.getAuthState()).toMatchObject({
+      status: "authenticated",
+      transport: "cookie",
+      session: {
+        user_id: "alice",
+        claims: expect.objectContaining({ role: "writer" }),
+      },
+    });
+    expect(states.at(-1)).toMatchObject({
+      status: "authenticated",
+      transport: "cookie",
     });
   });
 });

--- a/packages/jazz-tools/src/runtime/db.local-first-auth.test.ts
+++ b/packages/jazz-tools/src/runtime/db.local-first-auth.test.ts
@@ -11,6 +11,19 @@ describe("DbConfig auth validation", () => {
     };
     await expect(createDb(config)).rejects.toThrow("mutually exclusive");
   });
+
+  it("rejects setting both jwtToken and cookieSession", async () => {
+    const { createDb } = await import("./db.js");
+    const config: DbConfig = {
+      appId: "test-app",
+      jwtToken: "some-jwt",
+      cookieSession: {
+        user_id: "alice",
+        claims: { role: "reader" },
+      },
+    };
+    await expect(createDb(config)).rejects.toThrow("mutually exclusive");
+  });
 });
 
 describe("getLocalFirstIdentityProof", () => {

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -87,6 +87,8 @@ export interface DbConfig {
   userBranch?: string;
   /** JWT token for server authentication */
   jwtToken?: string;
+  /** Mirrored session for local permission evaluation when sync auth uses cookies. */
+  cookieSession?: Session;
   /** Admin secret for catalogue sync */
   adminSecret?: string;
   /** Database name for OPFS persistence (browser only, default: appId) */
@@ -817,6 +819,30 @@ export class Db {
     return true;
   }
 
+  protected applyCookieSessionUpdate(session: Session | null): boolean {
+    const cookieSession = session ?? undefined;
+    const previousSession = this.config.cookieSession;
+    const previousState = this.authStateStore.getState();
+    const nextState = this.authStateStore.applyCookieSession(cookieSession);
+    const sessionChanged = JSON.stringify(previousSession) !== JSON.stringify(cookieSession);
+
+    if (!sessionChanged && nextState === previousState) {
+      return false;
+    }
+
+    this.config.cookieSession = cookieSession;
+
+    for (const client of this.clients.values()) {
+      client.updateCookieSession(cookieSession);
+    }
+
+    this.workerBridge?.updateAuth({
+      jwtToken: this.config.jwtToken,
+    });
+
+    return true;
+  }
+
   /**
    * Create a Db instance with pre-loaded WASM module.
    * @internal Use createDb() instead.
@@ -919,6 +945,7 @@ export class Db {
           env: this.config.env,
           userBranch: this.config.userBranch,
           jwtToken: this.config.jwtToken,
+          cookieSession: this.config.cookieSession,
           adminSecret: this.config.adminSecret,
           tier: this.worker ? undefined : "worker",
           // Keep worker-bridged browser clients on worker durability by default.
@@ -1446,6 +1473,10 @@ export class Db {
 
   updateAuthToken(jwtToken: string | null): void {
     this.applyAuthUpdate(jwtToken);
+  }
+
+  updateCookieSession(cookieSession: Session | null): void {
+    this.applyCookieSessionUpdate(cookieSession);
   }
 
   getAuthState(): AuthState {
@@ -2108,6 +2139,18 @@ class ClientBackedDb extends Db {
     this.runtimeClient.updateAuthToken(jwtToken ?? undefined);
   }
 
+  override updateCookieSession(cookieSession: Session | null): void {
+    if (this.hasScopedAuthState) {
+      return;
+    }
+
+    if (!this.applyCookieSessionUpdate(cookieSession)) {
+      return;
+    }
+
+    this.runtimeClient.updateCookieSession(cookieSession ?? undefined);
+  }
+
   override insert<T, Init>(table: TableProxy<T, Init>, data: Init, options?: CreateOptions): T {
     const runtimeSchema = normalizeRuntimeSchema(this.runtimeClient.getSchema());
     const inputSchema = resolveSchemaWithTable(table._schema, runtimeSchema, table._table);
@@ -2409,8 +2452,11 @@ function isBrowser(): boolean {
  * ```
  */
 export async function createDb(config: DbConfig): Promise<Db> {
-  if (config.auth && config.jwtToken) {
-    throw new Error("DbConfig error: auth and jwtToken are mutually exclusive");
+  if (config.auth && (config.jwtToken || config.cookieSession)) {
+    throw new Error("DbConfig error: auth, jwtToken, and cookieSession are mutually exclusive");
+  }
+  if (config.jwtToken && config.cookieSession) {
+    throw new Error("DbConfig error: jwtToken and cookieSession are mutually exclusive");
   }
 
   let resolvedConfig = { ...config };


### PR DESCRIPTION
## What changed

- add server-side `auth_cookie_name` support so `jazz-tools` can authenticate requests from an HttpOnly JWT cookie
- add browser-side `cookieSession` / `updateCookieSession(...)` support so local permission checks still work without exposing the auth token to JavaScript
- allow websocket handshakes to inherit request cookies and reject cookie-authenticated cross-origin upgrades
- add a changeset for the new `jazz-tools` auth flow

## Why

Bearer-only browser auth required the client to hold a JS-readable JWT. This change adds a cookie transport for more XSS-resistant browser deployments while preserving local permission evaluation through an explicit mirrored session.

## Impact

Browser apps can now use same-origin HttpOnly cookie auth with Jazz sync. The mirrored session remains local-only and non-authoritative; the server still authenticates from the cookie.

## Validation

- `pnpm lint`
- pre-commit hook: `cargo clippy`, `oxfmt`, `oxlint`, `rustfmt`
- earlier targeted feature verification on this branch:
- `pnpm --filter jazz-tools exec vitest run src/runtime/client.test.ts src/runtime/client-session.test.ts src/runtime/db.auth-state.test.ts`
- `cargo test -p jazz-tools --features server --lib cookie -- --nocapture`
