### PR TITLE
Support recursive gather relation seeds

### DIFF
--- a/.changeset/curly-owls-walk.md
+++ b/.changeset/curly-owls-walk.md
@@ -1,0 +1,8 @@
+---
+"jazz-tools": patch
+"jazz-wasm": patch
+"jazz-napi": patch
+"jazz-rn": patch
+---
+
+Support recursive gather seeds built from composed same-table relations, including hop-based and unioned permission closures.

--- a/crates/jazz-tools/src/query_manager/graph.rs
+++ b/crates/jazz-tools/src/query_manager/graph.rs
@@ -419,6 +419,52 @@ impl QueryGraph {
         self.add_node(node)
     }
 
+    fn absorb_compiled_subgraph(&mut self, other: Self) -> Option<NodeId> {
+        let offset = self.nodes.len() as u64;
+        let remap = |id: NodeId| NodeId(id.0 + offset);
+
+        for compact in other.nodes {
+            self.nodes.push(CompactNode {
+                node: compact.node,
+                inputs: compact.inputs.into_iter().map(remap).collect(),
+                outputs: compact.outputs.into_iter().map(remap).collect(),
+            });
+        }
+        self.dirty_bitmap.extend(other.dirty_bitmap);
+        self.index_scan_nodes.extend(
+            other
+                .index_scan_nodes
+                .into_iter()
+                .map(|(id, table, column)| (remap(id), table, column)),
+        );
+        self.array_subquery_tables.extend(
+            other
+                .array_subquery_tables
+                .into_iter()
+                .map(|(id, table)| (remap(id), table)),
+        );
+        self.policy_filter_tables.extend(
+            other
+                .policy_filter_tables
+                .into_iter()
+                .map(|(id, table)| (remap(id), table)),
+        );
+        self.magic_column_tables.extend(
+            other
+                .magic_column_tables
+                .into_iter()
+                .map(|(id, table)| (remap(id), table)),
+        );
+        self.recursive_relation_tables.extend(
+            other
+                .recursive_relation_tables
+                .into_iter()
+                .map(|(id, table)| (remap(id), table)),
+        );
+
+        Some(remap(other.output_node))
+    }
+
     /// Get a reference to a node by ID.
     fn get_node(&self, id: NodeId) -> Option<&GraphNode> {
         self.nodes.get(id.0 as usize).map(|c| &c.node)
@@ -539,26 +585,14 @@ impl QueryGraph {
         features: RelationCompileFeatures,
         row_policy_mode: RowPolicyMode,
     ) -> Option<Self> {
-        let default_branches = vec!["main".to_string()];
-        let branches: &[String] = if branches.is_empty() {
-            &default_branches
-        } else {
-            branches
-        };
-        let plan = lower_relation_to_execution_plan(
-            relation,
-            branches,
-            features.include_deleted,
-            features.array_subqueries,
-            features.select_columns,
-        )?;
-        validate_execution_plan(&plan, schema).ok()?;
         let schema_context = Self::default_schema_context(schema);
-        Self::compile_execution_plan_with_schema_context(
-            &plan,
+        Self::compile_relation_ir_with_schema_context_and_features(
+            relation,
             schema,
+            branches,
             session,
             &schema_context,
+            features,
             row_policy_mode,
         )
     }
@@ -591,6 +625,16 @@ impl QueryGraph {
         features: RelationCompileFeatures,
         row_policy_mode: RowPolicyMode,
     ) -> Option<Self> {
+        if let RelExpr::Union { inputs } = relation {
+            return Self::compile_relation_ir_union_with_schema_context_and_features(
+                inputs,
+                schema,
+                branches,
+                session,
+                schema_context,
+                row_policy_mode,
+            );
+        }
         let plan = lower_relation_to_execution_plan(
             relation,
             branches,
@@ -606,6 +650,72 @@ impl QueryGraph {
             schema_context,
             row_policy_mode,
         )
+    }
+
+    fn compile_relation_ir_union_with_schema_context_and_features(
+        inputs: &[RelExpr],
+        schema: &Schema,
+        branches: &[String],
+        session: Option<Session>,
+        schema_context: &SchemaContext,
+        row_policy_mode: RowPolicyMode,
+    ) -> Option<Self> {
+        let mut compiled_inputs = inputs
+            .iter()
+            .map(|input| {
+                Self::compile_relation_ir_with_schema_context_and_features(
+                    input,
+                    schema,
+                    branches,
+                    session.clone(),
+                    schema_context,
+                    RelationCompileFeatures::default(),
+                    row_policy_mode,
+                )
+            })
+            .collect::<Option<Vec<_>>>()?;
+        let first_graph = compiled_inputs.first()?;
+        let first_output = match first_graph
+            .nodes
+            .get(first_graph.output_node.0 as usize)
+            .map(|ctx| &ctx.node)
+        {
+            Some(GraphNode::Output(node)) => node.output_tuple_descriptor().clone(),
+            _ => return None,
+        };
+
+        let mut graph = QueryGraph::new(first_graph.table, first_output.combined_descriptor());
+        let mut branch_outputs = Vec::with_capacity(compiled_inputs.len());
+        for compiled in compiled_inputs.drain(..) {
+            let output = graph.absorb_compiled_subgraph(compiled)?;
+            let output_tuple_descriptor =
+                match graph.nodes.get(output.0 as usize).map(|ctx| &ctx.node) {
+                    Some(GraphNode::Output(node)) => node.output_tuple_descriptor().clone(),
+                    _ => return None,
+                };
+            if !descriptors_compatible_by_shape(
+                &first_output.combined_descriptor(),
+                &output_tuple_descriptor.combined_descriptor(),
+            ) {
+                return None;
+            }
+            branch_outputs.push(output);
+        }
+
+        let union_node = UnionNode::with_tuple_descriptor(first_output.clone());
+        let union_id = graph.add_node(GraphNode::Union(union_node));
+        for branch_output in branch_outputs {
+            graph.add_edge(union_id, branch_output);
+        }
+
+        graph.combined_descriptor = first_output.combined_descriptor();
+        graph.table_descriptors = vec![graph.combined_descriptor.clone()];
+        let output_node = OutputNode::with_tuple_descriptor(first_output, OutputMode::Delta);
+        let output_id = graph.add_node(GraphNode::Output(output_node));
+        graph.add_edge(output_id, union_id);
+        graph.output_node = output_id;
+
+        Some(graph)
     }
 
     fn compile_execution_plan_with_schema_context(
@@ -640,7 +750,7 @@ impl QueryGraph {
             plan.branches.clone()
         };
 
-        if !plan.joins.is_empty() {
+        if plan.seed_relation.is_some() || !plan.joins.is_empty() {
             return Self::compile_join_plan(
                 plan,
                 schema,
@@ -1402,82 +1512,111 @@ impl QueryGraph {
         let mut table_descriptors = vec![base_descriptor.clone()];
         let mut seen_tables: HashSet<String> = HashSet::new();
         seen_tables.insert(plan.table.as_str().to_string());
-
-        // Build pipeline for base table: per-branch IndexScan (+Union) -> Materialize.
-        let mut base_scan_ids = Vec::new();
-        for branch in &join_branches {
-            let branch_schema_hash = branch_schema_map.get(*branch).copied();
-            let Some(base_scan_table) =
-                translate_scan_table_name(schema_context, plan.table.as_str(), branch_schema_hash)
-            else {
-                continue;
-            };
-            let id_column = ColumnName::new("_id");
-            let base_scan = IndexScanNode::new_with_branch(
-                base_scan_table,
-                id_column,
-                *branch,
-                ScanCondition::All,
-                base_descriptor.clone(),
-            );
-            let base_scan_id = graph.add_node(GraphNode::IndexScan(base_scan));
-            graph
-                .index_scan_nodes
-                .push((base_scan_id, base_scan_table, id_column));
-            base_scan_ids.push(base_scan_id);
-        }
-        let base_scan_output = if base_scan_ids.len() > 1 {
-            let union_node = UnionNode::new();
-            let union_id = graph.add_node(GraphNode::Union(union_node));
-            for scan_id in base_scan_ids {
-                graph.add_edge(union_id, scan_id);
-            }
-            union_id
-        } else {
-            *base_scan_ids.first()?
-        };
-
-        let base_tuple_desc = TupleDescriptor::single_with_materialization(
-            plan.base_scope.as_str(),
-            base_descriptor.clone(),
-            true,
-        );
-        let base_mat = MaterializeNode::new_all(base_tuple_desc);
-        let base_mat_id = graph.add_node(GraphNode::Materialize(base_mat));
-        graph.add_edge(base_mat_id, base_scan_output);
-
-        // Track current left side descriptor (accumulates columns from joins)
-        let mut left_id = base_mat_id;
-        if let (Some(session), Some(policy)) = (
-            &session,
-            effective_select_policy(base_table_schema, row_policy_mode),
-        ) {
-            let branch_for_policy = branches
-                .first()
-                .cloned()
-                .unwrap_or_else(|| "main".to_string());
-            let policy_node = PolicyFilterNode::new_with_branch_and_policy_mode(
-                base_descriptor.clone(),
-                policy,
+        let (mut left_id, mut left_descriptor) = if let Some(seed_relation) = &plan.seed_relation {
+            let seed_graph = Self::compile_relation_ir_with_schema_context_and_features(
+                seed_relation,
+                schema,
+                branches,
                 session.clone(),
-                schema.clone(),
-                plan.table.as_str(),
-                branch_for_policy,
+                schema_context,
+                RelationCompileFeatures::default(),
                 row_policy_mode,
-            );
-            let inherits_tables: Vec<TableName> = policy_node
-                .inherits_tables()
-                .iter()
-                .map(TableName::new)
-                .collect();
-            let policy_id = graph.add_node(GraphNode::PolicyFilter(policy_node));
-            graph.add_edge(policy_id, left_id);
-            for inherits_table in inherits_tables {
-                graph.policy_filter_tables.push((policy_id, inherits_table));
+            )?;
+            let seed_output_id = graph.absorb_compiled_subgraph(seed_graph)?;
+            let seed_output_descriptor = match graph
+                .nodes
+                .get(seed_output_id.0 as usize)
+                .map(|ctx| &ctx.node)
+            {
+                Some(GraphNode::Output(node)) => {
+                    node.output_tuple_descriptor().combined_descriptor()
+                }
+                _ => return None,
+            };
+            if !descriptors_compatible_by_shape(&base_descriptor, &seed_output_descriptor) {
+                return None;
             }
-            left_id = policy_id;
-        }
-        let mut left_descriptor = base_descriptor.clone();
+            table_descriptors[0] = seed_output_descriptor.clone();
+            (seed_output_id, seed_output_descriptor)
+        } else {
+            // Build pipeline for base table: per-branch IndexScan (+Union) -> Materialize.
+            let mut base_scan_ids = Vec::new();
+            for branch in &join_branches {
+                let branch_schema_hash = branch_schema_map.get(*branch).copied();
+                let Some(base_scan_table) = translate_scan_table_name(
+                    schema_context,
+                    plan.table.as_str(),
+                    branch_schema_hash,
+                ) else {
+                    continue;
+                };
+                let id_column = ColumnName::new("_id");
+                let base_scan = IndexScanNode::new_with_branch(
+                    base_scan_table,
+                    id_column,
+                    *branch,
+                    ScanCondition::All,
+                    base_descriptor.clone(),
+                );
+                let base_scan_id = graph.add_node(GraphNode::IndexScan(base_scan));
+                graph
+                    .index_scan_nodes
+                    .push((base_scan_id, base_scan_table, id_column));
+                base_scan_ids.push(base_scan_id);
+            }
+            let base_scan_output = if base_scan_ids.len() > 1 {
+                let union_node = UnionNode::new();
+                let union_id = graph.add_node(GraphNode::Union(union_node));
+                for scan_id in base_scan_ids {
+                    graph.add_edge(union_id, scan_id);
+                }
+                union_id
+            } else {
+                *base_scan_ids.first()?
+            };
+
+            let base_tuple_desc = TupleDescriptor::single_with_materialization(
+                plan.base_scope.as_str(),
+                base_descriptor.clone(),
+                true,
+            );
+            let base_mat = MaterializeNode::new_all(base_tuple_desc);
+            let base_mat_id = graph.add_node(GraphNode::Materialize(base_mat));
+            graph.add_edge(base_mat_id, base_scan_output);
+
+            // Track current left side descriptor (accumulates columns from joins)
+            let mut left_id = base_mat_id;
+            if let (Some(session), Some(policy)) = (
+                &session,
+                effective_select_policy(base_table_schema, row_policy_mode),
+            ) {
+                let branch_for_policy = branches
+                    .first()
+                    .cloned()
+                    .unwrap_or_else(|| "main".to_string());
+                let policy_node = PolicyFilterNode::new_with_branch_and_policy_mode(
+                    base_descriptor.clone(),
+                    policy,
+                    session.clone(),
+                    schema.clone(),
+                    plan.table.as_str(),
+                    branch_for_policy,
+                    row_policy_mode,
+                );
+                let inherits_tables: Vec<TableName> = policy_node
+                    .inherits_tables()
+                    .iter()
+                    .map(TableName::new)
+                    .collect();
+                let policy_id = graph.add_node(GraphNode::PolicyFilter(policy_node));
+                graph.add_edge(policy_id, left_id);
+                for inherits_table in inherits_tables {
+                    graph.policy_filter_tables.push((policy_id, inherits_table));
+                }
+                left_id = policy_id;
+            }
+            (left_id, base_descriptor.clone())
+        };
 
         if let Some(recursive_spec) = &plan.recursive
             && let Some((node, new_descriptor, step_table)) = graph.compile_recursive_relation(
@@ -2677,6 +2816,12 @@ fn ensure_relation_tables_exist(
             } else {
                 Err(QueryCompileError::UnknownTable(*table))
             }
+        }
+        RelExpr::Union { inputs } => {
+            for input in inputs {
+                ensure_relation_tables_exist(input, schema)?;
+            }
+            Ok(())
         }
         RelExpr::Filter { input, .. }
         | RelExpr::Project { input, .. }
@@ -4089,6 +4234,203 @@ mod tests {
         );
         assert_eq!(graph.recursive_relation_tables.len(), 1);
         assert_eq!(graph.recursive_relation_tables[0].1.as_str(), "team_edges");
+    }
+
+    #[test]
+    fn compile_query_with_relation_ir_gather_join_seed_uses_recursive_node() {
+        let schema = recursive_hop_schema();
+        let relation = RelExpr::Gather {
+            seed: Box::new(RelExpr::Project {
+                input: Box::new(RelExpr::Join {
+                    left: Box::new(RelExpr::Filter {
+                        input: Box::new(RelExpr::TableScan {
+                            table: TableName::new("team_edges"),
+                        }),
+                        predicate: PredicateExpr::Cmp {
+                            left: ColumnRef::scoped("team_edges", "child_team"),
+                            op: PredicateCmpOp::Eq,
+                            right: ValueRef::Literal(Value::Integer(1)),
+                        },
+                    }),
+                    right: Box::new(RelExpr::TableScan {
+                        table: TableName::new("teams"),
+                    }),
+                    on: vec![JoinCondition {
+                        left: ColumnRef::scoped("team_edges", "parent_team"),
+                        right: ColumnRef::scoped("__seed_hop_0", "id"),
+                    }],
+                    join_kind: crate::query_manager::relation_ir::JoinKind::Inner,
+                }),
+                columns: vec![ProjectColumn {
+                    alias: "id".to_string(),
+                    expr: ProjectExpr::Column(ColumnRef::scoped("__seed_hop_0", "id")),
+                }],
+            }),
+            step: Box::new(RelExpr::Project {
+                input: Box::new(RelExpr::Join {
+                    left: Box::new(RelExpr::Filter {
+                        input: Box::new(RelExpr::TableScan {
+                            table: TableName::new("team_edges"),
+                        }),
+                        predicate: PredicateExpr::Cmp {
+                            left: ColumnRef::scoped("team_edges", "child_team"),
+                            op: PredicateCmpOp::Eq,
+                            right: ValueRef::RowId(RowIdRef::Frontier),
+                        },
+                    }),
+                    right: Box::new(RelExpr::TableScan {
+                        table: TableName::new("teams"),
+                    }),
+                    on: vec![JoinCondition {
+                        left: ColumnRef::scoped("team_edges", "parent_team"),
+                        right: ColumnRef::scoped("__recursive_hop_0", "id"),
+                    }],
+                    join_kind: crate::query_manager::relation_ir::JoinKind::Inner,
+                }),
+                columns: vec![ProjectColumn {
+                    alias: "id".to_string(),
+                    expr: ProjectExpr::Column(ColumnRef::scoped("__recursive_hop_0", "id")),
+                }],
+            }),
+            frontier_key: KeyRef::RowId(RowIdRef::Current),
+            max_depth: 8,
+            dedupe_key: vec![KeyRef::RowId(RowIdRef::Current)],
+        };
+
+        let branches = vec!["main".to_string()];
+        let graph = QueryGraph::compile_relation_ir(&relation, &schema, &branches, None)
+            .expect("Graph should compile");
+        assert!(
+            has_recursive_relation_node(&graph),
+            "Gather relation IR with join seed should compile to RecursiveRelationNode"
+        );
+        assert_eq!(graph.recursive_relation_tables.len(), 1);
+        assert_eq!(graph.recursive_relation_tables[0].1.as_str(), "team_edges");
+    }
+
+    #[test]
+    fn compile_query_with_relation_ir_gather_union_seed_uses_recursive_node() {
+        let schema = recursive_hop_schema();
+        let relation = RelExpr::Gather {
+            seed: Box::new(RelExpr::Union {
+                inputs: vec![
+                    RelExpr::Project {
+                        input: Box::new(RelExpr::Join {
+                            left: Box::new(RelExpr::Filter {
+                                input: Box::new(RelExpr::TableScan {
+                                    table: TableName::new("team_edges"),
+                                }),
+                                predicate: PredicateExpr::Cmp {
+                                    left: ColumnRef::scoped("team_edges", "child_team"),
+                                    op: PredicateCmpOp::Eq,
+                                    right: ValueRef::Literal(Value::Integer(1)),
+                                },
+                            }),
+                            right: Box::new(RelExpr::TableScan {
+                                table: TableName::new("teams"),
+                            }),
+                            on: vec![JoinCondition {
+                                left: ColumnRef::scoped("team_edges", "parent_team"),
+                                right: ColumnRef::scoped("__seed_hop_0", "id"),
+                            }],
+                            join_kind: crate::query_manager::relation_ir::JoinKind::Inner,
+                        }),
+                        columns: vec![ProjectColumn {
+                            alias: "id".to_string(),
+                            expr: ProjectExpr::Column(ColumnRef::scoped("__seed_hop_0", "id")),
+                        }],
+                    },
+                    RelExpr::Gather {
+                        seed: Box::new(RelExpr::Filter {
+                            input: Box::new(RelExpr::TableScan {
+                                table: TableName::new("teams"),
+                            }),
+                            predicate: PredicateExpr::Cmp {
+                                left: ColumnRef::scoped("teams", "name"),
+                                op: PredicateCmpOp::Eq,
+                                right: ValueRef::Literal(Value::Text("seed".to_string())),
+                            },
+                        }),
+                        step: Box::new(RelExpr::Project {
+                            input: Box::new(RelExpr::Join {
+                                left: Box::new(RelExpr::Filter {
+                                    input: Box::new(RelExpr::TableScan {
+                                        table: TableName::new("team_edges"),
+                                    }),
+                                    predicate: PredicateExpr::Cmp {
+                                        left: ColumnRef::scoped("team_edges", "child_team"),
+                                        op: PredicateCmpOp::Eq,
+                                        right: ValueRef::RowId(RowIdRef::Frontier),
+                                    },
+                                }),
+                                right: Box::new(RelExpr::TableScan {
+                                    table: TableName::new("teams"),
+                                }),
+                                on: vec![JoinCondition {
+                                    left: ColumnRef::scoped("team_edges", "parent_team"),
+                                    right: ColumnRef::scoped("__recursive_hop_0", "id"),
+                                }],
+                                join_kind: crate::query_manager::relation_ir::JoinKind::Inner,
+                            }),
+                            columns: vec![ProjectColumn {
+                                alias: "id".to_string(),
+                                expr: ProjectExpr::Column(ColumnRef::scoped(
+                                    "__recursive_hop_0",
+                                    "id",
+                                )),
+                            }],
+                        }),
+                        frontier_key: KeyRef::RowId(RowIdRef::Current),
+                        max_depth: 8,
+                        dedupe_key: vec![KeyRef::RowId(RowIdRef::Current)],
+                    },
+                ],
+            }),
+            step: Box::new(RelExpr::Project {
+                input: Box::new(RelExpr::Join {
+                    left: Box::new(RelExpr::Filter {
+                        input: Box::new(RelExpr::TableScan {
+                            table: TableName::new("team_edges"),
+                        }),
+                        predicate: PredicateExpr::Cmp {
+                            left: ColumnRef::scoped("team_edges", "child_team"),
+                            op: PredicateCmpOp::Eq,
+                            right: ValueRef::RowId(RowIdRef::Frontier),
+                        },
+                    }),
+                    right: Box::new(RelExpr::TableScan {
+                        table: TableName::new("teams"),
+                    }),
+                    on: vec![JoinCondition {
+                        left: ColumnRef::scoped("team_edges", "parent_team"),
+                        right: ColumnRef::scoped("__recursive_hop_0", "id"),
+                    }],
+                    join_kind: crate::query_manager::relation_ir::JoinKind::Inner,
+                }),
+                columns: vec![ProjectColumn {
+                    alias: "id".to_string(),
+                    expr: ProjectExpr::Column(ColumnRef::scoped("__recursive_hop_0", "id")),
+                }],
+            }),
+            frontier_key: KeyRef::RowId(RowIdRef::Current),
+            max_depth: 8,
+            dedupe_key: vec![KeyRef::RowId(RowIdRef::Current)],
+        };
+
+        let branches = vec!["main".to_string()];
+        let graph = QueryGraph::compile_relation_ir(&relation, &schema, &branches, None)
+            .expect("Graph should compile");
+        assert!(
+            has_recursive_relation_node(&graph),
+            "Gather relation IR with union seed should compile to RecursiveRelationNode"
+        );
+        assert_eq!(graph.recursive_relation_tables.len(), 2);
+        assert!(
+            graph
+                .nodes
+                .iter()
+                .any(|ctx| matches!(&ctx.node, GraphNode::Union(_)))
+        );
     }
 
     #[test]

--- a/crates/jazz-tools/src/query_manager/graph_nodes/policy_eval.rs
+++ b/crates/jazz-tools/src/query_manager/graph_nodes/policy_eval.rs
@@ -527,6 +527,11 @@ fn collect_relation_tables(rel: &RelExpr, tables: &mut HashSet<String>) {
         RelExpr::TableScan { table } => {
             tables.insert(table.as_str().to_string());
         }
+        RelExpr::Union { inputs } => {
+            for input in inputs {
+                collect_relation_tables(input, tables);
+            }
+        }
         RelExpr::Filter { input, .. }
         | RelExpr::Project { input, .. }
         | RelExpr::Distinct { input, .. }

--- a/crates/jazz-tools/src/query_manager/policy.rs
+++ b/crates/jazz-tools/src/query_manager/policy.rs
@@ -1403,6 +1403,20 @@ pub fn bind_relation_refs(
                     outer_row_id,
                 )?,
             }),
+            RelExpr::Union { inputs } => Some(RelExpr::Union {
+                inputs: inputs
+                    .iter()
+                    .map(|input| {
+                        bind_rel_expr(
+                            input,
+                            outer_content,
+                            outer_descriptor,
+                            session,
+                            outer_row_id,
+                        )
+                    })
+                    .collect::<Option<Vec<_>>>()?,
+            }),
             RelExpr::Join {
                 left,
                 right,

--- a/crates/jazz-tools/src/query_manager/relation_ir.rs
+++ b/crates/jazz-tools/src/query_manager/relation_ir.rs
@@ -147,6 +147,9 @@ pub enum RelExpr {
         input: Box<RelExpr>,
         predicate: PredicateExpr,
     },
+    Union {
+        inputs: Vec<RelExpr>,
+    },
     Join {
         left: Box<RelExpr>,
         right: Box<RelExpr>,
@@ -225,6 +228,12 @@ pub fn canonicalize_rel_expr(expr: RelExpr) -> Result<RelExpr, RelationIrError> 
         RelExpr::Filter { input, predicate } => Ok(RelExpr::Filter {
             input: Box::new(canonicalize_rel_expr(*input)?),
             predicate: canonicalize_predicate(predicate),
+        }),
+        RelExpr::Union { inputs } => Ok(RelExpr::Union {
+            inputs: inputs
+                .into_iter()
+                .map(canonicalize_rel_expr)
+                .collect::<Result<Vec<_>, _>>()?,
         }),
         RelExpr::Join {
             left,
@@ -422,6 +431,31 @@ mod tests {
 
         let encoded = serde_json::to_string(&expr).expect("serialize relation IR");
         let decoded: RelExpr = serde_json::from_str(&encoded).expect("deserialize relation IR");
+        assert_eq!(decoded, expr);
+    }
+
+    #[test]
+    fn rel_expr_union_roundtrip_json() {
+        let expr = RelExpr::Union {
+            inputs: vec![
+                RelExpr::TableScan {
+                    table: TableName::new("teams"),
+                },
+                RelExpr::Filter {
+                    input: Box::new(RelExpr::TableScan {
+                        table: TableName::new("teams"),
+                    }),
+                    predicate: PredicateExpr::Cmp {
+                        left: ColumnRef::unscoped("kind"),
+                        op: PredicateCmpOp::Eq,
+                        right: ValueRef::Literal(Value::Text("individual".to_string())),
+                    },
+                },
+            ],
+        };
+
+        let encoded = serde_json::to_string(&expr).expect("serialize union relation IR");
+        let decoded: RelExpr = serde_json::from_str(&encoded).expect("deserialize union relation");
         assert_eq!(decoded, expr);
     }
 

--- a/crates/jazz-tools/src/query_manager/relation_ir_query_plan.rs
+++ b/crates/jazz-tools/src/query_manager/relation_ir_query_plan.rs
@@ -33,6 +33,7 @@ struct RuntimeCorePlan {
     joins: Vec<JoinSpec>,
     result_element_index: Option<usize>,
     recursive: Option<RecursiveSpec>,
+    seed_relation: Option<RelExpr>,
     project_columns: Option<Vec<ProjectColumn>>,
 }
 
@@ -44,6 +45,7 @@ pub(crate) struct ExecutionQueryPlan {
     pub disjuncts: Vec<Conjunction>,
     pub joins: Vec<JoinSpec>,
     pub recursive: Option<RecursiveSpec>,
+    pub seed_relation: Option<RelExpr>,
     pub result_element_index: Option<usize>,
     pub order_by: Vec<(String, SortDirection)>,
     pub offset: usize,
@@ -427,10 +429,7 @@ fn builder_select_columns_to_project_columns(columns: Vec<String>) -> Vec<Projec
 }
 
 fn parse_gather_core(seed: &RelExpr, step: &RelExpr, max_depth: usize) -> Option<RuntimeCorePlan> {
-    let seed_info = extract_linear_join_info(seed)?;
-    if !seed_info.joins.is_empty() {
-        return None;
-    }
+    let simple_seed = extract_linear_join_info(seed).filter(|info| info.joins.is_empty());
 
     let (step_core, step_projection) = match step {
         RelExpr::Project { input, columns } => (input.as_ref(), Some(columns.as_slice())),
@@ -445,6 +444,7 @@ fn parse_gather_core(seed: &RelExpr, step: &RelExpr, max_depth: usize) -> Option
             join_kind,
         } => (left, right, on, join_kind),
         _ => {
+            let seed_info = simple_seed.as_ref()?;
             let mut step_predicates = Vec::new();
             let mut select_columns = if let Some(columns) = step_projection {
                 Some(project_columns_to_select(columns)?)
@@ -471,10 +471,11 @@ fn parse_gather_core(seed: &RelExpr, step: &RelExpr, max_depth: usize) -> Option
             return Some(RuntimeCorePlan {
                 table: seed_info.base_table,
                 base_scope: seed_info.scope_order[0].clone(),
-                disjuncts: seed_info.disjuncts,
+                disjuncts: seed_info.disjuncts.clone(),
                 joins: Vec::new(),
                 result_element_index: None,
                 recursive: Some(recursive),
+                seed_relation: None,
                 project_columns: None,
             });
         }
@@ -545,13 +546,30 @@ fn parse_gather_core(seed: &RelExpr, step: &RelExpr, max_depth: usize) -> Option
         }
     };
 
+    let (table, base_scope, disjuncts, seed_relation) = if let Some(seed_info) = simple_seed {
+        (
+            seed_info.base_table,
+            seed_info.scope_order[0].clone(),
+            seed_info.disjuncts,
+            None,
+        )
+    } else {
+        (
+            step_hop_table,
+            step_hop_table.as_str().to_string(),
+            dnf_true(),
+            Some(seed.clone()),
+        )
+    };
+
     Some(RuntimeCorePlan {
-        table: seed_info.base_table,
-        base_scope: seed_info.scope_order[0].clone(),
-        disjuncts: seed_info.disjuncts,
+        table,
+        base_scope,
+        disjuncts,
         joins: Vec::new(),
         result_element_index: None,
         recursive: Some(recursive),
+        seed_relation,
         project_columns: None,
     })
 }
@@ -688,6 +706,7 @@ fn parse_runtime_core_plan(core: &RelExpr) -> Option<RuntimeCorePlan> {
                 joins: linear.joins.clone(),
                 result_element_index,
                 recursive: None,
+                seed_relation: None,
                 project_columns: result_element_index.is_none().then_some(normalized_columns),
             })
         }
@@ -704,6 +723,7 @@ fn parse_runtime_core_plan(core: &RelExpr) -> Option<RuntimeCorePlan> {
                 joins: linear.joins,
                 result_element_index: None,
                 recursive: None,
+                seed_relation: None,
                 project_columns: None,
             })
         }
@@ -779,6 +799,7 @@ pub(crate) fn lower_relation_to_execution_plan(
         disjuncts: core_plan.disjuncts,
         joins: core_plan.joins,
         recursive: core_plan.recursive,
+        seed_relation: core_plan.seed_relation,
         result_element_index: core_plan.result_element_index,
         order_by: envelope.order_by,
         offset: envelope.offset,

--- a/packages/jazz-tools/src/ir.ts
+++ b/packages/jazz-tools/src/ir.ts
@@ -58,6 +58,7 @@ export type RelOrderByExpr = {
 export type RelExpr =
   | { TableScan: { table: string } }
   | { Filter: { input: RelExpr; predicate: RelPredicateExpr } }
+  | { Union: { inputs: RelExpr[] } }
   | { Join: { left: RelExpr; right: RelExpr; on: RelJoinCondition[]; join_kind: RelJoinKind } }
   | { Project: { input: RelExpr; columns: RelProjectColumn[] } }
   | {

--- a/packages/jazz-tools/src/permissions/index.test.ts
+++ b/packages/jazz-tools/src/permissions/index.test.ts
@@ -946,6 +946,115 @@ describe("permissions DSL", () => {
     });
   });
 
+  it("allows gather(...) to start from a same-table hop relation seed", () => {
+    let relation: PermissionRelation | undefined;
+    definePermissions(app, ({ policy }) => {
+      const directParents = policy.team_team_edges
+        .where({ child_team: "team-a" })
+        .hopTo("parent_team");
+      relation = directParents.gather({
+        step: ({ current }) =>
+          policy.team_team_edges.where({ child_team: current }).hopTo("parent_team"),
+        maxDepth: 3,
+      });
+      return [];
+    });
+    if (!relation) {
+      throw new Error("Expected recursive relation to be initialized.");
+    }
+
+    const ir = toLegacyRelExprForTest(relationToIr(relation));
+    expect(ir.type).toBe("Gather");
+    if (ir.type !== "Gather") {
+      throw new Error("Expected gather relation IR.");
+    }
+    expect(ir.seed.type).toBe("Project");
+    if (ir.seed.type !== "Project") {
+      throw new Error("Expected projected seed relation IR.");
+    }
+    expect(ir.seed.input.type).toBe("Filter");
+    if (ir.seed.input.type !== "Filter") {
+      throw new Error("Expected filtered hop seed relation IR.");
+    }
+    expect(ir.seed.input.input.type).toBe("Join");
+    if (ir.seed.input.input.type !== "Join") {
+      throw new Error("Expected hop seed join relation IR.");
+    }
+  });
+
+  it("allows gather(...) to start from a union of same-table relations", () => {
+    let relation: PermissionRelation | undefined;
+    definePermissions(app, ({ policy }) => {
+      const directParents = policy.team_team_edges
+        .where({ child_team: "team-a" })
+        .hopTo("parent_team");
+      const adminReachableTeams = policy.teams.gather({
+        start: { kind: "individual" },
+        step: ({ current }) =>
+          policy.team_team_edges.where({ child_team: current }).hopTo("parent_team"),
+        maxDepth: 3,
+      });
+      relation = policy.union([directParents, adminReachableTeams]).gather({
+        step: ({ current }) =>
+          policy.team_team_edges.where({ child_team: current }).hopTo("parent_team"),
+        maxDepth: 3,
+      });
+      return [];
+    });
+    if (!relation) {
+      throw new Error("Expected recursive relation to be initialized.");
+    }
+
+    const ir = toLegacyRelExprForTest(relationToIr(relation));
+    expect(ir.type).toBe("Gather");
+    if (ir.type !== "Gather") {
+      throw new Error("Expected gather relation IR.");
+    }
+    expect(ir.seed.type).toBe("Union");
+    if (ir.seed.type !== "Union") {
+      throw new Error("Expected union seed relation IR.");
+    }
+    expect(ir.seed.inputs).toHaveLength(2);
+    expect(ir.seed.inputs[0]?.type).toBe("Project");
+    expect(ir.seed.inputs[1]?.type).toBe("Gather");
+  });
+
+  it("supports qualified gather(...) start columns via implicit related-table joins", () => {
+    let relation: PermissionRelation | undefined;
+    definePermissions(app, ({ policy }) => {
+      relation = policy.teams.gather({
+        start: { "team_team_edges.child_team": "team-a" },
+        step: ({ current }) =>
+          policy.team_team_edges.where({ child_team: current }).hopTo("parent_team"),
+        maxDepth: 3,
+      });
+      return [];
+    });
+    if (!relation) {
+      throw new Error("Expected recursive relation to be initialized.");
+    }
+
+    const ir = toLegacyRelExprForTest(relationToIr(relation));
+    expect(ir.type).toBe("Gather");
+    if (ir.type !== "Gather") {
+      throw new Error("Expected gather relation IR.");
+    }
+    expect(ir.seed.type).toBe("Filter");
+    if (ir.seed.type !== "Filter") {
+      throw new Error("Expected filtered seed relation IR.");
+    }
+    expect(ir.seed.input.type).toBe("Join");
+    if (ir.seed.input.type !== "Join") {
+      throw new Error("Expected joined seed relation IR.");
+    }
+    expect(ir.seed.predicate).toEqual({
+      type: "Cmp",
+      left: { scope: "__join_0", column: "child_team" },
+      op: "Eq",
+      right: { type: "Literal", value: "team-a" },
+    });
+  });
+
   it("compiles policy.exists(relation) to ExistsRel in definePermissions", () => {
     const compiled = definePermissions(app, ({ policy, session }) => {
       const reachableTeams = policy.teams.gather({
@@ -999,6 +1108,17 @@ describe("permissions DSL", () => {
         return [policy.todos.allowRead.where(policy.exists(reachableTeams))];
       }),
     ).toThrow(/where condition bound to current/i);
+
+    expect(() =>
+      definePermissions(app, ({ policy, session }) => {
+        const reachableTeams = policy.teams.gather({
+          start: { "team_team_edges.id": session.userId },
+          step: ({ current }) =>
+            policy.team_team_edges.where({ child_team: current }).hopTo("parent_team"),
+        });
+        return [policy.todos.allowRead.where(policy.exists(reachableTeams))];
+      }),
+    ).toThrow(/qualified.*start|ambiguous/i);
   });
 
   it("resolves allowedTo without Id suffix to the FK column", () => {

--- a/packages/jazz-tools/src/permissions/index.ts
+++ b/packages/jazz-tools/src/permissions/index.ts
@@ -116,13 +116,24 @@ interface RelationFilterEntry {
 }
 
 interface RelationExprState {
-  kind: "table" | "recursive";
+  kind: "table" | "recursive" | "union";
   outputTable: string;
   base: RelExpr;
   initialScope: string;
   filters: RelationFilterEntry[];
   joins: RelationJoinSpec[];
   selectMap?: Record<string, string>;
+}
+
+function relationJoinAlias(
+  kind: RelationExprState["kind"],
+  join: RelationJoinSpec,
+  index: number,
+): string {
+  if (kind === "recursive") {
+    return `__recursive_join_${index}`;
+  }
+  return join.viaHop ? `__hop_${index}` : `__join_${index}`;
 }
 
 interface TableJoinTarget {
@@ -138,7 +149,7 @@ export interface PermissionRelation {
   select(columns: Record<string, string>): PermissionRelation;
   hopTo(relation: string): PermissionRelation;
   gather(options: {
-    start: Record<string, unknown>;
+    start?: Record<string, unknown>;
     step: (ctx: { current: RecursiveCurrentValue }) => PermissionRelation;
     maxDepth?: number;
   }): PermissionRelation;
@@ -155,6 +166,9 @@ class PermissionRelationBuilder implements PermissionRelation {
   ) {}
 
   where(input: unknown): PermissionRelation {
+    if (this.state.kind === "union") {
+      throw new Error("where(...) does not support union(...) relations in MVP.");
+    }
     const where = resolveRelationWhereInput(input);
     const filters = [
       ...this.state.filters,
@@ -170,6 +184,9 @@ class PermissionRelationBuilder implements PermissionRelation {
   }
 
   join(target: RelationJoinTarget, on: { left: string; right: string }): PermissionRelation {
+    if (this.state.kind === "union") {
+      throw new Error("join(...) does not support union(...) relations in MVP.");
+    }
     const table = relationJoinTargetToTable(target);
     const joins = [
       ...this.state.joins,
@@ -189,6 +206,9 @@ class PermissionRelationBuilder implements PermissionRelation {
   }
 
   select(columns: Record<string, string>): PermissionRelation {
+    if (this.state.kind === "union") {
+      throw new Error("select(...) does not support union(...) relations in MVP.");
+    }
     return new PermissionRelationBuilder(
       {
         ...this.state,
@@ -199,6 +219,9 @@ class PermissionRelationBuilder implements PermissionRelation {
   }
 
   hopTo(relation: string): PermissionRelation {
+    if (this.state.kind === "union") {
+      throw new Error("hopTo(...) does not support union(...) relations in MVP.");
+    }
     const relationName = relation.trim();
     if (!relationName) {
       throw new Error("hopTo(...) requires a non-empty relation name.");
@@ -229,6 +252,7 @@ class PermissionRelationBuilder implements PermissionRelation {
       return new PermissionRelationBuilder(
         {
           ...this.state,
+          outputTable: rel.toTable,
           joins: [...this.state.joins, join],
         },
         this.relations,
@@ -250,6 +274,7 @@ class PermissionRelationBuilder implements PermissionRelation {
     return new PermissionRelationBuilder(
       {
         ...this.state,
+        outputTable: rel.toTable,
         joins: [
           ...this.state.joins,
           {
@@ -265,25 +290,21 @@ class PermissionRelationBuilder implements PermissionRelation {
   }
 
   gather(options: {
-    start: Record<string, unknown>;
+    start?: Record<string, unknown>;
     step: (ctx: { current: RecursiveCurrentValue }) => PermissionRelation;
     maxDepth?: number;
   }): PermissionRelation {
-    if (this.state.kind !== "table") {
-      throw new Error("gather(...) must start from policy.<table>.");
-    }
-    if (this.state.joins.length > 0) {
-      throw new Error("gather(...) does not support pre-joined start relations in MVP.");
-    }
     if (typeof options.step !== "function") {
       throw new Error("gather(...) requires a step callback.");
     }
+    if (this.state.selectMap && Object.keys(this.state.selectMap).length > 0) {
+      throw new Error("gather(...) does not support select(...) seeds in MVP.");
+    }
+    if (options.start && this.state.kind === "union") {
+      throw new Error("gather(...) start does not support union(...) seeds in MVP.");
+    }
 
-    const startWhere = resolveRelationWhereInput(options.start);
-    const startFilters = [
-      ...this.state.filters,
-      ...extractRelationFilters(startWhere, currentRelationScope(this.state)),
-    ];
+    const seedState = buildGatherSeedState(this.state, options.start, this.relations);
 
     const currentToken: RecursiveCurrentValue = {
       __jazzPermissionKind: "recursive-current",
@@ -322,8 +343,7 @@ class PermissionRelationBuilder implements PermissionRelation {
       );
     }
 
-    const seedPredicates = startFilters.flatMap((filter) => relationFilterToPredicates(filter));
-    const seed = applyRelFilter(this.state.base, seedPredicates);
+    const seed = relationStateToRelExpr(seedState);
 
     const stepPredicates = [
       ...stepFilters.flatMap((filter) => relationFilterToPredicates(filter)),
@@ -487,6 +507,7 @@ export type PolicyContext<TApp extends AppLike> = {
     >;
   } & {
     exists(relation: PermissionRelation): ExistsRelationCondition;
+    union(relations: readonly PermissionRelation[]): PermissionRelation;
   };
   anyOf: (conditions: readonly unknown[]) => Condition;
   allOf: (conditions: readonly unknown[]) => Condition;
@@ -660,6 +681,8 @@ function buildPolicyContext(
     __jazzPermissionKind: "exists-relation",
     relation,
   });
+  context.union = (relations: readonly PermissionRelation[]): PermissionRelation =>
+    createUnionRelation(relations, relationsByTable);
   return context;
 }
 
@@ -731,7 +754,7 @@ function buildTablePolicyBuilder(
       return createTableRelation(table, relationsByTable).hopTo(relation);
     },
     gather(options: {
-      start: Record<string, unknown>;
+      start?: Record<string, unknown>;
       step: (ctx: { current: unknown }) => PermissionRelation;
       maxDepth?: number;
     }): PermissionRelation {
@@ -760,6 +783,148 @@ function createTableRelation(
     },
     relationsByTable,
   );
+}
+
+function createUnionRelation(
+  relations: readonly PermissionRelation[],
+  relationsByTable: Map<string, Relation[]>,
+): PermissionRelation {
+  if (relations.length === 0) {
+    throw new Error("union(...) requires at least one relation.");
+  }
+
+  const states = relations.map((relation) => getRelationState(relation));
+  const firstState = states[0];
+  if (!firstState) {
+    throw new Error("union(...) requires at least one relation.");
+  }
+  if (states.some((state) => state.outputTable !== firstState.outputTable)) {
+    throw new Error("union(...) requires all relations to output the same table.");
+  }
+  if (states.some((state) => state.selectMap && Object.keys(state.selectMap).length > 0)) {
+    throw new Error("union(...) does not support select(...) relations in MVP.");
+  }
+
+  return new PermissionRelationBuilder(
+    {
+      kind: "union",
+      outputTable: firstState.outputTable,
+      base: {
+        Union: {
+          inputs: states.map((state) => relationStateToRelExpr(state)),
+        },
+      },
+      initialScope: "",
+      filters: [],
+      joins: [],
+      selectMap: undefined,
+    },
+    relationsByTable,
+  );
+}
+
+function buildGatherSeedState(
+  state: RelationExprState,
+  start: Record<string, unknown> | undefined,
+  relationsByTable: Map<string, Relation[]>,
+): RelationExprState {
+  if (start === undefined) {
+    return state;
+  }
+
+  const startWhere = resolveRelationWhereInput(start);
+  const baseScope = currentRelationScope(state);
+  const joins = [...state.joins];
+  const filters = [...state.filters];
+  const qualifiedRelationByPrefix = new Map<string, Relation>();
+  const qualifiedScopeByPrefix = new Map<string, string>();
+
+  for (const [column, raw] of Object.entries(startWhere)) {
+    if (raw === undefined) {
+      continue;
+    }
+
+    const [prefix, bare] = splitQualifiedColumn(column);
+    if (!prefix || prefix === state.outputTable) {
+      filters.push({ column: bare, raw, scope: baseScope });
+      continue;
+    }
+
+    const relation = resolveQualifiedGatherStartRelation(
+      relationsByTable,
+      state.outputTable,
+      prefix,
+      bare,
+    );
+    const existingRelation = qualifiedRelationByPrefix.get(prefix);
+    if (existingRelation && existingRelation.name !== relation.name) {
+      throw new Error(
+        `gather(...) qualified start table "${prefix}" is ambiguous from "${state.outputTable}"; use an explicit relation seed instead.`,
+      );
+    }
+    qualifiedRelationByPrefix.set(prefix, relation);
+
+    let scope = qualifiedScopeByPrefix.get(prefix);
+    if (!scope) {
+      const join = relationToJoinSpec(relation);
+      joins.push(join);
+      scope = relationJoinAlias(state.kind, join, joins.length - 1);
+      qualifiedScopeByPrefix.set(prefix, scope);
+    }
+
+    filters.push({ column: bare, raw, scope });
+  }
+
+  return {
+    ...state,
+    joins,
+    filters,
+  };
+}
+
+function resolveQualifiedGatherStartRelation(
+  relationsByTable: Map<string, Relation[]>,
+  outputTable: string,
+  qualifiedTable: string,
+  column: string,
+): Relation {
+  const candidates = (relationsByTable.get(outputTable) ?? []).filter(
+    (relation) => relation.toTable === qualifiedTable,
+  );
+  if (candidates.length === 0) {
+    throw new Error(
+      `gather(...) qualified start column "${qualifiedTable}.${column}" does not match a direct relation from "${outputTable}".`,
+    );
+  }
+  if (candidates.length === 1) {
+    return candidates[0]!;
+  }
+
+  const disambiguated = candidates.filter((relation) =>
+    relation.type === "forward" ? relation.fromColumn === column : relation.toColumn === column,
+  );
+  if (disambiguated.length === 1) {
+    return disambiguated[0]!;
+  }
+
+  throw new Error(
+    `gather(...) qualified start table "${qualifiedTable}" is ambiguous from "${outputTable}"; use an explicit relation seed instead.`,
+  );
+}
+
+function relationToJoinSpec(relation: Relation): RelationJoinSpec {
+  if (relation.type === "forward") {
+    return {
+      table: relation.toTable,
+      left: relation.fromColumn,
+      right: "id",
+    };
+  }
+  return {
+    table: relation.toTable,
+    left: "id",
+    right: relation.toColumn,
+  };
 }
 
 function relationJoinTargetToTable(target: RelationJoinTarget): string {
@@ -814,10 +979,7 @@ function currentRelationScope(state: RelationExprState): string {
 
   const joinIndex = state.joins.length - 1;
   const join = state.joins[joinIndex]!;
-  if (state.kind === "recursive") {
-    return `__recursive_join_${joinIndex}`;
-  }
-  return join.viaHop ? `__hop_${joinIndex}` : `__join_${joinIndex}`;
+  return relationJoinAlias(state.kind, join, joinIndex);
 }
 
 function extractRelationFilters(
@@ -885,7 +1047,7 @@ function relationColumnRef(column: string, defaultScope: string): RelColumnRef {
   if (prefix) {
     return { scope: prefix, column: bare };
   }
-  return { scope: defaultScope, column: bare };
+  return defaultScope ? { scope: defaultScope, column: bare } : { column: bare };
 }
 
 function toRelValueRef(value: unknown, options: { allowRowRefs: boolean }): RelValueRef {
@@ -1147,12 +1309,7 @@ function relationStateToRelExpr(state: RelationExprState): RelExpr {
     joins: state.joins,
     filters: state.filters,
     selectMap: state.selectMap,
-    joinAlias: (join, index) =>
-      state.kind === "recursive"
-        ? `__recursive_join_${index}`
-        : join.viaHop
-          ? `__hop_${index}`
-          : `__join_${index}`,
+    joinAlias: (join, index) => relationJoinAlias(state.kind, join, index),
   });
 }
 

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -44,7 +44,7 @@ import {
 import { analyzeRelations } from "../codegen/relation-analyzer.js";
 import { TabLeaderElection, type LeaderRole, type LeaderSnapshot } from "./tab-leader-election.js";
 import type { WorkerLifecycleEvent } from "../worker/worker-protocol.js";
-import { normalizeBuiltQuery } from "./query-builder-shape.js";
+import { normalizeBuiltQuery, type BuiltRelation } from "./query-builder-shape.js";
 import {
   appendWorkerRuntimeWasmUrl,
   resolveRuntimeConfigSyncInitInput,
@@ -197,6 +197,48 @@ function resolveHopOutputTable(
     currentTable = relation.toTable;
   }
   return currentTable;
+}
+
+function resolveBuiltRelationOutputTable(schema: WasmSchema, relation: BuiltRelation): string {
+  if (relation.union) {
+    const first = relation.union.inputs[0];
+    if (!first) {
+      throw new Error("union(...) requires at least one relation.");
+    }
+    const firstTable = resolveBuiltRelationOutputTable(schema, first);
+    for (const input of relation.union.inputs.slice(1)) {
+      const inputTable = resolveBuiltRelationOutputTable(schema, input);
+      if (inputTable !== firstTable) {
+        throw new Error("union(...) requires all relations to output the same table.");
+      }
+    }
+    return firstTable;
+  }
+
+  const seedTable = relation.gather?.seed
+    ? resolveBuiltRelationOutputTable(schema, relation.gather.seed)
+    : relation.table;
+  if (!seedTable) {
+    throw new Error("gather(...) seed relation is missing table metadata.");
+  }
+  const hops = relation.hops ?? [];
+  return hops.length > 0 ? resolveHopOutputTable(schema, seedTable, hops) : seedTable;
+}
+
+function resolveBuiltQueryOutputTable(
+  schema: WasmSchema,
+  builtQuery: ReturnType<typeof normalizeBuiltQuery>,
+): string {
+  if (builtQuery.gather?.seed) {
+    const gatherTable = resolveBuiltRelationOutputTable(schema, builtQuery.gather.seed);
+    return builtQuery.hops.length > 0
+      ? resolveHopOutputTable(schema, gatherTable, builtQuery.hops)
+      : gatherTable;
+  }
+
+  return builtQuery.hops.length > 0
+    ? resolveHopOutputTable(schema, builtQuery.table, builtQuery.hops)
+    : builtQuery.table;
 }
 
 function resolveSchemaWithTable(
@@ -1332,14 +1374,11 @@ export class Db {
     const builderJson = query._build();
     const builtQuery = normalizeBuiltQuery(JSON.parse(builderJson), query._table);
     const planningSchema = resolveSchemaWithTable(query._schema, runtimeSchema, builtQuery.table);
-    const outputTable =
-      builtQuery.hops.length > 0
-        ? resolveHopOutputTable(planningSchema, builtQuery.table, builtQuery.hops)
-        : query._table;
+    const outputTable = resolveBuiltQueryOutputTable(planningSchema, builtQuery);
     const outputSchema = resolveSchemaWithTable(query._schema, runtimeSchema, outputTable);
     await this.ensureQueryReady(options);
     const rows = await client.query(translateQuery(builderJson, planningSchema), options);
-    const outputIncludes = builtQuery.hops.length > 0 ? {} : builtQuery.includes;
+    const outputIncludes = outputTable !== builtQuery.table ? {} : builtQuery.includes;
     return transformRows<T>(rows, outputSchema, outputTable, outputIncludes, builtQuery.select);
   }
 
@@ -1442,12 +1481,9 @@ export class Db {
     const builderJson = query._build();
     const builtQuery = normalizeBuiltQuery(JSON.parse(builderJson), query._table);
     const planningSchema = resolveSchemaWithTable(query._schema, runtimeSchema, builtQuery.table);
-    const outputTable =
-      builtQuery.hops.length > 0
-        ? resolveHopOutputTable(planningSchema, builtQuery.table, builtQuery.hops)
-        : query._table;
+    const outputTable = resolveBuiltQueryOutputTable(planningSchema, builtQuery);
     const outputSchema = resolveSchemaWithTable(query._schema, runtimeSchema, outputTable);
-    const outputIncludes = builtQuery.hops.length > 0 ? {} : builtQuery.includes;
+    const outputIncludes = outputTable !== builtQuery.table ? {} : builtQuery.includes;
     const wasmQuery = translateQuery(builderJson, planningSchema);
 
     const transform = (row: WasmRow): T => {
@@ -1696,10 +1732,7 @@ class ClientBackedDb extends Db {
     const builderJson = query._build();
     const builtQuery = normalizeBuiltQuery(JSON.parse(builderJson), query._table);
     const planningSchema = resolveSchemaWithTable(query._schema, runtimeSchema, builtQuery.table);
-    const outputTable =
-      builtQuery.hops.length > 0
-        ? resolveHopOutputTable(planningSchema, builtQuery.table, builtQuery.hops)
-        : query._table;
+    const outputTable = resolveBuiltQueryOutputTable(planningSchema, builtQuery);
     const outputSchema = resolveSchemaWithTable(query._schema, runtimeSchema, outputTable);
     await this.ensureQueryReady(options);
     const rows = await this.runtimeClient.queryInternal(
@@ -1707,7 +1740,7 @@ class ClientBackedDb extends Db {
       this.session,
       options,
     );
-    const outputIncludes = builtQuery.hops.length > 0 ? {} : builtQuery.includes;
+    const outputIncludes = outputTable !== builtQuery.table ? {} : builtQuery.includes;
     return transformRows<T>(rows, outputSchema, outputTable, outputIncludes, builtQuery.select);
   }
 
@@ -1727,12 +1760,9 @@ class ClientBackedDb extends Db {
     const builderJson = query._build();
     const builtQuery = normalizeBuiltQuery(JSON.parse(builderJson), query._table);
     const planningSchema = resolveSchemaWithTable(query._schema, runtimeSchema, builtQuery.table);
-    const outputTable =
-      builtQuery.hops.length > 0
-        ? resolveHopOutputTable(planningSchema, builtQuery.table, builtQuery.hops)
-        : query._table;
+    const outputTable = resolveBuiltQueryOutputTable(planningSchema, builtQuery);
     const outputSchema = resolveSchemaWithTable(query._schema, runtimeSchema, outputTable);
-    const outputIncludes = builtQuery.hops.length > 0 ? {} : builtQuery.includes;
+    const outputIncludes = outputTable !== builtQuery.table ? {} : builtQuery.includes;
     const wasmQuery = translateQuery(builderJson, planningSchema);
 
     const transform = (row: WasmRow): T =>

--- a/packages/jazz-tools/src/runtime/db.ts
+++ b/packages/jazz-tools/src/runtime/db.ts
@@ -48,7 +48,6 @@ import { normalizeBuiltQuery, type BuiltRelation } from "./query-builder-shape.j
 import {
   appendWorkerRuntimeWasmUrl,
   resolveRuntimeConfigSyncInitInput,
-  resolveRuntimeConfigWasmUrl,
   resolveWorkerBootstrapWasmUrl,
   resolveRuntimeConfigWorkerUrl,
 } from "./runtime-config.js";

--- a/packages/jazz-tools/src/runtime/query-adapter.test.ts
+++ b/packages/jazz-tools/src/runtime/query-adapter.test.ts
@@ -1900,6 +1900,146 @@ describe("translateQuery", () => {
     });
   });
 
+  it("lowers gather metadata seeded from a hop relation", () => {
+    const schema: WasmSchema = {
+      teams: {
+        columns: [{ name: "name", column_type: { type: "Text" }, nullable: false }],
+      },
+      team_edges: {
+        columns: [
+          {
+            name: "child_team",
+            column_type: { type: "Uuid" },
+            nullable: false,
+            references: "teams",
+          },
+          {
+            name: "parent_team",
+            column_type: { type: "Uuid" },
+            nullable: false,
+            references: "teams",
+          },
+        ],
+      },
+    };
+
+    const builderJson = JSON.stringify({
+      table: "team_edges",
+      conditions: [],
+      includes: {},
+      orderBy: [],
+      gather: {
+        seed: {
+          table: "team_edges",
+          conditions: [{ column: "child_team", op: "eq", value: "team-a" }],
+          hops: ["parent_team"],
+        },
+        max_depth: 3,
+        step_table: "team_edges",
+        step_current_column: "child_team",
+        step_conditions: [],
+        step_hops: ["parent_team"],
+      },
+    });
+
+    const ir = toLegacyRelExprForTest(translateBuilderToRelationIr(builderJson, schema));
+    expect(ir.type).toBe("Gather");
+    if (ir.type !== "Gather") {
+      throw new Error("Expected gather relation IR.");
+    }
+    expect(ir.seed.type).toBe("Project");
+    if (ir.seed.type !== "Project") {
+      throw new Error("Expected projected seed relation IR.");
+    }
+    expect(ir.seed.input.type).toBe("Join");
+    if (ir.seed.input.type !== "Join") {
+      throw new Error("Expected joined seed relation IR.");
+    }
+    expect(ir.seed.input.left.type).toBe("Filter");
+    if (ir.seed.input.left.type !== "Filter") {
+      throw new Error("Expected filtered seed relation IR.");
+    }
+  });
+
+  it("lowers gather metadata seeded from a union relation", () => {
+    const schema: WasmSchema = {
+      teams: {
+        columns: [{ name: "name", column_type: { type: "Text" }, nullable: false }],
+      },
+      team_edges: {
+        columns: [
+          {
+            name: "child_team",
+            column_type: { type: "Uuid" },
+            nullable: false,
+            references: "teams",
+          },
+          {
+            name: "parent_team",
+            column_type: { type: "Uuid" },
+            nullable: false,
+            references: "teams",
+          },
+        ],
+      },
+    };
+
+    const builderJson = JSON.stringify({
+      table: "team_edges",
+      conditions: [],
+      includes: {},
+      orderBy: [],
+      gather: {
+        seed: {
+          union: {
+            inputs: [
+              {
+                table: "team_edges",
+                conditions: [{ column: "child_team", op: "eq", value: "team-a" }],
+                hops: ["parent_team"],
+              },
+              {
+                table: "teams",
+                conditions: [],
+                hops: [],
+                gather: {
+                  seed: {
+                    table: "teams",
+                    conditions: [{ column: "name", op: "eq", value: "admins" }],
+                    hops: [],
+                  },
+                  max_depth: 2,
+                  step_table: "team_edges",
+                  step_current_column: "child_team",
+                  step_conditions: [],
+                  step_hops: ["parent_team"],
+                },
+              },
+            ],
+          },
+        },
+        max_depth: 4,
+        step_table: "team_edges",
+        step_current_column: "child_team",
+        step_conditions: [],
+        step_hops: ["parent_team"],
+      },
+    });
+
+    const ir = toLegacyRelExprForTest(translateBuilderToRelationIr(builderJson, schema));
+    expect(ir.type).toBe("Gather");
+    if (ir.type !== "Gather") {
+      throw new Error("Expected gather relation IR.");
+    }
+    expect(ir.seed.type).toBe("Union");
+    if (ir.seed.type !== "Union") {
+      throw new Error("Expected union seed relation IR.");
+    }
+    expect(ir.seed.inputs).toHaveLength(2);
+    expect(ir.seed.inputs[0]?.type).toBe("Project");
+    expect(ir.seed.inputs[1]?.type).toBe("Gather");
+  });
+
   describe("error handling", () => {
     it("throws for unknown column", () => {
       const builderJson = JSON.stringify({

--- a/packages/jazz-tools/src/runtime/query-adapter.ts
+++ b/packages/jazz-tools/src/runtime/query-adapter.ts
@@ -16,6 +16,7 @@ import {
   normalizeBuiltQuery,
   type BuiltCondition,
   type BuiltGather,
+  type BuiltRelation,
   type NormalizedIncludeEntry,
   type NormalizedIncludeSpec,
 } from "./query-builder-shape.js";
@@ -619,6 +620,75 @@ function gatherToRelExpr(
   };
 }
 
+function resolveHopsOutputTable(
+  seedTable: string,
+  hops: readonly string[],
+  relations: Map<string, Relation[]>,
+): string {
+  let currentTable = seedTable;
+  for (const hopName of hops) {
+    const tableRelations = relations.get(currentTable) ?? [];
+    const relation = tableRelations.find((candidate) => candidate.name === hopName);
+    if (!relation) {
+      throw new Error(`Unknown relation "${hopName}" on table "${currentTable}"`);
+    }
+    currentTable = relation.toTable;
+  }
+  return currentTable;
+}
+
+function translateBuiltRelationToRelExpr(
+  relation: BuiltRelation,
+  relations: Map<string, Relation[]>,
+  schema: WasmSchema,
+): { expr: RelExpr; outputTable: string } {
+  if (relation.union) {
+    const inputs = relation.union.inputs.map((input) =>
+      translateBuiltRelationToRelExpr(input, relations, schema),
+    );
+    const first = inputs[0];
+    if (!first) {
+      throw new Error("union(...) requires at least one seed relation.");
+    }
+    if (inputs.some((input) => input.outputTable !== first.outputTable)) {
+      throw new Error("union(...) requires all seed relations to output the same table.");
+    }
+    return {
+      expr: {
+        Union: {
+          inputs: inputs.map((input) => input.expr),
+        },
+      },
+      outputTable: first.outputTable,
+    };
+  }
+
+  if (!relation.table) {
+    throw new Error("gather(...) seed relation is missing table metadata.");
+  }
+
+  let expr: RelExpr = { TableScan: { table: relation.table } };
+  expr = applyFilter(
+    expr,
+    conditionsToRelPredicate(relation.conditions ?? [], schema, relation.table, relation.table),
+  );
+
+  let outputTable = relation.table;
+  if (relation.gather) {
+    const seed = relation.gather.seed
+      ? translateBuiltRelationToRelExpr(relation.gather.seed, relations, schema)
+      : { expr, outputTable };
+    expr = gatherToRelExpr(relation.gather, seed.outputTable, seed.expr, relations, schema);
+    outputTable = seed.outputTable;
+  }
+
+  const hops = relation.hops ?? [];
+  expr = lowerHopsToRelExpr(expr, outputTable, hops, relations, schema);
+  outputTable = resolveHopsOutputTable(outputTable, hops, relations);
+
+  return { expr, outputTable };
+}
+
 /**
  * Translate QueryBuilder JSON to relation IR.
  *
@@ -638,20 +708,37 @@ export function translateBuilderToRelationIr(builderJson: string, schema: WasmSc
     throw new Error("hopTo(...) does not yet support include(...).");
   }
 
-  let relation: RelExpr = { TableScan: { table: builder.table } };
-  relation = applyFilter(
-    relation,
-    conditionsToRelPredicate(builder.conditions, schema, builder.table, builder.table),
-  );
+  let relation: RelExpr;
+  let relationTable: string;
 
-  if (builder.gather) {
-    relation = gatherToRelExpr(builder.gather, builder.table, relation, relations, schema);
+  if (builder.gather?.seed) {
+    const seed = translateBuiltRelationToRelExpr(builder.gather.seed, relations, schema);
+    relation = gatherToRelExpr(builder.gather, seed.outputTable, seed.expr, relations, schema);
+    relationTable = seed.outputTable;
+    relation = applyFilter(
+      relation,
+      conditionsToRelPredicate(builder.conditions, schema, relationTable, relationTable),
+    );
+    relation = lowerHopsToRelExpr(relation, relationTable, hops, relations, schema);
+    relationTable = resolveHopsOutputTable(relationTable, hops, relations);
+  } else {
+    const translated = translateBuiltRelationToRelExpr(
+      {
+        table: builder.table,
+        conditions: builder.conditions,
+        hops: builder.hops,
+        gather: builder.gather,
+      },
+      relations,
+      schema,
+    );
+    relation = translated.expr;
+    relationTable = translated.outputTable;
   }
-  relation = lowerHopsToRelExpr(relation, builder.table, hops, relations, schema);
 
   if (Array.isArray(builder.orderBy) && builder.orderBy.length > 0) {
     for (const [column] of builder.orderBy) {
-      const columnType = getColumnType(schema, builder.table, stripQualifier(column));
+      const columnType = getColumnType(schema, relationTable, stripQualifier(column));
       if (columnType?.type === "Bytea") {
         throw new Error(`BYTEA column "${column}" cannot be used in orderBy().`);
       }

--- a/packages/jazz-tools/src/runtime/query-builder-shape.ts
+++ b/packages/jazz-tools/src/runtime/query-builder-shape.ts
@@ -6,7 +6,18 @@ export interface BuiltCondition {
   value: unknown;
 }
 
+export interface BuiltRelation {
+  table?: string;
+  conditions?: BuiltCondition[];
+  hops?: string[];
+  gather?: BuiltGather;
+  union?: {
+    inputs: BuiltRelation[];
+  };
+}
+
 export interface BuiltGather {
+  seed?: BuiltRelation;
   max_depth: number;
   step_table: string;
   step_current_column: string;
@@ -110,6 +121,7 @@ function normalizeGather(value: unknown): BuiltGather | undefined {
   }
 
   return {
+    ...(isPlainObject(value) && value.seed ? { seed: normalizeBuiltRelation(value.seed) } : {}),
     max_depth: maxDepth,
     step_table: value.step_table,
     step_current_column: value.step_current_column,
@@ -118,6 +130,29 @@ function normalizeGather(value: unknown): BuiltGather | undefined {
       ? value.step_hops.filter((hop): hop is string => typeof hop === "string")
       : [],
   };
+}
+
+function normalizeBuiltRelation(value: unknown): BuiltRelation {
+  if (!isPlainObject(value)) {
+    return {};
+  }
+
+  const normalized: BuiltRelation = {
+    ...(typeof value.table === "string" && value.table.length > 0 ? { table: value.table } : {}),
+    conditions: normalizeConditions(value.conditions),
+    hops: Array.isArray(value.hops)
+      ? value.hops.filter((hop): hop is string => typeof hop === "string")
+      : [],
+    gather: normalizeGather(value.gather),
+  };
+
+  if (isPlainObject(value.union) && Array.isArray(value.union.inputs)) {
+    normalized.union = {
+      inputs: value.union.inputs.map((input) => normalizeBuiltRelation(input)),
+    };
+  }
+
+  return normalized;
 }
 
 function createEmptyIncludeEntry(): NormalizedIncludeEntry {

--- a/packages/jazz-tools/src/schema-permissions.ts
+++ b/packages/jazz-tools/src/schema-permissions.ts
@@ -235,6 +235,14 @@ function normalizeRelationExprForWasm(expr: RelExpr): RelExpr {
     };
   }
 
+  if ("Union" in expr) {
+    return {
+      Union: {
+        inputs: expr.Union.inputs.map((input) => normalizeRelationExprForWasm(input)),
+      },
+    };
+  }
+
   if ("Join" in expr) {
     return {
       Join: {

--- a/packages/jazz-tools/src/testing/relation-ir-test-helpers.ts
+++ b/packages/jazz-tools/src/testing/relation-ir-test-helpers.ts
@@ -171,6 +171,13 @@ export function toLegacyRelExprForTest(value: unknown): any {
         input: toLegacyRelExprForTest(payload.input),
         predicate: toLegacyRelPredicateForTest(payload.predicate),
       };
+    case "Union":
+      return {
+        type: "Union",
+        inputs: Array.isArray(payload.inputs)
+          ? payload.inputs.map((input) => toLegacyRelExprForTest(input))
+          : [],
+      };
     case "Join":
       return {
         type: "Join",

--- a/packages/jazz-tools/src/typed-app.ts
+++ b/packages/jazz-tools/src/typed-app.ts
@@ -438,6 +438,11 @@ type QueryBuilderShape<
   readonly _initType: TableInit<TSchema, TTable>;
 };
 
+type RelationSeedQuery<TTable extends string = string> = QueryBuilder<unknown> & {
+  readonly _table: TTable;
+  _serializeRelation(): unknown;
+};
+
 type PermissionIntrospectionColumns = {
   $canRead: boolean | null;
   $canEdit: boolean | null;
@@ -1032,7 +1037,7 @@ export class TypedTableQueryBuilder<
     return built;
   }
 
-  private _serializeRelation(): BuiltRelation {
+  _serializeRelation(): BuiltRelation {
     if (this._unionVal) {
       return cloneBuiltRelation(this._unionVal);
     }
@@ -1138,8 +1143,8 @@ export type App<TSchema extends SchemaLike> = Simplify<
   {
     [TTable in TableName<TSchema>]: Table<TTable, TSchema>;
   } & {
-    union(
-      relations: readonly TypedTableQueryBuilder<any, any, any, any>[],
+    union<TTable extends string>(
+      relations: readonly RelationSeedQuery<TTable>[],
     ): TypedTableQueryBuilder<any, any, any, any>;
     wasmSchema: WasmSchema;
   }
@@ -1228,7 +1233,7 @@ export function defineApp(
 
   return {
     ...tables,
-    union(relations: readonly TypedTableQueryBuilder<any, any, any, any>[]) {
+    union<TTable extends string>(relations: readonly RelationSeedQuery<TTable>[]) {
       if (relations.length === 0) {
         throw new Error("union(...) requires at least one relation.");
       }
@@ -1237,7 +1242,7 @@ export function defineApp(
       const builder = new TypedTableQueryBuilder(first._table, wasmSchema);
       (builder as any)._unionVal = {
         union: {
-          inputs: relations.map((relation) => (relation as any)._serializeRelation()),
+          inputs: relations.map((relation) => relation._serializeRelation() as BuiltRelation),
         },
       };
       return builder;

--- a/packages/jazz-tools/src/typed-app.ts
+++ b/packages/jazz-tools/src/typed-app.ts
@@ -748,13 +748,54 @@ type SelectedWithIncludesFromMeta<
 >;
 
 type BuiltCondition = { column: string; op: string; value: unknown };
+type BuiltRelation = {
+  table?: string;
+  conditions?: BuiltCondition[];
+  hops?: string[];
+  gather?: BuiltGather;
+  union?: {
+    inputs: BuiltRelation[];
+  };
+};
 type BuiltGather = {
+  seed?: BuiltRelation;
   max_depth: number;
   step_table: string;
   step_current_column: string;
   step_conditions: BuiltCondition[];
   step_hops: string[];
 };
+
+function cloneBuiltCondition(condition: BuiltCondition): BuiltCondition {
+  return { ...condition };
+}
+
+function cloneBuiltRelation(relation: BuiltRelation): BuiltRelation {
+  return {
+    ...(relation.table ? { table: relation.table } : {}),
+    ...(relation.conditions ? { conditions: relation.conditions.map(cloneBuiltCondition) } : {}),
+    ...(relation.hops ? { hops: [...relation.hops] } : {}),
+    ...(relation.gather ? { gather: cloneBuiltGather(relation.gather) } : {}),
+    ...(relation.union
+      ? {
+          union: {
+            inputs: relation.union.inputs.map(cloneBuiltRelation),
+          },
+        }
+      : {}),
+  };
+}
+
+function cloneBuiltGather(gather: BuiltGather): BuiltGather {
+  return {
+    ...(gather.seed ? { seed: cloneBuiltRelation(gather.seed) } : {}),
+    max_depth: gather.max_depth,
+    step_table: gather.step_table,
+    step_current_column: gather.step_current_column,
+    step_conditions: gather.step_conditions.map(cloneBuiltCondition),
+    step_hops: [...gather.step_hops],
+  };
+}
 
 export class TypedTableQueryBuilder<
   TMeta extends AnyTableMeta,
@@ -775,6 +816,7 @@ export class TypedTableQueryBuilder<
   private _offsetVal?: number;
   private _hops: string[] = [];
   private _gatherVal?: BuiltGather;
+  private _unionVal?: BuiltRelation;
 
   constructor(table: TableNameFromMeta<TMeta>, schema: WasmSchema) {
     this._table = table;
@@ -784,19 +826,11 @@ export class TypedTableQueryBuilder<
   where(
     conditions: TableWhereFromMeta<TMeta>,
   ): MetaQueryHandle<TMeta, TInclude, TSelection, TRequired> {
-    const clone = this._clone<TInclude, TSelection, TRequired>();
-    for (const [key, value] of Object.entries(conditions as Record<string, unknown>)) {
-      if (value === undefined) continue;
-      if (typeof value === "object" && value !== null && !Array.isArray(value)) {
-        for (const [op, opValue] of Object.entries(value)) {
-          if (opValue !== undefined) {
-            clone._conditions.push({ column: key, op, value: opValue });
-          }
-        }
-      } else {
-        clone._conditions.push({ column: key, op: "eq", value });
-      }
+    if (this._unionVal) {
+      throw new Error("union(...) currently only supports gather(...) in MVP.");
     }
+    const clone = this._clone<TInclude, TSelection, TRequired>();
+    clone._conditions.push(...this._whereConditions(conditions as Record<string, unknown>));
     return clone;
   }
 
@@ -846,19 +880,19 @@ export class TypedTableQueryBuilder<
   hopTo(
     relation: RelationNameFromMeta<TMeta>,
   ): MetaQueryHandle<TMeta, TInclude, TSelection, TRequired> {
+    if (this._unionVal) {
+      throw new Error("union(...) currently only supports gather(...) in MVP.");
+    }
     const clone = this._clone<TInclude, TSelection, TRequired>();
     clone._hops.push(relation as string);
     return clone;
   }
 
   gather(options: {
-    start: TableWhereFromMeta<TMeta>;
+    start?: TableWhereFromMeta<TMeta>;
     step: (ctx: { current: string }) => QueryBuilder<unknown>;
     maxDepth?: number;
   }): MetaQueryHandle<TMeta, TInclude, TSelection, TRequired> {
-    if (options.start === undefined) {
-      throw new Error("gather(...) requires start where conditions.");
-    }
     if (typeof options.step !== "function") {
       throw new Error("gather(...) requires step callback.");
     }
@@ -870,8 +904,8 @@ export class TypedTableQueryBuilder<
     if (Object.keys(this._includes).length > 0) {
       throw new Error("gather(...) does not support include(...) in MVP.");
     }
-    if (this._hops.length > 0) {
-      throw new Error("gather(...) must be called before hopTo(...).");
+    if (options.start && this._unionVal) {
+      throw new Error("gather(...) start does not support union(...) seeds in MVP.");
     }
 
     const currentToken = "__jazz_gather_current__";
@@ -918,16 +952,23 @@ export class TypedTableQueryBuilder<
       (condition) => !(condition.op === "eq" && condition.value === currentToken),
     );
 
-    const withStart = this.where(options.start);
-    const clone = withStart._clone<TInclude, TSelection, TRequired>();
+    const needsExplicitSeed =
+      this._unionVal !== undefined || this._hops.length > 0 || this._gatherVal !== undefined;
+    const seedSource = options.start === undefined ? this : this.where(options.start);
+    const clone = needsExplicitSeed
+      ? this._clone<TInclude, TSelection, TRequired>()
+      : seedSource._clone<TInclude, TSelection, TRequired>();
+    clone._conditions = [];
     clone._hops = [];
     clone._gatherVal = {
+      ...(needsExplicitSeed ? { seed: seedSource._serializeRelation() } : {}),
       max_depth: maxDepth,
       step_table: stepBuilt.table,
       step_current_column: currentCondition.column,
       step_conditions: stepConditions,
       step_hops: stepHops,
     };
+    clone._unionVal = undefined;
 
     return clone;
   }
@@ -944,6 +985,7 @@ export class TypedTableQueryBuilder<
       offset: this._offsetVal,
       hops: this._hops,
       gather: this._gatherVal,
+      ...(this._unionVal ? { union: cloneBuiltRelation(this._unionVal).union } : {}),
     });
   }
 
@@ -968,14 +1010,38 @@ export class TypedTableQueryBuilder<
     clone._limitVal = this._limitVal;
     clone._offsetVal = this._offsetVal;
     clone._hops = [...this._hops];
-    clone._gatherVal = this._gatherVal
-      ? {
-          ...this._gatherVal,
-          step_conditions: this._gatherVal.step_conditions.map((condition) => ({ ...condition })),
-          step_hops: [...this._gatherVal.step_hops],
-        }
-      : undefined;
+    clone._gatherVal = this._gatherVal ? cloneBuiltGather(this._gatherVal) : undefined;
+    clone._unionVal = this._unionVal ? cloneBuiltRelation(this._unionVal) : undefined;
     return clone;
+  }
+
+  private _whereConditions(conditions: Record<string, unknown>): BuiltCondition[] {
+    const built: BuiltCondition[] = [];
+    for (const [key, value] of Object.entries(conditions)) {
+      if (value === undefined) continue;
+      if (typeof value === "object" && value !== null && !Array.isArray(value)) {
+        for (const [op, opValue] of Object.entries(value)) {
+          if (opValue !== undefined) {
+            built.push({ column: key, op, value: opValue });
+          }
+        }
+      } else {
+        built.push({ column: key, op: "eq", value });
+      }
+    }
+    return built;
+  }
+
+  private _serializeRelation(): BuiltRelation {
+    if (this._unionVal) {
+      return cloneBuiltRelation(this._unionVal);
+    }
+    return {
+      table: this._table,
+      conditions: this._conditions.map(cloneBuiltCondition),
+      hops: [...this._hops],
+      ...(this._gatherVal ? { gather: cloneBuiltGather(this._gatherVal) } : {}),
+    };
   }
 }
 
@@ -1012,7 +1078,7 @@ export interface Query<
     relation: RelationNameFromMeta<SchemaMeta<TTable, TSchema>>,
   ): Query<TTable, TInclude, TSelection, TSchema>;
   gather(options: {
-    start: TableWhereInput<TSchema, Extract<TTable, TableName<TSchema>>>;
+    start?: TableWhereInput<TSchema, Extract<TTable, TableName<TSchema>>>;
     step: (ctx: { current: string }) => QueryBuilder<unknown>;
     maxDepth?: number;
   }): Query<TTable, TInclude, TSelection, TSchema>;
@@ -1044,7 +1110,7 @@ export interface RequiredQuery<
     relation: RelationNameFromMeta<SchemaMeta<TTable, TSchema>>,
   ): RequiredQuery<TTable, TInclude, TSelection, TSchema>;
   gather(options: {
-    start: TableWhereInput<TSchema, Extract<TTable, TableName<TSchema>>>;
+    start?: TableWhereInput<TSchema, Extract<TTable, TableName<TSchema>>>;
     step: (ctx: { current: string }) => QueryBuilder<unknown>;
     maxDepth?: number;
   }): RequiredQuery<TTable, TInclude, TSelection, TSchema>;
@@ -1072,6 +1138,9 @@ export type App<TSchema extends SchemaLike> = Simplify<
   {
     [TTable in TableName<TSchema>]: Table<TTable, TSchema>;
   } & {
+    union(
+      relations: readonly TypedTableQueryBuilder<any, any, any, any>[],
+    ): TypedTableQueryBuilder<any, any, any, any>;
     wasmSchema: WasmSchema;
   }
 >;
@@ -1159,6 +1228,20 @@ export function defineApp(
 
   return {
     ...tables,
+    union(relations: readonly TypedTableQueryBuilder<any, any, any, any>[]) {
+      if (relations.length === 0) {
+        throw new Error("union(...) requires at least one relation.");
+      }
+
+      const first = relations[0]!;
+      const builder = new TypedTableQueryBuilder(first._table, wasmSchema);
+      (builder as any)._unionVal = {
+        union: {
+          inputs: relations.map((relation) => (relation as any)._serializeRelation()),
+        },
+      };
+      return builder;
+    },
     wasmSchema,
   } as App<Schema<SchemaDefinition>>;
 }

--- a/packages/jazz-tools/tests/ts-dsl/typed-app.test.ts
+++ b/packages/jazz-tools/tests/ts-dsl/typed-app.test.ts
@@ -52,6 +52,18 @@ const defaultedSchema = {
 type DefaultedAppSchema = s.Schema<typeof defaultedSchema>;
 const defaultedApp: s.App<DefaultedAppSchema> = s.defineApp(defaultedSchema);
 
+const graphSchema = {
+  teams: s.table({
+    name: s.string(),
+  }),
+  team_edges: s.table({
+    child_team: s.ref("teams"),
+    parent_team: s.ref("teams"),
+  }),
+};
+type GraphAppSchema = s.Schema<typeof graphSchema>;
+const graphApp: s.App<GraphAppSchema> = s.defineApp(graphSchema);
+
 describe("typed app prototype", () => {
   it("serializes select/include metadata without codegen", () => {
     expect(JSON.parse(app.todos.select("title").include({ project: true })._build())).toEqual({
@@ -105,6 +117,88 @@ describe("typed app prototype", () => {
     expectTypeOf(row.title).toEqualTypeOf<string>();
     expectTypeOf(row.$createdBy).toEqualTypeOf<string>();
     expectTypeOf(row.$updatedAt).toEqualTypeOf<Date>();
+  });
+
+  it("serializes gather seeded from the current relation", () => {
+    const directParents = graphApp.team_edges.where({ child_team: "team-a" }).hopTo("parent_team");
+    const reachableTeams = directParents.gather({
+      step: ({ current }) =>
+        graphApp.team_edges.where({ child_team: current }).hopTo("parent_team"),
+      maxDepth: 3,
+    });
+
+    expect(JSON.parse(reachableTeams._build())).toEqual({
+      table: "team_edges",
+      conditions: [],
+      includes: {},
+      orderBy: [],
+      hops: [],
+      gather: {
+        seed: {
+          table: "team_edges",
+          conditions: [{ column: "child_team", op: "eq", value: "team-a" }],
+          hops: ["parent_team"],
+        },
+        max_depth: 3,
+        step_table: "team_edges",
+        step_current_column: "child_team",
+        step_conditions: [],
+        step_hops: ["parent_team"],
+      },
+    });
+  });
+
+  it("serializes union gather seeds", () => {
+    const directParents = graphApp.team_edges.where({ child_team: "team-a" }).hopTo("parent_team");
+    const adminReachableTeams = graphApp.teams.gather({
+      start: { name: "admins" },
+      step: ({ current }) =>
+        graphApp.team_edges.where({ child_team: current }).hopTo("parent_team"),
+      maxDepth: 2,
+    });
+    const reachableTeams = graphApp.union([directParents, adminReachableTeams]).gather({
+      step: ({ current }) =>
+        graphApp.team_edges.where({ child_team: current }).hopTo("parent_team"),
+      maxDepth: 4,
+    });
+
+    expect(JSON.parse(reachableTeams._build())).toEqual({
+      table: "team_edges",
+      conditions: [],
+      includes: {},
+      orderBy: [],
+      hops: [],
+      gather: {
+        seed: {
+          union: {
+            inputs: [
+              {
+                table: "team_edges",
+                conditions: [{ column: "child_team", op: "eq", value: "team-a" }],
+                hops: ["parent_team"],
+              },
+              {
+                table: "teams",
+                conditions: [],
+                hops: [],
+                gather: {
+                  max_depth: 2,
+                  step_table: "team_edges",
+                  step_current_column: "child_team",
+                  step_conditions: [],
+                  step_hops: ["parent_team"],
+                },
+              },
+            ],
+          },
+        },
+        max_depth: 4,
+        step_table: "team_edges",
+        step_current_column: "child_team",
+        step_conditions: [],
+        step_hops: ["parent_team"],
+      },
+    });
   });
 
   it("infers rows, init payloads, where inputs, and include names from schema literals", () => {

--- a/packages/jazz-tools/tests/ts-dsl/typed-app.test.ts
+++ b/packages/jazz-tools/tests/ts-dsl/typed-app.test.ts
@@ -258,7 +258,7 @@ describe("typed app prototype", () => {
 
     if ((globalThis as { __typecheck_only__?: boolean }).__typecheck_only__) {
       // @ts-expect-error invalid root key
-      app.unknown;
+      void app.unknown;
 
       // @ts-expect-error invalid where column
       app.todos.where({ missing: true });


### PR DESCRIPTION
## What changed

This teaches recursive `gather(...)` to start from composed same-table relations instead of only plain table filters.

It includes:
- permission-side relation unions via `policy.union([...])`
- permission/query lowering for gather seeds built from hop relations, recursive relations, and unions
- relation IR support for `Union` plus query-graph compilation/merging for unioned and nested gather seeds
- typed query/runtime support for the same recursive seed shapes
- regression tests across permissions, typed-app/query-adapter, and Rust query-graph compilation

## Why

The legacy-equivalent team permission model needs closures whose seed can be a same-table relation like:
- direct memberships hopped into teams
- an existing recursive closure
- a union of those relations

Before this change, those shapes either hit MVP guards (`pre-joined start relations`, missing union support) or compiled into unusable qualified-column hacks.

## Impact

Projects can now express permission closures like `reachableTeams = policy.union([directTeams, adminReachableTeams]).gather(...)` without precomputing closure claims outside Jazz.

## Validation

Ran:
- `pnpm --dir packages/jazz-tools exec vitest run src/permissions/index.test.ts`
- `pnpm --dir packages/jazz-tools exec vitest run src/runtime/query-adapter.test.ts`
- `pnpm --dir packages/jazz-tools exec vitest run tests/ts-dsl/typed-app.test.ts`
- `cargo test compile_query_with_relation_ir_gather_join_seed_uses_recursive_node --package jazz-tools`
- `cargo test compile_query_with_relation_ir_gather_union_seed_uses_recursive_node --package jazz-tools`
- `pnpm lint`

`pnpm lint` exited successfully. `oxlint` still reports existing warnings in unrelated files, plus two warnings in touched files that the repo currently allows during lint.